### PR TITLE
Implement `autumn destroy` command to cleanly reverse `generate` (issue #1048)

### DIFF
--- a/autumn-cli/src/generate/admin.rs
+++ b/autumn-cli/src/generate/admin.rs
@@ -220,9 +220,16 @@ pub fn plan_admin_with_options(
 /// depended on the model's content.
 ///
 /// # Errors
-/// Returns [`GenerateError`] when `project_root` isn't a valid project.
+/// Returns [`GenerateError`] when `project_root` isn't a valid project, or
+/// `name` fails validation.
 pub fn plan_admin_destroy_fallback(project_root: &Path, name: &str) -> Result<Plan, GenerateError> {
     ensure_project_root(project_root)?;
+    // Unlike `plan_admin_with_options`, this path has no model-file-exists
+    // check to incidentally narrow what `name` can be — it's reached
+    // precisely because that file is gone — so an invalid name (path
+    // separators, `..`) must be rejected explicitly before it's used to
+    // build filesystem paths (issue #1048 PR review).
+    super::model::validate_resource_name(name)?;
 
     let snake_name = snake(name);
     let mut plan = Plan::new(project_root);
@@ -2113,5 +2120,21 @@ pub struct Account {
         let tmp = TempDir::new().unwrap();
         let err = plan_admin_destroy_fallback(tmp.path(), "Post").unwrap_err();
         assert!(matches!(err, GenerateError::NotInProject));
+    }
+
+    #[test]
+    fn plan_admin_destroy_fallback_rejects_path_traversal_in_name() {
+        // issue #1048 PR review: unlike `plan_admin_with_options`, this
+        // fallback has no model-file-exists check to incidentally narrow
+        // `name` — it's reached precisely because that file is gone — so a
+        // name containing path separators must be rejected explicitly
+        // before it's used to build filesystem paths for deletion.
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("Cargo.toml"), "[package]\nname=\"x\"\n").unwrap();
+        let err = plan_admin_destroy_fallback(tmp.path(), "../../foo").unwrap_err();
+        assert!(
+            matches!(err, GenerateError::InvalidName(..)),
+            "expected InvalidName, got {err:?}"
+        );
     }
 }

--- a/autumn-cli/src/generate/admin.rs
+++ b/autumn-cli/src/generate/admin.rs
@@ -18,7 +18,7 @@ use super::dsl::{Field, FieldKind, parse_fields};
 use super::emit::Plan;
 use super::naming::{humanize_label, pascal, pluralize, snake};
 use super::schema_edit::add_mod_declaration;
-use super::{Flags, GenerateError, ensure_project_root, read_or_empty};
+use super::{GenerateError, ensure_project_root, read_or_empty};
 
 /// A parsed `--select FIELD=val1,val2,...` spec.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -181,6 +181,10 @@ pub fn plan_admin_with_options(
         admin_mod_path.clone(),
         add_mod_declaration(&read_or_empty(&admin_mod_path), &snake_name),
     );
+    plan.push_revert(crate::generate::emit::Revert::ModDecl {
+        path: admin_mod_path,
+        name: snake_name.clone(),
+    });
 
     // Smoke test: `tests/<snake>_admin.rs`
     plan.create(
@@ -198,25 +202,6 @@ pub fn plan_admin_with_options(
     );
 
     Ok(plan)
-}
-
-/// CLI entry point for `autumn generate admin`.
-pub fn run(name: &str, field_tokens: &[String], flags: Flags, options: &AdminOptions) {
-    let cwd = match std::env::current_dir() {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("Error: cannot determine current directory: {e}");
-            std::process::exit(1);
-        }
-    };
-    let plan = plan_admin_with_options(&cwd, name, field_tokens, options);
-    match plan.and_then(|p| p.execute(flags)) {
-        Ok(()) => {}
-        Err(e) => {
-            eprintln!("Error: {e}");
-            std::process::exit(1);
-        }
-    }
 }
 
 /// Returns true if the model struct `pascal_name` has a primary-key field `id`
@@ -1120,6 +1105,7 @@ fn render_admin_smoke_test(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::generate::Flags;
     use std::fs;
     use tempfile::TempDir;
 

--- a/autumn-cli/src/generate/admin.rs
+++ b/autumn-cli/src/generate/admin.rs
@@ -204,6 +204,48 @@ pub fn plan_admin_with_options(
     Ok(plan)
 }
 
+/// Fallback destroy-only plan for `autumn destroy admin <name>` when the
+/// backing model file no longer exists — e.g. `autumn destroy model <name>`
+/// already ran first (issue #1048 PR review). `plan_admin_with_options`
+/// needs the model source to detect fields/lock-version/encrypted columns
+/// for rendering, which is meaningless (and impossible) once the model is
+/// gone, so it can't be reused here.
+///
+/// The two generated files' expected content is unknowable without the
+/// model, so they're recorded with an empty placeholder — real content
+/// (never empty) always counts as diverged, so they're only removed with
+/// `--force`, exactly like any other file destroy can't confirm is safe to
+/// delete. The `src/admin/mod.rs` declaration removal is unaffected: it's a
+/// pure text edit ([`crate::generate::emit::Revert::ModDecl`]) that never
+/// depended on the model's content.
+///
+/// # Errors
+/// Returns [`GenerateError`] when `project_root` isn't a valid project.
+pub fn plan_admin_destroy_fallback(project_root: &Path, name: &str) -> Result<Plan, GenerateError> {
+    ensure_project_root(project_root)?;
+
+    let snake_name = snake(name);
+    let mut plan = Plan::new(project_root);
+
+    let admin_dir = project_root.join("src").join("admin");
+    plan.create(admin_dir.join(format!("{snake_name}.rs")), String::new());
+
+    let admin_mod_path = admin_dir.join("mod.rs");
+    plan.push_revert(crate::generate::emit::Revert::ModDecl {
+        path: admin_mod_path,
+        name: snake_name.clone(),
+    });
+
+    plan.create(
+        project_root
+            .join("tests")
+            .join(format!("{snake_name}_admin.rs")),
+        String::new(),
+    );
+
+    Ok(plan)
+}
+
 /// Returns true if the model struct `pascal_name` has a primary-key field `id`
 /// whose type is a UUID, written either fully-qualified (`uuid::Uuid`) or bare
 /// (`Uuid`). Parses the model AST (like [`detect_lock_version_field`]) so it is
@@ -2017,5 +2059,59 @@ pub struct Account {
             !admin.contains(".ilike("),
             "no ilike when there are no searchable fields"
         );
+    }
+
+    // ── `plan_admin_destroy_fallback` (issue #1048 PR review) ───────────────
+
+    #[test]
+    fn destroy_admin_after_model_already_destroyed_still_removes_admin_outputs() {
+        // A common cleanup order — `destroy model Post` then `destroy admin
+        // Post` — must not strand `src/admin/post.rs`, its mod declaration,
+        // and its smoke test just because `plan_admin_with_options` can no
+        // longer read the (now-gone) model file.
+        let tmp = project_with_model("post");
+        let plan = plan_admin(tmp.path(), "Post", &["title:String".into()]).unwrap();
+        plan.execute(Flags::default()).unwrap();
+        assert!(tmp.path().join("src/admin/post.rs").exists());
+        assert!(tmp.path().join("tests/post_admin.rs").exists());
+
+        // Simulate `autumn destroy model Post` having already run.
+        fs::remove_file(tmp.path().join("src/models/post.rs")).unwrap();
+        assert!(plan_admin(tmp.path(), "Post", &["title:String".into()]).is_err());
+
+        let fallback_plan = plan_admin_destroy_fallback(tmp.path(), "Post").unwrap();
+        // Without --force: content is unverifiable (the model is gone), so
+        // it's treated as diverged and left in place rather than guessed at.
+        let err = fallback_plan
+            .revert(Flags {
+                dry_run: false,
+                force: false,
+            })
+            .unwrap_err();
+        assert!(matches!(err, GenerateError::Diverged(_)));
+        assert!(tmp.path().join("src/admin/post.rs").exists());
+
+        let fallback_plan = plan_admin_destroy_fallback(tmp.path(), "Post").unwrap();
+        fallback_plan
+            .revert(Flags {
+                dry_run: false,
+                force: true,
+            })
+            .unwrap();
+        assert!(!tmp.path().join("src/admin/post.rs").exists());
+        assert!(!tmp.path().join("tests/post_admin.rs").exists());
+        assert!(
+            !fs::read_to_string(tmp.path().join("src/admin/mod.rs"))
+                .unwrap_or_default()
+                .contains("post"),
+            "the mod declaration removal doesn't depend on the model and must succeed too"
+        );
+    }
+
+    #[test]
+    fn plan_admin_destroy_fallback_fails_outside_project() {
+        let tmp = TempDir::new().unwrap();
+        let err = plan_admin_destroy_fallback(tmp.path(), "Post").unwrap_err();
+        assert!(matches!(err, GenerateError::NotInProject));
     }
 }

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -1448,10 +1448,22 @@ fn append_oauth_stubs_to_toml(existing: &str, providers: &[String]) -> String {
         if out.contains(&header) {
             continue;
         }
-        let preset = match name.as_str() {
-            "github" => {
-                r#"
-[auth.oauth2.github]
+        out.push('\n');
+        out.push_str(&oauth_provider_stub_block(name));
+    }
+    out.push('\n');
+    out
+}
+
+/// The exact `[auth.oauth2.<name>]` stub block [`append_oauth_stubs_to_toml`]
+/// inserts for a known or unknown provider name. Shared with
+/// `remove_oauth_provider_stubs` (via [`toml_table_block_matches`]) so
+/// `autumn destroy` can verify a block is still byte-identical to this stub
+/// — never hand-filled with real credentials, and never a pre-existing
+/// block `generate` left untouched — before removing it.
+fn oauth_provider_stub_block(name: &str) -> String {
+    match name {
+        "github" => r#"[auth.oauth2.github]
 client_id = ""
 client_secret = ""
 authorize_url = "https://github.com/login/oauth/authorize"
@@ -1460,10 +1472,8 @@ userinfo_url = "https://api.github.com/user"
 redirect_uri = "http://localhost:3000/auth/github/callback"
 scope = "read:user user:email"
 "#
-            }
-            "google" => {
-                r#"
-[auth.oauth2.google]
+        .to_owned(),
+        "google" => r#"[auth.oauth2.google]
 client_id = ""
 client_secret = ""
 authorize_url = "https://accounts.google.com/o/oauth2/v2/auth"
@@ -1475,10 +1485,8 @@ issuer = "https://accounts.google.com"
 jwks_url = "https://www.googleapis.com/oauth2/v3/certs"
 discovery_url = "https://accounts.google.com"
 "#
-            }
-            "microsoft" => {
-                r#"
-[auth.oauth2.microsoft]
+        .to_owned(),
+        "microsoft" => r#"[auth.oauth2.microsoft]
 client_id = ""
 client_secret = ""
 authorize_url = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
@@ -1489,10 +1497,9 @@ issuer = "https://login.microsoftonline.com/common/v2.0"
 jwks_url = "https://login.microsoftonline.com/common/discovery/v2.0/keys"
 discovery_url = "https://login.microsoftonline.com/common/v2.0"
 "#
-            }
-            _ => &format!(
-                r#"
-[auth.oauth2.{name}]
+        .to_owned(),
+        _ => format!(
+            r#"[auth.oauth2.{name}]
 client_id = ""
 client_secret = ""
 authorize_url = "https://example.com/oauth/authorize"
@@ -1500,13 +1507,8 @@ token_url = "https://example.com/oauth/token"
 redirect_uri = "http://localhost:3000/auth/{name}/callback"
 scope = "openid profile email"
 "#
-            ),
-        };
-        out.push('\n');
-        out.push_str(preset.trim_start());
+        ),
     }
-    out.push('\n');
-    out
 }
 
 // ── Template rendering ────────────────────────────────────────────────────────
@@ -7899,23 +7901,65 @@ fn append_webauthn_stub_to_toml(
 
 /// Inverse of [`append_oauth_stubs_to_toml`] (`autumn destroy`, issue #1048).
 ///
-/// Removes each `[auth.oauth2.<provider>]` stub block for `providers`, in
-/// order. A no-op for any provider whose header isn't present (already
-/// destroyed, or hand-edited away).
+/// Removes each `[auth.oauth2.<provider>]` stub block for `providers`, but
+/// only when its current content is still byte-identical to the stub
+/// `append_oauth_stubs_to_toml` would have inserted — never a block that
+/// pre-existed before this `generate` call (real credentials `generate`
+/// never touched), and never one the user has since filled in. A no-op for
+/// any provider whose header isn't present, or whose content no longer
+/// matches (already destroyed, hand-edited, or a pre-existing real config).
 pub(super) fn remove_oauth_provider_stubs(existing: &str, providers: &[String]) -> String {
     let mut content = existing.to_owned();
     for name in providers {
-        content = remove_toml_table_block(&content, &format!("[auth.oauth2.{name}]"));
+        let header = format!("[auth.oauth2.{name}]");
+        if toml_table_block_matches(&content, &header, &oauth_provider_stub_block(name)) {
+            content = remove_toml_table_block(&content, &header);
+        }
     }
     content
 }
 
 /// Inverse of [`append_webauthn_stub_to_toml`] (`autumn destroy`, issue #1048).
 ///
-/// A no-op if `[auth.webauthn]` isn't present (already destroyed, or
-/// hand-edited away).
+/// A no-op if `[auth.webauthn]` isn't present, or if its content no longer
+/// matches exactly what `append_webauthn_stub_to_toml` always inserts (the
+/// same "never touch a pre-existing or since-edited block" guard as
+/// [`remove_oauth_provider_stubs`]).
 pub(super) fn remove_webauthn_stub(existing: &str) -> String {
-    remove_toml_table_block(existing, "[auth.webauthn]")
+    const HEADER: &str = "[auth.webauthn]";
+    let expected = "[auth.webauthn]\n\
+                     rp_id = \"localhost\"\n\
+                     rp_name = \"My App\"\n\
+                     rp_origin = \"http://localhost:3000\"\n";
+    if toml_table_block_matches(existing, HEADER, expected) {
+        remove_toml_table_block(existing, HEADER)
+    } else {
+        existing.to_owned()
+    }
+}
+
+/// The `(start, end)` line-index span of a top-level `[header]` TOML table —
+/// the header line through the last line before the next top-level `[...]`
+/// header or EOF. `None` if `header` isn't present.
+fn toml_table_block_range(lines: &[&str], header: &str) -> Option<(usize, usize)> {
+    let start = lines.iter().position(|l| l.trim() == header)?;
+    let end = lines[start + 1..]
+        .iter()
+        .position(|l| l.trim_start().starts_with('['))
+        .map_or(lines.len(), |rel| start + 1 + rel);
+    Some((start, end))
+}
+
+/// Whether `[header]`'s current block content is byte-identical (ignoring a
+/// trailing-newline difference) to `expected_block` — used to verify a stub
+/// hasn't been hand-filled with real values, or didn't pre-exist before
+/// `generate` ever ran, before `autumn destroy` removes it.
+fn toml_table_block_matches(existing: &str, header: &str, expected_block: &str) -> bool {
+    let lines: Vec<&str> = existing.lines().collect();
+    let Some((start, end)) = toml_table_block_range(&lines, header) else {
+        return false;
+    };
+    lines[start..end].join("\n").trim_end() == expected_block.trim_end()
 }
 
 /// Remove a top-level `[header]` TOML table — the header line and every line
@@ -7931,13 +7975,9 @@ pub(super) fn remove_webauthn_stub(existing: &str) -> String {
 /// `header` isn't present.
 fn remove_toml_table_block(existing: &str, header: &str) -> String {
     let lines: Vec<&str> = existing.lines().collect();
-    let Some(start) = lines.iter().position(|l| l.trim() == header) else {
+    let Some((start, end)) = toml_table_block_range(&lines, header) else {
         return existing.to_owned();
     };
-    let end = lines[start + 1..]
-        .iter()
-        .position(|l| l.trim_start().starts_with('['))
-        .map_or(lines.len(), |rel| start + 1 + rel);
 
     let mut block_start = start;
     if block_start > 0 && lines[block_start - 1].trim().is_empty() {
@@ -8112,6 +8152,57 @@ mod tests {
         assert_eq!(
             fs::read_to_string(&autumn_toml_path).unwrap(),
             original_toml
+        );
+    }
+
+    #[test]
+    fn destroy_never_removes_a_pre_existing_oauth_provider_block_with_real_credentials() {
+        let tmp = project_with_main();
+        fs::write(tmp.path().join("Cargo.toml"), template_shipped_cargo_toml()).unwrap();
+        let autumn_toml_path = tmp.path().join("autumn.toml");
+        let real_github_block = "[server]\nport = 3000\n\n[auth.oauth2.github]\n\
+             client_id = \"real-client-id\"\n\
+             client_secret = \"real-client-secret\"\n\
+             authorize_url = \"https://github.com/login/oauth/authorize\"\n\
+             token_url = \"https://github.com/login/oauth/access_token\"\n\
+             userinfo_url = \"https://api.github.com/user\"\n\
+             redirect_uri = \"https://myapp.example.com/auth/github/callback\"\n\
+             scope = \"read:user user:email\"\n";
+        fs::write(&autumn_toml_path, real_github_block).unwrap();
+
+        // `--oauth github,google`: github's block already exists (with real
+        // credentials) so `append_oauth_stubs_to_toml` leaves it untouched;
+        // only google's stub is freshly inserted.
+        let oauth = AuthOAuthOptions {
+            providers: vec!["github".to_owned(), "google".to_owned()],
+        };
+        plan_auth_with_options(tmp.path(), "User", "20260508000000", &oauth)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        assert!(
+            fs::read_to_string(&autumn_toml_path)
+                .unwrap()
+                .contains("real-client-secret")
+        );
+
+        plan_auth_with_options(tmp.path(), "User", "20260508000000", &oauth)
+            .unwrap()
+            .revert(Flags::default())
+            .unwrap();
+
+        let toml_after = fs::read_to_string(&autumn_toml_path).unwrap();
+        assert!(
+            toml_after.contains("[auth.oauth2.github]"),
+            "pre-existing github block must survive destroy: {toml_after}"
+        );
+        assert!(
+            toml_after.contains("real-client-secret"),
+            "real credentials must never be deleted: {toml_after}"
+        );
+        assert!(
+            !toml_after.contains("[auth.oauth2.google]"),
+            "google's freshly-inserted stub must still be removed: {toml_after}"
         );
     }
 

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -470,8 +470,23 @@ pub fn plan_auth_with_providers(
         models_dir.join(format!("{snake_name}_session.rs")),
         render_session_model_file(&pascal_name, &snake_name, &table),
     );
-    model_mod = add_mod_declaration(&model_mod, &format!("{snake_name}_session"));
-    plan.modify(model_mod_path, model_mod);
+    let session_mod_name = format!("{snake_name}_session");
+    model_mod = add_mod_declaration(&model_mod, &session_mod_name);
+    plan.modify(model_mod_path.clone(), model_mod);
+    plan.push_revert(crate::generate::emit::Revert::ModDecl {
+        path: model_mod_path.clone(),
+        name: snake_name.clone(),
+    });
+    if totp {
+        plan.push_revert(crate::generate::emit::Revert::ModDecl {
+            path: model_mod_path.clone(),
+            name: "recovery_code".to_owned(),
+        });
+    }
+    plan.push_revert(crate::generate::emit::Revert::ModDecl {
+        path: model_mod_path,
+        name: session_mod_name,
+    });
 
     // ── src/schema.rs entry ────────────────────────────────────────────────
     // The generated model references `crate::schema::<table>`, so we must
@@ -513,7 +528,16 @@ pub fn plan_auth_with_providers(
     // would emit a second `CREATE TABLE recovery_codes` and `diesel migration
     // run` would fail with "relation already exists" (or clobber an unrelated
     // table). Reject up front rather than generate an unusable app.
-    if totp && schema_has_table(&schema_existing, "recovery_codes") {
+    //
+    // Only reject a *foreign* `recovery_codes` table: when the auth table
+    // itself is also already present, this is a re-run over our own output
+    // (`--force`, or `autumn destroy` recomputing this same plan against
+    // already-generated files — issue #1048), where the schema append below
+    // is an idempotent no-op. Mirrors the analogous `sess_table` guard below.
+    if totp
+        && schema_has_table(&schema_existing, "recovery_codes")
+        && !schema_has_table(&schema_existing, &table)
+    {
         return Err(GenerateError::InvalidName(
             name.to_owned(),
             "this project already defines a `recovery_codes` table, which `--totp` \
@@ -565,7 +589,21 @@ pub fn plan_auth_with_providers(
     .map(|t| super::dsl::parse_field(t).expect("session field tokens are always valid"))
     .collect();
     schema_new = append_schema_table(&schema_new, &sess_table, &session_fields);
-    plan.modify(schema_path, schema_new);
+    plan.modify(schema_path.clone(), schema_new);
+    plan.push_revert(crate::generate::emit::Revert::SchemaTable {
+        path: schema_path.clone(),
+        table: table.clone(),
+    });
+    if totp {
+        plan.push_revert(crate::generate::emit::Revert::SchemaTable {
+            path: schema_path.clone(),
+            table: "recovery_codes".to_owned(),
+        });
+    }
+    plan.push_revert(crate::generate::emit::Revert::SchemaTable {
+        path: schema_path,
+        table: sess_table,
+    });
 
     // ── Auth routes ────────────────────────────────────────────────────────
     let routes_dir = project_root.join("src").join("routes");
@@ -578,6 +616,10 @@ pub fn plan_auth_with_providers(
         route_mod_path.clone(),
         add_mod_declaration(&read_or_empty(&route_mod_path), "auth"),
     );
+    plan.push_revert(crate::generate::emit::Revert::ModDecl {
+        path: route_mod_path,
+        name: "auth".to_owned(),
+    });
 
     // ── Generated tests ────────────────────────────────────────────────────
     let tests_dir = project_root.join("tests");
@@ -619,7 +661,11 @@ pub fn plan_auth_with_providers(
     })?;
     let entries = auth_route_entries(totp);
     let updated = update_main_rs(&main_existing, &["models", "routes", "schema"], &entries);
-    plan.modify(main_path, updated);
+    plan.modify(main_path.clone(), updated);
+    plan.push_revert(crate::generate::emit::Revert::RoutesEntries {
+        path: main_path,
+        entries,
+    });
 
     // ── Cargo.toml deps + autumn-web/mail feature ─────────────────────────
     let cargo_toml_path = project_root.join("Cargo.toml");
@@ -641,8 +687,37 @@ pub fn plan_auth_with_providers(
     };
     let final_cargo = ensure_autumn_web_mail_feature(&with_deps);
     if final_cargo != cargo_existing {
-        plan.modify(cargo_toml_path, final_cargo);
+        plan.modify(cargo_toml_path.clone(), final_cargo);
     }
+    // Pushed unconditionally — see `plan_cargo_deps`'s matching comment in
+    // model.rs: destroy recomputes this plan against the already-generated
+    // Cargo.toml, where these entries are by definition already present.
+    // `owner_dir` is `src/models`: every auth resource always creates at
+    // least `<snake>.rs` and `<snake>_session.rs` there, and (unlike
+    // channels/mailers) an auth resource's routes file isn't
+    // name-parameterized (`src/routes/auth.rs` always, regardless of the
+    // resource name), so a second auth resource can't coexist under a
+    // different name anyway — `src/models` is a reliable "this auth resource
+    // still exists" marker.
+    let models_owner_dir = project_root.join("src").join("models");
+    let dep_names: Vec<String> = all_deps
+        .iter()
+        .map(|(name, _)| *name)
+        .filter(|name| !super::model::TEMPLATE_SHIPPED_CARGO_DEPS.contains(name))
+        .map(str::to_owned)
+        .collect();
+    if !dep_names.is_empty() {
+        plan.push_revert(crate::generate::emit::Revert::CargoDeps {
+            path: cargo_toml_path.clone(),
+            names: dep_names,
+            owner_dir: models_owner_dir.clone(),
+        });
+    }
+    plan.push_revert(crate::generate::emit::Revert::CargoAutumnWebFeature {
+        path: cargo_toml_path,
+        feature: "mail".to_owned(),
+        owner_dir: Some(models_owner_dir),
+    });
 
     Ok(plan)
 }
@@ -754,7 +829,11 @@ fn plan_auth_options_impl(
         .map(|t| super::dsl::parse_field(t).expect("oauth field tokens are always valid"))
         .collect();
         let updated_schema = append_schema_table(&schema_base, "oauth_identities", &oauth_fields);
-        plan.modify(schema_path, updated_schema);
+        plan.modify(schema_path.clone(), updated_schema);
+        plan.push_revert(crate::generate::emit::Revert::SchemaTable {
+            path: schema_path,
+            table: "oauth_identities".to_owned(),
+        });
 
         // ── oauth routes ───────────────────────────────────────────────────────
         let routes_dir = project_root.join("src").join("routes");
@@ -775,7 +854,11 @@ fn plan_auth_options_impl(
         let route_mod_base = find_plan_content_for_path(&plan, &route_mod_path)
             .unwrap_or_else(|| read_or_empty(&route_mod_path));
         let updated_route_mod = add_mod_declaration(&route_mod_base, "oauth");
-        plan.modify(route_mod_path, updated_route_mod);
+        plan.modify(route_mod_path.clone(), updated_route_mod);
+        plan.push_revert(crate::generate::emit::Revert::ModDecl {
+            path: route_mod_path,
+            name: "oauth".to_owned(),
+        });
 
         // ── Register oauth routes in src/main.rs ───────────────────────────────
         let main_path = project_root.join("src").join("main.rs");
@@ -794,7 +877,11 @@ fn plan_auth_options_impl(
             &["models", "routes", "schema"],
             &oauth_entries,
         );
-        plan.modify(main_path, updated_main);
+        plan.modify(main_path.clone(), updated_main);
+        plan.push_revert(crate::generate::emit::Revert::RoutesEntries {
+            path: main_path,
+            entries: oauth_entries,
+        });
 
         // ── docs/guide/oauth.md ────────────────────────────────────────────────
         let docs_dir = project_root.join("docs").join("guide");
@@ -811,8 +898,13 @@ fn plan_auth_options_impl(
             .unwrap_or_else(|| cargo_existing.clone());
         let with_oauth2 = ensure_autumn_web_oauth2_feature(&base_cargo);
         if with_oauth2 != base_cargo {
-            plan.modify(cargo_toml_path, with_oauth2);
+            plan.modify(cargo_toml_path.clone(), with_oauth2);
         }
+        plan.push_revert(crate::generate::emit::Revert::CargoAutumnWebFeature {
+            path: cargo_toml_path,
+            feature: "oauth2".to_owned(),
+            owner_dir: Some(project_root.join("src").join("models")),
+        });
 
         // ── autumn.toml OAuth provider stubs ───────────────────────────────────
         let autumn_toml_path = project_root.join("autumn.toml");
@@ -820,8 +912,12 @@ fn plan_auth_options_impl(
             let toml_existing = read_or_empty(&autumn_toml_path);
             let updated_toml = append_oauth_stubs_to_toml(&toml_existing, &oauth.providers);
             if updated_toml != toml_existing {
-                plan.modify(autumn_toml_path, updated_toml);
+                plan.modify(autumn_toml_path.clone(), updated_toml);
             }
+            plan.push_revert(crate::generate::emit::Revert::AuthOAuthProviderStubs {
+                path: autumn_toml_path,
+                providers: oauth.providers.clone(),
+            });
         }
     }
 
@@ -829,10 +925,18 @@ fn plan_auth_options_impl(
         // ── webauthn_credentials collision check ───────────────────────────────
         // If the project already has webauthn_credentials in schema.rs, the
         // migration below would fail at `diesel migration run`. Reject upfront.
+        //
+        // Only reject a *foreign* `webauthn_credentials` table: when the auth
+        // user table itself is also already present, this is a re-run over
+        // our own output (`--force`, or `autumn destroy` recomputing this
+        // same plan against already-generated files — issue #1048), where
+        // the schema append below is an idempotent no-op.
         let schema_for_check = project_root.join("src").join("schema.rs");
         let schema_existing_for_passkey = find_plan_content_for_path(&plan, &schema_for_check)
             .unwrap_or_else(|| read_or_empty(&schema_for_check));
-        if schema_has_table(&schema_existing_for_passkey, "webauthn_credentials") {
+        if schema_has_table(&schema_existing_for_passkey, "webauthn_credentials")
+            && !schema_has_table(&schema_existing_for_passkey, &user_table)
+        {
             return Err(GenerateError::InvalidName(
                 name.to_owned(),
                 "this project already defines a `webauthn_credentials` table, which \
@@ -868,9 +972,13 @@ fn plan_auth_options_impl(
         let model_mod_base = find_plan_content_for_path(&plan, &model_mod_path)
             .unwrap_or_else(|| read_or_empty(&model_mod_path));
         plan.modify(
-            model_mod_path,
+            model_mod_path.clone(),
             add_mod_declaration(&model_mod_base, "webauthn_credential"),
         );
+        plan.push_revert(crate::generate::emit::Revert::ModDecl {
+            path: model_mod_path,
+            name: "webauthn_credential".to_owned(),
+        });
 
         // ── src/schema.rs: webauthn_credentials table ─────────────────────────
         let schema_path = project_root.join("src").join("schema.rs");
@@ -887,7 +995,11 @@ fn plan_auth_options_impl(
         .map(|t| super::dsl::parse_field(t).expect("webauthn credential field tokens are valid"))
         .collect();
         let updated_schema = append_schema_table(&schema_base, "webauthn_credentials", &wc_fields);
-        plan.modify(schema_path, updated_schema);
+        plan.modify(schema_path.clone(), updated_schema);
+        plan.push_revert(crate::generate::emit::Revert::SchemaTable {
+            path: schema_path,
+            table: "webauthn_credentials".to_owned(),
+        });
 
         // ── src/routes/passkeys.rs ─────────────────────────────────────────────
         let routes_dir = project_root.join("src").join("routes");
@@ -899,9 +1011,13 @@ fn plan_auth_options_impl(
         let route_mod_base = find_plan_content_for_path(&plan, &route_mod_path)
             .unwrap_or_else(|| read_or_empty(&route_mod_path));
         plan.modify(
-            route_mod_path,
+            route_mod_path.clone(),
             add_mod_declaration(&route_mod_base, "passkeys"),
         );
+        plan.push_revert(crate::generate::emit::Revert::ModDecl {
+            path: route_mod_path,
+            name: "passkeys".to_owned(),
+        });
 
         // ── Register passkey routes in src/main.rs ─────────────────────────────
         let main_path = project_root.join("src").join("main.rs");
@@ -919,7 +1035,11 @@ fn plan_auth_options_impl(
             &["models", "routes", "schema"],
             &pk_entries,
         );
-        plan.modify(main_path, updated_main);
+        plan.modify(main_path.clone(), updated_main);
+        plan.push_revert(crate::generate::emit::Revert::RoutesEntries {
+            path: main_path,
+            entries: pk_entries,
+        });
 
         // ── tests/auth_passkeys.rs ─────────────────────────────────────────────
         let tests_dir = project_root.join("tests");
@@ -944,8 +1064,11 @@ fn plan_auth_options_impl(
                 "http://localhost:3000",
             );
             if updated_toml != toml_existing {
-                plan.modify(autumn_toml_path, updated_toml);
+                plan.modify(autumn_toml_path.clone(), updated_toml);
             }
+            plan.push_revert(crate::generate::emit::Revert::AuthWebauthnStub {
+                path: autumn_toml_path,
+            });
         }
 
         // ── Cargo.toml: add webauthn-rs dep + webauthn feature on autumn-web ───
@@ -959,8 +1082,27 @@ fn plan_auth_options_impl(
         let with_deps = ensure_webauthn_rs_features(&with_deps);
         let with_webauthn = ensure_autumn_web_webauthn_feature(&with_deps);
         if with_webauthn != base_cargo {
-            plan.modify(cargo_toml_path, with_webauthn);
+            plan.modify(cargo_toml_path.clone(), with_webauthn);
         }
+        let passkey_models_owner_dir = project_root.join("src").join("models");
+        let passkey_dep_names: Vec<String> = all_passkey_deps
+            .iter()
+            .map(|(name, _)| *name)
+            .filter(|name| !super::model::TEMPLATE_SHIPPED_CARGO_DEPS.contains(name))
+            .map(str::to_owned)
+            .collect();
+        if !passkey_dep_names.is_empty() {
+            plan.push_revert(crate::generate::emit::Revert::CargoDeps {
+                path: cargo_toml_path.clone(),
+                names: passkey_dep_names,
+                owner_dir: passkey_models_owner_dir.clone(),
+            });
+        }
+        plan.push_revert(crate::generate::emit::Revert::CargoAutumnWebFeature {
+            path: cargo_toml_path,
+            feature: "webauthn".to_owned(),
+            owner_dir: Some(passkey_models_owner_dir),
+        });
     }
 
     Ok(plan)
@@ -7755,6 +7897,63 @@ fn append_webauthn_stub_to_toml(
     out
 }
 
+/// Inverse of [`append_oauth_stubs_to_toml`] (`autumn destroy`, issue #1048).
+///
+/// Removes each `[auth.oauth2.<provider>]` stub block for `providers`, in
+/// order. A no-op for any provider whose header isn't present (already
+/// destroyed, or hand-edited away).
+pub(super) fn remove_oauth_provider_stubs(existing: &str, providers: &[String]) -> String {
+    let mut content = existing.to_owned();
+    for name in providers {
+        content = remove_toml_table_block(&content, &format!("[auth.oauth2.{name}]"));
+    }
+    content
+}
+
+/// Inverse of [`append_webauthn_stub_to_toml`] (`autumn destroy`, issue #1048).
+///
+/// A no-op if `[auth.webauthn]` isn't present (already destroyed, or
+/// hand-edited away).
+pub(super) fn remove_webauthn_stub(existing: &str) -> String {
+    remove_toml_table_block(existing, "[auth.webauthn]")
+}
+
+/// Remove a top-level `[header]` TOML table — the header line and every line
+/// up to (but not including) the next top-level `[...]` header or EOF — plus
+/// one immediately preceding blank separator line, if present.
+///
+/// This is the exact inverse shape of how [`append_oauth_stubs_to_toml`] and
+/// [`append_webauthn_stub_to_toml`] insert a table at the end of the file
+/// (`existing.trim_end()` followed by a separator and the new block): consuming
+/// one preceding blank line here undoes that separator, and discarding
+/// everything from the header to EOF when this is the last table in the file
+/// undoes the trailing blank line those functions leave behind. A no-op if
+/// `header` isn't present.
+fn remove_toml_table_block(existing: &str, header: &str) -> String {
+    let lines: Vec<&str> = existing.lines().collect();
+    let Some(start) = lines.iter().position(|l| l.trim() == header) else {
+        return existing.to_owned();
+    };
+    let end = lines[start + 1..]
+        .iter()
+        .position(|l| l.trim_start().starts_with('['))
+        .map_or(lines.len(), |rel| start + 1 + rel);
+
+    let mut block_start = start;
+    if block_start > 0 && lines[block_start - 1].trim().is_empty() {
+        block_start -= 1;
+    }
+
+    let mut new_lines: Vec<&str> = Vec::with_capacity(lines.len());
+    new_lines.extend_from_slice(&lines[..block_start]);
+    new_lines.extend_from_slice(&lines[end..]);
+    let mut out = new_lines.join("\n");
+    if !out.is_empty() {
+        out.push('\n');
+    }
+    out
+}
+
 // ── Unit tests ────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -7781,6 +7980,248 @@ mod tests {
         )
         .unwrap();
         tmp
+    }
+
+    /// A Cargo.toml matching what `autumn new`'s own template ships
+    /// (`autumn-web`, `diesel_migrations`, and `maud` already present — see
+    /// `TEMPLATE_SHIPPED_CARGO_DEPS`), used by the round-trip tests below so
+    /// those three names are genuinely pre-existing rather than freshly
+    /// added by this generator (and thus rightly excluded from its
+    /// `Revert::CargoDeps`).
+    fn template_shipped_cargo_toml() -> &'static str {
+        "[package]\nname=\"x\"\n\n[dependencies]\nautumn-web = \"0.3\"\n\
+         diesel_migrations = \"2\"\nmaud = { version = \"0.27\", features = [\"axum\"] }\n"
+    }
+
+    // ── generate/destroy round trips (issue #1048) ──────────────────────────
+    //
+    // `autumn destroy auth` recomputes the exact same plan `generate` did and
+    // interprets it in reverse (see `Plan::revert`): every `Create`d file is
+    // deleted, and every shared-file edit recorded via `plan.push_revert(...)`
+    // is undone. These tests assert the round trip is byte-identical for the
+    // base scaffold plus each optional feature flag.
+
+    #[test]
+    fn generate_then_destroy_base_auth_round_trips_to_original_project_state() {
+        let tmp = project_with_main();
+        let cargo_path = tmp.path().join("Cargo.toml");
+        fs::write(&cargo_path, template_shipped_cargo_toml()).unwrap();
+        let main_path = tmp.path().join("src/main.rs");
+        let original_cargo = fs::read_to_string(&cargo_path).unwrap();
+        let original_main = fs::read_to_string(&main_path).unwrap();
+
+        let plan = plan_auth(tmp.path(), "User", "20260508000000").unwrap();
+        plan.execute(Flags::default()).unwrap();
+        assert!(tmp.path().join("src/models/user.rs").exists());
+        assert!(
+            fs::read_to_string(&main_path)
+                .unwrap()
+                .contains("routes::auth::signup")
+        );
+        assert!(fs::read_to_string(&cargo_path).unwrap().contains("axum"));
+
+        let destroy_plan = plan_auth(tmp.path(), "User", "20260508000000").unwrap();
+        destroy_plan.revert(Flags::default()).unwrap();
+
+        assert!(!tmp.path().join("src/models").exists());
+        assert!(!tmp.path().join("src/routes").exists());
+        assert!(!tmp.path().join("src/schema.rs").exists());
+        assert!(!tmp.path().join("tests/auth.rs").exists());
+        assert!(!tmp.path().join("tests/auth_sessions.rs").exists());
+        assert!(!tmp.path().join("docs/guide/authentication.md").exists());
+        assert!(!tmp.path().join("migrations").exists());
+        assert_eq!(fs::read_to_string(&main_path).unwrap(), original_main);
+        assert_eq!(fs::read_to_string(&cargo_path).unwrap(), original_cargo);
+    }
+
+    #[test]
+    fn generate_then_destroy_auth_with_totp_round_trips_to_original_project_state() {
+        let tmp = project_with_main();
+        let cargo_path = tmp.path().join("Cargo.toml");
+        fs::write(&cargo_path, template_shipped_cargo_toml()).unwrap();
+        let main_path = tmp.path().join("src/main.rs");
+        let original_cargo = fs::read_to_string(&cargo_path).unwrap();
+        let original_main = fs::read_to_string(&main_path).unwrap();
+
+        let plan =
+            plan_auth_with_providers(tmp.path(), "User", "20260508000000", &[], true).unwrap();
+        plan.execute(Flags::default()).unwrap();
+        assert!(tmp.path().join("src/models/recovery_code.rs").exists());
+        assert!(tmp.path().join("tests/auth_2fa.rs").exists());
+        assert!(fs::read_to_string(&cargo_path).unwrap().contains("totp-rs"));
+        assert!(
+            fs::read_to_string(tmp.path().join("src/schema.rs"))
+                .unwrap()
+                .contains("recovery_codes")
+        );
+
+        let destroy_plan =
+            plan_auth_with_providers(tmp.path(), "User", "20260508000000", &[], true).unwrap();
+        destroy_plan.revert(Flags::default()).unwrap();
+
+        assert!(!tmp.path().join("src/models").exists());
+        assert!(!tmp.path().join("src/routes").exists());
+        assert!(!tmp.path().join("src/schema.rs").exists());
+        assert!(!tmp.path().join("tests/auth_2fa.rs").exists());
+        assert!(!tmp.path().join("migrations").exists());
+        assert_eq!(fs::read_to_string(&main_path).unwrap(), original_main);
+        assert_eq!(fs::read_to_string(&cargo_path).unwrap(), original_cargo);
+    }
+
+    #[test]
+    fn generate_then_destroy_auth_with_oauth_round_trips_to_original_project_state() {
+        let tmp = project_with_main();
+        let cargo_path = tmp.path().join("Cargo.toml");
+        fs::write(&cargo_path, template_shipped_cargo_toml()).unwrap();
+        let main_path = tmp.path().join("src/main.rs");
+        let autumn_toml_path = tmp.path().join("autumn.toml");
+        fs::write(&autumn_toml_path, "[server]\nport = 3000\n").unwrap();
+        let original_cargo = fs::read_to_string(&cargo_path).unwrap();
+        let original_main = fs::read_to_string(&main_path).unwrap();
+        let original_toml = fs::read_to_string(&autumn_toml_path).unwrap();
+
+        let oauth = AuthOAuthOptions {
+            providers: vec!["github".to_owned(), "google".to_owned()],
+        };
+        let plan = plan_auth_with_options(tmp.path(), "User", "20260508000000", &oauth).unwrap();
+        plan.execute(Flags::default()).unwrap();
+        assert!(tmp.path().join("src/routes/oauth.rs").exists());
+        assert!(
+            fs::read_to_string(&autumn_toml_path)
+                .unwrap()
+                .contains("[auth.oauth2.github]")
+        );
+        assert!(fs::read_to_string(&cargo_path).unwrap().contains("oauth2"));
+        assert!(
+            fs::read_to_string(tmp.path().join("src/schema.rs"))
+                .unwrap()
+                .contains("oauth_identities")
+        );
+
+        let destroy_plan =
+            plan_auth_with_options(tmp.path(), "User", "20260508000000", &oauth).unwrap();
+        destroy_plan.revert(Flags::default()).unwrap();
+
+        assert!(!tmp.path().join("src/models").exists());
+        assert!(!tmp.path().join("src/routes").exists());
+        assert!(!tmp.path().join("src/schema.rs").exists());
+        assert!(!tmp.path().join("docs/guide/oauth.md").exists());
+        assert!(!tmp.path().join("migrations").exists());
+        assert_eq!(fs::read_to_string(&main_path).unwrap(), original_main);
+        assert_eq!(fs::read_to_string(&cargo_path).unwrap(), original_cargo);
+        assert_eq!(
+            fs::read_to_string(&autumn_toml_path).unwrap(),
+            original_toml
+        );
+    }
+
+    #[test]
+    fn generate_then_destroy_auth_with_passkeys_round_trips_to_original_project_state() {
+        let tmp = project_with_main();
+        let cargo_path = tmp.path().join("Cargo.toml");
+        fs::write(&cargo_path, template_shipped_cargo_toml()).unwrap();
+        let main_path = tmp.path().join("src/main.rs");
+        let autumn_toml_path = tmp.path().join("autumn.toml");
+        fs::write(&autumn_toml_path, "[server]\nport = 3000\n").unwrap();
+        let original_cargo = fs::read_to_string(&cargo_path).unwrap();
+        let original_main = fs::read_to_string(&main_path).unwrap();
+        let original_toml = fs::read_to_string(&autumn_toml_path).unwrap();
+
+        let plan = plan_auth_full_ex(
+            tmp.path(),
+            "User",
+            "20260508000000",
+            &AuthOAuthOptions::default(),
+            false,
+            true,
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+        assert!(tmp.path().join("src/routes/passkeys.rs").exists());
+        assert!(
+            fs::read_to_string(&autumn_toml_path)
+                .unwrap()
+                .contains("[auth.webauthn]")
+        );
+        assert!(
+            fs::read_to_string(&cargo_path)
+                .unwrap()
+                .contains("webauthn-rs")
+        );
+        assert!(
+            fs::read_to_string(tmp.path().join("src/schema.rs"))
+                .unwrap()
+                .contains("webauthn_credentials")
+        );
+
+        let destroy_plan = plan_auth_full_ex(
+            tmp.path(),
+            "User",
+            "20260508000000",
+            &AuthOAuthOptions::default(),
+            false,
+            true,
+        )
+        .unwrap();
+        destroy_plan.revert(Flags::default()).unwrap();
+
+        assert!(!tmp.path().join("src/models").exists());
+        assert!(!tmp.path().join("src/routes").exists());
+        assert!(!tmp.path().join("src/schema.rs").exists());
+        assert!(!tmp.path().join("tests/auth_passkeys.rs").exists());
+        assert!(!tmp.path().join("docs/guide/passkeys.md").exists());
+        assert!(!tmp.path().join("migrations").exists());
+        assert_eq!(fs::read_to_string(&main_path).unwrap(), original_main);
+        assert_eq!(fs::read_to_string(&cargo_path).unwrap(), original_cargo);
+        assert_eq!(
+            fs::read_to_string(&autumn_toml_path).unwrap(),
+            original_toml
+        );
+    }
+
+    #[test]
+    fn generate_then_destroy_auth_with_totp_oauth_and_passkeys_round_trips_to_original_project_state()
+     {
+        // Combines every optional flag in one plan, exercising the trickiest
+        // case for the `autumn.toml` reverts: `--oauth` appends its stub
+        // block first, then `--passkeys` appends `[auth.webauthn]` on top of
+        // that (reading the base plan's already-updated content) — both
+        // edits must unwind cleanly regardless of their relative order in
+        // the file.
+        let tmp = project_with_main();
+        let cargo_path = tmp.path().join("Cargo.toml");
+        fs::write(&cargo_path, template_shipped_cargo_toml()).unwrap();
+        let main_path = tmp.path().join("src/main.rs");
+        let autumn_toml_path = tmp.path().join("autumn.toml");
+        fs::write(&autumn_toml_path, "[server]\nport = 3000\n").unwrap();
+        let original_cargo = fs::read_to_string(&cargo_path).unwrap();
+        let original_main = fs::read_to_string(&main_path).unwrap();
+        let original_toml = fs::read_to_string(&autumn_toml_path).unwrap();
+
+        let oauth = AuthOAuthOptions {
+            providers: vec!["github".to_owned()],
+        };
+        let plan =
+            plan_auth_full_ex(tmp.path(), "User", "20260508000000", &oauth, true, true).unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let toml_after_generate = fs::read_to_string(&autumn_toml_path).unwrap();
+        assert!(toml_after_generate.contains("[auth.oauth2.github]"));
+        assert!(toml_after_generate.contains("[auth.webauthn]"));
+
+        let destroy_plan =
+            plan_auth_full_ex(tmp.path(), "User", "20260508000000", &oauth, true, true).unwrap();
+        destroy_plan.revert(Flags::default()).unwrap();
+
+        assert!(!tmp.path().join("src/models").exists());
+        assert!(!tmp.path().join("src/routes").exists());
+        assert!(!tmp.path().join("src/schema.rs").exists());
+        assert!(!tmp.path().join("migrations").exists());
+        assert_eq!(fs::read_to_string(&main_path).unwrap(), original_main);
+        assert_eq!(fs::read_to_string(&cargo_path).unwrap(), original_cargo);
+        assert_eq!(
+            fs::read_to_string(&autumn_toml_path).unwrap(),
+            original_toml
+        );
     }
 
     // ── Plan structure ──────────────────────────────────────────────────────

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -593,16 +593,28 @@ pub fn plan_auth_with_providers(
     plan.push_revert(crate::generate::emit::Revert::SchemaTable {
         path: schema_path.clone(),
         table: table.clone(),
+        expected_block: append_schema_table("", &table, &auth_fields),
     });
     if totp {
+        let recovery_fields: Vec<super::dsl::Field> = [
+            "user_id:i64",
+            "code_digest:String",
+            "used_at:Option<NaiveDateTime>",
+        ]
+        .iter()
+        .map(|t| super::dsl::parse_field(t).expect("recovery field tokens are always valid"))
+        .collect();
         plan.push_revert(crate::generate::emit::Revert::SchemaTable {
             path: schema_path.clone(),
             table: "recovery_codes".to_owned(),
+            expected_block: append_schema_table("", "recovery_codes", &recovery_fields),
         });
     }
+    let sess_table_expected_block = append_schema_table("", &sess_table, &session_fields);
     plan.push_revert(crate::generate::emit::Revert::SchemaTable {
         path: schema_path,
         table: sess_table,
+        expected_block: sess_table_expected_block,
     });
 
     // ── Auth routes ────────────────────────────────────────────────────────
@@ -833,6 +845,7 @@ fn plan_auth_options_impl(
         plan.push_revert(crate::generate::emit::Revert::SchemaTable {
             path: schema_path,
             table: "oauth_identities".to_owned(),
+            expected_block: append_schema_table("", "oauth_identities", &oauth_fields),
         });
 
         // ── oauth routes ───────────────────────────────────────────────────────
@@ -999,6 +1012,7 @@ fn plan_auth_options_impl(
         plan.push_revert(crate::generate::emit::Revert::SchemaTable {
             path: schema_path,
             table: "webauthn_credentials".to_owned(),
+            expected_block: append_schema_table("", "webauthn_credentials", &wc_fields),
         });
 
         // ── src/routes/passkeys.rs ─────────────────────────────────────────────

--- a/autumn-cli/src/generate/channel.rs
+++ b/autumn-cli/src/generate/channel.rs
@@ -25,7 +25,7 @@ use super::schema_edit::{
     add_mod_declaration, ensure_autumn_web_feature, ensure_dev_dependency_tokio_test_features,
     remove_routes_entries_with_prefix, update_main_rs,
 };
-use super::{Flags, GenerateError, ensure_project_root, read_or_empty};
+use super::{GenerateError, ensure_project_root, read_or_empty};
 
 /// Which transport a generated channel uses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -75,6 +75,10 @@ pub fn plan_channel(
         mod_path.clone(),
         add_mod_declaration(&read_or_empty(&mod_path), &snake_name),
     );
+    plan.push_revert(crate::generate::emit::Revert::ModDecl {
+        path: mod_path,
+        name: snake_name.clone(),
+    });
 
     // ── src/main.rs: add mod channels; and route entries ────────────────────
     let main_path = project_root.join("src").join("main.rs");
@@ -93,7 +97,14 @@ pub fn plan_channel(
         remove_routes_entries_with_prefix(&main_existing, &format!("channels::{snake_name}::"));
     let route_entries = route_entries(&snake_name, transport);
     let updated_main = update_main_rs(&main_existing, &["channels"], &route_entries);
-    plan.modify(main_path, updated_main);
+    plan.modify(main_path.clone(), updated_main);
+    // `mod channels;` is a shared infrastructure declaration (see
+    // `emit::sync_main_rs_mod_declarations`) — only this channel's own
+    // route entries are reverted here.
+    plan.push_revert(crate::generate::emit::Revert::RoutesEntries {
+        path: main_path,
+        entries: route_entries,
+    });
 
     // ── tests/<snake>_channel.rs ──────────────────────────────────────────
     plan.create(
@@ -127,7 +138,30 @@ pub fn plan_channel(
     updated_cargo = ensure_cargo_dependencies(&updated_cargo, &deps);
     updated_cargo = ensure_dev_dependency_tokio_test_features(&updated_cargo);
     if updated_cargo != cargo_existing {
-        plan.modify(cargo_path, updated_cargo);
+        plan.modify(cargo_path.clone(), updated_cargo);
+    }
+    // Pushed unconditionally — see `plan_cargo_deps`'s matching comment in
+    // model.rs: destroy recomputes this plan against the already-generated
+    // Cargo.toml, where these entries are by definition already present.
+    // `maud` is excluded: `autumn new`'s own template already ships it as a
+    // direct dependency (see `TEMPLATE_SHIPPED_CARGO_DEPS`).
+    let dep_names: Vec<String> = deps
+        .iter()
+        .map(|(name, _)| *name)
+        .filter(|name| !super::model::TEMPLATE_SHIPPED_CARGO_DEPS.contains(name))
+        .map(str::to_owned)
+        .collect();
+    if !dep_names.is_empty() {
+        plan.push_revert(crate::generate::emit::Revert::CargoDeps {
+            path: cargo_path.clone(),
+            names: dep_names,
+        });
+    }
+    for feature in autumn_web_features {
+        plan.push_revert(crate::generate::emit::Revert::CargoAutumnWebFeature {
+            path: cargo_path.clone(),
+            feature: (*feature).to_owned(),
+        });
     }
 
     Ok(plan)
@@ -419,27 +453,10 @@ async fn {snake_name}_channel_delivers_published_message_to_subscriber() {{
     )
 }
 
-/// CLI entry point.
-pub fn run(name: &str, transport: Transport, flags: Flags) {
-    let cwd = match std::env::current_dir() {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("Error: cannot determine current directory: {e}");
-            std::process::exit(1);
-        }
-    };
-    match plan_channel(&cwd, name, transport).and_then(|p| p.execute(flags)) {
-        Ok(()) => {}
-        Err(e) => {
-            eprintln!("Error: {e}");
-            std::process::exit(1);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::generate::Flags;
     use std::fs;
     use tempfile::TempDir;
 
@@ -469,6 +486,39 @@ async fn main() {
         .await;
 }
 "#
+    }
+
+    #[test]
+    fn generate_then_destroy_channel_ws_round_trips_to_original_project_state() {
+        let tmp = project_with_main(default_main());
+        // Mirrors a real `autumn new` project's Cargo.toml: a `tokio`
+        // dev-dependency with `rt`/`macros` already present, so
+        // `ensure_dev_dependency_tokio_test_features` (which has no destroy
+        // wiring yet — a documented gap) is a no-op here, matching reality.
+        let cargo_path = tmp.path().join("Cargo.toml");
+        fs::write(
+            &cargo_path,
+            "[package]\nname=\"x\"\n\n[dependencies]\nautumn-web = \"0.6\"\n\n\
+             [dev-dependencies]\ntokio = { version = \"1\", features = [\"rt\", \"macros\"] }\n",
+        )
+        .unwrap();
+        let main_path = tmp.path().join("src/main.rs");
+        let original_cargo = fs::read_to_string(&cargo_path).unwrap();
+        let original_main = fs::read_to_string(&main_path).unwrap();
+
+        let plan = plan_channel(tmp.path(), "Chat", Transport::Ws).unwrap();
+        plan.execute(Flags::default()).unwrap();
+        assert!(tmp.path().join("src/channels/chat.rs").exists());
+        assert!(fs::read_to_string(&main_path).unwrap().contains("chat_ws"));
+
+        let destroy_plan = plan_channel(tmp.path(), "Chat", Transport::Ws).unwrap();
+        destroy_plan.revert(Flags::default()).unwrap();
+
+        assert!(!tmp.path().join("src/channels/chat.rs").exists());
+        assert!(!tmp.path().join("src/channels/mod.rs").exists());
+        assert!(!tmp.path().join("tests/chat_channel.rs").exists());
+        assert_eq!(fs::read_to_string(&main_path).unwrap(), original_main);
+        assert_eq!(fs::read_to_string(&cargo_path).unwrap(), original_cargo);
     }
 
     // ── RED: file plan assertions ─────────────────────────────────────────

--- a/autumn-cli/src/generate/channel.rs
+++ b/autumn-cli/src/generate/channel.rs
@@ -151,16 +151,19 @@ pub fn plan_channel(
         .filter(|name| !super::model::TEMPLATE_SHIPPED_CARGO_DEPS.contains(name))
         .map(str::to_owned)
         .collect();
+    let channels_dir = project_root.join("src").join("channels");
     if !dep_names.is_empty() {
         plan.push_revert(crate::generate::emit::Revert::CargoDeps {
             path: cargo_path.clone(),
             names: dep_names,
+            owner_dir: channels_dir.clone(),
         });
     }
     for feature in autumn_web_features {
         plan.push_revert(crate::generate::emit::Revert::CargoAutumnWebFeature {
             path: cargo_path.clone(),
             feature: (*feature).to_owned(),
+            owner_dir: Some(channels_dir.clone()),
         });
     }
 

--- a/autumn-cli/src/generate/emit.rs
+++ b/autumn-cli/src/generate/emit.rs
@@ -517,17 +517,14 @@ impl Plan {
         }
 
         for (path, new_content) in &plan.modifies {
-            match new_content {
-                Some(content) => {
-                    fs::write(path, content)?;
-                    println!("  Reverted {}", relative_display(path, &self.project_root));
-                }
-                None => {
-                    fs::remove_file(path)?;
-                    println!("  Removed {}", relative_display(path, &self.project_root));
-                    if let Some(parent) = path.parent() {
-                        touched_dirs.push(parent.to_path_buf());
-                    }
+            if let Some(content) = new_content {
+                fs::write(path, content)?;
+                println!("  Reverted {}", relative_display(path, &self.project_root));
+            } else {
+                fs::remove_file(path)?;
+                println!("  Removed {}", relative_display(path, &self.project_root));
+                if let Some(parent) = path.parent() {
+                    touched_dirs.push(parent.to_path_buf());
                 }
             }
         }
@@ -553,6 +550,13 @@ impl Plan {
     /// Compute what [`Plan::revert`] would do, without touching disk except
     /// to read files for divergence comparison. Shared by the `--dry-run`
     /// and real-run paths of `revert` so they can never disagree.
+    #[allow(
+        clippy::too_many_lines,
+        reason = "a linear sequence of independent passes (normal files, migrations, \
+                  create-if-absent shared files, modify reverts) that share the \
+                  files_to_remove/diverged accumulators — splitting it up would just \
+                  move the same state-threading around, not simplify it"
+    )]
     fn compute_revert_plan(&self, force: bool) -> RevertPlan {
         let migrations_root = self.project_root.join("migrations");
 
@@ -562,6 +566,13 @@ impl Plan {
         // path-stable file to check-and-delete.
         let mut migration_groups: Vec<(PathBuf, Vec<&Action>)> = Vec::new();
         let mut normal_actions: Vec<&Action> = Vec::new();
+        // `CreateIfAbsent` actions for a *shared* file (e.g. a mailer's
+        // `templates/mailers/_layout.html`) are deferred to their own pass
+        // below — unlike an owned `Create`, a later resource's `generate`
+        // call silently skips writing to it once an earlier resource's call
+        // already created it, so the action being present in THIS resource's
+        // plan doesn't mean this resource is the only one still using it.
+        let mut create_if_absent_actions: Vec<&Action> = Vec::new();
         for action in &self.actions {
             if matches!(action, Action::Modify { .. }) {
                 continue;
@@ -577,7 +588,11 @@ impl Plan {
                 }
                 continue;
             }
-            normal_actions.push(action);
+            if matches!(action, Action::CreateIfAbsent { .. }) {
+                create_if_absent_actions.push(action);
+            } else {
+                normal_actions.push(action);
+            }
         }
 
         let mut files_to_remove = Vec::new();
@@ -588,12 +603,47 @@ impl Plan {
                 continue; // already gone — idempotent skip.
             }
             let matches = match action {
-                Action::Create { contents, .. } | Action::CreateIfAbsent { contents, .. } => {
+                Action::Create { contents, .. } => {
                     fs::read_to_string(path).is_ok_and(|d| &d == contents)
                 }
                 Action::CreateBytes { bytes, .. } => fs::read(path).is_ok_and(|d| &d == bytes),
-                Action::Modify { .. } => unreachable!("filtered out above"),
+                Action::CreateIfAbsent { .. } | Action::Modify { .. } => {
+                    unreachable!("filtered out above")
+                }
             };
+            if matches || force {
+                files_to_remove.push(path.to_path_buf());
+            } else {
+                diverged.push(path.to_path_buf());
+            }
+        }
+
+        // Now resolve the deferred `CreateIfAbsent` actions: only remove a
+        // shared file once its directory holds no other file this destroy
+        // isn't itself already removing — including sibling `CreateIfAbsent`
+        // files from the SAME batch (excluded up front, so whichever one is
+        // checked first doesn't see the other, still-unprocessed one as
+        // false evidence that the directory is still occupied).
+        let create_if_absent_paths: Vec<PathBuf> = create_if_absent_actions
+            .iter()
+            .map(|a| a.path().to_path_buf())
+            .collect();
+        for action in create_if_absent_actions {
+            let path = action.path();
+            if !path.exists() {
+                continue;
+            }
+            if let Some(dir) = path.parent() {
+                let mut excluding = files_to_remove.clone();
+                excluding.extend(create_if_absent_paths.iter().cloned());
+                if resource_dir_has_other_files(dir, &excluding) {
+                    continue; // a sibling resource's file still lives here — keep it.
+                }
+            }
+            let Action::CreateIfAbsent { contents, .. } = action else {
+                unreachable!("filtered to CreateIfAbsent above");
+            };
+            let matches = fs::read_to_string(path).is_ok_and(|d| &d == contents);
             if matches || force {
                 files_to_remove.push(path.to_path_buf());
             } else {
@@ -773,7 +823,10 @@ fn migration_dir_matches_actions(dir: &Path, actions: &[&Action]) -> bool {
 /// ("version") and the remaining suffix, e.g.
 /// `"20260706120000_create_posts"` → `("20260706120000", "create_posts")`.
 fn split_migration_dir_name(name: &str) -> (&str, &str) {
-    let digit_len = name.chars().take_while(char::is_ascii_digit).count();
+    let digit_len = name
+        .bytes()
+        .position(|b| !b.is_ascii_digit())
+        .unwrap_or(name.len());
     let (version, rest) = name.split_at(digit_len);
     (version, rest.strip_prefix('_').unwrap_or(rest))
 }
@@ -886,16 +939,16 @@ fn migration_applied_status(version: &str, migrations_dir: &Path) -> MigrationSt
     ) else {
         return MigrationStatus::NotConfigured;
     };
-    match autumn_web::migrate::applied_user_migrations(&url, migrations_dir) {
-        Ok(applied) => {
+    autumn_web::migrate::applied_user_migrations(&url, migrations_dir).map_or(
+        MigrationStatus::Unknown,
+        |applied| {
             if applied.iter().any(|m| m.version == version) {
                 MigrationStatus::Applied
             } else {
                 MigrationStatus::NotApplied
             }
-        }
-        Err(_) => MigrationStatus::Unknown,
-    }
+        },
+    )
 }
 
 /// Shared, infrastructure-only module names any generator's `update_main_rs`

--- a/autumn-cli/src/generate/emit.rs
+++ b/autumn-cli/src/generate/emit.rs
@@ -982,7 +982,9 @@ enum MigrationOutcome {
     Diverged(PathBuf),
     /// The migration appears to be applied to a configured database (or the
     /// database couldn't be reached, which is treated conservatively the
-    /// same way) — never removed except with `--force`.
+    /// same way) — never removed, not even with `--force`: deleting the
+    /// files backing an applied migration would leave the database unable
+    /// to reconstruct or roll back that step.
     Applied(PathBuf),
     /// More than one on-disk migration directory normalizes to the same
     /// suffix (e.g. a `model`-generated migration and an independently
@@ -1103,10 +1105,13 @@ fn resolve_migration_removal(
         return MigrationOutcome::StillNeededElsewhere(real_dir);
     }
 
-    if force {
-        return MigrationOutcome::Remove(real_dir);
-    }
-
+    // Deliberately NOT gated on `force`: `--force` bypasses content
+    // divergence and the sibling-resource "still needed elsewhere" caution,
+    // but never the applied-migration check (issue #1048 PR review) —
+    // removing files backing a migration the database already recorded as
+    // applied would leave that database unable to reconstruct or roll back
+    // the step, which is a data-safety concern `--force`'s documented
+    // purpose (bypassing content mismatches) was never meant to cover.
     let real_dir_name = real_dir.file_name().and_then(|n| n.to_str()).unwrap_or("");
     let (version, _) = split_migration_dir_name(real_dir_name);
     match migration_applied_status(version, migrations_root) {
@@ -1615,6 +1620,51 @@ mod tests {
             assert!(matches!(err, GenerateError::Diverged(_)));
             assert!(real_dir.exists());
         });
+    }
+
+    #[test]
+    fn revert_never_removes_a_migration_with_an_unreachable_database_even_with_force() {
+        // A configured but unreachable database is treated the same as
+        // "applied" (conservative: destroy can't confirm it's safe). Even
+        // `--force` must not remove the migration files in that case
+        // (issue #1048 PR review) — `--force` bypasses content divergence
+        // and shared-resource caution, never the applied-migration guard,
+        // since deleting files backing a migration the database might
+        // already record as applied would leave it unable to reconstruct
+        // or roll back that step.
+        temp_env::with_vars(
+            [
+                ("AUTUMN_DATABASE__PRIMARY_URL", None::<&str>),
+                (
+                    "AUTUMN_DATABASE__URL",
+                    Some("postgres://postgres:x@127.0.0.1:1/nope"),
+                ),
+                ("DATABASE_URL", None::<&str>),
+            ],
+            || {
+                let (tmp, mut plan) = fixture();
+                fs::create_dir_all(tmp.path().join("migrations")).unwrap();
+                let plan_dir = tmp.path().join("migrations/99999999999999_create_posts");
+                let real_dir = tmp.path().join("migrations/20260101000000_create_posts");
+                fs::create_dir_all(&real_dir).unwrap();
+                fs::write(real_dir.join("up.sql"), "CREATE TABLE posts ();\n").unwrap();
+                fs::write(real_dir.join("down.sql"), "DROP TABLE posts;\n").unwrap();
+
+                plan.create(plan_dir.join("up.sql"), "CREATE TABLE posts ();\n");
+                plan.create(plan_dir.join("down.sql"), "DROP TABLE posts;\n");
+
+                plan.revert(Flags {
+                    force: true,
+                    dry_run: false,
+                })
+                .unwrap();
+
+                assert!(
+                    real_dir.exists(),
+                    "migration must survive even with --force when the database is unreachable"
+                );
+            },
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/emit.rs
+++ b/autumn-cli/src/generate/emit.rs
@@ -1235,6 +1235,24 @@ fn resolve_migration_removal(
         }
     }
 
+    // Refuse to sweep up files this generator never planned — a hand-added
+    // `README.md` or an auxiliary fixture living alongside `up.sql`/
+    // `down.sql` — unless `--force` is passed (issue #1048 PR review).
+    // Without this, `remove_dir_all` below would silently delete
+    // hand-authored content just because it happens to share a directory
+    // with the generated migration files.
+    if !force && let Ok(entries) = fs::read_dir(&real_dir) {
+        for entry in entries.filter_map(Result::ok) {
+            let name = entry.file_name();
+            let planned = actions
+                .iter()
+                .any(|action| action.path().file_name() == Some(name.as_os_str()));
+            if !planned {
+                return MigrationOutcome::Diverged(entry.path());
+            }
+        }
+    }
+
     if !force
         && mail_unsubscribes_migration_still_needed_elsewhere(&real_dir, project_root, excluding)
     {

--- a/autumn-cli/src/generate/emit.rs
+++ b/autumn-cli/src/generate/emit.rs
@@ -481,10 +481,15 @@ impl Plan {
     /// Undo this plan — the deterministic inverse of [`Plan::execute`]
     /// driving `autumn destroy` (issue #1048).
     ///
-    /// For each `Create`/`CreateBytes`/`CreateIfAbsent` action, deletes the
-    /// target file (refusing when its on-disk content has diverged from what
-    /// `generate` would have produced, unless `--force`), then prunes any
-    /// now-empty generated directories. For each [`Revert`] recorded via
+    /// For each `Create`/`CreateBytes` action, deletes the target file
+    /// (refusing when its on-disk content has diverged from what `generate`
+    /// would have produced, unless `--force`). A `CreateIfAbsent` target
+    /// (a file shared across resources that `generate` only ever writes
+    /// once) is deleted only when its content still matches exactly —
+    /// divergence there is left alone with a warning instead, never
+    /// force-deleted, since it may predate this resource entirely rather
+    /// than being this destroy's own edit gone stale. Either way, prunes any
+    /// now-empty generated directories afterward. For each [`Revert`] recorded via
     /// [`Plan::push_revert`], removes exactly the lines/entries `generate`
     /// inserted from the current file — never touching content this plan
     /// didn't itself add. A file emptied down to nothing by its reverts is
@@ -650,6 +655,7 @@ impl Plan {
 
         let mut files_to_remove = Vec::new();
         let mut diverged = Vec::new();
+        let mut warnings = Vec::new();
         for action in normal_actions {
             let path = action.path();
             if !path.exists() {
@@ -697,15 +703,29 @@ impl Plan {
                 unreachable!("filtered to CreateIfAbsent above");
             };
             let matches = fs::read_to_string(path).is_ok_and(|d| &d == contents);
-            if matches || force {
+            if matches {
                 files_to_remove.push(path.to_path_buf());
             } else {
-                diverged.push(path.to_path_buf());
+                // Unlike an owned `Create`, a `CreateIfAbsent` target may
+                // have pre-existed before ANY generator ever ran (`generate`
+                // silently skips writing to it either way) — e.g. a
+                // hand-rolled `templates/mailers/_layout.html`. Divergence
+                // here can't be attributed to "this destroy's own edit gone
+                // stale" the way it can for an owned `Create`, so it's never
+                // treated as a blocking error and never force-deleted
+                // (issue #1048 PR review): guessing wrong would destroy
+                // real, pre-existing project content this destroy never
+                // touched. Just leave it and say why.
+                warnings.push(format!(
+                    "{} doesn't match what this generator produces; leaving it in \
+                     place since it may predate this resource — remove it by hand \
+                     if it's actually orphaned.",
+                    relative_display(path, &self.project_root),
+                ));
             }
         }
 
         let mut migrations_to_remove = Vec::new();
-        let mut warnings = Vec::new();
         for (dir, actions) in &migration_groups {
             match resolve_migration_removal(
                 dir,
@@ -1572,6 +1592,51 @@ mod tests {
         assert!(!tmp.path().join("templates/posts").exists());
         assert!(tmp.path().join("templates").exists());
         assert!(tmp.path().join("templates/other/keep.tmpl").exists());
+    }
+
+    #[test]
+    fn revert_never_deletes_a_diverged_create_if_absent_file_even_with_force() {
+        // A `CreateIfAbsent` target (e.g. a shared mailer layout) may
+        // pre-exist before ANY generator ever wrote to it — `generate`
+        // silently skips it either way, so content divergence here can't be
+        // attributed to "this destroy's own edit gone stale" the way it can
+        // for an owned `Create`. `--force` must never delete it (issue
+        // #1048 PR review): guessing wrong would destroy real, pre-existing
+        // project content this destroy never touched.
+        let (tmp, mut plan) = fixture();
+        let layout = tmp.path().join("templates/mailers/_layout.html");
+        fs::create_dir_all(layout.parent().unwrap()).unwrap();
+        fs::write(&layout, "hand-rolled layout, predates any mailer").unwrap();
+        plan.create_if_absent(layout.clone(), "generated default layout");
+
+        plan.revert(Flags {
+            force: true,
+            dry_run: false,
+        })
+        .unwrap();
+
+        assert!(
+            layout.exists(),
+            "pre-existing content diverging from the generated default must survive \
+             even with --force"
+        );
+        assert_eq!(
+            fs::read_to_string(&layout).unwrap(),
+            "hand-rolled layout, predates any mailer"
+        );
+    }
+
+    #[test]
+    fn revert_deletes_a_create_if_absent_file_when_content_matches_the_generated_default() {
+        let (tmp, mut plan) = fixture();
+        let layout = tmp.path().join("templates/mailers/_layout.html");
+        fs::create_dir_all(layout.parent().unwrap()).unwrap();
+        plan.create_if_absent(layout.clone(), "generated default layout");
+        plan.execute(Flags::default()).unwrap();
+
+        plan.revert(Flags::default()).unwrap();
+
+        assert!(!layout.exists());
     }
 
     #[test]

--- a/autumn-cli/src/generate/emit.rs
+++ b/autumn-cli/src/generate/emit.rs
@@ -1306,22 +1306,45 @@ fn migration_applied_status(version: &str, migrations_dir: &Path) -> MigrationSt
     // which would defeat the applied-migration safety guard below.
     let profile = crate::migrate::effective_profile(None);
     let table = crate::migrate::read_autumn_toml_table_with_profile(Some(&profile));
-    let Some(url) = crate::migrate::resolve_primary_database_url_from_sources(
+    let control_url = crate::migrate::resolve_primary_database_url_from_sources(
         |k| std::env::var(k),
         table.as_ref(),
-    ) else {
+    );
+    // `autumn migrate run --shard <name>` applies user migrations to shard
+    // databases too, independently of the control database (issue #1048 PR
+    // review) — a sharded project checking only the control URL could
+    // delete a migration's files while a shard still records it as applied,
+    // leaving that shard unable to reconstruct or roll back the step.
+    let shard_urls = crate::migrate::resolve_shard_database_urls_from_sources(
+        |k| std::env::var(k),
+        table.as_ref(),
+    );
+    let urls: Vec<String> = control_url
+        .into_iter()
+        .chain(shard_urls.into_iter().map(|(_, url)| url))
+        .collect();
+    if urls.is_empty() {
         return MigrationStatus::NotConfigured;
-    };
-    autumn_web::migrate::applied_user_migrations(&url, migrations_dir).map_or(
-        MigrationStatus::Unknown,
-        |applied| {
-            if applied.iter().any(|m| m.version == version) {
-                MigrationStatus::Applied
-            } else {
-                MigrationStatus::NotApplied
+    }
+    // Applied on ANY target (control or a shard) blocks removal outright;
+    // otherwise an unreachable target is treated the same as "applied"
+    // (conservative: never delete migration files destroy can't confirm are
+    // safe to remove on every configured database).
+    let mut any_unreachable = false;
+    for url in urls {
+        match autumn_web::migrate::applied_user_migrations(&url, migrations_dir) {
+            Ok(applied) if applied.iter().any(|m| m.version == version) => {
+                return MigrationStatus::Applied;
             }
-        },
-    )
+            Ok(_) => {}
+            Err(_) => any_unreachable = true,
+        }
+    }
+    if any_unreachable {
+        MigrationStatus::Unknown
+    } else {
+        MigrationStatus::NotApplied
+    }
 }
 
 /// Shared, infrastructure-only module names any generator's `update_main_rs`
@@ -1896,6 +1919,52 @@ mod tests {
                 assert!(
                     real_dir.exists(),
                     "migration must survive even with --force when the database is unreachable"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn revert_never_removes_a_migration_when_only_an_unreachable_shard_is_configured() {
+        // A shard-only deployment (no control database role) is a valid
+        // shape (issue #1048 PR review): `autumn migrate run --shard
+        // <name>` applies user migrations to shard databases independently
+        // of any control URL. Checking only the control URL would see "no
+        // database configured" and happily delete migration files a shard
+        // still needs.
+        temp_env::with_vars(
+            [
+                ("AUTUMN_DATABASE__PRIMARY_URL", None::<&str>),
+                ("AUTUMN_DATABASE__URL", None::<&str>),
+                ("DATABASE_URL", None::<&str>),
+                ("AUTUMN_DATABASE__SHARDS__0__NAME", Some("shard0")),
+                (
+                    "AUTUMN_DATABASE__SHARDS__0__PRIMARY_URL",
+                    Some("postgres://postgres:x@127.0.0.1:1/nope"),
+                ),
+            ],
+            || {
+                let (tmp, mut plan) = fixture();
+                fs::create_dir_all(tmp.path().join("migrations")).unwrap();
+                let plan_dir = tmp.path().join("migrations/99999999999999_create_posts");
+                let real_dir = tmp.path().join("migrations/20260101000000_create_posts");
+                fs::create_dir_all(&real_dir).unwrap();
+                fs::write(real_dir.join("up.sql"), "CREATE TABLE posts ();\n").unwrap();
+                fs::write(real_dir.join("down.sql"), "DROP TABLE posts;\n").unwrap();
+
+                plan.create(plan_dir.join("up.sql"), "CREATE TABLE posts ();\n");
+                plan.create(plan_dir.join("down.sql"), "DROP TABLE posts;\n");
+
+                plan.revert(Flags {
+                    force: true,
+                    dry_run: false,
+                })
+                .unwrap();
+
+                assert!(
+                    real_dir.exists(),
+                    "migration must survive when a shard is configured but unreachable, \
+                     even with no control database URL and even with --force"
                 );
             },
         );

--- a/autumn-cli/src/generate/emit.rs
+++ b/autumn-cli/src/generate/emit.rs
@@ -5,7 +5,7 @@
 //! collision detection, `--force` / `--dry-run`, and the human-readable
 //! "Created/Modified" output that mirrors `autumn new`.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
@@ -195,7 +195,22 @@ impl Revert {
     /// Apply this revert to `content`, returning the new content. Every
     /// underlying transform is idempotent — a revert whose target is
     /// already absent returns `content` unchanged.
-    fn apply(&self, content: &str, project_root: &Path, excluding: &[PathBuf]) -> String {
+    ///
+    /// `overrides` supplies the already-computed post-destroy content of
+    /// OTHER files this same `Plan::revert` is also modifying (e.g.
+    /// `src/schema.rs`, once its own `SchemaTable` revert has run) — the
+    /// project-wide crate/feature usage scan ([`crate_referenced_elsewhere_in_project`]/
+    /// [`autumn_web_feature_still_needed_elsewhere`]) reads from there
+    /// instead of stale pre-destroy disk content when a path is present,
+    /// falling back to `excluding`-gated disk reads otherwise (issue #1048
+    /// PR review).
+    fn apply(
+        &self,
+        content: &str,
+        project_root: &Path,
+        excluding: &[PathBuf],
+        overrides: &HashMap<PathBuf, String>,
+    ) -> String {
         use super::inbound_mail::remove_inbound_mail_handler;
         use super::schema_edit::{
             remove_autumn_web_dev_dependency_feature, remove_autumn_web_feature, remove_job_entry,
@@ -225,7 +240,12 @@ impl Revert {
                     .iter()
                     .map(String::as_str)
                     .filter(|name| {
-                        !crate_referenced_elsewhere_in_project(project_root, name, excluding)
+                        !crate_referenced_elsewhere_in_project(
+                            project_root,
+                            name,
+                            excluding,
+                            overrides,
+                        )
                     })
                     .collect();
                 if survives.is_empty() {
@@ -235,14 +255,24 @@ impl Revert {
                 }
             }
             Self::CargoAutumnWebFeature { feature, .. } => {
-                if autumn_web_feature_still_needed_elsewhere(feature, project_root, excluding) {
+                if autumn_web_feature_still_needed_elsewhere(
+                    feature,
+                    project_root,
+                    excluding,
+                    overrides,
+                ) {
                     content.to_owned()
                 } else {
                     remove_autumn_web_feature(content, feature)
                 }
             }
             Self::CargoAutumnWebDevFeature { feature, .. } => {
-                if autumn_web_feature_still_needed_elsewhere(feature, project_root, excluding) {
+                if autumn_web_feature_still_needed_elsewhere(
+                    feature,
+                    project_root,
+                    excluding,
+                    overrides,
+                ) {
                     content.to_owned()
                 } else {
                     remove_autumn_web_dev_dependency_feature(content, feature)
@@ -763,9 +793,57 @@ impl Plan {
         // disk at scan time — the real rewrite/deletion happens later, in
         // `Plan::revert`'s apply phase) isn't evidence of anything a
         // *different* resource still needs, since this same operation is
-        // about to change it too.
+        // about to change it too. `scan_overrides` (below) supplies each
+        // such file's real final content instead, so this exclusion only
+        // ever falls back to "treat as absent" for a file that becomes
+        // empty (deleted) — never for one that survives with other content.
         let mut cargo_deps_excluding = files_to_remove.clone();
         cargo_deps_excluding.extend(grouped_reverts.iter().map(|(path, _)| path.clone()));
+
+        // Precompute the final, post-destroy content of every modified file
+        // OTHER than `Cargo.toml` via each file's own, self-contained
+        // reverts (none of them — `SchemaTable`, `ModDecl`, etc. — consult
+        // another file's content). `Cargo.toml`'s `CargoDeps`/
+        // `CargoAutumnWebFeature`/`CargoAutumnWebDevFeature` reverts are the
+        // only ones that DO (the project-wide crate/feature usage scan),
+        // and always target `Cargo.toml` itself, so computing every other
+        // file's result first and excluding `Cargo.toml` here avoids any
+        // ordering cycle. This is what lets that scan see what
+        // `src/schema.rs` (or `src/main.rs`, a `mod.rs`, ...) will actually
+        // look like once this destroy is done — e.g. a table this destroy
+        // ISN'T touching, still present after its own removal — rather than
+        // either stale pre-destroy content (would wrongly count a table
+        // being removed as "still needed") or hiding the file from the scan
+        // entirely (would wrongly hide unrelated content in the same file
+        // that legitimately still needs the dependency) — issue #1048 PR
+        // review.
+        let cargo_toml_path = self.project_root.join("Cargo.toml");
+        let mut scan_overrides: HashMap<PathBuf, String> = HashMap::new();
+        for (path, reverts) in &grouped_reverts {
+            if *path == cargo_toml_path || !path.exists() {
+                continue;
+            }
+            let Ok(original) = fs::read_to_string(path) else {
+                continue;
+            };
+            let mut content = original;
+            for revert in reverts {
+                if let Some(dir) = revert.owner_dir()
+                    && resource_dir_has_other_files(dir, &files_to_remove)
+                {
+                    continue;
+                }
+                content = revert.apply(
+                    &content,
+                    &self.project_root,
+                    &cargo_deps_excluding,
+                    &scan_overrides,
+                );
+            }
+            if !content.trim().is_empty() {
+                scan_overrides.insert(path.clone(), content);
+            }
+        }
 
         let mut modifies = Vec::new();
         for (path, reverts) in grouped_reverts {
@@ -785,7 +863,12 @@ impl Plan {
                     // feature — leave the Cargo.toml edit in place.
                     continue;
                 }
-                content = revert.apply(&content, &self.project_root, &cargo_deps_excluding);
+                content = revert.apply(
+                    &content,
+                    &self.project_root,
+                    &cargo_deps_excluding,
+                    &scan_overrides,
+                );
             }
             if content == original {
                 continue;
@@ -892,12 +975,13 @@ fn crate_referenced_elsewhere_in_project(
     project_root: &Path,
     crate_name: &str,
     excluding: &[PathBuf],
+    overrides: &HashMap<PathBuf, String>,
 ) -> bool {
     let ident = crate_name.replace('-', "_");
     let markers = [format!("{ident}::"), format!("use {ident}")];
     ["src", "tests", "benches"]
         .iter()
-        .any(|dir| rs_tree_contains_marker(&project_root.join(dir), &markers, excluding))
+        .any(|dir| rs_tree_contains_marker(&project_root.join(dir), &markers, excluding, overrides))
 }
 
 /// A text marker that reliably indicates `feature`'s autumn-web API surface
@@ -940,6 +1024,7 @@ fn autumn_web_feature_still_needed_elsewhere(
     feature: &str,
     project_root: &Path,
     excluding: &[PathBuf],
+    overrides: &HashMap<PathBuf, String>,
 ) -> bool {
     let Some(marker) = autumn_web_feature_marker(feature) else {
         return false;
@@ -947,7 +1032,7 @@ fn autumn_web_feature_still_needed_elsewhere(
     let markers = [marker.to_owned()];
     ["src", "tests", "benches"]
         .iter()
-        .any(|dir| rs_tree_contains_marker(&project_root.join(dir), &markers, excluding))
+        .any(|dir| rs_tree_contains_marker(&project_root.join(dir), &markers, excluding, overrides))
 }
 
 /// Whether a local Cargo `feature` (not an `autumn-web` feature — see
@@ -964,28 +1049,51 @@ pub(super) fn cargo_feature_still_gated_elsewhere(
     excluding: &[PathBuf],
 ) -> bool {
     let markers = [format!("feature = \"{feature}\"")];
-    ["src", "tests", "benches"]
-        .iter()
-        .any(|dir| rs_tree_contains_marker(&project_root.join(dir), &markers, excluding))
+    let no_overrides = HashMap::new();
+    ["src", "tests", "benches"].iter().any(|dir| {
+        rs_tree_contains_marker(&project_root.join(dir), &markers, excluding, &no_overrides)
+    })
 }
 
-/// Recursively scan `dir` for any `.rs` file (other than `excluding`)
-/// containing one of `markers` as a plain substring.
-fn rs_tree_contains_marker(dir: &Path, markers: &[String], excluding: &[PathBuf]) -> bool {
+/// Recursively scan `dir` for any `.rs` file containing one of `markers` as
+/// a plain substring.
+///
+/// `overrides` (path → already-computed post-destroy content) takes
+/// priority over both disk and `excluding` — it's how a caller supplies the
+/// real final content of a file this same `Plan::revert` is also modifying
+/// in place (e.g. `src/schema.rs`), so scanning it doesn't see stale
+/// pre-destroy content (issue #1048 PR review). A path in `excluding` but
+/// absent from `overrides` is skipped entirely — it's either being deleted
+/// outright, or emptied down to nothing by its own reverts, so it won't
+/// exist to provide evidence either way once this destroy finishes.
+fn rs_tree_contains_marker(
+    dir: &Path,
+    markers: &[String],
+    excluding: &[PathBuf],
+    overrides: &HashMap<PathBuf, String>,
+) -> bool {
     let Ok(entries) = fs::read_dir(dir) else {
         return false;
     };
     for entry in entries.filter_map(Result::ok) {
         let path = entry.path();
         if path.is_dir() {
-            if rs_tree_contains_marker(&path, markers, excluding) {
+            if rs_tree_contains_marker(&path, markers, excluding, overrides) {
                 return true;
             }
-        } else if path.extension().is_some_and(|ext| ext == "rs")
-            && !excluding.contains(&path)
-            && fs::read_to_string(&path)
-                .is_ok_and(|content| markers.iter().any(|m| content.contains(m.as_str())))
-        {
+            continue;
+        }
+        if path.extension().is_none_or(|ext| ext != "rs") {
+            continue;
+        }
+        let content = overrides.get(&path).cloned().or_else(|| {
+            if excluding.contains(&path) {
+                None
+            } else {
+                fs::read_to_string(&path).ok()
+            }
+        });
+        if content.is_some_and(|c| markers.iter().any(|m| c.contains(m.as_str()))) {
             return true;
         }
     }
@@ -1637,6 +1745,67 @@ mod tests {
         plan.revert(Flags::default()).unwrap();
 
         assert!(!layout.exists());
+    }
+
+    #[test]
+    fn revert_keeps_a_dependency_still_needed_by_another_table_in_the_same_schema_file() {
+        // issue #1048 PR review: excluding the WHOLE `src/schema.rs` from
+        // the crate-usage scan (because this destroy is also rewriting it)
+        // hid a second, unrelated `diesel::table!` block that survives the
+        // destroy — wrongly treating `diesel` as unused project-wide when
+        // it's still needed by that other table. The scan must see
+        // `schema.rs`'s real POST-destroy content, not exclude the file
+        // outright.
+        use crate::generate::dsl::parse_fields;
+        use crate::generate::schema_edit::append_schema_table;
+
+        let (tmp, mut plan) = fixture();
+        let fields = parse_fields(&["title:String".to_owned()]).unwrap();
+        let posts_block = append_schema_table("", "posts", &fields);
+        let schema_path = tmp.path().join("src/schema.rs");
+        fs::create_dir_all(schema_path.parent().unwrap()).unwrap();
+        // A second, pre-existing table this destroy never touches.
+        let schema_with_users = append_schema_table("", "users", &fields);
+        let schema_content = append_schema_table(&schema_with_users, "posts", &fields);
+        fs::write(&schema_path, &schema_content).unwrap();
+
+        let cargo_path = tmp.path().join("Cargo.toml");
+        fs::write(
+            &cargo_path,
+            "[package]\nname = \"x\"\n\n[dependencies]\ndiesel = \"2\"\n",
+        )
+        .unwrap();
+
+        plan.push_revert(Revert::SchemaTable {
+            path: schema_path.clone(),
+            table: "posts".to_owned(),
+            expected_block: posts_block,
+        });
+        let models_dir = tmp.path().join("src/models");
+        fs::create_dir_all(&models_dir).unwrap();
+        plan.push_revert(Revert::CargoDeps {
+            path: cargo_path.clone(),
+            names: vec!["diesel".to_owned()],
+            owner_dir: models_dir,
+        });
+
+        plan.revert(Flags::default()).unwrap();
+
+        let schema_after = fs::read_to_string(&schema_path).unwrap();
+        assert!(
+            !schema_after.contains("posts ("),
+            "posts table must be removed"
+        );
+        assert!(
+            schema_after.contains("users ("),
+            "the other table must survive: {schema_after}"
+        );
+        let cargo_after = fs::read_to_string(&cargo_path).unwrap();
+        assert!(
+            cargo_after.contains("diesel"),
+            "diesel must survive — schema.rs still has a diesel::table! for `users`: \
+             {cargo_after}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/emit.rs
+++ b/autumn-cli/src/generate/emit.rs
@@ -42,6 +42,98 @@ impl Action {
     }
 }
 
+/// One in-place edit `generate` made to a shared file, recorded so `autumn
+/// destroy` (issue #1048) can remove exactly that edit later — the
+/// per-generator "revoke" hook the issue calls for.
+///
+/// Lives on [`Plan`] rather than on the [`Action::Modify`] it accompanies:
+/// some generators (e.g. `scaffold`) collapse several `Modify` actions
+/// targeting the same file (`Cargo.toml`) into one via
+/// `plan.actions.retain(...)` + re-push, which would silently drop
+/// per-action metadata. A plan-level list survives that.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Revert {
+    /// Remove a `pub mod <name>;` declaration from a `mod.rs`-style file.
+    ModDecl { path: PathBuf, name: String },
+    /// Remove `entries` from the first `routes![...]` invocation in `path`
+    /// (`src/main.rs`).
+    RoutesEntries { path: PathBuf, entries: Vec<String> },
+    /// Remove the `diesel::table! { <table> ... }` block from `path`
+    /// (`src/schema.rs`).
+    SchemaTable { path: PathBuf, table: String },
+    /// Remove the named crates' shorthand `[dependencies]` lines from `path`
+    /// (`Cargo.toml`).
+    CargoDeps { path: PathBuf, names: Vec<String> },
+    /// Remove `feature` from `autumn-web`'s `[dependencies]` features list
+    /// in `path` (`Cargo.toml`), collapsing to a bare version string if that
+    /// empties it.
+    CargoAutumnWebFeature { path: PathBuf, feature: String },
+    /// Remove `feature` from `autumn-web`'s `[dev-dependencies]` features
+    /// list in `path` (`Cargo.toml`), deleting the whole line if that
+    /// empties it (that entry was always freshly inserted, never pre-existing).
+    CargoAutumnWebDevFeature { path: PathBuf, feature: String },
+    /// Remove `entry` from the `jobs![...]` list in `path`
+    /// (`src/jobs/mod.rs`), dropping the whole freshly-generated
+    /// `registered_jobs()` function if it was the only entry.
+    JobEntry { path: PathBuf, entry: String },
+    /// Remove the `.jobs(jobs::registered_jobs())` call from the
+    /// `AppBuilder` chain in `path` (`src/main.rs`).
+    JobsRegistration { path: PathBuf },
+    /// Remove `mailer_type` from the `mail_previews![...]` list in `path`
+    /// (`src/main.rs`), dropping the whole freshly-inserted
+    /// `.mail_previews(...)` call if it was the only entry.
+    MailPreview { path: PathBuf, mailer_type: String },
+}
+
+impl Revert {
+    /// The path this revert targets.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::ModDecl { path, .. }
+            | Self::RoutesEntries { path, .. }
+            | Self::SchemaTable { path, .. }
+            | Self::CargoDeps { path, .. }
+            | Self::CargoAutumnWebFeature { path, .. }
+            | Self::CargoAutumnWebDevFeature { path, .. }
+            | Self::JobEntry { path, .. }
+            | Self::JobsRegistration { path }
+            | Self::MailPreview { path, .. } => path,
+        }
+    }
+
+    /// Apply this revert to `content`, returning the new content. Every
+    /// underlying transform is idempotent — a revert whose target is
+    /// already absent returns `content` unchanged.
+    fn apply(&self, content: &str) -> String {
+        use super::schema_edit::{
+            remove_autumn_web_dev_dependency_feature, remove_autumn_web_feature, remove_job_entry,
+            remove_jobs_registration_from_app, remove_mail_preview_from_app,
+            remove_mod_declaration, remove_routes_entries, remove_schema_table,
+        };
+        match self {
+            Self::ModDecl { name, .. } => remove_mod_declaration(content, name),
+            Self::RoutesEntries { entries, .. } => remove_routes_entries(content, entries),
+            Self::SchemaTable { table, .. } => remove_schema_table(content, table),
+            Self::CargoDeps { names, .. } => {
+                let names: Vec<&str> = names.iter().map(String::as_str).collect();
+                super::model::remove_cargo_dependencies(content, &names)
+            }
+            Self::CargoAutumnWebFeature { feature, .. } => {
+                remove_autumn_web_feature(content, feature)
+            }
+            Self::CargoAutumnWebDevFeature { feature, .. } => {
+                remove_autumn_web_dev_dependency_feature(content, feature)
+            }
+            Self::JobEntry { entry, .. } => remove_job_entry(content, entry),
+            Self::JobsRegistration { .. } => remove_jobs_registration_from_app(content),
+            Self::MailPreview { mailer_type, .. } => {
+                remove_mail_preview_from_app(content, mailer_type)
+            }
+        }
+    }
+}
+
 /// A complete generator plan — a sequence of actions plus the project root
 /// they are anchored against.
 #[derive(Debug, Default)]
@@ -54,6 +146,10 @@ pub struct Plan {
     /// `--dry-run` and a real run), without failing the generator — e.g. a
     /// `references` field whose target model doesn't exist yet.
     pub warnings: Vec<String>,
+    /// In-place edits recorded alongside [`Action::Modify`]s, so
+    /// [`Plan::revert`] (`autumn destroy`, issue #1048) can remove exactly
+    /// what this plan would have inserted into a shared file.
+    pub reverts: Vec<Revert>,
 }
 
 impl Plan {
@@ -64,6 +160,7 @@ impl Plan {
             project_root: project_root.into(),
             actions: Vec::new(),
             warnings: Vec::new(),
+            reverts: Vec::new(),
         }
     }
 
@@ -71,6 +168,13 @@ impl Plan {
     /// fatal to the plan.
     pub fn warn(&mut self, message: impl Into<String>) {
         self.warnings.push(message.into());
+    }
+
+    /// Record a [`Revert`] describing how to undo an in-place edit this plan
+    /// makes elsewhere via [`Plan::modify`]. Used by `autumn destroy`
+    /// (issue #1048) — irrelevant to a normal `generate` run.
+    pub fn push_revert(&mut self, revert: Revert) {
+        self.reverts.push(revert);
     }
 
     /// Push a [`Action::Create`] action.
@@ -233,6 +337,472 @@ impl Plan {
             );
         }
     }
+
+    /// Undo this plan — the deterministic inverse of [`Plan::execute`]
+    /// driving `autumn destroy` (issue #1048).
+    ///
+    /// For each `Create`/`CreateBytes`/`CreateIfAbsent` action, deletes the
+    /// target file (refusing when its on-disk content has diverged from what
+    /// `generate` would have produced, unless `--force`), then prunes any
+    /// now-empty generated directories. For each [`Revert`] recorded via
+    /// [`Plan::push_revert`], removes exactly the lines/entries `generate`
+    /// inserted from the current file — never touching content this plan
+    /// didn't itself add. A file emptied down to nothing by its reverts is
+    /// deleted outright (e.g. a `schema.rs`/`mod.rs` that only ever held
+    /// this resource's single entry).
+    ///
+    /// Migration directories are matched by resource-name suffix, since
+    /// destroy recomputes the plan with a fresh timestamp that won't match
+    /// the original directory, and are removed only when not yet applied to
+    /// a configured database — destroy never touches the database itself.
+    ///
+    /// Honours `--dry-run` (prints a `Removed:`/`Reverted:` plan, touches
+    /// nothing) exactly like [`Plan::execute`].
+    ///
+    /// # Errors
+    /// Returns [`GenerateError::Diverged`] when any targeted file's content
+    /// no longer matches what `generate` would have produced and `--force`
+    /// was not given; or [`GenerateError::Io`] for filesystem failures.
+    pub fn revert(&self, flags: Flags) -> Result<(), GenerateError> {
+        let plan = self.compute_revert_plan(flags.force);
+
+        if flags.dry_run {
+            println!("Dry run — no files removed.");
+            for path in &plan.files_to_remove {
+                println!(
+                    "  Would remove {}",
+                    relative_display(path, &self.project_root)
+                );
+            }
+            for dir in &plan.migrations_to_remove {
+                println!(
+                    "  Would remove {}",
+                    relative_display(dir, &self.project_root)
+                );
+            }
+            for (path, new_content) in &plan.modifies {
+                let label = if new_content.is_none() {
+                    "Would remove"
+                } else {
+                    "Would revert"
+                };
+                println!("  {label} {}", relative_display(path, &self.project_root));
+            }
+            return Ok(());
+        }
+
+        if !plan.diverged.is_empty() && !flags.force {
+            return Err(GenerateError::Diverged(plan.diverged));
+        }
+
+        for warning in &plan.warnings {
+            eprintln!("Warning: {warning}");
+        }
+
+        let mut touched_dirs: Vec<PathBuf> = Vec::new();
+
+        for path in &plan.files_to_remove {
+            fs::remove_file(path)?;
+            println!("  Removed {}", relative_display(path, &self.project_root));
+            if let Some(parent) = path.parent() {
+                touched_dirs.push(parent.to_path_buf());
+            }
+        }
+
+        for dir in &plan.migrations_to_remove {
+            fs::remove_dir_all(dir)?;
+            println!("  Removed {}", relative_display(dir, &self.project_root));
+            touched_dirs.push(self.project_root.join("migrations"));
+        }
+
+        for (path, new_content) in &plan.modifies {
+            match new_content {
+                Some(content) => {
+                    fs::write(path, content)?;
+                    println!("  Reverted {}", relative_display(path, &self.project_root));
+                }
+                None => {
+                    fs::remove_file(path)?;
+                    println!("  Removed {}", relative_display(path, &self.project_root));
+                    if let Some(parent) = path.parent() {
+                        touched_dirs.push(parent.to_path_buf());
+                    }
+                }
+            }
+        }
+
+        for dir in touched_dirs {
+            prune_empty_ancestors(dir, &self.project_root);
+        }
+
+        // Nested sub-module declarations (e.g. `src/mailers/mod.rs`'s
+        // `pub mod previews;`) must be synced BEFORE `src/main.rs`'s, so a
+        // now-empty-and-deleted `src/mailers/mod.rs` is already gone by the
+        // time the `mod mailers;` orphan check runs.
+        sync_mod_declarations_in(
+            &self.project_root.join("src").join("mailers"),
+            &["previews"],
+            &self.project_root,
+        );
+        sync_main_rs_mod_declarations(&self.project_root);
+
+        Ok(())
+    }
+
+    /// Compute what [`Plan::revert`] would do, without touching disk except
+    /// to read files for divergence comparison. Shared by the `--dry-run`
+    /// and real-run paths of `revert` so they can never disagree.
+    fn compute_revert_plan(&self, force: bool) -> RevertPlan {
+        let migrations_root = self.project_root.join("migrations");
+
+        // `Create`/`CreateBytes`/`CreateIfAbsent` actions living directly
+        // under `migrations/<dir>/` need suffix-based matching (see
+        // `resolve_migration_removal`); everything else is a normal,
+        // path-stable file to check-and-delete.
+        let mut migration_groups: Vec<(PathBuf, Vec<&Action>)> = Vec::new();
+        let mut normal_actions: Vec<&Action> = Vec::new();
+        for action in &self.actions {
+            if matches!(action, Action::Modify { .. }) {
+                continue;
+            }
+            let path = action.path();
+            if let Some(dir) = path.parent()
+                && dir.parent() == Some(migrations_root.as_path())
+            {
+                if let Some(entry) = migration_groups.iter_mut().find(|(d, _)| d == dir) {
+                    entry.1.push(action);
+                } else {
+                    migration_groups.push((dir.to_path_buf(), vec![action]));
+                }
+                continue;
+            }
+            normal_actions.push(action);
+        }
+
+        let mut files_to_remove = Vec::new();
+        let mut diverged = Vec::new();
+        for action in normal_actions {
+            let path = action.path();
+            if !path.exists() {
+                continue; // already gone — idempotent skip.
+            }
+            let matches = match action {
+                Action::Create { contents, .. } | Action::CreateIfAbsent { contents, .. } => {
+                    fs::read_to_string(path).is_ok_and(|d| &d == contents)
+                }
+                Action::CreateBytes { bytes, .. } => fs::read(path).is_ok_and(|d| &d == bytes),
+                Action::Modify { .. } => unreachable!("filtered out above"),
+            };
+            if matches || force {
+                files_to_remove.push(path.to_path_buf());
+            } else {
+                diverged.push(path.to_path_buf());
+            }
+        }
+
+        let mut migrations_to_remove = Vec::new();
+        let mut warnings = Vec::new();
+        for (dir, actions) in &migration_groups {
+            match resolve_migration_removal(dir, actions, &migrations_root, force) {
+                MigrationOutcome::Remove(real_dir) => migrations_to_remove.push(real_dir),
+                MigrationOutcome::Diverged(path) => diverged.push(path),
+                MigrationOutcome::Applied(real_dir) => warnings.push(format!(
+                    "migration {} appears to be applied to the database; skipping it \
+                     — write a down-migration instead. destroy never touches the database.",
+                    relative_display(&real_dir, &self.project_root),
+                )),
+                MigrationOutcome::NotFound => {}
+            }
+        }
+
+        let mut modifies = Vec::new();
+        for (path, reverts) in group_reverts_by_path(&self.reverts) {
+            if !path.exists() {
+                continue;
+            }
+            let Ok(original) = fs::read_to_string(&path) else {
+                continue;
+            };
+            let mut content = original.clone();
+            for revert in &reverts {
+                content = revert.apply(&content);
+            }
+            if content == original {
+                continue;
+            }
+            if content.trim().is_empty() {
+                modifies.push((path, None));
+            } else {
+                modifies.push((path, Some(content)));
+            }
+        }
+
+        RevertPlan {
+            files_to_remove,
+            migrations_to_remove,
+            modifies,
+            diverged,
+            warnings,
+        }
+    }
+}
+
+/// The concrete result of [`Plan::compute_revert_plan`] — everything
+/// [`Plan::revert`] needs to either print (`--dry-run`) or perform (a real
+/// run), computed exactly once so the two paths can't disagree.
+struct RevertPlan {
+    files_to_remove: Vec<PathBuf>,
+    migrations_to_remove: Vec<PathBuf>,
+    /// `(path, new_content)`; `None` means the file should be deleted
+    /// (its reverts emptied it down to nothing).
+    modifies: Vec<(PathBuf, Option<String>)>,
+    diverged: Vec<PathBuf>,
+    warnings: Vec<String>,
+}
+
+/// Group `reverts` by target path, preserving push order both across groups
+/// and within each group.
+fn group_reverts_by_path(reverts: &[Revert]) -> Vec<(PathBuf, Vec<&Revert>)> {
+    let mut groups: Vec<(PathBuf, Vec<&Revert>)> = Vec::new();
+    for revert in reverts {
+        let path = revert.path().to_path_buf();
+        if let Some(entry) = groups.iter_mut().find(|(p, _)| p == &path) {
+            entry.1.push(revert);
+        } else {
+            groups.push((path, vec![revert]));
+        }
+    }
+    groups
+}
+
+/// Remove `dir` and walk up removing each now-empty ancestor, stopping at
+/// the first non-empty directory (or `project_root`). `fs::remove_dir`
+/// fails harmlessly on a non-empty or already-missing directory, which is
+/// exactly the stopping condition we want.
+fn prune_empty_ancestors(mut dir: PathBuf, project_root: &Path) {
+    while dir != *project_root && dir.starts_with(project_root) {
+        if fs::remove_dir(&dir).is_err() {
+            break;
+        }
+        match dir.parent() {
+            Some(parent) => dir = parent.to_path_buf(),
+            None => break,
+        }
+    }
+}
+
+/// Outcome of matching one plan-time migration directory (built with a
+/// fresh, destroy-time timestamp) against what's actually on disk.
+enum MigrationOutcome {
+    /// Safe to remove — content matched (or `--force`) and it is not applied.
+    Remove(PathBuf),
+    /// The real directory's content no longer matches what `generate` would
+    /// have produced.
+    Diverged(PathBuf),
+    /// The migration appears to be applied to a configured database (or the
+    /// database couldn't be reached, which is treated conservatively the
+    /// same way) — never removed except with `--force`.
+    Applied(PathBuf),
+    /// No on-disk directory matches this suffix — already destroyed, or
+    /// never generated.
+    NotFound,
+}
+
+/// Split a migration directory name into its leading numeric timestamp
+/// ("version") and the remaining suffix, e.g.
+/// `"20260706120000_create_posts"` → `("20260706120000", "create_posts")`.
+fn split_migration_dir_name(name: &str) -> (&str, &str) {
+    let digit_len = name.chars().take_while(char::is_ascii_digit).count();
+    let (version, rest) = name.split_at(digit_len);
+    (version, rest.strip_prefix('_').unwrap_or(rest))
+}
+
+/// Resolve one migration-directory group from the (destroy-time,
+/// fresh-timestamp) plan against the real on-disk `migrations/` directory,
+/// matched by suffix, and decide whether it's safe to remove.
+fn resolve_migration_removal(
+    plan_dir: &Path,
+    actions: &[&Action],
+    migrations_root: &Path,
+    force: bool,
+) -> MigrationOutcome {
+    let Some(plan_dir_name) = plan_dir.file_name().and_then(|n| n.to_str()) else {
+        return MigrationOutcome::NotFound;
+    };
+    let (_, suffix) = split_migration_dir_name(plan_dir_name);
+
+    let Ok(entries) = fs::read_dir(migrations_root) else {
+        return MigrationOutcome::NotFound;
+    };
+    let real_dir = entries.filter_map(Result::ok).map(|e| e.path()).find(|p| {
+        p.is_dir()
+            && p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|name| split_migration_dir_name(name).1 == suffix)
+    });
+    let Some(real_dir) = real_dir else {
+        return MigrationOutcome::NotFound;
+    };
+
+    for action in actions {
+        let Some(file_name) = action.path().file_name() else {
+            continue;
+        };
+        let expected: &str = match action {
+            Action::Create { contents, .. } | Action::CreateIfAbsent { contents, .. } => contents,
+            Action::CreateBytes { .. } | Action::Modify { .. } => continue,
+        };
+        let real_file = real_dir.join(file_name);
+        let matches = fs::read_to_string(&real_file).is_ok_and(|actual| actual == *expected);
+        if !matches && !force {
+            return MigrationOutcome::Diverged(real_file);
+        }
+    }
+
+    if force {
+        return MigrationOutcome::Remove(real_dir);
+    }
+
+    let real_dir_name = real_dir.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    let (version, _) = split_migration_dir_name(real_dir_name);
+    match migration_applied_status(version, migrations_root) {
+        MigrationStatus::Applied | MigrationStatus::Unknown => MigrationOutcome::Applied(real_dir),
+        MigrationStatus::NotApplied | MigrationStatus::NotConfigured => {
+            MigrationOutcome::Remove(real_dir)
+        }
+    }
+}
+
+/// Best-effort classification of whether a migration has already been
+/// applied to a database.
+enum MigrationStatus {
+    /// No database URL is configured — this project has never run
+    /// migrations against a real database, so the just-generated migration
+    /// cannot be applied either.
+    NotConfigured,
+    /// A live database check confirmed it has not been applied.
+    NotApplied,
+    /// A live database check confirmed it has been applied.
+    Applied,
+    /// A database URL is configured but couldn't be reached/queried —
+    /// treated the same as `Applied` (conservative: never delete migration
+    /// files destroy can't confirm are safe to remove).
+    Unknown,
+}
+
+fn migration_applied_status(version: &str, migrations_dir: &Path) -> MigrationStatus {
+    let table = crate::migrate::read_autumn_toml_table();
+    let Some(url) = crate::migrate::resolve_primary_database_url_from_sources(
+        |k| std::env::var(k),
+        table.as_ref(),
+    ) else {
+        return MigrationStatus::NotConfigured;
+    };
+    match autumn_web::migrate::applied_user_migrations(&url, migrations_dir) {
+        Ok(applied) => {
+            if applied.iter().any(|m| m.version == version) {
+                MigrationStatus::Applied
+            } else {
+                MigrationStatus::NotApplied
+            }
+        }
+        Err(_) => MigrationStatus::Unknown,
+    }
+}
+
+/// Shared, infrastructure-only module names any generator's `update_main_rs`
+/// call might declare in `src/main.rs` — never resource-specific. Destroy
+/// only ever removes one of these once its backing file/directory no longer
+/// exists, so a project with a second resource still using it is untouched
+/// (issue #1048's "never remove shared declarations" guarantee, made
+/// precise: shared while still needed, removed once genuinely orphaned).
+const SHARED_MAIN_MODULE_NAMES: &[&str] = &[
+    "models",
+    "schema",
+    "repositories",
+    "routes",
+    "channels",
+    "jobs",
+    "mailers",
+];
+
+/// Whether `name`'s backing module still exists on disk — either as
+/// `src/<name>.rs` (the shape `schema` and a single-file resource module
+/// use) or `src/<name>/mod.rs` (a directory of per-resource files).
+fn shared_module_backing_path_exists(project_root: &Path, name: &str) -> bool {
+    let src = project_root.join("src");
+    src.join(format!("{name}.rs")).is_file() || src.join(name).join("mod.rs").is_file()
+}
+
+/// After a real (non-dry-run) `Plan::revert`, strip any [`SHARED_MAIN_MODULE_NAMES`]
+/// declaration from `src/main.rs` whose backing module no longer exists —
+/// the corresponding directory/file was just emptied and deleted by this
+/// same `revert` call. A no-op if `src/main.rs` is missing or nothing
+/// qualifies.
+fn sync_main_rs_mod_declarations(project_root: &Path) {
+    let main_path = project_root.join("src").join("main.rs");
+    let Ok(content) = fs::read_to_string(&main_path) else {
+        return;
+    };
+    let orphaned: Vec<&str> = SHARED_MAIN_MODULE_NAMES
+        .iter()
+        .copied()
+        .filter(|name| {
+            content.lines().any(|l| l.trim() == format!("mod {name};"))
+                && !shared_module_backing_path_exists(project_root, name)
+        })
+        .collect();
+    if orphaned.is_empty() {
+        return;
+    }
+    let updated = super::schema_edit::remove_main_mod_declarations(&content, &orphaned);
+    if updated != content && fs::write(&main_path, &updated).is_ok() {
+        println!("  Reverted {}", relative_display(&main_path, project_root));
+    }
+}
+
+/// Strip a `pub mod <name>;` declaration from `<dir>/mod.rs` for any `name`
+/// in `shared_names` whose backing file/directory no longer exists — the
+/// same "shared while still needed, removed once orphaned" rule
+/// [`sync_main_rs_mod_declarations`] applies to `src/main.rs`, but for a
+/// nested shared sub-module declared in some *other* generated `mod.rs`
+/// (e.g. `src/mailers/mod.rs`'s `pub mod previews;`, shared by every
+/// generated mailer, not owned by one). A no-op if `<dir>/mod.rs` is missing
+/// or nothing qualifies. If removing every orphaned declaration empties the
+/// file, it is deleted instead of left blank.
+fn sync_mod_declarations_in(dir: &Path, shared_names: &[&str], project_root: &Path) {
+    let mod_path = dir.join("mod.rs");
+    let Ok(content) = fs::read_to_string(&mod_path) else {
+        return;
+    };
+    let orphaned: Vec<&str> = shared_names
+        .iter()
+        .copied()
+        .filter(|name| {
+            content
+                .lines()
+                .any(|l| l.trim() == format!("pub mod {name};"))
+                && !dir.join(format!("{name}.rs")).is_file()
+                && !dir.join(name).join("mod.rs").is_file()
+        })
+        .collect();
+    if orphaned.is_empty() {
+        return;
+    }
+    let mut updated = content.clone();
+    for name in orphaned {
+        updated = super::schema_edit::remove_mod_declaration(&updated, name);
+    }
+    if updated == content {
+        return;
+    }
+    if updated.trim().is_empty() {
+        if fs::remove_file(&mod_path).is_ok() {
+            println!("  Removed {}", relative_display(&mod_path, project_root));
+        }
+    } else if fs::write(&mod_path, &updated).is_ok() {
+        println!("  Reverted {}", relative_display(&mod_path, project_root));
+    }
 }
 
 fn relative_display(path: &Path, root: &Path) -> String {
@@ -384,5 +954,197 @@ mod tests {
         // assertion needs to match that form (Windows uses `\` natively).
         assert!(msg.contains(a.display().to_string().replace('\\', "/").as_str()));
         assert!(msg.contains(b.display().to_string().replace('\\', "/").as_str()));
+    }
+
+    // ── `Plan::revert` — the inverse of `Plan::execute` (issue #1048) ──────
+
+    fn no_db_env<R>(f: impl FnOnce() -> R) -> R {
+        temp_env::with_vars(
+            [
+                ("AUTUMN_DATABASE__PRIMARY_URL", None::<&str>),
+                ("AUTUMN_DATABASE__URL", None::<&str>),
+                ("DATABASE_URL", None::<&str>),
+            ],
+            f,
+        )
+    }
+
+    #[test]
+    fn revert_removes_create_action_file() {
+        let (tmp, mut plan) = fixture();
+        let target = tmp.path().join("out.txt");
+        plan.create(target.clone(), "hello");
+        plan.execute(Flags::default()).unwrap();
+        assert!(target.exists());
+        plan.revert(Flags::default()).unwrap();
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn revert_is_idempotent_when_file_already_missing() {
+        let (tmp, mut plan) = fixture();
+        let target = tmp.path().join("out.txt");
+        plan.create(target.clone(), "hello");
+        // Never executed — file was never created.
+        plan.revert(Flags::default()).unwrap();
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn revert_refuses_on_diverged_content_without_force() {
+        let (tmp, mut plan) = fixture();
+        let target = tmp.path().join("out.txt");
+        plan.create(target.clone(), "hello");
+        plan.execute(Flags::default()).unwrap();
+        fs::write(&target, "hand-edited by user").unwrap();
+        let err = plan.revert(Flags::default()).unwrap_err();
+        assert!(matches!(err, GenerateError::Diverged(_)));
+        assert!(target.exists(), "diverged file must not be deleted");
+    }
+
+    #[test]
+    fn revert_with_force_deletes_diverged_file() {
+        let (tmp, mut plan) = fixture();
+        let target = tmp.path().join("out.txt");
+        plan.create(target.clone(), "hello");
+        plan.execute(Flags::default()).unwrap();
+        fs::write(&target, "hand-edited by user").unwrap();
+        plan.revert(Flags {
+            force: true,
+            dry_run: false,
+        })
+        .unwrap();
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn revert_dry_run_does_not_touch_disk() {
+        let (tmp, mut plan) = fixture();
+        let target = tmp.path().join("out.txt");
+        plan.create(target.clone(), "hello");
+        plan.execute(Flags::default()).unwrap();
+        plan.revert(Flags {
+            dry_run: true,
+            force: false,
+        })
+        .unwrap();
+        assert!(target.exists());
+    }
+
+    #[test]
+    fn revert_applies_mod_decl_revert_and_deletes_now_empty_file() {
+        let (tmp, mut plan) = fixture();
+        let mod_path = tmp.path().join("mod.rs");
+        plan.modify(
+            mod_path.clone(),
+            crate::generate::schema_edit::add_mod_declaration("", "post"),
+        );
+        plan.push_revert(Revert::ModDecl {
+            path: mod_path.clone(),
+            name: "post".to_owned(),
+        });
+        plan.execute(Flags::default()).unwrap();
+        assert!(mod_path.exists());
+        plan.revert(Flags::default()).unwrap();
+        assert!(!mod_path.exists());
+    }
+
+    #[test]
+    fn revert_applies_mod_decl_revert_preserving_other_mods() {
+        let (tmp, mut plan) = fixture();
+        let mod_path = tmp.path().join("mod.rs");
+        fs::write(&mod_path, "pub mod user;\n").unwrap();
+        plan.modify(
+            mod_path.clone(),
+            crate::generate::schema_edit::add_mod_declaration("pub mod user;\n", "post"),
+        );
+        plan.push_revert(Revert::ModDecl {
+            path: mod_path.clone(),
+            name: "post".to_owned(),
+        });
+        plan.execute(Flags::default()).unwrap();
+        plan.revert(Flags::default()).unwrap();
+        assert!(mod_path.exists());
+        assert_eq!(fs::read_to_string(&mod_path).unwrap(), "pub mod user;\n");
+    }
+
+    #[test]
+    fn revert_prunes_now_empty_generated_directory_but_not_sibling_content() {
+        let (tmp, mut plan) = fixture();
+        let posts_tmpl = tmp.path().join("templates/posts/index.html.tmpl");
+        plan.create(posts_tmpl.clone(), "content");
+        plan.execute(Flags::default()).unwrap();
+        // A sibling directory under `templates/` must survive pruning.
+        fs::create_dir_all(tmp.path().join("templates/other")).unwrap();
+        fs::write(tmp.path().join("templates/other/keep.tmpl"), "keep").unwrap();
+
+        plan.revert(Flags::default()).unwrap();
+
+        assert!(!posts_tmpl.exists());
+        assert!(!tmp.path().join("templates/posts").exists());
+        assert!(tmp.path().join("templates").exists());
+        assert!(tmp.path().join("templates/other/keep.tmpl").exists());
+    }
+
+    #[test]
+    fn revert_removes_unapplied_migration_matched_by_suffix() {
+        no_db_env(|| {
+            let (tmp, mut plan) = fixture();
+            fs::create_dir_all(tmp.path().join("migrations")).unwrap();
+            // Destroy recomputes the plan with a FRESH timestamp, which won't
+            // match the real, already-generated directory on disk.
+            let plan_dir = tmp.path().join("migrations/99999999999999_create_posts");
+            let real_dir = tmp.path().join("migrations/20260101000000_create_posts");
+            fs::create_dir_all(&real_dir).unwrap();
+            fs::write(real_dir.join("up.sql"), "CREATE TABLE posts ();\n").unwrap();
+            fs::write(real_dir.join("down.sql"), "DROP TABLE posts;\n").unwrap();
+
+            plan.create(plan_dir.join("up.sql"), "CREATE TABLE posts ();\n");
+            plan.create(plan_dir.join("down.sql"), "DROP TABLE posts;\n");
+            // Not executing this plan (it would create the wrong-timestamp
+            // dir) — the point is that revert must find `real_dir` by suffix.
+
+            plan.revert(Flags::default()).unwrap();
+
+            assert!(!real_dir.exists());
+        });
+    }
+
+    #[test]
+    fn revert_refuses_diverged_migration_sql_without_force() {
+        no_db_env(|| {
+            let (tmp, mut plan) = fixture();
+            fs::create_dir_all(tmp.path().join("migrations")).unwrap();
+            let plan_dir = tmp.path().join("migrations/99999999999999_create_posts");
+            let real_dir = tmp.path().join("migrations/20260101000000_create_posts");
+            fs::create_dir_all(&real_dir).unwrap();
+            fs::write(
+                real_dir.join("up.sql"),
+                "CREATE TABLE posts (extra_col INT);\n",
+            )
+            .unwrap();
+            fs::write(real_dir.join("down.sql"), "DROP TABLE posts;\n").unwrap();
+
+            plan.create(plan_dir.join("up.sql"), "CREATE TABLE posts ();\n");
+            plan.create(plan_dir.join("down.sql"), "DROP TABLE posts;\n");
+
+            let err = plan.revert(Flags::default()).unwrap_err();
+            assert!(matches!(err, GenerateError::Diverged(_)));
+            assert!(real_dir.exists());
+        });
+    }
+
+    #[test]
+    fn revert_is_idempotent_when_migration_dir_missing() {
+        no_db_env(|| {
+            let (tmp, mut plan) = fixture();
+            fs::create_dir_all(tmp.path().join("migrations")).unwrap();
+            let plan_dir = tmp.path().join("migrations/99999999999999_create_posts");
+            plan.create(plan_dir.join("up.sql"), "CREATE TABLE posts ();\n");
+            plan.create(plan_dir.join("down.sql"), "DROP TABLE posts;\n");
+
+            // No matching real directory on disk at all — nothing to do.
+            plan.revert(Flags::default()).unwrap();
+        });
     }
 }

--- a/autumn-cli/src/generate/emit.rs
+++ b/autumn-cli/src/generate/emit.rs
@@ -224,10 +224,18 @@ impl Revert {
                 }
             }
             Self::CargoAutumnWebFeature { feature, .. } => {
-                remove_autumn_web_feature(content, feature)
+                if autumn_web_feature_still_needed_elsewhere(feature, project_root, excluding) {
+                    content.to_owned()
+                } else {
+                    remove_autumn_web_feature(content, feature)
+                }
             }
             Self::CargoAutumnWebDevFeature { feature, .. } => {
-                remove_autumn_web_dev_dependency_feature(content, feature)
+                if autumn_web_feature_still_needed_elsewhere(feature, project_root, excluding) {
+                    content.to_owned()
+                } else {
+                    remove_autumn_web_dev_dependency_feature(content, feature)
+                }
             }
             Self::JobEntry { entry, .. } => remove_job_entry(content, entry),
             Self::JobsRegistration { .. } => remove_jobs_registration_from_app(content),
@@ -851,6 +859,56 @@ fn crate_referenced_elsewhere_in_project(
 ) -> bool {
     let ident = crate_name.replace('-', "_");
     let markers = [format!("{ident}::"), format!("use {ident}")];
+    ["src", "tests", "benches"]
+        .iter()
+        .any(|dir| rs_tree_contains_marker(&project_root.join(dir), &markers, excluding))
+}
+
+/// A text marker that reliably indicates `feature`'s autumn-web API surface
+/// is in use somewhere in the project — used as a whole-project supplement
+/// to the same-generator `owner_dir` sibling check for
+/// [`Revert::CargoAutumnWebFeature`]/[`Revert::CargoAutumnWebDevFeature`],
+/// since a feature can be needed by a COMPLETELY DIFFERENT generator kind
+/// than the one being destroyed (e.g. `generate auth` and `generate mailer`
+/// both need `"mail"` — destroying the only mailer must not strip it while
+/// auth's routes still call `Mail::builder()`). `None` for a feature with no
+/// single reliable marker — falls back to the `owner_dir` check alone.
+fn autumn_web_feature_marker(feature: &str) -> Option<&'static str> {
+    match feature {
+        // `maud`/`htmx` are in autumn-web's own `default = [...]` feature
+        // set (see `autumn/Cargo.toml`) — a project's default-features
+        // dependency already carries them regardless of any generator, so
+        // removing the *explicit* `features = [...]` entry never actually
+        // disables the capability, and a project-wide marker check would
+        // wrongly treat autumn's own default-feature boilerplate (e.g.
+        // `src/main.rs`'s stock `layout()`, which always calls
+        // `maud::html!`) as "still needed" in every project. No check
+        // needed — fall through to the `owner_dir` check alone.
+        "mail" => Some("Mail::builder("),
+        "oauth2" => Some("OAuth2"),
+        "webauthn" => Some("Webauthn"),
+        "ws" => Some("#[ws]"),
+        // `TestDb::` (not bare `TestDb`) so a doc comment merely mentioning
+        // the type (e.g. the template-shipped `tests/integration_test.rs`'s
+        // "Add DB-backed tests with `TestDb`...") doesn't count as usage.
+        "test-support" => Some("TestDb::"),
+        _ => None,
+    }
+}
+
+/// Whether `feature` is still referenced anywhere under `project_root`'s
+/// `src/`, `tests/`, or `benches/` trees, other than in `excluding` — see
+/// [`autumn_web_feature_marker`]. Always `false` (never blocks removal) for
+/// a feature with no known marker.
+fn autumn_web_feature_still_needed_elsewhere(
+    feature: &str,
+    project_root: &Path,
+    excluding: &[PathBuf],
+) -> bool {
+    let Some(marker) = autumn_web_feature_marker(feature) else {
+        return false;
+    };
+    let markers = [marker.to_owned()];
     ["src", "tests", "benches"]
         .iter()
         .any(|dir| rs_tree_contains_marker(&project_root.join(dir), &markers, excluding))

--- a/autumn-cli/src/generate/emit.rs
+++ b/autumn-cli/src/generate/emit.rs
@@ -984,16 +984,17 @@ fn crate_referenced_elsewhere_in_project(
         .any(|dir| rs_tree_contains_marker(&project_root.join(dir), &markers, excluding, overrides))
 }
 
-/// A text marker that reliably indicates `feature`'s autumn-web API surface
+/// Text markers that reliably indicate `feature`'s autumn-web API surface
 /// is in use somewhere in the project — used as a whole-project supplement
 /// to the same-generator `owner_dir` sibling check for
 /// [`Revert::CargoAutumnWebFeature`]/[`Revert::CargoAutumnWebDevFeature`],
 /// since a feature can be needed by a COMPLETELY DIFFERENT generator kind
 /// than the one being destroyed (e.g. `generate auth` and `generate mailer`
 /// both need `"mail"` — destroying the only mailer must not strip it while
-/// auth's routes still call `Mail::builder()`). `None` for a feature with no
-/// single reliable marker — falls back to the `owner_dir` check alone.
-fn autumn_web_feature_marker(feature: &str) -> Option<&'static str> {
+/// auth's routes still call `Mail::builder()`). Any one marker matching is
+/// sufficient evidence. Empty for a feature with no reliable marker — falls
+/// back to the `owner_dir` check alone.
+fn autumn_web_feature_markers(feature: &str) -> &'static [&'static str] {
     match feature {
         // `maud`/`htmx` are in autumn-web's own `default = [...]` feature
         // set (see `autumn/Cargo.toml`) — a project's default-features
@@ -1004,21 +1005,27 @@ fn autumn_web_feature_marker(feature: &str) -> Option<&'static str> {
         // `src/main.rs`'s stock `layout()`, which always calls
         // `maud::html!`) as "still needed" in every project. No check
         // needed — fall through to the `owner_dir` check alone.
-        "mail" => Some("Mail::builder("),
-        "oauth2" => Some("OAuth2"),
-        "webauthn" => Some("Webauthn"),
-        "ws" => Some("#[ws]"),
+        "mail" => &["Mail::builder("],
+        "oauth2" => &["OAuth2"],
+        "webauthn" => &["Webauthn"],
+        // Real WebSocket-transport channels (`#[ws]`) AND SSE-transport
+        // channels/`--live` scaffolds (`autumn_web::sse::stream(`, no
+        // `#[ws]` marker at all) are both gated behind the same "ws"
+        // feature (issue #1048 PR review: destroying the only channel/live
+        // scaffold of one transport must not strip a feature the other
+        // transport, generated separately, still needs).
+        "ws" => &["#[ws]", "autumn_web::sse::stream("],
         // `TestDb::` (not bare `TestDb`) so a doc comment merely mentioning
         // the type (e.g. the template-shipped `tests/integration_test.rs`'s
         // "Add DB-backed tests with `TestDb`...") doesn't count as usage.
-        "test-support" => Some("TestDb::"),
-        _ => None,
+        "test-support" => &["TestDb::"],
+        _ => &[],
     }
 }
 
 /// Whether `feature` is still referenced anywhere under `project_root`'s
 /// `src/`, `tests/`, or `benches/` trees, other than in `excluding` — see
-/// [`autumn_web_feature_marker`]. Always `false` (never blocks removal) for
+/// [`autumn_web_feature_markers`]. Always `false` (never blocks removal) for
 /// a feature with no known marker.
 fn autumn_web_feature_still_needed_elsewhere(
     feature: &str,
@@ -1026,10 +1033,11 @@ fn autumn_web_feature_still_needed_elsewhere(
     excluding: &[PathBuf],
     overrides: &HashMap<PathBuf, String>,
 ) -> bool {
-    let Some(marker) = autumn_web_feature_marker(feature) else {
+    let markers = autumn_web_feature_markers(feature);
+    if markers.is_empty() {
         return false;
-    };
-    let markers = [marker.to_owned()];
+    }
+    let markers: Vec<String> = markers.iter().map(|m| (*m).to_owned()).collect();
     ["src", "tests", "benches"]
         .iter()
         .any(|dir| rs_tree_contains_marker(&project_root.join(dir), &markers, excluding, overrides))
@@ -1827,6 +1835,48 @@ mod tests {
         assert!(
             cargo_after.contains("diesel"),
             "diesel must survive — schema.rs still has a diesel::table! for `users`: \
+             {cargo_after}"
+        );
+    }
+
+    #[test]
+    fn revert_keeps_ws_feature_when_a_live_scaffold_route_still_uses_sse_stream() {
+        // `--live` scaffolds and SSE-transport channels both need the "ws"
+        // feature via `autumn_web::sse::stream(...)`, with no `#[ws]`
+        // marker at all (issue #1048 PR review) — destroying the only
+        // WebSocket-transport channel must not strip "ws" while a live
+        // scaffold's route in a completely different directory still needs
+        // it.
+        let (tmp, mut plan) = fixture();
+        let routes_dir = tmp.path().join("src/routes");
+        fs::create_dir_all(&routes_dir).unwrap();
+        fs::write(
+            routes_dir.join("posts.rs"),
+            "pub async fn stream_posts() {\n    autumn_web::sse::stream(&state, \"posts\")\n}\n",
+        )
+        .unwrap();
+
+        let cargo_path = tmp.path().join("Cargo.toml");
+        fs::write(
+            &cargo_path,
+            "[package]\nname = \"x\"\n\n[dependencies]\nautumn-web = { version = \"0.6\", features = [\"ws\"] }\n",
+        )
+        .unwrap();
+
+        let channels_dir = tmp.path().join("src/channels");
+        fs::create_dir_all(&channels_dir).unwrap();
+        plan.push_revert(Revert::CargoAutumnWebFeature {
+            path: cargo_path.clone(),
+            feature: "ws".to_owned(),
+            owner_dir: Some(channels_dir),
+        });
+
+        plan.revert(Flags::default()).unwrap();
+
+        let cargo_after = fs::read_to_string(&cargo_path).unwrap();
+        assert!(
+            cargo_after.contains("\"ws\""),
+            "ws must survive — a live scaffold route still uses autumn_web::sse::stream: \
              {cargo_after}"
         );
     }

--- a/autumn-cli/src/generate/emit.rs
+++ b/autumn-cli/src/generate/emit.rs
@@ -59,8 +59,15 @@ pub enum Revert {
     /// (`src/main.rs`).
     RoutesEntries { path: PathBuf, entries: Vec<String> },
     /// Remove the `diesel::table! { <table> ... }` block from `path`
-    /// (`src/schema.rs`).
-    SchemaTable { path: PathBuf, table: String },
+    /// (`src/schema.rs`) — but only if its content is still byte-identical
+    /// to `expected_block` (the literal text this generator invocation
+    /// would append for `table`), so a same-named table that pre-existed
+    /// with different columns is never destroyed (issue #1048 PR review).
+    SchemaTable {
+        path: PathBuf,
+        table: String,
+        expected_block: String,
+    },
     /// Remove the named crates' shorthand `[dependencies]` lines from `path`
     /// (`Cargo.toml`) — but only once `owner_dir` (e.g. `src/models`) has no
     /// other resource file left in it, so a sibling resource of the same
@@ -198,7 +205,11 @@ impl Revert {
         match self {
             Self::ModDecl { name, .. } => remove_mod_declaration(content, name),
             Self::RoutesEntries { entries, .. } => remove_routes_entries(content, entries),
-            Self::SchemaTable { table, .. } => remove_schema_table(content, table),
+            Self::SchemaTable {
+                table,
+                expected_block,
+                ..
+            } => remove_schema_table(content, table, expected_block),
             Self::CargoDeps { names, .. } => {
                 // In addition to the `owner_dir` sibling-directory check
                 // already applied by the caller, only remove a name if
@@ -247,7 +258,12 @@ impl Revert {
                 ..
             } => remove_inbound_mail_handler(content, handler_module_path),
             Self::SystemTestCargoPatch { snake_name, .. } => {
-                super::system_test::remove_cargo_toml_patch(content, snake_name)
+                super::system_test::remove_cargo_toml_patch(
+                    content,
+                    snake_name,
+                    project_root,
+                    excluding,
+                )
             }
             Self::PwaMainRsInjection { .. } => super::pwa::remove_pwa_injection(content),
             Self::AuthOAuthProviderStubs { providers, .. } => {
@@ -909,6 +925,25 @@ fn autumn_web_feature_still_needed_elsewhere(
         return false;
     };
     let markers = [marker.to_owned()];
+    ["src", "tests", "benches"]
+        .iter()
+        .any(|dir| rs_tree_contains_marker(&project_root.join(dir), &markers, excluding))
+}
+
+/// Whether a local Cargo `feature` (not an `autumn-web` feature — see
+/// [`autumn_web_feature_still_needed_elsewhere`] for that) is still gated on
+/// anywhere under `project_root`'s `src/`, `tests/`, or `benches/` trees,
+/// other than in `excluding`. Used by [`Revert::SystemTestCargoPatch`]:
+/// destroying the last generated system test (or `generate pwa`'s smoke
+/// test) must not strip a shared `[features] system-tests = [...]` entry
+/// that pre-existed for unrelated hand-written `#[cfg(feature =
+/// "system-tests")]` code (issue #1048 PR review).
+pub(super) fn cargo_feature_still_gated_elsewhere(
+    feature: &str,
+    project_root: &Path,
+    excluding: &[PathBuf],
+) -> bool {
+    let markers = [format!("feature = \"{feature}\"")];
     ["src", "tests", "benches"]
         .iter()
         .any(|dir| rs_tree_contains_marker(&project_root.join(dir), &markers, excluding))

--- a/autumn-cli/src/generate/emit.rs
+++ b/autumn-cli/src/generate/emit.rs
@@ -97,8 +97,16 @@ pub enum Revert {
     /// `registered_jobs()` function if it was the only entry.
     JobEntry { path: PathBuf, entry: String },
     /// Remove the `.jobs(jobs::registered_jobs())` call from the
-    /// `AppBuilder` chain in `path` (`src/main.rs`).
-    JobsRegistration { path: PathBuf },
+    /// `AppBuilder` chain in `path` (`src/main.rs`) — but only once
+    /// `owner_dir` (`src/jobs`) has no other job file left in it, so a
+    /// sibling job that's still registered in the SAME shared
+    /// `jobs![...]` list doesn't lose its only path to actually running
+    /// (unlike [`Revert::MailPreview`]/[`Revert::InboundMailHandler`],
+    /// whose entry-removal already collapses their own wrapper call only
+    /// when their own list empties, this call lives in a *different* file
+    /// than the `jobs![...]` list it depends on, so it needs the same
+    /// directory-sibling check [`Revert::CargoDeps`] uses instead).
+    JobsRegistration { path: PathBuf, owner_dir: PathBuf },
     /// Remove `mailer_type` from the `mail_previews![...]` list in `path`
     /// (`src/main.rs`), dropping the whole freshly-inserted
     /// `.mail_previews(...)` call if it was the only entry.
@@ -141,7 +149,7 @@ impl Revert {
             | Self::CargoAutumnWebFeature { path, .. }
             | Self::CargoAutumnWebDevFeature { path, .. }
             | Self::JobEntry { path, .. }
-            | Self::JobsRegistration { path }
+            | Self::JobsRegistration { path, .. }
             | Self::MailPreview { path, .. }
             | Self::InboundMailHandler { path, .. }
             | Self::SystemTestCargoPatch { path, .. }
@@ -159,14 +167,15 @@ impl Revert {
     /// where the pushing generator has no single owning directory).
     fn owner_dir(&self) -> Option<&Path> {
         match self {
-            Self::CargoDeps { owner_dir, .. } => Some(owner_dir),
+            Self::CargoDeps { owner_dir, .. } | Self::JobsRegistration { owner_dir, .. } => {
+                Some(owner_dir)
+            }
             Self::CargoAutumnWebFeature { owner_dir, .. }
             | Self::CargoAutumnWebDevFeature { owner_dir, .. } => owner_dir.as_deref(),
             Self::ModDecl { .. }
             | Self::RoutesEntries { .. }
             | Self::SchemaTable { .. }
             | Self::JobEntry { .. }
-            | Self::JobsRegistration { .. }
             | Self::MailPreview { .. }
             | Self::InboundMailHandler { .. }
             | Self::SystemTestCargoPatch { .. }
@@ -654,7 +663,14 @@ impl Plan {
         let mut migrations_to_remove = Vec::new();
         let mut warnings = Vec::new();
         for (dir, actions) in &migration_groups {
-            match resolve_migration_removal(dir, actions, &migrations_root, force) {
+            match resolve_migration_removal(
+                dir,
+                actions,
+                &migrations_root,
+                force,
+                &self.project_root,
+                &files_to_remove,
+            ) {
                 MigrationOutcome::Remove(real_dir) => migrations_to_remove.push(real_dir),
                 MigrationOutcome::Diverged(path) => diverged.push(path),
                 MigrationOutcome::Applied(real_dir) => warnings.push(format!(
@@ -665,6 +681,11 @@ impl Plan {
                 MigrationOutcome::Ambiguous(suffix) => warnings.push(format!(
                     "multiple migrations directories match the expected suffix '{suffix}'; \
                      skipping — remove the correct one manually."
+                )),
+                MigrationOutcome::StillNeededElsewhere(real_dir) => warnings.push(format!(
+                    "migration {} is still needed by another mailer's --list-unsubscribe; \
+                     skipping — pass --force to remove it anyway.",
+                    relative_display(&real_dir, &self.project_root),
                 )),
                 MigrationOutcome::NotFound => {}
             }
@@ -796,6 +817,13 @@ enum MigrationOutcome {
     /// comparison couldn't tell them apart either — never guess which one
     /// to delete.
     Ambiguous(String),
+    /// This is the `mail_unsubscribes` suppression migration (the one
+    /// migration in the codebase reused across multiple resources of the
+    /// same generator, via `create_if_absent` — see
+    /// `mailer::plan_unsubscribe_migration`) and another mailer file besides
+    /// the ones this destroy is itself removing still opts into
+    /// `--list-unsubscribe` — never removed except with `--force`.
+    StillNeededElsewhere(PathBuf),
     /// No on-disk directory matches this suffix — already destroyed, or
     /// never generated.
     NotFound,
@@ -839,6 +867,8 @@ fn resolve_migration_removal(
     actions: &[&Action],
     migrations_root: &Path,
     force: bool,
+    project_root: &Path,
+    excluding: &[PathBuf],
 ) -> MigrationOutcome {
     let Some(plan_dir_name) = plan_dir.file_name().and_then(|n| n.to_str()) else {
         return MigrationOutcome::NotFound;
@@ -894,6 +924,12 @@ fn resolve_migration_removal(
         }
     }
 
+    if !force
+        && mail_unsubscribes_migration_still_needed_elsewhere(&real_dir, project_root, excluding)
+    {
+        return MigrationOutcome::StillNeededElsewhere(real_dir);
+    }
+
     if force {
         return MigrationOutcome::Remove(real_dir);
     }
@@ -906,6 +942,37 @@ fn resolve_migration_removal(
             MigrationOutcome::Remove(real_dir)
         }
     }
+}
+
+/// Whether `real_dir` is the `mail_unsubscribes` suppression migration and
+/// another mailer file (besides ones this same destroy is itself removing)
+/// still opts into `--list-unsubscribe` — the one migration in the codebase
+/// reused across multiple resources of the same generator via
+/// `create_if_absent` (see `mailer::plan_unsubscribe_migration`), so it
+/// needs its own sibling check rather than the generic `owner_dir`
+/// mechanism `Revert::CargoDeps` and friends use.
+fn mail_unsubscribes_migration_still_needed_elsewhere(
+    real_dir: &Path,
+    project_root: &Path,
+    excluding: &[PathBuf],
+) -> bool {
+    let is_unsubscribes_migration = real_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|name| split_migration_dir_name(name).1 == "create_mail_unsubscribes");
+    if !is_unsubscribes_migration {
+        return false;
+    }
+    let Ok(entries) = fs::read_dir(project_root.join("src").join("mailers")) else {
+        return false;
+    };
+    entries.filter_map(Result::ok).any(|entry| {
+        let path = entry.path();
+        path.extension().is_some_and(|ext| ext == "rs")
+            && !excluding.contains(&path)
+            && fs::read_to_string(&path)
+                .is_ok_and(|content| content.contains("list_unsubscribe = "))
+    })
 }
 
 /// Best-effort classification of whether a migration has already been

--- a/autumn-cli/src/generate/emit.rs
+++ b/autumn-cli/src/generate/emit.rs
@@ -188,7 +188,7 @@ impl Revert {
     /// Apply this revert to `content`, returning the new content. Every
     /// underlying transform is idempotent — a revert whose target is
     /// already absent returns `content` unchanged.
-    fn apply(&self, content: &str) -> String {
+    fn apply(&self, content: &str, project_root: &Path, excluding: &[PathBuf]) -> String {
         use super::inbound_mail::remove_inbound_mail_handler;
         use super::schema_edit::{
             remove_autumn_web_dev_dependency_feature, remove_autumn_web_feature, remove_job_entry,
@@ -200,8 +200,28 @@ impl Revert {
             Self::RoutesEntries { entries, .. } => remove_routes_entries(content, entries),
             Self::SchemaTable { table, .. } => remove_schema_table(content, table),
             Self::CargoDeps { names, .. } => {
-                let names: Vec<&str> = names.iter().map(String::as_str).collect();
-                super::model::remove_cargo_dependencies(content, &names)
+                // In addition to the `owner_dir` sibling-directory check
+                // already applied by the caller, only remove a name if
+                // nothing else in the project's source tree still
+                // references it — a hand-added dependency unrelated to any
+                // generator (issue #1048 PR review) survives the same way a
+                // dependency shared with a sibling resource already does.
+                // Best-effort: usage via a re-export or a derive macro that
+                // never spells out the crate's own name (e.g. plain
+                // `#[derive(Serialize)]` with no qualified `serde::` path)
+                // isn't detected.
+                let survives: Vec<&str> = names
+                    .iter()
+                    .map(String::as_str)
+                    .filter(|name| {
+                        !crate_referenced_elsewhere_in_project(project_root, name, excluding)
+                    })
+                    .collect();
+                if survives.is_empty() {
+                    content.to_owned()
+                } else {
+                    super::model::remove_cargo_dependencies(content, &survives)
+                }
             }
             Self::CargoAutumnWebFeature { feature, .. } => {
                 remove_autumn_web_feature(content, feature)
@@ -691,8 +711,20 @@ impl Plan {
             }
         }
 
+        let grouped_reverts = group_reverts_by_path(&self.reverts);
+        // Every path this destroy is ITSELF also rewriting (e.g.
+        // `src/schema.rs`, emptied by a `SchemaTable` revert) must be
+        // excluded from `crate_referenced_elsewhere_in_project`'s scan
+        // alongside `files_to_remove`: its pre-destroy content (still on
+        // disk at scan time — the real rewrite/deletion happens later, in
+        // `Plan::revert`'s apply phase) isn't evidence of anything a
+        // *different* resource still needs, since this same operation is
+        // about to change it too.
+        let mut cargo_deps_excluding = files_to_remove.clone();
+        cargo_deps_excluding.extend(grouped_reverts.iter().map(|(path, _)| path.clone()));
+
         let mut modifies = Vec::new();
-        for (path, reverts) in group_reverts_by_path(&self.reverts) {
+        for (path, reverts) in grouped_reverts {
             if !path.exists() {
                 continue;
             }
@@ -709,7 +741,7 @@ impl Plan {
                     // feature — leave the Cargo.toml edit in place.
                     continue;
                 }
-                content = revert.apply(&content);
+                content = revert.apply(&content, &self.project_root, &cargo_deps_excluding);
             }
             if content == original {
                 continue;
@@ -797,6 +829,54 @@ fn resource_dir_has_other_files(dir: &Path, excluding: &[PathBuf]) -> bool {
             && path.file_name() != Some(std::ffi::OsStr::new("mod.rs"))
             && !excluding.contains(&path)
     })
+}
+
+/// Whether `crate_name`'s Rust identifier (`-` replaced with `_`) is
+/// referenced anywhere under `project_root`'s `src/`, `tests/`, or
+/// `benches/` trees — other than in `excluding` (this same destroy's own
+/// file deletions). A whole-project extension of [`resource_dir_has_other_files`]
+/// for [`Revert::CargoDeps`]: a project may hand-add a dependency for its
+/// own reasons with no generated resource ever touching it, so checking
+/// only the generator's `owner_dir` isn't enough to avoid stripping it.
+///
+/// Best-effort, not exhaustive: looks for `{ident}::` (a qualified path) or
+/// `use {ident}` (an import) as plain substrings; a crate used only via a
+/// re-export or a derive macro that never spells out its own name (e.g.
+/// bare `#[derive(Serialize)]` with no qualified `serde::` path anywhere)
+/// is not detected.
+fn crate_referenced_elsewhere_in_project(
+    project_root: &Path,
+    crate_name: &str,
+    excluding: &[PathBuf],
+) -> bool {
+    let ident = crate_name.replace('-', "_");
+    let markers = [format!("{ident}::"), format!("use {ident}")];
+    ["src", "tests", "benches"]
+        .iter()
+        .any(|dir| rs_tree_contains_marker(&project_root.join(dir), &markers, excluding))
+}
+
+/// Recursively scan `dir` for any `.rs` file (other than `excluding`)
+/// containing one of `markers` as a plain substring.
+fn rs_tree_contains_marker(dir: &Path, markers: &[String], excluding: &[PathBuf]) -> bool {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return false;
+    };
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if path.is_dir() {
+            if rs_tree_contains_marker(&path, markers, excluding) {
+                return true;
+            }
+        } else if path.extension().is_some_and(|ext| ext == "rs")
+            && !excluding.contains(&path)
+            && fs::read_to_string(&path)
+                .is_ok_and(|content| markers.iter().any(|m| content.contains(m.as_str())))
+        {
+            return true;
+        }
+    }
+    false
 }
 
 /// Outcome of matching one plan-time migration directory (built with a

--- a/autumn-cli/src/generate/emit.rs
+++ b/autumn-cli/src/generate/emit.rs
@@ -62,16 +62,36 @@ pub enum Revert {
     /// (`src/schema.rs`).
     SchemaTable { path: PathBuf, table: String },
     /// Remove the named crates' shorthand `[dependencies]` lines from `path`
-    /// (`Cargo.toml`).
-    CargoDeps { path: PathBuf, names: Vec<String> },
+    /// (`Cargo.toml`) — but only once `owner_dir` (e.g. `src/models`) has no
+    /// other resource file left in it, so a sibling resource of the same
+    /// generator that still needs this dependency (e.g. a second `model`
+    /// also using `uuid`) survives destroying just one of them.
+    CargoDeps {
+        path: PathBuf,
+        names: Vec<String>,
+        owner_dir: PathBuf,
+    },
     /// Remove `feature` from `autumn-web`'s `[dependencies]` features list
     /// in `path` (`Cargo.toml`), collapsing to a bare version string if that
-    /// empties it.
-    CargoAutumnWebFeature { path: PathBuf, feature: String },
+    /// empties it — but only once `owner_dir` has no other resource file
+    /// left in it (see [`Revert::CargoDeps`]); `None` when the generator
+    /// pushing this revert has no single clean owning directory to check
+    /// (falls back to the old always-remove behavior for that generator).
+    CargoAutumnWebFeature {
+        path: PathBuf,
+        feature: String,
+        owner_dir: Option<PathBuf>,
+    },
     /// Remove `feature` from `autumn-web`'s `[dev-dependencies]` features
     /// list in `path` (`Cargo.toml`), deleting the whole line if that
-    /// empties it (that entry was always freshly inserted, never pre-existing).
-    CargoAutumnWebDevFeature { path: PathBuf, feature: String },
+    /// empties it (that entry was always freshly inserted, never
+    /// pre-existing) — but only once `owner_dir` has no other resource file
+    /// left in it (see [`Revert::CargoDeps`]).
+    CargoAutumnWebDevFeature {
+        path: PathBuf,
+        feature: String,
+        owner_dir: Option<PathBuf>,
+    },
     /// Remove `entry` from the `jobs![...]` list in `path`
     /// (`src/jobs/mod.rs`), dropping the whole freshly-generated
     /// `registered_jobs()` function if it was the only entry.
@@ -83,6 +103,30 @@ pub enum Revert {
     /// (`src/main.rs`), dropping the whole freshly-inserted
     /// `.mail_previews(...)` call if it was the only entry.
     MailPreview { path: PathBuf, mailer_type: String },
+    /// Remove `.handler(<handler_module_path>())` from the
+    /// `.inbound_mail_router(...)` chain in `path` (`src/main.rs`), dropping
+    /// the whole freshly-inserted `.inbound_mail_router(...)` call if it was
+    /// the only handler registered.
+    InboundMailHandler {
+        path: PathBuf,
+        handler_module_path: String,
+    },
+    /// Remove `snake_name`'s `[[test]]` entry from `path` (`Cargo.toml`),
+    /// plus the shared `system-tests` feature declaration too if no other
+    /// `tests/system/*.rs` entry still needs it.
+    SystemTestCargoPatch { path: PathBuf, snake_name: String },
+    /// Remove the PWA `<link>`/`<meta>` tags and route-handler functions
+    /// `autumn generate pwa` injected into `path` (`src/main.rs`).
+    PwaMainRsInjection { path: PathBuf },
+    /// Remove each `[auth.oauth2.<provider>]` stub block `autumn generate
+    /// auth --oauth` appended to `path` (`autumn.toml`).
+    AuthOAuthProviderStubs {
+        path: PathBuf,
+        providers: Vec<String>,
+    },
+    /// Remove the `[auth.webauthn]` stub block `autumn generate auth
+    /// --passkeys` appended to `path` (`autumn.toml`).
+    AuthWebauthnStub { path: PathBuf },
 }
 
 impl Revert {
@@ -98,7 +142,37 @@ impl Revert {
             | Self::CargoAutumnWebDevFeature { path, .. }
             | Self::JobEntry { path, .. }
             | Self::JobsRegistration { path }
-            | Self::MailPreview { path, .. } => path,
+            | Self::MailPreview { path, .. }
+            | Self::InboundMailHandler { path, .. }
+            | Self::SystemTestCargoPatch { path, .. }
+            | Self::PwaMainRsInjection { path }
+            | Self::AuthOAuthProviderStubs { path, .. }
+            | Self::AuthWebauthnStub { path } => path,
+        }
+    }
+
+    /// The directory whose continued occupancy (by any file other than
+    /// this same destroy's own deletions) means this revert must NOT be
+    /// applied yet — a sibling resource of the same generator may still
+    /// need the dependency/feature. `None` means always apply (every
+    /// variant except the three Cargo-editing ones, plus the Cargo ones
+    /// where the pushing generator has no single owning directory).
+    fn owner_dir(&self) -> Option<&Path> {
+        match self {
+            Self::CargoDeps { owner_dir, .. } => Some(owner_dir),
+            Self::CargoAutumnWebFeature { owner_dir, .. }
+            | Self::CargoAutumnWebDevFeature { owner_dir, .. } => owner_dir.as_deref(),
+            Self::ModDecl { .. }
+            | Self::RoutesEntries { .. }
+            | Self::SchemaTable { .. }
+            | Self::JobEntry { .. }
+            | Self::JobsRegistration { .. }
+            | Self::MailPreview { .. }
+            | Self::InboundMailHandler { .. }
+            | Self::SystemTestCargoPatch { .. }
+            | Self::PwaMainRsInjection { .. }
+            | Self::AuthOAuthProviderStubs { .. }
+            | Self::AuthWebauthnStub { .. } => None,
         }
     }
 
@@ -106,6 +180,7 @@ impl Revert {
     /// underlying transform is idempotent — a revert whose target is
     /// already absent returns `content` unchanged.
     fn apply(&self, content: &str) -> String {
+        use super::inbound_mail::remove_inbound_mail_handler;
         use super::schema_edit::{
             remove_autumn_web_dev_dependency_feature, remove_autumn_web_feature, remove_job_entry,
             remove_jobs_registration_from_app, remove_mail_preview_from_app,
@@ -130,6 +205,18 @@ impl Revert {
             Self::MailPreview { mailer_type, .. } => {
                 remove_mail_preview_from_app(content, mailer_type)
             }
+            Self::InboundMailHandler {
+                handler_module_path,
+                ..
+            } => remove_inbound_mail_handler(content, handler_module_path),
+            Self::SystemTestCargoPatch { snake_name, .. } => {
+                super::system_test::remove_cargo_toml_patch(content, snake_name)
+            }
+            Self::PwaMainRsInjection { .. } => super::pwa::remove_pwa_injection(content),
+            Self::AuthOAuthProviderStubs { providers, .. } => {
+                super::auth::remove_oauth_provider_stubs(content, providers)
+            }
+            Self::AuthWebauthnStub { .. } => super::auth::remove_webauthn_stub(content),
         }
     }
 }
@@ -388,6 +475,20 @@ impl Plan {
                 };
                 println!("  {label} {}", relative_display(path, &self.project_root));
             }
+            if !plan.diverged.is_empty() {
+                println!(
+                    "  A real run would refuse (without --force) — content has diverged from what generate produced:"
+                );
+                for path in &plan.diverged {
+                    println!(
+                        "    Diverged {}",
+                        relative_display(path, &self.project_root)
+                    );
+                }
+            }
+            for warning in &plan.warnings {
+                eprintln!("Warning: {warning}");
+            }
             return Ok(());
         }
 
@@ -511,6 +612,10 @@ impl Plan {
                      — write a down-migration instead. destroy never touches the database.",
                     relative_display(&real_dir, &self.project_root),
                 )),
+                MigrationOutcome::Ambiguous(suffix) => warnings.push(format!(
+                    "multiple migrations directories match the expected suffix '{suffix}'; \
+                     skipping — remove the correct one manually."
+                )),
                 MigrationOutcome::NotFound => {}
             }
         }
@@ -525,6 +630,14 @@ impl Plan {
             };
             let mut content = original.clone();
             for revert in &reverts {
+                if let Some(dir) = revert.owner_dir()
+                    && resource_dir_has_other_files(dir, &files_to_remove)
+                {
+                    // A sibling resource of the same generator still lives
+                    // in `owner_dir` and may still need this dependency or
+                    // feature — leave the Cargo.toml edit in place.
+                    continue;
+                }
                 content = revert.apply(&content);
             }
             if content == original {
@@ -591,6 +704,30 @@ fn prune_empty_ancestors(mut dir: PathBuf, project_root: &Path) {
     }
 }
 
+/// Whether `dir` contains any regular file other than the ones this same
+/// destroy operation is itself about to delete (`excluding` — the
+/// already-computed `files_to_remove`). Used to gate
+/// [`Revert::CargoDeps`]/[`Revert::CargoAutumnWebFeature`]/[`Revert::CargoAutumnWebDevFeature`]:
+/// a dependency or feature shared by multiple resources of the same
+/// generator (e.g. two `model`s both using `uuid`, two `mailer`s both using
+/// the `mail` feature) must survive destroying just one of them. A missing
+/// or unreadable `dir` counts as "no other files" (nothing left to protect).
+fn resource_dir_has_other_files(dir: &Path, excluding: &[PathBuf]) -> bool {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return false;
+    };
+    entries.filter_map(Result::ok).any(|entry| {
+        let path = entry.path();
+        // `mod.rs` is the shared aggregator every one of these directories
+        // has (declaring `pub mod <resource>;` per file) — it is not itself
+        // a resource, so its mere presence must never count as "a sibling
+        // resource still needs this dependency/feature".
+        path.is_file()
+            && path.file_name() != Some(std::ffi::OsStr::new("mod.rs"))
+            && !excluding.contains(&path)
+    })
+}
+
 /// Outcome of matching one plan-time migration directory (built with a
 /// fresh, destroy-time timestamp) against what's actually on disk.
 enum MigrationOutcome {
@@ -603,9 +740,33 @@ enum MigrationOutcome {
     /// database couldn't be reached, which is treated conservatively the
     /// same way) — never removed except with `--force`.
     Applied(PathBuf),
+    /// More than one on-disk migration directory normalizes to the same
+    /// suffix (e.g. a `model`-generated migration and an independently
+    /// hand-run `generate migration` for the same resource) and content
+    /// comparison couldn't tell them apart either — never guess which one
+    /// to delete.
+    Ambiguous(String),
     /// No on-disk directory matches this suffix — already destroyed, or
     /// never generated.
     NotFound,
+}
+
+/// Whether every `Create`/`CreateIfAbsent` action's expected content
+/// exactly matches the corresponding file in `dir` — used only to
+/// disambiguate between multiple same-suffix migration directories, so it
+/// never honours `--force` (a loose match here would let `--force` guess
+/// wrong on top of bypassing safety, rather than just bypassing safety).
+fn migration_dir_matches_actions(dir: &Path, actions: &[&Action]) -> bool {
+    actions.iter().all(|action| {
+        let Some(file_name) = action.path().file_name() else {
+            return true;
+        };
+        let expected: &str = match action {
+            Action::Create { contents, .. } | Action::CreateIfAbsent { contents, .. } => contents,
+            Action::CreateBytes { .. } | Action::Modify { .. } => return true,
+        };
+        fs::read_to_string(dir.join(file_name)).is_ok_and(|actual| actual == *expected)
+    })
 }
 
 /// Split a migration directory name into its leading numeric timestamp
@@ -634,14 +795,35 @@ fn resolve_migration_removal(
     let Ok(entries) = fs::read_dir(migrations_root) else {
         return MigrationOutcome::NotFound;
     };
-    let real_dir = entries.filter_map(Result::ok).map(|e| e.path()).find(|p| {
-        p.is_dir()
-            && p.file_name()
-                .and_then(|n| n.to_str())
-                .is_some_and(|name| split_migration_dir_name(name).1 == suffix)
-    });
-    let Some(real_dir) = real_dir else {
-        return MigrationOutcome::NotFound;
+    let mut candidates: Vec<PathBuf> = entries
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| {
+            p.is_dir()
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|name| split_migration_dir_name(name).1 == suffix)
+        })
+        .collect();
+    candidates.sort();
+
+    let real_dir = match candidates.len() {
+        0 => return MigrationOutcome::NotFound,
+        1 => candidates.into_iter().next().expect("len checked above"),
+        _ => {
+            // Multiple on-disk directories share this suffix — disambiguate
+            // by exact content match rather than guessing (filesystem read
+            // order is unspecified, so picking the first would be
+            // non-deterministic).
+            let mut matching: Vec<PathBuf> = candidates
+                .into_iter()
+                .filter(|dir| migration_dir_matches_actions(dir, actions))
+                .collect();
+            if matching.len() != 1 {
+                return MigrationOutcome::Ambiguous(suffix.to_owned());
+            }
+            matching.remove(0)
+        }
     };
 
     for action in actions {
@@ -691,7 +873,13 @@ enum MigrationStatus {
 }
 
 fn migration_applied_status(version: &str, migrations_dir: &Path) -> MigrationStatus {
-    let table = crate::migrate::read_autumn_toml_table();
+    // Resolve the same profile/overlay `autumn migrate` would (see
+    // `migrate::resolve_targets`), not just the bare base `autumn.toml` — a
+    // project that only configures its database via `[profile.prod.database]`
+    // or an `autumn-prod.toml` overlay must not look "NotConfigured" here,
+    // which would defeat the applied-migration safety guard below.
+    let profile = crate::migrate::effective_profile(None);
+    let table = crate::migrate::read_autumn_toml_table_with_profile(Some(&profile));
     let Some(url) = crate::migrate::resolve_primary_database_url_from_sources(
         |k| std::env::var(k),
         table.as_ref(),
@@ -724,6 +912,7 @@ const SHARED_MAIN_MODULE_NAMES: &[&str] = &[
     "channels",
     "jobs",
     "mailers",
+    "inbound_mailers",
 ];
 
 /// Whether `name`'s backing module still exists on disk — either as
@@ -799,6 +988,7 @@ fn sync_mod_declarations_in(dir: &Path, shared_names: &[&str], project_root: &Pa
     if updated.trim().is_empty() {
         if fs::remove_file(&mod_path).is_ok() {
             println!("  Removed {}", relative_display(&mod_path, project_root));
+            prune_empty_ancestors(dir.to_path_buf(), project_root);
         }
     } else if fs::write(&mod_path, &updated).is_ok() {
         println!("  Reverted {}", relative_display(&mod_path, project_root));
@@ -1146,5 +1336,111 @@ mod tests {
             // No matching real directory on disk at all — nothing to do.
             plan.revert(Flags::default()).unwrap();
         });
+    }
+
+    #[test]
+    fn revert_refuses_to_guess_between_two_migrations_sharing_a_suffix() {
+        no_db_env(|| {
+            let (tmp, mut plan) = fixture();
+            fs::create_dir_all(tmp.path().join("migrations")).unwrap();
+            let plan_dir = tmp.path().join("migrations/99999999999999_create_posts");
+            // Two independently-created directories normalize to the same
+            // suffix (e.g. a `model`-generated one and a hand-run `generate
+            // migration` for the same resource), and BOTH have content that
+            // exactly matches what this plan expects — content-based
+            // disambiguation genuinely can't tell them apart either.
+            let first = tmp.path().join("migrations/20260101000000_create_posts");
+            let second = tmp.path().join("migrations/20260201000000_create_posts");
+            fs::create_dir_all(&first).unwrap();
+            fs::write(first.join("up.sql"), "CREATE TABLE posts ();\n").unwrap();
+            fs::write(first.join("down.sql"), "DROP TABLE posts;\n").unwrap();
+            fs::create_dir_all(&second).unwrap();
+            fs::write(second.join("up.sql"), "CREATE TABLE posts ();\n").unwrap();
+            fs::write(second.join("down.sql"), "DROP TABLE posts;\n").unwrap();
+
+            plan.create(plan_dir.join("up.sql"), "CREATE TABLE posts ();\n");
+            plan.create(plan_dir.join("down.sql"), "DROP TABLE posts;\n");
+
+            // Refuses to guess, even without --force: neither directory is removed.
+            plan.revert(Flags::default()).unwrap();
+            assert!(
+                first.exists(),
+                "ambiguous suffix must not delete either dir"
+            );
+            assert!(
+                second.exists(),
+                "ambiguous suffix must not delete either dir"
+            );
+        });
+    }
+
+    #[test]
+    fn revert_disambiguates_shared_suffix_migrations_by_exact_content_match() {
+        no_db_env(|| {
+            let (tmp, mut plan) = fixture();
+            fs::create_dir_all(tmp.path().join("migrations")).unwrap();
+            let plan_dir = tmp.path().join("migrations/99999999999999_create_posts");
+            // Two directories share a suffix, but only one has content that
+            // exactly matches what this plan would have produced — that one
+            // (and only that one) should be identified and removed.
+            let matching = tmp.path().join("migrations/20260101000000_create_posts");
+            let other = tmp.path().join("migrations/20260201000000_create_posts");
+            fs::create_dir_all(&matching).unwrap();
+            fs::write(matching.join("up.sql"), "CREATE TABLE posts ();\n").unwrap();
+            fs::write(matching.join("down.sql"), "DROP TABLE posts;\n").unwrap();
+            fs::create_dir_all(&other).unwrap();
+            fs::write(other.join("up.sql"), "CREATE TABLE posts (extra INT);\n").unwrap();
+            fs::write(other.join("down.sql"), "DROP TABLE posts;\n").unwrap();
+
+            plan.create(plan_dir.join("up.sql"), "CREATE TABLE posts ();\n");
+            plan.create(plan_dir.join("down.sql"), "DROP TABLE posts;\n");
+
+            plan.revert(Flags::default()).unwrap();
+
+            assert!(
+                !matching.exists(),
+                "the content-matching directory must be removed"
+            );
+            assert!(
+                other.exists(),
+                "the non-matching directory must be left alone"
+            );
+        });
+    }
+
+    #[test]
+    fn revert_prunes_now_empty_directory_after_shared_submodule_deletion() {
+        // A single mailer's `src/mailers/previews/mod.rs` empties down to
+        // nothing (deleted + pruned by the ordinary Modify-turned-empty
+        // path), which then orphans `pub mod previews;` in
+        // `src/mailers/mod.rs` — cleaned up by `sync_mod_declarations_in`.
+        // That leaves `src/mailers/` itself empty; it must be pruned too,
+        // exactly like every other now-empty generated directory.
+        let tmp = tempfile::TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname=\"x\"\n\n[dependencies]\nautumn-web = \"0.6\"\n",
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(
+            tmp.path().join("src/main.rs"),
+            "use autumn_web::prelude::*;\n\n#[autumn_web::main]\nasync fn main() {\n    \
+             autumn_web::app().routes(routes![]).run().await;\n}\n",
+        )
+        .unwrap();
+
+        let plan =
+            crate::generate::mailer::plan_mailer(tmp.path(), "Welcome", None, false).unwrap();
+        plan.execute(Flags::default()).unwrap();
+        assert!(tmp.path().join("src/mailers/mod.rs").exists());
+
+        plan.revert(Flags::default()).unwrap();
+
+        assert!(
+            !tmp.path().join("src/mailers").exists(),
+            "src/mailers/ must be fully pruned once mod.rs and every file under it are gone, \
+             just like every other now-empty generated directory"
+        );
     }
 }

--- a/autumn-cli/src/generate/inbound_mail.rs
+++ b/autumn-cli/src/generate/inbound_mail.rs
@@ -16,7 +16,7 @@ use super::emit::Plan;
 use super::model::validate_resource_name;
 use super::naming::{pascal, snake};
 use super::schema_edit::{add_mod_declaration, ensure_autumn_web_feature, update_main_rs};
-use super::{Flags, GenerateError, ensure_project_root, read_or_empty};
+use super::{GenerateError, ensure_project_root, read_or_empty};
 
 /// Compute the file actions for `autumn generate inbound_mail <name>`.
 ///
@@ -328,24 +328,6 @@ fn find_after_routes_call(src: &str) -> Option<usize> {
         pos += 1;
     }
     None
-}
-
-/// CLI entry point for `autumn generate inbound_mail <name>`.
-pub fn run(name: &str, flags: Flags) {
-    let cwd = match std::env::current_dir() {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("Error: cannot determine current directory: {e}");
-            std::process::exit(1);
-        }
-    };
-    match plan_inbound_mail(&cwd, name).and_then(|p| p.execute(flags)) {
-        Ok(()) => {}
-        Err(e) => {
-            eprintln!("Error: {e}");
-            std::process::exit(1);
-        }
-    }
 }
 
 #[cfg(test)]

--- a/autumn-cli/src/generate/inbound_mail.rs
+++ b/autumn-cli/src/generate/inbound_mail.rs
@@ -54,6 +54,10 @@ pub fn plan_inbound_mail(project_root: &Path, name: &str) -> Result<Plan, Genera
         mod_path.clone(),
         add_mod_declaration(&read_or_empty(&mod_path), &snake_name),
     );
+    plan.push_revert(crate::generate::emit::Revert::ModDecl {
+        path: mod_path,
+        name: snake_name.clone(),
+    });
 
     // ── tests/<snake>_inbound_mail.rs ──────────────────────────────────────
     plan.create(
@@ -73,15 +77,30 @@ pub fn plan_inbound_mail(project_root: &Path, name: &str) -> Result<Plan, Genera
     })?;
     let with_mods = update_main_rs(&main_existing, &["inbound_mailers"], &[]);
     let updated_main = add_inbound_mail_router_to_app(&with_mods, &module_path);
-    plan.modify(main_path, updated_main);
+    plan.modify(main_path.clone(), updated_main);
+    // `mod inbound_mailers;` is shared infrastructure (see
+    // `emit::SHARED_MAIN_MODULE_NAMES`) — only this handler's own router
+    // registration is reverted here.
+    plan.push_revert(crate::generate::emit::Revert::InboundMailHandler {
+        path: main_path,
+        handler_module_path: module_path,
+    });
 
     // ── Cargo.toml — ensure autumn-web has the "inbound-mailgun" feature ───
     let cargo_path = project_root.join("Cargo.toml");
     let cargo_existing = read_or_empty(&cargo_path);
     let updated_cargo = ensure_autumn_web_feature(&cargo_existing, "inbound-mailgun");
     if updated_cargo != cargo_existing {
-        plan.modify(cargo_path, updated_cargo);
+        plan.modify(cargo_path.clone(), updated_cargo);
     }
+    // Pushed unconditionally — see `plan_cargo_deps`'s matching comment in
+    // model.rs: destroy recomputes this plan against the already-generated
+    // Cargo.toml, where the feature is by definition already present.
+    plan.push_revert(crate::generate::emit::Revert::CargoAutumnWebFeature {
+        path: cargo_path,
+        feature: "inbound-mailgun".to_owned(),
+        owner_dir: Some(project_root.join("src").join("inbound_mailers")),
+    });
 
     Ok(plan)
 }
@@ -330,6 +349,39 @@ fn find_after_routes_call(src: &str) -> Option<usize> {
     None
 }
 
+/// Inverse of the chaining performed by [`add_inbound_mail_router_to_app`]
+/// (`autumn destroy`, issue #1048).
+///
+/// Both insertion paths in `add_inbound_mail_router_to_app` keep the whole
+/// `.inbound_mail_router(...)` call (and any chained `.handler(...)` calls)
+/// on one unbroken text line, so removal is line-based: strip exactly
+/// `.handler(<handler_module_path>())` from the line containing it; if that
+/// leaves other `.handler(...)` calls chained on, splice the shortened line
+/// back in, otherwise this was the only handler and the whole line (the
+/// `.inbound_mail_router(...)` call) is removed.
+///
+/// A no-op if `handler_module_path` isn't currently registered.
+pub(super) fn remove_inbound_mail_handler(existing: &str, handler_module_path: &str) -> String {
+    let handler_snippet = format!(".handler({handler_module_path}())");
+    if !existing.contains(&handler_snippet) {
+        return existing.to_owned();
+    }
+    let lines: Vec<&str> = existing.lines().collect();
+    let Some(idx) = lines.iter().position(|l| l.contains(&handler_snippet)) else {
+        return existing.to_owned();
+    };
+    let without_handler = lines[idx].replacen(&handler_snippet, "", 1);
+    if without_handler.contains(".handler(") {
+        return super::schema_edit::splice_single_line(
+            &lines,
+            idx,
+            &without_handler,
+            existing.ends_with('\n'),
+        );
+    }
+    super::schema_edit::remove_single_line(&lines, idx, existing.ends_with('\n'))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -362,6 +414,69 @@ async fn main() {
         .await;
 }
 "#
+    }
+
+    #[test]
+    fn generate_then_destroy_round_trips_to_original_project_state() {
+        use crate::generate::Flags;
+
+        let tmp = project_with_main(default_main());
+        let cargo_path = tmp.path().join("Cargo.toml");
+        let main_path = tmp.path().join("src/main.rs");
+        let original_cargo = fs::read_to_string(&cargo_path).unwrap();
+        let original_main = fs::read_to_string(&main_path).unwrap();
+
+        let plan = plan_inbound_mail(tmp.path(), "Replies").unwrap();
+        plan.execute(Flags::default()).unwrap();
+        assert!(tmp.path().join("src/inbound_mailers/replies.rs").exists());
+        assert!(
+            fs::read_to_string(&main_path)
+                .unwrap()
+                .contains(".inbound_mail_router(")
+        );
+        assert!(
+            fs::read_to_string(&cargo_path)
+                .unwrap()
+                .contains("inbound-mailgun")
+        );
+
+        let destroy_plan = plan_inbound_mail(tmp.path(), "Replies").unwrap();
+        destroy_plan.revert(Flags::default()).unwrap();
+
+        assert!(!tmp.path().join("src/inbound_mailers").exists());
+        assert_eq!(fs::read_to_string(&main_path).unwrap(), original_main);
+        assert_eq!(fs::read_to_string(&cargo_path).unwrap(), original_cargo);
+    }
+
+    #[test]
+    fn destroying_one_of_two_inbound_mail_handlers_keeps_the_other_registered() {
+        use crate::generate::Flags;
+
+        let tmp = project_with_main(default_main());
+        let first = plan_inbound_mail(tmp.path(), "Replies").unwrap();
+        first.execute(Flags::default()).unwrap();
+        let second = plan_inbound_mail(tmp.path(), "Bounces").unwrap();
+        second.execute(Flags::default()).unwrap();
+        let main_path = tmp.path().join("src/main.rs");
+        let main_with_both = fs::read_to_string(&main_path).unwrap();
+        assert!(main_with_both.contains("inbound_mailers::replies::replies_handler_info"));
+        assert!(main_with_both.contains("inbound_mailers::bounces::bounces_handler_info"));
+
+        let destroy_replies = plan_inbound_mail(tmp.path(), "Replies").unwrap();
+        destroy_replies.revert(Flags::default()).unwrap();
+
+        assert!(!tmp.path().join("src/inbound_mailers/replies.rs").exists());
+        assert!(tmp.path().join("src/inbound_mailers/bounces.rs").exists());
+        let main_after = fs::read_to_string(&main_path).unwrap();
+        assert!(
+            !main_after.contains("replies_handler_info"),
+            "the destroyed handler's registration must be gone"
+        );
+        assert!(
+            main_after.contains("inbound_mailers::bounces::bounces_handler_info"),
+            "the surviving handler must remain registered — must not remove the whole router"
+        );
+        assert!(main_after.contains(".inbound_mail_router("));
     }
 
     // ── RED: file plan assertions ─────────────────────────────────────────

--- a/autumn-cli/src/generate/inbound_mail.rs
+++ b/autumn-cli/src/generate/inbound_mail.rs
@@ -352,34 +352,79 @@ fn find_after_routes_call(src: &str) -> Option<usize> {
 /// Inverse of the chaining performed by [`add_inbound_mail_router_to_app`]
 /// (`autumn destroy`, issue #1048).
 ///
-/// Both insertion paths in `add_inbound_mail_router_to_app` keep the whole
-/// `.inbound_mail_router(...)` call (and any chained `.handler(...)` calls)
-/// on one unbroken text line, so removal is line-based: strip exactly
-/// `.handler(<handler_module_path>())` from the line containing it; if that
-/// leaves other `.handler(...)` calls chained on, splice the shortened line
-/// back in, otherwise this was the only handler and the whole line (the
-/// `.inbound_mail_router(...)` call) is removed.
+/// `generate` always inserts the `.inbound_mail_router(...)` call (and any
+/// chained `.handler(...)` calls) on one unbroken text line, but a project
+/// that runs `rustfmt` afterward commonly wraps this particular call across
+/// several lines — it's long, carrying an `.endpoint(...)` config with a
+/// path and an env-var lookup. Line-based removal would then strip only the
+/// line holding `.handler(...)`, leaving the rest of the (now handler-less)
+/// `.inbound_mail_router(...)` call behind (issue #1048 PR review). So this
+/// locates the WHOLE call by balanced-paren scan — regardless of how many
+/// lines it spans — and removes exactly `.handler(<handler_module_path>())`
+/// from within it; if other `.handler(...)` calls remain chained on, the
+/// shortened call is spliced back in place, otherwise this was the only
+/// handler and every full line the call spans is removed.
 ///
 /// A no-op if `handler_module_path` isn't currently registered.
 pub(super) fn remove_inbound_mail_handler(existing: &str, handler_module_path: &str) -> String {
+    const ROUTER_CALL: &str = ".inbound_mail_router(";
     let handler_snippet = format!(".handler({handler_module_path}())");
     if !existing.contains(&handler_snippet) {
         return existing.to_owned();
     }
-    let lines: Vec<&str> = existing.lines().collect();
-    let Some(idx) = lines.iter().position(|l| l.contains(&handler_snippet)) else {
+    let Some(router_pos) = existing.find(ROUTER_CALL) else {
         return existing.to_owned();
     };
-    let without_handler = lines[idx].replacen(&handler_snippet, "", 1);
-    if without_handler.contains(".handler(") {
-        return super::schema_edit::splice_single_line(
-            &lines,
-            idx,
-            &without_handler,
-            existing.ends_with('\n'),
-        );
+    let Some(call_end) = find_balanced_close_paren(existing, router_pos + ROUTER_CALL.len()) else {
+        return existing.to_owned();
+    };
+    let call_text = &existing[router_pos..call_end];
+    if !call_text.contains(&handler_snippet) {
+        return existing.to_owned();
     }
-    super::schema_edit::remove_single_line(&lines, idx, existing.ends_with('\n'))
+    let without_handler = call_text.replacen(handler_snippet.as_str(), "", 1);
+    if without_handler.contains(".handler(") {
+        let mut out = String::with_capacity(existing.len());
+        out.push_str(&existing[..router_pos]);
+        out.push_str(&without_handler);
+        out.push_str(&existing[call_end..]);
+        return out;
+    }
+
+    // No handlers left — remove every full line the call spans, whether
+    // `generate` left it on one line or `rustfmt` later wrapped it.
+    let start_line = existing[..router_pos].rfind('\n').map_or(0, |i| i + 1);
+    let end_line = existing[call_end..]
+        .find('\n')
+        .map_or(existing.len(), |i| call_end + i + 1);
+    let mut out = String::with_capacity(existing.len());
+    out.push_str(&existing[..start_line]);
+    out.push_str(&existing[end_line..]);
+    out
+}
+
+/// Scan forward from `start` (the byte position just after an already-open
+/// `(`, i.e. depth 1) for the matching closing paren, returning the index
+/// just past it. `None` if the parens never balance (malformed/truncated
+/// input — destroy never guesses).
+fn find_balanced_close_paren(src: &str, start: usize) -> Option<usize> {
+    let bytes = src.as_bytes();
+    let mut depth = 1usize;
+    let mut i = start;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i + 1);
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
 }
 
 #[cfg(test)]
@@ -646,6 +691,49 @@ async fn main() {
         assert!(
             updated.contains("support_handler_info()"),
             "must chain new handler, got:\n{updated}"
+        );
+    }
+
+    #[test]
+    fn remove_inbound_mail_handler_removes_a_rustfmt_wrapped_router_call() {
+        // rustfmt commonly wraps this call across several lines (it's long:
+        // an .endpoint(...) config with a path and an env-var lookup).
+        // Line-based removal would strip only the `.handler(...)` line and
+        // leave the rest of the (now handler-less) call behind — issue
+        // #1048 PR review.
+        let src = "fn main() {\n    App::new()\n        .routes(routes![index])\n        .inbound_mail_router(\n            ::autumn_web::inbound_mail::InboundMailRouter::new()\n                .endpoint(::autumn_web::inbound_mail::InboundMailEndpointConfig::mailgun(\n                    \"/inbound/mailgun\",\n                    std::env::var(\"MAILGUN_SIGNING_KEY\").unwrap_or_default(),\n                ))\n                .handler(inbound_mailers::replies::replies_handler_info()),\n        )\n        .run()\n}\n";
+        let updated =
+            remove_inbound_mail_handler(src, "inbound_mailers::replies::replies_handler_info");
+        assert!(
+            !updated.contains(".inbound_mail_router("),
+            "the whole call must be removed once its only handler is gone, got:\n{updated}"
+        );
+        assert!(
+            !updated.contains(".handler("),
+            "no dangling .handler( fragment may remain, got:\n{updated}"
+        );
+        assert_eq!(
+            updated,
+            "fn main() {\n    App::new()\n        .routes(routes![index])\n        .run()\n}\n"
+        );
+    }
+
+    #[test]
+    fn remove_inbound_mail_handler_keeps_other_handler_in_a_rustfmt_wrapped_call() {
+        let src = "fn main() {\n    App::new()\n        .inbound_mail_router(\n            ::autumn_web::inbound_mail::InboundMailRouter::new()\n                .endpoint(::autumn_web::inbound_mail::InboundMailEndpointConfig::mailgun(\n                    \"/inbound/mailgun\",\n                    std::env::var(\"MAILGUN_SIGNING_KEY\").unwrap_or_default(),\n                ))\n                .handler(inbound_mailers::replies::replies_handler_info())\n                .handler(inbound_mailers::bounces::bounces_handler_info()),\n        )\n        .run()\n}\n";
+        let updated =
+            remove_inbound_mail_handler(src, "inbound_mailers::replies::replies_handler_info");
+        assert!(
+            updated.contains(".inbound_mail_router("),
+            "the router call must survive while another handler remains, got:\n{updated}"
+        );
+        assert!(
+            updated.contains("bounces_handler_info"),
+            "the other handler must survive, got:\n{updated}"
+        );
+        assert!(
+            !updated.contains("replies_handler_info"),
+            "the destroyed handler must be gone, got:\n{updated}"
         );
     }
 

--- a/autumn-cli/src/generate/job.rs
+++ b/autumn-cli/src/generate/job.rs
@@ -157,7 +157,12 @@ pub fn plan_job(project_root: &Path, name: &str, fields: &[String]) -> Result<Pl
             &["db-diesel2-postgres", "serde"],
         );
     }
-    super::model::plan_cargo_deps(&mut plan, project_root, &job_deps(&parsed_fields));
+    super::model::plan_cargo_deps(
+        &mut plan,
+        project_root,
+        &job_deps(&parsed_fields),
+        &project_root.join("src/jobs"),
+    );
 
     Ok(plan)
 }

--- a/autumn-cli/src/generate/job.rs
+++ b/autumn-cli/src/generate/job.rs
@@ -138,8 +138,12 @@ pub fn plan_job(project_root: &Path, name: &str, fields: &[String]) -> Result<Pl
     plan.modify(main_path.clone(), updated_main);
     // `mod jobs;` is a shared infrastructure declaration (see
     // `emit::sync_main_rs_mod_declarations`) — only the `.jobs(...)` call is
-    // reverted here.
-    plan.push_revert(crate::generate::emit::Revert::JobsRegistration { path: main_path });
+    // reverted here, and only once no other job file remains (a sibling job
+    // still listed in the shared `jobs![...]` needs this call to actually run).
+    plan.push_revert(crate::generate::emit::Revert::JobsRegistration {
+        path: main_path,
+        owner_dir: project_root.join("src").join("jobs"),
+    });
 
     // ── Cargo.toml: ensure serde (always) plus uuid/chrono/decimal if used ──
     if parsed_fields.iter().any(|f| f.kind.is_decimal()) {
@@ -297,6 +301,51 @@ async fn main() {
         assert!(!tmp.path().join("src/jobs/mod.rs").exists());
         assert_eq!(fs::read_to_string(&main_path).unwrap(), original_main);
         assert_eq!(fs::read_to_string(&cargo_path).unwrap(), original_cargo);
+    }
+
+    #[test]
+    fn destroying_one_of_two_jobs_keeps_the_jobs_registration_call() {
+        let tmp = project_with_main(default_main());
+        let main_path = tmp.path().join("src/main.rs");
+
+        plan_job(tmp.path(), "SendWelcomeEmail", &[])
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        plan_job(tmp.path(), "SendGoodbyeEmail", &[])
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        assert!(fs::read_to_string(&main_path).unwrap().contains(".jobs("));
+
+        // Destroying one job alone must NOT strip the `.jobs(...)` call —
+        // the surviving job's `jobs![...]` entry still needs it to actually run.
+        plan_job(tmp.path(), "SendWelcomeEmail", &[])
+            .unwrap()
+            .revert(Flags::default())
+            .unwrap();
+
+        assert!(!tmp.path().join("src/jobs/send_welcome_email.rs").exists());
+        assert!(tmp.path().join("src/jobs/send_goodbye_email.rs").exists());
+        let main_after = fs::read_to_string(&main_path).unwrap();
+        assert!(
+            main_after.contains(".jobs(jobs::registered_jobs())"),
+            "the .jobs(...) call must survive — the surviving job still needs it to run: {main_after}"
+        );
+        let mod_after = fs::read_to_string(tmp.path().join("src/jobs/mod.rs")).unwrap();
+        assert!(mod_after.contains("send_goodbye_email"));
+        assert!(!mod_after.contains("send_welcome_email"));
+
+        // Now destroy the last remaining job — the call must finally go too.
+        plan_job(tmp.path(), "SendGoodbyeEmail", &[])
+            .unwrap()
+            .revert(Flags::default())
+            .unwrap();
+        assert!(!tmp.path().join("src/jobs/send_goodbye_email.rs").exists());
+        assert!(
+            !fs::read_to_string(&main_path).unwrap().contains(".jobs("),
+            "the .jobs(...) call must be removed once no job needs it anymore"
+        );
     }
 
     // ── RED: plan assertions ─────────────────────────────────────────────

--- a/autumn-cli/src/generate/job.rs
+++ b/autumn-cli/src/generate/job.rs
@@ -18,7 +18,7 @@ use super::naming::{pascal, snake};
 use super::schema_edit::{
     add_jobs_registration_to_app, add_mod_declaration, augment_registered_jobs, update_main_rs,
 };
-use super::{Flags, GenerateError, ensure_project_root, read_or_empty};
+use super::{GenerateError, ensure_project_root, read_or_empty};
 
 /// Cargo dependencies always required by generated job files.
 const JOB_DEPS_BASE: &[(&str, &str)] = &[("serde", "{ version = \"1\", features = [\"derive\"] }")];
@@ -115,7 +115,15 @@ pub fn plan_job(project_root: &Path, name: &str, fields: &[String]) -> Result<Pl
     let existing_mod = read_or_empty(&mod_path);
     let with_mod_decl = add_mod_declaration(&existing_mod, &snake_name);
     let with_aggregator = augment_registered_jobs(&with_mod_decl, &job_entry);
-    plan.modify(mod_path, with_aggregator);
+    plan.modify(mod_path.clone(), with_aggregator);
+    plan.push_revert(crate::generate::emit::Revert::ModDecl {
+        path: mod_path.clone(),
+        name: snake_name.clone(),
+    });
+    plan.push_revert(crate::generate::emit::Revert::JobEntry {
+        path: mod_path,
+        entry: job_entry,
+    });
 
     // ── src/main.rs: add mod jobs; and .jobs(…) ───────────────────────────
     let main_path = project_root.join("src").join("main.rs");
@@ -127,7 +135,11 @@ pub fn plan_job(project_root: &Path, name: &str, fields: &[String]) -> Result<Pl
     })?;
     let with_mod = update_main_rs(&main_existing, &["jobs"], &[]);
     let updated_main = add_jobs_registration_to_app(&with_mod);
-    plan.modify(main_path, updated_main);
+    plan.modify(main_path.clone(), updated_main);
+    // `mod jobs;` is a shared infrastructure declaration (see
+    // `emit::sync_main_rs_mod_declarations`) — only the `.jobs(...)` call is
+    // reverted here.
+    plan.push_revert(crate::generate::emit::Revert::JobsRegistration { path: main_path });
 
     // ── Cargo.toml: ensure serde (always) plus uuid/chrono/decimal if used ──
     if parsed_fields.iter().any(|f| f.kind.is_decimal()) {
@@ -224,27 +236,10 @@ mod {snake_name}_job_tests {{
     )
 }
 
-/// CLI entry point.
-pub fn run(name: &str, fields: &[String], flags: Flags) {
-    let cwd = match std::env::current_dir() {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("Error: cannot determine current directory: {e}");
-            std::process::exit(1);
-        }
-    };
-    match plan_job(&cwd, name, fields).and_then(|p| p.execute(flags)) {
-        Ok(()) => {}
-        Err(e) => {
-            eprintln!("Error: {e}");
-            std::process::exit(1);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::generate::Flags;
     use std::fs;
     use tempfile::TempDir;
 
@@ -274,6 +269,29 @@ async fn main() {
         .await;
 }
 "#
+    }
+
+    #[test]
+    fn generate_then_destroy_job_round_trips_to_original_project_state() {
+        let tmp = project_with_main(default_main());
+        let cargo_path = tmp.path().join("Cargo.toml");
+        let main_path = tmp.path().join("src/main.rs");
+        let original_cargo = fs::read_to_string(&cargo_path).unwrap();
+        let original_main = fs::read_to_string(&main_path).unwrap();
+
+        let plan = plan_job(tmp.path(), "SendWelcomeEmail", &[]).unwrap();
+        plan.execute(Flags::default()).unwrap();
+        assert!(tmp.path().join("src/jobs/send_welcome_email.rs").exists());
+        assert!(main_path.exists());
+        assert!(fs::read_to_string(&main_path).unwrap().contains(".jobs("));
+
+        let destroy_plan = plan_job(tmp.path(), "SendWelcomeEmail", &[]).unwrap();
+        destroy_plan.revert(Flags::default()).unwrap();
+
+        assert!(!tmp.path().join("src/jobs/send_welcome_email.rs").exists());
+        assert!(!tmp.path().join("src/jobs/mod.rs").exists());
+        assert_eq!(fs::read_to_string(&main_path).unwrap(), original_main);
+        assert_eq!(fs::read_to_string(&cargo_path).unwrap(), original_cargo);
     }
 
     // ── RED: plan assertions ─────────────────────────────────────────────

--- a/autumn-cli/src/generate/job.rs
+++ b/autumn-cli/src/generate/job.rs
@@ -118,7 +118,7 @@ pub fn plan_job(project_root: &Path, name: &str, fields: &[String]) -> Result<Pl
     plan.modify(mod_path.clone(), with_aggregator);
     plan.push_revert(crate::generate::emit::Revert::ModDecl {
         path: mod_path.clone(),
-        name: snake_name.clone(),
+        name: snake_name,
     });
     plan.push_revert(crate::generate::emit::Revert::JobEntry {
         path: mod_path,

--- a/autumn-cli/src/generate/mailer.rs
+++ b/autumn-cli/src/generate/mailer.rs
@@ -21,7 +21,7 @@
 //!
 //! Use `--no-layout` to opt out of the shared layout for a specific mailer.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use super::emit::Plan;
 use super::model::validate_resource_name;
@@ -179,6 +179,7 @@ pub fn plan_mailer(
     plan.push_revert(crate::generate::emit::Revert::CargoAutumnWebFeature {
         path: cargo_path,
         feature: "mail".to_owned(),
+        owner_dir: Some(project_root.join("src").join("mailers")),
     });
 
     // ── migrations/<ts>_create_mail_unsubscribes (opt-in, idempotent) ──────
@@ -211,28 +212,37 @@ fn validate_list_unsubscribe_scope(scope: &str) -> Result<(), GenerateError> {
     Ok(())
 }
 
-/// Add the `mail_unsubscribes` suppression migration unless one already exists.
+/// Add the `mail_unsubscribes` suppression migration, reusing the existing
+/// one (by its real on-disk path) if a prior mailer already created it.
+///
+/// The old design skipped pushing any action at all once a
+/// `*_create_mail_unsubscribes` directory existed — correct for `generate`,
+/// but it meant a second `--list-unsubscribe` mailer's plan carried no
+/// migration action, so `autumn destroy` recomputing that same plan could
+/// never locate (and thus never remove) the suppression migration. Instead,
+/// always push `create_if_absent` actions, targeting the *existing*
+/// directory's real path when one is already on disk (so `generate` is
+/// still a silent no-op there) and a fresh timestamp only when none exists
+/// yet. Either way the action is present for `autumn destroy`'s
+/// suffix-based migration matching (`resolve_migration_removal`) to find.
 fn plan_unsubscribe_migration(project_root: &Path, plan: &mut Plan) {
     let migrations_dir = project_root.join("migrations");
-    if migration_already_present(&migrations_dir) {
-        return;
-    }
-    let timestamp = timestamp_now();
-    let dir = migrations_dir.join(format!("{timestamp}_create_mail_unsubscribes"));
-    plan.create(dir.join("up.sql"), UNSUBSCRIBE_MIGRATION_UP.to_owned());
-    plan.create(dir.join("down.sql"), UNSUBSCRIBE_MIGRATION_DOWN.to_owned());
+    let dir = existing_mail_unsubscribes_dir(&migrations_dir).unwrap_or_else(|| {
+        migrations_dir.join(format!("{}_create_mail_unsubscribes", timestamp_now()))
+    });
+    plan.create_if_absent(dir.join("up.sql"), UNSUBSCRIBE_MIGRATION_UP.to_owned());
+    plan.create_if_absent(dir.join("down.sql"), UNSUBSCRIBE_MIGRATION_DOWN.to_owned());
 }
 
-/// Whether a `*_create_mail_unsubscribes` migration already exists on disk.
-fn migration_already_present(migrations_dir: &Path) -> bool {
-    let Ok(entries) = std::fs::read_dir(migrations_dir) else {
-        return false;
-    };
-    entries.filter_map(Result::ok).any(|entry| {
-        entry
-            .file_name()
-            .to_str()
-            .is_some_and(|name| name.ends_with("_create_mail_unsubscribes"))
+/// The real on-disk `*_create_mail_unsubscribes` migration directory, if one
+/// already exists (from a previous `--list-unsubscribe` mailer).
+fn existing_mail_unsubscribes_dir(migrations_dir: &Path) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(migrations_dir).ok()?;
+    entries.filter_map(Result::ok).map(|e| e.path()).find(|p| {
+        p.is_dir()
+            && p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|name| name.ends_with("_create_mail_unsubscribes"))
     })
 }
 
@@ -534,6 +544,54 @@ async fn main() {
         assert_eq!(fs::read_to_string(&cargo_path).unwrap(), original_cargo);
     }
 
+    #[test]
+    fn destroying_one_of_two_mailers_keeps_shared_mail_feature_the_other_still_needs() {
+        let tmp = project_with_main(default_main());
+        let cargo_path = tmp.path().join("Cargo.toml");
+
+        plan_mailer(tmp.path(), "Welcome", None, false)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        plan_mailer(tmp.path(), "Goodbye", None, false)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        assert!(
+            fs::read_to_string(&cargo_path)
+                .unwrap()
+                .contains("\"mail\"")
+        );
+
+        // Destroying Welcome alone must NOT strip the "mail" feature —
+        // Goodbye's mailer still needs it.
+        plan_mailer(tmp.path(), "Welcome", None, false)
+            .unwrap()
+            .revert(Flags::default())
+            .unwrap();
+
+        assert!(!tmp.path().join("src/mailers/welcome.rs").exists());
+        assert!(tmp.path().join("src/mailers/goodbye.rs").exists());
+        let cargo_after = fs::read_to_string(&cargo_path).unwrap();
+        assert!(
+            cargo_after.contains("\"mail\""),
+            "mail feature must survive — Goodbye's mailer still uses it: {cargo_after}"
+        );
+
+        // Now destroy the last remaining mailer — the feature must finally go.
+        plan_mailer(tmp.path(), "Goodbye", None, false)
+            .unwrap()
+            .revert(Flags::default())
+            .unwrap();
+        assert!(!tmp.path().join("src/mailers/goodbye.rs").exists());
+        assert!(
+            !fs::read_to_string(&cargo_path)
+                .unwrap()
+                .contains("\"mail\""),
+            "mail feature must be removed once no mailer uses it anymore"
+        );
+    }
+
     // ── RED: file plan assertions ─────────────────────────────────────────
 
     #[test]
@@ -709,15 +767,53 @@ async fn main() {
             .unwrap()
             .execute(Flags::default())
             .unwrap();
-        // A second list mailer must reuse the existing suppression table.
+        let migrations_dir = tmp.path().join("migrations");
+        let existing_dirs = || {
+            fs::read_dir(&migrations_dir)
+                .unwrap()
+                .filter_map(Result::ok)
+                .map(|e| e.path())
+                .filter(|p| p.is_dir())
+                .count()
+        };
+        assert_eq!(existing_dirs(), 1, "first mailer creates one migration dir");
+        let original_dir = fs::read_dir(&migrations_dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .find(|p| p.is_dir())
+            .unwrap();
+
+        // A second list mailer must reuse the existing suppression table:
+        // its plan still carries the migration's actions (so `autumn
+        // destroy` can find it later), but they all target the SAME
+        // already-existing directory, and executing must not create a
+        // second migration directory or error.
         let second =
             plan_mailer(tmp.path(), "ProductUpdates", Some("product_updates"), false).unwrap();
+        let migration_paths: Vec<_> = second
+            .actions
+            .iter()
+            .map(super::super::emit::Action::path)
+            .filter(|p| p.to_string_lossy().contains("mail_unsubscribes"))
+            .collect();
         assert!(
-            !second
-                .actions
-                .iter()
-                .any(|a| a.path().to_string_lossy().contains("mail_unsubscribes")),
-            "must not plan a duplicate suppression migration"
+            !migration_paths.is_empty(),
+            "the plan must still carry the migration's actions so `autumn destroy` can find it"
+        );
+        for path in &migration_paths {
+            assert_eq!(
+                path.parent().unwrap(),
+                original_dir,
+                "migration action must target the existing on-disk directory, not a fresh timestamp"
+            );
+        }
+
+        second.execute(Flags::default()).unwrap();
+        assert_eq!(
+            existing_dirs(),
+            1,
+            "must not plan or create a duplicate suppression migration"
         );
     }
 

--- a/autumn-cli/src/generate/mailer.rs
+++ b/autumn-cli/src/generate/mailer.rs
@@ -870,6 +870,54 @@ async fn main() {
         );
     }
 
+    #[test]
+    fn destroying_one_of_two_list_unsubscribe_mailers_keeps_the_shared_migration() {
+        let tmp = project_with_main(default_main());
+        let migrations_dir = tmp.path().join("migrations");
+        let migration_dir_exists = || {
+            fs::read_dir(&migrations_dir)
+                .map(|mut d| d.next().is_some())
+                .unwrap_or(false)
+        };
+
+        plan_mailer(tmp.path(), "WeeklyDigest", Some("weekly_digest"), false)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        plan_mailer(tmp.path(), "ProductUpdates", Some("product_updates"), false)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        assert!(migration_dir_exists());
+
+        // Destroying WeeklyDigest alone must NOT remove the shared
+        // mail_unsubscribes migration — ProductUpdates still opts into
+        // --list-unsubscribe and needs the suppression table.
+        plan_mailer(tmp.path(), "WeeklyDigest", Some("weekly_digest"), false)
+            .unwrap()
+            .revert(Flags::default())
+            .unwrap();
+
+        assert!(!tmp.path().join("src/mailers/weekly_digest.rs").exists());
+        assert!(tmp.path().join("src/mailers/product_updates.rs").exists());
+        assert!(
+            migration_dir_exists(),
+            "shared mail_unsubscribes migration must survive — ProductUpdates still needs it"
+        );
+
+        // Now destroy the last remaining list-unsubscribe mailer — the
+        // migration must finally go too.
+        plan_mailer(tmp.path(), "ProductUpdates", Some("product_updates"), false)
+            .unwrap()
+            .revert(Flags::default())
+            .unwrap();
+        assert!(!tmp.path().join("src/mailers/product_updates.rs").exists());
+        assert!(
+            !migration_dir_exists(),
+            "mail_unsubscribes migration must be removed once no mailer uses list_unsubscribe anymore"
+        );
+    }
+
     // ── GREEN: execute and inspect written content ────────────────────────
 
     #[test]

--- a/autumn-cli/src/generate/mailer.rs
+++ b/autumn-cli/src/generate/mailer.rs
@@ -874,11 +874,8 @@ async fn main() {
     fn destroying_one_of_two_list_unsubscribe_mailers_keeps_the_shared_migration() {
         let tmp = project_with_main(default_main());
         let migrations_dir = tmp.path().join("migrations");
-        let migration_dir_exists = || {
-            fs::read_dir(&migrations_dir)
-                .map(|mut d| d.next().is_some())
-                .unwrap_or(false)
-        };
+        let migration_dir_exists =
+            || fs::read_dir(&migrations_dir).is_ok_and(|mut d| d.next().is_some());
 
         plan_mailer(tmp.path(), "WeeklyDigest", Some("weekly_digest"), false)
             .unwrap()

--- a/autumn-cli/src/generate/mailer.rs
+++ b/autumn-cli/src/generate/mailer.rs
@@ -29,7 +29,7 @@ use super::naming::{pascal, snake};
 use super::schema_edit::{
     add_mail_preview_to_app, add_mod_declaration, ensure_autumn_web_feature, update_main_rs,
 };
-use super::{Flags, GenerateError, ensure_project_root, read_or_empty, timestamp_now};
+use super::{GenerateError, ensure_project_root, read_or_empty, timestamp_now};
 
 /// Compute the file actions for `autumn generate mailer`.
 ///
@@ -134,12 +134,24 @@ pub fn plan_mailer(
         previews_mod_path.clone(),
         add_mod_declaration(&read_or_empty(&previews_mod_path), &snake_name),
     );
+    plan.push_revert(crate::generate::emit::Revert::ModDecl {
+        path: previews_mod_path,
+        name: snake_name.clone(),
+    });
 
     // ── src/mailers/mod.rs (create or update) ──────────────────────────────
+    // The "previews" sub-module declared here is shared by every generated
+    // mailer, not owned by this one — `emit::sync_mod_declarations_in`
+    // removes it once `src/mailers/previews/mod.rs` no longer exists, so no
+    // static revert is pushed for it here.
     let mod_path = project_root.join("src").join("mailers").join("mod.rs");
     let with_mailer_mod = add_mod_declaration(&read_or_empty(&mod_path), &snake_name);
     let with_both_mods = add_mod_declaration(&with_mailer_mod, "previews");
-    plan.modify(mod_path, with_both_mods);
+    plan.modify(mod_path.clone(), with_both_mods);
+    plan.push_revert(crate::generate::emit::Revert::ModDecl {
+        path: mod_path,
+        name: snake_name.clone(),
+    });
 
     // ── src/main.rs: add mod mailers; and .mail_previews(…) ────────────────
     let main_path = project_root.join("src").join("main.rs");
@@ -151,15 +163,23 @@ pub fn plan_mailer(
     })?;
     let with_mods = update_main_rs(&main_existing, &["mailers"], &[]);
     let updated_main = add_mail_preview_to_app(&with_mods, &mailer_type);
-    plan.modify(main_path, updated_main);
+    plan.modify(main_path.clone(), updated_main);
+    plan.push_revert(crate::generate::emit::Revert::MailPreview {
+        path: main_path,
+        mailer_type,
+    });
 
     // ── Cargo.toml: ensure autumn-web has the "mail" feature ───────────────
     let cargo_path = project_root.join("Cargo.toml");
     let cargo_existing = read_or_empty(&cargo_path);
     let updated_cargo = ensure_autumn_web_feature(&cargo_existing, "mail");
     if updated_cargo != cargo_existing {
-        plan.modify(cargo_path, updated_cargo);
+        plan.modify(cargo_path.clone(), updated_cargo);
     }
+    plan.push_revert(crate::generate::emit::Revert::CargoAutumnWebFeature {
+        path: cargo_path,
+        feature: "mail".to_owned(),
+    });
 
     // ── migrations/<ts>_create_mail_unsubscribes (opt-in, idempotent) ──────
     if list_unsubscribe.is_some() {
@@ -447,27 +467,10 @@ fn render_smoke_test(struct_name: &str, snake_name: &str, no_layout: bool) -> St
     )
 }
 
-/// CLI entry point.
-pub fn run(name: &str, list_unsubscribe: Option<&str>, no_layout: bool, flags: Flags) {
-    let cwd = match std::env::current_dir() {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("Error: cannot determine current directory: {e}");
-            std::process::exit(1);
-        }
-    };
-    match plan_mailer(&cwd, name, list_unsubscribe, no_layout).and_then(|p| p.execute(flags)) {
-        Ok(()) => {}
-        Err(e) => {
-            eprintln!("Error: {e}");
-            std::process::exit(1);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::generate::Flags;
     use std::fs;
     use tempfile::TempDir;
 
@@ -497,6 +500,38 @@ async fn main() {
         .await;
 }
 "#
+    }
+
+    #[test]
+    fn generate_then_destroy_mailer_round_trips_to_original_project_state() {
+        let tmp = project_with_main(default_main());
+        let cargo_path = tmp.path().join("Cargo.toml");
+        let main_path = tmp.path().join("src/main.rs");
+        let original_cargo = fs::read_to_string(&cargo_path).unwrap();
+        let original_main = fs::read_to_string(&main_path).unwrap();
+
+        let plan = plan_mailer(tmp.path(), "Welcome", None, false).unwrap();
+        plan.execute(Flags::default()).unwrap();
+        assert!(tmp.path().join("src/mailers/welcome.rs").exists());
+        assert!(
+            fs::read_to_string(&main_path)
+                .unwrap()
+                .contains("mail_previews!")
+        );
+        assert!(
+            fs::read_to_string(&cargo_path)
+                .unwrap()
+                .contains("\"mail\"")
+        );
+
+        let destroy_plan = plan_mailer(tmp.path(), "Welcome", None, false).unwrap();
+        destroy_plan.revert(Flags::default()).unwrap();
+
+        assert!(!tmp.path().join("src/mailers/welcome.rs").exists());
+        assert!(!tmp.path().join("src/mailers/mod.rs").exists());
+        assert!(!tmp.path().join("src/mailers/previews").exists());
+        assert_eq!(fs::read_to_string(&main_path).unwrap(), original_main);
+        assert_eq!(fs::read_to_string(&cargo_path).unwrap(), original_cargo);
     }
 
     // ── RED: file plan assertions ─────────────────────────────────────────

--- a/autumn-cli/src/generate/mailer.rs
+++ b/autumn-cli/src/generate/mailer.rs
@@ -915,6 +915,45 @@ async fn main() {
         );
     }
 
+    #[test]
+    fn destroying_the_only_mailer_keeps_mail_feature_auth_still_needs() {
+        // Codex PR review (issue #1048): "mail" is needed by BOTH `generate
+        // auth` (password reset/confirmation emails) and `generate mailer` —
+        // two entirely different generators, so the mailer's own
+        // `src/mailers` owner_dir sibling check alone can't see that auth
+        // still needs the feature.
+        let tmp = project_with_main(default_main());
+        let cargo_path = tmp.path().join("Cargo.toml");
+
+        crate::generate::auth::plan_auth(tmp.path(), "User", "20260508000000")
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        plan_mailer(tmp.path(), "Welcome", None, false)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        assert!(
+            fs::read_to_string(&cargo_path)
+                .unwrap()
+                .contains("\"mail\"")
+        );
+
+        // Destroying the only mailer must NOT strip "mail" — auth's routes
+        // still call `Mail::builder()`.
+        plan_mailer(tmp.path(), "Welcome", None, false)
+            .unwrap()
+            .revert(Flags::default())
+            .unwrap();
+
+        assert!(!tmp.path().join("src/mailers/welcome.rs").exists());
+        let cargo_after = fs::read_to_string(&cargo_path).unwrap();
+        assert!(
+            cargo_after.contains("\"mail\""),
+            "mail feature must survive — auth still uses Mail::builder(): {cargo_after}"
+        );
+    }
+
     // ── GREEN: execute and inspect written content ────────────────────────
 
     #[test]

--- a/autumn-cli/src/generate/mailer.rs
+++ b/autumn-cli/src/generate/mailer.rs
@@ -46,6 +46,11 @@ use super::{GenerateError, ensure_project_root, read_or_empty, timestamp_now};
 ///
 /// # Errors
 /// Project layout and name validation errors surface here.
+#[allow(
+    clippy::too_many_lines,
+    reason = "linear sequence of independent file/revert steps mirroring the files this \
+              generator emits; splitting it up would not make any single step clearer"
+)]
 pub fn plan_mailer(
     project_root: &Path,
     name: &str,
@@ -150,7 +155,7 @@ pub fn plan_mailer(
     plan.modify(mod_path.clone(), with_both_mods);
     plan.push_revert(crate::generate::emit::Revert::ModDecl {
         path: mod_path,
-        name: snake_name.clone(),
+        name: snake_name,
     });
 
     // ── src/main.rs: add mod mailers; and .mail_previews(…) ────────────────
@@ -590,6 +595,54 @@ async fn main() {
                 .contains("\"mail\""),
             "mail feature must be removed once no mailer uses it anymore"
         );
+    }
+
+    #[test]
+    fn destroying_one_of_two_mailers_keeps_shared_layout_the_other_still_includes() {
+        let tmp = project_with_main(default_main());
+        let layout_html = tmp.path().join("templates/mailers/_layout.html");
+        let layout_txt = tmp.path().join("templates/mailers/_layout.txt");
+
+        // Welcome creates the shared layout files (create_if_absent);
+        // Goodbye's own plan carries the SAME create_if_absent actions
+        // (they're silently skipped at execute time since the files already
+        // exist), so both mailers' plans mention them.
+        plan_mailer(tmp.path(), "Welcome", None, false)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        plan_mailer(tmp.path(), "Goodbye", None, false)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        assert!(layout_html.exists());
+        assert!(layout_txt.exists());
+
+        // Destroying Welcome alone must NOT delete the shared layout —
+        // Goodbye's mailer/preview files still `include_str!` it.
+        plan_mailer(tmp.path(), "Welcome", None, false)
+            .unwrap()
+            .revert(Flags::default())
+            .unwrap();
+
+        assert!(!tmp.path().join("src/mailers/welcome.rs").exists());
+        assert!(
+            layout_html.exists(),
+            "shared _layout.html must survive — Goodbye's mailer still includes it"
+        );
+        assert!(
+            layout_txt.exists(),
+            "shared _layout.txt must survive — Goodbye's mailer still includes it"
+        );
+
+        // Now destroy the last remaining mailer — the shared layout must
+        // finally go too.
+        plan_mailer(tmp.path(), "Goodbye", None, false)
+            .unwrap()
+            .revert(Flags::default())
+            .unwrap();
+        assert!(!layout_html.exists());
+        assert!(!layout_txt.exists());
     }
 
     // ── RED: file plan assertions ─────────────────────────────────────────

--- a/autumn-cli/src/generate/migration.rs
+++ b/autumn-cli/src/generate/migration.rs
@@ -16,7 +16,7 @@ use super::schema_edit::{
     parse_model_search_config_for_table, remove_columns_down_sql, remove_columns_up_sql,
     singularize,
 };
-use super::{Flags, GenerateError, ensure_project_root, timestamp_now};
+use super::{GenerateError, ensure_project_root};
 
 fn collect_rs_files_recursive(dir: &Path, candidates: &mut Vec<std::path::PathBuf>) {
     if let Ok(entries) = std::fs::read_dir(dir) {
@@ -215,30 +215,10 @@ fn pascalish(name: &str) -> String {
     }
 }
 
-/// CLI entry point.
-pub fn run(name: &str, field_tokens: &[String], uniques: &[String], flags: Flags) {
-    let cwd = match std::env::current_dir() {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("Error: cannot determine current directory: {e}");
-            std::process::exit(1);
-        }
-    };
-    let timestamp = timestamp_now();
-    match plan_migration_with_options(&cwd, name, field_tokens, &timestamp, uniques)
-        .and_then(|p| p.execute(flags))
-    {
-        Ok(()) => {}
-        Err(e) => {
-            eprintln!("Error: {e}");
-            std::process::exit(1);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::generate::Flags;
     use std::fs;
     use tempfile::TempDir;
 
@@ -260,6 +240,50 @@ mod tests {
         let down = fs::read_to_string(dir.join("down.sql")).unwrap();
         assert!(up.is_empty());
         assert!(down.is_empty());
+    }
+
+    #[test]
+    fn generate_then_destroy_migration_round_trips_to_original_project_state() {
+        temp_env::with_vars(
+            [
+                ("AUTUMN_DATABASE__PRIMARY_URL", None::<&str>),
+                ("AUTUMN_DATABASE__URL", None::<&str>),
+                ("DATABASE_URL", None::<&str>),
+            ],
+            || {
+                let tmp = project();
+                let plan = plan_migration(
+                    tmp.path(),
+                    "AddTitleToPosts",
+                    &["title:String".into()],
+                    "20260427000000",
+                )
+                .unwrap();
+                plan.execute(Flags::default()).unwrap();
+                let dir = tmp
+                    .path()
+                    .join("migrations/20260427000000_add_title_to_posts");
+                assert!(dir.exists());
+
+                // Destroy recomputes the plan with a FRESH timestamp; the
+                // real on-disk directory must still be found by suffix.
+                let destroy_plan = plan_migration(
+                    tmp.path(),
+                    "AddTitleToPosts",
+                    &["title:String".into()],
+                    "99999999999999",
+                )
+                .unwrap();
+                destroy_plan.revert(Flags::default()).unwrap();
+
+                assert!(!dir.exists());
+                assert!(
+                    fs::read_dir(tmp.path().join("migrations"))
+                        .map(|mut d| d.next().is_none())
+                        .unwrap_or(true)
+                );
+            },
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/migration.rs
+++ b/autumn-cli/src/generate/migration.rs
@@ -323,6 +323,71 @@ mod tests {
     }
 
     #[test]
+    fn destroy_migration_refuses_directory_with_unplanned_file_unless_forced() {
+        // issue #1048 PR review: a developer may drop a README.md or an
+        // auxiliary fixture alongside the generated up.sql/down.sql. Destroy
+        // must treat that extra file as divergence rather than silently
+        // sweeping it up with `remove_dir_all`.
+        temp_env::with_vars(
+            [
+                ("AUTUMN_DATABASE__PRIMARY_URL", None::<&str>),
+                ("AUTUMN_DATABASE__URL", None::<&str>),
+                ("DATABASE_URL", None::<&str>),
+            ],
+            || {
+                let tmp = project();
+                let plan = plan_migration(
+                    tmp.path(),
+                    "AddTitleToPosts",
+                    &["title:String".into()],
+                    "20260427000000",
+                )
+                .unwrap();
+                plan.execute(Flags::default()).unwrap();
+                let dir = tmp
+                    .path()
+                    .join("migrations/20260427000000_add_title_to_posts");
+                assert!(dir.exists());
+                fs::write(dir.join("README.md"), "hand-authored notes\n").unwrap();
+
+                let destroy_plan = plan_migration(
+                    tmp.path(),
+                    "AddTitleToPosts",
+                    &["title:String".into()],
+                    "99999999999999",
+                )
+                .unwrap();
+                let err = destroy_plan
+                    .revert(Flags {
+                        dry_run: false,
+                        force: false,
+                    })
+                    .unwrap_err();
+                assert!(matches!(err, GenerateError::Diverged(_)));
+                assert!(
+                    dir.join("README.md").exists(),
+                    "hand-authored file must survive without --force"
+                );
+
+                let destroy_plan = plan_migration(
+                    tmp.path(),
+                    "AddTitleToPosts",
+                    &["title:String".into()],
+                    "99999999999999",
+                )
+                .unwrap();
+                destroy_plan
+                    .revert(Flags {
+                        dry_run: false,
+                        force: true,
+                    })
+                    .unwrap();
+                assert!(!dir.exists(), "--force must still remove the directory");
+            },
+        );
+    }
+
+    #[test]
     fn add_columns_migration_emits_alter() {
         let tmp = project();
         let plan = plan_migration(

--- a/autumn-cli/src/generate/migration.rs
+++ b/autumn-cli/src/generate/migration.rs
@@ -195,6 +195,43 @@ pub fn plan_migration_with_options(
     Ok(plan)
 }
 
+/// Fallback destroy-only plan for `autumn destroy migration <name>` when
+/// [`plan_migration_with_options`] can't be recomputed — e.g. an
+/// `AddSearchTo<Table>` migration whose model file (or its `#[searchable]`
+/// config) is already gone by the time destroy runs, a common cleanup order
+/// like deleting/destroying the model first (issue #1048 PR review).
+/// `plan_migration_with_options` needs that config to render the right SQL,
+/// which is meaningless (and an error) once it's gone.
+///
+/// Locates the migration directory by suffix only — the same
+/// `{timestamp}_{suffix}` naming [`plan_migration_with_options`] uses, which
+/// is all [`Plan::revert`] actually needs to find it (destroy always
+/// recomputes a fresh timestamp anyway, so exact SQL content was never
+/// load-bearing for *locating* the directory). Its expected content is
+/// unknowable without re-deriving the search config, so `up.sql`/`down.sql`
+/// are recorded with an empty placeholder — real content (never empty)
+/// always counts as diverged, so they're only removed with `--force`,
+/// exactly like [`super::admin::plan_admin_destroy_fallback`].
+///
+/// # Errors
+/// Returns [`GenerateError`] when `project_root` isn't a valid project, or
+/// `name` fails validation.
+pub fn plan_migration_destroy_fallback(
+    project_root: &Path,
+    name: &str,
+    timestamp: &str,
+) -> Result<Plan, GenerateError> {
+    ensure_project_root(project_root)?;
+    super::model::validate_resource_name(name)?;
+
+    let dir_name = format!("{timestamp}_{}", snake_or_pascal_to_snake(name));
+    let migration_dir = project_root.join("migrations").join(&dir_name);
+    let mut plan = Plan::new(project_root);
+    plan.create(migration_dir.join("up.sql"), String::new());
+    plan.create(migration_dir.join("down.sql"), String::new());
+    Ok(plan)
+}
+
 /// Convert a name like `AddTitleToPosts` → `add_title_to_posts`, while
 /// leaving an already-snake-case name untouched.
 fn snake_or_pascal_to_snake(name: &str) -> String {
@@ -468,6 +505,93 @@ pub struct Post {
         );
         assert!(down.contains("DROP INDEX IF EXISTS idx_posts_search_vector;"));
         assert!(down.contains("ALTER TABLE posts DROP COLUMN IF EXISTS search_vector;"));
+    }
+
+    // ── `plan_migration_destroy_fallback` (issue #1048 PR review) ───────────
+
+    #[test]
+    fn destroy_add_search_migration_after_model_already_destroyed_still_removes_it() {
+        // A common cleanup order — destroying the model before destroying
+        // an `AddSearchTo<Table>` migration that depended on its
+        // `#[searchable]` config — must not strand the migration directory
+        // just because `plan_migration_with_options` can no longer read it.
+        temp_env::with_vars(
+            [
+                ("AUTUMN_DATABASE__PRIMARY_URL", None::<&str>),
+                ("AUTUMN_DATABASE__URL", None::<&str>),
+                ("DATABASE_URL", None::<&str>),
+            ],
+            || {
+                let tmp = project();
+                let models_dir = tmp.path().join("src/models");
+                fs::create_dir_all(&models_dir).unwrap();
+                let model_src = r#"
+#[autumn_web::model(table = "posts")]
+#[searchable(language = "english")]
+pub struct Post {
+    #[id]
+    pub id: i64,
+    #[searchable(weight = "A")]
+    pub title: String,
+}
+"#;
+                fs::write(models_dir.join("post.rs"), model_src).unwrap();
+
+                let plan =
+                    plan_migration(tmp.path(), "AddSearchToPosts", &[], "20260427000000").unwrap();
+                plan.execute(Flags::default()).unwrap();
+                let dir = tmp
+                    .path()
+                    .join("migrations/20260427000000_add_search_to_posts");
+                assert!(dir.exists());
+
+                // Simulate `autumn destroy model Post` having already run.
+                fs::remove_file(models_dir.join("post.rs")).unwrap();
+                assert!(
+                    plan_migration(tmp.path(), "AddSearchToPosts", &[], "99999999999999").is_err()
+                );
+
+                let fallback_plan = plan_migration_destroy_fallback(
+                    tmp.path(),
+                    "AddSearchToPosts",
+                    "99999999999999",
+                )
+                .unwrap();
+                // Without --force: content is unverifiable (the search
+                // config is gone), so it's treated as diverged and left in
+                // place.
+                let err = fallback_plan
+                    .revert(Flags {
+                        dry_run: false,
+                        force: false,
+                    })
+                    .unwrap_err();
+                assert!(matches!(err, GenerateError::Diverged(_)));
+                assert!(dir.exists());
+
+                let fallback_plan = plan_migration_destroy_fallback(
+                    tmp.path(),
+                    "AddSearchToPosts",
+                    "99999999999999",
+                )
+                .unwrap();
+                fallback_plan
+                    .revert(Flags {
+                        dry_run: false,
+                        force: true,
+                    })
+                    .unwrap();
+                assert!(!dir.exists());
+            },
+        );
+    }
+
+    #[test]
+    fn plan_migration_destroy_fallback_fails_outside_project() {
+        let tmp = TempDir::new().unwrap();
+        let err = plan_migration_destroy_fallback(tmp.path(), "AddSearchToPosts", "20260427000000")
+            .unwrap_err();
+        assert!(matches!(err, GenerateError::NotInProject));
     }
 
     // ── references field: parity with `generate model` (issue #1026) ───────

--- a/autumn-cli/src/generate/migration.rs
+++ b/autumn-cli/src/generate/migration.rs
@@ -279,8 +279,7 @@ mod tests {
                 assert!(!dir.exists());
                 assert!(
                     fs::read_dir(tmp.path().join("migrations"))
-                        .map(|mut d| d.next().is_none())
-                        .unwrap_or(true)
+                        .map_or(true, |mut d| d.next().is_none())
                 );
             },
         );

--- a/autumn-cli/src/generate/mod.rs
+++ b/autumn-cli/src/generate/mod.rs
@@ -65,6 +65,15 @@ pub enum GenerateError {
     /// Generator config file is invalid or missing a required section.
     #[error("{0}")]
     Config(String),
+
+    /// `autumn destroy` refuses to remove file(s) whose content has diverged
+    /// from what the matching `generate` invocation would have produced
+    /// (issue #1048) — pass `--force` to override.
+    #[error(
+        "refusing to destroy — file(s) diverged from generated content, pass --force to override:\n{}",
+        format_collisions(.0)
+    )]
+    Diverged(Vec<PathBuf>),
 }
 
 /// ⚡ Bolt optimization: Formats collision paths directly into a pre-allocated

--- a/autumn-cli/src/generate/mod.rs
+++ b/autumn-cli/src/generate/mod.rs
@@ -6,8 +6,8 @@
 //!
 //! Three subcommands live here:
 //! - [`model::plan_model_with_options`] — model + migration + schema entry
-//! - [`migration::run`] — migration only (with optional add/remove DSL)
-//! - [`scaffold::run`] — model + repository + HTML routes + smoke test +
+//! - [`migration::plan_migration_with_options`] — migration only (with optional add/remove DSL)
+//! - [`scaffold::plan_scaffold_with_options`] — model + repository + HTML routes + smoke test +
 //!   `routes![]` registration
 
 pub mod admin;

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -201,6 +201,7 @@ pub fn plan_model_with_options(
     plan.push_revert(crate::generate::emit::Revert::SchemaTable {
         path: schema_path,
         table: table.clone(),
+        expected_block: append_schema_table_with_id("", &table, &schema_fields, options.id_type),
     });
 
     // (d) `Cargo.toml` deps — `#[autumn_web::model]` expands to references

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -100,6 +100,11 @@ pub fn plan_model(
 ///
 /// # Errors
 /// Surfaces project-layout, DSL, naming, and metadata errors before any file is written.
+#[allow(
+    clippy::too_many_lines,
+    reason = "linear sequence of independent file/revert steps mirroring the files this \
+              generator emits; splitting it up would not make any single step clearer"
+)]
 pub fn plan_model_with_options(
     project_root: &Path,
     name: &str,
@@ -160,7 +165,7 @@ pub fn plan_model_with_options(
     );
     plan.push_revert(crate::generate::emit::Revert::ModDecl {
         path: mod_path,
-        name: snake_name.clone(),
+        name: snake_name,
     });
 
     // (b) Diesel migration
@@ -1740,9 +1745,7 @@ mod tests {
         assert!(!tmp.path().join("src/models/mod.rs").exists());
         assert!(!tmp.path().join("src/schema.rs").exists());
         assert!(
-            fs::read_dir(tmp.path().join("migrations"))
-                .map(|mut d| d.next().is_none())
-                .unwrap_or(true),
+            fs::read_dir(tmp.path().join("migrations")).map_or(true, |mut d| d.next().is_none()),
             "migration directory must be removed"
         );
         assert_eq!(fs::read_to_string(&cargo_path).unwrap(), original_cargo);

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -1809,6 +1809,46 @@ mod tests {
     }
 
     #[test]
+    fn destroying_last_model_keeps_dep_still_used_by_hand_written_code() {
+        // Codex PR review (issue #1048): a project can hand-add a dependency
+        // for its own reasons, unrelated to any generated resource. Destroy
+        // must not strip it just because the last model that also happened
+        // to need it is gone.
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname = \"x\"\n\n[dependencies]\nautumn-web = \"0.6.0\"\ndiesel_migrations = \"2\"\n",
+        )
+        .unwrap();
+        let cargo_path = tmp.path().join("Cargo.toml");
+
+        plan_model(tmp.path(), "Post", &["owner:Uuid".into()], "20260427000000")
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        // Hand-written code elsewhere in the project also uses `uuid`,
+        // independent of the generated model.
+        fs::create_dir_all(tmp.path().join("src/tasks")).unwrap();
+        fs::write(
+            tmp.path().join("src/tasks/cleanup.rs"),
+            "pub fn new_id() -> uuid::Uuid {\n    uuid::Uuid::new_v4()\n}\n",
+        )
+        .unwrap();
+        assert!(fs::read_to_string(&cargo_path).unwrap().contains("uuid"));
+
+        plan_model(tmp.path(), "Post", &["owner:Uuid".into()], "99999999999999")
+            .unwrap()
+            .revert(Flags::default())
+            .unwrap();
+
+        assert!(!tmp.path().join("src/models/post.rs").exists());
+        assert!(
+            fs::read_to_string(&cargo_path).unwrap().contains("uuid"),
+            "uuid must survive — hand-written src/tasks/cleanup.rs still uses it"
+        );
+    }
+
+    #[test]
     fn plan_rejects_lowercase_first_char() {
         let tmp = project();
         let err = plan_model(tmp.path(), "123Bad", &[], "20260427000000").unwrap_err();

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -154,7 +154,14 @@ pub fn plan_model_with_options(
 
     let mod_path = models_dir.join("mod.rs");
     let mod_existing = read_or_empty(&mod_path);
-    plan.modify(mod_path, add_mod_declaration(&mod_existing, &snake_name));
+    plan.modify(
+        mod_path.clone(),
+        add_mod_declaration(&mod_existing, &snake_name),
+    );
+    plan.push_revert(crate::generate::emit::Revert::ModDecl {
+        path: mod_path,
+        name: snake_name.clone(),
+    });
 
     // (b) Diesel migration
     let migration_dir_name = format!("{timestamp}_create_{table}");
@@ -183,9 +190,13 @@ pub fn plan_model_with_options(
     let schema_path = project_root.join("src").join("schema.rs");
     let schema_existing = read_or_empty(&schema_path);
     plan.modify(
-        schema_path,
+        schema_path.clone(),
         append_schema_table_with_id(&schema_existing, &table, &schema_fields, options.id_type),
     );
+    plan.push_revert(crate::generate::emit::Revert::SchemaTable {
+        path: schema_path,
+        table: table.clone(),
+    });
 
     // (d) `Cargo.toml` deps — `#[autumn_web::model]` expands to references
     // for `diesel`, `serde`, `serde_json`, `chrono`, and supported field crates
@@ -508,9 +519,52 @@ pub(super) fn plan_cargo_deps(plan: &mut Plan, project_root: &Path, deps: &[(&st
     let existing = read_or_empty(&cargo_toml_path);
     let updated = ensure_cargo_dependencies(&existing, deps);
     if updated != existing {
-        plan.modify(cargo_toml_path, updated);
+        plan.modify(cargo_toml_path.clone(), updated);
+    }
+    // Recorded unconditionally — mirroring every other `push_revert` call in
+    // this module — so `autumn destroy` (issue #1048), which recomputes
+    // this same plan against the *already-generated* Cargo.toml (where
+    // these deps are, by definition, already present), still knows to
+    // remove them. Gating this on "did the Modify actually change
+    // anything" would make it a no-op at destroy time, since re-running
+    // this same idempotent transform against post-generate disk never
+    // produces a diff.
+    //
+    // `TEMPLATE_SHIPPED_CARGO_DEPS` names are excluded: `autumn new`'s own
+    // template already declares them (see `templates/Cargo.toml.tmpl`), so
+    // `ensure_cargo_dependencies` never actually adds them for a real
+    // project — they're only in `MODEL_DEPS`/`SCAFFOLD_EXTRA_DEPS` as a
+    // safety net for a hand-rolled Cargo.toml missing them. Reverting them
+    // unconditionally would strip a framework dependency the project needs
+    // regardless of any generated resource.
+    //
+    // Known limitation (documented, out of scope per issue #1048): for any
+    // *other* name, if a *different* resource's generator also depends on
+    // it, destroying this resource still removes it — reverting a shared
+    // dependency across multiple generated resources needs the multi-step
+    // undo history the issue explicitly scopes out.
+    let names: Vec<String> = deps
+        .iter()
+        .map(|(name, _)| *name)
+        .filter(|name| !TEMPLATE_SHIPPED_CARGO_DEPS.contains(name))
+        .map(str::to_owned)
+        .collect();
+    if !names.is_empty() {
+        plan.push_revert(crate::generate::emit::Revert::CargoDeps {
+            path: cargo_toml_path,
+            names,
+        });
     }
 }
+
+/// Crate dependencies `autumn new`'s own template already declares (see
+/// `templates/Cargo.toml.tmpl`) that also happen to appear in
+/// [`MODEL_DEPS`]/[`super::scaffold::SCAFFOLD_EXTRA_DEPS`] as a safety net
+/// for a hand-rolled project missing them. [`plan_cargo_deps`] never
+/// includes these in a `Revert::CargoDeps`, since a real project needs them
+/// regardless of whether any resource was ever generated.
+pub(super) const TEMPLATE_SHIPPED_CARGO_DEPS: &[&str] =
+    &["autumn-web", "maud", "diesel_migrations"];
 
 /// Insert each `(crate, version_spec)` pair at the end of the `[dependencies]`
 /// section, skipping entries already present. Pure string transformation —
@@ -603,6 +657,71 @@ pub(super) fn ensure_cargo_dependencies(existing: &str, deps: &[(&str, &str)]) -
     // Preserve whether the original file ended with a newline.
     if !existing.ends_with('\n') {
         out.pop();
+    }
+    out
+}
+
+/// Inverse of [`ensure_cargo_dependencies`] (`autumn destroy`, issue #1048).
+///
+/// Removes the exact `<name> = <spec>` shorthand line for each crate in
+/// `names` from `[dependencies]`, leaving every other entry (and the rest of
+/// the file) byte-for-byte intact. A no-op for any crate not present in that
+/// exact shorthand form — already destroyed, hand-edited into a subtable, or
+/// never added by this generator — destroy only reverses lines `generate`
+/// itself would have written.
+#[must_use]
+pub(super) fn remove_cargo_dependencies(existing: &str, names: &[&str]) -> String {
+    let mut lines: Vec<&str> = existing.lines().collect();
+    let Some(deps_idx) = lines
+        .iter()
+        .position(|l| is_table_header(l, "dependencies"))
+    else {
+        return existing.to_owned();
+    };
+    let mut scan_end = lines[deps_idx + 1..]
+        .iter()
+        .position(|l| is_any_table_header(l) && !is_dep_subtable_boundary_marker(l))
+        .map_or(lines.len(), |off| deps_idx + 1 + off);
+
+    let mut removed_any = false;
+    let mut i = deps_idx + 1;
+    while i < scan_end {
+        let trimmed = lines[i].trim_start();
+        let is_target = names.iter().any(|name| {
+            trimmed
+                .strip_prefix(name)
+                .is_some_and(|rest| rest.trim_start().starts_with('='))
+        });
+        if is_target {
+            lines.remove(i);
+            scan_end -= 1;
+            removed_any = true;
+            continue;
+        }
+        i += 1;
+    }
+    if !removed_any {
+        return existing.to_owned();
+    }
+    // If removing these deps emptied the whole `[dependencies]` section
+    // (allowing for a residual blank line — e.g. the separator a later
+    // `[dev-dependencies]` insertion added right after the last real entry),
+    // drop the header, every blank line in its now-empty body, and the
+    // blank separator line before it, if any — restoring the file to what
+    // it looked like before `ensure_cargo_dependencies` ever created this
+    // section from scratch.
+    if lines[deps_idx + 1..scan_end]
+        .iter()
+        .all(|l| l.trim().is_empty())
+    {
+        lines.drain(deps_idx..scan_end);
+        if deps_idx > 0 && lines[deps_idx - 1].trim().is_empty() {
+            lines.remove(deps_idx - 1);
+        }
+    }
+    let mut out = lines.join("\n");
+    if existing.ends_with('\n') && !out.is_empty() {
+        out.push('\n');
     }
     out
 }
@@ -1538,6 +1657,81 @@ mod tests {
     }
 
     #[test]
+    fn plan_records_reverts_for_mod_decl_schema_table_and_cargo_deps() {
+        let tmp = project();
+        let plan = plan_model(
+            tmp.path(),
+            "Post",
+            &["title:String".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert!(plan.reverts.iter().any(|r| matches!(
+            r,
+            crate::generate::emit::Revert::ModDecl { name, .. } if name == "post"
+        )));
+        assert!(plan.reverts.iter().any(|r| matches!(
+            r,
+            crate::generate::emit::Revert::SchemaTable { table, .. } if table == "posts"
+        )));
+        assert!(plan.reverts.iter().any(|r| matches!(
+            r,
+            crate::generate::emit::Revert::CargoDeps { names, .. } if names.iter().any(|n| n == "diesel")
+        )));
+    }
+
+    #[test]
+    fn generate_then_destroy_model_round_trips_to_original_project_state() {
+        // Mirrors a real `autumn new` project's Cargo.toml: `[dependencies]`
+        // already exists (autumn-web, diesel_migrations) before any
+        // generator runs — `diesel_migrations` is template-shipped (see
+        // `TEMPLATE_SHIPPED_CARGO_DEPS`) so `Revert::CargoDeps` never
+        // targets it, matching a real project where it always predates
+        // any `generate` call.
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname = \"x\"\n\n[dependencies]\nautumn-web = \"0.6.0\"\ndiesel_migrations = \"2\"\n",
+        )
+        .unwrap();
+        let cargo_path = tmp.path().join("Cargo.toml");
+        let original_cargo = fs::read_to_string(&cargo_path).unwrap();
+
+        let plan = plan_model(
+            tmp.path(),
+            "Post",
+            &["title:String".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+        assert!(tmp.path().join("src/models/post.rs").exists());
+
+        // Destroy recomputes the plan from the same params (a fresh
+        // timestamp doesn't matter here since the migration dir is matched
+        // by suffix), then reverts it.
+        let destroy_plan = plan_model(
+            tmp.path(),
+            "Post",
+            &["title:String".into()],
+            "99999999999999",
+        )
+        .unwrap();
+        destroy_plan.revert(Flags::default()).unwrap();
+
+        assert!(!tmp.path().join("src/models/post.rs").exists());
+        assert!(!tmp.path().join("src/models/mod.rs").exists());
+        assert!(!tmp.path().join("src/schema.rs").exists());
+        assert!(
+            fs::read_dir(tmp.path().join("migrations"))
+                .map(|mut d| d.next().is_none())
+                .unwrap_or(true),
+            "migration directory must be removed"
+        );
+        assert_eq!(fs::read_to_string(&cargo_path).unwrap(), original_cargo);
+    }
+
+    #[test]
     fn plan_rejects_lowercase_first_char() {
         let tmp = project();
         let err = plan_model(tmp.path(), "123Bad", &[], "20260427000000").unwrap_err();
@@ -2354,6 +2548,53 @@ autumn-web = \"0.3\"\n";
         assert!(updated.contains("autumn-web = \"0.3\""));
         assert!(updated.contains("chrono = \"0.4\""));
         assert_eq!(updated.matches("autumn-web =").count(), 1);
+    }
+
+    #[test]
+    fn remove_cargo_dependencies_restores_original() {
+        let original = "[package]\n\
+name = \"x\"\n\
+\n\
+[dependencies]\n\
+autumn-web = \"0.3\"\n";
+        let updated = ensure_cargo_dependencies(original, &[("chrono", "\"0.4\"")]);
+        assert_ne!(updated, original);
+        let reverted = remove_cargo_dependencies(&updated, &["chrono"]);
+        assert_eq!(reverted, original);
+    }
+
+    #[test]
+    fn remove_cargo_dependencies_removes_only_named_crates() {
+        let original = "[dependencies]\nautumn-web = \"0.3\"\n";
+        let updated =
+            ensure_cargo_dependencies(original, &[("chrono", "\"0.4\""), ("serde", "\"1\"")]);
+        let reverted = remove_cargo_dependencies(&updated, &["chrono"]);
+        assert!(!reverted.contains("chrono"));
+        assert!(reverted.contains("serde = \"1\""));
+        assert!(reverted.contains("autumn-web = \"0.3\""));
+    }
+
+    #[test]
+    fn remove_cargo_dependencies_is_idempotent_when_absent() {
+        let original = "[dependencies]\nautumn-web = \"0.3\"\n";
+        assert_eq!(remove_cargo_dependencies(original, &["chrono"]), original);
+    }
+
+    #[test]
+    fn remove_cargo_dependencies_does_not_touch_prefix_sharing_crate() {
+        let original = "[dependencies]\ndiesel-async = \"0.8\"\n";
+        assert_eq!(remove_cargo_dependencies(original, &["diesel"]), original);
+    }
+
+    #[test]
+    fn remove_cargo_dependencies_collapses_now_empty_section_created_from_scratch() {
+        // Mirrors `ensure_cargo_dependencies`'s "no [dependencies] section
+        // yet" branch: a minimal project with none at all.
+        let original = "[package]\nname = \"x\"\n";
+        let updated = ensure_cargo_dependencies(original, &[("chrono", "\"0.4\"")]);
+        assert_ne!(updated, original);
+        let reverted = remove_cargo_dependencies(&updated, &["chrono"]);
+        assert_eq!(reverted, original);
     }
 
     #[test]

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -221,7 +221,12 @@ pub fn plan_model_with_options(
             &["db-diesel2-postgres", "serde"],
         );
     }
-    plan_cargo_deps(&mut plan, project_root, &deps);
+    plan_cargo_deps(
+        &mut plan,
+        project_root,
+        &deps,
+        &project_root.join("src/models"),
+    );
 
     Ok(plan)
 }
@@ -514,7 +519,18 @@ pub(super) const MODEL_DEPS: &[(&str, &str)] = &[
 /// Append a `Modify` action to `plan` that ensures every `(crate, version_spec)`
 /// in `deps` is present under `[dependencies]` in the project's `Cargo.toml`.
 /// Existing entries are left untouched.
-pub(super) fn plan_cargo_deps(plan: &mut Plan, project_root: &Path, deps: &[(&str, &str)]) {
+///
+/// `owner_dir` is the directory this call's resource files live in (e.g.
+/// `src/models`, `src/jobs`) — `autumn destroy` only removes these deps once
+/// no OTHER file remains in `owner_dir`, so a sibling resource of the same
+/// generator that still needs one of `deps` (e.g. a second `model` also
+/// using `uuid`) survives destroying just one of them.
+pub(super) fn plan_cargo_deps(
+    plan: &mut Plan,
+    project_root: &Path,
+    deps: &[(&str, &str)],
+    owner_dir: &Path,
+) {
     let cargo_toml_path = project_root.join("Cargo.toml");
     let existing = read_or_empty(&cargo_toml_path);
     let updated = ensure_cargo_dependencies(&existing, deps);
@@ -553,6 +569,7 @@ pub(super) fn plan_cargo_deps(plan: &mut Plan, project_root: &Path, deps: &[(&st
         plan.push_revert(crate::generate::emit::Revert::CargoDeps {
             path: cargo_toml_path,
             names,
+            owner_dir: owner_dir.to_path_buf(),
         });
     }
 }
@@ -1729,6 +1746,63 @@ mod tests {
             "migration directory must be removed"
         );
         assert_eq!(fs::read_to_string(&cargo_path).unwrap(), original_cargo);
+    }
+
+    #[test]
+    fn destroying_one_of_two_models_keeps_shared_dep_the_other_still_needs() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname = \"x\"\n\n[dependencies]\nautumn-web = \"0.6.0\"\ndiesel_migrations = \"2\"\n",
+        )
+        .unwrap();
+        let cargo_path = tmp.path().join("Cargo.toml");
+
+        plan_model(tmp.path(), "Post", &["owner:Uuid".into()], "20260427000000")
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        plan_model(
+            tmp.path(),
+            "Comment",
+            &["owner:Uuid".into()],
+            "20260427000001",
+        )
+        .unwrap()
+        .execute(Flags::default())
+        .unwrap();
+        assert!(fs::read_to_string(&cargo_path).unwrap().contains("uuid"));
+
+        // Destroying Post alone must NOT strip `uuid` — Comment's model file
+        // still uses it.
+        plan_model(tmp.path(), "Post", &["owner:Uuid".into()], "99999999999999")
+            .unwrap()
+            .revert(Flags::default())
+            .unwrap();
+
+        assert!(!tmp.path().join("src/models/post.rs").exists());
+        assert!(tmp.path().join("src/models/comment.rs").exists());
+        let cargo_after = fs::read_to_string(&cargo_path).unwrap();
+        assert!(
+            cargo_after.contains("uuid"),
+            "uuid must survive — Comment's model still uses it: {cargo_after}"
+        );
+
+        // Now destroy the last remaining model — `uuid` must finally go.
+        plan_model(
+            tmp.path(),
+            "Comment",
+            &["owner:Uuid".into()],
+            "99999999999998",
+        )
+        .unwrap()
+        .revert(Flags::default())
+        .unwrap();
+        assert!(!tmp.path().join("src/models/comment.rs").exists());
+        assert!(
+            !fs::read_to_string(&cargo_path).unwrap().contains("uuid"),
+            "uuid must be removed once no model uses it anymore"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/pwa.rs
+++ b/autumn-cli/src/generate/pwa.rs
@@ -17,7 +17,7 @@ use std::path::Path;
 use super::emit::Plan;
 use super::schema_edit::update_main_rs;
 use super::system_test::patch_cargo_toml as patch_system_test_cargo_toml;
-use super::{Flags, GenerateError, ensure_project_root};
+use super::{GenerateError, ensure_project_root};
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
@@ -102,24 +102,6 @@ pub fn plan_pwa(project_root: &Path) -> Result<Plan, GenerateError> {
     }
 
     Ok(plan)
-}
-
-/// CLI entry point.
-pub fn run(flags: Flags) {
-    let cwd = match std::env::current_dir() {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("Error: cannot determine current directory: {e}");
-            std::process::exit(1);
-        }
-    };
-    match plan_pwa(&cwd).and_then(|p| p.execute(flags)) {
-        Ok(()) => {}
-        Err(e) => {
-            eprintln!("Error: {e}");
-            std::process::exit(1);
-        }
-    }
 }
 
 // ── Content renderers ─────────────────────────────────────────────────────────

--- a/autumn-cli/src/generate/pwa.rs
+++ b/autumn-cli/src/generate/pwa.rs
@@ -83,8 +83,23 @@ pub fn plan_pwa(project_root: &Path) -> Result<Plan, GenerateError> {
     // src/main.rs: inject PWA meta tags + route handlers (idempotent)
     let updated_main = inject_pwa_into_main(&main_existing);
     if updated_main != main_existing {
-        plan.modify(main_path, updated_main);
+        plan.modify(main_path.clone(), updated_main);
     }
+    // Pushed unconditionally — see `plan_cargo_deps`'s matching comment in
+    // model.rs: destroy recomputes this plan against the already-generated
+    // main.rs, where these edits are by definition already present.
+    plan.push_revert(crate::generate::emit::Revert::PwaMainRsInjection {
+        path: main_path.clone(),
+    });
+    plan.push_revert(crate::generate::emit::Revert::RoutesEntries {
+        path: main_path,
+        entries: vec![
+            "pwa_manifest".to_owned(),
+            "pwa_service_worker".to_owned(),
+            "pwa_register_js".to_owned(),
+            "pwa_offline".to_owned(),
+        ],
+    });
 
     // System test
     let system_test_path = project_root
@@ -98,8 +113,12 @@ pub fn plan_pwa(project_root: &Path) -> Result<Plan, GenerateError> {
     let cargo_existing = std::fs::read_to_string(&cargo_path).map_err(GenerateError::Io)?;
     let patched_cargo = patch_system_test_cargo_toml(&cargo_existing, "pwa_smoke");
     if patched_cargo != cargo_existing {
-        plan.modify(cargo_path, patched_cargo);
+        plan.modify(cargo_path.clone(), patched_cargo);
     }
+    plan.push_revert(crate::generate::emit::Revert::SystemTestCargoPatch {
+        path: cargo_path,
+        snake_name: "pwa_smoke".to_owned(),
+    });
 
     Ok(plan)
 }
@@ -489,12 +508,7 @@ fn count_top_level_commas(s: &str) -> usize {
 /// Append `pwa_manifest`, `pwa_service_worker`, `pwa_register_js`, and `pwa_offline`
 /// handler functions just before `#[autumn_web::main]`.  Idempotent — skipped when
 /// `pwa_manifest` is already defined.
-fn inject_pwa_handlers(source: &str) -> String {
-    if source.contains("async fn pwa_manifest()") {
-        return source.to_owned();
-    }
-
-    let handlers = "\
+const PWA_HANDLERS_BLOCK: &str = "\
 #[get(\"/manifest.webmanifest\")]\n\
 async fn pwa_manifest() -> impl IntoResponse {\n\
     (\n\
@@ -543,6 +557,11 @@ async fn pwa_offline(flash: Flash, path: CurrentPath) -> maud::Markup {\n\
 }\n\
 \n";
 
+fn inject_pwa_handlers(source: &str) -> String {
+    if source.contains("async fn pwa_manifest()") {
+        return source.to_owned();
+    }
+
     // Insert before `#[autumn_web::main]`, or append at end as fallback.
     source.find("#[autumn_web::main]").map_or_else(
         || {
@@ -551,13 +570,13 @@ async fn pwa_offline(flash: Flash, path: CurrentPath) -> maud::Markup {\n\
                 result.push('\n');
             }
             result.push('\n');
-            result.push_str(handlers);
+            result.push_str(PWA_HANDLERS_BLOCK);
             result
         },
         |pos| {
-            let mut result = String::with_capacity(source.len() + handlers.len());
+            let mut result = String::with_capacity(source.len() + PWA_HANDLERS_BLOCK.len());
             result.push_str(&source[..pos]);
-            result.push_str(handlers);
+            result.push_str(PWA_HANDLERS_BLOCK);
             result.push_str(&source[pos..]);
             result
         },
@@ -566,6 +585,72 @@ async fn pwa_offline(flash: Flash, path: CurrentPath) -> maud::Markup {\n\
 
 fn indent_count(line: &str) -> usize {
     line.len() - line.trim_start().len()
+}
+
+/// Inverse of [`inject_pwa_into_main`] (`autumn destroy`, issue #1048).
+///
+/// Removes the PWA `<link>`/`<meta>` tags from the `head {}` block and the
+/// `pwa_manifest`/`pwa_service_worker`/`pwa_register_js`/`pwa_offline`
+/// handler functions this generator injected. A no-op wherever its target
+/// isn't present (already destroyed, or hand-edited away).
+pub(super) fn remove_pwa_injection(existing: &str) -> String {
+    let without_handlers = remove_pwa_handlers(existing);
+    remove_pwa_meta_from_head(&without_handlers)
+}
+
+/// Inverse of [`inject_pwa_meta_into_head`]. Removes exactly the four lines
+/// that function inserts (three tag lines + the register-script line),
+/// identified by the unique `/pwa-register.js` script line together with the
+/// three lines immediately preceding it matching the known tag text
+/// (ignoring indentation) — restoring the `head {}` block byte-identically.
+///
+/// A no-op if the script line isn't present, or the three preceding lines
+/// don't match (hand-edited — never guesses at a partial match).
+fn remove_pwa_meta_from_head(existing: &str) -> String {
+    const SCRIPT_LINE: &str = "script src=\"/pwa-register.js\" {}";
+    const PRECEDING_LINES: [&str; 3] = [
+        "link rel=\"manifest\" href=\"/manifest.webmanifest\";",
+        "meta name=\"theme-color\" content=\"#ffffff\";",
+        "link rel=\"apple-touch-icon\" href=\"/static/icons/icon.svg\";",
+    ];
+    let lines: Vec<&str> = existing.lines().collect();
+    let Some(script_idx) = lines.iter().position(|l| l.trim() == SCRIPT_LINE) else {
+        return existing.to_owned();
+    };
+    if script_idx < PRECEDING_LINES.len() {
+        return existing.to_owned();
+    }
+    let start = script_idx - PRECEDING_LINES.len();
+    let matches = PRECEDING_LINES
+        .iter()
+        .enumerate()
+        .all(|(offset, expected)| lines[start + offset].trim() == *expected);
+    if !matches {
+        return existing.to_owned();
+    }
+    let mut new_lines: Vec<&str> = Vec::with_capacity(lines.len());
+    new_lines.extend_from_slice(&lines[..start]);
+    new_lines.extend_from_slice(&lines[script_idx + 1..]);
+    let mut out = new_lines.join("\n");
+    if existing.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+/// Inverse of [`inject_pwa_handlers`]. Removes the exact
+/// [`PWA_HANDLERS_BLOCK`] text that function inserts verbatim.
+///
+/// A no-op if the block isn't present (already destroyed, or hand-edited
+/// away).
+fn remove_pwa_handlers(existing: &str) -> String {
+    let Some(pos) = existing.find(PWA_HANDLERS_BLOCK) else {
+        return existing.to_owned();
+    };
+    let mut out = String::with_capacity(existing.len() - PWA_HANDLERS_BLOCK.len());
+    out.push_str(&existing[..pos]);
+    out.push_str(&existing[pos + PWA_HANDLERS_BLOCK.len()..]);
+    out
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -1217,6 +1302,42 @@ async fn main() {
         assert!(main_rs.contains("async fn pwa_service_worker()"));
         assert!(main_rs.contains("async fn pwa_register_js()"));
         assert!(main_rs.contains("async fn pwa_offline("));
+    }
+
+    #[test]
+    fn generate_then_destroy_pwa_round_trips_to_original_project_state() {
+        let tmp = project_with_main(DEFAULT_MAIN);
+        let cargo_path = tmp.path().join("Cargo.toml");
+        let main_path = tmp.path().join("src/main.rs");
+        let original_cargo = fs::read_to_string(&cargo_path).unwrap();
+        let original_main = fs::read_to_string(&main_path).unwrap();
+
+        plan_pwa(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        assert!(tmp.path().join("static/manifest.webmanifest").exists());
+        assert!(
+            fs::read_to_string(&main_path)
+                .unwrap()
+                .contains("async fn pwa_manifest()")
+        );
+        assert!(
+            fs::read_to_string(&cargo_path)
+                .unwrap()
+                .contains("system-tests")
+        );
+
+        plan_pwa(tmp.path())
+            .unwrap()
+            .revert(Flags::default())
+            .unwrap();
+
+        assert!(!tmp.path().join("static/manifest.webmanifest").exists());
+        assert!(!tmp.path().join("static").exists());
+        assert!(!tmp.path().join("tests/system/pwa_smoke.rs").exists());
+        assert_eq!(fs::read_to_string(&main_path).unwrap(), original_main);
+        assert_eq!(fs::read_to_string(&cargo_path).unwrap(), original_cargo);
     }
 
     #[test]

--- a/autumn-cli/src/generate/pwa.rs
+++ b/autumn-cli/src/generate/pwa.rs
@@ -21,6 +21,73 @@ use super::{GenerateError, ensure_project_root};
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
+/// The actions and reverts common to both `plan_pwa` and
+/// [`plan_pwa_destroy_fallback`]: every PWA-generated file is fully static
+/// (parameter-free — none of it depends on `src/main.rs`'s current shape),
+/// and the revert descriptors only need paths, not content (they read
+/// `main.rs`/`Cargo.toml` fresh off disk when `Plan::revert` runs them).
+fn plan_pwa_shared(project_root: &Path) -> Plan {
+    let mut plan = Plan::new(project_root);
+
+    // Static assets (served via generated route handlers + participate in fingerprinting)
+    plan.create(
+        project_root.join("static").join("manifest.webmanifest"),
+        render_manifest(),
+    );
+    plan.create(
+        project_root.join("static").join("service-worker.js"),
+        render_service_worker(),
+    );
+    plan.create(
+        project_root.join("static").join("pwa-register.js"),
+        render_pwa_register_js(),
+    );
+    plan.create(
+        project_root.join("static").join("icons").join("icon.svg"),
+        render_icon_svg(),
+    );
+    plan.create(
+        project_root
+            .join("static")
+            .join("icons")
+            .join("maskable-icon.svg"),
+        render_maskable_icon_svg(),
+    );
+
+    // Pushed unconditionally — see `plan_cargo_deps`'s matching comment in
+    // model.rs: destroy recomputes this plan against the already-generated
+    // main.rs, where these edits are by definition already present.
+    let main_path = project_root.join("src").join("main.rs");
+    plan.push_revert(crate::generate::emit::Revert::PwaMainRsInjection {
+        path: main_path.clone(),
+    });
+    plan.push_revert(crate::generate::emit::Revert::RoutesEntries {
+        path: main_path,
+        entries: vec![
+            "pwa_manifest".to_owned(),
+            "pwa_service_worker".to_owned(),
+            "pwa_register_js".to_owned(),
+            "pwa_offline".to_owned(),
+        ],
+    });
+
+    // System test
+    let system_test_path = project_root
+        .join("tests")
+        .join("system")
+        .join("pwa_smoke.rs");
+    plan.create(system_test_path, render_pwa_system_test());
+
+    // Cargo.toml: add system-tests feature if absent
+    let cargo_path = project_root.join("Cargo.toml");
+    plan.push_revert(crate::generate::emit::Revert::SystemTestCargoPatch {
+        path: cargo_path,
+        snake_name: "pwa_smoke".to_owned(),
+    });
+
+    plan
+}
+
 /// Compute the file actions for `autumn generate pwa`.
 ///
 /// # Errors
@@ -53,74 +120,39 @@ pub fn plan_pwa(project_root: &Path) -> Result<Plan, GenerateError> {
         )));
     }
 
-    let mut plan = Plan::new(project_root);
-
-    // Static assets (served via generated route handlers + participate in fingerprinting)
-    plan.create(
-        project_root.join("static").join("manifest.webmanifest"),
-        render_manifest(),
-    );
-    plan.create(
-        project_root.join("static").join("service-worker.js"),
-        render_service_worker(),
-    );
-    plan.create(
-        project_root.join("static").join("pwa-register.js"),
-        render_pwa_register_js(),
-    );
-    plan.create(
-        project_root.join("static").join("icons").join("icon.svg"),
-        render_icon_svg(),
-    );
-    plan.create(
-        project_root
-            .join("static")
-            .join("icons")
-            .join("maskable-icon.svg"),
-        render_maskable_icon_svg(),
-    );
+    let mut plan = plan_pwa_shared(project_root);
 
     // src/main.rs: inject PWA meta tags + route handlers (idempotent)
     let updated_main = inject_pwa_into_main(&main_existing);
     if updated_main != main_existing {
-        plan.modify(main_path.clone(), updated_main);
+        plan.modify(main_path, updated_main);
     }
-    // Pushed unconditionally — see `plan_cargo_deps`'s matching comment in
-    // model.rs: destroy recomputes this plan against the already-generated
-    // main.rs, where these edits are by definition already present.
-    plan.push_revert(crate::generate::emit::Revert::PwaMainRsInjection {
-        path: main_path.clone(),
-    });
-    plan.push_revert(crate::generate::emit::Revert::RoutesEntries {
-        path: main_path,
-        entries: vec![
-            "pwa_manifest".to_owned(),
-            "pwa_service_worker".to_owned(),
-            "pwa_register_js".to_owned(),
-            "pwa_offline".to_owned(),
-        ],
-    });
-
-    // System test
-    let system_test_path = project_root
-        .join("tests")
-        .join("system")
-        .join("pwa_smoke.rs");
-    plan.create(system_test_path, render_pwa_system_test());
 
     // Cargo.toml: add system-tests feature if absent
     let cargo_path = project_root.join("Cargo.toml");
     let cargo_existing = std::fs::read_to_string(&cargo_path).map_err(GenerateError::Io)?;
     let patched_cargo = patch_system_test_cargo_toml(&cargo_existing, "pwa_smoke");
     if patched_cargo != cargo_existing {
-        plan.modify(cargo_path.clone(), patched_cargo);
+        plan.modify(cargo_path, patched_cargo);
     }
-    plan.push_revert(crate::generate::emit::Revert::SystemTestCargoPatch {
-        path: cargo_path,
-        snake_name: "pwa_smoke".to_owned(),
-    });
 
     Ok(plan)
+}
+
+/// Destroy-only fallback (issue #1048 PR review): `plan_pwa` validates that
+/// `src/main.rs`'s `layout()` takes 4 parameters before building anything —
+/// necessary so a *fresh* generate never emits a call with the wrong arity,
+/// but that precondition is irrelevant (and can wrongly block cleanup) once
+/// `main.rs` has since been hand-edited, reverted, or otherwise no longer
+/// matches the shape `plan_pwa` expects. Every PWA-generated file is fully
+/// static, and `Plan::revert` never consults `Action::Modify` content —
+/// only `self.reverts`, which read `main.rs`/`Cargo.toml` fresh off disk at
+/// revert time — so `plan_pwa_shared` alone is already a complete, exact
+/// destroy plan; unlike the model-dependent admin/migration fallbacks, no
+/// `--force` is needed to use it.
+pub fn plan_pwa_destroy_fallback(project_root: &Path) -> Result<Plan, GenerateError> {
+    ensure_project_root(project_root)?;
+    Ok(plan_pwa_shared(project_root))
 }
 
 // ── Content renderers ─────────────────────────────────────────────────────────
@@ -1338,6 +1370,45 @@ async fn main() {
         assert!(!tmp.path().join("tests/system/pwa_smoke.rs").exists());
         assert_eq!(fs::read_to_string(&main_path).unwrap(), original_main);
         assert_eq!(fs::read_to_string(&cargo_path).unwrap(), original_cargo);
+    }
+
+    #[test]
+    fn destroy_pwa_still_works_after_main_rs_reverted_to_pre_nav_bar_shape() {
+        // issue #1048 PR review: `plan_pwa` (used to recompute the plan for
+        // destroy too) rejects `main.rs` whenever `layout()` has fewer than
+        // 4 parameters. That precondition only matters for a *fresh*
+        // generate — but a common cleanup order (hand-revert `main.rs` to
+        // the pre-`nav_bar` shape, or run a competing generator that
+        // rewrites `layout()`) would otherwise strand every PWA file
+        // because `destroy pwa` fails before `Plan::revert` ever runs.
+        let tmp = project_with_main(DEFAULT_MAIN);
+        plan_pwa(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        assert!(tmp.path().join("static/manifest.webmanifest").exists());
+
+        // Simulate main.rs having been rewritten to the old, incompatible
+        // arity after PWA was generated (still contains the PWA injections,
+        // just with layout() narrowed back down).
+        let main_path = tmp.path().join("src/main.rs");
+        let with_pwa = fs::read_to_string(&main_path).unwrap();
+        let narrowed = with_pwa.replace(
+            "pub fn layout(title: &str, current_path: &str, flash: maud::Markup, content: maud::Markup) -> maud::Markup {",
+            "pub fn layout(title: &str, flash: maud::Markup, content: maud::Markup) -> maud::Markup {",
+        );
+        assert_ne!(narrowed, with_pwa, "replacement must actually match");
+        fs::write(&main_path, &narrowed).unwrap();
+        assert!(plan_pwa(tmp.path()).is_err());
+
+        plan_pwa_destroy_fallback(tmp.path())
+            .unwrap()
+            .revert(Flags::default())
+            .unwrap();
+
+        assert!(!tmp.path().join("static/manifest.webmanifest").exists());
+        assert!(!tmp.path().join("static").exists());
+        assert!(!tmp.path().join("tests/system/pwa_smoke.rs").exists());
     }
 
     #[test]

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -286,7 +286,12 @@ pub fn plan_scaffold_with_options(
             "{ version = \"1\", features = [\"db-diesel2-postgres\", \"serde\"] }",
         ));
     }
-    plan_cargo_deps(&mut plan, project_root, &combined);
+    plan_cargo_deps(
+        &mut plan,
+        project_root,
+        &combined,
+        &project_root.join("src/models"),
+    );
 
     // The generated HTML routes render through `autumn_web::form::*` helpers
     // (issue #1124), which are gated behind autumn-web's `maud` feature — enable
@@ -314,6 +319,7 @@ pub fn plan_scaffold_with_options(
         plan.push_revert(Revert::CargoAutumnWebFeature {
             path: cargo_path,
             feature: "maud".to_owned(),
+            owner_dir: Some(project_root.join("src").join("routes")),
         });
     }
 
@@ -345,10 +351,12 @@ pub fn plan_scaffold_with_options(
             plan.modify(cargo_path.clone(), updated);
         }
         // Pushed unconditionally — see `plan_cargo_deps`'s matching comment.
+        let routes_dir = project_root.join("src").join("routes");
         for feat in feats {
             plan.push_revert(Revert::CargoAutumnWebFeature {
                 path: cargo_path.clone(),
                 feature: (*feat).to_owned(),
+                owner_dir: Some(routes_dir.clone()),
             });
         }
     }
@@ -376,9 +384,13 @@ pub fn plan_scaffold_with_options(
             plan.modify(cargo_path.clone(), updated);
         }
         // Pushed unconditionally — see `plan_cargo_deps`'s matching comment.
+        // `owner_dir` is `src/models` (not `src/routes`) because the smoke
+        // test — and thus `test-support` — is generated for EVERY scaffold,
+        // including `--api`-only ones that never get a routes file.
         plan.push_revert(Revert::CargoAutumnWebDevFeature {
             path: cargo_path,
             feature: "test-support".to_owned(),
+            owner_dir: Some(project_root.join("src").join("models")),
         });
     }
 

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -29,7 +29,7 @@ use super::{GenerateError, ensure_project_root, read_or_empty};
 /// Extra dependencies the *scaffold* generator's output requires on top of
 /// [`super::model::MODEL_DEPS`] — `maud` for HTML rendering and URL-encoded
 /// form helpers for blank nullable-field normalization.
-const SCAFFOLD_EXTRA_DEPS: &[(&str, &str)] = &[
+pub(super) const SCAFFOLD_EXTRA_DEPS: &[(&str, &str)] = &[
     ("maud", "{ version = \"0.27\", features = [\"axum\"] }"),
     ("serde_urlencoded", "\"0.7\""),
     ("url", "\"2\""),
@@ -3343,8 +3343,7 @@ async fn main() {
                 }
                 assert!(
                     fs::read_dir(tmp.path().join("migrations"))
-                        .map(|mut d| d.next().is_none())
-                        .unwrap_or(true),
+                        .map_or(true, |mut d| d.next().is_none()),
                     "migration directory must be removed"
                 );
                 assert_eq!(fs::read_to_string(&main_path).unwrap(), original_main);

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -4190,6 +4190,42 @@ async fn main() {
     }
 
     #[test]
+    fn destroying_the_only_scaffold_keeps_pre_existing_test_support_another_test_still_uses() {
+        // issue #1048 PR review: a project may already have `autumn-web`
+        // under `[dev-dependencies]` with `test-support` enabled for its
+        // OWN hand-written tests, independent of any scaffold.
+        // `ensure_dev_dependency_test_support` makes no Cargo.toml edit in
+        // that case, but the revert is still recorded unconditionally —
+        // must not strip `test-support` out from under that unrelated test
+        // when destroying the only scaffold.
+        let tmp = project_with_main(default_main());
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname=\"x\"\n\n[dev-dependencies]\nautumn-web = { version = \"0.6\", features = [\"test-support\"] }\n",
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("tests")).unwrap();
+        fs::write(
+            tmp.path().join("tests/hand_written.rs"),
+            "#[tokio::test]\nasync fn it_works() {\n    let _db = autumn_web::test::TestDb::shared().await;\n}\n",
+        )
+        .unwrap();
+
+        let plan = plan_scaffold(tmp.path(), "Post", &[], "20260427000000").unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let destroy_plan = plan_scaffold(tmp.path(), "Post", &[], "99999999999999").unwrap();
+        destroy_plan.revert(Flags::default()).unwrap();
+
+        let cargo_after = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        assert!(
+            cargo_after.contains("test-support"),
+            "pre-existing test-support must survive — the hand-written test still uses \
+             TestDb: {cargo_after}"
+        );
+    }
+
+    #[test]
     fn smoke_test_wires_dev_dependency_tokio_test_features() {
         // Regression test (Codex review, issue #1023): the generated smoke
         // test uses `#[tokio::test]`, which needs the `rt` and `macros`

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -13,7 +13,7 @@ use std::fmt::Write as _;
 use std::path::Path;
 
 use super::dsl::{Field, FieldKind, IdType, parse_fields};
-use super::emit::{Action, Plan};
+use super::emit::{Action, Plan, Revert};
 use super::model::{
     ModelOptions, augment_fields_for_soft_delete, field_by_name, parse_model_metadata,
     plan_cargo_deps, plan_model_with_options,
@@ -24,7 +24,7 @@ use super::schema_edit::{
     ensure_dev_dependency_test_support, ensure_dev_dependency_tokio_test_features,
     unique_index_name, update_main_rs,
 };
-use super::{Flags, GenerateError, ensure_project_root, read_or_empty, timestamp_now};
+use super::{GenerateError, ensure_project_root, read_or_empty};
 
 /// Extra dependencies the *scaffold* generator's output requires on top of
 /// [`super::model::MODEL_DEPS`] — `maud` for HTML rendering and URL-encoded
@@ -164,6 +164,10 @@ pub fn plan_scaffold_with_options(
         repo_mod_path.clone(),
         add_mod_declaration(&read_or_empty(&repo_mod_path), &snake_name),
     );
+    plan.push_revert(Revert::ModDecl {
+        path: repo_mod_path,
+        name: snake_name.clone(),
+    });
 
     // Route file under `src/routes/<plural>.rs`
     if !options_with_key.api {
@@ -189,6 +193,10 @@ pub fn plan_scaffold_with_options(
             route_mod_path.clone(),
             add_mod_declaration(&read_or_empty(&route_mod_path), &plural),
         );
+        plan.push_revert(Revert::ModDecl {
+            path: route_mod_path,
+            name: plural.clone(),
+        });
     }
 
     // Smoke test under `tests/<snake>.rs`. Uses the same soft-delete-augmented
@@ -235,7 +243,16 @@ pub fn plan_scaffold_with_options(
         mods.push("routes");
     }
     let updated = update_main_rs(&main_existing, &mods, &route_entries);
-    plan.modify(main_path, updated);
+    plan.modify(main_path.clone(), updated);
+    // `mod models;`/`mod schema;`/`mod repositories;`/`mod routes;` are
+    // shared infrastructure declarations, not owned by this resource — see
+    // `emit::sync_main_rs_mod_declarations`, which removes one only once its
+    // backing module no longer exists on disk. Only this resource's own
+    // `routes![]` entries are reverted here.
+    plan.push_revert(Revert::RoutesEntries {
+        path: main_path,
+        entries: route_entries,
+    });
 
     // The Maud `html!` macro pulls in a direct `maud` dep on top of the
     // model's deps. Both modify actions target Cargo.toml, so we combine
@@ -288,8 +305,16 @@ pub fn plan_scaffold_with_options(
         let updated = ensure_autumn_web_feature(&base, "maud");
         if updated != base {
             plan.actions.retain(|a| a.path() != cargo_path);
-            plan.modify(cargo_path, updated);
+            plan.modify(cargo_path.clone(), updated);
         }
+        // Pushed unconditionally — see `plan_cargo_deps`'s matching comment:
+        // at `destroy` time this same call recomputes the plan against the
+        // already-generated Cargo.toml, where "maud" is by definition
+        // already present, so `updated != base` above would never be true.
+        plan.push_revert(Revert::CargoAutumnWebFeature {
+            path: cargo_path,
+            feature: "maud".to_owned(),
+        });
     }
 
     // --live requires `ws` (sse::stream), `maud` (LiveFragment/Markup), and `htmx`.
@@ -317,7 +342,14 @@ pub fn plan_scaffold_with_options(
         }
         if updated != base {
             plan.actions.retain(|a| a.path() != cargo_path);
-            plan.modify(cargo_path, updated);
+            plan.modify(cargo_path.clone(), updated);
+        }
+        // Pushed unconditionally — see `plan_cargo_deps`'s matching comment.
+        for feat in feats {
+            plan.push_revert(Revert::CargoAutumnWebFeature {
+                path: cargo_path.clone(),
+                feature: (*feat).to_owned(),
+            });
         }
     }
 
@@ -341,8 +373,13 @@ pub fn plan_scaffold_with_options(
         let updated = ensure_dev_dependency_test_support(&base, env!("CARGO_PKG_VERSION"));
         if updated != base {
             plan.actions.retain(|a| a.path() != cargo_path);
-            plan.modify(cargo_path, updated);
+            plan.modify(cargo_path.clone(), updated);
         }
+        // Pushed unconditionally — see `plan_cargo_deps`'s matching comment.
+        plan.push_revert(Revert::CargoAutumnWebDevFeature {
+            path: cargo_path,
+            feature: "test-support".to_owned(),
+        });
     }
 
     // The generated smoke test also uses `#[tokio::test]`, which needs the
@@ -370,26 +407,6 @@ pub fn plan_scaffold_with_options(
     }
 
     Ok(plan)
-}
-
-/// CLI entry point.
-pub fn run(name: &str, field_tokens: &[String], flags: Flags, options: &ScaffoldOptions) {
-    let cwd = match std::env::current_dir() {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("Error: cannot determine current directory: {e}");
-            std::process::exit(1);
-        }
-    };
-    let timestamp = timestamp_now();
-    let plan = plan_scaffold_with_options(&cwd, name, field_tokens, &timestamp, options);
-    match plan.and_then(|p| p.execute(flags)) {
-        Ok(()) => {}
-        Err(e) => {
-            eprintln!("Error: {e}");
-            std::process::exit(1);
-        }
-    }
 }
 
 /// Fixed, unconditional (non-`--live`, non-attachment-gated) names the
@@ -3175,6 +3192,7 @@ fn main_route_entries(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::generate::Flags;
     use std::fs;
     use tempfile::TempDir;
 
@@ -3247,6 +3265,80 @@ async fn main() {
                 "missing expected action for {expected}; got {paths:?}"
             );
         }
+    }
+
+    #[test]
+    fn generate_then_destroy_scaffold_round_trips_to_original_project_state() {
+        temp_env::with_vars(
+            [
+                ("AUTUMN_DATABASE__PRIMARY_URL", None::<&str>),
+                ("AUTUMN_DATABASE__URL", None::<&str>),
+                ("DATABASE_URL", None::<&str>),
+            ],
+            || {
+                let tmp = project_with_main(default_main());
+                // Mirrors `autumn new`'s real template Cargo.toml (see
+                // `templates/Cargo.toml.tmpl`): `autumn-web`/`maud`/
+                // `diesel_migrations` and a `tokio` dev-dep with `rt`+`macros`
+                // already present, since a fresh project always ships them.
+                let cargo_path = tmp.path().join("Cargo.toml");
+                fs::write(
+                    &cargo_path,
+                    "[package]\nname = \"x\"\n\n\
+                     [dependencies]\n\
+                     autumn-web = \"0.6.0\"\n\
+                     maud = { version = \"0.27\", features = [\"axum\"] }\n\
+                     diesel_migrations = \"2\"\n\n\
+                     [dev-dependencies]\n\
+                     tokio = { version = \"1\", features = [\"rt\", \"macros\"] }\n",
+                )
+                .unwrap();
+                let main_path = tmp.path().join("src/main.rs");
+                let original_cargo = fs::read_to_string(&cargo_path).unwrap();
+                let original_main = fs::read_to_string(&main_path).unwrap();
+
+                let plan = plan_scaffold(
+                    tmp.path(),
+                    "Post",
+                    &["title:String".into()],
+                    "20260427000000",
+                )
+                .unwrap();
+                plan.execute(Flags::default()).unwrap();
+                assert!(tmp.path().join("src/models/post.rs").exists());
+                assert!(tmp.path().join("src/routes/posts.rs").exists());
+
+                let destroy_plan = plan_scaffold(
+                    tmp.path(),
+                    "Post",
+                    &["title:String".into()],
+                    "99999999999999",
+                )
+                .unwrap();
+                destroy_plan.revert(Flags::default()).unwrap();
+
+                for gone in [
+                    "src/models/post.rs",
+                    "src/models/mod.rs",
+                    "src/schema.rs",
+                    "src/repositories/post.rs",
+                    "src/repositories/mod.rs",
+                    "src/routes/posts.rs",
+                    "src/routes/mod.rs",
+                    "tests/post.rs",
+                ] {
+                    assert!(!tmp.path().join(gone).exists(), "{gone} should be removed");
+                }
+                assert!(
+                    fs::read_dir(tmp.path().join("migrations"))
+                        .map(|mut d| d.next().is_none())
+                        .unwrap_or(true),
+                    "migration directory must be removed"
+                );
+                assert_eq!(fs::read_to_string(&main_path).unwrap(), original_main);
+                assert_eq!(fs::read_to_string(&cargo_path).unwrap(), original_cargo);
+            },
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -111,12 +111,16 @@ fn has_table(existing: &str, table: &str) -> bool {
 /// byte to whatever preceded it (including becoming empty, in which case the
 /// caller deletes the file rather than leaving a blank `src/schema.rs`).
 ///
-/// A no-op (returns `existing` unchanged) if `table` isn't declared, or if
-/// the block's shape doesn't match what `append_schema_table_with_id` would
-/// have produced (hand-edited/malformed) — destroy never corrupts a file it
-/// can't confidently reverse.
+/// A no-op (returns `existing` unchanged) if `table` isn't declared, if the
+/// block's shape doesn't match what `append_schema_table_with_id` would have
+/// produced (hand-edited/malformed), or if the block's content isn't
+/// byte-identical to `expected_block` (the literal text this generator
+/// invocation would append for `table`) — the last check protects a
+/// same-named table that pre-existed with different columns from ever being
+/// destroyed (issue #1048 PR review): destroy never corrupts, nor deletes, a
+/// table it didn't itself produce.
 #[must_use]
-pub fn remove_schema_table(existing: &str, table: &str) -> String {
+pub fn remove_schema_table(existing: &str, table: &str, expected_block: &str) -> String {
     if !has_table(existing, table) {
         return existing.to_owned();
     }
@@ -143,6 +147,11 @@ pub fn remove_schema_table(existing: &str, table: &str) -> String {
         return existing.to_owned();
     }
     let outer_close_idx = inner_close_idx + 1;
+
+    let found_block = format!("{}\n", lines[open_idx..=outer_close_idx].join("\n"));
+    if found_block != expected_block {
+        return existing.to_owned();
+    }
 
     // Also consume one preceding blank separator line, if present.
     let mut start = open_idx;
@@ -6792,8 +6801,9 @@ pub struct Comment {
     #[test]
     fn remove_schema_table_restores_empty_file() {
         let f = fields(&["title:String"]);
-        let after_add = append_schema_table("", "posts", &f);
-        assert_eq!(remove_schema_table(&after_add, "posts"), "");
+        let block = append_schema_table("", "posts", &f);
+        let after_add = block.clone();
+        assert_eq!(remove_schema_table(&after_add, "posts", &block), "");
     }
 
     #[test]
@@ -6801,15 +6811,33 @@ pub struct Comment {
         let f1 = fields(&["title:String"]);
         let f2 = fields(&["name:String"]);
         let base = append_schema_table("", "users", &f2);
+        let block = append_schema_table("", "posts", &f1);
         let after_add = append_schema_table(&base, "posts", &f1);
-        assert_eq!(remove_schema_table(&after_add, "posts"), base);
+        assert_eq!(remove_schema_table(&after_add, "posts", &block), base);
     }
 
     #[test]
     fn remove_schema_table_is_idempotent_when_absent() {
         let f = fields(&["name:String"]);
         let base = append_schema_table("", "users", &f);
-        assert_eq!(remove_schema_table(&base, "posts"), base);
+        let block = append_schema_table("", "posts", &f);
+        assert_eq!(remove_schema_table(&base, "posts", &block), base);
+    }
+
+    #[test]
+    fn remove_schema_table_never_removes_a_pre_existing_table_with_different_columns() {
+        // A hand-rolled `posts` table with different columns than this
+        // generator invocation would produce must survive `destroy` — it
+        // wasn't generate's own output, even though the name matches
+        // (issue #1048 PR review).
+        let hand_written = "diesel::table! {\n    posts (id) {\n        id -> BigInt,\n        \
+                             body -> Text,\n    }\n}\n";
+        let generated_block = append_schema_table("", "posts", &fields(&["title:String"]));
+        assert_eq!(
+            remove_schema_table(hand_written, "posts", &generated_block),
+            hand_written,
+            "pre-existing table with different columns must not be removed"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -1298,9 +1298,17 @@ fn insert_mail_previews_call(existing: &str, mailer_type: &str) -> String {
 ///
 /// A no-op if there's no `mail_previews![...]`, or `mailer_type` isn't
 /// currently listed.
+///
+/// Locates the whole `.mail_previews(mail_previews![...])` call by balanced-
+/// paren scan (rather than assuming it stays on one line) when the list
+/// empties out, so a project that ran the call through `rustfmt` — which
+/// commonly wraps it across several lines once it has more than a couple of
+/// mailer names — doesn't end up with a dangling, now-meaningless remnant
+/// (issue #1048 PR review).
 #[must_use]
 pub fn remove_mail_preview_from_app(existing: &str, mailer_type: &str) -> String {
     const PREVIEW_MACRO: &str = "mail_previews![";
+    const CALL_PREFIX: &str = ".mail_previews(";
     let Some((spliced, now_empty)) =
         remove_entry_from_bracketed_list(existing, PREVIEW_MACRO, mailer_type)
     else {
@@ -1309,15 +1317,46 @@ pub fn remove_mail_preview_from_app(existing: &str, mailer_type: &str) -> String
     if !now_empty {
         return spliced;
     }
-    // Only entry -- remove the whole freshly-inserted line.
-    let lines: Vec<&str> = existing.lines().collect();
-    let Some(line_idx) = lines
-        .iter()
-        .position(|l| l.trim_start().starts_with(".mail_previews(mail_previews!["))
-    else {
+    // Only entry -- remove the whole freshly-inserted call, whichever lines
+    // it spans.
+    let Some(call_pos) = existing.find(CALL_PREFIX) else {
         return existing.to_owned();
     };
-    remove_single_line(&lines, line_idx, existing.ends_with('\n'))
+    let Some(call_end) = find_balanced_close_paren(existing, call_pos + CALL_PREFIX.len()) else {
+        return existing.to_owned();
+    };
+    let start_line = existing[..call_pos].rfind('\n').map_or(0, |i| i + 1);
+    let end_line = existing[call_end..]
+        .find('\n')
+        .map_or(existing.len(), |i| call_end + i + 1);
+    let mut out = String::with_capacity(existing.len());
+    out.push_str(&existing[..start_line]);
+    out.push_str(&existing[end_line..]);
+    out
+}
+
+/// Scan forward from `start` (the byte position just after an already-open
+/// `(`, i.e. depth 1) for the matching closing paren, returning the index
+/// just past it. `None` if the parens never balance (malformed/truncated
+/// input — destroy never guesses).
+fn find_balanced_close_paren(src: &str, start: usize) -> Option<usize> {
+    let bytes = src.as_bytes();
+    let mut depth = 1usize;
+    let mut i = start;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i + 1);
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
 }
 
 /// Shared bracket-list-entry removal behind [`remove_job_entry`] and
@@ -1977,6 +2016,30 @@ fn remove_feature_from_deps_section(
     None
 }
 
+/// Find the `features` key inside an inline-table `body` (e.g.
+/// `version = "1", default-features = false, features = ["mail"]`), as a
+/// whole key — not a substring match that a plain `body.find("features")`
+/// would also hit inside `default-features` when that key comes first
+/// (issue #1048 PR review: `default-features = false, features = ["mail"]`
+/// would otherwise truncate `before_features` mid-word at `default-` and
+/// rewrite the dependency into invalid TOML). Requires the match to be
+/// preceded by the body start or a non-identifier character, and followed
+/// by optional whitespace then `=`.
+fn find_features_key(body: &str) -> Option<usize> {
+    let mut search_from = 0;
+    while let Some(rel) = body[search_from..].find("features") {
+        let idx = search_from + rel;
+        let is_key_start = idx == 0
+            || !matches!(body.as_bytes()[idx - 1], b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' | b'-');
+        let is_key_end = body[idx + "features".len()..].trim_start().starts_with('=');
+        if is_key_start && is_key_end {
+            return Some(idx);
+        }
+        search_from = idx + "features".len();
+    }
+    None
+}
+
 /// Parse `line` as `{indent}{dep_name} = { ...features = [...] ... }` and
 /// decide how to rewrite it once `feature_quoted` is removed from the
 /// features array. Returns [`FeatureRemovalEdit::Unchanged`] whenever the
@@ -2003,7 +2066,7 @@ fn parse_feature_removal(
         return FeatureRemovalEdit::Unchanged;
     };
     let body = rest[..body_end].trim();
-    let Some(features_kw) = body.find("features") else {
+    let Some(features_kw) = find_features_key(body) else {
         return FeatureRemovalEdit::Unchanged;
     };
     let before_features = body[..features_kw].trim().trim_end_matches(',').trim();
@@ -5147,6 +5210,34 @@ async fn main() {\n\
     }
 
     #[test]
+    fn remove_mail_preview_from_app_removes_a_rustfmt_wrapped_call() {
+        // rustfmt commonly wraps `.mail_previews(mail_previews![...])`
+        // across several lines once it has a couple of mailer names. Naive
+        // line-start matching would strip only the opening line and leave
+        // the rest (`WelcomeMailer,` / `])`) dangling — issue #1048 PR
+        // review.
+        let src = "fn main() {\n    App::new()\n        .mail_previews(mail_previews![\n            WelcomeMailer,\n        ])\n        .run()\n}\n";
+        let updated = remove_mail_preview_from_app(src, "WelcomeMailer");
+        assert!(
+            !updated.contains("mail_previews"),
+            "the whole call must be removed once its only entry is gone, got:\n{updated}"
+        );
+        assert_eq!(updated, "fn main() {\n    App::new()\n        .run()\n}\n");
+    }
+
+    #[test]
+    fn remove_mail_preview_from_app_keeps_other_entry_in_a_rustfmt_wrapped_call() {
+        let src = "fn main() {\n    App::new()\n        .mail_previews(mail_previews![\n            WelcomeMailer,\n            ReceiptMailer,\n        ])\n        .run()\n}\n";
+        let updated = remove_mail_preview_from_app(src, "WelcomeMailer");
+        assert!(
+            updated.contains("mail_previews"),
+            "the call must survive while another entry remains, got:\n{updated}"
+        );
+        assert!(updated.contains("ReceiptMailer"));
+        assert!(!updated.contains("WelcomeMailer"));
+    }
+
+    #[test]
     fn remove_mail_preview_from_app_is_idempotent_when_absent() {
         let base = "fn main() {\n    App::new()\n        .run()\n}\n";
         assert_eq!(remove_mail_preview_from_app(base, "WelcomeMailer"), base);
@@ -7088,6 +7179,20 @@ pub struct Comment {
             reverted,
             "[dependencies]\nautumn-web = { version = \"0.6.0\", features = [\"maud\"], default-features = false }\n",
             "trailing keys after the features array must survive: {reverted}"
+        );
+    }
+
+    #[test]
+    fn remove_autumn_web_feature_handles_default_features_key_before_features() {
+        // issue #1048 PR review: a plain `body.find("features")` matches
+        // inside `default-features` when that key comes first, truncating
+        // `before_features` mid-word and corrupting the rewritten line.
+        let base = "[dependencies]\nautumn-web = { version = \"0.6.0\", default-features = false, features = [\"maud\", \"htmx\"] }\n";
+        let reverted = remove_autumn_web_feature(base, "htmx");
+        assert_eq!(
+            reverted,
+            "[dependencies]\nautumn-web = { version = \"0.6.0\", default-features = false, features = [\"maud\"] }\n",
+            "must remove only the target feature, keeping default-features intact: {reverted}"
         );
     }
 

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -1796,12 +1796,16 @@ pub fn ensure_autumn_web_feature(existing: &str, feature: &str) -> String {
 /// structure may predate `generate` entirely and destroy never restructures
 /// content it didn't itself add.
 ///
-/// A no-op for a renamed/aliased `autumn-web` dependency, or an entry
-/// `feature` doesn't currently list — destroy only reverses what `generate`
-/// itself would have written.
+/// A no-op for an entry `feature` doesn't currently list — destroy only
+/// reverses what `generate` itself would have written. A renamed/aliased
+/// `autumn-web` dependency (`autumn_web = { package = "autumn-web", ... }` or
+/// `[dependencies.autumn_web]`) is resolved to its actual key first (issue
+/// #1048 PR review) — [`ensure_autumn_web_feature_status_in_section`] adds
+/// features there too, so destroy must look under the same key it did.
 #[must_use]
 pub fn remove_autumn_web_feature(existing: &str, feature: &str) -> String {
-    remove_dep_feature_in_section(existing, "autumn-web", feature, "dependencies", true)
+    let dep_key = resolve_autumn_web_dep_key(existing, "dependencies");
+    remove_dep_feature_in_section(existing, dep_key, feature, "dependencies", true)
 }
 
 /// Inverse of [`ensure_dev_dependency_test_support`] (`autumn destroy`,
@@ -1817,7 +1821,73 @@ pub fn remove_autumn_web_feature(existing: &str, feature: &str) -> String {
 /// [`remove_autumn_web_feature`].
 #[must_use]
 pub fn remove_autumn_web_dev_dependency_feature(existing: &str, feature: &str) -> String {
-    remove_dep_feature_in_section(existing, "autumn-web", feature, "dev-dependencies", false)
+    let dep_key = resolve_autumn_web_dep_key(existing, "dev-dependencies");
+    remove_dep_feature_in_section(existing, dep_key, feature, "dev-dependencies", false)
+}
+
+/// Which literal identifier `autumn-web`'s dependency entry uses in
+/// `section` — either the plain crate name, or an importable alias declared
+/// with an explicit `package = "autumn-web"` (mirrors the alias detection in
+/// [`ensure_autumn_web_feature_status_in_section`], whose Pass 1 "else"
+/// branch and Pass 2b add features under exactly these two alias shapes:
+/// `autumn_web = { package = "autumn-web", ... }` and
+/// `[<section>.autumn_web]` with `package = "autumn-web"` inside).
+///
+/// [`remove_dep_feature_in_section`] previously always searched for the
+/// literal `"autumn-web"` key, so a project using either alias shape kept
+/// its generator-added feature forever — `destroy` located no matching line
+/// and silently made no edit (issue #1048 PR review).
+///
+/// Falls back to the literal key when no dependency entry is found at all —
+/// `remove_dep_feature_in_section` is already a no-op in that case.
+fn resolve_autumn_web_dep_key(existing: &str, section: &str) -> &'static str {
+    let lines: Vec<&str> = existing.lines().collect();
+    let mut in_section = false;
+    for &line in &lines {
+        let trimmed = line.trim();
+        if is_section_header(trimmed, section) {
+            in_section = true;
+            continue;
+        }
+        if in_section && is_section_boundary(trimmed, section) {
+            in_section = false;
+            continue;
+        }
+        if !in_section || trimmed.starts_with('#') {
+            continue;
+        }
+        let after_ws = line.trim_start();
+        if let Some(rest) = after_ws.strip_prefix("autumn-web") {
+            if rest.starts_with('.') || rest.trim_start().starts_with('=') {
+                return "autumn-web";
+            }
+            continue;
+        }
+        let Some((key, val)) = after_ws.split_once('=') else {
+            continue;
+        };
+        let alias = key
+            .trim()
+            .split_once('.')
+            .map_or(key.trim(), |(base, _)| base);
+        if alias.replace('-', "_") == "autumn_web" && declares_package(val, "autumn-web") {
+            return "autumn_web";
+        }
+    }
+
+    let literal_subtable_key = format!("[{section}.autumn-web]");
+    if lines
+        .iter()
+        .any(|l| l.trim().split('#').next().unwrap_or("").trim() == literal_subtable_key)
+    {
+        return "autumn-web";
+    }
+    let renamed_subtable_key = format!("[{section}.autumn_web]");
+    if find_section_start_with_autumn_web_package(&lines, &renamed_subtable_key).is_some() {
+        return "autumn_web";
+    }
+
+    "autumn-web"
 }
 
 /// How a single-line dependency declaration should be rewritten once a
@@ -2113,13 +2183,24 @@ fn parse_feature_removal(
         if !after_list.is_empty() {
             return FeatureRemovalEdit::Unchanged;
         }
-        return before_features
+        if let Some(v) = before_features
             .strip_prefix("version")
             .map(str::trim_start)
             .and_then(|r| r.strip_prefix('='))
-            .map_or(FeatureRemovalEdit::Unchanged, |v| {
-                FeatureRemovalEdit::Replace(format!("{indent}{dep_name} = {}", v.trim()))
-            });
+        {
+            return FeatureRemovalEdit::Replace(format!("{indent}{dep_name} = {}", v.trim()));
+        }
+        // Some other key remains besides the now-empty `features` array —
+        // e.g. a renamed dep's `package = "autumn-web"` (issue #1048 PR
+        // review), or `default-features = false`. Collapsing to a bare
+        // string would silently drop that key, so just remove the
+        // `features` key and keep the rest of the inline table intact.
+        if before_features.is_empty() {
+            return FeatureRemovalEdit::Unchanged;
+        }
+        return FeatureRemovalEdit::Replace(format!(
+            "{indent}{dep_name} = {{ {before_features} }}"
+        ));
     }
 
     FeatureRemovalEdit::Delete
@@ -7288,6 +7369,29 @@ pub struct Comment {
             "an emptied subtable features key must be removed outright, leaving \
              `version` and the header untouched: {reverted}"
         );
+    }
+
+    #[test]
+    fn remove_autumn_web_feature_reverts_renamed_inline_alias() {
+        // issue #1048 PR review: `ensure_autumn_web_feature_status_in_section`
+        // adds features to an importable rename like
+        // `autumn_web = { package = "autumn-web", ... }` too, but the old
+        // remover always searched for the literal `"autumn-web"` key and
+        // silently left the feature behind on this shape.
+        let base =
+            "[dependencies]\nautumn_web = { package = \"autumn-web\", version = \"0.6.0\" }\n";
+        let with_mail = ensure_autumn_web_feature(base, "mail");
+        assert_ne!(with_mail, base);
+        assert!(with_mail.contains("autumn_web"));
+        assert_eq!(remove_autumn_web_feature(&with_mail, "mail"), base);
+    }
+
+    #[test]
+    fn remove_autumn_web_feature_reverts_renamed_subtable_alias() {
+        let base = "[dependencies.autumn_web]\npackage = \"autumn-web\"\nversion = \"0.6.0\"\nfeatures = [\"db\"]\n\n[dev-dependencies]\n";
+        let with_mail = ensure_autumn_web_feature(base, "mail");
+        assert_ne!(with_mail, base);
+        assert_eq!(remove_autumn_web_feature(&with_mail, "mail"), base);
     }
 
     #[test]

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -32,6 +32,34 @@ pub fn add_mod_declaration(existing: &str, name: &str) -> String {
     format!("{trimmed}\n{line}\n")
 }
 
+/// Inverse of [`add_mod_declaration`] (`autumn destroy`, issue #1048).
+///
+/// Removes the exact `pub mod <name>;` line [`add_mod_declaration`] would
+/// have inserted. A no-op (returns `existing` unchanged) if that line isn't
+/// present — either because it was already destroyed, or because the module
+/// pre-existed as a bare `mod <name>;` that `add_mod_declaration` itself
+/// never touches (and destroy must not touch either).
+#[must_use]
+pub fn remove_mod_declaration(existing: &str, name: &str) -> String {
+    let line = format!("pub mod {name};");
+    let Some(idx) = existing.lines().position(|l| l.trim() == line) else {
+        return existing.to_owned();
+    };
+    let lines: Vec<&str> = existing.lines().collect();
+    let mut out = String::with_capacity(existing.len());
+    for (i, l) in lines.iter().enumerate() {
+        if i == idx {
+            continue;
+        }
+        out.push_str(l);
+        out.push('\n');
+    }
+    if !existing.ends_with('\n') && out.ends_with('\n') {
+        out.pop();
+    }
+    out
+}
+
 /// Build a new `diesel::table!` block for the given table, emitting the `id`
 /// column with the caller-supplied `id_type`.
 #[must_use]
@@ -82,6 +110,67 @@ pub fn append_schema_table_with_id(
 fn has_table(existing: &str, table: &str) -> bool {
     let needle = format!("{table} (");
     existing.lines().any(|l| l.trim().starts_with(&needle))
+}
+
+/// Inverse of [`append_schema_table_with_id`]/[`append_schema_table`]
+/// (`autumn destroy`, issue #1048).
+///
+/// Removes the whole `diesel::table! { <table> (...) { ... } }` block for
+/// `table`, plus the single blank separator line
+/// [`append_schema_table_with_id`] inserts before it when appending to a
+/// non-empty file — so removing the last table restores the file byte-for-
+/// byte to whatever preceded it (including becoming empty, in which case the
+/// caller deletes the file rather than leaving a blank `src/schema.rs`).
+///
+/// A no-op (returns `existing` unchanged) if `table` isn't declared, or if
+/// the block's shape doesn't match what `append_schema_table_with_id` would
+/// have produced (hand-edited/malformed) — destroy never corrupts a file it
+/// can't confidently reverse.
+#[must_use]
+pub fn remove_schema_table(existing: &str, table: &str) -> String {
+    if !has_table(existing, table) {
+        return existing.to_owned();
+    }
+    let lines: Vec<&str> = existing.lines().collect();
+    let needle = format!("{table} (");
+    let Some(table_line_idx) = lines.iter().position(|l| l.trim().starts_with(&needle)) else {
+        return existing.to_owned();
+    };
+    if table_line_idx == 0 || lines[table_line_idx - 1].trim() != "diesel::table! {" {
+        return existing.to_owned();
+    }
+    let open_idx = table_line_idx - 1;
+    let Some(inner_close_offset) = lines[table_line_idx + 1..]
+        .iter()
+        .position(|l| l.trim() == "}")
+    else {
+        return existing.to_owned();
+    };
+    let inner_close_idx = table_line_idx + 1 + inner_close_offset;
+    let Some(outer_close_line) = lines.get(inner_close_idx + 1) else {
+        return existing.to_owned();
+    };
+    if outer_close_line.trim() != "}" {
+        return existing.to_owned();
+    }
+    let outer_close_idx = inner_close_idx + 1;
+
+    // Also consume one preceding blank separator line, if present.
+    let mut start = open_idx;
+    if start > 0 && lines[start - 1].trim().is_empty() {
+        start -= 1;
+    }
+
+    let mut new_lines: Vec<&str> = Vec::with_capacity(lines.len());
+    new_lines.extend_from_slice(&lines[..start]);
+    if outer_close_idx + 1 < lines.len() {
+        new_lines.extend_from_slice(&lines[outer_close_idx + 1..]);
+    }
+    let mut out = new_lines.join("\n");
+    if !out.is_empty() {
+        out.push('\n');
+    }
+    out
 }
 
 /// Public predicate: whether `schema` already declares a `<table>` block.
@@ -810,6 +899,47 @@ fn has_mod_declaration(existing: &str, name: &str) -> bool {
         .any(|line| needles.iter().any(|n| line == n))
 }
 
+/// Inverse of [`ensure_mods`] (`autumn destroy`, issue #1048).
+///
+/// Removes each `mod <name>;` line (the bare, private form `ensure_mods`
+/// inserts) for a name in `names`, then collapses any run of blank lines the
+/// removal leaves behind down to at most one, and drops a leading blank line
+/// at the very start of the file — restoring the file exactly as it was
+/// before any of those declarations were added.
+///
+/// Unlike [`remove_mod_declaration`] (a resource's own `pub mod` entry in
+/// `src/models/mod.rs`), this targets `src/main.rs`'s shared infrastructure
+/// module names (`models`, `schema`, `repositories`, `routes`, …). The
+/// caller is responsible for only passing names whose backing module no
+/// longer exists on disk — these declarations are shared by every
+/// generated resource, not owned by one.
+#[must_use]
+pub fn remove_main_mod_declarations(existing: &str, names: &[&str]) -> String {
+    let lines: Vec<&str> = existing.lines().collect();
+    let matches_any = |line: &str| names.iter().any(|n| line.trim() == format!("mod {n};"));
+    if !lines.iter().any(|l| matches_any(l)) {
+        return existing.to_owned();
+    }
+    let kept: Vec<&str> = lines.into_iter().filter(|l| !matches_any(l)).collect();
+
+    let mut collapsed: Vec<&str> = Vec::with_capacity(kept.len());
+    for line in kept {
+        if line.trim().is_empty() && collapsed.last().is_some_and(|l: &&str| l.trim().is_empty()) {
+            continue;
+        }
+        collapsed.push(line);
+    }
+    while collapsed.first().is_some_and(|l| l.trim().is_empty()) {
+        collapsed.remove(0);
+    }
+
+    let mut out = collapsed.join("\n");
+    if existing.ends_with('\n') && !out.is_empty() {
+        out.push('\n');
+    }
+    out
+}
+
 /// Locate the body span (byte offsets, exclusive of the enclosing
 /// `routes![`/`]`) of the *first* `routes![ ... ]` macro invocation in
 /// `existing`. Returns `None` if there is no `routes![` or its brackets are
@@ -893,6 +1023,78 @@ pub fn remove_routes_entries_with_prefix(existing: &str, prefix: &str) -> String
         new_body.push_str(entry);
         new_body.push_str(",\n");
     }
+    let mut out = String::with_capacity(existing.len());
+    out.push_str(&existing[..body_start]);
+    out.push_str(&new_body);
+    out.push_str(&existing[body_end..]);
+    out
+}
+
+/// Inverse of [`augment_routes_body`] (`autumn destroy`, issue #1048).
+///
+/// Removes exactly `entries` from the first `routes![ ... ]` invocation and
+/// restores the pre-existing entries' original layout — byte-identically
+/// when they were on one line (the common case: a fresh `autumn new`
+/// project's `routes![index, hello, hello_name]`), since `augment_routes_body`
+/// only ever *appends* after existing content and never reformats it, so the
+/// text preceding the first entry being removed is exactly what preceded
+/// this generate call.
+///
+/// A no-op (returns `existing` unchanged) if there's no `routes![...]`, or if
+/// any of `entries` is no longer present (already destroyed, or the routes
+/// list was hand-edited) — destroy never guesses at a partial match.
+#[must_use]
+pub fn remove_routes_entries(existing: &str, entries: &[String]) -> String {
+    if entries.is_empty() {
+        return existing.to_owned();
+    }
+    let Some((body_start, body_end)) = find_routes_body_range(existing) else {
+        return existing.to_owned();
+    };
+    let body = &existing[body_start..body_end];
+    let present_entries: Vec<String> = body
+        .split([',', '\n'])
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+        .collect();
+    if !entries.iter().all(|e| present_entries.contains(e)) {
+        return existing.to_owned();
+    }
+    let kept: Vec<&String> = present_entries
+        .iter()
+        .filter(|e| !entries.contains(e))
+        .collect();
+
+    // The pre-existing entries' original formatting survives untouched in
+    // the current body, up to the point where this call's first removed
+    // entry begins. Strip the separator (`,`/whitespace/newline) forward
+    // added right after the original content to see whether that ORIGINAL
+    // content itself spanned multiple lines.
+    let first_removed_at = entries
+        .iter()
+        .filter_map(|e| body.find(e.as_str()))
+        .min()
+        .unwrap_or(body.len());
+    let original_segment = &body[..first_removed_at];
+    let original_core = original_segment.trim_end_matches([' ', '\t', '\n', ',']);
+    let multiline = original_core.contains('\n');
+
+    let new_body = if multiline {
+        let indent = leading_indent(body);
+        let mut out = String::with_capacity(body.len());
+        for entry in &kept {
+            out.push_str(&indent);
+            out.push_str(entry);
+            out.push_str(",\n");
+        }
+        out
+    } else {
+        kept.iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+
     let mut out = String::with_capacity(existing.len());
     out.push_str(&existing[..body_start]);
     out.push_str(&new_body);
@@ -1052,6 +1254,66 @@ fn insert_mail_previews_call(existing: &str, mailer_type: &str) -> String {
     )
 }
 
+/// Inverse of [`add_mail_preview_to_app`] (`autumn destroy`, issue #1048).
+///
+/// Removes `mailer_type` from the `mail_previews![...]` list. If it was the
+/// only entry, the whole freshly-inserted
+/// `.mail_previews(mail_previews![...])` line is removed too, rather than
+/// leaving an empty `mail_previews![]` call behind.
+///
+/// A no-op if there's no `mail_previews![...]`, or `mailer_type` isn't
+/// currently listed.
+#[must_use]
+pub fn remove_mail_preview_from_app(existing: &str, mailer_type: &str) -> String {
+    const PREVIEW_MACRO: &str = "mail_previews![";
+    let Some(macro_start) = existing.find(PREVIEW_MACRO) else {
+        return existing.to_owned();
+    };
+    let body_start = macro_start + PREVIEW_MACRO.len();
+    let rest = &existing[body_start..];
+    let Some(end_offset) = rest.find(']') else {
+        return existing.to_owned();
+    };
+    let body = &rest[..end_offset];
+    let items: Vec<&str> = body
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    if !items.contains(&mailer_type) {
+        return existing.to_owned();
+    }
+    let remaining: Vec<&str> = items.into_iter().filter(|s| *s != mailer_type).collect();
+    if !remaining.is_empty() {
+        let new_body = remaining.join(", ");
+        let mut out = String::with_capacity(existing.len());
+        out.push_str(&existing[..body_start]);
+        out.push_str(&new_body);
+        out.push_str(&existing[body_start + end_offset..]);
+        return out;
+    }
+    // Only entry -- remove the whole freshly-inserted line.
+    let lines: Vec<&str> = existing.lines().collect();
+    let Some(line_idx) = lines
+        .iter()
+        .position(|l| l.trim_start().starts_with(".mail_previews(mail_previews!["))
+    else {
+        return existing.to_owned();
+    };
+    let mut out = String::with_capacity(existing.len());
+    for (i, l) in lines.iter().enumerate() {
+        if i == line_idx {
+            continue;
+        }
+        out.push_str(l);
+        out.push('\n');
+    }
+    if !existing.ends_with('\n') && out.ends_with('\n') {
+        out.pop();
+    }
+    out
+}
+
 // ── Job registration helpers ──────────────────────────────────────────────
 
 /// Inject `.jobs(jobs::registered_jobs())` into the `AppBuilder` chain in
@@ -1103,6 +1365,109 @@ pub fn augment_registered_jobs(existing: &str, entry: &str) -> String {
 /// Splice `entry` into an already-present `jobs![...]` body.
 fn splice_jobs_list(existing: &str, body_start: usize, entry: &str) -> String {
     splice_into_macro_body(existing, body_start, entry)
+}
+
+/// Inverse of [`augment_registered_jobs`] (`autumn destroy`, issue #1048).
+///
+/// Removes `entry` from the `jobs![...]` list. If it was the only entry, the
+/// whole freshly-generated `registered_jobs()` function (plus its
+/// `#[must_use]` attribute and the blank separator line before it) is
+/// removed too, rather than leaving an empty `jobs![]` behind.
+///
+/// A no-op if there's no `jobs![...]`, or `entry` isn't currently listed.
+#[must_use]
+pub fn remove_job_entry(existing: &str, entry: &str) -> String {
+    const JOBS_MACRO: &str = "jobs![";
+    let Some(macro_start) = existing.find(JOBS_MACRO) else {
+        return existing.to_owned();
+    };
+    let body_start = macro_start + JOBS_MACRO.len();
+    let rest = &existing[body_start..];
+    let Some(end_offset) = rest.find(']') else {
+        return existing.to_owned();
+    };
+    let body = &rest[..end_offset];
+    let items: Vec<&str> = body
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    if !items.contains(&entry) {
+        return existing.to_owned();
+    }
+    let remaining: Vec<&str> = items.into_iter().filter(|s| *s != entry).collect();
+    if remaining.is_empty() {
+        return remove_registered_jobs_fn(existing);
+    }
+    let new_body = remaining.join(", ");
+    let mut out = String::with_capacity(existing.len());
+    out.push_str(&existing[..body_start]);
+    out.push_str(&new_body);
+    out.push_str(&existing[body_start + end_offset..]);
+    out
+}
+
+/// Remove the whole `registered_jobs()` function [`augment_registered_jobs`]
+/// generates when it creates one from scratch, plus its `#[must_use]`
+/// attribute and one preceding blank separator line.
+fn remove_registered_jobs_fn(existing: &str) -> String {
+    let lines: Vec<&str> = existing.lines().collect();
+    let Some(fn_line_idx) = lines
+        .iter()
+        .position(|l| l.trim_start().starts_with("pub fn registered_jobs("))
+    else {
+        return existing.to_owned();
+    };
+    let start = if fn_line_idx > 0 && lines[fn_line_idx - 1].trim() == "#[must_use]" {
+        fn_line_idx - 1
+    } else {
+        fn_line_idx
+    };
+    let Some(close_offset) = lines[fn_line_idx..].iter().position(|l| l.trim() == "}") else {
+        return existing.to_owned();
+    };
+    let end = fn_line_idx + close_offset;
+
+    let mut effective_start = start;
+    if effective_start > 0 && lines[effective_start - 1].trim().is_empty() {
+        effective_start -= 1;
+    }
+
+    let mut new_lines: Vec<&str> = Vec::with_capacity(lines.len());
+    new_lines.extend_from_slice(&lines[..effective_start]);
+    if end + 1 < lines.len() {
+        new_lines.extend_from_slice(&lines[end + 1..]);
+    }
+    let mut out = new_lines.join("\n");
+    if !out.is_empty() {
+        out.push('\n');
+    }
+    out
+}
+
+/// Inverse of [`add_jobs_registration_to_app`] (`autumn destroy`, issue #1048).
+///
+/// Removes the `.jobs(jobs::registered_jobs())` line from the `AppBuilder`
+/// chain. A no-op if it isn't present.
+#[must_use]
+pub fn remove_jobs_registration_from_app(existing: &str) -> String {
+    const JOBS_CALL: &str = ".jobs(jobs::registered_jobs())";
+    let lines: Vec<&str> = existing.lines().collect();
+    let Some(idx) = lines.iter().position(|l| l.trim() == JOBS_CALL) else {
+        return existing.to_owned();
+    };
+    let mut out = String::with_capacity(existing.len());
+    for (i, l) in lines.iter().enumerate() {
+        if i == idx {
+            continue;
+        }
+        out.push_str(l);
+        out.push('\n');
+    }
+    if !existing.ends_with('\n') && out.ends_with('\n') {
+        out.pop();
+    }
+    out
 }
 
 // ── Cargo.toml: feature injection ────────────────────────────────────────
@@ -1352,6 +1717,204 @@ fn patch_dotted_dep(
 #[must_use]
 pub fn ensure_autumn_web_feature(existing: &str, feature: &str) -> String {
     ensure_autumn_web_feature_status(existing, feature).0
+}
+
+/// Inverse of [`ensure_autumn_web_feature`] (`autumn destroy`, issue #1048),
+/// scoped to `[dependencies]`.
+///
+/// Removes `feature` from `autumn-web`'s single-line inline-table
+/// `features = [...]` list — the shape [`ensure_autumn_web_feature`] produces
+/// when it upgrades a bare-string dependency (`autumn-web = "x.y.z"` →
+/// `autumn-web = { version = "x.y.z", features = ["maud"] }`). If removing
+/// `feature` empties the list and `version` is the only other key, the whole
+/// entry collapses back to that bare string, restoring the pre-generate
+/// declaration byte-for-byte.
+///
+/// A no-op for any other declaration shape (dotted keys, multiline
+/// subtables, an entry `feature` doesn't currently list) — destroy only
+/// reverses what `generate` itself would have written.
+#[must_use]
+pub fn remove_autumn_web_feature(existing: &str, feature: &str) -> String {
+    remove_dep_feature_in_section(existing, "autumn-web", feature, "dependencies", true)
+}
+
+/// Inverse of [`ensure_dev_dependency_test_support`] (`autumn destroy`,
+/// issue #1048), scoped to `[dev-dependencies]`.
+///
+/// Unlike [`remove_autumn_web_feature`], a fresh project's
+/// `[dev-dependencies]` never has a prior `autumn-web` entry —
+/// [`ensure_dev_dependency_test_support`] always *inserts* a brand-new line.
+/// So when removing `feature` empties its features list, the whole line is
+/// deleted outright rather than collapsed to a bare string.
+///
+/// A no-op for any other declaration shape, mirroring
+/// [`remove_autumn_web_feature`].
+#[must_use]
+pub fn remove_autumn_web_dev_dependency_feature(existing: &str, feature: &str) -> String {
+    remove_dep_feature_in_section(existing, "autumn-web", feature, "dev-dependencies", false)
+}
+
+/// How a single-line dependency declaration should be rewritten once a
+/// feature has been removed from its `features = [...]` array.
+enum FeatureRemovalEdit {
+    /// Keep the line, with this new full text.
+    Replace(String),
+    /// Delete the line entirely.
+    Delete,
+    /// Leave the file completely unchanged — either `feature` wasn't found,
+    /// or the shape doesn't confidently invert.
+    Unchanged,
+}
+
+/// Shared implementation behind [`remove_autumn_web_feature`] and
+/// [`remove_autumn_web_dev_dependency_feature`]. See their docs for the two
+/// `collapse_to_bare` behaviours.
+fn remove_dep_feature_in_section(
+    existing: &str,
+    dep_name: &str,
+    feature: &str,
+    section: &str,
+    collapse_to_bare: bool,
+) -> String {
+    let feature_quoted = format!("\"{feature}\"");
+    let lines: Vec<&str> = existing.lines().collect();
+    let mut in_section = false;
+    for (i, &line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if is_section_header(trimmed, section) {
+            in_section = true;
+            continue;
+        }
+        if in_section && is_section_boundary(trimmed, section) {
+            in_section = false;
+            continue;
+        }
+        if !in_section {
+            continue;
+        }
+        let edit = parse_feature_removal(line, dep_name, &feature_quoted, collapse_to_bare);
+        return match edit {
+            FeatureRemovalEdit::Replace(new_line) => {
+                splice_single_line(&lines, i, &new_line, existing.ends_with('\n'))
+            }
+            FeatureRemovalEdit::Delete => remove_single_line(&lines, i, existing.ends_with('\n')),
+            FeatureRemovalEdit::Unchanged => continue,
+        };
+    }
+    existing.to_owned()
+}
+
+/// Parse `line` as `{indent}{dep_name} = { ...features = [...] ... }` and
+/// decide how to rewrite it once `feature_quoted` is removed from the
+/// features array. Returns [`FeatureRemovalEdit::Unchanged`] whenever the
+/// line doesn't match that exact single-line inline-table shape, or doesn't
+/// currently list the feature.
+fn parse_feature_removal(
+    line: &str,
+    dep_name: &str,
+    feature_quoted: &str,
+    collapse_to_bare: bool,
+) -> FeatureRemovalEdit {
+    let after_ws = line.trim_start();
+    let indent = &line[..line.len() - after_ws.len()];
+    let Some(rest) = after_ws.strip_prefix(dep_name) else {
+        return FeatureRemovalEdit::Unchanged;
+    };
+    let Some(rest) = rest.trim_start().strip_prefix('=') else {
+        return FeatureRemovalEdit::Unchanged;
+    };
+    let Some(rest) = rest.trim_start().strip_prefix('{') else {
+        return FeatureRemovalEdit::Unchanged;
+    };
+    let Some(body_end) = rest.rfind('}') else {
+        return FeatureRemovalEdit::Unchanged;
+    };
+    let body = rest[..body_end].trim();
+    let Some(features_kw) = body.find("features") else {
+        return FeatureRemovalEdit::Unchanged;
+    };
+    let before_features = body[..features_kw].trim().trim_end_matches(',').trim();
+    let after_kw = &body[features_kw + "features".len()..];
+    let Some(bracket_open) = after_kw.find('[') else {
+        return FeatureRemovalEdit::Unchanged;
+    };
+    let Some(bracket_close) = after_kw.find(']') else {
+        return FeatureRemovalEdit::Unchanged;
+    };
+    if bracket_close < bracket_open {
+        return FeatureRemovalEdit::Unchanged;
+    }
+    let list_body = &after_kw[bracket_open + 1..bracket_close];
+    let after_list = after_kw[bracket_close + 1..]
+        .trim()
+        .trim_start_matches(',')
+        .trim();
+    let items: Vec<&str> = list_body
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    if !items.contains(&feature_quoted) {
+        return FeatureRemovalEdit::Unchanged;
+    }
+    let remaining: Vec<&str> = items.into_iter().filter(|s| *s != feature_quoted).collect();
+
+    if !remaining.is_empty() {
+        let sep = if before_features.is_empty() { "" } else { ", " };
+        return FeatureRemovalEdit::Replace(format!(
+            "{indent}{dep_name} = {{ {before_features}{sep}features = [{}] }}",
+            remaining.join(", "),
+        ));
+    }
+
+    if collapse_to_bare {
+        if !after_list.is_empty() {
+            return FeatureRemovalEdit::Unchanged;
+        }
+        return before_features
+            .strip_prefix("version")
+            .map(str::trim_start)
+            .and_then(|r| r.strip_prefix('='))
+            .map_or(FeatureRemovalEdit::Unchanged, |v| {
+                FeatureRemovalEdit::Replace(format!("{indent}{dep_name} = {}", v.trim()))
+            });
+    }
+
+    FeatureRemovalEdit::Delete
+}
+
+/// Replace line `idx` with `new_line`, preserving the file's trailing-newline status.
+fn splice_single_line(
+    lines: &[&str],
+    idx: usize,
+    new_line: &str,
+    ends_with_newline: bool,
+) -> String {
+    let mut out = String::with_capacity(lines.len() * 24 + new_line.len());
+    for (i, &l) in lines.iter().enumerate() {
+        out.push_str(if i == idx { new_line } else { l });
+        out.push('\n');
+    }
+    if !ends_with_newline {
+        out.pop();
+    }
+    out
+}
+
+/// Remove line `idx` entirely, preserving the file's trailing-newline status.
+fn remove_single_line(lines: &[&str], idx: usize, ends_with_newline: bool) -> String {
+    let mut out = String::with_capacity(lines.len() * 24);
+    for (i, &l) in lines.iter().enumerate() {
+        if i == idx {
+            continue;
+        }
+        out.push_str(l);
+        out.push('\n');
+    }
+    if !ends_with_newline && out.ends_with('\n') {
+        out.pop();
+    }
+    out
 }
 
 /// Like [`ensure_autumn_web_feature`], but also reports whether the `autumn-web`
@@ -4345,6 +4908,76 @@ async fn main() {\n\
         assert!(updated.contains("jobs![foo::foo]"));
     }
 
+    // ── remove_job_entry / remove_jobs_registration_from_app (destroy, #1048) ──
+
+    #[test]
+    fn remove_job_entry_restores_original_when_it_was_the_only_one() {
+        let base = "pub mod send_welcome_email;\n";
+        let after_add = augment_registered_jobs(base, "send_welcome_email::send_welcome_email");
+        assert_ne!(after_add, base);
+        assert_eq!(
+            remove_job_entry(&after_add, "send_welcome_email::send_welcome_email"),
+            base
+        );
+    }
+
+    #[test]
+    fn remove_job_entry_keeps_other_entries() {
+        let base = "pub mod send_welcome_email;\n";
+        let with_one = augment_registered_jobs(base, "send_welcome_email::send_welcome_email");
+        let with_both = augment_registered_jobs(&with_one, "post_notification::post_notification");
+        let reverted = remove_job_entry(&with_both, "post_notification::post_notification");
+        assert!(reverted.contains("send_welcome_email::send_welcome_email"));
+        assert!(!reverted.contains("post_notification::post_notification"));
+    }
+
+    #[test]
+    fn remove_job_entry_is_idempotent_when_absent() {
+        let base = "pub mod send_welcome_email;\n";
+        assert_eq!(remove_job_entry(base, "nonexistent::nonexistent"), base);
+    }
+
+    #[test]
+    fn remove_jobs_registration_from_app_restores_original() {
+        let base = "fn main() {\n    App::new()\n        .run()\n}\n";
+        let after_add = add_jobs_registration_to_app(base);
+        assert_ne!(after_add, base);
+        assert_eq!(remove_jobs_registration_from_app(&after_add), base);
+    }
+
+    #[test]
+    fn remove_jobs_registration_from_app_is_idempotent_when_absent() {
+        let base = "fn main() {\n    App::new()\n        .run()\n}\n";
+        assert_eq!(remove_jobs_registration_from_app(base), base);
+    }
+
+    #[test]
+    fn remove_mail_preview_from_app_restores_original_when_only_entry() {
+        let base = "fn main() {\n    App::new()\n        .run()\n}\n";
+        let after_add = add_mail_preview_to_app(base, "WelcomeMailer");
+        assert_ne!(after_add, base);
+        assert_eq!(
+            remove_mail_preview_from_app(&after_add, "WelcomeMailer"),
+            base
+        );
+    }
+
+    #[test]
+    fn remove_mail_preview_from_app_keeps_other_entries() {
+        let base = "fn main() {\n    App::new()\n        .run()\n}\n";
+        let with_one = add_mail_preview_to_app(base, "WelcomeMailer");
+        let with_both = add_mail_preview_to_app(&with_one, "ReceiptMailer");
+        let reverted = remove_mail_preview_from_app(&with_both, "ReceiptMailer");
+        assert!(reverted.contains("WelcomeMailer"));
+        assert!(!reverted.contains("ReceiptMailer"));
+    }
+
+    #[test]
+    fn remove_mail_preview_from_app_is_idempotent_when_absent() {
+        let base = "fn main() {\n    App::new()\n        .run()\n}\n";
+        assert_eq!(remove_mail_preview_from_app(base, "WelcomeMailer"), base);
+    }
+
     // ── ensure_autumn_web_feature ─────────────────────────────────────────
 
     #[test]
@@ -6111,5 +6744,181 @@ pub struct Comment {
         let fs = fields(&["title:String"]);
         let schema = append_schema_table_with_id("", "posts", &fs, IdType::Uuid);
         assert!(schema.contains("id -> Uuid,"));
+    }
+
+    // ── `autumn destroy` inverse helpers (issue #1048) ─────────────────────
+    //
+    // Each inverse is tested for byte-identical round-tripping:
+    // `inverse(forward(base)) == base`.
+
+    #[test]
+    fn remove_mod_declaration_restores_empty_file() {
+        let after_add = add_mod_declaration("", "post");
+        assert_eq!(remove_mod_declaration(&after_add, "post"), "");
+    }
+
+    #[test]
+    fn remove_mod_declaration_restores_original_with_other_mods() {
+        let base = "pub mod user;\n";
+        let after_add = add_mod_declaration(base, "post");
+        assert_eq!(remove_mod_declaration(&after_add, "post"), base);
+    }
+
+    #[test]
+    fn remove_mod_declaration_is_idempotent_when_absent() {
+        let base = "pub mod user;\n";
+        assert_eq!(remove_mod_declaration(base, "post"), base);
+    }
+
+    #[test]
+    fn remove_mod_declaration_leaves_private_mod_untouched() {
+        // `add_mod_declaration` treats a bare `mod post;` as already-present and
+        // never writes `pub mod post;` in that case — so destroy must not
+        // remove a private `mod post;` it didn't add.
+        let base = "mod post;\n";
+        assert_eq!(remove_mod_declaration(base, "post"), base);
+    }
+
+    #[test]
+    fn remove_schema_table_restores_empty_file() {
+        let f = fields(&["title:String"]);
+        let after_add = append_schema_table("", "posts", &f);
+        assert_eq!(remove_schema_table(&after_add, "posts"), "");
+    }
+
+    #[test]
+    fn remove_schema_table_restores_original_with_other_tables() {
+        let f1 = fields(&["title:String"]);
+        let f2 = fields(&["name:String"]);
+        let base = append_schema_table("", "users", &f2);
+        let after_add = append_schema_table(&base, "posts", &f1);
+        assert_eq!(remove_schema_table(&after_add, "posts"), base);
+    }
+
+    #[test]
+    fn remove_schema_table_is_idempotent_when_absent() {
+        let f = fields(&["name:String"]);
+        let base = append_schema_table("", "users", &f);
+        assert_eq!(remove_schema_table(&base, "posts"), base);
+    }
+
+    #[test]
+    fn remove_routes_entries_restores_single_line_template_body() {
+        // Mirrors the `autumn new` template's `.routes(routes![index, hello, hello_name])`.
+        let base = "fn main() {\n    App::new()\n        .routes(routes![index, hello, hello_name])\n        .run()\n}\n";
+        let appended = vec![
+            "routes::posts::index".to_owned(),
+            "routes::posts::show".to_owned(),
+        ];
+        let after_add = ensure_routes_entries(base, &appended);
+        assert_ne!(
+            after_add, base,
+            "test setup: append must actually change the body"
+        );
+        let reverted = remove_routes_entries(&after_add, &appended);
+        assert_eq!(reverted, base);
+    }
+
+    #[test]
+    fn remove_routes_entries_is_idempotent_when_absent() {
+        let base =
+            "fn main() {\n    App::new()\n        .routes(routes![index])\n        .run()\n}\n";
+        let appended = vec!["routes::posts::index".to_owned()];
+        assert_eq!(remove_routes_entries(base, &appended), base);
+    }
+
+    #[test]
+    fn remove_routes_entries_preserves_other_resources_multiline() {
+        let base =
+            "fn main() {\n    App::new()\n        .routes(routes![index])\n        .run()\n}\n";
+        let comments_entries = vec![
+            "routes::comments::index".to_owned(),
+            "routes::comments::show".to_owned(),
+        ];
+        let after_comments = ensure_routes_entries(base, &comments_entries);
+        let posts_entries = vec![
+            "routes::posts::index".to_owned(),
+            "routes::posts::show".to_owned(),
+        ];
+        let after_posts = ensure_routes_entries(&after_comments, &posts_entries);
+        let reverted = remove_routes_entries(&after_posts, &posts_entries);
+        // Comments entries must survive destroying posts.
+        assert!(reverted.contains("routes::comments::index"));
+        assert!(reverted.contains("routes::comments::show"));
+        assert!(!reverted.contains("routes::posts::index"));
+        assert!(!reverted.contains("routes::posts::show"));
+    }
+
+    #[test]
+    fn remove_autumn_web_feature_collapses_to_bare_string() {
+        let base = "[dependencies]\nautumn-web = \"0.6.0\"\n";
+        let after_add = ensure_autumn_web_feature(base, "maud");
+        assert_ne!(after_add, base);
+        assert_eq!(remove_autumn_web_feature(&after_add, "maud"), base);
+    }
+
+    #[test]
+    fn remove_autumn_web_feature_keeps_other_features() {
+        let base = "[dependencies]\nautumn-web = \"0.6.0\"\n";
+        let with_maud = ensure_autumn_web_feature(base, "maud");
+        let with_both = ensure_autumn_web_feature(&with_maud, "htmx");
+        let reverted = remove_autumn_web_feature(&with_both, "htmx");
+        assert_eq!(reverted, with_maud);
+    }
+
+    #[test]
+    fn remove_autumn_web_feature_is_idempotent_when_absent() {
+        let base = "[dependencies]\nautumn-web = \"0.6.0\"\n";
+        assert_eq!(remove_autumn_web_feature(base, "maud"), base);
+    }
+
+    #[test]
+    fn remove_autumn_web_dev_dependency_feature_deletes_freshly_inserted_line() {
+        let base =
+            "[dev-dependencies]\ntokio = { version = \"1\", features = [\"rt\", \"macros\"] }\n";
+        let after_add = ensure_dev_dependency_test_support(base, "0.6.0");
+        assert_ne!(after_add, base);
+        assert_eq!(
+            remove_autumn_web_dev_dependency_feature(&after_add, "test-support"),
+            base
+        );
+    }
+
+    #[test]
+    fn remove_autumn_web_dev_dependency_feature_is_idempotent_when_absent() {
+        let base = "[dev-dependencies]\ntokio = { version = \"1\" }\n";
+        assert_eq!(
+            remove_autumn_web_dev_dependency_feature(base, "test-support"),
+            base
+        );
+    }
+
+    #[test]
+    fn remove_main_mod_declarations_restores_original_with_no_leading_attributes() {
+        // Mirrors `autumn new`'s template main.rs, which has no leading
+        // `//!`/`#![` lines at all.
+        let base = "use autumn_web::prelude::*;\n\nfn main() {}\n";
+        let after_add = ensure_mods(base, &["models", "repositories", "routes", "schema"]);
+        assert_ne!(after_add, base);
+        let reverted = remove_main_mod_declarations(
+            &after_add,
+            &["models", "repositories", "routes", "schema"],
+        );
+        assert_eq!(reverted, base);
+    }
+
+    #[test]
+    fn remove_main_mod_declarations_leaves_other_shared_mods_when_only_some_missing() {
+        let base = "fn main() {}\n";
+        let after_add = ensure_mods(base, &["models", "jobs"]);
+        let reverted = remove_main_mod_declarations(&after_add, &["jobs"]);
+        assert!(reverted.contains("mod models;"));
+        assert!(!reverted.contains("mod jobs;"));
+    }
+
+    #[test]
+    fn remove_main_mod_declarations_is_idempotent_when_absent() {
+        let base = "fn main() {}\n";
+        assert_eq!(remove_main_mod_declarations(base, &["models"]), base);
     }
 }

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -42,22 +42,11 @@ pub fn add_mod_declaration(existing: &str, name: &str) -> String {
 #[must_use]
 pub fn remove_mod_declaration(existing: &str, name: &str) -> String {
     let line = format!("pub mod {name};");
-    let Some(idx) = existing.lines().position(|l| l.trim() == line) else {
+    let lines: Vec<&str> = existing.lines().collect();
+    let Some(idx) = lines.iter().position(|l| l.trim() == line) else {
         return existing.to_owned();
     };
-    let lines: Vec<&str> = existing.lines().collect();
-    let mut out = String::with_capacity(existing.len());
-    for (i, l) in lines.iter().enumerate() {
-        if i == idx {
-            continue;
-        }
-        out.push_str(l);
-        out.push('\n');
-    }
-    if !existing.ends_with('\n') && out.ends_with('\n') {
-        out.pop();
-    }
-    out
+    remove_single_line(&lines, idx, existing.ends_with('\n'))
 }
 
 /// Build a new `diesel::table!` block for the given table, emitting the `id`
@@ -1070,9 +1059,22 @@ pub fn remove_routes_entries(existing: &str, entries: &[String]) -> String {
     // entry begins. Strip the separator (`,`/whitespace/newline) forward
     // added right after the original content to see whether that ORIGINAL
     // content itself spanned multiple lines.
+    //
+    // Locate that point via each entry's actual token span (from the same
+    // comma/newline split `present_entries` was built from), not a raw
+    // substring search — `body.find(e)` would also match `e` occurring
+    // inside a *different*, kept entry that has it as a textual prefix
+    // (e.g. removing `routes::posts::index` while `routes::posts::index_all`
+    // is kept), misdetecting where the original layout ends.
+    let spans = entry_spans(body);
     let first_removed_at = entries
         .iter()
-        .filter_map(|e| body.find(e.as_str()))
+        .filter_map(|e| {
+            spans
+                .iter()
+                .find(|(_, _, text)| text == e)
+                .map(|(start, ..)| *start)
+        })
         .min()
         .unwrap_or(body.len());
     let original_segment = &body[..first_removed_at];
@@ -1100,6 +1102,29 @@ pub fn remove_routes_entries(existing: &str, entries: &[String]) -> String {
     out.push_str(&new_body);
     out.push_str(&existing[body_end..]);
     out
+}
+
+/// Parse `body` into `(start, end, trimmed_text)` byte spans of each
+/// comma/newline-delimited entry, so callers can locate an entry's actual
+/// token occurrence rather than a raw substring search (which can match
+/// inside a different, unrelated entry that has it as a textual prefix).
+fn entry_spans(body: &str) -> Vec<(usize, usize, &str)> {
+    let mut spans = Vec::new();
+    let mut offset = 0usize;
+    for piece in body.split_inclusive([',', '\n']) {
+        let piece_start = offset;
+        offset += piece.len();
+        let trimmed = piece.trim_matches([',', '\n', ' ', '\t', '\r']);
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Some(inner_offset) = piece.find(trimmed) else {
+            continue;
+        };
+        let start = piece_start + inner_offset;
+        spans.push((start, start + trimmed.len(), trimmed));
+    }
+    spans
 }
 
 fn augment_routes_body(body: &str, entries: &[String]) -> String {
@@ -1266,31 +1291,13 @@ fn insert_mail_previews_call(existing: &str, mailer_type: &str) -> String {
 #[must_use]
 pub fn remove_mail_preview_from_app(existing: &str, mailer_type: &str) -> String {
     const PREVIEW_MACRO: &str = "mail_previews![";
-    let Some(macro_start) = existing.find(PREVIEW_MACRO) else {
+    let Some((spliced, now_empty)) =
+        remove_entry_from_bracketed_list(existing, PREVIEW_MACRO, mailer_type)
+    else {
         return existing.to_owned();
     };
-    let body_start = macro_start + PREVIEW_MACRO.len();
-    let rest = &existing[body_start..];
-    let Some(end_offset) = rest.find(']') else {
-        return existing.to_owned();
-    };
-    let body = &rest[..end_offset];
-    let items: Vec<&str> = body
-        .split(',')
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .collect();
-    if !items.contains(&mailer_type) {
-        return existing.to_owned();
-    }
-    let remaining: Vec<&str> = items.into_iter().filter(|s| *s != mailer_type).collect();
-    if !remaining.is_empty() {
-        let new_body = remaining.join(", ");
-        let mut out = String::with_capacity(existing.len());
-        out.push_str(&existing[..body_start]);
-        out.push_str(&new_body);
-        out.push_str(&existing[body_start + end_offset..]);
-        return out;
+    if !now_empty {
+        return spliced;
     }
     // Only entry -- remove the whole freshly-inserted line.
     let lines: Vec<&str> = existing.lines().collect();
@@ -1300,18 +1307,48 @@ pub fn remove_mail_preview_from_app(existing: &str, mailer_type: &str) -> String
     else {
         return existing.to_owned();
     };
+    remove_single_line(&lines, line_idx, existing.ends_with('\n'))
+}
+
+/// Shared bracket-list-entry removal behind [`remove_job_entry`] and
+/// [`remove_mail_preview_from_app`]: locate `macro_literal` (e.g.
+/// `"jobs!["`), remove `entry` from its comma-separated body, and rejoin.
+///
+/// Returns `None` if the macro isn't present or `entry` isn't currently
+/// listed (destroy never guesses at a partial match). Otherwise returns
+/// `Some((new_content, list_is_now_empty))` — callers that need to collapse
+/// or remove a now-meaningless surrounding call/function when the list
+/// empties out (which one text becomes home to.. differs — `jobs![]`
+/// removes a whole `fn`, `mail_previews![]` removes a call line) check the
+/// `bool` and discard `new_content` in that case, matching
+/// [`remove_dep_feature_in_section`]'s `collapse_to_bare` pattern for the
+/// analogous Cargo-feature-list case.
+fn remove_entry_from_bracketed_list(
+    existing: &str,
+    macro_literal: &str,
+    entry: &str,
+) -> Option<(String, bool)> {
+    let macro_start = existing.find(macro_literal)?;
+    let body_start = macro_start + macro_literal.len();
+    let rest = &existing[body_start..];
+    let end_offset = rest.find(']')?;
+    let body = &rest[..end_offset];
+    let items: Vec<&str> = body
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    if !items.contains(&entry) {
+        return None;
+    }
+    let remaining: Vec<&str> = items.into_iter().filter(|s| s != &entry).collect();
+    let now_empty = remaining.is_empty();
+    let new_body = remaining.join(", ");
     let mut out = String::with_capacity(existing.len());
-    for (i, l) in lines.iter().enumerate() {
-        if i == line_idx {
-            continue;
-        }
-        out.push_str(l);
-        out.push('\n');
-    }
-    if !existing.ends_with('\n') && out.ends_with('\n') {
-        out.pop();
-    }
-    out
+    out.push_str(&existing[..body_start]);
+    out.push_str(&new_body);
+    out.push_str(&existing[body_start + end_offset..]);
+    Some((out, now_empty))
 }
 
 // ── Job registration helpers ──────────────────────────────────────────────
@@ -1378,33 +1415,15 @@ fn splice_jobs_list(existing: &str, body_start: usize, entry: &str) -> String {
 #[must_use]
 pub fn remove_job_entry(existing: &str, entry: &str) -> String {
     const JOBS_MACRO: &str = "jobs![";
-    let Some(macro_start) = existing.find(JOBS_MACRO) else {
+    let Some((spliced, now_empty)) = remove_entry_from_bracketed_list(existing, JOBS_MACRO, entry)
+    else {
         return existing.to_owned();
     };
-    let body_start = macro_start + JOBS_MACRO.len();
-    let rest = &existing[body_start..];
-    let Some(end_offset) = rest.find(']') else {
-        return existing.to_owned();
-    };
-    let body = &rest[..end_offset];
-    let items: Vec<&str> = body
-        .split(',')
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .collect();
-    if !items.contains(&entry) {
-        return existing.to_owned();
+    if now_empty {
+        remove_registered_jobs_fn(existing)
+    } else {
+        spliced
     }
-    let remaining: Vec<&str> = items.into_iter().filter(|s| *s != entry).collect();
-    if remaining.is_empty() {
-        return remove_registered_jobs_fn(existing);
-    }
-    let new_body = remaining.join(", ");
-    let mut out = String::with_capacity(existing.len());
-    out.push_str(&existing[..body_start]);
-    out.push_str(&new_body);
-    out.push_str(&existing[body_start + end_offset..]);
-    out
 }
 
 /// Remove the whole `registered_jobs()` function [`augment_registered_jobs`]
@@ -1456,18 +1475,7 @@ pub fn remove_jobs_registration_from_app(existing: &str) -> String {
     let Some(idx) = lines.iter().position(|l| l.trim() == JOBS_CALL) else {
         return existing.to_owned();
     };
-    let mut out = String::with_capacity(existing.len());
-    for (i, l) in lines.iter().enumerate() {
-        if i == idx {
-            continue;
-        }
-        out.push_str(l);
-        out.push('\n');
-    }
-    if !existing.ends_with('\n') && out.ends_with('\n') {
-        out.pop();
-    }
-    out
+    remove_single_line(&lines, idx, existing.ends_with('\n'))
 }
 
 // ── Cargo.toml: feature injection ────────────────────────────────────────
@@ -1884,7 +1892,7 @@ fn parse_feature_removal(
 }
 
 /// Replace line `idx` with `new_line`, preserving the file's trailing-newline status.
-fn splice_single_line(
+pub(super) fn splice_single_line(
     lines: &[&str],
     idx: usize,
     new_line: &str,
@@ -1902,7 +1910,7 @@ fn splice_single_line(
 }
 
 /// Remove line `idx` entirely, preserving the file's trailing-newline status.
-fn remove_single_line(lines: &[&str], idx: usize, ends_with_newline: bool) -> String {
+pub(super) fn remove_single_line(lines: &[&str], idx: usize, ends_with_newline: bool) -> String {
     let mut out = String::with_capacity(lines.len() * 24);
     for (i, &l) in lines.iter().enumerate() {
         if i == idx {
@@ -6847,6 +6855,23 @@ pub struct Comment {
         assert!(reverted.contains("routes::comments::show"));
         assert!(!reverted.contains("routes::posts::index"));
         assert!(!reverted.contains("routes::posts::show"));
+    }
+
+    #[test]
+    fn remove_routes_entries_not_confused_by_kept_entry_sharing_a_prefix() {
+        // `routes::posts::index` is a textual PREFIX of the kept
+        // `routes::posts::index_all` entry that appears earlier in the body.
+        // A raw substring search for the removed entry would match inside
+        // the kept one and misdetect the original single-line layout as
+        // multi-line.
+        let base = "fn main() {\n    App::new()\n        .routes(routes![index, routes::posts::index_all, routes::posts::index])\n        .run()\n}\n";
+        let removed = vec!["routes::posts::index".to_owned()];
+        let reverted = remove_routes_entries(base, &removed);
+        assert_eq!(
+            reverted,
+            "fn main() {\n    App::new()\n        .routes(routes![index, routes::posts::index_all])\n        .run()\n}\n",
+            "must restore the original single-line layout byte-identically, not collapse/reformat it"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -905,7 +905,8 @@ fn has_mod_declaration(existing: &str, name: &str) -> bool {
 #[must_use]
 pub fn remove_main_mod_declarations(existing: &str, names: &[&str]) -> String {
     let lines: Vec<&str> = existing.lines().collect();
-    let matches_any = |line: &str| names.iter().any(|n| line.trim() == format!("mod {n};"));
+    let patterns: Vec<String> = names.iter().map(|n| format!("mod {n};")).collect();
+    let matches_any = |line: &str| patterns.iter().any(|p| line.trim() == p);
     if !lines.iter().any(|l| matches_any(l)) {
         return existing.to_owned();
     }
@@ -1869,8 +1870,9 @@ fn parse_feature_removal(
 
     if !remaining.is_empty() {
         let sep = if before_features.is_empty() { "" } else { ", " };
+        let after_sep = if after_list.is_empty() { "" } else { ", " };
         return FeatureRemovalEdit::Replace(format!(
-            "{indent}{dep_name} = {{ {before_features}{sep}features = [{}] }}",
+            "{indent}{dep_name} = {{ {before_features}{sep}features = [{}]{after_sep}{after_list} }}",
             remaining.join(", "),
         ));
     }
@@ -6889,6 +6891,21 @@ pub struct Comment {
         let with_both = ensure_autumn_web_feature(&with_maud, "htmx");
         let reverted = remove_autumn_web_feature(&with_both, "htmx");
         assert_eq!(reverted, with_maud);
+    }
+
+    #[test]
+    fn remove_autumn_web_feature_preserves_keys_after_the_features_array() {
+        // A hand-edited (or otherwise pre-existing) dependency line can carry
+        // keys after `features = [...]`, e.g. `default-features = false`.
+        // Removing one feature while others remain must not silently drop
+        // those trailing keys.
+        let base = "[dependencies]\nautumn-web = { version = \"0.6.0\", features = [\"maud\", \"htmx\"], default-features = false }\n";
+        let reverted = remove_autumn_web_feature(base, "htmx");
+        assert_eq!(
+            reverted,
+            "[dependencies]\nautumn-web = { version = \"0.6.0\", features = [\"maud\"], default-features = false }\n",
+            "trailing keys after the features array must survive: {reverted}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -1740,17 +1740,21 @@ pub fn ensure_autumn_web_feature(existing: &str, feature: &str) -> String {
 /// Inverse of [`ensure_autumn_web_feature`] (`autumn destroy`, issue #1048),
 /// scoped to `[dependencies]`.
 ///
-/// Removes `feature` from `autumn-web`'s single-line inline-table
-/// `features = [...]` list — the shape [`ensure_autumn_web_feature`] produces
-/// when it upgrades a bare-string dependency (`autumn-web = "x.y.z"` →
-/// `autumn-web = { version = "x.y.z", features = ["maud"] }`). If removing
-/// `feature` empties the list and `version` is the only other key, the whole
-/// entry collapses back to that bare string, restoring the pre-generate
-/// declaration byte-for-byte.
+/// Removes `feature` from `autumn-web`'s `features = [...]` list, in
+/// whichever of the four shapes [`ensure_autumn_web_feature`] can add it to:
+/// single-line inline table, dotted key (`autumn-web.features = [...]`),
+/// multiline inline table, or a `[dependencies.autumn-web]` subtable. Only
+/// the single-line inline-table case can collapse: when removing `feature`
+/// empties the list and `version` is the only other key, the whole entry
+/// collapses back to a bare string, restoring the pre-generate declaration
+/// byte-for-byte — the other three shapes only ever lose the one list entry
+/// (or the now-empty `features` line/key), since their surrounding
+/// structure may predate `generate` entirely and destroy never restructures
+/// content it didn't itself add.
 ///
-/// A no-op for any other declaration shape (dotted keys, multiline
-/// subtables, an entry `feature` doesn't currently list) — destroy only
-/// reverses what `generate` itself would have written.
+/// A no-op for a renamed/aliased `autumn-web` dependency, or an entry
+/// `feature` doesn't currently list — destroy only reverses what `generate`
+/// itself would have written.
 #[must_use]
 pub fn remove_autumn_web_feature(existing: &str, feature: &str) -> String {
     remove_dep_feature_in_section(existing, "autumn-web", feature, "dependencies", true)
@@ -1787,6 +1791,18 @@ enum FeatureRemovalEdit {
 /// Shared implementation behind [`remove_autumn_web_feature`] and
 /// [`remove_autumn_web_dev_dependency_feature`]. See their docs for the two
 /// `collapse_to_bare` behaviours.
+///
+/// Beyond the single-line inline-table shape [`parse_feature_removal`]
+/// handles, this also inverts the dotted-key (`<dep_name>.features =
+/// [...]`), multiline inline-table, and `[<section>.<dep_name>]` subtable
+/// forms [`ensure_autumn_web_feature_status_in_section`] can add a feature
+/// to (issue #1048 PR review) — `generate mailer`/`channel --ws` otherwise
+/// left the feature behind forever in a hand-maintained `Cargo.toml` using
+/// one of those shapes. Each of those three only ever edits the `features`
+/// line itself, never collapsing or restructuring the surrounding
+/// declaration — unlike the single-line case, that structure may predate
+/// `generate` entirely, so only what `generate` itself would have inserted
+/// (an entry in the list) is reverted.
 fn remove_dep_feature_in_section(
     existing: &str,
     dep_name: &str,
@@ -1796,6 +1812,7 @@ fn remove_dep_feature_in_section(
 ) -> String {
     let feature_quoted = format!("\"{feature}\"");
     let lines: Vec<&str> = existing.lines().collect();
+    let dotted_features_key = format!("{dep_name}.features");
     let mut in_section = false;
     for (i, &line) in lines.iter().enumerate() {
         let trimmed = line.trim();
@@ -1810,16 +1827,154 @@ fn remove_dep_feature_in_section(
         if !in_section {
             continue;
         }
-        let edit = parse_feature_removal(line, dep_name, &feature_quoted, collapse_to_bare);
-        return match edit {
-            FeatureRemovalEdit::Replace(new_line) => {
+
+        if line.trim_start().starts_with(&dotted_features_key)
+            && let Some((new_line, now_empty)) =
+                remove_feature_from_features_line(line, &feature_quoted)
+        {
+            return if now_empty {
+                remove_single_line(&lines, i, existing.ends_with('\n'))
+            } else {
                 splice_single_line(&lines, i, &new_line, existing.ends_with('\n'))
+            };
+        }
+
+        let edit = parse_feature_removal(line, dep_name, &feature_quoted, collapse_to_bare);
+        match edit {
+            FeatureRemovalEdit::Replace(new_line) => {
+                return splice_single_line(&lines, i, &new_line, existing.ends_with('\n'));
             }
-            FeatureRemovalEdit::Delete => remove_single_line(&lines, i, existing.ends_with('\n')),
-            FeatureRemovalEdit::Unchanged => continue,
-        };
+            FeatureRemovalEdit::Delete => {
+                return remove_single_line(&lines, i, existing.ends_with('\n'));
+            }
+            FeatureRemovalEdit::Unchanged => {
+                if let Some(result) = remove_feature_from_open_multiline_inline_table(
+                    &lines,
+                    i,
+                    existing,
+                    dep_name,
+                    &feature_quoted,
+                ) {
+                    return result;
+                }
+            }
+        }
     }
+
+    // Pass 2: multiline subtable form `[<section>.<dep_name>]`.
+    let subtable_key = format!("[{section}.{dep_name}]");
+    for (i, &line) in lines.iter().enumerate() {
+        let key_part = line.trim().split('#').next().unwrap_or("").trim();
+        if key_part != subtable_key {
+            continue;
+        }
+        let section_start = i + 1;
+        let section_end = lines[section_start..]
+            .iter()
+            .position(|l| {
+                let t = l.trim();
+                t.starts_with('[') && !t.is_empty()
+            })
+            .map_or(lines.len(), |p| section_start + p);
+        if let Some(result) = remove_feature_from_deps_section(
+            &lines,
+            section_start,
+            section_end,
+            existing,
+            &feature_quoted,
+        ) {
+            return result;
+        }
+    }
+
     existing.to_owned()
+}
+
+/// Remove `feature_quoted` from a standalone `key = [...]` TOML line
+/// (inverse of [`rewrite_features_line`]). `None` if the line has no
+/// bracketed array, or it doesn't list `feature_quoted`. Otherwise returns
+/// the rewritten line and whether the array is now empty.
+fn remove_feature_from_features_line(line: &str, feature_quoted: &str) -> Option<(String, bool)> {
+    let open = line.find('[')?;
+    let close_rel = line[open..].find(']')?;
+    let abs_end = open + close_rel;
+    let body = &line[open + 1..abs_end];
+    let items: Vec<&str> = body
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    if !items.contains(&feature_quoted) {
+        return None;
+    }
+    let remaining: Vec<&str> = items
+        .into_iter()
+        .filter(|it| *it != feature_quoted)
+        .collect();
+    let now_empty = remaining.is_empty();
+    let new_line = format!(
+        "{}{}{}",
+        &line[..=open],
+        remaining.join(", "),
+        &line[abs_end..]
+    );
+    Some((new_line, now_empty))
+}
+
+/// If `lines[open_idx]` opens a multiline inline-table declaration for
+/// `dep_name` (`<dep_name> = {` with no closing `}` on the same line),
+/// removes `feature_quoted` from its `features = [...]` entry — inverse of
+/// [`add_feature_to_multiline_inline_table`]. Only edits the `features`
+/// line; never collapses the surrounding table, since it may predate
+/// `generate` entirely. `None` if `lines[open_idx]` isn't that opening
+/// shape, no closing `}` is found, no `features` line exists inside the
+/// block, or that line doesn't list `feature_quoted`.
+fn remove_feature_from_open_multiline_inline_table(
+    lines: &[&str],
+    open_idx: usize,
+    existing: &str,
+    dep_name: &str,
+    feature_quoted: &str,
+) -> Option<String> {
+    let after_ws = lines[open_idx].trim_start();
+    let rest = after_ws.strip_prefix(dep_name)?;
+    let rest = rest.trim_start().strip_prefix('=')?;
+    let rest = rest.trim_start().strip_prefix('{')?;
+    if rest.contains('}') {
+        return None; // closes on the same line -- not the multiline form.
+    }
+    let close_idx = lines[open_idx + 1..]
+        .iter()
+        .position(|l| l.trim_start().starts_with('}'))
+        .map(|p| open_idx + 1 + p)?;
+    remove_feature_from_deps_section(lines, open_idx + 1, close_idx, existing, feature_quoted)
+}
+
+/// Remove `feature_quoted` from a `features = [...]` line found inside
+/// `lines[section_start..section_end)` (a multiline inline-table body or a
+/// `[<section>.<dep_name>]` subtable body). Only that one line is ever
+/// changed — every other key in the span is left untouched. `None` if no
+/// `features` line is found there, or it doesn't list `feature_quoted`.
+fn remove_feature_from_deps_section(
+    lines: &[&str],
+    section_start: usize,
+    section_end: usize,
+    existing: &str,
+    feature_quoted: &str,
+) -> Option<String> {
+    for (j, &sect_line) in lines[section_start..section_end].iter().enumerate() {
+        if !sect_line.trim_start().starts_with("features") {
+            continue;
+        }
+        let idx = section_start + j;
+        let (new_line, now_empty) = remove_feature_from_features_line(sect_line, feature_quoted)?;
+        return Some(if now_empty {
+            remove_single_line(lines, idx, existing.ends_with('\n'))
+        } else {
+            splice_single_line(lines, idx, &new_line, existing.ends_with('\n'))
+        });
+    }
+    None
 }
 
 /// Parse `line` as `{indent}{dep_name} = { ...features = [...] ... }` and
@@ -6940,6 +7095,66 @@ pub struct Comment {
     fn remove_autumn_web_feature_is_idempotent_when_absent() {
         let base = "[dependencies]\nautumn-web = \"0.6.0\"\n";
         assert_eq!(remove_autumn_web_feature(base, "maud"), base);
+    }
+
+    #[test]
+    fn remove_autumn_web_feature_reverts_dotted_key_form() {
+        // issue #1048 PR review: `ensure_autumn_web_feature` can add a
+        // feature to a pre-existing dotted-key declaration; destroy must be
+        // able to remove it again, not leave it behind forever.
+        let base =
+            "[dependencies]\nautumn-web.version = \"0.6.0\"\nautumn-web.features = [\"db\"]\n";
+        let with_mail = ensure_autumn_web_feature(base, "mail");
+        assert_ne!(with_mail, base);
+        assert_eq!(remove_autumn_web_feature(&with_mail, "mail"), base);
+    }
+
+    #[test]
+    fn remove_autumn_web_feature_deletes_dotted_features_key_when_emptied() {
+        let base =
+            "[dependencies]\nautumn-web.version = \"0.6.0\"\nautumn-web.features = [\"mail\"]\n";
+        let reverted = remove_autumn_web_feature(base, "mail");
+        assert_eq!(
+            reverted, "[dependencies]\nautumn-web.version = \"0.6.0\"\n",
+            "an emptied dotted features key must be removed outright: {reverted}"
+        );
+    }
+
+    #[test]
+    fn remove_autumn_web_feature_reverts_multiline_inline_table_form() {
+        let base = "[dependencies]\nautumn-web = {\n    version = \"0.6.0\",\n    features = [\"db\"],\n}\n";
+        let with_mail = ensure_autumn_web_feature(base, "mail");
+        assert_ne!(with_mail, base);
+        assert!(with_mail.contains("\"mail\""));
+        let reverted = remove_autumn_web_feature(&with_mail, "mail");
+        assert_eq!(
+            reverted, base,
+            "must remove only the added feature from the features line, restoring the \
+             original multiline table: {reverted}"
+        );
+    }
+
+    #[test]
+    fn remove_autumn_web_feature_reverts_subtable_form() {
+        // issue #1048 PR review: `[dependencies.autumn-web]` with a
+        // separate `features` key is a shape `ensure_autumn_web_feature`
+        // supports adding to, but the old remover only handled single-line
+        // inline tables.
+        let base = "[dependencies.autumn-web]\nversion = \"0.6.0\"\nfeatures = [\"db\"]\n\n[dev-dependencies]\n";
+        let with_mail = ensure_autumn_web_feature(base, "mail");
+        assert_ne!(with_mail, base);
+        assert_eq!(remove_autumn_web_feature(&with_mail, "mail"), base);
+    }
+
+    #[test]
+    fn remove_autumn_web_feature_deletes_subtable_features_key_when_emptied() {
+        let base = "[dependencies.autumn-web]\nversion = \"0.6.0\"\nfeatures = [\"mail\"]\n";
+        let reverted = remove_autumn_web_feature(base, "mail");
+        assert_eq!(
+            reverted, "[dependencies.autumn-web]\nversion = \"0.6.0\"\n",
+            "an emptied subtable features key must be removed outright, leaving \
+             `version` and the header untouched: {reverted}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -1866,10 +1866,10 @@ fn resolve_autumn_web_dep_key(existing: &str, section: &str) -> &'static str {
         let Some((key, val)) = after_ws.split_once('=') else {
             continue;
         };
-        let alias = key
-            .trim()
+        let key_trimmed = key.trim();
+        let alias = key_trimmed
             .split_once('.')
-            .map_or(key.trim(), |(base, _)| base);
+            .map_or(key_trimmed, |(base, _)| base);
         if alias.replace('-', "_") == "autumn_web" && declares_package(val, "autumn-web") {
             return "autumn_web";
         }

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -1040,8 +1040,13 @@ pub fn remove_routes_entries_with_prefix(existing: &str, prefix: &str) -> String
 /// this generate call.
 ///
 /// A no-op (returns `existing` unchanged) if there's no `routes![...]`, or if
-/// any of `entries` is no longer present (already destroyed, or the routes
-/// list was hand-edited) — destroy never guesses at a partial match.
+/// NONE of `entries` is present any more (already destroyed). Removes
+/// whichever of `entries` ARE currently present when only some are — e.g.
+/// the user hand-removed one of this resource's routes before running
+/// `destroy` — rather than abandoning the whole cleanup and leaving the
+/// rest dangling (issue #1048 PR review): a route this resource's own file
+/// deletion is about to orphan must not survive just because a sibling
+/// entry from the same call was already gone.
 #[must_use]
 pub fn remove_routes_entries(existing: &str, entries: &[String]) -> String {
     if entries.is_empty() {
@@ -1056,7 +1061,7 @@ pub fn remove_routes_entries(existing: &str, entries: &[String]) -> String {
         .map(|s| s.trim().to_owned())
         .filter(|s| !s.is_empty())
         .collect();
-    if !entries.iter().all(|e| present_entries.contains(e)) {
+    if !entries.iter().any(|e| present_entries.contains(e)) {
         return existing.to_owned();
     }
     let kept: Vec<&String> = present_entries
@@ -7109,6 +7114,29 @@ pub struct Comment {
             "fn main() {\n    App::new()\n        .routes(routes![index])\n        .run()\n}\n";
         let appended = vec!["routes::posts::index".to_owned()];
         assert_eq!(remove_routes_entries(base, &appended), base);
+    }
+
+    #[test]
+    fn remove_routes_entries_removes_present_entries_even_when_one_is_already_gone() {
+        // issue #1048 PR review: a user may have hand-removed one of a
+        // resource's own route entries before running destroy. The rest of
+        // that resource's routes are still present and about to be
+        // orphaned (the underlying handler file is deleted regardless) —
+        // abandoning the whole cleanup because ONE entry is already absent
+        // would leave `main.rs` referencing a missing function/module.
+        let appended = vec![
+            "routes::posts::index".to_owned(),
+            "routes::posts::show".to_owned(),
+        ];
+        // Simulate the user having already removed `show` by hand.
+        let hand_edited = "fn main() {\n    App::new()\n        .routes(routes![index, routes::posts::index])\n        .run()\n}\n";
+        let reverted = remove_routes_entries(hand_edited, &appended);
+        assert_eq!(
+            reverted,
+            "fn main() {\n    App::new()\n        .routes(routes![index])\n        .run()\n}\n",
+            "the still-present `index` entry must be removed even though `show` was \
+             already gone: {reverted}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/system_test.rs
+++ b/autumn-cli/src/generate/system_test.rs
@@ -85,8 +85,16 @@ pub fn plan_system_test(project_root: &Path, name: &str) -> Result<Plan, Generat
 
     let patched = patch_cargo_toml(&existing, &snake_name);
     if patched != existing {
-        plan.modify(cargo_path, patched);
+        plan.modify(cargo_path.clone(), patched);
     }
+    // Pushed unconditionally — see `plan_cargo_deps`'s matching comment in
+    // model.rs: destroy recomputes this plan against the already-generated
+    // Cargo.toml, where the `[[test]]` entry is by definition already
+    // present.
+    plan.push_revert(crate::generate::emit::Revert::SystemTestCargoPatch {
+        path: cargo_path,
+        snake_name,
+    });
 
     Ok(plan)
 }
@@ -365,6 +373,78 @@ pub(super) fn patch_cargo_toml(existing: &str, snake_name: &str) -> String {
     out
 }
 
+/// Inverse of [`patch_cargo_toml`] (`autumn destroy`, issue #1048).
+///
+/// Removes this test's own `[[test]]` entry — the exact block
+/// `patch_cargo_toml` appends for `snake_name` — then removes the shared
+/// `system-tests` feature declaration too, but only if no OTHER
+/// `tests/system/*.rs` entry remains, mirroring the "shared while still
+/// needed" rule `emit::SHARED_MAIN_MODULE_NAMES` applies to `src/main.rs`
+/// module declarations (multiple system-test resources, and `generate pwa`'s
+/// own smoke test, all share this one feature declaration).
+///
+/// A no-op if this test's `[[test]]` entry isn't present.
+pub(super) fn remove_cargo_toml_patch(existing: &str, snake_name: &str) -> String {
+    let test_block =
+        format!("\n[[test]]\nname = \"{snake_name}\"\npath = \"tests/system/{snake_name}.rs\"\n");
+    let Some(pos) = existing.find(&test_block) else {
+        return existing.to_owned();
+    };
+    let mut without_test_entry = String::with_capacity(existing.len() - test_block.len());
+    without_test_entry.push_str(&existing[..pos]);
+    without_test_entry.push_str(&existing[pos + test_block.len()..]);
+
+    if without_test_entry.contains("tests/system/") {
+        return without_test_entry;
+    }
+
+    let dep_key = resolve_autumn_web_dep_key(&without_test_entry);
+    let feature_line = format!("system-tests = [\"{dep_key}/system-tests\"]\n");
+    let Some(fpos) = without_test_entry.find(&feature_line) else {
+        return without_test_entry;
+    };
+    let mut without_feature = String::with_capacity(without_test_entry.len() - feature_line.len());
+    without_feature.push_str(&without_test_entry[..fpos]);
+    without_feature.push_str(&without_test_entry[fpos + feature_line.len()..]);
+    strip_empty_features_header(&without_feature)
+}
+
+/// If removing the `system-tests` feature line left the `[features]` table
+/// with no other keys, remove the header (plus one preceding blank
+/// separator line) too — mirroring `patch_cargo_toml`'s "create a brand new
+/// `[features]` section from scratch" branch, so a project that never had
+/// one before `generate system-test`/`generate pwa` ends up with none after
+/// `destroy`, byte-identical to its pre-generate state. A pre-existing
+/// `[features]` table with other keys is left untouched.
+fn strip_empty_features_header(existing: &str) -> String {
+    let lines: Vec<&str> = existing.lines().collect();
+    let Some(header_idx) = lines.iter().position(|l| is_features_header(l.trim())) else {
+        return existing.to_owned();
+    };
+    let section_end = lines[header_idx + 1..]
+        .iter()
+        .position(|l| l.trim_start().starts_with('['))
+        .map_or(lines.len(), |off| header_idx + 1 + off);
+    if lines[header_idx + 1..section_end]
+        .iter()
+        .any(|l| !l.trim().is_empty())
+    {
+        return existing.to_owned();
+    }
+    let mut start = header_idx;
+    if start > 0 && lines[start - 1].trim().is_empty() {
+        start -= 1;
+    }
+    let mut new_lines: Vec<&str> = Vec::with_capacity(lines.len());
+    new_lines.extend_from_slice(&lines[..start]);
+    new_lines.extend_from_slice(&lines[section_end..]);
+    let mut out = new_lines.join("\n");
+    if existing.ends_with('\n') && !new_lines.is_empty() {
+        out.push('\n');
+    }
+    out
+}
+
 fn render_system_test_file(snake_name: &str, pascal_name: &str, dep_crate: &str) -> String {
     format!(
         r#"//! System test: {pascal_name}
@@ -452,6 +532,74 @@ mod tests {
             content.contains("#[ignore"),
             "test must be #[ignore] by default (requires Chromium)"
         );
+    }
+
+    #[test]
+    fn generate_then_destroy_round_trips_to_original_cargo_toml() {
+        let tmp = temp_project();
+        let cargo_path = tmp.path().join("Cargo.toml");
+        let original_cargo = fs::read_to_string(&cargo_path).unwrap();
+
+        let plan = plan_system_test(tmp.path(), "TodoFlow").unwrap();
+        plan.execute(Flags::default()).unwrap();
+        assert!(
+            fs::read_to_string(&cargo_path)
+                .unwrap()
+                .contains("system-tests")
+        );
+
+        let destroy_plan = plan_system_test(tmp.path(), "TodoFlow").unwrap();
+        destroy_plan.revert(Flags::default()).unwrap();
+
+        assert!(
+            !tmp.path()
+                .join("tests")
+                .join("system")
+                .join("todo_flow.rs")
+                .exists()
+        );
+        assert_eq!(fs::read_to_string(&cargo_path).unwrap(), original_cargo);
+    }
+
+    #[test]
+    fn destroying_one_of_two_system_tests_keeps_the_others_feature_and_entry() {
+        let tmp = temp_project();
+        plan_system_test(tmp.path(), "TodoFlow")
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        plan_system_test(tmp.path(), "CheckoutFlow")
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        let cargo_path = tmp.path().join("Cargo.toml");
+
+        plan_system_test(tmp.path(), "TodoFlow")
+            .unwrap()
+            .revert(Flags::default())
+            .unwrap();
+
+        assert!(
+            !tmp.path()
+                .join("tests")
+                .join("system")
+                .join("todo_flow.rs")
+                .exists()
+        );
+        assert!(
+            tmp.path()
+                .join("tests")
+                .join("system")
+                .join("checkout_flow.rs")
+                .exists()
+        );
+        let cargo_after = fs::read_to_string(&cargo_path).unwrap();
+        assert!(
+            cargo_after.contains("system-tests"),
+            "the shared feature must survive — the other system test still needs it"
+        );
+        assert!(cargo_after.contains("checkout_flow"));
+        assert!(!cargo_after.contains("todo_flow"));
     }
 
     #[test]

--- a/autumn-cli/src/generate/system_test.rs
+++ b/autumn-cli/src/generate/system_test.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 use super::emit::Plan;
 use super::model::validate_resource_name;
 use super::naming::{pascal, snake};
-use super::{Flags, GenerateError, ensure_project_root};
+use super::{GenerateError, ensure_project_root};
 
 /// Returns `true` if `trimmed` is a TOML section header matching `name`,
 /// with or without a trailing inline comment (e.g. `[workspace] # root`).
@@ -417,27 +417,10 @@ async fn {snake_name}_index_renders() {{
     )
 }
 
-/// CLI entry point.
-pub fn run(name: &str, flags: Flags) {
-    let cwd = match std::env::current_dir() {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("Error: cannot determine current directory: {e}");
-            std::process::exit(1);
-        }
-    };
-    match plan_system_test(&cwd, name).and_then(|p| p.execute(flags)) {
-        Ok(()) => {}
-        Err(e) => {
-            eprintln!("Error: {e}");
-            std::process::exit(1);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::generate::Flags;
     use std::fs;
     use tempfile::TempDir;
 

--- a/autumn-cli/src/generate/system_test.rs
+++ b/autumn-cli/src/generate/system_test.rs
@@ -381,10 +381,18 @@ pub(super) fn patch_cargo_toml(existing: &str, snake_name: &str) -> String {
 /// `tests/system/*.rs` entry remains, mirroring the "shared while still
 /// needed" rule `emit::SHARED_MAIN_MODULE_NAMES` applies to `src/main.rs`
 /// module declarations (multiple system-test resources, and `generate pwa`'s
-/// own smoke test, all share this one feature declaration).
+/// own smoke test, all share this one feature declaration) — AND only if no
+/// hand-written `#[cfg(feature = "system-tests")]` elsewhere in the project
+/// still gates on it (issue #1048 PR review): the feature may have
+/// pre-existed for code this generator never touched.
 ///
 /// A no-op if this test's `[[test]]` entry isn't present.
-pub(super) fn remove_cargo_toml_patch(existing: &str, snake_name: &str) -> String {
+pub(super) fn remove_cargo_toml_patch(
+    existing: &str,
+    snake_name: &str,
+    project_root: &std::path::Path,
+    excluding: &[std::path::PathBuf],
+) -> String {
     let test_block =
         format!("\n[[test]]\nname = \"{snake_name}\"\npath = \"tests/system/{snake_name}.rs\"\n");
     let Some(pos) = existing.find(&test_block) else {
@@ -395,6 +403,9 @@ pub(super) fn remove_cargo_toml_patch(existing: &str, snake_name: &str) -> Strin
     without_test_entry.push_str(&existing[pos + test_block.len()..]);
 
     if without_test_entry.contains("tests/system/") {
+        return without_test_entry;
+    }
+    if super::emit::cargo_feature_still_gated_elsewhere("system-tests", project_root, excluding) {
         return without_test_entry;
     }
 
@@ -600,6 +611,44 @@ mod tests {
         );
         assert!(cargo_after.contains("checkout_flow"));
         assert!(!cargo_after.contains("todo_flow"));
+    }
+
+    #[test]
+    fn destroying_the_only_system_test_keeps_a_pre_existing_hand_written_feature_gate() {
+        // The project already gates unrelated hand-written code on
+        // `system-tests` (independent of this generator) before `generate
+        // system-test` ever runs. Destroying the only generated system test
+        // must not strip that pre-existing feature declaration out from
+        // under the hand-written code (issue #1048 PR review).
+        let tmp = temp_project();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(
+            tmp.path().join("src").join("lib.rs"),
+            "#[cfg(feature = \"system-tests\")]\npub fn only_for_browser_tests() {}\n",
+        )
+        .unwrap();
+
+        plan_system_test(tmp.path(), "TodoFlow")
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        plan_system_test(tmp.path(), "TodoFlow")
+            .unwrap()
+            .revert(Flags::default())
+            .unwrap();
+
+        assert!(
+            !tmp.path()
+                .join("tests")
+                .join("system")
+                .join("todo_flow.rs")
+                .exists()
+        );
+        let cargo_after = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        assert!(
+            cargo_after.contains("system-tests"),
+            "pre-existing hand-written feature gate must survive destroy"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/task.rs
+++ b/autumn-cli/src/generate/task.rs
@@ -24,7 +24,12 @@ pub fn plan_task(project_root: &Path, name: &str) -> Result<Plan, GenerateError>
         project_root.join("tasks").join(format!("{snake_name}.rs")),
         render_task_file(&snake_name, &pascal_name),
     );
-    plan_cargo_deps(&mut plan, project_root, TASK_DEPS);
+    plan_cargo_deps(
+        &mut plan,
+        project_root,
+        TASK_DEPS,
+        &project_root.join("tasks"),
+    );
     Ok(plan)
 }
 

--- a/autumn-cli/src/generate/task.rs
+++ b/autumn-cli/src/generate/task.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use super::emit::Plan;
 use super::model::{plan_cargo_deps, validate_resource_name};
 use super::naming::{pascal, snake};
-use super::{Flags, GenerateError, ensure_project_root};
+use super::{GenerateError, ensure_project_root};
 
 const TASK_DEPS: &[(&str, &str)] = &[("serde", "{ version = \"1\", features = [\"derive\"] }")];
 
@@ -55,27 +55,10 @@ pub async fn {snake_name}(TaskArgs(args): TaskArgs<{pascal_name}Args>) -> Autumn
     )
 }
 
-/// CLI entry point.
-pub fn run(name: &str, flags: Flags) {
-    let cwd = match std::env::current_dir() {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("Error: cannot determine current directory: {e}");
-            std::process::exit(1);
-        }
-    };
-    match plan_task(&cwd, name).and_then(|p| p.execute(flags)) {
-        Ok(()) => {}
-        Err(e) => {
-            eprintln!("Error: {e}");
-            std::process::exit(1);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::generate::Flags;
     use std::fs;
     use tempfile::TempDir;
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -42,7 +42,7 @@
 use std::path::Path;
 
 use super::emit::Plan;
-use super::{Flags, GenerateError, ensure_project_root};
+use super::{GenerateError, ensure_project_root};
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
@@ -124,28 +124,6 @@ pub fn plan_tauri(project_root: &Path) -> Result<Plan, GenerateError> {
     plan.create(tauri.join(".gitignore"), render_gitignore());
 
     Ok(plan)
-}
-
-/// CLI entry point — executes the plan and prints required prerequisites.
-pub fn run(flags: Flags) {
-    let cwd = match std::env::current_dir() {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("Error: cannot determine current directory: {e}");
-            std::process::exit(1);
-        }
-    };
-    match plan_tauri(&cwd).and_then(|p| p.execute(flags)) {
-        Ok(()) => {
-            if !flags.dry_run {
-                println!("\n{}", render_prerequisites());
-            }
-        }
-        Err(e) => {
-            eprintln!("Error: {e}");
-            std::process::exit(1);
-        }
-    }
 }
 
 // ── Package metadata helper ───────────────────────────────────────────────────

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -3804,6 +3804,39 @@ mod tests {
     // ── additive (does not touch app's src/main.rs or root Cargo.toml) ───────
 
     #[test]
+    fn generate_then_destroy_tauri_round_trips_to_original_project_state() {
+        // `plan_tauri` never pushes a `Modify` action (see
+        // `plan_does_not_modify_app_main_rs`/`plan_does_not_modify_root_cargo_toml`
+        // below) — everything it emits lives under the freshly-created
+        // `src-tauri/` directory, so `Plan::revert`'s generic
+        // Create-deletion + empty-directory pruning should already restore
+        // the project exactly, with no per-generator `Revert` wiring needed.
+        let tmp = project("my-app");
+        let cargo_path = tmp.path().join("Cargo.toml");
+        let main_path = tmp.path().join("src/main.rs");
+        let original_cargo = fs::read_to_string(&cargo_path).unwrap();
+        let original_main = fs::read_to_string(&main_path).unwrap();
+
+        plan_tauri(tmp.path())
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+        assert!(tmp.path().join("src-tauri").exists());
+
+        plan_tauri(tmp.path())
+            .unwrap()
+            .revert(Flags::default())
+            .unwrap();
+
+        assert!(
+            !tmp.path().join("src-tauri").exists(),
+            "src-tauri/ must be fully removed and pruned"
+        );
+        assert_eq!(fs::read_to_string(&main_path).unwrap(), original_main);
+        assert_eq!(fs::read_to_string(&cargo_path).unwrap(), original_cargo);
+    }
+
+    #[test]
     fn plan_does_not_modify_app_main_rs() {
         let tmp = project("my-app");
         let plan = plan_tauri(tmp.path()).unwrap();

--- a/autumn-cli/src/generate/wizard.rs
+++ b/autumn-cli/src/generate/wizard.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 use super::emit::Plan;
 use super::naming::{pascal, snake};
 use super::schema_edit::add_mod_declaration;
-use super::{Flags, GenerateError, ensure_project_root, read_or_empty};
+use super::{GenerateError, ensure_project_root, read_or_empty};
 
 /// Minimum two steps are required.
 const MIN_STEPS: usize = 2;
@@ -89,7 +89,11 @@ pub fn plan_wizard(
     // Update src/wizards/mod.rs — idempotent
     let mod_file = wizards_dir.join("mod.rs");
     let updated_mod = add_mod_declaration(&read_or_empty(&mod_file), &snake_name);
-    plan.modify(mod_file, updated_mod);
+    plan.modify(mod_file.clone(), updated_mod);
+    plan.push_revert(crate::generate::emit::Revert::ModDecl {
+        path: mod_file,
+        name: snake_name.clone(),
+    });
 
     // Integration test
     plan.create(
@@ -502,27 +506,10 @@ async fn {snake_name}_cancel_clears_session_state() {{
     )
 }
 
-/// CLI entry point.
-pub fn run(name: &str, steps: &[String], flags: Flags) {
-    let cwd = match std::env::current_dir() {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("Error: cannot determine current directory: {e}");
-            std::process::exit(1);
-        }
-    };
-    match plan_wizard(&cwd, name, steps).and_then(|p| p.execute(flags)) {
-        Ok(()) => {}
-        Err(e) => {
-            eprintln!("Error: {e}");
-            std::process::exit(1);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::generate::Flags;
     use std::fs;
     use tempfile::TempDir;
 

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -2852,8 +2852,25 @@ fn run_generate_command(cmd: GenerateCommands, mode: ApplyMode) {
                 // Encrypted-column flags are auto-detected from the model source.
                 ..Default::default()
             };
-            let plan =
-                generate::admin::plan_admin_with_options(&resolve_cwd(), &name, &fields, &options);
+            let project_root = resolve_cwd();
+            // `plan_admin_with_options` reads `src/models/<name>.rs` to
+            // detect fields/encrypted columns for rendering — meaningless
+            // (and an error) once the model is gone. A common cleanup order
+            // like `destroy model Post` then `destroy admin Post` would
+            // otherwise fail before ever reaching `Plan::revert`, stranding
+            // `src/admin/post.rs` (issue #1048 PR review). Fall back to a
+            // model-independent plan in that specific case.
+            let model_missing = mode == ApplyMode::Destroy
+                && !project_root
+                    .join("src")
+                    .join("models")
+                    .join(format!("{}.rs", generate::naming::snake(&name)))
+                    .exists();
+            let plan = if model_missing {
+                generate::admin::plan_admin_destroy_fallback(&project_root, &name)
+            } else {
+                generate::admin::plan_admin_with_options(&project_root, &name, &fields, &options)
+            };
             apply_plan(plan, generate::Flags { dry_run, force }, mode);
         }
         GenerateCommands::Wizard {

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -2713,13 +2713,32 @@ fn run_generate_command(cmd: GenerateCommands, mode: ApplyMode) {
             force,
         } => {
             let timestamp = generate::timestamp_now();
+            let project_root = resolve_cwd();
             let plan = generate::migration::plan_migration_with_options(
-                &resolve_cwd(),
+                &project_root,
                 &name,
                 &fields,
                 &timestamp,
                 &unique,
             );
+            // `plan_migration_with_options` needs the model's `#[searchable]`
+            // config to render `AddSearchTo<Table>`'s SQL — meaningless (and
+            // an error) once the model is already gone. A common cleanup
+            // order like `destroy model Post` then `destroy migration
+            // AddSearchToPosts` would otherwise strand the migration
+            // directory, since the failure happens before `Plan::revert`
+            // ever sees `--force` (issue #1048 PR review). Fall back to a
+            // suffix-only removal plan in destroy mode when the real plan
+            // can't be built.
+            let plan = if mode == ApplyMode::Destroy && plan.is_err() {
+                generate::migration::plan_migration_destroy_fallback(
+                    &project_root,
+                    &name,
+                    &timestamp,
+                )
+            } else {
+                plan
+            };
             apply_plan(plan, generate::Flags { dry_run, force }, mode);
         }
         GenerateCommands::Task {

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -2643,6 +2643,12 @@ fn apply_plan(
     }
 }
 
+#[allow(
+    clippy::too_many_lines,
+    reason = "one match arm per GenerateCommands variant, each a short, independent \
+              plan-then-apply dispatch — splitting the match itself would not make any \
+              single arm clearer"
+)]
 fn run_generate_command(cmd: GenerateCommands, mode: ApplyMode) {
     match cmd {
         GenerateCommands::Model {

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -2805,7 +2805,18 @@ fn run_generate_command(cmd: GenerateCommands, mode: ApplyMode) {
             apply_plan(plan, generate::Flags { dry_run, force }, mode);
         }
         GenerateCommands::Pwa { dry_run, force } => {
-            let plan = generate::pwa::plan_pwa(&resolve_cwd());
+            let project_root = resolve_cwd();
+            // `plan_pwa` validates `src/main.rs`'s `layout()` arity — needed
+            // so a fresh generate never emits a call with the wrong shape,
+            // but irrelevant to destroy (which never consults that arity)
+            // and can wrongly block cleanup if `main.rs` no longer matches
+            // (issue #1048 PR review). Always use the destroy-only fallback
+            // for `ApplyMode::Destroy`; it produces the identical plan for
+            // every other case.
+            let plan = match mode {
+                ApplyMode::Generate => generate::pwa::plan_pwa(&project_root),
+                ApplyMode::Destroy => generate::pwa::plan_pwa_destroy_fallback(&project_root),
+            };
             apply_plan(plan, generate::Flags { dry_run, force }, mode);
         }
         GenerateCommands::Tauri { dry_run, force } => {

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -318,6 +318,33 @@ enum Commands {
     #[command(subcommand, verbatim_doc_comment)]
     Generate(GenerateCommands),
 
+    /// Cleanly reverse a matching `autumn generate` invocation (issue #1048).
+    ///
+    /// Deletes every file that invocation would have created (refusing when
+    /// a targeted file's content has diverged from what `generate` would
+    /// produce, unless `--force`), removes exactly the lines it inserted
+    /// into shared files (`mod` declarations, `routes![]` entries,
+    /// `Cargo.toml` deps/features, `schema.rs` table blocks), and prunes any
+    /// now-empty generated directories.
+    ///
+    /// Takes the same subcommand and positional arguments as the matching
+    /// `autumn generate` call — pass the identical resource name, fields,
+    /// and flags (`--api`, `--live`, `--id`, `--soft-delete`, ...) so the
+    /// recomputed plan matches what was originally generated.
+    ///
+    /// A migration directory is matched by resource-name suffix (a fresh
+    /// timestamp won't match the original) and removed only when it is not
+    /// yet applied to a configured database — `destroy` never touches the
+    /// database itself.
+    ///
+    /// # Examples
+    ///
+    ///   autumn generate scaffold Post title:String
+    ///   autumn destroy scaffold Post title:String
+    ///   autumn destroy model Post title:String --dry-run
+    #[command(subcommand, verbatim_doc_comment)]
+    Destroy(GenerateCommands),
+
     /// Scaffold production deployment artifacts (Dockerfile, .dockerignore,
     /// runtime config template, and optional target-specific files).
     ///
@@ -2262,7 +2289,8 @@ fn run_command(command: Commands) {
                 &format,
             );
         }
-        Commands::Generate(cmd) => run_generate_command(cmd),
+        Commands::Generate(cmd) => run_generate_command(cmd, ApplyMode::Generate),
+        Commands::Destroy(cmd) => run_generate_command(cmd, ApplyMode::Destroy),
         Commands::Credentials(cmd) => match cmd {
             CredentialsCommands::Edit { env } => {
                 if let Err(e) = credentials::run_edit(&credentials::EditOptions { env }) {
@@ -2578,7 +2606,44 @@ fn run_release_command(cmd: ReleaseCommands) {
 }
 
 #[allow(clippy::too_many_lines)]
-fn run_generate_command(cmd: GenerateCommands) {
+/// Whether a [`GenerateCommands`] invocation should apply its plan forward
+/// (`autumn generate`) or in reverse (`autumn destroy`, issue #1048). Both
+/// subcommands share the same argument parsing and plan-building code —
+/// `destroy` recomputes the identical [`generate::emit::Plan`] a matching
+/// `generate` call would have built, then interprets it in reverse.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApplyMode {
+    Generate,
+    Destroy,
+}
+
+/// Resolve the current working directory, or print an error and exit(1).
+fn resolve_cwd() -> std::path::PathBuf {
+    std::env::current_dir().unwrap_or_else(|e| {
+        eprintln!("Error: cannot determine current directory: {e}");
+        std::process::exit(1);
+    })
+}
+
+/// Execute or revert `plan` depending on `mode`, printing `Error: ...` and
+/// exiting non-zero on failure — the shared tail every `generate`/`destroy`
+/// subcommand arm ends with.
+fn apply_plan(
+    plan: Result<generate::emit::Plan, generate::GenerateError>,
+    flags: generate::Flags,
+    mode: ApplyMode,
+) {
+    let result = plan.and_then(|p| match mode {
+        ApplyMode::Generate => p.execute(flags),
+        ApplyMode::Destroy => p.revert(flags),
+    });
+    if let Err(e) = result {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
+}
+
+fn run_generate_command(cmd: GenerateCommands, mode: ApplyMode) {
     match cmd {
         GenerateCommands::Model {
             name,
@@ -2625,21 +2690,14 @@ fn run_generate_command(cmd: GenerateCommands) {
                 ..Default::default()
             };
             let timestamp = generate::timestamp_now();
-            match generate::model::plan_model_with_options(
+            let plan = generate::model::plan_model_with_options(
                 &std::env::current_dir().unwrap_or_default(),
                 &name,
                 &fields,
                 &timestamp,
                 &options,
-            )
-            .and_then(|p| p.execute(generate::Flags { dry_run, force }))
-            {
-                Ok(()) => {}
-                Err(e) => {
-                    eprintln!("Error: {e}");
-                    std::process::exit(1);
-                }
-            }
+            );
+            apply_plan(plan, generate::Flags { dry_run, force }, mode);
         }
         GenerateCommands::Migration {
             name,
@@ -2647,30 +2705,49 @@ fn run_generate_command(cmd: GenerateCommands) {
             unique,
             dry_run,
             force,
-        } => generate::migration::run(&name, &fields, &unique, generate::Flags { dry_run, force }),
+        } => {
+            let timestamp = generate::timestamp_now();
+            let plan = generate::migration::plan_migration_with_options(
+                &resolve_cwd(),
+                &name,
+                &fields,
+                &timestamp,
+                &unique,
+            );
+            apply_plan(plan, generate::Flags { dry_run, force }, mode);
+        }
         GenerateCommands::Task {
             name,
             dry_run,
             force,
-        } => generate::task::run(&name, generate::Flags { dry_run, force }),
+        } => {
+            let plan = generate::task::plan_task(&resolve_cwd(), &name);
+            apply_plan(plan, generate::Flags { dry_run, force }, mode);
+        }
         GenerateCommands::Job {
             name,
             fields,
             dry_run,
             force,
-        } => generate::job::run(&name, &fields, generate::Flags { dry_run, force }),
+        } => {
+            let plan = generate::job::plan_job(&resolve_cwd(), &name, &fields);
+            apply_plan(plan, generate::Flags { dry_run, force }, mode);
+        }
         GenerateCommands::Mailer {
             name,
             list_unsubscribe,
             no_layout,
             dry_run,
             force,
-        } => generate::mailer::run(
-            &name,
-            list_unsubscribe.as_deref(),
-            no_layout,
-            generate::Flags { dry_run, force },
-        ),
+        } => {
+            let plan = generate::mailer::plan_mailer(
+                &resolve_cwd(),
+                &name,
+                list_unsubscribe.as_deref(),
+                no_layout,
+            );
+            apply_plan(plan, generate::Flags { dry_run, force }, mode);
+        }
         GenerateCommands::Channel {
             name,
             sse: _,
@@ -2683,23 +2760,47 @@ fn run_generate_command(cmd: GenerateCommands) {
             } else {
                 generate::channel::Transport::Sse
             };
-            generate::channel::run(&name, transport, generate::Flags { dry_run, force });
+            let plan = generate::channel::plan_channel(&resolve_cwd(), &name, transport);
+            apply_plan(plan, generate::Flags { dry_run, force }, mode);
         }
         GenerateCommands::InboundMail {
             name,
             dry_run,
             force,
-        } => generate::inbound_mail::run(&name, generate::Flags { dry_run, force }),
+        } => {
+            let plan = generate::inbound_mail::plan_inbound_mail(&resolve_cwd(), &name);
+            apply_plan(plan, generate::Flags { dry_run, force }, mode);
+        }
         GenerateCommands::SystemTest {
             name,
             dry_run,
             force,
-        } => generate::system_test::run(&name, generate::Flags { dry_run, force }),
+        } => {
+            let plan = generate::system_test::plan_system_test(&resolve_cwd(), &name);
+            apply_plan(plan, generate::Flags { dry_run, force }, mode);
+        }
         GenerateCommands::Pwa { dry_run, force } => {
-            generate::pwa::run(generate::Flags { dry_run, force });
+            let plan = generate::pwa::plan_pwa(&resolve_cwd());
+            apply_plan(plan, generate::Flags { dry_run, force }, mode);
         }
         GenerateCommands::Tauri { dry_run, force } => {
-            generate::tauri::run(generate::Flags { dry_run, force });
+            let flags = generate::Flags { dry_run, force };
+            let plan = generate::tauri::plan_tauri(&resolve_cwd());
+            let result = plan.and_then(|p| match mode {
+                ApplyMode::Generate => p.execute(flags),
+                ApplyMode::Destroy => p.revert(flags),
+            });
+            match result {
+                Ok(()) => {
+                    if mode == ApplyMode::Generate && !dry_run {
+                        println!("\n{}", generate::tauri::render_prerequisites());
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    std::process::exit(1);
+                }
+            }
         }
         GenerateCommands::Auth {
             name,
@@ -2710,13 +2811,16 @@ fn run_generate_command(cmd: GenerateCommands) {
             force,
         } => {
             let oauth_options = generate::auth::AuthOAuthOptions { providers: oauth };
-            generate::auth::run_with_options(
+            let timestamp = generate::timestamp_now();
+            let plan = generate::auth::plan_auth_full_ex(
+                &resolve_cwd(),
                 &name,
-                generate::Flags { dry_run, force },
+                &timestamp,
                 &oauth_options,
                 totp,
                 passkeys,
             );
+            apply_plan(plan, generate::Flags { dry_run, force }, mode);
         }
         GenerateCommands::Admin {
             name,
@@ -2742,7 +2846,9 @@ fn run_generate_command(cmd: GenerateCommands) {
                 // Encrypted-column flags are auto-detected from the model source.
                 ..Default::default()
             };
-            generate::admin::run(&name, &fields, generate::Flags { dry_run, force }, &options);
+            let plan =
+                generate::admin::plan_admin_with_options(&resolve_cwd(), &name, &fields, &options);
+            apply_plan(plan, generate::Flags { dry_run, force }, mode);
         }
         GenerateCommands::Wizard {
             name,
@@ -2750,7 +2856,8 @@ fn run_generate_command(cmd: GenerateCommands) {
             dry_run,
             force,
         } => {
-            generate::wizard::run(&name, &steps, generate::Flags { dry_run, force });
+            let plan = generate::wizard::plan_wizard(&resolve_cwd(), &name, &steps);
+            apply_plan(plan, generate::Flags { dry_run, force }, mode);
         }
         GenerateCommands::Scaffold {
             name,
@@ -2831,7 +2938,15 @@ fn run_generate_command(cmd: GenerateCommands) {
                     std::process::exit(1);
                 }
             };
-            generate::scaffold::run(&name, &fields, generate::Flags { dry_run, force }, &options);
+            let timestamp = generate::timestamp_now();
+            let plan = generate::scaffold::plan_scaffold_with_options(
+                &resolve_cwd(),
+                &name,
+                &fields,
+                &timestamp,
+                &options,
+            );
+            apply_plan(plan, generate::Flags { dry_run, force }, mode);
         }
         GenerateCommands::Plugin {
             name,
@@ -2839,23 +2954,22 @@ fn run_generate_command(cmd: GenerateCommands) {
             dry_run,
             force,
         } => {
-            let cwd = match std::env::current_dir() {
-                Ok(d) => d,
-                Err(e) => {
-                    eprintln!("Error: cannot determine current directory: {e}");
-                    std::process::exit(1);
-                }
-            };
+            let cwd = resolve_cwd();
+            let flags = generate::Flags { dry_run, force };
             match generate::plugin::plan_plugin(
                 &cwd,
                 &name,
                 path.as_deref().map(std::path::Path::new),
-                generate::Flags { dry_run, force },
+                flags,
             ) {
                 Ok(plugin_plan) => {
-                    match plugin_plan.plan.execute(generate::Flags { dry_run, force }) {
+                    let result = match mode {
+                        ApplyMode::Generate => plugin_plan.plan.execute(flags),
+                        ApplyMode::Destroy => plugin_plan.plan.revert(flags),
+                    };
+                    match result {
                         Ok(()) => {
-                            if !dry_run {
+                            if mode == ApplyMode::Generate && !dry_run {
                                 println!("\nNext steps:");
                                 println!(
                                     "  1. Add the plugin to your workspace members in `Cargo.toml`:"

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -2979,11 +2979,26 @@ fn run_generate_command(cmd: GenerateCommands, mode: ApplyMode) {
         } => {
             let cwd = resolve_cwd();
             let flags = generate::Flags { dry_run, force };
+            // `plan_plugin` refuses a non-empty target directory unless
+            // `--force` — a generate-time collision guard that makes no
+            // sense in destroy mode, where the directory legitimately
+            // exists (holding the files this destroy is about to remove).
+            // Always bypass it when building the plan for destroy, while
+            // still passing the user's real `flags` to `revert` below so
+            // its own, per-file content-divergence check still applies
+            // (issue #1048 PR review).
+            let plan_flags = match mode {
+                ApplyMode::Generate => flags,
+                ApplyMode::Destroy => generate::Flags {
+                    force: true,
+                    ..flags
+                },
+            };
             match generate::plugin::plan_plugin(
                 &cwd,
                 &name,
                 path.as_deref().map(std::path::Path::new),
-                flags,
+                plan_flags,
             ) {
                 Ok(plugin_plan) => {
                     let result = match mode {

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -625,7 +625,7 @@ where
     std::process::exit(1);
 }
 
-pub(crate) fn read_autumn_toml_table() -> Option<toml::Table> {
+pub fn read_autumn_toml_table() -> Option<toml::Table> {
     let config_path = Path::new("autumn.toml");
     if !config_path.exists() {
         return None;

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -625,7 +625,7 @@ where
     std::process::exit(1);
 }
 
-fn read_autumn_toml_table() -> Option<toml::Table> {
+pub(crate) fn read_autumn_toml_table() -> Option<toml::Table> {
     let config_path = Path::new("autumn.toml");
     if !config_path.exists() {
         return None;

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -1006,6 +1006,53 @@ fn generate_then_destroy_migration_round_trips_git_clean() {
     assert!(status_stdout.trim().is_empty());
 }
 
+#[test]
+fn generate_then_destroy_plugin_round_trips_git_clean() {
+    // Regression test (issue #1048 PR review): `plan_plugin` refuses a
+    // non-empty target directory unless `--force` — a generate-time
+    // collision guard. Without special-casing destroy mode, `autumn destroy
+    // plugin Foo` would always hit that same guard (the plugin directory
+    // legitimately exists, holding the files this destroy is about to
+    // remove) and fail before ever reaching `Plan::revert`, even with no
+    // `--force` flag and no actual divergence.
+    let (_tmp, project) = fresh_project("destroy-plugin-app");
+
+    run_git(&project, &["init"]);
+    run_git(&project, &["add", "-A"]);
+    run_git(
+        &project,
+        &[
+            "-c",
+            "user.email=t@t.com",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-m",
+            "base",
+        ],
+    );
+
+    let before = snapshot_tree(&project);
+
+    run_autumn(&project, &["generate", "plugin", "Foo"]);
+    assert!(project.join("autumn-foo-plugin/Cargo.toml").is_file());
+
+    run_autumn(&project, &["destroy", "plugin", "Foo"]);
+    assert!(!project.join("autumn-foo-plugin").exists());
+
+    let after = snapshot_tree(&project);
+    assert_eq!(
+        before, after,
+        "working tree must be byte-identical after generate+destroy"
+    );
+
+    let status_stdout = run_git(&project, &["status", "--porcelain"]);
+    assert!(
+        status_stdout.trim().is_empty(),
+        "git status must be clean after generate+destroy, got:\n{status_stdout}"
+    );
+}
+
 /// AC5: `destroy --dry-run` prints a plan and exits 0 without touching disk.
 #[test]
 fn destroy_dry_run_writes_nothing() {

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -829,6 +829,227 @@ fn generate_scaffold_full_e2e_post() {
     }
 }
 
+// ── `autumn destroy` (issue #1048) ─────────────────────────────────────────
+
+/// Spawn the system `git` binary in `dir` (NOT the `autumn` binary — see
+/// [`run_autumn`]), asserting success, and return its stdout.
+fn run_git(dir: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to run git");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        output.status.success(),
+        "git {args:?} failed (exit={:?})\nstdout: {stdout}\nstderr: {stderr}",
+        output.status.code(),
+    );
+    stdout
+}
+
+/// Recursively collect every file under `root` as `(relative_path, contents)`,
+/// sorted for deterministic comparison. Used to assert a project's working
+/// tree is byte-for-byte identical before/after a `generate`+`destroy`
+/// round-trip — a filesystem-level equivalent of `git status` being clean
+/// that doesn't require a `git` binary in the test sandbox.
+fn snapshot_tree(root: &Path) -> Vec<(String, Vec<u8>)> {
+    fn walk(dir: &Path, root: &Path, out: &mut Vec<(String, Vec<u8>)>) {
+        for entry in fs::read_dir(dir).expect("read_dir").filter_map(Result::ok) {
+            let path = entry.path();
+            if path.is_dir() {
+                walk(&path, root, out);
+            } else {
+                let rel = path
+                    .strip_prefix(root)
+                    .unwrap()
+                    .display()
+                    .to_string()
+                    .replace('\\', "/");
+                let contents = fs::read(&path).expect("read file");
+                out.push((rel, contents));
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(root, root, &mut out);
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    out
+}
+
+/// The headline acceptance test (issue #1048's success metric): `autumn
+/// generate scaffold Post title:String` immediately followed by `autumn
+/// destroy scaffold Post title:String` returns the project's working tree
+/// byte-for-byte identical to its pre-generate state — both via a
+/// filesystem snapshot comparison and via `git status --porcelain` being
+/// empty against a real commit, exactly the round-trip the issue describes.
+#[test]
+fn generate_then_destroy_scaffold_round_trips_git_clean() {
+    let (_tmp, project) = fresh_project("destroy-scaffold-app");
+
+    run_git(&project, &["init"]);
+    run_git(&project, &["add", "-A"]);
+    run_git(
+        &project,
+        &[
+            "-c",
+            "user.email=t@t.com",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-m",
+            "base",
+        ],
+    );
+
+    let before = snapshot_tree(&project);
+
+    run_autumn(&project, &["generate", "scaffold", "Post", "title:String"]);
+    assert!(project.join("src/models/post.rs").is_file());
+    assert!(project.join("src/routes/posts.rs").is_file());
+    assert!(project.join("src/repositories/post.rs").is_file());
+
+    run_autumn(&project, &["destroy", "scaffold", "Post", "title:String"]);
+
+    let after = snapshot_tree(&project);
+    assert_eq!(
+        before, after,
+        "working tree must be byte-identical after generate+destroy"
+    );
+
+    let status_stdout = run_git(&project, &["status", "--porcelain"]);
+    assert!(
+        status_stdout.trim().is_empty(),
+        "git status must be clean after generate+destroy, got:\n{status_stdout}"
+    );
+}
+
+#[test]
+fn generate_then_destroy_model_round_trips_git_clean() {
+    let (_tmp, project) = fresh_project("destroy-model-app");
+    run_git(&project, &["init"]);
+    run_git(&project, &["add", "-A"]);
+    run_git(
+        &project,
+        &[
+            "-c",
+            "user.email=t@t.com",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-m",
+            "base",
+        ],
+    );
+
+    let before = snapshot_tree(&project);
+    run_autumn(&project, &["generate", "model", "Post", "title:String"]);
+    run_autumn(&project, &["destroy", "model", "Post", "title:String"]);
+    let after = snapshot_tree(&project);
+    assert_eq!(before, after);
+
+    let status_stdout = run_git(&project, &["status", "--porcelain"]);
+    assert!(status_stdout.trim().is_empty());
+}
+
+#[test]
+fn generate_then_destroy_migration_round_trips_git_clean() {
+    let (_tmp, project) = fresh_project("destroy-migration-app");
+    run_autumn(&project, &["generate", "model", "Post", "title:String"]);
+    run_git(&project, &["init"]);
+    run_git(&project, &["add", "-A"]);
+    run_git(
+        &project,
+        &[
+            "-c",
+            "user.email=t@t.com",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-m",
+            "base",
+        ],
+    );
+
+    let before = snapshot_tree(&project);
+    run_autumn(
+        &project,
+        &[
+            "generate",
+            "migration",
+            "AddSubtitleToPosts",
+            "subtitle:String",
+        ],
+    );
+    run_autumn(
+        &project,
+        &[
+            "destroy",
+            "migration",
+            "AddSubtitleToPosts",
+            "subtitle:String",
+        ],
+    );
+    let after = snapshot_tree(&project);
+    assert_eq!(before, after);
+
+    let status_stdout = run_git(&project, &["status", "--porcelain"]);
+    assert!(status_stdout.trim().is_empty());
+}
+
+/// AC5: `destroy --dry-run` prints a plan and exits 0 without touching disk.
+#[test]
+fn destroy_dry_run_writes_nothing() {
+    let (_tmp, project) = fresh_project("destroy-dry-run-app");
+    run_autumn(&project, &["generate", "scaffold", "Post", "title:String"]);
+    let before = snapshot_tree(&project);
+
+    let (stdout, _) = run_autumn(
+        &project,
+        &["destroy", "scaffold", "Post", "title:String", "--dry-run"],
+    );
+    assert!(stdout.contains("Dry run"));
+    assert!(stdout.contains("Would remove") || stdout.contains("Would revert"));
+
+    let after = snapshot_tree(&project);
+    assert_eq!(before, after, "--dry-run must not touch disk");
+}
+
+/// AC7: destroy refuses on diverged content unless `--force`, and never
+/// deletes the hand-edited file in that case.
+#[test]
+fn destroy_refuses_on_diverged_file_without_force() {
+    let (_tmp, project) = fresh_project("destroy-diverged-app");
+    run_autumn(&project, &["generate", "scaffold", "Post", "title:String"]);
+
+    let model_path = project.join("src/models/post.rs");
+    let mut content = fs::read_to_string(&model_path).unwrap();
+    content.push_str("\n// hand-edited by the user\n");
+    fs::write(&model_path, &content).unwrap();
+
+    let (_, stderr, code) =
+        run_autumn_failing(&project, &["destroy", "scaffold", "Post", "title:String"]);
+    assert_eq!(code, Some(1));
+    assert!(
+        stderr.contains("diverged") || stderr.contains("Diverged"),
+        "expected a divergence error, got stderr: {stderr}"
+    );
+    assert!(model_path.is_file(), "diverged file must not be deleted");
+    assert!(
+        fs::read_to_string(&model_path)
+            .unwrap()
+            .contains("hand-edited")
+    );
+
+    // --force overrides the guard and proceeds with the destroy.
+    run_autumn(
+        &project,
+        &["destroy", "scaffold", "Post", "title:String", "--force"],
+    );
+    assert!(!model_path.exists());
+}
+
 #[test]
 fn generate_scaffold_api_only() {
     let (_tmp, project) = fresh_project("scaffold-api-app");
@@ -1043,6 +1264,39 @@ fn generate_scaffold_rejects_i32_default_outside_sql_integer_range() {
         stderr.contains("count=9223372036854775807")
             && stderr.contains("i32 defaults must fit the SQL INTEGER range"),
         "expected i32 default range validation error; got stderr: {stderr}"
+    );
+}
+
+/// Issue #1048's success metric, verified end-to-end: `autumn generate
+/// scaffold Post title:String` immediately followed by `autumn destroy
+/// scaffold Post title:String` leaves `cargo check` green on the
+/// round-tripped project — not just a clean working tree (already covered by
+/// [`generate_then_destroy_scaffold_round_trips_git_clean`]), but a project
+/// that still *compiles*, proving destroy never leaves a dangling `mod`
+/// declaration, `routes![]` entry, or Cargo.toml dependency behind.
+///
+/// Ignored by default; slow (compiles the full `autumn-web` dependency
+/// tree) and requires network access to fetch crates. Run with:
+/// `cargo test -p autumn-cli --test generate destroy_scaffold_round_trip_leaves_cargo_check_green -- --ignored --exact`
+#[test]
+#[ignore = "slow: compiles the generated project with cargo check"]
+fn destroy_scaffold_round_trip_leaves_cargo_check_green() {
+    let (_tmp, project) = fresh_project("destroy-scaffold-check-app");
+    patch_generated_cargo_toml(&project);
+
+    run_autumn(&project, &["generate", "scaffold", "Post", "title:String"]);
+    run_autumn(&project, &["destroy", "scaffold", "Post", "title:String"]);
+
+    let check = Command::new("cargo")
+        .args(["check", "--all-targets"])
+        .current_dir(&project)
+        .output()
+        .expect("failed to run cargo check");
+    assert!(
+        check.status.success(),
+        "cargo check failed on the round-tripped project:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr),
     );
 }
 

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -858,6 +858,14 @@ fn snapshot_tree(root: &Path) -> Vec<(String, Vec<u8>)> {
     fn walk(dir: &Path, root: &Path, out: &mut Vec<(String, Vec<u8>)>) {
         for entry in fs::read_dir(dir).expect("read_dir").filter_map(Result::ok) {
             let path = entry.path();
+            if path.file_name().is_some_and(|n| n == ".git") {
+                // Never compare git's own internals — its background
+                // maintenance can create/remove transient files (e.g.
+                // `.git/objects/maintenance.lock`) between snapshots,
+                // producing spurious diffs unrelated to anything
+                // generate/destroy touched.
+                continue;
+            }
             if path.is_dir() {
                 walk(&path, root, out);
             } else {


### PR DESCRIPTION
Implements the `autumn destroy` command that cleanly reverses a matching `autumn generate` invocation by:

1. **Deleting generated files** — removes every file that `generate` created (refusing when content has diverged unless `--force`)
2. **Reverting in-place edits** — removes exactly the lines/entries `generate` inserted into shared files (mod declarations, routes entries, Cargo.toml deps/features, schema.rs tables)
3. **Pruning empty directories** — removes now-empty generated directories

## Key Changes

- **New `Revert` enum** (`emit.rs`) — 14 variants representing each type of in-place edit that can be reversed (ModDecl, RoutesEntries, SchemaTable, CargoDeps, CargoAutumnWebFeature, etc.)
  - Each variant tracks the file path and edit-specific metadata
  - Includes `owner_dir` for dependency/feature reverts to avoid removing shared deps while sibling resources still need them
  - Implements `apply()` method that idempotently removes the edit from file content

- **`Plan::revert()` method** — the inverse of `Plan::execute()`, implementing the core destroy logic:
  - Deletes Create/CreateBytes/CreateIfAbsent actions with content divergence checking
  - Applies each Revert to remove in-place edits
  - Deletes files emptied by reverts
  - Matches migration directories by resource-name suffix (timestamps differ on re-run)
  - Honors `--dry-run` flag

- **`Plan::push_revert()` method** — allows generators to record reverts alongside their Modify actions

- **Generator updates** — all generators now push Revert entries:
  - `model.rs`, `auth.rs`, `scaffold.rs`, `mailer.rs`, `job.rs`, `channel.rs`, `inbound_mail.rs`, `system_test.rs`, `pwa.rs`
  - Each tracks its own ModDecl, SchemaTable, CargoDeps, and feature entries
  - Cargo dependency reverts include `owner_dir` to handle sibling resources correctly

- **Removal functions** (`schema_edit.rs`) — idempotent inverses of append/modify functions:
  - `remove_mod_declaration()`, `remove_schema_table()`, `remove_routes_entries()`
  - `remove_main_mod_declarations()` for shared infrastructure modules
  - `remove_cargo_toml_patch()` for system tests
  - All return content unchanged if target is already absent

- **CLI integration** (`main.rs`) — new `Destroy` command that:
  - Takes identical subcommand and arguments as the matching `generate` call
  - Recomputes the plan with fresh timestamp (migrations matched by suffix)
  - Applies the plan in destroy mode via `Plan::revert()`

- **Test coverage** (`tests/generate.rs`) — acceptance test verifying round-trip:
  - `generate scaffold Post title:String` followed by `destroy scaffold Post title:String`
  - Asserts working tree is byte-for-byte identical via filesystem snapshot
  - Verifies `git status --porcelain` is clean against a real commit

## Implementation Details

- Reverts are stored on `Plan` rather than per-action to survive action consolidation (e.g., scaffold collapsing multiple Modify actions into one)
- Cargo dependency/feature reverts only apply once `owner_dir` has no other resource files, allowing sibling resources to keep shared dependencies
- All removal transforms are idempotent — a revert whose target is already absent returns content unchanged, enabling safe re-runs
- Migration directories matched by suffix since destroy recomputes the plan with a fresh timestamp
- Destroy never touches the database itself, only removes unapplied migration directories

https://claude.ai/code/session_01KBKktGM5AKFJ5VJbNx1WCx