### PR TITLE
docs(plugin): document form_for and find_in_batches now that #1587/#1592 merged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -621,9 +621,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the `references`/`enum{...}`/`decimal`/`:unique` generator DSL, scoped
   tokens, observability defaults, and load shedding. Features merged on
   trunk-dev but absent from the published 0.5.0 crates are explicitly marked
-  "(unreleased)", and in-flight PRs (#1587 `form_for`, #1592
-  `find_in_batches`) are flagged as unmerged rather than documented as
-  available. Fixes stale claims (foreign keys/unique "not in the DSL", the
+  "(unreleased)". Follow-up: once #1587 (`form_for`) and #1592
+  (`find_in_batches`) merged, their in-flight/do-not-use flags were replaced
+  with real coverage — `form_for`/`FormModel`/`FieldControl` (builder methods,
+  derived control mapping, checkbox/datetime/serde-rename decode contracts,
+  scaffold `{snake}_form_for` emission) and
+  `find_in_batches`/`find_each`/`autumn_web::batches` (keyset semantics,
+  retryable errors, scoping/routing inheritance, sharding limits) — each
+  marked "(unreleased)". Fixes stale claims (foreign keys/unique "not in the DSL", the
   removed `--test repo_hygiene` target) and documents that published 0.5.0
   repositories have no pool constructor (`with_pool_untracked` is
   trunk-dev-only).

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -52,7 +52,8 @@ the framework almost certainly already generates or ships it:
 | Raw Diesel queries for CRUD, lookups, pagination, or bulk writes | `#[repository]`-generated methods: `find_by_id`, `find_all`, `save`, `update`, `delete_by_id`, derived `find_by_*`, `page(&PageRequest)`, `cursor_page(&CursorRequest)`, bulk `save_many`/`update_many`/`delete_many`/`upsert_many`. See `docs/guide/repositories.md`, `docs/guide/pagination.md` |
 | Manual per-item queries in a loop (N+1) or hand-written JOINs to fetch associations | `#[belongs_to]`/`#[has_many]`/`#[has_one]` + `repo.preload(records, Model::preload()...)` (unreleased) |
 | Hand-rolled auth, session, or token checks in handler bodies | `#[secured]` / `#[secured("role")]`, `#[authorize]`, repository `policy =`/`scope =`; `#[secured(scopes = [...])]` for service tokens (unreleased) |
-| Hand-assembled `<form>` markup with manual value re-fill and error display | `autumn_web::form` helpers — `form_tag`, `method_input`, `text_input` (published); `number_input`, `datetime_input`, `date_input`, `checkbox_input`, `select_input` + `Changeset` 422 re-render (unreleased). A whole-form `form_for` builder is in-flight (PR #1587, unmerged — do not use) |
+| Hand-assembled `<form>` markup with manual value re-fill and error display | `autumn_web::form::form_for(&changeset, action, method)` + the `#[model]`-derived `FormModel` (unreleased — trunk-dev, not in published 0.5.0) renders the whole form — CSRF, `_method` override, one pre-filled control per column, inline errors, submit — in one call; see "Whole-form rendering" below. Compose the per-field helpers only when its escape hatches don't fit: `form_tag`, `method_input`, `text_input` (published); `number_input`, `datetime_input`, `date_input`, `checkbox_input`, `select_input` + `Changeset` 422 re-render (unreleased) |
+| `find_all()` + a loop (or raw Diesel `LIMIT`/`OFFSET` paging) to sweep a whole table in a task/job/backfill | `repo.find_in_batches(n)` / `repo.find_each(n)` (unreleased — trunk-dev) — bounded-memory primary-key keyset iteration. See "Generated repository surface" below and `docs/guide/pagination.md` |
 | Ad-hoc `tokio::spawn` / background threads for deferred work | `#[job]` (+ retries, backends, uniqueness/concurrency caps), `#[scheduled]` for recurring, `#[task]` for operator CLI work |
 | Hand-written memoization or cache-aside code | `#[cached]` on functions; `cache::get_or_compute` / `get_or_compute_with` for stampede-safe read-through fills (unreleased) |
 | Hand-written transaction retry loops for serialization failures | `Db::tx(...)`; `Db::tx_with(TxOptions::serializable(), ...)` auto-retries 40001 (unreleased) |
@@ -415,7 +416,7 @@ raw Diesel:
 | `soft_delete`, `tenant_scoped` (attrs), `across_tenants()` | Soft deletion and tenant scoping |
 | `hooks = MyHooks` (attr) | `before_/after_create/update/delete` + `after_*_commit` lifecycle hooks with `MutationContext` |
 | `from_shard(&ShardedDb)`, `with_pool_untracked(pool)` | **(unreleased)** shard-scoped construction; `with_pool_untracked` is new on trunk-dev — published 0.5.0 repositories have **no** pool constructor at all |
-| `find_in_batches(n)` / `find_each(n)` | **In flight (PR #1592, unmerged) — do not use until merged**: bounded-memory keyset iteration |
+| `find_in_batches(batch_size)`, `find_each(batch_size)` | **(unreleased)** Bounded-memory whole-table iteration via a primary-key keyset cursor (`WHERE id > last ORDER BY id ASC LIMIT batch_size` — never `LIMIT`/`OFFSET`), generated on every repository. `find_in_batches` returns a `FindInBatches` handle — drive with `while let Some(chunk) = b.next_batch().await?`; `find_each` returns `FindEach` yielding one model per `next().await?`. Inherits soft-delete filtering, tenant scoping, and read routing like `find_all`; errors are retryable (cursor advances only on success; `Ok(None)` always means completion); `batch_size == 0` errors instead of spinning; `batch_size` is **not** clamped to `MAX_PAGE_SIZE`; sharded repos reject cross-shard `across_tenants()` iteration (iterate per shard via `from_shard`). Handle types: `autumn_web::batches::{FindInBatches, FindEach, BatchSource}` (not in the prelude). See "Batched iteration" in `docs/guide/pagination.md` |
 
 Read routing: with `database.replica_url` set, all generated reads use the
 replica automatically; writes always hit the primary. See
@@ -652,6 +653,53 @@ for the common cases:
 | `modal(id, title, &body, &ModalConfig)` / `confirm_action(...)` | Native `<dialog>` confirm for destructive actions — replaces `hx-confirm`/`window.confirm()` |
 | `pagination_nav(&page, &PagerOptions::new("/posts"))` / `cursor_pagination_nav` | Accessible, filter-preserving, htmx-opt-in pager from a `Page`/`CursorPage` (prelude re-export) |
 | `autumn_web::ui::WIDGETS_CSS` / `WIDGETS_CSS_PATH` | One shipped stylesheet backing every `autumn-*` widget class — link `href=(WIDGETS_CSS_PATH)` instead of copying widget CSS into `input.css`. Accent now follows `var(--primary)` (violet), not the old hardcoded indigo (`docs/guide/widget-styling.md`) |
+
+### Whole-form rendering — `form_for` (unreleased — trunk-dev, not in published 0.5.0)
+
+`#[model]` derives `autumn_web::form::FormModel` (one `FormField` per
+`NewX`-editable column: humanized label, type-appropriate `FieldControl`,
+`required` = non-`Option`), and `form_for` renders the entire `<form>` from a
+`Changeset` in one call — opening tag with CSRF and hidden `_method` override
+(same audited path as `form_tag`), pre-filled controls with inline per-field
+errors, and a submit button. Import from `autumn_web::form` (not in the
+prelude):
+
+```rust
+use autumn_web::form::{form_for, FieldControl};
+
+// changeset: Changeset<Post> — blank for `new`, error-carrying on 422 re-render
+let markup = form_for(&changeset, "/posts", "post") // non-GET/POST method emits hidden _method
+    .csrf(&csrf_token)                              // .csrf_field_name(...) overrides "_csrf"
+    .exclude("internal_notes")
+    .override_field("status", FieldControl::Select {
+        options: vec![("draft".into(), "Draft".into()), ("published".into(), "Published".into())],
+    })                                              // last call wins per field
+    .override_label("body", "Content")
+    .submit_label("Publish")                        // default "Save"
+    .render();
+```
+
+Derived control mapping: strings/`Uuid`/unknown types → `Text` (promote enums
+via `.override_field`), integers → `Number` (step 1), floats/`Decimal` →
+`Number` (step any), `bool` → `Checkbox` (nullable `bool` → tri-state
+`Select`), `NaiveDate` → `Date`, `NaiveDateTime`/`DateTime<Utc>`/
+`DateTime<Local>` → `DateTime`, any other `DateTime` zone → `Text` (an
+offsetless `datetime-local` value is ambiguous there). Any
+`FieldControl::File` field (or `.multipart()`) makes `render()` emit
+`enctype="multipart/form-data"`.
+
+Round-trip contracts are handled by the `#[model]`-generated `NewX`: unchecked
+checkboxes decode as `false` (`#[serde(default)]` — `checkbox_input` emits no
+hidden false fallback), and `datetime-local` submissions decode via the
+`deserialize_datetime_local_utc[_option]` /
+`deserialize_datetime_local_local[_option]` /
+`deserialize_naive_datetime_local[_option]` helpers (which also still accept
+RFC 3339 JSON bodies). Serde-renamed columns pre-fill correctly via
+`FormField::value_name` (set automatically by the derive; hand-written
+`FormModel` impls use `FormField::new(...).with_value_name(...)`). Trunk-dev
+`autumn generate scaffold` views render through a single shared
+`{snake}_form_for` helper built on this (except `--live-validation`, which
+keeps per-field htmx emission).
 
 ## Configuration
 

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -114,9 +114,19 @@ Published 0.5.0: `find_by_id`, `find_all`, `count`, `exists_by_id`, `save`,
 
 **(unreleased)**: `preload(records, spec)` (declarative associations);
 `from_shard(&ShardedDb)`; `with_pool_untracked` (new on
-trunk-dev — published 0.5.0 repositories have no pool constructor).
-**In flight (PR #1592, unmerged)**:
-`find_in_batches(n)` / `find_each(n)` — do not use until merged.
+trunk-dev — published 0.5.0 repositories have no pool constructor);
+`find_in_batches(batch_size)` / `find_each(batch_size)` — bounded-memory
+whole-table iteration on every repository via a primary-key keyset cursor
+(`WHERE id > last ORDER BY id ASC LIMIT batch_size`, never `LIMIT`/`OFFSET`).
+Handle types live in `autumn_web::batches`: `FindInBatches`
+(`next_batch().await? -> Option<Vec<Model>>`), `FindEach`
+(`next().await? -> Option<Model>`), and the macro-implemented `BatchSource`
+trait. Inherits soft-delete/tenant-scoping/read-routing like `find_all`;
+errors are retryable (keyset cursor advances only on success — `Ok(None)`
+always means completion); `batch_size == 0` is an error; `batch_size` is not
+clamped to `MAX_PAGE_SIZE`; sharded repositories reject cross-shard
+`across_tenants()` iteration like `cursor_page`. See "Batched iteration" in
+`docs/guide/pagination.md`.
 
 ## Db transactions
 
@@ -140,8 +150,34 @@ Free functions rendering changeset-aware, accessible inputs:
   `form.text_input(...)`).
 - **(unreleased)**: `checkbox_input`, `number_input`, `date_input`,
   `datetime_input`, `select_input`.
-- **In flight (PR #1587, unmerged)**: `form_for` whole-form builder +
-  `FormModel` derive — do not use until merged.
+- **(unreleased — trunk-dev, not in published 0.5.0)**: `form_for(&changeset,
+  action, method) -> FormFor` whole-form builder. Renders the opening
+  `<form>` (audited CSRF injection + hidden `_method` override, as
+  `form_tag`), one pre-filled control with inline errors per
+  `FormModel::form_fields()` entry, and a submit button. `FormFor` builder
+  methods: `.csrf(token)`, `.csrf_field_name(name)` (default `"_csrf"`),
+  `.exclude(field)`, `.override_field(field, FieldControl)`,
+  `.override_label(field, label)` (repeat calls on one field: last wins),
+  `.append(markup)` (extra markup before the submit button),
+  `.submit_label(label)` (default `"Save"`), `.multipart()`, `.render()`.
+  `FormModel` (`fn form_fields() -> Vec<FormField>`) is implemented by
+  `#[model]` for the same user-editable columns as `NewX`; hand-written
+  impls build `FormField::new(name, label, control, required)` and use
+  `.with_value_name(serialized_key)` when the data type serde-renames the
+  field (the derive resolves `rename`/`rename_all` automatically —
+  `value_name` affects only value pre-fill; input `name`/`id`, error
+  lookup, and builder matching keep the Rust identifier).
+  `FieldControl` variants (`#[non_exhaustive]`): `Text`, `Textarea`,
+  `Password`, `Number { step: Option<String> }`, `Checkbox`, `Date`,
+  `DateTime`, `Select { options: Vec<(String, String)> }`, `File` (any
+  `File` field ⇒ `enctype="multipart/form-data"`).
+  Decode-side contracts handled by the `#[model]`-generated `NewX`:
+  non-nullable `bool` columns are `#[serde(default)]` (unchecked checkbox ⇒
+  `false`); datetime columns attach `deserialize_datetime_local_utc[_option]`
+  / `deserialize_datetime_local_local[_option]` /
+  `deserialize_naive_datetime_local[_option]` (offsetless `datetime-local`
+  values decode; RFC 3339 still accepted). `DateTime` columns with a zone
+  other than `Utc`/`Local` render as `Text` (RFC 3339 string), not a picker.
 
 ## View widgets and UI (all unreleased — trunk-dev only)
 

--- a/skills/generate/SKILL.md
+++ b/skills/generate/SKILL.md
@@ -85,7 +85,15 @@ by hand in the generated migration's `up.sql`. On trunk-dev, use `:unique` /
 build a `Changeset` and, on a rejected submission, respond **422** and
 re-render the form with all submitted values preserved and per-field inline
 errors — do not "fix" this by adding a redirect-to-error-page. The published
-0.5.0 scaffold returns a 400 error page instead.
+0.5.0 scaffold returns a 400 error page instead. Trunk-dev create/edit views
+(and both 422 branches) render through one shared `{snake}_form_for` helper —
+a single `autumn_web::form::form_for` call driven by the `#[model]`-derived
+`FormModel` (enum columns get a `Select` override with their variants,
+`decimal` columns pin the browser `step` to the declared scale, `references`
+columns render a `<select>` of the referenced table's ids when that model
+exists in the project, attachment columns append a file input at the end of
+the form) — adding a column needs no view edits. `--live-validation` keeps the
+per-field htmx emission instead.
 
 ## Execution flow
 


### PR DESCRIPTION
Follow-up to #1599: two of the PRs the refreshed plugin flagged as in-flight have since merged into trunk-dev, so their "do not use" flags are now stale.

## Before

- `skills/autumn-web/SKILL.md` steering table: "A whole-form `form_for` builder is in-flight (PR #1587, unmerged — do not use)"
- `skills/autumn-web/SKILL.md` repository surface table: "`find_in_batches(n)` / `find_each(n)` — **In flight (PR #1592, unmerged) — do not use until merged**"
- `skills/autumn-web/references/api-reference.md`: both features listed as "In flight … do not use until merged"

## After

Both features are documented as real, usable API, marked **(unreleased — trunk-dev, not in published 0.5.0)** per the plugin's release-marker convention, with every symbol verified against the merged source:

- **`form_for` (#1587)** — `autumn/src/form.rs`, `autumn-macros/src/model.rs`: `form_for(&changeset, action, method) -> FormFor` builder (`.csrf`, `.csrf_field_name`, `.exclude`, `.override_field`/`.override_label` last-wins, `.append`, `.submit_label`, `.multipart`, `.render`), `#[model]`-derived `FormModel`/`FormField` (incl. `value_name` serde-rename handling), `#[non_exhaustive]` `FieldControl` variants, derived control mapping, and the checkbox/`datetime-local`/serde-rename decode contracts handled by the generated `NewX`. New "Whole-form rendering" subsection in SKILL.md with an idiomatic example; steering-table forms row now points at `form_for` first. `skills/generate/SKILL.md` notes the scaffold's shared `{snake}_form_for` view helper.
- **`find_in_batches` / `find_each` (#1592)** — `autumn/src/batches.rs`, `autumn-macros/src/repository.rs`: primary-key keyset iteration (`WHERE id > last ORDER BY id ASC LIMIT batch_size`), `FindInBatches::next_batch()` / `FindEach::next()` handles, retryable errors (`Ok(None)` always means completion), `batch_size == 0` error, no `MAX_PAGE_SIZE` clamp, soft-delete/tenant-scoping/read-routing inheritance, cross-shard `across_tenants()` rejection; references the "Batched iteration" section of `docs/guide/pagination.md`. New steering-table row steers whole-table sweeps away from `find_all()` loops.

PR #1590 (quickstart gate) is still open; the plugin carries no flag for it, so nothing needed preserving.

CHANGELOG: extended the existing Unreleased plugin bullet (it explicitly said #1587/#1592 were "flagged as unmerged rather than documented as available").

## Verification

- `scripts/check-plugin-freshness.sh --self-test`: 13/13 passed
- `BASE_REF=origin/trunk-dev scripts/check-plugin-freshness.sh`: static checks pass; gate not applicable (Documentation-section changelog edit only)
- Every documented symbol grep-verified in merged source (no invented API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGhNsqpjw2ZTpKng6uao6v

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGhNsqpjw2ZTpKng6uao6v)_