### PR TITLE
docs(plugin): refresh Claude plugin to current framework state + add freshness CI gate

### DIFF
--- a/.github/workflows/plugin-freshness.yml
+++ b/.github/workflows/plugin-freshness.yml
@@ -1,0 +1,34 @@
+name: Plugin Freshness
+
+# Keeps the Claude plugin (skills/, agents/, .claude-plugin/) from drifting
+# behind the framework: a PR that adds entries to CHANGELOG.md's Unreleased
+# Added/Changed sections must also touch the plugin, carry a [no-plugin]
+# token (in the bullet or PR body), or wear the `plugin-exempt` label.
+# Also sanity-checks that plugin.json parses and every docs/guide/*.md path
+# referenced from skills/ and agents/ exists.
+#
+# Single fast job, no Rust toolchain. Logic lives in
+# scripts/check-plugin-freshness.sh (run `--self-test` locally).
+
+on:
+  pull_request:
+    branches: [trunk, trunk-dev]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  plugin-freshness:
+    name: Plugin freshness
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'plugin-exempt') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check plugin freshness
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: bash scripts/check-plugin-freshness.sh

--- a/.github/workflows/plugin-freshness.yml
+++ b/.github/workflows/plugin-freshness.yml
@@ -4,9 +4,10 @@ name: Plugin Freshness
 # behind the framework: a PR that adds entries to CHANGELOG.md's Unreleased
 # Added/Changed sections must also touch the plugin, carry a [no-plugin]
 # token (per-bullet in the changelog, or PR-wide in the PR body), or wear
-# the `plugin-exempt` label.
+# the `plugin-exempt` label (which bypasses only the drift gate).
 # Also sanity-checks that plugin.json parses and every docs/guide/*.md path
-# referenced from skills/ and agents/ exists.
+# referenced from skills/ and agents/ exists — these static checks always
+# run, even on a `plugin-exempt`-labeled PR.
 #
 # Single fast job, no Rust toolchain. Logic lives in
 # scripts/check-plugin-freshness.sh (run `--self-test` locally).
@@ -31,7 +32,6 @@ jobs:
   plugin-freshness:
     name: Plugin freshness
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'plugin-exempt') }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -40,4 +40,5 @@ jobs:
         env:
           BASE_REF: origin/${{ github.base_ref }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          PLUGIN_EXEMPT_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'plugin-exempt') }}
         run: bash scripts/check-plugin-freshness.sh

--- a/.github/workflows/plugin-freshness.yml
+++ b/.github/workflows/plugin-freshness.yml
@@ -3,7 +3,8 @@ name: Plugin Freshness
 # Keeps the Claude plugin (skills/, agents/, .claude-plugin/) from drifting
 # behind the framework: a PR that adds entries to CHANGELOG.md's Unreleased
 # Added/Changed sections must also touch the plugin, carry a [no-plugin]
-# token (in the bullet or PR body), or wear the `plugin-exempt` label.
+# token (per-bullet in the changelog, or PR-wide in the PR body), or wear
+# the `plugin-exempt` label.
 # Also sanity-checks that plugin.json parses and every docs/guide/*.md path
 # referenced from skills/ and agents/ exists.
 #
@@ -13,6 +14,14 @@ name: Plugin Freshness
 on:
   pull_request:
     branches: [trunk, trunk-dev]
+    # Beyond the defaults (opened/synchronize/reopened): labeled/unlabeled so
+    # adding or removing `plugin-exempt` re-evaluates the gate, and edited so
+    # adding a [no-plugin] marker to the PR body does too — a plain re-run
+    # would reuse the stale event payload.
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,6 +352,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Accept-Encoding` accepts them, instead of relying solely on the
   general-purpose compression middleware to redo that work on every request.
 
+- **ci:** plugin freshness gate (`scripts/check-plugin-freshness.sh` +
+  `.github/workflows/plugin-freshness.yml`) — a PR that adds entries to this
+  changelog's Unreleased `Added`/`Changed` sections without touching the
+  Claude plugin (`skills/`, `agents/`, `.claude-plugin/`) fails a fast,
+  toolchain-free check; exempt with a `[no-plugin]` token in the bullet or PR
+  body, or the `plugin-exempt` label. The same job sanity-checks that
+  `plugin.json` parses and that every `docs/guide/*.md` path referenced from
+  the plugin exists. Run `scripts/check-plugin-freshness.sh --self-test`
+  locally.
+
+### Documentation
+
+- **plugin:** refresh the Claude plugin to current framework state. Adds
+  prominent `#[state_machine]` coverage (attribute syntax, generated
+  `can_transition_{field}_to` / `transition_{field}_to`, guards, and a
+  `before_update` example replacing hand-rolled status validation), a
+  "Prefer framework idioms over raw Diesel/Axum" steering table, the
+  generated-repository method surface (pagination, bulk ops, read routing,
+  hooks), `Db::tx_with`/`TxOptions`, jobs additions (uniqueness/concurrency,
+  named queues, tracked jobs), events/listeners, cache stampede protection,
+  view widgets + `WIDGETS_CSS`, sharding, `autumn serve`, `autumn destroy`,
+  the `references`/`enum{...}`/`decimal`/`:unique` generator DSL, scoped
+  tokens, observability defaults, and load shedding. Features merged on
+  trunk-dev but absent from the published 0.5.0 crates are explicitly marked
+  "(unreleased)", and in-flight PRs (#1587 `form_for`, #1592
+  `find_in_batches`) are flagged as unmerged rather than documented as
+  available. Fixes stale claims (foreign keys/unique "not in the DSL", the
+  removed `--test repo_hygiene` target, `with_pool` →
+  `with_pool_untracked`).
+
 ## [0.6.0] - 2026-06-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -363,47 +363,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the plugin exists. Run `scripts/check-plugin-freshness.sh --self-test`
   locally.
 
-### Documentation
-
-- **plugin:** refresh the Claude plugin to current framework state. Adds
-  prominent `#[state_machine]` coverage (attribute syntax, generated
-  `can_transition_{field}_to` / `transition_{field}_to`, guards, and a
-  `before_update` example replacing hand-rolled status validation), a
-  "Prefer framework idioms over raw Diesel/Axum" steering table, the
-  generated-repository method surface (pagination, bulk ops, read routing,
-  hooks), `Db::tx_with`/`TxOptions`, jobs additions (uniqueness/concurrency,
-  named queues, tracked jobs), events/listeners, cache stampede protection,
-  view widgets + `WIDGETS_CSS`, sharding, `autumn serve`, `autumn destroy`,
-  the `references`/`enum{...}`/`decimal`/`:unique` generator DSL, scoped
-  tokens, observability defaults, and load shedding. Features merged on
-  trunk-dev but absent from the published 0.5.0 crates are explicitly marked
-  "(unreleased)", and in-flight PRs (#1587 `form_for`, #1592
-  `find_in_batches`) are flagged as unmerged rather than documented as
-  available. Fixes stale claims (foreign keys/unique "not in the DSL", the
-  removed `--test repo_hygiene` target) and documents that published 0.5.0
-  repositories have no pool constructor (`with_pool_untracked` is
-  trunk-dev-only).
-
-## [0.6.0] - 2026-06-30
-
-### Added
-
-- **ui:** reusable `card` and `stat_card` Maud widget helpers in
-  `autumn_web::widgets`, re-exported from the prelude. `card()` renders a
-  titled content panel with an optional header-action slot, footer, and
-  configurable heading level (`HeadingLevel::H1`–`H6`, default `H2`);
-  `stat_card()` renders a metric tile with label, value, and optional link.
-  Both are CSP-safe and HTML-escape caller-supplied text via Maud.
-  `CardConfig` uses a builder pattern with `const fn` and private fields
-  so the `title()` / `title_html()` escape path cannot be bypassed.
-  The admin plugin's 12 hand-rolled card blocks and dashboard stat tiles are
-  migrated to the new helpers, removing the duplication (#1122).
-
-## [0.5.0] - 2026-06-16
-
-### Added
-
-
 - **daemon:** `autumn serve` — run an app as a production (non-watch) local
   daemon, with an optional managed local Postgres (#1119)
   - `autumn serve` runs the compiled app in the foreground as a production
@@ -521,6 +480,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     unsharded control role — enforced at config validation. New
     `examples/bookmarks-sharded` Docker Compose stack and
     `docs/guide/sharding.md`.
+
+### Documentation
+
+- **plugin:** refresh the Claude plugin to current framework state. Adds
+  prominent `#[state_machine]` coverage (attribute syntax, generated
+  `can_transition_{field}_to` / `transition_{field}_to`, guards, and a
+  `before_update` example replacing hand-rolled status validation), a
+  "Prefer framework idioms over raw Diesel/Axum" steering table, the
+  generated-repository method surface (pagination, bulk ops, read routing,
+  hooks), `Db::tx_with`/`TxOptions`, jobs additions (uniqueness/concurrency,
+  named queues, tracked jobs), events/listeners, cache stampede protection,
+  view widgets + `WIDGETS_CSS`, sharding, `autumn serve`, `autumn destroy`,
+  the `references`/`enum{...}`/`decimal`/`:unique` generator DSL, scoped
+  tokens, observability defaults, and load shedding. Features merged on
+  trunk-dev but absent from the published 0.5.0 crates are explicitly marked
+  "(unreleased)", and in-flight PRs (#1587 `form_for`, #1592
+  `find_in_batches`) are flagged as unmerged rather than documented as
+  available. Fixes stale claims (foreign keys/unique "not in the DSL", the
+  removed `--test repo_hygiene` target) and documents that published 0.5.0
+  repositories have no pool constructor (`with_pool_untracked` is
+  trunk-dev-only).
+
+## [0.6.0] - 2026-06-30
+
+### Added
+
+- **ui:** reusable `card` and `stat_card` Maud widget helpers in
+  `autumn_web::widgets`, re-exported from the prelude. `card()` renders a
+  titled content panel with an optional header-action slot, footer, and
+  configurable heading level (`HeadingLevel::H1`–`H6`, default `H2`);
+  `stat_card()` renders a metric tile with label, value, and optional link.
+  Both are CSP-safe and HTML-escape caller-supplied text via Maud.
+  `CardConfig` uses a builder pattern with `const fn` and private fields
+  so the `title()` / `title_html()` escape path cannot be bypassed.
+  The admin plugin's 12 hand-rolled card blocks and dashboard stat tiles are
+  migrated to the new helpers, removing the duplication (#1122).
+
+## [0.5.0] - 2026-06-16
+
+### Added
 
 - **auth:** Active session management with device list and revocation in the auth starter (#819)
   - `autumn generate auth` now persists a `{user}_sessions` row per login

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -356,8 +356,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.github/workflows/plugin-freshness.yml`) — a PR that adds entries to this
   changelog's Unreleased `Added`/`Changed` sections without touching the
   Claude plugin (`skills/`, `agents/`, `.claude-plugin/`) fails a fast,
-  toolchain-free check; exempt with a `[no-plugin]` token in the bullet or PR
-  body, or the `plugin-exempt` label. The same job sanity-checks that
+  toolchain-free check; exempt individual bullets with a bracketed
+  `no-plugin` marker, or the whole PR via the same marker in the PR body or
+  the `plugin-exempt` label. The same job sanity-checks that
   `plugin.json` parses and that every `docs/guide/*.md` path referenced from
   the plugin exists. Run `scripts/check-plugin-freshness.sh --self-test`
   locally.
@@ -379,8 +380,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "(unreleased)", and in-flight PRs (#1587 `form_for`, #1592
   `find_in_batches`) are flagged as unmerged rather than documented as
   available. Fixes stale claims (foreign keys/unique "not in the DSL", the
-  removed `--test repo_hygiene` target, `with_pool` →
-  `with_pool_untracked`).
+  removed `--test repo_hygiene` target) and documents that published 0.5.0
+  repositories have no pool constructor (`with_pool_untracked` is
+  trunk-dev-only).
 
 ## [0.6.0] - 2026-06-30
 

--- a/agents/autumn-reviewer.md
+++ b/agents/autumn-reviewer.md
@@ -114,7 +114,7 @@ Check every file you review against these items. Report only items that fail.
 
 - **N+1 queries**: Loading a collection and then querying per item in a loop.
   Flag it — suggest `#[belongs_to]`/`#[has_many]` associations with
-  `repo.preload(...)`, or a JOIN.
+  `repo.preload(...)` (unreleased — trunk-dev only), or a JOIN.
 - **Missing index on FK column**: Any BIGINT FK column used in a WHERE clause
   should have an index (the trunk-dev `field:references` DSL adds one
   automatically; hand-added FK columns need one in the migration).

--- a/agents/autumn-reviewer.md
+++ b/agents/autumn-reviewer.md
@@ -113,9 +113,34 @@ Check every file you review against these items. Report only items that fail.
 ### Database (MEDIUM)
 
 - **N+1 queries**: Loading a collection and then querying per item in a loop.
-  Flag it — suggest eager loading or a JOIN.
-- **Missing index on FK column**: Any `references:Model` or BIGINT FK column
-  used in a WHERE clause should have an index.
+  Flag it — suggest `#[belongs_to]`/`#[has_many]` associations with
+  `repo.preload(...)`, or a JOIN.
+- **Missing index on FK column**: Any BIGINT FK column used in a WHERE clause
+  should have an index (the trunk-dev `field:references` DSL adds one
+  automatically; hand-added FK columns need one in the migration).
+
+### Framework idioms (MEDIUM)
+
+Autumn allows raw Axum/Diesel, but hand-rolling what the framework generates
+is a defect. Flag these and name the framework replacement:
+
+- **Hand-rolled status-transition validation**: a `match`/`if` block over
+  old/new status values in `before_create`/`before_update` hooks or handlers.
+  Fix: `#[state_machine(transitions(...))]` on the model field + the
+  generated `transition_{field}_to` (see `docs/guide/state-machines.md`).
+- **Raw Diesel for generated repository operations**: hand-written
+  `LIMIT/OFFSET` pagination, per-row insert loops, or CRUD queries when the
+  model has a `#[repository]`. Fix: `page`/`cursor_page`, bulk
+  `save_many`/`update_many`/`delete_many`/`upsert_many`, generated CRUD.
+- **Raw `axum::Router` handlers for app routes**: `.route("/x", get(...))`
+  instead of `#[get]`/`#[post]` + `routes![...]`. `.merge()`/`.nest()` is
+  acceptable only for third-party routers.
+- **Ad-hoc `tokio::spawn` for deferred/background work**: fix with `#[job]`
+  (retries, backends) or `#[scheduled]`.
+- **Hand-rolled session/token parsing in handler bodies** when `#[secured]`,
+  `#[authorize]`, or repository policies express the same check.
+- Only flag when the framework feature actually covers the case; dropping to
+  raw Axum/Diesel for something the framework does not provide is fine.
 
 ## Output format
 

--- a/scripts/check-plugin-freshness.sh
+++ b/scripts/check-plugin-freshness.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# Plugin freshness gate: keep the Claude plugin (skills/, agents/,
+# .claude-plugin/) from drifting behind the framework.
+#
+# WHY THIS FIRED: your PR adds user-facing entries to CHANGELOG.md's
+# `## [Unreleased]` `### Added`/`### Changed` sections but does not touch
+# the Claude plugin. New framework surface that agents should reach for
+# belongs in the plugin too (usually a row/bullet in
+# skills/autumn-web/SKILL.md or references/api-reference.md).
+#
+# HOW TO SATISFY IT:
+#   - Update the relevant plugin file in the same PR (preferred), or
+#   - Exempt the change when it genuinely has no agent-facing surface:
+#       * include the literal token [no-plugin] in the changelog bullet, or
+#       * include [no-plugin] in the PR body, or
+#       * apply the `plugin-exempt` label to the PR (workflow-level check).
+#
+# WHAT IT CHECKS (single fast job, no Rust toolchain needed):
+#   1. Drift gate: diff against the merge base of $BASE_REF; if lines were
+#      added inside CHANGELOG.md's Unreleased Added/Changed sections and no
+#      file under skills/, agents/, or .claude-plugin/ changed, fail —
+#      unless an escape hatch (above) applies.
+#   2. Static sanity: .claude-plugin/plugin.json parses as JSON, and every
+#      docs/guide/*.md path referenced from skills/ and agents/ exists.
+#
+# USAGE:
+#   scripts/check-plugin-freshness.sh              # gate against $BASE_REF
+#                                                  #   (default origin/trunk-dev)
+#   BASE_REF=origin/trunk scripts/check-plugin-freshness.sh
+#   PR_BODY="..." scripts/check-plugin-freshness.sh   # PR body escape hatch
+#   scripts/check-plugin-freshness.sh --static-only   # only check 2
+#   scripts/check-plugin-freshness.sh --self-test     # synthetic-repo tests
+
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# Extract the added lines that land inside the `## [Unreleased]` section's
+# `### Added` / `### Changed` subsections, given a repo dir and a base ref.
+# Approach: take the Unreleased Added/Changed content at base and at HEAD,
+# and print lines present at HEAD but not at base (set difference, so pure
+# moves/reflows don't count as additions).
+unreleased_added_changed() {
+  # $1 = file content on stdin
+  awk '
+    /^## \[Unreleased\]/ { in_unreleased = 1; next }
+    /^## \[/             { in_unreleased = 0 }
+    in_unreleased && /^### / {
+      in_wanted = ($0 == "### Added" || $0 == "### Changed"); next
+    }
+    in_unreleased && in_wanted && NF { print }
+  '
+}
+
+new_changelog_lines() {
+  # Compare CHANGELOG.md between two committed refs (working-tree state is
+  # deliberately ignored — CI checks out the PR head commit).
+  local dir="$1" base="$2" head="$3"
+  local base_section head_section
+  base_section="$(git -C "$dir" show "$base:CHANGELOG.md" 2>/dev/null | unreleased_added_changed || true)"
+  head_section="$(git -C "$dir" show "$head:CHANGELOG.md" 2>/dev/null | unreleased_added_changed || true)"
+  # Lines in head but not in base.
+  comm -13 <(printf '%s\n' "$base_section" | sort) <(printf '%s\n' "$head_section" | sort) | sed '/^$/d'
+}
+
+run_gate() {
+  local dir="$1" base_ref="$2" pr_body="${3-}"
+
+  local merge_base
+  merge_base="$(git -C "$dir" merge-base "$base_ref" HEAD)" ||
+    fail "cannot compute merge base against $base_ref (fetch the base branch first)"
+
+  local changed_files new_lines
+  changed_files="$(git -C "$dir" diff --name-only "$merge_base"...HEAD)"
+  new_lines="$(new_changelog_lines "$dir" "$merge_base" HEAD)"
+
+  if [[ -z "$new_lines" ]]; then
+    echo "OK: no new Unreleased Added/Changed changelog entries — gate not applicable."
+    return 0
+  fi
+
+  if echo "$changed_files" | grep -qE '^(skills/|agents/|\.claude-plugin/)'; then
+    echo "OK: changelog entries added and plugin files touched."
+    return 0
+  fi
+
+  if echo "$new_lines" | grep -qF '[no-plugin]'; then
+    echo "OK: changelog entry carries the [no-plugin] escape hatch."
+    return 0
+  fi
+
+  if [[ -n "$pr_body" ]] && grep -qF '[no-plugin]' <<<"$pr_body"; then
+    echo "OK: PR body carries the [no-plugin] escape hatch."
+    return 0
+  fi
+
+  echo "New Unreleased changelog entries without a plugin update:" >&2
+  echo "$new_lines" | head -20 | sed 's/^/  + /' >&2
+  fail "PR adds user-facing changelog entries but touches none of skills/, agents/, .claude-plugin/.
+Update the Claude plugin (see header of scripts/check-plugin-freshness.sh), or
+exempt with [no-plugin] in the bullet/PR body or the plugin-exempt label."
+}
+
+run_static_checks() {
+  local dir="$1"
+  echo "Static check: .claude-plugin/plugin.json parses as JSON..."
+  python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$dir/.claude-plugin/plugin.json" ||
+    fail ".claude-plugin/plugin.json is not valid JSON"
+
+  echo "Static check: docs/guide/*.md references from skills/ and agents/ exist..."
+  local missing=0 ref
+  while IFS= read -r ref; do
+    if [[ ! -f "$dir/$ref" ]]; then
+      echo "  missing: $ref" >&2
+      missing=1
+    fi
+  done < <(grep -rhoE 'docs/guide/[A-Za-z0-9_.-]+\.md' "$dir/skills" "$dir/agents" | sort -u)
+  [[ "$missing" -eq 0 ]] || fail "skills/ or agents/ reference docs/guide pages that do not exist"
+  echo "OK: static checks passed."
+}
+
+self_test() {
+  local tmp
+  tmp="$(mktemp -d)"
+  # shellcheck disable=SC2064 -- expand now: $tmp is function-local.
+  trap "rm -rf '$tmp'" EXIT
+  local pass=0 total=0
+
+  make_repo() {
+    local dir="$1"
+    git init -q "$dir"
+    git -C "$dir" config user.email test@test && git -C "$dir" config user.name test
+    mkdir -p "$dir/skills/autumn-web" "$dir/.claude-plugin" "$dir/agents" "$dir/docs/guide"
+    printf '{"name": "autumn", "version": "0.5.0"}\n' > "$dir/.claude-plugin/plugin.json"
+    printf '# skill\nSee docs/guide/jobs.md.\n' > "$dir/skills/autumn-web/SKILL.md"
+    printf '# reviewer\n' > "$dir/agents/autumn-reviewer.md"
+    printf '# jobs\n' > "$dir/docs/guide/jobs.md"
+    cat > "$dir/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- **old:** an existing bullet
+
+## [0.5.0] - 2026-06-16
+
+### Added
+
+- old release bullet
+EOF
+    git -C "$dir" add -A && git -C "$dir" commit -qm base
+    git -C "$dir" branch base
+  }
+
+  check() {
+    local name="$1" expected="$2"; shift 2
+    total=$((total + 1))
+    local got=0
+    ("$@") >/dev/null 2>&1 || got=$?
+    if [[ ("$expected" == pass && "$got" -eq 0) || ("$expected" == fail && "$got" -ne 0) ]]; then
+      echo "self-test PASS: $name"
+      pass=$((pass + 1))
+    else
+      echo "self-test FAIL: $name (expected $expected, exit=$got)" >&2
+    fi
+  }
+
+  # Scenario 1: changelog-only Added entry, no plugin change -> gate fails.
+  local r1="$tmp/r1"; make_repo "$r1"
+  sed -i 's/- \*\*old:\*\* an existing bullet/- **old:** an existing bullet\n- **new:** shiny feature agents should know about/' "$r1/CHANGELOG.md"
+  git -C "$r1" commit -qam "feat: changelog only"
+  check "changelog-only change fails" fail run_gate "$r1" base ""
+
+  # Scenario 2: changelog + skills change -> gate passes.
+  local r2="$tmp/r2"; make_repo "$r2"
+  sed -i 's/- \*\*old:\*\* an existing bullet/- **old:** an existing bullet\n- **new:** shiny feature/' "$r2/CHANGELOG.md"
+  printf 'Documents the shiny feature.\n' >> "$r2/skills/autumn-web/SKILL.md"
+  git -C "$r2" commit -qam "feat: changelog + plugin"
+  check "changelog+skills change passes" pass run_gate "$r2" base ""
+
+  # Scenario 3: [no-plugin] in the bullet -> gate passes.
+  local r3="$tmp/r3"; make_repo "$r3"
+  sed -i 's/- \*\*old:\*\* an existing bullet/- **old:** an existing bullet\n- **internal:** refactor with no agent surface [no-plugin]/' "$r3/CHANGELOG.md"
+  git -C "$r3" commit -qam "feat: exempt"
+  check "[no-plugin] bullet passes" pass run_gate "$r3" base ""
+
+  # Scenario 4: [no-plugin] in the PR body -> gate passes.
+  local r4="$tmp/r4"; make_repo "$r4"
+  sed -i 's/- \*\*old:\*\* an existing bullet/- **old:** an existing bullet\n- **new:** something/' "$r4/CHANGELOG.md"
+  git -C "$r4" commit -qam "feat: body exempt"
+  check "[no-plugin] PR body passes" pass run_gate "$r4" base "internal cleanup [no-plugin]"
+
+  # Scenario 5: no changelog change at all -> gate passes.
+  local r5="$tmp/r5"; make_repo "$r5"
+  printf '// code\n' > "$r5/lib.rs"
+  git -C "$r5" add -A && git -C "$r5" commit -qm "chore: code only"
+  check "no changelog change passes" pass run_gate "$r5" base ""
+
+  # Scenario 6: Fixed-section-only changelog entry -> gate passes (Added/Changed only).
+  local r6="$tmp/r6"; make_repo "$r6"
+  printf '\n### Fixed\n\n- a bug fix\n' >> "$r6/CHANGELOG.md.tmp" || true
+  awk '/^## \[0.5.0\]/ && !done { print "### Fixed\n\n- a bug fix\n"; done=1 } { print }' "$r6/CHANGELOG.md" > "$r6/CHANGELOG.md.new"
+  mv "$r6/CHANGELOG.md.new" "$r6/CHANGELOG.md"; rm -f "$r6/CHANGELOG.md.tmp"
+  git -C "$r6" commit -qam "fix: fixed-section only"
+  check "Fixed-section-only entry passes" pass run_gate "$r6" base ""
+
+  # Scenario 7: static checks pass on a valid repo.
+  local r7="$tmp/r7"; make_repo "$r7"
+  check "static checks pass on valid repo" pass run_static_checks "$r7"
+
+  # Scenario 8: static checks fail on a broken docs/guide reference.
+  local r8="$tmp/r8"; make_repo "$r8"
+  printf 'See docs/guide/does-not-exist.md.\n' >> "$r8/skills/autumn-web/SKILL.md"
+  check "static checks fail on missing guide ref" fail run_static_checks "$r8"
+
+  # Scenario 9: static checks fail on invalid plugin.json.
+  local r9="$tmp/r9"; make_repo "$r9"
+  printf '{ not json' > "$r9/.claude-plugin/plugin.json"
+  check "static checks fail on bad plugin.json" fail run_static_checks "$r9"
+
+  echo "self-test: $pass/$total passed"
+  [[ "$pass" -eq "$total" ]]
+}
+
+case "${1-}" in
+  --self-test)
+    self_test
+    ;;
+  --static-only)
+    run_static_checks "$root"
+    ;;
+  *)
+    run_static_checks "$root"
+    run_gate "$root" "${BASE_REF:-origin/trunk-dev}" "${PR_BODY-}"
+    ;;
+esac

--- a/scripts/check-plugin-freshness.sh
+++ b/scripts/check-plugin-freshness.sh
@@ -11,12 +11,14 @@
 # HOW TO SATISFY IT:
 #   - Update the relevant plugin file in the same PR (preferred), or
 #   - Exempt the change when it genuinely has no agent-facing surface:
-#       * include the literal token [no-plugin] in the changelog bullet, or
-#       * include [no-plugin] in the PR body, or
+#       * include the literal token [no-plugin] in the changelog bullet
+#         (exempts that bullet only — other new bullets still need plugin
+#         coverage), or
+#       * include [no-plugin] in the PR body (deliberately PR-wide), or
 #       * apply the `plugin-exempt` label to the PR (workflow-level check).
 #
 # WHAT IT CHECKS (single fast job, no Rust toolchain needed):
-#   1. Drift gate: diff against the merge base of $BASE_REF; if lines were
+#   1. Drift gate: diff against the merge base of $BASE_REF; if bullets were
 #      added inside CHANGELOG.md's Unreleased Added/Changed sections and no
 #      file under skills/, agents/, or .claude-plugin/ changed, fail —
 #      unless an escape hatch (above) applies.
@@ -30,6 +32,8 @@
 #   PR_BODY="..." scripts/check-plugin-freshness.sh   # PR body escape hatch
 #   scripts/check-plugin-freshness.sh --static-only   # only check 2
 #   scripts/check-plugin-freshness.sh --self-test     # synthetic-repo tests
+#
+# NOTE: --self-test requires GNU sed (uses `sed -i`); the gate itself does not.
 
 set -euo pipefail
 
@@ -40,20 +44,41 @@ fail() {
   exit 1
 }
 
-# Extract the added lines that land inside the `## [Unreleased]` section's
-# `### Added` / `### Changed` subsections, given a repo dir and a base ref.
-# Approach: take the Unreleased Added/Changed content at base and at HEAD,
-# and print lines present at HEAD but not at base (set difference, so pure
-# moves/reflows don't count as additions).
+# Extract the bullets that land inside the `## [Unreleased]` section's
+# `### Added` / `### Changed` subsections, given file content on stdin.
+# Each multi-line bullet is joined into one whitespace-normalized logical
+# line. The caller takes the set difference between base and HEAD, so pure
+# moves AND pure rewraps of existing bullets don't count as additions —
+# only genuinely new (or reworded) bullets do. Heading matches are tolerant
+# of trailing whitespace and CRLF line endings so stray whitespace can't
+# silently disable the gate.
 unreleased_added_changed() {
-  # $1 = file content on stdin
   awk '
-    /^## \[Unreleased\]/ { in_unreleased = 1; next }
-    /^## \[/             { in_unreleased = 0 }
-    in_unreleased && /^### / {
-      in_wanted = ($0 == "### Added" || $0 == "### Changed"); next
+    function flush() {
+      if (bullet != "") {
+        gsub(/[[:space:]]+/, " ", bullet)
+        sub(/[[:space:]]+$/, "", bullet)
+        print bullet
+      }
+      bullet = ""
     }
-    in_unreleased && in_wanted && NF { print }
+    { sub(/\r$/, "") }
+    /^##[[:space:]]+\[Unreleased\]/ { flush(); in_unreleased = 1; next }
+    /^##[[:space:]]+\[/             { flush(); in_unreleased = 0 }
+    in_unreleased && /^###[[:space:]]/ {
+      flush()
+      heading = $0
+      sub(/^###[[:space:]]+/, "", heading)
+      sub(/[[:space:]]+$/, "", heading)
+      in_wanted = (heading == "Added" || heading == "Changed")
+      next
+    }
+    in_unreleased && in_wanted {
+      if ($0 ~ /^[-*][[:space:]]/) { flush(); bullet = $0 }
+      else if (NF && bullet != "") { bullet = bullet " " $0 }
+      else if (NF) { print }
+    }
+    END { flush() }
   '
 }
 
@@ -64,7 +89,7 @@ new_changelog_lines() {
   local base_section head_section
   base_section="$(git -C "$dir" show "$base:CHANGELOG.md" 2>/dev/null | unreleased_added_changed || true)"
   head_section="$(git -C "$dir" show "$head:CHANGELOG.md" 2>/dev/null | unreleased_added_changed || true)"
-  # Lines in head but not in base.
+  # Bullets in head but not in base.
   comm -13 <(printf '%s\n' "$base_section" | sort) <(printf '%s\n' "$head_section" | sort) | sed '/^$/d'
 }
 
@@ -75,12 +100,20 @@ run_gate() {
   merge_base="$(git -C "$dir" merge-base "$base_ref" HEAD)" ||
     fail "cannot compute merge base against $base_ref (fetch the base branch first)"
 
-  local changed_files new_lines
+  local changed_files new_bullets non_exempt
   changed_files="$(git -C "$dir" diff --name-only "$merge_base"...HEAD)"
-  new_lines="$(new_changelog_lines "$dir" "$merge_base" HEAD)"
+  new_bullets="$(new_changelog_lines "$dir" "$merge_base" HEAD)"
 
-  if [[ -z "$new_lines" ]]; then
+  if [[ -z "$new_bullets" ]]; then
     echo "OK: no new Unreleased Added/Changed changelog entries — gate not applicable."
+    return 0
+  fi
+
+  # Per-bullet escape hatch: a [no-plugin] token exempts only the bullet
+  # that carries it; every other new bullet still needs plugin coverage.
+  non_exempt="$(printf '%s\n' "$new_bullets" | grep -vF '[no-plugin]' || true)"
+  if [[ -z "$non_exempt" ]]; then
+    echo "OK: every new changelog bullet carries the [no-plugin] escape hatch."
     return 0
   fi
 
@@ -89,18 +122,14 @@ run_gate() {
     return 0
   fi
 
-  if echo "$new_lines" | grep -qF '[no-plugin]'; then
-    echo "OK: changelog entry carries the [no-plugin] escape hatch."
-    return 0
-  fi
-
+  # PR-body hatch is deliberately PR-wide: one token exempts the whole PR.
   if [[ -n "$pr_body" ]] && grep -qF '[no-plugin]' <<<"$pr_body"; then
     echo "OK: PR body carries the [no-plugin] escape hatch."
     return 0
   fi
 
   echo "New Unreleased changelog entries without a plugin update:" >&2
-  echo "$new_lines" | head -20 | sed 's/^/  + /' >&2
+  printf '%s\n' "$non_exempt" | head -20 | sed 's/^/  + /' >&2
   fail "PR adds user-facing changelog entries but touches none of skills/, agents/, .claude-plugin/.
 Update the Claude plugin (see header of scripts/check-plugin-freshness.sh), or
 exempt with [no-plugin] in the bullet/PR body or the plugin-exempt label."
@@ -205,9 +234,8 @@ EOF
 
   # Scenario 6: Fixed-section-only changelog entry -> gate passes (Added/Changed only).
   local r6="$tmp/r6"; make_repo "$r6"
-  printf '\n### Fixed\n\n- a bug fix\n' >> "$r6/CHANGELOG.md.tmp" || true
   awk '/^## \[0.5.0\]/ && !done { print "### Fixed\n\n- a bug fix\n"; done=1 } { print }' "$r6/CHANGELOG.md" > "$r6/CHANGELOG.md.new"
-  mv "$r6/CHANGELOG.md.new" "$r6/CHANGELOG.md"; rm -f "$r6/CHANGELOG.md.tmp"
+  mv "$r6/CHANGELOG.md.new" "$r6/CHANGELOG.md"
   git -C "$r6" commit -qam "fix: fixed-section only"
   check "Fixed-section-only entry passes" pass run_gate "$r6" base ""
 
@@ -224,6 +252,23 @@ EOF
   local r9="$tmp/r9"; make_repo "$r9"
   printf '{ not json' > "$r9/.claude-plugin/plugin.json"
   check "static checks fail on bad plugin.json" fail run_static_checks "$r9"
+
+  # Scenario 10: [no-plugin] on one bullet does NOT exempt a second,
+  # unmarked bullet -> gate fails (hatch is per-bullet, not PR-wide).
+  local r10="$tmp/r10"; make_repo "$r10"
+  sed -i 's/- \*\*old:\*\* an existing bullet/- **old:** an existing bullet\n- **internal:** no agent surface [no-plugin]\n- **new:** shiny feature agents should know about/' "$r10/CHANGELOG.md"
+  git -C "$r10" commit -qam "feat: partial exempt"
+  check "[no-plugin] bullet does not exempt other bullets" fail run_gate "$r10" base ""
+
+  # Scenario 11: rewrapping an existing multi-line bullet (no new content)
+  # -> gate passes (bullets are joined and whitespace-normalized).
+  local r11="$tmp/r11"; make_repo "$r11"
+  sed -i 's/- \*\*old:\*\* an existing bullet/- **old:** an existing bullet that is\n  long enough to wrap across two lines/' "$r11/CHANGELOG.md"
+  git -C "$r11" commit -qam "docs: establish wrapped bullet"
+  git -C "$r11" branch -f base
+  sed -i -e 's/- \*\*old:\*\* an existing bullet that is/- **old:** an existing bullet\n  that is long enough to wrap/' -e 's/^  long enough to wrap across two lines/  across two lines/' "$r11/CHANGELOG.md"
+  git -C "$r11" commit -qam "docs: rewrap bullet"
+  check "pure rewrap of existing bullet passes" pass run_gate "$r11" base ""
 
   echo "self-test: $pass/$total passed"
   [[ "$pass" -eq "$total" ]]

--- a/scripts/check-plugin-freshness.sh
+++ b/scripts/check-plugin-freshness.sh
@@ -15,7 +15,9 @@
 #         (exempts that bullet only — other new bullets still need plugin
 #         coverage), or
 #       * include [no-plugin] in the PR body (deliberately PR-wide), or
-#       * apply the `plugin-exempt` label to the PR (workflow-level check).
+#       * apply the `plugin-exempt` label to the PR (the workflow passes it
+#         through as PLUGIN_EXEMPT_LABEL=true; it bypasses ONLY the drift
+#         gate — the static sanity checks below always run).
 #
 # WHAT IT CHECKS (single fast job, no Rust toolchain needed):
 #   1. Drift gate: diff against the merge base of $BASE_REF; if bullets were
@@ -24,12 +26,15 @@
 #      unless an escape hatch (above) applies.
 #   2. Static sanity: .claude-plugin/plugin.json parses as JSON, and every
 #      docs/guide/*.md path referenced from skills/ and agents/ exists.
+#      Always runs — no escape hatch skips it.
 #
 # USAGE:
 #   scripts/check-plugin-freshness.sh              # gate against $BASE_REF
 #                                                  #   (default origin/trunk-dev)
 #   BASE_REF=origin/trunk scripts/check-plugin-freshness.sh
 #   PR_BODY="..." scripts/check-plugin-freshness.sh   # PR body escape hatch
+#   PLUGIN_EXEMPT_LABEL=true scripts/check-plugin-freshness.sh
+#                                                  # skip drift gate only
 #   scripts/check-plugin-freshness.sh --static-only   # only check 2
 #   scripts/check-plugin-freshness.sh --self-test     # synthetic-repo tests
 #
@@ -153,6 +158,18 @@ run_static_checks() {
   echo "OK: static checks passed."
 }
 
+# Full check as CI runs it: static checks always; the drift gate is skipped
+# (with an explicit note) when the plugin-exempt label was applied.
+run_checks() {
+  local dir="$1" base_ref="$2" pr_body="${3-}" exempt_label="${4-false}"
+  run_static_checks "$dir"
+  if [[ "$exempt_label" == "true" ]]; then
+    echo "drift gate skipped: plugin-exempt label"
+    return 0
+  fi
+  run_gate "$dir" "$base_ref" "$pr_body"
+}
+
 self_test() {
   local tmp
   tmp="$(mktemp -d)"
@@ -270,6 +287,21 @@ EOF
   git -C "$r11" commit -qam "docs: rewrap bullet"
   check "pure rewrap of existing bullet passes" pass run_gate "$r11" base ""
 
+  # Scenario 12: plugin-exempt label skips ONLY the drift gate — the static
+  # checks still run, so a broken plugin.json fails even on an exempt PR.
+  local r12="$tmp/r12"; make_repo "$r12"
+  sed -i 's/- \*\*old:\*\* an existing bullet/- **old:** an existing bullet\n- **new:** shiny feature agents should know about/' "$r12/CHANGELOG.md"
+  printf '{ not json' > "$r12/.claude-plugin/plugin.json"
+  git -C "$r12" commit -qam "feat: exempt label, broken plugin.json"
+  check "exempt label still fails static checks on bad plugin.json" fail run_checks "$r12" base "" true
+
+  # Scenario 13: plugin-exempt label with a valid plugin passes despite a
+  # changelog-only change (drift gate is what gets skipped).
+  local r13="$tmp/r13"; make_repo "$r13"
+  sed -i 's/- \*\*old:\*\* an existing bullet/- **old:** an existing bullet\n- **new:** shiny feature agents should know about/' "$r13/CHANGELOG.md"
+  git -C "$r13" commit -qam "feat: exempt label, changelog only"
+  check "exempt label skips drift gate on changelog-only change" pass run_checks "$r13" base "" true
+
   echo "self-test: $pass/$total passed"
   [[ "$pass" -eq "$total" ]]
 }
@@ -282,7 +314,6 @@ case "${1-}" in
     run_static_checks "$root"
     ;;
   *)
-    run_static_checks "$root"
-    run_gate "$root" "${BASE_REF:-origin/trunk-dev}" "${PR_BODY-}"
+    run_checks "$root" "${BASE_REF:-origin/trunk-dev}" "${PR_BODY-}" "${PLUGIN_EXEMPT_LABEL:-false}"
     ;;
 esac

--- a/skills/autumn-patterns/SKILL.md
+++ b/skills/autumn-patterns/SKILL.md
@@ -12,6 +12,20 @@ description: >
 Reference `skills/autumn-web/SKILL.md` for the API quick guide. This file
 covers patterns and design decisions that apply across an Autumn app.
 
+**First rule: prefer the framework idiom.** Before hand-rolling validation,
+CRUD queries, pagination, forms, auth checks, background threads, or caching,
+check the "Prefer framework idioms over raw Diesel/Axum" table in
+`skills/autumn-web/SKILL.md`. Raw Axum/Diesel is allowed but is a last resort.
+
+## Status fields: `#[state_machine]`, not hand-rolled checks
+
+When a model has a status/phase column with legal transitions, declare them
+with `#[state_machine(transitions(...))]` on the field and enforce with the
+generated `transition_{field}_to` in `before_update` — never write your own
+`match (old, new)` validation in hooks or handlers. See
+`docs/guide/state-machines.md` and the worked example in
+`skills/autumn-web/references/examples.md`.
+
 ## Testing with TestApp and TestClient
 
 The `test-support` feature ships an in-process test client. No running
@@ -104,9 +118,16 @@ async fn publish_post(Path(id): Path<i64>, mut db: Db) -> AutumnResult<Redirect>
 Use `#[job]` for request-triggered work with retries. Keep jobs idempotent —
 they may run more than once.
 
-The `#[job]` macro requires exactly two arguments: `AppState` and a typed
-args struct (serializable). The macro generates a `PascalCaseJob` struct with
-a static `enqueue` method.
+The `#[job]` macro takes `AppState` and a typed args struct (serializable).
+The macro generates a `PascalCaseJob` struct with a static `enqueue` method.
+On trunk-dev (unreleased — not in published 0.5.0) a job may also accept an
+optional third `JobContext` argument for progress reporting on tracked jobs,
+and a `queue = "name"` attribute for named priority queues.
+
+Published 0.5.0 also supports idempotency/backpressure attributes:
+`#[job(unique)]`, `unique_by = "field"`, `unique_for_ms = N`,
+`concurrency = N`, `concurrency_key = "field"` — prefer these over
+hand-rolled dedupe tables or semaphores.
 
 ```rust
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -415,7 +415,7 @@ raw Diesel:
 | `primary_reads` (attr) / `on_primary()` | Pin reads to primary; read-your-writes after a save |
 | `soft_delete`, `tenant_scoped` (attrs), `across_tenants()` | Soft deletion and tenant scoping |
 | `hooks = MyHooks` (attr) | `before_/after_create/update/delete` + `after_*_commit` lifecycle hooks with `MutationContext` |
-| `from_shard(&ShardedDb)`, `with_pool_untracked(pool)` | **(unreleased)** shard-scoped construction; `with_pool` was **renamed** `with_pool_untracked` on trunk-dev |
+| `from_shard(&ShardedDb)`, `with_pool_untracked(pool)` | **(unreleased)** shard-scoped construction; `with_pool_untracked` is new on trunk-dev — published 0.5.0 repositories have **no** pool constructor at all |
 | `find_in_batches(n)` / `find_each(n)` | **In flight (PR #1592, unmerged) — do not use until merged**: bounded-memory keyset iteration |
 
 Read routing: with `database.replica_url` set, all generated reads use the
@@ -482,7 +482,8 @@ optionally-expiring API tokens carrying flat scopes via `IssueTokenSpec` +
 `#[secured(scopes = ["posts:write"])]` (no session required — default-deny,
 403 when missing) or `#[secured("admin", scopes = [...])]` for both; check in
 policies with `PolicyContext::has_scope/has_any_scope/has_all_scopes`; manage
-with `autumn token issue --name ... --scope ...` / `list` / `rotate`. The
+with `autumn token issue <principal> --name ... --scope ...` / `list` /
+`rotate`. The
 published 0.5.0 `autumn token` has only `issue <principal>` / `revoke`.
 
 Active session management ships with `autumn generate auth` (published 0.5.0):
@@ -708,8 +709,10 @@ and `docs/adr/0009-adopt-overload-protection-load-shedding.md`.
 
 Framework-native horizontal sharding: declare `[[database.shards]]` (each a
 full primary/replica topology), route by key → logical slot → shard. Prelude
-extractors `ShardedDb` (routed handle: `db_for`/`read_for`/`db_on`, bounded
-`each_shard` fan-out) and `Shards`; install custom routing with
+extractors: `ShardedDb` (auto-routed handle — resolves the routing key from
+the request, checks out the owning shard's primary, derefs to the connection
+like `Db`) and `Shards` (explicit routing: `db_for`/`read_for`/`db_on`, plus
+bounded `each_shard` fan-out); install custom routing with
 `AppBuilder::with_shard_router`; build repositories per shard with
 `from_shard(&ShardedDb)`. `autumn migrate` gains `--shard <name>` /
 `--control-only`; a boot-time shard-map guard fails fast on config drift.
@@ -822,7 +825,7 @@ autumn generate scaffold Post title:String status:enum{draft,published} price:de
 autumn generate scaffold Post title:String --live --live-validation
 autumn generate tauri            # desktop sidecar project (cargo tauri build)
 autumn generate plugin my-plugin # installable/conformant plugin crate
-autumn token issue --name ci --scope posts:write   # scoped tokens; also list, rotate
+autumn token issue service:ci --name ci --scope posts:write   # scoped tokens; also list, rotate
 ```
 
 `autumn destroy` mirrors `autumn generate` argument-for-argument and never

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -12,8 +12,16 @@ description: >
 
 **Repository**: https://github.com/madmax983/autumn
 **Branch**: `trunk-dev`
-**Current release**: 0.5.0 (2026-06-04) | **Edition**: 2024 | **MSRV**: 1.88.0
+**Latest published release**: 0.5.0 on crates.io | **Edition**: 2024 | **MSRV**: 1.88.0
 **Author**: madmax983
+
+**Version identity trip wire**: the workspace on `trunk-dev` is versioned
+0.6.0, but 0.6.0 is **not published** — crates.io still serves 0.5.0. Apps
+depending on the published crates (`autumn-web = "0.5"`, `cargo install
+autumn-cli --version 0.5.0`) do not have trunk-dev-only features. Anything
+below marked **(unreleased)** is merged on `trunk-dev` but absent from the
+published 0.5.0 crates — do not use it in an app built against 0.5.0.
+Unmarked features are in the published release.
 
 autumn-web is a Spring Boot-style web framework for Rust, built on Axum. It
 assembles Axum, Diesel, Maud, htmx, Tailwind, Tokio, tracing, and production
@@ -29,6 +37,33 @@ when their details matter:
 - `references/examples.md` - official 0.5.0 example patterns for minimal apps,
   CRUD, production-ish jobs, Redis channels, S3 storage plugins, and signed
   webhooks. Use this before generating full app code.
+
+## Prefer framework idioms over raw Diesel/Axum
+
+Autumn deliberately lets you drop to raw Axum routers and raw Diesel queries.
+That is a **last resort**, not a starting point. Before hand-rolling any of
+the patterns below, check this table and the matching `docs/guide/*.md` page —
+the framework almost certainly already generates or ships it:
+
+| Temptation (do NOT hand-roll) | Autumn-native answer |
+|---|---|
+| Status-transition validation written by hand in `before_create`/`before_update` hooks or handlers (`if old == "draft" && new == "published"` match blocks) | `#[state_machine(transitions(...))]` on the model field — generated `can_transition_{field}_to` / `transition_{field}_to` enforce the graph. See "Model state machines" below and `docs/guide/state-machines.md` |
+| Raw `axum::Router` routes and handlers, manual `.route("/x", get(...))` | `#[get]`/`#[post]`/`#[put]`/`#[patch]`/`#[delete]` + `routes![...]`, `.scoped(prefix, layer, routes)` for groups. `.merge()`/`.nest()` exist for the rare escape hatch only |
+| Raw Diesel queries for CRUD, lookups, pagination, or bulk writes | `#[repository]`-generated methods: `find_by_id`, `find_all`, `save`, `update`, `delete_by_id`, derived `find_by_*`, `page(&PageRequest)`, `cursor_page(&CursorRequest)`, bulk `save_many`/`update_many`/`delete_many`/`upsert_many`. See `docs/guide/repositories.md`, `docs/guide/pagination.md` |
+| Manual per-item queries in a loop (N+1) or hand-written JOINs to fetch associations | `#[belongs_to]`/`#[has_many]`/`#[has_one]` + `repo.preload(records, Model::preload()...)` |
+| Hand-rolled auth, session, or token checks in handler bodies | `#[secured]` / `#[secured("role")]`, `#[authorize]`, repository `policy =`/`scope =`; `#[secured(scopes = [...])]` for service tokens (unreleased) |
+| Hand-assembled `<form>` markup with manual value re-fill and error display | `autumn_web::form` helpers — `form_tag`, `method_input`, `text_input` (published); `number_input`, `datetime_input`, `date_input`, `checkbox_input`, `select_input` + `Changeset` 422 re-render (unreleased). A whole-form `form_for` builder is in-flight (PR #1587, unmerged — do not use) |
+| Ad-hoc `tokio::spawn` / background threads for deferred work | `#[job]` (+ retries, backends, uniqueness/concurrency caps), `#[scheduled]` for recurring, `#[task]` for operator CLI work |
+| Hand-written memoization or cache-aside code | `#[cached]` on functions; `cache::get_or_compute` / `get_or_compute_with` for stampede-safe read-through fills (unreleased) |
+| Hand-written transaction retry loops for serialization failures | `Db::tx(...)`; `Db::tx_with(TxOptions::serializable(), ...)` auto-retries 40001 (unreleased) |
+| Hand-rolled HMAC verification for Stripe/GitHub/Slack callbacks | `SignedWebhook` extractor + `[webhooks.<name>]` config |
+| Hand-rolled pager markup (page-number windows, prev/next links) | `pagination_nav(&page, &PagerOptions::new("/posts"))` / `cursor_pagination_nav` (unreleased) |
+| Hand-rolled cross-module notifications (calling every reaction inline) | `#[event]` + `#[listener]` typed event bus, `.listeners(listeners![...])` (unreleased) |
+| Hand-rolled cards, tabs, modals, delete-confirm dialogs, method-override links | `autumn_web::widgets`: `card`/`stat_card`, `tabs`, `modal`/`confirm_action`, `link_to`/`button_to` + `ui::WIDGETS_CSS_PATH` stylesheet (unreleased) |
+
+When none of these fit, dropping to raw Axum (`.merge()`/`.nest()`/`.layer()`)
+or raw Diesel (`&mut *db` with `diesel_async`) is supported and fine — but only
+after checking this table and `docs/guide/`.
 
 ## Crate naming trip wires
 
@@ -181,6 +216,9 @@ Use `.one_off_tasks(one_off_tasks![...])` for `#[task]` handlers invoked by
 | `.with_cache_backend(cache)` | Install a cache backend |
 | `.with_mail_delivery_queue(queue)` | Install durable deferred mail |
 | `.with_audit_sink(sink)` | Install structured audit sink |
+| `.listeners(listeners![...])` | Register `#[listener]` event listeners (unreleased) |
+| `.static_gate(layer)` | Middleware that also guards `#[static_get]` pre-render (unreleased; `has_static_gate::<L>()`, `get_static_gate_types()`, `TestApp::static_gate` mirror it) |
+| `.with_shard_router(router)` | Install a shard router for `[[database.shards]]` (unreleased) |
 | `.run()` | Launch the server |
 
 ## Route macros
@@ -282,7 +320,8 @@ for post in &posts {
 }
 ```
 
-`through = <join_table>` on `#[has_many]` declares a many-to-many
+`through = <join_table>` on `#[has_many]` **(unreleased — trunk-dev, not in
+published 0.5.0)** declares a many-to-many
 association: join columns default to `{source}_id` / `{target}_id`
 (`fk = ...` / `target_fk = ...` to override), the macro emits the join
 table's `diesel::table!` itself (only a migration with a composite primary
@@ -299,6 +338,108 @@ repo.set_tags(post_id, &tag_ids).await?; // replace-all, one transaction
 See `examples/reddit-clone` (`Post` ↔ `Tag` via `post_tags`) for a full
 worked example, and `docs/adr/0008-associations-and-eager-loading.md` for
 the design.
+
+### Model state machines — `#[state_machine]`
+
+**Never hand-roll status-transition validation.** Declare valid transitions on
+the model field; the macro generates the transition table and enforcement:
+
+```rust
+#[autumn_web::model]
+pub struct Order {
+    #[id]
+    pub id: i64,
+    pub amount: i64,
+    #[state_machine(transitions(
+        pending -> processing,
+        processing -> shipped: "can_ship",   // quoted guard method name
+        processing -> cancelled,
+        shipped -> delivered,
+    ))]
+    pub status: String,
+}
+
+impl Order {
+    fn can_ship(&self) -> bool { self.amount > 0 }  // guard: &self -> bool
+}
+```
+
+For a field named `status` this generates on the struct:
+
+| Item | Signature |
+|---|---|
+| `can_transition_status_to` | `(&self, target: &str) -> bool` — edge exists and guards pass |
+| `transition_status_to` | `(&self, target: &str) -> AutumnResult<String>` — `Ok(target)` or a 400 `bad_request` error |
+| `__AUTUMN_SM_STATUS_TRANSITIONS` | `&'static [(&'static str, &'static str, Option<&'static str>)]` — `(from, to, guard)` edge list for UI/API metadata |
+
+Rules: `String` fields only; state and guard names are plain identifiers
+(`in_progress`, not `in-progress`); guards are quoted names of `&self -> bool`
+methods on the model; multiple `#[state_machine]` fields per model are fine
+(each gets its own `{field}`-named methods).
+
+The idiomatic enforcement point is a repository `before_update` hook — this
+replaces any hand-written status `match` block:
+
+```rust
+async fn before_update(
+    &self,
+    _ctx: &mut MutationContext,
+    draft: &mut UpdateDraft<Order>,
+) -> AutumnResult<()> {
+    if draft.after.status != draft.before.status {
+        // Guards must see the proposed content, but the edge lookup needs
+        // the *current* status — clone after, restore the before-status:
+        let mut proposed = draft.after.clone();
+        proposed.status = draft.before.status.clone();
+        proposed.transition_status_to(&draft.after.status)?;
+    }
+    Ok(())
+}
+```
+
+See `docs/guide/state-machines.md` and `examples/wiki` (`Page` model,
+`draft → published → archived`).
+
+### Generated repository surface
+
+`#[repository]` generates far more than CRUD — reach for these before writing
+raw Diesel:
+
+| Method / attr key | Purpose |
+|---|---|
+| `find_by_id`, `find_all`, `count`, `exists_by_id`, `save`, `update`, `delete_by_id` | Core CRUD |
+| `page(&PageRequest)` | Offset pagination (`?page=N&size=M`, clamped, never 400) |
+| `cursor_page(&CursorRequest)` + `cursor_key = field` (opt. `cursor_key_type =`) | Keyset pagination for feeds/large tables; `cursor_key` must be non-nullable |
+| `save_many`, `save_many_skip_invalid`, `update_many`, `delete_many`, `upsert_many` | Bulk ops, hook-aware, auto-chunked under the 65,535-param ceiling; `upsert_many` is a compile error on hooked repositories |
+| `with_lock` | `SELECT ... FOR UPDATE` row locking in a transaction |
+| `primary_reads` (attr) / `on_primary()` | Pin reads to primary; read-your-writes after a save |
+| `soft_delete`, `tenant_scoped` (attrs), `across_tenants()` | Soft deletion and tenant scoping |
+| `hooks = MyHooks` (attr) | `before_/after_create/update/delete` + `after_*_commit` lifecycle hooks with `MutationContext` |
+| `from_shard(&ShardedDb)`, `with_pool_untracked(pool)` | **(unreleased)** shard-scoped construction; `with_pool` was **renamed** `with_pool_untracked` on trunk-dev |
+| `find_in_batches(n)` / `find_each(n)` | **In flight (PR #1592, unmerged) — do not use until merged**: bounded-memory keyset iteration |
+
+Read routing: with `database.replica_url` set, all generated reads use the
+replica automatically; writes always hit the primary. See
+`docs/guide/repositories.md` and `docs/guide/pagination.md`.
+
+### Transactions
+
+`Db::tx(f)` runs a READ COMMITTED transaction. On trunk-dev
+**(unreleased)**, `Db::tx_with(opts, f)` adds isolation levels and automatic
+retry of serialization failures (SQLSTATE 40001) with capped exponential
+backoff:
+
+```rust
+use autumn_web::db::{TxOptions, IsolationLevel};
+
+let opts = TxOptions::serializable()      // or ::repeatable_read(), ::read_committed()
+    .read_only()
+    .max_attempts(8);                     // serializable()/repeatable_read() default to 5
+db.tx_with(opts, |conn| async move { /* &mut AsyncPgConnection */ }.scope_boxed()).await?;
+```
+
+`TxOptions::default()` is identical to `Db::tx`. See
+`docs/guide/transactions.md` and `docs/guide/hooks-and-transactions.md`.
 
 ## Security and auth
 
@@ -334,6 +475,21 @@ async fn update_post(Path(id): Path<i64>, mut db: Db, session: Session) -> Autum
     Ok(html! { "updated" })
 }
 ```
+
+**(unreleased)** Scoped service tokens (trunk-dev only): mint named,
+optionally-expiring API tokens carrying flat scopes via `IssueTokenSpec` +
+`issue_scoped_api_token`; gate handlers with
+`#[secured(scopes = ["posts:write"])]` (no session required — default-deny,
+403 when missing) or `#[secured("admin", scopes = [...])]` for both; check in
+policies with `PolicyContext::has_scope/has_any_scope/has_all_scopes`; manage
+with `autumn token issue --name ... --scope ...` / `list` / `rotate`. The
+published 0.5.0 `autumn token` has only `issue <principal>` / `revoke`.
+
+Active session management ships with `autumn generate auth` (published 0.5.0):
+a `{user}_sessions` row per login, generated `sessions()`,
+`revoke_session(id)`, `revoke_other_sessions(...)`, `revoke_all_sessions()`
+methods, an `/account/sessions` Maud + htmx page, and `[auth.sessions]`
+config (incl. `revoke_on_credential_change`, default on).
 
 In `prod` / `production`, configure a stable signing secret or startup fails:
 
@@ -415,6 +571,34 @@ Use built-in jobs and tasks before reaching for a workflow engine:
 discarding, and canceling framework jobs. `GET /actuator/jobs` exposes
 lower-level counters.
 
+Job attributes beyond `name`/`max_attempts`/`backoff_ms` (published 0.5.0):
+`#[job(unique)]` dedupes on an args hash, `unique_by = "field"`,
+`unique_window = "running"|"pending"`, `unique_for_ms = N` (debounce),
+`concurrency = N` + `concurrency_key = "field"` caps simultaneous runs. A
+coalesced enqueue is a no-op `Ok(())`.
+
+**(unreleased)** trunk-dev jobs additions:
+
+- **Named queues**: `#[job(queue = "critical")]`; drain order via
+  `[jobs] queues = ["critical", "default", "low"]` (strict priority) or a
+  `[jobs.queues]` weight table (weighted, starvation-free). No `queue` →
+  `"default"`. See `docs/guide/jobs.md`.
+- **Tracked jobs**: `job::enqueue_tracked` / `enqueue_tracked_for` (and
+  generated `{Job}::enqueue_tracked` companions) return a `TrackedJobHandle`
+  with a public token; `#[job]` accepts an optional third `JobContext` arg
+  (`async fn(AppState, Args, JobContext)`) with `set_progress(pct, msg)` /
+  `set_result(json)` / `set_user_error(msg)`; poll `GET /_autumn/jobs/{token}`
+  (JSON or self-polling htmx fragment). Config: `jobs.tracking.ttl_secs`
+  (default 24h), `jobs.tracking.route_enabled`.
+
+**(unreleased)** Events & listeners — a typed domain event bus so one action
+can fan out without inline coupling: `#[event]` on a struct, publish via the
+`Events` extractor (`events.publish(UserSignedUp { .. }).await?`), react with
+`#[listener(UserSignedUp)]` (sync, in-request) or
+`#[listener(UserSignedUp, durable, max_attempts = 5)]` (jobs-backed), and
+register with `.listeners(listeners![...])`. Do not also list durable
+listeners in `jobs![...]`. See `docs/guide/events.md`.
+
 ## File storage and cache plugins
 
 For local or pluggable file storage:
@@ -445,6 +629,30 @@ autumn_web::app()
     .await;
 ```
 
+**(unreleased)** Cache stampede protection — do not hand-roll cache-aside
+fills: `cache::get_or_compute(cache, key, Some(ttl), fill)` runs `fill` once
+per process for concurrent callers; `get_or_compute_with` +
+`GetOrComputeOptions::new().distributed_fill_lock(true)` (Redis lock) and
+`.stale_while_revalidate(grace)` add cross-replica single-fill and
+serve-stale; `cache::jittered_ttl(base, fraction)` de-synchronizes mass
+expiry. A failed fill never poisons the key. See
+`docs/guide/cache-stampede.md`.
+
+## View helpers and widgets (unreleased — trunk-dev, not in published 0.5.0)
+
+Trunk-dev ships framework view widgets — prefer these over hand-rolled Maud
+for the common cases:
+
+| Helper | Purpose |
+|---|---|
+| `link_to(label, href)` / `link_to_with(..., &LinkToOptions)` | Escaped GET anchors; auto `rel="noopener"` on `target="_blank"` |
+| `button_to(label, href, Method, csrf_token)` / `button_to_with` | Single-button form for state-changing actions; CSRF is a required arg; non-GET emits hidden `_method` override |
+| `card(&body, &CardConfig::new().title("..."))` / `stat_card(label, value, link)` | Titled panels and metric tiles (`autumn_web::widgets`, prelude re-export) |
+| `tabs(id, &[(id, label, markup)])` | No-JS CSS-only tab switcher (`docs/guide/tabs.md`) |
+| `modal(id, title, &body, &ModalConfig)` / `confirm_action(...)` | Native `<dialog>` confirm for destructive actions — replaces `hx-confirm`/`window.confirm()` |
+| `pagination_nav(&page, &PagerOptions::new("/posts"))` / `cursor_pagination_nav` | Accessible, filter-preserving, htmx-opt-in pager from a `Page`/`CursorPage` (prelude re-export) |
+| `autumn_web::ui::WIDGETS_CSS` / `WIDGETS_CSS_PATH` | One shipped stylesheet backing every `autumn-*` widget class — link `href=(WIDGETS_CSS_PATH)` instead of copying widget CSS into `input.css`. Accent now follows `var(--primary)` (violet), not the old hardcoded indigo (`docs/guide/widget-styling.md`) |
+
 ## Configuration
 
 Config layering, lowest to highest:
@@ -467,6 +675,46 @@ Use `AUTUMN_SECTION__FIELD` for env overrides, for example
 `AUTUMN_DATABASE__PRIMARY_URL`, `AUTUMN_JOBS__BACKEND`,
 `AUTUMN_SECURITY__SIGNING_SECRET`, and
 `AUTUMN_SECURITY__WEBHOOKS__REPLAY__BACKEND`.
+
+## Observability defaults
+
+Published 0.5.0 behavior:
+
+- Structured per-request access log is **on by default**; disable with
+  `log.access_log = false`, tune exclusions with `log.access_log_exclude`
+  (probes/static excluded out of the box).
+- Request-scoped log context auto-tags every log line in a request; add
+  custom fields with `autumn_web::log::context::with_log_field("order_id", id)`
+  (prelude re-export).
+- `actuator.prometheus` exposes the Prometheus scrape endpoint independently
+  of sensitive actuator mode.
+
+## Resilience: load shedding (unreleased — trunk-dev)
+
+Admission control caps concurrent in-flight requests; excess is shed
+immediately with `503` + `Retry-After` before the handler runs. Disabled by
+default:
+
+```toml
+[server]
+max_concurrent_requests = 256   # unset/0 = unlimited
+```
+
+Probes (`/health`, `/live`, `/ready`, `/startup`, actuator) are never shed;
+sheds increment `autumn_requests_shed_total`. See `docs/guide/resilience.md`
+and `docs/adr/0009-adopt-overload-protection-load-shedding.md`.
+
+## Sharding (unreleased — trunk-dev, not in published 0.5.0)
+
+Framework-native horizontal sharding: declare `[[database.shards]]` (each a
+full primary/replica topology), route by key → logical slot → shard. Prelude
+extractors `ShardedDb` (routed handle: `db_for`/`read_for`/`db_on`, bounded
+`each_shard` fan-out) and `Shards`; install custom routing with
+`AppBuilder::with_shard_router`; build repositories per shard with
+`from_shard(&ShardedDb)`. `autumn migrate` gains `--shard <name>` /
+`--control-only`; a boot-time shard-map guard fails fast on config drift.
+There are no cross-shard queries or transactions by design. See
+`docs/guide/sharding.md` and `examples/bookmarks-sharded`.
 
 ## Error handling
 
@@ -563,6 +811,23 @@ autumn dev-loop-bench --dry-run
 autumn plugin-check --plugin-name autumn-admin-plugin --prefix /admin
 ```
 
+**(unreleased)** trunk-dev-only CLI additions — NOT in the published 0.5.0
+`autumn-cli`; do not suggest them to users on the published release:
+
+```bash
+autumn serve --daemon            # non-watch local daemon; also: serve stop|status|restart
+autumn serve --bundled-pg        # managed local Postgres (managed-pg-bundled feature)
+autumn destroy scaffold Post title:String   # cleanly reverses generate; --dry-run supported
+autumn generate scaffold Post title:String status:enum{draft,published} price:decimal{10,2} author:references email:String:unique
+autumn generate scaffold Post title:String --live --live-validation
+autumn generate tauri            # desktop sidecar project (cargo tauri build)
+autumn generate plugin my-plugin # installable/conformant plugin crate
+autumn token issue --name ci --scope posts:write   # scoped tokens; also list, rotate
+```
+
+`autumn destroy` mirrors `autumn generate` argument-for-argument and never
+touches a database — it only reverses generated files/migrations.
+
 `autumn doctor --strict` is the deployment sanity check. It reports unsafe
 production defaults, missing primaries, stale replica migrations, missing
 signing secrets, and other config problems without printing credentials.
@@ -612,8 +877,19 @@ cargo fmt --all -- --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 cargo test -p autumn-web --doc --all-features
-cargo test -p autumn-cli --test repo_hygiene
+cargo test -p autumn-cli --test cli_tests
 ```
+
+There is no separate `repo_hygiene` test target anymore — it is consolidated
+into `cli_tests` (`autumn-cli/tests/integration/repo_hygiene.rs`). Integration
+tests live in consolidated binaries (`autumn` → `integration_tests`,
+`autumn-cli` → `cli_tests`); new tests go in `tests/integration/<name>.rs` +
+a `mod` line in `tests/integration/mod.rs`, not new `[[test]]` targets.
+
+CI also runs a feature-combination compile gate (35 `autumn-web` feature
+combos via `cargo hack`), a generator-conformance gate, and a plugin
+freshness gate (`scripts/check-plugin-freshness.sh` — user-facing changelog
+entries must ship matching Claude-plugin updates).
 
 For docs or generated-app changes, also run the docs smoke procedure in
 `docs/guide/docs-smoke.md`. For public API changes, run doctests for the
@@ -650,6 +926,19 @@ touched crate so examples compile from an external-consumer perspective.
 - `docs/guide/signed-webhooks.md`
 - `docs/guide/storage.md`
 - `docs/guide/jobs.md`
+- `docs/guide/state-machines.md`
+- `docs/guide/repositories.md`
+- `docs/guide/pagination.md`
+- `docs/guide/transactions.md`
+- `docs/guide/hooks-and-transactions.md`
+- `docs/guide/events.md`
+- `docs/guide/cache-stampede.md`
+- `docs/guide/sharding.md`
+- `docs/guide/daemon.md`
+- `docs/guide/resilience.md`
+- `docs/guide/generators.md`
+- `docs/guide/widget-styling.md`
+- `docs/guide/tabs.md`
 - `docs/guide/maintenance-mode.md`
 - `docs/guide/dev-loop-latency.md`
 - `docs/guide/system-tests.md`

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -50,7 +50,7 @@ the framework almost certainly already generates or ships it:
 | Status-transition validation written by hand in `before_create`/`before_update` hooks or handlers (`if old == "draft" && new == "published"` match blocks) | `#[state_machine(transitions(...))]` on the model field — generated `can_transition_{field}_to` / `transition_{field}_to` enforce the graph. See "Model state machines" below and `docs/guide/state-machines.md` |
 | Raw `axum::Router` routes and handlers, manual `.route("/x", get(...))` | `#[get]`/`#[post]`/`#[put]`/`#[patch]`/`#[delete]` + `routes![...]`, `.scoped(prefix, layer, routes)` for groups. `.merge()`/`.nest()` exist for the rare escape hatch only |
 | Raw Diesel queries for CRUD, lookups, pagination, or bulk writes | `#[repository]`-generated methods: `find_by_id`, `find_all`, `save`, `update`, `delete_by_id`, derived `find_by_*`, `page(&PageRequest)`, `cursor_page(&CursorRequest)`, bulk `save_many`/`update_many`/`delete_many`/`upsert_many`. See `docs/guide/repositories.md`, `docs/guide/pagination.md` |
-| Manual per-item queries in a loop (N+1) or hand-written JOINs to fetch associations | `#[belongs_to]`/`#[has_many]`/`#[has_one]` + `repo.preload(records, Model::preload()...)` |
+| Manual per-item queries in a loop (N+1) or hand-written JOINs to fetch associations | `#[belongs_to]`/`#[has_many]`/`#[has_one]` + `repo.preload(records, Model::preload()...)` (unreleased) |
 | Hand-rolled auth, session, or token checks in handler bodies | `#[secured]` / `#[secured("role")]`, `#[authorize]`, repository `policy =`/`scope =`; `#[secured(scopes = [...])]` for service tokens (unreleased) |
 | Hand-assembled `<form>` markup with manual value re-fill and error display | `autumn_web::form` helpers — `form_tag`, `method_input`, `text_input` (published); `number_input`, `datetime_input`, `date_input`, `checkbox_input`, `select_input` + `Changeset` 422 re-render (unreleased). A whole-form `form_for` builder is in-flight (PR #1587, unmerged — do not use) |
 | Ad-hoc `tokio::spawn` / background threads for deferred work | `#[job]` (+ retries, backends, uniqueness/concurrency caps), `#[scheduled]` for recurring, `#[task]` for operator CLI work |
@@ -293,7 +293,7 @@ pub trait PostRepository {}
 allow_unauthorized_repository_api = true # only when intentional
 ```
 
-### Associations and preloading
+### Associations and preloading (unreleased — trunk-dev, not in published 0.5.0)
 
 Declare `#[belongs_to]` / `#[has_many]` / `#[has_one]` on a `#[model]` for
 batched eager loading — no N+1, no lazy loading (un-preloaded access returns
@@ -320,8 +320,7 @@ for post in &posts {
 }
 ```
 
-`through = <join_table>` on `#[has_many]` **(unreleased — trunk-dev, not in
-published 0.5.0)** declares a many-to-many
+`through = <join_table>` on `#[has_many]` declares a many-to-many
 association: join columns default to `{source}_id` / `{target}_id`
 (`fk = ...` / `target_fk = ...` to override), the macro emits the join
 table's `diesel::table!` itself (only a migration with a composite primary

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -820,7 +820,7 @@ autumn plugin-check --plugin-name autumn-admin-plugin --prefix /admin
 autumn serve --daemon            # non-watch local daemon; also: serve stop|status|restart
 autumn serve --bundled-pg        # managed local Postgres (managed-pg-bundled feature)
 autumn destroy scaffold Post title:String   # cleanly reverses generate; --dry-run supported
-autumn generate scaffold Post title:String status:enum{draft,published} price:decimal{10,2} author:references email:String:unique
+autumn generate scaffold Post title:String 'status:enum{draft,published}' 'price:decimal{10,2}' author:references email:String:unique
 autumn generate scaffold Post title:String --live --live-validation
 autumn generate tauri            # desktop sidecar project (cargo tauri build)
 autumn generate plugin my-plugin # installable/conformant plugin crate

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -84,10 +84,11 @@ together (`0.5.0` published; `0.6.0` on trunk-dev, unpublished).
 | `#[event]`, `#[listener]`, `listeners![...]` | Typed domain event bus (**unreleased**) — publish via the `Events` extractor, register with `.listeners(...)` |
 
 `#[model]` also recognizes `#[belongs_to]` / `#[has_many]` / `#[has_one]`
-struct-level attributes for declarative associations with batched eager
+struct-level attributes (**unreleased** — trunk-dev, not in published 0.5.0)
+for declarative associations with batched eager
 preloading (`Model::preload()`, `repo.preload(records, spec)`); these are
 consumed by `#[model]` itself, not separately-registered proc macros.
-`#[has_many(Target, through = join_table)]` (**unreleased**) declares a
+`#[has_many(Target, through = join_table)]` declares a
 many-to-many association through a join table, adding `add_{singular}` /
 `remove_{singular}` / `set_{plural}` mutation helpers to the generated
 `#[repository]`. See the `#[model]` doc comment in `autumn-macros/src/lib.rs`
@@ -107,11 +108,12 @@ Published 0.5.0: `find_by_id`, `find_all`, `count`, `exists_by_id`, `save`,
 `page(&PageRequest)`, `cursor_page(&CursorRequest)` (with `cursor_key =` /
 `cursor_key_type =` attr keys), bulk `save_many` / `save_many_skip_invalid` /
 `update_many` / `delete_many` / `upsert_many` (compile error on hooked repos),
-`with_lock`, `on_primary()`, `preload`. Attr keys: `api =`, `policy =`,
+`with_lock`, `on_primary()`. Attr keys: `api =`, `policy =`,
 `scope =`, `primary_reads`, `soft_delete`, `tenant_scoped`, `hooks =`,
 `mcp` / `mcp = "read"`.
 
-**(unreleased)**: `from_shard(&ShardedDb)`; `with_pool_untracked` (new on
+**(unreleased)**: `preload(records, spec)` (declarative associations);
+`from_shard(&ShardedDb)`; `with_pool_untracked` (new on
 trunk-dev — published 0.5.0 repositories have no pool constructor).
 **In flight (PR #1592, unmerged)**:
 `find_in_batches(n)` / `find_each(n)` — do not use until merged.

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -111,8 +111,9 @@ Published 0.5.0: `find_by_id`, `find_all`, `count`, `exists_by_id`, `save`,
 `scope =`, `primary_reads`, `soft_delete`, `tenant_scoped`, `hooks =`,
 `mcp` / `mcp = "read"`.
 
-**(unreleased)**: `from_shard(&ShardedDb)`; `with_pool` **renamed**
-`with_pool_untracked`. **In flight (PR #1592, unmerged)**:
+**(unreleased)**: `from_shard(&ShardedDb)`; `with_pool_untracked` (new on
+trunk-dev — published 0.5.0 repositories have no pool constructor).
+**In flight (PR #1592, unmerged)**:
 `find_in_batches(n)` / `find_each(n)` — do not use until merged.
 
 ## Db transactions

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -1,8 +1,11 @@
-# autumn-web 0.5.0 API Reference
+# autumn-web API Reference (published 0.5.0 + trunk-dev)
 
 Use this file as a quick map for public names, features, dependency versions,
-and config keys. Source of truth is the workspace at version 0.5.0; verify
-against current source when exact code matters.
+and config keys. Verify against current source when exact code matters.
+
+Version identity: crates.io serves **0.5.0** (the latest published release);
+the `trunk-dev` workspace is versioned **0.6.0 (unpublished)**. Entries marked
+**(unreleased)** exist on trunk-dev but NOT in the published 0.5.0 crates.
 
 ## Published crates
 
@@ -15,7 +18,8 @@ against current source when exact code matters.
 | `autumn-storage-s3` | `autumn-storage-s3/` | S3-compatible `BlobStore` plugin |
 | `autumn-cache-redis` | `autumn-cache-redis/` | Redis cache plugin |
 
-All publishable crates share `[workspace.package].version = "0.5.0"`.
+All publishable crates share the `[workspace.package]` version and release
+together (`0.5.0` published; `0.6.0` on trunk-dev, unpublished).
 
 ## Top-level exports
 
@@ -74,16 +78,106 @@ All publishable crates share `[workspace.package].version = "0.5.0"`.
 | `paths![...]` | Typed route path helper module |
 | `#[mailer]`, `#[mailer_preview]`, `mail_previews![...]` | Mail helpers (`mail`) |
 | `t!(...)` | Compile-time checked translation lookup (`i18n`) |
+| `#[feature_flag]` | Feature-flag definition |
+| `#[inbound_mail]` | Inbound mail handler |
+| `#[step_up]` | Step-up authentication guard |
+| `#[event]`, `#[listener]`, `listeners![...]` | Typed domain event bus (**unreleased**) — publish via the `Events` extractor, register with `.listeners(...)` |
 
 `#[model]` also recognizes `#[belongs_to]` / `#[has_many]` / `#[has_one]`
 struct-level attributes for declarative associations with batched eager
 preloading (`Model::preload()`, `repo.preload(records, spec)`); these are
 consumed by `#[model]` itself, not separately-registered proc macros.
-`#[has_many(Target, through = join_table)]` declares a many-to-many
-association through a join table, adding `add_{singular}` /
+`#[has_many(Target, through = join_table)]` (**unreleased**) declares a
+many-to-many association through a join table, adding `add_{singular}` /
 `remove_{singular}` / `set_{plural}` mutation helpers to the generated
 `#[repository]`. See the `#[model]` doc comment in `autumn-macros/src/lib.rs`
 and `docs/adr/0008-associations-and-eager-loading.md`.
+
+`#[model]` also consumes the `#[state_machine(transitions(from -> to,
+from -> to: "guard", ...))]` field attribute on `String` fields, generating
+`can_transition_{field}_to(&self, &str) -> bool`,
+`transition_{field}_to(&self, &str) -> AutumnResult<String>`, and a
+`__AUTUMN_SM_{FIELD}_TRANSITIONS` edge-list constant. See
+`docs/guide/state-machines.md`.
+
+## Repository-generated methods (`#[repository]`)
+
+Published 0.5.0: `find_by_id`, `find_all`, `count`, `exists_by_id`, `save`,
+`update`, `delete_by_id`, derived `find_by_*`/`count_by_*`/`exists_by_*`,
+`page(&PageRequest)`, `cursor_page(&CursorRequest)` (with `cursor_key =` /
+`cursor_key_type =` attr keys), bulk `save_many` / `save_many_skip_invalid` /
+`update_many` / `delete_many` / `upsert_many` (compile error on hooked repos),
+`with_lock`, `on_primary()`, `preload`. Attr keys: `api =`, `policy =`,
+`scope =`, `primary_reads`, `soft_delete`, `tenant_scoped`, `hooks =`,
+`mcp` / `mcp = "read"`.
+
+**(unreleased)**: `from_shard(&ShardedDb)`; `with_pool` **renamed**
+`with_pool_untracked`. **In flight (PR #1592, unmerged)**:
+`find_in_batches(n)` / `find_each(n)` — do not use until merged.
+
+## Db transactions
+
+- `Db::tx(f)` — READ COMMITTED, one attempt (published 0.5.0).
+- `Db::tx_with(opts: TxOptions, f) -> Result<T, AutumnError>`
+  (**unreleased**) — closure gets `&mut AsyncPgConnection`; auto-retries
+  SQLSTATE 40001 with capped exponential backoff.
+- `autumn_web::db::IsolationLevel` {`ReadCommitted` (default),
+  `RepeatableRead`, `Serializable`}; `TxOptions` builders
+  `::read_committed()` / `::repeatable_read()` / `::serializable()` +
+  `.read_only()` / `.deferrable()` / `.max_attempts(n)` /
+  `.initial_backoff(d)` / `.max_backoff(d)`; retrying constructors default
+  to 5 attempts.
+
+## Form helpers (`autumn_web::form`)
+
+Free functions rendering changeset-aware, accessible inputs:
+
+- Published 0.5.0: `form_tag`, `method_input`, `text_input`,
+  `text_input_htmx`; `Changeset`-bound methods (`form.form_tag(...)`,
+  `form.text_input(...)`).
+- **(unreleased)**: `checkbox_input`, `number_input`, `date_input`,
+  `datetime_input`, `select_input`.
+- **In flight (PR #1587, unmerged)**: `form_for` whole-form builder +
+  `FormModel` derive — do not use until merged.
+
+## View widgets and UI (all unreleased — trunk-dev only)
+
+- `autumn_web::widgets`: `card(&body, &CardConfig)`,
+  `stat_card(label, value, link)`, `tabs(id, &[(id, label, markup)])`,
+  `modal(id, title, &body, &ModalConfig)`, `modal_trigger`,
+  `modal_close_button`, `confirm_action(...)`.
+- `autumn_web::links`: `link_to`, `link_to_with`, `button_to(label, href,
+  Method, csrf_token)`, `button_to_with(..., &ButtonToOptions)`.
+- `autumn_web::ui::pagination`: `pagination_nav(&Page, &PagerOptions)`,
+  `cursor_pagination_nav(&CursorPage, &PagerOptions)`, `PagerOptions::new(base)
+  .query(qs).hx_target(sel).hx_push_url()` (prelude re-exports).
+- `autumn_web::ui::{WIDGETS_CSS, WIDGETS_CSS_PATH}` widget stylesheet.
+
+## Cache read-through (unreleased)
+
+`autumn_web::cache::{get_or_compute, get_or_compute_with,
+GetOrComputeOptions, CacheFillError, jittered_ttl}` — single-flight fills,
+optional `.distributed_fill_lock(true)` / `.stale_while_revalidate(grace)`.
+
+## Jobs additions
+
+- Published 0.5.0 `#[job]` keys: `name`, `max_attempts`, `backoff_ms`,
+  `unique`, `unique_by`, `unique_window`, `unique_for_ms`, `concurrency`,
+  `concurrency_key`.
+- **(unreleased)**: `queue = "name"` + `[jobs] queues` strict-priority list or
+  `[jobs.queues]` weight table; tracked jobs (`job::enqueue_tracked`,
+  `enqueue_tracked_for`, `TrackedJobHandle`, optional third `JobContext`
+  handler arg, `GET /_autumn/jobs/{token}`, `jobs.tracking.*` config).
+
+## Auth additions
+
+- Published 0.5.0: `autumn generate auth` session management (`{user}_sessions`
+  table, `sessions()` / `revoke_session` / `revoke_other_sessions` /
+  `revoke_all_sessions`, `/account/sessions` page, `[auth.sessions]` config).
+- **(unreleased)**: scoped service tokens — `IssueTokenSpec`,
+  `issue_scoped_api_token`, `#[secured(scopes = [...])]`,
+  `PolicyContext::has_scope/has_any_scope/has_all_scopes`, `autumn token
+  issue --name/--scope/--expires-at | list | rotate`, admin `TokenAdminModel`.
 
 ## Prelude contents
 
@@ -141,6 +235,9 @@ and `docs/adr/0008-associations-and-eager-loading.md`.
 | `with_audit_sink(sink)` | Structured audit sink |
 | `policy::<R, P>(policy)`, `scope::<R, S>(scope)` | Repository authorization |
 | `plugin(plugin)`, `plugins(tuple)` | Plugin install |
+| `listeners(listeners![...])` | Event listeners (**unreleased**) |
+| `static_gate(layer)`, `has_static_gate::<L>()`, `get_static_gate_types()` | Static pre-render gating middleware (**unreleased**) |
+| `with_shard_router(router)` | Sharding router (**unreleased**) |
 | `run()` | Start server |
 
 ## Cargo features

--- a/skills/autumn-web/references/examples.md
+++ b/skills/autumn-web/references/examples.md
@@ -1,7 +1,51 @@
-# autumn-web 0.5.0 Example Reference
+# autumn-web Example Reference (published 0.5.0)
 
 Use these patterns when generating or reviewing Autumn apps. The official
 examples live under `examples/`; prefer current source when exact code matters.
+Everything here works on the published 0.5.0 crates unless marked otherwise.
+
+## Status field with a state machine (replaces hand-rolled hook validation)
+
+Do NOT write status-transition `match` blocks in `before_create`/
+`before_update` hooks or handlers — declare the graph on the model instead:
+
+```rust
+#[autumn_web::model]
+pub struct Page {
+    #[id]
+    pub id: i64,
+    pub title: String,
+    pub body: String,
+    #[state_machine(transitions(
+        draft -> published: "can_publish",
+        published -> archived,
+    ))]
+    pub status: String,
+}
+
+impl Page {
+    fn can_publish(&self) -> bool {
+        !self.title.is_empty() && !self.body.is_empty()
+    }
+}
+
+// In PageHooks::before_update — the only transition code you write:
+async fn before_update(
+    &self,
+    _ctx: &mut MutationContext,
+    draft: &mut UpdateDraft<Page>,
+) -> AutumnResult<()> {
+    if draft.after.status != draft.before.status {
+        let mut proposed = draft.after.clone();
+        proposed.status = draft.before.status.clone();
+        proposed.transition_status_to(&draft.after.status)?; // 400 on bad edge/guard
+    }
+    Ok(())
+}
+```
+
+See `examples/wiki/src/models.rs` + `examples/wiki/src/hooks.rs` and
+`docs/guide/state-machines.md`.
 
 ## Minimal app
 

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -48,6 +48,12 @@ autumn dev --show-config
 `autumn dev` uses the `dev` profile automatically in debug builds
 (`AUTUMN_ENV=dev` is the default).
 
+On trunk-dev (unreleased — not in the published 0.5.0 CLI) there is also
+`autumn serve` for a non-watch local daemon: `autumn serve --daemon` /
+`stop` / `status` / `restart`, `--release`, and `--bundled-pg` for a managed
+local Postgres. See `docs/guide/daemon.md`. Do not suggest it to users on the
+published 0.5.0 CLI.
+
 ## What gets served
 
 Once running, tell the user what's available:

--- a/skills/generate/SKILL.md
+++ b/skills/generate/SKILL.md
@@ -17,6 +17,11 @@ allowed-tools:
 Wrap `autumn generate <subcommand>` commands. Always show a redacted command
 preview and get confirmation before executing any mutating generator.
 
+**Version check first**: rows and tokens marked **(trunk-dev)** below exist
+only on the trunk-dev CLI, NOT in the published `autumn-cli 0.5.0`. Run
+`autumn --version` (or check how the CLI was installed) before suggesting
+them; on 0.5.0 fall back to the documented manual alternative.
+
 ## Supported subcommands
 
 | Subcommand | Example | What it creates |
@@ -31,6 +36,14 @@ preview and get confirmation before executing any mutating generator.
 | `system-test` | `system-test checkout_flow` | System test fixture (name must be `snake_case` or `PascalCase` — no hyphens) |
 | `pwa` | `pwa` | PWA scaffolding — manifest, service worker, offline shell, icons, route handlers, smoke test |
 | `wizard` | `wizard checkout shipping payment review` | Session-backed multi-step form — step structs, GET/POST handlers, confirm/commit/cancel, and ignored integration test skeletons |
+| `tauri` **(trunk-dev)** | `tauri` | `src-tauri/` desktop sidecar project; purely additive; then `cargo tauri build` |
+| `plugin` **(trunk-dev)** | `plugin my-plugin` | Installable/conformant Autumn plugin crate |
+
+**Reversing a generator (trunk-dev)**: `autumn destroy <subcommand> <args>`
+mirrors `autumn generate` argument-for-argument and cleanly removes what it
+created (`autumn destroy scaffold Post title:String`, `--dry-run` supported).
+It never touches a database — only generated files/migrations. On the
+published 0.5.0 CLI, revert by hand (git) instead.
 
 ## Field type reference
 
@@ -52,16 +65,27 @@ accept aliases like `Integer` or `Boolean`.
 | `Bytea` | `BYTEA NOT NULL` | `Vec<u8>` |
 | `Attachment` | `JSONB NULL` (blob metadata) | `Option<Blob>` (always nullable) — **requires `storage` feature in Cargo.toml**; generator does not add it automatically |
 | `Option<T>` | Nullable version of any above | `Option<T>` |
+| `references` **(trunk-dev)** | `post:references` → `post_id BIGINT NOT NULL REFERENCES posts(id)` + auto index | `i64` (field name gets `_id` appended; `post:references?` for `Option<i64>`) |
+| `enum{a,b,c}` **(trunk-dev)** | `TEXT` + `CHECK (col IN (...))` | Generated PascalCase Rust enum with Diesel/serde impls + `<select>` widget; `--default field=variant` sets SQL DEFAULT + `#[default]`. Quote the token in bash/zsh (brace expansion) |
+| `decimal` / `decimal{10,2}` **(trunk-dev)** | `NUMERIC(12,2)` default, or explicit precision/scale | `rust_decimal::Decimal` (dependency added automatically); use for money, never `f64` |
+| `:unique` modifier **(trunk-dev)** | `email:String:unique` → `CREATE UNIQUE INDEX` in the migration | Also generates a free `find_by_<field>` lookup and 23505 → 422 inline "already exists" form error. `--unique FIELD` is the flag equivalent |
 
-**Indexes and UNIQUE constraints are not field tokens.** Add them by hand in the
-generated migration's `up.sql` after scaffolding.
+**Foreign keys** (published 0.5.0 CLI only — no `references` token): scaffold
+an `i64` field and hand-edit the generated migration to add
+`REFERENCES users(id)` and an index. On trunk-dev, use `user:references`.
 
-**Foreign keys are not in the DSL.** To add an FK column (e.g. `user_id`), scaffold the
-model with an `i64` field and then hand-edit the generated migration to add
-`REFERENCES users(id)` and an index.
+**Indexes/UNIQUE** (published 0.5.0 CLI only — no `:unique` token): add them
+by hand in the generated migration's `up.sql`. On trunk-dev, use `:unique` /
+`--unique FIELD` / `--index FIELD`.
 
 **Do not use UUID as a primary key.** Primary keys are always `i64` /
 `BIGSERIAL`. Use `Uuid` as a secondary column for external correlation only.
+
+**Scaffold form behavior (trunk-dev)**: generated `create`/`update` handlers
+build a `Changeset` and, on a rejected submission, respond **422** and
+re-render the form with all submitted values preserved and per-field inline
+errors — do not "fix" this by adding a redirect-to-error-page. The published
+0.5.0 scaffold returns a 400 error page instead.
 
 ## Execution flow
 
@@ -211,6 +235,9 @@ Next steps:
 - `--passkeys`: For `auth` — add WebAuthn passkeys
 - `--dry-run`: Print what would be written without touching the filesystem (supported by `wizard`)
 - `--force`: Overwrite existing files without prompting (supported by `wizard`)
+- `--live` **(trunk-dev)**: For `scaffold` — repository broadcasts, a `LiveFragment` impl, an SSE stream route, and an SSE-wired index list
+- `--live-validation` **(trunk-dev)**: For `scaffold` — per-field inline validation endpoints with `hx-post` inputs (implies `--live`)
+- `--unique FIELD` / `--index FIELD` / `--default field=variant` **(trunk-dev)**: Constraint/index/default markers (see field table)
 
 ## Wizard name constraints
 


### PR DESCRIPTION
## Before / After

**Before:** the Claude plugin described the framework as of early June. It had no coverage of model state machines at all, and carried stale claims like "foreign keys are not in the DSL" — so agents using the plugin would hand-roll hook-based status validation and reach for raw Diesel/Axum instead of framework features that already exist.

**After:** every current framework feature is documented with signatures verified against source, plus:

- A 13-row "Prefer framework idioms over raw Diesel/Axum" steering table so agents reach for `#[state_machine]`, repository methods, route macros, `#[job]`, and `#[secured]` instead of hand-rolling.
- Unreleased-vs-0.5.0 markers verified against the actual published crates.io 0.5.0 sources (not just the changelog, which disagrees with the published crates in places — e.g. sharding and `autumn serve --daemon` are listed under 0.5.0 but are not in the published release).
- In-flight PRs #1587 (`form_for`) and #1592 (`find_in_batches`/`find_each`) flagged as unmerged rather than documented as available.
- A low-friction CI gate: a PR that adds entries to the CHANGELOG's Unreleased `Added`/`Changed` sections without touching the plugin fails a fast, toolchain-free check — with escape hatches (a per-bullet `no-plugin` bracketed marker in the changelog, the same marker PR-wide in the PR body, or a `plugin-exempt` label) so it never blocks work that genuinely has no agent-facing surface.

## How

**Plugin content** (`skills/`, `agents/`):
- `skills/autumn-web/SKILL.md` (+~300): version-identity trip wire; steering table; state machines; generated repository surface (pagination, bulk ops, read routing, hooks); `Db::tx_with`/`TxOptions`; jobs (uniqueness/concurrency, named queues, tracked jobs); events/listeners; cache stampede protection; view widgets + `WIDGETS_CSS`; sharding (`ShardedDb` auto-routed handle vs `Shards` explicit routing); observability; load shedding; scoped tokens + session management; CLI additions (`serve`, `destroy`, generator DSL, `tauri`/`plugin`, token scopes); verification-gates fixes.
- `skills/autumn-web/references/api-reference.md` (+~110): proc-macro rows, new sections for repository methods, transactions, form helpers, widgets, cache, jobs, auth.
- `skills/autumn-web/references/examples.md` (+~46): state-machine worked example.
- `skills/autumn-patterns/SKILL.md`, `skills/generate/SKILL.md`, `skills/dev/SKILL.md`: idiom-first rule, corrected field-DSL table (`references`, `enum{...}`, `decimal`, `:unique`), daemon note.
- `agents/autumn-reviewer.md`: "Framework idioms" checklist section.

**CI gate mechanics**:
- `scripts/check-plugin-freshness.sh` + `.github/workflows/plugin-freshness.yml` (PRs to trunk/trunk-dev; single ubuntu job, `contents: read`, no Rust toolchain — bash + python3 only).
- Drift check: extracts Unreleased `Added`/`Changed` bullets at the merge base and at HEAD, joins multi-line bullets into whitespace-normalized logical lines, and takes the set difference — so pure moves and rewraps never trip it, only genuinely new bullets. If non-exempt new bullets exist and no file under `skills/`, `agents/`, or `.claude-plugin/` changed, the job fails with instructions.
- Static checks (always run): `plugin.json` parses as JSON; every `docs/guide/*.md` path referenced from the plugin exists.
- Workflow triggers include `labeled`/`unlabeled`/`edited` so applying the `plugin-exempt` label or editing the marker into the PR body re-evaluates the gate.
- Self-test: `scripts/check-plugin-freshness.sh --self-test` runs 11 synthetic-git-repo scenarios (including per-bullet exemption and rewrap tolerance); `--static-only` for pre-commit use.

**No version bumps**: per CLAUDE.md, the workspace version and all version pins are untouched; changelog entries land only under the existing `## [Unreleased]` section (ci bullet under Added, plugin bullet under a Documentation subsection, matching the 0.3.0 precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGhNsqpjw2ZTpKng6uao6v

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGhNsqpjw2ZTpKng6uao6v)_