### PR TITLE
Fix broken and private intra-doc links across autumn-web and autumn-cli

### DIFF
--- a/autumn-cli/src/generate/controller.rs
+++ b/autumn-cli/src/generate/controller.rs
@@ -20,7 +20,7 @@
 //!
 //! # Modes
 //!
-//! - HTML (default): each action returns a Maud [`Markup`](maud::Markup) stub
+//! - HTML (default): each action returns a Maud `Markup` stub
 //!   rendered through a local `layout(...)` helper → HTTP 200 with placeholder
 //!   content.
 //! - `--api`: each action returns `AutumnResult<Json<serde_json::Value>>` with a

--- a/autumn-cli/src/i18n.rs
+++ b/autumn-cli/src/i18n.rs
@@ -2,7 +2,7 @@
 //! the keys defined in each `i18n/<locale>.ftl` (Fluent) file.
 //!
 //! autumn ships first-class Fluent i18n (`Locale::t("key")`, `t_with(...)`,
-//! and the [`t!`] macro), but the only signal that a key is missing from a
+//! and the `t!` macro), but the only signal that a key is missing from a
 //! locale is a *runtime* miss ([`Bundle::miss_count`] increments and a warning
 //! fires when a real user hits the page). This command surfaces those problems
 //! at build/CI time instead:
@@ -352,7 +352,7 @@ fn scan_stream(stream: &TokenStream, file: &str, result: &mut ScanResult) {
 
 /// Whether the identifier at `trees[i]` is preceded by a real `::` path
 /// separator — two consecutive `:` [`Punct`](TokenTree::Punct) tokens, the
-/// first (`trees[i - 2]`) joined to the second with [`Spacing::Joint`], which is
+/// first (`trees[i - 2]`) joined to the second with [`Spacing::Joint`](proc_macro2::Spacing::Joint), which is
 /// how `::` tokenizes.
 ///
 /// The caller has already confirmed `trees[i - 1]` is a `:` punct. A lone `:`

--- a/autumn/src/build_info.rs
+++ b/autumn/src/build_info.rs
@@ -2,7 +2,7 @@
 //!
 //! The consuming app's `build.rs` captures git + build-time facts and bakes
 //! them into the binary as `cargo:rustc-env` variables. The
-//! [`#[autumn_web::main]`](autumn_web_macros) entry-point macro reads those
+//! [`#[autumn_web::main]`](crate::main) entry-point macro reads those
 //! (via `option_env!`) **in the app crate's compile context** — together with
 //! the app's own `CARGO_PKG_NAME` / `CARGO_PKG_VERSION` — and hands them to
 //! [`__set_build_context`] at startup. `/actuator/info` then renders them.

--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -633,7 +633,7 @@ impl Subscriber {
 impl LocalChannelsBackend {
     /// Create a local backend with the given per-topic buffer capacity.
     ///
-    /// The replay ring buffer defaults to [`DEFAULT_REPLAY_CAPACITY`]. Use
+    /// The replay ring buffer defaults to `DEFAULT_REPLAY_CAPACITY`. Use
     /// [`LocalChannelsBackend::with_replay_capacity`] to override it.
     #[must_use]
     pub fn new(capacity: usize) -> Self {

--- a/autumn/src/dotenv.rs
+++ b/autumn/src/dotenv.rs
@@ -3,7 +3,7 @@
 //! A `.env` file is a **local-dev feeder for the highest configuration
 //! layer** — the `AUTUMN_*` environment-variable layer. It does *not*
 //! introduce a new precedence tier: `.env`-derived values are layered *under*
-//! the real environment via an overlay [`Env`] ([`DotenvEnv`] /
+//! the real environment via an overlay [`Env`] (`DotenvEnv` /
 //! [`DotenvOsEnv`]) rather than mutating the process environment, so a real
 //! shell environment variable always wins over the same key in a `.env` file.
 //!
@@ -25,7 +25,7 @@
 //! `AUTUMN_IS_DEBUG`) are intentionally **excluded** from the overlay — a
 //! `.env` file must not be able to change the active profile or bypass the
 //! prod / destructive-command guards. Set those in the real shell environment
-//! or via `--profile`. See [`PROFILE_SELECTOR_KEYS`].
+//! or via `--profile`. See `PROFILE_SELECTOR_KEYS`.
 
 use std::path::{Path, PathBuf};
 
@@ -347,12 +347,12 @@ pub(crate) fn dotenv_base_dir(env: &dyn Env) -> PathBuf {
 /// Resolve `.env` vars for the config manifest directory using the real OS env
 /// and resolved profile.
 ///
-/// The base directory is [`dotenv_base_dir`] — `AUTUMN_MANIFEST_DIR` when set,
+/// The base directory is `dotenv_base_dir` — `AUTUMN_MANIFEST_DIR` when set,
 /// else the process working directory — so `.env` is always read from the same
 /// place as `autumn.toml`.
 ///
 /// Returns the `(key, value)` pairs to apply (empty when gating disables
-/// loading — see [`should_load`]).
+/// loading — see `should_load`).
 ///
 /// # Errors
 /// Returns a [`DotenvError`] (with a `path:line` location) on a malformed or

--- a/autumn/src/download.rs
+++ b/autumn/src/download.rs
@@ -1,6 +1,6 @@
 //! Typed file downloads as an [`IntoResponse`].
 //!
-//! [`Download`] turns owned bytes, an async byte stream, an [`AsyncRead`], or
+//! [`Download`] turns owned bytes, an async byte stream, an [`AsyncRead`](tokio::io::AsyncRead), or
 //! a stored [`Blob`](crate::storage::Blob) into an HTTP response with the
 //! right `Content-Disposition`, `Content-Type`, and (when known)
 //! `Content-Length` headers — without hand-rolling header strings in every
@@ -196,7 +196,7 @@ impl Download {
         }
     }
 
-    /// Build a download from any [`AsyncRead`], streaming its bytes.
+    /// Build a download from any [`AsyncRead`](tokio::io::AsyncRead), streaming its bytes.
     ///
     /// The reader is wrapped with [`tokio_util::io::ReaderStream`], so the
     /// bytes are transferred incrementally rather than buffered in memory.
@@ -391,7 +391,7 @@ impl Download {
     ///   always serves the full `200` and does not advertise `Accept-Ranges`.
     ///
     /// This is the documented path to a seekable media response; see the
-    /// [`range`](crate::range) module docs for a `#[secured]` video example.
+    /// [`range`] module docs for a `#[secured]` video example.
     // The method is `async` for the blob path (which awaits a ranged store
     // read); without the `storage` feature that arm is compiled out, leaving no
     // `.await`, but the signature stays stable across feature sets.

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -3689,7 +3689,7 @@ fn unsubscribe_error_html(detail: &str) -> String {
 
 /// Bounce/complaint mail suppression list (issue #1247).
 ///
-/// Autumn already *detects* delivery failure: [`inbound_mail`] parses provider
+/// Autumn already *detects* delivery failure: `inbound_mail` parses provider
 /// bounce signals and spam complaints. This module closes the loop — it records
 /// the addresses that hard-bounced or complained and has [`Mailer::send`] skip
 /// them before transport, so a sending domain's reputation survives contact
@@ -3704,18 +3704,18 @@ fn unsubscribe_error_html(detail: &str) -> String {
 ///
 /// [`InMemorySuppressionStore`] is the zero-config default (process-local,
 /// lost on restart — perfect for a single instance, tests, and review apps).
-/// [`PgSuppressionStore`] (feature `db`) persists to a `mail_suppressions`
+/// [`PgSuppressionStore`](suppression::PgSuppressionStore) (feature `db`) persists to a `mail_suppressions`
 /// table for multi-instance deploys, mirroring the memory/durable split used
 /// by sessions and jobs. That table is **not** auto-created — provision it
-/// yourself (see [`PgSuppressionStore`]).
+/// yourself (see [`PgSuppressionStore`](suppression::PgSuppressionStore)).
 ///
 /// # Closing the loop
 ///
-/// Wire the provided [`record_inbound`] handler into the inbound router's
+/// Wire the provided `record_inbound` handler into the inbound router's
 /// `on_bounce` hook (or call [`SuppressionStore::suppress`] yourself) to turn a
 /// parsed provider bounce into a suppression entry. autumn's `on_spam` signal
 /// is an *inbound spam verdict*, not an outbound FBL complaint — see
-/// [`record_inbound`] for why routing it here is a safe no-op rather than
+/// `record_inbound` for why routing it here is a safe no-op rather than
 /// suppressing the wrong address.
 pub mod suppression {
     use std::future::Future;
@@ -3785,7 +3785,7 @@ pub mod suppression {
     }
 
     /// Cloneable handle to a [`SuppressionStore`] for storage on `AppState` and
-    /// attachment to a [`Mailer`].
+    /// attachment to a [`Mailer`](crate::mail::Mailer).
     #[derive(Clone)]
     pub struct SuppressionStoreHandle(Arc<dyn SuppressionStore>);
 
@@ -3884,7 +3884,7 @@ pub mod suppression {
     // ── Observability: a suppressed drop is never truly silent ───────────────
     static SUPPRESSED_SKIPS: AtomicU64 = AtomicU64::new(0);
 
-    /// Recipients [`Mailer::send`] has skipped as suppressed, process-wide.
+    /// Recipients [`Mailer::send`](crate::mail::Mailer::send) has skipped as suppressed, process-wide.
     ///
     /// Counted since startup. Pair with the structured `outcome =
     /// "skipped_suppressed"` log line emitted per skip.

--- a/autumn/src/middleware/server_timing.rs
+++ b/autumn/src/middleware/server_timing.rs
@@ -142,7 +142,7 @@ const fn read_db_snapshot(_timings: &DbTimings) -> (Option<f64>, usize) {
 static SERVER_TIMING: HeaderName = HeaderName::from_static("server-timing");
 
 /// Shared sentinel coordinating the primary and fallback `Server-Timing`
-/// layers, mirroring [`AccessLogEmitted`](crate::middleware::access_log).
+/// layers, mirroring `AccessLogEmitted`.
 ///
 /// The fallback inserts it into the **request** extensions on the way in, and
 /// the primary flips it once it appends its header, so the outermost fallback
@@ -175,7 +175,7 @@ impl ServerTimingEmitted {
 /// served response.
 ///
 /// Applied automatically by the framework router when
-/// [`server_timing_enabled`](crate::config::server_timing_enabled) resolves
+/// `server_timing_enabled` resolves
 /// to `true` for the active configuration/profile.
 #[derive(Clone, Debug)]
 pub struct ServerTimingLayer {

--- a/autumn/src/migrate.rs
+++ b/autumn/src/migrate.rs
@@ -808,7 +808,7 @@ where
 ///
 /// The table is created lazily by the *write* helpers ([`record_checksum`],
 /// [`record_checksums`], [`rebaseline_checksum`], [`delete_checksum`],
-/// [`delete_checksums`]), each of which calls [`ensure_checksum_table`] before
+/// [`delete_checksums`]), each of which calls `ensure_checksum_table` before
 /// writing. So the "validate → apply → record" sequence on the startup
 /// auto-migrate and shard paths still works: the pre-apply validate reads an
 /// empty map (nothing to fork from yet, no error), and the subsequent
@@ -928,7 +928,7 @@ where
 /// skips versions that already have a row), leaving a stale hash that only
 /// trips a validate on some *later* migrate run.
 ///
-/// [`ensure_checksum_table`] runs first (consistent with the other helpers,
+/// `ensure_checksum_table` runs first (consistent with the other helpers,
 /// and safe/idempotent under autocommit). Idempotent: deleting an absent row
 /// is a no-op.
 ///
@@ -950,7 +950,7 @@ where
 /// Delete the recorded checksum rows for several versions at once (bulk form of
 /// [`delete_checksum`]). Returns the number of rows actually removed.
 ///
-/// [`ensure_checksum_table`] runs first; an empty `versions` slice is a no-op
+/// `ensure_checksum_table` runs first; an empty `versions` slice is a no-op
 /// that returns `0`. Idempotent — versions with no recorded row are simply not
 /// counted.
 ///

--- a/autumn/src/payload_version.rs
+++ b/autumn/src/payload_version.rs
@@ -324,12 +324,12 @@ pub fn is_payload_version_error(message: &str) -> bool {
 /// Decode a stored payload into `T`, applying the declared upgrade chain.
 ///
 /// Reads the stored version `v` (missing marker → [`DEFAULT_VERSION`]). Then:
-/// - `v > expected_version` → [`VersionErrorKind::TooNew`] error;
+/// - `v > expected_version` → `VersionErrorKind::TooNew` error;
 /// - while `v < expected_version`: if no `upgrade` hook, a
-///   [`VersionErrorKind::NoUpgradePath`] error; otherwise apply the hook one
+///   `VersionErrorKind::NoUpgradePath` error; otherwise apply the hook one
 ///   step (`v -> v+1`);
 /// - finally `serde_json::from_value::<T>`; a failure here is a shape mismatch
-///   reported as [`VersionErrorKind::DecodeFailed`] (never a bare serde error).
+///   reported as `VersionErrorKind::DecodeFailed` (never a bare serde error).
 ///
 /// For the common un-versioned case (`expected_version == 1`, no marker, no
 /// upgrade) this reduces to a plain `from_value` — identical to the pre-#1205

--- a/autumn/src/test.rs
+++ b/autumn/src/test.rs
@@ -2727,7 +2727,7 @@ impl TestClient {
     /// Mints a fresh session containing the app's configured
     /// `auth.session_key` (default `"user_id"`) set to `user_id`, saves it to
     /// the session store the router reads, and seeds the cookie jar with the
-    /// session cookie. A subsequent request to a `#[secured]` / [`Auth`]-gated
+    /// session cookie. A subsequent request to a `#[secured]` / [`Auth`](crate::auth::Auth)-gated
     /// route then extracts the same identity a real login would produce.
     ///
     /// This sets **identity only** — authorization still runs. A user acted-as


### PR DESCRIPTION
## Before / After

**Before:** The **Documentation build** CI check failed on `trunk-dev` for every PR. The check runs `./scripts/check-docs.sh` with `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links"`, and rustdoc aborted with 24 errors in `autumn-web` (11 unresolved links, 13 links to private items) — pre-existing on trunk-dev, introduced by recently-merged doc churn.

**After:** `./scripts/check-docs.sh` exits 0. All 27 offending links (24 in `autumn-web` + 3 that surfaced in `autumn-cli` once `autumn-web` was clean) resolve or are correctly de-linked. No `#[allow(rustdoc::...)]` was used.

## How

Two strategies, chosen per site:
- **Linked to the real target** where a public/reachable item exists — e.g. `[`AsyncRead`](tokio::io::AsyncRead)`, `[`Mailer`](crate::mail::Mailer)`, `[`Auth`](crate::auth::Auth)`, `[`#[autumn_web::main]`](crate::main)`, `[`Spacing::Joint`](proc_macro2::Spacing::Joint)`.
- **De-linked to plain inline code** (kept the backticks, dropped the `[ ]`) where the item is private or gated out of the docs feature posture — e.g. `DEFAULT_REPLAY_CAPACITY`, the `dotenv` internals, `ensure_checksum_table`, `VersionErrorKind::*`, `server_timing_enabled`, and feature-gated `inbound-mail` items.

Also removed one redundant explicit link target (`[`range`](crate::range)` -> `[`range`]`) at `download.rs:394`.

### Files touched
- `autumn/src/build_info.rs`
- `autumn/src/channels.rs`
- `autumn/src/dotenv.rs`
- `autumn/src/download.rs`
- `autumn/src/mail.rs`
- `autumn/src/migrate.rs`
- `autumn/src/middleware/server_timing.rs`
- `autumn/src/payload_version.rs`
- `autumn/src/test.rs`
- `autumn-cli/src/generate/controller.rs`
- `autumn-cli/src/i18n.rs`

Doc-comment-only changes: 11 files, 28 insertions / 28 deletions. No CHANGELOG, no `skills/`, no version bump.

## Note on other CI reds
Known-external failures unrelated to this change: **Lint** (fix in #1705) and **Fuzz** jobs (fix in #1717). The target of this PR is the **Documentation build** check going green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCY2S3WLiNfvNgdMKhanxF)_