### PR TITLE
Add a fake-data source for factories and bulk seed generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,8 @@ dependencies = [
  "pq-sys",
  "proptest",
  "pulldown-cmark",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
  "redis",
  "reqwest 0.12.28",
  "rsa",

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -331,6 +331,16 @@ enum Commands {
         /// Package to run (for workspaces)
         #[arg(short, long)]
         package: Option<String>,
+        /// Number of faked rows to generate. Requires `--model`.
+        ///
+        /// When both `--count` and `--model` are given, the seed binary
+        /// generates and inserts that many faked rows for the model via its
+        /// factory, instead of running its hand-written seed body.
+        #[arg(long)]
+        count: Option<usize>,
+        /// Model to fake rows for (e.g. `Post`). Requires `--count`.
+        #[arg(long)]
+        model: Option<String>,
     },
     /// Run or list one-off operational tasks registered by the application.
     Task {
@@ -2377,7 +2387,12 @@ fn run_command(command: Commands) {
             secret,
             payload,
         }) => webhook::run_sim(&provider, &url, &secret, &payload),
-        Commands::Seed { profile, package } => seed::run(&profile, package.as_deref()),
+        Commands::Seed {
+            profile,
+            package,
+            count,
+            model,
+        } => seed::run(&profile, package.as_deref(), count, model.as_deref()),
         Commands::Task {
             package,
             bin,
@@ -4343,9 +4358,16 @@ mod tests {
     fn parse_seed_defaults() {
         let cli = Cli::try_parse_from(["autumn", "seed"]).unwrap();
         match cli.command {
-            Commands::Seed { profile, package } => {
+            Commands::Seed {
+                profile,
+                package,
+                count,
+                model,
+            } => {
                 assert_eq!(profile, "dev");
                 assert!(package.is_none());
+                assert!(count.is_none());
+                assert!(model.is_none());
             }
             _ => panic!("expected Seed command"),
         }
@@ -4368,6 +4390,34 @@ mod tests {
         match cli.command {
             Commands::Seed { package, .. } => {
                 assert_eq!(package.as_deref(), Some("my-app"));
+            }
+            _ => panic!("expected Seed command"),
+        }
+    }
+
+    #[test]
+    fn parse_seed_with_count_and_model() {
+        let cli =
+            Cli::try_parse_from(["autumn", "seed", "--count", "200", "--model", "Post"]).unwrap();
+        match cli.command {
+            Commands::Seed { count, model, .. } => {
+                assert_eq!(count, Some(200));
+                assert_eq!(model.as_deref(), Some("Post"));
+            }
+            _ => panic!("expected Seed command"),
+        }
+    }
+
+    #[test]
+    fn parse_seed_with_count_only() {
+        // Parsing succeeds (clap has no requires-relationship); the
+        // count-without-model error is enforced at run time by
+        // `resolve_fake_request`.
+        let cli = Cli::try_parse_from(["autumn", "seed", "--count", "50"]).unwrap();
+        match cli.command {
+            Commands::Seed { count, model, .. } => {
+                assert_eq!(count, Some(50));
+                assert!(model.is_none());
             }
             _ => panic!("expected Seed command"),
         }

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -331,15 +331,15 @@ enum Commands {
         /// Package to run (for workspaces)
         #[arg(short, long)]
         package: Option<String>,
-        /// Number of faked rows to generate. Requires `--model`.
+        /// Number of faked rows to generate. Requires --model.
         ///
         /// When both `--count` and `--model` are given, the seed binary
         /// generates and inserts that many faked rows for the model via its
         /// factory, instead of running its hand-written seed body.
-        #[arg(long)]
+        #[arg(long, requires = "model")]
         count: Option<usize>,
-        /// Model to fake rows for (e.g. `Post`). Requires `--count`.
-        #[arg(long)]
+        /// Model to fake rows for (e.g. `Post`). Requires --count.
+        #[arg(long, requires = "count")]
         model: Option<String>,
     },
     /// Run or list one-off operational tasks registered by the application.
@@ -4410,17 +4410,16 @@ mod tests {
 
     #[test]
     fn parse_seed_with_count_only() {
-        // Parsing succeeds (clap has no requires-relationship); the
-        // count-without-model error is enforced at run time by
-        // `resolve_fake_request`.
-        let cli = Cli::try_parse_from(["autumn", "seed", "--count", "50"]).unwrap();
-        match cli.command {
-            Commands::Seed { count, model, .. } => {
-                assert_eq!(count, Some(50));
-                assert!(model.is_none());
-            }
-            _ => panic!("expected Seed command"),
-        }
+        // `--count` declares `requires = "model"`, so clap rejects it at parse
+        // time when `--model` is absent. `resolve_fake_request` remains as a
+        // secondary run-time guard for callers that bypass clap.
+        assert!(Cli::try_parse_from(["autumn", "seed", "--count", "50"]).is_err());
+    }
+
+    #[test]
+    fn parse_seed_with_model_only() {
+        // Symmetrically, `--model` requires `--count`.
+        assert!(Cli::try_parse_from(["autumn", "seed", "--model", "Post"]).is_err());
     }
 
     #[test]

--- a/autumn-cli/src/seed.rs
+++ b/autumn-cli/src/seed.rs
@@ -201,7 +201,16 @@ pub fn run(profile: &str, package: Option<&str>, count: Option<usize>, model: Op
         }
     };
     if let Some((count, model)) = &fake_request {
-        eprintln!("  Faking: {count} row(s) of model `{model}`");
+        // Do not claim the rows were created: this command only *delegates* the
+        // request to the project's seed binary (via AUTUMN_SEED_COUNT/MODEL).
+        // Only a seed binary from a current scaffold — one that calls
+        // `autumn_web::seed::maybe_fake_seed` — actually performs the fake seed
+        // and reports the real inserted count itself.
+        eprintln!(
+            "  Requesting fake seed: {count} row(s) of model `{model}` \
+             (delegated to the seed binary; requires a seed binary from a \
+             current `autumn new` scaffold)"
+        );
     }
 
     // Determine the project directory: either the workspace member's root (when
@@ -236,10 +245,17 @@ pub fn run(profile: &str, package: Option<&str>, count: Option<usize>, model: Op
     cmd.env("AUTUMN_ENV", profile);
     cmd.env("AUTUMN_PROFILE", profile);
     // Forward the fake-seed request (if any) to the seed binary, which
-    // dispatches on these vars to `autumn_web::seed::fake_seed_model`.
+    // dispatches on these vars via `autumn_web::seed::maybe_fake_seed`. When no
+    // request was made, explicitly *remove* these vars from the child's
+    // environment so a stray ambient `AUTUMN_SEED_MODEL`/`AUTUMN_SEED_COUNT`
+    // inherited by this process can't silently trigger a fake seed the user did
+    // not ask for.
     if let Some((count, model)) = &fake_request {
         cmd.env("AUTUMN_SEED_COUNT", count.to_string());
         cmd.env("AUTUMN_SEED_MODEL", model);
+    } else {
+        cmd.env_remove("AUTUMN_SEED_COUNT");
+        cmd.env_remove("AUTUMN_SEED_MODEL");
     }
     // Run from the project directory so the seed binary's SeedContext reads
     // autumn.toml from the correct location (the package root, not the

--- a/autumn-cli/src/seed.rs
+++ b/autumn-cli/src/seed.rs
@@ -22,6 +22,30 @@ pub enum SeedError {
 
     #[error("pending migrations detected; run `autumn migrate` before `autumn seed`")]
     PendingMigrations,
+
+    #[error(
+        "`--count` and `--model` must be used together: pass both to generate \
+         faked rows (e.g. `autumn seed --count 200 --model Post`), or neither \
+         to run the project seed binary"
+    )]
+    IncompleteFakeFlags,
+}
+
+/// Resolve the `--count`/`--model` pair into the fake-seed request, if any.
+///
+/// - Both absent → `Ok(None)`: preserve today's behavior (run the seed binary).
+/// - Both present → `Ok(Some((count, model)))`: forward to the seed binary so
+///   it generates faked rows for that model.
+/// - Exactly one present → [`SeedError::IncompleteFakeFlags`].
+fn resolve_fake_request(
+    count: Option<usize>,
+    model: Option<&str>,
+) -> Result<Option<(usize, String)>, SeedError> {
+    match (count, model) {
+        (None, None) => Ok(None),
+        (Some(count), Some(model)) => Ok(Some((count, model.to_owned()))),
+        _ => Err(SeedError::IncompleteFakeFlags),
+    }
 }
 
 /// Returns `true` if the seed binary source file exists at `path`.
@@ -159,9 +183,26 @@ fn check_pending_migrations(database_url: &str, migrations_dir: &str) -> Result<
 }
 
 /// Entry point for `autumn seed`.
-pub fn run(profile: &str, package: Option<&str>) {
+///
+/// When both `count` and `model` are supplied, the seed binary is asked (via the
+/// `AUTUMN_SEED_COUNT`/`AUTUMN_SEED_MODEL` environment variables) to generate
+/// that many faked rows for the named model instead of running its hand-written
+/// seed body. Supplying only one of the two is an error; supplying neither
+/// preserves the original behavior (run the project seed binary).
+pub fn run(profile: &str, package: Option<&str>, count: Option<usize>, model: Option<&str>) {
     eprintln!("\u{1F342} autumn seed\n");
     eprintln!("  Profile: {profile}");
+
+    let fake_request = match resolve_fake_request(count, model) {
+        Ok(req) => req,
+        Err(e) => {
+            eprintln!("\u{2717} {e}");
+            std::process::exit(1);
+        }
+    };
+    if let Some((count, model)) = &fake_request {
+        eprintln!("  Faking: {count} row(s) of model `{model}`");
+    }
 
     // Determine the project directory: either the workspace member's root (when
     // --package is given) or the current working directory.
@@ -194,6 +235,12 @@ pub fn run(profile: &str, package: Option<&str>) {
     }
     cmd.env("AUTUMN_ENV", profile);
     cmd.env("AUTUMN_PROFILE", profile);
+    // Forward the fake-seed request (if any) to the seed binary, which
+    // dispatches on these vars to `autumn_web::seed::fake_seed_model`.
+    if let Some((count, model)) = &fake_request {
+        cmd.env("AUTUMN_SEED_COUNT", count.to_string());
+        cmd.env("AUTUMN_SEED_MODEL", model);
+    }
     // Run from the project directory so the seed binary's SeedContext reads
     // autumn.toml from the correct location (the package root, not the
     // workspace root).
@@ -256,6 +303,46 @@ mod tests {
         assert!(
             msg.contains("pending"),
             "error should mention pending migrations, got: {msg}"
+        );
+    }
+
+    // ── resolve_fake_request (--count / --model, #1343 AC4) ─────────────────
+
+    #[test]
+    fn resolve_fake_request_none_when_both_absent() {
+        assert_eq!(resolve_fake_request(None, None), Ok(None));
+    }
+
+    #[test]
+    fn resolve_fake_request_some_when_both_present() {
+        assert_eq!(
+            resolve_fake_request(Some(200), Some("Post")),
+            Ok(Some((200, "Post".to_string())))
+        );
+    }
+
+    #[test]
+    fn resolve_fake_request_errors_on_count_without_model() {
+        assert_eq!(
+            resolve_fake_request(Some(200), None),
+            Err(SeedError::IncompleteFakeFlags)
+        );
+    }
+
+    #[test]
+    fn resolve_fake_request_errors_on_model_without_count() {
+        assert_eq!(
+            resolve_fake_request(None, Some("Post")),
+            Err(SeedError::IncompleteFakeFlags)
+        );
+    }
+
+    #[test]
+    fn incomplete_fake_flags_error_is_actionable() {
+        let msg = SeedError::IncompleteFakeFlags.to_string();
+        assert!(
+            msg.contains("--count") && msg.contains("--model"),
+            "error should mention both flags, got: {msg}"
         );
     }
 

--- a/autumn-cli/src/templates/seed.rs.tmpl
+++ b/autumn-cli/src/templates/seed.rs.tmpl
@@ -13,10 +13,12 @@
 //!   autumn seed --count 200 --model Post
 //!
 //! `autumn seed` forwards `--count`/`--model` as the `AUTUMN_SEED_COUNT` and
-//! `AUTUMN_SEED_MODEL` environment variables; the dispatcher below then routes
-//! to `autumn_web::seed::fake_seed_model`, which drives the model's factory
-//! `.fake().create_many(...)`. Any `#[autumn_web::model]` is registered
-//! automatically — no code change needed here.
+//! `AUTUMN_SEED_MODEL` environment variables; `autumn_web::seed::maybe_fake_seed`
+//! (called first below) then routes to `autumn_web::seed::fake_seed_model`, which
+//! drives the model's factory `.fake().create_many(...)`. Any
+//! `#[autumn_web::model]` is registered automatically — no code change needed
+//! here. Because the dispatch lives in autumn-web, upgrading the framework picks
+//! up any fixes without re-scaffolding this file.
 use autumn_web::seed::SeedContext;
 
 #[autumn_web::main]
@@ -24,20 +26,14 @@ async fn main() {
     let ctx = SeedContext::build()
         .expect("failed to build seed context — is the database running?");
 
-    // Fake-seed dispatch: when invoked as `autumn seed --count N --model M`,
-    // generate faked rows for that model and return, skipping the hand-written
-    // seed body below.
-    if let (Ok(model), Ok(count)) = (
-        std::env::var("AUTUMN_SEED_MODEL"),
-        std::env::var("AUTUMN_SEED_COUNT"),
-    ) {
-        let count: usize = count
-            .parse()
-            .expect("AUTUMN_SEED_COUNT must be a non-negative integer");
-        let inserted = autumn_web::seed::fake_seed_model(&model, count, ctx.pool())
-            .await
-            .expect("fake-seed failed");
-        println!("Inserted {inserted} faked `{model}` row(s).");
+    // Fake-seed dispatch (owned by autumn-web): when invoked as
+    // `autumn seed --count N --model M`, generate faked rows for that model and
+    // return, skipping the hand-written seed body below. Returns `false` when no
+    // fake request was made, so the normal seed runs.
+    if autumn_web::seed::maybe_fake_seed(ctx.pool())
+        .await
+        .expect("fake-seed failed")
+    {
         return;
     }
 

--- a/autumn-cli/src/templates/seed.rs.tmpl
+++ b/autumn-cli/src/templates/seed.rs.tmpl
@@ -7,12 +7,39 @@
 //!
 //! Re-running this seed against an already-seeded database is safe because
 //! every insert uses `ON CONFLICT DO NOTHING` (upsert-by-natural-key).
+//!
+//! Faking rows without editing this file:
+//!
+//!   autumn seed --count 200 --model Post
+//!
+//! `autumn seed` forwards `--count`/`--model` as the `AUTUMN_SEED_COUNT` and
+//! `AUTUMN_SEED_MODEL` environment variables; the dispatcher below then routes
+//! to `autumn_web::seed::fake_seed_model`, which drives the model's factory
+//! `.fake().create_many(...)`. Any `#[autumn_web::model]` is registered
+//! automatically — no code change needed here.
 use autumn_web::seed::SeedContext;
 
 #[autumn_web::main]
 async fn main() {
     let ctx = SeedContext::build()
         .expect("failed to build seed context — is the database running?");
+
+    // Fake-seed dispatch: when invoked as `autumn seed --count N --model M`,
+    // generate faked rows for that model and return, skipping the hand-written
+    // seed body below.
+    if let (Ok(model), Ok(count)) = (
+        std::env::var("AUTUMN_SEED_MODEL"),
+        std::env::var("AUTUMN_SEED_COUNT"),
+    ) {
+        let count: usize = count
+            .parse()
+            .expect("AUTUMN_SEED_COUNT must be a non-negative integer");
+        let inserted = autumn_web::seed::fake_seed_model(&model, count, ctx.pool())
+            .await
+            .expect("fake-seed failed");
+        println!("Inserted {inserted} faked `{model}` row(s).");
+        return;
+    }
 
     println!("Seeding database (profile: {})...", ctx.profile());
 
@@ -33,6 +60,10 @@ async fn main() {
     //       .execute(&mut db)
     //       .await
     //       .expect("seed insert failed");
+    //
+    // Or, to populate 100+ faked rows in one line (requires `#[autumn_web::model]`):
+    //
+    //   MyModel::factory().fake().create_many(200, ctx.pool()).await;
 
     drop(db);
     println!("Seed complete.");

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -1650,6 +1650,143 @@ fn factory_assoc_type(field: &Field) -> Option<syn::Ident> {
     None
 }
 
+/// The identifier of a type's last path segment (e.g. `String`, `i64`,
+/// `DateTime`, `Uuid`), if the type is a simple path type.
+fn ty_last_ident(ty: &syn::Type) -> Option<String> {
+    if let syn::Type::Path(tp) = ty {
+        tp.path.segments.last().map(|s| s.ident.to_string())
+    } else {
+        None
+    }
+}
+
+/// The identifier of the first generic type argument of a path type's last
+/// segment (e.g. `Utc` for `DateTime<Utc>`, `String` for `Vec<String>`).
+fn ty_last_generic_ident(ty: &syn::Type) -> Option<String> {
+    if let syn::Type::Path(tp) = ty {
+        let seg = tp.path.segments.last()?;
+        if let syn::PathArguments::AngleBracketed(args) = &seg.arguments {
+            for arg in &args.args {
+                if let syn::GenericArgument::Type(inner) = arg {
+                    return ty_last_ident(inner);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// The inner type `T` of an `Option<T>`, if `ty` is an `Option`.
+fn option_inner_type(ty: &syn::Type) -> Option<&syn::Type> {
+    if let syn::Type::Path(tp) = ty {
+        let seg = tp.path.segments.last()?;
+        if seg.ident != "Option" {
+            return None;
+        }
+        if let syn::PathArguments::AngleBracketed(args) = &seg.arguments {
+            for arg in &args.args {
+                if let syn::GenericArgument::Type(inner) = arg {
+                    return Some(inner);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Infer the fake-data expression for a factory field when `.fake()` is active.
+///
+/// Selection order (per issue #1343):
+/// 1. **Name-based rules** — for `String` targets, the field identifier
+///    (case-insensitive, `contains` unless noted) picks a specialized generator
+///    (`email`, `url`, `title`, `body`, `slug`, …). Numeric/temporal/decimal
+///    fields already map cleanly from their type, so name hints for them
+///    coincide with the type fallback and need no special-casing.
+/// 2. **Type fallback** — the Rust type of the field maps to the natural
+///    generator (`String` → `sentence()`, integers → `int_range`, `bool` →
+///    `boolean()`, `Decimal` → `decimal()`, `DateTime` → `recent_datetime()`,
+///    `Uuid` → `uuid()`, …).
+/// 3. `Option<T>` wraps the inner expression in `Some(..)`.
+///
+/// Returns `None` when no sensible fake value can be produced — the caller then
+/// leaves the field at its `Default::default()` value. This function must NEVER
+/// emit an expression that fails to compile: when unsure, return `None`.
+fn fake_expr_for_field(ident: &syn::Ident, ty: &syn::Type) -> Option<TokenStream> {
+    let raw = ident.to_string();
+    let name = raw.strip_prefix("r#").unwrap_or(&raw).to_ascii_lowercase();
+
+    // Option<T>: fake the inner value, wrap in Some.
+    if let Some(inner) = option_inner_type(ty) {
+        let inner_expr = fake_expr_core(&name, inner)?;
+        return Some(quote! { ::core::option::Option::Some(#inner_expr) });
+    }
+
+    fake_expr_core(&name, ty)
+}
+
+/// Core inference over a non-`Option` target type. See [`fake_expr_for_field`].
+fn fake_expr_core(name: &str, ty: &syn::Type) -> Option<TokenStream> {
+    let last = ty_last_ident(ty)?;
+    match last.as_str() {
+        "String" => Some(fake_string_expr(name)),
+        "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "usize" | "isize" => {
+            let cast = format_ident!("{last}");
+            // Default numeric range covers the name-based hints (count/age/qty →
+            // small non-negative ints).
+            Some(quote! { (::autumn_web::fake::int_range(0, 1000) as #cast) })
+        }
+        "f32" | "f64" => {
+            let cast = format_ident!("{last}");
+            Some(quote! { (::autumn_web::fake::decimal_f64() as #cast) })
+        }
+        "bool" => Some(quote! { ::autumn_web::fake::boolean() }),
+        "Decimal" => Some(quote! { ::autumn_web::fake::decimal() }),
+        "Uuid" => Some(quote! { ::autumn_web::fake::uuid() }),
+        // `recent_datetime()` yields `DateTime<Utc>`, so only fake a `DateTime`
+        // whose timezone parameter is `Utc`. Other zones (e.g. `Local`,
+        // `FixedOffset`) fall through to Default to avoid a type mismatch.
+        "DateTime" if ty_last_generic_ident(ty).as_deref() == Some("Utc") => {
+            Some(quote! { ::autumn_web::fake::recent_datetime() })
+        }
+        "NaiveDateTime" => Some(quote! { ::autumn_web::fake::recent_datetime().naive_utc() }),
+        "NaiveDate" => Some(quote! { ::autumn_web::fake::recent_datetime().date_naive() }),
+        _ => None,
+    }
+}
+
+/// Choose a string generator from the field name (name-based rules for #1343).
+fn fake_string_expr(name: &str) -> TokenStream {
+    if name.contains("email") {
+        quote! { ::autumn_web::fake::email() }
+    } else if name == "username" || name.contains("user_name") {
+        quote! { ::autumn_web::fake::username() }
+    } else if name.contains("url") || name.contains("link") || name.contains("website") {
+        quote! { ::autumn_web::fake::url() }
+    } else if name.contains("slug") {
+        quote! {{
+            let __autumn_slug = ::autumn_web::fake::words(3);
+            __autumn_slug
+                .split_whitespace()
+                .collect::<::std::vec::Vec<&str>>()
+                .join("-")
+        }}
+    } else if name.contains("body")
+        || name.contains("content")
+        || name.contains("description")
+        || name.contains("summary")
+        || name.contains("bio")
+        || name.contains("text")
+    {
+        quote! { ::autumn_web::fake::paragraph() }
+    } else if name == "name" {
+        quote! { ::autumn_web::fake::name() }
+    } else if name.contains("title") || name.contains("name") {
+        quote! { ::autumn_web::fake::words(3) }
+    } else {
+        quote! { ::autumn_web::fake::sentence() }
+    }
+}
+
 /// Validate that every `#[factory_assoc(...)]` attribute contains a valid Ident.
 ///
 /// Returns a compile error token stream on the first malformed attribute so the
@@ -3205,6 +3342,10 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         .flat_map(|f| {
             let ident = f.ident.as_ref().unwrap();
             let ty = &f.ty;
+            // The field-name string recorded in `__autumn_set` when this setter
+            // runs, so `.fake()` skips explicitly-set fields. Must match the
+            // string used by the build/create fake bindings below.
+            let field_lit = ident.to_string();
 
             factory_assoc_type(f).map_or_else(
                 // Normal field: a single setter that assigns directly.
@@ -3213,6 +3354,7 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         #[must_use]
                         pub fn #ident(mut self, val: impl ::core::convert::Into<#ty>) -> Self {
                             self.#ident = val.into();
+                            self.__autumn_set.insert(#field_lit);
                             self
                         }
                     }]
@@ -3223,6 +3365,7 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         #[must_use]
                         pub fn #ident(mut self, val: impl ::core::convert::Into<#ty>) -> Self {
                             self.#ident = ::core::option::Option::Some(val.into());
+                            self.__autumn_set.insert(#field_lit);
                             self
                         }
                     };
@@ -3240,6 +3383,7 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         #[must_use]
                         pub fn #assoc_snake(mut self, val: &#assoc_type) -> Self {
                             self.#ident = ::core::option::Option::Some(val.__autumn_pk());
+                            self.__autumn_set.insert(#field_lit);
                             self
                         }
                     };
@@ -3249,37 +3393,73 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         })
         .collect();
 
-    // build() — assemble NewX.
-    // - Normal fields:  `{ident}: self.{ident}`
-    // - Assoc fields:   `{ident}: self.{ident}.unwrap_or_default()`
-    let factory_build_fields: Vec<TokenStream> = fields_for_new
+    // Per-field value bindings for NON-assoc fields, honoring `.fake()`.
+    //
+    // When the factory is in `.fake()` mode and the field was NOT explicitly set
+    // via its setter, draw a fake value inferred from the field name/type;
+    // otherwise use the value already stored on the factory. Each binding is a
+    // `let {ident} = …;` so both `build()` and `create()` can construct the
+    // record with struct-shorthand (`NewX { {ident}, … }`).
+    //
+    // `.clone()` (rather than moving `self.{ident}`) is required because the
+    // fake branch reads `self.__autumn_fake`/`self.__autumn_set` and the value
+    // is only conditionally consumed. All `NewX` field types are `Clone`.
+    let factory_value_bindings: Vec<TokenStream> = fields_for_new
         .iter()
+        .filter(|f| factory_assoc_type(f).is_none())
         .map(|f| {
-            let ident = &f.ident;
-            if factory_assoc_type(f).is_some() {
-                quote! { #ident: self.#ident.unwrap_or_default() }
-            } else {
-                quote! { #ident: self.#ident }
-            }
+            let ident = f.ident.as_ref().unwrap();
+            let field_lit = ident.to_string();
+            fake_expr_for_field(ident, &f.ty).map_or_else(
+                // No fake expression available for this type: leave the value
+                // as-is (its Default when `.fake()` was requested).
+                || {
+                    quote! {
+                        let #ident = ::core::clone::Clone::clone(&self.#ident);
+                    }
+                },
+                |fake_expr| {
+                    quote! {
+                        let #ident = if self.__autumn_fake
+                            && !self.__autumn_set.contains(#field_lit)
+                        {
+                            #fake_expr
+                        } else {
+                            ::core::clone::Clone::clone(&self.#ident)
+                        };
+                    }
+                },
+            )
+        })
+        .collect();
+
+    // build(): assoc fields resolve to their supplied value or `Default`.
+    let build_assoc_bindings: Vec<TokenStream> = fields_for_new
+        .iter()
+        .filter_map(|f| {
+            factory_assoc_type(f)?;
+            let ident = f.ident.as_ref().unwrap();
+            Some(quote! {
+                let #ident = self.#ident.unwrap_or_default();
+            })
         })
         .collect();
 
     // create() — auto-resolve assoc fields, then insert.
     //
-    // For each assoc field, emit a `let __resolved_{ident}` that either uses the
-    // supplied value or auto-creates the associated model via its factory.
+    // For each assoc field, bind `{ident}` to either the supplied value or an
+    // auto-created associated model's primary key.
     //
-    // A thread-local depth counter guards against cyclic associations: if the
+    // A task-local depth counter guards against cyclic associations: if the
     // chain exceeds 32 levels the factory panics with a clear message rather than
     // overflowing the stack.
-    let assoc_resolutions: Vec<TokenStream> = fields_for_new
+    let create_assoc_bindings: Vec<TokenStream> = fields_for_new
         .iter()
         .filter_map(|f| {
             let assoc_type = factory_assoc_type(f)?;
             let ident = f.ident.as_ref().unwrap();
-            let resolved = format_ident!("__resolved_{ident}");
             Some(quote! {
-                let #resolved = match self.#ident {
+                let #ident = match self.#ident {
                     ::core::option::Option::Some(id) => id,
                     ::core::option::Option::None => {
                         #assoc_type::factory().create(pool).await.__autumn_pk()
@@ -3289,17 +3469,12 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         })
         .collect();
 
-    // NewX construction inside create() uses resolved values for assoc fields.
-    let create_build_fields: Vec<TokenStream> = fields_for_new
+    // Struct-shorthand field list for `NewX { … }` (local bindings named to match).
+    let new_construct_fields: Vec<TokenStream> = fields_for_new
         .iter()
         .map(|f| {
             let ident = f.ident.as_ref().unwrap();
-            if factory_assoc_type(f).is_some() {
-                let resolved = format_ident!("__resolved_{ident}");
-                quote! { #ident: #resolved }
-            } else {
-                quote! { #ident: self.#ident }
-            }
+            quote! { #ident }
         })
         .collect();
 
@@ -3308,10 +3483,11 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         use ::autumn_web::reexports::diesel::prelude::*;
         use ::autumn_web::reexports::diesel_async::RunQueryDsl;
 
-        #(#assoc_resolutions)*
+        #(#factory_value_bindings)*
+        #(#create_assoc_bindings)*
 
         let new_record = #new_name {
-            #(#create_build_fields,)*
+            #(#new_construct_fields,)*
         };
         let mut conn = pool
             .get()
@@ -3380,6 +3556,33 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             ) -> #name {
                 #create_inner_body
             }
+        }
+    };
+
+    // create_many() — persist `count` records, cloning the factory per row so
+    // each iteration takes the same create() path. Under `.fake()`, every row
+    // re-draws its fake fields, yielding distinct rows (and distinct DB-assigned
+    // primary keys). Mirrors `create`'s signature exactly (returns Vec<#name>).
+    let factory_create_many_method = quote! {
+        /// Insert `count` records built from this factory and return them.
+        ///
+        /// The factory is cloned for each row, so with `.fake()` each record
+        /// gets freshly-generated field values. Without `.fake()` the records
+        /// are identical apart from database-assigned primary keys.
+        ///
+        /// Panics if any insert fails.
+        pub async fn create_many(
+            self,
+            count: usize,
+            pool: &::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Pool<
+                ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+            >,
+        ) -> ::std::vec::Vec<#name> {
+            let mut out = ::std::vec::Vec::with_capacity(count);
+            for _ in 0..count {
+                out.push(::core::clone::Clone::clone(&self).create(pool).await);
+            }
+            out
         }
     };
 
@@ -3949,12 +4152,22 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         #[derive(Debug, Clone)]
         #vis struct #factory_name {
             #(#factory_struct_fields,)*
+            /// Names of fields the caller explicitly set via a setter. `.fake()`
+            /// skips these so explicit overrides always win. (#1343)
+            #[doc(hidden)]
+            pub __autumn_set: ::std::collections::HashSet<&'static str>,
+            /// Whether `.fake()` was requested. When true, unset fields are
+            /// filled with generated data at `build()`/`create()` time. (#1343)
+            #[doc(hidden)]
+            pub __autumn_fake: bool,
         }
 
         impl ::core::default::Default for #factory_name {
             fn default() -> Self {
                 Self {
                     #(#factory_default_fields,)*
+                    __autumn_set: ::std::collections::HashSet::new(),
+                    __autumn_fake: false,
                 }
             }
         }
@@ -3962,18 +4175,48 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         impl #factory_name {
             #(#factory_setters)*
 
+            /// Fill every field that was not explicitly set with realistic
+            /// fake data when building. The value is inferred from each field's
+            /// name and type (see `autumn_web::fake`).
+            ///
+            /// This only flips a flag — values are drawn at `build()`/`create()`
+            /// time, so each build produces fresh, varied rows. Set
+            /// `AUTUMN_FAKE_SEED` (or call `autumn_web::fake::reseed`) for
+            /// reproducible output.
+            #[must_use]
+            pub fn fake(mut self) -> Self {
+                self.__autumn_fake = true;
+                self
+            }
+
             /// Build a [`#new_name`] instance from the current factory state.
             ///
             /// Does not touch the database. Use [`#factory_name::create`] to
             /// also persist the record.
             #[must_use]
             pub fn build(self) -> #new_name {
+                #(#factory_value_bindings)*
+                #(#build_assoc_bindings)*
                 #new_name {
-                    #(#factory_build_fields,)*
+                    #(#new_construct_fields,)*
                 }
             }
 
+            /// Build `count` [`#new_name`] instances. With `.fake()` each row is
+            /// re-drawn, so text fields vary across the batch. Without `.fake()`
+            /// the rows are identical copies of the factory state.
+            #[must_use]
+            pub fn build_many(self, count: usize) -> ::std::vec::Vec<#new_name> {
+                let mut out = ::std::vec::Vec::with_capacity(count);
+                for _ in 0..count {
+                    out.push(::core::clone::Clone::clone(&self).build());
+                }
+                out
+            }
+
             #factory_create_method
+
+            #factory_create_many_method
         }
 
         impl #name {

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -4241,6 +4241,15 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         }
 
+        // ── #1343 AC4: fake-seeder registration ─────────────────────────
+        // Register this model's factory so `autumn seed --count N --model M`
+        // (and any seed binary) can generate faked rows by name, without the
+        // user editing `src/bin/seed.rs`. The forwarding macro expands to an
+        // `inventory::submit!` only when autumn-web is built with the `seed`
+        // feature (which implies `db`, and hence `create_many`); otherwise it
+        // expands to nothing, so models compile unchanged when seeding is off.
+        ::autumn_web::__autumn_register_fake_seeder!(#name, stringify!(#name));
+
         // ── Durable commit-hook codec ───────────────────────────────────
         // Hidden durable commit-hook codec. These methods serialize fields
         // individually so public serde visibility attributes do not drop

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -1788,6 +1788,10 @@ fn fake_string_expr(name: &str) -> TokenStream {
         || name.contains("text")
     {
         quote! { ::autumn_web::fake::paragraph() }
+    } else if name.contains("first_name") || name.contains("firstname") {
+        quote! { ::autumn_web::fake::first_name() }
+    } else if name.contains("last_name") || name.contains("lastname") || name.contains("surname") {
+        quote! { ::autumn_web::fake::last_name() }
     } else if name == "name" {
         quote! { ::autumn_web::fake::name() }
     } else if name.contains("title") || name.contains("name") {

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -1729,11 +1729,21 @@ fn fake_expr_core(name: &str, ty: &syn::Type) -> Option<TokenStream> {
     let last = ty_last_ident(ty)?;
     match last.as_str() {
         "String" => Some(fake_string_expr(name)),
-        "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "usize" | "isize" => {
+        "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "u128" | "i128" | "usize"
+        | "isize" => {
             let cast = format_ident!("{last}");
             // Default numeric range covers the name-based hints (count/age/qty →
-            // small non-negative ints).
-            Some(quote! { (::autumn_web::fake::int_range(0, 1000) as #cast) })
+            // small non-negative ints). `int_range` works in `i64`, so pick an
+            // upper bound that both fits `i64` and stays inside the target type:
+            // for the narrow `i8`/`u8` types the default 1000 would overflow the
+            // `as` cast (`1000 as u8 == 232`, `1000 as i8 == -24`), so clamp to
+            // that type's own maximum. All wider types keep the 1000 default.
+            let hi: i64 = match last.as_str() {
+                "i8" => i64::from(i8::MAX),
+                "u8" => i64::from(u8::MAX),
+                _ => 1000,
+            };
+            Some(quote! { (::autumn_web::fake::int_range(0, #hi) as #cast) })
         }
         "f32" | "f64" => {
             let cast = format_ident!("{last}");
@@ -4189,6 +4199,15 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 self
             }
 
+            /// Alias for [`fake`](Self::fake): fill every field that was not
+            /// explicitly set with realistic fake data when building. Provided
+            /// so both spellings from the `.fake()`/`.fake_all()` API read
+            /// naturally (#1343 AC2).
+            #[must_use]
+            pub fn fake_all(self) -> Self {
+                self.fake()
+            }
+
             /// Build a [`#new_name`] instance from the current factory state.
             ///
             /// Does not touch the database. Use [`#factory_name::create`] to
@@ -4392,6 +4411,53 @@ pub fn pascal_to_snake(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Fake integer inference width safety (#1343 FIX4) ──────────────────
+
+    #[test]
+    fn fake_int_ranges_never_truncate_the_cast() {
+        // Narrow types must clamp the range to their own maximum so the `as`
+        // cast can't wrap (`1000 as u8 == 232`, `1000 as i8 == -24`).
+        let expr = |ty: syn::Type| {
+            fake_expr_core("count", &ty)
+                .expect("integer type should infer a fake expr")
+                .to_string()
+        };
+
+        let i8_expr = expr(syn::parse_quote!(i8));
+        assert!(i8_expr.contains("as i8"), "{i8_expr}");
+        assert!(
+            i8_expr.contains("127i64"),
+            "i8 must clamp to i8::MAX: {i8_expr}"
+        );
+
+        let u8_expr = expr(syn::parse_quote!(u8));
+        assert!(u8_expr.contains("as u8"), "{u8_expr}");
+        assert!(
+            u8_expr.contains("255i64"),
+            "u8 must clamp to u8::MAX: {u8_expr}"
+        );
+
+        // Wider types keep the default 1000 upper bound (all fit comfortably).
+        for wide in ["i16", "i32", "i64", "u16", "u32", "u64", "usize", "isize"] {
+            let ty: syn::Type = syn::parse_str(wide).unwrap();
+            let e = expr(ty);
+            assert!(e.contains(&format!("as {wide}")), "{e}");
+            assert!(e.contains("1000"), "{wide} should keep 1000 default: {e}");
+        }
+
+        // 128-bit widths are matched (previously fell through to Default 0).
+        let i128_expr = expr(syn::parse_quote!(i128));
+        assert!(
+            i128_expr.contains("as i128"),
+            "i128 must be matched: {i128_expr}"
+        );
+        let u128_expr = expr(syn::parse_quote!(u128));
+        assert!(
+            u128_expr.contains("as u128"),
+            "u128 must be matched: {u128_expr}"
+        );
+    }
 
     // ── Serde-rename resolution for FormField::value_name (#1135) ─────────
 

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -195,6 +195,8 @@ redis = { workspace = true, optional = true }
 tokio-cron-scheduler.workspace = true
 validator.workspace = true
 uuid = { version = "1", features = ["v4"] }
+rand = "0.9"
+rand_chacha = "0.9"
 chrono = { workspace = true }
 chrono-tz.workspace = true
 rust_decimal.workspace = true

--- a/autumn/src/fake.rs
+++ b/autumn/src/fake.rs
@@ -152,20 +152,27 @@ pub fn name() -> String {
 /// e.g. `"olivianguyen473"`.
 #[must_use]
 pub fn username() -> String {
-    let first = pick(FIRST_NAMES).to_ascii_lowercase();
-    let last = pick(LAST_NAMES).to_ascii_lowercase();
-    let n: u32 = with_rng(|r| r.random_range(0..1000));
-    format!("{first}{last}{n}")
+    // Draw both names and the digits under a single lock acquisition.
+    with_rng(|r| {
+        let first = FIRST_NAMES[r.random_range(0..FIRST_NAMES.len())].to_ascii_lowercase();
+        let last = LAST_NAMES[r.random_range(0..LAST_NAMES.len())].to_ascii_lowercase();
+        let n: u32 = r.random_range(0..1000);
+        format!("{first}{last}{n}")
+    })
 }
 
 /// A random email address containing exactly one `@`, e.g.
 /// `"olivia473@example.com"`.
 #[must_use]
 pub fn email() -> String {
-    let first = pick(FIRST_NAMES).to_ascii_lowercase();
-    let n: u32 = with_rng(|r| r.random_range(0..1000));
-    let domain = pick(DOMAINS);
-    format!("{first}{n}@{domain}")
+    // Local part (name + digits) and domain are drawn under one lock; the single
+    // `@` separator keeps exactly one `@` in the result.
+    with_rng(|r| {
+        let first = FIRST_NAMES[r.random_range(0..FIRST_NAMES.len())].to_ascii_lowercase();
+        let n: u32 = r.random_range(0..1000);
+        let domain = DOMAINS[r.random_range(0..DOMAINS.len())];
+        format!("{first}{n}@{domain}")
+    })
 }
 
 // ── Text ────────────────────────────────────────────────────────────────────
@@ -179,13 +186,20 @@ pub fn word() -> String {
 /// `n` space-joined lorem words. Returns an empty string when `n == 0`.
 #[must_use]
 pub fn words(n: usize) -> String {
-    let mut out = String::new();
-    for i in 0..n {
-        if i > 0 {
-            out.push(' ');
-        }
-        out.push_str(pick(LOREM));
+    if n == 0 {
+        return String::new();
     }
+    // Rough capacity: average lorem word (~6 chars) plus a joining space.
+    let mut out = String::with_capacity(n * 8);
+    // Build the whole string under a single lock acquisition.
+    with_rng(|r| {
+        for i in 0..n {
+            if i > 0 {
+                out.push(' ');
+            }
+            out.push_str(LOREM[r.random_range(0..LOREM.len())]);
+        }
+    });
     out
 }
 
@@ -220,7 +234,12 @@ pub fn paragraph() -> String {
 /// A random URL beginning with `"https://"`.
 #[must_use]
 pub fn url() -> String {
-    format!("https://{}/{}", pick(DOMAINS), pick(LOREM))
+    // Pick the domain and path segment under one lock acquisition.
+    with_rng(|r| {
+        let domain = DOMAINS[r.random_range(0..DOMAINS.len())];
+        let path = LOREM[r.random_range(0..LOREM.len())];
+        format!("https://{domain}/{path}")
+    })
 }
 
 /// A random boolean.

--- a/autumn/src/fake.rs
+++ b/autumn/src/fake.rs
@@ -9,7 +9,7 @@
 //! The generator can run in two modes:
 //!
 //! - **Deterministic**: when the `AUTUMN_FAKE_SEED` environment variable is set
-//!   to a `u64`, or when [`reseed`] is called explicitly, the thread-local RNG
+//!   to a `u64`, or when [`reseed`] is called explicitly, the process-global RNG
 //!   is seeded from that value. The exact same sequence of calls then produces
 //!   the exact same values on every run — ideal for golden tests and
 //!   reproducible fixtures. In this mode time-based helpers such as
@@ -20,8 +20,20 @@
 //!
 //! The RNG is [`rand_chacha::ChaCha8Rng`], chosen because ChaCha is portable and
 //! reproducible across platforms given the same seed.
+//!
+//! # Why process-global (not thread-local)
+//!
+//! The generator is a single process-global RNG behind a [`Mutex`], **not** a
+//! per-thread one. `#[autumn_web::main]` runs on a multi-thread tokio runtime,
+//! and a faked `create_many` awaits a pooled connection between rows, so the
+//! driving task freely migrates between worker threads mid-run. A thread-local
+//! RNG would let a freshly-touched thread lazily re-seed itself from the *same*
+//! `AUTUMN_FAKE_SEED` and restart the identical sequence — producing duplicate
+//! rows and destroying reproducibility under a seed. Drawing every value from
+//! one shared sequence keeps a seeded run deterministic and distinct no matter
+//! how tasks are scheduled across threads.
 
-use std::cell::RefCell;
+use std::sync::{Mutex, OnceLock, PoisonError};
 
 use chrono::{DateTime, Utc};
 use rand::{Rng, RngCore, SeedableRng};
@@ -29,7 +41,7 @@ use rand_chacha::ChaCha8Rng;
 use rust_decimal::Decimal;
 use uuid::Uuid;
 
-/// Per-thread generator state.
+/// Process-global generator state.
 struct FakeState {
     rng: ChaCha8Rng,
     /// True when the RNG was seeded deterministically (via `AUTUMN_FAKE_SEED` or
@@ -37,24 +49,25 @@ struct FakeState {
     deterministic: bool,
 }
 
-thread_local! {
-    static RNG: RefCell<Option<FakeState>> = const { RefCell::new(None) };
-}
+/// The one shared generator, initialized on first use. All threads and tasks
+/// draw from this single sequence so a seeded run is reproducible regardless of
+/// how work is scheduled across the multi-thread runtime.
+static RNG: OnceLock<Mutex<FakeState>> = OnceLock::new();
 
 /// The fixed base instant used by time helpers in deterministic mode.
 /// Chosen as `2024-01-01T00:00:00Z`.
 const DETERMINISTIC_BASE_EPOCH_SECS: i64 = 1_704_067_200;
 
-/// Ensure the thread-local generator is initialized, seeding it on first use.
+/// Get the process-global generator, initializing it on first use.
 ///
 /// Seeds deterministically from `AUTUMN_FAKE_SEED` when that env var parses as a
 /// `u64`; otherwise seeds from OS entropy.
-fn ensure_init(cell: &mut Option<FakeState>) {
-    if cell.is_none() {
+fn global() -> &'static Mutex<FakeState> {
+    RNG.get_or_init(|| {
         let seed = std::env::var("AUTUMN_FAKE_SEED")
             .ok()
             .and_then(|s| s.trim().parse::<u64>().ok());
-        *cell = Some(seed.map_or_else(
+        Mutex::new(seed.map_or_else(
             || FakeState {
                 rng: ChaCha8Rng::from_os_rng(),
                 deterministic: false,
@@ -63,39 +76,49 @@ fn ensure_init(cell: &mut Option<FakeState>) {
                 rng: ChaCha8Rng::seed_from_u64(seed),
                 deterministic: true,
             },
-        ));
-    }
+        ))
+    })
 }
 
-/// Run `f` with a mutable reference to the thread-local RNG.
+/// Lock the global state, recovering the inner value if a previous holder
+/// panicked (a poisoned RNG is not a correctness hazard — the bytes are still
+/// usable — so we never want to cascade a panic across unrelated draws).
+fn lock_state() -> std::sync::MutexGuard<'static, FakeState> {
+    global().lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// Run `f` with a mutable reference to the process-global RNG.
 fn with_rng<R>(f: impl FnOnce(&mut ChaCha8Rng) -> R) -> R {
-    RNG.with(|cell| {
-        let mut borrow = cell.borrow_mut();
-        ensure_init(&mut borrow);
-        f(&mut borrow.as_mut().expect("rng initialized").rng)
-    })
+    let mut state = lock_state();
+    f(&mut state.rng)
 }
 
 /// Whether the generator is currently in deterministic mode.
 fn is_deterministic() -> bool {
-    RNG.with(|cell| {
-        let mut borrow = cell.borrow_mut();
-        ensure_init(&mut borrow);
-        borrow.as_ref().expect("rng initialized").deterministic
-    })
+    lock_state().deterministic
 }
 
-/// Force the thread-local generator into deterministic mode seeded from `seed`.
+/// Force the process-global generator into deterministic mode seeded from
+/// `seed`.
 ///
 /// After this call, a fixed sequence of generator calls yields a fixed sequence
-/// of values. Primarily intended for tests and reproducible fixtures.
+/// of values, across every thread and task in the process. Primarily intended
+/// for tests and reproducible fixtures.
 pub fn reseed(seed: u64) {
-    RNG.with(|cell| {
-        *cell.borrow_mut() = Some(FakeState {
-            rng: ChaCha8Rng::seed_from_u64(seed),
-            deterministic: true,
-        });
-    });
+    let mut state = lock_state();
+    state.rng = ChaCha8Rng::seed_from_u64(seed);
+    state.deterministic = true;
+}
+
+/// Serializes `reseed`-based tests so the process-global RNG is not reseeded by
+/// a concurrently-running test in the middle of another test's draw sequence.
+///
+/// Hold the returned guard for the duration of any test that reseeds and then
+/// asserts on the exact values drawn. Test-only; not part of the stable API.
+#[doc(hidden)]
+pub fn test_serial_guard() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: Mutex<()> = Mutex::new(());
+    LOCK.lock().unwrap_or_else(PoisonError::into_inner)
 }
 
 /// Pick a random element from a non-empty static list.

--- a/autumn/src/fake.rs
+++ b/autumn/src/fake.rs
@@ -1,0 +1,686 @@
+//! Deterministic fake-data generation.
+//!
+//! This module backs the factory `.fake()` feature (issue #1343): it produces
+//! realistic-looking values — names, emails, sentences, timestamps, and so on —
+//! drawn from a per-thread pseudo-random generator.
+//!
+//! # Determinism
+//!
+//! The generator can run in two modes:
+//!
+//! - **Deterministic**: when the `AUTUMN_FAKE_SEED` environment variable is set
+//!   to a `u64`, or when [`reseed`] is called explicitly, the thread-local RNG
+//!   is seeded from that value. The exact same sequence of calls then produces
+//!   the exact same values on every run — ideal for golden tests and
+//!   reproducible fixtures. In this mode time-based helpers such as
+//!   [`recent_datetime`] anchor to a fixed base instant rather than the wall
+//!   clock, so even timestamps are reproducible.
+//! - **Random**: with no seed configured, the RNG is seeded from OS entropy and
+//!   output varies per run.
+//!
+//! The RNG is [`rand_chacha::ChaCha8Rng`], chosen because ChaCha is portable and
+//! reproducible across platforms given the same seed.
+
+use std::cell::RefCell;
+
+use chrono::{DateTime, Utc};
+use rand::{Rng, RngCore, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use rust_decimal::Decimal;
+use uuid::Uuid;
+
+/// Per-thread generator state.
+struct FakeState {
+    rng: ChaCha8Rng,
+    /// True when the RNG was seeded deterministically (via `AUTUMN_FAKE_SEED` or
+    /// [`reseed`]). Drives whether time helpers anchor to a fixed instant.
+    deterministic: bool,
+}
+
+thread_local! {
+    static RNG: RefCell<Option<FakeState>> = const { RefCell::new(None) };
+}
+
+/// The fixed base instant used by time helpers in deterministic mode.
+/// Chosen as `2024-01-01T00:00:00Z`.
+const DETERMINISTIC_BASE_EPOCH_SECS: i64 = 1_704_067_200;
+
+/// Ensure the thread-local generator is initialized, seeding it on first use.
+///
+/// Seeds deterministically from `AUTUMN_FAKE_SEED` when that env var parses as a
+/// `u64`; otherwise seeds from OS entropy.
+fn ensure_init(cell: &mut Option<FakeState>) {
+    if cell.is_none() {
+        let seed = std::env::var("AUTUMN_FAKE_SEED")
+            .ok()
+            .and_then(|s| s.trim().parse::<u64>().ok());
+        *cell = Some(seed.map_or_else(
+            || FakeState {
+                rng: ChaCha8Rng::from_os_rng(),
+                deterministic: false,
+            },
+            |seed| FakeState {
+                rng: ChaCha8Rng::seed_from_u64(seed),
+                deterministic: true,
+            },
+        ));
+    }
+}
+
+/// Run `f` with a mutable reference to the thread-local RNG.
+fn with_rng<R>(f: impl FnOnce(&mut ChaCha8Rng) -> R) -> R {
+    RNG.with(|cell| {
+        let mut borrow = cell.borrow_mut();
+        ensure_init(&mut borrow);
+        f(&mut borrow.as_mut().expect("rng initialized").rng)
+    })
+}
+
+/// Whether the generator is currently in deterministic mode.
+fn is_deterministic() -> bool {
+    RNG.with(|cell| {
+        let mut borrow = cell.borrow_mut();
+        ensure_init(&mut borrow);
+        borrow.as_ref().expect("rng initialized").deterministic
+    })
+}
+
+/// Force the thread-local generator into deterministic mode seeded from `seed`.
+///
+/// After this call, a fixed sequence of generator calls yields a fixed sequence
+/// of values. Primarily intended for tests and reproducible fixtures.
+pub fn reseed(seed: u64) {
+    RNG.with(|cell| {
+        *cell.borrow_mut() = Some(FakeState {
+            rng: ChaCha8Rng::seed_from_u64(seed),
+            deterministic: true,
+        });
+    });
+}
+
+/// Pick a random element from a non-empty static list.
+fn pick(list: &[&'static str]) -> &'static str {
+    debug_assert!(!list.is_empty(), "fake: word list must be non-empty");
+    let idx = with_rng(|r| r.random_range(0..list.len()));
+    list[idx]
+}
+
+// ── People ──────────────────────────────────────────────────────────────────
+
+/// A random first name, e.g. `"Olivia"`.
+#[must_use]
+pub fn first_name() -> String {
+    pick(FIRST_NAMES).to_string()
+}
+
+/// A random last name, e.g. `"Nguyen"`.
+#[must_use]
+pub fn last_name() -> String {
+    pick(LAST_NAMES).to_string()
+}
+
+/// A random full name (`"First Last"`).
+#[must_use]
+pub fn name() -> String {
+    format!("{} {}", first_name(), last_name())
+}
+
+/// A lowercase, space-free username derived from a name plus digits,
+/// e.g. `"olivianguyen473"`.
+#[must_use]
+pub fn username() -> String {
+    let first = pick(FIRST_NAMES).to_ascii_lowercase();
+    let last = pick(LAST_NAMES).to_ascii_lowercase();
+    let n: u32 = with_rng(|r| r.random_range(0..1000));
+    format!("{first}{last}{n}")
+}
+
+/// A random email address containing exactly one `@`, e.g.
+/// `"olivia473@example.com"`.
+#[must_use]
+pub fn email() -> String {
+    let first = pick(FIRST_NAMES).to_ascii_lowercase();
+    let n: u32 = with_rng(|r| r.random_range(0..1000));
+    let domain = pick(DOMAINS);
+    format!("{first}{n}@{domain}")
+}
+
+// ── Text ────────────────────────────────────────────────────────────────────
+
+/// A single lorem-style word.
+#[must_use]
+pub fn word() -> String {
+    pick(LOREM).to_string()
+}
+
+/// `n` space-joined lorem words. Returns an empty string when `n == 0`.
+#[must_use]
+pub fn words(n: usize) -> String {
+    let mut out = String::new();
+    for i in 0..n {
+        if i > 0 {
+            out.push(' ');
+        }
+        out.push_str(pick(LOREM));
+    }
+    out
+}
+
+/// A capitalized sentence of several words ending in `'.'`.
+#[must_use]
+pub fn sentence() -> String {
+    let n = with_rng(|r| r.random_range(4..12));
+    let mut s = words(n);
+    if let Some(head) = s.get_mut(0..1) {
+        head.make_ascii_uppercase();
+    }
+    s.push('.');
+    s
+}
+
+/// A paragraph of several sentences joined by spaces.
+#[must_use]
+pub fn paragraph() -> String {
+    let n = with_rng(|r| r.random_range(3..7));
+    let mut out = String::new();
+    for i in 0..n {
+        if i > 0 {
+            out.push(' ');
+        }
+        out.push_str(&sentence());
+    }
+    out
+}
+
+// ── Scalars ─────────────────────────────────────────────────────────────────
+
+/// A random URL beginning with `"https://"`.
+#[must_use]
+pub fn url() -> String {
+    format!("https://{}/{}", pick(DOMAINS), pick(LOREM))
+}
+
+/// A random boolean.
+#[must_use]
+pub fn boolean() -> bool {
+    with_rng(|r| r.random_bool(0.5))
+}
+
+/// A random integer within the inclusive range `[lo, hi]`.
+///
+/// If `lo >= hi`, returns `lo` (so the result is always within `[lo, hi]`).
+#[must_use]
+pub fn int_range(lo: i64, hi: i64) -> i64 {
+    if lo >= hi {
+        return lo;
+    }
+    with_rng(|r| r.random_range(lo..=hi))
+}
+
+/// A random non-negative [`Decimal`] with two fractional digits (0.00–9999.99).
+#[must_use]
+pub fn decimal() -> Decimal {
+    let cents = with_rng(|r| r.random_range(0..1_000_000_i64));
+    Decimal::new(cents, 2)
+}
+
+/// A random `f64` in `[0, 10000)`, for `f32`/`f64` fields.
+#[must_use]
+pub fn decimal_f64() -> f64 {
+    with_rng(|r| r.random_range(0.0..10_000.0))
+}
+
+/// A timestamp within roughly the last 30 days.
+///
+/// In deterministic mode the offset is subtracted from a fixed base instant
+/// (`2024-01-01T00:00:00Z`) so golden data is reproducible; otherwise it is
+/// subtracted from [`Utc::now`].
+#[must_use]
+pub fn recent_datetime() -> DateTime<Utc> {
+    const THIRTY_DAYS_SECS: i64 = 30 * 24 * 60 * 60;
+    let offset = with_rng(|r| r.random_range(0..THIRTY_DAYS_SECS));
+    // In deterministic mode, anchor to a fixed instant so timestamps reproduce.
+    // `UNIX_EPOCH + N seconds` is infallible (no panic path).
+    let base = if is_deterministic() {
+        DateTime::<Utc>::UNIX_EPOCH + chrono::Duration::seconds(DETERMINISTIC_BASE_EPOCH_SECS)
+    } else {
+        Utc::now()
+    };
+    base - chrono::Duration::seconds(offset)
+}
+
+/// A random v4 UUID drawn from the seeded RNG (so it is reproducible under a
+/// fixed seed, unlike [`Uuid::new_v4`] which uses OS entropy directly).
+#[must_use]
+pub fn uuid() -> Uuid {
+    let mut bytes = [0u8; 16];
+    with_rng(|r| r.fill_bytes(&mut bytes));
+    // Set the version (4) and variant (RFC 4122) bits.
+    bytes[6] = (bytes[6] & 0x0F) | 0x40;
+    bytes[8] = (bytes[8] & 0x3F) | 0x80;
+    Uuid::from_bytes(bytes)
+}
+
+// ── Word lists ──────────────────────────────────────────────────────────────
+// Bundled static lists, sized so name()/email()/sentence() have high
+// cardinality (AC3). ~120 first names, ~120 last names, ~150 lorem words.
+
+/// First names (~120).
+static FIRST_NAMES: &[&str] = &[
+    "Olivia",
+    "Liam",
+    "Emma",
+    "Noah",
+    "Ava",
+    "Oliver",
+    "Sophia",
+    "Elijah",
+    "Isabella",
+    "James",
+    "Mia",
+    "William",
+    "Amelia",
+    "Benjamin",
+    "Harper",
+    "Lucas",
+    "Evelyn",
+    "Henry",
+    "Abigail",
+    "Alexander",
+    "Emily",
+    "Mason",
+    "Elizabeth",
+    "Michael",
+    "Sofia",
+    "Ethan",
+    "Avery",
+    "Daniel",
+    "Ella",
+    "Jacob",
+    "Scarlett",
+    "Logan",
+    "Grace",
+    "Jackson",
+    "Chloe",
+    "Levi",
+    "Victoria",
+    "Sebastian",
+    "Riley",
+    "Mateo",
+    "Aria",
+    "Jack",
+    "Lily",
+    "Owen",
+    "Aubrey",
+    "Theodore",
+    "Zoey",
+    "Aiden",
+    "Penelope",
+    "Samuel",
+    "Lillian",
+    "Joseph",
+    "Addison",
+    "John",
+    "Layla",
+    "David",
+    "Natalie",
+    "Wyatt",
+    "Camila",
+    "Matthew",
+    "Hannah",
+    "Luke",
+    "Brooklyn",
+    "Asher",
+    "Zoe",
+    "Carter",
+    "Nora",
+    "Julian",
+    "Leah",
+    "Grayson",
+    "Savannah",
+    "Leo",
+    "Audrey",
+    "Jayden",
+    "Claire",
+    "Gabriel",
+    "Eleanor",
+    "Isaac",
+    "Skylar",
+    "Lincoln",
+    "Ellie",
+    "Anthony",
+    "Samantha",
+    "Hudson",
+    "Stella",
+    "Dylan",
+    "Paisley",
+    "Ezra",
+    "Violet",
+    "Thomas",
+    "Mila",
+    "Charles",
+    "Allison",
+    "Christopher",
+    "Alexa",
+    "Jaxon",
+    "Anna",
+    "Maverick",
+    "Hazel",
+    "Josiah",
+    "Aaliyah",
+    "Isaiah",
+    "Ariana",
+    "Andrew",
+    "Gabriella",
+    "Elias",
+    "Alice",
+    "Joshua",
+    "Sarah",
+    "Nathan",
+    "Ruby",
+    "Caleb",
+    "Eva",
+    "Ryan",
+    "Serenity",
+    "Adrian",
+    "Autumn",
+    "Miles",
+    "Quinn",
+    "Eli",
+    "Nova",
+];
+
+/// Last names (~120).
+static LAST_NAMES: &[&str] = &[
+    "Smith",
+    "Johnson",
+    "Williams",
+    "Brown",
+    "Jones",
+    "Garcia",
+    "Miller",
+    "Davis",
+    "Rodriguez",
+    "Martinez",
+    "Hernandez",
+    "Lopez",
+    "Gonzalez",
+    "Wilson",
+    "Anderson",
+    "Thomas",
+    "Taylor",
+    "Moore",
+    "Jackson",
+    "Martin",
+    "Lee",
+    "Perez",
+    "Thompson",
+    "White",
+    "Harris",
+    "Sanchez",
+    "Clark",
+    "Ramirez",
+    "Lewis",
+    "Robinson",
+    "Walker",
+    "Young",
+    "Allen",
+    "King",
+    "Wright",
+    "Scott",
+    "Torres",
+    "Nguyen",
+    "Hill",
+    "Flores",
+    "Green",
+    "Adams",
+    "Nelson",
+    "Baker",
+    "Hall",
+    "Rivera",
+    "Campbell",
+    "Mitchell",
+    "Carter",
+    "Roberts",
+    "Gomez",
+    "Phillips",
+    "Evans",
+    "Turner",
+    "Diaz",
+    "Parker",
+    "Cruz",
+    "Edwards",
+    "Collins",
+    "Reyes",
+    "Stewart",
+    "Morris",
+    "Morales",
+    "Murphy",
+    "Cook",
+    "Rogers",
+    "Gutierrez",
+    "Ortiz",
+    "Morgan",
+    "Cooper",
+    "Peterson",
+    "Bailey",
+    "Reed",
+    "Kelly",
+    "Howard",
+    "Ramos",
+    "Kim",
+    "Cox",
+    "Ward",
+    "Richardson",
+    "Watson",
+    "Brooks",
+    "Chavez",
+    "Wood",
+    "James",
+    "Bennett",
+    "Gray",
+    "Mendoza",
+    "Ruiz",
+    "Hughes",
+    "Price",
+    "Alvarez",
+    "Castillo",
+    "Sanders",
+    "Patel",
+    "Myers",
+    "Long",
+    "Ross",
+    "Foster",
+    "Jimenez",
+    "Powell",
+    "Jenkins",
+    "Perry",
+    "Russell",
+    "Sullivan",
+    "Bell",
+    "Coleman",
+    "Butler",
+    "Henderson",
+    "Barnes",
+    "Gonzales",
+    "Fisher",
+    "Vasquez",
+    "Simmons",
+    "Romero",
+    "Jordan",
+    "Patterson",
+    "Alexander",
+    "Hamilton",
+    "Graham",
+    "Reynolds",
+];
+
+/// Lorem-ipsum vocabulary (~150).
+static LOREM: &[&str] = &[
+    "lorem",
+    "ipsum",
+    "dolor",
+    "sit",
+    "amet",
+    "consectetur",
+    "adipiscing",
+    "elit",
+    "sed",
+    "do",
+    "eiusmod",
+    "tempor",
+    "incididunt",
+    "ut",
+    "labore",
+    "et",
+    "dolore",
+    "magna",
+    "aliqua",
+    "enim",
+    "ad",
+    "minim",
+    "veniam",
+    "quis",
+    "nostrud",
+    "exercitation",
+    "ullamco",
+    "laboris",
+    "nisi",
+    "aliquip",
+    "ex",
+    "ea",
+    "commodo",
+    "consequat",
+    "duis",
+    "aute",
+    "irure",
+    "in",
+    "reprehenderit",
+    "voluptate",
+    "velit",
+    "esse",
+    "cillum",
+    "eu",
+    "fugiat",
+    "nulla",
+    "pariatur",
+    "excepteur",
+    "sint",
+    "occaecat",
+    "cupidatat",
+    "non",
+    "proident",
+    "sunt",
+    "culpa",
+    "qui",
+    "officia",
+    "deserunt",
+    "mollit",
+    "anim",
+    "id",
+    "est",
+    "laborum",
+    "perspiciatis",
+    "unde",
+    "omnis",
+    "iste",
+    "natus",
+    "error",
+    "voluptatem",
+    "accusantium",
+    "doloremque",
+    "laudantium",
+    "totam",
+    "rem",
+    "aperiam",
+    "eaque",
+    "ipsa",
+    "quae",
+    "ab",
+    "illo",
+    "inventore",
+    "veritatis",
+    "quasi",
+    "architecto",
+    "beatae",
+    "vitae",
+    "dicta",
+    "explicabo",
+    "nemo",
+    "ipsam",
+    "quia",
+    "voluptas",
+    "aspernatur",
+    "aut",
+    "odit",
+    "fugit",
+    "consequuntur",
+    "magni",
+    "dolores",
+    "eos",
+    "ratione",
+    "sequi",
+    "nesciunt",
+    "neque",
+    "porro",
+    "quisquam",
+    "dolorem",
+    "adipisci",
+    "numquam",
+    "eius",
+    "modi",
+    "tempora",
+    "incidunt",
+    "magnam",
+    "quaerat",
+    "voluptatem",
+    "minus",
+    "quod",
+    "maxime",
+    "placeat",
+    "facere",
+    "possimus",
+    "assumenda",
+    "repellendus",
+    "temporibus",
+    "quibusdam",
+    "officiis",
+    "debitis",
+    "rerum",
+    "necessitatibus",
+    "saepe",
+    "eveniet",
+    "voluptates",
+    "repudiandae",
+    "recusandae",
+    "itaque",
+    "earum",
+    "hic",
+    "tenetur",
+    "sapiente",
+    "delectus",
+    "reiciendis",
+    "voluptatibus",
+    "maiores",
+    "alias",
+    "perferendis",
+    "doloribus",
+    "asperiores",
+    "repellat",
+];
+
+/// Email/URL domains (mixes several second-level names and TLDs).
+static DOMAINS: &[&str] = &[
+    "example.com",
+    "example.org",
+    "example.net",
+    "test.com",
+    "mail.com",
+    "acme.io",
+    "globex.dev",
+    "initech.co",
+    "umbrella.app",
+    "hooli.tech",
+    "stark.io",
+    "wayne.net",
+];

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -391,6 +391,50 @@ pub mod payload_version;
 pub mod runtime_config;
 #[cfg(feature = "seed")]
 pub mod seed;
+
+// ── #1343 AC4: fake-seeder registration forwarding ──────────────────────────
+//
+// `#[model]` emits a call to `autumn_web::__autumn_register_fake_seeder!` for
+// every model so `autumn seed --count N --model M` can find and run the model's
+// factory without the user editing `src/bin/seed.rs`. The registration must
+// exist *exactly* when `autumn_web::seed::FakeSeeder` and the db-backed
+// `create_many` do — i.e. when this crate is built with the `seed` feature.
+//
+// A downstream `#[cfg(feature = "seed")]` in the emitted code would test the
+// *application* crate's features, not autumn-web's, so it can't be used
+// directly. Instead we forward through a `#[macro_export]` macro whose two
+// cfg-gated definitions are resolved against *autumn-web's* features at the
+// point autumn-web is compiled: the real `inventory::submit!` when `seed` is on,
+// and a no-op otherwise. This keeps models compiling unchanged when seeding is
+// disabled (e.g. autumn-web's own default-feature test build).
+
+/// Register a model's factory as a CLI-callable fake seeder (internal; invoked
+/// by `#[model]`). Expands to an `inventory::submit!` of a
+/// [`seed::FakeSeeder`](crate::seed::FakeSeeder).
+#[cfg(feature = "seed")]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __autumn_register_fake_seeder {
+    ($model:ty, $name:expr) => {
+        $crate::reexports::inventory::submit! {
+            $crate::seed::FakeSeeder {
+                model: $name,
+                run: |__pool, __count| ::std::boxed::Box::pin(async move {
+                    <$model>::factory().fake().create_many(__count, __pool).await.len()
+                }),
+            }
+        }
+    };
+}
+
+/// No-op fake-seeder registration (internal): emitted when autumn-web is built
+/// without the `seed` feature, so `#[model]` compiles unchanged.
+#[cfg(not(feature = "seed"))]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __autumn_register_fake_seeder {
+    ($model:ty, $name:expr) => {};
+}
 /// Widget story gallery (issue #1526).
 ///
 /// Browsable `/_stories` UI plus a CI anti-rot registry of zero-arg widget

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -97,6 +97,8 @@ pub mod error;
 #[cfg(feature = "maud")]
 pub mod error_pages;
 pub mod extract;
+/// Deterministic fake-data generation backing factory `.fake()` support.
+pub mod fake;
 pub mod feed;
 /// View-layer value formatting helpers (currency, delimited numbers,
 /// pluralize, truncate, relative/absolute dates) for Maud templates.

--- a/autumn/src/seed.rs
+++ b/autumn/src/seed.rs
@@ -287,6 +287,14 @@ pub enum FakeSeedError {
         /// when none are registered).
         available: String,
     },
+
+    /// The `AUTUMN_SEED_COUNT` value forwarded by `autumn seed --count` did not
+    /// parse as a non-negative integer.
+    #[error("invalid AUTUMN_SEED_COUNT {value:?}: expected a non-negative integer")]
+    InvalidCount {
+        /// The raw `AUTUMN_SEED_COUNT` value that failed to parse.
+        value: String,
+    },
 }
 
 /// The names of every registered faked model, sorted, for diagnostics.
@@ -337,6 +345,45 @@ pub async fn fake_seed_model(
         requested: name.to_string(),
         available,
     })
+}
+
+/// Handle a fake-seed request forwarded by `autumn seed --count N --model M`, if
+/// one is present.
+///
+/// `autumn seed --count/--model` forwards the request as the
+/// `AUTUMN_SEED_COUNT` and `AUTUMN_SEED_MODEL` environment variables. This
+/// helper reads them and, when **both** are set, generates that many faked rows
+/// for the named model via [`fake_seed_model`] and prints a one-line summary.
+///
+/// The dispatch lives here — in versioned framework code — rather than being
+/// copied into every generated `src/bin/seed.rs`, so the scaffolded seed binary
+/// is a single call to this function. Fixes/extensions to the flag handling
+/// ship with autumn-web instead of requiring every project to re-scaffold.
+///
+/// Returns:
+/// - `Ok(true)` — a request was present and handled; the caller should return
+///   from its seed `main` without running its hand-written body.
+/// - `Ok(false)` — no request (neither var set); the caller runs its own body.
+///
+/// # Errors
+///
+/// Returns [`FakeSeedError::InvalidCount`] when `AUTUMN_SEED_COUNT` is set but
+/// does not parse as a non-negative integer, or [`FakeSeedError::UnknownModel`]
+/// when `AUTUMN_SEED_MODEL` names no registered `#[model]`.
+pub async fn maybe_fake_seed(pool: &Pool<AsyncPgConnection>) -> Result<bool, FakeSeedError> {
+    let (Ok(model), Ok(count)) = (
+        std::env::var("AUTUMN_SEED_MODEL"),
+        std::env::var("AUTUMN_SEED_COUNT"),
+    ) else {
+        return Ok(false);
+    };
+    let count: usize = count
+        .trim()
+        .parse()
+        .map_err(|_| FakeSeedError::InvalidCount { value: count })?;
+    let inserted = fake_seed_model(&model, count, pool).await?;
+    println!("Inserted {inserted} faked `{model}` row(s).");
+    Ok(true)
 }
 
 // ── #1343 AC4: fake-seeder registry test fixture ────────────────────────────
@@ -404,6 +451,58 @@ mod tests {
         assert!(
             msg.contains("DummyFakeSeederModel"),
             "error should list available registered models, got: {msg}"
+        );
+    }
+
+    // ── maybe_fake_seed dispatch (#1343 AC4 centralization) ────────────────
+
+    /// A lazily-built pool (deadpool does not connect until first use), so these
+    /// tests exercise `maybe_fake_seed`'s pre-connection branches without a live
+    /// database.
+    fn lazy_pool() -> Pool<AsyncPgConnection> {
+        crate::db::create_pool(&DatabaseConfig {
+            primary_url: Some("postgres://localhost/unused".to_string()),
+            ..DatabaseConfig::default()
+        })
+        .expect("pool builds")
+        .expect("url present => Some(pool)")
+    }
+
+    #[test]
+    fn maybe_fake_seed_returns_false_when_env_unset() {
+        let pool = lazy_pool();
+        temp_env::with_vars(
+            [
+                ("AUTUMN_SEED_MODEL", None::<&str>),
+                ("AUTUMN_SEED_COUNT", None::<&str>),
+            ],
+            || {
+                let handled = futures::executor::block_on(maybe_fake_seed(&pool))
+                    .expect("no request is not an error");
+                assert!(
+                    !handled,
+                    "with no fake request the caller must run its own seed body"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn maybe_fake_seed_errors_on_non_integer_count() {
+        let pool = lazy_pool();
+        temp_env::with_vars(
+            [
+                ("AUTUMN_SEED_MODEL", Some("DummyFakeSeederModel")),
+                ("AUTUMN_SEED_COUNT", Some("not-a-number")),
+            ],
+            || {
+                let err = futures::executor::block_on(maybe_fake_seed(&pool))
+                    .expect_err("a non-integer count must be an error, not a silent no-op");
+                assert!(
+                    matches!(err, FakeSeedError::InvalidCount { .. }),
+                    "expected InvalidCount, got: {err:?}"
+                );
+            },
         );
     }
 

--- a/autumn/src/seed.rs
+++ b/autumn/src/seed.rs
@@ -20,6 +20,40 @@
 //!     println!("Seed complete (profile: {})", ctx.profile());
 //! }
 //! ```
+//!
+//! # Faking data (issue #1343)
+//!
+//! Any `#[autumn_web::model]` gets a factory whose `.fake()` fills unset fields
+//! with realistic data. Populate 100+ rows in a single line to exercise
+//! pagination and search:
+//!
+//! ```no_run
+//! use autumn_web::seed::SeedContext;
+//!
+//! autumn_web::reexports::diesel::table! {
+//!     posts (id) { id -> Int8, title -> Text, body -> Text }
+//! }
+//!
+//! #[autumn_web::model(table = "posts")]
+//! struct Post {
+//!     #[id]
+//!     id: i64,
+//!     title: String,
+//!     body: String,
+//! }
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     let ctx = SeedContext::build().expect("seed context");
+//!
+//!     // 200 faked posts, each with distinct fake title/body:
+//!     Post::factory().fake().create_many(200, ctx.pool()).await;
+//! }
+//! ```
+//!
+//! The same registry powers `autumn seed --count 200 --model Post`, which drives
+//! a model's factory by name (via [`fake_seed_model`]) without editing the seed
+//! binary at all.
 
 use std::path::Path;
 
@@ -27,6 +61,7 @@ use crate::config::DatabaseConfig;
 use crate::db::create_pool;
 use diesel_async::AsyncPgConnection;
 use diesel_async::pooled_connection::deadpool::{Object, Pool};
+use futures::future::BoxFuture;
 
 /// Error type returned by [`SeedContext`] operations.
 #[derive(Debug, thiserror::Error)]
@@ -108,6 +143,16 @@ impl SeedContext {
     #[must_use]
     pub fn profile(&self) -> &str {
         &self.profile
+    }
+
+    /// Returns the underlying connection pool.
+    ///
+    /// Useful for APIs that take a `&Pool<AsyncPgConnection>` directly, such as
+    /// factory `create_many(count, pool)` and
+    /// [`fake_seed_model`](crate::seed::fake_seed_model).
+    #[must_use]
+    pub const fn pool(&self) -> &Pool<AsyncPgConnection> {
+        &self.pool
     }
 
     /// Acquires a pooled database connection.
@@ -205,9 +250,162 @@ fn first_database_url(database: Option<&toml::Value>) -> Option<String> {
     None
 }
 
+// ── #1343 AC4: model-name → factory fake-seeder registry ────────────────────
+//
+// The `autumn` CLI cannot name a project's generated model types directly, so
+// each `#[model]` registers a `FakeSeeder` via `inventory` (see the
+// `__autumn_register_fake_seeder!` forwarding macro in `lib.rs`). A seed binary
+// (or `autumn seed --count N --model M`) then looks a model up by name and runs
+// its factory's `.fake().create_many(count, pool)`, all without editing
+// `src/bin/seed.rs`.
+
+/// A registered model factory that `fake_seed_model` can drive by name.
+///
+/// One is submitted per `#[model]` (through the internal
+/// `__autumn_register_fake_seeder!` macro) when autumn-web is built with the
+/// `seed` feature. Collected at link time via [`inventory`].
+pub struct FakeSeeder {
+    /// The model's type name, e.g. `"Post"`. Matched case-insensitively.
+    pub model: &'static str,
+    /// Insert `count` faked rows via the model's factory and return how many
+    /// were inserted.
+    pub run: fn(&Pool<AsyncPgConnection>, usize) -> BoxFuture<'_, usize>,
+}
+
+inventory::collect!(FakeSeeder);
+
+/// Error returned by [`fake_seed_model`] when the requested model is not a
+/// registered faked model.
+#[derive(Debug, thiserror::Error)]
+pub enum FakeSeedError {
+    /// No registered `#[model]` matched the requested name.
+    #[error("unknown model {requested:?}; available faked models: {available}")]
+    UnknownModel {
+        /// The `--model` value that did not match any registered model.
+        requested: String,
+        /// Comma-separated list of registered model names (or a placeholder
+        /// when none are registered).
+        available: String,
+    },
+}
+
+/// The names of every registered faked model, sorted, for diagnostics.
+#[must_use]
+pub fn registered_fake_models() -> Vec<&'static str> {
+    let mut names: Vec<&'static str> = inventory::iter::<FakeSeeder>
+        .into_iter()
+        .map(|s| s.model)
+        .collect();
+    names.sort_unstable();
+    names.dedup();
+    names
+}
+
+/// Find the registered [`FakeSeeder`] whose model name matches `name`
+/// (case-insensitive), if any. Pool-free so the lookup can be unit-tested
+/// without a live database.
+fn find_fake_seeder(name: &str) -> Option<&'static FakeSeeder> {
+    inventory::iter::<FakeSeeder>
+        .into_iter()
+        .find(|s| s.model.eq_ignore_ascii_case(name))
+}
+
+/// Generate and insert `count` faked rows for the model named `name`
+/// (case-insensitive), using that model's factory `.fake().create_many(...)`.
+///
+/// Returns the number of rows inserted.
+///
+/// # Errors
+///
+/// Returns [`FakeSeedError::UnknownModel`] when no registered `#[model]`
+/// matches `name`. The error lists the available model names.
+pub async fn fake_seed_model(
+    name: &str,
+    count: usize,
+    pool: &Pool<AsyncPgConnection>,
+) -> Result<usize, FakeSeedError> {
+    if let Some(seeder) = find_fake_seeder(name) {
+        return Ok((seeder.run)(pool, count).await);
+    }
+    let available = registered_fake_models();
+    let available = if available.is_empty() {
+        "(none registered)".to_string()
+    } else {
+        available.join(", ")
+    };
+    Err(FakeSeedError::UnknownModel {
+        requested: name.to_string(),
+        available,
+    })
+}
+
+// ── #1343 AC4: fake-seeder registry test fixture ────────────────────────────
+//
+// Register a dummy model so the registry-lookup tests below have a known entry
+// to find without depending on any other crate's `#[model]`s. The `run` closure
+// never touches the pool (the lookup tests never invoke it), so it is safe to
+// leave a placeholder body.
+#[cfg(test)]
+inventory::submit! {
+    FakeSeeder {
+        model: "DummyFakeSeederModel",
+        run: |_pool, count| ::std::boxed::Box::pin(async move { count }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── fake-seeder registry (#1343 AC4) ───────────────────────────────────
+
+    #[test]
+    fn registry_collects_submitted_seeder() {
+        assert!(
+            registered_fake_models().contains(&"DummyFakeSeederModel"),
+            "expected the submitted dummy seeder to be collected via inventory, \
+             got: {:?}",
+            registered_fake_models()
+        );
+    }
+
+    #[test]
+    fn find_fake_seeder_is_case_insensitive() {
+        assert!(find_fake_seeder("DummyFakeSeederModel").is_some());
+        assert!(
+            find_fake_seeder("dummyfakeseedermodel").is_some(),
+            "lookup should be case-insensitive"
+        );
+        assert_eq!(
+            find_fake_seeder("DummyFakeSeederModel").unwrap().model,
+            "DummyFakeSeederModel"
+        );
+    }
+
+    #[test]
+    fn find_fake_seeder_returns_none_for_unknown() {
+        assert!(find_fake_seeder("NoSuchModelXYZ").is_none());
+    }
+
+    #[test]
+    fn unknown_model_error_lists_available_models() {
+        // Build the error the way `fake_seed_model` does for an unknown name,
+        // without needing a live pool.
+        let available = registered_fake_models().join(", ");
+        let err = FakeSeedError::UnknownModel {
+            requested: "NoSuchModelXYZ".to_string(),
+            available,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("NoSuchModelXYZ"),
+            "error should name the requested model, got: {msg}"
+        );
+        assert!(
+            msg.contains("DummyFakeSeederModel"),
+            "error should list available registered models, got: {msg}"
+        );
+    }
 
     // ── resolve_profile ────────────────────────────────────────────────────
 

--- a/autumn/tests/integration/factory_fake.rs
+++ b/autumn/tests/integration/factory_fake.rs
@@ -51,6 +51,7 @@ mod fake_factory_tests {
 
     #[test]
     fn fake_fills_unset_fields() {
+        let _guard = fake::test_serial_guard();
         fake::reseed(1);
         let a = FakeArticle::factory().fake().build();
         assert!(!a.name.is_empty(), "name should be faked");
@@ -72,6 +73,7 @@ mod fake_factory_tests {
 
     #[test]
     fn explicit_override_wins_over_fake() {
+        let _guard = fake::test_serial_guard();
         fake::reseed(1);
         let a = FakeArticle::factory().fake().title("Fixed Title").build();
         assert_eq!(a.title, "Fixed Title", "explicit set must survive .fake()");
@@ -81,6 +83,7 @@ mod fake_factory_tests {
 
     #[test]
     fn explicit_override_regardless_of_call_order() {
+        let _guard = fake::test_serial_guard();
         fake::reseed(1);
         // `.fake()` before the setter.
         let a = FakeArticle::factory().fake().name("Alice").build();
@@ -93,6 +96,7 @@ mod fake_factory_tests {
 
     #[test]
     fn fake_is_deterministic_under_seed() {
+        let _guard = fake::test_serial_guard();
         fake::reseed(99);
         let a = FakeArticle::factory().fake().build();
         fake::reseed(99);
@@ -108,7 +112,24 @@ mod fake_factory_tests {
     }
 
     #[test]
+    fn fake_all_is_an_alias_for_fake() {
+        // `.fake_all()` (AC2 spelling) must behave identically to `.fake()`.
+        let _guard = fake::test_serial_guard();
+        fake::reseed(77);
+        let via_fake = FakeArticle::factory().fake().build();
+        fake::reseed(77);
+        let via_fake_all = FakeArticle::factory().fake_all().build();
+        assert_eq!(via_fake.name, via_fake_all.name);
+        assert_eq!(via_fake.email, via_fake_all.email);
+        assert_eq!(via_fake.title, via_fake_all.title);
+        assert_eq!(via_fake.body, via_fake_all.body);
+        assert_eq!(via_fake.score, via_fake_all.score);
+        assert_eq!(via_fake.bio, via_fake_all.bio);
+    }
+
+    #[test]
     fn build_many_with_fake_varies() {
+        let _guard = fake::test_serial_guard();
         fake::reseed(5);
         let rows = FakeArticle::factory().fake().build_many(30);
         assert_eq!(rows.len(), 30);
@@ -130,6 +151,7 @@ mod fake_factory_tests {
 
     #[test]
     fn fake_datetime_anchored_in_deterministic_mode() {
+        let _guard = fake::test_serial_guard();
         fake::reseed(3);
         let a = FakeArticle::factory().fake().build();
         // Deterministic mode anchors to 2024-01-01T00:00:00Z minus a <=30d offset.
@@ -176,7 +198,11 @@ mod fake_factory_tests {
     #[cfg(feature = "test-support")]
     #[tokio::test]
     #[ignore = "requires Docker (testcontainers)"]
+    // The serial guard is held across the DB `.await`s to keep this reseed run
+    // isolated from other reseed-based tests sharing the process-global RNG.
+    #[allow(clippy::await_holding_lock)]
     async fn create_many_persists_distinct_records() {
+        let _guard = fake::test_serial_guard();
         let db: &autumn_web::test::TestDb = autumn_web::test::TestDb::shared().await;
         setup_table(&db.pool()).await;
 

--- a/autumn/tests/integration/factory_fake.rs
+++ b/autumn/tests/integration/factory_fake.rs
@@ -1,0 +1,198 @@
+//! Tests for factory `.fake()`, `build_many`, and `create_many` (issue #1343).
+//!
+//! In-memory tests (`build`/`build_many`) run everywhere. The `create_many`
+//! persistence test requires a live Postgres and is `#[ignore]`d like the other
+//! DB factory tests.
+
+#[cfg(feature = "db")]
+mod fake_factory_tests {
+    use autumn_web::fake;
+
+    #[cfg(feature = "test-support")]
+    use diesel::prelude::*;
+    #[cfg(feature = "test-support")]
+    use diesel_async::AsyncPgConnection;
+    #[cfg(feature = "test-support")]
+    use diesel_async::RunQueryDsl;
+    #[cfg(feature = "test-support")]
+    use diesel_async::pooled_connection::deadpool::Pool;
+
+    // ── Schema ─────────────────────────────────────────────────
+    diesel::table! {
+        fake_articles (id) {
+            id -> Int8,
+            name -> Text,
+            email -> Text,
+            title -> Text,
+            body -> Text,
+            score -> Int4,
+            active -> Bool,
+            created_at -> Timestamptz,
+            bio -> Nullable<Text>,
+        }
+    }
+
+    // ── Model ──────────────────────────────────────────────────
+    #[autumn_web::model(table = "fake_articles")]
+    pub struct FakeArticle {
+        #[id]
+        pub id: i64,
+        pub name: String,
+        pub email: String,
+        pub title: String,
+        pub body: String,
+        pub score: i32,
+        pub active: bool,
+        pub created_at: chrono::DateTime<chrono::Utc>,
+        pub bio: Option<String>,
+    }
+
+    // ── In-memory (.fake().build()) tests ──────────────────────
+
+    #[test]
+    fn fake_fills_unset_fields() {
+        fake::reseed(1);
+        let a = FakeArticle::factory().fake().build();
+        assert!(!a.name.is_empty(), "name should be faked");
+        assert_eq!(a.email.matches('@').count(), 1, "email should be faked");
+        assert!(!a.title.is_empty(), "title should be faked");
+        assert!(!a.body.is_empty(), "body should be faked");
+        assert!(a.bio.is_some(), "Option<String> bio should be Some(..)");
+    }
+
+    #[test]
+    fn without_fake_fields_stay_default() {
+        let a = FakeArticle::factory().build();
+        assert_eq!(a.name, "");
+        assert_eq!(a.email, "");
+        assert_eq!(a.score, 0);
+        assert!(!a.active);
+        assert_eq!(a.bio, None);
+    }
+
+    #[test]
+    fn explicit_override_wins_over_fake() {
+        fake::reseed(1);
+        let a = FakeArticle::factory().fake().title("Fixed Title").build();
+        assert_eq!(a.title, "Fixed Title", "explicit set must survive .fake()");
+        // Other unset fields are still faked.
+        assert!(!a.name.is_empty());
+    }
+
+    #[test]
+    fn explicit_override_regardless_of_call_order() {
+        fake::reseed(1);
+        // `.fake()` before the setter.
+        let a = FakeArticle::factory().fake().name("Alice").build();
+        assert_eq!(a.name, "Alice");
+        fake::reseed(1);
+        // setter before `.fake()`.
+        let b = FakeArticle::factory().name("Bob").fake().build();
+        assert_eq!(b.name, "Bob");
+    }
+
+    #[test]
+    fn fake_is_deterministic_under_seed() {
+        fake::reseed(99);
+        let a = FakeArticle::factory().fake().build();
+        fake::reseed(99);
+        let b = FakeArticle::factory().fake().build();
+        assert_eq!(a.name, b.name);
+        assert_eq!(a.email, b.email);
+        assert_eq!(a.title, b.title);
+        assert_eq!(a.body, b.body);
+        assert_eq!(a.score, b.score);
+        assert_eq!(a.active, b.active);
+        assert_eq!(a.created_at, b.created_at);
+        assert_eq!(a.bio, b.bio);
+    }
+
+    #[test]
+    fn build_many_with_fake_varies() {
+        fake::reseed(5);
+        let rows = FakeArticle::factory().fake().build_many(30);
+        assert_eq!(rows.len(), 30);
+        let distinct_names: std::collections::HashSet<_> =
+            rows.iter().map(|r| r.name.clone()).collect();
+        assert!(
+            distinct_names.len() > 10,
+            "expected varied names across the batch, got {}",
+            distinct_names.len()
+        );
+    }
+
+    #[test]
+    fn build_many_without_fake_is_identical() {
+        let rows = FakeArticle::factory().name("Same").build_many(3);
+        assert_eq!(rows.len(), 3);
+        assert!(rows.iter().all(|r| r.name == "Same"));
+    }
+
+    #[test]
+    fn fake_datetime_anchored_in_deterministic_mode() {
+        fake::reseed(3);
+        let a = FakeArticle::factory().fake().build();
+        // Deterministic mode anchors to 2024-01-01T00:00:00Z minus a <=30d offset.
+        let base = chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        assert!(
+            a.created_at <= base,
+            "created_at should be at/before the base"
+        );
+        assert!(
+            a.created_at >= base - chrono::Duration::days(31),
+            "created_at should be within ~30 days of the base"
+        );
+    }
+
+    // ── DB (create_many) test ──────────────────────────────────
+
+    #[cfg(feature = "test-support")]
+    async fn setup_table(pool: &Pool<AsyncPgConnection>) {
+        let mut conn = pool.get().await.unwrap();
+        diesel::sql_query(
+            "CREATE TABLE IF NOT EXISTS fake_articles (
+                id         BIGSERIAL PRIMARY KEY,
+                name       TEXT NOT NULL DEFAULT '',
+                email      TEXT NOT NULL DEFAULT '',
+                title      TEXT NOT NULL DEFAULT '',
+                body       TEXT NOT NULL DEFAULT '',
+                score      INT  NOT NULL DEFAULT 0,
+                active     BOOL NOT NULL DEFAULT FALSE,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                bio        TEXT
+            )",
+        )
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+        diesel::sql_query("TRUNCATE fake_articles RESTART IDENTITY")
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+    }
+
+    #[cfg(feature = "test-support")]
+    #[tokio::test]
+    #[ignore = "requires Docker (testcontainers)"]
+    async fn create_many_persists_distinct_records() {
+        let db: &autumn_web::test::TestDb = autumn_web::test::TestDb::shared().await;
+        setup_table(&db.pool()).await;
+
+        fake::reseed(123);
+        let rows = FakeArticle::factory()
+            .fake()
+            .create_many(5, &db.pool())
+            .await;
+
+        assert_eq!(rows.len(), 5);
+        let distinct_ids: std::collections::HashSet<_> = rows.iter().map(|r| r.id).collect();
+        assert_eq!(distinct_ids.len(), 5, "each row gets a distinct DB id");
+        for r in &rows {
+            assert!(r.id > 0);
+            assert!(!r.name.is_empty());
+            assert_eq!(r.email.matches('@').count(), 1);
+        }
+    }
+}

--- a/autumn/tests/integration/factory_fake.rs
+++ b/autumn/tests/integration/factory_fake.rs
@@ -22,6 +22,8 @@ mod fake_factory_tests {
         fake_articles (id) {
             id -> Int8,
             name -> Text,
+            first_name -> Text,
+            last_name -> Text,
             email -> Text,
             title -> Text,
             body -> Text,
@@ -38,6 +40,8 @@ mod fake_factory_tests {
         #[id]
         pub id: i64,
         pub name: String,
+        pub first_name: String,
+        pub last_name: String,
         pub email: String,
         pub title: String,
         pub body: String,
@@ -55,6 +59,14 @@ mod fake_factory_tests {
         fake::reseed(1);
         let a = FakeArticle::factory().fake().build();
         assert!(!a.name.is_empty(), "name should be faked");
+        assert!(
+            !a.first_name.is_empty(),
+            "first_name should be faked via fake::first_name()"
+        );
+        assert!(
+            !a.last_name.is_empty(),
+            "last_name should be faked via fake::last_name()"
+        );
         assert_eq!(a.email.matches('@').count(), 1, "email should be faked");
         assert!(!a.title.is_empty(), "title should be faked");
         assert!(!a.body.is_empty(), "body should be faked");
@@ -177,6 +189,8 @@ mod fake_factory_tests {
             "CREATE TABLE IF NOT EXISTS fake_articles (
                 id         BIGSERIAL PRIMARY KEY,
                 name       TEXT NOT NULL DEFAULT '',
+                first_name TEXT NOT NULL DEFAULT '',
+                last_name  TEXT NOT NULL DEFAULT '',
                 email      TEXT NOT NULL DEFAULT '',
                 title      TEXT NOT NULL DEFAULT '',
                 body       TEXT NOT NULL DEFAULT '',

--- a/autumn/tests/integration/fake_generators.rs
+++ b/autumn/tests/integration/fake_generators.rs
@@ -1,0 +1,132 @@
+//! Tests for the deterministic fake-data generators in `autumn_web::fake`.
+
+use autumn_web::fake;
+
+/// Draw a mixed sequence of values, exercising most generators, so determinism
+/// covers the full API surface (each draw advances the shared RNG).
+fn sample_sequence() -> Vec<String> {
+    let mut out = Vec::new();
+    for _ in 0..25 {
+        out.push(fake::name());
+        out.push(fake::email());
+        out.push(fake::username());
+        out.push(fake::sentence());
+        out.push(fake::paragraph());
+        out.push(fake::url());
+        out.push(fake::word());
+        out.push(fake::boolean().to_string());
+        out.push(fake::int_range(1, 10).to_string());
+        out.push(fake::decimal().to_string());
+        out.push(fake::decimal_f64().to_string());
+        out.push(fake::recent_datetime().to_rfc3339());
+        out.push(fake::uuid().to_string());
+    }
+    out
+}
+
+#[test]
+fn reseed_makes_output_deterministic() {
+    fake::reseed(42);
+    let first = sample_sequence();
+    fake::reseed(42);
+    let second = sample_sequence();
+    assert_eq!(
+        first, second,
+        "same seed must reproduce identical sequences"
+    );
+}
+
+#[test]
+fn different_seeds_diverge() {
+    fake::reseed(1);
+    let a = sample_sequence();
+    fake::reseed(2);
+    let b = sample_sequence();
+    assert_ne!(a, b, "different seeds should produce different sequences");
+}
+
+#[test]
+fn name_has_high_cardinality() {
+    fake::reseed(7);
+    let mut names = std::collections::HashSet::new();
+    for _ in 0..200 {
+        names.insert(fake::name());
+    }
+    assert!(
+        names.len() > 100,
+        "expected many distinct names, got {}",
+        names.len()
+    );
+}
+
+#[test]
+fn sentence_has_high_cardinality() {
+    fake::reseed(7);
+    let mut sentences = std::collections::HashSet::new();
+    for _ in 0..200 {
+        sentences.insert(fake::sentence());
+    }
+    assert!(
+        sentences.len() > 150,
+        "expected many distinct sentences, got {}",
+        sentences.len()
+    );
+}
+
+#[test]
+fn int_range_stays_within_bounds() {
+    fake::reseed(7);
+    for _ in 0..1000 {
+        let v = fake::int_range(1, 10);
+        assert!((1..=10).contains(&v), "int_range out of bounds: {v}");
+    }
+    // Degenerate range collapses to lo.
+    assert_eq!(fake::int_range(5, 5), 5);
+    assert_eq!(fake::int_range(9, 3), 9);
+}
+
+#[test]
+fn email_contains_exactly_one_at() {
+    fake::reseed(7);
+    for _ in 0..100 {
+        let e = fake::email();
+        assert_eq!(e.matches('@').count(), 1, "bad email: {e}");
+    }
+}
+
+#[test]
+fn url_is_https() {
+    fake::reseed(7);
+    for _ in 0..100 {
+        let u = fake::url();
+        assert!(u.starts_with("https://"), "bad url: {u}");
+    }
+}
+
+#[test]
+fn username_is_lowercase_and_spaceless() {
+    fake::reseed(7);
+    for _ in 0..100 {
+        let u = fake::username();
+        assert!(!u.contains(' '), "username has space: {u}");
+        assert_eq!(u, u.to_lowercase(), "username not lowercase: {u}");
+    }
+}
+
+#[test]
+fn uuids_are_distinct_and_v4() {
+    fake::reseed(7);
+    let mut seen = std::collections::HashSet::new();
+    for _ in 0..500 {
+        let id = fake::uuid();
+        assert_eq!(id.get_version_num(), 4, "uuid not v4: {id}");
+        assert!(seen.insert(id), "duplicate uuid: {id}");
+    }
+}
+
+#[test]
+fn words_zero_is_empty() {
+    fake::reseed(7);
+    assert_eq!(fake::words(0), "");
+    assert!(!fake::words(3).is_empty());
+}

--- a/autumn/tests/integration/fake_generators.rs
+++ b/autumn/tests/integration/fake_generators.rs
@@ -26,6 +26,7 @@ fn sample_sequence() -> Vec<String> {
 
 #[test]
 fn reseed_makes_output_deterministic() {
+    let _guard = fake::test_serial_guard();
     fake::reseed(42);
     let first = sample_sequence();
     fake::reseed(42);
@@ -38,6 +39,7 @@ fn reseed_makes_output_deterministic() {
 
 #[test]
 fn different_seeds_diverge() {
+    let _guard = fake::test_serial_guard();
     fake::reseed(1);
     let a = sample_sequence();
     fake::reseed(2);
@@ -45,8 +47,88 @@ fn different_seeds_diverge() {
     assert_ne!(a, b, "different seeds should produce different sequences");
 }
 
+/// Regression test for the determinism bug where the RNG was thread-local:
+/// under the multi-thread runtime a seeded run migrated threads, each fresh
+/// thread re-seeded itself independently from the same seed, and the sequence
+/// restarted — breaking reproducibility and producing duplicate rows.
+///
+/// With a single process-global seeded RNG, `reseed(42)` followed by draws
+/// spread across many concurrently-spawned tasks yields one shared sequence, so
+/// the *multiset* of all drawn values is identical run-to-run no matter how the
+/// tasks are scheduled. On the old thread-local design the spawned tasks would
+/// each draw from their own thread's RNG (seeded from OS entropy, since
+/// `AUTUMN_FAKE_SEED` is unset here), so the two runs diverge and this fails.
+///
+/// The per-draw unit is [`fake::uuid`], which consumes exactly one *atomic*
+/// 16-byte pull from the RNG under a single lock. That atomicity is what makes
+/// the multiset deterministic under interleaving: whichever task wins the lock,
+/// the set of 16-byte blocks consumed is always the first `TASKS * PER_TASK`
+/// blocks of the seeded stream. (A helper like `sentence()` that makes a
+/// *variable number* of separate locked draws would let concurrent tasks
+/// assemble strings from non-contiguous stream values, so its multiset is
+/// legitimately non-deterministic under interleaving — not a defect in the
+/// shared RNG.)
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// The serial guard is intentionally held across the `.await`s below to keep the
+// whole run isolated from other reseed-based tests; the spawned tasks never take
+// this lock, so there is no deadlock risk.
+#[allow(clippy::await_holding_lock)]
+async fn seeded_rng_is_deterministic_across_threads_and_tasks() {
+    // Reseed once, then draw `TASKS * PER_TASK` UUIDs spread across tasks that
+    // yield between draws to encourage migration across worker threads. Returns
+    // the sorted multiset of everything drawn this run. (Defined before any
+    // statement to satisfy `clippy::items_after_statements`.)
+    async fn run() -> Vec<String> {
+        const TASKS: usize = 8;
+        const PER_TASK: usize = 64;
+
+        fake::reseed(42);
+        let mut handles = Vec::with_capacity(TASKS);
+        for _ in 0..TASKS {
+            handles.push(tokio::spawn(async {
+                let mut drawn = Vec::with_capacity(PER_TASK);
+                for _ in 0..PER_TASK {
+                    // Yield so the task can be resumed on a different worker
+                    // thread — the exact scenario that broke the thread-local
+                    // design.
+                    tokio::task::yield_now().await;
+                    drawn.push(fake::uuid().to_string());
+                }
+                drawn
+            }));
+        }
+
+        let mut all = Vec::with_capacity(TASKS * PER_TASK);
+        for handle in handles {
+            all.extend(handle.await.expect("fake draw task panicked"));
+        }
+        all.sort();
+        all
+    }
+
+    let _guard = fake::test_serial_guard();
+    let first = run().await;
+    let second = run().await;
+
+    assert_eq!(first.len(), 8 * 64, "should draw every value");
+    // (a) No duplicates — distinct rows even across threads (#1343 AC3).
+    let distinct: std::collections::HashSet<&String> = first.iter().collect();
+    assert_eq!(
+        distinct.len(),
+        first.len(),
+        "a seeded multi-threaded batch must have no duplicate values"
+    );
+    // (b) Reproducible run-to-run — one shared sequence regardless of scheduling
+    // (#1343 AC5). This is what fails on the old thread-local design.
+    assert_eq!(
+        first, second,
+        "a seeded run must draw one reproducible sequence across all threads/tasks"
+    );
+}
+
 #[test]
 fn name_has_high_cardinality() {
+    let _guard = fake::test_serial_guard();
     fake::reseed(7);
     let mut names = std::collections::HashSet::new();
     for _ in 0..200 {
@@ -61,6 +143,7 @@ fn name_has_high_cardinality() {
 
 #[test]
 fn sentence_has_high_cardinality() {
+    let _guard = fake::test_serial_guard();
     fake::reseed(7);
     let mut sentences = std::collections::HashSet::new();
     for _ in 0..200 {
@@ -75,6 +158,7 @@ fn sentence_has_high_cardinality() {
 
 #[test]
 fn int_range_stays_within_bounds() {
+    let _guard = fake::test_serial_guard();
     fake::reseed(7);
     for _ in 0..1000 {
         let v = fake::int_range(1, 10);
@@ -87,6 +171,7 @@ fn int_range_stays_within_bounds() {
 
 #[test]
 fn email_contains_exactly_one_at() {
+    let _guard = fake::test_serial_guard();
     fake::reseed(7);
     for _ in 0..100 {
         let e = fake::email();
@@ -96,6 +181,7 @@ fn email_contains_exactly_one_at() {
 
 #[test]
 fn url_is_https() {
+    let _guard = fake::test_serial_guard();
     fake::reseed(7);
     for _ in 0..100 {
         let u = fake::url();
@@ -105,6 +191,7 @@ fn url_is_https() {
 
 #[test]
 fn username_is_lowercase_and_spaceless() {
+    let _guard = fake::test_serial_guard();
     fake::reseed(7);
     for _ in 0..100 {
         let u = fake::username();
@@ -115,6 +202,7 @@ fn username_is_lowercase_and_spaceless() {
 
 #[test]
 fn uuids_are_distinct_and_v4() {
+    let _guard = fake::test_serial_guard();
     fake::reseed(7);
     let mut seen = std::collections::HashSet::new();
     for _ in 0..500 {
@@ -126,6 +214,7 @@ fn uuids_are_distinct_and_v4() {
 
 #[test]
 fn words_zero_is_empty() {
+    let _guard = fake::test_serial_guard();
     fake::reseed(7);
     assert_eq!(fake::words(0), "");
     assert!(!fake::words(3).is_empty());

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -58,7 +58,9 @@ mod events_integration;
 #[cfg(feature = "db")]
 mod experiments_pg_integration;
 mod extractors;
+mod factory_fake;
 mod factory_integration;
+mod fake_generators;
 mod feature_flags_integration;
 mod feed;
 mod form_for_derive;

--- a/examples/bookmarks/Cargo.toml
+++ b/examples/bookmarks/Cargo.toml
@@ -5,7 +5,10 @@ version.workspace = true
 publish = false
 
 [dependencies]
-autumn-web = { path = "../../autumn", features = ["openapi"] }
+# `seed` enables `autumn_web::seed` (SeedContext + the fake-seeder registry) so
+# `src/bin/seed.rs` can do a one-line faked seed and answer
+# `autumn seed --count N --model Bookmark`.
+autumn-web = { path = "../../autumn", features = ["openapi", "seed"] }
 chrono = { version = "0.4", features = ["serde"] }
 diesel = { version = "2", features = ["postgres", "chrono"] }
 diesel-async = { version = "0.9", features = ["postgres"] }

--- a/examples/bookmarks/README.md
+++ b/examples/bookmarks/README.md
@@ -85,6 +85,36 @@ These routes are generated from `#[autumn_web::repository(Bookmark, api = "/api/
 | GET    | `/static/js/htmx.min.js` | Bundled htmx          |
 | GET    | `/static/css/autumn.css` | Compiled Tailwind CSS  |
 
+## Seeding fake data
+
+`src/bin/seed.rs` uses the `#[model]` factory's `.fake()` support (issue #1343)
+to fill the database with realistic rows so you can exercise pagination and
+search against a populated list.
+
+```bash
+# Populate 200 faked bookmarks in one shot (the seed binary's default body).
+# Idempotent: it only bulk-seeds when the table is empty.
+autumn seed
+```
+
+The one line that does the work in `src/bin/seed.rs`:
+
+```rust
+Bookmark::factory().fake().create_many(200, ctx.pool()).await;
+```
+
+You can also generate a specific count for any registered `#[model]` without
+editing the seed binary:
+
+```bash
+# Insert 200 faked Bookmark rows to try pagination/search on a full list.
+autumn seed --count 200 --model Bookmark
+```
+
+`autumn seed` forwards `--count`/`--model` to the seed binary, which routes them
+to `autumn_web::seed::fake_seed_model` — the model is looked up by name from a
+registry every `#[autumn_web::model]` joins automatically.
+
 ## Try the generated CRUD API
 
 ```bash

--- a/examples/bookmarks/src/bin/seed.rs
+++ b/examples/bookmarks/src/bin/seed.rs
@@ -1,0 +1,106 @@
+//! Seed binary for the bookmarks example.
+//!
+//! Two ways to populate the database:
+//!
+//! 1. **One-line faked seed** (the default `autumn seed` body below): inserts a
+//!    batch of realistic fake bookmarks with a single
+//!    `Bookmark::factory().fake().create_many(...)` call.
+//!
+//! 2. **On-demand fake seeding without editing this file**:
+//!
+//!    ```text
+//!    autumn seed --count 200 --model Bookmark
+//!    ```
+//!
+//!    `autumn seed` forwards `--count`/`--model` as `AUTUMN_SEED_COUNT` /
+//!    `AUTUMN_SEED_MODEL`, and the dispatcher routes to
+//!    `autumn_web::seed::fake_seed_model`, which drives the model's factory.
+//!    Any `#[autumn_web::model]` registers automatically.
+//!
+//! This example crate is a binary (no `lib` target), so — like the factory
+//! integration tests — the `Bookmark` model and its schema are declared inline
+//! here rather than imported from `src/models`.
+
+use autumn_web::seed::SeedContext;
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+
+// ── Inline schema (mirrors src/schema.rs) ────────────────────────────────────
+
+diesel::table! {
+    bookmarks (id) {
+        id -> Int8,
+        url -> Text,
+        title -> Text,
+        tag -> Text,
+        alive -> Bool,
+        created_at -> Timestamp,
+    }
+}
+
+// ── Model defined with #[model] to expose the generated `.fake()` factory ────
+
+#[autumn_web::model]
+pub struct Bookmark {
+    #[id]
+    pub id: i64,
+    #[validate(url)]
+    pub url: String,
+    #[validate(length(min = 1, max = 200))]
+    pub title: String,
+    pub tag: String,
+    #[default]
+    pub alive: bool,
+    #[default]
+    pub created_at: chrono::NaiveDateTime,
+}
+
+#[autumn_web::main]
+async fn main() {
+    let ctx =
+        SeedContext::build().expect("failed to build seed context — is the database running?");
+
+    // `autumn seed --count N --model Bookmark` dispatch: generate N faked rows
+    // for the named model and return, skipping the default body below.
+    if let (Ok(model), Ok(count)) = (
+        std::env::var("AUTUMN_SEED_MODEL"),
+        std::env::var("AUTUMN_SEED_COUNT"),
+    ) {
+        let count: usize = count
+            .parse()
+            .expect("AUTUMN_SEED_COUNT must be a non-negative integer");
+        let inserted = autumn_web::seed::fake_seed_model(&model, count, ctx.pool())
+            .await
+            .expect("fake-seed failed");
+        println!("Inserted {inserted} faked `{model}` row(s).");
+        return;
+    }
+
+    println!("Seeding database (profile: {})...", ctx.profile());
+
+    // Idempotent guard: only bulk-seed when the table is empty, so re-running
+    // `autumn seed` doesn't keep piling up rows.
+    let mut db = ctx
+        .conn()
+        .await
+        .expect("failed to acquire database connection");
+    let existing: i64 = bookmarks::table
+        .count()
+        .get_result(&mut *db)
+        .await
+        .expect("failed to count existing bookmarks");
+    drop(db);
+
+    if existing > 0 {
+        println!("Bookmarks already seeded ({existing} rows); nothing to do.");
+        return;
+    }
+
+    // One-line faked seed: populate 200 realistic bookmarks to exercise
+    // pagination and search.
+    let rows = Bookmark::factory()
+        .fake()
+        .create_many(200, ctx.pool())
+        .await;
+    println!("Seed complete: inserted {} faked bookmarks.", rows.len());
+}

--- a/examples/bookmarks/src/bin/seed.rs
+++ b/examples/bookmarks/src/bin/seed.rs
@@ -60,19 +60,13 @@ async fn main() {
     let ctx =
         SeedContext::build().expect("failed to build seed context — is the database running?");
 
-    // `autumn seed --count N --model Bookmark` dispatch: generate N faked rows
-    // for the named model and return, skipping the default body below.
-    if let (Ok(model), Ok(count)) = (
-        std::env::var("AUTUMN_SEED_MODEL"),
-        std::env::var("AUTUMN_SEED_COUNT"),
-    ) {
-        let count: usize = count
-            .parse()
-            .expect("AUTUMN_SEED_COUNT must be a non-negative integer");
-        let inserted = autumn_web::seed::fake_seed_model(&model, count, ctx.pool())
-            .await
-            .expect("fake-seed failed");
-        println!("Inserted {inserted} faked `{model}` row(s).");
+    // `autumn seed --count N --model Bookmark` dispatch (owned by autumn-web):
+    // generate N faked rows for the named model and return, skipping the default
+    // body below. Returns `false` when no fake request was made.
+    if autumn_web::seed::maybe_fake_seed(ctx.pool())
+        .await
+        .expect("fake-seed failed")
+    {
         return;
     }
 


### PR DESCRIPTION
Part of #1343.

## What changed

**Before:** `Note::factory().build()` filled every field with `Default::default()` — `title: &#34;&#34;`, `body: &#34;&#34;`, `0`, `false` — and `autumn seed` only ran a hand-written `src/bin/seed.rs` with no volume helper. Populating a dev DB meant hand-authoring rows or writing `format!(&#34;Note {i}&#34;)` loops, so the just-shipped list-view features (pagination, FTS search, bulk-select, CSV export, sort/filter) couldn&#39;t be demoed or perf-checked without manual fixtures.

**After:** a built-in fake-data source. `Foo::factory().fake().create_many(200, &amp;pool).await` inserts 200 realistic, varied rows in one call, and `autumn seed --count 200 --model Foo` does the same from the command line without editing `src/bin/seed.rs`. Field values are inferred from the column name first (`email` → email, `title`/`name` → words, `created_at` → recent timestamp) then the Rust type. Output is reproducible under `AUTUMN_FAKE_SEED=42` and varies otherwise.

## How it works

- **`autumn_web::fake`** (new module): deterministic generators — `name`/`first_name`/`last_name`, `username`, `email`, `word`/`words`/`sentence`/`paragraph` (lorem), `url`, `boolean`, `int_range`, `decimal`/`decimal_f64`, `recent_datetime`, `uuid`. Backed by a process-global `ChaCha8Rng` seeded from `AUTUMN_FAKE_SEED` (or OS entropy when unset); `reseed()` forces a deterministic seed for tests. Bundled English word/name lists give high cardinality for distinct rows. In seeded mode `recent_datetime` anchors to a fixed epoch and `uuid` draws from the seeded RNG, so golden data is stable.
- **Factory `.fake()` / `.fake_all()` / `create_many` / `build_many`** (generated in `autumn-macros`): the factory tracks explicitly-set fields; `.fake()` fills only the unset ones, re-drawing per row so batches vary. Inference maps field name → type to a generator; unrecognized types fall back to `Default` (never emits non-compiling code). FKs / assoc fields are never faked (single-table this slice).
- **`autumn seed --count N --model M`** (`autumn-cli`): new flags forwarded to the seed binary via env vars; a versioned `autumn_web::seed::maybe_fake_seed()` helper dispatches to a per-model `inventory` registry that each `#[model]` self-registers into. Absent flags preserve today&#39;s behavior (run the project seed binary). `--count`/`--model` must be given together.
- **Determinism** is process-global (not thread-local) so the multi-threaded seed runtime produces reproducible, non-duplicated rows under a seed; covered by a multi-thread regression test.
- **Example + docs:** `examples/bookmarks` ships a one-line faked seed and a README section showing `autumn seed --count 200 --model Bookmark` to populate 100+ rows for exercising pagination/search.

## New dependencies

`rand` + `rand_chacha` (already in the lockfile transitively; promoted to direct deps for the seeded `ChaCha8Rng`) and `inventory` (behind the `seed` feature) for the model-name → factory registry. A bundled-generator approach was chosen over the `fake` crate to keep full control of seeded reproducibility and match the &#34;common-English core&#34; scope with a small dependency footprint.

## Testing

- `autumn_web::fake` generator tests (determinism, ranges, variety) + a multi-thread determinism regression test.
- Factory `.fake()`/`.fake_all()` override-wins, inference, and `build_many` distinctness tests.
- CLI arg-parsing/validation + `inventory` registry lookup tests; seed doctest populating 100+ rows.
- The DB-backed `create_many` persistence test is `#[ignore]`d (no Postgres in CI, matching existing factory DB tests) — the full seed path is compile-proven via `cargo build -p bookmarks --bin seed`.
- `cargo clippy` clean on default and `--features seed`.

## Out of scope (per the issue)

Locale/domain-specific fakers, relationship-aware FK generation, fake blobs/attachments, and replacing the hand-written `src/bin/seed.rs` workflow (`--count` augments it).

## Known limitation — `--model` dispatch in real scaffolded apps (follow-up: #1718)

`autumn seed --count N --model M` resolves the model through an `inventory` registry that each `#[model]` submits into. In a project created by `autumn new` + `autumn generate model/scaffold`, models are declared via `mod models;` in `src/main.rs` only, while `src/bin/seed.rs` is a **separate `[[bin]]` Cargo target** that links none of those modules — so its registry is empty and `--model M` returns "unknown model M; available: (none)". The `examples/bookmarks` seed works only because it declares its model *inline* in `seed.rs`.

The `fake` module, factory `.fake()`/`.fake_all()`/`create_many`/`build_many`, the CLI flags, `maybe_fake_seed` dispatch, and the registry itself are all complete and tested — the gap is purely the cross-target linkage of scaffolded models into the seed binary. The clean fix (a generated `src/lib.rs` both binaries share, or injecting `#[path] mod models;`+`mod schema;` into the seed bin from the generators) lives in scaffold-generation code owned by a separate change and is tracked in the follow-up issue above.

## Note

Per this wave&#39;s coordination policy, `CHANGELOG.md` is intentionally not touched here (siblings are editing it); add the `## [Unreleased]` bullet at integration time.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W44NK2ycGpr3nfHQCjRGos)_