### PR TITLE
fix: clear Rust 1.97 clippy lints + repair broken intra-doc links on trunk-dev

### DIFF
--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -1267,8 +1267,7 @@ fn tool_on_path(tool: &str) -> bool {
     Command::new(tool)
         .arg("--version")
         .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+        .is_ok_and(|o| o.status.success())
 }
 
 // ─── Manifest ───────────────────────────────────────────────────────────────

--- a/autumn/src/fake.rs
+++ b/autumn/src/fake.rs
@@ -9,11 +9,11 @@
 //! The generator can run in two modes:
 //!
 //! - **Deterministic**: when the `AUTUMN_FAKE_SEED` environment variable is set
-//!   to a `u64`, or when [`reseed`] is called explicitly, the process-global RNG
+//!   to a `u64`, or when [`reseed`](crate::fake::reseed) is called explicitly, the process-global RNG
 //!   is seeded from that value. The exact same sequence of calls then produces
 //!   the exact same values on every run — ideal for golden tests and
 //!   reproducible fixtures. In this mode time-based helpers such as
-//!   [`recent_datetime`] anchor to a fixed base instant rather than the wall
+//!   [`recent_datetime`](crate::fake::recent_datetime) anchor to a fixed base instant rather than the wall
 //!   clock, so even timestamps are reproducible.
 //! - **Random**: with no seed configured, the RNG is seeded from OS entropy and
 //!   output varies per run.
@@ -23,7 +23,7 @@
 //!
 //! # Why process-global (not thread-local)
 //!
-//! The generator is a single process-global RNG behind a [`Mutex`], **not** a
+//! The generator is a single process-global RNG behind a [`Mutex`](std::sync::Mutex), **not** a
 //! per-thread one. `#[autumn_web::main]` runs on a multi-thread tokio runtime,
 //! and a faked `create_many` awaits a pooled connection between rows, so the
 //! driving task freely migrates between worker threads mid-run. A thread-local

--- a/autumn/tests/integration/factory_fake.rs
+++ b/autumn/tests/integration/factory_fake.rs
@@ -9,8 +9,6 @@ mod fake_factory_tests {
     use autumn_web::fake;
 
     #[cfg(feature = "test-support")]
-    use diesel::prelude::*;
-    #[cfg(feature = "test-support")]
     use diesel_async::AsyncPgConnection;
     #[cfg(feature = "test-support")]
     use diesel_async::RunQueryDsl;


### PR DESCRIPTION
Clears freshly-merged breakages on `trunk-dev` so its CI goes green. Two independent CI jobs were red; this PR addresses both.

## Lint (Rust 1.97 clippy, `-D warnings`)
Older local toolchains don't reproduce these; the PR's own Lint check is the acceptance test.
- **`autumn-cli/src/db/backup.rs`** (`clippy::map_unwrap_or`, from #1711): rewrote `.map(|o| o.status.success()).unwrap_or(false)` as `.is_ok_and(|o| o.status.success())`.
- **`autumn/tests/integration/factory_fake.rs`** (unused import, from #1715): removed the unused `use diesel::prelude::*;` and its `#[cfg(feature = "test-support")]` attribute. Remaining diesel refs are fully-qualified paths or come from `diesel_async`.

## Documentation build (`rustdoc::broken-intra-doc-links`, `-D warnings`)
- **`autumn/src/fake.rs`** (from #1715, missed by #1724): repaired three broken intra-doc links in the module doc — `` [`reseed`] `` → `` [`reseed`](crate::fake::reseed) ``, `` [`recent_datetime`] `` → `` [`recent_datetime`](crate::fake::recent_datetime) ``, `` [`Mutex`] `` → `` [`Mutex`](std::sync::Mutex) ``.

## Verification
- `cargo check -p autumn-cli` and `cargo check -p autumn-web --tests` — pass
- Lint check on this PR — green
- fake.rs doc build — cleared of broken-link errors
- The pre-existing `Test` job failure (`generate_auth_in_fresh_project_creates_expected_files`, "left: 4 right: 3") is unrelated to this PR (untouched auth generator) and is being handled separately.