### PR TITLE
Render compiler diagnostics as a browser overlay on failed dev rebuilds (#1115)

### DIFF
--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -833,7 +833,7 @@ fn cargo_build_capturing(package: Option<&str>) -> (bool, Vec<BuildDiagnostic>) 
                 // whatever we captured so far rather than panicking.
                 break;
             };
-            if let Some(rendered) = error_rendered_from_line(&line) {
+            if let Some(rendered) = compiler_message_rendered(&line) {
                 eprint!("{rendered}");
             }
             buffer.push_str(&line);
@@ -856,27 +856,28 @@ fn cargo_build_capturing(package: Option<&str>) -> (bool, Vec<BuildDiagnostic>) 
 }
 
 /// If `line` is a single `cargo build --message-format=json` record that is a
-/// `compiler-message` at `error` level, return its `rendered` text so it can be
-/// echoed to the terminal the instant it arrives. Non-JSON lines, warnings, and
-/// other message kinds yield `None`. Mirrors the filtering in
-/// [`parse_build_diagnostics`] so the live echo and the returned diagnostics
-/// stay in agreement.
-fn error_rendered_from_line(line: &str) -> Option<String> {
+/// `compiler-message` carrying a non-empty `rendered` block, return that text so
+/// it can be echoed to the terminal the instant it arrives. This deliberately
+/// echoes diagnostics at *every* level (errors, warnings, notes, help, etc.) so
+/// the live output matches what plain `cargo build` would print — the overlay
+/// payload, built separately by [`parse_build_diagnostics`], stays errors-only.
+/// Non-JSON lines and non-`compiler-message` records (artifacts, build scripts,
+/// build-finished) yield `None`, as do compiler messages with no `rendered`
+/// text.
+fn compiler_message_rendered(line: &str) -> Option<String> {
     let value = serde_json::from_str::<serde_json::Value>(line).ok()?;
     if value.get("reason").and_then(serde_json::Value::as_str) != Some("compiler-message") {
         return None;
     }
-    let message = value.get("message")?;
-    if message.get("level").and_then(serde_json::Value::as_str) != Some("error") {
+    let rendered = value
+        .get("message")?
+        .get("rendered")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    if rendered.is_empty() {
         return None;
     }
-    Some(
-        message
-            .get("rendered")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or_default()
-            .to_owned(),
-    )
+    Some(rendered.to_owned())
 }
 
 /// Run `cargo build` for the given package. Returns true on success.
@@ -2197,6 +2198,43 @@ mod tests {
         assert_eq!(diags[1].file, "src/lib.rs");
         assert_eq!(diags[1].line, 12);
         assert_eq!(diags[1].column, 9);
+    }
+
+    #[test]
+    fn compiler_message_rendered_echoes_all_levels_but_not_other_records() {
+        // Warning-level messages must be echoed live so the terminal matches
+        // plain `cargo build` output, even though they never enter the overlay.
+        let warning = r#"{"reason":"compiler-message","message":{"code":null,"level":"warning","message":"unused variable: `x`","rendered":"warning: unused variable\n"}}"#;
+        assert_eq!(
+            compiler_message_rendered(warning).as_deref(),
+            Some("warning: unused variable\n"),
+        );
+
+        // Error-level messages are echoed too.
+        let error = r#"{"reason":"compiler-message","message":{"code":{"code":"E0425"},"level":"error","message":"cannot find value `foo`","rendered":"error[E0425]: cannot find value `foo`\n"}}"#;
+        assert_eq!(
+            compiler_message_rendered(error).as_deref(),
+            Some("error[E0425]: cannot find value `foo`\n"),
+        );
+
+        // Non-JSON progress lines yield nothing.
+        assert_eq!(compiler_message_rendered("   Compiling app v0.1.0"), None);
+
+        // Non-`compiler-message` records (artifacts, build scripts, finished)
+        // are never echoed.
+        assert_eq!(
+            compiler_message_rendered(r#"{"reason":"compiler-artifact","target":{"name":"app"}}"#),
+            None,
+        );
+
+        // A compiler message with no `rendered` text yields nothing rather than
+        // an empty echo.
+        assert_eq!(
+            compiler_message_rendered(
+                r#"{"reason":"compiler-message","message":{"level":"warning","message":"x"}}"#
+            ),
+            None,
+        );
     }
 
     /// A representative single-error diagnostic list for the build-error tests.

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -712,31 +712,83 @@ fn parse_build_diagnostics(stdout: &[u8]) -> Vec<BuildDiagnostic> {
 /// Used by the watch loop so a failed rebuild can surface errors as a browser
 /// overlay; `serve` keeps using [`cargo_build`].
 fn cargo_build_capturing(package: Option<&str>) -> (bool, Vec<BuildDiagnostic>) {
+    use std::io::{BufRead, BufReader};
+
     let mut cmd = build_cargo_command(package, false);
     cmd.arg("--message-format=json");
+    // Pipe stdout so we can read structured JSON diagnostics line by line as the
+    // compiler emits them, while cargo's own progress/status output (the live
+    // "Compiling ..." lines) streams straight through on inherited stderr. This
+    // keeps the terminal responsive instead of freezing until the build ends.
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::inherit());
 
     eprintln!("  Compiling...");
-    let output = match cmd.output() {
-        Ok(output) => output,
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
         Err(e) => {
             eprintln!("  \u{2717} Failed to run cargo build: {e}");
             return (false, Vec::new());
         }
     };
 
-    let diagnostics = parse_build_diagnostics(&output.stdout);
-    // Echo the rendered diagnostics so the terminal still shows the errors
-    // (JSON message-format suppresses the usual human-readable stderr output).
-    for diagnostic in &diagnostics {
-        eprint!("{}", diagnostic.rendered);
+    // Accumulate raw stdout so `parse_build_diagnostics` can build the returned
+    // Vec once at the end. Error `rendered` blocks are echoed live in compiler
+    // order as their lines arrive, so each error appears exactly once and the
+    // final parse never re-prints them.
+    let mut buffer = String::new();
+    if let Some(stdout) = child.stdout.take() {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            let Ok(line) = line else {
+                // A read error mid-stream: stop consuming and fall back to
+                // whatever we captured so far rather than panicking.
+                break;
+            };
+            if let Some(rendered) = error_rendered_from_line(&line) {
+                eprint!("{rendered}");
+            }
+            buffer.push_str(&line);
+            buffer.push('\n');
+        }
     }
 
-    if output.status.success() {
-        eprintln!("  \u{2713} Build succeeded");
-        (true, diagnostics)
-    } else {
-        (false, diagnostics)
+    let diagnostics = parse_build_diagnostics(buffer.as_bytes());
+    match child.wait() {
+        Ok(status) if status.success() => {
+            eprintln!("  \u{2713} Build succeeded");
+            (true, diagnostics)
+        }
+        Ok(_) => (false, diagnostics),
+        Err(e) => {
+            eprintln!("  \u{2717} cargo build failed: {e}");
+            (false, diagnostics)
+        }
     }
+}
+
+/// If `line` is a single `cargo build --message-format=json` record that is a
+/// `compiler-message` at `error` level, return its `rendered` text so it can be
+/// echoed to the terminal the instant it arrives. Non-JSON lines, warnings, and
+/// other message kinds yield `None`. Mirrors the filtering in
+/// [`parse_build_diagnostics`] so the live echo and the returned diagnostics
+/// stay in agreement.
+fn error_rendered_from_line(line: &str) -> Option<String> {
+    let value = serde_json::from_str::<serde_json::Value>(line).ok()?;
+    if value.get("reason").and_then(serde_json::Value::as_str) != Some("compiler-message") {
+        return None;
+    }
+    let message = value.get("message")?;
+    if message.get("level").and_then(serde_json::Value::as_str) != Some("error") {
+        return None;
+    }
+    Some(
+        message
+            .get("rendered")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_owned(),
+    )
 }
 
 /// Run `cargo build` for the given package. Returns true on success.

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -132,6 +132,14 @@ impl ChangePlan {
 struct DevReloadState {
     path: PathBuf,
     version: u64,
+    /// The build-error payload for the currently-broken Rust build, if any.
+    ///
+    /// When set, every ordinary [`Self::signal`] re-emits it so a non-build
+    /// reload (CSS/Tailwind/static save routed through the watch loop) keeps
+    /// the compile-error overlay up instead of dismissing it and reloading the
+    /// still-broken stale app. Only a green Rust build clears it, via
+    /// [`Self::signal_build_success`].
+    active_build_error: Option<(Vec<BuildDiagnostic>, bool)>,
 }
 
 impl DevReloadState {
@@ -142,7 +150,11 @@ impl DevReloadState {
                 .map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
         }
 
-        let state = Self { path, version: 0 };
+        let state = Self {
+            path,
+            version: 0,
+            active_build_error: None,
+        };
         state.write(ReloadKind::Full)?;
         Ok(state)
     }
@@ -151,6 +163,14 @@ impl DevReloadState {
         &self.path
     }
 
+    /// Signal an ordinary reload (CSS/Tailwind/full). Bumps the version and
+    /// writes fresh state.
+    ///
+    /// If a Rust build is currently broken (`active_build_error` is `Some`),
+    /// the build-error payload is CARRIED FORWARD into the new state so the
+    /// overlay survives — a CSS/Tailwind/static save while the code doesn't
+    /// compile must not dismiss the overlay and reload the stale app. Only a
+    /// green Rust build ([`Self::signal_build_success`]) clears it.
     fn signal(&mut self, kind: ReloadKind) -> Result<(), String> {
         if kind == ReloadKind::None {
             return Ok(());
@@ -160,17 +180,27 @@ impl DevReloadState {
             .version
             .checked_add(1)
             .ok_or("live reload version overflowed")?;
-        self.write(kind)
+
+        if let Some((diagnostics, stale)) = self.active_build_error.as_ref() {
+            let (diagnostics, stale) = (diagnostics.clone(), *stale);
+            self.write_build_error(&diagnostics, stale)
+        } else {
+            self.write(kind)
+        }
     }
 
     /// Bump the version and write a full-reload state carrying compiler
     /// diagnostics so the browser client renders a compile-error overlay
     /// instead of reloading into a broken/stale page.
     ///
+    /// The payload is also stashed in `active_build_error` so subsequent
+    /// ordinary [`Self::signal`] calls carry it forward and keep the overlay
+    /// up until a green build clears it.
+    ///
     /// `stale` is true when a previously-built binary is still serving (the
-    /// browser is looking at a now-outdated page); false on a cold start where
-    /// no server is up yet. A subsequent [`Self::signal`] writes state with no
-    /// `build_error` field, which the client treats as "clear the overlay".
+    /// browser is looking at a now-outdated page); false on a cold start (or
+    /// on Windows, where the old binary must be stopped before rebuilding)
+    /// where no server is up yet.
     fn signal_build_error(
         &mut self,
         diagnostics: &[BuildDiagnostic],
@@ -181,6 +211,39 @@ impl DevReloadState {
             .checked_add(1)
             .ok_or("live reload version overflowed")?;
 
+        self.active_build_error = Some((diagnostics.to_vec(), stale));
+        self.write_build_error(diagnostics, stale)
+    }
+
+    /// Clear a previously-signaled build error after a GREEN Rust build, then
+    /// write ordinary reload state (with NO `build_error` field) so the client
+    /// dismisses the overlay and reloads into the freshly-built app.
+    ///
+    /// This is the ONLY path that clears the overlay: an ordinary
+    /// [`Self::signal`] carries an active build error forward instead.
+    fn signal_build_success(&mut self, kind: ReloadKind) -> Result<(), String> {
+        self.active_build_error = None;
+        // A successful build always warrants a reload to pick up the new
+        // binary, so treat `None` as a full reload rather than a no-op.
+        let kind = if kind == ReloadKind::None {
+            ReloadKind::Full
+        } else {
+            kind
+        };
+
+        self.version = self
+            .version
+            .checked_add(1)
+            .ok_or("live reload version overflowed")?;
+        self.write(kind)
+    }
+
+    /// Write full-reload state carrying a `build_error` payload.
+    fn write_build_error(
+        &self,
+        diagnostics: &[BuildDiagnostic],
+        stale: bool,
+    ) -> Result<(), String> {
         let body = serde_json::json!({
             "version": self.version,
             "kind": "full",
@@ -503,58 +566,83 @@ fn execute_plan(
     mut reload_state: Option<&mut DevReloadState>,
     show_config: bool,
 ) {
-    let mut applied_reload = ReloadKind::None;
-
     if plan.build {
-        // Build FIRST, with the old binary still running. Only tear it down
-        // once we have a fresh binary to replace it with — otherwise a failed
-        // rebuild would leave the app DOWN and the browser would see a
-        // connection-refused/stale page instead of a diagnostics overlay.
+        // The order of "stop old binary" vs. "cargo build" is platform-gated.
+        //
+        // On Unix/macOS, replacing a running binary file mid-build is safe
+        // (inode semantics), so we build FIRST with the old binary still
+        // serving. A failed rebuild then leaves the stale app up to answer the
+        // live-reload endpoint and render the diagnostics overlay.
+        //
+        // On Windows the running `target/debug/<app>.exe` is LOCKED while the
+        // process is alive, so `cargo build` can't relink over it (access
+        // denied / linker failure). There we must stop the old binary BEFORE
+        // building. The tradeoff: a failed Windows rebuild leaves the app down,
+        // so the overlay's stale-page serving isn't available and the client
+        // falls back to a normal reconnect (documented limitation).
+        let stop_before_build = cfg!(windows);
+
+        if stop_before_build {
+            stop_server(child);
+        }
+
         let (built, diagnostics) = cargo_build_capturing(package);
 
         if built {
-            stop_server(child);
+            if !stop_before_build {
+                stop_server(child);
+            }
             if restart_server(
                 package,
                 child,
                 reload_state.as_ref().map(|s| s.path()),
                 show_config,
-            ) {
-                // A normal full reload clears any prior build-error overlay.
-                applied_reload = ReloadKind::Full;
+            ) && let Some(reload_state) = reload_state.as_mut()
+                && let Err(error) = reload_state.signal_build_success(ReloadKind::Full)
+            {
+                // A green build is the only thing that clears the overlay.
+                eprintln!("  Warning: live reload signal failed: {error}");
             }
         } else {
             eprintln!("  \u{2717} Build failed. Waiting for changes...\n");
-            // Leave the (stale) binary running so it keeps answering the
-            // live-reload state endpoint; the browser then renders the overlay.
+            // On Unix the (stale) binary is still running, so it keeps
+            // answering the live-reload state endpoint and the browser renders
+            // the overlay. On Windows we already stopped it above, so nothing
+            // is serving: `child.is_some()` is false there and the client
+            // falls back to a normal reconnect.
             let stale = child.is_some();
             if let Some(reload_state) = reload_state.as_mut()
                 && let Err(error) = reload_state.signal_build_error(&diagnostics, stale)
             {
                 eprintln!("  Warning: live reload signal failed: {error}");
             }
-            return;
         }
-    } else {
-        if plan.tailwind && tailwind_build() {
-            applied_reload = applied_reload.max(ReloadKind::Css);
-        }
-
-        if plan.restart {
-            stop_server(child);
-            if restart_server(
-                package,
-                child,
-                reload_state.as_ref().map(|s| s.path()),
-                show_config,
-            ) {
-                applied_reload = ReloadKind::Full;
-            }
-        } else if plan.reload == ReloadKind::Full {
-            applied_reload = ReloadKind::Full;
-        }
+        return;
     }
 
+    let mut applied_reload = ReloadKind::None;
+
+    if plan.tailwind && tailwind_build() {
+        applied_reload = applied_reload.max(ReloadKind::Css);
+    }
+
+    if plan.restart {
+        stop_server(child);
+        if restart_server(
+            package,
+            child,
+            reload_state.as_ref().map(|s| s.path()),
+            show_config,
+        ) {
+            applied_reload = ReloadKind::Full;
+        }
+    } else if plan.reload == ReloadKind::Full {
+        applied_reload = ReloadKind::Full;
+    }
+
+    // Ordinary (non-build) reload. If a Rust build is still broken,
+    // `signal` carries the build-error overlay forward instead of dismissing
+    // it, so this CSS/Tailwind/static change doesn't reload the stale app.
     if let Some(reload_state) = reload_state.as_mut()
         && let Err(error) = reload_state.signal(applied_reload)
     {
@@ -2052,7 +2140,11 @@ mod tests {
     fn dev_reload_state_signal_writes_css_and_full_versions() {
         let reload_file = tempfile::NamedTempFile::new().expect("reload file");
         let path = reload_file.path().to_path_buf();
-        let mut state = DevReloadState { path, version: 0 };
+        let mut state = DevReloadState {
+            path,
+            version: 0,
+            active_build_error: None,
+        };
 
         state.signal(ReloadKind::Css).expect("css signal");
         let body = std::fs::read_to_string(state.path()).expect("read css");
@@ -2107,20 +2199,29 @@ mod tests {
         assert_eq!(diags[1].column, 9);
     }
 
-    #[test]
-    fn dev_reload_state_signal_build_error_writes_and_full_clears() {
-        let reload_file = tempfile::NamedTempFile::new().expect("reload file");
-        let path = reload_file.path().to_path_buf();
-        let mut state = DevReloadState { path, version: 0 };
-
-        let diags = vec![BuildDiagnostic {
+    /// A representative single-error diagnostic list for the build-error tests.
+    fn sample_build_diagnostics() -> Vec<BuildDiagnostic> {
+        vec![BuildDiagnostic {
             code: Some("E0425".to_owned()),
             message: "cannot find value `foo`".to_owned(),
             file: "src/main.rs".to_owned(),
             line: 3,
             column: 5,
             rendered: "error[E0425]: cannot find value `foo`".to_owned(),
-        }];
+        }]
+    }
+
+    #[test]
+    fn dev_reload_state_signal_build_error_writes_payload() {
+        let reload_file = tempfile::NamedTempFile::new().expect("reload file");
+        let path = reload_file.path().to_path_buf();
+        let mut state = DevReloadState {
+            path,
+            version: 0,
+            active_build_error: None,
+        };
+
+        let diags = sample_build_diagnostics();
 
         state
             .signal_build_error(&diags, true)
@@ -2143,26 +2244,107 @@ mod tests {
             value["build_error"]["diagnostics"][0]["message"],
             "cannot find value `foo`"
         );
+    }
 
-        // A subsequent normal full signal must clear the build_error field so
-        // the browser overlay dismisses and the page reloads.
+    #[test]
+    fn dev_reload_state_signal_carries_build_error_across_non_build_reloads() {
+        // P2 regression guard: once a Rust build is broken, an ordinary CSS
+        // (or other non-build) reload must NOT dismiss the overlay. It carries
+        // the build_error payload forward while still bumping the version so
+        // the client re-polls but stays on the overlay instead of reloading the
+        // stale app.
+        let reload_file = tempfile::NamedTempFile::new().expect("reload file");
+        let path = reload_file.path().to_path_buf();
+        let mut state = DevReloadState {
+            path,
+            version: 0,
+            active_build_error: None,
+        };
+
+        let diags = sample_build_diagnostics();
+        state
+            .signal_build_error(&diags, true)
+            .expect("build error signal");
+        assert_eq!(state.version, 1);
+
+        // A Tailwind/CSS save while Rust is broken.
+        state.signal(ReloadKind::Css).expect("css signal");
+        assert_eq!(state.version, 2, "carrying forward still bumps the version");
+        let body = std::fs::read_to_string(state.path()).expect("read carried");
+        let value: serde_json::Value = serde_json::from_str(&body).expect("valid json");
+        assert_eq!(value["version"], 2);
+        assert_eq!(value["kind"], "full", "build error state stays a full kind");
+        assert!(
+            value.get("build_error").is_some(),
+            "a non-build reload must carry the build_error forward"
+        );
+        assert_eq!(value["build_error"]["stale"], true);
+        assert_eq!(value["build_error"]["diagnostics"][0]["code"], "E0425");
+
+        // A plain full reload (e.g. a config-only restart) also carries it.
         state.signal(ReloadKind::Full).expect("full signal");
+        assert_eq!(state.version, 3);
+        let body = std::fs::read_to_string(state.path()).expect("read carried again");
+        let value: serde_json::Value = serde_json::from_str(&body).expect("valid json");
+        assert!(
+            value.get("build_error").is_some(),
+            "a plain full reload must also carry the build_error forward"
+        );
+    }
+
+    #[test]
+    fn dev_reload_state_signal_build_success_clears_overlay() {
+        // Only a green Rust build clears the overlay: the explicit
+        // success-clear drops the build_error field and bumps the version so
+        // the client dismisses the overlay and reloads the freshly-built app.
+        let reload_file = tempfile::NamedTempFile::new().expect("reload file");
+        let path = reload_file.path().to_path_buf();
+        let mut state = DevReloadState {
+            path,
+            version: 0,
+            active_build_error: None,
+        };
+
+        let diags = sample_build_diagnostics();
+        state
+            .signal_build_error(&diags, true)
+            .expect("build error signal");
+        assert_eq!(state.version, 1);
+
+        state
+            .signal_build_success(ReloadKind::Full)
+            .expect("success signal");
         assert_eq!(state.version, 2);
         let body = std::fs::read_to_string(state.path()).expect("read cleared");
         let value: serde_json::Value = serde_json::from_str(&body).expect("valid json");
         assert!(
             value.get("build_error").is_none(),
-            "a normal full signal must not carry a build_error field"
+            "a green build must clear the build_error field"
         );
         assert_eq!(value["version"], 2);
         assert_eq!(value["kind"], "full");
+
+        // After a green build, ordinary signals no longer carry an overlay.
+        state.signal(ReloadKind::Css).expect("css signal");
+        let body = std::fs::read_to_string(state.path()).expect("read post-clear");
+        let value: serde_json::Value = serde_json::from_str(&body).expect("valid json");
+        assert!(
+            value.get("build_error").is_none(),
+            "no overlay should persist once cleared by a green build"
+        );
+        assert_eq!(value["kind"], "css");
+        assert_eq!(value["version"], 3);
     }
 
     #[test]
     fn dev_reload_state_signal_none_is_noop() {
         let reload_file = tempfile::NamedTempFile::new().expect("reload file");
         let path = reload_file.path().to_path_buf();
-        let mut state = DevReloadState { path, version: 41 };
+        let mut state = DevReloadState {
+            path,
+            version: 41,
+            active_build_error: None,
+        };
 
         state.signal(ReloadKind::None).expect("noop signal");
         assert_eq!(state.version, 41);
@@ -2181,6 +2363,7 @@ mod tests {
         let mut state = DevReloadState {
             path,
             version: u64::MAX,
+            active_build_error: None,
         };
 
         let error = state

--- a/autumn-cli/src/dev.rs
+++ b/autumn-cli/src/dev.rs
@@ -14,7 +14,7 @@
 //! unnecessary rebuilds.
 
 use notify_debouncer_mini::{DebouncedEventKind, new_debouncer};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -163,6 +163,36 @@ impl DevReloadState {
         self.write(kind)
     }
 
+    /// Bump the version and write a full-reload state carrying compiler
+    /// diagnostics so the browser client renders a compile-error overlay
+    /// instead of reloading into a broken/stale page.
+    ///
+    /// `stale` is true when a previously-built binary is still serving (the
+    /// browser is looking at a now-outdated page); false on a cold start where
+    /// no server is up yet. A subsequent [`Self::signal`] writes state with no
+    /// `build_error` field, which the client treats as "clear the overlay".
+    fn signal_build_error(
+        &mut self,
+        diagnostics: &[BuildDiagnostic],
+        stale: bool,
+    ) -> Result<(), String> {
+        self.version = self
+            .version
+            .checked_add(1)
+            .ok_or("live reload version overflowed")?;
+
+        let body = serde_json::json!({
+            "version": self.version,
+            "kind": "full",
+            "build_error": {
+                "diagnostics": diagnostics,
+                "stale": stale,
+            },
+        });
+        std::fs::write(&self.path, body.to_string())
+            .map_err(|e| format!("failed to write {}: {e}", self.path.display()))
+    }
+
     fn write(&self, kind: ReloadKind) -> Result<(), String> {
         let kind = match kind {
             ReloadKind::None | ReloadKind::Full => "full",
@@ -207,9 +237,19 @@ pub fn run(package: Option<&str>, show_config: bool) {
             None
         }
     };
-    // Initial build
-    if !cargo_build(package, false) {
+    // Initial build. There is no prior server here (cold start), so a browser
+    // overlay isn't reachable — the CLI doesn't know the app's port and no
+    // process is up to answer the state endpoint. We still record the failure
+    // in the state file (harmless, and dismissed by the first green build);
+    // the terminal errors remain the primary feedback for this case.
+    let (built, diagnostics) = cargo_build_capturing(package);
+    if !built {
         eprintln!("\u{2717} Initial build failed. Fix errors and save to retry.\n");
+        if let Some(state) = reload_state.as_mut()
+            && let Err(error) = state.signal_build_error(&diagnostics, false)
+        {
+            eprintln!("  Warning: live reload signal failed: {error}");
+        }
     }
 
     let binary = find_binary(package, false);
@@ -466,20 +506,34 @@ fn execute_plan(
     let mut applied_reload = ReloadKind::None;
 
     if plan.build {
-        stop_server(child);
+        // Build FIRST, with the old binary still running. Only tear it down
+        // once we have a fresh binary to replace it with — otherwise a failed
+        // rebuild would leave the app DOWN and the browser would see a
+        // connection-refused/stale page instead of a diagnostics overlay.
+        let (built, diagnostics) = cargo_build_capturing(package);
 
-        if cargo_build(package, false) {
+        if built {
+            stop_server(child);
             if restart_server(
                 package,
                 child,
                 reload_state.as_ref().map(|s| s.path()),
                 show_config,
             ) {
+                // A normal full reload clears any prior build-error overlay.
                 applied_reload = ReloadKind::Full;
             }
         } else {
             eprintln!("  \u{2717} Build failed. Waiting for changes...\n");
-            *child = None;
+            // Leave the (stale) binary running so it keeps answering the
+            // live-reload state endpoint; the browser then renders the overlay.
+            let stale = child.is_some();
+            if let Some(reload_state) = reload_state.as_mut()
+                && let Err(error) = reload_state.signal_build_error(&diagnostics, stale)
+            {
+                eprintln!("  Warning: live reload signal failed: {error}");
+            }
+            return;
         }
     } else {
         if plan.tailwind && tailwind_build() {
@@ -544,6 +598,145 @@ pub fn build_cargo_command(package: Option<&str>, release: bool) -> Command {
         cmd.args(["-p", pkg]);
     }
     cmd
+}
+
+/// A single compiler error extracted from `cargo build --message-format=json`.
+///
+/// Serialized into the live-reload state file so the browser overlay can
+/// render the failure without the CLI needing to talk to the app directly.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct BuildDiagnostic {
+    /// Error code (e.g. `E0425`), when the compiler assigned one.
+    code: Option<String>,
+    /// Primary human-readable message (`message.message`).
+    message: String,
+    /// File of the primary span, empty when the error has no primary span.
+    file: String,
+    /// 1-based line of the primary span (0 when absent).
+    line: u32,
+    /// 1-based column of the primary span (0 when absent).
+    column: u32,
+    /// Full multi-line rendered diagnostic (`message.rendered`).
+    rendered: String,
+}
+
+/// Parse `cargo build --message-format=json` stdout into ordered error
+/// diagnostics.
+///
+/// Keeps only `compiler-message` records at `error` level (warnings are out of
+/// scope) and preserves the compiler's emission order. Non-JSON lines and other
+/// message kinds (artifacts, build-finished) are skipped. Mirrors the JSON
+/// walking pattern used by [`crate::dev_loop_bench::cargo_executable_path`].
+fn parse_build_diagnostics(stdout: &[u8]) -> Vec<BuildDiagnostic> {
+    let text = String::from_utf8_lossy(stdout);
+    let mut diagnostics = Vec::new();
+
+    for line in text.lines() {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if value.get("reason").and_then(serde_json::Value::as_str) != Some("compiler-message") {
+            continue;
+        }
+        let Some(message) = value.get("message") else {
+            continue;
+        };
+        if message.get("level").and_then(serde_json::Value::as_str) != Some("error") {
+            continue;
+        }
+
+        let code = message
+            .get("code")
+            .and_then(|code| code.get("code"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned);
+        let text_message = message
+            .get("message")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
+        let rendered = message
+            .get("rendered")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
+
+        let primary = message
+            .get("spans")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|spans| {
+                spans.iter().find(|span| {
+                    span.get("is_primary").and_then(serde_json::Value::as_bool) == Some(true)
+                })
+            });
+        let (file, line, column) = primary.map_or_else(
+            || (String::new(), 0, 0),
+            |span| {
+                let file = span
+                    .get("file_name")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default()
+                    .to_owned();
+                let line = span
+                    .get("line_start")
+                    .and_then(serde_json::Value::as_u64)
+                    .and_then(|n| u32::try_from(n).ok())
+                    .unwrap_or(0);
+                let column = span
+                    .get("column_start")
+                    .and_then(serde_json::Value::as_u64)
+                    .and_then(|n| u32::try_from(n).ok())
+                    .unwrap_or(0);
+                (file, line, column)
+            },
+        );
+
+        diagnostics.push(BuildDiagnostic {
+            code,
+            message: text_message,
+            file,
+            line,
+            column,
+            rendered,
+        });
+    }
+
+    diagnostics
+}
+
+/// Run `cargo build` for the given package while capturing compiler
+/// diagnostics as JSON.
+///
+/// Returns `(success, error_diagnostics)`. Diagnostics are echoed to stderr via
+/// their `rendered` form so the terminal experience matches a plain build.
+/// Used by the watch loop so a failed rebuild can surface errors as a browser
+/// overlay; `serve` keeps using [`cargo_build`].
+fn cargo_build_capturing(package: Option<&str>) -> (bool, Vec<BuildDiagnostic>) {
+    let mut cmd = build_cargo_command(package, false);
+    cmd.arg("--message-format=json");
+
+    eprintln!("  Compiling...");
+    let output = match cmd.output() {
+        Ok(output) => output,
+        Err(e) => {
+            eprintln!("  \u{2717} Failed to run cargo build: {e}");
+            return (false, Vec::new());
+        }
+    };
+
+    let diagnostics = parse_build_diagnostics(&output.stdout);
+    // Echo the rendered diagnostics so the terminal still shows the errors
+    // (JSON message-format suppresses the usual human-readable stderr output).
+    for diagnostic in &diagnostics {
+        eprint!("{}", diagnostic.rendered);
+    }
+
+    if output.status.success() {
+        eprintln!("  \u{2713} Build succeeded");
+        (true, diagnostics)
+    } else {
+        (false, diagnostics)
+    }
 }
 
 /// Run `cargo build` for the given package. Returns true on success.
@@ -1816,6 +2009,101 @@ mod tests {
         state.signal(ReloadKind::Full).expect("full signal");
         let body = std::fs::read_to_string(state.path()).expect("read full");
         assert_eq!(body, r#"{"kind":"full","version":2}"#);
+    }
+
+    #[test]
+    fn parse_build_diagnostics_extracts_errors_in_order_excluding_warnings() {
+        // A realistic `cargo build --message-format=json` stream: an artifact
+        // line, an error, a warning (must be excluded), a non-JSON line, a
+        // second error whose primary span is NOT the first span, and a
+        // build-finished line.
+        let stdout = concat!(
+            r#"{"reason":"compiler-artifact","target":{"name":"app"}}"#,
+            "\n",
+            r#"{"reason":"compiler-message","message":{"code":{"code":"E0425"},"level":"error","message":"cannot find value `foo` in this scope","rendered":"error[E0425]: cannot find value `foo`\n --> src/main.rs:3:5\n","spans":[{"file_name":"src/main.rs","line_start":3,"column_start":5,"is_primary":true}]}}"#,
+            "\n",
+            r#"{"reason":"compiler-message","message":{"code":null,"level":"warning","message":"unused variable: `x`","rendered":"warning: unused variable\n","spans":[{"file_name":"src/main.rs","line_start":9,"column_start":1,"is_primary":true}]}}"#,
+            "\n",
+            "   Compiling app v0.1.0 (not json)\n",
+            r#"{"reason":"compiler-message","message":{"code":{"code":"E0308"},"level":"error","message":"mismatched types","rendered":"error[E0308]: mismatched types\n --> src/lib.rs:12:9\n","spans":[{"file_name":"src/other.rs","line_start":1,"column_start":1,"is_primary":false},{"file_name":"src/lib.rs","line_start":12,"column_start":9,"is_primary":true}]}}"#,
+            "\n",
+            r#"{"reason":"build-finished","success":false}"#,
+            "\n",
+        );
+
+        let diags = parse_build_diagnostics(stdout.as_bytes());
+
+        assert_eq!(diags.len(), 2, "warnings and non-error lines excluded");
+        assert_eq!(
+            diags[0],
+            BuildDiagnostic {
+                code: Some("E0425".to_owned()),
+                message: "cannot find value `foo` in this scope".to_owned(),
+                file: "src/main.rs".to_owned(),
+                line: 3,
+                column: 5,
+                rendered: "error[E0425]: cannot find value `foo`\n --> src/main.rs:3:5\n"
+                    .to_owned(),
+            }
+        );
+        // Compiler order is preserved: E0425 first, then E0308.
+        assert_eq!(diags[1].code, Some("E0308".to_owned()));
+        assert_eq!(diags[1].message, "mismatched types");
+        // Primary span wins over the (earlier) non-primary span.
+        assert_eq!(diags[1].file, "src/lib.rs");
+        assert_eq!(diags[1].line, 12);
+        assert_eq!(diags[1].column, 9);
+    }
+
+    #[test]
+    fn dev_reload_state_signal_build_error_writes_and_full_clears() {
+        let reload_file = tempfile::NamedTempFile::new().expect("reload file");
+        let path = reload_file.path().to_path_buf();
+        let mut state = DevReloadState { path, version: 0 };
+
+        let diags = vec![BuildDiagnostic {
+            code: Some("E0425".to_owned()),
+            message: "cannot find value `foo`".to_owned(),
+            file: "src/main.rs".to_owned(),
+            line: 3,
+            column: 5,
+            rendered: "error[E0425]: cannot find value `foo`".to_owned(),
+        }];
+
+        state
+            .signal_build_error(&diags, true)
+            .expect("build error signal");
+        assert_eq!(state.version, 1, "build error bumps the version");
+
+        let body = std::fs::read_to_string(state.path()).expect("read build error");
+        let value: serde_json::Value = serde_json::from_str(&body).expect("valid json");
+        assert_eq!(value["version"], 1);
+        assert_eq!(value["kind"], "full");
+        assert_eq!(value["build_error"]["stale"], true);
+        assert_eq!(value["build_error"]["diagnostics"][0]["code"], "E0425");
+        assert_eq!(
+            value["build_error"]["diagnostics"][0]["file"],
+            "src/main.rs"
+        );
+        assert_eq!(value["build_error"]["diagnostics"][0]["line"], 3);
+        assert_eq!(value["build_error"]["diagnostics"][0]["column"], 5);
+        assert_eq!(
+            value["build_error"]["diagnostics"][0]["message"],
+            "cannot find value `foo`"
+        );
+
+        // A subsequent normal full signal must clear the build_error field so
+        // the browser overlay dismisses and the page reloads.
+        state.signal(ReloadKind::Full).expect("full signal");
+        assert_eq!(state.version, 2);
+        let body = std::fs::read_to_string(state.path()).expect("read cleared");
+        let value: serde_json::Value = serde_json::from_str(&body).expect("valid json");
+        assert!(
+            value.get("build_error").is_none(),
+            "a normal full signal must not carry a build_error field"
+        );
+        assert_eq!(value["version"], 2);
+        assert_eq!(value["kind"], "full");
     }
 
     #[test]

--- a/autumn/src/middleware/dev.rs
+++ b/autumn/src/middleware/dev.rs
@@ -349,7 +349,26 @@ fn live_reload_script_body() -> String {
       // Track the version so the next (green) build, which bumps the version
       // and drops `build_error`, triggers a real reload below.
       if (state.build_error) {{
+        // Only (re)build the overlay DOM when the build-error content actually
+        // changes. `renderBuildErrorOverlay` tears down and recreates the whole
+        // overlay subtree, which resets scroll position and clears any
+        // in-progress text selection. Since we poll every 700ms, rebuilding on
+        // an unchanged version would make the errors impossible to read or copy
+        // once they scroll. The recorded version lives on the overlay element
+        // (`data-autumn-build-error-version`) and survives across polls.
+        const existingOverlay = document.getElementById(OVERLAY_ID);
+        if (
+          existingOverlay &&
+          existingOverlay.dataset.autumnBuildErrorVersion === String(state.version)
+        ) {{
+          version = state.version;
+          return;
+        }}
         renderBuildErrorOverlay(state.build_error);
+        const overlay = document.getElementById(OVERLAY_ID);
+        if (overlay) {{
+          overlay.dataset.autumnBuildErrorVersion = String(state.version);
+        }}
         version = state.version;
         return;
       }}
@@ -799,6 +818,40 @@ mod tests {
         assert!(
             js.contains(".style."),
             "overlay must apply styling via CSSOM .style.<prop> assignments"
+        );
+    }
+
+    #[test]
+    fn live_reload_script_body_guards_overlay_rebuild_by_version() {
+        // The overlay must only be rebuilt when the build-error content changes.
+        // Because `renderBuildErrorOverlay` tears down and recreates the overlay
+        // DOM (resetting scroll position and clearing text selection) and the
+        // client polls every 700ms, an unchanged `state.version` must NOT
+        // trigger a rebuild — otherwise a developer can never read or copy a
+        // scrolling error list. The guard records the rendered version on the
+        // overlay element and compares it against `state.version` before
+        // re-rendering.
+        let js = live_reload_script_body();
+
+        // The rendered version is recorded on the overlay element's dataset so
+        // it survives across polls.
+        assert!(
+            js.contains("dataset.autumnBuildErrorVersion"),
+            "overlay must record the rendered build-error version on its dataset"
+        );
+        // The build_error branch compares the recorded version against the
+        // freshly polled `state.version` before rebuilding.
+        assert!(
+            js.contains(
+                "existingOverlay.dataset.autumnBuildErrorVersion === String(state.version)"
+            ),
+            "overlay rebuild must be guarded by a version comparison"
+        );
+        // renderBuildErrorOverlay is still reachable for the first appearance
+        // and for genuinely new (version-bumped) failed builds.
+        assert!(
+            js.contains("renderBuildErrorOverlay(state.build_error)"),
+            "overlay must still render on first appearance / new build"
         );
     }
 

--- a/autumn/src/middleware/dev.rs
+++ b/autumn/src/middleware/dev.rs
@@ -191,7 +191,15 @@ pub async fn capture_matched_path_middleware(
 /// escaping. It renders arbitrary compiler output exclusively via `textContent`
 /// on `<pre>`/`<code>`/`<div>` nodes — never `innerHTML` — so it is XSS-safe and
 /// needs no inline scripting (CSP `script-src 'self'` compliant).
-const BUILD_ERROR_OVERLAY_JS: &str = r#"
+///
+/// All styling is applied through individual CSSOM property assignments
+/// (`element.style.<prop> = value`) rather than literal `style` attributes.
+/// Styles set via the CSSOM are NOT governed by the CSP `style-src` directive
+/// (only literal `style` attributes, `<style>` blocks, and external stylesheets
+/// are), so the overlay renders correctly even under a strict nonce-based
+/// `style-src 'self' 'nonce-...'` policy — e.g. when a dev app enables
+/// `security.headers.csp_nonce`.
+const BUILD_ERROR_OVERLAY_JS: &str = r##"
   const OVERLAY_ID = "__autumn_build_error";
 
   function removeBuildErrorOverlay() {
@@ -209,13 +217,19 @@ const BUILD_ERROR_OVERLAY_JS: &str = r#"
     if (!overlay) {
       overlay = document.createElement("div");
       overlay.id = OVERLAY_ID;
-      overlay.setAttribute(
-        "style",
-        "position:fixed;inset:0;z-index:2147483647;overflow:auto;" +
-          "background:rgba(12,12,16,0.97);color:#f5f5f5;" +
-          "font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;" +
-          "padding:32px;box-sizing:border-box;"
-      );
+      overlay.style.position = "fixed";
+      overlay.style.top = "0";
+      overlay.style.right = "0";
+      overlay.style.bottom = "0";
+      overlay.style.left = "0";
+      overlay.style.zIndex = "2147483647";
+      overlay.style.overflow = "auto";
+      overlay.style.background = "rgba(12,12,16,0.97)";
+      overlay.style.color = "#f5f5f5";
+      overlay.style.fontFamily =
+        "ui-monospace,SFMono-Regular,Menlo,Consolas,monospace";
+      overlay.style.padding = "32px";
+      overlay.style.boxSizing = "border-box";
       document.body.appendChild(overlay);
     }
     while (overlay.firstChild) {
@@ -223,15 +237,18 @@ const BUILD_ERROR_OVERLAY_JS: &str = r#"
     }
 
     const panel = document.createElement("div");
-    panel.setAttribute("style", "max-width:960px;margin:0 auto;");
+    panel.style.maxWidth = "960px";
+    panel.style.margin = "0 auto";
 
     const banner = document.createElement("div");
-    banner.setAttribute(
-      "style",
-      "border-left:4px solid #ff5f56;background:#2a1416;color:#ffb3ad;" +
-        "padding:14px 18px;border-radius:6px;margin-bottom:20px;" +
-        "font-size:15px;font-weight:600;"
-    );
+    banner.style.borderLeft = "4px solid #ff5f56";
+    banner.style.background = "#2a1416";
+    banner.style.color = "#ffb3ad";
+    banner.style.padding = "14px 18px";
+    banner.style.borderRadius = "6px";
+    banner.style.marginBottom = "20px";
+    banner.style.fontSize = "15px";
+    banner.style.fontWeight = "600";
     banner.textContent = buildError.stale
       ? "Build failed — you're viewing a stale page. Fix the errors below and save."
       : "Build failed. Fix the errors below and save.";
@@ -242,37 +259,37 @@ const BUILD_ERROR_OVERLAY_JS: &str = r#"
       : [];
     diagnostics.forEach((diag) => {
       const item = document.createElement("div");
-      item.setAttribute(
-        "style",
-        "background:#1a1a20;border:1px solid #33333c;border-radius:6px;" +
-          "padding:16px 18px;margin-bottom:16px;"
-      );
+      item.style.background = "#1a1a20";
+      item.style.border = "1px solid #33333c";
+      item.style.borderRadius = "6px";
+      item.style.padding = "16px 18px";
+      item.style.marginBottom = "16px";
 
       const heading = document.createElement("div");
-      heading.setAttribute(
-        "style",
-        "color:#ff8a80;font-size:14px;font-weight:700;margin-bottom:6px;"
-      );
+      heading.style.color = "#ff8a80";
+      heading.style.fontSize = "14px";
+      heading.style.fontWeight = "700";
+      heading.style.marginBottom = "6px";
       const codePrefix = diag.code ? "[" + diag.code + "] " : "";
       heading.textContent = codePrefix + (diag.message || "");
       item.appendChild(heading);
 
       if (diag.file) {
         const loc = document.createElement("div");
-        loc.setAttribute(
-          "style",
-          "color:#9aa0a6;font-size:12px;margin-bottom:10px;"
-        );
+        loc.style.color = "#9aa0a6";
+        loc.style.fontSize = "12px";
+        loc.style.marginBottom = "10px";
         loc.textContent = diag.file + ":" + diag.line + ":" + diag.column;
         item.appendChild(loc);
       }
 
       const pre = document.createElement("pre");
-      pre.setAttribute(
-        "style",
-        "margin:0;white-space:pre-wrap;word-break:break-word;" +
-          "font-size:13px;line-height:1.5;color:#e8e8e8;"
-      );
+      pre.style.margin = "0";
+      pre.style.whiteSpace = "pre-wrap";
+      pre.style.wordBreak = "break-word";
+      pre.style.fontSize = "13px";
+      pre.style.lineHeight = "1.5";
+      pre.style.color = "#e8e8e8";
       const code = document.createElement("code");
       code.textContent = diag.rendered || "";
       pre.appendChild(code);
@@ -283,7 +300,7 @@ const BUILD_ERROR_OVERLAY_JS: &str = r#"
 
     overlay.appendChild(panel);
   }
-"#;
+"##;
 
 fn live_reload_script_body() -> String {
     format!(
@@ -758,6 +775,30 @@ mod tests {
         assert!(
             !js.contains("innerHTML"),
             "diagnostics must not be rendered via innerHTML"
+        );
+
+        // CSP-safety: the overlay must style elements via CSSOM per-property
+        // assignments (`element.style.<prop> = value`), which are NOT governed
+        // by the CSP `style-src` directive. Literal `style` attributes,
+        // `cssText`, and `setAttribute("style", ...)` ARE blocked under a
+        // strict nonce-based `style-src 'self' 'nonce-...'` policy, so none of
+        // those may appear or the overlay renders unstyled on apps that enable
+        // `security.headers.csp_nonce`.
+        assert!(
+            !js.contains(r#"setAttribute("style""#),
+            "overlay must not set styles via a literal style attribute"
+        );
+        assert!(
+            !js.contains(".cssText"),
+            "overlay must not set styles via cssText"
+        );
+        assert!(
+            !js.contains(" style="),
+            "overlay markup must not contain an inline style= attribute"
+        );
+        assert!(
+            js.contains(".style."),
+            "overlay must apply styling via CSSOM .style.<prop> assignments"
         );
     }
 

--- a/autumn/src/middleware/dev.rs
+++ b/autumn/src/middleware/dev.rs
@@ -185,12 +185,113 @@ pub async fn capture_matched_path_middleware(
     response
 }
 
+/// Compile-error overlay helpers, injected into [`live_reload_script_body`].
+///
+/// Kept as a standalone (non-`format!`) raw string so its many braces need no
+/// escaping. It renders arbitrary compiler output exclusively via `textContent`
+/// on `<pre>`/`<code>`/`<div>` nodes — never `innerHTML` — so it is XSS-safe and
+/// needs no inline scripting (CSP `script-src 'self'` compliant).
+const BUILD_ERROR_OVERLAY_JS: &str = r#"
+  const OVERLAY_ID = "__autumn_build_error";
+
+  function removeBuildErrorOverlay() {
+    const existing = document.getElementById(OVERLAY_ID);
+    if (existing) {
+      existing.remove();
+    }
+  }
+
+  function renderBuildErrorOverlay(buildError) {
+    if (!document.body) {
+      return;
+    }
+    let overlay = document.getElementById(OVERLAY_ID);
+    if (!overlay) {
+      overlay = document.createElement("div");
+      overlay.id = OVERLAY_ID;
+      overlay.setAttribute(
+        "style",
+        "position:fixed;inset:0;z-index:2147483647;overflow:auto;" +
+          "background:rgba(12,12,16,0.97);color:#f5f5f5;" +
+          "font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;" +
+          "padding:32px;box-sizing:border-box;"
+      );
+      document.body.appendChild(overlay);
+    }
+    while (overlay.firstChild) {
+      overlay.removeChild(overlay.firstChild);
+    }
+
+    const panel = document.createElement("div");
+    panel.setAttribute("style", "max-width:960px;margin:0 auto;");
+
+    const banner = document.createElement("div");
+    banner.setAttribute(
+      "style",
+      "border-left:4px solid #ff5f56;background:#2a1416;color:#ffb3ad;" +
+        "padding:14px 18px;border-radius:6px;margin-bottom:20px;" +
+        "font-size:15px;font-weight:600;"
+    );
+    banner.textContent = buildError.stale
+      ? "Build failed — you're viewing a stale page. Fix the errors below and save."
+      : "Build failed. Fix the errors below and save.";
+    panel.appendChild(banner);
+
+    const diagnostics = Array.isArray(buildError.diagnostics)
+      ? buildError.diagnostics
+      : [];
+    diagnostics.forEach((diag) => {
+      const item = document.createElement("div");
+      item.setAttribute(
+        "style",
+        "background:#1a1a20;border:1px solid #33333c;border-radius:6px;" +
+          "padding:16px 18px;margin-bottom:16px;"
+      );
+
+      const heading = document.createElement("div");
+      heading.setAttribute(
+        "style",
+        "color:#ff8a80;font-size:14px;font-weight:700;margin-bottom:6px;"
+      );
+      const codePrefix = diag.code ? "[" + diag.code + "] " : "";
+      heading.textContent = codePrefix + (diag.message || "");
+      item.appendChild(heading);
+
+      if (diag.file) {
+        const loc = document.createElement("div");
+        loc.setAttribute(
+          "style",
+          "color:#9aa0a6;font-size:12px;margin-bottom:10px;"
+        );
+        loc.textContent = diag.file + ":" + diag.line + ":" + diag.column;
+        item.appendChild(loc);
+      }
+
+      const pre = document.createElement("pre");
+      pre.setAttribute(
+        "style",
+        "margin:0;white-space:pre-wrap;word-break:break-word;" +
+          "font-size:13px;line-height:1.5;color:#e8e8e8;"
+      );
+      const code = document.createElement("code");
+      code.textContent = diag.rendered || "";
+      pre.appendChild(code);
+      item.appendChild(pre);
+
+      panel.appendChild(item);
+    });
+
+    overlay.appendChild(panel);
+  }
+"#;
+
 fn live_reload_script_body() -> String {
     format!(
         r#"(() => {{
   const endpoint = "{LIVE_RELOAD_PATH}";
   let version = null;
   let polling = false;
+{BUILD_ERROR_OVERLAY_JS}
 
   function refreshStylesheets(nextVersion) {{
     let refreshed = 0;
@@ -224,6 +325,22 @@ fn live_reload_script_body() -> String {
       }}
 
       const state = await response.json();
+
+      // A failed rebuild is surfaced as a `build_error` payload. Show the
+      // overlay and RETURN without reloading — the stale binary keeps serving
+      // this page so the developer keeps their scroll position and context.
+      // Track the version so the next (green) build, which bumps the version
+      // and drops `build_error`, triggers a real reload below.
+      if (state.build_error) {{
+        renderBuildErrorOverlay(state.build_error);
+        version = state.version;
+        return;
+      }}
+      // No build error: dismiss any overlay left over from a prior failure,
+      // then fall through to the normal version-change reload path so the
+      // recovered build reloads the page.
+      removeBuildErrorOverlay();
+
       if (version === null) {{
         version = state.version;
         return;
@@ -588,6 +705,79 @@ mod tests {
         // Assert valid JSON string containing expected structure
         assert!(body_str.contains(r#""version""#));
         assert!(body_str.contains(r#""kind""#));
+    }
+
+    #[tokio::test]
+    async fn live_reload_state_handler_passes_build_error_through() {
+        // The state file may now carry a `build_error` object (written by the
+        // CLI on a failed rebuild). The handler must return it verbatim so the
+        // browser client can render the compile-error overlay.
+        let tmp_file = tempfile::NamedTempFile::new().expect("failed to create temp file");
+        let content = r#"{"version":7,"kind":"full","build_error":{"stale":true,"diagnostics":[{"code":"E0425","message":"boom","file":"src/main.rs","line":3,"column":5,"rendered":"error[E0425]: boom"}]}}"#;
+        std::fs::write(tmp_file.path(), content).expect("failed to write to temp file");
+
+        temp_env::async_with_vars(
+            [
+                (DEV_RELOAD_ENV, Some("1")),
+                (
+                    DEV_RELOAD_STATE_ENV,
+                    Some(tmp_file.path().to_str().unwrap()),
+                ),
+            ],
+            async {
+                let response = super::live_reload_state_handler().await.into_response();
+                assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+                let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let body_str = std::str::from_utf8(&body_bytes).unwrap();
+
+                assert_eq!(body_str, content, "build_error must pass through verbatim");
+            },
+        )
+        .await;
+    }
+
+    #[test]
+    fn live_reload_script_body_renders_build_error_overlay_safely() {
+        // The polling client must render a compile-error overlay when the state
+        // carries a `build_error`, escaping arbitrary compiler output via
+        // `textContent` (never `innerHTML`) to stay XSS-safe and CSP-clean.
+        let js = live_reload_script_body();
+
+        assert!(
+            js.contains("__autumn_build_error"),
+            "overlay element id missing"
+        );
+        assert!(js.contains("build_error"), "build_error handling missing");
+        assert!(
+            js.contains("textContent"),
+            "diagnostics must be set via textContent"
+        );
+        assert!(
+            !js.contains("innerHTML"),
+            "diagnostics must not be rendered via innerHTML"
+        );
+    }
+
+    #[test]
+    fn build_error_overlay_is_gated_behind_dev_env() {
+        // The live-reload client (and thus the compile-error overlay) is only
+        // mounted when BOTH dev-reload env vars are present. Without them the
+        // middleware is disabled and nothing is served.
+        assert!(!is_enabled_with_env(&MockEnv::new()));
+        assert!(!is_enabled_with_env(
+            &MockEnv::new().with(DEV_RELOAD_ENV, "1")
+        ));
+
+        let enabled = MockEnv::new()
+            .with(DEV_RELOAD_ENV, "1")
+            .with(DEV_RELOAD_STATE_ENV, "state.json");
+        assert!(is_enabled_with_env(&enabled));
+
+        // When enabled, the served client carries the overlay logic.
+        assert!(live_reload_script_body().contains("__autumn_build_error"));
     }
 
     #[tokio::test]

--- a/docs/guide/dev-error-overlay.md
+++ b/docs/guide/dev-error-overlay.md
@@ -4,6 +4,14 @@ When a handler panics, returns an `Err`, or propagates a `?`, Autumn's dev
 profile renders a rich browser overlay instead of a plain 500 page. The overlay
 gives you everything you need to diagnose the failure without leaving the tab.
 
+Autumn ships two overlays that share the same dark, red-accented visual
+language:
+
+- The **runtime error overlay** (below) for errors raised while a request is
+  being served.
+- The **compile-error overlay** (see [Compile-error overlay](#compile-error-overlay))
+  for `cargo build` failures during `autumn dev`.
+
 ## What it shows
 
 | Section | Contents |
@@ -134,3 +142,108 @@ in red.
 
 When source files are absent, the overlay still shows the full stack trace
 (file, line, function name) without the inline code context.
+
+## Compile-error overlay
+
+The runtime overlay above only helps once the app is *running*. But during
+`autumn dev` the most common failure is a Rust file that no longer compiles —
+and historically a failed rebuild left the browser staring at a
+connection-refused error or a silently stale page, with the real compiler
+errors buried in the terminal.
+
+The **compile-error overlay** fixes that: when a rebuild triggered by
+`autumn dev` fails, the previously-built binary keeps running and the browser
+renders the compiler diagnostics as a full-screen overlay on top of the page
+you were already looking at.
+
+### What triggers it
+
+A `cargo build` failure during an `autumn dev` watch cycle — for example,
+saving a `src/**/*.rs` file that doesn't type-check. The dev orchestrator
+rebuilds with `--message-format=json`, extracts every **error**-level
+diagnostic (warnings are ignored), and writes them into the live-reload state
+file. The injected live-reload client polls that state and paints the overlay.
+
+### What it shows
+
+- Every error diagnostic, **in the order the compiler emitted them**.
+- For each one: the error code and primary message as a header, the
+  `file:line:column` of the primary span, and the compiler's full *rendered*
+  diagnostic (the same colored-caret block you see in the terminal, minus the
+  color) in a monospace panel.
+- A prominent banner at the top. When you are looking at a page served by the
+  still-running previous binary, the banner reads:
+
+  > Build failed — you're viewing a stale page. Fix the errors below and save.
+
+  so it's clear the page underneath is out of date (see
+  [Stale-page behavior](#stale-page-behavior)).
+
+Compiler output is inserted with `textContent` only (never `innerHTML`), so
+arbitrary diagnostic text can't inject markup, and the client is served as an
+external script — it needs no inline JavaScript and passes the framework's
+default `script-src 'self'` CSP.
+
+### Described mockup
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ ▎ Build failed — you're viewing a stale page. Fix the errors below    │
+│   and save.                                                            │
+│                                                                        │
+│  ┌──────────────────────────────────────────────────────────────────┐ │
+│  │ [E0425] cannot find value `user` in this scope                   │ │
+│  │ src/routes/home.rs:42:17                                          │ │
+│  │                                                                    │ │
+│  │ error[E0425]: cannot find value `user` in this scope             │ │
+│  │   --> src/routes/home.rs:42:17                                    │ │
+│  │    |                                                               │ │
+│  │ 42 |     let name = user.name;                                    │ │
+│  │    |                ^^^^ not found in this scope                  │ │
+│  └──────────────────────────────────────────────────────────────────┘ │
+│  ┌──────────────────────────────────────────────────────────────────┐ │
+│  │ [E0308] mismatched types                                          │ │
+│  │ src/routes/home.rs:50:9                                           │ │
+│  │ ...                                                                │ │
+│  └──────────────────────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Auto-dismiss on green
+
+The overlay clears itself automatically. Once you fix the errors and save, the
+next rebuild succeeds, the server restarts, and the live-reload state advances
+to a normal `full` reload with no `build_error` payload. The client removes the
+overlay and reloads the page — you're back to a working app without touching the
+browser.
+
+### Stale-page behavior
+
+On a failed rebuild the orchestrator deliberately **does not** stop the old
+binary. It keeps serving the last good build so that:
+
+- the browser can still reach the live-reload endpoint (that's how the overlay
+  is delivered at all), and
+- you keep your scroll position and page state while you fix the error.
+
+The overlay's banner makes the staleness explicit so you don't mistake the
+underlying page for the current code.
+
+### Dev-profile-only
+
+Like the runtime overlay, this is a development-only feature. The live-reload
+client and its state endpoint are mounted only when `autumn dev` is running
+(both `AUTUMN_DEV_RELOAD` and `AUTUMN_DEV_RELOAD_STATE` are set); a production
+build never serves the overlay client and never writes a build-error state.
+
+### Known limitation: cold start
+
+The overlay requires a previously-built binary to be running so it can answer
+the poll. If the **very first** build when you launch `autumn dev` fails, there
+is no server up yet (and the CLI doesn't know which port your app would have
+bound), so there is nothing for the browser to talk to. In that case the
+compiler errors are printed to the terminal as before. Once any successful
+build has started the server, subsequent failed rebuilds show the overlay.
+
+See [ADR 0006](../adr/0006-dev-error-overlay.md) for the design reasoning
+behind the dev overlays and their production guards.

--- a/docs/guide/dev-error-overlay.md
+++ b/docs/guide/dev-error-overlay.md
@@ -245,5 +245,21 @@ bound), so there is nothing for the browser to talk to. In that case the
 compiler errors are printed to the terminal as before. Once any successful
 build has started the server, subsequent failed rebuilds show the overlay.
 
+### Known limitation: Windows
+
+The stale-page serving described above is **not available on Windows**. Windows
+keeps the running `target/debug/<app>.exe` locked while the process is alive, so
+`cargo build` cannot relink over it. To rebuild at all, the dev orchestrator
+must stop the old binary *before* running `cargo build` on Windows (Unix/macOS
+build first and only stop once a fresh binary is ready).
+
+The consequence: on Windows a **failed** rebuild leaves the app already stopped,
+so there is no running server to answer the live-reload poll and paint the
+overlay. You get the compiler errors streamed to the terminal plus the client's
+normal reconnect behavior once a green build restarts the server. Unix and macOS
+get the full stale-page overlay experience. This is a documented, non-regressive
+platform limitation — Windows simply falls back to the pre-overlay terminal-only
+behavior for failed rebuilds.
+
 See [ADR 0006](../adr/0006-dev-error-overlay.md) for the design reasoning
 behind the dev overlays and their production guards.


### PR DESCRIPTION
Closes #1115

## What changed

**Before:** When a `cargo build` triggered by `autumn dev` failed, the CLI killed the running app *before* rebuilding, so the browser got a connection-refused page and the compiler errors were only visible in the terminal.

**After:** A failed rebuild now leaves the previous app binary serving and pushes the compiler diagnostics into the browser as a dev-only overlay — error code, message, `file:line:column`, and the full rendered span for every error, in compiler order. The overlay warns that the page is stale, and it auto-dismisses (and the page reloads) the moment the next save compiles cleanly. Zero app-side code required; dev-profile only.

## How

- **`autumn-cli/src/dev.rs`**: new `cargo_build_capturing` runs the build with `--message-format=json` and `parse_build_diagnostics` extracts error-level messages (warnings excluded) preserving compiler order. `execute_plan`'s build branch is reordered to **build before killing** the old binary: on failure the stale binary keeps serving and `DevReloadState::signal_build_error` writes the diagnostics (plus a `stale` flag) into the existing `target/autumn/live-reload.json` channel, bumping the version; on success the normal `Full` signal clears it.
- **`autumn/src/middleware/dev.rs`**: the already-dev-gated injected live-reload client renders the overlay entirely client-side. Diagnostic strings reach the DOM only via `createElement` + `textContent` (never `innerHTML`), so arbitrary source in compiler output can't inject HTML/JS, and it stays CSP-safe (external script). When `build_error` clears, the overlay is removed and the normal reload proceeds.
- **`docs/guide/dev-error-overlay.md`**: new "Compile-error overlay" section.

The overlay is strictly gated behind the `AUTUMN_DEV_RELOAD` + `AUTUMN_DEV_RELOAD_STATE` env vars that only `autumn dev` sets, so it never mounts in prod/release.

## Tests

5 new tests (2 in `dev.rs`: diagnostic parsing + `signal_build_error` clear-on-green; 3 in `middleware/dev.rs`: state pass-through, `textContent`/no-`innerHTML` overlay rendering, dev-env gating). All pass; `cargo fmt` clean.

## Known limitation

Cold start only: if the *very first* build at `autumn dev` startup fails, there is no running binary and the CLI doesn't know the app's port, so the overlay can't be served (errors still print to the terminal). The overlay covers every subsequent edit-loop failure. Documented in the guide.

## Note

Workspace clippy currently trips on a pre-existing `autumn/src/repository.rs:157` `needless-pass-by-value` error that is already on `trunk-dev` (from merged #1701), outside this PR's scope and files. This PR's 3 files are clippy-clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQVWUpHdcLvYzpmMvTGzhE)_