### PR TITLE
Inline stylesheet CSS into HTML email bodies at send time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a mailer that calls `.inline_css(true)`, demonstrating the happy path end to
   end. On inliner failure `send` fails loudly, returning a typed
   `MailError::CssInline` instead of delivering a corrupted body — the message is
-  not sent, so the body is never silently corrupted.
+  not sent, so the body is never silently corrupted. Deferred/durable-queue
+  sends (`deliver_later`) freeze the originating mailer's inlining default onto
+  the message before it is persisted, so a worker consuming the queue with a
+  different default still honors the sender's decision (explicit per-message
+  overrides are preserved).
 - **generator:** `autumn new` now generates a `README.md` at the project root
   (listed in the "Created …" output) with explicit prerequisites and a
   golden-path quickstart — configure the `[database]` block in `autumn.toml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,8 +113,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   its network/file stylesheet fetchers disabled — only embedded `<style>` CSS is
   inlined). `autumn generate mailer` now scaffolds a `<style>`-block template and
   a mailer that calls `.inline_css(true)`, demonstrating the happy path end to
-  end. On inliner failure a typed `MailError::CssInline` is surfaced and the
-  original body is preserved rather than delivered corrupted.
+  end. On inliner failure `send` fails loudly, returning a typed
+  `MailError::CssInline` instead of delivering a corrupted body — the message is
+  not sent, so the body is never silently corrupted.
 - **generator:** `autumn new` now generates a `README.md` at the project root
   (listed in the "Created …" output) with explicit prerequisites and a
   golden-path quickstart — configure the `[database]` block in `autumn.toml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **testing:** property-based (proptest) invariant tests for the parser/codec
   surfaces, asserting round-trip and well-formedness invariants alongside the
   fuzz harness. Test-only, no public API change. [no-plugin]
+- **mail:** automatic CSS inlining for HTML email (issue #1254). HTML bodies
+  authored with a `<style>` block and CSS classes are transformed at send time
+  so matching elements carry equivalent `style="…"` attributes in the delivered
+  message — the fix for Gmail/Outlook stripping `<head>`/`<style>`. Opt in per
+  message with `MailBuilder::inline_css(true)` or default it per environment via
+  `mail.inline_css = true` (`MailConfig::inline_css` / `MailerBuilder::inline_css`);
+  an explicit builder call wins over the config default in either direction, and
+  the default is off so existing apps are unaffected. Un-inlinable `@media`/
+  pseudo-class rules are preserved in a retained `<style>` block, text parts and
+  bodies with no `<style>` pass through unchanged, and inlining is idempotent.
+  Backed by the mature `css-inline` crate (gated behind the `mail` feature, with
+  its network/file stylesheet fetchers disabled — only embedded `<style>` CSS is
+  inlined). `autumn generate mailer` now scaffolds a `<style>`-block template and
+  a mailer that calls `.inline_css(true)`, demonstrating the happy path end to
+  end. On inliner failure a typed `MailError::CssInline` is surfaced and the
+  original body is preserved rather than delivered corrupted.
 - **generator:** `autumn new` now generates a `README.md` at the project root
   (listed in the "Created …" output) with explicit prerequisites and a
   golden-path quickstart — configure the `[database]` block in `autumn.toml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sends (`deliver_later`) freeze the originating mailer's inlining default onto
   the message before it is persisted, so a worker consuming the queue with a
   different default still honors the sender's decision (explicit per-message
-  overrides are preserved).
+  overrides are preserved). The dev mail preview UI runs the same inlining pass
+  as `send`, so previews of `<style>`-block templates show the inlined
+  `style="…"` bodies strict clients actually receive rather than raw CSS.
 - **generator:** `autumn new` now generates a `README.md` at the project root
   (listed in the "Created …" output) with explicit prerequisites and a
   golden-path quickstart — configure the `[database]` block in `autumn.toml`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "croner",
+ "css-inline",
  "csv",
  "deadpool",
  "diesel",
@@ -2031,6 +2032,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "css-inline"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f845f973dd2b71c48976c504756d7a163c5068dd6857b8d2f8ee1e92a190f6"
+dependencies = [
+ "cssparser",
+ "html5ever",
+ "memchr",
+ "precomputed-hash",
+ "rustc-hash",
+ "selectors",
+ "smallvec",
+ "url",
+]
+
+[[package]]
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,6 +2055,29 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf 0.11.3",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.13.1",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2543,6 +2583,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
 ]
 
 [[package]]
@@ -3310,6 +3365,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever",
 ]
 
 [[package]]
@@ -4117,6 +4182,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4304,6 +4380,12 @@ dependencies = [
  "spin 0.9.8",
  "version_check",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -4938,7 +5020,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -4957,6 +5039,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
+ "phf_macros 0.13.1",
  "phf_shared 0.13.1",
  "serde",
 ]
@@ -4967,8 +5050,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -4982,13 +5075,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
 name = "phf_macros"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -5261,6 +5377,12 @@ dependencies = [
  "pq-src",
  "vcpkg",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "primeorder"
@@ -6456,6 +6578,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "selectors"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cssparser",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6600,6 +6741,15 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -6937,6 +7087,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot 0.12.5",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7125,6 +7299,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendril"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
+dependencies = [
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7155,7 +7338,7 @@ dependencies = [
  "fnv",
  "nom 7.1.3",
  "phf 0.11.3",
- "phf_codegen",
+ "phf_codegen 0.11.3",
 ]
 
 [[package]]
@@ -8296,6 +8479,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]

--- a/autumn-cli/src/generate/mailer.rs
+++ b/autumn-cli/src/generate/mailer.rs
@@ -304,6 +304,10 @@ impl {struct_name} {{
             .subject("{struct_name}")
             .html(include_str!("../../templates/mailers/{snake_name}.html"))
             .text(include_str!("../../templates/mailers/{snake_name}.txt")){layout_call}
+            // Rewrite the template's `<style>` rules onto elements as inline
+            // `style="…"` attributes at send time, so the mail renders styled in
+            // Gmail/Outlook (which strip `<head>`/`<style>`). See issue #1254.
+            .inline_css(true)
             .build()
             .expect("valid mail")
     }}
@@ -415,19 +419,41 @@ fn render_layout_txt() -> String {
 /// full document is emitted instead.
 fn render_html_template(struct_name: &str, no_layout: bool) -> String {
     if no_layout {
+        // Full self-contained document with a `<head>` `<style>` block. The
+        // generated mailer calls `.inline_css(true)`, so these class rules are
+        // rewritten onto the elements as inline `style="…"` at send time and
+        // render in Gmail/Outlook (which drop `<head>`/`<style>`). See #1254.
         format!(
             "<!DOCTYPE html>\n\
              <html>\n\
-             <head><meta charset=\"utf-8\"></head>\n\
+             <head>\n\
+               <meta charset=\"utf-8\">\n\
+               <style>\n\
+            \x20    .lead {{ font-size:16px; line-height:1.6; color:#333333; }}\n\
+               </style>\n\
+             </head>\n\
              <body>\n\
-               <p>Hello from {struct_name}!</p>\n\
+               <p class=\"lead\">Hello from {struct_name}!</p>\n\
              </body>\n\
              </html>\n"
         )
     } else {
+        // Authored with a `<style>` block + CSS classes — the ergonomic way to
+        // style email. The generated mailer calls `.inline_css(true)`, so at
+        // send time Autumn rewrites these rules onto the elements as
+        // `style="…"` attributes (issue #1254); that is what makes them render
+        // in Gmail/Outlook, which strip `<head>`/`<style>`. The `@media` rule is
+        // preserved in a retained `<style>` block for clients that honor it.
         format!(
-            "<h1 style=\"margin:0 0 16px;font-size:24px;color:#1a1a2e;\">Hello from {struct_name}!</h1>\n\
-             <p style=\"margin:0;font-size:16px;line-height:1.6;color:#333333;\">Your email body goes here.</p>\n"
+            "<style>\n\
+            \x20 .greeting {{ margin:0 0 16px; font-size:24px; color:#1a1a2e; }}\n\
+            \x20 .lead {{ margin:0 0 24px; font-size:16px; line-height:1.6; color:#333333; }}\n\
+            \x20 .btn {{ display:inline-block; padding:12px 20px; background:#1a1a2e; color:#ffffff; text-decoration:none; border-radius:4px; }}\n\
+            \x20 @media (max-width:600px) {{ .btn {{ display:block; text-align:center; }} }}\n\
+             </style>\n\
+             <h1 class=\"greeting\">Hello from {struct_name}!</h1>\n\
+             <p class=\"lead\">Your email body goes here.</p>\n\
+             <a class=\"btn\" href=\"https://example.com\">Call to action</a>\n"
         )
     }
 }
@@ -1020,6 +1046,59 @@ async fn main() {
         );
         // With layout, per-mailer template is body-only; full document is in _layout.html.
         assert!(!html.is_empty(), "html template must not be empty");
+    }
+
+    #[test]
+    fn html_template_shows_style_block_example_relying_on_inlining() {
+        // AC6 (issue #1254): the scaffolded per-mailer template demonstrates the
+        // `<style>`-block + CSS-class happy path that inlining resolves.
+        let tmp = project_with_main(default_main());
+        plan_mailer(tmp.path(), "Welcome", None, false)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let html = fs::read_to_string(tmp.path().join("templates/mailers/welcome.html")).unwrap();
+        assert!(
+            html.contains("<style>"),
+            "with-layout template must show a <style>-block example: {html}"
+        );
+        assert!(
+            html.contains("class=\"btn\""),
+            "template must reference a CSS class that inlining resolves: {html}"
+        );
+    }
+
+    #[test]
+    fn generated_mailer_enables_css_inlining() {
+        // AC6 (issue #1254): the generated mailer opts into inlining so the
+        // `<style>`-block template renders styled end to end.
+        let tmp = project_with_main(default_main());
+        plan_mailer(tmp.path(), "Welcome", None, false)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let mailer = fs::read_to_string(tmp.path().join("src/mailers/welcome.rs")).unwrap();
+        assert!(
+            mailer.contains(".inline_css(true)"),
+            "generated mailer must enable CSS inlining: {mailer}"
+        );
+    }
+
+    #[test]
+    fn no_layout_template_also_shows_style_block() {
+        let tmp = project_with_main(default_main());
+        plan_mailer(tmp.path(), "Welcome", None, true)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let html = fs::read_to_string(tmp.path().join("templates/mailers/welcome.html")).unwrap();
+        assert!(
+            html.contains("<style>"),
+            "--no-layout template must also show a <style>-block example: {html}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/mailer.rs
+++ b/autumn-cli/src/generate/mailer.rs
@@ -346,6 +346,10 @@ impl {struct_name} {{
             .subject("{struct_name}")
             .html(include_str!("../../../templates/mailers/{snake_name}.html"))
             .text(include_str!("../../../templates/mailers/{snake_name}.txt")){layout_call}
+            // Match the production mailer's opt-in so the preview renders the
+            // `<style>` rules inlined regardless of the app's `mail.inline_css`
+            // config default. See issue #1254.
+            .inline_css(true)
             .build()
             .expect("valid preview mail")
     }}
@@ -1083,6 +1087,28 @@ async fn main() {
         assert!(
             mailer.contains(".inline_css(true)"),
             "generated mailer must enable CSS inlining: {mailer}"
+        );
+    }
+
+    #[test]
+    fn generated_preview_enables_css_inlining() {
+        // AC6 (issue #1254): the generated preview fixture must carry the same
+        // `.inline_css(true)` opt-in the production mailer has, so a scaffolded
+        // mailer's preview is inlined regardless of the app's `mail.inline_css`
+        // config default (the preview route resolves per-message-override-or-
+        // config-default, so without the override a `false` default would show
+        // RAW `<style>` CSS even though a real send is inlined).
+        let tmp = project_with_main(default_main());
+        plan_mailer(tmp.path(), "Welcome", None, false)
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let preview =
+            fs::read_to_string(tmp.path().join("src/mailers/previews/welcome.rs")).unwrap();
+        assert!(
+            preview.contains(".inline_css(true)"),
+            "generated preview fixture must enable CSS inlining to match the mailer: {preview}"
         );
     }
 

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -90,7 +90,7 @@ variants = ["storage", "dep:image"]
 # `LogReporter` as the default. On by default; disable to drop the panic-catch
 # layer and the reporting machinery.
 reporting = []
-mail = ["dep:lettre", "maud"]
+mail = ["dep:lettre", "dep:css-inline", "maud"]
 # First-class inbound email handling with provider webhooks and routing DSL.
 # Adds `autumn_web::inbound_mail` with the generic RFC 5322 adapter.
 inbound-mail = []
@@ -224,6 +224,11 @@ hex = "0.4"
 include_dir = { version = "0.7", optional = true }
 csv = { workspace = true, optional = true }
 lettre = { version = "0.11.21", default-features = false, features = ["builder", "smtp-transport", "tokio1-rustls-tls"], optional = true }
+# CSS inliner for HTML email (issue #1254). `default-features = false` drops the
+# optional network (`http`/reqwest) and local-file stylesheet fetchers — Autumn
+# only inlines embedded `<style>` blocks, never remote CSS — keeping the added
+# graph to the html5ever/selectors parsing stack. Gated behind the `mail` feature.
+css-inline = { version = "0.21", default-features = false, optional = true }
 chromiumoxide = { workspace = true, optional = true }
 image = { workspace = true, optional = true }
 

--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -46,8 +46,7 @@ fn next_topic_epoch() -> u64 {
         // value is only a per-process epoch seed, not a precise clock.
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_nanos() as u64)
-            .unwrap_or(0)
+            .map_or(0, |d| d.as_nanos() as u64)
     });
     seed.wrapping_add(COUNTER.fetch_add(1, Ordering::Relaxed))
 }

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -3660,6 +3660,7 @@ impl AutumnConfig {
             "AUTUMN_MAIL__MOUNT_UNSUBSCRIBE_ENDPOINT",
             &mut self.mail.mount_unsubscribe_endpoint,
         );
+        parse_env_bool(env, "AUTUMN_MAIL__INLINE_CSS", &mut self.mail.inline_css);
         if let Ok(val) = env.var("AUTUMN_MAIL__FILE_DIR") {
             self.mail.file_dir = PathBuf::from(val);
         }
@@ -9144,6 +9145,33 @@ path = "/api-spec.json"
         assert!(
             !config.mail.allow_in_process_deliver_later_in_production,
             "flag should default to false when env var is not set"
+        );
+    }
+
+    #[cfg(feature = "mail")]
+    #[test]
+    fn mail_inline_css_is_overridable_via_env() {
+        let env = MockEnv::new().with("AUTUMN_MAIL__INLINE_CSS", "true");
+
+        let mut config = AutumnConfig::default();
+        config.apply_mail_env_overrides_with_env(&env);
+
+        assert!(
+            config.mail.inline_css,
+            "AUTUMN_MAIL__INLINE_CSS=true should enable inline_css"
+        );
+    }
+
+    #[cfg(feature = "mail")]
+    #[test]
+    fn mail_inline_css_defaults_false() {
+        let env = MockEnv::new();
+        let mut config = AutumnConfig::default();
+        config.apply_mail_env_overrides_with_env(&env);
+
+        assert!(
+            !config.mail.inline_css,
+            "inline_css should default to false when env var is not set"
         );
     }
 

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -450,6 +450,12 @@ fn inline_css_html(html: &str) -> Result<String, MailError> {
         .load_remote_stylesheets(false)
         .build()
         .inline(html)
+        // Defensive / effectively unreachable: with remote-stylesheet loading
+        // disabled above and no file loader configured, `css-inline` only errors
+        // on IO/network — both compiled out here. It is fully lenient toward
+        // malformed CSS/HTML (garbage `<style>` bodies inline to an unchanged
+        // fragment, never an error). We still surface the typed error rather than
+        // `expect`ing, to keep the API stable if those loaders are ever enabled.
         .map_err(|error| MailError::CssInline(error.to_string()))
 }
 
@@ -914,9 +920,12 @@ pub enum MailError {
     /// [`MailBuilder::ignore_suppression`] for critical mail.
     #[error("all recipients are on the mail suppression list; nothing was sent")]
     AllRecipientsSuppressed,
-    /// CSS inlining of the HTML body failed (issue #1254). The original body is
-    /// preserved (never delivered corrupted) and this typed error is surfaced
-    /// so the caller can decide, rather than silently sending malformed HTML.
+    /// CSS inlining of the HTML body failed (issue #1254). `send` fails loudly
+    /// with this typed error instead of delivering a corrupted body — the
+    /// message is not sent, so callers can decide how to recover. Defensive:
+    /// with remote and file loaders disabled, `css-inline` is fully lenient and
+    /// this path is effectively unreachable, but the variant keeps the API
+    /// stable if those loaders are ever enabled.
     #[error("failed to inline CSS into HTML mail body: {0}")]
     CssInline(String),
 }
@@ -1597,9 +1606,9 @@ impl Mailer {
     ///
     /// Precedence: a per-message [`Mail::inline_css`] override wins; otherwise
     /// the [`Mailer`]'s configured [`MailConfig::inline_css`] default applies.
-    /// On inliner failure the original body is left untouched and a typed
-    /// [`MailError::CssInline`] is surfaced (rather than delivering a corrupted
-    /// body). Text bodies are never touched.
+    /// On inliner failure `send` fails loudly: a typed [`MailError::CssInline`]
+    /// is returned and the message is not delivered, rather than shipping a
+    /// corrupted body. Text bodies are never touched.
     fn apply_css_inlining(&self, mail: &mut Mail) -> Result<(), MailError> {
         let enabled = mail.inline_css.unwrap_or(self.inline_css_default);
         if !enabled {
@@ -4112,13 +4121,25 @@ mod tests {
         // inline `style="…"` on the anchor.
         let html = r#"<style>.btn{color:#fff;background:#06c}</style><a class="btn">Go</a>"#;
         let out = inline_css_html(html).expect("inlining succeeds");
+        // Inspect the `<a …>` opening tag specifically so every assertion is
+        // discriminating: `#fff`/`#06c` also appear in the retained `<style>`
+        // block, so a no-op would pass a bare `out.contains(...)`.
+        let anchor = out
+            .split("<a")
+            .nth(1)
+            .expect("an <a> tag is present in the output");
+        let anchor_open = &anchor[..anchor.find('>').expect("anchor tag closes")];
         assert!(
-            out.contains("<a") && out.contains("style=") && out.contains("#fff"),
-            "anchor must gain an inline style carrying the class rule; got: {out}"
+            anchor_open.contains("style="),
+            "anchor must gain an inline style attribute; got tag: {anchor_open}"
         );
         assert!(
-            out.contains("#06c") || out.contains("background"),
-            "background rule must be inlined too; got: {out}"
+            anchor_open.contains("#fff"),
+            "anchor's inline style must carry the color rule; got tag: {anchor_open}"
+        );
+        assert!(
+            anchor_open.contains("#06c") || anchor_open.contains("background"),
+            "anchor's inline style must carry the background rule; got tag: {anchor_open}"
         );
     }
 

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -480,7 +480,9 @@ fn unwrap_synthetic_document(doc: &str) -> String {
 ///   Because the inlinable rules are removed from the retained block, running
 ///   this again is a no-op: inlining is idempotent.
 /// - Remote/`<link>` stylesheets are never fetched (the `css-inline` network
-///   feature is not compiled in) — only embedded `<style>` CSS is inlined.
+///   feature is not compiled in) — only embedded `<style>` CSS is inlined. The
+///   `<link rel="stylesheet">` tags themselves are preserved in the body so the
+///   linked CSS still reaches clients rather than being silently dropped.
 /// - A raw *fragment* body (no `<html>`/`<body>`/doctype) stays a fragment.
 ///   `css-inline`'s document mode wraps fragment output in synthetic
 ///   `<html>`/`<head>`/`<body>` tags; those wrappers are stripped back off (see
@@ -509,6 +511,10 @@ fn inline_css_html(html: &str) -> Result<String, MailError> {
         .remove_inlined_selectors(true)
         // Never reach out to the network for `<link>`ed stylesheets.
         .load_remote_stylesheets(false)
+        // …but since we do NOT fetch them, keep the `<link rel="stylesheet">`
+        // tags in the body (dropped by default) so the linked CSS still reaches
+        // clients rather than being silently discarded from the delivered body.
+        .keep_link_tags(true)
         .build();
     // Inline in document mode. Its fragment mode would avoid the `<html>`/`<body>`
     // wrapping but drops retained `@media`/at-rules (it re-homes them to `<head>`,
@@ -4275,6 +4281,38 @@ mod tests {
         let html = r#"<p style="color:red">Hello</p><a href="/x">link</a>"#;
         let out = inline_css_html(html).expect("no-op inlining succeeds");
         assert_eq!(out, html, "no-<style> body must be returned unchanged");
+    }
+
+    #[test]
+    #[allow(
+        clippy::literal_string_with_formatting_args,
+        reason = "CSS rule braces are literal HTML, not format placeholders"
+    )]
+    fn inline_css_retains_link_stylesheet_tags() {
+        // We never fetch `<link>` stylesheets, so the `<link rel="stylesheet">`
+        // tag must survive inlining rather than being silently dropped from the
+        // delivered body — otherwise a message combining an embedded `<style>`
+        // with a linked stylesheet would lose the linked CSS. The embedded rule
+        // is still inlined onto the element.
+        let html = r#"<style>.x{color:red}</style><link rel="stylesheet" href="https://example.com/app.css"><p class="x">Hi</p>"#;
+        let out = inline_css_html(html).expect("inlining succeeds");
+        assert!(
+            out.contains("<link") && out.contains(r#"rel="stylesheet""#),
+            "the <link rel=\"stylesheet\"> tag must be preserved; got: {out}"
+        );
+        assert!(
+            out.contains("app.css"),
+            "the linked stylesheet href must be preserved; got: {out}"
+        );
+        let para = out
+            .split("<p")
+            .nth(1)
+            .expect("a <p> tag is present in the output");
+        let para_open = &para[..para.find('>').expect("paragraph tag closes")];
+        assert!(
+            para_open.contains("style=") && para_open.contains("red"),
+            "the embedded rule must still be inlined onto the paragraph; got tag: {para_open}"
+        );
     }
 
     #[test]

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -2491,7 +2491,15 @@ fn show_template_preview(state: &AppState, mailer: &str, method: &str) -> Respon
 
     match preview.render() {
         Ok(mail) => {
-            let mail = apply_preview_unsubscribe_headers(state, mailer, mail);
+            let mut mail = apply_preview_unsubscribe_headers(state, mailer, mail);
+            // Match Mailer::send: inline <style> CSS so the preview reflects what
+            // strict clients (Gmail/Outlook) actually receive. Reuses the send-time
+            // decision (per-message override vs. the mailer's inline_css_default).
+            if let Some(m) = state.extension::<Mailer>() {
+                // Dev preview: degrade gracefully on inliner error (leaves html un-inlined)
+                // rather than failing the preview; the inliner is effectively infallible here.
+                let _ = m.apply_css_inlining(&mut mail);
+            }
             let raw = render_eml(&mail);
             let parsed = parse_eml(&raw);
             html_response(render_mail_detail(&parsed, "Template preview"))
@@ -4262,6 +4270,101 @@ mod tests {
         assert!(
             anchor_open.contains("style=") && anchor_open.contains("#fff"),
             "computed styling must be carried inline so a style-stripped copy looks identical; got: {anchor_open}"
+        );
+    }
+
+    // ── Preview honours send-time CSS inlining (issue #1254) ──────────────
+
+    /// Render `show_template_preview` for a single registered preview and return
+    /// the full response body as a string. A [`Mailer`] is installed on the
+    /// state so the handler can reuse the send-time inlining decision — mirrors
+    /// the app build, where the mailer is always present before the preview
+    /// registry.
+    async fn preview_body_for(preview: MailPreview) -> String {
+        let state = crate::AppState::for_test();
+        state.insert_extension(MailPreviewRegistry::new(vec![preview]));
+        let mailer = Mailer::builder()
+            .build()
+            .expect("log-transport mailer builds");
+        state.insert_extension(mailer);
+
+        let response = show_template_preview(&state, "test", "styled");
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("preview body collects");
+        String::from_utf8(bytes.to_vec()).expect("preview body is utf-8")
+    }
+
+    /// Escaped opening `<a …>` tag of the email body as it appears in the
+    /// preview page (the email HTML is HTML-escaped into an `<iframe srcdoc>`).
+    /// Isolating the anchor keeps assertions discriminating: the colour rule
+    /// also lives in the retained/original `<style>` block.
+    fn escaped_anchor_open_tag(body: &str) -> String {
+        let after = body
+            .split("&lt;a")
+            .nth(1)
+            .expect("an <a> tag is present in the escaped preview body");
+        let open = &after[..after.find("&gt;").expect("anchor tag closes")];
+        open.to_owned()
+    }
+
+    #[tokio::test]
+    #[allow(
+        clippy::literal_string_with_formatting_args,
+        reason = "CSS rule braces are literal HTML, not format placeholders"
+    )]
+    async fn preview_inlines_style_block_when_inlining_enabled() {
+        // A preview whose Mail opts into inlining must reflect what strict
+        // clients receive: the `.btn` class rule inlined onto the anchor.
+        let preview = MailPreview::new("test", "styled", || {
+            Mail::builder()
+                .to("user@example.com")
+                .subject("Styled")
+                .html(r#"<style>.btn{color:#ff0000}</style><a class="btn">Go</a>"#)
+                .inline_css(true)
+                .build()
+                .expect("preview mail builds")
+        });
+
+        let body = preview_body_for(preview).await;
+        let anchor = escaped_anchor_open_tag(&body);
+        assert!(
+            anchor.contains("style="),
+            "preview must inline the <style> block onto the anchor; got tag: {anchor}"
+        );
+        assert!(
+            anchor.contains("#ff0000"),
+            "the .btn colour rule must be carried inline; got tag: {anchor}"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(
+        clippy::literal_string_with_formatting_args,
+        reason = "CSS rule braces are literal HTML, not format placeholders"
+    )]
+    async fn preview_leaves_style_block_raw_when_inlining_disabled() {
+        // The discriminating counterpart: with inlining off the anchor keeps no
+        // inline style and the raw `<style>` block survives untouched.
+        let preview = MailPreview::new("test", "styled", || {
+            Mail::builder()
+                .to("user@example.com")
+                .subject("Styled")
+                .html(r#"<style>.btn{color:#ff0000}</style><a class="btn">Go</a>"#)
+                .inline_css(false)
+                .build()
+                .expect("preview mail builds")
+        });
+
+        let body = preview_body_for(preview).await;
+        let anchor = escaped_anchor_open_tag(&body);
+        assert!(
+            !anchor.contains("style="),
+            "inlining is off, so the anchor must not gain an inline style; got tag: {anchor}"
+        );
+        assert!(
+            body.contains("&lt;style&gt;"),
+            "the raw <style> block must survive when inlining is off"
         );
     }
 

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -156,6 +156,17 @@ pub struct MailConfig {
     /// [`AppBuilder::mount_unsubscribe_endpoint`](crate::app::AppBuilder::mount_unsubscribe_endpoint).
     #[serde(default)]
     pub mount_unsubscribe_endpoint: bool,
+    /// Default for CSS inlining of HTML mail bodies (issue #1254).
+    ///
+    /// When `true`, every HTML body sent through a [`Mailer`] built from this
+    /// config has its `<style>` rules inlined onto matching elements as
+    /// `style="…"` attributes at send time, so it renders styled in clients
+    /// that strip `<head>`/`<style>` (Gmail, Outlook). Off by default —
+    /// existing apps are unaffected until they opt in. A per-message
+    /// [`MailBuilder::inline_css`] call overrides this default in either
+    /// direction (explicit builder value wins).
+    #[serde(default)]
+    pub inline_css: bool,
     /// SMTP settings.
     #[serde(default)]
     pub smtp: SmtpConfig,
@@ -256,6 +267,7 @@ impl Default for MailConfig {
             unsubscribe_mailto: None,
             unsubscribe_token_ttl_days: default_unsubscribe_ttl_days(),
             mount_unsubscribe_endpoint: false,
+            inline_css: false,
             smtp: SmtpConfig::default(),
         }
     }
@@ -391,6 +403,56 @@ pub fn compose_layout(layout: &str, body: &str) -> String {
     }
 }
 
+/// Whether `html` contains a `<style` tag (case-insensitive), i.e. there is any
+/// embedded stylesheet worth inlining. Allocation-free ASCII scan — the fast
+/// path for the common case of plain-text or already-inlined bodies.
+fn html_contains_style_block(html: &str) -> bool {
+    html.as_bytes()
+        .windows(6)
+        .any(|window| window.eq_ignore_ascii_case(b"<style"))
+}
+
+/// Inline the `<style>` rules of an HTML mail body onto matching elements as
+/// `style="…"` attributes, so the message renders styled in clients that strip
+/// `<head>`/`<style>` (Gmail, Outlook). See issue #1254.
+///
+/// Behavior:
+/// - Bodies with no `<style>` block are returned unchanged (fast path), so
+///   plain-text and already-fully-inlined bodies pass through byte-for-byte.
+/// - `<style>` blocks are retained, but rules that were successfully inlined are
+///   stripped from them — so what remains is exactly the un-inlinable
+///   `@media`/pseudo-class rules, which still reach clients that honor them.
+///   Because the inlinable rules are removed from the retained block, running
+///   this again is a no-op: inlining is idempotent.
+/// - Remote/`<link>` stylesheets are never fetched (the `css-inline` network
+///   feature is not compiled in) — only embedded `<style>` CSS is inlined.
+///
+/// # Errors
+///
+/// Returns [`MailError::CssInline`] if the body cannot be parsed/inlined, rather
+/// than returning a silently corrupted body.
+fn inline_css_html(html: &str) -> Result<String, MailError> {
+    // Fast path: nothing to inline. Keeps text-like, fragment, and
+    // already-inlined bodies byte-identical and makes re-inlining idempotent.
+    if !html_contains_style_block(html) {
+        return Ok(html.to_owned());
+    }
+    css_inline::CSSInliner::options()
+        // Retain `<style>` so un-inlinable rules survive…
+        .keep_style_tags(true)
+        // …including `@media`/other at-rules (dropped by default), so responsive
+        // tweaks still work in clients that honor them.
+        .keep_at_rules(true)
+        // …but drop the rules we did inline, leaving only the un-inlinable ones
+        // in the retained block (also what makes a second pass a no-op).
+        .remove_inlined_selectors(true)
+        // Never reach out to the network for `<link>`ed stylesheets.
+        .load_remote_stylesheets(false)
+        .build()
+        .inline(html)
+        .map_err(|error| MailError::CssInline(error.to_string()))
+}
+
 /// A file attached to a [`Mail`] message.
 ///
 /// Built via [`MailBuilder::attach`]. Carries raw, undecoded bytes so it
@@ -451,6 +513,16 @@ pub struct Mail {
     /// recipient regardless of prior delivery failures. `false` by default.
     #[serde(default)]
     pub ignore_suppression: bool,
+    /// Per-message override for CSS inlining (issue #1254).
+    ///
+    /// `Some(true)`/`Some(false)` force inlining on/off for this message,
+    /// overriding the [`Mailer`]'s configured default; `None` (the default)
+    /// defers to [`MailConfig::inline_css`]. Set via
+    /// [`MailBuilder::inline_css`]. Carried through a durable
+    /// [`MailDeliveryQueue`] so deferred mail inlines consistently with
+    /// immediate sends.
+    #[serde(default)]
+    pub inline_css: Option<bool>,
 }
 
 /// Stable root path for the dev mail preview UI.
@@ -599,6 +671,7 @@ pub struct MailBuilder {
     extra_headers: Vec<(String, String)>,
     attachments: Vec<MailAttachment>,
     ignore_suppression: bool,
+    inline_css: Option<bool>,
 }
 
 impl MailBuilder {
@@ -666,6 +739,26 @@ impl MailBuilder {
     #[must_use]
     pub const fn ignore_suppression(mut self) -> Self {
         self.ignore_suppression = true;
+        self
+    }
+
+    /// Force CSS inlining on or off for this message, overriding the
+    /// [`Mailer`]'s configured [`MailConfig::inline_css`] default.
+    ///
+    /// When enabled, the HTML body's `<style>` rules are inlined onto matching
+    /// elements as `style="…"` attributes at send time so the message renders
+    /// styled in clients that strip `<head>`/`<style>` (Gmail, Outlook).
+    /// Un-inlinable `@media`/pseudo-class rules are preserved in a retained
+    /// `<style>` block. Text bodies and HTML with no `<style>` block are left
+    /// untouched.
+    ///
+    /// Precedence: an explicit call here always wins over the config default —
+    /// `inline_css(false)` opts a single message out even when the environment
+    /// defaults inlining on, and `inline_css(true)` opts a single message in
+    /// when the default is off.
+    #[must_use]
+    pub const fn inline_css(mut self, enabled: bool) -> Self {
+        self.inline_css = Some(enabled);
         self
     }
 
@@ -784,6 +877,7 @@ impl MailBuilder {
             extra_headers: self.extra_headers,
             attachments: self.attachments,
             ignore_suppression: self.ignore_suppression,
+            inline_css: self.inline_css,
         })
     }
 }
@@ -820,6 +914,11 @@ pub enum MailError {
     /// [`MailBuilder::ignore_suppression`] for critical mail.
     #[error("all recipients are on the mail suppression list; nothing was sent")]
     AllRecipientsSuppressed,
+    /// CSS inlining of the HTML body failed (issue #1254). The original body is
+    /// preserved (never delivered corrupted) and this typed error is surfaced
+    /// so the caller can decide, rather than silently sending malformed HTML.
+    #[error("failed to inline CSS into HTML mail body: {0}")]
+    CssInline(String),
 }
 
 /// Escape hatch for custom transports.
@@ -1319,6 +1418,9 @@ pub struct Mailer {
     /// [`suppression`]. `None` disables the check (suppression is opt-in on a
     /// hand-built [`Mailer`]; the framework wires a default in-memory store).
     suppression: Option<Arc<dyn suppression::SuppressionStore>>,
+    /// Default for CSS inlining of HTML bodies when a message does not set its
+    /// own [`Mail::inline_css`] override. Sourced from [`MailConfig::inline_css`].
+    inline_css_default: bool,
 }
 
 impl Mailer {
@@ -1343,6 +1445,7 @@ impl Mailer {
     ) -> Result<Self, MailError> {
         let mut builder = Self::builder()
             .transport(config.transport)
+            .inline_css(config.inline_css)
             .resilience_config(resilience);
         if let Some(from) = &config.from {
             builder = builder.from(from.clone());
@@ -1368,6 +1471,7 @@ impl Mailer {
             delivery_queue: None,
             unsubscribe: None,
             suppression: None,
+            inline_css_default: false,
         }
     }
 
@@ -1439,6 +1543,13 @@ impl Mailer {
     pub async fn send(&self, mail: Mail) -> Result<(), MailError> {
         let mut mail = mail.with_defaults(&self.defaults);
 
+        // Inline `<style>` CSS into element `style="…"` attributes before
+        // transport, so every transport (SMTP, file, log, preview) delivers the
+        // inlined body and it renders styled in clients that strip
+        // `<head>`/`<style>`. Doing it here — ahead of the list-mail branch that
+        // clones per recipient — inlines exactly once regardless of path.
+        self.apply_css_inlining(&mut mail)?;
+
         // Consult the bounce/complaint suppression list *before* transport.
         // Suppressed recipients are dropped from `to` (skipped, not an error)
         // unless the message opts out via `Mail::ignore_suppression`. When every
@@ -1479,6 +1590,40 @@ impl Mailer {
             );
         }
         self.transport.send(mail).await
+    }
+
+    /// Resolve the CSS-inlining decision for a message and, when enabled, inline
+    /// its HTML body in place (issue #1254).
+    ///
+    /// Precedence: a per-message [`Mail::inline_css`] override wins; otherwise
+    /// the [`Mailer`]'s configured [`MailConfig::inline_css`] default applies.
+    /// On inliner failure the original body is left untouched and a typed
+    /// [`MailError::CssInline`] is surfaced (rather than delivering a corrupted
+    /// body). Text bodies are never touched.
+    fn apply_css_inlining(&self, mail: &mut Mail) -> Result<(), MailError> {
+        let enabled = mail.inline_css.unwrap_or(self.inline_css_default);
+        if !enabled {
+            return Ok(());
+        }
+        let Some(html) = mail.html.as_deref() else {
+            return Ok(());
+        };
+        match inline_css_html(html) {
+            Ok(inlined) => {
+                mail.html = Some(inlined);
+                Ok(())
+            }
+            Err(error) => {
+                // Leave `mail.html` as the original body (not corrupted) and make
+                // the failure loud rather than silently shipping broken HTML.
+                tracing::warn!(
+                    target: "mail",
+                    error = %error,
+                    "CSS inlining failed; HTML body left un-inlined"
+                );
+                Err(error)
+            }
+        }
     }
 
     /// Deliver a list mail recipient-by-recipient, applying suppression and
@@ -1718,6 +1863,7 @@ pub struct MailerBuilder {
     smtp: Option<SmtpConfig>,
     delivery_queue: Option<Arc<dyn MailDeliveryQueue>>,
     resilience_config: Option<Arc<crate::config::ResilienceConfig>>,
+    inline_css: bool,
 }
 
 impl Default for MailerBuilder {
@@ -1730,6 +1876,7 @@ impl Default for MailerBuilder {
             smtp: None,
             delivery_queue: None,
             resilience_config: None,
+            inline_css: false,
         }
     }
 }
@@ -1791,6 +1938,15 @@ impl MailerBuilder {
         self
     }
 
+    /// Set the default for CSS inlining of HTML bodies (issue #1254). Applied to
+    /// every message that does not carry its own [`MailBuilder::inline_css`]
+    /// override. Mirrors [`MailConfig::inline_css`].
+    #[must_use]
+    pub const fn inline_css(mut self, enabled: bool) -> Self {
+        self.inline_css = enabled;
+        self
+    }
+
     /// Build the mailer.
     ///
     /// # Errors
@@ -1823,6 +1979,7 @@ impl MailerBuilder {
             delivery_queue: self.delivery_queue,
             unsubscribe: None,
             suppression: None,
+            inline_css_default: self.inline_css,
         })
     }
 }
@@ -3939,6 +4096,165 @@ pub mod db_suppression {
 mod tests {
     use super::*;
 
+    // ── CSS inlining (issue #1254) ────────────────────────────────────────
+
+    #[test]
+    fn html_contains_style_block_is_case_insensitive() {
+        assert!(html_contains_style_block("<STYLE>.a{}</STYLE>"));
+        assert!(html_contains_style_block("<p>x</p><style>.a{}</style>"));
+        assert!(!html_contains_style_block("<p style=\"color:red\">x</p>"));
+        assert!(!html_contains_style_block("just plain text, no tags"));
+    }
+
+    #[test]
+    fn inline_css_applies_class_style_to_anchor() {
+        // AC1: a `<style>` block + a class-styled `<a>` yields an equivalent
+        // inline `style="…"` on the anchor.
+        let html = r#"<style>.btn{color:#fff;background:#06c}</style><a class="btn">Go</a>"#;
+        let out = inline_css_html(html).expect("inlining succeeds");
+        assert!(
+            out.contains("<a") && out.contains("style=") && out.contains("#fff"),
+            "anchor must gain an inline style carrying the class rule; got: {out}"
+        );
+        assert!(
+            out.contains("#06c") || out.contains("background"),
+            "background rule must be inlined too; got: {out}"
+        );
+    }
+
+    #[test]
+    fn inline_css_applies_class_style_to_table() {
+        // AC7: a class-styled `<table>` gains the expected inline style.
+        let html = r#"<style>.wrap{width:600px;background:#eee}</style><table class="wrap"><tr><td>x</td></tr></table>"#;
+        let out = inline_css_html(html).expect("inlining succeeds");
+        let table = out
+            .split("<table")
+            .nth(1)
+            .expect("a <table> tag is present in the output");
+        let table_open = &table[..table.find('>').expect("table tag closes")];
+        assert!(
+            table_open.contains("style=") && table_open.contains("600px"),
+            "table must carry an inline style with the width rule; got tag: {table_open}"
+        );
+    }
+
+    #[test]
+    fn inline_css_passthrough_without_style_block_is_byte_identical() {
+        // AC3: bodies already fully inlined (no `<style>`) pass through unchanged.
+        let html = r#"<p style="color:red">Hello</p><a href="/x">link</a>"#;
+        let out = inline_css_html(html).expect("no-op inlining succeeds");
+        assert_eq!(out, html, "no-<style> body must be returned unchanged");
+    }
+
+    #[test]
+    #[allow(
+        clippy::literal_string_with_formatting_args,
+        reason = "CSS rule braces are literal HTML, not format placeholders"
+    )]
+    fn inline_css_is_idempotent() {
+        // AC3: inlining twice equals inlining once.
+        let html = r#"<style>.btn{color:#fff}p{margin:0}</style><a class="btn">Go</a><p>hi</p>"#;
+        let once = inline_css_html(html).expect("first pass");
+        let twice = inline_css_html(&once).expect("second pass");
+        assert_eq!(once, twice, "inlining must be idempotent");
+    }
+
+    #[test]
+    #[allow(
+        clippy::literal_string_with_formatting_args,
+        reason = "CSS rule braces are literal HTML, not format placeholders"
+    )]
+    fn inline_css_retains_uninlinable_media_queries() {
+        // AC5: `@media` rules that cannot be inlined survive in a retained
+        // `<style>` block rather than being dropped.
+        let html = r#"<style>.btn{color:#fff}@media (max-width:600px){.btn{color:#000}}</style><a class="btn">Go</a>"#;
+        let out = inline_css_html(html).expect("inlining succeeds");
+        assert!(
+            out.contains("@media") && out.contains("max-width"),
+            "the @media rule must be preserved in a retained <style> block; got: {out}"
+        );
+        // And the inlinable rule was still applied to the element.
+        assert!(
+            out.contains("<a") && out.contains("style="),
+            "the inlinable rule must still be inlined onto the anchor; got: {out}"
+        );
+    }
+
+    #[test]
+    fn inline_css_stripped_style_renders_same_computed_styling() {
+        // AC7: a `<style>`-stripped copy of the inlined output renders the same
+        // computed styling — i.e. the visual styling lives in the inline
+        // `style="…"` attribute, independent of any `<head>`/`<style>` the
+        // client might drop.
+        let html = r#"<style>.btn{color:#fff;padding:8px}</style><a class="btn">Go</a>"#;
+        let inlined = inline_css_html(html).expect("inlining succeeds");
+
+        // Strip every <style>…</style> block (what Gmail/Outlook effectively do).
+        let mut stripped = String::new();
+        let mut rest = inlined.as_str();
+        while let Some(start) = rest.to_ascii_lowercase().find("<style") {
+            stripped.push_str(&rest[..start]);
+            let after = &rest[start..];
+            let end = after
+                .to_ascii_lowercase()
+                .find("</style>")
+                .map_or(after.len(), |e| e + "</style>".len());
+            rest = &after[end..];
+        }
+        stripped.push_str(rest);
+
+        // The anchor's inline style survives the strip, so styling is unchanged.
+        let anchor = stripped
+            .split("<a")
+            .nth(1)
+            .expect("anchor present after stripping <style>");
+        let anchor_open = &anchor[..anchor.find('>').expect("anchor closes")];
+        assert!(
+            anchor_open.contains("style=") && anchor_open.contains("#fff"),
+            "computed styling must be carried inline so a style-stripped copy looks identical; got: {anchor_open}"
+        );
+    }
+
+    #[test]
+    fn mail_builder_inline_css_sets_per_message_override() {
+        let on = Mail::builder()
+            .to("a@example.com")
+            .subject("s")
+            .html("<p>x</p>")
+            .inline_css(true)
+            .build()
+            .expect("valid mail");
+        assert_eq!(on.inline_css, Some(true));
+
+        let off = Mail::builder()
+            .to("a@example.com")
+            .subject("s")
+            .html("<p>x</p>")
+            .inline_css(false)
+            .build()
+            .expect("valid mail");
+        assert_eq!(off.inline_css, Some(false));
+
+        let unset = Mail::builder()
+            .to("a@example.com")
+            .subject("s")
+            .html("<p>x</p>")
+            .build()
+            .expect("valid mail");
+        assert_eq!(
+            unset.inline_css, None,
+            "unset builder must defer to the mailer/config default"
+        );
+    }
+
+    #[test]
+    fn mail_config_inline_css_defaults_off() {
+        assert!(
+            !MailConfig::default().inline_css,
+            "inlining must default off so existing apps are unaffected"
+        );
+    }
+
     // ── Attachments (issue #1256): pinning tests ──────────────────────────
     //
     // These prove attachment support introduces zero byte-for-byte regression
@@ -4347,6 +4663,7 @@ mod tests {
                 bytes: b"x".to_vec(),
             }],
             ignore_suppression: false,
+            inline_css: None,
         };
         let eml = render_eml(&mail);
         assert!(
@@ -4376,6 +4693,7 @@ mod tests {
             )],
             attachments: Vec::new(),
             ignore_suppression: false,
+            inline_css: None,
         };
         let eml = render_eml(&mail);
         assert!(
@@ -4410,6 +4728,7 @@ mod tests {
                 bytes: b"x".to_vec(),
             }],
             ignore_suppression: false,
+            inline_css: None,
         };
         let eml = render_eml(&mail);
         assert!(eml.contains("Content-Type: application/octet-stream"));
@@ -4433,6 +4752,7 @@ mod tests {
                 bytes: b"x".to_vec(),
             }],
             ignore_suppression: false,
+            inline_css: None,
         };
         let eml = render_eml(&mail);
         assert!(eml.contains("filename*=UTF-8''"));
@@ -4581,6 +4901,7 @@ mod tests {
                     bytes: b"x".to_vec(),
                 }],
                 ignore_suppression: false,
+                inline_css: None,
             };
             let message = lettre_message(&mail).expect("lettre message should build");
             let formatted = String::from_utf8_lossy(&message.formatted()).into_owned();
@@ -4616,6 +4937,7 @@ mod tests {
                 bytes: b"x".to_vec(),
             }],
             ignore_suppression: false,
+            inline_css: None,
         };
         let err = lettre_message(&mail).expect_err("invalid content type should error");
         assert!(matches!(err, MailError::InvalidMessage(_)));

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -412,6 +412,61 @@ fn html_contains_style_block(html: &str) -> bool {
         .any(|window| window.eq_ignore_ascii_case(b"<style"))
 }
 
+/// Whether `html` looks like a full HTML *document* — it carries a `<!doctype`,
+/// `<html`, or `<body` marker — rather than a bare fragment. Autumn permits raw
+/// fragment bodies when no layout wraps them, so [`inline_css_html`] uses this to
+/// decide whether to strip the synthetic document wrappers `css-inline` adds. A
+/// user-authored `<body>` is therefore recognized as a document and its
+/// structure is left untouched. Allocation-free case-insensitive ASCII scan.
+fn html_is_full_document(html: &str) -> bool {
+    let bytes = html.as_bytes();
+    bytes.windows(5).any(|w| w.eq_ignore_ascii_case(b"<html"))
+        || bytes.windows(5).any(|w| w.eq_ignore_ascii_case(b"<body"))
+        || bytes
+            .windows(9)
+            .any(|w| w.eq_ignore_ascii_case(b"<!doctype"))
+}
+
+/// Strip the synthetic `<html>`/`<head>`/`<body>` wrappers that `css-inline`'s
+/// document mode adds around fragment input, reconstructing the fragment.
+///
+/// [`inline_css_html`] always inlines in document mode because `css-inline`'s
+/// fragment mode drops retained `@media`/at-rules (it re-homes them to `<head>`,
+/// which a fragment lacks). Document mode instead wraps a fragment body in
+/// synthetic structural tags. This is only ever called on output we produced by
+/// document-inlining a body we already determined was a *fragment*, so those
+/// wrappers are always `css-inline`'s own, never user-authored.
+///
+/// `css-inline` (via `html5ever`) serializes a document as a canonical,
+/// attribute-free `<html><head>…</head><body>…</body></html>`, so exact-literal
+/// matching is safe. The result is the `<head>` contents (the retained `<style>`
+/// block carrying un-inlinable `@media`/pseudo rules, per AC5) followed by the
+/// `<body>` contents — preserving the original fragment ordering of `<style>`
+/// before body content. If the expected shape is absent, the input is returned
+/// unchanged rather than risking corruption.
+fn unwrap_synthetic_document(doc: &str) -> String {
+    // html5ever emits these exact byte sequences, lowercased and without
+    // attributes or whitespace, for the wrappers it synthesizes.
+    let inner = doc
+        .strip_prefix("<html>")
+        .and_then(|rest| rest.strip_suffix("</html>"))
+        .unwrap_or(doc);
+    let (head, after_head) = match inner.strip_prefix("<head>") {
+        Some(rest) => match rest.split_once("</head>") {
+            Some(split) => split,
+            // Malformed/unexpected shape: don't risk corrupting the body.
+            None => return doc.to_owned(),
+        },
+        None => ("", inner),
+    };
+    let body = after_head
+        .strip_prefix("<body>")
+        .map_or(after_head, |rest| {
+            rest.strip_suffix("</body>").unwrap_or(rest)
+        });
+    format!("{head}{body}")
+}
+
 /// Inline the `<style>` rules of an HTML mail body onto matching elements as
 /// `style="…"` attributes, so the message renders styled in clients that strip
 /// `<head>`/`<style>` (Gmail, Outlook). See issue #1254.
@@ -426,6 +481,12 @@ fn html_contains_style_block(html: &str) -> bool {
 ///   this again is a no-op: inlining is idempotent.
 /// - Remote/`<link>` stylesheets are never fetched (the `css-inline` network
 ///   feature is not compiled in) — only embedded `<style>` CSS is inlined.
+/// - A raw *fragment* body (no `<html>`/`<body>`/doctype) stays a fragment.
+///   `css-inline`'s document mode wraps fragment output in synthetic
+///   `<html>`/`<head>`/`<body>` tags; those wrappers are stripped back off (see
+///   [`unwrap_synthetic_document`]) so opting into inlining never promotes a
+///   fragment MIME body into a full document. Full-document bodies keep their
+///   structure unchanged.
 ///
 /// # Errors
 ///
@@ -437,7 +498,7 @@ fn inline_css_html(html: &str) -> Result<String, MailError> {
     if !html_contains_style_block(html) {
         return Ok(html.to_owned());
     }
-    css_inline::CSSInliner::options()
+    let inliner = css_inline::CSSInliner::options()
         // Retain `<style>` so un-inlinable rules survive…
         .keep_style_tags(true)
         // …including `@media`/other at-rules (dropped by default), so responsive
@@ -448,7 +509,14 @@ fn inline_css_html(html: &str) -> Result<String, MailError> {
         .remove_inlined_selectors(true)
         // Never reach out to the network for `<link>`ed stylesheets.
         .load_remote_stylesheets(false)
-        .build()
+        .build();
+    // Inline in document mode. Its fragment mode would avoid the `<html>`/`<body>`
+    // wrapping but drops retained `@media`/at-rules (it re-homes them to `<head>`,
+    // which a fragment lacks) — breaking AC5. So document-inline unconditionally,
+    // then, for a fragment body, strip the synthetic wrappers back off so the
+    // MIME body stays a fragment. Full documents keep their structure as-is.
+    let is_fragment = !html_is_full_document(html);
+    let rendered = inliner
         .inline(html)
         // Defensive / effectively unreachable: with remote-stylesheet loading
         // disabled above and no file loader configured, `css-inline` only errors
@@ -456,7 +524,12 @@ fn inline_css_html(html: &str) -> Result<String, MailError> {
         // malformed CSS/HTML (garbage `<style>` bodies inline to an unchanged
         // fragment, never an error). We still surface the typed error rather than
         // `expect`ing, to keep the API stable if those loaders are ever enabled.
-        .map_err(|error| MailError::CssInline(error.to_string()))
+        .map_err(|error| MailError::CssInline(error.to_string()))?;
+    Ok(if is_fragment {
+        unwrap_synthetic_document(&rendered)
+    } else {
+        rendered
+    })
 }
 
 /// A file attached to a [`Mail`] message.
@@ -4235,6 +4308,95 @@ mod tests {
         assert!(
             out.contains("<a") && out.contains("style="),
             "the inlinable rule must still be inlined onto the anchor; got: {out}"
+        );
+    }
+
+    #[test]
+    #[allow(
+        clippy::literal_string_with_formatting_args,
+        reason = "CSS rule braces are literal HTML, not format placeholders"
+    )]
+    fn inline_css_fragment_body_stays_a_fragment() {
+        // A no-layout FRAGMENT body must stay a fragment after inlining:
+        // opting into CSS inlining must not promote it into a full document by
+        // introducing synthetic `<html>`/`<head>`/`<body>` wrappers. The class
+        // rule is still inlined onto the element. See issue #1254 / PR #1681.
+        let html = r#"<style>.x{color:red}</style><p class="x">Hi</p>"#;
+        let out = inline_css_html(html).expect("inlining succeeds");
+        assert!(
+            !out.to_ascii_lowercase().contains("<html")
+                && !out.to_ascii_lowercase().contains("<body")
+                && !out.to_ascii_lowercase().contains("<head"),
+            "fragment body must not gain document wrappers; got: {out}"
+        );
+        let para = out
+            .split("<p")
+            .nth(1)
+            .expect("a <p> tag is present in the output");
+        let para_open = &para[..para.find('>').expect("paragraph tag closes")];
+        assert!(
+            para_open.contains("style=") && para_open.contains("red"),
+            "the class rule must be inlined onto the paragraph; got tag: {para_open}"
+        );
+    }
+
+    #[test]
+    #[allow(
+        clippy::literal_string_with_formatting_args,
+        reason = "CSS rule braces are literal HTML, not format placeholders"
+    )]
+    fn inline_css_fragment_body_retains_media_query_without_wrapping() {
+        // AC5 + fragment: a FRAGMENT body with an un-inlinable `@media` rule
+        // must stay a fragment (no synthetic wrappers) yet still carry the
+        // retained `@media` block. Document-mode inlining hoists that retained
+        // `<style>` into the synthetic `<head>`; the unwrap must fold it back
+        // into the fragment rather than dropping it. See PR #1681.
+        let html = r#"<style>.btn{color:#fff}@media (max-width:600px){.btn{color:#000}}</style><a class="btn">Go</a>"#;
+        let out = inline_css_html(html).expect("inlining succeeds");
+        assert!(
+            !out.to_ascii_lowercase().contains("<html")
+                && !out.to_ascii_lowercase().contains("<body")
+                && !out.to_ascii_lowercase().contains("<head"),
+            "fragment body must not gain document wrappers; got: {out}"
+        );
+        assert!(
+            out.contains("@media") && out.contains("max-width"),
+            "the retained @media block must survive the unwrap; got: {out}"
+        );
+        let anchor = out
+            .split("<a")
+            .nth(1)
+            .expect("an <a> tag is present in the output");
+        let anchor_open = &anchor[..anchor.find('>').expect("anchor tag closes")];
+        assert!(
+            anchor_open.contains("style=") && anchor_open.contains("#fff"),
+            "the inlinable rule must still be inlined onto the anchor; got tag: {anchor_open}"
+        );
+    }
+
+    #[test]
+    #[allow(
+        clippy::literal_string_with_formatting_args,
+        reason = "CSS rule braces are literal HTML, not format placeholders"
+    )]
+    fn inline_css_full_document_body_stays_a_document() {
+        // A FULL-DOCUMENT body keeps document-mode handling: its authored
+        // `<html>`/`<body>` structure survives and the class rule is inlined.
+        let html = r#"<html><head><style>.x{color:red}</style></head><body><p class="x">Hi</p></body></html>"#;
+        let out = inline_css_html(html).expect("inlining succeeds");
+        assert!(
+            out.to_ascii_lowercase().contains("<html")
+                && out.to_ascii_lowercase().contains("<body"),
+            "full-document body must retain its structure; got: {out}"
+        );
+        let para = out
+            .split("<p")
+            .nth(1)
+            .expect("a <p> tag is present in the output");
+        let para_open = &para[..para.find('>').expect("paragraph tag closes")];
+        assert!(
+            para_open.contains("style=") && para_open.contains("red"),
+            "the class rule must be inlined onto the paragraph; got tag: {para_open}"
         );
     }
 

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -515,6 +515,12 @@ fn inline_css_html(html: &str) -> Result<String, MailError> {
         // tags in the body (dropped by default) so the linked CSS still reaches
         // clients rather than being silently discarded from the delivered body.
         .keep_link_tags(true)
+        // Also emit the presentational HTML `width`/`height` attributes (from the
+        // inlined CSS dimensions) on `table`/`td`/`th`/`img` — both default off.
+        // Outlook-family clients ignore CSS `width`/`height`, so without these
+        // attributes those elements lose their intended sizing there.
+        .apply_width_attributes(true)
+        .apply_height_attributes(true)
         .build();
     // Inline in document mode. Its fragment mode would avoid the `<html>`/`<body>`
     // wrapping but drops retained `@media`/at-rules (it re-homes them to `<head>`,
@@ -4272,6 +4278,52 @@ mod tests {
         assert!(
             table_open.contains("style=") && table_open.contains("600px"),
             "table must carry an inline style with the width rule; got tag: {table_open}"
+        );
+    }
+
+    #[test]
+    #[allow(
+        clippy::literal_string_with_formatting_args,
+        reason = "CSS rule braces are literal HTML, not format placeholders"
+    )]
+    fn inline_css_emits_outlook_width_height_attributes() {
+        // Outlook-family clients ignore CSS `width`/`height`, so the inliner must
+        // also emit the presentational HTML `width`/`height` attributes on the
+        // supported elements (`table`/`td`/`th`/`img`) — not only the CSS `style=`.
+        let html = r#"<style>table{width:600px}img{height:40px}</style><table><tr><td><img src="/x.png"></td></tr></table>"#;
+        let out = inline_css_html(html).expect("inlining succeeds");
+
+        let table_open = {
+            let table = out
+                .split("<table")
+                .nth(1)
+                .expect("a <table> tag is present in the output");
+            &table[..table.find('>').expect("table tag closes")]
+        };
+        // Discriminating: the CSS style must be present AND the HTML attribute too.
+        assert!(
+            table_open.contains("style=") && table_open.contains("600px"),
+            "table must still carry the inline CSS width; got tag: {table_open}"
+        );
+        assert!(
+            table_open.contains(r#"width="600""#),
+            "table must gain the presentational HTML width attribute Outlook needs; got tag: {table_open}"
+        );
+
+        let img_open = {
+            let img = out
+                .split("<img")
+                .nth(1)
+                .expect("an <img> tag is present in the output");
+            &img[..img.find('>').expect("img tag closes")]
+        };
+        assert!(
+            img_open.contains("style=") && img_open.contains("40px"),
+            "img must still carry the inline CSS height; got tag: {img_open}"
+        );
+        assert!(
+            img_open.contains(r#"height="40""#),
+            "img must gain the presentational HTML height attribute Outlook needs; got tag: {img_open}"
         );
     }
 

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -524,9 +524,11 @@ pub struct Mail {
     /// `Some(true)`/`Some(false)` force inlining on/off for this message,
     /// overriding the [`Mailer`]'s configured default; `None` (the default)
     /// defers to [`MailConfig::inline_css`]. Set via
-    /// [`MailBuilder::inline_css`]. Carried through a durable
-    /// [`MailDeliveryQueue`] so deferred mail inlines consistently with
-    /// immediate sends.
+    /// [`MailBuilder::inline_css`]. On the deferred/durable path a `None` is
+    /// frozen to the originating mailer's default before the message is
+    /// persisted to a [`MailDeliveryQueue`], so the enqueued job is
+    /// self-describing and deferred mail inlines consistently with an immediate
+    /// send even when a different worker consumes the queue.
     #[serde(default)]
     pub inline_css: Option<bool>,
 }
@@ -1635,6 +1637,26 @@ impl Mailer {
         }
     }
 
+    /// Freeze this mailer's CSS-inlining default onto a message before it is
+    /// handed to a durable [`MailDeliveryQueue`] for deferred delivery (issue
+    /// #1254).
+    ///
+    /// A worker that later dequeues the persisted job resolves
+    /// [`Mail::inline_css`] against ITS OWN mailer's default via
+    /// [`apply_css_inlining`](Self::apply_css_inlining), which may differ from
+    /// (or be off by default relative to) the originating mailer. Recording the
+    /// originating decision here makes the persisted job self-describing, so
+    /// deferred mail inlines consistently with an immediate send. Only `None`
+    /// is resolved — explicit `Some(true)`/`Some(false)` per-message overrides
+    /// are preserved. The body itself is left un-inlined so the single inline
+    /// pass still happens once at the consumer's `send()`, keeping delivery
+    /// idempotent and avoiding a bloated persisted body.
+    const fn freeze_inline_css_default(&self, mail: &mut Mail) {
+        if mail.inline_css.is_none() {
+            mail.inline_css = Some(self.inline_css_default);
+        }
+    }
+
     /// Deliver a list mail recipient-by-recipient, applying suppression and
     /// per-recipient RFC 8058 headers.
     async fn send_list_mail(
@@ -1752,7 +1774,13 @@ impl Mailer {
         if self.transport.is_disabled() {
             return Ok(());
         }
-        let mail = mail.with_defaults(&self.defaults);
+        let mut mail = mail.with_defaults(&self.defaults);
+        // Resolve the CSS-inlining default onto the message once, at the top of
+        // the deferred path, so BOTH the durable-queue branch (persisted for a
+        // possibly-different worker to consume) and the in-process fallback
+        // branch carry the originating mailer's decision. Only `None` is frozen;
+        // explicit per-message overrides are preserved (issue #1254).
+        self.freeze_inline_css_default(&mut mail);
 
         // When inside a db.tx, push the spawn as an after-commit callback so
         // the mail only fires if the transaction commits successfully.
@@ -1809,7 +1837,8 @@ impl Mailer {
         if self.transport.is_disabled() {
             return Ok(());
         }
-        let mail = mail.with_defaults(&self.defaults);
+        let mut mail = mail.with_defaults(&self.defaults);
+        self.freeze_inline_css_default(&mut mail);
         self.spawn_mail_delivery(mail)
     }
 
@@ -6095,7 +6124,99 @@ mod tests {
             .expect("queue should receive within 1s")
             .expect("queue should receive the mail");
 
-        assert_eq!(received, mail);
+        // The deferred path freezes the originating mailer's CSS-inlining default
+        // onto the message before enqueue (issue #1254); this mailer defaults
+        // inlining off, so the enqueued job carries `Some(false)` where the
+        // source had `None`. Everything else (notably attachments) is untouched.
+        let mut expected = mail;
+        expected.inline_css = Some(false);
+        assert_eq!(received, expected);
+    }
+
+    #[tokio::test]
+    async fn deferred_enqueue_freezes_originating_inline_css_default() {
+        // A mailer whose config defaults CSS inlining ON must record that
+        // decision on the persisted job when the message carries no explicit
+        // override, so a worker consuming the durable queue (with a possibly
+        // different/off default) still inlines. Only the flag is frozen — the
+        // body is left un-inlined so the single inline pass happens once at the
+        // consumer's send() (issue #1254).
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Mail>();
+        let mailer = Mailer::builder()
+            .inline_css(true)
+            .delivery_queue(CapturingQueue { tx })
+            .build()
+            .expect("mailer should build");
+
+        let mail = Mail::builder()
+            .to("user@example.com")
+            .subject("Hi")
+            .html(
+                "<html><head><style>p { color: red; }</style></head><body><p>hi</p></body></html>",
+            )
+            .build()
+            .expect("mail should build");
+        assert_eq!(mail.inline_css, None, "sample relies on the mailer default");
+
+        mailer
+            .try_deliver_later(mail)
+            .expect("scheduling onto the queue should succeed");
+
+        let received = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("queue should receive within 1s")
+            .expect("queue should receive the mail");
+
+        assert_eq!(
+            received.inline_css,
+            Some(true),
+            "the originating mailer's inlining default must be frozen onto the enqueued job"
+        );
+        assert!(
+            received
+                .html
+                .as_deref()
+                .expect("html body")
+                .contains("<style>"),
+            "the body must be left un-inlined at enqueue time; inlining happens once at the consumer's send()"
+        );
+    }
+
+    #[tokio::test]
+    async fn deferred_enqueue_preserves_explicit_inline_css_override() {
+        // An explicit per-message `inline_css(false)` opt-out must survive the
+        // durable-queue handoff and never be clobbered by the mailer default.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Mail>();
+        let mailer = Mailer::builder()
+            .inline_css(true)
+            .delivery_queue(CapturingQueue { tx })
+            .build()
+            .expect("mailer should build");
+
+        let mail = Mail::builder()
+            .to("user@example.com")
+            .subject("Hi")
+            .html(
+                "<html><head><style>p { color: red; }</style></head><body><p>hi</p></body></html>",
+            )
+            .inline_css(false)
+            .build()
+            .expect("mail should build");
+
+        mailer
+            .try_deliver_later(mail)
+            .expect("scheduling onto the queue should succeed");
+
+        let received = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("queue should receive within 1s")
+            .expect("queue should receive the mail");
+
+        assert_eq!(
+            received.inline_css,
+            Some(false),
+            "an explicit per-message override must be preserved through the queue, not overwritten by the mailer default"
+        );
     }
 
     #[tokio::test]

--- a/autumn/tests/integration/mail_css_inline.rs
+++ b/autumn/tests/integration/mail_css_inline.rs
@@ -1,0 +1,242 @@
+//! End-to-end coverage for CSS inlining of HTML email (issue #1254): a
+//! `<style>` block is transformed into element `style="…"` attributes on the
+//! delivered message, opt-in works both on the builder and via `MailConfig`,
+//! per-message overrides beat the config default in both directions, and text
+//! bodies / no-`<style>` bodies are left untouched.
+#![cfg(feature = "mail")]
+// CSS rule braces like `.btn{color:#fff}` in these HTML literals look like
+// format placeholders to this lint, but they are literal test fixtures.
+#![allow(clippy::literal_string_with_formatting_args)]
+
+use std::sync::{Arc, Mutex};
+
+use autumn_web::mail::{Mail, MailConfig, MailError, MailTransport, Mailer, Transport};
+
+/// A `<style>` block plus a class-styled anchor — the canonical inlining input.
+const STYLED_HTML: &str = r#"<style>.btn{color:#fff;background:#06c}</style><a class="btn">Go</a>"#;
+
+/// Transport double that captures the most recently delivered [`Mail`] so tests
+/// can inspect the exact body that reached the wire (after inlining).
+#[derive(Clone, Default)]
+struct CapturingTransport {
+    last: Arc<Mutex<Option<Mail>>>,
+}
+
+impl CapturingTransport {
+    fn last_html(&self) -> String {
+        self.last
+            .lock()
+            .expect("lock")
+            .as_ref()
+            .expect("a mail was delivered")
+            .html
+            .clone()
+            .expect("delivered mail has an html body")
+    }
+
+    fn last_text(&self) -> Option<String> {
+        self.last
+            .lock()
+            .expect("lock")
+            .as_ref()
+            .expect("a mail was delivered")
+            .text
+            .clone()
+    }
+}
+
+impl MailTransport for CapturingTransport {
+    fn send<'a>(
+        &'a self,
+        mail: Mail,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), MailError>> + Send + 'a>>
+    {
+        Box::pin(async move {
+            *self.last.lock().expect("lock") = Some(mail);
+            Ok(())
+        })
+    }
+}
+
+fn styled_mail() -> Mail {
+    Mail::builder()
+        .from("app@example.com")
+        .to("user@example.com")
+        .subject("Hi")
+        .html(STYLED_HTML)
+        .build()
+        .expect("valid mail")
+}
+
+/// The anchor gained an inline `style` carrying the class rule, and the inlined
+/// selector was stripped from the retained `<style>` block.
+fn assert_inlined(html: &str) {
+    assert!(
+        html.contains("style=") && html.contains("#fff"),
+        "expected the anchor to carry an inline style with the class rule; got: {html}"
+    );
+    assert!(
+        !html.contains(".btn{color") && !html.contains(".btn {"),
+        "expected the inlined `.btn` selector to be stripped from the <style> block; got: {html}"
+    );
+}
+
+/// The body was delivered verbatim: the class rule is still only in the
+/// `<style>` block and the anchor carries no inline style.
+fn assert_not_inlined(html: &str) {
+    assert!(
+        html.contains(".btn{color:#fff;background:#06c}"),
+        "expected the raw <style> rule to be delivered unchanged; got: {html}"
+    );
+    assert!(
+        html.contains(r#"<a class="btn">Go</a>"#),
+        "expected the anchor to be delivered without an inline style; got: {html}"
+    );
+}
+
+// ── AC1 + AC2 (builder): explicit opt-in inlines at send ──────────────────────
+
+#[tokio::test]
+async fn builder_opt_in_inlines_html_at_send() {
+    let transport = CapturingTransport::default();
+    let mailer = Mailer::with_transport(transport.clone());
+
+    let mail = Mail::builder()
+        .from("app@example.com")
+        .to("user@example.com")
+        .subject("Hi")
+        .html(STYLED_HTML)
+        .inline_css(true)
+        .build()
+        .expect("valid mail");
+    mailer.send(mail).await.expect("send succeeds");
+
+    assert_inlined(&transport.last_html());
+}
+
+// ── Default off: unaffected unless opted in ───────────────────────────────────
+
+#[tokio::test]
+async fn default_off_leaves_html_untouched() {
+    let transport = CapturingTransport::default();
+    let mailer = Mailer::with_transport(transport.clone());
+
+    mailer.send(styled_mail()).await.expect("send succeeds");
+
+    assert_not_inlined(&transport.last_html());
+}
+
+// ── AC3: text bodies are never inlined ────────────────────────────────────────
+
+#[tokio::test]
+async fn text_body_is_never_inlined() {
+    let transport = CapturingTransport::default();
+    let mailer = Mailer::with_transport(transport.clone());
+
+    // A text part that *contains* a `<style>`-looking string must pass through
+    // untouched even with inlining forced on.
+    let mail = Mail::builder()
+        .from("app@example.com")
+        .to("user@example.com")
+        .subject("Hi")
+        .text("<style>.btn{color:#fff}</style> literal text")
+        .inline_css(true)
+        .build()
+        .expect("valid mail");
+    mailer.send(mail).await.expect("send succeeds");
+
+    assert_eq!(
+        transport.last_text().as_deref(),
+        Some("<style>.btn{color:#fff}</style> literal text"),
+        "text bodies must never be inlined"
+    );
+}
+
+// ── AC2 (config) + AC "delivered message": config default inlines via MIME ────
+
+#[tokio::test]
+async fn config_default_on_inlines_delivered_mime() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config = MailConfig {
+        transport: Transport::File,
+        file_dir: dir.path().to_path_buf(),
+        inline_css: true,
+        ..MailConfig::default()
+    };
+    let mailer = Mailer::from_config(&config).expect("mailer from config");
+
+    mailer.send(styled_mail()).await.expect("send succeeds");
+
+    let eml = read_only_eml(dir.path());
+    assert!(
+        eml.contains("text/html"),
+        "the delivered MIME must contain the html part; got: {eml}"
+    );
+    assert_inlined(&eml);
+}
+
+// ── AC2: per-message override beats the config default, both directions ───────
+
+#[tokio::test]
+async fn per_message_opt_out_overrides_config_default_on() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config = MailConfig {
+        transport: Transport::File,
+        file_dir: dir.path().to_path_buf(),
+        inline_css: true, // environment defaults inlining ON
+        ..MailConfig::default()
+    };
+    let mailer = Mailer::from_config(&config).expect("mailer from config");
+
+    // This single message opts OUT.
+    let mail = Mail::builder()
+        .from("app@example.com")
+        .to("user@example.com")
+        .subject("Hi")
+        .html(STYLED_HTML)
+        .inline_css(false)
+        .build()
+        .expect("valid mail");
+    mailer.send(mail).await.expect("send succeeds");
+
+    assert_not_inlined(&read_only_eml(dir.path()));
+}
+
+#[tokio::test]
+async fn per_message_opt_in_overrides_config_default_off() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config = MailConfig {
+        transport: Transport::File,
+        file_dir: dir.path().to_path_buf(),
+        // Environment default OFF (MailConfig::inline_css defaults to false).
+        ..MailConfig::default()
+    };
+    assert!(
+        !config.inline_css,
+        "config default must be off for this test"
+    );
+    let mailer = Mailer::from_config(&config).expect("mailer from config");
+
+    // This single message opts IN.
+    let mail = Mail::builder()
+        .from("app@example.com")
+        .to("user@example.com")
+        .subject("Hi")
+        .html(STYLED_HTML)
+        .inline_css(true)
+        .build()
+        .expect("valid mail");
+    mailer.send(mail).await.expect("send succeeds");
+
+    assert_inlined(&read_only_eml(dir.path()));
+}
+
+/// Read the single `.eml` file the file transport wrote into `dir`.
+fn read_only_eml(dir: &std::path::Path) -> String {
+    let entry = std::fs::read_dir(dir)
+        .expect("read mail dir")
+        .filter_map(Result::ok)
+        .find(|e| e.path().extension().is_some_and(|ext| ext == "eml"))
+        .expect("exactly one .eml was written");
+    std::fs::read_to_string(entry.path()).expect("read .eml")
+}

--- a/autumn/tests/integration/mail_css_inline.rs
+++ b/autumn/tests/integration/mail_css_inline.rs
@@ -231,6 +231,47 @@ async fn per_message_opt_in_overrides_config_default_off() {
     assert_inlined(&read_only_eml(dir.path()));
 }
 
+// ── AC4: malformed / non-document bodies are handled gracefully ───────────────
+
+/// With inlining forced ON, a garbage `<style>` body and a non-document HTML
+/// fragment must not error or panic: `send` returns `Ok` and a non-empty body
+/// is delivered. `css-inline` with remote and file loaders disabled is fully
+/// lenient, so malformed CSS/HTML never surfaces `MailError::CssInline`.
+#[tokio::test]
+async fn malformed_body_with_inlining_on_is_delivered_gracefully() {
+    // A `<style>` block full of nonsense CSS, followed by a bare text fragment
+    // (not a well-formed document).
+    let garbage = "<style>@@@!!!{{{color:::}}}</style>plain fragment";
+    // A `<style>` tag that is never closed.
+    let unclosed = r#"<style>.x{color:#123 <a class="x">dangling"#;
+
+    for body in [garbage, unclosed] {
+        let transport = CapturingTransport::default();
+        let mailer = Mailer::with_transport(transport.clone());
+
+        let mail = Mail::builder()
+            .from("app@example.com")
+            .to("user@example.com")
+            .subject("Hi")
+            .html(body)
+            .inline_css(true)
+            .build()
+            .expect("valid mail");
+
+        // Must not panic and must not error — inlining is lenient on bad input.
+        mailer
+            .send(mail)
+            .await
+            .expect("send succeeds on a malformed body");
+
+        let delivered = transport.last_html();
+        assert!(
+            !delivered.is_empty(),
+            "a non-empty body must still be delivered for input: {body:?}"
+        );
+    }
+}
+
 /// Read the single `.eml` file the file transport wrote into `dir`.
 fn read_only_eml(dir: &std::path::Path) -> String {
     let entry = std::fs::read_dir(dir)

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -87,6 +87,8 @@ mod load_shed;
 #[cfg(feature = "mail")]
 mod mail;
 #[cfg(feature = "mail")]
+mod mail_css_inline;
+#[cfg(feature = "mail")]
 mod mail_layout;
 #[cfg(feature = "mail")]
 mod mail_macro;

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -575,6 +575,41 @@ key_prefix = "myapp:webhooks:replay"
 
 Read `docs/guide/signed-webhooks.md` and `examples/signed-webhooks/`.
 
+## Mail CSS inlining — render styled in Gmail/Outlook (unreleased — trunk-dev)
+
+Gmail strips `<style>` in many contexts and Outlook (Word engine) ignores
+`<head>`/`<style>` and most external CSS, so email authored with a stylesheet
+arrives **unstyled**. The decades-old fix is to inline CSS onto elements at send
+time. Autumn does this for you (issue #1254).
+
+- **Author with a `<style>` block + classes**, then opt in — either per message
+  or per environment:
+  ```rust
+  // Per message (wins over the config default in both directions):
+  Mail::builder()
+      .to(to).subject("Welcome")
+      .html(r#"<style>.btn{color:#fff;background:#06c}</style><a class="btn">Go</a>"#)
+      .inline_css(true)      // ← rewrites .btn onto the <a> as style="…" at send
+      .build()?
+  ```
+  ```toml
+  # Per environment — default it on for every mailer:
+  [mail]
+  inline_css = true
+  ```
+- **Precedence:** an explicit `MailBuilder::inline_css(true|false)` always beats
+  the `mail.inline_css` default (`inline_css(false)` opts one message out of an
+  environment that defaults on). Default is **off** — existing apps are
+  unaffected until they opt in.
+- **What's preserved:** un-inlinable `@media`/pseudo-class rules stay in a
+  retained `<style>` block; text parts and bodies with no `<style>` pass through
+  unchanged; inlining is idempotent (running it twice equals once).
+- **Failure is loud, not corrupting:** on an inliner error the original body is
+  kept and a typed `MailError::CssInline` is surfaced rather than delivering
+  malformed HTML.
+- `autumn generate mailer` scaffolds this end to end (a `<style>` template + a
+  mailer that calls `.inline_css(true)`).
+
 ## Mail suppression — stop emailing bounced addresses (unreleased — trunk-dev)
 
 Autumn *detects* delivery failure (inbound bounce/complaint webhooks) **and**

--- a/skills/generate/SKILL.md
+++ b/skills/generate/SKILL.md
@@ -209,6 +209,14 @@ Next steps:
    .mail_previews(mail_previews![UserMailer])
 
 3. Preview at: http://localhost:3000/_autumn/mail (dev mode only)
+
+4. CSS inlining (issue #1254): the scaffolded `templates/mailers/<name>.html`
+   ships a `<style>` block with CSS classes, and the generated mailer calls
+   `.inline_css(true)`. At send time those `<style>` rules are rewritten onto the
+   elements as `style="…"` attributes so the mail renders styled in Gmail/Outlook
+   (which strip `<head>`/`<style>`). Author with classes; keep `.inline_css(true)`.
+   To default inlining on for every mailer instead, set `mail.inline_css = true`
+   in autumn.toml and drop the per-message call.
 ```
 
 ### task


### PR DESCRIPTION
Closes #1254

## Before / After

**Before.** HTML email templates authored with a `<style>` block and CSS classes rendered fine in a browser preview but arrived unstyled in strict clients. Gmail and Outlook strip or ignore `<style>` blocks, so class-based styling (`.btn { color:#fff }` + `<a class="btn">`) was silently dropped on delivery.

**After.** CSS is inlined to `style="..."` attributes at send time, so `<style>`-block templates render in strict clients like Gmail and Outlook. The behavior is **default off** so existing apps are unaffected, and is **opt-in**:

- per message via `MailBuilder::inline_css(true)`,
- per environment via `MailConfig::inline_css` (equivalently `MailerBuilder::inline_css`).

A per-message override wins in both directions: `inline_css(false)` opts a single message out even when the environment default is on, and `inline_css(true)` opts a single message in when the default is off.

## How

- **Single choke point.** Inlining happens in one place inside `Mailer::send` (`apply_css_inlining`), so every transport (SMTP, file, log, preview, custom) gets identical treatment.
- **Precedence.** `mail.inline_css.unwrap_or(self.inline_css_default)` — per-message override first, then the configured default.
- **Text parts untouched.** Only the HTML body is ever inlined; text bodies pass through verbatim even when they contain `<style>`-looking strings.
- **`@media` and pseudo-class rules retained.** The `<style>` block is kept (`keep_style_tags`, `keep_at_rules`); rules that were successfully inlined are stripped from it (`remove_inlined_selectors`), leaving only the un-inlinable rules for clients that honor them.
- **Idempotent.** Because inlined selectors are removed from the retained block, a second pass is a no-op. Bodies with no `<style>` block take a fast path and are returned byte-for-byte.
- **Fail loud, never corrupt.** If inlining ever fails, `send` returns a typed `MailError::CssInline` and the message is not delivered — the body is never silently corrupted.

## New dependency justification (`css-inline`)

- Added with `default-features = false`, which **drops the reqwest / remote-stylesheet and local-file loaders**. Combined with `load_remote_stylesheets(false)`, this means **no new network surface** — only embedded `<style>` CSS is inlined, nothing is fetched. It is gated behind the existing `mail` feature.
- Chosen over writing an in-house CSS cascade/specificity engine: correct CSS inlining requires a real parser plus cascade/specificity resolution, which is a large, bug-prone surface to maintain. `css-inline` is a mature, widely-used crate that solves exactly this.
- Side benefit: with those loaders compiled out, `css-inline` is fully lenient toward malformed CSS/HTML and only errors on IO/network paths that are not present — so the `MailError::CssInline` path is defensive and effectively unreachable, but retained to keep the API stable.

## AC audit

| # | Acceptance criterion | Status | Evidence |
|---|----------------------|--------|----------|
| AC1 | `<style>` + class-styled element yields an equivalent inline `style="..."` | PASS | unit `inline_css_applies_class_style_to_anchor`; e2e `builder_opt_in_inlines_html_at_send` |
| AC2 | Opt-in on builder and config; per-message override wins both directions | PASS | e2e `config_default_on_inlines_delivered_mime`, `per_message_opt_in_overrides_config_default_off`, `per_message_opt_out_overrides_config_default_on`; unit `mail_builder_inline_css_sets_per_message_override`, `mail_config_inline_css_defaults_off` |
| AC3 | Text parts and no-`<style>` bodies pass through unchanged | PASS | e2e `text_body_is_never_inlined`; unit `inline_css_passthrough_without_style_block_is_byte_identical` |
| AC4 | Malformed / non-document bodies handled gracefully (no panic, still delivered) | PASS | e2e `malformed_body_with_inlining_on_is_delivered_gracefully` (garbage `<style>` + unclosed `<style>`) |
| AC5 | Un-inlinable `@media` / pseudo-class rules retained | PASS | unit `inline_css_retains_uninlinable_media_queries` |
| AC6 | Inlining is idempotent (re-running is a no-op) | PASS | unit `inline_css_is_idempotent` |
| AC7 | Works for block elements such as `<table>` | PASS | unit `inline_css_applies_class_style_to_table` |

## Tests

- `autumn-web` mail lib unit tests (incl. `inline_css_*`) — green.
- `autumn-web` integration `mail_css_inline` (7 tests) — green.
- `autumn-cli` generator `mailer` tests (6 tests) — green (`autumn generate mailer` scaffolds a `<style>`-block template + `.inline_css(true)`).
- `cargo clippy --workspace --all-targets --features mail -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPkoiVtotUx5ma8w2H9nAx)_