### PR TITLE
Auto-load .env in dev/test and scaffold .env.example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **config:** Autumn now auto-loads a project-root `.env` file, feeding its
+  values into the highest (`AUTUMN_*` environment-variable) configuration layer.
+  It is not a new precedence tier: a real shell environment variable of the same
+  name always wins, so `.env` only fills keys that are still unset. Files load in
+  order `.env` → `.env.local` → `.env.{profile}` → `.env.{profile}.local`, and
+  earlier files (and real env vars) win. Auto-loading runs in the `dev` and
+  `test` profiles and is skipped in `prod` unless `AUTUMN_DOTENV=1` (conversely
+  `AUTUMN_DOTENV=0` disables it anywhere). A malformed `.env` fails loudly at
+  startup rather than being silently ignored. `autumn new` now scaffolds a
+  documented `.env.example` and gitignores `.env`, `.env.local`, and
+  `.env.*.local` (while keeping `.env.example` and committable `.env.{profile}`
+  files tracked). `autumn doctor` gained a `dotenv` check that warns when
+  `.env.example` is present without a `.env`, or when a `.env` exists but is not
+  gitignored (issue #1051).
 - **generator:** `autumn new` now generates a `README.md` at the project root
   (listed in the "Created …" output) with explicit prerequisites and a
   golden-path quickstart — configure the `[database]` block in `autumn.toml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.env.*.local` (while keeping `.env.example` and committable `.env.{profile}`
   files tracked). `autumn doctor` gained a `dotenv` check that warns when
   `.env.example` is present without a `.env`, or when a `.env` exists but is not
-  gitignored (issue #1051).
+  gitignored (issue #1051). The environment/profile selectors (`AUTUMN_ENV`,
+  `AUTUMN_PROFILE`, `AUTUMN_IS_DEBUG`) are intentionally NOT read from `.env` —
+  a `.env` file must not be able to switch the active profile, so it can never
+  flip `autumn migrate down` / `autumn db drop` / `autumn db reset` onto a
+  production target after their real-env (dev) guards have already passed; set
+  those in your shell or via `--profile`. The `dotenv` doctor check also
+  surfaces an ungitignored secret file even when `.env.example` exists without a
+  `.env`, so the copy-the-template hint can no longer hide a committable
+  `.env.local`.
 - **generator:** `autumn new` now generates a `README.md` at the project root
   (listed in the "Created …" output) with explicit prerequisites and a
   golden-path quickstart — configure the `[database]` block in `autumn.toml`

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -579,7 +579,7 @@ fn start_server(
     // makes a bare `DATABASE_URL` visible to the child. A malformed `.env`
     // fails loudly. Applied BEFORE the explicit `.env(...)` calls below so those
     // win on any key overlap.
-    let dotenv_vars = match autumn_web::dotenv::resolve_dotenv_for_cwd() {
+    let dotenv_vars = match autumn_web::dotenv::resolve_process_dotenv() {
         Ok(v) => v,
         Err(e) => {
             eprintln!("  \u{274C} .env: {e}");
@@ -653,7 +653,20 @@ fn classify_change(
     kind: DebouncedEventKind,
     custom_watch_dirs: &[CustomWatchDir],
 ) -> ChangeEffect {
-    if !matches!(kind, DebouncedEventKind::Any) || should_ignore_path(path) {
+    if !matches!(kind, DebouncedEventKind::Any) {
+        return ChangeEffect::Ignore;
+    }
+
+    // A root-level dotenv file the config loader reads (`.env`, `.env.local`,
+    // `.env.<profile>`, `.env.<profile>.local`) must restart the server so an
+    // edited `.env` takes effect — even though `should_ignore_path` would
+    // otherwise discard it as a dotfile. Checked before that ignore so the
+    // dotenv exception wins, while all other dotfiles stay ignored.
+    if is_watched_dotenv_file(path) {
+        return ChangeEffect::RestartOnly;
+    }
+
+    if should_ignore_path(path) {
         return ChangeEffect::Ignore;
     }
 
@@ -715,6 +728,61 @@ fn classify_change(
     }
 
     ChangeEffect::Ignore
+}
+
+/// Editor/tooling temp or backup suffixes (the final `.`-segment) that must not
+/// trigger a restart even when they decorate a dotenv filename — e.g. a vim swap
+/// file `.env.swp` or a backup `.env.tmp`. `.env.example` is a committed
+/// template the loader never reads, so it is excluded too.
+const DOTENV_NON_LOADED_SUFFIXES: &[&str] =
+    &["swp", "swo", "swx", "swpx", "tmp", "bak", "orig", "example"];
+
+/// Whether `name` is a dotenv file the config loader actually reads: `.env`,
+/// `.env.local`, `.env.<profile>`, or `.env.<profile>.local`.
+///
+/// Editor/backup decorations (`.env.swp`, `.env~`, `.env.tmp`, …) are rejected
+/// so a save-in-progress swap file does not cause a spurious restart.
+fn is_dotenv_loader_filename(name: &str) -> bool {
+    if name == ".env" {
+        return true;
+    }
+    // Must be `.env.<something>`; a bare `.env~`/`.env.swp`-style backup that
+    // lacks the `.env.` prefix is rejected here, and a trailing `~` backup
+    // (e.g. `.env.local~`) is rejected explicitly.
+    let Some(rest) = name.strip_prefix(".env.") else {
+        return false;
+    };
+    if rest.is_empty() || name.ends_with('~') {
+        return false;
+    }
+    let last_segment = rest.rsplit('.').next().unwrap_or(rest);
+    !DOTENV_NON_LOADED_SUFFIXES.contains(&last_segment)
+}
+
+/// Whether `path` is a project-root dotenv file the loader reads (see
+/// [`is_dotenv_loader_filename`]).
+///
+/// Scoped to root-level files: any dotenv-named file living under a dotted
+/// directory (e.g. `.git/.env`) or `target/` is rejected, mirroring
+/// [`should_ignore_path`] so only the genuine project-root `.env*` files are
+/// un-ignored.
+fn is_watched_dotenv_file(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    if !is_dotenv_loader_filename(name) {
+        return false;
+    }
+    path.parent().is_none_or(|parent| {
+        parent.components().all(|component| {
+            if let std::path::Component::Normal(part) = component {
+                let part = part.to_string_lossy();
+                part != "target" && !part.starts_with('.')
+            } else {
+                true
+            }
+        })
+    })
 }
 
 fn should_ignore_path(path: &Path) -> bool {
@@ -1105,6 +1173,70 @@ mod tests {
             classify_change(Path::new("autumn-dev.toml"), DebouncedEventKind::Any, &[]),
             ChangeEffect::RestartOnly
         );
+    }
+
+    #[test]
+    fn dotenv_change_requires_restart_only() {
+        for name in [".env", ".env.local", ".env.dev", ".env.production.local"] {
+            assert_eq!(
+                classify_change(Path::new(name), DebouncedEventKind::Any, &[]),
+                ChangeEffect::RestartOnly,
+                "{name} should restart the dev server",
+            );
+        }
+    }
+
+    #[test]
+    fn dotenv_editor_temp_files_are_ignored() {
+        // Editor swap/backup files must not trigger spurious restarts.
+        for name in [
+            ".env.swp",
+            ".env.swo",
+            ".env~",
+            ".env.local~",
+            ".env.tmp",
+            ".env.bak",
+        ] {
+            assert_eq!(
+                classify_change(Path::new(name), DebouncedEventKind::Any, &[]),
+                ChangeEffect::Ignore,
+                "{name} should not restart the dev server",
+            );
+        }
+    }
+
+    #[test]
+    fn dotenv_change_ignored_for_non_any_event() {
+        // A dotenv edit still only restarts on a settled `Any` event.
+        assert_eq!(
+            classify_change(Path::new(".env"), DebouncedEventKind::AnyContinuous, &[]),
+            ChangeEffect::Ignore
+        );
+    }
+
+    #[test]
+    fn nested_dotenv_under_hidden_dir_is_ignored() {
+        // Only root-level dotenv files are un-ignored; `.git/.env` stays ignored.
+        assert_eq!(
+            classify_change(Path::new(".git/.env"), DebouncedEventKind::Any, &[]),
+            ChangeEffect::Ignore
+        );
+    }
+
+    #[test]
+    fn is_watched_dotenv_file_classifies_variants() {
+        assert!(is_watched_dotenv_file(Path::new(".env")));
+        assert!(is_watched_dotenv_file(Path::new(".env.local")));
+        assert!(is_watched_dotenv_file(Path::new(".env.dev")));
+        assert!(is_watched_dotenv_file(Path::new(".env.dev.local")));
+        // Root-level file behind an absolute project path still matches.
+        assert!(is_watched_dotenv_file(Path::new("/home/alice/app/.env")));
+        // Non-loaded / decorated names do not.
+        assert!(!is_watched_dotenv_file(Path::new(".env.swp")));
+        assert!(!is_watched_dotenv_file(Path::new(".env.example")));
+        assert!(!is_watched_dotenv_file(Path::new("env")));
+        // A dotenv-named file under a dotted directory is not root-level.
+        assert!(!is_watched_dotenv_file(Path::new(".git/.env")));
     }
 
     #[test]

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -571,7 +571,24 @@ fn start_server(
     show_config: bool,
 ) -> Option<Child> {
     eprintln!("  Starting server...\n");
+
+    // Resolve `.env` fresh right before each spawn so a hot-reload restart
+    // picks up an edited `.env`. Values are injected explicitly into the child
+    // process (rather than mutating this process's environment); the child also
+    // self-loads via the config overlay, so this is belt-and-suspenders and
+    // makes a bare `DATABASE_URL` visible to the child. A malformed `.env`
+    // fails loudly. Applied BEFORE the explicit `.env(...)` calls below so those
+    // win on any key overlap.
+    let dotenv_vars = match autumn_web::dotenv::resolve_dotenv_for_cwd() {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("  \u{274C} .env: {e}");
+            std::process::exit(1);
+        }
+    };
+
     let mut command = Command::new(binary);
+    command.envs(dotenv_vars);
     // Inherit stdio so tracing output (including --show-config) is visible.
     // Previously used Stdio::null(), but server logs are valuable during dev.
     command.stdout(Stdio::inherit()).stderr(Stdio::inherit());

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2815,7 +2815,14 @@ fn resolve_dotenv_state() -> (bool, bool, bool) {
 fn gitignore_covers_dotenv(contents: &str) -> bool {
     contents.lines().any(|line| {
         let entry = line.trim();
+        if entry.starts_with('#') || entry.is_empty() {
+            return false;
+        }
         matches!(entry, ".env" | ".env*" | ".env.*" | "/.env" | "*.env")
+            || entry.ends_with("/.env")
+            || entry.ends_with("/.env*")
+            || entry.ends_with("/.env.*")
+            || entry.ends_with("/*.env")
     })
 }
 
@@ -5034,6 +5041,14 @@ redirect_uri = "http://localhost/callback"
         assert!(gitignore_covers_dotenv("  .env.*  \n"));
         assert!(!gitignore_covers_dotenv("/target\n.env.example\n"));
         assert!(!gitignore_covers_dotenv(""));
+        // Recursive-glob style entries must also count as coverage.
+        assert!(gitignore_covers_dotenv("**/.env\n"));
+        assert!(gitignore_covers_dotenv("**/.env*\n"));
+        assert!(gitignore_covers_dotenv("**/.env.*\n"));
+        // A bare `.env.example` line still does not cover `.env`.
+        assert!(!gitignore_covers_dotenv(".env.example\n"));
+        // Comment and blank lines are ignored.
+        assert!(!gitignore_covers_dotenv("# .env\n\n"));
     }
 
     #[test]

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2498,7 +2498,7 @@ pub fn run(opts: DoctorOptions) {
     let auth_extractor_mounted = resolve_auth_extractor_mounted();
     let compression_enabled = resolve_compression_enabled();
     let proxy_conflict_data = resolve_proxy_conflict_data();
-    let (dotenv_has_example, dotenv_has_env, dotenv_gitignored) = resolve_dotenv_state();
+    let (dotenv_has_example, dotenv_has_env, dotenv_uncovered) = resolve_dotenv_state();
 
     // ── Phase 2: build tasks in display order ────────────────────────────────
     let mut tasks: Vec<Task> = Vec::new();
@@ -2699,7 +2699,7 @@ pub fn run(opts: DoctorOptions) {
     // 12b. Local-dev `.env` handling (warn on `.env.example` without `.env`,
     //      or a present-but-ungitignored `.env`).
     tasks.push(Box::new(move || {
-        check_dotenv_impl(dotenv_has_example, dotenv_has_env, dotenv_gitignored)
+        check_dotenv_impl(dotenv_has_example, dotenv_has_env, &dotenv_uncovered)
     }));
 
     // 13. System-test browser (warn if missing; not all projects use system tests)
@@ -2799,43 +2799,140 @@ pub fn check_compression_impl(compression_enabled: bool, is_production: bool) ->
 
 /// Resolve `.env` filesystem state for [`check_dotenv_impl`].
 ///
-/// Returns `(has_env_example, has_env, env_gitignored)`. A `.env` is treated as
-/// gitignored when any trimmed `.gitignore` line equals `.env` or is a glob
-/// that covers it (`.env*` / `*.env`). Note that `.env.*` does NOT cover the
-/// root `.env` (it only matches `.env.local` etc.), so it is not counted.
-fn resolve_dotenv_state() -> (bool, bool, bool) {
+/// Returns `(has_env_example, has_env, uncovered_secret_files)`, where the last
+/// element lists every always-secret dotenv file present in the project root
+/// (`.env`, `.env.local`, and any `.env.<profile>.local`) that the project's
+/// `.gitignore` does NOT cover. Committable `.env.<profile>` (non-local) files
+/// are intentionally excluded from the secret set — they follow the Vite/Next
+/// convention of being safe to commit — so doctor never flags them.
+fn resolve_dotenv_state() -> (bool, bool, Vec<String>) {
     let has_env_example = std::path::Path::new(".env.example").exists();
     let has_env = std::path::Path::new(".env").exists();
-    let env_gitignored = std::fs::read_to_string(".gitignore")
-        .map(|contents| gitignore_covers_dotenv(&contents))
-        .unwrap_or(false);
-    (has_env_example, has_env, env_gitignored)
+    let gitignore = std::fs::read_to_string(".gitignore").unwrap_or_default();
+    let uncovered = present_secret_dotenv_files(std::path::Path::new("."))
+        .into_iter()
+        .filter(|name| !gitignore_covers(&gitignore, name))
+        .collect();
+    (has_env_example, has_env, uncovered)
 }
 
-/// Whether a `.gitignore` body ignores a root `.env` file.
-fn gitignore_covers_dotenv(contents: &str) -> bool {
+/// Enumerate the always-secret dotenv files present in `dir`: the root `.env`,
+/// `.env.local`, and any `.env.<profile>.local`. Returned sorted for stable
+/// output. Committable `.env.<profile>` (non-local) files are excluded — see
+/// [`is_secret_dotenv_filename`].
+fn present_secret_dotenv_files(dir: &std::path::Path) -> Vec<String> {
+    let mut files = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.filter_map(Result::ok) {
+            if !entry.path().is_file() {
+                continue;
+            }
+            if let Some(name) = entry.file_name().to_str()
+                && is_secret_dotenv_filename(name)
+            {
+                files.push(name.to_owned());
+            }
+        }
+    }
+    files.sort();
+    files
+}
+
+/// Whether `name` is an always-secret dotenv file the loader can auto-load:
+/// `.env`, `.env.local`, or a `.env.<profile>.local` variant.
+///
+/// A non-local `.env.<profile>` (e.g. `.env.dev`) is committable by convention
+/// and returns `false`, as does the `.env.example` template.
+fn is_secret_dotenv_filename(name: &str) -> bool {
+    // Everything after the mandatory `.env` prefix.
+    let Some(rest) = name.strip_prefix(".env") else {
+        return false;
+    };
+    match rest {
+        // Bare `.env` and the root `.env.local` are always secret.
+        "" | ".local" => true,
+        // `.env.<profile>.local` — a per-profile local override. `rest` here is
+        // `.<profile>.local`; require a leading `.`, a `local` final segment,
+        // and at least two `.` separators so `<profile>` is a real segment
+        // (excludes committable non-local `.env.<profile>` files).
+        _ => {
+            rest.starts_with('.')
+                && rest.rsplit('.').next() == Some("local")
+                && rest.matches('.').count() >= 2
+        }
+    }
+}
+
+/// Whether a `.gitignore` body ignores a project-root file named `filename`.
+///
+/// Git-ignore semantics, restricted to the cases needed for root-level dotenv
+/// files: comment (`#…`), blank, and negation (`!…`) lines are skipped; every
+/// other line is treated as a glob matched against the file's basename, where
+/// `*` matches any run of non-`/` characters (including empty). An optional
+/// leading `**/` (match in any directory) then an optional leading `/` (anchor
+/// to the repository root) are accepted and stripped before matching. A pattern
+/// that still contains a `/` after stripping those prefixes — or ends in `/`
+/// (directory-only) — is a path/dir pattern that cannot match a bare root-level
+/// file and never counts as coverage.
+fn gitignore_covers(contents: &str, filename: &str) -> bool {
     contents.lines().any(|line| {
         let entry = line.trim();
-        if entry.starts_with('#') || entry.is_empty() {
+        if entry.is_empty() || entry.starts_with('#') || entry.starts_with('!') {
             return false;
         }
-        matches!(entry, ".env" | ".env*" | "/.env" | "*.env")
-            || entry.ends_with("/.env")
-            || entry.ends_with("/.env*")
-            || entry.ends_with("/*.env")
+        let pattern = entry.strip_prefix("**/").unwrap_or(entry);
+        let pattern = pattern.strip_prefix('/').unwrap_or(pattern);
+        if pattern.ends_with('/') || pattern.contains('/') {
+            return false;
+        }
+        glob_matches_basename(pattern, filename)
     })
+}
+
+/// Match a basename glob against `text`, anchored at both ends. The only special
+/// character is `*`, which matches any run of characters (including empty).
+fn glob_matches_basename(pattern: &str, text: &str) -> bool {
+    let p: Vec<char> = pattern.chars().collect();
+    let t: Vec<char> = text.chars().collect();
+    // Iterative wildcard match with backtracking on the most recent `*`.
+    let (mut pi, mut ti) = (0_usize, 0_usize);
+    let mut star: Option<usize> = None;
+    let mut star_ti = 0_usize;
+    while ti < t.len() {
+        if pi < p.len() && p[pi] == t[ti] {
+            pi += 1;
+            ti += 1;
+        } else if pi < p.len() && p[pi] == '*' {
+            star = Some(pi);
+            star_ti = ti;
+            pi += 1;
+        } else if let Some(s) = star {
+            pi = s + 1;
+            star_ti += 1;
+            ti = star_ti;
+        } else {
+            return false;
+        }
+    }
+    while pi < p.len() && p[pi] == '*' {
+        pi += 1;
+    }
+    pi == p.len()
 }
 
 /// Check that project-root `.env` handling is set up safely.
 ///
 /// - `.env.example` present but no `.env` → Warn (developer likely needs to
 ///   copy the template).
-/// - `.env` present but not gitignored → Warn (risk of committing secrets).
+/// - Any always-secret dotenv file (`.env`, `.env.local`, `.env.<profile>.local`)
+///   present but NOT gitignore-covered → Warn, naming the offending file(s).
 /// - otherwise → Pass.
+///
+/// Warn-only by design (never Fail), consistent with the skill doc.
 pub fn check_dotenv_impl(
     has_env_example: bool,
     has_env: bool,
-    env_gitignored: bool,
+    uncovered_secret_files: &[String],
 ) -> CheckResult {
     if has_env_example && !has_env {
         return CheckResult {
@@ -2845,14 +2942,17 @@ pub fn check_dotenv_impl(
             hint: Some("Copy `.env.example` to `.env` and fill in local values"),
         };
     }
-    if has_env && !env_gitignored {
+    if !uncovered_secret_files.is_empty() {
         return CheckResult {
             name: "dotenv",
             status: CheckStatus::Warn,
-            detail: Some(
-                "`.env` is present but not gitignored — you risk committing secrets".into(),
+            detail: Some(format!(
+                "{} present but not gitignored — you risk committing secrets",
+                uncovered_secret_files.join(", ")
+            )),
+            hint: Some(
+                "Add your local .env files to .gitignore (e.g. `.env`, `.env.local`, `.env.*.local`)",
             ),
-            hint: Some("Add `.env` to .gitignore"),
         };
     }
     CheckResult {
@@ -4986,7 +5086,7 @@ redirect_uri = "http://localhost/callback"
 
     #[test]
     fn dotenv_warns_when_example_present_without_env() {
-        let result = check_dotenv_impl(true, false, false);
+        let result = check_dotenv_impl(true, false, &[]);
         assert_eq!(result.name, "dotenv");
         assert!(
             matches!(result.status, CheckStatus::Warn),
@@ -4998,7 +5098,23 @@ redirect_uri = "http://localhost/callback"
 
     #[test]
     fn dotenv_warns_when_env_present_but_not_gitignored() {
-        let result = check_dotenv_impl(true, true, false);
+        let result = check_dotenv_impl(true, true, &[".env".to_owned()]);
+        assert_eq!(result.name, "dotenv");
+        assert!(
+            matches!(result.status, CheckStatus::Warn),
+            "expected Warn, got {:?}",
+            result.status
+        );
+        let detail = result.detail.as_deref().unwrap();
+        assert!(detail.contains("not gitignored"), "got: {detail:?}");
+        assert!(detail.contains(".env"), "got: {detail:?}");
+    }
+
+    #[test]
+    fn dotenv_warns_when_env_local_present_but_not_gitignored() {
+        // A `.env.local` with no root `.env` must still warn: the loader reads
+        // it and it is always secret.
+        let result = check_dotenv_impl(false, false, &[".env.local".to_owned()]);
         assert_eq!(result.name, "dotenv");
         assert!(
             matches!(result.status, CheckStatus::Warn),
@@ -5006,15 +5122,31 @@ redirect_uri = "http://localhost/callback"
             result.status
         );
         assert!(
-            result.detail.as_deref().unwrap().contains("not gitignored"),
+            result.detail.as_deref().unwrap().contains(".env.local"),
+            "detail should name the offending file: {:?}",
+            result.detail
+        );
+    }
+
+    #[test]
+    fn dotenv_warns_when_profile_local_present_but_not_gitignored() {
+        let result = check_dotenv_impl(false, false, &[".env.dev.local".to_owned()]);
+        assert!(
+            matches!(result.status, CheckStatus::Warn),
+            "expected Warn, got {:?}",
+            result.status
+        );
+        assert!(
+            result.detail.as_deref().unwrap().contains(".env.dev.local"),
             "got: {:?}",
             result.detail
         );
     }
 
     #[test]
-    fn dotenv_passes_when_env_present_and_gitignored() {
-        let result = check_dotenv_impl(true, true, true);
+    fn dotenv_passes_when_all_present_secret_files_gitignored() {
+        // No uncovered secret files → Pass, even with a root `.env` present.
+        let result = check_dotenv_impl(true, true, &[]);
         assert_eq!(result.name, "dotenv");
         assert!(
             matches!(result.status, CheckStatus::Pass),
@@ -5025,7 +5157,7 @@ redirect_uri = "http://localhost/callback"
 
     #[test]
     fn dotenv_passes_when_nothing_configured() {
-        let result = check_dotenv_impl(false, false, false);
+        let result = check_dotenv_impl(false, false, &[]);
         assert_eq!(result.name, "dotenv");
         assert!(
             matches!(result.status, CheckStatus::Pass),
@@ -5035,23 +5167,49 @@ redirect_uri = "http://localhost/callback"
     }
 
     #[test]
-    fn gitignore_covers_dotenv_matches_common_globs() {
-        assert!(gitignore_covers_dotenv("/target\n.env\n"));
-        assert!(gitignore_covers_dotenv(".env*\n"));
-        assert!(gitignore_covers_dotenv("*.env\n"));
-        assert!(gitignore_covers_dotenv("/.env\n"));
-        // `.env.*` matches `.env.local` etc. but NOT the root `.env`, so a
-        // gitignore that only lists `.env.*` must count as NOT covering `.env`.
-        assert!(!gitignore_covers_dotenv("  .env.*  \n"));
-        assert!(!gitignore_covers_dotenv("/target\n.env.example\n"));
-        assert!(!gitignore_covers_dotenv(""));
-        // Recursive-glob style entries must also count as coverage.
-        assert!(gitignore_covers_dotenv("**/.env\n"));
-        assert!(gitignore_covers_dotenv("**/.env*\n"));
-        // A bare `.env.example` line still does not cover `.env`.
-        assert!(!gitignore_covers_dotenv(".env.example\n"));
-        // Comment and blank lines are ignored.
-        assert!(!gitignore_covers_dotenv("# .env\n\n"));
+    fn is_secret_dotenv_filename_classifies_local_vs_committable() {
+        assert!(is_secret_dotenv_filename(".env"));
+        assert!(is_secret_dotenv_filename(".env.local"));
+        assert!(is_secret_dotenv_filename(".env.dev.local"));
+        assert!(is_secret_dotenv_filename(".env.production.local"));
+        // Committable per-profile (non-local) files are NOT secret.
+        assert!(!is_secret_dotenv_filename(".env.dev"));
+        assert!(!is_secret_dotenv_filename(".env.production"));
+        // The template is not itself a secret.
+        assert!(!is_secret_dotenv_filename(".env.example"));
+        assert!(!is_secret_dotenv_filename("env.local"));
+    }
+
+    #[test]
+    fn gitignore_covers_truth_table() {
+        // `.env` covers `.env` but NOT `.env.local`.
+        assert!(gitignore_covers(".env\n", ".env"));
+        assert!(!gitignore_covers(".env\n", ".env.local"));
+        // `.env.*` covers `.env.local` but NOT `.env`.
+        assert!(gitignore_covers(".env.*\n", ".env.local"));
+        assert!(!gitignore_covers(".env.*\n", ".env"));
+        // `.env*` covers both.
+        assert!(gitignore_covers(".env*\n", ".env"));
+        assert!(gitignore_covers(".env*\n", ".env.local"));
+        // `*.local` and `.env.*.local` cover `.env.dev.local`.
+        assert!(gitignore_covers("*.local\n", ".env.dev.local"));
+        assert!(gitignore_covers(".env.*.local\n", ".env.dev.local"));
+        // `.env.example` covers neither `.env` nor `.env.local`.
+        assert!(!gitignore_covers(".env.example\n", ".env"));
+        assert!(!gitignore_covers(".env.example\n", ".env.local"));
+        // `**/.env` covers `.env`.
+        assert!(gitignore_covers("**/.env\n", ".env"));
+        // Leading `/` anchor and surrounding whitespace.
+        assert!(gitignore_covers("/target\n.env\n", ".env"));
+        assert!(gitignore_covers("  .env  \n", ".env"));
+        // Comment, blank, and negation lines never count as coverage.
+        assert!(!gitignore_covers("# .env\n\n", ".env"));
+        assert!(!gitignore_covers("!.env\n", ".env"));
+        assert!(!gitignore_covers("", ".env"));
+        // A path pattern in a subdirectory does not cover a root-level file.
+        assert!(!gitignore_covers("config/.env\n", ".env"));
+        // A directory-only pattern does not cover a regular file.
+        assert!(!gitignore_covers(".env/\n", ".env"));
     }
 
     #[test]

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2922,10 +2922,13 @@ fn glob_matches_basename(pattern: &str, text: &str) -> bool {
 
 /// Check that project-root `.env` handling is set up safely.
 ///
-/// - `.env.example` present but no `.env` → Warn (developer likely needs to
-///   copy the template).
 /// - Any always-secret dotenv file (`.env`, `.env.local`, `.env.<profile>.local`)
 ///   present but NOT gitignore-covered → Warn, naming the offending file(s).
+///   This security finding takes priority: it is surfaced even when
+///   `.env.example` exists without a root `.env` (so the copy-the-template hint
+///   can never hide an ungitignored, committable secret file).
+/// - `.env.example` present but no `.env` → Warn (developer likely needs to
+///   copy the template).
 /// - otherwise → Pass.
 ///
 /// Warn-only by design (never Fail), consistent with the skill doc.
@@ -2934,25 +2937,33 @@ pub fn check_dotenv_impl(
     has_env: bool,
     uncovered_secret_files: &[String],
 ) -> CheckResult {
+    // Security first: an ungitignored always-secret dotenv file risks committing
+    // secrets and must never be hidden behind the copy-the-template hint, so
+    // check it before the `.env.example`-without-`.env` case. When both apply,
+    // lead with the security issue and still mention copying the template.
+    if !uncovered_secret_files.is_empty() {
+        let mut detail = format!(
+            "{} present but not gitignored — you risk committing secrets",
+            uncovered_secret_files.join(", ")
+        );
+        if has_env_example && !has_env {
+            detail.push_str("; also copy `.env.example` to `.env` to get started");
+        }
+        return CheckResult {
+            name: "dotenv",
+            status: CheckStatus::Warn,
+            detail: Some(detail),
+            hint: Some(
+                "Add your local .env files to .gitignore (e.g. `.env`, `.env.local`, `.env.*.local`)",
+            ),
+        };
+    }
     if has_env_example && !has_env {
         return CheckResult {
             name: "dotenv",
             status: CheckStatus::Warn,
             detail: Some("`.env.example` is present but no `.env` exists".into()),
             hint: Some("Copy `.env.example` to `.env` and fill in local values"),
-        };
-    }
-    if !uncovered_secret_files.is_empty() {
-        return CheckResult {
-            name: "dotenv",
-            status: CheckStatus::Warn,
-            detail: Some(format!(
-                "{} present but not gitignored — you risk committing secrets",
-                uncovered_secret_files.join(", ")
-            )),
-            hint: Some(
-                "Add your local .env files to .gitignore (e.g. `.env`, `.env.local`, `.env.*.local`)",
-            ),
         };
     }
     CheckResult {
@@ -5125,6 +5136,36 @@ redirect_uri = "http://localhost/callback"
             result.detail.as_deref().unwrap().contains(".env.local"),
             "detail should name the offending file: {:?}",
             result.detail
+        );
+    }
+
+    #[test]
+    fn dotenv_uncovered_secret_takes_priority_over_missing_env() {
+        // Combined case: `.env.example` present, no root `.env`, and a present
+        // `.env.local` that is NOT gitignored. The ungitignored-secret warning
+        // must win (naming the file) rather than being hidden behind the
+        // copy-the-template hint.
+        let result = check_dotenv_impl(true, false, &[".env.local".to_owned()]);
+        assert_eq!(result.name, "dotenv");
+        assert!(
+            matches!(result.status, CheckStatus::Warn),
+            "expected Warn, got {:?}",
+            result.status
+        );
+        let detail = result.detail.as_deref().unwrap();
+        assert!(
+            detail.contains(".env.local"),
+            "detail must name the uncovered secret file: {detail:?}"
+        );
+        assert!(
+            detail.contains("not gitignored"),
+            "detail must lead with the security issue: {detail:?}"
+        );
+        // The gitignore hint is the actionable one for the security issue.
+        assert!(
+            result.hint.unwrap().contains(".gitignore"),
+            "hint should point at .gitignore: {:?}",
+            result.hint
         );
     }
 

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2801,7 +2801,8 @@ pub fn check_compression_impl(compression_enabled: bool, is_production: bool) ->
 ///
 /// Returns `(has_env_example, has_env, env_gitignored)`. A `.env` is treated as
 /// gitignored when any trimmed `.gitignore` line equals `.env` or is a glob
-/// that covers it (`.env*` / `.env.*`).
+/// that covers it (`.env*` / `*.env`). Note that `.env.*` does NOT cover the
+/// root `.env` (it only matches `.env.local` etc.), so it is not counted.
 fn resolve_dotenv_state() -> (bool, bool, bool) {
     let has_env_example = std::path::Path::new(".env.example").exists();
     let has_env = std::path::Path::new(".env").exists();
@@ -2818,10 +2819,9 @@ fn gitignore_covers_dotenv(contents: &str) -> bool {
         if entry.starts_with('#') || entry.is_empty() {
             return false;
         }
-        matches!(entry, ".env" | ".env*" | ".env.*" | "/.env" | "*.env")
+        matches!(entry, ".env" | ".env*" | "/.env" | "*.env")
             || entry.ends_with("/.env")
             || entry.ends_with("/.env*")
-            || entry.ends_with("/.env.*")
             || entry.ends_with("/*.env")
     })
 }
@@ -5038,13 +5038,16 @@ redirect_uri = "http://localhost/callback"
     fn gitignore_covers_dotenv_matches_common_globs() {
         assert!(gitignore_covers_dotenv("/target\n.env\n"));
         assert!(gitignore_covers_dotenv(".env*\n"));
-        assert!(gitignore_covers_dotenv("  .env.*  \n"));
+        assert!(gitignore_covers_dotenv("*.env\n"));
+        assert!(gitignore_covers_dotenv("/.env\n"));
+        // `.env.*` matches `.env.local` etc. but NOT the root `.env`, so a
+        // gitignore that only lists `.env.*` must count as NOT covering `.env`.
+        assert!(!gitignore_covers_dotenv("  .env.*  \n"));
         assert!(!gitignore_covers_dotenv("/target\n.env.example\n"));
         assert!(!gitignore_covers_dotenv(""));
         // Recursive-glob style entries must also count as coverage.
         assert!(gitignore_covers_dotenv("**/.env\n"));
         assert!(gitignore_covers_dotenv("**/.env*\n"));
-        assert!(gitignore_covers_dotenv("**/.env.*\n"));
         // A bare `.env.example` line still does not cover `.env`.
         assert!(!gitignore_covers_dotenv(".env.example\n"));
         // Comment and blank lines are ignored.

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2498,6 +2498,7 @@ pub fn run(opts: DoctorOptions) {
     let auth_extractor_mounted = resolve_auth_extractor_mounted();
     let compression_enabled = resolve_compression_enabled();
     let proxy_conflict_data = resolve_proxy_conflict_data();
+    let (dotenv_has_example, dotenv_has_env, dotenv_gitignored) = resolve_dotenv_state();
 
     // ── Phase 2: build tasks in display order ────────────────────────────────
     let mut tasks: Vec<Task> = Vec::new();
@@ -2695,6 +2696,12 @@ pub fn run(opts: DoctorOptions) {
         check_compression_impl(compression_enabled, is_production)
     }));
 
+    // 12b. Local-dev `.env` handling (warn on `.env.example` without `.env`,
+    //      or a present-but-ungitignored `.env`).
+    tasks.push(Box::new(move || {
+        check_dotenv_impl(dotenv_has_example, dotenv_has_env, dotenv_gitignored)
+    }));
+
     // 13. System-test browser (warn if missing; not all projects use system tests)
     tasks.push(Box::new(check_system_test_browser));
 
@@ -2785,6 +2792,69 @@ pub fn check_compression_impl(compression_enabled: bool, is_production: bool) ->
             "response compression is enabled".into()
         } else {
             "response compression is disabled (off by default; use CDN or enable explicitly)".into()
+        }),
+        hint: None,
+    }
+}
+
+/// Resolve `.env` filesystem state for [`check_dotenv_impl`].
+///
+/// Returns `(has_env_example, has_env, env_gitignored)`. A `.env` is treated as
+/// gitignored when any trimmed `.gitignore` line equals `.env` or is a glob
+/// that covers it (`.env*` / `.env.*`).
+fn resolve_dotenv_state() -> (bool, bool, bool) {
+    let has_env_example = std::path::Path::new(".env.example").exists();
+    let has_env = std::path::Path::new(".env").exists();
+    let env_gitignored = std::fs::read_to_string(".gitignore")
+        .map(|contents| gitignore_covers_dotenv(&contents))
+        .unwrap_or(false);
+    (has_env_example, has_env, env_gitignored)
+}
+
+/// Whether a `.gitignore` body ignores a root `.env` file.
+fn gitignore_covers_dotenv(contents: &str) -> bool {
+    contents.lines().any(|line| {
+        let entry = line.trim();
+        matches!(entry, ".env" | ".env*" | ".env.*" | "/.env" | "*.env")
+    })
+}
+
+/// Check that project-root `.env` handling is set up safely.
+///
+/// - `.env.example` present but no `.env` → Warn (developer likely needs to
+///   copy the template).
+/// - `.env` present but not gitignored → Warn (risk of committing secrets).
+/// - otherwise → Pass.
+pub fn check_dotenv_impl(
+    has_env_example: bool,
+    has_env: bool,
+    env_gitignored: bool,
+) -> CheckResult {
+    if has_env_example && !has_env {
+        return CheckResult {
+            name: "dotenv",
+            status: CheckStatus::Warn,
+            detail: Some("`.env.example` is present but no `.env` exists".into()),
+            hint: Some("Copy `.env.example` to `.env` and fill in local values"),
+        };
+    }
+    if has_env && !env_gitignored {
+        return CheckResult {
+            name: "dotenv",
+            status: CheckStatus::Warn,
+            detail: Some(
+                "`.env` is present but not gitignored — you risk committing secrets".into(),
+            ),
+            hint: Some("Add `.env` to .gitignore"),
+        };
+    }
+    CheckResult {
+        name: "dotenv",
+        status: CheckStatus::Pass,
+        detail: Some(if has_env {
+            "`.env` handling looks correct".into()
+        } else {
+            ".env not configured".into()
         }),
         hint: None,
     }
@@ -4903,6 +4973,67 @@ redirect_uri = "http://localhost/callback"
             "expected Pass in dev profile, got {:?}",
             result.status
         );
+    }
+
+    // ── check_dotenv ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn dotenv_warns_when_example_present_without_env() {
+        let result = check_dotenv_impl(true, false, false);
+        assert_eq!(result.name, "dotenv");
+        assert!(
+            matches!(result.status, CheckStatus::Warn),
+            "expected Warn, got {:?}",
+            result.status
+        );
+        assert!(result.detail.as_deref().unwrap().contains(".env.example"));
+    }
+
+    #[test]
+    fn dotenv_warns_when_env_present_but_not_gitignored() {
+        let result = check_dotenv_impl(true, true, false);
+        assert_eq!(result.name, "dotenv");
+        assert!(
+            matches!(result.status, CheckStatus::Warn),
+            "expected Warn, got {:?}",
+            result.status
+        );
+        assert!(
+            result.detail.as_deref().unwrap().contains("not gitignored"),
+            "got: {:?}",
+            result.detail
+        );
+    }
+
+    #[test]
+    fn dotenv_passes_when_env_present_and_gitignored() {
+        let result = check_dotenv_impl(true, true, true);
+        assert_eq!(result.name, "dotenv");
+        assert!(
+            matches!(result.status, CheckStatus::Pass),
+            "expected Pass, got {:?}",
+            result.status
+        );
+    }
+
+    #[test]
+    fn dotenv_passes_when_nothing_configured() {
+        let result = check_dotenv_impl(false, false, false);
+        assert_eq!(result.name, "dotenv");
+        assert!(
+            matches!(result.status, CheckStatus::Pass),
+            "expected Pass, got {:?}",
+            result.status
+        );
+    }
+
+    #[test]
+    fn gitignore_covers_dotenv_matches_common_globs() {
+        assert!(gitignore_covers_dotenv("/target\n.env\n"));
+        assert!(gitignore_covers_dotenv(".env*\n"));
+        assert!(gitignore_covers_dotenv("  .env.*  \n"));
+        assert!(!gitignore_covers_dotenv("/target\n.env.example\n"));
+        assert!(!gitignore_covers_dotenv(""));
     }
 
     #[test]

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2866,27 +2866,43 @@ fn is_secret_dotenv_filename(name: &str) -> bool {
 /// Whether a `.gitignore` body ignores a project-root file named `filename`.
 ///
 /// Git-ignore semantics, restricted to the cases needed for root-level dotenv
-/// files: comment (`#…`), blank, and negation (`!…`) lines are skipped; every
-/// other line is treated as a glob matched against the file's basename, where
-/// `*` matches any run of non-`/` characters (including empty). An optional
-/// leading `**/` (match in any directory) then an optional leading `/` (anchor
-/// to the repository root) are accepted and stripped before matching. A pattern
-/// that still contains a `/` after stripping those prefixes — or ends in `/`
+/// files: comment (`#…`) and blank lines are skipped; every other line is a
+/// pattern matched against the file's basename, where `*` matches any run of
+/// non-`/` characters (including empty). A leading `!` marks a negation that
+/// **re-includes** a previously excluded file. An optional leading `**/` (match
+/// in any directory) then an optional leading `/` (anchor to the repository
+/// root) are accepted and stripped before matching. A pattern that still
+/// contains a `/` after stripping those prefixes — or ends in `/`
 /// (directory-only) — is a path/dir pattern that cannot match a bare root-level
-/// file and never counts as coverage.
+/// file and is skipped.
+///
+/// Per gitignore precedence, the **last** matching pattern decides: patterns
+/// are evaluated top-to-bottom while tracking a running ignored state, so
+/// `.env*` followed by `!.env` correctly reports `.env` as NOT covered, and
+/// `!.env` followed by `.env` reports it as covered.
 fn gitignore_covers(contents: &str, filename: &str) -> bool {
-    contents.lines().any(|line| {
+    let mut ignored = false;
+    for line in contents.lines() {
         let entry = line.trim();
-        if entry.is_empty() || entry.starts_with('#') || entry.starts_with('!') {
-            return false;
+        if entry.is_empty() || entry.starts_with('#') {
+            continue;
         }
-        let pattern = entry.strip_prefix("**/").unwrap_or(entry);
+        // A leading `!` re-includes (un-ignores) a matching file.
+        let (negation, body) = entry
+            .strip_prefix('!')
+            .map_or((false, entry), |rest| (true, rest));
+        let pattern = body.strip_prefix("**/").unwrap_or(body);
         let pattern = pattern.strip_prefix('/').unwrap_or(pattern);
         if pattern.ends_with('/') || pattern.contains('/') {
-            return false;
+            continue;
         }
-        glob_matches_basename(pattern, filename)
-    })
+        if glob_matches_basename(pattern, filename) {
+            // Last match wins: a normal pattern ignores, a `!` negation
+            // re-includes.
+            ignored = !negation;
+        }
+    }
+    ignored
 }
 
 /// Match a basename glob against `text`, anchored at both ends. The only special
@@ -5251,6 +5267,14 @@ redirect_uri = "http://localhost/callback"
         assert!(!gitignore_covers("config/.env\n", ".env"));
         // A directory-only pattern does not cover a regular file.
         assert!(!gitignore_covers(".env/\n", ".env"));
+        // Last-match-wins with `!` negations (gitignore precedence): a `!.env`
+        // re-include after a broader ignore means `.env` is NOT covered.
+        assert!(!gitignore_covers(".env*\n!.env\n", ".env"));
+        assert!(!gitignore_covers(".env\n!.env\n", ".env"));
+        // `.env*` still covers a sibling the negation does not re-include.
+        assert!(gitignore_covers(".env*\n!.env\n", ".env.local"));
+        // Order matters: a later ignore re-covers a file an earlier `!` freed.
+        assert!(gitignore_covers("!.env\n.env\n", ".env"));
     }
 
     #[test]

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -998,9 +998,18 @@ fn deep_merge_toml(base: &mut toml::Table, overlay: toml::Table) {
 /// Returns `None` when no URL can be resolved, leaving the caller to decide how
 /// to report the failure (the `autumn db` commands surface their own message).
 pub fn resolve_primary_url(profile: Option<&str>) -> Option<String> {
+    use autumn_web::config::Env as _;
+
     let effective = effective_profile(profile);
     let config_table = read_autumn_toml_table_with_profile(Some(&effective));
-    resolve_primary_database_url_from_sources(|key| std::env::var(key), config_table.as_ref())
+    // Overlay a project-root `.env` UNDER the real environment so a
+    // `.env`-provided AUTUMN_DATABASE__* / DATABASE_URL is honored for the
+    // `autumn db` lifecycle commands (create/drop/reset) and `db pull`, exactly
+    // as `autumn migrate` resolves its target URLs via `resolve_targets`. A real
+    // env var of the same key still wins; a malformed `.env` fails loudly here
+    // (with a `path:line` location), where a DB URL is actually needed.
+    let env = os_env_with_dotenv_or_exit();
+    resolve_primary_database_url_from_sources(|key| env.var(key), config_table.as_ref())
 }
 
 pub fn resolve_primary_database_url_from_sources<F>(

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -118,33 +118,33 @@ pub fn run(
 ) {
     eprintln!("\u{1F342} autumn migrate\n");
 
-    // Overlay a project-root `.env` UNDER the real environment for DB-URL
-    // resolution, without mutating the process environment. A real env var of
-    // the same key always wins; a malformed `.env` fails loudly here.
-    let env = match autumn_web::dotenv::os_env_with_dotenv() {
-        Ok(env) => env,
-        Err(e) => {
-            eprintln!("  \u{274C} .env: {e}");
-            std::process::exit(1);
-        }
-    };
-
     match action {
         MigrateAction::Check => {
+            // `check` is an offline, SQL-only preflight that needs no database
+            // URL, so it must NOT parse `.env`. Resolving the overlay here would
+            // let a malformed/unreadable local `.env` abort the check (breaking
+            // offline / CI safety checks), so the `.env` overlay is built lazily
+            // only in the database-backed paths below.
             let migrations_dir = resolve_migrations_dir();
             run_safety_check(&migrations_dir);
             return;
         }
         MigrateAction::Down(args) => {
-            run_down(args, with_maintenance, target, profile, &env);
+            run_down(args, with_maintenance, target, profile);
             return;
         }
         MigrateAction::Baseline(args) => {
-            run_baseline(args, target, profile, &env);
+            run_baseline(args, target, profile);
             return;
         }
         _ => {}
     }
+
+    // Overlay a project-root `.env` UNDER the real environment for DB-URL
+    // resolution, without mutating the process environment. A real env var of
+    // the same key always wins; a malformed `.env` fails loudly here. Built only
+    // now — after the non-DB early returns — so `migrate check` never reads it.
+    let env = os_env_with_dotenv_or_exit();
 
     // 1. Resolve migration target databases from autumn.toml (+ profile
     //    overlay) + env.  The merged config table is returned so that
@@ -182,6 +182,23 @@ pub fn run(
         }
         MigrateAction::Check | MigrateAction::Down(_) | MigrateAction::Baseline(_) => {
             unreachable!("handled above")
+        }
+    }
+}
+
+/// Build the real OS environment overlaid with a project-root `.env`, exiting
+/// loudly (`exit(1)`) if a `.env` file exists but is malformed or unreadable.
+///
+/// Called only from the database-backed migrate actions (the main `run` flow,
+/// `run_down`, and `run_baseline`), right before each `resolve_targets` — so a
+/// broken local `.env` fails only where a DB URL is actually resolved, never for
+/// the offline `migrate check` preflight.
+fn os_env_with_dotenv_or_exit() -> autumn_web::dotenv::DotenvOsEnv {
+    match autumn_web::dotenv::os_env_with_dotenv() {
+        Ok(env) => env,
+        Err(e) => {
+            eprintln!("  \u{274C} .env: {e}");
+            std::process::exit(1);
         }
     }
 }
@@ -550,13 +567,11 @@ fn record_checksums_after_apply(database_url: &str, migrations_dir: &std::path::
 /// advisory migration lock that `run`/`down` use (via the `*_locked` helpers),
 /// so a concurrent `autumn migrate down` cannot revert a version between the
 /// read and the write (issue #1203 review).
-fn run_baseline(
-    args: &BaselineArgs,
-    target: &MigrateTarget,
-    profile: Option<&str>,
-    env: &dyn autumn_web::config::Env,
-) {
-    let (targets, _) = resolve_targets(target, profile, env);
+fn run_baseline(args: &BaselineArgs, target: &MigrateTarget, profile: Option<&str>) {
+    // Overlay `.env` under the real environment only now that we are about to
+    // resolve a DB URL (a malformed `.env` fails loudly here).
+    let env = os_env_with_dotenv_or_exit();
+    let (targets, _) = resolve_targets(target, profile, &env);
     let migrations_dir = resolve_migrations_dir();
     let dir = std::path::Path::new(&migrations_dir);
 
@@ -1357,7 +1372,6 @@ fn run_down(
     with_maintenance: bool,
     target: &MigrateTarget,
     profile: Option<&str>,
-    env: &dyn autumn_web::config::Env,
 ) {
     // 1. Production guard. Derive prod-ness from the SAME effective profile the
     //    rollback will target (env precedence + build-mode + explicit flag), so
@@ -1374,8 +1388,11 @@ fn run_down(
 
     // 2. Resolve target databases (control + shards / a single shard /
     //    control-only) and the migrations dir. `down` honors --shard /
-    //    --control-only exactly like `migrate run`.
-    let (targets, _) = resolve_targets(target, profile, env);
+    //    --control-only exactly like `migrate run`. Overlay `.env` under the
+    //    real environment only now that we are about to resolve a DB URL (a
+    //    malformed `.env` fails loudly here).
+    let env = os_env_with_dotenv_or_exit();
+    let (targets, _) = resolve_targets(target, profile, &env);
     let migrations_dir = resolve_migrations_dir();
     let dir = Path::new(&migrations_dir);
 

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -118,6 +118,17 @@ pub fn run(
 ) {
     eprintln!("\u{1F342} autumn migrate\n");
 
+    // Overlay a project-root `.env` UNDER the real environment for DB-URL
+    // resolution, without mutating the process environment. A real env var of
+    // the same key always wins; a malformed `.env` fails loudly here.
+    let env = match autumn_web::dotenv::os_env_with_dotenv() {
+        Ok(env) => env,
+        Err(e) => {
+            eprintln!("  \u{274C} .env: {e}");
+            std::process::exit(1);
+        }
+    };
+
     match action {
         MigrateAction::Check => {
             let migrations_dir = resolve_migrations_dir();
@@ -125,11 +136,11 @@ pub fn run(
             return;
         }
         MigrateAction::Down(args) => {
-            run_down(args, with_maintenance, target, profile);
+            run_down(args, with_maintenance, target, profile, &env);
             return;
         }
         MigrateAction::Baseline(args) => {
-            run_baseline(args, target, profile);
+            run_baseline(args, target, profile, &env);
             return;
         }
         _ => {}
@@ -138,7 +149,7 @@ pub fn run(
     // 1. Resolve migration target databases from autumn.toml (+ profile
     //    overlay) + env.  The merged config table is returned so that
     //    resolve_startup_wait can reuse it without a second filesystem read.
-    let (targets, config_table) = resolve_targets(target, profile);
+    let (targets, config_table) = resolve_targets(target, profile, &env);
 
     // 2. Resolve migrations directory
     let migrations_dir = resolve_migrations_dir();
@@ -183,6 +194,7 @@ pub fn run(
 fn resolve_targets(
     target: &MigrateTarget,
     profile: Option<&str>,
+    env: &dyn autumn_web::config::Env,
 ) -> (Vec<(String, String)>, Option<toml::Table>) {
     // Read autumn.toml once, deep-merging the `autumn-<profile>.toml` overlay
     // when a profile is selected, so control and shard URLs both resolve from
@@ -192,12 +204,15 @@ fn resolve_targets(
     // When no profile is given explicitly (via `--profile` / `AUTUMN_PROFILE`),
     // fall back to `AUTUMN_ENV` — the framework's preferred profile selector —
     // so `autumn migrate` resolves the same overlay the app itself would use.
+    //
+    // `env` overlays a project-root `.env` under the real environment, so a
+    // `.env`-provided DB URL is honored while a real env var still wins.
     let effective = effective_profile(profile);
     let config_table = read_autumn_toml_table_with_profile(Some(&effective));
     let control =
-        resolve_primary_database_url_from_sources(|key| std::env::var(key), config_table.as_ref());
+        resolve_primary_database_url_from_sources(|key| env.var(key), config_table.as_ref());
     let shards =
-        resolve_shard_database_urls_from_sources(|key| std::env::var(key), config_table.as_ref());
+        resolve_shard_database_urls_from_sources(|key| env.var(key), config_table.as_ref());
     match build_targets(control, shards, target) {
         Ok(targets) => (targets, config_table),
         Err(message) => {
@@ -535,8 +550,13 @@ fn record_checksums_after_apply(database_url: &str, migrations_dir: &std::path::
 /// advisory migration lock that `run`/`down` use (via the `*_locked` helpers),
 /// so a concurrent `autumn migrate down` cannot revert a version between the
 /// read and the write (issue #1203 review).
-fn run_baseline(args: &BaselineArgs, target: &MigrateTarget, profile: Option<&str>) {
-    let (targets, _) = resolve_targets(target, profile);
+fn run_baseline(
+    args: &BaselineArgs,
+    target: &MigrateTarget,
+    profile: Option<&str>,
+    env: &dyn autumn_web::config::Env,
+) {
+    let (targets, _) = resolve_targets(target, profile, env);
     let migrations_dir = resolve_migrations_dir();
     let dir = std::path::Path::new(&migrations_dir);
 
@@ -1337,6 +1357,7 @@ fn run_down(
     with_maintenance: bool,
     target: &MigrateTarget,
     profile: Option<&str>,
+    env: &dyn autumn_web::config::Env,
 ) {
     // 1. Production guard. Derive prod-ness from the SAME effective profile the
     //    rollback will target (env precedence + build-mode + explicit flag), so
@@ -1354,7 +1375,7 @@ fn run_down(
     // 2. Resolve target databases (control + shards / a single shard /
     //    control-only) and the migrations dir. `down` honors --shard /
     //    --control-only exactly like `migrate run`.
-    let (targets, _) = resolve_targets(target, profile);
+    let (targets, _) = resolve_targets(target, profile, env);
     let migrations_dir = resolve_migrations_dir();
     let dir = Path::new(&migrations_dir);
 

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -19,6 +19,7 @@ mod templates {
     pub const INPUT_CSS: &str = include_str!("templates/input.css.tmpl");
     pub const TAILWIND_CONFIG: &str = include_str!("templates/tailwind.config.js.tmpl");
     pub const GITIGNORE: &str = include_str!("templates/gitignore.tmpl");
+    pub const ENV_EXAMPLE: &str = include_str!("templates/env.example.tmpl");
     pub const SEED_RS: &str = include_str!("templates/seed.rs.tmpl");
     pub const SEED_CARGO_TOML: &str = include_str!("templates/seed_Cargo.toml.tmpl");
     pub const INTEGRATION_TEST: &str = include_str!("templates/tests/integration_test.rs.tmpl");
@@ -281,6 +282,10 @@ fn generate_inner(
         render(templates::TAILWIND_CONFIG),
     )?;
     fs::write(project_dir.join(".gitignore"), render(templates::GITIGNORE))?;
+    fs::write(
+        project_dir.join(".env.example"),
+        render(templates::ENV_EXAMPLE),
+    )?;
     fs::write(project_dir.join("migrations/.gitkeep"), "")?;
 
     scaffold_vendor_assets(&project_dir)?;
@@ -407,6 +412,7 @@ fn print_scaffold_summary(name: &str, opts: GenerateOptions) {
     println!("  Created {name}/static/css/input.css");
     println!("  Created {name}/tailwind.config.js");
     println!("  Created {name}/.gitignore");
+    println!("  Created {name}/.env.example");
     println!("  Created {name}/rust-toolchain.toml");
     println!("  Created {name}/rustfmt.toml");
     println!("  Created {name}/clippy.toml");
@@ -936,6 +942,7 @@ mod tests {
         );
         assert!(p.join("build.rs").is_file());
         assert!(p.join(".gitignore").is_file());
+        assert!(p.join(".env.example").is_file());
         assert!(p.join("static/css/input.css").is_file());
         assert!(p.join("tailwind.config.js").is_file());
         assert!(p.join("migrations/.gitkeep").is_file());
@@ -1146,6 +1153,32 @@ mod tests {
         assert!(content.contains("/target"));
         assert!(content.contains("static/css/autumn.css"));
         assert!(!content.contains("static/autumn/"));
+        // `.env` (and local variants) are gitignored, but the committable
+        // `.env.example` template is not.
+        assert!(content.lines().any(|l| l.trim() == ".env"));
+        assert!(!content.lines().any(|l| l.trim() == ".env.example"));
+    }
+
+    #[test]
+    fn scaffolds_env_example_and_gitignores_env() {
+        let tmp = TempDir::new().unwrap();
+        generate("dotenv-check", tmp.path()).unwrap();
+        let p = tmp.path().join("dotenv-check");
+
+        // `.env.example` is scaffolded and documents the DB URL env key.
+        let example = fs::read_to_string(p.join(".env.example")).unwrap();
+        assert!(
+            example.contains("AUTUMN_DATABASE__URL"),
+            ".env.example must document AUTUMN_DATABASE__URL:\n{example}"
+        );
+        // crate_name token is substituted into the example URL.
+        assert!(example.contains("dotenv_check"), "got:\n{example}");
+
+        // `.gitignore` ignores `.env` but the committable `.env.example` remains
+        // in the project (and is not ignored).
+        let gitignore = fs::read_to_string(p.join(".gitignore")).unwrap();
+        assert!(gitignore.lines().any(|l| l.trim() == ".env"));
+        assert!(p.join(".env.example").is_file());
     }
 
     #[test]

--- a/autumn-cli/src/templates/README.md.tmpl
+++ b/autumn-cli/src/templates/README.md.tmpl
@@ -47,6 +47,11 @@ before running it — open `autumn.toml`, uncomment the `[database]` block, and 
 url = "postgres://postgres:postgres@localhost:5432/{{crate_name}}"
 ```
 
+> Prefer environment variables? Instead of editing `autumn.toml`, copy
+> `.env.example` to `.env` (gitignored) and set `AUTUMN_DATABASE__URL` there.
+> `autumn dev` auto-loads `.env` in the dev/test profiles; real shell
+> environment variables always win over `.env` values.
+
 Don't have a Postgres to point at? Start a throwaway local instance with Docker.
 This matches the `url` above (user and password `postgres`, database
 `{{crate_name}}`), so the two line up with no extra edits. The `-d` flag runs it

--- a/autumn-cli/src/templates/env.example.tmpl
+++ b/autumn-cli/src/templates/env.example.tmpl
@@ -6,6 +6,11 @@
 #
 # Load order (later files fill only still-unset keys):
 #   .env  ->  .env.local  ->  .env.{profile}  ->  .env.{profile}.local
+#
+# Note: the environment/profile selectors (AUTUMN_ENV, AUTUMN_PROFILE,
+# AUTUMN_IS_DEBUG) are intentionally NOT read from `.env` — a `.env` file must
+# not be able to switch the active profile. Set them in your shell or pass
+# `--profile <name>` instead.
 
 # Primary database connection string.
 AUTUMN_DATABASE__URL=postgres://postgres:postgres@localhost:5432/{{crate_name}}

--- a/autumn-cli/src/templates/env.example.tmpl
+++ b/autumn-cli/src/templates/env.example.tmpl
@@ -1,0 +1,17 @@
+# Local development environment variables for {{project_name}}.
+#
+# Copy this file to `.env` (gitignored) and fill in real values.
+# Autumn auto-loads `.env` in the dev and test profiles. Real shell
+# environment variables always take precedence over values here.
+#
+# Load order (later files fill only still-unset keys):
+#   .env  ->  .env.local  ->  .env.{profile}  ->  .env.{profile}.local
+
+# Primary database connection string.
+AUTUMN_DATABASE__URL=postgres://postgres:postgres@localhost:5432/{{crate_name}}
+
+# Master key to decrypt config/credentials.enc (see `autumn credentials`).
+# AUTUMN_MASTER_KEY=
+
+# Log verbosity: error | warn | info | debug | trace
+AUTUMN_LOG__LEVEL=info

--- a/autumn-cli/src/templates/gitignore.tmpl
+++ b/autumn-cli/src/templates/gitignore.tmpl
@@ -1,3 +1,6 @@
 /target
 static/css/autumn.css
 config/master.key
+.env
+.env.local
+.env.*.local

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -13,6 +13,17 @@
 //! An Autumn application runs with zero configuration -- every field
 //! has a sensible default value. Override only what you need.
 //!
+//! # Local-dev `.env` files
+//!
+//! A project-root `.env` file is a **local-dev feeder for the highest layer**
+//! (the `AUTUMN_*` env-var layer) -- it does *not* add a new precedence tier.
+//! Values parsed from `.env` populate env-layer keys that are still unset; a
+//! real environment variable of the same name always wins. Auto-loaded in the
+//! `dev` and `test` profiles and ignored in `prod` unless `AUTUMN_DOTENV=1`.
+//! Files load in order `.env` -> `.env.local` -> `.env.{profile}` ->
+//! `.env.{profile}.local`, and earlier files (and real env vars) win. See the
+//! [`dotenv`](crate::dotenv) module.
+//!
 //! # Profiles
 //!
 //! Profiles are resolved in precedence order:
@@ -812,6 +823,10 @@ pub enum ConfigError {
     /// The credentials file exists but could not be decrypted.
     #[error("credentials error: {0}")]
     Credentials(String),
+
+    /// A project-root `.env` file exists but could not be read or parsed.
+    #[error("dotenv error: {0}")]
+    Dotenv(String),
 }
 
 /// Top-level framework configuration.
@@ -2261,7 +2276,19 @@ impl AutumnConfig {
     /// Panics if the internally-built TOML table fails to re-serialize
     /// (should never happen with well-formed profile defaults).
     pub fn load() -> Result<Self, ConfigError> {
-        Self::load_with_env(&OsEnv)
+        // Feed a project-root `.env` into the `AUTUMN_*` env layer before
+        // resolving config from the real environment. Rather than mutating the
+        // process environment, `.env` values are layered *under* the real
+        // environment via an overlay `Env`, so a real env var always wins. A
+        // malformed `.env` fails loudly here rather than silently skipping
+        // developer-provided values.
+        let base = OsEnv;
+        let profile = resolve_profile(&base);
+        let dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let vars = crate::dotenv::resolve_dotenv_vars(&dir, &profile, &base)
+            .map_err(|e| ConfigError::Dotenv(e.to_string()))?;
+        let env = crate::dotenv::DotenvEnv::new(&base, vars);
+        Self::load_with_env(&env)
     }
 
     /// Load configuration with profile-aware layering, using a provided
@@ -5250,7 +5277,20 @@ impl TomlEnvConfigLoader {
 
 impl ConfigLoader for TomlEnvConfigLoader {
     async fn load(&self) -> Result<AutumnConfig, ConfigError> {
-        AutumnConfig::load_with_env(&OsEnv)
+        // Feed a project-root `.env` into the `AUTUMN_*` env layer before
+        // resolving config from the real environment. Rather than mutating the
+        // process environment (unsound on a live multi-threaded runtime), `.env`
+        // values are layered *under* the real environment via an overlay `Env`,
+        // so a real env var always wins. The sync file IO in `resolve_dotenv_vars`
+        // is fine on the async path. A malformed `.env` fails loudly here rather
+        // than silently skipping developer-provided values.
+        let base = OsEnv;
+        let profile = resolve_profile(&base);
+        let dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let vars = crate::dotenv::resolve_dotenv_vars(&dir, &profile, &base)
+            .map_err(|e| ConfigError::Dotenv(e.to_string()))?;
+        let env = crate::dotenv::DotenvEnv::new(&base, vars);
+        AutumnConfig::load_with_env(&env)
     }
 }
 

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -2290,7 +2290,11 @@ impl AutumnConfig {
         // developer-provided values.
         let base = OsEnv;
         let profile = resolve_profile(&base);
-        let dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        // Resolve `.env` from the same base directory config uses for
+        // `autumn.toml` (AUTUMN_MANIFEST_DIR when set, else the process CWD),
+        // so a binary launched from outside its crate root reads the `.env`
+        // next to its config instead of the process working directory.
+        let dir = crate::dotenv::dotenv_base_dir(&base);
         let vars = crate::dotenv::resolve_dotenv_vars(&dir, &profile, &base)
             .map_err(|e| ConfigError::Dotenv(e.to_string()))?;
         let env = crate::dotenv::DotenvEnv::new(&base, vars);
@@ -5292,7 +5296,11 @@ impl ConfigLoader for TomlEnvConfigLoader {
         // than silently skipping developer-provided values.
         let base = OsEnv;
         let profile = resolve_profile(&base);
-        let dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        // Resolve `.env` from the same base directory config uses for
+        // `autumn.toml` (AUTUMN_MANIFEST_DIR when set, else the process CWD),
+        // so a binary launched from outside its crate root reads the `.env`
+        // next to its config instead of the process working directory.
+        let dir = crate::dotenv::dotenv_base_dir(&base);
         let vars = crate::dotenv::resolve_dotenv_vars(&dir, &profile, &base)
             .map_err(|e| ConfigError::Dotenv(e.to_string()))?;
         let env = crate::dotenv::DotenvEnv::new(&base, vars);

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -296,6 +296,12 @@ pub(crate) fn resolve_profile(env: &dyn Env) -> String {
 }
 
 /// Resolve the raw profile selector value (before normalization).
+///
+/// The env-var keys consulted here (`AUTUMN_ENV`, `AUTUMN_PROFILE`,
+/// `AUTUMN_IS_DEBUG`) are the profile *selectors*; they are deliberately
+/// excluded from the `.env` overlay (see [`crate::dotenv`]'s
+/// `PROFILE_SELECTOR_KEYS`) so a `.env` file cannot switch the active profile.
+/// Keep the two lists in sync.
 fn resolve_profile_input(env: &dyn Env) -> String {
     // 1. Preferred env var
     if let Ok(profile) = env.var("AUTUMN_ENV") {

--- a/autumn/src/dotenv.rs
+++ b/autumn/src/dotenv.rs
@@ -322,20 +322,45 @@ impl Env for DotenvOsEnv {
     }
 }
 
-/// Resolve `.env` vars for the current working directory using the real OS env
+/// The base directory `.env` files are resolved from — the SAME directory the
+/// config loader uses for `autumn.toml`.
+///
+/// `autumn.toml` is located via
+/// [`find_config_file_named`](crate::config), which prefers
+/// `AUTUMN_MANIFEST_DIR` (the crate root baked in by `#[autumn_web::main]`, or a
+/// launch-time override) when set and otherwise falls back to the process
+/// working directory. Resolving `.env` from the same base means a binary
+/// launched from outside its crate root (e.g. `cargo run -p app` from a
+/// workspace root) reads the `.env` next to its `autumn.toml` rather than the
+/// process CWD.
+///
+/// `AUTUMN_MANIFEST_DIR` must be read from the real/base [`Env`] (before the
+/// `.env` overlay is built), so the overlay can never redirect its own base
+/// directory.
+pub(crate) fn dotenv_base_dir(env: &dyn Env) -> PathBuf {
+    if let Ok(manifest_dir) = env.var("AUTUMN_MANIFEST_DIR") {
+        return PathBuf::from(manifest_dir);
+    }
+    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+}
+
+/// Resolve `.env` vars for the config manifest directory using the real OS env
 /// and resolved profile.
 ///
+/// The base directory is [`dotenv_base_dir`] — `AUTUMN_MANIFEST_DIR` when set,
+/// else the process working directory — so `.env` is always read from the same
+/// place as `autumn.toml`.
+///
 /// Returns the `(key, value)` pairs to apply (empty when gating disables
-/// loading — see [`should_load`]). If the current directory cannot be
-/// determined, resolution falls back to `.`.
+/// loading — see [`should_load`]).
 ///
 /// # Errors
 /// Returns a [`DotenvError`] (with a `path:line` location) on a malformed or
 /// unreadable `.env` file.
-pub fn resolve_dotenv_for_cwd() -> Result<Vec<(String, String)>, DotenvError> {
+pub fn resolve_process_dotenv() -> Result<Vec<(String, String)>, DotenvError> {
     let base = OsEnv;
     let profile = resolve_profile(&base);
-    let dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let dir = dotenv_base_dir(&base);
     resolve_dotenv_vars(&dir, &profile, &base)
 }
 
@@ -347,7 +372,7 @@ pub fn resolve_dotenv_for_cwd() -> Result<Vec<(String, String)>, DotenvError> {
 /// read or parsed.
 pub fn os_env_with_dotenv() -> Result<DotenvOsEnv, DotenvError> {
     Ok(DotenvOsEnv {
-        overlay: resolve_dotenv_for_cwd()?.into_iter().collect(),
+        overlay: resolve_process_dotenv()?.into_iter().collect(),
     })
 }
 
@@ -805,6 +830,37 @@ export BAZ=qux
         // The real-env value is still what callers observe.
         assert_eq!(env.var("AUTUMN_ENV").unwrap(), "dev");
         assert_eq!(map.get("OTHER").map(String::as_str), Some("x"));
+    }
+
+    #[test]
+    fn dotenv_base_dir_prefers_manifest_dir() {
+        // The `.env` base directory tracks config's `autumn.toml` base:
+        // AUTUMN_MANIFEST_DIR wins over the process CWD when set.
+        let dir = tempfile::tempdir().unwrap();
+        let env = MockEnv::new().with("AUTUMN_MANIFEST_DIR", dir.path().to_str().unwrap());
+        assert_eq!(dotenv_base_dir(&env), dir.path().to_path_buf());
+    }
+
+    #[test]
+    fn dotenv_base_dir_falls_back_to_cwd_when_unset() {
+        let env = MockEnv::new();
+        let expected = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        assert_eq!(dotenv_base_dir(&env), expected);
+    }
+
+    #[test]
+    fn resolve_reads_env_from_manifest_dir_not_cwd() {
+        // With AUTUMN_MANIFEST_DIR pointing at a temp dir that contains a `.env`,
+        // resolution reads THAT file — proving the base directory is the manifest
+        // dir, not the process working directory.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".env"), "FROM_MANIFEST=yes\n").unwrap();
+        let env = MockEnv::new().with("AUTUMN_MANIFEST_DIR", dir.path().to_str().unwrap());
+        let base = dotenv_base_dir(&env);
+        assert_eq!(base, dir.path().to_path_buf());
+        let out = resolve_dotenv_vars(&base, "dev", &env).unwrap();
+        let map: std::collections::HashMap<_, _> = out.into_iter().collect();
+        assert_eq!(map.get("FROM_MANIFEST").map(String::as_str), Some("yes"));
     }
 
     #[test]

--- a/autumn/src/dotenv.rs
+++ b/autumn/src/dotenv.rs
@@ -79,9 +79,10 @@ fn should_load(profile: &str, env: &dyn Env) -> bool {
 /// Parse the contents of a single `.env` file into ordered key/value pairs.
 ///
 /// Blank lines and `#` comments are skipped. A leading `export ` prefix is
-/// stripped. Keys must match `[A-Za-z_][A-Za-z0-9_]*`. Values are taken
-/// verbatim after the first `=`, trimmed, with matching surrounding single or
-/// double quotes stripped. There is no `${VAR}` interpolation.
+/// stripped. Keys must match `[A-Za-z_][A-Za-z0-9_]*`. Values are taken after
+/// the first `=`, trimmed, with matching surrounding single or double quotes
+/// stripped and any inline comment ignored (see [`parse_value`]). There is no
+/// `${VAR}` interpolation.
 ///
 /// # Errors
 /// Returns a [`DotenvError`] (with the correct 1-based line number) for a line
@@ -118,7 +119,7 @@ fn parse_dotenv(path: &Path, contents: &str) -> Result<Vec<(String, String)>, Do
         }
 
         let value_raw = body[eq + 1..].trim();
-        let value = strip_quotes(value_raw);
+        let value = parse_value(value_raw);
         out.push((key.to_owned(), value));
     }
     Ok(out)
@@ -135,18 +136,43 @@ fn is_valid_key(key: &str) -> bool {
     chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
-/// Strip a single matching pair of surrounding single or double quotes, if
-/// present. The content is otherwise returned verbatim (no interpolation).
-fn strip_quotes(value: &str) -> String {
-    let bytes = value.as_bytes();
-    if bytes.len() >= 2 {
-        let first = bytes[0];
-        let last = bytes[bytes.len() - 1];
-        if (first == b'"' || first == b'\'') && first == last {
-            return value[1..value.len() - 1].to_owned();
+/// Parse a value, stripping surrounding quotes if present and ignoring inline
+/// comments. The caller passes an already-trimmed value.
+///
+/// If the value starts with `"` or `'`, the inner content up to the matching
+/// closing quote is returned (respecting `\`-escapes while scanning) and
+/// anything after the closing quote — such as a trailing inline comment — is
+/// ignored; a `#` inside the quotes is preserved literally. Otherwise the value
+/// is unquoted: the first `#` that is at the start or preceded by ASCII
+/// whitespace begins an inline comment and the part before it (trimmed) is
+/// returned, while a `#` not preceded by whitespace (e.g. inside
+/// `postgres://u:p#ss@h`) is preserved. There is no `${VAR}` interpolation.
+fn parse_value(raw: &str) -> String {
+    if raw.is_empty() {
+        return String::new();
+    }
+    let bytes = raw.as_bytes();
+    let quote = bytes[0];
+    if quote == b'"' || quote == b'\'' {
+        let mut escaped = false;
+        let mut end_idx = None;
+        for (i, &b) in bytes.iter().enumerate().skip(1) {
+            if escaped {
+                escaped = false;
+            } else if b == b'\\' {
+                escaped = true;
+            } else if b == quote {
+                end_idx = Some(i);
+                break;
+            }
+        }
+        if let Some(end) = end_idx {
+            return raw[1..end].to_owned();
         }
     }
-    value.to_owned()
+    let comment_start = (0..bytes.len())
+        .find(|&i| bytes[i] == b'#' && (i == 0 || bytes[i - 1].is_ascii_whitespace()));
+    comment_start.map_or_else(|| raw.to_owned(), |idx| raw[..idx].trim().to_owned())
 }
 
 /// Resolve the merged `.env` variable set for a directory and profile.
@@ -319,6 +345,45 @@ mod tests {
     fn no_interpolation_of_dollar_vars() {
         let out = parse_dotenv(&p(), "A=${FOO}/literal\n").unwrap();
         assert_eq!(out[0], ("A".to_owned(), "${FOO}/literal".to_owned()));
+    }
+
+    #[test]
+    fn strips_unquoted_inline_comment() {
+        let out = parse_dotenv(&p(), "KEY=val # c\n").unwrap();
+        assert_eq!(out[0], ("KEY".to_owned(), "val".to_owned()));
+    }
+
+    #[test]
+    fn strips_trailing_comment_after_quoted_value() {
+        let out = parse_dotenv(&p(), "KEY=\"a b\" # c\n").unwrap();
+        assert_eq!(out[0], ("KEY".to_owned(), "a b".to_owned()));
+    }
+
+    #[test]
+    fn hash_inside_quotes_is_preserved() {
+        let out = parse_dotenv(&p(), "KEY=\"a#b\"\n").unwrap();
+        assert_eq!(out[0], ("KEY".to_owned(), "a#b".to_owned()));
+    }
+
+    #[test]
+    fn hash_not_preceded_by_whitespace_is_not_a_comment() {
+        let out = parse_dotenv(&p(), "KEY=a#b\n").unwrap();
+        assert_eq!(out[0], ("KEY".to_owned(), "a#b".to_owned()));
+    }
+
+    #[test]
+    fn hash_in_unquoted_connection_string_is_preserved() {
+        let out = parse_dotenv(&p(), "KEY=postgres://u:p#w@h/db\n").unwrap();
+        assert_eq!(
+            out[0],
+            ("KEY".to_owned(), "postgres://u:p#w@h/db".to_owned())
+        );
+    }
+
+    #[test]
+    fn empty_value_is_empty_string() {
+        let out = parse_dotenv(&p(), "KEY=\n").unwrap();
+        assert_eq!(out[0], ("KEY".to_owned(), String::new()));
     }
 
     #[test]

--- a/autumn/src/dotenv.rs
+++ b/autumn/src/dotenv.rs
@@ -20,6 +20,12 @@
 //! There is intentionally **no** `${VAR}` interpolation: values are treated
 //! as literal strings (with optional surrounding single or double quotes
 //! stripped).
+//!
+//! The environment/profile **selector** keys (`AUTUMN_ENV`, `AUTUMN_PROFILE`,
+//! `AUTUMN_IS_DEBUG`) are intentionally **excluded** from the overlay — a
+//! `.env` file must not be able to change the active profile or bypass the
+//! prod / destructive-command guards. Set those in the real shell environment
+//! or via `--profile`. See [`PROFILE_SELECTOR_KEYS`].
 
 use std::path::{Path, PathBuf};
 
@@ -48,6 +54,30 @@ impl std::fmt::Display for DotenvError {
 }
 
 impl std::error::Error for DotenvError {}
+
+/// Environment-variable keys that select the active profile / environment and
+/// are therefore deliberately **never** honored from a `.env` file.
+///
+/// Safety: the active profile is a safety-critical bootstrapping decision — it
+/// gates the production / destructive-command confirmations in `autumn migrate
+/// down`, `autumn db drop`, and `autumn db reset`, and it picks which config
+/// overlay (and thus which database) an app targets. A `.env` file must not be
+/// able to change it. Were `.env` allowed to set `AUTUMN_ENV=prod`, it could
+/// flip a command onto a production target *after* that command's real-env
+/// (dev) guard had already passed, bypassing the confirmation flag. Profile
+/// selection therefore stays sourced only from the real shell environment and
+/// the `--profile` flag — mirroring Rails/Next, where `.env` does not set
+/// `RAILS_ENV`/`NODE_ENV`.
+///
+/// These are exactly the keys [`crate::config::resolve_profile_input`] consults
+/// to pick the profile; keep the two lists in sync.
+const PROFILE_SELECTOR_KEYS: [&str; 3] = ["AUTUMN_ENV", "AUTUMN_PROFILE", "AUTUMN_IS_DEBUG"];
+
+/// Whether `key` selects the active profile / environment and so must be
+/// dropped from the `.env` overlay (see [`PROFILE_SELECTOR_KEYS`]).
+fn is_profile_selector_key(key: &str) -> bool {
+    PROFILE_SELECTOR_KEYS.contains(&key)
+}
 
 /// The ordered list of candidate `.env` files for a given profile.
 ///
@@ -187,6 +217,12 @@ fn parse_value(raw: &str) -> String {
 /// (real env always wins), and the first file to set a key wins over later
 /// files.
 ///
+/// Profile/environment selector keys ([`PROFILE_SELECTOR_KEYS`] — `AUTUMN_ENV`,
+/// `AUTUMN_PROFILE`, `AUTUMN_IS_DEBUG`) are dropped unconditionally, even when
+/// present in `.env`: a `.env` file must not be able to change the active
+/// profile or bypass the prod / destructive-command guards. See
+/// [`PROFILE_SELECTOR_KEYS`] for the full rationale.
+///
 /// # Errors
 /// Returns a [`DotenvError`] if a candidate file exists but cannot be read, or
 /// if a present file fails to parse.
@@ -217,6 +253,11 @@ pub(crate) fn resolve_dotenv_vars(
         };
 
         for (key, value) in parse_dotenv(&path, &contents)? {
+            // Safety: `.env` must never select the active profile/environment,
+            // so drop the profile-selector keys regardless of the file.
+            if is_profile_selector_key(&key) {
+                continue;
+            }
             // Real environment variables always win.
             if env.var(&key).is_ok() {
                 continue;
@@ -674,6 +715,25 @@ export BAZ=qux
     }
 
     #[test]
+    fn dotenv_env_prod_does_not_flip_resolved_profile() {
+        // End-to-end guard: a `.env`-provided `AUTUMN_ENV=prod` must NOT change
+        // the profile the overlay resolves to. `resolve_profile` is exactly the
+        // selector `autumn migrate` / config load consult, so this proves the
+        // prod/destructive guards can't be flipped by `.env`.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".env"),
+            "AUTUMN_ENV=prod\nAUTUMN_DATABASE__URL=postgres://localhost/app\n",
+        )
+        .unwrap();
+        let base = MockEnv::new();
+        let vars = resolve_dotenv_vars(dir.path(), "dev", &base).unwrap();
+        let env = DotenvEnv::new(&base, vars);
+        // The selector is not honored from `.env`, so the profile stays `dev`.
+        assert_eq!(crate::config::resolve_profile(&env), "dev");
+    }
+
+    #[test]
     fn dotenv_resolves_into_config_via_overlay() {
         // End-to-end: a `.env` value flows into `config.database.url` through
         // the overlay `Env`, with no process-environment mutation.
@@ -692,6 +752,59 @@ export BAZ=qux
             config.database.url.as_deref(),
             Some("postgres://localhost/from-dotenv")
         );
+    }
+
+    #[test]
+    fn profile_selector_keys_are_dropped_from_dotenv() {
+        // Safety: `.env` must never select the active profile/environment.
+        // `AUTUMN_ENV`, `AUTUMN_PROFILE`, and `AUTUMN_IS_DEBUG` are dropped even
+        // when present in `.env`, while ordinary keys still flow through.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".env"),
+            "AUTUMN_ENV=prod\n\
+             AUTUMN_PROFILE=prod\n\
+             AUTUMN_IS_DEBUG=0\n\
+             AUTUMN_DATABASE__URL=postgres://localhost/app\n",
+        )
+        .unwrap();
+        let env = MockEnv::new();
+        let out = resolve_dotenv_vars(dir.path(), "dev", &env).unwrap();
+        let map: std::collections::HashMap<_, _> = out.into_iter().collect();
+        assert!(
+            !map.contains_key("AUTUMN_ENV"),
+            "AUTUMN_ENV must not be honored from .env"
+        );
+        assert!(
+            !map.contains_key("AUTUMN_PROFILE"),
+            "AUTUMN_PROFILE must not be honored from .env"
+        );
+        assert!(
+            !map.contains_key("AUTUMN_IS_DEBUG"),
+            "AUTUMN_IS_DEBUG must not be honored from .env"
+        );
+        // Non-selector keys are unaffected.
+        assert_eq!(
+            map.get("AUTUMN_DATABASE__URL").map(String::as_str),
+            Some("postgres://localhost/app")
+        );
+    }
+
+    #[test]
+    fn real_env_profile_selector_is_unaffected_by_exclusion() {
+        // Excluding the selector keys from `.env` must not touch the REAL
+        // environment: a real-env `AUTUMN_ENV` remains readable through the
+        // base env even though a `.env`-provided one is dropped.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".env"), "AUTUMN_ENV=prod\nOTHER=x\n").unwrap();
+        let env = MockEnv::new().with("AUTUMN_ENV", "dev");
+        let out = resolve_dotenv_vars(dir.path(), "dev", &env).unwrap();
+        let map: std::collections::HashMap<_, _> = out.into_iter().collect();
+        // The `.env` selector is dropped, not surfaced.
+        assert!(!map.contains_key("AUTUMN_ENV"));
+        // The real-env value is still what callers observe.
+        assert_eq!(env.var("AUTUMN_ENV").unwrap(), "dev");
+        assert_eq!(map.get("OTHER").map(String::as_str), Some("x"));
     }
 
     #[test]

--- a/autumn/src/dotenv.rs
+++ b/autumn/src/dotenv.rs
@@ -12,9 +12,10 @@
 //! earlier files (and any real environment variable) win: a later file only
 //! fills keys that are still unset.
 //!
-//! Auto-loading happens in the `dev` and `test` profiles. It is skipped in
-//! `prod` unless `AUTUMN_DOTENV=1` (or `true`) is set; conversely it can be
-//! disabled anywhere with `AUTUMN_DOTENV=0` (or `false`).
+//! Auto-loading happens only in the `dev` and `test` profiles. Every other
+//! profile (`prod`, `staging`, and any custom profile) skips it unless
+//! `AUTUMN_DOTENV=1` (or `true`) is set; conversely it can be disabled anywhere
+//! with `AUTUMN_DOTENV=0` (or `false`).
 //!
 //! There is intentionally **no** `${VAR}` interpolation: values are treated
 //! as literal strings (with optional surrounding single or double quotes
@@ -64,7 +65,9 @@ fn candidate_files(profile: &str) -> Vec<String> {
 /// Decide whether `.env` auto-loading should run for `profile`.
 ///
 /// `AUTUMN_DOTENV=1`/`true` forces loading on; `AUTUMN_DOTENV=0`/`false`
-/// forces it off. Absent that override, every profile except `prod` loads.
+/// forces it off. Absent that override, only the `dev` and `test` profiles
+/// auto-load; every other profile (`prod`, `staging`, and any custom profile)
+/// requires `AUTUMN_DOTENV=1`.
 fn should_load(profile: &str, env: &dyn Env) -> bool {
     if let Ok(raw) = env.var("AUTUMN_DOTENV") {
         match raw.trim() {
@@ -73,7 +76,7 @@ fn should_load(profile: &str, env: &dyn Env) -> bool {
             _ => {}
         }
     }
-    profile != "prod"
+    matches!(profile, "dev" | "test")
 }
 
 /// Parse the contents of a single `.env` file into ordered key/value pairs.
@@ -550,6 +553,38 @@ export BAZ=qux
         let env = MockEnv::new().with("AUTUMN_DOTENV", "0");
         let out = resolve_dotenv_vars(dir.path(), "dev", &env).unwrap();
         assert!(out.is_empty(), "AUTUMN_DOTENV=0 must disable loading");
+    }
+
+    #[test]
+    fn gating_test_profile_loads() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".env"), "FOO=bar\n").unwrap();
+        let env = MockEnv::new();
+        let out = resolve_dotenv_vars(dir.path(), "test", &env).unwrap();
+        assert_eq!(out, vec![("FOO".to_owned(), "bar".to_owned())]);
+    }
+
+    #[test]
+    fn gating_custom_profile_does_not_load_by_default() {
+        // A non-prod custom profile such as `staging` must NOT auto-load `.env`
+        // without the explicit opt-in — only `dev`/`test` auto-load.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".env"), "FOO=bar\n").unwrap();
+        let env = MockEnv::new();
+        let out = resolve_dotenv_vars(dir.path(), "staging", &env).unwrap();
+        assert!(
+            out.is_empty(),
+            "a custom profile must not auto-load .env by default"
+        );
+    }
+
+    #[test]
+    fn gating_custom_profile_loads_with_opt_in() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".env"), "FOO=bar\n").unwrap();
+        let env = MockEnv::new().with("AUTUMN_DOTENV", "1");
+        let out = resolve_dotenv_vars(dir.path(), "staging", &env).unwrap();
+        assert_eq!(out, vec![("FOO".to_owned(), "bar".to_owned())]);
     }
 
     #[test]

--- a/autumn/src/dotenv.rs
+++ b/autumn/src/dotenv.rs
@@ -1,0 +1,618 @@
+//! Auto-loading of a project-root `.env` file in local development.
+//!
+//! A `.env` file is a **local-dev feeder for the highest configuration
+//! layer** — the `AUTUMN_*` environment-variable layer. It does *not*
+//! introduce a new precedence tier: `.env`-derived values are layered *under*
+//! the real environment via an overlay [`Env`] ([`DotenvEnv`] /
+//! [`DotenvOsEnv`]) rather than mutating the process environment, so a real
+//! shell environment variable always wins over the same key in a `.env` file.
+//!
+//! Files are loaded in order — `.env`, then `.env.local`, then
+//! `.env.{profile}`, then `.env.{profile}.local` — and, within that order,
+//! earlier files (and any real environment variable) win: a later file only
+//! fills keys that are still unset.
+//!
+//! Auto-loading happens in the `dev` and `test` profiles. It is skipped in
+//! `prod` unless `AUTUMN_DOTENV=1` (or `true`) is set; conversely it can be
+//! disabled anywhere with `AUTUMN_DOTENV=0` (or `false`).
+//!
+//! There is intentionally **no** `${VAR}` interpolation: values are treated
+//! as literal strings (with optional surrounding single or double quotes
+//! stripped).
+
+use std::path::{Path, PathBuf};
+
+use crate::config::{Env, OsEnv, resolve_profile};
+
+/// An error encountered while reading or parsing a `.env` file.
+///
+/// The [`Display`](std::fmt::Display) form is `"{path}:{line}: {message}"`,
+/// mirroring the compiler-style `file:line: message` convention so the
+/// offending location is obvious.
+#[derive(Debug)]
+pub struct DotenvError {
+    /// The `.env` file the error came from.
+    pub path: PathBuf,
+    /// The 1-based line number the error occurred on (`0` for whole-file
+    /// errors such as an I/O failure).
+    pub line: usize,
+    /// A human-readable description of what went wrong.
+    pub message: String,
+}
+
+impl std::fmt::Display for DotenvError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}: {}", self.path.display(), self.line, self.message)
+    }
+}
+
+impl std::error::Error for DotenvError {}
+
+/// The ordered list of candidate `.env` files for a given profile.
+///
+/// Order encodes precedence: earlier files win (a later file only fills keys
+/// that are still unset).
+fn candidate_files(profile: &str) -> Vec<String> {
+    vec![
+        ".env".to_owned(),
+        ".env.local".to_owned(),
+        format!(".env.{profile}"),
+        format!(".env.{profile}.local"),
+    ]
+}
+
+/// Decide whether `.env` auto-loading should run for `profile`.
+///
+/// `AUTUMN_DOTENV=1`/`true` forces loading on; `AUTUMN_DOTENV=0`/`false`
+/// forces it off. Absent that override, every profile except `prod` loads.
+fn should_load(profile: &str, env: &dyn Env) -> bool {
+    if let Ok(raw) = env.var("AUTUMN_DOTENV") {
+        match raw.trim() {
+            "1" | "true" => return true,
+            "0" | "false" => return false,
+            _ => {}
+        }
+    }
+    profile != "prod"
+}
+
+/// Parse the contents of a single `.env` file into ordered key/value pairs.
+///
+/// Blank lines and `#` comments are skipped. A leading `export ` prefix is
+/// stripped. Keys must match `[A-Za-z_][A-Za-z0-9_]*`. Values are taken
+/// verbatim after the first `=`, trimmed, with matching surrounding single or
+/// double quotes stripped. There is no `${VAR}` interpolation.
+///
+/// # Errors
+/// Returns a [`DotenvError`] (with the correct 1-based line number) for a line
+/// with no `=`, or a syntactically invalid key.
+fn parse_dotenv(path: &Path, contents: &str) -> Result<Vec<(String, String)>, DotenvError> {
+    let mut out = Vec::new();
+    for (idx, raw_line) in contents.lines().enumerate() {
+        let line_no = idx + 1;
+        let trimmed = raw_line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        // Strip an optional leading `export ` prefix.
+        let body = trimmed
+            .strip_prefix("export ")
+            .unwrap_or(trimmed)
+            .trim_start();
+
+        let Some(eq) = body.find('=') else {
+            return Err(DotenvError {
+                path: path.to_path_buf(),
+                line: line_no,
+                message: format!("expected KEY=VALUE, found `{raw_line}`"),
+            });
+        };
+
+        let key = body[..eq].trim();
+        if !is_valid_key(key) {
+            return Err(DotenvError {
+                path: path.to_path_buf(),
+                line: line_no,
+                message: format!("invalid variable name `{key}` in `{raw_line}`"),
+            });
+        }
+
+        let value_raw = body[eq + 1..].trim();
+        let value = strip_quotes(value_raw);
+        out.push((key.to_owned(), value));
+    }
+    Ok(out)
+}
+
+/// A key is valid when it is non-empty, starts with an ASCII letter or `_`,
+/// and otherwise contains only ASCII alphanumerics or `_`.
+fn is_valid_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Strip a single matching pair of surrounding single or double quotes, if
+/// present. The content is otherwise returned verbatim (no interpolation).
+fn strip_quotes(value: &str) -> String {
+    let bytes = value.as_bytes();
+    if bytes.len() >= 2 {
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        if (first == b'"' || first == b'\'') && first == last {
+            return value[1..value.len() - 1].to_owned();
+        }
+    }
+    value.to_owned()
+}
+
+/// Resolve the merged `.env` variable set for a directory and profile.
+///
+/// Returns an empty vector when loading is disabled (see [`should_load`]).
+/// Otherwise reads each candidate file in order; a missing file is skipped
+/// (not an error), any other read error becomes a [`DotenvError`]. Within the
+/// merge, a key already present in the real environment is dropped entirely
+/// (real env always wins), and the first file to set a key wins over later
+/// files.
+///
+/// # Errors
+/// Returns a [`DotenvError`] if a candidate file exists but cannot be read, or
+/// if a present file fails to parse.
+pub(crate) fn resolve_dotenv_vars(
+    dir: &Path,
+    profile: &str,
+    env: &dyn Env,
+) -> Result<Vec<(String, String)>, DotenvError> {
+    if !should_load(profile, env) {
+        return Ok(Vec::new());
+    }
+
+    let mut merged: Vec<(String, String)> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for filename in candidate_files(profile) {
+        let path = dir.join(&filename);
+        let contents = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => {
+                return Err(DotenvError {
+                    path,
+                    line: 0,
+                    message: format!("failed to read: {e}"),
+                });
+            }
+        };
+
+        for (key, value) in parse_dotenv(&path, &contents)? {
+            // Real environment variables always win.
+            if env.var(&key).is_ok() {
+                continue;
+            }
+            // Earlier file / already-seen key wins.
+            if seen.insert(key.clone()) {
+                merged.push((key, value));
+            }
+        }
+    }
+
+    Ok(merged)
+}
+
+/// An [`Env`] that overlays `.env`-derived values UNDER a base environment:
+/// the base (real process env) is consulted first; overlay values only fill
+/// keys the base does not define. Feeds the `AUTUMN_*` env-var layer from
+/// `.env` without mutating the process environment.
+pub(crate) struct DotenvEnv<'a> {
+    base: &'a dyn Env,
+    overlay: std::collections::BTreeMap<String, String>,
+}
+
+impl<'a> DotenvEnv<'a> {
+    /// Wrap `base`, layering `vars` (from [`resolve_dotenv_vars`]) underneath it.
+    pub(crate) fn new(base: &'a dyn Env, vars: Vec<(String, String)>) -> Self {
+        Self {
+            base,
+            overlay: vars.into_iter().collect(),
+        }
+    }
+}
+
+impl Env for DotenvEnv<'_> {
+    fn var(&self, key: &str) -> Result<String, std::env::VarError> {
+        // Base (real env) wins; the overlay only fills keys the base lacks.
+        self.base.var(key).or_else(|_| {
+            self.overlay
+                .get(key)
+                .cloned()
+                .ok_or(std::env::VarError::NotPresent)
+        })
+    }
+}
+
+/// Owning overlay over the real OS environment, for CLI callers that cannot
+/// borrow a local [`OsEnv`]. The real environment wins; `.env`-derived values
+/// only fill keys the OS environment does not define.
+pub struct DotenvOsEnv {
+    overlay: std::collections::BTreeMap<String, String>,
+}
+
+impl Env for DotenvOsEnv {
+    fn var(&self, key: &str) -> Result<String, std::env::VarError> {
+        // Real OS env wins; the overlay only fills keys the OS env lacks.
+        OsEnv.var(key).or_else(|_| {
+            self.overlay
+                .get(key)
+                .cloned()
+                .ok_or(std::env::VarError::NotPresent)
+        })
+    }
+}
+
+/// Resolve `.env` vars for the current working directory using the real OS env
+/// and resolved profile.
+///
+/// Returns the `(key, value)` pairs to apply (empty when gating disables
+/// loading — see [`should_load`]). If the current directory cannot be
+/// determined, resolution falls back to `.`.
+///
+/// # Errors
+/// Returns a [`DotenvError`] (with a `path:line` location) on a malformed or
+/// unreadable `.env` file.
+pub fn resolve_dotenv_for_cwd() -> Result<Vec<(String, String)>, DotenvError> {
+    let base = OsEnv;
+    let profile = resolve_profile(&base);
+    let dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    resolve_dotenv_vars(&dir, &profile, &base)
+}
+
+/// The real OS environment overlaid with `.env` values, for CLI resolution that
+/// must consult `.env` (e.g. DB URL resolution in `autumn migrate`).
+///
+/// # Errors
+/// Returns a [`DotenvError`] if a project-root `.env` file exists but cannot be
+/// read or parsed.
+pub fn os_env_with_dotenv() -> Result<DotenvOsEnv, DotenvError> {
+    Ok(DotenvOsEnv {
+        overlay: resolve_dotenv_for_cwd()?.into_iter().collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::MockEnv;
+    use std::path::PathBuf;
+
+    fn p() -> PathBuf {
+        PathBuf::from("/tmp/.env")
+    }
+
+    #[test]
+    fn parses_simple_pairs() {
+        let out = parse_dotenv(&p(), "FOO=bar\nBAZ=qux\n").unwrap();
+        assert_eq!(
+            out,
+            vec![
+                ("FOO".to_owned(), "bar".to_owned()),
+                ("BAZ".to_owned(), "qux".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn strips_matching_quotes() {
+        let out = parse_dotenv(
+            &p(),
+            "A=\"double quoted\"\nB='single quoted'\nC=unquoted value\n",
+        )
+        .unwrap();
+        assert_eq!(out[0], ("A".to_owned(), "double quoted".to_owned()));
+        assert_eq!(out[1], ("B".to_owned(), "single quoted".to_owned()));
+        assert_eq!(out[2], ("C".to_owned(), "unquoted value".to_owned()));
+    }
+
+    #[test]
+    fn no_interpolation_of_dollar_vars() {
+        let out = parse_dotenv(&p(), "A=${FOO}/literal\n").unwrap();
+        assert_eq!(out[0], ("A".to_owned(), "${FOO}/literal".to_owned()));
+    }
+
+    #[test]
+    fn skips_comments_blanks_and_handles_export() {
+        let contents = "\
+# a comment
+   # indented comment
+
+FOO=bar
+export BAZ=qux
+   export SPACED=value
+";
+        let out = parse_dotenv(&p(), contents).unwrap();
+        assert_eq!(
+            out,
+            vec![
+                ("FOO".to_owned(), "bar".to_owned()),
+                ("BAZ".to_owned(), "qux".to_owned()),
+                ("SPACED".to_owned(), "value".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn malformed_line_reports_correct_line_and_path() {
+        let contents = "FOO=bar\nNOEQUALS\nBAZ=qux\n";
+        let err = parse_dotenv(&p(), contents).unwrap_err();
+        assert_eq!(err.line, 2);
+        assert_eq!(err.path, p());
+        assert!(err.message.contains("KEY=VALUE"), "got: {}", err.message);
+        // Display form is file:line: message.
+        assert!(err.to_string().contains("/tmp/.env:2:"), "{err}");
+    }
+
+    #[test]
+    fn invalid_key_is_an_error() {
+        let contents = "FOO=ok\n1BAD=nope\n";
+        let err = parse_dotenv(&p(), contents).unwrap_err();
+        assert_eq!(err.line, 2);
+        assert!(
+            err.message.contains("invalid variable name"),
+            "got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn missing_files_are_ok_and_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = MockEnv::new();
+        let out = resolve_dotenv_vars(dir.path(), "dev", &env).unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn file_order_earlier_wins() {
+        let dir = tempfile::tempdir().unwrap();
+        // `.env` sets KEY=from_env and ONLY_BASE.
+        std::fs::write(dir.path().join(".env"), "KEY=from_env\nONLY_BASE=base\n").unwrap();
+        // `.env.local` tries to override KEY and adds ONLY_LOCAL.
+        std::fs::write(
+            dir.path().join(".env.local"),
+            "KEY=from_local\nONLY_LOCAL=local\n",
+        )
+        .unwrap();
+        // `.env.dev` tries to override KEY and adds ONLY_DEV.
+        std::fs::write(dir.path().join(".env.dev"), "KEY=from_dev\nONLY_DEV=dev\n").unwrap();
+
+        let env = MockEnv::new();
+        let out = resolve_dotenv_vars(dir.path(), "dev", &env).unwrap();
+        let map: std::collections::HashMap<_, _> = out.into_iter().collect();
+        // Earlier file wins for overlapping keys.
+        assert_eq!(map.get("KEY").map(String::as_str), Some("from_env"));
+        assert_eq!(map.get("ONLY_BASE").map(String::as_str), Some("base"));
+        assert_eq!(map.get("ONLY_LOCAL").map(String::as_str), Some("local"));
+        assert_eq!(map.get("ONLY_DEV").map(String::as_str), Some("dev"));
+    }
+
+    #[test]
+    fn real_env_always_wins() {
+        // AC #2 precedence test: a key already set in the real environment is
+        // excluded from the resolved `.env` set entirely.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".env"),
+            "AUTUMN_DATABASE__URL=postgres://from-dotenv\nOTHER=x\n",
+        )
+        .unwrap();
+
+        let env = MockEnv::new().with("AUTUMN_DATABASE__URL", "postgres://from-real-env");
+        let out = resolve_dotenv_vars(dir.path(), "dev", &env).unwrap();
+        let map: std::collections::HashMap<_, _> = out.into_iter().collect();
+        assert!(
+            !map.contains_key("AUTUMN_DATABASE__URL"),
+            "real env var must win and be excluded from the .env result"
+        );
+        assert_eq!(map.get("OTHER").map(String::as_str), Some("x"));
+    }
+
+    #[test]
+    fn bare_database_url_key_is_returned() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".env"),
+            "DATABASE_URL=postgres://localhost/app\n",
+        )
+        .unwrap();
+        let env = MockEnv::new();
+        let out = resolve_dotenv_vars(dir.path(), "dev", &env).unwrap();
+        let map: std::collections::HashMap<_, _> = out.into_iter().collect();
+        assert_eq!(
+            map.get("DATABASE_URL").map(String::as_str),
+            Some("postgres://localhost/app")
+        );
+    }
+
+    #[test]
+    fn read_error_becomes_dotenv_error() {
+        let dir = tempfile::tempdir().unwrap();
+        // Create `.env` as a directory so reading it as a file errors (not
+        // NotFound), which must surface as a DotenvError.
+        std::fs::create_dir(dir.path().join(".env")).unwrap();
+        let env = MockEnv::new();
+        let err = resolve_dotenv_vars(dir.path(), "dev", &env).unwrap_err();
+        assert_eq!(err.line, 0);
+        assert!(
+            err.message.contains("failed to read"),
+            "got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn gating_prod_does_not_load() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".env"), "FOO=bar\n").unwrap();
+        let env = MockEnv::new();
+        let out = resolve_dotenv_vars(dir.path(), "prod", &env).unwrap();
+        assert!(out.is_empty(), "prod must not auto-load .env");
+    }
+
+    #[test]
+    fn gating_prod_loads_with_opt_in() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".env"), "FOO=bar\n").unwrap();
+        let env = MockEnv::new().with("AUTUMN_DOTENV", "1");
+        let out = resolve_dotenv_vars(dir.path(), "prod", &env).unwrap();
+        assert_eq!(out, vec![("FOO".to_owned(), "bar".to_owned())]);
+    }
+
+    #[test]
+    fn gating_dev_loads() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".env"), "FOO=bar\n").unwrap();
+        let env = MockEnv::new();
+        let out = resolve_dotenv_vars(dir.path(), "dev", &env).unwrap();
+        assert_eq!(out, vec![("FOO".to_owned(), "bar".to_owned())]);
+    }
+
+    #[test]
+    fn gating_dev_disabled_with_opt_out() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".env"), "FOO=bar\n").unwrap();
+        let env = MockEnv::new().with("AUTUMN_DOTENV", "0");
+        let out = resolve_dotenv_vars(dir.path(), "dev", &env).unwrap();
+        assert!(out.is_empty(), "AUTUMN_DOTENV=0 must disable loading");
+    }
+
+    #[test]
+    fn candidate_file_order() {
+        assert_eq!(
+            candidate_files("dev"),
+            vec![".env", ".env.local", ".env.dev", ".env.dev.local"]
+        );
+    }
+
+    #[test]
+    fn dotenv_env_base_wins_over_overlay() {
+        // Real env (base) defines the key: base value must win.
+        let base = MockEnv::new().with("AUTUMN_DATABASE__URL", "postgres://from-real-env");
+        let env = DotenvEnv::new(
+            &base,
+            vec![(
+                "AUTUMN_DATABASE__URL".to_owned(),
+                "postgres://from-dotenv".to_owned(),
+            )],
+        );
+        assert_eq!(
+            env.var("AUTUMN_DATABASE__URL").unwrap(),
+            "postgres://from-real-env"
+        );
+    }
+
+    #[test]
+    fn dotenv_env_overlay_fills_unset_key() {
+        // Base does not define the key: overlay value fills it.
+        let base = MockEnv::new();
+        let env = DotenvEnv::new(
+            &base,
+            vec![(
+                "AUTUMN_DATABASE__URL".to_owned(),
+                "postgres://from-dotenv".to_owned(),
+            )],
+        );
+        assert_eq!(
+            env.var("AUTUMN_DATABASE__URL").unwrap(),
+            "postgres://from-dotenv"
+        );
+    }
+
+    #[test]
+    fn dotenv_env_miss_is_not_present() {
+        let base = MockEnv::new();
+        let env = DotenvEnv::new(&base, vec![("FOO".to_owned(), "bar".to_owned())]);
+        assert_eq!(env.var("MISSING"), Err(std::env::VarError::NotPresent));
+    }
+
+    #[test]
+    fn dotenv_os_env_base_wins_over_overlay() {
+        // A real OS env var must win over the overlay value for the same key.
+        // Uses a key that is essentially never set in the test environment,
+        // set locally for the duration of this test via `temp_env`.
+        let overlay = std::collections::BTreeMap::from([(
+            "AUTUMN_TEST_DOTENV_OVERLAY_KEY".to_owned(),
+            "from-dotenv".to_owned(),
+        )]);
+        let env = DotenvOsEnv { overlay };
+        temp_env::with_var(
+            "AUTUMN_TEST_DOTENV_OVERLAY_KEY",
+            Some("from-real-env"),
+            || {
+                assert_eq!(
+                    env.var("AUTUMN_TEST_DOTENV_OVERLAY_KEY").unwrap(),
+                    "from-real-env"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn dotenv_os_env_overlay_fills_unset_key() {
+        let overlay = std::collections::BTreeMap::from([(
+            "AUTUMN_TEST_DOTENV_OVERLAY_UNSET".to_owned(),
+            "from-dotenv".to_owned(),
+        )]);
+        let env = DotenvOsEnv { overlay };
+        temp_env::with_var_unset("AUTUMN_TEST_DOTENV_OVERLAY_UNSET", || {
+            assert_eq!(
+                env.var("AUTUMN_TEST_DOTENV_OVERLAY_UNSET").unwrap(),
+                "from-dotenv"
+            );
+        });
+    }
+
+    #[test]
+    fn dotenv_resolves_into_config_via_overlay() {
+        // End-to-end: a `.env` value flows into `config.database.url` through
+        // the overlay `Env`, with no process-environment mutation.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".env"),
+            "AUTUMN_DATABASE__URL=postgres://localhost/from-dotenv\n",
+        )
+        .unwrap();
+
+        let base = MockEnv::new();
+        let vars = resolve_dotenv_vars(dir.path(), "dev", &base).unwrap();
+        let env = DotenvEnv::new(&base, vars);
+        let config = crate::config::AutumnConfig::load_with_env(&env).unwrap();
+        assert_eq!(
+            config.database.url.as_deref(),
+            Some("postgres://localhost/from-dotenv")
+        );
+    }
+
+    #[test]
+    fn real_env_wins_over_dotenv_end_to_end() {
+        // A real env var of the same key must win over the `.env` value when
+        // resolved end-to-end into config.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".env"),
+            "AUTUMN_DATABASE__URL=postgres://localhost/from-dotenv\n",
+        )
+        .unwrap();
+
+        let base =
+            MockEnv::new().with("AUTUMN_DATABASE__URL", "postgres://localhost/from-real-env");
+        let vars = resolve_dotenv_vars(dir.path(), "dev", &base).unwrap();
+        let env = DotenvEnv::new(&base, vars);
+        let config = crate::config::AutumnConfig::load_with_env(&env).unwrap();
+        assert_eq!(
+            config.database.url.as_deref(),
+            Some("postgres://localhost/from-real-env")
+        );
+    }
+}

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -88,6 +88,7 @@ pub mod config;
 pub mod credentials;
 #[cfg(feature = "db")]
 pub mod db;
+pub mod dotenv;
 pub mod download;
 pub mod encryption;
 pub mod error;

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -558,6 +558,15 @@ Profile selection precedence:
 3. `--profile <name>`
 4. `AUTUMN_IS_DEBUG` auto-detection from the macro
 
+`.env` auto-loading (unreleased — trunk-dev): a project-root `.env` file is a
+local-dev feeder for the env-var layer (6), not a new precedence tier. On
+startup Autumn injects `.env` values into the process environment only for keys
+that are still unset, so a real environment variable of the same name always
+wins. Files load in order `.env` → `.env.local` → `.env.{profile}` →
+`.env.{profile}.local`, and earlier files (and real env vars) win. Auto-loaded
+in `dev`/`test`; skipped in `prod` unless `AUTUMN_DOTENV=1` (set `AUTUMN_DOTENV=0`
+to disable it anywhere). A malformed `.env` fails loudly at startup.
+
 Frequently used env keys:
 
 | Env | Config field |

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -22,7 +22,10 @@ Before running `autumn dev`, verify:
    if no database URL is present. Note: `autumn migrate check` analyzes
    migration SQL files only and does NOT test connectivity — to verify the
    database is reachable, attempt `autumn migrate status` or start the server
-   and watch the startup logs.
+   and watch the startup logs. `autumn dev` now auto-loads a project-root
+   `.env` file (dev/test profiles) into the `AUTUMN_*` env layer before boot,
+   so you can set `AUTUMN_DATABASE__URL` there (copy `.env.example` to `.env`);
+   real shell env vars still win, and a malformed `.env` fails loudly.
 
 2. **Tailwind binary is present** — if `autumn setup` has not been run:
    ```bash

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -67,7 +67,7 @@ These names match what `autumn doctor --json` actually emits in the `name` field
 | `trusted_hosts` | Set explicit `[security] trusted_hosts` in `autumn.toml` for production |
 | `rate_limit_key_strategy` | Set `rate_limit.key_strategy` to `"ip"`, `"api_token"`, or `"authenticated_principal"` |
 | `version_compat` | Upgrade `autumn-cli` to match the framework version: `cargo install autumn-cli --version 0.5.0` |
-| `dotenv` | Copy `.env.example` to `.env` and fill in local values, or add `.env` to `.gitignore` if it is present but not ignored (warns only; never fails) |
+| `dotenv` | Copy `.env.example` to `.env` and fill in local values, or add every present secret dotenv file (`.env`, `.env.local`, and any `.env.<profile>.local`) to `.gitignore` if it is not already ignored — committable `.env.<profile>` files are left alone (warns only; never fails) |
 
 ## Secrets redaction
 

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -67,6 +67,7 @@ These names match what `autumn doctor --json` actually emits in the `name` field
 | `trusted_hosts` | Set explicit `[security] trusted_hosts` in `autumn.toml` for production |
 | `rate_limit_key_strategy` | Set `rate_limit.key_strategy` to `"ip"`, `"api_token"`, or `"authenticated_principal"` |
 | `version_compat` | Upgrade `autumn-cli` to match the framework version: `cargo install autumn-cli --version 0.5.0` |
+| `dotenv` | Copy `.env.example` to `.env` and fill in local values, or add `.env` to `.gitignore` if it is present but not ignored (warns only; never fails) |
 
 ## Secrets redaction
 

--- a/skills/new/SKILL.md
+++ b/skills/new/SKILL.md
@@ -76,6 +76,7 @@ First-run checklist:
 | File | Purpose |
 |---|---|
 | `README.md` | Generated quickstart — prerequisites and the golden-path commands (configure the `[database]` block in `autumn.toml`, then `autumn migrate` → `autumn dev`) that take a clean checkout to a serving route, plus a CLI reference. Flag-aware: `--with-i18n` / `--with-seed` add sections for their extra steps. |
+| `.env.example` | Documented template of local env vars. Copy it to `.env` (gitignored) and fill in local values (e.g. `AUTUMN_DATABASE__URL`); Autumn auto-loads `.env` in the dev/test profiles. Real shell env vars always win over `.env`. |
 | `autumn.toml` | Base config (server, database, session, security, logging) |
 | `autumn-dev.toml` | Dev profile overrides (auto-detected in debug builds) |
 | `src/main.rs` | AppBuilder setup — register routes, tasks, jobs, migrations here |


### PR DESCRIPTION
Closes #1051

## Before / After

**Before:** to point a local app at a database (or set any config), developers had to `export AUTUMN_DATABASE__URL=...` in every shell, or risk committing secrets into `autumn.toml`. There was no ergonomic, git-safe place to keep local values.

**After:** drop your values into a gitignored project-root `.env` and they are auto-loaded in the `dev` and `test` profiles — no shell export, nothing to commit. Real shell environment variables still always win over `.env`, so `.env` never overrides an explicitly-set variable.

## How

- **Overlay `Env` feeding the env-var layer.** A new `autumn-web::dotenv` module parses `.env` and layers the values *under* the real environment via an overlay `Env` (`DotenvEnv` / `DotenvOsEnv`). It is not a new precedence tier and it does **not** mutate the process environment — it only fills `AUTUMN_*` env-layer keys that are still unset. `AutumnConfig::load` and the async config loader both resolve through this overlay; `autumn dev` injects the resolved vars into the child process and `autumn migrate` consults `.env` for DB-URL resolution.
- **`autumn new`** now scaffolds a documented `.env.example` (keys `AUTUMN_DATABASE__URL`, `AUTUMN_MASTER_KEY`, `AUTUMN_LOG__LEVEL`) and gitignores `.env`, `.env.local`, and `.env.*.local` while keeping `.env.example` tracked.
- **`autumn doctor`** gained a `dotenv` check that warns when `.env.example` exists without a `.env`, or when a `.env` is present but not gitignored.
- **Plugin skill docs** (`dev`, `doctor`, `new`, `autumn-web` reference) updated to describe the behavior.

## Load order and gating

Files load in order, later files filling only still-unset keys (earlier files and real env vars win):

```
.env  ->  .env.local  ->  .env.{profile}  ->  .env.{profile}.local
```

Missing files are not an error. A malformed `.env` line fails loudly with a `path:line` diagnostic. Auto-loading runs in `dev`/`test` and is skipped in `prod` unless you opt in with `AUTUMN_DOTENV=1` (and can be disabled anywhere with `AUTUMN_DOTENV=0`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6yWqihZqWmzNdTF6NaxcM)_