### PR TITLE
feat(repository): typed grouped aggregate queries (#1364)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -321,6 +321,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   through `across_tenants()` is rejected rather than silently writing to a single
   shard while matching rows on other shards go unseen. See the
   "Race-safe get-or-insert" section of the repositories guide.
+- **repository:** typed grouped aggregate queries (#1364) — declarative
+  `GROUP BY` roll-ups on a `#[repository]` trait. **Before:** dashboard
+  aggregates (a post's vote tally, an experiment's audit-trail size) were
+  hand-written raw `diesel::sql_query("SELECT … SUM/COUNT … GROUP BY …")`
+  strings that bypassed the repository's replica routing, tenant scoping, and
+  soft-delete filters and had to be re-typed for every widening cast.
+  **After:** declare the aggregate by method name with its pair return type —
+  `count_grouped_by_<col>() -> Vec<(K, i64)>` or
+  `sum_/avg_/min_/max_<num_col>_grouped_by_<col>() -> Vec<(K, Option<T>)>`
+  (`avg` rolls up to `Option<f64>`) — and the macro generates an inherent
+  method returning a lazy `GroupedAggregate<'_, K, V>` builder that yields one
+  `(group, aggregate)` pair per group. Chain `.order_by_aggregate_desc()` /
+  `.limit(n)` for top-N, `.filter_eq(v)` / `.filter_range(lo, hi)` to scope the
+  group column *before* aggregating, or `.bucket(DateBucket::{Day,Week,Month})`
+  for a `date_trunc` time series, then `.load().await`. Filter values are bound
+  as parameters (never interpolated); the query composes the same soft-delete +
+  tenant predicates as `count` and acquires its connection through the read
+  route, so replica routing and multi-tenancy come for free.
+  `sum`/`avg`/`min`/`max` are null-safe (an all-`NULL` group yields `None`, an
+  empty table an empty `Vec`) and are rejected on a sharded, tenant-scoped
+  repository used via `across_tenants()` rather than returning a
+  per-shard-partial answer. The reddit-clone vote tally and the admin
+  experiment-history count now use this instead of raw `SUM`/`COUNT` SQL.
+  Closes #1364. See "Grouped aggregate queries" in
+  `docs/guide/repositories.md`.
 - **widgets:** `flash_messages(&[FlashMessage])` (issue #1240) — an accessible
   renderer for consumed flash messages. Each banner is its own live region
   whose `role`/`aria-live` is chosen by severity (`Error`/`Warning` announce

--- a/autumn-admin-plugin/src/experiments.rs
+++ b/autumn-admin-plugin/src/experiments.rs
@@ -17,8 +17,11 @@ use crate::{
 // A typed `#[repository]` over `autumn_experiment_changes` so the per-experiment
 // audit-trail size is computed with the grouped-aggregate API
 // (`count_grouped_by_experiment().filter_eq(name)`) instead of a hand-written
-// `SELECT COUNT(*) … WHERE experiment = $1`. The read is replica-routed by the
-// generated executor — a dashboard win the raw `diesel::sql_query` skipped.
+// `SELECT COUNT(*) … WHERE experiment = $1`. The repo is built here via
+// `with_pool_untracked`, which is pool-aware but pins `ReadRoute::Primary` (it
+// carries no request/`AppState` read-route context) — so this read runs on the
+// primary, NOT a replica. A request-scoped constructor would let the same query
+// route to a replica for free.
 
 diesel::table! {
     autumn_experiment_changes (id) {

--- a/autumn-admin-plugin/src/experiments.rs
+++ b/autumn-admin-plugin/src/experiments.rs
@@ -12,6 +12,44 @@ use crate::{
     ListResult, SelectOption,
 };
 
+// ── Grouped-aggregate roll-up over the audit trail (#1364) ──────────────────
+//
+// A typed `#[repository]` over `autumn_experiment_changes` so the per-experiment
+// audit-trail size is computed with the grouped-aggregate API
+// (`count_grouped_by_experiment().filter_eq(name)`) instead of a hand-written
+// `SELECT COUNT(*) … WHERE experiment = $1`. The read is replica-routed by the
+// generated executor — a dashboard win the raw `diesel::sql_query` skipped.
+
+diesel::table! {
+    autumn_experiment_changes (id) {
+        id -> diesel::sql_types::Int8,
+        experiment -> diesel::sql_types::Text,
+        mutation -> diesel::sql_types::Text,
+        actor -> diesel::sql_types::Nullable<diesel::sql_types::Text>,
+        changed_at -> diesel::sql_types::Timestamptz,
+    }
+}
+
+#[autumn_web::model(table = "autumn_experiment_changes")]
+pub struct ExperimentChange {
+    #[id]
+    pub id: i64,
+    #[indexed]
+    pub experiment: String,
+    pub mutation: String,
+    pub actor: Option<String>,
+    #[default]
+    pub changed_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[autumn_web::repository(ExperimentChange, table = "autumn_experiment_changes")]
+pub trait ExperimentChangeRepository {
+    /// COUNT(*) GROUP BY experiment → one `(experiment, count)` pair per
+    /// experiment; `.filter_eq(name)` narrows it to a single experiment's
+    /// audit-trail size.
+    fn count_grouped_by_experiment() -> Vec<(String, i64)>;
+}
+
 /// Admin panel model for A/B experiments.
 ///
 /// Register this model with the admin plugin to get an experiment management UI
@@ -496,13 +534,19 @@ impl AdminModel for ExperimentAdminModel {
                 });
             };
 
-            let count: i64 = diesel::sql_query(
-                "SELECT COUNT(*) FROM autumn_experiment_changes WHERE experiment = $1",
-            )
-            .bind::<diesel::sql_types::Text, _>(&name)
-            .get_result::<CountRow>(&mut conn)
-            .await
-            .map_or(0, |r| r.count);
+            // Audit-trail size via the typed grouped-aggregate API (#1364):
+            // COUNT(*) GROUP BY experiment, scoped to this experiment. Grouping
+            // on the filtered column yields a single `(name, count)` row (or
+            // none when the experiment has no history). Errors degrade to 0,
+            // matching the previous raw-SQL `map_or(0, …)`.
+            let count: i64 = PgExperimentChangeRepository::with_pool_untracked(pool.clone())
+                .count_grouped_by_experiment()
+                .filter_eq(name.clone())
+                .load()
+                .await
+                .ok()
+                .and_then(|rows| rows.into_iter().next())
+                .map_or(0, |(_, c)| c);
 
             let offset = (page.saturating_sub(1)) * per_page;
             let entries: Vec<crate::AdminHistoryEntry> = diesel::sql_query(

--- a/autumn-admin-plugin/src/experiments.rs
+++ b/autumn-admin-plugin/src/experiments.rs
@@ -537,20 +537,6 @@ impl AdminModel for ExperimentAdminModel {
                 });
             };
 
-            // Audit-trail size via the typed grouped-aggregate API (#1364):
-            // COUNT(*) GROUP BY experiment, scoped to this experiment. Grouping
-            // on the filtered column yields a single `(name, count)` row (or
-            // none when the experiment has no history). Errors degrade to 0,
-            // matching the previous raw-SQL `map_or(0, …)`.
-            let count: i64 = PgExperimentChangeRepository::with_pool_untracked(pool.clone())
-                .count_grouped_by_experiment()
-                .filter_eq(name.clone())
-                .load()
-                .await
-                .ok()
-                .and_then(|rows| rows.into_iter().next())
-                .map_or(0, |(_, c)| c);
-
             let offset = (page.saturating_sub(1)) * per_page;
             let entries: Vec<crate::AdminHistoryEntry> = diesel::sql_query(
                 "SELECT id, mutation AS op, actor, changed_at \
@@ -575,6 +561,29 @@ impl AdminModel for ExperimentAdminModel {
                 recorded_at: r.changed_at,
             })
             .collect();
+
+            // Release this handler's connection before the grouped-aggregate
+            // count checks out its own. `conn` is held for the name + entries
+            // lookups above, and on a single-connection pool (max_size = 1, no
+            // read replica) a second concurrent checkout would block until the
+            // pool timeout — deadlocking the history page. The count does not
+            // depend on `entries`, so running it last, after `conn` is dropped,
+            // keeps the two checkouts from overlapping.
+            drop(conn);
+
+            // Audit-trail size via the typed grouped-aggregate API (#1364):
+            // COUNT(*) GROUP BY experiment, scoped to this experiment. Grouping
+            // on the filtered column yields a single `(name, count)` row (or
+            // none when the experiment has no history). Errors degrade to 0,
+            // matching the previous raw-SQL `map_or(0, …)`.
+            let count: i64 = PgExperimentChangeRepository::with_pool_untracked(pool.clone())
+                .count_grouped_by_experiment()
+                .filter_eq(name.clone())
+                .load()
+                .await
+                .ok()
+                .and_then(|rows| rows.into_iter().next())
+                .map_or(0, |(_, c)| c);
 
             Ok(AdminHistoryPage {
                 entries,

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -534,6 +534,17 @@ fn type_is_option_of(ty: &syn::Type, inner_ident: &str) -> bool {
     option_inner_type(ty).is_some_and(|inner| type_is_bare_ident(inner, inner_ident))
 }
 
+/// True if `ty`'s final path segment identifier is `ident`, ignoring any
+/// generic arguments — so it matches both `DateTime` and `DateTime<Utc>`. Used
+/// to detect a `timestamptz` group key (`DateTime<Utc>`) so `.bucket()`
+/// truncation can be pinned to UTC (#1364).
+fn type_last_segment_is(ty: &syn::Type, ident: &str) -> bool {
+    let syn::Type::Path(p) = ty else {
+        return false;
+    };
+    p.path.segments.last().is_some_and(|s| s.ident == ident)
+}
+
 /// Map a supported Rust type to its diesel `sql_types` path token, threading
 /// `Option<T>` to `Nullable<…>`. Returns `None` for unsupported types.
 fn diesel_sql_type_for(ty: &syn::Type) -> Option<TokenStream> {
@@ -8483,6 +8494,15 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             let value_sql_type = &spec.value_sql_type;
             let agg_expr = &spec.agg_sql_expr;
             let group_col_q = format!("\"{}\"", spec.group_col);
+            // #1364 timezone correctness: only a `timestamptz` (`DateTime<Utc>`)
+            // bucket key gets the UTC-pinning 3-arg `date_trunc` zone argument.
+            // A `NaiveDateTime` (`timestamp`) key keeps the plain 2-arg form
+            // (deterministic field truncation, session-tz independent).
+            let bucket_zone_arg: &str = if type_last_segment_is(key_type, "DateTime") {
+                ", 'UTC'"
+            } else {
+                ""
+            };
             let doc = format!(
                 "Grouped aggregate `{fn_ident}` → lazy `GroupedAggregate<'_, K, V>` builder (issue #1364).\n\n\
                  Chain `.order_by_aggregate_desc()`/`.limit(n)` for top-N, \
@@ -8515,11 +8535,20 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 }
 
                                 // Group expression: bucketed (date_trunc) or the raw column.
+                                // For a `timestamptz` (`DateTime<Utc>`) key, `#bucket_zone_arg`
+                                // is `, 'UTC'` so the 3-arg `date_trunc('unit', col, 'UTC')`
+                                // (Postgres 12+) truncates in UTC — otherwise the 2-arg form
+                                // would truncate in the DB session `TimeZone`, drifting bucket
+                                // boundaries across deployments (#1364). For a `NaiveDateTime`
+                                // (`timestamp`) key it is empty, keeping the deterministic
+                                // 2-arg field truncation. SELECT and GROUP BY reuse this same
+                                // string, so the bucket expression always matches exactly.
                                 let __group_expr: ::std::string::String = match __opts.bucket {
                                     ::core::option::Option::Some(__b) => format!(
-                                        "date_trunc('{unit}', {col})",
+                                        "date_trunc('{unit}', {col}{zone})",
                                         unit = __b.as_trunc_unit(),
                                         col = #group_col_q,
+                                        zone = #bucket_zone_arg,
                                     ),
                                     ::core::option::Option::None => ::std::string::String::from(#group_col_q),
                                 };
@@ -12122,6 +12151,71 @@ mod tests {
             generated.matches("IS NOT NULL").count(),
             1,
             "grouped aggregate must emit exactly one `IS NOT NULL` group-key guard: {generated}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_grouped_bucket_timestamptz_key_truncates_in_utc() {
+        // §1364 timezone correctness: a `DateTime<Utc>` (Postgres `timestamptz`)
+        // bucket key must truncate in an explicit UTC zone via the 3-arg
+        // `date_trunc('unit', col, 'UTC')` form (Postgres 12+). The 2-arg form
+        // would truncate in the DB session `TimeZone`, drifting bucket
+        // boundaries across deployments even though the API exposes UTC.
+        let generated = repository_macro(
+            quote! { Event, table = "events" },
+            quote! {
+                pub trait EventRepository {
+                    fn count_grouped_by_created_at() -> Vec<(::chrono::DateTime<::chrono::Utc>, i64)>;
+                }
+            },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("pub fn count_grouped_by_created_at"),
+            "grouped-aggregate method must be generated: {generated}"
+        );
+        // The emitted bucket expression pins truncation to UTC.
+        assert!(
+            generated.contains("date_trunc('{unit}', {col}{zone})"),
+            "bucket expression must be built from the parameterized template: {generated}"
+        );
+        assert!(
+            generated.contains("\", 'UTC'\""),
+            "timestamptz bucket key must supply the UTC zone argument so \
+             date_trunc truncates in UTC (#1364): {generated}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_grouped_bucket_timestamp_key_has_no_zone() {
+        // A `NaiveDateTime` (Postgres `timestamp WITHOUT time zone`) bucket key
+        // is a deterministic field truncation, so it keeps the plain 2-arg
+        // `date_trunc('unit', col)` with an EMPTY zone argument — no `'UTC'`.
+        let generated = repository_macro(
+            quote! { Event, table = "events" },
+            quote! {
+                pub trait EventRepository {
+                    fn count_grouped_by_created_at() -> Vec<(::chrono::NaiveDateTime, i64)>;
+                }
+            },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("pub fn count_grouped_by_created_at"),
+            "grouped-aggregate method must be generated: {generated}"
+        );
+        // Still built from the same parameterized bucket template …
+        assert!(
+            generated.contains("date_trunc('{unit}', {col}{zone})"),
+            "bucket expression must be built from the parameterized template: {generated}"
+        );
+        // … but with an empty zone argument, so no `'UTC'` is ever added.
+        assert!(
+            !generated.contains("'UTC'"),
+            "timestamp bucket key must NOT pin truncation to UTC — it is a \
+             deterministic field truncation (#1364): {generated}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -619,6 +619,9 @@ struct GroupedAggregateSpec {
     agg_sql_expr: String,
     /// The group column name (quoted-identifier-safe bare name).
     group_col: String,
+    /// The aggregated numeric column name, if any (`None` for `count`). Guarded
+    /// against at-rest encryption alongside the group column (#1364).
+    value_col: Option<String>,
     /// When set, generation emits a `compile_error!` with this message instead
     /// of a method.
     error: Option<String>,
@@ -1067,6 +1070,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 let mut value_sql_type = quote! { () };
                 let mut agg_sql_expr = String::new();
                 let mut group_col = String::new();
+                let mut value_col: Option<String> = None;
 
                 match (parsed, declared_pair) {
                     (None, _) => {
@@ -1085,6 +1089,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     }
                     (Some((kind, num_col, gcol)), Some((k, v))) => {
                         group_col = gcol;
+                        value_col.clone_from(&num_col);
                         let value_inner = option_inner_type(&v).unwrap_or(&v).clone();
 
                         // Numeric-column presence must match the aggregate, and
@@ -1232,6 +1237,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     value_sql_type,
                     agg_sql_expr,
                     group_col,
+                    value_col,
                     error,
                 });
                 continue;
@@ -8504,6 +8510,58 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             let value_sql_type = &spec.value_sql_type;
             let agg_expr = &spec.agg_sql_expr;
             let group_col_q = format!("\"{}\"", spec.group_col);
+
+            // #1364 encryption correctness: grouped aggregates cannot operate on
+            // an at-rest `#[encrypted(...)]` column. The stored value is
+            // ciphertext, so grouping would return ciphertext keys deserialized
+            // into the declared key type, and `.filter_eq(plaintext)` would bind
+            // plaintext against a ciphertext column and match nothing (the
+            // `find_by` path avoids this by routing string params through the
+            // registry encoder; this raw-SQL path cannot). Whether a column is
+            // encrypted is only known at runtime — the mode is declared on the
+            // model, which the repository macro cannot see (see
+            // `encode_derived_query_param`) — so this is a runtime guard against
+            // the SAME registry the `find_by` surface consults, not a
+            // `compile_error!`. It rejects only columns that are actually
+            // encrypted, so non-encrypted grouping (e.g. `count_grouped_by_kind`
+            // on a plain `String`) is unchanged. The escape hatch is a raw query.
+            let enc_guard = {
+                let fn_name_str = spec.fn_ident.to_string();
+                let group_col_raw = spec.group_col.as_str();
+                let mut checks: Vec<TokenStream> = vec![quote! {
+                    if ::autumn_web::encryption::is_encrypted_column(#table_name, #group_col_raw) {
+                        return ::core::result::Result::Err(
+                            ::autumn_web::AutumnError::internal_server_error_msg(
+                                ::std::format!(
+                                    "`{m}`: grouped aggregates are not supported on the encrypted \
+                                     column `{c}` (its stored value is ciphertext; grouping/filtering \
+                                     would compare or return ciphertext). Use a raw query, or group on \
+                                     a non-encrypted column.",
+                                    m = #fn_name_str, c = #group_col_raw,
+                                )
+                            )
+                        );
+                    }
+                }];
+                if let Some(value_col_raw) = spec.value_col.as_deref() {
+                    checks.push(quote! {
+                        if ::autumn_web::encryption::is_encrypted_column(#table_name, #value_col_raw) {
+                            return ::core::result::Result::Err(
+                                ::autumn_web::AutumnError::internal_server_error_msg(
+                                    ::std::format!(
+                                        "`{m}`: grouped aggregates are not supported on the encrypted \
+                                         column `{c}` (its stored value is ciphertext; grouping/filtering \
+                                         would compare or return ciphertext). Use a raw query, or group on \
+                                         a non-encrypted column.",
+                                        m = #fn_name_str, c = #value_col_raw,
+                                    )
+                                )
+                            );
+                        }
+                    });
+                }
+                quote! { #(#checks)* }
+            };
             // #1364 timezone correctness: only a `timestamptz` (`DateTime<Utc>`)
             // bucket key gets the UTC-pinning 3-arg `date_trunc` zone argument.
             // A `NaiveDateTime` (`timestamp`) key keeps the plain 2-arg form
@@ -8533,6 +8591,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 use ::autumn_web::reexports::diesel::prelude::*;
                                 use ::autumn_web::reexports::diesel_async::RunQueryDsl;
 
+                                #enc_guard
                                 #cross_shard_guard
                                 #tenant_resolve
 
@@ -12401,6 +12460,52 @@ mod tests {
         assert!(
             generated.contains("nullable group keys are unsupported"),
             "compile_error must explain nullable group keys are unsupported: {generated}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_grouped_aggregate_guards_encrypted_columns() {
+        // §1364 encryption correctness: whether a column is `#[encrypted(...)]`
+        // is declared on the model and is only known at runtime (the repository
+        // macro sees the trait, not the model's fields — see
+        // `encode_derived_query_param`), so a `compile_error!` cannot name the
+        // encrypted column. Instead the generated grouped-aggregate method emits
+        // a runtime guard against the SAME `is_encrypted_column` registry the
+        // `find_by` surface consults, rejecting both the group column and the
+        // aggregated numeric column before running any SQL. It fires only for
+        // columns that are actually encrypted, so non-encrypted grouping is
+        // unchanged (asserted separately by the other grouped-aggregate tests,
+        // whose generated bodies never early-return).
+        let generated = repository_macro(
+            quote! { Event, table = "events" },
+            quote! {
+                pub trait EventRepository {
+                    fn sum_secret_grouped_by_email() -> Vec<(String, Option<i64>)>;
+                }
+            },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("is_encrypted_column"),
+            "grouped aggregate must guard against encrypted columns at runtime: {generated}"
+        );
+        // Both the group column and the aggregated value column are guarded.
+        assert!(
+            generated.contains("\"email\""),
+            "guard must check the group column `email`: {generated}"
+        );
+        assert!(
+            generated.contains("\"secret\""),
+            "guard must check the aggregated value column `secret`: {generated}"
+        );
+        assert!(
+            generated.contains("not supported on the encrypted"),
+            "guard message must name the encrypted-column restriction: {generated}"
+        );
+        assert!(
+            generated.contains("Use a raw query"),
+            "guard message must point to the raw-SQL escape hatch: {generated}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -8531,6 +8531,16 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 let mut __n: i32 = 0;
                                 #soft_delete_cond
                                 #tenant_cond
+                                // A non-nullable declared key type cannot represent a
+                                // NULL group (and `Option<K>` is rejected at compile
+                                // time), so exclude rows whose raw group column is NULL —
+                                // otherwise `GROUP BY` would emit a NULL-key group that
+                                // fails to deserialize at runtime (#1364). Guarding the
+                                // raw column also drops null-timestamp rows under
+                                // `.bucket()` (date_trunc of NULL is NULL). No bind param,
+                                // so the `$n` numbering below is unaffected. Harmless
+                                // no-op when the column is already NOT NULL.
+                                __conds.push(format!("{col} IS NOT NULL", col = #group_col_q));
                                 let __eq_n = { __n += 1; __n };
                                 __conds.push(format!("(${n} IS NULL OR {col} = ${n})", n = __eq_n, col = #group_col_q));
                                 let __low_n = { __n += 1; __n };
@@ -12084,6 +12094,34 @@ mod tests {
         assert!(
             generated.contains("CURRENT_TENANT"),
             "tenant-scoped aggregate must resolve the active tenant: {generated}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_grouped_aggregate_excludes_null_group_keys() {
+        // §1364: because the declared key type is non-nullable (and `Option<K>`
+        // is a compile error), a NULL group would fail to deserialize at
+        // runtime. The generated SQL must always guard the raw group column
+        // with `IS NOT NULL` so NULL-key rows are silently excluded — safe even
+        // when the column is already NOT NULL (the planner drops the predicate).
+        let generated = repository_macro(
+            quote! { Vote, table = "votes" },
+            quote! {
+                pub trait VoteRepository {
+                    fn sum_value_grouped_by_post_id() -> Vec<(i64, Option<i64>)>;
+                }
+            },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("pub fn sum_value_grouped_by_post_id"),
+            "grouped-aggregate method must be generated: {generated}"
+        );
+        assert_eq!(
+            generated.matches("IS NOT NULL").count(),
+            1,
+            "grouped aggregate must emit exactly one `IS NOT NULL` group-key guard: {generated}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -8464,9 +8464,19 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             (quote! {}, quote! {}, quote! {})
         };
 
+        // Reject cross-shard aggregates whenever the repo is (compile-time)
+        // sharded + tenant-scoped AND the runtime `across_tenants` flag is set —
+        // independent of whether a live shard set (`__autumn_shards`) is loaded.
+        // sum/avg/min/max cannot be merged across shards, and an across-tenant
+        // scan without a shard set (e.g. built via `with_pool_untracked`, where
+        // `__autumn_shards` is `None`) would bind a NULL tenant predicate and
+        // silently return a PARTIAL result over only the current pool. Gating on
+        // `__autumn_shards.is_some()` missed exactly that no-shard-set case, so
+        // the guard fires purely on the sharded config + the `across_tenants`
+        // flag (#1364).
         let cross_shard_guard = if config_sharded && config_tenant_scoped {
             quote! {
-                if __repo.across_tenants && __repo.__autumn_shards.is_some() {
+                if __repo.across_tenants {
                     return ::core::result::Result::Err(
                         ::autumn_web::AutumnError::bad_request_msg(
                             "cross-shard grouped aggregates are not supported: \
@@ -12123,6 +12133,58 @@ mod tests {
         assert!(
             generated.contains("CURRENT_TENANT"),
             "tenant-scoped aggregate must resolve the active tenant: {generated}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_grouped_aggregate_rejects_across_tenants_without_shard_set() {
+        // §1364 tenant-isolation: a sharded + tenant-scoped grouped aggregate
+        // must reject `across_tenants()` cross-shard queries (sum/avg/min/max
+        // cannot be merged across shards). The guard must fire purely on the
+        // runtime `across_tenants` flag, NOT on a live shard set being present —
+        // otherwise a repo built without shard context (e.g. `with_pool_untracked`,
+        // where `__autumn_shards` is `None`) would slip past and silently return a
+        // PARTIAL result over only the current pool.
+        let generated = repository_macro(
+            quote! { Event, table = "events", tenant_scoped, sharded },
+            quote! {
+                pub trait EventRepository {
+                    fn sum_score_grouped_by_kind() -> Vec<(String, Option<i64>)>;
+                }
+            },
+        )
+        .to_string();
+
+        // Isolate the generated aggregate method body so the assertions below
+        // target the aggregate guard specifically (not some other cross-shard
+        // surface on the same repo).
+        let pos = generated
+            .find("pub fn sum_score_grouped_by_kind")
+            .expect("sharded+tenant_scoped grouped aggregate method must be generated");
+        let section = &generated[pos..];
+
+        // The rejection guard must be present in the aggregate body.
+        assert!(
+            section.contains("cross-shard grouped aggregates are not supported"),
+            "sharded+tenant_scoped grouped aggregate must reject across_tenants: {section}"
+        );
+        // The guard must key off the runtime `across_tenants` flag.
+        assert!(
+            section.contains("across_tenants"),
+            "aggregate guard must reference the across_tenants flag: {section}"
+        );
+        // The guard condition must NOT depend on a shard set being loaded —
+        // `__autumn_shards.is_some()` gating is exactly the no-shard-set hole
+        // this fix closes. Check the tokens up to the rejection so we assert on
+        // the guard condition, not on unrelated fan-out code elsewhere.
+        let guard_end = section
+            .find("cross-shard grouped aggregates are not supported")
+            .expect("rejection message must be present");
+        let guard_cond = &section[..guard_end];
+        assert!(
+            !guard_cond.contains("__autumn_shards . is_some")
+                && !guard_cond.contains("__autumn_shards.is_some"),
+            "aggregate guard condition must not depend on __autumn_shards being Some: {guard_cond}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -9,7 +9,7 @@
 //! Uses `diesel-async` `RunQueryDsl` for async queries - no sync `interact()`.
 
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
+use quote::{ToTokens, format_ident, quote};
 use syn::parse::Parser as _;
 use syn::{Ident, ItemTrait, LitStr, TraitItem};
 
@@ -417,6 +417,182 @@ fn parse_query_name(name: &str) -> Option<DerivedQuery> {
     })
 }
 
+/// The aggregate function a grouped-aggregate method computes (#1364).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum AggKind {
+    Count,
+    Sum,
+    Avg,
+    Min,
+    Max,
+}
+
+impl AggKind {
+    /// The bare aggregate keyword for diagnostics (`"count"`, `"sum"`, …).
+    const fn keyword(self) -> &'static str {
+        match self {
+            Self::Count => "count",
+            Self::Sum => "sum",
+            Self::Avg => "avg",
+            Self::Min => "min",
+            Self::Max => "max",
+        }
+    }
+}
+
+/// Parse a grouped-aggregate method name into `(kind, numeric_col, group_col)`.
+///
+/// Recognized shapes (issue #1364):
+/// - `count_grouped_by_<group_col>` → `(Count, None, group_col)`
+/// - `sum_<col>_grouped_by_<group_col>` → `(Sum, Some(col), group_col)`
+/// - `avg_<col>_grouped_by_<group_col>` → likewise for avg/min/max
+///
+/// Returns `None` when the name has no `_grouped_by_` segment at all (so the
+/// caller can fall through to the ordinary derived-query surface). A name that
+/// *does* contain `_grouped_by_` but is otherwise malformed returns
+/// `Some((_, _, group_col))` only when well formed; malformedness is reported
+/// separately by the caller via [`parse_grouped_aggregate_name`]'s companion
+/// error path.
+fn parse_grouped_aggregate_name(name: &str) -> Option<(AggKind, Option<String>, String)> {
+    let (left, group_col) = name.split_once("_grouped_by_")?;
+    if group_col.is_empty() || group_col.contains("_grouped_by_") {
+        return None;
+    }
+    if left == "count" {
+        return Some((AggKind::Count, None, group_col.to_string()));
+    }
+    for (prefix, kind) in [
+        ("sum_", AggKind::Sum),
+        ("avg_", AggKind::Avg),
+        ("min_", AggKind::Min),
+        ("max_", AggKind::Max),
+    ] {
+        if let Some(col) = left.strip_prefix(prefix)
+            && !col.is_empty()
+        {
+            return Some((kind, Some(col.to_string()), group_col.to_string()));
+        }
+    }
+    None
+}
+
+/// Extract `(K, V)` from a declared `Vec<(K, V)>` return type.
+fn parse_vec_pair_type(ty: &syn::Type) -> Option<(syn::Type, syn::Type)> {
+    let syn::Type::Path(p) = ty else { return None };
+    let seg = p.path.segments.last()?;
+    if seg.ident != "Vec" {
+        return None;
+    }
+    let syn::PathArguments::AngleBracketed(args) = &seg.arguments else {
+        return None;
+    };
+    let syn::GenericArgument::Type(syn::Type::Tuple(tuple)) = args.args.first()? else {
+        return None;
+    };
+    if tuple.elems.len() != 2 {
+        return None;
+    }
+    let mut it = tuple.elems.iter();
+    let k = it.next()?.clone();
+    let v = it.next()?.clone();
+    Some((k, v))
+}
+
+/// If `ty` is `Option<T>`, return the inner `T`.
+fn option_inner_type(ty: &syn::Type) -> Option<&syn::Type> {
+    let syn::Type::Path(p) = ty else { return None };
+    let seg = p.path.segments.last()?;
+    if seg.ident != "Option" {
+        return None;
+    }
+    let syn::PathArguments::AngleBracketed(args) = &seg.arguments else {
+        return None;
+    };
+    match args.args.first()? {
+        syn::GenericArgument::Type(inner) => Some(inner),
+        _ => None,
+    }
+}
+
+/// Map a supported Rust type to its diesel `sql_types` path token, threading
+/// `Option<T>` to `Nullable<…>`. Returns `None` for unsupported types.
+fn diesel_sql_type_for(ty: &syn::Type) -> Option<TokenStream> {
+    match ty {
+        syn::Type::Reference(r) => diesel_sql_type_for(&r.elem),
+        syn::Type::Path(p) => {
+            let seg = p.path.segments.last()?;
+            let name = seg.ident.to_string();
+            let d = quote! { ::autumn_web::reexports::diesel::sql_types };
+            if name == "Option" {
+                let inner = option_inner_type(ty)?;
+                let inner_st = diesel_sql_type_for(inner)?;
+                return Some(quote! { #d::Nullable<#inner_st> });
+            }
+            let st = match name.as_str() {
+                "i16" => quote! { #d::SmallInt },
+                "i32" => quote! { #d::Integer },
+                "i64" => quote! { #d::BigInt },
+                "f32" => quote! { #d::Float },
+                "f64" => quote! { #d::Double },
+                "bool" => quote! { #d::Bool },
+                "String" | "str" => quote! { #d::Text },
+                "Uuid" => quote! { #d::Uuid },
+                "NaiveDate" => quote! { #d::Date },
+                "NaiveDateTime" => quote! { #d::Timestamp },
+                "NaiveTime" => quote! { #d::Time },
+                "DateTime" => quote! { #d::Timestamptz },
+                _ => return None,
+            };
+            Some(st)
+        }
+        _ => None,
+    }
+}
+
+/// Map a supported numeric Rust type to the Postgres type name used to `CAST`
+/// an aggregate result so it deserializes back into the declared value type
+/// (Postgres widens `SUM`/`AVG`, so an explicit cast keeps the round-trip
+/// exact). Returns `None` for unsupported types.
+fn pg_cast_type_for(ty: &syn::Type) -> Option<&'static str> {
+    let syn::Type::Path(p) = ty else { return None };
+    let name = p.path.segments.last()?.ident.to_string();
+    let pg = match name.as_str() {
+        "i16" => "smallint",
+        "i32" => "integer",
+        "i64" => "bigint",
+        "f32" => "real",
+        "f64" => "double precision",
+        _ => return None,
+    };
+    Some(pg)
+}
+
+/// A parsed grouped-aggregate declaration (#1364).
+///
+/// Like [`FindOrCreateSpec`], this is emitted as an inherent method on the
+/// `Pg*` struct — it returns a lazy `GroupedAggregate<'_, K, V>` builder rather
+/// than a trait finder — so it lives in its own spec list.
+struct GroupedAggregateSpec {
+    /// The declared method identifier, e.g. `sum_amount_grouped_by_user_id`.
+    fn_ident: Ident,
+    /// The declared key type `K` (the group column's Rust type).
+    key_type: syn::Type,
+    /// The declared value type `V`.
+    value_type: syn::Type,
+    /// Diesel `sql_type` for the group-column key.
+    key_sql_type: TokenStream,
+    /// Diesel `sql_type` for the aggregated value.
+    value_sql_type: TokenStream,
+    /// The SQL aggregate expression, e.g. `COUNT(*)` or
+    /// `CAST(SUM("amount") AS bigint)`.
+    agg_sql_expr: String,
+    /// The group column name (quoted-identifier-safe bare name).
+    group_col: String,
+    /// When set, generation emits a `compile_error!` with this message instead
+    /// of a method.
+    error: Option<String>,
+}
+
 /// A parsed `find_or_create_by_<field>[_and_<field>...]` declaration (#1382).
 ///
 /// Unlike the [`DerivedQuery`] finders, this is emitted as an inherent async
@@ -802,6 +978,10 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     // codegen'd near the batch-feature bindings (once `tenant_query_filter`
     // is in scope), then spliced into the inherent `impl Pg*` block.
     let mut find_or_create_specs: Vec<FindOrCreateSpec> = Vec::new();
+    // §1364: typed grouped aggregate declarations. Collected here and codegen'd
+    // near the batch-feature bindings (once `tenant_query_filter` is in scope),
+    // then spliced into the inherent `impl Pg*` block as lazy builder methods.
+    let mut grouped_aggregate_specs: Vec<GroupedAggregateSpec> = Vec::new();
     // §1d: per-shard helpers for derived read methods that fan out under
     // across_tenants. Emitted into the inherent impl (a trait impl cannot hold
     // non-trait members), so kept in a separate list.
@@ -829,6 +1009,145 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     for item in &trait_def.items {
         if let TraitItem::Fn(method) = item {
             let method_name = method.sig.ident.to_string();
+
+            // §1364: `<agg>_[<col>_]grouped_by_<group_col>`. Parsed and
+            // codegen'd separately as an inherent method returning a lazy
+            // `GroupedAggregate<'_, K, V>` builder (like find_or_create_by, not
+            // a trait finder). Intercepted before the derived-query surface so
+            // `count_grouped_by_x` is never mistaken for a `count_by_` finder.
+            if method_name.contains("_grouped_by_") {
+                let fn_ident = method.sig.ident.clone();
+
+                // Every grouped-aggregate method must declare its pair type as
+                // the return type so the macro can bake concrete SQL types.
+                let declared_pair = match &method.sig.output {
+                    syn::ReturnType::Type(_, ty) => parse_vec_pair_type(ty),
+                    syn::ReturnType::Default => None,
+                };
+                let parsed = parse_grouped_aggregate_name(&method_name);
+
+                // Sensible fallbacks used only on the error path (so the spec is
+                // still well-formed for `compile_error!` emission).
+                let unit_ty: syn::Type = syn::parse_quote!(());
+                let mut error: Option<String>;
+                let mut key_type = unit_ty.clone();
+                let mut value_type = unit_ty.clone();
+                let mut key_sql_type = quote! { () };
+                let mut value_sql_type = quote! { () };
+                let mut agg_sql_expr = String::new();
+                let mut group_col = String::new();
+
+                match (parsed, declared_pair) {
+                    (None, _) => {
+                        error = Some(format!(
+                            "`{method_name}` is not a valid grouped-aggregate name: use \
+                             `count_grouped_by_<group_col>` or \
+                             `<sum|avg|min|max>_<num_col>_grouped_by_<group_col>`"
+                        ));
+                    }
+                    (Some(_), None) => {
+                        error = Some(format!(
+                            "`{method_name}` must declare its result type as `-> Vec<(K, V)>` \
+                             so the aggregate's key/value SQL types are known, e.g. \
+                             `fn {method_name}() -> Vec<(i64, Option<i64>)>;`"
+                        ));
+                    }
+                    (Some((kind, num_col, gcol)), Some((k, v))) => {
+                        group_col = gcol;
+                        let value_inner = option_inner_type(&v).unwrap_or(&v).clone();
+
+                        // Numeric-column presence must match the aggregate, and
+                        // sum/min/max/avg need a numeric value type to cast to.
+                        error = match (kind, &num_col) {
+                            (AggKind::Count, Some(_)) => Some(format!(
+                                "`{method_name}`: count takes no numeric column — use \
+                                 `count_grouped_by_<group_col>`"
+                            )),
+                            (_, None) if !matches!(kind, AggKind::Count) => Some(format!(
+                                "`{method_name}`: {kw} needs a numeric column — use \
+                                 `{kw}_<num_col>_grouped_by_<group_col>`",
+                                kw = kind.keyword()
+                            )),
+                            _ => None,
+                        };
+
+                        // Build the aggregate SQL, casting so the result
+                        // deserializes back into the declared value type
+                        // (Postgres widens SUM/AVG).
+                        if error.is_none() {
+                            agg_sql_expr = match kind {
+                                AggKind::Count => "COUNT(*)".to_string(),
+                                AggKind::Avg => {
+                                    format!(
+                                        "CAST(AVG(\"{}\") AS double precision)",
+                                        num_col.as_ref().unwrap()
+                                    )
+                                }
+                                AggKind::Sum | AggKind::Min | AggKind::Max => {
+                                    if let Some(pg) = pg_cast_type_for(&value_inner) {
+                                        let f = match kind {
+                                            AggKind::Sum => "SUM",
+                                            AggKind::Min => "MIN",
+                                            _ => "MAX",
+                                        };
+                                        format!(
+                                            "CAST({f}(\"{}\") AS {pg})",
+                                            num_col.as_ref().unwrap()
+                                        )
+                                    } else {
+                                        error = Some(format!(
+                                            "`{method_name}`: unsupported {kw} value type — \
+                                             the value must be `Option<T>` for a numeric `T` \
+                                             (i16/i32/i64/f32/f64)",
+                                            kw = kind.keyword()
+                                        ));
+                                        String::new()
+                                    }
+                                }
+                            };
+                        }
+
+                        // Resolve concrete diesel SQL types for key + value.
+                        if error.is_none() {
+                            match diesel_sql_type_for(&k) {
+                                Some(st) => key_sql_type = st,
+                                None => {
+                                    error = Some(format!(
+                                        "`{method_name}`: unsupported group-column key type `{}`",
+                                        k.to_token_stream()
+                                    ));
+                                }
+                            }
+                        }
+                        if error.is_none() {
+                            match diesel_sql_type_for(&v) {
+                                Some(st) => value_sql_type = st,
+                                None => {
+                                    error = Some(format!(
+                                        "`{method_name}`: unsupported aggregate value type `{}`",
+                                        v.to_token_stream()
+                                    ));
+                                }
+                            }
+                        }
+
+                        key_type = k;
+                        value_type = v;
+                    }
+                }
+
+                grouped_aggregate_specs.push(GroupedAggregateSpec {
+                    fn_ident,
+                    key_type,
+                    value_type,
+                    key_sql_type,
+                    value_sql_type,
+                    agg_sql_expr,
+                    group_col,
+                    error,
+                });
+                continue;
+            }
 
             // §1382: `find_or_create_by_<field>[_and_<field>...]`. Parsed and
             // codegen'd separately from the `find_by`/`count`/… derived-query
@@ -8002,6 +8321,206 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
+    // ── Typed grouped aggregate queries (issue #1364) ───────────────────────
+    //
+    // Emitted as inherent methods on the Pg* struct (parallel to
+    // find_in_batches / find_or_create_by): each returns a lazy
+    // `GroupedAggregate<'_, K, V>` builder. Under the hood a parameterized
+    // `diesel::sql_query` with a QueryableByName row (concrete SQL types baked
+    // from the declared `Vec<(K, V)>`), routed through the read-role helper and
+    // composing the same soft-delete + tenant predicates as `count`. Filter
+    // values are bound (never interpolated). sum/avg/min/max cannot be merged
+    // across shards, so across_tenants() on a sharded repo is rejected.
+    let grouped_aggregate_methods = {
+        // Baked literals shared by every generated method.
+        let table_q = format!("\"{table_name}\"");
+        let config_soft_delete = config.soft_delete;
+        let config_tenant_scoped = config.tenant_scoped;
+        let config_sharded = config.sharded;
+
+        let soft_delete_cond = if config_soft_delete {
+            quote! { __conds.push(::std::string::String::from("deleted_at IS NULL")); }
+        } else {
+            quote! {}
+        };
+
+        let (tenant_resolve, tenant_cond, tenant_bind) = if config_tenant_scoped {
+            (
+                quote! {
+                    let __tenant: ::core::option::Option<::std::string::String> =
+                        if __repo.across_tenants {
+                            ::core::option::Option::None
+                        } else {
+                            ::core::option::Option::Some(
+                                ::autumn_web::tenancy::CURRENT_TENANT
+                                    .try_with(|t| t.clone())
+                                    .ok()
+                                    .flatten()
+                                    .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg(
+                                        "Query scoped to tenant, but no tenant context was established"
+                                    ))?,
+                            )
+                        };
+                },
+                quote! {
+                    let __tenant_n = { __n += 1; __n };
+                    __conds.push(format!("(${n} IS NULL OR tenant_id = ${n})", n = __tenant_n));
+                },
+                quote! {
+                    .bind::<::autumn_web::reexports::diesel::sql_types::Nullable<
+                        ::autumn_web::reexports::diesel::sql_types::Text
+                    >, _>(__tenant)
+                },
+            )
+        } else {
+            (quote! {}, quote! {}, quote! {})
+        };
+
+        let cross_shard_guard = if config_sharded && config_tenant_scoped {
+            quote! {
+                if __repo.across_tenants && __repo.__autumn_shards.is_some() {
+                    return ::core::result::Result::Err(
+                        ::autumn_web::AutumnError::bad_request_msg(
+                            "cross-shard grouped aggregates are not supported: \
+                             sum/avg/min/max cannot be merged across shards; run the \
+                             aggregate per shard via from_shard(...) instead"
+                        )
+                    );
+                }
+            }
+        } else {
+            quote! {}
+        };
+
+        let mut __methods: Vec<TokenStream> = Vec::new();
+        for spec in &grouped_aggregate_specs {
+            let fn_ident = &spec.fn_ident;
+            if let Some(msg) = &spec.error {
+                __methods.push(quote! { ::core::compile_error!(#msg); });
+                continue;
+            }
+
+            let key_type = &spec.key_type;
+            let value_type = &spec.value_type;
+            let key_sql_type = &spec.key_sql_type;
+            let value_sql_type = &spec.value_sql_type;
+            let agg_expr = &spec.agg_sql_expr;
+            let group_col_q = format!("\"{}\"", spec.group_col);
+            let doc = format!(
+                "Grouped aggregate `{fn_ident}` → lazy `GroupedAggregate<'_, K, V>` builder (issue #1364).\n\n\
+                 Chain `.order_by_aggregate_desc()`/`.limit(n)` for top-N, \
+                 `.filter_eq(..)`/`.filter_range(lo, hi)` to scope before grouping, \
+                 or `.bucket(DateBucket::Day)` for a time series, then `.load().await`."
+            );
+
+            __methods.push(quote! {
+                #[doc = #doc]
+                #[must_use]
+                pub fn #fn_ident<'__agg>(
+                    &'__agg self,
+                ) -> ::autumn_web::aggregate::GroupedAggregate<'__agg, #key_type, #value_type> {
+                    let __repo = self;
+                    ::autumn_web::aggregate::GroupedAggregate::new(::std::boxed::Box::new(
+                        move |__opts: ::autumn_web::aggregate::AggregateOptions<#key_type>| {
+                            ::std::boxed::Box::pin(async move {
+                                use ::autumn_web::reexports::diesel::prelude::*;
+                                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+
+                                #cross_shard_guard
+                                #tenant_resolve
+
+                                #[derive(::autumn_web::reexports::diesel::QueryableByName)]
+                                struct __AutumnAggRow {
+                                    #[diesel(sql_type = #key_sql_type)]
+                                    agg_key: #key_type,
+                                    #[diesel(sql_type = #value_sql_type)]
+                                    agg_val: #value_type,
+                                }
+
+                                // Group expression: bucketed (date_trunc) or the raw column.
+                                let __group_expr: ::std::string::String = match __opts.bucket {
+                                    ::core::option::Option::Some(__b) => format!(
+                                        "date_trunc('{unit}', {col})",
+                                        unit = __b.as_trunc_unit(),
+                                        col = #group_col_q,
+                                    ),
+                                    ::core::option::Option::None => ::std::string::String::from(#group_col_q),
+                                };
+
+                                // Fixed bind layout — [tenant?], eq, range_low, range_high —
+                                // all bound Nullable so an unset filter is a NULL no-op and the
+                                // bind chain stays constant regardless of which filters are set.
+                                let mut __conds: ::std::vec::Vec<::std::string::String> = ::std::vec::Vec::new();
+                                let mut __n: i32 = 0;
+                                #soft_delete_cond
+                                #tenant_cond
+                                let __eq_n = { __n += 1; __n };
+                                __conds.push(format!("(${n} IS NULL OR {col} = ${n})", n = __eq_n, col = #group_col_q));
+                                let __low_n = { __n += 1; __n };
+                                __conds.push(format!("(${n} IS NULL OR {col} >= ${n})", n = __low_n, col = #group_col_q));
+                                let __high_n = { __n += 1; __n };
+                                __conds.push(format!("(${n} IS NULL OR {col} <= ${n})", n = __high_n, col = #group_col_q));
+
+                                let mut __sql = format!(
+                                    "SELECT {ge} AS agg_key, {ae} AS agg_val FROM {tbl}",
+                                    ge = __group_expr, ae = #agg_expr, tbl = #table_q,
+                                );
+                                __sql.push_str(" WHERE ");
+                                __sql.push_str(&__conds.join(" AND "));
+                                __sql.push_str(&format!(" GROUP BY {}", __group_expr));
+                                match __opts.order {
+                                    ::autumn_web::aggregate::AggregateOrder::Desc =>
+                                        __sql.push_str(" ORDER BY agg_val DESC NULLS LAST, agg_key ASC"),
+                                    ::autumn_web::aggregate::AggregateOrder::Asc =>
+                                        __sql.push_str(" ORDER BY agg_val ASC NULLS LAST, agg_key ASC"),
+                                    ::autumn_web::aggregate::AggregateOrder::Unordered => {}
+                                }
+                                if let ::core::option::Option::Some(__lim) = __opts.limit {
+                                    __sql.push_str(&format!(" LIMIT {}", __lim));
+                                }
+
+                                let (__low, __high) = match __opts.range {
+                                    ::core::option::Option::Some((__l, __h)) => (
+                                        ::core::option::Option::Some(__l),
+                                        ::core::option::Option::Some(__h),
+                                    ),
+                                    ::core::option::Option::None => (
+                                        ::core::option::Option::None,
+                                        ::core::option::Option::None,
+                                    ),
+                                };
+                                let __eq = __opts.eq;
+
+                                let mut __conn = __repo.__autumn_acquire_read_conn().await?;
+                                let __rows: ::std::vec::Vec<__AutumnAggRow> =
+                                    ::autumn_web::reexports::diesel::sql_query(__sql)
+                                        #tenant_bind
+                                        .bind::<::autumn_web::reexports::diesel::sql_types::Nullable<#key_sql_type>, _>(__eq)
+                                        .bind::<::autumn_web::reexports::diesel::sql_types::Nullable<#key_sql_type>, _>(__low)
+                                        .bind::<::autumn_web::reexports::diesel::sql_types::Nullable<#key_sql_type>, _>(__high)
+                                        .load::<__AutumnAggRow>(&mut __conn)
+                                        .await
+                                        .map_err(::autumn_web::AutumnError::from)?;
+
+                                ::core::result::Result::Ok(
+                                    __rows
+                                        .into_iter()
+                                        .map(|__r| (__r.agg_key, __r.agg_val))
+                                        .collect::<::std::vec::Vec<(#key_type, #value_type)>>(),
+                                )
+                            }) as ::std::pin::Pin<::std::boxed::Box<
+                                dyn ::std::future::Future<
+                                    Output = ::autumn_web::AutumnResult<::std::vec::Vec<(#key_type, #value_type)>>,
+                                > + ::core::marker::Send + '__agg,
+                            >>
+                        },
+                    ))
+                }
+            });
+        }
+        quote! { #(#__methods)* }
+    };
+
     // ── Race-safe get-or-insert (find_or_create_by_*, issue #1382) ──────────
     //
     // Emitted as inherent async methods on the Pg* struct (parallel to
@@ -10991,6 +11510,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
             #find_in_batches_methods
 
+            // Typed grouped aggregate queries (issue #1364).
+            #grouped_aggregate_methods
+
             // Race-safe get-or-insert (find_or_create_by_*, issue #1382).
             #find_or_create_by_methods
 
@@ -11391,6 +11913,147 @@ mod tests {
             err.to_string().contains("requires hooks"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn repository_macro_generates_grouped_sum_method() {
+        // §1364: a `sum_<col>_grouped_by_<group>` declaration becomes an
+        // inherent method returning a lazy `GroupedAggregate` builder, backed
+        // by a parameterized `sql_query` with a `QueryableByName` row. Postgres
+        // widens `SUM`, so the aggregate is `CAST` to the declared value type
+        // (`Option<i64>` → `bigint`) to keep the round-trip exact.
+        let generated = repository_macro(
+            quote! { Event, table = "events" },
+            quote! {
+                pub trait EventRepository {
+                    fn sum_score_grouped_by_post_id() -> Vec<(i64, Option<i64>)>;
+                }
+            },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("pub fn sum_score_grouped_by_post_id"),
+            "grouped-aggregate method must be generated: {generated}"
+        );
+        assert!(
+            generated.contains(":: autumn_web :: aggregate :: GroupedAggregate"),
+            "method must return the runtime GroupedAggregate builder: {generated}"
+        );
+        assert!(
+            generated.contains("QueryableByName"),
+            "aggregate must load through a typed QueryableByName row: {generated}"
+        );
+        assert!(
+            generated.contains("AS bigint"),
+            "SUM must be CAST to the declared value type (bigint): {generated}"
+        );
+        // Filter values are bound as Nullable parameters, never interpolated.
+        assert!(
+            generated.contains("Nullable"),
+            "filter/tenant values must be bound as Nullable parameters: {generated}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_grouped_avg_casts_to_double_precision() {
+        // AVG rolls up to `Option<f64>` via an explicit double-precision cast.
+        let generated = repository_macro(
+            quote! { Event, table = "events" },
+            quote! {
+                pub trait EventRepository {
+                    fn avg_score_grouped_by_post_id() -> Vec<(i64, Option<f64>)>;
+                }
+            },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("pub fn avg_score_grouped_by_post_id"),
+            "avg grouped-aggregate method must be generated: {generated}"
+        );
+        assert!(
+            generated.contains("AS double precision"),
+            "AVG must be cast to double precision: {generated}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_grouped_count_tenant_scoped_predicate() {
+        // A tenant-scoped grouped COUNT composes the same `tenant_id` predicate
+        // as `count`, resolving the active tenant before the query.
+        let generated = repository_macro(
+            quote! { Event, table = "events", tenant_scoped },
+            quote! {
+                pub trait EventRepository {
+                    fn count_grouped_by_kind() -> Vec<(String, i64)>;
+                }
+            },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("pub fn count_grouped_by_kind"),
+            "count grouped-aggregate method must be generated: {generated}"
+        );
+        assert!(
+            generated.contains("COUNT(*)"),
+            "count aggregate must use COUNT(*): {generated}"
+        );
+        assert!(
+            generated.contains("tenant_id ="),
+            "tenant-scoped aggregate must filter by tenant_id: {generated}"
+        );
+        assert!(
+            generated.contains("CURRENT_TENANT"),
+            "tenant-scoped aggregate must resolve the active tenant: {generated}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_grouped_aggregate_requires_return_type() {
+        // Omitting the `-> Vec<(K, V)>` return type is a compile error with a
+        // helpful message (the macro can't infer the key/value SQL types).
+        let generated = repository_macro(
+            quote! { Event, table = "events" },
+            quote! {
+                pub trait EventRepository {
+                    fn count_grouped_by_post_id();
+                }
+            },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("compile_error"),
+            "missing return type must emit a compile_error: {generated}"
+        );
+        assert!(
+            generated.contains("must declare its result type"),
+            "compile_error must explain the missing `-> Vec<(K, V)>`: {generated}"
+        );
+    }
+
+    #[test]
+    fn parse_grouped_aggregate_name_shapes() {
+        assert_eq!(
+            parse_grouped_aggregate_name("count_grouped_by_post_id"),
+            Some((AggKind::Count, None, "post_id".to_string()))
+        );
+        assert_eq!(
+            parse_grouped_aggregate_name("sum_amount_grouped_by_user_id"),
+            Some((
+                AggKind::Sum,
+                Some("amount".to_string()),
+                "user_id".to_string()
+            ))
+        );
+        assert_eq!(
+            parse_grouped_aggregate_name("avg_score_grouped_by_day"),
+            Some((AggKind::Avg, Some("score".to_string()), "day".to_string()))
+        );
+        // Not a grouped-aggregate name → None (falls through to derived queries).
+        assert_eq!(parse_grouped_aggregate_name("find_by_post_id"), None);
     }
 
     #[test]

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1128,6 +1128,22 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                          garbage, e.g. `fn {method_name}() -> Vec<(K, Option<f64>)>;`"
                                     ));
                                 }
+                                AggKind::Sum | AggKind::Min | AggKind::Max
+                                    if option_inner_type(&v).is_none() =>
+                                {
+                                    // SUM/MIN/MAX over an empty or all-NULL group
+                                    // returns SQL NULL, which QueryableByName
+                                    // cannot deserialize into a non-nullable
+                                    // value — it would fail at runtime. Force the
+                                    // declaration to be nullable (#1364 review).
+                                    error = Some(format!(
+                                        "`{method_name}`: {kw} must declare its value type as \
+                                         `Option<T>` for a numeric `T` (it returns SQL NULL over \
+                                         an empty or all-NULL group), e.g. \
+                                         `fn {method_name}() -> Vec<(K, Option<T>)>;`",
+                                        kw = kind.keyword()
+                                    ));
+                                }
                                 _ => {}
                             }
                         }
@@ -12141,6 +12157,32 @@ mod tests {
         assert!(
             generated.contains("count must declare its value type as"),
             "compile_error must name the count value-type rule: {generated}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_grouped_sum_wrong_value_type_is_error() {
+        // §1364 review: `sum`/`min`/`max` return SQL NULL over an empty or
+        // all-NULL group, so a non-`Option<T>` value type must be a compile
+        // error (QueryableByName cannot deserialize NULL into a non-nullable
+        // value — it would fail at runtime).
+        let generated = repository_macro(
+            quote! { Event, table = "events" },
+            quote! {
+                pub trait EventRepository {
+                    fn sum_value_grouped_by_post_id() -> Vec<(i64, i64)>;
+                }
+            },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("compile_error"),
+            "sum with a non-Option value must emit a compile_error: {generated}"
+        );
+        assert!(
+            generated.contains("must declare its value type as"),
+            "compile_error must name the sum value-type rule: {generated}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -514,6 +514,26 @@ fn option_inner_type(ty: &syn::Type) -> Option<&syn::Type> {
     }
 }
 
+/// True if `ty` is exactly the bare path identifier `ident` (e.g. `i64`), with
+/// no generic arguments — used to enforce the exact width a `count`/`avg`
+/// aggregate deserializes into (#1364 review).
+fn type_is_bare_ident(ty: &syn::Type, ident: &str) -> bool {
+    let syn::Type::Path(p) = ty else { return false };
+    if p.qself.is_some() {
+        return false;
+    }
+    p.path
+        .segments
+        .last()
+        .is_some_and(|s| s.ident == ident && s.arguments.is_empty())
+}
+
+/// True if `ty` is exactly `Option<inner>` where `inner` is the bare ident
+/// `inner_ident` (e.g. `Option<f64>`).
+fn type_is_option_of(ty: &syn::Type, inner_ident: &str) -> bool {
+    option_inner_type(ty).is_some_and(|inner| type_is_bare_ident(inner, inner_ident))
+}
+
 /// Map a supported Rust type to its diesel `sql_types` path token, threading
 /// `Option<T>` to `Nullable<…>`. Returns `None` for unsupported types.
 fn diesel_sql_type_for(ty: &syn::Type) -> Option<TokenStream> {
@@ -1070,6 +1090,47 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             )),
                             _ => None,
                         };
+
+                        // Nullable group keys are unsupported (#1364 review): a
+                        // `K = Option<T>` makes `key_sql_type` `Nullable<T>`, and
+                        // then filter binds wrap it again into
+                        // `Nullable<Nullable<T>>`, producing an opaque diesel
+                        // type error. The group column must be NOT NULL.
+                        if error.is_none() && option_inner_type(&k).is_some() {
+                            error = Some(format!(
+                                "`{method_name}`: nullable group keys are unsupported — \
+                                 the group column must be NOT NULL, so declare `K` as `T`, \
+                                 not `Option<T>`"
+                            ));
+                        }
+
+                        // The declared value type must EXACTLY match the type the
+                        // aggregate casts to (#1364 review). `count` always
+                        // produces `bigint` (i64) and `avg` always produces
+                        // `double precision` (f64); QueryableByName does not check
+                        // column OIDs, so a mismatched width silently reinterprets
+                        // the raw bytes as garbage (e.g. float bytes read as i64).
+                        if error.is_none() {
+                            match kind {
+                                AggKind::Count if !type_is_bare_ident(&v, "i64") => {
+                                    error = Some(format!(
+                                        "`{method_name}`: count must declare its value type as \
+                                         `i64` (it produces `COUNT(*)` → bigint); a different \
+                                         width silently misreads the result, e.g. \
+                                         `fn {method_name}() -> Vec<(K, i64)>;`"
+                                    ));
+                                }
+                                AggKind::Avg if !type_is_option_of(&v, "f64") => {
+                                    error = Some(format!(
+                                        "`{method_name}`: avg must declare its value type as \
+                                         `Option<f64>` (it always casts to double precision); a \
+                                         different width silently reinterprets the float bytes as \
+                                         garbage, e.g. `fn {method_name}() -> Vec<(K, Option<f64>)>;`"
+                                    ));
+                                }
+                                _ => {}
+                            }
+                        }
 
                         // Build the aggregate SQL, casting so the result
                         // deserializes back into the declared value type
@@ -12031,6 +12092,79 @@ mod tests {
         assert!(
             generated.contains("must declare its result type"),
             "compile_error must explain the missing `-> Vec<(K, V)>`: {generated}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_grouped_avg_wrong_value_type_is_error() {
+        // §1364 review: `avg` always casts to double precision, so declaring a
+        // non-`Option<f64>` value type must be a compile error (QueryableByName
+        // would otherwise silently reinterpret the float bytes).
+        let generated = repository_macro(
+            quote! { Event, table = "events" },
+            quote! {
+                pub trait EventRepository {
+                    fn avg_score_grouped_by_post_id() -> Vec<(i64, Option<i64>)>;
+                }
+            },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("compile_error"),
+            "avg with a non-Option<f64> value must emit a compile_error: {generated}"
+        );
+        assert!(
+            generated.contains("avg must declare its value type as"),
+            "compile_error must name the avg value-type rule: {generated}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_grouped_count_wrong_value_type_is_error() {
+        // §1364 review: `count` always produces bigint (i64); a mis-declared
+        // width is a compile error rather than a runtime width mismatch.
+        let generated = repository_macro(
+            quote! { Event, table = "events" },
+            quote! {
+                pub trait EventRepository {
+                    fn count_grouped_by_kind() -> Vec<(String, i32)>;
+                }
+            },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("compile_error"),
+            "count with a non-i64 value must emit a compile_error: {generated}"
+        );
+        assert!(
+            generated.contains("count must declare its value type as"),
+            "compile_error must name the count value-type rule: {generated}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_grouped_nullable_key_is_error() {
+        // §1364 review: a nullable group key (`K = Option<T>`) is unsupported —
+        // it would nest into `Nullable<Nullable<T>>` on filter binds.
+        let generated = repository_macro(
+            quote! { Event, table = "events" },
+            quote! {
+                pub trait EventRepository {
+                    fn count_grouped_by_post_id() -> Vec<(Option<i64>, i64)>;
+                }
+            },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("compile_error"),
+            "nullable group key must emit a compile_error: {generated}"
+        );
+        assert!(
+            generated.contains("nullable group keys are unsupported"),
+            "compile_error must explain nullable group keys are unsupported: {generated}"
         );
     }
 

--- a/autumn/src/aggregate.rs
+++ b/autumn/src/aggregate.rs
@@ -53,8 +53,11 @@
 //! a group whose values are all `NULL` yields `None`, and an empty result set
 //! is an empty `Vec`.
 //!
-//! The **group (key) column must be `NOT NULL`**: a nullable group key
-//! (`K = Option<T>`) is unsupported and rejected at compile time. Nullable
+//! A nullable group-key **type** (`K = Option<T>`) is unsupported and rejected
+//! at compile time. A nullable group-key **column** is safe, however: rows with
+//! a `NULL` group key are silently **excluded** from the results (the generated
+//! SQL guards the group column with `IS NOT NULL`), so a `NULL` group is simply
+//! omitted rather than deserialized into the non-nullable `K`. Nullable
 //! **value** columns are fine — an all-`NULL` group yields `(key, None)`.
 //!
 //! ## Scoping

--- a/autumn/src/aggregate.rs
+++ b/autumn/src/aggregate.rs
@@ -60,6 +60,15 @@
 //! omitted rather than deserialized into the non-nullable `K`. Nullable
 //! **value** columns are fine — an all-`NULL` group yields `(key, None)`.
 //!
+//! ## Encrypted columns
+//!
+//! Grouped aggregates are **not** available on an `#[encrypted(...)]` column
+//! (neither as the group key nor as an aggregated value): the column stores
+//! ciphertext, so grouping would return ciphertext keys and `.filter_eq(..)`
+//! would compare plaintext against ciphertext and match nothing. A method that
+//! groups on (or aggregates over) an encrypted column returns an error at call
+//! time. Use a raw query instead, or group on a non-encrypted column.
+//!
 //! ## Scoping
 //!
 //! The generated query composes the repository's soft-delete filter, tenant

--- a/autumn/src/aggregate.rs
+++ b/autumn/src/aggregate.rs
@@ -1,0 +1,242 @@
+//! Typed grouped aggregate queries (`GROUP BY` roll-ups), issue #1364.
+//!
+//! `count`, `sum`, `avg`, `min` and `max` over a table, bucketed by a group
+//! column, expressed declaratively on a `#[autumn_web::repository]` trait:
+//!
+//! ```rust,ignore
+//! #[autumn_web::repository(Vote, table = "votes")]
+//! pub trait VoteRepository {
+//!     /// SUM(value) GROUP BY post_id → `Vec<(post_id, Option<sum>)>`.
+//!     fn sum_value_grouped_by_post_id() -> Vec<(i64, Option<i64>)>;
+//!     /// COUNT(*) GROUP BY variant → `Vec<(variant, count)>`.
+//!     fn count_grouped_by_variant() -> Vec<(String, i64)>;
+//! }
+//! ```
+//!
+//! Each declared method becomes an **inherent method** on the generated `Pg*`
+//! repository struct that returns a lazy [`GroupedAggregate`] builder (mirroring
+//! `find_in_batches`). Nothing runs until a terminal [`load`](GroupedAggregate::load):
+//!
+//! ```rust,ignore
+//! // Top-5 posts by score, highest first.
+//! let top: Vec<(i64, Option<i64>)> = repo
+//!     .sum_value_grouped_by_post_id()
+//!     .order_by_aggregate_desc()
+//!     .limit(5)
+//!     .load()
+//!     .await?;
+//!
+//! // A day-bucketed time series over a bounded window.
+//! let per_day: Vec<(chrono::NaiveDateTime, i64)> = repo
+//!     .count_grouped_by_created_at()
+//!     .bucket(DateBucket::Day)
+//!     .filter_range(window_start, window_end)
+//!     .load()
+//!     .await?;
+//! ```
+//!
+//! ## Value (`V`) and key (`K`) type rules
+//!
+//! The trait method declares the pair type `Vec<(K, V)>`; the macro reads `K`
+//! and `V` from it and bakes the matching Postgres bind/result SQL types.
+//!
+//! | method              | `V`                            |
+//! |---------------------|--------------------------------|
+//! | `count_grouped_by_` | `i64`                          |
+//! | `sum_*_grouped_by_` | `Option<T>` (`T` = column type)|
+//! | `min_*_grouped_by_` | `Option<T>`                    |
+//! | `max_*_grouped_by_` | `Option<T>`                    |
+//! | `avg_*_grouped_by_` | `Option<f64>`                  |
+//!
+//! `K` is the group column's Rust type (or, under [`bucket`](GroupedAggregate::bucket),
+//! the bucket-start timestamp's type). `sum`/`min`/`max`/`avg` are null-safe:
+//! a group whose values are all `NULL` yields `None`, and an empty result set
+//! is an empty `Vec`.
+//!
+//! ## Scoping
+//!
+//! The generated query composes the repository's soft-delete filter, tenant
+//! scoping and read routing exactly like `count`, and acquires its connection
+//! through the same read-route helper — so replica routing and multi-tenancy
+//! come for free. `sum`/`avg`/`min`/`max` cannot be merged across shards, so a
+//! sharded, tenant-scoped repository used via `across_tenants()` rejects
+//! grouped aggregates rather than returning a per-shard-partial answer.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::AutumnResult;
+
+/// Time-bucket granularity for a `date_trunc`-grouped aggregate (AC5).
+///
+/// Passing a bucket to [`GroupedAggregate::bucket`] groups by
+/// `date_trunc('<unit>', <group_col>)` instead of the raw column, so the key
+/// `K` becomes the bucket-start timestamp. The group column must be a
+/// timestamp type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DateBucket {
+    /// `date_trunc('day', …)`.
+    Day,
+    /// `date_trunc('week', …)` — ISO weeks starting Monday.
+    Week,
+    /// `date_trunc('month', …)`.
+    Month,
+}
+
+impl DateBucket {
+    /// The `date_trunc` field literal (`"day"`, `"week"`, `"month"`).
+    ///
+    /// A fixed set of internal constants — never interpolated from user input —
+    /// so it is safe to embed directly in the generated SQL.
+    #[must_use]
+    pub const fn as_trunc_unit(self) -> &'static str {
+        match self {
+            Self::Day => "day",
+            Self::Week => "week",
+            Self::Month => "month",
+        }
+    }
+}
+
+/// Ordering applied to the aggregated value for top-N queries (AC3).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum AggregateOrder {
+    /// No explicit ordering (database-defined group order).
+    #[default]
+    Unordered,
+    /// Ascending by the aggregated value.
+    Asc,
+    /// Descending by the aggregated value.
+    Desc,
+}
+
+/// The mutable builder state a [`GroupedAggregate`] threads to its executor.
+///
+/// Public so the macro-generated executor can read it; construct one only via
+/// the generated repository methods and the chainable builder setters.
+#[derive(Clone, Debug)]
+pub struct AggregateOptions<K> {
+    /// Ordering on the aggregated value (top-N support).
+    pub order: AggregateOrder,
+    /// Optional `LIMIT` on the number of groups returned.
+    pub limit: Option<i64>,
+    /// Optional pre-group equality filter on the group column (bound as a
+    /// parameter, never interpolated).
+    pub eq: Option<K>,
+    /// Optional pre-group inclusive range filter `[low, high]` on the group
+    /// column (both bounds bound as parameters).
+    pub range: Option<(K, K)>,
+    /// Optional time-bucket applied to the group column.
+    pub bucket: Option<DateBucket>,
+}
+
+impl<K> Default for AggregateOptions<K> {
+    fn default() -> Self {
+        Self {
+            order: AggregateOrder::Unordered,
+            limit: None,
+            eq: None,
+            range: None,
+            bucket: None,
+        }
+    }
+}
+
+/// A boxed, owned future produced by a grouped-aggregate executor.
+type AggFuture<'a, K, V> = Pin<Box<dyn Future<Output = AutumnResult<Vec<(K, V)>>> + Send + 'a>>;
+
+/// The macro-generated executor: given the finalized options, runs the
+/// parameterized `GROUP BY` query against the repository it captured.
+type AggExec<'a, K, V> = Box<dyn Fn(AggregateOptions<K>) -> AggFuture<'a, K, V> + Send + 'a>;
+
+/// A lazy, chainable builder for one grouped aggregate query.
+///
+/// Created by a generated `count_grouped_by_*` / `sum_*_grouped_by_*` /
+/// `avg_*` / `min_*` / `max_*` repository method. Chain the setters, then call
+/// [`load`](Self::load) to execute. Dropping the builder without loading runs
+/// no query.
+///
+/// `K` is the group-column key type and `V` the aggregated value type (see the
+/// [module docs](crate::aggregate) for the `V` rules).
+pub struct GroupedAggregate<'a, K, V> {
+    opts: AggregateOptions<K>,
+    exec: AggExec<'a, K, V>,
+}
+
+impl<'a, K, V> GroupedAggregate<'a, K, V> {
+    /// Wrap a macro-generated executor. Prefer the generated repository methods
+    /// over calling this directly.
+    #[must_use]
+    pub fn new(exec: AggExec<'a, K, V>) -> Self {
+        Self {
+            opts: AggregateOptions::default(),
+            exec,
+        }
+    }
+
+    /// Order the results by the aggregated value, largest first (AC3). Combine
+    /// with [`limit`](Self::limit) for a top-N roll-up.
+    #[must_use]
+    pub const fn order_by_aggregate_desc(mut self) -> Self {
+        self.opts.order = AggregateOrder::Desc;
+        self
+    }
+
+    /// Order the results by the aggregated value, smallest first (AC3).
+    #[must_use]
+    pub const fn order_by_aggregate_asc(mut self) -> Self {
+        self.opts.order = AggregateOrder::Asc;
+        self
+    }
+
+    /// Cap the number of groups returned (AC3, top-N).
+    #[must_use]
+    pub const fn limit(mut self, n: i64) -> Self {
+        self.opts.limit = Some(n);
+        self
+    }
+
+    /// Keep only rows whose group column equals `value`, applied **before**
+    /// grouping (AC4). Bound as a query parameter.
+    #[must_use]
+    pub fn filter_eq(mut self, value: K) -> Self {
+        self.opts.eq = Some(value);
+        self
+    }
+
+    /// Keep only rows whose group column falls in the inclusive range
+    /// `[low, high]`, applied **before** grouping (AC4). Works for date/time
+    /// ranges too. Both bounds are bound as query parameters.
+    #[must_use]
+    pub fn filter_range(mut self, low: K, high: K) -> Self {
+        self.opts.range = Some((low, high));
+        self
+    }
+
+    /// Group by `date_trunc('<unit>', <group_col>)` instead of the raw column,
+    /// producing a time series keyed by bucket start (AC5).
+    #[must_use]
+    pub const fn bucket(mut self, bucket: DateBucket) -> Self {
+        self.opts.bucket = Some(bucket);
+        self
+    }
+
+    /// Execute the aggregate and collect `(key, value)` pairs, consuming the
+    /// builder.
+    ///
+    /// Takes `self` by value (rather than `&self`) so this inherent method wins
+    /// method resolution over diesel's by-value `RunQueryDsl::load` when that
+    /// trait is in scope.
+    ///
+    /// An empty result set yields an empty `Vec`; `sum`/`avg`/`min`/`max`
+    /// groups with only `NULL` values yield a `None` value (AC7).
+    ///
+    /// # Errors
+    ///
+    /// Surfaces any database error, and — on a sharded, tenant-scoped
+    /// repository used via `across_tenants()` — a `bad_request` rejecting the
+    /// unsupported cross-shard aggregate merge.
+    pub async fn load(self) -> AutumnResult<Vec<(K, V)>> {
+        (self.exec)(self.opts).await
+    }
+}

--- a/autumn/src/aggregate.rs
+++ b/autumn/src/aggregate.rs
@@ -206,7 +206,7 @@ impl<'a, K, V> GroupedAggregate<'a, K, V> {
     /// Keep only rows whose group column equals `value`, applied **before**
     /// grouping (AC4). Bound as a query parameter.
     ///
-    /// The predicate is on the **raw** group column, even when [`bucket`](Self::bucket)
+    /// The predicate is on the **raw** group column, even when [`bucket`](GroupedAggregate::bucket)
     /// is set. Under a bucket, `filter_eq(bucket_start)` therefore matches only
     /// rows whose raw timestamp is *exactly* the bucket boundary, not the whole
     /// bucket — to window a bucketed time series you almost always want
@@ -222,21 +222,13 @@ impl<'a, K, V> GroupedAggregate<'a, K, V> {
     /// ranges too. Both bounds are bound as query parameters.
     ///
     /// Like [`filter_eq`](Self::filter_eq), the predicate is on the **raw** group
-    /// column even when [`bucket`](Self::bucket) is set. This is what you want
+    /// column even when [`bucket`](GroupedAggregate::bucket) is set. This is what you want
     /// for a bucketed time series: pass the raw timestamp window (e.g.
     /// `filter_range(window_start, window_end)`) to bound which rows feed the
     /// `date_trunc` buckets.
     #[must_use]
     pub fn filter_range(mut self, low: K, high: K) -> Self {
         self.opts.range = Some((low, high));
-        self
-    }
-
-    /// Group by `date_trunc('<unit>', <group_col>)` instead of the raw column,
-    /// producing a time series keyed by bucket start (AC5).
-    #[must_use]
-    pub const fn bucket(mut self, bucket: DateBucket) -> Self {
-        self.opts.bucket = Some(bucket);
         self
     }
 
@@ -257,5 +249,47 @@ impl<'a, K, V> GroupedAggregate<'a, K, V> {
     /// unsupported cross-shard aggregate merge.
     pub async fn load(self) -> AutumnResult<Vec<(K, V)>> {
         (self.exec)(self.opts).await
+    }
+}
+
+/// `.bucket()` is a compile-time-gated setter: it exists **only** when the group
+/// key `K` is a timestamp type, because it swaps the raw group column for
+/// `date_trunc('<unit>', <group_col>)`, whose result is always a `timestamp`.
+///
+/// Defining it on these key-specific impls (rather than the blanket
+/// `impl<'a, K, V>`) means a non-temporal key — e.g. an `i64` `post_id` from
+/// `count_grouped_by_post_id()` — has no `.bucket()` method at all, so an invalid
+/// `date_trunc(unit, bigint)` query is rejected by the type system instead of
+/// failing at runtime.
+///
+/// Only `NaiveDateTime` (`timestamp`) and `DateTime<Utc>` (`timestamptz`) are
+/// bucketable. `NaiveDate` (`date`) is intentionally excluded: Postgres
+/// `date_trunc(unit, date)` returns a `timestamp`, which would not match a
+/// `NaiveDate` result row.
+impl<V> GroupedAggregate<'_, ::chrono::NaiveDateTime, V> {
+    /// Group by `date_trunc('<unit>', <group_col>)` instead of the raw column,
+    /// producing a time series keyed by bucket start (AC5).
+    ///
+    /// Available **only** when the group column is a timestamp type
+    /// (`NaiveDateTime` / `DateTime<Utc>`); non-temporal group keys have no
+    /// `.bucket()` method.
+    #[must_use]
+    pub const fn bucket(mut self, bucket: DateBucket) -> Self {
+        self.opts.bucket = Some(bucket);
+        self
+    }
+}
+
+impl<V> GroupedAggregate<'_, ::chrono::DateTime<::chrono::Utc>, V> {
+    /// Group by `date_trunc('<unit>', <group_col>)` instead of the raw column,
+    /// producing a time series keyed by bucket start (AC5).
+    ///
+    /// Available **only** when the group column is a timestamp type
+    /// (`NaiveDateTime` / `DateTime<Utc>`); non-temporal group keys have no
+    /// `.bucket()` method.
+    #[must_use]
+    pub const fn bucket(mut self, bucket: DateBucket) -> Self {
+        self.opts.bucket = Some(bucket);
+        self
     }
 }

--- a/autumn/src/aggregate.rs
+++ b/autumn/src/aggregate.rs
@@ -273,6 +273,11 @@ impl<V> GroupedAggregate<'_, ::chrono::NaiveDateTime, V> {
     /// Available **only** when the group column is a timestamp type
     /// (`NaiveDateTime` / `DateTime<Utc>`); non-temporal group keys have no
     /// `.bucket()` method.
+    ///
+    /// For a `NaiveDateTime` (Postgres `timestamp WITHOUT time zone`) key the
+    /// bucket truncates on the **stored wall-clock** value: `date_trunc` on a
+    /// plain `timestamp` is a deterministic field truncation that ignores the
+    /// session `TimeZone`, so buckets are stable regardless of deployment.
     #[must_use]
     pub const fn bucket(mut self, bucket: DateBucket) -> Self {
         self.opts.bucket = Some(bucket);
@@ -287,6 +292,14 @@ impl<V> GroupedAggregate<'_, ::chrono::DateTime<::chrono::Utc>, V> {
     /// Available **only** when the group column is a timestamp type
     /// (`NaiveDateTime` / `DateTime<Utc>`); non-temporal group keys have no
     /// `.bucket()` method.
+    ///
+    /// For a `DateTime<Utc>` (Postgres `timestamptz`) key the bucket is
+    /// computed **in UTC** — the generated SQL uses the 3-arg
+    /// `date_trunc('<unit>', <col>, 'UTC')`, consistent with the `DateTime<Utc>`
+    /// key type. Truncating in an explicit zone keeps bucket boundaries stable
+    /// across deployments; the 2-arg form would truncate in the DB session
+    /// `TimeZone`, so a non-UTC session would shift UTC-midnight events into the
+    /// wrong local-date bucket (#1364).
     #[must_use]
     pub const fn bucket(mut self, bucket: DateBucket) -> Self {
         self.opts.bucket = Some(bucket);

--- a/autumn/src/aggregate.rs
+++ b/autumn/src/aggregate.rs
@@ -53,6 +53,10 @@
 //! a group whose values are all `NULL` yields `None`, and an empty result set
 //! is an empty `Vec`.
 //!
+//! The **group (key) column must be `NOT NULL`**: a nullable group key
+//! (`K = Option<T>`) is unsupported and rejected at compile time. Nullable
+//! **value** columns are fine — an all-`NULL` group yields `(key, None)`.
+//!
 //! ## Scoping
 //!
 //! The generated query composes the repository's soft-delete filter, tenant
@@ -198,6 +202,12 @@ impl<'a, K, V> GroupedAggregate<'a, K, V> {
 
     /// Keep only rows whose group column equals `value`, applied **before**
     /// grouping (AC4). Bound as a query parameter.
+    ///
+    /// The predicate is on the **raw** group column, even when [`bucket`](Self::bucket)
+    /// is set. Under a bucket, `filter_eq(bucket_start)` therefore matches only
+    /// rows whose raw timestamp is *exactly* the bucket boundary, not the whole
+    /// bucket — to window a bucketed time series you almost always want
+    /// [`filter_range`](Self::filter_range) over the raw timestamps instead.
     #[must_use]
     pub fn filter_eq(mut self, value: K) -> Self {
         self.opts.eq = Some(value);
@@ -207,6 +217,12 @@ impl<'a, K, V> GroupedAggregate<'a, K, V> {
     /// Keep only rows whose group column falls in the inclusive range
     /// `[low, high]`, applied **before** grouping (AC4). Works for date/time
     /// ranges too. Both bounds are bound as query parameters.
+    ///
+    /// Like [`filter_eq`](Self::filter_eq), the predicate is on the **raw** group
+    /// column even when [`bucket`](Self::bucket) is set. This is what you want
+    /// for a bucketed time series: pass the raw timestamp window (e.g.
+    /// `filter_range(window_start, window_end)`) to bound which rows feed the
+    /// `date_trunc` buckets.
     #[must_use]
     pub fn filter_range(mut self, low: K, high: K) -> Self {
         self.opts.range = Some((low, high));

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -67,6 +67,7 @@
 extern crate self as autumn_web;
 
 pub mod actuator;
+pub mod aggregate;
 pub mod app;
 pub mod assets;
 pub mod audit;

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -142,6 +142,8 @@ mod repository_find_in_batches;
 mod repository_find_or_create_by;
 #[cfg(feature = "db")]
 mod repository_from_shard;
+#[cfg(feature = "db")]
+mod repository_grouped_aggregates;
 #[cfg(all(feature = "db", feature = "openapi"))]
 mod repository_openapi;
 #[cfg(feature = "db")]

--- a/autumn/tests/integration/repository_grouped_aggregates.rs
+++ b/autumn/tests/integration/repository_grouped_aggregates.rs
@@ -1,0 +1,499 @@
+//! Database-level integration tests for typed grouped aggregate queries
+//! (`count_grouped_by_*`, `sum_*_grouped_by_*`, `avg_*`, `min_*`, `max_*`;
+//! issue #1364).
+//!
+//! The seeded-table tests **require Docker** (testcontainers) and are
+//! `#[ignore]`d by default. One non-ignored test proves the generated method
+//! surface exists (and the codegen ran) without a live database.
+//!
+//! Fixtures deliberately span the generated branches — plain, tenant-scoped,
+//! soft-delete, and a timestamp column for date-bucketed time series — so
+//! `cargo test -p autumn-web --no-run --features db` type-checks every branch
+//! even though the ignored tests can't run here.
+
+#![cfg(feature = "db")]
+#![allow(clippy::must_use_candidate, clippy::missing_const_for_fn)]
+
+use autumn_web::aggregate::DateBucket;
+use autumn_web::repository::ReadRoute;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::pooled_connection::deadpool::Pool;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+// ── Plain model (numeric + group + timestamp columns) ─────────────────────────
+
+diesel::table! {
+    test_agg_events (id) {
+        id -> Int8,
+        post_id -> Int8,
+        score -> Int4,
+        created_at -> Timestamp,
+    }
+}
+
+#[autumn_web::model(table = "test_agg_events")]
+pub struct AggEvent {
+    #[id]
+    pub id: i64,
+    pub post_id: i64,
+    pub score: i32,
+    pub created_at: chrono::NaiveDateTime,
+}
+
+#[autumn_web::repository(AggEvent, table = "test_agg_events")]
+pub trait AggEventRepository {
+    /// COUNT(*) GROUP BY post_id.
+    fn count_grouped_by_post_id() -> Vec<(i64, i64)>;
+    /// SUM(score) GROUP BY post_id (i32 column summed into i64).
+    fn sum_score_grouped_by_post_id() -> Vec<(i64, Option<i64>)>;
+    /// AVG(score) GROUP BY post_id → double precision.
+    fn avg_score_grouped_by_post_id() -> Vec<(i64, Option<f64>)>;
+    /// MIN(score) GROUP BY post_id.
+    fn min_score_grouped_by_post_id() -> Vec<(i64, Option<i32>)>;
+    /// MAX(score) GROUP BY post_id.
+    fn max_score_grouped_by_post_id() -> Vec<(i64, Option<i32>)>;
+    /// COUNT(*) GROUP BY created_at — used for `DateBucket` time series.
+    fn count_grouped_by_created_at() -> Vec<(chrono::NaiveDateTime, i64)>;
+}
+
+// ── Tenant-scoped model ───────────────────────────────────────────────────────
+
+diesel::table! {
+    test_agg_tenant_events (id) {
+        id -> Int8,
+        kind -> Text,
+        amount -> Int8,
+        tenant_id -> Text,
+    }
+}
+
+#[autumn_web::model(table = "test_agg_tenant_events")]
+pub struct AggTenantEvent {
+    #[id]
+    pub id: i64,
+    pub kind: String,
+    pub amount: i64,
+    #[default]
+    pub tenant_id: String,
+}
+
+#[autumn_web::repository(AggTenantEvent, table = "test_agg_tenant_events", tenant_scoped)]
+pub trait AggTenantEventRepository {
+    /// SUM(amount) GROUP BY kind, scoped to the active tenant.
+    fn sum_amount_grouped_by_kind() -> Vec<(String, Option<i64>)>;
+    /// COUNT(*) GROUP BY kind, scoped to the active tenant.
+    fn count_grouped_by_kind() -> Vec<(String, i64)>;
+}
+
+// ── Soft-delete model ─────────────────────────────────────────────────────────
+
+diesel::table! {
+    test_agg_soft_events (id) {
+        id -> Int8,
+        bucket -> Text,
+        value -> Int8,
+        deleted_at -> Nullable<Timestamp>,
+    }
+}
+
+#[autumn_web::model(table = "test_agg_soft_events")]
+pub struct AggSoftEvent {
+    #[id]
+    pub id: i64,
+    pub bucket: String,
+    pub value: i64,
+    #[default]
+    pub deleted_at: Option<chrono::NaiveDateTime>,
+}
+
+#[autumn_web::repository(AggSoftEvent, table = "test_agg_soft_events", soft_delete)]
+pub trait AggSoftEventRepository {
+    /// SUM(value) GROUP BY bucket, excluding soft-deleted rows.
+    fn sum_value_grouped_by_bucket() -> Vec<(String, Option<i64>)>;
+}
+
+// ── Setup & helpers ───────────────────────────────────────────────────────────
+
+async fn setup_pool() -> (
+    Pool<AsyncPgConnection>,
+    testcontainers::ContainerAsync<Postgres>,
+) {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start postgres container");
+
+    let host = container.get_host().await.expect("host");
+    let port = container.get_host_port_ipv4(5432).await.expect("port");
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(&url);
+    let pool = Pool::builder(manager).max_size(5).build().expect("pool");
+
+    let mut conn = pool.get().await.expect("conn");
+    diesel::sql_query(
+        "CREATE TABLE IF NOT EXISTS test_agg_events \
+         (id BIGSERIAL PRIMARY KEY, post_id BIGINT NOT NULL, score INT NOT NULL, \
+          created_at TIMESTAMP NOT NULL)",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("create test_agg_events");
+    diesel::sql_query(
+        "CREATE TABLE IF NOT EXISTS test_agg_tenant_events \
+         (id BIGSERIAL PRIMARY KEY, kind TEXT NOT NULL, amount BIGINT NOT NULL, \
+          tenant_id TEXT NOT NULL)",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("create test_agg_tenant_events");
+    diesel::sql_query(
+        "CREATE TABLE IF NOT EXISTS test_agg_soft_events \
+         (id BIGSERIAL PRIMARY KEY, bucket TEXT NOT NULL, value BIGINT NOT NULL, \
+          deleted_at TIMESTAMP)",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("create test_agg_soft_events");
+
+    (pool, container)
+}
+
+fn build_repo(pool: Pool<AsyncPgConnection>) -> PgAggEventRepository {
+    PgAggEventRepository {
+        pool,
+        __autumn_read_route: ReadRoute::Primary,
+        __autumn_statement_timeout_ms: 0,
+        __autumn_slow_threshold: std::time::Duration::from_millis(500),
+        __autumn_route: None,
+    }
+}
+
+fn build_tenant_repo(pool: Pool<AsyncPgConnection>) -> PgAggTenantEventRepository {
+    PgAggTenantEventRepository {
+        pool,
+        across_tenants: false,
+        __autumn_read_route: ReadRoute::Primary,
+        __autumn_statement_timeout_ms: 0,
+        __autumn_slow_threshold: std::time::Duration::from_millis(500),
+        __autumn_route: None,
+    }
+}
+
+fn build_soft_repo(pool: Pool<AsyncPgConnection>) -> PgAggSoftEventRepository {
+    PgAggSoftEventRepository {
+        pool,
+        __autumn_read_route: ReadRoute::Primary,
+        __autumn_statement_timeout_ms: 0,
+        __autumn_slow_threshold: std::time::Duration::from_millis(500),
+        __autumn_route: None,
+    }
+}
+
+fn ts(secs: i64) -> chrono::NaiveDateTime {
+    chrono::DateTime::from_timestamp(secs, 0)
+        .expect("valid timestamp")
+        .naive_utc()
+}
+
+// ── Non-ignored: the generated surface exists without a live database ──────────
+
+/// The generated inherent methods type-check and can be named as function
+/// items (proving the codegen ran) even where Docker is unavailable. This is
+/// the primary verification available in the sandbox.
+#[test]
+fn grouped_aggregate_methods_are_generated() {
+    fn assert_is_fn<F>(_f: F) {}
+    assert_is_fn(PgAggEventRepository::count_grouped_by_post_id);
+    assert_is_fn(PgAggEventRepository::sum_score_grouped_by_post_id);
+    assert_is_fn(PgAggEventRepository::avg_score_grouped_by_post_id);
+    assert_is_fn(PgAggEventRepository::min_score_grouped_by_post_id);
+    assert_is_fn(PgAggEventRepository::max_score_grouped_by_post_id);
+    assert_is_fn(PgAggEventRepository::count_grouped_by_created_at);
+    // Tenant-scoped branch (tenant predicate composed like `count`).
+    assert_is_fn(PgAggTenantEventRepository::sum_amount_grouped_by_kind);
+    assert_is_fn(PgAggTenantEventRepository::count_grouped_by_kind);
+    // Soft-delete branch (`deleted_at IS NULL` predicate).
+    assert_is_fn(PgAggSoftEventRepository::sum_value_grouped_by_bucket);
+}
+
+// ── Tests (require Docker) ────────────────────────────────────────────────────
+
+async fn seed_events(repo: &PgAggEventRepository, rows: &[(i64, i32, i64)]) {
+    let new: Vec<NewAggEvent> = rows
+        .iter()
+        .map(|&(post_id, score, at)| NewAggEvent {
+            post_id,
+            score,
+            created_at: ts(at),
+        })
+        .collect();
+    repo.save_many(&new).await.expect("seed events");
+}
+
+/// AC1: a plain grouped `COUNT(*)`/`SUM` returns one `(key, value)` pair per
+/// group with the correct aggregate.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn grouped_count_and_sum_basic() {
+    let (pool, _container) = setup_pool().await;
+    let repo = build_repo(pool);
+    seed_events(
+        &repo,
+        &[(1, 10, 0), (1, 5, 1), (2, 7, 2), (2, 3, 3), (2, 100, 4)],
+    )
+    .await;
+
+    let mut counts = repo.count_grouped_by_post_id().load().await.expect("count");
+    counts.sort_by_key(|(k, _)| *k);
+    assert_eq!(counts, vec![(1, 2), (2, 3)]);
+
+    let mut sums = repo
+        .sum_score_grouped_by_post_id()
+        .load()
+        .await
+        .expect("sum");
+    sums.sort_by_key(|(k, _)| *k);
+    assert_eq!(sums, vec![(1, Some(15)), (2, Some(110))]);
+}
+
+/// AC2: `avg`/`min`/`max` roll-ups return the expected typed values.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn grouped_avg_min_max() {
+    let (pool, _container) = setup_pool().await;
+    let repo = build_repo(pool);
+    seed_events(&repo, &[(1, 10, 0), (1, 20, 1), (1, 30, 2)]).await;
+
+    let avg = repo
+        .avg_score_grouped_by_post_id()
+        .load()
+        .await
+        .expect("avg");
+    assert_eq!(avg, vec![(1, Some(20.0))]);
+
+    let min = repo
+        .min_score_grouped_by_post_id()
+        .load()
+        .await
+        .expect("min");
+    assert_eq!(min, vec![(1, Some(10))]);
+
+    let max = repo
+        .max_score_grouped_by_post_id()
+        .load()
+        .await
+        .expect("max");
+    assert_eq!(max, vec![(1, Some(30))]);
+}
+
+/// AC3: `order_by_aggregate_desc().limit(n)` yields the top-N groups by the
+/// aggregated value, highest first.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn grouped_top_n_order_and_limit() {
+    let (pool, _container) = setup_pool().await;
+    let repo = build_repo(pool);
+    seed_events(
+        &repo,
+        &[(1, 1, 0), (2, 50, 1), (2, 50, 2), (3, 10, 3), (4, 5, 4)],
+    )
+    .await;
+
+    let top2 = repo
+        .sum_score_grouped_by_post_id()
+        .order_by_aggregate_desc()
+        .limit(2)
+        .load()
+        .await
+        .expect("top-2");
+
+    // post 2 = 100, post 3 = 10 are the two largest.
+    assert_eq!(top2, vec![(2, Some(100)), (3, Some(10))]);
+}
+
+/// AC4: a pre-group range filter scopes the rows before aggregation, and the
+/// value is bound as a parameter (no interpolation).
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn grouped_range_filter_before_grouping() {
+    let (pool, _container) = setup_pool().await;
+    let repo = build_repo(pool);
+    seed_events(
+        &repo,
+        &[(1, 10, 0), (2, 10, 0), (3, 10, 0), (4, 10, 0), (5, 10, 0)],
+    )
+    .await;
+
+    // Only post_id in [2, 4] should survive → three groups.
+    let mut got = repo
+        .count_grouped_by_post_id()
+        .filter_range(2, 4)
+        .load()
+        .await
+        .expect("ranged count");
+    got.sort_by_key(|(k, _)| *k);
+    assert_eq!(got, vec![(2, 1), (3, 1), (4, 1)]);
+
+    // Equality filter narrows to a single group.
+    let eqd = repo
+        .count_grouped_by_post_id()
+        .filter_eq(3)
+        .load()
+        .await
+        .expect("eq count");
+    assert_eq!(eqd, vec![(3, 1)]);
+}
+
+/// AC5: `DateBucket` groups a timestamp column into day/month buckets keyed by
+/// the bucket-start timestamp, and a date range scopes the window first.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn grouped_date_bucket_time_series() {
+    let (pool, _container) = setup_pool().await;
+    let repo = build_repo(pool);
+
+    // Two events on 1970-01-01 and one on 1970-01-02 (86_400s = one day).
+    seed_events(&repo, &[(1, 1, 10), (1, 1, 20), (1, 1, 86_400 + 5)]).await;
+
+    let mut per_day = repo
+        .count_grouped_by_created_at()
+        .bucket(DateBucket::Day)
+        .filter_range(ts(0), ts(7 * 86_400))
+        .load()
+        .await
+        .expect("per-day series");
+    per_day.sort_by_key(|(k, _)| *k);
+
+    assert_eq!(per_day, vec![(ts(0), 2), (ts(86_400), 1)]);
+}
+
+/// AC6: the aggregate acquires its connection through the repository's read
+/// route (`__autumn_acquire_read_conn`), so a replica-routed repo reads from
+/// the replica — exercised here on the primary route for a smoke check.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn grouped_aggregate_routes_through_read_role() {
+    let (pool, _container) = setup_pool().await;
+    let repo = build_repo(pool);
+    seed_events(&repo, &[(1, 1, 0)]).await;
+
+    // Primary route resolves and the aggregate succeeds.
+    assert!(matches!(repo.__autumn_read_route(), ReadRoute::Primary));
+    let got = repo.count_grouped_by_post_id().load().await.expect("count");
+    assert_eq!(got, vec![(1, 1)]);
+}
+
+/// AC7: an empty table yields an empty `Vec`, and a `sum`/`min`/`max` over a
+/// NULL column is null-safe (`None`).
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn grouped_empty_and_null_safe() {
+    let (pool, _container) = setup_pool().await;
+    let repo = build_repo(pool);
+
+    // Empty table → empty result.
+    let empty = repo
+        .sum_score_grouped_by_post_id()
+        .load()
+        .await
+        .expect("empty ok");
+    assert!(empty.is_empty(), "empty table must yield an empty Vec");
+
+    let empty_count = repo.count_grouped_by_post_id().load().await.expect("empty");
+    assert!(empty_count.is_empty());
+}
+
+/// Tenant scoping: the aggregate only sees the routed tenant's rows, matching
+/// `count`'s tenant predicate.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn grouped_aggregate_is_tenant_scoped() {
+    use autumn_web::tenancy::with_tenant;
+
+    let (pool, _container) = setup_pool().await;
+    let repo = build_tenant_repo(pool);
+
+    with_tenant("tenant-a".to_string(), async {
+        repo.save_many(&[
+            NewAggTenantEvent {
+                kind: "click".to_string(),
+                amount: 3,
+            },
+            NewAggTenantEvent {
+                kind: "click".to_string(),
+                amount: 4,
+            },
+        ])
+        .await
+        .expect("seed tenant-a");
+    })
+    .await;
+    with_tenant("tenant-b".to_string(), async {
+        repo.save_many(&[NewAggTenantEvent {
+            kind: "click".to_string(),
+            amount: 100,
+        }])
+        .await
+        .expect("seed tenant-b");
+    })
+    .await;
+
+    let sums = with_tenant("tenant-a".to_string(), async {
+        repo.sum_amount_grouped_by_kind()
+            .load()
+            .await
+            .expect("tenant-a sum")
+    })
+    .await;
+
+    // Only tenant-a's rows (3 + 4 = 7); tenant-b's 100 must not leak.
+    assert_eq!(sums, vec![("click".to_string(), Some(7))]);
+}
+
+/// Soft-delete: soft-deleted rows are excluded from the aggregate, matching
+/// the other finders' `deleted_at IS NULL` filter.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn grouped_aggregate_excludes_soft_deleted() {
+    let (pool, _container) = setup_pool().await;
+    let repo = build_soft_repo(pool);
+
+    let inserted = repo
+        .save_many(&[
+            NewAggSoftEvent {
+                bucket: "a".to_string(),
+                value: 10,
+            },
+            NewAggSoftEvent {
+                bucket: "a".to_string(),
+                value: 20,
+            },
+            NewAggSoftEvent {
+                bucket: "b".to_string(),
+                value: 5,
+            },
+        ])
+        .await
+        .expect("seed soft rows");
+
+    // Soft-delete one of bucket "a"'s rows.
+    repo.delete_by_id(inserted[0].id)
+        .await
+        .expect("soft delete");
+
+    let mut sums = repo
+        .sum_value_grouped_by_bucket()
+        .load()
+        .await
+        .expect("sum excluding trashed");
+    sums.sort_by(|a, b| a.0.cmp(&b.0));
+
+    // bucket "a" now only counts the surviving 20; bucket "b" is unchanged.
+    assert_eq!(
+        sums,
+        vec![("a".to_string(), Some(20)), ("b".to_string(), Some(5))]
+    );
+}

--- a/autumn/tests/integration/repository_grouped_aggregates.rs
+++ b/autumn/tests/integration/repository_grouped_aggregates.rs
@@ -114,6 +114,40 @@ pub trait AggSoftEventRepository {
     fn sum_value_grouped_by_bucket() -> Vec<(String, Option<i64>)>;
 }
 
+// ── Nullable-value model (AC7 all-NULL group → None) ──────────────────────────
+//
+// The group key (`post_id`) stays NOT NULL — nullable group keys are
+// unsupported — but the aggregated `score` column is genuinely NULLABLE, so a
+// group with only NULL scores exercises the null-safe `→ None` path.
+
+diesel::table! {
+    test_agg_nullable_events (id) {
+        id -> Int8,
+        post_id -> Int8,
+        score -> Nullable<Int4>,
+    }
+}
+
+#[autumn_web::model(table = "test_agg_nullable_events")]
+pub struct AggNullableEvent {
+    #[id]
+    pub id: i64,
+    pub post_id: i64,
+    pub score: Option<i32>,
+}
+
+#[autumn_web::repository(AggNullableEvent, table = "test_agg_nullable_events")]
+pub trait AggNullableEventRepository {
+    /// SUM(score) GROUP BY post_id over a NULLABLE column.
+    fn sum_score_grouped_by_post_id() -> Vec<(i64, Option<i64>)>;
+    /// MIN(score) GROUP BY post_id over a NULLABLE column.
+    fn min_score_grouped_by_post_id() -> Vec<(i64, Option<i32>)>;
+    /// MAX(score) GROUP BY post_id over a NULLABLE column.
+    fn max_score_grouped_by_post_id() -> Vec<(i64, Option<i32>)>;
+    /// AVG(score) GROUP BY post_id over a NULLABLE column.
+    fn avg_score_grouped_by_post_id() -> Vec<(i64, Option<f64>)>;
+}
+
 // ── Setup & helpers ───────────────────────────────────────────────────────────
 
 async fn setup_pool() -> (
@@ -157,6 +191,13 @@ async fn setup_pool() -> (
     .execute(&mut conn)
     .await
     .expect("create test_agg_soft_events");
+    diesel::sql_query(
+        "CREATE TABLE IF NOT EXISTS test_agg_nullable_events \
+         (id BIGSERIAL PRIMARY KEY, post_id BIGINT NOT NULL, score INT)",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("create test_agg_nullable_events");
 
     (pool, container)
 }
@@ -192,6 +233,16 @@ fn build_soft_repo(pool: Pool<AsyncPgConnection>) -> PgAggSoftEventRepository {
     }
 }
 
+fn build_nullable_repo(pool: Pool<AsyncPgConnection>) -> PgAggNullableEventRepository {
+    PgAggNullableEventRepository {
+        pool,
+        __autumn_read_route: ReadRoute::Primary,
+        __autumn_statement_timeout_ms: 0,
+        __autumn_slow_threshold: std::time::Duration::from_millis(500),
+        __autumn_route: None,
+    }
+}
+
 fn ts(secs: i64) -> chrono::NaiveDateTime {
     chrono::DateTime::from_timestamp(secs, 0)
         .expect("valid timestamp")
@@ -217,6 +268,11 @@ fn grouped_aggregate_methods_are_generated() {
     assert_is_fn(PgAggTenantEventRepository::count_grouped_by_kind);
     // Soft-delete branch (`deleted_at IS NULL` predicate).
     assert_is_fn(PgAggSoftEventRepository::sum_value_grouped_by_bucket);
+    // Nullable-value branch (all-NULL group → None).
+    assert_is_fn(PgAggNullableEventRepository::sum_score_grouped_by_post_id);
+    assert_is_fn(PgAggNullableEventRepository::min_score_grouped_by_post_id);
+    assert_is_fn(PgAggNullableEventRepository::max_score_grouped_by_post_id);
+    assert_is_fn(PgAggNullableEventRepository::avg_score_grouped_by_post_id);
 }
 
 // ── Tests (require Docker) ────────────────────────────────────────────────────
@@ -386,8 +442,9 @@ async fn grouped_aggregate_routes_through_read_role() {
     assert_eq!(got, vec![(1, 1)]);
 }
 
-/// AC7: an empty table yields an empty `Vec`, and a `sum`/`min`/`max` over a
-/// NULL column is null-safe (`None`).
+/// AC7 (empty half): an empty table yields an empty `Vec`. The null-safe
+/// `→ None` half is covered by `grouped_all_null_group_yields_none` below (which
+/// needs a genuinely NULLABLE value column).
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn grouped_empty_and_null_safe() {
@@ -404,6 +461,59 @@ async fn grouped_empty_and_null_safe() {
 
     let empty_count = repo.count_grouped_by_post_id().load().await.expect("empty");
     assert!(empty_count.is_empty());
+}
+
+/// AC7 (null-safe half): a group whose numeric column is entirely NULL yields
+/// `(key, None)` for `sum`/`min`/`max`/`avg` — never `(key, Some(0))`. Uses a
+/// genuinely NULLABLE `score` column (the other fixtures are all NOT NULL), so
+/// the group key is present but every aggregated value is NULL.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn grouped_all_null_group_yields_none() {
+    let (pool, _container) = setup_pool().await;
+    let repo = build_nullable_repo(pool);
+
+    // One group (post_id = 1) with two rows, both with a NULL score.
+    repo.save_many(&[
+        NewAggNullableEvent {
+            post_id: 1,
+            score: None,
+        },
+        NewAggNullableEvent {
+            post_id: 1,
+            score: None,
+        },
+    ])
+    .await
+    .expect("seed all-NULL group");
+
+    let sum = repo
+        .sum_score_grouped_by_post_id()
+        .load()
+        .await
+        .expect("sum");
+    assert_eq!(sum, vec![(1, None)], "SUM over an all-NULL group is None");
+
+    let min = repo
+        .min_score_grouped_by_post_id()
+        .load()
+        .await
+        .expect("min");
+    assert_eq!(min, vec![(1, None)], "MIN over an all-NULL group is None");
+
+    let max = repo
+        .max_score_grouped_by_post_id()
+        .load()
+        .await
+        .expect("max");
+    assert_eq!(max, vec![(1, None)], "MAX over an all-NULL group is None");
+
+    let avg = repo
+        .avg_score_grouped_by_post_id()
+        .load()
+        .await
+        .expect("avg");
+    assert_eq!(avg, vec![(1, None)], "AVG over an all-NULL group is None");
 }
 
 /// Tenant scoping: the aggregate only sees the routed tenant's rows, matching

--- a/docs/guide/repositories.md
+++ b/docs/guide/repositories.md
@@ -323,6 +323,12 @@ group column with `IS NOT NULL`), so the `NULL` group is omitted rather than
 deserialized into the non-nullable `K`. Nullable **value** columns are fine — an
 all-`NULL` group simply yields `(key, None)`.
 
+Grouped aggregates are **not** available on an `#[encrypted(...)]` column (as the
+group key or as an aggregated value): the stored value is ciphertext, so grouping
+would return ciphertext keys and `.filter_eq(..)` would compare plaintext against
+ciphertext and match nothing. Such a method returns an error at call time — use a
+raw query, or group on a non-encrypted column.
+
 ### Builder chain
 
 - `.order_by_aggregate_desc()` / `.order_by_aggregate_asc()` — order by the

--- a/docs/guide/repositories.md
+++ b/docs/guide/repositories.md
@@ -336,6 +336,10 @@ all-`NULL` group simply yields `(key, None)`.
   `.filter_eq(bucket_start)` would match only rows on the exact bucket boundary.
 - `.bucket(DateBucket::{Day, Week, Month})` — group by
   `date_trunc('<unit>', <col>)`, producing a time series keyed by bucket start.
+  This method is **only available when the group column is a timestamp type**
+  (`NaiveDateTime` or `DateTime<Utc>`); non-temporal group keys (e.g. an `i64`
+  `post_id`) have no `.bucket()` method, so an invalid `date_trunc` over a
+  non-timestamp column is a compile error rather than a runtime failure.
 
 ### Scoping comes for free
 

--- a/docs/guide/repositories.md
+++ b/docs/guide/repositories.md
@@ -316,9 +316,12 @@ The trait method **must** declare its pair return type; the macro reads `K` and
 timestamp's type). `sum`/`min`/`max`/`avg` are **null-safe**: a group whose
 values are all `NULL` yields `None`, and an empty result set is an empty `Vec`.
 
-The **group (key) column must be `NOT NULL`**. A nullable group key
-(`K = Option<T>`) is unsupported and rejected at compile time. Nullable **value**
-columns are fine — an all-`NULL` group simply yields `(key, None)`.
+A nullable group-key **type** (`K = Option<T>`) is unsupported and rejected at
+compile time. A nullable group-key **column** is safe: rows whose group key is
+`NULL` are silently **excluded** from the results (the generated query guards the
+group column with `IS NOT NULL`), so the `NULL` group is omitted rather than
+deserialized into the non-nullable `K`. Nullable **value** columns are fine — an
+all-`NULL` group simply yields `(key, None)`.
 
 ### Builder chain
 

--- a/docs/guide/repositories.md
+++ b/docs/guide/repositories.md
@@ -245,6 +245,100 @@ single-constraint guarantee.
 
 ---
 
+## 7. Grouped aggregate queries: `count_/sum_/avg_/min_/max_..._grouped_by_<col>` *(unreleased)*
+
+Dashboard roll-ups — a post's vote tally, an experiment's audit-trail size, a
+per-day event time series — are `GROUP BY` aggregates. Hand-writing them as raw
+`diesel::sql_query("SELECT … SUM(...) … GROUP BY …")` strings bypasses the
+repository's replica routing, tenant scoping, and soft-delete filters, and has
+to be re-typed for every widening cast. Declare them on the `#[repository]`
+trait instead (issue #1364):
+
+```rust
+#[autumn_web::repository(Vote, table = "votes")]
+pub trait VoteRepository {
+    /// COUNT(*)  GROUP BY post_id → Vec<(post_id, count)>.
+    fn count_grouped_by_post_id() -> Vec<(i64, i64)>;
+    /// SUM(value) GROUP BY post_id → Vec<(post_id, Option<sum>)>.
+    fn sum_value_grouped_by_post_id() -> Vec<(i64, Option<i64>)>;
+    /// AVG(value) GROUP BY post_id → Vec<(post_id, Option<f64>)>.
+    fn avg_value_grouped_by_post_id() -> Vec<(i64, Option<f64>)>;
+}
+```
+
+Each declared method becomes an **inherent** method on the generated `Pg*`
+struct that returns a lazy `GroupedAggregate<'_, K, V>` builder — nothing runs
+until the terminal `.load().await`:
+
+```rust
+// Top-5 posts by score, highest first.
+let top: Vec<(i64, Option<i64>)> = repo
+    .sum_value_grouped_by_post_id()
+    .order_by_aggregate_desc()
+    .limit(5)
+    .load()
+    .await?;
+
+// One post's tally: group by post_id, scope to it, take the single row.
+let score = repo
+    .sum_value_grouped_by_post_id()
+    .filter_eq(post_id)
+    .load()
+    .await?
+    .into_iter()
+    .next()
+    .and_then(|(_, sum)| sum)
+    .unwrap_or(0);
+
+// A day-bucketed time series over a bounded window.
+use autumn_web::aggregate::DateBucket;
+let per_day: Vec<(chrono::NaiveDateTime, i64)> = repo
+    .count_grouped_by_created_at()
+    .bucket(DateBucket::Day)
+    .filter_range(window_start, window_end)
+    .load()
+    .await?;
+```
+
+### Method-name shapes and the `Vec<(K, V)>` return
+
+The trait method **must** declare its pair return type; the macro reads `K` and
+`V` from it and bakes the matching Postgres bind/result SQL types.
+
+| method shape                              | `V`                                |
+|-------------------------------------------|------------------------------------|
+| `count_grouped_by_<col>`                  | `i64`                              |
+| `sum_<num_col>_grouped_by_<col>`          | `Option<T>` (`T` = column type)    |
+| `min_/max_<num_col>_grouped_by_<col>`     | `Option<T>`                        |
+| `avg_<num_col>_grouped_by_<col>`          | `Option<f64>`                      |
+
+`K` is the group column's Rust type (or, under `.bucket(..)`, the bucket-start
+timestamp's type). `sum`/`min`/`max`/`avg` are **null-safe**: a group whose
+values are all `NULL` yields `None`, and an empty result set is an empty `Vec`.
+
+### Builder chain
+
+- `.order_by_aggregate_desc()` / `.order_by_aggregate_asc()` — order by the
+  aggregated value; combine with `.limit(n)` for a top-N roll-up.
+- `.limit(n)` — cap the number of groups returned.
+- `.filter_eq(v)` / `.filter_range(lo, hi)` — scope rows **before** grouping;
+  both filter the *group column* and are bound as query parameters (never
+  interpolated). `filter_range` is inclusive and works for date/time windows.
+- `.bucket(DateBucket::{Day, Week, Month})` — group by
+  `date_trunc('<unit>', <col>)`, producing a time series keyed by bucket start.
+
+### Scoping comes for free
+
+The generated query composes the repository's soft-delete filter and tenant
+predicate exactly like `count`, and acquires its connection through the same
+read-route helper — so **replica routing and multi-tenancy work with no extra
+code**. Because `sum`/`avg`/`min`/`max` cannot be merged across shards, a
+sharded, tenant-scoped repository used via `across_tenants()` **rejects** a
+grouped aggregate rather than returning a per-shard-partial answer; run it per
+shard with `from_shard(..)` instead.
+
+---
+
 ## Read Replicas: Automatic Read Routing
 
 When `database.replica_url` is configured, every generated **read-only** method — `find_by_id`, `find_all`, `count`, `exists_by_id`, `paginate`, `cursor_page`, derived `find_by_*` / `count_by_*` / `exists_by_*` queries, and full-text `search` / `search_page` — automatically acquires its connection from the replica pool. Mutating methods (`save`, `update`, `delete_by_id`, the bulk operations, hook-driven writes, `with_lock`) always run on the primary. Provisioning a replica therefore offloads your primary with **zero application code changes**.

--- a/docs/guide/repositories.md
+++ b/docs/guide/repositories.md
@@ -340,6 +340,13 @@ all-`NULL` group simply yields `(key, None)`.
   (`NaiveDateTime` or `DateTime<Utc>`); non-temporal group keys (e.g. an `i64`
   `post_id`) have no `.bucket()` method, so an invalid `date_trunc` over a
   non-timestamp column is a compile error rather than a runtime failure.
+  The truncation zone follows the key type: a `NaiveDateTime`
+  (`timestamp WITHOUT time zone`) bucket truncates on the **stored wall-clock**
+  value (a deterministic field truncation, independent of the session
+  `TimeZone`), while a `DateTime<Utc>` (`timestamptz`) bucket is computed **in
+  UTC** — the generated SQL uses `date_trunc('<unit>', <col>, 'UTC')` so bucket
+  boundaries stay stable across deployments regardless of the DB session zone,
+  consistent with the `DateTime<Utc>` key type.
 
 ### Scoping comes for free
 

--- a/docs/guide/repositories.md
+++ b/docs/guide/repositories.md
@@ -316,14 +316,21 @@ The trait method **must** declare its pair return type; the macro reads `K` and
 timestamp's type). `sum`/`min`/`max`/`avg` are **null-safe**: a group whose
 values are all `NULL` yields `None`, and an empty result set is an empty `Vec`.
 
+The **group (key) column must be `NOT NULL`**. A nullable group key
+(`K = Option<T>`) is unsupported and rejected at compile time. Nullable **value**
+columns are fine — an all-`NULL` group simply yields `(key, None)`.
+
 ### Builder chain
 
 - `.order_by_aggregate_desc()` / `.order_by_aggregate_asc()` — order by the
   aggregated value; combine with `.limit(n)` for a top-N roll-up.
 - `.limit(n)` — cap the number of groups returned.
 - `.filter_eq(v)` / `.filter_range(lo, hi)` — scope rows **before** grouping;
-  both filter the *group column* and are bound as query parameters (never
+  both filter the *raw group column* and are bound as query parameters (never
   interpolated). `filter_range` is inclusive and works for date/time windows.
+  Note they filter the **raw** column even under `.bucket(..)`, so to window a
+  bucketed time series pass the raw-timestamp range to `.filter_range(lo, hi)` —
+  `.filter_eq(bucket_start)` would match only rows on the exact bucket boundary.
 - `.bucket(DateBucket::{Day, Week, Month})` — group by
   `date_trunc('<unit>', <col>)`, producing a time series keyed by bucket start.
 

--- a/examples/reddit-clone/src/models.rs
+++ b/examples/reddit-clone/src/models.rs
@@ -117,25 +117,21 @@ pub struct Comment {
     pub created_at: chrono::NaiveDateTime,
 }
 
-// Manual model -- complex constraints.
-
-#[allow(dead_code)] // Used by generated API routes; not directly referenced in app code
-#[derive(Debug, Clone, diesel::Queryable, diesel::Selectable, serde::Serialize)]
-#[diesel(table_name = votes)]
+// `Vote` is an `#[autumn_web::model]` so `VoteRepository` (see
+// `crate::repositories`) can expose the typed grouped-aggregate roll-up
+// `sum_value_grouped_by_post_id` (#1364) used to recompute a post's score.
+// A vote references *either* a post or a comment, so both FKs are nullable.
+#[autumn_web::model(table = "votes")]
 pub struct Vote {
+    #[id]
     pub id: i64,
+    #[indexed]
     pub user_id: i64,
+    #[indexed]
     pub post_id: Option<i64>,
+    #[indexed]
     pub comment_id: Option<i64>,
     pub value: i16,
+    #[default]
     pub created_at: chrono::NaiveDateTime,
-}
-
-#[derive(Debug, diesel::Insertable)]
-#[diesel(table_name = votes)]
-pub struct NewVote {
-    pub user_id: i64,
-    pub post_id: Option<i64>,
-    pub comment_id: Option<i64>,
-    pub value: i16,
 }

--- a/examples/reddit-clone/src/models.rs
+++ b/examples/reddit-clone/src/models.rs
@@ -119,7 +119,8 @@ pub struct Comment {
 
 // `Vote` is an `#[autumn_web::model]` so `VoteRepository` (see
 // `crate::repositories`) can expose the typed grouped-aggregate roll-up
-// `sum_value_grouped_by_post_id` (#1364) used to recompute a post's score.
+// `sum_value_grouped_by_post_id` (#1364), which the front-page "Top posts by
+// votes" leaderboard uses as a replica-eligible top-N read.
 // A vote references *either* a post or a comment, so both FKs are nullable.
 #[autumn_web::model(table = "votes")]
 pub struct Vote {

--- a/examples/reddit-clone/src/repositories.rs
+++ b/examples/reddit-clone/src/repositories.rs
@@ -15,9 +15,10 @@
 
 use crate::hooks::PostHooks;
 use crate::models::{
-    NewPost, NewSubreddit, Post, PostDraftExt, Subreddit, UpdatePost, UpdateSubreddit,
+    NewPost, NewSubreddit, NewVote, Post, PostDraftExt, Subreddit, UpdatePost, UpdateSubreddit,
+    UpdateVote, Vote,
 };
-use crate::schema::{posts, subreddits};
+use crate::schema::{posts, subreddits, votes};
 
 #[autumn_web::repository(Subreddit, api = "/api/subreddits")]
 pub trait SubredditRepository {
@@ -54,6 +55,17 @@ pub trait PostRepository {
 
     /// SELECT * FROM posts WHERE author_id = $1
     fn find_by_author_id(author_id: i64) -> Vec<Post>;
+}
+
+// Typed grouped aggregate (#1364): `sum_value_grouped_by_post_id` rolls the
+// votes table up to `SUM(value) GROUP BY post_id`, returning one
+// `(post_id, Option<sum>)` pair per post. `cast_vote` scopes it to a single
+// post with `.filter_eq(post_id)` to recompute that post's score without a
+// hand-written `SUM` subquery -- the read is replica-routed automatically.
+#[autumn_web::repository(Vote, table = "votes")]
+pub trait VoteRepository {
+    /// SUM(value) GROUP BY post_id -> `Vec<(post_id, Option<sum>)>`.
+    fn sum_value_grouped_by_post_id() -> Vec<(i64, Option<i64>)>;
 }
 
 #[derive(Clone, Debug)]

--- a/examples/reddit-clone/src/repositories.rs
+++ b/examples/reddit-clone/src/repositories.rs
@@ -59,9 +59,12 @@ pub trait PostRepository {
 
 // Typed grouped aggregate (#1364): `sum_value_grouped_by_post_id` rolls the
 // votes table up to `SUM(value) GROUP BY post_id`, returning one
-// `(post_id, Option<sum>)` pair per post. `cast_vote` scopes it to a single
-// post with `.filter_eq(post_id)` to recompute that post's score without a
-// hand-written `SUM` subquery -- the read is replica-routed automatically.
+// `(post_id, Option<sum>)` pair per post. The front-page "Top posts by votes"
+// leaderboard (`routes::posts::front_page`) chains
+// `.order_by_aggregate_desc().limit(5)` for a top-N roll-up in a single call —
+// a *read*, so it is replica-eligible via the repository's read route. Note the
+// score-maintenance path in `routes::votes` is deliberately NOT this API: score
+// upkeep is an atomic primary-side `UPDATE`, not a read-then-write.
 #[autumn_web::repository(Vote, table = "votes")]
 pub trait VoteRepository {
     /// SUM(value) GROUP BY post_id -> `Vec<(post_id, Option<sum>)>`.

--- a/examples/reddit-clone/src/routes/posts.rs
+++ b/examples/reddit-clone/src/routes/posts.rs
@@ -42,6 +42,7 @@ pub async fn front_page(
     session: Session,
     csrf: CsrfToken,
     mut db: Db,
+    State(state): State<AppState>,
     repo: PgPostRepository,
     votes_repo: PgVoteRepository,
     flags: Flags,
@@ -66,6 +67,16 @@ pub async fn front_page(
         .load(&mut *db)
         .await?;
 
+    // Release the `Db` extractor's connection now, before any other pooled
+    // checkout. `Db` acquires its connection eagerly at extraction and holds it
+    // until it is dropped (not just for the duration of a `&mut *db` borrow), so
+    // on a single-connection pool (max_size = 1, no read replica) the
+    // leaderboard aggregate below — and the `preload` further down — would block
+    // forever waiting for a second connection that can never free up while `db`
+    // is still alive. Dropping `db` here lets each step below check out the one
+    // connection in turn.
+    drop(db);
+
     // "Top posts by votes" leaderboard (#1364, AC3): a single typed
     // grouped-aggregate call — `SUM(value) GROUP BY post_id`, ordered by the
     // aggregate descending, top 5 — replacing what would otherwise be a
@@ -78,7 +89,8 @@ pub async fn front_page(
     // the grouped-aggregate codegen guards the group column with `IS NOT NULL`,
     // so the NULL group is excluded — this leaderboard counts only
     // post-directed votes (comment votes are correctly omitted), no per-call
-    // filter needed.
+    // filter needed. Binding the result to an owned `Vec` releases the
+    // repository's pooled connection before the title lookup checks one out.
     let top_by_votes: Vec<(i64, Option<i64>)> = votes_repo
         .sum_value_grouped_by_post_id()
         .order_by_aggregate_desc()
@@ -93,21 +105,28 @@ pub async fn front_page(
     let top_titles: HashMap<i64, String> = if top_ids.is_empty() {
         HashMap::new()
     } else {
+        // Use a fresh, short-lived pool checkout — not the `Db` extractor, which
+        // was dropped above — so this lookup never overlaps another live
+        // connection on a single-connection pool. The `conn` guard is released
+        // at the end of this block, before `preload` checks one out.
+        let pool = state
+            .pool()
+            .ok_or_else(|| AutumnError::service_unavailable_msg("Database not configured"))?;
+        let mut conn = pool.get().await.map_err(AutumnError::from)?;
         posts::table
             .filter(posts::id.eq_any(&top_ids))
             .select((posts::id, posts::title))
-            .load::<(i64, String)>(&mut *db)
+            .load::<(i64, String)>(&mut conn)
             .await?
             .into_iter()
             .collect()
     };
 
-    // Release the base-query connection before `preload` checks one out, so the
-    // two never contend on a single-connection pool. The base rows were read
-    // from the primary via `Db`, so pin the preload to the primary too
-    // (`on_primary`) — otherwise, under replica lag, an author/subreddit just
-    // written may be missing on the replica and the post would be skipped.
-    drop(db);
+    // The base rows were read from the primary via `Db`, so pin the preload to
+    // the primary too (`on_primary`) — otherwise, under replica lag, an
+    // author/subreddit just written may be missing on the replica and the post
+    // would be skipped. `db` was already released above, so this checkout can
+    // never contend with it on a single-connection pool.
     let hot_posts = repo
         .on_primary()
         .preload(hot_posts, Post::preload().author().subreddit())

--- a/examples/reddit-clone/src/routes/posts.rs
+++ b/examples/reddit-clone/src/routes/posts.rs
@@ -82,13 +82,19 @@ pub async fn front_page(
     // Resolve the leaderboard entries' titles in one query (order preserved via
     // the `top_by_votes` iteration below).
     let top_ids: Vec<i64> = top_by_votes.iter().map(|(id, _)| *id).collect();
-    let top_titles: HashMap<i64, String> = posts::table
-        .filter(posts::id.eq_any(&top_ids))
-        .select((posts::id, posts::title))
-        .load::<(i64, String)>(&mut *db)
-        .await?
-        .into_iter()
-        .collect();
+    // Skip the follow-up title lookup entirely when the leaderboard is empty —
+    // otherwise we'd issue a pointless `WHERE id = ANY('{}')` query.
+    let top_titles: HashMap<i64, String> = if top_ids.is_empty() {
+        HashMap::new()
+    } else {
+        posts::table
+            .filter(posts::id.eq_any(&top_ids))
+            .select((posts::id, posts::title))
+            .load::<(i64, String)>(&mut *db)
+            .await?
+            .into_iter()
+            .collect()
+    };
 
     // Release the base-query connection before `preload` checks one out, so the
     // two never contend on a single-connection pool. The base rows were read

--- a/examples/reddit-clone/src/routes/posts.rs
+++ b/examples/reddit-clone/src/routes/posts.rs
@@ -73,6 +73,12 @@ pub async fn front_page(
     // *read*, so it is replica-eligible (routes through the repository's read
     // route). The score-maintenance path in `routes::votes` stays an atomic
     // primary-side WRITE — see the note there.
+    //
+    // `votes.post_id` is nullable (comment votes carry a NULL `post_id`), and
+    // the grouped-aggregate codegen guards the group column with `IS NOT NULL`,
+    // so the NULL group is excluded — this leaderboard counts only
+    // post-directed votes (comment votes are correctly omitted), no per-call
+    // filter needed.
     let top_by_votes: Vec<(i64, Option<i64>)> = votes_repo
         .sum_value_grouped_by_post_id()
         .order_by_aggregate_desc()

--- a/examples/reddit-clone/src/routes/posts.rs
+++ b/examples/reddit-clone/src/routes/posts.rs
@@ -20,7 +20,7 @@ use crate::jobs::{PostPublicationArgs, PostPublicationJob};
 use crate::models::{
     Comment, CommentAssociations, NewTag, Post, PostAssociations, PostTagsMutations, Subreddit, Tag,
 };
-use crate::repositories::{PgPostRepository, PostRepository};
+use crate::repositories::{PgPostRepository, PgVoteRepository, PostRepository};
 use crate::schema::{posts, subreddits, tags};
 use crate::slugify::slugify;
 
@@ -37,11 +37,13 @@ use super::layout::{layout, time_ago, vote_controls};
 // ── Front page — hot posts across all subreddits ───────────────
 
 #[get("/")]
+#[allow(clippy::too_many_arguments)]
 pub async fn front_page(
     session: Session,
     csrf: CsrfToken,
     mut db: Db,
     repo: PgPostRepository,
+    votes_repo: PgVoteRepository,
     flags: Flags,
     exps: Experiments,
     flash: Flash,
@@ -63,6 +65,31 @@ pub async fn front_page(
         .select(Post::as_select())
         .load(&mut *db)
         .await?;
+
+    // "Top posts by votes" leaderboard (#1364, AC3): a single typed
+    // grouped-aggregate call — `SUM(value) GROUP BY post_id`, ordered by the
+    // aggregate descending, top 5 — replacing what would otherwise be a
+    // hand-written `SUM ... GROUP BY ... ORDER BY ... LIMIT` string. This is a
+    // *read*, so it is replica-eligible (routes through the repository's read
+    // route). The score-maintenance path in `routes::votes` stays an atomic
+    // primary-side WRITE — see the note there.
+    let top_by_votes: Vec<(i64, Option<i64>)> = votes_repo
+        .sum_value_grouped_by_post_id()
+        .order_by_aggregate_desc()
+        .limit(5)
+        .load()
+        .await?;
+    // Resolve the leaderboard entries' titles in one query (order preserved via
+    // the `top_by_votes` iteration below).
+    let top_ids: Vec<i64> = top_by_votes.iter().map(|(id, _)| *id).collect();
+    let top_titles: HashMap<i64, String> = posts::table
+        .filter(posts::id.eq_any(&top_ids))
+        .select((posts::id, posts::title))
+        .load::<(i64, String)>(&mut *db)
+        .await?
+        .into_iter()
+        .collect();
+
     // Release the base-query connection before `preload` checks one out, so the
     // two never contend on a single-connection pool. The base rows were read
     // from the primary via `Db`, so pin the preload to the primary too
@@ -100,6 +127,31 @@ pub async fn front_page(
                 }
                 a href="/?sort=new" class="text-gray-500 hover:text-orange-600 px-3 py-1.5" {
                     "New"
+                }
+            }
+
+            // Top posts by votes — rendered from the typed grouped-aggregate
+            // leaderboard read (#1364, AC3). Empty until posts have votes.
+            @if !top_by_votes.is_empty() {
+                div class="mb-4 px-4 py-3 bg-white rounded-lg shadow-sm border border-gray-200" {
+                    div class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2" {
+                        "Top posts by votes"
+                    }
+                    ol class="space-y-1 text-sm" {
+                        @for (post_id, sum) in &top_by_votes {
+                            @if let Some(title) = top_titles.get(post_id) {
+                                li class="flex items-center gap-2" {
+                                    span class="font-semibold text-gray-500 w-8 text-right shrink-0" {
+                                        (sum.unwrap_or(0))
+                                    }
+                                    a href=(format!("/posts/{}", post_id))
+                                       class="text-gray-900 hover:text-orange-600 line-clamp-1" {
+                                        (title)
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
 

--- a/examples/reddit-clone/src/routes/votes.rs
+++ b/examples/reddit-clone/src/routes/votes.rs
@@ -10,7 +10,6 @@ use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
 use crate::models::Post;
-use crate::repositories::PgVoteRepository;
 use crate::schema::{posts, votes};
 
 use super::layout::vote_controls;
@@ -21,10 +20,9 @@ pub async fn upvote(
     Path(post_id): Path<i64>,
     session: Session,
     mut db: Db,
-    votes_repo: PgVoteRepository,
     State(state): State<AppState>,
 ) -> AutumnResult<Markup> {
-    cast_vote(post_id, 1, &session, &mut db, &votes_repo, &state).await
+    cast_vote(post_id, 1, &session, &mut db, &state).await
 }
 
 /// Downvote a post (-1). Returns updated vote controls HTML via htmx.
@@ -33,10 +31,9 @@ pub async fn downvote(
     Path(post_id): Path<i64>,
     session: Session,
     mut db: Db,
-    votes_repo: PgVoteRepository,
     State(state): State<AppState>,
 ) -> AutumnResult<Markup> {
-    cast_vote(post_id, -1, &session, &mut db, &votes_repo, &state).await
+    cast_vote(post_id, -1, &session, &mut db, &state).await
 }
 
 /// Cast a vote on a post. Handles insert-or-update and score recalculation.
@@ -45,7 +42,6 @@ async fn cast_vote(
     value: i16,
     session: &Session,
     db: &mut Db,
-    votes_repo: &PgVoteRepository,
     state: &AppState,
 ) -> AutumnResult<Markup> {
     let user_id: i64 = session
@@ -110,27 +106,22 @@ async fn cast_vote(
         }
     }
 
-    // Recompute the post's score from the typed grouped-aggregate roll-up
-    // (#1364) instead of a hand-written `SUM` subquery. Grouping votes by
-    // post_id and scoping to this post yields a single `(post_id, Option<sum>)`
-    // row; an absent row (no votes left) means a score of 0. The read is
-    // replica-routed automatically.
-    let new_score = votes_repo
-        .sum_value_grouped_by_post_id()
-        .filter_eq(post_id)
-        .load()
-        .await?
-        .into_iter()
-        .next()
-        .and_then(|(_, sum)| sum)
-        .unwrap_or(0);
-    diesel::update(posts::table.find(post_id))
-        .set(posts::score.eq(new_score))
-        .execute(&mut **db)
-        .await?;
+    // Recompute the score atomically in a single statement on the request's
+    // primary `db` connection — no read-then-write race. Score maintenance is a
+    // WRITE: it must see this transaction's just-written vote and stay atomic
+    // with it, so it must NOT be a replica-eligible read. (For a replica-routed
+    // *read* of vote tallies via the typed grouped-aggregate API (#1364), see
+    // the "Top posts by votes" leaderboard on the front page — routes::posts.)
+    diesel::sql_query(
+        "UPDATE posts SET score = COALESCE((SELECT SUM(value::bigint) FROM votes WHERE post_id = $1), 0) WHERE id = $1"
+    )
+    .bind::<diesel::sql_types::BigInt, _>(post_id)
+    .execute(&mut **db)
+    .await?;
 
-    // Load the updated post to broadcast it (its score now equals `new_score`).
+    // Load the updated post to broadcast it.
     let post: Post = posts::table.find(post_id).first(&mut **db).await?;
+    let new_score = post.score;
 
     // Load the subreddit to get its slug
     let sub: crate::models::Subreddit = crate::schema::subreddits::table

--- a/examples/reddit-clone/src/routes/votes.rs
+++ b/examples/reddit-clone/src/routes/votes.rs
@@ -10,6 +10,7 @@ use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
 use crate::models::Post;
+use crate::repositories::PgVoteRepository;
 use crate::schema::{posts, votes};
 
 use super::layout::vote_controls;
@@ -20,9 +21,10 @@ pub async fn upvote(
     Path(post_id): Path<i64>,
     session: Session,
     mut db: Db,
+    votes_repo: PgVoteRepository,
     State(state): State<AppState>,
 ) -> AutumnResult<Markup> {
-    cast_vote(post_id, 1, &session, &mut db, &state).await
+    cast_vote(post_id, 1, &session, &mut db, &votes_repo, &state).await
 }
 
 /// Downvote a post (-1). Returns updated vote controls HTML via htmx.
@@ -31,9 +33,10 @@ pub async fn downvote(
     Path(post_id): Path<i64>,
     session: Session,
     mut db: Db,
+    votes_repo: PgVoteRepository,
     State(state): State<AppState>,
 ) -> AutumnResult<Markup> {
-    cast_vote(post_id, -1, &session, &mut db, &state).await
+    cast_vote(post_id, -1, &session, &mut db, &votes_repo, &state).await
 }
 
 /// Cast a vote on a post. Handles insert-or-update and score recalculation.
@@ -42,6 +45,7 @@ async fn cast_vote(
     value: i16,
     session: &Session,
     db: &mut Db,
+    votes_repo: &PgVoteRepository,
     state: &AppState,
 ) -> AutumnResult<Markup> {
     let user_id: i64 = session
@@ -106,17 +110,27 @@ async fn cast_vote(
         }
     }
 
-    // Recompute score atomically in a single statement — no read-then-write race.
-    diesel::sql_query(
-        "UPDATE posts SET score = COALESCE((SELECT SUM(value::bigint) FROM votes WHERE post_id = $1), 0) WHERE id = $1"
-    )
-    .bind::<diesel::sql_types::BigInt, _>(post_id)
-    .execute(&mut **db)
-    .await?;
+    // Recompute the post's score from the typed grouped-aggregate roll-up
+    // (#1364) instead of a hand-written `SUM` subquery. Grouping votes by
+    // post_id and scoping to this post yields a single `(post_id, Option<sum>)`
+    // row; an absent row (no votes left) means a score of 0. The read is
+    // replica-routed automatically.
+    let new_score = votes_repo
+        .sum_value_grouped_by_post_id()
+        .filter_eq(post_id)
+        .load()
+        .await?
+        .into_iter()
+        .next()
+        .and_then(|(_, sum)| sum)
+        .unwrap_or(0);
+    diesel::update(posts::table.find(post_id))
+        .set(posts::score.eq(new_score))
+        .execute(&mut **db)
+        .await?;
 
-    // Load the updated post to broadcast it
+    // Load the updated post to broadcast it (its score now equals `new_score`).
     let post: Post = posts::table.find(post_id).first(&mut **db).await?;
-    let new_score = post.score;
 
     // Load the subreddit to get its slug
     let sub: crate::models::Subreddit = crate::schema::subreddits::table

--- a/skills/autumn-web/references/api-reference.md
+++ b/skills/autumn-web/references/api-reference.md
@@ -179,6 +179,26 @@ Requires a unique constraint covering the lookup column(s); `_or_` is rejected
 (it would span constraints). See "Race-safe get-or-insert" in
 `docs/guide/repositories.md`.
 
+**(unreleased)** — typed grouped aggregate queries (#1364): declare
+`fn count_grouped_by_<col>() -> Vec<(K, i64)>` or
+`fn <sum|avg|min|max>_<num_col>_grouped_by_<col>() -> Vec<(K, Option<T>)>`
+(`avg` → `Option<f64>`) in the `#[repository]` trait — the pair return type is
+**required** (the macro reads the key/value SQL types from it). Each becomes an
+inherent method returning a lazy `GroupedAggregate<'_, K, V>` builder that
+yields one `(group, aggregate)` pair per group; nothing runs until the terminal
+`.load().await -> AutumnResult<Vec<(K, V)>>`. Chain
+`.order_by_aggregate_desc()` / `.order_by_aggregate_asc()` + `.limit(n)` for
+top-N, `.filter_eq(v)` / `.filter_range(lo, hi)` to scope the group column
+*before* aggregating (bound as params, inclusive range), or
+`.bucket(autumn_web::aggregate::DateBucket::{Day,Week,Month})` for a
+`date_trunc` time series keyed by bucket start. `sum`/`avg`/`min`/`max` are
+null-safe (all-`NULL` group → `None`, empty table → empty `Vec`). Inherits
+soft-delete + tenant scoping + read routing like `count`; a sharded,
+tenant-scoped repo used via `across_tenants()` rejects the aggregate rather than
+returning a per-shard-partial answer. `DateBucket` and the `GroupedAggregate`
+builder live in `autumn_web::aggregate`. See "Grouped aggregate queries" in
+`docs/guide/repositories.md`.
+
 ## Db transactions
 
 - `Db::tx(f)` — READ COMMITTED, one attempt (published 0.5.0).


### PR DESCRIPTION
Closes #1364

## Before / After

**Before:** Dashboards and leaderboards hand-wrote raw `diesel::sql_query` aggregate statements. Because these bypassed the repository layer, they also bypassed read-replica routing, tenant scoping, and soft-delete filtering — every ad-hoc aggregate was a place where a query could silently read from the primary, leak across tenants, or count rows that had been soft-deleted.

**After:** Repositories expose typed `count` / `sum` / `avg` / `min` / `max` methods with a `grouped_by(...)` terminator that returns `Vec<(group, aggregate)>`. These are built through a lazy `GroupedAggregate` builder that supports top-N ordering, pre-group range/date filters, and day/week/month date bucketing. Every generated aggregate inherits the same replica routing, tenant scoping, and soft-delete semantics as the rest of the repository, so the correctness guarantees are no longer optional.

## How

- Declaration-driven macro codegen in `autumn-macros/src/repository.rs` emits inherent aggregate methods on the generated `Pg*` repository. Each method hands back a builder from the new `autumn_web::aggregate` runtime.
- The builder lowers to a parameterized `sql_query` with a baked `QueryableByName` result type, so grouping columns and aggregates are read back type-safely.
- Cross-shard aggregation is rejected: calling `across_tenants()` on a grouped aggregate is a hard error, since a single `sql_query` cannot fan out across shards.
- Compile-time guards enforce the value types: `avg` must be collected into `Option<f64>`, `count` into `i64`, and grouping on a nullable key is a compile error. These are covered by the macro's `trybuild`/parse-error tests.

## Testing

- `cargo build -p autumn-macros -p autumn-web` — clean.
- `cargo test -p autumn-macros` — 399 passed, including the new grouped-aggregate guard tests (`grouped_count_wrong_value_type`, `grouped_avg_wrong_value_type`, `grouped_nullable_key`).
- `cargo test -p autumn-web --no-run --features db` — the DB-backed integration test binary compiles. The live DB tests are `#[ignore]`-gated and were not executed (no Docker/Postgres in the sandbox).
- `cargo build -p reddit-clone -p autumn-admin-plugin` — both example/plugin consumers build against the new API.
- `cargo fmt --all` — clean.
- `cargo clippy -p autumn-macros -p autumn-web -p reddit-clone -p autumn-admin-plugin --all-targets --features db -- -D warnings` — clean.
- Plugin-freshness gate (`scripts/check-plugin-freshness.sh`) — exit 0.

### AC8 rewrites (raw-SQL sites moved onto the API)

- **reddit-clone** front-page "Top posts by votes" leaderboard now uses the grouped-aggregate API as a replica-eligible read. The atomic vote-score `UPDATE` was intentionally left as an atomic write and not routed through the aggregate API.
- **autumn-admin-plugin** experiment-history count now goes through the typed aggregate method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RdGoLK3CkXP5DaCy4i1Wec

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdGoLK3CkXP5DaCy4i1Wec)_