### PR TITLE
Add decimal field type to scaffold DSL for exact-precision money columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **generate:** `decimal` scaffold field type (#1038) — `price:decimal`
+  (default `NUMERIC(12,2)`) or `price:decimal{10,2}` for an explicit
+  precision/scale now generates an exact-precision Postgres `NUMERIC` column,
+  a `rust_decimal::Decimal` `#[model]` field, and a `Numeric`/`Nullable<Numeric>`
+  Diesel schema token, so money-shaped fields no longer have to fall back to
+  `f64` and its binary-float rounding. Both `decimal`/`Decimal` casings are
+  accepted (consistent with `Attachment`/`attachment`), it composes with
+  `Option<…>` and `:unique`, and the generated `new`/`edit` form renders
+  `input type="number" inputmode="decimal" step="…"` sized to the column's
+  scale. The `rust_decimal` dependency (with the `db-diesel2-postgres` and
+  `serde` features) is added to the generated app's `Cargo.toml` only when a
+  `decimal` field is present.
 - **views:** `modal`/`confirm_action` widgets — an accessible, testable
   confirm for destructive actions (#1233). `modal(id, title, body, config)`
   renders a native `<dialog>` (`aria-modal="true"`, `aria-labelledby`, a body

--- a/autumn-cli/src/generate/admin.rs
+++ b/autumn-cli/src/generate/admin.rs
@@ -337,7 +337,15 @@ const fn admin_field_kind(field: &Field) -> &'static str {
         // `render_fields_vec` always overrides an enum field with an explicit
         // `AdminFieldKind::Select(...)` (issue #1030), the same way an
         // explicit `--select` overrides this base kind today.
-        FieldKind::String | FieldKind::Uuid | FieldKind::Enum => "AdminFieldKind::Text",
+        // `Decimal` renders as plain text, not `AdminFieldKind::Float`: the
+        // admin update handler coerces `Float` input through `f64` (see
+        // `parse_form_value` in `autumn-admin-plugin`), which would
+        // reintroduce the exact binary-float rounding this field type exists
+        // to avoid. Routing it through `Text` leaves the raw decimal string
+        // untouched for `rust_decimal`'s exact `FromStr`/`Deserialize`.
+        FieldKind::String | FieldKind::Uuid | FieldKind::Enum | FieldKind::Decimal { .. } => {
+            "AdminFieldKind::Text"
+        }
         FieldKind::Text => "AdminFieldKind::TextArea",
         // A foreign-key id renders the same as any other integer column.
         FieldKind::I32 | FieldKind::I64 | FieldKind::References => "AdminFieldKind::Integer",

--- a/autumn-cli/src/generate/admin.rs
+++ b/autumn-cli/src/generate/admin.rs
@@ -339,7 +339,7 @@ const fn admin_field_kind(field: &Field) -> &'static str {
         // explicit `--select` overrides this base kind today.
         // `Decimal` renders as plain text, not `AdminFieldKind::Float`: the
         // admin update handler coerces `Float` input through `f64` (see
-        // `parse_form_value` in `autumn-admin-plugin`), which would
+        // `coerce_form_value` in `autumn-admin-plugin`), which would
         // reintroduce the exact binary-float rounding this field type exists
         // to avoid. Routing it through `Text` leaves the raw decimal string
         // untouched for `rust_decimal`'s exact `FromStr`/`Deserialize`.

--- a/autumn-cli/src/generate/dsl.rs
+++ b/autumn-cli/src/generate/dsl.rs
@@ -578,8 +578,14 @@ fn parse_enum_type(ty: &str) -> Result<Option<(Vec<String>, bool)>, String> {
     Ok(Some((variants, nullable)))
 }
 
-/// Postgres's documented maximum `NUMERIC` precision (total significant digits).
-const MAX_DECIMAL_PRECISION: u32 = 1000;
+/// The maximum `decimal` precision (total significant digits) this DSL
+/// accepts. Bounded by `rust_decimal::Decimal`'s own representable range —
+/// a 96-bit mantissa, guaranteeing at most 28 significant digits — not by
+/// Postgres's much larger `NUMERIC` limit (1000): a column declared wider
+/// than `rust_decimal` can hold would compile and migrate cleanly, then fail
+/// at runtime the first time a value actually needing that extra precision
+/// is deserialized into the generated `#[model]` field.
+const MAX_DECIMAL_PRECISION: u32 = 28;
 
 /// Parse a `decimal` (optionally `Option<decimal>`) type token, with an
 /// optional `{precision,scale}` modifier (`decimal{10,2}`). Accepts both
@@ -588,11 +594,12 @@ const MAX_DECIMAL_PRECISION: u32 = 1000;
 /// is omitted.
 ///
 /// Returns `Ok(None)` when `ty` isn't a decimal token at all, so the caller
-/// falls through to [`parse_type`]/[`atomic_type`] unchanged (e.g. a typo
-/// like `decimalize` still gets the general "unsupported type" error rather
-/// than a decimal-specific one). Returns `Err(reason)` when `ty` looks like a
-/// decimal token but is malformed (non-numeric precision/scale, scale
-/// exceeding precision, precision outside Postgres's `NUMERIC` range, …).
+/// falls through to [`parse_type`]/[`atomic_type`] unchanged. Returns
+/// `Err(reason)` when `ty` looks like a decimal token but is malformed
+/// (missing/unbalanced braces, non-numeric precision/scale, scale exceeding
+/// precision, precision outside `rust_decimal`'s representable range, …) —
+/// every reason is an actionable message, consistent with the field-name
+/// guarding above.
 ///
 /// # Errors
 /// See above.
@@ -614,10 +621,21 @@ fn parse_decimal_type(ty: &str) -> Result<Option<(u32, u32, bool)>, String> {
     }
 
     let Some(inner) = rest.strip_prefix('{') else {
-        // Doesn't actually look like a decimal token (e.g. a typo like
-        // `decimalize`) — fall through to the general "unsupported type"
-        // error rather than a decimal-specific one.
-        return Ok(None);
+        // Looks like a decimal token (starts with `decimal`/`Decimal` and
+        // has more text after it) but has no opening brace. As with
+        // `enum{...}`, the most common cause is bash/zsh brace-expanding an
+        // unquoted `decimal{10,2}` before the CLI ever sees it, turning
+        // `price:decimal{10,2}` into two separate arguments whose surviving
+        // fragments read like `price:decimal10` and `price:decimal2` — but
+        // `ty` could also just be an unrelated typo (e.g. `decimalize`), so
+        // the message covers both: the quoting hint for the shell-expansion
+        // case, and the full supported-types list for a genuine typo.
+        return Err(format!(
+            "expected decimal{{precision,scale}} (or bare `decimal` for the \
+             default NUMERIC(12,2)). If you typed this in bash or zsh, quote \
+             the token so the shell doesn't brace-expand it, e.g. \
+             'price:decimal{{10,2}}'. Supported: {SUPPORTED_TYPES}"
+        ));
     };
     let Some(body_inner) = inner.strip_suffix('}') else {
         return Err("expected decimal{precision,scale} (missing closing brace)".to_owned());
@@ -644,7 +662,7 @@ fn parse_decimal_type(ty: &str) -> Result<Option<(u32, u32, bool)>, String> {
     if precision == 0 || precision > MAX_DECIMAL_PRECISION {
         return Err(format!(
             "decimal precision must be between 1 and {MAX_DECIMAL_PRECISION} \
-             (Postgres's NUMERIC limit), got {precision}"
+             (rust_decimal's representable range), got {precision}"
         ));
     }
     if scale > precision {
@@ -1654,15 +1672,42 @@ mod tests {
     }
 
     #[test]
-    fn decimal_rejects_precision_over_postgres_max() {
-        let err = parse_field("price:decimal{1001,2}").unwrap_err();
+    fn decimal_rejects_precision_over_rust_decimal_max() {
+        // 29 exceeds rust_decimal::Decimal's 28-significant-digit range, even
+        // though Postgres's own NUMERIC would happily hold it — the DSL caps
+        // at what the generated struct field can actually represent, not
+        // what the column type technically permits.
+        let err = parse_field("price:decimal{29,2}").unwrap_err();
         assert!(err.to_string().contains("precision"));
+    }
+
+    #[test]
+    fn decimal_accepts_precision_at_rust_decimal_max() {
+        let f = parse_field("price:decimal{28,2}").unwrap();
+        assert_eq!(
+            f.kind,
+            FieldKind::Decimal {
+                precision: 28,
+                scale: 2
+            }
+        );
     }
 
     #[test]
     fn decimal_rejects_missing_closing_brace() {
         let err = parse_field("price:decimal{10,2").unwrap_err();
         assert!(err.to_string().contains("decimal{"));
+    }
+
+    #[test]
+    fn decimal_error_hints_about_shell_brace_expansion() {
+        // bash/zsh expand an unquoted `decimal{10,2}` into two separate
+        // words, so the token the CLI actually receives looks like
+        // `price:decimal10` — point the user at quoting, same as `enum{...}`.
+        let err = parse_field("price:decimal10").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("quote"), "must suggest quoting: {msg}");
+        assert!(msg.contains("Supported:"), "got: {msg}");
     }
 
     #[test]

--- a/autumn-cli/src/generate/dsl.rs
+++ b/autumn-cli/src/generate/dsl.rs
@@ -606,6 +606,12 @@ const MAX_DECIMAL_PRECISION: u32 = 28;
 fn parse_decimal_type(ty: &str) -> Result<Option<(u32, u32, bool)>, String> {
     let (body, nullable) =
         strip_wrapper(ty, "Option").map_or((ty, false), |inner| (inner.trim(), true));
+    // Defensive: every caller of `parse_field` already trims the outer `ty`
+    // before it reaches here, but trimming `body` again costs nothing and
+    // guards against a caller that doesn't (e.g. a direct unit-test call, or
+    // future refactor) — see the shell-brace-expansion hint below, which
+    // depends on `body` ending exactly at `}` with no trailing whitespace.
+    let body = body.trim();
 
     let Some(rest) = body
         .strip_prefix("decimal")
@@ -1714,6 +1720,35 @@ mod tests {
     fn decimal_rejects_wrong_number_of_brace_args() {
         let err = parse_field("price:decimal{10}").unwrap_err();
         assert!(err.to_string().contains("precision,scale"));
+    }
+
+    #[test]
+    fn decimal_prefixed_typo_still_lists_supported_types() {
+        // A type name that happens to start with `decimal` but isn't a
+        // genuine shell-mangled decimal token (e.g. a typo like
+        // `decimalize`) must still see the full supported-types list, not
+        // just the brace-expansion hint — mirrors enum's
+        // `enum_prefixed_typo_still_lists_supported_types` precedent.
+        let err = parse_field("price:decimalize").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("quote"), "got: {msg}");
+        assert!(msg.contains("Supported:"), "got: {msg}");
+        assert!(msg.contains("String"), "got: {msg}");
+    }
+
+    #[test]
+    fn parse_decimal_type_tolerates_untrimmed_input() {
+        // Defensive-in-depth (PR review, gemini-code-assist): `parse_field`
+        // already trims `ty` before any type parser sees it, so this isn't
+        // reachable through the public `parse_field` API today — but
+        // `parse_decimal_type` re-trims `body` itself too, so a direct call
+        // (or a future caller that doesn't pre-trim) with trailing
+        // whitespace after the closing brace still parses instead of
+        // failing `strip_suffix('}')`.
+        assert_eq!(
+            parse_decimal_type("decimal{10,2} ").unwrap(),
+            Some((10, 2, false))
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/dsl.rs
+++ b/autumn-cli/src/generate/dsl.rs
@@ -75,6 +75,19 @@ impl Field {
         self.kind.sql_type()
     }
 
+    /// The SQL column type used in `CREATE TABLE`/`ADD COLUMN`, including any
+    /// type parameters. Identical to [`Field::sql_type`] for every kind
+    /// except [`FieldKind::Decimal`], whose `precision`/`scale` can't be
+    /// represented in `sql_type`'s `&'static str` return type — this method
+    /// renders the full `NUMERIC(precision,scale)` instead.
+    #[must_use]
+    pub fn sql_column_type(&self) -> String {
+        match self.kind {
+            FieldKind::Decimal { precision, scale } => format!("NUMERIC({precision},{scale})"),
+            _ => self.sql_type().to_owned(),
+        }
+    }
+
     /// `"NULL"` or `"NOT NULL"` to append in the migration.
     #[must_use]
     pub const fn sql_nullability(&self) -> &'static str {
@@ -147,6 +160,19 @@ pub enum FieldKind {
     /// [`Field::rust_type`] and [`Field::enum_type_name`], which override this
     /// storage-representation fallback with the real generated type name.
     Enum,
+    /// `decimal{precision,scale}` (default `{12,2}` when the modifier is
+    /// omitted) — an exact-precision `NUMERIC(precision,scale)` column.
+    /// Unlike `f32`/`f64`, this never introduces binary-float rounding error,
+    /// making it the correct choice for money and other exact-decimal values.
+    /// Rendered in the `#[model]` struct as `rust_decimal::Decimal` (see
+    /// [`FieldKind::rust_type`]) — the same decimal type the `autumn` runtime
+    /// crate already re-exports and uses for its `number_to_currency` helper.
+    Decimal {
+        /// Total number of significant digits (`NUMERIC(precision, _)`).
+        precision: u32,
+        /// Number of digits after the decimal point (`NUMERIC(_, scale)`).
+        scale: u32,
+    },
 }
 
 impl FieldKind {
@@ -172,6 +198,7 @@ impl FieldKind {
             Self::DateTime => "chrono::DateTime<chrono::Utc>",
             Self::Bytea => "Vec<u8>",
             Self::Attachment => "autumn_web::storage::Blob",
+            Self::Decimal { .. } => "rust_decimal::Decimal",
         }
     }
 
@@ -190,6 +217,7 @@ impl FieldKind {
             Self::DateTime => "Timestamptz",
             Self::Bytea => "Bytea",
             Self::Attachment => "Jsonb",
+            Self::Decimal { .. } => "Numeric",
         }
     }
 
@@ -208,6 +236,7 @@ impl FieldKind {
             Self::DateTime => "TIMESTAMPTZ",
             Self::Bytea => "BYTEA",
             Self::Attachment => "JSONB",
+            Self::Decimal { .. } => "NUMERIC",
         }
     }
 
@@ -230,6 +259,15 @@ impl FieldKind {
     #[must_use]
     pub const fn is_enum(self) -> bool {
         matches!(self, Self::Enum)
+    }
+
+    /// Returns `true` for an exact-precision `decimal` field.
+    ///
+    /// Used by the scaffold/model generators to know when the project needs
+    /// the `rust_decimal` dependency wired in.
+    #[must_use]
+    pub const fn is_decimal(self) -> bool {
+        matches!(self, Self::Decimal { .. })
     }
 }
 
@@ -311,7 +349,7 @@ impl IdType {
 /// Comma-separated list of supported types, for error messages and `--help`.
 pub const SUPPORTED_TYPES: &str = "String, Text, i32, i64, bool, f32, f64, \
     Uuid, NaiveDateTime, DateTime, Vec<u8>, Bytea, Attachment, references, \
-    enum{a,b,…}, Option<…>, :unique";
+    enum{a,b,…}, decimal{precision,scale}, Option<…>, :unique";
 
 /// Comma-separated list of supported Postgres column types (`udt_name`), for
 /// the `db pull` introspection error message.
@@ -420,6 +458,21 @@ pub fn parse_field(token: &str) -> Result<Field, GenerateError> {
         });
     }
 
+    if let Some((precision, scale, nullable)) =
+        parse_decimal_type(ty).map_err(|reason| GenerateError::InvalidField {
+            token: token.to_owned(),
+            reason,
+        })?
+    {
+        return Ok(Field {
+            name: name.to_owned(),
+            kind: FieldKind::Decimal { precision, scale },
+            nullable,
+            variants: Vec::new(),
+            unique,
+        });
+    }
+
     let (kind, nullable) = parse_type(ty).ok_or_else(|| GenerateError::InvalidField {
         token: token.to_owned(),
         reason: format!("unsupported type '{ty}'. Supported: {SUPPORTED_TYPES}"),
@@ -523,6 +576,84 @@ fn parse_enum_type(ty: &str) -> Result<Option<(Vec<String>, bool)>, String> {
     }
 
     Ok(Some((variants, nullable)))
+}
+
+/// Postgres's documented maximum `NUMERIC` precision (total significant digits).
+const MAX_DECIMAL_PRECISION: u32 = 1000;
+
+/// Parse a `decimal` (optionally `Option<decimal>`) type token, with an
+/// optional `{precision,scale}` modifier (`decimal{10,2}`). Accepts both
+/// `decimal`/`Decimal` casings, consistent with `Attachment`/`attachment`.
+/// Defaults to `{12,2}` — a money-shaped `NUMERIC(12,2)` — when the modifier
+/// is omitted.
+///
+/// Returns `Ok(None)` when `ty` isn't a decimal token at all, so the caller
+/// falls through to [`parse_type`]/[`atomic_type`] unchanged (e.g. a typo
+/// like `decimalize` still gets the general "unsupported type" error rather
+/// than a decimal-specific one). Returns `Err(reason)` when `ty` looks like a
+/// decimal token but is malformed (non-numeric precision/scale, scale
+/// exceeding precision, precision outside Postgres's `NUMERIC` range, …).
+///
+/// # Errors
+/// See above.
+fn parse_decimal_type(ty: &str) -> Result<Option<(u32, u32, bool)>, String> {
+    let (body, nullable) =
+        strip_wrapper(ty, "Option").map_or((ty, false), |inner| (inner.trim(), true));
+
+    let Some(rest) = body
+        .strip_prefix("decimal")
+        .or_else(|| body.strip_prefix("Decimal"))
+    else {
+        return Ok(None);
+    };
+    let rest = rest.trim_start();
+
+    if rest.is_empty() {
+        // Bare `decimal`/`Decimal`: default to a money-shaped NUMERIC(12,2).
+        return Ok(Some((12, 2, nullable)));
+    }
+
+    let Some(inner) = rest.strip_prefix('{') else {
+        // Doesn't actually look like a decimal token (e.g. a typo like
+        // `decimalize`) — fall through to the general "unsupported type"
+        // error rather than a decimal-specific one.
+        return Ok(None);
+    };
+    let Some(body_inner) = inner.strip_suffix('}') else {
+        return Err("expected decimal{precision,scale} (missing closing brace)".to_owned());
+    };
+
+    let parts: Vec<&str> = body_inner.split(',').map(str::trim).collect();
+    let [precision_str, scale_str] = parts.as_slice() else {
+        return Err(format!(
+            "expected decimal{{precision,scale}} (exactly two comma-separated numbers), \
+             got 'decimal{{{body_inner}}}'"
+        ));
+    };
+
+    let precision: u32 = precision_str.parse().map_err(|_| {
+        format!(
+            "'{precision_str}' is not a valid decimal precision \
+             (expected a positive integer)"
+        )
+    })?;
+    let scale: u32 = scale_str.parse().map_err(|_| {
+        format!("'{scale_str}' is not a valid decimal scale (expected a non-negative integer)")
+    })?;
+
+    if precision == 0 || precision > MAX_DECIMAL_PRECISION {
+        return Err(format!(
+            "decimal precision must be between 1 and {MAX_DECIMAL_PRECISION} \
+             (Postgres's NUMERIC limit), got {precision}"
+        ));
+    }
+    if scale > precision {
+        return Err(format!(
+            "decimal scale ({scale}) cannot be greater than precision ({precision})"
+        ));
+    }
+
+    Ok(Some((precision, scale, nullable)))
 }
 
 /// Parse a list of `name:Type` tokens.
@@ -727,9 +858,9 @@ mod tests {
 
     #[test]
     fn unknown_type_rejected() {
-        let err = parse_field("price:Decimal").unwrap_err();
+        let err = parse_field("price:Money").unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("Decimal"));
+        assert!(msg.contains("Money"));
         assert!(msg.contains("Supported:"));
     }
 
@@ -1388,5 +1519,185 @@ mod tests {
             SUPPORTED_TYPES.contains("unique"),
             "SUPPORTED_TYPES must document the :unique modifier"
         );
+    }
+
+    // ── decimal field kind (issue #1038) ────────────────────────────────────
+
+    #[test]
+    fn parse_decimal_field_lowercase() {
+        let f = parse_field("price:decimal").unwrap();
+        assert_eq!(f.name, "price");
+        assert_eq!(
+            f.kind,
+            FieldKind::Decimal {
+                precision: 12,
+                scale: 2
+            }
+        );
+        assert!(!f.nullable);
+    }
+
+    #[test]
+    fn parse_decimal_field_pascal_case() {
+        let f = parse_field("price:Decimal").unwrap();
+        assert_eq!(
+            f.kind,
+            FieldKind::Decimal {
+                precision: 12,
+                scale: 2
+            }
+        );
+    }
+
+    #[test]
+    fn decimal_defaults_to_precision_12_scale_2() {
+        let f = parse_field("price:decimal").unwrap();
+        assert_eq!(f.sql_column_type(), "NUMERIC(12,2)");
+    }
+
+    #[test]
+    fn decimal_custom_precision_and_scale() {
+        let f = parse_field("price:decimal{10,2}").unwrap();
+        assert_eq!(
+            f.kind,
+            FieldKind::Decimal {
+                precision: 10,
+                scale: 2
+            }
+        );
+        assert_eq!(f.sql_column_type(), "NUMERIC(10,2)");
+    }
+
+    #[test]
+    fn decimal_rust_type_is_rust_decimal() {
+        let f = parse_field("price:decimal").unwrap();
+        assert_eq!(f.rust_type(), "rust_decimal::Decimal");
+    }
+
+    #[test]
+    fn decimal_schema_type_is_numeric() {
+        let f = parse_field("price:decimal").unwrap();
+        assert_eq!(f.schema_type(), "Numeric");
+    }
+
+    #[test]
+    fn decimal_sql_type_is_numeric() {
+        let f = parse_field("price:decimal").unwrap();
+        assert_eq!(f.sql_type(), "NUMERIC");
+    }
+
+    #[test]
+    fn optional_decimal_parses() {
+        let f = parse_field("balance:Option<decimal>").unwrap();
+        assert_eq!(
+            f.kind,
+            FieldKind::Decimal {
+                precision: 12,
+                scale: 2
+            }
+        );
+        assert!(f.nullable);
+        assert_eq!(f.rust_type(), "Option<rust_decimal::Decimal>");
+        assert_eq!(f.schema_type(), "Nullable<Numeric>");
+        assert_eq!(f.sql_nullability(), "NULL");
+    }
+
+    #[test]
+    fn optional_decimal_with_precision_scale_parses() {
+        let f = parse_field("balance:Option<decimal{10,2}>").unwrap();
+        assert_eq!(
+            f.kind,
+            FieldKind::Decimal {
+                precision: 10,
+                scale: 2
+            }
+        );
+        assert!(f.nullable);
+        assert_eq!(f.sql_column_type(), "NUMERIC(10,2)");
+    }
+
+    #[test]
+    fn unique_decimal_field_parses() {
+        let f = parse_field("price:decimal:unique").unwrap();
+        assert_eq!(
+            f.kind,
+            FieldKind::Decimal {
+                precision: 12,
+                scale: 2
+            }
+        );
+        assert!(f.unique);
+    }
+
+    #[test]
+    fn decimal_rejects_non_numeric_precision() {
+        let err = parse_field("price:decimal{abc,2}").unwrap_err();
+        assert!(err.to_string().contains("precision"));
+    }
+
+    #[test]
+    fn decimal_rejects_non_numeric_scale() {
+        let err = parse_field("price:decimal{10,xyz}").unwrap_err();
+        assert!(err.to_string().contains("scale"));
+    }
+
+    #[test]
+    fn decimal_rejects_scale_greater_than_precision() {
+        let err = parse_field("price:decimal{2,10}").unwrap_err();
+        assert!(err.to_string().contains("scale"));
+    }
+
+    #[test]
+    fn decimal_rejects_zero_precision() {
+        let err = parse_field("price:decimal{0,0}").unwrap_err();
+        assert!(err.to_string().contains("precision"));
+    }
+
+    #[test]
+    fn decimal_rejects_precision_over_postgres_max() {
+        let err = parse_field("price:decimal{1001,2}").unwrap_err();
+        assert!(err.to_string().contains("precision"));
+    }
+
+    #[test]
+    fn decimal_rejects_missing_closing_brace() {
+        let err = parse_field("price:decimal{10,2").unwrap_err();
+        assert!(err.to_string().contains("decimal{"));
+    }
+
+    #[test]
+    fn decimal_rejects_wrong_number_of_brace_args() {
+        let err = parse_field("price:decimal{10}").unwrap_err();
+        assert!(err.to_string().contains("precision,scale"));
+    }
+
+    #[test]
+    fn decimal_appears_in_supported_types_constant() {
+        assert!(
+            SUPPORTED_TYPES.contains("decimal"),
+            "SUPPORTED_TYPES must list decimal{{p,s}}"
+        );
+    }
+
+    #[test]
+    fn decimal_in_list_of_fields() {
+        let tokens = vec!["title:String".into(), "price:decimal".into()];
+        let fields = parse_fields(&tokens).unwrap();
+        assert_eq!(fields.len(), 2);
+        assert_eq!(
+            fields[1].kind,
+            FieldKind::Decimal {
+                precision: 12,
+                scale: 2
+            }
+        );
+    }
+
+    #[test]
+    fn decimal_numeric_stays_unmapped_for_db_pull_inverse() {
+        // Precision/scale can't be reconstructed from `numeric` udt_name alone
+        // (same precedent as `jsonb`/Attachment), so `db pull` introspection
+        // deliberately leaves it unsupported rather than guessing.
+        assert!(sql_type_to_field_kind("numeric").is_none());
     }
 }

--- a/autumn-cli/src/generate/job.rs
+++ b/autumn-cli/src/generate/job.rs
@@ -132,11 +132,17 @@ pub fn plan_job(project_root: &Path, name: &str, fields: &[String]) -> Result<Pl
     // ── Cargo.toml: ensure serde (always) plus uuid/chrono/decimal if used ──
     if parsed_fields.iter().any(|f| f.kind.is_decimal()) {
         let existing_cargo_toml = read_or_empty(&project_root.join("Cargo.toml"));
-        super::model::warn_if_existing_dep_missing_feature(
+        // Job args structs only derive Serialize/Deserialize (no Diesel
+        // Queryable/Insertable), so strictly only need `serde` — but
+        // JOB_DEPS_DECIMAL below requests the same feature set as
+        // MODEL_DEPS's rust_decimal entry for consistency (a project using
+        // both `generate job` and `generate model`/`scaffold` shares one
+        // `rust_decimal` dep line), so this warning checks the same set.
+        super::model::warn_if_existing_dep_missing_features(
             &mut plan,
             &existing_cargo_toml,
             "rust_decimal",
-            "db-diesel2-postgres",
+            &["db-diesel2-postgres", "serde"],
         );
     }
     super::model::plan_cargo_deps(&mut plan, project_root, &job_deps(&parsed_fields));

--- a/autumn-cli/src/generate/job.rs
+++ b/autumn-cli/src/generate/job.rs
@@ -29,6 +29,16 @@ const JOB_DEPS_UUID: (&str, &str) = ("uuid", "{ version = \"1\", features = [\"s
 /// Extra deps needed when the args struct uses `chrono` date/time fields.
 const JOB_DEPS_CHRONO: (&str, &str) = ("chrono", "{ version = \"0.4\", features = [\"serde\"] }");
 
+/// Extra dep needed when the args struct uses a `decimal` field — mirrors
+/// `model.rs`'s `MODEL_DEPS`/`plan_model` conditional so `render_fields`'s
+/// `f.rust_type()` (`"rust_decimal::Decimal"`) always has a matching
+/// Cargo.toml entry, the same way `JOB_DEPS_UUID`/`JOB_DEPS_CHRONO` already
+/// do for `uuid::Uuid`/`chrono` fields.
+const JOB_DEPS_DECIMAL: (&str, &str) = (
+    "rust_decimal",
+    "{ version = \"1\", features = [\"db-diesel2-postgres\", \"serde\"] }",
+);
+
 /// Build the complete dep list for a job based on which field types are used.
 fn job_deps(fields: &[Field]) -> Vec<(&'static str, &'static str)> {
     let mut deps: Vec<(&str, &str)> = JOB_DEPS_BASE.to_vec();
@@ -40,6 +50,9 @@ fn job_deps(fields: &[Field]) -> Vec<(&'static str, &'static str)> {
         .any(|f| matches!(f.kind, FieldKind::NaiveDateTime | FieldKind::DateTime))
     {
         deps.push(JOB_DEPS_CHRONO);
+    }
+    if fields.iter().any(|f| f.kind.is_decimal()) {
+        deps.push(JOB_DEPS_DECIMAL);
     }
     deps
 }
@@ -798,6 +811,56 @@ async fn main() {
         assert!(
             !cargo.contains("chrono"),
             "Cargo.toml must not include chrono for primitive fields"
+        );
+    }
+
+    #[test]
+    fn decimal_field_adds_rust_decimal_dep_to_cargo_toml() {
+        // Regression test (issue #1038 PR review): `render_fields` emits
+        // `f.rust_type()` ("rust_decimal::Decimal") into the args struct for
+        // any `decimal` field, so the generated Cargo.toml must declare the
+        // crate — job.rs previously had its own `job_deps` list that only
+        // special-cased `Uuid`/chrono and silently omitted `rust_decimal`,
+        // producing a job args struct that failed to compile.
+        let tmp = project_with_main(default_main());
+        plan_job(
+            tmp.path(),
+            "ProcessRefund",
+            &["amount:decimal".to_string()],
+        )
+        .unwrap()
+        .execute(Flags::default())
+        .unwrap();
+
+        let cargo = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        assert!(
+            cargo.contains("rust_decimal"),
+            "Cargo.toml must include rust_decimal: {cargo}"
+        );
+
+        let job_file = fs::read_to_string(tmp.path().join("src/jobs/process_refund.rs")).unwrap();
+        assert!(
+            job_file.contains("pub amount: rust_decimal::Decimal,"),
+            "job args struct must declare the decimal field: {job_file}"
+        );
+    }
+
+    #[test]
+    fn primitive_fields_do_not_add_rust_decimal() {
+        let tmp = project_with_main(default_main());
+        plan_job(
+            tmp.path(),
+            "SendWelcomeEmail",
+            &["user_id:i64".to_string(), "email:String".to_string()],
+        )
+        .unwrap()
+        .execute(Flags::default())
+        .unwrap();
+
+        let cargo = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        assert!(
+            !cargo.contains("rust_decimal"),
+            "Cargo.toml must not include rust_decimal for primitive fields"
         );
     }
 }

--- a/autumn-cli/src/generate/job.rs
+++ b/autumn-cli/src/generate/job.rs
@@ -823,14 +823,10 @@ async fn main() {
         // special-cased `Uuid`/chrono and silently omitted `rust_decimal`,
         // producing a job args struct that failed to compile.
         let tmp = project_with_main(default_main());
-        plan_job(
-            tmp.path(),
-            "ProcessRefund",
-            &["amount:decimal".to_string()],
-        )
-        .unwrap()
-        .execute(Flags::default())
-        .unwrap();
+        plan_job(tmp.path(), "ProcessRefund", &["amount:decimal".to_string()])
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
 
         let cargo = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
         assert!(

--- a/autumn-cli/src/generate/job.rs
+++ b/autumn-cli/src/generate/job.rs
@@ -129,7 +129,16 @@ pub fn plan_job(project_root: &Path, name: &str, fields: &[String]) -> Result<Pl
     let updated_main = add_jobs_registration_to_app(&with_mod);
     plan.modify(main_path, updated_main);
 
-    // ── Cargo.toml: ensure serde (always) plus uuid/chrono if used ───────
+    // ── Cargo.toml: ensure serde (always) plus uuid/chrono/decimal if used ──
+    if parsed_fields.iter().any(|f| f.kind.is_decimal()) {
+        let existing_cargo_toml = read_or_empty(&project_root.join("Cargo.toml"));
+        super::model::warn_if_existing_dep_missing_feature(
+            &mut plan,
+            &existing_cargo_toml,
+            "rust_decimal",
+            "db-diesel2-postgres",
+        );
+    }
     super::model::plan_cargo_deps(&mut plan, project_root, &job_deps(&parsed_fields));
 
     Ok(plan)
@@ -858,5 +867,19 @@ async fn main() {
             !cargo.contains("rust_decimal"),
             "Cargo.toml must not include rust_decimal for primitive fields"
         );
+    }
+
+    #[test]
+    fn decimal_field_warns_when_existing_rust_decimal_dep_lacks_diesel_feature() {
+        let tmp = project_with_main(default_main());
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname=\"x\"\n\n[dependencies]\nrust_decimal = \"1\"\n",
+        )
+        .unwrap();
+        let plan = plan_job(tmp.path(), "ProcessRefund", &["amount:decimal".to_string()]).unwrap();
+        assert_eq!(plan.warnings.len(), 1, "warnings: {:?}", plan.warnings);
+        assert!(plan.warnings[0].contains("rust_decimal"));
+        assert!(plan.warnings[0].contains("db-diesel2-postgres"));
     }
 }

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -202,6 +202,13 @@ pub fn plan_model_with_options(
             "rust_decimal",
             "{ version = \"1\", features = [\"db-diesel2-postgres\", \"serde\"] }",
         ));
+        let existing_cargo_toml = read_or_empty(&project_root.join("Cargo.toml"));
+        warn_if_existing_dep_missing_feature(
+            &mut plan,
+            &existing_cargo_toml,
+            "rust_decimal",
+            "db-diesel2-postgres",
+        );
     }
     plan_cargo_deps(&mut plan, project_root, &deps);
 
@@ -683,6 +690,82 @@ fn dep_section_has(dep_section: &[&str], crate_name: &str) -> bool {
         t.split_once('=')
             .is_some_and(|(name, _)| name.trim() == crate_name)
     })
+}
+
+/// `true` if `existing` Cargo.toml text already declares `crate_name` as a
+/// dependency, but that existing declaration doesn't (as far as this
+/// string-only check can tell) already list `feature`.
+///
+/// [`ensure_cargo_dependencies`] skips any crate name it finds already
+/// present — regardless of that entry's version or features — so a project
+/// that added `crate_name` for its own reasons (or inherited it from a
+/// workspace) before ever running a generator that needs `feature` would
+/// otherwise silently get code that fails to compile with no indication why
+/// (PR review, issue #1038: `rust_decimal = "1"` without
+/// `db-diesel2-postgres` lacks the Diesel `ToSql`/`FromSql` impls a
+/// generated `decimal` field's `#[model]` struct needs).
+///
+/// Checks the common single-line shorthand form (`crate = "1"` or
+/// `crate = { version = "1", features = [...] }`) and the
+/// `[dependencies.crate]` subtable form. Doesn't attempt to resolve
+/// `{ workspace = true }` inheritance or a `features` array split across
+/// multiple lines — those are rarer shapes this heuristic can't see through
+/// from Cargo.toml text alone, so it may occasionally warn when the feature
+/// is in fact present; a false-positive warning is far cheaper than the
+/// silent compile failure this check exists to catch.
+fn existing_dep_declared_without_feature(existing: &str, crate_name: &str, feature: &str) -> bool {
+    let lines: Vec<&str> = existing.lines().collect();
+    let Some(deps_idx) = lines
+        .iter()
+        .position(|l| is_table_header(l, "dependencies"))
+    else {
+        return false;
+    };
+    let scan_end = lines[deps_idx + 1..]
+        .iter()
+        .position(|l| is_any_table_header(l) && !is_dep_subtable_boundary_marker(l))
+        .map_or(lines.len(), |off| deps_idx + 1 + off);
+    let dep_section = &lines[deps_idx + 1..scan_end];
+
+    if let Some(sub_idx) = dep_section
+        .iter()
+        .position(|l| dep_subtable_crate_name(l) == Some(crate_name))
+    {
+        let sub_body_end = dep_section[sub_idx + 1..]
+            .iter()
+            .position(|l| is_any_table_header(l))
+            .map_or(dep_section.len(), |off| sub_idx + 1 + off);
+        let sub_body = dep_section[sub_idx + 1..sub_body_end].join("\n");
+        return !sub_body.contains(feature);
+    }
+
+    dep_section
+        .iter()
+        .find(|l| {
+            let t = l.trim_start();
+            !t.starts_with('#')
+                && t.split_once('=')
+                    .is_some_and(|(name, _)| name.trim() == crate_name)
+        })
+        .is_some_and(|line| !line.contains(feature))
+}
+
+/// If `existing` Cargo.toml text already declares `crate_name` without
+/// `feature`, record a `plan` warning naming exactly what to add by hand.
+/// See [`existing_dep_declared_without_feature`] for why this check exists.
+pub(super) fn warn_if_existing_dep_missing_feature(
+    plan: &mut Plan,
+    existing_cargo_toml: &str,
+    crate_name: &str,
+    feature: &str,
+) {
+    if existing_dep_declared_without_feature(existing_cargo_toml, crate_name, feature) {
+        plan.warn(format!(
+            "Cargo.toml already declares '{crate_name}' without the '{feature}' feature \
+             the generated code needs — add it by hand (e.g. `features = [\"{feature}\", ...]`) \
+             or the generated code may fail to compile."
+        ));
+    }
 }
 
 /// Reserved resource names whose snake-case form would collide with a special
@@ -1853,6 +1936,65 @@ mod tests {
                 "'{bad}' should be rejected as non-finite: {err}"
             );
         }
+    }
+
+    #[test]
+    fn decimal_field_warns_when_existing_rust_decimal_dep_lacks_diesel_feature() {
+        // Regression test (PR review, issue #1038): `ensure_cargo_dependencies`
+        // skips a crate that's already declared, regardless of its features —
+        // so a project that already had `rust_decimal = "1"` (e.g. for its own
+        // business logic) before ever using a `decimal` field would silently
+        // keep that feature-less entry, and the generated `#[model]` field's
+        // Diesel `ToSql`/`FromSql` impls (behind `db-diesel2-postgres`) would
+        // be missing, failing to compile with no indication why.
+        let tmp = project();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname=\"x\"\n\n[dependencies]\nrust_decimal = \"1\"\n",
+        )
+        .unwrap();
+        let plan = plan_model(
+            tmp.path(),
+            "Product",
+            &["price:decimal".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert_eq!(plan.warnings.len(), 1, "warnings: {:?}", plan.warnings);
+        assert!(plan.warnings[0].contains("rust_decimal"));
+        assert!(plan.warnings[0].contains("db-diesel2-postgres"));
+    }
+
+    #[test]
+    fn decimal_field_no_warning_when_existing_rust_decimal_dep_already_has_feature() {
+        let tmp = project();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname=\"x\"\n\n[dependencies]\n\
+             rust_decimal = { version = \"1\", features = [\"db-diesel2-postgres\"] }\n",
+        )
+        .unwrap();
+        let plan = plan_model(
+            tmp.path(),
+            "Product",
+            &["price:decimal".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert!(plan.warnings.is_empty(), "warnings: {:?}", plan.warnings);
+    }
+
+    #[test]
+    fn decimal_field_no_warning_when_rust_decimal_not_already_declared() {
+        let tmp = project();
+        let plan = plan_model(
+            tmp.path(),
+            "Product",
+            &["price:decimal".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert!(plan.warnings.is_empty(), "warnings: {:?}", plan.warnings);
     }
 
     // ── enum field: --default (issue #1030) ─────────────────────────────────

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -1034,6 +1034,45 @@ fn unquote_default_value(value: &str) -> &str {
         .unwrap_or(value)
 }
 
+/// Check that a `--default` value's *significant* digits fit a
+/// `NUMERIC(precision,scale)` column, so a decimal default never generates a
+/// migration that fails at apply time with a Postgres "numeric field
+/// overflow" (integer part too wide) — or silently gets rounded away
+/// (fractional part too precise), which would defeat the entire point of a
+/// field type that exists to avoid silent precision loss.
+///
+/// `value` is assumed to already be a plain (non-scientific-notation),
+/// finite numeric string — the caller checks that first. Trailing/leading
+/// zeros are trimmed before counting: `"1.500"` has one significant
+/// fractional digit (5), not three, and `"007"` has one significant integer
+/// digit, matching Postgres's own `NUMERIC` digit-counting semantics.
+fn validate_decimal_default_fits(value: &str, precision: u32, scale: u32) -> Result<(), String> {
+    let unsigned = value
+        .strip_prefix('-')
+        .or_else(|| value.strip_prefix('+'))
+        .unwrap_or(value);
+    let (int_part, frac_part) = unsigned.split_once('.').unwrap_or((unsigned, ""));
+
+    let frac_digits = frac_part.trim_end_matches('0').len();
+    if frac_digits > scale as usize {
+        return Err(format!(
+            "decimal default '{value}' has {frac_digits} fractional digit(s), but \
+             decimal{{{precision},{scale}}} only allows {scale}"
+        ));
+    }
+
+    let int_digits = int_part.trim_start_matches('0').len();
+    let max_int_digits = precision - scale;
+    if int_digits > max_int_digits as usize {
+        return Err(format!(
+            "decimal default '{value}' has {int_digits} integer digit(s), but \
+             decimal{{{precision},{scale}}} only allows {max_int_digits}"
+        ));
+    }
+
+    Ok(())
+}
+
 fn sql_default_literal(field: &Field, value: &str) -> Result<String, String> {
     match field.kind {
         FieldKind::Bool => match value.to_ascii_lowercase().as_str() {
@@ -1057,14 +1096,28 @@ fn sql_default_literal(field: &Field, value: &str) -> Result<String, String> {
             .parse::<f64>()
             .map(|_| value.to_owned())
             .map_err(|_| "float defaults must be valid numbers".to_owned()),
-        // Shape-validated the same way as F32/F64 (an `f64` parse is just a
-        // "does this look like a number" check) and emitted as the original
-        // string — `autumn-cli` doesn't depend on `rust_decimal` itself, and
-        // an unquoted numeric literal is valid Postgres `NUMERIC` SQL either way.
-        FieldKind::Decimal { .. } => value
-            .parse::<f64>()
-            .map(|_| value.to_owned())
-            .map_err(|_| "decimal defaults must be valid numbers".to_owned()),
+        FieldKind::Decimal { precision, scale } => {
+            let parsed: f64 = value
+                .parse()
+                .map_err(|_| "decimal defaults must be valid numbers".to_owned())?;
+            if !parsed.is_finite() {
+                return Err("decimal defaults must be finite numbers (not NaN/infinity)".to_owned());
+            }
+            if value.contains(['e', 'E']) {
+                return Err(
+                    "decimal defaults must be written in plain notation (e.g. '19.99'), \
+                     not scientific notation"
+                        .to_owned(),
+                );
+            }
+            validate_decimal_default_fits(value, precision, scale)?;
+            // Emitted as the original string, not `parsed.to_string()` —
+            // `autumn-cli` doesn't depend on `rust_decimal` itself, and an
+            // unquoted numeric literal is valid Postgres `NUMERIC` SQL
+            // whether or not it round-trips exactly through `f64` (this arm
+            // only used `f64` to reject non-numeric garbage above).
+            Ok(value.to_owned())
+        }
         FieldKind::Uuid
         | FieldKind::NaiveDateTime
         | FieldKind::DateTime
@@ -1642,6 +1695,162 @@ mod tests {
             assert!(
                 matches!(err, GenerateError::InvalidField { .. }),
                 "expected '{field_name}' to be rejected"
+            );
+        }
+    }
+
+    // ── decimal field: --default (issue #1038 PR review) ────────────────────
+
+    #[test]
+    fn decimal_default_within_precision_and_scale_is_accepted() {
+        let fields = parse_fields(&["price:decimal{12,2}".into()]).unwrap();
+        let metadata = parse_model_metadata(
+            &fields,
+            &ModelOptions {
+                defaults: vec!["price=19.99".into()],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            metadata.defaults().get("price").map(String::as_str),
+            Some("19.99")
+        );
+    }
+
+    #[test]
+    fn decimal_default_rejected_when_integer_part_overflows_precision() {
+        // decimal{2,2} has 0 integer digits of budget (precision - scale ==
+        // 0), so any value with magnitude >= 1 must be rejected rather than
+        // generating a migration Postgres fails at apply time with a
+        // "numeric field overflow".
+        let fields = parse_fields(&["amount:decimal{2,2}".into()]).unwrap();
+        let err = parse_model_metadata(
+            &fields,
+            &ModelOptions {
+                defaults: vec!["amount=1".into()],
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("integer digit"), "got: {msg}");
+    }
+
+    #[test]
+    fn decimal_default_rejected_when_fractional_part_exceeds_scale() {
+        // decimal{3,2} only allows 2 fractional digits; a third significant
+        // digit would silently round away rather than storing exactly.
+        let fields = parse_fields(&["amount:decimal{3,2}".into()]).unwrap();
+        let err = parse_model_metadata(
+            &fields,
+            &ModelOptions {
+                defaults: vec!["amount=1.999".into()],
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("fractional digit"), "got: {msg}");
+    }
+
+    #[test]
+    fn decimal_default_tolerates_insignificant_trailing_zeros() {
+        // "1.500" has one significant fractional digit (5), not three — it
+        // must not be rejected for a scale-2 column just because the source
+        // string happens to have an extra trailing zero.
+        let fields = parse_fields(&["amount:decimal{4,2}".into()]).unwrap();
+        let metadata = parse_model_metadata(
+            &fields,
+            &ModelOptions {
+                defaults: vec!["amount=1.500".into()],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            metadata.defaults().get("amount").map(String::as_str),
+            Some("1.500")
+        );
+    }
+
+    #[test]
+    fn decimal_default_tolerates_leading_zeros_in_integer_part() {
+        let fields = parse_fields(&["amount:decimal{2,2}".into()]).unwrap();
+        let metadata = parse_model_metadata(
+            &fields,
+            &ModelOptions {
+                defaults: vec!["amount=0.5".into()],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            metadata.defaults().get("amount").map(String::as_str),
+            Some("0.5")
+        );
+    }
+
+    #[test]
+    fn decimal_default_accepts_negative_value_within_range() {
+        let fields = parse_fields(&["amount:decimal{2,2}".into()]).unwrap();
+        let metadata = parse_model_metadata(
+            &fields,
+            &ModelOptions {
+                defaults: vec!["amount=-0.75".into()],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            metadata.defaults().get("amount").map(String::as_str),
+            Some("-0.75")
+        );
+    }
+
+    #[test]
+    fn decimal_default_rejects_non_numeric_value() {
+        let fields = parse_fields(&["price:decimal".into()]).unwrap();
+        let err = parse_model_metadata(
+            &fields,
+            &ModelOptions {
+                defaults: vec!["price=abc".into()],
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("valid numbers"));
+    }
+
+    #[test]
+    fn decimal_default_rejects_scientific_notation() {
+        let fields = parse_fields(&["price:decimal".into()]).unwrap();
+        let err = parse_model_metadata(
+            &fields,
+            &ModelOptions {
+                defaults: vec!["price=1e2".into()],
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("scientific notation"));
+    }
+
+    #[test]
+    fn decimal_default_rejects_nan_and_infinity() {
+        let fields = parse_fields(&["price:decimal".into()]).unwrap();
+        for bad in ["nan", "inf", "infinity"] {
+            let err = parse_model_metadata(
+                &fields,
+                &ModelOptions {
+                    defaults: vec![format!("price={bad}")],
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+            assert!(
+                err.to_string().contains("finite"),
+                "'{bad}' should be rejected as non-finite: {err}"
             );
         }
     }

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -203,11 +203,11 @@ pub fn plan_model_with_options(
             "{ version = \"1\", features = [\"db-diesel2-postgres\", \"serde\"] }",
         ));
         let existing_cargo_toml = read_or_empty(&project_root.join("Cargo.toml"));
-        warn_if_existing_dep_missing_feature(
+        warn_if_existing_dep_missing_features(
             &mut plan,
             &existing_cargo_toml,
             "rust_decimal",
-            "db-diesel2-postgres",
+            &["db-diesel2-postgres", "serde"],
         );
     }
     plan_cargo_deps(&mut plan, project_root, &deps);
@@ -750,19 +750,40 @@ fn existing_dep_declared_without_feature(existing: &str, crate_name: &str, featu
         .is_some_and(|line| !line.contains(feature))
 }
 
-/// If `existing` Cargo.toml text already declares `crate_name` without
-/// `feature`, record a `plan` warning naming exactly what to add by hand.
-/// See [`existing_dep_declared_without_feature`] for why this check exists.
-pub(super) fn warn_if_existing_dep_missing_feature(
+/// If `existing` Cargo.toml text already declares `crate_name` without one
+/// or more of `features`, record a single `plan` warning naming exactly
+/// which ones to add by hand. See [`existing_dep_declared_without_feature`]
+/// for why this check exists.
+///
+/// Checked against the *full* feature set a generator needs — not just one
+/// of them — because `ensure_cargo_dependencies` only ever gets one shot at
+/// a crate name: once it's present, no generator will ever revisit it again.
+/// A partial check (e.g. only `db-diesel2-postgres`, missing `serde`) would
+/// pass a project that already added `rust_decimal` with *some* but not all
+/// of the required features, still leaving the generated code unable to
+/// compile.
+pub(super) fn warn_if_existing_dep_missing_features(
     plan: &mut Plan,
     existing_cargo_toml: &str,
     crate_name: &str,
-    feature: &str,
+    features: &[&str],
 ) {
-    if existing_dep_declared_without_feature(existing_cargo_toml, crate_name, feature) {
+    let missing: Vec<&str> = features
+        .iter()
+        .copied()
+        .filter(|feature| {
+            existing_dep_declared_without_feature(existing_cargo_toml, crate_name, feature)
+        })
+        .collect();
+    if !missing.is_empty() {
+        let feature_list = missing
+            .iter()
+            .map(|f| format!("\"{f}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
         plan.warn(format!(
-            "Cargo.toml already declares '{crate_name}' without the '{feature}' feature \
-             the generated code needs — add it by hand (e.g. `features = [\"{feature}\", ...]`) \
+            "Cargo.toml already declares '{crate_name}' without the generated code's \
+             required feature(s) — add {feature_list} to its `features` list by hand \
              or the generated code may fail to compile."
         ));
     }
@@ -1971,7 +1992,7 @@ mod tests {
         fs::write(
             tmp.path().join("Cargo.toml"),
             "[package]\nname=\"x\"\n\n[dependencies]\n\
-             rust_decimal = { version = \"1\", features = [\"db-diesel2-postgres\"] }\n",
+             rust_decimal = { version = \"1\", features = [\"db-diesel2-postgres\", \"serde\"] }\n",
         )
         .unwrap();
         let plan = plan_model(
@@ -1982,6 +2003,32 @@ mod tests {
         )
         .unwrap();
         assert!(plan.warnings.is_empty(), "warnings: {:?}", plan.warnings);
+    }
+
+    #[test]
+    fn decimal_field_warns_naming_only_the_missing_feature() {
+        // Regression test (PR review, issue #1038): the earlier version of
+        // this check only verified `db-diesel2-postgres`, missing that the
+        // generated `#[model]` struct also derives Serialize/Deserialize and
+        // so needs `serde` too — a project with `rust_decimal` already
+        // declared with `db-diesel2-postgres` but not `serde` would pass the
+        // old single-feature check and still fail to compile.
+        let tmp = project();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname=\"x\"\n\n[dependencies]\n\
+             rust_decimal = { version = \"1\", features = [\"db-diesel2-postgres\"] }\n",
+        )
+        .unwrap();
+        let plan = plan_model(
+            tmp.path(),
+            "Product",
+            &["price:decimal".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert_eq!(plan.warnings.len(), 1, "warnings: {:?}", plan.warnings);
+        assert!(plan.warnings[0].contains("serde"));
     }
 
     #[test]

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -197,6 +197,12 @@ pub fn plan_model_with_options(
             "{ version = \"0.20\", features = [\"derive\"] }",
         ));
     }
+    if schema_fields.iter().any(|f| f.kind.is_decimal()) {
+        deps.push((
+            "rust_decimal",
+            "{ version = \"1\", features = [\"db-diesel2-postgres\", \"serde\"] }",
+        ));
+    }
     plan_cargo_deps(&mut plan, project_root, &deps);
 
     Ok(plan)
@@ -1051,6 +1057,14 @@ fn sql_default_literal(field: &Field, value: &str) -> Result<String, String> {
             .parse::<f64>()
             .map(|_| value.to_owned())
             .map_err(|_| "float defaults must be valid numbers".to_owned()),
+        // Shape-validated the same way as F32/F64 (an `f64` parse is just a
+        // "does this look like a number" check) and emitted as the original
+        // string — `autumn-cli` doesn't depend on `rust_decimal` itself, and
+        // an unquoted numeric literal is valid Postgres `NUMERIC` SQL either way.
+        FieldKind::Decimal { .. } => value
+            .parse::<f64>()
+            .map(|_| value.to_owned())
+            .map_err(|_| "decimal defaults must be valid numbers".to_owned()),
         FieldKind::Uuid
         | FieldKind::NaiveDateTime
         | FieldKind::DateTime
@@ -1419,7 +1433,7 @@ mod tests {
         let err = plan_model(
             tmp.path(),
             "Post",
-            &["price:Decimal".into()],
+            &["price:Money".into()],
             "20260427000000",
         )
         .unwrap_err();

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -253,9 +253,9 @@ pub fn plan_scaffold_with_options(
             "{ version = \"0.20\", features = [\"derive\"] }",
         ));
     }
-    // Not re-checked for a missing Diesel feature here: `plan` above *is*
-    // the `plan_model_with_options` plan (reused, not merged), and that call
-    // already ran `warn_if_existing_dep_missing_feature` for `rust_decimal`
+    // Not re-checked for missing features here: `plan` above *is* the
+    // `plan_model_with_options` plan (reused, not merged), and that call
+    // already ran `warn_if_existing_dep_missing_features` for `rust_decimal`
     // when it built its own decimal-conditional dep — re-running the same
     // check against the same (still on-disk, pre-`execute()`) Cargo.toml
     // here would just duplicate the warning.

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -2203,16 +2203,32 @@ const fn number_step(kind: FieldKind) -> &'static str {
     }
 }
 
+/// A decimal literal at the given `scale`, formed from a single trailing
+/// significant `digit` (1-9) — e.g. `decimal_literal_at_scale(2, 1)` ==
+/// `"0.01"`, `decimal_literal_at_scale(0, 2)` == `"2"`. The magnitude never
+/// exceeds `9 * 10^-scale` (well under `1` for any `scale >= 1`, and under
+/// `10` for `scale == 0`), so the result fits any valid
+/// `decimal{precision,scale}` column (the DSL enforces `1 <= precision` and
+/// `scale <= precision`) regardless of how tight `precision` is — used both
+/// for the `<input step="...">` attribute ([`decimal_step`]) and the SQL
+/// sample/duplicate literals the enum-rejection/unique-violation smoke-test
+/// generators splice in below ([`sql_sample_literal`], [`unique_sample_literal`],
+/// [`unique_sample_literal_variant`]), where a fixed literal like `"1.0"`
+/// would overflow a tightly-scaled column such as `decimal{1,1}`.
+fn decimal_literal_at_scale(scale: u32, digit: u32) -> String {
+    if scale == 0 {
+        digit.to_string()
+    } else {
+        format!("0.{}{digit}", "0".repeat(scale as usize - 1))
+    }
+}
+
 /// The HTML `step` attribute value for a `decimal{precision,scale}` field,
 /// derived from its declared `scale` — `0` steps by whole numbers, `2`
 /// produces `"0.01"`, matching the column's actual smallest representable
 /// increment (unlike float fields, whose `step="any"` accepts any input).
 fn decimal_step(scale: u32) -> String {
-    if scale == 0 {
-        "1".to_owned()
-    } else {
-        format!("0.{}1", "0".repeat(scale as usize - 1))
-    }
+    decimal_literal_at_scale(scale, 1)
 }
 
 #[allow(
@@ -2914,22 +2930,26 @@ fn render_smoke_test(
 /// test needs *some* valid value so the `INSERT`'s failure is attributable to
 /// the target enum column's `CHECK` constraint rather than some other
 /// required column being left out.
-const fn sql_sample_literal(kind: FieldKind) -> &'static str {
+fn sql_sample_literal(kind: FieldKind) -> String {
     match kind {
         // `Enum`'s "'sample'" here is never actually used: `enum_rejection_insert_sql`
         // special-cases every enum column (the field under test gets the
         // deliberately out-of-set literal; any *other* required enum column
         // gets one of its own real variants instead — see that function).
-        FieldKind::String | FieldKind::Text | FieldKind::Enum => "'sample'",
-        FieldKind::I32 | FieldKind::I64 | FieldKind::References => "1",
-        FieldKind::Bool => "TRUE",
-        FieldKind::F32 | FieldKind::F64 | FieldKind::Decimal { .. } => "1.0",
-        FieldKind::Uuid => "gen_random_uuid()",
-        FieldKind::NaiveDateTime | FieldKind::DateTime => "NOW()",
-        FieldKind::Bytea => "'\\x00'::bytea",
+        FieldKind::String | FieldKind::Text | FieldKind::Enum => "'sample'".to_owned(),
+        FieldKind::I32 | FieldKind::I64 | FieldKind::References => "1".to_owned(),
+        FieldKind::Bool => "TRUE".to_owned(),
+        FieldKind::F32 | FieldKind::F64 => "1.0".to_owned(),
+        // Scale-derived rather than a fixed "1.0": a tightly-scaled column
+        // like `decimal{1,1}` (valid range `(-1,1)`) would reject a literal
+        // "1.0" with a numeric field overflow — see `decimal_literal_at_scale`.
+        FieldKind::Decimal { scale, .. } => decimal_literal_at_scale(scale, 1),
+        FieldKind::Uuid => "gen_random_uuid()".to_owned(),
+        FieldKind::NaiveDateTime | FieldKind::DateTime => "NOW()".to_owned(),
+        FieldKind::Bytea => "'\\x00'::bytea".to_owned(),
         // Always nullable (see `FieldKind::Attachment`'s doc comment), so it
         // never needs a sample literal to satisfy a `NOT NULL` constraint.
-        FieldKind::Attachment => "NULL",
+        FieldKind::Attachment => "NULL".to_owned(),
     }
 }
 
@@ -2959,7 +2979,7 @@ fn enum_rejection_insert_sql(
             let value = if f.is_enum() {
                 format!("'{}'", f.variants.first().expect("enum field has variants"))
             } else {
-                sql_sample_literal(f.kind).to_owned()
+                sql_sample_literal(f.kind)
             };
             values.push(value);
         }
@@ -3082,10 +3102,10 @@ fn render_enum_rejection_smoke_test(
 /// this deliberately avoids non-deterministic SQL (`gen_random_uuid()`,
 /// `NOW()`) — two evaluations of either would almost certainly differ and
 /// the duplicate-insert assertion would never trip.
-const fn unique_sample_literal(kind: FieldKind) -> &'static str {
+fn unique_sample_literal(kind: FieldKind) -> String {
     match kind {
-        FieldKind::String | FieldKind::Text | FieldKind::Enum => "'dup_value'",
-        FieldKind::I32 | FieldKind::I64 => "424242",
+        FieldKind::String | FieldKind::Text | FieldKind::Enum => "'dup_value'".to_owned(),
+        FieldKind::I32 | FieldKind::I64 => "424242".to_owned(),
         // Must be a real seeded row's id, not an arbitrary literal — a
         // `references` target column is FK-constrained against the stub
         // table `render_reference_stub_tables_sql` seeds exactly one row
@@ -3093,14 +3113,17 @@ const fn unique_sample_literal(kind: FieldKind) -> &'static str {
         // constraint before the insert ever reaches the UNIQUE index this
         // test exists to exercise. Matches `sql_sample_literal`'s existing
         // convention for the same reason.
-        FieldKind::References => "1",
-        FieldKind::Bool => "TRUE",
-        FieldKind::F32 | FieldKind::F64 | FieldKind::Decimal { .. } => "1.5",
-        FieldKind::Uuid => "'00000000-0000-0000-0000-000000000001'::uuid",
-        FieldKind::NaiveDateTime => "'2024-01-01 00:00:00'::timestamp",
-        FieldKind::DateTime => "'2024-01-01 00:00:00+00'::timestamptz",
-        FieldKind::Bytea => "'\\xDEADBEEF'::bytea",
-        FieldKind::Attachment => "NULL",
+        FieldKind::References => "1".to_owned(),
+        FieldKind::Bool => "TRUE".to_owned(),
+        FieldKind::F32 | FieldKind::F64 => "1.5".to_owned(),
+        // Scale-derived, distinct from `sql_sample_literal`'s digit-1 value
+        // for the same field — see `decimal_literal_at_scale`.
+        FieldKind::Decimal { scale, .. } => decimal_literal_at_scale(scale, 2),
+        FieldKind::Uuid => "'00000000-0000-0000-0000-000000000001'::uuid".to_owned(),
+        FieldKind::NaiveDateTime => "'2024-01-01 00:00:00'::timestamp".to_owned(),
+        FieldKind::DateTime => "'2024-01-01 00:00:00+00'::timestamptz".to_owned(),
+        FieldKind::Bytea => "'\\xDEADBEEF'::bytea".to_owned(),
+        FieldKind::Attachment => "NULL".to_owned(),
     }
 }
 
@@ -3112,21 +3135,25 @@ const fn unique_sample_literal(kind: FieldKind) -> &'static str {
 /// exact same value for a non-target unique column on both inserts would
 /// trip *that* column's own UNIQUE index too, racing against the target's
 /// to decide which violation Postgres actually reports.
-const fn unique_sample_literal_variant(kind: FieldKind) -> &'static str {
+fn unique_sample_literal_variant(kind: FieldKind) -> String {
     match kind {
-        FieldKind::String | FieldKind::Text | FieldKind::Enum => "'dup_value_2'",
-        FieldKind::I32 | FieldKind::I64 => "424243",
+        FieldKind::String | FieldKind::Text | FieldKind::Enum => "'dup_value_2'".to_owned(),
+        FieldKind::I32 | FieldKind::I64 => "424243".to_owned(),
         // The second stub row `render_reference_stub_tables_sql` seeds —
         // distinct from `unique_sample_literal`'s "1" for the same reason
         // that one must be a real seeded row's id, not an arbitrary literal.
-        FieldKind::References => "2",
-        FieldKind::Bool => "FALSE",
-        FieldKind::F32 | FieldKind::F64 | FieldKind::Decimal { .. } => "2.5",
-        FieldKind::Uuid => "'00000000-0000-0000-0000-000000000002'::uuid",
-        FieldKind::NaiveDateTime => "'2024-01-02 00:00:00'::timestamp",
-        FieldKind::DateTime => "'2024-01-02 00:00:00+00'::timestamptz",
-        FieldKind::Bytea => "'\\xBEEFDEAD'::bytea",
-        FieldKind::Attachment => "NULL",
+        FieldKind::References => "2".to_owned(),
+        FieldKind::Bool => "FALSE".to_owned(),
+        FieldKind::F32 | FieldKind::F64 => "2.5".to_owned(),
+        // Scale-derived, distinct from both `sql_sample_literal`'s digit-1
+        // and `unique_sample_literal`'s digit-2 value — see
+        // `decimal_literal_at_scale`.
+        FieldKind::Decimal { scale, .. } => decimal_literal_at_scale(scale, 3),
+        FieldKind::Uuid => "'00000000-0000-0000-0000-000000000002'::uuid".to_owned(),
+        FieldKind::NaiveDateTime => "'2024-01-02 00:00:00'::timestamp".to_owned(),
+        FieldKind::DateTime => "'2024-01-02 00:00:00+00'::timestamptz".to_owned(),
+        FieldKind::Bytea => "'\\xBEEFDEAD'::bytea".to_owned(),
+        FieldKind::Attachment => "NULL".to_owned(),
     }
 }
 
@@ -3158,7 +3185,7 @@ fn unique_violation_insert_sql(
             let value = if f.is_enum() {
                 format!("'{}'", f.variants.first().expect("enum field has variants"))
             } else {
-                unique_sample_literal(f.kind).to_owned()
+                unique_sample_literal(f.kind)
             };
             values.push(value);
         } else if !f.nullable && !defaults.contains_key(&f.name) {
@@ -3167,11 +3194,11 @@ fn unique_violation_insert_sql(
                 let variant = f.variants.get(1).unwrap_or(&f.variants[0]);
                 format!("'{variant}'")
             } else if is_duplicate_insert && f.unique {
-                unique_sample_literal_variant(f.kind).to_owned()
+                unique_sample_literal_variant(f.kind)
             } else if f.is_enum() {
                 format!("'{}'", f.variants.first().expect("enum field has variants"))
             } else {
-                sql_sample_literal(f.kind).to_owned()
+                sql_sample_literal(f.kind)
             };
             values.push(value);
         }
@@ -5801,5 +5828,76 @@ async fn main() {
             "a self-referential FK must not stub its own table before creating it for real: {test}"
         );
         assert!(test.contains("category_id BIGINT NOT NULL REFERENCES categories(id)"));
+    }
+
+    // ── decimal sample literals fit tightly-scaled columns (issue #1038) ────
+
+    #[test]
+    fn decimal_literal_at_scale_never_reaches_one() {
+        // Every sample literal must stay strictly under `1` for scale >= 1,
+        // so it fits even the tightest valid column (`decimal{scale,scale}`,
+        // whose range is `(-1,1)`) regardless of how large `precision` is.
+        for scale in 1..=6 {
+            for digit in [1, 2, 3] {
+                let literal = decimal_literal_at_scale(scale, digit);
+                let value: f64 = literal.parse().unwrap();
+                assert!(
+                    value.abs() < 1.0,
+                    "decimal_literal_at_scale({scale}, {digit}) = {literal} must be < 1"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn decimal_sample_literals_are_pairwise_distinct_at_every_scale() {
+        for scale in 0..=6 {
+            let a = sql_sample_literal(FieldKind::Decimal {
+                precision: scale.max(1) + 1,
+                scale,
+            });
+            let b = unique_sample_literal(FieldKind::Decimal {
+                precision: scale.max(1) + 1,
+                scale,
+            });
+            let c = unique_sample_literal_variant(FieldKind::Decimal {
+                precision: scale.max(1) + 1,
+                scale,
+            });
+            assert!(a != b && b != c && a != c, "scale {scale}: {a}, {b}, {c}");
+        }
+    }
+
+    #[test]
+    fn enum_rejection_insert_sql_fits_tightly_scaled_decimal_column() {
+        // Regression test: a `decimal{1,1}` column (valid range `(-1,1)`)
+        // combined with a required enum column used to get a fixed "1.0"
+        // sample literal from `sql_sample_literal`, which Postgres's
+        // `NUMERIC(1,1)` rejects as a numeric field overflow — breaking a
+        // generated test that has nothing to do with the enum behavior it's
+        // meant to exercise.
+        let status = Field {
+            name: "status".to_string(),
+            kind: FieldKind::Enum,
+            nullable: false,
+            variants: vec!["a".to_string(), "b".to_string()],
+            unique: false,
+        };
+        let weight = Field {
+            name: "weight".to_string(),
+            kind: FieldKind::Decimal {
+                precision: 1,
+                scale: 1,
+            },
+            nullable: false,
+            variants: Vec::new(),
+            unique: false,
+        };
+        let fields = vec![status.clone(), weight];
+        let sql = enum_rejection_insert_sql("items", &fields, &status, &BTreeMap::new());
+        assert!(
+            sql.contains("weight) VALUES ('__not_a_real_variant__', 0.1)"),
+            "expected a scale-fitting 0.1 literal for NUMERIC(1,1), got: {sql}"
+        );
     }
 }

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -253,6 +253,12 @@ pub fn plan_scaffold_with_options(
             "{ version = \"0.20\", features = [\"derive\"] }",
         ));
     }
+    if fields.iter().any(|f| f.kind.is_decimal()) {
+        combined.push((
+            "rust_decimal",
+            "{ version = \"1\", features = [\"db-diesel2-postgres\", \"serde\"] }",
+        ));
+    }
     plan_cargo_deps(&mut plan, project_root, &combined);
 
     // --live requires `ws` (sse::stream), `maud` (LiveFragment/Markup), and `htmx`.
@@ -2075,6 +2081,23 @@ fn render_create_form_inputs(
                         hx_attrs = hx_attrs
                     )
                 }
+                // `inputmode="decimal"` hints a numeric-with-decimal-point
+                // keyboard on mobile; `step` matches the column's declared
+                // scale so the browser's stepper (and its "please match the
+                // requested format" validation) aligns with what the SQL
+                // column actually stores.
+                (FieldKind::Decimal { scale, .. }, _) => {
+                    let value_attr = submitted_var
+                        .map(|var| format!(" value=({})", edit_value_expr(f, var)))
+                        .unwrap_or_default();
+                    format!(
+                        "input type=\"number\" inputmode=\"decimal\" name=\"{name}\" step=\"{step}\"{value_attr}{required}{hx_attrs}",
+                        name = f.name,
+                        step = decimal_step(scale),
+                        required = required,
+                        hx_attrs = hx_attrs
+                    )
+                }
                 // `step="any"` lets the browser's picker show/accept
                 // seconds — see edit_datetime_local_value_expr for why a
                 // value with seconds must not be step-mismatch-rejected.
@@ -2180,6 +2203,18 @@ const fn number_step(kind: FieldKind) -> &'static str {
     }
 }
 
+/// The HTML `step` attribute value for a `decimal{precision,scale}` field,
+/// derived from its declared `scale` — `0` steps by whole numbers, `2`
+/// produces `"0.01"`, matching the column's actual smallest representable
+/// increment (unlike float fields, whose `step="any"` accepts any input).
+fn decimal_step(scale: u32) -> String {
+    if scale == 0 {
+        "1".to_owned()
+    } else {
+        format!("0.{}1", "0".repeat(scale as usize - 1))
+    }
+}
+
 #[allow(
     clippy::too_many_lines,
     reason = "One match arm per field-kind widget — splitting it produces less \
@@ -2262,6 +2297,14 @@ fn render_edit_form_inputs(
                     "input type=\"number\" name=\"{name}\" step=\"{step}\" value=({value}){required}{hx_attrs}",
                     name = f.name,
                     step = number_step(f.kind),
+                    value = edit_value_expr(f, var),
+                    required = required,
+                    hx_attrs = hx_attrs
+                ),
+                (FieldKind::Decimal { scale, .. }, _) => format!(
+                    "input type=\"number\" inputmode=\"decimal\" name=\"{name}\" step=\"{step}\" value=({value}){required}{hx_attrs}",
+                    name = f.name,
+                    step = decimal_step(scale),
                     value = edit_value_expr(f, var),
                     required = required,
                     hx_attrs = hx_attrs
@@ -2880,7 +2923,7 @@ const fn sql_sample_literal(kind: FieldKind) -> &'static str {
         FieldKind::String | FieldKind::Text | FieldKind::Enum => "'sample'",
         FieldKind::I32 | FieldKind::I64 | FieldKind::References => "1",
         FieldKind::Bool => "TRUE",
-        FieldKind::F32 | FieldKind::F64 => "1.0",
+        FieldKind::F32 | FieldKind::F64 | FieldKind::Decimal { .. } => "1.0",
         FieldKind::Uuid => "gen_random_uuid()",
         FieldKind::NaiveDateTime | FieldKind::DateTime => "NOW()",
         FieldKind::Bytea => "'\\x00'::bytea",
@@ -3052,7 +3095,7 @@ const fn unique_sample_literal(kind: FieldKind) -> &'static str {
         // convention for the same reason.
         FieldKind::References => "1",
         FieldKind::Bool => "TRUE",
-        FieldKind::F32 | FieldKind::F64 => "1.5",
+        FieldKind::F32 | FieldKind::F64 | FieldKind::Decimal { .. } => "1.5",
         FieldKind::Uuid => "'00000000-0000-0000-0000-000000000001'::uuid",
         FieldKind::NaiveDateTime => "'2024-01-01 00:00:00'::timestamp",
         FieldKind::DateTime => "'2024-01-01 00:00:00+00'::timestamptz",
@@ -3078,7 +3121,7 @@ const fn unique_sample_literal_variant(kind: FieldKind) -> &'static str {
         // that one must be a real seeded row's id, not an arbitrary literal.
         FieldKind::References => "2",
         FieldKind::Bool => "FALSE",
-        FieldKind::F32 | FieldKind::F64 => "2.5",
+        FieldKind::F32 | FieldKind::F64 | FieldKind::Decimal { .. } => "2.5",
         FieldKind::Uuid => "'00000000-0000-0000-0000-000000000002'::uuid",
         FieldKind::NaiveDateTime => "'2024-01-02 00:00:00'::timestamp",
         FieldKind::DateTime => "'2024-01-02 00:00:00+00'::timestamptz",

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -253,6 +253,12 @@ pub fn plan_scaffold_with_options(
             "{ version = \"0.20\", features = [\"derive\"] }",
         ));
     }
+    // Not re-checked for a missing Diesel feature here: `plan` above *is*
+    // the `plan_model_with_options` plan (reused, not merged), and that call
+    // already ran `warn_if_existing_dep_missing_feature` for `rust_decimal`
+    // when it built its own decimal-conditional dep — re-running the same
+    // check against the same (still on-disk, pre-`execute()`) Cargo.toml
+    // here would just duplicate the warning.
     if fields.iter().any(|f| f.kind.is_decimal()) {
         combined.push((
             "rust_decimal",
@@ -5899,5 +5905,25 @@ async fn main() {
             sql.contains("weight) VALUES ('__not_a_real_variant__', 0.1)"),
             "expected a scale-fitting 0.1 literal for NUMERIC(1,1), got: {sql}"
         );
+    }
+
+    #[test]
+    fn scaffold_decimal_field_warns_when_existing_rust_decimal_dep_lacks_diesel_feature() {
+        let tmp = project_with_main(default_main());
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname=\"x\"\n\n[dependencies]\nrust_decimal = \"1\"\n",
+        )
+        .unwrap();
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Product",
+            &["price:decimal".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert_eq!(plan.warnings.len(), 1, "warnings: {:?}", plan.warnings);
+        assert!(plan.warnings[0].contains("rust_decimal"));
+        assert!(plan.warnings[0].contains("db-diesel2-postgres"));
     }
 }

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -151,7 +151,7 @@ pub fn create_table_sql_with_metadata_and_id(
             sql,
             "    {} {} {}",
             f.name,
-            f.sql_type(),
+            f.sql_column_type(),
             f.sql_nullability()
         );
         if let Some(target) = f.reference_table() {
@@ -457,7 +457,7 @@ pub fn add_columns_up_sql(table: &str, fields: &[Field], existing_schema: &str) 
             out,
             "ALTER TABLE {table} ADD COLUMN {} {} {}",
             f.name,
-            f.sql_type(),
+            f.sql_column_type(),
             f.sql_nullability()
         );
         if let Some(target) = f.reference_table() {
@@ -698,7 +698,7 @@ pub fn remove_columns_down_sql(table: &str, fields: &[Field], existing_schema: &
             out,
             "ALTER TABLE {table} ADD COLUMN {} {} {}",
             f.name,
-            f.sql_type(),
+            f.sql_column_type(),
             f.sql_nullability()
         );
         if let Some(target) = f.reference_table() {

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -309,6 +309,7 @@ enum Commands {
     ///   Uuid                         (UUID)
     ///   `NaiveDateTime`, `DateTime`      (TIMESTAMP, TIMESTAMPTZ)
     ///   `Vec<u8>`, Bytea               (BYTEA)
+    ///   decimal{precision,scale}     (NUMERIC, default {12,2})
     ///   Option<...>                  (any of the above, nullable)
     ///
     /// # Example

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -1285,14 +1285,22 @@ fn generated_job_cargo_checks() {
             "SendWelcomeEmail",
             "user_id:i64",
             "email:String",
+            "amount:decimal",
         ],
     );
 
-    // The generated Cargo.toml must include serde.
+    // The generated Cargo.toml must include serde and — since a `decimal`
+    // field is present — rust_decimal (issue #1038 PR review: job_deps
+    // previously omitted it, so the generated args struct referenced
+    // rust_decimal::Decimal without the crate ever being declared).
     let cargo_toml = fs::read_to_string(project.join("Cargo.toml")).unwrap();
     assert!(
         cargo_toml.contains("serde"),
         "Cargo.toml must include serde after generate job"
+    );
+    assert!(
+        cargo_toml.contains("rust_decimal"),
+        "Cargo.toml must include rust_decimal after generate job with a decimal field"
     );
 
     // The generator must have created the expected files.

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -259,7 +259,7 @@ fn generate_model_force_overwrites() {
 fn generate_model_invalid_field_lists_supported_set() {
     let (_tmp, project) = fresh_project("badtype-app");
     let (_, stderr, code) =
-        run_autumn_failing(&project, &["generate", "model", "Post", "price:Decimal"]);
+        run_autumn_failing(&project, &["generate", "model", "Post", "price:Money"]);
     assert_eq!(code, Some(1));
     assert!(stderr.contains("unsupported type"));
     assert!(stderr.contains("Supported:"));
@@ -1161,6 +1161,22 @@ fn generate_help_documents_field_dsl() {
 }
 
 #[test]
+fn generate_help_documents_decimal_field_type() {
+    // AC4 (issue #1038): `decimal` must be discoverable from `--help`, not
+    // just accepted silently by the parser.
+    let tmp = tempfile::tempdir().unwrap();
+    let autumn_bin = env!("CARGO_BIN_EXE_autumn");
+    let output = Command::new(autumn_bin)
+        .args(["generate", "--help"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("decimal"), "got: {stdout}");
+    assert!(stdout.contains("NUMERIC"), "got: {stdout}");
+}
+
+#[test]
 fn generate_model_help_shows_example() {
     let tmp = tempfile::tempdir().unwrap();
     let autumn_bin = env!("CARGO_BIN_EXE_autumn");
@@ -1213,6 +1229,8 @@ fn generated_scaffold_cargo_checks() {
             "token:Option<Uuid>",
             "status:enum{draft,published,archived}",
             "mood:Option<enum{happy,sad}>",
+            "price:decimal{10,2}",
+            "balance:Option<decimal>",
         ],
     );
 
@@ -1227,6 +1245,7 @@ fn generated_scaffold_cargo_checks() {
         "serde_json",
         "serde_urlencoded",
         "url",
+        "rust_decimal",
     ] {
         assert!(
             cargo_toml_after.contains(&format!("{dep} =")),


### PR DESCRIPTION
`price:decimal` (default NUMERIC(12,2)) or `price:decimal{10,2}` for an
explicit precision/scale now generates an exact-precision Postgres
NUMERIC column, a rust_decimal::Decimal #[model] field, and a
Numeric/Nullable<Numeric> Diesel schema token, so money-shaped fields
no longer have to fall back to f64 and its binary-float rounding.

Both decimal/Decimal casings are accepted (consistent with
Attachment/attachment), it composes with Option<...> and :unique, and
the generated new/edit form renders inputmode="decimal" with a
step sized to the column's scale. The rust_decimal dependency (with
db-diesel2-postgres and serde features) is added to the generated
app's Cargo.toml only when a decimal field is present.

The DSL's own unknown_type_rejected test previously used price:Decimal
as its canonical rejected example; it and the equivalent generate.rs/
model.rs tests now use price:Money instead, since Decimal is accepted.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S5rbbnokRCUK85JoptuNfs