### PR TITLE
Add link_to/button_to view helpers for safe, method-aware links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that could collide with an ordinary cache key, and SWR freshness is now
   evaluated through the same injectable `ClockSource` used elsewhere in the
   framework rather than a hard-coded `SystemTime::now()`.
+- **views:** `link_to`/`button_to` view helpers for safe, method-aware links
+  (#1138). `link_to`/`link_to_with` render an HTML-escaped GET `<a>` anchor
+  with optional `class`/`target`/`rel`/extra attributes (e.g. htmx `hx-*`),
+  automatically adding `rel="noopener"` when `target="_blank"` is set.
+  `button_to`/`button_to_with` render a single-button `<form>` for
+  state-changing actions: the CSRF token is a **required** argument, so a
+  `button_to` call cannot compile without one in scope. For any method other
+  than `GET`, the form posts and carries a hidden `_method` override (reusing
+  `form::method_input`) plus the hidden CSRF field; `Method::GET` renders a
+  plain GET form with neither. Both helpers accept extra attributes on an
+  options struct, so `button_to_with("Delete", path, Method::DELETE, token,
+  &ButtonToOptions::new().attrs(&[("hx-delete", path)]))` upgrades to an
+  htmx interaction without hand-rolling the form. The admin plugin's
+  hand-rolled delete button now uses `button_to_with`, gaining a working
+  no-JS fallback (POST + `_method=DELETE` + CSRF) for free. Purely additive;
+  minor version bump.
 
 - **jobs:** tracked job handles with progress reporting and a built-in
   pollable status route (#1373). `job::enqueue_tracked`/`enqueue_tracked_for`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,9 +73,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   options struct, so `button_to_with("Delete", path, Method::DELETE, token,
   &ButtonToOptions::new().attrs(&[("hx-delete", path)]))` upgrades to an
   htmx interaction without hand-rolling the form. The admin plugin's
-  hand-rolled delete button now uses `button_to_with`, gaining a working
-  no-JS fallback (POST + `_method=DELETE` + CSRF) for free. Purely additive;
-  minor version bump.
+  hand-rolled delete button now uses `button_to_with` (honoring a
+  customized `security.csrf.form_field` via `.csrf_field(...)`), gaining a
+  working no-JS fallback (POST + `_method=DELETE` + CSRF) for free. `attrs`
+  entries that collide with a named option (`href`/`class`/`target`/`rel`
+  for `link_to`, `type`/`class` for `button_to`) panic rather than silently
+  emitting duplicate-attribute markup, and `target="_blank"`/`rel="noopener"`
+  handling is ASCII-case-insensitive. Purely additive; minor version bump.
 
 - **jobs:** tracked job handles with progress reporting and a built-in
   pollable status route (#1373). `job::enqueue_tracked`/`enqueue_tracked_for`

--- a/autumn-admin-plugin/src/routes.rs
+++ b/autumn-admin-plugin/src/routes.rs
@@ -771,6 +771,7 @@ async fn model_detail(
         id,
         &messages,
         csrf.token(),
+        csrf.form_field(),
         csrf.token_header(),
         &prefix,
         &actuator_prefix,

--- a/autumn-admin-plugin/src/routes.rs
+++ b/autumn-admin-plugin/src/routes.rs
@@ -14,7 +14,7 @@ use std::sync::LazyLock;
 use autumn_web::extract::Multipart;
 use autumn_web::flash::{Flash, FlashLevel, FlashMessage};
 use autumn_web::job::{JobAdminQuery, JobAdminSnapshot, JobScheduleSummary, job_admin_backend};
-use autumn_web::prelude::HxResponseExt;
+use autumn_web::prelude::{HxRequest, HxResponseExt};
 use autumn_web::security::{CsrfFormField, CsrfToken, CsrfTokenHeader};
 use autumn_web::{AppState, AutumnError, AutumnResult};
 use axum::extract::{FromRequestParts, Path, Query, State};
@@ -979,15 +979,20 @@ async fn model_action(
 
 /// `DELETE /admin/{slug}/{id}` — Delete a record.
 ///
-/// Called from the detail view's `hx-delete` button. Returns an empty 200
-/// body with `HX-Redirect` so htmx performs a full-page navigation to the
-/// list view (updating `window.location`), rather than swapping the list
-/// HTML into the stale detail page.
+/// Called from the detail view's `hx-delete` button, and reachable as a
+/// plain form submission (`POST` + `_method=DELETE`) from the no-JS
+/// `button_to_with` fallback. htmx requests get an empty 200 body with
+/// `HX-Redirect` so htmx performs a full-page navigation to the list view
+/// (updating `window.location`), rather than swapping the list HTML into
+/// the stale detail page. Non-htmx requests get a real 303 redirect, since
+/// a plain browser form submission ignores `HX-Redirect` and would
+/// otherwise land on a blank 200 response.
 async fn model_delete(
     State(state): State<AppState>,
     axum::Extension(registry): axum::Extension<Arc<AdminRegistry>>,
     axum::Extension(AdminPrefix(prefix)): axum::Extension<AdminPrefix>,
     Path((slug, id)): Path<(String, i64)>,
+    hx: HxRequest,
     flash: Flash,
 ) -> AutumnResult<Response> {
     let (pool, model) = resolve(&state, &registry, &slug)?;
@@ -999,7 +1004,12 @@ async fn model_delete(
     flash
         .success(format!("{} #{id} deleted.", model.display_name()))
         .await;
-    Ok(StatusCode::OK.hx_redirect(&format!("{prefix}/{slug}")))
+    let list_path = format!("{prefix}/{slug}");
+    if hx.is_htmx {
+        Ok(StatusCode::OK.hx_redirect(&list_path))
+    } else {
+        Ok(Redirect::to(&list_path).into_response())
+    }
 }
 
 // ── CSV export / import handlers ─────────────────────────────────────

--- a/autumn-admin-plugin/src/templates.rs
+++ b/autumn-admin-plugin/src/templates.rs
@@ -1365,6 +1365,7 @@ pub fn model_detail_page(
     id: i64,
     messages: &[FlashMessage],
     csrf_token: &str,
+    csrf_form_field: &str,
     csrf_token_header: &str,
     prefix: &str,
     actuator_prefix: &str,
@@ -1403,7 +1404,10 @@ pub fn model_detail_page(
                         &delete_url,
                         Method::DELETE,
                         csrf_token,
-                        &ButtonToOptions::new().class("btn btn-danger").attrs(&delete_attrs),
+                        &ButtonToOptions::new()
+                            .class("btn btn-danger")
+                            .csrf_field(csrf_form_field)
+                            .attrs(&delete_attrs),
                     ))
                 }
             };
@@ -2907,6 +2911,7 @@ mod tests {
             42,
             &[],
             "t",
+            "_csrf",
             "X-CSRF-Token",
             "/admin",
             "/actuator",
@@ -2939,6 +2944,44 @@ mod tests {
     }
 
     #[test]
+    fn detail_page_delete_button_honors_custom_csrf_form_field() {
+        // Regression: the delete button must emit the CSRF hidden input
+        // under the app's configured field name, not a hardcoded "_csrf" —
+        // otherwise a no-JS form submission fails CSRF validation whenever
+        // security.csrf.form_field is customized.
+        let r = dummy_registry();
+        let fields = vec![AdminField::new("name", AdminFieldKind::Text)];
+        let record = serde_json::json!({"id": 42, "name": "x"});
+        let html = model_detail_page(
+            &r,
+            "widgets",
+            "Widget",
+            "Widgets",
+            &fields,
+            &record,
+            "#42",
+            42,
+            &[],
+            "t",
+            "authenticity_token",
+            "X-CSRF-Token",
+            "/admin",
+            "/actuator",
+            false,
+            false,
+        )
+        .into_string();
+        assert!(
+            html.contains(r#"name="authenticity_token" value="t""#),
+            "Delete form must use the configured CSRF field name: {html}"
+        );
+        assert!(
+            !html.contains(r#"name="_csrf""#),
+            "Delete form must not fall back to the default CSRF field name: {html}"
+        );
+    }
+
+    #[test]
     fn detail_view_escapes_malicious_json() {
         let r = dummy_registry();
         let fields = vec![AdminField::new("meta", AdminFieldKind::Json)];
@@ -2959,6 +3002,7 @@ mod tests {
             1,
             &[],
             "t",
+            "_csrf",
             "X-CSRF-Token",
             "/admin",
             "/actuator",

--- a/autumn-admin-plugin/src/templates.rs
+++ b/autumn-admin-plugin/src/templates.rs
@@ -8,12 +8,14 @@ use autumn_web::flash::{FlashMessage, flash_message_divs};
 use autumn_web::job::{
     JobAdminPage, JobAdminRecord, JobAdminSnapshot, JobAdminStatus, JobScheduleSummary,
 };
+use autumn_web::links::{ButtonToOptions, button_to_with};
 use autumn_web::pagination::Page;
 use autumn_web::runtime_config::{ConfigChangeRecord, ConfigEntry};
 use autumn_web::ui::pagination::{PagerOptions, pagination_nav};
 use autumn_web::widgets::{
     CardConfig, NavBarConfig, NavBarLayout, NavItem, card, nav_bar, stat_card,
 };
+use http::Method;
 use maud::{DOCTYPE, Markup, PreEscaped, html};
 use serde_json::Value;
 
@@ -150,6 +152,7 @@ const ADMIN_CSS: &str = "
         padding: 1rem 1.5rem 0.75rem;
         border-bottom: 1px solid var(--border);
     }
+    .header-actions form { display: inline; }
     .card-title {
         font-size: 1.125rem;
         font-weight: 600;
@@ -1378,8 +1381,15 @@ pub fn model_detail_page(
         }
 
         ({
+            let delete_url = format!("{prefix}/{model_slug}/{id}");
+            let delete_confirm = format!("Are you sure you want to delete this {model_name}?");
+            let delete_attrs = [
+                ("hx-delete", delete_url.as_str()),
+                ("hx-confirm", delete_confirm.as_str()),
+                ("hx-target", "body"),
+            ];
             let header_action = html! {
-                div {
+                div class="header-actions" {
                     @if has_history {
                         a href={ (prefix) "/" (model_slug) "/" (id) "/history" }
                             class="btn btn-secondary" { "History" }
@@ -1388,12 +1398,13 @@ pub fn model_detail_page(
                     a href={ (prefix) "/" (model_slug) "/" (id) "/edit" }
                         class="btn btn-primary" { "Edit" }
                     " "
-                    button class="btn btn-danger"
-                        hx-delete={ (prefix) "/" (model_slug) "/" (id) }
-                        hx-confirm={ "Are you sure you want to delete this " (model_name) "?" }
-                        hx-target="body" {
-                        "Delete"
-                    }
+                    (button_to_with(
+                        "Delete",
+                        &delete_url,
+                        Method::DELETE,
+                        csrf_token,
+                        &ButtonToOptions::new().class("btn btn-danger").attrs(&delete_attrs),
+                    ))
                 }
             };
             let body = html! {
@@ -2914,6 +2925,16 @@ mod tests {
         assert!(
             !html.contains("widgets/99"),
             "payload id 99 must not route mutations: {html}"
+        );
+        // The delete button is now rendered via button_to_with, so a no-JS
+        // form submission also works: POST + _method=DELETE + CSRF.
+        assert!(
+            html.contains(r#"name="_method" value="DELETE""#),
+            "Delete form must carry a _method override: {html}"
+        );
+        assert!(
+            html.contains(r#"name="_csrf" value="t""#),
+            "Delete form must carry the CSRF token: {html}"
         );
     }
 

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -322,6 +322,9 @@ pub mod form;
 pub mod gdpr;
 pub mod job;
 pub mod job_tracking;
+/// Safe, method-aware link helpers: [`links::link_to`] anchors and
+/// [`links::button_to`] CSRF-protected action buttons.
+pub mod links;
 pub mod runtime_config;
 #[cfg(feature = "seed")]
 pub mod seed;

--- a/autumn/src/links.rs
+++ b/autumn/src/links.rs
@@ -399,13 +399,21 @@ pub fn button_to(label: &str, href: &str, method: Method, csrf_token: &str) -> m
 ///
 /// Panics when an extra attribute name is not a valid HTML attribute name
 /// (must start with an ASCII letter, followed by ASCII alphanumerics, `-`,
-/// `_`, or `:`), or when it collides (case-insensitively) with an attribute
-/// this helper already sets via a named option. Attribute names passed via
-/// `.attrs(...)` must be static, developer-authored literals (like
-/// `hx-delete` or `data-id`) — **never** built from user input or other
-/// untrusted runtime data — since a bad name panics in both debug and
-/// release builds by design, surfacing the typo instead of silently
-/// emitting broken or duplicate-attribute markup.
+/// `_`, or `:`), when it collides (case-insensitively) with an attribute
+/// this helper already sets via a named option, or when it is one of the
+/// `<button>` submit-override attributes (`formaction`, `formmethod`,
+/// `formenctype`, `formnovalidate`, `formtarget`) — those would silently
+/// change which URL/method/CSRF-field the no-JS form actually submits to,
+/// defeating the CSRF/method-override guarantee this helper exists to
+/// provide. Also panics when `method` is not `GET`, `POST`, `PUT`, `PATCH`,
+/// or `DELETE`, since a `<form>` cannot represent any other HTTP method and
+/// [`crate::form::method_input`] has no override for it — submitting would
+/// silently hit a plain `POST` at the same URL instead of the declared
+/// method. Attribute names passed via `.attrs(...)` must be static,
+/// developer-authored literals (like `hx-delete` or `data-id`) — **never**
+/// built from user input or other untrusted runtime data — since a bad name
+/// panics in both debug and release builds by design, surfacing the typo
+/// instead of silently emitting broken or duplicate-attribute markup.
 ///
 /// # Example
 ///
@@ -445,13 +453,29 @@ pub fn button_to_with(
     csrf_token: &str,
     options: &ButtonToOptions<'_>,
 ) -> maud::Markup {
+    assert!(
+        method == Method::GET
+            || method == Method::POST
+            || method == Method::PUT
+            || method == Method::PATCH
+            || method == Method::DELETE,
+        "button_to only supports GET, POST, PUT, PATCH, or DELETE (got {method}); \
+         a <form> cannot represent any other HTTP method"
+    );
+
     let mut button = String::with_capacity(64 + label.len());
     button.push_str("<button type=\"submit\"");
     if let Some(class) = options.class {
         push_attr(&mut button, "class", class);
     }
     for (name, value) in options.attrs {
-        let is_reserved = name.eq_ignore_ascii_case("type") || name.eq_ignore_ascii_case("class");
+        let is_reserved = name.eq_ignore_ascii_case("type")
+            || name.eq_ignore_ascii_case("class")
+            || name.eq_ignore_ascii_case("formaction")
+            || name.eq_ignore_ascii_case("formmethod")
+            || name.eq_ignore_ascii_case("formenctype")
+            || name.eq_ignore_ascii_case("formnovalidate")
+            || name.eq_ignore_ascii_case("formtarget");
         assert!(
             !is_reserved,
             "attrs cannot override the built-in {name:?} attribute on button_to; use the dedicated option instead"
@@ -781,5 +805,34 @@ mod tests {
         // never called, not only when it collides with an already-set value.
         let options = ButtonToOptions::new().attrs(&[("class", "evil")]);
         let _ = button_to_with("x", "/x", Method::POST, "tok", &options);
+    }
+
+    #[test]
+    #[should_panic(expected = "attrs cannot override the built-in \"formmethod\" attribute")]
+    fn button_to_attrs_cannot_override_formmethod_panics() {
+        // Regression: <button formmethod> overrides the wrapping <form>'s
+        // method for a no-JS submission, which would silently defeat the
+        // declared method (e.g. submitting DELETE's override fields as GET).
+        let options = ButtonToOptions::new().attrs(&[("formmethod", "get")]);
+        let _ = button_to_with("x", "/x", Method::DELETE, "tok", &options);
+    }
+
+    #[test]
+    #[should_panic(expected = "attrs cannot override the built-in \"formaction\" attribute")]
+    fn button_to_attrs_cannot_override_formaction_panics() {
+        // Regression: <button formaction> overrides the wrapping <form>'s
+        // action for a no-JS submission, redirecting the CSRF token and
+        // _method override to a different URL.
+        let options = ButtonToOptions::new().attrs(&[("formaction", "/evil")]);
+        let _ = button_to_with("x", "/x", Method::DELETE, "tok", &options);
+    }
+
+    #[test]
+    #[should_panic(expected = "button_to only supports GET, POST, PUT, PATCH, or DELETE")]
+    fn button_to_rejects_unsupported_method_panics() {
+        // Regression: a <form> cannot represent HEAD/OPTIONS/etc., and
+        // method_input has no override for them — silently falling through
+        // to a plain POST would submit to the wrong handler.
+        let _ = button_to("x", "/x", Method::HEAD, "tok");
     }
 }

--- a/autumn/src/links.rs
+++ b/autumn/src/links.rs
@@ -267,8 +267,13 @@ pub fn link_to(label: &str, href: &str) -> maud::Markup {
 ///
 /// Panics when an extra attribute name is not a valid HTML attribute name
 /// (must start with an ASCII letter, followed by ASCII alphanumerics, `-`,
-/// `_`, or `:`). Attribute names are developer-authored literals; a panic
-/// surfaces the typo instead of silently emitting broken markup.
+/// `_`, or `:`), or when it collides (case-insensitively) with an attribute
+/// this helper already sets via a named option. Attribute names passed via
+/// `.attrs(...)` must be static, developer-authored literals (like
+/// `hx-delete` or `data-id`) — **never** built from user input or other
+/// untrusted runtime data — since a bad name panics in both debug and
+/// release builds by design, surfacing the typo instead of silently
+/// emitting broken or duplicate-attribute markup.
 ///
 /// # Example
 ///
@@ -303,6 +308,14 @@ pub fn link_to_with(label: &str, href: &str, options: &LinkToOptions<'_>) -> mau
         push_attr(&mut out, "rel", rel);
     }
     for (name, value) in options.attrs {
+        let is_reserved = name.eq_ignore_ascii_case("href")
+            || (options.class.is_some() && name.eq_ignore_ascii_case("class"))
+            || (options.target.is_some() && name.eq_ignore_ascii_case("target"))
+            || (rel.is_some() && name.eq_ignore_ascii_case("rel"));
+        assert!(
+            !is_reserved,
+            "attrs cannot override the built-in {name:?} attribute on link_to; use the dedicated option instead"
+        );
         push_attr(&mut out, name, value);
     }
     out.push('>');
@@ -312,16 +325,21 @@ pub fn link_to_with(label: &str, href: &str, options: &LinkToOptions<'_>) -> mau
     maud::PreEscaped(out)
 }
 
-/// Compute the effective `rel` value for a link: when `target="_blank"`,
+/// Compute the effective `rel` value for a link: when `target="_blank"`
+/// (compared case-insensitively, matching the HTML browsing-context keyword),
 /// `noopener` is appended to the caller's `rel` (space-separated, no
-/// duplicate) or used on its own.
+/// duplicate — also compared case-insensitively) or used on its own.
 #[cfg(feature = "maud")]
 fn effective_rel(target: Option<&str>, rel: Option<&str>) -> Option<String> {
-    if target != Some("_blank") {
+    if !target.is_some_and(|t| t.eq_ignore_ascii_case("_blank")) {
         return rel.map(ToString::to_string);
     }
     match rel {
-        Some(rel) if rel.split_whitespace().any(|token| token == "noopener") => {
+        Some(rel)
+            if rel
+                .split_whitespace()
+                .any(|token| token.eq_ignore_ascii_case("noopener")) =>
+        {
             Some(rel.to_string())
         }
         Some(rel) => Some(format!("{rel} noopener")),
@@ -377,8 +395,13 @@ pub fn button_to(label: &str, href: &str, method: Method, csrf_token: &str) -> m
 ///
 /// Panics when an extra attribute name is not a valid HTML attribute name
 /// (must start with an ASCII letter, followed by ASCII alphanumerics, `-`,
-/// `_`, or `:`). Attribute names are developer-authored literals; a panic
-/// surfaces the typo instead of silently emitting broken markup.
+/// `_`, or `:`), or when it collides (case-insensitively) with an attribute
+/// this helper already sets via a named option. Attribute names passed via
+/// `.attrs(...)` must be static, developer-authored literals (like
+/// `hx-delete` or `data-id`) — **never** built from user input or other
+/// untrusted runtime data — since a bad name panics in both debug and
+/// release builds by design, surfacing the typo instead of silently
+/// emitting broken or duplicate-attribute markup.
 ///
 /// # Example
 ///
@@ -423,6 +446,12 @@ pub fn button_to_with(
         push_attr(&mut button, "class", class);
     }
     for (name, value) in options.attrs {
+        let is_reserved = name.eq_ignore_ascii_case("type")
+            || (options.class.is_some() && name.eq_ignore_ascii_case("class"));
+        assert!(
+            !is_reserved,
+            "attrs cannot override the built-in {name:?} attribute on button_to; use the dedicated option instead"
+        );
         push_attr(&mut button, name, value);
     }
     button.push('>');
@@ -522,6 +551,20 @@ mod tests {
     }
 
     #[test]
+    fn link_to_target_blank_case_insensitive() {
+        let options = LinkToOptions::new().target("_BLANK");
+        let html = link_to_with("Ext", "https://example.com", &options).into_string();
+        assert!(html.contains(r#"rel="noopener""#), "{html}");
+    }
+
+    #[test]
+    fn link_to_target_blank_rel_dedup_case_insensitive() {
+        let options = LinkToOptions::new().target("_blank").rel("NOOPENER");
+        let html = link_to_with("Ext", "https://example.com", &options).into_string();
+        assert_eq!(html.to_lowercase().matches("noopener").count(), 1, "{html}");
+    }
+
+    #[test]
     fn link_to_extra_hx_attrs() {
         let options =
             LinkToOptions::new().attrs(&[("hx-get", "/posts/1"), ("hx-target", "#detail")]);
@@ -542,6 +585,22 @@ mod tests {
     #[should_panic(expected = "invalid HTML attribute name")]
     fn link_to_invalid_attr_name_panics() {
         let options = LinkToOptions::new().attrs(&[("on click", "evil()")]);
+        let _ = link_to_with("x", "/x", &options);
+    }
+
+    #[test]
+    #[should_panic(expected = "attrs cannot override the built-in \"href\" attribute")]
+    fn link_to_attrs_cannot_override_href_panics() {
+        let options = LinkToOptions::new().attrs(&[("href", "/evil")]);
+        let _ = link_to_with("x", "/x", &options);
+    }
+
+    #[test]
+    #[should_panic(expected = "attrs cannot override the built-in \"class\" attribute")]
+    fn link_to_attrs_cannot_override_class_panics() {
+        let options = LinkToOptions::new()
+            .class("btn")
+            .attrs(&[("class", "evil")]);
         let _ = link_to_with("x", "/x", &options);
     }
 
@@ -666,6 +725,22 @@ mod tests {
     #[should_panic(expected = "invalid HTML attribute name")]
     fn button_to_invalid_attr_name_panics() {
         let options = ButtonToOptions::new().attrs(&[("foo=bar", "x")]);
+        let _ = button_to_with("x", "/x", Method::POST, "tok", &options);
+    }
+
+    #[test]
+    #[should_panic(expected = "attrs cannot override the built-in \"type\" attribute")]
+    fn button_to_attrs_cannot_override_type_panics() {
+        let options = ButtonToOptions::new().attrs(&[("type", "reset")]);
+        let _ = button_to_with("x", "/x", Method::POST, "tok", &options);
+    }
+
+    #[test]
+    #[should_panic(expected = "attrs cannot override the built-in \"class\" attribute")]
+    fn button_to_attrs_cannot_override_class_panics() {
+        let options = ButtonToOptions::new()
+            .class("btn")
+            .attrs(&[("class", "evil")]);
         let _ = button_to_with("x", "/x", Method::POST, "tok", &options);
     }
 }

--- a/autumn/src/links.rs
+++ b/autumn/src/links.rs
@@ -26,6 +26,8 @@
 //! [`ChangesetForm::form_tag`](crate::form::ChangesetForm::form_tag) instead —
 //! `button_to` is a zero-field action button, not a form builder.
 
+use std::borrow::Cow;
+
 use http::Method;
 
 /// Returns `true` when `name` is a valid HTML attribute name: an ASCII
@@ -296,7 +298,8 @@ pub fn link_to(label: &str, href: &str) -> maud::Markup {
 pub fn link_to_with(label: &str, href: &str, options: &LinkToOptions<'_>) -> maud::Markup {
     let rel = effective_rel(options.target, options.rel);
 
-    let mut out = String::from("<a");
+    let mut out = String::with_capacity(64 + href.len() + label.len());
+    out.push_str("<a");
     push_attr(&mut out, "href", href);
     if let Some(class) = options.class {
         push_attr(&mut out, "class", class);
@@ -309,9 +312,9 @@ pub fn link_to_with(label: &str, href: &str, options: &LinkToOptions<'_>) -> mau
     }
     for (name, value) in options.attrs {
         let is_reserved = name.eq_ignore_ascii_case("href")
-            || (options.class.is_some() && name.eq_ignore_ascii_case("class"))
-            || (options.target.is_some() && name.eq_ignore_ascii_case("target"))
-            || (rel.is_some() && name.eq_ignore_ascii_case("rel"));
+            || name.eq_ignore_ascii_case("class")
+            || name.eq_ignore_ascii_case("target")
+            || name.eq_ignore_ascii_case("rel");
         assert!(
             !is_reserved,
             "attrs cannot override the built-in {name:?} attribute on link_to; use the dedicated option instead"
@@ -329,10 +332,11 @@ pub fn link_to_with(label: &str, href: &str, options: &LinkToOptions<'_>) -> mau
 /// (compared case-insensitively, matching the HTML browsing-context keyword),
 /// `noopener` is appended to the caller's `rel` (space-separated, no
 /// duplicate — also compared case-insensitively) or used on its own.
+/// Borrows the caller's `rel` when no allocation is needed.
 #[cfg(feature = "maud")]
-fn effective_rel(target: Option<&str>, rel: Option<&str>) -> Option<String> {
+fn effective_rel<'a>(target: Option<&str>, rel: Option<&'a str>) -> Option<Cow<'a, str>> {
     if !target.is_some_and(|t| t.eq_ignore_ascii_case("_blank")) {
-        return rel.map(ToString::to_string);
+        return rel.map(Cow::Borrowed);
     }
     match rel {
         Some(rel)
@@ -340,10 +344,10 @@ fn effective_rel(target: Option<&str>, rel: Option<&str>) -> Option<String> {
                 .split_whitespace()
                 .any(|token| token.eq_ignore_ascii_case("noopener")) =>
         {
-            Some(rel.to_string())
+            Some(Cow::Borrowed(rel))
         }
-        Some(rel) => Some(format!("{rel} noopener")),
-        None => Some("noopener".to_string()),
+        Some(rel) => Some(Cow::Owned(format!("{rel} noopener"))),
+        None => Some(Cow::Borrowed("noopener")),
     }
 }
 
@@ -441,13 +445,13 @@ pub fn button_to_with(
     csrf_token: &str,
     options: &ButtonToOptions<'_>,
 ) -> maud::Markup {
-    let mut button = String::from("<button type=\"submit\"");
+    let mut button = String::with_capacity(64 + label.len());
+    button.push_str("<button type=\"submit\"");
     if let Some(class) = options.class {
         push_attr(&mut button, "class", class);
     }
     for (name, value) in options.attrs {
-        let is_reserved = name.eq_ignore_ascii_case("type")
-            || (options.class.is_some() && name.eq_ignore_ascii_case("class"));
+        let is_reserved = name.eq_ignore_ascii_case("type") || name.eq_ignore_ascii_case("class");
         assert!(
             !is_reserved,
             "attrs cannot override the built-in {name:?} attribute on button_to; use the dedicated option instead"
@@ -604,6 +608,32 @@ mod tests {
         let _ = link_to_with("x", "/x", &options);
     }
 
+    #[test]
+    #[should_panic(expected = "attrs cannot override the built-in \"class\" attribute")]
+    fn link_to_attrs_cannot_override_class_without_option_set_panics() {
+        // Regression: `class`/`target`/`rel` must be reserved even when the
+        // dedicated option was never called, not only when it collides with
+        // an already-set value.
+        let options = LinkToOptions::new().attrs(&[("class", "evil")]);
+        let _ = link_to_with("x", "/x", &options);
+    }
+
+    #[test]
+    #[should_panic(expected = "attrs cannot override the built-in \"target\" attribute")]
+    fn link_to_attrs_cannot_override_target_without_option_set_panics() {
+        // Regression: bypassing `.target("_blank")` via attrs would skip the
+        // automatic `rel="noopener"` safety net entirely.
+        let options = LinkToOptions::new().attrs(&[("target", "_blank")]);
+        let _ = link_to_with("x", "/x", &options);
+    }
+
+    #[test]
+    #[should_panic(expected = "attrs cannot override the built-in \"rel\" attribute")]
+    fn link_to_attrs_cannot_override_rel_without_option_set_panics() {
+        let options = LinkToOptions::new().attrs(&[("rel", "nofollow")]);
+        let _ = link_to_with("x", "/x", &options);
+    }
+
     // ── button_to ───────────────────────────────────────────────────────
 
     #[test]
@@ -741,6 +771,15 @@ mod tests {
         let options = ButtonToOptions::new()
             .class("btn")
             .attrs(&[("class", "evil")]);
+        let _ = button_to_with("x", "/x", Method::POST, "tok", &options);
+    }
+
+    #[test]
+    #[should_panic(expected = "attrs cannot override the built-in \"class\" attribute")]
+    fn button_to_attrs_cannot_override_class_without_option_set_panics() {
+        // Regression: `class` must be reserved even when `.class()` was
+        // never called, not only when it collides with an already-set value.
+        let options = ButtonToOptions::new().attrs(&[("class", "evil")]);
         let _ = button_to_with("x", "/x", Method::POST, "tok", &options);
     }
 }

--- a/autumn/src/links.rs
+++ b/autumn/src/links.rs
@@ -5,10 +5,12 @@
 //! but composing them by hand for every "Delete" button invites a forgotten
 //! CSRF field. These helpers close that gap:
 //!
-//! - [`link_to`] / [`link_to_with`] render a plain `<a>` anchor for GET
-//!   navigation, HTML-escaping both label and href, and automatically adding
-//!   `rel="noopener"` when `target="_blank"` is requested.
-//! - [`button_to`] / [`button_to_with`] render a single-button `<form>` for
+//! - [`link_to`](crate::links::link_to) / [`link_to_with`](crate::links::link_to_with)
+//!   render a plain `<a>` anchor for GET navigation, HTML-escaping both
+//!   label and href, and automatically adding `rel="noopener"` when
+//!   `target="_blank"` is requested.
+//! - [`button_to`](crate::links::button_to) / [`button_to_with`](crate::links::button_to_with)
+//!   render a single-button `<form>` for
 //!   state-changing actions: the browser transport is `POST`, a hidden
 //!   `_method` input (via [`crate::form::method_input`]) upgrades it to
 //!   `PUT`/`PATCH`/`DELETE` for the

--- a/autumn/src/links.rs
+++ b/autumn/src/links.rs
@@ -1,0 +1,546 @@
+//! `link_to` / `button_to` — safe, method-aware link helpers (issue #1138).
+//!
+//! Autumn ships the pieces of a safe action link — [`crate::form::method_input`]
+//! for `_method` overrides and the [`crate::security::CsrfToken`] plumbing —
+//! but composing them by hand for every "Delete" button invites a forgotten
+//! CSRF field. These helpers close that gap:
+//!
+//! - [`link_to`] / [`link_to_with`] render a plain `<a>` anchor for GET
+//!   navigation, HTML-escaping both label and href, and automatically adding
+//!   `rel="noopener"` when `target="_blank"` is requested.
+//! - [`button_to`] / [`button_to_with`] render a single-button `<form>` for
+//!   state-changing actions: the browser transport is `POST`, a hidden
+//!   `_method` input (via [`crate::form::method_input`]) upgrades it to
+//!   `PUT`/`PATCH`/`DELETE` for the
+//!   [`MethodOverrideLayer`](crate::middleware::MethodOverrideLayer), and a
+//!   hidden CSRF input is always emitted. The CSRF token is a **required**
+//!   positional argument, so a state-changing `button_to` that silently
+//!   omits the CSRF field is unrepresentable.
+//!
+//! Both helpers accept extra attributes (e.g. htmx `hx-*`) through their
+//! options structs, so a `button_to("Delete", path, Method::DELETE, token)`
+//! can be upgraded to an `hx-delete` interaction without abandoning the
+//! helper.
+//!
+//! For multi-field forms, use [`crate::form::form_tag`] or
+//! [`ChangesetForm::form_tag`](crate::form::ChangesetForm::form_tag) instead —
+//! `button_to` is a zero-field action button, not a form builder.
+
+use http::Method;
+
+/// Options for [`link_to_with`]: extra class, `target`, `rel`, and arbitrary
+/// additional attributes (e.g. htmx `hx-*`).
+///
+/// Build with [`LinkToOptions::new`] and chain the setters.
+///
+/// # Example
+///
+/// ```rust
+/// use autumn_web::links::LinkToOptions;
+///
+/// let options = LinkToOptions::new()
+///     .class("btn")
+///     .target("_blank")
+///     .attrs(&[("hx-boost", "true")]);
+/// ```
+#[cfg(feature = "maud")]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LinkToOptions<'a> {
+    /// `class` attribute for the anchor.
+    class: Option<&'a str>,
+    /// `target` attribute; `"_blank"` triggers the automatic `rel="noopener"`.
+    target: Option<&'a str>,
+    /// `rel` attribute. `noopener` is appended when `target="_blank"` is set
+    /// and the value does not already contain it.
+    rel: Option<&'a str>,
+    /// Extra attributes rendered on the anchor, e.g. `hx-*` or `data-*`.
+    attrs: &'a [(&'a str, &'a str)],
+}
+
+#[cfg(feature = "maud")]
+impl<'a> LinkToOptions<'a> {
+    /// Create empty link options.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            class: None,
+            target: None,
+            rel: None,
+            attrs: &[],
+        }
+    }
+
+    /// Set the anchor's `class` attribute.
+    #[must_use]
+    pub const fn class(mut self, class: &'a str) -> Self {
+        self.class = Some(class);
+        self
+    }
+
+    /// Set the anchor's `target` attribute. `"_blank"` automatically adds
+    /// `rel="noopener"` unless the configured `rel` already contains it.
+    #[must_use]
+    pub const fn target(mut self, target: &'a str) -> Self {
+        self.target = Some(target);
+        self
+    }
+
+    /// Set the anchor's `rel` attribute.
+    #[must_use]
+    pub const fn rel(mut self, rel: &'a str) -> Self {
+        self.rel = Some(rel);
+        self
+    }
+
+    /// Set extra attributes rendered on the anchor (e.g. `hx-get`,
+    /// `hx-target`, `data-*`). Values are HTML-escaped; names must be valid
+    /// attribute names (see [`link_to_with`] panics).
+    #[must_use]
+    pub const fn attrs(mut self, attrs: &'a [(&'a str, &'a str)]) -> Self {
+        self.attrs = attrs;
+        self
+    }
+}
+
+/// Options for [`button_to_with`]: button/form classes, a custom CSRF field
+/// name, and arbitrary additional attributes on the `<button>`.
+///
+/// Build with [`ButtonToOptions::new`] and chain the setters.
+///
+/// # Example
+///
+/// ```rust
+/// use autumn_web::links::ButtonToOptions;
+///
+/// let options = ButtonToOptions::new()
+///     .class("btn btn-danger")
+///     .attrs(&[("hx-confirm", "Are you sure?")]);
+/// ```
+#[cfg(feature = "maud")]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ButtonToOptions<'a> {
+    /// `class` attribute for the `<button>`.
+    class: Option<&'a str>,
+    /// `class` attribute for the wrapping `<form>` (layout, e.g. inline).
+    form_class: Option<&'a str>,
+    /// CSRF form field name; defaults to `"_csrf"`. Pass the configured
+    /// [`CsrfFormField`](crate::security::CsrfFormField) value when
+    /// `security.csrf.form_field` is customized.
+    csrf_field: Option<&'a str>,
+    /// Extra attributes rendered on the `<button>`, e.g. `hx-delete`,
+    /// `hx-confirm`, `data-*`.
+    attrs: &'a [(&'a str, &'a str)],
+}
+
+#[cfg(feature = "maud")]
+impl<'a> ButtonToOptions<'a> {
+    /// Create empty button options (default CSRF field name `"_csrf"`).
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            class: None,
+            form_class: None,
+            csrf_field: None,
+            attrs: &[],
+        }
+    }
+
+    /// Set the `<button>`'s `class` attribute.
+    #[must_use]
+    pub const fn class(mut self, class: &'a str) -> Self {
+        self.class = Some(class);
+        self
+    }
+
+    /// Set the wrapping `<form>`'s `class` attribute (e.g. an inline-display
+    /// class so the button sits in a row of actions).
+    #[must_use]
+    pub const fn form_class(mut self, form_class: &'a str) -> Self {
+        self.form_class = Some(form_class);
+        self
+    }
+
+    /// Override the CSRF hidden-input field name (default `"_csrf"`).
+    #[must_use]
+    pub const fn csrf_field(mut self, csrf_field: &'a str) -> Self {
+        self.csrf_field = Some(csrf_field);
+        self
+    }
+
+    /// Set extra attributes rendered on the `<button>` (e.g. `hx-delete`,
+    /// `hx-confirm`, `data-*`). Values are HTML-escaped; names must be valid
+    /// attribute names (see [`button_to_with`] panics).
+    #[must_use]
+    pub const fn attrs(mut self, attrs: &'a [(&'a str, &'a str)]) -> Self {
+        self.attrs = attrs;
+        self
+    }
+}
+
+/// Render a GET `<a>` anchor with HTML-escaped label and href.
+///
+/// Use [`link_to_with`] for extra attributes (`class`, `target`, `rel`,
+/// `hx-*`), and [`button_to`] for state-changing (non-GET) actions.
+///
+/// # Example
+///
+/// ```rust
+/// use autumn_web::links::link_to;
+///
+/// let html = link_to("Posts", "/posts").into_string();
+/// assert_eq!(html, r#"<a href="/posts">Posts</a>"#);
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn link_to(label: &str, href: &str) -> maud::Markup {
+    link_to_with(label, href, &LinkToOptions::new())
+}
+
+/// Render a GET `<a>` anchor with [`LinkToOptions`] — class, `target`,
+/// `rel`, and arbitrary extra attributes such as htmx `hx-*`.
+///
+/// Label, href, and all attribute values are HTML-escaped. When
+/// `target="_blank"` is set, `rel="noopener"` is added automatically (merged
+/// into any configured `rel` without duplication).
+///
+/// # Panics
+///
+/// Panics when an extra attribute name is not a valid HTML attribute name
+/// (must start with an ASCII letter, followed by ASCII alphanumerics, `-`,
+/// `_`, or `:`). Attribute names are developer-authored literals; a panic
+/// surfaces the typo instead of silently emitting broken markup.
+///
+/// # Example
+///
+/// ```rust
+/// use autumn_web::links::{LinkToOptions, link_to_with};
+///
+/// let html = link_to_with(
+///     "Preview",
+///     "/posts/1",
+///     &LinkToOptions::new()
+///         .class("btn")
+///         .attrs(&[("hx-get", "/posts/1/preview"), ("hx-target", "#preview")]),
+/// )
+/// .into_string();
+/// assert!(html.contains(r#"hx-get="/posts/1/preview""#));
+/// assert!(html.contains(r#"class="btn""#));
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn link_to_with(label: &str, href: &str, options: &LinkToOptions<'_>) -> maud::Markup {
+    let _ = (label, href, options);
+    todo!("implemented in the green phase of #1138")
+}
+
+/// Render a state-changing action button: a single-button `<form>` carrying
+/// a hidden `_method` override (for `PUT`/`PATCH`/`DELETE`) and a hidden
+/// CSRF token input.
+///
+/// The CSRF token is a required argument — pass
+/// [`CsrfToken::token()`](crate::security::CsrfToken::token) from the
+/// extractor — so a state-changing button cannot silently omit the CSRF
+/// field. Use [`button_to_with`] for classes, a custom CSRF field name, or
+/// extra (`hx-*`) attributes.
+///
+/// `Method::GET` renders a plain `<form method="get">` **without** `_method`
+/// or CSRF inputs (GET must not mutate state; the token argument is ignored).
+///
+/// # Example
+///
+/// ```rust
+/// use autumn_web::links::button_to;
+/// use http::Method;
+///
+/// let html = button_to("Log out", "/logout", Method::POST, "tok123").into_string();
+/// assert!(html.contains(r#"method="post""#));
+/// assert!(html.contains(r#"name="_csrf" value="tok123""#));
+/// assert!(html.contains(r#"<button type="submit">Log out</button>"#));
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+#[allow(clippy::needless_pass_by_value)]
+pub fn button_to(label: &str, href: &str, method: Method, csrf_token: &str) -> maud::Markup {
+    button_to_with(label, href, method, csrf_token, &ButtonToOptions::new())
+}
+
+/// Render a state-changing action button with [`ButtonToOptions`] — button
+/// and form classes, custom CSRF field name, and arbitrary extra attributes
+/// (e.g. htmx `hx-*`) on the `<button>`.
+///
+/// For any method other than `GET`, the form's browser transport is `POST`:
+/// a hidden `_method` input (via [`crate::form::method_input`]) carries the
+/// declared verb for `PUT`/`PATCH`/`DELETE`, and a hidden CSRF input (field
+/// name from [`ButtonToOptions::csrf_field`], default `"_csrf"`) is always
+/// emitted. `Method::GET` renders a plain GET form without `_method` or CSRF
+/// inputs (the token argument is ignored).
+///
+/// Label, action, and all attribute values are HTML-escaped.
+///
+/// # Panics
+///
+/// Panics when an extra attribute name is not a valid HTML attribute name
+/// (must start with an ASCII letter, followed by ASCII alphanumerics, `-`,
+/// `_`, or `:`). Attribute names are developer-authored literals; a panic
+/// surfaces the typo instead of silently emitting broken markup.
+///
+/// # Example
+///
+/// The admin-style htmx delete button — `hx-delete` handles the interaction
+/// when JavaScript is available, while the rendered form (`POST` +
+/// `_method=DELETE` + CSRF) keeps working without it:
+///
+/// ```rust
+/// use autumn_web::links::{ButtonToOptions, button_to_with};
+/// use http::Method;
+///
+/// let html = button_to_with(
+///     "Delete",
+///     "/admin/widgets/42",
+///     Method::DELETE,
+///     "tok123",
+///     &ButtonToOptions::new()
+///         .class("btn btn-danger")
+///         .attrs(&[
+///             ("hx-delete", "/admin/widgets/42"),
+///             ("hx-confirm", "Are you sure?"),
+///             ("hx-target", "body"),
+///         ]),
+/// )
+/// .into_string();
+/// assert!(html.contains(r#"name="_method" value="DELETE""#));
+/// assert!(html.contains(r#"name="_csrf" value="tok123""#));
+/// assert!(html.contains(r#"hx-delete="/admin/widgets/42""#));
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+#[allow(clippy::needless_pass_by_value)]
+pub fn button_to_with(
+    label: &str,
+    href: &str,
+    method: Method,
+    csrf_token: &str,
+    options: &ButtonToOptions<'_>,
+) -> maud::Markup {
+    let _ = (label, href, method, csrf_token, options);
+    todo!("implemented in the green phase of #1138")
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(all(test, feature = "maud"))]
+mod tests {
+    use super::*;
+
+    // ── link_to ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn link_to_renders_basic_anchor() {
+        let html = link_to("Posts", "/posts").into_string();
+        assert_eq!(html, r#"<a href="/posts">Posts</a>"#);
+    }
+
+    #[test]
+    fn link_to_escapes_label() {
+        let html = link_to("<script>alert(1)</script>", "/posts").into_string();
+        assert!(html.contains("&lt;script&gt;"), "{html}");
+        assert!(!html.contains("<script>"), "{html}");
+    }
+
+    #[test]
+    fn link_to_escapes_href() {
+        let html = link_to("x", r#"/x?a=1&b="><script>"#).into_string();
+        assert!(html.contains("&amp;"), "{html}");
+        assert!(html.contains("&quot;"), "{html}");
+        assert!(!html.contains("<script>"), "{html}");
+        assert!(!html.contains(r#"b=">"#), "{html}");
+    }
+
+    #[test]
+    fn link_to_with_class_target_rel() {
+        let options = LinkToOptions::new()
+            .class("btn btn-link")
+            .target("_top")
+            .rel("nofollow");
+        let html = link_to_with("Docs", "/docs", &options).into_string();
+        assert!(html.contains(r#"class="btn btn-link""#), "{html}");
+        assert!(html.contains(r#"target="_top""#), "{html}");
+        assert!(html.contains(r#"rel="nofollow""#), "{html}");
+    }
+
+    #[test]
+    fn link_to_target_blank_adds_noopener() {
+        let options = LinkToOptions::new().target("_blank");
+        let html = link_to_with("Ext", "https://example.com", &options).into_string();
+        assert!(html.contains(r#"rel="noopener""#), "{html}");
+    }
+
+    #[test]
+    fn link_to_target_blank_merges_rel() {
+        let options = LinkToOptions::new().target("_blank").rel("nofollow");
+        let html = link_to_with("Ext", "https://example.com", &options).into_string();
+        assert!(html.contains(r#"rel="nofollow noopener""#), "{html}");
+    }
+
+    #[test]
+    fn link_to_target_blank_no_duplicate_noopener() {
+        let options = LinkToOptions::new().target("_blank").rel("noopener external");
+        let html = link_to_with("Ext", "https://example.com", &options).into_string();
+        assert_eq!(html.matches("noopener").count(), 1, "{html}");
+        assert!(html.contains(r#"rel="noopener external""#), "{html}");
+    }
+
+    #[test]
+    fn link_to_no_target_no_auto_rel() {
+        let html = link_to("Posts", "/posts").into_string();
+        assert!(!html.contains("rel="), "{html}");
+    }
+
+    #[test]
+    fn link_to_extra_hx_attrs() {
+        let options =
+            LinkToOptions::new().attrs(&[("hx-get", "/posts/1"), ("hx-target", "#detail")]);
+        let html = link_to_with("Show", "/posts/1", &options).into_string();
+        assert!(html.contains(r#"hx-get="/posts/1""#), "{html}");
+        assert!(html.contains(r##"hx-target="#detail""##), "{html}");
+    }
+
+    #[test]
+    fn link_to_extra_attr_value_escaped() {
+        let options = LinkToOptions::new().attrs(&[("data-note", r#"x" onmouseover="evil()"#)]);
+        let html = link_to_with("x", "/x", &options).into_string();
+        assert!(html.contains("&quot;"), "{html}");
+        assert!(!html.contains(r#"" onmouseover"#), "{html}");
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid HTML attribute name")]
+    fn link_to_invalid_attr_name_panics() {
+        let options = LinkToOptions::new().attrs(&[("on click", "evil()")]);
+        let _ = link_to_with("x", "/x", &options);
+    }
+
+    // ── button_to ───────────────────────────────────────────────────────
+
+    #[test]
+    fn button_to_post_renders_form_csrf_and_button() {
+        let html = button_to("Log out", "/logout", Method::POST, "tok123").into_string();
+        assert!(html.contains(r#"<form action="/logout" method="post""#), "{html}");
+        assert!(
+            html.contains(r#"input type="hidden" name="_csrf" value="tok123""#),
+            "{html}"
+        );
+        assert!(
+            html.contains(r#"<button type="submit">Log out</button>"#),
+            "{html}"
+        );
+        assert!(!html.contains("_method"), "{html}");
+    }
+
+    #[test]
+    fn button_to_delete_adds_method_override() {
+        let html = button_to("Delete", "/posts/42", Method::DELETE, "tok123").into_string();
+        assert!(html.contains(r#"method="post""#), "{html}");
+        assert!(
+            html.contains(r#"name="_method" value="DELETE""#),
+            "{html}"
+        );
+        assert!(html.contains(r#"name="_csrf" value="tok123""#), "{html}");
+    }
+
+    #[test]
+    fn button_to_put_and_patch_overrides() {
+        for (method, value) in [(Method::PUT, "PUT"), (Method::PATCH, "PATCH")] {
+            let html = button_to("Save", "/posts/42", method, "tok123").into_string();
+            assert!(html.contains(r#"method="post""#), "{html}");
+            assert!(
+                html.contains(&format!(r#"name="_method" value="{value}""#)),
+                "{html}"
+            );
+            assert!(html.contains(r#"name="_csrf""#), "{html}");
+        }
+    }
+
+    #[test]
+    fn button_to_get_renders_plain_get_form() {
+        let html = button_to("Search", "/search", Method::GET, "tok123").into_string();
+        assert!(html.contains(r#"method="get""#), "{html}");
+        assert!(!html.contains("_csrf"), "{html}");
+        assert!(!html.contains("tok123"), "{html}");
+        assert!(!html.contains("_method"), "{html}");
+        assert!(
+            html.contains(r#"<button type="submit">Search</button>"#),
+            "{html}"
+        );
+    }
+
+    #[test]
+    fn button_to_escapes_label_and_action() {
+        let html = button_to(
+            "<b>Delete</b>",
+            r#"/x?a=1&b="><script>"#,
+            Method::DELETE,
+            "tok",
+        )
+        .into_string();
+        assert!(html.contains("&lt;b&gt;"), "{html}");
+        assert!(!html.contains("<b>"), "{html}");
+        assert!(html.contains("&amp;"), "{html}");
+        assert!(!html.contains("<script>"), "{html}");
+    }
+
+    #[test]
+    fn button_to_custom_csrf_field() {
+        let options = ButtonToOptions::new().csrf_field("csrf_tok");
+        let html =
+            button_to_with("Delete", "/posts/42", Method::DELETE, "tok123", &options).into_string();
+        assert!(html.contains(r#"name="csrf_tok" value="tok123""#), "{html}");
+        assert!(!html.contains(r#"name="_csrf""#), "{html}");
+    }
+
+    #[test]
+    fn button_to_button_and_form_classes() {
+        let options = ButtonToOptions::new()
+            .class("btn btn-danger")
+            .form_class("inline-form");
+        let html =
+            button_to_with("Delete", "/posts/42", Method::DELETE, "tok123", &options).into_string();
+        assert!(html.contains(r#"class="inline-form""#), "{html}");
+        assert!(html.contains(r#"class="btn btn-danger""#), "{html}");
+    }
+
+    #[test]
+    fn button_to_extra_attrs_on_button() {
+        // The admin-plugin delete-button shape (templates.rs): htmx handles
+        // the interaction when JS is on; the form fallback keeps working
+        // without it.
+        let options = ButtonToOptions::new().class("btn btn-danger").attrs(&[
+            ("hx-delete", "/admin/widgets/42"),
+            ("hx-confirm", "Are you sure you want to delete this Widget?"),
+            ("hx-target", "body"),
+        ]);
+        let html = button_to_with(
+            "Delete",
+            "/admin/widgets/42",
+            Method::DELETE,
+            "tok123",
+            &options,
+        )
+        .into_string();
+        assert!(html.contains(r#"hx-delete="/admin/widgets/42""#), "{html}");
+        assert!(html.contains(r#"hx-target="body""#), "{html}");
+        assert!(
+            html.contains("hx-confirm=\"Are you sure you want to delete this Widget?\""),
+            "{html}"
+        );
+        assert!(html.contains(r#"name="_method" value="DELETE""#), "{html}");
+        assert!(html.contains(r#"name="_csrf" value="tok123""#), "{html}");
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid HTML attribute name")]
+    fn button_to_invalid_attr_name_panics() {
+        let options = ButtonToOptions::new().attrs(&[("foo=bar", "x")]);
+        let _ = button_to_with("x", "/x", Method::POST, "tok", &options);
+    }
+}

--- a/autumn/src/links.rs
+++ b/autumn/src/links.rs
@@ -28,6 +28,66 @@
 
 use http::Method;
 
+/// Returns `true` when `name` is a valid HTML attribute name: an ASCII
+/// letter followed by ASCII alphanumerics, `-`, `_`, or `:`.
+#[cfg(feature = "maud")]
+fn is_valid_attr_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(first) if first.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == ':')
+}
+
+/// Append `text`, HTML-escaped (`&`, `<`, `>`), to `out`.
+#[cfg(feature = "maud")]
+fn push_escaped_text(out: &mut String, text: &str) {
+    for c in text.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            other => out.push(other),
+        }
+    }
+}
+
+/// Append `text`, HTML-escaped for use inside a double-quoted attribute
+/// value (`&`, `<`, `>`, `"`, `'`), to `out`.
+#[cfg(feature = "maud")]
+fn push_escaped_attr_value(out: &mut String, text: &str) {
+    for c in text.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            other => out.push(other),
+        }
+    }
+}
+
+/// Append a ` name="escaped-value"` attribute to `out`.
+///
+/// # Panics
+///
+/// Panics when `name` is not a valid HTML attribute name — see
+/// [`is_valid_attr_name`].
+#[cfg(feature = "maud")]
+fn push_attr(out: &mut String, name: &str, value: &str) {
+    assert!(
+        is_valid_attr_name(name),
+        "invalid HTML attribute name {name:?} passed to link_to/button_to"
+    );
+    out.push(' ');
+    out.push_str(name);
+    out.push_str("=\"");
+    push_escaped_attr_value(out, value);
+    out.push('"');
+}
+
 /// Options for [`link_to_with`]: extra class, `target`, `rel`, and arbitrary
 /// additional attributes (e.g. htmx `hx-*`).
 ///
@@ -229,8 +289,44 @@ pub fn link_to(label: &str, href: &str) -> maud::Markup {
 #[cfg(feature = "maud")]
 #[must_use]
 pub fn link_to_with(label: &str, href: &str, options: &LinkToOptions<'_>) -> maud::Markup {
-    let _ = (label, href, options);
-    todo!("implemented in the green phase of #1138")
+    let rel = effective_rel(options.target, options.rel);
+
+    let mut out = String::from("<a");
+    push_attr(&mut out, "href", href);
+    if let Some(class) = options.class {
+        push_attr(&mut out, "class", class);
+    }
+    if let Some(target) = options.target {
+        push_attr(&mut out, "target", target);
+    }
+    if let Some(rel) = rel.as_deref() {
+        push_attr(&mut out, "rel", rel);
+    }
+    for (name, value) in options.attrs {
+        push_attr(&mut out, name, value);
+    }
+    out.push('>');
+    push_escaped_text(&mut out, label);
+    out.push_str("</a>");
+
+    maud::PreEscaped(out)
+}
+
+/// Compute the effective `rel` value for a link: when `target="_blank"`,
+/// `noopener` is appended to the caller's `rel` (space-separated, no
+/// duplicate) or used on its own.
+#[cfg(feature = "maud")]
+fn effective_rel(target: Option<&str>, rel: Option<&str>) -> Option<String> {
+    if target != Some("_blank") {
+        return rel.map(ToString::to_string);
+    }
+    match rel {
+        Some(rel) if rel.split_whitespace().any(|token| token == "noopener") => {
+            Some(rel.to_string())
+        }
+        Some(rel) => Some(format!("{rel} noopener")),
+        None => Some("noopener".to_string()),
+    }
 }
 
 /// Render a state-changing action button: a single-button `<form>` carrying
@@ -322,8 +418,35 @@ pub fn button_to_with(
     csrf_token: &str,
     options: &ButtonToOptions<'_>,
 ) -> maud::Markup {
-    let _ = (label, href, method, csrf_token, options);
-    todo!("implemented in the green phase of #1138")
+    let mut button = String::from("<button type=\"submit\"");
+    if let Some(class) = options.class {
+        push_attr(&mut button, "class", class);
+    }
+    for (name, value) in options.attrs {
+        push_attr(&mut button, name, value);
+    }
+    button.push('>');
+    push_escaped_text(&mut button, label);
+    button.push_str("</button>");
+    let button = maud::PreEscaped(button);
+
+    let csrf_field = options.csrf_field.unwrap_or("_csrf");
+
+    if method == Method::GET {
+        maud::html! {
+            form action=(href) method="get" class=[options.form_class] {
+                (button)
+            }
+        }
+    } else {
+        maud::html! {
+            form action=(href) method="post" class=[options.form_class] {
+                (crate::form::method_input(method.as_str()))
+                input type="hidden" name=(csrf_field) value=(csrf_token);
+                (button)
+            }
+        }
+    }
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────
@@ -384,7 +507,9 @@ mod tests {
 
     #[test]
     fn link_to_target_blank_no_duplicate_noopener() {
-        let options = LinkToOptions::new().target("_blank").rel("noopener external");
+        let options = LinkToOptions::new()
+            .target("_blank")
+            .rel("noopener external");
         let html = link_to_with("Ext", "https://example.com", &options).into_string();
         assert_eq!(html.matches("noopener").count(), 1, "{html}");
         assert!(html.contains(r#"rel="noopener external""#), "{html}");
@@ -425,7 +550,10 @@ mod tests {
     #[test]
     fn button_to_post_renders_form_csrf_and_button() {
         let html = button_to("Log out", "/logout", Method::POST, "tok123").into_string();
-        assert!(html.contains(r#"<form action="/logout" method="post""#), "{html}");
+        assert!(
+            html.contains(r#"<form action="/logout" method="post""#),
+            "{html}"
+        );
         assert!(
             html.contains(r#"input type="hidden" name="_csrf" value="tok123""#),
             "{html}"
@@ -441,10 +569,7 @@ mod tests {
     fn button_to_delete_adds_method_override() {
         let html = button_to("Delete", "/posts/42", Method::DELETE, "tok123").into_string();
         assert!(html.contains(r#"method="post""#), "{html}");
-        assert!(
-            html.contains(r#"name="_method" value="DELETE""#),
-            "{html}"
-        );
+        assert!(html.contains(r#"name="_method" value="DELETE""#), "{html}");
         assert!(html.contains(r#"name="_csrf" value="tok123""#), "{html}");
     }
 

--- a/autumn/src/links.rs
+++ b/autumn/src/links.rs
@@ -401,11 +401,12 @@ pub fn button_to(label: &str, href: &str, method: Method, csrf_token: &str) -> m
 /// (must start with an ASCII letter, followed by ASCII alphanumerics, `-`,
 /// `_`, or `:`), when it collides (case-insensitively) with an attribute
 /// this helper already sets via a named option, or when it is one of the
-/// `<button>` submit-override attributes (`formaction`, `formmethod`,
-/// `formenctype`, `formnovalidate`, `formtarget`) — those would silently
-/// change which URL/method/CSRF-field the no-JS form actually submits to,
-/// defeating the CSRF/method-override guarantee this helper exists to
-/// provide. Also panics when `method` is not `GET`, `POST`, `PUT`, `PATCH`,
+/// `<button>` form-owner/submit-override attributes (`form`, `formaction`,
+/// `formmethod`, `formenctype`, `formnovalidate`, `formtarget`) — those
+/// would silently detach the button from the generated form (`form`) or
+/// change which URL/method it submits to, defeating the CSRF/method-override
+/// guarantee this helper exists to provide. Also panics when `method` is
+/// not `GET`, `POST`, `PUT`, `PATCH`,
 /// or `DELETE`, since a `<form>` cannot represent any other HTTP method and
 /// [`crate::form::method_input`] has no override for it — submitting would
 /// silently hit a plain `POST` at the same URL instead of the declared
@@ -471,6 +472,7 @@ pub fn button_to_with(
     for (name, value) in options.attrs {
         let is_reserved = name.eq_ignore_ascii_case("type")
             || name.eq_ignore_ascii_case("class")
+            || name.eq_ignore_ascii_case("form")
             || name.eq_ignore_ascii_case("formaction")
             || name.eq_ignore_ascii_case("formmethod")
             || name.eq_ignore_ascii_case("formenctype")
@@ -824,6 +826,16 @@ mod tests {
         // action for a no-JS submission, redirecting the CSRF token and
         // _method override to a different URL.
         let options = ButtonToOptions::new().attrs(&[("formaction", "/evil")]);
+        let _ = button_to_with("x", "/x", Method::DELETE, "tok", &options);
+    }
+
+    #[test]
+    #[should_panic(expected = "attrs cannot override the built-in \"form\" attribute")]
+    fn button_to_attrs_cannot_override_form_panics() {
+        // Regression: <button form="other-id"> detaches the button from the
+        // generated <form>, submitting whatever form owns that id instead —
+        // without the helper's _method/CSRF hidden inputs.
+        let options = ButtonToOptions::new().attrs(&[("form", "other-form")]);
         let _ = button_to_with("x", "/x", Method::DELETE, "tok", &options);
     }
 

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -126,6 +126,8 @@ pub use crate::{Presence, PresenceEntry, PresenceEvent, PresenceHandle};
 pub use axum::extract::State;
 /// Trait for types that can be converted into an HTTP response.
 pub use axum::response::IntoResponse;
+/// HTTP methods — pass to [`crate::links::button_to`]/[`crate::links::button_to_with`].
+pub use http::Method;
 /// HTTP status codes.
 pub use http::StatusCode;
 
@@ -183,6 +185,17 @@ pub use crate::widgets::{
     active_search_results, autocomplete_empty_state, autocomplete_input, autocomplete_option,
     breadcrumb, card, data_table, hero, nav_bar, nav_link, nav_link_matched, property_list,
     stat_card,
+};
+
+// ── Link helpers ─────────────────────────────────────────────────
+/// Safe, method-aware `<a>`/`<form>` link helpers: [`crate::links::link_to`]
+/// for GET navigation and [`crate::links::button_to`] for CSRF-protected,
+/// method-override action buttons.
+///
+/// See [`crate::links`] for the full API.
+#[cfg(feature = "maud")]
+pub use crate::links::{
+    ButtonToOptions, LinkToOptions, button_to, button_to_with, link_to, link_to_with,
 };
 
 // ── Hooks ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds `link_to`/`button_to` view helpers to safely render HTML-escaped GET anchors and CSRF-protected action buttons, addressing issue #1138. These helpers close the gap between low-level form primitives and common UI patterns, making it harder to accidentally omit CSRF tokens on state-changing actions.

## Key Changes

- **New `links` module** (`autumn/src/links.rs`): Implements four public functions and two options structs:
  - `link_to(label, href)` / `link_to_with(label, href, options)`: Render GET `<a>` anchors with HTML-escaped label/href, optional `class`/`target`/`rel`, and arbitrary extra attributes (e.g. htmx `hx-*`)
  - `button_to(label, href, method, csrf_token)` / `button_to_with(...)`: Render single-button `<form>` elements for state-changing actions; CSRF token is a required argument, preventing silent omission
  - `LinkToOptions` and `ButtonToOptions` builder structs for configuring extra attributes
  - Automatic `rel="noopener"` injection when `target="_blank"` is set (case-insensitive, deduplicating)
  - For non-GET methods, forms post with hidden `_method` override (via `form::method_input`) and hidden CSRF field; `GET` renders a plain form without either
  - Comprehensive HTML escaping for text content and attribute values; attribute names are validated and reserved names cannot be overridden

- **Admin plugin integration** (`autumn-admin-plugin/src/templates.rs`):
  - Refactored the model detail page delete button to use `button_to_with`, replacing hand-rolled form markup
  - Added `csrf_form_field` parameter to `model_detail_page` so the delete button respects customized CSRF field names
  - Added inline form styling (`.header-actions form { display: inline; }`) to keep action buttons in a row

- **Module exports**:
  - Added `links` module to `autumn/src/lib.rs`
  - Exported `link_to`, `link_to_with`, `button_to`, `button_to_with`, `LinkToOptions`, `ButtonToOptions` in `autumn/src/prelude.rs`
  - Re-exported `http::Method` in prelude for convenience

- **Documentation and tests**:
  - Comprehensive module-level docs with examples and panic conditions
  - 30+ unit tests covering basic rendering, HTML escaping, attribute handling, `target="_blank"` behavior, method overrides, CSRF field customization, and error cases

## Notable Implementation Details

- Attribute names are validated at runtime (must start with ASCII letter, followed by alphanumerics/`-`/`_`/`:`) and panic in both debug and release builds if invalid or reserved, surfacing typos early
- `target="_blank"` detection is case-insensitive per HTML spec; `noopener` deduplication in `rel` is also case-insensitive
- `Method::GET` is special-cased: forms render without `_method` or CSRF inputs (GET must not mutate state)
- Uses `maud::PreEscaped` for pre-escaped HTML to avoid double-escaping; all user input is escaped before wrapping
- The admin plugin now passes the configured CSRF form field name to the template, ensuring the delete button uses the correct field name for CSRF validation

https://claude.ai/code/session_018p14NHf6tB5Fg1yXWWhfr7