### PR TITLE
Add opt-in versioned job payloads with upgrade path (Closes #1205)

### DIFF
--- a/autumn-macros/src/job.rs
+++ b/autumn-macros/src/job.rs
@@ -347,6 +347,30 @@ pub fn job_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         },
     );
 
+    // Decode side (issue #1205). An opt-in (versioned) job decodes through the
+    // version-aware path, so a version/shape mismatch surfaces the precise
+    // `JobPayloadVersionError` naming the job type + versions. A default
+    // (unversioned) job keeps the exact pre-#1205 `from_value` path and error
+    // wording, guaranteeing zero behavior change for apps that never declare a
+    // version — and matching that its enqueue side stores raw args.
+    let decode_args = if should_wrap {
+        quote! {
+            let __autumn_upgrade: ::core::option::Option<::autumn_web::payload_version::UpgradeFn> = #upgrade_opt;
+            let args: #args_type = ::autumn_web::payload_version::decode_versioned(
+                #job_name,
+                #version,
+                __autumn_upgrade,
+                payload,
+            )
+                .map_err(|e| ::autumn_web::AutumnError::internal_server_error(::std::io::Error::other(e.to_string())))?;
+        }
+    } else {
+        quote! {
+            let args: #args_type = ::autumn_web::reexports::serde_json::from_value(payload)
+                .map_err(|e| ::autumn_web::AutumnError::internal_server_error(::std::io::Error::other(format!("job args deserialization failed: {e}"))))?;
+        }
+    };
+
     let handler_call = if takes_context {
         quote! { #fn_name(state, args, ::autumn_web::job::JobContext::current()).await }
     } else {
@@ -421,23 +445,10 @@ pub fn job_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 queue: #queue.to_string(),
                 uniqueness: #uniqueness,
                 concurrency: #concurrency,
+                version: #version,
                 handler: |state: ::autumn_web::AppState, payload: ::autumn_web::reexports::serde_json::Value| {
                     Box::pin(async move {
-                        // Version-aware decode (issue #1205): reads the stored
-                        // schema version (missing marker → 1), applies the
-                        // declared upgrade chain, then deserializes. A
-                        // version/shape mismatch surfaces the precise
-                        // `JobPayloadVersionError` (naming job type + versions)
-                        // rather than a generic serde error, so the dead-letter
-                        // record is self-diagnosing.
-                        let __autumn_upgrade: ::core::option::Option<::autumn_web::payload_version::UpgradeFn> = #upgrade_opt;
-                        let args: #args_type = ::autumn_web::payload_version::decode_versioned(
-                            #job_name,
-                            #version,
-                            __autumn_upgrade,
-                            payload,
-                        )
-                            .map_err(|e| ::autumn_web::AutumnError::internal_server_error(::std::io::Error::other(e.to_string())))?;
+                        #decode_args
                         #handler_call
                     })
                 },

--- a/autumn-macros/src/job.rs
+++ b/autumn-macros/src/job.rs
@@ -19,6 +19,11 @@ struct JobAttrs {
     unique_for_ms: Option<u64>,
     concurrency: Option<u32>,
     concurrency_key: Option<String>,
+    /// Declared schema version for this job's payload (issue #1205).
+    /// `None` = version 1 (un-versioned).
+    version: Option<u32>,
+    /// Optional payload-upgrade hook `fn(u32, Value) -> Result<Value, E>`.
+    upgrade: Option<syn::Path>,
 }
 
 fn parse_basic_arg(
@@ -48,6 +53,16 @@ fn parse_basic_arg(
             ));
         }
         result.queue = Some(queue);
+    } else if meta.path.is_ident("version") {
+        let value: LitInt = meta.value()?.parse()?;
+        let version = value.base10_parse::<u32>()?;
+        if version == 0 {
+            return Err(meta.error("version must be greater than zero"));
+        }
+        result.version = Some(version);
+    } else if meta.path.is_ident("upgrade") {
+        let value: syn::Path = meta.value()?.parse()?;
+        result.upgrade = Some(value);
     } else {
         return Ok(false);
     }
@@ -169,6 +184,8 @@ fn parse_job_args(attr: TokenStream) -> syn::Result<JobAttrs> {
         unique_for_ms: None,
         concurrency: None,
         concurrency_key: None,
+        version: None,
+        upgrade: None,
     };
 
     syn::meta::parser(|meta| {
@@ -180,7 +197,8 @@ fn parse_job_args(attr: TokenStream) -> syn::Result<JobAttrs> {
         } else {
             Err(meta.error(
                 "unsupported attribute: expected name, max_attempts, backoff_ms, queue, unique, \
-                 unique_by, unique_window, unique_for_ms, concurrency, or concurrency_key",
+                 unique_by, unique_window, unique_for_ms, concurrency, concurrency_key, version, \
+                 or upgrade",
             ))
         }
     })
@@ -300,6 +318,24 @@ pub fn job_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     let uniqueness = uniqueness_tokens(&attrs);
     let concurrency = concurrency_tokens(&attrs);
 
+    // ── Versioned payloads (issue #1205) ─────────────────────────────────────
+    // Wrap args in the schema-version envelope only when the job opts in
+    // (declares version > 1 or an upgrade hook); otherwise store raw args so
+    // un-versioned jobs are byte-identical to pre-#1205 behavior.
+    let version = attrs.version.unwrap_or(1);
+    let should_wrap = version > 1 || attrs.upgrade.is_some();
+    let wrap_payload = if should_wrap {
+        quote! { let payload = ::autumn_web::payload_version::wrap(#version, payload); }
+    } else {
+        quote! {}
+    };
+    let upgrade_opt = attrs.upgrade.as_ref().map_or_else(
+        || quote! { ::core::option::Option::None },
+        |path| {
+            quote! { ::core::option::Option::Some(#path as ::autumn_web::payload_version::UpgradeFn) }
+        },
+    );
+
     let handler_call = if takes_context {
         quote! { #fn_name(state, args, ::autumn_web::job::JobContext::current()).await }
     } else {
@@ -318,6 +354,7 @@ pub fn job_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             pub async fn enqueue(args: #args_type) -> ::autumn_web::AutumnResult<()> {
                 let payload = ::autumn_web::reexports::serde_json::to_value(&args)
                     .map_err(|e| ::autumn_web::AutumnError::internal_server_error(::std::io::Error::other(format!("job args serialization failed: {e}"))))?;
+                #wrap_payload
                 ::autumn_web::job::enqueue(#job_name, payload).await
             }
 
@@ -325,6 +362,7 @@ pub fn job_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             pub async fn enqueue_in(args: #args_type, delay: ::core::time::Duration) -> ::autumn_web::AutumnResult<()> {
                 let payload = ::autumn_web::reexports::serde_json::to_value(&args)
                     .map_err(|e| ::autumn_web::AutumnError::internal_server_error(::std::io::Error::other(format!("job args serialization failed: {e}"))))?;
+                #wrap_payload
                 ::autumn_web::job::enqueue_in(#job_name, payload, delay).await
             }
 
@@ -335,6 +373,7 @@ pub fn job_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             ) -> ::autumn_web::AutumnResult<()> {
                 let payload = ::autumn_web::reexports::serde_json::to_value(&args)
                     .map_err(|e| ::autumn_web::AutumnError::internal_server_error(::std::io::Error::other(format!("job args serialization failed: {e}"))))?;
+                #wrap_payload
                 ::autumn_web::job::enqueue_at(#job_name, payload, when).await
             }
 
@@ -344,6 +383,7 @@ pub fn job_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             pub async fn enqueue_tracked(args: #args_type) -> ::autumn_web::AutumnResult<::autumn_web::job::TrackedJobHandle> {
                 let payload = ::autumn_web::reexports::serde_json::to_value(&args)
                     .map_err(|e| ::autumn_web::AutumnError::internal_server_error(::std::io::Error::other(format!("job args serialization failed: {e}"))))?;
+                #wrap_payload
                 ::autumn_web::job::enqueue_tracked(#job_name, payload).await
             }
 
@@ -356,6 +396,7 @@ pub fn job_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             ) -> ::autumn_web::AutumnResult<::autumn_web::job::TrackedJobHandle> {
                 let payload = ::autumn_web::reexports::serde_json::to_value(&args)
                     .map_err(|e| ::autumn_web::AutumnError::internal_server_error(::std::io::Error::other(format!("job args serialization failed: {e}"))))?;
+                #wrap_payload
                 ::autumn_web::job::enqueue_tracked_for(#job_name, payload, owner).await
             }
         }
@@ -371,8 +412,21 @@ pub fn job_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 concurrency: #concurrency,
                 handler: |state: ::autumn_web::AppState, payload: ::autumn_web::reexports::serde_json::Value| {
                     Box::pin(async move {
-                        let args: #args_type = ::autumn_web::reexports::serde_json::from_value(payload)
-                            .map_err(|e| ::autumn_web::AutumnError::internal_server_error(::std::io::Error::other(format!("job args deserialization failed: {e}"))))?;
+                        // Version-aware decode (issue #1205): reads the stored
+                        // schema version (missing marker → 1), applies the
+                        // declared upgrade chain, then deserializes. A
+                        // version/shape mismatch surfaces the precise
+                        // `JobPayloadVersionError` (naming job type + versions)
+                        // rather than a generic serde error, so the dead-letter
+                        // record is self-diagnosing.
+                        let __autumn_upgrade: ::core::option::Option<::autumn_web::payload_version::UpgradeFn> = #upgrade_opt;
+                        let args: #args_type = ::autumn_web::payload_version::decode_versioned(
+                            #job_name,
+                            #version,
+                            __autumn_upgrade,
+                            payload,
+                        )
+                            .map_err(|e| ::autumn_web::AutumnError::internal_server_error(::std::io::Error::other(e.to_string())))?;
                         #handler_call
                     })
                 },
@@ -399,6 +453,23 @@ mod tests {
         assert_eq!(attrs.backoff_ms, Some(10));
         assert_eq!(attrs.unique, None);
         assert!(attrs.concurrency.is_none());
+    }
+
+    #[test]
+    fn parses_version_and_upgrade_attrs() {
+        let attrs = parse(quote! { version = 2, upgrade = crate::jobs::upgrade_welcome })
+            .expect("parse");
+        assert_eq!(attrs.version, Some(2));
+        let upgrade = attrs.upgrade.expect("upgrade path parsed");
+        assert!(quote!(#upgrade).to_string().contains("upgrade_welcome"));
+    }
+
+    #[test]
+    fn version_defaults_to_none_and_zero_is_rejected() {
+        let attrs = parse(quote! { name = "j" }).expect("parse");
+        assert_eq!(attrs.version, None);
+        assert!(attrs.upgrade.is_none());
+        assert!(parse(quote! { version = 0 }).is_err(), "zero version rejected");
     }
 
     #[test]

--- a/autumn-macros/src/job.rs
+++ b/autumn-macros/src/job.rs
@@ -156,6 +156,17 @@ fn validate_job_attrs(result: &mut JobAttrs) -> syn::Result<()> {
             "concurrency_key requires concurrency = N",
         ));
     }
+    // An `upgrade` hook is only ever invoked when the stored version is *older*
+    // than the current one, i.e. `version >= 2`. With `version` unset (1) the
+    // decode path never enters the upgrade loop, so the hook would be dead code
+    // while enqueue still paid to wrap the payload — a silent footgun. Reject it.
+    if result.upgrade.is_some() && result.version.unwrap_or(1) < 2 {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "`upgrade` requires `version >= 2` (an upgrade hook only runs when a \
+             stored payload is older than the current version)",
+        ));
+    }
     let uniqueness_configured = result.unique_by.is_some()
         || result.unique_window.is_some()
         || result.unique_for_ms.is_some();
@@ -457,8 +468,8 @@ mod tests {
 
     #[test]
     fn parses_version_and_upgrade_attrs() {
-        let attrs = parse(quote! { version = 2, upgrade = crate::jobs::upgrade_welcome })
-            .expect("parse");
+        let attrs =
+            parse(quote! { version = 2, upgrade = crate::jobs::upgrade_welcome }).expect("parse");
         assert_eq!(attrs.version, Some(2));
         let upgrade = attrs.upgrade.expect("upgrade path parsed");
         assert!(quote!(#upgrade).to_string().contains("upgrade_welcome"));
@@ -469,7 +480,29 @@ mod tests {
         let attrs = parse(quote! { name = "j" }).expect("parse");
         assert_eq!(attrs.version, None);
         assert!(attrs.upgrade.is_none());
-        assert!(parse(quote! { version = 0 }).is_err(), "zero version rejected");
+        assert!(
+            parse(quote! { version = 0 }).is_err(),
+            "zero version rejected"
+        );
+    }
+
+    #[test]
+    fn upgrade_requires_version_at_least_2() {
+        // An upgrade hook only fires when a stored payload is older than the
+        // current version, so `upgrade` without `version >= 2` is dead code and
+        // must be a compile error rather than a silent no-op.
+        let err = parse(quote! { upgrade = crate::jobs::up })
+            .err()
+            .expect("upgrade without version must be rejected");
+        assert!(err.to_string().contains("version >= 2"), "{err}");
+
+        let err = parse(quote! { version = 1, upgrade = crate::jobs::up })
+            .err()
+            .expect("upgrade with version = 1 must be rejected");
+        assert!(err.to_string().contains("version >= 2"), "{err}");
+
+        // version >= 2 with an upgrade hook is accepted.
+        assert!(parse(quote! { version = 2, upgrade = crate::jobs::up }).is_ok());
     }
 
     #[test]

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -3831,6 +3831,7 @@ mod tests {
         let shutdown = tokio_util::sync::CancellationToken::new();
         crate::job::start_runtime(
             vec![crate::job::JobInfo {
+                version: 1,
                 name: "autumn_webhook_delivery".to_string(),
                 max_attempts: 1,
                 initial_backoff_ms: 1,
@@ -3906,6 +3907,7 @@ mod tests {
         let shutdown = tokio_util::sync::CancellationToken::new();
         crate::job::start_runtime(
             vec![crate::job::JobInfo {
+                version: 1,
                 name: "autumn_webhook_delivery".to_string(),
                 max_attempts: 1,
                 initial_backoff_ms: 1,

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -8734,6 +8734,7 @@ mod tests {
 
         let builder = app()
             .jobs(vec![crate::job::JobInfo {
+                version: 1,
                 name: "startup-seed".to_string(),
                 max_attempts: 1,
                 initial_backoff_ms: 1,
@@ -8794,6 +8795,7 @@ mod tests {
 
         let error = initialize_job_runtime(
             vec![crate::job::JobInfo {
+                version: 1,
                 name: "startup-seed".to_string(),
                 max_attempts: 1,
                 initial_backoff_ms: 1,

--- a/autumn/src/events.rs
+++ b/autumn/src/events.rs
@@ -152,6 +152,7 @@ impl EventRegistry {
                 queue: "default".to_string(),
                 uniqueness: None,
                 concurrency: None,
+                version: 1,
                 handler: listener.handler,
             })
             .collect()

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -1258,6 +1258,7 @@ fn is_final_attempt<T: PartialOrd>(attempt: &T, max_attempts: &T) -> bool {
 /// stable hash of the full canonicalized payload.
 fn job_unique_key(uniqueness: &JobUniqueness, payload: &Value) -> String {
     let (_, payload) = crate::job_tracking::split_tracked_payload(payload);
+    let (_, payload) = crate::payload_version::split_version(payload);
     if uniqueness.by.is_empty() {
         let mut canonical = String::new();
         write_canonical_json(payload, &mut canonical);
@@ -1283,6 +1284,7 @@ fn job_unique_key(uniqueness: &JobUniqueness, payload: &Value) -> String {
 /// payloads lacking the field share one scope.
 fn job_concurrency_scope(concurrency: &JobConcurrency, payload: &Value) -> Option<String> {
     let (_, payload) = crate::job_tracking::split_tracked_payload(payload);
+    let (_, payload) = crate::payload_version::split_version(payload);
     concurrency.key.as_ref().map(|field| {
         let mut scope = String::new();
         write_canonical_json(payload.get(field).unwrap_or(&Value::Null), &mut scope);
@@ -1292,6 +1294,7 @@ fn job_concurrency_scope(concurrency: &JobConcurrency, payload: &Value) -> Optio
 
 fn job_payload_identity(payload: &Value) -> (Option<String>, Option<String>) {
     let (_, payload) = crate::job_tracking::split_tracked_payload(payload);
+    let (_, payload) = crate::payload_version::split_version(payload);
     let principal = first_payload_string(payload, &["principal_id", "principal", "user_id"]);
     let correlation = first_payload_string(payload, &["correlation_id", "request_id"]);
     (principal, correlation)
@@ -11494,6 +11497,54 @@ mod tests {
 
         let (principal, _) = job_payload_identity(&wrapped);
         assert_eq!(principal.as_deref(), Some("user:7"));
+    }
+
+    #[test]
+    fn job_unique_key_and_identity_strip_the_version_envelope() {
+        // A v1 job (raw args) and its versioned re-encoding must hash
+        // identically so dedup still coalesces across a deploy that starts
+        // wrapping payloads.
+        let inner = serde_json::json!({"account_id": 42, "principal_id": "user:7"});
+        let versioned = crate::payload_version::wrap(2, inner.clone());
+
+        let uniqueness = JobUniqueness {
+            by: Vec::new(),
+            window: JobUniquenessWindow::Running,
+        };
+        assert_eq!(
+            job_unique_key(&uniqueness, &versioned),
+            job_unique_key(&uniqueness, &inner),
+            "the version envelope must not change the derived unique key"
+        );
+
+        let by_field = JobUniqueness {
+            by: vec!["account_id".to_string()],
+            window: JobUniquenessWindow::Running,
+        };
+        assert_eq!(
+            job_unique_key(&by_field, &versioned),
+            job_unique_key(&by_field, &inner)
+        );
+
+        let concurrency = JobConcurrency {
+            limit: 1,
+            key: Some("account_id".to_string()),
+        };
+        assert_eq!(
+            job_concurrency_scope(&concurrency, &versioned),
+            job_concurrency_scope(&concurrency, &inner)
+        );
+
+        let (principal, _) = job_payload_identity(&versioned);
+        assert_eq!(principal.as_deref(), Some("user:7"));
+
+        // Composition: a tracked + versioned payload strips both envelopes.
+        let tracked_versioned = crate::job_tracking::wrap_tracked_payload("h", &versioned);
+        assert_eq!(
+            job_unique_key(&uniqueness, &tracked_versioned),
+            job_unique_key(&uniqueness, &inner),
+            "tracked + versioned must strip both envelopes for key derivation"
+        );
     }
 
     #[tokio::test]

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -11551,6 +11551,26 @@ mod tests {
         );
     }
 
+    #[test]
+    fn job_unique_key_hashes_whole_payload_when_marker_field_is_not_an_envelope() {
+        // A raw (unversioned) payload that legitimately carries a top-level
+        // `__autumn_schema_version` field is NOT a version envelope (Codex #1205
+        // collision fix): key derivation must hash the WHOLE object, so two such
+        // payloads differing only in a sibling field get distinct keys rather
+        // than both collapsing onto a stripped `args` subtree.
+        let uniqueness = JobUniqueness {
+            by: Vec::new(),
+            window: JobUniquenessWindow::Running,
+        };
+        let a = serde_json::json!({"__autumn_schema_version": 5, "other": 1});
+        let b = serde_json::json!({"__autumn_schema_version": 5, "other": 2});
+        assert_ne!(
+            job_unique_key(&uniqueness, &a),
+            job_unique_key(&uniqueness, &b),
+            "a marker field without the exact envelope shape must not be stripped"
+        );
+    }
+
     #[tokio::test]
     async fn deduplicated_tracked_enqueue_fails_new_token_with_duplicate_message() {
         let _guard = global_job_runtime_test_lock().lock().await;

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -92,6 +92,13 @@ pub struct JobInfo {
     pub uniqueness: Option<JobUniqueness>,
     /// In-flight concurrency cap; `None` means unbounded per-type concurrency.
     pub concurrency: Option<JobConcurrency>,
+    /// Declared payload schema version (issue #1205). Defaults to `1`. When it
+    /// is `> 1` every enqueue path wraps the args in the version envelope so a
+    /// deploy that changes the args struct can upgrade in-flight payloads. This
+    /// is threaded into `JobRuntimeSettings` so the name-keyed enqueue
+    /// chokepoints (including the transactional free functions) can wrap by
+    /// looking the version up from the registry.
+    pub version: u32,
     /// The async function that executes the job logic.
     pub handler: JobHandler,
 }
@@ -112,6 +119,7 @@ impl JobInfo {
             queue: "default".to_string(),
             uniqueness: None,
             concurrency: None,
+            version: 1,
             handler,
         }
     }
@@ -275,6 +283,10 @@ struct JobRuntimeSettings {
     queue: String,
     uniqueness: Option<JobUniqueness>,
     concurrency: Option<JobConcurrency>,
+    /// Declared payload schema version (issue #1205), copied from
+    /// [`JobInfo::version`]. `0` (the `Default`) and `1` both mean "unversioned"
+    /// so the enqueue chokepoints only wrap when `version > 1`.
+    version: u32,
 }
 
 #[cfg(test)]
@@ -2549,6 +2561,12 @@ impl JobClient {
         // transaction has already committed — by then it's too late for the
         // caller to roll back on a rejected payload.
         crate::job_tracking::reject_reserved_envelope_marker(&payload)?;
+        // Apply the schema-version envelope (issue #1205) here — the one
+        // after-commit chokepoint — so all three `*_after_commit` typed-args
+        // entry points wrap. This runs BEFORE the deferred `enqueue_due` (which
+        // never wraps), and the generated `#[job]` methods never reach this
+        // chokepoint, so there is no double-wrap.
+        let payload = self.wrap_payload_version(&name, payload);
         let client = self.clone();
         // Keep a copy for the debug log in the eager path (name is moved into f_opt).
         let name_for_log = name.clone();
@@ -2591,6 +2609,21 @@ impl JobClient {
         }
 
         Ok(())
+    }
+
+    /// Wrap `payload` in the schema-version envelope (issue #1205) when the
+    /// named job declares `version > 1`, resolving the version from the
+    /// name-keyed runtime settings. A no-op (raw args passed through) for
+    /// unversioned jobs or an unregistered name — registration is validated
+    /// separately by each caller. Used by the transactional after-commit
+    /// chokepoint, whose typed-args entry points would otherwise store raw args.
+    fn wrap_payload_version(&self, name: &str, payload: Value) -> Value {
+        match self.per_job_settings.get(name) {
+            Some(settings) if settings.version > 1 => {
+                crate::payload_version::wrap(settings.version, payload)
+            }
+            _ => payload,
+        }
     }
 
     /// Mark a coalesced enqueue in the registry counters and admin record.
@@ -2770,6 +2803,19 @@ impl JobClient {
             self.default_initial_backoff_ms
         };
         let job_queue = normalize_queue_name(&settings.queue);
+        // Apply the schema-version envelope (issue #1205) here — the shared
+        // transactional-DB chokepoint for `enqueue_on_conn`, `enqueue_at_on_conn`,
+        // `enqueue_in_on_conn`, and `enqueue_in_tx` (plus any direct
+        // `JobClient::enqueue_on_conn*` call). The generated `#[job]` methods
+        // funnel through `enqueue`/`enqueue_due`, never here, so their
+        // already-wrapped payload can never be double-wrapped. Wrap before
+        // constraint resolution — the unique/concurrency keys strip the version
+        // envelope, so a v1 job and its versioned re-encoding still coalesce.
+        let payload = if settings.version > 1 {
+            crate::payload_version::wrap(settings.version, payload)
+        } else {
+            payload
+        };
         let constraints = ResolvedJobConstraints::for_payload(settings, &payload);
         let id = uuid::Uuid::new_v4().to_string();
 
@@ -7421,6 +7467,7 @@ fn build_per_job_settings(jobs: &[JobInfo]) -> HashMap<String, JobRuntimeSetting
                     queue: normalize_queue_name(&job.queue),
                     uniqueness: job.uniqueness.clone(),
                     concurrency: job.concurrency.clone(),
+                    version: job.version,
                 },
             )
         })
@@ -8181,6 +8228,7 @@ mod tests {
         let shutdown = tokio_util::sync::CancellationToken::new();
         start_local_runtime(
             vec![JobInfo {
+                version: 1,
                 name: "noop".to_string(),
                 max_attempts: 3,
                 initial_backoff_ms: 10,
@@ -8223,6 +8271,7 @@ mod tests {
         let shutdown = tokio_util::sync::CancellationToken::new();
         start_local_runtime(
             vec![JobInfo {
+                version: 1,
                 name: "delayed".to_string(),
                 max_attempts: 3,
                 initial_backoff_ms: 10,
@@ -8280,6 +8329,7 @@ mod tests {
         let shutdown = tokio_util::sync::CancellationToken::new();
         start_local_runtime(
             vec![JobInfo {
+                version: 1,
                 name: "past".to_string(),
                 max_attempts: 3,
                 initial_backoff_ms: 10,
@@ -8323,6 +8373,7 @@ mod tests {
         let shutdown = tokio_util::sync::CancellationToken::new();
         start_local_runtime(
             vec![JobInfo {
+                version: 1,
                 name: "cancelable".to_string(),
                 max_attempts: 3,
                 initial_backoff_ms: 10,
@@ -8500,6 +8551,7 @@ mod tests {
         let shutdown = tokio_util::sync::CancellationToken::new();
         start_local_runtime(
             vec![JobInfo {
+                version: 1,
                 name: "noop".to_string(),
                 max_attempts: 3,
                 initial_backoff_ms: 10,
@@ -8542,6 +8594,7 @@ mod tests {
         jobs.insert(
             "panic".to_string(),
             JobInfo {
+                version: 1,
                 name: "panic".to_string(),
                 max_attempts: 3,
                 initial_backoff_ms: 1,
@@ -8602,6 +8655,7 @@ mod tests {
         jobs.insert(
             "flaky".to_string(),
             JobInfo {
+                version: 1,
                 name: "flaky".to_string(),
                 max_attempts: 2,
                 initial_backoff_ms: 1,
@@ -8664,6 +8718,7 @@ mod tests {
         jobs.insert(
             "flaky".to_string(),
             JobInfo {
+                version: 1,
                 name: "flaky".to_string(),
                 max_attempts: 1,
                 initial_backoff_ms: 1,
@@ -8721,6 +8776,7 @@ mod tests {
         jobs.insert(
             "flaky".to_string(),
             JobInfo {
+                version: 1,
                 name: "flaky".to_string(),
                 max_attempts: 2,
                 initial_backoff_ms: 60_000,
@@ -10707,6 +10763,7 @@ mod tests {
         let shutdown = tokio_util::sync::CancellationToken::new();
         start_local_runtime(
             vec![JobInfo {
+                version: 1,
                 name: "known".to_string(),
                 max_attempts: 3,
                 initial_backoff_ms: 10,
@@ -10758,6 +10815,7 @@ mod tests {
         let error = start_runtime(
             vec![
                 JobInfo {
+                    version: 1,
                     name: "dupe".to_string(),
                     max_attempts: 1,
                     initial_backoff_ms: 1,
@@ -10767,6 +10825,7 @@ mod tests {
                     handler: |_state, _payload| Box::pin(async move { Ok(()) }),
                 },
                 JobInfo {
+                    version: 1,
                     name: "dupe".to_string(),
                     max_attempts: 1,
                     initial_backoff_ms: 1,
@@ -10806,6 +10865,7 @@ mod tests {
 
         let error = start_runtime(
             vec![JobInfo {
+                version: 1,
                 name: "known".to_string(),
                 max_attempts: 1,
                 initial_backoff_ms: 1,
@@ -12252,6 +12312,7 @@ mod tests {
 
             let error = start_runtime(
                 vec![JobInfo {
+                    version: 1,
                     name: "test_job".to_string(),
                     max_attempts: 1,
                     initial_backoff_ms: 1,
@@ -14581,6 +14642,7 @@ mod tests {
         let shutdown = tokio_util::sync::CancellationToken::new();
         start_local_runtime(
             vec![JobInfo {
+                version: 1,
                 name: "unique_cancelable".to_string(),
                 max_attempts: 1,
                 initial_backoff_ms: 10,
@@ -15084,6 +15146,7 @@ mod uniqueness_concurrency_tests {
 
     fn unique_job(name: &str, window: JobUniquenessWindow, handler: JobHandler) -> JobInfo {
         JobInfo {
+            version: 1,
             name: name.to_string(),
             max_attempts: 1,
             initial_backoff_ms: 1,
@@ -15498,6 +15561,7 @@ mod uniqueness_concurrency_tests {
         let shutdown = tokio_util::sync::CancellationToken::new();
         start_local_runtime(
             vec![JobInfo {
+                version: 1,
                 name: "unique_by_field".to_string(),
                 max_attempts: 1,
                 initial_backoff_ms: 1,
@@ -15578,6 +15642,7 @@ mod uniqueness_concurrency_tests {
         let shutdown = tokio_util::sync::CancellationToken::new();
         start_local_runtime(
             vec![JobInfo {
+                version: 1,
                 name: "recalculate".to_string(),
                 max_attempts: 1,
                 initial_backoff_ms: 1,
@@ -15662,6 +15727,7 @@ mod uniqueness_concurrency_tests {
         let shutdown = tokio_util::sync::CancellationToken::new();
         start_local_runtime(
             vec![JobInfo {
+                version: 1,
                 name: "per_account".to_string(),
                 max_attempts: 1,
                 initial_backoff_ms: 1,
@@ -15732,6 +15798,7 @@ mod uniqueness_concurrency_tests {
         let shutdown = tokio_util::sync::CancellationToken::new();
         start_local_runtime(
             vec![JobInfo {
+                version: 1,
                 name: "retry_conflict".to_string(),
                 max_attempts: 1,
                 initial_backoff_ms: 1,
@@ -15829,6 +15896,7 @@ mod uniqueness_concurrency_tests {
         let shutdown = tokio_util::sync::CancellationToken::new();
         start_local_runtime(
             vec![JobInfo {
+                version: 1,
                 name: "pending_retry".to_string(),
                 max_attempts: 2,
                 initial_backoff_ms: 400,
@@ -15925,6 +15993,7 @@ mod uniqueness_concurrency_tests {
         let shutdown = tokio_util::sync::CancellationToken::new();
         start_local_runtime(
             vec![JobInfo {
+                version: 1,
                 name: "dropped_pending_retry".to_string(),
                 max_attempts: 2,
                 initial_backoff_ms: 1,
@@ -16015,6 +16084,7 @@ mod uniqueness_concurrency_tests {
         let shutdown = tokio_util::sync::CancellationToken::new();
         start_local_runtime(
             vec![JobInfo {
+                version: 1,
                 name: "limited_failing".to_string(),
                 max_attempts: 1,
                 initial_backoff_ms: 1,
@@ -16092,6 +16162,7 @@ mod uniqueness_concurrency_tests {
         start_local_runtime(
             vec![
                 JobInfo {
+                    version: 1,
                     name: "bulk".to_string(),
                     max_attempts: 1,
                     initial_backoff_ms: 1,
@@ -16101,6 +16172,7 @@ mod uniqueness_concurrency_tests {
                     handler: priority_low_handler,
                 },
                 JobInfo {
+                    version: 1,
                     name: "urgent".to_string(),
                     max_attempts: 1,
                     initial_backoff_ms: 1,

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -2402,9 +2402,13 @@ impl JobClient {
         let res = if let Some(interceptor) = &self.interceptor {
             let interceptor = (*interceptor).clone();
             // `payload` is the tracked-envelope-wrapped value for a tracked
-            // job (see `enqueue_tracked_for`); app-registered interceptors
-            // must see the real args, matching what `intercept_execute` sees
-            // at run time, not the internal envelope.
+            // job (see `enqueue_tracked_for`); strip that internal envelope so
+            // app-registered interceptors see the payload as enqueued, matching
+            // what `intercept_execute` sees at run time. The schema-version
+            // envelope (issue #1205) is *not* stripped here: for a versioned
+            // job the interceptor observes `{__autumn_schema_version, args}`,
+            // and the built-in test recorder unwraps it via
+            // `payload_version::split_version` when comparing payloads.
             let (_, interceptor_payload) = crate::job_tracking::split_tracked_payload(&payload);
             run_enqueue_interceptor(
                 interceptor,

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -8888,6 +8888,7 @@ mod tests {
     fn redis_retry_promotion_interval_uses_smallest_configured_backoff() {
         let jobs = vec![
             JobInfo {
+                version: 1,
                 name: "slow".to_string(),
                 max_attempts: 3,
                 initial_backoff_ms: 250,
@@ -8897,6 +8898,7 @@ mod tests {
                 handler: redis_counting_success_handler,
             },
             JobInfo {
+                version: 1,
                 name: "fast".to_string(),
                 max_attempts: 3,
                 initial_backoff_ms: 25,
@@ -8912,6 +8914,7 @@ mod tests {
 
         // Large retry backoffs must not delay one-shot delayed-job promotion.
         let slow_jobs = vec![JobInfo {
+            version: 1,
             name: "very_slow".to_string(),
             max_attempts: 3,
             initial_backoff_ms: 60_000,
@@ -9126,6 +9129,7 @@ mod tests {
         Arc::new(RwLock::new(HashMap::from([(
             "send_email".to_string(),
             JobInfo {
+                version: 1,
                 name: "send_email".to_string(),
                 max_attempts,
                 initial_backoff_ms: 1,
@@ -10908,6 +10912,7 @@ mod tests {
 
         let error = start_runtime(
             vec![JobInfo {
+                version: 1,
                 name: "known".to_string(),
                 max_attempts: 1,
                 initial_backoff_ms: 1,
@@ -13973,6 +13978,7 @@ mod tests {
             jobs.insert(
                 "noop".to_string(),
                 JobInfo {
+                    version: 1,
                     name: "noop".to_string(),
                     max_attempts: 1,
                     initial_backoff_ms: 0,

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -384,6 +384,7 @@ pub mod job_tracking;
 /// Safe, method-aware link helpers: [`links::link_to`] anchors and
 /// [`links::button_to`] CSRF-protected action buttons.
 pub mod links;
+pub mod payload_version;
 pub mod runtime_config;
 #[cfg(feature = "seed")]
 pub mod seed;

--- a/autumn/src/payload_version.rs
+++ b/autumn/src/payload_version.rs
@@ -22,6 +22,18 @@
 //! sees no churn. A missing `__autumn_schema_version` therefore always reads as
 //! version 1 (existing un-versioned rows read as v1).
 //!
+//! **Strict envelope detection.** To keep that promise even for apps whose raw
+//! args legitimately contain a top-level `__autumn_schema_version` field (via
+//! `#[serde(rename = "…")]` or hand-built JSON), a value is treated as an
+//! envelope *only* when it is an object with **exactly** two keys —
+//! `__autumn_schema_version` (a JSON integer `>= 1`) and `args`. Anything else
+//! is passed through as raw args. One residual ambiguity remains and is
+//! accepted: a raw payload whose shape is *exactly*
+//! `{ "__autumn_schema_version": <int>, "args": <any> }` is indistinguishable
+//! from a real envelope. That is the same fundamental limit any in-band envelope
+//! scheme has, and far tighter than a "any object carrying the marker key"
+//! check would be.
+//!
 //! # Composition with the tracked-payload envelope
 //!
 //! The tracked-job envelope (`job_tracking::wrap_tracked_payload`) and this
@@ -89,19 +101,38 @@ pub fn wrap(version: u32, args: Value) -> Value {
     Value::Object(obj)
 }
 
-/// Read the stored schema version, treating a missing/invalid marker as
-/// [`DEFAULT_VERSION`].
+/// Read the stored schema version, treating anything that is not an exact
+/// version envelope as [`DEFAULT_VERSION`].
 #[must_use]
 pub fn read_version(value: &Value) -> u32 {
-    marker_version(value).unwrap_or(DEFAULT_VERSION)
+    as_version_envelope(value).map_or(DEFAULT_VERSION, |(version, _)| version)
 }
 
-fn marker_version(value: &Value) -> Option<u32> {
-    value
-        .as_object()?
+/// The single shape predicate all read paths funnel through.
+///
+/// Recognizes `value` as a version envelope **only** when it is a JSON object
+/// with *exactly* two keys — `__autumn_schema_version` (a JSON integer that
+/// fits `u32` and is `>= 1`) and `args`. Any other shape (marker missing,
+/// non-integer marker, no `args`, or extra keys) is **not** an envelope, so a
+/// raw args payload that merely happens to contain a top-level
+/// `__autumn_schema_version` field is passed through untouched.
+///
+/// The exactly-two-keys requirement is safe because version detection always
+/// runs *after* the tracked envelope is stripped (see the module docs): a real
+/// versioned payload is exactly `{__autumn_schema_version, args}` at this layer,
+/// and [`wrap`] produces exactly those two keys.
+fn as_version_envelope(value: &Value) -> Option<(u32, &Value)> {
+    let obj = value.as_object()?;
+    if obj.len() != 2 {
+        return None;
+    }
+    let version = obj
         .get(VERSION_MARKER)?
         .as_u64()
         .and_then(|v| u32::try_from(v).ok())
+        .filter(|&v| v >= DEFAULT_VERSION)?;
+    let args = obj.get(VERSION_ARGS_KEY)?;
+    Some((version, args))
 }
 
 /// Borrowing counterpart of [`strip_version`].
@@ -111,26 +142,20 @@ fn marker_version(value: &Value) -> Option<u32> {
 /// needs to read fields off the inner args without consuming the payload.
 #[must_use]
 pub fn split_version(value: &Value) -> (u32, &Value) {
-    static NULL_ARGS: Value = Value::Null;
-    let Some(version) = marker_version(value) else {
-        return (DEFAULT_VERSION, value);
-    };
-    let inner = value
-        .as_object()
-        .and_then(|obj| obj.get(VERSION_ARGS_KEY))
-        .unwrap_or(&NULL_ARGS);
-    (version, inner)
+    as_version_envelope(value).unwrap_or((DEFAULT_VERSION, value))
 }
 
 /// Owning counterpart of [`split_version`].
 ///
 /// If `value` is a version envelope, removes and returns `(version,
-/// inner_args)`; otherwise `(DEFAULT_VERSION, value)` unchanged. Agrees with
-/// [`split_version`] on a malformed envelope (marker present, `args` missing):
-/// both report an empty (`Value::Null`) inner payload.
+/// inner_args)`; otherwise `(DEFAULT_VERSION, value)` unchanged. Mirrors
+/// [`split_version`]'s exact-shape detection, so the two never disagree on
+/// whether a given value is an envelope.
 #[must_use]
 pub fn strip_version(value: Value) -> (u32, Value) {
-    let Some(version) = marker_version(&value) else {
+    // Detect on a borrow first so the strict predicate lives in one place; only
+    // consume `obj` once we know it is a real envelope.
+    let Some((version, _)) = as_version_envelope(&value) else {
         return (DEFAULT_VERSION, value);
     };
     match value {
@@ -138,7 +163,7 @@ pub fn strip_version(value: Value) -> (u32, Value) {
             let inner = obj.remove(VERSION_ARGS_KEY).unwrap_or(Value::Null);
             (version, inner)
         }
-        // Unreachable: `marker_version` only returns `Some` for objects.
+        // Unreachable: `as_version_envelope` only returns `Some` for objects.
         other => (version, other),
     }
 }
@@ -415,15 +440,67 @@ mod tests {
     }
 
     #[test]
-    fn split_and_strip_agree_on_malformed_envelope() {
-        // Marker present but no `args` field: both report Null inner args.
-        let malformed = json!({ VERSION_MARKER: 2 });
-        let (sv, si) = split_version(&malformed);
-        assert_eq!(sv, 2);
-        assert_eq!(si, &Value::Null);
-        let (tv, ti) = strip_version(malformed);
-        assert_eq!(tv, 2);
-        assert_eq!(ti, Value::Null);
+    fn marker_without_args_is_not_an_envelope() {
+        // Marker present but no `args` field (only one key): NOT an envelope, so
+        // the whole object passes through as raw args at version 1. (Codex #1205
+        // collision fix: strict exact-shape detection.)
+        let raw = json!({ VERSION_MARKER: 5, "other": 1 });
+        assert_eq!(read_version(&raw), DEFAULT_VERSION);
+        let (sv, si) = split_version(&raw);
+        assert_eq!(sv, DEFAULT_VERSION);
+        assert_eq!(si, &raw);
+        let (tv, ti) = strip_version(raw.clone());
+        assert_eq!(tv, DEFAULT_VERSION);
+        assert_eq!(ti, raw);
+    }
+
+    #[test]
+    fn extra_keys_alongside_marker_and_args_is_not_an_envelope() {
+        // Three keys: a real envelope has exactly two, so this is raw args.
+        let raw = json!({ VERSION_MARKER: 5, "args": { "x": 1 }, "extra": 2 });
+        assert_eq!(read_version(&raw), DEFAULT_VERSION);
+        assert_eq!(split_version(&raw), (DEFAULT_VERSION, &raw));
+        assert_eq!(strip_version(raw.clone()), (DEFAULT_VERSION, raw));
+    }
+
+    #[test]
+    fn non_integer_marker_is_not_an_envelope() {
+        // Marker present with the right sibling key but a string value: raw.
+        let raw = json!({ VERSION_MARKER: "v3", "args": { "x": 1 } });
+        assert_eq!(read_version(&raw), DEFAULT_VERSION);
+        assert_eq!(split_version(&raw), (DEFAULT_VERSION, &raw));
+        assert_eq!(strip_version(raw.clone()), (DEFAULT_VERSION, raw));
+    }
+
+    #[test]
+    fn raw_payload_with_marker_field_decodes_whole_object() {
+        // A raw args struct that legitimately carries a top-level
+        // `__autumn_schema_version` field must deserialize as-is, not as a
+        // stripped envelope subtree — the "zero behavior change" guarantee.
+        #[derive(Debug, Deserialize, PartialEq, Eq)]
+        struct Raw {
+            #[serde(rename = "__autumn_schema_version")]
+            marker: u32,
+            other: i64,
+        }
+        let raw = json!({ "__autumn_schema_version": 5, "other": 7 });
+        let decoded: Raw = decode_versioned("j", 1, None, raw).unwrap();
+        assert_eq!(
+            decoded,
+            Raw {
+                marker: 5,
+                other: 7
+            }
+        );
+    }
+
+    #[test]
+    fn exact_two_key_envelope_is_detected() {
+        // The real envelope shape still matches and round-trips.
+        let env = wrap(3, json!({ "x": 1 }));
+        assert_eq!(read_version(&env), 3);
+        assert_eq!(split_version(&env), (3, &json!({ "x": 1 })));
+        assert_eq!(strip_version(env), (3, json!({ "x": 1 })));
     }
 
     #[derive(Debug, Deserialize, PartialEq, Eq)]

--- a/autumn/src/payload_version.rs
+++ b/autumn/src/payload_version.rs
@@ -1,0 +1,499 @@
+//! Opt-in schema-version envelope for persisted job payloads (issue #1205).
+//!
+//! Job args and (later) Harvest workflow state are persisted as plain serde
+//! JSON. The queue outlives any single deploy, so the moment a deploy changes a
+//! payload struct — renames a field, changes a type — in-flight jobs
+//! deserialize against code that no longer matches the stored bytes and land in
+//! the dead-letter table. This module adds a *version envelope* so a job type
+//! can declare a schema version and an upgrade path, letting a rolling deploy
+//! drain old payloads cleanly instead of dead-lettering them.
+//!
+//! # The envelope
+//!
+//! A versioned payload is stored as:
+//!
+//! ```json
+//! { "__autumn_schema_version": N, "args": <the real args value> }
+//! ```
+//!
+//! **Opt-in only.** A job that declares no version (default version `1`) and no
+//! upgrade hook is stored *exactly* as before — raw args, no envelope — so apps
+//! that never declare versions see zero behavior change and the test recorder
+//! sees no churn. A missing `__autumn_schema_version` therefore always reads as
+//! version 1 (existing un-versioned rows read as v1).
+//!
+//! # Composition with the tracked-payload envelope
+//!
+//! The tracked-job envelope (`job_tracking::wrap_tracked_payload`) and this
+//! version envelope compose by nesting, with the **tracked envelope outermost**
+//! and the **version envelope inside its `args`**:
+//!
+//! ```json
+//! { "__autumn_tracked": { "k": "<hash>" },
+//!   "args": { "__autumn_schema_version": 2, "args": <real args> } }
+//! ```
+//!
+//! This ordering falls out naturally from *where* each wrap happens: the
+//! `#[job]` macro version-wraps the args before calling `enqueue_tracked`,
+//! which then adds the tracked envelope. It requires **no change** to
+//! `take_tracked_payload`: the execution choke point strips the tracked
+//! envelope first (leaving the version envelope), and the generated handler
+//! decodes the version envelope second. Key-derivation
+//! (`job_unique_key`/`job_concurrency_scope`) strips the tracked envelope, then
+//! this module's [`split_version`], so a v1 job and its versioned re-encoding
+//! hash identically and dedup still coalesces across a deploy.
+//!
+//! # Replay compatibility
+//!
+//! Because a v1 payload and its upgraded re-encoding decode to the same `Args`
+//! struct — and un-versioned rows always read as v1 — a rolling deploy can run
+//! old and new workers against the same queue: old workers drain raw/v1
+//! payloads, new workers upgrade them. The upgrade chain is deterministic
+//! (`v -> v+1` one step at a time), which keeps replay-based consumers (Harvest,
+//! once wired) reproducible.
+
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+/// Reserved top-level key naming the stored schema version.
+pub const VERSION_MARKER: &str = "__autumn_schema_version";
+
+/// Key under which the real args live inside the version envelope. Chosen to
+/// match the tracked-payload envelope's `args` key so the two envelopes read
+/// consistently.
+pub const VERSION_ARGS_KEY: &str = "args";
+
+/// The version an un-versioned (marker-less) payload reads as.
+pub const DEFAULT_VERSION: u32 = 1;
+
+/// Boxed error type an upgrade hook returns on failure.
+pub type UpgradeError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// Signature of a job's payload-upgrade hook.
+///
+/// Called once per version step with the *from* version and the unwrapped args
+/// value; it returns the args migrated one version forward. The framework
+/// chains it (`v -> v+1`) until the args reach the current version. Because a
+/// fn pointer cannot be generic over its error type, the hook must return
+/// exactly [`UpgradeError`]; use `?` on any `E: Into<UpgradeError>` (which
+/// includes `String`, `&str`, and most `std::error::Error` types) or
+/// `.map_err(Into::into)`.
+pub type UpgradeFn = fn(u32, Value) -> Result<Value, UpgradeError>;
+
+/// Wrap `args` in the version envelope carrying `version`.
+#[must_use]
+pub fn wrap(version: u32, args: Value) -> Value {
+    let mut obj = serde_json::Map::with_capacity(2);
+    obj.insert(VERSION_MARKER.to_string(), Value::from(version));
+    obj.insert(VERSION_ARGS_KEY.to_string(), args);
+    Value::Object(obj)
+}
+
+/// Read the stored schema version, treating a missing/invalid marker as
+/// [`DEFAULT_VERSION`].
+#[must_use]
+pub fn read_version(value: &Value) -> u32 {
+    marker_version(value).unwrap_or(DEFAULT_VERSION)
+}
+
+fn marker_version(value: &Value) -> Option<u32> {
+    value
+        .as_object()?
+        .get(VERSION_MARKER)?
+        .as_u64()
+        .and_then(|v| u32::try_from(v).ok())
+}
+
+/// Borrowing counterpart of [`strip_version`].
+///
+/// If `value` is a version envelope, returns `(version, inner_args)`; otherwise
+/// `(DEFAULT_VERSION, value)` unchanged. Used by key-derivation, which only
+/// needs to read fields off the inner args without consuming the payload.
+#[must_use]
+pub fn split_version(value: &Value) -> (u32, &Value) {
+    static NULL_ARGS: Value = Value::Null;
+    let Some(version) = marker_version(value) else {
+        return (DEFAULT_VERSION, value);
+    };
+    let inner = value
+        .as_object()
+        .and_then(|obj| obj.get(VERSION_ARGS_KEY))
+        .unwrap_or(&NULL_ARGS);
+    (version, inner)
+}
+
+/// Owning counterpart of [`split_version`].
+///
+/// If `value` is a version envelope, removes and returns `(version,
+/// inner_args)`; otherwise `(DEFAULT_VERSION, value)` unchanged. Agrees with
+/// [`split_version`] on a malformed envelope (marker present, `args` missing):
+/// both report an empty (`Value::Null`) inner payload.
+#[must_use]
+pub fn strip_version(value: Value) -> (u32, Value) {
+    let Some(version) = marker_version(&value) else {
+        return (DEFAULT_VERSION, value);
+    };
+    match value {
+        Value::Object(mut obj) => {
+            let inner = obj.remove(VERSION_ARGS_KEY).unwrap_or(Value::Null);
+            (version, inner)
+        }
+        // Unreachable: `marker_version` only returns `Some` for objects.
+        other => (version, other),
+    }
+}
+
+/// Which stage of version decoding failed. Kept internal; the public surface is
+/// the [`JobPayloadVersionError`]'s accessors and [`std::fmt::Display`].
+#[derive(Debug)]
+enum VersionErrorKind {
+    /// Stored version < expected and no upgrade hook is declared.
+    NoUpgradePath,
+    /// Stored version > expected: this worker is older than the producer.
+    TooNew,
+    /// An upgrade-hook step returned an error.
+    UpgradeFailed,
+    /// The args did not match the current struct after reaching the expected
+    /// version (a shape mismatch).
+    DecodeFailed,
+}
+
+/// A version/shape mismatch decoding a persisted job payload.
+///
+/// Distinguishable from a generic serde error: it names the job type, the
+/// stored version, and the expected version, so a dead-lettered job is
+/// self-diagnosing. Detect it in an already-stringified error with
+/// [`is_payload_version_error`].
+#[derive(Debug)]
+pub struct JobPayloadVersionError {
+    job_type: String,
+    stored_version: u32,
+    expected_version: u32,
+    kind: VersionErrorKind,
+    source: Option<UpgradeError>,
+}
+
+/// Stable substring present in every [`JobPayloadVersionError`] `Display`, so a
+/// version/shape mismatch stays recognizable after it has been flattened to a
+/// string in the dead-letter record. See [`is_payload_version_error`].
+const ERROR_SENTINEL: &str = "stored payload version";
+
+impl JobPayloadVersionError {
+    /// The registered job type whose payload failed to decode.
+    #[must_use]
+    pub fn job_type(&self) -> &str {
+        &self.job_type
+    }
+
+    /// The schema version the stored payload carried (missing marker → 1).
+    #[must_use]
+    pub const fn stored_version(&self) -> u32 {
+        self.stored_version
+    }
+
+    /// The schema version the current code expects.
+    #[must_use]
+    pub const fn expected_version(&self) -> u32 {
+        self.expected_version
+    }
+
+    /// The underlying upgrade/deserialization error, if any.
+    #[must_use]
+    pub fn source_error(&self) -> Option<&(dyn std::error::Error + Send + Sync + 'static)> {
+        self.source.as_deref()
+    }
+}
+
+impl std::fmt::Display for JobPayloadVersionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            job_type,
+            stored_version,
+            expected_version,
+            kind,
+            source,
+        } = self;
+        // Every arm contains `ERROR_SENTINEL` ("stored payload version") so the
+        // error stays detectable once stringified.
+        match kind {
+            VersionErrorKind::NoUpgradePath => write!(
+                f,
+                "job \"{job_type}\": stored payload version {stored_version} is incompatible with \
+                 expected version {expected_version} (no upgrade path)"
+            ),
+            VersionErrorKind::TooNew => write!(
+                f,
+                "job \"{job_type}\": stored payload version {stored_version} is newer than expected \
+                 version {expected_version}; this worker cannot decode it (deploy the newer code, \
+                 or roll back the producer)"
+            ),
+            VersionErrorKind::UpgradeFailed => {
+                write!(
+                    f,
+                    "job \"{job_type}\": stored payload version {stored_version} could not be \
+                     upgraded to expected version {expected_version}"
+                )?;
+                if let Some(source) = source {
+                    write!(f, ": {source}")?;
+                }
+                Ok(())
+            }
+            VersionErrorKind::DecodeFailed => {
+                write!(
+                    f,
+                    "job \"{job_type}\": stored payload version {stored_version} does not match the \
+                     current args shape for expected version {expected_version}"
+                )?;
+                if let Some(source) = source {
+                    write!(f, ": {source}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::error::Error for JobPayloadVersionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source
+            .as_ref()
+            .map(|s| s.as_ref() as &(dyn std::error::Error + 'static))
+    }
+}
+
+/// Whether an already-stringified error came from a [`JobPayloadVersionError`].
+///
+/// Distinguishes a version/shape mismatch dead-letter from a generic serde
+/// failure once the typed error has been flattened into the dead-letter
+/// record's message column.
+#[must_use]
+pub fn is_payload_version_error(message: &str) -> bool {
+    message.contains(ERROR_SENTINEL)
+}
+
+/// Decode a stored payload into `T`, applying the declared upgrade chain.
+///
+/// Reads the stored version `v` (missing marker → [`DEFAULT_VERSION`]). Then:
+/// - `v > expected_version` → [`VersionErrorKind::TooNew`] error;
+/// - while `v < expected_version`: if no `upgrade` hook, a
+///   [`VersionErrorKind::NoUpgradePath`] error; otherwise apply the hook one
+///   step (`v -> v+1`);
+/// - finally `serde_json::from_value::<T>`; a failure here is a shape mismatch
+///   reported as [`VersionErrorKind::DecodeFailed`] (never a bare serde error).
+///
+/// For the common un-versioned case (`expected_version == 1`, no marker, no
+/// upgrade) this reduces to a plain `from_value` — identical to the pre-#1205
+/// behavior, just with a more precise error on failure.
+///
+/// # Errors
+///
+/// Returns [`JobPayloadVersionError`] on any version mismatch, failed upgrade
+/// step, or shape mismatch, always naming the job type and both versions.
+pub fn decode_versioned<T: DeserializeOwned>(
+    job_type: &str,
+    expected_version: u32,
+    upgrade: Option<UpgradeFn>,
+    stored: Value,
+) -> Result<T, JobPayloadVersionError> {
+    let (stored_version, mut args) = strip_version(stored);
+
+    if stored_version > expected_version {
+        return Err(JobPayloadVersionError {
+            job_type: job_type.to_string(),
+            stored_version,
+            expected_version,
+            kind: VersionErrorKind::TooNew,
+            source: None,
+        });
+    }
+
+    let mut version = stored_version;
+    while version < expected_version {
+        let Some(upgrade) = upgrade else {
+            return Err(JobPayloadVersionError {
+                job_type: job_type.to_string(),
+                stored_version,
+                expected_version,
+                kind: VersionErrorKind::NoUpgradePath,
+                source: None,
+            });
+        };
+        args = upgrade(version, args).map_err(|source| JobPayloadVersionError {
+            job_type: job_type.to_string(),
+            stored_version,
+            expected_version,
+            kind: VersionErrorKind::UpgradeFailed,
+            source: Some(source),
+        })?;
+        version += 1;
+    }
+
+    serde_json::from_value(args).map_err(|source| JobPayloadVersionError {
+        job_type: job_type.to_string(),
+        stored_version,
+        expected_version,
+        kind: VersionErrorKind::DecodeFailed,
+        source: Some(Box::new(source)),
+    })
+}
+
+/// CI-time golden-fixture guard: round-trip a *stored* sample payload through
+/// the version-aware decode into the current `T` and assert success.
+///
+/// Load a golden JSON fixture (a payload as it is actually stored — versioned
+/// or raw) and call this with the job's current `expected_version` and upgrade
+/// hook. A breaking change to `T` (that the upgrade chain does not cover) then
+/// fails in CI rather than in the queue. See the issue's falsifiable case: with
+/// the upgrade hook a v1 fixture decodes; remove the hook and this guard fails.
+///
+/// # Panics
+///
+/// Panics with the precise [`JobPayloadVersionError`] if `stored_json` does not
+/// decode into `T` at `expected_version`, or if `stored_json` is not valid JSON.
+pub fn assert_golden_payload<T: DeserializeOwned>(
+    job_type: &str,
+    expected_version: u32,
+    upgrade: Option<UpgradeFn>,
+    stored_json: &str,
+) {
+    let stored: Value = serde_json::from_str(stored_json)
+        .unwrap_or_else(|e| panic!("golden fixture for job \"{job_type}\" is not valid JSON: {e}"));
+    if let Err(error) = decode_versioned::<T>(job_type, expected_version, upgrade, stored) {
+        panic!("golden payload guard failed: {error}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+    use serde_json::json;
+
+    #[test]
+    fn wrap_then_strip_is_identity_on_args() {
+        let args = json!({ "a": 1, "b": [2, 3] });
+        let (version, inner) = strip_version(wrap(4, args.clone()));
+        assert_eq!(version, 4);
+        assert_eq!(inner, args);
+    }
+
+    #[test]
+    fn missing_marker_reads_as_default_version() {
+        let raw = json!({ "a": 1 });
+        assert_eq!(read_version(&raw), DEFAULT_VERSION);
+        let (version, inner) = split_version(&raw);
+        assert_eq!(version, DEFAULT_VERSION);
+        assert_eq!(inner, &raw);
+        // Non-objects, too.
+        assert_eq!(read_version(&Value::Null), DEFAULT_VERSION);
+        assert_eq!(strip_version(Value::Null), (DEFAULT_VERSION, Value::Null));
+    }
+
+    #[test]
+    fn split_and_strip_agree_on_malformed_envelope() {
+        // Marker present but no `args` field: both report Null inner args.
+        let malformed = json!({ VERSION_MARKER: 2 });
+        let (sv, si) = split_version(&malformed);
+        assert_eq!(sv, 2);
+        assert_eq!(si, &Value::Null);
+        let (tv, ti) = strip_version(malformed);
+        assert_eq!(tv, 2);
+        assert_eq!(ti, Value::Null);
+    }
+
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    struct Args {
+        user_id: i64,
+        greeting: String,
+    }
+
+    fn upgrade(from: u32, mut value: Value) -> Result<Value, UpgradeError> {
+        if from == 1 {
+            value
+                .as_object_mut()
+                .ok_or("expected object")?
+                .insert("greeting".into(), json!("hi"));
+        }
+        Ok(value)
+    }
+
+    #[test]
+    fn decode_upgrades_missing_marker_as_v1() {
+        // A raw (un-versioned) v1 payload upgrades to the current v2 struct.
+        let stored = json!({ "user_id": 3 });
+        let decoded: Args = decode_versioned("welcome", 2, Some(upgrade), stored).unwrap();
+        assert_eq!(
+            decoded,
+            Args {
+                user_id: 3,
+                greeting: "hi".into()
+            }
+        );
+    }
+
+    #[test]
+    fn decode_at_current_version_needs_no_upgrade() {
+        let stored = wrap(2, json!({ "user_id": 3, "greeting": "yo" }));
+        let decoded: Args = decode_versioned("welcome", 2, None, stored).unwrap();
+        assert_eq!(
+            decoded,
+            Args {
+                user_id: 3,
+                greeting: "yo".into()
+            }
+        );
+    }
+
+    #[test]
+    fn no_upgrade_path_error_names_job_and_versions() {
+        let stored = wrap(1, json!({ "user_id": 3 }));
+        let err = decode_versioned::<Args>("send_welcome", 3, None, stored).unwrap_err();
+        assert_eq!(err.job_type(), "send_welcome");
+        assert_eq!(err.stored_version(), 1);
+        assert_eq!(err.expected_version(), 3);
+        let msg = err.to_string();
+        assert!(is_payload_version_error(&msg), "detectable: {msg}");
+        assert!(msg.contains("no upgrade path"), "{msg}");
+    }
+
+    #[test]
+    fn too_new_error_when_stored_exceeds_expected() {
+        let stored = wrap(5, json!({ "user_id": 3, "greeting": "hi" }));
+        let err = decode_versioned::<Args>("welcome", 2, Some(upgrade), stored).unwrap_err();
+        assert_eq!(err.stored_version(), 5);
+        assert_eq!(err.expected_version(), 2);
+        assert!(err.to_string().contains("newer than expected"));
+        assert!(is_payload_version_error(&err.to_string()));
+    }
+
+    #[test]
+    fn upgrade_failure_surfaces_source_and_stays_detectable() {
+        fn bad_upgrade(_from: u32, _v: Value) -> Result<Value, UpgradeError> {
+            Err("boom".into())
+        }
+        let stored = wrap(1, json!({ "user_id": 3 }));
+        let err = decode_versioned::<Args>("welcome", 2, Some(bad_upgrade), stored).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("boom"), "{msg}");
+        assert!(is_payload_version_error(&msg));
+    }
+
+    #[test]
+    fn shape_mismatch_at_current_version_is_a_version_error_not_bare_serde() {
+        // Right version, wrong shape (missing `greeting`, no upgrade to add it).
+        let stored = wrap(2, json!({ "user_id": 3 }));
+        let err = decode_versioned::<Args>("welcome", 2, None, stored).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("does not match the current args shape")
+        );
+        assert!(is_payload_version_error(&err.to_string()));
+    }
+
+    #[test]
+    fn is_payload_version_error_rejects_generic_messages() {
+        assert!(!is_payload_version_error(
+            "job args deserialization failed: missing field"
+        ));
+    }
+}

--- a/autumn/src/payload_version.rs
+++ b/autumn/src/payload_version.rs
@@ -164,6 +164,18 @@ enum VersionErrorKind {
 /// stored version, and the expected version, so a dead-lettered job is
 /// self-diagnosing. Detect it in an already-stringified error with
 /// [`is_payload_version_error`].
+///
+/// # Retry behavior (follow-up)
+///
+/// A version mismatch is a *deterministic* failure — retrying the same stored
+/// bytes can never succeed. The job framework's execution outcome today only
+/// distinguishes ordinary failures (retried until `max_attempts`) from panics
+/// (dead-lettered immediately); there is no per-error "non-retryable" signal a
+/// handler can raise. So a version-mismatch job currently burns its retry
+/// budget with backoff before dead-lettering with this (precise) error. Routing
+/// it straight to the dead-letter table would require a new `JobExecutionOutcome`
+/// variant threaded through all three backends' retry decisions — deferred as a
+/// follow-up rather than built here.
 #[derive(Debug)]
 pub struct JobPayloadVersionError {
     job_type: String,
@@ -239,11 +251,24 @@ impl std::fmt::Display for JobPayloadVersionError {
                 Ok(())
             }
             VersionErrorKind::DecodeFailed => {
-                write!(
-                    f,
-                    "job \"{job_type}\": stored payload version {stored_version} does not match the \
-                     current args shape for expected version {expected_version}"
-                )?;
+                // When the stored and expected versions match (the common
+                // un-versioned case, both 1), naming "expected version 1" —
+                // a version the user never declared — reads as noise, so drop
+                // that clause. The `ERROR_SENTINEL` prefix is preserved either
+                // way so `is_payload_version_error` still matches.
+                if stored_version == expected_version {
+                    write!(
+                        f,
+                        "job \"{job_type}\": stored payload version {stored_version} does not match \
+                         the current args shape"
+                    )?;
+                } else {
+                    write!(
+                        f,
+                        "job \"{job_type}\": stored payload version {stored_version} does not match \
+                         the current args shape for expected version {expected_version}"
+                    )?;
+                }
                 if let Some(source) = source {
                     write!(f, ": {source}")?;
                 }

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -3726,6 +3726,7 @@ mod tests {
     impl crate::plugin::Plugin for CleanupJobPlugin {
         fn build(self, app: crate::app::AppBuilder) -> crate::app::AppBuilder {
             app.jobs(vec![crate::job::JobInfo {
+                version: 1,
                 name: "cleanup_probe".to_string(),
                 max_attempts: 1,
                 initial_backoff_ms: 1,

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -2540,8 +2540,12 @@ impl TestClient {
     #[allow(clippy::needless_pass_by_value)]
     pub fn assert_job_enqueued_with(&self, name: &str, payload: serde_json::Value) -> &Self {
         let jobs = self.enqueued_jobs();
+        // Strip the opt-in schema-version envelope (issue #1205) so payload
+        // assertions stay on clean args even for `#[job(version = N)]` jobs
+        // whose stored payload is wrapped as `{__autumn_schema_version, args}`.
         assert!(
-            jobs.iter().any(|j| j.name == name && j.payload == payload),
+            jobs.iter().any(|j| j.name == name
+                && *crate::payload_version::split_version(&j.payload).1 == payload),
             "expected a job named '{name}' enqueued with payload {payload}, but no match was found.\nEnqueued jobs:\n{}",
             format_recorded_jobs(&jobs)
         );

--- a/autumn/src/webhook_outbound.rs
+++ b/autumn/src/webhook_outbound.rs
@@ -777,6 +777,7 @@ impl crate::plugin::Plugin for OutboundWebhookPlugin {
             queue: "default".to_string(),
             uniqueness: None,
             concurrency: None,
+            version: 1,
             handler: deliver_webhook_job,
         }])
     }

--- a/autumn/tests/fixtures/versioned_welcome_v1.json
+++ b/autumn/tests/fixtures/versioned_welcome_v1.json
@@ -1,0 +1,6 @@
+{
+  "__autumn_schema_version": 1,
+  "args": {
+    "user_id": 7
+  }
+}

--- a/autumn/tests/integration/boundary_hooks_integration.rs
+++ b/autumn/tests/integration/boundary_hooks_integration.rs
@@ -267,6 +267,7 @@ async fn job_interceptor_intercepts_enqueue_and_execute() {
     let config = autumn_web::config::JobConfig::default();
 
     let job_info = JobInfo {
+        version: 1,
         name: "test-job".to_string(),
         max_attempts: 1,
         initial_backoff_ms: 1,

--- a/autumn/tests/integration/job_tracking_route.rs
+++ b/autumn/tests/integration/job_tracking_route.rs
@@ -46,6 +46,7 @@ struct TrackedGateJobPlugin;
 impl Plugin for TrackedGateJobPlugin {
     fn build(self, app: AppBuilder) -> AppBuilder {
         app.jobs(vec![JobInfo {
+            version: 1,
             name: "tracked_gate_job".to_string(),
             max_attempts: 1,
             initial_backoff_ms: 1,

--- a/autumn/tests/integration/job_tracking_stores_integration.rs
+++ b/autumn/tests/integration/job_tracking_stores_integration.rs
@@ -28,6 +28,7 @@ fn noop_handler(
 
 fn noop_job_info() -> JobInfo {
     JobInfo {
+        version: 1,
         name: "noop".to_string(),
         max_attempts: 1,
         initial_backoff_ms: 1,

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -127,6 +127,7 @@ mod openapi;
 mod pagination;
 mod pagination_cursor_proptest;
 mod path_helpers;
+mod payload_version_integration;
 #[cfg(feature = "db")]
 mod pg_tls;
 #[cfg(feature = "db")]

--- a/autumn/tests/integration/payload_version_integration.rs
+++ b/autumn/tests/integration/payload_version_integration.rs
@@ -164,7 +164,9 @@ fn upgrade_versioned_welcome(
     from: u32,
     mut value: Value,
 ) -> Result<Value, Box<dyn std::error::Error + Send + Sync>> {
-    if from == 1 && let Some(obj) = value.as_object_mut() {
+    if from == 1
+        && let Some(obj) = value.as_object_mut()
+    {
         obj.entry("greeting".to_string())
             .or_insert_with(|| json!("hi"));
     }

--- a/autumn/tests/integration/payload_version_integration.rs
+++ b/autumn/tests/integration/payload_version_integration.rs
@@ -1,0 +1,336 @@
+//! Integration + macro-level tests for versioned job payloads (issue #1205).
+//!
+//! Covers the opt-in schema-version envelope (`__autumn_schema_version`), the
+//! `#[job(version = N, upgrade = ...)]` macro surface, the precise
+//! dead-letter error on a version/shape mismatch, and the CI golden-fixture
+//! guard.
+//!
+//! These tests exercise the process-global job client (like
+//! `job_recorder_integration.rs`), so they serialize on
+//! `job::global_job_runtime_test_lock()` and clear the global client.
+
+use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
+
+use autumn_web::app::AppBuilder;
+use autumn_web::job;
+use autumn_web::payload_version::{self, JobPayloadVersionError};
+use autumn_web::plugin::Plugin;
+use autumn_web::prelude::*;
+use autumn_web::test::TestApp;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+// ── Pure module round-trip tests ─────────────────────────────────────────────
+
+#[test]
+fn wrap_read_strip_round_trip() {
+    let args = json!({ "user_id": 7 });
+    let wrapped = payload_version::wrap(3, args.clone());
+    assert_eq!(wrapped["__autumn_schema_version"], json!(3));
+    assert_eq!(wrapped["args"], args);
+
+    assert_eq!(payload_version::read_version(&wrapped), 3);
+
+    let (version, inner) = payload_version::strip_version(wrapped);
+    assert_eq!(version, 3);
+    assert_eq!(inner, args);
+}
+
+#[test]
+fn missing_marker_reads_as_version_1() {
+    let raw = json!({ "user_id": 7 });
+    assert_eq!(payload_version::read_version(&raw), 1);
+
+    let (version, inner) = payload_version::split_version(&raw);
+    assert_eq!(version, 1);
+    assert_eq!(inner, &raw, "un-versioned payloads pass through unchanged");
+
+    // A non-object payload also reads as v1 and passes through.
+    assert_eq!(payload_version::read_version(&Value::Null), 1);
+}
+
+#[test]
+fn decode_versioned_upgrades_chain_v1_to_v3() {
+    // v1 -> v2 adds `greeting`; v2 -> v3 adds `locale`.
+    fn upgrade(
+        from: u32,
+        mut value: Value,
+    ) -> Result<Value, Box<dyn std::error::Error + Send + Sync>> {
+        let obj = value.as_object_mut().ok_or("expected object args")?;
+        match from {
+            1 => {
+                obj.insert("greeting".into(), json!("hello"));
+            }
+            2 => {
+                obj.insert("locale".into(), json!("en"));
+            }
+            other => return Err(format!("no upgrade from version {other}").into()),
+        }
+        Ok(value)
+    }
+
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    struct ArgsV3 {
+        user_id: i64,
+        greeting: String,
+        locale: String,
+    }
+
+    let stored = payload_version::wrap(1, json!({ "user_id": 7 }));
+    let decoded: ArgsV3 = payload_version::decode_versioned("welcome", 3, Some(upgrade), stored)
+        .expect("upgrade v1->v3");
+    assert_eq!(
+        decoded,
+        ArgsV3 {
+            user_id: 7,
+            greeting: "hello".into(),
+            locale: "en".into()
+        }
+    );
+}
+
+#[test]
+fn decode_versioned_without_upgrade_hook_yields_precise_error() {
+    #[derive(Debug, Deserialize)]
+    struct ArgsV3 {
+        #[allow(dead_code)]
+        user_id: i64,
+    }
+
+    let stored = payload_version::wrap(1, json!({ "user_id": 7 }));
+    let err: JobPayloadVersionError =
+        payload_version::decode_versioned::<ArgsV3>("send_welcome", 3, None, stored)
+            .expect_err("no upgrade path must fail");
+
+    assert_eq!(err.job_type(), "send_welcome");
+    assert_eq!(err.stored_version(), 1);
+    assert_eq!(err.expected_version(), 3);
+
+    let msg = err.to_string();
+    assert!(msg.contains("send_welcome"), "names job: {msg}");
+    assert!(msg.contains("version 1"), "names stored version: {msg}");
+    assert!(msg.contains("version 3"), "names expected version: {msg}");
+    assert!(msg.contains("no upgrade path"), "explains why: {msg}");
+    assert!(
+        payload_version::is_payload_version_error(&msg),
+        "detectable as a payload-version error, not a generic serde error"
+    );
+}
+
+#[test]
+fn golden_fixture_round_trips_against_current_struct() {
+    // The falsifiable case from the issue: with the upgrade hook a v1 fixture
+    // decodes into the *current* v2 struct; without it, the guard fails (see
+    // `golden_fixture_without_upgrade_fails`).
+    let fixture = include_str!("../fixtures/versioned_welcome_v1.json");
+
+    payload_version::assert_golden_payload::<VersionedWelcomeArgs>(
+        "versioned_welcome",
+        2,
+        Some(upgrade_versioned_welcome),
+        fixture,
+    );
+}
+
+#[test]
+#[should_panic(expected = "versioned_welcome")]
+fn golden_fixture_without_upgrade_fails() {
+    // Removing the upgrade hook is exactly the breaking change the CI guard must
+    // catch: a v1 fixture can no longer become the current v2 struct.
+    let fixture = include_str!("../fixtures/versioned_welcome_v1.json");
+    payload_version::assert_golden_payload::<VersionedWelcomeArgs>(
+        "versioned_welcome",
+        2,
+        None,
+        fixture,
+    );
+}
+
+// ── Macro-level job definitions ──────────────────────────────────────────────
+
+// Current (v2) shape of the welcome args: `greeting` was added in v2.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct VersionedWelcomeArgs {
+    user_id: i64,
+    greeting: String,
+}
+
+/// v1 -> v2 upgrade: default the newly-added `greeting` field.
+///
+/// Always `Ok` here, but the signature must stay `Result<_, _>` to match
+/// `payload_version::UpgradeFn`, so `unnecessary_wraps` is allowed.
+#[allow(clippy::unnecessary_wraps)]
+fn upgrade_versioned_welcome(
+    from: u32,
+    mut value: Value,
+) -> Result<Value, Box<dyn std::error::Error + Send + Sync>> {
+    if from == 1 && let Some(obj) = value.as_object_mut() {
+        obj.entry("greeting".to_string())
+            .or_insert_with(|| json!("hi"));
+    }
+    Ok(value)
+}
+
+static VERSIONED_USER: AtomicI64 = AtomicI64::new(0);
+static VERSIONED_RUNS: AtomicUsize = AtomicUsize::new(0);
+
+#[job(name = "versioned_welcome", version = 2, upgrade = upgrade_versioned_welcome, max_attempts = 1, backoff_ms = 1)]
+async fn versioned_welcome(_state: AppState, args: VersionedWelcomeArgs) -> AutumnResult<()> {
+    VERSIONED_USER.store(args.user_id, Ordering::SeqCst);
+    VERSIONED_RUNS.fetch_add(1, Ordering::SeqCst);
+    Ok(())
+}
+
+// A default (un-versioned) job: proves opt-in-only wrapping stores raw args.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct PlainArgs {
+    user_id: i64,
+}
+
+#[job(name = "plain_job", max_attempts = 1, backoff_ms = 1)]
+async fn plain_job(_state: AppState, args: PlainArgs) -> AutumnResult<()> {
+    let _ = args;
+    Ok(())
+}
+
+// A versioned job WITHOUT an upgrade hook, to prove a stale-version payload
+// dead-letters with the precise error rather than a generic serde miss.
+#[job(
+    name = "strict_versioned",
+    version = 3,
+    max_attempts = 1,
+    backoff_ms = 1
+)]
+async fn strict_versioned(_state: AppState, args: PlainArgs) -> AutumnResult<()> {
+    let _ = args;
+    Ok(())
+}
+
+struct VersionedJobsPlugin;
+
+impl Plugin for VersionedJobsPlugin {
+    fn build(self, app: AppBuilder) -> AppBuilder {
+        app.jobs(jobs![versioned_welcome, plain_job, strict_versioned])
+    }
+}
+
+// ── Macro: opt-in wrapping + recorder strips the version marker ──────────────
+
+#[tokio::test]
+async fn opt_in_job_wraps_and_recorder_sees_clean_args() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let client = TestApp::new().plugin(VersionedJobsPlugin).build();
+
+    VersionedWelcomeJob::enqueue(VersionedWelcomeArgs {
+        user_id: 5,
+        greeting: "yo".into(),
+    })
+    .await
+    .unwrap();
+
+    // The recorder captures the raw (version-wrapped) payload, but the
+    // assertion helper strips the marker so tests compare on clean args.
+    client.assert_job_enqueued_with(
+        "versioned_welcome",
+        json!({ "user_id": 5, "greeting": "yo" }),
+    );
+
+    // The stored payload really is wrapped (opt-in job, version > 1).
+    let raw = &client.enqueued_jobs()[0].payload;
+    assert_eq!(
+        raw["__autumn_schema_version"],
+        json!(2),
+        "opt-in job is wrapped: {raw}"
+    );
+
+    job::clear_global_job_client();
+}
+
+#[tokio::test]
+async fn default_job_stores_raw_args_no_envelope() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let client = TestApp::new().plugin(VersionedJobsPlugin).build();
+
+    PlainJobJob::enqueue(PlainArgs { user_id: 9 })
+        .await
+        .unwrap();
+
+    let raw = &client.enqueued_jobs()[0].payload;
+    assert_eq!(
+        *raw,
+        json!({ "user_id": 9 }),
+        "default job stores raw args: {raw}"
+    );
+    assert!(
+        raw.get("__autumn_schema_version").is_none(),
+        "default job must not be wrapped: {raw}"
+    );
+
+    job::clear_global_job_client();
+}
+
+// ── Macro: a v1 payload upgrades and the handler runs ────────────────────────
+
+#[tokio::test]
+async fn stored_v1_payload_upgrades_and_handler_runs() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+    VERSIONED_RUNS.store(0, Ordering::SeqCst);
+    VERSIONED_USER.store(0, Ordering::SeqCst);
+
+    let client = TestApp::new().plugin(VersionedJobsPlugin).build();
+
+    // Simulate a payload enqueued by the *old* v1 code: wrapped at version 1
+    // with only `user_id`. The current v2 handler must upgrade it.
+    job::enqueue(
+        "versioned_welcome",
+        json!({ "__autumn_schema_version": 1, "args": { "user_id": 11 } }),
+    )
+    .await
+    .unwrap();
+
+    let report = client.perform_enqueued_jobs().await;
+    report.assert_all_succeeded();
+    assert_eq!(
+        VERSIONED_USER.load(Ordering::SeqCst),
+        11,
+        "v1 payload upgraded and ran"
+    );
+
+    job::clear_global_job_client();
+}
+
+// ── Macro: a stale-version payload dead-letters with the precise error ───────
+
+#[tokio::test]
+async fn stale_version_without_upgrade_dead_letters_with_precise_error() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let client = TestApp::new().plugin(VersionedJobsPlugin).build();
+
+    // strict_versioned is at version 3 with no upgrade hook; a v1 payload cannot
+    // be decoded and must surface the precise error.
+    job::enqueue(
+        "strict_versioned",
+        json!({ "__autumn_schema_version": 1, "args": { "user_id": 1 } }),
+    )
+    .await
+    .unwrap();
+
+    let report = client.perform_enqueued_jobs().await;
+    let failures = report.failures();
+    assert_eq!(failures.len(), 1, "the stale payload surfaced as a failure");
+    assert_eq!(failures[0].0, "strict_versioned");
+
+    let msg = format!("{:?}", failures[0].1);
+    assert!(msg.contains("strict_versioned"), "names job type: {msg}");
+    assert!(msg.contains("version 1"), "names stored version: {msg}");
+    assert!(msg.contains("version 3"), "names expected version: {msg}");
+
+    job::clear_global_job_client();
+}

--- a/autumn/tests/integration/payload_version_integration.rs
+++ b/autumn/tests/integration/payload_version_integration.rs
@@ -336,3 +336,125 @@ async fn stale_version_without_upgrade_dead_letters_with_precise_error() {
 
     job::clear_global_job_client();
 }
+
+// ── Transactional enqueue paths must wrap too (Codex tx-enqueue P2, #1205) ────
+//
+// The version envelope was originally applied only in the 5 generated enqueue
+// methods; the transactional free functions serialized typed args raw. These
+// tests drive `enqueue_after_commit` (which needs no DB connection — outside a
+// tx it enqueues eagerly through the same chokepoint the connection-based
+// paths use). The `*_on_conn` / `enqueue_in_tx` variants share the
+// `enqueue_on_conn_due` chokepoint and are compile-verified; a Docker-gated DB
+// test is out of scope here.
+
+#[tokio::test]
+async fn after_commit_enqueue_wraps_versioned_job() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let client = TestApp::new().plugin(VersionedJobsPlugin).build();
+
+    job::enqueue_after_commit(
+        "versioned_welcome",
+        VersionedWelcomeArgs {
+            user_id: 3,
+            greeting: "yo".into(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let raw = &client.enqueued_jobs()[0].payload;
+    assert_eq!(
+        raw["__autumn_schema_version"],
+        json!(2),
+        "transactional enqueue must wrap an opt-in job: {raw}"
+    );
+    client.assert_job_enqueued_with(
+        "versioned_welcome",
+        json!({ "user_id": 3, "greeting": "yo" }),
+    );
+
+    job::clear_global_job_client();
+}
+
+#[tokio::test]
+async fn after_commit_default_job_stores_raw() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let client = TestApp::new().plugin(VersionedJobsPlugin).build();
+
+    job::enqueue_after_commit("plain_job", PlainArgs { user_id: 1 })
+        .await
+        .unwrap();
+
+    let raw = &client.enqueued_jobs()[0].payload;
+    assert_eq!(
+        *raw,
+        json!({ "user_id": 1 }),
+        "default job stays raw via tx: {raw}"
+    );
+    assert!(
+        raw.get("__autumn_schema_version").is_none(),
+        "default job must not be wrapped: {raw}"
+    );
+
+    job::clear_global_job_client();
+}
+
+#[tokio::test]
+async fn after_commit_versioned_no_upgrade_decodes_at_current_version() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let client = TestApp::new().plugin(VersionedJobsPlugin).build();
+
+    // strict_versioned is version 3 with no upgrade hook. Enqueued transactionally
+    // with current args, the marker must be stored so decode lands at v3 — not
+    // read as a missing-marker v1 and dead-lettered with "no upgrade path".
+    job::enqueue_after_commit("strict_versioned", PlainArgs { user_id: 9 })
+        .await
+        .unwrap();
+
+    let raw = &client.enqueued_jobs()[0].payload;
+    assert_eq!(
+        raw["__autumn_schema_version"],
+        json!(3),
+        "wrapped at v3: {raw}"
+    );
+
+    let report = client.perform_enqueued_jobs().await;
+    report.assert_all_succeeded();
+
+    job::clear_global_job_client();
+}
+
+#[tokio::test]
+async fn generated_method_wraps_exactly_once_no_double_wrap() {
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+
+    let client = TestApp::new().plugin(VersionedJobsPlugin).build();
+
+    VersionedWelcomeJob::enqueue(VersionedWelcomeArgs {
+        user_id: 4,
+        greeting: "hi".into(),
+    })
+    .await
+    .unwrap();
+
+    let raw = &client.enqueued_jobs()[0].payload;
+    assert_eq!(raw["__autumn_schema_version"], json!(2));
+    assert_eq!(
+        raw.as_object().map(serde_json::Map::len),
+        Some(2),
+        "exactly a 2-key envelope, not nested: {raw}"
+    );
+    assert!(
+        raw["args"].get("__autumn_schema_version").is_none(),
+        "inner args must not itself be an envelope (no double wrap): {raw}"
+    );
+
+    job::clear_global_job_client();
+}

--- a/autumn/tests/integration/webhook_outbound.rs
+++ b/autumn/tests/integration/webhook_outbound.rs
@@ -54,6 +54,7 @@ async fn test_webhook_outbound_lifecycle() {
     let shutdown = tokio_util::sync::CancellationToken::new();
     let config = autumn_web::config::JobConfig::default();
     let job_info = JobInfo {
+        version: 1,
         name: "autumn_webhook_delivery".to_owned(),
         max_attempts: 1,
         initial_backoff_ms: 1,
@@ -150,6 +151,7 @@ async fn test_webhook_outbound_retries_and_dlq() {
     let shutdown = tokio_util::sync::CancellationToken::new();
     let config = autumn_web::config::JobConfig::default();
     let job_info = JobInfo {
+        version: 1,
         name: "autumn_webhook_delivery".to_owned(),
         max_attempts: 5,
         initial_backoff_ms: 1,
@@ -239,6 +241,7 @@ async fn test_webhook_outbound_failure_caps_deactivation() {
     let shutdown = tokio_util::sync::CancellationToken::new();
     let config = autumn_web::config::JobConfig::default();
     let job_info = JobInfo {
+        version: 1,
         name: "autumn_webhook_delivery".to_owned(),
         max_attempts: 5,
         initial_backoff_ms: 1,
@@ -320,6 +323,7 @@ async fn test_webhook_outbound_actuator_endpoints() {
     let shutdown = tokio_util::sync::CancellationToken::new();
     let config = autumn_web::config::JobConfig::default();
     let job_info = JobInfo {
+        version: 1,
         name: "autumn_webhook_delivery".to_owned(),
         max_attempts: 5,
         initial_backoff_ms: 1,

--- a/examples/reddit-clone/tests/webhook_outbound_integration.rs
+++ b/examples/reddit-clone/tests/webhook_outbound_integration.rs
@@ -86,6 +86,7 @@ async fn test_reddit_registration_triggers_outbound_webhook() {
 
     let mut jobs = reddit_clone::jobs::registered_jobs();
     jobs.push(JobInfo {
+        version: 1,
         name: "autumn_webhook_delivery".to_owned(),
         max_attempts: 1,
         initial_backoff_ms: 1,


### PR DESCRIPTION
## What changed

**Before:** Job args were persisted as plain serde JSON with no version tag. The moment a deploy renamed a field or changed a type, in-flight jobs and already-queued rows deserialized against code that no longer matched the stored bytes — landing in the dead-letter table with a generic serde error.

**After:** A job type can opt into a schema version and a declared upgrade path, so a rolling deploy with a changed payload struct drains old rows cleanly instead of dead-lettering them. Apps that never declare a version are completely unaffected — their payloads are still stored raw (no envelope), and un-versioned rows read as version 1.

- `#[job(version = N)]` (default 1) and an optional `#[job(upgrade = path)]` hook `fn(from_version: u32, value: Value) -> Result`. On decode, a stored payload older than the current version is upgraded one step at a time up to the current version, then deserialized. Declaring `upgrade` without `version >= 2` is now a compile error.
- Opt-in version envelope stored inside the existing JSONB payload: `{ "__autumn_schema_version": N, "args": ... }`. Only written when `version > 1` or an upgrade hook is declared — zero behavior change and zero stored-byte change for existing jobs. No migration needed.
- **All enqueue paths wrap, not just the generated methods.** The seven transactional typed-args free functions (`enqueue_on_conn`, `enqueue_in_on_conn`, `enqueue_at_on_conn`, `enqueue_in_tx`, `enqueue_after_commit`, `enqueue_in_after_commit`, `enqueue_at_after_commit`) now wrap too, so a `#[job(version = N)]` enqueued transactionally stores the version marker instead of a raw payload that would decode as v1.
- Precise dead-letter error: a version/shape mismatch produces a `JobPayloadVersionError` naming the job type, the stored version, and the expected version — distinguishable from a generic serde error. A default (unversioned) job keeps the exact pre-#1205 `from_value` error path.
- Dedup/uniqueness/concurrency key derivation strips the version marker (composing with the existing `__autumn_tracked` envelope), so a v1 job and its versioned re-encoding still coalesce across a deploy. Envelope detection requires the exact 2-key shape, so a raw payload that merely carries a top-level `__autumn_schema_version` field is not mis-stripped.
- CI golden-fixture guard: `assert_golden_payload::<T>(job_type, expected_version, upgrade, stored_json)` round-trips a stored sample payload against the current struct, so a breaking change fails in CI rather than in the queue.
- The built-in job test recorder's assertions unwrap the version envelope, so payload assertions stay on clean args.

## How

New generic `autumn/src/payload_version.rs` (wrap / read_version / split_version / strip_version / `decode_versioned` / `JobPayloadVersionError` / `assert_golden_payload`), kept generic over `serde_json::Value` so the future Harvest event history can reuse the same envelope.

Version metadata is threaded through the job registry: a `version: u32` field on `JobInfo` (default 1; the `#[job]` companion sets it) flows into `JobRuntimeSettings` via `build_per_job_settings`, so every name-keyed enqueue chokepoint can wrap by looking the version up. The generated `#[job]` methods wrap at args-serialization time and funnel through `enqueue`/`enqueue_due`; the transactional free functions wrap centrally at the two chokepoints they share — `JobClient::enqueue_on_conn_due` and `enqueue_after_commit_inner`. Those two chokepoints are never reached by the generated (already-wrapped) methods, so wrapping there can never double-wrap. Envelope composition: tracked envelope outermost, version envelope inside its `args`; the execution chokepoint strips tracked first, leaving the version envelope for the generated handler; decode and key-derivation order are unchanged.

## Acceptance criteria
- [x] AC1 — version envelope, default 1, un-versioned reads as v1, zero change for non-versioned apps
- [x] AC2 — declared upgrade path accepts version N−1 payloads
- [x] AC3 — distinguishable dead-letter error naming job type / stored / expected version
- [x] AC4 — reusable envelope generic enough for Harvest to adopt (Harvest is design-doc-only today; the Harvest guide / replay-contract doc is a follow-up docs task)
- [x] AC5 — CI golden-fixture round-trip guard
- [ ] AC6 — jobs/Harvest guide "deploying payload changes" sections — deferred to a follow-up docs session

## Testing
- 14 `payload_version` lib unit tests + 14 integration tests, covering: a v1→v3 upgrade chain, a `#[should_panic]` proving the CI guard fails when the hook is removed, stale-version dead-letter with the precise error, strict exact-2-key envelope detection (raw payloads carrying a marker field decode whole), transactional `enqueue_after_commit` wrapping a versioned job, a default job staying raw via a tx path, and a generated method producing exactly one 2-key envelope (no double wrap). Plus macro parse tests (incl. the `upgrade` requires `version >= 2` rejection) and canonical-key strip / collision tests. The full `job::tests` module (114 tests) and the job recorder / tracking / webhook integration suites pass; clippy clean on `autumn-web` + `autumn-macros`.
- The `*_on_conn` / `enqueue_in_tx` transactional paths share the wrapped `enqueue_on_conn_due` chokepoint and are compile-verified; their Docker-gated Postgres/Redis tests are `#[ignore]`-gated (no Docker in this environment).

## Follow-ups (out of this PR)
- Harvest event-history envelope wiring + replay-compatibility guide (AC4 docs) and the jobs/Harvest "deploying payload changes" doc sections (AC6) — batched into a docs session.
- Fast-dead-letter on `JobPayloadVersionError`: today a version mismatch still retries to `max_attempts` before dead-lettering because the job outcome enum has no non-retryable signal; making it immediate needs a new outcome variant threaded through all three backends (noted in code).

---
_Generated by [Claude Code](https://claude.ai/code/session_019VMRLbWPmQwXG1gVzuinxW)_