### PR TITLE
Add widget storybook: browsable gallery + CI anti-rot harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **views:** widget storybook (issue #1526) — a browsable gallery of every
+  built-in maud widget plus a CI anti-rot harness. `autumn_web::stories`
+  ships `Story`/`StoryRegistry`/`StoryGallery` (mirroring the mail-preview
+  registry), a `story!{ group, name, { ... } }` macro whose block is **both**
+  executed for the live render and captured byte-for-byte (comments and
+  formatting included) as the displayed snippet — so the shown code is
+  provably the code that rendered — and `stories::builtin()` with a story for
+  every gallery-visible widget. Stories are zero-arg pure `fn() -> Markup`
+  pointers: capturing a `Db` handle, `AppState`, or any local is a compile
+  error. Mount with `.with_story_gallery(StoryGallery::builtin())` — routes
+  at `GET /_stories` (grouped index) and `GET /_stories/{slug}` (live render
+  + Source + Rendered HTML tabs, dogfooding the `tabs` widget and styled by
+  the framework widget stylesheet) are **off by default** and opt in per
+  profile via `[stories] enabled = true` (e.g. `[profile.dev.stories]` for a
+  dev-only gallery, or a prod profile for a public showcase; `/_stories` is
+  404 wherever the resolved flag is false; `AUTUMN_STORIES__ENABLED`
+  overrides from the environment). Apps register their own widgets with the
+  same `story!` macro via `StoryGallery::builtin().extend(...)` or a
+  builtin-free `StoryGallery::new()`. CI renders every builtin story
+  (panic-free, non-empty, balanced HTML, unique slugs) and a two-layer
+  coverage gate fails the build when a widget in `widgets.rs` gains no story.
+  See `docs/guide/stories.md`.
+
 - **generator:** `autumn generate scaffold`'s `create`/`update` handlers now
   build a `Changeset` from the submission and re-render the `new`/`edit`
   form on a rejected submission (issue #1124). A failed submission responds

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ See [EXAMPLES.md](EXAMPLES.md) for the full catalog with personas, journeys, pre
 - [Operating Background Jobs](docs/guide/operating-background-jobs.md) - admin dashboard and recovery actions for `#[job]`
 - [Exposing Your API as MCP Tools](docs/guide/mcp.md) — project typed endpoints into a Model Context Protocol server with `#[api_doc(mcp)]` + `mount_mcp`
 - [Mail Guide](docs/guide/mail.md)
+- [Widget Stories](docs/guide/stories.md) — the `/_stories` widget gallery and the `story!` macro
 - [View Formatting Helpers](docs/guide/format-helpers.md) — `number_to_currency`, `pluralize`, `truncate`, `time_ago_in_words`, and friends for Maud templates
 - [Cloud-Native Guide](docs/guide/cloud-native.md)
 - [Logging & PII](docs/guide/logging-pii.md)

--- a/autumn-macros/src/lib.rs
+++ b/autumn-macros/src/lib.rs
@@ -45,6 +45,7 @@ mod service;
 mod static_route;
 mod static_routes_macro;
 mod step_up;
+mod story_macro;
 mod tasks_macro;
 mod ws;
 

--- a/autumn-macros/src/lib.rs
+++ b/autumn-macros/src/lib.rs
@@ -289,6 +289,20 @@ pub fn mail_previews(input: TokenStream) -> TokenStream {
     mail_previews_macro::mail_previews_macro(input.into()).into()
 }
 
+/// Define a widget story for the `/_stories` gallery:
+/// `story!{ "Group", "Name", { ... } }`.
+///
+/// The brace-delimited block is **both** executed for the live render and
+/// captured byte-for-byte (comments and formatting included) as the displayed
+/// source snippet, so the shown code is provably the code that rendered. The
+/// block must be a self-contained expression evaluating to `maud::Markup`:
+/// it is coerced to a plain `fn() -> Markup`, so capturing anything from the
+/// surrounding environment is a compile error.
+#[proc_macro]
+pub fn story(input: TokenStream) -> TokenStream {
+    story_macro::story_macro(input.into()).into()
+}
+
 /// Attribute macro for Autumn database models.
 ///
 /// Applies Diesel (`Queryable`, `Selectable`, `Insertable`) and Serde

--- a/autumn-macros/src/story_macro.rs
+++ b/autumn-macros/src/story_macro.rs
@@ -1,0 +1,92 @@
+//! `story!{ group, name, { ... } }` proc macro implementation (issue #1526).
+//!
+//! The macro takes a group string literal, a name string literal, and a
+//! brace-delimited block. The block is **both** executed for the live render
+//! and captured as the displayed source snippet, so the shown code is provably
+//! the code that rendered. Source capture uses `Span::source_text()` on the
+//! brace group (byte-faithful: comments and formatting survive), falling back
+//! to the token-stream rendering when source text is unavailable (e.g. in
+//! proc-macro2 fallback contexts such as unit tests).
+//!
+//! Expansion shape:
+//!
+//! ```ignore
+//! ::autumn_web::stories::Story::new(#group, #name, || #block, #source)
+//! ```
+//!
+//! The `|| #block` closure is coerced to a plain `fn() -> maud::Markup`
+//! pointer by `Story::new`, so any environment capture (a `Db` handle,
+//! `AppState`, request data) is a compile error — stories are zero-arg pure
+//! functions by construction.
+
+#[cfg(test)]
+mod tests {
+    use super::story_macro;
+    use quote::quote;
+
+    // M1 (AC2): the macro expands to `Story::new` carrying the group and name
+    // literals through verbatim.
+    #[test]
+    fn expands_to_story_new_with_group_name() {
+        let out = story_macro(quote! {
+            "Display", "Data table", { maud::html! { p { "demo" } } }
+        });
+        let rendered = out.to_string();
+        assert!(
+            rendered.contains("Story :: new"),
+            "expansion must construct ::autumn_web::stories::Story::new: {rendered}"
+        );
+        assert!(
+            rendered.contains("\"Display\""),
+            "expansion must carry the group literal: {rendered}"
+        );
+        assert!(
+            rendered.contains("\"Data table\""),
+            "expansion must carry the name literal: {rendered}"
+        );
+    }
+
+    // M2 (AC2): missing block and non-literal group/name produce targeted
+    // compile errors instead of opaque downstream failures.
+    #[test]
+    fn rejects_missing_block_and_non_literal_names() {
+        let missing_block = story_macro(quote! { "Display", "Data table" }).to_string();
+        assert!(
+            missing_block.contains("compile_error"),
+            "missing block must produce a compile error: {missing_block}"
+        );
+        assert!(
+            missing_block.contains("block"),
+            "missing-block error should mention the expected block: {missing_block}"
+        );
+
+        let non_literal =
+            story_macro(quote! { Display, "Data table", { maud::html! { p { "x" } } } })
+                .to_string();
+        assert!(
+            non_literal.contains("compile_error"),
+            "non-literal group must produce a compile error: {non_literal}"
+        );
+        assert!(
+            non_literal.contains("string literal"),
+            "non-literal error should ask for a string literal: {non_literal}"
+        );
+    }
+
+    // M3 (AC2, R14): when `Span::source_text()` is unavailable (always the
+    // case for proc-macro2 fallback spans, i.e. in this unit test), the
+    // emitted source literal falls back to the token-stream rendering of the
+    // block instead of an empty snippet.
+    #[test]
+    fn falls_back_to_token_stream_when_no_source_text() {
+        let block = quote! { maud::html! { p { "fallback-proof" } } };
+        let out = story_macro(quote! { "Display", "Fallback", { #block } });
+        let rendered = out.to_string();
+        let expected_literal = proc_macro2::Literal::string(&block.to_string()).to_string();
+        assert!(
+            rendered.contains(&expected_literal),
+            "with no source text available the source literal must equal the \
+             token rendering of the block\nexpected literal: {expected_literal}\nexpansion: {rendered}"
+        );
+    }
+}

--- a/autumn-macros/src/story_macro.rs
+++ b/autumn-macros/src/story_macro.rs
@@ -19,6 +19,153 @@
 //! `AppState`, request data) is a compile error — stories are zero-arg pure
 //! functions by construction.
 
+use proc_macro2::{Delimiter, Group, Span, TokenStream, TokenTree};
+use quote::quote;
+
+/// Expand `story!{ group, name, { ... } }` into a
+/// `::autumn_web::stories::Story::new(...)` constructor call.
+pub fn story_macro(input: TokenStream) -> TokenStream {
+    match expand(input) {
+        Ok(expanded) => expanded,
+        Err(error) => error.to_compile_error(),
+    }
+}
+
+fn expand(input: TokenStream) -> syn::Result<TokenStream> {
+    let mut tokens = input.into_iter();
+
+    let group_lit = parse_string_literal(tokens.next(), "group")?;
+    expect_comma(tokens.next(), "the story group")?;
+    let name_lit = parse_string_literal(tokens.next(), "name")?;
+    expect_comma(tokens.next(), "the story name")?;
+    let block_group = parse_block_group(tokens.next())?;
+
+    // Allow one trailing comma, then reject anything else.
+    match tokens.next() {
+        None => {}
+        Some(TokenTree::Punct(punct)) if punct.as_char() == ',' => {
+            if let Some(extra) = tokens.next() {
+                return Err(syn::Error::new(
+                    extra.span(),
+                    "unexpected tokens after the story block: \
+                     story!{ \"Group\", \"Name\", { ... } } takes exactly three arguments",
+                ));
+            }
+        }
+        Some(extra) => {
+            return Err(syn::Error::new(
+                extra.span(),
+                "unexpected tokens after the story block: \
+                 story!{ \"Group\", \"Name\", { ... } } takes exactly three arguments",
+            ));
+        }
+    }
+
+    // Validate the block parses as a real Rust block so authors get a
+    // span-correct error here instead of a confusing downstream one.
+    let block: syn::Block = syn::parse2(TokenStream::from(TokenTree::Group(block_group.clone())))?;
+
+    // Source capture: byte-faithful `Span::source_text()` on the brace group
+    // (comments and formatting survive), falling back to the token-stream
+    // rendering when source text is unavailable (proc-macro2 fallback spans).
+    let source = block_group.span().source_text().map_or_else(
+        || block_group.stream().to_string(),
+        |text| dedent_block_source(&text),
+    );
+    let source_lit = proc_macro2::Literal::string(&source);
+
+    // `|| #block` is coerced to a plain `fn() -> maud::Markup` pointer by
+    // `Story::new`, so any environment capture is a compile error.
+    Ok(quote! {
+        ::autumn_web::stories::Story::new(#group_lit, #name_lit, || #block, #source_lit)
+    })
+}
+
+fn parse_string_literal(token: Option<TokenTree>, what: &str) -> syn::Result<syn::LitStr> {
+    let Some(token) = token else {
+        return Err(syn::Error::new(
+            Span::call_site(),
+            format!(
+                "expected a string literal for the story {what}: story!{{ \"Group\", \"Name\", {{ ... }} }}"
+            ),
+        ));
+    };
+    let span = token.span();
+    syn::parse2::<syn::LitStr>(TokenStream::from(token)).map_err(|_| {
+        syn::Error::new(
+            span,
+            format!("expected a string literal for the story {what}: story!{{ \"Group\", \"Name\", {{ ... }} }}"),
+        )
+    })
+}
+
+fn expect_comma(token: Option<TokenTree>, after: &str) -> syn::Result<()> {
+    match token {
+        Some(TokenTree::Punct(punct)) if punct.as_char() == ',' => Ok(()),
+        Some(other) => Err(syn::Error::new(
+            other.span(),
+            format!("expected `,` after {after}"),
+        )),
+        None => Err(syn::Error::new(
+            Span::call_site(),
+            format!("expected `,` after {after}, then a brace-delimited block"),
+        )),
+    }
+}
+
+fn parse_block_group(token: Option<TokenTree>) -> syn::Result<Group> {
+    match token {
+        Some(TokenTree::Group(group)) if group.delimiter() == Delimiter::Brace => Ok(group),
+        Some(other) => Err(syn::Error::new(
+            other.span(),
+            "expected a brace-delimited block as the story body: \
+             story!{ \"Group\", \"Name\", { ... } }",
+        )),
+        None => Err(syn::Error::new(
+            Span::call_site(),
+            "missing the story body: expected a brace-delimited block as the third \
+             argument, story!{ \"Group\", \"Name\", { ... } }",
+        )),
+    }
+}
+
+/// Turn the captured `{ ... }` source text into a display-ready snippet:
+/// strip the outer braces, drop blank leading/trailing lines, and remove the
+/// common leading indentation so the snippet reads as top-level code.
+fn dedent_block_source(text: &str) -> String {
+    let inner = text.trim();
+    let inner = inner.strip_prefix('{').unwrap_or(inner);
+    let inner = inner.strip_suffix('}').unwrap_or(inner);
+
+    let lines: Vec<&str> = inner.lines().collect();
+    let first = lines.iter().position(|line| !line.trim().is_empty());
+    let Some(first) = first else {
+        return inner.trim().to_owned();
+    };
+    let last = lines
+        .iter()
+        .rposition(|line| !line.trim().is_empty())
+        .unwrap_or(first);
+    let lines = &lines[first..=last];
+
+    if lines.len() == 1 {
+        return lines[0].trim().to_owned();
+    }
+
+    let indent = lines
+        .iter()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| line.len() - line.trim_start().len())
+        .min()
+        .unwrap_or(0);
+
+    lines
+        .iter()
+        .map(|line| line.get(indent..).unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 #[cfg(test)]
 mod tests {
     use super::story_macro;

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -131,6 +131,8 @@ pub fn app() -> AppBuilder {
         mount_unsubscribe_endpoint: false,
         #[cfg(feature = "mail")]
         mail_previews: Vec::new(),
+        #[cfg(feature = "maud")]
+        story_gallery: None,
         declared_routes: Vec::new(),
         idempotency_enabled: false,
         #[cfg(feature = "mail")]
@@ -386,6 +388,9 @@ pub struct AppBuilder {
     /// Mail template previews registered for the dev preview UI.
     #[cfg(feature = "mail")]
     mail_previews: Vec<crate::mail::MailPreview>,
+    /// Widget story gallery registered for the `/_stories` UI (#1526).
+    #[cfg(feature = "maud")]
+    story_gallery: Option<crate::stories::StoryGallery>,
     /// Routes explicitly declared by plugins for listing purposes, to complement
     /// opaque `nest_routers`. Included in `autumn routes` output even though
     /// the underlying Axum router is not enumerable.
@@ -2151,6 +2156,21 @@ impl AppBuilder {
         self
     }
 
+    /// Register the widget story gallery served at `/_stories` (#1526).
+    ///
+    /// Routes mount only when the resolved config has `[stories] enabled =
+    /// true` (off by default, opt-in per profile). Start from
+    /// [`StoryGallery::builtin`](crate::stories::StoryGallery::builtin) for
+    /// the framework widget set and
+    /// [`extend`](crate::stories::StoryGallery::extend) it with your app's
+    /// own `story!{...}` entries. See `docs/guide/stories.md`.
+    #[cfg(feature = "maud")]
+    #[must_use]
+    pub fn with_story_gallery(mut self, gallery: crate::stories::StoryGallery) -> Self {
+        self.story_gallery = Some(gallery);
+        self
+    }
+
     /// Register an additional audit sink for structured audit events.
     ///
     /// Multiple calls accumulate sinks. Logged events are fanned out to all
@@ -2578,6 +2598,8 @@ impl AppBuilder {
             mount_unsubscribe_endpoint,
             #[cfg(feature = "mail")]
             mail_previews,
+            #[cfg(feature = "maud")]
+            story_gallery,
             declared_routes: _,
             idempotency_enabled,
             #[cfg(feature = "mail")]
@@ -2951,6 +2973,10 @@ impl AppBuilder {
         });
         #[cfg(feature = "mail")]
         state.insert_extension(crate::mail::MailPreviewRegistry::new(mail_previews));
+        #[cfg(feature = "maud")]
+        if let Some(gallery) = story_gallery {
+            state.insert_extension(gallery.into_registry());
+        }
         if let Some(logger) = audit_logger {
             state.insert_extension::<crate::audit::AuditLogger>((*logger).clone());
         }
@@ -3643,6 +3669,8 @@ impl AppBuilder {
             mount_unsubscribe_endpoint,
             #[cfg(feature = "mail")]
             mail_previews,
+            #[cfg(feature = "maud")]
+            story_gallery,
             declared_routes: _,
             idempotency_enabled,
             #[cfg(feature = "mail")]
@@ -3873,6 +3901,10 @@ impl AppBuilder {
         });
         #[cfg(feature = "mail")]
         state.insert_extension(crate::mail::MailPreviewRegistry::new(mail_previews));
+        #[cfg(feature = "maud")]
+        if let Some(gallery) = story_gallery {
+            state.insert_extension(gallery.into_registry());
+        }
         // run_build_mode used ProbeState::default(), which does not start as pending
         state.probes = crate::probe::ProbeState::default();
 

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2974,9 +2974,7 @@ impl AppBuilder {
         #[cfg(feature = "mail")]
         state.insert_extension(crate::mail::MailPreviewRegistry::new(mail_previews));
         #[cfg(feature = "maud")]
-        if let Some(gallery) = story_gallery {
-            state.insert_extension(gallery.into_registry());
-        }
+        install_story_registry(&state, story_gallery);
         if let Some(logger) = audit_logger {
             state.insert_extension::<crate::audit::AuditLogger>((*logger).clone());
         }
@@ -3902,9 +3900,7 @@ impl AppBuilder {
         #[cfg(feature = "mail")]
         state.insert_extension(crate::mail::MailPreviewRegistry::new(mail_previews));
         #[cfg(feature = "maud")]
-        if let Some(gallery) = story_gallery {
-            state.insert_extension(gallery.into_registry());
-        }
+        install_story_registry(&state, story_gallery);
         // run_build_mode used ProbeState::default(), which does not start as pending
         state.probes = crate::probe::ProbeState::default();
 
@@ -7238,6 +7234,17 @@ mod validate_repository_api_policies_tests {
             collect_unregistered_repository_handlers(&[], std::slice::from_ref(&group), &registry);
         assert_eq!(missing.len(), 1);
         assert_eq!(missing[0].0, "TestPost");
+    }
+}
+
+/// Publish the builder's story gallery (if any) as the [`StoryRegistry`]
+/// (`crate::stories::StoryRegistry`) `AppState` extension read by the
+/// `/_stories` handlers. Shared by the `run()` and build/SSG
+/// state-construction paths so the two stay in lockstep.
+#[cfg(feature = "maud")]
+fn install_story_registry(state: &AppState, story_gallery: Option<crate::stories::StoryGallery>) {
+    if let Some(gallery) = story_gallery {
+        state.insert_extension(gallery.into_registry());
     }
 }
 
@@ -10939,6 +10946,60 @@ mod tests {
                 .extension::<crate::http_client::SharedReqwestClient>()
                 .is_some(),
             "build_state must register a SharedReqwestClient for connection-pool sharing"
+        );
+    }
+
+    // AC5 plumbing (#1526): `with_story_gallery` stores the gallery on the
+    // builder, and `install_story_registry` — the single install step shared
+    // by both the run and build/SSG state-construction paths — publishes it
+    // as the StoryRegistry extension the `/_stories` handlers read.
+    #[cfg(feature = "maud")]
+    #[test]
+    fn with_story_gallery_installs_story_registry_extension() {
+        let builder = crate::app().with_story_gallery(crate::stories::StoryGallery::builtin());
+        let gallery = builder
+            .story_gallery
+            .expect("with_story_gallery must store the gallery on the builder");
+        let expected_count = gallery.stories().len();
+        assert!(expected_count > 0, "builtin gallery must not be empty");
+
+        let config = AutumnConfig::default();
+        let state = build_state(
+            &config,
+            #[cfg(feature = "db")]
+            None,
+            #[cfg(feature = "db")]
+            None,
+            #[cfg(feature = "ws")]
+            None,
+        );
+        install_story_registry(&state, Some(gallery));
+        let registry = state
+            .extension::<crate::stories::StoryRegistry>()
+            .expect("install_story_registry must publish the StoryRegistry extension");
+        assert_eq!(
+            registry.stories().len(),
+            expected_count,
+            "every registered story must reach the state extension"
+        );
+
+        // Without a registered gallery no extension is installed: the
+        // handlers fall back to the empty default and serve the empty state.
+        let bare_state = build_state(
+            &config,
+            #[cfg(feature = "db")]
+            None,
+            #[cfg(feature = "db")]
+            None,
+            #[cfg(feature = "ws")]
+            None,
+        );
+        install_story_registry(&bare_state, None);
+        assert!(
+            bare_state
+                .extension::<crate::stories::StoryRegistry>()
+                .is_none(),
+            "no gallery registered must mean no StoryRegistry extension"
         );
     }
 }

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -132,6 +132,7 @@
 //! | `AUTUMN_DEV__INSPECTOR_CAPACITY` | `dev.inspector_capacity` | `usize` |
 //! | `AUTUMN_DEV__INSPECTOR_N_PLUS_ONE_THRESHOLD` | `dev.inspector_n_plus_one_threshold` | `usize` |
 //! | `AUTUMN_COMPRESSION__ENABLED` | `compression.enabled` | `bool` |
+//! | `AUTUMN_STORIES__ENABLED` | `stories.enabled` | `bool` |
 //! | `AUTUMN_AUTH__LOCKOUT__ENABLED` | `auth.lockout.enabled` | `bool` |
 //! | `AUTUMN_AUTH__LOCKOUT__THRESHOLD` | `auth.lockout.threshold` | `i32` |
 //! | `AUTUMN_AUTH__LOCKOUT__WINDOW_SECS` | `auth.lockout.window_secs` | `u64` |
@@ -967,6 +968,15 @@ pub struct AutumnConfig {
     /// These settings have no effect outside the `dev` profile.
     #[serde(default)]
     pub dev: DevConfig,
+
+    /// Widget story gallery settings (`[stories]` section in `autumn.toml`).
+    ///
+    /// Off by default; opt-in per profile (e.g. `[profile.dev.stories]
+    /// enabled = true` for a dev-only gallery, or a prod profile for a
+    /// public showcase). See `docs/guide/stories.md`.
+    #[cfg(feature = "maud")]
+    #[serde(default)]
+    pub stories: crate::stories::StoriesConfig,
 
     /// Error-reporting settings (`[reporting]` section in `autumn.toml`).
     ///
@@ -2550,6 +2560,8 @@ impl AutumnConfig {
         self.apply_storage_env_overrides_with_env(env);
         #[cfg(feature = "mail")]
         self.apply_mail_env_overrides_with_env(env);
+        #[cfg(feature = "maud")]
+        self.apply_stories_env_overrides_with_env(env);
         self.apply_resilience_env_overrides_with_env(env);
         self.apply_time_zone_env_overrides_with_env(env);
     }
@@ -2600,6 +2612,11 @@ impl AutumnConfig {
             "AUTUMN_COMPRESSION__ENABLED",
             &mut self.compression.enabled,
         );
+    }
+
+    #[cfg(feature = "maud")]
+    fn apply_stories_env_overrides_with_env(&mut self, env: &dyn Env) {
+        parse_env_bool(env, "AUTUMN_STORIES__ENABLED", &mut self.stories.enabled);
     }
 
     fn apply_actuator_env_overrides_with_env(&mut self, env: &dyn Env) {

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -597,6 +597,12 @@ pub use autumn_macros::mailer_preview;
 /// }
 /// ```
 pub use autumn_macros::main;
+/// Author a widget story for the `/_stories` gallery:
+/// `story!{ "Group", "Name", { ... } }`.
+///
+/// Also available as [`stories::story`], the macro's module home.
+#[cfg(feature = "maud")]
+pub use autumn_macros::story;
 
 /// Derive Diesel and Serde traits for a database model struct.
 ///

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -328,9 +328,10 @@ pub mod links;
 pub mod runtime_config;
 #[cfg(feature = "seed")]
 pub mod seed;
-/// Widget story gallery: browsable `/_stories` UI plus a CI anti-rot
-/// registry of zero-arg widget render examples (issue #1526).
+/// Widget story gallery (issue #1526).
 ///
+/// Browsable `/_stories` UI plus a CI anti-rot registry of zero-arg widget
+/// render examples.
 #[cfg(feature = "maud")]
 pub mod stories;
 pub mod task;

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -328,6 +328,10 @@ pub mod links;
 pub mod runtime_config;
 #[cfg(feature = "seed")]
 pub mod seed;
+/// Widget story gallery: browsable `/_stories` UI plus a CI anti-rot
+/// registry of zero-arg widget render examples (issue #1526).
+#[cfg(feature = "maud")]
+pub mod stories;
 pub mod task;
 pub mod telemetry;
 pub mod ui;

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -330,6 +330,7 @@ pub mod runtime_config;
 pub mod seed;
 /// Widget story gallery: browsable `/_stories` UI plus a CI anti-rot
 /// registry of zero-arg widget render examples (issue #1526).
+///
 #[cfg(feature = "maud")]
 pub mod stories;
 pub mod task;

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -26,6 +26,12 @@
 pub use crate::Redirect;
 /// Typed path helper extension trait (`.with_query()`).
 pub use crate::paths::PathExt;
+/// Widget story gallery types (registered via `AppBuilder::with_story_gallery`).
+#[cfg(feature = "maud")]
+pub use crate::stories::{Story, StoryGallery, StoryRegistry};
+/// Widget story macro for the `/_stories` gallery: `story!{ "Group", "Name", { ... } }`.
+#[cfg(feature = "maud")]
+pub use autumn_macros::story;
 /// WebSocket route macro.
 #[cfg(feature = "ws")]
 pub use autumn_macros::ws;

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -26,12 +26,6 @@
 pub use crate::Redirect;
 /// Typed path helper extension trait (`.with_query()`).
 pub use crate::paths::PathExt;
-/// Widget story gallery types (registered via `AppBuilder::with_story_gallery`).
-#[cfg(feature = "maud")]
-pub use crate::stories::{Story, StoryGallery, StoryRegistry};
-/// Widget story macro for the `/_stories` gallery: `story!{ "Group", "Name", { ... } }`.
-#[cfg(feature = "maud")]
-pub use autumn_macros::story;
 /// WebSocket route macro.
 #[cfg(feature = "ws")]
 pub use autumn_macros::ws;
@@ -194,6 +188,17 @@ pub use crate::widgets::{
     confirm_action, data_table, hero, modal, modal_close_button, modal_trigger, nav_bar, nav_link,
     nav_link_matched, property_list, stat_card, tabs,
 };
+
+// ── Widget stories ───────────────────────────────────────────────
+/// Widget story macro for the `/_stories` gallery: `story!{ "Group", "Name", { ... } }`.
+#[cfg(feature = "maud")]
+pub use crate::stories::story;
+/// Widget story gallery types (registered via `AppBuilder::with_story_gallery`)
+/// and the error returned by `Story::render`.
+///
+/// See [`crate::stories`] for the full API.
+#[cfg(feature = "maud")]
+pub use crate::stories::{Story, StoryGallery, StoryRegistry, StoryRenderError};
 
 // ── Link helpers ─────────────────────────────────────────────────
 /// Safe, method-aware `<a>`/`<form>` link helpers: [`crate::links::link_to`]

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -292,6 +292,27 @@ pub(crate) fn append_framework_routes(
         }
     }
 
+    // Widget story gallery routes (#1526), listed iff the resolved config
+    // enables them (same gating condition as the router mount).
+    #[cfg(feature = "maud")]
+    if config.stories.enabled {
+        for (path, handler) in [
+            (crate::stories::STORIES_PATH, "story_gallery_index"),
+            ("/_stories/{slug}", "story_gallery_story"),
+        ] {
+            infos.push(RouteInfo {
+                method: "GET".to_owned(),
+                path: path.to_owned(),
+                handler: handler.to_owned(),
+                source: RouteSource::Framework,
+                middleware: Vec::new(),
+                api_version: None,
+                status: None,
+                sunset_opt_out: None,
+            });
+        }
+    }
+
     // Dev request inspector routes.
     if matches!(config.profile.as_deref(), Some("dev" | "development")) {
         let inspector_path = &config.dev.inspector_path;

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -737,6 +737,39 @@ mod tests {
         );
     }
 
+    /// T18 (AC5, issue #1526): `autumn routes` introspection lists the story
+    /// gallery endpoints exactly when the resolved config enables them.
+    #[cfg(feature = "maud")]
+    #[test]
+    fn framework_routes_include_stories_when_enabled() {
+        let mut config = AutumnConfig::default();
+        config.stories.enabled = true;
+        let mut infos = Vec::new();
+        append_framework_routes(&mut infos, &config);
+        let paths: Vec<&str> = infos.iter().map(|i| i.path.as_str()).collect();
+        assert!(
+            paths.contains(&crate::stories::STORIES_PATH),
+            "enabled stories must list the index route: {paths:?}"
+        );
+        assert!(
+            paths.contains(&"/_stories/{slug}"),
+            "enabled stories must list the detail route: {paths:?}"
+        );
+
+        let default_config = AutumnConfig::default();
+        let mut infos = Vec::new();
+        append_framework_routes(&mut infos, &default_config);
+        let paths: Vec<&str> = infos.iter().map(|i| i.path.as_str()).collect();
+        assert!(
+            !paths.contains(&"/_stories"),
+            "disabled stories must not be listed: {paths:?}"
+        );
+        assert!(
+            !paths.contains(&"/_stories/{slug}"),
+            "disabled stories must not list the detail route: {paths:?}"
+        );
+    }
+
     // ── join_scope_path ────────────────────────────────────────────────────
 
     #[test]

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -4856,6 +4856,46 @@ enabled = true
         );
     }
 
+    /// Review follow-up (#1526): with `security.headers.csp_nonce.enabled =
+    /// true` the default CSP's `style-src` drops `'unsafe-inline'` in favor of
+    /// a per-request nonce, so the gallery's inline `<style>` must carry the
+    /// exact nonce the CSP header advertises or browsers block all of the
+    /// gallery chrome CSS.
+    #[cfg(feature = "maud")]
+    #[tokio::test]
+    async fn story_pages_inline_style_carries_csp_header_nonce() {
+        let mut config = story_gallery_config();
+        config.security.headers.csp_nonce.enabled = true;
+
+        let router = build_router(Vec::new(), &config, stories_state_with_builtin());
+
+        for uri in ["/_stories", "/_stories/data-table"] {
+            let response = get_with_host(router.clone(), uri).await;
+            assert_eq!(response.status(), StatusCode::OK);
+
+            let csp = response
+                .headers()
+                .get("content-security-policy")
+                .expect("CSP header must be present")
+                .to_str()
+                .unwrap()
+                .to_owned();
+            let nonce = csp
+                .split("'nonce-")
+                .nth(1)
+                .and_then(|rest| rest.split('\'').next())
+                .unwrap_or_else(|| panic!("CSP header must advertise a nonce: {csp}"))
+                .to_owned();
+            assert!(!nonce.is_empty(), "advertised nonce must be non-empty");
+
+            let body = response_text(response).await;
+            assert!(
+                body.contains(&format!(r#"<style nonce="{nonce}">"#)),
+                "{uri} inline style must carry the CSP header nonce {nonce}: {body}"
+            );
+        }
+    }
+
     /// T17 (AC5, R12): enabled config but no registry extension (the user
     /// forgot `with_story_gallery`) serves a friendly empty state, not a 500.
     #[cfg(feature = "maud")]

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -1108,6 +1108,16 @@ fn collect_claimed_get_paths(
         claimed.insert("/_autumn/mail/messages/{message_id}".to_owned());
         claimed.insert("/_autumn/mail/previews/{mailer}/{method}".to_owned());
     }
+    // The widget story gallery merges GETs at `/_stories` and
+    // `/_stories/{slug}` when `stories.enabled` resolves true, before the
+    // late-merged OpenAPI/MCP routers — reserve them so a colliding
+    // configured mount path surfaces the typed collision error instead of
+    // panicking in `router.merge`.
+    #[cfg(feature = "maud")]
+    if config.stories.enabled {
+        claimed.insert(crate::stories::STORIES_PATH.to_owned());
+        claimed.insert("/_stories/{slug}".to_owned());
+    }
     // The default unsubscribe endpoint merges a GET (+POST) at `UNSUBSCRIBE_PATH`
     // before the late-merged OpenAPI/MCP routers, so reserve it too — otherwise an
     // OpenAPI/MCP mount configured at `/_autumn/unsubscribe` passes this preflight
@@ -5618,6 +5628,42 @@ enabled = true
                 field: "openapi_json_path",
                 ref path,
             } if path == crate::job_tracking::JOB_STATUS_ROUTE_PATH
+        ));
+    }
+
+    #[cfg(all(feature = "openapi", feature = "maud"))]
+    #[tokio::test]
+    async fn try_build_router_rejects_openapi_path_on_story_gallery() {
+        // The story gallery merges GETs at `/_stories` (+ `/_stories/{slug}`)
+        // when `stories.enabled` resolves true, before the late-merged
+        // OpenAPI router, so the collision preflight must reserve it —
+        // otherwise mounting OpenAPI there panics in `router.merge` instead
+        // of surfacing the typed collision.
+        let mut config = AutumnConfig::default();
+        config.stories.enabled = true;
+        let openapi = crate::openapi::OpenApiConfig::new("Demo", "1.0.0")
+            .openapi_json_path(crate::stories::STORIES_PATH);
+        let ctx = RouterContext {
+            exception_filters: Vec::new(),
+            scoped_groups: Vec::new(),
+            merge_routers: Vec::new(),
+            nest_routers: Vec::new(),
+            custom_layers: Vec::new(),
+            static_gate_layers: Vec::new(),
+            error_page_renderer: None,
+            session_store: None,
+            openapi: Some(openapi),
+            #[cfg(feature = "mcp")]
+            mcp: None,
+        };
+        let err = super::try_build_router_inner(Vec::new(), &config, test_state(), ctx)
+            .expect_err("story gallery path should be reserved while stories are enabled");
+        assert!(matches!(
+            err,
+            RouterBuildError::OpenApiPathCollision {
+                field: "openapi_json_path",
+                ref path,
+            } if path == crate::stories::STORIES_PATH
         ));
     }
 

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -533,6 +533,8 @@ fn build_router_pre_state(
     // ceiling instead of each getting its own independent (never-shared)
     // counter. See `apply_middleware`'s `load_shed_layer` parameter doc.
     let load_shed_layer = build_load_shed_layer(config, state);
+    #[cfg(feature = "mcp")]
+    let mcp_load_shed_layer = load_shed_layer.clone();
 
     router = apply_middleware(
         router,
@@ -544,7 +546,7 @@ fn build_router_pre_state(
         ctx.error_page_renderer,
         ctx.session_store,
         route_timeouts,
-        load_shed_layer.clone(),
+        load_shed_layer,
     )?;
 
     if dev_reload_enabled {
@@ -666,7 +668,7 @@ fn build_router_pre_state(
             // the envelope below is ALSO wrapped with that same shared layer,
             // a tools/call must mark its replay exempt (avoiding double-
             // counting against the same in-flight counter).
-            envelope_load_shed: load_shed_layer.is_some(),
+            envelope_load_shed: mcp_load_shed_layer.is_some(),
         };
         let mut mcp_router =
             crate::mcp::build_mcp_router(&mount_path, tools, dispatch, wiring, endpoint_layer);
@@ -695,7 +697,7 @@ fn build_router_pre_state(
         // (cloned, sharing its `Arc` in-flight counter) rather than building
         // a second, independently-counting layer — see that call site's
         // comment. `None` (the default) is a no-op, matching direct routes.
-        if let Some(load_shed) = load_shed_layer {
+        if let Some(load_shed) = mcp_load_shed_layer {
             mcp_router = mcp_router.layer(load_shed);
         }
         // Stamp `ResolvedClientIdentity` on the *outer* `/mcp` request too. The
@@ -1559,6 +1561,19 @@ fn mount_framework_routes(
         tracing::debug!(
             path = crate::mail::MAIL_PREVIEW_PATH,
             "Mounted dev mail preview endpoints"
+        );
+    }
+
+    // Widget story gallery (#1526) — off by default, opt-in in ANY profile
+    // via `[stories] enabled = true` (profile-layered). Handlers read the
+    // StoryRegistry from the AppState extension installed by
+    // `AppBuilder::with_story_gallery`.
+    #[cfg(feature = "maud")]
+    if config.stories.enabled {
+        router = router.merge(crate::stories::story_router());
+        tracing::debug!(
+            path = crate::stories::STORIES_PATH,
+            "Mounted story gallery endpoints"
         );
     }
 
@@ -4748,13 +4763,13 @@ mod tests {
     #[tokio::test]
     async fn story_routes_mount_iff_resolved_profile_flag() {
         // Private app: dev-only gallery, absent in prod.
-        let dev_only = r#"
+        let dev_only = r"
 [stories]
 enabled = false
 
 [profile.dev.stories]
 enabled = true
-"#;
+";
         assert_eq!(
             stories_status_for_layered_profile(dev_only, "dev").await,
             StatusCode::OK,
@@ -4767,13 +4782,13 @@ enabled = true
         );
 
         // Public showcase: enabled in prod, absent in dev.
-        let public_showcase = r#"
+        let public_showcase = r"
 [stories]
 enabled = false
 
 [profile.prod.stories]
 enabled = true
-"#;
+";
         assert_eq!(
             stories_status_for_layered_profile(public_showcase, "prod").await,
             StatusCode::OK,

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -4446,7 +4446,7 @@ mod tests {
         config
     }
 
-    #[cfg(feature = "mail")]
+    #[cfg(any(feature = "mail", feature = "maud"))]
     async fn response_text(response: axum::response::Response) -> String {
         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
@@ -4593,6 +4593,258 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    // ── Widget story gallery mount gating (issue #1526) ─────────────────────
+    //
+    // Unlike the dev-only mail preview, `/_stories` is opt-in in ANY profile
+    // via `[stories] enabled = true` (default false): mounting is gated only
+    // on the resolved config flag, while handlers read the `StoryRegistry`
+    // from the AppState extension installed by `with_story_gallery`.
+
+    #[cfg(feature = "maud")]
+    fn story_gallery_config() -> AutumnConfig {
+        let mut config = AutumnConfig::default();
+        config.stories.enabled = true;
+        config.security.trusted_hosts.hosts = vec!["example.com".to_owned()];
+        config
+    }
+
+    #[cfg(feature = "maud")]
+    fn stories_state_with_builtin() -> AppState {
+        let state = test_state();
+        state.insert_extension(crate::stories::builtin());
+        state
+    }
+
+    #[cfg(feature = "maud")]
+    async fn get_with_host(router: axum::Router, uri: &str) -> axum::response::Response {
+        router
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .header("host", "example.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    /// T1 (AC4/AC5): with `[stories] enabled = true` and the builtin registry
+    /// installed, the grouped index is served at `/_stories` and pulls in the
+    /// framework widget stylesheet.
+    #[cfg(feature = "maud")]
+    #[tokio::test]
+    async fn build_router_mounts_story_gallery_when_enabled() {
+        let router = build_router(
+            Vec::new(),
+            &story_gallery_config(),
+            stories_state_with_builtin(),
+        );
+
+        let response = get_with_host(router, crate::stories::STORIES_PATH).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_text(response).await;
+        assert!(
+            body.contains("Data table"),
+            "index should list builtin story names: {body}"
+        );
+        assert!(
+            body.contains("autumn-widgets.css"),
+            "index should link the framework widget stylesheet: {body}"
+        );
+    }
+
+    /// T2 (AC4): the detail route serves the live render plus Source and
+    /// Rendered HTML tabs.
+    #[cfg(feature = "maud")]
+    #[tokio::test]
+    async fn story_detail_route_serves_render_source_and_html() {
+        let router = build_router(
+            Vec::new(),
+            &story_gallery_config(),
+            stories_state_with_builtin(),
+        );
+
+        let response = get_with_host(router, "/_stories/data-table").await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_text(response).await;
+        assert!(
+            body.contains("<table"),
+            "detail page must contain the live data_table render: {body}"
+        );
+        assert!(
+            body.contains("data_table("),
+            "detail page must show the source snippet that produced the render: {body}"
+        );
+        assert!(
+            body.contains("Rendered HTML"),
+            "detail page must offer the rendered-HTML tab: {body}"
+        );
+        assert!(
+            body.contains("Source"),
+            "detail page must offer the source tab: {body}"
+        );
+    }
+
+    /// T3 (AC4): a mounted gallery 404s unknown slugs while the index stays up.
+    #[cfg(feature = "maud")]
+    #[tokio::test]
+    async fn story_detail_unknown_slug_is_404() {
+        let router = build_router(
+            Vec::new(),
+            &story_gallery_config(),
+            stories_state_with_builtin(),
+        );
+
+        let missing = get_with_host(router.clone(), "/_stories/nope").await;
+        assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+
+        let index = get_with_host(router, "/_stories").await;
+        assert_eq!(
+            index.status(),
+            StatusCode::OK,
+            "index route must exist even when a slug misses"
+        );
+    }
+
+    /// T4 (AC5/AC6): off by default — no `[stories] enabled = true`, no
+    /// routes, even when a registry extension is installed.
+    #[cfg(feature = "maud")]
+    #[tokio::test]
+    async fn build_router_omits_story_gallery_by_default() {
+        let mut config = AutumnConfig::default();
+        assert!(
+            !config.stories.enabled,
+            "stories gallery must be off by default"
+        );
+        config.security.trusted_hosts.hosts = vec!["example.com".to_owned()];
+
+        let router = build_router(Vec::new(), &config, stories_state_with_builtin());
+        let response = get_with_host(router, "/_stories").await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// Loads a layered `autumn.toml` for `profile` via `MockEnv` (no process
+    /// env, no `set_current_dir`) and reports the status `/_stories` returns.
+    #[cfg(feature = "maud")]
+    async fn stories_status_for_layered_profile(toml: &str, profile: &str) -> StatusCode {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("autumn.toml"), toml).expect("write autumn.toml");
+        let env = crate::config::MockEnv::new()
+            .with("AUTUMN_MANIFEST_DIR", dir.path().to_str().unwrap())
+            .with("AUTUMN_ENV", profile);
+        let mut config = AutumnConfig::load_with_env(&env).expect("layered config should load");
+        config.security.trusted_hosts.hosts = vec!["example.com".to_owned()];
+
+        let router = build_router(Vec::new(), &config, stories_state_with_builtin());
+        get_with_host(router, "/_stories").await.status()
+    }
+
+    /// T5 (AC6): profile-scoped gating works both ways through the existing
+    /// config layering — routes mount iff the resolved flag is true.
+    #[cfg(feature = "maud")]
+    #[tokio::test]
+    async fn story_routes_mount_iff_resolved_profile_flag() {
+        // Private app: dev-only gallery, absent in prod.
+        let dev_only = r#"
+[stories]
+enabled = false
+
+[profile.dev.stories]
+enabled = true
+"#;
+        assert_eq!(
+            stories_status_for_layered_profile(dev_only, "dev").await,
+            StatusCode::OK,
+            "dev profile override must mount the gallery"
+        );
+        assert_eq!(
+            stories_status_for_layered_profile(dev_only, "prod").await,
+            StatusCode::NOT_FOUND,
+            "prod must not mount the gallery when only dev enables it"
+        );
+
+        // Public showcase: enabled in prod, absent in dev.
+        let public_showcase = r#"
+[stories]
+enabled = false
+
+[profile.prod.stories]
+enabled = true
+"#;
+        assert_eq!(
+            stories_status_for_layered_profile(public_showcase, "prod").await,
+            StatusCode::OK,
+            "prod profile override must mount the gallery for a public showcase"
+        );
+        assert_eq!(
+            stories_status_for_layered_profile(public_showcase, "dev").await,
+            StatusCode::NOT_FOUND,
+            "dev must not mount the gallery when only prod enables it"
+        );
+    }
+
+    /// T6 (AC7): a custom app story registered via
+    /// `StoryGallery::builtin().extend(...)` is served alongside builtins.
+    #[cfg(feature = "maud")]
+    #[tokio::test]
+    async fn custom_story_served_alongside_builtins() {
+        let custom = crate::stories::story! {
+            "App",
+            "Badge",
+            {
+                maud::html! { span class="app-badge" { "hi from the app" } }
+            }
+        };
+        let state = test_state();
+        state.insert_extension(
+            crate::stories::StoryGallery::builtin()
+                .extend([custom])
+                .into_registry(),
+        );
+
+        let router = build_router(Vec::new(), &story_gallery_config(), state);
+
+        let detail = get_with_host(router.clone(), "/_stories/badge").await;
+        assert_eq!(detail.status(), StatusCode::OK);
+        let body = response_text(detail).await;
+        assert!(
+            body.contains("hi from the app"),
+            "custom story must render at its slug: {body}"
+        );
+
+        let index = get_with_host(router, "/_stories").await;
+        let body = response_text(index).await;
+        assert!(
+            body.contains("Badge"),
+            "index must list the custom story: {body}"
+        );
+        assert!(
+            body.contains("App"),
+            "index must show the custom story's group: {body}"
+        );
+        assert!(
+            body.contains("Data table"),
+            "builtins must still be listed alongside the custom story: {body}"
+        );
+    }
+
+    /// T17 (AC5, R12): enabled config but no registry extension (the user
+    /// forgot `with_story_gallery`) serves a friendly empty state, not a 500.
+    #[cfg(feature = "maud")]
+    #[tokio::test]
+    async fn enabled_without_registry_shows_empty_state() {
+        let router = build_router(Vec::new(), &story_gallery_config(), test_state());
+
+        let response = get_with_host(router, "/_stories").await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_text(response).await;
+        assert!(
+            body.contains("with_story_gallery"),
+            "empty state should point at AppBuilder::with_story_gallery: {body}"
+        );
     }
 
     #[tokio::test]

--- a/autumn/src/security/headers.rs
+++ b/autumn/src/security/headers.rs
@@ -89,6 +89,14 @@ impl CspNonce {
     pub fn value(&self) -> &str {
         &self.0
     }
+
+    /// Construct a nonce with a known value for unit tests elsewhere in the
+    /// crate (e.g. the story gallery's nonce-threading tests); production
+    /// nonces are only ever minted by [`SecurityHeadersLayer`].
+    #[cfg(test)]
+    pub(crate) fn new_for_tests(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
 }
 
 impl<S> FromRequestParts<S> for CspNonce

--- a/autumn/src/stories/builtin.rs
+++ b/autumn/src/stories/builtin.rs
@@ -1,0 +1,248 @@
+//! Built-in widget stories: one story per gallery-visible widget in
+//! [`crate::widgets`] (issue #1526).
+//!
+//! Every story is authored with the [`story!`](crate::stories::story) macro,
+//! so the snippet shown in the gallery is byte-for-byte the code that
+//! rendered. Blocks are self-contained (demo data is defined inside), because
+//! they are coerced to zero-arg `fn() -> Markup` pointers — no environment
+//! capture compiles.
+//!
+//! The CI coverage gate (`autumn/tests/integration/stories.rs`) enforces that
+//! every public widget fn in `src/widgets.rs` is exercised by at least one
+//! story's source. When you add a widget, add (or extend) a story here and
+//! add the new top-level widget's slug to `EXPECTED_STORY_SLUGS` in that test.
+
+use super::{Story, story};
+
+/// The built-in story set, in gallery display order.
+#[allow(clippy::too_many_lines)]
+pub(super) fn builtin_stories() -> Vec<Story> {
+    vec![
+        story! {
+            "Forms",
+            "Active search",
+            {
+                use autumn_web::widgets::{
+                    ActiveSearchConfig, active_search, active_search_empty_state,
+                    active_search_input, active_search_results,
+                };
+
+                let config = ActiveSearchConfig::new("/search", "#post-search-results")
+                    .placeholder("Search posts…");
+                maud::html! {
+                    (active_search("post-search", "Search posts", &config))
+                    // What your handler returns when nothing matches:
+                    (active_search_empty_state("No posts matched your search."))
+                    // Compose the pieces yourself when you need custom layout
+                    // between the input and the results container:
+                    div {
+                        (active_search_input("post-search-split", "Search posts", &config))
+                        (active_search_results("post-search-split"))
+                    }
+                }
+            }
+        },
+        story! {
+            "Forms",
+            "Autocomplete",
+            {
+                use autumn_web::widgets::{
+                    AutocompleteConfig, autocomplete_empty_state, autocomplete_input,
+                    autocomplete_option,
+                };
+
+                let config = AutocompleteConfig::new("/tags/search", "tag_id")
+                    .placeholder("Start typing a tag…");
+                maud::html! {
+                    (autocomplete_input("tag-picker", "Tag", &config))
+                    // One matching option, as your handler would render it:
+                    (autocomplete_option("42", "rust"))
+                    // And the empty state when nothing matches:
+                    (autocomplete_empty_state("No matching tags."))
+                }
+            }
+        },
+        story! {
+            "Display",
+            "Property list",
+            {
+                use autumn_web::widgets::property_list;
+
+                property_list(&[
+                    ("Title", maud::html! { "Autumn in Practice" }),
+                    ("Status", maud::html! { strong { "Published" } }),
+                    ("Views", maud::html! { "1,024" }),
+                ])
+            }
+        },
+        story! {
+            "Display",
+            "Data table",
+            {
+                use autumn_web::widgets::{Column, DataTableConfig, data_table};
+
+                struct Book {
+                    title: &'static str,
+                    author: &'static str,
+                    year: u16,
+                }
+                let books = [
+                    Book { title: "The Long Autumn", author: "R. Ellis", year: 2021 },
+                    Book { title: "Falling Leaves", author: "M. Okafor", year: 2023 },
+                ];
+                let columns = [
+                    Column::new("Title", |b: &Book| maud::html! { (b.title) })
+                        .sortable("title"),
+                    Column::new("Author", |b: &Book| maud::html! { (b.author) }),
+                    Column::new("Year", |b: &Book| maud::html! { (b.year) }),
+                ];
+                let config = DataTableConfig::new("No books yet.")
+                    .caption("Books")
+                    .base_path("/books");
+                data_table(&books, &columns, &config)
+            }
+        },
+        story! {
+            "Display",
+            "Breadcrumb",
+            {
+                use autumn_web::widgets::{Crumb, breadcrumb};
+
+                breadcrumb(&[
+                    Crumb::link("Home", "/"),
+                    Crumb::link("Posts", "/posts"),
+                    Crumb::current("My Post"),
+                ])
+            }
+        },
+        story! {
+            "Display",
+            "Card",
+            {
+                use autumn_web::widgets::{CardConfig, card};
+
+                let body = maud::html! { p { "Ship features, not boilerplate." } };
+                let config = CardConfig::new()
+                    .title("Release notes")
+                    .footer(maud::html! { a href="/changelog" { "Read the changelog" } });
+                card(&body, &config)
+            }
+        },
+        story! {
+            "Display",
+            "Stat card",
+            {
+                use autumn_web::widgets::stat_card;
+
+                maud::html! {
+                    (stat_card("Subscribers", "1,024", Some(("/subscribers", "View all"))))
+                    (stat_card("Open rate", "62%", None))
+                }
+            }
+        },
+        story! {
+            "Display",
+            "Tabs",
+            {
+                use autumn_web::widgets::tabs;
+
+                let panels = [
+                    ("demo-profile", "Profile", maud::html! { p { "Profile settings" } }),
+                    ("demo-security", "Security", maud::html! { p { "Security settings" } }),
+                    ("demo-billing", "Billing", maud::html! { p { "Billing settings" } }),
+                ];
+                tabs("settings-tabs", &panels)
+            }
+        },
+        story! {
+            "Navigation",
+            "Nav bar",
+            {
+                use autumn_web::widgets::{NavBarConfig, NavItem, NavMenu, nav_bar};
+
+                let config = NavBarConfig::new()
+                    .brand("Acme", "/")
+                    .item(NavItem::link("/", "Home"))
+                    .item(NavItem::link("/posts", "Posts"))
+                    .item(NavItem::menu(
+                        NavMenu::new("More")
+                            .link("/about", "About")
+                            .plain_link("https://docs.example.com", "Docs"),
+                    ))
+                    .trailing(NavItem::plain_link("/login", "Sign in"));
+                // "/posts" is the current request path, so that link is active.
+                nav_bar("/posts", &config)
+            }
+        },
+        story! {
+            "Navigation",
+            "Nav link",
+            {
+                use autumn_web::widgets::{NavLinkMatch, nav_link, nav_link_matched};
+
+                maud::html! {
+                    nav {
+                        // Exact match: active only on "/posts" itself.
+                        (nav_link("/posts", "/posts", "Posts"))
+                        // Prefix match: "/posts/3/edit" keeps "All posts" active.
+                        (nav_link_matched("/posts/3/edit", "/posts", "All posts", NavLinkMatch::Prefix))
+                        (nav_link("/posts", "/about", "About"))
+                    }
+                }
+            }
+        },
+        story! {
+            "Marketing",
+            "Hero",
+            {
+                use autumn_web::widgets::{Cta, HeroConfig, hero};
+
+                let config = HeroConfig::new("Welcome to the Blog")
+                    .subtitle("Thoughts, tutorials, and stories.")
+                    .cta(Cta::primary("New post", "/admin/new"))
+                    .cta(Cta::secondary("About", "/about"));
+                hero(&config)
+            }
+        },
+        story! {
+            "Overlays",
+            "Modal",
+            {
+                use autumn_web::widgets::{
+                    ModalConfig, modal, modal_close_button, modal_trigger,
+                };
+
+                let body = maud::html! { p { "This action cannot be undone." } };
+                let config = ModalConfig::new()
+                    .footer(maud::html! {
+                        (modal_close_button("Cancel", "delete-confirm", None))
+                    })
+                    .light_dismiss(true);
+                maud::html! {
+                    (modal_trigger("Delete post", "delete-confirm", None))
+                    (modal("delete-confirm", "Delete this post?", &body, &config))
+                }
+            }
+        },
+        story! {
+            "Overlays",
+            "Confirm action",
+            {
+                use autumn_web::widgets::{ConfirmActionConfig, confirm_action};
+
+                let config = ConfirmActionConfig::new()
+                    .title("Delete this post?")
+                    .message(maud::html! { p { "This permanently removes the post." } })
+                    .confirm_label("Delete post");
+                confirm_action(
+                    "delete-post",
+                    "Delete…",
+                    "/posts/42",
+                    http::Method::DELETE,
+                    "demo-csrf-token",
+                    &config,
+                )
+            }
+        },
+    ]
+}

--- a/autumn/src/stories/builtin.rs
+++ b/autumn/src/stories/builtin.rs
@@ -234,10 +234,13 @@ pub(super) fn builtin_stories() -> Vec<Story> {
                     .title("Delete this post?")
                     .message(maud::html! { p { "This permanently removes the post." } })
                     .confirm_label("Delete post");
+                // The rendered form is live, so this demo points it at a
+                // synthetic target (nothing is mounted there — submitting on
+                // a served gallery is a 404 no-op) with a fake CSRF token.
                 confirm_action(
                     "delete-post",
                     "Delete…",
-                    "/posts/42",
+                    "/_stories/demo/delete-post",
                     http::Method::DELETE,
                     "demo-csrf-token",
                     &config,

--- a/autumn/src/stories/mod.rs
+++ b/autumn/src/stories/mod.rs
@@ -737,4 +737,155 @@ mod tests {
             "empty state must explain how to register stories: {page}"
         );
     }
+
+    // ── Strict balanced-HTML check over the gallery chrome ──────────────
+    //
+    // The integration harness (tests/integration/stories.rs) runs this
+    // discipline over each story *fragment*; the full index/detail pages can
+    // only be rendered here (`render_story_*` are private), so a minimal
+    // copy of the strict checker lives in this module too. Unlike the
+    // lenient `crate::test_html` parser, it refuses auto-closing.
+
+    /// Panics when `html` is not well-formed (mismatched, unclosed, or
+    /// stray-closed tags).
+    fn assert_balanced_html(html: &str, context: &str) {
+        const VOID_ELEMENTS: &[&str] = &[
+            "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param",
+            "source", "track", "wbr",
+        ];
+        const RAW_TEXT_ELEMENTS: &[&str] = &["script", "style", "textarea", "title"];
+
+        let bytes = html.as_bytes();
+        let mut stack: Vec<String> = Vec::new();
+        let mut i = 0;
+
+        while i < bytes.len() {
+            if bytes[i] != b'<' {
+                i += 1;
+                continue;
+            }
+            if html[i..].starts_with("<!--") {
+                let end = html[i + 4..]
+                    .find("-->")
+                    .unwrap_or_else(|| panic!("unterminated comment in {context}:\n{html}"));
+                i += 4 + end + 3;
+                continue;
+            }
+            if html[i..].starts_with("<!") {
+                // Doctype or other declaration.
+                let end = html[i..]
+                    .find('>')
+                    .unwrap_or_else(|| panic!("unterminated declaration in {context}:\n{html}"));
+                i += end + 1;
+                continue;
+            }
+
+            let closing = html[i..].starts_with("</");
+            let name_start = i + if closing { 2 } else { 1 };
+            let name_len = html[name_start..]
+                .find(|c: char| !(c.is_ascii_alphanumeric() || c == '-'))
+                .unwrap_or(html.len() - name_start);
+            let name = html[name_start..name_start + name_len].to_ascii_lowercase();
+            assert!(
+                !name.is_empty(),
+                "malformed tag at byte {i} in {context}:\n{html}"
+            );
+
+            // Find the true end of the tag, skipping `>` inside quoted attrs.
+            let mut j = name_start + name_len;
+            let mut quote: Option<u8> = None;
+            while j < bytes.len() {
+                match (quote, bytes[j]) {
+                    (Some(q), c) if c == q => quote = None,
+                    (None, b'"') => quote = Some(b'"'),
+                    (None, b'\'') => quote = Some(b'\''),
+                    (None, b'>') => break,
+                    _ => {}
+                }
+                j += 1;
+            }
+            assert!(
+                j < bytes.len(),
+                "unterminated tag <{name} in {context}:\n{html}"
+            );
+            let self_closing = j > 0 && bytes[j - 1] == b'/';
+
+            if closing {
+                let open = stack.pop().unwrap_or_else(|| {
+                    panic!("closing </{name}> with no open tag in {context}:\n{html}")
+                });
+                assert_eq!(
+                    open, name,
+                    "mismatched close tag in {context}: expected </{open}>, found </{name}>:\n{html}"
+                );
+                i = j + 1;
+                continue;
+            }
+
+            if !self_closing && !VOID_ELEMENTS.contains(&name.as_str()) {
+                if RAW_TEXT_ELEMENTS.contains(&name.as_str()) {
+                    // Skip raw content up to the matching close tag.
+                    let close = format!("</{name}");
+                    let rest_start = j + 1;
+                    let end = html[rest_start..]
+                        .to_ascii_lowercase()
+                        .find(&close)
+                        .unwrap_or_else(|| {
+                            panic!("unclosed raw-text element <{name}> in {context}:\n{html}")
+                        });
+                    let close_gt = html[rest_start + end..]
+                        .find('>')
+                        .unwrap_or_else(|| panic!("unterminated </{name}> in {context}:\n{html}"));
+                    i = rest_start + end + close_gt + 1;
+                    continue;
+                }
+                stack.push(name);
+            }
+            i = j + 1;
+        }
+
+        assert!(
+            stack.is_empty(),
+            "unclosed tags {stack:?} in {context}:\n{html}"
+        );
+    }
+
+    // Guard the duplicated checker itself: a broken checker must not
+    // green-light rotten gallery chrome.
+    #[test]
+    fn balanced_html_checker_rejects_malformed_markup() {
+        assert_balanced_html(
+            r#"<!DOCTYPE html><div class="a > b"><p>ok<br></p></div>"#,
+            "self-test",
+        );
+        for bad in ["<div><p></div>", "<div>", "</div>"] {
+            let result = std::panic::catch_unwind(|| assert_balanced_html(bad, "self-test"));
+            assert!(result.is_err(), "checker should reject {bad}");
+        }
+    }
+
+    // U9 (AC4/AC8): the gallery chrome itself — grouped index, empty-state
+    // index, and every builtin detail page — is strictly balanced HTML, not
+    // just the story fragments the integration harness checks.
+    #[test]
+    fn gallery_index_and_detail_pages_render_balanced_html() {
+        let registry = builtin();
+        assert_balanced_html(
+            &render_story_index(&registry).into_string(),
+            "story index page",
+        );
+        assert_balanced_html(
+            &render_story_index(&StoryRegistry::default()).into_string(),
+            "empty-state index page",
+        );
+        for story in registry.stories() {
+            let rendered = story
+                .render()
+                .unwrap_or_else(|err| panic!("builtin story `{}` failed: {err}", story.slug()));
+            assert_balanced_html(
+                &render_story_detail(story, &rendered).into_string(),
+                &format!("detail page for `{}`", story.slug()),
+            );
+        }
+    }
 }

--- a/autumn/src/stories/mod.rs
+++ b/autumn/src/stories/mod.rs
@@ -430,7 +430,16 @@ body { margin: 0; font-family: system-ui, sans-serif; color: #1f2933; }
 .story-empty { padding: 2rem; border: 1px dashed #cbd2d9; border-radius: 6px; }
 ";
 
-/// Full HTML document shell: framework widget stylesheet + gallery chrome.
+/// Full HTML document shell: framework widget stylesheet + widget runtime
+/// script + gallery chrome.
+///
+/// Interactive widgets (`modal_trigger`, `confirm_action`, `nav_bar`, …) emit
+/// `data-*` hooks wired by the framework's `autumn-widgets.js` runtime, so the
+/// shell loads that same-origin script (always mounted under the `htmx`
+/// feature) alongside the stylesheet — otherwise the live previews of those
+/// stories would be inert in browsers that need the JS fallback. The script
+/// needs no CSP nonce: the framework's default policy keeps `'self'` in
+/// `script-src` in both plain and nonce modes.
 ///
 /// When the security layer's per-request CSP nonce is active
 /// (`security.headers.csp_nonce.enabled = true`, which drops
@@ -442,6 +451,10 @@ fn story_page(
     body: &maud::Markup,
     nonce: Option<&crate::security::CspNonce>,
 ) -> maud::Markup {
+    #[cfg(feature = "htmx")]
+    let widgets_js: Option<&str> = Some(crate::htmx::AUTUMN_WIDGETS_JS_PATH);
+    #[cfg(not(feature = "htmx"))]
+    let widgets_js: Option<&str> = None;
     maud::html! {
         (maud::DOCTYPE)
         html lang="en" {
@@ -450,6 +463,9 @@ fn story_page(
                 meta name="viewport" content="width=device-width, initial-scale=1";
                 title { (title) " — Autumn stories" }
                 link rel="stylesheet" href=(crate::ui::WIDGETS_CSS_PATH);
+                @if let Some(src) = widgets_js {
+                    script src=(src) defer {}
+                }
                 style nonce=[nonce.map(crate::security::CspNonce::value)] {
                     (maud::PreEscaped(STORY_GALLERY_CSS))
                 }
@@ -680,8 +696,8 @@ mod tests {
         assert!(fine.render().is_ok());
     }
 
-    // U6 (AC4): the index page links the framework widget stylesheet and
-    // lists stories grouped in the sidebar.
+    // U6 (AC4): the index page links the framework widget stylesheet, loads
+    // the widget runtime script, and lists stories grouped in the sidebar.
     #[test]
     fn index_page_links_widgets_css_and_groups_stories() {
         assert_eq!(STORIES_PATH, "/_stories");
@@ -702,6 +718,20 @@ mod tests {
             !css_selector.matches(&dom).is_empty(),
             "index must link the framework widget stylesheet: {page}"
         );
+
+        #[cfg(feature = "htmx")]
+        {
+            let js_selector = crate::test_html::SelectorList::parse(&format!(
+                "script[src=\"{}\"]",
+                crate::htmx::AUTUMN_WIDGETS_JS_PATH
+            ))
+            .expect("selector parses");
+            assert!(
+                !js_selector.matches(&dom).is_empty(),
+                "index must load the widget runtime script so interactive \
+                 stories (modal, confirm-action, nav-bar) work live: {page}"
+            );
+        }
 
         let link_selector =
             crate::test_html::SelectorList::parse("a[href=\"/_stories/data-table\"]")
@@ -749,6 +779,19 @@ mod tests {
             !tabs.matches(&dom).is_empty(),
             "detail page must use the tabs widget for Source / Rendered HTML: {page}"
         );
+
+        #[cfg(feature = "htmx")]
+        {
+            let js_selector = crate::test_html::SelectorList::parse(&format!(
+                "script[src=\"{}\"]",
+                crate::htmx::AUTUMN_WIDGETS_JS_PATH
+            ))
+            .expect("selector parses");
+            assert!(
+                !js_selector.matches(&dom).is_empty(),
+                "detail page must load the widget runtime script: {page}"
+            );
+        }
 
         assert!(
             page.contains("maud::html!"),

--- a/autumn/src/stories/mod.rs
+++ b/autumn/src/stories/mod.rs
@@ -7,23 +7,515 @@
 //! `StoryRegistry` served at `GET /_stories` (grouped index) and
 //! `GET /_stories/{slug}` (live render + Source + Rendered HTML tabs).
 //!
-//! RED phase note: this module currently contains only the failing unit
-//! tests below. The GREEN phase implements, above the test module:
+//! Two switches gate the gallery:
 //!
-//! - `pub const STORIES_PATH: &str = "/_stories";`
-//! - `Story { group, name, slug, render: fn() -> maud::Markup, source }`
-//!   with `new` (panics on empty slug), accessors, and a `catch_unwind`
-//!   `render()` returning `Result<maud::Markup, StoryRenderError>`
-//! - `fn slugify(name: &str) -> String`
-//! - `StoryRegistry` (`new` panics on duplicate slugs, `stories`, `find`,
-//!   `grouped`) and `pub fn builtin() -> StoryRegistry`
-//! - `StoryGallery` (`new`, `builtin`, `extend`, `stories`, `routes<S>()`,
-//!   `pub(crate) into_registry`)
-//! - `StoriesConfig { enabled: bool }` (default **false**) for the
-//!   `[stories]` config section
-//! - `pub(crate) fn story_router<S>()` plus the pure page renderers
-//!   `render_story_index(&StoryRegistry)` and `render_story_detail(&Story)`
-//! - `pub use autumn_macros::story;`
+//! 1. **Registration** — `AppBuilder::with_story_gallery(StoryGallery::builtin())`
+//!    installs the [`StoryRegistry`] on [`AppState`](crate::AppState).
+//! 2. **Config** — the routes mount only when the resolved config has
+//!    `[stories] enabled = true` ([`StoriesConfig`], default **false**).
+//!    Unlike the dev-only mail preview, stories may be enabled in *any*
+//!    profile (a public showcase is a supported use); safe because stories
+//!    only ever render synthetic demo data.
+//!
+//! Author stories with the [`story!`](crate::stories::story) macro — its
+//! block is both executed for the live render and captured byte-for-byte as
+//! the displayed snippet. See `docs/guide/stories.md`.
+
+use std::sync::Arc;
+
+use axum::response::{Html, IntoResponse, Response};
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::AppState;
+
+/// Author a widget story: `story!{ "Group", "Name", { ... } }`.
+pub use autumn_macros::story;
+
+mod builtin;
+
+/// Stable root path for the widget story gallery.
+pub const STORIES_PATH: &str = "/_stories";
+
+/// Route template for a single story's detail page.
+const STORY_DETAIL_PATH: &str = "/_stories/{slug}";
+
+/// Derive a URL slug from a story name: lowercase, alphanumeric runs joined
+/// by single `-`, everything else (punctuation, whitespace, non-ASCII)
+/// treated as a separator.
+fn slugify(name: &str) -> String {
+    let mut slug = String::with_capacity(name.len());
+    let mut pending_separator = false;
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() {
+            if pending_separator && !slug.is_empty() {
+                slug.push('-');
+            }
+            pending_separator = false;
+            slug.push(c.to_ascii_lowercase());
+        } else {
+            pending_separator = true;
+        }
+    }
+    slug
+}
+
+/// A zero-arg, pure widget render example shown in the `/_stories` gallery.
+///
+/// Construct with the [`story!`](crate::stories::story) macro, which captures
+/// the render block's source text so the displayed snippet is provably the
+/// code that rendered. `render` is a plain `fn() -> Markup` pointer: no `Db`,
+/// no `AppState`, no request data can be smuggled in.
+#[derive(Clone)]
+pub struct Story {
+    group: &'static str,
+    name: &'static str,
+    slug: String,
+    render: fn() -> maud::Markup,
+    source: &'static str,
+}
+
+impl std::fmt::Debug for Story {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Story")
+            .field("group", &self.group)
+            .field("name", &self.name)
+            .field("slug", &self.slug)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Story {
+    /// Register a story. Prefer the [`story!`](crate::stories::story) macro,
+    /// which fills in `source` from the render block automatically.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `name` produces an empty URL slug (e.g. a name made
+    /// entirely of punctuation) — a programmer error better caught loudly at
+    /// construction time than as a broken route.
+    #[must_use]
+    pub fn new(
+        group: &'static str,
+        name: &'static str,
+        render: fn() -> maud::Markup,
+        source: &'static str,
+    ) -> Self {
+        let slug = slugify(name);
+        assert!(
+            !slug.is_empty(),
+            "story name {name:?} (group {group:?}) produces an empty slug; \
+             use a name with at least one alphanumeric character"
+        );
+        Self {
+            group,
+            name,
+            slug,
+            render,
+            source,
+        }
+    }
+
+    /// Sidebar group this story is listed under.
+    #[must_use]
+    pub const fn group(&self) -> &'static str {
+        self.group
+    }
+
+    /// Human-readable story name.
+    #[must_use]
+    pub const fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// URL slug derived from the name (`/_stories/{slug}`).
+    #[must_use]
+    pub fn slug(&self) -> &str {
+        &self.slug
+    }
+
+    /// Source snippet that produced the render (shown in the Source tab).
+    #[must_use]
+    pub const fn source(&self) -> &'static str {
+        self.source
+    }
+
+    /// Render the story's markup.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoryRenderError::Panicked`] when the render function
+    /// panics, so one broken story cannot unwind through the gallery.
+    pub fn render(&self) -> Result<maud::Markup, StoryRenderError> {
+        std::panic::catch_unwind(self.render).map_err(|_| StoryRenderError::Panicked {
+            slug: self.slug.clone(),
+        })
+    }
+}
+
+/// Story gallery render errors.
+#[derive(Debug, Error)]
+pub enum StoryRenderError {
+    /// The story's render function panicked.
+    #[error("story `{slug}` panicked while rendering")]
+    Panicked {
+        /// Slug of the panicking story.
+        slug: String,
+    },
+}
+
+/// Immutable collection of registered stories, stored on
+/// [`AppState`](crate::AppState) as an extension by
+/// [`AppBuilder::with_story_gallery`](crate::AppBuilder::with_story_gallery).
+#[derive(Debug, Clone, Default)]
+pub struct StoryRegistry {
+    stories: Arc<Vec<Story>>,
+}
+
+impl StoryRegistry {
+    /// Create a registry from story registrations.
+    ///
+    /// # Panics
+    ///
+    /// Panics when two stories share a slug (slugs derive from names), since
+    /// one would shadow the other in routing — rename one of the stories.
+    #[must_use]
+    pub fn new(stories: Vec<Story>) -> Self {
+        let mut seen: std::collections::HashMap<&str, &Story> = std::collections::HashMap::new();
+        for story in &stories {
+            if let Some(existing) = seen.insert(story.slug(), story) {
+                panic!(
+                    "duplicate story slug `{}`: `{}` / `{}` collides with `{}` / `{}`; \
+                     story slugs derive from names, so rename one of them",
+                    story.slug(),
+                    existing.group(),
+                    existing.name(),
+                    story.group(),
+                    story.name(),
+                );
+            }
+        }
+        Self {
+            stories: Arc::new(stories),
+        }
+    }
+
+    /// Registered stories, in registration order.
+    #[must_use]
+    pub fn stories(&self) -> &[Story] {
+        &self.stories
+    }
+
+    /// Look a story up by its URL slug.
+    fn find(&self, slug: &str) -> Option<&Story> {
+        self.stories.iter().find(|story| story.slug() == slug)
+    }
+
+    /// Stories grouped for the index sidebar: groups in first-seen order,
+    /// stories in registration order within each group (deterministic,
+    /// author-controlled).
+    fn grouped(&self) -> Vec<(&'static str, Vec<&Story>)> {
+        let mut grouped: Vec<(&'static str, Vec<&Story>)> = Vec::new();
+        for story in self.stories.iter() {
+            match grouped
+                .iter_mut()
+                .find(|(group, _)| *group == story.group())
+            {
+                Some((_, stories)) => stories.push(story),
+                None => grouped.push((story.group(), vec![story])),
+            }
+        }
+        grouped
+    }
+}
+
+/// Registry of every built-in widget story: >=1 story per gallery-visible
+/// widget in [`crate::widgets`], enforced by the CI coverage gate
+/// (`autumn/tests/integration/stories.rs`).
+#[must_use]
+pub fn builtin() -> StoryRegistry {
+    StoryRegistry::new(builtin::builtin_stories())
+}
+
+/// Builder-side collection of stories, registered with
+/// [`AppBuilder::with_story_gallery`](crate::AppBuilder::with_story_gallery).
+///
+/// Start from [`StoryGallery::builtin`] to serve the framework widget set,
+/// or [`StoryGallery::new`] for an app-only gallery, then [`extend`](Self::extend)
+/// with stories authored via the [`story!`](crate::stories::story) macro.
+#[derive(Debug, Clone, Default)]
+pub struct StoryGallery {
+    stories: Vec<Story>,
+}
+
+impl StoryGallery {
+    /// Create an empty, builtin-free gallery (app stories only).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a gallery seeded with every built-in widget story.
+    #[must_use]
+    pub fn builtin() -> Self {
+        Self {
+            stories: builtin::builtin_stories(),
+        }
+    }
+
+    /// Append stories (e.g. custom app widgets authored with
+    /// [`story!`](crate::stories::story)).
+    #[must_use]
+    pub fn extend(mut self, stories: impl IntoIterator<Item = Story>) -> Self {
+        self.stories.extend(stories);
+        self
+    }
+
+    /// Stories collected so far, in registration order.
+    #[must_use]
+    pub fn stories(&self) -> &[Story] {
+        &self.stories
+    }
+
+    /// The gallery's axum sub-router (`GET /_stories`, `GET /_stories/{slug}`).
+    ///
+    /// The framework mounts this automatically when the resolved config has
+    /// `[stories] enabled = true`; handlers read the [`StoryRegistry`] from
+    /// the [`AppState`](crate::AppState) extension installed by
+    /// [`AppBuilder::with_story_gallery`](crate::AppBuilder::with_story_gallery),
+    /// so manual mounters must install that extension too.
+    pub fn routes<S>() -> axum::Router<S>
+    where
+        S: Clone + Send + Sync + 'static,
+        AppState: axum::extract::FromRef<S>,
+    {
+        story_router()
+    }
+
+    /// Freeze the gallery into the registry stored on `AppState`.
+    ///
+    /// # Panics
+    ///
+    /// Panics on duplicate slugs — see [`StoryRegistry::new`].
+    pub(crate) fn into_registry(self) -> StoryRegistry {
+        StoryRegistry::new(self.stories)
+    }
+}
+
+/// Widget story gallery settings (`[stories]` section in `autumn.toml`).
+///
+/// **Off by default, opt-in in any profile** — unlike the dev-only mail
+/// preview, a public showcase is a supported use (stories only ever render
+/// synthetic demo data). Profile overrides come free from the standard
+/// config layering, and `AUTUMN_STORIES__ENABLED` overrides from the
+/// environment:
+///
+/// ```toml
+/// [stories]
+/// enabled = false
+///
+/// # Dev-only gallery: mounted under `autumn dev`, 404 in prod.
+/// [profile.dev.stories]
+/// enabled = true
+/// ```
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct StoriesConfig {
+    /// Whether the `/_stories` gallery routes are mounted. Default `false`.
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+/// Build the gallery sub-router. Mounted by `build_router` when
+/// `config.stories.enabled` is true; handlers read the [`StoryRegistry`]
+/// from the `AppState` extension (mail-preview precedent).
+pub(crate) fn story_router<S>() -> axum::Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+    AppState: axum::extract::FromRef<S>,
+{
+    axum::Router::new()
+        .route(
+            STORIES_PATH,
+            axum::routing::get(
+                |axum::extract::State(state): axum::extract::State<AppState>| async move {
+                    story_index_response(&state)
+                },
+            ),
+        )
+        .route(
+            STORY_DETAIL_PATH,
+            axum::routing::get(
+                |axum::extract::Path(slug): axum::extract::Path<String>,
+                 axum::extract::State(state): axum::extract::State<AppState>| async move {
+                    story_detail_response(&state, &slug)
+                },
+            ),
+        )
+}
+
+fn registry_from_state(state: &AppState) -> StoryRegistry {
+    state
+        .extension::<StoryRegistry>()
+        .map(|registry| (*registry).clone())
+        .unwrap_or_default()
+}
+
+fn story_index_response(state: &AppState) -> Response {
+    Html(render_story_index(&registry_from_state(state)).into_string()).into_response()
+}
+
+fn story_detail_response(state: &AppState, slug: &str) -> Response {
+    let registry = registry_from_state(state);
+    let Some(story) = registry.find(slug) else {
+        let page = story_page(
+            "Story not found",
+            &maud::html! {
+                main class="story-content" {
+                    h1 { "Story not found" }
+                    p {
+                        "No story is registered under the slug " code { (slug) } ". "
+                        a href=(STORIES_PATH) { "Back to the gallery" }
+                    }
+                }
+            },
+        );
+        return (http::StatusCode::NOT_FOUND, Html(page.into_string())).into_response();
+    };
+
+    if let Err(error) = story.render() {
+        let page = story_page(
+            "Story failed to render",
+            &maud::html! {
+                main class="story-content" {
+                    h1 { "Story failed to render" }
+                    p { (error.to_string()) }
+                    p { a href=(STORIES_PATH) { "Back to the gallery" } }
+                }
+            },
+        );
+        return (
+            http::StatusCode::INTERNAL_SERVER_ERROR,
+            Html(page.into_string()),
+        )
+            .into_response();
+    }
+
+    Html(render_story_detail(story).into_string()).into_response()
+}
+
+/// Minimal gallery chrome layered on top of the framework widget stylesheet.
+const STORY_GALLERY_CSS: &str = r"
+body { margin: 0; font-family: system-ui, sans-serif; color: #1f2933; }
+.story-layout { display: flex; gap: 2rem; align-items: flex-start; }
+.story-sidebar { flex: 0 0 14rem; padding: 1rem 1.25rem; border-right: 1px solid #e0e0e0; min-height: 100vh; }
+.story-sidebar h2 { font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; color: #616e7c; margin: 1.25rem 0 0.25rem; }
+.story-sidebar ul { list-style: none; margin: 0; padding: 0; }
+.story-sidebar li { margin: 0.15rem 0; }
+.story-content { flex: 1 1 auto; padding: 1.5rem; max-width: 60rem; }
+.story-preview { padding: 1.5rem; border: 1px solid #e0e0e0; border-radius: 6px; margin-bottom: 1.5rem; }
+.story-content pre { background: #f5f7fa; border-radius: 6px; padding: 1rem; overflow-x: auto; }
+.story-empty { padding: 2rem; border: 1px dashed #cbd2d9; border-radius: 6px; }
+";
+
+/// Full HTML document shell: framework widget stylesheet + gallery chrome.
+fn story_page(title: &str, body: &maud::Markup) -> maud::Markup {
+    maud::html! {
+        (maud::DOCTYPE)
+        html lang="en" {
+            head {
+                meta charset="utf-8";
+                meta name="viewport" content="width=device-width, initial-scale=1";
+                title { (title) " — Autumn stories" }
+                link rel="stylesheet" href=(crate::ui::WIDGETS_CSS_PATH);
+                style { (maud::PreEscaped(STORY_GALLERY_CSS)) }
+            }
+            body { (body) }
+        }
+    }
+}
+
+/// Render the grouped `/_stories` index page.
+fn render_story_index(registry: &StoryRegistry) -> maud::Markup {
+    story_page(
+        "Widget stories",
+        &maud::html! {
+            div class="story-layout" {
+                nav class="story-sidebar" aria-label="Stories" {
+                    @for (group, stories) in registry.grouped() {
+                        h2 { (group) }
+                        ul {
+                            @for story in stories {
+                                li {
+                                    a href=(format!("{STORIES_PATH}/{}", story.slug())) {
+                                        (story.name())
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                main class="story-content" {
+                    h1 { "Widget stories" }
+                    @if registry.stories().is_empty() {
+                        div class="story-empty" {
+                            p {
+                                "No stories are registered. Add "
+                                code { ".with_story_gallery(StoryGallery::builtin())" }
+                                " to your " code { "AppBuilder" }
+                                " to serve the built-in widget gallery, or "
+                                code { "StoryGallery::new().extend([...])" }
+                                " for app-only stories."
+                            }
+                        }
+                    } @else {
+                        p {
+                            "Every entry renders live from a zero-arg widget example; "
+                            "its detail page shows the exact source that produced it. "
+                            "Pick a story from the sidebar."
+                        }
+                    }
+                }
+            }
+        },
+    )
+}
+
+/// Render a single story's detail page: live render above Source and
+/// Rendered HTML tabs (dogfooding the [`crate::widgets::tabs`] widget).
+fn render_story_detail(story: &Story) -> maud::Markup {
+    let rendered = story.render().unwrap_or_else(|error| {
+        maud::html! { p class="story-render-error" { (error.to_string()) } }
+    });
+    let rendered_html = rendered.clone().into_string();
+    story_page(
+        story.name(),
+        &maud::html! {
+            main class="story-content" {
+                p class="story-breadcrumb" {
+                    a href=(STORIES_PATH) { "Widget stories" }
+                    " / " (story.group())
+                }
+                h1 { (story.name()) }
+                section class="story-preview" { (rendered) }
+                (crate::widgets::tabs(
+                    "story-tabs",
+                    &[
+                        (
+                            "story-source",
+                            "Source",
+                            maud::html! { pre { code { (story.source()) } } },
+                        ),
+                        (
+                            "story-html",
+                            "Rendered HTML",
+                            maud::html! { pre { code { (rendered_html) } } },
+                        ),
+                    ],
+                ))
+            }
+        },
+    )
+}
 
 #[cfg(test)]
 mod tests {

--- a/autumn/src/stories/mod.rs
+++ b/autumn/src/stories/mod.rs
@@ -337,8 +337,9 @@ where
         .route(
             STORIES_PATH,
             axum::routing::get(
-                |axum::extract::State(state): axum::extract::State<AppState>| async move {
-                    story_index_response(&state)
+                |axum::extract::State(state): axum::extract::State<AppState>,
+                 nonce: Option<crate::security::CspNonce>| async move {
+                    story_index_response(&state, nonce.as_ref())
                 },
             ),
         )
@@ -346,8 +347,9 @@ where
             STORY_DETAIL_PATH,
             axum::routing::get(
                 |axum::extract::Path(slug): axum::extract::Path<String>,
-                 axum::extract::State(state): axum::extract::State<AppState>| async move {
-                    story_detail_response(&state, &slug)
+                 axum::extract::State(state): axum::extract::State<AppState>,
+                 nonce: Option<crate::security::CspNonce>| async move {
+                    story_detail_response(&state, &slug, nonce.as_ref())
                 },
             ),
         )
@@ -360,11 +362,15 @@ fn registry_from_state(state: &AppState) -> StoryRegistry {
         .unwrap_or_default()
 }
 
-fn story_index_response(state: &AppState) -> Response {
-    Html(render_story_index(&registry_from_state(state)).into_string()).into_response()
+fn story_index_response(state: &AppState, nonce: Option<&crate::security::CspNonce>) -> Response {
+    Html(render_story_index(&registry_from_state(state), nonce).into_string()).into_response()
 }
 
-fn story_detail_response(state: &AppState, slug: &str) -> Response {
+fn story_detail_response(
+    state: &AppState,
+    slug: &str,
+    nonce: Option<&crate::security::CspNonce>,
+) -> Response {
     let registry = registry_from_state(state);
     let Some(story) = registry.find(slug) else {
         let page = story_page(
@@ -378,12 +384,15 @@ fn story_detail_response(state: &AppState, slug: &str) -> Response {
                     }
                 }
             },
+            nonce,
         );
         return (http::StatusCode::NOT_FOUND, Html(page.into_string())).into_response();
     };
 
     match story.render() {
-        Ok(rendered) => Html(render_story_detail(story, &rendered).into_string()).into_response(),
+        Ok(rendered) => {
+            Html(render_story_detail(story, &rendered, nonce).into_string()).into_response()
+        }
         Err(error) => {
             let page = story_page(
                 "Story failed to render",
@@ -394,6 +403,7 @@ fn story_detail_response(state: &AppState, slug: &str) -> Response {
                         p { a href=(STORIES_PATH) { "Back to the gallery" } }
                     }
                 },
+                nonce,
             );
             (
                 http::StatusCode::INTERNAL_SERVER_ERROR,
@@ -419,7 +429,17 @@ body { margin: 0; font-family: system-ui, sans-serif; color: #1f2933; }
 ";
 
 /// Full HTML document shell: framework widget stylesheet + gallery chrome.
-fn story_page(title: &str, body: &maud::Markup) -> maud::Markup {
+///
+/// When the security layer's per-request CSP nonce is active
+/// (`security.headers.csp_nonce.enabled = true`, which drops
+/// `'unsafe-inline'` from `style-src`), the inline gallery stylesheet carries
+/// the request's nonce so browsers don't block it; without the layer no
+/// `nonce` attribute is emitted.
+fn story_page(
+    title: &str,
+    body: &maud::Markup,
+    nonce: Option<&crate::security::CspNonce>,
+) -> maud::Markup {
     maud::html! {
         (maud::DOCTYPE)
         html lang="en" {
@@ -428,7 +448,9 @@ fn story_page(title: &str, body: &maud::Markup) -> maud::Markup {
                 meta name="viewport" content="width=device-width, initial-scale=1";
                 title { (title) " — Autumn stories" }
                 link rel="stylesheet" href=(crate::ui::WIDGETS_CSS_PATH);
-                style { (maud::PreEscaped(STORY_GALLERY_CSS)) }
+                style nonce=[nonce.map(crate::security::CspNonce::value)] {
+                    (maud::PreEscaped(STORY_GALLERY_CSS))
+                }
             }
             body { (body) }
         }
@@ -436,7 +458,10 @@ fn story_page(title: &str, body: &maud::Markup) -> maud::Markup {
 }
 
 /// Render the grouped `/_stories` index page.
-fn render_story_index(registry: &StoryRegistry) -> maud::Markup {
+fn render_story_index(
+    registry: &StoryRegistry,
+    nonce: Option<&crate::security::CspNonce>,
+) -> maud::Markup {
     story_page(
         "Widget stories",
         &maud::html! {
@@ -478,6 +503,7 @@ fn render_story_index(registry: &StoryRegistry) -> maud::Markup {
                 }
             }
         },
+        nonce,
     )
 }
 
@@ -487,7 +513,11 @@ fn render_story_index(registry: &StoryRegistry) -> maud::Markup {
 /// `rendered` is the story's markup, rendered exactly once by the caller
 /// (which also owns the render-failure response), so the preview and the
 /// Rendered HTML tab always show the same output.
-fn render_story_detail(story: &Story, rendered: &maud::Markup) -> maud::Markup {
+fn render_story_detail(
+    story: &Story,
+    rendered: &maud::Markup,
+    nonce: Option<&crate::security::CspNonce>,
+) -> maud::Markup {
     let rendered_html = rendered.clone().into_string();
     story_page(
         story.name(),
@@ -516,6 +546,7 @@ fn render_story_detail(story: &Story, rendered: &maud::Markup) -> maud::Markup {
                 ))
             }
         },
+        nonce,
     )
 }
 
@@ -657,7 +688,7 @@ mod tests {
             demo_story("Display", "Data table"),
             demo_story("Forms", "Active search"),
         ]);
-        let page = render_story_index(&registry).into_string();
+        let page = render_story_index(&registry, None).into_string();
         let dom = crate::test_html::parse(&page);
 
         let css_selector = crate::test_html::SelectorList::parse(&format!(
@@ -696,7 +727,7 @@ mod tests {
             }
         };
         let rendered = story.render().expect("proof story renders");
-        let page = render_story_detail(&story, &rendered).into_string();
+        let page = render_story_detail(&story, &rendered, None).into_string();
         let dom = crate::test_html::parse(&page);
 
         let preview = crate::test_html::SelectorList::parse(".story-preview .proof-marker")
@@ -731,7 +762,7 @@ mod tests {
     // state pointing at AppBuilder::with_story_gallery, not a 500/blank page.
     #[test]
     fn index_empty_state_mentions_with_story_gallery() {
-        let page = render_story_index(&StoryRegistry::default()).into_string();
+        let page = render_story_index(&StoryRegistry::default(), None).into_string();
         assert!(
             page.contains("with_story_gallery"),
             "empty state must explain how to register stories: {page}"
@@ -871,11 +902,11 @@ mod tests {
     fn gallery_index_and_detail_pages_render_balanced_html() {
         let registry = builtin();
         assert_balanced_html(
-            &render_story_index(&registry).into_string(),
+            &render_story_index(&registry, None).into_string(),
             "story index page",
         );
         assert_balanced_html(
-            &render_story_index(&StoryRegistry::default()).into_string(),
+            &render_story_index(&StoryRegistry::default(), None).into_string(),
             "empty-state index page",
         );
         for story in registry.stories() {
@@ -883,9 +914,39 @@ mod tests {
                 .render()
                 .unwrap_or_else(|err| panic!("builtin story `{}` failed: {err}", story.slug()));
             assert_balanced_html(
-                &render_story_detail(story, &rendered).into_string(),
+                &render_story_detail(story, &rendered, None).into_string(),
                 &format!("detail page for `{}`", story.slug()),
             );
         }
+    }
+
+    // U10 (review follow-up): when the security layer's per-request CSP nonce
+    // is active, `style-src` drops `'unsafe-inline'`, so the gallery's inline
+    // stylesheet must carry the request nonce or browsers block it. Without
+    // the layer no nonce attribute is emitted.
+    #[test]
+    fn story_pages_apply_csp_nonce_to_inline_style() {
+        let nonce = crate::security::CspNonce::new_for_tests("test-nonce-value");
+        let registry = StoryRegistry::new(vec![demo_story("Display", "Card")]);
+
+        let index = render_story_index(&registry, Some(&nonce)).into_string();
+        assert!(
+            index.contains(r#"<style nonce="test-nonce-value">"#),
+            "index inline style must carry the CSP nonce: {index}"
+        );
+
+        let story = &registry.stories()[0];
+        let rendered = story.render().expect("demo story renders");
+        let detail = render_story_detail(story, &rendered, Some(&nonce)).into_string();
+        assert!(
+            detail.contains(r#"<style nonce="test-nonce-value">"#),
+            "detail inline style must carry the CSP nonce: {detail}"
+        );
+
+        let plain = render_story_index(&registry, None).into_string();
+        assert!(
+            plain.contains("<style>") && !plain.contains("nonce="),
+            "without the security layer no nonce attribute is emitted: {plain}"
+        );
     }
 }

--- a/autumn/src/stories/mod.rs
+++ b/autumn/src/stories/mod.rs
@@ -1,0 +1,245 @@
+//! Widget story gallery: a browsable `/_stories` UI plus a CI anti-rot
+//! registry for the built-in maud widgets (issue #1526).
+//!
+//! Mirrors the mail-preview registry precedent (`crate::mail::MailPreview` /
+//! `MailPreviewRegistry`): each story is a zero-arg pure `fn() -> Markup`
+//! paired with the source snippet that produced it, collected into a
+//! `StoryRegistry` served at `GET /_stories` (grouped index) and
+//! `GET /_stories/{slug}` (live render + Source + Rendered HTML tabs).
+//!
+//! RED phase note: this module currently contains only the failing unit
+//! tests below. The GREEN phase implements, above the test module:
+//!
+//! - `pub const STORIES_PATH: &str = "/_stories";`
+//! - `Story { group, name, slug, render: fn() -> maud::Markup, source }`
+//!   with `new` (panics on empty slug), accessors, and a `catch_unwind`
+//!   `render()` returning `Result<maud::Markup, StoryRenderError>`
+//! - `fn slugify(name: &str) -> String`
+//! - `StoryRegistry` (`new` panics on duplicate slugs, `stories`, `find`,
+//!   `grouped`) and `pub fn builtin() -> StoryRegistry`
+//! - `StoryGallery` (`new`, `builtin`, `extend`, `stories`, `routes<S>()`,
+//!   `pub(crate) into_registry`)
+//! - `StoriesConfig { enabled: bool }` (default **false**) for the
+//!   `[stories]` config section
+//! - `pub(crate) fn story_router<S>()` plus the pure page renderers
+//!   `render_story_index(&StoryRegistry)` and `render_story_detail(&Story)`
+//! - `pub use autumn_macros::story;`
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn demo_markup() -> maud::Markup {
+        maud::html! { p { "demo" } }
+    }
+
+    fn demo_story(group: &'static str, name: &'static str) -> Story {
+        Story::new(group, name, demo_markup, r#"maud::html! { p { "demo" } }"#)
+    }
+
+    // U1 (AC1): slug derivation folds case, joins alphanumeric runs with `-`,
+    // and treats punctuation/whitespace/non-ASCII as separators.
+    #[test]
+    fn slugify_handles_spaces_punctuation_unicode() {
+        assert_eq!(slugify("Data table"), "data-table");
+        assert_eq!(slugify("Nav / Links!"), "nav-links");
+        assert_eq!(slugify("HERO"), "hero");
+        // Non-ASCII acts as a separator and never leaks into the URL.
+        assert_eq!(slugify("Δ delta"), "delta");
+        assert_eq!(slugify("  Stat   Card  "), "stat-card");
+    }
+
+    // U1 (AC1): a name that slugifies to nothing is a programmer error caught
+    // loudly at construction time, not a broken route.
+    #[test]
+    #[should_panic(expected = "slug")]
+    fn story_new_panics_on_name_that_slugifies_to_empty() {
+        let _ = Story::new("Display", "!!!", demo_markup, "demo()");
+    }
+
+    // U2 (AC1): lookup is by slug.
+    #[test]
+    fn registry_find_matches_slug() {
+        let registry = StoryRegistry::new(vec![
+            demo_story("Display", "Data table"),
+            demo_story("Display", "Card"),
+        ]);
+        assert_eq!(registry.stories().len(), 2);
+        let found = registry
+            .find("data-table")
+            .expect("data-table slug should resolve");
+        assert_eq!(found.name(), "Data table");
+        assert_eq!(found.group(), "Display");
+        assert!(registry.find("nope").is_none());
+    }
+
+    // U2 (AC1, R7): duplicate slugs would let one story shadow another in
+    // routing — refuse them at registry construction.
+    #[test]
+    #[should_panic(expected = "duplicate")]
+    fn registry_new_panics_on_duplicate_slug() {
+        let _ = StoryRegistry::new(vec![
+            demo_story("Display", "Card"),
+            demo_story("Marketing", "Card"),
+        ]);
+    }
+
+    // U3 (AC1, R17): index grouping is deterministic — groups in first-seen
+    // order, stories in registration order within a group.
+    #[test]
+    fn grouped_preserves_first_seen_group_and_registration_order() {
+        let registry = StoryRegistry::new(vec![
+            demo_story("Display", "Data table"),
+            demo_story("Forms", "Active search"),
+            demo_story("Display", "Card"),
+        ]);
+        let grouped = registry.grouped();
+        let groups: Vec<&str> = grouped.iter().map(|(group, _)| *group).collect();
+        assert_eq!(groups, ["Display", "Forms"]);
+        let display_names: Vec<&str> = grouped[0].1.iter().map(|s| s.name()).collect();
+        assert_eq!(display_names, ["Data table", "Card"]);
+    }
+
+    // U4 (AC7): builder-side gallery — builtin-free constructor, seeded
+    // constructor, and extend with a custom `story!`.
+    #[test]
+    fn gallery_new_is_empty_builtin_is_seeded_extend_appends() {
+        assert!(
+            StoryGallery::new().into_registry().stories().is_empty(),
+            "StoryGallery::new() must start builtin-free"
+        );
+
+        let builtin_count = builtin().stories().len();
+        assert!(builtin_count > 0, "builtin registry must not be empty");
+        assert_eq!(
+            StoryGallery::builtin().into_registry().stories().len(),
+            builtin_count,
+            "StoryGallery::builtin() must be seeded with exactly the builtin stories"
+        );
+
+        let custom = crate::stories::story! {
+            "App",
+            "Badge",
+            {
+                maud::html! { span { "hi" } }
+            }
+        };
+        let registry = StoryGallery::builtin().extend([custom]).into_registry();
+        assert_eq!(registry.stories().len(), builtin_count + 1);
+        assert!(
+            registry.find("badge").is_some(),
+            "extended custom story must be findable by its slug"
+        );
+    }
+
+    fn panicking_story() -> maud::Markup {
+        panic!("story exploded on purpose")
+    }
+
+    // U5 (AC8, R4): a panicking story surfaces as an error, it does not
+    // unwind through the gallery.
+    #[test]
+    fn story_render_catches_panic() {
+        let boom = Story::new("Display", "Boom", panicking_story, "panicking_story()");
+        let err = boom
+            .render()
+            .expect_err("panic must be caught and reported as an error");
+        assert!(
+            matches!(err, StoryRenderError::Panicked { .. }),
+            "expected StoryRenderError::Panicked, got {err:?}"
+        );
+
+        let fine = Story::new("Display", "Fine", demo_markup, "demo()");
+        assert!(fine.render().is_ok());
+    }
+
+    // U6 (AC4): the index page links the framework widget stylesheet and
+    // lists stories grouped in the sidebar.
+    #[test]
+    fn index_page_links_widgets_css_and_groups_stories() {
+        assert_eq!(STORIES_PATH, "/_stories");
+
+        let registry = StoryRegistry::new(vec![
+            demo_story("Display", "Data table"),
+            demo_story("Forms", "Active search"),
+        ]);
+        let page = render_story_index(&registry).into_string();
+        let dom = crate::test_html::parse(&page);
+
+        let css_selector = crate::test_html::SelectorList::parse(&format!(
+            "link[href=\"{}\"]",
+            crate::ui::WIDGETS_CSS_PATH
+        ))
+        .expect("selector parses");
+        assert!(
+            !css_selector.matches(&dom).is_empty(),
+            "index must link the framework widget stylesheet: {page}"
+        );
+
+        let link_selector =
+            crate::test_html::SelectorList::parse("a[href=\"/_stories/data-table\"]")
+                .expect("selector parses");
+        assert!(
+            !link_selector.matches(&dom).is_empty(),
+            "index must link each story detail page: {page}"
+        );
+
+        assert!(
+            page.contains("Display") && page.contains("Forms"),
+            "sidebar must show group headings: {page}"
+        );
+    }
+
+    // U7 (AC4): the detail page shows the live render plus Source and
+    // Rendered HTML tabs (dogfooding the `tabs` widget).
+    #[test]
+    fn detail_page_has_live_render_source_tab_and_html_tab() {
+        let story = crate::stories::story! {
+            "Display",
+            "Proof",
+            {
+                maud::html! { p class="proof-marker" { "live proof" } }
+            }
+        };
+        let page = render_story_detail(&story).into_string();
+        let dom = crate::test_html::parse(&page);
+
+        let preview = crate::test_html::SelectorList::parse(".story-preview .proof-marker")
+            .expect("selector parses");
+        let matches = preview.matches(&dom);
+        assert!(
+            !matches.is_empty(),
+            "live render must appear inside .story-preview: {page}"
+        );
+        assert!(
+            matches[0].text().contains("live proof"),
+            "live render must contain the story's output: {page}"
+        );
+
+        let tabs = crate::test_html::SelectorList::parse(".autumn-tabs").expect("selector parses");
+        assert!(
+            !tabs.matches(&dom).is_empty(),
+            "detail page must use the tabs widget for Source / Rendered HTML: {page}"
+        );
+
+        assert!(
+            page.contains("maud::html!"),
+            "Source tab must show the captured snippet: {page}"
+        );
+        assert!(
+            page.contains("&lt;p"),
+            "Rendered HTML tab must show the escaped markup: {page}"
+        );
+    }
+
+    // U8 (AC4/AC5, R12): enabled-but-unregistered renders a helpful empty
+    // state pointing at AppBuilder::with_story_gallery, not a 500/blank page.
+    #[test]
+    fn index_empty_state_mentions_with_story_gallery() {
+        let page = render_story_index(&StoryRegistry::default()).into_string();
+        assert!(
+            page.contains("with_story_gallery"),
+            "empty state must explain how to register stories: {page}"
+        );
+    }
+}

--- a/autumn/src/stories/mod.rs
+++ b/autumn/src/stories/mod.rs
@@ -382,25 +382,26 @@ fn story_detail_response(state: &AppState, slug: &str) -> Response {
         return (http::StatusCode::NOT_FOUND, Html(page.into_string())).into_response();
     };
 
-    if let Err(error) = story.render() {
-        let page = story_page(
-            "Story failed to render",
-            &maud::html! {
-                main class="story-content" {
-                    h1 { "Story failed to render" }
-                    p { (error.to_string()) }
-                    p { a href=(STORIES_PATH) { "Back to the gallery" } }
-                }
-            },
-        );
-        return (
-            http::StatusCode::INTERNAL_SERVER_ERROR,
-            Html(page.into_string()),
-        )
-            .into_response();
+    match story.render() {
+        Ok(rendered) => Html(render_story_detail(story, &rendered).into_string()).into_response(),
+        Err(error) => {
+            let page = story_page(
+                "Story failed to render",
+                &maud::html! {
+                    main class="story-content" {
+                        h1 { "Story failed to render" }
+                        p { (error.to_string()) }
+                        p { a href=(STORIES_PATH) { "Back to the gallery" } }
+                    }
+                },
+            );
+            (
+                http::StatusCode::INTERNAL_SERVER_ERROR,
+                Html(page.into_string()),
+            )
+                .into_response()
+        }
     }
-
-    Html(render_story_detail(story).into_string()).into_response()
 }
 
 /// Minimal gallery chrome layered on top of the framework widget stylesheet.
@@ -482,10 +483,11 @@ fn render_story_index(registry: &StoryRegistry) -> maud::Markup {
 
 /// Render a single story's detail page: live render above Source and
 /// Rendered HTML tabs (dogfooding the [`crate::widgets::tabs`] widget).
-fn render_story_detail(story: &Story) -> maud::Markup {
-    let rendered = story.render().unwrap_or_else(|error| {
-        maud::html! { p class="story-render-error" { (error.to_string()) } }
-    });
+///
+/// `rendered` is the story's markup, rendered exactly once by the caller
+/// (which also owns the render-failure response), so the preview and the
+/// Rendered HTML tab always show the same output.
+fn render_story_detail(story: &Story, rendered: &maud::Markup) -> maud::Markup {
     let rendered_html = rendered.clone().into_string();
     story_page(
         story.name(),
@@ -693,7 +695,8 @@ mod tests {
                 maud::html! { p class="proof-marker" { "live proof" } }
             }
         };
-        let page = render_story_detail(&story).into_string();
+        let rendered = story.render().expect("proof story renders");
+        let page = render_story_detail(&story, &rendered).into_string();
         let dom = crate::test_html::parse(&page);
 
         let preview = crate::test_html::SelectorList::parse(".story-preview .proof-marker")

--- a/autumn/src/stories/mod.rs
+++ b/autumn/src/stories/mod.rs
@@ -10,9 +10,11 @@
 //! Two switches gate the gallery:
 //!
 //! 1. **Registration** — `AppBuilder::with_story_gallery(StoryGallery::builtin())`
-//!    installs the [`StoryRegistry`] on [`AppState`](crate::AppState).
+//!    installs the [`StoryRegistry`](crate::stories::StoryRegistry) on
+//!    [`AppState`](crate::AppState).
 //! 2. **Config** — the routes mount only when the resolved config has
-//!    `[stories] enabled = true` ([`StoriesConfig`], default **false**).
+//!    `[stories] enabled = true` ([`StoriesConfig`](crate::stories::StoriesConfig),
+//!    default **false**).
 //!    Unlike the dev-only mail preview, stories may be enabled in *any*
 //!    profile (a public showcase is a supported use); safe because stories
 //!    only ever render synthetic demo data.
@@ -165,8 +167,8 @@ pub enum StoryRenderError {
 }
 
 /// Immutable collection of registered stories, stored on
-/// [`AppState`](crate::AppState) as an extension by
-/// [`AppBuilder::with_story_gallery`](crate::AppBuilder::with_story_gallery).
+/// [`AppState`] as an extension by
+/// [`AppBuilder::with_story_gallery`](crate::app::AppBuilder::with_story_gallery).
 #[derive(Debug, Clone, Default)]
 pub struct StoryRegistry {
     stories: Arc<Vec<Story>>,
@@ -238,7 +240,7 @@ pub fn builtin() -> StoryRegistry {
 }
 
 /// Builder-side collection of stories, registered with
-/// [`AppBuilder::with_story_gallery`](crate::AppBuilder::with_story_gallery).
+/// [`AppBuilder::with_story_gallery`](crate::app::AppBuilder::with_story_gallery).
 ///
 /// Start from [`StoryGallery::builtin`] to serve the framework widget set,
 /// or [`StoryGallery::new`] for an app-only gallery, then [`extend`](Self::extend)
@@ -281,8 +283,8 @@ impl StoryGallery {
     ///
     /// The framework mounts this automatically when the resolved config has
     /// `[stories] enabled = true`; handlers read the [`StoryRegistry`] from
-    /// the [`AppState`](crate::AppState) extension installed by
-    /// [`AppBuilder::with_story_gallery`](crate::AppBuilder::with_story_gallery),
+    /// the [`AppState`] extension installed by
+    /// [`AppBuilder::with_story_gallery`](crate::app::AppBuilder::with_story_gallery),
     /// so manual mounters must install that extension too.
     pub fn routes<S>() -> axum::Router<S>
     where

--- a/autumn/tests/compile-fail/story_captures_environment.rs
+++ b/autumn/tests/compile-fail/story_captures_environment.rs
@@ -1,0 +1,18 @@
+//! AC1/AC2 (issue #1526): a `story!` block is coerced to a plain
+//! `fn() -> Markup` pointer, so capturing anything from the surrounding
+//! environment (a Db handle, AppState, request data, or any local) must be
+//! a compile error — stories are zero-arg pure functions by construction.
+
+use autumn_web::stories::story;
+
+fn main() {
+    let database_url = String::from("postgres://localhost/demo");
+
+    let _story = story! {
+        "App",
+        "Leaky",
+        {
+            maud::html! { p { (database_url) } }
+        }
+    };
+}

--- a/autumn/tests/compile-fail/story_captures_environment.stderr
+++ b/autumn/tests/compile-fail/story_captures_environment.stderr
@@ -1,0 +1,27 @@
+error[E0308]: mismatched types
+  --> tests/compile-fail/story_captures_environment.rs:11:18
+   |
+11 |       let _story = story! {
+   |  __________________^
+12 | |         "App",
+13 | |         "Leaky",
+...  |
+17 | |     };
+   | |     ^
+   | |     |
+   | |_____expected fn pointer, found closure
+   |       arguments to this function are incorrect
+   |
+   = note: expected fn pointer `fn() -> PreEscaped<std::string::String>`
+                 found closure `{closure@$DIR/tests/compile-fail/story_captures_environment.rs:11:18: 17:6}`
+note: closures can only be coerced to `fn` types if they do not capture any variables
+  --> tests/compile-fail/story_captures_environment.rs:15:32
+   |
+15 |             maud::html! { p { (database_url) } }
+   |                                ^^^^^^^^^^^^ `database_url` captured here
+note: associated function defined here
+  --> src/stories/mod.rs
+   |
+   |     pub fn new(
+   |            ^^^
+   = note: this error originates in the macro `story` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/autumn/tests/fixtures/schema_keys.snapshot
+++ b/autumn/tests/fixtures/schema_keys.snapshot
@@ -49,6 +49,7 @@ server.timeouts.request_timeout_ms
 server.unix_socket
 session
 storage
+stories
 telemetry
 tenancy
 time_zone

--- a/autumn/tests/integration/compile_fail.rs
+++ b/autumn/tests/integration/compile_fail.rs
@@ -39,6 +39,12 @@ fn compile_fail_tests() {
 
     #[cfg(feature = "db")]
     t.compile_fail("tests/compile-fail/repository_bulk_upsert_many_hooks.rs");
+
+    // `story!` blocks must be zero-arg pure functions: the block is coerced
+    // to a plain `fn() -> Markup`, so environment capture cannot compile
+    // (issue #1526).
+    #[cfg(feature = "maud")]
+    t.compile_fail("tests/compile-fail/story_captures_environment.rs");
 }
 
 #[test]

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -142,6 +142,8 @@ mod signed_webhooks;
 mod static_serving;
 #[cfg(feature = "storage")]
 mod storage_local_integration;
+#[cfg(feature = "maud")]
+mod stories;
 #[cfg(feature = "system-tests")]
 mod system_test_api;
 #[cfg(feature = "db")]

--- a/autumn/tests/integration/schema_drift_guard.rs
+++ b/autumn/tests/integration/schema_drift_guard.rs
@@ -51,13 +51,14 @@ use std::collections::BTreeSet;
 /// `#[cfg(feature = "...")]`. Keep in sync with `config.rs`'s `AutumnConfig`
 /// struct — [`feature_gated_roots_mapping_matches_config_when_enabled`] below
 /// self-checks this list whenever a listed feature happens to be enabled.
-const fn feature_gated_roots() -> [(bool, &'static str); 5] {
+const fn feature_gated_roots() -> [(bool, &'static str); 6] {
     [
         (cfg!(feature = "i18n"), "i18n"),
         (cfg!(feature = "mail"), "mail"),
         (cfg!(feature = "storage"), "storage"),
         (cfg!(feature = "http-client"), "http"),
         (cfg!(feature = "reporting"), "reporting"),
+        (cfg!(feature = "maud"), "stories"),
     ]
 }
 

--- a/autumn/tests/integration/stories.rs
+++ b/autumn/tests/integration/stories.rs
@@ -1,0 +1,476 @@
+//! CI anti-rot harness for the widget story gallery (issue #1526).
+//!
+//! Renders every built-in story (no panic, non-empty, balanced HTML, unique
+//! slugs), enforces the story coverage gate against `src/widgets.rs`, and
+//! pins the `story!` macro's source-fidelity and zero-arg purity contracts.
+//!
+//! Run with `cargo test -p autumn-web --test integration_tests stories`.
+
+#![cfg(feature = "maud")]
+
+use autumn_web::config::{AutumnConfig, MockEnv};
+use autumn_web::stories::{self, Story, StoryGallery, StoryRegistry, story};
+
+// ── Strict balanced-HTML checker ─────────────────────────────────────────
+//
+// `autumn_web`'s internal `test_html` parser is crate-private (and lenient:
+// it auto-closes). This local checker is strict: every non-void open tag must
+// be closed by a matching close tag, in order.
+
+/// Elements that never take a closing tag.
+const VOID_ELEMENTS: &[&str] = &[
+    "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source",
+    "track", "wbr",
+];
+
+/// Elements whose content is raw text (no nested tags are parsed).
+const RAW_TEXT_ELEMENTS: &[&str] = &["script", "style", "textarea", "title"];
+
+/// Panics with a descriptive message when `html` is not well-formed
+/// (mismatched, unclosed, or stray-closed tags).
+fn assert_balanced_html(html: &str, context: &str) {
+    let bytes = html.as_bytes();
+    let mut stack: Vec<String> = Vec::new();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] != b'<' {
+            i += 1;
+            continue;
+        }
+        if html[i..].starts_with("<!--") {
+            let end = html[i + 4..]
+                .find("-->")
+                .unwrap_or_else(|| panic!("unterminated comment in {context}:\n{html}"));
+            i += 4 + end + 3;
+            continue;
+        }
+        if html[i..].starts_with("<!") {
+            // Doctype or other declaration.
+            let end = html[i..]
+                .find('>')
+                .unwrap_or_else(|| panic!("unterminated declaration in {context}:\n{html}"));
+            i += end + 1;
+            continue;
+        }
+
+        let closing = html[i..].starts_with("</");
+        let name_start = i + if closing { 2 } else { 1 };
+        let name_len = html[name_start..]
+            .find(|c: char| !(c.is_ascii_alphanumeric() || c == '-'))
+            .unwrap_or(html.len() - name_start);
+        let name = html[name_start..name_start + name_len].to_ascii_lowercase();
+        assert!(
+            !name.is_empty(),
+            "malformed tag at byte {i} in {context}:\n{html}"
+        );
+
+        // Find the true end of the tag, skipping `>` inside quoted attributes.
+        let mut j = name_start + name_len;
+        let mut quote: Option<u8> = None;
+        while j < bytes.len() {
+            match (quote, bytes[j]) {
+                (Some(q), c) if c == q => quote = None,
+                (Some(_), _) => {}
+                (None, b'"') => quote = Some(b'"'),
+                (None, b'\'') => quote = Some(b'\''),
+                (None, b'>') => break,
+                (None, _) => {}
+            }
+            j += 1;
+        }
+        assert!(
+            j < bytes.len(),
+            "unterminated tag <{name} in {context}:\n{html}"
+        );
+        let self_closing = j > 0 && bytes[j - 1] == b'/';
+
+        if closing {
+            let open = stack.pop().unwrap_or_else(|| {
+                panic!("closing </{name}> with no open tag in {context}:\n{html}")
+            });
+            assert_eq!(
+                open, name,
+                "mismatched close tag in {context}: expected </{open}>, found </{name}>:\n{html}"
+            );
+            i = j + 1;
+            continue;
+        }
+
+        if !self_closing && !VOID_ELEMENTS.contains(&name.as_str()) {
+            if RAW_TEXT_ELEMENTS.contains(&name.as_str()) {
+                // Skip raw content up to the matching close tag.
+                let close = format!("</{name}");
+                let rest_start = j + 1;
+                let end = html[rest_start..]
+                    .to_ascii_lowercase()
+                    .find(&close)
+                    .unwrap_or_else(|| {
+                        panic!("unclosed raw-text element <{name}> in {context}:\n{html}")
+                    });
+                let close_gt = html[rest_start + end..]
+                    .find('>')
+                    .unwrap_or_else(|| panic!("unterminated </{name}> in {context}:\n{html}"));
+                i = rest_start + end + close_gt + 1;
+                continue;
+            }
+            stack.push(name);
+        }
+        i = j + 1;
+    }
+
+    assert!(
+        stack.is_empty(),
+        "unclosed tags {stack:?} in {context}:\n{html}"
+    );
+}
+
+#[test]
+fn balanced_html_checker_rejects_malformed_markup() {
+    // Sanity-check the harness itself so a broken checker can't green-light
+    // rotten widget markup.
+    assert_balanced_html(
+        r#"<div class="a > b"><p>ok<br></p></div><input value="x">"#,
+        "self-test",
+    );
+    for bad in ["<div><p></div>", "<div>", "</div>", "<span><b></span></b>"] {
+        let result = std::panic::catch_unwind(|| assert_balanced_html(bad, "self-test"));
+        assert!(result.is_err(), "checker should reject {bad}");
+    }
+}
+
+// ── T7 (AC3/AC8): every builtin story renders, panic-free and non-empty ──
+
+#[test]
+fn every_builtin_story_renders_without_panic_and_nonempty() {
+    let registry = stories::builtin();
+    assert!(
+        !registry.stories().is_empty(),
+        "stories::builtin() must ship at least one story per gallery-visible widget"
+    );
+    for story in registry.stories() {
+        let markup = story.render().unwrap_or_else(|err| {
+            panic!("builtin story `{}` failed to render: {err}", story.slug())
+        });
+        assert!(
+            !markup.into_string().trim().is_empty(),
+            "builtin story `{}` rendered empty markup",
+            story.slug()
+        );
+    }
+}
+
+// ── T8 (AC8, R9): rendered builtin HTML is well-formed/balanced ──────────
+
+#[test]
+fn every_builtin_story_renders_balanced_html() {
+    for story in stories::builtin().stories() {
+        let html = story
+            .render()
+            .unwrap_or_else(|err| panic!("builtin story `{}` failed: {err}", story.slug()))
+            .into_string();
+        assert_balanced_html(&html, &format!("builtin story `{}`", story.slug()));
+    }
+}
+
+// ── T9 (AC8): slugs unique + well-formed, groups/names non-empty ─────────
+
+fn is_well_formed_slug(slug: &str) -> bool {
+    // ^[a-z0-9]+(-[a-z0-9]+)*$ without pulling in a regex dependency.
+    !slug.is_empty()
+        && !slug.starts_with('-')
+        && !slug.ends_with('-')
+        && !slug.contains("--")
+        && slug
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+#[test]
+fn builtin_slugs_unique_groups_and_names_nonempty() {
+    let registry = stories::builtin();
+    let mut seen = std::collections::HashSet::new();
+    for story in registry.stories() {
+        assert!(
+            !story.group().trim().is_empty(),
+            "story `{}` has an empty group",
+            story.slug()
+        );
+        assert!(
+            !story.name().trim().is_empty(),
+            "story `{}` has an empty name",
+            story.slug()
+        );
+        assert!(
+            is_well_formed_slug(story.slug()),
+            "slug `{}` must match ^[a-z0-9]+(-[a-z0-9]+)*$",
+            story.slug()
+        );
+        assert!(
+            seen.insert(story.slug().to_owned()),
+            "duplicate builtin slug `{}`",
+            story.slug()
+        );
+    }
+}
+
+// ── T10 (AC9): coverage gate part 1 — inventory diffed both directions ───
+
+/// Expected slugs: one story per gallery-visible widget in
+/// `autumn/src/widgets.rs` (plan D7). Adding a widget without a story fails
+/// this gate; removing a widget without pruning its story fails the reverse
+/// direction.
+const EXPECTED_STORY_SLUGS: &[&str] = &[
+    "active-search",
+    "autocomplete",
+    "breadcrumb",
+    "card",
+    "confirm-action",
+    "data-table",
+    "hero",
+    "modal",
+    "nav-bar",
+    "nav-link",
+    "property-list",
+    "stat-card",
+    "tabs",
+];
+
+#[test]
+fn story_coverage_inventory_matches_registry() {
+    let registry = stories::builtin();
+    let actual: std::collections::BTreeSet<&str> =
+        registry.stories().iter().map(|s| s.slug()).collect();
+
+    for expected in EXPECTED_STORY_SLUGS {
+        assert!(
+            actual.contains(expected),
+            "widget `{expected}` has no builtin story — add a story! for it in \
+             autumn/src/stories/builtin.rs"
+        );
+    }
+    for slug in &actual {
+        assert!(
+            EXPECTED_STORY_SLUGS.contains(slug),
+            "builtin story `{slug}` is missing from EXPECTED_STORY_SLUGS — add it to the \
+             inventory in autumn/tests/integration/stories.rs (or remove the stale story)"
+        );
+    }
+}
+
+// ── T11 (AC9, R1): coverage gate part 2 — fn-name scan of widgets.rs ─────
+
+#[test]
+fn every_public_widget_fn_is_exercised_by_a_story() {
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let source = std::fs::read_to_string(manifest_dir.join("src/widgets.rs"))
+        .expect("failed to read src/widgets.rs");
+
+    // Production lines only (widget_css_coverage.rs discipline), stripped of
+    // `//` comments. Top-level widget fns start at column 0; config-struct
+    // methods are indented and deliberately excluded.
+    let mut widget_fns = Vec::new();
+    for line in source.lines().take_while(|l| l.trim() != "mod tests {") {
+        let code = line.split("//").next().unwrap_or("");
+        if let Some(rest) = code.strip_prefix("pub fn ") {
+            let name_len = rest
+                .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+                .unwrap_or(rest.len());
+            let name = &rest[..name_len];
+            if !name.is_empty() {
+                widget_fns.push(name.to_owned());
+            }
+        }
+    }
+    assert!(
+        widget_fns.len() >= 20,
+        "widgets.rs scan looks broken; found only {widget_fns:?}"
+    );
+
+    let all_sources: String = stories::builtin()
+        .stories()
+        .iter()
+        .map(|s| s.source())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let missing: Vec<&String> = widget_fns
+        .iter()
+        .filter(|name| !all_sources.contains(name.as_str()))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "widget fn(s) with no story mentioning them: {missing:?}\n\
+         Add a story!{{}} block exercising them in autumn/src/stories/builtin.rs and, for a \
+         new top-level widget, add its slug to EXPECTED_STORY_SLUGS in \
+         autumn/tests/integration/stories.rs."
+    );
+}
+
+// ── T12 (AC1): stories are zero-arg pure fn pointers ─────────────────────
+
+fn zero_arg_demo() -> maud::Markup {
+    maud::html! { p { "pure" } }
+}
+
+#[test]
+fn stories_are_zero_arg_fn_pointers() {
+    // `Story::new` accepts only a plain `fn() -> Markup` pointer, so a story
+    // can never smuggle in a Db handle, AppState, or request data. (The
+    // negative half — a capturing block failing to compile — is the trybuild
+    // case tests/compile-fail/story_captures_environment.rs.)
+    let render: fn() -> maud::Markup = zero_arg_demo;
+    let story = Story::new("Test", "Pure", zero_arg_demo, "zero_arg_demo()");
+    assert_eq!(
+        story
+            .render()
+            .expect("zero-arg story renders")
+            .into_string(),
+        render().into_string()
+    );
+}
+
+// ── T13 (AC5/AC6): config defaults off + layers by profile + env override ─
+
+#[test]
+fn stories_config_defaults_off_and_layers_by_profile() {
+    assert!(
+        !AutumnConfig::default().stories.enabled,
+        "stories gallery must be off by default"
+    );
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("autumn.toml"),
+        r#"
+[stories]
+enabled = false
+
+[profile.dev.stories]
+enabled = true
+"#,
+    )
+    .expect("write autumn.toml");
+    let manifest_dir = dir.path().to_str().unwrap();
+
+    let dev = MockEnv::new()
+        .with("AUTUMN_MANIFEST_DIR", manifest_dir)
+        .with("AUTUMN_ENV", "dev");
+    assert!(
+        AutumnConfig::load_with_env(&dev)
+            .expect("dev config loads")
+            .stories
+            .enabled,
+        "[profile.dev.stories] enabled = true must win over the base in dev"
+    );
+
+    let prod = MockEnv::new()
+        .with("AUTUMN_MANIFEST_DIR", manifest_dir)
+        .with("AUTUMN_ENV", "prod");
+    assert!(
+        !AutumnConfig::load_with_env(&prod)
+            .expect("prod config loads")
+            .stories
+            .enabled,
+        "base enabled = false must hold in prod when only dev overrides"
+    );
+
+    // Env override wins in any profile.
+    let empty_dir = tempfile::tempdir().expect("tempdir");
+    let env_override = MockEnv::new()
+        .with("AUTUMN_MANIFEST_DIR", empty_dir.path().to_str().unwrap())
+        .with("AUTUMN_ENV", "prod")
+        .with("AUTUMN_STORIES__ENABLED", "true");
+    assert!(
+        AutumnConfig::load_with_env(&env_override)
+            .expect("env-override config loads")
+            .stories
+            .enabled,
+        "AUTUMN_STORIES__ENABLED=true must enable the gallery"
+    );
+}
+
+// ── T14 (AC2, R2): the snippet is provably the code that rendered ────────
+
+#[test]
+fn story_macro_source_is_the_executed_code() {
+    let story = story! {
+        "Test",
+        "Fidelity",
+        {
+            // fidelity-comment: proves byte-level source capture
+            maud::html! { p { "fidelity-proof" } }
+        }
+    };
+
+    let rendered = story
+        .render()
+        .expect("fidelity story renders")
+        .into_string();
+    assert!(
+        rendered.contains("fidelity-proof"),
+        "the block must be executed for the live render: {rendered}"
+    );
+
+    assert_eq!(story.group(), "Test");
+    assert_eq!(story.name(), "Fidelity");
+    assert_eq!(story.slug(), "fidelity");
+
+    assert!(
+        story
+            .source()
+            .contains("// fidelity-comment: proves byte-level source capture"),
+        "comments must survive into the snippet (source-text capture, not token \
+         reconstruction): {}",
+        story.source()
+    );
+    assert!(
+        story
+            .source()
+            .contains(r#"maud::html! { p { "fidelity-proof" } }"#),
+        "the snippet must contain the exact expression text that rendered: {}",
+        story.source()
+    );
+}
+
+// ── T15 (AC7): gallery extend + builtin-free constructor ─────────────────
+
+#[test]
+fn gallery_extend_and_builtin_free_constructor() {
+    // Pins the prelude re-exports too (plan §4.9).
+    use autumn_web::prelude::{StoryGallery as PreludeStoryGallery, story as prelude_story};
+
+    assert!(
+        PreludeStoryGallery::new().stories().is_empty(),
+        "StoryGallery::new() must start builtin-free"
+    );
+
+    let builtin_count = stories::builtin().stories().len();
+    let custom = prelude_story! {
+        "App",
+        "Team badge",
+        {
+            maud::html! { span { "custom widget" } }
+        }
+    };
+    let gallery = StoryGallery::builtin().extend([custom]);
+    assert_eq!(
+        gallery.stories().len(),
+        builtin_count + 1,
+        "extend must append to the builtin set"
+    );
+    assert!(
+        gallery.stories().iter().any(|s| s.slug() == "team-badge"),
+        "extended custom story must be present under its slug"
+    );
+
+    // The registry type is also part of the public surface.
+    let registry: StoryRegistry = StoryRegistry::new(vec![prelude_story! {
+        "App",
+        "Solo",
+        {
+            maud::html! { p { "solo" } }
+        }
+    }]);
+    assert_eq!(registry.stories().len(), 1);
+}

--- a/autumn/tests/integration/stories.rs
+++ b/autumn/tests/integration/stories.rs
@@ -71,11 +71,10 @@ fn assert_balanced_html(html: &str, context: &str) {
         while j < bytes.len() {
             match (quote, bytes[j]) {
                 (Some(q), c) if c == q => quote = None,
-                (Some(_), _) => {}
                 (None, b'"') => quote = Some(b'"'),
                 (None, b'\'') => quote = Some(b'\''),
                 (None, b'>') => break,
-                (None, _) => {}
+                _ => {}
             }
             j += 1;
         }
@@ -240,7 +239,7 @@ const EXPECTED_STORY_SLUGS: &[&str] = &[
 fn story_coverage_inventory_matches_registry() {
     let registry = stories::builtin();
     let actual: std::collections::BTreeSet<&str> =
-        registry.stories().iter().map(|s| s.slug()).collect();
+        registry.stories().iter().map(Story::slug).collect();
 
     for expected in EXPECTED_STORY_SLUGS {
         assert!(
@@ -290,7 +289,7 @@ fn every_public_widget_fn_is_exercised_by_a_story() {
     let all_sources: String = stories::builtin()
         .stories()
         .iter()
-        .map(|s| s.source())
+        .map(Story::source)
         .collect::<Vec<_>>()
         .join("\n");
 
@@ -342,13 +341,13 @@ fn stories_config_defaults_off_and_layers_by_profile() {
     let dir = tempfile::tempdir().expect("tempdir");
     std::fs::write(
         dir.path().join("autumn.toml"),
-        r#"
+        r"
 [stories]
 enabled = false
 
 [profile.dev.stories]
 enabled = true
-"#,
+",
     )
     .expect("write autumn.toml");
     let manifest_dir = dir.path().to_str().unwrap();

--- a/autumn/tests/integration/stories.rs
+++ b/autumn/tests/integration/stories.rs
@@ -259,6 +259,46 @@ fn story_coverage_inventory_matches_registry() {
 
 // ── T11 (AC9, R1): coverage gate part 2 — fn-name scan of widgets.rs ─────
 
+/// True when `needle` occurs in `haystack` as a standalone identifier — i.e.
+/// not merely as a substring of a longer identifier (`card` inside
+/// `stat_card`, `search` inside `active_search`). Both neighbouring bytes
+/// must be non-identifier chars (`[^A-Za-z0-9_]`) or the string edge.
+fn contains_identifier(haystack: &str, needle: &str) -> bool {
+    let is_ident_byte = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+    let bytes = haystack.as_bytes();
+    let mut from = 0;
+    while let Some(offset) = haystack[from..].find(needle) {
+        let start = from + offset;
+        let end = start + needle.len();
+        let boundary_before = start == 0 || !is_ident_byte(bytes[start - 1]);
+        let boundary_after = end == bytes.len() || !is_ident_byte(bytes[end]);
+        if boundary_before && boundary_after {
+            return true;
+        }
+        from = start + 1;
+    }
+    false
+}
+
+#[test]
+fn contains_identifier_requires_identifier_boundaries() {
+    // Positive: true identifier occurrences (call sites, imports).
+    assert!(contains_identifier("let x = card(&config);", "card"));
+    assert!(contains_identifier(
+        "use autumn_web::widgets::{tabs};",
+        "tabs"
+    ));
+    assert!(contains_identifier("card", "card"));
+    // Negative: substrings of longer identifiers must NOT count — these are
+    // exactly the false-positive channels of a raw `contains` gate.
+    assert!(!contains_identifier("stat_card(&config)", "card"));
+    assert!(!contains_identifier("CardConfig::new()", "card"));
+    assert!(!contains_identifier("active_search(&config)", "search"));
+    assert!(!contains_identifier("modal_close_button(..)", "modal"));
+    assert!(!contains_identifier("nav_link_matched(..)", "nav_link"));
+    assert!(!contains_identifier("data_table(&config)", "table"));
+}
+
 #[test]
 fn every_public_widget_fn_is_exercised_by_a_story() {
     let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -295,7 +335,7 @@ fn every_public_widget_fn_is_exercised_by_a_story() {
 
     let missing: Vec<&String> = widget_fns
         .iter()
-        .filter(|name| !all_sources.contains(name.as_str()))
+        .filter(|name| !contains_identifier(&all_sources, name))
         .collect();
     assert!(
         missing.is_empty(),

--- a/docs/guide/stories.md
+++ b/docs/guide/stories.md
@@ -22,7 +22,7 @@ use autumn_web::prelude::*;
 
 #[autumn_web::main]
 async fn main() {
-    App::new()
+    autumn_web::app()
         .with_story_gallery(StoryGallery::builtin())
         .routes(routes![/* ... */])
         .run()
@@ -107,7 +107,9 @@ name with no alphanumeric characters panics at construction.
 
 A story that panics while rendering does not take the gallery down: the index
 never executes render functions, and the detail page returns a 500 error page
-naming the story.
+naming the story. Note that the caught panic still runs the process panic hook,
+so each view of a broken story's detail page emits a panic report to the logs —
+worth keeping in mind when exposing a gallery with custom stories publicly.
 
 ## Registering custom app widgets
 
@@ -130,10 +132,10 @@ fn app_stories() -> Vec<Story> {
 
 // Built-ins plus your own — your stories appear under their group ("App")
 // in the same sidebar:
-App::new().with_story_gallery(StoryGallery::builtin().extend(app_stories()));
+autumn_web::app().with_story_gallery(StoryGallery::builtin().extend(app_stories()));
 
 // Or an app-only gallery with no framework stories:
-App::new().with_story_gallery(StoryGallery::new().extend(app_stories()));
+autumn_web::app().with_story_gallery(StoryGallery::new().extend(app_stories()));
 ```
 
 `StoryGallery::routes()` returns the underlying sub-router if you need to
@@ -173,6 +175,6 @@ Configuration:
 |-----|---------|---------|
 | `stories.enabled` | `false` | Mount the gallery routes (any profile; `AUTUMN_STORIES__ENABLED` overrides) |
 
-Related: the dev mail preview (`/_autumn/mail`, see the mail guide) follows
+Related: the dev mail preview (`/_autumn/mail`, see the [mail guide](mail.md)) follows
 the same registry-plus-config pattern but is hardwired dev-only; the story
 gallery is profile-agnostic by design.

--- a/docs/guide/stories.md
+++ b/docs/guide/stories.md
@@ -1,0 +1,178 @@
+# Widget stories
+
+Autumn ships a Storybook-equivalent for its built-in maud widgets: a browsable
+gallery at `/_stories` where every widget renders live above the exact source
+snippet that produced it, plus a CI harness that fails the framework build when
+a widget loses its example or stops rendering. Apps can serve the built-in
+gallery as-is, extend it with their own widgets, or run an app-only gallery.
+
+The index page lists stories in a grouped sidebar; each detail page at
+`/_stories/{slug}` shows the live render, a **Source** tab with a copyable
+snippet, and a **Rendered HTML** tab with the escaped output — styled by the
+same framework widget stylesheet (`autumn-widgets.css`) your app already
+serves.
+
+## Enabling the gallery
+
+Two switches are required — registering the gallery on the builder, and
+enabling the routes in config:
+
+```rust
+use autumn_web::prelude::*;
+
+#[autumn_web::main]
+async fn main() {
+    App::new()
+        .with_story_gallery(StoryGallery::builtin())
+        .routes(routes![/* ... */])
+        .run()
+        .await;
+}
+```
+
+```toml
+[stories]
+enabled = true
+```
+
+Without the config flag the routes are absent (`/_stories` → 404) even when a
+gallery is registered; without the registration the routes serve an empty-state
+page pointing at `with_story_gallery`. The environment override is
+`AUTUMN_STORIES__ENABLED=true`.
+
+`/_stories` is a reserved framework path while the gallery is enabled, like
+`/_autumn/mail` for the mail preview.
+
+## Dev-only vs public showcase (profiles)
+
+Unlike the dev-only mail preview, stories may be enabled in **any** profile —
+serving the gallery publicly is a supported use, and it is safe because stories
+only ever render synthetic demo data defined inside their own blocks. Profile
+gating uses the standard config layering:
+
+```toml
+# Private app: gallery under `autumn dev`, 404 in prod.
+[stories]
+enabled = false
+
+[profile.dev.stories]
+enabled = true
+```
+
+```toml
+# Public showcase: gallery served in production.
+[stories]
+enabled = false
+
+[profile.prod.stories]
+enabled = true
+```
+
+Wherever the resolved flag is false, the routes are not mounted at all — the
+gallery is absent, not merely hidden.
+
+## Authoring stories with `story!`
+
+A story is a group, a name, and a brace-delimited block:
+
+```rust
+use autumn_web::prelude::*;
+
+let badge = story! {
+    "App",
+    "Team badge",
+    {
+        maud::html! { span class="team-badge" { "Platform" } }
+    }
+};
+```
+
+The block is **both** executed for the live render **and** captured
+byte-for-byte — comments and formatting included — as the displayed snippet,
+so the code shown in the Source tab is provably the code that rendered.
+That imposes two rules:
+
+- **Blocks are self-contained.** Define demo data inside the block (a local
+  struct, a `vec!` of sample rows) so the snippet is a complete, copyable
+  example.
+- **Blocks are zero-arg pure functions.** The block is coerced to a plain
+  `fn() -> Markup` pointer, so capturing anything from the surrounding
+  environment — a `Db` handle, `AppState`, request data, any local — is a
+  compile error. No extractors, no async, no I/O.
+
+The URL slug derives from the name (`"Team badge"` → `team-badge`):
+lowercase, alphanumeric runs joined by `-`. Two stories whose names produce
+the same slug panic at startup with a message naming both — rename one. A
+name with no alphanumeric characters panics at construction.
+
+A story that panics while rendering does not take the gallery down: the index
+never executes render functions, and the detail page returns a 500 error page
+naming the story.
+
+## Registering custom app widgets
+
+Extend the built-in set, or start empty with the builtin-free constructor:
+
+```rust
+use autumn_web::prelude::*;
+
+fn app_stories() -> Vec<Story> {
+    vec![
+        story! {
+            "App",
+            "Team badge",
+            {
+                maud::html! { span class="team-badge" { "Platform" } }
+            }
+        },
+    ]
+}
+
+// Built-ins plus your own — your stories appear under their group ("App")
+// in the same sidebar:
+App::new().with_story_gallery(StoryGallery::builtin().extend(app_stories()));
+
+// Or an app-only gallery with no framework stories:
+App::new().with_story_gallery(StoryGallery::new().extend(app_stories()));
+```
+
+`StoryGallery::routes()` returns the underlying sub-router if you need to
+mount it manually; note the handlers read the registry from the `AppState`
+extension, so `with_story_gallery` (which installs it) is the normal path.
+
+## What CI checks
+
+For framework contributors, `autumn/tests/integration/stories.rs` is the
+anti-rot harness. On every `cargo test` it renders each built-in story and
+asserts no panic, non-empty output, balanced/well-formed HTML, unique
+well-formed slugs, and non-empty groups and names. A two-layer coverage gate
+then enforces that widgets cannot ship without examples:
+
+1. an `EXPECTED_STORY_SLUGS` inventory is diffed both ways against
+   `stories::builtin()`, and
+2. every public widget fn in `src/widgets.rs` must appear in at least one
+   builtin story's source.
+
+Adding a widget without a story fails CI with instructions: add a `story!`
+block in `autumn/src/stories/builtin.rs` and, for a new top-level widget, add
+its slug to the inventory.
+
+## Reference
+
+Routes (mounted iff `stories.enabled` resolves true; listed by
+`autumn routes` under the same condition):
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/_stories` | Grouped story index |
+| GET | `/_stories/{slug}` | Live render + Source + Rendered HTML tabs |
+
+Configuration:
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `stories.enabled` | `false` | Mount the gallery routes (any profile; `AUTUMN_STORIES__ENABLED` overrides) |
+
+Related: the dev mail preview (`/_autumn/mail`, see the mail guide) follows
+the same registry-plus-config pattern but is hardwired dev-only; the story
+gallery is profile-agnostic by design.


### PR DESCRIPTION
Closes #1526

## Before / After

**Before:** Autumn ships a growing set of built-in maud widgets, but there is no way to browse them without hand-building a throwaway app, and nothing stops a widget from rotting — a signature or template can drift and only break when a downstream app upgrades.

**After:** an opt-in `/_stories` gallery renders every built-in widget live, with a grouped sidebar index and a per-story detail page offering the live render plus Source and Rendered-HTML tabs. Stories are authored with a `story!` macro whose block is both executed for the render and captured as the displayed snippet, so the shown code is provably the code that rendered. A CI gate fails the build when a widget lacks a story, so widgets can't silently rot between releases.

## How

A new `story!` proc-macro in `autumn-macros` captures the story block's exact source via `Span::source_text` (token-stream fallback when unavailable) while also emitting it as the zero-arg render fn. In `autumn-web`, a `stories` module provides `Story`/`StoryRegistry`/`StoryGallery`, mirroring the existing mail-preview registry pattern (registry stored as a state extension, sub-router merged conditionally in `build_router`). Mounting is via `AppBuilder::with_story_gallery(...)`, gated by a new `[stories] enabled` config section that is off by default and resolves through the existing profile layering, so a private app can enable it only under `dev` while a public showcase enables it in `prod`. `stories::builtin()` seeds 13 built-in stories covering every gallery-visible widget, and the coverage gate diffs the `pub fn`s of `widgets.rs` (identifier-boundary scan) plus a manual slug inventory against the registry, so adding a widget without a story fails CI. Developed test-first: failing tests landed before the implementation, followed by a refactor pass and review fixes.

## Acceptance criteria — evidence

| AC | Summary | Evidence (verified at HEAD d9340a3) |
|----|---------|-------------------------------------|
| AC1 | `stories` module + `Story`/`StoryRegistry`, zero-arg pure fns enforced | `slugify_handles_spaces_punctuation_unicode` (autumn/src/stories/mod.rs:537), `story_new_panics_on_name_that_slugifies_to_empty` (mod.rs:550), `registry_find_matches_slug` (mod.rs:556), `registry_new_panics_on_duplicate_slug` (mod.rs:574), `grouped_preserves_first_seen_group_and_registration_order` (mod.rs:584), `stories_are_zero_arg_fn_pointers` (autumn/tests/integration/stories.rs:356), trybuild compile-fail `story_captures_environment.rs` (autumn/tests/compile-fail/story_captures_environment.rs, registered at autumn/tests/integration/compile_fail.rs:47 with committed `.stderr`) |
| AC2 | `story!` macro: block both executed and captured as source | `story_macro_source_is_the_executed_code` (autumn/tests/integration/stories.rs:435 — byte-level `Span::source_text` fidelity incl. comment survival), `expands_to_story_new_with_group_name` (autumn-macros/src/story_macro.rs:177), `rejects_missing_block_and_non_literal_names` (story_macro.rs:199), `falls_back_to_token_stream_when_no_source_text` (story_macro.rs:228) |
| AC3 | `stories::builtin()` covers every gallery-visible widget | `every_builtin_story_renders_without_panic_and_nonempty` (autumn/tests/integration/stories.rs:144), `story_coverage_inventory_matches_registry` (stories.rs:239), `every_public_widget_fn_is_exercised_by_a_story` (stories.rs:303) |
| AC4 | Gallery routes: `/_stories` index + `/_stories/{slug}` detail (render + Source + Rendered-HTML tabs, autumn CSS) | `build_router_mounts_story_gallery_when_enabled` (autumn/src/router.rs:4664), `story_detail_route_serves_render_source_and_html` (router.rs:4688), `story_detail_unknown_slug_is_404` (router.rs:4719); structural: `index_page_links_widgets_css_and_groups_stories` (autumn/src/stories/mod.rs:653), `detail_page_has_live_render_source_tab_and_html_tab` (mod.rs:690), `gallery_index_and_detail_pages_render_balanced_html` (mod.rs:871) |
| AC5 | `AppBuilder::with_story_gallery` + `[stories] enabled` opt-in, off by default | `with_story_gallery_installs_story_registry_extension` (autumn/src/app.rs:10958 — builder plumbing through `build_state`), `build_router_omits_story_gallery_by_default` (autumn/src/router.rs:4741), `stories_config_defaults_off_and_layers_by_profile` (autumn/tests/integration/stories.rs:375), `enabled_without_registry_shows_empty_state` (router.rs:4863), `index_empty_state_mentions_with_story_gallery` (autumn/src/stories/mod.rs:733), `framework_routes_include_stories_when_enabled` (autumn/src/route_listing.rs:765), `try_build_router_rejects_openapi_path_on_story_gallery` (router.rs:5636, runs under `--features openapi`) |
| AC6 | Profile-scoped gating both ways; routes mount iff resolved flag | `story_routes_mount_iff_resolved_profile_flag` (autumn/src/router.rs:4774 — dev-only recipe: dev 200 / prod 404; public-showcase recipe: prod 200 / dev 404, end-to-end through `build_router`); config layering + `AUTUMN_STORIES__ENABLED` env override in `stories_config_defaults_off_and_layers_by_profile` (autumn/tests/integration/stories.rs:375) |
| AC7 | Custom app stories: `builtin().extend(...)` + builtin-free constructor | `custom_story_served_alongside_builtins` (autumn/src/router.rs:4818), `gallery_new_is_empty_builtin_is_seeded_extend_appends` (autumn/src/stories/mod.rs:600), `gallery_extend_and_builtin_free_constructor` (autumn/tests/integration/stories.rs:478 — also pins prelude re-exports) |
| AC8 | CI test renders every builtin: no panic, non-empty, balanced HTML, unique slugs, non-empty groups | `every_builtin_story_renders_without_panic_and_nonempty` (autumn/tests/integration/stories.rs:144), `every_builtin_story_renders_balanced_html` (stories.rs:165) + checker self-test `balanced_html_checker_rejects_malformed_markup` (stories.rs:128), `builtin_slugs_unique_groups_and_names_nonempty` (stories.rs:189), panic containment `story_render_catches_panic` (autumn/src/stories/mod.rs:636). **Deliberate deviation:** the issue names `autumn/tests/stories.rs`; tests live in the consolidated binary at `autumn/tests/integration/stories.rs` (module registered at autumn/tests/integration/mod.rs:146 under `#[cfg(feature = "maud")]`) per the repo CLAUDE.md integration-test-layout policy — same CI coverage, one fewer link step |
| AC9 | Coverage gate: inventory diffed vs registry; new widget without story fails CI | `story_coverage_inventory_matches_registry` (autumn/tests/integration/stories.rs:239, both directions), `every_public_widget_fn_is_exercised_by_a_story` (stories.rs:303, identifier-boundary scan of `widgets.rs` pub fns) + scan self-test `contains_identifier_requires_identifier_boundaries` (stories.rs:284) |
| AC10 | Guide doc `docs/guide/stories.md` | docs/guide/stories.md (180 lines): what the gallery is, enabling via `with_story_gallery` + `[stories] enabled`, dev-only vs public-showcase profile recipes, authoring with `story!`, registering custom app widgets, what CI checks, reference. All code samples compile-checked verbatim |

## Testing

Final gate numbers on this branch (HEAD d9340a3):

- `cargo test -p autumn-macros`: 350 passed, 0 failed
- `cargo test -p autumn-web`: lib 3036 passed; integration_tests 815 passed; doc-tests 188 passed; 0 failed
- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo check -p autumn-web --no-default-features`: clean (no new warnings vs baseline; cfg gating holds)
- `cargo test -p autumn-web --features openapi --lib try_build_router_rejects_openapi`: 7 passed (includes the new story-gallery reservation test; openapi is not a default feature)

## Notes for reviewers (incidental changes)

- **`router.rs` load-shed layer clone fix:** `build_router_pre_state` had a pre-existing `clippy::redundant_clone` on `load_shed_layer` (fails `-D warnings` on the base branch too, under default features). Fixed by taking a `#[cfg(feature = "mcp")]` clone before the move and using it in the mcp-gated `/mcp` envelope block. Verified semantics-preserving in every feature combo (the shared `Arc` in-flight counter behavior under `mcp` is unchanged; `cargo check`/`clippy -p autumn-web --features mcp` clean).
- **`tests/fixtures/schema_keys.snapshot`:** gained the new `stories` config root so the schema drift guard stays in step with the new `[stories]` section.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T2CszdYfAiVEbcW9AKiKmi)_