### PR TITLE
feat: add autumn test to provision an isolated test DB and run the suite

### DIFF
--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -248,8 +248,9 @@ enum Commands {
     ///      given (a bare `…/myapp` targets `…/myapp_test`).
     ///   2. Create the database if missing (existing data is left intact).
     ///   3. Run all pending app + framework migrations against it.
-    ///   4. Shell out to `cargo test`, forwarding trailing args, and exit with
-    ///      its exit code (a failing suite fails the command).
+    ///   4. Shell out to `cargo test`, forwarding trailing args to the test
+    ///      harness after `--` (like `cargo test -- <args>`), and exit with its
+    ///      exit code (a failing suite fails the command).
     ///
     /// `--reset` drops and recreates the database first (clean slate for schema
     /// drift). The command refuses to run against a non-test database name.
@@ -267,8 +268,9 @@ enum Commands {
         /// data is left intact).
         #[arg(long)]
         reset: bool,
-        /// Arguments forwarded verbatim to `cargo test`, e.g.
-        /// `autumn test -- --nocapture some_test`.
+        /// Arguments forwarded to the test harness after `--` (mirroring
+        /// `cargo test -- <args>`), e.g. `autumn test -- --nocapture some_test`
+        /// runs `cargo test -- --nocapture some_test`.
         #[arg(
             value_name = "CARGO_TEST_ARGS",
             trailing_var_arg = true,

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -38,6 +38,7 @@ mod setup;
 mod shard;
 mod starters;
 mod task;
+mod test_cmd;
 mod text_width;
 mod token;
 mod webhook;
@@ -231,6 +232,50 @@ enum Commands {
     ///   autumn db reset
     #[command(subcommand, verbatim_doc_comment, name = "db")]
     Db(DbCommands),
+    /// Provision the test database, migrate it, then run `cargo test`.
+    ///
+    /// A safety-first wrapper around `cargo test` for database-backed apps.
+    /// It always runs under the test profile and exports these for the suite:
+    ///
+    ///   AUTUMN_ENV=test
+    ///   DATABASE_URL / AUTUMN_DATABASE__PRIMARY_URL = <resolved test URL>
+    ///
+    /// Lifecycle (create → migrate → run):
+    ///
+    ///   1. Resolve the test database URL with the same precedence as
+    ///      `autumn migrate` (autumn.toml → AUTUMN_DATABASE__* → DATABASE_URL),
+    ///      defaulting the database name to `*_test` when only a base URL is
+    ///      given (a bare `…/myapp` targets `…/myapp_test`).
+    ///   2. Create the database if missing (existing data is left intact).
+    ///   3. Run all pending app + framework migrations against it.
+    ///   4. Shell out to `cargo test`, forwarding trailing args, and exit with
+    ///      its exit code (a failing suite fails the command).
+    ///
+    /// `--reset` drops and recreates the database first (clean slate for schema
+    /// drift). The command refuses to run against a non-test database name.
+    ///
+    ///   autumn test
+    ///   autumn test --reset
+    ///   autumn test -- --nocapture some_test
+    // Help text is shown verbatim by clap; backticks would leak into `--help`
+    // output, so keep the identifiers bare and silence the doc-markdown lint.
+    #[allow(clippy::doc_markdown)]
+    #[command(verbatim_doc_comment)]
+    Test {
+        /// Drop and recreate the test database before migrating, for a clean
+        /// slate (otherwise the database is created only if missing and existing
+        /// data is left intact).
+        #[arg(long)]
+        reset: bool,
+        /// Arguments forwarded verbatim to `cargo test`, e.g.
+        /// `autumn test -- --nocapture some_test`.
+        #[arg(
+            value_name = "CARGO_TEST_ARGS",
+            trailing_var_arg = true,
+            allow_hyphen_values = true
+        )]
+        cargo_args: Vec<String>,
+    },
     /// Shard operations (e.g. moving a tenant's data between shards)
     Shard(ShardCommands),
     /// Live monitoring dashboard for a running Autumn application
@@ -2182,6 +2227,7 @@ fn run_command(command: Commands) {
                 db::run(&command, profile.as_deref());
             }
         },
+        Commands::Test { reset, cargo_args } => test_cmd::run(reset, &cargo_args),
         Commands::Shard(cmd) => match cmd.command {
             ShardSubcommand::MoveSlot {
                 from,

--- a/autumn-cli/src/test_cmd.rs
+++ b/autumn-cli/src/test_cmd.rs
@@ -14,7 +14,10 @@
 //!   4. Runs all pending app + framework migrations against it, reusing the
 //!      existing `autumn migrate` path (no separate migration engine).
 //!   5. Shells out to `cargo test` with `AUTUMN_ENV=test` and the resolved
-//!      test `DATABASE_URL` exported, forwarding any trailing arguments.
+//!      test `DATABASE_URL` exported, forwarding any trailing arguments to the
+//!      test harness after a `--` separator (mirroring `cargo test -- <args>`),
+//!      so `autumn test -- --nocapture some_test` runs
+//!      `cargo test -- --nocapture some_test`.
 //!
 //! The command refuses to run against a database whose name cannot be made
 //! test-shaped, mirroring the production-safety guardrails of `autumn migrate`
@@ -77,11 +80,11 @@ pub fn run(reset: bool, cargo_args: &[String]) -> ! {
     run_step("migrate", &["migrate"], &test_url);
 
     // 5. Shell out to `cargo test` with the test environment exported and the
-    //    trailing args forwarded verbatim, then exit with its exact code.
+    //    trailing args forwarded to the test harness after `--`, then exit with
+    //    its exact code.
     eprintln!("\u{2500}\u{2500} cargo test \u{2500}\u{2500}");
     let status = Command::new("cargo")
-        .arg("test")
-        .args(cargo_args)
+        .args(cargo_test_args(cargo_args))
         .env("AUTUMN_ENV", "test")
         .env("DATABASE_URL", &test_url)
         .env("AUTUMN_DATABASE__PRIMARY_URL", &test_url)
@@ -98,6 +101,24 @@ pub fn run(reset: bool, cargo_args: &[String]) -> ! {
             std::process::exit(1);
         }
     }
+}
+
+/// Build the arguments passed to `cargo`, forwarding the user's trailing args to
+/// the test *harness* (libtest) after a `--` separator — mirroring
+/// `cargo test -- <harness-args>`.
+///
+/// clap strips the leading `--` from `autumn test -- --nocapture some_test`, so
+/// `user_args` arrives as `["--nocapture", "some_test"]`. Passing those straight
+/// to `cargo test` would make cargo reject `--nocapture` as an unknown flag; the
+/// `--` separator must be reinserted so they reach the harness instead. When
+/// there are no user args, plain `cargo test` (no trailing `--`) is emitted.
+fn cargo_test_args(user_args: &[String]) -> Vec<String> {
+    let mut args = vec!["test".to_owned()];
+    if !user_args.is_empty() {
+        args.push("--".to_owned());
+        args.extend(user_args.iter().cloned());
+    }
+    args
 }
 
 /// Run one provisioning step by self-invoking the `autumn` binary with the test
@@ -219,6 +240,26 @@ fn decode_percent(segment: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cargo_test_args_empty_input_is_plain_test() {
+        assert_eq!(cargo_test_args(&[]), vec!["test".to_owned()]);
+    }
+
+    #[test]
+    fn cargo_test_args_forwards_harness_args_after_separator() {
+        let user = vec!["--nocapture".to_owned(), "some_test".to_owned()];
+        assert_eq!(
+            cargo_test_args(&user),
+            vec!["test", "--", "--nocapture", "some_test"]
+        );
+    }
+
+    #[test]
+    fn cargo_test_args_forwards_single_filter_after_separator() {
+        let user = vec!["my_filter".to_owned()];
+        assert_eq!(cargo_test_args(&user), vec!["test", "--", "my_filter"]);
+    }
 
     #[test]
     fn is_test_db_name_accepts_test_and_underscore_test() {

--- a/autumn-cli/src/test_cmd.rs
+++ b/autumn-cli/src/test_cmd.rs
@@ -1,0 +1,290 @@
+//! `autumn test` — provision the test database, migrate it, then run the suite.
+//!
+//! `autumn test` is a thin, safety-first wrapper around `cargo test` for
+//! projects that talk to a real Postgres database. It:
+//!
+//!   1. Resolves the **test-profile** database URL the exact same way
+//!      `autumn migrate` does (`autumn.toml` → `AUTUMN_DATABASE__*` →
+//!      `DATABASE_URL`), forcing the `test` profile (`AUTUMN_ENV=test`).
+//!   2. Derives a **test** database from that URL: if the resolved database
+//!      name is not already test-shaped (`test` or `*_test`), it appends
+//!      `_test` — so a bare base URL of `…/myapp` targets `…/myapp_test`.
+//!   3. Creates that database if it is missing (leaving existing data intact
+//!      unless `--reset` drops and recreates it first).
+//!   4. Runs all pending app + framework migrations against it, reusing the
+//!      existing `autumn migrate` path (no separate migration engine).
+//!   5. Shells out to `cargo test` with `AUTUMN_ENV=test` and the resolved
+//!      test `DATABASE_URL` exported, forwarding any trailing arguments.
+//!
+//! The command refuses to run against a database whose name cannot be made
+//! test-shaped, mirroring the production-safety guardrails of `autumn migrate`
+//! / `autumn db`. Its exit code is the `cargo test` exit code, so a failing
+//! suite fails the command.
+
+use std::process::Command;
+
+use crate::migrate;
+
+/// Entry point dispatched from `main`. Provisions and migrates the test
+/// database, then execs `cargo test`, and never returns: it always exits with
+/// either a non-zero setup-failure code or the exact `cargo test` exit code.
+pub fn run(reset: bool, cargo_args: &[String]) -> ! {
+    eprintln!("\u{1F342} autumn test\n");
+
+    // 1. Resolve the base URL under the `test` profile using the same
+    //    precedence chain as `autumn migrate` (autumn.toml → AUTUMN_DATABASE__*
+    //    → DATABASE_URL). Forcing the `test` profile means an `autumn-test.toml`
+    //    / `[profile.test.database]` overlay is honored automatically.
+    let Some(base_url) = migrate::resolve_primary_url(Some("test")) else {
+        eprintln!("\u{2717} No test database URL found.");
+        eprintln!(
+            "  Set database.primary_url (or database.url) in autumn.toml (optionally under \
+             [profile.test.database]), or set AUTUMN_DATABASE__PRIMARY_URL / \
+             AUTUMN_DATABASE__URL / DATABASE_URL."
+        );
+        std::process::exit(1);
+    };
+
+    // 2. Derive the test database URL, defaulting the name to `*_test`. This is
+    //    also the guard (AC-6): a URL whose database name cannot be made
+    //    test-shaped is refused here rather than provisioned.
+    let (test_url, db_name) = match derive_test_url(&base_url) {
+        Ok(derived) => derived,
+        Err(e) => {
+            eprintln!("\u{2717} {e}");
+            std::process::exit(1);
+        }
+    };
+    eprintln!("  Test database: {db_name:?}");
+    eprintln!("  Profile:       test (AUTUMN_ENV=test)\n");
+
+    // 3. Provision the database, reusing the existing `autumn db` paths by
+    //    self-invoking this same binary with the derived test URL pinned via
+    //    the highest-precedence env var (mirrors `autumn db reset`).
+    if reset {
+        // Clean slate: drop first (AC-5), then create below. `--force` is
+        // redundant under the test profile (the destructive guard already
+        // allows `test`) but mirrors `db reset` and stays correct even if the
+        // child resolves the profile differently.
+        run_step("drop", &["db", "drop", "--force"], &test_url);
+    }
+    // Create-if-missing; idempotent — without `--reset` an existing database is
+    // left intact (AC-2), and after a `--reset` drop this recreates it fresh.
+    run_step("create", &["db", "create"], &test_url);
+
+    // 4. Apply all pending app + framework migrations, reusing `autumn migrate`
+    //    (no separate migration engine).
+    run_step("migrate", &["migrate"], &test_url);
+
+    // 5. Shell out to `cargo test` with the test environment exported and the
+    //    trailing args forwarded verbatim, then exit with its exact code.
+    eprintln!("\u{2500}\u{2500} cargo test \u{2500}\u{2500}");
+    let status = Command::new("cargo")
+        .arg("test")
+        .args(cargo_args)
+        .env("AUTUMN_ENV", "test")
+        .env("DATABASE_URL", &test_url)
+        .env("AUTUMN_DATABASE__PRIMARY_URL", &test_url)
+        .status();
+
+    match status {
+        Ok(status) => {
+            // Propagate the exact `cargo test` exit code (AC-7). A process
+            // terminated by a signal has no code; treat that as a failure.
+            std::process::exit(status.code().unwrap_or(1));
+        }
+        Err(e) => {
+            eprintln!("\u{2717} Failed to run `cargo test`: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Run one provisioning step by self-invoking the `autumn` binary with the test
+/// environment pinned. Exits non-zero (naming the step) if the child fails.
+fn run_step(name: &str, args: &[&str], test_url: &str) {
+    eprintln!("\u{2500}\u{2500} {name} \u{2500}\u{2500}");
+    let exe = std::env::current_exe().unwrap_or_else(|e| {
+        eprintln!("\u{2717} Could not locate the autumn executable: {e}");
+        std::process::exit(1);
+    });
+    let status = Command::new(exe)
+        .args(args)
+        .env("AUTUMN_ENV", "test")
+        .env("AUTUMN_DATABASE__PRIMARY_URL", test_url)
+        .env("DATABASE_URL", test_url)
+        .status();
+    match status {
+        Ok(status) if status.success() => {}
+        Ok(status) => {
+            eprintln!(
+                "\u{2717} `autumn {}` failed ({}).",
+                args.join(" "),
+                status.code().map_or_else(
+                    || "terminated by signal".to_owned(),
+                    |c| format!("exit {c}")
+                ),
+            );
+            std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("\u{2717} Failed to spawn `autumn {}`: {e}", args.join(" "));
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Whether a database name already satisfies the test-database convention:
+/// exactly `test`, or any name ending in `_test`.
+fn is_test_db_name(name: &str) -> bool {
+    name == "test" || name.ends_with("_test")
+}
+
+/// Assert that a database name is test-shaped, producing a credential-free,
+/// `migrate`-toned refusal otherwise (AC-6).
+fn ensure_test_db_name(name: &str) -> Result<(), String> {
+    if is_test_db_name(name) {
+        Ok(())
+    } else {
+        Err(format!(
+            "Refusing to run tests against the non-test database {name:?}.\n  \
+             `autumn test` only operates on a database named `test` or ending in `_test`."
+        ))
+    }
+}
+
+/// Derive the `(test_url, test_db_name)` pair from a resolved base URL.
+///
+/// The database name is the first path segment (percent-decoded, mirroring
+/// `db::maintenance_target`). When it is not already test-shaped, `_test` is
+/// appended — so a base URL of `…/myapp` yields `…/myapp_test` (AC-1's `_test`
+/// defaulting). The derived name is then guarded to be test-shaped (AC-6).
+///
+/// Returns `Err` (a human-readable message) when the URL cannot be parsed or
+/// names no database — such a target cannot be made test-safe, so the command
+/// refuses rather than guessing.
+fn derive_test_url(base_url: &str) -> Result<(String, String), String> {
+    let mut parsed = url::Url::parse(base_url)
+        .map_err(|_| "The resolved test database URL could not be parsed.".to_owned())?;
+
+    let name = parsed
+        .path_segments()
+        .and_then(|mut segments| segments.next())
+        .map(decode_percent)
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| {
+            "The resolved test database URL does not name a database (nothing to make test-safe)."
+                .to_owned()
+        })?;
+
+    let test_name = if is_test_db_name(&name) {
+        name
+    } else {
+        format!("{name}_test")
+    };
+    // Defensive guard — appending `_test` always satisfies the convention, but
+    // assert it explicitly so any future change to the derivation can't silently
+    // target a non-test database.
+    ensure_test_db_name(&test_name)?;
+
+    parsed.set_path(&format!("/{test_name}"));
+    Ok((parsed.to_string(), test_name))
+}
+
+/// Minimal percent-decoding for a URL path segment (database name), matching
+/// `db::maintenance_target`'s handling so the derived name equals the name the
+/// `db`/`migrate` paths will operate on.
+fn decode_percent(segment: &str) -> String {
+    let bytes = segment.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16);
+            let lo = (bytes[i + 2] as char).to_digit(16);
+            if let (Some(hi), Some(lo)) = (hi, lo)
+                && let Ok(byte) = u8::try_from(hi * 16 + lo)
+            {
+                out.push(byte);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_test_db_name_accepts_test_and_underscore_test() {
+        assert!(is_test_db_name("test"));
+        assert!(is_test_db_name("myapp_test"));
+        assert!(is_test_db_name("a_b_c_test"));
+    }
+
+    #[test]
+    fn is_test_db_name_rejects_non_test_names() {
+        assert!(!is_test_db_name("myapp"));
+        assert!(!is_test_db_name("production"));
+        assert!(!is_test_db_name("testing")); // does not end in `_test`
+        assert!(!is_test_db_name("test_db"));
+    }
+
+    #[test]
+    fn ensure_test_db_name_refuses_non_test_name() {
+        let err = ensure_test_db_name("production").unwrap_err();
+        assert!(err.contains("Refusing"), "message: {err}");
+        assert!(err.contains("production"), "message: {err}");
+        assert!(err.contains("_test"), "message: {err}");
+    }
+
+    #[test]
+    fn ensure_test_db_name_allows_test_shaped_names() {
+        assert!(ensure_test_db_name("test").is_ok());
+        assert!(ensure_test_db_name("myapp_test").is_ok());
+    }
+
+    #[test]
+    fn derive_appends_test_suffix_to_bare_name() {
+        let (url, name) = derive_test_url("postgres://user:pw@db.example.com:6543/myapp").unwrap();
+        assert_eq!(name, "myapp_test");
+        assert!(url.ends_with("/myapp_test"), "url: {url}");
+        // Host, port, and credentials are preserved.
+        assert!(url.contains("db.example.com:6543"), "url: {url}");
+    }
+
+    #[test]
+    fn derive_keeps_already_test_shaped_names() {
+        let (url, name) = derive_test_url("postgres://localhost/myapp_test").unwrap();
+        assert_eq!(name, "myapp_test");
+        assert!(url.ends_with("/myapp_test"), "url: {url}");
+
+        let (url, name) = derive_test_url("postgres://localhost/test").unwrap();
+        assert_eq!(name, "test");
+        assert!(url.ends_with("/test"), "url: {url}");
+    }
+
+    #[test]
+    fn derive_decodes_percent_encoded_name_before_suffixing() {
+        let (_url, name) = derive_test_url("postgres://localhost/my%5Fapp").unwrap();
+        // %5F is `_`; decoded name is `my_app`, which is not test-shaped.
+        assert_eq!(name, "my_app_test");
+    }
+
+    #[test]
+    fn derive_refuses_url_without_database_name() {
+        let err = derive_test_url("postgres://localhost/").unwrap_err();
+        assert!(err.contains("does not name a database"), "message: {err}");
+    }
+
+    #[test]
+    fn derive_refuses_unparsable_url() {
+        let err = derive_test_url("not a url").unwrap_err();
+        assert!(err.contains("could not be parsed"), "message: {err}");
+    }
+}

--- a/autumn-cli/tests/integration/mod.rs
+++ b/autumn-cli/tests/integration/mod.rs
@@ -11,4 +11,5 @@ mod scaffold_form_for;
 #[cfg(unix)]
 mod serve;
 mod tauri_mobile_thin_client;
+mod test_command;
 mod webhook_sim;

--- a/autumn-cli/tests/integration/test_command.rs
+++ b/autumn-cli/tests/integration/test_command.rs
@@ -23,6 +23,13 @@ fn run_autumn(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, Stri
     let output = Command::new(autumn_bin())
         .args(args)
         .current_dir(dir)
+        // Clear any inherited database URL vars so resolution depends only on
+        // `envs` — otherwise a machine/CI that exports `DATABASE_URL` would leak
+        // a real URL into the "no URL configured" case. Explicit `envs` below
+        // still win, since they are applied after these removals.
+        .env_remove("DATABASE_URL")
+        .env_remove("AUTUMN_DATABASE__URL")
+        .env_remove("AUTUMN_DATABASE__PRIMARY_URL")
         .envs(envs.iter().copied())
         .output()
         .expect("failed to run autumn");
@@ -189,14 +196,36 @@ async fn test_create_if_missing_is_idempotent_and_preserves_data() {
     let dir = tmp.path();
     write_cargo_fixture(dir, true);
 
-    // First run creates + migrates + runs.
+    // First run creates + migrates + runs. `keepdata_test` is already
+    // test-shaped, so the derived URL is exactly `url`.
     run_autumn_ok(dir, &["test"], &envs);
+
+    // Write a sentinel row into the migrated `widgets` table (created by the
+    // fixture migration). If the second run recreated or dropped the database,
+    // this row would vanish.
+    let sentinel = "sentinel-preserve-me";
+    crate::common::execute_params(&url, "INSERT INTO widgets (name) VALUES ($1)", &[&sentinel])
+        .await;
 
     // Second run (no --reset) must leave the existing database intact: the
     // create step reports the idempotent "already exists" notice.
     let (stdout, stderr) = run_autumn_ok(dir, &["test"], &envs);
     let combined = format!("{stdout}{stderr}");
     assert!(combined.contains("already exists"), "output: {combined}");
+
+    // The sentinel row survived — proving the database (and its data) was
+    // preserved rather than recreated.
+    let survived = crate::common::query_one_text(
+        &url,
+        "SELECT name FROM widgets WHERE name = $1",
+        &[&sentinel],
+    )
+    .await;
+    assert_eq!(
+        survived.as_deref(),
+        Some(sentinel),
+        "sentinel row was lost — the database was not preserved",
+    );
 }
 
 #[tokio::test]

--- a/autumn-cli/tests/integration/test_command.rs
+++ b/autumn-cli/tests/integration/test_command.rs
@@ -1,0 +1,238 @@
+//! Integration tests for `autumn test`.
+//!
+//! The Docker-backed cases (create / migrate / run lifecycle, `--reset`, exit
+//! code propagation) require a Postgres container via testcontainers and are
+//! marked `#[ignore]` so they only run when explicitly requested. The help /
+//! guard cases need no database and run in the default suite.
+//!
+//! Run the Docker cases with:
+//!   `cargo test -p autumn-cli --test cli_tests test_command -- --ignored`
+
+use std::path::Path;
+use std::process::Command;
+
+const fn autumn_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_autumn")
+}
+
+/// A distinctive password so tests can assert it never leaks into output.
+const SECRET_PW: &str = "s3cr3t_pw_do_not_leak";
+
+/// Run the autumn binary with `args` and env overrides; return (stdout, stderr, `exit_code`).
+fn run_autumn(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String, Option<i32>) {
+    let output = Command::new(autumn_bin())
+        .args(args)
+        .current_dir(dir)
+        .envs(envs.iter().copied())
+        .output()
+        .expect("failed to run autumn");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code(),
+    )
+}
+
+fn run_autumn_ok(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String) {
+    let (stdout, stderr, code) = run_autumn(dir, args, envs);
+    assert_eq!(
+        code,
+        Some(0),
+        "autumn {args:?} failed (exit={code:?})\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    (stdout, stderr)
+}
+
+fn run_autumn_fail(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String) {
+    let (stdout, stderr, code) = run_autumn(dir, args, envs);
+    assert_ne!(
+        code,
+        Some(0),
+        "autumn {args:?} should have failed but exited 0\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    (stdout, stderr)
+}
+
+/// Write a minimal migration directory with `up.sql` and `down.sql`.
+fn write_migration(migrations_dir: &Path, name: &str, up_sql: &str, down_sql: &str) {
+    let dir = migrations_dir.join(name);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("up.sql"), up_sql).unwrap();
+    std::fs::write(dir.join("down.sql"), down_sql).unwrap();
+}
+
+/// Scaffold a minimal, dependency-free Cargo project in `dir` whose single
+/// library test either passes or fails, so `autumn test`'s `cargo test` step
+/// exercises real exit-code propagation. Also writes one valid migration so the
+/// migrate step has work to do.
+fn write_cargo_fixture(dir: &Path, test_passes: bool) {
+    std::fs::write(
+        dir.join("Cargo.toml"),
+        "[package]\nname = \"autumn_test_fixture\"\nversion = \"0.0.0\"\nedition = \"2021\"\n\n[lib]\npath = \"src/lib.rs\"\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    let body = if test_passes {
+        "#[test]\nfn fixture_passes() { assert_eq!(2 + 2, 4); }\n"
+    } else {
+        "#[test]\nfn fixture_fails() { panic!(\"deliberate failure\"); }\n"
+    };
+    std::fs::write(dir.join("src/lib.rs"), body).unwrap();
+
+    let migrations = dir.join("migrations");
+    std::fs::create_dir_all(&migrations).unwrap();
+    write_migration(
+        &migrations,
+        "20260101000000_create_widgets",
+        "CREATE TABLE widgets (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);",
+        "DROP TABLE widgets;",
+    );
+}
+
+/// Start a Postgres container with a distinctive password and return its
+/// host/port. The per-test target database does **not** yet exist.
+async fn start_postgres() -> (
+    testcontainers::ContainerAsync<testcontainers_modules::postgres::Postgres>,
+    String,
+    u16,
+) {
+    use testcontainers::runners::AsyncRunner as _;
+    use testcontainers_modules::postgres::Postgres;
+
+    let container = Postgres::default()
+        .with_password(SECRET_PW)
+        .start()
+        .await
+        .expect("failed to start Postgres testcontainer — is Docker running?");
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    (container, host, port)
+}
+
+// ── Non-Docker: help + guard ───────────────────────────────────────────────
+
+#[test]
+fn test_help_documents_env_vars_and_lifecycle() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (stdout, _stderr) = run_autumn_ok(tmp.path(), &["test", "--help"], &[]);
+    // AC-8: the help text documents the env vars it sets…
+    assert!(stdout.contains("AUTUMN_ENV=test"), "help: {stdout}");
+    assert!(stdout.contains("DATABASE_URL"), "help: {stdout}");
+    // …and the create → migrate → run lifecycle, plus --reset.
+    assert!(stdout.contains("create"), "help: {stdout}");
+    assert!(stdout.contains("migrate"), "help: {stdout}");
+    assert!(stdout.contains("cargo test"), "help: {stdout}");
+    assert!(stdout.contains("--reset"), "help: {stdout}");
+}
+
+#[test]
+fn test_refuses_url_that_cannot_be_made_test_safe() {
+    // AC-6: a target URL with no database name cannot be made test-shaped, so
+    // the command refuses with a clear message and a non-zero exit — before it
+    // ever connects (so this needs no Docker).
+    let tmp = tempfile::tempdir().unwrap();
+    let envs = [("AUTUMN_DATABASE__PRIMARY_URL", "postgres://localhost/")];
+    let (stdout, stderr) = run_autumn_fail(tmp.path(), &["test"], &envs);
+    assert!(
+        stderr.contains("does not name a database"),
+        "stdout: {stdout}\nstderr: {stderr}",
+    );
+}
+
+#[test]
+fn test_refuses_when_no_url_configured() {
+    // With no autumn.toml and no DB env vars, there is nothing to resolve.
+    let tmp = tempfile::tempdir().unwrap();
+    let (_stdout, stderr) = run_autumn_fail(tmp.path(), &["test"], &[]);
+    assert!(
+        stderr.contains("No test database URL found"),
+        "stderr: {stderr}",
+    );
+}
+
+// ── Docker-backed: create → migrate → run lifecycle ────────────────────────
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn test_derives_test_suffix_creates_migrates_and_runs() {
+    let (_container, host, port) = start_postgres().await;
+    // A bare base name — `autumn test` must derive `myapp_test` (AC-1/AC-2).
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/myapp");
+    let envs = [("AUTUMN_DATABASE__PRIMARY_URL", url.as_str())];
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    write_cargo_fixture(dir, true);
+
+    let (stdout, stderr) = run_autumn_ok(dir, &["test"], &envs);
+    let combined = format!("{stdout}{stderr}");
+    // Derivation targeted the `_test` database and created it.
+    assert!(combined.contains("myapp_test"), "output: {combined}");
+    assert!(combined.contains("Created database"), "output: {combined}");
+    // Migrations ran, and the passing suite made the whole command exit 0.
+    assert!(
+        combined.contains("Migrations applied") || combined.contains("up to date"),
+        "output: {combined}",
+    );
+    assert!(
+        !combined.contains(SECRET_PW),
+        "credentials leaked!\n{combined}",
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn test_create_if_missing_is_idempotent_and_preserves_data() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/keepdata_test");
+    let envs = [("AUTUMN_DATABASE__PRIMARY_URL", url.as_str())];
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    write_cargo_fixture(dir, true);
+
+    // First run creates + migrates + runs.
+    run_autumn_ok(dir, &["test"], &envs);
+
+    // Second run (no --reset) must leave the existing database intact: the
+    // create step reports the idempotent "already exists" notice.
+    let (stdout, stderr) = run_autumn_ok(dir, &["test"], &envs);
+    let combined = format!("{stdout}{stderr}");
+    assert!(combined.contains("already exists"), "output: {combined}");
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn test_reset_drops_and_recreates() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/resetme_test");
+    let envs = [("AUTUMN_DATABASE__PRIMARY_URL", url.as_str())];
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    write_cargo_fixture(dir, true);
+
+    // Seed an initial database.
+    run_autumn_ok(dir, &["test"], &envs);
+
+    // --reset drops then recreates (AC-5): both the drop and a fresh create run.
+    let (stdout, stderr) = run_autumn_ok(dir, &["test", "--reset"], &envs);
+    let combined = format!("{stdout}{stderr}");
+    assert!(combined.contains("Dropped database"), "output: {combined}");
+    assert!(combined.contains("Created database"), "output: {combined}");
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn test_failing_suite_fails_the_command() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/exitcode_test");
+    let envs = [("AUTUMN_DATABASE__PRIMARY_URL", url.as_str())];
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    // A fixture whose test panics: `cargo test` exits non-zero, so must the
+    // command (AC-7), even though create + migrate succeeded.
+    write_cargo_fixture(dir, false);
+
+    let (stdout, stderr) = run_autumn_fail(dir, &["test"], &envs);
+    let combined = format!("{stdout}{stderr}");
+    // Provisioning still happened before the suite failed.
+    assert!(combined.contains("Created database"), "output: {combined}");
+}


### PR DESCRIPTION
Closes #1056

## Before

Getting a green DB-backed test run meant a manual four-step dance every time:

1. Create a `_test` database by hand.
2. Point `AUTUMN_ENV=test` / `DATABASE_URL` at it.
3. Run `autumn migrate up`.
4. Finally run `cargo test`.

Easy to get wrong, easy to forget a step, and easy to accidentally run the suite against a non-test database.

## After

`autumn test` does the whole thing in one command:

- Resolves the test-profile DB URL, defaulting the database name to `<base>_test`.
- Creates the database if it is missing (`--reset` drops and recreates it).
- Runs app + framework migrations by reusing the existing `autumn migrate` path.
- Shells out to `cargo test` with `AUTUMN_ENV=test` and the resolved `DATABASE_URL` exported.
- Forwards trailing harness args, e.g. `autumn test -- --nocapture some_test`.
- Exits with `cargo test`'s exit code.
- Refuses to run against non-test DB targets as a safety guard.

## How

- New `autumn-cli/src/test_cmd.rs` module plus a thin `Test { reset, cargo_args }` clap variant and dispatch arm in `main.rs`.
- Provisioning and migration reuse the existing `db` / `migrate` paths via binary self-invocation (the same pattern as `db reset`), with the derived test URL pinned through `AUTUMN_DATABASE__PRIMARY_URL`.
- URL resolution reuses `migrate::resolve_primary_url(Some("test"))`.

## Tests

- 12 unit tests.
- Non-Docker CLI tests (help text, guard refusals).
- 4 `#[ignore]` testcontainers integration tests covering create → migrate → run and `--reset`.

## Notes

Does not bump the workspace version or edit `CHANGELOG.md` / skills docs — those are batched separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBavKCTn6P4X1iMKepgEWp)_