### PR TITLE
Auto-attribute audit and version writes to the current actor

### DIFF
--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -871,7 +871,9 @@ fn is_string_param_type(ty: &syn::Type) -> bool {
 /// - `op` — `"insert"`, `"update"`, or `"delete"`
 /// - `with_ctx` — when `true` a `MutationContext` variable named `ctx`
 ///   is in scope; actor / `request_id` are taken from it.
-///   When `false` the actor is hard-coded to `"system"` and `request_id` is `NULL`.
+///   When `false` the actor is read from the ambient current-actor scope
+///   (`Current::actor()`), falling back to `SYSTEM_ACTOR`, and `request_id` is
+///   `NULL`.
 /// - `record_expr` — token stream for the record value (implements `Serialize`)
 /// - `before_expr` — token stream for the "before" record value for updates
 ///   (same type; ignored for inserts/deletes).
@@ -885,10 +887,22 @@ fn vh_insert_ts(
     conn_ident: &TokenStream,
     model_ident: &proc_macro2::Ident,
 ) -> TokenStream {
+    // Choose the version-history actor. Hooked repos read the per-record
+    // `MutationContext` (already seeded from the ambient current actor, and
+    // overridable by a `before_*` hook). Non-hooked repos have no `ctx`, so they
+    // read the ambient current actor directly. Both fall back to the canonical
+    // `SYSTEM_ACTOR` when no actor is in scope.
     let actor_ts = if with_ctx {
-        quote! { ctx.actor.as_deref().unwrap_or("system") }
+        quote! {
+            ctx.actor
+                .clone()
+                .unwrap_or_else(|| ::autumn_web::version_history::VersionEntry::SYSTEM_ACTOR.to_string())
+        }
     } else {
-        quote! { "system" }
+        quote! {
+            ::autumn_web::current::Current::actor()
+                .unwrap_or_else(|| ::autumn_web::version_history::VersionEntry::SYSTEM_ACTOR.to_string())
+        }
     };
     let request_id_ts = if with_ctx {
         quote! { ctx.request_id.as_deref() }
@@ -944,7 +958,7 @@ fn vh_insert_ts(
                 use ::autumn_web::version_history::VersionedRecord as _;
                 (#record_expr).version_tenant_id()
             };
-            let __vh_actor: &str = #actor_ts;
+            let __vh_actor: ::std::string::String = #actor_ts;
             let __vh_request_id: ::core::option::Option<&str> = #request_id_ts;
             ::autumn_web::reexports::diesel::sql_query(
                 "INSERT INTO _autumn_version_history \
@@ -13094,7 +13108,7 @@ mod tests {
             "hooked versioned save_many must record history for each inserted record before moving chunk results: {section}"
         );
         assert!(
-            section.contains("ctx . actor . as_deref"),
+            section.contains("ctx . actor . clone"),
             "hooked versioned save_many history should use the per-record MutationContext: {section}"
         );
     }

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -188,8 +188,11 @@ pub async fn __check_secured_with_key(
         ));
     };
 
-    // Tag the request-scoped log context (#1169) with the authenticated user
-    // so every subsequent event automatically carries `user_id`.
+    // Publish the authenticated principal as the request's current actor
+    // (#1383) so generated repository/audit writes auto-attribute to it, and
+    // tag the request-scoped log context (#1169) with the same user so every
+    // subsequent event automatically carries `user_id`.
+    crate::current::Current::set_actor(user_id.clone());
     crate::log::context::set_user_id(user_id);
 
     // Check authorization: if roles are specified, the session's "role"
@@ -392,9 +395,11 @@ where
                 // "authenticated_principal" works without an extra middleware shim.
                 req.extensions_mut()
                     .insert(crate::security::RateLimitPrincipal(user_id.clone()));
-                // Tag the request-scoped log context (#1169) so handler logs for
-                // middleware-authenticated requests carry `user_id` too, matching
-                // the `#[secured]` path.
+                // Publish the authenticated principal as the request's current
+                // actor (#1383) and tag the request-scoped log context (#1169)
+                // so handler logs for middleware-authenticated requests carry
+                // `user_id` too, matching the `#[secured]` path.
+                crate::current::Current::set_actor(user_id.clone());
                 crate::log::context::set_user_id(user_id);
                 inner.call(req).await
             } else {
@@ -2216,6 +2221,10 @@ where
                     // `#[secured(scopes = …)]` gate and `PolicyContext`
                     // scope-aware helpers read this extension.
                     req.extensions_mut().insert(ApiTokenScopes(scopes));
+                    // Publish the token's principal as the request's current
+                    // actor (#1383) so generated repository/audit writes
+                    // auto-attribute to it.
+                    crate::current::Current::set_actor(principal_id.clone());
                     req.extensions_mut().insert(ApiTokenPrincipal(principal_id));
                     inner.call(req).await
                 }

--- a/autumn/src/auth.rs
+++ b/autumn/src/auth.rs
@@ -192,7 +192,19 @@ pub async fn __check_secured_with_key(
     // (#1383) so generated repository/audit writes auto-attribute to it, and
     // tag the request-scoped log context (#1169) with the same user so every
     // subsequent event automatically carries `user_id`.
-    crate::current::Current::set_actor(user_id.clone());
+    //
+    // Seed the actor only if no stronger/earlier principal is already set. This
+    // `#[secured]` role check runs inside the handler body, *inner* to the auth
+    // middleware layers (`RequireApiToken` bearer, `RequireAuth` session). On a
+    // route that combines `RequireApiToken` with `#[secured]`, the bearer
+    // middleware has already published the token principal by the time this runs;
+    // a request that *also* carries a session cookie must stay attributed to the
+    // token principal, so we must not clobber it with the session user here.
+    // (`log::context::set_user_id` for #1169 is independent and stays
+    // unconditional.)
+    if crate::current::Current::actor().is_none() {
+        crate::current::Current::set_actor(user_id.clone());
+    }
     crate::log::context::set_user_id(user_id);
 
     // Check authorization: if roles are specified, the session's "role"
@@ -399,7 +411,18 @@ where
                 // actor (#1383) and tag the request-scoped log context (#1169)
                 // so handler logs for middleware-authenticated requests carry
                 // `user_id` too, matching the `#[secured]` path.
-                crate::current::Current::set_actor(user_id.clone());
+                //
+                // Seed the actor only if no stronger/earlier principal is already
+                // set. On a normal session-auth route nothing publishes an actor
+                // before this middleware (the outer `LogContextLayer` only
+                // establishes an empty scope), so `actor().is_none()` is true and
+                // this still seeds. The guard keeps the uniform "first/outermost
+                // resolver wins" rule: if an outer bearer layer or an explicit
+                // `with_actor(...)` scope already resolved a principal, that one
+                // stays. (`set_user_id` for #1169 is independent, stays unconditional.)
+                if crate::current::Current::actor().is_none() {
+                    crate::current::Current::set_actor(user_id.clone());
+                }
                 crate::log::context::set_user_id(user_id);
                 inner.call(req).await
             } else {
@@ -2224,7 +2247,17 @@ where
                     // Publish the token's principal as the request's current
                     // actor (#1383) so generated repository/audit writes
                     // auto-attribute to it.
-                    crate::current::Current::set_actor(principal_id.clone());
+                    //
+                    // Seed the actor only if no stronger/earlier principal is
+                    // already set. On a bearer-auth route nothing publishes an
+                    // actor before this middleware (the outer `LogContextLayer`
+                    // only establishes an empty scope), so `actor().is_none()` is
+                    // true and this still seeds. The guard keeps the uniform
+                    // "first/outermost resolver wins" rule: an explicit
+                    // `with_actor(...)` scope already in effect is preserved.
+                    if crate::current::Current::actor().is_none() {
+                        crate::current::Current::set_actor(principal_id.clone());
+                    }
                     req.extensions_mut().insert(ApiTokenPrincipal(principal_id));
                     inner.call(req).await
                 }
@@ -3355,6 +3388,47 @@ mod tests {
         let session = crate::session::Session::new_for_test("sess".into(), data);
         let result = __check_secured(&session, &["admin", "editor"]).await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn check_secured_seeds_actor_when_none_established() {
+        // On a normal single-auth `#[secured]` route nothing publishes an actor
+        // before the role check (the outer `LogContextLayer` establishes only an
+        // empty scope), so the resolved session user becomes the ambient actor
+        // and versioned writes attribute to them (#1383).
+        crate::current::scope_request(async {
+            assert_eq!(crate::current::Current::actor(), None);
+            let data = std::collections::HashMap::from([("user_id".into(), "42".into())]);
+            let session = crate::session::Session::new_for_test("sess".into(), data);
+            let result = __check_secured_with_key(&session, "user_id", &[]).await;
+            assert!(result.is_ok());
+            assert_eq!(crate::current::Current::actor(), Some("42".to_owned()));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn check_secured_preserves_already_established_actor() {
+        // The flagged clobber (#1383): a route that combines `RequireApiToken`
+        // (bearer, OUTER) with `#[secured]` and *also* carries a session cookie.
+        // The bearer middleware has already published the token principal by the
+        // time this inner role check runs; resolving the session user here must
+        // NOT overwrite the stronger, earlier principal, so versioned writes stay
+        // attributed to the token principal rather than the cookie user.
+        crate::current::scope_request(async {
+            crate::current::Current::set_actor("token-principal".to_owned());
+            let data = std::collections::HashMap::from([("user_id".into(), "42".into())]);
+            let session = crate::session::Session::new_for_test("sess".into(), data);
+            let result = __check_secured_with_key(&session, "user_id", &[]).await;
+            // The session still authenticates/authorizes normally...
+            assert!(result.is_ok());
+            // ...but the already-established principal wins as the ambient actor.
+            assert_eq!(
+                crate::current::Current::actor(),
+                Some("token-principal".to_owned())
+            );
+        })
+        .await;
     }
 
     // ── #[secured] macro integration tests ──────────────────────

--- a/autumn/src/authorization.rs
+++ b/autumn/src/authorization.rs
@@ -137,6 +137,25 @@ impl PolicyContext {
     /// instead.
     pub async fn from_session(session: &Session, auth_session_key: &str) -> Self {
         let user_id = session.get(auth_session_key).await;
+
+        // Seed the ambient current actor (#1383) with the authenticated session
+        // user, mirroring how `auth.rs` publishes the principal next to
+        // `log::context::set_user_id`. This is the single seam that covers every
+        // `#[repository(policy = ...)]` route which gates on a
+        // session-authenticated policy check but is NOT also wrapped by
+        // `RequireAuth`/`#[secured]`/an API-token bearer (the three existing
+        // `set_actor` sites) — without this, such a route's versioned writes
+        // would fall back to `SYSTEM_ACTOR` even though a real user is in scope.
+        //
+        // Only an *ambient* seed: it never overrides an explicit `AuditEvent`
+        // actor or a `before_*` hook's `ctx.actor`. `set_actor` is a no-op
+        // outside an established request scope, so this stays panic-safe for
+        // non-request callers (e.g. hand-rolled policy unit tests), and it never
+        // publishes for an anonymous session (guarded on `Some`).
+        if let Some(user_id) = &user_id {
+            crate::current::Current::set_actor(user_id.clone());
+        }
+
         let role = session.get("role").await;
         let roles = role.into_iter().collect();
         Self {
@@ -1136,6 +1155,37 @@ mod tests {
         let c = PolicyContext::from_session(&session, "user_id").await;
         assert!(c.scopes.is_empty());
         assert!(!c.has_scope("posts:read"));
+    }
+
+    #[tokio::test]
+    async fn from_session_seeds_current_actor_for_authenticated_user() {
+        // Mirrors the request path: the log-context middleware establishes an
+        // empty current-actor scope, then a session-authenticated policy check
+        // resolves the user via `from_session`. Even without RequireAuth /
+        // #[secured] / an API-token bearer having fired, the resolved user must
+        // become the ambient actor so versioned writes attribute to them rather
+        // than falling back to SYSTEM_ACTOR (#1383).
+        crate::current::scope_request(async {
+            assert_eq!(crate::current::Current::actor(), None);
+            let session = session_with(Some("42"), Some("editor"));
+            let c = PolicyContext::from_session(&session, "user_id").await;
+            assert_eq!(c.user_id.as_deref(), Some("42"));
+            assert_eq!(crate::current::Current::actor(), Some("42".to_owned()));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn from_session_leaves_current_actor_none_for_anonymous() {
+        // An anonymous session must never publish an actor, so unauthenticated
+        // requests behave exactly as before this feature existed.
+        crate::current::scope_request(async {
+            let session = session_with(None, None);
+            let c = PolicyContext::from_session(&session, "user_id").await;
+            assert!(c.user_id.is_none());
+            assert_eq!(crate::current::Current::actor(), None);
+        })
+        .await;
     }
 
     #[test]

--- a/autumn/src/authorization.rs
+++ b/autumn/src/authorization.rs
@@ -147,12 +147,25 @@ impl PolicyContext {
         // `set_actor` sites) — without this, such a route's versioned writes
         // would fall back to `SYSTEM_ACTOR` even though a real user is in scope.
         //
-        // Only an *ambient* seed: it never overrides an explicit `AuditEvent`
-        // actor or a `before_*` hook's `ctx.actor`. `set_actor` is a no-op
-        // outside an established request scope, so this stays panic-safe for
-        // non-request callers (e.g. hand-rolled policy unit tests), and it never
-        // publishes for an anonymous session (guarded on `Some`).
-        if let Some(user_id) = &user_id {
+        // This session seed is only a *fallback*: it never overrides an
+        // already-established principal. If a stronger actor is already in scope
+        // — an API-token bearer, `RequireAuth`/`#[secured]`, or an explicit
+        // `with_actor(...)` scope — `Current::actor()` is already `Some`, so we
+        // skip the seed and the stronger actor wins (a request carrying both a
+        // bearer token and a session cookie stays attributed to the token
+        // principal). It also never overrides an explicit `AuditEvent` actor or a
+        // `before_*` hook's `ctx.actor`, which are applied downstream.
+        //
+        // In-request but with nothing yet published, the empty `CURRENT_ACTOR`
+        // scope makes `Current::actor()` return `None` (an in-scope unset does not
+        // consult the process default), so a pure policy+session route still gets
+        // seeded here. `set_actor` is a no-op outside an established request scope,
+        // so this stays panic-safe for non-request callers (e.g. hand-rolled
+        // policy unit tests), and it never publishes for an anonymous session
+        // (guarded on `Some`).
+        if crate::current::Current::actor().is_none()
+            && let Some(user_id) = &user_id
+        {
             crate::current::Current::set_actor(user_id.clone());
         }
 
@@ -1184,6 +1197,27 @@ mod tests {
             let c = PolicyContext::from_session(&session, "user_id").await;
             assert!(c.user_id.is_none());
             assert_eq!(crate::current::Current::actor(), None);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn from_session_does_not_override_existing_actor() {
+        // The session seed is only a fallback. When a stronger principal is
+        // already established — an API-token bearer, RequireAuth/#[secured], or an
+        // explicit `with_actor(...)` scope — `from_session` must NOT clobber it,
+        // even if the request also carries a session cookie for a different user.
+        crate::current::scope_request(async {
+            crate::current::Current::set_actor("token-principal".to_owned());
+            let session = session_with(Some("42"), Some("editor"));
+            let c = PolicyContext::from_session(&session, "user_id").await;
+            // The session user is still resolved into the context...
+            assert_eq!(c.user_id.as_deref(), Some("42"));
+            // ...but the already-established principal wins as the ambient actor.
+            assert_eq!(
+                crate::current::Current::actor(),
+                Some("token-principal".to_owned())
+            );
         })
         .await;
     }

--- a/autumn/src/current.rs
+++ b/autumn/src/current.rs
@@ -31,7 +31,12 @@
 //! [`log::context::set_user_id`]: crate::log::context::set_user_id
 
 use std::future::Future;
+use std::pin::Pin;
 use std::sync::{Arc, RwLock};
+use std::task::{Context, Poll};
+
+use http_body::{Body as HttpBody, Frame, SizeHint};
+use pin_project_lite::pin_project;
 
 tokio::task_local! {
     /// The current request's actor scope. Holds a cheap-to-clone,
@@ -164,6 +169,67 @@ pub(crate) fn scope_request<F: Future>(
     CURRENT_ACTOR.scope(ActorScope::empty(), future)
 }
 
+/// Clone the current request's actor-scope handle, if a scope is in effect.
+///
+/// The returned handle is the same cheap-to-clone, interior-mutable storage the
+/// request scope holds, so re-entering it later — e.g. while producing a
+/// lazy/streaming response body after the request future has resolved — observes
+/// any actor the auth layer published during the request. Returns `None` outside
+/// a scope. Mirrors [`log::context::current`](crate::log::context::current).
+pub(crate) fn current_scope() -> Option<ActorScope> {
+    CURRENT_ACTOR.try_with(Clone::clone).ok()
+}
+
+pin_project! {
+    /// Response-body wrapper that re-establishes the request's current-actor
+    /// scope on every frame poll, so a `#[repository(versioned)]` write performed
+    /// while producing a lazy/streaming body (SSE, `Body::from_stream`) still
+    /// records the request's resolved actor instead of falling back to
+    /// `SYSTEM_ACTOR`. The sibling of [`LogContextBody`](crate::middleware::log_context)
+    /// and [`TenantPropagatingBody`](crate::tenancy::TenantPropagatingBody).
+    ///
+    /// Carries the **resolved** [`ActorScope`] handle captured when the response
+    /// was produced (shared, interior-mutable storage from the request), so any
+    /// actor the auth layer set during the request is visible while streaming.
+    pub struct CurrentActorBody<B> {
+        #[pin]
+        inner: B,
+        // `None` only when the body was wrapped outside any request scope, in
+        // which case poll_frame is a transparent pass-through (never panics).
+        scope: Option<ActorScope>,
+    }
+}
+
+impl<B> CurrentActorBody<B> {
+    pub(crate) const fn new(inner: B, scope: Option<ActorScope>) -> Self {
+        Self { inner, scope }
+    }
+}
+
+impl<B: HttpBody> HttpBody for CurrentActorBody<B> {
+    type Data = B::Data;
+    type Error = B::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let this = self.project();
+        match this.scope.clone() {
+            Some(scope) => CURRENT_ACTOR.sync_scope(scope, || this.inner.poll_frame(cx)),
+            None => this.inner.poll_frame(cx),
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.inner.size_hint()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -254,5 +320,24 @@ mod tests {
         // No tokio task-local scope in effect; must be inert, not panic.
         let _ = Current::actor();
         Current::set_actor("x");
+    }
+
+    #[tokio::test]
+    async fn captured_actor_scope_handle_is_reentrant() {
+        // Mirrors the streaming-body path: establish a request scope, let the
+        // auth layer publish the principal, and capture the interior-mutable
+        // scope handle while still inside the request.
+        let handle = scope_request(async {
+            Current::set_actor("streamed-user");
+            current_scope().expect("a scope is established here")
+        })
+        .await;
+
+        // The original request scope has now ended. Re-enter the captured handle
+        // from a DIFFERENT task-local frame (exactly what `CurrentActorBody` does
+        // on each `poll_frame`) and confirm the actor set during the request is
+        // still visible — so writes performed while streaming stay attributed.
+        let seen = CURRENT_ACTOR.sync_scope(handle, Current::actor);
+        assert_eq!(seen, Some("streamed-user".to_owned()));
     }
 }

--- a/autumn/src/current.rs
+++ b/autumn/src/current.rs
@@ -1,0 +1,258 @@
+//! Request-scoped **current actor** — batteries-included "who did this" scope.
+//!
+//! This is the fourth request-scoped ambient value in Autumn, alongside the
+//! [log context](crate::log::context), [tenancy](crate::tenancy), and the
+//! per-request DB-timing accumulator. It answers a single question: *which
+//! principal is responsible for the mutations happening right now?*
+//!
+//! Once the auth layer resolves an authenticated principal it publishes the
+//! principal's id here via [`Current::set_actor`]. From that point on any code
+//! in the request — most importantly the generated repository writes and audit
+//! call sites — can read it ambiently with [`Current::actor`] without
+//! re-extracting the session. Generated `#[repository(versioned)]` writes seed
+//! [`MutationContext::actor`](crate::hooks::MutationContext::actor) from it, so
+//! `VersionEntry.actor` records the authenticated user with **zero** per-call
+//! wiring.
+//!
+//! # Layering
+//!
+//! - **Requests**: the log-context middleware establishes an empty actor scope
+//!   for the whole request; the three auth resolution points then call
+//!   [`Current::set_actor`] (mirroring [`log::context::set_user_id`]).
+//! - **Background jobs / CLI / "on behalf of"**: wrap the work in
+//!   [`with_actor`] to set an explicit actor for that scope.
+//! - **Unconfigured non-request contexts**: fall back to the process-wide
+//!   default actor token (see [`Current::set_default_actor`]); when that is
+//!   unset the actor is simply `None`, exactly as before this feature existed.
+//!
+//! Every read goes through [`tokio::task_local`]'s `try_with`, so reads outside
+//! a scope never panic — they return the configured default (or `None`).
+//!
+//! [`log::context::set_user_id`]: crate::log::context::set_user_id
+
+use std::future::Future;
+use std::sync::{Arc, RwLock};
+
+tokio::task_local! {
+    /// The current request's actor scope. Holds a cheap-to-clone,
+    /// interior-mutable handle so the auth layer can publish the resolved
+    /// principal *after* the scope is established (mirroring the log context).
+    static CURRENT_ACTOR: ActorScope;
+}
+
+/// Process-wide default actor token for non-request contexts (jobs, scheduler,
+/// CLI). `None` by default, in which case out-of-scope reads yield `None` and
+/// behavior is unchanged from before this feature.
+static DEFAULT_ACTOR: RwLock<Option<String>> = RwLock::new(None);
+
+/// A cheap-to-clone, interior-mutable handle to one request's current actor.
+///
+/// Cloning shares the same underlying storage, so the value published by the
+/// auth layer via [`Current::set_actor`] after the scope was established is
+/// observed by every later read within the request.
+#[derive(Clone)]
+pub(crate) struct ActorScope(Arc<RwLock<Option<String>>>);
+
+impl ActorScope {
+    /// An actor scope with no actor yet resolved (the request default).
+    fn empty() -> Self {
+        Self(Arc::new(RwLock::new(None)))
+    }
+
+    /// An actor scope seeded with an explicit value (used by [`with_actor`]).
+    fn with_value(actor_id: Option<String>) -> Self {
+        Self(Arc::new(RwLock::new(actor_id)))
+    }
+
+    /// Read the current actor id, if any.
+    fn get(&self) -> Option<String> {
+        self.0.read().ok().and_then(|guard| guard.clone())
+    }
+
+    /// Publish (or clear) the actor id on this scope.
+    fn set(&self, actor_id: Option<String>) {
+        if let Ok(mut guard) = self.0.write() {
+            *guard = actor_id;
+        }
+    }
+}
+
+/// Public accessor for the ambient "current actor".
+///
+/// This is a zero-sized namespace type; all methods are associated functions.
+#[derive(Debug, Clone, Copy)]
+pub struct Current;
+
+impl Current {
+    /// The id of the actor responsible for the work in the current scope.
+    ///
+    /// Resolution order:
+    /// 1. an explicit actor set on the current scope (via [`with_actor`] or
+    ///    [`Current::set_actor`]);
+    /// 2. `None` when inside a request scope that has not resolved a principal
+    ///    (unauthenticated requests behave exactly as before);
+    /// 3. the process-wide default actor token when **no** scope is in effect
+    ///    (background jobs / CLI / startup) — see [`Current::set_default_actor`].
+    ///
+    /// Never panics: outside any scope it reads the default token, which is
+    /// `None` unless configured.
+    #[must_use]
+    pub fn actor() -> Option<String> {
+        match CURRENT_ACTOR.try_with(ActorScope::get) {
+            Ok(Some(actor_id)) => Some(actor_id),
+            Ok(None) => None,
+            Err(_) => default_actor(),
+        }
+    }
+
+    /// Publish the authenticated principal onto the current request scope.
+    ///
+    /// Called by the auth layer right after it resolves the user id (next to
+    /// [`log::context::set_user_id`](crate::log::context::set_user_id)). No-op
+    /// when called outside of an established scope, so it is always safe.
+    pub fn set_actor(actor_id: impl Into<String>) {
+        let actor_id = actor_id.into();
+        let _ = CURRENT_ACTOR.try_with(|scope| scope.set(Some(actor_id)));
+    }
+
+    /// Set (or clear) the process-wide default actor token used for non-request
+    /// contexts. Pass `None` to restore the "no default" behavior.
+    ///
+    /// This lets a job runner or scheduler attribute writes to a configured
+    /// identity (e.g. `"scheduler"`) instead of silently recording the
+    /// hard-coded `SYSTEM_ACTOR`.
+    pub fn set_default_actor(actor_id: Option<String>) {
+        if let Ok(mut guard) = DEFAULT_ACTOR.write() {
+            *guard = actor_id;
+        }
+    }
+
+    /// The currently configured process-wide default actor token, if any.
+    #[must_use]
+    pub fn default_actor() -> Option<String> {
+        default_actor()
+    }
+}
+
+fn default_actor() -> Option<String> {
+    DEFAULT_ACTOR.read().ok().and_then(|guard| guard.clone())
+}
+
+/// Run `future` with `actor_id` installed as the current actor.
+///
+/// The direct analog of [`tenancy::with_tenant`](crate::tenancy::with_tenant),
+/// for background jobs, CLI tasks, and "acting on behalf of" flows. Nested
+/// calls override the outer actor for the duration of the inner future.
+pub async fn with_actor<F, R>(actor_id: impl Into<String>, future: F) -> R
+where
+    F: Future<Output = R>,
+{
+    CURRENT_ACTOR
+        .scope(ActorScope::with_value(Some(actor_id.into())), future)
+        .await
+}
+
+/// Establish an empty actor scope for a request future.
+///
+/// Used by the log-context middleware so the three auth resolution points can
+/// publish the resolved principal via [`Current::set_actor`] after the request
+/// future has started. Returns the scoping future directly so the middleware
+/// can name it as a concrete `Future` type (no per-request box allocation).
+pub(crate) fn scope_request<F: Future>(
+    future: F,
+) -> tokio::task::futures::TaskLocalFuture<ActorScope, F> {
+    CURRENT_ACTOR.scope(ActorScope::empty(), future)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Serialize tests that touch the process-wide default actor so they don't
+    // race each other (the default is global state).
+    static DEFAULT_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[tokio::test]
+    async fn actor_is_none_outside_scope_by_default() {
+        let _g = DEFAULT_GUARD.lock().unwrap();
+        Current::set_default_actor(None);
+        assert_eq!(Current::actor(), None);
+    }
+
+    #[tokio::test]
+    async fn with_actor_sets_the_ambient_actor() {
+        with_actor("u1", async {
+            assert_eq!(Current::actor(), Some("u1".to_owned()));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn nested_with_actor_overrides_inner_and_restores_outer() {
+        with_actor("outer", async {
+            assert_eq!(Current::actor(), Some("outer".to_owned()));
+            with_actor("inner", async {
+                assert_eq!(Current::actor(), Some("inner".to_owned()));
+            })
+            .await;
+            // Back in the outer scope the outer actor is restored.
+            assert_eq!(Current::actor(), Some("outer".to_owned()));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn set_actor_publishes_onto_an_established_scope() {
+        // Mirrors the request path: an empty scope is established, then the
+        // auth layer publishes the principal via set_actor.
+        scope_request(async {
+            assert_eq!(Current::actor(), None);
+            Current::set_actor("resolved-user");
+            assert_eq!(Current::actor(), Some("resolved-user".to_owned()));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn set_actor_is_a_noop_outside_a_scope() {
+        let _g = DEFAULT_GUARD.lock().unwrap();
+        Current::set_default_actor(None);
+        // Must not panic and must not somehow persist a value.
+        Current::set_actor("nobody");
+        assert_eq!(Current::actor(), None);
+    }
+
+    #[tokio::test]
+    async fn default_actor_is_used_only_out_of_scope() {
+        // The default-dependent assertions touch process-global state, so guard
+        // them (and reset) without holding the lock across an `.await`.
+        {
+            let _g = DEFAULT_GUARD.lock().unwrap();
+            Current::set_default_actor(Some("scheduler".to_owned()));
+            // Out of scope: falls back to the configured default.
+            assert_eq!(Current::actor(), Some("scheduler".to_owned()));
+            // Reset before releasing the guard so no other test observes it.
+            Current::set_default_actor(None);
+            assert_eq!(Current::actor(), None);
+        }
+
+        // The scoped reads below do not depend on the process default: an empty
+        // request scope reads None, and an explicit scope overrides everything.
+        scope_request(async {
+            assert_eq!(Current::actor(), None);
+        })
+        .await;
+
+        with_actor("u1", async {
+            assert_eq!(Current::actor(), Some("u1".to_owned()));
+        })
+        .await;
+    }
+
+    #[test]
+    fn reads_never_panic_without_a_runtime_scope() {
+        // No tokio task-local scope in effect; must be inert, not panic.
+        let _ = Current::actor();
+        Current::set_actor("x");
+    }
+}

--- a/autumn/src/hooks.rs
+++ b/autumn/src/hooks.rs
@@ -787,15 +787,22 @@ mod tests {
 
     // ── MutationContext tests ───────────────────────────────────────
 
-    #[test]
-    fn mutation_context_auto_populates() {
-        let ctx = MutationContext::new(MutationOp::Create);
-        assert!(ctx.actor.is_none());
-        assert!(ctx.request_id.is_some());
-        // UUID v4 format: 8-4-4-4-12 = 36 chars
-        assert_eq!(ctx.request_id.as_ref().unwrap().len(), 36);
-        assert!(matches!(ctx.op, MutationOp::Create));
-        assert!(ctx.invalidate_keys.is_empty());
+    #[tokio::test]
+    async fn mutation_context_auto_populates() {
+        // Construct inside an (empty) request scope so `actor` is deterministically
+        // `None`: an in-scope read never consults the process-global default actor,
+        // which a concurrent test (`current::…default_actor_is_used_only_out_of_scope`)
+        // may transiently have set. Avoids a test-isolation race on that global.
+        crate::current::scope_request(async {
+            let ctx = MutationContext::new(MutationOp::Create);
+            assert!(ctx.actor.is_none());
+            assert!(ctx.request_id.is_some());
+            // UUID v4 format: 8-4-4-4-12 = 36 chars
+            assert_eq!(ctx.request_id.as_ref().unwrap().len(), 36);
+            assert!(matches!(ctx.op, MutationOp::Create));
+            assert!(ctx.invalidate_keys.is_empty());
+        })
+        .await;
     }
 
     #[test]
@@ -815,8 +822,13 @@ mod tests {
 
     #[tokio::test]
     async fn mutation_context_seeds_actor_from_ambient_scope() {
-        // Outside any actor scope the constructor yields `None` (unchanged).
-        assert!(MutationContext::new(MutationOp::Create).actor.is_none());
+        // Inside an (empty) request scope the constructor yields `None`
+        // deterministically — an in-scope read never consults the process-global
+        // default actor a concurrent test may transiently have set (isolation).
+        crate::current::scope_request(async {
+            assert!(MutationContext::new(MutationOp::Create).actor.is_none());
+        })
+        .await;
 
         // Inside `with_actor(...)` the constructor auto-populates the actor.
         crate::current::with_actor("u1", async {

--- a/autumn/src/hooks.rs
+++ b/autumn/src/hooks.rs
@@ -114,13 +114,20 @@ pub struct MutationContext {
 impl MutationContext {
     /// Create a new context for the given operation.
     ///
-    /// Auto-populates `now` with `Utc::now()` and `request_id` with a
-    /// freshly generated UUID v4.
+    /// Auto-populates `now` with `Utc::now()`, `request_id` with a freshly
+    /// generated UUID v4, and `actor` from the ambient
+    /// [`Current::actor`](crate::current::Current::actor) (the authenticated
+    /// principal when inside a request; `None` otherwise).
     #[must_use]
     pub fn new(op: MutationOp) -> Self {
         Self {
             op,
-            actor: None,
+            // Seed the actor from the ambient request-scoped current actor so
+            // generated writes auto-attribute to the authenticated principal
+            // with zero per-call wiring. `None` outside any scope, preserving
+            // the previous behavior. A `before_*` hook still overrides this,
+            // since hooks run after construction.
+            actor: crate::current::Current::actor(),
             request_id: Some(uuid::Uuid::new_v4().to_string()),
             now: chrono::Utc::now(),
             invalidate_keys: Vec::new(),
@@ -804,6 +811,19 @@ mod tests {
         let mut ctx = MutationContext::new(MutationOp::Update);
         ctx.actor = Some("user-123".into());
         assert_eq!(ctx.actor.as_deref(), Some("user-123"));
+    }
+
+    #[tokio::test]
+    async fn mutation_context_seeds_actor_from_ambient_scope() {
+        // Outside any actor scope the constructor yields `None` (unchanged).
+        assert!(MutationContext::new(MutationOp::Create).actor.is_none());
+
+        // Inside `with_actor(...)` the constructor auto-populates the actor.
+        crate::current::with_actor("u1", async {
+            let ctx = MutationContext::new(MutationOp::Create);
+            assert_eq!(ctx.actor.as_deref(), Some("u1"));
+        })
+        .await;
     }
 
     #[test]

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -87,6 +87,7 @@ pub mod canary;
 pub mod circuit_breaker;
 pub mod config;
 pub mod credentials;
+pub mod current;
 #[cfg(feature = "db")]
 pub mod db;
 pub mod dotenv;

--- a/autumn/src/middleware/log_context.rs
+++ b/autumn/src/middleware/log_context.rs
@@ -117,14 +117,22 @@ where
         // poll: a lazy/streaming body (SSE, `Body::from_stream`) is produced
         // after this future resolves, otherwise dropping the context before any
         // stream code runs. Mirrors `TenantPropagatingBody`.
-        Box::pin(context::scoped(ctx, async move {
-            let response = inner.await?;
-            let (parts, body) = response.into_parts();
-            Ok(Response::from_parts(
-                parts,
-                LogContextBody::new(body, body_ctx),
-            ))
-        }))
+        //
+        // Also establish an empty current-actor scope (#1383) for the whole
+        // request so the auth layer can publish the resolved principal via
+        // `Current::set_actor` after the request future has started, and the
+        // generated repository/audit writes read it ambiently.
+        Box::pin(crate::current::scope_request(context::scoped(
+            ctx,
+            async move {
+                let response = inner.await?;
+                let (parts, body) = response.into_parts();
+                Ok(Response::from_parts(
+                    parts,
+                    LogContextBody::new(body, body_ctx),
+                ))
+            },
+        )))
     }
 }
 

--- a/autumn/src/middleware/log_context.rs
+++ b/autumn/src/middleware/log_context.rs
@@ -74,7 +74,7 @@ where
     S::Error: 'static,
     ResBody: HttpBody + Send + 'static,
 {
-    type Response = Response<LogContextBody<ResBody>>;
+    type Response = Response<LogContextBody<crate::current::CurrentActorBody<ResBody>>>;
     type Error = S::Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
@@ -109,6 +109,12 @@ where
         // context installed, so any synchronous work a downstream layer performs
         // in its own `Service::call` (logging, `with_log_field`) is correlated
         // too — not just the async polling of the returned future.
+        //
+        // Note the deliberate asymmetry with the actor scope below: log context
+        // wraps this synchronous `call` (via `sync_scope`) *and* the async future,
+        // whereas `scope_request` wraps only the async future. No downstream
+        // synchronous `call` touches `Current`, so a future author must not add a
+        // synchronous `Current::set_actor` here expecting it to land.
         let inner = span
             .in_scope(|| context::sync_scope(ctx.clone(), || self.inner.call(req)))
             .instrument(span);
@@ -127,9 +133,17 @@ where
             async move {
                 let response = inner.await?;
                 let (parts, body) = response.into_parts();
+                // Capture the request's *resolved* actor scope (the auth layer has
+                // published the principal by now) and re-establish it on every
+                // streamed frame, so a lazy/SSE body's writes stay attributed to
+                // the request actor rather than falling back to SYSTEM_ACTOR.
+                // Wrapped inside the log-context body so both scopes are active
+                // during frame production, consistent with the tenant body wrap.
+                let actor_body =
+                    crate::current::CurrentActorBody::new(body, crate::current::current_scope());
                 Ok(Response::from_parts(
                     parts,
-                    LogContextBody::new(body, body_ctx),
+                    LogContextBody::new(actor_body, body_ctx),
                 ))
             },
         )))

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -141,6 +141,8 @@ mod raw_router_escape_hatch;
 #[cfg(feature = "db")]
 mod read_your_writes_routing;
 #[cfg(feature = "db")]
+mod repository_audit_actor;
+#[cfg(feature = "db")]
 mod repository_authorization;
 #[cfg(feature = "db")]
 mod repository_bulk_operations;

--- a/autumn/tests/integration/repository_audit_actor.rs
+++ b/autumn/tests/integration/repository_audit_actor.rs
@@ -1,0 +1,264 @@
+//! Database-level integration tests for auto-attributing version-history writes
+//! to the ambient current actor (issue #1383).
+//!
+//! **Requires Docker** to be running.
+//!
+//! These exercise the `#[repository(versioned)]` write path end-to-end:
+//! - inside `with_actor("alice", …)` the resulting `VersionEntry.actor` is the
+//!   scoped actor (covers both the non-hooked `Current::actor()` read and the
+//!   hooked `MutationContext.actor` seed);
+//! - with no actor scope in effect the entry falls back to `SYSTEM_ACTOR`.
+
+#![cfg(feature = "db")]
+#![allow(clippy::must_use_candidate, clippy::missing_const_for_fn)]
+
+use autumn_web::current::with_actor;
+use autumn_web::hooks::{MutationHooks, Patch};
+use autumn_web::version_history::{VersionFilter, VersionOp};
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::pooled_connection::deadpool::Pool;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+// ── Non-hooked versioned repo (exercises the direct `Current::actor()` read) ──
+
+diesel::table! {
+    test_audit_actor_records (id) {
+        id -> Int8,
+        name -> Text,
+    }
+}
+
+#[autumn_web::model(table = "test_audit_actor_records")]
+#[derive(PartialEq, Eq)]
+pub struct AuditActorRecord {
+    #[id]
+    pub id: i64,
+    pub name: String,
+}
+
+#[autumn_web::repository(AuditActorRecord, table = "test_audit_actor_records", versioned = true)]
+pub trait AuditActorRecordRepository {}
+
+// ── Hooked versioned repo (exercises the `MutationContext.actor` seed) ────────
+
+diesel::table! {
+    test_audit_actor_hooked_records (id) {
+        id -> Int8,
+        name -> Text,
+    }
+}
+
+#[autumn_web::model(table = "test_audit_actor_hooked_records")]
+#[derive(PartialEq, Eq)]
+pub struct AuditActorHookedRecord {
+    #[id]
+    pub id: i64,
+    pub name: String,
+}
+
+#[derive(Clone, Default)]
+pub struct AuditActorHookedRecordHooks;
+
+impl MutationHooks for AuditActorHookedRecordHooks {
+    type Model = AuditActorHookedRecord;
+    type NewModel = NewAuditActorHookedRecord;
+    type UpdateModel = UpdateAuditActorHookedRecord;
+}
+
+#[autumn_web::repository(
+    AuditActorHookedRecord,
+    table = "test_audit_actor_hooked_records",
+    hooks = AuditActorHookedRecordHooks,
+    versioned = true
+)]
+pub trait AuditActorHookedRecordRepository {}
+
+// ── Setup & helpers ──────────────────────────────────────────────────────────
+
+async fn setup_pool() -> (
+    Pool<AsyncPgConnection>,
+    testcontainers::ContainerAsync<Postgres>,
+) {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start postgres container");
+
+    let host = container.get_host().await.expect("host");
+    let port = container.get_host_port_ipv4(5432).await.expect("port");
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(&url);
+    let pool = Pool::builder(manager).max_size(5).build().expect("pool");
+
+    let mut conn = pool.get().await.expect("conn");
+    diesel::sql_query(
+        "CREATE TABLE IF NOT EXISTS test_audit_actor_records \
+         (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL)",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("create test_audit_actor_records");
+    diesel::sql_query(
+        "CREATE TABLE IF NOT EXISTS test_audit_actor_hooked_records \
+         (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL)",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("create test_audit_actor_hooked_records");
+    diesel::sql_query(
+        "CREATE TABLE IF NOT EXISTS _autumn_version_history (
+            id          BIGSERIAL   PRIMARY KEY,
+            table_name  TEXT        NOT NULL,
+            tenant_id   TEXT,
+            record_id   BIGINT      NOT NULL,
+            op          TEXT        NOT NULL CHECK (op IN ('insert', 'update', 'delete')),
+            actor       TEXT        NOT NULL DEFAULT 'system',
+            request_id  TEXT,
+            changes     JSONB       NOT NULL DEFAULT '[]',
+            recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("create _autumn_version_history");
+
+    (pool, container)
+}
+
+const fn build_repo(pool: Pool<AsyncPgConnection>) -> PgAuditActorRecordRepository {
+    PgAuditActorRecordRepository {
+        pool,
+        __autumn_read_route: autumn_web::repository::ReadRoute::Primary,
+        __autumn_statement_timeout_ms: 0,
+        __autumn_slow_threshold: std::time::Duration::from_millis(500),
+        __autumn_route: None,
+    }
+}
+
+const fn build_hooked_repo(pool: Pool<AsyncPgConnection>) -> PgAuditActorHookedRecordRepository {
+    PgAuditActorHookedRecordRepository {
+        pool,
+        hooks: AuditActorHookedRecordHooks,
+        __autumn_read_route: autumn_web::repository::ReadRoute::Primary,
+        __autumn_statement_timeout_ms: 0,
+        __autumn_slow_threshold: std::time::Duration::from_millis(500),
+        __autumn_route: None,
+    }
+}
+
+/// Actor recorded on the version entry for `op` on record `id`.
+async fn actor_for(repo: &PgAuditActorRecordRepository, id: i64, op: VersionOp) -> Option<String> {
+    let history = repo
+        .version_history(id, VersionFilter::default())
+        .await
+        .unwrap();
+    history
+        .entries
+        .into_iter()
+        .find(|entry| entry.op == op)
+        .map(|entry| entry.actor)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn non_hooked_versioned_writes_record_scoped_actor() {
+    let (pool, _container) = setup_pool().await;
+    let repo = build_repo(pool);
+
+    // create / update / delete all inside an explicit actor scope.
+    let id = with_actor("alice", async {
+        let created = repo
+            .save(&NewAuditActorRecord {
+                name: "row".to_string(),
+            })
+            .await
+            .unwrap();
+        repo.update(
+            created.id,
+            &UpdateAuditActorRecord {
+                name: Patch::Set("row-2".to_string()),
+            },
+        )
+        .await
+        .unwrap();
+        repo.delete_by_id(created.id).await.unwrap();
+        created.id
+    })
+    .await;
+
+    assert_eq!(
+        actor_for(&repo, id, VersionOp::Insert).await.as_deref(),
+        Some("alice"),
+        "insert history must record the scoped actor"
+    );
+    assert_eq!(
+        actor_for(&repo, id, VersionOp::Update).await.as_deref(),
+        Some("alice"),
+        "update history must record the scoped actor"
+    );
+    assert_eq!(
+        actor_for(&repo, id, VersionOp::Delete).await.as_deref(),
+        Some("alice"),
+        "delete history must record the scoped actor"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn non_hooked_versioned_write_without_scope_falls_back_to_system() {
+    let (pool, _container) = setup_pool().await;
+    let repo = build_repo(pool);
+
+    // No actor scope in effect: falls back to SYSTEM_ACTOR.
+    let created = repo
+        .save(&NewAuditActorRecord {
+            name: "unscoped".to_string(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        actor_for(&repo, created.id, VersionOp::Insert)
+            .await
+            .as_deref(),
+        Some("system"),
+        "an unscoped write must fall back to the system actor"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn hooked_versioned_write_records_scoped_actor_via_mutation_context() {
+    let (pool, _container) = setup_pool().await;
+    let repo = build_hooked_repo(pool);
+
+    let id = with_actor("bob", async {
+        let created = repo
+            .save(&NewAuditActorHookedRecord {
+                name: "hooked".to_string(),
+            })
+            .await
+            .unwrap();
+        created.id
+    })
+    .await;
+
+    let history = repo
+        .version_history(id, VersionFilter::default())
+        .await
+        .unwrap();
+    let insert = history
+        .entries
+        .iter()
+        .find(|entry| entry.op == VersionOp::Insert)
+        .expect("expected an insert history entry");
+    assert_eq!(
+        insert.actor, "bob",
+        "hooked versioned insert must seed MutationContext.actor from the scoped actor"
+    );
+}


### PR DESCRIPTION
Closes #1383

**Before:** every generated repository write recorded `MutationContext.actor = None`, so `#[repository(versioned)]` history rows were attributed to `"system"` unless a caller manually threaded the user through a before-hook or `AuditEvent::new`. Auto-attribution rate: 0%.

**After:** once the auth middleware resolves an authenticated principal, that user's ID is ambiently available for the rest of the request (including while a streamed/SSE response body is produced), and generated create/update/delete writes record it as the actor with zero per-call wiring. Unauthenticated requests and out-of-request contexts are unchanged (`None` / `SYSTEM_ACTOR`); no schema change, no migration.

**How:**
- New `autumn_web::current` module: a `CURRENT_ACTOR` task-local holding an interior-mutable `ActorScope` handle (mirrors `log/context.rs`). Public `Current::actor() -> Option<String>` accessor; `with_actor(id, fut)` scope override for jobs/CLI/on-behalf-of; `Current::set_default_actor(Option<String>)` configurable default token for non-request contexts. All reads go through `try_with`, so they no-op (never panic) out of scope.
- The always-on log-context middleware establishes an empty per-request actor scope; the three auth sites (`RequireAuth`, `#[secured]`, `ApiToken` bearer) publish the principal via `Current::set_actor(...)` next to their existing `set_user_id`. A new `CurrentActorBody` response-body wrapper re-enters the resolved scope on each `poll_frame`, so writes during streamed bodies are attributed too (parity with the tenancy / log-context body wrappers).
- `MutationContext::new` seeds `actor` from `Current::actor()`; before-hooks run afterward and still override. The `vh_insert_ts` codegen reads `ctx.actor` (hooked) or `Current::actor()` (non-hooked), both falling back to `VersionEntry::SYSTEM_ACTOR`.

**Tests:** unit tests for scope/override/default/no-panic and `MutationContext` seeding; a macro-expansion assertion update; and a Docker-gated (`#[ignore]`, testcontainers) integration module asserting versioned create/update/delete inside `with_actor("alice", …)` records `alice` and unscoped writes record `system`. `cargo clippy --workspace --all-targets -- -D warnings` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_018jYgA8mVMi5YSDUf3qZYZR)_