### PR TITLE
Add failing tests for tabs widget (red phase, #1316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `#panel-id`) and matching `role="tabpanel"` sections (`aria-labelledby`,
   `tabindex="0"`). Switching is pure CSS: `input.css` shows the panel whose
   `id` matches the URL's `:target` fragment, with a `:has()`-based fallback
-  that shows the first panel when nothing is targeted, so a 3-tab
-  detail/settings view needs zero hand-written JS or CSS and under 10 lines
-  of Maud. Tab/panel ids and labels are HTML-escaped by Maud; panel bodies
-  are pre-rendered `Markup` the caller owns, same as `card`'s `body`
-  parameter. See `docs/guide/tabs.md` for a full example.
+  that shows the first panel when nothing is targeted (and an
+  `@supports not selector(:has(a))` rule so browsers without `:has()`
+  degrade to "first panel always shown" instead of a blank widget), so a
+  3-tab detail/settings view needs zero hand-written JS or CSS and under 10
+  lines of Maud. The active-tab highlight also tracks whichever panel is
+  actually `:target`-ed, via position-based `:has()`/`:nth-child()` CSS
+  (covering the first 6 tabs). Tab/panel ids and labels are HTML-escaped by
+  Maud; panel bodies are pre-rendered `Markup` the caller owns, same as
+  `card`'s `body` parameter. Panel ids must be unique across the whole page
+  if more than one `tabs()` widget is rendered; `aria-selected` reflects
+  only the server's default selection, since the server never sees the URL
+  fragment. See `docs/guide/tabs.md` for a full example and these caveats.
 
 - **views:** `modal`/`confirm_action` widgets — an accessible, testable
   confirm for destructive actions (#1233). `modal(id, title, body, config)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **views:** `tabs` widget — a no-JavaScript panel switcher for detail and
+  settings views (#1316). `tabs(id, panels)` takes an ordered
+  `&[(id, label, maud::Markup)]` list and renders an `autumn-tabs` root with
+  a `role="tablist"` strip of `role="tab"` anchors (each linking to
+  `#panel-id`) and matching `role="tabpanel"` sections (`aria-labelledby`,
+  `tabindex="0"`). Switching is pure CSS: `input.css` shows the panel whose
+  `id` matches the URL's `:target` fragment, with a `:has()`-based fallback
+  that shows the first panel when nothing is targeted, so a 3-tab
+  detail/settings view needs zero hand-written JS or CSS and under 10 lines
+  of Maud. Tab/panel ids and labels are HTML-escaped by Maud; panel bodies
+  are pre-rendered `Markup` the caller owns, same as `card`'s `body`
+  parameter. See `docs/guide/tabs.md` for a full example.
+
 - **views:** `modal`/`confirm_action` widgets — an accessible, testable
   confirm for destructive actions (#1233). `modal(id, title, body, config)`
   renders a native `<dialog>` (`aria-modal="true"`, `aria-labelledby`, a body

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -186,7 +186,7 @@ pub use crate::widgets::{
     active_search_empty_state, active_search_input, active_search_results,
     autocomplete_empty_state, autocomplete_input, autocomplete_option, breadcrumb, card,
     confirm_action, data_table, hero, modal, modal_close_button, modal_trigger, nav_bar, nav_link,
-    nav_link_matched, property_list, stat_card,
+    nav_link_matched, property_list, stat_card, tabs,
 };
 
 // ── Link helpers ─────────────────────────────────────────────────

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -2709,6 +2709,20 @@ pub fn confirm_action(
 /// ambiguous. Prefix panel ids per widget instance (e.g. `"post-overview"`,
 /// `"related-overview"`) if more than one `tabs()` appears on a page.
 ///
+/// # Nesting a `tabs()` widget inside another `tabs()` panel
+///
+/// This is supported for panel *visibility*: `input.css` reveals the whole
+/// ancestor chain down to a deep-linked inner panel, so content nested
+/// inside any outer panel (not just the outer widget's default one) is
+/// reachable via its own fragment. The outer widget's *active-tab visual
+/// highlight*, however, can only be synced when the shown outer panel is
+/// itself the direct `:target` — CSS forbids nesting `:has()` inside
+/// another `:has()`, so a panel that's shown only because it *contains* a
+/// nested target (rather than being the target itself) can't be
+/// attributed to a specific outer tab position. In that case no outer tab
+/// is highlighted as active (a graceful degrade — no tab looks active,
+/// rather than the wrong one looking active).
+///
 /// # Example
 ///
 /// ```rust

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -2658,10 +2658,13 @@ pub fn confirm_action(
 /// from an ordered list of `(id, label, panel_body)` tuples.
 ///
 /// Switching is pure CSS: each tab is an `<a href="#panel-id">` and each
-/// panel is targeted by `:target` in `autumn-tabs.css`, so URL fragments
+/// panel is targeted by `:target` in `input.css`, so URL fragments
 /// (`/settings#security`) select a tab with zero JavaScript. The first
 /// panel additionally carries `autumn-tabs__panel--active` so a panel is
-/// always visible even when no fragment is present.
+/// always visible even when no fragment is present, and the active-tab
+/// highlight tracks the actually-`:target`ed panel by position for up to
+/// the first 6 tabs (see `input.css` — ids are arbitrary caller strings, so
+/// this can only be done positionally in a shared stylesheet).
 ///
 /// # CSS hooks
 ///
@@ -2681,13 +2684,30 @@ pub fn confirm_action(
 /// panel carries `role="tabpanel"`, `aria-labelledby` pointing at its tab's
 /// `id`, and `tabindex="0"` so it can receive keyboard focus directly.
 ///
+/// `aria-selected` reflects the *server's default selection* (the first
+/// tab) only. The server never sees the URL fragment (fragments aren't
+/// sent in HTTP requests), so it cannot know which tab a client-side
+/// `:target` navigation actually landed on — correcting `aria-selected` on
+/// navigation would require JavaScript, which this widget deliberately has
+/// none of. This is a known, accepted limitation of fragment-based no-JS
+/// tabs: a screen reader always hears the first tab announced as
+/// "selected", even when a different panel is what's visually shown.
+///
 /// # Panel `id`s
 ///
 /// A panel's `id` is the raw id from its tuple (not namespaced by `id`) so
 /// it can be targeted directly by a URL fragment. Each tab's own element
-/// `id` is `"{id}-tab-{panel_id}"`. Duplicate panel ids are rendered as
-/// given — the caller is responsible for uniqueness if fragment targeting
-/// of a specific panel matters.
+/// `id` is `"{id}-tab-{panel_id}"`. Duplicate panel ids within one call are
+/// rendered as given — the caller is responsible for uniqueness if
+/// fragment targeting of a specific panel matters.
+///
+/// **Rendering more than one `tabs()` widget on the same page:** panel ids
+/// must be unique across the *entire page*, not just within one call —
+/// two different `tabs()` calls that both use a panel id like `"overview"`
+/// will emit two elements with `id="overview"`, which is invalid duplicate-id
+/// HTML and makes `:target`/`aria-controls`/`aria-labelledby` lookups
+/// ambiguous. Prefix panel ids per widget instance (e.g. `"post-overview"`,
+/// `"related-overview"`) if more than one `tabs()` appears on a page.
 ///
 /// # Example
 ///
@@ -2708,29 +2728,31 @@ pub fn confirm_action(
 #[cfg(feature = "maud")]
 #[must_use]
 pub fn tabs(id: &str, panels: &[(&str, &str, maud::Markup)]) -> maud::Markup {
+    let tab_ids: Vec<String> = panels
+        .iter()
+        .map(|(panel_id, _, _)| format!("{id}-tab-{panel_id}"))
+        .collect();
     maud::html! {
         div id=(id) class="autumn-tabs" {
             div class="autumn-tabs__list" role="tablist" {
                 @for (i, (panel_id, label, _)) in panels.iter().enumerate() {
-                    @let tab_id = format!("{id}-tab-{panel_id}");
                     @let tab_class = merge_class(
                         "autumn-tabs__tab",
                         (i == 0).then_some("autumn-tabs__tab--active"),
                     );
-                    a id=(tab_id) class=(tab_class) role="tab" href=(format!("#{panel_id}"))
+                    a id=(tab_ids[i]) class=(tab_class) role="tab" href=(format!("#{panel_id}"))
                         aria-controls=(panel_id) aria-selected=(if i == 0 { "true" } else { "false" }) {
                         (label)
                     }
                 }
             }
             @for (i, (panel_id, _, body)) in panels.iter().enumerate() {
-                @let tab_id = format!("{id}-tab-{panel_id}");
                 @let panel_class = merge_class(
                     "autumn-tabs__panel",
                     (i == 0).then_some("autumn-tabs__panel--active"),
                 );
                 section id=(panel_id) class=(panel_class) role="tabpanel"
-                    aria-labelledby=(tab_id) tabindex="0" {
+                    aria-labelledby=(tab_ids[i]) tabindex="0" {
                     (body)
                 }
             }

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -2651,6 +2651,92 @@ pub fn confirm_action(
     }
 }
 
+// ── tabs ─────────────────────────────────────────────────────────────────
+
+/// Render a no-JavaScript tabs widget: a `tablist` strip plus its panels,
+/// from an ordered list of `(id, label, panel_body)` tuples.
+///
+/// Switching is pure CSS: each tab is an `<a href="#panel-id">` and each
+/// panel is targeted by `:target` in `autumn-tabs.css`, so URL fragments
+/// (`/settings#security`) select a tab with zero JavaScript. The first
+/// panel additionally carries `autumn-tabs__panel--active` so a panel is
+/// always visible even when no fragment is present.
+///
+/// # CSS hooks
+///
+/// | Selector | Element |
+/// |---|---|
+/// | `.autumn-tabs` | Root wrapper |
+/// | `.autumn-tabs__list` | Tab strip (`role="tablist"`) |
+/// | `.autumn-tabs__tab` | Individual tab link |
+/// | `.autumn-tabs__tab--active` | The initially-selected tab |
+/// | `.autumn-tabs__panel` | Individual panel |
+/// | `.autumn-tabs__panel--active` | The initially-visible panel |
+///
+/// # Accessibility
+///
+/// The tab strip carries `role="tablist"`; each tab carries `role="tab"`,
+/// `aria-controls` pointing at its panel's `id`, and `aria-selected`; each
+/// panel carries `role="tabpanel"`, `aria-labelledby` pointing at its tab's
+/// `id`, and `tabindex="0"` so it can receive keyboard focus directly.
+///
+/// # Panel `id`s
+///
+/// A panel's `id` is the raw id from its tuple (not namespaced by `id`) so
+/// it can be targeted directly by a URL fragment. Each tab's own element
+/// `id` is `"{id}-tab-{panel_id}"`. Duplicate panel ids are rendered as
+/// given — the caller is responsible for uniqueness if fragment targeting
+/// of a specific panel matters.
+///
+/// # Example
+///
+/// ```rust
+/// use autumn_web::widgets::tabs;
+/// use maud::html;
+///
+/// let panels = [
+///     ("profile", "Profile", html! { p { "Profile settings" } }),
+///     ("security", "Security", html! { p { "Security settings" } }),
+///     ("billing", "Billing", html! { p { "Billing settings" } }),
+/// ];
+/// let widget = tabs("settings-tabs", &panels).into_string();
+/// assert!(widget.contains(r#"role="tablist""#));
+/// assert!(widget.contains(r#"aria-controls="security""#));
+/// assert!(widget.contains(r##"href="#billing""##));
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn tabs(id: &str, panels: &[(&str, &str, maud::Markup)]) -> maud::Markup {
+    maud::html! {
+        div id=(id) class="autumn-tabs" {
+            div class="autumn-tabs__list" role="tablist" {
+                @for (i, (panel_id, label, _)) in panels.iter().enumerate() {
+                    @let tab_id = format!("{id}-tab-{panel_id}");
+                    @let tab_class = merge_class(
+                        "autumn-tabs__tab",
+                        (i == 0).then_some("autumn-tabs__tab--active"),
+                    );
+                    a id=(tab_id) class=(tab_class) role="tab" href=(format!("#{panel_id}"))
+                        aria-controls=(panel_id) aria-selected=(if i == 0 { "true" } else { "false" }) {
+                        (label)
+                    }
+                }
+            }
+            @for (i, (panel_id, _, body)) in panels.iter().enumerate() {
+                @let tab_id = format!("{id}-tab-{panel_id}");
+                @let panel_class = merge_class(
+                    "autumn-tabs__panel",
+                    (i == 0).then_some("autumn-tabs__panel--active"),
+                );
+                section id=(panel_id) class=(panel_class) role="tabpanel"
+                    aria-labelledby=(tab_id) tabindex="0" {
+                    (body)
+                }
+            }
+        }
+    }
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 #[cfg(all(test, feature = "maud"))]

--- a/autumn/src/widgets.rs
+++ b/autumn/src/widgets.rs
@@ -16,6 +16,7 @@
 //! | `hero` | Landing-page banner: headline, optional subtitle, and CTAs |
 //! | `nav_link` | Navigation anchor, auto-marked active + `aria-current` |
 //! | `nav_bar` | Top-bar/sidebar `<nav>` landmark: brand, links, dropdowns, responsive toggle |
+//! | `tabs` | No-JS `tablist`/`tab`/`tabpanel` switcher with `:target` deep-linking |
 //!
 //! # Interactive / search widgets
 //!

--- a/autumn/templates/static/css/input.css
+++ b/autumn/templates/static/css/input.css
@@ -346,14 +346,14 @@
 .autumn-tabs__list {
     display: flex;
     gap: 0.25rem;
-    border-bottom: 1px solid #e5e7eb;
+    border-bottom: 1px solid var(--autumn-border, #e5e7eb);
     margin-bottom: 1rem;
 }
 
 .autumn-tabs__tab {
     padding: 0.5rem 1rem;
     margin-bottom: -1px;
-    color: #6b7280;
+    color: var(--autumn-text-muted, #6b7280);
     font-weight: 500;
     font-size: 0.9375rem;
     text-decoration: none;
@@ -361,11 +361,11 @@
 }
 
 .autumn-tabs__tab:hover {
-    color: #111827;
+    color: var(--autumn-text, #111827);
 }
 
 .autumn-tabs__tab--active {
-    color: #111827;
+    color: var(--autumn-text, #111827);
     border-bottom-color: var(--autumn-primary, #2563eb);
 }
 
@@ -383,4 +383,38 @@
    this widget, so a panel is always visible. */
 .autumn-tabs:not(:has(.autumn-tabs__panel:target)) .autumn-tabs__panel--active {
     display: block;
+}
+
+/* Graceful degradation for browsers that support `:target` (universal)
+   but not `:has()` (narrower support): the `:not(:has(...))` fallback
+   above never applies, so without this rule every panel would stay
+   `display: none` on first load. Unconditionally showing the first panel
+   here is a strictly better failure mode than a blank widget — in these
+   browsers, navigating to a different panel's fragment may show that
+   panel alongside the first rather than replacing it. */
+@supports not selector(:has(a)) {
+    .autumn-tabs__panel--active {
+        display: block;
+    }
+}
+
+/* Sync the active-tab highlight with whichever panel is actually
+   `:target`-ed. Panel/tab ids are arbitrary caller strings, so a shared
+   stylesheet can't match them by value — match by position instead, for
+   the first 6 tabs. Widgets with more tabs keep switching panels
+   correctly; only the active-tab highlight past the 6th degrades to
+   showing no tab as active. */
+.autumn-tabs:has(.autumn-tabs__panel:target) .autumn-tabs__tab--active {
+    color: var(--autumn-text-muted, #6b7280);
+    border-bottom-color: transparent;
+}
+
+.autumn-tabs:has(.autumn-tabs__panel:nth-of-type(1):target) .autumn-tabs__list .autumn-tabs__tab:nth-child(1),
+.autumn-tabs:has(.autumn-tabs__panel:nth-of-type(2):target) .autumn-tabs__list .autumn-tabs__tab:nth-child(2),
+.autumn-tabs:has(.autumn-tabs__panel:nth-of-type(3):target) .autumn-tabs__list .autumn-tabs__tab:nth-child(3),
+.autumn-tabs:has(.autumn-tabs__panel:nth-of-type(4):target) .autumn-tabs__list .autumn-tabs__tab:nth-child(4),
+.autumn-tabs:has(.autumn-tabs__panel:nth-of-type(5):target) .autumn-tabs__list .autumn-tabs__tab:nth-child(5),
+.autumn-tabs:has(.autumn-tabs__panel:nth-of-type(6):target) .autumn-tabs__list .autumn-tabs__tab:nth-child(6) {
+    color: var(--autumn-text, #111827);
+    border-bottom-color: var(--autumn-primary, #2563eb);
 }

--- a/autumn/templates/static/css/input.css
+++ b/autumn/templates/static/css/input.css
@@ -387,20 +387,28 @@
     display: block;
 }
 
-/* Fallback: show the first panel only when NONE of this widget's OWN
-   panels are already effectively shown — i.e. no panel anywhere in this
-   widget's subtree (its own panels, or a nested tabs() widget's panels) is
-   itself `:target`. The `:has()` argument here is intentionally UNSCOPED
-   (no `>`, checked at any depth): CSS forbids nesting `:has()` inside
-   another `:has()`, so the `:has(:target)` half of the rule above can't be
-   tested from inside this `:has()` directly — but any `:target` anywhere
-   in the subtree, direct or nested, is exactly the signal that some panel
-   is already shown by one half of the rule above or the other, so testing
+/* Fallback: show the first panel only when NOTHING inside this widget is
+   currently targeted — checked as bare `:target` (any element at all, not
+   just `.autumn-tabs__panel`), since the fragment can target an arbitrary
+   element inside a panel's body (a heading, an anchor) and not just a
+   panel or a nested tabs() widget's panel; any such target means some
+   panel of ours is already shown by the rule above, so the default must
+   be suppressed. (An earlier version checked only
+   `.autumn-tabs__panel:target`, which missed body-anchor targets: the
+   panel containing the anchor would correctly show via `:has(:target)`
+   above, but this fallback wouldn't detect anything was targeted and
+   would show the default panel *too* — two panels visible for one
+   deep link.) The `:has()` argument here is intentionally UNSCOPED (no
+   `>`, checked at any depth): CSS forbids nesting `:has()` inside another
+   `:has()`, so the `:has(:target)` half of the rule above can't be tested
+   from inside this `:has()` directly — but any `:target` anywhere in the
+   subtree, direct or nested, is exactly the signal that some panel is
+   already shown by one half of the rule above or the other, so testing
    for plain `:target` gives the same answer without needing to nest. The
    *consequent* (`> .autumn-tabs__panel--active`) IS scoped to direct
    children, so this rule only ever reveals THIS widget's own default
    panel, never a nested widget's. */
-.autumn-tabs:not(:has(.autumn-tabs__panel:target)) > .autumn-tabs__panel--active {
+.autumn-tabs:not(:has(:target)) > .autumn-tabs__panel--active {
     display: block;
 }
 
@@ -422,15 +430,18 @@
    match them by value — match by position instead, for the first 6 tabs.
    Widgets with more tabs keep switching panels correctly; only the
    active-tab highlight past the 6th degrades to showing no tab as active.
-   The suppression rule below uses the same unscoped-argument /
-   scoped-consequent pattern as the panel fallback above, for the same
-   :has()-can't-nest-in-:has() reason. The per-tab rules that follow can
-   only match a panel that is ITSELF the direct `:target` — a panel
-   revealed only because it *contains* a nested target can't be attributed
-   to a specific tab position without nesting `:has()` inside `:has()`,
-   which CSS disallows, so in that case no tab gets highlighted (a graceful
-   degrade: no tab looks active, rather than the wrong one). */
-.autumn-tabs:has(.autumn-tabs__panel:target) > .autumn-tabs__list > .autumn-tabs__tab--active {
+   The suppression rule below checks bare `:target` (any element, matching
+   the panel-fallback reasoning above — the fragment can target an
+   arbitrary element inside a panel body, not just a panel), with the same
+   unscoped-argument / scoped-consequent pattern as the panel fallback,
+   for the same :has()-can't-nest-in-:has() reason. The per-tab rules that
+   follow can only match a panel that is ITSELF the direct `:target` — a
+   panel shown only because it *contains* a target (nested widget or plain
+   body anchor) can't be attributed to a specific tab position without
+   nesting `:has()` inside `:has()`, which CSS disallows, so in that case
+   no tab gets highlighted (a graceful degrade: no tab looks active,
+   rather than the wrong one). */
+.autumn-tabs:has(:target) > .autumn-tabs__list > .autumn-tabs__tab--active {
     color: var(--autumn-text-muted, #6b7280);
     border-bottom-color: transparent;
 }

--- a/autumn/templates/static/css/input.css
+++ b/autumn/templates/static/css/input.css
@@ -380,8 +380,13 @@
 }
 
 /* Fallback: show the first panel when no fragment targets any panel in
-   this widget, so a panel is always visible. */
-.autumn-tabs:not(:has(.autumn-tabs__panel:target)) .autumn-tabs__panel--active {
+   this widget, so a panel is always visible. Scoped to direct children
+   (`>`) throughout so a nested `tabs()` widget inside one of this widget's
+   own panels doesn't leak its `:target` state up to this `:has()` check —
+   without the `>` combinators, an inner tabs() widget's targeted panel
+   would make the outer widget think one of ITS OWN panels is targeted,
+   hiding the outer widget's default panel entirely. */
+.autumn-tabs:not(:has(> .autumn-tabs__panel:target)) > .autumn-tabs__panel--active {
     display: block;
 }
 
@@ -393,7 +398,7 @@
    browsers, navigating to a different panel's fragment may show that
    panel alongside the first rather than replacing it. */
 @supports not selector(:has(a)) {
-    .autumn-tabs__panel--active {
+    .autumn-tabs > .autumn-tabs__panel--active {
         display: block;
     }
 }
@@ -403,18 +408,21 @@
    stylesheet can't match them by value — match by position instead, for
    the first 6 tabs. Widgets with more tabs keep switching panels
    correctly; only the active-tab highlight past the 6th degrades to
-   showing no tab as active. */
-.autumn-tabs:has(.autumn-tabs__panel:target) .autumn-tabs__tab--active {
+   showing no tab as active. Scoped to direct children (`>`) throughout,
+   same reasoning as the fallback above: keeps a nested `tabs()` widget's
+   `:target` state from leaking into this widget's own tab highlighting,
+   and vice versa. */
+.autumn-tabs:has(> .autumn-tabs__panel:target) > .autumn-tabs__list > .autumn-tabs__tab--active {
     color: var(--autumn-text-muted, #6b7280);
     border-bottom-color: transparent;
 }
 
-.autumn-tabs:has(.autumn-tabs__panel:nth-of-type(1):target) .autumn-tabs__list .autumn-tabs__tab:nth-child(1),
-.autumn-tabs:has(.autumn-tabs__panel:nth-of-type(2):target) .autumn-tabs__list .autumn-tabs__tab:nth-child(2),
-.autumn-tabs:has(.autumn-tabs__panel:nth-of-type(3):target) .autumn-tabs__list .autumn-tabs__tab:nth-child(3),
-.autumn-tabs:has(.autumn-tabs__panel:nth-of-type(4):target) .autumn-tabs__list .autumn-tabs__tab:nth-child(4),
-.autumn-tabs:has(.autumn-tabs__panel:nth-of-type(5):target) .autumn-tabs__list .autumn-tabs__tab:nth-child(5),
-.autumn-tabs:has(.autumn-tabs__panel:nth-of-type(6):target) .autumn-tabs__list .autumn-tabs__tab:nth-child(6) {
+.autumn-tabs:has(> .autumn-tabs__panel:nth-of-type(1):target) > .autumn-tabs__list > .autumn-tabs__tab:nth-child(1),
+.autumn-tabs:has(> .autumn-tabs__panel:nth-of-type(2):target) > .autumn-tabs__list > .autumn-tabs__tab:nth-child(2),
+.autumn-tabs:has(> .autumn-tabs__panel:nth-of-type(3):target) > .autumn-tabs__list > .autumn-tabs__tab:nth-child(3),
+.autumn-tabs:has(> .autumn-tabs__panel:nth-of-type(4):target) > .autumn-tabs__list > .autumn-tabs__tab:nth-child(4),
+.autumn-tabs:has(> .autumn-tabs__panel:nth-of-type(5):target) > .autumn-tabs__list > .autumn-tabs__tab:nth-child(5),
+.autumn-tabs:has(> .autumn-tabs__panel:nth-of-type(6):target) > .autumn-tabs__list > .autumn-tabs__tab:nth-child(6) {
     color: var(--autumn-text, #111827);
     border-bottom-color: var(--autumn-primary, #2563eb);
 }

--- a/autumn/templates/static/css/input.css
+++ b/autumn/templates/static/css/input.css
@@ -340,3 +340,47 @@
     background-color: var(--autumn-danger-hover, #b91c1c);
     border-color: var(--autumn-danger-hover, #b91c1c);
 }
+
+/* ── Tabs (autumn-tabs) ──────────────────────────────────────────────────── */
+
+.autumn-tabs__list {
+    display: flex;
+    gap: 0.25rem;
+    border-bottom: 1px solid #e5e7eb;
+    margin-bottom: 1rem;
+}
+
+.autumn-tabs__tab {
+    padding: 0.5rem 1rem;
+    margin-bottom: -1px;
+    color: #6b7280;
+    font-weight: 500;
+    font-size: 0.9375rem;
+    text-decoration: none;
+    border-bottom: 2px solid transparent;
+}
+
+.autumn-tabs__tab:hover {
+    color: #111827;
+}
+
+.autumn-tabs__tab--active {
+    color: #111827;
+    border-bottom-color: var(--autumn-primary, #2563eb);
+}
+
+.autumn-tabs__panel {
+    display: none;
+}
+
+/* No-JS switching: a panel becomes visible when its id is the URL's
+   fragment (`:target`), so `#<tab-id>` deep-links a tab on page load. */
+.autumn-tabs__panel:target {
+    display: block;
+}
+
+/* Fallback: show the first panel when no fragment targets any panel in
+   this widget, so a panel is always visible. */
+.autumn-tabs:not(:has(.autumn-tabs__panel:target)) .autumn-tabs__panel--active {
+    display: block;
+}

--- a/autumn/templates/static/css/input.css
+++ b/autumn/templates/static/css/input.css
@@ -374,19 +374,33 @@
 }
 
 /* No-JS switching: a panel becomes visible when its id is the URL's
-   fragment (`:target`), so `#<tab-id>` deep-links a tab on page load. */
-.autumn-tabs__panel:target {
+   fragment (`:target`), OR when it contains — at any depth — a currently
+   `:target`-ed element. The second half reveals the whole ancestor chain
+   down to a panel deep-linked inside a *nested* `tabs()` widget (one
+   `tabs()` call rendered inside another's panel body): without it, the
+   ancestor panel that merely contains the nested widget would stay
+   `display: none` and hide the correctly-targeted inner panel along with
+   it, even though the inner panel's own `:target` rule matched. This half
+   is deliberately unscoped (no `>`) since the target may be arbitrarily
+   deep. */
+.autumn-tabs__panel:is(:target, :has(:target)) {
     display: block;
 }
 
-/* Fallback: show the first panel when no fragment targets any panel in
-   this widget, so a panel is always visible. Scoped to direct children
-   (`>`) throughout so a nested `tabs()` widget inside one of this widget's
-   own panels doesn't leak its `:target` state up to this `:has()` check —
-   without the `>` combinators, an inner tabs() widget's targeted panel
-   would make the outer widget think one of ITS OWN panels is targeted,
-   hiding the outer widget's default panel entirely. */
-.autumn-tabs:not(:has(> .autumn-tabs__panel:target)) > .autumn-tabs__panel--active {
+/* Fallback: show the first panel only when NONE of this widget's OWN
+   panels are already effectively shown — i.e. no panel anywhere in this
+   widget's subtree (its own panels, or a nested tabs() widget's panels) is
+   itself `:target`. The `:has()` argument here is intentionally UNSCOPED
+   (no `>`, checked at any depth): CSS forbids nesting `:has()` inside
+   another `:has()`, so the `:has(:target)` half of the rule above can't be
+   tested from inside this `:has()` directly — but any `:target` anywhere
+   in the subtree, direct or nested, is exactly the signal that some panel
+   is already shown by one half of the rule above or the other, so testing
+   for plain `:target` gives the same answer without needing to nest. The
+   *consequent* (`> .autumn-tabs__panel--active`) IS scoped to direct
+   children, so this rule only ever reveals THIS widget's own default
+   panel, never a nested widget's. */
+.autumn-tabs:not(:has(.autumn-tabs__panel:target)) > .autumn-tabs__panel--active {
     display: block;
 }
 
@@ -403,16 +417,20 @@
     }
 }
 
-/* Sync the active-tab highlight with whichever panel is actually
-   `:target`-ed. Panel/tab ids are arbitrary caller strings, so a shared
-   stylesheet can't match them by value — match by position instead, for
-   the first 6 tabs. Widgets with more tabs keep switching panels
-   correctly; only the active-tab highlight past the 6th degrades to
-   showing no tab as active. Scoped to direct children (`>`) throughout,
-   same reasoning as the fallback above: keeps a nested `tabs()` widget's
-   `:target` state from leaking into this widget's own tab highlighting,
-   and vice versa. */
-.autumn-tabs:has(> .autumn-tabs__panel:target) > .autumn-tabs__list > .autumn-tabs__tab--active {
+/* Sync the active-tab highlight with whichever panel is actually shown.
+   Panel/tab ids are arbitrary caller strings, so a shared stylesheet can't
+   match them by value — match by position instead, for the first 6 tabs.
+   Widgets with more tabs keep switching panels correctly; only the
+   active-tab highlight past the 6th degrades to showing no tab as active.
+   The suppression rule below uses the same unscoped-argument /
+   scoped-consequent pattern as the panel fallback above, for the same
+   :has()-can't-nest-in-:has() reason. The per-tab rules that follow can
+   only match a panel that is ITSELF the direct `:target` — a panel
+   revealed only because it *contains* a nested target can't be attributed
+   to a specific tab position without nesting `:has()` inside `:has()`,
+   which CSS disallows, so in that case no tab gets highlighted (a graceful
+   degrade: no tab looks active, rather than the wrong one). */
+.autumn-tabs:has(.autumn-tabs__panel:target) > .autumn-tabs__list > .autumn-tabs__tab--active {
     color: var(--autumn-text-muted, #6b7280);
     border-bottom-color: transparent;
 }

--- a/autumn/tests/widgets_tabs.rs
+++ b/autumn/tests/widgets_tabs.rs
@@ -117,7 +117,10 @@ mod tabs_tests {
     fn panel_aria_labelledby_matches_tab_id() {
         let panels = [("security", "Security", html! { p { "a" } })];
         let html = tabs("settings-tabs", &panels).into_string();
-        assert!(html.contains(r#"id="settings-tabs-tab-security""#), "{html}");
+        assert!(
+            html.contains(r#"id="settings-tabs-tab-security""#),
+            "{html}"
+        );
         assert!(
             html.contains(r#"aria-labelledby="settings-tabs-tab-security""#),
             "{html}"
@@ -178,11 +181,7 @@ mod tabs_tests {
 
     #[test]
     fn label_html_is_escaped() {
-        let panels = [(
-            "overview",
-            "<script>alert(1)</script>",
-            html! { p { "a" } },
-        )];
+        let panels = [("overview", "<script>alert(1)</script>", html! { p { "a" } })];
         let html = tabs("post-tabs", &panels).into_string();
         assert!(html.contains("&lt;script&gt;"), "{html}");
         assert!(!html.contains("<script>alert"), "{html}");
@@ -193,7 +192,10 @@ mod tabs_tests {
         let panels = [("a\"b", "Label", html! { p { "x" } })];
         let html = tabs("post-tabs", &panels).into_string();
         assert!(!html.contains(r#"id="a"b""#), "{html}");
-        assert!(html.contains("a&quot;b") || html.contains("a%22b"), "{html}");
+        assert!(
+            html.contains("a&quot;b") || html.contains("a%22b"),
+            "{html}"
+        );
     }
 
     // ── empty list ──────────────────────────────────────────────────────
@@ -234,7 +236,11 @@ mod test_client_integration {
     #[get("/posts/{id}")]
     async fn show_post(Path(id): Path<i64>) -> Markup {
         let panels = [
-            ("overview", "Overview", html! { p { "Post " (id) " overview" } }),
+            (
+                "overview",
+                "Overview",
+                html! { p { "Post " (id) " overview" } },
+            ),
             ("comments", "Comments", html! { p { "Comments for " (id) } }),
             ("activity", "Activity", html! { p { "Activity for " (id) } }),
         ];
@@ -254,10 +260,6 @@ mod test_client_integration {
             .assert_selector(r#"[role="tablist"]"#)
             .assert_selector(r#"[role="tab"]"#)
             .assert_selector(r#"[role="tabpanel"]"#)
-            .assert_attr(
-                r##"a[href="#comments"]"##,
-                "aria-controls",
-                "comments",
-            );
+            .assert_attr(r##"a[href="#comments"]"##, "aria-controls", "comments");
     }
 }

--- a/autumn/tests/widgets_tabs.rs
+++ b/autumn/tests/widgets_tabs.rs
@@ -1,0 +1,263 @@
+//! Tests for the `tabs` widget (issue #1316).
+//!
+//! Run with `cargo test --test widgets_tabs`.
+
+#![allow(clippy::must_use_candidate)]
+
+#[cfg(feature = "maud")]
+mod tabs_tests {
+    use autumn_web::widgets::tabs;
+    use maud::html;
+
+    // ── structure ───────────────────────────────────────────────────────
+
+    #[test]
+    fn renders_root_container_with_id_and_class() {
+        let panels = [("overview", "Overview", html! { p { "a" } })];
+        let html = tabs("post-tabs", &panels).into_string();
+        assert!(html.contains(r#"id="post-tabs""#), "{html}");
+        assert!(html.contains(r#"class="autumn-tabs""#), "{html}");
+    }
+
+    #[test]
+    fn renders_tablist_role() {
+        let panels = [("overview", "Overview", html! { p { "a" } })];
+        let html = tabs("post-tabs", &panels).into_string();
+        assert!(html.contains(r#"role="tablist""#), "{html}");
+        assert!(html.contains("autumn-tabs__list"), "{html}");
+    }
+
+    #[test]
+    fn renders_n_panels_and_n_tabs() {
+        let panels = [
+            ("overview", "Overview", html! { p { "Overview body" } }),
+            ("comments", "Comments", html! { p { "Comments body" } }),
+            ("activity", "Activity", html! { p { "Activity body" } }),
+        ];
+        let html = tabs("post-tabs", &panels).into_string();
+        assert_eq!(html.matches(r#"role="tab""#).count(), 3, "{html}");
+        assert_eq!(html.matches(r#"role="tabpanel""#).count(), 3, "{html}");
+        assert!(html.contains("Overview"), "{html}");
+        assert!(html.contains("Comments"), "{html}");
+        assert!(html.contains("Activity"), "{html}");
+        assert!(html.contains("Overview body"), "{html}");
+        assert!(html.contains("Comments body"), "{html}");
+        assert!(html.contains("Activity body"), "{html}");
+    }
+
+    #[test]
+    fn tabs_use_semantic_class_names() {
+        let panels = [("overview", "Overview", html! { p { "a" } })];
+        let html = tabs("post-tabs", &panels).into_string();
+        assert!(html.contains("autumn-tabs__tab"), "{html}");
+        assert!(html.contains("autumn-tabs__panel"), "{html}");
+    }
+
+    // ── active state ────────────────────────────────────────────────────
+
+    #[test]
+    fn first_tab_is_selected_by_default() {
+        let panels = [
+            ("overview", "Overview", html! { p { "a" } }),
+            ("comments", "Comments", html! { p { "b" } }),
+        ];
+        let html = tabs("post-tabs", &panels).into_string();
+        assert_eq!(html.matches("aria-selected=\"true\"").count(), 1, "{html}");
+        assert_eq!(html.matches("aria-selected=\"false\"").count(), 1, "{html}");
+    }
+
+    #[test]
+    fn exactly_one_active_tab_and_one_active_panel() {
+        let panels = [
+            ("overview", "Overview", html! { p { "a" } }),
+            ("comments", "Comments", html! { p { "b" } }),
+            ("activity", "Activity", html! { p { "c" } }),
+        ];
+        let html = tabs("post-tabs", &panels).into_string();
+        assert_eq!(
+            html.matches("autumn-tabs__tab--active").count(),
+            1,
+            "{html}"
+        );
+        assert_eq!(
+            html.matches("autumn-tabs__panel--active").count(),
+            1,
+            "{html}"
+        );
+    }
+
+    #[test]
+    fn first_panel_and_tab_carry_active_class() {
+        let panels = [
+            ("overview", "Overview", html! { p { "a" } }),
+            ("comments", "Comments", html! { p { "b" } }),
+        ];
+        let html = tabs("post-tabs", &panels).into_string();
+        // First tab's markup (contains "Overview") should be the one with --active.
+        let first_tab_start = html.find("Overview").unwrap();
+        let preceding = &html[..first_tab_start];
+        let last_tag_start = preceding.rfind('<').unwrap();
+        assert!(
+            preceding[last_tag_start..].contains("autumn-tabs__tab--active"),
+            "{html}"
+        );
+    }
+
+    // ── ARIA wiring ─────────────────────────────────────────────────────
+
+    #[test]
+    fn tab_aria_controls_matches_panel_id() {
+        let panels = [("security", "Security", html! { p { "a" } })];
+        let html = tabs("settings-tabs", &panels).into_string();
+        assert!(html.contains(r#"aria-controls="security""#), "{html}");
+        assert!(html.contains(r#"id="security""#), "{html}");
+    }
+
+    #[test]
+    fn panel_aria_labelledby_matches_tab_id() {
+        let panels = [("security", "Security", html! { p { "a" } })];
+        let html = tabs("settings-tabs", &panels).into_string();
+        assert!(html.contains(r#"id="settings-tabs-tab-security""#), "{html}");
+        assert!(
+            html.contains(r#"aria-labelledby="settings-tabs-tab-security""#),
+            "{html}"
+        );
+    }
+
+    #[test]
+    fn panels_have_tabindex_zero() {
+        let panels = [("security", "Security", html! { p { "a" } })];
+        let html = tabs("settings-tabs", &panels).into_string();
+        assert!(html.contains(r#"tabindex="0""#), "{html}");
+    }
+
+    #[test]
+    fn panels_have_role_tabpanel_and_tabs_have_role_tab() {
+        let panels = [("security", "Security", html! { p { "a" } })];
+        let html = tabs("settings-tabs", &panels).into_string();
+        assert!(html.contains(r#"role="tab""#), "{html}");
+        assert!(html.contains(r#"role="tabpanel""#), "{html}");
+    }
+
+    // ── deep-linking ────────────────────────────────────────────────────
+
+    #[test]
+    fn tab_href_points_at_raw_panel_id_fragment() {
+        let panels = [("billing", "Billing", html! { p { "a" } })];
+        let html = tabs("settings-tabs", &panels).into_string();
+        assert!(html.contains(r##"href="#billing""##), "{html}");
+    }
+
+    #[test]
+    fn panel_id_is_raw_tuple_id_for_fragment_targeting() {
+        let panels = [("billing", "Billing", html! { p { "a" } })];
+        let html = tabs("settings-tabs", &panels).into_string();
+        // The panel element itself must carry id="billing" (not namespaced)
+        // so `#billing` in the URL can :target it directly.
+        assert!(html.contains(r#"id="billing""#), "{html}");
+    }
+
+    // ── no-JS ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn no_script_tag_emitted() {
+        let panels = [("overview", "Overview", html! { p { "a" } })];
+        let html = tabs("post-tabs", &panels).into_string();
+        assert!(!html.contains("<script"), "{html}");
+    }
+
+    #[test]
+    fn no_inline_event_handlers_or_htmx_attrs() {
+        let panels = [("overview", "Overview", html! { p { "a" } })];
+        let html = tabs("post-tabs", &panels).into_string();
+        assert!(!html.contains("onclick"), "{html}");
+        assert!(!html.contains("hx-"), "{html}");
+    }
+
+    // ── security / XSS ──────────────────────────────────────────────────
+
+    #[test]
+    fn label_html_is_escaped() {
+        let panels = [(
+            "overview",
+            "<script>alert(1)</script>",
+            html! { p { "a" } },
+        )];
+        let html = tabs("post-tabs", &panels).into_string();
+        assert!(html.contains("&lt;script&gt;"), "{html}");
+        assert!(!html.contains("<script>alert"), "{html}");
+    }
+
+    #[test]
+    fn id_containing_quote_does_not_break_out_of_attribute() {
+        let panels = [("a\"b", "Label", html! { p { "x" } })];
+        let html = tabs("post-tabs", &panels).into_string();
+        assert!(!html.contains(r#"id="a"b""#), "{html}");
+        assert!(html.contains("a&quot;b") || html.contains("a%22b"), "{html}");
+    }
+
+    // ── empty list ──────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_panel_list_renders_container_without_panic() {
+        let panels: [(&str, &str, maud::Markup); 0] = [];
+        let html = tabs("post-tabs", &panels).into_string();
+        assert!(html.contains(r#"class="autumn-tabs""#), "{html}");
+        assert!(!html.contains(r#"role="tab""#), "{html}");
+        assert!(!html.contains(r#"role="tabpanel""#), "{html}");
+    }
+
+    // ── duplicate ids ───────────────────────────────────────────────────
+
+    #[test]
+    fn duplicate_panel_ids_render_both_without_panic() {
+        let panels = [
+            ("dup", "First", html! { p { "first body" } }),
+            ("dup", "Second", html! { p { "second body" } }),
+        ];
+        let html = tabs("post-tabs", &panels).into_string();
+        assert_eq!(html.matches(r#"role="tabpanel""#).count(), 2, "{html}");
+        assert!(html.contains("first body"), "{html}");
+        assert!(html.contains("second body"), "{html}");
+    }
+}
+
+// ── TestClient integration: markup fully present in the response body ─────
+
+#[cfg(feature = "maud")]
+mod test_client_integration {
+    use autumn_web::prelude::*;
+    use autumn_web::test::TestApp;
+    use autumn_web::widgets::tabs;
+    use maud::html;
+
+    #[get("/posts/{id}")]
+    async fn show_post(Path(id): Path<i64>) -> Markup {
+        let panels = [
+            ("overview", "Overview", html! { p { "Post " (id) " overview" } }),
+            ("comments", "Comments", html! { p { "Comments for " (id) } }),
+            ("activity", "Activity", html! { p { "Activity for " (id) } }),
+        ];
+        html! {
+            h1 { "Post " (id) }
+            (tabs("post-tabs", &panels))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_client_can_assert_tabs_structure() {
+        let client = TestApp::new().routes(routes![show_post]).build();
+
+        let resp = client.get("/posts/42").send().await;
+        resp.assert_ok()
+            .assert_selector("div.autumn-tabs")
+            .assert_selector(r#"[role="tablist"]"#)
+            .assert_selector(r#"[role="tab"]"#)
+            .assert_selector(r#"[role="tabpanel"]"#)
+            .assert_attr(
+                r##"a[href="#comments"]"##,
+                "aria-controls",
+                "comments",
+            );
+    }
+}

--- a/docs/guide/tabs.md
+++ b/docs/guide/tabs.md
@@ -1,0 +1,86 @@
+# Tabs
+
+`autumn_web::widgets::tabs` groups related content into switchable panels —
+"Profile / Security / Billing", "Overview / Comments / Activity" — with
+**zero hand-written JavaScript or CSS**. Switching is pure CSS (`:target`
+anchors), so it works with JavaScript disabled and each panel is
+deep-linkable via a URL fragment.
+
+Out of scope: lazy loading, dynamically-added tabs, visual variants, and
+related widgets like accordions or drawers.
+
+---
+
+## A three-tab detail view
+
+```rust
+use autumn_web::prelude::*;
+use maud::html;
+
+#[get("/posts/{id}")]
+async fn show(Path(id): Path<i64>) -> Markup {
+    let panels = [
+        ("overview", "Overview", html! { p { "Post " (id) " overview" } }),
+        ("comments", "Comments", html! { p { "Comments for post " (id) } }),
+        ("activity", "Activity", html! { p { "Activity for post " (id) } }),
+    ];
+    html! {
+        h1 { "Post " (id) }
+        (tabs("post-tabs", &panels))
+    }
+}
+```
+
+That's the whole widget: 9 lines of Maud produce a full `tablist` strip and
+three panels. Visiting `/posts/42` shows the Overview panel by default;
+visiting `/posts/42#comments` shows the Comments panel on load — no
+JavaScript involved either way.
+
+## Signature
+
+```rust,ignore
+pub fn tabs(id: &str, panels: &[(&str, &str, maud::Markup)]) -> maud::Markup
+```
+
+Each tuple is `(panel_id, label, body)`, in display order. `panel_id` and
+`label` are `&str` (HTML-escaped by Maud); `body` is pre-rendered
+`maud::Markup` — the caller owns escaping for rich content, same as `card`'s
+`body` parameter.
+
+- `panel_id` becomes the panel's own `id`, so `#<panel_id>` in the URL
+  targets it directly.
+- The tab's element `id` is `"{id}-tab-{panel_id}"`.
+- The first tab/panel is marked active by default (`aria-selected="true"`,
+  `autumn-tabs__tab--active` / `autumn-tabs__panel--active`), so a panel is
+  always visible even before any fragment is present.
+- An empty `panels` slice renders the empty `autumn-tabs` container without
+  panicking.
+
+## CSS hooks
+
+| Selector | Element |
+|---|---|
+| `.autumn-tabs` | Root wrapper |
+| `.autumn-tabs__list` | Tab strip (`role="tablist"`) |
+| `.autumn-tabs__tab` | Individual tab link |
+| `.autumn-tabs__tab--active` | The initially-selected tab |
+| `.autumn-tabs__panel` | Individual panel |
+| `.autumn-tabs__panel--active` | The initially-visible panel |
+
+---
+
+## Accessibility
+
+- The tab strip carries `role="tablist"`.
+- Each tab carries `role="tab"`, `aria-controls` (pointing at its panel's
+  `id`), and `aria-selected`.
+- Each panel carries `role="tabpanel"`, `aria-labelledby` (pointing at its
+  tab's `id`), and `tabindex="0"` so it can receive keyboard focus directly.
+
+## No-JavaScript switching
+
+Each tab is a plain `<a href="#panel-id">`. The framework's `input.css`
+targets `.autumn-tabs__panel:target` to show the panel matching the URL
+fragment, with a `:has()`-based fallback that shows the first (`--active`)
+panel when no fragment targets any panel in the widget. No `<script>`,
+inline event handler, or `hx-*` attribute is emitted or required.

--- a/docs/guide/tabs.md
+++ b/docs/guide/tabs.md
@@ -55,6 +55,13 @@ Each tuple is `(panel_id, label, body)`, in display order. `panel_id` and
   always visible even before any fragment is present.
 - An empty `panels` slice renders the empty `autumn-tabs` container without
   panicking.
+- **Rendering more than one `tabs()` widget on the same page:** panel ids
+  must be unique across the *entire page*, not just within one call. Two
+  `tabs()` calls that both use a panel id like `"overview"` emit two
+  elements with `id="overview"` — invalid duplicate-id HTML that makes
+  `:target`/`aria-controls`/`aria-labelledby` lookups ambiguous. Prefix
+  panel ids per widget instance (e.g. `"post-overview"`,
+  `"related-overview"`) if more than one `tabs()` appears on a page.
 
 ## CSS hooks
 
@@ -76,6 +83,12 @@ Each tuple is `(panel_id, label, body)`, in display order. `panel_id` and
   `id`), and `aria-selected`.
 - Each panel carries `role="tabpanel"`, `aria-labelledby` (pointing at its
   tab's `id`), and `tabindex="0"` so it can receive keyboard focus directly.
+- **Known limitation:** `aria-selected` reflects the server's default
+  selection (the first tab) only. The server never sees the URL fragment,
+  so it can't know which tab a client-side `:target` navigation actually
+  landed on — fixing this would require JavaScript, which this widget
+  deliberately has none of. A screen reader always hears the first tab
+  announced as "selected", even when a different panel is what's shown.
 
 ## No-JavaScript switching
 
@@ -84,3 +97,17 @@ targets `.autumn-tabs__panel:target` to show the panel matching the URL
 fragment, with a `:has()`-based fallback that shows the first (`--active`)
 panel when no fragment targets any panel in the widget. No `<script>`,
 inline event handler, or `hx-*` attribute is emitted or required.
+
+The active-tab *visual highlight* also tracks whichever panel is actually
+`:target`-ed, using position-based `:has()`/`:nth-child()` CSS (ids are
+arbitrary caller strings, so a shared stylesheet can only match them by
+position, not value) — this covers the first 6 tabs; widgets with more tabs
+keep switching panels correctly, but the highlight itself stops updating
+past the 6th.
+
+`:has()` has narrower browser support than `:target`. In a browser that
+supports `:target` but not `:has()`, the tabs widget degrades gracefully
+rather than breaking: an `@supports not selector(:has(a))` rule
+unconditionally shows the first panel, so the widget is never blank — a
+fragment link to a different panel in such a browser may show that panel
+*alongside* the first rather than replacing it.

--- a/docs/guide/tabs.md
+++ b/docs/guide/tabs.md
@@ -62,6 +62,15 @@ Each tuple is `(panel_id, label, body)`, in display order. `panel_id` and
   `:target`/`aria-controls`/`aria-labelledby` lookups ambiguous. Prefix
   panel ids per widget instance (e.g. `"post-overview"`,
   `"related-overview"`) if more than one `tabs()` appears on a page.
+- **Nesting a `tabs()` widget inside another `tabs()` panel:** panel
+  *visibility* handles this — `input.css` reveals the whole ancestor chain
+  down to a deep-linked inner panel, so nested content is reachable no
+  matter which outer panel it lives in. The outer widget's *active-tab
+  highlight* can only sync when the shown outer panel is itself the direct
+  target, though — CSS forbids nesting `:has()` inside `:has()`, so a panel
+  shown only because it contains a nested target can't be tied back to a
+  specific outer tab position. No outer tab is highlighted in that case,
+  rather than the wrong one being highlighted.
 
 ## CSS hooks
 


### PR DESCRIPTION
Covers structure, ARIA wiring (tablist/tab/tabpanel), active-tab
state, :target-based deep-linking, no-JS output, XSS escaping,
and empty/duplicate-id edge cases. Fails to compile: `tabs` does
not exist yet.