### PR TITLE
feat(repository): dependent destroy/nullify/restrict cascade (Part of #1369)

### DIFF
--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1257,6 +1257,15 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         // pre-fetch is needed. Mirrors the inline delete broadcast the normal
         // `delete_by_id` wrapper emits (static/dynamic topic, tenant scoping,
         // custom `broadcast_render`), keyed on the destroyed child record.
+        // #1369 broadcast timing: do NOT publish the cascaded child's OOB delete
+        // mid-transaction. If a later dependent action or the parent mutation
+        // fails and the tx rolls back, a mid-tx publish can't be retracted and
+        // clients would drop a fragment for a child that still exists. Instead,
+        // accumulate (topic, dom_id) into `__ret_broadcasts` and hand them back to
+        // the parent, which publishes them only AFTER the tx commits (mirroring
+        // the normal inline delete broadcast, which effectively fires post-commit
+        // for that single op). Commit-hook children defer via the durable outbox
+        // and are unaffected (they never accumulate here — no double publish).
         let destroy_broadcast = if dep_needs_broadcast {
             let base_topic = match generate_topic_format(
                 config
@@ -1301,31 +1310,33 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 }
             };
             quote! {
-                if let ::core::option::Option::Some(__channels) =
-                    ::autumn_web::__private::get_global_channels()
                 {
                     let __broadcast_rec: &#model_name = &__record;
-                    let __del_topic = #topic_expr;
-                    let __del_id = #dom_id_expr;
-                    let __fragment = ::autumn_web::html! {};
-                    if let ::core::result::Result::Err(__err) = __channels
-                        .broadcast()
-                        .publish_oob(
-                            &__del_topic,
-                            &__del_id,
-                            &::autumn_web::htmx::OobSwap::Delete,
-                            &__fragment,
-                        )
-                    {
-                        ::autumn_web::reexports::tracing::warn!(
-                            error = %__err,
-                            "auto-broadcast dependent-destroy delete failed"
-                        );
-                    }
+                    let __del_topic: ::std::string::String =
+                        ::std::string::ToString::to_string(&#topic_expr);
+                    let __del_id: ::std::string::String =
+                        ::std::string::ToString::to_string(&#dom_id_expr);
+                    __ret_broadcasts.push((__del_topic, __del_id));
                 }
             }
         } else {
             quote! {}
+        };
+        // Declaration + return of the deferred-broadcast buffer for the Destroy
+        // arm. Only a broadcasts-only child accumulates; every other repo returns
+        // an empty buffer (zero-cost).
+        let destroy_ret_decl = if dep_needs_broadcast {
+            quote! {
+                let mut __ret_broadcasts: ::std::vec::Vec<(::std::string::String, ::std::string::String)> =
+                    ::std::vec::Vec::new();
+            }
+        } else {
+            quote! {}
+        };
+        let destroy_ret_value = if dep_needs_broadcast {
+            quote! { __ret_broadcasts }
+        } else {
+            quote! { ::std::vec::Vec::new() }
         };
         let destroy_post_mutation = if dep_needs_post {
             quote! {
@@ -1350,6 +1361,11 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             /// The `Destroy` action follows it so a soft-delete child is only
             /// soft-deleted alongside a soft-deleted parent (see below).
             ///
+            /// Returns the `(topic, dom_id)` OOB delete broadcasts accumulated for
+            /// `broadcasts = true` (non-commit-hook) children — the parent
+            /// publishes them only AFTER its transaction commits, so a rolled-back
+            /// cascade broadcasts nothing. Empty for every other configuration.
+            ///
             /// NOTE (#1369 scope / see #1702): the `Destroy` cascade is
             /// single-level — it applies this model's mutation to each child but
             /// does NOT recursively invoke the child's own `dependent(...)`
@@ -1363,7 +1379,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 __parent_id: i64,
                 __action: ::autumn_web::repository::DependentAction,
                 __parent_soft: bool,
-            ) -> ::autumn_web::AutumnResult<()> {
+            ) -> ::autumn_web::AutumnResult<
+                ::std::vec::Vec<(::std::string::String, ::std::string::String)>,
+            > {
                 use ::autumn_web::reexports::diesel::prelude::*;
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl;
                 #dep_hooks_use
@@ -1399,7 +1417,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 ))
                             );
                         }
-                        ::core::result::Result::Ok(())
+                        ::core::result::Result::Ok(::std::vec::Vec::new())
                     }
                     ::autumn_web::repository::DependentAction::Nullify => {
                         let __q = format!(
@@ -1411,7 +1429,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             .execute(conn)
                             .await
                             .map_err(::autumn_web::AutumnError::from)?;
-                        ::core::result::Result::Ok(())
+                        ::core::result::Result::Ok(::std::vec::Vec::new())
                     }
                     ::autumn_web::repository::DependentAction::DeleteAll => {
                         let __q = format!(
@@ -1423,7 +1441,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             .execute(conn)
                             .await
                             .map_err(::autumn_web::AutumnError::from)?;
-                        ::core::result::Result::Ok(())
+                        ::core::result::Result::Ok(::std::vec::Vec::new())
                     }
                     ::autumn_web::repository::DependentAction::Destroy => {
                         // Single-level cascade (#1369 scope; recursion tracked in
@@ -1431,6 +1449,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         // child's OWN `dependent(...)` cascade is NOT invoked, so
                         // grandchildren are not recursively destroyed/nullified.
                         #destroy_register
+                        #destroy_ret_decl
                         #[derive(::autumn_web::reexports::diesel::QueryableByName)]
                         struct __AutumnDepId {
                             #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::BigInt)]
@@ -1461,7 +1480,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 #destroy_post_mutation
                             }
                         }
-                        ::core::result::Result::Ok(())
+                        ::core::result::Result::Ok(#destroy_ret_value)
                     }
                 }
             }
@@ -7859,15 +7878,19 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 let __autumn_dep_repo = #child_repo::with_pool_untracked(
                     ::core::clone::Clone::clone(&self.pool)
                 );
-                __autumn_dep_repo
-                    .__autumn_apply_dependent_on_conn(
-                        conn,
-                        #fk,
-                        id,
-                        ::autumn_web::repository::DependentAction::#action_variant,
-                        #parent_soft_lit,
-                    )
-                    .await?;
+                // Deferred delete broadcasts accumulate here; they are published
+                // only after the tx commits (see the post-commit region below).
+                __autumn_dep_broadcasts.extend(
+                    __autumn_dep_repo
+                        .__autumn_apply_dependent_on_conn(
+                            conn,
+                            #fk,
+                            id,
+                            ::autumn_web::repository::DependentAction::#action_variant,
+                            #parent_soft_lit,
+                        )
+                        .await?
+                );
             }
         });
         let cascade_calls = quote! { #(#cascade_calls)* };
@@ -8082,35 +8105,48 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             #parent_register
             #tenant_id_setup
             let mut conn = self.__autumn_acquire_conn().await?;
-            ::autumn_web::__private::scoped_transaction::<(), ::autumn_web::AutumnError, _, _>(
-                &mut *conn,
-                |conn| {
-                    async move {
-                        #parent_ctx_decl
-                        #parent_idempotency_setup
+            // Deferred OOB delete broadcasts for broadcasts-only cascaded children
+            // (#1369). Accumulated inside the tx and returned on commit, so a
+            // rollback drops them and no spurious client deletes are published.
+            let __autumn_dep_broadcasts: ::std::vec::Vec<(::std::string::String, ::std::string::String)> =
+                ::autumn_web::__private::scoped_transaction::<
+                    ::std::vec::Vec<(::std::string::String, ::std::string::String)>,
+                    ::autumn_web::AutumnError, _, _,
+                >(
+                    &mut *conn,
+                    |conn| {
+                        async move {
+                            let mut __autumn_dep_broadcasts: ::std::vec::Vec<(::std::string::String, ::std::string::String)> =
+                                ::std::vec::Vec::new();
+                            #parent_ctx_decl
+                            #parent_idempotency_setup
 
-                        #parent_load
+                            #parent_load
 
-                        #parent_before_delete
+                            #parent_before_delete
 
-                        // Cascade to dependent children FIRST so the parent
-                        // delete never trips a foreign-key constraint and no
-                        // orphan can survive the transaction.
-                        #cascade_calls
+                            // Cascade to dependent children FIRST so the parent
+                            // delete never trips a foreign-key constraint and no
+                            // orphan can survive the transaction.
+                            #cascade_calls
 
-                        #parent_mutation
+                            #parent_mutation
 
-                        #parent_vh
+                            #parent_vh
 
-                        #parent_commit_enqueue
+                            #parent_commit_enqueue
 
-                        Ok(())
-                    }
-                    .scope_boxed()
-                },
-            )
-            .await?;
+                            Ok(__autumn_dep_broadcasts)
+                        }
+                        .scope_boxed()
+                    },
+                )
+                .await?;
             ::core::mem::drop(conn);
+            // Publish the cascaded children's OOB delete broadcasts only now that
+            // the transaction has committed (a rolled-back cascade published
+            // nothing). No-op when the buffer is empty / live channels are off.
+            ::autumn_web::repository::publish_deferred_dependent_broadcasts(__autumn_dep_broadcasts);
             // Always kick the durable commit-hook dispatcher after a dependent
             // delete: even when this parent has no commit hooks, a cascaded
             // `dependent = destroy` child may have enqueued one in the same
@@ -11455,6 +11491,15 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         fn save_many(&self, new: &[#new_name]) -> impl ::std::future::Future<Output = ::autumn_web::AutumnResult<Vec<#model_name>>> + Send;
         fn save_many_skip_invalid(&self, new: &[#new_name]) -> impl ::std::future::Future<Output = ::autumn_web::AutumnResult<(Vec<#model_name>, Vec<(usize, ::autumn_web::AutumnError)>)>> + Send;
         fn update_many(&self, ids: &[i64], changes: &#update_name) -> impl ::std::future::Future<Output = ::autumn_web::AutumnResult<Vec<#model_name>>> + Send;
+        /// Bulk-delete the given ids in one statement.
+        ///
+        /// NOTE (#1369 scope; see #1702): `dependent(...)` cascade actions are
+        /// NOT applied on this bulk path — AC2 scopes dependent actions to the
+        /// single-record `delete_by_id`/`destroy`. On a repository that declares
+        /// `dependent(...)`, `delete_many` issues a plain bulk parent
+        /// delete/soft-delete and does not cascade, so it can FK-fail or orphan
+        /// children. Callers who need the cascade must use `delete_by_id`. Bulk
+        /// cascade is a tracked follow-up.
         fn delete_many(&self, ids: &[i64]) -> impl ::std::future::Future<Output = ::autumn_web::AutumnResult<()>> + Send;
         #upsert_many_trait_method
     };
@@ -14331,37 +14376,52 @@ mod tests {
     }
 
     #[test]
-    fn repository_macro_dependent_destroy_emits_inline_broadcast_for_broadcasts_only_child() {
-        // AC4: a child declared `broadcasts = true` (without commit_hooks)
-        // publishes its OOB delete fragment inline in the normal delete path;
-        // the cascade helper must emit the SAME inline delete broadcast per
-        // cascaded child so live clients don't keep a stale fragment.
+    fn repository_macro_dependent_destroy_defers_broadcast_to_post_commit() {
+        // AC4 + broadcast timing: a `broadcasts = true` (non-commit-hook) child
+        // must NOT publish mid-transaction — a rollback couldn't retract it.
+        // Instead the cascade *accumulates* (topic, dom_id) into a buffer, and
+        // the parent publishes them only AFTER the tx closure commits.
         let generated = repository_macro(
             quote! { Comment, broadcasts = true, dependent(PgReplyRepository, fk = "comment_id", on_delete = destroy) },
             quote! { pub trait CommentRepository {} },
         )
         .to_string();
+        // Child side: the destroy arm ACCUMULATES, it does not publish mid-tx.
         let destroy_arm = dependent_destroy_arm(&generated);
         assert!(
-            destroy_arm.contains("publish_oob"),
-            "broadcasts-only child destroy must publish an inline OOB broadcast: {destroy_arm}"
+            destroy_arm.contains("__ret_broadcasts . push"),
+            "broadcasts-only child destroy must accumulate (topic, dom_id), not publish: {destroy_arm}"
         );
         assert!(
-            destroy_arm.contains("OobSwap :: Delete"),
-            "the inline cascade broadcast must be an OOB Delete: {destroy_arm}"
+            !destroy_arm.contains("publish_oob"),
+            "the child cascade must not publish an OOB broadcast mid-transaction: {destroy_arm}"
         );
-        // A broadcasts-only child does not enqueue a durable commit hook.
         assert!(
             !destroy_arm.contains("enqueue_repository_commit_hook_on_conn"),
             "a broadcasts-only child must not enqueue a durable commit hook: {destroy_arm}"
         );
+        // Parent side: the deferred broadcasts are published AFTER the tx closure
+        // (post-commit), i.e. after the connection is dropped.
+        let section = delete_by_id_section(&generated);
+        let tx_pos = section
+            .find("scoped_transaction")
+            .expect("dependent delete_by_id opens a transaction");
+        let drop_pos = section
+            .find("mem :: drop")
+            .expect("dependent delete_by_id drops the conn after the tx");
+        let publish_pos = section
+            .find("publish_deferred_dependent_broadcasts")
+            .expect("parent must publish deferred cascade broadcasts");
+        assert!(
+            tx_pos < drop_pos && drop_pos < publish_pos,
+            "deferred cascade broadcasts must be published AFTER the tx closure / conn drop (post-commit): {section}"
+        );
     }
 
     #[test]
-    fn repository_macro_dependent_destroy_commit_hooks_child_enqueues_and_does_not_inline_broadcast()
-     {
+    fn repository_macro_dependent_destroy_commit_hooks_child_enqueues_and_does_not_broadcast() {
         // A commit_hooks child enqueues the durable hook (which carries the
-        // broadcast) and must NOT also emit the inline broadcast — no double emit.
+        // broadcast) and must NOT also accumulate/publish inline — no double emit.
         let generated = repository_macro(
             quote! { Comment, hooks = CommentHooks, commit_hooks = true, broadcasts = true, dependent(PgReplyRepository, fk = "comment_id", on_delete = destroy) },
             quote! { pub trait CommentRepository {} },
@@ -14373,8 +14433,9 @@ mod tests {
             "a commit_hooks child destroy must enqueue the durable commit hook: {destroy_arm}"
         );
         assert!(
-            !destroy_arm.contains("publish_oob"),
-            "a commit_hooks child must not also emit the inline broadcast (no double emit): {destroy_arm}"
+            !destroy_arm.contains("publish_oob")
+                && !destroy_arm.contains("__ret_broadcasts . push"),
+            "a commit_hooks child must not also accumulate/publish the inline broadcast (no double emit): {destroy_arm}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1467,7 +1467,16 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 .map_err(::autumn_web::AutumnError::from)?;
                         for __row in __ids {
                             let __cid = __row.id;
-                            let __record = #table_ident::table.find(__cid) #sd_filter
+                            // #1369: reload the EXACT id the (parent-soft-gated)
+                            // selection returned — do NOT re-apply `#sd_filter`
+                            // (`deleted_at IS NULL`) here. On a hard parent delete
+                            // the selection intentionally includes already
+                            // soft-deleted children (their FK still references the
+                            // parent), so a live-only reload would return `None`,
+                            // skip the hard delete, and leave the row to FK-fail
+                            // the parent DELETE. The id set is authoritative for
+                            // the parent kind; the row is locked with `for_update`.
+                            let __record = #table_ident::table.find(__cid)
                                 .for_update()
                                 .first::<#model_name>(conn)
                                 .await
@@ -14326,6 +14335,28 @@ mod tests {
         assert!(
             destroy_arm.contains("diesel :: delete"),
             "destroy hard arm (parent hard-deleted) must issue a real DELETE even for a soft_delete child: {destroy_arm}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_dependent_destroy_reload_does_not_filter_deleted_at() {
+        // #1369 (second live-filter site): the per-ID reload that fetches each
+        // selected child must NOT re-apply `deleted_at IS NULL`. The id-selection
+        // is already parent-soft-gated, so on a HARD parent delete it returns
+        // already-soft-deleted children too; a live-only reload would return
+        // `None`, skip the hard delete, and leave the FK to fail the parent
+        // DELETE. Assert the reload goes straight `find(__cid).for_update()` with
+        // no intervening `deleted_at` filter, even for a soft_delete child.
+        let generated = repository_macro(
+            quote! { Comment, soft_delete, dependent(PgReplyRepository, fk = "comment_id", on_delete = destroy) },
+            quote! { pub trait CommentRepository {} },
+        )
+        .to_string();
+        let destroy_arm = dependent_destroy_arm(&generated);
+        assert!(
+            destroy_arm.contains("find (__cid) . for_update"),
+            "the per-ID reload must load the selected id straight to for_update, \
+             with no deleted_at filter that could drop a pre-soft-deleted child: {destroy_arm}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1215,12 +1215,21 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         } else {
             quote! {}
         };
-        // Soft-delete-aware live-child filter for the id selection (only live
-        // children are destroyed; already soft-deleted rows are left as-is).
+        // Live-child filter (`AND deleted_at IS NULL`), gated on the PARENT's
+        // delete kind at runtime (#1369). The filter applies only when the parent
+        // is being soft-deleted: the parent row survives, so an already
+        // soft-deleted child is logically gone and would cause no FK problem, and
+        // a live-only selection is correct. When the parent is HARD-deleted the
+        // filter is dropped so the cascade (and the restrict EXISTS probe) operate
+        // on EVERY physically-present child row — otherwise a pre-soft-deleted
+        // child whose NOT NULL FK still points at the parent would survive the
+        // filter and make the subsequent hard parent DELETE fail (destroy) or slip
+        // past the existence check as a raw DB 500 instead of a 409 (restrict).
+        // Non-soft-delete children have no `deleted_at` column, so no filter ever.
         let destroy_live_filter = if config.soft_delete {
-            " AND \"deleted_at\" IS NULL"
+            quote! { if __parent_soft { " AND \"deleted_at\" IS NULL" } else { "" } }
         } else {
-            ""
+            quote! { "" }
         };
         // The mutation context (`ctx`) is referenced by the before_delete hook,
         // the version-history writer, and the commit-hook enqueue. Declare it —
@@ -13924,19 +13933,36 @@ mod tests {
     /// (which ends right before the always-generated `pub fn on_primary`), so
     /// assertions don't accidentally match the repository's OWN broadcast /
     /// commit-hook codegen emitted elsewhere in the output.
-    fn dependent_destroy_arm(generated: &str) -> &str {
+    fn dependent_helper_body(generated: &str) -> &str {
         // Anchor on the method *definition* — the bare name also appears at the
-        // parent's cascade *call* site inside `delete_by_id`.
+        // parent's cascade *call* site inside `delete_by_id`. Bound to the method
+        // (it ends right before the always-generated `pub fn on_primary`).
         let hstart = generated
             .find("pub async fn __autumn_apply_dependent_on_conn")
             .expect("dependent-apply helper definition present");
         let hrest = &generated[hstart..];
         let hend = hrest.find("pub fn on_primary").unwrap_or(hrest.len());
-        let helper = &hrest[..hend];
+        &hrest[..hend]
+    }
+
+    fn dependent_destroy_arm(generated: &str) -> &str {
+        let helper = dependent_helper_body(generated);
         let destroy_at = helper
             .find("DependentAction :: Destroy")
             .expect("destroy arm present");
         &helper[destroy_at..]
+    }
+
+    /// The `Restrict` match arm, bounded to before the `Nullify` arm so
+    /// assertions don't leak into the other arms.
+    fn dependent_restrict_arm(generated: &str) -> &str {
+        let helper = dependent_helper_body(generated);
+        let start = helper
+            .find("DependentAction :: Restrict")
+            .expect("restrict arm present");
+        let arm = &helper[start..];
+        let end = arm.find("DependentAction :: Nullify").unwrap_or(arm.len());
+        &arm[..end]
     }
 
     #[test]
@@ -14100,29 +14126,30 @@ mod tests {
     }
 
     #[test]
-    fn repository_macro_dependent_restrict_is_soft_delete_aware() {
-        // Finding 1: for a soft-delete child, the restrict EXISTS probe must
-        // carry the live filter so an already-soft-deleted child does not block
-        // the parent with a spurious 409.
+    fn repository_macro_dependent_restrict_live_filter_gated_on_parent_soft() {
+        // For a soft-delete child, the restrict EXISTS probe's live filter is
+        // gated on the PARENT's delete kind (`__parent_soft`): a soft parent
+        // keeps the filter (a logically-gone child shouldn't spuriously 409),
+        // but a HARD parent drops it so any physically-present FK-referencing
+        // child yields a clean 409 rather than a raw DB 500 on the parent DELETE.
         let generated = repository_macro(
             quote! { Comment, soft_delete, dependent(PgReplyRepository, fk = "comment_id", on_delete = restrict) },
             quote! { pub trait CommentRepository {} },
         )
         .to_string();
-        let start = generated
-            .find("__autumn_apply_dependent_on_conn")
-            .expect("helper present");
-        let helper = &generated[start..];
-        // The live filter is appended to the EXISTS probe format string. Token
-        // stringification renders the string literals with spaced-out escaped
-        // quotes, so match on the stable inner fragment.
+        let restrict_arm = dependent_restrict_arm(&generated);
         assert!(
-            helper.contains("SELECT EXISTS"),
-            "restrict must probe for existing children: {helper}"
+            restrict_arm.contains("SELECT EXISTS"),
+            "restrict must probe for existing children: {restrict_arm}"
+        );
+        // The live filter is a runtime `if __parent_soft { \" AND ...deleted_at.. IS NULL\" } else { \"\" }`.
+        assert!(
+            restrict_arm.contains("if __parent_soft"),
+            "soft-delete restrict probe's live filter must be gated on __parent_soft: {restrict_arm}"
         );
         assert!(
-            helper.contains("deleted_at") && helper.contains("IS NULL"),
-            "soft-delete restrict probe must exclude already-soft-deleted children (live filter): {helper}"
+            restrict_arm.contains("deleted_at") && restrict_arm.contains("IS NULL"),
+            "the soft-parent branch of the restrict probe must carry the live filter: {restrict_arm}"
         );
     }
 
@@ -14154,24 +14181,66 @@ mod tests {
 
     #[test]
     fn repository_macro_dependent_destroy_helper_is_soft_delete_aware() {
-        // AC3: a soft_delete child soft-deletes its rows on cascade and only
-        // selects live children.
+        // AC3: a soft_delete child soft-deletes its rows on cascade. The
+        // child-selection live filter is gated on the parent's delete kind
+        // (`__parent_soft`): kept for a soft parent, dropped for a hard parent so
+        // even a pre-soft-deleted child is hard-deleted (no surviving FK row).
         let generated = repository_macro(
             quote! { Comment, soft_delete, dependent(PgReplyRepository, fk = "comment_id", on_delete = destroy) },
             quote! { pub trait CommentRepository {} },
         )
         .to_string();
-        let start = generated
-            .find("__autumn_apply_dependent_on_conn")
-            .expect("helper present");
-        let helper = &generated[start..];
+        let destroy_arm = dependent_destroy_arm(&generated);
         assert!(
-            helper.contains("deleted_at"),
-            "soft_delete repo's destroy path must soft-delete (touch deleted_at): {helper}"
+            destroy_arm.contains("deleted_at"),
+            "soft_delete repo's destroy path must soft-delete (touch deleted_at): {destroy_arm}"
         );
         assert!(
-            helper.contains("IS NULL"),
-            "soft_delete repo's destroy path must select only live children: {helper}"
+            destroy_arm.contains("if __parent_soft"),
+            "the child-selection live filter must be gated on __parent_soft: {destroy_arm}"
+        );
+        assert!(
+            destroy_arm.contains("IS NULL"),
+            "the soft-parent branch must select only live children: {destroy_arm}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_dependent_live_filter_is_parent_soft_gated_not_child_only() {
+        // The live filter (`deleted_at IS NULL`) must be a RUNTIME choice keyed on
+        // `__parent_soft`, not baked in unconditionally for a soft_delete child.
+        // Both the destroy child-selection and the restrict EXISTS probe carry the
+        // gated form `if __parent_soft { \" AND ..deleted_at.. IS NULL\" } else { \"\" }`,
+        // so a hard parent delete operates on ALL physically-present children.
+        let generated = repository_macro(
+            quote! {
+                Comment, soft_delete,
+                dependent(PgReplyRepository, fk = "comment_id", on_delete = destroy),
+                dependent(PgFlagRepository, fk = "comment_id", on_delete = restrict)
+            },
+            quote! { pub trait CommentRepository {} },
+        )
+        .to_string();
+        let destroy_arm = dependent_destroy_arm(&generated);
+        let restrict_arm = dependent_restrict_arm(&generated);
+        // Gated form present in both arms.
+        assert!(
+            destroy_arm.contains("if __parent_soft") && destroy_arm.contains("else { \"\" }"),
+            "destroy live filter must be parent-soft-gated with an empty else: {destroy_arm}"
+        );
+        assert!(
+            restrict_arm.contains("if __parent_soft") && restrict_arm.contains("else { \"\" }"),
+            "restrict live filter must be parent-soft-gated with an empty else: {restrict_arm}"
+        );
+        // Sanity: a non-soft-delete child carries no live filter at all.
+        let non_soft = repository_macro(
+            quote! { Post, dependent(PgAwardRepository, fk = "post_id", on_delete = restrict) },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+        assert!(
+            !non_soft.contains("deleted_at"),
+            "a non-soft-delete child must have no live filter"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1257,9 +1257,12 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         }
                         // `AS dep_present` (not `AS exists`): `exists` is a
                         // Postgres reserved word and would need quoting.
+                        // The live filter makes `restrict` soft-delete-aware: an
+                        // already-soft-deleted child must not block the parent
+                        // with a 409 (it is no longer a live orphan).
                         let __q = format!(
-                            "SELECT EXISTS(SELECT 1 FROM \"{}\" WHERE \"{}\" = $1) AS dep_present",
-                            __table, __fk_column
+                            "SELECT EXISTS(SELECT 1 FROM \"{}\" WHERE \"{}\" = $1{}) AS dep_present",
+                            __table, __fk_column, #destroy_live_filter
                         );
                         let __row: __AutumnDepExists =
                             ::autumn_web::reexports::diesel::sql_query(__q)
@@ -13943,6 +13946,39 @@ mod tests {
         assert!(
             generated.contains("SELECT EXISTS"),
             "restrict must probe for existing children"
+        );
+        // Non-soft-delete child: the EXISTS probe carries no live filter
+        // (a non-soft-delete repository references `deleted_at` nowhere).
+        assert!(
+            !generated.contains("deleted_at"),
+            "a non-soft-delete restrict probe must not filter on deleted_at"
+        );
+    }
+
+    #[test]
+    fn repository_macro_dependent_restrict_is_soft_delete_aware() {
+        // Finding 1: for a soft-delete child, the restrict EXISTS probe must
+        // carry the live filter so an already-soft-deleted child does not block
+        // the parent with a spurious 409.
+        let generated = repository_macro(
+            quote! { Comment, soft_delete, dependent(PgReplyRepository, fk = "comment_id", on_delete = restrict) },
+            quote! { pub trait CommentRepository {} },
+        )
+        .to_string();
+        let start = generated
+            .find("__autumn_apply_dependent_on_conn")
+            .expect("helper present");
+        let helper = &generated[start..];
+        // The live filter is appended to the EXISTS probe format string. Token
+        // stringification renders the string literals with spaced-out escaped
+        // quotes, so match on the stable inner fragment.
+        assert!(
+            helper.contains("SELECT EXISTS"),
+            "restrict must probe for existing children: {helper}"
+        );
+        assert!(
+            helper.contains("deleted_at") && helper.contains("IS NULL"),
+            "soft-delete restrict probe must exclude already-soft-deleted children (live filter): {helper}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1138,16 +1138,30 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         } else {
             quote! { let _ }
         };
+        // #1369 P1: the child destroy cascade follows the *parent's* delete kind.
+        // A child is soft-deleted only when it is a `#[soft_delete]` model AND the
+        // parent is being soft-deleted (`__parent_soft`) — leaving the parent row
+        // present so the child FK stays valid. When the parent is hard-deleted, a
+        // soft-delete child must be hard-deleted too: a soft-deleted child left
+        // pointing at a hard-deleted parent is both FK-invalid (NOT NULL FK) and a
+        // semantic orphan. Non-soft-delete children are always hard-deleted.
         let destroy_mutation = if config.soft_delete {
             quote! {
-                let __now = ::autumn_web::reexports::chrono::Utc::now().naive_utc();
-                #destroy_count_bind = ::autumn_web::reexports::diesel::update(
-                    #table_ident::table.find(__cid).filter(#table_ident::deleted_at.is_null())
-                )
-                    .set(#table_ident::deleted_at.eq(::core::option::Option::Some(__now)))
-                    .execute(conn)
-                    .await
-                    .map_err(::autumn_web::AutumnError::from)?;
+                #destroy_count_bind = if __parent_soft {
+                    let __now = ::autumn_web::reexports::chrono::Utc::now().naive_utc();
+                    ::autumn_web::reexports::diesel::update(
+                        #table_ident::table.find(__cid).filter(#table_ident::deleted_at.is_null())
+                    )
+                        .set(#table_ident::deleted_at.eq(::core::option::Option::Some(__now)))
+                        .execute(conn)
+                        .await
+                        .map_err(::autumn_web::AutumnError::from)?
+                } else {
+                    ::autumn_web::reexports::diesel::delete(#table_ident::table.find(__cid))
+                        .execute(conn)
+                        .await
+                        .map_err(::autumn_web::AutumnError::from)?
+                };
             }
         } else {
             quote! {
@@ -1236,6 +1250,17 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             /// to this model's rows whose `__fk_column` equals `__parent_id`,
             /// on the caller's connection/transaction. Framework plumbing for
             /// `#[repository(..., dependent(...))]` (#1369); not a public API.
+            ///
+            /// `__parent_soft` is the parent repository's delete kind: `true`
+            /// when the parent is being soft-deleted, `false` when hard-deleted.
+            /// The `Destroy` action follows it so a soft-delete child is only
+            /// soft-deleted alongside a soft-deleted parent (see below).
+            ///
+            /// NOTE (#1369 scope / see #1702): the `Destroy` cascade is
+            /// single-level — it applies this model's mutation to each child but
+            /// does NOT recursively invoke the child's own `dependent(...)`
+            /// cascade, so grandchildren are not handled. #1369's target graph is
+            /// single-level; recursive/multi-level cascade is a tracked follow-up.
             #[doc(hidden)]
             pub async fn __autumn_apply_dependent_on_conn(
                 &self,
@@ -1243,6 +1268,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 __fk_column: &str,
                 __parent_id: i64,
                 __action: ::autumn_web::repository::DependentAction,
+                __parent_soft: bool,
             ) -> ::autumn_web::AutumnResult<()> {
                 use ::autumn_web::reexports::diesel::prelude::*;
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl;
@@ -1306,6 +1332,10 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         ::core::result::Result::Ok(())
                     }
                     ::autumn_web::repository::DependentAction::Destroy => {
+                        // Single-level cascade (#1369 scope; recursion tracked in
+                        // #1702): each child's mutation is applied inline here; the
+                        // child's OWN `dependent(...)` cascade is NOT invoked, so
+                        // grandchildren are not recursively destroyed/nullified.
                         #destroy_register
                         #[derive(::autumn_web::reexports::diesel::QueryableByName)]
                         struct __AutumnDepId {
@@ -7719,6 +7749,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     let delete_body = if config.dependents.is_empty() {
         delete_body
     } else {
+        // The parent's own delete kind (soft vs hard) drives the child `destroy`
+        // cascade (#1369 P1): a soft-delete child is only soft-deleted alongside
+        // a soft-deleted parent; a hard-deleted parent hard-deletes its children.
+        let parent_soft_lit = if config.soft_delete {
+            quote! { true }
+        } else {
+            quote! { false }
+        };
         let cascade_calls = config.dependents.iter().map(|dep| {
             let child_repo = &dep.child_repo;
             let fk = &dep.fk;
@@ -7733,6 +7771,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         #fk,
                         id,
                         ::autumn_web::repository::DependentAction::#action_variant,
+                        #parent_soft_lit,
                     )
                     .await?;
             }
@@ -14028,6 +14067,74 @@ mod tests {
         assert!(
             helper.contains("IS NULL"),
             "soft_delete repo's destroy path must select only live children: {helper}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_dependent_destroy_follows_parent_delete_kind() {
+        // #1369 P1: a soft_delete child's destroy branch must branch on
+        // `__parent_soft` — soft-deleting only when the parent is soft-deleted,
+        // and hard-deleting (a real `diesel::delete`) when the parent is
+        // hard-deleted, so a soft child never dangles off a hard-deleted parent.
+        let generated = repository_macro(
+            quote! { Comment, soft_delete, dependent(PgReplyRepository, fk = "comment_id", on_delete = destroy) },
+            quote! { pub trait CommentRepository {} },
+        )
+        .to_string();
+        let start = generated
+            .find("__autumn_apply_dependent_on_conn")
+            .expect("helper present");
+        let helper = &generated[start..];
+        // The helper takes the parent delete-kind flag and branches on it.
+        assert!(
+            helper.contains("__parent_soft"),
+            "destroy must thread the parent's delete kind (__parent_soft): {helper}"
+        );
+        assert!(
+            helper.contains("if __parent_soft"),
+            "soft_delete child destroy must branch on __parent_soft: {helper}"
+        );
+        // Both a soft mutation (UPDATE deleted_at) and a hard delete must be
+        // present in the destroy branch (one per parent-delete-kind arm).
+        let destroy_at = helper
+            .find("DependentAction :: Destroy")
+            .expect("destroy arm present");
+        let destroy_arm = &helper[destroy_at..];
+        assert!(
+            destroy_arm.contains("diesel :: update") && destroy_arm.contains("deleted_at"),
+            "destroy soft arm must UPDATE deleted_at: {destroy_arm}"
+        );
+        assert!(
+            destroy_arm.contains("diesel :: delete"),
+            "destroy hard arm (parent hard-deleted) must issue a real DELETE even for a soft_delete child: {destroy_arm}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_dependent_cascade_passes_parent_soft_flag() {
+        // The soft-delete parent passes `true`; a hard-delete parent passes
+        // `false`, so the child cascade can follow the parent's delete kind.
+        let soft_parent = repository_macro(
+            quote! { Post, soft_delete, dependent(PgCommentRepository, fk = "post_id", on_delete = destroy) },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+        let soft_section = delete_by_id_section(&soft_parent);
+        assert!(
+            soft_section.contains("__autumn_apply_dependent_on_conn")
+                && soft_section.contains(", true ,"),
+            "a soft-delete parent must pass __parent_soft = true to the cascade: {soft_section}"
+        );
+        let hard_parent = repository_macro(
+            quote! { Post, dependent(PgCommentRepository, fk = "post_id", on_delete = destroy) },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+        let hard_section = delete_by_id_section(&hard_parent);
+        assert!(
+            hard_section.contains("__autumn_apply_dependent_on_conn")
+                && hard_section.contains(", false ,"),
+            "a hard-delete parent must pass __parent_soft = false to the cascade: {hard_section}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -127,6 +127,41 @@ enum McpExpose {
     Read,
 }
 
+/// The `on_delete` action for a `dependent(...)` association (issue #1369).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum DependentAction {
+    Destroy,
+    DeleteAll,
+    Nullify,
+    Restrict,
+}
+
+impl DependentAction {
+    /// The `::autumn_web::repository::DependentAction` variant token.
+    fn variant_ident(self) -> proc_macro2::Ident {
+        let name = match self {
+            Self::Destroy => "Destroy",
+            Self::DeleteAll => "DeleteAll",
+            Self::Nullify => "Nullify",
+            Self::Restrict => "Restrict",
+        };
+        format_ident!("{name}")
+    }
+}
+
+/// One `dependent(ChildRepository, fk = "col", on_delete = action)` clause on a
+/// `#[repository]`. Threads the cascade action from the parent repository's
+/// `delete_by_id` into the child repository's delete path.
+#[derive(Clone)]
+struct DependentSpec {
+    /// The child repository struct type (e.g. `PgCommentRepository`).
+    child_repo: syn::Path,
+    /// The foreign-key column on the child table referencing the parent id.
+    fk: String,
+    /// What to do with the children when the parent is deleted.
+    action: DependentAction,
+}
+
 #[allow(clippy::struct_excessive_bools)]
 struct RepoConfig {
     model_name: Ident,
@@ -179,6 +214,10 @@ struct RepoConfig {
     broadcast_render: Option<syn::Path>,
     broadcast_container: Option<String>,
     generated_internal_hooks: bool,
+    /// `dependent(...)` association clauses (issue #1369). When non-empty,
+    /// `delete_by_id` runs a transactional, soft-delete-aware, hook-firing
+    /// cascade over these child associations before deleting the parent.
+    dependents: Vec<DependentSpec>,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -206,6 +245,7 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
     let mut broadcast_topic: Option<String> = None;
     let mut broadcast_render: Option<syn::Path> = None;
     let mut broadcast_container: Option<String> = None;
+    let mut dependents: Vec<DependentSpec> = Vec::new();
 
     syn::meta::parser(|meta| {
         // `hooks = Ident` must be checked before the catch-all model_name case,
@@ -322,12 +362,74 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
         } else if meta.path.is_ident("sharded") {
             sharded = true;
             Ok(())
+        } else if meta.path.is_ident("dependent") {
+            // `dependent(ChildRepository, fk = "col", on_delete = <action>)`
+            let mut child_repo: Option<syn::Path> = None;
+            let mut fk: Option<String> = None;
+            let mut action: Option<DependentAction> = None;
+            meta.parse_nested_meta(|nested| {
+                if nested.path.is_ident("fk") {
+                    let value: LitStr = nested.value()?.parse()?;
+                    fk = Some(value.value());
+                    Ok(())
+                } else if nested.path.is_ident("on_delete") || nested.path.is_ident("action") {
+                    let value: Ident = nested.value()?.parse()?;
+                    let parsed = match value.to_string().as_str() {
+                        "destroy" => DependentAction::Destroy,
+                        "delete_all" => DependentAction::DeleteAll,
+                        "nullify" => DependentAction::Nullify,
+                        "restrict" => DependentAction::Restrict,
+                        other => {
+                            return Err(syn::Error::new(
+                                value.span(),
+                                format!(
+                                    "unknown dependent action `{other}`; expected one of \
+                                     `destroy`, `delete_all`, `nullify`, `restrict`"
+                                ),
+                            ));
+                        }
+                    };
+                    action = Some(parsed);
+                    Ok(())
+                } else if child_repo.is_none()
+                    && (nested.input.peek(syn::Token![,]) || nested.input.is_empty())
+                {
+                    // The first bare path (no `= value`) is the child repository type.
+                    child_repo = Some(nested.path);
+                    Ok(())
+                } else {
+                    Err(nested.error(
+                        "expected `dependent(ChildRepository, fk = \"column\", \
+                         on_delete = destroy|delete_all|nullify|restrict)`",
+                    ))
+                }
+            })?;
+            let child_repo = child_repo.ok_or_else(|| {
+                meta.error(
+                    "dependent(...) requires a child repository type as its first argument, \
+                     e.g. dependent(PgCommentRepository, fk = \"post_id\", on_delete = destroy)",
+                )
+            })?;
+            let fk = fk.ok_or_else(|| {
+                meta.error("dependent(...) requires `fk = \"<child_fk_column>\"`")
+            })?;
+            let action = action.ok_or_else(|| {
+                meta.error(
+                    "dependent(...) requires `on_delete = destroy|delete_all|nullify|restrict`",
+                )
+            })?;
+            dependents.push(DependentSpec {
+                child_repo,
+                fk,
+                action,
+            });
+            Ok(())
         } else if meta.path.get_ident().is_some() && model_name.is_none() {
             model_name = Some(meta.path.get_ident().unwrap().clone());
             Ok(())
         } else {
             Err(meta.error(
-                "expected model name, table = \"...\", hooks = Type, commit_hooks = true, api = \"/path\", mcp, mcp = \"read\", policy = Type, scope = Type, cursor_key = field, cursor_key_type = Type, soft_delete, tenant_scoped, no_upsert_trait, searchable, versioned = true, no_versioned_record_impl, primary_reads, sharded, broadcasts = true, topic = \"...\", render = fn, or container = \"...\"",
+                "expected model name, table = \"...\", hooks = Type, commit_hooks = true, api = \"/path\", mcp, mcp = \"read\", policy = Type, scope = Type, cursor_key = field, cursor_key_type = Type, soft_delete, tenant_scoped, no_upsert_trait, searchable, versioned = true, no_versioned_record_impl, primary_reads, sharded, dependent(ChildRepository, fk = \"...\", on_delete = ...), broadcasts = true, topic = \"...\", render = fn, or container = \"...\"",
             ))
         }
     })
@@ -378,6 +480,7 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
         broadcast_render,
         broadcast_container,
         generated_internal_hooks,
+        dependents,
     })
 }
 
@@ -1003,6 +1106,239 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         quote! { .filter(#table_ident::deleted_at.is_null()) }
     } else {
         quote! {}
+    };
+
+    // ── #1369 dependent destroy/nullify ─────────────────────────────
+    //
+    // Every generated repository exposes an internal, connection-taking helper
+    // that applies a `DependentAction` to *this* model's rows selected by an
+    // arbitrary foreign-key column. It runs on the caller's connection (and
+    // therefore inside the caller's transaction), so a parent repository's
+    // `delete_by_id` can cascade to its children transactionally. The helper is
+    // generated for every repository (cheap, no callers when unused) so the
+    // parent side only needs the child repository *type* — it never has to know
+    // the child's Diesel schema module.
+    let dependent_child_helper = {
+        // Per-row DESTROY: mirror the repository delete path for one child id
+        // (`__cid`) on the caller's connection — load for-update (soft-delete
+        // aware), fire `before_delete`, apply the soft/hard delete mutation,
+        // record version history, and enqueue the durable commit hook. This is
+        // what makes `dependent = destroy` soft-delete-aware and hook-firing.
+        let destroy_before_delete = if config.hooks_type.is_some() {
+            quote! { self.hooks.before_delete(&mut ctx, &__record).await?; }
+        } else {
+            quote! {}
+        };
+        // Version history / commit-hook enqueue only run when a row was actually
+        // mutated; bind the affected-row count only when that gate is needed so
+        // hook-free, unversioned repos emit no unused binding.
+        let dep_needs_post = config.versioned || commit_hooks_enabled;
+        let destroy_count_bind = if dep_needs_post {
+            quote! { let __n }
+        } else {
+            quote! { let _ }
+        };
+        let destroy_mutation = if config.soft_delete {
+            quote! {
+                let __now = ::autumn_web::reexports::chrono::Utc::now().naive_utc();
+                #destroy_count_bind = ::autumn_web::reexports::diesel::update(
+                    #table_ident::table.find(__cid).filter(#table_ident::deleted_at.is_null())
+                )
+                    .set(#table_ident::deleted_at.eq(::core::option::Option::Some(__now)))
+                    .execute(conn)
+                    .await
+                    .map_err(::autumn_web::AutumnError::from)?;
+            }
+        } else {
+            quote! {
+                #destroy_count_bind = ::autumn_web::reexports::diesel::delete(#table_ident::table.find(__cid))
+                    .execute(conn)
+                    .await
+                    .map_err(::autumn_web::AutumnError::from)?;
+            }
+        };
+        let destroy_vh = if config.versioned {
+            vh_insert_ts(
+                table_name,
+                "delete",
+                true,
+                &quote! { __record },
+                None,
+                &quote! { conn },
+                model_name,
+            )
+        } else {
+            quote! {}
+        };
+        let destroy_commit_enqueue = if commit_hooks_enabled {
+            quote! {
+                let __autumn_commit_hook_record = __record.__autumn_commit_hook_to_value()?;
+                ::autumn_web::__private::enqueue_repository_commit_hook_on_conn(
+                    conn,
+                    Self::__autumn_repository_commit_hook_key(),
+                    "delete",
+                    ctx.idempotency_key.as_deref(),
+                    ::core::option::Option::None,
+                    &ctx,
+                    &__autumn_commit_hook_record,
+                )
+                .await?;
+            }
+        } else {
+            quote! {}
+        };
+        let destroy_register = if commit_hooks_enabled {
+            quote! { Self::__autumn_register_repository_commit_hooks(); }
+        } else {
+            quote! {}
+        };
+        // Soft-delete-aware live-child filter for the id selection (only live
+        // children are destroyed; already soft-deleted rows are left as-is).
+        let destroy_live_filter = if config.soft_delete {
+            " AND \"deleted_at\" IS NULL"
+        } else {
+            ""
+        };
+        // The mutation context (`ctx`) is referenced by the before_delete hook,
+        // the version-history writer, and the commit-hook enqueue. Declare it —
+        // and import the hooks types — only when at least one of those is
+        // present, mirroring the no-hooks delete path so hook-free, unversioned
+        // repos emit no unused imports/bindings. `mut` is only required when a
+        // hook mutates it (before_delete); version-history reads it immutably.
+        let dep_ctx_needed = config.hooks_type.is_some() || dep_needs_post;
+        let dep_hooks_use = if config.hooks_type.is_some() {
+            quote! { use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks}; }
+        } else if dep_ctx_needed {
+            quote! { use ::autumn_web::hooks::{MutationContext, MutationOp}; }
+        } else {
+            quote! {}
+        };
+        let destroy_ctx_decl = if config.hooks_type.is_some() {
+            quote! { let mut ctx = MutationContext::new(MutationOp::Delete); }
+        } else if dep_ctx_needed {
+            quote! { let ctx = MutationContext::new(MutationOp::Delete); }
+        } else {
+            quote! {}
+        };
+        let destroy_post_mutation = if dep_needs_post {
+            quote! {
+                if __n != 0 {
+                    #destroy_vh
+                    #destroy_commit_enqueue
+                }
+            }
+        } else {
+            quote! {}
+        };
+
+        quote! {
+            /// Apply a [`DependentAction`](::autumn_web::repository::DependentAction)
+            /// to this model's rows whose `__fk_column` equals `__parent_id`,
+            /// on the caller's connection/transaction. Framework plumbing for
+            /// `#[repository(..., dependent(...))]` (#1369); not a public API.
+            #[doc(hidden)]
+            pub async fn __autumn_apply_dependent_on_conn(
+                &self,
+                conn: &mut ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                __fk_column: &str,
+                __parent_id: i64,
+                __action: ::autumn_web::repository::DependentAction,
+            ) -> ::autumn_web::AutumnResult<()> {
+                use ::autumn_web::reexports::diesel::prelude::*;
+                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                #dep_hooks_use
+                let __table: &str = #table_name;
+                match __action {
+                    ::autumn_web::repository::DependentAction::Restrict => {
+                        #[derive(::autumn_web::reexports::diesel::QueryableByName)]
+                        struct __AutumnDepExists {
+                            #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::Bool)]
+                            dep_present: bool,
+                        }
+                        // `AS dep_present` (not `AS exists`): `exists` is a
+                        // Postgres reserved word and would need quoting.
+                        let __q = format!(
+                            "SELECT EXISTS(SELECT 1 FROM \"{}\" WHERE \"{}\" = $1) AS dep_present",
+                            __table, __fk_column
+                        );
+                        let __row: __AutumnDepExists =
+                            ::autumn_web::reexports::diesel::sql_query(__q)
+                                .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(__parent_id)
+                                .get_result::<__AutumnDepExists>(conn)
+                                .await
+                                .map_err(::autumn_web::AutumnError::from)?;
+                        if __row.dep_present {
+                            return ::core::result::Result::Err(
+                                ::autumn_web::AutumnError::conflict_msg(format!(
+                                    "cannot delete: dependent {} row(s) referencing this record \
+                                     via \"{}\".\"{}\" still exist (dependent = restrict)",
+                                    stringify!(#model_name), __table, __fk_column
+                                ))
+                            );
+                        }
+                        ::core::result::Result::Ok(())
+                    }
+                    ::autumn_web::repository::DependentAction::Nullify => {
+                        let __q = format!(
+                            "UPDATE \"{}\" SET \"{}\" = NULL WHERE \"{}\" = $1",
+                            __table, __fk_column, __fk_column
+                        );
+                        ::autumn_web::reexports::diesel::sql_query(__q)
+                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(__parent_id)
+                            .execute(conn)
+                            .await
+                            .map_err(::autumn_web::AutumnError::from)?;
+                        ::core::result::Result::Ok(())
+                    }
+                    ::autumn_web::repository::DependentAction::DeleteAll => {
+                        let __q = format!(
+                            "DELETE FROM \"{}\" WHERE \"{}\" = $1",
+                            __table, __fk_column
+                        );
+                        ::autumn_web::reexports::diesel::sql_query(__q)
+                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(__parent_id)
+                            .execute(conn)
+                            .await
+                            .map_err(::autumn_web::AutumnError::from)?;
+                        ::core::result::Result::Ok(())
+                    }
+                    ::autumn_web::repository::DependentAction::Destroy => {
+                        #destroy_register
+                        #[derive(::autumn_web::reexports::diesel::QueryableByName)]
+                        struct __AutumnDepId {
+                            #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::BigInt)]
+                            id: i64,
+                        }
+                        let __q = format!(
+                            "SELECT id FROM \"{}\" WHERE \"{}\" = $1{} ORDER BY id",
+                            __table, __fk_column, #destroy_live_filter
+                        );
+                        let __ids: ::std::vec::Vec<__AutumnDepId> =
+                            ::autumn_web::reexports::diesel::sql_query(__q)
+                                .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(__parent_id)
+                                .load::<__AutumnDepId>(conn)
+                                .await
+                                .map_err(::autumn_web::AutumnError::from)?;
+                        for __row in __ids {
+                            let __cid = __row.id;
+                            let __record = #table_ident::table.find(__cid) #sd_filter
+                                .for_update()
+                                .first::<#model_name>(conn)
+                                .await
+                                .optional()
+                                .map_err(::autumn_web::AutumnError::from)?;
+                            if let ::core::option::Option::Some(__record) = __record {
+                                #destroy_ctx_decl
+                                #destroy_before_delete
+                                #destroy_mutation
+                                #destroy_post_mutation
+                            }
+                        }
+                        ::core::result::Result::Ok(())
+                    }
+                }
+            }
+        }
     };
 
     // Parse derived query methods from trait body
@@ -7363,6 +7699,292 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         quote! {}
     };
 
+    // ── #1369: transactional dependent cascade for delete_by_id ──────
+    //
+    // When the repository declares `dependent(...)` associations, override the
+    // default `delete_body` with one that (1) always opens a transaction, (2)
+    // loads and locks the parent, (3) applies every declared dependent action
+    // to the children on that same connection *before* deleting the parent, and
+    // (4) deletes the parent. Any error rolls the whole graph back. Children are
+    // removed/nullified before the parent delete so no FK/orphan can occur.
+    //
+    // This override is computed before the `cross_shard_write_guard` tuple below
+    // so the guard is prepended here too: on a sharded + tenant_scoped repo an
+    // `across_tenants()` delete is rejected rather than cascading across shards
+    // from a single routed connection (honoring the #1592/#1664/#1687 guards; a
+    // cascade cannot silently skip children living on other shards).
+    let delete_body = if config.dependents.is_empty() {
+        delete_body
+    } else {
+        let cascade_calls = config.dependents.iter().map(|dep| {
+            let child_repo = &dep.child_repo;
+            let fk = &dep.fk;
+            let action_variant = dep.action.variant_ident();
+            quote! {
+                let __autumn_dep_repo = #child_repo::with_pool_untracked(
+                    ::core::clone::Clone::clone(&self.pool)
+                );
+                __autumn_dep_repo
+                    .__autumn_apply_dependent_on_conn(
+                        conn,
+                        #fk,
+                        id,
+                        ::autumn_web::repository::DependentAction::#action_variant,
+                    )
+                    .await?;
+            }
+        });
+        let cascade_calls = quote! { #(#cascade_calls)* };
+
+        let tenant_id_setup = if config.tenant_scoped {
+            quote! {
+                let tenant_id = if self.across_tenants {
+                    ::core::option::Option::None
+                } else {
+                    let t = ::autumn_web::tenancy::CURRENT_TENANT
+                        .try_with(|t| t.clone()).ok().flatten()
+                        .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg(
+                            "Query scoped to tenant, but no tenant context was established"
+                        ))?;
+                    ::core::option::Option::Some(t)
+                };
+            }
+        } else {
+            quote! {}
+        };
+
+        // The parent record is loaded (and row-locked via `for_update`) to run
+        // the not-found check and to feed the before_delete hook / version
+        // history / commit-hook payload. When the parent has none of those, the
+        // load still runs (lock + not-found) but the binding is discarded so a
+        // hook-free parent emits no unused binding.
+        let parent_needs_record =
+            config.hooks_type.is_some() || config.versioned || commit_hooks_enabled;
+        let parent_record_bind = if parent_needs_record {
+            quote! { record }
+        } else {
+            quote! { _record }
+        };
+        let parent_load = if config.tenant_scoped {
+            quote! {
+                let __load_query = #table_ident::table.find(id) #sd_filter;
+                let #parent_record_bind = if let ::core::option::Option::Some(ref t) = tenant_id {
+                    __load_query.filter(#table_ident::tenant_id.eq(t)).for_update().first::<#model_name>(conn).await
+                } else {
+                    __load_query.for_update().first::<#model_name>(conn).await
+                }
+                .optional()
+                .map_err(::autumn_web::AutumnError::from)?
+                .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
+                    format!("{} with id {} not found", stringify!(#model_name), id)
+                ))?;
+            }
+        } else {
+            quote! {
+                let #parent_record_bind = #table_ident::table.find(id) #sd_filter
+                    .for_update()
+                    .first::<#model_name>(conn)
+                    .await
+                    .optional()
+                    .map_err(::autumn_web::AutumnError::from)?
+                    .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
+                        format!("{} with id {} not found", stringify!(#model_name), id)
+                    ))?;
+            }
+        };
+
+        let parent_mutation = if config.soft_delete {
+            let tenant_scoped_update = if config.tenant_scoped {
+                quote! {
+                    let __count = if let ::core::option::Option::Some(ref t) = tenant_id {
+                        ::autumn_web::reexports::diesel::update(
+                            #table_ident::table.find(id)
+                                .filter(#table_ident::deleted_at.is_null())
+                                .filter(#table_ident::tenant_id.eq(t))
+                        )
+                            .set(#table_ident::deleted_at.eq(::core::option::Option::Some(__now)))
+                            .execute(conn).await
+                    } else {
+                        ::autumn_web::reexports::diesel::update(
+                            #table_ident::table.find(id).filter(#table_ident::deleted_at.is_null())
+                        )
+                            .set(#table_ident::deleted_at.eq(::core::option::Option::Some(__now)))
+                            .execute(conn).await
+                    }
+                    .map_err(::autumn_web::AutumnError::from)?;
+                }
+            } else {
+                quote! {
+                    let __count = ::autumn_web::reexports::diesel::update(
+                        #table_ident::table.find(id).filter(#table_ident::deleted_at.is_null())
+                    )
+                        .set(#table_ident::deleted_at.eq(::core::option::Option::Some(__now)))
+                        .execute(conn).await
+                        .map_err(::autumn_web::AutumnError::from)?;
+                }
+            };
+            quote! {
+                let __now = ::autumn_web::reexports::chrono::Utc::now().naive_utc();
+                #tenant_scoped_update
+                if __count == 0 {
+                    return Err(::autumn_web::AutumnError::not_found_msg(
+                        format!("{} with id {} not found", stringify!(#model_name), id)
+                    ));
+                }
+            }
+        } else {
+            let delete_stmt = if config.tenant_scoped {
+                quote! {
+                    let __count = if let ::core::option::Option::Some(ref t) = tenant_id {
+                        ::autumn_web::reexports::diesel::delete(
+                            #table_ident::table.find(id).filter(#table_ident::tenant_id.eq(t))
+                        ).execute(conn).await
+                    } else {
+                        ::autumn_web::reexports::diesel::delete(#table_ident::table.find(id))
+                            .execute(conn).await
+                    }
+                    .map_err(::autumn_web::AutumnError::from)?;
+                }
+            } else {
+                quote! {
+                    let __count = ::autumn_web::reexports::diesel::delete(#table_ident::table.find(id))
+                        .execute(conn).await
+                        .map_err(::autumn_web::AutumnError::from)?;
+                }
+            };
+            quote! {
+                #delete_stmt
+                if __count == 0 {
+                    return Err(::autumn_web::AutumnError::not_found_msg(
+                        format!("{} with id {} not found", stringify!(#model_name), id)
+                    ));
+                }
+            }
+        };
+
+        let parent_before_delete = if config.hooks_type.is_some() {
+            quote! { self.hooks.before_delete(&mut ctx, &record).await?; }
+        } else {
+            quote! {}
+        };
+        let parent_vh = if config.versioned {
+            vh_insert_ts(
+                table_name,
+                "delete",
+                true,
+                &quote! { record },
+                None,
+                &quote! { conn },
+                model_name,
+            )
+        } else {
+            quote! {}
+        };
+        let (parent_register, parent_idempotency_setup, parent_commit_enqueue, _parent_kick) =
+            if commit_hooks_enabled {
+                (
+                    quote! { Self::__autumn_register_repository_commit_hooks(); },
+                    quote! {
+                        let mut __autumn_commit_hook_discriminator: ::core::option::Option<::std::string::String> =
+                            ::core::option::Option::None;
+                        if let ::core::option::Option::Some(__autumn_idempotency) = &self.idempotency {
+                            ctx.set_idempotency_key(__autumn_idempotency.scoped_key());
+                            __autumn_commit_hook_discriminator =
+                                ::core::option::Option::Some(__autumn_idempotency.next_mutation_discriminator());
+                        }
+                    },
+                    quote! {
+                        let __autumn_commit_hook_record = record.__autumn_commit_hook_to_value()?;
+                        ::autumn_web::__private::enqueue_repository_commit_hook_on_conn(
+                            conn,
+                            Self::__autumn_repository_commit_hook_key(),
+                            "delete",
+                            ctx.idempotency_key.as_deref(),
+                            __autumn_commit_hook_discriminator.as_deref(),
+                            &ctx,
+                            &__autumn_commit_hook_record,
+                        )
+                        .await?;
+                    },
+                    quote! { ::autumn_web::__private::kick_repository_commit_hook_dispatcher(&self.pool); },
+                )
+            } else {
+                (quote! {}, quote! {}, quote! {}, quote! {})
+            };
+
+        // `ctx` is referenced by the before_delete hook, the version-history
+        // writer, and the commit-hook enqueue/idempotency setup — declare it and
+        // import the hooks types only when at least one is present, so a
+        // hook-free, unversioned parent (dependents only) emits no unused
+        // import/binding. `mut` is only required when it is written (hook or
+        // idempotency setup); version-history reads it immutably.
+        let parent_ctx_needed = parent_needs_record;
+        let parent_ctx_mut = config.hooks_type.is_some() || commit_hooks_enabled;
+        let parent_hooks_use = if config.hooks_type.is_some() {
+            quote! { use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks}; }
+        } else if parent_ctx_needed {
+            quote! { use ::autumn_web::hooks::{MutationContext, MutationOp}; }
+        } else {
+            quote! {}
+        };
+        let parent_ctx_decl = if parent_ctx_needed {
+            if parent_ctx_mut {
+                quote! { let mut ctx = MutationContext::new(MutationOp::Delete); }
+            } else {
+                quote! { let ctx = MutationContext::new(MutationOp::Delete); }
+            }
+        } else {
+            quote! {}
+        };
+        quote! {
+            use ::autumn_web::reexports::diesel::prelude::*;
+            use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+            use ::autumn_web::reexports::diesel_async::AsyncConnection;
+            use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
+            #parent_hooks_use
+
+            #parent_register
+            #tenant_id_setup
+            let mut conn = self.__autumn_acquire_conn().await?;
+            ::autumn_web::__private::scoped_transaction::<(), ::autumn_web::AutumnError, _, _>(
+                &mut *conn,
+                |conn| {
+                    async move {
+                        #parent_ctx_decl
+                        #parent_idempotency_setup
+
+                        #parent_load
+
+                        #parent_before_delete
+
+                        // Cascade to dependent children FIRST so the parent
+                        // delete never trips a foreign-key constraint and no
+                        // orphan can survive the transaction.
+                        #cascade_calls
+
+                        #parent_mutation
+
+                        #parent_vh
+
+                        #parent_commit_enqueue
+
+                        Ok(())
+                    }
+                    .scope_boxed()
+                },
+            )
+            .await?;
+            ::core::mem::drop(conn);
+            // Always kick the durable commit-hook dispatcher after a dependent
+            // delete: even when this parent has no commit hooks, a cascaded
+            // `dependent = destroy` child may have enqueued one in the same
+            // transaction. The kick is idempotent.
+            ::autumn_web::__private::kick_repository_commit_hook_dispatcher(&self.pool);
+
+            Ok(())
+        }
+    };
+
     let (
         save_body,
         update_body,
@@ -11671,6 +12293,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             #search_one_shard_helpers
             #with_pool_method
             #hook_support_methods
+            #dependent_child_helper
 
             /// Returns a clone of this repository whose generated read
             /// methods are pinned to the primary pool for the rest of the
@@ -13152,6 +13775,241 @@ mod tests {
         assert!(
             delete_pos < history_pos,
             "hooked versioned delete_many must record history after database deletion/update: {section}"
+        );
+    }
+
+    // ── #1369: dependent destroy/nullify ───────────────────────────
+
+    /// Helper: slice the generated `delete_by_id` trait-impl body (up to the
+    /// next `async fn`) so assertions target the parent delete path, not the
+    /// always-generated `__autumn_apply_dependent_on_conn` helper.
+    fn delete_by_id_section(generated: &str) -> &str {
+        let start = generated
+            .find("async fn delete_by_id")
+            .expect("repository must generate delete_by_id");
+        let rest = &generated[start + "async fn delete_by_id".len()..];
+        let end = rest.find("async fn ").map_or(rest.len(), |p| p);
+        &rest[..end]
+    }
+
+    #[test]
+    fn parse_repo_args_parses_dependent_destroy() {
+        let tokens: proc_macro2::TokenStream =
+            r#"Post, dependent(PgCommentRepository, fk = "post_id", on_delete = destroy)"#
+                .parse()
+                .unwrap();
+        let config = parse_repo_args(tokens).unwrap();
+        assert_eq!(config.dependents.len(), 1, "one dependent spec expected");
+        let dep = &config.dependents[0];
+        assert_eq!(dep.fk, "post_id");
+        assert_eq!(dep.action, DependentAction::Destroy);
+        let child_repo = &dep.child_repo;
+        assert_eq!(
+            quote! { #child_repo }.to_string(),
+            "PgCommentRepository",
+            "child repo path must be captured"
+        );
+    }
+
+    #[test]
+    fn parse_repo_args_parses_all_dependent_actions_and_multiple_specs() {
+        let tokens: proc_macro2::TokenStream = r#"Post,
+            dependent(PgCommentRepository, fk = "post_id", on_delete = destroy),
+            dependent(PgVoteRepository, fk = "post_id", on_delete = delete_all),
+            dependent(PgBookmarkRepository, fk = "post_id", on_delete = nullify),
+            dependent(PgAwardRepository, fk = "post_id", on_delete = restrict)"#
+            .parse()
+            .unwrap();
+        let config = parse_repo_args(tokens).unwrap();
+        let actions: Vec<DependentAction> = config.dependents.iter().map(|d| d.action).collect();
+        assert_eq!(
+            actions,
+            vec![
+                DependentAction::Destroy,
+                DependentAction::DeleteAll,
+                DependentAction::Nullify,
+                DependentAction::Restrict,
+            ],
+            "all four actions parse and preserve declared order"
+        );
+    }
+
+    #[test]
+    fn parse_repo_args_rejects_unknown_dependent_action() {
+        let tokens: proc_macro2::TokenStream =
+            r#"Post, dependent(PgCommentRepository, fk = "post_id", on_delete = explode)"#
+                .parse()
+                .unwrap();
+        let Err(err) = parse_repo_args(tokens) else {
+            panic!("unknown action must be rejected");
+        };
+        assert!(
+            err.to_string().contains("unknown dependent action"),
+            "error should name the bad action: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_repo_args_dependent_requires_fk() {
+        let tokens: proc_macro2::TokenStream =
+            r"Post, dependent(PgCommentRepository, on_delete = destroy)"
+                .parse()
+                .unwrap();
+        let Err(err) = parse_repo_args(tokens) else {
+            panic!("missing fk must be rejected");
+        };
+        assert!(
+            err.to_string().contains("fk"),
+            "error should mention fk: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_repo_args_dependents_default_empty() {
+        let config = parse_repo_args("Post".parse().unwrap()).unwrap();
+        assert!(
+            config.dependents.is_empty(),
+            "no dependents unless declared (AC7: default unchanged)"
+        );
+    }
+
+    #[test]
+    fn repository_macro_always_generates_dependent_helper() {
+        // The connection-taking helper is generated for every repository so the
+        // parent side only needs the child repository *type*.
+        let generated =
+            repository_macro(quote! { Post }, quote! { pub trait PostRepository {} }).to_string();
+        assert!(
+            generated.contains("__autumn_apply_dependent_on_conn"),
+            "every repository must expose the dependent-apply helper"
+        );
+        assert!(
+            generated.contains("DependentAction"),
+            "helper must match on the DependentAction enum"
+        );
+    }
+
+    #[test]
+    fn repository_macro_without_dependents_delete_by_id_has_no_cascade() {
+        // AC7: default behavior unchanged — delete_by_id must not call the
+        // cascade helper when no dependents are declared.
+        let generated =
+            repository_macro(quote! { Post }, quote! { pub trait PostRepository {} }).to_string();
+        let section = delete_by_id_section(&generated);
+        assert!(
+            !section.contains("__autumn_apply_dependent_on_conn"),
+            "delete_by_id must not cascade when no dependent(...) is declared: {section}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_dependent_delete_cascades_inside_transaction_before_parent_delete() {
+        // AC2 + AC6: cascade runs inside a single scoped_transaction and before
+        // the parent DELETE (children removed first → no FK/orphan).
+        let generated = repository_macro(
+            quote! { Post, dependent(PgCommentRepository, fk = "post_id", on_delete = destroy) },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+        let section = delete_by_id_section(&generated);
+        assert!(
+            section.contains("scoped_transaction"),
+            "dependent delete_by_id must open a transaction: {section}"
+        );
+        let cascade_pos = section
+            .find("__autumn_apply_dependent_on_conn")
+            .expect("dependent delete_by_id must call the cascade helper");
+        let parent_delete_pos = section
+            .find("diesel :: delete")
+            .expect("dependent delete_by_id must issue the parent DELETE");
+        assert!(
+            cascade_pos < parent_delete_pos,
+            "children must be cascaded before the parent DELETE: {section}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_dependent_helper_restrict_uses_conflict_error() {
+        // AC1 + AC5: restrict surfaces a typed 409 Conflict, not a 500.
+        let generated = repository_macro(
+            quote! { Post, dependent(PgAwardRepository, fk = "post_id", on_delete = restrict) },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+        assert!(
+            generated.contains("conflict_msg"),
+            "restrict must produce a typed conflict error"
+        );
+        assert!(
+            generated.contains("SELECT EXISTS"),
+            "restrict must probe for existing children"
+        );
+    }
+
+    #[test]
+    fn repository_macro_dependent_helper_nullify_sets_fk_null() {
+        let generated = repository_macro(
+            quote! { Post, dependent(PgBookmarkRepository, fk = "post_id", on_delete = nullify) },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+        assert!(
+            generated.contains("= NULL WHERE"),
+            "nullify must UPDATE the child FK column to NULL"
+        );
+    }
+
+    #[test]
+    fn repository_macro_dependent_helper_delete_all_bulk_deletes() {
+        let generated = repository_macro(
+            quote! { Post, dependent(PgVoteRepository, fk = "post_id", on_delete = delete_all) },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+        assert!(
+            generated.contains("DELETE FROM"),
+            "delete_all must issue a bulk DELETE"
+        );
+    }
+
+    #[test]
+    fn repository_macro_dependent_destroy_helper_is_soft_delete_aware() {
+        // AC3: a soft_delete child soft-deletes its rows on cascade and only
+        // selects live children.
+        let generated = repository_macro(
+            quote! { Comment, soft_delete, dependent(PgReplyRepository, fk = "comment_id", on_delete = destroy) },
+            quote! { pub trait CommentRepository {} },
+        )
+        .to_string();
+        let start = generated
+            .find("__autumn_apply_dependent_on_conn")
+            .expect("helper present");
+        let helper = &generated[start..];
+        assert!(
+            helper.contains("deleted_at"),
+            "soft_delete repo's destroy path must soft-delete (touch deleted_at): {helper}"
+        );
+        assert!(
+            helper.contains("IS NULL"),
+            "soft_delete repo's destroy path must select only live children: {helper}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_dependent_destroy_helper_fires_child_hooks() {
+        // AC4: destroy fires the child's before_delete lifecycle hook.
+        let generated = repository_macro(
+            quote! { Comment, hooks = CommentHooks, dependent(PgReplyRepository, fk = "comment_id", on_delete = destroy) },
+            quote! { pub trait CommentRepository {} },
+        )
+        .to_string();
+        let start = generated
+            .find("__autumn_apply_dependent_on_conn")
+            .expect("helper present");
+        let helper = &generated[start..];
+        assert!(
+            helper.contains("before_delete"),
+            "destroy path must fire the child's before_delete hook: {helper}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1129,10 +1129,19 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         } else {
             quote! {}
         };
-        // Version history / commit-hook enqueue only run when a row was actually
-        // mutated; bind the affected-row count only when that gate is needed so
-        // hook-free, unversioned repos emit no unused binding.
-        let dep_needs_post = config.versioned || commit_hooks_enabled;
+        // #1369 AC4: a child declared `broadcasts = true` WITHOUT `commit_hooks`
+        // (the scaffolded live path) publishes its OOB delete fragment inline in
+        // the normal `delete_by_id` wrapper. The cascade helper bypasses that
+        // wrapper, so it must emit the same inline delete broadcast per cascaded
+        // child — otherwise live clients keep a stale fragment for a destroyed
+        // child. Commit-hook children enqueue the broadcast durably as before
+        // (unchanged), so only the broadcasts-only case needs the inline emit.
+        let dep_needs_broadcast = config.broadcasts && !commit_hooks_enabled;
+        // Version history / commit-hook enqueue / inline broadcast only run when a
+        // row was actually mutated; bind the affected-row count only when that
+        // gate is needed so hook-free, unversioned, non-broadcasting repos emit no
+        // unused binding.
+        let dep_needs_post = config.versioned || commit_hooks_enabled || dep_needs_broadcast;
         let destroy_count_bind = if dep_needs_post {
             quote! { let __n }
         } else {
@@ -1234,11 +1243,87 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         } else {
             quote! {}
         };
+        // #1369 AC4: inline OOB delete broadcast for a broadcasts-only child,
+        // built from the child record we already hold (`__record`) so no
+        // pre-fetch is needed. Mirrors the inline delete broadcast the normal
+        // `delete_by_id` wrapper emits (static/dynamic topic, tenant scoping,
+        // custom `broadcast_render`), keyed on the destroyed child record.
+        let destroy_broadcast = if dep_needs_broadcast {
+            let base_topic = match generate_topic_format(
+                config
+                    .broadcast_topic
+                    .as_deref()
+                    .unwrap_or(&config.table_name),
+                &quote! { __broadcast_rec },
+            ) {
+                Ok(expr) => expr,
+                Err(err) => return err.to_compile_error(),
+            };
+            let topic_expr = if config.tenant_scoped {
+                quote! {
+                    ::std::format!(
+                        "tenant:{}:{}",
+                        ::autumn_web::tenancy::DisplayTenantId::tenant_id_str(
+                            &__broadcast_rec.tenant_id
+                        ),
+                        #base_topic
+                    )
+                }
+            } else {
+                base_topic
+            };
+            let model_prefix = to_snake_case(&config.model_name.to_string());
+            let dom_id_expr = if let Some(ref render_path) = config.broadcast_render {
+                quote! {
+                    ::autumn_web::htmx::extract_html_id(
+                        &{ #render_path(__broadcast_rec) }.into_string()
+                    )
+                    .unwrap_or_else(|| ::std::format!(
+                        "{}-{}",
+                        #model_prefix,
+                        ::autumn_web::repository::ModelPrimaryKey::primary_key_value(
+                            __broadcast_rec
+                        )
+                    ))
+                }
+            } else {
+                quote! {
+                    <#model_name as ::autumn_web::live::LiveFragment>::dom_id(__broadcast_rec)
+                }
+            };
+            quote! {
+                if let ::core::option::Option::Some(__channels) =
+                    ::autumn_web::__private::get_global_channels()
+                {
+                    let __broadcast_rec: &#model_name = &__record;
+                    let __del_topic = #topic_expr;
+                    let __del_id = #dom_id_expr;
+                    let __fragment = ::autumn_web::html! {};
+                    if let ::core::result::Result::Err(__err) = __channels
+                        .broadcast()
+                        .publish_oob(
+                            &__del_topic,
+                            &__del_id,
+                            &::autumn_web::htmx::OobSwap::Delete,
+                            &__fragment,
+                        )
+                    {
+                        ::autumn_web::reexports::tracing::warn!(
+                            error = %__err,
+                            "auto-broadcast dependent-destroy delete failed"
+                        );
+                    }
+                }
+            }
+        } else {
+            quote! {}
+        };
         let destroy_post_mutation = if dep_needs_post {
             quote! {
                 if __n != 0 {
                     #destroy_vh
                     #destroy_commit_enqueue
+                    #destroy_broadcast
                 }
             }
         } else {
@@ -13834,6 +13919,26 @@ mod tests {
         &rest[..end]
     }
 
+    /// Helper: slice the `Destroy` match arm of the generated
+    /// `__autumn_apply_dependent_on_conn` helper, bounded to the helper method
+    /// (which ends right before the always-generated `pub fn on_primary`), so
+    /// assertions don't accidentally match the repository's OWN broadcast /
+    /// commit-hook codegen emitted elsewhere in the output.
+    fn dependent_destroy_arm(generated: &str) -> &str {
+        // Anchor on the method *definition* — the bare name also appears at the
+        // parent's cascade *call* site inside `delete_by_id`.
+        let hstart = generated
+            .find("pub async fn __autumn_apply_dependent_on_conn")
+            .expect("dependent-apply helper definition present");
+        let hrest = &generated[hstart..];
+        let hend = hrest.find("pub fn on_primary").unwrap_or(hrest.len());
+        let helper = &hrest[..hend];
+        let destroy_at = helper
+            .find("DependentAction :: Destroy")
+            .expect("destroy arm present");
+        &helper[destroy_at..]
+    }
+
     #[test]
     fn parse_repo_args_parses_dependent_destroy() {
         let tokens: proc_macro2::TokenStream =
@@ -14153,6 +14258,54 @@ mod tests {
         assert!(
             helper.contains("before_delete"),
             "destroy path must fire the child's before_delete hook: {helper}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_dependent_destroy_emits_inline_broadcast_for_broadcasts_only_child() {
+        // AC4: a child declared `broadcasts = true` (without commit_hooks)
+        // publishes its OOB delete fragment inline in the normal delete path;
+        // the cascade helper must emit the SAME inline delete broadcast per
+        // cascaded child so live clients don't keep a stale fragment.
+        let generated = repository_macro(
+            quote! { Comment, broadcasts = true, dependent(PgReplyRepository, fk = "comment_id", on_delete = destroy) },
+            quote! { pub trait CommentRepository {} },
+        )
+        .to_string();
+        let destroy_arm = dependent_destroy_arm(&generated);
+        assert!(
+            destroy_arm.contains("publish_oob"),
+            "broadcasts-only child destroy must publish an inline OOB broadcast: {destroy_arm}"
+        );
+        assert!(
+            destroy_arm.contains("OobSwap :: Delete"),
+            "the inline cascade broadcast must be an OOB Delete: {destroy_arm}"
+        );
+        // A broadcasts-only child does not enqueue a durable commit hook.
+        assert!(
+            !destroy_arm.contains("enqueue_repository_commit_hook_on_conn"),
+            "a broadcasts-only child must not enqueue a durable commit hook: {destroy_arm}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_dependent_destroy_commit_hooks_child_enqueues_and_does_not_inline_broadcast()
+     {
+        // A commit_hooks child enqueues the durable hook (which carries the
+        // broadcast) and must NOT also emit the inline broadcast — no double emit.
+        let generated = repository_macro(
+            quote! { Comment, hooks = CommentHooks, commit_hooks = true, broadcasts = true, dependent(PgReplyRepository, fk = "comment_id", on_delete = destroy) },
+            quote! { pub trait CommentRepository {} },
+        )
+        .to_string();
+        let destroy_arm = dependent_destroy_arm(&generated);
+        assert!(
+            destroy_arm.contains("enqueue_repository_commit_hook_on_conn"),
+            "a commit_hooks child destroy must enqueue the durable commit hook: {destroy_arm}"
+        );
+        assert!(
+            !destroy_arm.contains("publish_oob"),
+            "a commit_hooks child must not also emit the inline broadcast (no double emit): {destroy_arm}"
         );
     }
 

--- a/autumn/src/repository.rs
+++ b/autumn/src/repository.rs
@@ -115,6 +115,31 @@ pub enum RepositoryError {
     },
 }
 
+/// How a parent's dependent children are handled when the parent is deleted.
+///
+/// Declared per association on the `#[repository]` macro via
+/// `dependent(ChildRepository, fk = "parent_fk", on_delete = <action>)`, and
+/// applied inside the parent's `delete_by_id` transaction so a parent delete
+/// never leaves orphaned child rows (issue #1369).
+///
+/// The cascade runs app-side (not via a DB `ON DELETE` constraint) so that
+/// soft-delete, lifecycle/commit hooks, and counter caches stay correct — a
+/// guarantee raw `ON DELETE CASCADE` cannot provide.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DependentAction {
+    /// Delete each child through the child repository's delete path, honoring
+    /// the child's soft-delete mode and firing its lifecycle/commit hooks.
+    Destroy,
+    /// Bulk hard-delete every child in a single `DELETE`, skipping per-row hooks.
+    DeleteAll,
+    /// Set the child's foreign-key column to `NULL` (the child rows survive,
+    /// detached from the deleted parent).
+    Nullify,
+    /// Refuse to delete the parent while any child exists, surfacing a typed
+    /// `409 Conflict` error instead of orphaning or cascading.
+    Restrict,
+}
+
 /// Extension trait that provides a fallback `None` for model structs that do
 /// not have a `#[lock_version]` field — or that are defined manually without
 /// going through `#[model]`.

--- a/autumn/src/repository.rs
+++ b/autumn/src/repository.rs
@@ -140,6 +140,49 @@ pub enum DependentAction {
     Restrict,
 }
 
+/// Publish a batch of deferred dependent-cascade OOB *delete* broadcasts,
+/// accumulated during a `dependent = destroy` cascade over `broadcasts = true`
+/// children and published **after** the parent transaction commits (#1369).
+///
+/// Each entry is `(topic, dom_id)`; the fragment is empty and the swap is
+/// [`OobSwap::Delete`](crate::htmx::OobSwap::Delete). Deferring to post-commit
+/// means a rolled-back cascade publishes nothing, so live clients are never told
+/// to remove a child that still exists. Commit-hook children defer via the
+/// durable outbox instead and are not routed through here.
+///
+/// Framework plumbing; not a public API. No-op when the live-channel /
+/// `maud` / `htmx` features are not built in (the buffer is always empty then).
+#[cfg(all(feature = "ws", feature = "maud", feature = "htmx"))]
+#[doc(hidden)]
+pub fn publish_deferred_dependent_broadcasts(broadcasts: Vec<(String, String)>) {
+    if broadcasts.is_empty() {
+        return;
+    }
+    if let Some(channels) = crate::__private::get_global_channels() {
+        let fragment = crate::html! {};
+        for (topic, dom_id) in &broadcasts {
+            if let Err(err) = channels.broadcast().publish_oob(
+                topic,
+                dom_id,
+                &crate::htmx::OobSwap::Delete,
+                &fragment,
+            ) {
+                tracing::warn!(
+                    error = %err,
+                    "auto-broadcast dependent-destroy delete failed"
+                );
+            }
+        }
+    }
+}
+
+/// No-op fallback when live broadcasting is not compiled in. The accumulation
+/// side only runs for `broadcasts = true` children (which require these
+/// features), so the buffer is always empty in this configuration.
+#[cfg(not(all(feature = "ws", feature = "maud", feature = "htmx")))]
+#[doc(hidden)]
+pub fn publish_deferred_dependent_broadcasts(_broadcasts: Vec<(String, String)>) {}
+
 /// Extension trait that provides a fallback `None` for model structs that do
 /// not have a `#[lock_version]` field — or that are defined manually without
 /// going through `#[model]`.

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -143,6 +143,8 @@ mod repository_authorization;
 #[cfg(feature = "db")]
 mod repository_bulk_operations;
 #[cfg(feature = "db")]
+mod repository_dependent_destroy;
+#[cfg(feature = "db")]
 mod repository_find_in_batches;
 #[cfg(feature = "db")]
 mod repository_find_or_create_by;

--- a/autumn/tests/integration/repository_dependent_destroy.rs
+++ b/autumn/tests/integration/repository_dependent_destroy.rs
@@ -546,7 +546,7 @@ async fn destroy_soft_parent_soft_deletes_soft_children() {
 /// #1369 P1 (hard parent + soft child, incl. a PRE-soft-deleted child): a
 /// NON-soft parent that `destroy`s a `#[soft_delete]` child. Because the parent
 /// is hard-deleted, the children must be HARD-deleted too (rows gone) — even a
-/// child that was ALREADY soft-deleted (deleted_at set) whose NOT NULL FK still
+/// child that was ALREADY soft-deleted (`deleted_at` set) whose NOT NULL FK still
 /// points at the parent. The parent-soft-gated live filter is dropped for a hard
 /// parent, so the cascade selects every physically-present child. Assert zero
 /// surviving children, zero FK errors, parent gone.

--- a/autumn/tests/integration/repository_dependent_destroy.rs
+++ b/autumn/tests/integration/repository_dependent_destroy.rs
@@ -172,12 +172,18 @@ pub struct DepAward {
 #[autumn_web::repository(DepAward, table = "dep_awards")]
 pub trait DepAwardRepository {}
 
-// ── Soft-delete-aware destroy graph (AC3) ─────────────────────────────────────
+// ── AC3: both-soft destroy graph (soft parent + soft children) ────────────────
+//
+// The parent is `#[soft_delete]` too, so `delete_by_id` soft-deletes the parent
+// (row remains, FK stays valid) and the cascade soft-deletes the children — the
+// AC3 "parent soft-deleted, cascade still runs, live graph stays consistent"
+// case, satisfiable against real Postgres.
 
 diesel::table! {
     dep_soft_posts (id) {
         id -> Int8,
         title -> Text,
+        deleted_at -> Nullable<Timestamp>,
     }
 }
 
@@ -186,11 +192,13 @@ pub struct DepSoftPost {
     #[id]
     pub id: i64,
     pub title: String,
+    pub deleted_at: Option<chrono::NaiveDateTime>,
 }
 
 #[autumn_web::repository(
     DepSoftPost,
     table = "dep_soft_posts",
+    soft_delete,
     dependent(PgDepSoftCommentRepository, fk = "post_id", on_delete = destroy)
 )]
 pub trait DepSoftPostRepository {}
@@ -215,6 +223,55 @@ pub struct DepSoftComment {
 
 #[autumn_web::repository(DepSoftComment, table = "dep_soft_comments", soft_delete)]
 pub trait DepSoftCommentRepository {}
+
+// ── #1369 P1: hard parent + soft-delete child destroy graph ───────────────────
+//
+// A NON-soft parent that `destroy`s a `#[soft_delete]` child. Because the parent
+// is hard-deleted, the child must be HARD-deleted too (not merely soft-deleted),
+// otherwise a NOT NULL FK to the removed parent would be violated and the row
+// would be a semantic orphan. Locks in the P1 fix (child follows parent kind).
+
+diesel::table! {
+    dep_hard_posts (id) {
+        id -> Int8,
+        title -> Text,
+    }
+}
+
+#[autumn_web::model(table = "dep_hard_posts")]
+pub struct DepHardPost {
+    #[id]
+    pub id: i64,
+    pub title: String,
+}
+
+#[autumn_web::repository(
+    DepHardPost,
+    table = "dep_hard_posts",
+    dependent(PgDepHardSoftCommentRepository, fk = "post_id", on_delete = destroy)
+)]
+pub trait DepHardPostRepository {}
+
+diesel::table! {
+    dep_hard_soft_comments (id) {
+        id -> Int8,
+        post_id -> Int8,
+        body -> Text,
+        deleted_at -> Nullable<Timestamp>,
+    }
+}
+
+#[autumn_web::model(table = "dep_hard_soft_comments")]
+pub struct DepHardSoftComment {
+    #[id]
+    pub id: i64,
+    pub post_id: i64,
+    pub body: String,
+    pub deleted_at: Option<chrono::NaiveDateTime>,
+}
+
+#[autumn_web::repository(DepHardSoftComment, table = "dep_hard_soft_comments", soft_delete)]
+pub trait DepHardSoftCommentRepository {}
 
 // ── Row-count helpers ─────────────────────────────────────────────────────────
 
@@ -254,8 +311,10 @@ async fn setup_pool() -> (
         "CREATE TABLE dep_votes (id BIGSERIAL PRIMARY KEY, post_id BIGINT NOT NULL REFERENCES dep_posts(id), value INT NOT NULL)",
         "CREATE TABLE dep_bookmarks (id BIGSERIAL PRIMARY KEY, post_id BIGINT REFERENCES dep_posts(id), label TEXT NOT NULL)",
         "CREATE TABLE dep_awards (id BIGSERIAL PRIMARY KEY, post_id BIGINT NOT NULL REFERENCES dep_posts(id), name TEXT NOT NULL)",
-        "CREATE TABLE dep_soft_posts (id BIGSERIAL PRIMARY KEY, title TEXT NOT NULL)",
+        "CREATE TABLE dep_soft_posts (id BIGSERIAL PRIMARY KEY, title TEXT NOT NULL, deleted_at TIMESTAMP NULL)",
         "CREATE TABLE dep_soft_comments (id BIGSERIAL PRIMARY KEY, post_id BIGINT NOT NULL REFERENCES dep_soft_posts(id), body TEXT NOT NULL, deleted_at TIMESTAMP NULL)",
+        "CREATE TABLE dep_hard_posts (id BIGSERIAL PRIMARY KEY, title TEXT NOT NULL)",
+        "CREATE TABLE dep_hard_soft_comments (id BIGSERIAL PRIMARY KEY, post_id BIGINT NOT NULL REFERENCES dep_hard_posts(id), body TEXT NOT NULL, deleted_at TIMESTAMP NULL)",
     ] {
         diesel::sql_query(stmt)
             .execute(&mut conn)
@@ -281,6 +340,9 @@ fn dependent_repository_surface_is_generated() {
     assert_is_fn(PgDepBookmarkRepository::__autumn_apply_dependent_on_conn);
     assert_is_fn(PgDepAwardRepository::__autumn_apply_dependent_on_conn);
     assert_is_fn(PgDepSoftCommentRepository::__autumn_apply_dependent_on_conn);
+    assert_is_fn(<PgDepSoftPostRepository as DepSoftPostRepository>::delete_by_id);
+    assert_is_fn(<PgDepHardPostRepository as DepHardPostRepository>::delete_by_id);
+    assert_is_fn(PgDepHardSoftCommentRepository::__autumn_apply_dependent_on_conn);
 }
 
 // ── Tests (require Docker) ────────────────────────────────────────────────────
@@ -423,12 +485,14 @@ async fn restrict_blocks_delete_with_conflict_and_rolls_back() {
     );
 }
 
-/// AC3: when the child model is `#[soft_delete]`, a `dependent = destroy`
-/// cascade soft-deletes children (rows remain with `deleted_at` set) rather
-/// than hard-deleting them.
+/// AC3 (both-soft): a `#[soft_delete]` parent with a `dependent = destroy` on a
+/// `#[soft_delete]` child. `delete_by_id` soft-deletes the parent (row remains,
+/// FK stays valid) and the cascade soft-deletes the children — all rows remain
+/// with `deleted_at` set, no FK error. This is the AC3 "parent soft-deleted,
+/// cascade still runs so the live graph stays consistent" scenario.
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
-async fn destroy_is_soft_delete_aware_for_soft_delete_children() {
+async fn destroy_soft_parent_soft_deletes_soft_children() {
     let (pool, _c) = setup_pool().await;
     let mut conn = pool.get().await.expect("conn");
 
@@ -448,7 +512,17 @@ async fn destroy_is_soft_delete_aware_for_soft_delete_children() {
     let repo = PgDepSoftPostRepository::with_pool_untracked(pool.clone());
     repo.delete_by_id(9).await.expect("soft cascade delete");
 
-    // Rows still present (soft-deleted, not hard-deleted) with deleted_at set.
+    // Parent row remains (soft-deleted, FK targets stay valid).
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_soft_posts WHERE id = 9 AND deleted_at IS NOT NULL"
+        )
+        .await,
+        1,
+        "a soft-delete parent row must remain with deleted_at set"
+    );
+    // Children remain (soft-deleted, not hard-deleted) with deleted_at set.
     assert_eq!(
         count(
             &mut conn,
@@ -456,7 +530,7 @@ async fn destroy_is_soft_delete_aware_for_soft_delete_children() {
         )
         .await,
         2,
-        "soft-delete children must not be hard-deleted"
+        "soft-delete children must not be hard-deleted when the parent is soft-deleted"
     );
     assert_eq!(
         count(
@@ -466,5 +540,55 @@ async fn destroy_is_soft_delete_aware_for_soft_delete_children() {
         .await,
         2,
         "each child must be soft-deleted (deleted_at set)"
+    );
+}
+
+/// #1369 P1 (hard parent + soft child): a NON-soft parent that `destroy`s a
+/// `#[soft_delete]` child. Because the parent is hard-deleted, the children must
+/// be HARD-deleted too (rows gone) — a soft-deleted child left pointing at a
+/// removed parent would violate the NOT NULL FK and be a semantic orphan. Assert
+/// zero surviving children, zero FK errors, parent gone.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn destroy_hard_parent_hard_deletes_soft_children() {
+    let (pool, _c) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+
+    diesel::sql_query("INSERT INTO dep_hard_posts (id, title) VALUES (11, 'hard')")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    for i in 1..=3 {
+        diesel::sql_query(format!(
+            "INSERT INTO dep_hard_soft_comments (id, post_id, body) VALUES ({i}, 11, 'h{i}')"
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    }
+
+    let repo = PgDepHardPostRepository::with_pool_untracked(pool.clone());
+    repo.delete_by_id(11)
+        .await
+        .expect("hard-parent cascade must not FK-error");
+
+    // Parent gone.
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_hard_posts WHERE id = 11"
+        )
+        .await,
+        0
+    );
+    // Soft-delete children were HARD-deleted (rows gone), not left soft-deleted.
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_hard_soft_comments WHERE post_id = 11"
+        )
+        .await,
+        0,
+        "a hard-deleted parent must hard-delete its soft-delete children (no orphans, no FK error)"
     );
 }

--- a/autumn/tests/integration/repository_dependent_destroy.rs
+++ b/autumn/tests/integration/repository_dependent_destroy.rs
@@ -1,0 +1,470 @@
+//! Database-level integration tests for `dependent` destroy/nullify/restrict
+//! on repository associations (issue #1369).
+//!
+//! The seeded-graph tests **require Docker** (testcontainers) and are
+//! `#[ignore]`d by default. Two non-ignored tests prove the generated method
+//! surface exists (the `#1592`-style guard) without a live database, so
+//! `cargo test -p autumn --no-run --features db` type-checks every branch —
+//! plain `destroy`/`delete_all`/`nullify`/`restrict`, a soft-delete-aware
+//! `destroy`, and a hook-firing `destroy` — even where Docker is unavailable.
+//!
+//! Graph under test (the reddit-clone shape from the issue):
+//!
+//! ```text
+//!   dep_posts (parent)
+//!     - dep_comments   dependent = destroy    (per-row delete path)
+//!     - dep_votes      dependent = delete_all  (bulk hard delete)
+//!     - dep_bookmarks  dependent = nullify     (FK set to NULL)
+//!     - dep_awards     dependent = restrict    (409 if any exist)
+//! ```
+
+#![cfg(feature = "db")]
+#![allow(clippy::must_use_candidate, clippy::missing_const_for_fn)]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use autumn_web::AutumnResult;
+use autumn_web::hooks::{MutationContext, MutationHooks};
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::pooled_connection::deadpool::Pool;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+// ── Parent ────────────────────────────────────────────────────────────────
+
+diesel::table! {
+    dep_posts (id) {
+        id -> Int8,
+        title -> Text,
+    }
+}
+
+#[autumn_web::model(table = "dep_posts")]
+pub struct DepPost {
+    #[id]
+    pub id: i64,
+    pub title: String,
+}
+
+#[autumn_web::repository(
+    DepPost,
+    table = "dep_posts",
+    dependent(PgDepCommentRepository, fk = "post_id", on_delete = destroy),
+    dependent(PgDepVoteRepository, fk = "post_id", on_delete = delete_all),
+    dependent(PgDepBookmarkRepository, fk = "post_id", on_delete = nullify),
+    dependent(PgDepAwardRepository, fk = "post_id", on_delete = restrict)
+)]
+pub trait DepPostRepository {}
+
+// A second parent whose only dependent is `restrict`, to exercise the blocking
+// path in isolation.
+#[autumn_web::model(table = "dep_posts")]
+pub struct DepPostRestrictOnly {
+    #[id]
+    pub id: i64,
+    pub title: String,
+}
+
+#[autumn_web::repository(
+    DepPostRestrictOnly,
+    table = "dep_posts",
+    dependent(PgDepAwardRepository, fk = "post_id", on_delete = restrict)
+)]
+pub trait DepPostRestrictOnlyRepository {}
+
+// ── Children ────────────────────────────────────────────────────────────────
+
+diesel::table! {
+    dep_comments (id) {
+        id -> Int8,
+        post_id -> Int8,
+        body -> Text,
+    }
+}
+
+pub static DESTROYED_COMMENTS: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Clone, Default)]
+pub struct DepCommentHooks;
+
+impl MutationHooks for DepCommentHooks {
+    type Model = DepComment;
+    type NewModel = NewDepComment;
+    type UpdateModel = UpdateDepComment;
+
+    async fn before_delete(
+        &self,
+        _ctx: &mut MutationContext,
+        _record: &DepComment,
+    ) -> AutumnResult<()> {
+        // AC4: proves the child's lifecycle hook fires during a cascade.
+        DESTROYED_COMMENTS.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[autumn_web::model(table = "dep_comments")]
+pub struct DepComment {
+    #[id]
+    pub id: i64,
+    pub post_id: i64,
+    pub body: String,
+}
+
+#[autumn_web::repository(DepComment, table = "dep_comments", hooks = DepCommentHooks)]
+pub trait DepCommentRepository {}
+
+diesel::table! {
+    dep_votes (id) {
+        id -> Int8,
+        post_id -> Int8,
+        value -> Int4,
+    }
+}
+
+#[autumn_web::model(table = "dep_votes")]
+pub struct DepVote {
+    #[id]
+    pub id: i64,
+    pub post_id: i64,
+    pub value: i32,
+}
+
+#[autumn_web::repository(DepVote, table = "dep_votes")]
+pub trait DepVoteRepository {}
+
+diesel::table! {
+    dep_bookmarks (id) {
+        id -> Int8,
+        post_id -> Nullable<Int8>,
+        label -> Text,
+    }
+}
+
+#[autumn_web::model(table = "dep_bookmarks")]
+pub struct DepBookmark {
+    #[id]
+    pub id: i64,
+    pub post_id: Option<i64>,
+    pub label: String,
+}
+
+#[autumn_web::repository(DepBookmark, table = "dep_bookmarks")]
+pub trait DepBookmarkRepository {}
+
+diesel::table! {
+    dep_awards (id) {
+        id -> Int8,
+        post_id -> Int8,
+        name -> Text,
+    }
+}
+
+#[autumn_web::model(table = "dep_awards")]
+pub struct DepAward {
+    #[id]
+    pub id: i64,
+    pub post_id: i64,
+    pub name: String,
+}
+
+#[autumn_web::repository(DepAward, table = "dep_awards")]
+pub trait DepAwardRepository {}
+
+// ── Soft-delete-aware destroy graph (AC3) ─────────────────────────────────────
+
+diesel::table! {
+    dep_soft_posts (id) {
+        id -> Int8,
+        title -> Text,
+    }
+}
+
+#[autumn_web::model(table = "dep_soft_posts")]
+pub struct DepSoftPost {
+    #[id]
+    pub id: i64,
+    pub title: String,
+}
+
+#[autumn_web::repository(
+    DepSoftPost,
+    table = "dep_soft_posts",
+    dependent(PgDepSoftCommentRepository, fk = "post_id", on_delete = destroy)
+)]
+pub trait DepSoftPostRepository {}
+
+diesel::table! {
+    dep_soft_comments (id) {
+        id -> Int8,
+        post_id -> Int8,
+        body -> Text,
+        deleted_at -> Nullable<Timestamp>,
+    }
+}
+
+#[autumn_web::model(table = "dep_soft_comments")]
+pub struct DepSoftComment {
+    #[id]
+    pub id: i64,
+    pub post_id: i64,
+    pub body: String,
+    pub deleted_at: Option<chrono::NaiveDateTime>,
+}
+
+#[autumn_web::repository(DepSoftComment, table = "dep_soft_comments", soft_delete)]
+pub trait DepSoftCommentRepository {}
+
+// ── Row-count helpers ─────────────────────────────────────────────────────────
+
+#[derive(diesel::QueryableByName)]
+struct CountRow {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    n: i64,
+}
+
+async fn count(conn: &mut AsyncPgConnection, sql: &str) -> i64 {
+    let row: CountRow = diesel::sql_query(sql)
+        .get_result::<CountRow>(conn)
+        .await
+        .expect("count query");
+    row.n
+}
+
+async fn setup_pool() -> (
+    Pool<AsyncPgConnection>,
+    testcontainers::ContainerAsync<Postgres>,
+) {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start postgres container");
+    let host = container.get_host().await.expect("host");
+    let port = container.get_host_port_ipv4(5432).await.expect("port");
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(&url);
+    let pool = Pool::builder(manager).max_size(8).build().expect("pool");
+
+    let mut conn = pool.get().await.expect("conn");
+    for stmt in [
+        "CREATE TABLE dep_posts (id BIGSERIAL PRIMARY KEY, title TEXT NOT NULL)",
+        "CREATE TABLE dep_comments (id BIGSERIAL PRIMARY KEY, post_id BIGINT NOT NULL REFERENCES dep_posts(id), body TEXT NOT NULL)",
+        "CREATE TABLE dep_votes (id BIGSERIAL PRIMARY KEY, post_id BIGINT NOT NULL REFERENCES dep_posts(id), value INT NOT NULL)",
+        "CREATE TABLE dep_bookmarks (id BIGSERIAL PRIMARY KEY, post_id BIGINT REFERENCES dep_posts(id), label TEXT NOT NULL)",
+        "CREATE TABLE dep_awards (id BIGSERIAL PRIMARY KEY, post_id BIGINT NOT NULL REFERENCES dep_posts(id), name TEXT NOT NULL)",
+        "CREATE TABLE dep_soft_posts (id BIGSERIAL PRIMARY KEY, title TEXT NOT NULL)",
+        "CREATE TABLE dep_soft_comments (id BIGSERIAL PRIMARY KEY, post_id BIGINT NOT NULL REFERENCES dep_soft_posts(id), body TEXT NOT NULL, deleted_at TIMESTAMP NULL)",
+    ] {
+        diesel::sql_query(stmt)
+            .execute(&mut conn)
+            .await
+            .unwrap_or_else(|e| panic!("failed to create schema ({stmt}): {e}"));
+    }
+
+    (pool, container)
+}
+
+// ── Non-ignored: generated surface exists without a live database ─────────────
+
+/// AC1: proves the `dependent(...)` codegen ran on every variant — the delete
+/// path (`delete_by_id`) and the connection-taking cascade helper monomorphize
+/// as nameable function items without needing Docker.
+#[test]
+fn dependent_repository_surface_is_generated() {
+    fn assert_is_fn<F>(_f: F) {}
+    assert_is_fn(<PgDepPostRepository as DepPostRepository>::delete_by_id);
+    assert_is_fn(<PgDepPostRestrictOnlyRepository as DepPostRestrictOnlyRepository>::delete_by_id);
+    assert_is_fn(PgDepCommentRepository::__autumn_apply_dependent_on_conn);
+    assert_is_fn(PgDepVoteRepository::__autumn_apply_dependent_on_conn);
+    assert_is_fn(PgDepBookmarkRepository::__autumn_apply_dependent_on_conn);
+    assert_is_fn(PgDepAwardRepository::__autumn_apply_dependent_on_conn);
+    assert_is_fn(PgDepSoftCommentRepository::__autumn_apply_dependent_on_conn);
+}
+
+// ── Tests (require Docker) ────────────────────────────────────────────────────
+
+/// AC1/AC2/AC4/AC6 + success metric: deleting a post with N comments + votes +
+/// bookmarks leaves **zero** orphaned/dangling child rows and **zero** FK
+/// errors, in one transaction. Comments are destroyed via the repository delete
+/// path (firing hooks), votes are bulk-deleted, bookmarks are nullified.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn deleting_parent_cascades_and_leaves_no_orphans() {
+    let (pool, _c) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+
+    diesel::sql_query("INSERT INTO dep_posts (id, title) VALUES (1, 'hello')")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    for i in 1..=3 {
+        diesel::sql_query(format!(
+            "INSERT INTO dep_comments (id, post_id, body) VALUES ({i}, 1, 'c{i}')"
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+        diesel::sql_query(format!(
+            "INSERT INTO dep_votes (id, post_id, value) VALUES ({i}, 1, 1)"
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+        diesel::sql_query(format!(
+            "INSERT INTO dep_bookmarks (id, post_id, label) VALUES ({i}, 1, 'b{i}')"
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    }
+
+    DESTROYED_COMMENTS.store(0, Ordering::SeqCst);
+
+    let repo = PgDepPostRepository::with_pool_untracked(pool.clone());
+    repo.delete_by_id(1)
+        .await
+        .expect("cascade delete must not FK-error");
+
+    // Parent gone.
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_posts WHERE id = 1"
+        )
+        .await,
+        0
+    );
+    // destroy: comments hard-deleted (not soft-delete repo) → 0 orphans.
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_comments WHERE post_id = 1"
+        )
+        .await,
+        0
+    );
+    // delete_all: votes gone.
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_votes WHERE post_id = 1"
+        )
+        .await,
+        0
+    );
+    // nullify: bookmarks survive but detached.
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_bookmarks WHERE post_id = 1"
+        )
+        .await,
+        0
+    );
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_bookmarks WHERE post_id IS NULL"
+        )
+        .await,
+        3
+    );
+    // AC4: each destroyed comment fired its before_delete hook.
+    // (UFCS: `RunQueryDsl` is in scope, so disambiguate from diesel's `.load`.)
+    assert_eq!(AtomicUsize::load(&DESTROYED_COMMENTS, Ordering::SeqCst), 3);
+}
+
+/// AC5: `dependent = restrict` blocks the delete with a typed 409 Conflict when
+/// children exist, and rolls back (parent survives).
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn restrict_blocks_delete_with_conflict_and_rolls_back() {
+    let (pool, _c) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+
+    diesel::sql_query("INSERT INTO dep_posts (id, title) VALUES (5, 'guarded')")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    diesel::sql_query("INSERT INTO dep_awards (id, post_id, name) VALUES (1, 5, 'gold')")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    let repo = PgDepPostRestrictOnlyRepository::with_pool_untracked(pool.clone());
+    let err = repo
+        .delete_by_id(5)
+        .await
+        .expect_err("restrict must block the delete");
+    assert_eq!(
+        err.status(),
+        autumn_web::reexports::http::StatusCode::CONFLICT,
+        "restrict must surface a 409, not a 500"
+    );
+
+    // Rolled back: parent and child both survive.
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_posts WHERE id = 5"
+        )
+        .await,
+        1
+    );
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_awards WHERE post_id = 5"
+        )
+        .await,
+        1
+    );
+}
+
+/// AC3: when the child model is `#[soft_delete]`, a `dependent = destroy`
+/// cascade soft-deletes children (rows remain with `deleted_at` set) rather
+/// than hard-deleting them.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn destroy_is_soft_delete_aware_for_soft_delete_children() {
+    let (pool, _c) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+
+    diesel::sql_query("INSERT INTO dep_soft_posts (id, title) VALUES (9, 'soft')")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    for i in 1..=2 {
+        diesel::sql_query(format!(
+            "INSERT INTO dep_soft_comments (id, post_id, body) VALUES ({i}, 9, 's{i}')"
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    }
+
+    let repo = PgDepSoftPostRepository::with_pool_untracked(pool.clone());
+    repo.delete_by_id(9).await.expect("soft cascade delete");
+
+    // Rows still present (soft-deleted, not hard-deleted) with deleted_at set.
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_soft_comments WHERE post_id = 9"
+        )
+        .await,
+        2,
+        "soft-delete children must not be hard-deleted"
+    );
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_soft_comments WHERE post_id = 9 AND deleted_at IS NOT NULL"
+        )
+        .await,
+        2,
+        "each child must be soft-deleted (deleted_at set)"
+    );
+}

--- a/autumn/tests/integration/repository_dependent_destroy.rs
+++ b/autumn/tests/integration/repository_dependent_destroy.rs
@@ -543,11 +543,13 @@ async fn destroy_soft_parent_soft_deletes_soft_children() {
     );
 }
 
-/// #1369 P1 (hard parent + soft child): a NON-soft parent that `destroy`s a
-/// `#[soft_delete]` child. Because the parent is hard-deleted, the children must
-/// be HARD-deleted too (rows gone) — a soft-deleted child left pointing at a
-/// removed parent would violate the NOT NULL FK and be a semantic orphan. Assert
-/// zero surviving children, zero FK errors, parent gone.
+/// #1369 P1 (hard parent + soft child, incl. a PRE-soft-deleted child): a
+/// NON-soft parent that `destroy`s a `#[soft_delete]` child. Because the parent
+/// is hard-deleted, the children must be HARD-deleted too (rows gone) — even a
+/// child that was ALREADY soft-deleted (deleted_at set) whose NOT NULL FK still
+/// points at the parent. The parent-soft-gated live filter is dropped for a hard
+/// parent, so the cascade selects every physically-present child. Assert zero
+/// surviving children, zero FK errors, parent gone.
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn destroy_hard_parent_hard_deletes_soft_children() {
@@ -566,11 +568,18 @@ async fn destroy_hard_parent_hard_deletes_soft_children() {
         .await
         .unwrap();
     }
+    // Pre-soft-delete one child: its deleted_at is already set, but its NOT NULL
+    // FK still references the parent. This row must NOT be skipped by the live
+    // filter on a hard-parent cascade, or the parent DELETE would FK-fail.
+    diesel::sql_query("UPDATE dep_hard_soft_comments SET deleted_at = now() WHERE id = 2")
+        .execute(&mut conn)
+        .await
+        .unwrap();
 
     let repo = PgDepHardPostRepository::with_pool_untracked(pool.clone());
     repo.delete_by_id(11)
         .await
-        .expect("hard-parent cascade must not FK-error");
+        .expect("hard-parent cascade must not FK-error, even with a pre-soft-deleted child");
 
     // Parent gone.
     assert_eq!(
@@ -581,7 +590,7 @@ async fn destroy_hard_parent_hard_deletes_soft_children() {
         .await,
         0
     );
-    // Soft-delete children were HARD-deleted (rows gone), not left soft-deleted.
+    // All children HARD-deleted (rows gone), including the pre-soft-deleted one.
     assert_eq!(
         count(
             &mut conn,
@@ -589,6 +598,6 @@ async fn destroy_hard_parent_hard_deletes_soft_children() {
         )
         .await,
         0,
-        "a hard-deleted parent must hard-delete its soft-delete children (no orphans, no FK error)"
+        "a hard-deleted parent must hard-delete every physically-present soft-delete child (incl. pre-soft-deleted), leaving no orphan and no FK error"
     );
 }


### PR DESCRIPTION
> ⚠️ **Known deviation from the AC spelling.** The AC example shows `#[has_many(Comment, dependent = destroy)]`, but this PR declares the feature on the **`#[repository(...)]`** macro instead:
>
> ```rust
> #[autumn_web::repository(
>     Post,
>     dependent(PgCommentRepository, fk = "post_id", on_delete = destroy),
>     dependent(PgVoteRepository,    fk = "post_id", on_delete = delete_all),
>     dependent(PgBookmarkRepository, fk = "post_id", on_delete = nullify),
>     dependent(PgAwardRepository,   fk = "post_id", on_delete = restrict),
> )]
> pub trait PostRepository {}
> ```
>
> **Why:** `#[has_many]` is parsed in `autumn-macros/src/model.rs`, whose attribute parser **hard-errors on unknown keys** — so `dependent = …` on `#[has_many]` cannot compile without editing `model.rs`, which is owned by a concurrent wave-4 session during this wave. The repository macro is where `delete_by_id` is generated, so the cascade naturally lives there. **All behavioral ACs are met** (transactional, soft-delete-aware, hook-firing, broadcasts-correct, `restrict` → 409, zero orphans); only the *declaration site* differs. Wiring the Rails-style `#[has_many]` spelling onto this machinery is tracked as a follow-up (see below), so the issue stays open — hence **Part of #1369**, not *Closes*.

## Before / After

**Before** — deleting a parent silently orphans its children. There is no `dependent`/`on_delete` option on any association, and generated migrations emit no FK delete behavior. The flagship reddit-clone `delete_post` runs a bare `diesel::delete(posts::table.find(post.id))` and leaves every comment and vote dangling with a stale `post_id`. Every relational app must hand-roll ordered deletion in a transaction per handler.

**After** — a repository declares how each child is handled when the parent is deleted, and `delete_by_id` performs the declared action for every dependent association **inside a single transaction**, children first, so a delete never leaves orphans, never trips an FK error, and stays consistent with soft-delete + lifecycle/commit hooks + live broadcasts. Four actions:

| action | behavior |
| --- | --- |
| `destroy` | delete each child via the child repository delete path — fires the child's lifecycle/commit hooks and (for a `broadcasts = true` child) publishes its OOB delete fragment; **the soft-delete cascade follows the parent's delete kind** (see below) |
| `delete_all` | one bulk `DELETE`, skipping per-row hooks/broadcasts |
| `nullify` | set the child FK column to `NULL` |
| `restrict` | return a typed **409 Conflict** if a referencing child exists (live children for a soft parent; every physically-present child for a hard parent — see below) |

**Soft-delete cascade semantics — the child follows the *parent's* delete kind.** A `#[soft_delete]` child is only soft-deleted when the parent is itself being soft-deleted (parent row remains, child FK stays valid — the AC3 case). When the parent is **hard-deleted**, its children are **hard-deleted too, even if the child is `#[soft_delete]`** — a soft-deleted child left pointing at a removed parent would violate a NOT NULL FK and be a semantic orphan. Concretely, the `deleted_at IS NULL` **live filter** is **gated on the parent's delete kind** via a `__parent_soft` flag at every cascade site — the `destroy` child-selection and the `restrict` existence probe carry it only for a soft parent, and the per-ID reload that fetches each selected child loads exactly the selected id with **no re-applied `deleted_at` filter** (the id set is already authoritative for the parent kind, and the row is locked with `for_update`). So a hard parent delete covers every physically-present child — including a child that was *already* soft-deleted but whose FK still references the parent — and never drops one at reload. Non-soft children are always hard-deleted; `nullify`/`delete_all` already touch every row.

**Broadcasts (AC4), published post-commit:** a cascaded `destroy` of a `broadcasts = true` child (without `commit_hooks`) produces the same OOB delete fragment the normal `delete_by_id` path emits, **but it is buffered during the cascade and published only after the parent transaction commits** — so a rolled-back cascade broadcasts nothing (clients are never told to remove a child that still exists). Commit-hook children enqueue the broadcast durably as before (no double publish).

## How

- **`autumn/src/repository.rs`** — new public `DependentAction { Destroy, DeleteAll, Nullify, Restrict }` + `publish_deferred_dependent_broadcasts` (cfg-gated post-commit publisher) (core runtime support).
- **`autumn-macros/src/repository.rs`**
  - `RepoConfig.dependents` + parsing of `dependent(ChildRepository, fk = "col", on_delete = …)` on the `#[repository]` attribute.
  - `__autumn_apply_dependent_on_conn(&self, conn, fk, parent_id, action, parent_soft) -> Vec<(topic, dom_id)>` — generated on **every** repository, running on the caller's transaction connection so the parent only needs the child repository *type*. Restrict probes `SELECT EXISTS(… WHERE fk = $1 [live-filter gated on parent_soft])`; nullify/`delete_all` issue bulk statements; destroy selects child ids (live-filter gated on parent_soft), reloads each by exact id (no re-filter), and runs the per-row delete path (`before_delete` hook + soft/hard mutation keyed on `parent_soft` + version history + commit-hook enqueue), **accumulating** broadcasts-only delete payloads to return to the parent.
  - A transactional dependent `delete_by_id` body (single `scoped_transaction`) that loads+locks the parent, cascades to children **before** the parent delete, deletes the parent, and — **after the tx commits** — publishes the accumulated child delete broadcasts. Used only when `dependent(...)` is declared. Wrapped by the existing `cross_shard_write_guard`, so an `across_tenants()` cascade on a sharded+tenant repo is rejected rather than silently skipping children on other shards (honors #1592/#1664/#1687; does not reintroduce the #1692 hole).
- **`autumn/tests/integration/repository_dependent_destroy.rs`** (new) — Docker-gated `#[ignore]` testcontainers cascade tests (no-orphans, `restrict` 409 + rollback, both-soft destroy, hard-parent + soft-child destroy incl. a pre-soft-deleted child) + one non-ignored surface test proving the codegen ran.

## AC audit

| # | Criterion | Status | Evidence |
| --- | --- | --- | --- |
| 1 | 4 variants (`destroy`/`delete_all`/`nullify`/`restrict`) | Met (repository spelling) | `DependentAction` `autumn/src/repository.rs`; parse + apply helper `autumn-macros/src/repository.rs`; tests `parse_repo_args_parses_all_dependent_actions_and_multiple_specs`, `..._rejects_unknown_dependent_action` |
| 2 | Single-txn cascade, rollback on failure | Met (single-record `delete_by_id`; bulk `delete_many` out of scope — see Known limitations) | dependent `delete_body` (one `scoped_transaction`, cascade before parent delete); test `repository_macro_dependent_delete_cascades_inside_transaction_before_parent_delete`; Docker `deleting_parent_cascades_and_leaves_no_orphans` |
| 3 | `destroy` soft-delete-aware (parent soft → children soft, cascade still runs; parent hard → children hard incl. pre-soft-deleted) | Met | child-follows-parent mutation + parent-soft-gated live filter at every cascade site (selection, restrict probe, per-ID reload); tests `repository_macro_dependent_destroy_follows_parent_delete_kind`, `repository_macro_dependent_destroy_helper_is_soft_delete_aware`, `repository_macro_dependent_live_filter_is_parent_soft_gated_not_child_only`, `repository_macro_dependent_restrict_live_filter_gated_on_parent_soft`, `repository_macro_dependent_destroy_reload_does_not_filter_deleted_at`; Docker `destroy_soft_parent_soft_deletes_soft_children`, `destroy_hard_parent_hard_deletes_soft_children` |
| 4 | `destroy` fires child hooks + keeps counter_cache/broadcasts/audit correct | Met | per-row `before_delete` + commit-hook enqueue + **post-commit** OOB broadcast; tests `repository_macro_dependent_destroy_helper_fires_child_hooks`, `repository_macro_dependent_destroy_defers_broadcast_to_post_commit`, `repository_macro_dependent_destroy_commit_hooks_child_enqueues_and_does_not_broadcast`; Docker test asserts hook counter == N |
| 5 | `restrict` typed error, handler surfaces it (no 500) | Met | `AutumnError::conflict_msg` (409) propagated by the scaffold delete handler; parent-soft-gated probe so a hard parent yields 409 (not a raw FK 500); test `repository_macro_dependent_helper_restrict_uses_conflict_error`; Docker `restrict_blocks_delete_with_conflict_and_rolls_back` |
| 6 | Integration test: N children → 0 orphans, 0 FK errors | Met (compile-verified; execution Docker-gated) | `deleting_parent_cascades_and_leaves_no_orphans`; hard-parent + soft-child (incl. pre-soft-deleted) FK-safety in `destroy_hard_parent_hard_deletes_soft_children` |
| 7 | Default (no `dependent`) unchanged | Met | override gated on `config.dependents.is_empty()`; tests `parse_repo_args_dependents_default_empty`, `repository_macro_without_dependents_delete_by_id_has_no_cascade` |

## Verification

- `cargo test -p autumn-macros --lib dependent` → **20 passed; 0 failed** (`cargo test -p autumn-macros --lib` → 425 passed)
- `cargo clippy -p autumn-macros -p autumn-web --all-targets -- -D warnings` → **clean** (exit 0)
- `cargo test -p autumn-web --test integration_tests --no-run` → **compiles** (surface test passes; Docker tests `#[ignore]`)
- `cargo fmt --all` applied

## Known limitations

- **Single-level cascade only.** The `destroy` cascade applies each child's mutation inline but does **not** recursively invoke the child's own `dependent(...)` cascade, so grandchildren (e.g. post → comments → replies) are not handled. Documented at the destroy call site; tracked in **#1702**.
- **`delete_many` bypasses dependent cascade.** The cascade override only replaces the single-record `delete_body`; the bulk `delete_many` path still issues a plain bulk parent delete/soft-delete and does **not** run the dependent actions, so it can FK-fail or orphan children. AC2 scopes dependent actions to the single-record `delete_by_id`/`destroy`; callers who need cascade must use `delete_by_id`. Noted on the generated `delete_many` doc comment; bulk cascade tracked in **#1702**.

## Known follow-ups

- **Wire the `#[has_many(Comment, dependent = destroy)]` spelling** onto this machinery once `model.rs` is free — it would forward the parsed association spec into `RepoConfig.dependents`. Tracked in **#1702**; #1369 stays open until then.
- **Recursive/multi-level cascade** (grandchildren) and **bulk `delete_many` cascade** — see Known limitations; tracked in **#1702**.
- **Docker tests are `#[ignore]`** and were compile-verified only in CI-less local runs; they assert AC 2/3/4/5/6 against a live Postgres when run with testcontainers.

Part of #1369

🤖 Generated with [Claude Code](https://claude.com/claude-code)