### PR TITLE
fix(cli): stop generator main.rs edits from matching inside comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -548,8 +548,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **cli:** the generators' `main.rs` editing no longer matches inside
   comments (supersedes #1516): route-registration edits skip `routes![`
-  occurrences on `//`/`///`/`//!` comment lines instead of injecting route
-  entries into the comment text, and the PWA generator inserts its handlers
+  occurrences on `//`/`///`/`//!` comment lines (a `//` inside a string
+  literal on the line — e.g. a `https://` URL — is code, not a comment
+  marker) instead of injecting route entries into the comment text, and
+  the PWA generator inserts its handlers
   before the line that is exactly `#[autumn_web::main]` rather than before
   any comment that merely mentions the macro — both used to produce
   uncompilable `main.rs` output when such comments were present.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -544,6 +544,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   previously gitignored) so builds are reproducible and dependency updates
   are reviewable.
 
+### Fixed
+
+- **cli:** the generators' `main.rs` editing no longer matches inside
+  comments (supersedes #1516): route-registration edits skip `routes![`
+  occurrences on `//`/`///`/`//!` comment lines instead of injecting route
+  entries into the comment text, and the PWA generator inserts its handlers
+  before the line that is exactly `#[autumn_web::main]` rather than before
+  any comment that merely mentions the macro — both used to produce
+  uncompilable `main.rs` output when such comments were present.
+
 ## [0.6.0] - 2026-06-30
 
 ### Added

--- a/autumn-cli/src/generate/pwa.rs
+++ b/autumn-cli/src/generate/pwa.rs
@@ -594,8 +594,11 @@ fn inject_pwa_handlers(source: &str) -> String {
         return source.to_owned();
     }
 
-    // Insert before `#[autumn_web::main]`, or append at end as fallback.
-    source.find("#[autumn_web::main]").map_or_else(
+    // Insert before the line that is exactly `#[autumn_web::main]` — a naive
+    // substring search would also match the text inside a comment that merely
+    // mentions the macro (e.g. `// routes are wired under #[autumn_web::main]`)
+    // and slice the file mid-comment. Appends at end as fallback.
+    find_main_attr_line_start(source).map_or_else(
         || {
             let mut result = source.to_owned();
             if !result.ends_with('\n') {
@@ -613,6 +616,21 @@ fn inject_pwa_handlers(source: &str) -> String {
             result
         },
     )
+}
+
+/// Byte offset of the start of the first line whose entire content (modulo
+/// surrounding whitespace) is `#[autumn_web::main]`, or `None` when no such
+/// line exists. Line-exact matching prevents false positives on comments
+/// that mention the attribute.
+fn find_main_attr_line_start(source: &str) -> Option<usize> {
+    let mut offset = 0;
+    for line in source.split_inclusive('\n') {
+        if line.trim() == "#[autumn_web::main]" {
+            return Some(offset);
+        }
+        offset += line.len();
+    }
+    None
 }
 
 fn indent_count(line: &str) -> usize {
@@ -1153,6 +1171,53 @@ async fn main() {
         assert!(
             handler_pos < main_pos,
             "PWA handlers must appear before #[autumn_web::main]"
+        );
+    }
+
+    #[test]
+    fn inject_handlers_ignores_main_attr_mentioned_in_comment() {
+        // A comment that merely mentions `#[autumn_web::main]` must not be
+        // treated as the insertion point — the naive substring search used to
+        // slice the file mid-comment, leaving the handlers inside the comment
+        // text and the file uncompilable.
+        let source = "\
+use autumn_web::prelude::*;
+
+// Route handlers are registered under #[autumn_web::main] via routes![].
+fn helper() {}
+
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app().routes(routes![]).run().await;
+}
+";
+        let updated = inject_pwa_handlers(source);
+        assert!(
+            updated.contains(
+                "// Route handlers are registered under #[autumn_web::main] via routes![]."
+            ),
+            "comment must be untouched: {updated}"
+        );
+        let handler_pos = updated.find("async fn pwa_manifest()").unwrap();
+        let helper_pos = updated.find("fn helper()").unwrap();
+        let real_main_pos = updated.find("\n#[autumn_web::main]\n").unwrap();
+        assert!(
+            helper_pos < handler_pos && handler_pos < real_main_pos,
+            "handlers must be inserted immediately before the real attribute line: {updated}"
+        );
+    }
+
+    #[test]
+    fn inject_handlers_appends_when_only_comment_mentions_main_attr() {
+        let source = "// see #[autumn_web::main]\nfn main() {}\n";
+        let updated = inject_pwa_handlers(source);
+        assert!(
+            updated.starts_with("// see #[autumn_web::main]\nfn main() {}\n"),
+            "original source must be untouched: {updated}"
+        );
+        assert!(
+            updated.ends_with(PWA_HANDLERS_BLOCK),
+            "handlers must be appended at end as fallback: {updated}"
         );
     }
 

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -939,13 +939,31 @@ pub fn remove_main_mod_declarations(existing: &str, names: &[&str]) -> String {
     out
 }
 
+/// Whether the byte offset `pos` in `text` sits after a `//` on its own line —
+/// i.e. the match at `pos` lives inside a line comment (`//`, `///`, or `//!`).
+/// Used to skip `routes![` occurrences that appear in comments (e.g. a doc
+/// comment explaining the macro) rather than in real code.
+fn is_on_comment_line(text: &str, pos: usize) -> bool {
+    let line_start = text[..pos].rfind('\n').map_or(0, |nl| nl + 1);
+    text[line_start..pos].contains("//")
+}
+
 /// Locate the body span (byte offsets, exclusive of the enclosing
 /// `routes![`/`]`) of the *first* `routes![ ... ]` macro invocation in
-/// `existing`. Returns `None` if there is no `routes![` or its brackets are
-/// unmatched. Shared by every function that reads or rewrites the
+/// `existing`, skipping occurrences on comment lines (a doc comment such as
+/// `//! routes![...]` must not be edited — injecting entries there breaks
+/// compilation). Returns `None` if there is no non-comment `routes![` or its
+/// brackets are unmatched. Shared by every function that reads or rewrites the
 /// `routes![...]` body so the bracket-scan logic lives in exactly one place.
 fn find_routes_body_range(existing: &str) -> Option<(usize, usize)> {
-    let start = existing.find("routes![")?;
+    let mut search_from = 0;
+    let start = loop {
+        let pos = search_from + existing[search_from..].find("routes![")?;
+        if !is_on_comment_line(existing, pos) {
+            break pos;
+        }
+        search_from = pos + "routes![".len();
+    };
     let body_start = start + "routes![".len();
     // Find the matching closing bracket. The macro body cannot contain a
     // raw `]` outside of nested `[ ... ]`, so we just track depth.
@@ -5003,6 +5021,66 @@ async fn main() {\n\
         let original = "fn main() {\n    routes![]\n}\n";
         let updated = ensure_routes_entries(original, &["foo".into()]);
         assert!(updated.contains("foo"));
+    }
+
+    #[test]
+    fn ensure_routes_entries_skips_routes_macro_in_comments() {
+        // A doc comment mentioning `routes![]` must not receive the injected
+        // entries — that used to break compilation by editing the comment.
+        let original = "\
+//! Register handlers with `.routes(routes![])` in main.
+// e.g. routes![index]
+fn main() {
+    routes![]
+}
+";
+        let updated = ensure_routes_entries(original, &["foo".into()]);
+        assert!(
+            updated.contains("//! Register handlers with `.routes(routes![])` in main."),
+            "doc comment must be untouched: {updated}"
+        );
+        assert!(
+            updated.contains("// e.g. routes![index]"),
+            "line comment must be untouched: {updated}"
+        );
+        assert!(
+            updated.contains("foo,"),
+            "entry must land in the real macro: {updated}"
+        );
+        assert!(
+            updated.rfind("foo,").unwrap() > updated.find("fn main()").unwrap(),
+            "entry must be inside the macro in fn main, not in the comments: {updated}"
+        );
+    }
+
+    #[test]
+    fn ensure_routes_entries_only_comment_matches_is_noop() {
+        let original = "//! Add handlers via routes![].\nfn main() {}\n";
+        let updated = ensure_routes_entries(original, &["foo".into()]);
+        assert_eq!(updated, original);
+    }
+
+    #[test]
+    fn remove_routes_entries_with_prefix_skips_commented_macro() {
+        let original = "\
+// routes![channels::chat::chat_page]
+fn main() {
+    routes![
+        channels::chat::chat_page,
+        index,
+    ]
+}
+";
+        let updated = remove_routes_entries_with_prefix(original, "channels::chat::");
+        assert!(
+            updated.contains("// routes![channels::chat::chat_page]"),
+            "comment must be untouched: {updated}"
+        );
+        assert!(updated.contains("index,"));
+        assert!(
+            !updated.contains("routes![\n        channels::chat::chat_page"),
+            "real entry must be removed: {updated}"
+        );
     }
 
     // ── remove_routes_entries_with_prefix ──────────────────────────────────

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -943,9 +943,29 @@ pub fn remove_main_mod_declarations(existing: &str, names: &[&str]) -> String {
 /// i.e. the match at `pos` lives inside a line comment (`//`, `///`, or `//!`).
 /// Used to skip `routes![` occurrences that appear in comments (e.g. a doc
 /// comment explaining the macro) rather than in real code.
+///
+/// A `//` inside a double-quoted string literal is content, not a comment
+/// marker — e.g. the URL in
+/// `let url = "https://example.com"; app.routes(routes![index])` must not
+/// make the line look commented out. This stays a line-local heuristic: it
+/// tracks `"…"` state with `\`-escape handling but does not understand raw
+/// strings (`r#"…"#`), char literals containing `"`, or block comments.
 fn is_on_comment_line(text: &str, pos: usize) -> bool {
     let line_start = text[..pos].rfind('\n').map_or(0, |nl| nl + 1);
-    text[line_start..pos].contains("//")
+    let mut in_string = false;
+    let mut chars = text[line_start..pos].chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' if in_string => {
+                // Skip the escaped character so `\"` doesn't end the string.
+                chars.next();
+            }
+            '"' => in_string = !in_string,
+            '/' if !in_string && chars.peek() == Some(&'/') => return true,
+            _ => {}
+        }
+    }
+    false
 }
 
 /// Locate the body span (byte offsets, exclusive of the enclosing
@@ -5058,6 +5078,57 @@ fn main() {
         let original = "//! Add handlers via routes![].\nfn main() {}\n";
         let updated = ensure_routes_entries(original, &["foo".into()]);
         assert_eq!(updated, original);
+    }
+
+    #[test]
+    fn ensure_routes_entries_url_in_string_before_macro_is_code() {
+        // The `//` in the URL string literal is content, not a comment
+        // marker — the `routes![` on the same line is real code and must
+        // receive the injected entry.
+        let original =
+            "fn main() {\n    let url = \"https://example.com\"; app.routes(routes![index]);\n}\n";
+        let updated = ensure_routes_entries(original, &["foo".into()]);
+        assert!(
+            updated.contains("foo"),
+            "routes![ after a URL string must be edited as code: {updated}"
+        );
+        assert!(
+            updated.contains("\"https://example.com\""),
+            "the string literal must be untouched: {updated}"
+        );
+    }
+
+    #[test]
+    fn ensure_routes_entries_genuinely_commented_macro_still_skipped() {
+        // A real line comment before `routes![` must still be skipped, even
+        // when the comment itself contains quotes.
+        let original = "\
+// see \"docs\": routes![index]
+fn main() {
+    routes![]
+}
+";
+        let updated = ensure_routes_entries(original, &["foo".into()]);
+        assert!(
+            updated.contains("// see \"docs\": routes![index]"),
+            "comment must be untouched: {updated}"
+        );
+        assert!(
+            updated.rfind("foo").unwrap() > updated.find("fn main()").unwrap(),
+            "entry must land in the real macro, not the comment: {updated}"
+        );
+    }
+
+    #[test]
+    fn ensure_routes_entries_slashes_in_string_with_macro_on_line() {
+        // A string literal containing `//` followed by a real macro use on
+        // the same line: the escaped quote must not flip the string state.
+        let original = "fn main() {\n    let s = \"say \\\"// not a comment\\\"\"; app.routes(routes![index]);\n}\n";
+        let updated = ensure_routes_entries(original, &["foo".into()]);
+        assert!(
+            updated.contains("foo"),
+            "escaped quotes in a string must not hide the real macro: {updated}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Ports the two CLI-generator injection fixes from #1516 onto current `trunk-dev`. Supersedes #1516's generator fixes (that PR is stale/conflicted and being closed; its PWA scaffolding changes are not included here).

## Fix 1: route registration injected into comments

**Before:** when `main.rs` contained a comment mentioning the routes macro (e.g. a doc comment like `//! Register handlers with .routes(routes[]) in main.`), the generator's route-registration edit matched the `routes[` inside the comment and injected new route entries into the comment text — producing a `main.rs` that no longer compiled.

**After:** the shared `routes[ ... ]` locator (`find_routes_body_range` in `autumn-cli/src/generate/schema_edit.rs`) skips occurrences on `//` / `///` / `//!` comment lines and edits the first real macro invocation. Comments are left untouched. Because the guard lives in the shared locator, `ensure_routes_entries`, `remove_routes_entries`, and `remove_routes_entries_with_prefix` all benefit.

## Fix 2: PWA handlers spliced into a comment mentioning `#[autumn_web::main]`

**Before:** `autumn generate pwa` inserted its handler block before the first *substring* occurrence of `#[autumn_web::main]`. If a comment merely mentioned the attribute (e.g. `// Route handlers are registered under #[autumn_web::main] via routes[]`), the file was sliced mid-comment and the generated handler functions landed inside the comment line — again breaking compilation.

**After:** `inject_pwa_handlers` (`autumn-cli/src/generate/pwa.rs`) inserts before the first line whose entire content is exactly `#[autumn_web::main]`; when no such line exists it appends at end of file as before. The splice happens at the line's byte offset, so the rest of the file stays byte-identical and `autumn destroy pwa`'s exact-block removal keeps working.

## How

The original patch in #1516 no longer applies: `ensure_routes_entries`'s bracket-scanning has since been refactored into the shared `find_routes_body_range` helper. Both fixes were therefore ported by intent onto the refactored code rather than cherry-picked — the comment-line guard now lives in the shared locator, and the `#[autumn_web::main]` search uses a line-exact byte-offset match instead of the old PR's join/split rewrite. Unit tests added next to the existing inline test suites in both files; CHANGELOG updated under `[Unreleased]` &gt; `Fixed`.

Verified: `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test -p autumn-cli` fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4pc9qsMGH9QaxcCw5XAHi

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4pc9qsMGH9QaxcCw5XAHi)_