### PR TITLE
Add find_in_batches/find_each for bounded-memory table iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **repository:** bounded-memory batched iteration (#1395) — every
+  `#[repository]` now generates `find_in_batches(batch_size)` (yielding
+  successive `Vec<Model>` chunks of at most `batch_size`) and
+  `find_each(batch_size)` (yielding one `Model` at a time), the read-side
+  companion to the bulk writes from #841. Iteration is primary-key keyset-based
+  (`WHERE id > last ORDER BY id ASC LIMIT batch_size`), not `LIMIT`/`OFFSET`, so
+  walking a million-row table in a `#[autumn_web::task]`, job, or sweep holds
+  `O(batch_size)` models — never `O(table)` — and stays stable under concurrent
+  inserts. Unlike a `cursor_page` request, `batch_size` is not clamped to
+  `MAX_PAGE_SIZE`. The iterators reuse the same soft-delete filter and read
+  routing as `find_all`/`cursor_page` (trashed rows are skipped; a
+  replica-routed repo iterates off the replica), an error mid-iteration surfaces
+  on the failing batch and stops iteration without swallowing progress, a
+  `batch_size` of `0` errors rather than spinning, and sharded repositories
+  reject cross-shard `across_tenants()` iteration exactly as `cursor_page` does.
+  The generic handle types live in `autumn_web::batches`
+  (`FindInBatches`, `FindEach`, `BatchSource`). See the "Batched iteration"
+  section of the pagination guide.
+
 - **generator:** `autumn generate scaffold`'s `create`/`update` handlers now
   build a `Changeset` from the submission and re-render the `new`/`edit`
   form on a rejected submission (issue #1124). A failed submission responds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `MAX_PAGE_SIZE`. The iterators reuse the same soft-delete filter and read
   routing as `find_all`/`cursor_page` (trashed rows are skipped; a
   replica-routed repo iterates off the replica), an error mid-iteration surfaces
-  on the failing batch and stops iteration without swallowing progress, a
+  on the failing batch and is retryable (the keyset cursor only advances on
+  success, so a retry resumes with no duplicated or skipped rows — `Ok(None)`
+  always means completion), a
   `batch_size` of `0` errors rather than spinning, and sharded repositories
   reject cross-shard `across_tenants()` iteration exactly as `cursor_page` does.
   The generic handle types live in `autumn_web::batches`

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -7769,6 +7769,120 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         (quote! {}, quote! {})
     };
 
+    // ── Batched iteration (find_in_batches / find_each), issue #1395 ─────────
+    //
+    // Generated for EVERY repository (not gated on cursor_key): a primary-key
+    // ascending keyset walk that streams the whole table in bounded-memory
+    // chunks. Each batch is `WHERE id > last ORDER BY id ASC LIMIT batch_size`
+    // (no id predicate on the first batch), reusing the same soft-delete
+    // filter, tenant scoping and read-routing as `find_all`/`cursor_page`, so
+    // those semantics come for free.
+    //
+    // The generic driver + handle types live in `autumn_web::batches`; the
+    // macro only emits a thin per-repo `BatchSource` impl (the keyset query)
+    // plus two inherent constructors. Sharded repos mirror `cursor_page`:
+    // cross-shard `across_tenants` iteration is rejected (shard fan-out is out
+    // of scope per #1395); a single routed shard iterates normally.
+    let batch_cross_shard_guard = if config.sharded && config.tenant_scoped {
+        quote! {
+            if self.across_tenants {
+                if self.__autumn_shards.is_some() {
+                    return ::core::result::Result::Err(
+                        ::autumn_web::AutumnError::bad_request_msg(
+                            "cross-shard batched iteration is not supported: \
+                             use find_all() with across_tenants() on a \
+                             sharded repository instead"
+                        )
+                    );
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    let batch_source_impl = quote! {
+        impl ::autumn_web::batches::BatchSource for #pg_name {
+            type Model = #model_name;
+
+            async fn fetch_batch_after(
+                &self,
+                after_id: ::core::option::Option<i64>,
+                limit: i64,
+            ) -> ::autumn_web::AutumnResult<::std::vec::Vec<#model_name>> {
+                #batch_cross_shard_guard
+                use ::autumn_web::reexports::diesel::prelude::*;
+                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                let mut conn = self.__autumn_acquire_read_conn().await?;
+                let mut query = #table_ident::table.into_boxed();
+                #tenant_query_filter
+                if let ::core::option::Option::Some(after) = after_id {
+                    query = query.filter(#table_ident::id.gt(after));
+                }
+                // Apply soft-delete filter when enabled.
+                #[allow(unused_mut)]
+                let mut query = query #sd_filter;
+                query
+                    .order(#table_ident::id.asc())
+                    .limit(limit)
+                    .select(#model_name::as_select())
+                    .load::<#model_name>(&mut conn)
+                    .await
+                    .map_err(::autumn_web::AutumnError::from)
+            }
+
+            fn batch_key(model: &#model_name) -> i64 {
+                model.id
+            }
+        }
+    };
+
+    let find_in_batches_methods = quote! {
+        /// Iterate the whole table in bounded-memory chunks of at most
+        /// `batch_size` rows, using a primary-key keyset cursor (not
+        /// `LIMIT`/`OFFSET`), so deep iteration stays flat and is stable under
+        /// concurrent inserts of rows ordered after the current position.
+        ///
+        /// Soft-delete filtering, tenant scoping and read routing match
+        /// `find_all`. Drive the returned handle with `next_batch()` in a
+        /// `while let` loop; drop each chunk before requesting the next to hold
+        /// at most `batch_size` models at a time.
+        ///
+        /// A `batch_size` of `0` yields an error on the first `next_batch()`.
+        ///
+        /// ```rust,ignore
+        /// let mut batches = repo.find_in_batches(1_000);
+        /// while let Some(chunk) = batches.next_batch().await? {
+        ///     repo.save_many(&recompute(chunk)).await?;
+        /// }
+        /// ```
+        #[must_use]
+        pub fn find_in_batches(
+            &self,
+            batch_size: usize,
+        ) -> ::autumn_web::batches::FindInBatches<'_, Self> {
+            ::autumn_web::batches::FindInBatches::new(self, batch_size)
+        }
+
+        /// Iterate the whole table one model at a time while still fetching in
+        /// bounded `batch_size` chunks — a convenience over
+        /// [`find_in_batches`](Self::find_in_batches).
+        ///
+        /// ```rust,ignore
+        /// let mut each = repo.find_each(500);
+        /// while let Some(row) = each.next().await? {
+        ///     repo.update(row.id, &patch).await?;
+        /// }
+        /// ```
+        #[must_use]
+        pub fn find_each(
+            &self,
+            batch_size: usize,
+        ) -> ::autumn_web::batches::FindEach<'_, Self> {
+            ::autumn_web::batches::FindEach::new(self, batch_size)
+        }
+    };
+
     let tenant_scoped_traits = if config.tenant_scoped {
         quote! {
             impl ::autumn_web::tenancy::HasTenantIdColumn for #table_ident::table {
@@ -10171,6 +10285,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         #clone_impl
 
+        // Bounded-memory batched iteration (find_in_batches / find_each, #1395).
+        #batch_source_impl
+
         #[allow(clippy::useless_let_if_seq)]
         impl #trait_name for #pg_name {
             async fn find_by_id(&self, id: i64) -> ::autumn_web::AutumnResult<Option<#model_name>> {
@@ -10272,6 +10389,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 repo.__autumn_read_route = ::autumn_web::repository::ReadRoute::Primary;
                 repo
             }
+
+            #find_in_batches_methods
 
             /// Eager-load associations for records returned by a finder.
             ///

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -7790,8 +7790,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     return ::core::result::Result::Err(
                         ::autumn_web::AutumnError::bad_request_msg(
                             "cross-shard batched iteration is not supported: \
-                             use find_all() with across_tenants() on a \
-                             sharded repository instead"
+                             across_tenants() cannot fan find_in_batches/\
+                             find_each out across shards; iterate each shard \
+                             separately via from_shard(...) instead"
                         )
                     );
                 }
@@ -7848,14 +7849,21 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         /// `while let` loop; drop each chunk before requesting the next to hold
         /// at most `batch_size` models at a time.
         ///
-        /// A `batch_size` of `0` yields an error on the first `next_batch()`.
+        /// Iteration ends at the first short batch; rows inserted after that
+        /// point require a new iteration. Errors are retryable: the cursor
+        /// only advances on success, so calling `next_batch()` again after an
+        /// `Err` retries the same batch (`Ok(None)` always means completion).
+        /// A `batch_size` of `0` yields an error on every `next_batch()`.
         ///
         /// ```rust,ignore
         /// let mut batches = repo.find_in_batches(1_000);
         /// while let Some(chunk) = batches.next_batch().await? {
-        ///     repo.save_many(&recompute(chunk)).await?;
+        ///     repo.upsert_many(&recompute(chunk)).await?;
         /// }
         /// ```
+        ///
+        /// (`upsert_many` is not generated on repositories with hooks
+        /// configured; use per-row `update` there.)
         #[must_use]
         pub fn find_in_batches(
             &self,

--- a/autumn/src/batches.rs
+++ b/autumn/src/batches.rs
@@ -1,0 +1,203 @@
+//! Bounded-memory, keyset-based iteration over an entire table.
+//!
+//! `find_all()` materializes the whole table into one `Vec` — an instant OOM
+//! on a million-row table inside a `#[autumn_web::task]`, scheduled sweep, or
+//! job. The [`BatchSource`]-backed iterators here walk the table in
+//! `batch_size`-sized chunks using a primary-key ascending **keyset** cursor
+//! (`WHERE id > last ORDER BY id ASC LIMIT batch_size`), so peak additional
+//! memory is bounded by `batch_size` regardless of table size, and deep
+//! iteration never degrades the way `LIMIT`/`OFFSET` does.
+//!
+//! The `#[autumn_web::repository]` macro generates two entry points on every
+//! repository:
+//!
+//! - [`find_in_batches(batch_size)`](FindInBatches) — yields successive
+//!   `Vec<Model>` chunks of at most `batch_size` rows.
+//! - [`find_each(batch_size)`](FindEach) — a convenience over the former that
+//!   yields one `Model` at a time while still fetching in bounded batches.
+//!
+//! Both inherit the repository's soft-delete filter, tenant scoping and read
+//! routing (replica / `primary_reads`) for free, because they share the same
+//! connection-acquisition path as `find_all`/`cursor_page`.
+//!
+//! # Example — `find_each` in a task doing a per-row update
+//!
+//! ```rust,ignore
+//! #[autumn_web::task(name = "backfill-slugs")]
+//! pub async fn backfill_slugs(repo: PgPostRepository) -> AutumnResult<()> {
+//!     let mut each = repo.find_each(500);
+//!     while let Some(post) = each.next().await? {
+//!         let slug = slugify(&post.title);
+//!         repo.update(post.id, &UpdatePost { slug: Patch::Set(slug), ..Default::default() })
+//!             .await?;
+//!     }
+//!     Ok(())
+//! }
+//! ```
+//!
+//! # Example — `find_in_batches` + `save_many` recompute loop
+//!
+//! ```rust,ignore
+//! let mut batches = repo.find_in_batches(1_000);
+//! while let Some(chunk) = batches.next_batch().await? {
+//!     let recomputed: Vec<Account> = chunk
+//!         .into_iter()
+//!         .map(|mut a| { a.balance = recompute(&a); a })
+//!         .collect();
+//!     repo.save_many(&recomputed).await?; // O(batch_size) memory, not O(table)
+//! }
+//! ```
+
+use std::future::Future;
+
+use crate::{AutumnError, AutumnResult};
+
+/// A repository that can fetch a keyset batch of models ordered by ascending
+/// primary key. Implemented by the generated repository struct; you never
+/// implement this by hand.
+///
+/// The generated implementation applies the repository's soft-delete filter,
+/// tenant scoping, and read routing, mirroring `find_all`/`cursor_page`.
+pub trait BatchSource: Send + Sync {
+    /// The model type yielded by iteration.
+    type Model: Send;
+
+    /// Fetch up to `limit` models with `id > after_id` (or from the start of
+    /// the table when `after_id` is `None`), ordered by `id` ascending.
+    fn fetch_batch_after(
+        &self,
+        after_id: Option<i64>,
+        limit: i64,
+    ) -> impl Future<Output = AutumnResult<Vec<Self::Model>>> + Send;
+
+    /// The primary key of a model, used to advance the keyset cursor.
+    fn batch_key(model: &Self::Model) -> i64;
+}
+
+/// Iterator over successive `Vec<Model>` chunks of a table, each holding at
+/// most `batch_size` rows.
+///
+/// Created by the generated `find_in_batches(batch_size)` repository method.
+/// Drive it with [`next_batch`](FindInBatches::next_batch) in a `while let`
+/// loop; each chunk should be dropped before requesting the next so that at
+/// most one `batch_size` chunk of models is resident at a time.
+pub struct FindInBatches<'a, S: BatchSource> {
+    source: &'a S,
+    batch_size: usize,
+    /// Exclusive lower bound on `id` for the next batch (`None` == from start).
+    after: Option<i64>,
+    /// Set once the table is exhausted or an error occurred; further calls
+    /// return `Ok(None)` rather than silently resuming.
+    ended: bool,
+}
+
+impl<'a, S: BatchSource> FindInBatches<'a, S> {
+    /// Construct a new batched iterator. Prefer the generated
+    /// `find_in_batches` method over calling this directly.
+    #[must_use]
+    pub const fn new(source: &'a S, batch_size: usize) -> Self {
+        Self {
+            source,
+            batch_size,
+            after: None,
+            ended: false,
+        }
+    }
+
+    /// Fetch the next chunk of at most `batch_size` models.
+    ///
+    /// Returns `Ok(Some(chunk))` with `1..=batch_size` models, `Ok(None)` once
+    /// the table is exhausted. After an error or exhaustion the iterator stays
+    /// ended: subsequent calls return `Ok(None)` and never silently resume.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `batch_size` is `0`, or if the underlying batch
+    /// query fails. The error surfaces on the failing batch and stops
+    /// iteration; progress already yielded is not swallowed.
+    pub async fn next_batch(&mut self) -> AutumnResult<Option<Vec<S::Model>>> {
+        if self.ended {
+            return Ok(None);
+        }
+        if self.batch_size == 0 {
+            self.ended = true;
+            return Err(AutumnError::bad_request_msg(
+                "find_in_batches: batch_size must be greater than zero",
+            ));
+        }
+
+        // Clamp to `i64::MAX` rather than wrapping negative on a >i64::MAX
+        // batch_size (a nonsensical request that would never fit in memory).
+        let limit = i64::try_from(self.batch_size).unwrap_or(i64::MAX);
+        let batch = match self.source.fetch_batch_after(self.after, limit).await {
+            Ok(batch) => batch,
+            Err(err) => {
+                // Surface the error on the failing batch and stop iterating;
+                // do not swallow it or resume on the next call.
+                self.ended = true;
+                return Err(err);
+            }
+        };
+
+        if batch.is_empty() {
+            self.ended = true;
+            return Ok(None);
+        }
+
+        // Advance the keyset cursor past the last row of this chunk.
+        if let Some(last) = batch.last() {
+            self.after = Some(S::batch_key(last));
+        }
+
+        // A short batch means the table is exhausted; the next query would
+        // return empty, so end now and avoid the extra round-trip.
+        if batch.len() < self.batch_size {
+            self.ended = true;
+        }
+
+        Ok(Some(batch))
+    }
+}
+
+/// Iterator that yields individual models one at a time while still fetching
+/// the underlying rows in bounded `batch_size` chunks.
+///
+/// Created by the generated `find_each(batch_size)` repository method. A thin
+/// convenience over [`FindInBatches`].
+pub struct FindEach<'a, S: BatchSource> {
+    batches: FindInBatches<'a, S>,
+    buffer: std::vec::IntoIter<S::Model>,
+}
+
+impl<'a, S: BatchSource> FindEach<'a, S> {
+    /// Construct a new per-row iterator. Prefer the generated `find_each`
+    /// method over calling this directly.
+    #[must_use]
+    pub fn new(source: &'a S, batch_size: usize) -> Self {
+        Self {
+            batches: FindInBatches::new(source, batch_size),
+            buffer: Vec::new().into_iter(),
+        }
+    }
+
+    /// Fetch the next model, pulling a fresh batch when the current buffer is
+    /// drained.
+    ///
+    /// Returns `Ok(Some(model))`, or `Ok(None)` once the table is exhausted.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `batch_size` is `0` or an underlying batch query
+    /// fails (after which the iterator stays ended).
+    pub async fn next(&mut self) -> AutumnResult<Option<S::Model>> {
+        loop {
+            if let Some(model) = self.buffer.next() {
+                return Ok(Some(model));
+            }
+            match self.batches.next_batch().await? {
+                Some(chunk) => self.buffer = chunk.into_iter(),
+                None => return Ok(None),
+            }
+        }
+    }
+}

--- a/autumn/src/batches.rs
+++ b/autumn/src/batches.rs
@@ -20,6 +20,20 @@
 //! routing (replica / `primary_reads`) for free, because they share the same
 //! connection-acquisition path as `find_all`/`cursor_page`.
 //!
+//! Iteration ends at the first short batch (fewer than `batch_size` rows);
+//! rows inserted after that point are not seen by the current handle — start
+//! a new iteration to pick them up (matching Rails' `find_each`).
+//!
+//! # Errors are retryable
+//!
+//! When a batch query fails, [`FindInBatches::next_batch`] returns the error
+//! **without** ending the iteration: the keyset cursor is only advanced on
+//! success, so calling `next_batch()` again re-issues the same
+//! `WHERE id > last` query and resumes exactly where the failure happened —
+//! no duplicated and no skipped rows. A failed run is therefore never
+//! mistaken for a completed one: `Ok(None)` means the table is exhausted,
+//! nothing else.
+//!
 //! # Example — `find_each` in a task doing a per-row update
 //!
 //! ```rust,ignore
@@ -35,7 +49,7 @@
 //! }
 //! ```
 //!
-//! # Example — `find_in_batches` + `save_many` recompute loop
+//! # Example — `find_in_batches` + `upsert_many` recompute loop
 //!
 //! ```rust,ignore
 //! let mut batches = repo.find_in_batches(1_000);
@@ -44,17 +58,22 @@
 //!         .into_iter()
 //!         .map(|mut a| { a.balance = recompute(&a); a })
 //!         .collect();
-//!     repo.save_many(&recomputed).await?; // O(batch_size) memory, not O(table)
+//!     repo.upsert_many(&recomputed).await?; // O(batch_size) memory, not O(table)
 //! }
 //! ```
+//!
+//! (`upsert_many` writes back existing models; it is not generated on
+//! repositories with hooks configured — fall back to per-row `update` there.)
 
 use std::future::Future;
 
 use crate::{AutumnError, AutumnResult};
 
 /// A repository that can fetch a keyset batch of models ordered by ascending
-/// primary key. Implemented by the generated repository struct; you never
-/// implement this by hand.
+/// primary key.
+///
+/// Implemented by the generated repository struct; you normally don't
+/// implement this by hand — the macro generates it.
 ///
 /// The generated implementation applies the repository's soft-delete filter,
 /// tenant scoping, and read routing, mirroring `find_all`/`cursor_page`.
@@ -84,10 +103,16 @@ pub trait BatchSource: Send + Sync {
 pub struct FindInBatches<'a, S: BatchSource> {
     source: &'a S,
     batch_size: usize,
-    /// Exclusive lower bound on `id` for the next batch (`None` == from start).
+    /// `batch_size` as an `i64` query limit, clamped to `i64::MAX` rather
+    /// than wrapping negative on a `> i64::MAX` batch size (a nonsensical
+    /// request that would never fit in memory anyway).
+    limit: i64,
+    /// Exclusive lower bound on `id` for the next batch (`None` == from
+    /// start). Only advanced on success, so a failed batch can be retried by
+    /// calling `next_batch()` again.
     after: Option<i64>,
-    /// Set once the table is exhausted or an error occurred; further calls
-    /// return `Ok(None)` rather than silently resuming.
+    /// Set once the table is exhausted (an empty or short batch was
+    /// observed); further calls return `Ok(None)`. Never set on error.
     ended: bool,
 }
 
@@ -95,10 +120,11 @@ impl<'a, S: BatchSource> FindInBatches<'a, S> {
     /// Construct a new batched iterator. Prefer the generated
     /// `find_in_batches` method over calling this directly.
     #[must_use]
-    pub const fn new(source: &'a S, batch_size: usize) -> Self {
+    pub fn new(source: &'a S, batch_size: usize) -> Self {
         Self {
             source,
             batch_size,
+            limit: i64::try_from(batch_size).unwrap_or(i64::MAX),
             after: None,
             ended: false,
         }
@@ -106,38 +132,35 @@ impl<'a, S: BatchSource> FindInBatches<'a, S> {
 
     /// Fetch the next chunk of at most `batch_size` models.
     ///
-    /// Returns `Ok(Some(chunk))` with `1..=batch_size` models, `Ok(None)` once
-    /// the table is exhausted. After an error or exhaustion the iterator stays
-    /// ended: subsequent calls return `Ok(None)` and never silently resume.
+    /// Returns `Ok(Some(chunk))` with `1..=batch_size` models, or `Ok(None)`
+    /// once the table is exhausted (first short or empty batch). `Ok(None)`
+    /// always means completion — a failed batch never turns into `Ok(None)`.
     ///
     /// # Errors
     ///
-    /// Returns an error if `batch_size` is `0`, or if the underlying batch
-    /// query fails. The error surfaces on the failing batch and stops
-    /// iteration; progress already yielded is not swallowed.
+    /// Returns an error if `batch_size` is `0` (a programmer error — every
+    /// call errors), or if the underlying batch query fails. Errors are
+    /// **retryable**: the keyset cursor is not advanced on failure, so
+    /// calling `next_batch()` again re-issues the same `WHERE id > last`
+    /// query and resumes with no duplicated or skipped rows.
     pub async fn next_batch(&mut self) -> AutumnResult<Option<Vec<S::Model>>> {
         if self.ended {
             return Ok(None);
         }
         if self.batch_size == 0 {
-            self.ended = true;
-            return Err(AutumnError::bad_request_msg(
+            // Programmer error (task/job code, not client input); surfaced on
+            // every call so a retrying caller can never read it as success.
+            return Err(AutumnError::internal_server_error_msg(
                 "find_in_batches: batch_size must be greater than zero",
             ));
         }
 
-        // Clamp to `i64::MAX` rather than wrapping negative on a >i64::MAX
-        // batch_size (a nonsensical request that would never fit in memory).
-        let limit = i64::try_from(self.batch_size).unwrap_or(i64::MAX);
-        let batch = match self.source.fetch_batch_after(self.after, limit).await {
-            Ok(batch) => batch,
-            Err(err) => {
-                // Surface the error on the failing batch and stop iterating;
-                // do not swallow it or resume on the next call.
-                self.ended = true;
-                return Err(err);
-            }
-        };
+        // On `Err` the cursor is untouched: the caller may retry this same
+        // batch by calling `next_batch()` again.
+        let batch = self
+            .source
+            .fetch_batch_after(self.after, self.limit)
+            .await?;
 
         if batch.is_empty() {
             self.ended = true;
@@ -188,7 +211,9 @@ impl<'a, S: BatchSource> FindEach<'a, S> {
     /// # Errors
     ///
     /// Returns an error if `batch_size` is `0` or an underlying batch query
-    /// fails (after which the iterator stays ended).
+    /// fails. Like [`FindInBatches::next_batch`], errors are retryable:
+    /// calling `next()` again retries the failed batch from the same keyset
+    /// position.
     pub async fn next(&mut self) -> AutumnResult<Option<S::Model>> {
         loop {
             if let Some(model) = self.buffer.next() {
@@ -199,5 +224,199 @@ impl<'a, S: BatchSource> FindEach<'a, S> {
                 None => return Ok(None),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    /// Live/high-water-mark counters shared between a fake source and the
+    /// guards embedded in the models it hands out.
+    #[derive(Debug, Default)]
+    struct Counters {
+        live: AtomicUsize,
+        max_live: AtomicUsize,
+    }
+
+    /// Drop-tracking guard: increments the live count on creation (recording
+    /// the high-water mark) and decrements it on drop.
+    #[derive(Debug)]
+    struct Guard {
+        counters: Arc<Counters>,
+    }
+
+    impl Guard {
+        fn new(counters: Arc<Counters>) -> Self {
+            let live = counters.live.fetch_add(1, Ordering::SeqCst) + 1;
+            counters.max_live.fetch_max(live, Ordering::SeqCst);
+            Self { counters }
+        }
+    }
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            self.counters.live.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    #[derive(Debug)]
+    struct FakeModel {
+        id: i64,
+        _guard: Guard,
+    }
+
+    /// In-memory `BatchSource` over ids `1..=total` that instruments model
+    /// residency, and can be told to fail specific fetch calls.
+    struct FakeSource {
+        total: i64,
+        counters: Arc<Counters>,
+        calls: AtomicUsize,
+        /// 1-based indices of fetch calls that should fail.
+        fail_on_calls: &'static [usize],
+    }
+
+    impl FakeSource {
+        fn new(total: i64) -> Self {
+            Self {
+                total,
+                counters: Arc::new(Counters::default()),
+                calls: AtomicUsize::new(0),
+                fail_on_calls: &[],
+            }
+        }
+    }
+
+    impl BatchSource for FakeSource {
+        type Model = FakeModel;
+
+        async fn fetch_batch_after(
+            &self,
+            after_id: Option<i64>,
+            limit: i64,
+        ) -> AutumnResult<Vec<FakeModel>> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+            if self.fail_on_calls.contains(&call) {
+                return Err(AutumnError::internal_server_error_msg(
+                    "injected batch failure",
+                ));
+            }
+            let start = after_id.unwrap_or(0) + 1;
+            Ok((start..=self.total)
+                .take(usize::try_from(limit).unwrap_or(usize::MAX))
+                .map(|id| FakeModel {
+                    id,
+                    _guard: Guard::new(Arc::clone(&self.counters)),
+                })
+                .collect())
+        }
+
+        fn batch_key(model: &FakeModel) -> i64 {
+            model.id
+        }
+    }
+
+    /// AC3: `find_in_batches` never holds more than `batch_size` live models
+    /// at once — instrumented via drop-counting guards, asserting the actual
+    /// high-water mark, not just per-chunk length.
+    #[tokio::test]
+    async fn find_in_batches_high_water_mark_is_bounded_by_batch_size() {
+        const N: i64 = 25;
+        const B: usize = 4;
+
+        let source = FakeSource::new(N);
+        let mut yielded = Vec::new();
+        let mut batches = FindInBatches::new(&source, B);
+        while let Some(chunk) = batches.next_batch().await.expect("fetch") {
+            assert!(chunk.len() <= B);
+            for model in &chunk {
+                yielded.push(model.id);
+            }
+            // Chunk dropped here, before the next fetch.
+        }
+
+        assert_eq!(yielded, (1..=N).collect::<Vec<_>>(), "exactly N, in order");
+        let max = source.counters.max_live.load(Ordering::SeqCst);
+        assert!(max <= B, "high-water mark {max} exceeded batch_size {B}");
+        assert_eq!(
+            source.counters.live.load(Ordering::SeqCst),
+            0,
+            "all models dropped after iteration"
+        );
+    }
+
+    /// AC3: `find_each` buffers at most one batch, so its live-model
+    /// high-water mark is also bounded by `batch_size`.
+    #[tokio::test]
+    async fn find_each_high_water_mark_is_bounded_by_batch_size() {
+        const N: i64 = 25;
+        const B: usize = 4;
+
+        let source = FakeSource::new(N);
+        let mut yielded = Vec::new();
+        let mut each = FindEach::new(&source, B);
+        while let Some(model) = each.next().await.expect("fetch") {
+            yielded.push(model.id);
+            // Model dropped here, before the next call.
+        }
+
+        assert_eq!(yielded, (1..=N).collect::<Vec<_>>(), "exactly N, in order");
+        let max = source.counters.max_live.load(Ordering::SeqCst);
+        assert!(max <= B, "high-water mark {max} exceeded batch_size {B}");
+        assert_eq!(source.counters.live.load(Ordering::SeqCst), 0);
+    }
+
+    /// M2: a failed batch is retryable — the cursor does not advance on
+    /// error, so the retry resumes from the same keyset position with no
+    /// duplicated or skipped rows, and an error is never fused into
+    /// `Ok(None)`.
+    #[tokio::test]
+    async fn failed_batch_is_retryable_without_dupes_or_gaps() {
+        const N: i64 = 10;
+        const B: usize = 3;
+
+        let source = FakeSource {
+            fail_on_calls: &[2],
+            ..FakeSource::new(N)
+        };
+        let mut batches = FindInBatches::new(&source, B);
+
+        let first = batches.next_batch().await.expect("call 1 ok").unwrap();
+        assert_eq!(first.iter().map(|m| m.id).collect::<Vec<_>>(), [1, 2, 3]);
+
+        // Call 2 fails; the iterator must surface it, not end.
+        batches
+            .next_batch()
+            .await
+            .expect_err("call 2 injected failure");
+
+        // Retry resumes from id > 3: same batch, no dupes, no gaps.
+        let mut yielded: Vec<i64> = first.iter().map(|m| m.id).collect();
+        while let Some(chunk) = batches.next_batch().await.expect("retry ok") {
+            yielded.extend(chunk.iter().map(|m| m.id));
+        }
+        assert_eq!(yielded, (1..=N).collect::<Vec<_>>());
+    }
+
+    /// m2: `batch_size == 0` is a programmer error — every call errors (it is
+    /// never converted into an `Ok(None)` "completed" signal), and the error
+    /// is the internal-server-error kind, not a client `bad_request`.
+    #[tokio::test]
+    async fn batch_size_zero_errors_on_every_call() {
+        let source = FakeSource::new(5);
+        let mut batches = FindInBatches::new(&source, 0);
+        for _ in 0..2 {
+            let err = batches.next_batch().await.expect_err("must error");
+            assert!(err.to_string().contains("batch_size"), "got: {err}");
+            assert_eq!(err.status(), http::StatusCode::INTERNAL_SERVER_ERROR);
+        }
+        assert_eq!(
+            source.calls.load(Ordering::SeqCst),
+            0,
+            "no query is ever issued for batch_size == 0"
+        );
     }
 }

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -72,10 +72,6 @@ pub mod assets;
 pub mod audit;
 pub mod auth;
 pub mod authorization;
-/// Bounded-memory, keyset-based iteration over an entire table.
-///
-/// See [`batches`] for [`batches::FindInBatches`], [`batches::FindEach`], and
-/// the [`batches::BatchSource`] trait that generated repositories implement.
 pub mod batches;
 pub mod cache;
 #[cfg(feature = "ws")]

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -72,6 +72,11 @@ pub mod assets;
 pub mod audit;
 pub mod auth;
 pub mod authorization;
+/// Bounded-memory, keyset-based iteration over an entire table.
+///
+/// See [`batches`] for [`batches::FindInBatches`], [`batches::FindEach`], and
+/// the [`batches::BatchSource`] trait that generated repositories implement.
+pub mod batches;
 pub mod cache;
 #[cfg(feature = "ws")]
 pub mod channels;
@@ -243,11 +248,6 @@ pub mod etag;
 pub mod http_client;
 #[cfg(feature = "http-client")]
 pub use http_client as http;
-/// Bounded-memory, keyset-based iteration over an entire table.
-///
-/// See [`batches`] for [`batches::FindInBatches`], [`batches::FindEach`], and
-/// the [`batches::BatchSource`] trait that generated repositories implement.
-pub mod batches;
 #[cfg(feature = "flash")]
 pub mod flash;
 #[cfg(feature = "htmx")]

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -243,6 +243,11 @@ pub mod etag;
 pub mod http_client;
 #[cfg(feature = "http-client")]
 pub use http_client as http;
+/// Bounded-memory, keyset-based iteration over an entire table.
+///
+/// See [`batches`] for [`batches::FindInBatches`], [`batches::FindEach`], and
+/// the [`batches::BatchSource`] trait that generated repositories implement.
+pub mod batches;
 #[cfg(feature = "flash")]
 pub mod flash;
 #[cfg(feature = "htmx")]

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -114,6 +114,8 @@ mod repository_authorization;
 #[cfg(feature = "db")]
 mod repository_bulk_operations;
 #[cfg(feature = "db")]
+mod repository_find_in_batches;
+#[cfg(feature = "db")]
 mod repository_from_shard;
 #[cfg(all(feature = "db", feature = "openapi"))]
 mod repository_openapi;

--- a/autumn/tests/integration/repository_find_in_batches.rs
+++ b/autumn/tests/integration/repository_find_in_batches.rs
@@ -63,6 +63,28 @@ pub struct BatchSoftRecord {
 #[autumn_web::repository(BatchSoftRecord, table = "test_batch_soft_records", soft_delete)]
 pub trait BatchSoftRecordRepository {}
 
+// ── Tenant-scoped model ───────────────────────────────────────────────────────
+
+diesel::table! {
+    test_batch_tenant_records (id) {
+        id -> Int8,
+        name -> Text,
+        tenant_id -> Text,
+    }
+}
+
+#[autumn_web::model(table = "test_batch_tenant_records")]
+pub struct BatchTenantRecord {
+    #[id]
+    pub id: i64,
+    pub name: String,
+    #[default]
+    pub tenant_id: String,
+}
+
+#[autumn_web::repository(BatchTenantRecord, table = "test_batch_tenant_records", tenant_scoped)]
+pub trait BatchTenantRecordRepository {}
+
 // ── Setup & helpers ───────────────────────────────────────────────────────────
 
 async fn setup_pool() -> (
@@ -94,6 +116,12 @@ async fn setup_pool() -> (
     .execute(&mut conn)
     .await
     .expect("create test_batch_soft_records");
+    diesel::sql_query(
+        "CREATE TABLE IF NOT EXISTS test_batch_tenant_records (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL, tenant_id TEXT NOT NULL)",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("create test_batch_tenant_records");
 
     (pool, container)
 }
@@ -111,6 +139,17 @@ const fn build_batch_repo(pool: Pool<AsyncPgConnection>) -> PgBatchRecordReposit
 const fn build_soft_repo(pool: Pool<AsyncPgConnection>) -> PgBatchSoftRecordRepository {
     PgBatchSoftRecordRepository {
         pool,
+        __autumn_read_route: ReadRoute::Primary,
+        __autumn_statement_timeout_ms: 0,
+        __autumn_slow_threshold: std::time::Duration::from_millis(500),
+        __autumn_route: None,
+    }
+}
+
+const fn build_tenant_repo(pool: Pool<AsyncPgConnection>) -> PgBatchTenantRecordRepository {
+    PgBatchTenantRecordRepository {
+        pool,
+        across_tenants: false,
         __autumn_read_route: ReadRoute::Primary,
         __autumn_statement_timeout_ms: 0,
         __autumn_slow_threshold: std::time::Duration::from_millis(500),
@@ -276,33 +315,44 @@ async fn find_in_batches_empty_table() {
     assert!(each.next().await.expect("empty each").is_none());
 }
 
-/// AC6-adjacent: `batch_size == 0` returns an error rather than spinning.
+/// AC6-adjacent: `batch_size == 0` is a programmer error — it surfaces as an
+/// internal-server-error kind on **every** call rather than spinning or
+/// turning into a "completed" `Ok(None)`.
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn find_in_batches_batch_size_zero() {
+    use autumn_web::reexports::http::StatusCode;
+
     let (pool, _container) = setup_pool().await;
     let repo = build_batch_repo(pool);
     seed_records(&repo, 5).await;
 
     let mut batches = repo.find_in_batches(0);
-    let err = batches
-        .next_batch()
-        .await
-        .expect_err("batch_size 0 must error");
-    assert!(
-        err.to_string().to_lowercase().contains("batch_size"),
-        "error should mention batch_size, got: {err}"
-    );
-    // Stays ended (no silent success) after the error.
-    assert!(batches.next_batch().await.expect("stays ended").is_none());
+    for _ in 0..2 {
+        let err = batches
+            .next_batch()
+            .await
+            .expect_err("batch_size 0 must error on every call, never Ok(None)");
+        assert!(
+            err.to_string().to_lowercase().contains("batch_size"),
+            "error should mention batch_size, got: {err}"
+        );
+        assert_eq!(
+            err.status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "batch_size == 0 is task/job programmer error, not client input"
+        );
+    }
 }
 
-/// AC6: an error mid-iteration surfaces on the failing batch, stops iteration,
-/// and does not silently resume. We drop the table between batches to force a
-/// DB error on the next fetch.
+/// AC6: an error mid-iteration surfaces on the failing batch and keeps
+/// surfacing on subsequent calls while the failure persists — it is never
+/// fused into `Ok(None)`, so a retrying backfill can't mistake a failed run
+/// for a completed one. We drop the table between batches to force a DB error
+/// on the next fetch.
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
-async fn find_in_batches_error_mid_iteration_stops() {
+async fn find_in_batches_error_mid_iteration_surfaces_and_is_retryable() {
     const N: usize = 100;
     const B: usize = 10;
 
@@ -333,10 +383,128 @@ async fn find_in_batches_error_mid_iteration_stops() {
         .expect_err("dropped table must surface an error");
     assert!(!err.to_string().is_empty());
 
-    // Once errored it stays ended: no silent success on the next call.
+    // Errors are retryable, never fused into completion: while the failure
+    // persists, every retry surfaces Err again — never Ok(None).
+    batches
+        .next_batch()
+        .await
+        .expect_err("retry against a persistent failure must error again, never Ok(None)");
+}
+
+/// Regression guard against `LIMIT`/`OFFSET` creeping back in: on a static
+/// table, OFFSET and keyset are indistinguishable, so this test mutates the
+/// table mid-iteration. Hard-deleting the already-visited batch would make an
+/// OFFSET-based iterator skip `B` unvisited rows; the keyset cursor continues
+/// from the last-seen id and still visits every remaining row exactly once.
+/// Rows inserted ahead of the cursor (higher ids) are picked up too.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn find_in_batches_keyset_survives_mid_iteration_mutation() {
+    const N: usize = 100;
+    const B: usize = 10;
+
+    let (pool, _container) = setup_pool().await;
+    let repo = build_batch_repo(pool);
+    let seeded = seed_records(&repo, N).await;
+
+    let mut batches = repo.find_in_batches(B);
+    let first = batches
+        .next_batch()
+        .await
+        .expect("first batch ok")
+        .expect("first batch present");
+    let first_ids: Vec<i64> = first.iter().map(|r| r.id).collect();
+    assert_eq!(first_ids.len(), B);
+
+    // Hard-delete the rows already visited. Under OFFSET, the next page
+    // (OFFSET B) would now skip B unvisited rows; keyset does not.
+    repo.delete_many(&first_ids)
+        .await
+        .expect("hard delete batch 1");
+
+    let second = batches
+        .next_batch()
+        .await
+        .expect("second batch ok")
+        .expect("second batch present");
+    let mut seen: Vec<i64> = first_ids;
+    seen.extend(second.iter().map(|r| r.id));
+
+    // Insert rows ahead of the cursor mid-iteration: BIGSERIAL assigns ids
+    // above the current position, so keyset iteration must reach them.
+    let inserted_late = seed_records(&repo, 15).await;
+
+    while let Some(chunk) = batches.next_batch().await.expect("batch fetch") {
+        seen.extend(chunk.iter().map(|r| r.id));
+    }
+
+    let mut expected = seeded;
+    expected.extend(inserted_late);
+    expected.sort_unstable();
+    seen.sort_unstable();
+    assert_eq!(
+        seen, expected,
+        "every row visited exactly once despite mid-iteration delete + insert \
+         (OFFSET would have skipped {B} rows)"
+    );
+}
+
+/// Tenant scoping: iteration only visits the routed tenant's rows, matching
+/// `find_all` on a tenant-scoped repository.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn find_in_batches_is_tenant_scoped() {
+    use autumn_web::tenancy::with_tenant;
+
+    let (pool, _container) = setup_pool().await;
+    let repo = build_tenant_repo(pool);
+
+    let mut a_ids: Vec<i64> = with_tenant("tenant-a".to_string(), async {
+        let new: Vec<NewBatchTenantRecord> = (0..12)
+            .map(|i| NewBatchTenantRecord {
+                name: format!("a-{i}"),
+            })
+            .collect();
+        repo.save_many(&new)
+            .await
+            .expect("seed tenant-a rows")
+            .into_iter()
+            .map(|r| r.id)
+            .collect()
+    })
+    .await;
+    with_tenant("tenant-b".to_string(), async {
+        let new: Vec<NewBatchTenantRecord> = (0..8)
+            .map(|i| NewBatchTenantRecord {
+                name: format!("b-{i}"),
+            })
+            .collect();
+        repo.save_many(&new).await.expect("seed tenant-b rows");
+    })
+    .await;
+
+    let seen: Vec<(i64, String)> = with_tenant("tenant-a".to_string(), async {
+        let mut seen = Vec::new();
+        let mut batches = repo.find_in_batches(5);
+        while let Some(chunk) = batches.next_batch().await.expect("batch fetch") {
+            for row in chunk {
+                seen.push((row.id, row.tenant_id));
+            }
+        }
+        seen
+    })
+    .await;
+
     assert!(
-        batches.next_batch().await.expect("stays ended").is_none(),
-        "iterator must not resume after an error"
+        seen.iter().all(|(_, tenant)| tenant == "tenant-a"),
+        "no foreign-tenant row may be visited"
+    );
+    let mut seen_ids: Vec<i64> = seen.into_iter().map(|(id, _)| id).collect();
+    seen_ids.sort_unstable();
+    a_ids.sort_unstable();
+    assert_eq!(
+        seen_ids, a_ids,
+        "iteration visits exactly the routed tenant's rows"
     );
 }
 

--- a/autumn/tests/integration/repository_find_in_batches.rs
+++ b/autumn/tests/integration/repository_find_in_batches.rs
@@ -1,0 +1,409 @@
+//! Database-level integration tests for bounded-memory batched iteration
+//! (`find_in_batches` / `find_each`, issue #1395).
+//!
+//! The seeded-table tests **require Docker** (testcontainers) and are
+//! `#[ignore]`d by default. The read-routing test runs without a live
+//! database (two lazily-created pools + a `FailReadiness` policy), mirroring
+//! `repository_replica_routing.rs`.
+
+#![cfg(feature = "db")]
+#![allow(clippy::must_use_candidate, clippy::missing_const_for_fn)]
+
+use autumn_web::AppState;
+use autumn_web::config::{DatabaseConfig, ReplicaFallback};
+use autumn_web::db;
+use autumn_web::reexports::axum::extract::FromRequestParts;
+use autumn_web::reexports::http::Request;
+use autumn_web::repository::ReadRoute;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::pooled_connection::deadpool::Pool;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+// ── Plain model ───────────────────────────────────────────────────────────────
+
+diesel::table! {
+    test_batch_records (id) {
+        id -> Int8,
+        name -> Text,
+    }
+}
+
+#[autumn_web::model(table = "test_batch_records")]
+#[derive(PartialEq, Eq)]
+pub struct BatchRecord {
+    #[id]
+    pub id: i64,
+    pub name: String,
+}
+
+#[autumn_web::repository(BatchRecord, table = "test_batch_records")]
+pub trait BatchRecordRepository {}
+
+// ── Soft-delete model ─────────────────────────────────────────────────────────
+
+diesel::table! {
+    test_batch_soft_records (id) {
+        id -> Int8,
+        name -> Text,
+        deleted_at -> Nullable<Timestamp>,
+    }
+}
+
+#[autumn_web::model(table = "test_batch_soft_records")]
+pub struct BatchSoftRecord {
+    #[id]
+    pub id: i64,
+    pub name: String,
+    #[default]
+    pub deleted_at: Option<chrono::NaiveDateTime>,
+}
+
+#[autumn_web::repository(BatchSoftRecord, table = "test_batch_soft_records", soft_delete)]
+pub trait BatchSoftRecordRepository {}
+
+// ── Setup & helpers ───────────────────────────────────────────────────────────
+
+async fn setup_pool() -> (
+    Pool<AsyncPgConnection>,
+    testcontainers::ContainerAsync<Postgres>,
+) {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start postgres container");
+
+    let host = container.get_host().await.expect("host");
+    let port = container.get_host_port_ipv4(5432).await.expect("port");
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(&url);
+    let pool = Pool::builder(manager).max_size(5).build().expect("pool");
+
+    let mut conn = pool.get().await.expect("conn");
+    diesel::sql_query(
+        "CREATE TABLE IF NOT EXISTS test_batch_records (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL)",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("create test_batch_records");
+    diesel::sql_query(
+        "CREATE TABLE IF NOT EXISTS test_batch_soft_records (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL, deleted_at TIMESTAMP)",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("create test_batch_soft_records");
+
+    (pool, container)
+}
+
+const fn build_batch_repo(pool: Pool<AsyncPgConnection>) -> PgBatchRecordRepository {
+    PgBatchRecordRepository {
+        pool,
+        __autumn_read_route: ReadRoute::Primary,
+        __autumn_statement_timeout_ms: 0,
+        __autumn_slow_threshold: std::time::Duration::from_millis(500),
+        __autumn_route: None,
+    }
+}
+
+const fn build_soft_repo(pool: Pool<AsyncPgConnection>) -> PgBatchSoftRecordRepository {
+    PgBatchSoftRecordRepository {
+        pool,
+        __autumn_read_route: ReadRoute::Primary,
+        __autumn_statement_timeout_ms: 0,
+        __autumn_slow_threshold: std::time::Duration::from_millis(500),
+        __autumn_route: None,
+    }
+}
+
+async fn seed_records(repo: &PgBatchRecordRepository, n: usize) -> Vec<i64> {
+    let new: Vec<NewBatchRecord> = (0..n)
+        .map(|i| NewBatchRecord {
+            name: format!("row-{i}"),
+        })
+        .collect();
+    let inserted = repo.save_many(&new).await.expect("seed rows");
+    inserted.into_iter().map(|r| r.id).collect()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// AC1/AC2/AC3: every row visited exactly once, no dupes/gaps, and never more
+/// than `batch_size` models resident at a time (each chunk is bounded and is
+/// dropped before the next fetch).
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn find_in_batches_visits_all_rows_no_dupes_no_gaps() {
+    const N: usize = 250;
+    const B: usize = 40;
+
+    let (pool, _container) = setup_pool().await;
+    let repo = build_batch_repo(pool);
+    let mut expected: Vec<i64> = seed_records(&repo, N).await;
+    expected.sort_unstable();
+
+    let mut seen: Vec<i64> = Vec::new();
+    let mut chunk_count = 0usize;
+    let mut batches = repo.find_in_batches(B);
+    while let Some(chunk) = batches.next_batch().await.expect("batch fetch") {
+        // AC3 high-water-mark: a single chunk holds at most B models.
+        assert!(
+            chunk.len() <= B,
+            "chunk exceeded batch_size: {}",
+            chunk.len()
+        );
+        assert!(!chunk.is_empty(), "no empty chunk should ever be yielded");
+        chunk_count += 1;
+        for row in &chunk {
+            seen.push(row.id);
+        }
+        // Chunk dropped here before the next fetch: O(batch_size) residency.
+    }
+
+    // 250 / 40 = 7 chunks (6 full + 1 short of 10).
+    assert_eq!(chunk_count, N.div_ceil(B));
+    seen.sort_unstable();
+    assert_eq!(seen.len(), N, "visited exactly N rows");
+    assert_eq!(seen, expected, "no dupes, no gaps — exact seeded id set");
+}
+
+/// AC1: `find_each` yields every model individually.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn find_each_visits_all_rows() {
+    const N: usize = 250;
+    const B: usize = 40;
+
+    let (pool, _container) = setup_pool().await;
+    let repo = build_batch_repo(pool);
+    let mut expected = seed_records(&repo, N).await;
+    expected.sort_unstable();
+
+    let mut seen = Vec::new();
+    let mut each = repo.find_each(B);
+    while let Some(row) = each.next().await.expect("row fetch") {
+        seen.push(row.id);
+    }
+
+    seen.sort_unstable();
+    assert_eq!(seen.len(), N);
+    assert_eq!(seen, expected);
+}
+
+/// AC: `batch_size > 100` is honored (no clamp to `MAX_PAGE_SIZE`).
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn find_in_batches_batch_size_over_100() {
+    const N: usize = 300;
+    const B: usize = 150;
+
+    let (pool, _container) = setup_pool().await;
+    let repo = build_batch_repo(pool);
+    seed_records(&repo, N).await;
+
+    let mut chunk_sizes = Vec::new();
+    let mut batches = repo.find_in_batches(B);
+    while let Some(chunk) = batches.next_batch().await.expect("batch fetch") {
+        chunk_sizes.push(chunk.len());
+    }
+
+    // 300 rows / 150 => two full chunks of 150, proving no clamp to 100.
+    assert_eq!(chunk_sizes, vec![150, 150]);
+}
+
+/// AC4: soft-deleted rows are never visited, matching `find_all`.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn find_in_batches_soft_delete_excludes_trashed() {
+    let (pool, _container) = setup_pool().await;
+    let repo = build_soft_repo(pool);
+
+    // Seed 20 live + trash the even ids.
+    let new: Vec<NewBatchSoftRecord> = (0..20)
+        .map(|i| NewBatchSoftRecord {
+            name: format!("s-{i}"),
+        })
+        .collect();
+    let inserted = repo.save_many(&new).await.expect("seed soft rows");
+    let mut trashed: Vec<i64> = Vec::new();
+    for row in inserted.iter().filter(|r| r.id % 2 == 0) {
+        repo.delete_by_id(row.id).await.expect("soft delete");
+        trashed.push(row.id);
+    }
+
+    let mut seen = Vec::new();
+    let mut batches = repo.find_in_batches(5);
+    while let Some(chunk) = batches.next_batch().await.expect("batch fetch") {
+        for row in &chunk {
+            seen.push(row.id);
+        }
+    }
+
+    for id in &trashed {
+        assert!(!seen.contains(id), "trashed row {id} must not be visited");
+    }
+    // Should match find_all, which also filters soft-deleted rows.
+    let mut via_find_all: Vec<i64> = repo
+        .find_all()
+        .await
+        .unwrap()
+        .iter()
+        .map(|r| r.id)
+        .collect();
+    via_find_all.sort_unstable();
+    seen.sort_unstable();
+    assert_eq!(
+        seen, via_find_all,
+        "batches match find_all soft-delete semantics"
+    );
+}
+
+/// AC: empty table yields nothing immediately.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn find_in_batches_empty_table() {
+    let (pool, _container) = setup_pool().await;
+    let repo = build_batch_repo(pool);
+
+    let mut batches = repo.find_in_batches(10);
+    assert!(batches.next_batch().await.expect("empty fetch").is_none());
+    // Stays ended.
+    assert!(batches.next_batch().await.expect("empty fetch").is_none());
+
+    let mut each = repo.find_each(10);
+    assert!(each.next().await.expect("empty each").is_none());
+}
+
+/// AC6-adjacent: `batch_size == 0` returns an error rather than spinning.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn find_in_batches_batch_size_zero() {
+    let (pool, _container) = setup_pool().await;
+    let repo = build_batch_repo(pool);
+    seed_records(&repo, 5).await;
+
+    let mut batches = repo.find_in_batches(0);
+    let err = batches
+        .next_batch()
+        .await
+        .expect_err("batch_size 0 must error");
+    assert!(
+        err.to_string().to_lowercase().contains("batch_size"),
+        "error should mention batch_size, got: {err}"
+    );
+    // Stays ended (no silent success) after the error.
+    assert!(batches.next_batch().await.expect("stays ended").is_none());
+}
+
+/// AC6: an error mid-iteration surfaces on the failing batch, stops iteration,
+/// and does not silently resume. We drop the table between batches to force a
+/// DB error on the next fetch.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn find_in_batches_error_mid_iteration_stops() {
+    const N: usize = 100;
+    const B: usize = 10;
+
+    let (pool, _container) = setup_pool().await;
+    let repo = build_batch_repo(pool.clone());
+    seed_records(&repo, N).await;
+
+    let mut batches = repo.find_in_batches(B);
+    // Pull the first batch successfully.
+    let first = batches
+        .next_batch()
+        .await
+        .expect("first batch ok")
+        .expect("first batch present");
+    assert_eq!(first.len(), B);
+
+    // Break the table out from under the iterator.
+    let mut conn = pool.get().await.unwrap();
+    diesel::sql_query("DROP TABLE test_batch_records")
+        .execute(&mut conn)
+        .await
+        .expect("drop table");
+
+    // Next batch surfaces the DB error, not a silent Ok(None)/Ok(Some).
+    let err = batches
+        .next_batch()
+        .await
+        .expect_err("dropped table must surface an error");
+    assert!(!err.to_string().is_empty());
+
+    // Once errored it stays ended: no silent success on the next call.
+    assert!(
+        batches.next_batch().await.expect("stays ended").is_none(),
+        "iterator must not resume after an error"
+    );
+}
+
+// ── Read-routing (no live database required) ──────────────────────────────────
+
+const PRIMARY_POOL_SIZE: usize = 5;
+const REPLICA_POOL_SIZE: usize = 2;
+
+fn make_pool(database: &str, pool_size: usize) -> Pool<AsyncPgConnection> {
+    let config = DatabaseConfig {
+        url: Some(format!("postgres://localhost/{database}")),
+        pool_size,
+        ..Default::default()
+    };
+    db::create_pool(&config)
+        .expect("pool config is valid")
+        .expect("url is set")
+}
+
+async fn extract<R>(state: &AppState) -> R
+where
+    R: FromRequestParts<AppState, Rejection = autumn_web::AutumnError>,
+{
+    let (mut parts, ()) = Request::builder().body(()).unwrap().into_parts();
+    R::from_request_parts(&mut parts, state)
+        .await
+        .expect("repository extraction succeeds")
+}
+
+/// AC5: the batch iterator routes through the repository's read role. Under a
+/// `FailReadiness` policy with an unready replica the read route is
+/// `Unavailable`, so the first `next_batch()` fails fast with the same
+/// "replica unavailable" error a finder would — before touching any pool,
+/// proving the iterator honors read routing (no live database needed).
+#[tokio::test]
+async fn find_in_batches_honors_read_route_and_fails_fast_when_unavailable() {
+    let state = AppState::for_test()
+        .with_pool(make_pool("primary", PRIMARY_POOL_SIZE))
+        .with_replica_pool(make_pool("replica", REPLICA_POOL_SIZE));
+    state
+        .probes()
+        .configure_replica_dependency(ReplicaFallback::FailReadiness);
+    state
+        .probes()
+        .mark_replica_unready("replica connection failed");
+
+    let repo: PgBatchRecordRepository = extract(&state).await;
+    assert!(matches!(repo.__autumn_read_route(), ReadRoute::Unavailable));
+
+    let mut batches = repo.find_in_batches(50);
+    let err = batches
+        .next_batch()
+        .await
+        .expect_err("batched iteration must honor the unavailable read route");
+    assert!(
+        err.to_string().to_lowercase().contains("replica"),
+        "batch iterator should route through the read role and report the \
+         replica is unavailable, got: {err}"
+    );
+
+    // A replica-routed repo (healthy) snapshots the replica pool for its reads.
+    let healthy = AppState::for_test()
+        .with_pool(make_pool("primary", PRIMARY_POOL_SIZE))
+        .with_replica_pool(make_pool("replica", REPLICA_POOL_SIZE));
+    let repo: PgBatchRecordRepository = extract(&healthy).await;
+    assert!(
+        matches!(repo.__autumn_read_route(), ReadRoute::ReadPool(_)),
+        "reads (including batched iteration) target the replica pool"
+    );
+}

--- a/docs/guide/pagination.md
+++ b/docs/guide/pagination.md
@@ -185,6 +185,86 @@ module docs for the full signing API.
 
 ---
 
+## Batched iteration (server-side, bounded memory)
+
+Cursor pagination shapes an HTTP *response*. When you instead need to touch
+*every* row of a table from inside a `#[autumn_web::task]`, a scheduled sweep,
+or a job — a backfill, a counter-cache recompute, a re-encryption pass — reach
+for **batched iteration** instead of `find_all()`. `find_all()` materializes
+the whole table into one `Vec` (a 1 M-row table is an instant OOM); the batched
+iterators walk the table in bounded-size chunks with flat memory.
+
+Every `#[repository]` generates two methods:
+
+- `find_in_batches(batch_size)` — yields successive `Vec<Model>` chunks of at
+  most `batch_size` rows.
+- `find_each(batch_size)` — yields one `Model` at a time, still fetching under
+  the hood in `batch_size`-sized batches.
+
+Iteration is keyset-based (primary-key ascending: `WHERE id > last ORDER BY id
+ASC LIMIT batch_size`), not `LIMIT`/`OFFSET`, so deep iteration never degrades
+and is stable under concurrent inserts. At most one `batch_size` chunk of
+models is resident at a time — memory is `O(batch_size)`, never `O(table)`.
+Unlike a `cursor_page` request, `batch_size` is **not** clamped to
+`MAX_PAGE_SIZE` (100); pass whatever fits your memory budget.
+
+Batched iteration inherits the repository's soft-delete filter (trashed rows
+are skipped, matching `find_all`) and its read routing (a replica-routed repo
+iterates off the replica, a `primary_reads` repo off the primary), so backfills
+read off a replica with no extra ceremony. An error mid-iteration surfaces as
+an `AutumnResult` error on the failing batch and stops the iterator; progress
+already yielded is not swallowed.
+
+### `find_each` in a task — per-row update
+
+```rust
+#[autumn_web::task(name = "backfill-slugs")]
+pub async fn backfill_slugs(repo: PgPostRepository) -> AutumnResult<()> {
+    let mut each = repo.find_each(500);
+    while let Some(post) = each.next().await? {
+        let slug = slugify(&post.title);
+        repo.update(
+            post.id,
+            &UpdatePost {
+                slug: Patch::Set(slug),
+                ..Default::default()
+            },
+        )
+        .await?;
+    }
+    Ok(())
+}
+```
+
+Register it with `.one_off_tasks(one_off_tasks![tasks::backfill_slugs])` and run
+`autumn task backfill-slugs` (see the [tasks guide](./tasks.md)).
+
+### `find_in_batches` + `save_many` — recompute loop
+
+Pair batched reads with the bulk writes from
+[`save_many`](./repositories.md) to recompute a whole table with flat memory on
+both the read and write side:
+
+```rust
+let mut batches = repo.find_in_batches(1_000);
+while let Some(chunk) = batches.next_batch().await? {
+    let recomputed: Vec<Account> = chunk
+        .into_iter()
+        .map(|mut account| {
+            account.balance = recompute_balance(&account);
+            account
+        })
+        .collect();
+    repo.save_many(&recomputed).await?; // O(batch_size) memory, not O(table)
+}
+```
+
+A `batch_size` of `0` returns an error on the first call rather than spinning.
+On a **sharded** repository, cross-shard `across_tenants()` iteration is
+rejected (mirroring `cursor_page`); iterate a single routed shard instead.
+
+---
+
 ## Offset vs cursor: decision guide
 
 | Question | Use offset | Use cursor |

--- a/docs/guide/pagination.md
+++ b/docs/guide/pagination.md
@@ -212,8 +212,14 @@ Batched iteration inherits the repository's soft-delete filter (trashed rows
 are skipped, matching `find_all`) and its read routing (a replica-routed repo
 iterates off the replica, a `primary_reads` repo off the primary), so backfills
 read off a replica with no extra ceremony. An error mid-iteration surfaces as
-an `AutumnResult` error on the failing batch and stops the iterator; progress
-already yielded is not swallowed.
+an `AutumnResult` error on the failing batch, and errors are **retryable**:
+the keyset cursor only advances on success, so calling `next_batch()` again
+retries the same batch with no duplicated or skipped rows — `Ok(None)` always
+means the table is exhausted, never a swallowed failure.
+
+Iteration ends at the first short batch (fewer than `batch_size` rows); rows
+inserted after that point are not seen by the current handle — start a new
+iteration to pick them up (matching Rails' `find_each`).
 
 ### `find_each` in a task — per-row update
 
@@ -239,11 +245,13 @@ pub async fn backfill_slugs(repo: PgPostRepository) -> AutumnResult<()> {
 Register it with `.one_off_tasks(one_off_tasks![tasks::backfill_slugs])` and run
 `autumn task backfill-slugs` (see the [tasks guide](./tasks.md)).
 
-### `find_in_batches` + `save_many` — recompute loop
+### `find_in_batches` + `upsert_many` — recompute loop
 
 Pair batched reads with the bulk writes from
-[`save_many`](./repositories.md) to recompute a whole table with flat memory on
-both the read and write side:
+[`upsert_many`](./repositories.md) to recompute a whole table with flat memory
+on both the read and write side (`upsert_many` takes existing `&[Model]`
+values and writes them back; `save_many` takes `&[NewModel]` and would insert
+duplicates here):
 
 ```rust
 let mut batches = repo.find_in_batches(1_000);
@@ -255,13 +263,16 @@ while let Some(chunk) = batches.next_batch().await? {
             account
         })
         .collect();
-    repo.save_many(&recomputed).await?; // O(batch_size) memory, not O(table)
+    repo.upsert_many(&recomputed).await?; // O(batch_size) memory, not O(table)
 }
 ```
 
-A `batch_size` of `0` returns an error on the first call rather than spinning.
-On a **sharded** repository, cross-shard `across_tenants()` iteration is
-rejected (mirroring `cursor_page`); iterate a single routed shard instead.
+Note: `upsert_many` is not generated on repositories with hooks configured —
+use per-row `update` there.
+
+A `batch_size` of `0` returns an error rather than spinning. On a **sharded**
+repository, cross-shard `across_tenants()` iteration is rejected (mirroring
+`cursor_page`); iterate each shard separately via `from_shard(...)` instead.
 
 ---
 


### PR DESCRIPTION
## Before / After

**Before:** touching every row of a large table from a task, job, or scheduled sweep meant `find_all()`, which materializes the entire table into one `Vec` — a million-row backfill is an instant OOM.

**After:** every `#[repository]` exposes two streaming iterators that walk the whole table in bounded chunks:

- `find_in_batches(batch_size)` — yields successive `Vec<Model>` chunks of at most `batch_size` rows.
- `find_each(batch_size)` — yields one `Model` at a time, still fetching in `batch_size` chunks under the hood.

Peak memory is `O(batch_size)` regardless of table size — the read-side companion to the bulk writes from #841.

## How

- Iteration is primary-key **keyset**-based (`WHERE id > last ORDER BY id ASC LIMIT batch_size`, no id predicate on the first batch), not `LIMIT`/`OFFSET`, so deep iteration stays flat and mid-iteration mutations can't cause skips.
- The generated `fetch_batch_after` query goes through the exact same soft-delete filter (`sd_filter`), tenant scoping (`tenant_query_filter`), and read-connection acquisition (`__autumn_acquire_read_conn`: replica / `primary_reads` / RYWW pin) as `find_all`/`cursor_page`, so those semantics come for free.
- Generic handle types live in a new `autumn_web::batches` module (`FindInBatches`, `FindEach`, and the `BatchSource` trait); the macro only emits a thin per-repo `BatchSource` impl plus the two constructors.
- Sharded repositories reject cross-shard `across_tenants()` iteration (mirroring `cursor_page`); iterate each shard separately via `from_shard(...)`.
- `batch_size` is deliberately **not** clamped to `MAX_PAGE_SIZE` (100); `batch_size == 0` is surfaced as an internal-server-error on every call (task/job programmer error, not client input).
- Iteration ends at the first short batch; rows inserted after that point require a new iteration (matching Rails' `find_each`).

## Tests

- No-DB unit tests in `autumn_web::batches` with a drop-counting fake source: instrumented high-water-mark residency ≤ `batch_size` for both handles, retry-after-failure resumes with no dupes/gaps, `batch_size == 0` errors on every call.
- No-DB read-routing test: an unready replica under `FailReadiness` makes the first `next_batch()` fail fast with the replica-unavailable error.
- DB integration tests (testcontainers): full coverage/no-dupes/no-gaps, `batch_size > 100`, soft-delete exclusion, tenant scoping, empty table, mid-iteration error retryability, and a mid-iteration mutation test (hard-delete the visited batch + insert ahead of the cursor) that would catch any `LIMIT`/`OFFSET` regression.
- Docs: new "Batched iteration" section in the pagination guide; CHANGELOG bullet under Unreleased.

## Design notes / deviations from issue text

1. **Inherent methods, not trait methods.** `find_in_batches`/`find_each` are generated as inherent methods on the `Pg*` struct (precedent: `with_lock`, `preload`) rather than on the repository trait — trait placement would force `Sized + BatchSource` bounds onto every trait object/generic bound and reintroduce RPITIT `Send` hazards for callers.
2. **Doc example uses `upsert_many`, not `save_many`.** `save_many` takes `&[NewModel]` and INSERTs — a recompute loop over existing rows would insert duplicates. `upsert_many` takes `&[Model]` and writes them back. (`upsert_many` is not generated on hooked repositories; use per-row `update` there.)
3. **Fresh keyset path rather than literal `CursorRequest` reuse.** `CursorRequest` clamps page size to `MAX_PAGE_SIZE = 100`, which is wrong for server-side backfills; the iterators share the same filter/routing codepaths but issue their own unclamped keyset query.
4. **Retryable error semantics.** The keyset cursor only advances on success, so after an `Err` a retrying caller can call `next_batch()` again and resume the same batch with no duplicated or skipped rows. `Ok(None)` always means the table is exhausted — a failed run is never mistaken for a completed one.
5. **DB tests are `#[ignore]`-gated on Docker** (testcontainers) and were compile-verified in this environment (no Docker available); the no-DB routing and residency tests run unconditionally.

Closes #1395

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDLaSooQLLj1k9uw1JrHx9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDLaSooQLLj1k9uw1JrHx9)_