### PR TITLE
Add transaction isolation levels and automatic retry (issue #1202)

### DIFF
--- a/autumn-storage-s3/Cargo.toml
+++ b/autumn-storage-s3/Cargo.toml
@@ -31,16 +31,24 @@ aws-smithy-types = ">=1.4, <1.5"
 time = { version = ">=0.3.36, <0.3.48", default-features = false }
 # aws-smithy-async 1.3.0 bumped its rust-version to 1.94.1, above this
 # workspace's pinned toolchains (MSRV 1.88.0; CI's semver-check runner is
-# 1.92.0). Below 1.3, aws-smithy-runtime-api also stays below the 1.12.0
-# line that pulls in aws-smithy-runtime-api-macros (whose only sub-1.91.0-MSRV
-# release is an unusable 0.0.1 placeholder), so constraining this one crate is
-# enough — a separate direct pin on aws-smithy-runtime-api-macros is not
-# needed and must not be added. This is a transitive dep pulled in via
-# aws-config/aws-sdk-s3, not used directly by this crate — it only bounds
-# resolution, same as the aws-smithy-types/time constraints above. Lift once
-# CI's toolchain is bumped past 1.94.1 or upstream ships an
-# older-rustc-compatible release.
+# 1.92.0). This is a transitive dep pulled in via aws-config/aws-sdk-s3, not
+# used directly by this crate — it only bounds resolution, same as the
+# aws-smithy-types/time constraints above. Lift once CI's toolchain is bumped
+# past 1.94.1 or upstream ships an older-rustc-compatible release.
 aws-smithy-async = ">=1.2, <1.3"
+# aws-smithy-runtime-api is NOT tightly bound by the aws-smithy-async
+# constraint above -- some other crate in this graph (aws-config/aws-runtime/
+# aws-sdk-s3) has a looser requirement on it, so it can independently float up
+# to 1.12.0+, which depends on aws-smithy-runtime-api-macros (MSRV 1.94.1;
+# its only earlier release is an unusable 0.0.1 placeholder). Confirmed by
+# reproducing cargo-semver-checks' own isolated-crate resolution (`cargo new
+# --lib example && echo '[workspace]' >> Cargo.toml && cargo add --path
+# autumn-storage-s3`), which floats aws-smithy-runtime-api to 1.12.3 even with
+# the aws-smithy-async pin above in place. 1.11.4+ also bumps its own
+# rust-version to 1.91, above this workspace's 1.88.0 MSRV, so pin the ceiling
+# at the last 1.88.0-compatible patch. Lift alongside aws-smithy-async once
+# CI's toolchain allows it.
+aws-smithy-runtime-api = ">=1.11, <1.11.4"
 aws-sdk-s3 = "1"
 bytes = "1"
 futures = { workspace = true }

--- a/autumn-storage-s3/Cargo.toml
+++ b/autumn-storage-s3/Cargo.toml
@@ -29,15 +29,18 @@ aws-smithy-types = ">=1.4, <1.5"
 # crates, so this only bounds resolution. Lift once upstream releases
 # are compatible.
 time = { version = ">=0.3.36, <0.3.48", default-features = false }
-# aws-smithy-async 1.3.0 and aws-smithy-runtime-api-macros 1.1.0 bumped their
-# rust-version to 1.94.1, above this workspace's pinned toolchains (MSRV
-# 1.88.0; CI's semver-check runner is 1.92.0). Both are transitive deps
-# pulled in via aws-config/aws-sdk-s3, not used directly by this crate — this
-# only bounds resolution, same as the aws-smithy-types/time constraints
-# above. Lift once CI's toolchain is bumped past 1.94.1 or upstream ships an
+# aws-smithy-async 1.3.0 bumped its rust-version to 1.94.1, above this
+# workspace's pinned toolchains (MSRV 1.88.0; CI's semver-check runner is
+# 1.92.0). Below 1.3, aws-smithy-runtime-api also stays below the 1.12.0
+# line that pulls in aws-smithy-runtime-api-macros (whose only sub-1.91.0-MSRV
+# release is an unusable 0.0.1 placeholder), so constraining this one crate is
+# enough — a separate direct pin on aws-smithy-runtime-api-macros is not
+# needed and must not be added. This is a transitive dep pulled in via
+# aws-config/aws-sdk-s3, not used directly by this crate — it only bounds
+# resolution, same as the aws-smithy-types/time constraints above. Lift once
+# CI's toolchain is bumped past 1.94.1 or upstream ships an
 # older-rustc-compatible release.
 aws-smithy-async = ">=1.2, <1.3"
-aws-smithy-runtime-api-macros = ">=1.0, <1.1"
 aws-sdk-s3 = "1"
 bytes = "1"
 futures = { workspace = true }

--- a/autumn-storage-s3/Cargo.toml
+++ b/autumn-storage-s3/Cargo.toml
@@ -29,6 +29,15 @@ aws-smithy-types = ">=1.4, <1.5"
 # crates, so this only bounds resolution. Lift once upstream releases
 # are compatible.
 time = { version = ">=0.3.36, <0.3.48", default-features = false }
+# aws-smithy-async 1.3.0 and aws-smithy-runtime-api-macros 1.1.0 bumped their
+# rust-version to 1.94.1, above this workspace's pinned toolchains (MSRV
+# 1.88.0; CI's semver-check runner is 1.92.0). Both are transitive deps
+# pulled in via aws-config/aws-sdk-s3, not used directly by this crate — this
+# only bounds resolution, same as the aws-smithy-types/time constraints
+# above. Lift once CI's toolchain is bumped past 1.94.1 or upstream ships an
+# older-rustc-compatible release.
+aws-smithy-async = ">=1.2, <1.3"
+aws-smithy-runtime-api-macros = ">=1.0, <1.1"
 aws-sdk-s3 = "1"
 bytes = "1"
 futures = { workspace = true }

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -1609,6 +1609,12 @@ struct ActuatorHealth {
     uptime: String,
     #[cfg(feature = "db")]
     autumn_after_commit_failures_total: u64,
+    /// Total transaction retries triggered by a `40001`/`40P01` (issue #1202).
+    #[cfg(feature = "db")]
+    autumn_tx_retries_total: u64,
+    /// Total transactions that exhausted their retry budget (issue #1202).
+    #[cfg(feature = "db")]
+    autumn_tx_retry_exhausted_total: u64,
     /// Per-component health, keyed by indicator name.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     components: HashMap<String, ComponentHealth>,
@@ -1762,6 +1768,12 @@ pub async fn health<S: ProvideActuatorState + Send + Sync + 'static>(
         uptime: state.uptime_display(),
         #[cfg(feature = "db")]
         autumn_after_commit_failures_total: crate::db::AFTER_COMMIT_FAILURES_TOTAL
+            .load(std::sync::atomic::Ordering::Relaxed),
+        #[cfg(feature = "db")]
+        autumn_tx_retries_total: crate::db::TX_RETRIES_TOTAL
+            .load(std::sync::atomic::Ordering::Relaxed),
+        #[cfg(feature = "db")]
+        autumn_tx_retry_exhausted_total: crate::db::TX_RETRY_EXHAUSTED_TOTAL
             .load(std::sync::atomic::Ordering::Relaxed),
         components,
         checks,

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -558,6 +558,33 @@ where
     })
 }
 
+/// Walk `err`'s source chain looking for a `tokio_postgres` SQLSTATE matching
+/// `predicate`, downcasting each link to [`tokio_postgres::Error`] and
+/// [`tokio_postgres::error::DbError`] in turn. Shared by [`is_query_canceled`]
+/// and [`is_retryable_txn_error`] — both need the same downcast-through-the-
+/// chain strategy, only with a different SQLSTATE to look for.
+fn source_chain_has_sqlstate(
+    err: &(dyn std::error::Error + 'static),
+    predicate: impl Fn(&tokio_postgres::error::SqlState) -> bool,
+) -> bool {
+    let mut source: Option<&(dyn std::error::Error + 'static)> = Some(err);
+    while let Some(e) = source {
+        if e.downcast_ref::<tokio_postgres::Error>()
+            .and_then(tokio_postgres::Error::code)
+            .is_some_and(&predicate)
+        {
+            return true;
+        }
+        if e.downcast_ref::<tokio_postgres::error::DbError>()
+            .is_some_and(|db_err| predicate(db_err.code()))
+        {
+            return true;
+        }
+        source = e.source();
+    }
+    false
+}
+
 /// Check whether a Diesel error wraps a Postgres `57014` `query_canceled` error.
 ///
 /// Prefers downcasting through the source chain to find a
@@ -575,25 +602,9 @@ fn is_query_canceled(err: &diesel::result::Error) -> bool {
         return true;
     }
 
-    let mut source: Option<&(dyn std::error::Error + 'static)> = Some(err);
-
-    while let Some(e) = source {
-        // Try downcasting to tokio_postgres::Error
-        if e.downcast_ref::<tokio_postgres::Error>()
-            .and_then(|pg_err| pg_err.code())
-            == Some(&tokio_postgres::error::SqlState::QUERY_CANCELED)
-        {
-            return true;
-        }
-        // Try downcasting to tokio_postgres::error::DbError
-        if e.downcast_ref::<tokio_postgres::error::DbError>()
-            .is_some_and(|db_err| db_err.code() == &tokio_postgres::error::SqlState::QUERY_CANCELED)
-        {
-            return true;
-        }
-        source = e.source();
-    }
-    false
+    source_chain_has_sqlstate(err, |state| {
+        *state == tokio_postgres::error::SqlState::QUERY_CANCELED
+    })
 }
 
 /// Error type for pool creation failures.
@@ -924,6 +935,22 @@ impl TxOptions {
         self
     }
 
+    /// `max_attempts`, clamped to at least 1.
+    ///
+    /// The `max_attempts` field is public (struct-literal update syntax is a
+    /// supported way to build a `TxOptions`), so a value of `0` can reach the
+    /// struct without going through [`TxOptions::max_attempts`]'s clamp. The
+    /// retry loop calls this instead of reading the field directly, so `0`
+    /// always behaves like `1` (run the closure once, no retry) rather than
+    /// skipping the closure entirely.
+    const fn effective_max_attempts(&self) -> u32 {
+        if self.max_attempts < 1 {
+            1
+        } else {
+            self.max_attempts
+        }
+    }
+
     /// Set the backoff before the first retry.
     #[must_use]
     pub const fn initial_backoff(mut self, delay: Duration) -> Self {
@@ -973,32 +1000,32 @@ fn retry_backoff_base(initial: Duration, max: Duration, attempt: u32) -> Duratio
 /// [`retry_backoff_base`] with +/-20% jitter applied, never exceeding `max`.
 ///
 /// Jitter decorrelates a thundering herd of transactions all retrying after the
-/// same conflict. Randomness is drawn via `getrandom`, matching
-/// [`crate::cache`]'s `jittered_ttl`; a `getrandom` failure degrades to no
-/// jitter rather than panicking.
+/// same conflict. Delegates to [`crate::cache::jittered_ttl`] (rather than
+/// re-implementing the RNG/fallback logic) so there's one jitter
+/// implementation in the crate, including its `getrandom`-failure fallback to
+/// `SystemTime` entropy instead of silently degrading to no jitter.
 fn retry_backoff_delay(initial: Duration, max: Duration, attempt: u32) -> Duration {
     let base = retry_backoff_base(initial, max, attempt);
-
-    let mut buf = [0u8; 4];
-    let factor = if getrandom::getrandom(&mut buf).is_ok() {
-        // Map the random u32 into [0, 1], then into the +/-20% band [0.8, 1.2].
-        let unit = f64::from(u32::from_le_bytes(buf)) / f64::from(u32::MAX);
-        0.2_f64.mul_add(2.0_f64.mul_add(unit, -1.0), 1.0)
-    } else {
-        1.0
-    };
-
-    base.mul_f64(factor).min(max)
+    crate::cache::jittered_ttl(base, 0.2).min(max)
 }
 
 /// Whether `err` wraps a Postgres serialization failure (`40001`) or deadlock
 /// (`40P01`) — the two transient errors that are safe to retry by re-running
 /// the whole transaction.
 ///
-/// Recovers the underlying `diesel::result::Error` from the [`AutumnError`] and
-/// walks its source chain for the authoritative `SqlState`, mirroring the
-/// downcast strategy in [`is_query_canceled`]. Falls back to string matching so
-/// custom error types that only preserve the message are still classified.
+/// When `err` preserves a `diesel::result::Error`, classification is
+/// structural and authoritative: diesel maps `40001` to
+/// `DatabaseErrorKind::SerializationFailure`, and any *other* `DatabaseErrorKind`
+/// (e.g. `UniqueViolation`) is trusted as non-retryable outright — it is never
+/// string-matched, so a constraint name or key value that happens to contain
+/// `"40001"` cannot misclassify it. `40P01` has no dedicated
+/// `DatabaseErrorKind` and surfaces as `Unknown`; for that one kind, the source
+/// chain's `SqlState` is checked first (locale-independent) and an
+/// English-locale message match is used only as a last resort.
+///
+/// Only when `err` does **not** preserve a `diesel::result::Error` at all (a
+/// custom `E` that only kept the message) does this fall back to scanning the
+/// displayed message and source chain for the two SQLSTATEs.
 fn is_retryable_txn_error(err: &AutumnError) -> bool {
     use tokio_postgres::error::SqlState;
 
@@ -1006,37 +1033,42 @@ fn is_retryable_txn_error(err: &AutumnError) -> bool {
         *state == SqlState::T_R_SERIALIZATION_FAILURE || *state == SqlState::T_R_DEADLOCK_DETECTED
     }
 
-    // Primary path: recover the raw diesel error and inspect it structurally.
     if let Some(diesel_err) = err.downcast_ref::<diesel::result::Error>() {
-        // Fast path: diesel maps 40001 to SerializationFailure. (40P01 is not
-        // mapped, so it is caught by the SqlState/string walk below.)
-        if let diesel::result::Error::DatabaseError(
-            diesel::result::DatabaseErrorKind::SerializationFailure,
-            _,
-        ) = diesel_err
-        {
-            return true;
-        }
-
-        let mut source: Option<&(dyn std::error::Error + 'static)> = Some(diesel_err);
-        while let Some(e) = source {
-            if e.downcast_ref::<tokio_postgres::Error>()
-                .and_then(tokio_postgres::Error::code)
-                .is_some_and(is_retryable_sqlstate)
-            {
-                return true;
+        return match diesel_err {
+            // Fast path: diesel maps 40001 to SerializationFailure.
+            diesel::result::Error::DatabaseError(
+                diesel::result::DatabaseErrorKind::SerializationFailure,
+                _,
+            ) => true,
+            // 40P01 (deadlock) — and, on some paths, 40001 too — has no
+            // dedicated `DatabaseErrorKind` and surfaces as `Unknown`: check
+            // the chain first (locale-independent), then this kind's own
+            // message as a last resort. Scoped to `Unknown` only so an
+            // unrelated kind's message (e.g. a unique-violation's constraint
+            // name) can never trigger a false positive.
+            diesel::result::Error::DatabaseError(
+                diesel::result::DatabaseErrorKind::Unknown,
+                info,
+            ) => {
+                if source_chain_has_sqlstate(diesel_err, is_retryable_sqlstate) {
+                    return true;
+                }
+                let message = info.message().to_lowercase();
+                message.contains("40001")
+                    || message.contains("40p01")
+                    || message.contains("could not serialize access")
+                    || message.contains("deadlock detected")
+                    || message.contains("serialization failure")
             }
-            if e.downcast_ref::<tokio_postgres::error::DbError>()
-                .is_some_and(|db| is_retryable_sqlstate(db.code()))
-            {
-                return true;
-            }
-            source = e.source();
-        }
+            // Any other kind (UniqueViolation, NotNullViolation, ...) is
+            // authoritatively non-retryable — no string matching against its
+            // message/constraint text.
+            _ => source_chain_has_sqlstate(diesel_err, is_retryable_sqlstate),
+        };
     }
 
-    // Fallback: scan the displayed message and its source chain. Covers custom
-    // `E` types whose conversion to `AutumnError` boxed away the diesel error.
+    // Fallback: `E` didn't preserve a `diesel::result::Error` at all — scan the
+    // displayed message and source chain for the two SQLSTATEs.
     let mut haystack = err.to_string().to_lowercase();
     for source in err.source_chain() {
         haystack.push('\n');
@@ -1356,7 +1388,38 @@ impl Db {
             db.tx.attempts = tracing::field::Empty,
         );
 
-        let is_test_tx = self.is_test_tx;
+        if self.is_test_tx {
+            // Under a transactional `TestApp` the connection is already inside
+            // the test harness's outer transaction (`begin_test_transaction`),
+            // so issuing a literal `BEGIN`/`SET TRANSACTION ISOLATION LEVEL`
+            // via `build_transaction()` here would be invalid — Postgres
+            // rejects `SET TRANSACTION ISOLATION LEVEL` inside a
+            // subtransaction, and the retry loop's per-attempt `&mut f`
+            // re-borrow doesn't type-check against the plain `transaction()`
+            // method's lifetime shape (unlike `build_transaction().run()`, its
+            // bound is not scoped to a single call). So: nest via `SAVEPOINT`
+            // instead, exactly like `Db::tx`, running the closure exactly
+            // once — the requested isolation/read-only/deferrable/retry
+            // options are inherited from (or meaningless nested inside) the
+            // outer test transaction, so there is nothing to retry against a
+            // single test-harness connection.
+            use diesel_async::AsyncConnection as _;
+            let registry: Arc<Mutex<Vec<CommitCallback>>> = Arc::new(Mutex::new(Vec::new()));
+            let conn: &mut AsyncPgConnection = &mut self.conn;
+            let result = AFTER_COMMIT_REGISTRY
+                .scope(registry, conn.transaction::<T, E, _>(f))
+                .instrument(span.clone())
+                .await
+                .map_err(Into::into);
+
+            span.record("db.tx.attempts", 1u32);
+            guard.disarmed = true;
+            // `is_test_tx` always suppresses after-commit spawning (matching
+            // `Db::tx`), so the registry is simply dropped without draining.
+            return result;
+        }
+
+        let max_attempts = opts.effective_max_attempts();
         let mut attempt: u32 = 0;
 
         let outcome: Result<T, crate::error::AutumnError> = loop {
@@ -1394,16 +1457,15 @@ impl Db {
 
             match attempt_result {
                 Ok(value) => {
-                    // Commit path: drain THIS attempt's callbacks and spawn them,
-                    // unless we're in a rolled-back transactional test.
-                    if !is_test_tx {
-                        let callbacks: Vec<CommitCallback> = {
-                            let mut reg = registry.lock().expect("registry lock");
-                            std::mem::take(&mut *reg)
-                        };
-                        if !callbacks.is_empty() {
-                            let _ = spawn_committed_after_commit_callbacks(callbacks);
-                        }
+                    // Commit path: drain THIS attempt's callbacks and spawn
+                    // them. (The `is_test_tx` case already returned above, so
+                    // spawning here is always live.)
+                    let callbacks: Vec<CommitCallback> = {
+                        let mut reg = registry.lock().expect("registry lock");
+                        std::mem::take(&mut *reg)
+                    };
+                    if !callbacks.is_empty() {
+                        let _ = spawn_committed_after_commit_callbacks(callbacks);
                     }
                     break Ok(value);
                 }
@@ -1411,7 +1473,7 @@ impl Db {
                     // Convert to AutumnError first, then classify on it.
                     let ae = crate::error::AutumnError::from(e);
                     let retryable = is_retryable_txn_error(&ae);
-                    match retry_decision(attempt, opts.max_attempts, retryable) {
+                    match retry_decision(attempt, max_attempts, retryable) {
                         RetryDecision::Retry => {
                             let retries_total = record_tx_retry();
                             let delay = retry_backoff_delay(
@@ -1422,7 +1484,7 @@ impl Db {
                             tracing::debug!(
                                 parent: &span,
                                 attempt,
-                                max_attempts = opts.max_attempts,
+                                max_attempts,
                                 delay_ms = u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
                                 autumn.tx.retries_total = retries_total,
                                 "retrying transaction after serialization/deadlock failure"
@@ -1438,7 +1500,7 @@ impl Db {
                                 tracing::warn!(
                                     parent: &span,
                                     attempt,
-                                    max_attempts = opts.max_attempts,
+                                    max_attempts,
                                     autumn.tx.retry_exhausted_total = exhausted_total,
                                     "transaction retry budget exhausted; returning final error"
                                 );
@@ -2604,6 +2666,23 @@ mod tests {
         assert_eq!(TxOptions::default().max_attempts(0).max_attempts, 1);
     }
 
+    #[test]
+    fn tx_options_effective_max_attempts_clamps_struct_literal_bypass() {
+        // `max_attempts` is a public field, so struct-literal update syntax can
+        // set it to 0 directly, bypassing the `max_attempts()` builder's clamp.
+        // The retry loop must still treat this as "run once", not "never run".
+        let opts = TxOptions {
+            max_attempts: 0,
+            ..TxOptions::default()
+        };
+        assert_eq!(opts.max_attempts, 0, "the raw field is not itself clamped");
+        assert_eq!(
+            opts.effective_max_attempts(),
+            1,
+            "the retry loop's accessor must clamp a struct-literal 0 to 1"
+        );
+    }
+
     // ── Backoff ──────────────────────────────────────────────────
 
     #[test]
@@ -2696,6 +2775,18 @@ mod tests {
         let err: AutumnError = AutumnError::internal_server_error(diesel_db_error(
             diesel::result::DatabaseErrorKind::UniqueViolation,
             "duplicate key value violates unique constraint",
+        ));
+        assert!(!is_retryable_txn_error(&err));
+    }
+
+    #[test]
+    fn unique_violation_with_magic_substring_in_message_is_not_retryable() {
+        // Regression: a non-retryable `DatabaseErrorKind` must never be
+        // misclassified just because its message/constraint text happens to
+        // contain a magic substring like "40001" or "deadlock detected".
+        let err: AutumnError = AutumnError::internal_server_error(diesel_db_error(
+            diesel::result::DatabaseErrorKind::UniqueViolation,
+            "duplicate key value violates unique constraint \"orders_40001_key\"",
         ));
         assert!(!is_retryable_txn_error(&err));
     }

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -1017,22 +1017,36 @@ fn retry_backoff_delay(initial: Duration, max: Duration, attempt: u32) -> Durati
 /// arbitrary error's displayed message: a `diesel::result::Error` anywhere in
 /// `err`'s source chain (not just the top-level wrapped error — a custom `E`
 /// that wraps a diesel error via `#[source]`/`#[from]` is still found) is
-/// classified by its `DatabaseErrorKind`. diesel maps `40001` to
-/// `SerializationFailure`; any *other* kind (e.g. `UniqueViolation`) is trusted
-/// as non-retryable outright — it is never string-matched, so a constraint
-/// name or key value that happens to contain `"40001"` cannot misclassify it.
-/// `40P01` has no dedicated kind and surfaces as `Unknown`; for that one kind,
-/// the source chain's `SqlState` is checked first (locale-independent) and an
-/// English-locale message match is used only as a last resort.
+/// classified by its `DatabaseErrorKind`. `diesel-async`'s Postgres backend
+/// maps `40001` to `SerializationFailure` directly from the real SQLSTATE (see
+/// `diesel_async::pg::error_helper::from_tokio_postgres_error`) — fully
+/// reliable, no message inspection involved. Any *other* kind (e.g.
+/// `UniqueViolation`) is trusted as non-retryable outright — never
+/// string-matched, so a constraint name or key value that happens to contain
+/// `"40001"` cannot misclassify it.
+///
+/// `40P01` (deadlock) has no dedicated `DatabaseErrorKind` and always surfaces
+/// as `Unknown`. Worse: the wrapper type diesel-async uses to carry Postgres's
+/// error fields for an `Unknown`-kind error (`PostgresDbErrorWrapper`, private
+/// to diesel-async) implements only `DatabaseErrorInformation`, not
+/// `std::error::Error` — so [`source_chain_has_sqlstate`]'s downcast walk can
+/// **never** reach the real SQLSTATE for it; there is no structural path to a
+/// deadlock's code at all through this crate boundary. The only signal
+/// available is the message, so this checks it — but with an **exact**
+/// match, not a substring: Postgres's deadlock detector always raises the
+/// primary message as precisely `"deadlock detected"` with nothing else (the
+/// context lives in DETAIL/HINT, not here), so an app's own `RAISE EXCEPTION`
+/// would have to reproduce that exact string as its *entire* message to
+/// collide — unlike a substring check, which a longer business message
+/// merely mentioning the phrase would already trip.
 ///
 /// When no `diesel::result::Error` is found anywhere in the chain, this checks
 /// for a raw `tokio_postgres` SQLSTATE directly (a custom `E` that bypasses
 /// diesel). If neither is found, the error is **not** retried — there is
-/// deliberately no generic message-substring fallback beyond structured
-/// signals: retrying based on bare text risks misclassifying an unrelated
-/// domain/validation error (e.g. an order id that happens to be `40001`) as a
-/// transient conflict, silently re-running a non-idempotent closure and
-/// delaying the response.
+/// deliberately no generic message-substring fallback beyond the one exact
+/// match above: retrying based on bare text risks misclassifying an unrelated
+/// domain/validation error as a transient conflict, silently re-running a
+/// non-idempotent closure and delaying the response.
 fn is_retryable_txn_error(err: &AutumnError) -> bool {
     use tokio_postgres::error::SqlState;
 
@@ -1042,30 +1056,29 @@ fn is_retryable_txn_error(err: &AutumnError) -> bool {
 
     if let Some(diesel_err) = err.downcast_chain_ref::<diesel::result::Error>() {
         return match diesel_err {
-            // Fast path: diesel maps 40001 to SerializationFailure.
+            // Fast path: diesel-async maps 40001 to SerializationFailure from
+            // the real SQLSTATE. Fully structural, no message involved.
             diesel::result::Error::DatabaseError(
                 diesel::result::DatabaseErrorKind::SerializationFailure,
                 _,
             ) => true,
-            // 40P01 (deadlock) — and, on some paths, 40001 too — has no
-            // dedicated `DatabaseErrorKind` and surfaces as `Unknown`: check
-            // the chain first (locale-independent), then this kind's own
-            // message as a last resort. Scoped to `Unknown` only so an
-            // unrelated kind's message (e.g. a unique-violation's constraint
-            // name) can never trigger a false positive.
+            // 40P01 (deadlock) has no dedicated kind and surfaces as Unknown.
+            // The chain walk is kept for forward-compatibility (a future
+            // diesel/diesel-async release, or another backend, could start
+            // exposing the real SQLSTATE through the source chain) but is
+            // currently unreachable for diesel-async's own Postgres backend
+            // — see the doc comment above. The message check that follows is
+            // therefore the only thing that actually fires deadlock retries
+            // today, hence the exact (not substring) match.
             diesel::result::Error::DatabaseError(
                 diesel::result::DatabaseErrorKind::Unknown,
                 info,
             ) => {
-                if source_chain_has_sqlstate(diesel_err, is_retryable_sqlstate) {
-                    return true;
-                }
-                let message = info.message().to_lowercase();
-                message.contains("40001")
-                    || message.contains("40p01")
-                    || message.contains("could not serialize access")
-                    || message.contains("deadlock detected")
-                    || message.contains("serialization failure")
+                source_chain_has_sqlstate(diesel_err, is_retryable_sqlstate)
+                    || info
+                        .message()
+                        .trim()
+                        .eq_ignore_ascii_case("deadlock detected")
             }
             // Any other kind (UniqueViolation, NotNullViolation, ...) is
             // authoritatively non-retryable — no string matching against its
@@ -2756,8 +2769,9 @@ mod tests {
 
     #[test]
     fn deadlock_is_retryable() {
-        // Postgres 40P01 is not mapped to a dedicated DatabaseErrorKind, so it is
-        // caught via the message/SQLSTATE fallback.
+        // Postgres 40P01 is not mapped to a dedicated DatabaseErrorKind, so it
+        // is caught via an exact match against Postgres's own invariant
+        // primary message for this condition.
         let err: AutumnError = AutumnError::internal_server_error(diesel_db_error(
             diesel::result::DatabaseErrorKind::Unknown,
             "deadlock detected",
@@ -2766,12 +2780,40 @@ mod tests {
     }
 
     #[test]
-    fn sqlstate_40001_string_is_retryable() {
+    fn deadlock_message_is_matched_case_and_whitespace_insensitively() {
+        let err: AutumnError = AutumnError::internal_server_error(diesel_db_error(
+            diesel::result::DatabaseErrorKind::Unknown,
+            "  Deadlock Detected  ",
+        ));
+        assert!(is_retryable_txn_error(&err));
+    }
+
+    #[test]
+    fn unknown_kind_message_merely_mentioning_deadlock_is_not_retryable() {
+        // Regression (PR #1581 review, round 2): an `Unknown`-kind Postgres
+        // error from application SQL (e.g. `RAISE EXCEPTION`) whose message
+        // merely *mentions* "deadlock detected" or "40001" as part of a
+        // longer business message must not be retried -- only an exact match
+        // against Postgres's own invariant primary message counts.
+        let err: AutumnError = AutumnError::internal_server_error(diesel_db_error(
+            diesel::result::DatabaseErrorKind::Unknown,
+            "order 40001 could not be processed: deadlock detected in workflow",
+        ));
+        assert!(!is_retryable_txn_error(&err));
+    }
+
+    #[test]
+    fn unknown_kind_40001_text_alone_is_not_retryable() {
+        // A bare "40001" in an Unknown-kind message is no longer treated as a
+        // retry signal -- genuine 40001s are already reliably classified via
+        // the DatabaseErrorKind::SerializationFailure fast path (diesel-async
+        // maps the real SQLSTATE), so this text pattern is dead weight that
+        // only added false-positive risk.
         let err: AutumnError = AutumnError::internal_server_error(diesel_db_error(
             diesel::result::DatabaseErrorKind::Unknown,
             "ERROR: 40001: could not serialize access",
         ));
-        assert!(is_retryable_txn_error(&err));
+        assert!(!is_retryable_txn_error(&err));
     }
 
     #[test]

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -1013,19 +1013,26 @@ fn retry_backoff_delay(initial: Duration, max: Duration, attempt: u32) -> Durati
 /// (`40P01`) — the two transient errors that are safe to retry by re-running
 /// the whole transaction.
 ///
-/// When `err` preserves a `diesel::result::Error`, classification is
-/// structural and authoritative: diesel maps `40001` to
-/// `DatabaseErrorKind::SerializationFailure`, and any *other* `DatabaseErrorKind`
-/// (e.g. `UniqueViolation`) is trusted as non-retryable outright — it is never
-/// string-matched, so a constraint name or key value that happens to contain
-/// `"40001"` cannot misclassify it. `40P01` has no dedicated
-/// `DatabaseErrorKind` and surfaces as `Unknown`; for that one kind, the source
-/// chain's `SqlState` is checked first (locale-independent) and an
+/// Classification is structural and authoritative, never based on scanning an
+/// arbitrary error's displayed message: a `diesel::result::Error` anywhere in
+/// `err`'s source chain (not just the top-level wrapped error — a custom `E`
+/// that wraps a diesel error via `#[source]`/`#[from]` is still found) is
+/// classified by its `DatabaseErrorKind`. diesel maps `40001` to
+/// `SerializationFailure`; any *other* kind (e.g. `UniqueViolation`) is trusted
+/// as non-retryable outright — it is never string-matched, so a constraint
+/// name or key value that happens to contain `"40001"` cannot misclassify it.
+/// `40P01` has no dedicated kind and surfaces as `Unknown`; for that one kind,
+/// the source chain's `SqlState` is checked first (locale-independent) and an
 /// English-locale message match is used only as a last resort.
 ///
-/// Only when `err` does **not** preserve a `diesel::result::Error` at all (a
-/// custom `E` that only kept the message) does this fall back to scanning the
-/// displayed message and source chain for the two SQLSTATEs.
+/// When no `diesel::result::Error` is found anywhere in the chain, this checks
+/// for a raw `tokio_postgres` SQLSTATE directly (a custom `E` that bypasses
+/// diesel). If neither is found, the error is **not** retried — there is
+/// deliberately no generic message-substring fallback beyond structured
+/// signals: retrying based on bare text risks misclassifying an unrelated
+/// domain/validation error (e.g. an order id that happens to be `40001`) as a
+/// transient conflict, silently re-running a non-idempotent closure and
+/// delaying the response.
 fn is_retryable_txn_error(err: &AutumnError) -> bool {
     use tokio_postgres::error::SqlState;
 
@@ -1033,7 +1040,7 @@ fn is_retryable_txn_error(err: &AutumnError) -> bool {
         *state == SqlState::T_R_SERIALIZATION_FAILURE || *state == SqlState::T_R_DEADLOCK_DETECTED
     }
 
-    if let Some(diesel_err) = err.downcast_ref::<diesel::result::Error>() {
+    if let Some(diesel_err) = err.downcast_chain_ref::<diesel::result::Error>() {
         return match diesel_err {
             // Fast path: diesel maps 40001 to SerializationFailure.
             diesel::result::Error::DatabaseError(
@@ -1067,18 +1074,15 @@ fn is_retryable_txn_error(err: &AutumnError) -> bool {
         };
     }
 
-    // Fallback: `E` didn't preserve a `diesel::result::Error` at all — scan the
-    // displayed message and source chain for the two SQLSTATEs.
-    let mut haystack = err.to_string().to_lowercase();
-    for source in err.source_chain() {
-        haystack.push('\n');
-        haystack.push_str(&source.to_lowercase());
-    }
-    haystack.contains("40001")
-        || haystack.contains("40p01")
-        || haystack.contains("could not serialize access")
-        || haystack.contains("deadlock detected")
-        || haystack.contains("serialization failure")
+    // No `diesel::result::Error` anywhere in the chain — check for a raw
+    // `tokio_postgres` SQLSTATE directly. No text-based fallback beyond this;
+    // see the doc comment above for why.
+    err.downcast_chain_ref::<tokio_postgres::Error>()
+        .and_then(tokio_postgres::Error::code)
+        .is_some_and(is_retryable_sqlstate)
+        || err
+            .downcast_chain_ref::<tokio_postgres::error::DbError>()
+            .is_some_and(|db| is_retryable_sqlstate(db.code()))
 }
 
 /// Run `f` inside a Postgres `SAVEPOINT` on a connection already inside a
@@ -2794,6 +2798,46 @@ mod tests {
     #[test]
     fn plain_internal_error_is_not_retryable() {
         let err = AutumnError::internal_server_error_msg("something unrelated broke");
+        assert!(!is_retryable_txn_error(&err));
+    }
+
+    #[test]
+    fn domain_error_with_magic_substring_and_no_db_error_is_not_retryable() {
+        // Regression (PR #1581 review): a plain domain/validation error — no
+        // diesel::result::Error or tokio_postgres error anywhere in its
+        // chain — must never be retried just because its message happens to
+        // contain a magic substring like "40001" or "deadlock detected".
+        // Retry requires a structured signal, never bare text.
+        let err = AutumnError::bad_request_msg(
+            "order 40001 could not be processed: deadlock detected in workflow",
+        );
+        assert!(!is_retryable_txn_error(&err));
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("app error")]
+    struct WrappedDbError(#[source] diesel::result::Error);
+
+    #[test]
+    fn serialization_failure_wrapped_in_custom_error_is_retryable() {
+        // A custom `E` (e.g. an app error enum with a `#[from] diesel::result::Error`
+        // variant) is not itself a `diesel::result::Error`, so it isn't found by
+        // a top-level-only downcast. `downcast_chain_ref` walks `source()` to
+        // find it, so wrapped diesel errors are still classified structurally
+        // — no need to fall back to message scanning for this common case.
+        let err: AutumnError = AutumnError::internal_server_error(WrappedDbError(diesel_db_error(
+            diesel::result::DatabaseErrorKind::SerializationFailure,
+            "could not serialize access due to read/write dependencies among transactions",
+        )));
+        assert!(is_retryable_txn_error(&err));
+    }
+
+    #[test]
+    fn unique_violation_wrapped_in_custom_error_is_not_retryable() {
+        let err: AutumnError = AutumnError::internal_server_error(WrappedDbError(diesel_db_error(
+            diesel::result::DatabaseErrorKind::UniqueViolation,
+            "duplicate key value violates unique constraint",
+        )));
         assert!(!is_retryable_txn_error(&err));
     }
 

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -79,11 +79,34 @@ pub(crate) fn record_after_commit_failure() -> u64 {
     AFTER_COMMIT_FAILURES_TOTAL.fetch_add(1, Ordering::Relaxed) + 1
 }
 
+/// Total number of transaction retries triggered by a transient serialization
+/// failure (`40001`) or deadlock (`40P01`) since process start.
+///
+/// Incremented by [`Db::tx_with`] each time a retryable transaction error is
+/// re-run under a stronger isolation level. Surfaces contention on the existing
+/// metrics surface (`autumn_tx_retries_total`).
+pub static TX_RETRIES_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+/// Total number of transactions that exhausted their retry budget without
+/// succeeding, since process start. Exposed as `autumn_tx_retry_exhausted_total`.
+pub static TX_RETRY_EXHAUSTED_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn record_tx_retry() -> u64 {
+    TX_RETRIES_TOTAL.fetch_add(1, Ordering::Relaxed) + 1
+}
+
+pub(crate) fn record_tx_retry_exhausted() -> u64 {
+    TX_RETRY_EXHAUSTED_TOTAL.fetch_add(1, Ordering::Relaxed) + 1
+}
+
+/// Guidance appended to the nested-`tx` rejection, naming the supported
+/// alternative for a same-connection nested transaction.
+const NESTED_TX_MESSAGE: &str = "Nested Db::tx calls are not supported; use \
+    autumn_web::db::savepoint(conn, ..) inside the closure for a same-connection savepoint";
+
 pub(crate) fn reject_ambient_after_commit_registry_for_tx() -> Result<(), AutumnError> {
     if AFTER_COMMIT_REGISTRY.try_with(|_| ()).is_ok() {
-        return Err(AutumnError::bad_request_msg(
-            "Nested Db::tx calls are not supported",
-        ));
+        return Err(AutumnError::bad_request_msg(NESTED_TX_MESSAGE));
     }
     Ok(())
 }
@@ -757,6 +780,317 @@ pub fn create_shard_topology(
     Ok(DatabaseTopology::from_pools(primary, replica))
 }
 
+// ── Transaction options, retry, and isolation (issue #1202) ──────────────────
+
+/// Postgres transaction isolation level, requested per call via [`TxOptions`].
+///
+/// `ReadCommitted` is Postgres' default and Autumn's default; the stronger
+/// levels are opt-in on [`Db::tx_with`]. See the transactions guide for what
+/// each level buys and costs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum IsolationLevel {
+    /// Postgres default. Each statement sees rows committed before it began.
+    #[default]
+    ReadCommitted,
+    /// A snapshot fixed at the first query; no non-repeatable or phantom reads.
+    RepeatableRead,
+    /// Full serializability (SSI). Transactions behave as if run one at a time;
+    /// conflicts surface as `40001` and are retried by [`Db::tx_with`].
+    Serializable,
+}
+
+impl IsolationLevel {
+    /// The SQL fragment used in tracing (`db.isolation`).
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadCommitted => "read_committed",
+            Self::RepeatableRead => "repeatable_read",
+            Self::Serializable => "serializable",
+        }
+    }
+}
+
+/// Default number of attempts (including the first) for the retrying isolation
+/// levels. Chosen to match the jobs system's default retry budget.
+const DEFAULT_TX_MAX_ATTEMPTS: u32 = 5;
+
+/// Options for [`Db::tx_with`]: isolation level, access mode, and the automatic
+/// retry policy for transient serialization failures.
+///
+/// [`TxOptions::default`] is byte-for-byte equivalent to today's [`Db::tx`]:
+/// READ COMMITTED, read-write, a single attempt, and no retry.
+///
+/// ```rust
+/// use autumn_web::db::{TxOptions, IsolationLevel};
+///
+/// let opts = TxOptions::serializable().read_only().max_attempts(8);
+/// assert_eq!(opts.isolation, IsolationLevel::Serializable);
+/// assert!(opts.read_only);
+/// assert_eq!(opts.max_attempts, 8);
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct TxOptions {
+    /// Requested isolation level.
+    pub isolation: IsolationLevel,
+    /// Run the transaction `READ ONLY`.
+    pub read_only: bool,
+    /// Add `DEFERRABLE` (only meaningful for `SERIALIZABLE READ ONLY`).
+    pub deferrable: bool,
+    /// Total attempts including the first. `1` disables retry.
+    pub max_attempts: u32,
+    /// Backoff before the first retry; doubles each subsequent retry.
+    pub initial_backoff: Duration,
+    /// Upper bound on any single backoff delay.
+    pub max_backoff: Duration,
+}
+
+impl Default for TxOptions {
+    fn default() -> Self {
+        Self {
+            isolation: IsolationLevel::ReadCommitted,
+            read_only: false,
+            deferrable: false,
+            max_attempts: 1,
+            initial_backoff: Duration::from_millis(5),
+            max_backoff: Duration::from_millis(500),
+        }
+    }
+}
+
+impl TxOptions {
+    /// READ COMMITTED, no retry — identical to [`Db::tx`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// READ COMMITTED (the default), no retry.
+    #[must_use]
+    pub fn read_committed() -> Self {
+        Self {
+            isolation: IsolationLevel::ReadCommitted,
+            ..Self::default()
+        }
+    }
+
+    /// REPEATABLE READ with automatic retry (`serialization_failure` can occur
+    /// at this level too).
+    #[must_use]
+    pub fn repeatable_read() -> Self {
+        Self {
+            isolation: IsolationLevel::RepeatableRead,
+            max_attempts: DEFAULT_TX_MAX_ATTEMPTS,
+            ..Self::default()
+        }
+    }
+
+    /// SERIALIZABLE with automatic retry. This is the correctness-critical
+    /// default: conflicts surface as `40001` and are retried transparently.
+    #[must_use]
+    pub fn serializable() -> Self {
+        Self {
+            isolation: IsolationLevel::Serializable,
+            max_attempts: DEFAULT_TX_MAX_ATTEMPTS,
+            ..Self::default()
+        }
+    }
+
+    /// Set the isolation level, keeping the other options.
+    #[must_use]
+    pub const fn isolation(mut self, level: IsolationLevel) -> Self {
+        self.isolation = level;
+        self
+    }
+
+    /// Run the transaction `READ ONLY`.
+    #[must_use]
+    pub const fn read_only(mut self) -> Self {
+        self.read_only = true;
+        self
+    }
+
+    /// Add `DEFERRABLE` (for `SERIALIZABLE READ ONLY`).
+    #[must_use]
+    pub const fn deferrable(mut self) -> Self {
+        self.deferrable = true;
+        self
+    }
+
+    /// Set the maximum number of attempts (clamped to at least 1). A value of
+    /// `1` disables retry.
+    #[must_use]
+    pub const fn max_attempts(mut self, attempts: u32) -> Self {
+        self.max_attempts = if attempts < 1 { 1 } else { attempts };
+        self
+    }
+
+    /// Set the backoff before the first retry.
+    #[must_use]
+    pub const fn initial_backoff(mut self, delay: Duration) -> Self {
+        self.initial_backoff = delay;
+        self
+    }
+
+    /// Set the ceiling on any single backoff delay.
+    #[must_use]
+    pub const fn max_backoff(mut self, delay: Duration) -> Self {
+        self.max_backoff = delay;
+        self
+    }
+}
+
+/// Whether the retry loop should re-run the closure or return the error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RetryDecision {
+    Retry,
+    Stop,
+}
+
+/// Decide whether a just-failed attempt should be retried.
+///
+/// `attempt` is the 1-indexed number of the attempt that just failed. A retry
+/// happens only when the error is retryable **and** attempts remain.
+const fn retry_decision(attempt: u32, max_attempts: u32, retryable: bool) -> RetryDecision {
+    if retryable && attempt < max_attempts {
+        RetryDecision::Retry
+    } else {
+        RetryDecision::Stop
+    }
+}
+
+/// Deterministic capped exponential backoff base: `initial * 2^(attempt-1)`,
+/// saturating on overflow and capped at `max`.
+///
+/// Mirrors the jobs system's backoff shape (`pg_retry_delay_ms`) plus the cap
+/// idiom from the migrate startup loop. Kept jitter-free so it is unit-testable.
+fn retry_backoff_base(initial: Duration, max: Duration, attempt: u32) -> Duration {
+    // Cap the shift so `2^shift` never overflows and huge attempts saturate.
+    let shift = attempt.saturating_sub(1).min(31);
+    let multiplier = 1u32 << shift;
+    initial.checked_mul(multiplier).unwrap_or(max).min(max)
+}
+
+/// [`retry_backoff_base`] with +/-20% jitter applied, never exceeding `max`.
+///
+/// Jitter decorrelates a thundering herd of transactions all retrying after the
+/// same conflict. Randomness is drawn via `getrandom`, matching
+/// [`crate::cache`]'s `jittered_ttl`; a `getrandom` failure degrades to no
+/// jitter rather than panicking.
+fn retry_backoff_delay(initial: Duration, max: Duration, attempt: u32) -> Duration {
+    let base = retry_backoff_base(initial, max, attempt);
+
+    let mut buf = [0u8; 4];
+    let factor = if getrandom::getrandom(&mut buf).is_ok() {
+        // Map the random u32 into [0, 1], then into the +/-20% band [0.8, 1.2].
+        let unit = f64::from(u32::from_le_bytes(buf)) / f64::from(u32::MAX);
+        0.2_f64.mul_add(2.0_f64.mul_add(unit, -1.0), 1.0)
+    } else {
+        1.0
+    };
+
+    base.mul_f64(factor).min(max)
+}
+
+/// Whether `err` wraps a Postgres serialization failure (`40001`) or deadlock
+/// (`40P01`) — the two transient errors that are safe to retry by re-running
+/// the whole transaction.
+///
+/// Recovers the underlying `diesel::result::Error` from the [`AutumnError`] and
+/// walks its source chain for the authoritative `SqlState`, mirroring the
+/// downcast strategy in [`is_query_canceled`]. Falls back to string matching so
+/// custom error types that only preserve the message are still classified.
+fn is_retryable_txn_error(err: &AutumnError) -> bool {
+    use tokio_postgres::error::SqlState;
+
+    fn is_retryable_sqlstate(state: &SqlState) -> bool {
+        *state == SqlState::T_R_SERIALIZATION_FAILURE || *state == SqlState::T_R_DEADLOCK_DETECTED
+    }
+
+    // Primary path: recover the raw diesel error and inspect it structurally.
+    if let Some(diesel_err) = err.downcast_ref::<diesel::result::Error>() {
+        // Fast path: diesel maps 40001 to SerializationFailure. (40P01 is not
+        // mapped, so it is caught by the SqlState/string walk below.)
+        if let diesel::result::Error::DatabaseError(
+            diesel::result::DatabaseErrorKind::SerializationFailure,
+            _,
+        ) = diesel_err
+        {
+            return true;
+        }
+
+        let mut source: Option<&(dyn std::error::Error + 'static)> = Some(diesel_err);
+        while let Some(e) = source {
+            if e.downcast_ref::<tokio_postgres::Error>()
+                .and_then(tokio_postgres::Error::code)
+                .is_some_and(is_retryable_sqlstate)
+            {
+                return true;
+            }
+            if e.downcast_ref::<tokio_postgres::error::DbError>()
+                .is_some_and(|db| is_retryable_sqlstate(db.code()))
+            {
+                return true;
+            }
+            source = e.source();
+        }
+    }
+
+    // Fallback: scan the displayed message and its source chain. Covers custom
+    // `E` types whose conversion to `AutumnError` boxed away the diesel error.
+    let mut haystack = err.to_string().to_lowercase();
+    for source in err.source_chain() {
+        haystack.push('\n');
+        haystack.push_str(&source.to_lowercase());
+    }
+    haystack.contains("40001")
+        || haystack.contains("40p01")
+        || haystack.contains("could not serialize access")
+        || haystack.contains("deadlock detected")
+        || haystack.contains("serialization failure")
+}
+
+/// Run `f` inside a Postgres `SAVEPOINT` on a connection already inside a
+/// transaction.
+///
+/// Pass the `conn` handed to a [`Db::tx`] / [`Db::tx_with`] closure. The
+/// savepoint is released when `f` returns `Ok`, or rolled back (`ROLLBACK TO
+/// SAVEPOINT`) when it returns `Err` — leaving the surrounding transaction
+/// intact.
+///
+/// This is the supported way to get a nested, partially-rollbackable unit of
+/// work: `Db::tx` itself cannot be re-entered on the same connection (its
+/// closure receives `&mut PooledConnection`, not `&mut Db`), so a same-connection
+/// savepoint can only live here, inside the closure.
+///
+/// # Caveat
+///
+/// After-commit callbacks registered inside the savepoint via
+/// [`register_after_commit`] fire when the **outer** transaction commits,
+/// regardless of whether this savepoint rolled back — the callback registry is
+/// transaction-scoped, not savepoint-scoped.
+///
+/// # Errors
+///
+/// Returns the error from `f`, or a `diesel::result::Error` if the savepoint
+/// itself cannot be established or released.
+pub async fn savepoint<'a, C, T, E, F>(conn: &'a mut C, f: F) -> Result<T, E>
+where
+    // Generic over the connection so it works with the `&mut PooledConnection`
+    // handed to a `tx` closure and the `&mut AsyncPgConnection` handed to a
+    // `tx_with` closure alike.
+    C: diesel_async::AsyncConnection + Send,
+    T: Send + 'a,
+    E: From<diesel::result::Error> + Send + 'a,
+    F: for<'r> FnOnce(&'r mut C) -> scoped_futures::ScopedBoxFuture<'a, 'r, Result<T, E>>
+        + Send
+        + 'a,
+{
+    // `conn.transaction` comes from the `AsyncConnection` bound on `C`.
+    // diesel-async issues SAVEPOINT (not BEGIN) because `conn` is already in a
+    // transaction, and RELEASE / ROLLBACK TO on Ok / Err respectively.
+    conn.transaction(f).await
+}
+
 // ── Db extractor ─────────────────────────────────────────────
 
 /// Connection type managed by the deadpool pool.
@@ -850,10 +1184,12 @@ impl Db {
         &self.span
     }
 
-    /// Run an async closure inside a database transaction.
+    /// Run an async closure inside a database transaction at the default
+    /// isolation level (READ COMMITTED).
     ///
     /// Commits when the closure returns `Ok(_)`, rolls back when it returns
-    /// `Err(_)`.
+    /// `Err(_)`. For a stronger isolation level and/or automatic
+    /// serialization-failure retry, use [`Db::tx_with`].
     ///
     /// # Errors
     ///
@@ -889,7 +1225,7 @@ impl Db {
         }
         if self.tx_depth > 0 {
             return Err(crate::error::AutumnError::bad_request_msg(
-                "Nested Db::tx calls are not supported",
+                NESTED_TX_MESSAGE,
             ));
         }
         reject_ambient_after_commit_registry_for_tx()?;
@@ -906,6 +1242,11 @@ impl Db {
         // read the registry after the `scope` future completes.
         let registry: Arc<Mutex<Vec<CommitCallback>>> = Arc::new(Mutex::new(Vec::new()));
 
+        // NOTE: `tx` keeps its own body rather than delegating to `tx_with`
+        // because the two hand out different connection types. `transaction()`
+        // runs on the pooled `Object` (closure sees `&mut PooledConnection`),
+        // whereas `tx_with` must use `build_transaction()` — only available on
+        // `AsyncPgConnection` — so its closure sees `&mut AsyncPgConnection`.
         let result = AFTER_COMMIT_REGISTRY
             .scope(registry.clone(), self.conn.transaction::<T, E, _>(f))
             .await
@@ -931,6 +1272,187 @@ impl Db {
         }
 
         result
+    }
+
+    /// Run an async closure inside a database transaction with explicit
+    /// [`TxOptions`] — isolation level, read-only/deferrable mode, and automatic
+    /// retry of transient serialization failures (`40001`) and deadlocks
+    /// (`40P01`).
+    ///
+    /// Commits when the closure returns `Ok(_)`, rolls back when it returns
+    /// `Err(_)`. On a retryable failure with attempts remaining, the whole
+    /// closure is re-run after a capped exponential backoff with jitter.
+    ///
+    /// # The closure must be re-runnable
+    ///
+    /// **Because the closure can run more than once, it must be free of
+    /// side effects that are not themselves transactional (or must be
+    /// idempotent).** Database work is rolled back between attempts, and
+    /// after-commit callbacks from failed attempts are discarded — but any
+    /// non-database side effect in the closure body (logging aside — external
+    /// API calls, channel sends, in-memory mutation) will re-execute on each
+    /// retry. Keep such effects out of the closure, or gate them on the final
+    /// success.
+    ///
+    /// # Observability
+    ///
+    /// The transaction runs under a `db.transaction` span carrying
+    /// `db.isolation` and the final `db.tx.attempts` count. Each retry also
+    /// increments [`TX_RETRIES_TOTAL`]; an exhausted retry budget increments
+    /// [`TX_RETRY_EXHAUSTED_TOTAL`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AutumnError`] under the same conditions as [`Db::tx`]. A
+    /// non-retryable error is returned immediately; when the retry budget is
+    /// exhausted, the **final** underlying error is returned (never swallowed).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal after-commit registry mutex is poisoned (only
+    /// possible if a previous thread holding the lock panicked).
+    #[allow(clippy::too_many_lines)]
+    pub async fn tx_with<'a, T, E, F>(
+        &'a mut self,
+        opts: TxOptions,
+        mut f: F,
+    ) -> Result<T, crate::error::AutumnError>
+    where
+        T: Send + 'a,
+        E: From<diesel::result::Error> + Send + Sync + 'a,
+        crate::error::AutumnError: From<E>,
+        // The closure receives `&mut AsyncPgConnection` (not `&mut PooledConnection`
+        // as `tx` does): isolation levels require `build_transaction()`, which is
+        // inherent on `AsyncPgConnection`. Diesel query methods work on either.
+        F: for<'r> FnMut(
+                &'r mut AsyncPgConnection,
+            ) -> scoped_futures::ScopedBoxFuture<'a, 'r, Result<T, E>>
+            + Send
+            + 'a,
+    {
+        if self.tx_poisoned {
+            return Err(crate::error::AutumnError::service_unavailable_msg(
+                "Database connection is in an invalid transaction state",
+            ));
+        }
+        if self.tx_depth > 0 {
+            return Err(crate::error::AutumnError::bad_request_msg(
+                NESTED_TX_MESSAGE,
+            ));
+        }
+        reject_ambient_after_commit_registry_for_tx()?;
+
+        self.tx_depth += 1;
+        let mut guard = TxDepthGuard {
+            depth: &mut self.tx_depth,
+            poisoned: &mut self.tx_poisoned,
+            disarmed: false,
+        };
+
+        let span = tracing::info_span!(
+            "db.transaction",
+            db.system = "postgresql",
+            db.isolation = opts.isolation.as_str(),
+            db.tx.attempts = tracing::field::Empty,
+        );
+
+        let is_test_tx = self.is_test_tx;
+        let mut attempt: u32 = 0;
+
+        let outcome: Result<T, crate::error::AutumnError> = loop {
+            attempt += 1;
+
+            // A fresh registry per attempt: a rolled-back attempt's after-commit
+            // callbacks are discarded simply by dropping this `Arc` undrained.
+            let registry: Arc<Mutex<Vec<CommitCallback>>> = Arc::new(Mutex::new(Vec::new()));
+
+            let attempt_result: Result<T, E> = {
+                // *** LOAD-BEARING ORDER: borrow `f` BEFORE `build_transaction()`.
+                // diesel-async's `TransactionBuilder::run` bounds the closure by
+                // the connection-borrow lifetime; `&mut f`'s region must start
+                // earlier than that borrow or it fails to compile. Do not reorder.
+                let f_ref = &mut f;
+
+                let mut builder = self.conn.build_transaction();
+                builder = match opts.isolation {
+                    IsolationLevel::ReadCommitted => builder.read_committed(),
+                    IsolationLevel::RepeatableRead => builder.repeatable_read(),
+                    IsolationLevel::Serializable => builder.serializable(),
+                };
+                if opts.read_only {
+                    builder = builder.read_only();
+                }
+                if opts.deferrable {
+                    builder = builder.deferrable();
+                }
+
+                AFTER_COMMIT_REGISTRY
+                    .scope(registry.clone(), builder.run::<T, E, _>(f_ref))
+                    .instrument(span.clone())
+                    .await
+            };
+
+            match attempt_result {
+                Ok(value) => {
+                    // Commit path: drain THIS attempt's callbacks and spawn them,
+                    // unless we're in a rolled-back transactional test.
+                    if !is_test_tx {
+                        let callbacks: Vec<CommitCallback> = {
+                            let mut reg = registry.lock().expect("registry lock");
+                            std::mem::take(&mut *reg)
+                        };
+                        if !callbacks.is_empty() {
+                            let _ = spawn_committed_after_commit_callbacks(callbacks);
+                        }
+                    }
+                    break Ok(value);
+                }
+                Err(e) => {
+                    // Convert to AutumnError first, then classify on it.
+                    let ae = crate::error::AutumnError::from(e);
+                    let retryable = is_retryable_txn_error(&ae);
+                    match retry_decision(attempt, opts.max_attempts, retryable) {
+                        RetryDecision::Retry => {
+                            let retries_total = record_tx_retry();
+                            let delay = retry_backoff_delay(
+                                opts.initial_backoff,
+                                opts.max_backoff,
+                                attempt,
+                            );
+                            tracing::debug!(
+                                parent: &span,
+                                attempt,
+                                max_attempts = opts.max_attempts,
+                                delay_ms = u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
+                                autumn.tx.retries_total = retries_total,
+                                "retrying transaction after serialization/deadlock failure"
+                            );
+                            // `registry` drops here → rolled-back attempt's
+                            // after-commit callbacks are discarded; the loop
+                            // then re-runs the closure.
+                            tokio::time::sleep(delay).await;
+                        }
+                        RetryDecision::Stop => {
+                            if retryable {
+                                let exhausted_total = record_tx_retry_exhausted();
+                                tracing::warn!(
+                                    parent: &span,
+                                    attempt,
+                                    max_attempts = opts.max_attempts,
+                                    autumn.tx.retry_exhausted_total = exhausted_total,
+                                    "transaction retry budget exhausted; returning final error"
+                                );
+                            }
+                            break Err(ae);
+                        }
+                    }
+                }
+            }
+        };
+
+        span.record("db.tx.attempts", attempt);
+        guard.disarmed = true;
+        outcome
     }
 }
 
@@ -1058,6 +1580,31 @@ impl Db {
             start_time,
             is_test_tx,
         })
+    }
+
+    /// Check a plain, uninstrumented connection out of `pool` for use in tests.
+    ///
+    /// Unlike the request extractor, this applies no interceptors, statement
+    /// timeout, or route metrics — it exists so integration tests can drive
+    /// [`Db::tx`] / [`Db::tx_with`] directly against a [`crate::test::TestDb`]
+    /// pool without spinning up a full `TestApp`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AutumnError`] if a connection cannot be acquired from `pool`.
+    #[cfg(feature = "test-support")]
+    pub async fn connect_for_test(pool: &Pool<AsyncPgConnection>) -> Result<Self, AutumnError> {
+        Self::checkout(DbCheckoutParams {
+            pool,
+            pool_name: "test",
+            shard: None,
+            statement_timeout: None,
+            route_key: None,
+            metrics: None,
+            slow_query_threshold: std::time::Duration::from_millis(500),
+            interceptors: Vec::new(),
+        })
+        .await
     }
 }
 
@@ -1965,5 +2512,223 @@ mod tests {
         assert_eq!(super::scrub_sql("SELECT 1_000.5_0"), "SELECT ?");
         assert_eq!(super::scrub_sql("SELECT col_5_val"), "SELECT col_5_val");
         assert_eq!(super::scrub_sql("SELECT col_5"), "SELECT col_5");
+    }
+
+    // ── Transaction isolation + retry (issue #1202) ─────────────────
+
+    #[derive(Debug)]
+    struct FakeDbErrorInfo {
+        message: &'static str,
+    }
+
+    impl diesel::result::DatabaseErrorInformation for FakeDbErrorInfo {
+        fn message(&self) -> &str {
+            self.message
+        }
+        fn details(&self) -> Option<&str> {
+            None
+        }
+        fn hint(&self) -> Option<&str> {
+            None
+        }
+        fn table_name(&self) -> Option<&str> {
+            None
+        }
+        fn column_name(&self) -> Option<&str> {
+            None
+        }
+        fn constraint_name(&self) -> Option<&str> {
+            None
+        }
+        fn statement_position(&self) -> Option<i32> {
+            None
+        }
+    }
+
+    fn diesel_db_error(
+        kind: diesel::result::DatabaseErrorKind,
+        message: &'static str,
+    ) -> diesel::result::Error {
+        diesel::result::Error::DatabaseError(kind, Box::new(FakeDbErrorInfo { message }))
+    }
+
+    // ── TxOptions builder ────────────────────────────────────────
+
+    #[test]
+    fn tx_options_default_is_read_committed_no_retry() {
+        let opts = TxOptions::default();
+        assert_eq!(opts.isolation, IsolationLevel::ReadCommitted);
+        assert!(!opts.read_only);
+        assert!(!opts.deferrable);
+        assert_eq!(
+            opts.max_attempts, 1,
+            "default must behave exactly like today's tx(): one attempt, no retry"
+        );
+    }
+
+    #[test]
+    fn tx_options_serializable_enables_retry() {
+        let opts = TxOptions::serializable();
+        assert_eq!(opts.isolation, IsolationLevel::Serializable);
+        assert!(
+            opts.max_attempts > 1,
+            "serializable() should default to retrying since retry is the point"
+        );
+    }
+
+    #[test]
+    fn tx_options_repeatable_read_enables_retry() {
+        let opts = TxOptions::repeatable_read();
+        assert_eq!(opts.isolation, IsolationLevel::RepeatableRead);
+        assert!(opts.max_attempts > 1);
+    }
+
+    #[test]
+    fn tx_options_builder_chains() {
+        let opts = TxOptions::serializable()
+            .read_only()
+            .deferrable()
+            .max_attempts(9)
+            .initial_backoff(Duration::from_millis(3))
+            .max_backoff(Duration::from_millis(30));
+        assert!(opts.read_only);
+        assert!(opts.deferrable);
+        assert_eq!(opts.max_attempts, 9);
+        assert_eq!(opts.initial_backoff, Duration::from_millis(3));
+        assert_eq!(opts.max_backoff, Duration::from_millis(30));
+    }
+
+    #[test]
+    fn tx_options_max_attempts_clamps_to_at_least_one() {
+        // A zero here must never produce a loop that skips the closure entirely.
+        assert_eq!(TxOptions::default().max_attempts(0).max_attempts, 1);
+    }
+
+    // ── Backoff ──────────────────────────────────────────────────
+
+    #[test]
+    fn retry_backoff_base_doubles_per_attempt() {
+        let initial = Duration::from_millis(5);
+        let max = Duration::from_secs(60);
+        assert_eq!(
+            retry_backoff_base(initial, max, 1),
+            Duration::from_millis(5)
+        );
+        assert_eq!(
+            retry_backoff_base(initial, max, 2),
+            Duration::from_millis(10)
+        );
+        assert_eq!(
+            retry_backoff_base(initial, max, 3),
+            Duration::from_millis(20)
+        );
+        assert_eq!(
+            retry_backoff_base(initial, max, 4),
+            Duration::from_millis(40)
+        );
+    }
+
+    #[test]
+    fn retry_backoff_base_caps_at_max() {
+        let initial = Duration::from_millis(5);
+        let max = Duration::from_millis(50);
+        // 5,10,20,40 then capped at 50 for all higher attempts.
+        assert_eq!(
+            retry_backoff_base(initial, max, 5),
+            Duration::from_millis(50)
+        );
+        assert_eq!(retry_backoff_base(initial, max, 40), max);
+        // Huge attempt must not panic on shift overflow.
+        assert_eq!(retry_backoff_base(initial, max, u32::MAX), max);
+    }
+
+    #[test]
+    fn retry_backoff_delay_stays_within_jitter_bounds_and_cap() {
+        let initial = Duration::from_millis(100);
+        let max = Duration::from_secs(10);
+        for attempt in 1..=6u32 {
+            let base = retry_backoff_base(initial, max, attempt);
+            for _ in 0..64 {
+                let d = retry_backoff_delay(initial, max, attempt);
+                // Jitter is +/-20% of base, never exceeding the cap.
+                assert!(
+                    d >= base.mul_f64(0.8) && d <= base.mul_f64(1.2),
+                    "delay {d:?} out of jitter bounds for base {base:?}"
+                );
+                assert!(d <= max, "delay {d:?} exceeded cap {max:?}");
+            }
+        }
+    }
+
+    // ── Retryable-error classification ───────────────────────────
+
+    #[test]
+    fn serialization_failure_is_retryable() {
+        let err: AutumnError = AutumnError::internal_server_error(diesel_db_error(
+            diesel::result::DatabaseErrorKind::SerializationFailure,
+            "could not serialize access due to read/write dependencies among transactions",
+        ));
+        assert!(is_retryable_txn_error(&err));
+    }
+
+    #[test]
+    fn deadlock_is_retryable() {
+        // Postgres 40P01 is not mapped to a dedicated DatabaseErrorKind, so it is
+        // caught via the message/SQLSTATE fallback.
+        let err: AutumnError = AutumnError::internal_server_error(diesel_db_error(
+            diesel::result::DatabaseErrorKind::Unknown,
+            "deadlock detected",
+        ));
+        assert!(is_retryable_txn_error(&err));
+    }
+
+    #[test]
+    fn sqlstate_40001_string_is_retryable() {
+        let err: AutumnError = AutumnError::internal_server_error(diesel_db_error(
+            diesel::result::DatabaseErrorKind::Unknown,
+            "ERROR: 40001: could not serialize access",
+        ));
+        assert!(is_retryable_txn_error(&err));
+    }
+
+    #[test]
+    fn unique_violation_is_not_retryable() {
+        let err: AutumnError = AutumnError::internal_server_error(diesel_db_error(
+            diesel::result::DatabaseErrorKind::UniqueViolation,
+            "duplicate key value violates unique constraint",
+        ));
+        assert!(!is_retryable_txn_error(&err));
+    }
+
+    #[test]
+    fn plain_internal_error_is_not_retryable() {
+        let err = AutumnError::internal_server_error_msg("something unrelated broke");
+        assert!(!is_retryable_txn_error(&err));
+    }
+
+    // ── Attempt accounting ───────────────────────────────────────
+
+    #[test]
+    fn retry_decision_retries_until_attempts_exhausted() {
+        // A retryable error keeps retrying while attempts remain, then stops.
+        let max = 3;
+        assert_eq!(retry_decision(1, max, true), RetryDecision::Retry);
+        assert_eq!(retry_decision(2, max, true), RetryDecision::Retry);
+        assert_eq!(
+            retry_decision(3, max, true),
+            RetryDecision::Stop,
+            "the final attempt must stop even when the error is retryable (exhausted)"
+        );
+    }
+
+    #[test]
+    fn retry_decision_stops_immediately_on_non_retryable() {
+        assert_eq!(retry_decision(1, 5, false), RetryDecision::Stop);
+    }
+
+    #[test]
+    fn retry_decision_single_attempt_never_retries() {
+        // max_attempts == 1 (the default) must behave exactly like today's tx().
+        assert_eq!(retry_decision(1, 1, true), RetryDecision::Stop);
     }
 }

--- a/autumn/src/error.rs
+++ b/autumn/src/error.rs
@@ -683,6 +683,25 @@ impl AutumnError {
         let err: &(dyn std::error::Error + 'static) = self.inner.as_ref();
         err.downcast_ref::<T>()
     }
+
+    /// Try to downcast the inner error, or any error in its `source()` chain,
+    /// to a specific type.
+    ///
+    /// Unlike [`downcast_ref`](Self::downcast_ref), which only inspects the
+    /// top-level wrapped error, this walks the full chain — useful when a
+    /// custom error type wraps a lower-level error (e.g. via
+    /// `#[source]`/`#[from]`) without itself being that type.
+    #[must_use]
+    pub fn downcast_chain_ref<T: std::error::Error + 'static>(&self) -> Option<&T> {
+        let mut current: Option<&(dyn std::error::Error + 'static)> = Some(self.inner.as_ref());
+        while let Some(err) = current {
+            if let Some(t) = err.downcast_ref::<T>() {
+                return Some(t);
+            }
+            current = err.source();
+        }
+        None
+    }
 }
 
 /// Checks whether `err`'s inner error is a Postgres unique-constraint

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -426,6 +426,11 @@ pub use app::{ApiVersion, RegisteredApiVersions};
 #[cfg(feature = "db")]
 pub use db::Db;
 
+/// Transaction options (isolation level + retry policy) and the savepoint
+/// helper for [`Db::tx_with`]. See [`db::TxOptions`].
+#[cfg(feature = "db")]
+pub use db::{IsolationLevel, TxOptions, savepoint};
+
 /// Framework error type and result alias.
 ///
 /// [`AutumnError`] wraps any `Error + Send + Sync` with an HTTP status code.

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -57,6 +57,9 @@ pub use crate::canary::CanaryRoute;
 /// Database connection extractor.
 #[cfg(feature = "db")]
 pub use crate::db::Db;
+/// Transaction isolation levels and retry options for [`crate::db::Db::tx_with`].
+#[cfg(feature = "db")]
+pub use crate::db::{IsolationLevel, TxOptions};
 /// Typed domain event bus publisher extractor. The `Event` trait it works with
 /// lives at [`crate::events::Event`] (kept out of the prelude to avoid clashing
 /// with [`crate::sse::Event`]).

--- a/autumn/src/sharding.rs
+++ b/autumn/src/sharding.rs
@@ -1933,6 +1933,32 @@ impl ShardedDb {
         self.db.tx(f).await
     }
 
+    /// Run an async closure inside a transaction **on this shard** with explicit
+    /// [`TxOptions`](crate::db::TxOptions) (isolation level + retry). Same
+    /// semantics as [`Db::tx_with`](crate::db::Db::tx_with); the transaction
+    /// never spans shards.
+    ///
+    /// # Errors
+    ///
+    /// See [`Db::tx_with`](crate::db::Db::tx_with).
+    pub async fn tx_with<'a, T, E, F>(
+        &'a mut self,
+        opts: crate::db::TxOptions,
+        f: F,
+    ) -> Result<T, AutumnError>
+    where
+        T: Send + 'a,
+        E: From<diesel::result::Error> + Send + Sync + 'a,
+        AutumnError: From<E>,
+        F: for<'r> FnMut(
+                &'r mut diesel_async::AsyncPgConnection,
+            ) -> scoped_futures::ScopedBoxFuture<'a, 'r, Result<T, E>>
+            + Send
+            + 'a,
+    {
+        self.db.tx_with(opts, f).await
+    }
+
     /// Borrow the underlying [`Db`](crate::db::Db) (e.g. to pass to
     /// helpers written against the unsharded extractor).
     pub const fn db_mut(&mut self) -> &mut crate::db::Db {

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -151,6 +151,7 @@ mod test_app_integration;
 mod test_db_integration;
 mod time_zone_integration;
 mod transactional_test_integration;
+mod tx_isolation_retry_integration;
 mod webhook_outbound;
 mod widgets_modal;
 mod widgets_tabs;

--- a/autumn/tests/integration/tx_isolation_retry_integration.rs
+++ b/autumn/tests/integration/tx_isolation_retry_integration.rs
@@ -122,8 +122,19 @@ mod tx_isolation_retry_tests {
         let t1 = tokio::spawn(async move { try_go_off_call(db1, 1, o1, b1).await });
         let t2 = tokio::spawn(async move { try_go_off_call(db2, 2, o2, b2).await });
 
-        let _ = t1.await.expect("task1 join");
-        let _ = t2.await.expect("task2 join");
+        // If either task hits a non-retryable error before reaching the
+        // barrier, its partner would otherwise block on `barrier.wait()`
+        // forever. Bound the whole race so an unexpected failure surfaces as a
+        // clean test failure instead of an indefinite CI hang.
+        tokio::time::timeout(std::time::Duration::from_secs(30), async {
+            let _ = t1.await.expect("task1 join");
+            let _ = t2.await.expect("task2 join");
+        })
+        .await
+        .expect(
+            "write-skew race did not complete within 30s — likely one participant hit a \
+             non-retryable error before reaching the barrier, leaving its partner blocked",
+        );
     }
 
     // ── The falsifiable success-metric test ────────────────────

--- a/autumn/tests/integration/tx_isolation_retry_integration.rs
+++ b/autumn/tests/integration/tx_isolation_retry_integration.rs
@@ -126,15 +126,24 @@ mod tx_isolation_retry_tests {
         // barrier, its partner would otherwise block on `barrier.wait()`
         // forever. Bound the whole race so an unexpected failure surfaces as a
         // clean test failure instead of an indefinite CI hang.
-        tokio::time::timeout(std::time::Duration::from_secs(30), async {
-            let _ = t1.await.expect("task1 join");
-            let _ = t2.await.expect("task2 join");
+        let (r1, r2) = tokio::time::timeout(std::time::Duration::from_secs(30), async {
+            let r1 = t1.await.expect("task1 join");
+            let r2 = t2.await.expect("task2 join");
+            (r1, r2)
         })
         .await
         .expect(
             "write-skew race did not complete within 30s — likely one participant hit a \
              non-retryable error before reaching the barrier, leaving its partner blocked",
         );
+
+        // Both participants must actually commit. If `tx_with` exhausted its
+        // retry budget instead of transparently succeeding (e.g. a regression
+        // in the retry/backoff logic), the later count/retry-counter
+        // assertions could still incidentally pass — so assert directly here
+        // rather than silently discarding either result.
+        r1.expect("participant 1 (doctor id=1) failed to commit its transaction");
+        r2.expect("participant 2 (doctor id=2) failed to commit its transaction");
     }
 
     // ── The falsifiable success-metric test ────────────────────

--- a/autumn/tests/integration/tx_isolation_retry_integration.rs
+++ b/autumn/tests/integration/tx_isolation_retry_integration.rs
@@ -1,0 +1,234 @@
+//! Integration tests for transaction isolation levels + serialization-failure
+//! retry (issue #1202).
+//!
+//! Requires Docker (testcontainers). Run with:
+//!
+//!     cargo test -p autumn --test integration_tests --features db,test-support \
+//!         -- --ignored tx_isolation_retry
+
+#[cfg(all(feature = "db", feature = "test-support"))]
+mod tx_isolation_retry_tests {
+    use autumn_web::db::{Db, TX_RETRIES_TOTAL, TxOptions};
+    use autumn_web::test::TestDb;
+    use diesel::prelude::*;
+    use diesel_async::RunQueryDsl;
+    use scoped_futures::ScopedFutureExt;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+    // `RunQueryDsl` brings a `.load` method into scope that collides with
+    // `AtomicU64::load`; read the counter through a fully-qualified call.
+    fn retries_total() -> u64 {
+        AtomicU64::load(&TX_RETRIES_TOTAL, Ordering::Relaxed)
+    }
+
+    // ── Schema ─────────────────────────────────────────────────
+
+    diesel::table! {
+        oncall_doctors (id) {
+            id -> Int8,
+            name -> Text,
+            on_call -> Bool,
+        }
+    }
+
+    static SETUP: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
+
+    async fn setup(db: &TestDb) {
+        SETUP
+            .get_or_init(|| async {
+                db.execute_sql(
+                    "CREATE TABLE IF NOT EXISTS oncall_doctors (
+                        id BIGSERIAL PRIMARY KEY,
+                        name TEXT NOT NULL,
+                        on_call BOOLEAN NOT NULL
+                    )",
+                )
+                .await;
+            })
+            .await;
+    }
+
+    async fn reset_two_on_call(db: &TestDb) {
+        db.execute_sql("TRUNCATE oncall_doctors RESTART IDENTITY")
+            .await;
+        db.execute_sql(
+            "INSERT INTO oncall_doctors (name, on_call) VALUES ('Alice', true), ('Bob', true)",
+        )
+        .await;
+    }
+
+    async fn on_call_count(db: &TestDb) -> i64 {
+        let mut conn = db.pool().get().await.expect("checkout");
+        oncall_doctors::table
+            .filter(oncall_doctors::on_call.eq(true))
+            .count()
+            .get_result(&mut *conn)
+            .await
+            .expect("count")
+    }
+
+    /// One participant in the write-skew race: read how many doctors are on
+    /// call, and — only if the invariant (>= 1 on call) would still hold —
+    /// take *this* doctor off call. Two of these running concurrently under a
+    /// weak isolation level can both observe "2 on call" and both go off,
+    /// leaving nobody on call (the anomaly).
+    async fn try_go_off_call(
+        mut db: Db,
+        doctor_id: i64,
+        opts: TxOptions,
+        barrier: Arc<tokio::sync::Barrier>,
+    ) -> autumn_web::AutumnResult<()> {
+        // Sync on the FIRST attempt only, so both transactions do their SELECT
+        // before either commits. Retried attempts must not wait (their partner
+        // has already finished) or they would deadlock.
+        let first_attempt = Arc::new(AtomicBool::new(true));
+
+        db.tx_with(opts, move |conn| {
+            let barrier = barrier.clone();
+            let first_attempt = first_attempt.clone();
+            async move {
+                let count: i64 = oncall_doctors::table
+                    .filter(oncall_doctors::on_call.eq(true))
+                    .count()
+                    .get_result(conn)
+                    .await?;
+
+                if first_attempt.swap(false, Ordering::SeqCst) {
+                    barrier.wait().await;
+                }
+
+                if count >= 2 {
+                    diesel::update(oncall_doctors::table.find(doctor_id))
+                        .set(oncall_doctors::on_call.eq(false))
+                        .execute(conn)
+                        .await?;
+                }
+                Ok::<_, autumn_web::AutumnError>(())
+            }
+            .scope_boxed()
+        })
+        .await
+    }
+
+    async fn run_race(db: &TestDb, opts: TxOptions) {
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+
+        let db1 = Db::connect_for_test(&db.pool()).await.expect("db1");
+        let db2 = Db::connect_for_test(&db.pool()).await.expect("db2");
+
+        let (b1, b2) = (barrier.clone(), barrier.clone());
+        let (o1, o2) = (opts, opts);
+        let t1 = tokio::spawn(async move { try_go_off_call(db1, 1, o1, b1).await });
+        let t2 = tokio::spawn(async move { try_go_off_call(db2, 2, o2, b2).await });
+
+        let _ = t1.await.expect("task1 join");
+        let _ = t2.await.expect("task2 join");
+    }
+
+    // ── The falsifiable success-metric test ────────────────────
+
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn read_committed_allows_write_skew_serializable_prevents_it() {
+        let db = TestDb::shared().await;
+        setup(db).await;
+
+        // --- READ COMMITTED: the write-skew anomaly occurs (nobody on call). ---
+        reset_two_on_call(db).await;
+        run_race(db, TxOptions::read_committed()).await;
+        assert_eq!(
+            on_call_count(db).await,
+            0,
+            "under READ COMMITTED the write-skew anomaly leaves nobody on call"
+        );
+
+        // --- SERIALIZABLE + automatic retry: invariant provably preserved. ---
+        reset_two_on_call(db).await;
+        let retries_before = retries_total();
+        run_race(db, TxOptions::serializable()).await;
+        let retries_after = retries_total();
+
+        assert!(
+            on_call_count(db).await >= 1,
+            "under SERIALIZABLE at least one doctor must remain on call — with zero app-side retry code"
+        );
+        assert!(
+            retries_after > retries_before,
+            "a 40001 serialization failure should have been retried automatically"
+        );
+    }
+
+    // ── Savepoint helper ───────────────────────────────────────
+
+    diesel::table! {
+        savepoint_rows (id) {
+            id -> Int8,
+            tag -> Text,
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn savepoint_inner_rollback_preserves_outer_writes() {
+        let db = TestDb::shared().await;
+        db.execute_sql(
+            "CREATE TABLE IF NOT EXISTS savepoint_rows (id BIGSERIAL PRIMARY KEY, tag TEXT NOT NULL)",
+        )
+        .await;
+        db.execute_sql("TRUNCATE savepoint_rows RESTART IDENTITY")
+            .await;
+
+        let mut outer = Db::connect_for_test(&db.pool()).await.expect("db");
+        outer
+            .tx(|conn| {
+                async move {
+                    diesel::insert_into(savepoint_rows::table)
+                        .values(savepoint_rows::tag.eq("outer-before"))
+                        .execute(conn)
+                        .await?;
+
+                    // Inner savepoint that rolls back — must NOT undo the outer row.
+                    let inner: Result<(), autumn_web::AutumnError> =
+                        autumn_web::db::savepoint(conn, |conn| {
+                            async move {
+                                diesel::insert_into(savepoint_rows::table)
+                                    .values(savepoint_rows::tag.eq("inner-doomed"))
+                                    .execute(conn)
+                                    .await?;
+                                Err(autumn_web::AutumnError::internal_server_error_msg(
+                                    "roll back the savepoint",
+                                ))
+                            }
+                            .scope_boxed()
+                        })
+                        .await;
+                    assert!(inner.is_err(), "inner savepoint should have rolled back");
+
+                    diesel::insert_into(savepoint_rows::table)
+                        .values(savepoint_rows::tag.eq("outer-after"))
+                        .execute(conn)
+                        .await?;
+
+                    Ok::<_, autumn_web::AutumnError>(())
+                }
+                .scope_boxed()
+            })
+            .await
+            .expect("outer tx commits");
+
+        let mut conn = db.pool().get().await.expect("checkout");
+        let tags: Vec<String> = savepoint_rows::table
+            .select(savepoint_rows::tag)
+            .order(savepoint_rows::id.asc())
+            .load(&mut *conn)
+            .await
+            .expect("load tags");
+
+        assert_eq!(
+            tags,
+            vec!["outer-before".to_string(), "outer-after".to_string()],
+            "the two outer writes commit; the rolled-back savepoint write is gone"
+        );
+    }
+}

--- a/docs/guide/transactions.md
+++ b/docs/guide/transactions.md
@@ -57,13 +57,152 @@ Hooks executed inside `db.tx` participate in the same database transaction.
 - `Err(_)` rolls back
 - panics unwind through the transaction boundary and do not commit partial work
 
+## Isolation levels and automatic retry
+
+`db.tx` always runs at Postgres' default **READ COMMITTED**. For
+correctness-critical work (ledgers, inventory, uniqueness invariants) you can
+request a stronger isolation level — and have transient conflicts retried
+automatically — with `db.tx_with(TxOptions::…, |conn| …)`:
+
+```rust,no_run
+use autumn_web::prelude::*;
+use autumn_web::db::TxOptions;
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+use scoped_futures::ScopedFutureExt;
+
+async fn transfer(mut db: Db, from: i64, to: i64, cents: i64) -> AutumnResult<()> {
+    // SERIALIZABLE + automatic retry: one argument, no hand-rolled retry loop.
+    db.tx_with(TxOptions::serializable(), |conn| {
+        async move {
+            // ... read balances, check invariants, write both rows ...
+            Ok::<_, AutumnError>(())
+        }
+        .scope_boxed()
+    })
+    .await
+}
+```
+
+### What each level buys — and costs
+
+| Level | Guards against | Cost |
+| --- | --- | --- |
+| `read_committed()` (default) | dirty reads | none — each statement sees the latest committed data, so read-then-write races (lost updates, write skew) are possible |
+| `repeatable_read()` | non-repeatable & phantom reads | a fixed snapshot per transaction; concurrent writers to your rows abort with `40001` |
+| `serializable()` | **all** serialization anomalies, incl. write skew | strongest guarantee; contention surfaces as `40001` and must be retried |
+
+`TxOptions` is a small builder:
+
+```rust
+use autumn_web::db::{TxOptions, IsolationLevel};
+
+let opts = TxOptions::serializable()    // Serializable + retry (max_attempts = 5)
+    .read_only()                        // SET TRANSACTION READ ONLY
+    .max_attempts(10)                   // override the retry budget
+    .initial_backoff(std::time::Duration::from_millis(5));
+assert_eq!(opts.isolation, IsolationLevel::Serializable);
+```
+
+`TxOptions::default()` (and `read_committed()`) is byte-for-byte equivalent to
+`db.tx`: READ COMMITTED, one attempt, no retry. `repeatable_read()` and
+`serializable()` default to a 5-attempt retry budget because retry is the whole
+point at those levels.
+
+### Automatic retry
+
+At REPEATABLE READ and SERIALIZABLE, Postgres rejects transactions that would
+break isolation with a **serialization failure** (`40001`); deadlocks surface as
+`40P01`. `tx_with` classifies these two SQLSTATEs and re-runs the whole closure,
+sleeping a **capped exponential backoff with jitter** between attempts
+(`initial_backoff * 2^(n-1)`, capped at `max_backoff`, ±20% jitter). Any other
+error, and an exhausted retry budget, propagate as today's `AutumnError` — the
+**final** underlying error, never swallowed.
+
+> **The closure must be re-runnable.** Because it can execute more than once, the
+> closure must be free of side effects that are not themselves transactional (or
+> must be idempotent). Database work is rolled back between attempts, and
+> after-commit callbacks from failed attempts are discarded — but any
+> non-database side effect in the body (an external API call, a channel send, an
+> in-memory mutation) will re-run on every retry. Keep such effects out of the
+> closure, or gate them on the final success.
+
+Retries are observable: the transaction runs under a `db.transaction` span
+carrying `db.isolation` and the final `db.tx.attempts` count, and each retry
+increments the process metric `autumn_tx_retries_total` (exhausted budgets
+increment `autumn_tx_retry_exhausted_total`) — both surfaced on the actuator
+health endpoint.
+
+### When SERIALIZABLE + retry, `#[lock_version]`, or `with_lock`?
+
+Autumn gives you three tools for concurrent writes; they compose rather than
+compete (see the [cloud-native guide](./cloud-native.md) for the locking
+attributes):
+
+- **`TxOptions::serializable()` + retry** — the right default when correctness
+  depends on an invariant spanning **multiple rows or tables** that a single-row
+  version check can't see (write skew: two transactions each read a set and
+  write into it). One argument; the database detects the conflict and `tx_with`
+  retries.
+- **`#[lock_version]` optimistic locking** — best for **low-contention,
+  single-row** updates through the generated repository. No stronger isolation
+  needed; a stale write returns `RepositoryError::Conflict` (HTTP 409) for the
+  client to retry.
+- **`with_lock` pessimistic locking** — best for a **hot single row** where you
+  want to serialize writers explicitly with `SELECT … FOR UPDATE` and avoid
+  wasted retry work.
+
 ## Nesting policy
 
-Nested `Db::tx` calls are currently **rejected at runtime** with:
+Nested `Db::tx` / `Db::tx_with` calls are **rejected at runtime**:
 
-`Nested Db::tx calls are not supported`
+`Nested Db::tx calls are not supported; use autumn_web::db::savepoint(conn, ..) inside the closure for a same-connection savepoint`
 
-This avoids ambiguity and keeps transaction boundaries explicit.
+`Db::tx` cannot be re-entered on the same connection — its closure receives
+`&mut PooledConnection`, not `&mut Db` — and a second `Db` is a *separate*
+connection, which a savepoint cannot model. Keep transaction boundaries explicit
+and reach for a savepoint (below) when you need a partial rollback.
+
+### Savepoints via `savepoint`
+
+For a nested, partially-rollbackable unit of work on the **same** connection,
+call `autumn_web::db::savepoint(conn, |conn| …)` inside a `tx`/`tx_with` closure.
+It issues a Postgres `SAVEPOINT`, releasing it when your closure returns `Ok` and
+rolling back to it (`ROLLBACK TO SAVEPOINT`) on `Err` — leaving the surrounding
+transaction intact:
+
+```rust,no_run
+use autumn_web::prelude::*;
+use autumn_web::db::savepoint;
+use scoped_futures::ScopedFutureExt;
+
+async fn with_optional_step(mut db: Db) -> AutumnResult<()> {
+    db.tx(|conn| {
+        async move {
+            // ... required write on the outer transaction ...
+
+            // Optional step: if it fails, roll back only this savepoint.
+            let _ = savepoint(conn, |conn| {
+                async move {
+                    // ... best-effort write ...
+                    Ok::<_, AutumnError>(())
+                }
+                .scope_boxed()
+            })
+            .await;
+
+            // ... more outer-transaction work; commits regardless of the savepoint ...
+            Ok::<_, AutumnError>(())
+        }
+        .scope_boxed()
+    })
+    .await
+}
+```
+
+> After-commit callbacks registered inside a savepoint fire when the **outer**
+> transaction commits, regardless of whether the savepoint rolled back — the
+> callback registry is transaction-scoped, not savepoint-scoped.
 
 ---
 

--- a/docs/guide/transactions.md
+++ b/docs/guide/transactions.md
@@ -133,6 +133,16 @@ increments the process metric `autumn_tx_retries_total` (exhausted budgets
 increment `autumn_tx_retry_exhausted_total`) — both surfaced on the actuator
 health endpoint.
 
+> **Under a transactional test** (`TestApp::with_transactional_db`), the
+> connection is already inside the test harness's own outer transaction, so
+> `tx_with` nests via `SAVEPOINT` — exactly like `Db::tx` — and runs the
+> closure exactly once, ignoring the requested isolation level and retry
+> budget. Postgres rejects `SET TRANSACTION ISOLATION LEVEL` inside a
+> subtransaction, and there's nothing meaningful to retry against a single
+> test-harness connection. Test the *closure's logic*; verify isolation/retry
+> behavior itself against a real Postgres instance (see the `#[ignore]`d
+> integration tests in `tests/integration/tx_isolation_retry_integration.rs`).
+
 ### When SERIALIZABLE + retry, `#[lock_version]`, or `with_lock`?
 
 Autumn gives you three tools for concurrent writes; they compose rather than


### PR DESCRIPTION
Adds `Db::tx_with(TxOptions, closure)` for running transactions at explicit isolation levels (READ COMMITTED, REPEATABLE READ, SERIALIZABLE) with automatic retry of transient serialization failures (`40001`) and deadlocks (`40P01`).

## Key Changes

- **New `TxOptions` builder** for configuring isolation level, read-only/deferrable mode, and retry policy (max attempts, backoff strategy)
  - `TxOptions::default()` / `read_committed()` — READ COMMITTED, no retry (equivalent to existing `Db::tx`)
  - `TxOptions::repeatable_read()` — REPEATABLE READ with 5-attempt retry budget
  - `TxOptions::serializable()` — SERIALIZABLE with 5-attempt retry budget
  - Chainable methods: `.read_only()`, `.deferrable()`, `.max_attempts(n)`, `.initial_backoff()`, `.max_backoff()`

- **New `Db::tx_with()` method** implementing the retry loop
  - Classifies retryable errors (`40001` / `40P01`) via `is_retryable_txn_error()` helper
  - Sleeps capped exponential backoff with ±20% jitter between attempts
  - Records metrics: `TX_RETRIES_TOTAL` (per retry), `TX_RETRY_EXHAUSTED_TOTAL` (budget exhausted)
  - Surfaces `db.isolation` and `db.tx.attempts` in tracing spans
  - Under transactional tests, nests via SAVEPOINT (ignoring isolation/retry options)

- **New `savepoint()` helper** for same-connection nested transactions
  - Wraps `AsyncConnection::transaction()` to issue SAVEPOINT instead of BEGIN
  - Rolls back on error, releases on success
  - After-commit callbacks fire on outer transaction commit (not savepoint-scoped)

- **Refactored error classification** with `source_chain_has_sqlstate()`
  - Shared by `is_query_canceled()` and `is_retryable_txn_error()`
  - Walks error source chain downcasting to `tokio_postgres::Error` and `DbError`
  - Locale-independent SQLSTATE matching with English-locale message fallback

- **Updated documentation** (`docs/guide/transactions.md`)
  - Isolation level comparison table (guards against / cost)
  - Retry semantics and closure re-runnability requirement
  - Guidance on SERIALIZABLE + retry vs. `#[lock_version]` vs. `with_lock`
  - Test harness behavior (SAVEPOINT nesting, no retry)

- **Integration tests** (`tests/integration/tx_isolation_retry_integration.rs`)
  - Write-skew race demonstrating READ COMMITTED anomaly vs. SERIALIZABLE prevention
  - Savepoint rollback preserving outer transaction writes
  - Marked `#[ignore]` (requires Docker/testcontainers)

- **Metrics exposure** in actuator health endpoint
  - `autumn_tx_retries_total`
  - `autumn_tx_retry_exhausted_total`

- **Extended `ShardedDb::tx_with()`** for sharded transactions (same semantics, never spans shards)

- **Test helper** `Db::connect_for_test()` for driving `tx` / `tx_with` directly against `TestDb` pools without a full `TestApp`

## Implementation Details

- Closure receives `&mut AsyncPgConnection` (not `&mut PooledConnection`) to access `build_transaction()` for isolation level configuration
- Per-attempt after-commit registry: rolled-back attempts' callbacks are discarded by dropping the `Arc` undrained
- Load-bearing borrow order in retry loop: `&mut f` must be borrowed before `build_transaction()` to satisfy diesel-async's lifetime bounds
- Nested error classification: diesel's `DatabaseErrorKind::SerializationFailure` fast-path, then source chain SQLSTATE check, then message fallback (only for `Unknown` kind to avoid false positives)
- Back

https://claude.ai/code/session_01FzMEWshJNyuBYQWuP5B7jA