### PR TITLE
fix(stories): reconcile Badge story-slug collision after post-merge conflict

### DIFF
--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -5202,9 +5202,9 @@ enabled = true
     async fn custom_story_served_alongside_builtins() {
         let custom = crate::stories::story! {
             "App",
-            "Badge",
+            "Greeting",
             {
-                maud::html! { span class="app-badge" { "hi from the app" } }
+                maud::html! { span class="app-greeting" { "hi from the app" } }
             }
         };
         let state = test_state();
@@ -5216,7 +5216,7 @@ enabled = true
 
         let router = build_router(Vec::new(), &story_gallery_config(), state);
 
-        let detail = get_with_host(router.clone(), "/_stories/badge").await;
+        let detail = get_with_host(router.clone(), "/_stories/greeting").await;
         assert_eq!(detail.status(), StatusCode::OK);
         let body = response_text(detail).await;
         assert!(
@@ -5227,7 +5227,7 @@ enabled = true
         let index = get_with_host(router, "/_stories").await;
         let body = response_text(index).await;
         assert!(
-            body.contains("Badge"),
+            body.contains("Greeting"),
             "index must list the custom story: {body}"
         );
         assert!(

--- a/autumn/src/stories/mod.rs
+++ b/autumn/src/stories/mod.rs
@@ -662,7 +662,7 @@ mod tests {
 
         let custom = crate::stories::story! {
             "App",
-            "Badge",
+            "Greeting",
             {
                 maud::html! { span { "hi" } }
             }
@@ -670,7 +670,7 @@ mod tests {
         let registry = StoryGallery::builtin().extend([custom]).into_registry();
         assert_eq!(registry.stories().len(), builtin_count + 1);
         assert!(
-            registry.find("badge").is_some(),
+            registry.find("greeting").is_some(),
             "extended custom story must be findable by its slug"
         );
     }


### PR DESCRIPTION
## Before

`cargo test -p autumn-web --lib` failed 2 tests:

- `router::tests::custom_story_served_alongside_builtins`
- `stories::tests::gallery_new_is_empty_builtin_is_seeded_extend_appends`

Both panicked in `StoryRegistry::new` with `duplicate story slug 'badge'`.

## After

Both tests pass; `cargo test -p autumn-web --lib` is green (3262 passed; 0 failed; 19 ignored).

## Root cause

Two PRs that were each green on their own base collided when merged into `trunk-dev`:

- PR #1657 (widgets) added a real builtin `Display / Badge` story. Its slug derives to the flat slug `badge`.
- Two older **test fixtures** (added earlier, commit `9c630404`) were arbitrarily named `App / Badge` and derive the same flat slug `badge`.

Story slugs are a deliberate flat namespace keyed on the bare name (the group is intentionally not part of the slug), so `StoryRegistry::new`'s duplicate-slug guard correctly panics. Neither PR was wrong in isolation; the collision only appears once both land together.

## How

Renamed **only the test fixtures** `App / Badge` → `App / Greeting` (slug `greeting`) in the two spots that define them:

- `autumn/src/stories/mod.rs` — fixture name and the `registry.find("greeting")` assertion.
- `autumn/src/router.rs` — fixture name, the `/_stories/greeting` route path, the `app-greeting` CSS class, and the index-listing assertion.

No product code is touched — the builtin `Badge` feature from #1657 is untouched and still served at `/_stories/badge`. `EXPECTED_STORY_SLUGS` is unchanged (it enumerates builtins only, and already lists `badge`). No changelog entry or version bump: this is a test-only reconciliation with nothing user-visible.

## Verification

The full workspace suite was run; the only genuine failures were these two. The throttle / rate-limit cluster (#1662) is green:

- `cargo test -p autumn-macros throttle` → 18 passed, 0 failed
- `cargo test -p autumn-web --test integration_tests` → 937 passed, 0 failed

`cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` both pass.

Refs #1657, #1662.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpowdQJgwhbyvcpRnprP1e)_