### PR TITLE
Add form_for builder derived from #[model] models (#1135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,10 +68,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the offsetless browser value is interpreted as UTC, an empty nullable value
   decodes as `None`, and RFC 3339 JSON create bodies keep decoding — the
   `DateTime<Utc>` helpers now also accept RFC 3339 input, honoring an explicit
-  offset by converting to UTC. (`DateTime` columns with a non-`Utc` zone
-  parameter keep chrono's default `Deserialize`.) These four `form`
-  deserializer helpers, previously `maud`-gated, are now available
-  unconditionally. `UpdateX` is untouched: it has no `Validate` impl so no
+  offset by converting to UTC. These four `form` deserializer helpers,
+  previously `maud`-gated, are now available unconditionally.
+  `chrono::DateTime<Local>` columns (diesel's other `Timestamptz`-capable
+  zone) get the same treatment via new
+  `autumn_web::form::deserialize_datetime_local_local` /
+  `deserialize_datetime_local_local_option` helpers: the offsetless browser
+  value is interpreted as the server's local wall clock (a wall clock
+  repeated by a DST fall-back maps to the earlier instant; one skipped by a
+  spring-forward is a decode error), and RFC 3339 input converts the instant
+  to the local zone. `DateTime` columns with any *other* zone parameter
+  (e.g. `FixedOffset`, or a bare `DateTime` alias hiding its zone from the
+  derive) no longer render the `datetime-local` picker at all — an
+  offsetless wall clock is genuinely ambiguous there, and the picker's
+  submission used to 400 unconditionally; they fall back to a text input
+  pre-filled with the serialized RFC 3339 string, which chrono's default
+  `Deserialize` round-trips as-is. `UpdateX` is untouched: it has no `Validate` impl so no
   `ChangesetForm`/`form_for` round-trip reaches it, and its JSON PATCH bodies
   are RFC 3339, which already decodes. Required `NaiveDate` columns need no
   treatment (the browser's `YYYY-MM-DD` is exactly chrono's wire shape).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   attachment columns stay a hand-rolled file input (appended before the submit
   button, so attachment fields now always render at the end of the form
   regardless of their declared column position, and the form remains
-  URL-encoded). `references` columns render as a `<select>` of the referenced
+  URL-encoded) that renders the same inline-error/ARIA skeleton as the derived
+  controls, so changeset errors on the attachment key surface next to the
+  file input. `references` columns render as a `<select>` of the referenced
   table's ids (AC "enum/references→select"): the generated handlers load the
   ids via a per-column `{column}_select_options` loader and thread them into
   the shared form helper — option labels are the raw id (which column makes a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **form:** `autumn_web::form::form_for` — a model-driven form builder that
+  renders a complete form in one call (issue #1135): opening `<form>` (hidden
+  `_method` override for `PUT`/`PATCH`/`DELETE` + auto-injected CSRF, via the
+  same audited path as `form_tag`), one type-appropriate control per field with
+  values pre-filled and inline per-field errors, and a submit button. Controls
+  come from a new `#[model]`-derived `FormModel`/`FormField`/`FieldControl`
+  descriptor, reusing the #1131 typed inputs — no per-field control selection in
+  caller code. Escape hatches: `.exclude`, `.override_field`, `.override_label`,
+  `.append`, `.submit_label`, `.multipart`. Plain no-JS HTML; htmx stays opt-in.
+  Public API addition (minor bump); existing helpers unchanged.
+
 - **generator:** `autumn generate scaffold`'s `create`/`update` handlers now
   build a `Changeset` from the submission and re-render the `new`/`edit`
   form on a rejected submission (issue #1124). A failed submission responds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ids via a per-column `{column}_select_options` loader and thread them into
   the shared form helper — option labels are the raw id (which column makes a
   human-friendly label is a display decision the generator can't know; the
-  generated loader's doc comment says where to swap one in). This requires
-  the referenced resource's `src/schema.rs` entry to exist, i.e. generate the
-  referenced model first — the same ordering the FOREIGN KEY already imposes.
+  generated loader's doc comment says where to swap one in). The select needs
+  the referenced resource's `src/schema.rs` entry, so it applies when the
+  referenced model is already in the project (generate it first — the same
+  ordering the FOREIGN KEY already imposes); when the target is missing (a
+  warning-only situation: the table is assumed to exist out-of-band), the
+  column falls back to the derived numeric id input so the generated code
+  still compiles, and the scaffold warns that generating the referenced model
+  first (or re-running the scaffold afterwards) yields the select.
   Adding a column no longer requires any view edits.
   `--live-validation` scaffolds keep the per-field emission (their htmx
   inline-validation inputs have no `FieldControl` equivalent).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Adding a column no longer requires any view edits.
   `--live-validation` scaffolds keep the per-field emission (their htmx
   inline-validation inputs have no `FieldControl` equivalent).
+  Non-nullable `bool` columns: the `#[model]`-generated `NewX` insert struct
+  now marks them `#[serde(default)]`, so an unchecked `form_for` checkbox
+  (which submits no key at all — `checkbox_input` deliberately emits no hidden
+  `false` fallback because serde_urlencoded rejects duplicate keys) decodes as
+  `false` instead of rejecting the submission with a missing-field error,
+  matching the scaffold's `{Model}Form` convention. Side effect: a JSON create
+  body that omits a non-nullable `bool` now also decodes it as `false` rather
+  than erroring.
   `FieldControl` is `#[non_exhaustive]` (new control kinds won't be
   semver-major); duplicate `.override_field`/`.override_label` calls on the
   same field now resolve last-wins; `FieldControl::File` renders the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   matching the scaffold's `{Model}Form` convention. Side effect: a JSON create
   body that omits a non-nullable `bool` now also decodes it as `false` rather
   than erroring.
+  Datetime columns: `form_for` renders `chrono::DateTime<Utc>` and
+  `NaiveDateTime` columns as `<input type="datetime-local">`, whose submitted
+  value carries no timezone offset (and not always seconds) — chrono's default
+  `Deserialize` for `DateTime<Utc>` would reject even an untouched pre-filled
+  value as a 400 before validation. The `#[model]`-generated `NewX` insert
+  struct now attaches `autumn_web::form::deserialize_datetime_local_utc`
+  (`_option` for nullable) to `DateTime<Utc>` columns and
+  `deserialize_naive_datetime_local` (`_option`) to `NaiveDateTime` columns:
+  the offsetless browser value is interpreted as UTC, an empty nullable value
+  decodes as `None`, and RFC 3339 JSON create bodies keep decoding — the
+  `DateTime<Utc>` helpers now also accept RFC 3339 input, honoring an explicit
+  offset by converting to UTC. (`DateTime` columns with a non-`Utc` zone
+  parameter keep chrono's default `Deserialize`.) These four `form`
+  deserializer helpers, previously `maud`-gated, are now available
+  unconditionally. `UpdateX` is untouched: it has no `Validate` impl so no
+  `ChangesetForm`/`form_for` round-trip reaches it, and its JSON PATCH bodies
+  are RFC 3339, which already decodes. Required `NaiveDate` columns need no
+  treatment (the browser's `YYYY-MM-DD` is exactly chrono's wire shape).
   `FieldControl` is `#[non_exhaustive]` (new control kinds won't be
   semver-major); duplicate `.override_field`/`.override_label` calls on the
   same field now resolve last-wins; `FieldControl::File` renders the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ChangesetForm`/`form_for` round-trip reaches it, and its JSON PATCH bodies
   are RFC 3339, which already decodes. Required `NaiveDate` columns need no
   treatment (the browser's `YYYY-MM-DD` is exactly chrono's wire shape).
+  Serde-renamed columns: a model field carrying `#[serde(rename = "...")]`
+  (or covered by a struct-level `#[serde(rename_all = "...")]`, both of which
+  pass through to the emitted model struct's `Serialize` derive) serializes
+  under a key that differs from its Rust identifier, and `form_for`'s
+  pre-fill lookup (`Changeset::field_value`) indexes serialized data — so
+  edit forms for renamed fields rendered blank/unselected values despite the
+  data being present. `FormField` now carries the serde-effective serialized
+  key separately as a new `value_name: Option<String>` field (constructor
+  defaults it to `None` = same as `name`; set via the new
+  `FormField::with_value_name`), which the `#[model]` derive resolves
+  automatically — field-level `rename`/`rename(serialize = ...)` wins over
+  struct-level `rename_all`, mirroring serde, with all eight serde field
+  casings implemented. `form_for` uses `value_name` **only** for the value
+  pre-fill; the rendered input `name`/`id`, error lookup, and
+  `.exclude`/`.override_*` matching keep the Rust identifier, which is what
+  the generated `NewX`/`UpdateX` structs (which do not propagate serde
+  renames) decode by. Hand-written `FormModel` impls over renaming data
+  types should call `.with_value_name(...)` themselves. (`FormField` gains a
+  public field; code constructing it via struct literal instead of
+  `FormField::new` needs the extra field.)
   `FieldControl` is `#[non_exhaustive]` (new control kinds won't be
   semver-major); duplicate `.override_field`/`.override_label` calls on the
   same field now resolve last-wins; `FieldControl::File` renders the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   descriptor, reusing the #1131 typed inputs — no per-field control selection in
   caller code. Escape hatches: `.exclude`, `.override_field`, `.override_label`,
   `.append`, `.submit_label`, `.multipart`. Plain no-JS HTML; htmx stays opt-in.
-  Public API addition (minor bump); existing helpers unchanged.
+  A required `FieldControl::Date` field now renders via a new
+  `required_date_input` helper (`required` + `aria-required="true"`), matching
+  the other `required_*` siblings. Public API addition (minor bump); existing
+  helpers unchanged.
+  `autumn generate scaffold` now consumes it: the generated create/edit views
+  (and both 422 re-render branches) render through one shared
+  `{snake}_form_for` helper instead of hand-emitting one input per column —
+  the generated `{Model}Form` delegates `FormModel` to the `#[model]`-derived
+  descriptors, enum columns get a `.override_field(...)` `Select` with their
+  variants, decimal columns pin the browser `step` to the declared scale, and
+  attachment columns stay a hand-rolled file input (appended before the submit
+  button, so attachment fields now always render at the end of the form
+  regardless of their declared column position, and the form remains
+  URL-encoded). `references` columns render as a `<select>` of the referenced
+  table's ids (AC "enum/references→select"): the generated handlers load the
+  ids via a per-column `{column}_select_options` loader and thread them into
+  the shared form helper — option labels are the raw id (which column makes a
+  human-friendly label is a display decision the generator can't know; the
+  generated loader's doc comment says where to swap one in). This requires
+  the referenced resource's `src/schema.rs` entry to exist, i.e. generate the
+  referenced model first — the same ordering the FOREIGN KEY already imposes.
+  Adding a column no longer requires any view edits.
+  `--live-validation` scaffolds keep the per-field emission (their htmx
+  inline-validation inputs have no `FieldControl` equivalent).
+  `FieldControl` is `#[non_exhaustive]` (new control kinds won't be
+  semver-major); duplicate `.override_field`/`.override_label` calls on the
+  same field now resolve last-wins; `FieldControl::File` renders the same
+  inline-error/ARIA/required skeleton as the other controls; and the
+  multipart render path now flows through the same audited CSRF/
+  method-override code as every other form (`enctype` is threaded, not
+  duplicated).
 
 - **generator:** `autumn generate scaffold`'s `create`/`update` handlers now
   build a `Changeset` from the submission and re-render the `new`/`edit`

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -223,7 +223,13 @@ pub fn plan_model_with_options(
 /// single-file `src/models.rs` (only counts if its content actually declares
 /// the resource's table, via a word-boundary-aware check so `posts` isn't
 /// confused with a longer table name like `posts_tags`).
-fn model_file_exists(project_root: &Path, table: &str, base: &str) -> bool {
+///
+/// Shared with the scaffold generator (`pub(super)`): the same presence test
+/// that decides whether [`check_reference_targets`] warns also decides
+/// whether a scaffolded `references` column can render as a `<select>` of
+/// the target table's ids (which needs the target's `src/schema.rs` entry)
+/// or must fall back to the derived numeric id input.
+pub(super) fn model_file_exists(project_root: &Path, table: &str, base: &str) -> bool {
     let per_resource = project_root
         .join("src")
         .join("models")

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -145,6 +145,52 @@ pub fn plan_scaffold_with_options(
     let snake_name = snake(name);
     let plural = pluralize(&snake_name);
 
+    // `references` columns whose target model can't be found in the project
+    // (same presence test `check_reference_targets` used for its warning —
+    // the table presumably exists out-of-band, or gets generated later).
+    // Their "select over the referenced table's ids" promotion (issue #1135
+    // AC 2) needs the target's `src/schema.rs` entry at compile time, so the
+    // routes renderer skips the select machinery for these columns and lets
+    // them fall back to the derived numeric id input — a warning-only missing
+    // target has always produced compilable output, and importing a
+    // nonexistent schema module would break that. A self-referential column
+    // (target == this scaffold's own table) is never "missing": its schema
+    // entry is being generated right now.
+    let missing_reference_targets: BTreeSet<String> = form_fields
+        .iter()
+        .filter(|f| f.kind.is_reference())
+        .filter_map(|f| {
+            let table = f.reference_table()?;
+            if table == plural {
+                return None;
+            }
+            let base = f.name.strip_suffix("_id").unwrap_or(&f.name);
+            if super::model::model_file_exists(project_root, &table, base) {
+                None
+            } else {
+                Some(f.name.clone())
+            }
+        })
+        .collect();
+    if !options_with_key.api && !options_with_key.live_validation {
+        for f in form_fields.iter().filter(|f| f.kind.is_reference()) {
+            if !missing_reference_targets.contains(&f.name) {
+                continue;
+            }
+            let Some(table) = f.reference_table() else {
+                continue;
+            };
+            let base = f.name.strip_suffix("_id").unwrap_or(&f.name);
+            plan.warn(format!(
+                "'{}' will render as a plain numeric id input in the generated form: \
+                 without the '{base}' model, table '{table}' has no `src/schema.rs` entry \
+                 to load select options from. Generate the '{base}' model first (or re-run \
+                 this scaffold once it exists) to get a select of {table} ids instead.",
+                f.name
+            ));
+        }
+    }
+
     // Repository file under `src/repositories/<snake>.rs`
     let repos_dir = project_root.join("src").join("repositories");
     plan.create(
@@ -182,6 +228,7 @@ pub fn plan_scaffold_with_options(
                 options_with_key.live,
                 options_with_key.live_validation,
                 metadata.validations(),
+                &missing_reference_targets,
             ),
         );
         let route_mod_path = routes_dir.join("mod.rs");
@@ -1068,6 +1115,7 @@ fn render_routes_file(
     live: bool,
     live_validation: bool,
     validations: &BTreeMap<String, Vec<String>>,
+    missing_reference_targets: &BTreeSet<String>,
 ) -> String {
     let id_rust = id_type.rust_type();
     let validated_fields: Vec<&str> = validations.keys().map(String::as_str).collect();
@@ -1080,11 +1128,18 @@ fn render_routes_file(
     // runtime data, so the handlers that render the form load them and pass
     // them into the shared `{snake}_form_for` helper. `--live-validation`
     // keeps the old per-field emission (no `form_for`), so no options are
-    // loaded there.
+    // loaded there. Columns in `missing_reference_targets` (their referenced
+    // model — and therefore its `src/schema.rs` entry — isn't in the project)
+    // are left out entirely: no loader, no schema import, no Select override,
+    // so they fall back to the derived numeric id input and the generated
+    // file still compiles (the caller warned about the downgrade).
     let reference_fields: Vec<&Field> = if live_validation {
         Vec::new()
     } else {
-        fields.iter().filter(|f| f.kind.is_reference()).collect()
+        fields
+            .iter()
+            .filter(|f| f.kind.is_reference() && !missing_reference_targets.contains(&f.name))
+            .collect()
     };
     let has_reference_selects = !reference_fields.is_empty();
     let model_form = render_model_form(pascal_name, fields, validations);
@@ -1362,7 +1417,7 @@ fn render_routes_file(
         (
             new_form_body,
             edit_form_body,
-            render_form_for_helper(pascal_name, snake_name, fields)
+            render_form_for_helper(pascal_name, snake_name, fields, missing_reference_targets)
                 + &render_reference_option_loaders(&reference_fields, db_ty),
         )
     };
@@ -1657,10 +1712,11 @@ pub async fn index(
 
     // Schema imports: the resource's own table, plus — when reference selects
     // are rendered — each referenced table so its ids can be loaded for the
-    // select options. Requires the referenced resource to have been generated
-    // first (its `diesel::table!` entry must exist in `src/schema.rs`), the
-    // same ordering the migration's FOREIGN KEY already imposes at the
-    // database level.
+    // select options. Only targets that are actually present in the project
+    // reach this point (`reference_fields` already excludes
+    // `missing_reference_targets`): importing a table whose `diesel::table!`
+    // entry doesn't exist in `src/schema.rs` would fail to compile, and a
+    // missing target has always been a warning, not an error.
     let schema_import = {
         let mut extra_tables: BTreeSet<String> = reference_fields
             .iter()
@@ -2052,8 +2108,17 @@ fn render_form_model_impl(pascal_name: &str) -> String {
 ///   table's ids (issue #1135 AC 2). The options are runtime data, so the
 ///   helper takes one `{column}_options: &[(String, String)]` parameter per
 ///   reference and the calling handlers load them (see the generated
-///   `{column}_select_options` loader).
-fn render_form_for_helper(pascal_name: &str, snake_name: &str, fields: &[Field]) -> String {
+///   `{column}_select_options` loader). Columns named in
+///   `missing_reference_targets` (their referenced model isn't in the
+///   project, so there is no schema entry to load options from) keep the
+///   derived numeric id input instead — the plan carries a warning saying
+///   how to get the select.
+fn render_form_for_helper(
+    pascal_name: &str,
+    snake_name: &str,
+    fields: &[Field],
+    missing_reference_targets: &BTreeSet<String>,
+) -> String {
     use std::fmt::Write as _;
     let mut extra_params = String::new();
     let mut preludes = String::new();
@@ -2120,7 +2185,13 @@ fn render_form_for_helper(pascal_name: &str, snake_name: &str, fields: &[Field])
                 // input; the reference renders as a select over the
                 // referenced table's ids instead. A blank first option gives
                 // required selects browser-native "please select" behavior
-                // (nullable references use it to unset the value).
+                // (nullable references use it to unset the value). When the
+                // referenced model is missing from the project the select's
+                // option loader could not compile (no schema entry to query),
+                // so the column keeps the derived number input.
+                if missing_reference_targets.contains(name) {
+                    continue;
+                }
                 let placeholder = if f.nullable {
                     "— Unset —"
                 } else {
@@ -3512,6 +3583,22 @@ mod tests {
         tmp
     }
 
+    /// Write a minimal existing `src/models/<base>.rs` (i64-keyed) so a
+    /// `references` column targeting it counts as present — both for
+    /// `check_reference_targets`' warning and for the scaffold's
+    /// references→select promotion (issue #1135 AC 2), which needs the
+    /// target's schema entry to exist.
+    fn write_target_model(tmp: &TempDir, base: &str, pascal: &str) {
+        fs::create_dir_all(tmp.path().join("src/models")).unwrap();
+        fs::write(
+            tmp.path().join(format!("src/models/{base}.rs")),
+            format!(
+                "#[autumn_web::model]\npub struct {pascal} {{\n    #[id]\n    pub id: i64,\n}}\n"
+            ),
+        )
+        .unwrap();
+    }
+
     fn default_main() -> &'static str {
         r#"use autumn_web::prelude::*;
 
@@ -3626,8 +3713,12 @@ async fn main() {
         // plain `i64` and emits a number input; the scaffold overrides the
         // reference to a `Select` whose options (the referenced table's ids)
         // are loaded by every handler that renders the form and threaded
-        // through the shared `comment_form_for` helper.
+        // through the shared `comment_form_for` helper. The `Post` target
+        // model exists, so the promotion applies (a missing target falls
+        // back to the derived number input — see
+        // `execute_references_column_with_missing_target_falls_back_to_number_input`).
         let tmp = project_with_main(default_main());
+        write_target_model(&tmp, "post", "Post");
         let plan = plan_scaffold(
             tmp.path(),
             "Comment",
@@ -3694,6 +3785,7 @@ async fn main() {
     #[test]
     fn execute_nullable_references_column_gets_unset_placeholder() {
         let tmp = project_with_main(default_main());
+        write_target_model(&tmp, "post", "Post");
         let plan = plan_scaffold(
             tmp.path(),
             "Comment",
@@ -3709,6 +3801,135 @@ async fn main() {
                 "let mut post_id_select = vec![(String::new(), \"— Unset —\".to_string())];"
             ),
             "nullable reference must get an '— Unset —' placeholder: {routes}"
+        );
+    }
+
+    #[test]
+    fn execute_references_column_with_missing_target_falls_back_to_number_input() {
+        // Regression test (issue #1135 review): a missing reference target has
+        // always been a warning, not an error — the scaffold assumes the table
+        // exists out-of-band (or gets generated later) and its output must
+        // still compile. The references→select promotion needs the target's
+        // `src/schema.rs` entry, so with no `Post` model in the project the
+        // `post_id` column must skip the whole select pipeline (schema
+        // import, options loader, Select override, threaded options) and keep
+        // the derived numeric id input.
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Comment",
+            &["body:Text".into(), "post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/comments.rs")).unwrap();
+        assert!(
+            routes.contains("use crate::schema::comments;"),
+            "only the resource's own schema module may be imported: {routes}"
+        );
+        assert!(
+            !routes.contains("posts::"),
+            "the missing target's schema module must never be referenced: {routes}"
+        );
+        assert!(
+            !routes.contains("post_id_select_options"),
+            "no options loader may be emitted for a missing target: {routes}"
+        );
+        assert!(
+            !routes.contains(".override_field(\"post_id\""),
+            "the column must keep the derived number input, not a Select: {routes}"
+        );
+        assert!(
+            !routes.contains("post_id_options"),
+            "the form helper must not take options for a missing target: {routes}"
+        );
+        // Without reference selects, `new_form` keeps its no-DB signature.
+        assert!(
+            !routes.contains("pub async fn new_form(\n    mut db: Db,"),
+            "new_form must not gain a DB handle when no options are loaded: {routes}"
+        );
+    }
+
+    #[test]
+    fn execute_mixed_reference_targets_keeps_select_only_for_present_target() {
+        // One reference whose target exists (`author` → src/models/author.rs)
+        // and one whose target is missing (`post`): only the present target
+        // gets the select promotion; the missing one falls back to the
+        // derived number input and stays out of the schema import.
+        let tmp = project_with_main(default_main());
+        write_target_model(&tmp, "author", "Author");
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Comment",
+            &["author:references".into(), "post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/comments.rs")).unwrap();
+        assert!(
+            routes.contains("use crate::schema::{comments, authors};")
+                || routes.contains("use crate::schema::{authors, comments};"),
+            "only the present target may join the schema import: {routes}"
+        );
+        assert!(
+            routes.contains(
+                ".override_field(\"author_id\", autumn_web::form::FieldControl::Select { options: author_id_select })"
+            ),
+            "the present target must keep its Select promotion: {routes}"
+        );
+        assert!(
+            routes.contains("async fn author_id_select_options"),
+            "the present target must keep its options loader: {routes}"
+        );
+        assert!(
+            !routes.contains("posts::") && !routes.contains("post_id_select_options"),
+            "the missing target must not produce select machinery: {routes}"
+        );
+        assert!(
+            !routes.contains(".override_field(\"post_id\""),
+            "the missing target's column must keep the derived number input: {routes}"
+        );
+    }
+
+    #[test]
+    fn execute_self_referential_reference_keeps_select_without_target_model() {
+        // A self-referential column targets the scaffold's own table, whose
+        // schema entry this very command generates — it is never "missing",
+        // so the select promotion applies even though no `src/models/
+        // category.rs` exists beforehand.
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Category",
+            &["name:String".into(), "category:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        assert!(
+            plan.warnings.is_empty(),
+            "a self-reference must not warn: {:?}",
+            plan.warnings
+        );
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/categories.rs")).unwrap();
+        assert!(
+            routes.contains(
+                ".override_field(\"category_id\", autumn_web::form::FieldControl::Select { options: category_id_select })"
+            ),
+            "self-referential column must keep the Select promotion: {routes}"
+        );
+        assert!(
+            routes.contains("async fn category_id_select_options"),
+            "self-referential column must keep its options loader: {routes}"
+        );
+        assert!(
+            routes.contains("use crate::schema::categories;"),
+            "own table needs no extra schema import: {routes}"
         );
     }
 
@@ -6343,8 +6564,22 @@ async fn main() {
             "20260427000000",
         )
         .unwrap();
-        assert_eq!(plan.warnings.len(), 1, "warnings: {:?}", plan.warnings);
+        // Two warnings: the shared "assuming table exists" one from
+        // `check_reference_targets`, plus the scaffold-specific note that the
+        // form falls back to a numeric id input (no schema entry to load
+        // select options from) and how to get the select instead.
+        assert_eq!(plan.warnings.len(), 2, "warnings: {:?}", plan.warnings);
         assert!(plan.warnings[0].contains("posts"));
+        assert!(
+            plan.warnings[1].contains("numeric id input"),
+            "warnings: {:?}",
+            plan.warnings
+        );
+        assert!(
+            plan.warnings[1].contains("Generate the 'post' model first"),
+            "warnings: {:?}",
+            plan.warnings
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -2045,7 +2045,9 @@ fn render_form_model_impl(pascal_name: &str) -> String {
 ///   blob key — a file input can't be repopulated, and `FieldControl::File`
 ///   would flip the form to `multipart/form-data` while scaffold forms stay
 ///   URL-encoded (uploads go through direct-upload URLs; see
-///   docs/guide/storage.md#direct-uploads);
+///   docs/guide/storage.md#direct-uploads). The appended markup renders the
+///   same inline-error/ARIA skeleton as the derived controls, so changeset
+///   errors on the attachment key still surface;
 /// - `references` columns are promoted to a `Select` over the referenced
 ///   table's ids (issue #1135 AC 2). The options are runtime data, so the
 ///   helper takes one `{column}_options: &[(String, String)]` parameter per
@@ -2063,11 +2065,31 @@ fn render_form_for_helper(pascal_name: &str, snake_name: &str, fields: &[Field])
             FieldKind::Attachment => {
                 let label = humanize_label(name);
                 let _ = write!(builder_calls, "\n        .exclude(\"{name}\")");
+                // The appended markup mirrors the inline-error/ARIA skeleton
+                // `FieldControl::File` renders (autumn-web's form.rs), so
+                // changeset errors on the attachment key surface next to the
+                // file input instead of being silently dropped — while still
+                // avoiding `FieldControl::File` itself, which would flip the
+                // form to `multipart/form-data`. Attachments are always
+                // `Option<String>`, so no `required`/`aria-required` signal.
                 let _ = write!(
                     appends,
-                    "\n        .append(html! {{ label {{ \"{label}\" }} \
-                     input type=\"file\" name=\"{name}\"; \
-                     input type=\"hidden\" name=\"{name}\" value=(changeset.field_value(\"{name}\").unwrap_or_default()); }})"
+                    "\n        .append(html! {{\n            \
+                     @let errors = changeset.errors_for(\"{name}\");\n            \
+                     div id=\"{name}-field\" class=\"autumn-field\" {{\n                \
+                     label for=\"{name}\" class=\"autumn-field__label\" {{ \"{label}\" }}\n                \
+                     input type=\"file\" id=\"{name}\" name=\"{name}\"\n                    \
+                     class=(if errors.is_empty() {{ \"autumn-field__input\" }} else {{ \"autumn-field__input autumn-field__input--invalid\" }})\n                    \
+                     aria-invalid=(if errors.is_empty() {{ \"false\" }} else {{ \"true\" }})\n                    \
+                     aria-describedby=(if errors.is_empty() {{ \"\" }} else {{ \"{name}-error\" }});\n                \
+                     input type=\"hidden\" name=\"{name}\" value=(changeset.field_value(\"{name}\").unwrap_or_default());\n                \
+                     @if !errors.is_empty() {{\n                    \
+                     div id=\"{name}-error\" role=\"alert\" class=\"autumn-field__errors\" {{\n                        \
+                     @for error in errors {{ p class=\"autumn-field__error\" {{ (error) }} }}\n                    \
+                     }}\n                \
+                     }}\n            \
+                     }}\n        \
+                     }})"
                 );
             }
             FieldKind::Enum => {
@@ -4840,10 +4862,28 @@ async fn main() {
         // the form to multipart, but scaffold forms stay URL-encoded.
         assert!(routes.contains(".exclude(\"avatar\")"), "{routes}");
         assert!(routes.contains(".append(html! {"), "{routes}");
-        assert!(routes.contains("input type=\"file\" name=\"avatar\""));
+        assert!(routes.contains("input type=\"file\" id=\"avatar\" name=\"avatar\""));
         assert!(routes.contains(
             "input type=\"hidden\" name=\"avatar\" value=(changeset.field_value(\"avatar\").unwrap_or_default())"
         ));
+
+        // The hand-rolled file input renders the same inline-error/ARIA
+        // skeleton as the derived controls (mirroring `FieldControl::File`
+        // in autumn-web's form.rs), so changeset errors on the attachment
+        // key are not silently dropped.
+        assert!(
+            routes.contains("@let errors = changeset.errors_for(\"avatar\");"),
+            "{routes}"
+        );
+        assert!(
+            routes.contains("aria-invalid=(if errors.is_empty() { \"false\" } else { \"true\" })"),
+            "{routes}"
+        );
+        assert!(
+            routes
+                .contains("div id=\"avatar-error\" role=\"alert\" class=\"autumn-field__errors\""),
+            "{routes}"
+        );
         assert!(
             !routes.contains("enctype"),
             "scaffold forms must stay URL-encoded even with attachments: {routes}"

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1071,22 +1071,22 @@ fn render_routes_file(
 ) -> String {
     let id_rust = id_type.rust_type();
     let validated_fields: Vec<&str> = validations.keys().map(String::as_str).collect();
-    // Issue #1124: `new_form`, `edit_form`, and both 422 re-render branches
-    // render the same inputs from a `Changeset<{Pascal}Form>` variable named
-    // `changeset`, so one renderer serves every site and the markup can never
-    // drift between them. Preserved values and inline errors come from the
-    // changeset via the shipped `autumn_web::form` helpers.
-    let changeset_inputs = render_changeset_form_inputs(
-        fields,
-        "changeset",
-        plural,
-        live_validation,
-        &validated_fields,
-    );
     let unique_fields: Vec<&Field> = fields.iter().filter(|f| f.unique).collect();
     let update_columns = render_update_columns(plural, fields);
     let nullable_field_match = render_nullable_field_match(fields);
     let has_attachments = has_attachment_fields(fields);
+    // `references` columns render as a `<select>` of the referenced table's
+    // ids (issue #1135 AC 2: "enum/references→select"). The options are
+    // runtime data, so the handlers that render the form load them and pass
+    // them into the shared `{snake}_form_for` helper. `--live-validation`
+    // keeps the old per-field emission (no `form_for`), so no options are
+    // loaded there.
+    let reference_fields: Vec<&Field> = if live_validation {
+        Vec::new()
+    } else {
+        fields.iter().filter(|f| f.kind.is_reference()).collect()
+    };
+    let has_reference_selects = !reference_fields.is_empty();
     let model_form = render_model_form(pascal_name, fields, validations);
     // Enum fields need their generated Rust type in scope here — `into_new`
     // parses into it and the `From<&Row>` seed matches against its variants
@@ -1237,6 +1237,29 @@ fn render_routes_file(
         1,
     );
 
+    // Issue #1135: reference selects need a DB handle to load their options
+    // in every handler that renders the form. `create`/`update` already carry
+    // `mut db` except on the live non-sharded path (which uses the repository
+    // extractor); `new_form` never had one. Keep `body: Bytes` last — axum's
+    // `Handler` impl requires the body-consuming extractor in final position.
+    let (create_signature, update_signature) = if has_reference_selects && live && !sharded {
+        (
+            create_signature.replacen("body: Bytes", &format!("mut db: {db_ty}, body: Bytes"), 1),
+            update_signature.replacen(
+                "body: Bytes",
+                &format!("mut db: {db_ty},\n    body: Bytes"),
+                1,
+            ),
+        )
+    } else {
+        (create_signature, update_signature)
+    };
+    let new_form_db_param = if has_reference_selects {
+        format!("mut db: {db_ty},\n    ")
+    } else {
+        String::new()
+    };
+
     // `decode_form` always returns the `{Pascal}Form` (sync — attachment blob
     // resolution moved into `into_new`, which needs `&state`). `into_new`
     // converts the validated form into `New{Pascal}` on the success path.
@@ -1252,28 +1275,98 @@ fn render_routes_file(
     // emit, reused verbatim by the 422 branches so the form can't drift. Both
     // read from a `Changeset<{Pascal}Form>` named `changeset` and the CSRF
     // params now present on every create/update signature.
-    let new_form_body = format!(
-        "layout(\"New {pascal_name}\", flash.render().await, html! {{\n        \
-         h1 {{ \"New {pascal_name}\" }}\n        \
-         form action=\"/{plural}\" method=\"post\"{form_enctype} {{\n            \
-         (csrf_input(csrf.as_ref(), csrf_field.as_ref()))\n{changeset_inputs}            \
-         button type=\"submit\" {{ \"Create\" }}\n        \
-         }}\n    \
-         }})"
-    );
-    let edit_form_body = format!(
-        "layout(&format!(\"Edit {pascal_name} #{{}}\", *id), flash.render().await, html! {{\n        \
-         h1 {{ \"Edit {pascal_name} #\" (*id) }}\n        \
-         form action=(format!(\"/{plural}/{{}}/update\", *id)) method=\"post\"{form_enctype} {{\n            \
-         (csrf_input(csrf.as_ref(), csrf_field.as_ref()))\n{changeset_inputs}            \
-         button type=\"submit\" {{ \"Save\" }}\n        \
-         }}\n        \
-         form action=(format!(\"/{plural}/{{}}/delete\", *id)) method=\"post\" {{\n            \
-         (csrf_input(csrf.as_ref(), csrf_field.as_ref()))\n            \
-         button type=\"submit\" onclick=\"return confirm('Delete this {pascal_name}?')\" {{ \"Delete\" }}\n        \
-         }}\n    \
-         }})"
-    );
+    //
+    // Issue #1135: the standard scaffold renders the whole form through one
+    // shared `{snake}_form_for` helper (a single `form_for` call deriving
+    // every control from the `FormModel` descriptors), so the view bodies
+    // carry zero per-column code. `--live-validation` keeps the per-field
+    // emission path: its htmx inline-validation inputs (`text_input_htmx`)
+    // have no `FieldControl` equivalent for `form_for` to dispatch to.
+    let (new_form_body, edit_form_body, form_for_helper) = if live_validation {
+        // Issue #1124: `new_form`, `edit_form`, and both 422 re-render
+        // branches render the same inputs from a `Changeset<{Pascal}Form>`
+        // variable named `changeset`, so one renderer serves every site and
+        // the markup can never drift between them. Preserved values and
+        // inline errors come from the changeset via the shipped
+        // `autumn_web::form` helpers.
+        let changeset_inputs = render_changeset_form_inputs(
+            fields,
+            "changeset",
+            plural,
+            live_validation,
+            &validated_fields,
+        );
+        let new_form_body = format!(
+            "layout(\"New {pascal_name}\", flash.render().await, html! {{\n        \
+             h1 {{ \"New {pascal_name}\" }}\n        \
+             form action=\"/{plural}\" method=\"post\"{form_enctype} {{\n            \
+             (csrf_input(csrf.as_ref(), csrf_field.as_ref()))\n{changeset_inputs}            \
+             button type=\"submit\" {{ \"Create\" }}\n        \
+             }}\n    \
+             }})"
+        );
+        let edit_form_body = format!(
+            "layout(&format!(\"Edit {pascal_name} #{{}}\", *id), flash.render().await, html! {{\n        \
+             h1 {{ \"Edit {pascal_name} #\" (*id) }}\n        \
+             form action=(format!(\"/{plural}/{{}}/update\", *id)) method=\"post\"{form_enctype} {{\n            \
+             (csrf_input(csrf.as_ref(), csrf_field.as_ref()))\n{changeset_inputs}            \
+             button type=\"submit\" {{ \"Save\" }}\n        \
+             }}\n        \
+             form action=(format!(\"/{plural}/{{}}/delete\", *id)) method=\"post\" {{\n            \
+             (csrf_input(csrf.as_ref(), csrf_field.as_ref()))\n            \
+             button type=\"submit\" onclick=\"return confirm('Delete this {pascal_name}?')\" {{ \"Delete\" }}\n        \
+             }}\n    \
+             }})"
+        );
+        (new_form_body, edit_form_body, String::new())
+    } else {
+        // Reference selects: load the referenced ids before rendering and
+        // thread them into the shared helper (issue #1135, AC 2
+        // "references→select"). The loads live in a block expression wrapped
+        // around the `layout(...)` call so the same body splices into the GET
+        // handlers and the 422 re-render branches unchanged.
+        let mut option_loads = String::new();
+        let mut option_args = String::new();
+        for f in &reference_fields {
+            let name = &f.name;
+            let _ = writeln!(
+                option_loads,
+                "        let {name}_options = {name}_select_options(&mut db).await?;"
+            );
+            let _ = write!(option_args, ", &{name}_options");
+        }
+        let new_form_layout = format!(
+            "layout(\"New {pascal_name}\", flash.render().await, html! {{\n        \
+             h1 {{ \"New {pascal_name}\" }}\n        \
+             ({snake_name}_form_for(&changeset, \"/{plural}\".to_string(), \"Create\", csrf.as_ref(), csrf_field.as_ref(){option_args}))\n    \
+             }})"
+        );
+        let edit_form_layout = format!(
+            "layout(&format!(\"Edit {pascal_name} #{{}}\", *id), flash.render().await, html! {{\n        \
+             h1 {{ \"Edit {pascal_name} #\" (*id) }}\n        \
+             ({snake_name}_form_for(&changeset, format!(\"/{plural}/{{}}/update\", *id), \"Save\", csrf.as_ref(), csrf_field.as_ref(){option_args}))\n        \
+             form action=(format!(\"/{plural}/{{}}/delete\", *id)) method=\"post\" {{\n            \
+             (csrf_input(csrf.as_ref(), csrf_field.as_ref()))\n            \
+             button type=\"submit\" onclick=\"return confirm('Delete this {pascal_name}?')\" {{ \"Delete\" }}\n        \
+             }}\n    \
+             }})"
+        );
+        let (new_form_body, edit_form_body) = if has_reference_selects {
+            (
+                format!("{{\n{option_loads}        {new_form_layout}\n    }}"),
+                format!("{{\n{option_loads}        {edit_form_layout}\n    }}"),
+            )
+        } else {
+            (new_form_layout, edit_form_layout)
+        };
+        (
+            new_form_body,
+            edit_form_body,
+            render_form_for_helper(pascal_name, snake_name, fields)
+                + &render_reference_option_loaders(&reference_fields, db_ty),
+        )
+    };
+    let form_model_impl = render_form_model_impl(pascal_name);
 
     // `unique` fields (issue #1032) still classify DB constraint violations,
     // but now feed the error into the *same* changeset renderer via
@@ -1562,6 +1655,29 @@ pub async fn index(
             .to_owned()
     };
 
+    // Schema imports: the resource's own table, plus — when reference selects
+    // are rendered — each referenced table so its ids can be loaded for the
+    // select options. Requires the referenced resource to have been generated
+    // first (its `diesel::table!` entry must exist in `src/schema.rs`), the
+    // same ordering the migration's FOREIGN KEY already imposes at the
+    // database level.
+    let schema_import = {
+        let mut extra_tables: BTreeSet<String> = reference_fields
+            .iter()
+            .filter_map(|f| f.reference_table())
+            .collect();
+        extra_tables.remove(plural);
+        if extra_tables.is_empty() {
+            plural.to_owned()
+        } else {
+            let mut list = plural.to_owned();
+            for table in extra_tables {
+                let _ = write!(list, ", {table}");
+            }
+            format!("{{{list}}}")
+        }
+    };
+
     // When `--live-validation`, emit one inline-validation handler per validated
     // field. Each handler decodes the *whole* submitted form (htmx's
     // `hx-include="closest form"` posts every field, not just the one that
@@ -1640,7 +1756,7 @@ use diesel_async::RunQueryDsl;
 
 use crate::models::{snake_name}::{{{pascal_name}, New{pascal_name}, Update{pascal_name}{enum_import_suffix}}};
 use crate::repositories::{snake_name}::{{{pascal_name}Repository, Pg{pascal_name}Repository}};
-use crate::schema::{plural};",
+use crate::schema::{schema_import};",
         attachment_note = if has_attachments {
             "//!\n\
              //! This scaffold includes file-attachment fields. File uploads are handled\n\
@@ -1738,7 +1854,7 @@ pub async fn show(id: Path<{id_rust}>, mut db: {db_ty}, flash: Flash) -> AutumnR
 #[secured]
 #[get("/{plural}/new")]
 pub async fn new_form(
-    flash: Flash,
+    {new_form_db_param}flash: Flash,
     csrf: Option<CsrfToken>,
     csrf_field: Option<CsrfFormField>,
 ) -> AutumnResult<Markup> {{
@@ -1799,7 +1915,9 @@ pub async fn destroy(
 
 {from_row_impl}
 
-{decode_form_sig} {{
+{form_model_impl}
+
+{form_for_helper}{decode_form_sig} {{
     let pairs: Vec<_> = url::form_urlencoded::parse(body.as_ref())
         .filter(|(key, value)| !(value.is_empty() && is_nullable_form_field(key)))
         .collect();
@@ -1888,8 +2006,194 @@ fn has_attachment_fields(fields: &[Field]) -> bool {
     fields.iter().any(|f| f.kind.is_attachment())
 }
 
-/// Render the form inputs for a scaffold's new/edit/re-render views through
-/// the shipped, changeset-aware `autumn_web::form` helpers (issue #1124).
+/// Emit the `FormModel` delegation impl for the generated `{Pascal}Form`
+/// (issue #1135). `form_for` derives its controls from the changeset's own
+/// type, and the `#[model]` derive already produces the field descriptors on
+/// `{Pascal}` — same field names, same declaration order, and both exclude
+/// the primary key and `#[default]` columns — so the form struct simply
+/// reuses the model's list instead of restating it.
+fn render_form_model_impl(pascal_name: &str) -> String {
+    format!(
+        "/// `form_for` field descriptors (issue #1135): delegate to the\n\
+         /// `#[model]`-derived implementation on `{pascal_name}` so the rendered form\n\
+         /// always tracks the model's columns.\n\
+         impl autumn_web::form::FormModel for {pascal_name}Form {{\n    \
+         fn form_fields() -> Vec<autumn_web::form::FormField> {{\n        \
+         <{pascal_name} as autumn_web::form::FormModel>::form_fields()\n    \
+         }}\n\
+         }}"
+    )
+}
+
+/// Render the shared `{snake}_form_for` helper the generated views call
+/// (issue #1135): one `form_for` call renders the open `<form>` tag, the CSRF
+/// hidden input, one type-appropriate control per `FormModel` field (with
+/// pre-filled values and inline errors from the changeset), and the submit
+/// button — so `new_form`, `edit_form`, and both 422 re-render branches carry
+/// zero per-column view code, and adding a model column requires no view
+/// edits.
+///
+/// The scaffold layers on only what the derive can't know statically:
+/// - enum columns are promoted to a `Select` with one option per declared
+///   variant plus a blank placeholder (the derive sees an opaque Rust enum
+///   type and falls back to a text control);
+/// - decimal columns pin the browser `step` to the column's declared scale
+///   (the derive emits a free `step="any"`, losing the column's actual
+///   smallest representable increment);
+/// - attachment columns are excluded from the derived list and re-appended
+///   as a hand-rolled file input plus a hidden input carrying the existing
+///   blob key — a file input can't be repopulated, and `FieldControl::File`
+///   would flip the form to `multipart/form-data` while scaffold forms stay
+///   URL-encoded (uploads go through direct-upload URLs; see
+///   docs/guide/storage.md#direct-uploads);
+/// - `references` columns are promoted to a `Select` over the referenced
+///   table's ids (issue #1135 AC 2). The options are runtime data, so the
+///   helper takes one `{column}_options: &[(String, String)]` parameter per
+///   reference and the calling handlers load them (see the generated
+///   `{column}_select_options` loader).
+fn render_form_for_helper(pascal_name: &str, snake_name: &str, fields: &[Field]) -> String {
+    use std::fmt::Write as _;
+    let mut extra_params = String::new();
+    let mut preludes = String::new();
+    let mut builder_calls = String::new();
+    let mut appends = String::new();
+    for f in fields {
+        let name = &f.name;
+        match f.kind {
+            FieldKind::Attachment => {
+                let label = humanize_label(name);
+                let _ = write!(builder_calls, "\n        .exclude(\"{name}\")");
+                let _ = write!(
+                    appends,
+                    "\n        .append(html! {{ label {{ \"{label}\" }} \
+                     input type=\"file\" name=\"{name}\"; \
+                     input type=\"hidden\" name=\"{name}\" value=(changeset.field_value(\"{name}\").unwrap_or_default()); }})"
+                );
+            }
+            FieldKind::Enum => {
+                let placeholder = if f.nullable {
+                    "— Unset —"
+                } else {
+                    "— Select —"
+                };
+                let mut options = format!("(\"\".into(), \"{placeholder}\".into())");
+                for v in &f.variants {
+                    let vlabel = humanize_label(v);
+                    let _ = write!(options, ", (\"{v}\".into(), \"{vlabel}\".into())");
+                }
+                let _ = write!(
+                    builder_calls,
+                    "\n        .override_field(\"{name}\", autumn_web::form::FieldControl::Select {{ options: vec![{options}] }})"
+                );
+            }
+            FieldKind::Decimal { scale, .. } => {
+                let step = decimal_step(scale);
+                let _ = write!(
+                    builder_calls,
+                    "\n        .override_field(\"{name}\", autumn_web::form::FieldControl::Number {{ step: Some(\"{step}\".into()) }})"
+                );
+            }
+            FieldKind::References => {
+                // The derive sees a plain `i64` column and emits a number
+                // input; the reference renders as a select over the
+                // referenced table's ids instead. A blank first option gives
+                // required selects browser-native "please select" behavior
+                // (nullable references use it to unset the value).
+                let placeholder = if f.nullable {
+                    "— Unset —"
+                } else {
+                    "— Select —"
+                };
+                let _ = write!(extra_params, ",\n    {name}_options: &[(String, String)]");
+                let _ = write!(
+                    preludes,
+                    "    let mut {name}_select = vec![(String::new(), \"{placeholder}\".to_string())];\n    \
+                     {name}_select.extend({name}_options.iter().cloned());\n"
+                );
+                let _ = write!(
+                    builder_calls,
+                    "\n        .override_field(\"{name}\", autumn_web::form::FieldControl::Select {{ options: {name}_select }})"
+                );
+            }
+            _ => {}
+        }
+    }
+    format!(
+        "/// Render the create/edit form in a single `form_for` call (issue #1135).\n\
+         ///\n\
+         /// Controls, labels, pre-filled values, and inline errors all derive from\n\
+         /// `{pascal_name}Form`'s `FormModel` field descriptors, so adding a model\n\
+         /// column requires no edits here — any enum/decimal/attachment overrides\n\
+         /// below are the only schema-specific lines, and regeneration maintains\n\
+         /// them.\n\
+         fn {snake_name}_form_for(\n    \
+         changeset: &Changeset<{pascal_name}Form>,\n    \
+         action: String,\n    \
+         submit_label: &str,\n    \
+         csrf: Option<&CsrfToken>,\n    \
+         csrf_field: Option<&CsrfFormField>{extra_params},\n\
+         ) -> Markup {{\n\
+         {preludes}    \
+         let mut form = autumn_web::form::form_for(changeset, action, \"post\")\n        \
+         .submit_label(submit_label){builder_calls}{appends};\n    \
+         if let Some(csrf) = csrf {{\n        \
+         form = form.csrf(csrf.token());\n    \
+         }}\n    \
+         if let Some(field) = csrf_field {{\n        \
+         form = form.csrf_field_name(field.0.as_str());\n    \
+         }}\n    \
+         form.render()\n\
+         }}\n\n"
+    )
+}
+
+/// Render one async `{column}_select_options` loader per `references` column
+/// (issue #1135 AC 2: "references→select"). Each loader queries the
+/// referenced table's ids and returns them as `(value, label)` pairs for the
+/// `Select` override in the shared `{snake}_form_for` helper. Every handler
+/// that renders the form (`new_form`, `edit_form`, and the `create`/`update`
+/// 422 re-render branches) calls the loaders before rendering.
+///
+/// Labels are the raw id rendered as a string: which referenced-table column
+/// makes a human-friendly label is a display decision the generator can't
+/// know, so the generated doc comment tells the author where to swap in a
+/// real label column.
+fn render_reference_option_loaders(reference_fields: &[&Field], db_ty: &str) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    for f in reference_fields {
+        let name = &f.name;
+        let Some(table) = f.reference_table() else {
+            continue;
+        };
+        let _ = write!(
+            out,
+            "/// Load the `(value, label)` select options for the `{name}` reference —\n\
+             /// one option per `{table}` row, ordered by id (issue #1135).\n\
+             ///\n\
+             /// Labels are the row id rendered as a string: which `{table}` column makes\n\
+             /// a human-friendly label is a display decision the generator can't know —\n\
+             /// swap the `map` below to use a real label column.\n\
+             async fn {name}_select_options(db: &mut {db_ty}) -> AutumnResult<Vec<(String, String)>> {{\n    \
+             let ids: Vec<i64> = {table}::table\n        \
+             .select({table}::id)\n        \
+             .order({table}::id.asc())\n        \
+             .load(&mut **db)\n        \
+             .await?;\n    \
+             Ok(ids.into_iter().map(|id| (id.to_string(), id.to_string())).collect())\n\
+             }}\n\n"
+        );
+    }
+    out
+}
+
+/// Render the form inputs for a scaffold's `--live-validation` new/edit/
+/// re-render views through the shipped, changeset-aware `autumn_web::form`
+/// helpers (issue #1124). Standard scaffolds render through a single
+/// `form_for` call instead (issue #1135, see [`render_form_for_helper`]);
+/// this per-field path survives only for `--live-validation`, whose htmx
+/// inline-validation inputs (`text_input_htmx`) have no `FieldControl`
+/// equivalent.
 ///
 /// Every helper reads its value and any inline errors from the
 /// `Changeset<{Pascal}Form>` bound to `changeset_var` in the calling handler,
@@ -3258,14 +3562,12 @@ async fn main() {
     }
 
     #[test]
-    fn execute_writes_required_attribute_for_unvalidated_required_text_field() {
-        // Regression guard (issue #1124 review): the pre-#1124 generator added
-        // the HTML `required` attribute to every non-nullable field
-        // unconditionally, independent of whether a `--validate` rule was
-        // declared. `autumn generate scaffold Post title:String` (no
-        // `--validate` at all) must still mark `title` `required` — otherwise
-        // a blank browser submission is treated as valid and inserts `title =
-        // ""`, silently accepting empty required data.
+    fn execute_writes_form_for_helper_with_formmodel_delegation() {
+        // Issue #1135: per-column control selection (and the required /
+        // `aria-required` signal issue #1124 guarded here) now lives in the
+        // `#[model]`-derived `FormModel` descriptors — the routes file
+        // delegates `PostForm`'s fields to the model's derived impl and
+        // renders the whole form through one shared `form_for` helper.
         let tmp = project_with_main(default_main());
         let plan = plan_scaffold(
             tmp.path(),
@@ -3278,11 +3580,113 @@ async fn main() {
 
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
         assert!(
+            routes.contains("impl autumn_web::form::FormModel for PostForm"),
+            "PostForm must implement FormModel: {routes}"
+        );
+        assert!(
+            routes.contains("<Post as autumn_web::form::FormModel>::form_fields()"),
+            "PostForm must delegate its descriptors to the derived model impl: {routes}"
+        );
+        assert!(routes.contains("fn post_form_for("), "{routes}");
+        assert!(
+            routes.contains("autumn_web::form::form_for(changeset, action, \"post\")"),
+            "the shared helper must render through form_for: {routes}"
+        );
+        assert!(
+            !routes.contains("autumn_web::form::required_text_input(&changeset"),
+            "no per-field input helpers may remain in the views: {routes}"
+        );
+    }
+
+    #[test]
+    fn execute_references_column_renders_select_with_loaded_options() {
+        // Issue #1135 AC 2: "references→select". The `#[model]` derive sees a
+        // plain `i64` and emits a number input; the scaffold overrides the
+        // reference to a `Select` whose options (the referenced table's ids)
+        // are loaded by every handler that renders the form and threaded
+        // through the shared `comment_form_for` helper.
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Comment",
+            &["body:Text".into(), "post:references".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/comments.rs")).unwrap();
+        // The helper takes the loaded options and promotes the column.
+        assert!(
+            routes.contains("post_id_options: &[(String, String)],"),
+            "helper must take the reference options: {routes}"
+        );
+        assert!(
             routes.contains(
-                "autumn_web::form::required_text_input(&changeset, \"title\", \"Title\")"
+                "let mut post_id_select = vec![(String::new(), \"— Select —\".to_string())];"
             ),
-            "an unvalidated but required field must still render via \
-             required_text_input: {routes}"
+            "non-nullable reference must get a blank 'please select' placeholder: {routes}"
+        );
+        assert!(
+            routes.contains(
+                ".override_field(\"post_id\", autumn_web::form::FieldControl::Select { options: post_id_select })"
+            ),
+            "reference column must be promoted to a Select: {routes}"
+        );
+        // A shared loader queries the referenced table's ids.
+        assert!(
+            routes.contains(
+                "async fn post_id_select_options(db: &mut Db) -> AutumnResult<Vec<(String, String)>>"
+            ),
+            "must emit an options loader: {routes}"
+        );
+        assert!(
+            routes.contains("posts::table") && routes.contains(".select(posts::id)"),
+            "loader must query the referenced table's ids: {routes}"
+        );
+        assert!(
+            routes.contains("use crate::schema::{comments, posts};"),
+            "referenced table's schema module must be imported: {routes}"
+        );
+        // Every rendering handler loads the options: new_form/edit_form GETs
+        // plus the create/update 422 re-render branches.
+        assert_eq!(
+            routes
+                .matches("let post_id_options = post_id_select_options(&mut db).await?;")
+                .count(),
+            4,
+            "new_form, edit_form, create 422, and update 422 must all load options: {routes}"
+        );
+        // `new_form` gains the DB handle it previously didn't need.
+        assert!(
+            routes.contains("pub async fn new_form(\n    mut db: Db,"),
+            "new_form must take a DB handle to load reference options: {routes}"
+        );
+        // The helper call threads the options through.
+        assert!(
+            routes.contains("csrf_field.as_ref(), &post_id_options))"),
+            "view bodies must pass the loaded options to the helper: {routes}"
+        );
+    }
+
+    #[test]
+    fn execute_nullable_references_column_gets_unset_placeholder() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Comment",
+            &["post:Option<references>".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/comments.rs")).unwrap();
+        assert!(
+            routes.contains(
+                "let mut post_id_select = vec![(String::new(), \"— Unset —\".to_string())];"
+            ),
+            "nullable reference must get an '— Unset —' placeholder: {routes}"
         );
     }
 
@@ -3360,14 +3764,15 @@ async fn main() {
         plan_and_execute_post_scaffold_with_status_enum(&tmp);
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
 
-        // Enum fields render through the changeset-aware `select_input` helper
-        // (issue #1124), with one `(value, label)` option per variant plus a
-        // leading placeholder. The selected option is chosen by the helper from
-        // the changeset's current value, not a hand-rolled `selected[...]`.
-        // Required (non-nullable), so the `required_select_input` sibling.
+        // Enum fields are promoted to a `Select` control via a `form_for`
+        // override (issue #1135) — the `#[model]` derive sees only an opaque
+        // Rust enum type, but the scaffold knows the variants statically and
+        // emits one `(value, label)` option per variant plus a leading
+        // placeholder. The selected option is chosen by the shipped
+        // `select_input` helper from the changeset's current value.
         assert!(
             routes.contains(
-                "autumn_web::form::required_select_input(&changeset, \"status\", \"Status\", &[(\"\", \"— Select —\"), (\"draft\", \"Draft\"), (\"published\", \"Published\"), (\"archived\", \"Archived\")])"
+                ".override_field(\"status\", autumn_web::form::FieldControl::Select { options: vec![(\"\".into(), \"— Select —\".into()), (\"draft\".into(), \"Draft\".into()), (\"published\".into(), \"Published\".into()), (\"archived\".into(), \"Archived\".into())] })"
             ),
             "got:\n{routes}"
         );
@@ -3458,8 +3863,12 @@ async fn main() {
         plan.execute(Flags::default()).unwrap();
 
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        // A `--default` field is excluded from the derived `FormModel` list
+        // (the model marks it `#[default]`), so the scaffold must not emit a
+        // select override for it either — otherwise `form_for` would carry a
+        // dangling override for a field it never renders.
         assert!(
-            !routes.contains("select name=\"status\""),
+            !routes.contains(".override_field(\"status\""),
             "a --default field must be excluded from the create/edit forms: {routes}"
         );
     }
@@ -3606,7 +4015,7 @@ async fn main() {
 
         assert!(
             routes.contains(
-                "autumn_web::form::select_input(&changeset, \"status\", \"Status\", &[(\"\", \"— Unset —\"), (\"draft\", \"Draft\"), (\"published\", \"Published\")])"
+                ".override_field(\"status\", autumn_web::form::FieldControl::Select { options: vec![(\"\".into(), \"— Unset —\".into()), (\"draft\".into(), \"Draft\".into()), (\"published\".into(), \"Published\".into())] })"
             ),
             "got:\n{routes}"
         );
@@ -3769,7 +4178,7 @@ async fn main() {
     }
 
     #[test]
-    fn execute_new_and_edit_forms_use_changeset_helpers() {
+    fn execute_new_and_edit_forms_render_via_form_for() {
         let tmp = project_with_main(default_main());
         let plan = plan_scaffold_with_options(
             tmp.path(),
@@ -3793,26 +4202,42 @@ async fn main() {
         plan.execute(Flags::default()).unwrap();
 
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
-        // AC6: new/edit render through the changeset-aware input helpers.
-        // Every field here is required (non-nullable), so each uses its
-        // `required_*` sibling helper (issue #1124 review).
-        assert!(
-            routes.contains("autumn_web::form::required_text_input(&changeset, \"title\""),
-            "string fields must render via required_text_input: {routes}"
+        // Issue #1135: new/edit render the whole form through one shared
+        // `form_for` helper — control selection per column (text/number/
+        // checkbox/datetime, required or not) lives in the derived
+        // `FormModel` descriptors, so the routes file carries no per-field
+        // input lines at all.
+        let new_form_start = routes
+            .find("pub async fn new_form")
+            .expect("new_form handler");
+        let create_start = routes.find("pub async fn create(").expect("create handler");
+        let new_form_body = &routes[new_form_start..create_start];
+        assert_eq!(
+            new_form_body.matches("post_form_for(&changeset").count(),
+            1,
+            "the new view must render via exactly one form_for call: {new_form_body}"
         );
-        assert!(
-            routes.contains("autumn_web::form::required_number_input(&changeset, \"rank\""),
-            "numeric fields must render via required_number_input: {routes}"
+        let edit_form_start = routes
+            .find("pub async fn edit_form")
+            .expect("edit_form handler");
+        let update_start = routes.find("pub async fn update(").expect("update handler");
+        let edit_form_body = &routes[edit_form_start..update_start];
+        assert_eq!(
+            edit_form_body.matches("post_form_for(&changeset").count(),
+            1,
+            "the edit view must render via exactly one form_for call: {edit_form_body}"
         );
-        assert!(
-            routes.contains("autumn_web::form::checkbox_input(&changeset, \"published\""),
-            "bool fields must render via checkbox_input: {routes}"
-        );
-        assert!(
-            routes
-                .contains("autumn_web::form::required_datetime_input(&changeset, \"published_at\""),
-            "datetime fields must render via required_datetime_input: {routes}"
-        );
+        for helper in [
+            "required_text_input",
+            "required_number_input",
+            "checkbox_input",
+            "required_datetime_input",
+        ] {
+            assert!(
+                !routes.contains(&format!("autumn_web::form::{helper}(&changeset")),
+                "no per-field {helper} lines may remain: {routes}"
+            );
+        }
         // The old hand-rolled bare-HTML text input must be gone for standard fields.
         assert!(
             !routes.contains(r#"input type="text" name="title""#),
@@ -3856,12 +4281,12 @@ async fn main() {
             routes.contains("views: row.views.clone(),"),
             "seed must copy nullable numeric fields from the loaded row: {routes}"
         );
-        // Both new and edit render the numeric field via the number helper.
+        // The nullable numeric control itself comes from the derived
+        // `FormModel` descriptors (Option<i64> → non-required number input);
+        // the routes file needs no per-field code or override for it.
         assert!(
-            routes.contains(
-                "autumn_web::form::number_input(&changeset, \"views\", \"Views\", Some(\"1\"))"
-            ),
-            "nullable numeric fields render via number_input: {routes}"
+            !routes.contains(".override_field(\"views\""),
+            "plain numeric fields need no form_for override: {routes}"
         );
     }
 
@@ -4408,12 +4833,21 @@ async fn main() {
 
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
 
-        // Attachment fields keep a hand-rolled file input plus a hidden field
-        // carrying the existing blob key from the changeset (issue #1124).
+        // Attachment fields are excluded from the derived `FormModel` list
+        // and re-appended to the `form_for` builder as a hand-rolled file
+        // input plus a hidden field carrying the existing blob key from the
+        // changeset (issues #1124/#1135) — `FieldControl::File` would flip
+        // the form to multipart, but scaffold forms stay URL-encoded.
+        assert!(routes.contains(".exclude(\"avatar\")"), "{routes}");
+        assert!(routes.contains(".append(html! {"), "{routes}");
         assert!(routes.contains("input type=\"file\" name=\"avatar\""));
         assert!(routes.contains(
             "input type=\"hidden\" name=\"avatar\" value=(changeset.field_value(\"avatar\").unwrap_or_default())"
         ));
+        assert!(
+            !routes.contains("enctype"),
+            "scaffold forms must stay URL-encoded even with attachments: {routes}"
+        );
 
         // The form struct carries the attachment key as an Option<String>.
         assert!(routes.contains("pub struct PostForm"));
@@ -4439,12 +4873,16 @@ async fn main() {
 
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
 
-        // Bool fields render through the changeset-aware `checkbox_input`
-        // helper (issue #1124), which reflects the value and emits exactly one
-        // `name="active"` input — no duplicate-key hidden fallback.
+        // Bool fields map to a checkbox in the derived `FormModel`
+        // descriptors (issue #1135) — no per-field helper line and no
+        // `form_for` override needed in the routes file.
         assert!(
-            routes.contains("autumn_web::form::checkbox_input(&changeset, \"active\", \"Active\")"),
+            !routes.contains("autumn_web::form::checkbox_input(&changeset"),
             "{routes}"
+        );
+        assert!(
+            !routes.contains(".override_field(\"active\""),
+            "bool fields need no form_for override: {routes}"
         );
         assert!(
             !routes.contains("input type=\"text\" name=\"active\""),
@@ -4479,13 +4917,16 @@ async fn main() {
             !routes.contains("input type=\"checkbox\" name=\"archived\""),
             "nullable bool must not render a checkbox: {routes}"
         );
-        // A nullable bool renders a 3-option `select_input` (unset/true/false);
-        // the changeset picks the current option (issue #1124).
+        // A nullable bool maps to a 3-option select (unset/true/false) in the
+        // derived `FormModel` descriptors (issue #1135) — no per-field helper
+        // line and no `form_for` override needed in the routes file.
         assert!(
-            routes.contains(
-                "autumn_web::form::select_input(&changeset, \"archived\", \"Archived\", &[(\"\", \"— Unset —\"), (\"true\", \"Yes\"), (\"false\", \"No\")])"
-            ),
+            !routes.contains("autumn_web::form::select_input(&changeset"),
             "{routes}"
+        );
+        assert!(
+            !routes.contains(".override_field(\"archived\""),
+            "nullable bool fields need no form_for override: {routes}"
         );
         // The form field is an Option<bool> so a blank submission stays None.
         assert!(routes.contains("pub archived: Option<bool>,"), "{routes}");
@@ -4505,20 +4946,19 @@ async fn main() {
 
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
 
-        // Both fields are required (non-nullable), so both use
-        // `required_number_input` (issue #1124 review).
+        // Integer fields map to a stepped number control in the derived
+        // `FormModel` descriptors (issue #1135) — no per-field helper line
+        // and no `form_for` override needed in the routes file.
         assert!(
-            routes.contains(
-                "autumn_web::form::required_number_input(&changeset, \"views\", \"Views\", Some(\"1\"))"
-            ),
+            !routes.contains("autumn_web::form::required_number_input(&changeset"),
             "{routes}"
         );
-        assert!(
-            routes.contains(
-                "autumn_web::form::required_number_input(&changeset, \"rank\", \"Rank\", Some(\"1\"))"
-            ),
-            "{routes}"
-        );
+        for field in ["views", "rank"] {
+            assert!(
+                !routes.contains(&format!(".override_field(\"{field}\"")),
+                "integer fields need no form_for override: {routes}"
+            );
+        }
         assert!(
             !routes.contains("input type=\"text\" name=\"views\""),
             "{routes}"
@@ -4543,20 +4983,19 @@ async fn main() {
 
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
 
-        // Both fields are required (non-nullable), so both use
-        // `required_number_input` (issue #1124 review).
+        // Float fields map to a free-step number control in the derived
+        // `FormModel` descriptors (issue #1135) — no per-field helper line
+        // and no `form_for` override needed in the routes file.
         assert!(
-            routes.contains(
-                "autumn_web::form::required_number_input(&changeset, \"price\", \"Price\", Some(\"any\"))"
-            ),
+            !routes.contains("autumn_web::form::required_number_input(&changeset"),
             "{routes}"
         );
-        assert!(
-            routes.contains(
-                "autumn_web::form::required_number_input(&changeset, \"weight\", \"Weight\", Some(\"any\"))"
-            ),
-            "{routes}"
-        );
+        for field in ["price", "weight"] {
+            assert!(
+                !routes.contains(&format!(".override_field(\"{field}\"")),
+                "float fields need no form_for override: {routes}"
+            );
+        }
     }
 
     #[test]
@@ -4582,12 +5021,6 @@ async fn main() {
         plan.execute(Flags::default()).unwrap();
 
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
-        assert!(
-            routes.contains(
-                "autumn_web::form::required_number_input(&changeset, \"price\", \"Price\", Some(\"any\"))"
-            ),
-            "{routes}"
-        );
         assert!(routes.contains("pub price: String,"), "{routes}");
         assert!(
             routes.contains(
@@ -4705,14 +5138,9 @@ async fn main() {
         plan.execute(Flags::default()).unwrap();
 
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
-        // The edit form seeds the changeset from the row; `required_number_input`
-        // (required, non-nullable field) reads the value back (issue #1124).
-        assert!(
-            routes.contains(
-                "autumn_web::form::required_number_input(&changeset, \"views\", \"Views\", Some(\"1\"))"
-            ),
-            "{routes}"
-        );
+        // The edit form seeds the changeset from the row; the number control
+        // (from the derived `FormModel` descriptors) reads the value back
+        // through `form_for` (issues #1124/#1135).
         assert!(routes.contains("views: row.views.to_string(),"), "{routes}");
     }
 
@@ -4730,13 +5158,16 @@ async fn main() {
 
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
 
-        // Datetime fields render via the `datetime_input` helper (issue #1124);
-        // required (non-nullable), so the `required_datetime_input` sibling.
+        // Datetime fields map to a datetime-local control in the derived
+        // `FormModel` descriptors (issue #1135) — no per-field helper line
+        // and no `form_for` override needed in the routes file.
         assert!(
-            routes.contains(
-                "autumn_web::form::required_datetime_input(&changeset, \"published_at\", \"Published At\")"
-            ),
+            !routes.contains("autumn_web::form::required_datetime_input(&changeset"),
             "{routes}"
+        );
+        assert!(
+            !routes.contains(".override_field(\"published_at\""),
+            "datetime fields need no form_for override: {routes}"
         );
         assert!(
             !routes.contains("input type=\"text\" name=\"published_at\""),
@@ -4775,11 +5206,10 @@ async fn main() {
 
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
 
-        // Required (non-nullable), so the `required_datetime_input` sibling.
+        // The datetime-local control comes from the derived `FormModel`
+        // descriptors (issue #1135) — no per-field line or override needed.
         assert!(
-            routes.contains(
-                "autumn_web::form::required_datetime_input(&changeset, \"scheduled_at\", \"Scheduled At\")"
-            ),
+            !routes.contains(".override_field(\"scheduled_at\""),
             "{routes}"
         );
         assert!(routes.contains("pub scheduled_at: String,"), "{routes}");
@@ -4842,33 +5272,25 @@ async fn main() {
         plan.execute(Flags::default()).unwrap();
 
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
-        // Genuine string fields (String/Text) render via `text_input`; every
-        // other kind uses its own changeset-aware helper (issue #1124). Every
-        // field here is required, so each uses its `required_*` sibling.
-        assert!(
-            routes.contains(
-                "autumn_web::form::required_text_input(&changeset, \"title\", \"Title\")"
-            ),
-            "{routes}"
-        );
-        assert!(
-            routes
-                .contains("autumn_web::form::required_text_input(&changeset, \"body\", \"Body\")"),
-            "{routes}"
-        );
-        assert!(
-            routes.contains("autumn_web::form::checkbox_input(&changeset, \"active\""),
-            "{routes}"
-        );
-        assert!(
-            routes.contains("autumn_web::form::required_number_input(&changeset, \"views\""),
-            "{routes}"
-        );
-        assert!(
-            routes
-                .contains("autumn_web::form::required_datetime_input(&changeset, \"published_at\""),
-            "{routes}"
-        );
+        // Control selection per kind (text vs checkbox vs number vs
+        // datetime-local, required or not) lives in the derived `FormModel`
+        // descriptors (issue #1135): the routes file renders everything
+        // through the single shared `form_for` helper, with no per-field
+        // helper lines and no overrides for these plain kinds.
+        assert!(routes.contains("fn post_form_for("), "{routes}");
+        for helper in [
+            "text_input",
+            "required_text_input",
+            "checkbox_input",
+            "required_number_input",
+            "required_datetime_input",
+        ] {
+            assert!(
+                !routes.contains(&format!("autumn_web::form::{helper}(&changeset")),
+                "no per-field {helper} lines may remain: {routes}"
+            );
+        }
+        assert!(!routes.contains(".override_field("), "{routes}");
         // No hand-rolled bare text inputs remain for the non-string fields.
         assert!(
             !routes.contains("input type=\"text\" name=\"active\""),

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -946,11 +946,14 @@ fn generate_scaffold_accepts_metadata_flags() {
     assert!(repo.contains("fn find_by_alive(alive: bool) -> Vec<Bookmark>;"));
 
     let routes = fs::read_to_string(project.join("src/routes/bookmarks.rs")).unwrap();
-    // Fields render through the changeset-aware helpers (issue #1124); all
-    // three are required (non-nullable), so each uses `required_text_input`.
-    assert!(routes.contains("autumn_web::form::required_text_input(&changeset, \"url\""));
-    assert!(routes.contains("autumn_web::form::required_text_input(&changeset, \"title\""));
-    assert!(routes.contains("autumn_web::form::required_text_input(&changeset, \"tag\""));
+    // The views render through one `form_for` call (issue #1135): the
+    // per-field controls (including the required signal for the three
+    // non-nullable strings) come from the `#[model]`-derived `FormModel`
+    // descriptors, delegated to from the generated form struct.
+    assert!(routes.contains("impl autumn_web::form::FormModel for BookmarkForm"));
+    assert!(routes.contains("<Bookmark as autumn_web::form::FormModel>::form_fields()"));
+    assert!(routes.contains("autumn_web::form::form_for(changeset, action, \"post\")"));
+    assert!(!routes.contains("autumn_web::form::required_text_input(&changeset"));
     // `alive` is defaulted → excluded from the form entirely.
     assert!(!routes.contains("\"alive\""));
     assert!(routes.contains("bookmarks::tag.eq(new.tag.clone())"));
@@ -1730,17 +1733,16 @@ fn generate_scaffold_unique_field_create_violation_form_preserves_submitted_valu
         create_body.contains("Changeset::from_errors(changeset.into_inner(), errors)"),
         "got:\n{create_body}"
     );
+    // The re-render goes through the same shared `form_for` helper as the GET
+    // views (issue #1135) — every submitted value is preserved because the
+    // controls all read from the rebuilt changeset.
     assert!(
-        create_body.contains("autumn_web::form::required_number_input(&changeset, \"age\""),
+        create_body.contains("user_form_for(&changeset"),
         "got:\n{create_body}"
     );
     assert!(
-        create_body.contains("autumn_web::form::checkbox_input(&changeset, \"active\""),
-        "got:\n{create_body}"
-    );
-    assert!(
-        create_body.contains("autumn_web::form::required_select_input(&changeset, \"status\""),
-        "got:\n{create_body}"
+        routes.contains(".override_field(\"status\", autumn_web::form::FieldControl::Select"),
+        "got:\n{routes}"
     );
 }
 
@@ -1788,12 +1790,10 @@ fn generate_scaffold_unique_field_update_violation_form_preserves_submitted_valu
         update_body.contains("Changeset::from_errors(changeset.into_inner(), errors)"),
         "got:\n{update_body}"
     );
+    // Same shared `form_for` helper as the GET views (issue #1135): the
+    // rebuilt changeset carries the submitted values into every control.
     assert!(
-        update_body.contains("autumn_web::form::required_number_input(&changeset, \"age\""),
-        "got:\n{update_body}"
-    );
-    assert!(
-        update_body.contains("autumn_web::form::required_select_input(&changeset, \"status\""),
+        update_body.contains("user_form_for(&changeset"),
         "got:\n{update_body}"
     );
     assert!(

--- a/autumn-cli/tests/integration/mod.rs
+++ b/autumn-cli/tests/integration/mod.rs
@@ -4,6 +4,7 @@ mod db_pull;
 mod generate_references_postgres;
 mod migrate_down;
 mod repo_hygiene;
+mod scaffold_form_for;
 #[cfg(unix)]
 mod serve;
 mod webhook_sim;

--- a/autumn-cli/tests/integration/scaffold_form_for.rs
+++ b/autumn-cli/tests/integration/scaffold_form_for.rs
@@ -1,0 +1,288 @@
+//! Scaffold view emission via `form_for` (issue #1135, phase 3).
+//!
+//! The generated create/edit views must render their whole form through a
+//! single shared `form_for` call (one `<resource>_form_for` helper), with the
+//! per-field controls derived from the `#[model]`-derived `FormModel`
+//! descriptors — no hand-emitted per-field `*_input(...)` lines. Enum and
+//! decimal columns get `.override_field(...)` escape hatches (the derive
+//! can't know enum variants, and maps decimals to a free `step="any"` rather
+//! than the column's declared scale).
+
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Run the production `autumn` binary in `dir`, asserting success.
+fn run_autumn(dir: &Path, args: &[&str]) {
+    let autumn_bin = env!("CARGO_BIN_EXE_autumn");
+    let output = Command::new(autumn_bin)
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to run autumn");
+    assert!(
+        output.status.success(),
+        "autumn {args:?} failed (exit={:?})\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// `autumn new` + `autumn generate scaffold` in a fresh tempdir, returning
+/// the tempdir guard and the project root.
+fn scaffold_project(
+    project_name: &str,
+    resource: &str,
+    columns: &[&str],
+) -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn(tmp.path(), &["new", project_name]);
+    let project = tmp.path().join(project_name);
+    let mut args = vec!["generate", "scaffold", resource];
+    args.extend_from_slice(columns);
+    run_autumn(&project, &args);
+    (tmp, project)
+}
+
+/// A representative column mix: string, text, integer, decimal, boolean,
+/// date-valued (datetime — the field DSL has no bare-date kind), tz datetime,
+/// enum, a foreign-key reference, and an optional (nullable) column.
+const WIDGET_COLUMNS: &[&str] = &[
+    "name:String",
+    "description:Text",
+    "quantity:i32",
+    "price:decimal{10,2}",
+    "active:bool",
+    "published_on:NaiveDateTime",
+    "released_at:DateTime",
+    "status:enum{draft,live,retired}",
+    "post:references",
+    "notes:Option<String>",
+];
+
+fn scaffold_widget() -> (tempfile::TempDir, String) {
+    let (tmp, project) = scaffold_project("form-for-app", "Widget", WIDGET_COLUMNS);
+    let routes = fs::read_to_string(project.join("src/routes/widgets.rs")).unwrap();
+    (tmp, routes)
+}
+
+/// Slice `routes` from the start of one handler to the start of the next.
+fn handler_body<'a>(routes: &'a str, from: &str, to: &str) -> &'a str {
+    let start = routes
+        .find(from)
+        .unwrap_or_else(|| panic!("missing {from} in:\n{routes}"));
+    let end = routes[start..]
+        .find(to)
+        .unwrap_or_else(|| panic!("missing {to} after {from} in:\n{routes}"));
+    &routes[start..start + end]
+}
+
+/// The changeset-aware per-field helpers the pre-#1135 generator emitted one
+/// call per column of. None of them may appear in the generated views any
+/// more — `form_for` dispatches to them internally.
+const PER_FIELD_HELPERS: &[&str] = &[
+    "text_input",
+    "required_text_input",
+    "textarea_input",
+    "number_input",
+    "required_number_input",
+    "checkbox_input",
+    "date_input",
+    "required_date_input",
+    "datetime_input",
+    "required_datetime_input",
+    "select_input",
+    "required_select_input",
+];
+
+#[test]
+fn scaffold_create_and_edit_views_use_single_form_for_call() {
+    let (_tmp, routes) = scaffold_widget();
+
+    // Exactly one real `form_for` builder call in the whole file — inside the
+    // shared `widget_form_for` helper both views (and the 422 re-render
+    // branches) call.
+    assert_eq!(
+        routes.matches("autumn_web::form::form_for(").count(),
+        1,
+        "expected exactly one form_for builder call:\n{routes}"
+    );
+
+    // Each view body renders through exactly one call of the shared helper.
+    let new_form = handler_body(&routes, "pub async fn new_form", "pub async fn create");
+    assert_eq!(
+        new_form.matches("widget_form_for(&changeset").count(),
+        1,
+        "new view must contain exactly one form_for call:\n{new_form}"
+    );
+    let edit_form = handler_body(&routes, "pub async fn edit_form", "pub async fn update");
+    assert_eq!(
+        edit_form.matches("widget_form_for(&changeset").count(),
+        1,
+        "edit view must contain exactly one form_for call:\n{edit_form}"
+    );
+
+    // No per-field input helper lines remain anywhere in the generated file.
+    for helper in PER_FIELD_HELPERS {
+        let line = format!("autumn_web::form::{helper}(&changeset");
+        assert!(
+            !routes.contains(&line),
+            "generated views must not hand-emit {helper}:\n{routes}"
+        );
+    }
+
+    // The controls come from the `#[model]`-derived FormModel descriptors,
+    // delegated to from the scaffold's form struct.
+    assert!(
+        routes.contains("impl autumn_web::form::FormModel for WidgetForm"),
+        "WidgetForm must implement FormModel:\n{routes}"
+    );
+    assert!(
+        routes.contains("<Widget as autumn_web::form::FormModel>::form_fields()"),
+        "WidgetForm must delegate its form fields to the derived Widget impl:\n{routes}"
+    );
+}
+
+#[test]
+fn scaffold_enum_column_overrides_to_select() {
+    let (_tmp, routes) = scaffold_widget();
+
+    // The derive maps unknown types (the generated `Status` enum) to a text
+    // control; the scaffold knows the variants statically and must promote
+    // the field to a select with a placeholder plus one option per variant.
+    assert!(
+        routes.contains(
+            ".override_field(\"status\", autumn_web::form::FieldControl::Select { options: vec![(\"\".into(), \"— Select —\".into()), (\"draft\".into(), \"Draft\".into()), (\"live\".into(), \"Live\".into()), (\"retired\".into(), \"Retired\".into())] })"
+        ),
+        "enum column must get a Select override with its variants:\n{routes}"
+    );
+}
+
+#[test]
+fn scaffold_references_column_overrides_to_select_and_loads_options() {
+    let (_tmp, routes) = scaffold_widget();
+
+    // Issue #1135 AC 2: "references→select". The derive maps the `i64` FK
+    // column to a number input; the scaffold promotes it to a select whose
+    // options are the referenced table's ids, loaded at render time by the
+    // controller and threaded through the shared helper.
+    assert!(
+        routes.contains(
+            ".override_field(\"post_id\", autumn_web::form::FieldControl::Select { options: post_id_select })"
+        ),
+        "references column must be promoted to a Select: {routes}"
+    );
+    assert!(
+        routes.contains("post_id_options: &[(String, String)],"),
+        "the form helper must take the loaded options: {routes}"
+    );
+    assert!(
+        routes.contains(
+            "async fn post_id_select_options(db: &mut Db) -> AutumnResult<Vec<(String, String)>>"
+        ),
+        "the controller must have an options loader: {routes}"
+    );
+    assert!(
+        routes.contains(".select(posts::id)"),
+        "the loader must query the referenced table's ids: {routes}"
+    );
+    // Every form-rendering site loads the options: the new_form and edit_form
+    // GET handlers plus the create/update 422 re-render branches.
+    assert_eq!(
+        routes
+            .matches("let post_id_options = post_id_select_options(&mut db).await?;")
+            .count(),
+        4,
+        "all four form-rendering sites must load the reference options: {routes}"
+    );
+}
+
+#[test]
+fn scaffold_decimal_column_overrides_number_step() {
+    let (_tmp, routes) = scaffold_widget();
+
+    // The derive maps `rust_decimal::Decimal` to `Number {{ step: "any" }}`;
+    // the scaffold knows the declared scale and must pin the browser step to
+    // the column's smallest representable increment (`decimal{10,2}` → 0.01).
+    assert!(
+        routes.contains(
+            ".override_field(\"price\", autumn_web::form::FieldControl::Number { step: Some(\"0.01\".into()) })"
+        ),
+        "decimal column must get a scale-derived Number step override:\n{routes}"
+    );
+}
+
+/// Slow end-to-end check: the `form_for`-rendered scaffold (delegated
+/// `FormModel` impl, shared `widget_form_for` helper, enum select override,
+/// decimal step override, references select with loaded options) actually
+/// type-checks against the real framework.
+///
+/// Ignored by default; run with `cargo test -p autumn-cli -- --ignored`.
+#[test]
+#[ignore = "slow: cargo-checks a fresh project — run with `cargo test -p autumn-cli -- --ignored`"]
+fn generated_form_for_scaffold_cargo_checks() {
+    let (_tmp, project) = scaffold_project("form-for-check", "Widget", WIDGET_COLUMNS);
+
+    // The `post:references` column's select options are loaded from the
+    // referenced table, so its schema entry must exist — generate the `Post`
+    // model the reference points at (same ordering the FOREIGN KEY imposes at
+    // the database level).
+    run_autumn(&project, &["generate", "model", "Post", "title:String"]);
+
+    // Point the generated project at the local autumn-web crate so the check
+    // exercises this workspace's `form_for`, not a published version.
+    let cargo_toml_path = project.join("Cargo.toml");
+    let mut content = fs::read_to_string(&cargo_toml_path).unwrap();
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root");
+    let autumn_web = workspace_root.join("autumn");
+    let _ = write!(
+        content,
+        "\n[patch.crates-io]\nautumn-web = {{ path = \"{}\" }}\n",
+        autumn_web.display().to_string().replace('\\', "/")
+    );
+    fs::write(&cargo_toml_path, content).unwrap();
+
+    let check = Command::new("cargo")
+        .args(["check", "--tests"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    assert!(
+        check.status.success(),
+        "cargo check on generated form_for scaffold failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr),
+    );
+}
+
+#[test]
+fn rescaffold_with_added_column_leaves_view_form_call_unchanged() {
+    // Issue #1135 success metric: adding a column requires zero view edits.
+    // Scaffold the same resource twice — once with an extra column — and the
+    // view bodies plus the shared form helper must be byte-identical: every
+    // schema-derived difference lives in the form struct / conversions, not
+    // in the views.
+    let base = &["name:String", "quantity:i32"];
+    let extended = &["name:String", "quantity:i32", "notes:Option<String>"];
+    let (_tmp_a, project_a) = scaffold_project("regen-a", "Gadget", base);
+    let (_tmp_b, project_b) = scaffold_project("regen-b", "Gadget", extended);
+    let routes_a = fs::read_to_string(project_a.join("src/routes/gadgets.rs")).unwrap();
+    let routes_b = fs::read_to_string(project_b.join("src/routes/gadgets.rs")).unwrap();
+
+    for (from, to) in [
+        ("pub async fn new_form", "pub async fn create"),
+        ("pub async fn edit_form", "pub async fn update"),
+        ("fn gadget_form_for(", "form.render()"),
+    ] {
+        let body_a = handler_body(&routes_a, from, to);
+        let body_b = handler_body(&routes_b, from, to);
+        assert_eq!(
+            body_a, body_b,
+            "the {from} view section must not change when a plain column is added"
+        );
+    }
+}

--- a/autumn-cli/tests/integration/scaffold_form_for.rs
+++ b/autumn-cli/tests/integration/scaffold_form_for.rs
@@ -62,8 +62,24 @@ const WIDGET_COLUMNS: &[&str] = &[
     "notes:Option<String>",
 ];
 
+/// `autumn new` + `generate model Post` + `generate scaffold Widget`: the
+/// `post:references` column's select promotion requires the referenced
+/// model (and its `src/schema.rs` entry) to exist at scaffold time —
+/// otherwise the column falls back to a plain numeric id input (see
+/// `scaffold_references_column_with_missing_target_falls_back_to_number_input`).
+fn scaffold_widget_project(project_name: &str) -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn(tmp.path(), &["new", project_name]);
+    let project = tmp.path().join(project_name);
+    run_autumn(&project, &["generate", "model", "Post", "title:String"]);
+    let mut args = vec!["generate", "scaffold", "Widget"];
+    args.extend_from_slice(WIDGET_COLUMNS);
+    run_autumn(&project, &args);
+    (tmp, project)
+}
+
 fn scaffold_widget() -> (tempfile::TempDir, String) {
-    let (tmp, project) = scaffold_project("form-for-app", "Widget", WIDGET_COLUMNS);
+    let (tmp, project) = scaffold_widget_project("form-for-app");
     let routes = fs::read_to_string(project.join("src/routes/widgets.rs")).unwrap();
     (tmp, routes)
 }
@@ -223,14 +239,19 @@ fn scaffold_decimal_column_overrides_number_step() {
 #[test]
 #[ignore = "slow: cargo-checks a fresh project — run with `cargo test -p autumn-cli -- --ignored`"]
 fn generated_form_for_scaffold_cargo_checks() {
-    let (_tmp, project) = scaffold_project("form-for-check", "Widget", WIDGET_COLUMNS);
-
     // The `post:references` column's select options are loaded from the
-    // referenced table, so its schema entry must exist — generate the `Post`
-    // model the reference points at (same ordering the FOREIGN KEY imposes at
-    // the database level).
-    run_autumn(&project, &["generate", "model", "Post", "title:String"]);
+    // referenced table, so its schema entry must exist at scaffold time —
+    // `scaffold_widget_project` generates the `Post` model the reference
+    // points at before scaffolding (same ordering the FOREIGN KEY imposes at
+    // the database level). A missing target downgrades the column to a
+    // numeric id input instead (covered by the sibling ignored test below).
+    let (_tmp, project) = scaffold_widget_project("form-for-check");
+    assert_project_cargo_checks(&project);
+}
 
+/// Patch the generated project to use this workspace's `autumn-web`, then
+/// `cargo check --tests` it, asserting success.
+fn assert_project_cargo_checks(project: &Path) {
     // Point the generated project at the local autumn-web crate so the check
     // exercises this workspace's `form_for`, not a published version.
     let cargo_toml_path = project.join("Cargo.toml");
@@ -248,15 +269,61 @@ fn generated_form_for_scaffold_cargo_checks() {
 
     let check = Command::new("cargo")
         .args(["check", "--tests"])
-        .current_dir(&project)
+        .current_dir(project)
         .output()
         .unwrap();
     assert!(
         check.status.success(),
-        "cargo check on generated form_for scaffold failed:\nstdout:\n{}\nstderr:\n{}",
+        "cargo check on generated scaffold failed:\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&check.stdout),
         String::from_utf8_lossy(&check.stderr),
     );
+}
+
+#[test]
+fn scaffold_references_column_with_missing_target_falls_back_to_number_input() {
+    // Regression test (issue #1135 review): a `references` column whose
+    // target model hasn't been generated has always been a warning, not an
+    // error — the scaffold assumes the table exists out-of-band and its
+    // output must still compile. Without the `Post` model there is no
+    // `posts` entry in `src/schema.rs`, so the scaffold must skip the whole
+    // select pipeline for `post_id` (schema import, options loader, Select
+    // override) and keep the derived numeric id input.
+    let (_tmp, project) = scaffold_project("missing-target-app", "Widget", WIDGET_COLUMNS);
+    let routes = fs::read_to_string(project.join("src/routes/widgets.rs")).unwrap();
+
+    assert!(
+        routes.contains("use crate::schema::widgets;"),
+        "only the resource's own schema module may be imported: {routes}"
+    );
+    assert!(
+        !routes.contains("posts::") && !routes.contains("post_id_select_options"),
+        "the missing target must not produce select machinery: {routes}"
+    );
+    assert!(
+        !routes.contains(".override_field(\"post_id\""),
+        "the column must keep the derived number input, not a Select: {routes}"
+    );
+    // The other schema-specific overrides are unaffected by the fallback.
+    assert!(
+        routes.contains(".override_field(\"status\""),
+        "the enum Select override must survive the reference fallback: {routes}"
+    );
+}
+
+/// Slow end-to-end sibling of `generated_form_for_scaffold_cargo_checks`:
+/// the warning-only missing-reference-target path must still produce a
+/// project that type-checks (the review regression this guards against was
+/// an unconditional `use crate::schema::{widgets, posts};` import plus a
+/// `posts::table` option loader with no `posts` schema entry to satisfy
+/// them).
+///
+/// Ignored by default; run with `cargo test -p autumn-cli -- --ignored`.
+#[test]
+#[ignore = "slow: cargo-checks a fresh project — run with `cargo test -p autumn-cli -- --ignored`"]
+fn generated_scaffold_with_missing_reference_target_cargo_checks() {
+    let (_tmp, project) = scaffold_project("missing-target-check", "Widget", WIDGET_COLUMNS);
+    assert_project_cargo_checks(&project);
 }
 
 #[test]

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -2214,7 +2214,17 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 parse_field_encrypted_mode(f).unwrap_or(EncryptedMode::None),
             )
             .map(|w| quote! { #[diesel(serialize_as = #w)] });
-            quote! { #(#val_attrs)* #enc pub #ident: #ty }
+            // Non-nullable `bool` columns render as a checkbox in `form_for`
+            // (see `emit_form_model_impl`), and an unchecked HTML checkbox
+            // submits *no* key at all — a hidden `false` sibling is not an
+            // option because serde_urlencoded rejects duplicate keys (see
+            // `checkbox_input`'s doc in autumn/src/form.rs). Mark the field
+            // `#[serde(default)]` so a missing key decodes as `false` instead
+            // of failing with "missing field", mirroring the scaffold's
+            // `{Model}Form` convention.
+            let bool_default = (!is_option_type(ty) && type_name_str(ty) == "bool")
+                .then(|| quote! { #[serde(default)] });
+            quote! { #(#val_attrs)* #enc #bool_default pub #ident: #ty }
         })
         .collect();
 

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -1616,7 +1616,25 @@ fn form_control_tokens(inner_ty: &syn::Type, nullable: bool) -> TokenStream {
             }
         },
         "NaiveDate" => quote! { ::autumn_web::form::FieldControl::Date },
-        "NaiveDateTime" | "DateTime" => quote! { ::autumn_web::form::FieldControl::DateTime },
+        "NaiveDateTime" => quote! { ::autumn_web::form::FieldControl::DateTime },
+        // `<input type="datetime-local">` posts an *offsetless* wall-clock
+        // value, so only zone parameters with a sound interpretation of that
+        // shape get the picker: `Utc` and the server's `Local` (each wired to
+        // a matching tolerant deserializer — see `datetime_local_serde_attr`).
+        // Any other zone (`FixedOffset`, chrono-tz zones, or a bare
+        // `DateTime` alias whose zone the derive can't see) falls back to a
+        // text input: the pre-filled value is the field's serialized RFC 3339
+        // string, which chrono's default `Deserialize` round-trips as-is —
+        // honest, if plainer, instead of a picker whose submission 400s.
+        "DateTime" => {
+            let picker_zone = crate::api_doc::unwrap_single_generic(inner_ty, "DateTime")
+                .is_some_and(|tz| matches!(type_name_str(&tz).as_str(), "Utc" | "Local"));
+            if picker_zone {
+                quote! { ::autumn_web::form::FieldControl::DateTime }
+            } else {
+                quote! { ::autumn_web::form::FieldControl::Text }
+            }
+        }
         // `String`/`str`/`Uuid` render as text, and so do unknown types
         // (user enums, JSON, custom newtypes) as a safe fallback; promote
         // via `.override_field(...)` where a richer control is known.
@@ -1633,13 +1651,16 @@ fn form_control_tokens(inner_ty: &syn::Type, nullable: bool) -> TokenStream {
 /// with seconds), which chrono's default `Deserialize` for `DateTime<Utc>`
 /// rejects — so a `form_for` submission would 400 before validation even when
 /// the pre-filled value is untouched. The referenced helpers accept both the
-/// browser shape (`YYYY-MM-DDTHH:MM[:SS[.f]]`, interpreted as UTC) *and*
-/// RFC 3339 (offset converted to UTC), so JSON API create bodies posted to
-/// the same `NewX` keep decoding.
+/// browser shape (`YYYY-MM-DDTHH:MM[:SS[.f]]`, interpreted as UTC for
+/// `DateTime<Utc>` columns and as the server's local wall clock for
+/// `DateTime<Local>` ones) *and* RFC 3339 (offset converted to the field's
+/// zone), so JSON API create bodies posted to the same `NewX` keep decoding.
 ///
 /// Returns `None` for non-datetime fields, and for `DateTime<Tz>` with a
-/// non-`Utc` zone parameter (the helper produces a `DateTime<Utc>`; other
-/// zone parameters keep chrono's default `Deserialize`).
+/// zone parameter other than `Utc`/`Local` — those columns don't render a
+/// `datetime-local` control in the first place (`form_control_tokens` falls
+/// back to a text input whose RFC 3339 value chrono's default `Deserialize`
+/// round-trips), so they keep that default.
 fn datetime_local_serde_attr(ty: &syn::Type) -> Option<TokenStream> {
     let nullable = is_option_type(ty);
     let inner = if nullable {
@@ -1651,10 +1672,11 @@ fn datetime_local_serde_attr(ty: &syn::Type) -> Option<TokenStream> {
         "NaiveDateTime" => "deserialize_naive_datetime_local",
         "DateTime" => {
             let tz = crate::api_doc::unwrap_single_generic(&inner, "DateTime")?;
-            if type_name_str(&tz) != "Utc" {
-                return None;
+            match type_name_str(&tz).as_str() {
+                "Utc" => "deserialize_datetime_local_utc",
+                "Local" => "deserialize_datetime_local_local",
+                _ => return None,
             }
-            "deserialize_datetime_local_utc"
         }
         _ => return None,
     };
@@ -4813,5 +4835,66 @@ mod tests {
             generated.contains("transition_priority_to"),
             "multi-sm model must emit `transition_priority_to`: {generated}"
         );
+    }
+
+    // ── Datetime control/deserializer selection per zone parameter (#1135) ─
+
+    /// Regression test (Codex P2 on #1587): only `DateTime<Utc>` and
+    /// `DateTime<Local>` — the zones whose offsetless `datetime-local`
+    /// submission has a matching tolerant deserializer — may render the
+    /// datetime picker. Any other zone parameter (`FixedOffset`, chrono-tz
+    /// zones, a bare un-parameterized `DateTime` alias) must fall back to a
+    /// text control whose RFC 3339 value round-trips through chrono's
+    /// default `Deserialize`; giving them the picker would 400 every
+    /// submission.
+    #[test]
+    fn form_control_tokens_gates_datetime_picker_on_zone_param() {
+        let control = |ty: syn::Type| form_control_tokens(&ty, false).to_string();
+
+        let utc = control(syn::parse_quote!(chrono::DateTime<chrono::Utc>));
+        assert!(utc.contains("FieldControl :: DateTime"), "{utc}");
+        let local = control(syn::parse_quote!(chrono::DateTime<chrono::Local>));
+        assert!(local.contains("FieldControl :: DateTime"), "{local}");
+
+        let fixed = control(syn::parse_quote!(chrono::DateTime<chrono::FixedOffset>));
+        assert!(fixed.contains("FieldControl :: Text"), "{fixed}");
+        let tz = control(syn::parse_quote!(chrono::DateTime<chrono_tz::Tz>));
+        assert!(tz.contains("FieldControl :: Text"), "{tz}");
+        // A bare alias hides the zone from the derive — no picker either.
+        let bare = control(syn::parse_quote!(DateTime));
+        assert!(bare.contains("FieldControl :: Text"), "{bare}");
+    }
+
+    /// The deserializer wiring must stay in lockstep with the control choice
+    /// above: `Utc`/`Local` get their zone-matching tolerant deserializer
+    /// (`_option` for nullable), everything else keeps chrono's default
+    /// `Deserialize` (fine — those columns render as text, whose RFC 3339
+    /// value the default parses).
+    #[test]
+    fn datetime_local_serde_attr_matches_zone_param() {
+        let attr = |ty: syn::Type| datetime_local_serde_attr(&ty).map(|t| t.to_string());
+
+        let utc = attr(syn::parse_quote!(chrono::DateTime<chrono::Utc>)).unwrap();
+        assert!(utc.contains("deserialize_datetime_local_utc"), "{utc}");
+
+        let local = attr(syn::parse_quote!(chrono::DateTime<chrono::Local>)).unwrap();
+        assert!(
+            local.contains("deserialize_datetime_local_local"),
+            "{local}"
+        );
+        assert!(!local.contains("_option"), "{local}");
+
+        let nullable = attr(syn::parse_quote!(Option<chrono::DateTime<chrono::Local>>)).unwrap();
+        assert!(
+            nullable.contains("deserialize_datetime_local_local_option"),
+            "{nullable}"
+        );
+        assert!(nullable.contains("default"), "{nullable}");
+
+        assert_eq!(
+            attr(syn::parse_quote!(chrono::DateTime<chrono::FixedOffset>)),
+            None
+        );
+        assert_eq!(attr(syn::parse_quote!(DateTime)), None);
     }
 }

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -1445,7 +1445,7 @@ fn type_name_str(ty: &syn::Type) -> String {
     crate::api_doc::last_segment_name(ty).unwrap_or_else(|| "unknown".to_owned())
 }
 
-/// Humanize a snake_case field name into a `<label>`-friendly title
+/// Humanize a `snake_case` field name into a `<label>`-friendly title
 /// (e.g. `published_at` -> `"Published At"`). Mirrors the scaffold's
 /// `humanize_label` so a derived form and a hand-written one read alike.
 fn humanize_field_label(name: &str) -> String {
@@ -1477,7 +1477,6 @@ fn humanize_field_label(name: &str) -> String {
 fn form_control_tokens(inner_ty: &syn::Type, nullable: bool) -> TokenStream {
     let name = type_name_str(inner_ty);
     match name.as_str() {
-        "String" | "str" | "Uuid" => quote! { ::autumn_web::form::FieldControl::Text },
         "bool" => {
             if nullable {
                 quote! {
@@ -1506,8 +1505,9 @@ fn form_control_tokens(inner_ty: &syn::Type, nullable: bool) -> TokenStream {
         },
         "NaiveDate" => quote! { ::autumn_web::form::FieldControl::Date },
         "NaiveDateTime" | "DateTime" => quote! { ::autumn_web::form::FieldControl::DateTime },
-        // Unknown types (user enums, JSON, custom newtypes) -> text by default;
-        // promote via `.override_field(...)` where a richer control is known.
+        // `String`/`str`/`Uuid` render as text, and so do unknown types
+        // (user enums, JSON, custom newtypes) as a safe fallback; promote
+        // via `.override_field(...)` where a richer control is known.
         _ => quote! { ::autumn_web::form::FieldControl::Text },
     }
 }

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -1512,6 +1512,53 @@ fn form_control_tokens(inner_ty: &syn::Type, nullable: bool) -> TokenStream {
     }
 }
 
+/// For a `NewX` field whose column `form_for` renders as an HTML
+/// `datetime-local` control (see `form_control_tokens`), emit the serde
+/// attribute wiring the matching datetime-local-tolerant deserializer from
+/// `autumn_web::form`.
+///
+/// `<input type="datetime-local">` posts an offsetless value (and not always
+/// with seconds), which chrono's default `Deserialize` for `DateTime<Utc>`
+/// rejects — so a `form_for` submission would 400 before validation even when
+/// the pre-filled value is untouched. The referenced helpers accept both the
+/// browser shape (`YYYY-MM-DDTHH:MM[:SS[.f]]`, interpreted as UTC) *and*
+/// RFC 3339 (offset converted to UTC), so JSON API create bodies posted to
+/// the same `NewX` keep decoding.
+///
+/// Returns `None` for non-datetime fields, and for `DateTime<Tz>` with a
+/// non-`Utc` zone parameter (the helper produces a `DateTime<Utc>`; other
+/// zone parameters keep chrono's default `Deserialize`).
+fn datetime_local_serde_attr(ty: &syn::Type) -> Option<TokenStream> {
+    let nullable = is_option_type(ty);
+    let inner = if nullable {
+        crate::api_doc::unwrap_single_generic(ty, "Option")?
+    } else {
+        ty.clone()
+    };
+    let base = match type_name_str(&inner).as_str() {
+        "NaiveDateTime" => "deserialize_naive_datetime_local",
+        "DateTime" => {
+            let tz = crate::api_doc::unwrap_single_generic(&inner, "DateTime")?;
+            if type_name_str(&tz) != "Utc" {
+                return None;
+            }
+            "deserialize_datetime_local_utc"
+        }
+        _ => return None,
+    };
+    if nullable {
+        // `deserialize_with` disables serde's implicit missing-`Option`-field
+        // -is-`None` handling; `default` restores it so a JSON body may still
+        // omit the nullable column. (The `_option` helper itself maps a
+        // present-but-empty form value to `None`.)
+        let path = format!("::autumn_web::form::{base}_option");
+        Some(quote! { #[serde(default, deserialize_with = #path)] })
+    } else {
+        let path = format!("::autumn_web::form::{base}");
+        Some(quote! { #[serde(deserialize_with = #path)] })
+    }
+}
+
 /// Emit `impl ::autumn_web::form::FormModel for #name` (issue #1135), listing
 /// one `FormField` descriptor per user-editable column (the same
 /// `fields_for_new` set the insertable `NewX` struct uses -- i.e. excluding the
@@ -2224,7 +2271,14 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             // `{Model}Form` convention.
             let bool_default = (!is_option_type(ty) && type_name_str(ty) == "bool")
                 .then(|| quote! { #[serde(default)] });
-            quote! { #(#val_attrs)* #enc #bool_default pub #ident: #ty }
+            // Datetime columns render as `<input type="datetime-local">` in
+            // `form_for`, whose submitted value carries no timezone offset —
+            // chrono's default `Deserialize` for `DateTime<Utc>` would reject
+            // even an unchanged pre-filled value as a 400. Wire the tolerant
+            // deserializer (which also still accepts RFC 3339 JSON bodies);
+            // see `datetime_local_serde_attr`.
+            let datetime_local = datetime_local_serde_attr(ty);
+            quote! { #(#val_attrs)* #enc #bool_default #datetime_local pub #ident: #ty }
         })
         .collect();
 

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -1445,6 +1445,116 @@ fn type_name_str(ty: &syn::Type) -> String {
     crate::api_doc::last_segment_name(ty).unwrap_or_else(|| "unknown".to_owned())
 }
 
+/// Humanize a snake_case field name into a `<label>`-friendly title
+/// (e.g. `published_at` -> `"Published At"`). Mirrors the scaffold's
+/// `humanize_label` so a derived form and a hand-written one read alike.
+fn humanize_field_label(name: &str) -> String {
+    let name = name.strip_prefix("r#").unwrap_or(name);
+    name.split('_')
+        .filter(|word| !word.is_empty())
+        .map(|word| {
+            let mut chars = word.chars();
+            chars.next().map_or_else(String::new, |c| {
+                c.to_uppercase().to_string() + &chars.collect::<String>()
+            })
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Emit the `::autumn_web::form::FieldControl` expression for a model field,
+/// derived from its (Option-unwrapped) Rust type. `nullable` is `true` for
+/// `Option<...>` fields.
+///
+/// The mapping mirrors the scaffold's `render_changeset_form_inputs` control
+/// selection (#1131): strings/UUID -> text, integers -> stepped number,
+/// floats/decimals -> free-step number, `bool` -> checkbox (nullable `bool` ->
+/// a tri-state select so `NULL` stays reachable), dates/datetimes -> the
+/// corresponding pickers. Unrecognized types (e.g. user enums) fall back to a
+/// plain text control; callers can promote them to a `Select` via
+/// `FormFor::override_field` (which is exactly what the scaffold does for enum
+/// columns, whose variants it knows statically).
+fn form_control_tokens(inner_ty: &syn::Type, nullable: bool) -> TokenStream {
+    let name = type_name_str(inner_ty);
+    match name.as_str() {
+        "String" | "str" | "Uuid" => quote! { ::autumn_web::form::FieldControl::Text },
+        "bool" => {
+            if nullable {
+                quote! {
+                    ::autumn_web::form::FieldControl::Select {
+                        options: ::std::vec![
+                            (::std::string::String::from(""), ::std::string::String::from("— Unset —")),
+                            (::std::string::String::from("true"), ::std::string::String::from("Yes")),
+                            (::std::string::String::from("false"), ::std::string::String::from("No")),
+                        ],
+                    }
+                }
+            } else {
+                quote! { ::autumn_web::form::FieldControl::Checkbox }
+            }
+        }
+        "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64" | "u128"
+        | "usize" => quote! {
+            ::autumn_web::form::FieldControl::Number {
+                step: ::core::option::Option::Some(::std::string::String::from("1")),
+            }
+        },
+        "f32" | "f64" | "Decimal" | "BigDecimal" => quote! {
+            ::autumn_web::form::FieldControl::Number {
+                step: ::core::option::Option::Some(::std::string::String::from("any")),
+            }
+        },
+        "NaiveDate" => quote! { ::autumn_web::form::FieldControl::Date },
+        "NaiveDateTime" | "DateTime" => quote! { ::autumn_web::form::FieldControl::DateTime },
+        // Unknown types (user enums, JSON, custom newtypes) -> text by default;
+        // promote via `.override_field(...)` where a richer control is known.
+        _ => quote! { ::autumn_web::form::FieldControl::Text },
+    }
+}
+
+/// Emit `impl ::autumn_web::form::FormModel for #name` (issue #1135), listing
+/// one `FormField` descriptor per user-editable column (the same
+/// `fields_for_new` set the insertable `NewX` struct uses -- i.e. excluding the
+/// primary key, `#[default]`, and `#[lock_version]` columns).
+///
+/// This is what lets `form_for::<T>(...)` render a whole form in one call: the
+/// descriptor carries each field's serialized name, humanized label,
+/// type-appropriate control, and `required` flag (derived from non-`Option`).
+fn emit_form_model_impl(name: &syn::Ident, fields_for_new: &[&&Field]) -> TokenStream {
+    let field_exprs: Vec<TokenStream> = fields_for_new
+        .iter()
+        .filter_map(|f| {
+            let ident = f.ident.as_ref()?;
+            let field_name = ident.to_string();
+            let field_name = field_name.strip_prefix("r#").unwrap_or(&field_name);
+            let label = humanize_field_label(field_name);
+            let nullable = is_option_type(&f.ty);
+            let inner = crate::api_doc::unwrap_single_generic(&f.ty, "Option")
+                .unwrap_or_else(|| f.ty.clone());
+            let control = form_control_tokens(&inner, nullable);
+            let required = !nullable;
+            Some(quote! {
+                ::autumn_web::form::FormField::new(
+                    #field_name,
+                    #label,
+                    #control,
+                    #required,
+                )
+            })
+        })
+        .collect();
+
+    quote! {
+        impl ::autumn_web::form::FormModel for #name {
+            fn form_fields() -> ::std::vec::Vec<::autumn_web::form::FormField> {
+                ::std::vec![
+                    #(#field_exprs),*
+                ]
+            }
+        }
+    }
+}
+
 /// Emit a `TokenStream` that evaluates (at runtime) to a `serde_json::Value`
 /// representing the JSON Schema for the given Rust type.
 ///
@@ -3109,6 +3219,10 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         quote! { where #(#commit_hook_deserialize_bounds,)* }
     };
 
+    // `impl FormModel for #name` (issue #1135) -- one descriptor per editable
+    // column, driving the single-call `form_for::<#name>(...)` builder.
+    let form_model_impl = emit_form_model_impl(name, &fields_for_new);
+
     quote! {
         #encrypted_use
 
@@ -3120,6 +3234,8 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             #(#query_fields,)*
         }
         #name_debug_impl
+
+        #form_model_impl
 
         #[derive(#new_debug_derive Clone, ::diesel::Insertable)]
         #[derive(::serde::Serialize, ::serde::Deserialize)]

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -1164,6 +1164,118 @@ fn field_has_serde_rename(field: &syn::Field) -> bool {
     renamed
 }
 
+/// The struct-level `#[serde(rename_all = "...")]` casing rule that applies
+/// to *serialization*, if any. Handles both the plain form and the split
+/// `rename_all(serialize = "...", deserialize = "...")` form (taking the
+/// `serialize` side — that is what `Changeset::field_value` indexes by).
+///
+/// Same parsing convention as `field_has_serde_rename`: a `#[serde(...)]`
+/// list this parser can't fully walk simply yields no rule (the real serde
+/// derive still validates the attribute itself).
+fn serde_rename_all_serialize_rule(attrs: &[syn::Attribute]) -> Option<String> {
+    let mut rule = None;
+    for attr in attrs.iter().filter(|a| a.path().is_ident("serde")) {
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("rename_all") {
+                if let Ok(value) = meta.value() {
+                    // rename_all = "camelCase"
+                    if let Ok(syn::Lit::Str(s)) = value.parse::<syn::Lit>() {
+                        rule = Some(s.value());
+                    }
+                } else {
+                    // rename_all(serialize = "...", deserialize = "...")
+                    let _ = meta.parse_nested_meta(|inner| {
+                        if let Ok(value) = inner.value()
+                            && let Ok(syn::Lit::Str(s)) = value.parse::<syn::Lit>()
+                            && inner.path.is_ident("serialize")
+                        {
+                            rule = Some(s.value());
+                        }
+                        Ok(())
+                    });
+                }
+            } else if let Ok(value) = meta.value() {
+                // Consume any `= value` so sibling metas keep parsing.
+                let _: syn::Result<syn::Lit> = value.parse();
+            }
+            Ok(())
+        });
+    }
+    rule
+}
+
+/// The field-level `#[serde(rename = "...")]` name that applies to
+/// *serialization*, if any. Handles both the plain form and the split
+/// `rename(serialize = "...", deserialize = "...")` form (taking the
+/// `serialize` side). Field-level `rename` overrides a struct-level
+/// `rename_all`, mirroring serde's own precedence.
+fn field_serde_serialize_rename(field: &syn::Field) -> Option<String> {
+    let mut renamed = None;
+    for attr in field.attrs.iter().filter(|a| a.path().is_ident("serde")) {
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("rename") {
+                if let Ok(value) = meta.value() {
+                    // rename = "headline"
+                    if let Ok(syn::Lit::Str(s)) = value.parse::<syn::Lit>() {
+                        renamed = Some(s.value());
+                    }
+                } else {
+                    // rename(serialize = "...", deserialize = "...")
+                    let _ = meta.parse_nested_meta(|inner| {
+                        if let Ok(value) = inner.value()
+                            && let Ok(syn::Lit::Str(s)) = value.parse::<syn::Lit>()
+                            && inner.path.is_ident("serialize")
+                        {
+                            renamed = Some(s.value());
+                        }
+                        Ok(())
+                    });
+                }
+            } else if let Ok(value) = meta.value() {
+                // Consume any `= value` so sibling metas keep parsing.
+                let _: syn::Result<syn::Lit> = value.parse();
+            }
+            Ok(())
+        });
+    }
+    renamed
+}
+
+/// Apply a struct-level `#[serde(rename_all = "...")]` casing rule to a
+/// (`snake_case`) field identifier, mirroring `serde_derive`'s
+/// `RenameRule::apply_to_field`. Returns `None` for a rule string serde
+/// itself would reject (the `Serialize` derive on the emitted struct then
+/// reports the error — no point duplicating it here).
+fn apply_serde_rename_all_rule(rule: &str, field: &str) -> Option<String> {
+    fn pascal(field: &str) -> String {
+        field
+            .split('_')
+            .map(|word| {
+                let mut chars = word.chars();
+                chars.next().map_or_else(String::new, |first| {
+                    first.to_uppercase().collect::<String>() + chars.as_str()
+                })
+            })
+            .collect()
+    }
+    match rule {
+        // serde treats fields as already snake_case/lowercase.
+        "lowercase" | "snake_case" => Some(field.to_owned()),
+        "UPPERCASE" | "SCREAMING_SNAKE_CASE" => Some(field.to_ascii_uppercase()),
+        "PascalCase" => Some(pascal(field)),
+        "camelCase" => {
+            let pascal = pascal(field);
+            let mut chars = pascal.chars();
+            chars
+                .next()
+                .map(|first| first.to_lowercase().collect::<String>() + chars.as_str())
+        }
+        "kebab-case" => Some(field.replace('_', "-")),
+        "SCREAMING-KEBAB-CASE" => Some(field.to_ascii_uppercase().replace('_', "-")),
+        _ => None,
+    }
+}
+
 /// Parse the struct-level language dictionary configuration from `#[searchable(language = "...")]`
 fn parse_model_searchable_lang(attrs: &[syn::Attribute]) -> syn::Result<Option<String>> {
     for attr in attrs {
@@ -1565,9 +1677,23 @@ fn datetime_local_serde_attr(ty: &syn::Type) -> Option<TokenStream> {
 /// primary key, `#[default]`, and `#[lock_version]` columns).
 ///
 /// This is what lets `form_for::<T>(...)` render a whole form in one call: the
-/// descriptor carries each field's serialized name, humanized label,
+/// descriptor carries each field's name (the Rust identifier — the POST key
+/// the generated `NewX`/`UpdateX` decode by), humanized label,
 /// type-appropriate control, and `required` flag (derived from non-`Option`).
-fn emit_form_model_impl(name: &syn::Ident, fields_for_new: &[&&Field]) -> TokenStream {
+///
+/// `rename_all_rule` is the struct-level `#[serde(rename_all = "...")]`
+/// serialization rule, if any. When a column's serde-effective *serialized*
+/// key differs from its identifier (field-level `#[serde(rename)]` wins over
+/// `rename_all`, mirroring serde), the descriptor records that key as
+/// `FormField::value_name` so `form_for`'s pre-fill lookup
+/// (`Changeset::field_value`, which indexes the changeset's serialized data)
+/// still finds the value — while the rendered input `name` stays the
+/// identifier the insert struct expects.
+fn emit_form_model_impl(
+    name: &syn::Ident,
+    fields_for_new: &[&&Field],
+    rename_all_rule: Option<&str>,
+) -> TokenStream {
     let field_exprs: Vec<TokenStream> = fields_for_new
         .iter()
         .filter_map(|f| {
@@ -1580,6 +1706,12 @@ fn emit_form_model_impl(name: &syn::Ident, fields_for_new: &[&&Field]) -> TokenS
                 .unwrap_or_else(|| f.ty.clone());
             let control = form_control_tokens(&inner, nullable);
             let required = !nullable;
+            let serialized_name = field_serde_serialize_rename(f).or_else(|| {
+                rename_all_rule.and_then(|rule| apply_serde_rename_all_rule(rule, field_name))
+            });
+            let value_name = serialized_name
+                .filter(|serialized| serialized != field_name)
+                .map(|serialized| quote! { .with_value_name(#serialized) });
             Some(quote! {
                 ::autumn_web::form::FormField::new(
                     #field_name,
@@ -1587,6 +1719,7 @@ fn emit_form_model_impl(name: &syn::Ident, fields_for_new: &[&&Field]) -> TokenS
                     #control,
                     #required,
                 )
+                #value_name
             })
         })
         .collect();
@@ -3284,8 +3417,15 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     // `impl FormModel for #name` (issue #1135) -- one descriptor per editable
-    // column, driving the single-call `form_for::<#name>(...)` builder.
-    let form_model_impl = emit_form_model_impl(name, &fields_for_new);
+    // column, driving the single-call `form_for::<#name>(...)` builder. The
+    // struct-level `rename_all` serialization rule (attrs pass through to the
+    // emitted query struct's `Serialize` derive) feeds the descriptors'
+    // pre-fill lookup keys for serde-renamed columns.
+    let form_model_impl = emit_form_model_impl(
+        name,
+        &fields_for_new,
+        serde_rename_all_serialize_rule(outer_attrs).as_deref(),
+    );
 
     quote! {
         #encrypted_use
@@ -3708,6 +3848,83 @@ pub fn pascal_to_snake(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Serde-rename resolution for FormField::value_name (#1135) ─────────
+
+    #[test]
+    fn field_serde_serialize_rename_parses_plain_and_split_forms() {
+        let field: syn::Field = syn::Field::parse_named
+            .parse2(quote! { #[serde(rename = "headline")] pub title: String })
+            .unwrap();
+        assert_eq!(
+            field_serde_serialize_rename(&field).as_deref(),
+            Some("headline")
+        );
+
+        let field: syn::Field = syn::Field::parse_named
+            .parse2(quote! {
+                #[serde(rename(serialize = "out", deserialize = "in"))]
+                pub title: String
+            })
+            .unwrap();
+        assert_eq!(field_serde_serialize_rename(&field).as_deref(), Some("out"));
+
+        // Deserialize-only rename leaves the serialized key alone.
+        let field: syn::Field = syn::Field::parse_named
+            .parse2(quote! { #[serde(rename(deserialize = "in"))] pub title: String })
+            .unwrap();
+        assert_eq!(field_serde_serialize_rename(&field), None);
+
+        let field: syn::Field = syn::Field::parse_named
+            .parse2(quote! { #[serde(default)] pub title: String })
+            .unwrap();
+        assert_eq!(field_serde_serialize_rename(&field), None);
+    }
+
+    #[test]
+    fn serde_rename_all_serialize_rule_parses_plain_and_split_forms() {
+        let attrs: Vec<syn::Attribute> =
+            vec![syn::parse_quote!(#[serde(rename_all = "camelCase")])];
+        assert_eq!(
+            serde_rename_all_serialize_rule(&attrs).as_deref(),
+            Some("camelCase")
+        );
+
+        let attrs: Vec<syn::Attribute> = vec![syn::parse_quote!(
+            #[serde(rename_all(serialize = "kebab-case", deserialize = "camelCase"))]
+        )];
+        assert_eq!(
+            serde_rename_all_serialize_rule(&attrs).as_deref(),
+            Some("kebab-case")
+        );
+
+        let attrs: Vec<syn::Attribute> = vec![syn::parse_quote!(#[serde(deny_unknown_fields)])];
+        assert_eq!(serde_rename_all_serialize_rule(&attrs), None);
+    }
+
+    #[test]
+    fn apply_serde_rename_all_rule_mirrors_serde_field_casings() {
+        let cases = [
+            ("lowercase", "word_count", "word_count"),
+            ("snake_case", "word_count", "word_count"),
+            ("UPPERCASE", "word_count", "WORD_COUNT"),
+            ("SCREAMING_SNAKE_CASE", "word_count", "WORD_COUNT"),
+            ("PascalCase", "word_count", "WordCount"),
+            ("camelCase", "word_count", "wordCount"),
+            ("camelCase", "title", "title"),
+            ("kebab-case", "word_count", "word-count"),
+            ("SCREAMING-KEBAB-CASE", "word_count", "WORD-COUNT"),
+        ];
+        for (rule, field, expected) in cases {
+            assert_eq!(
+                apply_serde_rename_all_rule(rule, field).as_deref(),
+                Some(expected),
+                "rule {rule} on {field}"
+            );
+        }
+        // A rule serde itself rejects resolves to no rename here.
+        assert_eq!(apply_serde_rename_all_rule("bogusCase", "word_count"), None);
+    }
 
     // ── RED: #[lock_version] detection ────────────────────────────────────
     // These tests cover the new `excluded_from_new` behaviour (must also

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -1761,6 +1761,379 @@ pub fn skip_link(target: &str, label: &str) -> maud::Markup {
     }
 }
 
+// ── form_for (issue #1135 phase 2) ──────────────────────────────────
+
+/// The HTML control a model field renders as inside [`form_for`].
+///
+/// This is plain data (no `maud` dependency) so the `#[model]`-derived
+/// [`FormModel`] implementation is always available; only the rendering side
+/// ([`form_for`]) is gated behind the `maud` feature.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FieldControl {
+    /// `<input type="text">`.
+    Text,
+    /// `<textarea>`.
+    Textarea,
+    /// `<input type="password">`.
+    Password,
+    /// `<input type="number">`, with an optional HTML `step` attribute.
+    Number {
+        /// The HTML `step` attribute, e.g. `Some("0.01")`, or `None` to use
+        /// the browser default.
+        step: Option<String>,
+    },
+    /// `<input type="checkbox">`.
+    Checkbox,
+    /// `<input type="date">`.
+    Date,
+    /// `<input type="datetime-local">`.
+    DateTime,
+    /// `<select>` with `(value, label)` option pairs, e.g. enum variants or
+    /// a nullable-bool tri-state.
+    Select {
+        /// The `(value, label)` option pairs rendered as `<option>` elements.
+        options: Vec<(String, String)>,
+    },
+    /// `<input type="file">`. The presence of any `File` field makes
+    /// [`FormFor::render`] emit `enctype="multipart/form-data"`.
+    File,
+}
+
+/// One field descriptor consumed by [`form_for`].
+///
+/// Typically produced by a `#[model]`-derived [`FormModel::form_fields`]
+/// implementation, one entry per persisted column that should render as a
+/// form control.
+#[derive(Debug, Clone)]
+pub struct FormField {
+    /// The field's `name`/`id` attribute — must match the changeset's
+    /// serialized field name.
+    pub name: String,
+    /// The human-readable `<label>` text.
+    pub label: String,
+    /// Which HTML control renders this field.
+    pub control: FieldControl,
+    /// Whether the rendered control should be marked required (`required`
+    /// attribute + `aria-required="true"`), where a required variant of the
+    /// control exists.
+    pub required: bool,
+}
+
+impl FormField {
+    /// Construct a new field descriptor.
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        label: impl Into<String>,
+        control: FieldControl,
+        required: bool,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            label: label.into(),
+            control,
+            required,
+        }
+    }
+}
+
+/// Implemented by model types (typically via `#[model]`) to drive
+/// [`form_for`].
+///
+/// Returns the ordered list of fields to render — one [`FormField`] per
+/// column that should appear as a control in the generated form.
+pub trait FormModel {
+    /// The ordered list of fields [`form_for`] should render.
+    fn form_fields() -> Vec<FormField>;
+}
+
+/// Render a full `<form>` for `T` from `changeset`, deriving one control per
+/// [`FormModel::form_fields`] entry.
+///
+/// This is the "one call renders the whole form" counterpart to composing
+/// the individual typed-input helpers (e.g. [`text_input`], [`select_input`])
+/// by hand: `form_for` walks `T::form_fields()`, dispatches each field to the
+/// matching helper based on its [`FieldControl`], and wraps the result in a
+/// `<form>` via the same audited CSRF/method-override path as [`form_tag`].
+///
+/// Use the [`FormFor`] builder methods to exclude fields, override a field's
+/// control or label, inject a CSRF token, append extra markup before the
+/// submit button, or force a `multipart/form-data` encoding.
+///
+/// # Example
+///
+/// ```rust
+/// use autumn_web::form::{Changeset, FieldControl, FormField, FormModel, form_for};
+/// use serde::Serialize;
+///
+/// #[derive(Serialize)]
+/// struct Post {
+///     title: String,
+///     views: i32,
+///     published: bool,
+/// }
+///
+/// impl FormModel for Post {
+///     fn form_fields() -> Vec<FormField> {
+///         vec![
+///             FormField::new("title", "Title", FieldControl::Text, true),
+///             FormField::new("views", "Views", FieldControl::Number { step: None }, false),
+///             FormField::new("published", "Published", FieldControl::Checkbox, false),
+///         ]
+///     }
+/// }
+///
+/// let changeset = Changeset::new(Post { title: "Hello".into(), views: 0, published: false });
+/// let html = form_for(&changeset, "/posts", "post")
+///     .csrf("tok")
+///     .render()
+///     .into_string();
+///
+/// assert!(html.contains("<form"));
+/// assert!(html.contains(r#"name="_csrf""#));
+/// assert!(html.contains(r#"name="title""#));
+/// assert!(html.contains(r#"name="views""#));
+/// assert!(html.contains(r#"name="published""#));
+/// assert!(html.contains(r#"type="submit""#));
+/// ```
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn form_for<'a, T>(
+    changeset: &'a Changeset<T>,
+    action: impl Into<String>,
+    method: impl Into<String>,
+) -> FormFor<'a, T>
+where
+    T: Serialize + FormModel,
+{
+    FormFor {
+        changeset,
+        action: action.into(),
+        method: method.into(),
+        csrf_token: None,
+        csrf_field_name: "_csrf".to_string(),
+        excluded: Vec::new(),
+        field_overrides: Vec::new(),
+        label_overrides: Vec::new(),
+        appended: Vec::new(),
+        submit_label: "Save".to_string(),
+        force_multipart: false,
+    }
+}
+
+/// Builder returned by [`form_for`]; call [`FormFor::render`] to produce the
+/// final `<form>` markup.
+#[cfg(feature = "maud")]
+pub struct FormFor<'a, T: Serialize + FormModel> {
+    changeset: &'a Changeset<T>,
+    action: String,
+    method: String,
+    csrf_token: Option<String>,
+    csrf_field_name: String,
+    excluded: Vec<String>,
+    field_overrides: Vec<(String, FieldControl)>,
+    label_overrides: Vec<(String, String)>,
+    appended: Vec<maud::Markup>,
+    submit_label: String,
+    force_multipart: bool,
+}
+
+#[cfg(feature = "maud")]
+impl<'a, T: Serialize + FormModel> FormFor<'a, T> {
+    /// Inject a hidden CSRF input carrying `token`.
+    #[must_use]
+    pub fn csrf(mut self, token: impl Into<String>) -> Self {
+        self.csrf_token = Some(token.into());
+        self
+    }
+
+    /// Override the hidden CSRF field name (default `"_csrf"`).
+    #[must_use]
+    pub fn csrf_field_name(mut self, name: impl Into<String>) -> Self {
+        self.csrf_field_name = name.into();
+        self
+    }
+
+    /// Drop `field` from the rendered form.
+    #[must_use]
+    pub fn exclude(mut self, field: impl Into<String>) -> Self {
+        self.excluded.push(field.into());
+        self
+    }
+
+    /// Replace the derived control for `field`.
+    #[must_use]
+    pub fn override_field(mut self, field: impl Into<String>, control: FieldControl) -> Self {
+        self.field_overrides.push((field.into(), control));
+        self
+    }
+
+    /// Replace the label for `field`.
+    #[must_use]
+    pub fn override_label(mut self, field: impl Into<String>, label: impl Into<String>) -> Self {
+        self.label_overrides.push((field.into(), label.into()));
+        self
+    }
+
+    /// Insert extra markup before the submit button.
+    #[must_use]
+    pub fn append(mut self, markup: maud::Markup) -> Self {
+        self.appended.push(markup);
+        self
+    }
+
+    /// Override the submit button label (default `"Save"`).
+    #[must_use]
+    pub fn submit_label(mut self, label: impl Into<String>) -> Self {
+        self.submit_label = label.into();
+        self
+    }
+
+    /// Force `enctype="multipart/form-data"` even when no field is a
+    /// [`FieldControl::File`].
+    #[must_use]
+    pub fn multipart(mut self) -> Self {
+        self.force_multipart = true;
+        self
+    }
+
+    /// Render the full `<form>` markup.
+    #[must_use]
+    pub fn render(self) -> maud::Markup {
+        let Self {
+            changeset,
+            action,
+            method,
+            csrf_token,
+            csrf_field_name,
+            excluded,
+            field_overrides,
+            label_overrides,
+            appended,
+            submit_label,
+            force_multipart,
+        } = self;
+
+        let fields = effective_form_fields::<T>(&excluded, &field_overrides, &label_overrides);
+        let is_multipart = force_multipart
+            || fields
+                .iter()
+                .any(|f| matches!(f.control, FieldControl::File));
+
+        let inner = maud::html! {
+            @for field in &fields {
+                (render_form_field(changeset, field))
+            }
+            @for markup in appended {
+                (markup)
+            }
+            button type="submit" { (submit_label) }
+        };
+
+        if is_multipart {
+            let (browser_method, override_value) = browser_method_and_override(&method);
+            maud::html! {
+                form action=(action) method=(browser_method) enctype="multipart/form-data" {
+                    @if let Some(override_method) = override_value {
+                        input
+                            type="hidden"
+                            name=(crate::middleware::DEFAULT_METHOD_OVERRIDE_FIELD)
+                            value=(override_method);
+                    }
+                    @if let Some(token) = csrf_token.as_deref() {
+                        input type="hidden" name=(csrf_field_name) value=(token);
+                    }
+                    (inner)
+                }
+            }
+        } else {
+            form_tag_inner(
+                &action,
+                &method,
+                &csrf_field_name,
+                csrf_token.as_deref(),
+                inner,
+            )
+        }
+    }
+}
+
+/// Compute the effective field list for a [`FormFor::render`] call: start
+/// from `T::form_fields()`, drop excluded fields, then apply control/label
+/// overrides in place.
+#[cfg(feature = "maud")]
+fn effective_form_fields<T: FormModel>(
+    excluded: &[String],
+    field_overrides: &[(String, FieldControl)],
+    label_overrides: &[(String, String)],
+) -> Vec<FormField> {
+    T::form_fields()
+        .into_iter()
+        .filter(|field| !excluded.contains(&field.name))
+        .map(|mut field| {
+            if let Some((_, control)) = field_overrides.iter().find(|(name, _)| *name == field.name)
+            {
+                field.control = control.clone();
+            }
+            if let Some((_, label)) = label_overrides.iter().find(|(name, _)| *name == field.name) {
+                field.label = label.clone();
+            }
+            field
+        })
+        .collect()
+}
+
+/// Dispatch a single [`FormField`] to the matching typed-input helper.
+#[cfg(feature = "maud")]
+fn render_form_field<T: Serialize>(changeset: &Changeset<T>, field: &FormField) -> maud::Markup {
+    match &field.control {
+        FieldControl::Text => {
+            if field.required {
+                required_text_input(changeset, &field.name, &field.label)
+            } else {
+                text_input(changeset, &field.name, &field.label)
+            }
+        }
+        FieldControl::Textarea => textarea_input(changeset, &field.name, &field.label),
+        FieldControl::Password => password_input(changeset, &field.name, &field.label),
+        FieldControl::Number { step } => {
+            if field.required {
+                required_number_input(changeset, &field.name, &field.label, step.as_deref())
+            } else {
+                number_input(changeset, &field.name, &field.label, step.as_deref())
+            }
+        }
+        FieldControl::Checkbox => checkbox_input(changeset, &field.name, &field.label),
+        FieldControl::Date => date_input(changeset, &field.name, &field.label),
+        FieldControl::DateTime => {
+            if field.required {
+                required_datetime_input(changeset, &field.name, &field.label)
+            } else {
+                datetime_input(changeset, &field.name, &field.label)
+            }
+        }
+        FieldControl::Select { options } => {
+            let opts: Vec<(&str, &str)> = options
+                .iter()
+                .map(|(v, l)| (v.as_str(), l.as_str()))
+                .collect();
+            if field.required {
+                required_select_input(changeset, &field.name, &field.label, &opts)
+            } else {
+                select_input(changeset, &field.name, &field.label, &opts)
+            }
+        }
+        FieldControl::File => {
+            maud::html! {
+                div class="autumn-field" {
+                    label for=(field.name) class="autumn-field__label" { (field.label) }
+                    input type="file" id=(field.name) name=(field.name);
+                }
+            }
+        }
+    }
+}
+
 // ── Tests ──────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -3421,6 +3794,161 @@ mod tests {
         let options = [("draft", "Draft"), ("published", "Published")];
         let html = select_input(&cs, "status", "Status", &options).into_string();
         assert!(html.contains(r#"id="status-field""#), "{html}");
+    }
+
+    // ── form_for (issue #1135 phase 2) ──────────────────────────────
+
+    #[cfg(feature = "maud")]
+    #[derive(serde::Serialize)]
+    struct FormForTestModel {
+        title: String,
+        views: i32,
+        published: bool,
+    }
+
+    #[cfg(feature = "maud")]
+    impl FormModel for FormForTestModel {
+        fn form_fields() -> Vec<FormField> {
+            vec![
+                FormField::new("title", "Title", FieldControl::Text, true),
+                FormField::new("views", "Views", FieldControl::Number { step: None }, false),
+                FormField::new("published", "Published", FieldControl::Checkbox, false),
+            ]
+        }
+    }
+
+    #[cfg(feature = "maud")]
+    fn blank_form_for_model() -> FormForTestModel {
+        FormForTestModel {
+            title: String::new(),
+            views: 0,
+            published: false,
+        }
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn form_for_renders_form_tag_csrf_and_submit() {
+        let cs = Changeset::new(blank_form_for_model());
+        let html = form_for(&cs, "/posts", "post")
+            .csrf("tok123")
+            .render()
+            .into_string();
+        assert!(html.contains("<form"), "{html}");
+        assert!(html.contains(r#"name="_csrf""#), "{html}");
+        assert!(html.contains(r#"value="tok123""#), "{html}");
+        assert!(html.contains(r#"type="submit""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn form_for_method_override_emits_hidden_input() {
+        let cs = Changeset::new(blank_form_for_model());
+        let html = form_for(&cs, "/posts/1", "PUT").render().into_string();
+        assert!(html.contains(r#"name="_method""#), "{html}");
+        assert!(html.contains(r#"value="PUT""#), "{html}");
+        assert!(html.contains(r#"method="post""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn form_for_renders_one_control_per_field() {
+        let cs = Changeset::new(blank_form_for_model());
+        let html = form_for(&cs, "/posts", "post").render().into_string();
+        assert!(html.contains(r#"name="title""#), "{html}");
+        assert!(html.contains(r#"name="views""#), "{html}");
+        assert!(html.contains(r#"name="published""#), "{html}");
+        assert!(html.contains(r#"type="checkbox""#), "{html}");
+        assert!(html.contains(r#"type="number""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn form_for_prefills_values() {
+        let cs = Changeset::new(FormForTestModel {
+            title: "Hello".into(),
+            ..blank_form_for_model()
+        });
+        let html = form_for(&cs, "/posts", "post").render().into_string();
+        assert!(html.contains(r#"value="Hello""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn form_for_renders_inline_error_adjacent() {
+        let mut errors = HashMap::new();
+        errors.insert("title".to_string(), vec!["can't be blank".to_string()]);
+        let cs = Changeset::from_errors(blank_form_for_model(), errors);
+        let html = form_for(&cs, "/posts", "post").render().into_string();
+        assert!(html.contains("can't be blank"), "{html}");
+        assert!(html.contains(r#"role="alert""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn form_for_exclude_drops_field() {
+        let cs = Changeset::new(blank_form_for_model());
+        let html = form_for(&cs, "/posts", "post")
+            .exclude("published")
+            .render()
+            .into_string();
+        assert!(!html.contains(r#"name="published""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn form_for_override_field_changes_control() {
+        let cs = Changeset::new(blank_form_for_model());
+        let html = form_for(&cs, "/posts", "post")
+            .override_field(
+                "title",
+                FieldControl::Select {
+                    options: vec![("a".into(), "A".into())],
+                },
+            )
+            .render()
+            .into_string();
+        assert!(html.contains("<select"), "{html}");
+        assert!(html.contains(r#"name="title""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn form_for_override_label() {
+        let cs = Changeset::new(blank_form_for_model());
+        let html = form_for(&cs, "/posts", "post")
+            .override_label("title", "Headline")
+            .render()
+            .into_string();
+        assert!(html.contains("Headline"), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn form_for_append_inserts_before_submit() {
+        let cs = Changeset::new(blank_form_for_model());
+        let html = form_for(&cs, "/posts", "post")
+            .append(maud::html! { input type="password" name="confirm"; })
+            .render()
+            .into_string();
+        let append_idx = html
+            .find(r#"name="confirm""#)
+            .expect("append markup missing");
+        let submit_idx = html
+            .find(r#"type="submit""#)
+            .expect("submit button missing");
+        assert!(append_idx < submit_idx, "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn form_for_file_field_sets_multipart() {
+        let cs = Changeset::new(blank_form_for_model());
+        let html = form_for(&cs, "/posts", "post")
+            .override_field("title", FieldControl::File)
+            .render()
+            .into_string();
+        assert!(html.contains(r#"enctype="multipart/form-data""#), "{html}");
     }
 
     // ── ChangesetForm extractor (axum integration) ─────────────────

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -1913,6 +1913,19 @@ pub trait FormModel {
 /// control or label, inject a CSRF token, append extra markup before the
 /// submit button, or force a `multipart/form-data` encoding.
 ///
+/// # Checkboxes and `bool` fields
+///
+/// A [`FieldControl::Checkbox`] field renders via [`checkbox_input`], which
+/// deliberately emits **no** hidden `false` fallback (`serde_urlencoded` — used
+/// by axum's `Form` and [`ChangesetForm`] — rejects duplicate keys, so a
+/// hidden sibling would 400 every *checked* submission). An unchecked box
+/// therefore submits no key at all, and the struct the form posts into must
+/// decode a missing key as `false` via `#[serde(default)]` on the `bool`
+/// field. The `#[model]`-generated `NewX` insert struct already does this for
+/// non-nullable `bool` columns (matching the scaffold's `{Model}Form`
+/// convention); hand-written form targets must add the attribute themselves —
+/// see [`checkbox_input`]'s documentation.
+///
 /// # Example
 ///
 /// ```rust

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -1890,8 +1890,17 @@ pub enum FieldControl {
 /// form control.
 #[derive(Debug, Clone)]
 pub struct FormField {
-    /// The field's `name`/`id` attribute — must match the changeset's
-    /// serialized field name.
+    /// The field's `name`/`id` attribute — i.e. the key the browser POSTs
+    /// this control under, which must match what the form's decode target
+    /// (e.g. the `#[model]`-generated `NewX` insert struct) expects. Also
+    /// the key [`Changeset::errors_for`] messages are looked up by, and the
+    /// key [`FormFor::exclude`]/[`FormFor::override_field`]/
+    /// [`FormFor::override_label`] match on.
+    ///
+    /// When the changeset's data type serializes this field under a
+    /// *different* key (a serde rename), set [`FormField::value_name`] so the
+    /// pre-filled value is still found — `name` itself deliberately stays the
+    /// POST key, not the serialized key.
     pub name: String,
     /// The human-readable `<label>` text.
     pub label: String,
@@ -1901,10 +1910,27 @@ pub struct FormField {
     /// attribute + `aria-required="true"`), where a required variant of the
     /// control exists.
     pub required: bool,
+    /// The serde-effective *serialized* key of this field on the changeset's
+    /// data type, when it differs from [`FormField::name`] (e.g.
+    /// `#[serde(rename = "headline")]` or a struct-level
+    /// `#[serde(rename_all = "camelCase")]`). Used **only** to look up the
+    /// pre-filled value via [`Changeset::field_value`]; the rendered
+    /// `name`/`id` attributes, error lookup, and builder matching all keep
+    /// using [`FormField::name`]. `None` means the serialized key equals
+    /// `name` (the common case).
+    ///
+    /// The `#[model]`-derived [`FormModel`] sets this automatically for
+    /// serde-renamed columns; hand-written descriptors use
+    /// [`FormField::with_value_name`].
+    pub value_name: Option<String>,
 }
 
 impl FormField {
     /// Construct a new field descriptor.
+    ///
+    /// The pre-fill lookup key ([`FormField::value_name`]) defaults to
+    /// `name`; use [`FormField::with_value_name`] when the changeset's data
+    /// type serializes the field under a different (serde-renamed) key.
     #[must_use]
     pub fn new(
         name: impl Into<String>,
@@ -1917,7 +1943,17 @@ impl FormField {
             label: label.into(),
             control,
             required,
+            value_name: None,
         }
+    }
+
+    /// Set the serialized key used to pre-fill this field's value from the
+    /// changeset (see [`FormField::value_name`]), returning `self` for
+    /// chaining after [`FormField::new`].
+    #[must_use]
+    pub fn with_value_name(mut self, value_name: impl Into<String>) -> Self {
+        self.value_name = Some(value_name.into());
+        self
     }
 }
 
@@ -1975,6 +2011,25 @@ pub trait FormModel {
 /// `YYYY-MM-DD` wire shape is exactly what chrono's `NaiveDate`
 /// `Deserialize` accepts. Hand-written form targets must attach the
 /// deserializers themselves — see each helper's documentation.
+///
+/// # Serde-renamed fields
+///
+/// A model column carrying `#[serde(rename = "...")]` (or covered by a
+/// struct-level `#[serde(rename_all = "...")]`) serializes under a key that
+/// differs from its Rust identifier, and [`Changeset::field_value`] — which
+/// pre-fills every control by serializing the changeset's data — indexes by
+/// that *serialized* key. The rendered input `name`, however, must stay the
+/// Rust identifier: the `#[model]`-generated `NewX`/`UpdateX` structs the
+/// form posts into do **not** propagate serde renames, so they decode by
+/// identifier. [`FormField`] therefore carries the two keys separately:
+/// [`FormField::name`] is the input `name`/`id`/error-lookup key, and
+/// [`FormField::value_name`] is the serde-effective serialized key used only
+/// for the pre-fill lookup. The `#[model]`-derived [`FormModel`] resolves
+/// field-level `rename`/`rename(serialize = ...)` and struct-level
+/// `rename_all` automatically; hand-written [`FormModel`] impls whose data
+/// type renames fields must call [`FormField::with_value_name`] themselves.
+/// Validation errors stay keyed by the Rust identifier (the `validator`
+/// crate reports the field ident, and the generated `NewX` has no renames).
 ///
 /// # Example
 ///
@@ -2193,9 +2248,70 @@ fn effective_form_fields<T: FormModel>(
         .collect()
 }
 
-/// Dispatch a single [`FormField`] to the matching typed-input helper.
+/// Serialize adapter that re-exposes one serde-renamed field of `data`
+/// under the descriptor's [`FormField::name`], so the typed-input helpers'
+/// [`Changeset::field_value`] lookup (keyed by the rendered input name)
+/// finds the value that `data` actually serializes under
+/// [`FormField::value_name`].
+///
+/// Serializes as a single-entry map `{ exposed_name: data.serialized_name }`
+/// (`null` when the serialized key is absent, which [`Changeset::field_value`]
+/// renders as an empty value — same as any missing field today).
+#[cfg(feature = "maud")]
+struct PrefillAlias<'a, T> {
+    /// The changeset's inner data (serialized in full, then re-keyed).
+    data: &'a T,
+    /// The serde-effective key `data` serializes the field under.
+    serialized_name: &'a str,
+    /// The key the rendering helpers look the value up by (`FormField::name`).
+    exposed_name: &'a str,
+}
+
+#[cfg(feature = "maud")]
+impl<T: Serialize> Serialize for PrefillAlias<'_, T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::{Error as _, SerializeMap as _};
+        let value = serde_json::to_value(self.data).map_err(S::Error::custom)?;
+        let field_value = value
+            .get(self.serialized_name)
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        let mut map = serializer.serialize_map(Some(1))?;
+        map.serialize_entry(self.exposed_name, &field_value)?;
+        map.end()
+    }
+}
+
+/// Render a single [`FormField`], routing the pre-fill lookup through the
+/// field's serialized key ([`FormField::value_name`]) when it differs from
+/// the rendered input name — see [`PrefillAlias`]. Everything else (input
+/// `name`/`id`, error lookup) stays keyed by [`FormField::name`].
 #[cfg(feature = "maud")]
 fn render_form_field<T: Serialize>(changeset: &Changeset<T>, field: &FormField) -> maud::Markup {
+    if let Some(value_name) = field
+        .value_name
+        .as_deref()
+        .filter(|value_name| *value_name != field.name)
+    {
+        let aliased = Changeset::from_errors(
+            PrefillAlias {
+                data: changeset.data(),
+                serialized_name: value_name,
+                exposed_name: &field.name,
+            },
+            changeset.errors().clone(),
+        );
+        return render_form_control(&aliased, field);
+    }
+    render_form_control(changeset, field)
+}
+
+/// Dispatch a single [`FormField`] to the matching typed-input helper.
+#[cfg(feature = "maud")]
+fn render_form_control<T: Serialize>(changeset: &Changeset<T>, field: &FormField) -> maud::Markup {
     match &field.control {
         FieldControl::Text => {
             if field.required {
@@ -3989,6 +4105,45 @@ mod tests {
             views: 0,
             published: false,
         }
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn form_for_prefills_serde_renamed_field_via_value_name() {
+        // The data type serializes `title` under "headline" — field_value
+        // indexes serialized output, so without value_name routing the
+        // pre-fill would come back blank even though the data is present.
+        #[derive(serde::Serialize)]
+        struct RenamedModel {
+            #[serde(rename = "headline")]
+            title: String,
+        }
+        impl FormModel for RenamedModel {
+            fn form_fields() -> Vec<FormField> {
+                vec![
+                    FormField::new("title", "Title", FieldControl::Text, true)
+                        .with_value_name("headline"),
+                ]
+            }
+        }
+
+        let mut errors = HashMap::new();
+        errors.insert("title".to_string(), vec!["too short".to_string()]);
+        let cs = Changeset::from_errors(
+            RenamedModel {
+                title: "Hello".into(),
+            },
+            errors,
+        );
+        let html = form_for(&cs, "/posts", "post").render().into_string();
+
+        // The POST key / id stays the Rust identifier…
+        assert!(html.contains(r#"name="title""#), "{html}");
+        assert!(!html.contains(r#"name="headline""#), "{html}");
+        // …the value is pre-filled through the serialized key…
+        assert!(html.contains(r#"value="Hello""#), "{html}");
+        // …and errors stay keyed by the identifier.
+        assert!(html.contains("too short"), "{html}");
     }
 
     #[cfg(feature = "maud")]

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -1333,7 +1333,6 @@ fn normalize_datetime_local_value(raw: &str) -> String {
 /// Pad an HTML `datetime-local` submission (`YYYY-MM-DDTHH:MM`, seconds
 /// omitted by the browser at minute granularity) to `YYYY-MM-DDTHH:MM:00` so
 /// chrono's parser — which requires the seconds component — accepts it.
-#[cfg(feature = "maud")]
 fn pad_datetime_local_seconds(raw: &str) -> String {
     if raw.chars().count() == 16 {
         format!("{raw}:00")
@@ -1342,16 +1341,40 @@ fn pad_datetime_local_seconds(raw: &str) -> String {
     }
 }
 
+/// Parse a submitted datetime string into `chrono::DateTime<Utc>`, accepting
+/// both wire shapes the same struct has to serve:
+///
+/// - RFC 3339 with an explicit offset (JSON API bodies) — the offset is
+///   honored and the instant converted to UTC;
+/// - the offsetless HTML `datetime-local` shape `YYYY-MM-DDTHH:MM[:SS[.f]]`
+///   (browser form posts) — interpreted as UTC wall-clock time.
+fn parse_datetime_local_or_rfc3339_utc(
+    raw: &str,
+) -> Result<chrono::DateTime<chrono::Utc>, chrono::ParseError> {
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(raw) {
+        return Ok(dt.with_timezone(&chrono::Utc));
+    }
+    chrono::NaiveDateTime::parse_from_str(&pad_datetime_local_seconds(raw), "%Y-%m-%dT%H:%M:%S%.f")
+        .map(|ndt| ndt.and_utc())
+}
+
 /// Deserialize an HTML `datetime-local` submission into `chrono::DateTime<Utc>`,
-/// treating the submitted wall-clock value as UTC.
+/// treating an offsetless submitted wall-clock value as UTC.
+///
+/// RFC 3339 input with an explicit offset is also accepted (converted to
+/// UTC), so a struct that doubles as a JSON API body keeps decoding.
 ///
 /// `<input type="datetime-local">` has no timezone concept, so [`datetime_input`]
 /// necessarily strips any offset when rendering a `DateTime<Utc>` field's
 /// current value — the browser then posts back an offsetless string (e.g.
 /// `2024-03-15T10:30:56`). Chrono's *default* `Deserialize` for
 /// `DateTime<Utc>` requires an RFC 3339 offset and rejects that string with
-/// "premature end of input" on every submission. Attach this function to any
-/// `DateTime<Utc>` field rendered with `datetime_input`:
+/// "premature end of input" on every submission. The `#[model]`-generated
+/// `NewX` insert struct attaches this deserializer to non-nullable
+/// `DateTime<Utc>` columns automatically (and
+/// [`deserialize_datetime_local_utc_option`] to nullable ones); attach it
+/// yourself on any hand-written form struct with a `DateTime<Utc>` field
+/// rendered via `datetime_input`:
 ///
 /// ```rust,ignore
 /// #[derive(serde::Deserialize)]
@@ -1367,9 +1390,9 @@ fn pad_datetime_local_seconds(raw: &str) -> String {
 ///
 /// # Errors
 ///
-/// Returns a deserializer error when the submitted value isn't a valid
-/// `YYYY-MM-DDTHH:MM[:SS[.f]]` local datetime string.
-#[cfg(feature = "maud")]
+/// Returns a deserializer error when the submitted value is neither a valid
+/// `YYYY-MM-DDTHH:MM[:SS[.f]]` local datetime string nor a valid RFC 3339
+/// timestamp.
 pub fn deserialize_datetime_local_utc<'de, D>(
     deserializer: D,
 ) -> Result<chrono::DateTime<chrono::Utc>, D::Error>
@@ -1377,20 +1400,25 @@ where
     D: serde::Deserializer<'de>,
 {
     let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
-    chrono::NaiveDateTime::parse_from_str(&pad_datetime_local_seconds(&raw), "%Y-%m-%dT%H:%M:%S%.f")
-        .map(|ndt| ndt.and_utc())
-        .map_err(serde::de::Error::custom)
+    parse_datetime_local_or_rfc3339_utc(&raw).map_err(serde::de::Error::custom)
 }
 
 /// `Option<chrono::DateTime<Utc>>` counterpart to
-/// [`deserialize_datetime_local_utc`], for a nullable field — an absent or
-/// empty submitted value decodes as `None`.
+/// [`deserialize_datetime_local_utc`], for a nullable field — an absent,
+/// `null`, or empty submitted value decodes as `None`.
+///
+/// Like the required variant, both the offsetless `datetime-local` shape
+/// (interpreted as UTC) and RFC 3339 (offset converted to UTC) are accepted.
+///
+/// Pair it with `#[serde(default)]`: `deserialize_with` disables serde's
+/// implicit missing-`Option`-field-is-`None` handling, and `default` restores
+/// it (the `#[model]`-generated `NewX` struct emits both).
 ///
 /// # Errors
 ///
-/// Returns a deserializer error when a non-empty submitted value isn't a
-/// valid `YYYY-MM-DDTHH:MM[:SS[.f]]` local datetime string.
-#[cfg(feature = "maud")]
+/// Returns a deserializer error when a non-empty submitted value is neither
+/// a valid `YYYY-MM-DDTHH:MM[:SS[.f]]` local datetime string nor a valid
+/// RFC 3339 timestamp.
 pub fn deserialize_datetime_local_utc_option<'de, D>(
     deserializer: D,
 ) -> Result<Option<chrono::DateTime<chrono::Utc>>, D::Error>
@@ -1399,12 +1427,9 @@ where
 {
     let raw = <Option<String> as serde::Deserialize>::deserialize(deserializer)?;
     match raw {
-        Some(s) if !s.is_empty() => chrono::NaiveDateTime::parse_from_str(
-            &pad_datetime_local_seconds(&s),
-            "%Y-%m-%dT%H:%M:%S%.f",
-        )
-        .map(|ndt| Some(ndt.and_utc()))
-        .map_err(serde::de::Error::custom),
+        Some(s) if !s.is_empty() => parse_datetime_local_or_rfc3339_utc(&s)
+            .map(Some)
+            .map_err(serde::de::Error::custom),
         _ => Ok(None),
     }
 }
@@ -1418,7 +1443,11 @@ where
 /// browser's native picker isn't guaranteed to include seconds (`step="any"`
 /// only requests that the control *allow* seconds; it doesn't guarantee
 /// every browser's UI captures them), which would otherwise 400 with
-/// "premature end of input". Attach this function to defend against that:
+/// "premature end of input". The `#[model]`-generated `NewX` insert struct
+/// attaches this deserializer to non-nullable `NaiveDateTime` columns
+/// automatically (and [`deserialize_naive_datetime_local_option`] to nullable
+/// ones); attach it yourself on hand-written form structs to defend against
+/// that:
 ///
 /// ```rust,ignore
 /// #[derive(serde::Deserialize)]
@@ -1432,7 +1461,6 @@ where
 ///
 /// Returns a deserializer error when the submitted value isn't a valid
 /// `YYYY-MM-DDTHH:MM[:SS[.f]]` local datetime string.
-#[cfg(feature = "maud")]
 pub fn deserialize_naive_datetime_local<'de, D>(
     deserializer: D,
 ) -> Result<chrono::NaiveDateTime, D::Error>
@@ -1445,14 +1473,17 @@ where
 }
 
 /// `Option<chrono::NaiveDateTime>` counterpart to
-/// [`deserialize_naive_datetime_local`], for a nullable field — an absent or
-/// empty submitted value decodes as `None`.
+/// [`deserialize_naive_datetime_local`], for a nullable field — an absent,
+/// `null`, or empty submitted value decodes as `None`.
+///
+/// Pair it with `#[serde(default)]`: `deserialize_with` disables serde's
+/// implicit missing-`Option`-field-is-`None` handling, and `default` restores
+/// it (the `#[model]`-generated `NewX` struct emits both).
 ///
 /// # Errors
 ///
 /// Returns a deserializer error when a non-empty submitted value isn't a
 /// valid `YYYY-MM-DDTHH:MM[:SS[.f]]` local datetime string.
-#[cfg(feature = "maud")]
 pub fn deserialize_naive_datetime_local_option<'de, D>(
     deserializer: D,
 ) -> Result<Option<chrono::NaiveDateTime>, D::Error>
@@ -1925,6 +1956,25 @@ pub trait FormModel {
 /// non-nullable `bool` columns (matching the scaffold's `{Model}Form`
 /// convention); hand-written form targets must add the attribute themselves —
 /// see [`checkbox_input`]'s documentation.
+///
+/// # Datetime fields and `datetime-local` values
+///
+/// A [`FieldControl::DateTime`] field renders via [`datetime_input`], whose
+/// `<input type="datetime-local">` has no timezone concept: the pre-filled
+/// value is offsetless (`YYYY-MM-DDTHH:MM:SS`) and the browser posts back an
+/// offsetless string — not always with seconds. Chrono's default
+/// `Deserialize` for `DateTime<Utc>` demands an RFC 3339 offset, so a plain
+/// field would reject even an *untouched* submission as a 400 before
+/// validation. The `#[model]`-generated `NewX` insert struct therefore
+/// attaches [`deserialize_datetime_local_utc`] (or the `_option` variant) to
+/// `DateTime<Utc>` columns and [`deserialize_naive_datetime_local`] (or its
+/// `_option` variant) to `NaiveDateTime` columns: the offsetless value is
+/// interpreted as UTC, and RFC 3339 JSON API bodies posted to the same
+/// struct keep decoding (an explicit offset is converted to UTC).
+/// A required [`FieldControl::Date`] needs no such treatment — the browser's
+/// `YYYY-MM-DD` wire shape is exactly what chrono's `NaiveDate`
+/// `Deserialize` accepts. Hand-written form targets must attach the
+/// deserializers themselves — see each helper's documentation.
 ///
 /// # Example
 ///
@@ -3692,6 +3742,32 @@ mod tests {
                 chrono::Utc,
             )
         );
+    }
+
+    #[test]
+    fn deserialize_datetime_local_utc_accepts_rfc3339_with_offset() {
+        // The same struct often serves JSON API create bodies — the helper
+        // must keep accepting RFC 3339, honoring an explicit offset by
+        // converting to UTC.
+        #[derive(serde::Deserialize)]
+        struct Decoded {
+            #[serde(deserialize_with = "deserialize_datetime_local_utc")]
+            starts_at: chrono::DateTime<chrono::Utc>,
+        }
+        let expected = chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(
+            chrono::NaiveDate::from_ymd_opt(2024, 3, 15)
+                .unwrap()
+                .and_hms_opt(10, 30, 56)
+                .unwrap(),
+            chrono::Utc,
+        );
+        let decoded: Decoded =
+            serde_json::from_str(r#"{"starts_at":"2024-03-15T10:30:56Z"}"#).unwrap();
+        assert_eq!(decoded.starts_at, expected);
+        // +09:00 wall clock 19:30:56 is the same instant.
+        let decoded: Decoded =
+            serde_json::from_str(r#"{"starts_at":"2024-03-15T19:30:56+09:00"}"#).unwrap();
+        assert_eq!(decoded.starts_at, expected);
     }
 
     #[cfg(feature = "maud")]

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -1358,6 +1358,37 @@ fn parse_datetime_local_or_rfc3339_utc(
         .map(|ndt| ndt.and_utc())
 }
 
+/// Parse a submitted datetime string into `chrono::DateTime<Local>`,
+/// accepting both wire shapes the same struct has to serve:
+///
+/// - RFC 3339 with an explicit offset (JSON API bodies) — the offset is
+///   honored and the instant converted to the server's local zone;
+/// - the offsetless HTML `datetime-local` shape `YYYY-MM-DDTHH:MM[:SS[.f]]`
+///   (browser form posts) — interpreted as wall-clock time in the server's
+///   local zone. A wall clock repeated by a DST fall-back transition maps to
+///   the **earlier** of the two instants (deterministic rather than
+///   rejected); a wall clock skipped by a spring-forward transition has no
+///   corresponding instant and errors.
+fn parse_datetime_local_or_rfc3339_local(
+    raw: &str,
+) -> Result<chrono::DateTime<chrono::Local>, String> {
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(raw) {
+        return Ok(dt.with_timezone(&chrono::Local));
+    }
+    let ndt = chrono::NaiveDateTime::parse_from_str(
+        &pad_datetime_local_seconds(raw),
+        "%Y-%m-%dT%H:%M:%S%.f",
+    )
+    .map_err(|e| e.to_string())?;
+    match ndt.and_local_timezone(chrono::Local) {
+        chrono::LocalResult::Single(dt) => Ok(dt),
+        chrono::LocalResult::Ambiguous(earliest, _) => Ok(earliest),
+        chrono::LocalResult::None => Err(format!(
+            "local time {ndt} does not exist in the server's timezone (skipped by a DST transition)"
+        )),
+    }
+}
+
 /// Deserialize an HTML `datetime-local` submission into `chrono::DateTime<Utc>`,
 /// treating an offsetless submitted wall-clock value as UTC.
 ///
@@ -1428,6 +1459,80 @@ where
     let raw = <Option<String> as serde::Deserialize>::deserialize(deserializer)?;
     match raw {
         Some(s) if !s.is_empty() => parse_datetime_local_or_rfc3339_utc(&s)
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+        _ => Ok(None),
+    }
+}
+
+/// Deserialize an HTML `datetime-local` submission into
+/// `chrono::DateTime<Local>`, treating an offsetless submitted wall-clock
+/// value as the server's local time.
+///
+/// RFC 3339 input with an explicit offset is also accepted (the instant is
+/// converted to the local zone), so a struct that doubles as a JSON API body
+/// keeps decoding.
+///
+/// This is the `DateTime<chrono::Local>` counterpart to
+/// [`deserialize_datetime_local_utc`] — see its doc comment for why derived
+/// forms need a datetime-local-tolerant deserializer at all. The
+/// `#[model]`-generated `NewX` insert struct attaches this deserializer to
+/// non-nullable `DateTime<Local>` columns automatically (and
+/// [`deserialize_datetime_local_local_option`] to nullable ones); attach it
+/// yourself on any hand-written form struct with a `DateTime<Local>` field
+/// rendered via [`datetime_input`].
+///
+/// **DST edge cases** (the submitted wall clock has no offset, so the local
+/// zone decides which instant it names): a wall clock that occurs twice
+/// because of a fall-back transition maps to the **earlier** of the two
+/// instants — deterministic, rather than rejecting the submission; a wall
+/// clock skipped by a spring-forward transition names no instant at all and
+/// is rejected as a decode error.
+///
+/// # Errors
+///
+/// Returns a deserializer error when the submitted value is neither a valid
+/// `YYYY-MM-DDTHH:MM[:SS[.f]]` local datetime string nor a valid RFC 3339
+/// timestamp, or when the offsetless wall clock falls in a DST gap of the
+/// server's local zone.
+pub fn deserialize_datetime_local_local<'de, D>(
+    deserializer: D,
+) -> Result<chrono::DateTime<chrono::Local>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+    parse_datetime_local_or_rfc3339_local(&raw).map_err(serde::de::Error::custom)
+}
+
+/// `Option<chrono::DateTime<Local>>` counterpart to
+/// [`deserialize_datetime_local_local`], for a nullable field — an absent,
+/// `null`, or empty submitted value decodes as `None`.
+///
+/// Like the required variant, both the offsetless `datetime-local` shape
+/// (interpreted as the server's local wall clock; DST-ambiguous values map
+/// to the earlier instant, DST-skipped values error) and RFC 3339 (offset
+/// converted to the local zone) are accepted.
+///
+/// Pair it with `#[serde(default)]`: `deserialize_with` disables serde's
+/// implicit missing-`Option`-field-is-`None` handling, and `default` restores
+/// it (the `#[model]`-generated `NewX` struct emits both).
+///
+/// # Errors
+///
+/// Returns a deserializer error when a non-empty submitted value is neither
+/// a valid `YYYY-MM-DDTHH:MM[:SS[.f]]` local datetime string nor a valid
+/// RFC 3339 timestamp, or when the offsetless wall clock falls in a DST gap
+/// of the server's local zone.
+pub fn deserialize_datetime_local_local_option<'de, D>(
+    deserializer: D,
+) -> Result<Option<chrono::DateTime<chrono::Local>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = <Option<String> as serde::Deserialize>::deserialize(deserializer)?;
+    match raw {
+        Some(s) if !s.is_empty() => parse_datetime_local_or_rfc3339_local(&s)
             .map(Some)
             .map_err(serde::de::Error::custom),
         _ => Ok(None),
@@ -1606,7 +1711,14 @@ pub fn required_date_input<T: Serialize>(
 /// chrono's default `Deserialize` for `DateTime<Utc>` requires one and
 /// rejects the submission. Attach [`deserialize_datetime_local_utc`] (or
 /// [`deserialize_datetime_local_utc_option`] for `Option<DateTime<Utc>>`)
-/// via `#[serde(deserialize_with = "...")]` on that field.
+/// via `#[serde(deserialize_with = "...")]` on that field. `DateTime<Local>`
+/// fields have the same problem and take
+/// [`deserialize_datetime_local_local`] (or its `_option` variant), which
+/// interprets the offsetless wall clock in the server's local zone. Other
+/// zone parameters (e.g. `DateTime<FixedOffset>`) have **no** sound
+/// interpretation of an offsetless value — don't render them through this
+/// control; use a text input carrying the RFC 3339 string instead (which is
+/// what a derived `form_for` does).
 ///
 /// `NaiveDateTime` fields don't hit that offset problem, but a value the
 /// user actively edits through the browser's native picker isn't guaranteed
@@ -2003,10 +2115,24 @@ pub trait FormModel {
 /// field would reject even an *untouched* submission as a 400 before
 /// validation. The `#[model]`-generated `NewX` insert struct therefore
 /// attaches [`deserialize_datetime_local_utc`] (or the `_option` variant) to
-/// `DateTime<Utc>` columns and [`deserialize_naive_datetime_local`] (or its
-/// `_option` variant) to `NaiveDateTime` columns: the offsetless value is
-/// interpreted as UTC, and RFC 3339 JSON API bodies posted to the same
-/// struct keep decoding (an explicit offset is converted to UTC).
+/// `DateTime<Utc>` columns, [`deserialize_datetime_local_local`] (or its
+/// `_option` variant) to `DateTime<Local>` columns, and
+/// [`deserialize_naive_datetime_local`] (or its `_option` variant) to
+/// `NaiveDateTime` columns: the offsetless value is interpreted as UTC or
+/// the server's local zone respectively (see
+/// [`deserialize_datetime_local_local`] for the DST edge cases), and
+/// RFC 3339 JSON API bodies posted to the same struct keep decoding (an
+/// explicit offset is converted to the field's zone).
+///
+/// A `DateTime` column with any **other** zone parameter (e.g.
+/// `DateTime<FixedOffset>`, or a bare `DateTime` alias whose zone the derive
+/// can't see) does *not* get the `datetime-local` picker: an offsetless
+/// wall clock is genuinely ambiguous for such a zone, so inventing an
+/// interpretation would silently shift instants. The derived [`FormModel`]
+/// falls back to [`FieldControl::Text`] for those columns — the pre-filled
+/// value is the field's serialized RFC 3339 string, which chrono's default
+/// `Deserialize` round-trips as-is.
+///
 /// A required [`FieldControl::Date`] needs no such treatment — the browser's
 /// `YYYY-MM-DD` wire shape is exactly what chrono's `NaiveDate`
 /// `Deserialize` accepts. Hand-written form targets must attach the
@@ -3916,6 +4042,83 @@ mod tests {
                     .unwrap(),
                 chrono::Utc,
             ))
+        );
+    }
+
+    #[test]
+    fn deserialize_datetime_local_local_interprets_offsetless_as_local_wall_clock() {
+        // The offsetless datetime-local shape names a wall clock in the
+        // server's local zone; the decoded instant's local wall clock must
+        // match it regardless of what TZ the test host runs in. Midday is
+        // safely outside every real zone's DST transition window, so this is
+        // deterministic without pinning `TZ`.
+        #[derive(serde::Deserialize)]
+        struct Decoded {
+            #[serde(deserialize_with = "deserialize_datetime_local_local")]
+            starts_at: chrono::DateTime<chrono::Local>,
+        }
+        let expected_wall_clock = chrono::NaiveDate::from_ymd_opt(2024, 3, 15)
+            .unwrap()
+            .and_hms_opt(12, 30, 56)
+            .unwrap();
+        let decoded: Decoded =
+            serde_json::from_str(r#"{"starts_at":"2024-03-15T12:30:56"}"#).unwrap();
+        assert_eq!(decoded.starts_at.naive_local(), expected_wall_clock);
+
+        // Seconds dropped by a minute-granularity picker are padded.
+        let decoded: Decoded = serde_json::from_str(r#"{"starts_at":"2024-03-15T12:30"}"#).unwrap();
+        assert_eq!(
+            decoded.starts_at.naive_local(),
+            chrono::NaiveDate::from_ymd_opt(2024, 3, 15)
+                .unwrap()
+                .and_hms_opt(12, 30, 0)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn deserialize_datetime_local_local_accepts_rfc3339_with_offset() {
+        // The same struct often serves JSON API create bodies — the helper
+        // must keep accepting RFC 3339, honoring an explicit offset by
+        // converting the instant to the local zone.
+        #[derive(serde::Deserialize)]
+        struct Decoded {
+            #[serde(deserialize_with = "deserialize_datetime_local_local")]
+            starts_at: chrono::DateTime<chrono::Local>,
+        }
+        let expected = chrono::DateTime::parse_from_rfc3339("2024-03-15T10:30:56Z")
+            .unwrap()
+            .with_timezone(&chrono::Local);
+        let decoded: Decoded =
+            serde_json::from_str(r#"{"starts_at":"2024-03-15T10:30:56Z"}"#).unwrap();
+        assert_eq!(decoded.starts_at, expected);
+        // +09:00 wall clock 19:30:56 is the same instant.
+        let decoded: Decoded =
+            serde_json::from_str(r#"{"starts_at":"2024-03-15T19:30:56+09:00"}"#).unwrap();
+        assert_eq!(decoded.starts_at, expected);
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn deserialize_datetime_local_local_option_absent_and_empty_are_none() {
+        #[derive(serde::Deserialize)]
+        struct Decoded {
+            #[serde(default, deserialize_with = "deserialize_datetime_local_local_option")]
+            starts_at: Option<chrono::DateTime<chrono::Local>>,
+        }
+        let decoded: Decoded = serde_urlencoded::from_str("").unwrap();
+        assert_eq!(decoded.starts_at, None);
+        let decoded: Decoded = serde_urlencoded::from_str("starts_at=").unwrap();
+        assert_eq!(decoded.starts_at, None);
+        let decoded: Decoded = serde_urlencoded::from_str("starts_at=2024-03-15T12:30:56").unwrap();
+        assert_eq!(
+            decoded.starts_at.map(|dt| dt.naive_local()),
+            Some(
+                chrono::NaiveDate::from_ymd_opt(2024, 3, 15)
+                    .unwrap()
+                    .and_hms_opt(12, 30, 56)
+                    .unwrap()
+            )
         );
     }
 

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -411,6 +411,7 @@ impl<T: Serialize> ChangesetForm<T> {
             method,
             &self.csrf_field,
             self.csrf_token.as_deref(),
+            None,
             content,
         )
     }
@@ -708,7 +709,7 @@ pub fn form_tag(
     csrf_token: Option<&str>,
     content: maud::Markup,
 ) -> maud::Markup {
-    form_tag_inner(action, method, "_csrf", csrf_token, content)
+    form_tag_inner(action, method, "_csrf", csrf_token, None, content)
 }
 
 /// Internal: render a `<form>` element using an explicit CSRF field name.
@@ -720,6 +721,11 @@ pub fn form_tag(
 /// rewrite the request back to the declared method before route matching.
 /// This lets server-rendered HTML target `#[put]` / `#[patch]` /
 /// `#[delete]` routes without any client JavaScript.
+///
+/// `enctype` is emitted verbatim when `Some` (e.g.
+/// `Some("multipart/form-data")` for [`FormFor`] forms containing a file
+/// input) so every `<form>` — whatever its encoding — flows through this one
+/// audited CSRF/method-override path.
 #[cfg(feature = "maud")]
 #[allow(clippy::needless_pass_by_value)]
 fn form_tag_inner(
@@ -727,11 +733,12 @@ fn form_tag_inner(
     method: &str,
     csrf_field: &str,
     csrf_token: Option<&str>,
+    enctype: Option<&str>,
     content: maud::Markup,
 ) -> maud::Markup {
     let (browser_method, override_value) = browser_method_and_override(method);
     maud::html! {
-        form action=(action) method=(browser_method) {
+        form action=(action) method=(browser_method) enctype=[enctype] {
             @if let Some(override_method) = override_value {
                 input
                     type="hidden"
@@ -1506,6 +1513,48 @@ pub fn date_input<T: Serialize>(
     }
 }
 
+/// Render a labeled `<input type="date">` for a required field.
+///
+/// Identical to [`date_input`] but adds `aria-required="true"` and the HTML
+/// `required` attribute, giving both AT users and browser-native validation
+/// the required-field signal without relying solely on color.
+#[cfg(feature = "maud")]
+#[must_use]
+pub fn required_date_input<T: Serialize>(
+    changeset: &Changeset<T>,
+    field: &str,
+    label: &str,
+) -> maud::Markup {
+    let errors = changeset.errors_for(field);
+    let has_errors = !errors.is_empty();
+    let value = normalize_date_value(&changeset.field_value(field).unwrap_or_default());
+    let error_id = format!("{field}-error");
+    let wrapper_id = format!("{field}-field");
+
+    maud::html! {
+        div id=(wrapper_id) class="autumn-field" {
+            label for=(field) class="autumn-field__label" { (label) }
+            input
+                type="date"
+                id=(field)
+                name=(field)
+                value=(value)
+                required
+                aria-required="true"
+                class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
+                aria-invalid=(if has_errors { "true" } else { "false" })
+                aria-describedby=(if has_errors { error_id.as_str() } else { "" });
+            @if has_errors {
+                div id=(error_id) role="alert" class="autumn-field__errors" {
+                    @for error in errors {
+                        p class="autumn-field__error" { (error) }
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Render a labeled `<input type="datetime-local">` tied to a changeset
 /// field (`NaiveDateTime` or `DateTime`).
 ///
@@ -1768,7 +1817,11 @@ pub fn skip_link(target: &str, label: &str) -> maud::Markup {
 /// This is plain data (no `maud` dependency) so the `#[model]`-derived
 /// [`FormModel`] implementation is always available; only the rendering side
 /// ([`form_for`]) is gated behind the `maud` feature.
+/// The enum is `#[non_exhaustive]`: new control kinds will be added without
+/// a semver-major bump, so external `match`es need a wildcard arm. All
+/// existing variants remain freely constructible.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum FieldControl {
     /// `<input type="text">`.
     Text,
@@ -1898,11 +1951,11 @@ pub trait FormModel {
 /// ```
 #[cfg(feature = "maud")]
 #[must_use]
-pub fn form_for<'a, T>(
-    changeset: &'a Changeset<T>,
+pub fn form_for<T>(
+    changeset: &Changeset<T>,
     action: impl Into<String>,
     method: impl Into<String>,
-) -> FormFor<'a, T>
+) -> FormFor<'_, T>
 where
     T: Serialize + FormModel,
 {
@@ -1939,7 +1992,7 @@ pub struct FormFor<'a, T: Serialize + FormModel> {
 }
 
 #[cfg(feature = "maud")]
-impl<'a, T: Serialize + FormModel> FormFor<'a, T> {
+impl<T: Serialize + FormModel> FormFor<'_, T> {
     /// Inject a hidden CSRF input carrying `token`.
     #[must_use]
     pub fn csrf(mut self, token: impl Into<String>) -> Self {
@@ -1961,14 +2014,16 @@ impl<'a, T: Serialize + FormModel> FormFor<'a, T> {
         self
     }
 
-    /// Replace the derived control for `field`.
+    /// Replace the derived control for `field`. Calling this again for the
+    /// same field replaces the earlier override (last call wins).
     #[must_use]
     pub fn override_field(mut self, field: impl Into<String>, control: FieldControl) -> Self {
         self.field_overrides.push((field.into(), control));
         self
     }
 
-    /// Replace the label for `field`.
+    /// Replace the label for `field`. Calling this again for the same field
+    /// replaces the earlier override (last call wins).
     #[must_use]
     pub fn override_label(mut self, field: impl Into<String>, label: impl Into<String>) -> Self {
         self.label_overrides.push((field.into(), label.into()));
@@ -1992,7 +2047,7 @@ impl<'a, T: Serialize + FormModel> FormFor<'a, T> {
     /// Force `enctype="multipart/form-data"` even when no field is a
     /// [`FieldControl::File`].
     #[must_use]
-    pub fn multipart(mut self) -> Self {
+    pub const fn multipart(mut self) -> Self {
         self.force_multipart = true;
         self
     }
@@ -2030,37 +2085,22 @@ impl<'a, T: Serialize + FormModel> FormFor<'a, T> {
             button type="submit" { (submit_label) }
         };
 
-        if is_multipart {
-            let (browser_method, override_value) = browser_method_and_override(&method);
-            maud::html! {
-                form action=(action) method=(browser_method) enctype="multipart/form-data" {
-                    @if let Some(override_method) = override_value {
-                        input
-                            type="hidden"
-                            name=(crate::middleware::DEFAULT_METHOD_OVERRIDE_FIELD)
-                            value=(override_method);
-                    }
-                    @if let Some(token) = csrf_token.as_deref() {
-                        input type="hidden" name=(csrf_field_name) value=(token);
-                    }
-                    (inner)
-                }
-            }
-        } else {
-            form_tag_inner(
-                &action,
-                &method,
-                &csrf_field_name,
-                csrf_token.as_deref(),
-                inner,
-            )
-        }
+        form_tag_inner(
+            &action,
+            &method,
+            &csrf_field_name,
+            csrf_token.as_deref(),
+            is_multipart.then_some("multipart/form-data"),
+            inner,
+        )
     }
 }
 
 /// Compute the effective field list for a [`FormFor::render`] call: start
 /// from `T::form_fields()`, drop excluded fields, then apply control/label
-/// overrides in place.
+/// overrides in place. Overrides apply in registration order, so when the
+/// same field is overridden twice the **last** call wins — conventional
+/// builder semantics.
 #[cfg(feature = "maud")]
 fn effective_form_fields<T: FormModel>(
     excluded: &[String],
@@ -2071,11 +2111,18 @@ fn effective_form_fields<T: FormModel>(
         .into_iter()
         .filter(|field| !excluded.contains(&field.name))
         .map(|mut field| {
-            if let Some((_, control)) = field_overrides.iter().find(|(name, _)| *name == field.name)
+            if let Some((_, control)) = field_overrides
+                .iter()
+                .rev()
+                .find(|(name, _)| *name == field.name)
             {
                 field.control = control.clone();
             }
-            if let Some((_, label)) = label_overrides.iter().find(|(name, _)| *name == field.name) {
+            if let Some((_, label)) = label_overrides
+                .iter()
+                .rev()
+                .find(|(name, _)| *name == field.name)
+            {
                 field.label = label.clone();
             }
             field
@@ -2104,7 +2151,13 @@ fn render_form_field<T: Serialize>(changeset: &Changeset<T>, field: &FormField) 
             }
         }
         FieldControl::Checkbox => checkbox_input(changeset, &field.name, &field.label),
-        FieldControl::Date => date_input(changeset, &field.name, &field.label),
+        FieldControl::Date => {
+            if field.required {
+                required_date_input(changeset, &field.name, &field.label)
+            } else {
+                date_input(changeset, &field.name, &field.label)
+            }
+        }
         FieldControl::DateTime => {
             if field.required {
                 required_datetime_input(changeset, &field.name, &field.label)
@@ -2124,10 +2177,33 @@ fn render_form_field<T: Serialize>(changeset: &Changeset<T>, field: &FormField) 
             }
         }
         FieldControl::File => {
+            // No dedicated file helper exists upstream, so this arm renders
+            // the same inline-error/ARIA/wrapper skeleton the changeset-aware
+            // helpers emit (a file input can't be value-prefilled — browser
+            // security — so only the value attribute is omitted).
+            let errors = changeset.errors_for(&field.name);
+            let has_errors = !errors.is_empty();
+            let error_id = format!("{}-error", field.name);
+            let wrapper_id = format!("{}-field", field.name);
             maud::html! {
-                div class="autumn-field" {
+                div id=(wrapper_id) class="autumn-field" {
                     label for=(field.name) class="autumn-field__label" { (field.label) }
-                    input type="file" id=(field.name) name=(field.name);
+                    input
+                        type="file"
+                        id=(field.name)
+                        name=(field.name)
+                        required[field.required]
+                        aria-required=[field.required.then_some("true")]
+                        class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
+                        aria-invalid=(if has_errors { "true" } else { "false" })
+                        aria-describedby=(if has_errors { error_id.as_str() } else { "" });
+                    @if has_errors {
+                        div id=(error_id) role="alert" class="autumn-field__errors" {
+                            @for error in errors {
+                                p class="autumn-field__error" { (error) }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -3942,6 +4018,21 @@ mod tests {
 
     #[cfg(feature = "maud")]
     #[test]
+    fn form_for_required_date_field_renders_required_attribute() {
+        let cs = Changeset::new(blank_form_for_model());
+        // `title` is a required field; promoted to a Date control it must
+        // keep the required signal (issue #1135 audit: `required` used to be
+        // silently dropped for `FieldControl::Date`).
+        let html = form_for(&cs, "/posts", "post")
+            .override_field("title", FieldControl::Date)
+            .render()
+            .into_string();
+        assert!(html.contains(r#"type="date""#), "{html}");
+        assert!(html.contains(r#"aria-required="true""#), "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
     fn form_for_file_field_sets_multipart() {
         let cs = Changeset::new(blank_form_for_model());
         let html = form_for(&cs, "/posts", "post")
@@ -3949,6 +4040,94 @@ mod tests {
             .render()
             .into_string();
         assert!(html.contains(r#"enctype="multipart/form-data""#), "{html}");
+    }
+
+    /// A multipart `PUT` form must carry the method-override hidden input,
+    /// the CSRF hidden input, AND the `enctype` in the *same* rendered output
+    /// — the multipart path flows through the same audited `form_tag_inner`
+    /// as every other form, so none of the three can drift apart.
+    #[cfg(feature = "maud")]
+    #[test]
+    fn form_for_multipart_put_emits_method_override_and_csrf_together() {
+        let cs = Changeset::new(blank_form_for_model());
+        let html = form_for(&cs, "/posts/1", "PUT")
+            .csrf("tok456")
+            .multipart()
+            .render()
+            .into_string();
+        assert!(html.contains(r#"enctype="multipart/form-data""#), "{html}");
+        assert!(html.contains(r#"method="post""#), "{html}");
+        assert!(html.contains(r#"name="_method""#), "{html}");
+        assert!(html.contains(r#"value="PUT""#), "{html}");
+        assert!(html.contains(r#"name="_csrf""#), "{html}");
+        assert!(html.contains(r#"value="tok456""#), "{html}");
+
+        // The non-multipart sibling keeps the same combined contract.
+        let cs = Changeset::new(blank_form_for_model());
+        let html = form_for(&cs, "/posts/1", "PUT")
+            .csrf("tok456")
+            .render()
+            .into_string();
+        assert!(!html.contains("enctype"), "{html}");
+        assert!(html.contains(r#"name="_method""#), "{html}");
+        assert!(html.contains(r#"name="_csrf""#), "{html}");
+    }
+
+    /// `FieldControl::File` renders the same inline-error/ARIA/wrapper
+    /// skeleton as the changeset-aware helpers: `{field}-field` wrapper id,
+    /// `aria-invalid`/`aria-describedby`, a `role="alert"` error block, and
+    /// the required signal.
+    #[cfg(feature = "maud")]
+    #[test]
+    fn form_for_file_field_renders_errors_aria_and_required() {
+        let mut errors = HashMap::new();
+        errors.insert("title".to_string(), vec!["must be a PDF".to_string()]);
+        let cs = Changeset::from_errors(blank_form_for_model(), errors);
+        // `title` is required in the test model.
+        let html = form_for(&cs, "/posts", "post")
+            .override_field("title", FieldControl::File)
+            .render()
+            .into_string();
+        assert!(html.contains(r#"type="file""#), "{html}");
+        assert!(html.contains(r#"id="title-field""#), "{html}");
+        assert!(html.contains(r#"aria-invalid="true""#), "{html}");
+        assert!(html.contains(r#"aria-describedby="title-error""#), "{html}");
+        assert!(html.contains(r#"role="alert""#), "{html}");
+        assert!(html.contains("must be a PDF"), "{html}");
+        assert!(html.contains(r#"aria-required="true""#), "{html}");
+        assert!(html.contains("required"), "{html}");
+
+        // Error-free, non-required file field: no required signal, no alert.
+        // (`title` — the only required field — is excluded so any
+        // `aria-required` in the output could only come from the file arm.)
+        let cs = Changeset::new(blank_form_for_model());
+        let html = form_for(&cs, "/posts", "post")
+            .exclude("title")
+            .override_field("published", FieldControl::File)
+            .render()
+            .into_string();
+        assert!(html.contains(r#"id="published-field""#), "{html}");
+        assert!(html.contains(r#"aria-invalid="false""#), "{html}");
+        assert!(!html.contains(r#"aria-required="true""#), "{html}");
+    }
+
+    /// Duplicate `.override_field`/`.override_label` calls on the same field
+    /// resolve last-wins (conventional builder semantics).
+    #[cfg(feature = "maud")]
+    #[test]
+    fn form_for_duplicate_overrides_last_wins() {
+        let cs = Changeset::new(blank_form_for_model());
+        let html = form_for(&cs, "/posts", "post")
+            .override_field("title", FieldControl::Date)
+            .override_field("title", FieldControl::Textarea)
+            .override_label("title", "First")
+            .override_label("title", "Second")
+            .render()
+            .into_string();
+        assert!(html.contains("<textarea"), "{html}");
+        assert!(!html.contains(r#"type="date""#), "{html}");
+        assert!(html.contains("Second"), "{html}");
+        assert!(!html.contains("First"), "{html}");
     }
 
     // ── ChangesetForm extractor (axum integration) ─────────────────

--- a/autumn/tests/integration/form_for_derive.rs
+++ b/autumn/tests/integration/form_for_derive.rs
@@ -1,0 +1,133 @@
+//! Derived-`FormModel` integration tests for `#[model]` (issue #1135).
+//!
+//! Proves the acceptance criteria that the framework knows every field and its
+//! type at the derive layer: a plain `#[model]` struct gains a `FormModel`
+//! implementation whose `form_fields()` lists one type-appropriate descriptor
+//! per editable column (primary key excluded), and that `form_for` renders a
+//! complete form from it in a single call.
+//!
+//! NB: diesel prelude imports are deliberately omitted so the sync
+//! `RunQueryDsl` never clashes with the model's generated async query code
+//! (same convention as `encryption_columns.rs`).
+
+#![cfg(all(feature = "db", feature = "maud"))]
+
+use autumn_web::form::{Changeset, FieldControl, FormModel, form_for};
+
+diesel::table! {
+    articles (id) {
+        id -> Integer,
+        title -> Text,
+        body -> Nullable<Text>,
+        views -> Integer,
+        rating -> Double,
+        published -> Bool,
+    }
+}
+
+#[autumn_web::model(table = "articles")]
+pub struct Article {
+    pub id: i32,
+    pub title: String,
+    pub body: Option<String>,
+    pub views: i32,
+    pub rating: f64,
+    pub published: bool,
+}
+
+#[test]
+fn derived_form_fields_exclude_pk_and_map_types() {
+    let fields = Article::form_fields();
+
+    // Primary key is excluded; remaining columns keep declaration order.
+    let names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
+    assert_eq!(names, ["title", "body", "views", "rating", "published"]);
+
+    // Humanized labels.
+    assert_eq!(fields[0].label, "Title");
+
+    // String -> Text, required (non-Option).
+    assert!(matches!(fields[0].control, FieldControl::Text));
+    assert!(fields[0].required);
+
+    // Option<String> -> Text, not required.
+    assert!(matches!(fields[1].control, FieldControl::Text));
+    assert!(!fields[1].required);
+
+    // i32 -> Number { step: "1" }, required.
+    assert!(
+        matches!(&fields[2].control, FieldControl::Number { step } if step.as_deref() == Some("1"))
+    );
+    assert!(fields[2].required);
+
+    // f64 -> Number { step: "any" }.
+    assert!(
+        matches!(&fields[3].control, FieldControl::Number { step } if step.as_deref() == Some("any"))
+    );
+
+    // bool -> Checkbox.
+    assert!(matches!(fields[4].control, FieldControl::Checkbox));
+}
+
+#[test]
+fn form_for_renders_full_form_from_derived_model() {
+    let changeset = Changeset::new(Article {
+        id: 1,
+        title: "Hello".into(),
+        body: None,
+        views: 3,
+        rating: 4.5,
+        published: true,
+    });
+
+    let html = form_for(&changeset, "/articles", "post")
+        .csrf("tok")
+        .render()
+        .into_string();
+
+    // Opening form tag + auto-injected CSRF + one control per field + submit.
+    assert!(html.contains("<form"));
+    assert!(html.contains(r#"name="_csrf""#));
+    assert!(html.contains(r#"value="tok""#));
+    assert!(html.contains(r#"name="title""#));
+    assert!(html.contains(r#"name="body""#));
+    assert!(html.contains(r#"name="views""#));
+    assert!(html.contains(r#"type="checkbox""#));
+    assert!(html.contains(r#"name="published""#));
+    assert!(html.contains(r#"type="submit""#));
+    // Current values are pre-filled from the changeset.
+    assert!(html.contains(r#"value="Hello""#));
+}
+
+#[test]
+fn form_for_override_promotes_field_to_select() {
+    // The scaffold uses this exact escape hatch to turn an enum column into a
+    // <select>; here we prove it works on a derived model.
+    let changeset = Changeset::new(Article {
+        id: 1,
+        title: "Hello".into(),
+        body: None,
+        views: 3,
+        rating: 4.5,
+        published: true,
+    });
+
+    let html = form_for(&changeset, "/articles", "post")
+        .exclude("rating")
+        .override_field(
+            "title",
+            FieldControl::Select {
+                options: vec![
+                    ("draft".to_string(), "Draft".to_string()),
+                    ("live".to_string(), "Live".to_string()),
+                ],
+            },
+        )
+        .render()
+        .into_string();
+
+    assert!(html.contains("<select"));
+    assert!(html.contains(r#"name="title""#));
+    // Excluded field is gone.
+    assert!(!html.contains(r#"name="rating""#));
+}

--- a/autumn/tests/integration/form_for_derive.rs
+++ b/autumn/tests/integration/form_for_derive.rs
@@ -11,6 +11,11 @@
 //! (same convention as `encryption_columns.rs`).
 
 #![cfg(all(feature = "db", feature = "maud"))]
+// `Article`'s `f64` column makes the `#[model]` expansion (change tracking
+// uses strict equality) trip clippy's `float_cmp`; that generated comparison
+// is the macro's concern, not this test's, and an item-level allow can't
+// reach the macro-emitted impls.
+#![allow(clippy::float_cmp)]
 
 use autumn_web::form::{Changeset, FieldControl, FormModel, form_for};
 

--- a/autumn/tests/integration/form_for_derive.rs
+++ b/autumn/tests/integration/form_for_derive.rs
@@ -105,6 +105,46 @@ fn form_for_renders_full_form_from_derived_model() {
 }
 
 #[test]
+fn derived_new_struct_decodes_unchecked_checkbox_as_false() {
+    // Regression test (Codex P2 on #1587): `form_for` renders a non-nullable
+    // `bool` as a checkbox, and `checkbox_input` deliberately emits no hidden
+    // `false` fallback (serde_urlencoded rejects duplicate keys, so a hidden
+    // sibling would 400 every *checked* submission). An unchecked box thus
+    // submits no `published` key at all — the `#[model]`-generated insert
+    // struct must decode that as `false` via `#[serde(default)]`, not reject
+    // the whole submission with "missing field `published`".
+    let changeset = Changeset::new(Article {
+        id: 1,
+        title: "Hello".into(),
+        body: None,
+        views: 3,
+        rating: 4.5,
+        published: false,
+    });
+    let html = form_for(&changeset, "/articles", "post")
+        .csrf("tok")
+        .render()
+        .into_string();
+    // Exactly one control carries the field name (no hidden fallback input).
+    assert_eq!(html.matches(r#"name="published""#).count(), 1, "{html}");
+
+    // A browser submitting this form with the box UNCHECKED sends every other
+    // field but omits `published` entirely. Decode through the same
+    // serde_urlencoded machinery axum's `Form` extractor and ChangesetForm
+    // use, straight into the generated insert struct.
+    let new_article: NewArticle =
+        serde_urlencoded::from_str("title=Hello&body=&views=3&rating=4.5")
+            .expect("unchecked checkbox submission must decode, not 400");
+    assert!(!new_article.published);
+    assert_eq!(new_article.title, "Hello");
+
+    // And a CHECKED box submits `published=true` exactly once.
+    let new_article: NewArticle =
+        serde_urlencoded::from_str("title=Hello&body=&views=3&rating=4.5&published=true").unwrap();
+    assert!(new_article.published);
+}
+
+#[test]
 fn form_for_override_promotes_field_to_select() {
     // The scaffold uses this exact escape hatch to turn an enum column into a
     // <select>; here we prove it works on a derived model.

--- a/autumn/tests/integration/form_for_derive.rs
+++ b/autumn/tests/integration/form_for_derive.rs
@@ -262,6 +262,88 @@ fn derived_new_struct_still_decodes_rfc3339_json_bodies() {
     assert_eq!(new_event.ends_at, None);
 }
 
+diesel::table! {
+    reviews (id) {
+        id -> Integer,
+        title -> Text,
+        author_name -> Text,
+        word_count -> Integer,
+    }
+}
+
+// Struct-level `rename_all` plus a field-level `rename` override — both pass
+// through to the emitted model struct's `Serialize` derive, so the model's
+// JSON keys are "headline", "authorName", and "wordCount".
+#[autumn_web::model(table = "reviews")]
+#[serde(rename_all = "camelCase")]
+pub struct Review {
+    pub id: i32,
+    #[serde(rename = "headline")]
+    pub title: String,
+    pub author_name: String,
+    pub word_count: i32,
+}
+
+#[test]
+fn derived_form_fields_resolve_serde_renames_into_value_name() {
+    // Regression test (Codex P2 on #1587): `FormField.name` must stay the
+    // Rust identifier (the POST key the generated `NewReview` decodes by),
+    // while the serde-effective serialized key lands in `value_name` so the
+    // pre-fill lookup (`Changeset::field_value`, which indexes serialized
+    // data) still finds the value.
+    let fields = Review::form_fields();
+    let names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
+    assert_eq!(names, ["title", "author_name", "word_count"]);
+
+    // Field-level rename wins over the struct-level rename_all.
+    assert_eq!(fields[0].value_name.as_deref(), Some("headline"));
+    assert_eq!(fields[1].value_name.as_deref(), Some("authorName"));
+    assert_eq!(fields[2].value_name.as_deref(), Some("wordCount"));
+}
+
+#[test]
+fn form_for_prefills_serde_renamed_fields_and_posts_rust_identifiers() {
+    // Regression test (Codex P2 on #1587): an edit form for a model with
+    // serde renames must pre-fill from the renamed serialized keys — before
+    // the `value_name` routing, `field_value("title")` found no "title" key
+    // in the serialized JSON (it's "headline") and rendered blank inputs
+    // despite the data being present.
+    let changeset = Changeset::new(Review {
+        id: 1,
+        title: "Great read".into(),
+        author_name: "Jane Doe".into(),
+        word_count: 812,
+    });
+    let html = form_for(&changeset, "/reviews/1", "put")
+        .csrf("tok")
+        .render()
+        .into_string();
+
+    // Values come from the serde-renamed serialized keys…
+    assert!(html.contains(r#"value="Great read""#), "{html}");
+    assert!(html.contains(r#"value="Jane Doe""#), "{html}");
+    assert!(html.contains(r#"value="812""#), "{html}");
+    // …while the POST keys stay the Rust identifiers the generated insert
+    // struct expects (NewX does not propagate serde renames)…
+    assert!(html.contains(r#"name="title""#), "{html}");
+    assert!(html.contains(r#"name="author_name""#), "{html}");
+    assert!(html.contains(r#"name="word_count""#), "{html}");
+    // …and the serialized keys never leak into the rendered form.
+    assert!(!html.contains(r#"name="headline""#), "{html}");
+    assert!(!html.contains(r#"name="authorName""#), "{html}");
+    assert!(!html.contains(r#"name="wordCount""#), "{html}");
+
+    // A browser round-trips exactly those identifier keys; the generated
+    // insert struct decodes them through the same serde_urlencoded machinery
+    // axum's `Form`/ChangesetForm use.
+    let new_review: NewReview =
+        serde_urlencoded::from_str("title=Great+read&author_name=Jane+Doe&word_count=812")
+            .expect("form_for submission must decode into the generated insert struct");
+    assert_eq!(new_review.title, "Great read");
+    assert_eq!(new_review.author_name, "Jane Doe");
+    assert_eq!(new_review.word_count, 812);
+}
+
 #[test]
 fn form_for_override_promotes_field_to_select() {
     // The scaffold uses this exact escape hatch to turn an enum column into a

--- a/autumn/tests/integration/form_for_derive.rs
+++ b/autumn/tests/integration/form_for_derive.rs
@@ -263,6 +263,125 @@ fn derived_new_struct_still_decodes_rfc3339_json_bodies() {
 }
 
 diesel::table! {
+    meetings (id) {
+        id -> Integer,
+        title -> Text,
+        scheduled_at -> Timestamptz,
+        reminder_at -> Nullable<Timestamptz>,
+    }
+}
+
+// `DateTime<Local>` is the other zone parameter diesel's chrono support can
+// round-trip for `Timestamptz` (it has no `FromSql` for `DateTime<FixedOffset>`
+// or chrono-tz zones, so those can't appear on a compilable `#[model]` struct
+// — their text-input fallback is asserted at the token level in
+// autumn-macros' `form_control_tokens_gates_datetime_picker_on_zone_param`).
+#[autumn_web::model(table = "meetings")]
+pub struct Meeting {
+    pub id: i32,
+    pub title: String,
+    pub scheduled_at: chrono::DateTime<chrono::Local>,
+    pub reminder_at: Option<chrono::DateTime<chrono::Local>>,
+}
+
+#[test]
+fn derived_new_struct_decodes_datetime_local_submission_for_local_zone() {
+    // Regression test (Codex P2 on #1587): `form_for` renders a
+    // `DateTime<Local>` column as `<input type="datetime-local">` too, but
+    // `datetime_local_serde_attr` used to wire a tolerant deserializer only
+    // for `DateTime<Utc>` — the generated `NewMeeting` kept chrono's default
+    // `Deserialize` for `DateTime<Local>`, which demands an RFC 3339 offset,
+    // so posting the rendered form back 400'd even with the value untouched.
+    //
+    // All wall clocks below sit at midday, which no real timezone's DST
+    // transition touches, so the test is deterministic without pinning `TZ`.
+    use chrono::TimeZone as _;
+    let scheduled = chrono::Local
+        .with_ymd_and_hms(2024, 3, 15, 12, 30, 56)
+        .earliest()
+        .expect("midday local wall clock must exist");
+    let changeset = Changeset::new(Meeting {
+        id: 1,
+        title: "Standup".into(),
+        scheduled_at: scheduled,
+        reminder_at: None,
+    });
+
+    // The derived control for a Local column is still the datetime picker…
+    let fields = Meeting::form_fields();
+    assert!(matches!(fields[1].control, FieldControl::DateTime));
+    assert!(matches!(fields[2].control, FieldControl::DateTime));
+
+    // …whose pre-filled value is the offsetless local wall clock (chrono
+    // serializes `DateTime<Local>` as RFC 3339 with the local offset;
+    // `datetime_input` strips it, keeping the wall clock).
+    let html = form_for(&changeset, "/meetings", "post")
+        .csrf("tok")
+        .render()
+        .into_string();
+    assert!(html.contains(r#"value="2024-03-15T12:30:56""#), "{html}");
+
+    // A browser that round-trips the form untouched posts back exactly that
+    // offsetless value; it must decode to the same instant, not 400.
+    let body = "title=Standup&scheduled_at=2024-03-15T12%3A30%3A56&reminder_at=";
+    let new_meeting: NewMeeting = serde_urlencoded::from_str(body)
+        .expect("untouched datetime-local submission must decode, not 400");
+    assert_eq!(new_meeting.scheduled_at, scheduled);
+    // Empty nullable datetime decodes as None, not a parse error.
+    assert_eq!(new_meeting.reminder_at, None);
+
+    // A value edited through the browser's native picker may drop seconds.
+    let body = "title=Standup&scheduled_at=2024-03-15T12%3A30&reminder_at=2024-03-15T13%3A00";
+    let new_meeting: NewMeeting = serde_urlencoded::from_str(body)
+        .expect("minute-granularity datetime-local submission must decode");
+    assert_eq!(
+        new_meeting.scheduled_at,
+        chrono::Local
+            .with_ymd_and_hms(2024, 3, 15, 12, 30, 0)
+            .earliest()
+            .unwrap()
+    );
+    assert_eq!(
+        new_meeting.reminder_at,
+        Some(
+            chrono::Local
+                .with_ymd_and_hms(2024, 3, 15, 13, 0, 0)
+                .earliest()
+                .unwrap()
+        )
+    );
+}
+
+#[test]
+fn derived_new_struct_still_decodes_rfc3339_json_bodies_for_local_zone() {
+    // The generated `NewMeeting` also serves JSON API create bodies — the
+    // datetime-local deserializer must keep accepting RFC 3339, honoring the
+    // explicit offset and converting the instant to the local zone.
+    let expected = chrono::DateTime::parse_from_rfc3339("2024-03-15T10:30:56Z")
+        .unwrap()
+        .with_timezone(&chrono::Local);
+
+    let json = r#"{
+        "title": "Standup",
+        "scheduled_at": "2024-03-15T10:30:56Z",
+        "reminder_at": "2024-03-15T19:30:56+09:00"
+    }"#;
+    let new_meeting: NewMeeting =
+        serde_json::from_str(json).expect("RFC 3339 JSON create body must keep decoding");
+    assert_eq!(new_meeting.scheduled_at, expected);
+    assert_eq!(new_meeting.reminder_at, Some(expected));
+
+    // A JSON body may still omit the nullable column entirely.
+    let json = r#"{
+        "title": "Standup",
+        "scheduled_at": "2024-03-15T10:30:56Z"
+    }"#;
+    let new_meeting: NewMeeting =
+        serde_json::from_str(json).expect("omitted nullable datetime must decode as None");
+    assert_eq!(new_meeting.reminder_at, None);
+}
+
+diesel::table! {
     reviews (id) {
         id -> Integer,
         title -> Text,

--- a/autumn/tests/integration/form_for_derive.rs
+++ b/autumn/tests/integration/form_for_derive.rs
@@ -144,6 +144,124 @@ fn derived_new_struct_decodes_unchecked_checkbox_as_false() {
     assert!(new_article.published);
 }
 
+diesel::table! {
+    events (id) {
+        id -> Integer,
+        title -> Text,
+        published_at -> Timestamptz,
+        starts_at -> Timestamp,
+        ends_at -> Nullable<Timestamptz>,
+    }
+}
+
+#[autumn_web::model(table = "events")]
+pub struct Event {
+    pub id: i32,
+    pub title: String,
+    pub published_at: chrono::DateTime<chrono::Utc>,
+    pub starts_at: chrono::NaiveDateTime,
+    pub ends_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[test]
+fn derived_new_struct_decodes_datetime_local_submission() {
+    // Regression test (Codex P2 on #1587): `form_for` renders
+    // `DateTime<Utc>`/`NaiveDateTime` columns as `<input
+    // type="datetime-local">`, whose value has no timezone offset — chrono's
+    // default `Deserialize` for `DateTime<Utc>` demands an RFC 3339 offset,
+    // so without the generated `deserialize_with` wiring even an *untouched*
+    // pre-filled value would be rejected as a 400 before validation.
+    use chrono::TimeZone as _;
+    let published = chrono::Utc
+        .with_ymd_and_hms(2024, 3, 15, 10, 30, 56)
+        .unwrap();
+    let changeset = Changeset::new(Event {
+        id: 1,
+        title: "Launch".into(),
+        published_at: published,
+        starts_at: published.naive_utc(),
+        ends_at: None,
+    });
+    let html = form_for(&changeset, "/events", "post")
+        .csrf("tok")
+        .render()
+        .into_string();
+
+    // The pre-filled value is the offsetless datetime-local shape (browsers
+    // reject a trailing `Z`/offset in a datetime-local input).
+    assert!(html.contains(r#"value="2024-03-15T10:30:56""#), "{html}");
+    assert!(!html.contains("2024-03-15T10:30:56Z"), "{html}");
+
+    // A browser that round-trips the form untouched posts back exactly that
+    // offsetless value. Decode through the same serde_urlencoded machinery
+    // axum's `Form` and ChangesetForm use, straight into the generated
+    // insert struct — the wall clock is interpreted as UTC.
+    let body = "title=Launch\
+                &published_at=2024-03-15T10%3A30%3A56\
+                &starts_at=2024-03-15T10%3A30%3A56\
+                &ends_at=";
+    let new_event: NewEvent = serde_urlencoded::from_str(body)
+        .expect("untouched datetime-local submission must decode, not 400");
+    assert_eq!(new_event.published_at, published);
+    assert_eq!(new_event.starts_at, published.naive_utc());
+    // Empty nullable datetime decodes as None, not a parse error.
+    assert_eq!(new_event.ends_at, None);
+
+    // A value edited through the browser's native picker may drop the
+    // seconds component entirely (minute granularity).
+    let body = "title=Launch\
+                &published_at=2024-03-15T10%3A30\
+                &starts_at=2024-03-15T10%3A30\
+                &ends_at=2024-03-15T11%3A00";
+    let new_event: NewEvent = serde_urlencoded::from_str(body)
+        .expect("minute-granularity datetime-local submission must decode");
+    assert_eq!(
+        new_event.published_at,
+        chrono::Utc
+            .with_ymd_and_hms(2024, 3, 15, 10, 30, 0)
+            .unwrap()
+    );
+    assert_eq!(
+        new_event.ends_at,
+        Some(chrono::Utc.with_ymd_and_hms(2024, 3, 15, 11, 0, 0).unwrap())
+    );
+}
+
+#[test]
+fn derived_new_struct_still_decodes_rfc3339_json_bodies() {
+    // The generated `NewX` also serves JSON API create bodies — attaching the
+    // datetime-local deserializer must not break RFC 3339 input. An explicit
+    // offset is honored and normalized to UTC.
+    use chrono::TimeZone as _;
+    let expected = chrono::Utc
+        .with_ymd_and_hms(2024, 3, 15, 10, 30, 56)
+        .unwrap();
+
+    let json = r#"{
+        "title": "Launch",
+        "published_at": "2024-03-15T10:30:56Z",
+        "starts_at": "2024-03-15T10:30:56",
+        "ends_at": "2024-03-15T19:30:56+09:00"
+    }"#;
+    let new_event: NewEvent =
+        serde_json::from_str(json).expect("RFC 3339 JSON create body must keep decoding");
+    assert_eq!(new_event.published_at, expected);
+    assert_eq!(new_event.starts_at, expected.naive_utc());
+    assert_eq!(new_event.ends_at, Some(expected));
+
+    // A JSON body may still omit the nullable column entirely
+    // (`#[serde(default)]` restores the implicit-None handling that
+    // `deserialize_with` would otherwise disable).
+    let json = r#"{
+        "title": "Launch",
+        "published_at": "2024-03-15T10:30:56Z",
+        "starts_at": "2024-03-15T10:30:56"
+    }"#;
+    let new_event: NewEvent =
+        serde_json::from_str(json).expect("omitted nullable datetime must decode as None");
+    assert_eq!(new_event.ends_at, None);
+}
+
 #[test]
 fn form_for_override_promotes_field_to_select() {
     // The scaffold uses this exact escape hatch to turn an enum column into a

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -52,6 +52,7 @@ mod experiments_pg_integration;
 mod extractors;
 mod factory_integration;
 mod feature_flags_integration;
+mod form_for_derive;
 mod form_search_widgets;
 #[cfg(all(feature = "maud", feature = "cache-moka"))]
 mod fragment_cache_integration;


### PR DESCRIPTION
## Before / After

**Before:** every create/edit form is hand-assembled. The scaffold emits one `*_input(...)` line per column into the generated views, and an app author writing a form by hand re-wires the form tag, the method override, the CSRF field, one input per column, value pre-fill, per-field errors, and a submit button — roughly 20 lines of Maud per form that must be edited every time the schema changes.

**After:** one `form_for` call renders the whole, correct form — opening form tag with the hidden `_method` override for PUT/PATCH/DELETE, auto-injected CSRF hidden field, one type-appropriate control per model field with current values pre-filled and inline validation errors adjacent, and a submit button. Scaffolded views contain a single call, and regenerating after adding a column requires no view edits.

## How

- **`FormModel` derive in `#[model]`** (`autumn-macros`): every model gets a derived `form_fields()` descriptor list — field name, humanized label, `FieldControl`, required flag — for its new-record fields (PK, `#[default]`, and lock-version columns excluded).
- **`form_for` builder in `autumn-web`** (`autumn/src/form.rs`): walks the descriptors and dispatches each field to the existing typed inputs from #1131, so value pre-fill and inline errors come from the #1124 changeset round-trip rather than being re-implemented. Every render — including multipart — flows through the same audited `form_tag` CSRF/method-override path (`enctype` is threaded through `form_tag_inner`, not duplicated). Escape hatches: `.exclude`, `.override_field` / `.override_label` (last-wins on duplicates), `.append` (before the submit button), `.submit_label`, `.csrf` / `.csrf_field_name`, `.multipart`. `FieldControl` is `#[non_exhaustive]` so new control kinds are not semver-major.
- **Scaffold emission** (`autumn-cli/src/generate/scaffold.rs`): generated create/edit views and both 422 re-render branches render through one shared `{snake}_form_for` helper containing the single `form_for` call; the generated `{Model}Form` delegates `FormModel` to the model's derived impl. The scaffold layers on only what the derive can't know:
  - enum columns → `Select` with one option per declared variant (+ blank placeholder);
  - decimal columns → `Number` step pinned to the declared scale;
  - attachment columns → excluded and re-appended as a file input + hidden blob-key input (they render at the end of the form; the form stays URL-encoded for the direct-upload contract);
  - **references columns → `Select` over the referenced table's ids**: handlers (`new_form`, `edit_form`, and the `create`/`update` 422 branches) load the ids through a generated per-column `{column}_select_options` loader and thread them into the helper. Option labels are the raw id — which referenced column makes a human-friendly label is a display decision the generator can't know, and the generated doc comment says where to swap one in. Requires the referenced model's schema entry to exist (generate the referenced model first — the same ordering the FOREIGN KEY imposes).
  - `--live-validation` scaffolds keep the per-field htmx emission (those inputs have no `FieldControl` equivalent; htmx stays opt-in per the issue).

## Acceptance criteria

- [x] `form_for` builder renders form tag + hidden `_method` override + auto-injected CSRF + one input per declared field + submit button in a single call
- [x] Type-appropriate controls (string→text, bool→checkbox, integer/decimal→number, date/datetime→date, enum/references→select), reusing the #1131 typed inputs
- [x] Values pre-filled from the changeset; inline errors adjacent to the control (consuming #1124)
- [x] Escape hatches: exclude a field, override a field's control or label, append custom markup before submit
- [x] Scaffold create/edit views call `form_for`; regeneration after adding a column needs no manual view edits (byte-identical view sections asserted)
- [x] Plain HTML form that round-trips with JavaScript disabled; htmx remains opt-in
- [x] Doctest renders a full form for a 3-field model asserting form tag, CSRF field, one input per field, and submit button

## Testing

- `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` EXIT=0.
- `cargo test -p autumn-web` EXIT=0 — 3001 lib tests (form_for suite includes `form_for_renders_form_tag_csrf_and_submit`, `form_for_method_override_emits_hidden_input`, `form_for_prefills_values`, `form_for_renders_inline_error_adjacent`, `form_for_exclude_drops_field`, `form_for_override_field_changes_control`, `form_for_append_inserts_before_submit`, `form_for_required_date_field_renders_required_attribute`, and new `form_for_multipart_put_emits_method_override_and_csrf_together`, `form_for_file_field_renders_errors_aria_and_required`, `form_for_duplicate_overrides_last_wins`), 800 integration tests (incl. the `form_for_derive` derive round-trip and the trybuild suites), 189 doc-tests (incl. the AC-7 `form_for` doctest).
- `cargo test --workspace --exclude autumn-web` EXIT=0 — autumn-cli bin 2668 (new `execute_references_column_renders_select_with_loaded_options`, `execute_nullable_references_column_gets_unset_placeholder`), `cli_tests` 167 (new `scaffold_references_column_overrides_to_select_and_loads_options` plus `scaffold_create_and_edit_views_use_single_form_for_call`, `scaffold_enum_column_overrides_to_select`, `scaffold_decimal_column_overrides_number_step`, `rescaffold_with_added_column_leaves_view_form_call_unchanged`), `generate` 40, autumn-macros 347, all other packages green. (Workspace run split in two with the trybuild scratch dir cleared between — its ~17 GB temporary build plus the full set of workspace test binaries exceeds the CI runner's disk; the two runs cover every workspace target.)
- Ignored end-to-end check `generated_form_for_scaffold_cargo_checks -- --ignored` passes (45 s): scaffolds the full column mix — String/Text/i32/decimal{10,2}/bool/NaiveDateTime/DateTime/enum/**references**/Option — generates the referenced `Post` model, and `cargo check --tests` succeeds against the local autumn-web.

Closes #1135

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfxLZ1tYRchJH5yF7gcViE

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfxLZ1tYRchJH5yF7gcViE)_