### PR TITLE
feat(cli): autumn generate controller for handler-only, non-CRUD routes

### DIFF
--- a/.github/workflows/generator-conformance.yml
+++ b/.github/workflows/generator-conformance.yml
@@ -69,6 +69,8 @@ jobs:
   #   generated_project_compiles_runs_and_serves  (e2e.rs)
   #   generated_scaffold_cargo_checks             (generate.rs)
   #   generated_scaffold_config_cargo_checks      (generate.rs)
+  #   controller_generates_compiles_and_lists_routes (generate.rs)
+  #   controller_api_generates_json               (generate.rs)
   #   generated_auth_totp_cargo_checks            (generate.rs)
   #   generated_job_cargo_checks                  (generate.rs)
   #   generated_channel_cargo_checks              (generate.rs)
@@ -115,6 +117,16 @@ jobs:
         run: |
           cargo test -p autumn-cli --test generate \
             generated_scaffold_config_cargo_checks -- --ignored --exact
+
+      - name: controller_generates_compiles_and_lists_routes
+        run: |
+          cargo test -p autumn-cli --test generate \
+            controller_generates_compiles_and_lists_routes -- --ignored --exact
+
+      - name: controller_api_generates_json
+        run: |
+          cargo test -p autumn-cli --test generate \
+            controller_api_generates_json -- --ignored --exact
 
       - name: Pre-fetch TOTP deps (absent from workspace Cargo.lock)
         # totp-rs is not a workspace dep, so it is absent from the workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **generator:** `autumn generate controller <name> <action>...` scaffolds a handler-only module (named actions, wired routes, Maud stub views) for non-CRUD pages/endpoints — no model, migration, or DB; `--api` emits JSON actions. (issue #1050)
 - **ci:** README-quickstart gate against the published crates (issue #1586) —
   `.github/workflows/quickstart-gate.yml` + `scripts/check-quickstart.sh`
   install the README-pinned `autumn-cli` from crates.io (never the local

--- a/autumn-cli/src/generate/controller.rs
+++ b/autumn-cli/src/generate/controller.rs
@@ -31,7 +31,7 @@ use std::path::Path;
 
 use super::emit::{Plan, Revert};
 use super::naming::{humanize_label, snake};
-use super::schema_edit::{add_mod_declaration, update_main_rs};
+use super::schema_edit::{add_mod_declaration, remove_routes_entries_with_prefix, update_main_rs};
 use super::{GenerateError, ensure_project_root, read_or_empty};
 
 /// HTTP methods a controller action may bind to.
@@ -298,9 +298,19 @@ pub fn plan_controller(
             entries.join(", ")
         ));
     }
+    // On a `--force` regeneration with a changed action set, the overwritten
+    // handler file no longer defines the old actions, so any stale
+    // `routes::<controller>::*` entries left in `routes![...]` would reference
+    // functions that no longer exist and break compilation. Strip every
+    // existing entry for THIS controller first, then add the fresh set. A
+    // no-op on first generation (nothing matches the prefix), and scoped to
+    // this controller's `routes::<snake>::` prefix so other controllers' and
+    // unrelated routes are untouched.
+    let pruned =
+        remove_routes_entries_with_prefix(&main_existing, &format!("routes::{controller}::"));
     plan.modify(
         main_path.clone(),
-        update_main_rs(&main_existing, &["routes"], &entries),
+        update_main_rs(&pruned, &["routes"], &entries),
     );
     plan.push_revert(Revert::RoutesEntries {
         path: main_path,
@@ -492,5 +502,46 @@ mod tests {
         run(&tmp, "pages", &["layout"], true, false).unwrap();
         let file = fs::read_to_string(tmp.path().join("src/routes/pages.rs")).unwrap();
         assert!(file.contains("pub async fn layout"), "{file}");
+    }
+
+    #[test]
+    fn force_regeneration_prunes_stale_route_entries() {
+        let tmp = project_with_main();
+        // Seed an unrelated controller's entry so we can prove it survives the
+        // prune-and-rewrite of `pages`.
+        let main_path = tmp.path().join("src/main.rs");
+        let seeded = fs::read_to_string(&main_path)
+            .unwrap()
+            .replace("routes![index]", "routes![index, routes::other::index]");
+        fs::write(&main_path, seeded).unwrap();
+
+        run(&tmp, "pages", &["home", "about"], false, false).unwrap();
+        let after_first = fs::read_to_string(&main_path).unwrap();
+        assert!(after_first.contains("routes::pages::home"), "{after_first}");
+        assert!(
+            after_first.contains("routes::pages::about"),
+            "{after_first}"
+        );
+
+        // Regenerate with a changed action set (`about` dropped, `contact`
+        // added) using --force.
+        run(&tmp, "pages", &["home", "contact"], false, true).unwrap();
+        let after_force = fs::read_to_string(&main_path).unwrap();
+        assert!(after_force.contains("routes::pages::home"), "{after_force}");
+        assert!(
+            after_force.contains("routes::pages::contact"),
+            "{after_force}"
+        );
+        // The stale entry for the now-removed `about` action must be gone.
+        assert!(
+            !after_force.contains("routes::pages::about"),
+            "stale routes::pages::about should have been pruned:\n{after_force}"
+        );
+        // Unrelated entries must be untouched.
+        assert!(
+            after_force.contains("routes::other::index"),
+            "unrelated route entry must survive:\n{after_force}"
+        );
+        assert!(after_force.contains("index"), "{after_force}");
     }
 }

--- a/autumn-cli/src/generate/controller.rs
+++ b/autumn-cli/src/generate/controller.rs
@@ -1,0 +1,496 @@
+//! `autumn generate controller` — handler-only, non-CRUD route modules.
+//!
+//! Unlike [`scaffold`](super::scaffold), which emits a full model + migration +
+//! repository + CRUD routes, this generator emits *only* a route module: one
+//! handler function per named action, wired into `routes![...]` and registered
+//! in `src/routes/mod.rs`. No model, no migration, no database, no schema
+//! changes, no `Cargo.toml` changes — the generated code compiles and serves
+//! immediately.
+//!
+//! # Path rule
+//!
+//! Each action maps to `/<controller>/<action>`, except an action literally
+//! named `index`, which maps to `/<controller>` (the collection root). Under
+//! `--api` the prefix becomes `/api/<controller>[/<action>]`.
+//!
+//! # Method rule
+//!
+//! Actions default to `GET`. Request another method with `action:method`, where
+//! `method` is one of `get`, `post`, `put`, `patch`, `delete`.
+//!
+//! # Modes
+//!
+//! - HTML (default): each action returns a Maud [`Markup`](maud::Markup) stub
+//!   rendered through a local `layout(...)` helper → HTTP 200 with placeholder
+//!   content.
+//! - `--api`: each action returns `AutumnResult<Json<serde_json::Value>>` with a
+//!   JSON placeholder body; no view stubs.
+
+use std::fmt::Write as _;
+use std::path::Path;
+
+use super::emit::{Plan, Revert};
+use super::naming::{humanize_label, snake};
+use super::schema_edit::{add_mod_declaration, update_main_rs};
+use super::{GenerateError, ensure_project_root, read_or_empty};
+
+/// HTTP methods a controller action may bind to.
+const VALID_METHODS: &[&str] = &["get", "post", "put", "patch", "delete"];
+
+/// A single parsed controller action: its handler function name, HTTP method,
+/// fully-qualified route path, and display title.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControllerAction {
+    /// Snake-case handler function name (also the route path segment).
+    pub fn_name: String,
+    /// Lowercased HTTP method (`get`/`post`/`put`/`patch`/`delete`).
+    pub method: String,
+    /// Fully-qualified route path (e.g. `/pages/home`, `/api/pages`).
+    pub path: String,
+    /// Humanized display title (e.g. `Home`).
+    pub title: String,
+}
+
+/// Parse and validate the CLI action tokens against `controller` (already
+/// snake-normalized), honouring the `--api` path prefix.
+fn parse_actions(
+    controller: &str,
+    actions: &[String],
+    api: bool,
+) -> Result<Vec<ControllerAction>, GenerateError> {
+    if actions.is_empty() {
+        return Err(GenerateError::InvalidName(
+            controller.to_owned(),
+            "at least one action is required (e.g. `autumn generate controller pages home about`)"
+                .to_owned(),
+        ));
+    }
+
+    let base = if api {
+        format!("/api/{controller}")
+    } else {
+        format!("/{controller}")
+    };
+
+    let mut parsed = Vec::with_capacity(actions.len());
+    for token in actions {
+        let (raw_action, method) = match token.split_once(':') {
+            Some((a, m)) => (a, m.to_ascii_lowercase()),
+            None => (token.as_str(), "get".to_owned()),
+        };
+        if !VALID_METHODS.contains(&method.as_str()) {
+            return Err(GenerateError::InvalidName(
+                token.clone(),
+                format!(
+                    "invalid HTTP method '{method}' — expected one of {}",
+                    VALID_METHODS.join(", ")
+                ),
+            ));
+        }
+        let fn_name = snake(raw_action);
+        if !super::dsl::is_valid_ident(&fn_name)
+            || super::dsl::RUST_KEYWORDS.contains(&fn_name.as_str())
+        {
+            return Err(GenerateError::InvalidName(
+                token.clone(),
+                format!("action '{raw_action}' is not a valid Rust identifier"),
+            ));
+        }
+        // In HTML mode the module also emits a private `fn layout` helper, so an
+        // action named `layout` would produce two items with the same name.
+        if !api && fn_name == "layout" {
+            return Err(GenerateError::InvalidName(
+                token.clone(),
+                "action `layout` is reserved in HTML mode (it collides with the \
+                 generated `layout` view helper); rename the action or use `--api`"
+                    .to_owned(),
+            ));
+        }
+        let path = if fn_name == "index" {
+            base.clone()
+        } else {
+            format!("{base}/{fn_name}")
+        };
+        let title = humanize_label(&fn_name);
+        parsed.push(ControllerAction {
+            fn_name,
+            method,
+            path,
+            title,
+        });
+    }
+    // Each action becomes one `pub async fn <fn_name>`; two actions with the
+    // same handler name (e.g. `new:get new:post`, or `home home`) would emit
+    // duplicate functions and fail to compile. A single fn can't bind two
+    // methods, so this is always a user error.
+    for (i, action) in parsed.iter().enumerate() {
+        if let Some(dup) = parsed[..i].iter().find(|a| a.fn_name == action.fn_name) {
+            return Err(GenerateError::InvalidName(
+                action.fn_name.clone(),
+                format!(
+                    "action `{}` specified twice — handler names must be unique; \
+                     a single fn can't bind both {} and {}",
+                    action.fn_name, dup.method, action.method
+                ),
+            ));
+        }
+    }
+    Ok(parsed)
+}
+
+/// Render the HTML (Maud) controller module for `actions`.
+fn render_html(actions: &[ControllerAction]) -> String {
+    let mut out = String::with_capacity(actions.len() * 200 + 512);
+    out.push_str(
+        "//! Generated by `autumn generate controller`.\n\
+         //!\n\
+         //! Handler-only routes — no model, no migration, no database. Edit freely.\n\
+         \n\
+         use autumn_web::prelude::*;\n\
+         \n\
+         fn layout(title: &str, content: Markup) -> Markup {\n\
+         \x20   html! {\n\
+         \x20       (PreEscaped(\"<!DOCTYPE html>\"))\n\
+         \x20       html lang=\"en\" {\n\
+         \x20           head {\n\
+         \x20               meta charset=\"utf-8\";\n\
+         \x20               title { (title) }\n\
+         \x20           }\n\
+         \x20           body {\n\
+         \x20               (content)\n\
+         \x20           }\n\
+         \x20       }\n\
+         \x20   }\n\
+         }\n",
+    );
+    for action in actions {
+        let ControllerAction {
+            fn_name,
+            method,
+            path,
+            title,
+        } = action;
+        let _ = write!(
+            out,
+            "\n#[{method}(\"{path}\")]\n\
+             pub async fn {fn_name}() -> Markup {{\n\
+             \x20   layout(\"{title}\", html! {{\n\
+             \x20       h1 {{ \"{title}\" }}\n\
+             \x20       p {{ \"Placeholder for the {fn_name} action — replace with real content.\" }}\n\
+             \x20   }})\n\
+             }}\n"
+        );
+    }
+    out
+}
+
+/// Render the `--api` (JSON) controller module for `actions`.
+fn render_api(actions: &[ControllerAction]) -> String {
+    let mut out = String::with_capacity(actions.len() * 160 + 320);
+    out.push_str(
+        "//! Generated by `autumn generate controller --api`.\n\
+         //!\n\
+         //! JSON handler-only routes — no model, no migration, no database. Edit freely.\n\
+         \n\
+         use autumn_web::prelude::*;\n\
+         use autumn_web::reexports::serde_json;\n",
+    );
+    for action in actions {
+        let ControllerAction {
+            fn_name,
+            method,
+            path,
+            ..
+        } = action;
+        let _ = write!(
+            out,
+            "\n#[{method}(\"{path}\")]\n\
+             pub async fn {fn_name}() -> AutumnResult<Json<serde_json::Value>> {{\n\
+             \x20   Ok(Json(serde_json::json!({{ \"action\": \"{fn_name}\" }})))\n\
+             }}\n"
+        );
+    }
+    out
+}
+
+/// Compute the file plan for `autumn generate controller <name> <action>...`.
+///
+/// Emits a single handler module `src/routes/<name>.rs`, registers it in
+/// `src/routes/mod.rs`, and wires each action's handler into `routes![...]` in
+/// `src/main.rs`. No model, migration, schema, or `Cargo.toml` edits.
+///
+/// # Errors
+/// - [`GenerateError::NotInProject`] outside an Autumn project root.
+/// - [`GenerateError::InvalidName`] for an empty/invalid controller name, an
+///   empty action list, an invalid method suffix, a non-identifier action, a
+///   duplicate action handler name, or (in HTML mode) the reserved `layout`
+///   action.
+/// - [`GenerateError::Io`] when `src/main.rs` is missing.
+pub fn plan_controller(
+    project_root: &Path,
+    name: &str,
+    actions: &[String],
+    api: bool,
+) -> Result<Plan, GenerateError> {
+    ensure_project_root(project_root)?;
+
+    let controller = snake(name);
+    if controller.is_empty()
+        || !super::dsl::is_valid_ident(&controller)
+        || super::dsl::RUST_KEYWORDS.contains(&controller.as_str())
+    {
+        return Err(GenerateError::InvalidName(
+            name.to_owned(),
+            "controller name must be a valid Rust identifier".to_owned(),
+        ));
+    }
+
+    let parsed = parse_actions(&controller, actions, api)?;
+
+    let mut plan = Plan::new(project_root.to_path_buf());
+
+    // ── Handler module ────────────────────────────────────────────────────
+    let rendered = if api {
+        render_api(&parsed)
+    } else {
+        render_html(&parsed)
+    };
+    plan.create(
+        project_root
+            .join("src")
+            .join("routes")
+            .join(format!("{controller}.rs")),
+        rendered,
+    );
+
+    // ── src/routes/mod.rs registration ────────────────────────────────────
+    let mod_path = project_root.join("src").join("routes").join("mod.rs");
+    plan.modify(
+        mod_path.clone(),
+        add_mod_declaration(&read_or_empty(&mod_path), &controller),
+    );
+    plan.push_revert(Revert::ModDecl {
+        path: mod_path,
+        name: controller.clone(),
+    });
+
+    // ── src/main.rs — `mod routes;` + route registration ──────────────────
+    let entries: Vec<String> = parsed
+        .iter()
+        .map(|a| format!("routes::{controller}::{}", a.fn_name))
+        .collect();
+    let main_path = project_root.join("src").join("main.rs");
+    let main_existing = std::fs::read_to_string(&main_path).map_err(|_| {
+        GenerateError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("missing {}", main_path.display()),
+        ))
+    })?;
+    if !main_existing.contains("routes![") {
+        // `update_main_rs` can only inject entries into an existing
+        // `routes![...]` invocation; without one the handlers are created but
+        // never mounted. Tell the user to wire them by hand rather than
+        // silently emit dead routes.
+        plan.warn(format!(
+            "no `routes![...]` macro found in {} — the generated handlers were \
+             not mounted; add them manually, e.g. `routes![{}]`",
+            main_path.display(),
+            entries.join(", ")
+        ));
+    }
+    plan.modify(
+        main_path.clone(),
+        update_main_rs(&main_existing, &["routes"], &entries),
+    );
+    plan.push_revert(Revert::RoutesEntries {
+        path: main_path,
+        entries,
+    });
+
+    Ok(plan)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::generate::Flags;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn project_with_main() -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("Cargo.toml"), "[package]\nname=\"x\"\n").unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(
+            tmp.path().join("src/main.rs"),
+            "use autumn_web::prelude::*;\n\
+             \n\
+             #[get(\"/\")]\n\
+             async fn index() -> &'static str { \"ok\" }\n\
+             \n\
+             #[autumn_web::main]\n\
+             async fn main() {\n\
+             \x20   autumn_web::app()\n\
+             \x20       .routes(routes![index])\n\
+             \x20       .run()\n\
+             \x20       .await;\n\
+             }\n",
+        )
+        .unwrap();
+        // A fresh `autumn new` project has no src/routes/; the generator creates it.
+        tmp
+    }
+
+    fn actions(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    fn run(
+        tmp: &TempDir,
+        name: &str,
+        list: &[&str],
+        api: bool,
+        force: bool,
+    ) -> Result<(), GenerateError> {
+        let plan = plan_controller(tmp.path(), name, &actions(list), api)?;
+        plan.execute(Flags {
+            force,
+            dry_run: false,
+        })
+    }
+
+    #[test]
+    fn html_controller_creates_handlers_and_wires_routes() {
+        let tmp = project_with_main();
+        run(&tmp, "pages", &["home", "about", "contact"], false, false).unwrap();
+
+        let file = fs::read_to_string(tmp.path().join("src/routes/pages.rs")).unwrap();
+        assert!(file.contains("#[get(\"/pages/home\")]"), "{file}");
+        assert!(file.contains("pub async fn home"), "{file}");
+        assert!(file.contains("#[get(\"/pages/about\")]"), "{file}");
+        assert!(file.contains("#[get(\"/pages/contact\")]"), "{file}");
+        assert!(file.contains("fn layout"), "{file}");
+        assert!(file.contains("html!"), "{file}");
+
+        let main = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert!(main.contains("routes::pages::home"), "{main}");
+        assert!(main.contains("routes::pages::about"), "{main}");
+        assert!(main.contains("routes::pages::contact"), "{main}");
+        assert!(main.contains("mod routes;"), "{main}");
+
+        let routes_mod = fs::read_to_string(tmp.path().join("src/routes/mod.rs")).unwrap();
+        assert!(routes_mod.contains("pub mod pages;"), "{routes_mod}");
+
+        // No model / migration / schema / Cargo.toml side effects.
+        assert!(!tmp.path().join("migrations").exists(), "no migrations");
+        assert!(!tmp.path().join("src/models").exists(), "no models dir");
+        assert!(!tmp.path().join("src/schema.rs").exists(), "no schema.rs");
+        let cargo = fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+        assert_eq!(cargo, "[package]\nname=\"x\"\n", "Cargo.toml unchanged");
+    }
+
+    #[test]
+    fn action_method_suffix_parsed() {
+        let tmp = project_with_main();
+        run(&tmp, "pages", &["submit:post"], false, false).unwrap();
+        let file = fs::read_to_string(tmp.path().join("src/routes/pages.rs")).unwrap();
+        assert!(file.contains("#[post(\"/pages/submit\")]"), "{file}");
+        assert!(file.contains("pub async fn submit"), "{file}");
+    }
+
+    #[test]
+    fn index_action_maps_to_controller_root() {
+        let tmp = project_with_main();
+        run(&tmp, "pages", &["index"], false, false).unwrap();
+        let file = fs::read_to_string(tmp.path().join("src/routes/pages.rs")).unwrap();
+        assert!(file.contains("#[get(\"/pages\")]"), "{file}");
+        assert!(!file.contains("#[get(\"/pages/index\")]"), "{file}");
+    }
+
+    #[test]
+    fn api_mode_emits_json_and_no_views() {
+        let tmp = project_with_main();
+        run(&tmp, "pages", &["index", "stats"], true, false).unwrap();
+        let file = fs::read_to_string(tmp.path().join("src/routes/pages.rs")).unwrap();
+        assert!(
+            file.contains("AutumnResult<Json<serde_json::Value>>"),
+            "{file}"
+        );
+        assert!(file.contains("#[get(\"/api/pages\")]"), "{file}");
+        assert!(file.contains("#[get(\"/api/pages/stats\")]"), "{file}");
+        assert!(!file.contains("layout("), "{file}");
+        assert!(!file.contains("html!"), "{file}");
+    }
+
+    #[test]
+    fn rerun_without_force_fails_and_preserves_file() {
+        let tmp = project_with_main();
+        run(&tmp, "pages", &["home"], false, false).unwrap();
+        let original = fs::read_to_string(tmp.path().join("src/routes/pages.rs")).unwrap();
+
+        // A second run with different actions must NOT overwrite.
+        let err = run(&tmp, "pages", &["home", "about"], false, false).unwrap_err();
+        assert!(matches!(err, GenerateError::Collisions(_)), "{err:?}");
+        let after = fs::read_to_string(tmp.path().join("src/routes/pages.rs")).unwrap();
+        assert_eq!(original, after, "file must be untouched on collision");
+
+        // With --force it succeeds and rewrites.
+        run(&tmp, "pages", &["home", "about"], false, true).unwrap();
+        let forced = fs::read_to_string(tmp.path().join("src/routes/pages.rs")).unwrap();
+        assert!(forced.contains("#[get(\"/pages/about\")]"), "{forced}");
+    }
+
+    #[test]
+    fn empty_actions_rejected() {
+        let tmp = project_with_main();
+        let err = plan_controller(tmp.path(), "pages", &[], false).unwrap_err();
+        assert!(matches!(err, GenerateError::InvalidName(_, _)), "{err:?}");
+    }
+
+    #[test]
+    fn bad_method_suffix_rejected() {
+        let tmp = project_with_main();
+        let err = plan_controller(tmp.path(), "pages", &actions(&["submit:frobnicate"]), false)
+            .unwrap_err();
+        assert!(matches!(err, GenerateError::InvalidName(_, _)), "{err:?}");
+    }
+
+    #[test]
+    fn empty_name_rejected() {
+        let tmp = project_with_main();
+        let err = plan_controller(tmp.path(), "", &actions(&["home"]), false).unwrap_err();
+        assert!(matches!(err, GenerateError::InvalidName(_, _)), "{err:?}");
+    }
+
+    #[test]
+    fn duplicate_action_names_rejected() {
+        let tmp = project_with_main();
+        // Same stem via two methods → two `pub async fn new` → would not compile.
+        let err = plan_controller(
+            tmp.path(),
+            "posts",
+            &actions(&["new:get", "new:post"]),
+            false,
+        )
+        .unwrap_err();
+        assert!(matches!(err, GenerateError::InvalidName(_, _)), "{err:?}");
+
+        // Plain repeated stem is rejected too.
+        let err2 =
+            plan_controller(tmp.path(), "pages", &actions(&["home", "home"]), false).unwrap_err();
+        assert!(matches!(err2, GenerateError::InvalidName(_, _)), "{err2:?}");
+    }
+
+    #[test]
+    fn layout_action_reserved_in_html_mode() {
+        let tmp = project_with_main();
+        // HTML mode emits a `fn layout` helper, so an action named `layout` collides.
+        let err = plan_controller(tmp.path(), "pages", &actions(&["layout"]), false).unwrap_err();
+        assert!(matches!(err, GenerateError::InvalidName(_, _)), "{err:?}");
+
+        // In --api mode there is no `layout` helper, so it's allowed.
+        run(&tmp, "pages", &["layout"], true, false).unwrap();
+        let file = fs::read_to_string(tmp.path().join("src/routes/pages.rs")).unwrap();
+        assert!(file.contains("pub async fn layout"), "{file}");
+    }
+}

--- a/autumn-cli/src/generate/mod.rs
+++ b/autumn-cli/src/generate/mod.rs
@@ -14,6 +14,7 @@ pub mod admin;
 pub mod auth;
 pub mod channel;
 pub mod config;
+pub mod controller;
 pub mod dsl;
 pub mod emit;
 pub mod inbound_mail;

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1883,6 +1883,41 @@ enum GenerateCommands {
         #[arg(long)]
         force: bool,
     },
+    /// Generate a handler-only, non-CRUD route module (no model, migration, or
+    /// database).
+    ///
+    /// Each action maps to `/<controller>/<action>`, except an action literally
+    /// named `index`, which maps to `/<controller>`. Under `--api` the prefix is
+    /// `/api/<controller>[/<action>]`.
+    ///
+    /// Actions default to GET; request another method with `action:method`
+    /// (method ∈ get, post, put, patch, delete), e.g. `submit:post`.
+    ///
+    /// HTML mode (default) emits Maud stub views returning HTTP 200; `--api`
+    /// emits JSON actions with no view stubs. Re-running against an existing
+    /// controller fails without `--force`.
+    ///
+    /// Example:
+    ///
+    ///   autumn generate controller pages home about contact
+    #[command(verbatim_doc_comment)]
+    Controller {
+        /// Controller name (`snake_case` or `PascalCase`, e.g. `pages`).
+        name: String,
+        /// Action names, each optionally suffixed with `:method`
+        /// (e.g. `home`, `submit:post`, `index`).
+        #[arg(required = true)]
+        actions: Vec<String>,
+        /// Emit JSON actions (no HTML/Maud views).
+        #[arg(long)]
+        api: bool,
+        /// Print the file plan and exit without writing anything.
+        #[arg(long)]
+        dry_run: bool,
+        /// Overwrite existing files instead of erroring on collision.
+        #[arg(long)]
+        force: bool,
+    },
     /// Generate model, migration, repository, HTML routes, smoke test, and
     /// register the new routes in `src/main.rs`.
     ///
@@ -3075,6 +3110,16 @@ fn run_generate_command(cmd: GenerateCommands, mode: ApplyMode) {
             force,
         } => {
             let plan = generate::wizard::plan_wizard(&resolve_cwd(), &name, &steps);
+            apply_plan(plan, generate::Flags { dry_run, force }, mode);
+        }
+        GenerateCommands::Controller {
+            name,
+            actions,
+            api,
+            dry_run,
+            force,
+        } => {
+            let plan = generate::controller::plan_controller(&resolve_cwd(), &name, &actions, api);
             apply_plan(plan, generate::Flags { dry_run, force }, mode);
         }
         GenerateCommands::Scaffold {

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -6483,6 +6483,48 @@ fn controller_generates_compiles_and_lists_routes() {
             "autumn routes must list {path}:\n{stdout}"
         );
     }
+
+    // --force regeneration with a CHANGED action set must prune the stale
+    // route entries (`about`) from main.rs, not just append the new one
+    // (`services`) — otherwise `routes::pages::about` would reference a
+    // handler the overwritten file no longer defines and break the build.
+    run_autumn(
+        &project,
+        &[
+            "generate",
+            "controller",
+            "pages",
+            "home",
+            "contact",
+            "services",
+            "--force",
+        ],
+    );
+
+    let rebuild = Command::new("cargo")
+        .args(["build"])
+        .current_dir(&project)
+        .output()
+        .expect("failed to run cargo build after --force regen");
+    assert!(
+        rebuild.status.success(),
+        "cargo build failed after --force regen (stale route entry not pruned?):\n\
+         stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&rebuild.stdout),
+        String::from_utf8_lossy(&rebuild.stderr),
+    );
+
+    let (stdout2, _stderr2) = run_autumn(&project, &["routes"]);
+    for path in ["/pages/home", "/pages/contact", "/pages/services"] {
+        assert!(
+            stdout2.contains(path),
+            "autumn routes must list {path} after regen:\n{stdout2}"
+        );
+    }
+    assert!(
+        !stdout2.contains("/pages/about"),
+        "the dropped action /pages/about must no longer be listed:\n{stdout2}"
+    );
 }
 
 /// Slow end-to-end check: `generate controller --api` must compile and list its

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -6414,3 +6414,115 @@ fn generate_tauri_reuses_pwa_icon() {
         "PWA icon must still exist"
     );
 }
+
+// ── generate controller (issue #1050) ──────────────────────────────────────
+
+/// Re-running `generate controller` against an existing controller must fail
+/// (non-zero exit) and leave the first file byte-for-byte intact. Fast — no
+/// compile needed.
+#[test]
+fn controller_rerun_without_force_fails() {
+    let (_tmp, project) = fresh_project("controller-rerun-app");
+    run_autumn(
+        &project,
+        &["generate", "controller", "pages", "home", "about"],
+    );
+    let original = fs::read_to_string(project.join("src/routes/pages.rs")).unwrap();
+
+    let (_out, _err, code) = run_autumn_failing(
+        &project,
+        &["generate", "controller", "pages", "home", "contact"],
+    );
+    assert_eq!(code, Some(1), "second run must exit non-zero");
+    let after = fs::read_to_string(project.join("src/routes/pages.rs")).unwrap();
+    assert_eq!(
+        original, after,
+        "existing controller file must be untouched"
+    );
+}
+
+/// Slow end-to-end check: a fresh project + `generate controller` (HTML) must
+/// compile with zero edits, and `autumn routes` must list every generated
+/// route.
+///
+/// Ignored by default; run with `cargo test -p autumn-cli -- --ignored`.
+#[test]
+#[ignore = "slow: cargo-builds a fresh project — run with `cargo test -p autumn-cli -- --ignored`"]
+fn controller_generates_compiles_and_lists_routes() {
+    let (_tmp, project) = fresh_project("controller-html-build");
+    patch_generated_cargo_toml(&project);
+
+    run_autumn(
+        &project,
+        &[
+            "generate",
+            "controller",
+            "pages",
+            "home",
+            "about",
+            "contact",
+        ],
+    );
+
+    let build = Command::new("cargo")
+        .args(["build"])
+        .current_dir(&project)
+        .output()
+        .expect("failed to run cargo build");
+    assert!(
+        build.status.success(),
+        "cargo build failed on generated controller:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr),
+    );
+
+    let (stdout, _stderr) = run_autumn(&project, &["routes"]);
+    for path in ["/pages/home", "/pages/about", "/pages/contact"] {
+        assert!(
+            stdout.contains(path),
+            "autumn routes must list {path}:\n{stdout}"
+        );
+    }
+}
+
+/// Slow end-to-end check: `generate controller --api` must compile and list its
+/// JSON routes under `/api/<controller>`.
+///
+/// Ignored by default; run with `cargo test -p autumn-cli -- --ignored`.
+#[test]
+#[ignore = "slow: cargo-builds a fresh project — run with `cargo test -p autumn-cli -- --ignored`"]
+fn controller_api_generates_json() {
+    let (_tmp, project) = fresh_project("controller-api-build");
+    patch_generated_cargo_toml(&project);
+
+    run_autumn(
+        &project,
+        &["generate", "controller", "pages", "index", "stats", "--api"],
+    );
+
+    let file = fs::read_to_string(project.join("src/routes/pages.rs")).unwrap();
+    assert!(
+        file.contains("AutumnResult<Json<serde_json::Value>>"),
+        "--api controller must return JSON:\n{file}"
+    );
+
+    let build = Command::new("cargo")
+        .args(["build"])
+        .current_dir(&project)
+        .output()
+        .expect("failed to run cargo build");
+    assert!(
+        build.status.success(),
+        "cargo build failed on generated --api controller:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr),
+    );
+
+    let (stdout, _stderr) = run_autumn(&project, &["routes"]);
+    for path in ["/api/pages", "/api/pages/stats"] {
+        assert!(
+            stdout.contains(path),
+            "autumn routes must list {path}:\n{stdout}"
+        );
+    }
+}

--- a/skills/generate/SKILL.md
+++ b/skills/generate/SKILL.md
@@ -27,6 +27,7 @@ them; on 0.5.0 fall back to the documented manual alternative.
 | Subcommand | Example | What it creates |
 |---|---|---|
 | `scaffold` | `scaffold Post title:String body:Text` | Model + migration + routes (index/show/new/create/edit/update/delete) + views + smoke test. Also updates `src/main.rs`. |
+| `controller` **(trunk-dev)** | `controller pages home about contact` | Handler-only route module for non-CRUD pages/endpoints — one handler per named action, Maud stub views (HTTP 200), wired into `routes![...]` and `src/routes/mod.rs`. **No** model, migration, DB, schema, or `Cargo.toml` changes. `--api` emits JSON actions instead of views. |
 | `model` | `model Post title:String body:Text` | Model struct + migration |
 | `migration` | `migration add_slug_to_posts` | Empty timestamped migration file |
 | `mailer` | `mailer User` | Mailer struct + email templates (generator appends `Mailer` → produces `UserMailer`) |
@@ -118,6 +119,34 @@ Next steps:
 1. Run: autumn migrate   (the generator already updated src/main.rs)
 2. Run: autumn dev
 3. Visit: http://localhost:3000/<plural>
+```
+
+### controller (trunk-dev)
+```
+Next steps:
+1. The generator already:
+   - Created src/routes/<controller>.rs (one handler per action)
+   - Added `pub mod <controller>;` to src/routes/mod.rs
+   - Wired each action into routes![...] and added `mod routes;` in src/main.rs
+   No model, migration, database, schema, or Cargo.toml changes are made.
+
+2. Path rule: each action maps to /<controller>/<action>, except an action
+   literally named `index`, which maps to /<controller>. Under `--api` the
+   prefix is /api/<controller>[/<action>].
+
+3. Method rule: actions default to GET. Request another method with
+   `action:method` (method ∈ get, post, put, patch, delete), e.g.
+   `autumn generate controller pages home submit:post`.
+
+4. HTML mode returns a Maud stub view (HTTP 200 placeholder) per action;
+   `--api` returns AutumnResult<Json<serde_json::Value>> with a JSON stub and
+   no view. Edit the generated handlers to add real content.
+
+5. Re-running against an existing controller fails (non-destructive); pass
+   `--force` to overwrite. `autumn destroy controller <name> <action>...`
+   reverts it.
+
+6. Run: cargo check   (then `autumn routes` lists every new route)
 ```
 
 ### model


### PR DESCRIPTION
Closes #1050

## What & why

Adds a new `autumn generate controller <name> <action>...` generator for handler-only, non-CRUD routes (landing pages, dashboards, webhook receivers, simple JSON endpoints) that don't warrant a full CRUD scaffold. It emits **only** a route module — no model, migration, database, schema, or `Cargo.toml` changes.

### Before / After

**Before** — to add a few non-CRUD pages you hand-write everything: create `src/routes/<name>.rs`, write one handler per page, write a Maud view for each, add `pub mod <name>;` to `src/routes/mod.rs`, and manually edit `routes[...]` in `src/main.rs` for every handler. Easy to forget a wiring step, and the app won't serve the route until you do.

**After** — one command:

```
autumn generate controller pages home about contact
```

produces a module that compiles with zero edits and immediately serves HTTP 200 at `/pages/home`, `/pages/about`, `/pages/contact`, all mounted and listed by `autumn routes`.

## How

- New generator `autumn-cli/src/generate/controller.rs` (`plan_controller`) — mirrors the emit/revert machinery the `scaffold`/`auth` generators use.
- One `pub async fn` handler per named action.
- **Route wiring** reuses `schema_edit::update_main_rs` to inject each handler into the existing `routes[...]` invocation in `src/main.rs` (and add `mod routes;`), plus `add_mod_declaration` to register `pub mod <name>;` in `src/routes/mod.rs` — the same mechanism scaffold/auth use, so no manual edits.
- **HTML mode** (default): each action returns a Maud `Markup` stub rendered through a local `layout(...)` helper (HTTP 200 placeholder).
- **`--api`**: each action returns `AutumnResult<Json<serde_json::Value>>` with a JSON placeholder; no view stubs.
- **Non-destructive re-run**: re-running against an existing controller fails via the emit `Create` collision check (`--force` overrides). Reverts (`Revert::ModDecl`, `Revert::RoutesEntries`) are pushed so `autumn destroy controller ...` cleanly undoes it.
- Clap variant marks `actions` as `required = true`; a missing-`routes[` `main.rs` emits a warning telling the user to wire the handlers manually rather than silently dropping them.

### Path rule

Each action maps to `/<controller>/<action>`, **except** an action literally named `index`, which maps to `/<controller>` (the collection root). Under `--api` the prefix becomes `/api/<controller>[/<action>]`.

### Method rule

Actions default to `GET`. Request another method with `action:method`, where `method` ∈ `get | post | put | patch | delete` (e.g. `submit:post`).

### Validation

Rejects (clear `GenerateError`): empty controller name / action list, invalid method suffix, non-identifier action, duplicate handler names (e.g. `new:get new:post`), and — in HTML mode — the reserved `layout` action (would collide with the generated view helper).

## Tests

- **10 unit tests** in `controller.rs`: HTML wiring + no model/migration/schema/Cargo.toml side effects, `action:method` parsing, the `index` path rule, `--api` JSON output, idempotency/`--force`, and the validation cases (empty, bad method, duplicate names, reserved `layout`).
- **3 E2E tests** in `autumn-cli/tests/generate.rs`: fresh `autumn new` project → `generate controller` → **`cargo build` succeeds (zero-edit compile)** → **`autumn routes` lists every generated route** (HTML and `--api`), plus a non-destructive re-run check. The two build tests are wired into `.github/workflows/generator-conformance.yml` (invoked by `--ignored --exact`, mirroring the existing `generated_scaffold_*` steps).

Docs: `CHANGELOG.md` (Unreleased → Added) and `skills/generate/SKILL.md` (subcommand row + `controller` next-steps block).


---
_Generated by [Claude Code](https://claude.ai/code/session_01YDz1Lkepv3nboPenYc5dLb)_