### PR TITLE
fix(auth): do not grant step-up strong-auth on remember-cookie restore (#1397)

### DIFF
--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -2506,6 +2506,12 @@ async fn establish_remember_login(
     headers: &axum::http::HeaderMap,
 ) {{
     session.rotate_id().await;
+    // `rotate_id()` PRESERVES existing session data, so a stale step-up
+    // "recently did strong auth" claim from a prior authenticated state in this
+    // browser could survive into the restored session. Actively CLEAR it before
+    // writing identity keys — a remember-cookie restore must never inherit a
+    // prior session's "sudo mode" (issue #833/#1397).
+    session.remove(autumn_web::step_up::STEP_UP_SESSION_KEY).await;
     // A remembered request must be fully authenticated for protected routes:
     // write the SAME identity keys login writes. `{snake_name}_id` powers the
     // identity extractors / tracked-session lookup, and the configured
@@ -2517,9 +2523,10 @@ async fn establish_remember_login(
     // remember cookie is *not* strong authentication. Restoring a session from
     // it must not satisfy step-up "sudo mode" — otherwise a stolen/unattended
     // persistent cookie would silently pass `#[step_up]` routes (e.g. account
-    // deletion) with no password reauth. Leaving the claim absent/stale forces
-    // those routes to redirect to `/reauth` until the user re-enters their
-    // password (issue #833).
+    // deletion) with no password reauth. Because `rotate_id()` preserves data we
+    // additionally CLEAR any pre-existing claim above (defense against a prior
+    // fresh step-up surviving the restore), forcing those routes to redirect to
+    // `/reauth` until the user re-enters their password (issue #833).
     if let Ok(mut db) = pool.get().await {{
         let session_row = build_session_row(session, {snake_name}_id, ip, headers).await;
         let _ = diesel::insert_into({sess_table}::table)

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -2513,7 +2513,13 @@ async fn establish_remember_login(
     // it a remember-cookie restore would rotate the token but still 401.
     session.insert("{snake_name}_id", {snake_name}_id.to_string()).await;
     session.insert(auth_session_key, {snake_name}_id.to_string()).await;
-    autumn_web::step_up::set_last_strong_auth_at(session).await;
+    // Intentionally do NOT stamp `set_last_strong_auth_at` here: a long-lived
+    // remember cookie is *not* strong authentication. Restoring a session from
+    // it must not satisfy step-up "sudo mode" — otherwise a stolen/unattended
+    // persistent cookie would silently pass `#[step_up]` routes (e.g. account
+    // deletion) with no password reauth. Leaving the claim absent/stale forces
+    // those routes to redirect to `/reauth` until the user re-enters their
+    // password (issue #833).
     if let Ok(mut db) = pool.get().await {{
         let session_row = build_session_row(session, {snake_name}_id, ip, headers).await;
         let _ = diesel::insert_into({sess_table}::table)

--- a/autumn-cli/src/generate/auth.rs
+++ b/autumn-cli/src/generate/auth.rs
@@ -2506,12 +2506,22 @@ async fn establish_remember_login(
     headers: &axum::http::HeaderMap,
 ) {{
     session.rotate_id().await;
-    // `rotate_id()` PRESERVES existing session data, so a stale step-up
-    // "recently did strong auth" claim from a prior authenticated state in this
-    // browser could survive into the restored session. Actively CLEAR it before
+    // `rotate_id()` PRESERVES existing session data, so ANY stale step-up /
+    // reauth elevation marker from a prior authenticated state in this browser
+    // could survive into the restored session. Actively CLEAR them ALL before
     // writing identity keys — a remember-cookie restore must never inherit a
-    // prior session's "sudo mode" (issue #833/#1397).
+    // prior session's "sudo mode", nor resume a mid-step-up elevated state.
+    // Two markers grant/advance elevation and must be dropped:
+    //   * `last_strong_auth_at` (STEP_UP_SESSION_KEY) — the "recently did strong
+    //     auth" claim that `#[step_up]` routes check.
+    //   * `reauth_pw_ok` — the reauth flow's "password already verified, awaiting
+    //     TOTP code" marker (valid ~10 min). Left behind, a restored session
+    //     could POST /reauth with only a TOTP/recovery code and mint a fresh
+    //     `last_strong_auth_at` WITHOUT re-entering the password, defeating this
+    //     downgrade. `rotate_id()` preserves it too, so clear it here as well.
+    // (issue #833/#1397).
     session.remove(autumn_web::step_up::STEP_UP_SESSION_KEY).await;
+    session.remove("reauth_pw_ok").await;
     // A remembered request must be fully authenticated for protected routes:
     // write the SAME identity keys login writes. `{snake_name}_id` powers the
     // identity extractors / tracked-session lookup, and the configured

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -3149,8 +3149,10 @@ fn generate_auth_in_fresh_project_creates_expected_files() {
     );
     assert_eq!(
         routes.matches("session.insert(\"user_id\"").count(),
-        3,
-        "User auth routes should only write user_id as the generated account id key"
+        4,
+        "User auth routes should only write user_id as the generated account id key \
+         (login, reset_password, confirm_email, and the remember-me restore path \
+         establish_remember_login, which must set the same identity keys as a fresh login)"
     );
     assert!(
         routes.contains("email.split_once('@')"),


### PR DESCRIPTION
## What & why

**Before:** in apps generated by `autumn generate auth`, restoring a session from a "Remember me" cookie stamped `set_last_strong_auth_at`, marking the request as if the user had just re-entered their password.
**After:** it no longer does. A long-lived remember cookie is not strong authentication, so `#[step_up]` routes (e.g. account deletion) correctly redirect to `/reauth` until the user actually re-enters their password.

**Security impact:** a stolen or unattended "Remember me" cookie could auto-login through the remember-me middleware and then silently satisfy step-up "sudo mode" for the default freshness window with no password reauthentication. This is the P1 raised by the Codex review on #1704.

**Why this is a follow-up rather than part of #1704:** the fix was committed during #1704's review, but this session's git push was temporarily blocked (the session's git proxy was re-provisioned mid-work and its credentials were wiped), and #1704 merged before the commit could be pushed. This lands it cleanly on top of current trunk-dev.

## How
One change in the generated auth template `autumn-cli/src/generate/auth.rs`, inside `establish_remember_login`: remove the `set_last_strong_auth_at(session)` call on the remember-restore path and replace it with an explanatory comment. The legitimate login / reauth / TOTP paths still stamp strong-auth. Generator-only; the saas example has no step-up concept and is unaffected.

## Verification
- `cargo check -p autumn-cli` — clean
- `cargo clippy -p autumn-cli --all-targets -- -D warnings` — clean
- `cargo test -p autumn-cli --bins embedded_saas_matches_example_saas` — drift gate green
- `cargo fmt --all --check` — clean

Refs #1397

---
_Generated by [Claude Code](https://claude.ai/code/session_01USvLLjGSnwdvb8fYWUbU7J)_

---
## Also in this PR (trunk-dev unblock)
A second commit (`c60d49e2`) fixes a generator test that regressed from #1704: `generate_auth_in_fresh_project_creates_expected_files` (`autumn-cli/tests/generate.rs`) asserted exactly 3 `session.insert("user_id")` occurrences, but the remember-me restore path `establish_remember_login` now legitimately emits a 4th (mirroring the `login` handler's identity inserts). The assertion is updated 3 → 4 with an expanded message naming the four emitting handlers (login, reset_password, confirm_email, and the remember-me restore). No generated runtime behavior changes; the step-up fix is unaffected. Verified: the test, the saas drift gate, `cargo clippy -p autumn-cli --all-targets -D warnings`, and `cargo fmt --check` all pass.