### PR TITLE
feat(app): add web/worker process roles for independent scaling

### DIFF
--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -2164,10 +2164,17 @@ fn resolve_process_role_and_backend_from_sources<F>(
 where
     F: Fn(&str) -> Option<String>,
 {
+    // Mirror the runtime (`apply_role_env_overrides_with_env`): an invalid
+    // `AUTUMN_ROLE` env value is ignored and we fall through to the configured
+    // TOML `role`, rather than short-circuiting straight to `Combined`.
     let role = first_env(&env_var, &["AUTUMN_ROLE"])
-        .or_else(|| first_toml_string(table, &["role"]))
         .as_deref()
         .and_then(ProcessRole::from_env_value)
+        .or_else(|| {
+            first_toml_string(table, &["role"])
+                .as_deref()
+                .and_then(ProcessRole::from_env_value)
+        })
         .unwrap_or(ProcessRole::Combined);
 
     let jobs = table
@@ -4805,6 +4812,26 @@ foo = "bar"
         );
         assert_eq!(role, ProcessRole::Web);
         assert_eq!(backend, "postgres");
+    }
+
+    #[test]
+    fn resolve_process_role_falls_back_to_toml_when_env_role_invalid() {
+        // An invalid AUTUMN_ROLE must be ignored in favor of the configured
+        // TOML role, exactly like the runtime's apply_role_env_overrides_with_env.
+        let table: toml::Table =
+            toml::from_str("role = \"worker\"\n[jobs]\nbackend = \"local\"\n").expect("parse toml");
+        let (role, backend) = resolve_process_role_and_backend_from_sources(
+            |key| (key == "AUTUMN_ROLE").then(|| "garbage".to_owned()),
+            Some(&table),
+        );
+        assert_eq!(role, ProcessRole::Worker);
+        assert_eq!(backend, "local");
+
+        // ...and doctor therefore flags the split-on-local misconfiguration the
+        // runtime rejects at startup, instead of wrongly passing.
+        let result = check_split_topology_on_local(role, &backend);
+        assert_eq!(result.status, CheckStatus::Fail);
+        assert!(result.detail.unwrap_or_default().contains("worker"));
     }
 
     #[test]

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -1354,20 +1354,24 @@ fn check_database_topology_contract(
 /// Verify the selected process role is compatible with the jobs backend.
 ///
 /// A split web/worker role runs the HTTP tier and the job/scheduler tier in
-/// **separate processes**. The `local` jobs backend is an in-process, in-memory
-/// queue, so a web replica's enqueue never reaches a worker replica's queue.
-/// [`autumn_web::config::split_role_on_local_backend`] flags that invalid combo;
-/// the app itself rejects it at startup, and doctor surfaces it up front.
+/// **separate processes**, so it needs a durable jobs backend the two processes
+/// can share. Only the recognized durable backends (`postgres`/`redis`) qualify;
+/// any other value — the in-process `local` queue, a typo like `postgresql`, or a
+/// blank backend — falls through to the per-process local runtime, where a web
+/// replica's enqueue never reaches a worker replica's queue.
+/// [`autumn_web::config::split_role_requires_durable_backend`] flags that invalid
+/// combo; the app itself rejects it at startup, and doctor surfaces it up front.
 fn check_split_topology_on_local(role: ProcessRole, jobs_backend: &str) -> CheckResult {
     let backend = jobs_backend.trim();
-    if autumn_web::config::split_role_on_local_backend(role, jobs_backend) {
+    if autumn_web::config::split_role_requires_durable_backend(role, jobs_backend) {
         return CheckResult {
             name: "process_role_backend",
             status: CheckStatus::Fail,
             detail: Some(format!(
                 "role={} with jobs.backend=\"{backend}\": a split web/worker role needs a durable \
-                 (postgres/redis) jobs backend because `local` is in-process and cannot share a \
-                 job queue across the separate web and worker processes",
+                 (postgres/redis) jobs backend; \"{backend}\" is not a recognized durable backend \
+                 and falls through to the in-process `local` runtime, which cannot share a job \
+                 queue across the separate web and worker processes",
                 role.as_str(),
             )),
             hint: Some(
@@ -4781,6 +4785,42 @@ foo = "bar"
         let detail = result.detail.unwrap_or_default();
         assert!(detail.contains("role=web"), "got: {detail}");
         assert!(detail.contains("postgres"), "got: {detail}");
+    }
+
+    #[test]
+    fn split_topology_passes_for_worker_role_on_redis_backend() {
+        let result = check_split_topology_on_local(ProcessRole::Worker, "redis");
+        assert_eq!(result.status, CheckStatus::Pass);
+        let detail = result.detail.unwrap_or_default();
+        assert!(detail.contains("role=worker"), "got: {detail}");
+        assert!(detail.contains("redis"), "got: {detail}");
+    }
+
+    #[test]
+    fn split_topology_fails_on_web_role_with_backend_typo() {
+        // A typo like `postgresql` is not a recognized durable backend: it falls
+        // through to the in-process local runtime, so a split role must be
+        // rejected exactly as it is for the literal `local`.
+        let result = check_split_topology_on_local(ProcessRole::Web, "postgresql");
+        assert_eq!(result.status, CheckStatus::Fail);
+        let detail = result.detail.unwrap_or_default();
+        assert!(
+            detail.contains("web"),
+            "detail must name the role: {detail}"
+        );
+        assert!(
+            detail.contains("postgresql"),
+            "detail must name the offending backend: {detail}"
+        );
+        assert!(result.hint.unwrap_or_default().contains("postgres"));
+    }
+
+    #[test]
+    fn split_topology_fails_on_web_role_with_blank_backend() {
+        // A blank backend also falls through to the local runtime.
+        let result = check_split_topology_on_local(ProcessRole::Web, "");
+        assert_eq!(result.status, CheckStatus::Fail);
+        assert!(result.detail.unwrap_or_default().contains("web"));
     }
 
     #[test]

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -4,6 +4,7 @@
 //! reports each as ✅/⚠️/❌ with a one-line remediation hint, and exits with
 //! code 0 (all clear) or 1 (any failure detected).
 
+use autumn_web::config::ProcessRole;
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 
@@ -1350,6 +1351,43 @@ fn check_database_topology_contract(
     }
 }
 
+/// Verify the selected process role is compatible with the jobs backend.
+///
+/// A split web/worker role runs the HTTP tier and the job/scheduler tier in
+/// **separate processes**. The `local` jobs backend is an in-process, in-memory
+/// queue, so a web replica's enqueue never reaches a worker replica's queue.
+/// [`autumn_web::config::split_role_on_local_backend`] flags that invalid combo;
+/// the app itself rejects it at startup, and doctor surfaces it up front.
+fn check_split_topology_on_local(role: ProcessRole, jobs_backend: &str) -> CheckResult {
+    let backend = jobs_backend.trim();
+    if autumn_web::config::split_role_on_local_backend(role, jobs_backend) {
+        return CheckResult {
+            name: "process_role_backend",
+            status: CheckStatus::Fail,
+            detail: Some(format!(
+                "role={} with jobs.backend=\"{backend}\": a split web/worker role needs a durable \
+                 (postgres/redis) jobs backend because `local` is in-process and cannot share a \
+                 job queue across the separate web and worker processes",
+                role.as_str(),
+            )),
+            hint: Some(
+                "Set jobs.backend = \"postgres\" (or redis) for split web/worker roles, or run the combined role",
+            ),
+        };
+    }
+    let detail = if role == ProcessRole::Combined {
+        format!("role={}", role.as_str())
+    } else {
+        format!("role={}, jobs.backend={backend}", role.as_str())
+    };
+    CheckResult {
+        name: "process_role_backend",
+        status: CheckStatus::Pass,
+        detail: Some(detail),
+        hint: None,
+    }
+}
+
 fn check_replica_migration_versions(
     primary_latest: Option<&str>,
     replica_latest: Option<&str>,
@@ -2108,6 +2146,40 @@ where
     }
 }
 
+/// Resolve the selected process role and jobs backend from the same sources the
+/// runtime reads: the `AUTUMN_ROLE` / `AUTUMN_JOBS__BACKEND` env vars take
+/// precedence over the top-level `role` / `[jobs] backend` keys in the config
+/// table. Defaults to [`ProcessRole::Combined`] and the `"local"` backend.
+fn resolve_process_role_and_backend(table: Option<&toml::Table>) -> (ProcessRole, String) {
+    resolve_process_role_and_backend_from_sources(
+        |key| std::env::var(key).ok().filter(|value| !value.is_empty()),
+        table,
+    )
+}
+
+fn resolve_process_role_and_backend_from_sources<F>(
+    env_var: F,
+    table: Option<&toml::Table>,
+) -> (ProcessRole, String)
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let role = first_env(&env_var, &["AUTUMN_ROLE"])
+        .or_else(|| first_toml_string(table, &["role"]))
+        .as_deref()
+        .and_then(ProcessRole::from_env_value)
+        .unwrap_or(ProcessRole::Combined);
+
+    let jobs = table
+        .and_then(|t| t.get("jobs"))
+        .and_then(toml::Value::as_table);
+    let backend = first_env(&env_var, &["AUTUMN_JOBS__BACKEND"])
+        .or_else(|| first_toml_string(jobs, &["backend"]))
+        .unwrap_or_else(|| "local".to_owned());
+
+    (role, backend)
+}
+
 fn first_env<F>(env_var: &F, keys: &[&str]) -> Option<String>
 where
     F: Fn(&str) -> Option<String>,
@@ -2489,6 +2561,7 @@ pub fn run(opts: DoctorOptions) {
         .and_then(|content| toml::from_str::<toml::Table>(content).ok())
         .or_else(read_autumn_toml_table);
     let db_topology = resolve_database_topology(toml_table.as_ref());
+    let (process_role, jobs_backend) = resolve_process_role_and_backend(toml_table.as_ref());
     let port = resolve_server_port();
     let tailwind = tailwind_enabled();
     let signing_secret = resolve_optional_signing_secret();
@@ -2526,6 +2599,12 @@ pub fn run(opts: DoctorOptions) {
     let topology_for_check = db_topology.clone();
     tasks.push(Box::new(move || {
         check_database_topology_contract(&topology_for_check, is_production)
+    }));
+
+    // 4b. Process role vs. jobs backend: a split web/worker role can't share the
+    // in-process `local` job queue across separate processes.
+    tasks.push(Box::new(move || {
+        check_split_topology_on_local(process_role, &jobs_backend)
     }));
 
     if let Some(url) = db_topology.primary_url.clone() {
@@ -4652,6 +4731,80 @@ foo = "bar"
 
         assert_eq!(result.status, CheckStatus::Warn);
         assert!(result.detail.unwrap_or_default().contains("primary"));
+    }
+
+    // ── process role vs. jobs backend ─────────────────────────────────────────
+
+    #[test]
+    fn split_topology_fails_on_web_role_with_local_backend() {
+        let result = check_split_topology_on_local(ProcessRole::Web, "local");
+        assert_eq!(result.status, CheckStatus::Fail);
+        let detail = result.detail.unwrap_or_default();
+        assert!(
+            detail.contains("web"),
+            "detail must name the role: {detail}"
+        );
+        assert!(
+            detail.contains("local"),
+            "detail must name the backend: {detail}"
+        );
+        assert!(result.hint.unwrap_or_default().contains("postgres"));
+    }
+
+    #[test]
+    fn split_topology_fails_on_worker_role_with_local_backend() {
+        let result = check_split_topology_on_local(ProcessRole::Worker, "local");
+        assert_eq!(result.status, CheckStatus::Fail);
+        assert!(result.detail.unwrap_or_default().contains("worker"));
+    }
+
+    #[test]
+    fn split_topology_passes_for_combined_role_on_local_backend() {
+        let result = check_split_topology_on_local(ProcessRole::Combined, "local");
+        assert_eq!(result.status, CheckStatus::Pass);
+        // Combined never splits, so the detail need not mention the backend.
+        assert_eq!(result.detail.as_deref(), Some("role=combined"));
+        assert!(result.hint.is_none());
+    }
+
+    #[test]
+    fn split_topology_passes_for_web_role_on_postgres_backend() {
+        let result = check_split_topology_on_local(ProcessRole::Web, "postgres");
+        assert_eq!(result.status, CheckStatus::Pass);
+        let detail = result.detail.unwrap_or_default();
+        assert!(detail.contains("role=web"), "got: {detail}");
+        assert!(detail.contains("postgres"), "got: {detail}");
+    }
+
+    #[test]
+    fn resolve_process_role_prefers_env_over_toml() {
+        let table: toml::Table =
+            toml::from_str("role = \"web\"\n[jobs]\nbackend = \"local\"\n").expect("parse toml");
+        // Env overrides the toml `role`, and reads the jobs backend from toml.
+        let (role, backend) = resolve_process_role_and_backend_from_sources(
+            |key| (key == "AUTUMN_ROLE").then(|| "worker".to_owned()),
+            Some(&table),
+        );
+        assert_eq!(role, ProcessRole::Worker);
+        assert_eq!(backend, "local");
+    }
+
+    #[test]
+    fn resolve_process_role_defaults_to_combined_and_local() {
+        let (role, backend) = resolve_process_role_and_backend_from_sources(|_| None, None);
+        assert_eq!(role, ProcessRole::Combined);
+        assert_eq!(backend, "local");
+    }
+
+    #[test]
+    fn resolve_process_role_reads_backend_from_env() {
+        let table: toml::Table = toml::from_str("role = \"web\"\n").expect("parse toml");
+        let (role, backend) = resolve_process_role_and_backend_from_sources(
+            |key| (key == "AUTUMN_JOBS__BACKEND").then(|| "postgres".to_owned()),
+            Some(&table),
+        );
+        assert_eq!(role, ProcessRole::Web);
+        assert_eq!(backend, "postgres");
     }
 
     #[test]

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 mod assets;
 mod build;
@@ -175,6 +175,10 @@ enum Commands {
         /// Package to run (for workspaces)
         #[arg(short, long)]
         package: Option<String>,
+        /// Process role: web serves HTTP only, worker runs jobs+scheduler only,
+        /// combined (default) does both.
+        #[arg(long, value_enum)]
+        role: Option<ServeRole>,
     },
     /// Download and configure external tools (Tailwind CSS)
     Setup {
@@ -958,6 +962,29 @@ enum ServeCommands {
     Restart,
 }
 
+/// Process role selector for `autumn serve --role`.
+///
+/// Mirrors `autumn_web::config::ProcessRole`: `web` serves HTTP only, `worker`
+/// runs job workers + the cron scheduler only, and `combined` (the default)
+/// does both. The chosen role is forwarded to the app binary via `AUTUMN_ROLE`.
+#[derive(Clone, Copy, ValueEnum)]
+enum ServeRole {
+    Combined,
+    Web,
+    Worker,
+}
+
+impl ServeRole {
+    /// Stable lowercase identifier forwarded to the app via `AUTUMN_ROLE`.
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Combined => "combined",
+            Self::Web => "web",
+            Self::Worker => "worker",
+        }
+    }
+}
+
 /// Subcommands for `autumn migrate`.
 #[derive(Subcommand)]
 enum MigrateCommands {
@@ -1499,6 +1526,13 @@ enum ReleaseCommands {
         /// Deployment target: fly | docker-compose (omit for bare Dockerfile).
         #[arg(long, value_name = "TARGET")]
         target: Option<String>,
+        /// Scaffold a separate worker-role service in the generated
+        /// docker-compose.yml (opt-in split topology). The `app` service runs
+        /// the web role and a new `worker` service runs jobs+scheduler, both on
+        /// the shared `postgres` jobs backend. Only affects `--target
+        /// docker-compose`; the default output is a single combined service.
+        #[arg(long)]
+        split_workers: bool,
     },
 }
 
@@ -2156,6 +2190,7 @@ fn run_command(command: Commands) {
             release,
             bundled_pg,
             package,
+            role,
         } => {
             let action = action.map(|a| match a {
                 ServeCommands::Stop => serve::ServeAction::Stop,
@@ -2173,6 +2208,9 @@ fn run_command(command: Commands) {
                     // Normal start: the child inherits this shell's env. Only
                     // `restart` sets this, to restore a lost profile.
                     profile: None,
+                    // Forwarded to the app binary via `AUTUMN_ROLE`. `None` lets
+                    // the child pick its default (combined) or read its own env.
+                    role: role.map(|r| r.as_str().to_owned()),
                 },
             );
         }
@@ -2837,14 +2875,22 @@ fn run_routes_command(
 
 fn run_release_command(cmd: ReleaseCommands) {
     match cmd {
-        ReleaseCommands::Init { force, target } => {
+        ReleaseCommands::Init {
+            force,
+            target,
+            split_workers,
+        } => {
             let t = target.as_deref().map_or(release::Target::Default, |s| {
                 s.parse().unwrap_or_else(|e| {
                     eprintln!("autumn release init: {e}");
                     std::process::exit(1);
                 })
             });
-            release::run(release::ReleaseAction::Init { force, target: t });
+            release::run(release::ReleaseAction::Init {
+                force,
+                target: t,
+                split_workers,
+            });
         }
     }
 }
@@ -4722,7 +4768,7 @@ mod tests {
     #[test]
     fn parse_release_init_defaults() {
         let cli = Cli::try_parse_from(["autumn", "release", "init"]).unwrap();
-        let Commands::Release(ReleaseCommands::Init { force, target }) = cli.command else {
+        let Commands::Release(ReleaseCommands::Init { force, target, .. }) = cli.command else {
             panic!("expected release init");
         };
         assert!(!force);
@@ -4732,7 +4778,7 @@ mod tests {
     #[test]
     fn parse_release_init_with_force() {
         let cli = Cli::try_parse_from(["autumn", "release", "init", "--force"]).unwrap();
-        let Commands::Release(ReleaseCommands::Init { force, target }) = cli.command else {
+        let Commands::Release(ReleaseCommands::Init { force, target, .. }) = cli.command else {
             panic!("expected release init");
         };
         assert!(force);
@@ -4742,7 +4788,7 @@ mod tests {
     #[test]
     fn parse_release_init_with_fly_target() {
         let cli = Cli::try_parse_from(["autumn", "release", "init", "--target", "fly"]).unwrap();
-        let Commands::Release(ReleaseCommands::Init { force, target }) = cli.command else {
+        let Commands::Release(ReleaseCommands::Init { force, target, .. }) = cli.command else {
             panic!("expected release init");
         };
         assert!(!force);
@@ -4763,11 +4809,43 @@ mod tests {
     fn parse_release_init_force_and_target() {
         let cli = Cli::try_parse_from(["autumn", "release", "init", "--force", "--target", "fly"])
             .unwrap();
-        let Commands::Release(ReleaseCommands::Init { force, target }) = cli.command else {
+        let Commands::Release(ReleaseCommands::Init { force, target, .. }) = cli.command else {
             panic!("expected release init");
         };
         assert!(force);
         assert_eq!(target.as_deref(), Some("fly"));
+    }
+
+    #[test]
+    fn parse_release_init_split_workers_defaults_false() {
+        let cli = Cli::try_parse_from(["autumn", "release", "init"]).unwrap();
+        let Commands::Release(ReleaseCommands::Init { split_workers, .. }) = cli.command else {
+            panic!("expected release init");
+        };
+        assert!(!split_workers, "split_workers must default to false");
+    }
+
+    #[test]
+    fn parse_release_init_with_split_workers() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "release",
+            "init",
+            "--target",
+            "docker-compose",
+            "--split-workers",
+        ])
+        .unwrap();
+        let Commands::Release(ReleaseCommands::Init {
+            target,
+            split_workers,
+            ..
+        }) = cli.command
+        else {
+            panic!("expected release init");
+        };
+        assert_eq!(target.as_deref(), Some("docker-compose"));
+        assert!(split_workers, "--split-workers must set the flag");
     }
 
     #[test]

--- a/autumn-cli/src/release.rs
+++ b/autumn-cli/src/release.rs
@@ -49,7 +49,13 @@ impl std::str::FromStr for Target {
 
 #[derive(Clone, Copy)]
 pub enum ReleaseAction {
-    Init { force: bool, target: Target },
+    Init {
+        force: bool,
+        target: Target,
+        /// Scaffold a separate `worker` service (docker-compose target) that runs
+        /// the app's worker role alongside a web-only `app` service.
+        split_workers: bool,
+    },
 }
 
 pub fn run(action: ReleaseAction) {
@@ -61,13 +67,17 @@ pub fn run(action: ReleaseAction) {
     });
 
     match action {
-        ReleaseAction::Init { force, target } => {
+        ReleaseAction::Init {
+            force,
+            target,
+            split_workers,
+        } => {
             let project_name = read_project_name(&cwd).unwrap_or_else(|e| {
                 eprintln!("Error: {e}");
                 std::process::exit(1);
             });
 
-            match init(&cwd, &project_name, force, target) {
+            match init(&cwd, &project_name, force, target, split_workers) {
                 Ok(files) => {
                     for f in &files {
                         println!("  Created {f}");
@@ -197,6 +207,7 @@ pub fn init(
     project_name: &str,
     force: bool,
     target: Target,
+    split_workers: bool,
 ) -> Result<Vec<String>, ReleaseError> {
     let files = planned_files(target);
 
@@ -216,7 +227,10 @@ pub fn init(
 
     let mut created = Vec::new();
     for (name, template) in files {
-        fs::write(dir.join(name), render(template, project_name, embed))?;
+        fs::write(
+            dir.join(name),
+            render(template, project_name, embed, split_workers),
+        )?;
         created.push(name.to_string());
     }
     Ok(created)
@@ -244,7 +258,26 @@ fn project_has_embed_assets(dir: &Path) -> bool {
         .is_some_and(|features| features.contains_key("embed-assets"))
 }
 
-fn render(template: &str, project_name: &str, embed: bool) -> String {
+/// The extra `worker:` service block spliced into the docker-compose output when
+/// `--split-workers` is set. Runs the SAME image (`build: .`) and default
+/// entrypoint as the `app` service, but with `AUTUMN_ROLE=worker` so it runs the
+/// job workers + scheduler only. Shares the app's database URL, signing secret,
+/// and one-shot migration gate. Both tiers use the durable `postgres` jobs
+/// backend so the queue is shared across the separate web and worker processes
+/// (the in-process `local` backend can't span processes).
+const WORKER_SERVICE_BLOCK: &str = "\n  worker:\n    build: .\n    environment:\n      \
+AUTUMN_PROFILE: prod\n      AUTUMN_ROLE: worker\n      AUTUMN_JOBS__BACKEND: postgres\n      \
+AUTUMN_DATABASE__PRIMARY_URL: postgres://autumn:autumn@db:5432/{{project_name}}_prod\n      \
+AUTUMN_SECURITY__SIGNING_SECRET: \"${AUTUMN_SECURITY__SIGNING_SECRET:?set it first}\"\n    \
+depends_on:\n      db:\n        condition: service_healthy\n      migrate:\n        \
+condition: service_completed_successfully\n    restart: unless-stopped\n";
+
+/// The web-tier role env spliced into the `app` service when `--split-workers`
+/// is set: pin the app to the HTTP-only `web` role and the shared `postgres`
+/// jobs backend so enqueues land in the queue the worker process drains.
+const WEB_ROLE_ENV: &str = "\n      AUTUMN_ROLE: web\n      AUTUMN_JOBS__BACKEND: postgres";
+
+fn render(template: &str, project_name: &str, embed: bool, split_workers: bool) -> String {
     let (build_step, static_copy) = if embed {
         (
             "# Single-binary build: fingerprint static assets, then compile with the\n\
@@ -262,7 +295,18 @@ fn render(template: &str, project_name: &str, embed: bool) -> String {
             "COPY --chown=autumn:autumn --from=builder /app/static /app/static\n",
         )
     };
+    // Split-topology placeholders exist only in the docker-compose template, so
+    // these replacements are no-ops for the other files. Substitute them before
+    // `{{project_name}}` so the worker block's own `{{project_name}}` tokens are
+    // resolved by the shared replacement below.
+    let (worker_service, web_role_env) = if split_workers {
+        (WORKER_SERVICE_BLOCK, WEB_ROLE_ENV)
+    } else {
+        ("", "")
+    };
     template
+        .replace("{{worker_service}}", worker_service)
+        .replace("{{app_role_env}}", web_role_env)
         .replace("{{project_name}}", project_name)
         .replace(
             "{{rust_version}}",
@@ -314,7 +358,7 @@ mod tests {
     fn init_creates_dockerfile() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         assert!(dir.join("Dockerfile").is_file(), "Dockerfile not created");
     }
 
@@ -322,7 +366,7 @@ mod tests {
     fn init_creates_dockerignore() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         assert!(
             dir.join(".dockerignore").is_file(),
             ".dockerignore not created"
@@ -333,7 +377,7 @@ mod tests {
     fn init_creates_production_config_example() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         assert!(
             dir.join("autumn.production.toml.example").is_file(),
             "autumn.production.toml.example not created"
@@ -344,7 +388,7 @@ mod tests {
     fn init_returns_list_of_created_files() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        let files = init(&dir, "my-app", false, Target::Default).unwrap();
+        let files = init(&dir, "my-app", false, Target::Default, false).unwrap();
         assert!(files.contains(&"Dockerfile".to_string()));
         assert!(files.contains(&".dockerignore".to_string()));
         assert!(files.contains(&"autumn.production.toml.example".to_string()));
@@ -356,7 +400,7 @@ mod tests {
     fn dockerfile_has_cargo_chef_stages() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
         assert!(
             content.contains("cargo-chef"),
@@ -376,7 +420,7 @@ mod tests {
     fn dockerfile_uses_declared_msrv_for_rust_build_image() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
         let msrv = option_env!("CARGO_PKG_RUST_VERSION").unwrap_or("1.88.0");
 
@@ -394,7 +438,7 @@ mod tests {
     fn dockerfile_has_three_stages() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
         let from_count = content.lines().filter(|l| l.starts_with("FROM ")).count();
         assert!(
@@ -407,7 +451,7 @@ mod tests {
     fn dockerfile_copies_production_config_as_runtime_autumn_toml() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
         assert!(
             content.contains("autumn.production.toml.example"),
@@ -420,7 +464,7 @@ mod tests {
     fn dockerfile_runtime_uses_debian_slim() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
         assert!(
             content.contains("debian:bookworm-slim"),
@@ -432,7 +476,7 @@ mod tests {
     fn dockerfile_runtime_installs_libpq_and_tini() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
         assert!(
             content.contains("libpq"),
@@ -455,7 +499,7 @@ mod tests {
         // its Docker build keeps working.
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
         assert!(
             content.contains("RUN cargo build --release"),
@@ -483,7 +527,7 @@ mod tests {
              [features]\nembed-assets = [\"autumn-web/embed-assets\"]\n",
         )
         .unwrap();
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
         assert!(
             content.contains("autumn build --embed"),
@@ -499,7 +543,7 @@ mod tests {
     fn dockerfile_copies_migrations() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
         assert!(
             content.contains("migrations"),
@@ -511,7 +555,7 @@ mod tests {
     fn dockerfile_defers_migrations_to_one_shot_primary_job() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
         assert!(
             !content.contains("auto_migrate_in_production = true"),
@@ -527,7 +571,7 @@ mod tests {
     fn dockerfile_installs_autumn_cli_for_migration_jobs() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
         assert!(
             content.contains("cargo install")
@@ -541,7 +585,7 @@ mod tests {
     fn dockerfile_installs_diesel_cli_for_migration_jobs() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
         assert!(
             content.contains("cargo install")
@@ -557,7 +601,7 @@ mod tests {
     fn dockerfile_has_healthcheck() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
         assert!(
             content.contains("HEALTHCHECK"),
@@ -573,7 +617,7 @@ mod tests {
     fn dockerfile_exposes_port_3000() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
         assert!(
             content.contains("EXPOSE 3000"),
@@ -585,7 +629,7 @@ mod tests {
     fn dockerfile_substitutes_project_name() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-blog");
-        init(&dir, "my-blog", false, Target::Default).unwrap();
+        init(&dir, "my-blog", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
         assert!(
             content.contains("my-blog"),
@@ -607,7 +651,7 @@ mod tests {
     fn dockerignore_excludes_target() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join(".dockerignore")).unwrap();
         assert!(
             content.contains("target"),
@@ -619,7 +663,7 @@ mod tests {
     fn dockerignore_excludes_git() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join(".dockerignore")).unwrap();
         assert!(content.contains(".git"), ".dockerignore must exclude .git");
     }
@@ -628,7 +672,7 @@ mod tests {
     fn dockerignore_excludes_node_modules() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join(".dockerignore")).unwrap();
         assert!(
             content.contains("node_modules"),
@@ -640,7 +684,7 @@ mod tests {
     fn dockerignore_excludes_dist() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join(".dockerignore")).unwrap();
         assert!(content.contains("dist"), ".dockerignore must exclude dist/");
     }
@@ -649,7 +693,7 @@ mod tests {
     fn dockerignore_excludes_master_key() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join(".dockerignore")).unwrap();
         assert!(
             content.contains("/config/master.key") || content.contains("config/master.key"),
@@ -663,7 +707,7 @@ mod tests {
     fn production_config_template_documents_signing_secret_env_var() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("autumn.production.toml.example")).unwrap();
         assert!(
             content.contains("AUTUMN_SECURITY__SIGNING_SECRET"),
@@ -675,7 +719,7 @@ mod tests {
     fn production_config_template_documents_openssl_rand_command() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("autumn.production.toml.example")).unwrap();
         assert!(
             content.contains("openssl rand -hex 32"),
@@ -687,7 +731,7 @@ mod tests {
     fn production_config_template_mentions_signing_secrets_guide() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("autumn.production.toml.example")).unwrap();
         assert!(
             content.contains("signing-secrets.md"),
@@ -740,7 +784,7 @@ previous_secrets = []
     fn production_config_has_placeholder_db_url_not_real_credentials() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("autumn.production.toml.example")).unwrap();
         // Must have a DB URL entry
         assert!(
@@ -764,7 +808,7 @@ previous_secrets = []
     fn production_config_has_placeholder_for_project_name() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-blog");
-        init(&dir, "my-blog", false, Target::Default).unwrap();
+        init(&dir, "my-blog", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("autumn.production.toml.example")).unwrap();
         assert!(
             content.contains("my-blog"),
@@ -780,7 +824,7 @@ previous_secrets = []
     fn production_config_documents_port() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("autumn.production.toml.example")).unwrap();
         assert!(
             content.contains("port"),
@@ -795,7 +839,7 @@ previous_secrets = []
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
         fs::write(dir.join("Dockerfile"), "existing content").unwrap();
-        let err = init(&dir, "my-app", false, Target::Default).unwrap_err();
+        let err = init(&dir, "my-app", false, Target::Default, false).unwrap_err();
         assert!(
             matches!(err, ReleaseError::FileExists(_)),
             "expected FileExists, got: {err}"
@@ -811,7 +855,7 @@ previous_secrets = []
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
         fs::write(dir.join(".dockerignore"), "existing").unwrap();
-        let err = init(&dir, "my-app", false, Target::Default).unwrap_err();
+        let err = init(&dir, "my-app", false, Target::Default, false).unwrap_err();
         assert!(matches!(err, ReleaseError::FileExists(_)));
     }
 
@@ -820,7 +864,7 @@ previous_secrets = []
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
         fs::write(dir.join("Dockerfile"), "old content").unwrap();
-        init(&dir, "my-app", true, Target::Default).unwrap();
+        init(&dir, "my-app", true, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
         assert_ne!(
             content, "old content",
@@ -834,7 +878,7 @@ previous_secrets = []
     fn fly_target_creates_fly_toml() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Fly).unwrap();
+        init(&dir, "my-app", false, Target::Fly, false).unwrap();
         assert!(
             dir.join("fly.toml").is_file(),
             "fly.toml must be created for --target=fly"
@@ -845,7 +889,7 @@ previous_secrets = []
     fn fly_toml_references_dockerfile() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Fly).unwrap();
+        init(&dir, "my-app", false, Target::Fly, false).unwrap();
         let content = fs::read_to_string(dir.join("fly.toml")).unwrap();
         assert!(
             content.contains("Dockerfile"),
@@ -857,7 +901,7 @@ previous_secrets = []
     fn fly_toml_has_app_name() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-blog");
-        init(&dir, "my-blog", false, Target::Fly).unwrap();
+        init(&dir, "my-blog", false, Target::Fly, false).unwrap();
         let content = fs::read_to_string(dir.join("fly.toml")).unwrap();
         assert!(
             content.contains("my-blog"),
@@ -873,7 +917,7 @@ previous_secrets = []
     fn fly_toml_has_liveness_probe() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Fly).unwrap();
+        init(&dir, "my-app", false, Target::Fly, false).unwrap();
         let content = fs::read_to_string(dir.join("fly.toml")).unwrap();
         assert!(
             content.contains("path") && content.contains("/live"),
@@ -885,7 +929,7 @@ previous_secrets = []
     fn fly_toml_has_readiness_probe() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Fly).unwrap();
+        init(&dir, "my-app", false, Target::Fly, false).unwrap();
         let content = fs::read_to_string(dir.join("fly.toml")).unwrap();
         assert!(
             content.contains("path") && content.contains("/ready"),
@@ -898,7 +942,7 @@ previous_secrets = []
     fn fly_toml_has_kill_timeout() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Fly).unwrap();
+        init(&dir, "my-app", false, Target::Fly, false).unwrap();
         let content = fs::read_to_string(dir.join("fly.toml")).unwrap();
         assert!(
             content.contains("kill_timeout"),
@@ -915,7 +959,7 @@ previous_secrets = []
     fn fly_toml_has_metrics_endpoint() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Fly).unwrap();
+        init(&dir, "my-app", false, Target::Fly, false).unwrap();
         let content = fs::read_to_string(dir.join("fly.toml")).unwrap();
         assert!(
             content.contains("[metrics]"),
@@ -935,7 +979,7 @@ previous_secrets = []
         // The template documents the opt-in pattern so DB users can uncomment it.
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Fly).unwrap();
+        init(&dir, "my-app", false, Target::Fly, false).unwrap();
         let content = fs::read_to_string(dir.join("fly.toml")).unwrap();
         assert!(
             content.contains("autumn migrate"),
@@ -952,7 +996,7 @@ previous_secrets = []
     fn default_target_does_not_create_fly_toml() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         assert!(
             !dir.join("fly.toml").exists(),
             "fly.toml must NOT be created for the default target"
@@ -965,7 +1009,7 @@ previous_secrets = []
     fn docker_compose_target_creates_docker_compose_yml() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::DockerCompose).unwrap();
+        init(&dir, "my-app", false, Target::DockerCompose, false).unwrap();
         assert!(
             dir.join("docker-compose.yml").is_file(),
             "docker-compose.yml must be created for --target=docker-compose"
@@ -976,7 +1020,7 @@ previous_secrets = []
     fn docker_compose_has_app_service() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::DockerCompose).unwrap();
+        init(&dir, "my-app", false, Target::DockerCompose, false).unwrap();
         let content = fs::read_to_string(dir.join("docker-compose.yml")).unwrap();
         assert!(
             content.contains("app:"),
@@ -988,7 +1032,7 @@ previous_secrets = []
     fn docker_compose_has_postgres_service() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::DockerCompose).unwrap();
+        init(&dir, "my-app", false, Target::DockerCompose, false).unwrap();
         let content = fs::read_to_string(dir.join("docker-compose.yml")).unwrap();
         assert!(
             content.contains("postgres") || content.contains("db:"),
@@ -1000,7 +1044,7 @@ previous_secrets = []
     fn docker_compose_app_depends_on_db() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::DockerCompose).unwrap();
+        init(&dir, "my-app", false, Target::DockerCompose, false).unwrap();
         let content = fs::read_to_string(dir.join("docker-compose.yml")).unwrap();
         assert!(
             content.contains("depends_on"),
@@ -1012,7 +1056,7 @@ previous_secrets = []
     fn docker_compose_app_requires_signing_secret_env() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::DockerCompose).unwrap();
+        init(&dir, "my-app", false, Target::DockerCompose, false).unwrap();
         let content = fs::read_to_string(dir.join("docker-compose.yml")).unwrap();
 
         assert!(
@@ -1027,7 +1071,7 @@ previous_secrets = []
     fn docker_compose_runs_one_shot_migration_before_app() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::DockerCompose).unwrap();
+        init(&dir, "my-app", false, Target::DockerCompose, false).unwrap();
         let content = fs::read_to_string(dir.join("docker-compose.yml")).unwrap();
 
         assert!(
@@ -1048,7 +1092,7 @@ previous_secrets = []
     fn docker_compose_substitutes_project_name() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-blog");
-        init(&dir, "my-blog", false, Target::DockerCompose).unwrap();
+        init(&dir, "my-blog", false, Target::DockerCompose, false).unwrap();
         let content = fs::read_to_string(dir.join("docker-compose.yml")).unwrap();
         assert!(
             content.contains("my-blog"),
@@ -1064,10 +1108,98 @@ previous_secrets = []
     fn default_target_does_not_create_docker_compose() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         assert!(
             !dir.join("docker-compose.yml").exists(),
             "docker-compose.yml must NOT be created for the default target"
+        );
+    }
+
+    // ── --split-workers (opt-in split topology) ───────────────────────────────
+
+    #[test]
+    fn docker_compose_default_omits_worker_service() {
+        let tmp = TempDir::new().unwrap();
+        let dir = make_project(&tmp, "my-app");
+        init(&dir, "my-app", false, Target::DockerCompose, false).unwrap();
+        let content = fs::read_to_string(dir.join("docker-compose.yml")).unwrap();
+        assert!(
+            !content.contains("worker:"),
+            "default docker-compose.yml must NOT scaffold a worker service: {content}"
+        );
+        assert!(
+            !content.contains("AUTUMN_ROLE"),
+            "default (combined) docker-compose.yml must not pin a process role: {content}"
+        );
+        // No leftover template placeholders.
+        assert!(
+            !content.contains("{{"),
+            "docker-compose.yml must not contain unsubstituted placeholders: {content}"
+        );
+    }
+
+    #[test]
+    fn docker_compose_split_workers_emits_worker_service() {
+        let tmp = TempDir::new().unwrap();
+        let dir = make_project(&tmp, "my-app");
+        init(&dir, "my-app", false, Target::DockerCompose, true).unwrap();
+        let content = fs::read_to_string(dir.join("docker-compose.yml")).unwrap();
+
+        assert!(
+            content.contains("worker:"),
+            "--split-workers must scaffold a worker service: {content}"
+        );
+        // Worker runs the SAME image as the web/app service.
+        assert_eq!(
+            content.matches("build: .").count(),
+            3,
+            "app, worker, and migrate services must all build the same image: {content}"
+        );
+        assert!(
+            content.contains("AUTUMN_ROLE: worker"),
+            "worker service must run the worker role: {content}"
+        );
+        assert!(
+            content.contains("AUTUMN_ROLE: web"),
+            "app service must run the web role when split: {content}"
+        );
+        // Both tiers must use a durable jobs backend (not in-process `local`).
+        assert_eq!(
+            content.matches("AUTUMN_JOBS__BACKEND: postgres").count(),
+            2,
+            "both app and worker must share the durable postgres jobs backend: {content}"
+        );
+        // Worker shares the migration gate and signing secret.
+        assert!(
+            content.contains("condition: service_completed_successfully"),
+            "worker must wait for the one-shot migration job: {content}"
+        );
+        assert!(
+            content.contains(
+                r#"AUTUMN_SECURITY__SIGNING_SECRET: "${AUTUMN_SECURITY__SIGNING_SECRET:?set it first}""#
+            ),
+            "worker must pass the required signing secret like the app service: {content}"
+        );
+        // Placeholders (including the worker block's own project name) resolved.
+        assert!(
+            !content.contains("{{"),
+            "split docker-compose.yml must not contain unsubstituted placeholders: {content}"
+        );
+        assert!(
+            content.contains("my-app_prod"),
+            "worker DB URL must substitute the project name: {content}"
+        );
+    }
+
+    #[test]
+    fn split_workers_only_affects_docker_compose_output() {
+        // The split-topology flag is scoped to the compose file; the Dockerfile
+        // and other scaffolds are byte-for-byte identical regardless.
+        let default_dockerfile = render(templates::DOCKERFILE, "my-app", false, false);
+        let split_dockerfile = render(templates::DOCKERFILE, "my-app", false, true);
+        assert_eq!(
+            default_dockerfile, split_dockerfile,
+            "--split-workers must not change the Dockerfile"
         );
     }
 
@@ -1100,7 +1232,7 @@ previous_secrets = []
     fn production_config_disables_startup_migrations_by_default() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");
-        init(&dir, "my-app", false, Target::Default).unwrap();
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
         let content = fs::read_to_string(dir.join("autumn.production.toml.example")).unwrap();
         assert!(
             content.contains("auto_migrate_in_production = false"),

--- a/autumn-cli/src/serve.rs
+++ b/autumn-cli/src/serve.rs
@@ -1047,7 +1047,10 @@ fn write_mode_file(paths: &RuntimePaths, opts: &ServeOptions) {
     let mode = ModeFile {
         release: opts.release,
         profile: opts.profile.clone().or_else(env_profile),
-        role: opts.role.clone(),
+        // Persist the *effective* role: the explicit `--role`, else the
+        // `AUTUMN_ROLE` an env-selected daemon inherited, so a later bare
+        // `restart` recovers it instead of dropping back to combined.
+        role: effective_role_from(opts.role.clone(), std::env::var("AUTUMN_ROLE").ok()),
     };
     let Ok(toml) = toml::to_string(&mode) else {
         return;
@@ -1384,6 +1387,24 @@ fn env_profile() -> Option<String> {
                 .ok()
                 .filter(|s| !s.trim().is_empty())
         })
+}
+
+/// The effective process role to record for `restart` recovery: the explicit
+/// `--role` when set, else the `AUTUMN_ROLE` value the daemon selected via its
+/// environment (trimmed, blank treated as absent).
+///
+/// `AUTUMN_ROLE=worker autumn serve --daemon` picks the role through the env the
+/// child inherits, so `opts.role` is `None`; recording only `opts.role` would let
+/// a later bare `autumn serve restart` (from a shell without `AUTUMN_ROLE`)
+/// silently relaunch as the combined default. Separated from the env read so the
+/// precedence/normalization is unit-testable without mutating the process
+/// environment.
+fn effective_role_from(explicit: Option<String>, env_value: Option<String>) -> Option<String> {
+    explicit.or_else(|| {
+        env_value
+            .map(|v| v.trim().to_owned())
+            .filter(|v| !v.is_empty())
+    })
 }
 
 /// Resolve `(prestop_grace_secs, shutdown_timeout_secs)` with the app's layering
@@ -2093,5 +2114,35 @@ mod tests {
             Some("worker"),
             "restart must recover the persisted --role",
         );
+    }
+
+    #[test]
+    fn effective_role_prefers_flag_then_env() {
+        // `AUTUMN_ROLE=worker autumn serve --daemon` selects the role via the env
+        // the child inherits (so `opts.role` is None); write_mode_file records the
+        // effective role through this seam so a bare `serve restart` from a shell
+        // without `AUTUMN_ROLE` recovers it instead of relaunching as combined.
+        // The crate forbids `unsafe`, so this exercises the pure precedence/
+        // normalization core rather than mutating the real process environment.
+
+        // An explicit `--role` always wins over the environment.
+        assert_eq!(
+            effective_role_from(Some("web".to_owned()), Some("worker".to_owned())).as_deref(),
+            Some("web"),
+        );
+        // No flag: fall back to a non-blank `AUTUMN_ROLE`, trimmed — this is the
+        // env-selected-daemon case that `restart` must recover.
+        assert_eq!(
+            effective_role_from(None, Some("worker".to_owned())).as_deref(),
+            Some("worker"),
+        );
+        assert_eq!(
+            effective_role_from(None, Some("  worker  ".to_owned())).as_deref(),
+            Some("worker"),
+        );
+        // A blank or absent `AUTUMN_ROLE` leaves the role unset (combined default),
+        // so the CLI never records a bogus empty role.
+        assert_eq!(effective_role_from(None, Some("   ".to_owned())), None);
+        assert_eq!(effective_role_from(None, None), None);
     }
 }

--- a/autumn-cli/src/serve.rs
+++ b/autumn-cli/src/serve.rs
@@ -53,6 +53,10 @@ pub struct ServeOptions {
     /// restore the original daemon's profile when the restart shell doesn't have
     /// one.
     pub profile: Option<String>,
+    /// Process role forwarded to the app binary via `AUTUMN_ROLE` (`"web"`,
+    /// `"worker"`, or `"combined"`). `None` leaves the child to resolve its own
+    /// role from its environment/config (defaulting to combined).
+    pub role: Option<String>,
 }
 
 /// How long to wait for a freshly-spawned daemon to become reachable.
@@ -196,11 +200,21 @@ fn run_unix(action: Option<ServeAction>, opts: &ServeOptions) -> i32 {
                     |a| a.profile.clone(),
                 )
             });
+            // Preserve the original daemon's process role: an explicit `--role` on
+            // *this* restart wins, otherwise restore what the running daemon
+            // recorded. The role lives only in the `serve.mode` marker (not the
+            // address file), so a bare `restart` doesn't silently drop the daemon
+            // back to the combined default.
+            let keep_role = opts
+                .role
+                .clone()
+                .or_else(|| recorded_mode.as_ref().and_then(|m| m.role.clone()));
             let daemon_opts = ServeOptions {
                 daemon: true,
                 bundled_pg: keep_managed,
                 release: keep_release,
                 profile: keep_profile,
+                role: keep_role,
                 ..opts.clone()
             };
             // Stop using the *recovered* mode, not the bare restart flags: when
@@ -636,6 +650,12 @@ fn base_command(binary: &Path, paths: Option<&RuntimePaths>, opts: &ServeOptions
     {
         cmd.env(MANAGED_PG_DATA_DIR_ENV, paths.pg_data_dir());
     }
+    // Select the process role for the spawned app. A worker-role daemon still
+    // binds its socket/port for liveness probes, so the daemon plumbing above
+    // needs no special-casing — just forward the role the app reads at startup.
+    if let Some(role) = &opts.role {
+        cmd.env("AUTUMN_ROLE", role);
+    }
     // Restore an explicit profile (set by `restart`) so the relaunched daemon
     // loads the same config as the original even when the restart shell didn't
     // set `AUTUMN_ENV`.
@@ -1015,6 +1035,11 @@ struct ModeFile {
     /// The explicit profile (`AUTUMN_ENV`/`AUTUMN_PROFILE`) the daemon used.
     #[serde(default)]
     profile: Option<String>,
+    /// The process role (`AUTUMN_ROLE`) the daemon was started with, recorded so
+    /// `restart` can restore it. `None` when the daemon ran the default combined
+    /// role (or for mode files written before this field existed).
+    #[serde(default)]
+    role: Option<String>,
 }
 
 /// Write the `serve.mode` marker (`0600`). Best-effort.
@@ -1022,6 +1047,7 @@ fn write_mode_file(paths: &RuntimePaths, opts: &ServeOptions) {
     let mode = ModeFile {
         release: opts.release,
         profile: opts.profile.clone().or_else(env_profile),
+        role: opts.role.clone(),
     };
     let Ok(toml) = toml::to_string(&mode) else {
         return;
@@ -1987,5 +2013,85 @@ mod tests {
         // Non-numeric content is ignored rather than misread.
         std::fs::write(paths.ready_file(), "not-a-number").expect("write ready");
         assert_eq!(child_reported_budget(&paths), None);
+    }
+
+    fn serve_opts_with_role(role: Option<&str>) -> ServeOptions {
+        ServeOptions {
+            package: None,
+            daemon: false,
+            release: false,
+            bundled_pg: false,
+            profile: None,
+            role: role.map(str::to_owned),
+        }
+    }
+
+    /// Look up the value the command would set for `key`, if any. `get_envs`
+    /// yields `(key, Some(value))` for sets and `(key, None)` for removals.
+    fn env_value(cmd: &Command, key: &str) -> Option<String> {
+        cmd.get_envs().find_map(|(k, v)| {
+            (k == std::ffi::OsStr::new(key))
+                .then(|| v.map(|v| v.to_string_lossy().into_owned()))
+                .flatten()
+        })
+    }
+
+    #[test]
+    fn base_command_forwards_role_env() {
+        for role in ["web", "worker", "combined"] {
+            let opts = serve_opts_with_role(Some(role));
+            let cmd = base_command(Path::new("/bin/true"), None, &opts);
+            assert_eq!(
+                env_value(&cmd, "AUTUMN_ROLE").as_deref(),
+                Some(role),
+                "serve --role {role} must forward AUTUMN_ROLE={role} to the app binary",
+            );
+        }
+    }
+
+    #[test]
+    fn base_command_omits_role_env_by_default() {
+        let opts = serve_opts_with_role(None);
+        let cmd = base_command(Path::new("/bin/true"), None, &opts);
+        // With no explicit role the CLI must not set AUTUMN_ROLE, so the child
+        // resolves its own role from its environment/config (combined default).
+        assert!(
+            cmd.get_envs()
+                .all(|(k, _)| k != std::ffi::OsStr::new("AUTUMN_ROLE")),
+            "no --role must leave AUTUMN_ROLE unset for the app binary",
+        );
+    }
+
+    #[test]
+    fn mode_file_role_defaults_none_for_legacy_files() {
+        // Mode files written before the `role` field omit it; parsing must not
+        // fail and must default to None (the daemon ran the combined role).
+        let legacy = "release = true\nprofile = \"prod\"\n";
+        let parsed: ModeFile = toml::from_str(legacy).expect("parse legacy mode file");
+        assert_eq!(parsed.role, None);
+        assert!(parsed.release);
+        assert_eq!(parsed.profile.as_deref(), Some("prod"));
+    }
+
+    #[test]
+    fn write_mode_file_persists_role_for_restart_recovery() {
+        // A `serve --role worker` start must persist the role into `serve.mode`
+        // so a bare `serve restart` can recover it (mirroring the profile path)
+        // instead of silently dropping back to the combined default.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let paths = RuntimePaths::from_base(dir.path(), "p");
+        paths.ensure_dirs().expect("dirs");
+        let opts = serve_opts_with_role(Some("worker"));
+        write_mode_file(&paths, &opts);
+
+        // Recover exactly as `restart`'s `running_daemon_mode` would: read and
+        // parse the marker, then take its role.
+        let contents = std::fs::read_to_string(paths.mode_file()).expect("read mode file");
+        let recovered: ModeFile = toml::from_str(&contents).expect("parse mode file");
+        assert_eq!(
+            recovered.role.as_deref(),
+            Some("worker"),
+            "restart must recover the persisted --role",
+        );
     }
 }

--- a/autumn-cli/src/templates/release/docker-compose.yml.tmpl
+++ b/autumn-cli/src/templates/release/docker-compose.yml.tmpl
@@ -9,14 +9,14 @@ services:
     environment:
       AUTUMN_PROFILE: prod
       AUTUMN_DATABASE__PRIMARY_URL: postgres://autumn:autumn@db:5432/{{project_name}}_prod
-      AUTUMN_SECURITY__SIGNING_SECRET: "${AUTUMN_SECURITY__SIGNING_SECRET:?set it first}"
+      AUTUMN_SECURITY__SIGNING_SECRET: "${AUTUMN_SECURITY__SIGNING_SECRET:?set it first}"{{app_role_env}}
     depends_on:
       db:
         condition: service_healthy
       migrate:
         condition: service_completed_successfully
     restart: unless-stopped
-
+{{worker_service}}
   migrate:
     build: .
     command: ["sh", "-lc", "autumn migrate"]

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -3843,6 +3843,7 @@ mod tests {
             &runtime_state,
             &shutdown,
             &crate::config::JobConfig::default(),
+            true,
         )
         .expect("job runtime should start");
 
@@ -3919,6 +3920,7 @@ mod tests {
             &runtime_state,
             &shutdown,
             &crate::config::JobConfig::default(),
+            true,
         )
         .expect("job runtime should start");
 

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2652,20 +2652,25 @@ impl AppBuilder {
             load_config_and_telemetry(config_loader_factory, telemetry_provider).await;
 
         // Process role selects which slice of the runtime this replica runs. A
-        // split role (web/worker) on the in-process `local` jobs backend cannot
-        // work: the web replica would enqueue into an in-memory queue no worker
-        // can drain, and a worker replica's in-memory queue starts empty. Reject
-        // it here — before any boot work — rather than in `validate()` so the
-        // doctor can still load the config. Combined role is always fine.
+        // split role (web/worker) requires a durable jobs backend the separate
+        // HTTP and worker processes can share. Any backend that isn't a
+        // recognized durable one (`postgres`/`redis`) — the in-process `local`
+        // queue, a typo, or a blank value — falls through to the per-process
+        // local runtime: the web replica would enqueue into an in-memory queue no
+        // worker can drain, and a worker replica's queue starts empty. Reject it
+        // here — before any boot work — rather than in `validate()` so the doctor
+        // can still load the config. Combined role is always fine.
         let role = config.role;
-        if crate::config::split_role_on_local_backend(role, &config.jobs.backend) {
+        if crate::config::split_role_requires_durable_backend(role, &config.jobs.backend) {
             tracing::error!(
                 role = role.as_str(),
                 jobs_backend = %config.jobs.backend,
-                "process role '{}' requires a durable jobs backend: the in-process \
-                 'local' backend cannot be shared across a split web/worker topology. \
+                "process role '{}' requires a durable jobs backend: backend '{}' is not \
+                 a recognized durable backend and falls through to the in-process 'local' \
+                 runtime, which cannot be shared across a split web/worker topology. \
                  Set jobs.backend = \"postgres\" or \"redis\", or run the combined role.",
                 role.as_str(),
+                config.jobs.backend,
             );
             #[cfg(feature = "managed-pg")]
             crate::managed_pg::emergency_stop_async().await;
@@ -3329,8 +3334,14 @@ impl AppBuilder {
             crate::repository_commit_hooks::set_global_channels(state.channels().clone());
         }
 
+        // Draining durable after-commit hook rows is background execution, so gate
+        // it on the process role exactly like the `#[job]` runtime above: a `web`
+        // replica must not claim/execute hook rows (that work belongs to the
+        // worker tier), while `worker`/`combined` replicas keep running it.
         #[cfg(feature = "db")]
-        if let Some(pool) = state.pool().cloned() {
+        if role.runs_workers()
+            && let Some(pool) = state.pool().cloned()
+        {
             #[cfg(feature = "ws")]
             {
                 let channels = state.channels().clone();
@@ -3347,9 +3358,13 @@ impl AppBuilder {
             );
         }
         // Repositories built over a shard pool (`with_pool`) enqueue durable
-        // commit hooks into that shard's queue table; drain each one too.
+        // commit hooks into that shard's queue table; drain each one too — again
+        // only on a role that runs workers, so a web replica leaves shard hook
+        // rows for the worker tier.
         #[cfg(feature = "db")]
-        if let Some(shards) = state.shards() {
+        if role.runs_workers()
+            && let Some(shards) = state.shards()
+        {
             for shard in shards.iter() {
                 #[cfg(feature = "ws")]
                 crate::repository_commit_hooks::start_repository_commit_hook_worker(
@@ -8039,6 +8054,27 @@ mod tests {
                     .find(task_worker)
                     .expect("task runner path should start repository hook worker"),
             "task runner startup must initialize jobs before repository commit hooks can enqueue them"
+        );
+    }
+
+    #[cfg(feature = "db")]
+    #[test]
+    fn repository_commit_hook_workers_are_gated_on_worker_role() {
+        // Draining durable after-commit hook rows is background execution, so the
+        // primary-pool and shard commit-hook worker starts on the normal server
+        // path must both be guarded by `role.runs_workers()` — a web-role replica
+        // must not claim/execute hook rows (that work belongs to the worker tier).
+        let source = include_str!("app.rs").replace("\r\n", "\n");
+        let primary_gate =
+            "if role.runs_workers()\n            && let Some(pool) = state.pool().cloned()";
+        let shard_gate = "if role.runs_workers()\n            && let Some(shards) = state.shards()";
+        assert!(
+            source.contains(primary_gate),
+            "primary-pool commit-hook worker must be gated on role.runs_workers()"
+        );
+        assert!(
+            source.contains(shard_gate),
+            "shard commit-hook workers must be gated on role.runs_workers()"
         );
     }
 

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2651,6 +2651,27 @@ impl AppBuilder {
         let (mut config, telemetry_guard) =
             load_config_and_telemetry(config_loader_factory, telemetry_provider).await;
 
+        // Process role selects which slice of the runtime this replica runs. A
+        // split role (web/worker) on the in-process `local` jobs backend cannot
+        // work: the web replica would enqueue into an in-memory queue no worker
+        // can drain, and a worker replica's in-memory queue starts empty. Reject
+        // it here — before any boot work — rather than in `validate()` so the
+        // doctor can still load the config. Combined role is always fine.
+        let role = config.role;
+        if crate::config::split_role_on_local_backend(role, &config.jobs.backend) {
+            tracing::error!(
+                role = role.as_str(),
+                jobs_backend = %config.jobs.backend,
+                "process role '{}' requires a durable jobs backend: the in-process \
+                 'local' backend cannot be shared across a split web/worker topology. \
+                 Set jobs.backend = \"postgres\" or \"redis\", or run the combined role.",
+                role.as_str(),
+            );
+            #[cfg(feature = "managed-pg")]
+            crate::managed_pg::emergency_stop_async().await;
+            std::process::exit(1);
+        }
+
         #[cfg(feature = "mail")]
         if mount_unsubscribe_endpoint {
             config.mail.mount_unsubscribe_endpoint = true;
@@ -3130,34 +3151,44 @@ impl AppBuilder {
                 merge_routers.push(axum_router);
             }
         }
-        let router = crate::router::try_build_router_with_static_inner(
-            all_routes,
-            &config,
-            state.clone(),
-            dist_ref,
-            crate::router::RouterContext {
-                exception_filters,
-                scoped_groups,
-                merge_routers,
-                nest_routers,
-                custom_layers,
-                static_gate_layers,
-                #[cfg(feature = "maud")]
-                error_page_renderer,
-                session_store,
-                // Respect the [openapi] profile gate: if disabled in config,
-                // suppress the endpoint even when .openapi(...) was called.
-                #[cfg(feature = "openapi")]
-                openapi: if config.openapi_runtime.enabled {
-                    openapi
-                } else {
-                    None
+        // Worker role does not serve user routes: build a probe-only router that
+        // exposes just the framework liveness/readiness probes and the actuator,
+        // so orchestrators can supervise the process and `/actuator/jobs` works.
+        // Web and combined roles build the full application router. All the
+        // route/router-context inputs assembled above are simply dropped in the
+        // worker branch.
+        let router_build = if role.serves_http() {
+            crate::router::try_build_router_with_static_inner(
+                all_routes,
+                &config,
+                state.clone(),
+                dist_ref,
+                crate::router::RouterContext {
+                    exception_filters,
+                    scoped_groups,
+                    merge_routers,
+                    nest_routers,
+                    custom_layers,
+                    static_gate_layers,
+                    #[cfg(feature = "maud")]
+                    error_page_renderer,
+                    session_store,
+                    // Respect the [openapi] profile gate: if disabled in config,
+                    // suppress the endpoint even when .openapi(...) was called.
+                    #[cfg(feature = "openapi")]
+                    openapi: if config.openapi_runtime.enabled {
+                        openapi
+                    } else {
+                        None
+                    },
+                    #[cfg(feature = "mcp")]
+                    mcp,
                 },
-                #[cfg(feature = "mcp")]
-                mcp,
-            },
-        )
-        .unwrap_or_else(|error| {
+            )
+        } else {
+            crate::router::try_build_probe_only_router(&config, state.clone())
+        };
+        let router = router_build.unwrap_or_else(|error| {
             tracing::error!(error = %error, "Failed to build router");
             exit_stop_managed_pg();
             std::process::exit(1);
@@ -3277,7 +3308,13 @@ impl AppBuilder {
         let prestop_grace = config.server.prestop_grace_secs;
         let server_shutdown = tokio_util::sync::CancellationToken::new();
 
-        if let Err(error) = initialize_job_runtime(jobs, &state, &server_shutdown, &config.jobs) {
+        if let Err(error) = initialize_job_runtime(
+            jobs,
+            &state,
+            &server_shutdown,
+            &config.jobs,
+            role.runs_workers(),
+        ) {
             tracing::error!(error = %error, "job runtime initialization failed");
             // Post-DB failure: `process::exit` skips `on_shutdown`, so stop any
             // managed Postgres before bailing.
@@ -3542,7 +3579,10 @@ impl AppBuilder {
         }
 
         if !state.probes().is_shutting_down() {
-            if !tasks.is_empty() {
+            // Web role runs no cron scheduler (workers/combined only). Skipping
+            // the scheduler must not regress readiness: mark_startup_complete and
+            // signal_serve_ready below still run.
+            if role.runs_workers() && !tasks.is_empty() {
                 let res = start_task_scheduler_with_config(
                     tasks,
                     &state,
@@ -4476,7 +4516,8 @@ impl AppBuilder {
         finalize_event_bus(listeners, &mut jobs, &state);
 
         let task_shutdown = tokio_util::sync::CancellationToken::new();
-        if let Err(error) = initialize_job_runtime(jobs, &state, &task_shutdown, &config.jobs) {
+        if let Err(error) = initialize_job_runtime(jobs, &state, &task_shutdown, &config.jobs, true)
+        {
             eprintln!("job runtime initialization failed: {error}");
             #[cfg(feature = "managed-pg")]
             crate::managed_pg::emergency_stop_async().await;
@@ -5205,12 +5246,13 @@ fn initialize_job_runtime(
     state: &AppState,
     shutdown: &tokio_util::sync::CancellationToken,
     config: &crate::config::JobConfig,
+    run_workers: bool,
 ) -> crate::AutumnResult<()> {
     crate::job::clear_global_job_client();
     if jobs.is_empty() {
         Ok(())
     } else {
-        crate::job::start_runtime(jobs, state, shutdown, config)
+        crate::job::start_runtime(jobs, state, shutdown, config, run_workers)
     }
 }
 
@@ -7972,9 +8014,12 @@ mod tests {
     #[test]
     fn repository_commit_hook_worker_starts_after_job_runtime_initialization() {
         let source = include_str!("app.rs").replace("\r\n", "\n");
-        let server_init = "initialize_job_runtime(jobs, &state, &server_shutdown, &config.jobs)";
+        let server_init = "initialize_job_runtime(
+            jobs,
+            &state,
+            &server_shutdown,";
         let server_worker = "start_repository_commit_hook_worker(\n                pool,\n                server_shutdown.child_token(),\n            );";
-        let task_init = "initialize_job_runtime(jobs, &state, &task_shutdown, &config.jobs)";
+        let task_init = "initialize_job_runtime(jobs, &state, &task_shutdown, &config.jobs, true)";
         let task_worker = "start_repository_commit_hook_worker(\n                pool,\n                task_shutdown.child_token(),\n            );";
 
         assert!(
@@ -8011,8 +8056,11 @@ mod tests {
             .expect("task runner path should exist");
         let server_source = &source[server_start..build_mode_start];
         let task_source = &source[task_start..];
-        let server_init = "initialize_job_runtime(jobs, &state, &server_shutdown, &config.jobs)";
-        let task_init = "initialize_job_runtime(jobs, &state, &task_shutdown, &config.jobs)";
+        let server_init = "initialize_job_runtime(
+            jobs,
+            &state,
+            &server_shutdown,";
+        let task_init = "initialize_job_runtime(jobs, &state, &task_shutdown, &config.jobs, true)";
         let server_initializer = server_source
             .find("run_state_initializers(state_initializers, &state);")
             .expect("normal server path should run state initializers");
@@ -8755,6 +8803,7 @@ mod tests {
             &state,
             &shutdown,
             &crate::config::JobConfig::default(),
+            true,
         )
         .expect("job runtime should initialize before startup hooks");
 
@@ -8807,6 +8856,7 @@ mod tests {
             &state,
             &shutdown,
             &config,
+            true,
         )
         .expect_err("redis init errors should abort startup");
 

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -1660,16 +1660,24 @@ impl ProcessRole {
 }
 
 /// Whether a `role` / `jobs.backend` combination is invalid because a split
-/// role sits on the in-process `local` jobs backend.
+/// (web/worker) role sits on a non-durable jobs backend.
 ///
-/// The `local` backend is a per-process, in-memory queue: a [`Web`](ProcessRole::Web)
-/// replica would enqueue into a queue no separate worker can drain, and a
-/// [`Worker`](ProcessRole::Worker) replica's in-memory queue starts empty. Split
-/// topologies therefore require a durable backend (`postgres` or `redis`). The
-/// combined role is always fine because it enqueues and drains in one process.
+/// A split role runs the HTTP tier and the job/scheduler tier in **separate
+/// processes**, so it needs a jobs backend the two processes can share. Only the
+/// recognized durable backends [`start_runtime`](crate::job::start_runtime)
+/// dispatches to durably — exactly `"postgres"` or `"redis"` — qualify. Every
+/// other value (the in-process `"local"` queue, a typo like `"postgresql"`, or a
+/// blank backend) falls through to the per-process local runtime, where a
+/// [`Web`](ProcessRole::Web) replica would enqueue into a queue no separate
+/// worker can drain and a [`Worker`](ProcessRole::Worker) replica's queue starts
+/// empty. The match is intentionally exact (no trim/case-fold) so this guard and
+/// `start_runtime`'s dispatch agree precisely on which backends are durable.
+///
+/// The combined role is always valid because it enqueues and drains in one
+/// process. Returns `true` when the combination is **invalid**.
 #[must_use]
-pub fn split_role_on_local_backend(role: ProcessRole, jobs_backend: &str) -> bool {
-    role != ProcessRole::Combined && jobs_backend.trim().eq_ignore_ascii_case("local")
+pub fn split_role_requires_durable_backend(role: ProcessRole, jobs_backend: &str) -> bool {
+    role != ProcessRole::Combined && !matches!(jobs_backend, "postgres" | "redis")
 }
 
 /// Scheduled task coordination runtime configuration.
@@ -9932,20 +9940,52 @@ redirect_uri = "http://localhost:3000/auth/github/callback"
     }
 
     #[test]
-    fn split_role_on_local_backend_truth_table() {
-        // Combined is always fine (enqueues and drains in one process).
-        assert!(!split_role_on_local_backend(ProcessRole::Combined, "local"));
-        assert!(!split_role_on_local_backend(
+    fn split_role_requires_durable_backend_truth_table() {
+        // Combined is always fine (enqueues and drains in one process), even on
+        // the in-process local backend.
+        assert!(!split_role_requires_durable_backend(
+            ProcessRole::Combined,
+            "local"
+        ));
+        assert!(!split_role_requires_durable_backend(
             ProcessRole::Combined,
             "postgres"
         ));
-        // Split roles on the in-process local backend are invalid.
-        assert!(split_role_on_local_backend(ProcessRole::Web, "local"));
-        assert!(split_role_on_local_backend(ProcessRole::Worker, "local"));
-        assert!(split_role_on_local_backend(ProcessRole::Web, "LOCAL"));
-        // Split roles on durable backends are fine.
-        assert!(!split_role_on_local_backend(ProcessRole::Web, "postgres"));
-        assert!(!split_role_on_local_backend(ProcessRole::Worker, "redis"));
+        // Split roles on any backend that falls through to the per-process local
+        // runtime are invalid: the literal `local`, a typo like `postgresql`, a
+        // blank backend, or any other unknown value.
+        assert!(split_role_requires_durable_backend(
+            ProcessRole::Web,
+            "local"
+        ));
+        assert!(split_role_requires_durable_backend(
+            ProcessRole::Worker,
+            "local"
+        ));
+        assert!(split_role_requires_durable_backend(
+            ProcessRole::Web,
+            "postgresql"
+        ));
+        assert!(split_role_requires_durable_backend(ProcessRole::Web, ""));
+        assert!(split_role_requires_durable_backend(
+            ProcessRole::Web,
+            "unknown"
+        ));
+        // The match is exact (mirroring `start_runtime`'s dispatch), so a
+        // case-variant like `LOCAL` is likewise a non-durable fall-through.
+        assert!(split_role_requires_durable_backend(
+            ProcessRole::Web,
+            "LOCAL"
+        ));
+        // Split roles on the recognized durable backends are fine.
+        assert!(!split_role_requires_durable_backend(
+            ProcessRole::Web,
+            "postgres"
+        ));
+        assert!(!split_role_requires_durable_backend(
+            ProcessRole::Worker,
+            "redis"
+        ));
     }
 
     #[test]

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -926,6 +926,13 @@ pub struct AutumnConfig {
     #[serde(default)]
     pub scheduler: SchedulerConfig,
 
+    /// Process role: which slice of the runtime this replica runs (web tier,
+    /// worker tier, or both). Defaults to [`ProcessRole::Combined`] so existing
+    /// single-process deployments are unaffected. Also settable via the flat
+    /// `AUTUMN_ROLE` env var.
+    #[serde(default)]
+    pub role: ProcessRole,
+
     /// Authentication settings.
     #[serde(default)]
     pub auth: crate::auth::AuthConfig,
@@ -1572,6 +1579,97 @@ impl SchedulerBackend {
             _ => None,
         }
     }
+}
+
+/// Process role: which slice of the framework runtime this replica runs.
+///
+/// The same binary can be deployed under different roles so a fleet can scale
+/// its HTTP tier independently of its background-work tier. The role is chosen
+/// by config (`role = "..."`) or the `AUTUMN_ROLE` env var only — application
+/// code never changes. The default, [`Combined`](ProcessRole::Combined),
+/// preserves today's single-process behavior exactly.
+///
+/// - [`Combined`](ProcessRole::Combined): serves HTTP **and** runs job workers
+///   + the cron scheduler (default).
+/// - [`Web`](ProcessRole::Web): serves HTTP and can still **enqueue** jobs, but
+///   runs no `#[job]` worker loops and no `#[scheduled]`/cron scheduler.
+/// - [`Worker`](ProcessRole::Worker): runs job workers + the cron scheduler and
+///   does **not** serve user routes, but still binds the HTTP listener to serve
+///   only the liveness/readiness probes and the actuator (so orchestrators can
+///   supervise it and `/actuator/jobs` works).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ProcessRole {
+    /// Serve HTTP and run background workers + scheduler (default; unchanged
+    /// single-process behavior).
+    #[serde(
+        alias = "all",
+        alias = "combined",
+        alias = "web_and_worker",
+        alias = "server_and_worker"
+    )]
+    #[default]
+    Combined,
+    /// Serve HTTP (and enqueue jobs) only — no worker loops, no scheduler.
+    #[serde(alias = "server", alias = "http")]
+    Web,
+    /// Run workers + scheduler only — probe/actuator HTTP only, no user routes.
+    #[serde(alias = "jobs", alias = "worker_only")]
+    Worker,
+}
+
+impl ProcessRole {
+    /// Parse an environment variable / flag value for process-role selection.
+    ///
+    /// Accepts (case-insensitive, trimmed): `combined`/`all`, `web`/`server`/
+    /// `http`, `worker`/`jobs`. Returns `None` for anything else so callers can
+    /// warn and keep the default.
+    #[must_use]
+    pub fn from_env_value(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "combined" | "all" | "web_and_worker" | "server_and_worker" => Some(Self::Combined),
+            "web" | "server" | "http" => Some(Self::Web),
+            "worker" | "jobs" | "worker_only" => Some(Self::Worker),
+            _ => None,
+        }
+    }
+
+    /// Stable lowercase identifier for the role (round-trips `from_env_value`).
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Combined => "combined",
+            Self::Web => "web",
+            Self::Worker => "worker",
+        }
+    }
+
+    /// Whether this role serves user HTTP routes ([`Combined`](Self::Combined)
+    /// or [`Web`](Self::Web)).
+    #[must_use]
+    pub const fn serves_http(self) -> bool {
+        matches!(self, Self::Combined | Self::Web)
+    }
+
+    /// Whether this role runs background job workers and the cron scheduler
+    /// ([`Combined`](Self::Combined) or [`Worker`](Self::Worker)).
+    #[must_use]
+    pub const fn runs_workers(self) -> bool {
+        matches!(self, Self::Combined | Self::Worker)
+    }
+}
+
+/// Whether a `role` / `jobs.backend` combination is invalid because a split
+/// role sits on the in-process `local` jobs backend.
+///
+/// The `local` backend is a per-process, in-memory queue: a [`Web`](ProcessRole::Web)
+/// replica would enqueue into a queue no separate worker can drain, and a
+/// [`Worker`](ProcessRole::Worker) replica's in-memory queue starts empty. Split
+/// topologies therefore require a durable backend (`postgres` or `redis`). The
+/// combined role is always fine because it enqueues and drains in one process.
+#[must_use]
+pub fn split_role_on_local_backend(role: ProcessRole, jobs_backend: &str) -> bool {
+    role != ProcessRole::Combined && jobs_backend.trim().eq_ignore_ascii_case("local")
 }
 
 /// Scheduled task coordination runtime configuration.
@@ -2663,6 +2761,7 @@ impl AutumnConfig {
         self.apply_channels_env_overrides_with_env(env);
         self.apply_jobs_env_overrides_with_env(env);
         self.apply_scheduler_env_overrides_with_env(env);
+        self.apply_role_env_overrides_with_env(env);
         self.apply_auth_env_overrides_with_env(env);
         self.apply_security_env_overrides_with_env(env);
         self.apply_bot_protection_env_overrides_with_env(env);
@@ -3194,6 +3293,18 @@ impl AutumnConfig {
             "AUTUMN_JOBS__TRACKING__ROUTE_ENABLED",
             &mut self.jobs.tracking.route_enabled,
         );
+    }
+
+    fn apply_role_env_overrides_with_env(&mut self, env: &dyn Env) {
+        if let Ok(val) = env.var("AUTUMN_ROLE") {
+            match ProcessRole::from_env_value(&val) {
+                Some(role) => self.role = role,
+                None => eprintln!(
+                    "Warning: AUTUMN_ROLE={val:?} is not valid \
+                     (expected combined, web, or worker), ignoring"
+                ),
+            }
+        }
     }
 
     fn apply_scheduler_env_overrides_with_env(&mut self, env: &dyn Env) {
@@ -9742,5 +9853,129 @@ redirect_uri = "http://localhost:3000/auth/github/callback"
             "message must name computed shards: {err}"
         );
         assert!(err.contains("s0"), "message must name stored shards: {err}");
+    }
+
+    // ── Process role (#1613) ────────────────────────────────────────────────
+
+    #[test]
+    fn process_role_default_is_combined() {
+        assert_eq!(ProcessRole::default(), ProcessRole::Combined);
+        assert_eq!(AutumnConfig::default().role, ProcessRole::Combined);
+    }
+
+    #[test]
+    fn process_role_from_env_value_accepts_aliases_case_insensitively() {
+        for v in [
+            "combined",
+            "COMBINED",
+            "  all ",
+            "web_and_worker",
+            "server_and_worker",
+        ] {
+            assert_eq!(
+                ProcessRole::from_env_value(v),
+                Some(ProcessRole::Combined),
+                "{v}"
+            );
+        }
+        for v in ["web", "Web", " SERVER ", "http"] {
+            assert_eq!(
+                ProcessRole::from_env_value(v),
+                Some(ProcessRole::Web),
+                "{v}"
+            );
+        }
+        for v in ["worker", "WORKER", " jobs ", "worker_only"] {
+            assert_eq!(
+                ProcessRole::from_env_value(v),
+                Some(ProcessRole::Worker),
+                "{v}"
+            );
+        }
+        for v in ["", "webby", "workers", "scheduler", "both"] {
+            assert_eq!(ProcessRole::from_env_value(v), None, "{v}");
+        }
+    }
+
+    #[test]
+    fn process_role_as_str_round_trips_through_from_env_value() {
+        for role in [ProcessRole::Combined, ProcessRole::Web, ProcessRole::Worker] {
+            assert_eq!(ProcessRole::from_env_value(role.as_str()), Some(role));
+        }
+    }
+
+    #[test]
+    fn process_role_serves_http_and_runs_workers_truth_table() {
+        assert!(ProcessRole::Combined.serves_http());
+        assert!(ProcessRole::Combined.runs_workers());
+        assert!(ProcessRole::Web.serves_http());
+        assert!(!ProcessRole::Web.runs_workers());
+        assert!(!ProcessRole::Worker.serves_http());
+        assert!(ProcessRole::Worker.runs_workers());
+    }
+
+    #[test]
+    fn process_role_deserializes_from_toml() {
+        let web: AutumnConfig = toml::from_str("role = \"web\"\n").expect("web role");
+        assert_eq!(web.role, ProcessRole::Web);
+        let worker: AutumnConfig = toml::from_str("role = \"worker\"\n").expect("worker role");
+        assert_eq!(worker.role, ProcessRole::Worker);
+        let combined: AutumnConfig =
+            toml::from_str("role = \"combined\"\n").expect("combined role");
+        assert_eq!(combined.role, ProcessRole::Combined);
+        // Serde alias also works.
+        let aliased: AutumnConfig = toml::from_str("role = \"all\"\n").expect("all alias");
+        assert_eq!(aliased.role, ProcessRole::Combined);
+        // Absent → default.
+        let absent: AutumnConfig = toml::from_str("").expect("empty config");
+        assert_eq!(absent.role, ProcessRole::Combined);
+    }
+
+    #[test]
+    fn split_role_on_local_backend_truth_table() {
+        // Combined is always fine (enqueues and drains in one process).
+        assert!(!split_role_on_local_backend(ProcessRole::Combined, "local"));
+        assert!(!split_role_on_local_backend(
+            ProcessRole::Combined,
+            "postgres"
+        ));
+        // Split roles on the in-process local backend are invalid.
+        assert!(split_role_on_local_backend(ProcessRole::Web, "local"));
+        assert!(split_role_on_local_backend(ProcessRole::Worker, "local"));
+        assert!(split_role_on_local_backend(ProcessRole::Web, "LOCAL"));
+        // Split roles on durable backends are fine.
+        assert!(!split_role_on_local_backend(ProcessRole::Web, "postgres"));
+        assert!(!split_role_on_local_backend(ProcessRole::Worker, "redis"));
+    }
+
+    #[test]
+    fn autumn_role_env_override_sets_role() {
+        let env = MockEnv::new().with("AUTUMN_ROLE", "worker");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert_eq!(config.role, ProcessRole::Worker);
+
+        let env = MockEnv::new().with("AUTUMN_ROLE", "  WEB ");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert_eq!(config.role, ProcessRole::Web);
+    }
+
+    #[test]
+    fn autumn_role_env_override_ignores_invalid_value_keeping_default() {
+        let env = MockEnv::new().with("AUTUMN_ROLE", "nonsense");
+        // Start from a non-default to prove invalid values do not reset it and
+        // do not force it either — they leave the current value untouched.
+        let mut config = AutumnConfig {
+            role: ProcessRole::Worker,
+            ..Default::default()
+        };
+        config.apply_env_overrides_with_env(&env);
+        assert_eq!(config.role, ProcessRole::Worker);
+
+        // And from the default, an invalid value keeps Combined.
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert_eq!(config.role, ProcessRole::Combined);
     }
 }

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -2912,6 +2912,7 @@ pub fn start_runtime(
     state: &AppState,
     shutdown: &tokio_util::sync::CancellationToken,
     config: &crate::config::JobConfig,
+    run_workers: bool,
 ) -> AutumnResult<()> {
     validate_unique_job_names(&jobs).map_err(|error| {
         AutumnError::internal_server_error(std::io::Error::other(format!(
@@ -2923,7 +2924,7 @@ pub fn start_runtime(
 
     match config.backend.as_str() {
         "local" => {
-            start_local_runtime(
+            start_local_runtime_inner(
                 jobs,
                 state,
                 shutdown,
@@ -2931,17 +2932,18 @@ pub fn start_runtime(
                 config.max_attempts,
                 config.initial_backoff_ms,
                 &config.queues,
+                run_workers,
             );
             Ok(())
         }
         "postgres" => {
             #[cfg(feature = "db")]
             {
-                start_postgres_runtime(jobs, state, shutdown, config)
+                start_postgres_runtime(jobs, state, shutdown, config, run_workers)
             }
             #[cfg(not(feature = "db"))]
             {
-                let _ = (jobs, state, shutdown, config);
+                let _ = (jobs, state, shutdown, config, run_workers);
                 Err(AutumnError::internal_server_error(std::io::Error::other(
                     "jobs.backend=postgres requested but db feature is disabled",
                 )))
@@ -2950,7 +2952,7 @@ pub fn start_runtime(
         "redis" => {
             #[cfg(feature = "redis")]
             {
-                start_redis_runtime(jobs, state, shutdown, config)
+                start_redis_runtime(jobs, state, shutdown, config, run_workers)
             }
             #[cfg(not(feature = "redis"))]
             {
@@ -2958,6 +2960,7 @@ pub fn start_runtime(
                 let _ = state;
                 let _ = shutdown;
                 let _ = config;
+                let _ = run_workers;
                 Err(AutumnError::internal_server_error(std::io::Error::other(
                     "jobs.backend=redis requested but redis feature is disabled",
                 )))
@@ -2965,7 +2968,7 @@ pub fn start_runtime(
         }
         other => {
             tracing::warn!(backend = %other, "unknown jobs backend; falling back to local backend");
-            start_local_runtime(
+            start_local_runtime_inner(
                 jobs,
                 state,
                 shutdown,
@@ -2973,6 +2976,7 @@ pub fn start_runtime(
                 config.max_attempts,
                 config.initial_backoff_ms,
                 &config.queues,
+                run_workers,
             );
             Ok(())
         }
@@ -3109,6 +3113,10 @@ impl LocalJobCoordination {
     }
 }
 
+/// Combined/worker-role local startup used by the in-crate test suites, which
+/// always run workers. The role-aware [`start_local_runtime_inner`] carries the
+/// `run_workers` gate for the production dispatch.
+#[cfg(test)]
 pub(crate) fn start_local_runtime(
     jobs: Vec<JobInfo>,
     state: &AppState,
@@ -3117,6 +3125,36 @@ pub(crate) fn start_local_runtime(
     default_max_attempts: u32,
     default_initial_backoff_ms: u64,
     queues_config: &crate::config::JobQueuesConfig,
+) {
+    start_local_runtime_inner(
+        jobs,
+        state,
+        shutdown,
+        workers,
+        default_max_attempts,
+        default_initial_backoff_ms,
+        queues_config,
+        true,
+    );
+}
+
+/// Local-backend startup with explicit worker gating.
+///
+/// `run_workers == false` (web role) installs the enqueue client but spawns no
+/// ingress/worker tasks, so `Jobs::enqueue` still works while zero `#[job]`
+/// loops run. The in-process `local` backend is non-durable, so a split role on
+/// it is rejected earlier at startup; this path only sees `run_workers == false`
+/// via direct calls in tests.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn start_local_runtime_inner(
+    jobs: Vec<JobInfo>,
+    state: &AppState,
+    shutdown: &tokio_util::sync::CancellationToken,
+    workers: usize,
+    default_max_attempts: u32,
+    default_initial_backoff_ms: u64,
+    queues_config: &crate::config::JobQueuesConfig,
+    run_workers: bool,
 ) {
     let job_admin = default_job_admin_backend_for_state(state);
     let per_job_settings = build_per_job_settings(&jobs);
@@ -3131,7 +3169,9 @@ pub(crate) fn start_local_runtime(
         }
     }
 
-    let worker_count = workers.max(1);
+    // Web role installs the enqueue client but drains nothing: bypass the
+    // `workers.max(1)` floor so zero worker loops run.
+    let worker_count = if run_workers { workers.max(1) } else { 0 };
     let (tx, mut rx) = tokio::sync::mpsc::channel::<QueuedJob>(1024);
     let coordination = Arc::new(LocalJobCoordination::default());
 
@@ -3172,8 +3212,9 @@ pub(crate) fn start_local_runtime(
 
     // Ingress task: own the channel receiver and route each job into its named
     // queue in the shared priority buffer. Retries and concurrency-unparked jobs
-    // re-enter here too, preserving their queue.
-    {
+    // re-enter here too, preserving their queue. Skipped when no workers run
+    // (web role) — there is nothing to drain the buffer it would fill.
+    if run_workers {
         let buffer = Arc::clone(&buffer);
         let shutdown = shutdown.clone();
         tokio::spawn(async move {
@@ -5661,6 +5702,7 @@ fn start_redis_runtime(
     state: &AppState,
     shutdown: &tokio_util::sync::CancellationToken,
     config: &crate::config::JobConfig,
+    run_workers: bool,
 ) -> Result<(), AutumnError> {
     let job_admin = JobAdminMemoryBackend::new();
     let url = config
@@ -5782,6 +5824,13 @@ fn start_redis_runtime(
                 .map(|c| Arc::new(c.resilience.clone())),
         },
     );
+
+    // Web role installs the enqueue client above but runs no worker loops:
+    // another (worker/combined) replica drains the durable Redis queue. Bypass
+    // the `workers.max(1)` floor so zero loops run.
+    if !run_workers {
+        return Ok(());
+    }
 
     let worker_count = config.workers.max(1);
     for _ in 0..worker_count {
@@ -7350,6 +7399,7 @@ fn start_postgres_runtime(
     state: &AppState,
     shutdown: &tokio_util::sync::CancellationToken,
     config: &crate::config::JobConfig,
+    run_workers: bool,
 ) -> AutumnResult<()> {
     let pool = state.pool().cloned().ok_or_else(|| {
         AutumnError::internal_server_error(std::io::Error::other(
@@ -7409,6 +7459,13 @@ fn start_postgres_runtime(
                 .map(|c| Arc::new(c.resilience.clone())),
         },
     );
+
+    // Web role installs the enqueue client above but runs no worker loops and
+    // no maintenance loop: another (worker/combined) replica drains the durable
+    // Postgres queue. Bypass the `workers.max(1)` floor so zero loops run.
+    if !run_workers {
+        return Ok(());
+    }
 
     let visibility_timeout_ms = config.postgres.visibility_timeout_ms;
     let worker_count = config.workers.max(1);
@@ -10842,6 +10899,7 @@ mod tests {
             &state,
             &shutdown,
             &crate::config::JobConfig::default(),
+            true,
         )
         .expect_err("duplicate job names should surface as init errors");
 
@@ -10852,6 +10910,129 @@ mod tests {
             "unexpected error: {error}"
         );
         assert!(global_job_client().is_none());
+    }
+
+    // ── Process role: worker gating (#1613) ─────────────────────────────────
+    //
+    // These exercise the `run_workers` flag threaded through `start_runtime` on
+    // the in-process `local` backend (no external infra needed). AC #1: a web
+    // replica (run_workers = false) must still install the enqueue client so
+    // `enqueue` works, but must run zero worker loops so an enqueued job is
+    // never executed; a combined/worker replica (run_workers = true) executes it.
+
+    static ROLE_GATING_JOB_RUNS: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+
+    fn role_gating_counting_handler(
+        _state: AppState,
+        _payload: Value,
+    ) -> Pin<Box<dyn Future<Output = AutumnResult<()>> + Send + 'static>> {
+        ROLE_GATING_JOB_RUNS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Box::pin(async move { Ok(()) })
+    }
+
+    // The enqueue client is always installed (so `enqueue` is wired up), yet no
+    // worker loop runs. On the in-process `local` backend the enqueue channel's
+    // receiver lives on the (skipped) ingress task, so a web-role enqueue fails
+    // with "channel closed" — which is precisely why a split web/worker topology
+    // must NOT use the local backend (enforced by `split_role_on_local_backend`
+    // + the startup guard). The durable-backend equivalent (a web replica
+    // enqueues, a worker replica drains) is covered by the Docker-gated
+    // `web_role_does_not_execute_jobs_while_worker_role_does` integration test.
+    #[tokio::test]
+    async fn web_role_installs_enqueue_client_but_spawns_no_worker_loops() {
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+        ROLE_GATING_JOB_RUNS.store(0, std::sync::atomic::Ordering::SeqCst);
+
+        let state = AppState::for_test().with_profile("dev");
+        let shutdown = tokio_util::sync::CancellationToken::new();
+
+        // Web role: run_workers = false.
+        start_runtime(
+            vec![JobInfo::new(
+                "role_gated",
+                1,
+                10,
+                role_gating_counting_handler,
+            )],
+            &state,
+            &shutdown,
+            &crate::config::JobConfig::default(),
+            false,
+        )
+        .expect("web-role job runtime should start");
+
+        // The enqueue client is installed even though zero workers run.
+        assert!(
+            global_job_client().is_some(),
+            "web role must install the enqueue client"
+        );
+
+        // No ingress/worker task holds the local channel receiver, so an enqueue
+        // onto the in-process backend fails — the very reason the local backend
+        // is disallowed for split roles.
+        let result = crate::job::enqueue("role_gated", serde_json::json!({})).await;
+        assert!(
+            result.is_err(),
+            "local backend cannot enqueue with zero workers (split roles must use \
+             a durable backend); got {result:?}"
+        );
+
+        // And nothing ever executes.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(
+            ROLE_GATING_JOB_RUNS.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "web role must not execute jobs"
+        );
+
+        shutdown.cancel();
+        clear_global_job_client();
+    }
+
+    #[tokio::test]
+    async fn combined_role_runs_workers_and_executes_enqueued_jobs() {
+        let _guard = global_job_runtime_test_lock().lock().await;
+        clear_global_job_client();
+        ROLE_GATING_JOB_RUNS.store(0, std::sync::atomic::Ordering::SeqCst);
+
+        let state = AppState::for_test().with_profile("dev");
+        let shutdown = tokio_util::sync::CancellationToken::new();
+
+        // Combined/worker role: run_workers = true.
+        start_runtime(
+            vec![JobInfo::new(
+                "role_gated",
+                1,
+                10,
+                role_gating_counting_handler,
+            )],
+            &state,
+            &shutdown,
+            &crate::config::JobConfig::default(),
+            true,
+        )
+        .expect("combined-role job runtime should start");
+
+        crate::job::enqueue("role_gated", serde_json::json!({}))
+            .await
+            .expect("combined role should be able to enqueue");
+
+        // A worker loop drains and executes the job.
+        let executed = timeout(Duration::from_secs(2), async {
+            loop {
+                if ROLE_GATING_JOB_RUNS.load(std::sync::atomic::Ordering::SeqCst) >= 1 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+        assert!(executed.is_ok(), "combined role must execute enqueued jobs");
+
+        shutdown.cancel();
+        clear_global_job_client();
     }
 
     #[tokio::test]
@@ -10881,6 +11062,7 @@ mod tests {
             &state,
             &shutdown,
             &config,
+            true,
         )
         .expect_err("redis backend must fail without the redis feature");
 
@@ -10924,6 +11106,7 @@ mod tests {
             &state,
             &shutdown,
             &config,
+            true,
         )
         .expect_err("redis backend must fail when its url is missing");
 
@@ -12329,6 +12512,7 @@ mod tests {
                 &state,
                 &shutdown,
                 &config,
+                true,
             )
             .expect_err("postgres backend must fail when no db pool is configured");
 

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -10935,8 +10935,8 @@ mod tests {
     // worker loop runs. On the in-process `local` backend the enqueue channel's
     // receiver lives on the (skipped) ingress task, so a web-role enqueue fails
     // with "channel closed" — which is precisely why a split web/worker topology
-    // must NOT use the local backend (enforced by `split_role_on_local_backend`
-    // + the startup guard). The durable-backend equivalent (a web replica
+    // must NOT use the local backend (enforced by
+    // `split_role_requires_durable_backend` + the startup guard). The durable-backend equivalent (a web replica
     // enqueues, a worker replica drains) is covered by the Docker-gated
     // `web_role_does_not_execute_jobs_while_worker_role_does` integration test.
     #[tokio::test]

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -370,6 +370,33 @@ pub fn try_build_router_inner(
     Ok(router.with_state(state))
 }
 
+/// Build a probe-only router for the [`Worker`](crate::config::ProcessRole::Worker)
+/// process role.
+///
+/// A worker replica runs job workers and the cron scheduler but serves no user
+/// routes. It still binds the HTTP listener so orchestrators can supervise it,
+/// exposing **only** the framework liveness/readiness/startup/health probes
+/// (per `config.health.*`) and the actuator (`/actuator/*`, so `/actuator/jobs`
+/// works). This mirrors how [`try_build_router_with_static_inner`] finalizes the
+/// full router — same startup barrier and `with_state` — so probe/actuator
+/// behavior is identical, only the user route table is absent.
+///
+/// # Errors
+///
+/// Returns [`RouterBuildError`] when the actuator prefix collides with a probe
+/// path (the same guard the full build path applies).
+pub fn try_build_probe_only_router(
+    config: &AutumnConfig,
+    state: AppState,
+) -> Result<axum::Router, RouterBuildError> {
+    let barrier_state = state.clone();
+    let (mounted_probe_paths, router) =
+        mount_probe_endpoints(axum::Router::<AppState>::new(), config);
+    let router = mount_actuator_endpoints(router, config, &mounted_probe_paths)?;
+    let router = router.with_state(state);
+    Ok(apply_startup_barrier(router, config, &barrier_state))
+}
+
 /// Prepared MCP exposure carried through `build_router_pre_state`: the mount
 /// path, the derived tool catalog, and the optional whole-endpoint auth layer.
 #[cfg(feature = "mcp")]
@@ -4151,6 +4178,48 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(legacy.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// Worker-role (#1613) probe-only router: exposes the framework probes and
+    /// the actuator, but no user routes. A sample user path 404s.
+    #[tokio::test]
+    async fn probe_only_router_mounts_probes_and_actuator_but_no_user_routes() {
+        let config = AutumnConfig::default();
+        let app = try_build_probe_only_router(&config, test_state())
+            .expect("probe-only router should build");
+
+        // Probe + actuator paths respond.
+        for path in [
+            config.health.live_path.as_str(),
+            config.health.ready_path.as_str(),
+            config.health.startup_path.as_str(),
+            config.health.path.as_str(),
+            "/actuator/health",
+            "/actuator/info",
+        ] {
+            let response = app
+                .clone()
+                .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_ne!(
+                response.status(),
+                StatusCode::NOT_FOUND,
+                "probe-only router should serve {path}"
+            );
+        }
+
+        // A made-up user route is absent (probe-only router has no user table).
+        let missing = app
+            .oneshot(
+                Request::builder()
+                    .uri("/definitely-not-a-user-route")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(missing.status(), StatusCode::NOT_FOUND);
     }
 
     /// The framework-owned widget stylesheet (#1215) is served the same way

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -1926,8 +1926,14 @@ impl TestApp {
             None
         } else {
             let shutdown = tokio_util::sync::CancellationToken::new();
-            crate::job::start_runtime(self.jobs.clone(), &state, &shutdown, &self.config.jobs)
-                .expect("Failed to start job runtime in test");
+            crate::job::start_runtime(
+                self.jobs.clone(),
+                &state,
+                &shutdown,
+                &self.config.jobs,
+                true,
+            )
+            .expect("Failed to start job runtime in test");
             Some(TestJobRuntime { shutdown })
         };
 

--- a/autumn/tests/fixtures/schema_keys.snapshot
+++ b/autumn/tests/fixtures/schema_keys.snapshot
@@ -35,6 +35,7 @@ observability
 openapi
 reporting
 resilience
+role
 scheduler
 security
 seo

--- a/autumn/tests/integration/boundary_hooks_integration.rs
+++ b/autumn/tests/integration/boundary_hooks_integration.rs
@@ -277,7 +277,7 @@ async fn job_interceptor_intercepts_enqueue_and_execute() {
         handler: test_job_handler,
     };
 
-    job::start_runtime(vec![job_info], &state, &shutdown, &config).unwrap();
+    job::start_runtime(vec![job_info], &state, &shutdown, &config, true).unwrap();
 
     job::enqueue("test-job", json!({ "data": "hello" }))
         .await

--- a/autumn/tests/integration/job_tracking_stores_integration.rs
+++ b/autumn/tests/integration/job_tracking_stores_integration.rs
@@ -75,7 +75,7 @@ async fn redis_backend_persists_tracked_job_and_expires_it() {
 
     let state = AppState::for_test().with_profile("dev");
     let shutdown = tokio_util::sync::CancellationToken::new();
-    job::start_runtime(vec![noop_job_info()], &state, &shutdown, &config)
+    job::start_runtime(vec![noop_job_info()], &state, &shutdown, &config, true)
         .expect("start redis-backed job runtime");
 
     let handle = job::enqueue_tracked("noop", serde_json::json!({}))
@@ -188,7 +188,7 @@ async fn postgres_backend_persists_tracked_job_and_expires_it() {
         .with_profile("dev")
         .with_pool(pool.clone());
     let shutdown = tokio_util::sync::CancellationToken::new();
-    job::start_runtime(vec![noop_job_info()], &state, &shutdown, &config)
+    job::start_runtime(vec![noop_job_info()], &state, &shutdown, &config, true)
         .expect("start postgres-backed job runtime");
 
     let handle = job::enqueue_tracked("noop", serde_json::json!({}))

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -133,6 +133,8 @@ mod pg_tls;
 #[cfg(feature = "db")]
 mod preload_scoping;
 mod problem_details;
+#[cfg(feature = "redis")]
+mod process_role_worker_gating;
 mod query_count_asserts;
 mod range;
 mod rate_limit_pipeline;

--- a/autumn/tests/integration/process_role_worker_gating.rs
+++ b/autumn/tests/integration/process_role_worker_gating.rs
@@ -1,0 +1,228 @@
+//! Process-role worker-gating contract tests for issue #1613.
+//!
+//! These prove the durable-backend behavior that the in-process `local` backend
+//! cannot demonstrate (a split web/worker topology is disallowed on `local`):
+//!
+//! - AC #1: a **web** replica (`run_workers = false`) installs the enqueue
+//!   client and enqueues into the durable queue, but runs **no** worker loops,
+//!   so the job is not executed until a **worker**/combined replica drains it.
+//! - AC #5: a **worker** replica drains an in-flight job to completion when its
+//!   shutdown token is cancelled (the worker loop only breaks between jobs, so a
+//!   claimed job finishes first).
+//!
+//! Both require Docker (testcontainers Redis) and are marked `#[ignore]`. Run:
+//!
+//! ```text
+//! cargo test -p autumn-web --features redis,db \
+//!   --test integration_tests process_role_worker_gating -- --ignored
+//! ```
+//!
+//! They are gated on `#[cfg(feature = "redis")]` so they always compile; they
+//! need the Redis container to actually run.
+
+#![cfg(feature = "redis")]
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use autumn_web::config::{JobConfig, JobRedisConfig};
+use autumn_web::job::{self, JobInfo};
+use autumn_web::{AppState, AutumnResult};
+use serde_json::Value;
+use tokio::time::{sleep, timeout};
+
+static EXECUTED: AtomicUsize = AtomicUsize::new(0);
+
+fn counting_handler(
+    _state: AppState,
+    _payload: Value,
+) -> Pin<Box<dyn Future<Output = AutumnResult<()>> + Send + 'static>> {
+    EXECUTED.fetch_add(1, Ordering::SeqCst);
+    Box::pin(async move { Ok(()) })
+}
+
+fn counting_job_info() -> JobInfo {
+    JobInfo::new("role_counting", 1, 10, counting_handler)
+}
+
+static SLOW_STARTED: AtomicUsize = AtomicUsize::new(0);
+static SLOW_COMPLETED: AtomicUsize = AtomicUsize::new(0);
+
+fn slow_handler(
+    _state: AppState,
+    _payload: Value,
+) -> Pin<Box<dyn Future<Output = AutumnResult<()>> + Send + 'static>> {
+    Box::pin(async move {
+        SLOW_STARTED.fetch_add(1, Ordering::SeqCst);
+        sleep(Duration::from_millis(400)).await;
+        SLOW_COMPLETED.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    })
+}
+
+fn slow_job_info() -> JobInfo {
+    JobInfo::new("role_slow", 1, 10, slow_handler)
+}
+
+fn redis_config(url: &str) -> JobConfig {
+    JobConfig {
+        backend: "redis".to_owned(),
+        redis: JobRedisConfig {
+            url: Some(url.to_owned()),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// AC #1: a web replica enqueues into the durable queue but never executes the
+/// job; a worker replica against the same Redis drains and runs it.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn web_role_does_not_execute_jobs_while_worker_role_does() {
+    use testcontainers::runners::AsyncRunner as _;
+    use testcontainers_modules::redis::Redis as RedisImage;
+
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+    EXECUTED.store(0, Ordering::SeqCst);
+
+    let container = RedisImage::default()
+        .start()
+        .await
+        .expect("start Redis container");
+    let port = container
+        .get_host_port_ipv4(6379)
+        .await
+        .expect("redis port");
+    let url = format!("redis://127.0.0.1:{port}");
+    let config = redis_config(&url);
+
+    // Web replica: run_workers = false. Installs the enqueue client, no workers.
+    let web_state = AppState::for_test().with_profile("dev");
+    let web_shutdown = tokio_util::sync::CancellationToken::new();
+    job::start_runtime(
+        vec![counting_job_info()],
+        &web_state,
+        &web_shutdown,
+        &config,
+        false,
+    )
+    .expect("web-role job runtime should start");
+
+    // The web replica can enqueue into the durable Redis queue.
+    job::enqueue("role_counting", serde_json::json!({}))
+        .await
+        .expect("web replica should enqueue into the durable queue");
+
+    // With no worker loops running, the job stays pending — never executed.
+    sleep(Duration::from_millis(500)).await;
+    assert_eq!(
+        EXECUTED.load(Ordering::SeqCst),
+        0,
+        "web role must not execute enqueued jobs"
+    );
+
+    // Bring up a worker replica against the same Redis; run_workers = true.
+    job::clear_global_job_client();
+    let worker_state = AppState::for_test().with_profile("dev");
+    let worker_shutdown = tokio_util::sync::CancellationToken::new();
+    job::start_runtime(
+        vec![counting_job_info()],
+        &worker_state,
+        &worker_shutdown,
+        &config,
+        true,
+    )
+    .expect("worker-role job runtime should start");
+
+    // The durable job enqueued by the web replica is now drained and executed.
+    let drained = timeout(Duration::from_secs(5), async {
+        loop {
+            if EXECUTED.load(Ordering::SeqCst) >= 1 {
+                break;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await;
+    assert!(
+        drained.is_ok(),
+        "worker role must drain and execute the durable job the web replica enqueued"
+    );
+
+    web_shutdown.cancel();
+    worker_shutdown.cancel();
+    job::clear_global_job_client();
+}
+
+/// AC #5: a worker replica drains an in-flight job to completion when its
+/// shutdown token is cancelled mid-flight (the loop only breaks between jobs).
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn worker_role_drains_in_flight_job_on_shutdown() {
+    use testcontainers::runners::AsyncRunner as _;
+    use testcontainers_modules::redis::Redis as RedisImage;
+
+    let _guard = job::global_job_runtime_test_lock().lock().await;
+    job::clear_global_job_client();
+    SLOW_STARTED.store(0, Ordering::SeqCst);
+    SLOW_COMPLETED.store(0, Ordering::SeqCst);
+
+    let container = RedisImage::default()
+        .start()
+        .await
+        .expect("start Redis container");
+    let port = container
+        .get_host_port_ipv4(6379)
+        .await
+        .expect("redis port");
+    let url = format!("redis://127.0.0.1:{port}");
+    let config = redis_config(&url);
+
+    let state = AppState::for_test().with_profile("dev");
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    job::start_runtime(vec![slow_job_info()], &state, &shutdown, &config, true)
+        .expect("worker-role job runtime should start");
+
+    job::enqueue("role_slow", serde_json::json!({}))
+        .await
+        .expect("enqueue slow job");
+
+    // Wait until the worker has claimed and started the job (it is in-flight).
+    let started = timeout(Duration::from_secs(5), async {
+        loop {
+            if SLOW_STARTED.load(Ordering::SeqCst) >= 1 {
+                break;
+            }
+            sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await;
+    assert!(started.is_ok(), "job should start executing");
+    assert_eq!(
+        SLOW_COMPLETED.load(Ordering::SeqCst),
+        0,
+        "job should still be in-flight when we cancel"
+    );
+
+    // Cancel while the handler is mid-flight; the worker finishes it first.
+    shutdown.cancel();
+    let drained = timeout(Duration::from_secs(5), async {
+        loop {
+            if SLOW_COMPLETED.load(Ordering::SeqCst) >= 1 {
+                break;
+            }
+            sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await;
+    assert!(
+        drained.is_ok(),
+        "worker must drain the in-flight job to completion on shutdown"
+    );
+
+    job::clear_global_job_client();
+}

--- a/autumn/tests/integration/webhook_outbound.rs
+++ b/autumn/tests/integration/webhook_outbound.rs
@@ -63,7 +63,7 @@ async fn test_webhook_outbound_lifecycle() {
         concurrency: None,
         handler: autumn_web::webhook_outbound::deliver_webhook_job,
     };
-    job::start_runtime(vec![job_info], state, &shutdown, &config).unwrap();
+    job::start_runtime(vec![job_info], state, &shutdown, &config, true).unwrap();
 
     // 3. Create a webhook subscription for topic "order.created"
     let sub = WebhookSubscription {
@@ -160,7 +160,7 @@ async fn test_webhook_outbound_retries_and_dlq() {
         concurrency: None,
         handler: autumn_web::webhook_outbound::deliver_webhook_job,
     };
-    job::start_runtime(vec![job_info], state, &shutdown, &config).unwrap();
+    job::start_runtime(vec![job_info], state, &shutdown, &config, true).unwrap();
 
     let sub = WebhookSubscription {
         id: "sub_retry".to_owned(),
@@ -250,7 +250,7 @@ async fn test_webhook_outbound_failure_caps_deactivation() {
         concurrency: None,
         handler: autumn_web::webhook_outbound::deliver_webhook_job,
     };
-    job::start_runtime(vec![job_info], state, &shutdown, &config).unwrap();
+    job::start_runtime(vec![job_info], state, &shutdown, &config, true).unwrap();
 
     let sub = WebhookSubscription {
         id: "sub_cap".to_owned(),
@@ -332,7 +332,7 @@ async fn test_webhook_outbound_actuator_endpoints() {
         concurrency: None,
         handler: autumn_web::webhook_outbound::deliver_webhook_job,
     };
-    job::start_runtime(vec![job_info], state, &shutdown, &config).unwrap();
+    job::start_runtime(vec![job_info], state, &shutdown, &config, true).unwrap();
 
     // 1. Initial DLQ should be empty
     let res = app.get("/actuator/webhooks/dlq").send().await;

--- a/docs/guide/cloud-native.md
+++ b/docs/guide/cloud-native.md
@@ -257,6 +257,59 @@ Use Harvest when:
 - work should be coordinated across replicas
 - you are really describing a workflow, not a cron callback
 
+## Split web/worker topology
+
+The same image can run as two deployments: **web** replicas that serve HTTP and
+enqueue jobs, and **worker** replicas that drain jobs and run the scheduler.
+Pick the role per deployment with `AUTUMN_ROLE` — no app code or image changes.
+This is the standard "web tier + separately scaled worker tier" production shape
+(Rails/Sidekiq, Laravel Horizon, Django/Celery, Loco.rs `--worker`); scale,
+deploy, and drain each tier on its own.
+
+Requirements:
+
+- **A durable jobs backend** — `jobs.backend = "postgres"` or `"redis"`. The
+  `local` backend is in-process, so a web replica would enqueue where no worker
+  can drain. Autumn rejects a split role on `local` at startup and
+  `autumn doctor --strict` flags it. See
+  [Web and worker process roles](jobs.md#web-and-worker-process-roles).
+- **The same migration gate** — both tiers share one backend, so run the
+  dedicated migration job (below) once before either tier starts.
+- **Probes on the worker tier** — a `worker` replica serves no user routes but
+  still binds `/live`, `/ready`, `/startup`, and `/actuator/*`, so wire the same
+  liveness/readiness probes you use for web.
+
+Docker Compose sketch — one image, two roles, shared Postgres backend:
+
+```yaml
+services:
+  # db + migrate: as in the Migration Jobs section below — migrate runs once, first.
+
+  web:
+    image: my-app:latest
+    environment:
+      AUTUMN_ROLE: web
+      AUTUMN_DATABASE__PRIMARY_URL: postgres://app:secret@db:5432/app
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+
+  worker:
+    image: my-app:latest
+    environment:
+      AUTUMN_ROLE: worker
+      AUTUMN_DATABASE__PRIMARY_URL: postgres://app:secret@db:5432/app
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+```
+
+On Kubernetes this is two `Deployment`s off the same image — one with
+`AUTUMN_ROLE=web`, one with `AUTUMN_ROLE=worker` — each with its own replica
+count and autoscaler, both pointing the readiness probe at `/ready` so the
+[rolling-deploy drain](#rolling-deploy-lifecycle) supervises worker rollouts the
+same way it does web.
+
 ## Migration Jobs
 
 For multi-replica deployments, do not rely on each web process racing to apply
@@ -835,6 +888,7 @@ Before calling an Autumn app "cloud ready", verify:
 - migrations run before web rollout via a dedicated migration job
 - destructive/irreversible migrations follow the expand/contract pattern
 - background jobs use the right runtime model
+- a split web/worker topology (`AUTUMN_ROLE=web` / `worker`) runs on a durable jobs backend (`postgres`/`redis`, never `local`), with worker replicas exposing `/live` + `/ready`
 - `autumn_jobs` has `traceparent` / `tracestate` columns if using the Postgres backend with `telemetry-otlp`
 - multi-replica write paths use `#[lock_version]` (optimistic) or `with_lock` (pessimistic) to prevent lost updates
 - the generated container image builds without manual template surgery

--- a/docs/guide/jobs.md
+++ b/docs/guide/jobs.md
@@ -149,6 +149,84 @@ visibility_timeout_ms = 30000
 - `redis`: Durable, Redis-backed queue for multi-replica workers. Higher
   throughput ceiling than `postgres` but adds Redis as an infrastructure dependency.
 
+## Web and worker process roles
+
+The same binary can run in one of three **process roles**, so you can scale the
+HTTP tier separately from the background-work tier without touching app code. No
+handler, `#[job]`, or `#[scheduled]` definition changes — only config or a flag.
+
+| Role | Serves user routes | Runs workers + scheduler | Enqueues jobs |
+|---|---|---|---|
+| `combined` (default) | Yes | Yes | Yes |
+| `web` | Yes | **No** | Yes |
+| `worker` | **No** (probes/actuator only) | Yes | Yes |
+
+- **`combined`** is the default and preserves today's single-process behavior:
+  it serves HTTP, drains `#[job]` workers, and runs the `#[scheduled]` cron.
+  Existing apps and `autumn dev` need zero changes.
+- **`web`** serves HTTP and still **enqueues** jobs, but runs no workers and no
+  scheduler, so background work never competes with request handling on a web
+  replica.
+- **`worker`** runs the workers and the cron scheduler against the shared
+  durable backend and does **not** serve user routes — but it still binds the
+  HTTP listener to expose only the liveness/readiness probes (`/live`, `/ready`,
+  `/startup`, `/health`) and the actuator (`/actuator/*`, including
+  `/actuator/jobs`), so an orchestrator can supervise it.
+
+### Selecting a role
+
+Three equivalent mechanisms:
+
+```bash
+# Environment variable — the usual container knob.
+AUTUMN_ROLE=web     # or: worker | combined
+```
+
+```toml
+# autumn.toml — top-level key.
+role = "worker"     # or: web | combined
+```
+
+```bash
+# CLI flag on the production server command.
+autumn serve --role worker   # or: --role web
+```
+
+### Split roles require a durable backend
+
+A split web/worker topology **requires a durable jobs backend**
+(`jobs.backend = "postgres"` or `"redis"`). The default `local` backend is an
+in-process, in-memory queue: a `web` replica would enqueue into its own memory,
+where no separate `worker` replica can ever drain it.
+
+Autumn rejects this combination at startup — a `web` or `worker` role on the
+`local` backend exits with a clear error rather than silently dropping work —
+and `autumn doctor --strict` reports it as a **Fail**. `combined` on `local` is
+always fine, because one process both enqueues and drains.
+
+```toml
+[jobs]
+backend = "postgres"   # or "redis"; required once role is "web" or "worker"
+```
+
+### Graceful drain on workers
+
+A `worker`-role process joins the same shutdown sequence as a web replica. On
+SIGTERM it stops claiming new jobs, gives in-flight jobs the configured drain
+window (`server.shutdown_timeout_secs` / `server.prestop_grace_secs`) to finish
+or be released back to the queue, then exits cleanly. Its `/ready` probe flips
+to `503` during the drain, so an orchestrator supervises a rolling worker deploy
+exactly as it would a web deploy. See
+[Rolling Deploy Lifecycle](cloud-native.md#rolling-deploy-lifecycle) for the
+full phase ordering.
+
+### Where job execution shows up
+
+`/actuator/jobs` and the admin dashboard attribute each job's execution to the
+process that actually ran it. In a split topology that is always a `worker`
+process — `web` replicas only enqueue, so handler execution, in-flight counts,
+and last-error data surface on the worker tier.
+
 ## Postgres delivery semantics
 
 The Postgres backend provides **at-least-once delivery**. Each job is a row in
@@ -252,8 +330,13 @@ a loud, documented condition — it is logged at startup (`WARN`) and the queue 
 appended at lowest priority so the job still drains instead of silently stalling.
 Add the queue to `[jobs] queues` to control its priority.
 
-> Out of scope (separate follow-ups): per-job-instance dynamic priority at
-> enqueue time, and per-queue concurrency caps / dedicated worker pools.
+> **Role-based scaling** — running a separately scaled worker tier that drains
+> all configured queues — is covered in
+> [Web and worker process roles](#web-and-worker-process-roles). Still out of
+> scope (separate follow-ups): per-job-instance dynamic priority at enqueue
+> time, and pinning specific queues to dedicated worker processes / per-queue
+> concurrency pools (#1623). Today a worker process drains all configured
+> queues.
 
 ## Uniqueness and concurrency limits
 

--- a/examples/reddit-clone/tests/webhook_outbound_integration.rs
+++ b/examples/reddit-clone/tests/webhook_outbound_integration.rs
@@ -95,7 +95,7 @@ async fn test_reddit_registration_triggers_outbound_webhook() {
         concurrency: None,
         handler: autumn_web::webhook_outbound::deliver_webhook_job,
     });
-    job::start_runtime(jobs, state, &shutdown, &config).unwrap();
+    job::start_runtime(jobs, state, &shutdown, &config, true).unwrap();
 
     // 5. Fire a POST request to /register to trigger the user.created webhook event
     let response = app


### PR DESCRIPTION
## What & why

**Before:** every Autumn process is web server + job worker + scheduler at once — `run()` always starts the job runtime and cron scheduler beside the HTTP listener. There's no supported way to run a web-only replica or a worker-only replica, so CPU/memory-heavy background jobs compete with request handling on every web replica, and the worker tier can't be scaled, deployed, or drained independently.

**After:** the same binary can run in one of three **process roles**, chosen by config/flag/env with zero application-code changes:

- **combined** (default) — HTTP + job workers + scheduler. Unchanged; existing apps and `autumn dev` behave exactly as today.
- **web** — serves HTTP and still enqueues jobs, but runs no `#[job]` worker loops and no `#[scheduled]`/cron scheduler.
- **worker** — runs job workers + the cron scheduler against the shared durable backend, serves no user routes, but still binds the listener exposing only liveness/readiness probes (`/live`, `/ready`, `/startup`, `/health`) and the actuator (`/actuator/*`, including `/actuator/jobs`) so an orchestrator can supervise it.

Select a role three ways:
- `AUTUMN_ROLE=web|worker|combined`
- top-level `role = "web"` in the autumn config
- `autumn serve --role web|worker`

## How

- `ProcessRole` enum in `config.rs` (modeled on `SchedulerBackend`), added as top-level `AutumnConfig.role` with an `AUTUMN_ROLE` env override.
- `run()` gating: web role skips the job worker loops + cron scheduler (still marks startup complete / signals ready, no readiness regression); worker role builds a probe+actuator-only router (`try_build_probe_only_router`) instead of the user router. The enqueue **client** is always installed (via a `run_workers: bool` threaded through `job::start_runtime` and each backend) so web replicas can enqueue while spawning zero worker loops.
- **Misconfiguration guard:** a split role on the in-process `local` jobs backend (where web-enqueued jobs can never reach a separate worker) is rejected at startup (`split_role_on_local_backend`) and flagged by `autumn doctor --strict` (new `process_role_backend` check).
- `autumn release init --split-workers` scaffolds a docker-compose `worker` service on the same image/env/migration gate as web (`AUTUMN_ROLE=worker`, durable `AUTUMN_JOBS__BACKEND=postgres`). Default output is unchanged.
- Worker processes reuse the existing `CancellationToken` + `shutdown_signal()` drain, so on SIGTERM they stop claiming and finish/release in-flight jobs within the configured `server.shutdown_timeout_secs` / `prestop_grace_secs` window.
- Docs: `docs/guide/jobs.md` (Web and worker process roles) and `docs/guide/cloud-native.md` (Split web/worker topology), including `/actuator/jobs` + dashboard execution attribution.

## Follow-up (#1623)

Role is a clean typed value threaded to job/scheduler startup; per-queue dedicated pools and pinning specific queues to specific worker processes are the planned follow-up (#1623) and layer on without rework. Today a worker process drains all configured queues.

## Testing

- `cargo test -p autumn-web --lib` → 3433 passed
- `cargo test -p autumn-cli` → 3034 + 117 + 174 passed
- New coverage: `ProcessRole` unit tests, split-guard truth table, `AUTUMN_ROLE` env override, probe-only router mount test, doctor split-topology check, release-init split-compose output tests, and Redis-backed `#[ignore]` integration tests for AC #1 (web leaves an enqueued job pending until a worker drains) and AC #5 (worker drains an in-flight job on shutdown) — these require Docker to run.

## Known-red CI (external, not from this diff)

Two checks are red on every open PR right now for reasons unrelated to this change; fixes are already in flight:
- **Lint** — a pre-existing `needless_pass_by_value` clippy error at `autumn/src/repository.rs:157` on `trunk-dev` (from merged #1701). Fix is up in #1705. The file is byte-identical on `trunk-dev` and untouched here.
- **Fuzz** (all five jobs) — `taiki-e/install-action` resolves with an empty tool input so `cargo-fuzz` never installs. Fix is up in #1717. Unrelated to this diff.

Everything else should reflect this PR's own changes.

Closes #1613

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKdHfxosQsxQWRvaVS2t74)_