### PR TITLE
👺 Havoc: [Idempotency TTL Panic]

### DIFF
--- a/autumn/src/idempotency.rs
+++ b/autumn/src/idempotency.rs
@@ -467,7 +467,7 @@ impl IdempotencyStore for MemoryIdempotencyStore {
         let entry = IdempotencyEntry {
             record,
             body_hash,
-            expires_at: Instant::now() + ttl,
+            expires_at: Instant::now().checked_add(ttl).unwrap_or_else(Instant::now),
         };
         let mut entries = self.entries.write().unwrap();
         entries.insert(key.to_owned(), entry);
@@ -504,7 +504,7 @@ impl IdempotencyStore for MemoryIdempotencyStore {
             key.to_owned(),
             MemoryInFlightLock {
                 owner: owner.to_owned(),
-                expires_at: now + ttl,
+                expires_at: now.checked_add(ttl).unwrap_or_else(Instant::now),
             },
         );
         true
@@ -631,7 +631,7 @@ mod redis_store {
                                     body_hash: e.body_hash,
                                     // Redis manages TTL natively. Use a fixed 24 h offset
                                     // so the in-process expiry check never fires early.
-                                    expires_at: Instant::now() + Duration::from_secs(86_400),
+                                    expires_at: Instant::now().checked_add(Duration::from_secs(86_400)).unwrap_or_else(Instant::now),
                                 }
                             })
                             .map_err(|e| {

--- a/autumn/src/idempotency.rs
+++ b/autumn/src/idempotency.rs
@@ -631,7 +631,9 @@ mod redis_store {
                                     body_hash: e.body_hash,
                                     // Redis manages TTL natively. Use a fixed 24 h offset
                                     // so the in-process expiry check never fires early.
-                                    expires_at: Instant::now().checked_add(Duration::from_secs(86_400)).unwrap_or_else(Instant::now),
+                                    expires_at: Instant::now()
+                                        .checked_add(Duration::from_secs(86_400))
+                                        .unwrap_or_else(Instant::now),
                                 }
                             })
                             .map_err(|e| {

--- a/autumn/tests/chaos_idempotency_ttl_proptest.proptest-regressions
+++ b/autumn/tests/chaos_idempotency_ttl_proptest.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 31c50a889c3d036e2a5604052298a48d5479ffe3cf59cb7147df7e9790f333a9 # shrinks to ttl = 9223372036854774733.425055866s

--- a/autumn/tests/chaos_idempotency_ttl_proptest.rs
+++ b/autumn/tests/chaos_idempotency_ttl_proptest.rs
@@ -1,4 +1,4 @@
-use autumn_web::idempotency::{MemoryIdempotencyStore, IdempotencyStore, IdempotencyRecord};
+use autumn_web::idempotency::{IdempotencyRecord, IdempotencyStore, MemoryIdempotencyStore};
 use proptest::prelude::*;
 use std::time::Duration;
 

--- a/autumn/tests/chaos_idempotency_ttl_proptest.rs
+++ b/autumn/tests/chaos_idempotency_ttl_proptest.rs
@@ -1,0 +1,18 @@
+use autumn_web::idempotency::{MemoryIdempotencyStore, IdempotencyStore, IdempotencyRecord};
+use proptest::prelude::*;
+use std::time::Duration;
+
+proptest! {
+    #[test]
+    fn test_memory_idempotency_store_does_not_panic(ttl in any::<Duration>()) {
+        let store = MemoryIdempotencyStore::new(Duration::from_secs(60));
+        let record = IdempotencyRecord {
+            status: 200,
+            headers: vec![],
+            body: vec![],
+            metadata: vec![],
+        };
+        // This should not panic now with the safe math applied
+        let _ = store.try_set("test_key", record, vec![], ttl);
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:** Passing a maliciously large or corrupted `Duration` (e.g., `Duration::MAX`) as a TTL when storing an idempotency record causes an unchecked overflow when added to `Instant::now()`.

📉 **The Stack Trace:**
```
thread 'test_memory_idempotency_store_does_not_panic' panicked at library/std/src/time.rs:429:33:
overflow when adding duration to instant
```

🧪 **Reproduction:** Run the new proptest harness `cargo test -p autumn-web --test chaos_idempotency_ttl_proptest` which feeds random durations into `MemoryIdempotencyStore::try_set`. 

😈 **Comment:** You trusted the network to give you a sensible expiration time. The network is not your friend. We now safely fail-closed by expiring the time immediately instead of risking a secondary panic.

---
*PR created automatically by Jules for task [6219637002025656250](https://jules.google.com/task/6219637002025656250) started by @madmax983*