### PR TITLE
fix: align repo-hygiene install-pin test with published-version README pin

### DIFF
--- a/autumn-cli/tests/integration/repo_hygiene.rs
+++ b/autumn-cli/tests/integration/repo_hygiene.rs
@@ -50,6 +50,41 @@ fn read_workspace_manifest(root: &Path) -> toml::Value {
     toml::from_str(&root_manifest).expect("workspace Cargo.toml should parse as TOML")
 }
 
+fn parse_semver_triple(version: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = version.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((major, minor, patch))
+}
+
+/// The version the first-run docs pin is the latest *published* autumn-cli
+/// release, which can lag the (unreleased) workspace version between releases
+/// (PR #1622). The README quickstart is the source of truth for that pin —
+/// the same convention `scripts/check-quickstart.sh` uses — so parse it from
+/// there and hold every other first-run doc to it.
+fn published_cli_version(readme: &str) -> String {
+    readme
+        .lines()
+        .find_map(|line| {
+            line.trim()
+                .strip_prefix("cargo install autumn-cli --version ")
+        })
+        .and_then(|rest| rest.split_whitespace().next())
+        .map_or_else(
+            || {
+                panic!(
+                    "README.md must pin the published CLI install command \
+                     `cargo install autumn-cli --version <x.y.z>`"
+                )
+            },
+            str::to_owned,
+        )
+}
+
 fn read_docs_once(root: &Path) -> Vec<(&'static str, String)> {
     FIRST_RUN_DOCS
         .iter()
@@ -144,13 +179,39 @@ fn workspace_test_profile_keeps_ci_artifacts_bounded() {
 fn first_run_docs_match_current_release_line() {
     let root = workspace_root();
     let root_toml = read_workspace_manifest(&root);
-    let current_version = workspace_package_value(&root_toml, "version");
-    let current_series = current_version
-        .rsplit_once('.')
-        .map_or(current_version.as_str(), |(series, _)| series);
+    let workspace_version = workspace_package_value(&root_toml, "version");
     let rust_version = workspace_package_value(&root_toml, "rust-version");
-    let current_health_json = format!(r#"{{ "status": "ok", "version": "{current_version}" }}"#);
     let docs = read_docs_once(&root);
+
+    // The first-run docs pin the latest *published* release, parsed from the
+    // README quickstart. Validate the pin so this test still catches a
+    // malformed or future-dated pin: it must be a plain x.y.z semver and must
+    // not be newer than the (possibly unreleased) workspace version.
+    let readme = docs
+        .iter()
+        .find(|(doc, _)| *doc == "README.md")
+        .map(|(_, content)| content)
+        .expect("README.md should be included in FIRST_RUN_DOCS");
+    let published_version = published_cli_version(readme);
+    let published_triple = parse_semver_triple(&published_version).unwrap_or_else(|| {
+        panic!(
+            "README.md pins a malformed autumn-cli version `{published_version}`; expected x.y.z"
+        )
+    });
+    let workspace_triple = parse_semver_triple(&workspace_version).unwrap_or_else(|| {
+        panic!("workspace.package.version `{workspace_version}` should be x.y.z")
+    });
+    assert!(
+        published_triple <= workspace_triple,
+        "README.md pins autumn-cli {published_version}, which is newer than the workspace \
+         version {workspace_version}; the quickstart must pin the latest published release",
+    );
+
+    let published_series = published_version
+        .rsplit_once('.')
+        .map_or(published_version.as_str(), |(series, _)| series);
+    let published_health_json =
+        format!(r#"{{ "status": "ok", "version": "{published_version}" }}"#);
 
     for (doc, content) in &docs {
         for stale in [
@@ -190,26 +251,26 @@ fn first_run_docs_match_current_release_line() {
         if content.contains("cargo install autumn-cli") {
             assert!(
                 content.contains(&format!(
-                    "cargo install autumn-cli --version {current_version}"
+                    "cargo install autumn-cli --version {published_version}"
                 )),
-                "{doc} must show the published CLI install command for autumn-cli {current_version}"
+                "{doc} must show the published CLI install command for autumn-cli {published_version}"
             );
         }
 
         if content.contains("autumn-web =") {
             assert!(
-                content.contains(&format!("autumn-web = \"{current_series}\""))
-                    || content.contains(&format!("autumn-web = \"{current_version}\""))
-                    || content.contains(&format!("version = \"{current_series}\""))
-                    || content.contains(&format!("version = \"{current_version}\"")),
-                "{doc} must show the current autumn-web release line ({current_series} or {current_version})",
+                content.contains(&format!("autumn-web = \"{published_series}\""))
+                    || content.contains(&format!("autumn-web = \"{published_version}\""))
+                    || content.contains(&format!("version = \"{published_series}\""))
+                    || content.contains(&format!("version = \"{published_version}\"")),
+                "{doc} must show the published autumn-web release line ({published_series} or {published_version})",
             );
         }
 
         if content.contains(r#""status": "ok""#) {
             assert!(
-                content.contains(&current_health_json),
-                "{doc} must show the current JSON health version {current_version}"
+                content.contains(&published_health_json),
+                "{doc} must show the published JSON health version {published_version}"
             );
         }
     }
@@ -224,9 +285,23 @@ fn first_run_docs_match_current_release_line() {
         "docs-smoke must expect the root page generated by `autumn new smoke-app`"
     );
     assert!(
-        docs_smoke.contains(&current_health_json),
-        "docs-smoke must show the exact health JSON with version {current_version}"
+        docs_smoke.contains(&published_health_json),
+        "docs-smoke must show the exact health JSON with version {published_version}"
     );
+}
+
+#[test]
+fn published_cli_version_parses_readme_quickstart_pin() {
+    let readme = "## Quickstart\n\n```bash\n# Install the published CLI\ncargo install autumn-cli --version 0.5.0\n```\n";
+    assert_eq!(published_cli_version(readme), "0.5.0");
+}
+
+#[test]
+fn semver_triple_parser_rejects_malformed_pins() {
+    assert_eq!(parse_semver_triple("0.5.0"), Some((0, 5, 0)));
+    assert_eq!(parse_semver_triple("0.5"), None);
+    assert_eq!(parse_semver_triple("0.5.0.1"), None);
+    assert_eq!(parse_semver_triple("0.5.x"), None);
 }
 
 #[test]


### PR DESCRIPTION
## Problem

trunk-dev has been left inconsistent by #1622: it deliberately re-pinned the first-run docs to the latest **published** release (`cargo install autumn-cli --version 0.5.0`, `autumn-web = "0.5"`, health JSON `"version": "0.5.0"`) while the workspace version stayed at the unreleased 0.6.0. The hygiene test `integration::repo_hygiene::first_run_docs_match_current_release_line` still asserted those docs match the **workspace** version, so it fails on every merge ref against trunk-dev.

## Before

Every PR's Test jobs fail with:

```
README.md must show the published CLI install command for autumn-cli 0.6.0
```

(and, once past that assertion, the same test's autumn-web-series and health-JSON checks would fail next for the same published-vs-workspace divergence — #1622 changed all three surfaces).

## After

The test accepts a published-version pin that may lag the workspace version:

- The published version is parsed from the README quickstart's `cargo install autumn-cli --version <x.y.z>` line — the same source of truth `scripts/check-quickstart.sh` already uses.
- The pin is validated: it must exist, be a well-formed `x.y.z` semver, and be **≤ the workspace version** (a missing, malformed, or future-dated pin still fails the test).
- All first-run-doc release-line checks (install pin, `autumn-web` series, health JSON, docs-smoke health JSON) are held to that published version, so cross-doc drift is still caught.
- Small unit tests added for the two new helpers, matching the file's existing style.

```
test integration::repo_hygiene::first_run_docs_match_current_release_line ... ok
```

No README or version changes (per CLAUDE.md, no version bumps). `cargo fmt` and `cargo clippy -p autumn-cli --all-targets -- -D warnings` are clean.

## Impact

Unblocks CI Test jobs for **all open PRs** targeting trunk-dev, including #1585.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNcGm5CPEhi5AjjCS7QH5s

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNcGm5CPEhi5AjjCS7QH5s)_