### PR TITLE
docs: re-pin quickstart install to autumn-cli 0.5.0 (latest published)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ for that same "ship the app, not the plumbing" shape in Rust.
 
 ```bash
 # Install the published CLI
-cargo install autumn-cli --version 0.6.0
+cargo install autumn-cli --version 0.5.0
 
 # Local development only, from an Autumn checkout:
 # cargo install --path autumn-cli

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -27,7 +27,7 @@ internet connection.
 - **Rust 1.88.0+** with `cargo`
 - **Docker** (or Docker Desktop) — `docker --version`
 - **PostgreSQL** accessible at a connection string you control (local or remote)
-- The `autumn` CLI - `cargo install autumn-cli --version 0.6.0`
+- The `autumn` CLI - `cargo install autumn-cli --version 0.5.0`
 
 ---
 
@@ -121,7 +121,7 @@ Visit [http://localhost:3000/health](http://localhost:3000/health) — a healthy
 response looks like:
 
 ```json
-{ "status": "ok", "version": "0.6.0" }
+{ "status": "ok", "version": "0.5.0" }
 ```
 
 > **Migration failure stops the rollout.** If the primary URL is wrong or the

--- a/docs/guide/docs-smoke.md
+++ b/docs/guide/docs-smoke.md
@@ -8,7 +8,7 @@ Run it in a clean temporary directory, not inside the Autumn checkout:
 
 ```bash
 rustc --version
-cargo install autumn-cli --version 0.6.0
+cargo install autumn-cli --version 0.5.0
 
 mkdir autumn-docs-smoke
 cd autumn-docs-smoke
@@ -33,7 +33,7 @@ Passing output:
 - `/health` returns:
 
   ```json
-  { "status": "ok", "version": "0.6.0" }
+  { "status": "ok", "version": "0.5.0" }
   ```
 
 Do not add `[patch.crates-io]`, path dependencies, or `cargo install --path`
@@ -52,5 +52,5 @@ were not yet available on crates.io.
 ```
 
 That rehearsal does not certify the release. The published docs-smoke must be
-rerun with `cargo install autumn-cli --version 0.6.0` and no workspace patches
+rerun with `cargo install autumn-cli --version 0.5.0` and no workspace patches
 before announcing the release.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -39,7 +39,7 @@ Autumn ships a small CLI for project scaffolding and tooling setup. Install the
 published CLI from crates.io:
 
 ```bash
-cargo install autumn-cli --version 0.6.0
+cargo install autumn-cli --version 0.5.0
 ```
 
 For local development only, from an Autumn source checkout, install the CLI you
@@ -239,7 +239,7 @@ Probe endpoints are also available at `/live`, `/ready`, and `/startup`.
 The `/health` response looks like:
 
 ```json
-{ "status": "ok", "version": "0.6.0" }
+{ "status": "ok", "version": "0.5.0" }
 ```
 
 Press **Ctrl+C** to stop the server (graceful shutdown with a configurable
@@ -471,7 +471,7 @@ Add the required dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-autumn-web = "0.6"
+autumn-web = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
 diesel = { version = "2", features = ["postgres", "chrono"] }
 diesel-async = { version = "0.8", features = ["postgres"] }

--- a/docs/guide/tutorial/01-project-setup.md
+++ b/docs/guide/tutorial/01-project-setup.md
@@ -11,7 +11,7 @@ Before you start, make sure you have:
 
 - **Rust 1.88.0+** (edition 2024) — install from <https://rustup.rs> if you haven't already
 - **The Autumn CLI** — install the published CLI with
-  `cargo install autumn-cli --version 0.6.0`
+  `cargo install autumn-cli --version 0.5.0`
 - A terminal and a text editor
 
 Docker is not needed until Chapter 3 (Database Setup). For now, you only need
@@ -85,7 +85,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-autumn-web = "0.6"
+autumn-web = "0.5"
 ```
 
 This is a standard Rust project manifest. The only dependency is `autumn-web`

--- a/docs/guide/websockets.md
+++ b/docs/guide/websockets.md
@@ -32,7 +32,7 @@ async fn main() {
 Enable the feature in your `Cargo.toml`:
 
 ```toml
-autumn-web = { version = "0.6", features = ["ws"] }
+autumn-web = { version = "0.5", features = ["ws"] }
 ```
 
 ## The two-function pattern


### PR DESCRIPTION
## Before / After

**Before:** the README quickstart (and the guide docs mirroring it) tell new users to run `cargo install autumn-cli --version 0.6.0`. That version is not published — crates.io serves **0.5.0** as the newest release of both `autumn-cli` and `autumn-web` (verified via the crates.io API: `newest_version` = `max_stable_version` = `0.5.0` for both). The command fails for every new user, and the quickstart CI gate (#1590), which parses the pinned version straight out of README.md, goes red at its `install` step.

**After:** every user-facing install/dependency instruction points at the published 0.5.0 line, so the quickstart works verbatim for a fresh user and the gate can pass again.

## Changes (docs only)

- `cargo install autumn-cli --version 0.6.0` → `0.5.0` in:
  - `README.md` (Quickstart)
  - `docs/guide/getting-started.md`
  - `docs/guide/deployment.md` (Prerequisites)
  - `docs/guide/tutorial/01-project-setup.md`
  - `docs/guide/docs-smoke.md` (both occurrences)
- `autumn-web = "0.6"` dependency snippets → `"0.5"` in `docs/guide/getting-started.md`, `docs/guide/tutorial/01-project-setup.md`, and `docs/guide/websockets.md` — `"0.6"` resolves to `>=0.6.0, <0.7.0`, which doesn't exist on crates.io, so those snippets fail the same way.
- `/health` example outputs (`{ "status": "ok", "version": "0.6.0" }`) → `0.5.0` in `getting-started.md`, `deployment.md`, and `docs-smoke.md` — the `version` field reports the framework version, so a user on the published crates sees `0.5.0`.

## Not changed

- Workspace `Cargo.toml` versions and in-tree `autumn-web`/`autumn-macros` pins stay at 0.6.0 (per repo guidelines, versions only move on a deliberate release).
- `scripts/check-quickstart.sh` needs no change — it reads the pinned version out of README.md (`readme_cli_version()`), so it follows this fix automatically.
- `docs/release-checklist.md` already has the reminder to bump the README pin when publishing (Quickstart Gate section, "Confirm the README quickstart's pinned `cargo install autumn-cli --version` matches the version just published").
- No changelog bullet — docs-only fix.

## Notes

0.6.0 ships soon; the pin gets bumped back to 0.6.0 as part of cutting that release (the release checklist covers it). After merge, the quickest way to confirm the gate goes green is a manual `workflow_dispatch` of the Quickstart Gate workflow (Actions → Quickstart Gate → Run workflow) — the push-triggered run validates the README at this commit against the currently published crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQY4Q7KrChXzbN2SLYhv3k

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQY4Q7KrChXzbN2SLYhv3k)_