### PR TITLE
ci: pin taiki-e/install-action to @v2 with explicit tool input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.7.8
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        # Pin @v2 and pass the tool explicitly. The bare @cargo-llvm-cov tag form can
+        # resolve with an empty tool input and install nothing (broke the Fuzz
+        # jobs with `error: no such command: fuzz`). Keep the explicit tool: input.
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
       - name: Generate coverage
         run: |
           cargo llvm-cov clean --workspace

--- a/.github/workflows/feature-combinations.yml
+++ b/.github/workflows/feature-combinations.yml
@@ -83,7 +83,12 @@ jobs:
           sudo apt-get install -y --no-install-recommends protobuf-compiler
 
       - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
+        # Pin @v2 and pass the tool explicitly. The bare @cargo-hack tag form can
+        # resolve with an empty tool input and install nothing (broke the Fuzz
+        # jobs with `error: no such command: fuzz`). Keep the explicit tool: input.
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
 
       - name: Run feature-combination compile gate
         run: ./scripts/check-feature-combinations.sh 2>&1 | tee gate-output.txt

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -45,7 +45,12 @@ jobs:
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@nightly
       - name: Install cargo-fuzz
-        uses: taiki-e/install-action@cargo-fuzz
+        # Pin @v2 and pass the tool explicitly. The bare @cargo-fuzz tag form can
+        # resolve with an empty tool input and install nothing (broke the Fuzz
+        # jobs with `error: no such command: fuzz`). Keep the explicit tool: input.
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz
       - uses: Swatinem/rust-cache@v2.7.8
         with:
           workspaces: fuzz

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -69,7 +69,10 @@ jobs:
             fuzz-corpus-${{ matrix.target }}-${{ github.ref }}-
             fuzz-corpus-${{ matrix.target }}-
       - name: Fuzz ${{ matrix.target }} (5 min, corpus persisted across runs)
-        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=300 -timeout=10
+        # Force the gnu host target: cargo-fuzz is installed as a musl-static binary
+        # (via install-action's cargo-binstall fallback) and would otherwise default to
+        # x86_64-unknown-linux-musl, where the ASAN build fails (sanitizer vs static libc).
+        run: cargo +nightly fuzz run ${{ matrix.target }} --target x86_64-unknown-linux-gnu -- -max_total_time=300 -timeout=10
       - name: Upload crash reproducers
         if: failure()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -51,7 +51,10 @@ jobs:
       - name: Fuzz ${{ matrix.target }} (30s burst, seeded from committed corpus)
         # Corpus dir defaults to fuzz/corpus/${{ matrix.target }}; -max_total_time
         # caps the run and -timeout flags any single input that hangs past 10s.
-        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=30 -timeout=10
+        # Force the gnu host target: cargo-fuzz is installed as a musl-static binary
+        # (via install-action's cargo-binstall fallback) and would otherwise default to
+        # x86_64-unknown-linux-musl, where the ASAN build fails (sanitizer vs static libc).
+        run: cargo +nightly fuzz run ${{ matrix.target }} --target x86_64-unknown-linux-gnu -- -max_total_time=30 -timeout=10
       - name: Upload crash reproducers
         if: failure()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -39,7 +39,12 @@ jobs:
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@nightly
       - name: Install cargo-fuzz
-        uses: taiki-e/install-action@cargo-fuzz
+        # Pin @v2 and pass the tool explicitly. The bare @cargo-fuzz tag form can
+        # resolve with an empty tool input and install nothing (broke the Fuzz
+        # jobs with `error: no such command: fuzz`). Keep the explicit tool: input.
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz
       - uses: Swatinem/rust-cache@v2.7.8
         with:
           workspaces: fuzz

--- a/.github/workflows/publish-gate.yml
+++ b/.github/workflows/publish-gate.yml
@@ -177,7 +177,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.94.1
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-semver-checks
-        uses: taiki-e/install-action@cargo-semver-checks
+        # Pin @v2 and pass the tool explicitly. The bare @cargo-semver-checks tag form can
+        # resolve with an empty tool input and install nothing (broke the Fuzz
+        # jobs with `error: no such command: fuzz`). Keep the explicit tool: input.
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-semver-checks
       - name: Check public API SemVer compatibility
         # GITHUB_EVENT_NAME is set by the runner automatically, but pass it
         # explicitly so the script can distinguish PR (informational) from
@@ -278,7 +283,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install git-cliff
-        uses: taiki-e/install-action@git-cliff
+        # Pin @v2 and pass the tool explicitly. The bare @git-cliff tag form can
+        # resolve with an empty tool input and install nothing (broke the Fuzz
+        # jobs with `error: no such command: fuzz`). Keep the explicit tool: input.
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff
       - name: Generate release notes artifact
         run: |
           # CHANGELOG.md must be updated before tagging so the packaged crates


### PR DESCRIPTION
## Summary

Fixes the repo-wide Fuzz CI breakage in two steps. Both are CI-infra only — no source, CHANGELOG, or skills changes.

## Fix 1 — cargo-fuzz install (the reported breakage)

**Before:** every Fuzz check (routing / body / headers / session / idempotency) failed with `error: no such command: 'fuzz'`; the install step logged `##[warning]no tool specified`.

**After:** the install step passes `tool: cargo-fuzz` explicitly and cargo-fuzz is installed, so `cargo fuzz run` is reached.

**Root cause:** the workflows used the shorthand `uses: taiki-e/install-action@cargo-fuzz` (tool-name-as-git-ref). At runtime that resolved with an empty tool input (`INPUT_TOOL:` blank), so the action installed nothing. This is NOT caused by a Dependabot PR in this repo (there is none touching it) — the action's own warning names that scenario generically, but the shorthand-tag form is simply unreliable.

**Change:** converted all six `taiki-e/install-action@<tool>` shorthand usages to the canonical `@v2` + `with: tool: <name>` form, each with an inline comment on why the explicit `tool:` must stay:
- `fuzz.yml` (cargo-fuzz), `fuzz-nightly.yml` (cargo-fuzz)
- `ci.yml` (cargo-llvm-cov)
- `feature-combinations.yml` (cargo-hack)
- `publish-gate.yml` (cargo-semver-checks, git-cliff)

**Verified on CI:** on the first fuzz job to run (`Fuzz (session)`), the install step logged `INPUT_TOOL: cargo-fuzz`, no `no tool specified` warning, and installed cargo-fuzz v0.13.2.

## Fix 2 — fuzz build target (uncovered by Fix 1)

**Before (only reachable after Fix 1):** the `cargo fuzz run` build failed with `error: sanitizer is incompatible with statically linked libc` and `error[E0463]: can't find crate for core`, building for `x86_64-unknown-linux-musl`.

**After:** the fuzz targets build for the gnu host target, the standard ASAN-compatible target already installed on the runner.

**Root cause:** cargo-fuzz is installed as a musl-static binary (via install-action's cargo-binstall fallback), so it defaulted the fuzz build to `x86_64-unknown-linux-musl`, where ASAN can't link against static musl libc and the musl `core` crate isn't present. This build path had never run before because the fuzz jobs always died at the install step first.

**Change:** pass `--target x86_64-unknown-linux-gnu` to the `cargo +nightly fuzz run` step in `fuzz.yml` and `fuzz-nightly.yml`.

## Scope

CI-infra only. Five workflow files touched under `.github/workflows/`. Note: the separate `Lint` check failing on this PR is pre-existing on trunk-dev (a `clippy::needless_pass_by_value` error in `autumn/src/repository.rs:157`, also red on unrelated PR #1715) and is unrelated to these changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017fhWzzZryCowcHPCRM5Fx6)_