### PR TITLE
Probe restrict dependents before mutating dependents on parent delete (Part of #1369)

### DIFF
--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -7893,7 +7893,16 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         } else {
             quote! { false }
         };
-        let cascade_calls = config.dependents.iter().map(|dep| {
+        // #1369 restrict ordering: probe every `restrict` dependent BEFORE
+        // running any mutating dependent (`destroy`/`delete_all`/`nullify`).
+        // Mutating actions fire child `before_delete` hooks (counters, cache
+        // invalidation, external calls) that are NOT commit hooks — a later
+        // `restrict` 409 rolls back the DB but cannot retract those side effects.
+        // Hoisting all restrict probes ahead of the mutating pass means a blocked
+        // delete never touches a child hook. Per-action semantics are unchanged;
+        // only the order within the single transaction changes. `restrict` probes
+        // keep their parent-soft gating and short-circuit via `AutumnError`.
+        let emit_cascade_call = |dep: &DependentSpec| {
             let child_repo = &dep.child_repo;
             let fk = &dep.fk;
             let action_variant = dep.action.variant_ident();
@@ -7915,8 +7924,26 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         .await?
                 );
             }
-        });
-        let cascade_calls = quote! { #(#cascade_calls)* };
+        };
+        let restrict_calls: ::std::vec::Vec<_> = config
+            .dependents
+            .iter()
+            .filter(|dep| dep.action == DependentAction::Restrict)
+            .map(&emit_cascade_call)
+            .collect();
+        let mutating_calls: ::std::vec::Vec<_> = config
+            .dependents
+            .iter()
+            .filter(|dep| dep.action != DependentAction::Restrict)
+            .map(&emit_cascade_call)
+            .collect();
+        let cascade_calls = quote! {
+            // Phase 1: probe all `restrict` dependents first — a 409 here rolls
+            // back before any mutating action fires a child hook.
+            #(#restrict_calls)*
+            // Phase 2: mutating dependents in declaration order.
+            #(#mutating_calls)*
+        };
 
         let tenant_id_setup = if config.tenant_scoped {
             quote! {
@@ -14166,6 +14193,42 @@ mod tests {
         assert!(
             cascade_pos < parent_delete_pos,
             "children must be cascaded before the parent DELETE: {section}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_dependent_restrict_probes_before_mutating_actions() {
+        // #1369 restrict ordering: even when a mutating dependent (destroy) is
+        // declared BEFORE a `restrict` dependent, the generated delete_by_id must
+        // run ALL restrict probes before ANY mutating apply call — so a 409 rolls
+        // back before a child `before_delete` side effect ever fires.
+        let generated = repository_macro(
+            quote! {
+                Post,
+                dependent(PgCommentRepository, fk = "post_id", on_delete = destroy),
+                dependent(PgVoteRepository, fk = "post_id", on_delete = delete_all),
+                dependent(PgAwardRepository, fk = "post_id", on_delete = restrict),
+                dependent(PgBadgeRepository, fk = "post_id", on_delete = restrict)
+            },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+        let section = delete_by_id_section(&generated);
+        // Every restrict apply call must precede every mutating apply call. The
+        // apply calls pass the action as `DependentAction :: <Variant>`.
+        let last_restrict = section
+            .rfind("DependentAction :: Restrict")
+            .expect("restrict apply calls must be emitted");
+        let first_mutating = section
+            .find("DependentAction :: Destroy")
+            .into_iter()
+            .chain(section.find("DependentAction :: DeleteAll"))
+            .chain(section.find("DependentAction :: Nullify"))
+            .min()
+            .expect("mutating apply calls must be emitted");
+        assert!(
+            last_restrict < first_mutating,
+            "all restrict probes must be hoisted ahead of the first mutating apply call: {section}"
         );
     }
 

--- a/autumn/src/repository.rs
+++ b/autumn/src/repository.rs
@@ -160,10 +160,13 @@ pub fn publish_deferred_dependent_broadcasts(broadcasts: Vec<(String, String)>) 
     }
     if let Some(channels) = crate::__private::get_global_channels() {
         let fragment = crate::html! {};
-        for (topic, dom_id) in &broadcasts {
+        // Consume the buffer so the owned (topic, dom_id) strings move straight
+        // into the publish call (no needless clone, and the `Vec` is consumed —
+        // avoiding `clippy::needless_pass_by_value`).
+        for (topic, dom_id) in broadcasts {
             if let Err(err) = channels.broadcast().publish_oob(
-                topic,
-                dom_id,
+                &topic,
+                &dom_id,
                 &crate::htmx::OobSwap::Delete,
                 &fragment,
             ) {

--- a/autumn/tests/integration/repository_dependent_destroy.rs
+++ b/autumn/tests/integration/repository_dependent_destroy.rs
@@ -601,3 +601,85 @@ async fn destroy_hard_parent_hard_deletes_soft_children() {
         "a hard-deleted parent must hard-delete every physically-present soft-delete child (incl. pre-soft-deleted), leaving no orphan and no FK error"
     );
 }
+
+/// #1369 restrict ordering: `DepPost` declares `destroy(Comment)` BEFORE
+/// `restrict(Award)`, and `DepComment`'s `before_delete` increments a counter.
+/// When a restrict child (award) has rows, `delete_by_id` must return 409 and
+/// roll back WITHOUT ever firing the destroy child's `before_delete` — the
+/// restrict probe runs before any mutating dependent. Asserts: 409, the destroy
+/// hook counter did NOT move, and nothing was deleted.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn restrict_probes_before_destroy_fires_no_child_hooks() {
+    let (pool, _c) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+
+    diesel::sql_query("INSERT INTO dep_posts (id, title) VALUES (21, 'guarded')")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    for i in 1..=3 {
+        diesel::sql_query(format!(
+            "INSERT INTO dep_comments (id, post_id, body) VALUES ({i}, 21, 'c{i}')"
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    }
+    // A restrict child (award) with a row → the delete must be blocked.
+    diesel::sql_query("INSERT INTO dep_awards (id, post_id, name) VALUES (1, 21, 'gold')")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    DESTROYED_COMMENTS.store(0, Ordering::SeqCst);
+
+    let repo = PgDepPostRepository::with_pool_untracked(pool.clone());
+    let err = repo
+        .delete_by_id(21)
+        .await
+        .expect_err("restrict child with rows must block the delete");
+    assert_eq!(
+        err.status(),
+        autumn_web::reexports::http::StatusCode::CONFLICT,
+        "a blocking restrict must surface a 409"
+    );
+
+    // The destroy child's before_delete hook must NOT have fired — the restrict
+    // probe runs before any mutating dependent, so no non-transactional side
+    // effect happened for a delete that never committed.
+    assert_eq!(
+        AtomicUsize::load(&DESTROYED_COMMENTS, Ordering::SeqCst),
+        0,
+        "restrict must be probed before destroy so the child before_delete hook never fires"
+    );
+
+    // Nothing was deleted (whole tx rolled back).
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_posts WHERE id = 21"
+        )
+        .await,
+        1,
+        "the parent must survive a blocked delete"
+    );
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_comments WHERE post_id = 21"
+        )
+        .await,
+        3,
+        "the destroy child rows must be untouched"
+    );
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_awards WHERE post_id = 21"
+        )
+        .await,
+        1,
+        "the restrict child row must survive"
+    );
+}


### PR DESCRIPTION
Follow-up to the merged #1701 (dependent destroy/nullify/restrict cascade). **Part of #1369.**

> Also folds in a small fix for a **pre-existing trunk-dev clippy lint** in the same file: `clippy::needless_pass_by_value` on `publish_deferred_dependent_broadcasts` (added by #1701). It only surfaces at **workspace scope under the `ws` feature**, where the real cfg-gated body (not the no-op fallback) is compiled — the per-crate/default-feature clippy runs used the no-op arm and never triggered it. The helper now consumes the `Vec` via `.into_iter()` (owned strings move straight into `publish_oob`, no clone); signature and behavior unchanged.

## Before / After

**Before** — dependent actions ran in **declaration order** inside the `delete_by_id` transaction. If a mutating dependent (`destroy`/`delete_all`/`nullify`) was declared **before** a `restrict` dependent, the mutating action ran first — `destroy` fires each child's `before_delete` hook (counters, cache invalidation, external calls; these are **not** commit hooks, so they are not rolled back) — and only *then* did the later `restrict` probe find rows, return **409**, and roll the transaction back. The database rolled back cleanly, but those non-transactional side effects had already fired for a delete that never committed.

```rust
#[repository(Post,
  dependent(PgCommentRepository, fk = "post_id", on_delete = destroy),  // fires before_delete first…
  dependent(PgAwardRepository,   fk = "post_id", on_delete = restrict), // …then blocks with 409 + rollback
)]
```

**After** — the cascade emission is split into two phases within the same transaction:
1. **Phase 1** — probe every `restrict` dependent first (reusing the existing `AutumnError::conflict_msg` 409 path). If any restrict association has rows, the 409 short-circuits **before any mutating action runs**.
2. **Phase 2** — run the mutating dependents (`destroy`/`delete_all`/`nullify`) in declaration order, exactly as today.

A blocked delete therefore never touches a child hook. Only the **order** changes; every per-action behavior is unchanged.

## How

- **`autumn-macros/src/repository.rs`** — where `delete_by_id`'s `#cascade_calls` is built, partition `config.dependents` into `restrict` and non-`restrict` at codegen time and emit the restrict apply calls first, the mutating apply calls second. Everything else is intact: single `scoped_transaction`, cascade before the parent mutation, parent-soft gating on the live filters (selection + restrict probe + reload), deferred post-commit broadcast buffer, cross-shard write guard, and `destroy` hook firing.
- **`autumn/src/repository.rs`** — `publish_deferred_dependent_broadcasts` now consumes its `Vec` argument (fixes the `needless_pass_by_value` lint described above).

## Tests

- **Expansion** (`repository_macro_dependent_restrict_probes_before_mutating_actions`): a repo declaring `destroy` + `delete_all` **before** two `restrict` dependents — asserts every restrict apply call precedes the first mutating apply call (token-position ordering).
- **Docker `#[ignore]`** (`restrict_probes_before_destroy_fires_no_child_hooks`): `DepPost` declares `destroy(Comment)` before `restrict(Award)`, and `DepComment::before_delete` increments a counter. With an award row present, `delete_by_id` returns **409**, the destroy child's `before_delete` counter stays **0**, and nothing is deleted (whole tx rolled back). Compile-verified (testcontainers-gated).
- All existing dependent unit tests remain green (reorder only).

## Verification

- `cargo test -p autumn-macros --lib dependent` → **21 passed; 0 failed**
- `cargo clippy --workspace --all-targets --features ws -- -D warnings` → **clean** (exit 0) — reproduces + clears the pre-existing lint
- `cargo test -p autumn-web --test integration_tests --no-run` → **compiles** (Docker tests `#[ignore]`)
- `cargo fmt --all` applied

Part of #1369

🤖 Generated with [Claude Code](https://claude.com/claude-code)