### PR TITLE
🌟 Nova: Postman Collection Exporter

### DIFF
--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -607,7 +607,7 @@ enum Commands {
         /// Binary target to inspect (for packages with multiple bin targets).
         #[arg(long, value_name = "BIN")]
         bin: Option<String>,
-        /// Output format.
+        /// Output format: `table`, `json`, or `postman`.
         #[arg(long, default_value = "table", value_name = "FORMAT")]
         format: String,
         /// Show only routes whose path starts with PREFIX (positional shorthand for --filter).
@@ -4464,6 +4464,17 @@ mod tests {
         match cli.command {
             Commands::Routes { format, .. } => {
                 assert_eq!(format, "json");
+            }
+            _ => panic!("expected Routes command"),
+        }
+    }
+
+    #[test]
+    fn parse_routes_format_postman() {
+        let cli = Cli::try_parse_from(["autumn", "routes", "--format", "postman"]).unwrap();
+        match cli.command {
+            Commands::Routes { format, .. } => {
+                assert_eq!(format, "postman");
             }
             _ => panic!("expected Routes command"),
         }

--- a/autumn-cli/src/routes.rs
+++ b/autumn-cli/src/routes.rs
@@ -17,6 +17,7 @@ use crate::text_width::display_width;
 pub enum OutputFormat {
     Table,
     Json,
+    Postman,
 }
 
 impl std::str::FromStr for OutputFormat {
@@ -26,8 +27,9 @@ impl std::str::FromStr for OutputFormat {
         match s.to_lowercase().as_str() {
             "table" => Ok(Self::Table),
             "json" => Ok(Self::Json),
+            "postman" => Ok(Self::Postman),
             other => Err(format!(
-                "unknown format '{other}'; expected 'table' or 'json'"
+                "unknown format '{other}'; expected 'table', 'json', or 'postman'"
             )),
         }
     }
@@ -97,6 +99,7 @@ pub fn run(opts: &RoutesOptions<'_>) {
     match &opts.format {
         OutputFormat::Table => print_table(&routes),
         OutputFormat::Json => print_json(&routes),
+        OutputFormat::Postman => print_postman(&routes),
     }
 }
 
@@ -250,6 +253,53 @@ fn format_row(cells: &[String; 7], widths: &[usize; 7]) -> String {
 pub fn print_json(routes: &[RouteInfo]) {
     let json =
         serde_json::to_string_pretty(routes).unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"));
+    println!("{json}");
+}
+
+pub fn generate_postman(routes: &[RouteInfo]) -> serde_json::Value {
+    let mut items = Vec::new();
+    for route in routes {
+        let name = format!("{} {}", route.method, route.path);
+        // Replace `{param}` with `:param` for Postman path variables
+        let url = format!(
+            "{{{{base_url}}}}{}",
+            route.path.replace('{', ":").replace('}', "")
+        );
+        let item = serde_json::json!({
+            "name": name,
+            "request": {
+                "method": route.method,
+                "header": [],
+                "url": {
+                    "raw": url,
+                    "host": ["{{base_url}}"],
+                    "path": route.path.trim_start_matches('/').split('/').map(|s| s.replace('{', ":").replace('}', "")).collect::<Vec<_>>()
+                }
+            },
+            "response": []
+        });
+        items.push(item);
+    }
+
+    serde_json::json!({
+        "info": {
+            "name": "Autumn Routes",
+            "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+        },
+        "item": items,
+        "variable": [
+            {
+                "key": "base_url",
+                "value": "http://localhost:3000",
+                "type": "string"
+            }
+        ]
+    })
+}
+
+pub fn print_postman(routes: &[RouteInfo]) {
+    let json = serde_json::to_string_pretty(&generate_postman(routes))
+        .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"));
     println!("{json}");
 }
 
@@ -630,6 +680,14 @@ mod tests {
         assert!(table.contains("cached(60s)"), "missing middleware label");
     }
 
+    #[test]
+    fn parse_output_format_postman() {
+        assert_eq!(
+            "postman".parse::<OutputFormat>().unwrap(),
+            OutputFormat::Postman
+        );
+    }
+
     // ── print_json ─────────────────────────────────────────────────────────
 
     #[test]
@@ -638,6 +696,30 @@ mod tests {
         let json_str = serde_json::to_string_pretty(&routes).unwrap();
         let parsed: Vec<RouteInfo> = serde_json::from_str(&json_str).unwrap();
         assert_eq!(parsed.len(), routes.len());
+    }
+
+    // ── generate_postman ───────────────────────────────────────────────────
+
+    #[test]
+    fn generate_postman_produces_valid_collection() {
+        let routes = sample_routes();
+        let collection = generate_postman(&routes);
+        assert_eq!(collection["info"]["name"], "Autumn Routes");
+        assert!(
+            collection["info"]["schema"]
+                .as_str()
+                .unwrap()
+                .contains("v2.1.0")
+        );
+        let items = collection["item"].as_array().unwrap();
+        assert_eq!(items.len(), routes.len());
+        assert_eq!(items[0]["request"]["method"], "GET");
+        assert_eq!(items[0]["request"]["url"]["raw"], "{{base_url}}/posts");
+        assert_eq!(items[2]["request"]["url"]["raw"], "{{base_url}}/posts/:id");
+        assert_eq!(
+            items[2]["request"]["url"]["path"],
+            serde_json::json!(["posts", ":id"])
+        );
     }
 
     // ── resolve_binary_from_metadata ──────────────────────────────────────


### PR DESCRIPTION
💡 **The Spark:** I noticed we already inspect and collect the full route map via `autumn routes`. Developers usually need an easy way to interact with their backend APIs locally, and Postman is a ubiquitous tool for that. Can we just hand them a ready-to-use collection?

🚀 **The Feature:** `autumn routes --format postman` automatically converts discovered routes into an importable Postman Collection v2.1.0 format.

🔮 **The Potential:** Eases immediate backend API interaction for testing and frontend development. It dramatically cuts down onboarding friction for APIs built in Autumn.

⚠️ **Risk:** Low. Isolated in the CLI presentation layer (`autumn-cli/src/routes.rs`). Does not affect core framework runtime or existing output formats (`table` and `json`).

---
*PR created automatically by Jules for task [10798782224088103831](https://jules.google.com/task/10798782224088103831) started by @madmax983*