### PR TITLE
feat(alerts): operator alerts on critical production failures (#1610)

### DIFF
--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -490,12 +490,16 @@ pub fn check_alert_destination_impl(
     // alert `Mail` is built, so a present-but-unparsable address (e.g.
     // `not-an-address`) passes every earlier gate yet fails EVERY delivery at
     // runtime with `MailError::InvalidAddress`. An invalid address therefore
-    // does not count as a usable destination. Validity reuses the same address
-    // check the mailer applies to `[mail] unsubscribe_mailto`
-    // (`is_valid_mailto_address_doctor`) so doctor and the mailer agree.
+    // does not count as a usable destination. Validity uses a BARE-mailbox check
+    // (`is_valid_bare_mailbox_doctor`) that matches what lettre accepts for a
+    // recipient — deliberately NOT `is_valid_mailto_address_doctor`, which strips
+    // a leading `mailto:` (correct for the `List-Unsubscribe` header but wrong
+    // here). The runtime hands `[alerts] email` verbatim to
+    // `Mail::builder().to(...)`, and lettre parses it as a bare mailbox at send
+    // time; a `mailto:` URI would fail EVERY delivery, so doctor must reject it.
     let email_trimmed = email.trim();
     let email_configured = !email_trimmed.is_empty();
-    let email_valid = email_configured && is_valid_mailto_address_doctor(email_trimmed);
+    let email_valid = email_configured && is_valid_bare_mailbox_doctor(email_trimmed);
 
     // Whether a configured email would actually deliver. It needs a valid
     // address, a usable (non-disabled) transport AND — for transports that build
@@ -910,6 +914,42 @@ fn is_valid_mailto_address_doctor(value: &str) -> bool {
                 && !domain.is_empty()
                 && domain.contains('.')
                 && !address.contains(char::is_whitespace)
+                && !address.contains([':', '/'])
+        }
+        None => false,
+    }
+}
+
+/// Whether `value` is a syntactically valid **bare** recipient mailbox — a single
+/// `local@domain` with a dotted domain and no scheme prefix.
+///
+/// This is DISTINCT from [`is_valid_mailto_address_doctor`], which accepts a
+/// leading `mailto:` (correct for the `[mail] unsubscribe_mailto`
+/// `List-Unsubscribe` header). The `[alerts] email` is handed verbatim to
+/// `Mail::builder().to(...)` and parsed by lettre as a bare recipient mailbox at
+/// SEND time (`parse_mailbox`/`lettre_message`); lettre does NOT strip a
+/// `mailto:` scheme, so `mailto:oncall@example.com` fails EVERY delivery with
+/// `MailError::InvalidAddress`. Reject the URI form here so doctor agrees with the
+/// SMTP path rather than passing a config that can never deliver.
+fn is_valid_bare_mailbox_doctor(value: &str) -> bool {
+    // Reject control characters and address delimiters anywhere in the value.
+    if value
+        .chars()
+        .any(|c| c.is_control() || matches!(c, '<' | '>' | ','))
+    {
+        return false;
+    }
+    // Note: no `mailto:` strip here — a bare recipient mailbox has no scheme.
+    let address = value.trim();
+    match address.split_once('@') {
+        Some((local, domain)) => {
+            !local.is_empty()
+                && !domain.is_empty()
+                && domain.contains('.')
+                && !address.contains(char::is_whitespace)
+                // A bare mailbox never contains `:` or `/`. This is what makes
+                // `mailto:oncall@example.com` (and any other scheme/URI form)
+                // INVALID — lettre would reject it as a recipient too.
                 && !address.contains([':', '/'])
         }
         None => false,
@@ -4668,6 +4708,23 @@ pub struct Vault {
     }
 
     #[test]
+    fn is_valid_bare_mailbox_rejects_mailto_uri_and_accepts_bare() {
+        // Bare recipient mailboxes are accepted (this is what lettre parses at
+        // send time for `[alerts] email`).
+        assert!(is_valid_bare_mailbox_doctor("oncall@example.com"));
+        assert!(is_valid_bare_mailbox_doctor("a+b@sub.example.co"));
+        // The `mailto:` URI form is REJECTED here (unlike the unsubscribe-mailto
+        // validator): the runtime passes it verbatim to lettre, which rejects it
+        // as a bare recipient. Doctor must not pass a config that can't deliver.
+        assert!(!is_valid_bare_mailbox_doctor("mailto:oncall@example.com"));
+        // Other scheme/URI forms and malformed values stay rejected.
+        assert!(!is_valid_bare_mailbox_doctor("https://oncall@example.com"));
+        assert!(!is_valid_bare_mailbox_doctor("not-an-address"));
+        assert!(!is_valid_bare_mailbox_doctor("oncall example.com"));
+        assert!(!is_valid_bare_mailbox_doctor("oncall@localhost"));
+    }
+
+    #[test]
     fn mail_unsubscribe_usage_with_both_url_and_mailto_warns_in_prod() {
         // base_url presence drives the suppression-backend warning even when a
         // mailto fallback is also configured.
@@ -5147,6 +5204,41 @@ pub struct Vault {
         assert!(
             matches!(r.status, CheckStatus::Pass),
             "a valid `+`-addressed, multi-label-domain email is a working destination"
+        );
+    }
+
+    #[test]
+    fn alert_destination_mailto_uri_email_warns_in_prod() {
+        // `[alerts] email = "mailto:oncall@example.com"` is handed verbatim to
+        // lettre, which rejects the `mailto:` URI as a bare recipient — so every
+        // send fails at runtime. A prior fix used the unsubscribe-mailto validator
+        // (which strips `mailto:` and returned true), letting doctor PASS a config
+        // that can never deliver. The bare-mailbox check must reject it and surface
+        // the dedicated invalid-email warning.
+        let r = check_alert_destination_impl(
+            true,
+            "mailto:oncall@example.com",
+            false,
+            true, // usable transport
+            true, // production
+            true, // [mail] from present
+            true, // smtp requires from
+        );
+        assert!(
+            matches!(r.status, CheckStatus::Warn),
+            "a mailto: URI alert email delivers nothing at runtime → must warn in prod"
+        );
+        assert!(
+            r.detail
+                .as_deref()
+                .is_some_and(|d| d.contains("not a valid email address")),
+            "the dedicated invalid-email warning must fire for the mailto: URI form"
+        );
+        assert!(
+            r.detail
+                .as_deref()
+                .is_some_and(|d| d.contains("mailto:oncall@example.com")),
+            "the warning should echo the offending value"
         );
     }
 

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -780,6 +780,81 @@ pub fn check_alert_destination_impl(
     }
 }
 
+/// Check that a configured `[alerts] error_rate_threshold` is a usable 5xx rate
+/// (issue #1610).
+///
+/// The runtime compares the threshold against a rate computed as
+/// `err_delta / req_delta` (`autumn/src/alerts.rs`'s `evaluate_error_rate`), i.e.
+/// a **fraction in `[0, 1]`**, so the only meaningful thresholds are in `(0, 1]`.
+/// A non-finite value (`nan`/`inf`) or one `> 1` makes `rate >= threshold` false
+/// for every possible rate — the 5xx alert would NEVER fire; a value `<= 0` makes
+/// it fire on a 0%-error window. The runtime (`AlerterSettings::from_config`)
+/// sanitizes such a value by falling back to the default, but doctor still flags
+/// it so the operator fixes the config rather than silently running on the default.
+///
+/// `raw` is the RAW resolved value (empty when unset — the default `0.05` is used,
+/// which is valid). In **production** an invalid value warns with a dedicated
+/// message naming it; outside production it passes quietly (alerts are optional
+/// locally), matching the leniency of the other alert checks. Never blocks beyond
+/// a warning.
+///
+/// The returned check name is `"alert_error_rate_threshold"`.
+pub fn check_alert_error_rate_threshold_impl(raw: &str, is_production: bool) -> CheckResult {
+    const NAME: &str = "alert_error_rate_threshold";
+    let trimmed = raw.trim();
+    // Unset (or cleared) -> the runtime uses the valid default (0.05). Nothing to
+    // flag.
+    if trimmed.is_empty() {
+        return CheckResult {
+            name: NAME,
+            status: CheckStatus::Pass,
+            detail: Some("no [alerts] error_rate_threshold set (defaults to 0.05)".into()),
+            hint: None,
+        };
+    }
+    // Valid iff it parses to a finite fraction in (0, 1]. `str::parse::<f64>`
+    // accepts `nan`/`inf`/`-inf` (which `is_finite()` then rejects), matching the
+    // runtime's `f64` config value; an entirely unparsable value is invalid too.
+    let valid = trimmed
+        .parse::<f64>()
+        .is_ok_and(|v| v.is_finite() && v > 0.0 && v <= 1.0);
+    if valid {
+        return CheckResult {
+            name: NAME,
+            status: CheckStatus::Pass,
+            detail: Some(format!(
+                "[alerts] error_rate_threshold ({trimmed}) is a valid 5xx rate in (0, 1]"
+            )),
+            hint: None,
+        };
+    }
+    if is_production {
+        CheckResult {
+            name: NAME,
+            status: CheckStatus::Warn,
+            detail: Some(format!(
+                "[alerts] error_rate_threshold (\"{trimmed}\") is not a valid rate in (0, 1]; \
+                 the 5xx alert will not work as intended (the runtime falls back to the default \
+                 0.05)"
+            )),
+            hint: Some(
+                "Set [alerts] error_rate_threshold (or AUTUMN_ALERTS__ERROR_RATE_THRESHOLD) to a \
+                 fraction in (0, 1], e.g. 0.05 for 5%. See docs/guide/operator-alerts.md",
+            ),
+        }
+    } else {
+        CheckResult {
+            name: NAME,
+            status: CheckStatus::Pass,
+            detail: Some(format!(
+                "[alerts] error_rate_threshold (\"{trimmed}\") is not a valid rate in (0, 1] \
+                 (optional outside production; the runtime falls back to the default 0.05)"
+            )),
+            hint: None,
+        }
+    }
+}
+
 /// Check a single `[auth.oauth2.<provider>]` entry for common misconfigurations.
 ///
 /// - In production (`is_production = true`): fails when `client_secret` is empty.
@@ -3351,6 +3426,95 @@ where
     false
 }
 
+/// Resolve the RAW effective `[alerts] error_rate_threshold` (empty when unset)
+/// against the same fully-merged config the runtime boots with, mirroring
+/// [`resolve_alert_enabled`]'s profile selection and merged-table build.
+///
+/// The raw string (not a parsed number) is surfaced so
+/// [`check_alert_error_rate_threshold_impl`] can both validate its range and name
+/// a bad value in its warning. Env vars still take highest precedence.
+fn resolve_alert_error_rate_threshold() -> String {
+    let selected_input = std::env::var("AUTUMN_ENV")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| {
+            std::env::var("AUTUMN_PROFILE")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+        })
+        .unwrap_or_default()
+        .trim()
+        .to_owned();
+    let normalized_profile = normalize_alert_profile(&selected_input);
+    // The merge flattens the active profile into the top-level `[alerts]`, so
+    // resolve against an EMPTY profile (mirroring `resolve_alert_enabled`).
+    let merged = get_merged_toml_table_runtime(&normalized_profile, &selected_input);
+    resolve_alert_error_rate_threshold_from_sources(
+        |key| std::env::var(key).ok(),
+        Some(&merged),
+        "",
+    )
+}
+
+/// Resolve the RAW `[alerts] error_rate_threshold` under the same layer precedence
+/// the runtime config merge applies (env `AUTUMN_ALERTS__ERROR_RATE_THRESHOLD` >
+/// `[profile.{profile}.alerts].error_rate_threshold` > base
+/// `[alerts].error_rate_threshold`), returning an empty string when unset — the
+/// runtime then uses the default `0.05`.
+///
+/// The value is a TOML float in config files but a string via the env var, so it
+/// is stringified regardless of its TOML scalar type (float/integer/string).
+/// The highest-priority PRESENT layer wins; a present env var is terminal (even
+/// empty, an explicit clear). Split out from [`resolve_alert_error_rate_threshold`]
+/// so the precedence is unit-testable without mutating process-global env/cwd state.
+fn resolve_alert_error_rate_threshold_from_sources<F>(
+    env_var: F,
+    table: Option<&toml::Table>,
+    profile: &str,
+) -> String
+where
+    F: Fn(&str) -> Option<String>,
+{
+    // Stringify a TOML scalar so a float (`0.05`), an integer (`1`), or a string
+    // value all resolve to a comparable raw representation.
+    let stringify = |v: &toml::Value| -> Option<String> {
+        match v {
+            toml::Value::Float(f) => Some(f.to_string()),
+            toml::Value::Integer(i) => Some(i.to_string()),
+            toml::Value::String(s) => Some(s.clone()),
+            _ => None,
+        }
+    };
+    // 1. Env var — highest priority. Present (even empty) is terminal.
+    if let Some(val) = env_var("AUTUMN_ALERTS__ERROR_RATE_THRESHOLD") {
+        return val;
+    }
+    // 2. Profile-specific `[profile.{profile}.alerts].error_rate_threshold`.
+    if !profile.is_empty()
+        && let Some(v) = table
+            .and_then(|t| t.get("profile"))
+            .and_then(|v| v.get(profile))
+            .and_then(toml::Value::as_table)
+            .and_then(|p| p.get("alerts"))
+            .and_then(toml::Value::as_table)
+            .and_then(|a| a.get("error_rate_threshold"))
+            .and_then(&stringify)
+    {
+        return v;
+    }
+    // 3. Base `[alerts].error_rate_threshold`.
+    if let Some(v) = table
+        .and_then(|t| t.get("alerts"))
+        .and_then(toml::Value::as_table)
+        .and_then(|a| a.get("error_rate_threshold"))
+        .and_then(stringify)
+    {
+        return v;
+    }
+    // 4. Unset everywhere → empty (runtime uses the default 0.05).
+    String::new()
+}
+
 /// Resolve whether the active profile is production from the environment or
 /// `autumn.toml`.
 fn resolve_is_production() -> bool {
@@ -3467,6 +3631,7 @@ pub fn run(opts: DoctorOptions) {
     let (alert_email, alert_webhook_configured, alert_webhook_url) = resolve_alert_destination();
     let alerts_enabled = resolve_alert_enabled();
     let alert_custom_channel = resolve_alert_custom_channel();
+    let alert_error_rate_threshold = resolve_alert_error_rate_threshold();
     let proxy_conflict_data = resolve_proxy_conflict_data();
     let (dotenv_has_example, dotenv_has_env, dotenv_uncovered) = resolve_dotenv_state();
 
@@ -3704,6 +3869,13 @@ pub fn run(opts: DoctorOptions) {
             transport_requires_from,
             alert_custom_channel,
         )
+    }));
+
+    // 12a2. `[alerts] error_rate_threshold` sanity: a non-finite or out-of-(0,1]
+    //       value silently breaks the 5xx alert (the runtime falls back to the
+    //       default). Warn in production so the operator fixes the config.
+    tasks.push(Box::new(move || {
+        check_alert_error_rate_threshold_impl(&alert_error_rate_threshold, is_production)
     }));
 
     // 12b. Local-dev `.env` handling (warn on `.env.example` without `.env`,
@@ -6598,6 +6770,129 @@ pub struct Vault {
             no_env,
             Some(&table),
             ""
+        ));
+    }
+
+    // ── check_alert_error_rate_threshold_impl (issue #1610) ──────────────────
+    // The threshold is compared against a FRACTION in [0, 1] (rate = err/req), so
+    // only (0, 1] is meaningful. A non-finite value or one > 1 makes the 5xx alert
+    // never fire; a value <= 0 makes it fire on 0%-error windows. In production
+    // doctor warns; outside production it passes quietly (alerts are optional).
+
+    #[test]
+    fn alert_threshold_unset_passes() {
+        // No value set: the runtime uses the valid default (0.05).
+        let r = check_alert_error_rate_threshold_impl("", true);
+        assert!(matches!(r.status, CheckStatus::Pass));
+        let r = check_alert_error_rate_threshold_impl("   ", true);
+        assert!(matches!(r.status, CheckStatus::Pass));
+    }
+
+    #[test]
+    fn alert_threshold_valid_in_range_passes() {
+        for v in ["0.05", "0.2", "1", "1.0", "0.001"] {
+            let r = check_alert_error_rate_threshold_impl(v, true);
+            assert!(
+                matches!(r.status, CheckStatus::Pass),
+                "{v} is a valid (0, 1] rate and must pass"
+            );
+        }
+    }
+
+    #[test]
+    fn alert_threshold_nan_warns_in_prod() {
+        let r = check_alert_error_rate_threshold_impl("nan", true);
+        assert!(matches!(r.status, CheckStatus::Warn));
+        assert!(
+            r.detail.as_deref().is_some_and(|d| d.contains("nan")),
+            "the warning must name the offending value"
+        );
+        assert!(r.hint.is_some());
+    }
+
+    #[test]
+    fn alert_threshold_out_of_range_warns_in_prod() {
+        // > 1: the alert can never fire. <= 0: it fires on 0%-error windows.
+        for v in ["1.5", "0", "-0.1", "inf"] {
+            let r = check_alert_error_rate_threshold_impl(v, true);
+            assert!(
+                matches!(r.status, CheckStatus::Warn),
+                "{v} is out of (0, 1] and must warn in production"
+            );
+        }
+    }
+
+    #[test]
+    fn alert_threshold_unparsable_warns_in_prod() {
+        let r = check_alert_error_rate_threshold_impl("high", true);
+        assert!(matches!(r.status, CheckStatus::Warn));
+    }
+
+    #[test]
+    fn alert_threshold_invalid_is_lenient_outside_prod() {
+        // Dev leniency, consistent with the other alert checks: still pass.
+        for v in ["nan", "1.5", "0", "-0.1"] {
+            let r = check_alert_error_rate_threshold_impl(v, false);
+            assert!(
+                matches!(r.status, CheckStatus::Pass),
+                "{v} must pass quietly outside production"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_alert_error_rate_threshold_reads_base_float() {
+        let table: toml::Table = toml::from_str("[alerts]\nerror_rate_threshold = 0.2\n").unwrap();
+        let raw = resolve_alert_error_rate_threshold_from_sources(no_env, Some(&table), "prod");
+        assert_eq!(raw, "0.2");
+        let r = check_alert_error_rate_threshold_impl(&raw, true);
+        assert!(matches!(r.status, CheckStatus::Pass));
+    }
+
+    #[test]
+    fn resolve_alert_error_rate_threshold_out_of_range_float_warns() {
+        // A present, out-of-range float resolves and the check warns in prod.
+        let table: toml::Table = toml::from_str("[alerts]\nerror_rate_threshold = 1.5\n").unwrap();
+        let raw = resolve_alert_error_rate_threshold_from_sources(no_env, Some(&table), "prod");
+        assert_eq!(raw, "1.5");
+        let r = check_alert_error_rate_threshold_impl(&raw, true);
+        assert!(matches!(r.status, CheckStatus::Warn));
+    }
+
+    #[test]
+    fn resolve_alert_error_rate_threshold_env_overrides_base() {
+        // A present env var (even a bad one) wins over the base TOML.
+        let table: toml::Table = toml::from_str("[alerts]\nerror_rate_threshold = 0.05\n").unwrap();
+        let env = |k: &str| (k == "AUTUMN_ALERTS__ERROR_RATE_THRESHOLD").then(|| "nan".to_owned());
+        let raw = resolve_alert_error_rate_threshold_from_sources(env, Some(&table), "prod");
+        assert_eq!(raw, "nan");
+        assert!(matches!(
+            check_alert_error_rate_threshold_impl(&raw, true).status,
+            CheckStatus::Warn
+        ));
+    }
+
+    #[test]
+    fn resolve_alert_error_rate_threshold_profile_overrides_base() {
+        let table: toml::Table = toml::from_str(
+            "[alerts]\nerror_rate_threshold = 0.05\n[profile.prod.alerts]\nerror_rate_threshold = 2.0\n",
+        )
+        .unwrap();
+        let under_profile =
+            resolve_alert_error_rate_threshold_from_sources(no_env, Some(&table), "prod");
+        assert_eq!(under_profile, "2");
+        let under_base = resolve_alert_error_rate_threshold_from_sources(no_env, Some(&table), "");
+        assert_eq!(under_base, "0.05");
+    }
+
+    #[test]
+    fn resolve_alert_error_rate_threshold_unset_is_empty() {
+        let table: toml::Table = toml::from_str("[alerts]\nemail = \"ops@example.com\"\n").unwrap();
+        let raw = resolve_alert_error_rate_threshold_from_sources(no_env, Some(&table), "prod");
+        assert_eq!(raw, "");
+        assert!(matches!(
+            check_alert_error_rate_threshold_impl(&raw, true).status,
+            CheckStatus::Pass
         ));
     }
 

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2571,46 +2571,77 @@ fn resolve_trusted_hosts() -> Vec<String> {
 ///
 /// Returns `(email_configured, webhook_configured)`.
 fn resolve_alert_destination() -> (bool, bool) {
-    let env_set = |name: &str| {
-        std::env::var(name)
-            .ok()
-            .is_some_and(|v| !v.trim().is_empty())
+    let table = read_autumn_toml_table();
+    let profile = std::env::var("AUTUMN_ENV")
+        .ok()
+        .or_else(|| std::env::var("AUTUMN_PROFILE").ok())
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase();
+    // `.ok()` deliberately does NOT filter empty values: a set-but-empty env
+    // var is a PRESENT higher-priority layer that CLEARS the destination,
+    // distinct from an unset var (which falls through to the TOML layers).
+    resolve_alert_destination_from_sources(|key| std::env::var(key).ok(), table.as_ref(), &profile)
+}
+
+/// Resolve whether an email and/or webhook alert destination is configured,
+/// honouring layer precedence exactly as the runtime config merge does.
+///
+/// The highest-priority layer that is PRESENT wins, and an explicitly-empty
+/// higher layer CLEARS the value rather than falling back to a lower one — so a
+/// base `[alerts] email = "…"` cleared by `[profile.prod.alerts] email = ""`
+/// (or an empty `AUTUMN_ALERTS__EMAIL`) correctly resolves as "no destination".
+/// Layers, highest first: env var, `[profile.{profile}.alerts]`, base
+/// `[alerts]`. Only a layer that omits the key entirely falls through.
+///
+/// Split out from [`resolve_alert_destination`] so the precedence logic is unit
+/// testable without mutating process-global env/cwd state.
+fn resolve_alert_destination_from_sources<F>(
+    env_var: F,
+    table: Option<&toml::Table>,
+    profile: &str,
+) -> (bool, bool)
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let profile_alerts = if profile.is_empty() {
+        None
+    } else {
+        table
+            .and_then(|t| t.get("profile"))
+            .and_then(|v| v.get(profile))
+            .and_then(toml::Value::as_table)
+            .and_then(|p| p.get("alerts"))
+            .and_then(toml::Value::as_table)
     };
-    let mut email = env_set("AUTUMN_ALERTS__EMAIL");
-    let mut webhook = env_set("AUTUMN_ALERTS__WEBHOOK_URL");
+    let base_alerts = table
+        .and_then(|t| t.get("alerts"))
+        .and_then(toml::Value::as_table);
 
-    if !(email && webhook) {
-        let table = read_autumn_toml_table().unwrap_or_default();
-        let profile = std::env::var("AUTUMN_ENV")
-            .ok()
-            .or_else(|| std::env::var("AUTUMN_PROFILE").ok())
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase();
-
-        let str_set = |root: &toml::Table, key: &str| {
-            root.get("alerts")
-                .and_then(|a| a.get(key))
-                .and_then(toml::Value::as_str)
-                .is_some_and(|s| !s.trim().is_empty())
-        };
-
-        let mut check = |root: &toml::Table| {
-            email = email || str_set(root, "email");
-            webhook = webhook || str_set(root, "webhook_url");
-        };
-
-        if !profile.is_empty()
-            && let Some(profile_table) = table
-                .get("profile")
-                .and_then(|v| v.get(&profile))
-                .and_then(toml::Value::as_table)
-        {
-            check(profile_table);
+    let resolve = |env_key: &str, key: &str| -> bool {
+        // 1. Env var — highest priority. Set-and-empty clears; unset falls through.
+        if let Some(val) = env_var(env_key) {
+            return !val.trim().is_empty();
         }
-        check(&table);
-    }
+        // 2. Profile-specific `[profile.{profile}.alerts].{key}`.
+        if let Some(v) = profile_alerts
+            .and_then(|t| t.get(key))
+            .and_then(toml::Value::as_str)
+        {
+            return !v.trim().is_empty();
+        }
+        // 3. Base `[alerts].{key}`.
+        if let Some(v) = base_alerts
+            .and_then(|t| t.get(key))
+            .and_then(toml::Value::as_str)
+        {
+            return !v.trim().is_empty();
+        }
+        false
+    };
 
+    let email = resolve("AUTUMN_ALERTS__EMAIL", "email");
+    let webhook = resolve("AUTUMN_ALERTS__WEBHOOK_URL", "webhook_url");
     (email, webhook)
 }
 
@@ -4478,6 +4509,79 @@ pub struct Vault {
     fn alert_destination_passes_in_dev_without_destination() {
         let r = check_alert_destination_impl(false, false, false);
         assert!(matches!(r.status, CheckStatus::Pass));
+    }
+
+    // ── resolve_alert_destination_from_sources precedence (issue #1610) ───────
+
+    fn no_env(_: &str) -> Option<String> {
+        None
+    }
+
+    #[test]
+    fn resolve_alert_destination_base_email_is_detected() {
+        let table: toml::Table = toml::from_str("[alerts]\nemail = \"dev@example.com\"\n").unwrap();
+        let (email, webhook) =
+            resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        assert!(email, "base [alerts] email should resolve as configured");
+        assert!(!webhook);
+    }
+
+    #[test]
+    fn resolve_alert_destination_prod_profile_clears_base_email() {
+        // Base sets an email; the prod profile explicitly clears it with an empty
+        // string. A production run must resolve to "no destination" so doctor warns.
+        let table: toml::Table = toml::from_str(
+            "[alerts]\nemail = \"dev@example.com\"\n[profile.prod.alerts]\nemail = \"\"\n",
+        )
+        .unwrap();
+        let (email, _webhook) =
+            resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        assert!(
+            !email,
+            "an empty prod-profile override must CLEAR the base email, not OR it back in"
+        );
+
+        // And the surfaced doctor check warns in production for this config.
+        let r = check_alert_destination_impl(email, false, true);
+        assert!(matches!(r.status, CheckStatus::Warn));
+    }
+
+    #[test]
+    fn resolve_alert_destination_dev_profile_does_not_clear_base_for_prod_run() {
+        // A dev-profile override must not affect a prod run: only the active
+        // profile's layer participates.
+        let table: toml::Table = toml::from_str(
+            "[alerts]\nemail = \"dev@example.com\"\n[profile.dev.alerts]\nemail = \"\"\n",
+        )
+        .unwrap();
+        let (email, _webhook) =
+            resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        assert!(email, "dev-profile clear must not affect a prod run");
+    }
+
+    #[test]
+    fn resolve_alert_destination_empty_env_clears_base_email() {
+        // An explicitly-empty AUTUMN_ALERTS__EMAIL is the highest-priority layer
+        // and must CLEAR a base value; an unset webhook var falls through to base.
+        let table: toml::Table = toml::from_str(
+            "[alerts]\nemail = \"dev@example.com\"\nwebhook_url = \"https://hooks.example/x\"\n",
+        )
+        .unwrap();
+        let env = |key: &str| (key == "AUTUMN_ALERTS__EMAIL").then(String::new);
+        let (email, webhook) =
+            resolve_alert_destination_from_sources(env, Some(&table), "prod");
+        assert!(!email, "empty AUTUMN_ALERTS__EMAIL must clear the base email");
+        assert!(webhook, "unset webhook env should fall through to base");
+    }
+
+    #[test]
+    fn resolve_alert_destination_nonempty_env_wins_over_absent_toml() {
+        let env = |key: &str| {
+            (key == "AUTUMN_ALERTS__WEBHOOK_URL").then(|| "https://hooks.example/y".to_owned())
+        };
+        let (email, webhook) = resolve_alert_destination_from_sources(env, None, "prod");
+        assert!(!email);
+        assert!(webhook, "env webhook should resolve as configured with no TOML");
     }
 
     // ── compute_summary ──────────────────────────────────────────────────────

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -447,27 +447,63 @@ fn alert_email_from_missing_warning() -> CheckResult {
     }
 }
 
-// Seven independent config booleans (alerting enabled, email present, webhook
-// signed, mail transport usable, production, mail `from` present, transport
-// requires a `from`) each gate a distinct branch; grouping them into enums would
-// obscure rather than clarify the destination-resolution logic.
+/// Dedicated production warning for a present-but-syntactically-invalid
+/// `[alerts] email`: lettre parses the recipient only at send time (in
+/// `lettre_message`, not at `Mail::builder().to(...)`), so an unparsable
+/// address like `not-an-address` passes every earlier gate yet fails EVERY
+/// alert delivery at runtime with `MailError::InvalidAddress`. Distinct from
+/// the disabled-transport, missing-`from`, and no-destination warnings.
+fn alert_email_invalid_warning(email: &str) -> CheckResult {
+    CheckResult {
+        name: "alert_destination",
+        status: CheckStatus::Warn,
+        detail: Some(format!(
+            "`[alerts] email` (\"{email}\") is not a valid email address, so alert delivery \
+             will fail; the runtime parses the recipient only when sending and rejects it \
+             with an invalid-address error, delivering nothing"
+        )),
+        hint: Some(
+            "Set [alerts] email (or AUTUMN_ALERTS__EMAIL) to a valid address like \
+             alerts@example.com, or configure a signed webhook ([alerts] webhook_url + \
+             webhook_secret). See docs/guide/operator-alerts.md",
+        ),
+    }
+}
+
+// Six independent config booleans (alerting enabled, webhook signed, mail
+// transport usable, production, mail `from` present, transport requires a
+// `from`) plus the resolved `[alerts] email` each gate a distinct branch;
+// grouping them into enums would obscure rather than clarify the
+// destination-resolution logic.
 #[allow(clippy::fn_params_excessive_bools)]
 pub fn check_alert_destination_impl(
     alerts_enabled: bool,
-    email_configured: bool,
+    email: &str,
     webhook_configured: bool,
     mail_transport_usable: bool,
     is_production: bool,
     mail_from_present: bool,
     transport_requires_from: bool,
 ) -> CheckResult {
-    // Whether a configured email would actually deliver. It needs a usable
-    // (non-disabled) transport AND — for transports that build a real RFC 5322
-    // message (SMTP) — a non-empty `[mail] from`, because the runtime's alert
-    // mail carries no per-message `from` and falls back to the mailer default.
-    // `log`/`file` deliver without a `from`, so they do not need one.
+    // Presence and syntactic validity of the resolved `[alerts] email`. lettre
+    // parses the recipient only at SEND time (`lettre_message`), not when the
+    // alert `Mail` is built, so a present-but-unparsable address (e.g.
+    // `not-an-address`) passes every earlier gate yet fails EVERY delivery at
+    // runtime with `MailError::InvalidAddress`. An invalid address therefore
+    // does not count as a usable destination. Validity reuses the same address
+    // check the mailer applies to `[mail] unsubscribe_mailto`
+    // (`is_valid_mailto_address_doctor`) so doctor and the mailer agree.
+    let email_trimmed = email.trim();
+    let email_configured = !email_trimmed.is_empty();
+    let email_valid = email_configured && is_valid_mailto_address_doctor(email_trimmed);
+
+    // Whether a configured email would actually deliver. It needs a valid
+    // address, a usable (non-disabled) transport AND — for transports that build
+    // a real RFC 5322 message (SMTP) — a non-empty `[mail] from`, because the
+    // runtime's alert mail carries no per-message `from` and falls back to the
+    // mailer default. `log`/`file` deliver without a `from`, so they do not need one.
     let email_from_ok = mail_from_present || !transport_requires_from;
-    let email_destination = email_configured && mail_transport_usable && email_from_ok;
+    let email_destination = email_valid && mail_transport_usable && email_from_ok;
 
     // Master off switch: when `[alerts] enabled = false`, the runtime installs no
     // alerter at all, so a configured destination is inert. Handle this BEFORE
@@ -521,6 +557,16 @@ pub fn check_alert_destination_impl(
         };
     }
     if is_production {
+        // An email is set but is not a syntactically valid address: the runtime
+        // parses the recipient only at send time, so every alert fails in
+        // `lettre_message` with an invalid-address error and nothing is
+        // delivered. Surface a dedicated warning naming the offending value,
+        // distinct from the missing-`from`, disabled-transport, and
+        // no-destination cases. Checked first because a malformed address is
+        // unusable regardless of transport or `from`.
+        if email_configured && !email_valid {
+            return alert_email_invalid_warning(email_trimmed);
+        }
         // An email is set on a usable transport that needs a `from` (SMTP), but
         // no `[mail] from` is configured: the runtime's alert mail has no
         // per-message `from`, so `lettre_message` fails with "mail from address
@@ -2753,8 +2799,11 @@ fn resolve_trusted_hosts() -> Vec<String> {
 /// `autumn.toml` layered with the active profile's `[profile.{name}]` section and
 /// `autumn-{profile}.toml` override file, alias-normalized exactly as the runtime).
 ///
-/// Returns `(email_configured, webhook_configured)`.
-fn resolve_alert_destination() -> (bool, bool) {
+/// Returns `(email, webhook_configured)`, where `email` is the RAW resolved
+/// `[alerts] email` value (empty when unset/cleared) so the caller can check
+/// both its presence and its syntactic validity — an invalid address delivers
+/// nothing at runtime.
+fn resolve_alert_destination() -> (String, bool) {
     // Evaluate the SAME fully-merged effective config the runtime boots with, not
     // just the raw base `autumn.toml`. The runtime config loader (a) normalizes
     // profile aliases (`production` → `prod`, `development` → `dev`) and (b) layers
@@ -2790,7 +2839,22 @@ fn resolve_alert_destination() -> (bool, bool) {
     // `.ok()` deliberately does NOT filter empty values: a set-but-empty env
     // var is a PRESENT higher-priority layer that CLEARS the destination,
     // distinct from an unset var (which falls through to the TOML layers).
-    resolve_alert_destination_from_sources(|key| std::env::var(key).ok(), Some(&merged), "")
+    let (_email_present, webhook) =
+        resolve_alert_destination_from_sources(|key| std::env::var(key).ok(), Some(&merged), "");
+    // Surface the RAW resolved email string (not just presence) so the
+    // destination check can validate its syntax. Mirror the same env > base
+    // precedence `_from_sources` applies to the flattened top-level `[alerts]`:
+    // a PRESENT `AUTUMN_ALERTS__EMAIL` (even empty) wins and is terminal;
+    // otherwise fall through to the merged base `[alerts] email`.
+    let email = std::env::var("AUTUMN_ALERTS__EMAIL").unwrap_or_else(|_| {
+        merged
+            .get("alerts")
+            .and_then(|a| a.get("email"))
+            .and_then(toml::Value::as_str)
+            .unwrap_or("")
+            .to_owned()
+    });
+    (email, webhook)
 }
 
 /// Normalize a raw profile input to the canonical name the runtime config loader
@@ -3076,7 +3140,7 @@ pub fn run(opts: DoctorOptions) {
     let rate_limit_key_strategy = resolve_rate_limit_key_strategy();
     let auth_extractor_mounted = resolve_auth_extractor_mounted();
     let compression_enabled = resolve_compression_enabled();
-    let (alert_email_configured, alert_webhook_configured) = resolve_alert_destination();
+    let (alert_email, alert_webhook_configured) = resolve_alert_destination();
     let alerts_enabled = resolve_alert_enabled();
     let proxy_conflict_data = resolve_proxy_conflict_data();
     let (dotenv_has_example, dotenv_has_env, dotenv_uncovered) = resolve_dotenv_state();
@@ -3303,7 +3367,7 @@ pub fn run(opts: DoctorOptions) {
     tasks.push(Box::new(move || {
         check_alert_destination_impl(
             alerts_enabled,
-            alert_email_configured,
+            &alert_email,
             alert_webhook_configured,
             mail_transport_usable,
             is_production,
@@ -4823,7 +4887,7 @@ pub struct Vault {
 
     #[test]
     fn alert_destination_warns_in_production_when_none() {
-        let r = check_alert_destination_impl(true, false, false, true, true, true, true);
+        let r = check_alert_destination_impl(true, "", false, true, true, true, true);
         assert_eq!(r.name, "alert_destination");
         assert!(matches!(r.status, CheckStatus::Warn));
         assert!(r.hint.is_some());
@@ -4831,19 +4895,20 @@ pub struct Vault {
 
     #[test]
     fn alert_destination_passes_in_production_with_email() {
-        let r = check_alert_destination_impl(true, true, false, true, true, true, true);
+        let r =
+            check_alert_destination_impl(true, "ops@example.com", false, true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
     #[test]
     fn alert_destination_passes_in_production_with_webhook() {
-        let r = check_alert_destination_impl(true, false, true, true, true, true, true);
+        let r = check_alert_destination_impl(true, "", true, true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
     #[test]
     fn alert_destination_passes_in_dev_without_destination() {
-        let r = check_alert_destination_impl(true, false, false, true, false, true, true);
+        let r = check_alert_destination_impl(true, "", false, true, false, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
@@ -4867,7 +4932,15 @@ pub struct Vault {
         let transport = resolve_effective_mail_transport(None, None, "prod");
         assert_eq!(transport, "disabled");
         let usable = transport != "disabled";
-        let r = check_alert_destination_impl(true, email, webhook, usable, true, true, true);
+        let r = check_alert_destination_impl(
+            true,
+            "ops@example.com",
+            webhook,
+            usable,
+            true,
+            true,
+            true,
+        );
         assert!(
             matches!(r.status, CheckStatus::Warn),
             "email with a disabled mail transport delivers nothing → must warn in prod"
@@ -4886,13 +4959,14 @@ pub struct Vault {
         // the runtime installs the channel, so doctor counts the email and passes.
         let table: toml::Table = toml::from_str("[alerts]\nemail = \"ops@example.com\"\n").unwrap();
         let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        assert!(email, "the [alerts] email resolves as present");
         let transport = resolve_effective_mail_transport(None, Some("smtp"), "prod");
         assert_eq!(transport, "smtp");
         // SMTP requires a `from`; this happy path has one set, so it still passes.
         let requires_from = mail_transport_requires_from(&transport);
         let r = check_alert_destination_impl(
             true,
-            email,
+            "ops@example.com",
             webhook,
             transport != "disabled",
             true,
@@ -4935,7 +5009,7 @@ pub struct Vault {
         let mail_from_present = true;
         let r = check_alert_destination_impl(
             true,
-            true,
+            "ops@example.com",
             false,
             transport != "disabled",
             true,
@@ -4959,7 +5033,7 @@ pub struct Vault {
         let mail_from_present = false;
         let r = check_alert_destination_impl(
             true,
-            true,
+            "ops@example.com",
             false,
             transport != "disabled",
             true,
@@ -4993,7 +5067,7 @@ pub struct Vault {
         let mail_from_present = false;
         let r = check_alert_destination_impl(
             true,
-            true,
+            "ops@example.com",
             false,
             transport != "disabled",
             true,
@@ -5003,6 +5077,99 @@ pub struct Vault {
         assert!(
             matches!(r.status, CheckStatus::Pass),
             "email on a log transport delivers without a from → must not warn"
+        );
+    }
+
+    // ── invalid `[alerts] email` (issue #1610 follow-up) ──────────────────────
+    // lettre parses the recipient only at SEND time (`lettre_message`), not when
+    // the alert `Mail` is built, so a present-but-unparsable address passes every
+    // earlier gate yet fails EVERY delivery at runtime with
+    // `MailError::InvalidAddress`. Doctor must count such an email as no usable
+    // destination and surface a dedicated warning naming the bad value.
+
+    #[test]
+    fn alert_destination_invalid_email_warns_in_prod() {
+        // A non-empty but syntactically invalid address on an otherwise-usable
+        // SMTP transport with a `[mail] from` set: without this gate doctor would
+        // PASS, yet every runtime send fails with an invalid-address error.
+        let r = check_alert_destination_impl(
+            true,
+            "not-an-address",
+            false,
+            true, // usable transport
+            true, // production
+            true, // [mail] from present
+            true, // smtp requires from
+        );
+        assert!(
+            matches!(r.status, CheckStatus::Warn),
+            "an invalid alert email delivers nothing at runtime → must warn in prod"
+        );
+        assert!(
+            r.detail
+                .as_deref()
+                .is_some_and(|d| d.contains("not a valid email address")),
+            "the dedicated warning must name the invalid address as the cause"
+        );
+        assert!(
+            r.detail
+                .as_deref()
+                .is_some_and(|d| d.contains("not-an-address")),
+            "the warning should echo the offending value"
+        );
+    }
+
+    #[test]
+    fn alert_destination_invalid_email_is_lenient_in_dev() {
+        // Dev-mode leniency mirrors the rest of the check: an invalid email is not
+        // a hard problem locally, so it must NOT warn outside production.
+        let r = check_alert_destination_impl(
+            true,
+            "not-an-address",
+            false,
+            true,
+            false, // dev
+            true,
+            true,
+        );
+        assert!(
+            matches!(r.status, CheckStatus::Pass),
+            "dev-mode leniency: an invalid alert email must not warn outside production"
+        );
+    }
+
+    #[test]
+    fn alert_destination_valid_plus_addressing_passes_in_prod() {
+        // A perfectly valid address using `+` sub-addressing and a multi-label
+        // domain must NOT be rejected — the validity check must not over-reject.
+        let r =
+            check_alert_destination_impl(true, "a+b@sub.example.co", false, true, true, true, true);
+        assert!(
+            matches!(r.status, CheckStatus::Pass),
+            "a valid `+`-addressed, multi-label-domain email is a working destination"
+        );
+    }
+
+    #[test]
+    fn alert_destination_invalid_email_not_a_destination_when_alerts_disabled() {
+        // With alerting disabled, an invalid email is not a (real) destination, so
+        // the disabled-switch warning must NOT claim a destination is configured.
+        let r = check_alert_destination_impl(
+            false, // alerting disabled
+            "not-an-address",
+            false,
+            true,
+            true,
+            true,
+            true,
+        );
+        assert!(matches!(r.status, CheckStatus::Warn));
+        assert!(
+            r.detail
+                .as_deref()
+                .is_some_and(|d| d.contains("alerting is disabled")
+                    && !d.contains("even though a destination is configured")),
+            "an invalid email must not be counted as a configured destination"
         );
     }
 
@@ -5019,7 +5186,7 @@ pub struct Vault {
         assert!(!email, "the prod profile cleared the email");
         assert!(webhook, "the signed webhook remains configured");
         // Mail transport disabled — irrelevant to the webhook path.
-        let r = check_alert_destination_impl(true, email, webhook, false, true, true, true);
+        let r = check_alert_destination_impl(true, "", webhook, false, true, true, true);
         assert!(
             matches!(r.status, CheckStatus::Pass),
             "a signed webhook is a valid destination regardless of mail transport"
@@ -5056,7 +5223,7 @@ pub struct Vault {
         );
 
         // And the surfaced doctor check warns in production for this config.
-        let r = check_alert_destination_impl(true, email, false, true, true, true, true);
+        let r = check_alert_destination_impl(true, "", false, true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Warn));
     }
 
@@ -5123,7 +5290,7 @@ pub struct Vault {
             webhook,
             "webhook_url + webhook_secret must count as configured"
         );
-        let r = check_alert_destination_impl(true, email, webhook, true, true, true, true);
+        let r = check_alert_destination_impl(true, "", webhook, true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
@@ -5139,7 +5306,7 @@ pub struct Vault {
             !webhook,
             "a webhook_url with no signing secret is not a destination"
         );
-        let r = check_alert_destination_impl(true, email, webhook, true, true, true, true);
+        let r = check_alert_destination_impl(true, "", webhook, true, true, true, true);
         assert!(
             matches!(r.status, CheckStatus::Warn),
             "URL-without-secret in production must warn"
@@ -5161,7 +5328,7 @@ pub struct Vault {
             !webhook,
             "a prod-profile empty webhook_secret must clear the base secret"
         );
-        let r = check_alert_destination_impl(true, email, webhook, true, true, true, true);
+        let r = check_alert_destination_impl(true, "", webhook, true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Warn));
 
         // And an empty AUTUMN_ALERTS__WEBHOOK_SECRET env var clears it just the same.
@@ -5215,7 +5382,7 @@ pub struct Vault {
             !email,
             "an autumn-prod.toml that clears [alerts].email must resolve as no destination"
         );
-        let r = check_alert_destination_impl(true, email, false, true, true, true, true);
+        let r = check_alert_destination_impl(true, "", false, true, true, true, true);
         assert!(
             matches!(r.status, CheckStatus::Warn),
             "a production deploy whose override file cleared the only alert channel must WARN"
@@ -5254,7 +5421,8 @@ pub struct Vault {
         let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&merged), "");
         assert!(email);
         assert!(!webhook);
-        let r = check_alert_destination_impl(true, email, webhook, true, true, true, true);
+        let r =
+            check_alert_destination_impl(true, "ops@example.com", webhook, true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
@@ -5277,7 +5445,7 @@ pub struct Vault {
             !webhook,
             "a webhook whose secret was cleared by the override file is not a signed destination"
         );
-        let r = check_alert_destination_impl(true, email, webhook, true, true, true, true);
+        let r = check_alert_destination_impl(true, "", webhook, true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Warn));
 
         // With both left intact through the merged view, the webhook still counts.
@@ -5361,7 +5529,15 @@ pub struct Vault {
         let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
         assert!(!enabled);
         assert!(email, "the email itself is still configured");
-        let r = check_alert_destination_impl(enabled, email, webhook, true, true, true, true);
+        let r = check_alert_destination_impl(
+            enabled,
+            "ops@example.com",
+            webhook,
+            true,
+            true,
+            true,
+            true,
+        );
         assert!(
             matches!(r.status, CheckStatus::Warn),
             "disabled alerting with a configured destination must warn in prod"
@@ -5379,9 +5555,18 @@ pub struct Vault {
         let env = |k: &str| (k == "AUTUMN_ALERTS__ENABLED").then(|| "false".to_owned());
         let table: toml::Table = toml::from_str("[alerts]\nemail = \"ops@example.com\"\n").unwrap();
         let enabled = resolve_alert_enabled_from_sources(env, Some(&table), "prod");
-        let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        let (_email, webhook) =
+            resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
         assert!(!enabled);
-        let r = check_alert_destination_impl(enabled, email, webhook, true, true, true, true);
+        let r = check_alert_destination_impl(
+            enabled,
+            "ops@example.com",
+            webhook,
+            true,
+            true,
+            true,
+            true,
+        );
         assert!(matches!(r.status, CheckStatus::Warn));
     }
 
@@ -5391,9 +5576,18 @@ pub struct Vault {
         // transport in prod still passes exactly as before this change.
         let table: toml::Table = toml::from_str("[alerts]\nemail = \"ops@example.com\"\n").unwrap();
         let enabled = resolve_alert_enabled_from_sources(no_env, Some(&table), "prod");
-        let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        let (_email, webhook) =
+            resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
         assert!(enabled);
-        let r = check_alert_destination_impl(enabled, email, webhook, true, true, true, true);
+        let r = check_alert_destination_impl(
+            enabled,
+            "ops@example.com",
+            webhook,
+            true,
+            true,
+            true,
+            true,
+        );
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
@@ -5403,9 +5597,17 @@ pub struct Vault {
         let table: toml::Table =
             toml::from_str("[alerts]\nenabled = false\nemail = \"ops@example.com\"\n").unwrap();
         let enabled = resolve_alert_enabled_from_sources(no_env, Some(&table), "dev");
-        let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "dev");
+        let (_email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "dev");
         assert!(!enabled);
-        let r = check_alert_destination_impl(enabled, email, webhook, true, false, true, true);
+        let r = check_alert_destination_impl(
+            enabled,
+            "ops@example.com",
+            webhook,
+            true,
+            false,
+            true,
+            true,
+        );
         assert!(
             matches!(r.status, CheckStatus::Pass),
             "dev-mode leniency: disabled alerting must not warn outside production"

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -383,6 +383,57 @@ pub fn check_trusted_hosts_impl(hosts: &[String], is_production: bool) -> CheckR
     }
 }
 
+/// Check that an operator-alert destination is configured (issue #1610).
+///
+/// Operator alerts (dead-lettered jobs, Down health indicators, 5xx-rate
+/// spikes, scheduled-task failures) are only delivered when an `[alerts]`
+/// destination — an operator `email` and/or a `webhook_url` — is configured.
+///
+/// - **Production** (`is_production = true`): warns when neither is configured,
+///   so a deploy does not run silently blind to its own failures.
+/// - **Dev/test**: passes quietly (alerts are optional locally).
+///
+/// The returned check name is `"alert_destination"`.
+pub fn check_alert_destination_impl(
+    email_configured: bool,
+    webhook_configured: bool,
+    is_production: bool,
+) -> CheckResult {
+    if email_configured || webhook_configured {
+        return CheckResult {
+            name: "alert_destination",
+            status: CheckStatus::Pass,
+            detail: Some("operator alert destination configured".into()),
+            hint: None,
+        };
+    }
+    if is_production {
+        CheckResult {
+            name: "alert_destination",
+            status: CheckStatus::Warn,
+            detail: Some(
+                "no operator alert destination configured in production; failure conditions \
+                 (dead-lettered jobs, Down health indicators, 5xx spikes, scheduled-task \
+                 failures) will not be delivered anywhere"
+                    .into(),
+            ),
+            hint: Some(
+                "Set [alerts] email and/or webhook_url (or AUTUMN_ALERTS__EMAIL / \
+                 AUTUMN_ALERTS__WEBHOOK_URL). See docs/guide/operator-alerts.md",
+            ),
+        }
+    } else {
+        CheckResult {
+            name: "alert_destination",
+            status: CheckStatus::Pass,
+            detail: Some(
+                "no operator alert destination configured (optional outside production)".into(),
+            ),
+            hint: None,
+        }
+    }
+}
+
 /// Check a single `[auth.oauth2.<provider>]` entry for common misconfigurations.
 ///
 /// - In production (`is_production = true`): fails when `client_secret` is empty.
@@ -2515,6 +2566,54 @@ fn resolve_trusted_hosts() -> Vec<String> {
     parse_hosts(&table)
 }
 
+/// Resolve whether an operator-alert destination (email and/or webhook URL) is
+/// configured, from the environment or `autumn.toml` `[alerts]`.
+///
+/// Returns `(email_configured, webhook_configured)`.
+fn resolve_alert_destination() -> (bool, bool) {
+    let env_set = |name: &str| {
+        std::env::var(name)
+            .ok()
+            .is_some_and(|v| !v.trim().is_empty())
+    };
+    let mut email = env_set("AUTUMN_ALERTS__EMAIL");
+    let mut webhook = env_set("AUTUMN_ALERTS__WEBHOOK_URL");
+
+    if !(email && webhook) {
+        let table = read_autumn_toml_table().unwrap_or_default();
+        let profile = std::env::var("AUTUMN_ENV")
+            .ok()
+            .or_else(|| std::env::var("AUTUMN_PROFILE").ok())
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase();
+
+        let str_set = |root: &toml::Table, key: &str| {
+            root.get("alerts")
+                .and_then(|a| a.get(key))
+                .and_then(toml::Value::as_str)
+                .is_some_and(|s| !s.trim().is_empty())
+        };
+
+        let mut check = |root: &toml::Table| {
+            email = email || str_set(root, "email");
+            webhook = webhook || str_set(root, "webhook_url");
+        };
+
+        if !profile.is_empty()
+            && let Some(profile_table) = table
+                .get("profile")
+                .and_then(|v| v.get(&profile))
+                .and_then(toml::Value::as_table)
+        {
+            check(profile_table);
+        }
+        check(&table);
+    }
+
+    (email, webhook)
+}
+
 /// Resolve whether the active profile is production from the environment or
 /// `autumn.toml`.
 fn resolve_is_production() -> bool {
@@ -2628,6 +2727,7 @@ pub fn run(opts: DoctorOptions) {
     let rate_limit_key_strategy = resolve_rate_limit_key_strategy();
     let auth_extractor_mounted = resolve_auth_extractor_mounted();
     let compression_enabled = resolve_compression_enabled();
+    let (alert_email_configured, alert_webhook_configured) = resolve_alert_destination();
     let proxy_conflict_data = resolve_proxy_conflict_data();
     let (dotenv_has_example, dotenv_has_env, dotenv_uncovered) = resolve_dotenv_state();
 
@@ -2834,6 +2934,15 @@ pub fn run(opts: DoctorOptions) {
     // 12. Compression (warn in production when disabled)
     tasks.push(Box::new(move || {
         check_compression_impl(compression_enabled, is_production)
+    }));
+
+    // 12a. Operator alerts (warn in production when no destination configured)
+    tasks.push(Box::new(move || {
+        check_alert_destination_impl(
+            alert_email_configured,
+            alert_webhook_configured,
+            is_production,
+        )
     }));
 
     // 12b. Local-dev `.env` handling (warn on `.env.example` without `.env`,
@@ -4341,6 +4450,34 @@ pub struct Vault {
         let result = check_trusted_hosts_impl(&["example.com".to_owned(), "*".to_owned()], true);
         assert_eq!(result.name, "trusted_hosts");
         assert!(matches!(result.status, CheckStatus::Warn));
+    }
+
+    // ── check_alert_destination_impl (issue #1610) ───────────────────────────
+
+    #[test]
+    fn alert_destination_warns_in_production_when_none() {
+        let r = check_alert_destination_impl(false, false, true);
+        assert_eq!(r.name, "alert_destination");
+        assert!(matches!(r.status, CheckStatus::Warn));
+        assert!(r.hint.is_some());
+    }
+
+    #[test]
+    fn alert_destination_passes_in_production_with_email() {
+        let r = check_alert_destination_impl(true, false, true);
+        assert!(matches!(r.status, CheckStatus::Pass));
+    }
+
+    #[test]
+    fn alert_destination_passes_in_production_with_webhook() {
+        let r = check_alert_destination_impl(false, true, true);
+        assert!(matches!(r.status, CheckStatus::Pass));
+    }
+
+    #[test]
+    fn alert_destination_passes_in_dev_without_destination() {
+        let r = check_alert_destination_impl(false, false, false);
+        assert!(matches!(r.status, CheckStatus::Pass));
     }
 
     // ── compute_summary ──────────────────────────────────────────────────────

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -397,23 +397,71 @@ pub fn check_trusted_hosts_impl(hosts: &[String], is_production: bool) -> CheckR
 /// it is `false` when the effective merged `[mail] transport` resolves to
 /// `disabled`. The webhook path is independent of the mailer.
 ///
-/// - **Production** (`is_production = true`): warns when no usable destination
-///   is configured, so a deploy does not run silently blind to its own
-///   failures. An email whose mail transport is disabled gets a dedicated,
-///   clearer warning rather than the generic "no destination" one.
+/// The `[alerts] enabled` master switch is honoured up front: when alerting is
+/// disabled the runtime (`alerts::install_from_config`) returns BEFORE
+/// installing any `Alerter`, so NO operator alerts are delivered regardless of a
+/// configured destination. In production that earns a dedicated warning (a
+/// deploy running blind), distinct from the "no destination" one; outside
+/// production it stays lenient like the rest of this check.
+///
+/// - **Production** (`is_production = true`): warns when alerting is disabled, or
+///   when no usable destination is configured, so a deploy does not run silently
+///   blind to its own failures. An email whose mail transport is disabled gets a
+///   dedicated, clearer warning rather than the generic "no destination" one.
 /// - **Dev/test**: passes quietly (alerts are optional locally).
 ///
 /// The returned check name is `"alert_destination"`.
-// Four independent config booleans (email present, webhook signed, mail
-// transport usable, production) each gate a distinct branch; grouping them into
-// enums would obscure rather than clarify the destination-resolution logic.
+// Five independent config booleans (alerting enabled, email present, webhook
+// signed, mail transport usable, production) each gate a distinct branch;
+// grouping them into enums would obscure rather than clarify the
+// destination-resolution logic.
 #[allow(clippy::fn_params_excessive_bools)]
 pub fn check_alert_destination_impl(
+    alerts_enabled: bool,
     email_configured: bool,
     webhook_configured: bool,
     mail_transport_usable: bool,
     is_production: bool,
 ) -> CheckResult {
+    // Master off switch: when `[alerts] enabled = false`, the runtime installs no
+    // alerter at all, so a configured destination is inert. Handle this BEFORE
+    // the destination gate — doctor must not pass on the strength of a
+    // configured-but-inert destination.
+    if !alerts_enabled {
+        if is_production {
+            // Name the disabled switch explicitly. Mention the (otherwise valid)
+            // destination when one is configured so the operator understands the
+            // deploy is blind despite it; keep the message accurate otherwise.
+            let has_destination = (email_configured && mail_transport_usable) || webhook_configured;
+            let detail = if has_destination {
+                "alerting is disabled ([alerts] enabled = false) in production, so no operator \
+                 alerts will be delivered — even though a destination is configured"
+            } else {
+                "alerting is disabled ([alerts] enabled = false) in production, so no operator \
+                 alerts will be delivered"
+            };
+            return CheckResult {
+                name: "alert_destination",
+                status: CheckStatus::Warn,
+                detail: Some(detail.into()),
+                hint: Some(
+                    "Set [alerts] enabled = true (or AUTUMN_ALERTS__ENABLED=true) to deliver \
+                     operator alerts, or remove the setting (it defaults to enabled). See \
+                     docs/guide/operator-alerts.md",
+                ),
+            };
+        }
+        return CheckResult {
+            name: "alert_destination",
+            status: CheckStatus::Pass,
+            detail: Some(
+                "operator alerting is disabled ([alerts] enabled = false) (optional outside \
+                 production)"
+                    .into(),
+            ),
+            hint: None,
+        };
+    }
     // Email only counts as a real destination when the mail transport can
     // actually send — mirroring the runtime, which skips MailAlertChannel when
     // `mailer.is_disabled()`.
@@ -2739,6 +2787,88 @@ where
     (email, webhook)
 }
 
+/// Resolve the effective `[alerts] enabled` master switch, mirroring the runtime
+/// config merge and the `AlertConfig::default().enabled` default of `true`.
+///
+/// The runtime's `alerts::install_from_config` returns before installing any
+/// `Alerter` when `enabled` is false, so doctor must consult it: an
+/// `enabled = false` prod config delivers NO operator alerts even with an
+/// `email`/signed-`webhook` populated.
+fn resolve_alert_enabled() -> bool {
+    // Mirror `resolve_alert_destination`'s profile selection and merged-table
+    // build so `enabled` resolves against the same effective config the runtime
+    // boots with (profile inline section + `autumn-{profile}.toml` layered in),
+    // env vars still highest priority.
+    let selected_input = std::env::var("AUTUMN_ENV")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| {
+            std::env::var("AUTUMN_PROFILE")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+        })
+        .unwrap_or_default()
+        .trim()
+        .to_owned();
+    let normalized_profile = normalize_alert_profile(&selected_input);
+    // The merge flattens the active profile into the top-level `[alerts]`, so
+    // resolve against an EMPTY profile (mirroring `resolve_alert_destination`).
+    let merged = get_merged_toml_table_runtime(&normalized_profile, &selected_input);
+    resolve_alert_enabled_from_sources(|key| std::env::var(key).ok(), Some(&merged), "")
+}
+
+/// Resolve the effective `[alerts] enabled` flag under the same layer precedence
+/// the runtime config merge applies (env `AUTUMN_ALERTS__ENABLED` >
+/// `[profile.{profile}.alerts].enabled` > base `[alerts].enabled`), defaulting to
+/// `true` when unset — matching `AlertConfig::default().enabled`.
+///
+/// Env parsing mirrors the runtime's `parse_env_bool`: `true`/`1` enable,
+/// `false`/`0` disable, and any other value is ignored (falls through to the
+/// TOML layers). Split out from [`resolve_alert_enabled`] so the precedence is
+/// unit-testable without mutating process-global env/cwd state.
+fn resolve_alert_enabled_from_sources<F>(
+    env_var: F,
+    table: Option<&toml::Table>,
+    profile: &str,
+) -> bool
+where
+    F: Fn(&str) -> Option<String>,
+{
+    // 1. Env var — highest priority, mirroring runtime `parse_env_bool`. An
+    //    invalid value (not true/false/1/0) is ignored and falls through.
+    if let Some(val) = env_var("AUTUMN_ALERTS__ENABLED") {
+        match val.as_str() {
+            "true" | "1" => return true,
+            "false" | "0" => return false,
+            _ => {}
+        }
+    }
+    // 2. Profile-specific `[profile.{profile}.alerts].enabled`.
+    if !profile.is_empty()
+        && let Some(v) = table
+            .and_then(|t| t.get("profile"))
+            .and_then(|v| v.get(profile))
+            .and_then(toml::Value::as_table)
+            .and_then(|p| p.get("alerts"))
+            .and_then(toml::Value::as_table)
+            .and_then(|a| a.get("enabled"))
+            .and_then(toml::Value::as_bool)
+    {
+        return v;
+    }
+    // 3. Base `[alerts].enabled`.
+    if let Some(v) = table
+        .and_then(|t| t.get("alerts"))
+        .and_then(toml::Value::as_table)
+        .and_then(|a| a.get("enabled"))
+        .and_then(toml::Value::as_bool)
+    {
+        return v;
+    }
+    // 4. Unset everywhere → alerts enabled (mirrors `AlertConfig::default()`).
+    true
+}
+
 /// Resolve whether the active profile is production from the environment or
 /// `autumn.toml`.
 fn resolve_is_production() -> bool {
@@ -2853,6 +2983,7 @@ pub fn run(opts: DoctorOptions) {
     let auth_extractor_mounted = resolve_auth_extractor_mounted();
     let compression_enabled = resolve_compression_enabled();
     let (alert_email_configured, alert_webhook_configured) = resolve_alert_destination();
+    let alerts_enabled = resolve_alert_enabled();
     let proxy_conflict_data = resolve_proxy_conflict_data();
     let (dotenv_has_example, dotenv_has_env, dotenv_uncovered) = resolve_dotenv_state();
 
@@ -3071,6 +3202,7 @@ pub fn run(opts: DoctorOptions) {
     let mail_transport_usable = !mail_transport_disabled;
     tasks.push(Box::new(move || {
         check_alert_destination_impl(
+            alerts_enabled,
             alert_email_configured,
             alert_webhook_configured,
             mail_transport_usable,
@@ -4589,7 +4721,7 @@ pub struct Vault {
 
     #[test]
     fn alert_destination_warns_in_production_when_none() {
-        let r = check_alert_destination_impl(false, false, true, true);
+        let r = check_alert_destination_impl(true, false, false, true, true);
         assert_eq!(r.name, "alert_destination");
         assert!(matches!(r.status, CheckStatus::Warn));
         assert!(r.hint.is_some());
@@ -4597,19 +4729,19 @@ pub struct Vault {
 
     #[test]
     fn alert_destination_passes_in_production_with_email() {
-        let r = check_alert_destination_impl(true, false, true, true);
+        let r = check_alert_destination_impl(true, true, false, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
     #[test]
     fn alert_destination_passes_in_production_with_webhook() {
-        let r = check_alert_destination_impl(false, true, true, true);
+        let r = check_alert_destination_impl(true, false, true, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
     #[test]
     fn alert_destination_passes_in_dev_without_destination() {
-        let r = check_alert_destination_impl(false, false, true, false);
+        let r = check_alert_destination_impl(true, false, false, true, false);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
@@ -4635,7 +4767,7 @@ pub struct Vault {
         let transport = resolve_effective_mail_transport(None, None, "prod");
         assert_eq!(transport, "disabled");
         let usable = transport != "disabled";
-        let r = check_alert_destination_impl(email, webhook, usable, true);
+        let r = check_alert_destination_impl(true, email, webhook, usable, true);
         assert!(
             matches!(r.status, CheckStatus::Warn),
             "email with a disabled mail transport delivers nothing → must warn in prod"
@@ -4658,7 +4790,7 @@ pub struct Vault {
             resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
         let transport = resolve_effective_mail_transport(None, Some("smtp"), "prod");
         assert_eq!(transport, "smtp");
-        let r = check_alert_destination_impl(email, webhook, transport != "disabled", true);
+        let r = check_alert_destination_impl(true, email, webhook, transport != "disabled", true);
         assert!(
             matches!(r.status, CheckStatus::Pass),
             "email with a usable (smtp) transport is a valid destination in prod"
@@ -4679,7 +4811,7 @@ pub struct Vault {
         assert!(!email, "the prod profile cleared the email");
         assert!(webhook, "the signed webhook remains configured");
         // Mail transport disabled — irrelevant to the webhook path.
-        let r = check_alert_destination_impl(email, webhook, false, true);
+        let r = check_alert_destination_impl(true, email, webhook, false, true);
         assert!(
             matches!(r.status, CheckStatus::Pass),
             "a signed webhook is a valid destination regardless of mail transport"
@@ -4716,7 +4848,7 @@ pub struct Vault {
         );
 
         // And the surfaced doctor check warns in production for this config.
-        let r = check_alert_destination_impl(email, false, true, true);
+        let r = check_alert_destination_impl(true, email, false, true, true);
         assert!(matches!(r.status, CheckStatus::Warn));
     }
 
@@ -4783,7 +4915,7 @@ pub struct Vault {
             webhook,
             "webhook_url + webhook_secret must count as configured"
         );
-        let r = check_alert_destination_impl(email, webhook, true, true);
+        let r = check_alert_destination_impl(true, email, webhook, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
@@ -4799,7 +4931,7 @@ pub struct Vault {
             !webhook,
             "a webhook_url with no signing secret is not a destination"
         );
-        let r = check_alert_destination_impl(email, webhook, true, true);
+        let r = check_alert_destination_impl(true, email, webhook, true, true);
         assert!(
             matches!(r.status, CheckStatus::Warn),
             "URL-without-secret in production must warn"
@@ -4821,7 +4953,7 @@ pub struct Vault {
             !webhook,
             "a prod-profile empty webhook_secret must clear the base secret"
         );
-        let r = check_alert_destination_impl(email, webhook, true, true);
+        let r = check_alert_destination_impl(true, email, webhook, true, true);
         assert!(matches!(r.status, CheckStatus::Warn));
 
         // And an empty AUTUMN_ALERTS__WEBHOOK_SECRET env var clears it just the same.
@@ -4875,7 +5007,7 @@ pub struct Vault {
             !email,
             "an autumn-prod.toml that clears [alerts].email must resolve as no destination"
         );
-        let r = check_alert_destination_impl(email, false, true, true);
+        let r = check_alert_destination_impl(true, email, false, true, true);
         assert!(
             matches!(r.status, CheckStatus::Warn),
             "a production deploy whose override file cleared the only alert channel must WARN"
@@ -4914,7 +5046,7 @@ pub struct Vault {
         let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&merged), "");
         assert!(email);
         assert!(!webhook);
-        let r = check_alert_destination_impl(email, webhook, true, true);
+        let r = check_alert_destination_impl(true, email, webhook, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
@@ -4937,7 +5069,7 @@ pub struct Vault {
             !webhook,
             "a webhook whose secret was cleared by the override file is not a signed destination"
         );
-        let r = check_alert_destination_impl(email, webhook, true, true);
+        let r = check_alert_destination_impl(true, email, webhook, true, true);
         assert!(matches!(r.status, CheckStatus::Warn));
 
         // With both left intact through the merged view, the webhook still counts.
@@ -4949,6 +5081,126 @@ pub struct Vault {
         assert!(
             webhook_ok,
             "url + secret through the merged view is a signed destination"
+        );
+    }
+
+    // ── [alerts] enabled master switch (issue #1610 follow-up) ────────────────
+    // The runtime `alerts::install_from_config` returns BEFORE installing any
+    // Alerter when `config.enabled` is false, so a prod deploy with alerting
+    // disabled delivers nothing even with a destination configured. Doctor must
+    // honour the same master switch (env > profile > base > default `true`).
+
+    #[test]
+    fn resolve_alert_enabled_defaults_true_when_unset() {
+        // No `enabled` key anywhere → the runtime default (`true`) applies.
+        let table: toml::Table = toml::from_str("[alerts]\nemail = \"ops@example.com\"\n").unwrap();
+        let enabled = resolve_alert_enabled_from_sources(no_env, Some(&table), "prod");
+        assert!(enabled);
+        // Nothing configured at all still defaults to enabled.
+        assert!(resolve_alert_enabled_from_sources(no_env, None, "prod"));
+    }
+
+    #[test]
+    fn resolve_alert_enabled_base_false_is_detected() {
+        let table: toml::Table =
+            toml::from_str("[alerts]\nenabled = false\nemail = \"ops@example.com\"\n").unwrap();
+        let enabled = resolve_alert_enabled_from_sources(no_env, Some(&table), "prod");
+        assert!(!enabled);
+    }
+
+    #[test]
+    fn resolve_alert_enabled_env_true_overrides_base_false() {
+        // Env parsing mirrors runtime `parse_env_bool`: "true"/"1" enable.
+        let env = |k: &str| (k == "AUTUMN_ALERTS__ENABLED").then(|| "true".to_owned());
+        let table: toml::Table = toml::from_str("[alerts]\nenabled = false\n").unwrap();
+        let enabled = resolve_alert_enabled_from_sources(env, Some(&table), "prod");
+        assert!(enabled);
+        let env1 = |k: &str| (k == "AUTUMN_ALERTS__ENABLED").then(|| "1".to_owned());
+        let enabled_one = resolve_alert_enabled_from_sources(env1, Some(&table), "prod");
+        assert!(enabled_one);
+    }
+
+    #[test]
+    fn resolve_alert_enabled_invalid_env_falls_through_to_toml() {
+        // A non-boolean env value is ignored (mirrors runtime), so the base
+        // `enabled = false` still wins.
+        let env = |k: &str| (k == "AUTUMN_ALERTS__ENABLED").then(|| "yes".to_owned());
+        let table: toml::Table = toml::from_str("[alerts]\nenabled = false\n").unwrap();
+        let enabled = resolve_alert_enabled_from_sources(env, Some(&table), "prod");
+        assert!(!enabled);
+    }
+
+    #[test]
+    fn resolve_alert_enabled_profile_false_overrides_base_true() {
+        // A profile-specific `enabled = false` disables under that profile while
+        // the base (empty-profile resolution) stays enabled.
+        let table: toml::Table = toml::from_str(
+            "[alerts]\nemail = \"ops@example.com\"\n[profile.prod.alerts]\nenabled = false\n",
+        )
+        .unwrap();
+        let under_profile = resolve_alert_enabled_from_sources(no_env, Some(&table), "prod");
+        assert!(!under_profile);
+        let under_base = resolve_alert_enabled_from_sources(no_env, Some(&table), "");
+        assert!(under_base);
+    }
+
+    #[test]
+    fn alert_disabled_at_base_in_prod_with_email_warns() {
+        // (a) `[alerts] enabled = false` at base, email set, production run → warn.
+        let table: toml::Table =
+            toml::from_str("[alerts]\nenabled = false\nemail = \"ops@example.com\"\n").unwrap();
+        let enabled = resolve_alert_enabled_from_sources(no_env, Some(&table), "prod");
+        let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        assert!(!enabled);
+        assert!(email, "the email itself is still configured");
+        let r = check_alert_destination_impl(enabled, email, webhook, true, true);
+        assert!(
+            matches!(r.status, CheckStatus::Warn),
+            "disabled alerting with a configured destination must warn in prod"
+        );
+        assert!(
+            r.detail.as_deref().is_some_and(|d| d.contains("disabled")),
+            "the warning must name the disabled master switch"
+        );
+    }
+
+    #[test]
+    fn alert_disabled_via_env_in_prod_warns() {
+        // (b) `AUTUMN_ALERTS__ENABLED=false` env override in production → warn,
+        // even though the base leaves alerting enabled with an email set.
+        let env = |k: &str| (k == "AUTUMN_ALERTS__ENABLED").then(|| "false".to_owned());
+        let table: toml::Table = toml::from_str("[alerts]\nemail = \"ops@example.com\"\n").unwrap();
+        let enabled = resolve_alert_enabled_from_sources(env, Some(&table), "prod");
+        let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        assert!(!enabled);
+        let r = check_alert_destination_impl(enabled, email, webhook, true, true);
+        assert!(matches!(r.status, CheckStatus::Warn));
+    }
+
+    #[test]
+    fn alert_enabled_default_true_preserves_existing_prod_pass() {
+        // (c) `enabled` unset → defaults true; a configured email + usable
+        // transport in prod still passes exactly as before this change.
+        let table: toml::Table = toml::from_str("[alerts]\nemail = \"ops@example.com\"\n").unwrap();
+        let enabled = resolve_alert_enabled_from_sources(no_env, Some(&table), "prod");
+        let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        assert!(enabled);
+        let r = check_alert_destination_impl(enabled, email, webhook, true, true);
+        assert!(matches!(r.status, CheckStatus::Pass));
+    }
+
+    #[test]
+    fn alert_disabled_in_dev_does_not_warn() {
+        // (d) Disabled in DEV stays lenient (no warning) like the rest of the check.
+        let table: toml::Table =
+            toml::from_str("[alerts]\nenabled = false\nemail = \"ops@example.com\"\n").unwrap();
+        let enabled = resolve_alert_enabled_from_sources(no_env, Some(&table), "dev");
+        let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "dev");
+        assert!(!enabled);
+        let r = check_alert_destination_impl(enabled, email, webhook, true, false);
+        assert!(
+            matches!(r.status, CheckStatus::Pass),
+            "dev-mode leniency: disabled alerting must not warn outside production"
         );
     }
 

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -545,16 +545,19 @@ pub fn check_alert_destination_impl(
     // alert `Mail` is built, so a present-but-unparsable address (e.g.
     // `not-an-address`) passes every earlier gate yet fails EVERY delivery at
     // runtime with `MailError::InvalidAddress`. An invalid address therefore
-    // does not count as a usable destination. Validity uses a BARE-mailbox check
-    // (`is_valid_bare_mailbox_doctor`) that matches what lettre accepts for a
-    // recipient — deliberately NOT `is_valid_mailto_address_doctor`, which strips
-    // a leading `mailto:` (correct for the `List-Unsubscribe` header but wrong
-    // here). The runtime hands `[alerts] email` verbatim to
-    // `Mail::builder().to(...)`, and lettre parses it as a bare mailbox at send
-    // time; a `mailto:` URI would fail EVERY delivery, so doctor must reject it.
+    // does not count as a usable destination. Validity is checked with the SAME
+    // lettre parser the runtime uses (`is_valid_alert_mailbox_doctor` runs
+    // `value.parse::<lettre::message::Mailbox>()`, exact parity with
+    // `autumn/src/alerts.rs`'s `is_valid_alert_mailbox`) — deliberately NOT
+    // `is_valid_mailto_address_doctor`, which strips a leading `mailto:` (correct
+    // for the `List-Unsubscribe` header but wrong here). This accepts everything
+    // lettre accepts, including RFC 5322 display-name forms like
+    // `Ops <ops@example.com>`, and rejects what lettre rejects: the runtime hands
+    // `[alerts] email` verbatim to `Mail::builder().to(...)`, so a `mailto:` URI
+    // would fail EVERY delivery and doctor must reject it too.
     let email_trimmed = email.trim();
     let email_configured = !email_trimmed.is_empty();
-    let email_valid = email_configured && is_valid_bare_mailbox_doctor(email_trimmed);
+    let email_valid = email_configured && is_valid_alert_mailbox_doctor(email_trimmed);
 
     // Whether a configured email would actually deliver. It needs a valid
     // address, a usable (non-disabled) transport AND — for transports that build
@@ -1000,40 +1003,33 @@ fn is_valid_mailto_address_doctor(value: &str) -> bool {
     }
 }
 
-/// Whether `value` is a syntactically valid **bare** recipient mailbox — a single
-/// `local@domain` with a dotted domain and no scheme prefix.
+/// Whether `value` parses as the SAME lettre [`Mailbox`](lettre::message::Mailbox)
+/// the alert mail send path requires of every recipient — EXACT parity with the
+/// runtime's `is_valid_alert_mailbox` (`autumn/src/alerts.rs`), which validates
+/// `[alerts] email` with `email.parse::<lettre::message::Mailbox>()`.
 ///
-/// This is DISTINCT from [`is_valid_mailto_address_doctor`], which accepts a
-/// leading `mailto:` (correct for the `[mail] unsubscribe_mailto`
-/// `List-Unsubscribe` header). The `[alerts] email` is handed verbatim to
-/// `Mail::builder().to(...)` and parsed by lettre as a bare recipient mailbox at
-/// SEND time (`parse_mailbox`/`lettre_message`); lettre does NOT strip a
-/// `mailto:` scheme, so `mailto:oncall@example.com` fails EVERY delivery with
-/// `MailError::InvalidAddress`. Reject the URI form here so doctor agrees with the
-/// SMTP path rather than passing a config that can never deliver.
-fn is_valid_bare_mailbox_doctor(value: &str) -> bool {
-    // Reject control characters and address delimiters anywhere in the value.
-    if value
-        .chars()
-        .any(|c| c.is_control() || matches!(c, '<' | '>' | ','))
-    {
-        return false;
-    }
-    // Note: no `mailto:` strip here — a bare recipient mailbox has no scheme.
-    let address = value.trim();
-    match address.split_once('@') {
-        Some((local, domain)) => {
-            !local.is_empty()
-                && !domain.is_empty()
-                && domain.contains('.')
-                && !address.contains(char::is_whitespace)
-                // A bare mailbox never contains `:` or `/`. This is what makes
-                // `mailto:oncall@example.com` (and any other scheme/URI form)
-                // INVALID — lettre would reject it as a recipient too.
-                && !address.contains([':', '/'])
-        }
-        None => false,
-    }
+/// The runtime hands `[alerts] email` verbatim to `Mail::builder().to(...)`, and
+/// lettre parses the recipient only at SEND time (`parse_mailbox`/`lettre_message`),
+/// not when the alert `Mail` is built. Reusing the exact same parser here means
+/// doctor accepts precisely what the runtime accepts — bare mailboxes
+/// (`ops@example.com`), `+`-addressing (`a+b@sub.example.co`) AND RFC 5322
+/// display-name forms (`Ops <ops@example.com>`) — instead of a hand-rolled
+/// approximation that was STRICTER than lettre and rejected valid display-name
+/// mailboxes, producing a false `autumn doctor --strict` failure on a config the
+/// runtime registers and delivers to fine.
+///
+/// A `mailto:` URI (e.g. `mailto:oncall@example.com`) is still rejected: lettre's
+/// parser treats the whole string as one mailbox and the `:` is not valid in a
+/// dot-atom local part, so it fails to parse — matching the runtime, where such a
+/// value fails EVERY delivery with `MailError::InvalidAddress`.
+///
+/// lettre is reachable from the CLI via `autumn_web`'s `mail`-gated re-export
+/// (`autumn_web::reexports::lettre`); `autumn-cli` enables that feature, so no
+/// direct `lettre` dependency is required.
+fn is_valid_alert_mailbox_doctor(value: &str) -> bool {
+    value
+        .parse::<autumn_web::reexports::lettre::message::Mailbox>()
+        .is_ok()
 }
 
 // ─── Pure helper functions (fully unit-testable) ──────────────────────────────
@@ -4852,20 +4848,49 @@ pub struct Vault {
     }
 
     #[test]
-    fn is_valid_bare_mailbox_rejects_mailto_uri_and_accepts_bare() {
+    fn is_valid_alert_mailbox_matches_lettre_and_accepts_display_name() {
         // Bare recipient mailboxes are accepted (this is what lettre parses at
         // send time for `[alerts] email`).
-        assert!(is_valid_bare_mailbox_doctor("oncall@example.com"));
-        assert!(is_valid_bare_mailbox_doctor("a+b@sub.example.co"));
-        // The `mailto:` URI form is REJECTED here (unlike the unsubscribe-mailto
+        assert!(is_valid_alert_mailbox_doctor("oncall@example.com"));
+        assert!(is_valid_alert_mailbox_doctor("a+b@sub.example.co"));
+        // RFC 5322 display-name form is ACCEPTED — the runtime's lettre parser
+        // accepts it and registers + delivers to it fine, so doctor must not
+        // reject it (the regression this fix addresses: a false `--strict`
+        // failure on a valid config).
+        assert!(is_valid_alert_mailbox_doctor("Ops <ops@example.com>"));
+        // The `mailto:` URI form is REJECTED (unlike the unsubscribe-mailto
         // validator): the runtime passes it verbatim to lettre, which rejects it
-        // as a bare recipient. Doctor must not pass a config that can't deliver.
-        assert!(!is_valid_bare_mailbox_doctor("mailto:oncall@example.com"));
+        // as a recipient. Doctor must not pass a config that can't deliver.
+        assert!(!is_valid_alert_mailbox_doctor("mailto:oncall@example.com"));
         // Other scheme/URI forms and malformed values stay rejected.
-        assert!(!is_valid_bare_mailbox_doctor("https://oncall@example.com"));
-        assert!(!is_valid_bare_mailbox_doctor("not-an-address"));
-        assert!(!is_valid_bare_mailbox_doctor("oncall example.com"));
-        assert!(!is_valid_bare_mailbox_doctor("oncall@localhost"));
+        assert!(!is_valid_alert_mailbox_doctor("https://oncall@example.com"));
+        assert!(!is_valid_alert_mailbox_doctor("not-an-address"));
+        assert!(!is_valid_alert_mailbox_doctor("oncall example.com"));
+        assert!(!is_valid_alert_mailbox_doctor(""));
+
+        // Exact parity with the runtime: doctor's check must agree with the very
+        // parser `autumn/src/alerts.rs`'s `is_valid_alert_mailbox` runs, for every
+        // case above. This is what keeps doctor from being stricter (or looser)
+        // than the SMTP send path.
+        for case in [
+            "oncall@example.com",
+            "a+b@sub.example.co",
+            "Ops <ops@example.com>",
+            "mailto:oncall@example.com",
+            "https://oncall@example.com",
+            "not-an-address",
+            "oncall example.com",
+            "",
+        ] {
+            let runtime_ok = case
+                .parse::<autumn_web::reexports::lettre::message::Mailbox>()
+                .is_ok();
+            assert_eq!(
+                is_valid_alert_mailbox_doctor(case),
+                runtime_ok,
+                "doctor and the runtime lettre parser must agree on {case:?}"
+            );
+        }
     }
 
     #[test]

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -397,6 +397,17 @@ pub fn check_trusted_hosts_impl(hosts: &[String], is_production: bool) -> CheckR
 /// it is `false` when the effective merged `[mail] transport` resolves to
 /// `disabled`. The webhook path is independent of the mailer.
 ///
+/// An `email` destination ALSO needs a mail `from` address for transports that
+/// build a real RFC 5322 message: the runtime's alert mail
+/// (`MailAlertChannel`) sets no per-message `from`, so it falls back to the
+/// mailer default (`[mail] from`). Under `transport = "smtp"` with no `[mail]
+/// from`, delivery fails in `lettre_message` with "mail from address is
+/// required" — so an SMTP email with no `from` is not a working destination.
+/// `transport_requires_from` mirrors which transports actually enforce this:
+/// only `smtp` (the `log` and `file` transports render `from` only when present
+/// and deliver without it; `disabled` is already not usable). `mail_from_present`
+/// is `true` when the effective merged `[mail] from` resolves non-empty.
+///
 /// The `[alerts] enabled` master switch is honoured up front: when alerting is
 /// disabled the runtime (`alerts::install_from_config`) returns BEFORE
 /// installing any `Alerter`, so NO operator alerts are delivered regardless of a
@@ -406,15 +417,40 @@ pub fn check_trusted_hosts_impl(hosts: &[String], is_production: bool) -> CheckR
 ///
 /// - **Production** (`is_production = true`): warns when alerting is disabled, or
 ///   when no usable destination is configured, so a deploy does not run silently
-///   blind to its own failures. An email whose mail transport is disabled gets a
-///   dedicated, clearer warning rather than the generic "no destination" one.
+///   blind to its own failures. An email whose mail transport is disabled — or
+///   whose SMTP transport has no `[mail] from` — gets a dedicated, clearer
+///   warning rather than the generic "no destination" one.
 /// - **Dev/test**: passes quietly (alerts are optional locally).
 ///
 /// The returned check name is `"alert_destination"`.
-// Five independent config booleans (alerting enabled, email present, webhook
-// signed, mail transport usable, production) each gate a distinct branch;
-// grouping them into enums would obscure rather than clarify the
-// destination-resolution logic.
+/// Dedicated production warning for an email destination on an SMTP transport
+/// with no `[mail] from`: the runtime's alert mail carries no per-message
+/// `from`, so `lettre_message` fails with "mail from address is required" and
+/// nothing is delivered. Distinct from the disabled-transport and no-destination
+/// warnings. Extracted so [`check_alert_destination_impl`] stays under the
+/// line-count lint.
+fn alert_email_from_missing_warning() -> CheckResult {
+    CheckResult {
+        name: "alert_destination",
+        status: CheckStatus::Warn,
+        detail: Some(
+            "an operator alert email is configured but `[mail] from` is not set, so SMTP \
+             delivery will fail; the runtime's alert mail carries no per-message from and \
+             the mailer has no default from address to fall back to"
+                .into(),
+        ),
+        hint: Some(
+            "Set [mail] from (or AUTUMN_MAIL__FROM) to a sender address like \
+             alerts@example.com, or configure a signed webhook ([alerts] webhook_url + \
+             webhook_secret). See docs/guide/operator-alerts.md",
+        ),
+    }
+}
+
+// Seven independent config booleans (alerting enabled, email present, webhook
+// signed, mail transport usable, production, mail `from` present, transport
+// requires a `from`) each gate a distinct branch; grouping them into enums would
+// obscure rather than clarify the destination-resolution logic.
 #[allow(clippy::fn_params_excessive_bools)]
 pub fn check_alert_destination_impl(
     alerts_enabled: bool,
@@ -422,7 +458,17 @@ pub fn check_alert_destination_impl(
     webhook_configured: bool,
     mail_transport_usable: bool,
     is_production: bool,
+    mail_from_present: bool,
+    transport_requires_from: bool,
 ) -> CheckResult {
+    // Whether a configured email would actually deliver. It needs a usable
+    // (non-disabled) transport AND — for transports that build a real RFC 5322
+    // message (SMTP) — a non-empty `[mail] from`, because the runtime's alert
+    // mail carries no per-message `from` and falls back to the mailer default.
+    // `log`/`file` deliver without a `from`, so they do not need one.
+    let email_from_ok = mail_from_present || !transport_requires_from;
+    let email_destination = email_configured && mail_transport_usable && email_from_ok;
+
     // Master off switch: when `[alerts] enabled = false`, the runtime installs no
     // alerter at all, so a configured destination is inert. Handle this BEFORE
     // the destination gate — doctor must not pass on the strength of a
@@ -432,7 +478,7 @@ pub fn check_alert_destination_impl(
             // Name the disabled switch explicitly. Mention the (otherwise valid)
             // destination when one is configured so the operator understands the
             // deploy is blind despite it; keep the message accurate otherwise.
-            let has_destination = (email_configured && mail_transport_usable) || webhook_configured;
+            let has_destination = email_destination || webhook_configured;
             let detail = if has_destination {
                 "alerting is disabled ([alerts] enabled = false) in production, so no operator \
                  alerts will be delivered — even though a destination is configured"
@@ -462,10 +508,10 @@ pub fn check_alert_destination_impl(
             hint: None,
         };
     }
-    // Email only counts as a real destination when the mail transport can
-    // actually send — mirroring the runtime, which skips MailAlertChannel when
-    // `mailer.is_disabled()`.
-    let email_destination = email_configured && mail_transport_usable;
+    // `email_destination` (computed above) already folds in the usable-transport
+    // and `from` requirements — mirroring the runtime, which skips
+    // MailAlertChannel when `mailer.is_disabled()` and whose SMTP send fails
+    // without a `from`.
     if email_destination || webhook_configured {
         return CheckResult {
             name: "alert_destination",
@@ -475,6 +521,18 @@ pub fn check_alert_destination_impl(
         };
     }
     if is_production {
+        // An email is set on a usable transport that needs a `from` (SMTP), but
+        // no `[mail] from` is configured: the runtime's alert mail has no
+        // per-message `from`, so `lettre_message` fails with "mail from address
+        // is required" and nothing is delivered. Surface a dedicated warning
+        // distinct from both the disabled-transport and no-destination cases.
+        if email_configured
+            && mail_transport_usable
+            && transport_requires_from
+            && !mail_from_present
+        {
+            return alert_email_from_missing_warning();
+        }
         // An email is set but the mail transport is disabled: the runtime
         // installs no alert channel and delivers nothing. Surface a dedicated
         // warning that points at the real cause instead of the generic
@@ -2174,6 +2232,30 @@ fn resolve_mail_unsubscribe(table: Option<&toml::Table>) -> (Option<String>, Opt
     )
 }
 
+/// Resolve the effective `[mail] from` sender address, preferring an
+/// `AUTUMN_MAIL__FROM` env override over the merged `[mail].from` (mirroring the
+/// runtime's `AUTUMN_MAIL__*` precedence — a *present* env var wins even when
+/// blank, clearing the TOML value; only an *absent* env var falls back to TOML).
+/// Returns the trimmed non-empty value, or `None` when no usable `from` is set.
+fn resolve_mail_from(table: Option<&toml::Table>) -> Option<String> {
+    let mail = table
+        .and_then(|t| t.get("mail"))
+        .and_then(toml::Value::as_table);
+    std::env::var("AUTUMN_MAIL__FROM").map_or_else(
+        |_| {
+            mail.and_then(|m| m.get("from"))
+                .and_then(toml::Value::as_str)
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(std::borrow::ToOwned::to_owned)
+        },
+        |value| {
+            let trimmed = value.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_owned())
+        },
+    )
+}
+
 /// Resolve the effective `unsubscribe_token_ttl_days`, mirroring the runtime
 /// precedence: `[mail].unsubscribe_token_ttl_days` (or the default of 30) is the
 /// base, and a present, *parseable* `AUTUMN_MAIL__UNSUBSCRIBE_TOKEN_TTL_DAYS`
@@ -2282,6 +2364,18 @@ fn resolve_effective_mail_transport(
     } else {
         "disabled".to_owned()
     }
+}
+
+/// Whether a mail transport actually requires a `from` address to deliver.
+///
+/// Only `smtp` builds a real RFC 5322 message: autumn-web's `lettre_message`
+/// errors with "mail from address is required" when `from` is absent, and it is
+/// reached solely from the SMTP transport. The `log` and `file` transports
+/// render `from` only when present and deliver without it; `disabled` delivers
+/// nothing at all (and is already treated as an unusable transport). Mirrors
+/// autumn-web `mail.rs`.
+fn mail_transport_requires_from(transport: &str) -> bool {
+    transport == "smtp"
 }
 
 fn resolve_database_topology(table: Option<&toml::Table>) -> DoctorDatabaseTopology {
@@ -3200,6 +3294,12 @@ pub fn run(opts: DoctorOptions) {
     //      `mailer.is_disabled()`: an email with a disabled transport installs
     //      no alert channel, so it must not count toward a valid destination.
     let mail_transport_usable = !mail_transport_disabled;
+    // Also gate the email destination on a resolved `[mail] from` for transports
+    // that require one (SMTP): the runtime's alert mail sets no per-message
+    // `from`, so an SMTP email with no `[mail] from` fails to deliver. Reuse the
+    // SAME merged config / effective transport the mail checks above resolved.
+    let mail_from_present = resolve_mail_from(Some(&merged_mail_toml)).is_some();
+    let transport_requires_from = mail_transport_requires_from(&effective_transport);
     tasks.push(Box::new(move || {
         check_alert_destination_impl(
             alerts_enabled,
@@ -3207,6 +3307,8 @@ pub fn run(opts: DoctorOptions) {
             alert_webhook_configured,
             mail_transport_usable,
             is_production,
+            mail_from_present,
+            transport_requires_from,
         )
     }));
 
@@ -4721,7 +4823,7 @@ pub struct Vault {
 
     #[test]
     fn alert_destination_warns_in_production_when_none() {
-        let r = check_alert_destination_impl(true, false, false, true, true);
+        let r = check_alert_destination_impl(true, false, false, true, true, true, true);
         assert_eq!(r.name, "alert_destination");
         assert!(matches!(r.status, CheckStatus::Warn));
         assert!(r.hint.is_some());
@@ -4729,19 +4831,19 @@ pub struct Vault {
 
     #[test]
     fn alert_destination_passes_in_production_with_email() {
-        let r = check_alert_destination_impl(true, true, false, true, true);
+        let r = check_alert_destination_impl(true, true, false, true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
     #[test]
     fn alert_destination_passes_in_production_with_webhook() {
-        let r = check_alert_destination_impl(true, false, true, true, true);
+        let r = check_alert_destination_impl(true, false, true, true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
     #[test]
     fn alert_destination_passes_in_dev_without_destination() {
-        let r = check_alert_destination_impl(true, false, false, true, false);
+        let r = check_alert_destination_impl(true, false, false, true, false, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
@@ -4765,7 +4867,7 @@ pub struct Vault {
         let transport = resolve_effective_mail_transport(None, None, "prod");
         assert_eq!(transport, "disabled");
         let usable = transport != "disabled";
-        let r = check_alert_destination_impl(true, email, webhook, usable, true);
+        let r = check_alert_destination_impl(true, email, webhook, usable, true, true, true);
         assert!(
             matches!(r.status, CheckStatus::Warn),
             "email with a disabled mail transport delivers nothing → must warn in prod"
@@ -4786,10 +4888,121 @@ pub struct Vault {
         let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
         let transport = resolve_effective_mail_transport(None, Some("smtp"), "prod");
         assert_eq!(transport, "smtp");
-        let r = check_alert_destination_impl(true, email, webhook, transport != "disabled", true);
+        // SMTP requires a `from`; this happy path has one set, so it still passes.
+        let requires_from = mail_transport_requires_from(&transport);
+        let r = check_alert_destination_impl(
+            true,
+            email,
+            webhook,
+            transport != "disabled",
+            true,
+            true,
+            requires_from,
+        );
         assert!(
             matches!(r.status, CheckStatus::Pass),
             "email with a usable (smtp) transport is a valid destination in prod"
+        );
+    }
+
+    #[test]
+    fn mail_transport_requires_from_only_for_smtp() {
+        // Only SMTP builds an RFC 5322 message (`lettre_message`), which errors
+        // without a `from`. `log`/`file` render `from` only when present and
+        // deliver without it; `disabled` delivers nothing at all.
+        assert!(mail_transport_requires_from("smtp"));
+        assert!(!mail_transport_requires_from("log"));
+        assert!(!mail_transport_requires_from("file"));
+        assert!(!mail_transport_requires_from("disabled"));
+    }
+
+    // ── email destination requires a mail `from` for SMTP (issue #1610) ───────
+    // The runtime's `MailAlertChannel` builds alert mail with NO per-message
+    // `from`, so it falls back to the mailer default (`[mail] from`). Under
+    // `transport = "smtp"` with no `[mail] from`, delivery fails in
+    // autumn-web's `lettre_message` with "mail from address is required". Doctor
+    // mirrors this: an SMTP email with no `from` is not a working destination.
+    // `log`/`file` deliver without a `from`, so they must NOT be over-gated.
+
+    #[test]
+    fn alert_destination_email_smtp_with_from_passes_in_prod() {
+        // (a) email + smtp + a `[mail] from` set → the runtime installs a channel
+        // that can send, so doctor counts the email and passes in prod.
+        let transport = resolve_effective_mail_transport(None, Some("smtp"), "prod");
+        assert_eq!(transport, "smtp");
+        let requires_from = mail_transport_requires_from(&transport);
+        assert!(requires_from, "smtp must be flagged as requiring a from");
+        let mail_from_present = true;
+        let r = check_alert_destination_impl(
+            true,
+            true,
+            false,
+            transport != "disabled",
+            true,
+            mail_from_present,
+            requires_from,
+        );
+        assert!(
+            matches!(r.status, CheckStatus::Pass),
+            "email + smtp + [mail] from is a valid destination in prod"
+        );
+    }
+
+    #[test]
+    fn alert_destination_email_smtp_without_from_warns_in_prod() {
+        // (b) email + smtp + NO `[mail] from` → SMTP delivery fails with "mail
+        // from address is required", so doctor must NOT count the email and must
+        // warn with the dedicated `from` message (distinct from the
+        // disabled-transport and no-destination warnings).
+        let transport = resolve_effective_mail_transport(None, Some("smtp"), "prod");
+        let requires_from = mail_transport_requires_from(&transport);
+        let mail_from_present = false;
+        let r = check_alert_destination_impl(
+            true,
+            true,
+            false,
+            transport != "disabled",
+            true,
+            mail_from_present,
+            requires_from,
+        );
+        assert!(
+            matches!(r.status, CheckStatus::Warn),
+            "email on smtp with no [mail] from delivers nothing → must warn in prod"
+        );
+        assert!(
+            r.detail
+                .as_deref()
+                .is_some_and(|d| d.contains("`[mail] from` is not set")),
+            "the dedicated warning must name the missing [mail] from as the cause"
+        );
+    }
+
+    #[test]
+    fn alert_destination_email_log_transport_without_from_still_passes() {
+        // (c) email + `log` transport + NO `[mail] from` → the log transport
+        // renders `from` only when present and delivers without it, so a missing
+        // `from` must NOT down-grade the destination. Do not over-gate.
+        let transport = resolve_effective_mail_transport(None, Some("log"), "prod");
+        assert_eq!(transport, "log");
+        let requires_from = mail_transport_requires_from(&transport);
+        assert!(
+            !requires_from,
+            "log must NOT be flagged as requiring a from"
+        );
+        let mail_from_present = false;
+        let r = check_alert_destination_impl(
+            true,
+            true,
+            false,
+            transport != "disabled",
+            true,
+            mail_from_present,
+            requires_from,
+        );
+        assert!(
+            matches!(r.status, CheckStatus::Pass),
+            "email on a log transport delivers without a from → must not warn"
         );
     }
 
@@ -4806,7 +5019,7 @@ pub struct Vault {
         assert!(!email, "the prod profile cleared the email");
         assert!(webhook, "the signed webhook remains configured");
         // Mail transport disabled — irrelevant to the webhook path.
-        let r = check_alert_destination_impl(true, email, webhook, false, true);
+        let r = check_alert_destination_impl(true, email, webhook, false, true, true, true);
         assert!(
             matches!(r.status, CheckStatus::Pass),
             "a signed webhook is a valid destination regardless of mail transport"
@@ -4843,7 +5056,7 @@ pub struct Vault {
         );
 
         // And the surfaced doctor check warns in production for this config.
-        let r = check_alert_destination_impl(true, email, false, true, true);
+        let r = check_alert_destination_impl(true, email, false, true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Warn));
     }
 
@@ -4910,7 +5123,7 @@ pub struct Vault {
             webhook,
             "webhook_url + webhook_secret must count as configured"
         );
-        let r = check_alert_destination_impl(true, email, webhook, true, true);
+        let r = check_alert_destination_impl(true, email, webhook, true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
@@ -4926,7 +5139,7 @@ pub struct Vault {
             !webhook,
             "a webhook_url with no signing secret is not a destination"
         );
-        let r = check_alert_destination_impl(true, email, webhook, true, true);
+        let r = check_alert_destination_impl(true, email, webhook, true, true, true, true);
         assert!(
             matches!(r.status, CheckStatus::Warn),
             "URL-without-secret in production must warn"
@@ -4948,7 +5161,7 @@ pub struct Vault {
             !webhook,
             "a prod-profile empty webhook_secret must clear the base secret"
         );
-        let r = check_alert_destination_impl(true, email, webhook, true, true);
+        let r = check_alert_destination_impl(true, email, webhook, true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Warn));
 
         // And an empty AUTUMN_ALERTS__WEBHOOK_SECRET env var clears it just the same.
@@ -5002,7 +5215,7 @@ pub struct Vault {
             !email,
             "an autumn-prod.toml that clears [alerts].email must resolve as no destination"
         );
-        let r = check_alert_destination_impl(true, email, false, true, true);
+        let r = check_alert_destination_impl(true, email, false, true, true, true, true);
         assert!(
             matches!(r.status, CheckStatus::Warn),
             "a production deploy whose override file cleared the only alert channel must WARN"
@@ -5041,7 +5254,7 @@ pub struct Vault {
         let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&merged), "");
         assert!(email);
         assert!(!webhook);
-        let r = check_alert_destination_impl(true, email, webhook, true, true);
+        let r = check_alert_destination_impl(true, email, webhook, true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
@@ -5064,7 +5277,7 @@ pub struct Vault {
             !webhook,
             "a webhook whose secret was cleared by the override file is not a signed destination"
         );
-        let r = check_alert_destination_impl(true, email, webhook, true, true);
+        let r = check_alert_destination_impl(true, email, webhook, true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Warn));
 
         // With both left intact through the merged view, the webhook still counts.
@@ -5148,7 +5361,7 @@ pub struct Vault {
         let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
         assert!(!enabled);
         assert!(email, "the email itself is still configured");
-        let r = check_alert_destination_impl(enabled, email, webhook, true, true);
+        let r = check_alert_destination_impl(enabled, email, webhook, true, true, true, true);
         assert!(
             matches!(r.status, CheckStatus::Warn),
             "disabled alerting with a configured destination must warn in prod"
@@ -5168,7 +5381,7 @@ pub struct Vault {
         let enabled = resolve_alert_enabled_from_sources(env, Some(&table), "prod");
         let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
         assert!(!enabled);
-        let r = check_alert_destination_impl(enabled, email, webhook, true, true);
+        let r = check_alert_destination_impl(enabled, email, webhook, true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Warn));
     }
 
@@ -5180,7 +5393,7 @@ pub struct Vault {
         let enabled = resolve_alert_enabled_from_sources(no_env, Some(&table), "prod");
         let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
         assert!(enabled);
-        let r = check_alert_destination_impl(enabled, email, webhook, true, true);
+        let r = check_alert_destination_impl(enabled, email, webhook, true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
@@ -5192,7 +5405,7 @@ pub struct Vault {
         let enabled = resolve_alert_enabled_from_sources(no_env, Some(&table), "dev");
         let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "dev");
         assert!(!enabled);
-        let r = check_alert_destination_impl(enabled, email, webhook, true, false);
+        let r = check_alert_destination_impl(enabled, email, webhook, true, false, true, true);
         assert!(
             matches!(r.status, CheckStatus::Pass),
             "dev-mode leniency: disabled alerting must not warn outside production"

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -658,9 +658,12 @@ pub fn check_alert_destination_impl(
             name: "alert_destination",
             status: CheckStatus::Warn,
             detail: Some(
-                "no operator alert destination configured in production; failure conditions \
-                 (dead-lettered jobs, Down health indicators, 5xx spikes, scheduled-task \
-                 failures) will not be delivered anywhere"
+                "no operator alert destination found in [alerts] config (email or webhook) in \
+                 production; if your app registers an alert channel in code via \
+                 AppBuilder::with_alert_channel, alerts will still be delivered and this warning \
+                 can be ignored (doctor is a config-only checker and cannot see code-registered \
+                 channels); otherwise failure conditions (dead-lettered jobs, Down health \
+                 indicators, 5xx spikes, scheduled-task failures) will not be delivered anywhere"
                     .into(),
             ),
             hint: Some(

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -4757,10 +4757,8 @@ pub struct Vault {
         // `[alerts] email` is set, but there is no `[mail] transport` — in a prod
         // profile that resolves to the `disabled` default, so the runtime installs
         // NO email alert channel. Doctor must NOT count the email and must warn.
-        let table: toml::Table =
-            toml::from_str("[alerts]\nemail = \"ops@example.com\"\n").unwrap();
-        let (email, webhook) =
-            resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        let table: toml::Table = toml::from_str("[alerts]\nemail = \"ops@example.com\"\n").unwrap();
+        let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
         assert!(email, "the [alerts] email itself resolves as present");
         assert!(!webhook);
         // No env override, no `[mail] transport`, prod profile → "disabled".
@@ -4784,10 +4782,8 @@ pub struct Vault {
     fn alert_destination_email_with_usable_transport_passes_in_prod() {
         // Same email, but `[mail] transport = "smtp"` (a real, usable backend) →
         // the runtime installs the channel, so doctor counts the email and passes.
-        let table: toml::Table =
-            toml::from_str("[alerts]\nemail = \"ops@example.com\"\n").unwrap();
-        let (email, webhook) =
-            resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        let table: toml::Table = toml::from_str("[alerts]\nemail = \"ops@example.com\"\n").unwrap();
+        let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
         let transport = resolve_effective_mail_transport(None, Some("smtp"), "prod");
         assert_eq!(transport, "smtp");
         let r = check_alert_destination_impl(true, email, webhook, transport != "disabled", true);
@@ -4806,8 +4802,7 @@ pub struct Vault {
             "[alerts]\nemail = \"ops@example.com\"\nwebhook_url = \"https://hooks.example/x\"\nwebhook_secret = \"s3cr3t\"\n[profile.prod.alerts]\nemail = \"\"\n",
         )
         .unwrap();
-        let (email, webhook) =
-            resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
         assert!(!email, "the prod profile cleared the email");
         assert!(webhook, "the signed webhook remains configured");
         // Mail transport disabled — irrelevant to the webhook path.

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -389,17 +389,36 @@ pub fn check_trusted_hosts_impl(hosts: &[String], is_production: bool) -> CheckR
 /// spikes, scheduled-task failures) are only delivered when an `[alerts]`
 /// destination — an operator `email` and/or a `webhook_url` — is configured.
 ///
-/// - **Production** (`is_production = true`): warns when neither is configured,
-///   so a deploy does not run silently blind to its own failures.
+/// An `email` destination only counts when a *usable* `[mail] transport` can
+/// actually send: the runtime (`alerts::install_from_config`) refuses to
+/// register a `MailAlertChannel` when `mailer.is_disabled()` (the disabled
+/// transport, which is the default outside dev), so an email paired with a
+/// disabled transport delivers nothing. `mail_transport_usable` mirrors that —
+/// it is `false` when the effective merged `[mail] transport` resolves to
+/// `disabled`. The webhook path is independent of the mailer.
+///
+/// - **Production** (`is_production = true`): warns when no usable destination
+///   is configured, so a deploy does not run silently blind to its own
+///   failures. An email whose mail transport is disabled gets a dedicated,
+///   clearer warning rather than the generic "no destination" one.
 /// - **Dev/test**: passes quietly (alerts are optional locally).
 ///
 /// The returned check name is `"alert_destination"`.
+// Four independent config booleans (email present, webhook signed, mail
+// transport usable, production) each gate a distinct branch; grouping them into
+// enums would obscure rather than clarify the destination-resolution logic.
+#[allow(clippy::fn_params_excessive_bools)]
 pub fn check_alert_destination_impl(
     email_configured: bool,
     webhook_configured: bool,
+    mail_transport_usable: bool,
     is_production: bool,
 ) -> CheckResult {
-    if email_configured || webhook_configured {
+    // Email only counts as a real destination when the mail transport can
+    // actually send — mirroring the runtime, which skips MailAlertChannel when
+    // `mailer.is_disabled()`.
+    let email_destination = email_configured && mail_transport_usable;
+    if email_destination || webhook_configured {
         return CheckResult {
             name: "alert_destination",
             status: CheckStatus::Pass,
@@ -408,6 +427,27 @@ pub fn check_alert_destination_impl(
         };
     }
     if is_production {
+        // An email is set but the mail transport is disabled: the runtime
+        // installs no alert channel and delivers nothing. Surface a dedicated
+        // warning that points at the real cause instead of the generic
+        // "no destination" message (which would read as "you set nothing").
+        if email_configured && !mail_transport_usable {
+            return CheckResult {
+                name: "alert_destination",
+                status: CheckStatus::Warn,
+                detail: Some(
+                    "an operator alert email is configured but [mail] transport is disabled, so \
+                     no email alerts will be delivered; the runtime installs no email alert \
+                     channel when the mailer is disabled"
+                        .into(),
+                ),
+                hint: Some(
+                    "Set [mail] transport to a real backend (smtp/log/file) or configure a signed \
+                     webhook ([alerts] webhook_url + webhook_secret). See \
+                     docs/guide/operator-alerts.md",
+                ),
+            };
+        }
         CheckResult {
             name: "alert_destination",
             status: CheckStatus::Warn,
@@ -3021,11 +3061,19 @@ pub fn run(opts: DoctorOptions) {
         check_compression_impl(compression_enabled, is_production)
     }));
 
-    // 12a. Operator alerts (warn in production when no destination configured)
+    // 12a. Operator alerts (warn in production when no destination configured).
+    //      Gate the email destination on a usable mail transport, reusing the
+    //      SAME `mail_transport_disabled` the mail-unsubscribe check resolved
+    //      from the merged config above (a `Copy` bool, still readable after it
+    //      was moved into the mail closure). This mirrors runtime
+    //      `mailer.is_disabled()`: an email with a disabled transport installs
+    //      no alert channel, so it must not count toward a valid destination.
+    let mail_transport_usable = !mail_transport_disabled;
     tasks.push(Box::new(move || {
         check_alert_destination_impl(
             alert_email_configured,
             alert_webhook_configured,
+            mail_transport_usable,
             is_production,
         )
     }));
@@ -4541,7 +4589,7 @@ pub struct Vault {
 
     #[test]
     fn alert_destination_warns_in_production_when_none() {
-        let r = check_alert_destination_impl(false, false, true);
+        let r = check_alert_destination_impl(false, false, true, true);
         assert_eq!(r.name, "alert_destination");
         assert!(matches!(r.status, CheckStatus::Warn));
         assert!(r.hint.is_some());
@@ -4549,20 +4597,93 @@ pub struct Vault {
 
     #[test]
     fn alert_destination_passes_in_production_with_email() {
-        let r = check_alert_destination_impl(true, false, true);
+        let r = check_alert_destination_impl(true, false, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
     #[test]
     fn alert_destination_passes_in_production_with_webhook() {
-        let r = check_alert_destination_impl(false, true, true);
+        let r = check_alert_destination_impl(false, true, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
     #[test]
     fn alert_destination_passes_in_dev_without_destination() {
-        let r = check_alert_destination_impl(false, false, false);
+        let r = check_alert_destination_impl(false, false, true, false);
         assert!(matches!(r.status, CheckStatus::Pass));
+    }
+
+    // ── email destination requires a usable mail transport (issue #1610) ──────
+    // Runtime `alerts::install_from_config` skips `MailAlertChannel` when
+    // `mailer.is_disabled()` (the disabled transport, which is the default
+    // outside dev), so doctor must not count an email against a disabled
+    // transport. These wire `resolve_effective_mail_transport` (the exact helper
+    // the doctor mail check uses) to the destination check, mirroring `run()`.
+
+    #[test]
+    fn alert_destination_email_only_with_disabled_transport_warns_in_prod() {
+        // `[alerts] email` is set, but there is no `[mail] transport` — in a prod
+        // profile that resolves to the `disabled` default, so the runtime installs
+        // NO email alert channel. Doctor must NOT count the email and must warn.
+        let table: toml::Table =
+            toml::from_str("[alerts]\nemail = \"ops@example.com\"\n").unwrap();
+        let (email, webhook) =
+            resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        assert!(email, "the [alerts] email itself resolves as present");
+        assert!(!webhook);
+        // No env override, no `[mail] transport`, prod profile → "disabled".
+        let transport = resolve_effective_mail_transport(None, None, "prod");
+        assert_eq!(transport, "disabled");
+        let usable = transport != "disabled";
+        let r = check_alert_destination_impl(email, webhook, usable, true);
+        assert!(
+            matches!(r.status, CheckStatus::Warn),
+            "email with a disabled mail transport delivers nothing → must warn in prod"
+        );
+        assert!(
+            r.detail
+                .as_deref()
+                .is_some_and(|d| d.contains("transport is disabled")),
+            "the dedicated warning must name the disabled transport as the cause"
+        );
+    }
+
+    #[test]
+    fn alert_destination_email_with_usable_transport_passes_in_prod() {
+        // Same email, but `[mail] transport = "smtp"` (a real, usable backend) →
+        // the runtime installs the channel, so doctor counts the email and passes.
+        let table: toml::Table =
+            toml::from_str("[alerts]\nemail = \"ops@example.com\"\n").unwrap();
+        let (email, webhook) =
+            resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        let transport = resolve_effective_mail_transport(None, Some("smtp"), "prod");
+        assert_eq!(transport, "smtp");
+        let r = check_alert_destination_impl(email, webhook, transport != "disabled", true);
+        assert!(
+            matches!(r.status, CheckStatus::Pass),
+            "email with a usable (smtp) transport is a valid destination in prod"
+        );
+    }
+
+    #[test]
+    fn alert_destination_webhook_survives_disabled_transport() {
+        // The prod profile clears the email, but a signed webhook is present. The
+        // webhook path is independent of the mailer, so a disabled mail transport
+        // must not down-grade an otherwise-valid webhook destination.
+        let table: toml::Table = toml::from_str(
+            "[alerts]\nemail = \"ops@example.com\"\nwebhook_url = \"https://hooks.example/x\"\nwebhook_secret = \"s3cr3t\"\n[profile.prod.alerts]\nemail = \"\"\n",
+        )
+        .unwrap();
+        let (email, webhook) =
+            resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        assert!(!email, "the prod profile cleared the email");
+        assert!(webhook, "the signed webhook remains configured");
+        // Mail transport disabled — irrelevant to the webhook path.
+        let r = check_alert_destination_impl(email, webhook, false, true);
+        assert!(
+            matches!(r.status, CheckStatus::Pass),
+            "a signed webhook is a valid destination regardless of mail transport"
+        );
     }
 
     // ── resolve_alert_destination_from_sources precedence (issue #1610) ───────
@@ -4595,7 +4716,7 @@ pub struct Vault {
         );
 
         // And the surfaced doctor check warns in production for this config.
-        let r = check_alert_destination_impl(email, false, true);
+        let r = check_alert_destination_impl(email, false, true, true);
         assert!(matches!(r.status, CheckStatus::Warn));
     }
 
@@ -4662,7 +4783,7 @@ pub struct Vault {
             webhook,
             "webhook_url + webhook_secret must count as configured"
         );
-        let r = check_alert_destination_impl(email, webhook, true);
+        let r = check_alert_destination_impl(email, webhook, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
@@ -4678,7 +4799,7 @@ pub struct Vault {
             !webhook,
             "a webhook_url with no signing secret is not a destination"
         );
-        let r = check_alert_destination_impl(email, webhook, true);
+        let r = check_alert_destination_impl(email, webhook, true, true);
         assert!(
             matches!(r.status, CheckStatus::Warn),
             "URL-without-secret in production must warn"
@@ -4700,7 +4821,7 @@ pub struct Vault {
             !webhook,
             "a prod-profile empty webhook_secret must clear the base secret"
         );
-        let r = check_alert_destination_impl(email, webhook, true);
+        let r = check_alert_destination_impl(email, webhook, true, true);
         assert!(matches!(r.status, CheckStatus::Warn));
 
         // And an empty AUTUMN_ALERTS__WEBHOOK_SECRET env var clears it just the same.
@@ -4754,7 +4875,7 @@ pub struct Vault {
             !email,
             "an autumn-prod.toml that clears [alerts].email must resolve as no destination"
         );
-        let r = check_alert_destination_impl(email, false, true);
+        let r = check_alert_destination_impl(email, false, true, true);
         assert!(
             matches!(r.status, CheckStatus::Warn),
             "a production deploy whose override file cleared the only alert channel must WARN"
@@ -4793,7 +4914,7 @@ pub struct Vault {
         let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&merged), "");
         assert!(email);
         assert!(!webhook);
-        let r = check_alert_destination_impl(email, webhook, true);
+        let r = check_alert_destination_impl(email, webhook, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
@@ -4816,7 +4937,7 @@ pub struct Vault {
             !webhook,
             "a webhook whose secret was cleared by the override file is not a signed destination"
         );
-        let r = check_alert_destination_impl(email, webhook, true);
+        let r = check_alert_destination_impl(email, webhook, true, true);
         assert!(matches!(r.status, CheckStatus::Warn));
 
         // With both left intact through the merged view, the webhook still counts.

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2567,21 +2567,62 @@ fn resolve_trusted_hosts() -> Vec<String> {
 }
 
 /// Resolve whether an operator-alert destination (email and/or webhook URL) is
-/// configured, from the environment or `autumn.toml` `[alerts]`.
+/// configured, from the environment or the fully-merged effective `[alerts]` (base
+/// `autumn.toml` layered with the active profile's `[profile.{name}]` section and
+/// `autumn-{profile}.toml` override file, alias-normalized exactly as the runtime).
 ///
 /// Returns `(email_configured, webhook_configured)`.
 fn resolve_alert_destination() -> (bool, bool) {
-    let table = read_autumn_toml_table();
-    let profile = std::env::var("AUTUMN_ENV")
+    // Evaluate the SAME fully-merged effective config the runtime boots with, not
+    // just the raw base `autumn.toml`. The runtime config loader (a) normalizes
+    // profile aliases (`production` → `prod`, `development` → `dev`) and (b) layers
+    // the active profile's inline `[profile.{name}]` section plus its
+    // `autumn-{profile}.toml` override file over the base. Reading only the base
+    // `[alerts]` with a raw lower-cased profile string let doctor greenlight a prod
+    // deploy whose `autumn-prod.toml` (or `[profile.prod.alerts]`) CLEARED the
+    // destination — installing NO alert channel at runtime. Build the merged table
+    // through the runtime-mirroring loader and resolve against its flattened
+    // top-level `[alerts]`; env vars still take highest precedence.
+    //
+    // Profile selection mirrors `resolve_profile_input`: a blank/whitespace
+    // AUTUMN_ENV is ignored before falling back to AUTUMN_PROFILE, so a blank
+    // preferred var does not silently downgrade a prod selection to dev.
+    let selected_input = std::env::var("AUTUMN_ENV")
         .ok()
-        .or_else(|| std::env::var("AUTUMN_PROFILE").ok())
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| {
+            std::env::var("AUTUMN_PROFILE")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+        })
         .unwrap_or_default()
         .trim()
-        .to_ascii_lowercase();
+        .to_owned();
+    let normalized_profile = normalize_alert_profile(&selected_input);
+    // The merge flattens the active profile's inline section and override file into
+    // the top-level `[alerts]`, so resolve against an EMPTY profile: `_from_sources`
+    // then reads only the effective top-level `[alerts]` (env vars still override).
+    // Passing the profile here would re-read the STALE raw `[profile.{name}.alerts]`
+    // section and ignore the higher-priority `autumn-{profile}.toml` layer.
+    let merged = get_merged_toml_table_runtime(&normalized_profile, &selected_input);
     // `.ok()` deliberately does NOT filter empty values: a set-but-empty env
     // var is a PRESENT higher-priority layer that CLEARS the destination,
     // distinct from an unset var (which falls through to the TOML layers).
-    resolve_alert_destination_from_sources(|key| std::env::var(key).ok(), table.as_ref(), &profile)
+    resolve_alert_destination_from_sources(|key| std::env::var(key).ok(), Some(&merged), "")
+}
+
+/// Normalize a raw profile input to the canonical name the runtime config loader
+/// uses, mirroring `autumn_web::config::normalize_profile_name`'s alias table
+/// (`production`/`PROD` → `prod`, `development`/`DEV` → `dev`; custom names keep
+/// their operator-specified spelling; blank stays blank). Kept in lock-step with
+/// the runtime so doctor merges the same profile sources the app will boot with.
+fn normalize_alert_profile(selected_input: &str) -> String {
+    match selected_input.trim().to_ascii_lowercase().as_str() {
+        "prod" | "production" => "prod".to_owned(),
+        "dev" | "development" => "dev".to_owned(),
+        "" => String::new(),
+        _ => selected_input.trim().to_owned(),
+    }
 }
 
 /// Resolve whether an email and/or webhook alert destination is configured,
@@ -4533,8 +4574,7 @@ pub struct Vault {
     #[test]
     fn resolve_alert_destination_base_email_is_detected() {
         let table: toml::Table = toml::from_str("[alerts]\nemail = \"dev@example.com\"\n").unwrap();
-        let (email, webhook) =
-            resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
         assert!(email, "base [alerts] email should resolve as configured");
         assert!(!webhook);
     }
@@ -4583,9 +4623,11 @@ pub struct Vault {
         )
         .unwrap();
         let env = |key: &str| (key == "AUTUMN_ALERTS__EMAIL").then(String::new);
-        let (email, webhook) =
-            resolve_alert_destination_from_sources(env, Some(&table), "prod");
-        assert!(!email, "empty AUTUMN_ALERTS__EMAIL must clear the base email");
+        let (email, webhook) = resolve_alert_destination_from_sources(env, Some(&table), "prod");
+        assert!(
+            !email,
+            "empty AUTUMN_ALERTS__EMAIL must clear the base email"
+        );
         assert!(webhook, "unset webhook env should fall through to base");
     }
 
@@ -4600,7 +4642,10 @@ pub struct Vault {
         };
         let (email, webhook) = resolve_alert_destination_from_sources(env, None, "prod");
         assert!(!email);
-        assert!(webhook, "env webhook should resolve as configured with no TOML");
+        assert!(
+            webhook,
+            "env webhook should resolve as configured with no TOML"
+        );
     }
 
     #[test]
@@ -4611,10 +4656,12 @@ pub struct Vault {
             "[alerts]\nwebhook_url = \"https://hooks.example/x\"\nwebhook_secret = \"s3cr3t\"\n",
         )
         .unwrap();
-        let (email, webhook) =
-            resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
         assert!(!email);
-        assert!(webhook, "webhook_url + webhook_secret must count as configured");
+        assert!(
+            webhook,
+            "webhook_url + webhook_secret must count as configured"
+        );
         let r = check_alert_destination_impl(email, webhook, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
@@ -4625,8 +4672,7 @@ pub struct Vault {
         // so doctor must NOT count it and must warn in production.
         let table: toml::Table =
             toml::from_str("[alerts]\nwebhook_url = \"https://hooks.example/x\"\n").unwrap();
-        let (email, webhook) =
-            resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
         assert!(!email);
         assert!(
             !webhook,
@@ -4648,8 +4694,7 @@ pub struct Vault {
             "[alerts]\nwebhook_url = \"https://hooks.example/x\"\nwebhook_secret = \"s3cr3t\"\n[profile.prod.alerts]\nwebhook_secret = \"\"\n",
         )
         .unwrap();
-        let (email, webhook) =
-            resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
         assert!(!email);
         assert!(
             !webhook,
@@ -4665,6 +4710,124 @@ pub struct Vault {
         assert!(
             !webhook_env,
             "an empty AUTUMN_ALERTS__WEBHOOK_SECRET must clear the secret"
+        );
+    }
+
+    // ── merged-config view (issue #1610) ──────────────────────────────────────
+    // The wrapper now resolves against the fully-merged effective config the
+    // runtime boots with — base `autumn.toml` layered with `[profile.{name}]` and
+    // the `autumn-{profile}.toml` override file, alias-normalized — reading the
+    // flattened top-level `[alerts]` with an EMPTY profile. These tests build the
+    // merged table with the same `deep_merge` the runtime loader uses (the doctor
+    // bin deliberately avoids process-global cwd mutation, so the file merge is
+    // exercised through its merge primitive rather than real on-disk files).
+
+    #[test]
+    fn normalize_alert_profile_resolves_aliases() {
+        // Mirrors `autumn_web::config::normalize_profile_name`'s alias table so
+        // doctor merges the same profile sources the app will boot with.
+        assert_eq!(normalize_alert_profile("production"), "prod");
+        assert_eq!(normalize_alert_profile("PRODUCTION"), "prod");
+        assert_eq!(normalize_alert_profile("  prod "), "prod");
+        assert_eq!(normalize_alert_profile("development"), "dev");
+        assert_eq!(normalize_alert_profile("DEV"), "dev");
+        // Custom profiles keep their operator-specified spelling; blank stays blank.
+        assert_eq!(normalize_alert_profile("staging"), "staging");
+        assert_eq!(normalize_alert_profile(""), "");
+        assert_eq!(normalize_alert_profile("   "), "");
+    }
+
+    #[test]
+    fn resolve_alert_destination_merged_override_file_clears_base_email() {
+        // Base `autumn.toml` sets the only alert channel; an `autumn-prod.toml`
+        // override file CLEARS it with an empty string. `deep_merge` flattens the
+        // override over the base into the top-level `[alerts]`, exactly as
+        // `get_merged_toml_table_runtime` produces. Resolving against this flattened
+        // view with an EMPTY profile must see NO destination → doctor warns in prod.
+        let mut merged: toml::Table =
+            toml::from_str("[alerts]\nemail = \"dev@example.com\"\n").unwrap();
+        let override_file: toml::Table = toml::from_str("[alerts]\nemail = \"\"\n").unwrap();
+        deep_merge(&mut merged, &override_file);
+
+        let (email, _webhook) = resolve_alert_destination_from_sources(no_env, Some(&merged), "");
+        assert!(
+            !email,
+            "an autumn-prod.toml that clears [alerts].email must resolve as no destination"
+        );
+        let r = check_alert_destination_impl(email, false, true);
+        assert!(
+            matches!(r.status, CheckStatus::Warn),
+            "a production deploy whose override file cleared the only alert channel must WARN"
+        );
+    }
+
+    #[test]
+    fn resolve_alert_destination_merged_ignores_stale_profile_section() {
+        // The merged table still carries the ORIGINAL raw `[profile.prod.alerts]`
+        // (the base is deep-merged wholesale), but the override file already
+        // flattened the effective value onto the top-level `[alerts]`. Resolving
+        // with an EMPTY profile must read the flattened top-level, NOT the stale
+        // `[profile.prod.alerts]` — otherwise a non-empty stale section would
+        // spuriously mask a file-cleared destination and re-open the #1610 hole.
+        let mut merged: toml::Table = toml::from_str(
+            "[alerts]\nemail = \"dev@example.com\"\n[profile.prod.alerts]\nemail = \"ops@example.com\"\n",
+        )
+        .unwrap();
+        // autumn-prod.toml clears email; deep_merge flattens it onto top-level [alerts].
+        let override_file: toml::Table = toml::from_str("[alerts]\nemail = \"\"\n").unwrap();
+        deep_merge(&mut merged, &override_file);
+
+        let (email, _webhook) = resolve_alert_destination_from_sources(no_env, Some(&merged), "");
+        assert!(
+            !email,
+            "the flattened top-level [alerts] wins; a stale [profile.prod.alerts] must not mask a cleared destination"
+        );
+    }
+
+    #[test]
+    fn resolve_alert_destination_merged_base_email_survives_without_override() {
+        // No override / profile clear: the base email flows through the merged view
+        // and a production run passes.
+        let merged: toml::Table =
+            toml::from_str("[alerts]\nemail = \"ops@example.com\"\n").unwrap();
+        let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&merged), "");
+        assert!(email);
+        assert!(!webhook);
+        let r = check_alert_destination_impl(email, webhook, true);
+        assert!(matches!(r.status, CheckStatus::Pass));
+    }
+
+    #[test]
+    fn resolve_alert_destination_merged_webhook_requires_both_url_and_secret() {
+        // Base configures a signed webhook (url + secret); the override file clears
+        // the SECRET. Through the flattened merged view the webhook is no longer a
+        // signed destination, so doctor must not count it and must warn in prod.
+        let mut merged: toml::Table = toml::from_str(
+            "[alerts]\nwebhook_url = \"https://hooks.example/x\"\nwebhook_secret = \"s3cr3t\"\n",
+        )
+        .unwrap();
+        let override_file: toml::Table =
+            toml::from_str("[alerts]\nwebhook_secret = \"\"\n").unwrap();
+        deep_merge(&mut merged, &override_file);
+
+        let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&merged), "");
+        assert!(!email);
+        assert!(
+            !webhook,
+            "a webhook whose secret was cleared by the override file is not a signed destination"
+        );
+        let r = check_alert_destination_impl(email, webhook, true);
+        assert!(matches!(r.status, CheckStatus::Warn));
+
+        // With both left intact through the merged view, the webhook still counts.
+        let intact: toml::Table = toml::from_str(
+            "[alerts]\nwebhook_url = \"https://hooks.example/x\"\nwebhook_secret = \"s3cr3t\"\n",
+        )
+        .unwrap();
+        let (_e, webhook_ok) = resolve_alert_destination_from_sources(no_env, Some(&intact), "");
+        assert!(
+            webhook_ok,
+            "url + secret through the merged view is a signed destination"
         );
     }
 

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -405,8 +405,11 @@ pub fn check_trusted_hosts_impl(hosts: &[String], is_production: bool) -> CheckR
 /// required" — so an SMTP email with no `from` is not a working destination.
 /// `transport_requires_from` mirrors which transports actually enforce this:
 /// only `smtp` (the `log` and `file` transports render `from` only when present
-/// and deliver without it; `disabled` is already not usable). `mail_from_present`
-/// is `true` when the effective merged `[mail] from` resolves non-empty.
+/// and deliver without it; `disabled` is already not usable). `mail_from` is the
+/// effective merged `[mail] from` (empty string when unset); for SMTP it must be
+/// both non-empty AND a valid lettre mailbox — the runtime parses it at boot
+/// (`MailerBuilder::build`) and refuses to start on an unparsable sender, so a
+/// present-but-invalid value is not a working destination.
 ///
 /// The `[alerts] enabled` master switch is honoured up front: when alerting is
 /// disabled the runtime (`alerts::install_from_config`) returns BEFORE
@@ -441,6 +444,33 @@ fn alert_email_from_missing_warning() -> CheckResult {
         ),
         hint: Some(
             "Set [mail] from (or AUTUMN_MAIL__FROM) to a sender address like \
+             alerts@example.com, or configure a signed webhook ([alerts] webhook_url + \
+             webhook_secret). See docs/guide/operator-alerts.md",
+        ),
+    }
+}
+
+/// Dedicated production warning for a present-but-syntactically-invalid `[mail]
+/// from` on an SMTP transport: the runtime parses `[mail] from` at boot
+/// (`MailerBuilder::build` runs `parse_mailbox`), so an unparsable value like
+/// `not-a-mailbox` aborts startup outright — and even before that the alert mail
+/// (which carries no per-message `from` and falls back to this default) would
+/// fail EVERY send with an invalid-address error. Distinct from the
+/// missing-`from`, disabled-transport, invalid-email, and no-destination
+/// warnings, and it names the offending value. Validity is checked with the SAME
+/// lettre `Mailbox` parser the runtime uses (`is_valid_alert_mailbox_doctor`).
+/// Extracted so [`check_alert_destination_impl`] stays under the line-count lint.
+fn alert_email_from_invalid_warning(from: &str) -> CheckResult {
+    CheckResult {
+        name: "alert_destination",
+        status: CheckStatus::Warn,
+        detail: Some(format!(
+            "`[mail] from` (\"{from}\") is not a valid email address, so SMTP alert \
+             delivery will fail; the runtime parses it at boot and refuses to start on \
+             an unparsable sender, and the alert mail has no other `from` to fall back to"
+        )),
+        hint: Some(
+            "Set [mail] from (or AUTUMN_MAIL__FROM) to a valid sender address like \
              alerts@example.com, or configure a signed webhook ([alerts] webhook_url + \
              webhook_secret). See docs/guide/operator-alerts.md",
         ),
@@ -569,14 +599,15 @@ fn alert_disabled_in_production_warning(has_destination: bool) -> CheckResult {
     }
 }
 
-// Six independent config booleans (alerting enabled, webhook is a usable signed
-// destination, mail transport usable, production, mail `from` present, transport
-// requires a `from`) plus the resolved `[alerts] email` and `[alerts]
-// webhook_url` strings each gate a distinct branch; grouping them into enums
-// would obscure rather than clarify the destination-resolution logic. The raw
-// `webhook_url` is used only to name a present-but-non-absolute value in its
-// dedicated warning — `webhook_configured` already folds in absoluteness and the
-// signing-secret requirement.
+// Five independent config booleans (alerting enabled, webhook is a usable signed
+// destination, mail transport usable, production, transport requires a `from`)
+// plus the resolved `[alerts] email`, `[alerts] webhook_url`, and `[mail] from`
+// strings each gate a distinct branch; grouping them into enums would obscure
+// rather than clarify the destination-resolution logic. The raw `webhook_url` is
+// used only to name a present-but-non-absolute value in its dedicated warning —
+// `webhook_configured` already folds in absoluteness and the signing-secret
+// requirement — and `mail_from` likewise names a present-but-invalid sender in
+// its dedicated warning while its presence+validity gate the email destination.
 #[allow(clippy::fn_params_excessive_bools, clippy::too_many_arguments)]
 pub fn check_alert_destination_impl(
     alerts_enabled: bool,
@@ -585,7 +616,7 @@ pub fn check_alert_destination_impl(
     webhook_url: &str,
     mail_transport_usable: bool,
     is_production: bool,
-    mail_from_present: bool,
+    mail_from: &str,
     transport_requires_from: bool,
     custom_channel: bool,
 ) -> CheckResult {
@@ -608,12 +639,24 @@ pub fn check_alert_destination_impl(
     let email_configured = !email_trimmed.is_empty();
     let email_valid = email_configured && is_valid_alert_mailbox_doctor(email_trimmed);
 
+    // Presence and syntactic validity of the resolved `[mail] from`. For
+    // transports that build a real RFC 5322 message (SMTP), a `from` must be both
+    // present AND a valid lettre mailbox: the runtime parses it at boot
+    // (`MailerBuilder::build` runs `parse_mailbox`), so an unparsable value like
+    // `not-a-mailbox` aborts startup and the alert mail — which sets no
+    // per-message `from` — has no valid default to fall back to. Checked with the
+    // SAME lettre parser the recipient uses (`is_valid_alert_mailbox_doctor`),
+    // exact parity with `autumn/src/mail.rs`'s `parse_mailbox`.
+    let mail_from_trimmed = mail_from.trim();
+    let mail_from_present = !mail_from_trimmed.is_empty();
+    let mail_from_valid = mail_from_present && is_valid_alert_mailbox_doctor(mail_from_trimmed);
+
     // Whether a configured email would actually deliver. It needs a valid
     // address, a usable (non-disabled) transport AND — for transports that build
-    // a real RFC 5322 message (SMTP) — a non-empty `[mail] from`, because the
+    // a real RFC 5322 message (SMTP) — a present, VALID `[mail] from`, because the
     // runtime's alert mail carries no per-message `from` and falls back to the
     // mailer default. `log`/`file` deliver without a `from`, so they do not need one.
-    let email_from_ok = mail_from_present || !transport_requires_from;
+    let email_from_ok = mail_from_valid || !transport_requires_from;
     let email_destination = email_valid && mail_transport_usable && email_from_ok;
 
     // Master off switch: when `[alerts] enabled = false`, the runtime installs no
@@ -672,6 +715,20 @@ pub fn check_alert_destination_impl(
             && !mail_from_present
         {
             return alert_email_from_missing_warning();
+        }
+        // An email is set on a usable transport that needs a `from` (SMTP) and a
+        // `[mail] from` IS set but is not a syntactically valid mailbox: the
+        // runtime parses it at boot (`MailerBuilder::build`) and refuses to start,
+        // so it never even reaches a send. Surface a dedicated warning naming the
+        // offending value, distinct from the missing-`from` case (which reads as
+        // "you set nothing" and would mislead here).
+        if email_configured
+            && mail_transport_usable
+            && transport_requires_from
+            && mail_from_present
+            && !mail_from_valid
+        {
+            return alert_email_from_invalid_warning(mail_from_trimmed);
         }
         // An email is set but the mail transport is disabled: the runtime
         // installs no alert channel and delivers nothing. Surface a dedicated
@@ -3626,11 +3683,14 @@ pub fn run(opts: DoctorOptions) {
     //      `mailer.is_disabled()`: an email with a disabled transport installs
     //      no alert channel, so it must not count toward a valid destination.
     let mail_transport_usable = !mail_transport_disabled;
-    // Also gate the email destination on a resolved `[mail] from` for transports
-    // that require one (SMTP): the runtime's alert mail sets no per-message
-    // `from`, so an SMTP email with no `[mail] from` fails to deliver. Reuse the
-    // SAME merged config / effective transport the mail checks above resolved.
-    let mail_from_present = resolve_mail_from(Some(&merged_mail_toml)).is_some();
+    // Also gate the email destination on a resolved, VALID `[mail] from` for
+    // transports that require one (SMTP): the runtime's alert mail sets no
+    // per-message `from`, so an SMTP email with no `[mail] from` — or a
+    // present-but-unparsable one, which aborts boot in `MailerBuilder::build` —
+    // fails to deliver. Pass the effective value (empty when unset) so the check
+    // can both gate on validity and name a bad value. Reuse the SAME merged config
+    // / effective transport the mail checks above resolved.
+    let mail_from = resolve_mail_from(Some(&merged_mail_toml)).unwrap_or_default();
     let transport_requires_from = mail_transport_requires_from(&effective_transport);
     tasks.push(Box::new(move || {
         check_alert_destination_impl(
@@ -3640,7 +3700,7 @@ pub fn run(opts: DoctorOptions) {
             &alert_webhook_url,
             mail_transport_usable,
             is_production,
-            mail_from_present,
+            &mail_from,
             transport_requires_from,
             alert_custom_channel,
         )
@@ -5236,7 +5296,17 @@ pub struct Vault {
 
     #[test]
     fn alert_destination_warns_in_production_when_none() {
-        let r = check_alert_destination_impl(true, "", false, "", true, true, true, true, false);
+        let r = check_alert_destination_impl(
+            true,
+            "",
+            false,
+            "",
+            true,
+            true,
+            "noreply@example.com",
+            true,
+            false,
+        );
         assert_eq!(r.name, "alert_destination");
         assert!(matches!(r.status, CheckStatus::Warn));
         assert!(r.hint.is_some());
@@ -5251,7 +5321,7 @@ pub struct Vault {
             "",
             true,
             true,
-            true,
+            "noreply@example.com",
             true,
             false,
         );
@@ -5260,13 +5330,33 @@ pub struct Vault {
 
     #[test]
     fn alert_destination_passes_in_production_with_webhook() {
-        let r = check_alert_destination_impl(true, "", true, "", true, true, true, true, false);
+        let r = check_alert_destination_impl(
+            true,
+            "",
+            true,
+            "",
+            true,
+            true,
+            "noreply@example.com",
+            true,
+            false,
+        );
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
     #[test]
     fn alert_destination_passes_in_dev_without_destination() {
-        let r = check_alert_destination_impl(true, "", false, "", true, false, true, true, false);
+        let r = check_alert_destination_impl(
+            true,
+            "",
+            false,
+            "",
+            true,
+            false,
+            "noreply@example.com",
+            true,
+            false,
+        );
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
@@ -5297,7 +5387,7 @@ pub struct Vault {
             "",
             usable,
             true,
-            true,
+            "noreply@example.com",
             true,
             false,
         );
@@ -5331,7 +5421,7 @@ pub struct Vault {
             "",
             transport != "disabled",
             true,
-            true,
+            "noreply@example.com",
             requires_from,
             false,
         );
@@ -5368,7 +5458,7 @@ pub struct Vault {
         assert_eq!(transport, "smtp");
         let requires_from = mail_transport_requires_from(&transport);
         assert!(requires_from, "smtp must be flagged as requiring a from");
-        let mail_from_present = true;
+        let mail_from = "noreply@example.com";
         let r = check_alert_destination_impl(
             true,
             "ops@example.com",
@@ -5376,7 +5466,7 @@ pub struct Vault {
             "",
             transport != "disabled",
             true,
-            mail_from_present,
+            mail_from,
             requires_from,
             false,
         );
@@ -5394,7 +5484,7 @@ pub struct Vault {
         // disabled-transport and no-destination warnings).
         let transport = resolve_effective_mail_transport(None, Some("smtp"), "prod");
         let requires_from = mail_transport_requires_from(&transport);
-        let mail_from_present = false;
+        let mail_from = "";
         let r = check_alert_destination_impl(
             true,
             "ops@example.com",
@@ -5402,7 +5492,7 @@ pub struct Vault {
             "",
             transport != "disabled",
             true,
-            mail_from_present,
+            mail_from,
             requires_from,
             false,
         );
@@ -5430,7 +5520,7 @@ pub struct Vault {
             !requires_from,
             "log must NOT be flagged as requiring a from"
         );
-        let mail_from_present = false;
+        let mail_from = "";
         let r = check_alert_destination_impl(
             true,
             "ops@example.com",
@@ -5438,13 +5528,124 @@ pub struct Vault {
             "",
             transport != "disabled",
             true,
-            mail_from_present,
+            mail_from,
             requires_from,
             false,
         );
         assert!(
             matches!(r.status, CheckStatus::Pass),
             "email on a log transport delivers without a from → must not warn"
+        );
+    }
+
+    // ── invalid `[mail] from` for SMTP (issue #1610 follow-up) ────────────────
+    // A present-but-unparsable `[mail] from` on an SMTP transport makes the
+    // runtime ABORT boot (`MailerBuilder::build` runs `parse_mailbox`), and the
+    // alert mail — which carries no per-message `from` — has no valid default to
+    // fall back to. Doctor must catch this PRE-deploy: NOT count the email and
+    // surface a dedicated warning naming the value, distinct from the
+    // missing-`from` case. Valid display-name senders must NOT be over-rejected,
+    // and non-SMTP transports (which never parse `from`) stay lenient.
+
+    #[test]
+    fn alert_destination_email_smtp_with_invalid_from_warns_in_prod() {
+        let transport = resolve_effective_mail_transport(None, Some("smtp"), "prod");
+        let requires_from = mail_transport_requires_from(&transport);
+        assert!(requires_from, "smtp must require a from");
+        let r = check_alert_destination_impl(
+            true,
+            "ops@example.com",
+            false,
+            "",
+            transport != "disabled",
+            true,
+            "not-a-mailbox",
+            requires_from,
+            false,
+        );
+        assert!(
+            matches!(r.status, CheckStatus::Warn),
+            "smtp with an unparsable [mail] from delivers nothing → must warn in prod"
+        );
+        let detail = r.detail.unwrap_or_default();
+        assert!(
+            detail.contains("`[mail] from`")
+                && detail.contains("not a valid email address")
+                && detail.contains("not-a-mailbox"),
+            "the dedicated invalid-from warning must fire and name the value, got: {detail}"
+        );
+    }
+
+    #[test]
+    fn alert_destination_email_smtp_with_display_name_from_passes_in_prod() {
+        // A valid RFC 5322 display-name `from` (`Ops <ops@example.com>`) is what
+        // the runtime's `parse_mailbox` accepts, so doctor must accept it too and
+        // still count the email destination — no over-rejection.
+        let transport = resolve_effective_mail_transport(None, Some("smtp"), "prod");
+        let requires_from = mail_transport_requires_from(&transport);
+        let r = check_alert_destination_impl(
+            true,
+            "ops@example.com",
+            false,
+            "",
+            transport != "disabled",
+            true,
+            "Ops <ops@example.com>",
+            requires_from,
+            false,
+        );
+        assert!(
+            matches!(r.status, CheckStatus::Pass),
+            "a valid display-name [mail] from is a working sender → must not warn"
+        );
+    }
+
+    #[test]
+    fn alert_destination_email_smtp_with_invalid_from_is_lenient_in_dev() {
+        // Dev-mode leniency mirrors the rest of the check: an invalid `[mail] from`
+        // is not a hard problem locally, so it must NOT warn outside production.
+        let transport = resolve_effective_mail_transport(None, Some("smtp"), "prod");
+        let requires_from = mail_transport_requires_from(&transport);
+        let r = check_alert_destination_impl(
+            true,
+            "ops@example.com",
+            false,
+            "",
+            transport != "disabled",
+            false, // dev
+            "not-a-mailbox",
+            requires_from,
+            false,
+        );
+        assert!(
+            matches!(r.status, CheckStatus::Pass),
+            "dev-mode leniency: an invalid [mail] from must not warn outside production"
+        );
+    }
+
+    #[test]
+    fn alert_destination_email_log_transport_with_invalid_from_still_passes() {
+        // A `log` transport never parses `[mail] from`, so even a garbage value
+        // must NOT down-grade the destination. Do not over-gate non-SMTP
+        // transports (parity with the runtime, which requires a from only for smtp).
+        let transport = resolve_effective_mail_transport(None, Some("log"), "prod");
+        assert_eq!(transport, "log");
+        let requires_from = mail_transport_requires_from(&transport);
+        assert!(!requires_from, "log must NOT require a from");
+        let r = check_alert_destination_impl(
+            true,
+            "ops@example.com",
+            false,
+            "",
+            transport != "disabled",
+            true,
+            "not-a-mailbox",
+            requires_from,
+            false,
+        );
+        assert!(
+            matches!(r.status, CheckStatus::Pass),
+            "log transport ignores [mail] from → an invalid value must not warn"
         );
     }
 
@@ -5465,11 +5666,11 @@ pub struct Vault {
             "not-an-address",
             false,
             "",
-            true,  // usable transport
-            true,  // production
-            true,  // [mail] from present
-            true,  // smtp requires from
-            false, // custom_channel
+            true,                  // usable transport
+            true,                  // production
+            "noreply@example.com", // [mail] from present
+            true,                  // smtp requires from
+            false,                 // custom_channel
         );
         assert!(
             matches!(r.status, CheckStatus::Warn),
@@ -5500,7 +5701,7 @@ pub struct Vault {
             "",
             true,
             false, // dev
-            true,
+            "noreply@example.com",
             true,
             false,
         );
@@ -5521,7 +5722,7 @@ pub struct Vault {
             "",
             true,
             true,
-            true,
+            "noreply@example.com",
             true,
             false,
         );
@@ -5544,11 +5745,11 @@ pub struct Vault {
             "mailto:oncall@example.com",
             false,
             "",
-            true,  // usable transport
-            true,  // production
-            true,  // [mail] from present
-            true,  // smtp requires from
-            false, // custom_channel
+            true,                  // usable transport
+            true,                  // production
+            "noreply@example.com", // [mail] from present
+            true,                  // smtp requires from
+            false,                 // custom_channel
         );
         assert!(
             matches!(r.status, CheckStatus::Warn),
@@ -5579,7 +5780,7 @@ pub struct Vault {
             "",
             true,
             true,
-            true,
+            "noreply@example.com",
             true,
             false,
         );
@@ -5606,7 +5807,17 @@ pub struct Vault {
         assert!(!email, "the prod profile cleared the email");
         assert!(webhook, "the signed webhook remains configured");
         // Mail transport disabled — irrelevant to the webhook path.
-        let r = check_alert_destination_impl(true, "", webhook, "", false, true, true, true, false);
+        let r = check_alert_destination_impl(
+            true,
+            "",
+            webhook,
+            "",
+            false,
+            true,
+            "noreply@example.com",
+            true,
+            false,
+        );
         assert!(
             matches!(r.status, CheckStatus::Pass),
             "a signed webhook is a valid destination regardless of mail transport"
@@ -5643,7 +5854,17 @@ pub struct Vault {
         );
 
         // And the surfaced doctor check warns in production for this config.
-        let r = check_alert_destination_impl(true, "", false, "", true, true, true, true, false);
+        let r = check_alert_destination_impl(
+            true,
+            "",
+            false,
+            "",
+            true,
+            true,
+            "noreply@example.com",
+            true,
+            false,
+        );
         assert!(matches!(r.status, CheckStatus::Warn));
     }
 
@@ -5710,7 +5931,17 @@ pub struct Vault {
             webhook,
             "webhook_url + webhook_secret must count as configured"
         );
-        let r = check_alert_destination_impl(true, "", webhook, "", true, true, true, true, false);
+        let r = check_alert_destination_impl(
+            true,
+            "",
+            webhook,
+            "",
+            true,
+            true,
+            "noreply@example.com",
+            true,
+            false,
+        );
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
@@ -5726,7 +5957,17 @@ pub struct Vault {
             !webhook,
             "a webhook_url with no signing secret is not a destination"
         );
-        let r = check_alert_destination_impl(true, "", webhook, "", true, true, true, true, false);
+        let r = check_alert_destination_impl(
+            true,
+            "",
+            webhook,
+            "",
+            true,
+            true,
+            "noreply@example.com",
+            true,
+            false,
+        );
         assert!(
             matches!(r.status, CheckStatus::Warn),
             "URL-without-secret in production must warn"
@@ -5748,7 +5989,17 @@ pub struct Vault {
             !webhook,
             "a prod-profile empty webhook_secret must clear the base secret"
         );
-        let r = check_alert_destination_impl(true, "", webhook, "", true, true, true, true, false);
+        let r = check_alert_destination_impl(
+            true,
+            "",
+            webhook,
+            "",
+            true,
+            true,
+            "noreply@example.com",
+            true,
+            false,
+        );
         assert!(matches!(r.status, CheckStatus::Warn));
 
         // And an empty AUTUMN_ALERTS__WEBHOOK_SECRET env var clears it just the same.
@@ -5779,7 +6030,7 @@ pub struct Vault {
             "https://hooks.example/x",
             true,
             true,
-            true,
+            "noreply@example.com",
             true,
             false,
         );
@@ -5807,7 +6058,7 @@ pub struct Vault {
             "http://hooks.example/x",
             true,
             true,
-            true,
+            "noreply@example.com",
             true,
             false,
         );
@@ -5838,7 +6089,7 @@ pub struct Vault {
             "hooks.example/x",
             true,
             true,
-            true,
+            "noreply@example.com",
             true,
             false,
         );
@@ -5864,7 +6115,7 @@ pub struct Vault {
             "hooks.example/x",
             true,
             false, // dev
-            true,
+            "noreply@example.com",
             true,
             false,
         );
@@ -5912,7 +6163,17 @@ pub struct Vault {
             !email,
             "an autumn-prod.toml that clears [alerts].email must resolve as no destination"
         );
-        let r = check_alert_destination_impl(true, "", false, "", true, true, true, true, false);
+        let r = check_alert_destination_impl(
+            true,
+            "",
+            false,
+            "",
+            true,
+            true,
+            "noreply@example.com",
+            true,
+            false,
+        );
         assert!(
             matches!(r.status, CheckStatus::Warn),
             "a production deploy whose override file cleared the only alert channel must WARN"
@@ -5958,7 +6219,7 @@ pub struct Vault {
             "",
             true,
             true,
-            true,
+            "noreply@example.com",
             true,
             false,
         );
@@ -5984,7 +6245,17 @@ pub struct Vault {
             !webhook,
             "a webhook whose secret was cleared by the override file is not a signed destination"
         );
-        let r = check_alert_destination_impl(true, "", webhook, "", true, true, true, true, false);
+        let r = check_alert_destination_impl(
+            true,
+            "",
+            webhook,
+            "",
+            true,
+            true,
+            "noreply@example.com",
+            true,
+            false,
+        );
         assert!(matches!(r.status, CheckStatus::Warn));
 
         // With both left intact through the merged view, the webhook still counts.
@@ -6075,7 +6346,7 @@ pub struct Vault {
             "",
             true,
             true,
-            true,
+            "noreply@example.com",
             true,
             false,
         );
@@ -6106,7 +6377,7 @@ pub struct Vault {
             "",
             true,
             true,
-            true,
+            "noreply@example.com",
             true,
             false,
         );
@@ -6129,7 +6400,7 @@ pub struct Vault {
             "",
             true,
             true,
-            true,
+            "noreply@example.com",
             true,
             false,
         );
@@ -6151,7 +6422,7 @@ pub struct Vault {
             "",
             true,
             false,
-            true,
+            "noreply@example.com",
             true,
             false,
         );
@@ -6173,7 +6444,15 @@ pub struct Vault {
         // custom_channel = true + no email/webhook in prod → PASS (not Warn), so
         // `autumn doctor --strict` succeeds for a code-only alert setup.
         let r = check_alert_destination_impl(
-            true, "", false, "", true, true, true, true, /* custom_channel */ true,
+            true,
+            "",
+            false,
+            "",
+            true,
+            true,
+            "noreply@example.com",
+            true,
+            /* custom_channel */ true,
         );
         assert!(
             matches!(r.status, CheckStatus::Pass),
@@ -6192,7 +6471,15 @@ pub struct Vault {
         // custom_channel = false (default) + no destination in prod → still Warn,
         // preserving the pre-existing behavior; the warning now points at the flag.
         let r = check_alert_destination_impl(
-            true, "", false, "", true, true, true, true, /* custom_channel */ false,
+            true,
+            "",
+            false,
+            "",
+            true,
+            true,
+            "noreply@example.com",
+            true,
+            /* custom_channel */ false,
         );
         assert!(matches!(r.status, CheckStatus::Warn));
         assert!(
@@ -6215,7 +6502,7 @@ pub struct Vault {
             "not-a-url/hooks", // present but non-absolute → dedicated invalid warning
             true,
             true,
-            true,
+            "noreply@example.com",
             true,
             /* custom_channel */ true,
         );
@@ -6282,7 +6569,17 @@ pub struct Vault {
             custom,
             "AUTUMN_ALERTS__CUSTOM_CHANNEL=true must resolve true"
         );
-        let r = check_alert_destination_impl(true, "", false, "", true, true, true, true, custom);
+        let r = check_alert_destination_impl(
+            true,
+            "",
+            false,
+            "",
+            true,
+            true,
+            "noreply@example.com",
+            true,
+            custom,
+        );
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -470,16 +470,71 @@ fn alert_email_invalid_warning(email: &str) -> CheckResult {
     }
 }
 
-// Six independent config booleans (alerting enabled, webhook signed, mail
-// transport usable, production, mail `from` present, transport requires a
-// `from`) plus the resolved `[alerts] email` each gate a distinct branch;
-// grouping them into enums would obscure rather than clarify the
-// destination-resolution logic.
-#[allow(clippy::fn_params_excessive_bools)]
+/// Dedicated production warning for a present-but-non-absolute `[alerts]
+/// webhook_url`: the runtime's HTTP client (`http_client::Client::build_request`)
+/// dispatches a URL verbatim only when it starts with `http://` or `https://`,
+/// otherwise treating it as a path to join onto a base-url alias the alert
+/// webhook never has — so a relative value like `hooks.example/x` fails EVERY
+/// signed POST. Distinct from the missing-secret, invalid-email, and
+/// no-destination warnings, and it names the offending value.
+fn alert_webhook_url_invalid_warning(url: &str) -> CheckResult {
+    CheckResult {
+        name: "alert_destination",
+        status: CheckStatus::Warn,
+        detail: Some(format!(
+            "`[alerts] webhook_url` (\"{url}\") is not an absolute http(s) URL, so alert \
+             delivery will fail; the runtime's HTTP client only sends a URL starting with \
+             http:// or https://, and a relative value has no base URL to resolve against, so \
+             every signed webhook POST fails to send"
+        )),
+        hint: Some(
+            "Set [alerts] webhook_url (or AUTUMN_ALERTS__WEBHOOK_URL) to an absolute URL like \
+             https://alerts.example.com/hooks/autumn, or configure an email destination \
+             ([alerts] email). See docs/guide/operator-alerts.md",
+        ),
+    }
+}
+
+/// Dedicated production warning for the `[alerts] enabled = false` master switch:
+/// the runtime (`alerts::install_from_config`) returns BEFORE installing any
+/// `Alerter`, so NO operator alerts are delivered regardless of a configured
+/// destination. Mentions the (otherwise valid) destination when one is present so
+/// the operator understands the deploy is blind despite it. Extracted so
+/// [`check_alert_destination_impl`] stays under the line-count lint.
+fn alert_disabled_in_production_warning(has_destination: bool) -> CheckResult {
+    let detail = if has_destination {
+        "alerting is disabled ([alerts] enabled = false) in production, so no operator \
+         alerts will be delivered — even though a destination is configured"
+    } else {
+        "alerting is disabled ([alerts] enabled = false) in production, so no operator \
+         alerts will be delivered"
+    };
+    CheckResult {
+        name: "alert_destination",
+        status: CheckStatus::Warn,
+        detail: Some(detail.into()),
+        hint: Some(
+            "Set [alerts] enabled = true (or AUTUMN_ALERTS__ENABLED=true) to deliver \
+             operator alerts, or remove the setting (it defaults to enabled). See \
+             docs/guide/operator-alerts.md",
+        ),
+    }
+}
+
+// Six independent config booleans (alerting enabled, webhook is a usable signed
+// destination, mail transport usable, production, mail `from` present, transport
+// requires a `from`) plus the resolved `[alerts] email` and `[alerts]
+// webhook_url` strings each gate a distinct branch; grouping them into enums
+// would obscure rather than clarify the destination-resolution logic. The raw
+// `webhook_url` is used only to name a present-but-non-absolute value in its
+// dedicated warning — `webhook_configured` already folds in absoluteness and the
+// signing-secret requirement.
+#[allow(clippy::fn_params_excessive_bools, clippy::too_many_arguments)]
 pub fn check_alert_destination_impl(
     alerts_enabled: bool,
     email: &str,
     webhook_configured: bool,
+    webhook_url: &str,
     mail_transport_usable: bool,
     is_production: bool,
     mail_from_present: bool,
@@ -518,24 +573,7 @@ pub fn check_alert_destination_impl(
             // Name the disabled switch explicitly. Mention the (otherwise valid)
             // destination when one is configured so the operator understands the
             // deploy is blind despite it; keep the message accurate otherwise.
-            let has_destination = email_destination || webhook_configured;
-            let detail = if has_destination {
-                "alerting is disabled ([alerts] enabled = false) in production, so no operator \
-                 alerts will be delivered — even though a destination is configured"
-            } else {
-                "alerting is disabled ([alerts] enabled = false) in production, so no operator \
-                 alerts will be delivered"
-            };
-            return CheckResult {
-                name: "alert_destination",
-                status: CheckStatus::Warn,
-                detail: Some(detail.into()),
-                hint: Some(
-                    "Set [alerts] enabled = true (or AUTUMN_ALERTS__ENABLED=true) to deliver \
-                     operator alerts, or remove the setting (it defaults to enabled). See \
-                     docs/guide/operator-alerts.md",
-                ),
-            };
+            return alert_disabled_in_production_warning(email_destination || webhook_configured);
         }
         return CheckResult {
             name: "alert_destination",
@@ -603,6 +641,18 @@ pub fn check_alert_destination_impl(
                      docs/guide/operator-alerts.md",
                 ),
             };
+        }
+        // A webhook URL is set but is not an absolute http(s) URL: the runtime's
+        // HTTP client dispatches a URL verbatim only when it starts with
+        // `http://`/`https://`, and an alert webhook has no base-url alias to join
+        // a relative value onto — so every signed POST fails to send. Surface a
+        // dedicated warning naming the offending value, distinct from the
+        // missing-secret ("no destination") and email cases. `webhook_configured`
+        // is already false here (it requires an absolute URL), so this only fires
+        // when there is no other working destination.
+        let webhook_url_trimmed = webhook_url.trim();
+        if !webhook_url_trimmed.is_empty() && !is_absolute_http_url_doctor(webhook_url_trimmed) {
+            return alert_webhook_url_invalid_warning(webhook_url_trimmed);
         }
         CheckResult {
             name: "alert_destination",
@@ -891,6 +941,33 @@ fn is_valid_https_base_url_doctor(url: &str) -> bool {
         && parsed.password().is_none()
         && parsed.query().is_none()
         && parsed.fragment().is_none()
+}
+
+/// Whether `url` is an absolute http(s) URL that the runtime's HTTP client would
+/// actually dispatch — the exact absoluteness rule an `[alerts] webhook_url`
+/// must satisfy to deliver.
+///
+/// `autumn_web`'s `http_client::Client::build_request` sends a URL verbatim ONLY
+/// when it starts with `http://` or `https://`; any other string is treated as a
+/// path to be joined onto a base-url alias, and an alert webhook (posted via
+/// `named(&url).post(&url)`) has no such alias, so a relative value like
+/// `hooks.example/x` fails EVERY signed send. Mirror that rule byte-for-byte:
+/// accept BOTH schemes (the runtime does not require TLS, so neither do we) and
+/// additionally require the URL to parse with a non-empty host — a value such as
+/// `https://` or `http:///path` carries the prefix yet reqwest cannot send it.
+///
+/// Deliberately MORE permissive than [`is_valid_https_base_url_doctor`]
+/// (https-only; forbids query/fragment/userinfo): a webhook URL is a full
+/// endpoint the runtime posts as-is, so rejecting `http://` or a query string
+/// here would warn about configs that deliver fine — a false positive.
+fn is_absolute_http_url_doctor(url: &str) -> bool {
+    if !(url.starts_with("http://") || url.starts_with("https://")) {
+        return false;
+    }
+    ::url::Url::parse(url)
+        .ok()
+        .and_then(|parsed| parsed.host_str().map(|h| !h.is_empty()))
+        .unwrap_or(false)
 }
 
 /// Mirror of `autumn_web`'s `is_valid_mailto_address` (see above).
@@ -2839,11 +2916,13 @@ fn resolve_trusted_hosts() -> Vec<String> {
 /// `autumn.toml` layered with the active profile's `[profile.{name}]` section and
 /// `autumn-{profile}.toml` override file, alias-normalized exactly as the runtime).
 ///
-/// Returns `(email, webhook_configured)`, where `email` is the RAW resolved
-/// `[alerts] email` value (empty when unset/cleared) so the caller can check
-/// both its presence and its syntactic validity — an invalid address delivers
-/// nothing at runtime.
-fn resolve_alert_destination() -> (String, bool) {
+/// Returns `(email, webhook_configured, webhook_url)`, where `email` and
+/// `webhook_url` are the RAW resolved `[alerts] email` / `[alerts] webhook_url`
+/// values (empty when unset/cleared) so the caller can check both their presence
+/// and their syntactic validity — an invalid address, or a non-absolute webhook
+/// URL, delivers nothing at runtime. `webhook_configured` already folds in the
+/// URL absoluteness and signing-secret requirements.
+fn resolve_alert_destination() -> (String, bool, String) {
     // Evaluate the SAME fully-merged effective config the runtime boots with, not
     // just the raw base `autumn.toml`. The runtime config loader (a) normalizes
     // profile aliases (`production` → `prod`, `development` → `dev`) and (b) layers
@@ -2894,7 +2973,19 @@ fn resolve_alert_destination() -> (String, bool) {
             .unwrap_or("")
             .to_owned()
     });
-    (email, webhook)
+    // Surface the RAW resolved webhook URL (not just presence) under the same
+    // env > merged-base precedence, so the destination check can name a
+    // present-but-non-absolute value in its dedicated warning. `webhook` (above)
+    // already gates on this URL being absolute AND the secret resolving.
+    let webhook_url = std::env::var("AUTUMN_ALERTS__WEBHOOK_URL").unwrap_or_else(|_| {
+        merged
+            .get("alerts")
+            .and_then(|a| a.get("webhook_url"))
+            .and_then(toml::Value::as_str)
+            .unwrap_or("")
+            .to_owned()
+    });
+    (email, webhook, webhook_url)
 }
 
 /// Normalize a raw profile input to the canonical name the runtime config loader
@@ -2921,10 +3012,12 @@ fn normalize_alert_profile(selected_input: &str) -> String {
 /// Layers, highest first: env var, `[profile.{profile}.alerts]`, base
 /// `[alerts]`. Only a layer that omits the key entirely falls through.
 ///
-/// A webhook counts as configured only when BOTH `webhook_url` and
-/// `webhook_secret` resolve non-empty under this precedence — mirroring the
-/// runtime, which never registers an unsigned webhook channel — so a webhook URL
-/// with a missing or cleared secret is not a destination.
+/// A webhook counts as configured only when `webhook_url` resolves to a
+/// non-empty ABSOLUTE http(s) URL AND `webhook_secret` resolves non-empty under
+/// this precedence — mirroring the runtime, which never registers an unsigned
+/// webhook channel and whose HTTP client cannot dispatch a relative URL — so a
+/// webhook URL with a missing/cleared secret, or a non-absolute URL, is not a
+/// destination.
 ///
 /// Split out from [`resolve_alert_destination`] so the precedence logic is unit
 /// testable without mutating process-global env/cwd state.
@@ -2950,38 +3043,52 @@ where
         .and_then(|t| t.get("alerts"))
         .and_then(toml::Value::as_table);
 
-    let resolve = |env_key: &str, key: &str| -> bool {
-        // 1. Env var — highest priority. Set-and-empty clears; unset falls through.
+    // Resolve the RAW winning value for a key under the same layer precedence,
+    // stopping at (not falling through) the first PRESENT layer — a present layer
+    // wins even when its value is empty (an explicit clear). Returns an empty
+    // string when no layer sets the key.
+    let resolve_value = |env_key: &str, key: &str| -> String {
+        // 1. Env var — highest priority. Present (even empty) is terminal.
         if let Some(val) = env_var(env_key) {
-            return !val.trim().is_empty();
+            return val;
         }
         // 2. Profile-specific `[profile.{profile}.alerts].{key}`.
         if let Some(v) = profile_alerts
             .and_then(|t| t.get(key))
             .and_then(toml::Value::as_str)
         {
-            return !v.trim().is_empty();
+            return v.to_owned();
         }
         // 3. Base `[alerts].{key}`.
         if let Some(v) = base_alerts
             .and_then(|t| t.get(key))
             .and_then(toml::Value::as_str)
         {
-            return !v.trim().is_empty();
+            return v.to_owned();
         }
-        false
+        String::new()
     };
+    let resolve =
+        |env_key: &str, key: &str| -> bool { !resolve_value(env_key, key).trim().is_empty() };
 
     let email = resolve("AUTUMN_ALERTS__EMAIL", "email");
-    // A webhook destination requires BOTH a URL and a signing secret to be a real
-    // destination: the runtime (`alerts::install_from_config`) refuses to register
-    // an unsigned webhook channel, so a URL with a missing/cleared secret installs
-    // NO channel. Count the webhook only when both resolve non-empty under the same
-    // per-field precedence, so doctor agrees with runtime (URL-without-secret is
-    // NOT a destination → in production with no other destination, doctor warns).
-    let webhook_url = resolve("AUTUMN_ALERTS__WEBHOOK_URL", "webhook_url");
+    // A webhook destination requires a well-formed URL AND a signing secret to be
+    // a real destination:
+    //   * The runtime (`alerts::install_from_config`) refuses to register an
+    //     unsigned webhook channel, so a URL with a missing/cleared secret
+    //     installs NO channel.
+    //   * The runtime's HTTP client (`http_client::Client::build_request`) only
+    //     dispatches a URL that starts with `http://`/`https://`; a relative value
+    //     (which an alert webhook can never resolve against a base-url alias) fails
+    //     EVERY signed POST. So a present-but-non-absolute URL is not a working
+    //     destination either.
+    // Count the webhook only when the resolved URL is a non-empty ABSOLUTE http(s)
+    // URL AND the secret resolves non-empty, under the same per-field precedence —
+    // so doctor agrees with runtime (URL-without-secret, or a relative URL, is NOT
+    // a destination → in production with no other destination, doctor warns).
+    let webhook_url = resolve_value("AUTUMN_ALERTS__WEBHOOK_URL", "webhook_url");
     let webhook_secret = resolve("AUTUMN_ALERTS__WEBHOOK_SECRET", "webhook_secret");
-    let webhook = webhook_url && webhook_secret;
+    let webhook = is_absolute_http_url_doctor(webhook_url.trim()) && webhook_secret;
     (email, webhook)
 }
 
@@ -3180,7 +3287,7 @@ pub fn run(opts: DoctorOptions) {
     let rate_limit_key_strategy = resolve_rate_limit_key_strategy();
     let auth_extractor_mounted = resolve_auth_extractor_mounted();
     let compression_enabled = resolve_compression_enabled();
-    let (alert_email, alert_webhook_configured) = resolve_alert_destination();
+    let (alert_email, alert_webhook_configured, alert_webhook_url) = resolve_alert_destination();
     let alerts_enabled = resolve_alert_enabled();
     let proxy_conflict_data = resolve_proxy_conflict_data();
     let (dotenv_has_example, dotenv_has_env, dotenv_uncovered) = resolve_dotenv_state();
@@ -3409,6 +3516,7 @@ pub fn run(opts: DoctorOptions) {
             alerts_enabled,
             &alert_email,
             alert_webhook_configured,
+            &alert_webhook_url,
             mail_transport_usable,
             is_production,
             mail_from_present,
@@ -4708,6 +4816,39 @@ pub struct Vault {
     }
 
     #[test]
+    fn is_absolute_http_url_doctor_matches_runtime_absoluteness() {
+        // Runtime (`http_client::Client::build_request`) treats a URL as absolute
+        // iff it starts with `http://` or `https://`. Accept BOTH schemes — the
+        // runtime does not require TLS for a webhook, so neither may doctor
+        // (rejecting `http://` would be a false-positive warning).
+        assert!(is_absolute_http_url_doctor(
+            "https://alerts.example.com/hooks"
+        ));
+        assert!(is_absolute_http_url_doctor(
+            "http://alerts.example.com/hooks"
+        ));
+        // A query string / userinfo / non-standard port is fine: the runtime posts
+        // the URL verbatim, so doctor must not reject what delivers (unlike the
+        // stricter https-base-url validator).
+        assert!(is_absolute_http_url_doctor(
+            "https://user@h.example.com/x?a=1"
+        ));
+        assert!(is_absolute_http_url_doctor("http://h.example.com:8080/x"));
+        // Relative values never carry the scheme prefix runtime requires, and an
+        // alert webhook has no base-url alias to resolve them against.
+        assert!(!is_absolute_http_url_doctor("hooks.example/x"));
+        assert!(!is_absolute_http_url_doctor("/hooks/autumn"));
+        assert!(!is_absolute_http_url_doctor("alerts.example.com"));
+        assert!(!is_absolute_http_url_doctor(""));
+        // Non-http(s) schemes are not dispatched by the client as absolute here.
+        assert!(!is_absolute_http_url_doctor("ftp://h.example.com/x"));
+        assert!(!is_absolute_http_url_doctor("ws://h.example.com/x"));
+        // Carries the prefix but has no host reqwest can send to.
+        assert!(!is_absolute_http_url_doctor("https://"));
+        assert!(!is_absolute_http_url_doctor("http://"));
+    }
+
+    #[test]
     fn is_valid_bare_mailbox_rejects_mailto_uri_and_accepts_bare() {
         // Bare recipient mailboxes are accepted (this is what lettre parses at
         // send time for `[alerts] email`).
@@ -4944,7 +5085,7 @@ pub struct Vault {
 
     #[test]
     fn alert_destination_warns_in_production_when_none() {
-        let r = check_alert_destination_impl(true, "", false, true, true, true, true);
+        let r = check_alert_destination_impl(true, "", false, "", true, true, true, true);
         assert_eq!(r.name, "alert_destination");
         assert!(matches!(r.status, CheckStatus::Warn));
         assert!(r.hint.is_some());
@@ -4952,20 +5093,28 @@ pub struct Vault {
 
     #[test]
     fn alert_destination_passes_in_production_with_email() {
-        let r =
-            check_alert_destination_impl(true, "ops@example.com", false, true, true, true, true);
+        let r = check_alert_destination_impl(
+            true,
+            "ops@example.com",
+            false,
+            "",
+            true,
+            true,
+            true,
+            true,
+        );
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
     #[test]
     fn alert_destination_passes_in_production_with_webhook() {
-        let r = check_alert_destination_impl(true, "", true, true, true, true, true);
+        let r = check_alert_destination_impl(true, "", true, "", true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
     #[test]
     fn alert_destination_passes_in_dev_without_destination() {
-        let r = check_alert_destination_impl(true, "", false, true, false, true, true);
+        let r = check_alert_destination_impl(true, "", false, "", true, false, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
@@ -4993,6 +5142,7 @@ pub struct Vault {
             true,
             "ops@example.com",
             webhook,
+            "",
             usable,
             true,
             true,
@@ -5025,6 +5175,7 @@ pub struct Vault {
             true,
             "ops@example.com",
             webhook,
+            "",
             transport != "disabled",
             true,
             true,
@@ -5068,6 +5219,7 @@ pub struct Vault {
             true,
             "ops@example.com",
             false,
+            "",
             transport != "disabled",
             true,
             mail_from_present,
@@ -5092,6 +5244,7 @@ pub struct Vault {
             true,
             "ops@example.com",
             false,
+            "",
             transport != "disabled",
             true,
             mail_from_present,
@@ -5126,6 +5279,7 @@ pub struct Vault {
             true,
             "ops@example.com",
             false,
+            "",
             transport != "disabled",
             true,
             mail_from_present,
@@ -5153,6 +5307,7 @@ pub struct Vault {
             true,
             "not-an-address",
             false,
+            "",
             true, // usable transport
             true, // production
             true, // [mail] from present
@@ -5184,6 +5339,7 @@ pub struct Vault {
             true,
             "not-an-address",
             false,
+            "",
             true,
             false, // dev
             true,
@@ -5199,8 +5355,16 @@ pub struct Vault {
     fn alert_destination_valid_plus_addressing_passes_in_prod() {
         // A perfectly valid address using `+` sub-addressing and a multi-label
         // domain must NOT be rejected — the validity check must not over-reject.
-        let r =
-            check_alert_destination_impl(true, "a+b@sub.example.co", false, true, true, true, true);
+        let r = check_alert_destination_impl(
+            true,
+            "a+b@sub.example.co",
+            false,
+            "",
+            true,
+            true,
+            true,
+            true,
+        );
         assert!(
             matches!(r.status, CheckStatus::Pass),
             "a valid `+`-addressed, multi-label-domain email is a working destination"
@@ -5219,6 +5383,7 @@ pub struct Vault {
             true,
             "mailto:oncall@example.com",
             false,
+            "",
             true, // usable transport
             true, // production
             true, // [mail] from present
@@ -5250,6 +5415,7 @@ pub struct Vault {
             false, // alerting disabled
             "not-an-address",
             false,
+            "",
             true,
             true,
             true,
@@ -5278,7 +5444,7 @@ pub struct Vault {
         assert!(!email, "the prod profile cleared the email");
         assert!(webhook, "the signed webhook remains configured");
         // Mail transport disabled — irrelevant to the webhook path.
-        let r = check_alert_destination_impl(true, "", webhook, false, true, true, true);
+        let r = check_alert_destination_impl(true, "", webhook, "", false, true, true, true);
         assert!(
             matches!(r.status, CheckStatus::Pass),
             "a signed webhook is a valid destination regardless of mail transport"
@@ -5315,7 +5481,7 @@ pub struct Vault {
         );
 
         // And the surfaced doctor check warns in production for this config.
-        let r = check_alert_destination_impl(true, "", false, true, true, true, true);
+        let r = check_alert_destination_impl(true, "", false, "", true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Warn));
     }
 
@@ -5382,7 +5548,7 @@ pub struct Vault {
             webhook,
             "webhook_url + webhook_secret must count as configured"
         );
-        let r = check_alert_destination_impl(true, "", webhook, true, true, true, true);
+        let r = check_alert_destination_impl(true, "", webhook, "", true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
@@ -5398,7 +5564,7 @@ pub struct Vault {
             !webhook,
             "a webhook_url with no signing secret is not a destination"
         );
-        let r = check_alert_destination_impl(true, "", webhook, true, true, true, true);
+        let r = check_alert_destination_impl(true, "", webhook, "", true, true, true, true);
         assert!(
             matches!(r.status, CheckStatus::Warn),
             "URL-without-secret in production must warn"
@@ -5420,7 +5586,7 @@ pub struct Vault {
             !webhook,
             "a prod-profile empty webhook_secret must clear the base secret"
         );
-        let r = check_alert_destination_impl(true, "", webhook, true, true, true, true);
+        let r = check_alert_destination_impl(true, "", webhook, "", true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Warn));
 
         // And an empty AUTUMN_ALERTS__WEBHOOK_SECRET env var clears it just the same.
@@ -5431,6 +5597,112 @@ pub struct Vault {
             !webhook_env,
             "an empty AUTUMN_ALERTS__WEBHOOK_SECRET must clear the secret"
         );
+    }
+
+    #[test]
+    fn resolve_alert_destination_absolute_webhook_url_with_secret_passes() {
+        // An absolute https URL + secret is a real destination: the runtime's HTTP
+        // client dispatches it and the signed POST is deliverable → prod passes.
+        let table: toml::Table = toml::from_str(
+            "[alerts]\nwebhook_url = \"https://hooks.example/x\"\nwebhook_secret = \"s3cr3t\"\n",
+        )
+        .unwrap();
+        let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        assert!(!email);
+        assert!(webhook, "absolute https webhook_url + secret is configured");
+        let r = check_alert_destination_impl(
+            true,
+            "",
+            webhook,
+            "https://hooks.example/x",
+            true,
+            true,
+            true,
+            true,
+        );
+        assert!(matches!(r.status, CheckStatus::Pass));
+    }
+
+    #[test]
+    fn resolve_alert_destination_absolute_http_webhook_url_with_secret_passes() {
+        // Runtime treats `http://…` as absolute too (it does not require TLS), so
+        // doctor must accept it — rejecting it would be a false-positive warning.
+        let table: toml::Table = toml::from_str(
+            "[alerts]\nwebhook_url = \"http://hooks.example/x\"\nwebhook_secret = \"s3cr3t\"\n",
+        )
+        .unwrap();
+        let (_email, webhook) =
+            resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        assert!(
+            webhook,
+            "an absolute http:// webhook_url + secret must count, matching runtime"
+        );
+        let r = check_alert_destination_impl(
+            true,
+            "",
+            webhook,
+            "http://hooks.example/x",
+            true,
+            true,
+            true,
+            true,
+        );
+        assert!(matches!(r.status, CheckStatus::Pass));
+    }
+
+    #[test]
+    fn resolve_alert_destination_relative_webhook_url_is_not_configured_and_warns() {
+        // A relative `webhook_url` (no scheme) + secret: the runtime's HTTP client
+        // only dispatches URLs starting with http(s)://, and an alert webhook has
+        // no base-url alias to resolve a relative value against, so EVERY signed
+        // POST fails. doctor must NOT count it and must emit its DEDICATED warning
+        // naming the value in production — not the generic "no destination" one.
+        let table: toml::Table = toml::from_str(
+            "[alerts]\nwebhook_url = \"hooks.example/x\"\nwebhook_secret = \"s3cr3t\"\n",
+        )
+        .unwrap();
+        let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        assert!(!email);
+        assert!(
+            !webhook,
+            "a relative webhook_url is not an absolute http(s) URL, so it is not a destination"
+        );
+        let r = check_alert_destination_impl(
+            true,
+            "",
+            webhook,
+            "hooks.example/x",
+            true,
+            true,
+            true,
+            true,
+        );
+        assert!(
+            matches!(r.status, CheckStatus::Warn),
+            "a relative webhook_url in production must warn"
+        );
+        let detail = r.detail.unwrap_or_default();
+        assert!(
+            detail.contains("not an absolute http(s) URL") && detail.contains("hooks.example/x"),
+            "the warning must name the offending value and its cause, got: {detail}"
+        );
+    }
+
+    #[test]
+    fn alert_destination_relative_webhook_url_is_lenient_in_dev() {
+        // Outside production the check stays lenient — a malformed webhook URL is
+        // not fatal locally, so it passes quietly like the rest of this check.
+        let r = check_alert_destination_impl(
+            true,
+            "",
+            false,
+            "hooks.example/x",
+            true,
+            false, // dev
+            true,
+            true,
+        );
+        assert!(matches!(r.status, CheckStatus::Pass));
     }
 
     // ── merged-config view (issue #1610) ──────────────────────────────────────
@@ -5474,7 +5746,7 @@ pub struct Vault {
             !email,
             "an autumn-prod.toml that clears [alerts].email must resolve as no destination"
         );
-        let r = check_alert_destination_impl(true, "", false, true, true, true, true);
+        let r = check_alert_destination_impl(true, "", false, "", true, true, true, true);
         assert!(
             matches!(r.status, CheckStatus::Warn),
             "a production deploy whose override file cleared the only alert channel must WARN"
@@ -5513,8 +5785,16 @@ pub struct Vault {
         let (email, webhook) = resolve_alert_destination_from_sources(no_env, Some(&merged), "");
         assert!(email);
         assert!(!webhook);
-        let r =
-            check_alert_destination_impl(true, "ops@example.com", webhook, true, true, true, true);
+        let r = check_alert_destination_impl(
+            true,
+            "ops@example.com",
+            webhook,
+            "",
+            true,
+            true,
+            true,
+            true,
+        );
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
@@ -5537,7 +5817,7 @@ pub struct Vault {
             !webhook,
             "a webhook whose secret was cleared by the override file is not a signed destination"
         );
-        let r = check_alert_destination_impl(true, "", webhook, true, true, true, true);
+        let r = check_alert_destination_impl(true, "", webhook, "", true, true, true, true);
         assert!(matches!(r.status, CheckStatus::Warn));
 
         // With both left intact through the merged view, the webhook still counts.
@@ -5625,6 +5905,7 @@ pub struct Vault {
             enabled,
             "ops@example.com",
             webhook,
+            "",
             true,
             true,
             true,
@@ -5654,6 +5935,7 @@ pub struct Vault {
             enabled,
             "ops@example.com",
             webhook,
+            "",
             true,
             true,
             true,
@@ -5675,6 +5957,7 @@ pub struct Vault {
             enabled,
             "ops@example.com",
             webhook,
+            "",
             true,
             true,
             true,
@@ -5695,6 +5978,7 @@ pub struct Vault {
             enabled,
             "ops@example.com",
             webhook,
+            "",
             true,
             false,
             true,

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -495,6 +495,54 @@ fn alert_webhook_url_invalid_warning(url: &str) -> CheckResult {
     }
 }
 
+/// Resolve the production result when no `[alerts]` email/webhook destination is
+/// configured and no earlier value-validation warning fired.
+///
+/// When `custom_channel` is true the operator has DECLARED, via `[alerts]
+/// custom_channel = true` (or `AUTUMN_ALERTS__CUSTOM_CHANNEL`), that they register
+/// an alert channel in code with `AppBuilder::with_alert_channel`. The runtime
+/// installs code-registered channels regardless, so the destination is treated as
+/// present and the check passes — the sanctioned way to satisfy `autumn doctor
+/// --strict` for a code-only alert setup. Otherwise there is genuinely nowhere to
+/// deliver, so it warns and points at the flag. This runs AFTER every
+/// value-validation warning, so `custom_channel` only suppresses the pure "no
+/// destination configured" fall-through, never a broken *configured* destination.
+/// Extracted so [`check_alert_destination_impl`] stays under the line-count lint.
+fn alert_no_destination_in_production(custom_channel: bool) -> CheckResult {
+    if custom_channel {
+        return CheckResult {
+            name: "alert_destination",
+            status: CheckStatus::Pass,
+            detail: Some(
+                "no [alerts] email/webhook destination configured, but [alerts] \
+                 custom_channel = true declares a code-registered alert channel \
+                 (AppBuilder::with_alert_channel), which the runtime installs regardless"
+                    .into(),
+            ),
+            hint: None,
+        };
+    }
+    CheckResult {
+        name: "alert_destination",
+        status: CheckStatus::Warn,
+        detail: Some(
+            "no operator alert destination found in [alerts] config (email or webhook) in \
+             production; if your app registers an alert channel in code via \
+             AppBuilder::with_alert_channel, set [alerts] custom_channel = true (or \
+             AUTUMN_ALERTS__CUSTOM_CHANNEL=true) to declare that and silence this warning \
+             (doctor is a config-only checker and cannot see code-registered channels); \
+             otherwise failure conditions (dead-lettered jobs, Down health indicators, 5xx \
+             spikes, scheduled-task failures) will not be delivered anywhere"
+                .into(),
+        ),
+        hint: Some(
+            "Set [alerts] email and/or webhook_url (or AUTUMN_ALERTS__EMAIL / \
+             AUTUMN_ALERTS__WEBHOOK_URL); or if you register a channel in code, set [alerts] \
+             custom_channel = true. See docs/guide/operator-alerts.md",
+        ),
+    }
+}
+
 /// Dedicated production warning for the `[alerts] enabled = false` master switch:
 /// the runtime (`alerts::install_from_config`) returns BEFORE installing any
 /// `Alerter`, so NO operator alerts are delivered regardless of a configured
@@ -539,6 +587,7 @@ pub fn check_alert_destination_impl(
     is_production: bool,
     mail_from_present: bool,
     transport_requires_from: bool,
+    custom_channel: bool,
 ) -> CheckResult {
     // Presence and syntactic validity of the resolved `[alerts] email`. lettre
     // parses the recipient only at SEND time (`lettre_message`), not when the
@@ -657,23 +706,11 @@ pub fn check_alert_destination_impl(
         if !webhook_url_trimmed.is_empty() && !is_absolute_http_url_doctor(webhook_url_trimmed) {
             return alert_webhook_url_invalid_warning(webhook_url_trimmed);
         }
-        CheckResult {
-            name: "alert_destination",
-            status: CheckStatus::Warn,
-            detail: Some(
-                "no operator alert destination found in [alerts] config (email or webhook) in \
-                 production; if your app registers an alert channel in code via \
-                 AppBuilder::with_alert_channel, alerts will still be delivered and this warning \
-                 can be ignored (doctor is a config-only checker and cannot see code-registered \
-                 channels); otherwise failure conditions (dead-lettered jobs, Down health \
-                 indicators, 5xx spikes, scheduled-task failures) will not be delivered anywhere"
-                    .into(),
-            ),
-            hint: Some(
-                "Set [alerts] email and/or webhook_url (or AUTUMN_ALERTS__EMAIL / \
-                 AUTUMN_ALERTS__WEBHOOK_URL). See docs/guide/operator-alerts.md",
-            ),
-        }
+        // No config destination resolved. Either the operator has DECLARED a
+        // code-registered channel via `[alerts] custom_channel = true` (pass), or
+        // there is genuinely nowhere to deliver (warn). Extracted so this function
+        // stays under the line-count lint.
+        alert_no_destination_in_production(custom_channel)
     } else {
         CheckResult {
             name: "alert_destination",
@@ -3173,6 +3210,90 @@ where
     true
 }
 
+/// Resolve the effective `[alerts] custom_channel` flag the same way the runtime
+/// config merge and `AlertConfig::default().custom_channel` (default `false`)
+/// do.
+///
+/// This is a doctor-only declaration: when true, the operator asserts they
+/// register an alert channel in code via `AppBuilder::with_alert_channel`, so the
+/// no-destination warning is suppressed. The runtime installs code-registered
+/// channels regardless of this flag; it exists purely so `autumn doctor --strict`
+/// can pass a validly-configured code-only alert setup.
+fn resolve_alert_custom_channel() -> bool {
+    // Mirror `resolve_alert_enabled`'s profile selection and merged-table build so
+    // `custom_channel` resolves against the same effective config the runtime
+    // boots with, env vars still highest priority.
+    let selected_input = std::env::var("AUTUMN_ENV")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| {
+            std::env::var("AUTUMN_PROFILE")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+        })
+        .unwrap_or_default()
+        .trim()
+        .to_owned();
+    let normalized_profile = normalize_alert_profile(&selected_input);
+    // The merge flattens the active profile into the top-level `[alerts]`, so
+    // resolve against an EMPTY profile (mirroring `resolve_alert_enabled`).
+    let merged = get_merged_toml_table_runtime(&normalized_profile, &selected_input);
+    resolve_alert_custom_channel_from_sources(|key| std::env::var(key).ok(), Some(&merged), "")
+}
+
+/// Resolve the effective `[alerts] custom_channel` flag under the same layer
+/// precedence the runtime config merge applies (env
+/// `AUTUMN_ALERTS__CUSTOM_CHANNEL` > `[profile.{profile}.alerts].custom_channel` >
+/// base `[alerts].custom_channel`), defaulting to `false` when unset — matching
+/// `AlertConfig::default().custom_channel`.
+///
+/// Env parsing mirrors the runtime's `parse_env_bool`: `true`/`1` enable,
+/// `false`/`0` disable, and any other value is ignored (falls through to the TOML
+/// layers). Split out from [`resolve_alert_custom_channel`] so the precedence is
+/// unit-testable without mutating process-global env/cwd state.
+fn resolve_alert_custom_channel_from_sources<F>(
+    env_var: F,
+    table: Option<&toml::Table>,
+    profile: &str,
+) -> bool
+where
+    F: Fn(&str) -> Option<String>,
+{
+    // 1. Env var — highest priority, mirroring runtime `parse_env_bool`. An
+    //    invalid value (not true/false/1/0) is ignored and falls through.
+    if let Some(val) = env_var("AUTUMN_ALERTS__CUSTOM_CHANNEL") {
+        match val.as_str() {
+            "true" | "1" => return true,
+            "false" | "0" => return false,
+            _ => {}
+        }
+    }
+    // 2. Profile-specific `[profile.{profile}.alerts].custom_channel`.
+    if !profile.is_empty()
+        && let Some(v) = table
+            .and_then(|t| t.get("profile"))
+            .and_then(|v| v.get(profile))
+            .and_then(toml::Value::as_table)
+            .and_then(|p| p.get("alerts"))
+            .and_then(toml::Value::as_table)
+            .and_then(|a| a.get("custom_channel"))
+            .and_then(toml::Value::as_bool)
+    {
+        return v;
+    }
+    // 3. Base `[alerts].custom_channel`.
+    if let Some(v) = table
+        .and_then(|t| t.get("alerts"))
+        .and_then(toml::Value::as_table)
+        .and_then(|a| a.get("custom_channel"))
+        .and_then(toml::Value::as_bool)
+    {
+        return v;
+    }
+    // 4. Unset everywhere → false (mirrors `AlertConfig::default()`).
+    false
+}
+
 /// Resolve whether the active profile is production from the environment or
 /// `autumn.toml`.
 fn resolve_is_production() -> bool {
@@ -3288,6 +3409,7 @@ pub fn run(opts: DoctorOptions) {
     let compression_enabled = resolve_compression_enabled();
     let (alert_email, alert_webhook_configured, alert_webhook_url) = resolve_alert_destination();
     let alerts_enabled = resolve_alert_enabled();
+    let alert_custom_channel = resolve_alert_custom_channel();
     let proxy_conflict_data = resolve_proxy_conflict_data();
     let (dotenv_has_example, dotenv_has_env, dotenv_uncovered) = resolve_dotenv_state();
 
@@ -3520,6 +3642,7 @@ pub fn run(opts: DoctorOptions) {
             is_production,
             mail_from_present,
             transport_requires_from,
+            alert_custom_channel,
         )
     }));
 
@@ -5113,7 +5236,7 @@ pub struct Vault {
 
     #[test]
     fn alert_destination_warns_in_production_when_none() {
-        let r = check_alert_destination_impl(true, "", false, "", true, true, true, true);
+        let r = check_alert_destination_impl(true, "", false, "", true, true, true, true, false);
         assert_eq!(r.name, "alert_destination");
         assert!(matches!(r.status, CheckStatus::Warn));
         assert!(r.hint.is_some());
@@ -5130,19 +5253,20 @@ pub struct Vault {
             true,
             true,
             true,
+            false,
         );
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
     #[test]
     fn alert_destination_passes_in_production_with_webhook() {
-        let r = check_alert_destination_impl(true, "", true, "", true, true, true, true);
+        let r = check_alert_destination_impl(true, "", true, "", true, true, true, true, false);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
     #[test]
     fn alert_destination_passes_in_dev_without_destination() {
-        let r = check_alert_destination_impl(true, "", false, "", true, false, true, true);
+        let r = check_alert_destination_impl(true, "", false, "", true, false, true, true, false);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
@@ -5175,6 +5299,7 @@ pub struct Vault {
             true,
             true,
             true,
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Warn),
@@ -5208,6 +5333,7 @@ pub struct Vault {
             true,
             true,
             requires_from,
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Pass),
@@ -5252,6 +5378,7 @@ pub struct Vault {
             true,
             mail_from_present,
             requires_from,
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Pass),
@@ -5277,6 +5404,7 @@ pub struct Vault {
             true,
             mail_from_present,
             requires_from,
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Warn),
@@ -5312,6 +5440,7 @@ pub struct Vault {
             true,
             mail_from_present,
             requires_from,
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Pass),
@@ -5336,10 +5465,11 @@ pub struct Vault {
             "not-an-address",
             false,
             "",
-            true, // usable transport
-            true, // production
-            true, // [mail] from present
-            true, // smtp requires from
+            true,  // usable transport
+            true,  // production
+            true,  // [mail] from present
+            true,  // smtp requires from
+            false, // custom_channel
         );
         assert!(
             matches!(r.status, CheckStatus::Warn),
@@ -5372,6 +5502,7 @@ pub struct Vault {
             false, // dev
             true,
             true,
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Pass),
@@ -5392,6 +5523,7 @@ pub struct Vault {
             true,
             true,
             true,
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Pass),
@@ -5412,10 +5544,11 @@ pub struct Vault {
             "mailto:oncall@example.com",
             false,
             "",
-            true, // usable transport
-            true, // production
-            true, // [mail] from present
-            true, // smtp requires from
+            true,  // usable transport
+            true,  // production
+            true,  // [mail] from present
+            true,  // smtp requires from
+            false, // custom_channel
         );
         assert!(
             matches!(r.status, CheckStatus::Warn),
@@ -5448,6 +5581,7 @@ pub struct Vault {
             true,
             true,
             true,
+            false,
         );
         assert!(matches!(r.status, CheckStatus::Warn));
         assert!(
@@ -5472,7 +5606,7 @@ pub struct Vault {
         assert!(!email, "the prod profile cleared the email");
         assert!(webhook, "the signed webhook remains configured");
         // Mail transport disabled — irrelevant to the webhook path.
-        let r = check_alert_destination_impl(true, "", webhook, "", false, true, true, true);
+        let r = check_alert_destination_impl(true, "", webhook, "", false, true, true, true, false);
         assert!(
             matches!(r.status, CheckStatus::Pass),
             "a signed webhook is a valid destination regardless of mail transport"
@@ -5509,7 +5643,7 @@ pub struct Vault {
         );
 
         // And the surfaced doctor check warns in production for this config.
-        let r = check_alert_destination_impl(true, "", false, "", true, true, true, true);
+        let r = check_alert_destination_impl(true, "", false, "", true, true, true, true, false);
         assert!(matches!(r.status, CheckStatus::Warn));
     }
 
@@ -5576,7 +5710,7 @@ pub struct Vault {
             webhook,
             "webhook_url + webhook_secret must count as configured"
         );
-        let r = check_alert_destination_impl(true, "", webhook, "", true, true, true, true);
+        let r = check_alert_destination_impl(true, "", webhook, "", true, true, true, true, false);
         assert!(matches!(r.status, CheckStatus::Pass));
     }
 
@@ -5592,7 +5726,7 @@ pub struct Vault {
             !webhook,
             "a webhook_url with no signing secret is not a destination"
         );
-        let r = check_alert_destination_impl(true, "", webhook, "", true, true, true, true);
+        let r = check_alert_destination_impl(true, "", webhook, "", true, true, true, true, false);
         assert!(
             matches!(r.status, CheckStatus::Warn),
             "URL-without-secret in production must warn"
@@ -5614,7 +5748,7 @@ pub struct Vault {
             !webhook,
             "a prod-profile empty webhook_secret must clear the base secret"
         );
-        let r = check_alert_destination_impl(true, "", webhook, "", true, true, true, true);
+        let r = check_alert_destination_impl(true, "", webhook, "", true, true, true, true, false);
         assert!(matches!(r.status, CheckStatus::Warn));
 
         // And an empty AUTUMN_ALERTS__WEBHOOK_SECRET env var clears it just the same.
@@ -5647,6 +5781,7 @@ pub struct Vault {
             true,
             true,
             true,
+            false,
         );
         assert!(matches!(r.status, CheckStatus::Pass));
     }
@@ -5674,6 +5809,7 @@ pub struct Vault {
             true,
             true,
             true,
+            false,
         );
         assert!(matches!(r.status, CheckStatus::Pass));
     }
@@ -5704,6 +5840,7 @@ pub struct Vault {
             true,
             true,
             true,
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Warn),
@@ -5729,6 +5866,7 @@ pub struct Vault {
             false, // dev
             true,
             true,
+            false,
         );
         assert!(matches!(r.status, CheckStatus::Pass));
     }
@@ -5774,7 +5912,7 @@ pub struct Vault {
             !email,
             "an autumn-prod.toml that clears [alerts].email must resolve as no destination"
         );
-        let r = check_alert_destination_impl(true, "", false, "", true, true, true, true);
+        let r = check_alert_destination_impl(true, "", false, "", true, true, true, true, false);
         assert!(
             matches!(r.status, CheckStatus::Warn),
             "a production deploy whose override file cleared the only alert channel must WARN"
@@ -5822,6 +5960,7 @@ pub struct Vault {
             true,
             true,
             true,
+            false,
         );
         assert!(matches!(r.status, CheckStatus::Pass));
     }
@@ -5845,7 +5984,7 @@ pub struct Vault {
             !webhook,
             "a webhook whose secret was cleared by the override file is not a signed destination"
         );
-        let r = check_alert_destination_impl(true, "", webhook, "", true, true, true, true);
+        let r = check_alert_destination_impl(true, "", webhook, "", true, true, true, true, false);
         assert!(matches!(r.status, CheckStatus::Warn));
 
         // With both left intact through the merged view, the webhook still counts.
@@ -5938,6 +6077,7 @@ pub struct Vault {
             true,
             true,
             true,
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Warn),
@@ -5968,6 +6108,7 @@ pub struct Vault {
             true,
             true,
             true,
+            false,
         );
         assert!(matches!(r.status, CheckStatus::Warn));
     }
@@ -5990,6 +6131,7 @@ pub struct Vault {
             true,
             true,
             true,
+            false,
         );
         assert!(matches!(r.status, CheckStatus::Pass));
     }
@@ -6011,11 +6153,155 @@ pub struct Vault {
             false,
             true,
             true,
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Pass),
             "dev-mode leniency: disabled alerting must not warn outside production"
         );
+    }
+
+    // ── [alerts] custom_channel declaration (issue #1610 follow-up) ───────────
+    // An app that delivers alerts ONLY via `AppBuilder::with_alert_channel`
+    // (code, not config) still triggered doctor's no-destination Warn, which
+    // `--strict` turns into exit 1. `[alerts] custom_channel = true` lets the
+    // operator DECLARE the code-registered channel so the pure no-destination
+    // fall-through passes — while a *broken configured* destination still warns.
+
+    #[test]
+    fn alert_destination_custom_channel_passes_in_prod_without_destination() {
+        // custom_channel = true + no email/webhook in prod → PASS (not Warn), so
+        // `autumn doctor --strict` succeeds for a code-only alert setup.
+        let r = check_alert_destination_impl(
+            true, "", false, "", true, true, true, true, /* custom_channel */ true,
+        );
+        assert!(
+            matches!(r.status, CheckStatus::Pass),
+            "custom_channel = true declares a code-registered channel → no-destination must pass"
+        );
+        assert!(
+            r.detail
+                .as_deref()
+                .is_some_and(|d| d.contains("custom_channel")),
+            "the pass detail should name the custom_channel declaration"
+        );
+    }
+
+    #[test]
+    fn alert_destination_without_custom_channel_still_warns_in_prod() {
+        // custom_channel = false (default) + no destination in prod → still Warn,
+        // preserving the pre-existing behavior; the warning now points at the flag.
+        let r = check_alert_destination_impl(
+            true, "", false, "", true, true, true, true, /* custom_channel */ false,
+        );
+        assert!(matches!(r.status, CheckStatus::Warn));
+        assert!(
+            r.detail
+                .as_deref()
+                .is_some_and(|d| d.contains("custom_channel")),
+            "the no-destination warning should mention the custom_channel escape hatch"
+        );
+    }
+
+    #[test]
+    fn alert_destination_custom_channel_does_not_mask_broken_webhook() {
+        // custom_channel = true but a CONFIGURED webhook_url is relative/invalid →
+        // STILL warns about the broken value. custom_channel only suppresses the
+        // pure "no destination configured" fall-through, never a misconfigured one.
+        let r = check_alert_destination_impl(
+            true,
+            "",
+            false, // relative URL is not a usable webhook, so webhook_configured is false
+            "not-a-url/hooks", // present but non-absolute → dedicated invalid warning
+            true,
+            true,
+            true,
+            true,
+            /* custom_channel */ true,
+        );
+        assert!(
+            matches!(r.status, CheckStatus::Warn),
+            "a broken configured webhook_url must still warn even with custom_channel = true"
+        );
+        assert!(
+            r.detail
+                .as_deref()
+                .is_some_and(|d| d.contains("not an absolute")),
+            "the broken-webhook warning must fire, not the custom_channel pass"
+        );
+    }
+
+    #[test]
+    fn resolve_alert_custom_channel_defaults_false_when_unset() {
+        let table: toml::Table = toml::from_str("[alerts]\nemail = \"ops@example.com\"\n").unwrap();
+        assert!(!resolve_alert_custom_channel_from_sources(
+            no_env,
+            Some(&table),
+            "prod"
+        ));
+        assert!(!resolve_alert_custom_channel_from_sources(
+            no_env, None, "prod"
+        ));
+    }
+
+    #[test]
+    fn resolve_alert_custom_channel_base_true_is_detected() {
+        let table: toml::Table = toml::from_str("[alerts]\ncustom_channel = true\n").unwrap();
+        assert!(resolve_alert_custom_channel_from_sources(
+            no_env,
+            Some(&table),
+            "prod"
+        ));
+    }
+
+    #[test]
+    fn resolve_alert_custom_channel_env_true_overrides_base_false() {
+        let table: toml::Table = toml::from_str("[alerts]\ncustom_channel = false\n").unwrap();
+        let env = |k: &str| (k == "AUTUMN_ALERTS__CUSTOM_CHANNEL").then(|| "true".to_owned());
+        assert!(resolve_alert_custom_channel_from_sources(
+            env,
+            Some(&table),
+            "prod"
+        ));
+        let env1 = |k: &str| (k == "AUTUMN_ALERTS__CUSTOM_CHANNEL").then(|| "1".to_owned());
+        assert!(resolve_alert_custom_channel_from_sources(
+            env1,
+            Some(&table),
+            "prod"
+        ));
+    }
+
+    #[test]
+    fn resolve_alert_custom_channel_env_resolves_and_passes() {
+        // End-to-end at the resolver + check boundary: env sets the flag true, and
+        // with no configured destination in prod the check passes.
+        let table: toml::Table = toml::from_str("[alerts]\nemail = \"ops@example.com\"\n").unwrap();
+        let env = |k: &str| (k == "AUTUMN_ALERTS__CUSTOM_CHANNEL").then(|| "true".to_owned());
+        let custom = resolve_alert_custom_channel_from_sources(env, Some(&table), "prod");
+        assert!(
+            custom,
+            "AUTUMN_ALERTS__CUSTOM_CHANNEL=true must resolve true"
+        );
+        let r = check_alert_destination_impl(true, "", false, "", true, true, true, true, custom);
+        assert!(matches!(r.status, CheckStatus::Pass));
+    }
+
+    #[test]
+    fn resolve_alert_custom_channel_profile_true_overrides_base_false() {
+        let table: toml::Table = toml::from_str(
+            "[alerts]\ncustom_channel = false\n[profile.prod.alerts]\ncustom_channel = true\n",
+        )
+        .unwrap();
+        assert!(resolve_alert_custom_channel_from_sources(
+            no_env,
+            Some(&table),
+            "prod"
+        ));
+        assert!(!resolve_alert_custom_channel_from_sources(
+            no_env,
+            Some(&table),
+            ""
+        ));
     }
 
     // ── compute_summary ──────────────────────────────────────────────────────

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2594,6 +2594,11 @@ fn resolve_alert_destination() -> (bool, bool) {
 /// Layers, highest first: env var, `[profile.{profile}.alerts]`, base
 /// `[alerts]`. Only a layer that omits the key entirely falls through.
 ///
+/// A webhook counts as configured only when BOTH `webhook_url` and
+/// `webhook_secret` resolve non-empty under this precedence — mirroring the
+/// runtime, which never registers an unsigned webhook channel — so a webhook URL
+/// with a missing or cleared secret is not a destination.
+///
 /// Split out from [`resolve_alert_destination`] so the precedence logic is unit
 /// testable without mutating process-global env/cwd state.
 fn resolve_alert_destination_from_sources<F>(
@@ -2641,7 +2646,15 @@ where
     };
 
     let email = resolve("AUTUMN_ALERTS__EMAIL", "email");
-    let webhook = resolve("AUTUMN_ALERTS__WEBHOOK_URL", "webhook_url");
+    // A webhook destination requires BOTH a URL and a signing secret to be a real
+    // destination: the runtime (`alerts::install_from_config`) refuses to register
+    // an unsigned webhook channel, so a URL with a missing/cleared secret installs
+    // NO channel. Count the webhook only when both resolve non-empty under the same
+    // per-field precedence, so doctor agrees with runtime (URL-without-secret is
+    // NOT a destination → in production with no other destination, doctor warns).
+    let webhook_url = resolve("AUTUMN_ALERTS__WEBHOOK_URL", "webhook_url");
+    let webhook_secret = resolve("AUTUMN_ALERTS__WEBHOOK_SECRET", "webhook_secret");
+    let webhook = webhook_url && webhook_secret;
     (email, webhook)
 }
 
@@ -4563,8 +4576,10 @@ pub struct Vault {
     fn resolve_alert_destination_empty_env_clears_base_email() {
         // An explicitly-empty AUTUMN_ALERTS__EMAIL is the highest-priority layer
         // and must CLEAR a base value; an unset webhook var falls through to base.
+        // The base carries BOTH a webhook_url and a webhook_secret so the webhook
+        // is a real (signed) destination.
         let table: toml::Table = toml::from_str(
-            "[alerts]\nemail = \"dev@example.com\"\nwebhook_url = \"https://hooks.example/x\"\n",
+            "[alerts]\nemail = \"dev@example.com\"\nwebhook_url = \"https://hooks.example/x\"\nwebhook_secret = \"s3cr3t\"\n",
         )
         .unwrap();
         let env = |key: &str| (key == "AUTUMN_ALERTS__EMAIL").then(String::new);
@@ -4576,12 +4591,81 @@ pub struct Vault {
 
     #[test]
     fn resolve_alert_destination_nonempty_env_wins_over_absent_toml() {
-        let env = |key: &str| {
-            (key == "AUTUMN_ALERTS__WEBHOOK_URL").then(|| "https://hooks.example/y".to_owned())
+        // Env supplies both the webhook URL and its signing secret, so the webhook
+        // resolves as a real signed destination with no TOML present.
+        let env = |key: &str| match key {
+            "AUTUMN_ALERTS__WEBHOOK_URL" => Some("https://hooks.example/y".to_owned()),
+            "AUTUMN_ALERTS__WEBHOOK_SECRET" => Some("s3cr3t".to_owned()),
+            _ => None,
         };
         let (email, webhook) = resolve_alert_destination_from_sources(env, None, "prod");
         assert!(!email);
         assert!(webhook, "env webhook should resolve as configured with no TOML");
+    }
+
+    #[test]
+    fn resolve_alert_destination_webhook_requires_secret() {
+        // (a) URL + secret both set at base → webhook is a real destination and a
+        // production run passes.
+        let table: toml::Table = toml::from_str(
+            "[alerts]\nwebhook_url = \"https://hooks.example/x\"\nwebhook_secret = \"s3cr3t\"\n",
+        )
+        .unwrap();
+        let (email, webhook) =
+            resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        assert!(!email);
+        assert!(webhook, "webhook_url + webhook_secret must count as configured");
+        let r = check_alert_destination_impl(email, webhook, true);
+        assert!(matches!(r.status, CheckStatus::Pass));
+    }
+
+    #[test]
+    fn resolve_alert_destination_webhook_url_without_secret_is_not_configured() {
+        // (b) URL set but secret MISSING → runtime installs no (unsigned) channel,
+        // so doctor must NOT count it and must warn in production.
+        let table: toml::Table =
+            toml::from_str("[alerts]\nwebhook_url = \"https://hooks.example/x\"\n").unwrap();
+        let (email, webhook) =
+            resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        assert!(!email);
+        assert!(
+            !webhook,
+            "a webhook_url with no signing secret is not a destination"
+        );
+        let r = check_alert_destination_impl(email, webhook, true);
+        assert!(
+            matches!(r.status, CheckStatus::Warn),
+            "URL-without-secret in production must warn"
+        );
+    }
+
+    #[test]
+    fn resolve_alert_destination_prod_profile_clears_webhook_secret() {
+        // (c) URL + secret set at base, but the prod profile CLEARS the secret with
+        // an empty string → the higher (profile) layer wins, so the webhook is not
+        // a signed destination and doctor warns in production.
+        let table: toml::Table = toml::from_str(
+            "[alerts]\nwebhook_url = \"https://hooks.example/x\"\nwebhook_secret = \"s3cr3t\"\n[profile.prod.alerts]\nwebhook_secret = \"\"\n",
+        )
+        .unwrap();
+        let (email, webhook) =
+            resolve_alert_destination_from_sources(no_env, Some(&table), "prod");
+        assert!(!email);
+        assert!(
+            !webhook,
+            "a prod-profile empty webhook_secret must clear the base secret"
+        );
+        let r = check_alert_destination_impl(email, webhook, true);
+        assert!(matches!(r.status, CheckStatus::Warn));
+
+        // And an empty AUTUMN_ALERTS__WEBHOOK_SECRET env var clears it just the same.
+        let env = |key: &str| (key == "AUTUMN_ALERTS__WEBHOOK_SECRET").then(String::new);
+        let (_email, webhook_env) =
+            resolve_alert_destination_from_sources(env, Some(&table), "prod");
+        assert!(
+            !webhook_env,
+            "an empty AUTUMN_ALERTS__WEBHOOK_SECRET must clear the secret"
+        );
     }
 
     // ── compute_summary ──────────────────────────────────────────────────────

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -675,7 +675,15 @@ pub fn alerter(state: &AppState) -> Option<Arc<Alerter>> {
 
 /// Condition (a): a background job was dead-lettered. Called from the job
 /// backends' dead-letter sites. No-op when no alerter is installed.
-pub fn notify_dead_lettered_job(state: &AppState, job_name: &str, error: &str) {
+///
+/// The dedup key is scoped to `job_name` (NOT `job_id`) **by design**: during a
+/// mass failure of one job type the operator gets a bounded number of alerts —
+/// at most one per failing job type per dedup window (AC #3) — rather than one
+/// per dead-lettered instance. So that the bounded alert does not hide which
+/// concrete job failed, the specific `job_id` is threaded into the alert's
+/// human-facing title/summary and its `job_id` detail; the full set of
+/// dead-lettered jobs remains visible at the `/actuator/jobs` endpoint.
+pub fn notify_dead_lettered_job(state: &AppState, job_name: &str, job_id: &str, error: &str) {
     let Some(alerter) = alerter(state) else {
         return;
     };
@@ -683,9 +691,9 @@ pub fn notify_dead_lettered_job(state: &AppState, job_name: &str, error: &str) {
         AlertCondition::DeadLetteredJob,
         format!("dead_lettered_job:{job_name}"),
     )
-    .title(format!("Job '{job_name}' was dead-lettered"))
+    .title(format!("Job '{job_name}' (id {job_id}) was dead-lettered"))
     .summary(format!(
-        "Background job '{job_name}' exhausted its retries and was moved to the dead-letter queue. Last error: {error}"
+        "Background job '{job_name}' (id {job_id}) exhausted its retries and was moved to the dead-letter queue. Last error: {error}"
     ))
     .where_to_look(sensitive_gated_where_to_look(
         &alerter.settings().actuator_prefix,
@@ -693,6 +701,7 @@ pub fn notify_dead_lettered_job(state: &AppState, job_name: &str, error: &str) {
         alerter.settings().actuator_sensitive,
     ))
     .detail("job", job_name)
+    .detail("job_id", job_id)
     .detail("error", error)
     .build();
     let _ = alerter.notify(alert);

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -1,0 +1,1262 @@
+//! Operator alerts connect Autumn's built-in failure signals to its existing
+//! delivery channels — **with zero application code**.
+//!
+//! The signals reach the configured mailer and the signed outbound webhook
+//! behind a small set of `[alerts]` config keys.
+//!
+//! # What this is
+//!
+//! Autumn already knows when things go wrong: a job is dead-lettered, a health
+//! indicator reports `Down`, the 5xx rate spikes, or a framework-scheduled task
+//! fails. Historically an operator had to wire each of those signals to a
+//! notification sink by hand. This module closes that gap: provide an operator
+//! email and/or a webhook URL in `[alerts]` and every built-in condition is
+//! delivered to you, deduplicated, with a recovery notice when it clears.
+//!
+//! ## Built-in alertable conditions
+//!
+//! | Condition | Fires when | Where to look |
+//! |-----------|------------|---------------|
+//! | [`AlertCondition::DeadLetteredJob`] | a background job exhausts its retries and is dead-lettered | `/actuator/jobs` |
+//! | [`AlertCondition::HealthIndicatorDown`] | a registered health indicator reports `Down` past the grace period | `/actuator/health` |
+//! | [`AlertCondition::HighErrorRate`] | the rolling 5xx rate crosses the configured threshold | `/actuator/metrics` |
+//! | [`AlertCondition::ScheduledTaskFailure`] | a framework-scheduled task (backup, cert-renewal, cron/fixed-delay) fails | `/actuator/tasks` |
+//!
+//! # Delivery is a trait (extension point)
+//!
+//! Every destination implements [`AlertChannel`]. The [`Alerter`] holds a
+//! fan-out list of channels and delivers each alert to all of them on a
+//! detached task — so a slow or unreachable channel never adds latency to a
+//! request or blocks the others. Two built-in channels ship:
+//! [`MailAlertChannel`] (reuses the app's [`Mailer`](crate::mail::Mailer)) and
+//! [`WebhookAlertChannel`] (a signed, Stripe-style HMAC POST reusing the same
+//! signing scheme as [`webhook_outbound`](crate::webhook_outbound)).
+//!
+//! **Design intent (follow-up #1630):** PagerDuty / Slack / Discord transports
+//! are added purely by implementing [`AlertChannel`] and registering them with
+//! [`AppBuilder::with_alert_channel`](crate::app::AppBuilder::with_alert_channel);
+//! the core never changes. That is why every [`Alert`] carries a **stable dedup
+//! key** ([`Alert::dedup_key`], which PagerDuty correlates on), a **severity
+//! class** ([`Alert::severity`]), and a **trigger vs resolve** discriminator
+//! ([`Alert::event`]).
+//!
+//! # Deduplication and recovery
+//!
+//! A sustained or repeating condition does **not** produce one notification per
+//! occurrence. [`AlertDeduplicator`] bounds notifications to **at most one per
+//! condition per dedup window** (default 15 minutes); the condition re-notifies
+//! once per window while it persists. When a previously-alerted condition
+//! clears, a single [`AlertEventKind::Resolve`] recovery notification is sent.
+//!
+//! # Fail-safe
+//!
+//! Delivery is best-effort and off the request path: if a channel is
+//! unreachable the app keeps serving, the failure is logged, and no latency is
+//! added. See [`AppBuilder::with_alert_channel`](crate::app::AppBuilder::with_alert_channel)
+//! and `docs/guide/operator-alerts.md` for the full guide.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::state::AppState;
+
+// ── Core value types ────────────────────────────────────────────────────────
+
+/// The built-in condition that produced an [`Alert`].
+///
+/// The condition determines the stable dedup-key prefix and the "where to look
+/// next" actuator pointer. New transports (#1630) match on this to route.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AlertCondition {
+    /// A background job exhausted its retries and was dead-lettered.
+    DeadLetteredJob,
+    /// A registered health indicator reported `Down` past the grace period.
+    HealthIndicatorDown,
+    /// The rolling 5xx error rate crossed the configured threshold.
+    HighErrorRate,
+    /// A framework-scheduled task (cron or fixed-delay) failed.
+    ScheduledTaskFailure,
+}
+
+impl AlertCondition {
+    /// A short, stable machine name for this condition (used in dedup keys and
+    /// webhook payloads).
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::DeadLetteredJob => "dead_lettered_job",
+            Self::HealthIndicatorDown => "health_indicator_down",
+            Self::HighErrorRate => "high_error_rate",
+            Self::ScheduledTaskFailure => "scheduled_task_failure",
+        }
+    }
+
+    /// The actuator endpoint an operator should consult for this condition.
+    #[must_use]
+    pub const fn where_to_look(self) -> &'static str {
+        match self {
+            Self::DeadLetteredJob => "/actuator/jobs",
+            Self::HealthIndicatorDown => "/actuator/health",
+            Self::HighErrorRate => "/actuator/metrics",
+            Self::ScheduledTaskFailure => "/actuator/tasks",
+        }
+    }
+}
+
+/// Severity class of an [`Alert`]. External routers (`PagerDuty` etc.) map this
+/// onto their own severity/priority taxonomy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum AlertSeverity {
+    /// A condition is firing and needs operator attention.
+    Critical,
+    /// A previously-firing condition has recovered (informational).
+    Recovery,
+}
+
+/// Whether this alert opens (trigger) or closes (resolve) a condition. This is
+/// the field an incident manager keys on to auto-resolve a correlated alert.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum AlertEventKind {
+    /// The condition started (or is still) firing.
+    Trigger,
+    /// The condition cleared; correlated triggers may be auto-resolved.
+    Resolve,
+}
+
+/// A single operator alert.
+///
+/// Carries everything AC #4 requires: **what** failed ([`title`](Self::title) /
+/// [`summary`](Self::summary)), **when** ([`timestamp`](Self::timestamp)), on
+/// **which host/replica** ([`host`](Self::host)), and **where to look next**
+/// ([`where_to_look`](Self::where_to_look)) — plus the machine-routing fields
+/// ([`dedup_key`](Self::dedup_key), [`severity`](Self::severity),
+/// [`event`](Self::event)).
+#[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
+pub struct Alert {
+    /// Stable key identifying the *condition instance* (e.g. the specific job
+    /// or indicator). Identical across trigger and its recovery so an external
+    /// system can correlate them. Never contains a timestamp.
+    pub dedup_key: String,
+    /// The built-in condition family.
+    pub condition: AlertCondition,
+    /// Severity class.
+    pub severity: AlertSeverity,
+    /// Trigger vs resolve.
+    pub event: AlertEventKind,
+    /// One-line human summary of what failed.
+    pub title: String,
+    /// Longer human-readable detail (the underlying error, counts, etc.).
+    pub summary: String,
+    /// When the alert was produced (UTC).
+    pub timestamp: DateTime<Utc>,
+    /// Host / replica identity the alert originated from.
+    pub host: String,
+    /// Where the operator should look next (an actuator endpoint or a log
+    /// correlation id).
+    pub where_to_look: String,
+    /// Extra structured context (job name, error string, rates, …).
+    pub details: HashMap<String, String>,
+}
+
+impl Alert {
+    /// Build a trigger alert for `condition` with a stable dedup `key`.
+    #[must_use]
+    pub fn trigger(condition: AlertCondition, key: impl Into<String>) -> AlertBuilder {
+        AlertBuilder::new(condition, key.into(), AlertEventKind::Trigger)
+    }
+
+    /// Build a recovery (resolve) alert for `condition` with the same stable
+    /// dedup `key` its trigger used.
+    #[must_use]
+    pub fn recovery(condition: AlertCondition, key: impl Into<String>) -> AlertBuilder {
+        AlertBuilder::new(condition, key.into(), AlertEventKind::Resolve)
+    }
+}
+
+/// Builder for an [`Alert`]. Fills host, timestamp, severity, and the
+/// where-to-look pointer from sensible defaults.
+#[derive(Debug, Clone)]
+pub struct AlertBuilder {
+    alert: Alert,
+}
+
+impl AlertBuilder {
+    fn new(condition: AlertCondition, dedup_key: String, event: AlertEventKind) -> Self {
+        let severity = match event {
+            AlertEventKind::Trigger => AlertSeverity::Critical,
+            AlertEventKind::Resolve => AlertSeverity::Recovery,
+        };
+        Self {
+            alert: Alert {
+                dedup_key,
+                condition,
+                severity,
+                event,
+                title: String::new(),
+                summary: String::new(),
+                timestamp: Utc::now(),
+                host: host_id(),
+                where_to_look: condition.where_to_look().to_owned(),
+                details: HashMap::new(),
+            },
+        }
+    }
+
+    /// Set the one-line title.
+    #[must_use]
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.alert.title = title.into();
+        self
+    }
+
+    /// Set the longer human summary.
+    #[must_use]
+    pub fn summary(mut self, summary: impl Into<String>) -> Self {
+        self.alert.summary = summary.into();
+        self
+    }
+
+    /// Override the "where to look next" pointer (defaults to the condition's
+    /// actuator endpoint). Use this to attach a log correlation id.
+    #[must_use]
+    pub fn where_to_look(mut self, where_to_look: impl Into<String>) -> Self {
+        self.alert.where_to_look = where_to_look.into();
+        self
+    }
+
+    /// Add a structured detail field.
+    #[must_use]
+    pub fn detail(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.alert.details.insert(key.into(), value.into());
+        self
+    }
+
+    /// Finish building.
+    #[must_use]
+    pub fn build(self) -> Alert {
+        self.alert
+    }
+}
+
+/// Resolve the host/replica identity to stamp on every alert.
+///
+/// Prefers an explicit `AUTUMN_REPLICA_ID`, then the container/host `HOSTNAME`,
+/// falling back to `"unknown-host"`.
+#[must_use]
+pub fn host_id() -> String {
+    std::env::var("AUTUMN_REPLICA_ID")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| {
+            std::env::var("HOSTNAME")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+        })
+        .unwrap_or_else(|| "unknown-host".to_owned())
+}
+
+// ── Delivery trait ──────────────────────────────────────────────────────────
+
+/// The future returned by [`AlertChannel::deliver`].
+pub type AlertDeliveryFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<(), AlertDeliveryError>> + Send + 'a>>;
+
+/// A delivery failure. Channels return this so the [`Alerter`] can log it; a
+/// failure never propagates to the request path.
+#[derive(Debug, thiserror::Error)]
+#[error("alert delivery via {channel} failed: {message}")]
+pub struct AlertDeliveryError {
+    /// Name of the channel that failed.
+    pub channel: &'static str,
+    /// Human-readable failure detail.
+    pub message: String,
+}
+
+impl AlertDeliveryError {
+    /// Construct a delivery error for `channel`.
+    #[must_use]
+    pub fn new(channel: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            channel,
+            message: message.into(),
+        }
+    }
+}
+
+/// A destination that operator alerts are delivered to.
+///
+/// This is the framework's extension point for #1630: implement it for
+/// `PagerDuty`, Slack, Discord, or any sink and register it with
+/// [`AppBuilder::with_alert_channel`](crate::app::AppBuilder::with_alert_channel).
+/// Implementations MUST be non-blocking and swallow nothing silently — return
+/// [`AlertDeliveryError`] so the framework can log it. Delivery runs on a
+/// detached task, so an implementation that is slow or panics can never affect
+/// a live request.
+pub trait AlertChannel: Send + Sync + 'static {
+    /// A short static name for logs (e.g. `"mail"`, `"webhook"`).
+    fn name(&self) -> &'static str;
+
+    /// Deliver `alert` to this channel.
+    fn deliver<'a>(&'a self, alert: &'a Alert) -> AlertDeliveryFuture<'a>;
+}
+
+// ── Deduplication ───────────────────────────────────────────────────────────
+
+/// Decision returned by the [`AlertDeduplicator`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DedupDecision {
+    /// Deliver this alert.
+    Send,
+    /// Suppress this alert (a bounded duplicate, or a recovery for something
+    /// that was never alerted).
+    Suppress,
+}
+
+impl DedupDecision {
+    /// Whether the alert should be delivered.
+    #[must_use]
+    pub const fn should_send(self) -> bool {
+        matches!(self, Self::Send)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct KeyState {
+    /// Whether a trigger is currently outstanding (used to gate recovery).
+    active: bool,
+    /// When we last *delivered* a trigger for this key.
+    last_sent: DateTime<Utc>,
+}
+
+/// Bounds alert volume for sustained/repeating conditions and gates recovery
+/// notifications.
+///
+/// Policy (AC #3): the first occurrence of a condition alerts immediately;
+/// further occurrences within `window` are suppressed. After `window` elapses
+/// while the condition still fires, exactly one re-notification is allowed — so
+/// the steady-state rate is bounded to **at most one notification per condition
+/// per window**, never one-per-occurrence. A recovery is delivered exactly once
+/// when a previously-alerted key clears, and never for a key that never fired.
+#[derive(Debug)]
+pub struct AlertDeduplicator {
+    window: chrono::Duration,
+    keys: HashMap<String, KeyState>,
+}
+
+impl AlertDeduplicator {
+    /// Create a deduplicator with the given re-notification window.
+    #[must_use]
+    pub fn new(window: std::time::Duration) -> Self {
+        Self {
+            window: chrono::Duration::from_std(window)
+                .unwrap_or_else(|_| chrono::Duration::seconds(900)),
+            keys: HashMap::new(),
+        }
+    }
+
+    /// Decide whether a trigger for `key` at `now` should be delivered.
+    pub fn on_trigger(&mut self, key: &str, now: DateTime<Utc>) -> DedupDecision {
+        match self.keys.get_mut(key) {
+            Some(state) if state.active && (now - state.last_sent) < self.window => {
+                // Still firing, still inside the window: bounded suppression.
+                DedupDecision::Suppress
+            }
+            Some(state) => {
+                // Either it had recovered, or the window has elapsed: re-notify.
+                state.active = true;
+                state.last_sent = now;
+                DedupDecision::Send
+            }
+            None => {
+                self.keys.insert(
+                    key.to_owned(),
+                    KeyState {
+                        active: true,
+                        last_sent: now,
+                    },
+                );
+                DedupDecision::Send
+            }
+        }
+    }
+
+    /// Decide whether a recovery for `key` should be delivered. Only keys with
+    /// an outstanding (delivered) trigger recover; the key is then cleared so a
+    /// future trigger alerts immediately.
+    pub fn on_resolve(&mut self, key: &str) -> DedupDecision {
+        match self.keys.get_mut(key) {
+            Some(state) if state.active => {
+                state.active = false;
+                DedupDecision::Send
+            }
+            _ => DedupDecision::Suppress,
+        }
+    }
+}
+
+// ── Alerter ─────────────────────────────────────────────────────────────────
+
+/// Tunables the [`Alerter`] and its background evaluation loop read.
+#[derive(Debug, Clone)]
+pub struct AlerterSettings {
+    /// Dedup / re-notification window.
+    pub dedup_window: std::time::Duration,
+    /// How long an indicator must stay `Down` before it alerts (condition b).
+    pub health_grace: std::time::Duration,
+    /// 5xx fraction (of requests in the sample window) that trips the alert.
+    pub error_rate_threshold: f64,
+    /// Minimum requests in the sample window before the rate is evaluated.
+    pub error_rate_min_requests: u64,
+    /// Background evaluation cadence (conditions b and c).
+    pub eval_interval: std::time::Duration,
+}
+
+impl AlerterSettings {
+    fn from_config(config: &AlertConfig) -> Self {
+        Self {
+            dedup_window: std::time::Duration::from_secs(config.dedup_window_secs.max(1)),
+            health_grace: std::time::Duration::from_secs(config.health_grace_secs),
+            error_rate_threshold: config.error_rate_threshold,
+            error_rate_min_requests: config.error_rate_min_requests.max(1),
+            eval_interval: std::time::Duration::from_secs(config.eval_interval_secs.max(1)),
+        }
+    }
+}
+
+struct AlerterInner {
+    channels: Vec<Arc<dyn AlertChannel>>,
+    dedup: Mutex<AlertDeduplicator>,
+    settings: AlerterSettings,
+}
+
+/// Runtime fan-out hub for operator alerts, installed as an [`AppState`]
+/// extension so the built-in condition hooks can reach it.
+///
+/// Cloning is cheap (shared `Arc`). Use [`notify`](Self::notify) /
+/// [`recover`](Self::recover) to emit alerts; both deduplicate and dispatch on
+/// a detached task so nothing blocks the caller.
+#[derive(Clone)]
+pub struct Alerter {
+    inner: Arc<AlerterInner>,
+}
+
+impl Alerter {
+    /// Build an alerter from a channel list and settings.
+    #[must_use]
+    pub fn new(channels: Vec<Arc<dyn AlertChannel>>, settings: AlerterSettings) -> Self {
+        let dedup = AlertDeduplicator::new(settings.dedup_window);
+        Self {
+            inner: Arc::new(AlerterInner {
+                channels,
+                dedup: Mutex::new(dedup),
+                settings,
+            }),
+        }
+    }
+
+    /// Whether any channel is registered. When false, emitting is a no-op.
+    #[must_use]
+    pub fn has_channels(&self) -> bool {
+        !self.inner.channels.is_empty()
+    }
+
+    pub(crate) fn settings(&self) -> &AlerterSettings {
+        &self.inner.settings
+    }
+
+    /// Emit a trigger alert. Deduplicated; delivered on a detached task.
+    /// Returns whether the alert passed the dedup gate (was dispatched).
+    #[must_use]
+    pub fn notify(&self, alert: Alert) -> bool {
+        let decision = self
+            .inner
+            .dedup
+            .lock()
+            .map_or(DedupDecision::Send, |mut d| {
+                d.on_trigger(&alert.dedup_key, alert.timestamp)
+            });
+        if decision.should_send() {
+            self.dispatch(alert);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Emit a recovery alert if `dedup_key` had an outstanding trigger. The
+    /// caller supplies the fully-built recovery [`Alert`]. Returns whether a
+    /// recovery was actually dispatched.
+    #[must_use]
+    pub fn recover(&self, alert: Alert) -> bool {
+        let decision = self
+            .inner
+            .dedup
+            .lock()
+            .map_or(DedupDecision::Suppress, |mut d| {
+                d.on_resolve(&alert.dedup_key)
+            });
+        if decision.should_send() {
+            self.dispatch(alert);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Fan the alert out to every channel on a detached task (fail-safe).
+    fn dispatch(&self, alert: Alert) {
+        if self.inner.channels.is_empty() {
+            return;
+        }
+        let inner = Arc::clone(&self.inner);
+        let run = async move {
+            for channel in &inner.channels {
+                match channel.deliver(&alert).await {
+                    Ok(()) => tracing::debug!(
+                        channel = channel.name(),
+                        dedup_key = %alert.dedup_key,
+                        "operator alert delivered"
+                    ),
+                    Err(error) => tracing::error!(
+                        channel = channel.name(),
+                        dedup_key = %alert.dedup_key,
+                        error = %error,
+                        "operator alert delivery failed; app continues serving"
+                    ),
+                }
+            }
+        };
+        // Dispatch is best-effort: with a Tokio runtime handle we spawn a
+        // detached task; with no handle available (unlikely from a hook site)
+        // the alert is logged and skipped, never blocking the caller.
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                handle.spawn(run);
+            }
+            Err(_) => {
+                tracing::warn!("no tokio runtime available for alert dispatch; skipping");
+            }
+        }
+    }
+}
+
+// ── Built-in condition hooks ────────────────────────────────────────────────
+
+/// Look up the installed [`Alerter`] on `state`, if any.
+#[must_use]
+pub fn alerter(state: &AppState) -> Option<Arc<Alerter>> {
+    state.extension::<Alerter>()
+}
+
+/// Condition (a): a background job was dead-lettered. Called from the job
+/// backends' dead-letter sites. No-op when no alerter is installed.
+pub fn notify_dead_lettered_job(state: &AppState, job_name: &str, error: &str) {
+    let Some(alerter) = alerter(state) else {
+        return;
+    };
+    let alert = Alert::trigger(
+        AlertCondition::DeadLetteredJob,
+        format!("dead_lettered_job:{job_name}"),
+    )
+    .title(format!("Job '{job_name}' was dead-lettered"))
+    .summary(format!(
+        "Background job '{job_name}' exhausted its retries and was moved to the dead-letter queue. Last error: {error}"
+    ))
+    .detail("job", job_name)
+    .detail("error", error)
+    .build();
+    let _ = alerter.notify(alert);
+}
+
+/// Condition (d): a framework-scheduled task failed. Called from the scheduler's
+/// failure arms. No-op when no alerter is installed.
+pub fn notify_scheduled_task_failure(state: &AppState, task_name: &str, error: &str) {
+    let Some(alerter) = alerter(state) else {
+        return;
+    };
+    let alert = Alert::trigger(
+        AlertCondition::ScheduledTaskFailure,
+        format!("scheduled_task_failure:{task_name}"),
+    )
+    .title(format!("Scheduled task '{task_name}' failed"))
+    .summary(format!(
+        "The framework-scheduled task '{task_name}' returned an error on its last run: {error}"
+    ))
+    .detail("task", task_name)
+    .detail("error", error)
+    .build();
+    let _ = alerter.notify(alert);
+}
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+const fn default_alerts_enabled() -> bool {
+    true
+}
+const fn default_dedup_window_secs() -> u64 {
+    900
+}
+const fn default_health_grace_secs() -> u64 {
+    60
+}
+const fn default_error_rate_threshold() -> f64 {
+    0.05
+}
+const fn default_error_rate_min_requests() -> u64 {
+    20
+}
+const fn default_eval_interval_secs() -> u64 {
+    30
+}
+
+/// `[alerts]` configuration.
+///
+/// Providing **only** a destination (an operator [`email`](Self::email) and/or
+/// a [`webhook_url`](Self::webhook_url)) is enough to receive alerts for every
+/// built-in condition — no application code required. Every destination and
+/// tuning knob is also settable via `AUTUMN_ALERTS__*` environment variables.
+///
+/// ```toml
+/// [alerts]
+/// email = "oncall@example.com"
+/// webhook_url = "https://alerts.example.com/hooks/autumn"
+/// webhook_secret = "..."          # prefer AUTUMN_ALERTS__WEBHOOK_SECRET
+/// # Tuning (defaults shown):
+/// dedup_window_secs = 900         # at most one notice per condition per 15 min
+/// health_grace_secs = 60          # indicator must stay Down this long
+/// error_rate_threshold = 0.05     # 5% of sampled requests are 5xx
+/// error_rate_min_requests = 20    # ignore the rate below this sample size
+/// eval_interval_secs = 30         # background evaluation cadence
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct AlertConfig {
+    /// Master switch. Alerts are only ever emitted when this is `true` **and**
+    /// at least one destination is configured.
+    pub enabled: bool,
+    /// Operator email destination (mail channel). Delivered via the app's
+    /// configured mailer with suppression bypassed (alerts are security-class).
+    pub email: Option<String>,
+    /// Signed outbound webhook destination.
+    pub webhook_url: Option<String>,
+    /// HMAC signing secret for the webhook destination. Prefer the
+    /// `AUTUMN_ALERTS__WEBHOOK_SECRET` env var over committing it.
+    pub webhook_secret: Option<String>,
+    /// At most one notification per condition per this many seconds.
+    pub dedup_window_secs: u64,
+    /// How long (seconds) an indicator must stay `Down` before it alerts.
+    pub health_grace_secs: u64,
+    /// 5xx fraction of the sampled request window that trips the alert.
+    pub error_rate_threshold: f64,
+    /// Minimum requests in the sample window before the 5xx rate is evaluated.
+    pub error_rate_min_requests: u64,
+    /// Background evaluation cadence (seconds) for the health and 5xx-rate
+    /// conditions.
+    pub eval_interval_secs: u64,
+}
+
+impl Default for AlertConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_alerts_enabled(),
+            email: None,
+            webhook_url: None,
+            webhook_secret: None,
+            dedup_window_secs: default_dedup_window_secs(),
+            health_grace_secs: default_health_grace_secs(),
+            error_rate_threshold: default_error_rate_threshold(),
+            error_rate_min_requests: default_error_rate_min_requests(),
+            eval_interval_secs: default_eval_interval_secs(),
+        }
+    }
+}
+
+impl AlertConfig {
+    /// Whether a delivery destination is configured (email and/or webhook URL).
+    #[must_use]
+    pub fn has_destination(&self) -> bool {
+        self.email.as_ref().is_some_and(|s| !s.trim().is_empty())
+            || self
+                .webhook_url
+                .as_ref()
+                .is_some_and(|s| !s.trim().is_empty())
+    }
+
+    /// Whether alerts should actually be active (enabled + a destination).
+    #[must_use]
+    pub fn is_active(&self) -> bool {
+        self.enabled && self.has_destination()
+    }
+}
+
+// ── Built-in channels ───────────────────────────────────────────────────────
+
+/// Mail alert channel: delivers each alert as an email through the app's
+/// configured [`Mailer`](crate::mail::Mailer).
+///
+/// The message is built with
+/// [`Mail::ignore_suppression`](crate::mail::MailBuilder::ignore_suppression):
+/// operator alerts are security-class and must never be silently dropped by the
+/// bounce/complaint suppression list.
+#[cfg(feature = "mail")]
+pub struct MailAlertChannel {
+    mailer: Arc<crate::mail::Mailer>,
+    to: String,
+}
+
+#[cfg(feature = "mail")]
+impl MailAlertChannel {
+    /// Create a mail channel delivering to `to` via `mailer`.
+    #[must_use]
+    pub fn new(mailer: Arc<crate::mail::Mailer>, to: impl Into<String>) -> Self {
+        Self {
+            mailer,
+            to: to.into(),
+        }
+    }
+
+    fn render_text(alert: &Alert) -> String {
+        use std::fmt::Write as _;
+        let mut body = format!(
+            "{}\n\nSeverity: {:?}\nEvent: {:?}\nCondition: {}\nHost/replica: {}\nWhen: {}\nWhere to look next: {}\n\n{}\n",
+            alert.title,
+            alert.severity,
+            alert.event,
+            alert.condition.as_str(),
+            alert.host,
+            alert.timestamp.to_rfc3339(),
+            alert.where_to_look,
+            alert.summary,
+        );
+        if !alert.details.is_empty() {
+            body.push_str("\nDetails:\n");
+            let mut keys: Vec<&String> = alert.details.keys().collect();
+            keys.sort();
+            for k in keys {
+                if let Some(v) = alert.details.get(k) {
+                    let _ = writeln!(body, "  {k}: {v}");
+                }
+            }
+        }
+        body
+    }
+}
+
+#[cfg(feature = "mail")]
+impl AlertChannel for MailAlertChannel {
+    fn name(&self) -> &'static str {
+        "mail"
+    }
+
+    fn deliver<'a>(&'a self, alert: &'a Alert) -> AlertDeliveryFuture<'a> {
+        Box::pin(async move {
+            let prefix = match alert.event {
+                AlertEventKind::Trigger => "[ALERT]",
+                AlertEventKind::Resolve => "[RECOVERED]",
+            };
+            let subject = format!("{prefix} {}", alert.title);
+            let mail = crate::mail::Mail::builder()
+                .to(self.to.clone())
+                .subject(subject)
+                .text(Self::render_text(alert))
+                .ignore_suppression()
+                .build()
+                .map_err(|e| AlertDeliveryError::new("mail", e.to_string()))?;
+            self.mailer
+                .send(mail)
+                .await
+                .map_err(|e| AlertDeliveryError::new("mail", e.to_string()))
+        })
+    }
+}
+
+/// Signed-webhook alert channel: POSTs the alert as JSON to a configured URL.
+///
+/// The request is signed with the same Stripe-style
+/// `Autumn-Signature: t=<ts>,v1=<hmac>` scheme as the outbound webhook
+/// machinery ([`webhook_outbound`](crate::webhook_outbound)) — no new
+/// dependency.
+#[cfg(feature = "http-client")]
+pub struct WebhookAlertChannel {
+    client: crate::http_client::Client,
+    url: String,
+    secret: Option<String>,
+}
+
+#[cfg(feature = "http-client")]
+impl WebhookAlertChannel {
+    /// Create a webhook channel posting to `url`, optionally HMAC-signing with
+    /// `secret`.
+    #[must_use]
+    pub fn new(
+        client: crate::http_client::Client,
+        url: impl Into<String>,
+        secret: Option<String>,
+    ) -> Self {
+        Self {
+            client,
+            url: url.into(),
+            secret,
+        }
+    }
+}
+
+#[cfg(feature = "http-client")]
+impl AlertChannel for WebhookAlertChannel {
+    fn name(&self) -> &'static str {
+        "webhook"
+    }
+
+    fn deliver<'a>(&'a self, alert: &'a Alert) -> AlertDeliveryFuture<'a> {
+        Box::pin(async move {
+            let body = serde_json::to_string(alert)
+                .map_err(|e| AlertDeliveryError::new("webhook", e.to_string()))?;
+            let mut req = self
+                .client
+                .named(&self.url)
+                .post(&self.url)
+                .header("Content-Type", "application/json");
+            if let Some(secret) = self.secret.as_ref() {
+                let timestamp = Utc::now().timestamp();
+                let signing_payload = format!("{timestamp}.{body}");
+                let signature = crate::security::config::hmac_sha256_hex(
+                    secret.as_bytes(),
+                    signing_payload.as_bytes(),
+                );
+                req = req.header("Autumn-Signature", format!("t={timestamp},v1={signature}"));
+            }
+            let response = req
+                .text_body(body)
+                .send()
+                .await
+                .map_err(|e| AlertDeliveryError::new("webhook", e.to_string()))?;
+            if response.is_success() {
+                Ok(())
+            } else {
+                Err(AlertDeliveryError::new(
+                    "webhook",
+                    format!("endpoint returned status {}", response.status()),
+                ))
+            }
+        })
+    }
+}
+
+// ── Wiring ──────────────────────────────────────────────────────────────────
+
+/// Install the operator alerter from `config` plus any builder channels.
+///
+/// Builds the built-in channels from `config`, combines them with any
+/// `extra_channels` registered via the builder, installs the resulting
+/// [`Alerter`] onto `state`, and starts the background evaluation loop for the
+/// health and 5xx-rate conditions.
+///
+/// Does nothing (and installs nothing) when alerts are inactive
+/// ([`AlertConfig::is_active`] is `false`) *and* no extra channels were
+/// registered — so an app with no destination pays nothing.
+pub fn install_from_config(
+    state: &AppState,
+    config: &AlertConfig,
+    extra_channels: Vec<Arc<dyn AlertChannel>>,
+) {
+    let mut channels: Vec<Arc<dyn AlertChannel>> = Vec::new();
+
+    if config.enabled {
+        #[cfg(feature = "mail")]
+        if let Some(email) = config.email.as_ref().filter(|s| !s.trim().is_empty()) {
+            if let Some(mailer) = state.extension::<crate::mail::Mailer>() {
+                channels.push(Arc::new(MailAlertChannel::new(mailer, email.clone())));
+            } else {
+                tracing::warn!(
+                    "alerts: an operator email is configured but no mailer is installed; \
+                     configure [mail] to enable email alerts"
+                );
+            }
+        }
+        #[cfg(feature = "http-client")]
+        if let Some(url) = config.webhook_url.as_ref().filter(|s| !s.trim().is_empty()) {
+            let client = crate::http_client::Client::from_state(state);
+            channels.push(Arc::new(WebhookAlertChannel::new(
+                client,
+                url.clone(),
+                config.webhook_secret.clone(),
+            )));
+        }
+    }
+
+    channels.extend(extra_channels);
+
+    if channels.is_empty() {
+        return;
+    }
+
+    let settings = AlerterSettings::from_config(config);
+    let alerter = Alerter::new(channels, settings);
+    state.insert_extension(alerter.clone());
+    spawn_evaluation_loop(state.clone(), alerter);
+}
+
+/// Spawn the background loop that evaluates the *pull-based* conditions:
+/// health-indicator down-duration (b) and the rolling 5xx rate (c). Both are
+/// evaluated off the request path so AC #6 (no request-path latency) holds.
+fn spawn_evaluation_loop(state: AppState, alerter: Alerter) {
+    let settings = alerter.settings().clone();
+    tokio::spawn(async move {
+        // Per-indicator: when it first went Down (None once it is Up again).
+        let mut down_since: HashMap<String, DateTime<Utc>> = HashMap::new();
+        // Prime the cumulative counters so the first tick measures a real delta.
+        let (mut last_requests, mut last_5xx) = {
+            let snap = state.metrics().snapshot();
+            (snap.http.requests_total, snap.http.by_status.s5xx)
+        };
+        loop {
+            tokio::time::sleep(settings.eval_interval).await;
+            evaluate_error_rate(
+                &alerter,
+                &state,
+                &settings,
+                &mut last_requests,
+                &mut last_5xx,
+            );
+            evaluate_health(&alerter, &state, &settings, &mut down_since).await;
+        }
+    });
+}
+
+/// Condition (c): compute the 5xx rate over the requests seen since the last
+/// tick and compare to the threshold. Reads existing cumulative counters — the
+/// request path is untouched.
+fn evaluate_error_rate(
+    alerter: &Alerter,
+    state: &AppState,
+    settings: &AlerterSettings,
+    last_requests: &mut u64,
+    last_5xx: &mut u64,
+) {
+    let snap = state.metrics().snapshot();
+    let total = snap.http.requests_total;
+    let s5xx = snap.http.by_status.s5xx;
+    let req_delta = total.saturating_sub(*last_requests);
+    let err_delta = s5xx.saturating_sub(*last_5xx);
+    *last_requests = total;
+    *last_5xx = s5xx;
+
+    if req_delta < settings.error_rate_min_requests {
+        return;
+    }
+    #[allow(clippy::cast_precision_loss)]
+    let rate = err_delta as f64 / req_delta as f64;
+    let key = "high_error_rate:5xx".to_owned();
+    if rate >= settings.error_rate_threshold {
+        let pct = rate * 100.0;
+        let threshold_pct = settings.error_rate_threshold * 100.0;
+        let alert = Alert::trigger(AlertCondition::HighErrorRate, key)
+            .title(format!("5xx error rate is {pct:.1}%"))
+            .summary(format!(
+                "{err_delta} of the last {req_delta} requests returned 5xx ({pct:.1}%), \
+                 crossing the {threshold_pct:.1}% threshold."
+            ))
+            .detail("rate", format!("{rate:.4}"))
+            .detail("errors", err_delta.to_string())
+            .detail("requests", req_delta.to_string())
+            .build();
+        let _ = alerter.notify(alert);
+    } else {
+        let alert = Alert::recovery(AlertCondition::HighErrorRate, key)
+            .title("5xx error rate recovered")
+            .summary(format!(
+                "The 5xx error rate is back under the threshold ({pct:.1}% of {req_delta} requests).",
+                pct = rate * 100.0,
+            ))
+            .build();
+        let _ = alerter.recover(alert);
+    }
+}
+
+/// Condition (b): run all health indicators, track how long each has been
+/// `Down`, and alert once an indicator has stayed `Down` past the grace period.
+/// Recover when it reports healthy again.
+async fn evaluate_health(
+    alerter: &Alerter,
+    state: &AppState,
+    settings: &AlerterSettings,
+    down_since: &mut HashMap<String, DateTime<Utc>>,
+) {
+    let results = state.health_indicator_registry().run_all().await;
+    let now = Utc::now();
+    let grace = chrono::Duration::from_std(settings.health_grace)
+        .unwrap_or_else(|_| chrono::Duration::seconds(60));
+
+    for result in &results {
+        let key = format!("health_indicator_down:{}", result.name);
+        if result.output.status == crate::actuator::HealthStatus::Down {
+            let first = *down_since.entry(result.name.clone()).or_insert(now);
+            if now - first >= grace {
+                let secs = (now - first).num_seconds().max(0);
+                let alert = Alert::trigger(AlertCondition::HealthIndicatorDown, key)
+                    .title(format!("Health indicator '{}' is Down", result.name))
+                    .summary(format!(
+                        "Health indicator '{}' has reported Down for {secs}s, past the \
+                         {grace_secs}s grace period.",
+                        result.name,
+                        grace_secs = settings.health_grace.as_secs(),
+                    ))
+                    .detail("indicator", result.name.clone())
+                    .detail("down_seconds", secs.to_string())
+                    .build();
+                let _ = alerter.notify(alert);
+            }
+        } else if down_since.remove(&result.name).is_some() {
+            let alert = Alert::recovery(AlertCondition::HealthIndicatorDown, key)
+                .title(format!("Health indicator '{}' recovered", result.name))
+                .summary(format!(
+                    "Health indicator '{}' is reporting healthy again.",
+                    result.name
+                ))
+                .detail("indicator", result.name.clone())
+                .build();
+            let _ = alerter.recover(alert);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    fn ts(secs: i64) -> DateTime<Utc> {
+        DateTime::from_timestamp(1_700_000_000 + secs, 0).expect("valid timestamp")
+    }
+
+    // ── Dedup window bounding (AC #3) ────────────────────────────────────────
+
+    #[test]
+    fn first_trigger_sends() {
+        let mut d = AlertDeduplicator::new(std::time::Duration::from_secs(900));
+        assert_eq!(d.on_trigger("k", ts(0)), DedupDecision::Send);
+    }
+
+    #[test]
+    fn repeated_triggers_within_window_are_suppressed() {
+        let mut d = AlertDeduplicator::new(std::time::Duration::from_secs(900));
+        assert_eq!(d.on_trigger("k", ts(0)), DedupDecision::Send);
+        // Many occurrences inside the window -> all suppressed (not one-per).
+        for s in 1..100 {
+            assert_eq!(
+                d.on_trigger("k", ts(s)),
+                DedupDecision::Suppress,
+                "occurrence at {s}s inside window must be suppressed"
+            );
+        }
+    }
+
+    #[test]
+    fn trigger_renotifies_once_after_window_elapses() {
+        let mut d = AlertDeduplicator::new(std::time::Duration::from_secs(900));
+        assert_eq!(d.on_trigger("k", ts(0)), DedupDecision::Send);
+        assert_eq!(d.on_trigger("k", ts(500)), DedupDecision::Suppress);
+        // Window elapsed: exactly one re-notification.
+        assert_eq!(d.on_trigger("k", ts(901)), DedupDecision::Send);
+        assert_eq!(d.on_trigger("k", ts(902)), DedupDecision::Suppress);
+    }
+
+    #[test]
+    fn distinct_keys_are_independent() {
+        let mut d = AlertDeduplicator::new(std::time::Duration::from_secs(900));
+        assert_eq!(d.on_trigger("a", ts(0)), DedupDecision::Send);
+        assert_eq!(d.on_trigger("b", ts(0)), DedupDecision::Send);
+    }
+
+    // ── Recovery emission (AC #3) ────────────────────────────────────────────
+
+    #[test]
+    fn recovery_sends_only_for_active_key() {
+        let mut d = AlertDeduplicator::new(std::time::Duration::from_secs(900));
+        // Never triggered: no recovery.
+        assert_eq!(d.on_resolve("k"), DedupDecision::Suppress);
+        // Trigger, then recover once.
+        assert_eq!(d.on_trigger("k", ts(0)), DedupDecision::Send);
+        assert_eq!(d.on_resolve("k"), DedupDecision::Send);
+        // Double-recover: suppressed.
+        assert_eq!(d.on_resolve("k"), DedupDecision::Suppress);
+    }
+
+    #[test]
+    fn trigger_after_recovery_alerts_immediately() {
+        let mut d = AlertDeduplicator::new(std::time::Duration::from_secs(900));
+        assert_eq!(d.on_trigger("k", ts(0)), DedupDecision::Send);
+        assert_eq!(d.on_resolve("k"), DedupDecision::Send);
+        // Fresh trigger inside the original window still sends because the key
+        // recovered in between.
+        assert_eq!(d.on_trigger("k", ts(10)), DedupDecision::Send);
+    }
+
+    // ── Severity classification ──────────────────────────────────────────────
+
+    #[test]
+    fn trigger_is_critical_resolve_is_recovery() {
+        let t = Alert::trigger(AlertCondition::DeadLetteredJob, "k").build();
+        assert_eq!(t.severity, AlertSeverity::Critical);
+        assert_eq!(t.event, AlertEventKind::Trigger);
+        let r = Alert::recovery(AlertCondition::DeadLetteredJob, "k").build();
+        assert_eq!(r.severity, AlertSeverity::Recovery);
+        assert_eq!(r.event, AlertEventKind::Resolve);
+    }
+
+    #[test]
+    fn where_to_look_defaults_per_condition() {
+        assert_eq!(
+            Alert::trigger(AlertCondition::DeadLetteredJob, "k")
+                .build()
+                .where_to_look,
+            "/actuator/jobs"
+        );
+        assert_eq!(
+            Alert::trigger(AlertCondition::HighErrorRate, "k")
+                .build()
+                .where_to_look,
+            "/actuator/metrics"
+        );
+        assert_eq!(
+            Alert::trigger(AlertCondition::HealthIndicatorDown, "k")
+                .build()
+                .where_to_look,
+            "/actuator/health"
+        );
+        assert_eq!(
+            Alert::trigger(AlertCondition::ScheduledTaskFailure, "k")
+                .build()
+                .where_to_look,
+            "/actuator/tasks"
+        );
+    }
+
+    #[test]
+    fn stable_dedup_key_survives_trigger_and_recovery() {
+        let key = "dead_lettered_job:emailer";
+        let t = Alert::trigger(AlertCondition::DeadLetteredJob, key).build();
+        let r = Alert::recovery(AlertCondition::DeadLetteredJob, key).build();
+        assert_eq!(t.dedup_key, r.dedup_key);
+    }
+
+    // ── Fan-out (delivery to every channel) ──────────────────────────────────
+
+    #[derive(Default)]
+    struct CapturingChannel {
+        received: Arc<StdMutex<Vec<Alert>>>,
+        name: &'static str,
+    }
+
+    impl AlertChannel for CapturingChannel {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+        fn deliver<'a>(&'a self, alert: &'a Alert) -> AlertDeliveryFuture<'a> {
+            let received = Arc::clone(&self.received);
+            let cloned = alert.clone();
+            Box::pin(async move {
+                received.lock().expect("lock").push(cloned);
+                Ok(())
+            })
+        }
+    }
+
+    fn settings() -> AlerterSettings {
+        AlerterSettings {
+            dedup_window: std::time::Duration::from_secs(900),
+            health_grace: std::time::Duration::from_secs(60),
+            error_rate_threshold: 0.05,
+            error_rate_min_requests: 20,
+            eval_interval: std::time::Duration::from_secs(30),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_fans_out_to_all_channels() {
+        let a = Arc::new(StdMutex::new(Vec::new()));
+        let b = Arc::new(StdMutex::new(Vec::new()));
+        let channels: Vec<Arc<dyn AlertChannel>> = vec![
+            Arc::new(CapturingChannel {
+                received: Arc::clone(&a),
+                name: "a",
+            }),
+            Arc::new(CapturingChannel {
+                received: Arc::clone(&b),
+                name: "b",
+            }),
+        ];
+        let alerter = Alerter::new(channels, settings());
+        assert!(
+            alerter.notify(
+                Alert::trigger(AlertCondition::DeadLetteredJob, "dead_lettered_job:x")
+                    .title("x failed")
+                    .build()
+            )
+        );
+        // Let the detached task run.
+        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert_eq!(a.lock().expect("lock").len(), 1);
+        assert_eq!(b.lock().expect("lock").len(), 1);
+        assert_eq!(a.lock().expect("lock")[0].title, "x failed");
+    }
+
+    #[tokio::test]
+    async fn sustained_condition_dispatches_once_per_window() {
+        let seen = Arc::new(StdMutex::new(Vec::new()));
+        let channels: Vec<Arc<dyn AlertChannel>> = vec![Arc::new(CapturingChannel {
+            received: Arc::clone(&seen),
+            name: "cap",
+        })];
+        let alerter = Alerter::new(channels, settings());
+        // 50 occurrences of the same condition in quick succession.
+        let mut sent = 0;
+        for _ in 0..50 {
+            if alerter.notify(
+                Alert::trigger(AlertCondition::HighErrorRate, "high_error_rate:5xx").build(),
+            ) {
+                sent += 1;
+            }
+        }
+        assert_eq!(sent, 1, "sustained condition must alert once per window");
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert_eq!(seen.lock().expect("lock").len(), 1);
+    }
+
+    #[test]
+    fn config_active_requires_enabled_and_destination() {
+        let mut c = AlertConfig::default();
+        assert!(!c.is_active(), "no destination -> inactive");
+        c.email = Some("ops@example.com".to_owned());
+        assert!(c.is_active());
+        c.enabled = false;
+        assert!(!c.is_active(), "disabled -> inactive even with destination");
+    }
+
+    #[test]
+    fn alert_serializes_to_json_for_webhook() {
+        let alert = Alert::trigger(AlertCondition::DeadLetteredJob, "dead_lettered_job:x")
+            .title("x failed")
+            .detail("job", "x")
+            .build();
+        let v: serde_json::Value = serde_json::to_value(&alert).expect("serialize");
+        assert_eq!(v["dedup_key"], "dead_lettered_job:x");
+        assert_eq!(v["condition"], "dead_lettered_job");
+        assert_eq!(v["severity"], "critical");
+        assert_eq!(v["event"], "trigger");
+        assert_eq!(v["where_to_look"], "/actuator/jobs");
+    }
+}

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -530,6 +530,33 @@ pub struct AlerterSettings {
     pub actuator_sensitive: bool,
 }
 
+/// Validate the configured 5xx `error_rate_threshold`, falling back to the
+/// [`default_error_rate_threshold`] when it is unusable.
+///
+/// The threshold is compared against a rate computed as `err_delta / req_delta`
+/// (see [`evaluate_error_rate`]), i.e. a **fraction in `[0, 1]`**, so the only
+/// meaningful thresholds are in `(0, 1]`. A non-finite value (`NaN`/`±inf`) or
+/// one `> 1` makes `rate >= threshold` false for every possible rate — the 5xx
+/// alert would NEVER fire; a value `<= 0` makes it true even on a 0%-error
+/// window — the alert would fire constantly. Neither can be meaningfully clamped
+/// (`NaN` especially), so a bad value falls back to the default and is logged,
+/// keeping 5xx alerting functional (fail-safe) rather than silently broken.
+fn sanitize_error_rate_threshold(threshold: f64) -> f64 {
+    if threshold.is_finite() && threshold > 0.0 && threshold <= 1.0 {
+        threshold
+    } else {
+        let default = default_error_rate_threshold();
+        tracing::warn!(
+            configured = threshold,
+            default,
+            "alerts: [alerts] error_rate_threshold ({threshold}) is not a valid 5xx rate in \
+             (0, 1]; falling back to the default ({default}) so 5xx alerting keeps working. Fix \
+             [alerts] error_rate_threshold (or the AUTUMN_ALERTS__ERROR_RATE_THRESHOLD env var)."
+        );
+        default
+    }
+}
+
 impl AlerterSettings {
     fn from_config(
         config: &AlertConfig,
@@ -539,7 +566,7 @@ impl AlerterSettings {
         Self {
             dedup_window: std::time::Duration::from_secs(config.dedup_window_secs.max(1)),
             health_grace: std::time::Duration::from_secs(config.health_grace_secs),
-            error_rate_threshold: config.error_rate_threshold,
+            error_rate_threshold: sanitize_error_rate_threshold(config.error_rate_threshold),
             error_rate_min_requests: config.error_rate_min_requests.max(1),
             eval_interval: std::time::Duration::from_secs(config.eval_interval_secs.max(1)),
             actuator_prefix,
@@ -1989,6 +2016,98 @@ mod tests {
         assert!(c.is_active());
         c.enabled = false;
         assert!(!c.is_active(), "disabled -> inactive even with destination");
+    }
+
+    // ── 5xx error_rate_threshold sanitization (P2) ───────────────────────────
+    // The threshold is compared against a FRACTION in [0, 1] (rate = err/req),
+    // so only (0, 1] is meaningful. A non-finite value or one > 1 makes the
+    // alert never fire; a value <= 0 makes it fire on 0%-error windows. Any such
+    // value falls back to the default so 5xx alerting stays functional.
+
+    fn from_config_with_threshold(threshold: f64) -> AlerterSettings {
+        let config = AlertConfig {
+            error_rate_threshold: threshold,
+            ..AlertConfig::default()
+        };
+        AlerterSettings::from_config(&config, "/actuator".to_owned(), false)
+    }
+
+    // Compare two f64s for the EXACT equality these tests intend (the sanitizer
+    // returns either the verbatim input or the bit-identical default constant), by
+    // bit pattern — avoids `clippy::float_cmp` while staying exact.
+    fn assert_threshold_eq(actual: f64, expected: f64, msg: &str) {
+        assert_eq!(actual.to_bits(), expected.to_bits(), "{msg}");
+    }
+
+    #[test]
+    fn valid_error_rate_threshold_is_kept() {
+        // An in-range finite value is preserved verbatim.
+        assert_threshold_eq(
+            from_config_with_threshold(0.2).error_rate_threshold,
+            0.2,
+            "a valid (0, 1] threshold must be kept",
+        );
+        // The boundary value 1.0 (100% of requests) is valid.
+        assert_threshold_eq(
+            from_config_with_threshold(1.0).error_rate_threshold,
+            1.0,
+            "the boundary 1.0 must be kept",
+        );
+    }
+
+    #[test]
+    fn nan_error_rate_threshold_falls_back_to_default() {
+        assert_threshold_eq(
+            from_config_with_threshold(f64::NAN).error_rate_threshold,
+            default_error_rate_threshold(),
+            "NaN threshold must fall back to the default (can't be clamped)",
+        );
+        // Infinities are non-finite too and must fall back.
+        assert_threshold_eq(
+            from_config_with_threshold(f64::INFINITY).error_rate_threshold,
+            default_error_rate_threshold(),
+            "infinity threshold must fall back to the default",
+        );
+    }
+
+    #[test]
+    fn out_of_range_error_rate_threshold_falls_back_to_default() {
+        // > 1: the alert would NEVER fire (no rate can reach it).
+        assert_threshold_eq(
+            from_config_with_threshold(1.5).error_rate_threshold,
+            default_error_rate_threshold(),
+            "a threshold > 1 must fall back to the default",
+        );
+        // <= 0: the alert would fire even on a 0%-error window.
+        assert_threshold_eq(
+            from_config_with_threshold(0.0).error_rate_threshold,
+            default_error_rate_threshold(),
+            "a zero threshold must fall back to the default",
+        );
+        assert_threshold_eq(
+            from_config_with_threshold(-0.1).error_rate_threshold,
+            default_error_rate_threshold(),
+            "a negative threshold must fall back to the default",
+        );
+    }
+
+    #[test]
+    fn sanitized_threshold_behaves_as_default_in_comparison() {
+        // A valid threshold fires for a rate at/above it and not below (the
+        // runtime gate is `rate >= threshold`).
+        let valid = from_config_with_threshold(0.10).error_rate_threshold;
+        assert!(0.10 >= valid, "a rate at the threshold fires");
+        assert!(0.05 < valid, "a rate below the threshold does not fire");
+        // The sanitized (bad) threshold compares exactly like the default: a rate
+        // at/above the DEFAULT fires, one below does not — the 5xx alert stays
+        // functional rather than silently broken.
+        let sanitized = from_config_with_threshold(f64::NAN).error_rate_threshold;
+        let default = default_error_rate_threshold();
+        assert!(default >= sanitized, "a rate at the default fires");
+        assert!(
+            default - 0.001 < sanitized,
+            "a rate below the default does not"
+        );
     }
 
     #[test]

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -887,7 +887,19 @@ pub fn install_from_config(
     #[cfg(feature = "mail")]
     if let Some(email) = config.email.as_ref().filter(|s| !s.trim().is_empty()) {
         if let Some(mailer) = state.extension::<crate::mail::Mailer>() {
-            channels.push(Arc::new(MailAlertChannel::new(mailer, email.clone())));
+            // A `Mailer` backed by the disabled (no-op) transport accepts and
+            // silently drops every message, so registering a `MailAlertChannel`
+            // here would make an email-only prod config look active while
+            // delivering nothing. Warn and skip the dead channel instead.
+            if mailer.is_disabled() {
+                tracing::warn!(
+                    "alerts: an operator email is configured but [mail] transport is disabled; \
+                     no email alerts will be delivered. Set [mail] transport to a real backend \
+                     or use a webhook destination."
+                );
+            } else {
+                channels.push(Arc::new(MailAlertChannel::new(mailer, email.clone())));
+            }
         } else {
             tracing::warn!(
                 "alerts: an operator email is configured but no mailer is installed; \

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -1021,6 +1021,31 @@ impl AlertChannel for WebhookAlertChannel {
 
 // ── Wiring ──────────────────────────────────────────────────────────────────
 
+/// Whether `url` is a non-empty ABSOLUTE `http(s)` URL that the outbound HTTP
+/// client will actually dispatch.
+///
+/// This mirrors the runtime absoluteness rule in
+/// [`http_client::Client::build_request`](crate::http_client::Client): a request
+/// URL is dispatched verbatim only when it starts with `http://` or `https://`
+/// (both schemes accepted, no TLS requirement); anything else is treated as
+/// relative and resolved against a base-url alias — of which the alert webhook
+/// client has none, so a relative/malformed value fails `reqwest::Url::parse` at
+/// send time and every alert POST fails. Requiring a parseable URL with a
+/// non-empty host here rejects such values BEFORE the channel is registered, so
+/// a webhook that looks configured actually delivers. Kept in lock-step with
+/// `autumn-cli`'s `is_absolute_http_url_doctor` (same rule) so doctor and the
+/// runtime agree on which webhook URLs are usable.
+#[cfg(feature = "http-client")]
+fn is_absolute_http_url(url: &str) -> bool {
+    if !(url.starts_with("http://") || url.starts_with("https://")) {
+        return false;
+    }
+    ::url::Url::parse(url)
+        .ok()
+        .and_then(|parsed| parsed.host_str().map(|h| !h.is_empty()))
+        .unwrap_or(false)
+}
+
 /// Install the operator alerter from `config` plus any builder channels.
 ///
 /// Builds the built-in channels from `config`, combines them with any
@@ -1084,23 +1109,48 @@ pub fn install_from_config(
         );
     }
     #[cfg(feature = "http-client")]
-    if let Some(url) = config.webhook_url.as_ref().filter(|s| !s.trim().is_empty()) {
-        // Alert webhooks are ALWAYS signed: the operator guide documents receivers
-        // verifying the `Autumn-Signature` header. A configured webhook with no
-        // non-empty signing secret would send UNSIGNED requests that a documented
-        // receiver rejects (or accepts unauthenticated) — so refuse to register the
-        // channel and warn, mirroring the disabled-mail-transport skip above.
-        // Never send unsigned.
-        if let Some(secret) = config
+    if let Some(raw_url) = config.webhook_url.as_ref().filter(|s| !s.trim().is_empty()) {
+        // TRIM the resolved webhook URL and treat the trimmed value as canonical:
+        // a copied env var commonly carries leading/trailing whitespace, and the
+        // runtime dispatch rule matches on `http://`/`https://` PREFIXES, so an
+        // untrimmed `"  https://…"` would never be treated as absolute and every
+        // POST would fail `reqwest::Url::parse`. Building the channel with the
+        // trimmed URL also keeps doctor (which trims + validates) and the runtime
+        // from disagreeing about whether the webhook is usable.
+        let url = raw_url.trim();
+        // Match the missing-secret check's trimming so the stored secret is the
+        // canonical, whitespace-free value used to sign.
+        let secret = config
             .webhook_secret
             .as_ref()
-            .filter(|s| !s.trim().is_empty())
-        {
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty());
+        // Reject an unusable webhook URL BEFORE registering the channel. Without
+        // this, a relative/malformed value (or one whose whitespace an app that
+        // doesn't run doctor never trims) installs a webhook channel that looks
+        // configured but fails EVERY delivery at `build_request`. Mirror the
+        // disabled-transport / missing-secret skip-and-warn pattern above.
+        if !is_absolute_http_url(url) {
+            tracing::warn!(
+                webhook_url = url,
+                "alerts: the configured [alerts] webhook_url ({url}) is not an absolute http(s) \
+                 URL (it must start with `http://` or `https://` and have a host); no webhook \
+                 alerts will be delivered. Fix [alerts] webhook_url (or the \
+                 AUTUMN_ALERTS__WEBHOOK_URL env var)."
+            );
+        } else if let Some(secret) = secret {
+            // Alert webhooks are ALWAYS signed: the operator guide documents
+            // receivers verifying the `Autumn-Signature` header. A configured
+            // webhook with no non-empty signing secret would send UNSIGNED
+            // requests that a documented receiver rejects (or accepts
+            // unauthenticated) — so refuse to register the channel and warn,
+            // mirroring the disabled-mail-transport skip above. Never send
+            // unsigned.
             let client = crate::http_client::Client::from_state(state);
             channels.push(Arc::new(WebhookAlertChannel::new(
                 client,
-                url.clone(),
-                Some(secret.clone()),
+                url.to_owned(),
+                Some(secret.to_owned()),
             )));
         } else {
             tracing::warn!(
@@ -1891,6 +1941,26 @@ mod tests {
             "baseline held across the next sub-threshold tick"
         );
         assert_eq!(last_5xx, 3);
+    }
+
+    #[cfg(feature = "http-client")]
+    #[test]
+    fn is_absolute_http_url_matches_runtime_absoluteness() {
+        // Both schemes are accepted (runtime dispatches either verbatim), with no
+        // TLS requirement and query/fragment allowed.
+        assert!(is_absolute_http_url(
+            "https://alerts.example.com/hooks/autumn"
+        ));
+        assert!(is_absolute_http_url(
+            "http://alerts.example.com/hooks/autumn"
+        ));
+        assert!(is_absolute_http_url("http://h.example.com:8080/x?a=1#f"));
+        // Relative / malformed / non-http / empty-host values are rejected.
+        assert!(!is_absolute_http_url("hooks.example/x"));
+        assert!(!is_absolute_http_url("/hooks/autumn"));
+        assert!(!is_absolute_http_url("ftp://h.example.com/x"));
+        assert!(!is_absolute_http_url("https://"));
+        assert!(!is_absolute_http_url(""));
     }
 
     #[test]

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -1167,9 +1167,45 @@ fn evaluate_error_rate(
     }
 }
 
+/// How a health indicator's current status maps onto the alert state machine.
+///
+/// Factored out of [`evaluate_health`] so the three-way branch is unit-testable
+/// without an `AppState`/registry. The key subtlety: recovery must be gated on
+/// [`HealthStatus::is_healthy`], NOT merely `!= Down`. `OutOfService` is a
+/// non-`Down` status that is still UNHEALTHY (`/actuator/health` reports
+/// non-200), so treating it as "recovered" would emit a false recovery while the
+/// service is still degraded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HealthTransition {
+    /// Status is `Down`: run the grace-period trigger logic.
+    Down,
+    /// Status is genuinely healthy again (`is_healthy()`): clear tracking and
+    /// emit a recovery for any outstanding alert.
+    Recover,
+    /// Status is non-`Down` but still not healthy (e.g. `OutOfService`): hold
+    /// the active alert as-is — no recovery, and no new trigger (only `Down`
+    /// triggers, matching existing behavior).
+    Hold,
+}
+
+/// Classify a health indicator's status into the alert-state transition it
+/// drives. Uses [`HealthStatus::is_healthy`] (not `== Up`) so `Unknown` — which
+/// the actuator reports as healthy — recovers, while `OutOfService` holds.
+const fn classify_health_transition(status: crate::actuator::HealthStatus) -> HealthTransition {
+    if matches!(status, crate::actuator::HealthStatus::Down) {
+        HealthTransition::Down
+    } else if status.is_healthy() {
+        HealthTransition::Recover
+    } else {
+        HealthTransition::Hold
+    }
+}
+
 /// Condition (b): run all health indicators, track how long each has been
 /// `Down`, and alert once an indicator has stayed `Down` past the grace period.
-/// Recover when it reports healthy again.
+/// Recover only when it reports a genuinely healthy status again — a non-`Down`
+/// but still-unhealthy status (e.g. `OutOfService`) holds the active alert
+/// rather than emitting a false recovery.
 async fn evaluate_health(
     alerter: &Alerter,
     state: &AppState,
@@ -1183,41 +1219,54 @@ async fn evaluate_health(
 
     for result in &results {
         let key = format!("health_indicator_down:{}", result.name);
-        if result.output.status == crate::actuator::HealthStatus::Down {
-            let first = *down_since.entry(result.name.clone()).or_insert(now);
-            if now - first >= grace {
-                let secs = (now - first).num_seconds().max(0);
-                let alert = Alert::trigger(AlertCondition::HealthIndicatorDown, key)
-                    .title(format!("Health indicator '{}' is Down", result.name))
-                    .summary(format!(
-                        "Health indicator '{}' has reported Down for {secs}s, past the \
-                         {grace_secs}s grace period.",
-                        result.name,
-                        grace_secs = settings.health_grace.as_secs(),
-                    ))
-                    .where_to_look(actuator_where_to_look(
-                        &settings.actuator_prefix,
-                        AlertCondition::HealthIndicatorDown,
-                    ))
-                    .detail("indicator", result.name.clone())
-                    .detail("down_seconds", secs.to_string())
-                    .build();
-                let _ = alerter.notify(alert);
+        match classify_health_transition(result.output.status) {
+            HealthTransition::Down => {
+                let first = *down_since.entry(result.name.clone()).or_insert(now);
+                if now - first >= grace {
+                    let secs = (now - first).num_seconds().max(0);
+                    let alert = Alert::trigger(AlertCondition::HealthIndicatorDown, key)
+                        .title(format!("Health indicator '{}' is Down", result.name))
+                        .summary(format!(
+                            "Health indicator '{}' has reported Down for {secs}s, past the \
+                             {grace_secs}s grace period.",
+                            result.name,
+                            grace_secs = settings.health_grace.as_secs(),
+                        ))
+                        .where_to_look(actuator_where_to_look(
+                            &settings.actuator_prefix,
+                            AlertCondition::HealthIndicatorDown,
+                        ))
+                        .detail("indicator", result.name.clone())
+                        .detail("down_seconds", secs.to_string())
+                        .build();
+                    let _ = alerter.notify(alert);
+                }
             }
-        } else if down_since.remove(&result.name).is_some() {
-            let alert = Alert::recovery(AlertCondition::HealthIndicatorDown, key)
-                .title(format!("Health indicator '{}' recovered", result.name))
-                .summary(format!(
-                    "Health indicator '{}' is reporting healthy again.",
-                    result.name
-                ))
-                .where_to_look(actuator_where_to_look(
-                    &settings.actuator_prefix,
-                    AlertCondition::HealthIndicatorDown,
-                ))
-                .detail("indicator", result.name.clone())
-                .build();
-            let _ = alerter.recover(alert);
+            HealthTransition::Recover => {
+                // Only clear the down-tracking (and emit a recovery) when the
+                // indicator is genuinely healthy again. `recover` is itself gated
+                // by `on_resolve`, so it is a no-op unless an alert was active.
+                if down_since.remove(&result.name).is_some() {
+                    let alert = Alert::recovery(AlertCondition::HealthIndicatorDown, key)
+                        .title(format!("Health indicator '{}' recovered", result.name))
+                        .summary(format!(
+                            "Health indicator '{}' is reporting healthy again.",
+                            result.name
+                        ))
+                        .where_to_look(actuator_where_to_look(
+                            &settings.actuator_prefix,
+                            AlertCondition::HealthIndicatorDown,
+                        ))
+                        .detail("indicator", result.name.clone())
+                        .build();
+                    let _ = alerter.recover(alert);
+                }
+            }
+            HealthTransition::Hold => {
+                // Non-`Down` but still unhealthy (e.g. `OutOfService`): leave the
+                // active alert and `down_since` bookkeeping untouched so we do not
+                // emit a "recovered" alert while `/actuator/health` is non-healthy.
+            }
         }
     }
 }
@@ -1292,6 +1341,112 @@ mod tests {
         // Fresh trigger inside the original window still sends because the key
         // recovered in between.
         assert_eq!(d.on_trigger("k", ts(10)), DedupDecision::Send);
+    }
+
+    // ── Health-indicator recovery classification (P2: recover only when healthy)
+    // The three-way branch in `evaluate_health`: `Down` triggers, a genuinely
+    // healthy status recovers, and any other non-healthy status (`OutOfService`)
+    // holds the active alert instead of emitting a false recovery.
+
+    use crate::actuator::HealthStatus;
+
+    #[test]
+    fn health_down_status_drives_trigger_branch() {
+        assert_eq!(
+            classify_health_transition(HealthStatus::Down),
+            HealthTransition::Down
+        );
+    }
+
+    #[test]
+    fn healthy_statuses_recover() {
+        // `is_healthy()` treats both `Up` and `Unknown` as healthy, so both
+        // recover — the actuator reports 200 for either.
+        assert_eq!(
+            classify_health_transition(HealthStatus::Up),
+            HealthTransition::Recover
+        );
+        assert_eq!(
+            classify_health_transition(HealthStatus::Unknown),
+            HealthTransition::Recover
+        );
+    }
+
+    #[test]
+    fn out_of_service_holds_active_alert_instead_of_recovering() {
+        // `OutOfService` is non-`Down` but still UNHEALTHY: it must NOT recover.
+        assert!(!HealthStatus::OutOfService.is_healthy());
+        assert_eq!(
+            classify_health_transition(HealthStatus::OutOfService),
+            HealthTransition::Hold
+        );
+    }
+
+    /// Drive the exact `down_since` + deduplicator bookkeeping `evaluate_health`
+    /// performs for a single indicator across a status sequence, returning the
+    /// dedup decision for any recovery emitted on the final tick (`None` when no
+    /// recovery was attempted). Proves the recovery is gated on a genuinely
+    /// healthy status, not merely `!= Down`.
+    fn recovery_decision_for_sequence(statuses: &[HealthStatus]) -> Option<DedupDecision> {
+        let name = "db";
+        let key = format!("health_indicator_down:{name}");
+        let mut dedup = AlertDeduplicator::new(std::time::Duration::from_secs(900));
+        let mut down_since: HashMap<String, DateTime<Utc>> = HashMap::new();
+        // Zero grace period so a single `Down` tick alerts immediately.
+        let grace = chrono::Duration::seconds(0);
+        let mut last = None;
+        for (i, status) in statuses.iter().enumerate() {
+            last = None;
+            let now = ts(i as i64);
+            match classify_health_transition(*status) {
+                HealthTransition::Down => {
+                    let first = *down_since.entry(name.to_owned()).or_insert(now);
+                    if now - first >= grace {
+                        let _ = dedup.on_trigger(&key, now);
+                    }
+                }
+                HealthTransition::Recover => {
+                    if down_since.remove(name).is_some() {
+                        last = Some(dedup.on_resolve(&key));
+                    }
+                }
+                HealthTransition::Hold => {}
+            }
+        }
+        last
+    }
+
+    #[test]
+    fn down_then_out_of_service_does_not_recover() {
+        // Down (alert) → OutOfService: the alert stays active; no recovery emitted.
+        let decision =
+            recovery_decision_for_sequence(&[HealthStatus::Down, HealthStatus::OutOfService]);
+        assert_eq!(
+            decision, None,
+            "OutOfService after Down must NOT emit a recovery (service still unhealthy)"
+        );
+    }
+
+    #[test]
+    fn down_then_up_recovers() {
+        // Down (alert) → Up: a genuine recovery is emitted for the active key.
+        let decision = recovery_decision_for_sequence(&[HealthStatus::Down, HealthStatus::Up]);
+        assert_eq!(
+            decision,
+            Some(DedupDecision::Send),
+            "a genuinely healthy status after Down must emit a recovery"
+        );
+    }
+
+    #[test]
+    fn down_then_out_of_service_then_up_recovers_once() {
+        // The alert survives the OutOfService dip and recovers when finally Up.
+        let decision = recovery_decision_for_sequence(&[
+            HealthStatus::Down,
+            HealthStatus::OutOfService,
+            HealthStatus::Up,
+        ]);
+        assert_eq!(decision, Some(DedupDecision::Send));
     }
 
     // ── Severity classification ──────────────────────────────────────────────

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -600,6 +600,31 @@ pub fn notify_scheduled_task_failure(state: &AppState, task_name: &str, error: &
     let _ = alerter.notify(alert);
 }
 
+/// Recovery for condition (d): a previously-failing framework-scheduled task
+/// completed successfully. Called from the scheduler's success arms.
+///
+/// No-op when no alerter is installed. Uses the SAME dedup key as
+/// [`notify_scheduled_task_failure`] so the recovery clears an outstanding
+/// failure; the dedup gate ([`AlertDeduplicator::on_resolve`]) makes it a no-op
+/// when the failure key was never active, so a task that has only ever succeeded
+/// sends nothing.
+pub fn notify_scheduled_task_recovered(state: &AppState, task_name: &str) {
+    let Some(alerter) = alerter(state) else {
+        return;
+    };
+    let alert = Alert::recovery(
+        AlertCondition::ScheduledTaskFailure,
+        format!("scheduled_task_failure:{task_name}"),
+    )
+    .title(format!("Scheduled task '{task_name}' recovered"))
+    .summary(format!(
+        "The framework-scheduled task '{task_name}' completed successfully after a previous failure."
+    ))
+    .detail("task", task_name)
+    .build();
+    let _ = alerter.recover(alert);
+}
+
 // ── Config ──────────────────────────────────────────────────────────────────
 
 const fn default_alerts_enabled() -> bool {
@@ -920,12 +945,45 @@ pub fn install_from_config(
     }
     #[cfg(feature = "http-client")]
     if let Some(url) = config.webhook_url.as_ref().filter(|s| !s.trim().is_empty()) {
-        let client = crate::http_client::Client::from_state(state);
-        channels.push(Arc::new(WebhookAlertChannel::new(
-            client,
-            url.clone(),
-            config.webhook_secret.clone(),
-        )));
+        // Alert webhooks are ALWAYS signed: the operator guide documents receivers
+        // verifying the `Autumn-Signature` header. A configured webhook with no
+        // non-empty signing secret would send UNSIGNED requests that a documented
+        // receiver rejects (or accepts unauthenticated) — so refuse to register the
+        // channel and warn, mirroring the disabled-mail-transport skip above.
+        // Never send unsigned.
+        if let Some(secret) = config
+            .webhook_secret
+            .as_ref()
+            .filter(|s| !s.trim().is_empty())
+        {
+            let client = crate::http_client::Client::from_state(state);
+            channels.push(Arc::new(WebhookAlertChannel::new(
+                client,
+                url.clone(),
+                Some(secret.clone()),
+            )));
+        } else {
+            tracing::warn!(
+                "alerts: a webhook destination is configured but no `webhook_secret` is set; \
+                 alert webhooks are always signed, so no webhook alerts will be delivered. Set \
+                 [alerts] webhook_secret (or the AUTUMN_ALERTS__WEBHOOK_SECRET env var)."
+            );
+        }
+    }
+    // Without the `http-client` feature the webhook branch above is compiled out,
+    // so a webhook-only config would silently install no channels and deliver no
+    // alerts. Warn loudly so operators don't believe webhook alerts are active.
+    #[cfg(not(feature = "http-client"))]
+    if config
+        .webhook_url
+        .as_ref()
+        .is_some_and(|s| !s.trim().is_empty())
+    {
+        tracing::warn!(
+            "operator-alerts: a webhook destination is configured but the `http-client` feature \
+             is not enabled; no webhook alerts will be delivered. Enable the `http-client` \
+             feature or use an email destination."
+        );
     }
 
     channels.extend(extra_channels);

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -1046,6 +1046,106 @@ fn is_absolute_http_url(url: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Whether `email` parses as the SAME lettre [`Mailbox`](lettre::message::Mailbox)
+/// the mail send path requires of every recipient.
+///
+/// The runtime's alert mail hands `[alerts] email` verbatim to
+/// `Mail::builder().to(...)`, and lettre parses the recipient only at SEND time —
+/// in [`parse_mailbox`](crate::mail)/`lettre_message`, not when the alert `Mail`
+/// is built. So a present-but-unparsable value like `not-an-address` or
+/// `mailto:oncall@example.com` passes every earlier gate yet fails EVERY delivery
+/// with `MailError::InvalidAddress`. Running the exact same `str::parse::<Mailbox>`
+/// here rejects such a value BEFORE the channel is registered, mirroring the
+/// disabled-transport / invalid-webhook skips and keeping the runtime in lock-step
+/// with `autumn-cli`'s `is_valid_bare_mailbox_doctor` (same validity notion) so
+/// doctor and the runtime agree on which addresses are usable.
+#[cfg(feature = "mail")]
+fn is_valid_alert_mailbox(email: &str) -> bool {
+    email.parse::<lettre::message::Mailbox>().is_ok()
+}
+
+/// Whether a mail transport actually needs a `from` address to deliver an alert.
+///
+/// Only `smtp` builds a real RFC 5322 message: `mail.rs`'s `lettre_message` errors
+/// with "mail from address is required" when `from` is absent, and it is reached
+/// solely from the SMTP transport. The `log` and `file` transports render `from`
+/// only when present and deliver without it; `disabled` is already skipped by the
+/// [`Mailer::is_disabled`](crate::mail::Mailer::is_disabled) guard. Mirrors
+/// `autumn-cli`'s `mail_transport_requires_from` so doctor and the runtime agree
+/// on which transports are blocked by a missing `from`.
+#[cfg(feature = "mail")]
+const fn mail_transport_requires_from(transport: crate::mail::Transport) -> bool {
+    matches!(transport, crate::mail::Transport::Smtp)
+}
+
+/// Resolve the built-in mail alert channel for a configured, non-empty `[alerts]
+/// email`, or `None` (after a dedicated `tracing::warn!`) when the mailer would
+/// deliver nothing at runtime.
+///
+/// Mirrors the disabled-transport / invalid-webhook skip-and-warn pattern in
+/// [`install_from_config`], skipping when:
+/// - the transport is the no-op disabled one (`Mailer::is_disabled`): it accepts
+///   and silently drops every message, so a registered channel would make an
+///   email-only prod config look active while delivering nothing;
+/// - the address is not a valid lettre [`Mailbox`](lettre::message::Mailbox):
+///   lettre parses `[alerts] email` only at SEND time, so a malformed value fails
+///   EVERY delivery with `MailError::InvalidAddress`;
+/// - the transport needs a `from` (SMTP) and no non-empty `[mail] from` resolves:
+///   the alert mail carries no per-message `from` and falls back to the mailer
+///   default, so SMTP send fails with "mail from address is required".
+///
+/// The resolved `[mail]` config is the faithful source for the last two
+/// preconditions: the framework builds this `Mailer` from `config.mail`
+/// (`Mailer::from_config`), so its transport kind and default `from` are exactly
+/// these fields — keeping the runtime skips in lock-step with doctor.
+#[cfg(feature = "mail")]
+fn build_mail_alert_channel(
+    state: &AppState,
+    mailer: Arc<crate::mail::Mailer>,
+    email: &str,
+) -> Option<Arc<dyn AlertChannel>> {
+    // TRIM the resolved address and treat the trimmed value as canonical (the
+    // caller already guaranteed it is non-empty after trimming): lettre parses
+    // the recipient at send time, so validate — and deliver to — the exact
+    // address the send path would parse.
+    let email_trimmed = email.trim();
+    if mailer.is_disabled() {
+        tracing::warn!(
+            "alerts: an operator email is configured but [mail] transport is disabled; \
+             no email alerts will be delivered. Set [mail] transport to a real backend \
+             or use a webhook destination."
+        );
+        return None;
+    }
+    if !is_valid_alert_mailbox(email_trimmed) {
+        tracing::warn!(
+            email = email_trimmed,
+            "alerts: the configured [alerts] email ({email_trimmed}) is not a valid email \
+             address; no email alerts will be delivered. Fix [alerts] email (or the \
+             AUTUMN_ALERTS__EMAIL env var)."
+        );
+        return None;
+    }
+    let mail_cfg = state.config().mail;
+    if mail_transport_requires_from(mail_cfg.transport)
+        && mail_cfg
+            .from
+            .as_deref()
+            .is_none_or(|from| from.trim().is_empty())
+    {
+        tracing::warn!(
+            "alerts: an operator email is configured but [mail] from is not set, so SMTP alert \
+             delivery will fail; no email alerts will be delivered. Set [mail] from (or the \
+             AUTUMN_MAIL__FROM env var) to a sender address, or use a webhook destination."
+        );
+        return None;
+    }
+    Some(Arc::new(MailAlertChannel::new(
+        mailer,
+        email_trimmed.to_owned(),
+    )))
+}
+
 /// Install the operator alerter from `config` plus any builder channels.
 ///
 /// Builds the built-in channels from `config`, combines them with any
@@ -1077,18 +1177,8 @@ pub fn install_from_config(
     #[cfg(feature = "mail")]
     if let Some(email) = config.email.as_ref().filter(|s| !s.trim().is_empty()) {
         if let Some(mailer) = state.extension::<crate::mail::Mailer>() {
-            // A `Mailer` backed by the disabled (no-op) transport accepts and
-            // silently drops every message, so registering a `MailAlertChannel`
-            // here would make an email-only prod config look active while
-            // delivering nothing. Warn and skip the dead channel instead.
-            if mailer.is_disabled() {
-                tracing::warn!(
-                    "alerts: an operator email is configured but [mail] transport is disabled; \
-                     no email alerts will be delivered. Set [mail] transport to a real backend \
-                     or use a webhook destination."
-                );
-            } else {
-                channels.push(Arc::new(MailAlertChannel::new(mailer, email.clone())));
+            if let Some(channel) = build_mail_alert_channel(state, mailer, email) {
+                channels.push(channel);
             }
         } else {
             tracing::warn!(

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -1645,8 +1645,14 @@ mod tests {
             "first sub-threshold tick must not evaluate"
         );
         // Baselines must be untouched so progress is preserved.
-        assert_eq!(last_requests, 0, "sub-threshold tick must not reset baseline");
-        assert_eq!(last_5xx, 0, "sub-threshold tick must not reset 5xx baseline");
+        assert_eq!(
+            last_requests, 0,
+            "sub-threshold tick must not reset baseline"
+        );
+        assert_eq!(
+            last_5xx, 0,
+            "sub-threshold tick must not reset 5xx baseline"
+        );
 
         // Tick 2: total=8, 5xx=2 -> still below threshold (delta from 0 is 8).
         assert_eq!(
@@ -1673,7 +1679,10 @@ mod tests {
             sample_error_window(15, 3, &mut last_requests, &mut last_5xx, min_requests),
             None
         );
-        assert_eq!(last_requests, 12, "baseline held across the next sub-threshold tick");
+        assert_eq!(
+            last_requests, 12,
+            "baseline held across the next sub-threshold tick"
+        );
         assert_eq!(last_5xx, 3);
     }
 

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -338,6 +338,30 @@ pub fn host_id() -> String {
         .unwrap_or_else(|| "unknown-host".to_owned())
 }
 
+/// Dedup key for the process-local **5xx-rate** condition, scoped to `host`.
+///
+/// The 5xx rate is evaluated from THIS process's local metrics, so every
+/// replica computes its own rate. The key is host-scoped so a consumer that
+/// correlates on `dedup_key` keeps each replica's incident separate: without
+/// the suffix, replica B's resolve would clear replica A's still-active
+/// incident and simultaneous spikes on different hosts would collapse into one
+/// condition. A trigger and its later resolve run in the SAME process, so
+/// `host_id()` yields an identical suffix and they still correlate.
+fn error_rate_dedup_key(host: &str) -> String {
+    format!("high_error_rate:5xx:{host}")
+}
+
+/// Dedup key for the process-local **health-indicator-down** condition, scoped
+/// to the specific `indicator` and to `host`.
+///
+/// Health is evaluated from THIS process's local indicator registry, so — like
+/// [`error_rate_dedup_key`] — the key is host-scoped so per-replica incidents
+/// stay distinct while a trigger and its later resolve (same process, same
+/// `host_id()`) still correlate.
+fn health_indicator_dedup_key(indicator: &str, host: &str) -> String {
+    format!("health_indicator_down:{indicator}:{host}")
+}
+
 // ── Delivery trait ──────────────────────────────────────────────────────────
 
 /// The future returned by [`AlertChannel::deliver`].
@@ -711,6 +735,18 @@ pub fn notify_scheduled_task_recovered(state: &AppState, task_name: &str) {
     let Some(alerter) = alerter(state) else {
         return;
     };
+    // KNOWN LIMITATION (multi-replica fleets): the `AlertDeduplicator` is
+    // process-local, so a recovery only clears an outstanding failure when it is
+    // emitted by the SAME replica that observed the failure. Scheduled tasks are
+    // lease-coordinated across the fleet, so the failure can be seen by replica A
+    // and the later success run by replica B after a leader handoff; B has no
+    // active `scheduled_task_failure:{task}` key locally, so `on_resolve`
+    // suppresses the resolve and A's failure alert is never cleared. This is why
+    // the scheduled-task key is deliberately NOT host-scoped (a global key is
+    // still the closest correlation available). A real fix needs shared
+    // active-alert state (Postgres/Redis) or an unconditional correlated resolve,
+    // both out of scope for #1610 (fleet-level alert aggregation is listed as a
+    // non-goal); tracked for the shared-alert-state follow-up (#1630).
     let alert = Alert::recovery(
         AlertCondition::ScheduledTaskFailure,
         format!("scheduled_task_failure:{task_name}"),
@@ -1190,7 +1226,10 @@ fn evaluate_error_rate(
     };
     #[allow(clippy::cast_precision_loss)]
     let rate = err_delta as f64 / req_delta as f64;
-    let key = "high_error_rate:5xx".to_owned();
+    // Host-scope the key: this rate is from the local process's metrics, so
+    // each replica must own its incident (see `error_rate_dedup_key`). The
+    // trigger and resolve below share this same `key`, so they still correlate.
+    let key = error_rate_dedup_key(&host_id());
     if rate >= settings.error_rate_threshold {
         let pct = rate * 100.0;
         let threshold_pct = settings.error_rate_threshold * 100.0;
@@ -1275,8 +1314,13 @@ async fn evaluate_health(
     let grace = chrono::Duration::from_std(settings.health_grace)
         .unwrap_or_else(|_| chrono::Duration::seconds(60));
 
+    let host = host_id();
     for result in &results {
-        let key = format!("health_indicator_down:{}", result.name);
+        // Host-scope the per-indicator key: health is evaluated from this
+        // process's local registry, so each replica owns its incident (see
+        // `health_indicator_dedup_key`). The trigger and resolve arms below
+        // share this same `key`, so they still correlate.
+        let key = health_indicator_dedup_key(&result.name, &host);
         match classify_health_transition(result.output.status) {
             HealthTransition::Down => {
                 let first = *down_since.entry(result.name.clone()).or_insert(now);
@@ -1642,6 +1686,58 @@ mod tests {
         let t = Alert::trigger(AlertCondition::DeadLetteredJob, key).build();
         let r = Alert::recovery(AlertCondition::DeadLetteredJob, key).build();
         assert_eq!(t.dedup_key, r.dedup_key);
+    }
+
+    // ── Host-scoped dedup keys for the process-local conditions (P2) ──────────
+    // The 5xx-rate and health-indicator-down conditions are evaluated from THIS
+    // process's local metrics/registry, so their dedup keys carry the host id:
+    // two replicas produce DIFFERENT keys (their incidents stay distinct), while
+    // a single replica's trigger and resolve — same process, same `host_id()` —
+    // produce the SAME key so a consumer still correlates them.
+
+    #[test]
+    fn error_rate_dedup_key_is_host_scoped() {
+        // Different hosts -> different keys (incidents stay separate per replica).
+        assert_ne!(
+            error_rate_dedup_key("replica-a"),
+            error_rate_dedup_key("replica-b"),
+            "two replicas must not share the 5xx dedup key"
+        );
+        // Same host -> the trigger and its later resolve (both in-process) match.
+        let host = "replica-a";
+        let trigger_key = error_rate_dedup_key(host);
+        let resolve_key = error_rate_dedup_key(host);
+        assert_eq!(
+            trigger_key, resolve_key,
+            "same-host trigger and resolve must correlate"
+        );
+        // The host is appended to the existing key format.
+        assert_eq!(trigger_key, "high_error_rate:5xx:replica-a");
+    }
+
+    #[test]
+    fn health_indicator_dedup_key_is_host_scoped() {
+        // Different hosts -> different keys for the same indicator.
+        assert_ne!(
+            health_indicator_dedup_key("db", "replica-a"),
+            health_indicator_dedup_key("db", "replica-b"),
+            "two replicas must not share a health dedup key for the same indicator"
+        );
+        // Different indicators on the same host also stay distinct.
+        assert_ne!(
+            health_indicator_dedup_key("db", "replica-a"),
+            health_indicator_dedup_key("cache", "replica-a"),
+        );
+        // Same host + indicator -> the trigger and its resolve match.
+        let host = "replica-a";
+        let trigger_key = health_indicator_dedup_key("db", host);
+        let resolve_key = health_indicator_dedup_key("db", host);
+        assert_eq!(
+            trigger_key, resolve_key,
+            "same-host trigger and resolve must correlate"
+        );
+        // The host is appended to the existing per-indicator key format.
+        assert_eq!(trigger_key, "health_indicator_down:db:replica-a");
     }
 
     // ── Fan-out (delivery to every channel) ──────────────────────────────────

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -863,37 +863,57 @@ impl AlertChannel for WebhookAlertChannel {
 /// [`Alerter`] onto `state`, and starts the background evaluation loop for the
 /// health and 5xx-rate conditions.
 ///
-/// Does nothing (and installs nothing) when alerts are inactive
-/// ([`AlertConfig::is_active`] is `false`) *and* no extra channels were
-/// registered — so an app with no destination pays nothing.
+/// `config.enabled` is the master off switch. When it is `false` the *entire*
+/// alerting subsystem is silent: no built-in channels, no custom/extra channels
+/// registered via [`AppBuilder::with_alert_channel`](crate::app::AppBuilder::with_alert_channel),
+/// no background evaluation loop, and no [`Alerter`] installed onto `state` (so
+/// the `notify_*` hooks become no-ops). Nothing is installed either when
+/// alerting is enabled but there is no destination and no extra channel — so an
+/// app with no configured destination pays nothing.
 pub fn install_from_config(
     state: &AppState,
     config: &AlertConfig,
     extra_channels: Vec<Arc<dyn AlertChannel>>,
 ) {
+    // Master off switch: `enabled = false` silences EVERYTHING, including any
+    // custom channel registered via `with_alert_channel`. Install nothing, do
+    // not start the evaluation loop, and do not put an alerter onto `state`.
+    if !config.enabled {
+        return;
+    }
+
     let mut channels: Vec<Arc<dyn AlertChannel>> = Vec::new();
 
-    if config.enabled {
-        #[cfg(feature = "mail")]
-        if let Some(email) = config.email.as_ref().filter(|s| !s.trim().is_empty()) {
-            if let Some(mailer) = state.extension::<crate::mail::Mailer>() {
-                channels.push(Arc::new(MailAlertChannel::new(mailer, email.clone())));
-            } else {
-                tracing::warn!(
-                    "alerts: an operator email is configured but no mailer is installed; \
-                     configure [mail] to enable email alerts"
-                );
-            }
+    #[cfg(feature = "mail")]
+    if let Some(email) = config.email.as_ref().filter(|s| !s.trim().is_empty()) {
+        if let Some(mailer) = state.extension::<crate::mail::Mailer>() {
+            channels.push(Arc::new(MailAlertChannel::new(mailer, email.clone())));
+        } else {
+            tracing::warn!(
+                "alerts: an operator email is configured but no mailer is installed; \
+                 configure [mail] to enable email alerts"
+            );
         }
-        #[cfg(feature = "http-client")]
-        if let Some(url) = config.webhook_url.as_ref().filter(|s| !s.trim().is_empty()) {
-            let client = crate::http_client::Client::from_state(state);
-            channels.push(Arc::new(WebhookAlertChannel::new(
-                client,
-                url.clone(),
-                config.webhook_secret.clone(),
-            )));
-        }
+    }
+    // Without the `mail` feature the email branch above is compiled out, so an
+    // email-only config would silently install no channels and deliver no
+    // alerts. Warn loudly so operators don't believe email alerts are active.
+    #[cfg(not(feature = "mail"))]
+    if config.email.as_ref().is_some_and(|s| !s.trim().is_empty()) {
+        tracing::warn!(
+            "operator-alerts: an email destination is configured but the `mail` feature is not \
+             enabled; no email alerts will be delivered. Enable the `mail` feature or use a \
+             webhook destination."
+        );
+    }
+    #[cfg(feature = "http-client")]
+    if let Some(url) = config.webhook_url.as_ref().filter(|s| !s.trim().is_empty()) {
+        let client = crate::http_client::Client::from_state(state);
+        channels.push(Arc::new(WebhookAlertChannel::new(
+            client,
+            url.clone(),
+            config.webhook_secret.clone(),
+        )));
     }
 
     channels.extend(extra_channels);

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -520,34 +520,34 @@ impl Alerter {
         if self.inner.channels.is_empty() {
             return;
         }
-        let inner = Arc::clone(&self.inner);
-        let run = async move {
-            for channel in &inner.channels {
+        // Dispatch is best-effort: with a Tokio runtime handle we spawn one
+        // detached task *per channel* so a slow or hanging channel never blocks
+        // delivery to the others; with no handle available (unlikely from a hook
+        // site) the alert is logged and skipped, never blocking the caller.
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            tracing::warn!("no tokio runtime available for alert dispatch; skipping");
+            return;
+        };
+        let alert = Arc::new(alert);
+        for channel in &self.inner.channels {
+            let channel = Arc::clone(channel);
+            let alert = Arc::clone(&alert);
+            handle.spawn(async move {
+                let name = channel.name();
                 match channel.deliver(&alert).await {
                     Ok(()) => tracing::debug!(
-                        channel = channel.name(),
+                        channel = name,
                         dedup_key = %alert.dedup_key,
                         "operator alert delivered"
                     ),
                     Err(error) => tracing::error!(
-                        channel = channel.name(),
+                        channel = name,
                         dedup_key = %alert.dedup_key,
                         error = %error,
                         "operator alert delivery failed; app continues serving"
                     ),
                 }
-            }
-        };
-        // Dispatch is best-effort: with a Tokio runtime handle we spawn a
-        // detached task; with no handle available (unlikely from a hook site)
-        // the alert is logged and skipped, never blocking the caller.
-        match tokio::runtime::Handle::try_current() {
-            Ok(handle) => {
-                handle.spawn(run);
-            }
-            Err(_) => {
-                tracing::warn!("no tokio runtime available for alert dispatch; skipping");
-            }
+            });
         }
     }
 }
@@ -935,9 +935,37 @@ fn spawn_evaluation_loop(state: AppState, alerter: Alerter) {
     });
 }
 
+/// Advance the 5xx sampling window for one tick.
+///
+/// Returns `Some((req_delta, err_delta))` — and advances the baseline counters
+/// — only when the accumulated request delta has reached `min_requests`, i.e.
+/// when a real evaluation should happen. When the tick is still below the
+/// threshold it returns `None` and leaves the baselines **untouched**, so a
+/// low-traffic app whose per-tick traffic never reaches `min_requests` keeps
+/// accumulating requests across ticks instead of resetting every tick. The
+/// window therefore measures "since the last evaluation" rather than "since the
+/// last tick."
+const fn sample_error_window(
+    total: u64,
+    s5xx: u64,
+    last_requests: &mut u64,
+    last_5xx: &mut u64,
+    min_requests: u64,
+) -> Option<(u64, u64)> {
+    let req_delta = total.saturating_sub(*last_requests);
+    if req_delta < min_requests {
+        // Leave baselines untouched so counts accumulate across ticks.
+        return None;
+    }
+    let err_delta = s5xx.saturating_sub(*last_5xx);
+    *last_requests = total;
+    *last_5xx = s5xx;
+    Some((req_delta, err_delta))
+}
+
 /// Condition (c): compute the 5xx rate over the requests seen since the last
-/// tick and compare to the threshold. Reads existing cumulative counters — the
-/// request path is untouched.
+/// evaluation and compare to the threshold. Reads existing cumulative counters
+/// — the request path is untouched.
 fn evaluate_error_rate(
     alerter: &Alerter,
     state: &AppState,
@@ -948,14 +976,15 @@ fn evaluate_error_rate(
     let snap = state.metrics().snapshot();
     let total = snap.http.requests_total;
     let s5xx = snap.http.by_status.s5xx;
-    let req_delta = total.saturating_sub(*last_requests);
-    let err_delta = s5xx.saturating_sub(*last_5xx);
-    *last_requests = total;
-    *last_5xx = s5xx;
-
-    if req_delta < settings.error_rate_min_requests {
+    let Some((req_delta, err_delta)) = sample_error_window(
+        total,
+        s5xx,
+        last_requests,
+        last_5xx,
+        settings.error_rate_min_requests,
+    ) else {
         return;
-    }
+    };
     #[allow(clippy::cast_precision_loss)]
     let rate = err_delta as f64 / req_delta as f64;
     let key = "high_error_rate:5xx".to_owned();
@@ -1244,6 +1273,54 @@ mod tests {
         assert!(c.is_active());
         c.enabled = false;
         assert!(!c.is_active(), "disabled -> inactive even with destination");
+    }
+
+    #[test]
+    fn sub_threshold_ticks_accumulate_until_window_crosses_min_requests() {
+        // min_requests = 10; each tick adds 4 requests (below threshold) with
+        // 1 new 5xx. Baselines must NOT reset on the sub-threshold ticks so the
+        // requests accumulate until the summed window finally crosses 10.
+        let min_requests = 10;
+        let mut last_requests = 0;
+        let mut last_5xx = 0;
+
+        // Tick 1: total=4, 5xx=1 -> below threshold, no evaluation.
+        assert_eq!(
+            sample_error_window(4, 1, &mut last_requests, &mut last_5xx, min_requests),
+            None,
+            "first sub-threshold tick must not evaluate"
+        );
+        // Baselines must be untouched so progress is preserved.
+        assert_eq!(last_requests, 0, "sub-threshold tick must not reset baseline");
+        assert_eq!(last_5xx, 0, "sub-threshold tick must not reset 5xx baseline");
+
+        // Tick 2: total=8, 5xx=2 -> still below threshold (delta from 0 is 8).
+        assert_eq!(
+            sample_error_window(8, 2, &mut last_requests, &mut last_5xx, min_requests),
+            None,
+            "second sub-threshold tick must not evaluate"
+        );
+        assert_eq!(last_requests, 0);
+        assert_eq!(last_5xx, 0);
+
+        // Tick 3: total=12, 5xx=3 -> accumulated delta 12 >= 10, evaluate now
+        // over the whole accumulated window (12 requests, 3 errors).
+        assert_eq!(
+            sample_error_window(12, 3, &mut last_requests, &mut last_5xx, min_requests),
+            Some((12, 3)),
+            "window must evaluate once summed requests cross the threshold"
+        );
+        // Only now do the baselines advance to the evaluated point.
+        assert_eq!(last_requests, 12, "baseline advances only after evaluation");
+        assert_eq!(last_5xx, 3);
+
+        // Next sub-threshold tick starts a fresh accumulation from 12.
+        assert_eq!(
+            sample_error_window(15, 3, &mut last_requests, &mut last_5xx, min_requests),
+            None
+        );
+        assert_eq!(last_requests, 12, "baseline held across the next sub-threshold tick");
+        assert_eq!(last_5xx, 3);
     }
 
     #[test]

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -1448,43 +1448,44 @@ fn evaluate_error_rate(
 
 /// How a health indicator's current status maps onto the alert state machine.
 ///
-/// Factored out of [`evaluate_health`] so the three-way branch is unit-testable
-/// without an `AppState`/registry. The key subtlety: recovery must be gated on
-/// [`HealthStatus::is_healthy`], NOT merely `!= Down`. `OutOfService` is a
-/// non-`Down` status that is still UNHEALTHY (`/actuator/health` reports
-/// non-200), so treating it as "recovered" would emit a false recovery while the
-/// service is still degraded.
+/// Factored out of [`evaluate_health`] so the branch is unit-testable without an
+/// `AppState`/registry. The decision hinges on [`HealthStatus::is_healthy`]: any
+/// non-healthy status triggers, and only a genuinely healthy status recovers.
+/// `OutOfService` is non-`Down` but still UNHEALTHY (`/actuator/health` reports
+/// non-200), so it takes the **trigger** path — an indicator that reports
+/// `OUT_OF_SERVICE` without ever passing through `Down` is still alerted. This
+/// also preserves the no-false-recovery property: an already-alerted `Down`
+/// indicator that dips to `OutOfService` stays unhealthy, so it stays active
+/// instead of emitting a spurious "recovered".
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum HealthTransition {
-    /// Status is `Down`: run the grace-period trigger logic.
-    Down,
+    /// Status is not healthy (`Down`, `OutOfService`, or any other non-healthy
+    /// variant): run the grace-period trigger logic.
+    Trigger,
     /// Status is genuinely healthy again (`is_healthy()`): clear tracking and
     /// emit a recovery for any outstanding alert.
     Recover,
-    /// Status is non-`Down` but still not healthy (e.g. `OutOfService`): hold
-    /// the active alert as-is — no recovery, and no new trigger (only `Down`
-    /// triggers, matching existing behavior).
-    Hold,
 }
 
 /// Classify a health indicator's status into the alert-state transition it
-/// drives. Uses [`HealthStatus::is_healthy`] (not `== Up`) so `Unknown` — which
-/// the actuator reports as healthy — recovers, while `OutOfService` holds.
+/// drives. Uses [`HealthStatus::is_healthy`] (not `== Up`/`== Down`) so `Unknown`
+/// — which the actuator reports as healthy — recovers, while every non-healthy
+/// status (`Down`, `OutOfService`, …) triggers.
 const fn classify_health_transition(status: crate::actuator::HealthStatus) -> HealthTransition {
-    if matches!(status, crate::actuator::HealthStatus::Down) {
-        HealthTransition::Down
-    } else if status.is_healthy() {
+    if status.is_healthy() {
         HealthTransition::Recover
     } else {
-        HealthTransition::Hold
+        HealthTransition::Trigger
     }
 }
 
 /// Condition (b): run all health indicators, track how long each has been
-/// `Down`, and alert once an indicator has stayed `Down` past the grace period.
-/// Recover only when it reports a genuinely healthy status again — a non-`Down`
-/// but still-unhealthy status (e.g. `OutOfService`) holds the active alert
-/// rather than emitting a false recovery.
+/// non-healthy, and alert once an indicator has stayed non-healthy past the grace
+/// period. The trigger fires for **any** non-healthy status (`Down`,
+/// `OutOfService`, …), matching what `/actuator/health` reports as non-200.
+/// Recover only when it reports a genuinely healthy status again — a still-unhealthy
+/// status (e.g. `OutOfService` after `Down`) keeps the active alert rather than
+/// emitting a false recovery.
 async fn evaluate_health(
     alerter: &Alerter,
     state: &AppState,
@@ -1504,14 +1505,15 @@ async fn evaluate_health(
         // share this same `key`, so they still correlate.
         let key = health_indicator_dedup_key(&result.name, &host);
         match classify_health_transition(result.output.status) {
-            HealthTransition::Down => {
+            HealthTransition::Trigger => {
+                let status = result.output.status;
                 let first = *down_since.entry(result.name.clone()).or_insert(now);
                 if now - first >= grace {
                     let secs = (now - first).num_seconds().max(0);
                     let alert = Alert::trigger(AlertCondition::HealthIndicatorDown, key)
-                        .title(format!("Health indicator '{}' is Down", result.name))
+                        .title(format!("Health indicator '{}' is {status:?}", result.name))
                         .summary(format!(
-                            "Health indicator '{}' has reported Down for {secs}s, past the \
+                            "Health indicator '{}' has reported {status:?} for {secs}s, past the \
                              {grace_secs}s grace period.",
                             result.name,
                             grace_secs = settings.health_grace.as_secs(),
@@ -1521,6 +1523,7 @@ async fn evaluate_health(
                             AlertCondition::HealthIndicatorDown,
                         ))
                         .detail("indicator", result.name.clone())
+                        .detail("status", status.as_str())
                         .detail("down_seconds", secs.to_string())
                         .build();
                     let _ = alerter.notify(alert);
@@ -1545,11 +1548,6 @@ async fn evaluate_health(
                         .build();
                     let _ = alerter.recover(alert);
                 }
-            }
-            HealthTransition::Hold => {
-                // Non-`Down` but still unhealthy (e.g. `OutOfService`): leave the
-                // active alert and `down_since` bookkeeping untouched so we do not
-                // emit a "recovered" alert while `/actuator/health` is non-healthy.
             }
         }
     }
@@ -1627,10 +1625,12 @@ mod tests {
         assert_eq!(d.on_trigger("k", ts(10)), DedupDecision::Send);
     }
 
-    // ── Health-indicator recovery classification (P2: recover only when healthy)
-    // The three-way branch in `evaluate_health`: `Down` triggers, a genuinely
-    // healthy status recovers, and any other non-healthy status (`OutOfService`)
-    // holds the active alert instead of emitting a false recovery.
+    // ── Health-indicator classification (P2: unhealthy triggers, healthy recovers)
+    // The branch in `evaluate_health`: any non-healthy status (`Down`,
+    // `OutOfService`, …) triggers the grace-period logic, and only a genuinely
+    // healthy status recovers. This means `OutOfService` reached WITHOUT a prior
+    // `Down` is still alerted, while a `Down`→`OutOfService` dip stays unhealthy
+    // (no false recovery).
 
     use crate::actuator::HealthStatus;
 
@@ -1638,7 +1638,7 @@ mod tests {
     fn health_down_status_drives_trigger_branch() {
         assert_eq!(
             classify_health_transition(HealthStatus::Down),
-            HealthTransition::Down
+            HealthTransition::Trigger
         );
     }
 
@@ -1657,67 +1657,104 @@ mod tests {
     }
 
     #[test]
-    fn out_of_service_holds_active_alert_instead_of_recovering() {
-        // `OutOfService` is non-`Down` but still UNHEALTHY: it must NOT recover.
+    fn out_of_service_triggers_like_down() {
+        // `OutOfService` is non-`Down` but still UNHEALTHY: it must take the
+        // trigger path (not recover, not silently hold), so an indicator that
+        // reports `OUT_OF_SERVICE` without ever going `Down` is still alerted.
         assert!(!HealthStatus::OutOfService.is_healthy());
         assert_eq!(
             classify_health_transition(HealthStatus::OutOfService),
-            HealthTransition::Hold
+            HealthTransition::Trigger
         );
     }
 
+    /// What `evaluate_health` did for an indicator on a single tick. Lets the
+    /// sequence tests distinguish a *trigger* send from a *recovery* send (an
+    /// `Option<DedupDecision>` alone would conflate them).
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum HealthTick {
+        /// The trigger arm ran (non-healthy, past grace); carries the dedup
+        /// decision (`Send` on first alert, `Suppress` while already active).
+        Triggered(DedupDecision),
+        /// The recover arm emitted a resolve for a previously-active key.
+        Recovered(DedupDecision),
+        /// Nothing was emitted (inside the grace window, or a healthy tick with
+        /// no active alert to clear).
+        Idle,
+    }
+
     /// Drive the exact `down_since` + deduplicator bookkeeping `evaluate_health`
-    /// performs for a single indicator across a status sequence, returning the
-    /// dedup decision for any recovery emitted on the final tick (`None` when no
-    /// recovery was attempted). Proves the recovery is gated on a genuinely
-    /// healthy status, not merely `!= Down`.
-    fn recovery_decision_for_sequence(statuses: &[HealthStatus]) -> Option<DedupDecision> {
+    /// performs for a single indicator across a status sequence, applying the
+    /// given grace period, and reporting what happened on the FINAL tick. Proves
+    /// both directions of the unified rule: any non-healthy status triggers, and
+    /// recovery is gated on a genuinely healthy status (not merely `!= Down`).
+    fn health_tick_for_sequence(statuses: &[HealthStatus], grace: chrono::Duration) -> HealthTick {
         let name = "db";
         let key = format!("health_indicator_down:{name}");
         let mut dedup = AlertDeduplicator::new(std::time::Duration::from_secs(900));
         let mut down_since: HashMap<String, DateTime<Utc>> = HashMap::new();
-        // Zero grace period so a single `Down` tick alerts immediately.
-        let grace = chrono::Duration::seconds(0);
-        let mut last = None;
+        let mut last = HealthTick::Idle;
         for (i, status) in statuses.iter().enumerate() {
-            last = None;
+            last = HealthTick::Idle;
             let now = ts(i64::try_from(i).unwrap());
             match classify_health_transition(*status) {
-                HealthTransition::Down => {
+                HealthTransition::Trigger => {
                     let first = *down_since.entry(name.to_owned()).or_insert(now);
                     if now - first >= grace {
-                        let _ = dedup.on_trigger(&key, now);
+                        last = HealthTick::Triggered(dedup.on_trigger(&key, now));
                     }
                 }
                 HealthTransition::Recover => {
                     if down_since.remove(name).is_some() {
-                        last = Some(dedup.on_resolve(&key));
+                        last = HealthTick::Recovered(dedup.on_resolve(&key));
                     }
                 }
-                HealthTransition::Hold => {}
             }
         }
         last
     }
 
+    /// Convenience wrapper: run [`health_tick_for_sequence`] with a zero grace
+    /// period (so a single non-healthy tick alerts immediately). Used by the
+    /// recovery-focused sequences below.
+    fn recovery_tick_for_sequence(statuses: &[HealthStatus]) -> HealthTick {
+        health_tick_for_sequence(statuses, chrono::Duration::seconds(0))
+    }
+
+    #[test]
+    fn out_of_service_without_prior_down_triggers_after_grace() {
+        // The former bug: an indicator that reports OutOfService WITHOUT ever
+        // going Down was never alerted. Now it takes the trigger path, so once the
+        // down-duration passes the grace period an alert fires (Send on the first
+        // notification).
+        let tick = recovery_tick_for_sequence(&[HealthStatus::OutOfService]);
+        assert_eq!(
+            tick,
+            HealthTick::Triggered(DedupDecision::Send),
+            "OutOfService with no prior Down must fire an alert once past the grace period"
+        );
+    }
+
     #[test]
     fn down_then_out_of_service_does_not_recover() {
-        // Down (alert) → OutOfService: the alert stays active; no recovery emitted.
-        let decision =
-            recovery_decision_for_sequence(&[HealthStatus::Down, HealthStatus::OutOfService]);
+        // Down (alert) → OutOfService: the alert stays active (the OutOfService
+        // tick re-enters the trigger arm and is deduped as still-active) and NO
+        // recovery is emitted — the service is still unhealthy.
+        let tick = recovery_tick_for_sequence(&[HealthStatus::Down, HealthStatus::OutOfService]);
         assert_eq!(
-            decision, None,
-            "OutOfService after Down must NOT emit a recovery (service still unhealthy)"
+            tick,
+            HealthTick::Triggered(DedupDecision::Suppress),
+            "OutOfService after Down must stay active (no recovery, deduped trigger)"
         );
     }
 
     #[test]
     fn down_then_up_recovers() {
         // Down (alert) → Up: a genuine recovery is emitted for the active key.
-        let decision = recovery_decision_for_sequence(&[HealthStatus::Down, HealthStatus::Up]);
+        let tick = recovery_tick_for_sequence(&[HealthStatus::Down, HealthStatus::Up]);
         assert_eq!(
-            decision,
-            Some(DedupDecision::Send),
+            tick,
+            HealthTick::Recovered(DedupDecision::Send),
             "a genuinely healthy status after Down must emit a recovery"
         );
     }
@@ -1725,12 +1762,32 @@ mod tests {
     #[test]
     fn down_then_out_of_service_then_up_recovers_once() {
         // The alert survives the OutOfService dip and recovers when finally Up.
-        let decision = recovery_decision_for_sequence(&[
+        let tick = recovery_tick_for_sequence(&[
             HealthStatus::Down,
             HealthStatus::OutOfService,
             HealthStatus::Up,
         ]);
-        assert_eq!(decision, Some(DedupDecision::Send));
+        assert_eq!(tick, HealthTick::Recovered(DedupDecision::Send));
+    }
+
+    #[test]
+    fn brief_unhealthy_blip_inside_grace_window_does_not_alert() {
+        // A single non-healthy tick that recovers before the grace period elapses
+        // must NOT alert. With a 60s grace and consecutive 1s ticks, the lone
+        // OutOfService tick is inside the window (no trigger fires), and the
+        // following Up tick clears the tracking — but since no alert ever
+        // triggered, the resolve is dedup-gated to `Suppress`, so no notification
+        // is sent either way.
+        let tick = health_tick_for_sequence(
+            &[HealthStatus::OutOfService, HealthStatus::Up],
+            chrono::Duration::seconds(60),
+        );
+        assert_eq!(
+            tick,
+            HealthTick::Recovered(DedupDecision::Suppress),
+            "an unhealthy blip inside the grace window must not send a trigger, and its \
+             resolve must be suppressed (no active alert to clear)"
+        );
     }
 
     // ── Severity classification ──────────────────────────────────────────────

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -98,7 +98,14 @@ impl AlertCondition {
         }
     }
 
-    /// The actuator endpoint an operator should consult for this condition.
+    /// The actuator endpoint an operator should consult for this condition,
+    /// under the **default** actuator prefix (`/actuator`).
+    ///
+    /// This is the builder default. When the app configures a custom
+    /// `[actuator] prefix`, the emitted alert's `where_to_look` is rebuilt from
+    /// the effective prefix (see [`actuator_where_to_look`]) so it points at the
+    /// real endpoint rather than a `/actuator/*` 404. Keep the suffixes here in
+    /// sync with [`Self::actuator_suffix`].
     #[must_use]
     pub const fn where_to_look(self) -> &'static str {
         match self {
@@ -108,6 +115,32 @@ impl AlertCondition {
             Self::ScheduledTaskFailure => "/actuator/tasks",
         }
     }
+
+    /// The actuator endpoint suffix (path *below* the actuator prefix) an
+    /// operator should consult for this condition. Combined with the effective
+    /// prefix by [`actuator_where_to_look`].
+    const fn actuator_suffix(self) -> &'static str {
+        match self {
+            Self::DeadLetteredJob => "/jobs",
+            Self::HealthIndicatorDown => "/health",
+            Self::HighErrorRate => "/metrics",
+            Self::ScheduledTaskFailure => "/tasks",
+        }
+    }
+}
+
+/// Build the actuator `where_to_look` pointer for `condition` under the
+/// effective actuator `prefix`.
+///
+/// Uses the same path builder as the router
+/// ([`actuator_route_path`](crate::actuator::actuator_route_path)) so the
+/// derived path matches the mounted endpoint exactly — including prefix
+/// normalization (leading slash added, trailing slash trimmed, `/` or empty
+/// treated as root) — and never yields `//` or a missing slash. With the
+/// default prefix (`/actuator`) this reproduces
+/// [`AlertCondition::where_to_look`] byte-for-byte.
+fn actuator_where_to_look(prefix: &str, condition: AlertCondition) -> String {
+    crate::actuator::actuator_route_path(prefix, condition.actuator_suffix())
 }
 
 /// Severity class of an [`Alert`]. External routers (`PagerDuty` etc.) map this
@@ -421,16 +454,22 @@ pub struct AlerterSettings {
     pub error_rate_min_requests: u64,
     /// Background evaluation cadence (conditions b and c).
     pub eval_interval: std::time::Duration,
+    /// The effective actuator URL prefix (`[actuator] prefix`, default
+    /// `/actuator`). Every alert's `where_to_look` pointer is built from this so
+    /// operators are sent to the real actuator endpoint even when the prefix is
+    /// customized. Stored raw; normalization happens in [`actuator_where_to_look`].
+    pub actuator_prefix: String,
 }
 
 impl AlerterSettings {
-    fn from_config(config: &AlertConfig) -> Self {
+    fn from_config(config: &AlertConfig, actuator_prefix: String) -> Self {
         Self {
             dedup_window: std::time::Duration::from_secs(config.dedup_window_secs.max(1)),
             health_grace: std::time::Duration::from_secs(config.health_grace_secs),
             error_rate_threshold: config.error_rate_threshold,
             error_rate_min_requests: config.error_rate_min_requests.max(1),
             eval_interval: std::time::Duration::from_secs(config.eval_interval_secs.max(1)),
+            actuator_prefix,
         }
     }
 }
@@ -574,6 +613,10 @@ pub fn notify_dead_lettered_job(state: &AppState, job_name: &str, error: &str) {
     .summary(format!(
         "Background job '{job_name}' exhausted its retries and was moved to the dead-letter queue. Last error: {error}"
     ))
+    .where_to_look(actuator_where_to_look(
+        &alerter.settings().actuator_prefix,
+        AlertCondition::DeadLetteredJob,
+    ))
     .detail("job", job_name)
     .detail("error", error)
     .build();
@@ -593,6 +636,10 @@ pub fn notify_scheduled_task_failure(state: &AppState, task_name: &str, error: &
     .title(format!("Scheduled task '{task_name}' failed"))
     .summary(format!(
         "The framework-scheduled task '{task_name}' returned an error on its last run: {error}"
+    ))
+    .where_to_look(actuator_where_to_look(
+        &alerter.settings().actuator_prefix,
+        AlertCondition::ScheduledTaskFailure,
     ))
     .detail("task", task_name)
     .detail("error", error)
@@ -619,6 +666,10 @@ pub fn notify_scheduled_task_recovered(state: &AppState, task_name: &str) {
     .title(format!("Scheduled task '{task_name}' recovered"))
     .summary(format!(
         "The framework-scheduled task '{task_name}' completed successfully after a previous failure."
+    ))
+    .where_to_look(actuator_where_to_look(
+        &alerter.settings().actuator_prefix,
+        AlertCondition::ScheduledTaskFailure,
     ))
     .detail("task", task_name)
     .build();
@@ -992,7 +1043,11 @@ pub fn install_from_config(
         return;
     }
 
-    let settings = AlerterSettings::from_config(config);
+    // Capture the effective actuator prefix so every alert's `where_to_look`
+    // points at the real actuator endpoints even under a custom `[actuator]
+    // prefix`. The full config is installed on `state` before this runs.
+    let actuator_prefix = state.config().actuator.prefix;
+    let settings = AlerterSettings::from_config(config, actuator_prefix);
     let alerter = Alerter::new(channels, settings);
     state.insert_extension(alerter.clone());
     spawn_evaluation_loop(state.clone(), alerter);
@@ -1087,6 +1142,10 @@ fn evaluate_error_rate(
                 "{err_delta} of the last {req_delta} requests returned 5xx ({pct:.1}%), \
                  crossing the {threshold_pct:.1}% threshold."
             ))
+            .where_to_look(actuator_where_to_look(
+                &settings.actuator_prefix,
+                AlertCondition::HighErrorRate,
+            ))
             .detail("rate", format!("{rate:.4}"))
             .detail("errors", err_delta.to_string())
             .detail("requests", req_delta.to_string())
@@ -1098,6 +1157,10 @@ fn evaluate_error_rate(
             .summary(format!(
                 "The 5xx error rate is back under the threshold ({pct:.1}% of {req_delta} requests).",
                 pct = rate * 100.0,
+            ))
+            .where_to_look(actuator_where_to_look(
+                &settings.actuator_prefix,
+                AlertCondition::HighErrorRate,
             ))
             .build();
         let _ = alerter.recover(alert);
@@ -1132,6 +1195,10 @@ async fn evaluate_health(
                         result.name,
                         grace_secs = settings.health_grace.as_secs(),
                     ))
+                    .where_to_look(actuator_where_to_look(
+                        &settings.actuator_prefix,
+                        AlertCondition::HealthIndicatorDown,
+                    ))
                     .detail("indicator", result.name.clone())
                     .detail("down_seconds", secs.to_string())
                     .build();
@@ -1143,6 +1210,10 @@ async fn evaluate_health(
                 .summary(format!(
                     "Health indicator '{}' is reporting healthy again.",
                     result.name
+                ))
+                .where_to_look(actuator_where_to_look(
+                    &settings.actuator_prefix,
+                    AlertCondition::HealthIndicatorDown,
                 ))
                 .detail("indicator", result.name.clone())
                 .build();
@@ -1264,6 +1335,43 @@ mod tests {
     }
 
     #[test]
+    fn actuator_where_to_look_honors_prefix() {
+        // Default prefix reproduces the const builder default byte-for-byte.
+        assert_eq!(
+            actuator_where_to_look("/actuator", AlertCondition::DeadLetteredJob),
+            "/actuator/jobs"
+        );
+        assert_eq!(
+            actuator_where_to_look("/actuator", AlertCondition::HealthIndicatorDown),
+            "/actuator/health"
+        );
+        // A custom prefix is honored for every condition.
+        assert_eq!(
+            actuator_where_to_look("/_ops", AlertCondition::DeadLetteredJob),
+            "/_ops/jobs"
+        );
+        assert_eq!(
+            actuator_where_to_look("/_ops", AlertCondition::HighErrorRate),
+            "/_ops/metrics"
+        );
+        assert_eq!(
+            actuator_where_to_look("/_ops", AlertCondition::ScheduledTaskFailure),
+            "/_ops/tasks"
+        );
+        // Normalization matches the router: a trailing slash is trimmed and a
+        // missing leading slash is added, so no `//` or missing-slash paths.
+        assert_eq!(
+            actuator_where_to_look("_ops/", AlertCondition::HealthIndicatorDown),
+            "/_ops/health"
+        );
+        // Root ("/" or empty) prefix yields the bare suffix, matching the router.
+        assert_eq!(
+            actuator_where_to_look("/", AlertCondition::DeadLetteredJob),
+            "/jobs"
+        );
+    }
+
+    #[test]
     fn stable_dedup_key_survives_trigger_and_recovery() {
         let key = "dead_lettered_job:emailer";
         let t = Alert::trigger(AlertCondition::DeadLetteredJob, key).build();
@@ -1300,6 +1408,7 @@ mod tests {
             error_rate_threshold: 0.05,
             error_rate_min_requests: 20,
             eval_interval: std::time::Duration::from_secs(30),
+            actuator_prefix: "/actuator".to_owned(),
         }
     }
 

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -1639,7 +1639,7 @@ mod tests {
         let mut last = None;
         for (i, status) in statuses.iter().enumerate() {
             last = None;
-            let now = ts(i as i64);
+            let now = ts(i64::try_from(i).unwrap());
             match classify_health_transition(*status) {
                 HealthTransition::Down => {
                     let first = *down_since.entry(name.to_owned()).or_insert(now);

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -17,10 +17,15 @@
 //!
 //! | Condition | Fires when | Where to look |
 //! |-----------|------------|---------------|
-//! | [`AlertCondition::DeadLetteredJob`] | a background job exhausts its retries and is dead-lettered | `/actuator/jobs` |
+//! | [`AlertCondition::DeadLetteredJob`] | a background job exhausts its retries and is dead-lettered | `/actuator/jobs` † |
 //! | [`AlertCondition::HealthIndicatorDown`] | a registered health indicator reports `Down` past the grace period | `/actuator/health` |
 //! | [`AlertCondition::HighErrorRate`] | the rolling 5xx rate crosses the configured threshold | `/actuator/metrics` |
-//! | [`AlertCondition::ScheduledTaskFailure`] | a framework-scheduled task (backup, cert-renewal, cron/fixed-delay) fails | `/actuator/tasks` |
+//! | [`AlertCondition::ScheduledTaskFailure`] | a framework-scheduled task (backup, cert-renewal, cron/fixed-delay) fails | `/actuator/tasks` † |
+//!
+//! † `/actuator/jobs` and `/actuator/tasks` are mounted only when `[actuator]
+//! sensitive = true` (default `false`). When it is off, those two alerts point at
+//! the always-mounted `/actuator/health` instead and note that the richer
+//! endpoint needs `sensitive = true` (see [`sensitive_gated_where_to_look`]).
 //!
 //! # Delivery is a trait (extension point)
 //!
@@ -141,6 +146,39 @@ impl AlertCondition {
 /// [`AlertCondition::where_to_look`] byte-for-byte.
 fn actuator_where_to_look(prefix: &str, condition: AlertCondition) -> String {
     crate::actuator::actuator_route_path(prefix, condition.actuator_suffix())
+}
+
+/// Build the `where_to_look` pointer for a condition whose primary actuator
+/// endpoint is gated behind `[actuator] sensitive`.
+///
+/// The `/jobs` (dead-lettered-job) and `/tasks` (scheduled-task-failure)
+/// endpoints are mounted ONLY inside the `if sensitive` block of
+/// `actuator_router_with_prefix`, and `[actuator] sensitive` defaults to
+/// `false`. Pointing an alert at an unmounted endpoint would send operators to a
+/// 404, so:
+///
+/// * `sensitive == true`: the gated endpoint exists — point straight at it
+///   (`{prefix}/jobs`, `{prefix}/tasks`), reproducing the prior behavior.
+/// * `sensitive == false` (default): the gated endpoint is a 404 — point at the
+///   always-mounted `{prefix}/health` endpoint instead and append a short hint
+///   naming the richer, sensitive-gated endpoint and the setting that exposes it.
+///
+/// `/health` (not `/metrics`) is the fallback because the job/task counters live
+/// in the sensitive `/jobs` and `/tasks` registries; the HTTP `/metrics` snapshot
+/// carries request/status counters, not job/task state — so `/metrics` is no more
+/// informative here than the always-mounted `/health`.
+fn sensitive_gated_where_to_look(
+    prefix: &str,
+    condition: AlertCondition,
+    sensitive: bool,
+) -> String {
+    if sensitive {
+        actuator_where_to_look(prefix, condition)
+    } else {
+        let fallback = actuator_where_to_look(prefix, AlertCondition::HealthIndicatorDown);
+        let gated = actuator_where_to_look(prefix, condition);
+        format!("{fallback} ({gated} requires [actuator] sensitive = true)")
+    }
 }
 
 /// Severity class of an [`Alert`]. External routers (`PagerDuty` etc.) map this
@@ -459,10 +497,21 @@ pub struct AlerterSettings {
     /// operators are sent to the real actuator endpoint even when the prefix is
     /// customized. Stored raw; normalization happens in [`actuator_where_to_look`].
     pub actuator_prefix: String,
+    /// The effective `[actuator] sensitive` flag (default `false`). The `/jobs`
+    /// and `/tasks` actuator endpoints are mounted ONLY when this is `true`
+    /// (see `actuator_router_with_prefix`), so the dead-lettered-job and
+    /// scheduled-task-failure alerts point at them only when they exist and fall
+    /// back to an always-mounted endpoint otherwise (see
+    /// [`sensitive_gated_where_to_look`]).
+    pub actuator_sensitive: bool,
 }
 
 impl AlerterSettings {
-    fn from_config(config: &AlertConfig, actuator_prefix: String) -> Self {
+    fn from_config(
+        config: &AlertConfig,
+        actuator_prefix: String,
+        actuator_sensitive: bool,
+    ) -> Self {
         Self {
             dedup_window: std::time::Duration::from_secs(config.dedup_window_secs.max(1)),
             health_grace: std::time::Duration::from_secs(config.health_grace_secs),
@@ -470,6 +519,7 @@ impl AlerterSettings {
             error_rate_min_requests: config.error_rate_min_requests.max(1),
             eval_interval: std::time::Duration::from_secs(config.eval_interval_secs.max(1)),
             actuator_prefix,
+            actuator_sensitive,
         }
     }
 }
@@ -613,9 +663,10 @@ pub fn notify_dead_lettered_job(state: &AppState, job_name: &str, error: &str) {
     .summary(format!(
         "Background job '{job_name}' exhausted its retries and was moved to the dead-letter queue. Last error: {error}"
     ))
-    .where_to_look(actuator_where_to_look(
+    .where_to_look(sensitive_gated_where_to_look(
         &alerter.settings().actuator_prefix,
         AlertCondition::DeadLetteredJob,
+        alerter.settings().actuator_sensitive,
     ))
     .detail("job", job_name)
     .detail("error", error)
@@ -637,9 +688,10 @@ pub fn notify_scheduled_task_failure(state: &AppState, task_name: &str, error: &
     .summary(format!(
         "The framework-scheduled task '{task_name}' returned an error on its last run: {error}"
     ))
-    .where_to_look(actuator_where_to_look(
+    .where_to_look(sensitive_gated_where_to_look(
         &alerter.settings().actuator_prefix,
         AlertCondition::ScheduledTaskFailure,
+        alerter.settings().actuator_sensitive,
     ))
     .detail("task", task_name)
     .detail("error", error)
@@ -667,9 +719,10 @@ pub fn notify_scheduled_task_recovered(state: &AppState, task_name: &str) {
     .summary(format!(
         "The framework-scheduled task '{task_name}' completed successfully after a previous failure."
     ))
-    .where_to_look(actuator_where_to_look(
+    .where_to_look(sensitive_gated_where_to_look(
         &alerter.settings().actuator_prefix,
         AlertCondition::ScheduledTaskFailure,
+        alerter.settings().actuator_sensitive,
     ))
     .detail("task", task_name)
     .build();
@@ -1043,11 +1096,16 @@ pub fn install_from_config(
         return;
     }
 
-    // Capture the effective actuator prefix so every alert's `where_to_look`
-    // points at the real actuator endpoints even under a custom `[actuator]
-    // prefix`. The full config is installed on `state` before this runs.
-    let actuator_prefix = state.config().actuator.prefix;
-    let settings = AlerterSettings::from_config(config, actuator_prefix);
+    // Capture the effective actuator prefix AND the `sensitive` flag so every
+    // alert's `where_to_look` points at a REAL, mounted actuator endpoint: the
+    // prefix keeps custom-prefix deployments off `/actuator/*` 404s, and
+    // `sensitive` keeps the dead-lettered-job/scheduled-task alerts off the
+    // `/jobs` and `/tasks` endpoints, which are mounted only when `sensitive =
+    // true`. The full config is installed on `state` before this runs.
+    let actuator_cfg = state.config().actuator;
+    let actuator_sensitive = actuator_cfg.sensitive;
+    let actuator_prefix = actuator_cfg.prefix;
+    let settings = AlerterSettings::from_config(config, actuator_prefix, actuator_sensitive);
     let alerter = Alerter::new(channels, settings);
     state.insert_extension(alerter.clone());
     spawn_evaluation_loop(state.clone(), alerter);
@@ -1527,6 +1585,58 @@ mod tests {
     }
 
     #[test]
+    fn sensitive_gated_where_to_look_points_at_mounted_endpoint() {
+        // `sensitive = true`: `/jobs` and `/tasks` ARE mounted, so point at them.
+        assert_eq!(
+            sensitive_gated_where_to_look("/actuator", AlertCondition::DeadLetteredJob, true),
+            "/actuator/jobs"
+        );
+        assert_eq!(
+            sensitive_gated_where_to_look("/actuator", AlertCondition::ScheduledTaskFailure, true),
+            "/actuator/tasks"
+        );
+
+        // `sensitive = false` (the production default): `/jobs` and `/tasks` are
+        // NOT mounted (404). The pointer must NOT link them directly — it points
+        // at the always-mounted `/health` and names the setting that would expose
+        // the richer endpoint.
+        let dead =
+            sensitive_gated_where_to_look("/actuator", AlertCondition::DeadLetteredJob, false);
+        assert!(
+            !dead.starts_with("/actuator/jobs"),
+            "must not link the unmounted /jobs endpoint directly: {dead}"
+        );
+        assert!(
+            dead.contains("/actuator/health"),
+            "must point at the always-mounted /health endpoint: {dead}"
+        );
+        assert!(
+            dead.contains("/actuator/jobs") && dead.contains("[actuator] sensitive = true"),
+            "must hint that /jobs requires enabling [actuator] sensitive: {dead}"
+        );
+
+        let task =
+            sensitive_gated_where_to_look("/actuator", AlertCondition::ScheduledTaskFailure, false);
+        assert!(
+            !task.starts_with("/actuator/tasks"),
+            "must not link the unmounted /tasks endpoint directly: {task}"
+        );
+        assert!(
+            task.contains("/actuator/health"),
+            "must point at the always-mounted /health endpoint: {task}"
+        );
+        assert!(
+            task.contains("/actuator/tasks") && task.contains("[actuator] sensitive = true"),
+            "must hint that /tasks requires enabling [actuator] sensitive: {task}"
+        );
+
+        // The custom prefix flows through both the fallback and the hint.
+        let custom = sensitive_gated_where_to_look("/_ops", AlertCondition::DeadLetteredJob, false);
+        assert!(custom.contains("/_ops/health"));
+        assert!(custom.contains("/_ops/jobs"));
+    }
+
+    #[test]
     fn stable_dedup_key_survives_trigger_and_recovery() {
         let key = "dead_lettered_job:emailer";
         let t = Alert::trigger(AlertCondition::DeadLetteredJob, key).build();
@@ -1564,6 +1674,7 @@ mod tests {
             error_rate_min_requests: 20,
             eval_interval: std::time::Duration::from_secs(30),
             actuator_prefix: "/actuator".to_owned(),
+            actuator_sensitive: false,
         }
     }
 

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -819,6 +819,11 @@ pub struct AlertConfig {
     /// HMAC signing secret for the webhook destination. Prefer the
     /// `AUTUMN_ALERTS__WEBHOOK_SECRET` env var over committing it.
     pub webhook_secret: Option<String>,
+    /// Set true to tell `autumn doctor` you register an alert channel in code via
+    /// `AppBuilder::with_alert_channel`; suppresses the no-destination warning.
+    /// The runtime installs code-registered channels regardless of this flag.
+    #[serde(default)]
+    pub custom_channel: bool,
     /// At most one notification per condition per this many seconds.
     pub dedup_window_secs: u64,
     /// How long (seconds) an indicator must stay `Down` before it alerts.
@@ -839,6 +844,7 @@ impl Default for AlertConfig {
             email: None,
             webhook_url: None,
             webhook_secret: None,
+            custom_channel: false,
             dedup_window_secs: default_dedup_window_secs(),
             health_grace_secs: default_health_grace_secs(),
             error_rate_threshold: default_error_rate_threshold(),

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -109,6 +109,7 @@ pub fn app() -> AppBuilder {
         cache_backend: None,
         #[cfg(feature = "reporting")]
         error_reporters: Vec::new(),
+        alert_channels: Vec::new(),
         #[cfg(feature = "openapi")]
         openapi: None,
         #[cfg(feature = "mcp")]
@@ -333,6 +334,12 @@ pub struct AppBuilder {
     /// the built-in [`LogReporter`](crate::reporting::LogReporter) is used.
     #[cfg(feature = "reporting")]
     pub(crate) error_reporters: Vec<Arc<dyn crate::reporting::ErrorReporter>>,
+    /// Operator-alert channels registered via [`AppBuilder::with_alert_channel`].
+    /// Combined with the built-in mail/webhook channels derived from
+    /// `[alerts]` config and installed onto `AppState` so the built-in
+    /// condition hooks can fan out to each. Empty means only config-derived
+    /// destinations are used. See [`crate::alerts`].
+    pub(crate) alert_channels: Vec<Arc<dyn crate::alerts::AlertChannel>>,
     /// `OpenAPI` generation configuration. When `Some`, the router mounts
     /// `/v3/api-docs` (serving `openapi.json`) and `/swagger-ui` (if the
     /// Swagger UI path is set). When `None`, no docs endpoints are mounted.
@@ -1860,6 +1867,48 @@ impl AppBuilder {
         self
     }
 
+    /// Register an operator-alert delivery channel.
+    ///
+    /// Alerts for the built-in conditions (dead-lettered jobs, Down health
+    /// indicators, 5xx-rate spikes, scheduled-task failures) are delivered to
+    /// every registered [`AlertChannel`](crate::alerts::AlertChannel) **plus**
+    /// the built-in mail/webhook channels derived from `[alerts]` config.
+    ///
+    /// This is the extension seam for additional transports (`PagerDuty`, Slack,
+    /// Discord — follow-up #1630): implement
+    /// [`AlertChannel`](crate::alerts::AlertChannel) and register it here. The
+    /// framework core never changes. Most apps need no code at all — configuring
+    /// an `email` and/or `webhook_url` under `[alerts]` is sufficient.
+    ///
+    /// ```rust,no_run
+    /// use autumn_web::alerts::{Alert, AlertChannel, AlertDeliveryError, AlertDeliveryFuture};
+    ///
+    /// struct PagerDuty;
+    /// impl AlertChannel for PagerDuty {
+    ///     fn name(&self) -> &'static str { "pagerduty" }
+    ///     fn deliver<'a>(&'a self, alert: &'a Alert) -> AlertDeliveryFuture<'a> {
+    ///         Box::pin(async move {
+    ///             let _ = (&alert.dedup_key, alert.severity);
+    ///             Ok::<(), AlertDeliveryError>(())
+    ///         })
+    ///     }
+    /// }
+    ///
+    /// # #[autumn_web::main]
+    /// # async fn main() {
+    /// autumn_web::app()
+    ///     .with_alert_channel(PagerDuty)
+    /// #   .routes(vec![])
+    /// #   ;
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn with_alert_channel<C: crate::alerts::AlertChannel>(mut self, channel: C) -> Self {
+        self.alert_channels
+            .push(Arc::new(channel) as Arc<dyn crate::alerts::AlertChannel>);
+        self
+    }
+
     /// Register a [`FlagStore`](crate::feature_flags::FlagStore) backend for
     /// feature-flag evaluation.
     ///
@@ -2601,6 +2650,7 @@ impl AppBuilder {
             cache_backend,
             #[cfg(feature = "reporting")]
             error_reporters,
+            alert_channels,
             #[cfg(feature = "openapi")]
             openapi,
             #[cfg(feature = "mcp")]
@@ -3038,6 +3088,12 @@ impl AppBuilder {
         state.insert_extension(crate::mail::MailPreviewRegistry::new(mail_previews));
         #[cfg(feature = "maud")]
         install_story_registry(&state, story_gallery);
+        // Operator alerts: build the built-in mail/webhook channels from
+        // `[alerts]` config, combine with any builder-registered channels, and
+        // start the background evaluation loop. No-op when nothing is
+        // configured. Installed after the mailer so the mail channel can bind
+        // to the live `Mailer` extension.
+        crate::alerts::install_from_config(&state, &config.alerts, alert_channels);
         if let Some(logger) = audit_logger {
             state.insert_extension::<crate::audit::AuditLogger>((*logger).clone());
         }
@@ -3737,6 +3793,7 @@ impl AppBuilder {
             cache_backend,
             #[cfg(feature = "reporting")]
             error_reporters,
+            alert_channels: _,
             #[cfg(feature = "openapi")]
             openapi,
             #[cfg(feature = "mcp")]
@@ -4971,6 +5028,7 @@ async fn execute_fixed_delay_task(
             state
                 .task_registry
                 .record_failure(&name, duration_ms, &error_str);
+            crate::alerts::notify_scheduled_task_failure(&state, &name, &error_str);
             tracing::warn!(task = %name, error = %error_str, "Task failed");
             send_ws_sys_task_msg(
                 &state,
@@ -5044,6 +5102,7 @@ async fn execute_cron_task(
             state
                 .task_registry
                 .record_failure(&name, duration_ms, &error_str);
+            crate::alerts::notify_scheduled_task_failure(&state, &name, &error_str);
             tracing::warn!(task = %name, error = %error_str, "Cron task failed");
             send_ws_sys_task_msg(
                 &state,

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -5016,6 +5016,7 @@ async fn execute_fixed_delay_task(
     {
         Ok(duration_ms) => {
             state.task_registry.record_success(&name, duration_ms);
+            crate::alerts::notify_scheduled_task_recovered(&state, &name);
             tracing::debug!(task = %name, "Task completed");
             send_ws_sys_task_msg(
                 &state,
@@ -5090,6 +5091,7 @@ async fn execute_cron_task(
     {
         Ok(duration_ms) => {
             state.task_registry.record_success(&name, duration_ms);
+            crate::alerts::notify_scheduled_task_recovered(&state, &name);
             tracing::debug!(task = %name, "Cron task completed");
             send_ws_sys_task_msg(
                 &state,

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -1075,6 +1075,15 @@ pub struct AutumnConfig {
     /// [`ObservabilityConfig`] and `docs/guide/observability/server-timing.md`.
     #[serde(default)]
     pub observability: ObservabilityConfig,
+
+    /// Operator alerts settings (`[alerts]` section in `autumn.toml`).
+    ///
+    /// Configure an operator email and/or a webhook URL to receive alerts for
+    /// built-in failure conditions (dead-lettered jobs, Down health indicators,
+    /// 5xx-rate spikes, scheduled-task failures) with zero application code.
+    /// See [`crate::alerts::AlertConfig`] and `docs/guide/operator-alerts.md`.
+    #[serde(default)]
+    pub alerts: crate::alerts::AlertConfig,
 }
 
 /// Observability configuration (`[observability]` section in `autumn.toml`).
@@ -2789,6 +2798,47 @@ impl AutumnConfig {
         self.apply_stories_env_overrides_with_env(env);
         self.apply_resilience_env_overrides_with_env(env);
         self.apply_time_zone_env_overrides_with_env(env);
+        self.apply_alerts_env_overrides_with_env(env);
+    }
+
+    fn apply_alerts_env_overrides_with_env(&mut self, env: &dyn Env) {
+        parse_env_bool(env, "AUTUMN_ALERTS__ENABLED", &mut self.alerts.enabled);
+        parse_env_option_string(env, "AUTUMN_ALERTS__EMAIL", &mut self.alerts.email);
+        parse_env_option_string(
+            env,
+            "AUTUMN_ALERTS__WEBHOOK_URL",
+            &mut self.alerts.webhook_url,
+        );
+        parse_env_option_string(
+            env,
+            "AUTUMN_ALERTS__WEBHOOK_SECRET",
+            &mut self.alerts.webhook_secret,
+        );
+        parse_env(
+            env,
+            "AUTUMN_ALERTS__DEDUP_WINDOW_SECS",
+            &mut self.alerts.dedup_window_secs,
+        );
+        parse_env(
+            env,
+            "AUTUMN_ALERTS__HEALTH_GRACE_SECS",
+            &mut self.alerts.health_grace_secs,
+        );
+        parse_env(
+            env,
+            "AUTUMN_ALERTS__ERROR_RATE_THRESHOLD",
+            &mut self.alerts.error_rate_threshold,
+        );
+        parse_env(
+            env,
+            "AUTUMN_ALERTS__ERROR_RATE_MIN_REQUESTS",
+            &mut self.alerts.error_rate_min_requests,
+        );
+        parse_env(
+            env,
+            "AUTUMN_ALERTS__EVAL_INTERVAL_SECS",
+            &mut self.alerts.eval_interval_secs,
+        );
     }
 
     fn apply_time_zone_env_overrides_with_env(&mut self, env: &dyn Env) {

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -1082,8 +1082,16 @@ pub struct AutumnConfig {
     /// built-in failure conditions (dead-lettered jobs, Down health indicators,
     /// 5xx-rate spikes, scheduled-task failures) with zero application code.
     /// See [`crate::alerts::AlertConfig`] and `docs/guide/operator-alerts.md`.
+    ///
+    /// Boxed so the large `[alerts]` struct is stored behind a pointer rather
+    /// than inline in `AutumnConfig`: `AutumnConfig` is held by value on the
+    /// `app().run()` stack frame across await points, and inlining
+    /// `AlertConfig` (many `Option<String>` destinations + tuning knobs) grew
+    /// that future past the `clippy::large_futures` threshold. `Box<T>` keeps
+    /// `Default`/`Deserialize` (both hold when `T` does), and field
+    /// reads/writes still work through `Deref`/`DerefMut`.
     #[serde(default)]
-    pub alerts: crate::alerts::AlertConfig,
+    pub alerts: Box<crate::alerts::AlertConfig>,
 }
 
 /// Observability configuration (`[observability]` section in `autumn.toml`).

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -2822,6 +2822,11 @@ impl AutumnConfig {
             "AUTUMN_ALERTS__WEBHOOK_SECRET",
             &mut self.alerts.webhook_secret,
         );
+        parse_env_bool(
+            env,
+            "AUTUMN_ALERTS__CUSTOM_CHANNEL",
+            &mut self.alerts.custom_channel,
+        );
         parse_env(
             env,
             "AUTUMN_ALERTS__DEDUP_WINDOW_SECS",

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -3376,6 +3376,7 @@ async fn execute_local_job(
         crate::alerts::notify_dead_lettered_job(
             state,
             &job.name,
+            &job.id,
             &format!("unknown job '{}'", job.name),
         );
         job_admin.record_failure(&job.id, format!("unknown job '{}'", job.name));
@@ -3555,7 +3556,7 @@ async fn execute_local_job(
                 state
                     .job_registry
                     .record_failure(&job.name, error.clone(), true);
-                crate::alerts::notify_dead_lettered_job(state, &job.name, &error);
+                crate::alerts::notify_dead_lettered_job(state, &job.name, &job.id, &error);
                 job_admin.record_failure(&job.id, error);
                 release_local_unique_hold(
                     coordination,
@@ -3571,7 +3572,7 @@ async fn execute_local_job(
             state
                 .job_registry
                 .record_failure(&job.name, error.clone(), true);
-            crate::alerts::notify_dead_lettered_job(state, &job.name, &error);
+            crate::alerts::notify_dead_lettered_job(state, &job.name, &job.id, &error);
             job_admin.record_failure(&job.id, error);
             release_local_unique_hold(
                 coordination,
@@ -5315,7 +5316,7 @@ async fn recover_stale_redis_jobs(
                     state
                         .job_registry
                         .record_failure(&dead.name, error.clone(), true);
-                    crate::alerts::notify_dead_lettered_job(state, &dead.name, &error);
+                    crate::alerts::notify_dead_lettered_job(state, &dead.name, &dead.id, &error);
                     job_admin.record_failure(&dead.id, error);
                     // The worker that held this claim is gone and the job is
                     // now terminally dead-lettered — settle the tracked
@@ -5491,7 +5492,7 @@ async fn settle_failed_redis_job(
                     state
                         .job_registry
                         .record_failure(&dead.name, error.clone(), true);
-                    crate::alerts::notify_dead_lettered_job(state, &dead.name, &error);
+                    crate::alerts::notify_dead_lettered_job(state, &dead.name, &dead.id, &error);
                     job_admin.record_failure(&dead.id, error);
                 }
                 Ok(false) => tracing::warn!(
@@ -5527,7 +5528,7 @@ async fn dead_letter_panicked_redis_job(
             state
                 .job_registry
                 .record_failure(&dead.name, error.clone(), true);
-            crate::alerts::notify_dead_lettered_job(state, &dead.name, &error);
+            crate::alerts::notify_dead_lettered_job(state, &dead.name, &dead.id, &error);
             job_admin.record_failure(&dead.id, error);
         }
         Ok(false) => tracing::warn!(
@@ -5556,7 +5557,7 @@ async fn dead_letter_invalid_redis_job(
     state
         .job_registry
         .record_failure(&record.name, error.to_owned(), true);
-    crate::alerts::notify_dead_lettered_job(state, &record.name, error);
+    crate::alerts::notify_dead_lettered_job(state, &record.name, &record.id, error);
     job_admin.record_failure(&record.id, error.to_owned());
     let mut dead = record.clone();
     clear_redis_claim(&mut dead);
@@ -5971,7 +5972,7 @@ fn record_pg_lifecycle_after_ack(
             state
                 .job_registry
                 .record_failure(job_name, error.to_owned(), true);
-            crate::alerts::notify_dead_lettered_job(state, job_name, error);
+            crate::alerts::notify_dead_lettered_job(state, job_name, job_id, error);
             job_admin.record_failure(job_id, error.to_owned());
         }
     }
@@ -6723,6 +6724,8 @@ async fn pg_ack_dead_letter(
 #[derive(diesel::QueryableByName)]
 struct PgStaleRecoveryRow {
     #[diesel(sql_type = diesel::sql_types::Text)]
+    id: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
     name: String,
     #[diesel(sql_type = diesel::sql_types::Text)]
     payload: String,
@@ -6795,7 +6798,7 @@ async fn pg_recover_stale_claims(pool: &PgPool, visibility_timeout_ms: u64, stat
            FOR UPDATE SKIP LOCKED \
            LIMIT 100 \
          ) \
-         RETURNING name, payload::TEXT AS payload, status",
+         RETURNING id, name, payload::TEXT AS payload, status",
     )
     .bind::<diesel::sql_types::BigInt, _>(i64::try_from(visibility_timeout_ms).unwrap_or(i64::MAX))
     .get_results::<PgStaleRecoveryRow>(&mut *conn)
@@ -6830,6 +6833,7 @@ async fn pg_recover_stale_claims(pool: &PgPool, visibility_timeout_ms: u64, stat
                 crate::alerts::notify_dead_lettered_job(
                     state,
                     &row.name,
+                    &row.id,
                     "visibility timeout expired",
                 );
                 let payload = serde_json::from_str::<Value>(&row.payload).unwrap_or(Value::Null);
@@ -12298,6 +12302,7 @@ mod tests {
             crate::alerts::notify_dead_lettered_job(
                 &state,
                 "crashed_elsewhere",
+                "job-crashed-elsewhere-1",
                 "visibility timeout expired",
             );
 
@@ -12550,6 +12555,7 @@ mod tests {
             crate::alerts::notify_dead_lettered_job(
                 &state,
                 "slow_resumer",
+                &job_id,
                 "visibility timeout expired",
             );
 

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -5922,11 +5922,26 @@ fn record_pg_lifecycle_after_ack(
         // Mirror whichever outcome the worker intended so /actuator metrics stay
         // consistent with the database row.
         if let PgLifecycleRecord::Failure { error } = lifecycle {
-            // Stale recovery dead-lettered the row (final attempt).
-            state
-                .job_registry
-                .record_failure(job_name, error.to_owned(), true);
-            crate::alerts::notify_dead_lettered_job(state, job_name, error);
+            // Terminal failure whose ack no longer applies: stale-claim recovery
+            // already transitioned this row out from under the worker, and it —
+            // not this resuming worker — OWNS the dead-letter accounting for
+            // `!ack_applied` rows:
+            //   * final attempt: `pg_recover_stale_claims` flipped the row to
+            //     `failed` AND already called `record_failure(.., dead_letter=true)`
+            //     + `notify_dead_lettered_job` for it. Recording again here would
+            //     double the `/actuator/jobs` failure/dead-letter counters and fire
+            //     a second (dedup-suppressed) alert for one DB row.
+            //   * non-final panic / unknown-type dead-letter: recovery instead
+            //     requeued the row (it is still alive, so no dead-letter is owed
+            //     yet — the real terminal outcome is recorded when it next runs).
+            // Either way we must NOT record a failure/dead-letter or alert here.
+            // Still balance this worker's own `record_start` so the process-local
+            // `in_flight` gauge doesn't leak — `record_retry` decrements in_flight
+            // without touching the failure/dead-letter counters — and settle this
+            // job_id's admin record to Failed (admin state is keyed per job_id and
+            // is left untouched by the maintenance loop, so this is the single,
+            // non-duplicated update that moves it out of Running).
+            state.job_registry.record_retry(job_name, error, 0);
             job_admin.record_failure(job_id, error.to_owned());
         } else {
             // Non-terminal or successful outcome: decrement in_flight and
@@ -12209,10 +12224,13 @@ mod tests {
         }
 
         #[test]
-        fn pg_terminal_failure_stale_eviction_records_dead_letter() {
+        fn pg_terminal_failure_stale_eviction_defers_dead_letter_to_recovery() {
             // When a final-attempt job's ack returns Ok(false), stale-claim
-            // recovery already dead-lettered the row; total_failures and
-            // dead_letters must be incremented to stay in sync with the DB.
+            // recovery already dead-lettered the row AND recorded the failure +
+            // dead-letter + alert itself (`pg_recover_stale_claims`). The resuming
+            // worker must NOT record a second failure/dead-letter (that would
+            // double the /actuator/jobs counters for one DB row) — it only
+            // balances its own in_flight and settles the admin record to Failed.
             let state = AppState::for_test().with_profile("dev");
             state.job_registry().register("slow_failure");
             state.job_registry().record_enqueue("slow_failure");
@@ -12235,19 +12253,19 @@ mod tests {
             ));
 
             let status = state.job_registry().snapshot()["slow_failure"].clone();
-            assert_eq!(status.in_flight, 0);
+            assert_eq!(status.in_flight, 0, "in_flight must be balanced");
             assert_eq!(
-                status.total_failures, 1,
-                "terminal stale eviction must increment total_failures"
+                status.total_failures, 0,
+                "resuming worker must not re-record the failure stale recovery already counted"
             );
             assert_eq!(
-                status.dead_letters, 1,
-                "terminal stale eviction must increment dead_letters"
+                status.dead_letters, 0,
+                "resuming worker must not re-record the dead-letter stale recovery already counted"
             );
             let snapshot = job_admin.snapshot_sync(&JobAdminQuery::default());
             assert_eq!(
                 snapshot.failed.total, 1,
-                "failed list must show the dead-lettered job"
+                "admin state (keyed per job_id, untouched by recovery) still moves to Failed"
             );
             assert_eq!(snapshot.running.total, 0);
         }
@@ -12448,10 +12466,13 @@ mod tests {
         }
 
         #[test]
-        fn pg_terminal_stale_eviction_records_failure_and_dead_letter() {
+        fn pg_terminal_stale_eviction_balances_inflight_without_double_recording() {
             // When ack returns Ok(false) on a final-attempt job (lifecycle=Failure),
-            // stale recovery already dead-lettered the row in the DB.  The
-            // in-memory metrics must reflect a dead-letter, not a retry.
+            // stale recovery already dead-lettered the row in the DB and recorded
+            // the failure + dead-letter itself. The resuming worker must only
+            // balance in_flight and settle the admin record to Failed — recording
+            // a second failure/dead-letter would double-count one DB row on
+            // /actuator/jobs. It must also show Failed, not Retrying, in admin.
             let state = AppState::for_test().with_profile("dev");
             state.job_registry().register("terminal_job");
             state.job_registry().record_enqueue("terminal_job");
@@ -12476,12 +12497,12 @@ mod tests {
             let status = state.job_registry().snapshot()["terminal_job"].clone();
             assert_eq!(status.in_flight, 0, "in_flight must be balanced");
             assert_eq!(
-                status.total_failures, 1,
-                "terminal stale eviction must increment total_failures"
+                status.total_failures, 0,
+                "resuming worker must not re-record a failure stale recovery already counted"
             );
             assert_eq!(
-                status.dead_letters, 1,
-                "terminal stale eviction must increment dead_letters"
+                status.dead_letters, 0,
+                "resuming worker must not re-record a dead-letter stale recovery already counted"
             );
             let admin_status = job_admin
                 .inner
@@ -12495,6 +12516,82 @@ mod tests {
                 admin_status,
                 JobAdminStatus::Failed,
                 "admin must show Failed, not Retrying, after terminal stale eviction"
+            );
+        }
+
+        #[test]
+        fn pg_slow_worker_resume_after_stale_recovery_counts_dead_letter_once() {
+            // End-to-end coordination proof for a combined-role replica (one
+            // process runs BOTH the maintenance loop and a worker loop):
+            // a final-attempt job merely runs LONGER than the visibility timeout
+            // (slow worker, not crashed). Stale-claim recovery flips the row to
+            // `failed` and records the failure + dead-letter + alert; the original
+            // worker then resumes and its terminal ack returns Ok(false). The
+            // logical dead-letter must be counted EXACTLY ONCE across both paths —
+            // regression guard for the double-count this fix removes.
+            let state = AppState::for_test().with_profile("dev");
+            state.job_registry().register("slow_resumer");
+            state.job_registry().record_enqueue("slow_resumer");
+            // The worker claimed and started the job: in_flight == 1.
+            state.job_registry().record_start("slow_resumer");
+            let job_admin = JobAdminMemoryBackend::new_for_test(32);
+            let job_id =
+                job_admin.record_enqueue_for_test("slow_resumer", serde_json::json!({}), 1, 1);
+            job_admin.record_start_for_test(&job_id, 1);
+
+            // 1) Stale-claim recovery dead-letters the final-attempt row, mirroring
+            //    the exact two-line sequence `pg_recover_stale_claims` runs per
+            //    `failed` row it flips.
+            state.job_registry().record_failure(
+                "slow_resumer",
+                "visibility timeout expired".to_owned(),
+                true,
+            );
+            crate::alerts::notify_dead_lettered_job(
+                &state,
+                "slow_resumer",
+                "visibility timeout expired",
+            );
+
+            // 2) The slow worker finally resumes; its terminal ack no longer
+            //    applies because recovery already moved the row (Ok(false)).
+            assert!(!record_pg_lifecycle_ack_result(
+                Ok(false),
+                "slow_resumer",
+                &job_id,
+                "failure",
+                PgLifecycleRecord::Failure {
+                    error: "handler returned error"
+                },
+                &state,
+                &job_admin
+            ));
+
+            let status = state.job_registry().snapshot()["slow_resumer"].clone();
+            assert_eq!(
+                status.in_flight, 0,
+                "in_flight must settle to 0 with no underflow after the worker resumes"
+            );
+            assert_eq!(
+                status.total_failures, 1,
+                "one DB row must count as exactly one failure, not two"
+            );
+            assert_eq!(
+                status.dead_letters, 1,
+                "one DB row must count as exactly one dead-letter, not two"
+            );
+            let admin_status = job_admin
+                .inner
+                .read()
+                .expect("job admin lock")
+                .records
+                .get(&job_id)
+                .expect("admin record")
+                .status;
+            assert_eq!(
+                admin_status,
+                JobAdminStatus::Failed,
+                "the resuming worker still settles the admin record to Failed"
             );
         }
 

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -3373,6 +3373,11 @@ async fn execute_local_job(
         state
             .job_registry
             .record_failure(&job.name, format!("unknown job '{}'", job.name), true);
+        crate::alerts::notify_dead_lettered_job(
+            state,
+            &job.name,
+            &format!("unknown job '{}'", job.name),
+        );
         job_admin.record_failure(&job.id, format!("unknown job '{}'", job.name));
         crate::job_tracking::settle_tracked_payload_as_failed(
             state,
@@ -3550,6 +3555,7 @@ async fn execute_local_job(
                 state
                     .job_registry
                     .record_failure(&job.name, error.clone(), true);
+                crate::alerts::notify_dead_lettered_job(state, &job.name, &error);
                 job_admin.record_failure(&job.id, error);
                 release_local_unique_hold(
                     coordination,
@@ -3565,6 +3571,7 @@ async fn execute_local_job(
             state
                 .job_registry
                 .record_failure(&job.name, error.clone(), true);
+            crate::alerts::notify_dead_lettered_job(state, &job.name, &error);
             job_admin.record_failure(&job.id, error);
             release_local_unique_hold(
                 coordination,
@@ -5308,6 +5315,7 @@ async fn recover_stale_redis_jobs(
                     state
                         .job_registry
                         .record_failure(&dead.name, error.clone(), true);
+                    crate::alerts::notify_dead_lettered_job(state, &dead.name, &error);
                     job_admin.record_failure(&dead.id, error);
                     // The worker that held this claim is gone and the job is
                     // now terminally dead-lettered — settle the tracked
@@ -5483,6 +5491,7 @@ async fn settle_failed_redis_job(
                     state
                         .job_registry
                         .record_failure(&dead.name, error.clone(), true);
+                    crate::alerts::notify_dead_lettered_job(state, &dead.name, &error);
                     job_admin.record_failure(&dead.id, error);
                 }
                 Ok(false) => tracing::warn!(
@@ -5518,6 +5527,7 @@ async fn dead_letter_panicked_redis_job(
             state
                 .job_registry
                 .record_failure(&dead.name, error.clone(), true);
+            crate::alerts::notify_dead_lettered_job(state, &dead.name, &error);
             job_admin.record_failure(&dead.id, error);
         }
         Ok(false) => tracing::warn!(
@@ -5546,6 +5556,7 @@ async fn dead_letter_invalid_redis_job(
     state
         .job_registry
         .record_failure(&record.name, error.to_owned(), true);
+    crate::alerts::notify_dead_lettered_job(state, &record.name, error);
     job_admin.record_failure(&record.id, error.to_owned());
     let mut dead = record.clone();
     clear_redis_claim(&mut dead);
@@ -5915,6 +5926,7 @@ fn record_pg_lifecycle_after_ack(
             state
                 .job_registry
                 .record_failure(job_name, error.to_owned(), true);
+            crate::alerts::notify_dead_lettered_job(state, job_name, error);
             job_admin.record_failure(job_id, error.to_owned());
         } else {
             // Non-terminal or successful outcome: decrement in_flight and
@@ -5944,6 +5956,7 @@ fn record_pg_lifecycle_after_ack(
             state
                 .job_registry
                 .record_failure(job_name, error.to_owned(), true);
+            crate::alerts::notify_dead_lettered_job(state, job_name, error);
             job_admin.record_failure(job_id, error.to_owned());
         }
     }

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -5554,15 +5554,21 @@ async fn dead_letter_invalid_redis_job(
     error: &str,
     job_admin: &JobAdminMemoryBackend,
 ) {
-    state
-        .job_registry
-        .record_failure(&record.name, error.to_owned(), true);
-    crate::alerts::notify_dead_lettered_job(state, &record.name, &record.id, error);
-    job_admin.record_failure(&record.id, error.to_owned());
     let mut dead = record.clone();
     clear_redis_claim(&mut dead);
     dead.last_error = Some(error.to_owned());
-    let _ = dead_letter_redis_job(connection, worker_config, record, &dead).await;
+    // Only record the failure / page the operator once the job is actually
+    // moved to the dead queue. If the move errors or the claim changed
+    // (`Ok(false)`), the job was NOT dead-lettered, so alerting here would be a
+    // false page — mirror the sibling redis dead-letter paths that gate all of
+    // this on the confirmed `Ok(true)` result.
+    if dead_letter_redis_job(connection, worker_config, record, &dead).await == Ok(true) {
+        state
+            .job_registry
+            .record_failure(&record.name, error.to_owned(), true);
+        crate::alerts::notify_dead_lettered_job(state, &record.name, &record.id, error);
+        job_admin.record_failure(&record.id, error.to_owned());
+    }
     crate::job_tracking::settle_tracked_payload_as_failed(
         state,
         &record.payload,

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -6708,6 +6708,8 @@ async fn pg_ack_dead_letter(
 #[derive(diesel::QueryableByName)]
 struct PgStaleRecoveryRow {
     #[diesel(sql_type = diesel::sql_types::Text)]
+    name: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
     payload: String,
     #[diesel(sql_type = diesel::sql_types::Text)]
     status: String,
@@ -6778,7 +6780,7 @@ async fn pg_recover_stale_claims(pool: &PgPool, visibility_timeout_ms: u64, stat
            FOR UPDATE SKIP LOCKED \
            LIMIT 100 \
          ) \
-         RETURNING payload::TEXT AS payload, status",
+         RETURNING name, payload::TEXT AS payload, status",
     )
     .bind::<diesel::sql_types::BigInt, _>(i64::try_from(visibility_timeout_ms).unwrap_or(i64::MAX))
     .get_results::<PgStaleRecoveryRow>(&mut *conn)
@@ -6792,6 +6794,16 @@ async fn pg_recover_stale_claims(pool: &PgPool, visibility_timeout_ms: u64, stat
     match rows {
         Ok(rows) => {
             for row in rows.into_iter().filter(|row| row.status == "failed") {
+                // A crashed worker never resumes to observe its ack returning
+                // `Ok(false)`, so `record_pg_lifecycle_after_ack` never fires
+                // the dead-letter alert for these rows. Emit it here — mirroring
+                // the other dead-letter sites — so genuine crashed-worker
+                // dead-letters still page the operator.
+                crate::alerts::notify_dead_lettered_job(
+                    state,
+                    &row.name,
+                    "visibility timeout expired",
+                );
                 let payload = serde_json::from_str::<Value>(&row.payload).unwrap_or(Value::Null);
                 crate::job_tracking::settle_tracked_payload_as_failed(
                     state,

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -6799,6 +6799,19 @@ async fn pg_recover_stale_claims(pool: &PgPool, visibility_timeout_ms: u64, stat
                 // the dead-letter alert for these rows. Emit it here — mirroring
                 // the other dead-letter sites — so genuine crashed-worker
                 // dead-letters still page the operator.
+                //
+                // Record the failure in the registry *before* alerting, exactly
+                // as the sibling stale-recovery route
+                // (`record_pg_lifecycle_after_ack`, `!ack_applied` branch) and
+                // every other dead-letter site do. The alert points operators
+                // at `/actuator/jobs`, which is backed by `JobRegistry::snapshot()`;
+                // without this, a crashed-worker dead-letter would page but not
+                // appear where the alert tells operators to look.
+                state.job_registry.record_failure(
+                    &row.name,
+                    "visibility timeout expired".to_owned(),
+                    true,
+                );
                 crate::alerts::notify_dead_lettered_job(
                     state,
                     &row.name,
@@ -12237,6 +12250,57 @@ mod tests {
                 "failed list must show the dead-lettered job"
             );
             assert_eq!(snapshot.running.total, 0);
+        }
+
+        #[test]
+        fn pg_maintenance_stale_recovery_records_dead_letter_in_registry() {
+            // `pg_recover_stale_claims` runs on a maintenance replica that did
+            // NOT execute the job: the worker that claimed it crashed on another
+            // process, so this process never called `record_start` for it and
+            // `in_flight` is 0 here. The maintenance loop still records the
+            // terminal failure in the registry *before* alerting — mirroring the
+            // sibling ack-resume route (`record_pg_lifecycle_after_ack`,
+            // `!ack_applied` branch) — so the crashed-worker dead-letter shows up
+            // in `JobRegistry::snapshot()`, the data behind `/actuator/jobs`
+            // where the alert points operators to look.
+            //
+            // The full `pg_recover_stale_claims` UPDATE ... RETURNING needs a
+            // live Postgres, so this exercises the exact registry recording the
+            // loop now performs for each stale-recovered `failed` row (and proves
+            // it is safe when this process never started the job).
+            let state = AppState::for_test().with_profile("dev");
+            state.job_registry().register("crashed_elsewhere");
+
+            // The two-line sequence the maintenance loop now runs per failed row.
+            state.job_registry().record_failure(
+                "crashed_elsewhere",
+                "visibility timeout expired".to_owned(),
+                true,
+            );
+            crate::alerts::notify_dead_lettered_job(
+                &state,
+                "crashed_elsewhere",
+                "visibility timeout expired",
+            );
+
+            let status = state.job_registry().snapshot()["crashed_elsewhere"].clone();
+            assert_eq!(
+                status.in_flight, 0,
+                "recording a dead-letter for a job this process never started must not underflow in_flight"
+            );
+            assert_eq!(
+                status.total_failures, 1,
+                "stale-recovered dead-letter must increment total_failures"
+            );
+            assert_eq!(
+                status.dead_letters, 1,
+                "stale-recovered dead-letter must appear in the /actuator/jobs dead-letter count"
+            );
+            assert_eq!(
+                status.last_error.as_deref(),
+                Some("visibility timeout expired"),
+                "snapshot must carry the stale-recovery reason as the last error"
+            );
         }
 
         #[test]

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -68,6 +68,13 @@ extern crate self as autumn_web;
 
 pub mod actuator;
 pub mod aggregate;
+/// Operator alerts for built-in failure conditions.
+///
+/// Connects built-in failure signals (dead-lettered jobs, Down health
+/// indicators, 5xx-rate spikes, scheduled-task failures) to the app's
+/// configured mailer and signed outbound webhook behind `[alerts]` config —
+/// with zero application code. See [`mod@alerts`].
+pub mod alerts;
 pub mod app;
 pub mod assets;
 pub mod audit;

--- a/autumn/tests/fixtures/schema_keys.snapshot
+++ b/autumn/tests/fixtures/schema_keys.snapshot
@@ -1,4 +1,5 @@
 actuator
+alerts
 auth
 bot_protection
 cache

--- a/autumn/tests/integration/alerts.rs
+++ b/autumn/tests/integration/alerts.rs
@@ -95,6 +95,7 @@ async fn dead_lettered_job_delivers_alert_to_configured_channel() {
     autumn_web::alerts::notify_dead_lettered_job(
         client.state(),
         "reporting_job",
+        "job-abc-123",
         "connection refused after 5 attempts",
     );
 
@@ -105,12 +106,63 @@ async fn dead_lettered_job_delivers_alert_to_configured_channel() {
     assert_eq!(alert.condition, AlertCondition::DeadLetteredJob);
     assert_eq!(alert.severity, AlertSeverity::Critical);
     assert_eq!(alert.event, AlertEventKind::Trigger);
+    // The dedup key stays scoped to the job TYPE (not the instance id) so a mass
+    // failure of one job type yields a bounded number of alerts (AC #3).
     assert_eq!(alert.dedup_key, "dead_lettered_job:reporting_job");
     // AC #4: states what, where to look, and on which host.
     assert_eq!(alert.where_to_look, "/actuator/jobs");
     assert!(alert.title.contains("reporting_job"));
+    // The bounded alert still names a concrete failed instance so the operator
+    // knows a specific job to look at: the id appears in the title, summary, and
+    // the structured `job_id` detail.
+    assert!(alert.title.contains("job-abc-123"));
+    assert!(alert.summary.contains("job-abc-123"));
+    assert_eq!(
+        alert.details.get("job_id").map(String::as_str),
+        Some("job-abc-123")
+    );
     assert!(alert.summary.contains("connection refused"));
     assert!(!alert.host.is_empty());
+}
+
+/// AC #3 (bounded, per JOB TYPE): two DISTINCT instances of the SAME job name
+/// that dead-letter within the dedup window collapse into ONE alert — the dedup
+/// key is scoped to the job type (`dead_lettered_job:{job_name}`), NOT the
+/// instance id, so a mass failure of one job type never floods the operator with
+/// one alert per failed job. The single delivered alert still names a concrete
+/// representative failed instance (the first one observed) so the operator has a
+/// job id to look at; the full set is visible at `/actuator/jobs`.
+#[tokio::test]
+async fn distinct_ids_of_same_job_dedup_to_one_bounded_alert() {
+    let channel = CapturingChannel::default();
+    let alerter = Alerter::new(vec![Arc::new(channel.clone())], test_settings());
+
+    let client = TestApp::new()
+        .state_initializer(move |state| state.insert_extension(alerter))
+        .build();
+
+    // Two different job instances of the SAME job name fail within the window.
+    autumn_web::alerts::notify_dead_lettered_job(client.state(), "reporting_job", "job-1", "boom");
+    autumn_web::alerts::notify_dead_lettered_job(client.state(), "reporting_job", "job-2", "boom");
+
+    // Give any (erroneously) dispatched second delivery a chance to arrive.
+    wait_for(&channel, 1).await;
+    tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+
+    let alerts = channel.alerts();
+    assert_eq!(
+        alerts.len(),
+        1,
+        "distinct instances of the same job type must dedup to one bounded alert: {alerts:?}"
+    );
+    // Still keyed on the job TYPE, and it names the first (representative) id.
+    assert_eq!(alerts[0].dedup_key, "dead_lettered_job:reporting_job");
+    assert_eq!(
+        alerts[0].details.get("job_id").map(String::as_str),
+        Some("job-1"),
+        "the bounded alert names the first observed failed instance"
+    );
+    assert!(alerts[0].title.contains("job-1"));
 }
 
 /// Finding 2: an alert's `where_to_look` must honor the configured `[actuator]
@@ -130,7 +182,7 @@ async fn where_to_look_honors_custom_actuator_prefix() {
         .state_initializer(move |state| state.insert_extension(alerter))
         .build();
 
-    autumn_web::alerts::notify_dead_lettered_job(client.state(), "reporting_job", "boom");
+    autumn_web::alerts::notify_dead_lettered_job(client.state(), "reporting_job", "job-1", "boom");
 
     wait_for(&channel, 1).await;
     let alerts = channel.alerts();
@@ -194,7 +246,7 @@ async fn sensitive_false_alerts_point_at_mounted_endpoint() {
         .state_initializer(move |state| state.insert_extension(alerter))
         .build();
 
-    autumn_web::alerts::notify_dead_lettered_job(client.state(), "reporting_job", "boom");
+    autumn_web::alerts::notify_dead_lettered_job(client.state(), "reporting_job", "job-1", "boom");
     autumn_web::alerts::notify_scheduled_task_failure(
         client.state(),
         "nightly_backup",
@@ -234,7 +286,7 @@ async fn sensitive_false_alerts_point_at_mounted_endpoint() {
         .state_initializer(move |state| state.insert_extension(alerter2))
         .build();
 
-    autumn_web::alerts::notify_dead_lettered_job(client2.state(), "reporting_job", "boom");
+    autumn_web::alerts::notify_dead_lettered_job(client2.state(), "reporting_job", "job-1", "boom");
     autumn_web::alerts::notify_scheduled_task_failure(
         client2.state(),
         "nightly_backup",
@@ -474,7 +526,7 @@ async fn webhook_with_whitespace_padded_url_registers_and_uses_trimmed_url() {
     );
 
     // Fire an alert and wait for the detached delivery task to POST to the mock.
-    autumn_web::alerts::notify_dead_lettered_job(client.state(), "reporting_job", "boom");
+    autumn_web::alerts::notify_dead_lettered_job(client.state(), "reporting_job", "job-1", "boom");
     for _ in 0..100 {
         if mock.call_count() >= 1 {
             break;
@@ -838,7 +890,7 @@ async fn alert_fans_out_to_every_channel() {
         .state_initializer(move |state| state.insert_extension(alerter))
         .build();
 
-    autumn_web::alerts::notify_dead_lettered_job(client.state(), "widget_job", "boom");
+    autumn_web::alerts::notify_dead_lettered_job(client.state(), "widget_job", "job-1", "boom");
 
     wait_for(&a, 1).await;
     wait_for(&b, 1).await;
@@ -875,7 +927,7 @@ async fn disabled_master_switch_silences_custom_channels() {
     );
 
     // Triggering a condition through the real seam delivers nothing.
-    autumn_web::alerts::notify_dead_lettered_job(client.state(), "reporting_job", "boom");
+    autumn_web::alerts::notify_dead_lettered_job(client.state(), "reporting_job", "job-1", "boom");
     autumn_web::alerts::notify_scheduled_task_failure(client.state(), "nightly_backup", "boom");
 
     // Give any (erroneously) spawned delivery task a chance to run.

--- a/autumn/tests/integration/alerts.rs
+++ b/autumn/tests/integration/alerts.rs
@@ -47,6 +47,15 @@ fn test_settings() -> AlerterSettings {
 }
 
 fn settings_with_prefix(prefix: &str) -> AlerterSettings {
+    settings_with_prefix_sensitive(prefix, true)
+}
+
+fn settings_with_prefix_sensitive(prefix: &str, actuator_sensitive: bool) -> AlerterSettings {
+    // `actuator_sensitive` defaults to `true` for the prefix helper so the
+    // dead-lettered-job/scheduled-task alerts point straight at the (mounted)
+    // `/jobs` and `/tasks` endpoints — the behavior those tests assert. The
+    // `sensitive = false` fallback is covered explicitly by
+    // `sensitive_false_alerts_point_at_mounted_endpoint`.
     AlerterSettings {
         dedup_window: std::time::Duration::from_secs(900),
         health_grace: std::time::Duration::from_secs(60),
@@ -54,6 +63,7 @@ fn settings_with_prefix(prefix: &str) -> AlerterSettings {
         error_rate_min_requests: 20,
         eval_interval: std::time::Duration::from_secs(30),
         actuator_prefix: prefix.to_owned(),
+        actuator_sensitive,
     }
 }
 
@@ -163,6 +173,78 @@ async fn scheduled_task_failure_delivers_alert() {
     assert_eq!(alerts[0].condition, AlertCondition::ScheduledTaskFailure);
     assert_eq!(alerts[0].where_to_look, "/actuator/tasks");
     assert!(alerts[0].summary.contains("disk full"));
+}
+
+/// Code-review fix: the `/actuator/jobs` and `/actuator/tasks` endpoints are
+/// mounted ONLY when `[actuator] sensitive = true` (default `false`). With the
+/// default `sensitive = false`, the dead-lettered-job and scheduled-task-failure
+/// alerts must NOT point operators at those unmounted (404) endpoints — they must
+/// point at the always-mounted `/actuator/health` and hint that the richer
+/// endpoint needs `[actuator] sensitive = true`. With `sensitive = true` the
+/// alerts point straight at `/jobs` / `/tasks`.
+#[tokio::test]
+async fn sensitive_false_alerts_point_at_mounted_endpoint() {
+    // sensitive = false (the production default): fallback + hint, never a 404.
+    let channel = CapturingChannel::default();
+    let alerter = Alerter::new(
+        vec![Arc::new(channel.clone())],
+        settings_with_prefix_sensitive("/actuator", false),
+    );
+    let client = TestApp::new()
+        .state_initializer(move |state| state.insert_extension(alerter.clone()))
+        .build();
+
+    autumn_web::alerts::notify_dead_lettered_job(client.state(), "reporting_job", "boom");
+    autumn_web::alerts::notify_scheduled_task_failure(
+        client.state(),
+        "nightly_backup",
+        "disk full",
+    );
+    wait_for(&channel, 2).await;
+    let alerts = channel.alerts();
+    assert_eq!(alerts.len(), 2);
+
+    let dead = &alerts[0].where_to_look;
+    assert!(
+        !dead.starts_with("/actuator/jobs"),
+        "dead-letter alert must not link the unmounted /actuator/jobs: {dead}"
+    );
+    assert!(
+        dead.contains("/actuator/health") && dead.contains("[actuator] sensitive = true"),
+        "must point at /actuator/health and hint the sensitive requirement: {dead}"
+    );
+
+    let task = &alerts[1].where_to_look;
+    assert!(
+        !task.starts_with("/actuator/tasks"),
+        "scheduled-task alert must not link the unmounted /actuator/tasks: {task}"
+    );
+    assert!(
+        task.contains("/actuator/health") && task.contains("[actuator] sensitive = true"),
+        "must point at /actuator/health and hint the sensitive requirement: {task}"
+    );
+
+    // sensitive = true: the endpoints are mounted, so link them directly.
+    let channel2 = CapturingChannel::default();
+    let alerter2 = Alerter::new(
+        vec![Arc::new(channel2.clone())],
+        settings_with_prefix_sensitive("/actuator", true),
+    );
+    let client2 = TestApp::new()
+        .state_initializer(move |state| state.insert_extension(alerter2.clone()))
+        .build();
+
+    autumn_web::alerts::notify_dead_lettered_job(client2.state(), "reporting_job", "boom");
+    autumn_web::alerts::notify_scheduled_task_failure(
+        client2.state(),
+        "nightly_backup",
+        "disk full",
+    );
+    wait_for(&channel2, 2).await;
+    let alerts2 = channel2.alerts();
+    assert_eq!(alerts2.len(), 2);
+    assert_eq!(alerts2[0].where_to_look, "/actuator/jobs");
+    assert_eq!(alerts2[1].where_to_look, "/actuator/tasks");
 }
 
 /// AC #3: a sustained/repeating condition is deduplicated (bounded, not

--- a/autumn/tests/integration/alerts.rs
+++ b/autumn/tests/integration/alerts.rs
@@ -88,7 +88,7 @@ async fn dead_lettered_job_delivers_alert_to_configured_channel() {
     let alerter = Alerter::new(vec![Arc::new(channel.clone())], test_settings());
 
     let client = TestApp::new()
-        .state_initializer(move |state| state.insert_extension(alerter.clone()))
+        .state_initializer(move |state| state.insert_extension(alerter))
         .build();
 
     // Induce the dead-letter signal exactly as the job runtime does.
@@ -127,7 +127,7 @@ async fn where_to_look_honors_custom_actuator_prefix() {
     );
 
     let client = TestApp::new()
-        .state_initializer(move |state| state.insert_extension(alerter.clone()))
+        .state_initializer(move |state| state.insert_extension(alerter))
         .build();
 
     autumn_web::alerts::notify_dead_lettered_job(client.state(), "reporting_job", "boom");
@@ -158,7 +158,7 @@ async fn scheduled_task_failure_delivers_alert() {
     let alerter = Alerter::new(vec![Arc::new(channel.clone())], test_settings());
 
     let client = TestApp::new()
-        .state_initializer(move |state| state.insert_extension(alerter.clone()))
+        .state_initializer(move |state| state.insert_extension(alerter))
         .build();
 
     autumn_web::alerts::notify_scheduled_task_failure(
@@ -191,7 +191,7 @@ async fn sensitive_false_alerts_point_at_mounted_endpoint() {
         settings_with_prefix_sensitive("/actuator", false),
     );
     let client = TestApp::new()
-        .state_initializer(move |state| state.insert_extension(alerter.clone()))
+        .state_initializer(move |state| state.insert_extension(alerter))
         .build();
 
     autumn_web::alerts::notify_dead_lettered_job(client.state(), "reporting_job", "boom");
@@ -231,7 +231,7 @@ async fn sensitive_false_alerts_point_at_mounted_endpoint() {
         settings_with_prefix_sensitive("/actuator", true),
     );
     let client2 = TestApp::new()
-        .state_initializer(move |state| state.insert_extension(alerter2.clone()))
+        .state_initializer(move |state| state.insert_extension(alerter2))
         .build();
 
     autumn_web::alerts::notify_dead_lettered_job(client2.state(), "reporting_job", "boom");
@@ -297,7 +297,7 @@ async fn scheduled_task_recovers_then_realerts_on_new_failure() {
     let alerter = Alerter::new(vec![Arc::new(channel.clone())], test_settings());
 
     let client = TestApp::new()
-        .state_initializer(move |state| state.insert_extension(alerter.clone()))
+        .state_initializer(move |state| state.insert_extension(alerter))
         .build();
     let state = client.state();
 
@@ -340,7 +340,7 @@ async fn scheduled_task_recovery_without_prior_failure_is_silent() {
     let alerter = Alerter::new(vec![Arc::new(channel.clone())], test_settings());
 
     let client = TestApp::new()
-        .state_initializer(move |state| state.insert_extension(alerter.clone()))
+        .state_initializer(move |state| state.insert_extension(alerter))
         .build();
 
     autumn_web::alerts::notify_scheduled_task_recovered(client.state(), "healthy_task");
@@ -835,7 +835,7 @@ async fn alert_fans_out_to_every_channel() {
     );
 
     let client = TestApp::new()
-        .state_initializer(move |state| state.insert_extension(alerter.clone()))
+        .state_initializer(move |state| state.insert_extension(alerter))
         .build();
 
     autumn_web::alerts::notify_dead_lettered_job(client.state(), "widget_job", "boom");

--- a/autumn/tests/integration/alerts.rs
+++ b/autumn/tests/integration/alerts.rs
@@ -224,6 +224,93 @@ async fn mail_channel_reuses_mailer_and_bypasses_suppression() {
     );
 }
 
+/// Regression: with the `mail` feature on but the mail transport disabled
+/// (the default `DisabledTransport`, or a prod profile turning it off), an
+/// email-only alert config must NOT register a `MailAlertChannel`. That channel
+/// would report `Ok(())` while the disabled transport silently drops the
+/// message, making an email-only prod config look active while sending nothing.
+/// `install_from_config` must skip the dead channel and, with no other
+/// destination, install no alerter at all.
+#[cfg(feature = "mail")]
+#[tokio::test]
+async fn disabled_mail_transport_does_not_register_email_channel() {
+    use autumn_web::mail::{Mail, MailError, MailTransport, Mailer};
+
+    #[derive(Clone, Default)]
+    struct DisabledTestTransport;
+    impl MailTransport for DisabledTestTransport {
+        fn send<'a>(
+            &'a self,
+            _mail: Mail,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), MailError>> + Send + 'a>>
+        {
+            Box::pin(async move { Ok(()) })
+        }
+        fn is_disabled(&self) -> bool {
+            true
+        }
+    }
+
+    let mailer = Arc::new(Mailer::with_transport(DisabledTestTransport));
+    assert!(mailer.is_disabled(), "sanity: transport reports disabled");
+
+    let client = TestApp::new()
+        .state_initializer(move |state| state.insert_extension((*mailer).clone()))
+        .build();
+
+    let config = AlertConfig {
+        email: Some("oncall@example.com".to_owned()),
+        ..AlertConfig::default()
+    };
+    autumn_web::alerts::install_from_config(client.state(), &config, Vec::new());
+
+    // The only configured destination was email over a disabled transport, so
+    // no channel is registered and therefore no alerter is installed — the
+    // `notify_*` hooks stay no-ops rather than pretending to deliver.
+    assert!(
+        client.state().extension::<Alerter>().is_none(),
+        "email-only config over a disabled mail transport must not install an alerter"
+    );
+}
+
+/// Companion to the above: an ENABLED mail transport with an email destination
+/// DOES register the mail channel (proving the guard keys off `is_disabled`).
+#[cfg(feature = "mail")]
+#[tokio::test]
+async fn enabled_mail_transport_registers_email_channel() {
+    use autumn_web::mail::{Mail, MailError, MailTransport, Mailer};
+
+    #[derive(Clone, Default)]
+    struct EnabledTestTransport;
+    impl MailTransport for EnabledTestTransport {
+        fn send<'a>(
+            &'a self,
+            _mail: Mail,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), MailError>> + Send + 'a>>
+        {
+            Box::pin(async move { Ok(()) })
+        }
+    }
+
+    let mailer = Arc::new(Mailer::with_transport(EnabledTestTransport));
+    assert!(!mailer.is_disabled(), "sanity: transport reports enabled");
+
+    let client = TestApp::new()
+        .state_initializer(move |state| state.insert_extension((*mailer).clone()))
+        .build();
+
+    let config = AlertConfig {
+        email: Some("oncall@example.com".to_owned()),
+        ..AlertConfig::default()
+    };
+    autumn_web::alerts::install_from_config(client.state(), &config, Vec::new());
+
+    assert!(
+        client.state().extension::<Alerter>().is_some(),
+        "an enabled mail transport with an email destination must install the mail channel"
+    );
+}
+
 /// AC #1 (fan-out): every registered channel receives the alert.
 #[tokio::test]
 async fn alert_fans_out_to_every_channel() {

--- a/autumn/tests/integration/alerts.rs
+++ b/autumn/tests/integration/alerts.rs
@@ -414,6 +414,100 @@ async fn webhook_with_secret_registers_channel() {
     );
 }
 
+/// P2 finding: the RUNTIME path must reject an unusable webhook URL before
+/// registering the channel. A relative/malformed `webhook_url` (here
+/// `hooks.example/x`) — even WITH a secret — is not an absolute `http(s)` URL, so
+/// `http_client::Client::build_request` would never dispatch it (it has no
+/// base-url alias to resolve against) and every alert POST would fail
+/// `reqwest::Url::parse`. `install_from_config` must skip the channel and, with
+/// the webhook as the only destination, install no alerter at all — so the caller
+/// is unaffected.
+#[cfg(feature = "http-client")]
+#[tokio::test]
+async fn webhook_with_relative_url_does_not_register_channel() {
+    let client = TestApp::new().build();
+
+    let config = AlertConfig {
+        webhook_url: Some("hooks.example/x".to_owned()),
+        webhook_secret: Some("s3cr3t".to_owned()),
+        ..AlertConfig::default()
+    };
+    autumn_web::alerts::install_from_config(client.state(), &config, Vec::new());
+
+    assert!(
+        client.state().extension::<Alerter>().is_none(),
+        "a relative/malformed webhook_url must not install a non-delivering webhook channel"
+    );
+}
+
+/// P2 finding, whitespace case: a copied env var commonly carries leading/
+/// trailing whitespace. The URL is otherwise valid, so `install_from_config` must
+/// TRIM it, register the channel, and deliver to the TRIMMED URL. We prove the
+/// trimmed URL is the one actually dispatched by registering an HTTP mock at the
+/// clean path and asserting the delivered alert hits it exactly once — an
+/// untrimmed `"  https://…  "` would fail to match (and, under the mock, error as
+/// `NoMock`) so the mock would never be called.
+#[cfg(feature = "http-client")]
+#[tokio::test]
+async fn webhook_with_whitespace_padded_url_registers_and_uses_trimmed_url() {
+    let trimmed = "https://alerts.example.com/hooks/autumn";
+    let mut app = TestApp::new();
+    // The webhook channel names its client with the (trimmed) URL, so the mock's
+    // alias must equal that trimmed URL for the outbound POST to match.
+    let mock = app
+        .http_mock(trimmed)
+        .post("/hooks/autumn")
+        .respond_with_status(200);
+    let client = app.build();
+
+    let config = AlertConfig {
+        webhook_url: Some(format!("  {trimmed}  ")),
+        webhook_secret: Some("s3cr3t".to_owned()),
+        ..AlertConfig::default()
+    };
+    autumn_web::alerts::install_from_config(client.state(), &config, Vec::new());
+
+    // The channel must be installed despite the surrounding whitespace.
+    assert!(
+        client.state().extension::<Alerter>().is_some(),
+        "a whitespace-padded but valid webhook_url must install the webhook channel"
+    );
+
+    // Fire an alert and wait for the detached delivery task to POST to the mock.
+    autumn_web::alerts::notify_dead_lettered_job(client.state(), "reporting_job", "boom");
+    for _ in 0..100 {
+        if mock.call_count() >= 1 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    mock.expect_called(1);
+}
+
+/// Companion: BOTH `https://` and `http://` absolute URLs (with a secret) are
+/// usable destinations and must register the webhook channel — the runtime rule
+/// accepts either scheme, so the install path must too.
+#[cfg(feature = "http-client")]
+#[tokio::test]
+async fn webhook_with_absolute_http_and_https_urls_register_channel() {
+    for url in [
+        "https://alerts.example.com/hooks/autumn",
+        "http://alerts.example.com/hooks/autumn",
+    ] {
+        let client = TestApp::new().build();
+        let config = AlertConfig {
+            webhook_url: Some(url.to_owned()),
+            webhook_secret: Some("s3cr3t".to_owned()),
+            ..AlertConfig::default()
+        };
+        autumn_web::alerts::install_from_config(client.state(), &config, Vec::new());
+        assert!(
+            client.state().extension::<Alerter>().is_some(),
+            "an absolute {url} webhook must install the webhook channel"
+        );
+    }
+}
+
 /// AC #1/#2: the built-in mail channel reuses the app's configured `Mailer` and
 /// delivers the alert even to a suppressed address (alerts are security-class;
 /// `ignore_suppression()` is called on the builder).

--- a/autumn/tests/integration/alerts.rs
+++ b/autumn/tests/integration/alerts.rs
@@ -10,8 +10,8 @@
 use std::sync::{Arc, Mutex};
 
 use autumn_web::alerts::{
-    Alert, AlertChannel, AlertCondition, AlertDeliveryError, AlertDeliveryFuture, AlertEventKind,
-    AlertSeverity, Alerter, AlerterSettings,
+    Alert, AlertChannel, AlertCondition, AlertConfig, AlertDeliveryError, AlertDeliveryFuture,
+    AlertEventKind, AlertSeverity, Alerter, AlerterSettings,
 };
 use autumn_web::test::TestApp;
 
@@ -244,6 +244,47 @@ async fn alert_fans_out_to_every_channel() {
     wait_for(&b, 1).await;
     assert_eq!(a.alerts().len(), 1);
     assert_eq!(b.alerts().len(), 1);
+}
+
+/// Master switch: `enabled = false` silences EVERYTHING, including a custom
+/// channel registered via the builder. `install_from_config` must install no
+/// alerter (so the `notify_*` hooks are no-ops) and must not deliver anything to
+/// the custom channel nor spawn the evaluation loop.
+#[tokio::test]
+async fn disabled_master_switch_silences_custom_channels() {
+    let channel = CapturingChannel::default();
+
+    let client = TestApp::new().build();
+
+    // A production-shaped config with alerting fully disabled, wired together
+    // with a custom channel exactly as `with_alert_channel` would surface it.
+    let config = AlertConfig {
+        enabled: false,
+        ..AlertConfig::default()
+    };
+    autumn_web::alerts::install_from_config(
+        client.state(),
+        &config,
+        vec![Arc::new(channel.clone())],
+    );
+
+    // With the master switch off, no alerter is installed onto state.
+    assert!(
+        client.state().extension::<Alerter>().is_none(),
+        "disabled alerting must not install an alerter (hooks stay no-ops)"
+    );
+
+    // Triggering a condition through the real seam delivers nothing.
+    autumn_web::alerts::notify_dead_lettered_job(client.state(), "reporting_job", "boom");
+    autumn_web::alerts::notify_scheduled_task_failure(client.state(), "nightly_backup", "boom");
+
+    // Give any (erroneously) spawned delivery task a chance to run.
+    tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+    assert!(
+        channel.alerts().is_empty(),
+        "custom channel must receive nothing when alerting is disabled: {:?}",
+        channel.alerts()
+    );
 }
 
 /// AC #6 (fail-safe): a channel that always errors never propagates the failure

--- a/autumn/tests/integration/alerts.rs
+++ b/autumn/tests/integration/alerts.rs
@@ -657,6 +657,173 @@ async fn enabled_mail_transport_registers_email_channel() {
     );
 }
 
+/// A non-disabled mail transport that would `send` fine at the transport layer,
+/// used to isolate the address/`from` preconditions from the disabled-transport
+/// skip. `is_disabled` returns the trait default (`false`).
+#[cfg(feature = "mail")]
+#[derive(Clone, Default)]
+struct UsableTestTransport;
+
+#[cfg(feature = "mail")]
+impl autumn_web::mail::MailTransport for UsableTestTransport {
+    fn send<'a>(
+        &'a self,
+        _mail: autumn_web::mail::Mail,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<(), autumn_web::mail::MailError>> + Send + 'a>,
+    > {
+        Box::pin(async move { Ok(()) })
+    }
+}
+
+/// Regression: lettre parses `[alerts] email` only at SEND time, so a
+/// present-but-unparsable address (`not-an-address`, a `mailto:` URI) passes
+/// every earlier gate yet fails EVERY delivery with `MailError::InvalidAddress`.
+/// With a usable (non-disabled) transport, `install_from_config` must still SKIP
+/// the mail channel — and, with no other destination, install no alerter — rather
+/// than register a channel that can never deliver.
+#[cfg(feature = "mail")]
+#[tokio::test]
+async fn invalid_email_address_does_not_register_email_channel() {
+    use autumn_web::mail::Mailer;
+
+    for invalid in ["not-an-address", "mailto:oncall@example.com"] {
+        let mailer = Arc::new(Mailer::with_transport(UsableTestTransport));
+        assert!(!mailer.is_disabled(), "sanity: transport reports enabled");
+
+        // A usable, `from`-free transport, so the ONLY reason to skip is the
+        // malformed address.
+        let mut config_full = autumn_web::config::AutumnConfig::default();
+        config_full.mail.transport = autumn_web::mail::Transport::Log;
+
+        let client = TestApp::new()
+            .config(config_full)
+            .state_initializer(move |state| state.insert_extension((*mailer).clone()))
+            .build();
+
+        let config = AlertConfig {
+            email: Some(invalid.to_owned()),
+            ..AlertConfig::default()
+        };
+        autumn_web::alerts::install_from_config(client.state(), &config, Vec::new());
+
+        assert!(
+            client.state().extension::<Alerter>().is_none(),
+            "an invalid [alerts] email ({invalid}) must not install a mail channel"
+        );
+    }
+}
+
+/// Regression: the alert mail carries no per-message `from`, so it falls back to
+/// the mailer default (`[mail] from`). Under `transport = "smtp"` with no `[mail]
+/// from`, `lettre_message` fails with "mail from address is required" and every
+/// delivery fails. `install_from_config` must SKIP the mail channel — and, with
+/// no other destination, install no alerter.
+#[cfg(feature = "mail")]
+#[tokio::test]
+async fn smtp_transport_without_from_does_not_register_email_channel() {
+    use autumn_web::mail::Mailer;
+
+    let mailer = Arc::new(Mailer::with_transport(UsableTestTransport));
+    assert!(!mailer.is_disabled(), "sanity: transport reports enabled");
+
+    let mut config_full = autumn_web::config::AutumnConfig::default();
+    config_full.mail.transport = autumn_web::mail::Transport::Smtp;
+    // A host is required only so `TestApp` can build its throwaway config mailer;
+    // our `UsableTestTransport` mailer (inserted below) is what the alerter uses.
+    config_full.mail.smtp.host = Some("smtp.example.com".to_owned());
+    config_full.mail.from = None;
+
+    let client = TestApp::new()
+        .config(config_full)
+        .state_initializer(move |state| state.insert_extension((*mailer).clone()))
+        .build();
+
+    let config = AlertConfig {
+        email: Some("oncall@example.com".to_owned()),
+        ..AlertConfig::default()
+    };
+    autumn_web::alerts::install_from_config(client.state(), &config, Vec::new());
+
+    assert!(
+        client.state().extension::<Alerter>().is_none(),
+        "an SMTP transport with no [mail] from must not install a mail channel"
+    );
+}
+
+/// Companion: a valid address on an SMTP transport WITH a `[mail] from` set is a
+/// working destination, so `install_from_config` registers the mail channel.
+#[cfg(feature = "mail")]
+#[tokio::test]
+async fn smtp_transport_with_from_registers_email_channel() {
+    use autumn_web::mail::Mailer;
+
+    let mailer = Arc::new(Mailer::with_transport(UsableTestTransport));
+    assert!(!mailer.is_disabled(), "sanity: transport reports enabled");
+
+    let mut config_full = autumn_web::config::AutumnConfig::default();
+    config_full.mail.transport = autumn_web::mail::Transport::Smtp;
+    // A host is required only so `TestApp` can build its throwaway config mailer;
+    // our `UsableTestTransport` mailer (inserted below) is what the alerter uses.
+    config_full.mail.smtp.host = Some("smtp.example.com".to_owned());
+    config_full.mail.from = Some("alerts@example.com".to_owned());
+
+    let client = TestApp::new()
+        .config(config_full)
+        .state_initializer(move |state| state.insert_extension((*mailer).clone()))
+        .build();
+
+    let config = AlertConfig {
+        email: Some("oncall@example.com".to_owned()),
+        ..AlertConfig::default()
+    };
+    autumn_web::alerts::install_from_config(client.state(), &config, Vec::new());
+
+    assert!(
+        client.state().extension::<Alerter>().is_some(),
+        "a valid email on an SMTP transport with [mail] from must install the mail channel"
+    );
+}
+
+/// Regression (no over-gating): the `log` and `file` transports render `from`
+/// only when present and deliver without it, so a valid email on a `log`
+/// transport with NO `[mail] from` is a working destination —
+/// `install_from_config` must still register the mail channel. Only SMTP is
+/// blocked by a missing `from`.
+#[cfg(feature = "mail")]
+#[tokio::test]
+async fn log_transport_without_from_registers_email_channel() {
+    use autumn_web::mail::Mailer;
+
+    for transport in [
+        autumn_web::mail::Transport::Log,
+        autumn_web::mail::Transport::File,
+    ] {
+        let mailer = Arc::new(Mailer::with_transport(UsableTestTransport));
+        assert!(!mailer.is_disabled(), "sanity: transport reports enabled");
+
+        let mut config_full = autumn_web::config::AutumnConfig::default();
+        config_full.mail.transport = transport;
+        config_full.mail.from = None;
+
+        let client = TestApp::new()
+            .config(config_full)
+            .state_initializer(move |state| state.insert_extension((*mailer).clone()))
+            .build();
+
+        let config = AlertConfig {
+            email: Some("oncall@example.com".to_owned()),
+            ..AlertConfig::default()
+        };
+        autumn_web::alerts::install_from_config(client.state(), &config, Vec::new());
+
+        assert!(
+            client.state().extension::<Alerter>().is_some(),
+            "a {transport:?} transport with no [mail] from must still install the mail channel"
+        );
+    }
+}
+
 /// AC #1 (fan-out): every registered channel receives the alert.
 #[tokio::test]
 async fn alert_fans_out_to_every_channel() {

--- a/autumn/tests/integration/alerts.rs
+++ b/autumn/tests/integration/alerts.rs
@@ -1,0 +1,277 @@
+//! End-to-end coverage for operator alerts (issue #1610).
+//!
+//! Proves the acceptance-criteria contract: a dead-lettered job (condition a)
+//! and a failed scheduled task (condition d) produce an alert on the configured
+//! channel; the built-in mail channel reuses the app's existing `Mailer` and
+//! bypasses the suppression list (alerts are security-class); and a
+//! sustained/repeating condition is deduplicated with a recovery notice when it
+//! clears.
+
+use std::sync::{Arc, Mutex};
+
+use autumn_web::alerts::{
+    Alert, AlertChannel, AlertCondition, AlertDeliveryError, AlertDeliveryFuture, AlertEventKind,
+    AlertSeverity, Alerter, AlerterSettings,
+};
+use autumn_web::test::TestApp;
+
+/// Test channel that records every alert it is asked to deliver.
+#[derive(Clone, Default)]
+struct CapturingChannel {
+    received: Arc<Mutex<Vec<Alert>>>,
+}
+
+impl CapturingChannel {
+    fn alerts(&self) -> Vec<Alert> {
+        self.received.lock().expect("lock").clone()
+    }
+}
+
+impl AlertChannel for CapturingChannel {
+    fn name(&self) -> &'static str {
+        "capturing"
+    }
+
+    fn deliver<'a>(&'a self, alert: &'a Alert) -> AlertDeliveryFuture<'a> {
+        let received = Arc::clone(&self.received);
+        let cloned = alert.clone();
+        Box::pin(async move {
+            received.lock().expect("lock").push(cloned);
+            Ok(())
+        })
+    }
+}
+
+fn test_settings() -> AlerterSettings {
+    AlerterSettings {
+        dedup_window: std::time::Duration::from_secs(900),
+        health_grace: std::time::Duration::from_secs(60),
+        error_rate_threshold: 0.05,
+        error_rate_min_requests: 20,
+        eval_interval: std::time::Duration::from_secs(30),
+    }
+}
+
+/// Wait for the detached delivery task(s) to run, polling until `channel` has at
+/// least `n` alerts or the deadline elapses.
+async fn wait_for(channel: &CapturingChannel, n: usize) {
+    for _ in 0..100 {
+        if channel.alerts().len() >= n {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+}
+
+/// AC #8: induce a dead-lettered job and assert the alert arrives on the
+/// configured channel. Drives the exact seam function
+/// (`alerts::notify_dead_lettered_job`) that every job backend's dead-letter
+/// site calls, over a real `AppState` with the alerter installed.
+#[tokio::test]
+async fn dead_lettered_job_delivers_alert_to_configured_channel() {
+    let channel = CapturingChannel::default();
+    let alerter = Alerter::new(vec![Arc::new(channel.clone())], test_settings());
+
+    let client = TestApp::new()
+        .state_initializer(move |state| state.insert_extension(alerter.clone()))
+        .build();
+
+    // Induce the dead-letter signal exactly as the job runtime does.
+    autumn_web::alerts::notify_dead_lettered_job(
+        client.state(),
+        "reporting_job",
+        "connection refused after 5 attempts",
+    );
+
+    wait_for(&channel, 1).await;
+    let alerts = channel.alerts();
+    assert_eq!(alerts.len(), 1, "exactly one alert delivered");
+    let alert = &alerts[0];
+    assert_eq!(alert.condition, AlertCondition::DeadLetteredJob);
+    assert_eq!(alert.severity, AlertSeverity::Critical);
+    assert_eq!(alert.event, AlertEventKind::Trigger);
+    assert_eq!(alert.dedup_key, "dead_lettered_job:reporting_job");
+    // AC #4: states what, where to look, and on which host.
+    assert_eq!(alert.where_to_look, "/actuator/jobs");
+    assert!(alert.title.contains("reporting_job"));
+    assert!(alert.summary.contains("connection refused"));
+    assert!(!alert.host.is_empty());
+}
+
+/// AC #2 (condition d): a framework-scheduled task failure produces an alert.
+#[tokio::test]
+async fn scheduled_task_failure_delivers_alert() {
+    let channel = CapturingChannel::default();
+    let alerter = Alerter::new(vec![Arc::new(channel.clone())], test_settings());
+
+    let client = TestApp::new()
+        .state_initializer(move |state| state.insert_extension(alerter.clone()))
+        .build();
+
+    autumn_web::alerts::notify_scheduled_task_failure(
+        client.state(),
+        "nightly_backup",
+        "disk full",
+    );
+
+    wait_for(&channel, 1).await;
+    let alerts = channel.alerts();
+    assert_eq!(alerts.len(), 1);
+    assert_eq!(alerts[0].condition, AlertCondition::ScheduledTaskFailure);
+    assert_eq!(alerts[0].where_to_look, "/actuator/tasks");
+    assert!(alerts[0].summary.contains("disk full"));
+}
+
+/// AC #3: a sustained/repeating condition is deduplicated (bounded, not
+/// one-per-occurrence), and a recovery notice is sent when it clears.
+#[tokio::test]
+async fn repeated_condition_is_deduplicated_then_recovers() {
+    let channel = CapturingChannel::default();
+    let alerter = Alerter::new(vec![Arc::new(channel.clone())], test_settings());
+
+    // 10 dead-letters of the SAME job in quick succession.
+    for _ in 0..10 {
+        let _ = alerter.notify(
+            Alert::trigger(AlertCondition::DeadLetteredJob, "dead_lettered_job:emailer")
+                .title("emailer dead-lettered")
+                .build(),
+        );
+    }
+    // A recovery for that same condition.
+    let recovered = alerter.recover(
+        Alert::recovery(AlertCondition::DeadLetteredJob, "dead_lettered_job:emailer")
+            .title("emailer recovered")
+            .build(),
+    );
+    assert!(
+        recovered,
+        "recovery of a previously-alerted condition sends"
+    );
+
+    wait_for(&channel, 2).await;
+    let alerts = channel.alerts();
+    assert_eq!(
+        alerts.len(),
+        2,
+        "one trigger (deduped) + one recovery, not one-per-occurrence: {alerts:?}"
+    );
+    assert_eq!(alerts[0].event, AlertEventKind::Trigger);
+    assert_eq!(alerts[1].event, AlertEventKind::Resolve);
+    assert_eq!(alerts[1].severity, AlertSeverity::Recovery);
+    // Stable dedup key correlates trigger and recovery.
+    assert_eq!(alerts[0].dedup_key, alerts[1].dedup_key);
+}
+
+/// AC #1/#2: the built-in mail channel reuses the app's configured `Mailer` and
+/// delivers the alert even to a suppressed address (alerts are security-class;
+/// `ignore_suppression()` is called on the builder).
+#[cfg(feature = "mail")]
+#[tokio::test]
+async fn mail_channel_reuses_mailer_and_bypasses_suppression() {
+    use autumn_web::alerts::MailAlertChannel;
+    use autumn_web::mail::suppression::{
+        InMemorySuppressionStore, SuppressionReason, SuppressionStore, SuppressionStoreHandle,
+    };
+    use autumn_web::mail::{Mail, MailError, MailTransport, Mailer};
+
+    #[derive(Clone, Default)]
+    struct RecordingTransport {
+        sent_to: Arc<Mutex<Vec<String>>>,
+    }
+    impl MailTransport for RecordingTransport {
+        fn send<'a>(
+            &'a self,
+            mail: Mail,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), MailError>> + Send + 'a>>
+        {
+            Box::pin(async move {
+                self.sent_to
+                    .lock()
+                    .expect("lock")
+                    .extend(mail.to.iter().cloned());
+                Ok(())
+            })
+        }
+    }
+
+    // The operator address is on the suppression list — a normal send would be
+    // skipped, but an alert must still be delivered.
+    let store = InMemorySuppressionStore::new();
+    store
+        .suppress("oncall@example.com", SuppressionReason::HardBounce)
+        .await
+        .expect("suppress");
+
+    let transport = RecordingTransport::default();
+    let mailer = Arc::new(
+        Mailer::with_transport(transport.clone())
+            .with_suppression(SuppressionStoreHandle::new(store)),
+    );
+
+    let channel = MailAlertChannel::new(mailer, "oncall@example.com");
+    let alert = Alert::trigger(AlertCondition::HighErrorRate, "high_error_rate:5xx")
+        .title("5xx spike")
+        .summary("10% of requests are failing")
+        .build();
+
+    channel.deliver(&alert).await.expect("alert delivered");
+
+    let recipients = transport.sent_to.lock().expect("lock").clone();
+    assert_eq!(
+        recipients,
+        vec!["oncall@example.com".to_owned()],
+        "alert delivered to the suppressed operator address (ignore_suppression)"
+    );
+}
+
+/// AC #1 (fan-out): every registered channel receives the alert.
+#[tokio::test]
+async fn alert_fans_out_to_every_channel() {
+    let a = CapturingChannel::default();
+    let b = CapturingChannel::default();
+    let alerter = Alerter::new(
+        vec![Arc::new(a.clone()), Arc::new(b.clone())],
+        test_settings(),
+    );
+
+    let client = TestApp::new()
+        .state_initializer(move |state| state.insert_extension(alerter.clone()))
+        .build();
+
+    autumn_web::alerts::notify_dead_lettered_job(client.state(), "widget_job", "boom");
+
+    wait_for(&a, 1).await;
+    wait_for(&b, 1).await;
+    assert_eq!(a.alerts().len(), 1);
+    assert_eq!(b.alerts().len(), 1);
+}
+
+/// AC #6 (fail-safe): a channel that always errors never propagates the failure
+/// to the caller — the emit returns normally and the app keeps running.
+#[tokio::test]
+async fn unreachable_channel_does_not_break_the_caller() {
+    struct FailingChannel;
+    impl AlertChannel for FailingChannel {
+        fn name(&self) -> &'static str {
+            "failing"
+        }
+        fn deliver<'a>(&'a self, _alert: &'a Alert) -> AlertDeliveryFuture<'a> {
+            Box::pin(async move { Err(AlertDeliveryError::new("failing", "unreachable")) })
+        }
+    }
+
+    let alerter = Alerter::new(vec![Arc::new(FailingChannel)], test_settings());
+    // notify() returns synchronously with the dedup decision; delivery happens
+    // on a detached task and its failure is only logged.
+    let dispatched = alerter.notify(
+        Alert::trigger(AlertCondition::DeadLetteredJob, "dead_lettered_job:x")
+            .title("x")
+            .build(),
+    );
+    assert!(
+        dispatched,
+        "emit returns without surfacing the delivery error"
+    );
+    // Give the detached task a chance to run and swallow its error.
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+}

--- a/autumn/tests/integration/alerts.rs
+++ b/autumn/tests/integration/alerts.rs
@@ -111,7 +111,10 @@ async fn dead_lettered_job_delivers_alert_to_configured_channel() {
 #[tokio::test]
 async fn where_to_look_honors_custom_actuator_prefix() {
     let channel = CapturingChannel::default();
-    let alerter = Alerter::new(vec![Arc::new(channel.clone())], settings_with_prefix("/_ops"));
+    let alerter = Alerter::new(
+        vec![Arc::new(channel.clone())],
+        settings_with_prefix("/_ops"),
+    );
 
     let client = TestApp::new()
         .state_initializer(move |state| state.insert_extension(alerter.clone()))
@@ -128,7 +131,11 @@ async fn where_to_look_honors_custom_actuator_prefix() {
     );
 
     // A scheduled-task failure uses the same prefix for its /tasks pointer.
-    autumn_web::alerts::notify_scheduled_task_failure(client.state(), "nightly_backup", "disk full");
+    autumn_web::alerts::notify_scheduled_task_failure(
+        client.state(),
+        "nightly_backup",
+        "disk full",
+    );
     wait_for(&channel, 2).await;
     let alerts = channel.alerts();
     assert_eq!(alerts[1].where_to_look, "/_ops/tasks");

--- a/autumn/tests/integration/alerts.rs
+++ b/autumn/tests/integration/alerts.rs
@@ -43,12 +43,17 @@ impl AlertChannel for CapturingChannel {
 }
 
 fn test_settings() -> AlerterSettings {
+    settings_with_prefix("/actuator")
+}
+
+fn settings_with_prefix(prefix: &str) -> AlerterSettings {
     AlerterSettings {
         dedup_window: std::time::Duration::from_secs(900),
         health_grace: std::time::Duration::from_secs(60),
         error_rate_threshold: 0.05,
         error_rate_min_requests: 20,
         eval_interval: std::time::Duration::from_secs(30),
+        actuator_prefix: prefix.to_owned(),
     }
 }
 
@@ -96,6 +101,37 @@ async fn dead_lettered_job_delivers_alert_to_configured_channel() {
     assert!(alert.title.contains("reporting_job"));
     assert!(alert.summary.contains("connection refused"));
     assert!(!alert.host.is_empty());
+}
+
+/// Finding 2: an alert's `where_to_look` must honor the configured `[actuator]
+/// prefix`. With a custom prefix, the emitted alert points operators at the real
+/// actuator endpoint (`/_ops/jobs`) instead of a hard-coded `/actuator/jobs`
+/// that would 404. The default-prefix case is covered by
+/// `dead_lettered_job_delivers_alert_to_configured_channel` above (`/actuator/jobs`).
+#[tokio::test]
+async fn where_to_look_honors_custom_actuator_prefix() {
+    let channel = CapturingChannel::default();
+    let alerter = Alerter::new(vec![Arc::new(channel.clone())], settings_with_prefix("/_ops"));
+
+    let client = TestApp::new()
+        .state_initializer(move |state| state.insert_extension(alerter.clone()))
+        .build();
+
+    autumn_web::alerts::notify_dead_lettered_job(client.state(), "reporting_job", "boom");
+
+    wait_for(&channel, 1).await;
+    let alerts = channel.alerts();
+    assert_eq!(alerts.len(), 1);
+    assert_eq!(
+        alerts[0].where_to_look, "/_ops/jobs",
+        "where_to_look must use the configured actuator prefix, not a hard-coded /actuator"
+    );
+
+    // A scheduled-task failure uses the same prefix for its /tasks pointer.
+    autumn_web::alerts::notify_scheduled_task_failure(client.state(), "nightly_backup", "disk full");
+    wait_for(&channel, 2).await;
+    let alerts = channel.alerts();
+    assert_eq!(alerts[1].where_to_look, "/_ops/tasks");
 }
 
 /// AC #2 (condition d): a framework-scheduled task failure produces an alert.

--- a/autumn/tests/integration/alerts.rs
+++ b/autumn/tests/integration/alerts.rs
@@ -162,6 +162,133 @@ async fn repeated_condition_is_deduplicated_then_recovers() {
     assert_eq!(alerts[0].dedup_key, alerts[1].dedup_key);
 }
 
+/// Finding 2 (recovery): a scheduled task that fails, then succeeds, delivers a
+/// recovery notice; and a subsequent failure within the dedup window alerts
+/// again rather than being suppressed as if still failing. Proves the scheduler
+/// success arms clear the `scheduled_task_failure:{task}` dedup key.
+#[tokio::test]
+async fn scheduled_task_recovers_then_realerts_on_new_failure() {
+    let channel = CapturingChannel::default();
+    let alerter = Alerter::new(vec![Arc::new(channel.clone())], test_settings());
+
+    let client = TestApp::new()
+        .state_initializer(move |state| state.insert_extension(alerter.clone()))
+        .build();
+    let state = client.state();
+
+    // Fail → alert.
+    autumn_web::alerts::notify_scheduled_task_failure(state, "nightly_backup", "disk full");
+    wait_for(&channel, 1).await;
+
+    // Succeed → recovery notice for the same key.
+    autumn_web::alerts::notify_scheduled_task_recovered(state, "nightly_backup");
+    wait_for(&channel, 2).await;
+
+    // Fail again within the (900s) dedup window → must alert again, not be
+    // suppressed as if still failing (the success cleared the active key).
+    autumn_web::alerts::notify_scheduled_task_failure(state, "nightly_backup", "disk full again");
+    wait_for(&channel, 3).await;
+
+    let alerts = channel.alerts();
+    assert_eq!(
+        alerts.len(),
+        3,
+        "fail → recover → fail must produce trigger, resolve, trigger: {alerts:?}"
+    );
+    assert_eq!(alerts[0].event, AlertEventKind::Trigger);
+    assert_eq!(alerts[0].condition, AlertCondition::ScheduledTaskFailure);
+    assert_eq!(alerts[1].event, AlertEventKind::Resolve);
+    assert_eq!(alerts[1].severity, AlertSeverity::Recovery);
+    assert_eq!(alerts[2].event, AlertEventKind::Trigger);
+    // Stable dedup key correlates the whole lifecycle.
+    assert_eq!(alerts[0].dedup_key, "scheduled_task_failure:nightly_backup");
+    assert_eq!(alerts[0].dedup_key, alerts[1].dedup_key);
+    assert_eq!(alerts[1].dedup_key, alerts[2].dedup_key);
+}
+
+/// Recovery is a no-op when the task never failed: a success for a task with no
+/// outstanding failure delivers nothing (the dedup gate suppresses it), so a
+/// task that has only ever succeeded stays silent.
+#[tokio::test]
+async fn scheduled_task_recovery_without_prior_failure_is_silent() {
+    let channel = CapturingChannel::default();
+    let alerter = Alerter::new(vec![Arc::new(channel.clone())], test_settings());
+
+    let client = TestApp::new()
+        .state_initializer(move |state| state.insert_extension(alerter.clone()))
+        .build();
+
+    autumn_web::alerts::notify_scheduled_task_recovered(client.state(), "healthy_task");
+
+    tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+    assert!(
+        channel.alerts().is_empty(),
+        "a success with no outstanding failure must deliver no recovery: {:?}",
+        channel.alerts()
+    );
+}
+
+/// Finding 3: alert webhooks are ALWAYS signed, so a webhook destination with no
+/// signing secret must NOT register a webhook channel — sending unsigned would be
+/// rejected by receivers following the documented verification. With the webhook
+/// as the only destination, `install_from_config` installs no alerter at all.
+#[cfg(feature = "http-client")]
+#[tokio::test]
+async fn webhook_without_secret_does_not_register_channel() {
+    let client = TestApp::new().build();
+
+    let config = AlertConfig {
+        webhook_url: Some("https://alerts.example.com/hooks/autumn".to_owned()),
+        webhook_secret: None,
+        ..AlertConfig::default()
+    };
+    autumn_web::alerts::install_from_config(client.state(), &config, Vec::new());
+
+    assert!(
+        client.state().extension::<Alerter>().is_none(),
+        "a webhook destination with no signing secret must not install an (unsigned) channel"
+    );
+}
+
+/// Companion: a whitespace-only secret is treated as absent — still no channel.
+#[cfg(feature = "http-client")]
+#[tokio::test]
+async fn webhook_with_blank_secret_does_not_register_channel() {
+    let client = TestApp::new().build();
+
+    let config = AlertConfig {
+        webhook_url: Some("https://alerts.example.com/hooks/autumn".to_owned()),
+        webhook_secret: Some("   ".to_owned()),
+        ..AlertConfig::default()
+    };
+    autumn_web::alerts::install_from_config(client.state(), &config, Vec::new());
+
+    assert!(
+        client.state().extension::<Alerter>().is_none(),
+        "a blank signing secret must be treated as absent (no unsigned channel)"
+    );
+}
+
+/// Companion: a webhook destination WITH a non-empty secret registers the signed
+/// webhook channel, so an alerter is installed.
+#[cfg(feature = "http-client")]
+#[tokio::test]
+async fn webhook_with_secret_registers_channel() {
+    let client = TestApp::new().build();
+
+    let config = AlertConfig {
+        webhook_url: Some("https://alerts.example.com/hooks/autumn".to_owned()),
+        webhook_secret: Some("s3cr3t".to_owned()),
+        ..AlertConfig::default()
+    };
+    autumn_web::alerts::install_from_config(client.state(), &config, Vec::new());
+
+    assert!(
+        client.state().extension::<Alerter>().is_some(),
+        "a webhook destination with a signing secret must install the webhook channel"
+    );
+}
+
 /// AC #1/#2: the built-in mail channel reuses the app's configured `Mailer` and
 /// delivers the alert even to a suppressed address (alerts are security-class;
 /// `ignore_suppression()` is called on the builder).

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -1,6 +1,7 @@
 mod access_log;
 mod acting_as_integration;
 mod after_commit_integration;
+mod alerts;
 mod api_versioning_integration;
 #[cfg(feature = "openapi")]
 mod api_versioning_openapi;

--- a/docs/guide/operator-alerts.md
+++ b/docs/guide/operator-alerts.md
@@ -1,7 +1,7 @@
 # Operator Alerts
 
 Autumn already knows when your app is in trouble: a background job gets
-dead-lettered, a health indicator goes `Down`, the 5xx rate spikes, or a
+dead-lettered, a health indicator goes unhealthy, the 5xx rate spikes, or a
 framework-scheduled task fails. **Operator alerts** connect those built-in
 failure signals to the delivery channels your app already has — the configured
 mailer and the signed outbound webhook — so you find out **without writing any
@@ -98,7 +98,7 @@ look next** pointer.
 | Condition | Fires when | Where to look | Tuning knob (default) |
 |-----------|------------|---------------|-----------------------|
 | **Dead-lettered job** | a background job exhausts its retries and is dead-lettered | `/actuator/jobs` † | always on |
-| **Health indicator Down** | a registered health indicator reports `Down` continuously past a grace period | `/actuator/health` | `health_grace_secs` (`60`) |
+| **Health indicator down** | a registered health indicator reports a non-healthy status (`DOWN` or `OUT_OF_SERVICE`) continuously past a grace period | `/actuator/health` | `health_grace_secs` (`60`) |
 | **High 5xx rate** | the rolling 5xx rate crosses a threshold | `/actuator/metrics` | `error_rate_threshold` (`0.05`), `error_rate_min_requests` (`20`) |
 | **Scheduled-task failure** | a framework-scheduled task (cron or fixed-delay — e.g. backup, cert-renewal) returns an error | `/actuator/tasks` † | always on |
 
@@ -150,8 +150,8 @@ webhook_secret = "…"           # REQUIRED with webhook_url; alerts are always
 # Deduplication
 dedup_window_secs = 900        # at most one notice per condition per 15 min
 
-# Condition (b): health indicator Down
-health_grace_secs = 60         # indicator must stay Down this long before alerting
+# Condition (b): health indicator down
+health_grace_secs = 60         # indicator must stay non-healthy this long before alerting
 
 # Condition (c): 5xx rate
 error_rate_threshold = 0.05    # fraction in (0, 1]; 0.05 = 5% of sampled requests
@@ -178,12 +178,16 @@ previously-alerted condition clears, **exactly one recovery notification** is
 sent (severity `recovery`, event `resolve`), carrying the same stable dedup key
 as its trigger so an incident manager can auto-resolve the correlated alert.
 
-For the **health-indicator Down** condition, "clears" means the indicator
-reports a genuinely healthy status again (`UP`, or `UNKNOWN` — both of which
-`/actuator/health` treats as healthy). A `Down` indicator that later reports
-`OUT_OF_SERVICE` is **not** a recovery: the service is still non-healthy, so the
-alert stays active and no false recovery is emitted until the indicator is
-actually healthy.
+For the **health-indicator down** condition, the alert **fires** whenever an
+indicator reports any non-healthy status — `DOWN` *or* `OUT_OF_SERVICE` — past
+the grace period. (An indicator that jumps straight to `OUT_OF_SERVICE` without
+first going `DOWN` is alerted just the same; `/actuator/health` returns a non-200
+for either.) The alert names the actual status it observed. "Clears" means the
+indicator reports a genuinely healthy status again (`UP`, or `UNKNOWN` — both of
+which `/actuator/health` treats as healthy). An already-alerted indicator that
+transitions from `DOWN` to `OUT_OF_SERVICE` is **not** a recovery: the service is
+still non-healthy, so the alert stays active and no false recovery is emitted
+until the indicator is actually healthy.
 
 ### Dead-lettered jobs: bounded per job type
 

--- a/docs/guide/operator-alerts.md
+++ b/docs/guide/operator-alerts.md
@@ -126,6 +126,17 @@ since the previous tick; it is only evaluated once at least
 `error_rate_min_requests` requests have been seen in that window, so a couple of
 errors during a quiet period never trip a false alarm.
 
+`error_rate_threshold` is a **fraction of sampled requests in `(0, 1]`** (it is
+compared against `errors / requests`), so `0.05` means "5% of sampled requests
+returned 5xx" and `1.0` means "100%". A value outside `(0, 1]` — non-finite
+(`nan`/`inf`), zero or negative, or greater than `1` — silently breaks the alert:
+a value `> 1` (or `nan`) can never be reached, so the 5xx alert would **never**
+fire, while a value `<= 0` would fire on a window with zero errors. Autumn is
+fail-safe here: at startup an invalid `error_rate_threshold` is **ignored and
+falls back to the default `0.05`** (logged with a `warn`), so 5xx alerting keeps
+working. `autumn doctor` also flags an invalid value in production so you can fix
+the config rather than unknowingly run on the default.
+
 ### Full `[alerts]` reference
 
 ```toml
@@ -143,7 +154,9 @@ dedup_window_secs = 900        # at most one notice per condition per 15 min
 health_grace_secs = 60         # indicator must stay Down this long before alerting
 
 # Condition (c): 5xx rate
-error_rate_threshold = 0.05    # 5% of sampled requests are 5xx
+error_rate_threshold = 0.05    # fraction in (0, 1]; 0.05 = 5% of sampled requests
+                               # are 5xx. An invalid value (non-finite, <= 0, or
+                               # > 1) falls back to the default 0.05 at startup.
 error_rate_min_requests = 20   # ignore the rate below this sample size
 
 # Background evaluation

--- a/docs/guide/operator-alerts.md
+++ b/docs/guide/operator-alerts.md
@@ -219,6 +219,13 @@ If a `webhook_url` is configured but no non-empty `webhook_secret` resolves,
 Autumn logs a startup `warn` and **does not register the webhook channel** —
 it never sends unsigned requests that your receiver would reject.
 
+`webhook_url` must be an **absolute `http(s)` URL** — it has to start with
+`http://` or `https://` and include a host (surrounding whitespace, common when
+the value comes from a copied env var, is trimmed automatically). A relative or
+malformed value could never be dispatched, so Autumn logs a startup `warn` and
+**does not register the webhook channel** rather than installing one that looks
+configured but fails every delivery.
+
 Email alerts are delivered through your configured mailer with the
 bounce/complaint **suppression list bypassed** — operator alerts are
 security-class and must never be silently dropped.

--- a/docs/guide/operator-alerts.md
+++ b/docs/guide/operator-alerts.md
@@ -159,6 +159,27 @@ actually healthy.
 
 ---
 
+## Limitations
+
+Deduplication is **process-local**: each replica keeps its own in-memory record
+of which conditions are currently firing. For the 5xx-rate and health-indicator
+conditions this is exactly right — each replica evaluates its own metrics and its
+alerts carry a host-scoped dedup key, so incidents stay separate per replica.
+
+There is one known gap for **scheduled-task recovery on multi-replica fleets**.
+A scheduled task is lease-coordinated across the fleet, so it can fail on one
+replica and later succeed on another after a leader handoff. Because the failure
+and the success were observed by different replicas — and the recovery is gated
+by the replica-local record of the failure — the replica that runs the success
+has no outstanding failure to clear, so the recovery notice is skipped and the
+original failure alert may linger until it ages out. **Single-VPS deployments
+(the common case) are unaffected**, since there is only one replica; only
+multi-replica fleets can hit this after a leader handoff. Cross-app or
+fleet-level alert aggregation and shared active-alert state are tracked as a
+follow-up (#1630) and are out of scope here.
+
+---
+
 ## What an alert contains
 
 Each alert states **what** failed, **when**, on **which host/replica**, and

--- a/docs/guide/operator-alerts.md
+++ b/docs/guide/operator-alerts.md
@@ -45,7 +45,13 @@ only counts when a usable `[mail] transport` is configured: the mailer defaults
 to `disabled` outside dev, and a disabled mailer installs no email alert channel
 (it silently drops mail), so doctor warns for an email paired with a disabled
 transport just as it does for a missing destination. Set `[mail] transport` to a
-real backend (`smtp`/`log`/`file`) or use a signed webhook. Doctor also honours
+real backend (`smtp`/`log`/`file`) or use a signed webhook. Email alerts also
+need a sender address: the alert mail carries no per-message `from`, so it uses
+the mailer default (`[mail] from`). With `transport = "smtp"` and no `[mail]
+from`, SMTP delivery fails with "mail from address is required", so doctor warns
+(in production) for an SMTP email destination with no `[mail] from` — set
+`[mail] from` (or `AUTUMN_MAIL__FROM`). The `log` and `file` transports deliver
+without a `from`, so they are not gated on it. Doctor also honours
 the master switch: when `[alerts] enabled = false` (or
 `AUTUMN_ALERTS__ENABLED=false`) in production it warns that no operator alerts
 will be delivered even though a destination is configured, because the runtime

--- a/docs/guide/operator-alerts.md
+++ b/docs/guide/operator-alerts.md
@@ -58,6 +58,13 @@ look next** pointer.
 | **High 5xx rate** | the rolling 5xx rate crosses a threshold | `/actuator/metrics` | `error_rate_threshold` (`0.05`), `error_rate_min_requests` (`20`) |
 | **Scheduled-task failure** | a framework-scheduled task (cron or fixed-delay — e.g. backup, cert-renewal) returns an error | `/actuator/tasks` | always on |
 
+The "where to look" paths above assume the default actuator prefix. If you
+change `[actuator] prefix` (or set `AUTUMN_ACTUATOR__PREFIX`), each alert's
+`where_to_look` is rebuilt from the configured prefix — e.g. with
+`prefix = "/_ops"` a dead-lettered-job alert points at `/_ops/jobs` — so it
+always references the endpoint you actually mounted rather than a `/actuator/*`
+404.
+
 The 5xx-rate and health conditions are evaluated on a **background tick**
 (`eval_interval_secs`, default `30`) — never on the request path — so they add
 no request latency (AC #6). The 5xx rate is measured over the requests seen
@@ -140,6 +147,9 @@ The webhook payload is JSON:
   "details": { "job": "reporting_job", "error": "connection refused" }
 }
 ```
+
+`where_to_look` uses your configured actuator prefix, so under a custom
+`[actuator] prefix` (e.g. `/_ops`) it reads `/_ops/jobs` instead.
 
 Alert webhooks are **always signed**, exactly like Autumn's outbound webhooks:
 an `Autumn-Signature: t=<unix>,v1=<hmac-sha256>` header over `"<t>.<body>"` using

--- a/docs/guide/operator-alerts.md
+++ b/docs/guide/operator-alerts.md
@@ -230,6 +230,18 @@ Email alerts are delivered through your configured mailer with the
 bounce/complaint **suppression list bypassed** — operator alerts are
 security-class and must never be silently dropped.
 
+Just as with webhooks, Autumn refuses to register a mail alert channel that
+could never deliver. It logs a startup `warn` and **does not register the mail
+channel** when the `[mail] transport` is `disabled` (it silently drops mail),
+when `[alerts] email` is not a valid address (lettre parses the recipient only
+when sending, so a malformed value like `not-an-address` or a `mailto:` URI
+would fail every delivery with an invalid-address error), or when the transport
+is `smtp` with no `[mail] from` (the alert mail carries no per-message `from`, so
+SMTP send fails with "mail from address is required"). The `log` and `file`
+transports deliver without a `from`, so they are never gated on it. These runtime
+skips mirror the `autumn doctor` warnings above, so doctor and the running app
+agree on which email destinations are usable.
+
 > Email alerts require the `mail` feature. If your binary is built without it, an
 > email-only `[alerts]` destination delivers nothing — Autumn logs a startup
 > `warn` in that case. Enable the `mail` feature or configure a `webhook_url`

--- a/docs/guide/operator-alerts.md
+++ b/docs/guide/operator-alerts.md
@@ -68,10 +68,10 @@ look next** pointer.
 
 | Condition | Fires when | Where to look | Tuning knob (default) |
 |-----------|------------|---------------|-----------------------|
-| **Dead-lettered job** | a background job exhausts its retries and is dead-lettered | `/actuator/jobs` | always on |
+| **Dead-lettered job** | a background job exhausts its retries and is dead-lettered | `/actuator/jobs` † | always on |
 | **Health indicator Down** | a registered health indicator reports `Down` continuously past a grace period | `/actuator/health` | `health_grace_secs` (`60`) |
 | **High 5xx rate** | the rolling 5xx rate crosses a threshold | `/actuator/metrics` | `error_rate_threshold` (`0.05`), `error_rate_min_requests` (`20`) |
-| **Scheduled-task failure** | a framework-scheduled task (cron or fixed-delay — e.g. backup, cert-renewal) returns an error | `/actuator/tasks` | always on |
+| **Scheduled-task failure** | a framework-scheduled task (cron or fixed-delay — e.g. backup, cert-renewal) returns an error | `/actuator/tasks` † | always on |
 
 The "where to look" paths above assume the default actuator prefix. If you
 change `[actuator] prefix` (or set `AUTUMN_ACTUATOR__PREFIX`), each alert's
@@ -79,6 +79,16 @@ change `[actuator] prefix` (or set `AUTUMN_ACTUATOR__PREFIX`), each alert's
 `prefix = "/_ops"` a dead-lettered-job alert points at `/_ops/jobs` — so it
 always references the endpoint you actually mounted rather than a `/actuator/*`
 404.
+
+**† `/actuator/jobs` and `/actuator/tasks` require `[actuator] sensitive = true`.**
+Those two endpoints are mounted only when the sensitive actuator surface is
+enabled, and `[actuator] sensitive` defaults to `false` (off in production). When
+it is off, the dead-lettered-job and scheduled-task-failure alerts do **not** link
+those endpoints (they would 404); instead they point at the always-mounted
+`/actuator/health` and note that the richer `/jobs` (resp. `/tasks`) endpoint
+becomes available once you set `[actuator] sensitive = true`. `/actuator/health`
+and `/actuator/metrics` are always mounted, so the health and 5xx-rate alerts link
+them unconditionally.
 
 The 5xx-rate and health conditions are evaluated on a **background tick**
 (`eval_interval_secs`, default `30`) — never on the request path — so they add
@@ -171,7 +181,11 @@ The webhook payload is JSON:
 ```
 
 `where_to_look` uses your configured actuator prefix, so under a custom
-`[actuator] prefix` (e.g. `/_ops`) it reads `/_ops/jobs` instead.
+`[actuator] prefix` (e.g. `/_ops`) it reads `/_ops/jobs` instead. The example
+above shows the value with `[actuator] sensitive = true`; with the default
+`sensitive = false` this dead-lettered-job alert instead reads
+`/actuator/health (/actuator/jobs requires [actuator] sensitive = true)`, because
+`/actuator/jobs` is not mounted (see the table note above).
 
 Alert webhooks are **always signed**, exactly like Autumn's outbound webhooks:
 an `Autumn-Signature: t=<unix>,v1=<hmac-sha256>` header over `"<t>.<body>"` using

--- a/docs/guide/operator-alerts.md
+++ b/docs/guide/operator-alerts.md
@@ -25,10 +25,12 @@ notice when it clears.
 [alerts]
 email = "oncall@example.com"
 webhook_url = "https://alerts.example.com/hooks/autumn"
+webhook_secret = "…"   # required with webhook_url; prefer the env var below
 ```
 
 That's it. With a destination configured, a scaffolded app delivers an alert for
-every built-in condition below. Prefer environment variables for secrets and
+every built-in condition below. A `webhook_url` requires a `webhook_secret`
+(alerts are always signed). Prefer environment variables for secrets and
 per-environment destinations:
 
 ```bash
@@ -70,7 +72,8 @@ errors during a quiet period never trip a false alarm.
 enabled = true                 # master switch (default true)
 email = "oncall@example.com"   # operator email destination
 webhook_url = "https://…"      # signed webhook destination
-webhook_secret = "…"           # HMAC secret (prefer AUTUMN_ALERTS__WEBHOOK_SECRET)
+webhook_secret = "…"           # REQUIRED with webhook_url; alerts are always
+                               # signed (prefer AUTUMN_ALERTS__WEBHOOK_SECRET)
 
 # Deduplication
 dedup_window_secs = 900        # at most one notice per condition per 15 min
@@ -138,9 +141,16 @@ The webhook payload is JSON:
 }
 ```
 
-The webhook is signed exactly like Autumn's outbound webhooks: an
-`Autumn-Signature: t=<unix>,v1=<hmac-sha256>` header over `"<t>.<body>"` using
+Alert webhooks are **always signed**, exactly like Autumn's outbound webhooks:
+an `Autumn-Signature: t=<unix>,v1=<hmac-sha256>` header over `"<t>.<body>"` using
 `webhook_secret`. Verify it the same way you verify any Autumn outbound webhook.
+
+Because alerts are always signed, **`webhook_secret` is required** whenever a
+`webhook_url` is configured. Set it in `[alerts]` or, preferably, via the
+`AUTUMN_ALERTS__WEBHOOK_SECRET` environment variable (which overrides the file).
+If a `webhook_url` is configured but no non-empty `webhook_secret` resolves,
+Autumn logs a startup `warn` and **does not register the webhook channel** —
+it never sends unsigned requests that your receiver would reject.
 
 Email alerts are delivered through your configured mailer with the
 bounce/complaint **suppression list bypassed** — operator alerts are

--- a/docs/guide/operator-alerts.md
+++ b/docs/guide/operator-alerts.md
@@ -45,7 +45,11 @@ only counts when a usable `[mail] transport` is configured: the mailer defaults
 to `disabled` outside dev, and a disabled mailer installs no email alert channel
 (it silently drops mail), so doctor warns for an email paired with a disabled
 transport just as it does for a missing destination. Set `[mail] transport` to a
-real backend (`smtp`/`log`/`file`) or use a signed webhook.
+real backend (`smtp`/`log`/`file`) or use a signed webhook. Doctor also honours
+the master switch: when `[alerts] enabled = false` (or
+`AUTUMN_ALERTS__ENABLED=false`) in production it warns that no operator alerts
+will be delivered even though a destination is configured, because the runtime
+installs no alerter at all when alerting is disabled.
 
 ---
 
@@ -115,6 +119,13 @@ keeps firing it re-notifies at most once per window as a reminder. When a
 previously-alerted condition clears, **exactly one recovery notification** is
 sent (severity `recovery`, event `resolve`), carrying the same stable dedup key
 as its trigger so an incident manager can auto-resolve the correlated alert.
+
+For the **health-indicator Down** condition, "clears" means the indicator
+reports a genuinely healthy status again (`UP`, or `UNKNOWN` — both of which
+`/actuator/health` treats as healthy). A `Down` indicator that later reports
+`OUT_OF_SERVICE` is **not** a recovery: the service is still non-healthy, so the
+alert stays active and no false recovery is emitted until the indicator is
+actually healthy.
 
 ### Silencing a condition
 

--- a/docs/guide/operator-alerts.md
+++ b/docs/guide/operator-alerts.md
@@ -103,7 +103,12 @@ as its trigger so an incident manager can auto-resolve the correlated alert.
 
 ### Silencing a condition
 
-- **Silence everything:** remove the destination, or set `enabled = false`.
+- **Silence everything:** set `enabled = false`. This is the master off switch
+  and silences **all** alerts — not just the built-in mail and webhook channels
+  but every custom [`AlertChannel`] registered with `with_alert_channel` too. No
+  channels are installed, the background evaluation loop is never started, and
+  the `notify_*` hooks become no-ops, so nothing is delivered anywhere.
+  (Removing the destination only silences the built-in channels.)
 - **Quiet the 5xx alert:** raise `error_rate_threshold` (e.g. `0.2`) or
   `error_rate_min_requests`.
 - **Tolerate flapping dependencies:** raise `health_grace_secs` so a brief blip
@@ -141,6 +146,11 @@ Email alerts are delivered through your configured mailer with the
 bounce/complaint **suppression list bypassed** — operator alerts are
 security-class and must never be silently dropped.
 
+> Email alerts require the `mail` feature. If your binary is built without it, an
+> email-only `[alerts]` destination delivers nothing — Autumn logs a startup
+> `warn` in that case. Enable the `mail` feature or configure a `webhook_url`
+> destination instead.
+
 The host/replica identity is read from `AUTUMN_REPLICA_ID`, falling back to
 `HOSTNAME`.
 
@@ -151,6 +161,10 @@ The host/replica identity is read from `AUTUMN_REPLICA_ID`, falling back to
 Delivery is a trait. Implement [`AlertChannel`] and register it — the built-in
 mail/webhook channels stay active alongside yours. This is the extension seam
 for additional transports; the framework core never changes.
+
+> Custom channels are still governed by the master switch: with
+> `enabled = false` your channel is not installed and receives nothing, exactly
+> like the built-in ones.
 
 ```rust,no_run
 use autumn_web::alerts::{Alert, AlertChannel, AlertDeliveryError, AlertDeliveryFuture};

--- a/docs/guide/operator-alerts.md
+++ b/docs/guide/operator-alerts.md
@@ -40,7 +40,12 @@ AUTUMN_ALERTS__WEBHOOK_SECRET=…       # HMAC signing secret for the webhook
 ```
 
 `autumn doctor` warns (in production mode) when no destination is configured, so
-a deploy never runs silently blind to its own failures.
+a deploy never runs silently blind to its own failures. An `email` destination
+only counts when a usable `[mail] transport` is configured: the mailer defaults
+to `disabled` outside dev, and a disabled mailer installs no email alert channel
+(it silently drops mail), so doctor warns for an email paired with a disabled
+transport just as it does for a missing destination. Set `[mail] transport` to a
+real backend (`smtp`/`log`/`file`) or use a signed webhook.
 
 ---
 

--- a/docs/guide/operator-alerts.md
+++ b/docs/guide/operator-alerts.md
@@ -1,0 +1,188 @@
+# Operator Alerts
+
+Autumn already knows when your app is in trouble: a background job gets
+dead-lettered, a health indicator goes `Down`, the 5xx rate spikes, or a
+framework-scheduled task fails. **Operator alerts** connect those built-in
+failure signals to the delivery channels your app already has — the configured
+mailer and the signed outbound webhook — so you find out **without writing any
+application code**.
+
+Provide an operator email and/or a webhook URL under `[alerts]` and you are
+done: every built-in condition is delivered, deduplicated, with a recovery
+notice when it clears.
+
+> Alerts reuse your existing mailer and outbound-webhook machinery — **no new
+> external dependency**. Delivery is best-effort and off the request path: if a
+> channel is unreachable the app keeps serving, the failure is logged, and **no
+> latency is added to any request**.
+
+---
+
+## Quick start
+
+```toml
+# autumn.toml
+[alerts]
+email = "oncall@example.com"
+webhook_url = "https://alerts.example.com/hooks/autumn"
+```
+
+That's it. With a destination configured, a scaffolded app delivers an alert for
+every built-in condition below. Prefer environment variables for secrets and
+per-environment destinations:
+
+```bash
+AUTUMN_ALERTS__EMAIL=oncall@example.com
+AUTUMN_ALERTS__WEBHOOK_URL=https://alerts.example.com/hooks/autumn
+AUTUMN_ALERTS__WEBHOOK_SECRET=…       # HMAC signing secret for the webhook
+```
+
+`autumn doctor` warns (in production mode) when no destination is configured, so
+a deploy never runs silently blind to its own failures.
+
+---
+
+## Built-in conditions, defaults, and how to tune each
+
+Every condition is on as soon as a destination is configured. Each carries a
+**stable dedup key**, a **severity** (`critical` on trigger, `recovery` on
+resolve), a **timestamp**, the **host/replica** it fired on, and a **where to
+look next** pointer.
+
+| Condition | Fires when | Where to look | Tuning knob (default) |
+|-----------|------------|---------------|-----------------------|
+| **Dead-lettered job** | a background job exhausts its retries and is dead-lettered | `/actuator/jobs` | always on |
+| **Health indicator Down** | a registered health indicator reports `Down` continuously past a grace period | `/actuator/health` | `health_grace_secs` (`60`) |
+| **High 5xx rate** | the rolling 5xx rate crosses a threshold | `/actuator/metrics` | `error_rate_threshold` (`0.05`), `error_rate_min_requests` (`20`) |
+| **Scheduled-task failure** | a framework-scheduled task (cron or fixed-delay — e.g. backup, cert-renewal) returns an error | `/actuator/tasks` | always on |
+
+The 5xx-rate and health conditions are evaluated on a **background tick**
+(`eval_interval_secs`, default `30`) — never on the request path — so they add
+no request latency (AC #6). The 5xx rate is measured over the requests seen
+since the previous tick; it is only evaluated once at least
+`error_rate_min_requests` requests have been seen in that window, so a couple of
+errors during a quiet period never trip a false alarm.
+
+### Full `[alerts]` reference
+
+```toml
+[alerts]
+enabled = true                 # master switch (default true)
+email = "oncall@example.com"   # operator email destination
+webhook_url = "https://…"      # signed webhook destination
+webhook_secret = "…"           # HMAC secret (prefer AUTUMN_ALERTS__WEBHOOK_SECRET)
+
+# Deduplication
+dedup_window_secs = 900        # at most one notice per condition per 15 min
+
+# Condition (b): health indicator Down
+health_grace_secs = 60         # indicator must stay Down this long before alerting
+
+# Condition (c): 5xx rate
+error_rate_threshold = 0.05    # 5% of sampled requests are 5xx
+error_rate_min_requests = 20   # ignore the rate below this sample size
+
+# Background evaluation
+eval_interval_secs = 30        # cadence for the health + 5xx-rate conditions
+```
+
+Every key above is also settable via `AUTUMN_ALERTS__<KEY>` (e.g.
+`AUTUMN_ALERTS__ERROR_RATE_THRESHOLD=0.02`).
+
+---
+
+## Deduplication and recovery
+
+A sustained or repeating condition does **not** produce one notification per
+occurrence. Autumn bounds it to **at most one notification per condition per
+dedup window** (`dedup_window_secs`, default 15 minutes). While the condition
+keeps firing it re-notifies at most once per window as a reminder. When a
+previously-alerted condition clears, **exactly one recovery notification** is
+sent (severity `recovery`, event `resolve`), carrying the same stable dedup key
+as its trigger so an incident manager can auto-resolve the correlated alert.
+
+### Silencing a condition
+
+- **Silence everything:** remove the destination, or set `enabled = false`.
+- **Quiet the 5xx alert:** raise `error_rate_threshold` (e.g. `0.2`) or
+  `error_rate_min_requests`.
+- **Tolerate flapping dependencies:** raise `health_grace_secs` so a brief blip
+  never alerts.
+- **Reduce reminder volume:** raise `dedup_window_secs`.
+
+---
+
+## What an alert contains
+
+Each alert states **what** failed, **when**, on **which host/replica**, and
+**where to look next** (an actuator endpoint or a log correlation id) — AC #4.
+The webhook payload is JSON:
+
+```json
+{
+  "dedup_key": "dead_lettered_job:reporting_job",
+  "condition": "dead_lettered_job",
+  "severity": "critical",
+  "event": "trigger",
+  "title": "Job 'reporting_job' was dead-lettered",
+  "summary": "Background job 'reporting_job' exhausted its retries …",
+  "timestamp": "2026-07-10T12:00:00Z",
+  "host": "web-7c9f",
+  "where_to_look": "/actuator/jobs",
+  "details": { "job": "reporting_job", "error": "connection refused" }
+}
+```
+
+The webhook is signed exactly like Autumn's outbound webhooks: an
+`Autumn-Signature: t=<unix>,v1=<hmac-sha256>` header over `"<t>.<body>"` using
+`webhook_secret`. Verify it the same way you verify any Autumn outbound webhook.
+
+Email alerts are delivered through your configured mailer with the
+bounce/complaint **suppression list bypassed** — operator alerts are
+security-class and must never be silently dropped.
+
+The host/replica identity is read from `AUTUMN_REPLICA_ID`, falling back to
+`HOSTNAME`.
+
+---
+
+## Adding your own destination (PagerDuty, Slack, Discord, …)
+
+Delivery is a trait. Implement [`AlertChannel`] and register it — the built-in
+mail/webhook channels stay active alongside yours. This is the extension seam
+for additional transports; the framework core never changes.
+
+```rust,no_run
+use autumn_web::alerts::{Alert, AlertChannel, AlertDeliveryError, AlertDeliveryFuture};
+
+struct PagerDuty {
+    routing_key: String,
+}
+
+impl AlertChannel for PagerDuty {
+    fn name(&self) -> &'static str { "pagerduty" }
+
+    fn deliver<'a>(&'a self, alert: &'a Alert) -> AlertDeliveryFuture<'a> {
+        Box::pin(async move {
+            // PagerDuty correlates incidents on `alert.dedup_key`; map
+            // `alert.severity` and `alert.event` onto its trigger/resolve API.
+            let _ = (&self.routing_key, &alert.dedup_key, alert.severity, alert.event);
+            Ok::<(), AlertDeliveryError>(())
+        })
+    }
+}
+
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .with_alert_channel(PagerDuty { routing_key: "…".into() })
+        .run()
+        .await;
+}
+```
+
+Because every alert carries a stable `dedup_key`, a `severity` class, and a
+`trigger`/`resolve` event, external incident managers can correlate and
+auto-resolve alerts without any per-condition glue.
+
+[`AlertChannel`]: https://docs.rs/autumn-web/latest/autumn_web/alerts/trait.AlertChannel.html

--- a/docs/guide/operator-alerts.md
+++ b/docs/guide/operator-alerts.md
@@ -61,8 +61,24 @@ installs no alerter at all when alerting is disabled.
 `AUTUMN_ALERTS__*` environment) and cannot see alert channels registered in code
 with `AppBuilder::with_alert_channel`. If your app installs a custom
 [`AlertChannel`] that way, alerts are still delivered even though nothing appears
-under `[alerts]`, so the "no alert destination" warning is expected and can be
-safely ignored (including under `autumn doctor --strict`).
+under `[alerts]`, so the "no alert destination" warning is expected.
+
+To make that pass — instead of ignoring the warning — declare the
+code-registered channel so `autumn doctor --strict` succeeds:
+
+```toml
+[alerts]
+custom_channel = true   # or AUTUMN_ALERTS__CUSTOM_CHANNEL=true
+```
+
+`custom_channel = true` tells doctor you register an alert channel in code via
+`AppBuilder::with_alert_channel`, suppressing the no-destination warning so a
+valid code-only deploy is not blocked by `--strict`. It is a doctor-only
+declaration: the runtime installs code-registered channels regardless of this
+flag, and it does **not** mask a *broken configured* destination — a malformed
+`[alerts] email`, an SMTP email with no `[mail] from`, a disabled mail transport,
+or a non-absolute `webhook_url` still warns. It suppresses only the pure "no
+destination configured" case.
 
 ---
 

--- a/docs/guide/operator-alerts.md
+++ b/docs/guide/operator-alerts.md
@@ -172,6 +172,25 @@ reports a genuinely healthy status again (`UP`, or `UNKNOWN` — both of which
 alert stays active and no false recovery is emitted until the indicator is
 actually healthy.
 
+### Dead-lettered jobs: bounded per job type
+
+The **dead-lettered-job** condition is deduplicated **per job type** — its dedup
+key is `dead_lettered_job:{job_name}`, scoped to the job's name, not the
+individual job instance. So when many instances of the *same* job type
+dead-letter within the dedup window (a mass failure — a dependency outage
+dead-lettering every `reporting_job` in the queue), you receive a **bounded
+number of alerts** (at most one per job type per window) rather than one alert
+per failed job. This deliberately protects a single-VPS operator from being
+flooded during an incident.
+
+So the bounded alert never hides *which* job failed, it names a concrete,
+representative failed instance: the specific job's id appears in the alert title
+and summary (`Job 'reporting_job' (id job-abc-123) was dead-lettered: …`) and in
+the structured `job_id` detail field. The **full set** of dead-lettered jobs —
+every instance, not just the one named in the alert — is always visible at the
+`/actuator/jobs` endpoint (the alert's "where to look next" pointer), so start
+from the named id and consult `/actuator/jobs` for the complete list.
+
 ### Silencing a condition
 
 - **Silence everything:** set `enabled = false`. This is the master off switch
@@ -221,12 +240,12 @@ The webhook payload is JSON:
   "condition": "dead_lettered_job",
   "severity": "critical",
   "event": "trigger",
-  "title": "Job 'reporting_job' was dead-lettered",
-  "summary": "Background job 'reporting_job' exhausted its retries …",
+  "title": "Job 'reporting_job' (id job-abc-123) was dead-lettered",
+  "summary": "Background job 'reporting_job' (id job-abc-123) exhausted its retries …",
   "timestamp": "2026-07-10T12:00:00Z",
   "host": "web-7c9f",
   "where_to_look": "/actuator/jobs",
-  "details": { "job": "reporting_job", "error": "connection refused" }
+  "details": { "job": "reporting_job", "job_id": "job-abc-123", "error": "connection refused" }
 }
 ```
 

--- a/docs/guide/operator-alerts.md
+++ b/docs/guide/operator-alerts.md
@@ -57,6 +57,13 @@ the master switch: when `[alerts] enabled = false` (or
 will be delivered even though a destination is configured, because the runtime
 installs no alerter at all when alerting is disabled.
 
+`autumn doctor` is a config-only checker: it reads `autumn.toml` (and the
+`AUTUMN_ALERTS__*` environment) and cannot see alert channels registered in code
+with `AppBuilder::with_alert_channel`. If your app installs a custom
+[`AlertChannel`] that way, alerts are still delivered even though nothing appears
+under `[alerts]`, so the "no alert destination" warning is expected and can be
+safely ignored (including under `autumn doctor --strict`).
+
 ---
 
 ## Built-in conditions, defaults, and how to tune each

--- a/docs/guide/operator-alerts.md
+++ b/docs/guide/operator-alerts.md
@@ -50,8 +50,14 @@ need a sender address: the alert mail carries no per-message `from`, so it uses
 the mailer default (`[mail] from`). With `transport = "smtp"` and no `[mail]
 from`, SMTP delivery fails with "mail from address is required", so doctor warns
 (in production) for an SMTP email destination with no `[mail] from` — set
-`[mail] from` (or `AUTUMN_MAIL__FROM`). The `log` and `file` transports deliver
-without a `from`, so they are not gated on it. Doctor also honours
+`[mail] from` (or `AUTUMN_MAIL__FROM`). The `from` must also be a *valid* mailbox:
+the runtime parses `[mail] from` at boot and refuses to start when it is set to an
+unparsable value like `not-a-mailbox`, so doctor warns (in production) for a
+present-but-invalid `[mail] from` on an SMTP transport — naming the offending
+value — to catch it before deploy rather than via a boot crash. Display-name
+senders such as `Ops <ops@example.com>` are accepted (they parse fine). The `log`
+and `file` transports deliver without a `from`, so they are not gated on it.
+Doctor also honours
 the master switch: when `[alerts] enabled = false` (or
 `AUTUMN_ALERTS__ENABLED=false`) in production it warns that no operator alerts
 will be delivered even though a destination is configured, because the runtime


### PR DESCRIPTION
Connect Autumn&#39;s built-in failure signals to its existing mail and signed-webhook delivery channels so a self-hosted operator learns about critical failures within minutes — with zero application code.

## Before / After

**Before:** A self-hosted operator&#39;s first signal of a dead-lettered job, a health indicator gone down, a 5xx spike, or a failed backup was &#34;whenever someone next reads the logs.&#34; Detection existed all over the framework; it was just never connected to anything that tells a human.

**After:** They get an email and/or a signed webhook within minutes of the condition occurring — no app code required, just an alert destination (an operator email and/or a webhook URL) in config.

## How it works

New `autumn/src/alerts.rs` wires the framework&#39;s existing failure signals to its existing delivery machinery:

- **Delivery reuses what&#39;s already there.** Critical alert mail is sent through the app&#39;s configured `Mailer` with `ignore_suppression()` so an operator alert is never dropped by the #1673 bounce/complaint suppression list; the webhook channel reuses the same Stripe-style HMAC signing scheme as `webhook_outbound`.
- **Fan-out over a trait.** Delivery is a fan-out over an `AlertChannel` trait, so mail and webhook are just two built-in implementations and additional transports plug in without touching the hooks.
- **Deduplicated, with recovery.** Alerts are deduplicated to at most one per condition per window; when a previously alerted condition clears, a recovery notification is sent.
- **Every alert is actionable.** Each alert carries what failed, when, on which host/replica, and where to look next (the relevant actuator endpoint / correlation pointer).
- **Hooks.** Dead-letter sites in `job.rs`, scheduler-failure arms in `app.rs`, plus a background evaluator for the health grace-period and the 5xx-rate window. The evaluator runs off the request path — zero added request latency.
- **Ops surface.** A production-mode `autumn doctor` check in `autumn-cli`, and a single guide page at `docs/guide/operator-alerts.md`.

## Acceptance criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Alert destination in config only (email and/or webhook URL), zero app code, reusing the existing mailer + outbound-webhook machinery with no new external dependency | PASS | `install_from_config` `autumn/src/alerts.rs:869`; `MailAlertChannel` reuses `crate::mail::Mailer` (`alerts.rs:774` `.ignore_suppression()`); `WebhookAlertChannel` reuses the `webhook_outbound` HMAC scheme (`alerts.rs:833-838`); `[alerts]` wired into config at `autumn/src/config.rs:1078` with `AUTUMN_ALERTS__*` overrides (`config.rs:2696`); test `config_active_requires_enabled_and_destination` |
| 2 | Delivers for (a) dead-lettered job, (b) health indicator down past grace, (c) 5xx rate over threshold, (d) framework-scheduled operation fails | PASS | (a) dead-letter hooks in `autumn/src/job.rs` (lines 3335, 3517, 3533, 5277, 5453, 5489, 5518, 5880, 5910); (b) `evaluate_health` `alerts.rs:991`; (c) `evaluate_error_rate` `alerts.rs:941`; (d) `notify_scheduled_task_failure` `autumn/src/app.rs:4975` &amp; `5049`; integration tests `dead_lettered_job_delivers_alert_to_configured_channel`, `scheduled_task_failure_delivers_alert` |
| 3 | Deduplicated to a bounded, documented count per window; recovery notification when the condition clears | PASS | `AlertDeduplicator` `alerts.rs:353`; `Alerter::notify` / `Alerter::recover` `alerts.rs:482` / `502`; tests `repeated_triggers_within_window_are_suppressed`, `trigger_renotifies_once_after_window_elapses`, `recovery_sends_only_for_active_key`, `sustained_condition_dispatches_once_per_window`; integration `repeated_condition_is_deduplicated_then_recovers` |
| 4 | Each alert states what failed, when, host/replica, and where to look next | PASS | `Alert` fields incl. `where_to_look` `alerts.rs:168`; per-condition defaults `AlertCondition::where_to_look` `alerts.rs:103`; tests `where_to_look_defaults_per_condition`, `alert_serializes_to_json_for_webhook` (asserts `where_to_look == &#34;/actuator/jobs&#34;`) |
| 5 | Full set of conditions, default thresholds, and how to tune/silence each documented on a single guide page | PASS | `docs/guide/operator-alerts.md` (188 lines) |
| 6 | Fail-safe: unreachable channel → app keeps serving, failure logged, no request-path latency | PASS | `Alerter::dispatch` fans out on a detached task off the request path `alerts.rs:519-551`; delivery failure logged at `alerts.rs:532`; integration `unreachable_channel_does_not_break_the_caller` |
| 7 | `autumn doctor` in production mode warns when no alert destination is configured | PASS | `check_alert_destination_impl` `autumn-cli/src/doctor.rs:396`, wired at `doctor.rs:2801`; tests `alert_destination_warns_in_production_when_none`, `alert_destination_passes_in_production_with_email`, `alert_destination_passes_in_production_with_webhook`, `alert_destination_passes_in_dev_without_destination` |
| 8 | System test proves end-to-end path: induce a dead-lettered job, assert the alert arrives | PASS | integration `dead_lettered_job_delivers_alert_to_configured_channel` `autumn/tests/integration/alerts.rs:71` |

All 8 PASS.

## Testing

- **13 unit** tests (`alerts::tests` in `autumn-web --lib`)
- **5 integration** tests (`integration::alerts`, including the end-to-end dead-letter → alert path)
- **4 doctor** tests (`alert_destination` in `autumn-cli --bins`)

All passing. `clippy` clean for the touched crates:
- `cargo clippy -p autumn-web --lib --features mail -- -D warnings`
- `cargo clippy -p autumn-cli --bins -- -D warnings`

## Follow-ups

- **Native PagerDuty / Slack / Discord delivery is issue #1630.** The `AlertChannel` trait is the extension point it plugs into — the design deliberately left room for it: stable dedup keys, severity classes, recovery events, and destination fan-out are all already in place.
- Two deferred minor items from review:
  - The background evaluation loop takes no `CancellationToken` yet (graceful-shutdown hygiene; needs threading a child token from the `run()` wiring).
  - Resolved dedup keys are marked inactive rather than garbage-collected. This is bounded for all built-in conditions (a fixed, small set of keys), so it does not grow unbounded in practice.

Closes #1610

---
_Generated by [Claude Code](https://claude.ai/code/session_01LK7ZjuYgaNLMaQH4ynhDLt)_

## CI note — known-red checks (external, not from this diff)

Three checks have been red on this PR for reasons unrelated to these changes. None is caused by this diff, and this branch is now rebased on the latest `trunk-dev`:

- **Fuzz** — fixed and merged to `trunk-dev` via #1717 (`taiki-e/install-action` pinned to `@v2` with an explicit tool input so `cargo-fuzz` installs). Now that this branch is rebased on top of that merge, Fuzz should be green.
- **Lint** — still red, pre-existing on `trunk-dev`: a `clippy::needless_pass_by_value` error at `autumn/src/repository.rs:157` (introduced by merged #1701). This diff does not touch `repository.rs`; the fix is in-flight in #1705 and will clear the check repo-wide once #1705 merges.
- **Documentation** (`cargo doc`) — pre-existing red on `trunk-dev`, tracked by fix #1724; unrelated to this diff.

All checks this diff can affect (the alerts unit/integration/doctor tests and clippy on the touched crates) pass locally.