### PR TITLE
Bump semver-check toolchain 1.92.0 -> 1.94.1 for aws-smithy MSRV (fixes repo-wide SemVer check failure)

### DIFF
--- a/.github/workflows/publish-gate.yml
+++ b/.github/workflows/publish-gate.yml
@@ -171,7 +171,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@1.92.0
+      # Pinned toolchain for cargo-semver-checks — must stay in sync with
+      # AUTUMN_SEMVER_RUST_VERSION's default in scripts/check-semver.sh
+      # (1.94.1: aws-smithy MSRV floor; 1.96.0 ICEs — see script comment).
+      - uses: dtolnay/rust-toolchain@1.94.1
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-semver-checks
         uses: taiki-e/install-action@cargo-semver-checks

--- a/autumn-cli/tests/integration/repo_hygiene.rs
+++ b/autumn-cli/tests/integration/repo_hygiene.rs
@@ -463,8 +463,8 @@ fn semver_script_checks_optional_features_with_pinned_rustdoc_toolchain() {
         .unwrap_or_else(|err| panic!("failed to read {}: {err}", script_path.display()));
 
     assert!(
-        script.contains(r#"semver_toolchain="${AUTUMN_SEMVER_RUST_VERSION:-1.92.0}""#),
-        "{} must pin the semver rustdoc toolchain to Rust 1.92.0 by default",
+        script.contains(r#"semver_toolchain="${AUTUMN_SEMVER_RUST_VERSION:-1.94.1}""#),
+        "{} must pin the semver rustdoc toolchain to Rust 1.94.1 by default",
         script_path.display(),
     );
     assert!(
@@ -492,8 +492,8 @@ fn semver_script_checks_optional_features_with_pinned_rustdoc_toolchain() {
         .and_then(|job| job.split("\n  # ---").next())
         .unwrap_or_else(|| panic!("{} must define a semver job", workflow_path.display()));
     assert!(
-        semver_job.contains("dtolnay/rust-toolchain@1.92.0"),
-        "{} semver job must install the pinned Rust 1.92.0 toolchain",
+        semver_job.contains("dtolnay/rust-toolchain@1.94.1"),
+        "{} semver job must install the pinned Rust 1.94.1 toolchain",
         workflow_path.display(),
     );
     assert!(

--- a/scripts/check-semver.sh
+++ b/scripts/check-semver.sh
@@ -61,7 +61,13 @@ migration_guide="docs/migrations/${workspace_version}.md"
 # cargo-semver-checks 0.48 requires rustc >= 1.91.0, while rustc 1.96.0 has
 # ICE'd in the rustdoc JSON path for the Diesel/diesel-async graph. Keep this
 # pinned to a known-good toolchain instead of following latest stable.
-semver_toolchain="${AUTUMN_SEMVER_RUST_VERSION:-1.92.0}"
+# Floor raised from 1.92.0 to 1.94.1: the aws-smithy-* releases of 2026-07-07
+# (e.g. aws-smithy-async 1.3.0) declare rust-version 1.94.1, and
+# cargo-semver-checks builds the autumn-storage-s3 crates.io baseline with a
+# fresh lockfile, so any toolchain below that MSRV fails the baseline build.
+# Keep in sync with the dtolnay/rust-toolchain pin in the semver job of
+# .github/workflows/publish-gate.yml.
+semver_toolchain="${AUTUMN_SEMVER_RUST_VERSION:-1.94.1}"
 
 command -v rustup &>/dev/null || die "rustup is required to run SemVer checks with Rust $semver_toolchain"
 if ! rustup toolchain list | grep -Fq "${semver_toolchain}-"; then


### PR DESCRIPTION
## Before

Every PR's "SemVer check" job (publish-gate.yml) fails since 2026-07-07 20:13 UTC:

```
    Building autumn-storage-s3 v0.5.0 (baseline)
error: rustc 1.92.0 is not supported by the following packages:
  aws-smithy-async@1.3.0 requires rustc 1.94.1
  ...
  FAIL: autumn-storage-s3 — cargo-semver-checks failed with an unexpected error (exit 1).
error: SemVer check had 1 tool/invocation failure(s).
```

The aws-smithy-* releases of 2026-07-07 (aws-smithy-async 1.3.0 et al.) declare `rust-version = 1.94.1`. cargo-semver-checks builds the autumn-storage-s3 crates.io baseline in a scratch workspace with a fresh lockfile, so it resolves those new releases regardless of our own pins — and the script's pinned toolchain (1.92.0) is below their MSRV. Nothing in any open PR causes or can fix this; it fails identically for all branches (last green run 15:33 UTC, first red 20:13 UTC, all reds identical).

## After

The SemVer check runs again on every PR; real semver violations for autumn-storage-s3 keep being reported (no SKIP added, no coverage lost).

## How

Bump the pinned semver-check toolchain 1.92.0 → 1.94.1 in both places that pin it:

- `scripts/check-semver.sh` — `AUTUMN_SEMVER_RUST_VERSION` default, with a comment explaining the new MSRV floor (and keeping the existing note that 1.96.0 ICEs, which is why the pin doesn't just follow stable).
- `.github/workflows/publish-gate.yml` — the `dtolnay/rust-toolchain@…` step of the `semver` job, with a keep-in-sync comment.

1.94.1 is the minimum satisfying the new aws-smithy MSRV and stays well below the ICE'd 1.96.0.

## Verification

Reproduced the exact CI failure mode locally and confirmed the fix:

- Extracted the actual baseline crate (`autumn-storage-s3-0.5.0.crate` from crates.io), regenerated a fresh lockfile the way cargo-semver-checks' scratch workspace does (latest versions: aws-smithy-async **1.3.0**, aws-smithy-types 1.6.1 — the exact versions from the failing CI log), and ran the rustdoc JSON baseline build under `rustup run 1.94.1`:

  ```
      Checking aws-runtime v1.7.5
      Checking aws-sdk-s3 v1.137.0
      Checking aws-config v1.8.18
   Documenting autumn-storage-s3 v0.5.0 (.../baseline-repro/s3-latest)
      Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 34s
  EXIT=0
  ```

  The old failure fired before any compilation started ("rustc 1.92.0 is not supported by the following packages"); on 1.94.1 the same resolve builds and documents cleanly.
- Ran the real tool end-to-end from this branch: `rustup run 1.94.1 cargo semver-checks check-release --package autumn-storage-s3` (cargo-semver-checks 0.48.0, built from crates.io):

  ```
      Building autumn-storage-s3 v0.6.0 (current)
         Built [ 117.790s] (current)
      Building autumn-storage-s3 v0.5.0 (baseline)
         Built [  76.906s] (baseline)
      Checking autumn-storage-s3 v0.5.0 -> v0.6.0 (major change)
       Checked [   0.000s] 0 checks: 0 pass, 253 skip
       Summary no semver update required
      Finished [ 202.461s] autumn-storage-s3
  SEMVER_CHECKS_EXIT=0
  ```

  The `Building autumn-storage-s3 v0.5.0 (baseline)` step is exactly where CI has been dying since 20:13 UTC; it now completes.
- `bash -n scripts/check-semver.sh` clean.

## Note

This unblocks the currently-red SemVer check on PRs #1583, #1585, and every other open PR against trunk/trunk-dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4V2uKDmFp6KguogGwvxkp

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4V2uKDmFp6KguogGwvxkp)_