### PR TITLE
test: accept published-version doc pins in first-run hygiene check

### DIFF
--- a/autumn-cli/tests/integration/repo_hygiene.rs
+++ b/autumn-cli/tests/integration/repo_hygiene.rs
@@ -51,7 +51,11 @@ fn read_workspace_manifest(root: &Path) -> toml::Value {
 }
 
 fn semver_triple(version: &str) -> (u64, u64, u64) {
-    let mut parts = version.splitn(3, '.').map(|part| {
+    // Ignore any pre-release/build-metadata suffix (e.g. `0.6.0-beta.1`).
+    let core = version
+        .split_once(['-', '+'])
+        .map_or(version, |(core, _)| core);
+    let mut parts = core.splitn(3, '.').map(|part| {
         part.parse::<u64>().unwrap_or_else(|err| {
             panic!("version component `{part}` of `{version}` should be numeric: {err}")
         })

--- a/autumn-cli/tests/integration/repo_hygiene.rs
+++ b/autumn-cli/tests/integration/repo_hygiene.rs
@@ -50,6 +50,40 @@ fn read_workspace_manifest(root: &Path) -> toml::Value {
     toml::from_str(&root_manifest).expect("workspace Cargo.toml should parse as TOML")
 }
 
+fn semver_triple(version: &str) -> (u64, u64, u64) {
+    let mut parts = version.splitn(3, '.').map(|part| {
+        part.parse::<u64>().unwrap_or_else(|err| {
+            panic!("version component `{part}` of `{version}` should be numeric: {err}")
+        })
+    });
+    let mut next = |name: &str| {
+        parts
+            .next()
+            .unwrap_or_else(|| panic!("version `{version}` should have a {name} component"))
+    };
+    (next("major"), next("minor"), next("patch"))
+}
+
+/// The CLI version the README quickstart pins, e.g. `0.5.0` out of
+/// `cargo install autumn-cli --version 0.5.0`. The README is the source of
+/// truth for what new users install (scripts/check-quickstart.sh parses the
+/// same line), and it tracks the latest *published* release, which can lag
+/// the workspace version between a version bump and the crates.io publish.
+fn readme_pinned_cli_version(docs: &[(&'static str, String)]) -> String {
+    let readme = docs
+        .iter()
+        .find(|(doc, _)| *doc == "README.md")
+        .map(|(_, content)| content)
+        .expect("README.md should be included in FIRST_RUN_DOCS");
+    let pinned = readme
+        .split("cargo install autumn-cli --version ")
+        .nth(1)
+        .and_then(|rest| rest.split(|c: char| c.is_whitespace() || c == '`').next())
+        .filter(|version| !version.is_empty())
+        .expect("README.md must pin `cargo install autumn-cli --version X.Y.Z` in the quickstart");
+    pinned.to_owned()
+}
+
 fn read_docs_once(root: &Path) -> Vec<(&'static str, String)> {
     FIRST_RUN_DOCS
         .iter()
@@ -144,13 +178,23 @@ fn workspace_test_profile_keeps_ci_artifacts_bounded() {
 fn first_run_docs_match_current_release_line() {
     let root = workspace_root();
     let root_toml = read_workspace_manifest(&root);
-    let current_version = workspace_package_value(&root_toml, "version");
-    let current_series = current_version
-        .rsplit_once('.')
-        .map_or(current_version.as_str(), |(series, _)| series);
+    let workspace_version = workspace_package_value(&root_toml, "version");
     let rust_version = workspace_package_value(&root_toml, "rust-version");
-    let current_health_json = format!(r#"{{ "status": "ok", "version": "{current_version}" }}"#);
     let docs = read_docs_once(&root);
+
+    // Docs pin the latest *published* CLI release (README is the source of
+    // truth), which may lag the workspace version between a version bump and
+    // the crates.io publish — but must never run ahead of it.
+    let pinned_version = readme_pinned_cli_version(&docs);
+    assert!(
+        semver_triple(&pinned_version) <= semver_triple(&workspace_version),
+        "README.md pins autumn-cli {pinned_version}, which is newer than the workspace \
+         version {workspace_version}; docs must pin a published release",
+    );
+    let pinned_series = pinned_version
+        .rsplit_once('.')
+        .map_or(pinned_version.as_str(), |(series, _)| series);
+    let pinned_health_json = format!(r#"{{ "status": "ok", "version": "{pinned_version}" }}"#);
 
     for (doc, content) in &docs {
         for stale in [
@@ -190,26 +234,26 @@ fn first_run_docs_match_current_release_line() {
         if content.contains("cargo install autumn-cli") {
             assert!(
                 content.contains(&format!(
-                    "cargo install autumn-cli --version {current_version}"
+                    "cargo install autumn-cli --version {pinned_version}"
                 )),
-                "{doc} must show the published CLI install command for autumn-cli {current_version}"
+                "{doc} must show the published CLI install command for autumn-cli {pinned_version} (the version pinned in README.md)"
             );
         }
 
         if content.contains("autumn-web =") {
             assert!(
-                content.contains(&format!("autumn-web = \"{current_series}\""))
-                    || content.contains(&format!("autumn-web = \"{current_version}\""))
-                    || content.contains(&format!("version = \"{current_series}\""))
-                    || content.contains(&format!("version = \"{current_version}\"")),
-                "{doc} must show the current autumn-web release line ({current_series} or {current_version})",
+                content.contains(&format!("autumn-web = \"{pinned_series}\""))
+                    || content.contains(&format!("autumn-web = \"{pinned_version}\""))
+                    || content.contains(&format!("version = \"{pinned_series}\""))
+                    || content.contains(&format!("version = \"{pinned_version}\"")),
+                "{doc} must show the published autumn-web release line ({pinned_series} or {pinned_version})",
             );
         }
 
         if content.contains(r#""status": "ok""#) {
             assert!(
-                content.contains(&current_health_json),
-                "{doc} must show the current JSON health version {current_version}"
+                content.contains(&pinned_health_json),
+                "{doc} must show the published JSON health version {pinned_version}"
             );
         }
     }
@@ -224,8 +268,8 @@ fn first_run_docs_match_current_release_line() {
         "docs-smoke must expect the root page generated by `autumn new smoke-app`"
     );
     assert!(
-        docs_smoke.contains(&current_health_json),
-        "docs-smoke must show the exact health JSON with version {current_version}"
+        docs_smoke.contains(&pinned_health_json),
+        "docs-smoke must show the exact health JSON with version {pinned_version}"
     );
 }
 


### PR DESCRIPTION
## Before / After

**Before:** every PR's Test (macos/ubuntu/windows) jobs fail on trunk-dev. #1622 deliberately re-pinned the quickstart docs to the latest *published* release — `cargo install autumn-cli --version 0.5.0`, `autumn-web = "0.5"` snippets, and `"version": "0.5.0"` health JSON — because workspace 0.6.0 is not on crates.io yet. But the hygiene test `first_run_docs_match_current_release_line` (autumn-cli/tests/integration/repo_hygiene.rs) still asserts the docs pin exactly the workspace version (0.6.0), so it now fails deterministically on trunk-dev and on every PR merge ref (currently blocking #1626's Test jobs).

**After:** the test encodes #1622's intent — docs pin the latest published release line, which may lag the workspace version between a version bump and the crates.io publish. It derives the pinned version from README.md (the same source of truth `scripts/check-quickstart.sh` parses with `readme_cli_version()`), then asserts:

- the pinned version is a well-formed `X.Y.Z` that is **no newer than** the workspace version (docs must never pin an unpublished future version), and
- all first-run docs agree with that one pinned version — the `cargo install autumn-cli --version` command, the `autumn-web` dependency snippets, and the `/health` JSON examples (including the exact docs-smoke health JSON).

When 0.6.0 ships and the release checklist bumps the README pin back up, the test follows automatically — no test change needed at release time.

## Changes (test only)

- `autumn-cli/tests/integration/repo_hygiene.rs`: `first_run_docs_match_current_release_line` compares docs against the README-pinned published version instead of the workspace version, plus two small helpers (`readme_pinned_cli_version`, `semver_triple`). No docs, workspace versions, or other tests touched. No changelog bullet — test-only fix (same convention as #1622's docs-only fix).

## Verification

- `cargo test -p autumn-cli --test cli_tests repo_hygiene` — 25 passed, 0 failed (including `first_run_docs_match_current_release_line`).
- `cargo fmt --all` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.

Refs #1622; unblocks #1626.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017v8vpD8Q9QofYSBZ3vjj75

---
_Generated by [Claude Code](https://claude.ai/code/session_017v8vpD8Q9QofYSBZ3vjj75)_