### PR TITLE
docs: changelog + skills for merged feature waves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1040,7 +1040,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   general-purpose compression middleware to redo that work on every request.
 - **cli:** `autumn test` provisions and targets an isolated test database before
   running your suite — it resolves the test DB URL with the same precedence as
-  `autumn migrate` (autumn.toml → `AUTUMN_DATABASE__*` → `DATABASE_URL`), derives
+  `autumn migrate` (`AUTUMN_DATABASE__PRIMARY_URL` → `AUTUMN_DATABASE__URL` →
+  `DATABASE_URL` → `autumn.toml`), derives
   a `_test`-suffixed database name, creates it if missing, runs all pending app +
   framework migrations, exports `AUTUMN_ENV=test` and the resolved
   `DATABASE_URL`, then shells out to `cargo test` (exiting with its code).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1038,6 +1038,89 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bodies (computed once per process, not per request) when the client's
   `Accept-Encoding` accepts them, instead of relying solely on the
   general-purpose compression middleware to redo that work on every request.
+- **cli:** `autumn test` provisions and targets an isolated test database before
+  running your suite — it resolves the test DB URL with the same precedence as
+  `autumn migrate` (autumn.toml → `AUTUMN_DATABASE__*` → `DATABASE_URL`), derives
+  a `_test`-suffixed database name, creates it if missing, runs all pending app +
+  framework migrations, exports `AUTUMN_ENV=test` and the resolved
+  `DATABASE_URL`, then shells out to `cargo test` (exiting with its code).
+  `--reset` drops and recreates the test DB first, and trailing `-- <args>` are
+  forwarded to the harness (`autumn test -- --nocapture`). Refuses to run against
+  a non-`_test` database (issue #1056).
+- **test:** `TestResponse::query_count()` and
+  `TestResponse::assert_max_queries(n)` turn the `Server-Timing` query counter
+  into a test assertion, so you can pin a route's SQL budget and catch N+1
+  regressions — chained after a request, `assert_max_queries` panics naming the
+  route when the observed count exceeds `n` (issue #1262).
+- **widgets:** server-rendered, accessible, zero-JavaScript SVG chart helpers in
+  `autumn_web::widgets` (all prelude re-exported, with `/_stories` gallery
+  entries) — `sparkline`, `bar_chart` (bars anchored at zero), and `line_chart`,
+  each with a `_with` variant taking a `ChartConfig` builder (`.title(...)`,
+  `.min(...)`/`.max(...)` axis override, accessible name) (issue #1231).
+- **jobs:** opt-in versioned job payloads with an upgrade path — annotate a
+  handler with `#[job(version = N, upgrade = ...)]` to wrap its args in an
+  `{ "__autumn_schema_version": N, "args": … }` envelope, and the `upgrade` hook
+  (`fn(u32, Value) -> Result<Value, E>`) migrates older stored payloads on the
+  fly so rolling deploys drain the old queue instead of dead-lettering. Jobs with
+  no version are stored raw (zero behaviour change); runtime helpers live in
+  `autumn_web::payload_version` (issue #1205).
+- **repository:** `#[repository(...)]` associations can now declare a
+  `dependent(ChildRepository, fk = "col", on_delete = …)` cascade, so deleting a
+  parent handles its children in one transaction —
+  `on_delete = destroy` (soft-delete-aware, fires child hooks) `| delete_all |
+  nullify | restrict` (probes for referencing rows before mutating and errors if
+  any still exist) (issue #1369).
+- **audit:** version/audit writes are auto-attributed to the current actor. A new
+  `autumn_web::current` module carries a request-scoped actor
+  (`Current::set_actor` / `Current::actor`, plus `Current::set_default_actor` for
+  jobs and the scheduler); `VersionEntry.actor` now records the authenticated
+  user with no per-call plumbing, and stays `None` when unset (issue #1383).
+- **auth:** configurable password policy and persistent "remember me" login, both
+  scaffolded automatically by `autumn generate auth`. `[auth.password]`
+  (`min_length`, `reject_common` against a bundled weak-password corpus,
+  `breach_check` = `off` | `fail_open` | `fail_closed` HIBP lookups) is enforced
+  via `autumn_web::auth::PasswordConfig`/`PasswordPolicy`; `[auth.remember]`
+  (`enabled`, `duration_secs`, `cookie_name`) issues selector/verifier remember
+  cookies backed by a `{user}_remember_tokens` table (issues #1345, #1397).
+- **api:** generated `#[repository(api = ...)]` JSON list endpoints now return a
+  page envelope — `content`, `page`, `size`, `total_elements`, `total_pages`,
+  `has_next`, `has_previous` — driven by `?page=`/`?size=` query params, and
+  create/update handlers validate the decoded payload against the model's
+  `#[validate(...)]` rules before hitting the database, returning **422 Problem
+  Details** with a per-field `errors` map. Payloads without `Validate` compile to
+  a no-op via the autoref `MaybeValidate` specialization (issues #1237, #1253).
+- **cli:** first-class `autumn db backup` and `autumn db restore` with retention.
+  `db backup [--dir DIR] [--format custom|plain] [--keep N] [--shard NAME]
+  [--control-only]` dumps the control DB and every shard into
+  `<dir>/<profile>/<timestamp>/` with a `manifest.json`, integrity-checks each
+  artifact with `pg_restore --list` before reporting success, and `--keep N`
+  prunes to the newest N runs. `db restore <ARTIFACT> [--shard NAME] [--force]`
+  verifies every artifact before touching a database and is gated by the same
+  production guard as `db drop` (issue #1595).
+- **security:** multipart uploads are validated by magic bytes rather than the
+  spoofable client `Content-Type` — the extractor sniffs the real content type
+  whenever an `allowed_content_types` allow-list is configured or strict mode is
+  on. Set `security.upload.reject_on_content_type_mismatch = true` to reject a
+  declared-vs-sniffed mismatch (or an unsniffable declared-binary upload) as a
+  spoof (issue #1354).
+- **app:** web/worker process roles for independent scaling — a process `role`
+  (`combined` | `web` | `worker`), set via `role = "…"` in config or the
+  `AUTUMN_ROLE` env var, selects whether it serves HTTP, runs job workers + the
+  cron scheduler, or both (`combined`, the default, is unchanged; `web` can still
+  enqueue jobs). Run with `autumn serve --role web|worker|combined`, and
+  `release init --split-workers` splices a dedicated `worker:` service into the
+  generated docker-compose output. A split (non-combined) role requires a
+  `postgres`/`redis` jobs backend, since an in-memory queue can't cross processes
+  (issue #1613).
+- **test:** fake-data factories for models plus bulk seed generation. A new
+  `autumn_web::fake` module exposes deterministic fake generators (`name`,
+  `email`, `sentence`, `int_range`, `uuid`, … seeded via `AUTUMN_FAKE_SEED` or
+  `reseed`), and `#[model]` now generates a `{Model}Factory` with per-field
+  setters, `.fake()`/`.fake_all()` to fill unset fields with realistic data
+  inferred from field name + type, and `.build`/`.build_many`/`.create`/
+  `.create_many`. `autumn seed --count N --model <Name>` (used together)
+  generates and inserts N faked rows via the model's factory instead of running
+  the hand-written seed body (issue #1343).
 
 ### Fixed
 
@@ -1185,6 +1268,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **workspace:** `Cargo.lock` is now committed to the repository (it was
   previously gitignored) so builds are reproducible and dependency updates
   are reviewable.
+- **dev:** `autumn dev` now renders a full-screen browser overlay carrying the
+  compiler diagnostics when a rebuild fails, instead of leaving a blank or stale
+  page — injected under the strict nonce-based CSP and cleared on the next
+  successful rebuild (issue #1115).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1074,7 +1074,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `autumn_web::current` module carries a request-scoped actor
   (`Current::set_actor` / `Current::actor`, plus `Current::set_default_actor` for
   jobs and the scheduler); `VersionEntry.actor` now records the authenticated
-  user with no per-call plumbing, and stays `None` when unset (issue #1383).
+  user with no per-call plumbing, and falls back to `"system"` when unset — the
+  `_autumn_version_history.actor` column is `NOT NULL DEFAULT 'system'` and the
+  generated repository code substitutes `VersionEntry::SYSTEM_ACTOR` (issue #1383).
 - **auth:** configurable password policy and persistent "remember me" login, both
   scaffolded automatically by `autumn generate auth`. `[auth.password]`
   (`min_length`, `reject_common` against a bundled weak-password corpus,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1067,8 +1067,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **repository:** `#[repository(...)]` associations can now declare a
   `dependent(ChildRepository, fk = "col", on_delete = …)` cascade, so deleting a
   parent handles its children in one transaction —
-  `on_delete = destroy` (soft-delete-aware, fires child hooks) `| delete_all |
-  nullify | restrict` (probes for referencing rows before mutating and errors if
+  `on_delete` = `destroy` (soft-delete-aware, fires child hooks) | `delete_all` |
+  `nullify` | `restrict` (probes for referencing rows before mutating and errors if
   any still exist) (issue #1369).
 - **audit:** version/audit writes are auto-attributed to the current actor. A new
   `autumn_web::current` module carries a request-scoped actor

--- a/skills/autumn-patterns/SKILL.md
+++ b/skills/autumn-patterns/SKILL.md
@@ -60,6 +60,37 @@ async fn create_post_returns_redirect() {
 Always use `TestApp` in tests — never spin up a real server or hit a live
 database in unit tests.
 
+### Assert a route's query budget — catch N+1 (trunk-dev)
+
+Pin the SQL a route is allowed to run so an accidental N+1 fails the test:
+
+```rust
+client.get("/posts").send().await
+    .assert_status(200)
+    .assert_max_queries(3);   // panics naming the route if the count exceeds 3
+```
+
+`TestResponse::query_count()` returns the observed count (from the
+`Server-Timing` query counter); `assert_max_queries(n)` chains and returns
+`&Self` (issue #1262).
+
+### Fake-data factories and bulk seeding (trunk-dev)
+
+Don't hand-build model fixtures. `#[model]` generates a `{Model}Factory`; fill
+the rest with realistic fake data inferred from each field's name + type:
+
+```rust
+let post = Post::factory().title("Fixed").fake().build();  // NewPost, unset fields faked
+let posts = Post::factory().fake().build_many(10);         // Vec<NewPost>, each row re-drawn
+let saved = Post::factory().fake().create(&mut db).await?; // persist
+```
+
+Generators live in `autumn_web::fake` (`name`, `email`, `sentence`,
+`int_range`, `uuid`, …); seed deterministically with `AUTUMN_FAKE_SEED` or
+`autumn_web::fake::reseed(seed)`. For bulk data outside tests,
+`autumn seed --count N --model <Name>` (both flags together) inserts N faked rows
+via the model's factory (issue #1343). See `docs/guide/seeding.md`.
+
 ## Repository design
 
 Prefer free functions over a repository struct unless `#[repository]` is

--- a/skills/autumn-patterns/SKILL.md
+++ b/skills/autumn-patterns/SKILL.md
@@ -82,7 +82,7 @@ the rest with realistic fake data inferred from each field's name + type:
 ```rust
 let post = Post::factory().title("Fixed").fake().build();  // NewPost, unset fields faked
 let posts = Post::factory().fake().build_many(10);         // Vec<NewPost>, each row re-drawn
-let saved = Post::factory().fake().create(&mut db).await?; // persist
+let saved = Post::factory().fake().create(&pool).await;    // persist (panics on failure)
 ```
 
 Generators live in `autumn_web::fake` (`name`, `email`, `sentence`,

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -356,6 +356,24 @@ See `examples/reddit-clone` (`Post` ↔ `Tag` via `post_tags`) for a full
 worked example, and `docs/adr/0008-associations-and-eager-loading.md` for
 the design.
 
+Deleting a parent can cascade to its children in one transaction — declare
+`dependent(...)` on the parent's `#[repository]` instead of hand-writing the
+child cleanup **(unreleased — trunk-dev)**:
+
+```rust
+#[autumn_web::repository(Post,
+    dependent(CommentRepository, fk = "post_id", on_delete = destroy))]
+pub trait PostRepository {}
+```
+
+`on_delete` = `destroy` (soft-delete-aware, fires each child's hooks — does
+**not** recurse into the child's own `dependent`) | `delete_all` (bulk delete,
+no child hooks) | `nullify` (set the FK null) | `restrict` (probe for
+referencing rows *before* mutating; errors `cannot delete: dependent N row(s) …`
+if any still exist). The generated `delete_by_id` loads and locks the parent,
+applies every declared action, then deletes the parent — all in a single
+transaction (Part of #1369). See `docs/guide/repositories.md`.
+
 ### Model state machines — `#[state_machine]`
 
 **Never hand-roll status-transition validation.** Declare valid transitions on
@@ -440,6 +458,22 @@ Read routing: with `database.replica_url` set, all generated reads use the
 replica automatically; writes always hit the primary. See
 `docs/guide/repositories.md` and `docs/guide/pagination.md`.
 
+### JSON API endpoints — page envelope + write validation (unreleased — trunk-dev)
+
+A `#[repository(api = "/api/posts")]` list endpoint returns a page envelope, and
+create/update handlers validate the decoded payload before touching the DB:
+
+- **List** — `GET /api/posts?page=1&size=20` returns
+  `{ content: [...], page, size, total_elements, total_pages, has_next,
+  has_previous }` (`page` is 1-based, default 1; `size` clamped). Custom
+  handlers can use `filter.page()` / `filter.per_page()` / `filter.limit_offset()`.
+- **Create/update** — the decoded write payload runs the model's
+  `#[validate(...)]` rules first; on failure the handler returns **422 Problem
+  Details** with a per-field `errors` map instead of inserting. Models without a
+  `Validate` derive compile to a no-op via the autoref `MaybeValidate`
+  specialization (no migration burden), and this applies to plain and
+  policy-backed handlers (#1237, #1253). See `docs/guide/pagination.md`.
+
 ### Transactions
 
 `Db::tx(f)` runs a READ COMMITTED transaction. On trunk-dev
@@ -518,6 +552,25 @@ export AUTUMN_SECURITY__SIGNING_SECRET="$(openssl rand -hex 32)"
 
 For rotation, set `[security.signing_secret].previous_secrets` until old
 cookies, CSRF tokens, flash state, and signed storage URLs expire.
+
+### Audit actor attribution (unreleased — trunk-dev)
+
+Version/audit writes are auto-attributed to the current actor — no per-call
+plumbing. The log-context middleware opens an empty actor scope per request; set
+the authenticated user once and every `VersionEntry.actor` (via
+`MutationContext::actor`) records it:
+
+```rust
+use autumn_web::current::Current;
+
+Current::set_actor(format!("user:{user_id}")); // ambient, task-local, request-scoped
+// any repository mutation in this request now records this actor on its VersionEntry
+```
+
+For jobs and the scheduler (no request scope), set a process-wide default with
+`Current::set_default_actor(...)`, or run a bounded scope via
+`autumn_web::current::with_actor(actor, async { ... })`. Unset → `actor` is
+`None` (prior behaviour) (#1383). See `docs/guide/version-history.md`.
 
 ## OAuth2/OIDC scaffolding
 
@@ -730,6 +783,14 @@ coalesced enqueue is a no-op `Ok(())`.
   `set_result(json)` / `set_user_error(msg)`; poll `GET /_autumn/jobs/{token}`
   (JSON or self-polling htmx fragment). Config: `jobs.tracking.ttl_secs`
   (default 24h), `jobs.tracking.route_enabled`.
+- **Versioned payloads**: opt into a payload schema version with
+  `#[job(version = N, upgrade = upgrade_fn)]`. Autumn wraps the args in an
+  `{ "__autumn_schema_version": N, "args": … }` envelope; the `upgrade` hook
+  (`fn(u32, serde_json::Value) -> Result<Value, E>`) runs only for older stored
+  payloads, so a rolling deploy drains the old queue instead of dead-lettering.
+  A job with no `version` is stored raw (zero behaviour change). Helpers:
+  `autumn_web::payload_version::{split_version, wrap}` (Closes #1205). See
+  `docs/guide/jobs.md`.
 
 **(unreleased)** Events & listeners — a typed domain event bus so one action
 can fan out without inline coupling: `#[event]` on a struct, publish via the
@@ -809,6 +870,20 @@ serve-stale; `cache::jittered_ttl(base, fraction)` de-synchronizes mass
 expiry. A failed fill never poisons the key. See
 `docs/guide/cache-stampede.md`.
 
+**(unreleased)** Upload content-type validation — multipart uploads are
+validated by **magic bytes**, not the spoofable client `Content-Type`. The
+`Multipart` extractor sniffs the real type (`sniff_content_type`) whenever an
+`allowed_content_types` allow-list is configured or strict mode is on. Reject
+spoofs with:
+
+```toml
+[security.upload]
+reject_on_content_type_mismatch = true  # declared-vs-sniffed mismatch (or an
+                                        # unsniffable declared-binary) → rejected
+```
+
+(env `AUTUMN_SECURITY__UPLOAD__REJECT_ON_CONTENT_TYPE_MISMATCH`) (#1354).
+
 ## View helpers and widgets (unreleased — trunk-dev, not in published 0.5.0)
 
 Trunk-dev ships framework view widgets — prefer these over hand-rolled Maud
@@ -819,6 +894,7 @@ for the common cases:
 | `link_to(label, href)` / `link_to_with(..., &LinkToOptions)` | Escaped GET anchors; auto `rel="noopener"` on `target="_blank"` |
 | `button_to(label, href, Method, csrf_token)` / `button_to_with` | Single-button form for state-changing actions; CSRF is a required arg; non-GET emits hidden `_method` override |
 | `card(&body, &CardConfig::new().title("..."))` / `stat_card(label, value, link)` | Titled panels and metric tiles (`autumn_web::widgets`, prelude re-export) |
+| `sparkline(&points)` / `bar_chart(&series)` / `line_chart(&series)` (+ `_with(&ChartConfig)`) | Server-rendered, accessible, zero-JS **SVG charts** from `&[(&str, f64)]` (`/_stories` gallery). `bar_chart` anchors bars at zero; `ChartConfig::new().title(...).min(...).max(...)` sets an axis override / accessible name (#1231) |
 | `tabs(id, &[(id, label, markup)])` | No-JS CSS-only tab switcher (`docs/guide/tabs.md`) |
 | `modal(id, title, &body, &ModalConfig)` / `confirm_action(...)` | Native `<dialog>` confirm for destructive actions — replaces `hx-confirm`/`window.confirm()` |
 | `badge(label, BadgeVariant::for_label(status))` / `status_tag(label)` | Semantic status pill; `BadgeVariant` = `Neutral`/`Info`/`Success`/`Warning`/`Danger`, `for_label` picks a deterministic color; `badge_with`/`BadgeConfig` set `title`/`aria-label`. Composes inside a `data_table` cell |
@@ -979,6 +1055,25 @@ Use `AUTUMN_SECTION__FIELD` for env overrides, for example
 `AUTUMN_DATABASE__PRIMARY_URL`, `AUTUMN_JOBS__BACKEND`,
 `AUTUMN_SECURITY__SIGNING_SECRET`, and
 `AUTUMN_SECURITY__WEBHOOKS__REPLAY__BACKEND`.
+
+### Process roles — web/worker split (unreleased — trunk-dev)
+
+Scale HTTP and background work independently by giving a process a **role** (no
+app-code change) via `role = "web"|"worker"|"combined"` in config or the
+`AUTUMN_ROLE` env var:
+
+| Role | Serves HTTP | Runs workers + scheduler |
+|---|---|---|
+| `combined` (default) | yes | yes — unchanged behaviour |
+| `web` | yes (can still enqueue jobs) | no |
+| `worker` | no (probe-only router) | yes |
+
+- Run a specific tier: `autumn serve --role web|worker|combined`.
+- A split (non-`combined`) role **requires a `postgres`/`redis` jobs backend** —
+  an in-memory queue can't cross processes.
+- `release init --split-workers` splices a dedicated `worker:` service into the
+  generated **docker-compose** output and sets the web-tier role on the `app`
+  service (#1613). See `docs/guide/cloud-native.md`.
 
 ## Observability defaults
 
@@ -1210,6 +1305,11 @@ autumn generate tauri            # desktop sidecar project (cargo tauri build)
 autumn generate plugin my-plugin # installable/conformant plugin crate
 autumn token issue service:ci --name ci --scope posts:write   # scoped tokens; also list, rotate
 autumn i18n check                # compare t!/t(...) keys vs i18n/*.ftl; --strict, --format json
+autumn test                      # provision/target an isolated *_test DB, migrate, then cargo test
+autumn test --reset -- --nocapture   # drop+recreate the test DB; forward args to the harness
+autumn db backup --keep 7        # dump control DB + shards to ./backups/<profile>/<ts>/; db restore <artifact> reverses it
+autumn seed --count 50 --model Post  # generate+insert 50 faked rows via the model's factory (both flags together)
+autumn serve --role worker       # run only workers + scheduler (web/worker split); also --role web|combined
 ```
 
 `autumn i18n check` scans `**/*.rs` for string-literal keys passed to
@@ -1271,6 +1371,28 @@ applied migration's state as `ok`, `changed`, or `unrecorded`. Use
 legacy migrations applied before the checksum feature existed; use
 `autumn migrate baseline --force <version>` only when a deliberate edit
 is intended and the fork risk is accepted.
+
+### `autumn test` — isolated test DB (unreleased — trunk-dev, issue #1056)
+
+`autumn test` resolves the test DB URL with the same precedence as
+`autumn migrate` (autumn.toml → `AUTUMN_DATABASE__*` → `DATABASE_URL`), derives a
+`_test`-suffixed name, creates it if missing, runs all pending app + framework
+migrations, exports `AUTUMN_ENV=test` + the resolved `DATABASE_URL`, then runs
+`cargo test` (exiting with its code). `--reset` drops and recreates the test DB
+first; trailing `-- <args>` forward to the harness. It refuses to run against a
+non-`_test` database.
+
+### `autumn db backup` / `db restore` (unreleased — trunk-dev, issue #1595)
+
+`autumn db backup [--dir DIR] [--format custom|plain] [--keep N] [--shard NAME]
+[--control-only]` dumps the control DB and every shard to
+`<dir>/<profile>/<timestamp>/` (default `./backups`) with a `manifest.json`,
+integrity-checks each artifact with `pg_restore --list` before reporting success
+(a partial artifact is removed and the command exits non-zero), and `--keep N`
+prunes to the newest N runs. `autumn db restore <ARTIFACT> [--shard NAME]
+[--force]` verifies every artifact before touching a database and is gated by the
+same production guard as `db drop` (refuses non-dev/test without `--force`). See
+`docs/guide/deployment.md`.
 
 `autumn destroy` mirrors `autumn generate` argument-for-argument and never
 touches a database — it only reverses generated files/migrations.

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -466,7 +466,8 @@ create/update handlers validate the decoded payload before touching the DB:
 - **List** — `GET /api/posts?page=1&size=20` returns
   `{ content: [...], page, size, total_elements, total_pages, has_next,
   has_previous }` (`page` is 1-based, default 1; `size` clamped). Custom
-  handlers can use `filter.page()` / `filter.per_page()` / `filter.limit_offset()`.
+  handlers can use `filter.page()` / `filter.size()` / `filter.limit()` /
+  `filter.offset()`.
 - **Create/update** — the decoded write payload runs the model's
   `#[validate(...)]` rules first; on failure the handler returns **422 Problem
   Details** with a per-field `errors` map instead of inserting. Models without a
@@ -570,7 +571,9 @@ Current::set_actor(format!("user:{user_id}")); // ambient, task-local, request-s
 For jobs and the scheduler (no request scope), set a process-wide default with
 `Current::set_default_actor(...)`, or run a bounded scope via
 `autumn_web::current::with_actor(actor, async { ... })`. Unset → `actor` is
-`None` (prior behaviour) (#1383). See `docs/guide/version-history.md`.
+recorded as `"system"` — the `_autumn_version_history.actor` column is `NOT NULL
+DEFAULT 'system'` and the generated code falls back to `VersionEntry::SYSTEM_ACTOR`
+(#1383). See `docs/guide/version-history.md`.
 
 ## OAuth2/OIDC scaffolding
 
@@ -1375,7 +1378,8 @@ is intended and the fork risk is accepted.
 ### `autumn test` — isolated test DB (unreleased — trunk-dev, issue #1056)
 
 `autumn test` resolves the test DB URL with the same precedence as
-`autumn migrate` (autumn.toml → `AUTUMN_DATABASE__*` → `DATABASE_URL`), derives a
+`autumn migrate` (`AUTUMN_DATABASE__PRIMARY_URL` → `AUTUMN_DATABASE__URL` →
+`DATABASE_URL` → autumn.toml — env wins over TOML), derives a
 `_test`-suffixed name, creates it if missing, runs all pending app + framework
 migrations, exports `AUTUMN_ENV=test` + the resolved `DATABASE_URL`, then runs
 `cargo test` (exiting with its code). `--reset` drops and recreates the test DB

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -82,6 +82,12 @@ If the `mail` feature is enabled:
 recompiles + restarts automatically. Tailwind CSS is rebuilt on template
 changes.
 
+On trunk-dev (unreleased — not in the published 0.5.0 CLI), when a rebuild
+**fails** the browser renders the compiler diagnostics as a full-screen overlay
+(under a strict nonce-based CSP) instead of leaving a blank or stale page; it
+clears on the next successful rebuild (issue #1115). See
+`docs/guide/dev-error-overlay.md`.
+
 ## Common failures
 
 | Symptom | Fix |

--- a/skills/generate/SKILL.md
+++ b/skills/generate/SKILL.md
@@ -32,7 +32,7 @@ them; on 0.5.0 fall back to the documented manual alternative.
 | `migration` | `migration add_slug_to_posts` | Empty timestamped migration file |
 | `mailer` | `mailer User` | Mailer struct + email templates (generator appends `Mailer` → produces `UserMailer`) |
 | `task` | `task RecalculateCounts` | `#[task]` operational command |
-| `auth` | `auth User --oauth github,google` | Full auth scaffold (login/register/password reset/OAuth) |
+| `auth` | `auth User --oauth github,google` | Full auth scaffold (login/register/password reset/OAuth); **(trunk-dev)** also scaffolds a configurable password policy and persistent "remember me" login by default |
 | `admin` | `admin Post title:String body:Text` | Admin plugin resource page — fields must be supplied explicitly; generator does not read the model |
 | `system-test` | `system-test checkout_flow` | System test fixture (name must be `snake_case` or `PascalCase` — no hyphens) |
 | `pwa` | `pwa` | PWA scaffolding — manifest, service worker, offline shell, icons, route handlers, smoke test |
@@ -286,6 +286,23 @@ Next steps:
    background_color, and start_url.
 
 4. Run the smoke test: cargo test --features system-tests pwa_smoke
+```
+
+### auth (trunk-dev)
+```
+Next steps:
+1. `autumn generate auth User` now scaffolds a configurable password policy and
+   persistent "remember me" login automatically — no extra flag.
+   - Password policy `[auth.password]`: `min_length` (default 8),
+     `reject_common` (default true; bundled weak-password corpus), and
+     `breach_check` = off | fail_open | fail_closed (HIBP lookups). Enforced via
+     autumn_web::auth::PasswordConfig / PasswordPolicy.
+   - Remember-me `[auth.remember]`: `enabled` (default true), `duration_secs`,
+     `cookie_name` (default "autumn.remember"). The generator adds a
+     {snake}_remember_token model + table and wires the remember middleware.
+2. Run: autumn migrate   (applies the sessions + remember-token migrations)
+3. --oauth / --totp / --passkeys still apply; there is no --remember or
+   --password-policy flag — both are on by default (#1345, #1397).
 ```
 
 ## Flags


### PR DESCRIPTION
## What & why

The recent feature waves merged to `trunk-dev` under a policy where feature sessions made **zero** edits to `CHANGELOG.md` and the plugin `skills/`. This is the batch session that documents all of it: adds the missing `## [Unreleased]` bullets and refreshes the Claude plugin skills so agents use the new surface idiomatically. Docs-only — no code changes.

**Before:** 15 merged features had no CHANGELOG entry and no plugin-skills coverage.
**After:** 12 new `### Added` bullets + 1 `### Changed` bullet under the existing `## [Unreleased]` section, and 4 refreshed skill files. Plugin-freshness gate passes green.

## Coverage: PR/issue → changelog bullet → skill

| PR / issue | CHANGELOG bullet | Skill file |
|---|---|---|
| #1695 / #1056 | Added: `autumn test` (isolated `_test` DB, create→migrate→run) | `skills/autumn-web` |
| #1696 / #1262 | Added: `query_count()` / `assert_max_queries(n)` | `skills/autumn-patterns` |
| #1697 / #1231 | Added: chart widgets `sparkline`/`bar_chart`/`line_chart` + `ChartConfig` | `skills/autumn-web` |
| #1698 / #1205 | Added: versioned job payloads `#[job(version, upgrade)]` + `payload_version` | `skills/autumn-web` |
| #1701 + #1705 / #1369 | Added: `dependent(...)` cascade `destroy\|delete_all\|nullify\|restrict` | `skills/autumn-web` |
| #1703 / #1383 | Added: audit actor attribution `autumn_web::current` → `VersionEntry.actor` | `skills/autumn-web` |
| #1704 / #1345, #1397 | Added: `[auth.password]` policy + `[auth.remember]` via `generate auth` | `skills/generate` |
| #1707 / #1237, #1253 | Added: JSON API pagination envelope + `MaybeValidate` 422 validation | `skills/autumn-web` |
| #1711 / #1595 | Added: `autumn db backup` / `db restore` | `skills/autumn-web` |
| #1712 / #1354 | Added: magic-byte upload validation + `reject_on_content_type_mismatch` | `skills/autumn-web` |
| #1714 / #1613 | Added: web/worker split `AUTUMN_ROLE`/`--role`, `release init --split-workers` | `skills/autumn-web` |
| #1715 / #1343 | Added: fake-data factories + `autumn seed --count/--model` | `skills/autumn-patterns`, `skills/autumn-web` |
| #1709 / #1115 | Changed: `autumn dev` browser compiler-error overlay | `skills/dev` |

## Excluded / skipped
- **#1690 (fuzz/proptest), #1693 (loom):** already in `## [Unreleased]`; skipped to avoid duplication.
- **#1710 (macro transparency doc), #1717 (CI action pin), #1724 (intra-doc link fixes):** docs/CI-only, no user-facing surface — no bullet.
- **#1610/#1713 (operator alerts), #1708 (shared-layout/flash scaffold):** not merged on `trunk-dev` — not documented.

## Verification
- `scripts/check-plugin-freshness.sh` → `EXIT=0` (static checks + drift gate green; no `[no-plugin]` tokens needed).
- `cargo fmt --all` clean.
- `git diff --name-only origin/trunk-dev` = `CHANGELOG.md`, `skills/autumn-patterns/SKILL.md`, `skills/autumn-web/SKILL.md`, `skills/dev/SKILL.md`, `skills/generate/SKILL.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9YBW1Cb3AFVUhoa2E5cbN)_