### PR TITLE
Validate multipart uploads by magic bytes, not the spoofable Content-Type header (#1354)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,7 @@ dependencies = [
  "image",
  "include_dir",
  "indexmap 2.14.0",
+ "infer",
  "inventory",
  "jsonwebtoken",
  "lettre",
@@ -1523,6 +1524,17 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cfb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
 ]
 
 [[package]]
@@ -3785,6 +3797,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "infer"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc150e5ce2330295b8616ce0e3f53250e53af31759a9dbedad1621ba29151847"
+dependencies = [
+ "cfb",
 ]
 
 [[package]]

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -20,7 +20,7 @@ flash = []
 cache-moka = ["dep:moka"]
 maud = ["dep:maud"]
 htmx = []
-multipart = ["axum/multipart"]
+multipart = ["axum/multipart", "dep:infer"]
 tailwind = []
 http-client = ["dep:reqwest"]
 oauth2 = ["http-client"]
@@ -216,6 +216,7 @@ secrecy = { version = "0.10.3", features = ["serde"] }
 lru = "0.18.0"
 hmac = "0.12"
 sha2 = "0.10"
+infer = { version = "0.16", optional = true }
 sha1 = { version = "0.10", optional = true }
 rsa = { version = "0.9", default-features = false, features = ["std", "pem"], optional = true }
 aes-gcm = "0.10"

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -133,6 +133,7 @@
 //! | `AUTUMN_SECURITY__UPLOAD__MAX_REQUEST_SIZE_BYTES` | `security.upload.max_request_size_bytes` | `usize` |
 //! | `AUTUMN_SECURITY__UPLOAD__MAX_FILE_SIZE_BYTES` | `security.upload.max_file_size_bytes` | `usize` |
 //! | `AUTUMN_SECURITY__UPLOAD__ALLOWED_MIME_TYPES` | `security.upload.allowed_mime_types` | comma-separated `String` |
+//! | `AUTUMN_SECURITY__UPLOAD__REJECT_ON_CONTENT_TYPE_MISMATCH` | `security.upload.reject_on_content_type_mismatch` | `bool` |
 //! | `AUTUMN_SECURITY__FORBIDDEN_RESPONSE` | `security.forbidden_response` | `"403"` or `"404"` |
 //! | `AUTUMN_SECURITY__ALLOW_UNAUTHORIZED_REPOSITORY_API` | `security.allow_unauthorized_repository_api` | `bool` |
 //! | `AUTUMN_SECURITY__SIGNING_SECRET` | `security.signing_secret.secret` | `String` |
@@ -3348,6 +3349,11 @@ impl AutumnConfig {
             env,
             "AUTUMN_SECURITY__UPLOAD__ALLOWED_MIME_TYPES",
             &mut self.security.upload.allowed_mime_types,
+        );
+        parse_env_bool(
+            env,
+            "AUTUMN_SECURITY__UPLOAD__REJECT_ON_CONTENT_TYPE_MISMATCH",
+            &mut self.security.upload.reject_on_content_type_mismatch,
         );
 
         // Authorization deny shape + repository-API escape hatch.
@@ -7083,6 +7089,18 @@ path = "/healthz"
         assert!(!config.actuator.sensitive);
         config.apply_env_overrides_with_env(&env);
         assert!(config.actuator.sensitive);
+    }
+
+    #[test]
+    fn env_override_upload_reject_on_content_type_mismatch() {
+        let env = MockEnv::new().with(
+            "AUTUMN_SECURITY__UPLOAD__REJECT_ON_CONTENT_TYPE_MISMATCH",
+            "true",
+        );
+        let mut config = AutumnConfig::default();
+        assert!(!config.security.upload.reject_on_content_type_mismatch);
+        config.apply_env_overrides_with_env(&env);
+        assert!(config.security.upload.reject_on_content_type_mismatch);
     }
 
     #[test]

--- a/autumn/src/extract.rs
+++ b/autumn/src/extract.rs
@@ -299,17 +299,28 @@ fn truncate_for_error(value: &str) -> String {
     value.chars().take(MAX_CHARS).collect()
 }
 
+/// Types that legitimately have no magic-byte signature, so a content sniff of
+/// `None` is expected and the declared type may be trusted for the allow-list.
+/// Binary/sniffable types (image/*, application/pdf, …) are deliberately
+/// excluded: a genuine one always sniffs positively, so `None` for such a type
+/// means the declared header is spoofed.
+#[cfg(feature = "multipart")]
+fn is_signatureless_text_type(essence: &str) -> bool {
+    essence.starts_with("text/") || matches!(essence, "application/json" | "application/csv")
+}
+
 /// Enforce a MIME allow-list against a file part, using content sniffing as the
 /// primary signal. `infer` only recognizes binary formats by magic bytes; text
-/// formats (text/plain, application/json, text/csv, image/svg+xml, …) have no
-/// signature and always sniff to `None`. Precedence:
+/// formats (text/plain, application/json, text/csv, …) have no signature and
+/// always sniff to `None`. Precedence:
 ///
 /// 1. **Sniffed recognized** → must be in the list, else reject. Header ignored.
 /// 2. **Unrecognized + markup** (leading `<…`) → reject unconditionally, so
 ///    HTML/SVG/XML can't ride in under a spoofed declared type.
-/// 3. **Unrecognized + not markup** (genuine signature-less text) → fall back to
-///    the declared essence, which must be in the list. This is the only case
-///    where the declared header is trusted.
+/// 3. **Unrecognized + not markup** → the declared header is trusted ONLY when
+///    it names a signature-less TEXT type (see [`is_signatureless_text_type`])
+///    that is in the list. A declared binary/sniffable type on unrecognizable
+///    bytes is definitionally a spoof (a real one would have sniffed) → reject.
 #[cfg(feature = "multipart")]
 fn enforce_upload_allow_list(
     allowed: &[String],
@@ -332,21 +343,14 @@ fn enforce_upload_allow_list(
         return Err(crate::AutumnError::bad_request_msg(
             "upload rejected: unrecognized file content looks like markup",
         ));
-    } else {
-        match declared_essence {
-            Some(essence) if in_list(essence) => {}
-            Some(essence) => {
-                return Err(crate::AutumnError::bad_request_msg(format!(
-                    "upload content type not allowed: declared={}",
-                    truncate_for_error(essence)
-                )));
-            }
-            None => {
-                return Err(crate::AutumnError::bad_request_msg(
-                    "upload content type not allowed: no recognized or declared type",
-                ));
-            }
-        }
+    } else if !matches!(
+        declared_essence,
+        Some(essence) if is_signatureless_text_type(essence) && in_list(essence)
+    ) {
+        return Err(crate::AutumnError::bad_request_msg(format!(
+            "upload content type could not be verified from its content: declared={}",
+            declared_essence.map_or_else(String::new, truncate_for_error)
+        )));
     }
     Ok(())
 }

--- a/autumn/src/extract.rs
+++ b/autumn/src/extract.rs
@@ -181,7 +181,7 @@ impl Multipart {
     /// Returns [`crate::AutumnError`] when multipart parsing fails or the
     /// field MIME type is not allowed by config.
     pub async fn next_field(&mut self) -> crate::AutumnResult<Option<MultipartField<'_>>> {
-        let Some(field) = self
+        let Some(mut field) = self
             .inner
             .next_field()
             .await
@@ -190,31 +190,93 @@ impl Multipart {
             return Ok(None);
         };
 
-        // Only enforce MIME allow-lists for file parts. Regular form
-        // fields often omit `Content-Type`.
-        if field.file_name().is_some() && !self.config.allowed_mime_types.is_empty() {
-            let Some(content_type) = field.content_type().map(str::to_owned) else {
-                return Err(crate::AutumnError::bad_request_msg(
-                    "missing content type on uploaded file",
-                ));
-            };
-            if !self
-                .config
-                .allowed_mime_types
-                .iter()
-                .any(|allowed| allowed.eq_ignore_ascii_case(&content_type))
+        // Only file parts carry uploadable content worth validating. Regular
+        // form fields often omit `Content-Type` and are never sniffed.
+        //
+        // We sniff whenever an allow-list is configured OR strict
+        // mismatch-rejection is enabled — either check needs the actual
+        // (magic-byte) content type rather than the spoofable client header.
+        let needs_sniff = field.file_name().is_some()
+            && (!self.config.allowed_mime_types.is_empty()
+                || self.config.reject_on_content_type_mismatch);
+
+        if !needs_sniff {
+            return Ok(Some(MultipartField::new(
+                field,
+                self.config.max_file_size_bytes,
+            )));
+        }
+
+        // Buffer a bounded leading prefix (a few chunks at most) for sniffing,
+        // preserving streaming: the rest of the field is still pulled lazily by
+        // the consuming methods, which replay this prefix first.
+        let mut prefix: Vec<u8> = Vec::new();
+        while prefix.len() < SNIFF_PREFIX_BYTES {
+            match field
+                .chunk()
+                .await
+                .map_err(|err| multipart_error_to_error(&err))?
             {
+                Some(chunk) => prefix.extend_from_slice(&chunk),
+                None => break,
+            }
+        }
+
+        let declared = field.content_type().map(str::to_owned);
+        let sniffed = sniff_content_type(&prefix);
+
+        // Allow-list enforcement against the SNIFFED type. A file whose content
+        // cannot be recognized (short/empty/unknown → sniffed is None) is
+        // rejected when an allow-list is configured.
+        if !self.config.allowed_mime_types.is_empty() {
+            let allowed = sniffed.as_ref().is_some_and(|s| {
+                self.config
+                    .allowed_mime_types
+                    .iter()
+                    .any(|allowed| allowed.eq_ignore_ascii_case(s))
+            });
+            if !allowed {
                 return Err(crate::AutumnError::bad_request_msg(format!(
-                    "unsupported upload content type: {content_type}"
+                    "upload content type not allowed: sniffed={sniffed:?}"
                 )));
+            }
+        }
+
+        // Strict mismatch mode: the declared header must match the sniffed type.
+        if self.config.reject_on_content_type_mismatch
+            && let Some(declared) = declared.as_deref()
+        {
+            match sniffed.as_deref() {
+                Some(sniffed) if declared.eq_ignore_ascii_case(sniffed) => {}
+                Some(sniffed) => {
+                    return Err(crate::AutumnError::bad_request_msg(format!(
+                        "declared content type {declared:?} does not match sniffed \
+                         content type {sniffed:?}"
+                    )));
+                }
+                None => {
+                    return Err(crate::AutumnError::bad_request_msg(format!(
+                        "cannot verify declared content type {declared:?}: \
+                         file content is unrecognized"
+                    )));
+                }
             }
         }
 
         Ok(Some(MultipartField {
             inner: field,
             max_file_size_bytes: self.config.max_file_size_bytes,
+            prefix,
+            sniffed_content_type: sniffed,
         }))
     }
+}
+
+/// Sniff the content type of a file from its leading bytes via magic-byte
+/// detection. Returns `None` when the format is unrecognized.
+#[cfg(feature = "multipart")]
+fn sniff_content_type(prefix: &[u8]) -> Option<String> {
+    infer::get(prefix).map(|kind| kind.mime_type().to_owned())
 }
 
 #[cfg(feature = "multipart")]
@@ -243,16 +305,31 @@ where
     }
 }
 
+/// Number of leading bytes buffered for magic-byte content sniffing.
+///
+/// `infer` only needs a small header prefix to recognize a format, so we read
+/// at most this many bytes (a few chunks) and never buffer the whole upload.
+#[cfg(feature = "multipart")]
+const SNIFF_PREFIX_BYTES: usize = 512;
+
 /// A multipart field wrapper that provides safe streaming helpers.
 #[cfg(feature = "multipart")]
 pub struct MultipartField<'a> {
     inner: axum::extract::multipart::Field<'a>,
     max_file_size_bytes: usize,
+    /// Leading bytes already consumed from `inner` during content sniffing.
+    /// Empty when no sniffing occurred. Consuming methods must emit these
+    /// first so the already-read prefix is not lost.
+    prefix: Vec<u8>,
+    /// Sniffed (magic-byte) content type, if the leading bytes were recognized.
+    sniffed_content_type: Option<String>,
 }
 
 #[cfg(all(feature = "multipart", feature = "storage"))]
 struct MultipartFieldStreamState<'a> {
     inner: axum::extract::multipart::Field<'a>,
+    /// Sniffed prefix bytes to emit before draining `inner`. Taken once.
+    prefix: Option<bytes::Bytes>,
     total: usize,
     max: usize,
     errored: bool,
@@ -261,10 +338,33 @@ struct MultipartFieldStreamState<'a> {
 #[cfg(feature = "multipart")]
 #[allow(clippy::elidable_lifetime_names)]
 impl<'a> MultipartField<'a> {
+    /// Wrap a raw multipart field with no sniffed prefix (the common path for
+    /// non-file parts or when no content validation is configured).
+    const fn new(inner: axum::extract::multipart::Field<'a>, max_file_size_bytes: usize) -> Self {
+        Self {
+            inner,
+            max_file_size_bytes,
+            prefix: Vec::new(),
+            sniffed_content_type: None,
+        }
+    }
+
     /// Field name from the multipart form.
     #[must_use]
     pub fn name(&self) -> Option<&str> {
         self.inner.name()
+    }
+
+    /// The sniffed (magic-byte) content type of this field, if it was
+    /// validated by content and the format was recognized.
+    ///
+    /// Returns `None` when no sniffing occurred (non-file part, or no
+    /// allow-list / mismatch policy configured) or the content was
+    /// unrecognized. Prefer this over [`content_type`](Self::content_type),
+    /// which returns the spoofable client-declared header.
+    #[must_use]
+    pub fn sniffed_content_type(&self) -> Option<&str> {
+        self.sniffed_content_type.as_deref()
     }
 
     /// Uploaded file name (if this field represents a file).
@@ -313,7 +413,13 @@ impl<'a> MultipartField<'a> {
     /// `security.upload.max_file_size_bytes`.
     pub async fn bytes_limited(mut self) -> crate::AutumnResult<Vec<u8>> {
         let mut out = Vec::new();
-        let mut read = 0usize;
+        // Replay any bytes already consumed during content sniffing first, and
+        // count them toward the size cap.
+        let mut read = self.prefix.len();
+        if read > self.max_file_size_bytes {
+            return Err(file_too_large_error(self.max_file_size_bytes));
+        }
+        out.append(&mut self.prefix);
         while let Some(chunk) = self
             .inner
             .chunk()
@@ -375,17 +481,28 @@ impl<'a> MultipartField<'a> {
         'a: 'b,
     {
         let key = key.into();
+        // Persist the VERIFIED (sniffed) type when available, falling back to
+        // the client-declared header only when no sniffing occurred.
         let content_type = self
-            .inner
-            .content_type()
-            .map_or_else(|| "application/octet-stream".to_owned(), str::to_owned);
+            .sniffed_content_type
+            .clone()
+            .or_else(|| self.inner.content_type().map(str::to_owned))
+            .unwrap_or_else(|| "application/octet-stream".to_owned());
+
+        let prefix = if self.prefix.is_empty() {
+            None
+        } else {
+            Some(bytes::Bytes::from(self.prefix))
+        };
 
         // Adapt the multipart chunk iterator into the trait's
         // `ByteStream`, enforcing the per-file size cap as we go so we
         // never buffer the whole upload in memory and large files flow
-        // straight through to the store's streaming path.
+        // straight through to the store's streaming path. Any sniffed prefix
+        // is replayed as the first chunk so it is not lost.
         let state = MultipartFieldStreamState {
             inner: self.inner,
+            prefix,
             total: 0,
             max: self.max_file_size_bytes,
             errored: false,
@@ -394,6 +511,18 @@ impl<'a> MultipartField<'a> {
         let stream = futures::stream::unfold(state, |mut state| async move {
             if state.errored {
                 return None;
+            }
+            if let Some(prefix) = state.prefix.take() {
+                state.total = state.total.saturating_add(prefix.len());
+                if state.total > state.max {
+                    let err = crate::storage::BlobStoreError::PayloadTooLarge(format!(
+                        "uploaded file exceeds limit of {} bytes",
+                        state.max,
+                    ));
+                    state.errored = true;
+                    return Some((Err(err), state));
+                }
+                return Some((Ok(prefix), state));
             }
             match state.inner.chunk().await {
                 Ok(Some(chunk)) => {
@@ -448,6 +577,19 @@ impl<'a> MultipartField<'a> {
             .map_err(crate::AutumnError::internal_server_error)?;
 
         let mut written = 0usize;
+        // Write any sniffed prefix bytes first so they are not lost, counting
+        // them toward the per-file cap.
+        if !self.prefix.is_empty() {
+            written += self.prefix.len();
+            if written > self.max_file_size_bytes {
+                drop(file);
+                let _ = tokio::fs::remove_file(path).await;
+                return Err(file_too_large_error(self.max_file_size_bytes));
+            }
+            file.write_all(&self.prefix)
+                .await
+                .map_err(crate::AutumnError::internal_server_error)?;
+        }
         while let Some(chunk) = self
             .inner
             .chunk()
@@ -535,10 +677,7 @@ mod tests {
             .unwrap();
         let field = multipart.next_field().await.unwrap().unwrap();
 
-        let wrapper = MultipartField {
-            inner: field,
-            max_file_size_bytes: 100,
-        };
+        let wrapper = MultipartField::new(field, 100);
 
         let bytes = wrapper.bytes_limited().await.unwrap();
         assert_eq!(bytes, b"hello");
@@ -557,10 +696,7 @@ mod tests {
             .unwrap();
         let field = multipart.next_field().await.unwrap().unwrap();
 
-        let wrapper = MultipartField {
-            inner: field,
-            max_file_size_bytes: 5,
-        };
+        let wrapper = MultipartField::new(field, 5);
 
         let err = wrapper.bytes_limited().await.unwrap_err();
         assert_eq!(err.status(), http::StatusCode::PAYLOAD_TOO_LARGE);
@@ -579,10 +715,7 @@ mod tests {
             .unwrap();
         let field = multipart.next_field().await.unwrap().unwrap();
 
-        let wrapper = MultipartField {
-            inner: field,
-            max_file_size_bytes: 100,
-        };
+        let wrapper = MultipartField::new(field, 100);
 
         let dir = tempfile::tempdir().unwrap();
         let file_path = dir.path().join("out.txt");
@@ -607,10 +740,7 @@ mod tests {
             .unwrap();
         let field = multipart.next_field().await.unwrap().unwrap();
 
-        let wrapper = MultipartField {
-            inner: field,
-            max_file_size_bytes: 4,
-        };
+        let wrapper = MultipartField::new(field, 4);
 
         let dir = tempfile::tempdir().unwrap();
         let file_path = dir.path().join("out_large.txt");
@@ -638,10 +768,7 @@ mod tests {
             .unwrap();
         let field = multipart.next_field().await.unwrap().unwrap();
 
-        let wrapper = MultipartField {
-            inner: field,
-            max_file_size_bytes: 100,
-        };
+        let wrapper = MultipartField::new(field, 100);
 
         let root = tempfile::tempdir().unwrap();
         let store = LocalBlobStore::new(
@@ -679,10 +806,7 @@ mod tests {
             .unwrap();
         let field = multipart.next_field().await.unwrap().unwrap();
 
-        let wrapper = MultipartField {
-            inner: field,
-            max_file_size_bytes: 4, // "blob content" is 12 bytes
-        };
+        let wrapper = MultipartField::new(field, 4); // "blob content" is 12 bytes
 
         let root = tempfile::tempdir().unwrap();
         let store = LocalBlobStore::new(
@@ -719,10 +843,7 @@ mod tests {
             .unwrap();
         let field = multipart.next_field().await.unwrap().unwrap();
 
-        let wrapper = MultipartField {
-            inner: field,
-            max_file_size_bytes: 100,
-        };
+        let wrapper = MultipartField::new(field, 100);
 
         assert_eq!(wrapper.name(), Some("custom_name"));
         assert_eq!(wrapper.file_name(), Some("custom_file.png"));
@@ -733,6 +854,56 @@ mod tests {
 
         let not_tighter = tighter.with_max_bytes(200);
         assert_eq!(not_tighter.max_file_size_bytes, 50); // should not relax
+    }
+
+    #[test]
+    fn sniff_content_type_recognizes_png() {
+        let png = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00];
+        assert_eq!(sniff_content_type(&png).as_deref(), Some("image/png"));
+    }
+
+    #[test]
+    fn sniff_content_type_unknown_is_none() {
+        assert_eq!(sniff_content_type(&[0x01, 0x02]), None);
+        assert_eq!(sniff_content_type(&[]), None);
+    }
+
+    #[tokio::test]
+    async fn next_field_exposes_sniffed_content_type_for_genuine_png() {
+        // Genuine PNG bytes declared as octet-stream: the extractor must
+        // recognize the real type from magic bytes and expose it.
+        let mut body: Vec<u8> = Vec::new();
+        body.extend_from_slice(
+            b"--boundary\r\nContent-Disposition: form-data; name=\"file\"; \
+              filename=\"real.png\"\r\nContent-Type: application/octet-stream\r\n\r\n",
+        );
+        body.extend_from_slice(&[
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48,
+            0x44, 0x52,
+        ]);
+        body.extend_from_slice(b"\r\n--boundary--\r\n");
+
+        let req = Request::builder()
+            .header("content-type", "multipart/form-data; boundary=boundary")
+            .body(axum::body::Body::from(body))
+            .unwrap();
+
+        let inner = axum::extract::Multipart::from_request(req, &())
+            .await
+            .unwrap();
+        let mut multipart = Multipart {
+            inner,
+            config: crate::security::config::UploadConfig {
+                allowed_mime_types: vec!["image/png".to_owned()],
+                ..crate::security::config::UploadConfig::default()
+            },
+        };
+
+        let field = multipart.next_field().await.unwrap().unwrap();
+        assert_eq!(field.sniffed_content_type(), Some("image/png"));
+        // The prefix bytes consumed during sniffing are not lost.
+        let bytes = field.bytes_limited().await.unwrap();
+        assert_eq!(bytes.len(), 16);
     }
 }
 

--- a/autumn/src/extract.rs
+++ b/autumn/src/extract.rs
@@ -210,7 +210,7 @@ impl Multipart {
         // Buffer a bounded leading prefix (a few chunks at most) for sniffing,
         // preserving streaming: the rest of the field is still pulled lazily by
         // the consuming methods, which replay this prefix first.
-        let mut prefix: Vec<u8> = Vec::new();
+        let mut prefix: Vec<u8> = Vec::with_capacity(SNIFF_PREFIX_BYTES);
         while prefix.len() < SNIFF_PREFIX_BYTES {
             match field
                 .chunk()
@@ -228,10 +228,12 @@ impl Multipart {
             return Err(file_too_large_error(self.config.max_file_size_bytes));
         }
 
-        let declared = field.content_type().map(str::to_owned);
+        // Borrow the declared header rather than allocating: `declared_essence`
+        // only needs a slice, and the borrow of `field` ends before it is moved
+        // into the returned wrapper below.
         // Compare on the type ESSENCE (media type without parameters), so a
         // header like `image/png; charset=binary` matches sniffed `image/png`.
-        let declared_essence = declared.as_deref().map(content_type_essence);
+        let declared_essence = field.content_type().map(content_type_essence);
         let sniffed = sniff_content_type(&prefix);
 
         // Enforce the allow-list (sniffed → markup-guard → declared fallback)
@@ -242,11 +244,11 @@ impl Multipart {
                 &self.config.allowed_mime_types,
                 &prefix,
                 declared_essence,
-                sniffed.as_deref(),
+                sniffed,
             )?;
         }
         if self.config.reject_on_content_type_mismatch {
-            enforce_content_type_match(declared_essence, sniffed.as_deref())?;
+            enforce_content_type_match(declared_essence, sniffed)?;
         }
 
         Ok(Some(MultipartField {
@@ -259,10 +261,11 @@ impl Multipart {
 }
 
 /// Sniff the content type of a file from its leading bytes via magic-byte
-/// detection. Returns `None` when the format is unrecognized.
+/// detection. Returns `None` when the format is unrecognized. `infer` yields a
+/// `&'static str` media type, so no allocation is needed.
 #[cfg(feature = "multipart")]
-fn sniff_content_type(prefix: &[u8]) -> Option<String> {
-    infer::get(prefix).map(|kind| kind.mime_type().to_owned())
+fn sniff_content_type(prefix: &[u8]) -> Option<&'static str> {
+    infer::get(prefix).map(|kind| kind.mime_type())
 }
 
 /// The essence of a content-type header — the media type without any
@@ -417,7 +420,8 @@ pub struct MultipartField<'a> {
     /// first so the already-read prefix is not lost.
     prefix: Vec<u8>,
     /// Sniffed (magic-byte) content type, if the leading bytes were recognized.
-    sniffed_content_type: Option<String>,
+    /// `infer` returns a `&'static str`, so this stores the borrow directly.
+    sniffed_content_type: Option<&'static str>,
 }
 
 #[cfg(all(feature = "multipart", feature = "storage"))]
@@ -458,8 +462,8 @@ impl<'a> MultipartField<'a> {
     /// unrecognized. Prefer this over [`content_type`](Self::content_type),
     /// which returns the spoofable client-declared header.
     #[must_use]
-    pub fn sniffed_content_type(&self) -> Option<&str> {
-        self.sniffed_content_type.as_deref()
+    pub const fn sniffed_content_type(&self) -> Option<&str> {
+        self.sniffed_content_type
     }
 
     /// Uploaded file name (if this field represents a file).
@@ -580,7 +584,7 @@ impl<'a> MultipartField<'a> {
         // the client-declared header only when no sniffing occurred.
         let content_type = self
             .sniffed_content_type
-            .clone()
+            .map(str::to_owned)
             .or_else(|| self.inner.content_type().map(str::to_owned))
             .unwrap_or_else(|| "application/octet-stream".to_owned());
 
@@ -954,7 +958,7 @@ mod tests {
     #[test]
     fn sniff_content_type_recognizes_png() {
         let png = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00];
-        assert_eq!(sniff_content_type(&png).as_deref(), Some("image/png"));
+        assert_eq!(sniff_content_type(&png), Some("image/png"));
     }
 
     #[test]

--- a/autumn/src/extract.rs
+++ b/autumn/src/extract.rs
@@ -217,15 +217,16 @@ impl Multipart {
                 .await
                 .map_err(|err| multipart_error_to_error(&err))?
             {
-                Some(chunk) => prefix.extend_from_slice(&chunk),
+                Some(chunk) => {
+                    prefix.extend_from_slice(&chunk);
+                    // Reject as soon as the buffered prefix exceeds the per-file
+                    // cap, so an oversized leading chunk bails without reading on.
+                    if prefix.len() > self.config.max_file_size_bytes {
+                        return Err(file_too_large_error(self.config.max_file_size_bytes));
+                    }
+                }
                 None => break,
             }
-        }
-
-        // Never buffer past the per-file cap while sniffing: a single leading
-        // chunk larger than the limit is already a size violation.
-        if prefix.len() > self.config.max_file_size_bytes {
-            return Err(file_too_large_error(self.config.max_file_size_bytes));
         }
 
         // Borrow the declared header rather than allocating: `declared_essence`
@@ -511,14 +512,14 @@ impl<'a> MultipartField<'a> {
     /// Returns `413 Payload Too Large` if the field exceeds
     /// `security.upload.max_file_size_bytes`.
     pub async fn bytes_limited(mut self) -> crate::AutumnResult<Vec<u8>> {
-        let mut out = Vec::new();
-        // Replay any bytes already consumed during content sniffing first, and
-        // count them toward the size cap.
-        let mut read = self.prefix.len();
+        // Reuse the sniff prefix as the output buffer: it already holds exactly
+        // the leading bytes in order, so appending the inner stream after it
+        // reproduces the original byte sequence with no extra allocation.
+        let mut out = self.prefix;
+        let mut read = out.len();
         if read > self.max_file_size_bytes {
             return Err(file_too_large_error(self.max_file_size_bytes));
         }
-        out.append(&mut self.prefix);
         while let Some(chunk) = self
             .inner
             .chunk()

--- a/autumn/src/extract.rs
+++ b/autumn/src/extract.rs
@@ -306,7 +306,9 @@ fn truncate_for_error(value: &str) -> String {
 /// means the declared header is spoofed.
 #[cfg(feature = "multipart")]
 fn is_signatureless_text_type(essence: &str) -> bool {
-    essence.starts_with("text/") || matches!(essence, "application/json" | "application/csv")
+    // Media types are case-insensitive, so normalize before comparing.
+    let lower = essence.to_ascii_lowercase();
+    lower.starts_with("text/") || matches!(lower.as_str(), "application/json" | "application/csv")
 }
 
 /// Enforce a MIME allow-list against a file part, using content sniffing as the
@@ -981,6 +983,24 @@ mod tests {
         assert_eq!(content_type_essence("  text/csv  "), "text/csv");
         assert_eq!(content_type_essence("application/json"), "application/json");
         assert_eq!(content_type_essence(""), "");
+    }
+
+    #[test]
+    fn is_signatureless_text_type_is_case_insensitive() {
+        // Media types are case-insensitive, so mixed-case declarations must be
+        // recognized as signature-less text.
+        assert!(is_signatureless_text_type("text/csv"));
+        assert!(is_signatureless_text_type("Text/Csv"));
+        assert!(is_signatureless_text_type("TEXT/PLAIN"));
+        assert!(is_signatureless_text_type("application/json"));
+        assert!(is_signatureless_text_type("Application/JSON"));
+        assert!(is_signatureless_text_type("application/csv"));
+        // Binary/sniffable types are never treated as signature-less text —
+        // the P1 fix must be preserved regardless of case.
+        assert!(!is_signatureless_text_type("image/png"));
+        assert!(!is_signatureless_text_type("Image/PNG"));
+        assert!(!is_signatureless_text_type("application/octet-stream"));
+        assert!(!is_signatureless_text_type("application/pdf"));
     }
 
     #[test]

--- a/autumn/src/extract.rs
+++ b/autumn/src/extract.rs
@@ -222,45 +222,31 @@ impl Multipart {
             }
         }
 
-        let declared = field.content_type().map(str::to_owned);
-        let sniffed = sniff_content_type(&prefix);
-
-        // Allow-list enforcement against the SNIFFED type. A file whose content
-        // cannot be recognized (short/empty/unknown → sniffed is None) is
-        // rejected when an allow-list is configured.
-        if !self.config.allowed_mime_types.is_empty() {
-            let allowed = sniffed.as_ref().is_some_and(|s| {
-                self.config
-                    .allowed_mime_types
-                    .iter()
-                    .any(|allowed| allowed.eq_ignore_ascii_case(s))
-            });
-            if !allowed {
-                return Err(crate::AutumnError::bad_request_msg(format!(
-                    "upload content type not allowed: sniffed={sniffed:?}"
-                )));
-            }
+        // Never buffer past the per-file cap while sniffing: a single leading
+        // chunk larger than the limit is already a size violation.
+        if prefix.len() > self.config.max_file_size_bytes {
+            return Err(file_too_large_error(self.config.max_file_size_bytes));
         }
 
-        // Strict mismatch mode: the declared header must match the sniffed type.
-        if self.config.reject_on_content_type_mismatch
-            && let Some(declared) = declared.as_deref()
-        {
-            match sniffed.as_deref() {
-                Some(sniffed) if declared.eq_ignore_ascii_case(sniffed) => {}
-                Some(sniffed) => {
-                    return Err(crate::AutumnError::bad_request_msg(format!(
-                        "declared content type {declared:?} does not match sniffed \
-                         content type {sniffed:?}"
-                    )));
-                }
-                None => {
-                    return Err(crate::AutumnError::bad_request_msg(format!(
-                        "cannot verify declared content type {declared:?}: \
-                         file content is unrecognized"
-                    )));
-                }
-            }
+        let declared = field.content_type().map(str::to_owned);
+        // Compare on the type ESSENCE (media type without parameters), so a
+        // header like `image/png; charset=binary` matches sniffed `image/png`.
+        let declared_essence = declared.as_deref().map(content_type_essence);
+        let sniffed = sniff_content_type(&prefix);
+
+        // Enforce the allow-list (sniffed → markup-guard → declared fallback)
+        // and, when enabled, strict declared-vs-sniffed matching. See the
+        // helpers below for the exact rules.
+        if !self.config.allowed_mime_types.is_empty() {
+            enforce_upload_allow_list(
+                &self.config.allowed_mime_types,
+                &prefix,
+                declared_essence,
+                sniffed.as_deref(),
+            )?;
+        }
+        if self.config.reject_on_content_type_mismatch {
+            enforce_content_type_match(declared_essence, sniffed.as_deref())?;
         }
 
         Ok(Some(MultipartField {
@@ -277,6 +263,115 @@ impl Multipart {
 #[cfg(feature = "multipart")]
 fn sniff_content_type(prefix: &[u8]) -> Option<String> {
     infer::get(prefix).map(|kind| kind.mime_type().to_owned())
+}
+
+/// The essence of a content-type header — the media type without any
+/// parameters (e.g. `image/png` from `image/png; charset=binary`).
+#[cfg(feature = "multipart")]
+fn content_type_essence(raw: &str) -> &str {
+    raw.split(';').next().unwrap_or("").trim()
+}
+
+/// Whether the leading bytes look like textual markup (`<…`), after skipping a
+/// UTF-8 BOM and any leading ASCII whitespace. Catches HTML (`<!DOCTYPE`,
+/// `<html`, `<script`), SVG (`<svg`), and XML (`<?xml`) that `infer` cannot
+/// recognize by magic bytes, so they can never be admitted via the declared
+/// content-type fallback.
+#[cfg(feature = "multipart")]
+fn prefix_looks_like_markup(prefix: &[u8]) -> bool {
+    let bytes = prefix.strip_prefix(&[0xEF, 0xBB, 0xBF]).unwrap_or(prefix);
+    let trimmed = bytes
+        .iter()
+        .position(|byte| !byte.is_ascii_whitespace())
+        .map_or(&[][..], |idx| &bytes[idx..]);
+    trimmed.first() == Some(&b'<')
+}
+
+/// Bound a content-type value before echoing it into an error message, so a
+/// hostile client can't inflate responses with an arbitrarily long header.
+#[cfg(feature = "multipart")]
+fn truncate_for_error(value: &str) -> String {
+    const MAX_CHARS: usize = 128;
+    value.chars().take(MAX_CHARS).collect()
+}
+
+/// Enforce a MIME allow-list against a file part, using content sniffing as the
+/// primary signal. `infer` only recognizes binary formats by magic bytes; text
+/// formats (text/plain, application/json, text/csv, image/svg+xml, …) have no
+/// signature and always sniff to `None`. Precedence:
+///
+/// 1. **Sniffed recognized** → must be in the list, else reject. Header ignored.
+/// 2. **Unrecognized + markup** (leading `<…`) → reject unconditionally, so
+///    HTML/SVG/XML can't ride in under a spoofed declared type.
+/// 3. **Unrecognized + not markup** (genuine signature-less text) → fall back to
+///    the declared essence, which must be in the list. This is the only case
+///    where the declared header is trusted.
+#[cfg(feature = "multipart")]
+fn enforce_upload_allow_list(
+    allowed: &[String],
+    prefix: &[u8],
+    declared_essence: Option<&str>,
+    sniffed: Option<&str>,
+) -> crate::AutumnResult<()> {
+    let in_list = |value: &str| {
+        allowed
+            .iter()
+            .any(|entry| entry.eq_ignore_ascii_case(value))
+    };
+    if let Some(sniffed) = sniffed {
+        if !in_list(sniffed) {
+            return Err(crate::AutumnError::bad_request_msg(format!(
+                "upload content type not allowed: sniffed={sniffed}"
+            )));
+        }
+    } else if prefix_looks_like_markup(prefix) {
+        return Err(crate::AutumnError::bad_request_msg(
+            "upload rejected: unrecognized file content looks like markup",
+        ));
+    } else {
+        match declared_essence {
+            Some(essence) if in_list(essence) => {}
+            Some(essence) => {
+                return Err(crate::AutumnError::bad_request_msg(format!(
+                    "upload content type not allowed: declared={}",
+                    truncate_for_error(essence)
+                )));
+            }
+            None => {
+                return Err(crate::AutumnError::bad_request_msg(
+                    "upload content type not allowed: no recognized or declared type",
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Strict declared-vs-sniffed matching (`reject_on_content_type_mismatch`).
+/// Comparison is on the declared essence. Omitting the header is itself a
+/// failure — otherwise an attacker could bypass the check by sending no
+/// `Content-Type`.
+#[cfg(feature = "multipart")]
+fn enforce_content_type_match(
+    declared_essence: Option<&str>,
+    sniffed: Option<&str>,
+) -> crate::AutumnResult<()> {
+    let Some(declared_essence) = declared_essence else {
+        return Err(crate::AutumnError::bad_request_msg(
+            "content-type mismatch check enabled but the upload declared no content type",
+        ));
+    };
+    match sniffed {
+        Some(sniffed) if declared_essence.eq_ignore_ascii_case(sniffed) => Ok(()),
+        Some(sniffed) => Err(crate::AutumnError::bad_request_msg(format!(
+            "declared content type {} does not match sniffed content type {sniffed}",
+            truncate_for_error(declared_essence)
+        ))),
+        None => Err(crate::AutumnError::bad_request_msg(format!(
+            "cannot verify declared content type {}: file content is unrecognized",
+            truncate_for_error(declared_essence)
+        ))),
+    }
 }
 
 #[cfg(feature = "multipart")]
@@ -866,6 +961,32 @@ mod tests {
     fn sniff_content_type_unknown_is_none() {
         assert_eq!(sniff_content_type(&[0x01, 0x02]), None);
         assert_eq!(sniff_content_type(&[]), None);
+    }
+
+    #[test]
+    fn content_type_essence_strips_parameters() {
+        assert_eq!(
+            content_type_essence("image/png; charset=binary"),
+            "image/png"
+        );
+        assert_eq!(content_type_essence("  text/csv  "), "text/csv");
+        assert_eq!(content_type_essence("application/json"), "application/json");
+        assert_eq!(content_type_essence(""), "");
+    }
+
+    #[test]
+    fn prefix_looks_like_markup_detects_leading_angle_bracket() {
+        assert!(prefix_looks_like_markup(b"<!DOCTYPE html>"));
+        assert!(prefix_looks_like_markup(b"<svg onload=alert(1)>"));
+        assert!(prefix_looks_like_markup(b"<?xml version=\"1.0\"?>"));
+        // Leading whitespace and a UTF-8 BOM are skipped.
+        assert!(prefix_looks_like_markup(b"   \n\t<html>"));
+        assert!(prefix_looks_like_markup(&[0xEF, 0xBB, 0xBF, b'<', b'a']));
+        // Genuine non-markup text and binary are not flagged.
+        assert!(!prefix_looks_like_markup(b"a,b\n1,2"));
+        assert!(!prefix_looks_like_markup(br#"{"a":1}"#));
+        assert!(!prefix_looks_like_markup(&[0x01, 0x02]));
+        assert!(!prefix_looks_like_markup(b""));
     }
 
     #[tokio::test]

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -1175,12 +1175,15 @@ pub struct UploadConfig {
     /// 2. **Unrecognized but looks like markup** (leading `<…` after a BOM /
     ///    whitespace — HTML, SVG, XML) → always rejected (`400`), so scripts
     ///    or `<svg onload=…>` can't ride in under a spoofed declared type.
-    /// 3. **Unrecognized and not markup** (genuine text such as `text/plain`,
-    ///    `application/json`, `text/csv`, which have no magic bytes) → falls
-    ///    back to the **declared** content-type essence (media type without
-    ///    parameters), which must appear in the list. This is the only case
-    ///    where the declared header is trusted, and only to disambiguate among
-    ///    signature-less text formats.
+    /// 3. **Unrecognized and not markup** → the declared content-type essence
+    ///    (media type without parameters) is trusted **only** when it names a
+    ///    signature-less TEXT type (`text/*`, `application/json`,
+    ///    `application/csv`) that appears in the list. Binary/sniffable types
+    ///    (`image/*`, `application/pdf`, …) are always enforced strictly by
+    ///    magic bytes: unrecognizable bytes declaring such a type are rejected
+    ///    (`400`), since a genuine file of that type would have sniffed
+    ///    positively. This is the only case where the declared header is
+    ///    trusted, and only to disambiguate among signature-less text formats.
     #[serde(default)]
     pub allowed_mime_types: Vec<String>,
     /// When `true`, reject an uploaded file part if the client-declared

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -54,6 +54,7 @@
 //! | `AUTUMN_SECURITY__UPLOAD__MAX_REQUEST_SIZE_BYTES` | `security.upload.max_request_size_bytes` | `usize` |
 //! | `AUTUMN_SECURITY__UPLOAD__MAX_FILE_SIZE_BYTES` | `security.upload.max_file_size_bytes` | `usize` |
 //! | `AUTUMN_SECURITY__UPLOAD__ALLOWED_MIME_TYPES` | `security.upload.allowed_mime_types` | comma-separated `String` |
+//! | `AUTUMN_SECURITY__UPLOAD__REJECT_ON_CONTENT_TYPE_MISMATCH` | `security.upload.reject_on_content_type_mismatch` | `bool` |
 //! | `AUTUMN_SECURITY__WEBHOOKS__REPLAY__BACKEND` | `security.webhooks.replay.backend` | `memory` / `redis` |
 //! | `AUTUMN_SECURITY__WEBHOOKS__REPLAY__REDIS__URL` | `security.webhooks.replay.redis.url` | `String` |
 //! | `AUTUMN_SECURITY__WEBHOOKS__REPLAY__REDIS__KEY_PREFIX` | `security.webhooks.replay.redis.key_prefix` | `String` |
@@ -1143,8 +1144,18 @@ fn default_rate_limit_redis_key_prefix() -> String {
 /// - `max_request_size_bytes`: global request body cap (enforced by middleware)
 /// - `max_file_size_bytes`: per-file cap for `crate::extract::Multipart` helpers
 /// - `allowed_mime_types`: optional MIME-type allow list for uploaded parts
+/// - `reject_on_content_type_mismatch`: strict mode that rejects when the
+///   client-declared `Content-Type` disagrees with the sniffed content
 ///
 /// Leave `allowed_mime_types` empty to allow any content type.
+///
+/// # Content sniffing
+///
+/// The `crate::extract::Multipart` extractor validates uploaded file parts by
+/// their actual content (magic bytes), **not** the spoofable client-declared
+/// `Content-Type` header. When `allowed_mime_types` is non-empty, the sniffed
+/// type must be present in the list; files that are too short, empty, or of an
+/// unrecognized type (sniffed type is unknown) are rejected deterministically.
 #[derive(Debug, Clone, Deserialize)]
 pub struct UploadConfig {
     /// Maximum total multipart request body size in bytes.
@@ -1154,8 +1165,26 @@ pub struct UploadConfig {
     #[serde(default = "default_max_file_size_bytes")]
     pub max_file_size_bytes: usize,
     /// Optional allowed MIME types (e.g. `["image/png", "image/jpeg"]`).
+    ///
+    /// Enforced against the **sniffed** (magic-byte) content type, never the
+    /// client-declared header. A file whose content type cannot be recognized
+    /// (too short, empty, or unknown format) is rejected when this list is
+    /// non-empty.
     #[serde(default)]
     pub allowed_mime_types: Vec<String>,
+    /// When `true`, reject an uploaded file part if the client-declared
+    /// `Content-Type` header disagrees with the sniffed (magic-byte) content
+    /// type. Default: `false`.
+    ///
+    /// Behavior when enabled:
+    /// - declared and sniffed both known but differ → reject (`400`)
+    /// - declared known but content unrecognized (sniffed unknown) → reject
+    ///   (`400`, the declared type cannot be verified)
+    /// - no declared header → skip the mismatch check (nothing to compare)
+    ///
+    /// This is independent of `allowed_mime_types`; both checks apply when set.
+    #[serde(default)]
+    pub reject_on_content_type_mismatch: bool,
 }
 
 impl Default for UploadConfig {
@@ -1164,6 +1193,7 @@ impl Default for UploadConfig {
             max_request_size_bytes: default_max_request_size_bytes(),
             max_file_size_bytes: default_max_file_size_bytes(),
             allowed_mime_types: Vec::new(),
+            reject_on_content_type_mismatch: false,
         }
     }
 }

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -1153,9 +1153,8 @@ fn default_rate_limit_redis_key_prefix() -> String {
 ///
 /// The `crate::extract::Multipart` extractor validates uploaded file parts by
 /// their actual content (magic bytes), **not** the spoofable client-declared
-/// `Content-Type` header. When `allowed_mime_types` is non-empty, the sniffed
-/// type must be present in the list; files that are too short, empty, or of an
-/// unrecognized type (sniffed type is unknown) are rejected deterministically.
+/// `Content-Type` header. See `allowed_mime_types` for the exact sniffed →
+/// markup-guard → declared-fallback precedence used when a list is configured.
 #[derive(Debug, Clone, Deserialize)]
 pub struct UploadConfig {
     /// Maximum total multipart request body size in bytes.
@@ -1166,21 +1165,35 @@ pub struct UploadConfig {
     pub max_file_size_bytes: usize,
     /// Optional allowed MIME types (e.g. `["image/png", "image/jpeg"]`).
     ///
-    /// Enforced against the **sniffed** (magic-byte) content type, never the
-    /// client-declared header. A file whose content type cannot be recognized
-    /// (too short, empty, or unknown format) is rejected when this list is
-    /// non-empty.
+    /// Enforced primarily against the **sniffed** (magic-byte) content type,
+    /// never blindly against the client-declared header. Because `infer` only
+    /// recognizes binary formats, the check applies this precedence for each
+    /// file part when the list is non-empty:
+    ///
+    /// 1. **Sniffed type recognized** → it must appear in the list, else the
+    ///    upload is rejected (`400`). The declared header is ignored.
+    /// 2. **Unrecognized but looks like markup** (leading `<…` after a BOM /
+    ///    whitespace — HTML, SVG, XML) → always rejected (`400`), so scripts
+    ///    or `<svg onload=…>` can't ride in under a spoofed declared type.
+    /// 3. **Unrecognized and not markup** (genuine text such as `text/plain`,
+    ///    `application/json`, `text/csv`, which have no magic bytes) → falls
+    ///    back to the **declared** content-type essence (media type without
+    ///    parameters), which must appear in the list. This is the only case
+    ///    where the declared header is trusted, and only to disambiguate among
+    ///    signature-less text formats.
     #[serde(default)]
     pub allowed_mime_types: Vec<String>,
     /// When `true`, reject an uploaded file part if the client-declared
     /// `Content-Type` header disagrees with the sniffed (magic-byte) content
     /// type. Default: `false`.
     ///
-    /// Behavior when enabled:
+    /// Behavior when enabled (comparison uses the declared essence — the media
+    /// type without parameters):
     /// - declared and sniffed both known but differ → reject (`400`)
     /// - declared known but content unrecognized (sniffed unknown) → reject
     ///   (`400`, the declared type cannot be verified)
-    /// - no declared header → skip the mismatch check (nothing to compare)
+    /// - no declared header → reject (`400`); omitting `Content-Type` must not
+    ///   silently bypass the mismatch check
     ///
     /// This is independent of `allowed_mime_types`; both checks apply when set.
     #[serde(default)]

--- a/autumn/tests/integration/extractors.rs
+++ b/autumn/tests/integration/extractors.rs
@@ -562,6 +562,31 @@ async fn multipart_short_file_rejected_when_allow_list_set() {
 
 #[cfg(feature = "multipart")]
 #[tokio::test]
+async fn multipart_unrecognized_binary_declared_png_is_rejected() {
+    let boundary = "X-BOUNDARY";
+    // Unrecognized, non-markup bytes declared as image/png. A genuine PNG would
+    // ALWAYS sniff positively, so unsniffable bytes claiming a binary type are
+    // definitionally a spoof. The declared-header fallback must NOT apply to
+    // binary/sniffable types — only to signature-less text — so this is a 400.
+    let body = single_file_multipart_body(
+        boundary,
+        "file",
+        "fake.png",
+        "image/png",
+        &[0x01, 0x02, 0x03, 0x04],
+    );
+
+    let config = autumn_web::security::UploadConfig {
+        allowed_mime_types: vec!["image/png".to_owned()],
+        ..autumn_web::security::UploadConfig::default()
+    };
+
+    let response = run_sniff_upload(config, body, boundary).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[cfg(feature = "multipart")]
+#[tokio::test]
 async fn multipart_empty_allow_list_passes_through() {
     let boundary = "X-BOUNDARY";
     let html = b"<!DOCTYPE html><script>alert(1)</script>";

--- a/autumn/tests/integration/extractors.rs
+++ b/autumn/tests/integration/extractors.rs
@@ -389,6 +389,29 @@ fn single_file_multipart_body(
     body
 }
 
+/// Same as `single_file_multipart_body`, but emits NO `Content-Type` header
+/// for the file part (used to prove strict mismatch mode can't be bypassed by
+/// omitting the declared type).
+#[cfg(feature = "multipart")]
+fn single_file_multipart_body_no_content_type(
+    boundary: &str,
+    field_name: &str,
+    file_name: &str,
+    file_bytes: &[u8],
+) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(
+        format!(
+            "Content-Disposition: form-data; name=\"{field_name}\"; filename=\"{file_name}\"\r\n\r\n"
+        )
+        .as_bytes(),
+    );
+    body.extend_from_slice(file_bytes);
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+    body
+}
+
 #[cfg(feature = "multipart")]
 async fn sniff_handler(mut multipart: Multipart) -> autumn_web::AutumnResult<String> {
     let field = multipart
@@ -516,8 +539,17 @@ async fn multipart_mismatch_mode_rejects_when_declared_disagrees() {
 #[tokio::test]
 async fn multipart_short_file_rejected_when_allow_list_set() {
     let boundary = "X-BOUNDARY";
-    // 2-byte file — too short for `infer` to recognize (sniffed = None).
-    let body = single_file_multipart_body(boundary, "file", "tiny.png", "image/png", &[0x01, 0x02]);
+    // 2-byte binary file — too short for `infer` to recognize (sniffed = None)
+    // and not markup. Its declared type (octet-stream) is NOT in the allow-list,
+    // so the declared-essence fallback also fails → reject. This proves an
+    // unverifiable file cannot slip in unless its declared type is allow-listed.
+    let body = single_file_multipart_body(
+        boundary,
+        "file",
+        "tiny.bin",
+        "application/octet-stream",
+        &[0x01, 0x02],
+    );
 
     let config = autumn_web::security::UploadConfig {
         allowed_mime_types: vec!["image/png".to_owned()],
@@ -572,4 +604,149 @@ async fn multipart_jpeg_allow_list_passes() {
         .await
         .unwrap();
     assert_eq!(&out[..], format!("image/jpeg:{}", jpeg.len()).as_bytes());
+}
+
+// ── FIX 1: signature-less text formats via declared-essence fallback ─
+
+#[cfg(feature = "multipart")]
+#[tokio::test]
+async fn multipart_genuine_json_passes_via_declared_fallback() {
+    let boundary = "X-BOUNDARY";
+    // `infer` has no magic bytes for JSON → sniffed None, not markup →
+    // declared essence `application/json` (in allow-list) admits it.
+    let body = single_file_multipart_body(
+        boundary,
+        "file",
+        "data.json",
+        "application/json",
+        br#"{"a":1}"#,
+    );
+
+    let config = autumn_web::security::UploadConfig {
+        allowed_mime_types: vec!["application/json".to_owned()],
+        ..autumn_web::security::UploadConfig::default()
+    };
+
+    let response = run_sniff_upload(config, body, boundary).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let out = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    // Sniffing could not positively verify the type, so it stays "none".
+    assert_eq!(&out[..], b"none:7");
+}
+
+#[cfg(feature = "multipart")]
+#[tokio::test]
+async fn multipart_genuine_csv_passes_via_declared_fallback() {
+    let boundary = "X-BOUNDARY";
+    let body = single_file_multipart_body(boundary, "file", "data.csv", "text/csv", b"a,b\n1,2");
+
+    let config = autumn_web::security::UploadConfig {
+        allowed_mime_types: vec!["text/csv".to_owned()],
+        ..autumn_web::security::UploadConfig::default()
+    };
+
+    let response = run_sniff_upload(config, body, boundary).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let out = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&out[..], b"none:7");
+}
+
+#[cfg(feature = "multipart")]
+#[tokio::test]
+async fn multipart_svg_rejected_even_when_declared_image() {
+    let boundary = "X-BOUNDARY";
+    // SVG is markup: the leading `<` must trip the markup guard (or be sniffed
+    // as image/svg+xml), so it can never be admitted under an image/png list.
+    let body = single_file_multipart_body(
+        boundary,
+        "file",
+        "evil.png",
+        "image/png",
+        b"<svg onload=alert(1)></svg>",
+    );
+
+    let config = autumn_web::security::UploadConfig {
+        allowed_mime_types: vec!["image/png".to_owned()],
+        ..autumn_web::security::UploadConfig::default()
+    };
+
+    let response = run_sniff_upload(config, body, boundary).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[cfg(feature = "multipart")]
+#[tokio::test]
+async fn multipart_html_markup_guard_blocks_declared_fallback() {
+    let boundary = "X-BOUNDARY";
+    // HTML declared as text/csv (an allow-listed text type): the markup guard
+    // must reject before the declared-essence fallback can admit it.
+    let body = single_file_multipart_body(
+        boundary,
+        "file",
+        "page.csv",
+        "text/csv",
+        b"<!DOCTYPE html><script>alert(1)</script>",
+    );
+
+    let config = autumn_web::security::UploadConfig {
+        allowed_mime_types: vec!["text/csv".to_owned()],
+        ..autumn_web::security::UploadConfig::default()
+    };
+
+    let response = run_sniff_upload(config, body, boundary).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+// ── FIX 2: strict mode can't be bypassed by omitting Content-Type ────
+
+#[cfg(feature = "multipart")]
+#[tokio::test]
+async fn multipart_strict_mode_rejects_missing_content_type() {
+    let boundary = "X-BOUNDARY";
+    let png = png_fixture();
+    // Genuine PNG but NO declared Content-Type. Strict mode must reject rather
+    // than let an attacker skip the mismatch check by omitting the header.
+    let body = single_file_multipart_body_no_content_type(boundary, "file", "real.png", &png);
+
+    let config = autumn_web::security::UploadConfig {
+        reject_on_content_type_mismatch: true,
+        ..autumn_web::security::UploadConfig::default()
+    };
+
+    let response = run_sniff_upload(config, body, boundary).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+// ── FIX 3: declared essence ignores parameters ──────────────────────
+
+#[cfg(feature = "multipart")]
+#[tokio::test]
+async fn multipart_declared_essence_ignores_parameters() {
+    let boundary = "X-BOUNDARY";
+    let png = png_fixture();
+    // `image/png; charset=binary` must compare equal to sniffed `image/png`.
+    let body = single_file_multipart_body(
+        boundary,
+        "file",
+        "real.png",
+        "image/png; charset=binary",
+        &png,
+    );
+
+    let config = autumn_web::security::UploadConfig {
+        allowed_mime_types: vec!["image/png".to_owned()],
+        reject_on_content_type_mismatch: true,
+        ..autumn_web::security::UploadConfig::default()
+    };
+
+    let response = run_sniff_upload(config, body, boundary).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let out = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&out[..], format!("image/png:{}", png.len()).as_bytes());
 }

--- a/autumn/tests/integration/extractors.rs
+++ b/autumn/tests/integration/extractors.rs
@@ -682,6 +682,28 @@ async fn multipart_genuine_csv_passes_via_declared_fallback() {
 
 #[cfg(feature = "multipart")]
 #[tokio::test]
+async fn multipart_mixed_case_text_type_passes_via_fallback() {
+    let boundary = "X-BOUNDARY";
+    // Media types are case-insensitive: a mixed-case declared `Text/Csv` must
+    // still be recognized as a signature-less text type and admitted via the
+    // declared-header fallback, matching the case-insensitive allow-list.
+    let body = single_file_multipart_body(boundary, "file", "data.csv", "Text/Csv", b"a,b\n1,2");
+
+    let config = autumn_web::security::UploadConfig {
+        allowed_mime_types: vec!["text/csv".to_owned()],
+        ..autumn_web::security::UploadConfig::default()
+    };
+
+    let response = run_sniff_upload(config, body, boundary).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let out = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&out[..], b"none:7");
+}
+
+#[cfg(feature = "multipart")]
+#[tokio::test]
 async fn multipart_svg_rejected_even_when_declared_image() {
     let boundary = "X-BOUNDARY";
     // SVG is markup: the leading `<` must trip the markup guard (or be sniffed

--- a/autumn/tests/integration/extractors.rs
+++ b/autumn/tests/integration/extractors.rs
@@ -216,10 +216,28 @@ async fn multipart_mime_allow_list_skips_non_file_fields() {
         Ok(format!("text={text_seen},file={file_seen}"))
     }
 
+    // The allow-list is enforced by CONTENT (magic bytes), not the declared
+    // header, and only for file parts. The non-file `title` field must bypass
+    // it entirely, while the genuine PNG file part is accepted by its sniffed
+    // type even though its declared header says octet-stream.
     let boundary = "X-BOUNDARY";
-    let payload = format!(
-        "--{boundary}\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\nreport\r\n--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\nhello world\r\n--{boundary}--\r\n"
+    let mut payload: Vec<u8> = Vec::new();
+    payload.extend_from_slice(
+        format!("--{boundary}\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\nreport\r\n")
+            .as_bytes(),
     );
+    payload.extend_from_slice(
+        format!(
+            "--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; \
+             filename=\"real.png\"\r\nContent-Type: application/octet-stream\r\n\r\n"
+        )
+        .as_bytes(),
+    );
+    payload.extend_from_slice(&[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
+        0x52,
+    ]);
+    payload.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
 
     let app = Router::new()
         .route("/", axum::routing::post(handler))
@@ -227,7 +245,7 @@ async fn multipart_mime_allow_list_skips_non_file_fields() {
             |mut req: axum::extract::Request, next: axum::middleware::Next| async move {
                 req.extensions_mut()
                     .insert(autumn_web::security::UploadConfig {
-                        allowed_mime_types: vec!["text/plain".to_owned()],
+                        allowed_mime_types: vec!["image/png".to_owned()],
                         ..autumn_web::security::UploadConfig::default()
                     });
                 next.run(req).await
@@ -343,4 +361,215 @@ async fn multipart_request_size_limit_returns_413() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+// ── Content-sniffing (magic-byte) MIME validation (issue #1354) ──────
+
+/// Build a multipart body for a single file part as raw bytes, since binary
+/// fixtures (PNG/JPEG) are not valid UTF-8.
+#[cfg(feature = "multipart")]
+fn single_file_multipart_body(
+    boundary: &str,
+    field_name: &str,
+    file_name: &str,
+    declared_content_type: &str,
+    file_bytes: &[u8],
+) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(
+        format!(
+            "Content-Disposition: form-data; name=\"{field_name}\"; filename=\"{file_name}\"\r\n"
+        )
+        .as_bytes(),
+    );
+    body.extend_from_slice(format!("Content-Type: {declared_content_type}\r\n\r\n").as_bytes());
+    body.extend_from_slice(file_bytes);
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+    body
+}
+
+#[cfg(feature = "multipart")]
+async fn sniff_handler(mut multipart: Multipart) -> autumn_web::AutumnResult<String> {
+    let field = multipart
+        .next_field()
+        .await?
+        .expect("expected one multipart field");
+    let sniffed = field.sniffed_content_type().unwrap_or("none").to_string();
+    let body = field.bytes_limited().await?;
+    Ok(format!("{sniffed}:{}", body.len()))
+}
+
+#[cfg(feature = "multipart")]
+async fn run_sniff_upload(
+    config: autumn_web::security::UploadConfig,
+    body: Vec<u8>,
+    boundary: &str,
+) -> axum::http::Response<Body> {
+    let app = Router::new()
+        .route("/", axum::routing::post(sniff_handler))
+        .layer(axum::middleware::from_fn(
+            move |mut req: axum::extract::Request, next: axum::middleware::Next| {
+                let config = config.clone();
+                async move {
+                    req.extensions_mut().insert(config);
+                    next.run(req).await
+                }
+            },
+        ));
+
+    app.oneshot(
+        Request::builder()
+            .method("POST")
+            .uri("/")
+            .header(
+                "content-type",
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(Body::from(body))
+            .unwrap(),
+    )
+    .await
+    .unwrap()
+}
+
+#[cfg(feature = "multipart")]
+fn png_fixture() -> Vec<u8> {
+    // PNG magic bytes + a bit more so `infer` recognizes it.
+    vec![
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
+        0x52,
+    ]
+}
+
+#[cfg(feature = "multipart")]
+fn jpeg_fixture() -> Vec<u8> {
+    vec![
+        0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01,
+    ]
+}
+
+#[cfg(feature = "multipart")]
+#[tokio::test]
+async fn multipart_spoofed_html_declared_png_is_rejected() {
+    let boundary = "X-BOUNDARY";
+    let html = b"<!DOCTYPE html><script>alert(1)</script>";
+    let body = single_file_multipart_body(boundary, "file", "evil.png", "image/png", html);
+
+    let config = autumn_web::security::UploadConfig {
+        allowed_mime_types: vec!["image/png".to_owned()],
+        ..autumn_web::security::UploadConfig::default()
+    };
+
+    let response = run_sniff_upload(config, body, boundary).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[cfg(feature = "multipart")]
+#[tokio::test]
+async fn multipart_genuine_png_passes() {
+    let boundary = "X-BOUNDARY";
+    let png = png_fixture();
+    // Deliberately declare a NON-png type to prove the client header is ignored.
+    let body = single_file_multipart_body(
+        boundary,
+        "file",
+        "real.png",
+        "application/octet-stream",
+        &png,
+    );
+
+    let config = autumn_web::security::UploadConfig {
+        allowed_mime_types: vec!["image/png".to_owned()],
+        ..autumn_web::security::UploadConfig::default()
+    };
+
+    let response = run_sniff_upload(config, body, boundary).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let out = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    // Verified type is exposed and full byte count preserved (prefix not lost).
+    assert_eq!(&out[..], format!("image/png:{}", png.len()).as_bytes());
+}
+
+#[cfg(feature = "multipart")]
+#[tokio::test]
+async fn multipart_mismatch_mode_rejects_when_declared_disagrees() {
+    let boundary = "X-BOUNDARY";
+    let png = png_fixture();
+    // Genuine PNG but declared image/jpeg. Both are individually allowed,
+    // yet strict mismatch mode must reject because declared != sniffed.
+    let body = single_file_multipart_body(boundary, "file", "real.png", "image/jpeg", &png);
+
+    let config = autumn_web::security::UploadConfig {
+        allowed_mime_types: vec!["image/png".to_owned(), "image/jpeg".to_owned()],
+        reject_on_content_type_mismatch: true,
+        ..autumn_web::security::UploadConfig::default()
+    };
+
+    let response = run_sniff_upload(config, body, boundary).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[cfg(feature = "multipart")]
+#[tokio::test]
+async fn multipart_short_file_rejected_when_allow_list_set() {
+    let boundary = "X-BOUNDARY";
+    // 2-byte file — too short for `infer` to recognize (sniffed = None).
+    let body = single_file_multipart_body(boundary, "file", "tiny.png", "image/png", &[0x01, 0x02]);
+
+    let config = autumn_web::security::UploadConfig {
+        allowed_mime_types: vec!["image/png".to_owned()],
+        ..autumn_web::security::UploadConfig::default()
+    };
+
+    let response = run_sniff_upload(config, body, boundary).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[cfg(feature = "multipart")]
+#[tokio::test]
+async fn multipart_empty_allow_list_passes_through() {
+    let boundary = "X-BOUNDARY";
+    let html = b"<!DOCTYPE html><script>alert(1)</script>";
+    // No allow-list, mismatch mode off: additive change must not reject.
+    let body = single_file_multipart_body(boundary, "file", "page.png", "image/png", html);
+
+    let config = autumn_web::security::UploadConfig::default();
+
+    let response = run_sniff_upload(config, body, boundary).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let out = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    // No sniff happened (empty allow-list, mismatch off) → sniffed = none,
+    // and the full body is still readable.
+    assert_eq!(&out[..], format!("none:{}", html.len()).as_bytes());
+}
+
+#[cfg(feature = "multipart")]
+#[tokio::test]
+async fn multipart_jpeg_allow_list_passes() {
+    let boundary = "X-BOUNDARY";
+    let jpeg = jpeg_fixture();
+    let body = single_file_multipart_body(
+        boundary,
+        "file",
+        "photo.bin",
+        "application/octet-stream",
+        &jpeg,
+    );
+
+    let config = autumn_web::security::UploadConfig {
+        allowed_mime_types: vec!["image/jpeg".to_owned()],
+        ..autumn_web::security::UploadConfig::default()
+    };
+
+    let response = run_sniff_upload(config, body, boundary).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let out = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&out[..], format!("image/jpeg:{}", jpeg.len()).as_bytes());
 }


### PR DESCRIPTION
## Before / After

**Before:** Autumn&#39;s file-upload MIME allow-list (`security.upload.allowed_mime_types`) was enforced against the client-declared `Content-Type` header. An attacker could rename an HTML/SVG/script payload, send it as `Content-Type: image/png`, and it would sail past an `image/png` allow-list — then execute as stored XSS when served back inline. The knob advertised a defense it didn&#39;t actually provide.

**After:** The allow-list is enforced against the file&#39;s **actual content**, sniffed from its leading bytes. A spoofed HTML/SVG-as-`image/png` upload is rejected with `400`; a genuine PNG/JPEG/PDF passes regardless of its declared header. Uploads streamed to `BlobStore` now persist the **verified** content type, and handlers can read it via `field.sniffed_content_type()`.

## What changed for users
- New optional config `security.upload.reject_on_content_type_mismatch` (default **`false`**): when `true`, rejects any file whose sniffed type disagrees with its declared type, even if both are individually allow-listed.
- Behavior is **additive**: with `allowed_mime_types` empty, nothing new is rejected — no migration needed.
- Enforcement precedence for a file part when an allow-list is set: **sniffed type** (binary formats: PNG/JPEG/PDF/GIF/WebP/…) → if the leading bytes are unrecognized, a **markup guard** rejects anything that looks like HTML/SVG/XML (leading `&lt;` after BOM/whitespace) → otherwise a **declared-essence fallback** admits genuine text formats that have no magic bytes (`text/csv`, `application/json`, `text/plain`). Short/empty/unverifiable non-markup files whose declared type isn&#39;t allow-listed are rejected (`400`). This precedence is documented in the `UploadConfig` doc-comments.

## How it works
- `autumn/src/extract.rs`: `Multipart::next_field` buffers a bounded 512-byte prefix (`SNIFF_PREFIX_BYTES`), sniffs it, and applies the allow-list / strict-mode rules before returning the field. `MultipartField` carries the prefix + sniffed type; `bytes_limited`, `save_to`, and `save_to_blob_store` replay the prefix first, so streaming-to-storage is preserved and the full file is never buffered into memory. The size cap counts the prefix bytes.
- `autumn/src/security/config.rs`: adds `UploadConfig.reject_on_content_type_mismatch` (env key `AUTUMN_SECURITY__UPLOAD__REJECT_ON_CONTENT_TYPE_MISMATCH`, default `false`, documented).
- **New dependency:** `infer = &#34;0.16&#34;`, optional and gated behind the `multipart` feature. Chosen over a hand-rolled signature table because it is pure-Rust with **zero transitive dependencies** (supply-chain-minimal), covers every image/document signature this feature needs plus 100+ others, and is the detector the issue&#39;s own gap analysis recommends. A bespoke table would reinvent a maintained, tested one and risk format gaps.

## Security review
An adversarial review pass verified the prefix-replay is byte-exact (no upload corruption) for files crossing the 512-byte boundary, that size-cap accounting is correct, and that every rejection returns `400` (no `500`s). It surfaced findings this PR fixes: text-type allow-lists no longer reject all uploads (markup-guarded declared fallback), strict mode can no longer be bypassed by omitting the header, parameterized declared types (`image/png; charset=…`) are normalized to their `type/subtype` essence before comparison, and declared values are length-bounded in error messages.

## Testing
20 integration tests (`autumn/tests/integration/extractors.rs`) + 12 unit tests (`autumn/src/extract.rs`), all green. Coverage: spoofed HTML-as-PNG rejected, SVG-as-image rejected, genuine PNG/JPEG passes ignoring the header, mismatch-mode rejection, short file rejected, empty allow-list pass-through, genuine JSON/CSV admitted via the declared-essence fallback, markup guard blocking the fallback, strict-mode missing-header rejection, and parameterized-type normalization.

```
cargo test -p autumn-web --features &#34;multipart storage&#34; --test integration_tests extractors   # 20 passed
cargo test -p autumn-web --features &#34;multipart storage&#34; --lib -- &#39;extract::tests&#39;              # 12 passed
cargo clippy -p autumn-web --features &#34;multipart storage&#34; --all-targets -- -D warnings         # clean
```

Closes #1354

---
_Generated by [Claude Code](https://claude.ai/code/session_019TkxqjifD47bC5HGeydzmG)_

---

## Known-red CI (not caused by this diff)
Two check families are red on every open PR for external reasons and are being fixed separately — this PR&#39;s diff does not touch either area:
- **Lint** — a pre-existing `clippy::needless_pass_by_value` error at `autumn/src/repository.rs:157` (from merged #1701), unrelated to this change. Fix is in flight as #1705.
- **Fuzz (routing / idempotency / headers / body / session)** — the `taiki-e/install-action` shorthand resolves to an empty tool input so `cargo-fuzz` never installs. Fix is in flight as #1717.

This PR&#39;s own gates (compile, feature-combination, this crate&#39;s clippy) are the checks that reflect this diff.