### PR TITLE
👺 Havoc: [Idempotency TTL Overflow Panic]

### DIFF
--- a/autumn/src/idempotency.rs
+++ b/autumn/src/idempotency.rs
@@ -467,7 +467,9 @@ impl IdempotencyStore for MemoryIdempotencyStore {
         let entry = IdempotencyEntry {
             record,
             body_hash,
-            expires_at: Instant::now() + ttl,
+            expires_at: Instant::now()
+                .checked_add(ttl)
+                .unwrap_or_else(|| Instant::now() + Duration::from_secs(86_400)),
         };
         let mut entries = self.entries.write().unwrap();
         entries.insert(key.to_owned(), entry);
@@ -504,7 +506,9 @@ impl IdempotencyStore for MemoryIdempotencyStore {
             key.to_owned(),
             MemoryInFlightLock {
                 owner: owner.to_owned(),
-                expires_at: now + ttl,
+                expires_at: now
+                    .checked_add(ttl)
+                    .unwrap_or_else(|| now + Duration::from_secs(86_400)),
             },
         );
         true

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -544,7 +544,7 @@ fn build_router_pre_state(
         ctx.error_page_renderer,
         ctx.session_store,
         route_timeouts,
-        load_shed_layer.clone(),
+        load_shed_layer,
     )?;
 
     if dev_reload_enabled {

--- a/autumn/tests/integration/chaos_idempotency_ttl_crash.rs
+++ b/autumn/tests/integration/chaos_idempotency_ttl_crash.rs
@@ -1,0 +1,22 @@
+use autumn_web::idempotency::{IdempotencyRecord, IdempotencyStore, MemoryIdempotencyStore};
+use std::time::Duration;
+
+#[test]
+fn idempotency_ttl_overflow_crash() {
+    let store = MemoryIdempotencyStore::new(Duration::from_secs(10));
+    let rec = IdempotencyRecord {
+        status: 200,
+        headers: vec![],
+        body: vec![],
+        metadata: vec![],
+    };
+    // Should panic if Instant::now() + Duration::MAX is executed
+    store.set("key", rec, vec![], Duration::MAX);
+}
+
+#[test]
+fn idempotency_lock_ttl_overflow_crash() {
+    let store = MemoryIdempotencyStore::new(Duration::from_secs(10));
+    // Should panic if Instant::now() + Duration::MAX is executed
+    store.try_lock("key_lock", Duration::MAX);
+}

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -21,6 +21,7 @@ mod chaos_channels_loom;
 mod chaos_channels_proptest;
 #[cfg(feature = "ws")]
 mod chaos_channels_subscribe_loom;
+mod chaos_idempotency_ttl_crash;
 mod chaos_metrics_compute_percentiles_proptest;
 mod chaos_metrics_leak;
 mod chaos_metrics_leak_loom;


### PR DESCRIPTION
🧨 **The Trigger:** Passing an extremely large `Duration` to `MemoryIdempotencyStore` methods `set` and `try_lock_owned` causes `Instant::now() + ttl` to panic due to arithmetic overflow.
📉 **The Stack Trace:** `panicked at ... library/std/src/time.rs:429:33: overflow when adding duration to instant`
🧪 **Reproduction:** Run `cargo test -p autumn-web --test integration_tests -- chaos_idempotency_ttl_crash`
😈 **Comment:** You assumed TTLs would never be larger than what an Instant can hold. You were wrong.

---
*PR created automatically by Jules for task [2106698065947016470](https://jules.google.com/task/2106698065947016470) started by @madmax983*