### PR TITLE
Add read-through cache fills with stampede protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
           cargo test -p autumn-web --all-features --test feature_flags_pg_integration -- --ignored
           cargo test -p autumn-web --test scoped_tokens_db -- --ignored
           cargo test -p autumn-admin-plugin --test token_admin_db -- --ignored
+          cargo test -p autumn-cache-redis -- --ignored
 
   coverage:
     name: Coverage
@@ -106,6 +107,7 @@ jobs:
             --test scoped_tokens_db -- --ignored
           cargo llvm-cov --no-report -p autumn-admin-plugin \
             --test token_admin_db -- --ignored
+          cargo llvm-cov --no-report -p autumn-cache-redis -- --ignored
           cargo llvm-cov report --lcov --output-path lcov.info
       - name: Upload to Codecov
         uses: codecov/codecov-action@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **cache:** read-through fills with single-flight cache stampede protection
+  (#1204). `cache::get_or_compute(cache, key, ttl, fill)` computes a missing
+  value once per process for concurrent callers — the first miss becomes the
+  "leader" and runs `fill`; every other concurrent caller for the same key
+  awaits that one fill via a process-global in-flight registry instead of
+  recomputing it. `cache::get_or_compute_with(cache, key, options, fill)`
+  adds opt-in cross-replica protection: `GetOrComputeOptions::
+  distributed_fill_lock(true)` acquires a Redis `SET NX PX` lock (with a Lua
+  compare-and-delete release) so N replicas don't refill the same key N
+  times, and `GetOrComputeOptions::stale_while_revalidate(grace)` serves the
+  last-known value immediately while at most one background refresh runs. A
+  failing fill never poisons the key: the leader gets a typed
+  `CacheFillError::Fill`, waiters get a rendered `CacheFillError::FillFailed`,
+  nothing is written to the cache, and the next caller retries; the
+  distributed lock's TTL bounds the damage from a crashed filler.
+  `cache::jittered_ttl(base, fraction)` de-synchronizes mass expiry of keys
+  written together. New `autumn_cache_read_through_*` and
+  `autumn_cache_fill_lock_*` counters are exposed on both
+  `/actuator/metrics` and `/actuator/prometheus`. Additive: the `Cache` trait
+  gains two default methods (`try_acquire_fill_lock`/`release_fill_lock`,
+  default `Unsupported`/no-op) so existing backends keep working unchanged.
+  See the new [Cache Stampede Protection guide](docs/guide/cache-stampede.md).
+
 - **jobs:** tracked job handles with progress reporting and a built-in
   pollable status route (#1373). `job::enqueue_tracked`/`enqueue_tracked_for`
   (and the generated `{Job}::enqueue_tracked`/`enqueue_tracked_for`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gains two default methods (`try_acquire_fill_lock`/`release_fill_lock`,
   default `Unsupported`/no-op) so existing backends keep working unchanged.
   See the new [Cache Stampede Protection guide](docs/guide/cache-stampede.md).
+  Hardening from review: SWR freshness checks now correctly distinguish a
+  stale envelope from a completed refresh in the lock-poll path, `ttl: None`
+  combined with `stale_while_revalidate` no longer serves as permanently
+  stale, the lock-poll loop backs off exponentially instead of polling at a
+  fixed cadence, background refreshes are capped at 64 concurrent across all
+  keys, the Redis fill-lock key lives in its own namespace instead of one
+  that could collide with an ordinary cache key, and SWR freshness is now
+  evaluated through the same injectable `ClockSource` used elsewhere in the
+  framework rather than a hard-coded `SystemTime::now()`.
 
 - **jobs:** tracked job handles with progress reporting and a built-in
   pollable status route (#1373). `job::enqueue_tracked`/`enqueue_tracked_for`

--- a/autumn-cache-redis/src/lib.rs
+++ b/autumn-cache-redis/src/lib.rs
@@ -654,12 +654,9 @@ mod tests {
             .lock_wait_timeout(Duration::from_millis(300))
             .lock_poll_interval(Duration::from_millis(50));
 
-        let value: i32 = autumn_web::cache::get_or_compute_with(&cache, key, opts, move || {
-            let fc = fc.clone();
-            async move {
-                fc.fetch_add(1, Ordering::SeqCst);
-                Ok::<i32, String>(123)
-            }
+        let value: i32 = autumn_web::cache::get_or_compute_with(&cache, key, opts, move || async move {
+            fc.fetch_add(1, Ordering::SeqCst);
+            Ok::<i32, String>(123)
         })
         .await
         .unwrap();
@@ -687,12 +684,9 @@ mod tests {
             &cache,
             "rt-key",
             Some(Duration::from_secs(60)),
-            move || {
-                let fc = fc.clone();
-                async move {
-                    fc.fetch_add(1, Ordering::SeqCst);
-                    Ok::<String, String>("value-from-redis".to_string())
-                }
+            move || async move {
+                fc.fetch_add(1, Ordering::SeqCst);
+                Ok::<String, String>("value-from-redis".to_string())
             },
         )
         .await
@@ -704,12 +698,9 @@ mod tests {
             &cache,
             "rt-key",
             Some(Duration::from_secs(60)),
-            move || {
-                let fc = fc.clone();
-                async move {
-                    fc.fetch_add(1, Ordering::SeqCst);
-                    Ok::<String, String>("should-not-run".to_string())
-                }
+            move || async move {
+                fc.fetch_add(1, Ordering::SeqCst);
+                Ok::<String, String>("should-not-run".to_string())
             },
         )
         .await
@@ -748,13 +739,10 @@ mod tests {
                     .lock_wait_timeout(Duration::from_secs(5));
                 handles.push(tokio::spawn(async move {
                     autumn_web::cache::get_or_compute_with::<String, String, _, _>(
-                        &replica, key, opts, move || {
-                            let fc = fc.clone();
-                            async move {
-                                fc.fetch_add(1, Ordering::SeqCst);
-                                tokio::time::sleep(Duration::from_millis(300)).await;
-                                Ok("cross-replica-value".to_string())
-                            }
+                        &replica, key, opts, move || async move {
+                            fc.fetch_add(1, Ordering::SeqCst);
+                            tokio::time::sleep(Duration::from_millis(300)).await;
+                            Ok("cross-replica-value".to_string())
                         },
                     )
                     .await

--- a/autumn-cache-redis/src/lib.rs
+++ b/autumn-cache-redis/src/lib.rs
@@ -38,12 +38,25 @@
 
 use std::any::Any;
 use std::sync::Arc;
+use std::time::Duration;
 
-use autumn_web::cache::{Cache, RawCacheBytes};
+use autumn_web::cache::{Cache, FillLockStatus, RawCacheBytes};
 use redis::AsyncCommands as _;
 use redis::aio::ConnectionManager;
 use thiserror::Error;
 use tracing::debug;
+
+/// Lua script for a compare-and-delete fill-lock release: only deletes the
+/// lock key if it still holds the caller's token, so a caller can never
+/// release a lock that another replica has since acquired (e.g. after this
+/// caller's lock expired and was taken over).
+const RELEASE_FILL_LOCK_SCRIPT: &str = r"
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+    return redis.call('DEL', KEYS[1])
+else
+    return 0
+end
+";
 
 /// Errors that can occur when constructing or using a [`RedisCache`].
 #[derive(Debug, Error)]
@@ -118,6 +131,10 @@ impl RedisCache {
 
     fn prefixed(&self, key: &str) -> String {
         format!("{}:{}", self.key_prefix, key)
+    }
+
+    fn fill_lock_key(&self, key: &str) -> String {
+        format!("{}:{}:fill-lock", self.key_prefix, key)
     }
 
     fn redis_get(&self, key: &str) -> Option<Vec<u8>> {
@@ -254,6 +271,57 @@ impl Cache for RedisCache {
             });
         });
     }
+
+    /// Acquires a cross-replica fill lock via `SET NX PX`. Redis errors are
+    /// treated as [`FillLockStatus::Held`] (fail closed toward "someone else
+    /// may be filling") — the caller's `lock_wait_timeout` bounds how long it
+    /// waits before falling back to filling locally.
+    fn try_acquire_fill_lock(&self, key: &str, token: &str, ttl: Duration) -> FillLockStatus {
+        let lock_key = self.fill_lock_key(key);
+        let millis = ttl_millis_for_redis(ttl);
+        let mut conn = self.manager.clone();
+        let token = token.to_owned();
+        let acquired = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async move {
+                redis::cmd("SET")
+                    .arg(&lock_key)
+                    .arg(&token)
+                    .arg("NX")
+                    .arg("PX")
+                    .arg(millis)
+                    .query_async::<Option<String>>(&mut conn)
+                    .await
+            })
+        });
+        match acquired {
+            Ok(Some(_)) => FillLockStatus::Acquired,
+            Ok(None) => FillLockStatus::Held,
+            Err(e) => {
+                debug!(key, error = %e, "RedisCache: fill lock acquire failed, treating as held");
+                FillLockStatus::Held
+            }
+        }
+    }
+
+    /// Releases the fill lock only if `token` still owns it (compare-and-delete
+    /// via a Lua script), so a caller can never release a lock another replica
+    /// has since taken over after this caller's lock expired.
+    fn release_fill_lock(&self, key: &str, token: &str) {
+        let lock_key = self.fill_lock_key(key);
+        let mut conn = self.manager.clone();
+        let token = token.to_owned();
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async move {
+                let script = redis::Script::new(RELEASE_FILL_LOCK_SCRIPT);
+                let _: Result<i64, _> = script
+                    .key(&lock_key)
+                    .arg(&token)
+                    .invoke_async(&mut conn)
+                    .await;
+            });
+        });
+        debug!(key, "RedisCache: released fill lock");
+    }
 }
 
 // ── Plugin ────────────────────────────────────────────────────────────────────
@@ -311,6 +379,7 @@ impl autumn_web::plugin::Plugin for RedisCachePlugin {
 mod tests {
     use super::*;
     use autumn_web::cache::{get_cached, insert_cached};
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use testcontainers::runners::AsyncRunner;
     use testcontainers_modules::redis::Redis as RedisImage;
 
@@ -430,7 +499,6 @@ mod tests {
     #[ignore = "requires Docker (testcontainers)"]
     async fn redis_cache_response_layer_caches_http_gets() {
         use std::convert::Infallible;
-        use std::sync::atomic::{AtomicUsize, Ordering};
 
         use autumn_web::cache::CacheResponseLayer;
         use autumn_web::reexports::axum::body::{Body, to_bytes};
@@ -503,5 +571,206 @@ mod tests {
         assert_eq!(counter.load(Ordering::SeqCst), 1);
 
         cache.invalidate("http:/redis-backed");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn redis_fill_lock_acquire_conflict_release() {
+        let container = RedisImage::default().start().await.unwrap();
+        let port = container.get_host_port_ipv4(6379).await.unwrap();
+        let url = format!("redis://127.0.0.1:{port}");
+        let cache = RedisCache::connect(&url, "fill-lock-test").await.unwrap();
+
+        assert_eq!(
+            cache.try_acquire_fill_lock("k", "token-a", Duration::from_secs(10)),
+            FillLockStatus::Acquired
+        );
+        assert_eq!(
+            cache.try_acquire_fill_lock("k", "token-b", Duration::from_secs(10)),
+            FillLockStatus::Held,
+            "a second replica must not acquire a lock already held"
+        );
+
+        // Releasing with the wrong token must not free the lock.
+        cache.release_fill_lock("k", "token-b");
+        assert_eq!(
+            cache.try_acquire_fill_lock("k", "token-b", Duration::from_secs(10)),
+            FillLockStatus::Held,
+            "releasing with a stale/foreign token must be a no-op"
+        );
+
+        // Releasing with the owning token frees it for the next acquirer.
+        cache.release_fill_lock("k", "token-a");
+        assert_eq!(
+            cache.try_acquire_fill_lock("k", "token-b", Duration::from_secs(10)),
+            FillLockStatus::Acquired
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn redis_fill_lock_expires_after_ttl() {
+        let container = RedisImage::default().start().await.unwrap();
+        let port = container.get_host_port_ipv4(6379).await.unwrap();
+        let url = format!("redis://127.0.0.1:{port}");
+        let cache = RedisCache::connect(&url, "fill-lock-ttl-test").await.unwrap();
+
+        assert_eq!(
+            cache.try_acquire_fill_lock("k", "crashed-filler", Duration::from_millis(200)),
+            FillLockStatus::Acquired
+        );
+        // Never release — simulate a filler that crashed while holding the lock.
+        tokio::time::sleep(Duration::from_millis(400)).await;
+
+        assert_eq!(
+            cache.try_acquire_fill_lock("k", "new-filler", Duration::from_secs(10)),
+            FillLockStatus::Acquired,
+            "the lock TTL must bound damage from a crashed filler"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn redis_lock_wait_timeout_falls_back_to_self_fill() {
+        use autumn_web::cache::GetOrComputeOptions;
+
+        let container = RedisImage::default().start().await.unwrap();
+        let port = container.get_host_port_ipv4(6379).await.unwrap();
+        let url = format!("redis://127.0.0.1:{port}");
+        let cache: Arc<dyn Cache> =
+            Arc::new(RedisCache::connect(&url, "lock-timeout-test").await.unwrap());
+
+        // Simulate a stuck holder that never releases and outlives the test.
+        let key = "stuck-key";
+        assert_eq!(
+            cache.try_acquire_fill_lock(key, "stuck-holder", Duration::from_secs(60)),
+            FillLockStatus::Acquired
+        );
+
+        let fill_count = Arc::new(AtomicUsize::new(0));
+        let fc = fill_count.clone();
+        let opts = GetOrComputeOptions::new()
+            .distributed_fill_lock(true)
+            .lock_wait_timeout(Duration::from_millis(300))
+            .lock_poll_interval(Duration::from_millis(50));
+
+        let value: i32 = autumn_web::cache::get_or_compute_with(&cache, key, opts, move || {
+            let fc = fc.clone();
+            async move {
+                fc.fetch_add(1, Ordering::SeqCst);
+                Ok::<i32, String>(123)
+            }
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(value, 123);
+        assert_eq!(
+            fill_count.load(Ordering::SeqCst),
+            1,
+            "after the wait timeout the caller must fall back to filling locally"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn redis_get_or_compute_round_trip() {
+        let container = RedisImage::default().start().await.unwrap();
+        let port = container.get_host_port_ipv4(6379).await.unwrap();
+        let url = format!("redis://127.0.0.1:{port}");
+        let cache: Arc<dyn Cache> =
+            Arc::new(RedisCache::connect(&url, "read-through-test").await.unwrap());
+
+        let fill_count = Arc::new(AtomicUsize::new(0));
+        let fc = fill_count.clone();
+        let v: String = autumn_web::cache::get_or_compute(
+            &cache,
+            "rt-key",
+            Some(Duration::from_secs(60)),
+            move || {
+                let fc = fc.clone();
+                async move {
+                    fc.fetch_add(1, Ordering::SeqCst);
+                    Ok::<String, String>("value-from-redis".to_string())
+                }
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(v, "value-from-redis");
+
+        let fc = fill_count.clone();
+        let v: String = autumn_web::cache::get_or_compute(
+            &cache,
+            "rt-key",
+            Some(Duration::from_secs(60)),
+            move || {
+                let fc = fc.clone();
+                async move {
+                    fc.fetch_add(1, Ordering::SeqCst);
+                    Ok::<String, String>("should-not-run".to_string())
+                }
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(v, "value-from-redis", "second call must hit via RawCacheBytes deserialization");
+        assert_eq!(fill_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn redis_cross_replica_single_fill() {
+        use autumn_web::cache::GetOrComputeOptions;
+
+        let container = RedisImage::default().start().await.unwrap();
+        let port = container.get_host_port_ipv4(6379).await.unwrap();
+        let url = format!("redis://127.0.0.1:{port}");
+
+        // Two independent connections sharing the same key prefix, modeling
+        // two application replicas.
+        let replica_a: Arc<dyn Cache> =
+            Arc::new(RedisCache::connect(&url, "xrepl-fill").await.unwrap());
+        let replica_b: Arc<dyn Cache> =
+            Arc::new(RedisCache::connect(&url, "xrepl-fill").await.unwrap());
+
+        let fill_count = Arc::new(AtomicUsize::new(0));
+        let key = "hot-key";
+
+        let mut handles = Vec::new();
+        for replica in [replica_a, replica_b] {
+            for _ in 0..4 {
+                let replica = replica.clone();
+                let fc = fill_count.clone();
+                let opts = GetOrComputeOptions::new()
+                    .distributed_fill_lock(true)
+                    .lock_poll_interval(Duration::from_millis(30))
+                    .lock_wait_timeout(Duration::from_secs(5));
+                handles.push(tokio::spawn(async move {
+                    autumn_web::cache::get_or_compute_with::<String, String, _, _>(
+                        &replica, key, opts, move || {
+                            let fc = fc.clone();
+                            async move {
+                                fc.fetch_add(1, Ordering::SeqCst);
+                                tokio::time::sleep(Duration::from_millis(300)).await;
+                                Ok("cross-replica-value".to_string())
+                            }
+                        },
+                    )
+                    .await
+                }));
+            }
+        }
+
+        for h in handles {
+            let v = h.await.unwrap().unwrap();
+            assert_eq!(v, "cross-replica-value");
+        }
+
+        assert_eq!(
+            fill_count.load(Ordering::SeqCst),
+            1,
+            "the distributed fill lock must limit total fills to 1 across both replicas"
+        );
     }
 }

--- a/autumn-cache-redis/src/lib.rs
+++ b/autumn-cache-redis/src/lib.rs
@@ -693,6 +693,51 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "requires Docker (testcontainers)"]
+    async fn redis_lock_wait_timeout_not_overshot_by_poll_interval() {
+        use autumn_web::cache::GetOrComputeOptions;
+
+        let container = RedisImage::default().start().await.unwrap();
+        let port = container.get_host_port_ipv4(6379).await.unwrap();
+        let url = format!("redis://127.0.0.1:{port}");
+        let cache: Arc<dyn Cache> = Arc::new(
+            RedisCache::connect(&url, "lock-timeout-overshoot-test")
+                .await
+                .unwrap(),
+        );
+
+        // Simulate a stuck holder that never releases and outlives the test.
+        let key = "stuck-key-overshoot";
+        assert_eq!(
+            cache.try_acquire_fill_lock(key, "stuck-holder", Duration::from_secs(60)),
+            FillLockStatus::Acquired
+        );
+
+        // A poll interval much larger than the wait timeout must not make the
+        // caller sleep past the timeout before falling back: lock_wait_timeout
+        // bounds the total wait regardless of the poll cadence.
+        let opts = GetOrComputeOptions::new()
+            .distributed_fill_lock(true)
+            .lock_wait_timeout(Duration::from_millis(100))
+            .lock_poll_interval(Duration::from_secs(5));
+
+        let start = std::time::Instant::now();
+        let value: i32 =
+            autumn_web::cache::get_or_compute_with(&cache, key, opts, move || async move {
+                Ok::<i32, String>(456)
+            })
+            .await
+            .unwrap();
+        let elapsed = start.elapsed();
+
+        assert_eq!(value, 456);
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "lock_wait_timeout must bound the wait even when lock_poll_interval is much larger; took {elapsed:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "requires Docker (testcontainers)"]
     async fn redis_get_or_compute_round_trip() {
         let container = RedisImage::default().start().await.unwrap();
         let port = container.get_host_port_ipv4(6379).await.unwrap();

--- a/autumn-cache-redis/src/lib.rs
+++ b/autumn-cache-redis/src/lib.rs
@@ -133,8 +133,19 @@ impl RedisCache {
         format!("{}:{}", self.key_prefix, key)
     }
 
+    /// Physical key for `key`'s distributed fill lock.
+    ///
+    /// Deliberately **not** nested under `key_prefix:` (i.e. not
+    /// `prefixed(format!("{key}:fill-lock"))`): `prefixed()` maps every
+    /// possible `key` onto `"{key_prefix}:{key}"`, so any suffix appended
+    /// under that same namespace is reachable by *some* ordinary cache key
+    /// (e.g. an app key literally named `"session:fill-lock"`) and could
+    /// silently collide with a lock entry. Using a distinct top-level sentinel
+    /// here means a collision would require the operator's own `key_prefix`
+    /// to equal `"__autumn_fill_lock__"`, not merely an unlucky choice of
+    /// cache key.
     fn fill_lock_key(&self, key: &str) -> String {
-        format!("{}:{}:fill-lock", self.key_prefix, key)
+        format!("__autumn_fill_lock__:{}:{}", self.key_prefix, key)
     }
 
     fn redis_get(&self, key: &str) -> Option<Vec<u8>> {
@@ -310,17 +321,22 @@ impl Cache for RedisCache {
         let lock_key = self.fill_lock_key(key);
         let mut conn = self.manager.clone();
         let token = token.to_owned();
-        tokio::task::block_in_place(|| {
+        let result: Result<i64, _> = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async move {
                 let script = redis::Script::new(RELEASE_FILL_LOCK_SCRIPT);
-                let _: Result<i64, _> = script
+                script
                     .key(&lock_key)
                     .arg(&token)
                     .invoke_async(&mut conn)
-                    .await;
-            });
+                    .await
+            })
         });
-        debug!(key, "RedisCache: released fill lock");
+        match result {
+            Ok(_) => debug!(key, "RedisCache: released fill lock"),
+            Err(e) => {
+                debug!(key, error = %e, "RedisCache: fill lock release failed");
+            }
+        }
     }
 }
 

--- a/autumn-cache-redis/src/lib.rs
+++ b/autumn-cache-redis/src/lib.rs
@@ -613,7 +613,9 @@ mod tests {
         let container = RedisImage::default().start().await.unwrap();
         let port = container.get_host_port_ipv4(6379).await.unwrap();
         let url = format!("redis://127.0.0.1:{port}");
-        let cache = RedisCache::connect(&url, "fill-lock-ttl-test").await.unwrap();
+        let cache = RedisCache::connect(&url, "fill-lock-ttl-test")
+            .await
+            .unwrap();
 
         assert_eq!(
             cache.try_acquire_fill_lock("k", "crashed-filler", Duration::from_millis(200)),
@@ -637,8 +639,11 @@ mod tests {
         let container = RedisImage::default().start().await.unwrap();
         let port = container.get_host_port_ipv4(6379).await.unwrap();
         let url = format!("redis://127.0.0.1:{port}");
-        let cache: Arc<dyn Cache> =
-            Arc::new(RedisCache::connect(&url, "lock-timeout-test").await.unwrap());
+        let cache: Arc<dyn Cache> = Arc::new(
+            RedisCache::connect(&url, "lock-timeout-test")
+                .await
+                .unwrap(),
+        );
 
         // Simulate a stuck holder that never releases and outlives the test.
         let key = "stuck-key";
@@ -654,12 +659,13 @@ mod tests {
             .lock_wait_timeout(Duration::from_millis(300))
             .lock_poll_interval(Duration::from_millis(50));
 
-        let value: i32 = autumn_web::cache::get_or_compute_with(&cache, key, opts, move || async move {
-            fc.fetch_add(1, Ordering::SeqCst);
-            Ok::<i32, String>(123)
-        })
-        .await
-        .unwrap();
+        let value: i32 =
+            autumn_web::cache::get_or_compute_with(&cache, key, opts, move || async move {
+                fc.fetch_add(1, Ordering::SeqCst);
+                Ok::<i32, String>(123)
+            })
+            .await
+            .unwrap();
 
         assert_eq!(value, 123);
         assert_eq!(
@@ -675,8 +681,11 @@ mod tests {
         let container = RedisImage::default().start().await.unwrap();
         let port = container.get_host_port_ipv4(6379).await.unwrap();
         let url = format!("redis://127.0.0.1:{port}");
-        let cache: Arc<dyn Cache> =
-            Arc::new(RedisCache::connect(&url, "read-through-test").await.unwrap());
+        let cache: Arc<dyn Cache> = Arc::new(
+            RedisCache::connect(&url, "read-through-test")
+                .await
+                .unwrap(),
+        );
 
         let fill_count = Arc::new(AtomicUsize::new(0));
         let fc = fill_count.clone();
@@ -705,7 +714,10 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(v, "value-from-redis", "second call must hit via RawCacheBytes deserialization");
+        assert_eq!(
+            v, "value-from-redis",
+            "second call must hit via RawCacheBytes deserialization"
+        );
         assert_eq!(fill_count.load(Ordering::SeqCst), 1);
     }
 
@@ -739,7 +751,10 @@ mod tests {
                     .lock_wait_timeout(Duration::from_secs(5));
                 handles.push(tokio::spawn(async move {
                     autumn_web::cache::get_or_compute_with::<String, String, _, _>(
-                        &replica, key, opts, move || async move {
+                        &replica,
+                        key,
+                        opts,
+                        move || async move {
                             fc.fetch_add(1, Ordering::SeqCst);
                             tokio::time::sleep(Duration::from_millis(300)).await;
                             Ok("cross-replica-value".to_string())

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -1872,6 +1872,16 @@ pub(crate) async fn metrics_endpoint<S: ProvideActuatorState + Send + Sync + 'st
     let snapshot = state.metrics().snapshot();
     let mut result = serde_json::to_value(&snapshot).unwrap_or_default();
 
+    // Include read-through cache stampede-protection counters (always
+    // present; the read-through API works standalone without app state).
+    if let serde_json::Value::Object(ref mut map) = result {
+        map.insert(
+            "cache".to_string(),
+            serde_json::to_value(crate::cache::read_through_metrics().snapshot())
+                .unwrap_or_default(),
+        );
+    }
+
     // Include DB pool stats if available
     #[cfg(feature = "db")]
     if let Some(pool) = state.pool() {
@@ -2301,6 +2311,67 @@ fn write_builtin_http_metrics(
     }
 }
 
+/// Render the built-in `autumn_cache_*` read-through stampede-protection
+/// counters into `out`, tagged with the replica's deploy `version` label.
+/// These counters are process-wide (the read-through API works standalone
+/// without app state), unlike the HTTP metrics which come from per-app state.
+fn write_builtin_cache_metrics(
+    out: &mut String,
+    version: &str,
+    snapshot: &crate::cache::ReadThroughMetricsSnapshot,
+) {
+    use std::fmt::Write;
+
+    for (name, help, value) in [
+        (
+            "autumn_cache_read_through_hits_total",
+            "Read-through cache reads served from a fresh cached value",
+            snapshot.hits,
+        ),
+        (
+            "autumn_cache_read_through_misses_total",
+            "Read-through cache reads that found no fresh cached value",
+            snapshot.misses,
+        ),
+        (
+            "autumn_cache_read_through_coalesced_waits_total",
+            "Read-through callers that awaited a concurrent in-process fill instead of \
+             computing their own (single-flight coalescing)",
+            snapshot.coalesced_waits,
+        ),
+        (
+            "autumn_cache_read_through_fills_total",
+            "Read-through fill closures that completed successfully",
+            snapshot.fills,
+        ),
+        (
+            "autumn_cache_read_through_fill_failures_total",
+            "Read-through fill closures that returned an error",
+            snapshot.fill_failures,
+        ),
+        (
+            "autumn_cache_read_through_stale_serves_total",
+            "Stale-while-revalidate reads that served a stale value while a background \
+             refresh ran",
+            snapshot.stale_serves,
+        ),
+        (
+            "autumn_cache_fill_lock_acquires_total",
+            "Distributed cache fill locks acquired by this process",
+            snapshot.fill_lock_acquires,
+        ),
+        (
+            "autumn_cache_fill_lock_contended_total",
+            "Distributed cache fill lock attempts that found the lock held by another replica",
+            snapshot.fill_lock_contended,
+        ),
+    ] {
+        let _ = writeln!(out, "# HELP {name} {help}");
+        let _ = writeln!(out, "# TYPE {name} counter");
+        let _ = writeln!(out, "{name}{{version=\"{version}\"}} {value}");
+    }
+}
+
 /// `GET <actuator-prefix>/prometheus` -- export metrics in Prometheus format.
 pub(crate) async fn prometheus_endpoint<S: ProvideActuatorState + Send + Sync + 'static>(
     State(state): State<S>,
@@ -2313,6 +2384,11 @@ pub(crate) async fn prometheus_endpoint<S: ProvideActuatorState + Send + Sync + 
     let mut out = String::with_capacity(2048);
 
     write_builtin_http_metrics(&mut out, &version, &snapshot);
+    write_builtin_cache_metrics(
+        &mut out,
+        &version,
+        &crate::cache::read_through_metrics().snapshot(),
+    );
 
     // Plugin-contributed metric families — seed with built-in names so
     // plugins cannot shadow or duplicate them.
@@ -2327,6 +2403,14 @@ pub(crate) async fn prometheus_endpoint<S: ProvideActuatorState + Send + Sync + 
             "autumn_read_your_writes_pins_total",
             "autumn_http_route_requests_total",
             "autumn_metrics_source_errors_total",
+            "autumn_cache_read_through_hits_total",
+            "autumn_cache_read_through_misses_total",
+            "autumn_cache_read_through_coalesced_waits_total",
+            "autumn_cache_read_through_fills_total",
+            "autumn_cache_read_through_fill_failures_total",
+            "autumn_cache_read_through_stale_serves_total",
+            "autumn_cache_fill_lock_acquires_total",
+            "autumn_cache_fill_lock_contended_total",
         ]
         .iter()
         .map(|s| (*s).to_string())
@@ -4295,6 +4379,105 @@ mod tests {
         assert!(text.contains("# HELP autumn_read_your_writes_pins_total"));
         assert!(text.contains("# TYPE autumn_read_your_writes_pins_total counter"));
         assert!(text.contains("autumn_read_your_writes_pins_total{version=\"stable\"} 0"));
+    }
+
+    #[cfg(feature = "cache-moka")]
+    #[tokio::test]
+    async fn prometheus_includes_cache_read_through_counters() {
+        // read_through_metrics() is a process-wide singleton shared with other
+        // tests in this crate; assert presence and a monotonic delta rather
+        // than an absolute value.
+        let before = crate::cache::read_through_metrics().snapshot();
+        let cache: std::sync::Arc<dyn crate::cache::Cache> =
+            std::sync::Arc::new(crate::cache::MokaCache::new(10, None));
+        let key = format!("actuator-prometheus-cache-test-{before:?}");
+        let _: i32 =
+            crate::cache::get_or_compute(
+                &cache,
+                &key,
+                None,
+                || async move { Ok::<i32, String>(1) },
+            )
+            .await
+            .unwrap();
+        let after = crate::cache::read_through_metrics().snapshot();
+        assert!(after.fills > before.fills, "fills counter must increase");
+
+        let state = test_state();
+        let app = actuator_router(true).with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/prometheus")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+
+        for name in [
+            "autumn_cache_read_through_hits_total",
+            "autumn_cache_read_through_misses_total",
+            "autumn_cache_read_through_coalesced_waits_total",
+            "autumn_cache_read_through_fills_total",
+            "autumn_cache_read_through_fill_failures_total",
+            "autumn_cache_read_through_stale_serves_total",
+            "autumn_cache_fill_lock_acquires_total",
+            "autumn_cache_fill_lock_contended_total",
+        ] {
+            assert!(
+                text.contains(&format!("# TYPE {name} counter")),
+                "missing TYPE line for {name} in:\n{text}"
+            );
+            assert!(
+                text.contains(&format!("{name}{{version=\"stable\"}}")),
+                "missing value line for {name} in:\n{text}"
+            );
+        }
+    }
+
+    #[cfg(feature = "cache-moka")]
+    #[tokio::test]
+    async fn metrics_json_includes_cache_section() {
+        let cache: std::sync::Arc<dyn crate::cache::Cache> =
+            std::sync::Arc::new(crate::cache::MokaCache::new(10, None));
+        let key = "actuator-metrics-json-cache-test";
+        let _: i32 =
+            crate::cache::get_or_compute(&cache, key, None, || async move { Ok::<i32, String>(1) })
+                .await
+                .unwrap();
+
+        let state = test_state();
+        let app = actuator_router(true).with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/actuator/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["cache"]["fills"].as_u64().unwrap() >= 1);
+        assert!(json["cache"]["hits"].is_u64());
+        assert!(json["cache"]["misses"].is_u64());
+        assert!(json["cache"]["coalesced_waits"].is_u64());
+        assert!(json["cache"]["fill_failures"].is_u64());
+        assert!(json["cache"]["stale_serves"].is_u64());
+        assert!(json["cache"]["fill_lock_acquires"].is_u64());
+        assert!(json["cache"]["fill_lock_contended"].is_u64());
     }
 
     #[tokio::test]

--- a/autumn/src/cache/mod.rs
+++ b/autumn/src/cache/mod.rs
@@ -38,16 +38,22 @@ mod fragment;
 mod layer;
 #[cfg(feature = "cache-moka")]
 mod moka_impl;
+mod read_through;
 
 #[cfg(feature = "maud")]
 pub use fragment::{cache_fragment, cache_fragment_global};
 pub use layer::{CacheResponseLayer, CacheResponseService};
 #[cfg(feature = "cache-moka")]
 pub use moka_impl::MokaCache;
+pub use read_through::{
+    CacheFillError, GetOrComputeOptions, ReadThroughMetrics, ReadThroughMetricsSnapshot,
+    get_or_compute, get_or_compute_with, jittered_ttl, read_through_metrics,
+};
 
 use std::any::Any;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 
 // ── Global cache registry ────────────────────────────────────────────
 
@@ -148,6 +154,45 @@ pub trait Cache: Send + Sync + 'static {
     ///
     /// [`insert_value`]: Cache::insert_value
     fn insert_raw_bytes(&self, _key: &str, _bytes: Vec<u8>, _ttl: Option<std::time::Duration>) {}
+
+    /// Try to acquire a cross-replica fill lock for `key`, used by
+    /// [`get_or_compute_with`] to ensure at most one replica refills a hot
+    /// key at a time.
+    ///
+    /// `token` identifies the caller so [`release_fill_lock`] can safely
+    /// release only a lock it still owns. `ttl` bounds how long the lock is
+    /// held if the caller crashes before releasing it.
+    ///
+    /// The default implementation reports [`FillLockStatus::Unsupported`],
+    /// which degrades callers to in-process-only single-flight protection —
+    /// safe for backends (like the in-process Moka cache) that have no
+    /// cross-replica visibility.
+    ///
+    /// [`release_fill_lock`]: Cache::release_fill_lock
+    fn try_acquire_fill_lock(&self, _key: &str, _token: &str, _ttl: Duration) -> FillLockStatus {
+        FillLockStatus::Unsupported
+    }
+
+    /// Release the fill lock previously acquired with `token`, if this
+    /// caller still owns it. The default is a no-op, matching the default
+    /// [`try_acquire_fill_lock`] returning [`FillLockStatus::Unsupported`].
+    ///
+    /// [`try_acquire_fill_lock`]: Cache::try_acquire_fill_lock
+    fn release_fill_lock(&self, _key: &str, _token: &str) {}
+}
+
+/// Outcome of [`Cache::try_acquire_fill_lock`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FillLockStatus {
+    /// The caller now holds the lock and must call
+    /// [`Cache::release_fill_lock`] when the fill completes (success or
+    /// failure).
+    Acquired,
+    /// Another replica currently holds the lock.
+    Held,
+    /// This backend has no cross-replica fill lock; callers fall back to
+    /// in-process-only single-flight protection.
+    Unsupported,
 }
 
 // ── Typed convenience functions ──────────────────────────────────────

--- a/autumn/src/cache/read_through.rs
+++ b/autumn/src/cache/read_through.rs
@@ -437,6 +437,14 @@ const MAX_LOCK_POLL_INTERVAL: Duration = Duration::from_secs(1);
 /// "lock free," acquires the now-unlocked lock, and runs its own redundant
 /// fill — exactly the duplicate-recompute the distributed lock exists to
 /// prevent.
+///
+/// Re-checks the cache immediately after acquiring the lock, before running
+/// `fill`: another replica's entire acquire-fill-write-release cycle can
+/// complete between this caller's last cache read and this successful
+/// acquisition, in which case the lock is "free" only because that replica
+/// already finished — running `fill` again here would be a redundant (and,
+/// for a non-idempotent fill, harmful) duplicate of work someone else just
+/// did.
 async fn run_fill_and_release<V, E, F, Fut>(
     cache: &Arc<dyn Cache>,
     key: &str,
@@ -451,6 +459,12 @@ where
     F: FnOnce() -> Fut + Send,
     Fut: Future<Output = Result<V, E>> + Send,
 {
+    if let Some(value) = fast_path_value::<V>(cache, key, options) {
+        cache.release_fill_lock(key, token);
+        let _ = tx.send(FillState::Done(Arc::new(value.clone())));
+        return Ok(value);
+    }
+
     read_through_metrics()
         .fill_lock_acquires
         .fetch_add(1, Ordering::Relaxed);
@@ -932,6 +946,45 @@ mod tests {
             fast_path_value::<String>(&cache, key, &options),
             Some("fresh-value".to_string())
         );
+    }
+
+    #[cfg(feature = "cache-moka")]
+    #[tokio::test]
+    async fn run_fill_and_release_skips_fill_if_value_already_present() {
+        use super::super::MokaCache;
+
+        let cache: Arc<dyn Cache> = Arc::new(MokaCache::new(10, None));
+        let key = "recheck-after-lock-key";
+        let options = GetOrComputeOptions::new();
+        let (tx, mut rx) = watch::channel(FillState::Pending);
+
+        // Simulate another replica having already run an entire
+        // acquire-fill-write-release cycle in the gap between this caller's
+        // last cache read and its own (now successful) lock acquisition.
+        insert_cached(cache.as_ref(), key, "already-written".to_string(), None);
+
+        let fill_count = Arc::new(AtomicU64::new(0));
+        let fc = fill_count.clone();
+        let result: Result<String, CacheFillError<String>> = run_fill_and_release(
+            &cache,
+            key,
+            &options,
+            move || async move {
+                fc.fetch_add(1, Ordering::Relaxed);
+                Ok::<String, String>("redundant-recompute".to_string())
+            },
+            &tx,
+            "token",
+        )
+        .await;
+
+        assert_eq!(result.unwrap(), "already-written");
+        assert_eq!(
+            fill_count.load(Ordering::Relaxed),
+            0,
+            "fill must not run when another replica already wrote the value"
+        );
+        assert!(matches!(*rx.borrow_and_update(), FillState::Done(_)));
     }
 
     #[test]

--- a/autumn/src/cache/read_through.rs
+++ b/autumn/src/cache/read_through.rs
@@ -30,11 +30,11 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex, PoisonError};
-use std::time::Duration;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use tokio::sync::watch;
 
-use super::Cache;
+use super::{Cache, FillLockStatus, get_cached, insert_cached};
 
 // ── Options ──────────────────────────────────────────────────────────
 
@@ -203,14 +203,25 @@ impl ReadThroughMetrics {
     /// Take a consistent-enough snapshot of all counters (each counter is
     /// read atomically; the set is not read under a global lock).
     pub fn snapshot(&self) -> ReadThroughMetricsSnapshot {
-        todo!("green phase")
+        ReadThroughMetricsSnapshot {
+            hits: self.hits.load(Ordering::Relaxed),
+            misses: self.misses.load(Ordering::Relaxed),
+            coalesced_waits: self.coalesced_waits.load(Ordering::Relaxed),
+            fills: self.fills.load(Ordering::Relaxed),
+            fill_failures: self.fill_failures.load(Ordering::Relaxed),
+            stale_serves: self.stale_serves.load(Ordering::Relaxed),
+            fill_lock_acquires: self.fill_lock_acquires.load(Ordering::Relaxed),
+            fill_lock_contended: self.fill_lock_contended.load(Ordering::Relaxed),
+        }
     }
 }
 
 /// The process-wide [`ReadThroughMetrics`] instance updated by
 /// [`get_or_compute`] and [`get_or_compute_with`].
+#[must_use]
 pub fn read_through_metrics() -> &'static ReadThroughMetrics {
-    todo!("green phase")
+    static METRICS: LazyLock<ReadThroughMetrics> = LazyLock::new(ReadThroughMetrics::default);
+    &METRICS
 }
 
 // ── TTL jitter ───────────────────────────────────────────────────────
@@ -224,8 +235,28 @@ pub fn read_through_metrics() -> &'static ReadThroughMetrics {
 /// `0.0` (no jitter).
 #[must_use]
 pub fn jittered_ttl(base: Duration, fraction: f64) -> Duration {
-    let _ = (base, fraction);
-    todo!("green phase")
+    let fraction = if fraction.is_finite() {
+        fraction.clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    if fraction == 0.0 {
+        return base;
+    }
+
+    let mut buf = [0_u8; 4];
+    if getrandom::getrandom(&mut buf).is_err() {
+        // Fallback entropy source if the OS RNG is unavailable.
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0);
+        buf = nanos.to_le_bytes();
+    }
+    let unit = f64::from(u32::from_le_bytes(buf)) / f64::from(u32::MAX);
+    // factor is uniform in [1 - fraction, 1 + fraction].
+    let factor = fraction.mul_add(2.0f64.mul_add(unit, -1.0), 1.0);
+    base.mul_f64(factor)
 }
 
 // ── In-flight registry (single-flight) ──────────────────────────────
@@ -238,17 +269,20 @@ enum FillState {
     Failed(Arc<str>),
 }
 
+/// Identifies a single in-flight fill: which cache backend, and which key.
+type InFlightKey = (usize, String);
+
 /// In-flight fills, keyed by (cache identity, key). Two distinct
 /// `Arc<dyn Cache>` allocations never coalesce with each other.
-#[allow(dead_code)] // used from the green phase onwards
-static IN_FLIGHT: LazyLock<Mutex<HashMap<(usize, String), watch::Receiver<FillState>>>> =
+static IN_FLIGHT: LazyLock<Mutex<HashMap<InFlightKey, watch::Receiver<FillState>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// RAII removal of an in-flight entry: covers success, error, panic, and
-/// cancellation (the leader's future being dropped mid-fill).
-#[allow(dead_code)] // used from the green phase onwards
+/// cancellation (the leader's future being dropped mid-fill). Dropping the
+/// paired `watch::Sender` also closes the channel, which is how waiters
+/// notice a cancelled leader and re-contend for leadership.
 struct InFlightGuard {
-    key: (usize, String),
+    key: InFlightKey,
 }
 
 impl Drop for InFlightGuard {
@@ -257,6 +291,341 @@ impl Drop for InFlightGuard {
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .remove(&self.key);
+    }
+}
+
+/// Which role a caller plays for a given (cache, key): the single leader that
+/// runs the fill, or a waiter that awaits the leader's result.
+enum Role {
+    Leader(watch::Sender<FillState>, InFlightGuard),
+    Waiter(watch::Receiver<FillState>),
+}
+
+/// Identity of a cache backend, stable for the lifetime of the `Arc`
+/// allocation. Used so single-flight coalescing is scoped per cache handle:
+/// two distinct `Arc<dyn Cache>`s (e.g. two Redis "replica" connections in a
+/// test) never coalesce with each other, matching the fact that in-process
+/// coalescing is inherently per-process.
+fn cache_identity(cache: &Arc<dyn Cache>) -> usize {
+    (Arc::as_ptr(cache).cast::<()>()) as usize
+}
+
+/// Register as the leader for `(cache, key)`, or discover an existing leader
+/// and become a waiter. The `std::sync::Mutex` guard is held only for this
+/// synchronous lookup/insert — never across an `.await` point.
+fn claim_role(cache: &Arc<dyn Cache>, key: &str) -> Role {
+    use std::collections::hash_map::Entry;
+
+    let map_key: InFlightKey = (cache_identity(cache), key.to_owned());
+    // A single lock acquisition covers the whole check-then-insert so two
+    // threads can never both observe "no entry" and both become leader.
+    let mut in_flight = IN_FLIGHT.lock().unwrap_or_else(PoisonError::into_inner);
+    match in_flight.entry(map_key.clone()) {
+        Entry::Occupied(entry) => Role::Waiter(entry.get().clone()),
+        Entry::Vacant(entry) => {
+            let (tx, rx) = watch::channel(FillState::Pending);
+            entry.insert(rx);
+            Role::Leader(tx, InFlightGuard { key: map_key })
+        }
+    }
+}
+
+/// Await the leader's outcome. Returns `None` when the caller should retry
+/// (`claim_role` again) rather than trust the result: either the leader's
+/// future was dropped/cancelled before publishing an outcome (channel
+/// closed), or the leader published a value of a different type than `V`
+/// (the same key was used with two different value types).
+async fn await_result<V, E>(mut rx: watch::Receiver<FillState>) -> Option<Result<V, CacheFillError<E>>>
+where
+    V: Clone + Send + Sync + 'static,
+{
+    let state = {
+        let waited = rx.wait_for(|s| !matches!(s, FillState::Pending)).await;
+        match waited {
+            Ok(state_ref) => state_ref.clone(),
+            Err(_closed) => return None,
+        }
+    };
+    match state {
+        FillState::Pending => unreachable!("wait_for guarantees a non-pending state"),
+        FillState::Done(value) => value.downcast_ref::<V>().cloned().map(Ok),
+        FillState::Failed(message) => Some(Err(CacheFillError::FillFailed(message))),
+    }
+}
+
+// ── Stale-while-revalidate envelope ─────────────────────────────────
+
+/// Wraps a cached value with its freshness deadline when
+/// stale-while-revalidate is enabled. Stored in place of the bare value, so a
+/// key must be used consistently with or without SWR.
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+struct SwrEnvelope<V> {
+    value: V,
+    fresh_until_unix_ms: u64,
+}
+
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}
+
+/// Read the current value regardless of freshness (used for lock-poll and
+/// leader double-checks, where "does a value exist yet" is all that matters).
+fn fast_path_value<V>(cache: &Arc<dyn Cache>, key: &str, options: &GetOrComputeOptions) -> Option<V>
+where
+    V: Clone + serde::de::DeserializeOwned + Send + Sync + 'static,
+{
+    if options.stale_while_revalidate.is_some() {
+        get_cached::<SwrEnvelope<V>>(cache.as_ref(), key).map(|envelope| envelope.value)
+    } else {
+        get_cached::<V>(cache.as_ref(), key)
+    }
+}
+
+/// Run the fill closure (honoring the distributed fill lock if enabled),
+/// write the result, and publish the outcome to `tx`. Shared by the cold-miss
+/// leader path and the stale-while-revalidate background refresh.
+async fn run_leader_fill<V, E, F, Fut>(
+    cache: &Arc<dyn Cache>,
+    key: &str,
+    options: &GetOrComputeOptions,
+    fill: F,
+    tx: watch::Sender<FillState>,
+) -> Result<V, CacheFillError<E>>
+where
+    V: Clone + serde::Serialize + serde::de::DeserializeOwned + Send + Sync + 'static,
+    E: std::fmt::Display + Send + 'static,
+    F: FnOnce() -> Fut + Send,
+    Fut: Future<Output = Result<V, E>> + Send,
+{
+    if !options.distributed_fill_lock {
+        let result = fill().await;
+        return finish_fill(cache, key, options, result, &tx);
+    }
+
+    let token = uuid::Uuid::new_v4().to_string();
+    match cache.try_acquire_fill_lock(key, &token, options.lock_ttl) {
+        FillLockStatus::Unsupported => {
+            let result = fill().await;
+            finish_fill(cache, key, options, result, &tx)
+        }
+        FillLockStatus::Acquired => {
+            read_through_metrics()
+                .fill_lock_acquires
+                .fetch_add(1, Ordering::Relaxed);
+            let result = fill().await;
+            cache.release_fill_lock(key, &token);
+            finish_fill(cache, key, options, result, &tx)
+        }
+        FillLockStatus::Held => {
+            read_through_metrics()
+                .fill_lock_contended
+                .fetch_add(1, Ordering::Relaxed);
+            let start = Instant::now();
+            loop {
+                tokio::time::sleep(options.lock_poll_interval).await;
+
+                if let Some(value) = fast_path_value::<V>(cache, key, options) {
+                    let _ = tx.send(FillState::Done(Arc::new(value.clone())));
+                    return Ok(value);
+                }
+
+                if start.elapsed() >= options.lock_wait_timeout {
+                    // Bounded damage: give up waiting and fill locally rather
+                    // than block the caller indefinitely.
+                    let result = fill().await;
+                    return finish_fill(cache, key, options, result, &tx);
+                }
+
+                if cache.try_acquire_fill_lock(key, &token, options.lock_ttl)
+                    == FillLockStatus::Acquired
+                {
+                    read_through_metrics()
+                        .fill_lock_acquires
+                        .fetch_add(1, Ordering::Relaxed);
+                    let result = fill().await;
+                    cache.release_fill_lock(key, &token);
+                    return finish_fill(cache, key, options, result, &tx);
+                }
+            }
+        }
+    }
+}
+
+/// Write the fill outcome to the cache (as a bare value, or a
+/// [`SwrEnvelope`] when stale-while-revalidate is enabled) and publish it to
+/// waiters. A failure writes nothing, so the key is never poisoned.
+fn finish_fill<V, E>(
+    cache: &Arc<dyn Cache>,
+    key: &str,
+    options: &GetOrComputeOptions,
+    result: Result<V, E>,
+    tx: &watch::Sender<FillState>,
+) -> Result<V, CacheFillError<E>>
+where
+    V: Clone + serde::Serialize + serde::de::DeserializeOwned + Send + Sync + 'static,
+    E: std::fmt::Display,
+{
+    match result {
+        Ok(value) => {
+            if let Some(grace) = options.stale_while_revalidate {
+                let ttl_ms = options
+                    .ttl
+                    .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX));
+                let envelope = SwrEnvelope {
+                    value: value.clone(),
+                    fresh_until_unix_ms: now_unix_ms().saturating_add(ttl_ms),
+                };
+                let physical_ttl = options.ttl.map(|ttl| ttl + grace);
+                insert_cached(cache.as_ref(), key, envelope, physical_ttl);
+            } else {
+                insert_cached(cache.as_ref(), key, value.clone(), options.ttl);
+            }
+            read_through_metrics().fills.fetch_add(1, Ordering::Relaxed);
+            let _ = tx.send(FillState::Done(Arc::new(value.clone())));
+            Ok(value)
+        }
+        Err(error) => {
+            let message: Arc<str> = error.to_string().into();
+            read_through_metrics()
+                .fill_failures
+                .fetch_add(1, Ordering::Relaxed);
+            let _ = tx.send(FillState::Failed(message));
+            Err(CacheFillError::Fill(error))
+        }
+    }
+}
+
+/// Try to become the leader for a stale-while-revalidate background refresh.
+/// If another fill (a cold-miss leader, or an earlier refresh) is already
+/// in-flight for this key, do nothing and drop `fill` unrun — only one
+/// refresh should run at a time per key.
+fn spawn_background_refresh<V, E, F, Fut>(
+    cache: Arc<dyn Cache>,
+    key: String,
+    options: GetOrComputeOptions,
+    fill: F,
+) where
+    V: Clone + serde::Serialize + serde::de::DeserializeOwned + Send + Sync + 'static,
+    E: std::fmt::Display + Send + 'static,
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: Future<Output = Result<V, E>> + Send + 'static,
+{
+    match claim_role(&cache, &key) {
+        Role::Leader(tx, guard) => {
+            tokio::spawn(async move {
+                let _result = run_leader_fill(&cache, &key, &options, fill, tx).await;
+                drop(guard);
+            });
+        }
+        Role::Waiter(_rx) => {
+            // A refresh (or an unrelated fill) is already in flight for this
+            // key; the stale value has already been returned to this caller.
+        }
+    }
+}
+
+/// In-process single-flight read-through: no stale-while-revalidate, so
+/// `fill` need not be `'static` (it is always awaited inline, never spawned).
+async fn simple_read_through<V, E, F, Fut>(
+    cache: &Arc<dyn Cache>,
+    key: &str,
+    options: &GetOrComputeOptions,
+    fill: F,
+) -> Result<V, CacheFillError<E>>
+where
+    V: Clone + serde::Serialize + serde::de::DeserializeOwned + Send + Sync + 'static,
+    E: std::fmt::Display + Send + 'static,
+    F: FnOnce() -> Fut + Send,
+    Fut: Future<Output = Result<V, E>> + Send,
+{
+    loop {
+        if let Some(value) = get_cached::<V>(cache.as_ref(), key) {
+            read_through_metrics().hits.fetch_add(1, Ordering::Relaxed);
+            return Ok(value);
+        }
+        read_through_metrics().misses.fetch_add(1, Ordering::Relaxed);
+
+        match claim_role(cache, key) {
+            Role::Leader(tx, guard) => {
+                // Double-check: another leader may have filled the key
+                // between the fast-path read above and winning leadership.
+                if let Some(value) = get_cached::<V>(cache.as_ref(), key) {
+                    let _ = tx.send(FillState::Done(Arc::new(value.clone())));
+                    drop(guard);
+                    return Ok(value);
+                }
+                let result = run_leader_fill(cache, key, options, fill, tx).await;
+                drop(guard);
+                return result;
+            }
+            Role::Waiter(rx) => {
+                read_through_metrics()
+                    .coalesced_waits
+                    .fetch_add(1, Ordering::Relaxed);
+                if let Some(result) = await_result::<V, E>(rx).await {
+                    return result;
+                }
+                // Channel closed or type mismatch: loop back and re-contend.
+            }
+        }
+    }
+}
+
+/// Stale-while-revalidate read-through: `fill` must be `'static` because a
+/// stale read may hand it to a background task instead of awaiting it.
+async fn swr_read_through<V, E, F, Fut>(
+    cache: &Arc<dyn Cache>,
+    key: &str,
+    options: GetOrComputeOptions,
+    fill: F,
+) -> Result<V, CacheFillError<E>>
+where
+    V: Clone + serde::Serialize + serde::de::DeserializeOwned + Send + Sync + 'static,
+    E: std::fmt::Display + Send + 'static,
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: Future<Output = Result<V, E>> + Send + 'static,
+{
+    loop {
+        match get_cached::<SwrEnvelope<V>>(cache.as_ref(), key) {
+            Some(envelope) if now_unix_ms() < envelope.fresh_until_unix_ms => {
+                read_through_metrics().hits.fetch_add(1, Ordering::Relaxed);
+                return Ok(envelope.value);
+            }
+            Some(envelope) => {
+                read_through_metrics()
+                    .stale_serves
+                    .fetch_add(1, Ordering::Relaxed);
+                spawn_background_refresh(cache.clone(), key.to_owned(), options.clone(), fill);
+                return Ok(envelope.value);
+            }
+            None => {
+                read_through_metrics().misses.fetch_add(1, Ordering::Relaxed);
+                match claim_role(cache, key) {
+                    Role::Leader(tx, guard) => {
+                        if let Some(envelope) = get_cached::<SwrEnvelope<V>>(cache.as_ref(), key) {
+                            let _ = tx.send(FillState::Done(Arc::new(envelope.value.clone())));
+                            drop(guard);
+                            return Ok(envelope.value);
+                        }
+                        let result = run_leader_fill(cache, key, &options, fill, tx).await;
+                        drop(guard);
+                        return result;
+                    }
+                    Role::Waiter(rx) => {
+                        read_through_metrics()
+                            .coalesced_waits
+                            .fetch_add(1, Ordering::Relaxed);
+                        if let Some(result) = await_result::<V, E>(rx).await {
+                            return result;
+                        }
+                        // Channel closed or type mismatch: loop back and re-contend.
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -293,8 +662,11 @@ where
     F: FnOnce() -> Fut + Send,
     Fut: Future<Output = Result<V, E>> + Send,
 {
-    let _ = (cache, key, ttl, fill);
-    todo!("green phase")
+    let options = GetOrComputeOptions {
+        ttl,
+        ..GetOrComputeOptions::new()
+    };
+    simple_read_through(cache, key, &options, fill).await
 }
 
 /// [`get_or_compute`] with cross-replica options: a distributed fill lock
@@ -319,8 +691,11 @@ where
     F: FnOnce() -> Fut + Send + 'static,
     Fut: Future<Output = Result<V, E>> + Send + 'static,
 {
-    let _ = (cache, key, options, fill);
-    todo!("green phase")
+    if options.stale_while_revalidate.is_some() {
+        swr_read_through(cache, key, options, fill).await
+    } else {
+        simple_read_through(cache, key, &options, fill).await
+    }
 }
 
 #[cfg(test)]

--- a/autumn/src/cache/read_through.rs
+++ b/autumn/src/cache/read_through.rs
@@ -282,8 +282,7 @@ pub fn jittered_ttl(base: Duration, fraction: f64) -> Duration {
         // Fallback entropy source if the OS RNG is unavailable.
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map(|d| d.subsec_nanos())
-            .unwrap_or(0);
+            .map_or(0, |d| d.subsec_nanos());
         buf = nanos.to_le_bytes();
     }
     let unit = f64::from(u32::from_le_bytes(buf)) / f64::from(u32::MAX);
@@ -431,6 +430,13 @@ const MAX_LOCK_POLL_INTERVAL: Duration = Duration::from_secs(1);
 /// Shared by the immediate-`Acquired` path and the poll loop's re-acquire
 /// path in [`run_leader_fill`], which otherwise duplicate this exact
 /// increment-fill-release-finish sequence.
+///
+/// The lock is released only *after* `finish_fill` has written and published
+/// the value, not right after `fill()` returns: releasing it earlier opens a
+/// window where a contending replica's poll tick sees both "no value yet" and
+/// "lock free," acquires the now-unlocked lock, and runs its own redundant
+/// fill — exactly the duplicate-recompute the distributed lock exists to
+/// prevent.
 async fn run_fill_and_release<V, E, F, Fut>(
     cache: &Arc<dyn Cache>,
     key: &str,
@@ -449,8 +455,9 @@ where
         .fill_lock_acquires
         .fetch_add(1, Ordering::Relaxed);
     let result = fill().await;
+    let outcome = finish_fill(cache, key, options, result, tx);
     cache.release_fill_lock(key, token);
-    finish_fill(cache, key, options, result, tx)
+    outcome
 }
 
 /// Run the fill closure (honoring the distributed fill lock if enabled),
@@ -669,6 +676,17 @@ where
     }
 }
 
+/// Whether an SWR envelope is still usable (fresh or stale-but-in-grace) at
+/// `now`, i.e. `now < fresh_until_unix_ms + grace`. Once this is false the
+/// entry is past `ttl + grace` and must be treated as a cold miss rather than
+/// served indefinitely: relying on physical eviction to make that happen
+/// doesn't hold for the in-process Moka backend, which (per its own
+/// per-cache TTL, commonly `None`) may never evict the entry on its own.
+fn swr_within_grace(now_unix_ms: u64, fresh_until_unix_ms: u64, grace: Option<Duration>) -> bool {
+    let grace_ms = grace.map_or(0, |g| u64::try_from(g.as_millis()).unwrap_or(u64::MAX));
+    now_unix_ms < fresh_until_unix_ms.saturating_add(grace_ms)
+}
+
 /// Stale-while-revalidate read-through: `fill` must be `'static` because a
 /// stale read may hand it to a background task instead of awaiting it.
 async fn swr_read_through<V, E, F, Fut>(
@@ -684,45 +702,62 @@ where
     Fut: Future<Output = Result<V, E>> + Send + 'static,
 {
     loop {
-        match get_cached::<SwrEnvelope<V>>(cache.as_ref(), key) {
-            Some(envelope)
-                if now_unix_ms(options.clock.as_ref()) < envelope.fresh_until_unix_ms =>
-            {
+        let envelope = get_cached::<SwrEnvelope<V>>(cache.as_ref(), key);
+        let now = now_unix_ms(options.clock.as_ref());
+
+        if let Some(envelope) = &envelope {
+            if now < envelope.fresh_until_unix_ms {
                 read_through_metrics().hits.fetch_add(1, Ordering::Relaxed);
-                return Ok(envelope.value);
+                return Ok(envelope.value.clone());
             }
-            Some(envelope) => {
+            if swr_within_grace(
+                now,
+                envelope.fresh_until_unix_ms,
+                options.stale_while_revalidate,
+            ) {
                 read_through_metrics()
                     .stale_serves
                     .fetch_add(1, Ordering::Relaxed);
                 spawn_background_refresh(cache.clone(), key.to_owned(), options.clone(), fill);
-                return Ok(envelope.value);
+                return Ok(envelope.value.clone());
             }
-            None => {
-                read_through_metrics()
-                    .misses
-                    .fetch_add(1, Ordering::Relaxed);
-                match claim_role(cache, key) {
-                    Role::Leader(tx, guard) => {
-                        if let Some(envelope) = get_cached::<SwrEnvelope<V>>(cache.as_ref(), key) {
-                            let _ = tx.send(FillState::Done(Arc::new(envelope.value.clone())));
-                            drop(guard);
-                            return Ok(envelope.value);
-                        }
-                        let result = run_leader_fill(cache, key, &options, fill, tx).await;
-                        drop(guard);
-                        return result;
-                    }
-                    Role::Waiter(rx) => {
-                        read_through_metrics()
-                            .coalesced_waits
-                            .fetch_add(1, Ordering::Relaxed);
-                        if let Some(result) = await_result::<V, E>(rx).await {
-                            return result;
-                        }
-                        // Channel closed or type mismatch: loop back and re-contend.
-                    }
+            // Past `ttl + grace`: fall through to the cold-miss path below
+            // instead of serving this indefinitely-stale value forever.
+        }
+
+        read_through_metrics()
+            .misses
+            .fetch_add(1, Ordering::Relaxed);
+        match claim_role(cache, key) {
+            Role::Leader(tx, guard) => {
+                // Double-check: another leader may have refreshed the key
+                // between the read above and winning leadership. Only trust
+                // that write if it's actually usable (fresh or in grace) —
+                // otherwise this would just re-observe the same expired
+                // envelope and skip filling entirely.
+                if let Some(envelope) = get_cached::<SwrEnvelope<V>>(cache.as_ref(), key)
+                    && swr_within_grace(
+                        now_unix_ms(options.clock.as_ref()),
+                        envelope.fresh_until_unix_ms,
+                        options.stale_while_revalidate,
+                    )
+                {
+                    let _ = tx.send(FillState::Done(Arc::new(envelope.value.clone())));
+                    drop(guard);
+                    return Ok(envelope.value);
                 }
+                let result = run_leader_fill(cache, key, &options, fill, tx).await;
+                drop(guard);
+                return result;
+            }
+            Role::Waiter(rx) => {
+                read_through_metrics()
+                    .coalesced_waits
+                    .fetch_add(1, Ordering::Relaxed);
+                if let Some(result) = await_result::<V, E>(rx).await {
+                    return result;
+                }
+                // Channel closed or type mismatch: loop back and re-contend.
             }
         }
     }

--- a/autumn/src/cache/read_through.rs
+++ b/autumn/src/cache/read_through.rs
@@ -502,7 +502,17 @@ where
             // clear the lock is held and unlikely to free up immediately.
             let mut poll_interval = options.lock_poll_interval;
             loop {
-                tokio::time::sleep(poll_interval).await;
+                // Never sleep past the deadline: a growing poll_interval (or
+                // simply a lock_wait_timeout shorter than lock_poll_interval)
+                // could otherwise overshoot lock_wait_timeout by a full
+                // interval before this loop gets a chance to check it,
+                // making the "bounded wait" option not actually bounded.
+                let remaining = options.lock_wait_timeout.saturating_sub(start.elapsed());
+                if remaining.is_zero() {
+                    let result = fill().await;
+                    return finish_fill(cache, key, options, result, &tx);
+                }
+                tokio::time::sleep(poll_interval.min(remaining)).await;
                 poll_interval = poll_interval.saturating_mul(2).min(MAX_LOCK_POLL_INTERVAL);
 
                 if let Some(value) = fast_path_value::<V>(cache, key, options) {

--- a/autumn/src/cache/read_through.rs
+++ b/autumn/src/cache/read_through.rs
@@ -335,7 +335,9 @@ fn claim_role(cache: &Arc<dyn Cache>, key: &str) -> Role {
 /// future was dropped/cancelled before publishing an outcome (channel
 /// closed), or the leader published a value of a different type than `V`
 /// (the same key was used with two different value types).
-async fn await_result<V, E>(mut rx: watch::Receiver<FillState>) -> Option<Result<V, CacheFillError<E>>>
+async fn await_result<V, E>(
+    mut rx: watch::Receiver<FillState>,
+) -> Option<Result<V, CacheFillError<E>>>
 where
     V: Clone + Send + Sync + 'static,
 {
@@ -546,7 +548,9 @@ where
             read_through_metrics().hits.fetch_add(1, Ordering::Relaxed);
             return Ok(value);
         }
-        read_through_metrics().misses.fetch_add(1, Ordering::Relaxed);
+        read_through_metrics()
+            .misses
+            .fetch_add(1, Ordering::Relaxed);
 
         match claim_role(cache, key) {
             Role::Leader(tx, guard) => {
@@ -602,7 +606,9 @@ where
                 return Ok(envelope.value);
             }
             None => {
-                read_through_metrics().misses.fetch_add(1, Ordering::Relaxed);
+                read_through_metrics()
+                    .misses
+                    .fetch_add(1, Ordering::Relaxed);
                 match claim_role(cache, key) {
                     Role::Leader(tx, guard) => {
                         if let Some(envelope) = get_cached::<SwrEnvelope<V>>(cache.as_ref(), key) {

--- a/autumn/src/cache/read_through.rs
+++ b/autumn/src/cache/read_through.rs
@@ -32,9 +32,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex, PoisonError};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use tokio::sync::watch;
+use tokio::sync::{Semaphore, watch};
 
 use super::{Cache, FillLockStatus, get_cached, insert_cached};
+use crate::time::{ClockSource, SystemClock, clock_unix_duration};
 
 // ── Options ──────────────────────────────────────────────────────────
 
@@ -42,7 +43,7 @@ use super::{Cache, FillLockStatus, get_cached, insert_cached};
 ///
 /// The default (`GetOrComputeOptions::new()`) is in-process single-flight
 /// only: no TTL, no distributed lock, no stale-while-revalidate.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct GetOrComputeOptions {
     /// Freshness TTL for the value written on fill. `None` = no expiry.
     pub ttl: Option<Duration>,
@@ -65,12 +66,19 @@ pub struct GetOrComputeOptions {
     /// considered stale but is still served for up to `grace` while a single
     /// background task refreshes it.
     pub stale_while_revalidate: Option<Duration>,
+    /// Clock used to evaluate stale-while-revalidate freshness. Defaults to
+    /// [`SystemClock`]; overridden in tests via [`with_clock`] so freshness
+    /// transitions are deterministic instead of depending on real
+    /// `tokio::time::sleep` calls.
+    ///
+    /// [`with_clock`]: GetOrComputeOptions::with_clock
+    clock: Arc<dyn ClockSource>,
 }
 
 impl GetOrComputeOptions {
     /// Create options with defaults: no TTL, in-process single-flight only.
     #[must_use]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             ttl: None,
             distributed_fill_lock: false,
@@ -78,6 +86,7 @@ impl GetOrComputeOptions {
             lock_poll_interval: Duration::from_millis(50),
             lock_wait_timeout: Duration::from_secs(5),
             stale_while_revalidate: None,
+            clock: Arc::new(SystemClock),
         }
     }
 
@@ -122,11 +131,35 @@ impl GetOrComputeOptions {
         self.stale_while_revalidate = Some(grace);
         self
     }
+
+    /// Override the clock used to evaluate stale-while-revalidate freshness.
+    ///
+    /// Defaults to [`SystemClock`]; tests can pass a
+    /// [`crate::time::FixedClock`] / [`crate::time::TickingClock`] to make
+    /// freshness transitions deterministic.
+    #[must_use]
+    pub fn with_clock(mut self, clock: Arc<dyn ClockSource>) -> Self {
+        self.clock = clock;
+        self
+    }
 }
 
 impl Default for GetOrComputeOptions {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl std::fmt::Debug for GetOrComputeOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GetOrComputeOptions")
+            .field("ttl", &self.ttl)
+            .field("distributed_fill_lock", &self.distributed_fill_lock)
+            .field("lock_ttl", &self.lock_ttl)
+            .field("lock_poll_interval", &self.lock_poll_interval)
+            .field("lock_wait_timeout", &self.lock_wait_timeout)
+            .field("stale_while_revalidate", &self.stale_while_revalidate)
+            .finish_non_exhaustive()
     }
 }
 
@@ -366,24 +399,58 @@ struct SwrEnvelope<V> {
     fresh_until_unix_ms: u64,
 }
 
-fn now_unix_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
-        .unwrap_or(0)
+fn now_unix_ms(clock: &dyn ClockSource) -> u64 {
+    u64::try_from(clock_unix_duration(clock).as_millis()).unwrap_or(u64::MAX)
 }
 
-/// Read the current value regardless of freshness (used for lock-poll and
-/// leader double-checks, where "does a value exist yet" is all that matters).
+/// Read the current value, used for the lock-poll loop and the leader's
+/// pre-fill double-check.
+///
+/// In SWR mode this must still check freshness: entry into the poll loop, by
+/// construction, only happens when a *stale* envelope already exists (that's
+/// why a refresh was triggered in the first place), so treating "an envelope
+/// exists" as "the lock winner published a fresh value" would let a losing
+/// replica mistake the old stale envelope for a completed refresh.
 fn fast_path_value<V>(cache: &Arc<dyn Cache>, key: &str, options: &GetOrComputeOptions) -> Option<V>
 where
     V: Clone + serde::de::DeserializeOwned + Send + Sync + 'static,
 {
     if options.stale_while_revalidate.is_some() {
-        get_cached::<SwrEnvelope<V>>(cache.as_ref(), key).map(|envelope| envelope.value)
+        get_cached::<SwrEnvelope<V>>(cache.as_ref(), key)
+            .filter(|envelope| now_unix_ms(options.clock.as_ref()) < envelope.fresh_until_unix_ms)
+            .map(|envelope| envelope.value)
     } else {
         get_cached::<V>(cache.as_ref(), key)
     }
+}
+
+/// Ceiling on the lock-poll loop's exponential backoff (see [`run_leader_fill`]).
+const MAX_LOCK_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Run `fill`, release the distributed lock, and publish/write the result.
+/// Shared by the immediate-`Acquired` path and the poll loop's re-acquire
+/// path in [`run_leader_fill`], which otherwise duplicate this exact
+/// increment-fill-release-finish sequence.
+async fn run_fill_and_release<V, E, F, Fut>(
+    cache: &Arc<dyn Cache>,
+    key: &str,
+    options: &GetOrComputeOptions,
+    fill: F,
+    tx: &watch::Sender<FillState>,
+    token: &str,
+) -> Result<V, CacheFillError<E>>
+where
+    V: Clone + serde::Serialize + serde::de::DeserializeOwned + Send + Sync + 'static,
+    E: std::fmt::Display + Send + 'static,
+    F: FnOnce() -> Fut + Send,
+    Fut: Future<Output = Result<V, E>> + Send,
+{
+    read_through_metrics()
+        .fill_lock_acquires
+        .fetch_add(1, Ordering::Relaxed);
+    let result = fill().await;
+    cache.release_fill_lock(key, token);
+    finish_fill(cache, key, options, result, tx)
 }
 
 /// Run the fill closure (honoring the distributed fill lock if enabled),
@@ -414,20 +481,22 @@ where
             finish_fill(cache, key, options, result, &tx)
         }
         FillLockStatus::Acquired => {
-            read_through_metrics()
-                .fill_lock_acquires
-                .fetch_add(1, Ordering::Relaxed);
-            let result = fill().await;
-            cache.release_fill_lock(key, &token);
-            finish_fill(cache, key, options, result, &tx)
+            run_fill_and_release(cache, key, options, fill, &tx, &token).await
         }
         FillLockStatus::Held => {
             read_through_metrics()
                 .fill_lock_contended
                 .fetch_add(1, Ordering::Relaxed);
             let start = Instant::now();
+            // Exponential backoff, capped at MAX_LOCK_POLL_INTERVAL: a flat
+            // poll cadence means every waiting replica hammers Redis (a cache
+            // read plus a lock-acquire attempt, each a block_in_place round
+            // trip) at a constant rate for the whole wait, even once it's
+            // clear the lock is held and unlikely to free up immediately.
+            let mut poll_interval = options.lock_poll_interval;
             loop {
-                tokio::time::sleep(options.lock_poll_interval).await;
+                tokio::time::sleep(poll_interval).await;
+                poll_interval = poll_interval.saturating_mul(2).min(MAX_LOCK_POLL_INTERVAL);
 
                 if let Some(value) = fast_path_value::<V>(cache, key, options) {
                     let _ = tx.send(FillState::Done(Arc::new(value.clone())));
@@ -444,12 +513,7 @@ where
                 if cache.try_acquire_fill_lock(key, &token, options.lock_ttl)
                     == FillLockStatus::Acquired
                 {
-                    read_through_metrics()
-                        .fill_lock_acquires
-                        .fetch_add(1, Ordering::Relaxed);
-                    let result = fill().await;
-                    cache.release_fill_lock(key, &token);
-                    return finish_fill(cache, key, options, result, &tx);
+                    return run_fill_and_release(cache, key, options, fill, &tx, &token).await;
                 }
             }
         }
@@ -473,12 +537,19 @@ where
     match result {
         Ok(value) => {
             if let Some(grace) = options.stale_while_revalidate {
-                let ttl_ms = options
-                    .ttl
-                    .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX));
+                // `ttl: None` means "no expiry" (per its own doc comment): the
+                // envelope must stay fresh forever, not go stale immediately.
+                // Treating a missing TTL as `ttl_ms = 0` would stamp
+                // `fresh_until` as "now", making the very next read (and every
+                // read after) take the stale branch and re-trigger a
+                // background refresh in a tight loop.
+                let fresh_until_unix_ms = options.ttl.map_or(u64::MAX, |ttl| {
+                    let ttl_ms = u64::try_from(ttl.as_millis()).unwrap_or(u64::MAX);
+                    now_unix_ms(options.clock.as_ref()).saturating_add(ttl_ms)
+                });
                 let envelope = SwrEnvelope {
                     value: value.clone(),
-                    fresh_until_unix_ms: now_unix_ms().saturating_add(ttl_ms),
+                    fresh_until_unix_ms,
                 };
                 let physical_ttl = options.ttl.map(|ttl| ttl + grace);
                 insert_cached(cache.as_ref(), key, envelope, physical_ttl);
@@ -500,10 +571,25 @@ where
     }
 }
 
+/// Process-wide ceiling on concurrently running stale-while-revalidate
+/// background refreshes, across *all* keys. The per-key single-flight
+/// registry only dedupes refreshes for the *same* key; without this, many
+/// keys going stale around the same time (e.g. after a bulk write with
+/// unjittered TTLs) could spawn an unbounded number of detached tasks, each
+/// holding open whatever resource the `fill` closure captured (a pooled DB
+/// connection, say), risking pool exhaustion under load.
+const MAX_CONCURRENT_BACKGROUND_REFRESHES: usize = 64;
+
+static BACKGROUND_REFRESH_LIMIT: LazyLock<Semaphore> =
+    LazyLock::new(|| Semaphore::new(MAX_CONCURRENT_BACKGROUND_REFRESHES));
+
 /// Try to become the leader for a stale-while-revalidate background refresh.
 /// If another fill (a cold-miss leader, or an earlier refresh) is already
 /// in-flight for this key, do nothing and drop `fill` unrun — only one
-/// refresh should run at a time per key.
+/// refresh should run at a time per key. If the process-wide concurrent
+/// refresh limit is already saturated, also drop `fill` unrun rather than
+/// spawn an unbounded task: the stale value was already returned to this
+/// caller, and the next stale read will retry the refresh.
 fn spawn_background_refresh<V, E, F, Fut>(
     cache: Arc<dyn Cache>,
     key: String,
@@ -517,7 +603,12 @@ fn spawn_background_refresh<V, E, F, Fut>(
 {
     match claim_role(&cache, &key) {
         Role::Leader(tx, guard) => {
+            let Ok(permit) = BACKGROUND_REFRESH_LIMIT.try_acquire() else {
+                drop(guard);
+                return;
+            };
             tokio::spawn(async move {
+                let _permit = permit;
                 let _result = run_leader_fill(&cache, &key, &options, fill, tx).await;
                 drop(guard);
             });
@@ -594,7 +685,9 @@ where
 {
     loop {
         match get_cached::<SwrEnvelope<V>>(cache.as_ref(), key) {
-            Some(envelope) if now_unix_ms() < envelope.fresh_until_unix_ms => {
+            Some(envelope)
+                if now_unix_ms(options.clock.as_ref()) < envelope.fresh_until_unix_ms =>
+            {
                 read_through_metrics().hits.fetch_add(1, Ordering::Relaxed);
                 return Ok(envelope.value);
             }
@@ -755,6 +848,45 @@ mod tests {
         );
         // Default release is a no-op and must not panic.
         Cache::release_fill_lock(&cache, "k", "token");
+    }
+
+    #[cfg(feature = "cache-moka")]
+    #[test]
+    fn fast_path_value_ignores_stale_swr_envelope() {
+        use super::super::MokaCache;
+
+        let cache: Arc<dyn Cache> = Arc::new(MokaCache::new(10, None));
+        let key = "fast-path-swr-key";
+        let options = GetOrComputeOptions::new().stale_while_revalidate(Duration::from_secs(10));
+
+        // A stale envelope (fresh_until in the past) must NOT be reported as
+        // "the fill landed": the lock-poll loop in `run_leader_fill` relies on
+        // `fast_path_value` to distinguish a fresh write by the lock winner
+        // from the pre-existing stale value that triggered the refresh in the
+        // first place. Reporting the stale value here would make a losing
+        // replica stop waiting/polling prematurely and publish stale data as
+        // if it were the completed refresh.
+        let stale = SwrEnvelope {
+            value: "stale-value".to_string(),
+            fresh_until_unix_ms: 0,
+        };
+        insert_cached(cache.as_ref(), key, stale, None);
+        assert_eq!(
+            fast_path_value::<String>(&cache, key, &options),
+            None,
+            "a stale SWR envelope must not be reported as a completed fill"
+        );
+
+        // A fresh envelope (fresh_until far in the future) is reported.
+        let fresh = SwrEnvelope {
+            value: "fresh-value".to_string(),
+            fresh_until_unix_ms: u64::MAX,
+        };
+        insert_cached(cache.as_ref(), key, fresh, None);
+        assert_eq!(
+            fast_path_value::<String>(&cache, key, &options),
+            Some("fresh-value".to_string())
+        );
     }
 
     #[test]

--- a/autumn/src/cache/read_through.rs
+++ b/autumn/src/cache/read_through.rs
@@ -1,0 +1,418 @@
+//! Read-through cache fills with stampede protection.
+//!
+//! When a hot key expires, every concurrent request misses and recomputes the
+//! same value at once — the classic thundering herd. This module adds a
+//! read-through API over any [`Cache`] backend:
+//!
+//! - [`get_or_compute`] — get the cached value, or run `fill` **once per
+//!   process** and share the result with every concurrent caller
+//!   (single-flight coalescing).
+//! - [`get_or_compute_with`] — the same, plus opt-in cross-replica protection
+//!   via a distributed fill lock and/or stale-while-revalidate, configured
+//!   with [`GetOrComputeOptions`].
+//! - [`jittered_ttl`] — de-synchronize mass expiry of keys written together.
+//! - [`read_through_metrics`] — process-wide counters (hits, misses,
+//!   coalesced waiters, fills, fill failures, …) surfaced through the
+//!   actuator's metrics endpoints.
+//!
+//! # Single-flight protocol
+//!
+//! Concurrent misses for the same key elect one *leader* (the first caller to
+//! register in a process-global in-flight table); the leader runs the fill and
+//! publishes the outcome over a watch channel. Every other caller becomes a
+//! *waiter* and awaits that outcome instead of recomputing. A failing fill
+//! never poisons the key: the leader's error propagates (typed) to the leader
+//! and (rendered) to the waiters, the in-flight entry is removed, and the next
+//! caller retries the fill.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, LazyLock, Mutex, PoisonError};
+use std::time::Duration;
+
+use tokio::sync::watch;
+
+use super::Cache;
+
+// ── Options ──────────────────────────────────────────────────────────
+
+/// Configuration for [`get_or_compute_with`].
+///
+/// The default (`GetOrComputeOptions::new()`) is in-process single-flight
+/// only: no TTL, no distributed lock, no stale-while-revalidate.
+#[derive(Clone, Debug)]
+pub struct GetOrComputeOptions {
+    /// Freshness TTL for the value written on fill. `None` = no expiry.
+    pub ttl: Option<Duration>,
+    /// Opt in to a cross-replica fill lock (supported by backends that
+    /// implement [`Cache::try_acquire_fill_lock`], e.g. Redis). When another
+    /// replica holds the lock this replica polls for the value instead of
+    /// filling.
+    pub distributed_fill_lock: bool,
+    /// Expiry of the distributed fill lock. Bounds the damage from a filler
+    /// that crashes while holding the lock: after this the lock self-clears
+    /// and another replica takes over.
+    pub lock_ttl: Duration,
+    /// How often a replica that lost the distributed lock polls the cache for
+    /// the winner's value (and re-attempts the lock).
+    pub lock_poll_interval: Duration,
+    /// How long a replica waits on another replica's fill before giving up
+    /// and computing the value itself (bounded damage, never unavailability).
+    pub lock_wait_timeout: Duration,
+    /// `Some(grace)` enables stale-while-revalidate: after `ttl` the value is
+    /// considered stale but is still served for up to `grace` while a single
+    /// background task refreshes it.
+    pub stale_while_revalidate: Option<Duration>,
+}
+
+impl GetOrComputeOptions {
+    /// Create options with defaults: no TTL, in-process single-flight only.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            ttl: None,
+            distributed_fill_lock: false,
+            lock_ttl: Duration::from_secs(10),
+            lock_poll_interval: Duration::from_millis(50),
+            lock_wait_timeout: Duration::from_secs(5),
+            stale_while_revalidate: None,
+        }
+    }
+
+    /// Set the freshness TTL.
+    #[must_use]
+    pub const fn ttl(mut self, ttl: Duration) -> Self {
+        self.ttl = Some(ttl);
+        self
+    }
+
+    /// Opt in to the distributed fill lock (Redis backend).
+    #[must_use]
+    pub const fn distributed_fill_lock(mut self, enabled: bool) -> Self {
+        self.distributed_fill_lock = enabled;
+        self
+    }
+
+    /// Set the distributed lock's expiry.
+    #[must_use]
+    pub const fn lock_ttl(mut self, ttl: Duration) -> Self {
+        self.lock_ttl = ttl;
+        self
+    }
+
+    /// Set the poll cadence used while another replica holds the fill lock.
+    #[must_use]
+    pub const fn lock_poll_interval(mut self, interval: Duration) -> Self {
+        self.lock_poll_interval = interval;
+        self
+    }
+
+    /// Set how long to wait on another replica's fill before self-filling.
+    #[must_use]
+    pub const fn lock_wait_timeout(mut self, timeout: Duration) -> Self {
+        self.lock_wait_timeout = timeout;
+        self
+    }
+
+    /// Enable stale-while-revalidate with the given grace period.
+    #[must_use]
+    pub const fn stale_while_revalidate(mut self, grace: Duration) -> Self {
+        self.stale_while_revalidate = Some(grace);
+        self
+    }
+}
+
+impl Default for GetOrComputeOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Error type ───────────────────────────────────────────────────────
+
+/// Error returned by [`get_or_compute`] / [`get_or_compute_with`].
+///
+/// A failing fill never poisons the key: nothing is written to the cache, the
+/// in-flight entry is removed before waiters are woken, and the next caller
+/// retries the fill.
+#[derive(Debug, thiserror::Error)]
+pub enum CacheFillError<E> {
+    /// This caller ran the fill closure itself and it failed.
+    #[error("cache fill failed: {0}")]
+    Fill(E),
+    /// This caller coalesced onto a concurrent fill (same key, same process)
+    /// whose fill failed. Carries the leader's error rendered via `Display`
+    /// (`E` is not required to be `Clone`).
+    #[error("cache fill failed in concurrent caller: {0}")]
+    FillFailed(Arc<str>),
+}
+
+impl<E> CacheFillError<E> {
+    /// Return the typed fill error if this caller ran the fill itself.
+    pub fn into_fill(self) -> Option<E> {
+        match self {
+            Self::Fill(e) => Some(e),
+            Self::FillFailed(_) => None,
+        }
+    }
+}
+
+// ── Metrics ──────────────────────────────────────────────────────────
+
+/// Process-wide read-through cache counters.
+///
+/// Exposed as `autumn_cache_*` counters on `/actuator/prometheus` and under
+/// `cache` in the `/actuator/metrics` JSON snapshot. Obtain the live instance
+/// with [`read_through_metrics`].
+#[derive(Debug, Default)]
+pub struct ReadThroughMetrics {
+    hits: AtomicU64,
+    misses: AtomicU64,
+    coalesced_waits: AtomicU64,
+    fills: AtomicU64,
+    fill_failures: AtomicU64,
+    stale_serves: AtomicU64,
+    fill_lock_acquires: AtomicU64,
+    fill_lock_contended: AtomicU64,
+}
+
+/// Point-in-time copy of [`ReadThroughMetrics`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub struct ReadThroughMetricsSnapshot {
+    /// Fresh fast-path reads served from the cache.
+    pub hits: u64,
+    /// Fast-path reads that found no (fresh) value.
+    pub misses: u64,
+    /// Callers that parked behind an in-process leader instead of filling.
+    pub coalesced_waits: u64,
+    /// Fill closures that completed successfully in this process.
+    pub fills: u64,
+    /// Fill closures that returned an error.
+    pub fill_failures: u64,
+    /// Stale values served while a background refresh ran (SWR mode).
+    pub stale_serves: u64,
+    /// Distributed fill locks acquired by this process.
+    pub fill_lock_acquires: u64,
+    /// Distributed fill lock attempts that found the lock held elsewhere.
+    pub fill_lock_contended: u64,
+}
+
+impl ReadThroughMetrics {
+    /// Take a consistent-enough snapshot of all counters (each counter is
+    /// read atomically; the set is not read under a global lock).
+    pub fn snapshot(&self) -> ReadThroughMetricsSnapshot {
+        todo!("green phase")
+    }
+}
+
+/// The process-wide [`ReadThroughMetrics`] instance updated by
+/// [`get_or_compute`] and [`get_or_compute_with`].
+pub fn read_through_metrics() -> &'static ReadThroughMetrics {
+    todo!("green phase")
+}
+
+// ── TTL jitter ───────────────────────────────────────────────────────
+
+/// Multiply `base` by a random factor drawn uniformly from
+/// `[1 - fraction, 1 + fraction]`.
+///
+/// Use this when writing many keys together (bulk warmups, batch imports) so
+/// they don't all expire in the same instant and stampede together.
+/// `fraction` is clamped to `[0.0, 1.0]`; non-finite values are treated as
+/// `0.0` (no jitter).
+#[must_use]
+pub fn jittered_ttl(base: Duration, fraction: f64) -> Duration {
+    let _ = (base, fraction);
+    todo!("green phase")
+}
+
+// ── In-flight registry (single-flight) ──────────────────────────────
+
+/// Outcome of an in-flight fill, published to waiters over a watch channel.
+#[derive(Clone)]
+enum FillState {
+    Pending,
+    Done(Arc<dyn Any + Send + Sync>),
+    Failed(Arc<str>),
+}
+
+/// In-flight fills, keyed by (cache identity, key). Two distinct
+/// `Arc<dyn Cache>` allocations never coalesce with each other.
+#[allow(dead_code)] // used from the green phase onwards
+static IN_FLIGHT: LazyLock<Mutex<HashMap<(usize, String), watch::Receiver<FillState>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// RAII removal of an in-flight entry: covers success, error, panic, and
+/// cancellation (the leader's future being dropped mid-fill).
+#[allow(dead_code)] // used from the green phase onwards
+struct InFlightGuard {
+    key: (usize, String),
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        IN_FLIGHT
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(&self.key);
+    }
+}
+
+// ── Public API ───────────────────────────────────────────────────────
+
+/// Read `key` from the cache, or compute it with `fill` — at most once per
+/// process for concurrent callers (single-flight).
+///
+/// On a hit the cached value is returned immediately. On a miss, the first
+/// caller runs `fill`; every concurrent caller for the same key awaits that
+/// one fill and shares its result. The computed value is written back with
+/// `ttl` (honored natively by backends like Redis; in-process Moka caches use
+/// their per-instance TTL).
+///
+/// For cross-replica protection or stale-while-revalidate, use
+/// [`get_or_compute_with`].
+///
+/// # Errors
+///
+/// - [`CacheFillError::Fill`] if this caller ran `fill` and it failed.
+/// - [`CacheFillError::FillFailed`] if a concurrent caller ran `fill` and it
+///   failed; the message is the leader's error rendered via `Display`.
+///
+/// A failed fill writes nothing: the next caller retries.
+pub async fn get_or_compute<V, E, F, Fut>(
+    cache: &Arc<dyn Cache>,
+    key: &str,
+    ttl: Option<Duration>,
+    fill: F,
+) -> Result<V, CacheFillError<E>>
+where
+    V: Clone + serde::Serialize + serde::de::DeserializeOwned + Send + Sync + 'static,
+    E: std::fmt::Display + Send + 'static,
+    F: FnOnce() -> Fut + Send,
+    Fut: Future<Output = Result<V, E>> + Send,
+{
+    let _ = (cache, key, ttl, fill);
+    todo!("green phase")
+}
+
+/// [`get_or_compute`] with cross-replica options: a distributed fill lock
+/// and/or stale-while-revalidate. See [`GetOrComputeOptions`].
+///
+/// The `'static` bounds on `fill` exist because stale-while-revalidate may
+/// run the fill on a background task; capture owned handles (`Arc`-clone your
+/// pool into the closure).
+///
+/// # Errors
+///
+/// Same as [`get_or_compute`].
+pub async fn get_or_compute_with<V, E, F, Fut>(
+    cache: &Arc<dyn Cache>,
+    key: &str,
+    options: GetOrComputeOptions,
+    fill: F,
+) -> Result<V, CacheFillError<E>>
+where
+    V: Clone + serde::Serialize + serde::de::DeserializeOwned + Send + Sync + 'static,
+    E: std::fmt::Display + Send + 'static,
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: Future<Output = Result<V, E>> + Send + 'static,
+{
+    let _ = (cache, key, options, fill);
+    todo!("green phase")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jittered_ttl_within_bounds() {
+        let base = Duration::from_secs(100);
+        let mut distinct = std::collections::HashSet::new();
+        for _ in 0..100 {
+            let jittered = jittered_ttl(base, 0.2);
+            assert!(
+                jittered >= Duration::from_secs(80) && jittered <= Duration::from_secs(120),
+                "jittered TTL {jittered:?} outside [80s, 120s]"
+            );
+            distinct.insert(jittered.as_nanos());
+        }
+        assert!(
+            distinct.len() >= 2,
+            "expected at least 2 distinct jittered values, got {}",
+            distinct.len()
+        );
+        assert_eq!(jittered_ttl(base, 0.0), base, "fraction 0.0 must be exact");
+    }
+
+    #[test]
+    fn jittered_ttl_clamps_fraction() {
+        let base = Duration::from_secs(10);
+        for _ in 0..50 {
+            let jittered = jittered_ttl(base, 5.0);
+            assert!(
+                jittered <= Duration::from_secs(20),
+                "fraction must clamp to 1.0; got {jittered:?}"
+            );
+        }
+        // Non-finite fractions degrade to no jitter rather than panicking.
+        assert_eq!(jittered_ttl(base, f64::NAN), base);
+        assert_eq!(jittered_ttl(base, f64::INFINITY), base);
+    }
+
+    #[cfg(feature = "cache-moka")]
+    #[test]
+    fn fill_lock_default_unsupported() {
+        use super::super::{FillLockStatus, MokaCache};
+
+        let cache = MokaCache::new(10, None);
+        assert_eq!(
+            Cache::try_acquire_fill_lock(&cache, "k", "token", Duration::from_secs(1)),
+            FillLockStatus::Unsupported
+        );
+        // Default release is a no-op and must not panic.
+        Cache::release_fill_lock(&cache, "k", "token");
+    }
+
+    #[test]
+    fn metrics_snapshot_starts_at_zero_and_counts() {
+        let metrics = ReadThroughMetrics::default();
+        let snap = metrics.snapshot();
+        assert_eq!(snap.hits, 0);
+        assert_eq!(snap.misses, 0);
+        assert_eq!(snap.coalesced_waits, 0);
+        assert_eq!(snap.fills, 0);
+        assert_eq!(snap.fill_failures, 0);
+        assert_eq!(snap.stale_serves, 0);
+        assert_eq!(snap.fill_lock_acquires, 0);
+        assert_eq!(snap.fill_lock_contended, 0);
+
+        metrics.hits.fetch_add(2, Ordering::Relaxed);
+        metrics.misses.fetch_add(1, Ordering::Relaxed);
+        metrics.coalesced_waits.fetch_add(3, Ordering::Relaxed);
+        metrics.fills.fetch_add(4, Ordering::Relaxed);
+        metrics.fill_failures.fetch_add(5, Ordering::Relaxed);
+        metrics.stale_serves.fetch_add(6, Ordering::Relaxed);
+        metrics.fill_lock_acquires.fetch_add(7, Ordering::Relaxed);
+        metrics.fill_lock_contended.fetch_add(8, Ordering::Relaxed);
+
+        let snap = metrics.snapshot();
+        assert_eq!(snap.hits, 2);
+        assert_eq!(snap.misses, 1);
+        assert_eq!(snap.coalesced_waits, 3);
+        assert_eq!(snap.fills, 4);
+        assert_eq!(snap.fill_failures, 5);
+        assert_eq!(snap.stale_serves, 6);
+        assert_eq!(snap.fill_lock_acquires, 7);
+        assert_eq!(snap.fill_lock_contended, 8);
+    }
+
+    #[test]
+    fn read_through_metrics_is_a_stable_singleton() {
+        let a: *const ReadThroughMetrics = read_through_metrics();
+        let b: *const ReadThroughMetrics = read_through_metrics();
+        assert_eq!(a, b);
+    }
+}

--- a/autumn/tests/cache_stampede.rs
+++ b/autumn/tests/cache_stampede.rs
@@ -497,6 +497,51 @@ async fn swr_without_ttl_never_goes_stale() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn swr_past_grace_window_becomes_cold_miss() {
+    let _guard = METRICS_LOCK.lock().await;
+    let cache = fresh_cache();
+    let key = unique_key("swr_past_grace_window_becomes_cold_miss");
+    let fill_count = Arc::new(AtomicUsize::new(0));
+
+    let opts = GetOrComputeOptions::new()
+        .ttl(Duration::from_millis(30))
+        .stale_while_revalidate(Duration::from_millis(30));
+
+    let fc = fill_count.clone();
+    let v: String = get_or_compute_with(&cache, &key, opts.clone(), move || async move {
+        fc.fetch_add(1, Ordering::SeqCst);
+        Ok::<String, String>("v1".to_string())
+    })
+    .await
+    .unwrap();
+    assert_eq!(v, "v1");
+
+    // Elapse past both `ttl` (30ms) and `grace` (30ms): per the docs ("Once
+    // past ttl + grace, the key is treated as a cold miss again"), the entry
+    // must no longer be served as stale-but-usable data — the in-process
+    // Moka backend never physically evicts it on its own (its own per-cache
+    // TTL here is `None`), so this can't rely on eviction to happen.
+    tokio::time::sleep(Duration::from_millis(120)).await;
+
+    let fc = fill_count.clone();
+    let v: String = get_or_compute_with(&cache, &key, opts.clone(), move || async move {
+        fc.fetch_add(1, Ordering::SeqCst);
+        Ok::<String, String>("v2".to_string())
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        v, "v2",
+        "past ttl + grace the caller must get a fresh fill, not the ancient stale value"
+    );
+    assert_eq!(
+        fill_count.load(Ordering::SeqCst),
+        2,
+        "exactly one fresh fill should run for the cold-miss read"
+    );
+}
+
 /// A minimal `Cache` implementation that only ever stores `RawCacheBytes`
 /// (mirroring how a serializing, cross-process backend like Redis behaves),
 /// proving `get_or_compute` works over the serde slow path too.

--- a/autumn/tests/cache_stampede.rs
+++ b/autumn/tests/cache_stampede.rs
@@ -9,7 +9,7 @@
 #![cfg(feature = "cache-moka")]
 
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, PoisonError};
 use std::time::Duration;
 
 use autumn_web::cache::{
@@ -18,10 +18,12 @@ use autumn_web::cache::{
 };
 use autumn_web::cache::MokaCache;
 
-/// Serializes tests that assert *exact* metric deltas, since
-/// `read_through_metrics()` is a process-wide singleton and `cargo test` runs
-/// tests in parallel by default.
-static METRICS_LOCK: Mutex<()> = Mutex::new(());
+/// Serializes tests that touch `read_through_metrics()` (a process-wide
+/// singleton), since `cargo test` runs tests in parallel by default and
+/// several of these tests assert *exact* metric deltas. A `tokio::sync::Mutex`
+/// is used (rather than `std::sync::Mutex`) because the guard is held across
+/// `.await` points for the whole test body.
+static METRICS_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 fn fresh_cache() -> Arc<dyn Cache> {
     Arc::new(MokaCache::new(1_000, None))
@@ -35,7 +37,7 @@ fn unique_key(name: &str) -> String {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn miss_fills_then_hits() {
-    let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = METRICS_LOCK.lock().await;
     let cache = fresh_cache();
     let key = unique_key("miss_fills_then_hits");
     let fill_count = Arc::new(AtomicUsize::new(0));
@@ -76,23 +78,39 @@ async fn miss_fills_then_hits() {
 async fn concurrent_misses_run_fill_once() {
     // The issue's falsifiable success metric: K concurrent requests at an
     // expired/missing key produce exactly 1 fill and K-1 coalesced waits.
-    let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    //
+    // Rather than guess a sleep duration long enough to outlast scheduler
+    // jitter on shared/oversubscribed CI hardware, the fill closure blocks
+    // until every contender has actually reached `get_or_compute` (tracked by
+    // `started`). That makes the test deterministic: whichever task becomes
+    // leader always waits for all K contenders before finishing its fill, no
+    // matter how delayed some of them are to get scheduled.
+    const K: usize = 16;
+
+    let _guard = METRICS_LOCK.lock().await;
     let cache = fresh_cache();
     let key = unique_key("concurrent_misses_run_fill_once");
     let fill_count = Arc::new(AtomicUsize::new(0));
+    let started = Arc::new(AtomicUsize::new(0));
 
     let before = read_through_metrics().snapshot();
 
-    const K: usize = 16;
     let mut handles = Vec::with_capacity(K);
     for _ in 0..K {
         let cache = cache.clone();
         let key = key.clone();
         let fc = fill_count.clone();
+        let started = started.clone();
         handles.push(tokio::spawn(async move {
+            started.fetch_add(1, Ordering::SeqCst);
             get_or_compute::<i32, String, _, _>(&cache, &key, None, || async move {
                 fc.fetch_add(1, Ordering::SeqCst);
-                tokio::time::sleep(Duration::from_millis(100)).await;
+                while started.load(Ordering::SeqCst) < K {
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                }
+                // Small extra margin for the last-registered contender to
+                // finish its (synchronous, no-await) claim_role call.
+                tokio::time::sleep(Duration::from_millis(50)).await;
                 Ok(7)
             })
             .await
@@ -100,7 +118,11 @@ async fn concurrent_misses_run_fill_once() {
     }
 
     for h in handles {
-        let v = h.await.unwrap().unwrap();
+        let v = tokio::time::timeout(Duration::from_secs(30), h)
+            .await
+            .expect("all contenders must resolve well within 30s")
+            .unwrap()
+            .unwrap();
         assert_eq!(v, 7);
     }
 
@@ -118,23 +140,30 @@ async fn concurrent_misses_run_fill_once() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn fill_error_propagates_and_does_not_poison() {
-    let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    const WAITERS: usize = 4;
+
+    let _guard = METRICS_LOCK.lock().await;
     let cache = fresh_cache();
     let key = unique_key("fill_error_propagates_and_does_not_poison");
     let attempt = Arc::new(AtomicUsize::new(0));
 
     let before = read_through_metrics().snapshot();
 
-    const WAITERS: usize = 4;
+    let started = Arc::new(AtomicUsize::new(0));
     let mut handles = Vec::with_capacity(WAITERS);
     for _ in 0..WAITERS {
         let cache = cache.clone();
         let key = key.clone();
         let attempt = attempt.clone();
+        let started = started.clone();
         handles.push(tokio::spawn(async move {
+            started.fetch_add(1, Ordering::SeqCst);
             get_or_compute::<i32, String, _, _>(&cache, &key, None, || async move {
                 attempt.fetch_add(1, Ordering::SeqCst);
-                tokio::time::sleep(Duration::from_millis(80)).await;
+                while started.load(Ordering::SeqCst) < WAITERS {
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
                 Err("boom".to_string())
             })
             .await
@@ -168,16 +197,33 @@ async fn fill_error_propagates_and_does_not_poison() {
     let after = read_through_metrics().snapshot();
     assert!(after.fill_failures - before.fill_failures >= 1);
 
-    // The key is not poisoned: the next caller retries and can succeed.
-    let v: i32 = get_or_compute(&cache, &key, None, || async move { Ok::<i32, String>(5) })
-        .await
-        .unwrap();
+    // The key is not poisoned: the next caller retries and can succeed. Use a
+    // fresh counter for the retry's own closure so we can prove *this* call
+    // actually ran a fill rather than serving a (nonexistent) cached value.
+    let retry_ran = Arc::new(AtomicUsize::new(0));
+    let retry_ran2 = retry_ran.clone();
+    let v: i32 = get_or_compute(&cache, &key, None, || async move {
+        retry_ran2.fetch_add(1, Ordering::SeqCst);
+        Ok::<i32, String>(5)
+    })
+    .await
+    .unwrap();
     assert_eq!(v, 5);
-    assert!(attempt.load(Ordering::SeqCst) >= 2, "retry after failure must run fill again");
+    assert_eq!(
+        retry_ran.load(Ordering::SeqCst),
+        1,
+        "retry after failure must run its fill closure exactly once"
+    );
+    assert!(attempt.load(Ordering::SeqCst) >= 1, "the failing round must have run at least once");
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn cancelled_leader_does_not_deadlock_waiters() {
+    // read_through_metrics() is a process-wide singleton; hold the same lock
+    // other tests use so concurrent metric increments don't race (this test
+    // doesn't assert on metrics itself, but must not pollute others' deltas
+    // while it runs).
+    let _guard = METRICS_LOCK.lock().await;
     let cache = fresh_cache();
     let key = unique_key("cancelled_leader_does_not_deadlock_waiters");
 
@@ -217,6 +263,7 @@ async fn cancelled_leader_does_not_deadlock_waiters() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn different_keys_do_not_coalesce() {
+    let _guard = METRICS_LOCK.lock().await;
     let cache = fresh_cache();
     let key_a = unique_key("different_keys_a");
     let key_b = unique_key("different_keys_b");
@@ -224,9 +271,8 @@ async fn different_keys_do_not_coalesce() {
 
     let fc_a = fill_count.clone();
     let cache_a = cache.clone();
-    let key_a2 = key_a.clone();
     let a = tokio::spawn(async move {
-        get_or_compute::<i32, String, _, _>(&cache_a, &key_a2, None, || async move {
+        get_or_compute::<i32, String, _, _>(&cache_a, &key_a, None, || async move {
             fc_a.fetch_add(1, Ordering::SeqCst);
             tokio::time::sleep(Duration::from_millis(80)).await;
             Ok(1)
@@ -236,9 +282,8 @@ async fn different_keys_do_not_coalesce() {
 
     let fc_b = fill_count.clone();
     let cache_b = cache.clone();
-    let key_b2 = key_b.clone();
     let b = tokio::spawn(async move {
-        get_or_compute::<i32, String, _, _>(&cache_b, &key_b2, None, || async move {
+        get_or_compute::<i32, String, _, _>(&cache_b, &key_b, None, || async move {
             fc_b.fetch_add(1, Ordering::SeqCst);
             tokio::time::sleep(Duration::from_millis(80)).await;
             Ok(2)
@@ -253,7 +298,7 @@ async fn different_keys_do_not_coalesce() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn swr_serves_stale_and_refreshes_in_background() {
-    let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = METRICS_LOCK.lock().await;
     let cache = fresh_cache();
     let key = unique_key("swr_serves_stale_and_refreshes_in_background");
     let fill_count = Arc::new(AtomicUsize::new(0));
@@ -265,12 +310,9 @@ async fn swr_serves_stale_and_refreshes_in_background() {
         .stale_while_revalidate(Duration::from_secs(10));
 
     let fc = fill_count.clone();
-    let v: String = get_or_compute_with(&cache, &key, opts.clone(), move || {
-        let fc = fc.clone();
-        async move {
-            fc.fetch_add(1, Ordering::SeqCst);
-            Ok::<String, String>("v1".to_string())
-        }
+    let v: String = get_or_compute_with(&cache, &key, opts.clone(), move || async move {
+        fc.fetch_add(1, Ordering::SeqCst);
+        Ok::<String, String>("v1".to_string())
     })
     .await
     .unwrap();
@@ -282,13 +324,10 @@ async fn swr_serves_stale_and_refreshes_in_background() {
 
     let start = std::time::Instant::now();
     let fc = fill_count.clone();
-    let v: String = get_or_compute_with(&cache, &key, opts.clone(), move || {
-        let fc = fc.clone();
-        async move {
-            fc.fetch_add(1, Ordering::SeqCst);
-            tokio::time::sleep(Duration::from_millis(200)).await;
-            Ok::<String, String>("v2".to_string())
-        }
+    let v: String = get_or_compute_with(&cache, &key, opts.clone(), move || async move {
+        fc.fetch_add(1, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        Ok::<String, String>("v2".to_string())
     })
     .await
     .unwrap();
@@ -303,12 +342,9 @@ async fn swr_serves_stale_and_refreshes_in_background() {
     let refreshed = tokio::time::timeout(Duration::from_secs(2), async {
         loop {
             let fc = fill_count.clone();
-            let v: String = get_or_compute_with(&cache, &key, opts.clone(), move || {
-                let fc = fc.clone();
-                async move {
-                    fc.fetch_add(1, Ordering::SeqCst);
-                    Ok::<String, String>("unexpected-refill".to_string())
-                }
+            let v: String = get_or_compute_with(&cache, &key, opts.clone(), move || async move {
+                fc.fetch_add(1, Ordering::SeqCst);
+                Ok::<String, String>("unexpected-refill".to_string())
             })
             .await
             .unwrap();
@@ -329,6 +365,9 @@ async fn swr_serves_stale_and_refreshes_in_background() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn swr_only_one_background_refresh() {
+    const N: usize = 8;
+
+    let _guard = METRICS_LOCK.lock().await;
     let cache = fresh_cache();
     let key = unique_key("swr_only_one_background_refresh");
     let fill_count = Arc::new(AtomicUsize::new(0));
@@ -338,19 +377,15 @@ async fn swr_only_one_background_refresh() {
         .stale_while_revalidate(Duration::from_secs(10));
 
     let fc = fill_count.clone();
-    get_or_compute_with(&cache, &key, opts.clone(), move || {
-        let fc = fc.clone();
-        async move {
-            fc.fetch_add(1, Ordering::SeqCst);
-            Ok::<String, String>("v1".to_string())
-        }
+    get_or_compute_with(&cache, &key, opts.clone(), move || async move {
+        fc.fetch_add(1, Ordering::SeqCst);
+        Ok::<String, String>("v1".to_string())
     })
     .await
     .unwrap();
 
     tokio::time::sleep(Duration::from_millis(80)).await;
 
-    const N: usize = 8;
     let mut handles = Vec::with_capacity(N);
     for _ in 0..N {
         let cache = cache.clone();
@@ -358,13 +393,10 @@ async fn swr_only_one_background_refresh() {
         let opts = opts.clone();
         let fc = fill_count.clone();
         handles.push(tokio::spawn(async move {
-            get_or_compute_with(&cache, &key, opts, move || {
-                let fc = fc.clone();
-                async move {
-                    fc.fetch_add(1, Ordering::SeqCst);
-                    tokio::time::sleep(Duration::from_millis(150)).await;
-                    Ok::<String, String>("v2".to_string())
-                }
+            get_or_compute_with(&cache, &key, opts, move || async move {
+                fc.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(150)).await;
+                Ok::<String, String>("v2".to_string())
             })
             .await
         }));
@@ -398,14 +430,14 @@ async fn swr_only_one_background_refresh() {
 /// proving `get_or_compute` works over the serde slow path too.
 #[derive(Default)]
 struct RawBytesCache {
-    inner: Mutex<std::collections::HashMap<String, autumn_web::cache::RawCacheBytes>>,
+    inner: std::sync::Mutex<std::collections::HashMap<String, autumn_web::cache::RawCacheBytes>>,
 }
 
 impl Cache for RawBytesCache {
     fn get_value(&self, key: &str) -> Option<Arc<dyn std::any::Any + Send + Sync>> {
         self.inner
             .lock()
-            .unwrap_or_else(|e| e.into_inner())
+            .unwrap_or_else(PoisonError::into_inner)
             .get(key)
             .map(|raw| Arc::new(raw.clone()) as Arc<dyn std::any::Any + Send + Sync>)
     }
@@ -415,23 +447,24 @@ impl Cache for RawBytesCache {
     }
 
     fn invalidate(&self, key: &str) {
-        self.inner.lock().unwrap_or_else(|e| e.into_inner()).remove(key);
+        self.inner.lock().unwrap_or_else(PoisonError::into_inner).remove(key);
     }
 
     fn clear(&self) {
-        self.inner.lock().unwrap_or_else(|e| e.into_inner()).clear();
+        self.inner.lock().unwrap_or_else(PoisonError::into_inner).clear();
     }
 
     fn insert_raw_bytes(&self, key: &str, bytes: Vec<u8>, _ttl: Option<Duration>) {
         self.inner
             .lock()
-            .unwrap_or_else(|e| e.into_inner())
+            .unwrap_or_else(PoisonError::into_inner)
             .insert(key.to_owned(), autumn_web::cache::RawCacheBytes(bytes));
     }
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn works_through_arc_dyn_cache_raw_bytes_backend() {
+    let _guard = METRICS_LOCK.lock().await;
     let cache: Arc<dyn Cache> = Arc::new(RawBytesCache::default());
     let key = unique_key("works_through_arc_dyn_cache_raw_bytes_backend");
 

--- a/autumn/tests/cache_stampede.rs
+++ b/autumn/tests/cache_stampede.rs
@@ -12,11 +12,11 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, PoisonError};
 use std::time::Duration;
 
+use autumn_web::cache::MokaCache;
 use autumn_web::cache::{
-    Cache, CacheFillError, GetOrComputeOptions, get_or_compute, get_or_compute_with, get_cached,
+    Cache, CacheFillError, GetOrComputeOptions, get_cached, get_or_compute, get_or_compute_with,
     read_through_metrics,
 };
-use autumn_web::cache::MokaCache;
 
 /// Serializes tests that touch `read_through_metrics()` (a process-wide
 /// singleton), since `cargo test` runs tests in parallel by default and
@@ -134,7 +134,10 @@ async fn concurrent_misses_run_fill_once() {
 
     let after = read_through_metrics().snapshot();
     assert_eq!(after.fills - before.fills, 1);
-    assert_eq!(after.coalesced_waits - before.coalesced_waits, (K - 1) as u64);
+    assert_eq!(
+        after.coalesced_waits - before.coalesced_waits,
+        (K - 1) as u64
+    );
     assert!(after.misses - before.misses >= 1);
 }
 
@@ -179,15 +182,24 @@ async fn fill_error_propagates_and_does_not_poison() {
                 saw_typed_fill = true;
             }
             Err(CacheFillError::FillFailed(msg)) => {
-                assert!(msg.contains("boom"), "waiter error should mention 'boom': {msg}");
+                assert!(
+                    msg.contains("boom"),
+                    "waiter error should mention 'boom': {msg}"
+                );
                 saw_fill_failed = true;
             }
             Ok(_) => panic!("a failing fill must never return Ok"),
         }
     }
-    assert!(saw_typed_fill, "the leader must get a typed CacheFillError::Fill");
+    assert!(
+        saw_typed_fill,
+        "the leader must get a typed CacheFillError::Fill"
+    );
     // With WAITERS=4 concurrent callers there should be at least one coalesced waiter.
-    assert!(saw_fill_failed, "at least one waiter must see CacheFillError::FillFailed");
+    assert!(
+        saw_fill_failed,
+        "at least one waiter must see CacheFillError::FillFailed"
+    );
 
     assert!(
         get_cached::<i32>(&*cache, &key).is_none(),
@@ -214,7 +226,10 @@ async fn fill_error_propagates_and_does_not_poison() {
         1,
         "retry after failure must run its fill closure exactly once"
     );
-    assert!(attempt.load(Ordering::SeqCst) >= 1, "the failing round must have run at least once");
+    assert!(
+        attempt.load(Ordering::SeqCst) >= 1,
+        "the failing round must have run at least once"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -242,12 +257,13 @@ async fn cancelled_leader_does_not_deadlock_waiters() {
 
     let waiter_key = key.clone();
     let waiter_cache = cache.clone();
-    let waiter = tokio::spawn(async move {
-        get_or_compute::<i32, String, _, _>(&waiter_cache, &waiter_key, None, || async move {
-            Ok(2)
-        })
-        .await
-    });
+    let waiter =
+        tokio::spawn(async move {
+            get_or_compute::<i32, String, _, _>(&waiter_cache, &waiter_key, None, || async move {
+                Ok(2)
+            })
+            .await
+        });
 
     // Abort the stuck leader; the waiter must recover (re-contend for
     // leadership) instead of hanging forever.
@@ -293,7 +309,11 @@ async fn different_keys_do_not_coalesce() {
 
     assert_eq!(a.await.unwrap().unwrap(), 1);
     assert_eq!(b.await.unwrap().unwrap(), 2);
-    assert_eq!(fill_count.load(Ordering::SeqCst), 2, "distinct keys must each fill");
+    assert_eq!(
+        fill_count.load(Ordering::SeqCst),
+        2,
+        "distinct keys must each fill"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -332,7 +352,10 @@ async fn swr_serves_stale_and_refreshes_in_background() {
     .await
     .unwrap();
     let elapsed = start.elapsed();
-    assert_eq!(v, "v1", "a stale-but-in-grace value must be served immediately");
+    assert_eq!(
+        v, "v1",
+        "a stale-but-in-grace value must be served immediately"
+    );
     assert!(
         elapsed < Duration::from_millis(150),
         "serving stale must not wait on the slow background refresh, took {elapsed:?}"
@@ -404,7 +427,10 @@ async fn swr_only_one_background_refresh() {
 
     for h in handles {
         let v: String = h.await.unwrap().unwrap();
-        assert_eq!(v, "v1", "all concurrent stale reads must return the stale value fast");
+        assert_eq!(
+            v, "v1",
+            "all concurrent stale reads must return the stale value fast"
+        );
     }
 
     // Give the single background refresh time to land, then confirm exactly
@@ -447,11 +473,17 @@ impl Cache for RawBytesCache {
     }
 
     fn invalidate(&self, key: &str) {
-        self.inner.lock().unwrap_or_else(PoisonError::into_inner).remove(key);
+        self.inner
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(key);
     }
 
     fn clear(&self) {
-        self.inner.lock().unwrap_or_else(PoisonError::into_inner).clear();
+        self.inner
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clear();
     }
 
     fn insert_raw_bytes(&self, key: &str, bytes: Vec<u8>, _ttl: Option<Duration>) {

--- a/autumn/tests/cache_stampede.rs
+++ b/autumn/tests/cache_stampede.rs
@@ -451,6 +451,52 @@ async fn swr_only_one_background_refresh() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn swr_without_ttl_never_goes_stale() {
+    let _guard = METRICS_LOCK.lock().await;
+    let cache = fresh_cache();
+    let key = unique_key("swr_without_ttl_never_goes_stale");
+    let fill_count = Arc::new(AtomicUsize::new(0));
+
+    // SWR enabled but no `.ttl(...)`: per its own doc comment, `ttl: None`
+    // means "no expiry", so the value must stay fresh forever rather than
+    // going stale (and re-triggering a background refresh) on every read
+    // after the very first.
+    let opts = GetOrComputeOptions::new().stale_while_revalidate(Duration::from_secs(10));
+
+    let fc = fill_count.clone();
+    let v: String = get_or_compute_with(&cache, &key, opts.clone(), move || async move {
+        fc.fetch_add(1, Ordering::SeqCst);
+        Ok::<String, String>("v1".to_string())
+    })
+    .await
+    .unwrap();
+    assert_eq!(v, "v1");
+
+    // Real time elapses. With the bug, any elapsed time makes the entry
+    // stale, since `fresh_until` was stamped as "now" at write time.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    for _ in 0..5 {
+        let fc = fill_count.clone();
+        let v: String = get_or_compute_with(&cache, &key, opts.clone(), move || async move {
+            fc.fetch_add(1, Ordering::SeqCst);
+            Ok::<String, String>("unexpected-refill".to_string())
+        })
+        .await
+        .unwrap();
+        assert_eq!(v, "v1", "a value with no TTL must never appear stale");
+    }
+
+    // Give any (incorrectly) spawned background refresh a chance to run.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert_eq!(
+        fill_count.load(Ordering::SeqCst),
+        1,
+        "no TTL + SWR must mean 'never stale': only the first fill should ever run"
+    );
+}
+
 /// A minimal `Cache` implementation that only ever stores `RawCacheBytes`
 /// (mirroring how a serializing, cross-process backend like Redis behaves),
 /// proving `get_or_compute` works over the serde slow path too.

--- a/autumn/tests/cache_stampede.rs
+++ b/autumn/tests/cache_stampede.rs
@@ -1,0 +1,452 @@
+//! Integration tests for read-through cache stampede protection (issue #1204).
+//!
+//! These exercise the public API (`autumn_web::cache::get_or_compute` /
+//! `get_or_compute_with`) against the in-process `MokaCache` backend, proving
+//! the single-flight, failure-semantics, and stale-while-revalidate
+//! acceptance criteria. Redis-specific (cross-replica) coverage lives in
+//! `autumn-cache-redis/src/lib.rs`.
+
+#![cfg(feature = "cache-moka")]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use autumn_web::cache::{
+    Cache, CacheFillError, GetOrComputeOptions, get_or_compute, get_or_compute_with, get_cached,
+    read_through_metrics,
+};
+use autumn_web::cache::MokaCache;
+
+/// Serializes tests that assert *exact* metric deltas, since
+/// `read_through_metrics()` is a process-wide singleton and `cargo test` runs
+/// tests in parallel by default.
+static METRICS_LOCK: Mutex<()> = Mutex::new(());
+
+fn fresh_cache() -> Arc<dyn Cache> {
+    Arc::new(MokaCache::new(1_000, None))
+}
+
+fn unique_key(name: &str) -> String {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("cache-stampede-test:{name}:{n}")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn miss_fills_then_hits() {
+    let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let cache = fresh_cache();
+    let key = unique_key("miss_fills_then_hits");
+    let fill_count = Arc::new(AtomicUsize::new(0));
+
+    let before = read_through_metrics().snapshot();
+
+    let fc = fill_count.clone();
+    let v: i32 = get_or_compute(&cache, &key, None, || async move {
+        fc.fetch_add(1, Ordering::SeqCst);
+        Ok::<i32, String>(42)
+    })
+    .await
+    .unwrap();
+    assert_eq!(v, 42);
+    assert_eq!(fill_count.load(Ordering::SeqCst), 1);
+
+    let fc = fill_count.clone();
+    let v: i32 = get_or_compute(&cache, &key, None, || async move {
+        fc.fetch_add(1, Ordering::SeqCst);
+        Ok::<i32, String>(99) // should never run: cache should hit
+    })
+    .await
+    .unwrap();
+    assert_eq!(v, 42, "second call must hit the cache, not refill");
+    assert_eq!(
+        fill_count.load(Ordering::SeqCst),
+        1,
+        "fill must not run again on a hit"
+    );
+
+    let after = read_through_metrics().snapshot();
+    assert_eq!(after.fills - before.fills, 1);
+    assert_eq!(after.hits - before.hits, 1);
+    assert!(after.misses - before.misses >= 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_misses_run_fill_once() {
+    // The issue's falsifiable success metric: K concurrent requests at an
+    // expired/missing key produce exactly 1 fill and K-1 coalesced waits.
+    let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let cache = fresh_cache();
+    let key = unique_key("concurrent_misses_run_fill_once");
+    let fill_count = Arc::new(AtomicUsize::new(0));
+
+    let before = read_through_metrics().snapshot();
+
+    const K: usize = 16;
+    let mut handles = Vec::with_capacity(K);
+    for _ in 0..K {
+        let cache = cache.clone();
+        let key = key.clone();
+        let fc = fill_count.clone();
+        handles.push(tokio::spawn(async move {
+            get_or_compute::<i32, String, _, _>(&cache, &key, None, || async move {
+                fc.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                Ok(7)
+            })
+            .await
+        }));
+    }
+
+    for h in handles {
+        let v = h.await.unwrap().unwrap();
+        assert_eq!(v, 7);
+    }
+
+    assert_eq!(
+        fill_count.load(Ordering::SeqCst),
+        1,
+        "exactly one fill must run for {K} concurrent misses on the same key"
+    );
+
+    let after = read_through_metrics().snapshot();
+    assert_eq!(after.fills - before.fills, 1);
+    assert_eq!(after.coalesced_waits - before.coalesced_waits, (K - 1) as u64);
+    assert!(after.misses - before.misses >= 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fill_error_propagates_and_does_not_poison() {
+    let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let cache = fresh_cache();
+    let key = unique_key("fill_error_propagates_and_does_not_poison");
+    let attempt = Arc::new(AtomicUsize::new(0));
+
+    let before = read_through_metrics().snapshot();
+
+    const WAITERS: usize = 4;
+    let mut handles = Vec::with_capacity(WAITERS);
+    for _ in 0..WAITERS {
+        let cache = cache.clone();
+        let key = key.clone();
+        let attempt = attempt.clone();
+        handles.push(tokio::spawn(async move {
+            get_or_compute::<i32, String, _, _>(&cache, &key, None, || async move {
+                attempt.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(80)).await;
+                Err("boom".to_string())
+            })
+            .await
+        }));
+    }
+
+    let mut saw_typed_fill = false;
+    let mut saw_fill_failed = false;
+    for h in handles {
+        match h.await.unwrap() {
+            Err(CacheFillError::Fill(e)) => {
+                assert_eq!(e, "boom");
+                saw_typed_fill = true;
+            }
+            Err(CacheFillError::FillFailed(msg)) => {
+                assert!(msg.contains("boom"), "waiter error should mention 'boom': {msg}");
+                saw_fill_failed = true;
+            }
+            Ok(_) => panic!("a failing fill must never return Ok"),
+        }
+    }
+    assert!(saw_typed_fill, "the leader must get a typed CacheFillError::Fill");
+    // With WAITERS=4 concurrent callers there should be at least one coalesced waiter.
+    assert!(saw_fill_failed, "at least one waiter must see CacheFillError::FillFailed");
+
+    assert!(
+        get_cached::<i32>(&*cache, &key).is_none(),
+        "a failed fill must not write anything to the cache"
+    );
+
+    let after = read_through_metrics().snapshot();
+    assert!(after.fill_failures - before.fill_failures >= 1);
+
+    // The key is not poisoned: the next caller retries and can succeed.
+    let v: i32 = get_or_compute(&cache, &key, None, || async move { Ok::<i32, String>(5) })
+        .await
+        .unwrap();
+    assert_eq!(v, 5);
+    assert!(attempt.load(Ordering::SeqCst) >= 2, "retry after failure must run fill again");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cancelled_leader_does_not_deadlock_waiters() {
+    let cache = fresh_cache();
+    let key = unique_key("cancelled_leader_does_not_deadlock_waiters");
+
+    let leader_key = key.clone();
+    let leader_cache = cache.clone();
+    let leader = tokio::spawn(async move {
+        get_or_compute::<i32, String, _, _>(&leader_cache, &leader_key, None, || async move {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            Ok(1)
+        })
+        .await
+    });
+
+    // Give the leader a moment to register as the in-flight leader.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let waiter_key = key.clone();
+    let waiter_cache = cache.clone();
+    let waiter = tokio::spawn(async move {
+        get_or_compute::<i32, String, _, _>(&waiter_cache, &waiter_key, None, || async move {
+            Ok(2)
+        })
+        .await
+    });
+
+    // Abort the stuck leader; the waiter must recover (re-contend for
+    // leadership) instead of hanging forever.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    leader.abort();
+
+    let result = tokio::time::timeout(Duration::from_secs(5), waiter)
+        .await
+        .expect("waiter must not deadlock after the leader is cancelled")
+        .unwrap();
+    assert_eq!(result.unwrap(), 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn different_keys_do_not_coalesce() {
+    let cache = fresh_cache();
+    let key_a = unique_key("different_keys_a");
+    let key_b = unique_key("different_keys_b");
+    let fill_count = Arc::new(AtomicUsize::new(0));
+
+    let fc_a = fill_count.clone();
+    let cache_a = cache.clone();
+    let key_a2 = key_a.clone();
+    let a = tokio::spawn(async move {
+        get_or_compute::<i32, String, _, _>(&cache_a, &key_a2, None, || async move {
+            fc_a.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(80)).await;
+            Ok(1)
+        })
+        .await
+    });
+
+    let fc_b = fill_count.clone();
+    let cache_b = cache.clone();
+    let key_b2 = key_b.clone();
+    let b = tokio::spawn(async move {
+        get_or_compute::<i32, String, _, _>(&cache_b, &key_b2, None, || async move {
+            fc_b.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(80)).await;
+            Ok(2)
+        })
+        .await
+    });
+
+    assert_eq!(a.await.unwrap().unwrap(), 1);
+    assert_eq!(b.await.unwrap().unwrap(), 2);
+    assert_eq!(fill_count.load(Ordering::SeqCst), 2, "distinct keys must each fill");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn swr_serves_stale_and_refreshes_in_background() {
+    let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let cache = fresh_cache();
+    let key = unique_key("swr_serves_stale_and_refreshes_in_background");
+    let fill_count = Arc::new(AtomicUsize::new(0));
+
+    let before = read_through_metrics().snapshot();
+
+    let opts = GetOrComputeOptions::new()
+        .ttl(Duration::from_millis(50))
+        .stale_while_revalidate(Duration::from_secs(10));
+
+    let fc = fill_count.clone();
+    let v: String = get_or_compute_with(&cache, &key, opts.clone(), move || {
+        let fc = fc.clone();
+        async move {
+            fc.fetch_add(1, Ordering::SeqCst);
+            Ok::<String, String>("v1".to_string())
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(v, "v1");
+
+    // Let the freshness TTL elapse so the value is stale (but still within
+    // the grace period).
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    let start = std::time::Instant::now();
+    let fc = fill_count.clone();
+    let v: String = get_or_compute_with(&cache, &key, opts.clone(), move || {
+        let fc = fc.clone();
+        async move {
+            fc.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            Ok::<String, String>("v2".to_string())
+        }
+    })
+    .await
+    .unwrap();
+    let elapsed = start.elapsed();
+    assert_eq!(v, "v1", "a stale-but-in-grace value must be served immediately");
+    assert!(
+        elapsed < Duration::from_millis(150),
+        "serving stale must not wait on the slow background refresh, took {elapsed:?}"
+    );
+
+    // Poll until the background refresh completes and the fresh value is visible.
+    let refreshed = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let fc = fill_count.clone();
+            let v: String = get_or_compute_with(&cache, &key, opts.clone(), move || {
+                let fc = fc.clone();
+                async move {
+                    fc.fetch_add(1, Ordering::SeqCst);
+                    Ok::<String, String>("unexpected-refill".to_string())
+                }
+            })
+            .await
+            .unwrap();
+            if v == "v2" {
+                break v;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("background refresh must eventually publish the new value");
+    assert_eq!(refreshed, "v2");
+
+    let after = read_through_metrics().snapshot();
+    assert!(after.stale_serves - before.stale_serves >= 1);
+    assert!(fill_count.load(Ordering::SeqCst) >= 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn swr_only_one_background_refresh() {
+    let cache = fresh_cache();
+    let key = unique_key("swr_only_one_background_refresh");
+    let fill_count = Arc::new(AtomicUsize::new(0));
+
+    let opts = GetOrComputeOptions::new()
+        .ttl(Duration::from_millis(50))
+        .stale_while_revalidate(Duration::from_secs(10));
+
+    let fc = fill_count.clone();
+    get_or_compute_with(&cache, &key, opts.clone(), move || {
+        let fc = fc.clone();
+        async move {
+            fc.fetch_add(1, Ordering::SeqCst);
+            Ok::<String, String>("v1".to_string())
+        }
+    })
+    .await
+    .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    const N: usize = 8;
+    let mut handles = Vec::with_capacity(N);
+    for _ in 0..N {
+        let cache = cache.clone();
+        let key = key.clone();
+        let opts = opts.clone();
+        let fc = fill_count.clone();
+        handles.push(tokio::spawn(async move {
+            get_or_compute_with(&cache, &key, opts, move || {
+                let fc = fc.clone();
+                async move {
+                    fc.fetch_add(1, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(150)).await;
+                    Ok::<String, String>("v2".to_string())
+                }
+            })
+            .await
+        }));
+    }
+
+    for h in handles {
+        let v: String = h.await.unwrap().unwrap();
+        assert_eq!(v, "v1", "all concurrent stale reads must return the stale value fast");
+    }
+
+    // Give the single background refresh time to land, then confirm exactly
+    // one refresh fill ran (1 initial fill + 1 refresh = 2 total).
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while fill_count.load(Ordering::SeqCst) < 2 {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("background refresh must complete");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert_eq!(
+        fill_count.load(Ordering::SeqCst),
+        2,
+        "only one background refresh should run despite N concurrent stale reads"
+    );
+}
+
+/// A minimal `Cache` implementation that only ever stores `RawCacheBytes`
+/// (mirroring how a serializing, cross-process backend like Redis behaves),
+/// proving `get_or_compute` works over the serde slow path too.
+#[derive(Default)]
+struct RawBytesCache {
+    inner: Mutex<std::collections::HashMap<String, autumn_web::cache::RawCacheBytes>>,
+}
+
+impl Cache for RawBytesCache {
+    fn get_value(&self, key: &str) -> Option<Arc<dyn std::any::Any + Send + Sync>> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(key)
+            .map(|raw| Arc::new(raw.clone()) as Arc<dyn std::any::Any + Send + Sync>)
+    }
+
+    fn insert_value(&self, _key: &str, _value: Arc<dyn std::any::Any + Send + Sync>) {
+        // Simulate a backend that only accepts the serialized path.
+    }
+
+    fn invalidate(&self, key: &str) {
+        self.inner.lock().unwrap_or_else(|e| e.into_inner()).remove(key);
+    }
+
+    fn clear(&self) {
+        self.inner.lock().unwrap_or_else(|e| e.into_inner()).clear();
+    }
+
+    fn insert_raw_bytes(&self, key: &str, bytes: Vec<u8>, _ttl: Option<Duration>) {
+        self.inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(key.to_owned(), autumn_web::cache::RawCacheBytes(bytes));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn works_through_arc_dyn_cache_raw_bytes_backend() {
+    let cache: Arc<dyn Cache> = Arc::new(RawBytesCache::default());
+    let key = unique_key("works_through_arc_dyn_cache_raw_bytes_backend");
+
+    let v: String = get_or_compute(&cache, &key, None, || async move {
+        Ok::<String, String>("hello".to_string())
+    })
+    .await
+    .unwrap();
+    assert_eq!(v, "hello");
+
+    // Second call must hit via the RawCacheBytes/serde_json slow path.
+    let v: String = get_or_compute(&cache, &key, None, || async move {
+        Ok::<String, String>("should-not-run".to_string())
+    })
+    .await
+    .unwrap();
+    assert_eq!(v, "hello");
+}

--- a/docs/guide/cache-stampede.md
+++ b/docs/guide/cache-stampede.md
@@ -102,9 +102,15 @@ let opts = GetOrComputeOptions::new()
 
 - While the value is **fresh** (within `ttl`), reads return it immediately.
 - Once **stale** (past `ttl` but within `ttl + grace`), reads still return the
-  last-known value immediately, and kick off **at most one** background
-  refresh per key (through the same single-flight registry — concurrent stale
-  reads never start a second refresh).
+  last-known value immediately, and kick off **at most one background refresh
+  per replica** (through the same process-local single-flight registry —
+  concurrent stale reads on the same replica never start a second refresh).
+  This is a per-process guarantee, not cluster-wide: with only
+  `stale_while_revalidate` enabled, N replicas can each independently start
+  their own refresh for the same stale key at expiry (N fills, not 1). Add
+  `.distributed_fill_lock(true)` for the cluster-wide "at most one refresh
+  fleet-wide" guarantee — the background refresh honors the distributed lock
+  exactly like a cold-miss fill.
 - Once past `ttl + grace`, the key is treated as a cold miss again.
 
 **Trade-offs:** callers may observe a value up to `grace` old. The fill

--- a/docs/guide/cache-stampede.md
+++ b/docs/guide/cache-stampede.md
@@ -22,18 +22,23 @@ read-through API fixes both:
 ## Quick start
 
 ```rust,ignore
-use autumn_web::cache::{get_or_compute, Cache};
+use autumn_web::cache::{get_or_compute, Cache, CacheFillError};
 use std::sync::Arc;
 use std::time::Duration;
 
-async fn cached_bookmark_count(cache: &Arc<dyn Cache>) -> Result<i64, sqlx::Error> {
+async fn cached_bookmark_count(
+    cache: &Arc<dyn Cache>,
+) -> Result<i64, CacheFillError<sqlx::Error>> {
     get_or_compute(cache, "bookmark_count", Some(Duration::from_secs(30)), || async {
         count_bookmarks_in_db().await
     })
     .await
-    .map_err(|e| e.into_fill().expect("fill error is the only variant reachable here"))
 }
 ```
+
+Concurrent callers that coalesce onto someone else's in-flight fill can see
+`CacheFillError::FillFailed` (not just `CacheFillError::Fill`) if that fill
+failed — don't assume `into_fill()` always returns `Some`.
 
 On a hit, the cached value returns immediately. On a miss, the first caller
 runs the closure; every concurrent caller for the same key awaits that one

--- a/docs/guide/cache-stampede.md
+++ b/docs/guide/cache-stampede.md
@@ -1,0 +1,169 @@
+# Cache Stampede Protection
+
+When a hot cache key expires, every concurrent request misses at once and
+recomputes the same value — one expiry turns into a database load spike.
+`get_or_compute` / `get_or_compute_with` add read-through fills to Autumn's
+cache abstraction that coalesce those concurrent misses, so a hot-key expiry
+degrades to **one recompute** instead of a thundering herd.
+
+## Why it matters
+
+Autumn's cache already exposes `get`/`insert`/`invalidate`, but nothing
+coalesces concurrent misses: in-process callers race each other to refill the
+same key, and across replicas N processes each refill the same Redis key. The
+read-through API fixes both:
+
+- **In-process:** concurrent misses for the same key run the fill once per
+  replica; every other caller awaits that one fill and shares its result.
+- **Cross-replica (opt-in, Redis):** a distributed fill lock ensures at most
+  one replica fills a hot key at a time, and/or stale-while-revalidate serves
+  the last-known-good value while one replica refreshes in the background.
+
+## Quick start
+
+```rust,ignore
+use autumn_web::cache::{get_or_compute, Cache};
+use std::sync::Arc;
+use std::time::Duration;
+
+async fn cached_bookmark_count(cache: &Arc<dyn Cache>) -> Result<i64, sqlx::Error> {
+    get_or_compute(cache, "bookmark_count", Some(Duration::from_secs(30)), || async {
+        count_bookmarks_in_db().await
+    })
+    .await
+    .map_err(|e| e.into_fill().expect("fill error is the only variant reachable here"))
+}
+```
+
+On a hit, the cached value returns immediately. On a miss, the first caller
+runs the closure; every concurrent caller for the same key awaits that one
+fill instead of recomputing it themselves.
+
+For cross-replica protection, use `get_or_compute_with` with a Redis-backed
+cache:
+
+```rust,ignore
+use autumn_web::cache::{get_or_compute_with, GetOrComputeOptions};
+use std::time::Duration;
+
+let opts = GetOrComputeOptions::new()
+    .ttl(Duration::from_secs(30))
+    .distributed_fill_lock(true);           // opt-in: requires a backend that
+                                             // implements Cache::try_acquire_fill_lock
+                                             // (RedisCache does)
+
+let count: i64 = get_or_compute_with(&cache, "bookmark_count", opts, || async {
+    count_bookmarks_in_db().await
+})
+.await?;
+```
+
+## In-process vs distributed protection
+
+| | In-process single-flight | Distributed fill lock |
+|---|---|---|
+| Scope | one replica | across all replicas sharing the backend |
+| Mechanism | a process-global in-flight registry keyed by `(cache, key)`; concurrent callers await a `tokio::sync::watch` channel published by whichever caller became the "leader" | `Cache::try_acquire_fill_lock` (Redis: `SET NX PX` + a Lua compare-and-delete release) |
+| Opt-in? | always on | `GetOrComputeOptions::distributed_fill_lock(true)` |
+| Backend support | any `Cache` | any backend implementing the two lock methods (Redis, out of the box) |
+
+**Per-replica divergence note:** the in-process registry only ever sees
+requests on *its own* replica. With the default in-process Moka cache and no
+distributed lock, N replicas each independently coalesce their own concurrent
+misses — so a hot-key expiry still produces up to N fills (one per replica),
+just not N × (requests per replica). This mirrors the existing divergence
+between per-replica Moka caches described in the [cloud-native
+guide](cloud-native.md#shared-cache): if you need a single fill *cluster-wide*,
+enable the Redis backend and the distributed fill lock.
+
+When the lock is contended, the losing replica polls the cache (at
+`lock_poll_interval`, default 50ms) for the winner's value and also
+re-attempts the lock (picking up a crashed holder once its lock TTL expires).
+If neither happens within `lock_wait_timeout` (default 5s), the replica gives
+up waiting and fills locally — bounded extra work, never unavailability.
+
+## Stale-while-revalidate
+
+`GetOrComputeOptions::stale_while_revalidate(grace)` trades a bounded window
+of staleness for zero-latency reads at expiry:
+
+```rust,ignore
+let opts = GetOrComputeOptions::new()
+    .ttl(Duration::from_secs(30))
+    .stale_while_revalidate(Duration::from_secs(300));
+```
+
+- While the value is **fresh** (within `ttl`), reads return it immediately.
+- Once **stale** (past `ttl` but within `ttl + grace`), reads still return the
+  last-known value immediately, and kick off **at most one** background
+  refresh per key (through the same single-flight registry — concurrent stale
+  reads never start a second refresh).
+- Once past `ttl + grace`, the key is treated as a cold miss again.
+
+**Trade-offs:** callers may observe a value up to `grace` old. The fill
+closure passed to `get_or_compute_with` must be `'static` (it may run on a
+background task rather than the calling task) — capture owned handles
+(`Arc`-clone your pool) rather than borrows. On the in-process Moka backend,
+per-entry physical expiry isn't available (Moka's TTL is per-cache-instance);
+freshness is tracked in a stored envelope instead, so correctness doesn't
+depend on Moka evicting the entry.
+
+## Failure semantics
+
+A failing fill never poisons the key:
+
+- Nothing is written to the cache on error.
+- The caller that ran the fill gets a typed `CacheFillError::Fill(e)`.
+- Every coalesced waiter gets `CacheFillError::FillFailed(message)` — the
+  leader's error rendered via `Display` (the error type isn't required to be
+  `Clone`).
+- The in-flight entry is removed before waiters are notified, so the **next**
+  caller retries the fill from scratch.
+- If a leader is cancelled or panics mid-fill, the in-flight entry is removed
+  (RAII), and any waiters see their channel close and re-contend for
+  leadership instead of hanging forever.
+- The distributed lock's `lock_ttl` bounds the damage from a filler that
+  crashes while holding it: the lock self-clears and another replica takes
+  over.
+
+## De-synchronizing mass expiry
+
+Keys written together in a batch (a bulk warmup, a scheduled refresh) tend to
+expire together too, turning a single expiry into a stampede across many keys
+at once. `jittered_ttl` spreads them out:
+
+```rust
+use autumn_web::cache::jittered_ttl;
+use std::time::Duration;
+
+// Each key's TTL is uniformly randomized within ±20% of 5 minutes.
+let ttl = jittered_ttl(Duration::from_secs(300), 0.2);
+```
+
+## Metrics
+
+The read-through API updates process-wide counters, visible on
+`/actuator/metrics` (under `"cache"`) and `/actuator/prometheus`:
+
+| Prometheus name | Meaning |
+|---|---|
+| `autumn_cache_read_through_hits_total` | fast-path reads served from a fresh value |
+| `autumn_cache_read_through_misses_total` | fast-path reads that found no fresh value |
+| `autumn_cache_read_through_coalesced_waits_total` | callers that awaited a concurrent in-process fill |
+| `autumn_cache_read_through_fills_total` | fill closures that completed successfully |
+| `autumn_cache_read_through_fill_failures_total` | fill closures that returned an error |
+| `autumn_cache_read_through_stale_serves_total` | stale-while-revalidate reads served while a refresh ran |
+| `autumn_cache_fill_lock_acquires_total` | distributed fill locks acquired |
+| `autumn_cache_fill_lock_contended_total` | distributed fill lock attempts that found the lock held elsewhere |
+
+**Falsifiable success metric:** K concurrent requests hitting an expired key
+should record 1 fill and K−1 coalesced waits. With the Redis distributed fill
+lock enabled across replicas, total fills across all replicas should be 1.
+
+## See also
+
+- [Data caching and `#[cached]`](cloud-native.md#shared-cache) — function-level
+  memoization and the Redis backend
+- [Maud fragment caching](fragment-caching.md) — caching rendered view fragments
+- [Plugin Metrics Sources](metrics-sources.md) — the `MetricsSource` extension
+  point for app- and plugin-contributed metrics

--- a/docs/guide/cache-stampede.md
+++ b/docs/guide/cache-stampede.md
@@ -76,11 +76,13 @@ between per-replica Moka caches described in the [cloud-native
 guide](cloud-native.md#shared-cache): if you need a single fill *cluster-wide*,
 enable the Redis backend and the distributed fill lock.
 
-When the lock is contended, the losing replica polls the cache (at
-`lock_poll_interval`, default 50ms) for the winner's value and also
-re-attempts the lock (picking up a crashed holder once its lock TTL expires).
-If neither happens within `lock_wait_timeout` (default 5s), the replica gives
-up waiting and fills locally — bounded extra work, never unavailability.
+When the lock is contended, the losing replica polls the cache (starting at
+`lock_poll_interval`, default 50ms, doubling on each attempt up to a 1s
+ceiling so sustained contention doesn't hammer the backend at a fixed rate)
+for the winner's value and also re-attempts the lock (picking up a crashed
+holder once its lock TTL expires). If neither happens within
+`lock_wait_timeout` (default 5s), the replica gives up waiting and fills
+locally — bounded extra work, never unavailability.
 
 ## Stale-while-revalidate
 
@@ -106,7 +108,13 @@ background task rather than the calling task) — capture owned handles
 (`Arc`-clone your pool) rather than borrows. On the in-process Moka backend,
 per-entry physical expiry isn't available (Moka's TTL is per-cache-instance);
 freshness is tracked in a stored envelope instead, so correctness doesn't
-depend on Moka evicting the entry.
+depend on Moka evicting the entry. Omitting `.ttl(...)` (leaving it at its
+`None` default) combined with SWR means the value is fresh forever — it
+never goes stale and never triggers a background refresh, matching `ttl`'s
+own "no expiry" semantics. A process-wide cap (64) limits how many background
+refreshes can run concurrently across all keys, so a burst of simultaneously
+expiring keys can't spawn unbounded background work; a key that misses the
+cap simply retries the refresh on its next stale read.
 
 ## Failure semantics
 

--- a/docs/guide/cloud-native.md
+++ b/docs/guide/cloud-native.md
@@ -545,6 +545,11 @@ with the default per-function Moka caches.
 The `memory` default produces a startup warning in the `prod` profile — the
 same pattern as sessions and file storage.
 
+For read-through fills that coalesce concurrent misses into a single
+recompute (in-process single-flight, plus an opt-in distributed fill lock and
+stale-while-revalidate on the Redis backend), see [Cache Stampede
+Protection](cache-stampede.md).
+
 ## Concurrent Writes
 
 ### The lost-update problem

--- a/docs/guide/fragment-caching.md
+++ b/docs/guide/fragment-caching.md
@@ -227,3 +227,5 @@ written against these helpers works identically with or without a cache.
 - [`#[cached]` and data caching](cloud-native.md) — cache query/function results
 - [Conditional GET and ETags](conditional-get.md) — skip the *network* path
 - [Version history](version-history.md) — per-record version tokens
+- [Cache Stampede Protection](cache-stampede.md) — coalesce concurrent misses
+  into a single fill


### PR DESCRIPTION
## Summary

Implements read-through cache fills with single-flight coalescing to prevent cache stampedes when hot keys expire. Concurrent misses for the same key are coalesced into a single fill operation per process, with optional cross-replica protection via distributed fill locks and stale-while-revalidate.

## Key Changes

- **New `read_through` module** (`autumn/src/cache/read_through.rs`):
  - `get_or_compute()` — basic read-through with in-process single-flight coalescing
  - `get_or_compute_with()` — extended API with `GetOrComputeOptions` for TTL, distributed locks, and stale-while-revalidate
  - `jittered_ttl()` — utility to de-synchronize mass expiry of keys written together
  - `CacheFillError<E>` — typed error distinguishing leader fill failures from coalesced waiter failures
  - `ReadThroughMetrics` — process-wide counters (hits, misses, coalesced waits, fills, failures, lock contention)

- **Cache trait extensions** (`autumn/src/cache/mod.rs`):
  - `try_acquire_fill_lock()` — acquire a distributed fill lock (returns `FillLockStatus`)
  - `release_fill_lock()` — release a distributed fill lock with token validation

- **Redis backend support** (`autumn-cache-redis/src/lib.rs`):
  - Implements distributed fill lock via `SET NX PX` (acquire) and Lua compare-and-delete (release)
  - Prevents lock takeover races with token-based validation
  - Tests for lock acquire/conflict/release semantics

- **Metrics integration** (`autumn/src/actuator.rs`):
  - Exposes `autumn_cache_*` counters on `/actuator/prometheus` and `/actuator/metrics`
  - Tracks hits, misses, coalesced waits, fills, failures, stale serves, and lock contention

- **Comprehensive test suite** (`autumn/tests/cache_stampede.rs`):
  - Single-flight coalescing (K concurrent misses → 1 fill)
  - Failure semantics (errors don't poison keys; next caller retries)
  - Cancellation safety (cancelled leader doesn't deadlock waiters)
  - Stale-while-revalidate behavior
  - Different keys don't coalesce

- **Documentation** (`docs/guide/cache-stampede.md`):
  - Explains the problem and solution
  - Quick-start examples for both in-process and distributed modes
  - Comparison table of protection scopes and mechanisms

## Notable Implementation Details

- **In-flight registry:** Process-global `HashMap<(cache_identity, key), watch::Receiver>` keyed by cache pointer identity and key string, ensuring distinct `Arc<dyn Cache>` allocations never coalesce
- **Single-flight protocol:** First caller becomes "leader" and runs fill; others become "waiters" and await the leader's result via `tokio::sync::watch` channel
- **Failure handling:** Failed fills never poison the key — the in-flight entry is removed before waiters are woken, allowing retries
- **Stale-while-revalidate:** Wraps values in `SwrEnvelope` with freshness deadline; serves stale values while background refresh runs
- **Distributed lock polling:** Exponential backoff (50ms → 1s ceiling) when lock is contended, with configurable timeouts
- **Token-based lock release:** Lua script ensures a caller can only release a lock it still owns, preventing takeover races

https://claude.ai/code/session_019SZCth6AhHKZhoPKUS1xMo