### PR TITLE
Add query-count test assertions to catch N+1 regressions

### DIFF
--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -1280,7 +1280,7 @@ const fn default_inspector_capacity() -> usize {
 }
 
 const fn default_inspector_n_plus_one_threshold() -> usize {
-    5
+    crate::inspector::DEFAULT_N_PLUS_ONE_THRESHOLD
 }
 
 /// Top-level `[http]` configuration section.

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -120,6 +120,18 @@ impl RequestDbTimings {
             .map(|mut g| g.take().unwrap_or_default())
             .unwrap_or_default()
     }
+
+    /// Whether this accumulator is capturing the full SQL query list — i.e.
+    /// was built via [`RequestDbTimings::with_capture`] (its `captured` field
+    /// holds `Some(vec)`) rather than the non-capturing [`Default`].
+    ///
+    /// Used by the `Server-Timing` middleware to distinguish the test
+    /// harness's capturing scope (which must be reused so captures survive)
+    /// from a production non-capturing `Server-Timing` scope (which must stay
+    /// isolated). Treats a poisoned lock as non-capturing.
+    pub(crate) fn is_capturing(&self) -> bool {
+        self.captured.lock().map(|g| g.is_some()).unwrap_or(false)
+    }
 }
 
 tokio::task_local! {

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -89,6 +89,37 @@ pub(crate) struct RequestDbTimings {
     pub(crate) total_us: AtomicU64,
     /// Number of instrumented DB queries this request performed.
     pub(crate) query_count: std::sync::atomic::AtomicUsize,
+    /// Opt-in capture of the full SQL query list for this request.
+    ///
+    /// `None` (the `Default`) means capture is **off**: the production
+    /// `Server-Timing` path constructs `RequestDbTimings::default()` and pays
+    /// nothing beyond the count/time bumps. The test harness opts in via
+    /// [`RequestDbTimings::with_capture`], which sets `Some(Vec::new())` so a
+    /// [`crate::inspector::QueryRecord`] is retained per counted statement and
+    /// surfaced to `TestResponse` for query-count / N+1 assertions.
+    pub(crate) captured: std::sync::Mutex<Option<Vec<crate::inspector::QueryRecord>>>,
+}
+
+impl RequestDbTimings {
+    /// Construct an accumulator that additionally captures the full SQL query
+    /// list. Used by the test harness so `TestResponse` can assert on the
+    /// queries a request issued; the production `Server-Timing` path uses
+    /// [`Default`] and captures nothing.
+    pub(crate) fn with_capture() -> Self {
+        Self {
+            captured: std::sync::Mutex::new(Some(Vec::new())),
+            ..Self::default()
+        }
+    }
+
+    /// Swap out and return the captured query list, leaving `None` behind.
+    /// Returns an empty vec when capture was off or the lock was poisoned.
+    pub(crate) fn take_captured(&self) -> Vec<crate::inspector::QueryRecord> {
+        self.captured
+            .lock()
+            .map(|mut g| g.take().unwrap_or_default())
+            .unwrap_or_default()
+    }
 }
 
 tokio::task_local! {
@@ -101,12 +132,27 @@ tokio::task_local! {
 /// [`REQUEST_DB_TIMINGS`], if any. No-op when the task-local is unset —
 /// which is the case whenever the `Server-Timing` middleware is disabled
 /// or the query runs outside a request (e.g. background job).
-pub(crate) fn record_request_db_query(elapsed: Duration) {
+pub(crate) fn record_request_db_query(elapsed: Duration, sql: Option<&str>) {
     let _ = REQUEST_DB_TIMINGS.try_with(|t| {
         let micros = u64::try_from(elapsed.as_micros()).unwrap_or(u64::MAX);
         t.total_us.fetch_add(micros, Ordering::Relaxed);
         t.query_count
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        // Retain the statement text only when a test opted into capture (see
+        // `RequestDbTimings::with_capture`). A poisoned lock or capture-off
+        // (`None`) accumulator simply skips this — the count/time bumps above
+        // are unaffected.
+        if let Some(sql) = sql
+            && let Ok(mut g) = t.captured.lock()
+            && let Some(list) = g.as_mut()
+        {
+            list.push(crate::inspector::QueryRecord {
+                sql: sql.to_owned(),
+                params: Vec::new(),
+                elapsed_ms: u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX),
+                location: String::new(),
+            });
+        }
     });
 }
 
@@ -183,8 +229,20 @@ pub(crate) fn request_db_timing_active() -> bool {
 #[cfg(feature = "db")]
 #[derive(Default, Debug)]
 pub(crate) struct RequestQueryTimer {
-    /// Start instant of the currently in-flight statement, if any.
-    started_at: Option<std::time::Instant>,
+    /// The currently in-flight statement (start instant + SQL text), if any.
+    pending: Option<PendingQuery>,
+}
+
+/// A statement whose `StartQuery` has fired but whose `FinishQuery` has not.
+///
+/// Holds the start instant (for latency) and the materialised SQL text (so a
+/// capturing accumulator can retain it). Queries on a single connection are
+/// strictly sequential, so a single slot suffices.
+#[cfg(feature = "db")]
+#[derive(Debug)]
+struct PendingQuery {
+    started_at: std::time::Instant,
+    sql: String,
 }
 
 #[cfg(feature = "db")]
@@ -242,13 +300,20 @@ impl RequestQueryTimer {
     /// (non-exhaustive, unstable-to-build) `InstrumentationEvent`.
     fn on_start(&mut self, now: std::time::Instant, sql: impl FnOnce() -> String) {
         if !request_db_timing_active() {
-            self.started_at = None;
+            self.pending = None;
             return;
         }
-        self.started_at = if Self::is_uncounted_statement(&sql()) {
+        // Materialise the SQL once: it is needed both for the housekeeping
+        // filter and (when a test opted into capture) to retain the statement
+        // text at `on_finish`.
+        let sql = sql();
+        self.pending = if Self::is_uncounted_statement(&sql) {
             None
         } else {
-            Some(now)
+            Some(PendingQuery {
+                started_at: now,
+                sql,
+            })
         };
     }
 
@@ -256,8 +321,8 @@ impl RequestQueryTimer {
     /// elapsed time into the per-request accumulator. A `FinishQuery` without
     /// a matching `StartQuery` is ignored.
     fn on_finish(&mut self, now: std::time::Instant) {
-        if let Some(start) = self.started_at.take() {
-            record_request_db_query(now.saturating_duration_since(start));
+        if let Some(p) = self.pending.take() {
+            record_request_db_query(now.saturating_duration_since(p.started_at), Some(&p.sql));
         }
     }
 }

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -89,55 +89,28 @@ pub(crate) struct RequestDbTimings {
     pub(crate) total_us: AtomicU64,
     /// Number of instrumented DB queries this request performed.
     pub(crate) query_count: std::sync::atomic::AtomicUsize,
-    /// Opt-in capture of the full SQL query list for this request.
-    ///
-    /// `None` (the `Default`) means capture is **off**: the production
-    /// `Server-Timing` path constructs `RequestDbTimings::default()` and pays
-    /// nothing beyond the count/time bumps. The test harness opts in via
-    /// [`RequestDbTimings::with_capture`], which sets `Some(Vec::new())` so a
-    /// [`crate::inspector::QueryRecord`] is retained per counted statement and
-    /// surfaced to `TestResponse` for query-count / N+1 assertions.
-    pub(crate) captured: std::sync::Mutex<Option<Vec<crate::inspector::QueryRecord>>>,
-}
-
-impl RequestDbTimings {
-    /// Construct an accumulator that additionally captures the full SQL query
-    /// list. Used by the test harness so `TestResponse` can assert on the
-    /// queries a request issued; the production `Server-Timing` path uses
-    /// [`Default`] and captures nothing.
-    pub(crate) fn with_capture() -> Self {
-        Self {
-            captured: std::sync::Mutex::new(Some(Vec::new())),
-            ..Self::default()
-        }
-    }
-
-    /// Swap out and return the captured query list, leaving `None` behind.
-    /// Returns an empty vec when capture was off or the lock was poisoned.
-    pub(crate) fn take_captured(&self) -> Vec<crate::inspector::QueryRecord> {
-        self.captured
-            .lock()
-            .map(|mut g| g.take().unwrap_or_default())
-            .unwrap_or_default()
-    }
-
-    /// Whether this accumulator is capturing the full SQL query list — i.e.
-    /// was built via [`RequestDbTimings::with_capture`] (its `captured` field
-    /// holds `Some(vec)`) rather than the non-capturing [`Default`].
-    ///
-    /// Used by the `Server-Timing` middleware to distinguish the test
-    /// harness's capturing scope (which must be reused so captures survive)
-    /// from a production non-capturing `Server-Timing` scope (which must stay
-    /// isolated). Treats a poisoned lock as non-capturing.
-    pub(crate) fn is_capturing(&self) -> bool {
-        self.captured.lock().map(|g| g.is_some()).unwrap_or(false)
-    }
 }
 
 tokio::task_local! {
     /// Task-local accumulator populated by DB instrumentation and read by
     /// the `Server-Timing` middleware. See [`RequestDbTimings`].
     pub(crate) static REQUEST_DB_TIMINGS: Arc<RequestDbTimings>;
+}
+
+tokio::task_local! {
+    /// Task-local sink for request-wide SQL query capture, independent of the
+    /// `Server-Timing` timing accumulator ([`REQUEST_DB_TIMINGS`]).
+    ///
+    /// Scoped by the test harness (`RequestBuilder::send`) around the whole
+    /// request so every instrumented statement is retained as a
+    /// [`crate::inspector::QueryRecord`] for `TestResponse` query-count / N+1
+    /// assertions. Kept as a separate task-local lane — not folded into
+    /// `RequestDbTimings` — so query capture is unaffected by how the
+    /// `Server-Timing` middleware scopes (and nests) its per-scope timing
+    /// accumulators. Absent in production, where the capture lane is never
+    /// scoped and nothing is retained.
+    #[cfg(feature = "db")]
+    pub(crate) static REQUEST_QUERY_CAPTURE: Arc<Mutex<Vec<crate::inspector::QueryRecord>>>;
 }
 
 /// Strip the trailing `-- binds: [...]` annotation that diesel's `DebugQuery`
@@ -167,6 +140,7 @@ tokio::task_local! {
 /// `batch_execute`, or synthetic test input): returns the input unchanged. Uses
 /// the last occurrence, since diesel always appends the annotation after the
 /// full statement.
+#[cfg(feature = "db")]
 fn strip_bind_annotation(sql: &str) -> &str {
     sql.rfind("-- binds:")
         .map_or(sql, |idx| sql[..idx].trim_end())
@@ -177,32 +151,37 @@ fn strip_bind_annotation(sql: &str) -> &str {
 /// which is the case whenever the `Server-Timing` middleware is disabled
 /// or the query runs outside a request (e.g. background job).
 pub(crate) fn record_request_db_query(elapsed: Duration, sql: Option<&str>) {
+    // Lane 1: the `Server-Timing` timing accumulator (count + cumulative time).
     let _ = REQUEST_DB_TIMINGS.try_with(|t| {
         let micros = u64::try_from(elapsed.as_micros()).unwrap_or(u64::MAX);
         t.total_us.fetch_add(micros, Ordering::Relaxed);
         t.query_count
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        // Retain the statement text only when a test opted into capture (see
-        // `RequestDbTimings::with_capture`). A poisoned lock or capture-off
-        // (`None`) accumulator simply skips this — the count/time bumps above
-        // are unaffected.
-        if let Some(sql) = sql
-            && let Ok(mut g) = t.captured.lock()
-            && let Some(list) = g.as_mut()
-        {
-            list.push(crate::inspector::QueryRecord {
-                // Store the parameterised statement WITHOUT diesel's per-row
-                // `-- binds: [...]` annotation (the `$N` placeholders stay), so
-                // repeated per-row queries normalise to the same template and
-                // `detect_n_plus_one` can see the repetition. See
-                // [`strip_bind_annotation`].
-                sql: strip_bind_annotation(sql).to_owned(),
-                params: Vec::new(),
-                elapsed_ms: u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX),
-                location: String::new(),
-            });
-        }
     });
+
+    // Lane 2: request-wide SQL capture, independent of the timing lane. Only
+    // active when a test scoped `REQUEST_QUERY_CAPTURE`; a no-op otherwise
+    // (production, background jobs). The two `try_with` calls are independent —
+    // either lane may be active without the other — and no lock is held across
+    // an await.
+    #[cfg(feature = "db")]
+    if let Some(sql) = sql {
+        let _ = REQUEST_QUERY_CAPTURE.try_with(|sink| {
+            if let Ok(mut list) = sink.lock() {
+                list.push(crate::inspector::QueryRecord {
+                    // Store the parameterised statement WITHOUT diesel's per-row
+                    // `-- binds: [...]` annotation (the `$N` placeholders stay), so
+                    // repeated per-row queries normalise to the same template and
+                    // `detect_n_plus_one` can see the repetition. See
+                    // [`strip_bind_annotation`].
+                    sql: strip_bind_annotation(sql).to_owned(),
+                    params: Vec::new(),
+                    elapsed_ms: u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX),
+                    location: String::new(),
+                });
+            }
+        });
+    }
 }
 
 /// Whether the current task is inside a [`REQUEST_DB_TIMINGS`] scope — i.e.
@@ -218,6 +197,20 @@ pub(crate) fn record_request_db_query(elapsed: Duration, sql: Option<&str>) {
 #[cfg(feature = "db")]
 pub(crate) fn request_db_timing_active() -> bool {
     REQUEST_DB_TIMINGS.try_with(|_| ()).is_ok()
+}
+
+/// Whether the current task is inside a [`REQUEST_QUERY_CAPTURE`] scope — i.e.
+/// whether the test harness (`RequestBuilder::send`) has scoped a capture sink
+/// around this request.
+///
+/// Mirrors [`request_db_timing_active`]: a cheap task-local probe that neither
+/// clones the `Arc` nor allocates. [`Db::checkout`] installs the
+/// [`RequestQueryTimer`] instrumentation when EITHER this lane or the timing
+/// lane is active, so query capture works even when `server_timing` is off (the
+/// common test case) and no `REQUEST_DB_TIMINGS` scope exists.
+#[cfg(feature = "db")]
+pub(crate) fn request_query_capture_active() -> bool {
+    REQUEST_QUERY_CAPTURE.try_with(|_| ()).is_ok()
 }
 
 /// diesel-async [`Instrumentation`](diesel::connection::Instrumentation)
@@ -328,15 +321,16 @@ impl RequestQueryTimer {
 
     /// Record the start of a statement.
     ///
-    /// Probes [`request_db_timing_active`] first: when no `REQUEST_DB_TIMINGS`
-    /// scope is active (the opted-out / off-request path) the timer does
-    /// nothing and — crucially — never invokes `sql`, so the caller's
-    /// `DebugQuery` `to_string()` allocation is skipped entirely. This is what
-    /// makes it safe to leave a `RequestQueryTimer` installed on a pooled
-    /// connection that a later opted-out request reuses: the stale timer is a
-    /// cheap bool-probe no-op, not a per-query allocator.
+    /// Probes both [`request_db_timing_active`] and
+    /// [`request_query_capture_active`] first: when NEITHER the timing
+    /// accumulator nor the capture sink is scoped (the opted-out / off-request
+    /// path) the timer does nothing and — crucially — never invokes `sql`, so
+    /// the caller's `DebugQuery` `to_string()` allocation is skipped entirely.
+    /// This is what makes it safe to leave a `RequestQueryTimer` installed on a
+    /// pooled connection that a later opted-out request reuses: the stale timer
+    /// is a cheap bool-probe no-op, not a per-query allocator.
     ///
-    /// When a scope *is* active, the SQL text is materialised and inspected:
+    /// When either lane *is* active, the SQL text is materialised and inspected:
     /// housekeeping / transaction-control statements (see
     /// [`Self::is_uncounted_statement`], e.g. the checkout `SET
     /// statement_timeout`) leave the slot empty so they are excluded from the
@@ -348,7 +342,13 @@ impl RequestQueryTimer {
     /// the start/finish accounting is unit-testable without constructing a
     /// (non-exhaustive, unstable-to-build) `InstrumentationEvent`.
     fn on_start(&mut self, now: std::time::Instant, sql: impl FnOnce() -> String) {
-        if !request_db_timing_active() {
+        // Probe BOTH lanes: the timing accumulator (`server_timing`) and the
+        // query-capture sink (test harness). Either being active means the
+        // upcoming statement must be observed. When neither is scoped (the
+        // opted-out / off-request path) the timer does nothing and never
+        // invokes `sql`, so the caller's `DebugQuery` `to_string()` allocation
+        // is skipped — keeping a stale installed timer a cheap bool-probe no-op.
+        if !request_db_timing_active() && !request_query_capture_active() {
             self.pending = None;
             return;
         }
@@ -2036,11 +2036,13 @@ impl Db {
                 .min(PG_TIMEOUT_MAX_MS)
         });
 
-        // Install a fresh per-request query timer, but ONLY when a
-        // `REQUEST_DB_TIMINGS` scope is active — i.e. only for requests the
-        // `ServerTimingLayer` (enabled by `[observability] server_timing`) is
-        // measuring. Installed BEFORE the `SET statement_timeout` housekeeping
-        // statement below.
+        // Install a fresh per-request query timer, but ONLY when a query
+        // observer is active — EITHER a `REQUEST_DB_TIMINGS` scope (the
+        // `ServerTimingLayer`, enabled by `[observability] server_timing`) OR a
+        // `REQUEST_QUERY_CAPTURE` scope (the test harness capturing the SQL
+        // list, which runs with `server_timing` off). The timer feeds both
+        // lanes via `record_request_db_query`. Installed BEFORE the `SET
+        // statement_timeout` housekeeping statement below.
         //
         // `set_instrumentation` WHOLESALE REPLACES the connection's
         // instrumentation, so it must not run unconditionally: an application
@@ -2048,12 +2050,12 @@ impl Db {
         // `diesel::connection::set_default_instrumentation` (query logging,
         // tracing, metrics) would have it silently clobbered on the first
         // checkout and never restored — even when `server_timing` is disabled.
-        // Gating on `request_db_timing_active()` preserves the app's
-        // instrumentation whenever `server_timing` is off (the scope is never
-        // entered, so we never install), and only overwrites it for the
-        // duration the feature is measuring.
+        // Gating on `request_db_timing_active() || request_query_capture_active()`
+        // preserves the app's instrumentation whenever neither lane is scoped
+        // (no `server_timing`, no test capture — the production default), and
+        // only overwrites it for the duration a query observer is active.
         //
-        // Installing a *fresh* timer on every measured checkout also clears any
+        // Installing a *fresh* timer on every observed checkout also clears any
         // stale `RequestQueryTimer` a pooled connection carried from a prior
         // request (diesel-async's deadpool manager never resets instrumentation
         // on recycle), so a stale timer can never record the upcoming
@@ -2062,12 +2064,12 @@ impl Db {
         // `is_uncounted_statement` classifies as housekeeping) keeps that
         // statement out of the `Server-Timing` `db` count regardless. Any stale
         // timer left on a connection later reused by an opted-out request is a
-        // cheap no-op: `on_start` probes `request_db_timing_active()` before
-        // formatting or recording anything, so it never allocates off-scope.
+        // cheap no-op: `on_start` probes both lanes before formatting or
+        // recording anything, so it never allocates off-scope.
         #[cfg(feature = "db")]
         {
             use diesel_async::AsyncConnection as _;
-            if request_db_timing_active() {
+            if request_db_timing_active() || request_query_capture_active() {
                 conn.set_instrumentation(RequestQueryTimer::default());
             }
         }
@@ -2678,6 +2680,7 @@ mod tests {
     /// them. Without the strip, each `-- binds: [N]` would normalise to a
     /// distinct template and the N+1 would go undetected. Locks the fix with no
     /// live database.
+    #[cfg(feature = "db")]
     #[test]
     fn strip_bind_annotation_lets_detect_n_plus_one_see_per_row_repetition() {
         use crate::inspector::{QueryRecord, detect_n_plus_one};

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -128,6 +128,38 @@ tokio::task_local! {
     pub(crate) static REQUEST_DB_TIMINGS: Arc<RequestDbTimings>;
 }
 
+/// Strip the trailing `-- binds: [...]` annotation that diesel's `DebugQuery`
+/// `Display` appends to a query's SQL text.
+///
+/// diesel-async feeds each real query into the `StartQuery` instrumentation
+/// event as a `DebugQuery` (see `diesel::debug_query` /
+/// `AsyncPgConnection::with_prepared_statement`), whose `Display` renders
+/// `"{sql} -- binds: {binds:?}"` — the format lives in
+/// `diesel::query_builder::debug_query::display`
+/// (`write!(f, "{query} -- binds: {debug_binds:?}")`). So the SQL text we
+/// materialise from `query.to_string()` is e.g.
+/// `SELECT * FROM books WHERE author_id = $1 -- binds: [1]`.
+///
+/// The per-row executions of an N+1 pattern share the same parameterised
+/// statement (`… WHERE author_id = $1`) and differ only in their bind values
+/// (`-- binds: [1]`, `-- binds: [2]`, …). If the capture path retained that
+/// annotation, [`crate::inspector::normalize_sql`] (which only collapses
+/// whitespace and lower-cases) would treat each per-row execution as a distinct
+/// template, so [`crate::inspector::detect_n_plus_one`] would never see the
+/// repetition and `assert_no_n_plus_one()` would miss the N+1 it exists to
+/// catch. Truncating at the `-- binds` marker leaves the parameterised
+/// statement — `$N` placeholders intact — so repeated per-row queries collapse
+/// to one template.
+///
+/// Robust to input without the marker (transaction-control SQL diesel runs via
+/// `batch_execute`, or synthetic test input): returns the input unchanged. Uses
+/// the last occurrence, since diesel always appends the annotation after the
+/// full statement.
+fn strip_bind_annotation(sql: &str) -> &str {
+    sql.rfind("-- binds:")
+        .map_or(sql, |idx| sql[..idx].trim_end())
+}
+
 /// Record one instrumented DB query into the current request's
 /// [`REQUEST_DB_TIMINGS`], if any. No-op when the task-local is unset —
 /// which is the case whenever the `Server-Timing` middleware is disabled
@@ -147,7 +179,12 @@ pub(crate) fn record_request_db_query(elapsed: Duration, sql: Option<&str>) {
             && let Some(list) = g.as_mut()
         {
             list.push(crate::inspector::QueryRecord {
-                sql: sql.to_owned(),
+                // Store the parameterised statement WITHOUT diesel's per-row
+                // `-- binds: [...]` annotation (the `$N` placeholders stay), so
+                // repeated per-row queries normalise to the same template and
+                // `detect_n_plus_one` can see the repetition. See
+                // [`strip_bind_annotation`].
+                sql: strip_bind_annotation(sql).to_owned(),
                 params: Vec::new(),
                 elapsed_ms: u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX),
                 location: String::new(),
@@ -2620,6 +2657,76 @@ mod tests {
                 "{sql:?} should be treated as a countable query"
             );
         }
+    }
+
+    /// Finding-1 regression: the capture path stores the parameterised
+    /// statement WITHOUT diesel's trailing `-- binds: [...]` annotation, so the
+    /// per-row executions of an N+1 pattern (which differ only in their bind
+    /// values) collapse to a single template and `detect_n_plus_one` catches
+    /// them. Without the strip, each `-- binds: [N]` would normalise to a
+    /// distinct template and the N+1 would go undetected. Locks the fix with no
+    /// live database.
+    #[test]
+    fn strip_bind_annotation_lets_detect_n_plus_one_see_per_row_repetition() {
+        use crate::inspector::{QueryRecord, detect_n_plus_one};
+
+        // Construct QueryRecords exactly as `record_request_db_query` does:
+        // the captured `sql` is diesel's `DebugQuery` `Display` output run
+        // through `strip_bind_annotation`.
+        fn record(diesel_display: &str) -> QueryRecord {
+            QueryRecord {
+                sql: strip_bind_annotation(diesel_display).to_owned(),
+                params: Vec::new(),
+                elapsed_ms: 1,
+                location: String::new(),
+            }
+        }
+
+        // The `-- binds:` marker (and the leading whitespace before it) is
+        // stripped; the `$N` placeholder is preserved.
+        assert_eq!(
+            strip_bind_annotation("SELECT * FROM books WHERE author_id = $1 -- binds: [1]"),
+            "SELECT * FROM books WHERE author_id = $1"
+        );
+        // Zero-bind annotation is stripped too.
+        assert_eq!(
+            strip_bind_annotation("SELECT * FROM authors -- binds: []"),
+            "SELECT * FROM authors"
+        );
+        // No marker (transaction-control / synthetic input) → unchanged.
+        assert_eq!(strip_bind_annotation("SELECT 1"), "SELECT 1");
+        assert_eq!(strip_bind_annotation("BEGIN"), "BEGIN");
+
+        // A classic N+1: one parent query, then the same per-row child query
+        // executed once per row with a different bind value each time.
+        let n_plus_one = vec![
+            record("SELECT * FROM authors -- binds: []"),
+            record("SELECT * FROM books WHERE author_id = $1 -- binds: [1]"),
+            record("SELECT * FROM books WHERE author_id = $1 -- binds: [2]"),
+            record("SELECT * FROM books WHERE author_id = $1 -- binds: [3]"),
+        ];
+        let warning = detect_n_plus_one(&n_plus_one, 3)
+            .expect("three identical per-row templates should trip the N+1 detector");
+        assert_eq!(
+            warning.count, 3,
+            "all three per-row executions collapse to a single template"
+        );
+        assert_eq!(
+            warning.sql_template, "select * from books where author_id = $1",
+            "the reported template is the parameterised statement, bind-free"
+        );
+
+        // Distinct query templates must NOT trip the detector, even at the
+        // same total query count.
+        let distinct = vec![
+            record("SELECT * FROM authors -- binds: []"),
+            record("SELECT * FROM books WHERE id = $1 -- binds: [1]"),
+            record("UPDATE users SET name = $1 WHERE id = $2 -- binds: [\"x\", 2]"),
+        ];
+        assert!(
+            detect_n_plus_one(&distinct, 3).is_none(),
+            "three distinct query templates must not be reported as N+1"
+        );
     }
 
     // ── after_commit tests ───────────────────────────────────────

--- a/autumn/src/inspector.rs
+++ b/autumn/src/inspector.rs
@@ -195,6 +195,15 @@ impl InspectorBuffer {
 
 // ── N+1 detector ─────────────────────────────────────────────────────────────
 
+/// Default N+1 detection threshold: the minimum number of structurally
+/// identical SQL statements in a single request before an N+1 warning fires.
+///
+/// Single source of truth shared by `dev.inspector_n_plus_one_threshold`'s
+/// config default and the `Default` impl of `crate::test::TestResponse`. A
+/// threshold of `0` disables detection, so directly-constructed responses must
+/// inherit this non-zero default rather than a zero-filled one.
+pub(crate) const DEFAULT_N_PLUS_ONE_THRESHOLD: usize = 5;
+
 /// Examine a query list and return a warning if any SQL template was issued
 /// ≥ `threshold` times. Returns `None` when below threshold, or when
 /// `threshold == 0`, or when `queries` is empty.

--- a/autumn/src/middleware/server_timing.rs
+++ b/autumn/src/middleware/server_timing.rs
@@ -81,22 +81,32 @@ type ScopedInner<F> = F;
 /// without `db` it is a no-op passing the future through untouched.
 #[cfg(feature = "db")]
 fn scope_inner<F: Future>(fut: F) -> (DbTimings, ScopedInner<F>) {
-    // Reuse an already-active `REQUEST_DB_TIMINGS` accumulator when one is
-    // scoped in the current task; only fall back to a fresh one otherwise.
+    // Reuse an already-active `REQUEST_DB_TIMINGS` accumulator ONLY when it is
+    // a CAPTURING one; otherwise always construct a fresh accumulator.
     //
     // In production/dev there is no outer scope, so this constructs a fresh
-    // non-capturing `RequestDbTimings::default()` — identical to before, and
-    // server-timing reads its own per-request counts. But the test harness
-    // (`TestApp::send`) establishes an OUTER capturing scope around the whole
-    // request; if we unconditionally scoped a fresh default here it would
-    // SHADOW that outer accumulator, so queries would record into the throwaway
-    // one and `take_captured()` would come back empty — silently zeroing query
+    // non-capturing `RequestDbTimings::default()` — server-timing reads its own
+    // per-request counts. The test harness (`TestApp::send`) instead establishes
+    // an OUTER *capturing* scope (`with_capture()`) around the whole request; if
+    // we unconditionally scoped a fresh default here it would SHADOW that outer
+    // accumulator, so queries would record into the throwaway one and
+    // `take_captured()` would come back empty — silently zeroing query
     // assertions on any test that also enables `server_timing`. Reusing the
-    // outer `Arc` keeps both the query count AND the captured SQL list flowing
-    // into the accumulator the harness reads back.
+    // outer `Arc` in that case keeps both the query count AND the captured SQL
+    // list flowing into the accumulator the harness reads back.
+    //
+    // The reuse is gated to CAPTURING outers (the test-capture case) on
+    // purpose. In production, when both `server_timing` and `mcp` are enabled,
+    // `ServerTimingLayer` nests `REQUEST_DB_TIMINGS` twice (outer `/mcp`
+    // envelope + inner dispatch); those production scopes are non-capturing, and
+    // reusing them would make the inner dispatch and outer fallback share DB
+    // counts — double-emitting the `db` metric for a DB-backed MCP tool call.
+    // Non-capturing outers must therefore stay isolated (fresh accumulator).
     let timings = REQUEST_DB_TIMINGS
-        .try_with(Arc::clone)
-        .unwrap_or_else(|_| Arc::new(RequestDbTimings::default()));
+        .try_with(|active| active.is_capturing().then(|| Arc::clone(active)))
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| Arc::new(RequestDbTimings::default()));
     // Scope the inner future so any DB query instrumentation that runs
     // during it can record into `timings` via the task-local. We keep a
     // clone of the Arc outside the scope to read back after poll.
@@ -427,23 +437,44 @@ mod tests {
         assert_eq!(v, "total;dur=1.000");
     }
 
-    /// Finding-2 regression: when a `REQUEST_DB_TIMINGS` scope is already
-    /// active — as `TestApp::send` establishes around the whole request —
-    /// `scope_inner` must REUSE that accumulator rather than shadow it with a
-    /// fresh non-capturing default. Otherwise the `ServerTimingLayer`'s inner
-    /// scope would divert queries into a throwaway accumulator and the harness's
-    /// `take_captured()` / `query_count()` would silently come back empty for
-    /// any test that also enables `server_timing`.
+    /// Finding-2 regression: when a *capturing* `REQUEST_DB_TIMINGS` scope is
+    /// already active — as `TestApp::send` establishes around the whole request
+    /// via `with_capture()` — `scope_inner` must REUSE that accumulator rather
+    /// than shadow it with a fresh non-capturing default. Otherwise the
+    /// `ServerTimingLayer`'s inner scope would divert queries into a throwaway
+    /// accumulator and the harness's `take_captured()` / `query_count()` would
+    /// silently come back empty for any test that also enables `server_timing`.
     #[cfg(feature = "db")]
     #[tokio::test]
-    async fn scope_inner_reuses_active_outer_accumulator() {
-        let outer = Arc::new(RequestDbTimings::default());
+    async fn scope_inner_reuses_active_capturing_outer_accumulator() {
+        let outer = Arc::new(RequestDbTimings::with_capture());
         REQUEST_DB_TIMINGS
             .scope(Arc::clone(&outer), async {
                 let (reused, _scope) = scope_inner(std::future::ready(()));
                 assert!(
                     Arc::ptr_eq(&reused, &outer),
-                    "scope_inner must reuse the active outer accumulator, not shadow it"
+                    "scope_inner must reuse the active capturing outer accumulator, not shadow it"
+                );
+            })
+            .await;
+    }
+
+    /// Production nested-MCP isolation guarantee: when the active outer
+    /// `REQUEST_DB_TIMINGS` scope is NON-capturing (the production/dev shape,
+    /// e.g. the `/mcp` envelope's outer scope), `scope_inner` must NOT reuse it
+    /// — it must build a FRESH accumulator so the inner dispatch and the outer
+    /// fallback keep separate DB counts and a DB-backed MCP tool call does not
+    /// double-emit the `db` metric.
+    #[cfg(feature = "db")]
+    #[tokio::test]
+    async fn scope_inner_does_not_reuse_noncapturing_outer_accumulator() {
+        let outer = Arc::new(RequestDbTimings::default());
+        REQUEST_DB_TIMINGS
+            .scope(Arc::clone(&outer), async {
+                let (fresh, _scope) = scope_inner(std::future::ready(()));
+                assert!(
+                    !Arc::ptr_eq(&fresh, &outer),
+                    "scope_inner must isolate a non-capturing outer scope with a fresh accumulator"
                 );
             })
             .await;

--- a/autumn/src/middleware/server_timing.rs
+++ b/autumn/src/middleware/server_timing.rs
@@ -81,7 +81,22 @@ type ScopedInner<F> = F;
 /// without `db` it is a no-op passing the future through untouched.
 #[cfg(feature = "db")]
 fn scope_inner<F: Future>(fut: F) -> (DbTimings, ScopedInner<F>) {
-    let timings = Arc::new(RequestDbTimings::default());
+    // Reuse an already-active `REQUEST_DB_TIMINGS` accumulator when one is
+    // scoped in the current task; only fall back to a fresh one otherwise.
+    //
+    // In production/dev there is no outer scope, so this constructs a fresh
+    // non-capturing `RequestDbTimings::default()` — identical to before, and
+    // server-timing reads its own per-request counts. But the test harness
+    // (`TestApp::send`) establishes an OUTER capturing scope around the whole
+    // request; if we unconditionally scoped a fresh default here it would
+    // SHADOW that outer accumulator, so queries would record into the throwaway
+    // one and `take_captured()` would come back empty — silently zeroing query
+    // assertions on any test that also enables `server_timing`. Reusing the
+    // outer `Arc` keeps both the query count AND the captured SQL list flowing
+    // into the accumulator the harness reads back.
+    let timings = REQUEST_DB_TIMINGS
+        .try_with(Arc::clone)
+        .unwrap_or_else(|_| Arc::new(RequestDbTimings::default()));
     // Scope the inner future so any DB query instrumentation that runs
     // during it can record into `timings` via the task-local. We keep a
     // clone of the Arc outside the scope to read back after poll.
@@ -410,6 +425,42 @@ mod tests {
     fn build_header_value_zero_query_count_omits_db_even_with_ms() {
         let v = build_header_value(1.0, Some(0.0), 0, false);
         assert_eq!(v, "total;dur=1.000");
+    }
+
+    /// Finding-2 regression: when a `REQUEST_DB_TIMINGS` scope is already
+    /// active — as `TestApp::send` establishes around the whole request —
+    /// `scope_inner` must REUSE that accumulator rather than shadow it with a
+    /// fresh non-capturing default. Otherwise the `ServerTimingLayer`'s inner
+    /// scope would divert queries into a throwaway accumulator and the harness's
+    /// `take_captured()` / `query_count()` would silently come back empty for
+    /// any test that also enables `server_timing`.
+    #[cfg(feature = "db")]
+    #[tokio::test]
+    async fn scope_inner_reuses_active_outer_accumulator() {
+        let outer = Arc::new(RequestDbTimings::default());
+        REQUEST_DB_TIMINGS
+            .scope(Arc::clone(&outer), async {
+                let (reused, _scope) = scope_inner(std::future::ready(()));
+                assert!(
+                    Arc::ptr_eq(&reused, &outer),
+                    "scope_inner must reuse the active outer accumulator, not shadow it"
+                );
+            })
+            .await;
+    }
+
+    /// Complement to the reuse test: with NO active outer scope (the
+    /// production/dev path), `scope_inner` builds a fresh accumulator so
+    /// server-timing reads its own per-request counts — unchanged behavior.
+    #[cfg(feature = "db")]
+    #[tokio::test]
+    async fn scope_inner_creates_fresh_accumulator_off_scope() {
+        let (fresh, _scope) = scope_inner(std::future::ready(()));
+        assert_eq!(
+            fresh.query_count.load(Ordering::Relaxed),
+            0,
+            "a fresh off-scope accumulator starts with no recorded queries"
+        );
     }
 
     /// End-to-end coverage of the db-metric path without a live database:

--- a/autumn/src/middleware/server_timing.rs
+++ b/autumn/src/middleware/server_timing.rs
@@ -427,8 +427,8 @@ mod tests {
         let timings = Arc::new(RequestDbTimings::default());
         REQUEST_DB_TIMINGS
             .scope(Arc::clone(&timings), async {
-                crate::db::record_request_db_query(Duration::from_micros(1_500));
-                crate::db::record_request_db_query(Duration::from_micros(2_500));
+                crate::db::record_request_db_query(Duration::from_micros(1_500), None);
+                crate::db::record_request_db_query(Duration::from_micros(2_500), None);
             })
             .await;
 

--- a/autumn/src/middleware/server_timing.rs
+++ b/autumn/src/middleware/server_timing.rs
@@ -81,32 +81,23 @@ type ScopedInner<F> = F;
 /// without `db` it is a no-op passing the future through untouched.
 #[cfg(feature = "db")]
 fn scope_inner<F: Future>(fut: F) -> (DbTimings, ScopedInner<F>) {
-    // Reuse an already-active `REQUEST_DB_TIMINGS` accumulator ONLY when it is
-    // a CAPTURING one; otherwise always construct a fresh accumulator.
+    // Always construct a FRESH per-scope accumulator. Each `ServerTimingLayer`
+    // scope measures only the DB queries that run under its own scope, so
+    // nested Server-Timing scopes stay isolated and never share counts.
     //
-    // In production/dev there is no outer scope, so this constructs a fresh
-    // non-capturing `RequestDbTimings::default()` — server-timing reads its own
-    // per-request counts. The test harness (`TestApp::send`) instead establishes
-    // an OUTER *capturing* scope (`with_capture()`) around the whole request; if
-    // we unconditionally scoped a fresh default here it would SHADOW that outer
-    // accumulator, so queries would record into the throwaway one and
-    // `take_captured()` would come back empty — silently zeroing query
-    // assertions on any test that also enables `server_timing`. Reusing the
-    // outer `Arc` in that case keeps both the query count AND the captured SQL
-    // list flowing into the accumulator the harness reads back.
+    // This isolation is load-bearing. When both `server_timing` and `mcp` are
+    // enabled, `ServerTimingLayer` nests `REQUEST_DB_TIMINGS` twice (the outer
+    // `/mcp` fallback envelope + the inner dispatch). If the inner scope reused
+    // the outer accumulator, the inner dispatch and the outer fallback would
+    // share DB counts and the fallback would re-emit the same `db` metric the
+    // MCP path already forwarded — double-emitting `db` for a DB-backed MCP
+    // tool call. A fresh accumulator per scope keeps each `db` metric correct.
     //
-    // The reuse is gated to CAPTURING outers (the test-capture case) on
-    // purpose. In production, when both `server_timing` and `mcp` are enabled,
-    // `ServerTimingLayer` nests `REQUEST_DB_TIMINGS` twice (outer `/mcp`
-    // envelope + inner dispatch); those production scopes are non-capturing, and
-    // reusing them would make the inner dispatch and outer fallback share DB
-    // counts — double-emitting the `db` metric for a DB-backed MCP tool call.
-    // Non-capturing outers must therefore stay isolated (fresh accumulator).
-    let timings = REQUEST_DB_TIMINGS
-        .try_with(|active| active.is_capturing().then(|| Arc::clone(active)))
-        .ok()
-        .flatten()
-        .unwrap_or_else(|| Arc::new(RequestDbTimings::default()));
+    // Request-wide SQL capture (the test harness's `TestResponse` assertions)
+    // rides a SEPARATE task-local lane — `crate::db::REQUEST_QUERY_CAPTURE` —
+    // scoped once around the whole request, so it is entirely unaffected by how
+    // this timing accumulator is scoped or nested here.
+    let timings = Arc::new(RequestDbTimings::default());
     // Scope the inner future so any DB query instrumentation that runs
     // during it can record into `timings` via the task-local. We keep a
     // clone of the Arc outside the scope to read back after poll.
@@ -437,52 +428,33 @@ mod tests {
         assert_eq!(v, "total;dur=1.000");
     }
 
-    /// Finding-2 regression: when a *capturing* `REQUEST_DB_TIMINGS` scope is
-    /// already active — as `TestApp::send` establishes around the whole request
-    /// via `with_capture()` — `scope_inner` must REUSE that accumulator rather
-    /// than shadow it with a fresh non-capturing default. Otherwise the
-    /// `ServerTimingLayer`'s inner scope would divert queries into a throwaway
-    /// accumulator and the harness's `take_captured()` / `query_count()` would
-    /// silently come back empty for any test that also enables `server_timing`.
+    /// P2 nested-isolation regression: with an active outer `REQUEST_DB_TIMINGS`
+    /// scope (as `ServerTimingLayer`'s outer `/mcp` fallback establishes when
+    /// both `server_timing` and `mcp` are enabled), `scope_inner` must build a
+    /// FRESH accumulator — NOT reuse the outer one. Sharing the accumulator
+    /// would make the inner dispatch and the outer fallback accumulate into the
+    /// same counts, so the fallback re-emits the same `db` metric the MCP path
+    /// already forwarded, double-emitting `db` for a DB-backed MCP tool call.
+    /// A distinct `Arc` per scope is what keeps each `db` metric correct.
     #[cfg(feature = "db")]
     #[tokio::test]
-    async fn scope_inner_reuses_active_capturing_outer_accumulator() {
-        let outer = Arc::new(RequestDbTimings::with_capture());
-        REQUEST_DB_TIMINGS
-            .scope(Arc::clone(&outer), async {
-                let (reused, _scope) = scope_inner(std::future::ready(()));
-                assert!(
-                    Arc::ptr_eq(&reused, &outer),
-                    "scope_inner must reuse the active capturing outer accumulator, not shadow it"
-                );
-            })
-            .await;
-    }
-
-    /// Production nested-MCP isolation guarantee: when the active outer
-    /// `REQUEST_DB_TIMINGS` scope is NON-capturing (the production/dev shape,
-    /// e.g. the `/mcp` envelope's outer scope), `scope_inner` must NOT reuse it
-    /// — it must build a FRESH accumulator so the inner dispatch and the outer
-    /// fallback keep separate DB counts and a DB-backed MCP tool call does not
-    /// double-emit the `db` metric.
-    #[cfg(feature = "db")]
-    #[tokio::test]
-    async fn scope_inner_does_not_reuse_noncapturing_outer_accumulator() {
+    async fn scope_inner_isolates_nested_scopes() {
         let outer = Arc::new(RequestDbTimings::default());
         REQUEST_DB_TIMINGS
             .scope(Arc::clone(&outer), async {
-                let (fresh, _scope) = scope_inner(std::future::ready(()));
+                let (inner, _scope) = scope_inner(std::future::ready(()));
                 assert!(
-                    !Arc::ptr_eq(&fresh, &outer),
-                    "scope_inner must isolate a non-capturing outer scope with a fresh accumulator"
+                    !Arc::ptr_eq(&inner, &outer),
+                    "nested scope_inner must isolate with a fresh accumulator, \
+                     not share the outer one (which would double-emit the db metric)"
                 );
             })
             .await;
     }
 
-    /// Complement to the reuse test: with NO active outer scope (the
-    /// production/dev path), `scope_inner` builds a fresh accumulator so
-    /// server-timing reads its own per-request counts — unchanged behavior.
+    /// With NO active outer scope (the production/dev path), `scope_inner`
+    /// builds a fresh accumulator so server-timing reads its own per-request
+    /// counts — unchanged behavior.
     #[cfg(feature = "db")]
     #[tokio::test]
     async fn scope_inner_creates_fresh_accumulator_off_scope() {
@@ -492,6 +464,56 @@ mod tests {
             0,
             "a fresh off-scope accumulator starts with no recorded queries"
         );
+    }
+
+    /// The P2 fix decouples query capture from the timing accumulator: capturing
+    /// rides `crate::db::REQUEST_QUERY_CAPTURE`, a task-local separate from the
+    /// nested `REQUEST_DB_TIMINGS` timing scopes. This reproduces the reported
+    /// scenario without a live database: with a capture sink scoped, record a
+    /// query under an INNER `scope_inner` timing scope nested inside an OUTER
+    /// one, and assert (a) the capture sink collects the query exactly once (no
+    /// duplication) and (b) the two nested timing accumulators are distinct
+    /// `Arc`s (no shared counts → no duplicate `db` metric).
+    #[cfg(feature = "db")]
+    #[tokio::test]
+    async fn nested_scopes_do_not_duplicate_capture_and_stay_isolated() {
+        use std::sync::Mutex;
+        use std::time::Duration;
+
+        let capture = Arc::new(Mutex::new(Vec::new()));
+        crate::db::REQUEST_QUERY_CAPTURE
+            .scope(Arc::clone(&capture), async {
+                // Outer timing scope (e.g. the `/mcp` fallback envelope).
+                let (outer_timings, outer_scope) = scope_inner(async {
+                    // Inner timing scope (the dispatch layer) runs the query.
+                    let (inner_timings, inner_scope) = scope_inner(async {
+                        crate::db::record_request_db_query(
+                            Duration::from_micros(500),
+                            Some("SELECT * FROM books WHERE id = $1"),
+                        );
+                    });
+                    inner_scope.await;
+                    inner_timings
+                });
+                let inner_timings = outer_scope.await;
+                assert!(
+                    !Arc::ptr_eq(&outer_timings, &inner_timings),
+                    "nested timing scopes must be distinct Arcs (no shared counts)"
+                );
+            })
+            .await;
+
+        let captured = capture
+            .lock()
+            .map(|v| v.clone())
+            .expect("capture mutex poisoned");
+        assert_eq!(
+            captured.len(),
+            1,
+            "the query must be captured exactly once — no duplication across \
+             nested Server-Timing scopes"
+        );
+        assert_eq!(captured[0].sql, "SELECT * FROM books WHERE id = $1");
     }
 
     /// End-to-end coverage of the db-metric path without a live database:

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -3224,7 +3224,11 @@ impl Default for TestResponse {
             queries: Vec::new(),
             request_method: String::new(),
             request_path: String::new(),
-            n_plus_one_threshold: 0,
+            // Inherit the detector's default (5) — not a zero-filled `0`, which
+            // `inspector::detect_n_plus_one` treats as DISABLED — so the
+            // documented `TestResponse { .. ..Default::default() }` construction
+            // still catches N+1 patterns.
+            n_plus_one_threshold: crate::inspector::DEFAULT_N_PLUS_ONE_THRESHOLD,
         }
     }
 }
@@ -4601,6 +4605,54 @@ mod tests {
         assert!(
             panic_message(err.as_ref()).contains("2 times"),
             "override fires at the explicit threshold"
+        );
+    }
+
+    #[test]
+    fn default_test_response_inherits_detector_threshold() {
+        // A directly-constructed `TestResponse` must inherit the shared detector
+        // default (5), not a zero-filled `0` — otherwise `..Default::default()`
+        // would silently DISABLE N+1 detection.
+        assert_eq!(
+            TestResponse::default().n_plus_one_threshold,
+            crate::inspector::DEFAULT_N_PLUS_ONE_THRESHOLD,
+        );
+    }
+
+    #[test]
+    fn default_constructed_response_catches_n_plus_one() {
+        // Build a response purely via the documented `{ .., ..Default::default() }`
+        // pattern (no explicit threshold). With a zero-filled default this passed
+        // silently (0 == DISABLED); with the detector default (5) it must panic on
+        // the normalized template repeated to the threshold.
+        let resp = TestResponse {
+            queries: [
+                "SELECT * FROM comments WHERE post_id = $1",
+                "SELECT  * FROM comments WHERE post_id = $1",
+                "select * from comments where post_id = $1",
+                "SELECT * FROM  comments WHERE post_id = $1",
+                "Select * From comments Where post_id = $1",
+            ]
+            .iter()
+            .map(|s| crate::inspector::QueryRecord {
+                sql: (*s).to_owned(),
+                params: Vec::new(),
+                elapsed_ms: 1,
+                location: String::new(),
+            })
+            .collect(),
+            ..Default::default()
+        };
+        let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            resp.assert_no_n_plus_one();
+        }))
+        .expect_err(
+            "a default-constructed TestResponse must inherit the non-zero detector \
+             threshold and fire on an N+1 pattern",
+        );
+        assert!(
+            panic_message(err.as_ref()).contains("select * from comments where post_id = $1"),
+            "reports the normalized SQL template",
         );
     }
 }

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -3058,27 +3058,51 @@ impl RequestBuilder {
         // required. `oneshot` runs on this same task, so the task-local is
         // visible to the checkout. When the `db` feature is off there is no DB,
         // so the captured query list is simply empty.
+        //
+        // The response body is drained (`to_bytes`) *inside* the scope so that
+        // handlers returning a lazy or streaming body (`Sse`, `Body::from_stream`,
+        // …) which perform DB work when the stream is polled still record those
+        // body-time checkouts against this request's timings. `take_captured()`
+        // only runs after the body is fully collected, so nothing is missed.
         #[cfg(feature = "db")]
-        let (response, queries) = {
+        let (status, headers, body_bytes, queries) = {
             let timings = std::sync::Arc::new(crate::db::RequestDbTimings::with_capture());
-            let response = crate::db::REQUEST_DB_TIMINGS
-                .scope(std::sync::Arc::clone(&timings), service.oneshot(request))
-                .await
-                .expect("request failed");
-            (response, timings.take_captured())
+            let (status, headers, body_bytes) = crate::db::REQUEST_DB_TIMINGS
+                .scope(std::sync::Arc::clone(&timings), async move {
+                    let response = service.oneshot(request).await.expect("request failed");
+                    let status = response.status();
+                    let headers: Vec<(String, String)> = response
+                        .headers()
+                        .iter()
+                        .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_owned()))
+                        .collect();
+                    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                        .await
+                        .expect("failed to read response body");
+                    (status, headers, body_bytes)
+                })
+                .await;
+            (status, headers, body_bytes, timings.take_captured())
         };
         #[cfg(not(feature = "db"))]
-        let (response, queries): (_, Vec<crate::inspector::QueryRecord>) = (
-            service.oneshot(request).await.expect("request failed"),
-            Vec::new(),
-        );
-
-        let status = response.status();
-        let headers: Vec<(String, String)> = response
-            .headers()
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_owned()))
-            .collect();
+        let (status, headers, body_bytes, queries): (
+            _,
+            _,
+            _,
+            Vec<crate::inspector::QueryRecord>,
+        ) = {
+            let response = service.oneshot(request).await.expect("request failed");
+            let status = response.status();
+            let headers: Vec<(String, String)> = response
+                .headers()
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_owned()))
+                .collect();
+            let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("failed to read response body");
+            (status, headers, body_bytes, Vec::new())
+        };
 
         // Fold every `Set-Cookie` from the response back into the jar so the
         // next request from the same client replays it. Cookies whose
@@ -3096,10 +3120,6 @@ impl RequestBuilder {
                 }
             }
         }
-
-        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .expect("failed to read response body");
 
         TestResponse {
             status,
@@ -4455,6 +4475,55 @@ mod tests {
         assert_eq!(resp.query_count(), 2);
         assert_eq!(resp.queries().len(), 2);
         assert_eq!(resp.queries()[0].sql, "SELECT 1");
+    }
+
+    /// Regression guard: the `REQUEST_DB_TIMINGS` capture scope must stay active
+    /// while a lazy/streaming response body is drained, so DB work performed
+    /// *during* body polling (as `Sse` / `Body::from_stream` handlers do) is
+    /// still counted. `service.oneshot` returns the response head without
+    /// polling the stream; `send()` drains the body with `to_bytes` — if that
+    /// drain happened after the scope closed, these body-time queries would be
+    /// recorded against an unset task-local and silently dropped, so
+    /// `query_count()` would under-report (here: read 0 instead of 3).
+    #[cfg(feature = "db")]
+    #[tokio::test]
+    async fn query_capture_stays_active_while_draining_streaming_body() {
+        use futures::StreamExt as _;
+
+        // Each streamed chunk records a DB query when it is polled. The stream is
+        // lazy: nothing runs until `to_bytes` polls it inside `send()`.
+        async fn stream_handler() -> axum::response::Response {
+            let body_stream = futures::stream::iter(0..3).map(|_| {
+                crate::db::record_request_db_query(
+                    std::time::Duration::from_millis(1),
+                    Some("SELECT 1"),
+                );
+                Ok::<_, std::convert::Infallible>(bytes::Bytes::from_static(b"x"))
+            });
+            axum::response::Response::new(Body::from_stream(body_stream))
+        }
+
+        let router = axum::Router::new().route("/stream", axum::routing::get(stream_handler));
+        let resp = RequestBuilder {
+            router,
+            method: Method::GET,
+            uri: "/stream".to_owned(),
+            headers: Vec::new(),
+            body: Body::empty(),
+            cookie_jar: None,
+            clock: None,
+            n_plus_one_threshold: 5,
+        }
+        .send()
+        .await;
+
+        resp.assert_ok();
+        assert_eq!(
+            resp.query_count(),
+            3,
+            "body-time DB queries must be captured while the streaming body is \
+             drained inside the active capture scope"
+        );
     }
 
     #[test]

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -3051,24 +3051,27 @@ impl RequestBuilder {
         let service =
             tower::Layer::layer(&crate::middleware::MethodOverrideLayer::new(), self.router);
 
-        // Drive the request under a per-request `REQUEST_DB_TIMINGS` capture
-        // scope so the connection-level `RequestQueryTimer` (installed at
-        // `Db::checkout` whenever this scope is active) records every SQL
-        // statement the handler issues — no manual `DbInterceptor` wiring
-        // required. `oneshot` runs on this same task, so the task-local is
-        // visible to the checkout. When the `db` feature is off there is no DB,
-        // so the captured query list is simply empty.
+        // Drive the request under a per-request `REQUEST_QUERY_CAPTURE` scope so
+        // the connection-level `RequestQueryTimer` (installed at `Db::checkout`
+        // whenever this capture lane is active) records every SQL statement the
+        // handler issues into the capture sink — no manual `DbInterceptor`
+        // wiring required. This lane is independent of the `Server-Timing`
+        // timing accumulator (`REQUEST_DB_TIMINGS`), so query capture is
+        // unaffected by however `ServerTimingLayer` scopes (and nests) its
+        // per-scope DB metrics. `oneshot` runs on this same task, so the
+        // task-local is visible to the checkout. When the `db` feature is off
+        // there is no DB, so the captured query list is simply empty.
         //
         // The response body is drained (`to_bytes`) *inside* the scope so that
         // handlers returning a lazy or streaming body (`Sse`, `Body::from_stream`,
         // …) which perform DB work when the stream is polled still record those
-        // body-time checkouts against this request's timings. `take_captured()`
-        // only runs after the body is fully collected, so nothing is missed.
+        // body-time checkouts into the capture sink. The sink is read only after
+        // the body is fully collected, so nothing is missed.
         #[cfg(feature = "db")]
         let (status, headers, body_bytes, queries) = {
-            let timings = std::sync::Arc::new(crate::db::RequestDbTimings::with_capture());
-            let (status, headers, body_bytes) = crate::db::REQUEST_DB_TIMINGS
-                .scope(std::sync::Arc::clone(&timings), async move {
+            let capture = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            let (status, headers, body_bytes) = crate::db::REQUEST_QUERY_CAPTURE
+                .scope(std::sync::Arc::clone(&capture), async move {
                     let response = service.oneshot(request).await.expect("request failed");
                     let status = response.status();
                     let headers: Vec<(String, String)> = response
@@ -3082,7 +3085,8 @@ impl RequestBuilder {
                     (status, headers, body_bytes)
                 })
                 .await;
-            (status, headers, body_bytes, timings.take_captured())
+            let queries = capture.lock().map(|v| v.clone()).unwrap_or_default();
+            (status, headers, body_bytes, queries)
         };
         #[cfg(not(feature = "db"))]
         let (status, headers, body_bytes, queries): (
@@ -4477,10 +4481,10 @@ mod tests {
         assert_eq!(resp.queries()[0].sql, "SELECT 1");
     }
 
-    /// Regression guard: the `REQUEST_DB_TIMINGS` capture scope must stay active
+    /// Regression guard: the `REQUEST_QUERY_CAPTURE` scope must stay active
     /// while a lazy/streaming response body is drained, so DB work performed
     /// *during* body polling (as `Sse` / `Body::from_stream` handlers do) is
-    /// still counted. `service.oneshot` returns the response head without
+    /// still captured. `service.oneshot` returns the response head without
     /// polling the stream; `send()` drains the body with `to_bytes` — if that
     /// drain happened after the scope closed, these body-time queries would be
     /// recorded against an unset task-local and silently dropped, so

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -73,6 +73,7 @@
 //!           </tbody>
 //!         </table>
 //!     "#.to_vec(),
+//!     ..Default::default()
 //! };
 //!
 //! resp.assert_ok()
@@ -2628,6 +2629,14 @@ impl TestClient {
         PerformedJobs { outcomes }
     }
 
+    /// The app's configured N+1 detection threshold
+    /// (`dev.inspector_n_plus_one_threshold`), threaded into every
+    /// [`RequestBuilder`] so the resulting [`TestResponse`] can default
+    /// [`TestResponse::assert_no_n_plus_one`] to it.
+    fn n_plus_one_threshold(&self) -> usize {
+        self.state.config().dev.inspector_n_plus_one_threshold
+    }
+
     /// Start building a GET request.
     #[must_use]
     pub fn get(&self, uri: &str) -> RequestBuilder {
@@ -2637,6 +2646,7 @@ impl TestClient {
             uri,
             self.cookie_jar.clone(),
             Some(self.state.clock.clone()),
+            self.n_plus_one_threshold(),
         )
     }
 
@@ -2649,6 +2659,7 @@ impl TestClient {
             uri,
             self.cookie_jar.clone(),
             Some(self.state.clock.clone()),
+            self.n_plus_one_threshold(),
         )
     }
 
@@ -2661,6 +2672,7 @@ impl TestClient {
             uri,
             self.cookie_jar.clone(),
             Some(self.state.clock.clone()),
+            self.n_plus_one_threshold(),
         )
     }
 
@@ -2673,6 +2685,7 @@ impl TestClient {
             uri,
             self.cookie_jar.clone(),
             Some(self.state.clock.clone()),
+            self.n_plus_one_threshold(),
         )
     }
 
@@ -2685,6 +2698,7 @@ impl TestClient {
             uri,
             self.cookie_jar.clone(),
             Some(self.state.clock.clone()),
+            self.n_plus_one_threshold(),
         )
     }
 
@@ -2697,6 +2711,7 @@ impl TestClient {
             uri,
             self.cookie_jar.clone(),
             Some(self.state.clock.clone()),
+            self.n_plus_one_threshold(),
         )
     }
 
@@ -2911,6 +2926,10 @@ pub struct RequestBuilder {
     /// The originating client's clock, used to evaluate `Expires` when folding
     /// `Set-Cookie` back into the jar. `None` falls back to [`chrono::Utc::now`].
     clock: Option<std::sync::Arc<dyn crate::time::ClockSource>>,
+    /// Default N+1 detection threshold (`dev.inspector_n_plus_one_threshold`),
+    /// propagated to the resulting [`TestResponse`] so
+    /// [`TestResponse::assert_no_n_plus_one`] can honour the app's config.
+    n_plus_one_threshold: usize,
 }
 
 impl RequestBuilder {
@@ -2920,6 +2939,7 @@ impl RequestBuilder {
         uri: &str,
         cookie_jar: CookieJar,
         clock: Option<std::sync::Arc<dyn crate::time::ClockSource>>,
+        n_plus_one_threshold: usize,
     ) -> Self {
         Self {
             router,
@@ -2929,6 +2949,7 @@ impl RequestBuilder {
             body: Body::empty(),
             cookie_jar: Some(cookie_jar),
             clock,
+            n_plus_one_threshold,
         }
     }
 
@@ -2979,6 +3000,12 @@ impl RequestBuilder {
     /// Fire the request through the full middleware pipeline and return
     /// a [`TestResponse`].
     pub async fn send(self) -> TestResponse {
+        // Captured for failure messages and the N+1 default threshold on the
+        // resulting `TestResponse`.
+        let request_method = self.method.to_string();
+        let request_path = self.uri.clone();
+        let n_plus_one_threshold = self.n_plus_one_threshold;
+
         let mut builder = Request::builder().method(self.method).uri(&self.uri);
 
         // Replay the cookie jar: compose a `Cookie` header from stored cookies
@@ -3023,7 +3050,28 @@ impl RequestBuilder {
         // unconditionally.
         let service =
             tower::Layer::layer(&crate::middleware::MethodOverrideLayer::new(), self.router);
-        let response = service.oneshot(request).await.expect("request failed");
+
+        // Drive the request under a per-request `REQUEST_DB_TIMINGS` capture
+        // scope so the connection-level `RequestQueryTimer` (installed at
+        // `Db::checkout` whenever this scope is active) records every SQL
+        // statement the handler issues — no manual `DbInterceptor` wiring
+        // required. `oneshot` runs on this same task, so the task-local is
+        // visible to the checkout. When the `db` feature is off there is no DB,
+        // so the captured query list is simply empty.
+        #[cfg(feature = "db")]
+        let (response, queries) = {
+            let timings = std::sync::Arc::new(crate::db::RequestDbTimings::with_capture());
+            let response = crate::db::REQUEST_DB_TIMINGS
+                .scope(std::sync::Arc::clone(&timings), service.oneshot(request))
+                .await
+                .expect("request failed");
+            (response, timings.take_captured())
+        };
+        #[cfg(not(feature = "db"))]
+        let (response, queries): (_, Vec<crate::inspector::QueryRecord>) = (
+            service.oneshot(request).await.expect("request failed"),
+            Vec::new(),
+        );
 
         let status = response.status();
         let headers: Vec<(String, String)> = response
@@ -3057,6 +3105,10 @@ impl RequestBuilder {
             status,
             headers,
             body: body_bytes.to_vec(),
+            queries,
+            request_method,
+            request_path,
+            n_plus_one_threshold,
         }
     }
 }
@@ -3074,8 +3126,10 @@ impl RequestBuilder {
 ///     .assert_body_contains("Alice");
 /// ```
 ///
-/// Fields are public so you can construct a `TestResponse` directly in unit
-/// tests that don't need a full HTTP round-trip:
+/// The `status`, `headers`, and `body` fields are public so you can construct a
+/// `TestResponse` directly in unit tests that don't need a full HTTP
+/// round-trip. Fill the remaining (query-capture) fields with
+/// `..Default::default()`:
 ///
 /// ```rust
 /// use autumn_web::test::TestResponse;
@@ -3088,6 +3142,7 @@ impl RequestBuilder {
 ///         ("x-request-id".into(), "abc-123".into()),
 ///     ],
 ///     body: br#"{"name":"Alice"}"#.to_vec(),
+///     ..Default::default()
 /// };
 ///
 /// resp.assert_ok()
@@ -3096,6 +3151,23 @@ impl RequestBuilder {
 ///
 /// assert_eq!(resp.header("x-request-id"), Some("abc-123"));
 /// ```
+///
+/// # Query-count and N+1 assertions
+///
+/// When the response was produced by [`RequestBuilder::send`] against a
+/// database-backed app, every SQL statement the handler issued is captured
+/// automatically (no manual interceptor wiring). Assert on it with
+/// [`TestResponse::query_count`], [`TestResponse::assert_max_queries`], and
+/// [`TestResponse::assert_no_n_plus_one`]:
+///
+/// ```rust,no_run
+/// # async fn ex(client: autumn_web::test::TestClient) {
+/// client.get("/posts").send().await
+///     .assert_ok()
+///     .assert_max_queries(3)   // fails, naming GET /posts, if > 3 queries ran
+///     .assert_no_n_plus_one(); // fails if a query repeats >= the dev threshold
+/// # }
+/// ```
 pub struct TestResponse {
     /// HTTP status code.
     pub status: StatusCode,
@@ -3103,6 +3175,34 @@ pub struct TestResponse {
     pub headers: Vec<(String, String)>,
     /// Raw response body bytes.
     pub body: Vec<u8>,
+    /// SQL queries captured while handling the request, in execution order.
+    ///
+    /// Populated automatically by [`RequestBuilder::send`] for
+    /// database-backed apps; empty for directly-constructed responses or when
+    /// the `db` feature is disabled. Prefer the [`TestResponse::queries`]
+    /// accessor for reading.
+    pub queries: Vec<crate::inspector::QueryRecord>,
+    /// HTTP method of the originating request, for assertion failure messages.
+    pub request_method: String,
+    /// Path of the originating request, for assertion failure messages.
+    pub request_path: String,
+    /// Default N+1 threshold (`dev.inspector_n_plus_one_threshold`) used by
+    /// [`TestResponse::assert_no_n_plus_one`].
+    pub n_plus_one_threshold: usize,
+}
+
+impl Default for TestResponse {
+    fn default() -> Self {
+        Self {
+            status: StatusCode::OK,
+            headers: Vec::new(),
+            body: Vec::new(),
+            queries: Vec::new(),
+            request_method: String::new(),
+            request_path: String::new(),
+            n_plus_one_threshold: 0,
+        }
+    }
 }
 
 impl TestResponse {
@@ -3461,6 +3561,109 @@ impl TestResponse {
             ),
         }
         self
+    }
+
+    // ── Database query assertions (#1262) ──────────────────────
+
+    /// Number of SQL queries the request issued.
+    ///
+    /// Captured automatically by [`RequestBuilder::send`] for database-backed
+    /// apps; `0` for directly-constructed responses or when the `db` feature
+    /// is disabled.
+    #[must_use]
+    pub const fn query_count(&self) -> usize {
+        self.queries.len()
+    }
+
+    /// The SQL queries the request issued, in execution order.
+    ///
+    /// Lets a test assert on specific normalized SQL. Empty for
+    /// directly-constructed responses or when the `db` feature is disabled.
+    #[must_use]
+    pub fn queries(&self) -> &[crate::inspector::QueryRecord] {
+        &self.queries
+    }
+
+    /// A per-query listing for assertion failure messages: one line per query
+    /// (`#N  <elapsed>ms  <sql>`), followed by repetition counts per
+    /// normalized statement so the offending pattern is obvious.
+    fn query_report(&self) -> String {
+        use std::collections::BTreeMap;
+        use std::fmt::Write as _;
+        let mut out = String::new();
+        for (i, q) in self.queries.iter().enumerate() {
+            let _ = write!(
+                out,
+                "\n  #{n:<3} {ms:>4}ms  {sql}",
+                n = i + 1,
+                ms = q.elapsed_ms,
+                sql = q.sql,
+            );
+        }
+        // Counts per normalized statement (stable, sorted for determinism).
+        let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+        for q in &self.queries {
+            *counts
+                .entry(q.sql.split_whitespace().collect::<Vec<_>>().join(" "))
+                .or_insert(0) += 1;
+        }
+        if counts.len() != self.queries.len() {
+            out.push_str("\n  ── counts per statement ──");
+            for (sql, count) in &counts {
+                let _ = write!(out, "\n  {count}x  {sql}");
+            }
+        }
+        out
+    }
+
+    /// Assert the request issued at most `n` SQL queries.
+    ///
+    /// Passes when `query_count() <= n`. Panics otherwise with a message
+    /// naming the request (method + path), the expected and actual counts, and
+    /// the full query list.
+    #[track_caller]
+    pub fn assert_max_queries(&self, n: usize) -> &Self {
+        let actual = self.queries.len();
+        assert!(
+            actual <= n,
+            "assert_max_queries failed for {method} {path}: expected <= {n} queries, issued {actual}.{report}",
+            method = self.request_method,
+            path = self.request_path,
+            report = self.query_report(),
+        );
+        self
+    }
+
+    /// Assert the request contains no N+1 query pattern, using the app's
+    /// configured `dev.inspector_n_plus_one_threshold` (default 5).
+    ///
+    /// Reuses [`crate::inspector::detect_n_plus_one`]. Panics, naming the
+    /// request and the offending normalized query + repetition count, when a
+    /// single normalized statement was issued at least `threshold` times.
+    ///
+    /// Use [`TestResponse::assert_no_n_plus_one_with_threshold`] to override
+    /// the threshold explicitly.
+    #[track_caller]
+    pub fn assert_no_n_plus_one(&self) -> &Self {
+        self.assert_no_n_plus_one_with_threshold(self.n_plus_one_threshold)
+    }
+
+    /// Like [`TestResponse::assert_no_n_plus_one`] but with an explicit
+    /// repetition `threshold` instead of the configured default.
+    #[track_caller]
+    pub fn assert_no_n_plus_one_with_threshold(&self, threshold: usize) -> &Self {
+        match crate::inspector::detect_n_plus_one(&self.queries, threshold) {
+            Some(w) => panic!(
+                "assert_no_n_plus_one failed for {method} {path}: query repeated {count} times \
+                 (threshold {threshold}):\n  {sql}{report}",
+                method = self.request_method,
+                path = self.request_path,
+                count = w.count,
+                sql = w.sql_template,
+                report = self.query_report(),
+            ),
+            None => self,
+        }
     }
 }
 
@@ -4212,6 +4415,119 @@ mod tests {
             "framework security headers must wrap method-override rejections; \
              observed headers: {:?}",
             response.headers
+        );
+    }
+
+    // ── #1262: query-count / N+1 assertions (pure, no Postgres) ─────────
+    //
+    // These exercise the assertion *logic* on a directly-constructed
+    // `TestResponse`, so they run in the always-on CI lane without a database
+    // — the framework self-test that guarantees the assertions actually fire.
+
+    fn resp_with_queries(sqls: &[&str], threshold: usize) -> TestResponse {
+        TestResponse {
+            queries: sqls
+                .iter()
+                .map(|s| crate::inspector::QueryRecord {
+                    sql: (*s).to_owned(),
+                    params: Vec::new(),
+                    elapsed_ms: 1,
+                    location: String::new(),
+                })
+                .collect(),
+            request_method: "GET".to_owned(),
+            request_path: "/posts".to_owned(),
+            n_plus_one_threshold: threshold,
+            ..Default::default()
+        }
+    }
+
+    fn panic_message(err: &(dyn std::any::Any + Send)) -> String {
+        err.downcast_ref::<String>()
+            .cloned()
+            .or_else(|| err.downcast_ref::<&str>().map(|s| (*s).to_owned()))
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn query_count_and_queries_reflect_captured_list() {
+        let resp = resp_with_queries(&["SELECT 1", "SELECT 2"], 5);
+        assert_eq!(resp.query_count(), 2);
+        assert_eq!(resp.queries().len(), 2);
+        assert_eq!(resp.queries()[0].sql, "SELECT 1");
+    }
+
+    #[test]
+    fn assert_max_queries_passes_at_boundary() {
+        // len == n is within budget and must not panic.
+        resp_with_queries(&["SELECT 1", "SELECT 2"], 5).assert_max_queries(2);
+    }
+
+    #[test]
+    fn assert_max_queries_panics_when_exceeded() {
+        let resp = resp_with_queries(&["SELECT 1", "SELECT 2", "SELECT 3"], 5);
+        let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            resp.assert_max_queries(2);
+        }))
+        .expect_err("assert_max_queries must panic when the query count exceeds the limit");
+        let msg = panic_message(err.as_ref());
+        assert!(
+            msg.contains("GET /posts"),
+            "message names the request: {msg}"
+        );
+        assert!(
+            msg.contains("issued 3"),
+            "message reports the actual count: {msg}"
+        );
+        assert!(msg.contains("<= 2"), "message reports the limit: {msg}");
+    }
+
+    #[test]
+    fn assert_no_n_plus_one_passes_for_distinct_queries() {
+        // Three distinct statements: no normalized template repeats.
+        resp_with_queries(&["SELECT 1", "SELECT 2", "SELECT 3"], 2).assert_no_n_plus_one();
+    }
+
+    #[test]
+    fn assert_no_n_plus_one_panics_on_repetition() {
+        // Same statement modulo whitespace/case, repeated `threshold` times.
+        let resp = resp_with_queries(
+            &[
+                "SELECT * FROM comments WHERE post_id = $1",
+                "SELECT  * FROM comments WHERE post_id = $1",
+                "select * from comments where post_id = $1",
+            ],
+            3,
+        );
+        let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            resp.assert_no_n_plus_one();
+        }))
+        .expect_err("assert_no_n_plus_one must panic on an N+1 pattern");
+        let msg = panic_message(err.as_ref());
+        assert!(msg.contains("GET /posts"), "names the request: {msg}");
+        assert!(
+            msg.contains("3 times"),
+            "reports the repetition count: {msg}"
+        );
+        assert!(
+            msg.contains("select * from comments where post_id = $1"),
+            "reports the normalized SQL template: {msg}"
+        );
+    }
+
+    #[test]
+    fn assert_no_n_plus_one_with_threshold_overrides_default() {
+        // Two identical queries; the configured default threshold (10) does not
+        // fire, but an explicit override of 2 does.
+        let resp = resp_with_queries(&["SELECT 1", "SELECT 1"], 10);
+        resp.assert_no_n_plus_one(); // default threshold 10 -> passes
+        let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            resp.assert_no_n_plus_one_with_threshold(2);
+        }))
+        .expect_err("an explicit threshold override must be honoured");
+        assert!(
+            panic_message(err.as_ref()).contains("2 times"),
+            "override fires at the explicit threshold"
         );
     }
 }

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -132,6 +132,7 @@ mod pg_tls;
 #[cfg(feature = "db")]
 mod preload_scoping;
 mod problem_details;
+mod query_count_asserts;
 mod range;
 mod rate_limit_pipeline;
 mod rate_limit_principal;

--- a/autumn/tests/integration/query_count_asserts.rs
+++ b/autumn/tests/integration/query_count_asserts.rs
@@ -108,14 +108,13 @@ mod query_count_tests {
         resp.assert_max_queries(1).assert_no_n_plus_one();
     }
 
-    /// Finding-2 regression: with `observability.server_timing` enabled the
-    /// router installs `ServerTimingLayer`, whose inner `REQUEST_DB_TIMINGS`
-    /// scope previously SHADOWED the harness's outer capturing accumulator —
-    /// so `take_captured()` came back empty and query assertions silently
-    /// passed at zero. With `scope_inner` reusing the active outer accumulator,
-    /// capture still works AND the `Server-Timing` header is emitted: the flat
-    /// handler's single SELECT is both counted for the header and captured for
-    /// the assertions.
+    /// Regression: with `observability.server_timing` enabled the router
+    /// installs `ServerTimingLayer`, whose inner `REQUEST_DB_TIMINGS` timing
+    /// scope is independent of the harness's `REQUEST_QUERY_CAPTURE` lane. Query
+    /// capture rides that separate task-local, so it is unaffected by however
+    /// the Server-Timing layer scopes (and nests) its per-scope DB metric — the
+    /// flat handler's single SELECT is both counted for the `Server-Timing`
+    /// header AND captured (exactly once) for the assertions.
     #[tokio::test]
     #[ignore = "requires Docker (testcontainers)"]
     async fn server_timing_enabled_still_captures_queries() {

--- a/autumn/tests/integration/query_count_asserts.rs
+++ b/autumn/tests/integration/query_count_asserts.rs
@@ -108,6 +108,61 @@ mod query_count_tests {
         resp.assert_max_queries(1).assert_no_n_plus_one();
     }
 
+    /// Finding-2 regression: with `observability.server_timing` enabled the
+    /// router installs `ServerTimingLayer`, whose inner `REQUEST_DB_TIMINGS`
+    /// scope previously SHADOWED the harness's outer capturing accumulator —
+    /// so `take_captured()` came back empty and query assertions silently
+    /// passed at zero. With `scope_inner` reusing the active outer accumulator,
+    /// capture still works AND the `Server-Timing` header is emitted: the flat
+    /// handler's single SELECT is both counted for the header and captured for
+    /// the assertions.
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn server_timing_enabled_still_captures_queries() {
+        use autumn_web::config::AutumnConfig;
+
+        let db = TestDb::shared().await;
+        setup(db).await;
+
+        let mut config = AutumnConfig {
+            profile: Some("test".into()),
+            ..AutumnConfig::default()
+        };
+        config.security.csrf.enabled = false;
+        // Force the Server-Timing layer on (off by default in the test profile).
+        config.observability.server_timing = Some(true);
+
+        let client = TestApp::new()
+            .config(config)
+            .routes(routes![posts_flat])
+            .with_db(db.pool())
+            .build();
+
+        let resp = client.get("/posts-flat").send().await;
+        resp.assert_ok();
+
+        // The Server-Timing layer is active: it must have stamped the header,
+        // including the `db` metric for the one counted query.
+        let server_timing = resp
+            .header("server-timing")
+            .expect("server_timing enabled must emit a Server-Timing header")
+            .to_owned();
+        assert!(
+            server_timing.contains("db;dur="),
+            "the db metric should surface the counted query: {server_timing:?}"
+        );
+
+        // Crucially, query CAPTURE must still work despite the layer's inner
+        // scope — this is the regression the reuse fix guards.
+        assert_eq!(
+            resp.query_count(),
+            1,
+            "server_timing must not zero out captured queries, got: {:?}",
+            resp.queries()
+        );
+        resp.assert_max_queries(1).assert_no_n_plus_one();
+    }
+
     #[tokio::test]
     #[ignore = "requires Docker (testcontainers)"]
     async fn n_plus_one_handler_trips_assertion() {

--- a/autumn/tests/integration/query_count_asserts.rs
+++ b/autumn/tests/integration/query_count_asserts.rs
@@ -1,0 +1,150 @@
+//! Integration tests for #1262: automatic capture of a request's SQL query
+//! list and the `TestResponse` query-count / N+1 assertions built on it.
+//!
+//! Capture requires **zero** manual interceptor wiring: driving a request with
+//! `TestClient` against a real Postgres pool (`with_db`) is enough for
+//! `TestResponse::query_count` / `assert_max_queries` / `assert_no_n_plus_one`
+//! to see every statement the handler issued.
+//!
+//! Requires Docker (testcontainers), so both tests are `#[ignore]`d and run in
+//! CI with:
+//!
+//!     cargo test -p autumn-web --test integration_tests -- --include-ignored query_count
+
+#[cfg(all(feature = "db", feature = "test-support"))]
+mod query_count_tests {
+    use autumn_web::prelude::*;
+    use autumn_web::test::{TestApp, TestDb};
+    use diesel::prelude::*;
+    use diesel_async::RunQueryDsl;
+
+    diesel::table! {
+        qc_posts (id) {
+            id -> Int8,
+            title -> Text,
+        }
+    }
+
+    #[derive(Debug, Queryable, Selectable)]
+    #[diesel(table_name = qc_posts)]
+    struct Post {
+        pub id: i64,
+        pub title: String,
+    }
+
+    /// Issues exactly one application query: a single `SELECT` over all posts.
+    #[get("/posts-flat")]
+    async fn posts_flat(mut db: Db) -> AutumnResult<Json<usize>> {
+        let posts = qc_posts::table
+            .select(Post::as_select())
+            .load(&mut *db)
+            .await?;
+        Ok(Json(posts.len()))
+    }
+
+    /// Classic N+1: one `SELECT` for the list, then one `SELECT` per row. The
+    /// per-row statement normalizes to a single template repeated once per row.
+    #[get("/posts-n-plus-one")]
+    async fn posts_n_plus_one(mut db: Db) -> AutumnResult<Json<usize>> {
+        let posts = qc_posts::table
+            .select(Post::as_select())
+            .load(&mut *db)
+            .await?;
+        let mut total = 0usize;
+        for p in &posts {
+            let one: Post = qc_posts::table
+                .filter(qc_posts::id.eq(p.id))
+                .select(Post::as_select())
+                .first(&mut *db)
+                .await?;
+            total += one.title.len();
+        }
+        Ok(Json(total))
+    }
+
+    static SETUP: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
+
+    async fn setup(db: &TestDb) {
+        SETUP
+            .get_or_init(|| async {
+                db.execute_sql(
+                    "CREATE TABLE IF NOT EXISTS qc_posts (
+                        id BIGSERIAL PRIMARY KEY,
+                        title TEXT NOT NULL
+                    )",
+                )
+                .await;
+                db.execute_sql("DELETE FROM qc_posts").await;
+                db.execute_sql(
+                    "INSERT INTO qc_posts (title) VALUES ('a'),('bb'),('ccc'),('dddd'),('eeeee')",
+                )
+                .await;
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn flat_handler_query_count_and_max_queries() {
+        let db = TestDb::shared().await;
+        setup(db).await;
+
+        let client = TestApp::new()
+            .routes(routes![posts_flat])
+            .with_db(db.pool())
+            .build();
+
+        let resp = client.get("/posts-flat").send().await;
+        resp.assert_ok();
+
+        // The housekeeping `SET statement_timeout` at checkout is excluded, so
+        // the flat handler's single SELECT is the only counted query.
+        assert_eq!(
+            resp.query_count(),
+            1,
+            "flat handler issues exactly one application query, got: {:?}",
+            resp.queries()
+        );
+        resp.assert_max_queries(1).assert_no_n_plus_one();
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn n_plus_one_handler_trips_assertion() {
+        let db = TestDb::shared().await;
+        setup(db).await;
+
+        let client = TestApp::new()
+            .routes(routes![posts_n_plus_one])
+            .with_db(db.pool())
+            .build();
+
+        let resp = client.get("/posts-n-plus-one").send().await;
+        resp.assert_ok();
+
+        // 1 list query + 5 per-row queries = 6 counted statements.
+        assert_eq!(
+            resp.query_count(),
+            6,
+            "captured queries: {:?}",
+            resp.queries()
+        );
+
+        // The default dev threshold is 5; the per-row template repeats 5 times,
+        // so `assert_no_n_plus_one` must fire, naming the request.
+        let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            resp.assert_no_n_plus_one();
+        }))
+        .expect_err("the N+1 handler must trip assert_no_n_plus_one");
+        let msg = err
+            .downcast_ref::<String>()
+            .cloned()
+            .or_else(|| err.downcast_ref::<&str>().map(|s| (*s).to_owned()))
+            .unwrap_or_default();
+        assert!(
+            msg.contains("GET /posts-n-plus-one"),
+            "failure names the request: {msg}"
+        );
+        assert!(msg.contains("5 times"), "failure reports the count: {msg}");
+    }
+}


### PR DESCRIPTION
**Before:** N+1 query explosions could only be spotted by eyeballing the dev-mode request inspector in a browser — there was no way to lock a fix in so CI fails when someone reintroduces the regression.

**After:** A handler test can assert its query budget in a couple of lines with zero interceptor wiring:
```rust
let resp = app.get("/posts").send().await;
resp.assert_status(200)
    .assert_max_queries(3)
    .assert_no_n_plus_one();
```
New `TestResponse` methods: `query_count()`, `queries()`, `assert_max_queries(n)`, `assert_no_n_plus_one()`, `assert_no_n_plus_one_with_threshold(n)`. Failing assertions name the request (method + path) and print the query list plus per-normalized-statement counts.

**How:** Reuses the diesel `Instrumentation` seam added for Server-Timing (`RequestQueryTimer` in `autumn/src/db.rs`) rather than adding a second instrumentation path. `RequestDbTimings` gains an opt-in capture list (default off — prod/dev pay nothing); the timer already materializes each statement's SQL to filter housekeeping statements, so it now retains it as an `inspector::QueryRecord` when a test opts in. `TestApp::send()` scopes the `REQUEST_DB_TIMINGS` task-local around the handler future and reads the captured queries into `TestResponse`. N+1 detection reuses the shipped `inspector::detect_n_plus_one`; the default threshold comes from `dev.inspector_n_plus_one_threshold` (default 5). Scope is single-request; queries from spawned after-commit callbacks are intentionally out of scope.

**Testing:** Pure assertion-logic unit tests (no DB) run in CI: boundary pass/panic for `assert_max_queries`, N+1 detection + threshold override, and `query_count()`/`queries()` — all green (`cargo test -p autumn-web --lib`: 3364 passed). A Docker/testcontainers Postgres end-to-end test (`autumn/tests/integration/query_count_asserts.rs`) exercises real query capture — an N+1 handler trips the assertion and a flat handler passes its budget; it's `#[ignore]`d/cfg-gated like the other testcontainer tests and runs in the DB CI job.

Closes #1262

---
_Generated by [Claude Code](https://claude.ai/code/session_017cHvCNDR58B1GHdm54TbSe)_