### PR TITLE
feat(cli): Tauri mobile thin-client mode via --remote-url (Option A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **generator:** `autumn generate tauri --remote-url <URL>` scaffolds a
+  **mobile thin-client** Tauri shell (issue #1506): the webview loads your
+  remote HTTPS Autumn server directly (https enforced; `localhost`/`127.0.0.1`/
+  `::1` exempt for dev, embedded userinfo rejected), a
+  `capabilities/remote-app.json` grants exactly that origin access to native
+  device APIs, and `tauri-plugin-notification`/`tauri-plugin-biometric`
+  (target-gated to Android/iOS, with a generated `Info.ios.plist` carrying
+  `NSFaceIDUsageDescription`)/`tauri-plugin-store` are pre-registered to
+  satisfy App Store Guideline 4.2 (Minimum Functionality). The shell crate is
+  named `{package}-mobile` with `staticlib`/`cdylib` crate types for
+  `cargo tauri android/ios init`; no sidecar, staging scripts, or per-OS
+  overlay confs are emitted, and `autumn destroy tauri --remote-url <URL>`
+  reverts the scaffold. Desktop `autumn generate tauri` output is unchanged.
+  See `docs/guide/tauri-mobile-thin-client.md` for routing, capability, and
+  cookie/`Authorization`-token session-handoff guidance.
+
 - **generator:** `autumn generate scaffold`'s `create`/`update` handlers now
   build a `Changeset` from the submission and re-render the `new`/`edit`
   form on a rejected submission (issue #1124). A failed submission responds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`capabilities/remote-app.json`, plus `remote-app-mobile.json` restricting
   the biometric grant to Android/iOS so desktop smoke-test builds still
   pass), and `autumn destroy tauri --remote-url <URL>` reverts the
-  scaffold. Desktop `autumn generate tauri` output is unchanged. See
+  scaffold. Desktop `autumn generate tauri` output is unchanged. Generating
+  one Tauri mode over the other's files is rejected (even with `--force`,
+  which only overwrites within the same mode) with a pointer at the matching
+  `autumn destroy tauri [--remote-url <URL>]` to run first — mixing modes
+  would leave stale files that break the new scaffold's build. See
   `docs/guide/tauri-mobile-thin-client.md`.
 
 - **generator:** `autumn generate scaffold`'s `create`/`update` handlers now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **generator:** `autumn generate tauri --remote-url <URL>` scaffolds a
   **mobile thin-client** Tauri shell (issue #1506): the webview loads your
   remote HTTPS Autumn server directly (https enforced; loopback and
-  Android-emulator hosts exempt for dev), a `capabilities/remote-app.json`
-  grants exactly that origin access to the notification/biometric/store
-  plugins, and `autumn destroy tauri --remote-url <URL>` reverts the
+  Android-emulator hosts exempt for dev), capability files grant exactly
+  that origin access to the notification/biometric/store plugins
+  (`capabilities/remote-app.json`, plus `remote-app-mobile.json` restricting
+  the biometric grant to Android/iOS so desktop smoke-test builds still
+  pass), and `autumn destroy tauri --remote-url <URL>` reverts the
   scaffold. Desktop `autumn generate tauri` output is unchanged. See
   `docs/guide/tauri-mobile-thin-client.md`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **generator:** `autumn generate tauri --remote-url <URL>` scaffolds a
   **mobile thin-client** Tauri shell (issue #1506): the webview loads your
-  remote HTTPS Autumn server directly (https enforced; `localhost`/`127.0.0.1`/
-  `::1` exempt for dev, embedded userinfo rejected), a
-  `capabilities/remote-app.json` grants exactly that origin access to native
-  device APIs, and `tauri-plugin-notification`/`tauri-plugin-biometric`
-  (target-gated to Android/iOS, with a generated `Info.ios.plist` carrying
-  `NSFaceIDUsageDescription`)/`tauri-plugin-store` are pre-registered to
-  satisfy App Store Guideline 4.2 (Minimum Functionality). The shell crate is
-  named `{package}-mobile` with `staticlib`/`cdylib` crate types for
-  `cargo tauri android/ios init`; no sidecar, staging scripts, or per-OS
-  overlay confs are emitted, and `autumn destroy tauri --remote-url <URL>`
-  reverts the scaffold. Desktop `autumn generate tauri` output is unchanged.
-  See `docs/guide/tauri-mobile-thin-client.md` for routing, capability, and
-  cookie/`Authorization`-token session-handoff guidance.
+  remote HTTPS Autumn server directly (https enforced; loopback and
+  Android-emulator hosts exempt for dev), a `capabilities/remote-app.json`
+  grants exactly that origin access to the notification/biometric/store
+  plugins, and `autumn destroy tauri --remote-url <URL>` reverts the
+  scaffold. Desktop `autumn generate tauri` output is unchanged. See
+  `docs/guide/tauri-mobile-thin-client.md`.
 
 - **generator:** `autumn generate scaffold`'s `create`/`update` handlers now
   build a `Changeset` from the submission and re-render the `new`/`edit`

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -1377,8 +1377,9 @@ Required prerequisites for `cargo tauri build`:\n\
 /// Compute the file actions for `autumn generate tauri --remote-url <URL>` —
 /// the **mobile thin-client** mode: the webview loads a remote HTTPS Autumn
 /// server directly (no sidecar binary, no staging scripts, no local database),
-/// and a `capabilities/remote-app.json` grants the remote origin access to the
-/// notification/biometric/store plugins.
+/// and capability files (`capabilities/remote-app.json` plus the
+/// mobile-platform-restricted `remote-app-mobile.json`) grant the remote
+/// origin access to the notification/biometric/store plugins.
 ///
 /// # Errors
 /// Returns [`GenerateError::NotInProject`] when not at a project root, or
@@ -1428,12 +1429,21 @@ pub fn plan_tauri_thin_client(
         render_thin_client_lib_rs(&package_name, normalized_url),
     );
 
-    // Capability grant: pages served from the remote origin may invoke the
+    // Capability grants: pages served from the remote origin may invoke the
     // permitted plugin commands. Auto-discovered by tauri-build from
-    // src-tauri/capabilities/.
+    // src-tauri/capabilities/. The biometric grant lives in a separate,
+    // platform-restricted capability because tauri-build validates every
+    // applicable capability's permissions against the plugins compiled for
+    // the current target — and tauri-plugin-biometric is target-gated to
+    // Android/iOS in the generated Cargo.toml, so an unrestricted
+    // `biometric:default` would break desktop smoke-test builds.
     plan.create(
         tauri.join("capabilities").join("remote-app.json"),
         render_thin_client_capability(&remote_origin),
+    );
+    plan.create(
+        tauri.join("capabilities").join("remote-app-mobile.json"),
+        render_thin_client_capability_mobile(&remote_origin),
     );
 
     // iOS usage-description plist — the biometric plugin hard-requires
@@ -1640,8 +1650,9 @@ fn render_thin_client_lib_rs(package_name: &str, remote_url: &str) -> String {
 //! The webview loads the remote Autumn server at {remote_url} directly —
 //! there is no local sidecar binary, no local database, and no staging step.
 //! Native device capabilities (notifications, biometric authentication,
-//! key-value storage) are exposed to the remote pages through
-//! `capabilities/remote-app.json`.
+//! key-value storage) are exposed to the remote pages through the files in
+//! `capabilities/` (biometric is granted only on Android/iOS, where the
+//! plugin exists).
 //!
 //! Trust model: pages served from the remote origin can invoke every plugin
 //! command that capability permits — the origin is fully trusted. Keep the
@@ -1682,18 +1693,23 @@ pub fn run() {{
 }
 
 /// `capabilities/remote-app.json` — grants pages served from exactly
-/// `remote_origin` access to the core APIs and the notification, biometric,
-/// and store plugin commands. Never emit a wildcard here: any page the
-/// listed origins serve can invoke these device APIs.
+/// `remote_origin` access to the core APIs and the notification and store
+/// plugin commands. Never emit a wildcard here: any page the listed origins
+/// serve can invoke these device APIs.
 ///
 /// `core:default` is kept (rather than a narrower core subset) because the
 /// injected `window.__TAURI__` API relies on the core event/window plumbing
 /// it permits; prune it only after verifying the trimmed set on a device.
+///
+/// The biometric grant is deliberately absent — it lives in the
+/// platform-restricted [`render_thin_client_capability_mobile`] file, because
+/// tauri-build rejects permissions of plugins not compiled for the current
+/// target and tauri-plugin-biometric only exists on Android/iOS.
 fn render_thin_client_capability(remote_origin: &str) -> String {
     format!(
         r#"{{
   "identifier": "remote-autumn-app",
-  "description": "Allow pages served by the remote Autumn server to use the native device plugins (notifications, biometric authentication, key-value storage).",
+  "description": "Allow pages served by the remote Autumn server to use the native device plugins (notifications, key-value storage).",
   "windows": ["main"],
   "remote": {{
     "urls": ["{remote_origin}"]
@@ -1701,8 +1717,33 @@ fn render_thin_client_capability(remote_origin: &str) -> String {
   "permissions": [
     "core:default",
     "notification:default",
-    "biometric:default",
     "store:default"
+  ]
+}}
+"#
+    )
+}
+
+/// `capabilities/remote-app-mobile.json` — the Android/iOS-only companion to
+/// [`render_thin_client_capability`]: grants the same single remote origin the
+/// biometric plugin commands. It is restricted via `platforms` because the
+/// capability schema has no per-permission platform scoping and tauri-build
+/// validates every applicable capability against the plugins compiled for the
+/// current target — tauri-plugin-biometric is target-gated to mobile in the
+/// generated Cargo.toml, so granting `biometric:default` in an unrestricted
+/// capability would fail desktop `cargo tauri dev`/`build` smoke tests.
+fn render_thin_client_capability_mobile(remote_origin: &str) -> String {
+    format!(
+        r#"{{
+  "identifier": "remote-autumn-app-mobile",
+  "description": "Allow pages served by the remote Autumn server to use biometric authentication (Android/iOS only — the plugin does not exist on desktop).",
+  "platforms": ["android", "iOS"],
+  "windows": ["main"],
+  "remote": {{
+    "urls": ["{remote_origin}"]
+  }},
+  "permissions": [
+    "biometric:default"
   ]
 }}
 "#
@@ -1760,8 +1801,9 @@ Next steps for the mobile thin client (webview → {remote_url}):\n\
 \n\
   5. Serve your Autumn app at {remote_url} over HTTPS with a valid TLS\n\
      certificate and `session.secure = true` (AUTUMN_SESSION__SECURE=true) in\n\
-     production. The capability file src-tauri/capabilities/remote-app.json\n\
-     grants exactly that origin access to the native device plugins.\n\
+     production. The capability files under src-tauri/capabilities/ grant\n\
+     exactly that origin access to the native device plugins (biometric is\n\
+     granted only on Android/iOS, where the plugin exists).\n\
 \n\
   6. Replace the placeholder icons before shipping:\n\
        cargo tauri icon static/icons/icon.svg   (from the app root)\n\
@@ -4842,6 +4884,7 @@ mod tests {
                 "src-tauri/Cargo.toml",
                 "src-tauri/Info.ios.plist",
                 "src-tauri/build.rs",
+                "src-tauri/capabilities/remote-app-mobile.json",
                 "src-tauri/capabilities/remote-app.json",
                 "src-tauri/icons/128x128.png",
                 "src-tauri/icons/128x128@2x.png",
@@ -4881,17 +4924,52 @@ mod tests {
     fn thin_client_capability_file_grants_plugin_permissions() {
         let (_tmp, plan) = thin_plan("https://app.example.com");
         let cap = created_str(&plan, "capabilities/remote-app.json");
-        for permission in [
-            "core:default",
-            "notification:default",
-            "biometric:default",
-            "store:default",
-        ] {
-            assert!(
-                cap.contains(permission),
-                "capability file must grant '{permission}':\n{cap}"
-            );
-        }
+        let parsed: serde_json::Value =
+            serde_json::from_str(cap).expect("capability file must be valid JSON");
+        assert_eq!(
+            parsed["permissions"],
+            serde_json::json!(["core:default", "notification:default", "store:default"]),
+            "base capability must grant exactly the plugins compiled on every \
+             target — biometric is mobile-only and lives in remote-app-mobile.json"
+        );
+        assert!(
+            parsed.get("platforms").is_none(),
+            "base capability must apply to all platforms (no 'platforms' key):\n{cap}"
+        );
+    }
+
+    #[test]
+    fn thin_client_mobile_capability_gates_biometric_to_mobile_platforms() {
+        // tauri-build validates every capability's permissions against the
+        // plugins compiled for the current target; tauri-plugin-biometric is
+        // target-gated to Android/iOS in the generated Cargo.toml, so a
+        // desktop build would fail on an unknown `biometric:default` unless
+        // the grant lives in a capability restricted to mobile platforms.
+        let (_tmp, plan) = thin_plan("https://app.example.com");
+        let cap = created_str(&plan, "capabilities/remote-app-mobile.json");
+        let parsed: serde_json::Value =
+            serde_json::from_str(cap).expect("mobile capability file must be valid JSON");
+        assert_eq!(
+            parsed["platforms"],
+            serde_json::json!(["android", "iOS"]),
+            "mobile capability must be restricted to the platforms that \
+             compile tauri-plugin-biometric"
+        );
+        assert_eq!(
+            parsed["permissions"],
+            serde_json::json!(["biometric:default"]),
+            "mobile capability must grant exactly the biometric permission"
+        );
+        assert_eq!(
+            parsed["remote"]["urls"],
+            serde_json::json!(["https://app.example.com"]),
+            "mobile capability must grant the same single remote origin"
+        );
+        assert_eq!(
+            parsed["windows"],
+            serde_json::json!(["main"]),
+            "mobile capability must be scoped to the main window"
+        );
     }
 
     #[test]
@@ -5091,13 +5169,18 @@ mod tests {
         // The capability grant must be the path-free origin, while the
         // webview still loads the full URL including its path.
         let (_tmp, plan) = thin_plan("https://app.example.com:8443/base/");
-        let cap = created_str(&plan, "capabilities/remote-app.json");
-        let parsed: serde_json::Value = serde_json::from_str(cap).unwrap();
-        assert_eq!(
-            parsed["remote"]["urls"],
-            serde_json::json!(["https://app.example.com:8443"]),
-            "capability must grant the origin only — no path, no trailing slash"
-        );
+        for capability_file in [
+            "capabilities/remote-app.json",
+            "capabilities/remote-app-mobile.json",
+        ] {
+            let cap = created_str(&plan, capability_file);
+            let parsed: serde_json::Value = serde_json::from_str(cap).unwrap();
+            assert_eq!(
+                parsed["remote"]["urls"],
+                serde_json::json!(["https://app.example.com:8443"]),
+                "{capability_file} must grant the origin only — no path, no trailing slash"
+            );
+        }
         let lib = created_str(&plan, "src/lib.rs");
         assert!(
             lib.contains("https://app.example.com:8443/base/"),

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -479,9 +479,19 @@ fn resolve_bin_name(
     )))
 }
 
-fn read_package_meta(
+/// Parse `Cargo.toml` and return `(package_name, version, parsed_doc)` — the
+/// subset of package metadata that does **not** require a resolvable binary
+/// target. The thin-client planner uses this directly: it never builds or
+/// spawns a sidecar, so a library-only package or a multi-`[[bin]]` package
+/// without `default-run` is a perfectly fine thin-client host and must not
+/// be blocked by sidecar-target validation (issue #1506 review).
+///
+/// `version` resolves workspace inheritance: if `[package] version.workspace
+/// = true` the function walks up the directory tree to find
+/// `[workspace.package] version` in an ancestor `Cargo.toml`.
+fn read_package_name_version(
     project_root: &Path,
-) -> Result<(String, String, String, bool, String), GenerateError> {
+) -> Result<(String, String, toml::Value), GenerateError> {
     let cargo_path = project_root.join("Cargo.toml");
     let content = std::fs::read_to_string(&cargo_path).map_err(GenerateError::Io)?;
     let doc: toml::Value = toml::from_str(&content)
@@ -505,6 +515,17 @@ fn read_package_meta(
         }
         _ => "0.1.0".to_owned(),
     };
+
+    Ok((name, version, doc))
+}
+
+fn read_package_meta(
+    project_root: &Path,
+) -> Result<(String, String, String, bool, String), GenerateError> {
+    let (name, version, doc) = read_package_name_version(project_root)?;
+    let pkg = doc
+        .get("package")
+        .ok_or_else(|| GenerateError::Config("Cargo.toml missing [package].name".to_owned()))?;
 
     let default_run = pkg
         .get("default-run")
@@ -1492,8 +1513,10 @@ pub fn plan_tauri_thin_client(
     // doc comment. The raw flag value is not.
     let normalized_url = validated.as_str();
 
-    let (package_name, package_version, _bin_name, _has_embed_assets, _dep_key) =
-        read_package_meta(project_root)?;
+    // Deliberately not read_package_meta: that helper also resolves the
+    // sidecar binary target, which a thin client neither builds nor spawns —
+    // requiring one would wrongly reject lib-only and multi-bin packages.
+    let (package_name, package_version, _doc) = read_package_name_version(project_root)?;
     let mut plan = Plan::new(project_root);
     let tauri = project_root.join("src-tauri");
 
@@ -5451,5 +5474,63 @@ mod tests {
             "desktop `autumn generate tauri` (no --remote-url) must keep emitting \
              exactly the sidecar file set — and never a capabilities/ file"
         );
+    }
+
+    // ── Thin-client planning must not require a sidecar binary (#1506) ────────
+    //
+    // The thin client never builds or spawns a sidecar, so packages with no
+    // selectable binary target must still scaffold. The mirror-image desktop
+    // behaviour (plan_tauri *must* error on these layouts) is pinned above by
+    // `plan_errors_when_package_has_no_bin_target` and
+    // `plan_errors_on_multiple_explicit_bins_without_default_run`.
+
+    /// Fixture: a library-only package — no `src/main.rs`, no `[[bin]]`,
+    /// nothing under `src/bin/` — just `src/lib.rs`.
+    fn project_lib_only(pkg_name: &str) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            format!(
+                "[package]\nname=\"{pkg_name}\"\nversion=\"0.3.0\"\nedition=\"2024\"\n\
+                 \n[dependencies]\nautumn-web = \"0.5.0\"\n"
+            ),
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(tmp.path().join("src/lib.rs"), "pub fn hello() {}\n").unwrap();
+        tmp
+    }
+
+    #[test]
+    fn thin_client_plan_succeeds_on_library_only_package() {
+        let tmp = project_lib_only("libonly-app");
+        let plan = plan_tauri_thin_client(tmp.path(), "https://app.example.com")
+            .expect("thin-client planning must not require a binary target");
+        // The package name and version must still flow into tauri.conf.json.
+        let conf: serde_json::Value =
+            serde_json::from_str(created_str(&plan, "src-tauri/tauri.conf.json")).unwrap();
+        assert_eq!(
+            conf["version"].as_str(),
+            Some("0.3.0"),
+            "package version must reach tauri.conf.json for a lib-only package"
+        );
+        assert_eq!(
+            conf["identifier"].as_str(),
+            Some("com.example.libonlyapp"),
+            "package name must reach tauri.conf.json for a lib-only package"
+        );
+    }
+
+    #[test]
+    fn thin_client_plan_succeeds_on_multi_bin_package_without_default_run() {
+        // Multiple explicit [[bin]] targets and no `default-run` is ambiguous
+        // for the *sidecar* — but a thin client has no sidecar, so planning
+        // must succeed without asking the user to pick one.
+        let tmp = project_with_multiple_bins_no_default("multibin-app", &["worker", "web"]);
+        let plan = plan_tauri_thin_client(tmp.path(), "https://app.example.com")
+            .expect("thin-client planning must not resolve a sidecar binary");
+        let conf: serde_json::Value =
+            serde_json::from_str(created_str(&plan, "src-tauri/tauri.conf.json")).unwrap();
+        assert_eq!(conf["identifier"].as_str(), Some("com.example.multibinapp"));
     }
 }

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -133,6 +133,94 @@ fn plan_icons(plan: &mut Plan, project_root: &Path, tauri: &Path) -> Result<(), 
     Ok(())
 }
 
+// ── Mixed-mode guard (issue #1506) ────────────────────────────────────────────
+
+/// Files only the mobile thin-client scaffold (`--remote-url`) emits, relative
+/// to `src-tauri/` — checked before scaffolding the desktop mode.
+///
+/// The capability files are the actively harmful leftovers: Tauri loads
+/// *every* file under `src-tauri/capabilities/`, and the desktop shell crate
+/// compiles none of the notification/store/biometric plugins those grants
+/// name, so `tauri-build` fails permission validation. `Info.ios.plist` is
+/// merely dead on desktop but is equally unambiguous evidence of a
+/// thin-client scaffold.
+const THIN_CLIENT_MARKERS: [&str; 3] = [
+    "capabilities/remote-app.json",
+    "capabilities/remote-app-mobile.json",
+    "Info.ios.plist",
+];
+
+/// Files only the desktop (sidecar) scaffold emits, relative to `src-tauri/`
+/// — checked before scaffolding the thin-client mode.
+///
+/// The per-OS overlay confs are the actively harmful leftovers: Tauri CLI
+/// merges `tauri.<platform>.conf.json` on top of `tauri.conf.json`
+/// automatically, so a stale overlay keeps running the sidecar staging script
+/// as `beforeBuildCommand`/`beforeDevCommand` on every `cargo tauri
+/// build`/`dev` of the thin client.
+const DESKTOP_MARKERS: [&str; 5] = [
+    "stage-sidecar.sh",
+    "stage-sidecar.ps1",
+    "tauri.linux.conf.json",
+    "tauri.macos.conf.json",
+    "tauri.windows.conf.json",
+];
+
+/// Refuse to scaffold one Tauri mode on top of the other's files.
+///
+/// `autumn generate tauri` (desktop sidecar) and `autumn generate tauri
+/// --remote-url` (mobile thin client) both write to `src-tauri/`, but their
+/// file sets only partially overlap — `--force` would overwrite the shared
+/// files and leave the other mode's leftovers behind, some of which actively
+/// break the new mode's build (see [`THIN_CLIENT_MARKERS`] /
+/// [`DESKTOP_MARKERS`]). `--force` means "overwrite within the same mode",
+/// never "silently mix modes", so this check runs regardless of `--force`.
+///
+/// Called only for `autumn generate` — never for `autumn destroy`, which is
+/// the documented remedy and must keep working on a mixed tree.
+///
+/// # Errors
+/// Returns [`GenerateError::Config`] naming the conflicting marker file and
+/// the matching `autumn destroy tauri [--remote-url <URL>]` command to run
+/// first.
+pub fn ensure_no_opposite_mode_scaffold(
+    project_root: &Path,
+    thin_client: bool,
+) -> Result<(), GenerateError> {
+    let tauri = project_root.join("src-tauri");
+    let first_existing = |markers: &[&str]| -> Option<String> {
+        markers
+            .iter()
+            .find(|m| tauri.join(m).is_file())
+            .map(|m| format!("src-tauri/{m}"))
+    };
+    if thin_client {
+        if let Some(marker) = first_existing(&DESKTOP_MARKERS) {
+            return Err(GenerateError::Config(format!(
+                "src-tauri/ already contains a desktop (sidecar) Tauri scaffold \
+                 ({marker} exists); refusing to scaffold the mobile thin client on \
+                 top of it — stale per-OS tauri.*.conf.json overlays would keep \
+                 running the sidecar staging scripts on every `cargo tauri build`. \
+                 Run `autumn destroy tauri` first, then re-run `autumn generate \
+                 tauri --remote-url <URL>`. --force only overwrites files within \
+                 the same mode; it never mixes modes."
+            )));
+        }
+    } else if let Some(marker) = first_existing(&THIN_CLIENT_MARKERS) {
+        return Err(GenerateError::Config(format!(
+            "src-tauri/ already contains a mobile thin-client Tauri scaffold \
+             ({marker} exists); refusing to scaffold the desktop mode on top of \
+             it — Tauri loads every capability file under src-tauri/capabilities/, \
+             so the stale thin-client grants would fail validation against the \
+             desktop shell crate. Run `autumn destroy tauri --remote-url <URL>` \
+             (the URL the thin client was generated with) first, then re-run \
+             `autumn generate tauri`. --force only overwrites files within the \
+             same mode; it never mixes modes."
+        )));
+    }
+    Ok(())
+}
+
 // ── Package metadata helper ───────────────────────────────────────────────────
 
 /// Returns `(package_name, version, bin_name)`.
@@ -2216,6 +2304,81 @@ mod tests {
         assert!(
             matches!(err, GenerateError::Config(_)),
             "expected Config error, got: {err:?}"
+        );
+    }
+
+    // ── Mixed-mode guard (issue #1506) ────────────────────────────────────────
+
+    /// Create an empty file at `src-tauri/<rel>` under `root`.
+    fn touch_tauri_file(root: &Path, rel: &str) {
+        let path = root.join("src-tauri").join(rel);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, "").unwrap();
+    }
+
+    #[test]
+    fn guard_rejects_desktop_generation_over_each_thin_client_marker() {
+        for marker in THIN_CLIENT_MARKERS {
+            let tmp = TempDir::new().unwrap();
+            touch_tauri_file(tmp.path(), marker);
+            let err = ensure_no_opposite_mode_scaffold(tmp.path(), false)
+                .expect_err("desktop generation over a thin-client marker must be rejected");
+            let msg = err.to_string();
+            assert!(
+                msg.contains(marker),
+                "error must name the conflicting file '{marker}':\n{msg}"
+            );
+            assert!(
+                msg.contains("destroy tauri --remote-url"),
+                "error must point at the matching destroy command:\n{msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn guard_rejects_thin_client_generation_over_each_desktop_marker() {
+        for marker in DESKTOP_MARKERS {
+            let tmp = TempDir::new().unwrap();
+            touch_tauri_file(tmp.path(), marker);
+            let err = ensure_no_opposite_mode_scaffold(tmp.path(), true)
+                .expect_err("thin-client generation over a desktop marker must be rejected");
+            let msg = err.to_string();
+            assert!(
+                msg.contains(marker),
+                "error must name the conflicting file '{marker}':\n{msg}"
+            );
+            assert!(
+                msg.contains("`autumn destroy tauri`"),
+                "error must point at the matching destroy command:\n{msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn guard_allows_clean_trees_and_same_mode_regeneration() {
+        // Clean tree (no src-tauri/ at all): both modes may scaffold.
+        let clean = TempDir::new().unwrap();
+        assert!(ensure_no_opposite_mode_scaffold(clean.path(), false).is_ok());
+        assert!(ensure_no_opposite_mode_scaffold(clean.path(), true).is_ok());
+
+        // A mode's own files are never a conflict — `--force` re-generation
+        // within the same mode must stay possible.
+        let desktop = TempDir::new().unwrap();
+        for marker in DESKTOP_MARKERS {
+            touch_tauri_file(desktop.path(), marker);
+        }
+        assert!(
+            ensure_no_opposite_mode_scaffold(desktop.path(), false).is_ok(),
+            "desktop regeneration over desktop files must be allowed"
+        );
+
+        let thin = TempDir::new().unwrap();
+        for marker in THIN_CLIENT_MARKERS {
+            touch_tauri_file(thin.path(), marker);
+        }
+        assert!(
+            ensure_no_opposite_mode_scaffold(thin.path(), true).is_ok(),
+            "thin-client regeneration over thin-client files must be allowed"
         );
     }
 

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -1383,9 +1383,9 @@ Required prerequisites for `cargo tauri build`:\n\
 /// # Errors
 /// Returns [`GenerateError::NotInProject`] when not at a project root, or
 /// [`GenerateError::Config`] when `remote_url` is not an acceptable HTTPS URL
-/// (plain `http` is allowed only for `localhost` / `127.0.0.1` / `::1` dev
-/// servers; URLs with embedded userinfo are rejected) or when `Cargo.toml`
-/// is missing `[package].name`.
+/// (plain `http` is allowed only for `localhost` / `127.0.0.1` / `::1` /
+/// `10.0.2.2` dev servers; URLs with embedded userinfo are rejected) or when
+/// `Cargo.toml` is missing `[package].name`.
 pub fn plan_tauri_thin_client(
     project_root: &Path,
     remote_url: &str,
@@ -1394,9 +1394,14 @@ pub fn plan_tauri_thin_client(
     let validated = validate_remote_url(remote_url)?;
     // The capability grant is scoped to the URL's *origin* (scheme://host[:port],
     // no path, no trailing slash) — the exact form Tauri matches remote pages
-    // against. The webview itself loads the URL as given, so a path component
+    // against. The webview itself loads the full URL, so a path component
     // (e.g. https://example.com/app) still lands on the right page.
     let remote_origin = validated.origin().ascii_serialization();
+    // Everywhere the URL lands in generated source, embed the parser's
+    // normalized serialization — it percent-encodes quotes/braces/spaces and
+    // strips newlines, so it is always safe inside a Rust string literal or
+    // doc comment. The raw flag value is not.
+    let normalized_url = validated.as_str();
 
     let (package_name, package_version, _bin_name, _has_embed_assets, _dep_key) =
         read_package_meta(project_root)?;
@@ -1420,7 +1425,7 @@ pub fn plan_tauri_thin_client(
     );
     plan.create(
         tauri.join("src").join("lib.rs"),
-        render_thin_client_lib_rs(&package_name, remote_url),
+        render_thin_client_lib_rs(&package_name, normalized_url),
     );
 
     // Capability grant: pages served from the remote origin may invoke the
@@ -1450,7 +1455,8 @@ pub fn plan_tauri_thin_client(
 }
 
 /// Validate a `--remote-url` value: require `https`, allow `http` only for
-/// loopback dev hosts (`localhost`, `127.0.0.1`, `::1`), and reject URLs
+/// dev hosts (`localhost`, `127.0.0.1`, `::1`, and `10.0.2.2` — the Android
+/// emulator's alias for the host machine's loopback), and reject URLs
 /// carrying embedded userinfo (`https://user:pass@…`).
 fn validate_remote_url(raw: &str) -> Result<url::Url, GenerateError> {
     let parsed = url::Url::parse(raw).map_err(|e| {
@@ -1458,6 +1464,22 @@ fn validate_remote_url(raw: &str) -> Result<url::Url, GenerateError> {
             "--remote-url must be an https:// URL (got '{raw}'): {e}"
         ))
     })?;
+    // Belt and braces: the serialization is interpolated into generated Rust
+    // source, so refuse anything the parser somehow leaves unsafe there. The
+    // WHATWG serialization percent-encodes quotes and strips control
+    // characters, so this should be unreachable — but a parser upgrade must
+    // never silently turn into generated-code injection.
+    if parsed
+        .as_str()
+        .chars()
+        .any(|c| c == '"' || c == '\\' || c.is_ascii_control())
+    {
+        return Err(GenerateError::Config(format!(
+            "--remote-url contains characters that cannot be embedded in generated \
+             code (got '{}')",
+            raw.escape_debug()
+        )));
+    }
     if !parsed.username().is_empty() || parsed.password().is_some() {
         return Err(GenerateError::Config(format!(
             "--remote-url must not embed userinfo (got '{raw}'): credentials do not \
@@ -1470,13 +1492,17 @@ fn validate_remote_url(raw: &str) -> Result<url::Url, GenerateError> {
         "http" => {
             // Plain http is only acceptable against a local dev server —
             // a shipped mobile app must talk TLS to its remote origin.
+            // `Url::host_str` always returns IPv6 hosts bracketed, so only
+            // the `[::1]` form can occur. `10.0.2.2` is how an Android
+            // emulator reaches the host machine's loopback.
             let host = parsed.host_str().unwrap_or("");
-            if matches!(host, "localhost" | "127.0.0.1" | "[::1]" | "::1") {
+            if matches!(host, "localhost" | "127.0.0.1" | "[::1]" | "10.0.2.2") {
                 Ok(parsed)
             } else {
                 Err(GenerateError::Config(format!(
                     "--remote-url must be an https:// URL (got '{raw}'): plain http is \
-                     allowed only for localhost / 127.0.0.1 / ::1 dev servers"
+                     allowed only for localhost / 127.0.0.1 / ::1 / 10.0.2.2 \
+                     (Android emulator) dev servers"
                 )))
             }
         }
@@ -1492,14 +1518,31 @@ fn mobile_lib_name(package_name: &str) -> String {
     package_name.replace('-', "_") + "_mobile"
 }
 
+/// Bundle identifier for the mobile thin client: reverse-DNS with `-` and `_`
+/// stripped from the package name (`demo-app` → `com.example.demoapp`).
+///
+/// Unlike the desktop derivation ([`derive_identifier`], which hyphenates for
+/// Apple), the mobile identifier must satisfy *both* stores: Android forbids
+/// hyphens in application ids — `cargo tauri android init` panics on them
+/// (tauri-apps/tauri#9707) — and Apple forbids underscores. Alphanumeric
+/// segments are valid on both. Users should replace the `com.example.*`
+/// placeholder with their real identifier before running `android`/`ios init`.
+fn derive_mobile_identifier(package_name: &str) -> String {
+    format!("com.example.{}", package_name.replace(['-', '_'], ""))
+}
+
 /// `tauri.conf.json` for the thin client: productName/version/identifier and
 /// bundle icons only — no `externalBin` (no sidecar binary) and no `resources`
 /// (config files live on the remote server, not in the app bundle).
 ///
+/// `withGlobalTauri` is enabled because the pages come from a server-rendered
+/// Autumn app with no npm bundler: the injected `window.__TAURI__` global is
+/// how those remote pages call the granted plugins.
+///
 /// `csp` stays `null`: the webview renders remote pages, which carry the
 /// server's own Content-Security-Policy headers.
 fn render_thin_client_tauri_conf(package_name: &str, version: &str) -> String {
-    let identifier = derive_identifier(package_name);
+    let identifier = derive_mobile_identifier(package_name);
     let title = derive_title(package_name);
     format!(
         r#"{{
@@ -1520,6 +1563,7 @@ fn render_thin_client_tauri_conf(package_name: &str, version: &str) -> String {
     ]
   }},
   "app": {{
+    "withGlobalTauri": true,
     "security": {{
       "csp": null
     }}
@@ -1641,6 +1685,10 @@ pub fn run() {{
 /// `remote_origin` access to the core APIs and the notification, biometric,
 /// and store plugin commands. Never emit a wildcard here: any page the
 /// listed origins serve can invoke these device APIs.
+///
+/// `core:default` is kept (rather than a narrower core subset) because the
+/// injected `window.__TAURI__` API relies on the core event/window plumbing
+/// it permits; prune it only after verifying the trimmed set on a device.
 fn render_thin_client_capability(remote_origin: &str) -> String {
     format!(
         r#"{{
@@ -1682,6 +1730,11 @@ fn render_thin_client_ios_plist(package_name: &str) -> String {
 /// Human-readable prerequisites message printed after a successful
 /// thin-client scaffold (`autumn generate tauri --remote-url <URL>`).
 pub fn render_thin_client_prerequisites(remote_url: &str) -> String {
+    // Echo the normalized serialization — the form actually embedded in the
+    // scaffold — rather than the raw flag value (which may differ in case or
+    // percent-encoding). The URL was already validated at plan time.
+    let remote_url =
+        url::Url::parse(remote_url).map_or_else(|_| remote_url.to_owned(), |u| u.to_string());
     format!(
         "\
 Next steps for the mobile thin client (webview → {remote_url}):\n\
@@ -1695,8 +1748,9 @@ Next steps for the mobile thin client (webview → {remote_url}):\n\
        iOS:     rustup target add aarch64-apple-ios aarch64-apple-ios-sim\n\
      (Android also needs the Android SDK/NDK; iOS needs Xcode on macOS.)\n\
 \n\
-  3. Initialise the mobile projects (writes into src-tauri/gen/, which is\n\
-     .gitignore'd):\n\
+  3. Set your real reverse-DNS bundle identifier in src-tauri/tauri.conf.json\n\
+     (the scaffold derives a com.example.* placeholder), then initialise the\n\
+     mobile projects (writes into src-tauri/gen/, which is .gitignore'd):\n\
        cd src-tauri && cargo tauri android init\n\
        cd src-tauri && cargo tauri ios init\n\
 \n\
@@ -4858,19 +4912,43 @@ mod tests {
         assert_eq!(parsed["version"].as_str(), Some("0.1.0"));
         assert_eq!(
             parsed["identifier"].as_str(),
-            Some("com.example.my-app"),
-            "identifier must keep the underscore→hyphen derivation rule"
+            Some("com.example.myapp"),
+            "mobile identifier must contain no hyphens (they break \
+             `cargo tauri android init` — tauri-apps/tauri#9707)"
         );
+    }
 
-        // Underscored package names must still hyphenate in the identifier.
-        let tmp = project("my_cool_app");
-        let plan = plan_tauri_thin_client(tmp.path(), "https://app.example.com").unwrap();
+    #[test]
+    fn thin_client_identifier_strips_hyphens_and_underscores() {
+        // Hyphens in the bundle identifier make `cargo tauri android init`
+        // panic (tauri-apps/tauri#9707) and Apple forbids underscores — the
+        // mobile identifier must keep only alphanumeric segments.
+        for (package, expected) in [
+            ("demo-app", "com.example.demoapp"),
+            ("my_cool_app", "com.example.mycoolapp"),
+        ] {
+            let tmp = project(package);
+            let plan = plan_tauri_thin_client(tmp.path(), "https://app.example.com").unwrap();
+            let conf = created_str(&plan, "tauri.conf.json");
+            let parsed: serde_json::Value = serde_json::from_str(conf).unwrap();
+            assert_eq!(
+                parsed["identifier"].as_str(),
+                Some(expected),
+                "'{package}' must derive an identifier valid on both Android and iOS"
+            );
+        }
+    }
+
+    #[test]
+    fn thin_client_conf_enables_global_tauri() {
+        let (_tmp, plan) = thin_plan("https://app.example.com");
         let conf = created_str(&plan, "tauri.conf.json");
         let parsed: serde_json::Value = serde_json::from_str(conf).unwrap();
         assert_eq!(
-            parsed["identifier"].as_str(),
-            Some("com.example.my-cool-app"),
-            "Apple forbids underscores in bundle identifiers"
+            parsed["app"]["withGlobalTauri"],
+            serde_json::json!(true),
+            "remote server-rendered pages have no bundler — they call the \
+             plugins via the injected window.__TAURI__ global:\n{conf}"
         );
     }
 
@@ -4980,7 +5058,13 @@ mod tests {
     #[test]
     fn thin_client_allows_http_localhost_for_dev() {
         let tmp = project("my-app");
-        for url in ["http://localhost:3000", "http://127.0.0.1:8080"] {
+        // 10.0.2.2 is the Android emulator's alias for the host machine's
+        // loopback — the standard Android dev-loop target.
+        for url in [
+            "http://localhost:3000",
+            "http://127.0.0.1:8080",
+            "http://10.0.2.2:3000",
+        ] {
             assert!(
                 plan_tauri_thin_client(tmp.path(), url).is_ok(),
                 "loopback http URL '{url}' must be accepted for dev"
@@ -5003,6 +5087,70 @@ mod tests {
     }
 
     #[test]
+    fn thin_client_capability_scopes_grant_to_origin_not_full_url() {
+        // The capability grant must be the path-free origin, while the
+        // webview still loads the full URL including its path.
+        let (_tmp, plan) = thin_plan("https://app.example.com:8443/base/");
+        let cap = created_str(&plan, "capabilities/remote-app.json");
+        let parsed: serde_json::Value = serde_json::from_str(cap).unwrap();
+        assert_eq!(
+            parsed["remote"]["urls"],
+            serde_json::json!(["https://app.example.com:8443"]),
+            "capability must grant the origin only — no path, no trailing slash"
+        );
+        let lib = created_str(&plan, "src/lib.rs");
+        assert!(
+            lib.contains("https://app.example.com:8443/base/"),
+            "webview must load the full URL including its path:\n{lib}"
+        );
+    }
+
+    #[test]
+    fn thin_client_lib_rs_embeds_normalized_url_for_adversarial_inputs() {
+        // `url::Url::parse` accepts inputs whose *raw* form is unsafe inside
+        // a Rust string literal or `//!` doc comment (quotes, backslashes,
+        // raw newlines — the parser percent-encodes or strips them only in
+        // its own serialization). The generator must embed that normalized
+        // serialization, never the raw input — or reject the URL outright.
+        for raw in [
+            "https://app.example.com/pa\"th",
+            "https://app.example.com/x\\admin",
+            "https://app.example.com/a\nfn evil(){}//",
+            "https://app.example.com/{id}/x",
+            "HTTPS://App.Example.COM/Path",
+        ] {
+            let tmp = project("my-app");
+            let Ok(plan) = plan_tauri_thin_client(tmp.path(), raw) else {
+                continue; // clean rejection is equally acceptable
+            };
+            let lib = created_str(&plan, "src/lib.rs");
+            let normalized = url::Url::parse(raw)
+                .expect("an accepted URL must reparse")
+                .to_string();
+            assert!(
+                lib.contains(&normalized),
+                "lib.rs must embed the normalized serialization '{normalized}' \
+                 for raw input {raw:?}:\n{lib}"
+            );
+            if raw != normalized {
+                assert!(
+                    !lib.contains(raw),
+                    "lib.rs must not embed the raw input {raw:?}:\n{lib}"
+                );
+            }
+            assert!(
+                !lib.contains('\\'),
+                "generated lib.rs must contain no backslash (raw input {raw:?}):\n{lib}"
+            );
+            assert!(
+                !lib.contains("fn evil"),
+                "a raw newline in the URL must never break out of the doc \
+                 comment into top-level source:\n{lib}"
+            );
+        }
+    }
+
+    #[test]
     fn thin_client_prerequisites_mention_mobile_init() {
         let text = render_thin_client_prerequisites("https://app.example.com");
         for anchor in [
@@ -5016,6 +5164,13 @@ mod tests {
                 "thin-client prerequisites must mention '{anchor}':\n{text}"
             );
         }
+        // The echoed URL must be the normalized form actually granted in the
+        // capability file, not the raw flag value.
+        let echoed = render_thin_client_prerequisites("HTTPS://App.Example.COM");
+        assert!(
+            echoed.contains("https://app.example.com/"),
+            "prerequisites must echo the normalized URL:\n{echoed}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -1357,6 +1357,44 @@ Required prerequisites for `cargo tauri build`:\n\
         .to_owned()
 }
 
+// ── Thin-client (mobile) mode — issue #1506 ──────────────────────────────────
+
+/// Compute the file actions for `autumn generate tauri --remote-url <URL>` —
+/// the **mobile thin-client** mode: the webview loads a remote HTTPS Autumn
+/// server directly (no sidecar binary, no staging scripts, no local database),
+/// and a `capabilities/remote-app.json` grants the remote origin access to the
+/// notification/biometric/store plugins.
+///
+/// # Errors
+/// Returns [`GenerateError::NotInProject`] when not at a project root, or
+/// [`GenerateError::Config`] when `remote_url` is not an acceptable HTTPS URL
+/// (plain `http` is allowed only for `localhost` / `127.0.0.1` / `::1` dev
+/// servers; URLs with embedded userinfo are rejected) or when `Cargo.toml`
+/// is missing `[package].name`.
+pub fn plan_tauri_thin_client(
+    project_root: &Path,
+    remote_url: &str,
+) -> Result<Plan, GenerateError> {
+    ensure_project_root(project_root)?;
+    let _ = validate_remote_url(remote_url)?;
+    todo!("green phase — issue #1506")
+}
+
+/// Validate a `--remote-url` value: require `https`, allow `http` only for
+/// loopback dev hosts (`localhost`, `127.0.0.1`, `::1`), and reject URLs
+/// carrying embedded userinfo (`https://user:pass@…`).
+fn validate_remote_url(raw: &str) -> Result<url::Url, GenerateError> {
+    let _ = raw;
+    todo!("green phase — issue #1506")
+}
+
+/// Human-readable prerequisites message printed after a successful
+/// thin-client scaffold (`autumn generate tauri --remote-url <URL>`).
+pub fn render_thin_client_prerequisites(remote_url: &str) -> String {
+    let _ = remote_url;
+    todo!("green phase — issue #1506")
+}
+
 // ── Placeholder icon bytes ────────────────────────────────────────────────────
 // Minimal valid 1×1 RGBA PNG (autumn green #4F7942, opaque).
 // Replace with proper icons using: cargo tauri icon static/icons/icon.svg
@@ -4366,6 +4404,327 @@ mod tests {
         assert_eq!(
             version, None,
             "must return None when no ancestor has [workspace.package] version"
+        );
+    }
+
+    // ── Thin-client (mobile) mode tests — issue #1506 ─────────────────────────
+
+    /// Fixture: a fresh project + its thin-client plan for the given remote URL.
+    fn thin_plan(url: &str) -> (TempDir, Plan) {
+        let tmp = project("my-app");
+        let plan = plan_tauri_thin_client(tmp.path(), url)
+            .expect("plan_tauri_thin_client must succeed for a valid https URL");
+        (tmp, plan)
+    }
+
+    /// The contents of the `Create` action whose path ends with `suffix`.
+    fn created_str<'a>(plan: &'a Plan, suffix: &str) -> &'a str {
+        plan.actions
+            .iter()
+            .find(|a| {
+                a.path()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+                    .ends_with(suffix)
+            })
+            .and_then(|a| {
+                if let crate::generate::emit::Action::Create { contents, .. } = a {
+                    Some(contents.as_str())
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_else(|| panic!("expected a Create action for '{suffix}'"))
+    }
+
+    /// All planned action paths, relative to the project root, sorted.
+    fn planned_paths(plan: &Plan, root: &std::path::Path) -> Vec<String> {
+        let mut paths: Vec<String> = plan
+            .actions
+            .iter()
+            .map(|a| {
+                a.path()
+                    .strip_prefix(root)
+                    .expect("action paths are under the project root")
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+        paths.sort();
+        paths
+    }
+
+    #[test]
+    fn thin_client_plan_creates_expected_file_set() {
+        let (tmp, plan) = thin_plan("https://app.example.com");
+        assert_eq!(
+            planned_paths(&plan, tmp.path()),
+            vec![
+                "src-tauri/.gitignore",
+                "src-tauri/Cargo.toml",
+                "src-tauri/Info.ios.plist",
+                "src-tauri/build.rs",
+                "src-tauri/capabilities/remote-app.json",
+                "src-tauri/icons/128x128.png",
+                "src-tauri/icons/128x128@2x.png",
+                "src-tauri/icons/32x32.png",
+                "src-tauri/icons/icon.icns",
+                "src-tauri/icons/icon.ico",
+                "src-tauri/icons/icon.png",
+                "src-tauri/icons/icon.svg",
+                "src-tauri/src/lib.rs",
+                "src-tauri/src/main.rs",
+                "src-tauri/tauri.conf.json",
+            ],
+            "thin-client plan must emit exactly the mobile file set — \
+             no staging scripts, no per-OS overlay confs"
+        );
+    }
+
+    #[test]
+    fn thin_client_capability_file_grants_remote_url() {
+        let (_tmp, plan) = thin_plan("https://app.example.com");
+        let cap = created_str(&plan, "capabilities/remote-app.json");
+        let parsed: serde_json::Value =
+            serde_json::from_str(cap).expect("capability file must be valid JSON");
+        assert_eq!(
+            parsed["remote"]["urls"],
+            serde_json::json!(["https://app.example.com"]),
+            "capability must grant exactly the given remote origin (no wildcard)"
+        );
+        assert_eq!(
+            parsed["windows"],
+            serde_json::json!(["main"]),
+            "capability must be scoped to the main window"
+        );
+    }
+
+    #[test]
+    fn thin_client_capability_file_grants_plugin_permissions() {
+        let (_tmp, plan) = thin_plan("https://app.example.com");
+        let cap = created_str(&plan, "capabilities/remote-app.json");
+        for permission in [
+            "core:default",
+            "notification:default",
+            "biometric:default",
+            "store:default",
+        ] {
+            assert!(
+                cap.contains(permission),
+                "capability file must grant '{permission}':\n{cap}"
+            );
+        }
+    }
+
+    #[test]
+    fn thin_client_conf_has_no_sidecar_config() {
+        let (_tmp, plan) = thin_plan("https://app.example.com");
+        let conf = created_str(&plan, "tauri.conf.json");
+        assert!(
+            !conf.contains("externalBin"),
+            "thin-client tauri.conf.json must not reference a sidecar externalBin:\n{conf}"
+        );
+        assert!(
+            !conf.contains("resources"),
+            "thin-client tauri.conf.json must not stage sidecar resources:\n{conf}"
+        );
+        let parsed: serde_json::Value =
+            serde_json::from_str(conf).expect("tauri.conf.json must be valid JSON");
+        assert_eq!(parsed["productName"].as_str(), Some("My App"));
+        assert_eq!(parsed["version"].as_str(), Some("0.1.0"));
+        assert_eq!(
+            parsed["identifier"].as_str(),
+            Some("com.example.my-app"),
+            "identifier must keep the underscore→hyphen derivation rule"
+        );
+
+        // Underscored package names must still hyphenate in the identifier.
+        let tmp = project("my_cool_app");
+        let plan = plan_tauri_thin_client(tmp.path(), "https://app.example.com").unwrap();
+        let conf = created_str(&plan, "tauri.conf.json");
+        let parsed: serde_json::Value = serde_json::from_str(conf).unwrap();
+        assert_eq!(
+            parsed["identifier"].as_str(),
+            Some("com.example.my-cool-app"),
+            "Apple forbids underscores in bundle identifiers"
+        );
+    }
+
+    #[test]
+    fn thin_client_lib_rs_points_webview_at_remote_url() {
+        let (_tmp, plan) = thin_plan("https://app.example.com");
+        let lib = created_str(&plan, "src/lib.rs");
+        assert!(
+            lib.contains("WebviewUrl::External"),
+            "thin-client lib.rs must open the webview on an external URL:\n{lib}"
+        );
+        assert!(
+            lib.contains("https://app.example.com"),
+            "thin-client lib.rs must embed the exact remote URL:\n{lib}"
+        );
+        for sidecar_marker in ["tauri_plugin_shell", "SidecarHandle", "AUTUMN_SERVER__PORT"] {
+            assert!(
+                !lib.contains(sidecar_marker),
+                "thin-client lib.rs must contain no sidecar machinery ('{sidecar_marker}')"
+            );
+        }
+    }
+
+    #[test]
+    fn thin_client_lib_rs_registers_plugins_and_mobile_entry() {
+        let (_tmp, plan) = thin_plan("https://app.example.com");
+        let lib = created_str(&plan, "src/lib.rs");
+        assert!(
+            lib.contains("tauri_plugin_notification::init()"),
+            "lib.rs must register the notification plugin:\n{lib}"
+        );
+        assert!(
+            lib.contains("tauri_plugin_store::Builder"),
+            "lib.rs must register the store plugin:\n{lib}"
+        );
+        assert!(
+            lib.contains("tauri_plugin_biometric"),
+            "lib.rs must register the biometric plugin:\n{lib}"
+        );
+        assert!(
+            lib.contains("#[cfg(mobile)]"),
+            "biometric registration must be #[cfg(mobile)]-gated (plugin is mobile-only):\n{lib}"
+        );
+        assert!(
+            lib.contains("#[cfg_attr(mobile, tauri::mobile_entry_point)]"),
+            "lib.rs must keep the mobile entry point attribute:\n{lib}"
+        );
+    }
+
+    #[test]
+    fn thin_client_cargo_toml_declares_mobile_plugins() {
+        let (_tmp, plan) = thin_plan("https://app.example.com");
+        let cargo = created_str(&plan, "src-tauri/Cargo.toml");
+        assert!(
+            cargo.contains("\"my-app-mobile\""),
+            "shell crate must be named '{{package}}-mobile', not '-desktop':\n{cargo}"
+        );
+        assert!(
+            cargo.contains("tauri-plugin-notification"),
+            "Cargo.toml must depend on tauri-plugin-notification:\n{cargo}"
+        );
+        assert!(
+            cargo.contains("tauri-plugin-store"),
+            "Cargo.toml must depend on tauri-plugin-store:\n{cargo}"
+        );
+        assert!(
+            cargo.contains(
+                "[target.'cfg(any(target_os = \"android\", target_os = \"ios\"))'.dependencies]"
+            ),
+            "biometric dependency must be target-gated to mobile:\n{cargo}"
+        );
+        assert!(
+            cargo.contains("tauri-plugin-biometric"),
+            "Cargo.toml must depend on tauri-plugin-biometric:\n{cargo}"
+        );
+        assert!(
+            !cargo.contains("tauri-plugin-shell"),
+            "thin client has no sidecar, so tauri-plugin-shell must be absent:\n{cargo}"
+        );
+    }
+
+    #[test]
+    fn thin_client_emits_ios_faceid_plist() {
+        let (_tmp, plan) = thin_plan("https://app.example.com");
+        let plist = created_str(&plan, "Info.ios.plist");
+        assert!(
+            plist.contains("NSFaceIDUsageDescription"),
+            "Info.ios.plist must declare NSFaceIDUsageDescription — the biometric \
+             plugin hard-requires it on iOS:\n{plist}"
+        );
+    }
+
+    #[test]
+    fn thin_client_rejects_plain_http_url() {
+        let tmp = project("my-app");
+        let err = plan_tauri_thin_client(tmp.path(), "http://app.example.com")
+            .expect_err("plain http remote URL must be rejected");
+        match err {
+            GenerateError::Config(msg) => assert!(
+                msg.contains("https"),
+                "error message must point at the https requirement: {msg}"
+            ),
+            other => panic!("expected GenerateError::Config, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn thin_client_allows_http_localhost_for_dev() {
+        let tmp = project("my-app");
+        for url in ["http://localhost:3000", "http://127.0.0.1:8080"] {
+            assert!(
+                plan_tauri_thin_client(tmp.path(), url).is_ok(),
+                "loopback http URL '{url}' must be accepted for dev"
+            );
+        }
+    }
+
+    #[test]
+    fn thin_client_rejects_unparseable_url_and_userinfo() {
+        let tmp = project("my-app");
+        for url in ["not a url", "https://user:pass@app.example.com"] {
+            let Err(err) = plan_tauri_thin_client(tmp.path(), url) else {
+                panic!("'{url}' must be rejected as a remote URL");
+            };
+            assert!(
+                matches!(err, GenerateError::Config(_)),
+                "expected GenerateError::Config for '{url}', got: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn thin_client_prerequisites_mention_mobile_init() {
+        let text = render_thin_client_prerequisites("https://app.example.com");
+        for anchor in [
+            "tauri android init",
+            "tauri ios init",
+            "https://app.example.com",
+            "4.2",
+        ] {
+            assert!(
+                text.contains(anchor),
+                "thin-client prerequisites must mention '{anchor}':\n{text}"
+            );
+        }
+    }
+
+    #[test]
+    fn desktop_plan_file_set_unchanged_by_thin_client_feature() {
+        // Regression pin (issue #1506): the no-flag desktop path must stay
+        // byte-identical in shape — exactly the pre-existing file list, and
+        // in particular no capabilities/ entry leaking in from thin-client mode.
+        let tmp = project("my-app");
+        let plan = plan_tauri(tmp.path()).unwrap();
+        assert_eq!(
+            planned_paths(&plan, tmp.path()),
+            vec![
+                "src-tauri/.gitignore",
+                "src-tauri/Cargo.toml",
+                "src-tauri/build.rs",
+                "src-tauri/icons/128x128.png",
+                "src-tauri/icons/128x128@2x.png",
+                "src-tauri/icons/32x32.png",
+                "src-tauri/icons/icon.icns",
+                "src-tauri/icons/icon.ico",
+                "src-tauri/icons/icon.png",
+                "src-tauri/icons/icon.svg",
+                "src-tauri/src/lib.rs",
+                "src-tauri/src/main.rs",
+                "src-tauri/stage-sidecar.ps1",
+                "src-tauri/stage-sidecar.sh",
+                "src-tauri/tauri.conf.json",
+                "src-tauri/tauri.linux.conf.json",
+                "src-tauri/tauri.macos.conf.json",
+                "src-tauri/tauri.windows.conf.json",
+            ],
+            "desktop `autumn generate tauri` (no --remote-url) must keep emitting \
+             exactly the sidecar file set — and never a capabilities/ file"
         );
     }
 }

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -464,13 +464,16 @@ fn resolve_workspace_version(project_root: &Path) -> Option<String> {
 
 // ── Content renderers ─────────────────────────────────────────────────────────
 
-fn render_tauri_conf(package_name: &str, version: &str, bin_name: &str) -> String {
-    // Bundle identifier: reverse-DNS with underscores replaced by hyphens.
-    // Apple's spec allows only alphanumerics, hyphens, and periods — underscores are invalid.
-    let identifier = format!("com.example.{}", package_name.replace('_', "-"));
-    // Display title: capitalise first letter of each word; split on both '-' and '_'
-    // so kebab-case (`my-app` → `My App`) and snake_case (`my_app` → `My App`) both work.
-    let title: String = package_name
+/// Bundle identifier: reverse-DNS with underscores replaced by hyphens.
+/// Apple's spec allows only alphanumerics, hyphens, and periods — underscores are invalid.
+fn derive_identifier(package_name: &str) -> String {
+    format!("com.example.{}", package_name.replace('_', "-"))
+}
+
+/// Display title: capitalise first letter of each word; split on both '-' and '_'
+/// so kebab-case (`my-app` → `My App`) and `snake_case` (`my_app` → `My App`) both work.
+fn derive_title(package_name: &str) -> String {
+    package_name
         .split(['-', '_'])
         .map(|word| {
             let mut chars = word.chars();
@@ -479,7 +482,12 @@ fn render_tauri_conf(package_name: &str, version: &str, bin_name: &str) -> Strin
             })
         })
         .collect::<Vec<_>>()
-        .join(" ");
+        .join(" ")
+}
+
+fn render_tauri_conf(package_name: &str, version: &str, bin_name: &str) -> String {
+    let identifier = derive_identifier(package_name);
+    let title = derive_title(package_name);
     // beforeBuildCommand and beforeDevCommand are declared in the platform-specific
     // overlay files (tauri.linux.conf.json, tauri.macos.conf.json,
     // tauri.windows.conf.json) that Tauri CLI merges at build/dev time.
@@ -1376,23 +1384,338 @@ pub fn plan_tauri_thin_client(
     remote_url: &str,
 ) -> Result<Plan, GenerateError> {
     ensure_project_root(project_root)?;
-    let _ = validate_remote_url(remote_url)?;
-    todo!("green phase — issue #1506")
+    let validated = validate_remote_url(remote_url)?;
+    // The capability grant is scoped to the URL's *origin* (scheme://host[:port],
+    // no path, no trailing slash) — the exact form Tauri matches remote pages
+    // against. The webview itself loads the URL as given, so a path component
+    // (e.g. https://example.com/app) still lands on the right page.
+    let remote_origin = validated.origin().ascii_serialization();
+
+    let (package_name, package_version, _bin_name, _has_embed_assets, _dep_key) =
+        read_package_meta(project_root)?;
+    let mut plan = Plan::new(project_root);
+    let tauri = project_root.join("src-tauri");
+
+    // Core Tauri project files — no sidecar config, no staging scripts,
+    // no per-OS overlay confs: a thin client has nothing to build or stage.
+    plan.create(
+        tauri.join("tauri.conf.json"),
+        render_thin_client_tauri_conf(&package_name, &package_version),
+    );
+    plan.create(
+        tauri.join("Cargo.toml"),
+        render_thin_client_cargo_toml(&package_name),
+    );
+    plan.create(tauri.join("build.rs"), render_build_rs());
+    plan.create(
+        tauri.join("src").join("main.rs"),
+        render_thin_client_main_rs(&package_name),
+    );
+    plan.create(
+        tauri.join("src").join("lib.rs"),
+        render_thin_client_lib_rs(&package_name, remote_url),
+    );
+
+    // Capability grant: pages served from the remote origin may invoke the
+    // permitted plugin commands. Auto-discovered by tauri-build from
+    // src-tauri/capabilities/.
+    plan.create(
+        tauri.join("capabilities").join("remote-app.json"),
+        render_thin_client_capability(&remote_origin),
+    );
+
+    // iOS usage-description plist — the biometric plugin hard-requires
+    // NSFaceIDUsageDescription; without it the app crashes on first Face ID use.
+    plan.create(
+        tauri.join("Info.ios.plist"),
+        render_thin_client_ios_plist(&package_name),
+    );
+
+    // Icons — identical to the desktop path: reuse the PWA icon when the user
+    // already ran `autumn generate pwa`, placeholder bytes otherwise.
+    let icons_dir = tauri.join("icons");
+    let pwa_icon_src = project_root.join("static").join("icons").join("icon.svg");
+    if pwa_icon_src.is_file() {
+        let contents = std::fs::read_to_string(&pwa_icon_src).map_err(GenerateError::Io)?;
+        plan.create_if_absent(icons_dir.join("icon.svg"), contents);
+    } else {
+        plan.create_if_absent(icons_dir.join("icon.svg"), render_placeholder_icon_svg());
+    }
+    plan.create_bytes(icons_dir.join("32x32.png"), PLACEHOLDER_PNG);
+    plan.create_bytes(icons_dir.join("128x128.png"), PLACEHOLDER_PNG);
+    plan.create_bytes(icons_dir.join("128x128@2x.png"), PLACEHOLDER_PNG);
+    plan.create_bytes(icons_dir.join("icon.png"), PLACEHOLDER_PNG);
+    plan.create_bytes(icons_dir.join("icon.ico"), PLACEHOLDER_ICO);
+    plan.create_bytes(icons_dir.join("icon.icns"), PLACEHOLDER_ICNS);
+
+    // /gen covers the `cargo tauri android init` / `ios init` output.
+    plan.create(tauri.join(".gitignore"), render_gitignore());
+
+    Ok(plan)
 }
 
 /// Validate a `--remote-url` value: require `https`, allow `http` only for
 /// loopback dev hosts (`localhost`, `127.0.0.1`, `::1`), and reject URLs
 /// carrying embedded userinfo (`https://user:pass@…`).
 fn validate_remote_url(raw: &str) -> Result<url::Url, GenerateError> {
-    let _ = raw;
-    todo!("green phase — issue #1506")
+    let parsed = url::Url::parse(raw).map_err(|e| {
+        GenerateError::Config(format!(
+            "--remote-url must be an https:// URL (got '{raw}'): {e}"
+        ))
+    })?;
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(GenerateError::Config(format!(
+            "--remote-url must not embed userinfo (got '{raw}'): credentials do not \
+             belong in the webview URL — use the session/auth handoff patterns in \
+             docs/guide/tauri-mobile-thin-client.md instead"
+        )));
+    }
+    match parsed.scheme() {
+        "https" => Ok(parsed),
+        "http" => {
+            // Plain http is only acceptable against a local dev server —
+            // a shipped mobile app must talk TLS to its remote origin.
+            let host = parsed.host_str().unwrap_or("");
+            if matches!(host, "localhost" | "127.0.0.1" | "[::1]" | "::1") {
+                Ok(parsed)
+            } else {
+                Err(GenerateError::Config(format!(
+                    "--remote-url must be an https:// URL (got '{raw}'): plain http is \
+                     allowed only for localhost / 127.0.0.1 / ::1 dev servers"
+                )))
+            }
+        }
+        other => Err(GenerateError::Config(format!(
+            "--remote-url must be an https:// URL (got '{raw}'): unsupported scheme '{other}'"
+        ))),
+    }
+}
+
+/// `tauri.conf.json` for the thin client: productName/version/identifier and
+/// bundle icons only — no `externalBin` (no sidecar binary) and no `resources`
+/// (config files live on the remote server, not in the app bundle).
+///
+/// `csp` stays `null`: the webview renders remote pages, which carry the
+/// server's own Content-Security-Policy headers.
+fn render_thin_client_tauri_conf(package_name: &str, version: &str) -> String {
+    let identifier = derive_identifier(package_name);
+    let title = derive_title(package_name);
+    format!(
+        r#"{{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "{title}",
+  "version": "{version}",
+  "identifier": "{identifier}",
+  "bundle": {{
+    "active": true,
+    "targets": "all",
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.png",
+      "icons/icon.ico",
+      "icons/icon.icns"
+    ]
+  }},
+  "app": {{
+    "security": {{
+      "csp": null
+    }}
+  }}
+}}
+"#
+    )
+}
+
+/// Standalone shell crate for the mobile thin client. `staticlib`/`cdylib`
+/// crate types are required by `cargo tauri android init` / `ios init` — the
+/// mobile projects link the Rust core as a library, not a binary.
+fn render_thin_client_cargo_toml(package_name: &str) -> String {
+    let mobile_name = format!("{package_name}-mobile");
+    let lib_name = package_name.replace('-', "_") + "_mobile";
+    format!(
+        r#"[package]
+name = "{mobile_name}"
+version = "0.0.1"
+edition = "2021"
+
+# Standalone workspace so this crate is independent from the autumn app workspace —
+# no change to the root Cargo.toml is needed.
+[workspace]
+
+# staticlib (iOS) and cdylib (Android) are required by `cargo tauri ios init` /
+# `cargo tauri android init`; rlib keeps the desktop smoke-test build working.
+[lib]
+name = "{lib_name}"
+crate-type = ["staticlib", "cdylib", "rlib"]
+
+[build-dependencies]
+tauri-build = {{ version = "2", features = [] }}
+
+[dependencies]
+tauri = {{ version = "2", features = [] }}
+tauri-plugin-notification = "2"
+tauri-plugin-store = "2"
+
+# The biometric plugin only exists on Android/iOS — target-gate it so the
+# thin-client shell still builds on desktop for local smoke-testing.
+[target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
+tauri-plugin-biometric = "2"
+
+[profile.release]
+panic = "abort"
+codegen-units = 1
+lto = true
+opt-level = "s"
+strip = true
+"#
+    )
+}
+
+fn render_thin_client_main_rs(package_name: &str) -> String {
+    let lib_name = package_name.replace('-', "_") + "_mobile";
+    format!(
+        "#![cfg_attr(not(debug_assertions), windows_subsystem = \"windows\")]\n\
+         \n\
+         fn main() {{\n\
+         \x20   {lib_name}::run();\n\
+         }}\n"
+    )
+}
+
+/// The thin-client `src/lib.rs`: register the native-capability plugins and
+/// open the webview directly on the remote HTTPS Autumn server. No sidecar,
+/// no port logic, no shutdown supervision — the server lives in the cloud.
+fn render_thin_client_lib_rs(package_name: &str, remote_url: &str) -> String {
+    let title = derive_title(package_name);
+    format!(
+        r#"//! Tauri mobile thin-client shell for {package_name}.
+//!
+//! The webview loads the remote Autumn server at {remote_url} directly —
+//! there is no local sidecar binary, no local database, and no staging step.
+//! Native device capabilities (notifications, biometric authentication,
+//! key-value storage) are exposed to the remote pages through
+//! `capabilities/remote-app.json`.
+//!
+//! Trust model: pages served from the remote origin can invoke every plugin
+//! command that capability permits — the origin is fully trusted. Keep the
+//! grant scoped to exactly one origin you control and never widen it to a
+//! wildcard.
+
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {{
+    tauri::Builder::default()
+        .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_store::Builder::new().build())
+        .setup(|app| {{
+            // The biometric plugin only exists on Android/iOS; its dependency
+            // is target-gated in Cargo.toml and its registration is gated here
+            // so this shell also builds on desktop for local smoke-testing
+            // (notifications and the store work there too).
+            #[cfg(mobile)]
+            app.handle().plugin(tauri_plugin_biometric::init())?;
+
+            tauri::WebviewWindowBuilder::new(
+                app,
+                "main",
+                tauri::WebviewUrl::External(
+                    "{remote_url}"
+                        .parse()
+                        .expect("remote URL was validated at generate time"),
+                ),
+            )
+            .title("{title}")
+            .build()?;
+            Ok(())
+        }})
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}}
+"#
+    )
+}
+
+/// `capabilities/remote-app.json` — grants pages served from exactly
+/// `remote_origin` access to the core APIs and the notification, biometric,
+/// and store plugin commands. Never emit a wildcard here: any page the
+/// listed origins serve can invoke these device APIs.
+fn render_thin_client_capability(remote_origin: &str) -> String {
+    format!(
+        r#"{{
+  "identifier": "remote-autumn-app",
+  "description": "Allow pages served by the remote Autumn server to use the native device plugins (notifications, biometric authentication, key-value storage).",
+  "windows": ["main"],
+  "remote": {{
+    "urls": ["{remote_origin}"]
+  }},
+  "permissions": [
+    "core:default",
+    "notification:default",
+    "biometric:default",
+    "store:default"
+  ]
+}}
+"#
+    )
+}
+
+/// Minimal iOS Info plist overlay declaring `NSFaceIDUsageDescription` —
+/// required by the biometric plugin before Face ID can be used; iOS kills
+/// the app on first Face ID prompt without it.
+fn render_thin_client_ios_plist(package_name: &str) -> String {
+    let title = derive_title(package_name);
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSFaceIDUsageDescription</key>
+  <string>{title} uses Face ID to unlock your account.</string>
+</dict>
+</plist>
+"#
+    )
 }
 
 /// Human-readable prerequisites message printed after a successful
 /// thin-client scaffold (`autumn generate tauri --remote-url <URL>`).
 pub fn render_thin_client_prerequisites(remote_url: &str) -> String {
-    let _ = remote_url;
-    todo!("green phase — issue #1506")
+    format!(
+        "\
+Next steps for the mobile thin client (webview → {remote_url}):\n\
+\n\
+  1. Tauri CLI:\n\
+       cargo install tauri-cli --version '^2'\n\
+\n\
+  2. Mobile Rust targets:\n\
+       Android: rustup target add aarch64-linux-android armv7-linux-androideabi \\\n\
+                  i686-linux-android x86_64-linux-android\n\
+       iOS:     rustup target add aarch64-apple-ios aarch64-apple-ios-sim\n\
+     (Android also needs the Android SDK/NDK; iOS needs Xcode on macOS.)\n\
+\n\
+  3. Initialise the mobile projects (writes into src-tauri/gen/, which is\n\
+     .gitignore'd):\n\
+       cd src-tauri && cargo tauri android init\n\
+       cd src-tauri && cargo tauri ios init\n\
+\n\
+  4. Develop on a device or emulator:\n\
+       cd src-tauri && cargo tauri android dev\n\
+       cd src-tauri && cargo tauri ios dev\n\
+\n\
+  5. Serve your Autumn app at {remote_url} over HTTPS with a valid TLS\n\
+     certificate and `session.secure = true` (AUTUMN_SESSION__SECURE=true) in\n\
+     production. The capability file src-tauri/capabilities/remote-app.json\n\
+     grants exactly that origin access to the native device plugins.\n\
+\n\
+  6. Replace the placeholder icons before shipping:\n\
+       cargo tauri icon static/icons/icon.svg   (from the app root)\n\
+\n\
+  7. App Store note — Guideline 4.2 (Minimum Functionality) rejects bare\n\
+     website wrappers. The scaffolded notification/biometric/store plugin\n\
+     integrations exist to make the app genuinely app-like; wire them into\n\
+     your pages before submitting. See docs/guide/tauri-mobile-thin-client.md.\n"
+    )
 }
 
 // ── Placeholder icon bytes ────────────────────────────────────────────────────

--- a/autumn-cli/src/generate/tauri.rs
+++ b/autumn-cli/src/generate/tauri.rs
@@ -78,23 +78,8 @@ pub fn plan_tauri(project_root: &Path) -> Result<Plan, GenerateError> {
         render_shell_lib_rs(&package_name, &bin_name),
     );
 
-    // Icons — reuse the PWA icon when the user already ran `autumn generate pwa`
-    let icons_dir = tauri.join("icons");
-    let pwa_icon_src = project_root.join("static").join("icons").join("icon.svg");
-    if pwa_icon_src.is_file() {
-        let contents = std::fs::read_to_string(&pwa_icon_src).map_err(GenerateError::Io)?;
-        plan.create_if_absent(icons_dir.join("icon.svg"), contents);
-    } else {
-        plan.create_if_absent(icons_dir.join("icon.svg"), render_placeholder_icon_svg());
-    }
-    // Placeholder raster icons so `cargo tauri build` works immediately.
-    // Replace with proper icons by running: cargo tauri icon static/icons/icon.svg
-    plan.create_bytes(icons_dir.join("32x32.png"), PLACEHOLDER_PNG);
-    plan.create_bytes(icons_dir.join("128x128.png"), PLACEHOLDER_PNG);
-    plan.create_bytes(icons_dir.join("128x128@2x.png"), PLACEHOLDER_PNG);
-    plan.create_bytes(icons_dir.join("icon.png"), PLACEHOLDER_PNG);
-    plan.create_bytes(icons_dir.join("icon.ico"), PLACEHOLDER_ICO);
-    plan.create_bytes(icons_dir.join("icon.icns"), PLACEHOLDER_ICNS);
+    // Icons — shared with the thin-client plan.
+    plan_icons(&mut plan, project_root, &tauri)?;
 
     // Platform-specific Tauri config overlays — Tauri CLI merges them at build/dev time.
     // beforeBuildCommand and beforeDevCommand live here so tauri.conf.json is
@@ -124,6 +109,28 @@ pub fn plan_tauri(project_root: &Path) -> Result<Plan, GenerateError> {
     plan.create(tauri.join(".gitignore"), render_gitignore());
 
     Ok(plan)
+}
+
+/// Register the icon actions shared by the desktop and thin-client plans:
+/// reuse the PWA icon when the user already ran `autumn generate pwa`, then
+/// add placeholder raster icons so `cargo tauri build` works immediately.
+/// Replace them with proper icons by running: `cargo tauri icon static/icons/icon.svg`
+fn plan_icons(plan: &mut Plan, project_root: &Path, tauri: &Path) -> Result<(), GenerateError> {
+    let icons_dir = tauri.join("icons");
+    let pwa_icon_src = project_root.join("static").join("icons").join("icon.svg");
+    if pwa_icon_src.is_file() {
+        let contents = std::fs::read_to_string(&pwa_icon_src).map_err(GenerateError::Io)?;
+        plan.create_if_absent(icons_dir.join("icon.svg"), contents);
+    } else {
+        plan.create_if_absent(icons_dir.join("icon.svg"), render_placeholder_icon_svg());
+    }
+    plan.create_bytes(icons_dir.join("32x32.png"), PLACEHOLDER_PNG);
+    plan.create_bytes(icons_dir.join("128x128.png"), PLACEHOLDER_PNG);
+    plan.create_bytes(icons_dir.join("128x128@2x.png"), PLACEHOLDER_PNG);
+    plan.create_bytes(icons_dir.join("icon.png"), PLACEHOLDER_PNG);
+    plan.create_bytes(icons_dir.join("icon.ico"), PLACEHOLDER_ICO);
+    plan.create_bytes(icons_dir.join("icon.icns"), PLACEHOLDER_ICNS);
+    Ok(())
 }
 
 // ── Package metadata helper ───────────────────────────────────────────────────
@@ -1431,22 +1438,10 @@ pub fn plan_tauri_thin_client(
         render_thin_client_ios_plist(&package_name),
     );
 
-    // Icons — identical to the desktop path: reuse the PWA icon when the user
-    // already ran `autumn generate pwa`, placeholder bytes otherwise.
-    let icons_dir = tauri.join("icons");
-    let pwa_icon_src = project_root.join("static").join("icons").join("icon.svg");
-    if pwa_icon_src.is_file() {
-        let contents = std::fs::read_to_string(&pwa_icon_src).map_err(GenerateError::Io)?;
-        plan.create_if_absent(icons_dir.join("icon.svg"), contents);
-    } else {
-        plan.create_if_absent(icons_dir.join("icon.svg"), render_placeholder_icon_svg());
-    }
-    plan.create_bytes(icons_dir.join("32x32.png"), PLACEHOLDER_PNG);
-    plan.create_bytes(icons_dir.join("128x128.png"), PLACEHOLDER_PNG);
-    plan.create_bytes(icons_dir.join("128x128@2x.png"), PLACEHOLDER_PNG);
-    plan.create_bytes(icons_dir.join("icon.png"), PLACEHOLDER_PNG);
-    plan.create_bytes(icons_dir.join("icon.ico"), PLACEHOLDER_ICO);
-    plan.create_bytes(icons_dir.join("icon.icns"), PLACEHOLDER_ICNS);
+    // Icons — identical to the desktop path (shared helper): reuse the PWA
+    // icon when the user already ran `autumn generate pwa`, placeholder
+    // bytes otherwise.
+    plan_icons(&mut plan, project_root, &tauri)?;
 
     // /gen covers the `cargo tauri android init` / `ios init` output.
     plan.create(tauri.join(".gitignore"), render_gitignore());
@@ -1491,6 +1486,12 @@ fn validate_remote_url(raw: &str) -> Result<url::Url, GenerateError> {
     }
 }
 
+/// Library target name for the thin-client shell crate: `{package_name}_mobile`
+/// with hyphens underscored (Cargo library target names cannot contain hyphens).
+fn mobile_lib_name(package_name: &str) -> String {
+    package_name.replace('-', "_") + "_mobile"
+}
+
 /// `tauri.conf.json` for the thin client: productName/version/identifier and
 /// bundle icons only — no `externalBin` (no sidecar binary) and no `resources`
 /// (config files live on the remote server, not in the app bundle).
@@ -1533,7 +1534,7 @@ fn render_thin_client_tauri_conf(package_name: &str, version: &str) -> String {
 /// mobile projects link the Rust core as a library, not a binary.
 fn render_thin_client_cargo_toml(package_name: &str) -> String {
     let mobile_name = format!("{package_name}-mobile");
-    let lib_name = package_name.replace('-', "_") + "_mobile";
+    let lib_name = mobile_lib_name(package_name);
     format!(
         r#"[package]
 name = "{mobile_name}"
@@ -1574,7 +1575,7 @@ strip = true
 }
 
 fn render_thin_client_main_rs(package_name: &str) -> String {
-    let lib_name = package_name.replace('-', "_") + "_mobile";
+    let lib_name = mobile_lib_name(package_name);
     format!(
         "#![cfg_attr(not(debug_assertions), windows_subsystem = \"windows\")]\n\
          \n\

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -2871,10 +2871,29 @@ fn run_generate_command(cmd: GenerateCommands, mode: ApplyMode) {
         } => {
             let flags = generate::Flags { dry_run, force };
             let project_root = resolve_cwd();
-            let plan = remote_url.as_ref().map_or_else(
-                || generate::tauri::plan_tauri(&project_root),
-                |url| generate::tauri::plan_tauri_thin_client(&project_root, url),
-            );
+            // Mixed-mode guard (issue #1506): generating one Tauri mode over
+            // the other's files is rejected outright, even with --force —
+            // --force means "overwrite within the same mode", and the other
+            // mode's leftovers would actively break the new scaffold's build
+            // (stale capability files fail tauri-build validation on desktop;
+            // stale per-OS overlays keep running the sidecar staging scripts
+            // for a thin client). Destroy is exempt: `autumn destroy tauri
+            // [--remote-url <URL>]` is the documented remedy and must keep
+            // working on a mixed tree.
+            let guard = if mode == ApplyMode::Generate {
+                generate::tauri::ensure_no_opposite_mode_scaffold(
+                    &project_root,
+                    remote_url.is_some(),
+                )
+            } else {
+                Ok(())
+            };
+            let plan = guard.and_then(|()| {
+                remote_url.as_ref().map_or_else(
+                    || generate::tauri::plan_tauri(&project_root),
+                    |url| generate::tauri::plan_tauri_thin_client(&project_root, url),
+                )
+            });
             let result = plan.and_then(|p| match mode {
                 ApplyMode::Generate => p.execute(flags),
                 ApplyMode::Destroy => p.revert(flags),

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1801,6 +1801,7 @@ enum GenerateCommands {
     ///   autumn generate tauri
     ///   autumn generate tauri --dry-run
     ///   autumn generate tauri --remote-url https://app.example.com
+    #[allow(clippy::doc_markdown)]
     #[command(verbatim_doc_comment)]
     Tauri {
         /// Print the file plan and exit without writing anything.
@@ -2870,10 +2871,10 @@ fn run_generate_command(cmd: GenerateCommands, mode: ApplyMode) {
         } => {
             let flags = generate::Flags { dry_run, force };
             let project_root = resolve_cwd();
-            let plan = match &remote_url {
-                Some(url) => generate::tauri::plan_tauri_thin_client(&project_root, url),
-                None => generate::tauri::plan_tauri(&project_root),
-            };
+            let plan = remote_url.as_ref().map_or_else(
+                || generate::tauri::plan_tauri(&project_root),
+                |url| generate::tauri::plan_tauri_thin_client(&project_root, url),
+            );
             let result = plan.and_then(|p| match mode {
                 ApplyMode::Generate => p.execute(flags),
                 ApplyMode::Destroy => p.revert(flags),

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1791,10 +1791,16 @@ enum GenerateCommands {
     ///   - `src-tauri/stage-sidecar.sh` — build + stage the sidecar (Unix)
     ///   - `src-tauri/stage-sidecar.ps1`— build + stage the sidecar (Windows)
     ///
+    /// With `--remote-url <URL>` the generator instead scaffolds a **mobile
+    /// thin client** (issue #1506): no sidecar — the webview loads the given
+    /// remote HTTPS Autumn server directly, and a `capabilities/remote-app.json`
+    /// grants that origin access to the notification/biometric/store plugins.
+    ///
     /// Example:
     ///
     ///   autumn generate tauri
     ///   autumn generate tauri --dry-run
+    ///   autumn generate tauri --remote-url https://app.example.com
     #[command(verbatim_doc_comment)]
     Tauri {
         /// Print the file plan and exit without writing anything.
@@ -1803,6 +1809,10 @@ enum GenerateCommands {
         /// Overwrite existing files instead of erroring on collision.
         #[arg(long)]
         force: bool,
+        /// Scaffold a mobile thin client whose webview loads this remote HTTPS
+        /// URL instead of a local sidecar (plain http allowed for localhost dev).
+        #[arg(long, value_name = "URL")]
+        remote_url: Option<String>,
     },
     /// Scaffold a multi-step form wizard with session-backed state and per-step validation.
     ///
@@ -2853,9 +2863,17 @@ fn run_generate_command(cmd: GenerateCommands, mode: ApplyMode) {
             };
             apply_plan(plan, generate::Flags { dry_run, force }, mode);
         }
-        GenerateCommands::Tauri { dry_run, force } => {
+        GenerateCommands::Tauri {
+            dry_run,
+            force,
+            remote_url,
+        } => {
             let flags = generate::Flags { dry_run, force };
-            let plan = generate::tauri::plan_tauri(&resolve_cwd());
+            let project_root = resolve_cwd();
+            let plan = match &remote_url {
+                Some(url) => generate::tauri::plan_tauri_thin_client(&project_root, url),
+                None => generate::tauri::plan_tauri(&project_root),
+            };
             let result = plan.and_then(|p| match mode {
                 ApplyMode::Generate => p.execute(flags),
                 ApplyMode::Destroy => p.revert(flags),
@@ -2863,7 +2881,13 @@ fn run_generate_command(cmd: GenerateCommands, mode: ApplyMode) {
             match result {
                 Ok(()) => {
                     if mode == ApplyMode::Generate && !dry_run {
-                        println!("\n{}", generate::tauri::render_prerequisites());
+                        match &remote_url {
+                            Some(url) => println!(
+                                "\n{}",
+                                generate::tauri::render_thin_client_prerequisites(url)
+                            ),
+                            None => println!("\n{}", generate::tauri::render_prerequisites()),
+                        }
                     }
                 }
                 Err(e) => {
@@ -5971,7 +5995,8 @@ mod tests {
             cli.command,
             Commands::Generate(GenerateCommands::Tauri {
                 dry_run: false,
-                force: false
+                force: false,
+                remote_url: None
             })
         ));
     }
@@ -5979,21 +6004,68 @@ mod tests {
     #[test]
     fn parse_generate_tauri_dry_run() {
         let cli = Cli::try_parse_from(["autumn", "generate", "tauri", "--dry-run"]).unwrap();
-        let Commands::Generate(GenerateCommands::Tauri { dry_run, force }) = cli.command else {
+        let Commands::Generate(GenerateCommands::Tauri {
+            dry_run,
+            force,
+            remote_url,
+        }) = cli.command
+        else {
             panic!("expected Tauri variant");
         };
         assert!(dry_run);
         assert!(!force);
+        assert!(remote_url.is_none());
     }
 
     #[test]
     fn parse_generate_tauri_force() {
         let cli = Cli::try_parse_from(["autumn", "generate", "tauri", "--force"]).unwrap();
-        let Commands::Generate(GenerateCommands::Tauri { dry_run, force }) = cli.command else {
+        let Commands::Generate(GenerateCommands::Tauri {
+            dry_run,
+            force,
+            remote_url,
+        }) = cli.command
+        else {
             panic!("expected Tauri variant");
         };
         assert!(!dry_run);
         assert!(force);
+        assert!(remote_url.is_none());
+    }
+
+    #[test]
+    fn parse_generate_tauri_remote_url() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "generate",
+            "tauri",
+            "--remote-url",
+            "https://app.example.com",
+        ])
+        .unwrap();
+        let Commands::Generate(GenerateCommands::Tauri {
+            dry_run,
+            force,
+            remote_url,
+        }) = cli.command
+        else {
+            panic!("expected Tauri variant");
+        };
+        assert!(!dry_run);
+        assert!(!force);
+        assert_eq!(remote_url.as_deref(), Some("https://app.example.com"));
+    }
+
+    #[test]
+    fn parse_generate_tauri_remote_url_defaults_none() {
+        let cli = Cli::try_parse_from(["autumn", "generate", "tauri"]).unwrap();
+        let Commands::Generate(GenerateCommands::Tauri { remote_url, .. }) = cli.command else {
+            panic!("expected Tauri variant");
+        };
+        assert!(
+            remote_url.is_none(),
+            "--remote-url must default to None so the desktop sidecar path stays the default"
+        );
     }
 
     #[test]

--- a/autumn-cli/tests/integration/mod.rs
+++ b/autumn-cli/tests/integration/mod.rs
@@ -6,4 +6,5 @@ mod migrate_down;
 mod repo_hygiene;
 #[cfg(unix)]
 mod serve;
+mod tauri_mobile_thin_client;
 mod webhook_sim;

--- a/autumn-cli/tests/integration/tauri_mobile_thin_client.rs
+++ b/autumn-cli/tests/integration/tauri_mobile_thin_client.rs
@@ -75,6 +75,31 @@ fn generate_tauri_remote_url_scaffolds_thin_client() {
         capability.contains("https://app.example.com"),
         "capability file must grant the remote URL:\n{capability}"
     );
+    assert!(
+        !capability.contains("biometric:default"),
+        "base capability must not grant biometric — the plugin is not compiled \
+         on desktop, so tauri-build would reject the permission there:\n{capability}"
+    );
+
+    let mobile_capability_path = project.join("src-tauri/capabilities/remote-app-mobile.json");
+    let mobile_capability = fs::read_to_string(&mobile_capability_path).unwrap_or_else(|e| {
+        panic!(
+            "thin-client scaffold must write {}: {e}",
+            mobile_capability_path.display()
+        )
+    });
+    assert!(
+        mobile_capability.contains("https://app.example.com"),
+        "mobile capability file must grant the remote URL:\n{mobile_capability}"
+    );
+    assert!(
+        mobile_capability.contains("biometric:default"),
+        "mobile capability file must grant biometric:\n{mobile_capability}"
+    );
+    assert!(
+        mobile_capability.contains(r#""platforms": ["android", "iOS"]"#),
+        "mobile capability must be restricted to Android/iOS:\n{mobile_capability}"
+    );
 
     let lib = fs::read_to_string(project.join("src-tauri/src/lib.rs"))
         .expect("thin-client scaffold must write src-tauri/src/lib.rs");
@@ -202,6 +227,12 @@ fn destroy_tauri_remote_url_reverts_thin_client_scaffold() {
         "destroy must remove the generated capability file"
     );
     assert!(
+        !project
+            .join("src-tauri/capabilities/remote-app-mobile.json")
+            .exists(),
+        "destroy must remove the generated mobile capability file"
+    );
+    assert!(
         !project.join("src-tauri/src/lib.rs").exists(),
         "destroy must remove the generated shell sources"
     );
@@ -225,6 +256,8 @@ fn thin_client_docs_page_covers_required_topics() {
         "notification:default",
         "biometric:default",
         "store:default",
+        "remote-app-mobile.json",
+        "platforms",
         "SameSite=None",
         "Authorization",
         "Guideline 4.2",

--- a/autumn-cli/tests/integration/tauri_mobile_thin_client.rs
+++ b/autumn-cli/tests/integration/tauri_mobile_thin_client.rs
@@ -9,7 +9,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
-fn autumn_bin() -> &'static str {
+const fn autumn_bin() -> &'static str {
     env!("CARGO_BIN_EXE_autumn")
 }
 

--- a/autumn-cli/tests/integration/tauri_mobile_thin_client.rs
+++ b/autumn-cli/tests/integration/tauri_mobile_thin_client.rs
@@ -1,0 +1,237 @@
+//! E2E tests for `autumn generate tauri --remote-url <URL>` — the mobile
+//! thin-client mode (issue #1506).
+//!
+//! All tests are pure codegen assertions: they run the real `autumn` binary in
+//! a tempdir and inspect files on disk. Nothing invokes the Tauri CLI, no
+//! network, no mobile toolchain.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn autumn_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_autumn")
+}
+
+/// Scaffold a fresh autumn project with `autumn new` and return
+/// (tempdir guard, project dir).
+fn fresh_project(name: &str) -> (tempfile::TempDir, PathBuf) {
+    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let output = Command::new(autumn_bin())
+        .args(["new", name])
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("failed to run `autumn new`");
+    assert!(
+        output.status.success(),
+        "autumn new failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let project = temp_dir.path().join(name);
+    (temp_dir, project)
+}
+
+/// Run the autumn binary with `args` in `dir` and return the raw output.
+fn run_autumn(dir: &Path, args: &[&str]) -> Output {
+    Command::new(autumn_bin())
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to run autumn")
+}
+
+fn assert_success(output: &Output, what: &str) {
+    assert!(
+        output.status.success(),
+        "{what} failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn generate_tauri_remote_url_scaffolds_thin_client() {
+    let (_tmp, project) = fresh_project("thin-client-app");
+    let output = run_autumn(
+        &project,
+        &[
+            "generate",
+            "tauri",
+            "--remote-url",
+            "https://app.example.com",
+        ],
+    );
+    assert_success(&output, "autumn generate tauri --remote-url");
+
+    let capability_path = project.join("src-tauri/capabilities/remote-app.json");
+    let capability = fs::read_to_string(&capability_path).unwrap_or_else(|e| {
+        panic!(
+            "thin-client scaffold must write {}: {e}",
+            capability_path.display()
+        )
+    });
+    assert!(
+        capability.contains("https://app.example.com"),
+        "capability file must grant the remote URL:\n{capability}"
+    );
+
+    let lib = fs::read_to_string(project.join("src-tauri/src/lib.rs"))
+        .expect("thin-client scaffold must write src-tauri/src/lib.rs");
+    assert!(
+        lib.contains("https://app.example.com"),
+        "generated lib.rs must point the webview at the remote URL:\n{lib}"
+    );
+
+    assert!(
+        !project.join("src-tauri/stage-sidecar.sh").exists(),
+        "thin-client scaffold must not emit sidecar staging scripts"
+    );
+}
+
+#[test]
+fn generate_tauri_remote_url_rejects_http() {
+    let (_tmp, project) = fresh_project("thin-client-http-app");
+    let output = run_autumn(
+        &project,
+        &[
+            "generate",
+            "tauri",
+            "--remote-url",
+            "http://app.example.com",
+        ],
+    );
+    assert!(
+        !output.status.success(),
+        "a plain-http --remote-url must be rejected with a non-zero exit:\nstdout: {}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("https"),
+        "the error must point at the https requirement:\n{stderr}"
+    );
+    assert!(
+        !project.join("src-tauri").exists(),
+        "a rejected --remote-url must not leave a partial src-tauri/ behind"
+    );
+}
+
+#[test]
+fn generate_tauri_without_flag_still_scaffolds_desktop_sidecar() {
+    let (_tmp, project) = fresh_project("desktop-sidecar-app");
+    let output = run_autumn(&project, &["generate", "tauri"]);
+    assert_success(&output, "autumn generate tauri");
+
+    assert!(
+        project.join("src-tauri/stage-sidecar.sh").is_file(),
+        "no-flag desktop scaffold must still emit stage-sidecar.sh"
+    );
+    let conf = fs::read_to_string(project.join("src-tauri/tauri.conf.json"))
+        .expect("desktop scaffold must write tauri.conf.json");
+    assert!(
+        conf.contains("externalBin"),
+        "desktop tauri.conf.json must keep the sidecar externalBin:\n{conf}"
+    );
+    assert!(
+        !project.join("src-tauri/capabilities").exists(),
+        "desktop scaffold must not grow a capabilities/ dir from the thin-client feature"
+    );
+}
+
+#[test]
+fn generate_tauri_remote_url_dry_run_writes_nothing() {
+    let (_tmp, project) = fresh_project("thin-client-dry-app");
+    let output = run_autumn(
+        &project,
+        &[
+            "generate",
+            "tauri",
+            "--dry-run",
+            "--remote-url",
+            "https://app.example.com",
+        ],
+    );
+    assert_success(&output, "autumn generate tauri --dry-run --remote-url");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("capabilities/remote-app.json"),
+        "dry-run must print the planned capability file path:\n{stdout}"
+    );
+    assert!(
+        !project.join("src-tauri").exists(),
+        "dry-run must not write anything to disk"
+    );
+}
+
+#[test]
+fn destroy_tauri_remote_url_reverts_thin_client_scaffold() {
+    let (_tmp, project) = fresh_project("thin-client-destroy-app");
+    let generate = run_autumn(
+        &project,
+        &[
+            "generate",
+            "tauri",
+            "--remote-url",
+            "https://app.example.com",
+        ],
+    );
+    assert_success(&generate, "autumn generate tauri --remote-url");
+    assert!(
+        project
+            .join("src-tauri/capabilities/remote-app.json")
+            .is_file()
+    );
+
+    let destroy = run_autumn(
+        &project,
+        &[
+            "destroy",
+            "tauri",
+            "--remote-url",
+            "https://app.example.com",
+        ],
+    );
+    assert_success(&destroy, "autumn destroy tauri --remote-url");
+
+    assert!(
+        !project
+            .join("src-tauri/capabilities/remote-app.json")
+            .exists(),
+        "destroy must remove the generated capability file"
+    );
+    assert!(
+        !project.join("src-tauri/src/lib.rs").exists(),
+        "destroy must remove the generated shell sources"
+    );
+}
+
+#[test]
+fn thin_client_docs_page_covers_required_topics() {
+    // The docs page is a co-equal deliverable of issue #1506; this pins it to
+    // the generator so they cannot drift apart silently.
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("autumn-cli should live under the workspace root")
+        .to_path_buf();
+    let doc_path = workspace_root.join("docs/guide/tauri-mobile-thin-client.md");
+    let doc = fs::read_to_string(&doc_path)
+        .unwrap_or_else(|e| panic!("{} must exist: {e}", doc_path.display()));
+
+    for anchor in [
+        "remote",
+        "urls",
+        "notification:default",
+        "biometric:default",
+        "store:default",
+        "SameSite=None",
+        "Authorization",
+        "Guideline 4.2",
+    ] {
+        assert!(
+            doc.contains(anchor),
+            "docs/guide/tauri-mobile-thin-client.md must cover '{anchor}'"
+        );
+    }
+}

--- a/autumn-cli/tests/integration/tauri_mobile_thin_client.rs
+++ b/autumn-cli/tests/integration/tauri_mobile_thin_client.rs
@@ -239,6 +239,176 @@ fn destroy_tauri_remote_url_reverts_thin_client_scaffold() {
 }
 
 #[test]
+fn generate_tauri_desktop_over_thin_client_is_rejected_even_with_force() {
+    let (_tmp, project) = fresh_project("switch-to-desktop-app");
+    let thin = run_autumn(
+        &project,
+        &[
+            "generate",
+            "tauri",
+            "--remote-url",
+            "https://app.example.com",
+        ],
+    );
+    assert_success(&thin, "autumn generate tauri --remote-url");
+
+    // Both a plain run and a --force run must refuse: --force means
+    // "overwrite within the same mode", never "silently mix modes" —
+    // stale capability files would break the desktop shell build
+    // (tauri-build loads every file under src-tauri/capabilities/).
+    for args in [
+        &["generate", "tauri"][..],
+        &["generate", "tauri", "--force"][..],
+    ] {
+        let output = run_autumn(&project, args);
+        assert!(
+            !output.status.success(),
+            "`autumn {}` over a thin-client scaffold must fail:\nstdout: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("destroy tauri --remote-url"),
+            "the error must point at the matching destroy command:\n{stderr}"
+        );
+    }
+
+    // The rejection must leave the existing thin-client scaffold untouched
+    // and write no desktop files.
+    assert!(
+        project
+            .join("src-tauri/capabilities/remote-app.json")
+            .is_file(),
+        "rejection must not delete the existing thin-client scaffold"
+    );
+    assert!(
+        !project.join("src-tauri/stage-sidecar.sh").exists(),
+        "rejection must not write any desktop files"
+    );
+
+    // The prescribed remedy works: destroy the thin client, then desktop
+    // generates cleanly with no stale capability files left over.
+    let destroy = run_autumn(
+        &project,
+        &[
+            "destroy",
+            "tauri",
+            "--remote-url",
+            "https://app.example.com",
+        ],
+    );
+    assert_success(&destroy, "autumn destroy tauri --remote-url");
+    let desktop = run_autumn(&project, &["generate", "tauri"]);
+    assert_success(&desktop, "autumn generate tauri after destroy");
+    assert!(
+        !project.join("src-tauri/capabilities").exists(),
+        "mode switch via destroy must leave no stale capability files"
+    );
+    assert!(project.join("src-tauri/stage-sidecar.sh").is_file());
+}
+
+#[test]
+fn generate_tauri_thin_client_over_desktop_is_rejected_even_with_force() {
+    let (_tmp, project) = fresh_project("switch-to-thin-app");
+    let desktop = run_autumn(&project, &["generate", "tauri"]);
+    assert_success(&desktop, "autumn generate tauri");
+
+    for args in [
+        &[
+            "generate",
+            "tauri",
+            "--remote-url",
+            "https://app.example.com",
+        ][..],
+        &[
+            "generate",
+            "tauri",
+            "--force",
+            "--remote-url",
+            "https://app.example.com",
+        ][..],
+    ] {
+        let output = run_autumn(&project, args);
+        assert!(
+            !output.status.success(),
+            "`autumn {}` over a desktop scaffold must fail:\nstdout: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("`autumn destroy tauri`"),
+            "the error must point at the matching destroy command:\n{stderr}"
+        );
+    }
+
+    // The rejection must leave the desktop scaffold untouched and write no
+    // thin-client files.
+    assert!(
+        project.join("src-tauri/stage-sidecar.sh").is_file(),
+        "rejection must not delete the existing desktop scaffold"
+    );
+    assert!(
+        !project.join("src-tauri/capabilities").exists(),
+        "rejection must not write any thin-client files"
+    );
+
+    // The prescribed remedy works: destroy the desktop scaffold, then the
+    // thin client generates cleanly with no stale sidecar files left over.
+    let destroy = run_autumn(&project, &["destroy", "tauri"]);
+    assert_success(&destroy, "autumn destroy tauri");
+    let thin = run_autumn(
+        &project,
+        &[
+            "generate",
+            "tauri",
+            "--remote-url",
+            "https://app.example.com",
+        ],
+    );
+    assert_success(&thin, "autumn generate tauri --remote-url after destroy");
+    for stale in [
+        "src-tauri/stage-sidecar.sh",
+        "src-tauri/stage-sidecar.ps1",
+        "src-tauri/tauri.linux.conf.json",
+        "src-tauri/tauri.macos.conf.json",
+        "src-tauri/tauri.windows.conf.json",
+    ] {
+        assert!(
+            !project.join(stale).exists(),
+            "mode switch via destroy must leave no stale desktop file {stale}"
+        );
+    }
+    assert!(
+        project
+            .join("src-tauri/capabilities/remote-app.json")
+            .is_file()
+    );
+}
+
+#[test]
+fn destroy_tauri_still_works_on_a_mixed_tree() {
+    // Users who mixed modes with an older autumn (before the guard) need the
+    // documented remedy to actually run — destroy must never be blocked by
+    // the other mode's leftovers.
+    let (_tmp, project) = fresh_project("mixed-tree-destroy-app");
+    let desktop = run_autumn(&project, &["generate", "tauri"]);
+    assert_success(&desktop, "autumn generate tauri");
+    // Simulate the old bug: thin-client capability files alongside the
+    // desktop scaffold.
+    fs::create_dir_all(project.join("src-tauri/capabilities")).unwrap();
+    fs::write(project.join("src-tauri/capabilities/remote-app.json"), "{}").unwrap();
+
+    let destroy = run_autumn(&project, &["destroy", "tauri"]);
+    assert_success(&destroy, "autumn destroy tauri on a mixed tree");
+    assert!(
+        !project.join("src-tauri/stage-sidecar.sh").exists(),
+        "destroy must remove the desktop scaffold despite thin-client leftovers"
+    );
+}
+
+#[test]
 fn thin_client_docs_page_covers_required_topics() {
     // The docs page is a co-equal deliverable of issue #1506; this pins it to
     // the generator so they cannot drift apart silently.
@@ -261,6 +431,7 @@ fn thin_client_docs_page_covers_required_topics() {
         "SameSite=None",
         "Authorization",
         "Guideline 4.2",
+        "Switching between desktop and thin-client scaffolds",
     ] {
         assert!(
             doc.contains(anchor),

--- a/docs/guide/tauri-mobile-thin-client.md
+++ b/docs/guide/tauri-mobile-thin-client.md
@@ -43,14 +43,15 @@ autumn generate tauri --remote-url https://app.example.com
 ```
 
 The URL must be `https://`; plain `http://` is accepted only for
-`localhost` / `127.0.0.1` / `::1` dev servers, and URLs with embedded userinfo
-(`https://user:pass@…`) are rejected outright. `--dry-run` prints the file plan
-without writing, `--force` overwrites collisions, and
+`localhost` / `127.0.0.1` / `::1` / `10.0.2.2` dev servers (the last is the
+Android emulator's alias for the host machine's loopback), and URLs with
+embedded userinfo (`https://user:pass@…`) are rejected outright. `--dry-run`
+prints the file plan without writing, `--force` overwrites collisions, and
 `autumn destroy tauri --remote-url <URL>` reverts the scaffold.
 
 ```
 src-tauri/
-  tauri.conf.json              — productName, identifier, version, bundle icons
+  tauri.conf.json              — productName, identifier, withGlobalTauri, icons
   Cargo.toml                   — "{app}-mobile" crate; staticlib/cdylib for android/ios init
   build.rs                     — calls tauri_build::build()
   Info.ios.plist               — NSFaceIDUsageDescription for Face ID
@@ -79,6 +80,31 @@ cargo tauri android init && cargo tauri android dev
 cargo tauri ios init && cargo tauri ios dev
 ```
 
+> **Before `android init` / `ios init`:** the scaffold derives a placeholder
+> bundle identifier by stripping `-`/`_` from your package name
+> (`demo-app` → `com.example.demoapp`) — Android forbids hyphens in
+> application ids and Apple forbids underscores. Replace the placeholder with
+> your real reverse-DNS identifier in `tauri.conf.json` *before* running the
+> init commands, because the generated mobile projects bake it in.
+
+### Developing against a local server on Android
+
+Inside the app, `localhost` is the *phone*, not your workstation. Two dev
+routes reach a server running on the host machine:
+
+- **Emulator:** scaffold with `--remote-url http://10.0.2.2:3000` — the
+  emulator's built-in alias for the host's loopback, accepted by the
+  generator's http dev exception.
+- **Physical device:** run `adb reverse tcp:3000 tcp:3000`, then a
+  `--remote-url http://localhost:3000` scaffold works as-is — the device's
+  own `localhost:3000` is forwarded to the host.
+
+Either way, Android blocks cleartext (plain-http) traffic by default on API
+28+: for an http dev URL, set `android:usesCleartextTraffic="true"` (or a
+network-security-config scoped to your dev host) on the `<application>`
+element under `src-tauri/gen/android/`, and remove it before shipping.
+Release builds should always point at the `https://` production URL.
+
 ## Routing the webview to a remote HTTPS domain
 
 The generated `src/lib.rs` opens the main window directly on your server using
@@ -89,7 +115,7 @@ tauri::WebviewWindowBuilder::new(
     app,
     "main",
     tauri::WebviewUrl::External(
-        "https://app.example.com"
+        "https://app.example.com/"
             .parse()
             .expect("remote URL was validated at generate time"),
     ),
@@ -171,26 +197,31 @@ bundled local pages):
   wildcard: every origin listed here can drive the device APIs.
 - `permissions` — the default permission set of each plugin plus Tauri's core
   APIs (`core:default`, `notification:default`, `biometric:default`,
-  `store:default`).
+  `store:default`). `core:default` is kept because the injected
+  `window.__TAURI__` API relies on the core event/window plumbing it permits;
+  prune it to a narrower core subset only after verifying the trimmed set on
+  a device.
 
 > **Caveat:** on Linux and Android, Tauri cannot distinguish an embedded
 > iframe from the window itself — a page your app embeds from another origin
 > could be treated as the remote origin. Avoid third-party iframes on pages
 > served to the mobile shell.
 
-Your server pages call the plugins through the `@tauri-apps/api` npm packages
-— or, simplest for a server-rendered Maud/htmx app, via the global that Tauri
-injects when `app.withGlobalTauri` is enabled, or a small bundled script. The
-samples below use the plugin packages; they run *on your remote Autumn pages*,
-which is exactly what the `remote.urls` grant enables.
+The generated `tauri.conf.json` sets `"withGlobalTauri": true`, so Tauri
+injects its API — including the registered plugins' bindings — into pages
+served by the granted origin as the `window.__TAURI__` global. That global is
+the natural form for a server-rendered Maud/htmx app: no npm packages, no
+bundler. The samples below use it; they run *on your remote Autumn pages*,
+which is exactly what the `remote.urls` grant enables. (If your front end
+does have a bundler, the same APIs ship as the `@tauri-apps/plugin-notification`,
+`@tauri-apps/plugin-biometric`, and `@tauri-apps/plugin-store` npm packages —
+`import { … } from '@tauri-apps/plugin-…'` instead of reading the global.)
 
 Detect the shell first, so the same pages degrade gracefully in an ordinary
-browser:
+browser, where the global does not exist:
 
 ```js
-import { isTauri } from '@tauri-apps/api/core';
-
-if (isTauri()) {
+if (window.__TAURI__) {
   // running inside the mobile shell — native plugins are available
 } else {
   // plain browser — fall back to web APIs or hide native-only UI
@@ -200,11 +231,8 @@ if (isTauri()) {
 ### Notifications
 
 ```js
-import {
-  isPermissionGranted,
-  requestPermission,
-  sendNotification,
-} from '@tauri-apps/plugin-notification';
+const { isPermissionGranted, requestPermission, sendNotification } =
+  window.__TAURI__.notification;
 
 let granted = await isPermissionGranted();
 if (!granted) {
@@ -224,7 +252,7 @@ shell still builds on desktop for local smoke-testing. On iOS the generated
 the first Face ID prompt kills the app.
 
 ```js
-import { authenticate } from '@tauri-apps/plugin-biometric';
+const { authenticate } = window.__TAURI__.biometric;
 
 try {
   await authenticate('Unlock your account', {
@@ -239,7 +267,7 @@ try {
 ### Device storage
 
 ```js
-import { load } from '@tauri-apps/plugin-store';
+const { load } = window.__TAURI__.store;
 
 const store = await load('app-data.json');
 await store.set('draft', { body: 'unsent message…' });
@@ -267,16 +295,29 @@ cookie. Requirements and caveats specific to a *remote HTTPS origin inside a
 mobile shell*:
 
 - **`Secure` is mandatory.** Set `session.secure = true`
-  (`AUTUMN_SESSION__SECURE=true`) in production. Cookies without `Secure` over
-  HTTPS are increasingly dropped by mobile webviews.
+  (`AUTUMN_SESSION__SECURE=true`) in production. `SameSite=None` — which any
+  cross-context request below needs — is rejected outright without `Secure`,
+  the `__Secure-`/`__Host-` cookie-name prefixes require it, and it
+  guarantees the session cookie never transits plaintext HTTP.
 - **Set `SameSite` explicitly.** Since your pages, form posts, and htmx
   requests all originate from your own origin, `SameSite=Lax` (Autumn's
-  sensible default) works for normal navigation. But iOS 18+ WKWebView treats
-  cookies with *no* `SameSite` attribute inconsistently (historically `None`,
-  now effectively `Lax`), so never rely on the unset default. If a request to
+  sensible default; the `session.same_site` knob,
+  `AUTUMN_SESSION__SAME_SITE`) works for normal navigation. Never rely on the
+  *unset* default, though: iOS 18.0 briefly changed WKWebView's
+  unset-`SameSite` default from `None` to `Lax` — reverted in iOS 18.0.1
+  ([WebKit bug 279153](https://bugs.webkit.org/show_bug.cgi?id=279153)) —
+  breaking every app that leaned on the implicit behavior. If a request to
   your server originates from a *different* context (a plugin webview, an
   OAuth popup, an embedded page), the cookie must be `SameSite=None; Secure`
   to be attached cross-site.
+- **CSRF protection keeps working — leave it on.** Autumn's CSRF middleware
+  (`security.csrf`, enabled by the `prod` profile's smart defaults) is
+  double-submit: it sets an `autumn-csrf` cookie and expects the token echoed
+  back in the `X-CSRF-Token` header or `_csrf` form field on mutating
+  requests. Pages and htmx posts rendered by your server carry it exactly as
+  they do in a browser, so cookie mode needs no changes. And if you do relax
+  a cookie to `SameSite=None`, the browser-side CSRF mitigation is gone — the
+  middleware is then your only line of defence.
 - **Persistence is flaky on iOS.** WKWebView's cookie persistence interacts
   badly with Intelligent Tracking Prevention and has long-standing
   synchronization bugs (see WebKit bug 213510): a session cookie can survive a
@@ -286,7 +327,8 @@ mobile shell*:
   re-authentication fallback — the token handoff below is a good one — so a
   dropped cookie degrades to a background token refresh instead of a login
   screen.
-- Autumn knobs that matter here: `session.secure`, the signing secret
+- Autumn knobs that matter here: `session.secure`, `session.same_site`, the
+  CSRF settings (`security.csrf`), the signing secret
   (`AUTUMN_SECURITY__SIGNING_SECRET`), and trusted hosts
   (`AUTUMN_SECURITY__TRUSTED_HOSTS__HOSTS`).
 
@@ -297,7 +339,7 @@ store it natively via the store plugin. On successful login your page stores
 the token:
 
 ```js
-import { load } from '@tauri-apps/plugin-store';
+const { load } = window.__TAURI__.store;
 
 // after POST /login succeeds and returns { token }
 const store = await load('auth.json');
@@ -321,12 +363,19 @@ Issue short-lived access tokens and rotate them server-side (a refresh
 endpoint the shell calls when a request comes back `401`); revoke on logout by
 deleting the store entry *and* invalidating server-side.
 
+**CSRF interplay:** Autumn's CSRF middleware validates *all* mutating
+requests, including bearer-token `fetch` posts like the one above. Either
+attach the token too (read the `autumn-csrf` cookie into the `X-CSRF-Token`
+header), or register your token-authenticated API paths under
+`security.csrf.exempt_paths` (prefix match, e.g. `"/api/"`) — that knob
+exists precisely for endpoints that authenticate with non-cookie credentials.
+
 **Biometric-gated token release** ties the two plugin integrations together —
 require Face ID / fingerprint before the stored token is read:
 
 ```js
-import { authenticate } from '@tauri-apps/plugin-biometric';
-import { load } from '@tauri-apps/plugin-store';
+const { authenticate } = window.__TAURI__.biometric;
+const { load } = window.__TAURI__.store;
 
 async function unlockToken() {
   await authenticate('Unlock your account'); // throws if cancelled/unavailable

--- a/docs/guide/tauri-mobile-thin-client.md
+++ b/docs/guide/tauri-mobile-thin-client.md
@@ -120,7 +120,7 @@ hand-maintained project.
 
 **Server-side prerequisites** for the remote origin:
 
-- A valid, publicly-trusted TLS certificate — mobile webviews do not show
+- A valid, publicly trusted TLS certificate — mobile webviews do not show
   certificate-error interstitials; a bad cert is just a blank screen.
 - `session.secure = true` (or `AUTUMN_SESSION__SECURE=true`) in production so
   session cookies carry the `Secure` attribute (see

--- a/docs/guide/tauri-mobile-thin-client.md
+++ b/docs/guide/tauri-mobile-thin-client.md
@@ -27,7 +27,7 @@ and shipping a server fix updates every installed app instantly. Choose the
 [desktop sidecar model](tauri.md) instead when the app must be fully
 self-contained on the user's machine.
 
-**Trust model, up front:** the generated capability file grants pages served
+**Trust model, up front:** the generated capability files grant pages served
 from your remote origin the right to invoke native device APIs on the phone.
 That origin is *fully trusted* — a compromised server can call every permitted
 plugin command. Keep the grant scoped to exactly one origin you control, keep
@@ -57,6 +57,7 @@ src-tauri/
   Info.ios.plist               — NSFaceIDUsageDescription for Face ID
   capabilities/
     remote-app.json            — grants the remote origin the plugin permissions
+    remote-app-mobile.json     — biometric grant, restricted to android/iOS
   src/
     main.rs                    — calls {app}_mobile::run()
     lib.rs                     — plugin registration + webview → remote URL
@@ -165,16 +166,17 @@ rejection risk by making the app app-like, but nothing guarantees approval —
 review is holistic, and the strongest defence is UX that feels like an app
 (native-feature use, offline handling, no browser chrome metaphors).
 
-### The capability file, field by field
+### The capability files, field by field
 
-`src-tauri/capabilities/remote-app.json` is what lets JavaScript served by your
-*remote* server call into the native plugins (by default, Tauri only trusts
-bundled local pages):
+The two files under `src-tauri/capabilities/` are what let JavaScript served
+by your *remote* server call into the native plugins (by default, Tauri only
+trusts bundled local pages). `remote-app.json` grants the plugins that are
+compiled on every target:
 
 ```json
 {
   "identifier": "remote-autumn-app",
-  "description": "Allow pages served by the remote Autumn server to use the native device plugins (notifications, biometric authentication, key-value storage).",
+  "description": "Allow pages served by the remote Autumn server to use the native device plugins (notifications, key-value storage).",
   "windows": ["main"],
   "remote": {
     "urls": ["https://app.example.com"]
@@ -182,22 +184,48 @@ bundled local pages):
   "permissions": [
     "core:default",
     "notification:default",
-    "biometric:default",
     "store:default"
   ]
 }
 ```
 
-- `identifier` — a unique name for this capability; tauri-build auto-discovers
+`remote-app-mobile.json` carries the biometric grant, restricted via
+`platforms` to Android and iOS:
+
+```json
+{
+  "identifier": "remote-autumn-app-mobile",
+  "description": "Allow pages served by the remote Autumn server to use biometric authentication (Android/iOS only — the plugin does not exist on desktop).",
+  "platforms": ["android", "iOS"],
+  "windows": ["main"],
+  "remote": {
+    "urls": ["https://app.example.com"]
+  },
+  "permissions": [
+    "biometric:default"
+  ]
+}
+```
+
+- `identifier` — a unique name for each capability; tauri-build auto-discovers
   every JSON file under `src-tauri/capabilities/`.
+- `platforms` — which build targets the capability applies to (valid values:
+  `linux`, `macOS`, `windows`, `android`, `iOS`; omitted means all). The
+  biometric grant lives in its own platform-restricted file because
+  tauri-build validates every applicable capability's permissions against the
+  plugins compiled for the current target — `tauri-plugin-biometric` is
+  target-gated to Android/iOS in the generated `Cargo.toml`, so an
+  unrestricted `biometric:default` would fail a desktop `cargo tauri dev`
+  smoke-test build. (Capabilities cannot scope *individual* permissions to
+  platforms — hence two files.)
 - `windows` — which webview windows the grant applies to (only `main` exists
   in this scaffold).
 - `remote.urls` — the origins whose pages may invoke the permitted commands.
   The generator emits exactly the origin you passed — never widen this to a
   wildcard: every origin listed here can drive the device APIs.
 - `permissions` — the default permission set of each plugin plus Tauri's core
-  APIs (`core:default`, `notification:default`, `biometric:default`,
-  `store:default`). `core:default` is kept because the injected
+  APIs (`core:default`, `notification:default`, `store:default`, and — on
+  mobile — `biometric:default`). `core:default` is kept because the injected
   `window.__TAURI__` API relies on the core event/window plumbing it permits;
   prune it to a narrower core subset only after verifying the trimmed set on
   a device.
@@ -246,8 +274,10 @@ if (granted) {
 ### Biometric authentication
 
 The biometric plugin exists only on Android and iOS — its Cargo dependency is
-target-gated and its registration in `lib.rs` is `#[cfg(mobile)]`-gated, so the
-shell still builds on desktop for local smoke-testing. On iOS the generated
+target-gated, its registration in `lib.rs` is `#[cfg(mobile)]`-gated, and its
+capability grant lives in the `platforms`-restricted
+`capabilities/remote-app-mobile.json`, so the shell still builds on desktop
+for local smoke-testing. On iOS the generated
 `Info.ios.plist` provides the required `NSFaceIDUsageDescription`; without it,
 the first Face ID prompt kills the app.
 

--- a/docs/guide/tauri-mobile-thin-client.md
+++ b/docs/guide/tauri-mobile-thin-client.md
@@ -106,6 +106,28 @@ network-security-config scoped to your dev host) on the `<application>`
 element under `src-tauri/gen/android/`, and remove it before shipping.
 Release builds should always point at the `https://` production URL.
 
+### Switching between desktop and thin-client scaffolds
+
+Both modes write to `src-tauri/`, but their file sets only partially overlap,
+so generating one mode on top of the other would leave stale files behind:
+Tauri loads *every* capability file under `src-tauri/capabilities/`, so
+leftover thin-client grants fail `tauri-build` validation against the desktop
+shell crate; in the other direction, leftover per-OS `tauri.*.conf.json`
+overlays keep running the sidecar staging scripts on every
+`cargo tauri build`. The generator therefore refuses to scaffold one mode
+while the other's marker files are present — even with `--force`, which only
+overwrites files within the same mode. Destroy the existing scaffold first:
+
+```bash
+# thin client → desktop
+autumn destroy tauri --remote-url https://app.example.com
+autumn generate tauri
+
+# desktop → thin client
+autumn destroy tauri
+autumn generate tauri --remote-url https://app.example.com
+```
+
 ## Routing the webview to a remote HTTPS domain
 
 The generated `src/lib.rs` opens the main window directly on your server using

--- a/docs/guide/tauri-mobile-thin-client.md
+++ b/docs/guide/tauri-mobile-thin-client.md
@@ -1,0 +1,369 @@
+# Mobile Thin-Client Apps with Tauri (`autumn generate tauri --remote-url`)
+
+`autumn generate tauri --remote-url <URL>` scaffolds a `src-tauri/` sub-project
+for the **mobile thin-client** architecture: the app you install on a phone is a
+native Tauri shell whose webview loads your **cloud-hosted Autumn server**
+directly over HTTPS. There is no local sidecar binary, no bundled database, and
+no build-time staging step — your existing routes, Maud/htmx templates, and
+sessions run unmodified on the server, exactly as they do for browser users.
+
+```
+┌─────────────────────────────┐          ┌──────────────────────────┐
+│  Phone (Android / iOS)      │          │  Cloud                   │
+│  ┌───────────────────────┐  │  HTTPS   │  ┌────────────────────┐  │
+│  │ Tauri shell           │◄─┼──────────┼─►│ Autumn server      │  │
+│  │  webview → remote URL │  │          │  │ (routes, sessions, │  │
+│  │  + native plugins:    │  │          │  │  Postgres, …)      │  │
+│  │  notification         │  │          │  └────────────────────┘  │
+│  │  biometric            │  │          └──────────────────────────┘
+│  │  store                │  │
+│  └───────────────────────┘  │
+└─────────────────────────────┘
+```
+
+Choose the thin client when your app is online-first and you already run it as
+a normal web service: one deployment serves browsers, PWAs, and the mobile app,
+and shipping a server fix updates every installed app instantly. Choose the
+[desktop sidecar model](tauri.md) instead when the app must be fully
+self-contained on the user's machine.
+
+**Trust model, up front:** the generated capability file grants pages served
+from your remote origin the right to invoke native device APIs on the phone.
+That origin is *fully trusted* — a compromised server can call every permitted
+plugin command. Keep the grant scoped to exactly one origin you control, keep
+the permission list minimal, and never widen `urls` to a wildcard like
+`https://*`.
+
+## Scaffolding
+
+Run the generator from your project root:
+
+```bash
+autumn generate tauri --remote-url https://app.example.com
+```
+
+The URL must be `https://`; plain `http://` is accepted only for
+`localhost` / `127.0.0.1` / `::1` dev servers, and URLs with embedded userinfo
+(`https://user:pass@…`) are rejected outright. `--dry-run` prints the file plan
+without writing, `--force` overwrites collisions, and
+`autumn destroy tauri --remote-url <URL>` reverts the scaffold.
+
+```
+src-tauri/
+  tauri.conf.json              — productName, identifier, version, bundle icons
+  Cargo.toml                   — "{app}-mobile" crate; staticlib/cdylib for android/ios init
+  build.rs                     — calls tauri_build::build()
+  Info.ios.plist               — NSFaceIDUsageDescription for Face ID
+  capabilities/
+    remote-app.json            — grants the remote origin the plugin permissions
+  src/
+    main.rs                    — calls {app}_mobile::run()
+    lib.rs                     — plugin registration + webview → remote URL
+  icons/                       — same placeholder set as the desktop scaffold
+  .gitignore                   — /target /binaries /configs /gen
+```
+
+Compared with the desktop scaffold, note what is *absent*: no
+`stage-sidecar.sh`/`.ps1`, no per-OS `tauri.*.conf.json` overlays, no
+`externalBin`, and no bundled `autumn.toml` resources. All of those exist
+solely to build and supervise a local sidecar binary — a thin client has
+nothing to stage, and its configuration lives on the server.
+
+After scaffolding, initialise the mobile projects (output goes to
+`src-tauri/gen/`, which is `.gitignore`d):
+
+```bash
+cargo install tauri-cli --version "^2"
+cd src-tauri
+cargo tauri android init && cargo tauri android dev
+cargo tauri ios init && cargo tauri ios dev
+```
+
+## Routing the webview to a remote HTTPS domain
+
+The generated `src/lib.rs` opens the main window directly on your server using
+`WebviewUrl::External`:
+
+```rust
+tauri::WebviewWindowBuilder::new(
+    app,
+    "main",
+    tauri::WebviewUrl::External(
+        "https://app.example.com"
+            .parse()
+            .expect("remote URL was validated at generate time"),
+    ),
+)
+.title("My App")
+.build()?;
+```
+
+This mirrors the mechanism the desktop scaffold already uses (there it points
+at a loopback port), so the codebase has one webview-creation idiom.
+
+**Alternative: `frontendDist` as a remote URL.** Tauri also accepts a URL in
+`tauri.conf.json`'s `build.frontendDist` field, in which case you don't create
+the window in Rust at all:
+
+```json
+{
+  "build": { "frontendDist": "https://app.example.com" }
+}
+```
+
+The generator deliberately does not use this form: `tauri dev` has a known bug
+with URL-form `frontendDist`
+([tauri-apps/tauri#12333](https://github.com/tauri-apps/tauri/issues/12333)),
+and the Rust-side builder keeps the URL next to the plugin registration it
+belongs with. The config form remains valid if you prefer it for a
+hand-maintained project.
+
+**Server-side prerequisites** for the remote origin:
+
+- A valid, publicly-trusted TLS certificate — mobile webviews do not show
+  certificate-error interstitials; a bad cert is just a blank screen.
+- `session.secure = true` (or `AUTUMN_SESSION__SECURE=true`) in production so
+  session cookies carry the `Secure` attribute (see
+  [Sessions & auth](#sessions--auth-handoff) below).
+- If you restrict trusted hosts (`AUTUMN_SECURITY__TRUSTED_HOSTS__HOSTS`),
+  include the domain the app loads.
+
+## Native device capabilities (App Store Guideline 4.2)
+
+Apple's [Guideline 4.2 — Minimum Functionality](https://developer.apple.com/app-store/review/guidelines/#minimum-functionality)
+rejects apps that are "not particularly useful, unique, or app-like" — in
+practice, bare webview wrappers around a website. The scaffold pre-registers
+three official Tauri plugins so your remote pages can use genuinely native
+device features. Be honest with yourself here: these integrations *reduce*
+rejection risk by making the app app-like, but nothing guarantees approval —
+review is holistic, and the strongest defence is UX that feels like an app
+(native-feature use, offline handling, no browser chrome metaphors).
+
+### The capability file, field by field
+
+`src-tauri/capabilities/remote-app.json` is what lets JavaScript served by your
+*remote* server call into the native plugins (by default, Tauri only trusts
+bundled local pages):
+
+```json
+{
+  "identifier": "remote-autumn-app",
+  "description": "Allow pages served by the remote Autumn server to use the native device plugins (notifications, biometric authentication, key-value storage).",
+  "windows": ["main"],
+  "remote": {
+    "urls": ["https://app.example.com"]
+  },
+  "permissions": [
+    "core:default",
+    "notification:default",
+    "biometric:default",
+    "store:default"
+  ]
+}
+```
+
+- `identifier` — a unique name for this capability; tauri-build auto-discovers
+  every JSON file under `src-tauri/capabilities/`.
+- `windows` — which webview windows the grant applies to (only `main` exists
+  in this scaffold).
+- `remote.urls` — the origins whose pages may invoke the permitted commands.
+  The generator emits exactly the origin you passed — never widen this to a
+  wildcard: every origin listed here can drive the device APIs.
+- `permissions` — the default permission set of each plugin plus Tauri's core
+  APIs (`core:default`, `notification:default`, `biometric:default`,
+  `store:default`).
+
+> **Caveat:** on Linux and Android, Tauri cannot distinguish an embedded
+> iframe from the window itself — a page your app embeds from another origin
+> could be treated as the remote origin. Avoid third-party iframes on pages
+> served to the mobile shell.
+
+Your server pages call the plugins through the `@tauri-apps/api` npm packages
+— or, simplest for a server-rendered Maud/htmx app, via the global that Tauri
+injects when `app.withGlobalTauri` is enabled, or a small bundled script. The
+samples below use the plugin packages; they run *on your remote Autumn pages*,
+which is exactly what the `remote.urls` grant enables.
+
+Detect the shell first, so the same pages degrade gracefully in an ordinary
+browser:
+
+```js
+import { isTauri } from '@tauri-apps/api/core';
+
+if (isTauri()) {
+  // running inside the mobile shell — native plugins are available
+} else {
+  // plain browser — fall back to web APIs or hide native-only UI
+}
+```
+
+### Notifications
+
+```js
+import {
+  isPermissionGranted,
+  requestPermission,
+  sendNotification,
+} from '@tauri-apps/plugin-notification';
+
+let granted = await isPermissionGranted();
+if (!granted) {
+  granted = (await requestPermission()) === 'granted';
+}
+if (granted) {
+  sendNotification({ title: 'Order shipped', body: 'Your order #1042 is on its way.' });
+}
+```
+
+### Biometric authentication
+
+The biometric plugin exists only on Android and iOS — its Cargo dependency is
+target-gated and its registration in `lib.rs` is `#[cfg(mobile)]`-gated, so the
+shell still builds on desktop for local smoke-testing. On iOS the generated
+`Info.ios.plist` provides the required `NSFaceIDUsageDescription`; without it,
+the first Face ID prompt kills the app.
+
+```js
+import { authenticate } from '@tauri-apps/plugin-biometric';
+
+try {
+  await authenticate('Unlock your account', {
+    allowDeviceCredential: false,
+  });
+  // success — proceed (e.g. release a stored token, see below)
+} catch (e) {
+  // user cancelled or biometry unavailable — fall back to password login
+}
+```
+
+### Device storage
+
+```js
+import { load } from '@tauri-apps/plugin-store';
+
+const store = await load('app-data.json');
+await store.set('draft', { body: 'unsent message…' });
+const draft = await store.get('draft');
+await store.save();
+```
+
+The store persists as plaintext JSON on the device. For secrets that warrant
+encryption at rest, upgrade to
+[`tauri-plugin-stronghold`](https://v2.tauri.app/plugin/stronghold/) — the
+generator wires the lighter store plugin by default because Stronghold brings
+heavy build dependencies.
+
+## Sessions & auth handoff
+
+Two patterns work between the webview and a remote Autumn server. Cookie-based
+sessions are the default and require no app changes; the token pattern adds
+native-storage control and composes with biometrics.
+
+### Cookie-based sessions
+
+Autumn's server-side sessions work in WKWebView (iOS) and Android WebView the
+same way they do in a browser — the webview stores and replays the session
+cookie. Requirements and caveats specific to a *remote HTTPS origin inside a
+mobile shell*:
+
+- **`Secure` is mandatory.** Set `session.secure = true`
+  (`AUTUMN_SESSION__SECURE=true`) in production. Cookies without `Secure` over
+  HTTPS are increasingly dropped by mobile webviews.
+- **Set `SameSite` explicitly.** Since your pages, form posts, and htmx
+  requests all originate from your own origin, `SameSite=Lax` (Autumn's
+  sensible default) works for normal navigation. But iOS 18+ WKWebView treats
+  cookies with *no* `SameSite` attribute inconsistently (historically `None`,
+  now effectively `Lax`), so never rely on the unset default. If a request to
+  your server originates from a *different* context (a plugin webview, an
+  OAuth popup, an embedded page), the cookie must be `SameSite=None; Secure`
+  to be attached cross-site.
+- **Persistence is flaky on iOS.** WKWebView's cookie persistence interacts
+  badly with Intelligent Tracking Prevention and has long-standing
+  synchronization bugs (see WebKit bug 213510): a session cookie can survive a
+  relaunch one day and vanish the next. Mitigate by using **server-side
+  sessions keyed by a persistent, `HttpOnly`, `Secure` cookie with a long
+  `Max-Age`** (not a browser-session cookie), and implement a silent
+  re-authentication fallback — the token handoff below is a good one — so a
+  dropped cookie degrades to a background token refresh instead of a login
+  screen.
+- Autumn knobs that matter here: `session.secure`, the signing secret
+  (`AUTUMN_SECURITY__SIGNING_SECRET`), and trusted hosts
+  (`AUTUMN_SECURITY__TRUSTED_HOSTS__HOSTS`).
+
+### Authorization-header token handoff
+
+Instead of (or as a fallback to) cookies, hand the webview a bearer token and
+store it natively via the store plugin. On successful login your page stores
+the token:
+
+```js
+import { load } from '@tauri-apps/plugin-store';
+
+// after POST /login succeeds and returns { token }
+const store = await load('auth.json');
+await store.set('auth_token', token);
+await store.save();
+```
+
+Subsequent requests from your remote pages attach it as an `Authorization`
+header:
+
+```js
+const store = await load('auth.json');
+const token = await store.get('auth_token');
+
+const res = await fetch('https://app.example.com/api/orders', {
+  headers: { Authorization: `Bearer ${token}` },
+});
+```
+
+Issue short-lived access tokens and rotate them server-side (a refresh
+endpoint the shell calls when a request comes back `401`); revoke on logout by
+deleting the store entry *and* invalidating server-side.
+
+**Biometric-gated token release** ties the two plugin integrations together —
+require Face ID / fingerprint before the stored token is read:
+
+```js
+import { authenticate } from '@tauri-apps/plugin-biometric';
+import { load } from '@tauri-apps/plugin-store';
+
+async function unlockToken() {
+  await authenticate('Unlock your account'); // throws if cancelled/unavailable
+  const store = await load('auth.json');
+  return store.get('auth_token');
+}
+```
+
+Remember the store file is plaintext on disk — for high-sensitivity apps keep
+tokens short-lived or move them to `tauri-plugin-stronghold`.
+
+## Building & shipping
+
+```bash
+cd src-tauri
+cargo tauri android build      # .aab / .apk under gen/android
+cargo tauri ios build          # .ipa via Xcode under gen/apple
+```
+
+Signing, provisioning profiles, and store submission are covered by the
+official Tauri distribution docs for
+[Google Play](https://v2.tauri.app/distribute/google-play/) and the
+[App Store](https://v2.tauri.app/distribute/app-store/). Replace the
+placeholder icons before shipping (`cargo tauri icon static/icons/icon.svg`
+from the app root).
+
+**Offline UX:** a thin client is online-first, but "airplane mode shows a
+white screen" is both a bad experience and App Store rejection bait. At
+minimum, detect load failures (`window.addEventListener('offline', …)` on
+page, or a page-load error handler in the shell) and show a friendly retry
+view; a small local fallback page bundled with the shell is a worthwhile
+manual addition.
+
+## Relationship to other options
+
+This page covers **Option A** of Autumn's Tauri mobile roadmap (issue #1506):
+the pure thin client. Option B (in-process backend with a remote database,
+issue #1507) and Option C (in-process backend with local SQLite and sync,
+issue #1508) are separate roadmap items. For desktop packaging, see the
+[Tauri desktop guide](tauri.md).

--- a/docs/guide/tauri.md
+++ b/docs/guide/tauri.md
@@ -7,6 +7,8 @@ child process and the webview loads the app from a loopback port chosen at
 runtime. Your existing routes, Maud/htmx templates, and sessions run entirely
 unmodified — the generator is purely additive and never rewrites your app code.
 
+> **See also:** building for **mobile (Android/iOS)** as a thin client against a remote server — [Mobile thin-client apps with Tauri](tauri-mobile-thin-client.md) (`autumn generate tauri --remote-url <URL>`).
+
 ## Prerequisites
 
 ### External toolchain

--- a/docs/guide/tauri.md
+++ b/docs/guide/tauri.md
@@ -7,7 +7,9 @@ child process and the webview loads the app from a loopback port chosen at
 runtime. Your existing routes, Maud/htmx templates, and sessions run entirely
 unmodified — the generator is purely additive and never rewrites your app code.
 
-> **See also:** building for **mobile (Android/iOS)** as a thin client against a remote server — [Mobile thin-client apps with Tauri](tauri-mobile-thin-client.md) (`autumn generate tauri --remote-url <URL>`).
+> **See also:** building for **mobile (Android/iOS)** as a thin client against
+> a remote server — [Mobile thin-client apps with Tauri](tauri-mobile-thin-client.md)
+> (`autumn generate tauri --remote-url <URL>`).
 
 ## Prerequisites
 


### PR DESCRIPTION
## Before / After

**Before:** `autumn generate tauri` only scaffolds a desktop app that bundles the Autumn server as a sidecar binary; there is no supported path for shipping a mobile app whose WebView loads a remote Autumn server.

**After:** `autumn generate tauri --remote-url https://app.example.com` scaffolds a mobile thin-client crate: the WebView loads the remote HTTPS server directly, a `capabilities/remote-app.json` grants the remote origin access to the notification/biometric/store plugins, an iOS `Info.ios.plist` carries the Face ID usage description, and the post-generate prerequisites walk through `cargo tauri android init` / `ios init`. A new guide at `docs/guide/tauri-mobile-thin-client.md` covers remote routing, native capabilities for App Store Guideline 4.2 (Minimum Functionality), and cookie/token session handoff between the webview and the remote server. The no-flag desktop path is byte-identical to before.

## How

- `autumn-cli/src/generate/tauri.rs`: new additive section with `plan_tauri_thin_client(project_root, remote_url)` as a separate plan entry point (`plan_tauri` untouched), `validate_remote_url` (https-only, with `localhost`/`127.0.0.1`/`::1`/`10.0.2.2` exempt for dev; rejects userinfo and URLs whose normalized serialization contains quotes/backslashes/control chars), `derive_mobile_identifier` (strips `-`/`_` so `cargo tauri android init` accepts the bundle identifier), and renderers for the thin-client `tauri.conf.json` (`withGlobalTauri: true`, no `externalBin`/`resources`), `Cargo.toml` (`{pkg}-mobile` crate, `staticlib`/`cdylib`/`rlib`, target-gated `tauri-plugin-biometric`), `lib.rs` (`WebviewUrl::External` pointed at the normalized remote URL, plugin registration, `#[cfg_attr(mobile, tauri::mobile_entry_point)]`), `capabilities/remote-app.json`, `Info.ios.plist`, and mobile prerequisites text.
- `autumn-cli/src/main.rs`: optional `--remote-url <URL>` field on the existing `GenerateCommands::Tauri` variant plus dispatch (`Some(url)` → thin-client plan and prerequisites, `None` → existing desktop path). `autumn destroy tauri --remote-url <URL>` reverts the thin-client scaffold through the existing plan/revert machinery.
- `autumn-cli/tests/integration/tauri_mobile_thin_client.rs` (+ one `mod` line in `tests/integration/mod.rs`): 6 end-to-end tests in the consolidated binary, including desktop-regression and docs-anchor guards; ~20 new unit tests in `tauri.rs`/`main.rs`.
- Docs: new `docs/guide/tauri-mobile-thin-client.md`; one cross-link blockquote in `docs/guide/tauri.md`; one `README.md` Documentation bullet; one `CHANGELOG.md` bullet under `## [Unreleased]`.

## Process

Built test-first: red commit (706e94f, failing unit + e2e tests), green commit (feebb0e, implementation), refactor commit (15ee592), then a four-angle review (correctness, security, docs accuracy, conventions) whose findings — including a blocker (hyphenated bundle identifiers break `cargo tauri android init`) and a URL-injection issue in the generated `lib.rs` — were fixed in 1fed7e5 with adversarial-input probes verifying the generated crate stays parseable.

Verified: `cargo test -p autumn-cli` all targets green (2823 + 173 + others), `cargo fmt` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Deconfliction

This PR is deliberately additive-only in files shared with the sibling roadmap items #1507 (Option B) and #1508 (Option C): new functions appended in a delimited block in `tauri.rs`, a new docs page rather than restructuring `tauri.md`, single-line insertions in `mod.rs`/`CHANGELOG.md`/`README.md`, and no changes to `tests/generate.rs`, `docs/guide/generators.md`, or any existing desktop renderer body.

Closes #1506

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4V2uKDmFp6KguogGwvxkp

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4V2uKDmFp6KguogGwvxkp)_