### PR TITLE
http::Client SSRF hardening: no-redirect / SSRF-safe redirects (#1238) + IP-pinned connections (#1239)

### DIFF
--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -298,6 +298,13 @@ harness = false
 name = "integration_tests"
 path = "tests/integration_tests.rs"
 
+# Isolated: sets process-wide proxy env vars (HTTP_PROXY/HTTPS_PROXY/ALL_PROXY)
+# to verify pinned SSRF-safe clients bypass env proxies. Cannot share the
+# consolidated binary — those vars would race the inline network tests.
+[[test]]
+name = "ssrf_proxy_bypass"
+path = "tests/ssrf_proxy_bypass.rs"
+
 # Isolated: installs the process-global tracing subscriber (issue #1044), a
 # process-wide side-effect that cannot share the consolidated binary.
 [[test]]

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -285,6 +285,15 @@ fn is_blocked_ipv6(ip: Ipv6Addr) -> bool {
     }
 
     let segs = ip.segments();
+    // RFC 8215 local-use NAT64 prefix `64:ff9b:1::/48`: deny the whole prefix
+    // outright. Unlike the well-known `64:ff9b::/96` (where a public embedded
+    // IPv4 like 8.8.8.8 is legitimately allowed), this is a private/site-local
+    // NAT64 allocation with no legitimate public destination, and the RFC 6052
+    // embedding position varies with prefix length — a blanket deny is both
+    // simpler and strictly safer (e.g. `64:ff9b:1::a9fe:a9fe` == 169.254.169.254).
+    if segs[0] == 0x0064 && segs[1] == 0xff9b && segs[2] == 0x0001 {
+        return true;
+    }
     // :: (unspecified)
     if ip == Ipv6Addr::UNSPECIFIED {
         return true;
@@ -2852,9 +2861,13 @@ mod tests {
         let blocked = [
             "64:ff9b::a9fe:a9fe", // NAT64 → 169.254.169.254 (cloud metadata)
             "64:ff9b::7f00:1",    // NAT64 → 127.0.0.1 (loopback)
-            "2002:a9fe:a9fe::",   // 6to4  → 169.254.169.254
-            "2002:7f00:1::",      // 6to4  → 127.0.0.1
-            "2002:0a00:0001::",   // 6to4  → 10.0.0.1
+            // RFC 8215 local-use NAT64 `64:ff9b:1::/48` is denied outright.
+            "64:ff9b:1::a9fe:a9fe", // local-use NAT64 → 169.254.169.254
+            "64:ff9b:1::7f00:1",    // local-use NAT64 → 127.0.0.1
+            "64:ff9b:1::808:808",   // local-use NAT64 embedding public 8.8.8.8: still blocked
+            "2002:a9fe:a9fe::",     // 6to4  → 169.254.169.254
+            "2002:7f00:1::",        // 6to4  → 127.0.0.1
+            "2002:0a00:0001::",     // 6to4  → 10.0.0.1
         ];
         for s in blocked {
             let ip: IpAddr = s.parse().unwrap();

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -158,9 +158,10 @@ impl Response {
 ///
 /// IPv6 addresses that embed an IPv4 via a transition mechanism — IPv4-mapped
 /// (`::ffff:a.b.c.d`), the deprecated IPv4-compatible (`::a.b.c.d`), NAT64
-/// (`64:ff9b::/96`), and 6to4 (`2002::/16`) — are unwrapped and re-checked as
-/// IPv4, so encodings such as `::ffff:169.254.169.254`,
-/// `64:ff9b::a9fe:a9fe`, and `2002:a9fe:a9fe::` are all correctly blocked.
+/// (`64:ff9b::/96`), 6to4 (`2002::/16`), and the SIIT IPv4-translated prefix
+/// (`::ffff:0:0:0/96`) — are unwrapped and re-checked as IPv4, so encodings
+/// such as `::ffff:169.254.169.254`, `64:ff9b::a9fe:a9fe`, `2002:a9fe:a9fe::`,
+/// and `::ffff:0:169.254.169.254` are all correctly blocked.
 #[must_use]
 pub fn is_blocked_ip(ip: IpAddr) -> bool {
     match ip {
@@ -246,12 +247,34 @@ fn is_blocked_ipv4(ip: Ipv4Addr) -> bool {
 ///   `64:ff9b::a9fe:a9fe` decodes to `169.254.169.254`
 /// - 6to4 `2002::/16` (RFC 3056) — e.g. `2002:a9fe:a9fe::` embeds
 ///   `169.254.169.254`
+/// - SIIT "IPv4-translated" prefix `::ffff:0:0:0/96` (RFC 6052) — e.g.
+///   `::ffff:0:169.254.169.254` decodes to `169.254.169.254`. Note this is a
+///   DIFFERENT segment layout from IPv4-mapped `::ffff:0:0/96` (here
+///   `segments()[4] == 0xffff && segments()[5] == 0`, whereas IPv4-mapped has
+///   `segments()[5] == 0xffff`), so it is NOT caught by `to_ipv4_mapped()`.
 ///
 /// Returns `None` for a genuinely-native IPv6 address (no embedded v4). Using
 /// `octets()` avoids any lossy `u16 -> u8` casts.
 fn embedded_ipv4(ip: Ipv6Addr) -> Option<Ipv4Addr> {
     if let Some(v4) = ip.to_ipv4_mapped() {
         return Some(v4);
+    }
+    let segs = ip.segments();
+    // SIIT IPv4-translated `::ffff:0:0:0/96` (RFC 6052): 64 zero bits, then
+    // 0xffff, then 16 zero bits, then the IPv4 in the last 32 bits. Distinct
+    // from IPv4-mapped `::ffff:0:0/96` (segment[5] == 0xffff) — here
+    // segment[4] == 0xffff and segment[5] == 0 — so `to_ipv4_mapped()` above
+    // does NOT catch it. Decode it so the embedded IPv4 is re-checked by the
+    // IPv4 policy (e.g. `::ffff:0:169.254.169.254` must be blocked).
+    if segs[0] == 0
+        && segs[1] == 0
+        && segs[2] == 0
+        && segs[3] == 0
+        && segs[4] == 0xffff
+        && segs[5] == 0
+    {
+        let o = ip.octets();
+        return Some(Ipv4Addr::new(o[12], o[13], o[14], o[15]));
     }
     let o = ip.octets();
     // NAT64 64:ff9b::/96 — embedded IPv4 in the last 32 bits (octets 12..16),
@@ -274,8 +297,9 @@ fn embedded_ipv4(ip: Ipv6Addr) -> Option<Ipv4Addr> {
 
 fn is_blocked_ipv6(ip: Ipv6Addr) -> bool {
     // Block any private / loopback / link-local / metadata IPv4 that is
-    // tunnelled inside this v6 address (IPv4-mapped, IPv4-compatible, NAT64, or
-    // 6to4) by re-running the IPv4 policy on the embedded address. A public
+    // tunnelled inside this v6 address (IPv4-mapped, IPv4-compatible, NAT64,
+    // 6to4, or SIIT IPv4-translated `::ffff:0:0:0/96`) by re-running the IPv4
+    // policy on the embedded address. A public
     // embedded IPv4 (e.g. 6to4 `2002:0808:0808::` == 8.8.8.8) is NOT blocked
     // here — it falls through to the native v6 range checks below.
     if let Some(v4) = embedded_ipv4(ip)
@@ -948,6 +972,14 @@ impl Client {
     /// Like the test-mock path, this custom send path bypasses the process-wide
     /// circuit-breaker registry to avoid entangling per-URL SSRF fetches with
     /// the shared per-host breaker state.
+    ///
+    /// **Env proxies are bypassed.** Each pinned per-hop client is built with
+    /// `.no_proxy()`, so `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` are ignored
+    /// and the socket connects directly to the validated/pinned address. This is
+    /// required for the pin to hold: reqwest checks proxy interception before the
+    /// connector where the `resolve()` override applies, so a configured proxy
+    /// would otherwise receive the request and re-resolve the host — reopening
+    /// the DNS-rebinding / SSRF window this API closes.
     #[must_use]
     pub fn get_ssrf_safe(&self, url: impl Into<String>) -> RequestBuilder {
         let mut builder = self.build_request(Method::GET, url.into());
@@ -1165,6 +1197,13 @@ impl RequestBuilder {
     /// does for addresses obtained by resolving that same URL). Routes the
     /// request through the custom one-shot-client send path, which bypasses the
     /// process-wide circuit breaker.
+    ///
+    /// **Env proxies are bypassed.** The pinned client is built with
+    /// `.no_proxy()`, so `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` are ignored
+    /// and the socket connects directly to `addr`. This is required for the pin
+    /// to hold: reqwest checks proxy interception before the connector where the
+    /// `resolve()` override applies, so a configured proxy would otherwise
+    /// receive the request and re-resolve the host — defeating the pin.
     #[must_use]
     pub const fn pin_to(mut self, addr: SocketAddr) -> Self {
         self.pin_addr = Some(addr);
@@ -1566,6 +1605,15 @@ const fn is_retryable_status(status: u16) -> bool {
 
 /// Build a one-shot `reqwest::Client` for the custom send path, with the given
 /// redirect policy, per-request timeout, and optional DNS `resolve` override.
+///
+/// **Proxy bypass on pinned clients.** When a `resolve` override is present the
+/// client is built with `.no_proxy()` so the request connects DIRECTLY to the
+/// validated/pinned address. reqwest evaluates proxy interception (from
+/// `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY`) BEFORE the connector where the
+/// `resolve()` override applies, so a configured env proxy would otherwise send
+/// the request to the proxy — which re-resolves the target host, reopening the
+/// exact DNS-rebinding / SSRF window that pinning closes. Non-pinned callers
+/// (`resolve == None`) keep reqwest's default proxy behaviour untouched.
 fn build_oneshot_client(
     resolve: Option<(String, SocketAddr)>,
     policy: reqwest::redirect::Policy,
@@ -1575,7 +1623,8 @@ fn build_oneshot_client(
         .timeout(timeout)
         .redirect(policy);
     if let Some((host, addr)) = resolve {
-        builder = builder.resolve(&host, addr);
+        // A pinned request must never route through a re-resolving proxy.
+        builder = builder.no_proxy().resolve(&host, addr);
     }
     builder.build().map_err(ClientError::Request)
 }
@@ -2868,6 +2917,11 @@ mod tests {
             "2002:a9fe:a9fe::",     // 6to4  → 169.254.169.254
             "2002:7f00:1::",        // 6to4  → 127.0.0.1
             "2002:0a00:0001::",     // 6to4  → 10.0.0.1
+            // SIIT IPv4-translated `::ffff:0:0:0/96` (RFC 6052): segment[4] ==
+            // 0xffff, segment[5] == 0, IPv4 in the last 32 bits. Distinct from
+            // IPv4-mapped `::ffff:0:0/96`, so must be decoded and re-checked.
+            "::ffff:0:169.254.169.254", // SIIT → 169.254.169.254 (cloud metadata)
+            "::ffff:0:127.0.0.1",       // SIIT → 127.0.0.1 (loopback)
         ];
         for s in blocked {
             let ip: IpAddr = s.parse().unwrap();
@@ -2882,7 +2936,10 @@ mod tests {
         // A 6to4 address embedding a genuinely-public IPv4 (8.8.8.8) stays
         // public (the embedded v4 is public, so it falls through to the native
         // v6 checks, which do not match 2002::/16). So does a native public v6.
-        for s in ["2002:0808:0808::", "2606:4700::1111"] {
+        // A SIIT IPv4-translated address embedding a genuinely-public IPv4
+        // (8.8.8.8) stays public — the decoded v4 is public, so it falls
+        // through to the native v6 checks, which do not match it.
+        for s in ["2002:0808:0808::", "2606:4700::1111", "::ffff:0:8.8.8.8"] {
             let ip: IpAddr = s.parse().unwrap();
             assert!(is_public_ip(ip), "{s} should be public");
             assert!(!is_blocked_ip(ip), "{s} should not be blocked");

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -110,6 +110,14 @@ pub enum ClientError {
     /// validates the literal and connects to that same IP, so it is unaffected.)
     #[error("{0}")]
     PinRequiresDomainHost(&'static str),
+    /// [`pin_to`](RequestBuilder::pin_to) was combined with
+    /// [`Client::get_ssrf_safe`] — an incompatible pair. The SSRF-safe path runs
+    /// its own per-hop resolve→validate→pin and never reads the caller's
+    /// `pin_to` address, so an explicit pin would be silently ignored. Use
+    /// `pin_to` alone for a caller-chosen fixed address, or `get_ssrf_safe`
+    /// alone for guarded automatic per-hop pinning — not both.
+    #[error("{0}")]
+    PinNotAllowedWithSsrfSafe(&'static str),
 }
 
 // ── Response ─────────────────────────────────────────────────────────────────
@@ -1032,7 +1040,7 @@ impl Client {
     /// full set of validated addresses so reqwest cannot re-resolve the host
     /// (closing the DNS-rebinding / TOCTOU window) yet can still fall back across
     /// them in order if the first is unreachable. Redirects are followed manually up to
-    /// [`SSRF_SAFE_MAX_REDIRECTS`] hops, re-running resolve→validate→pin on each
+    /// `SSRF_SAFE_MAX_REDIRECTS` hops, re-running resolve→validate→pin on each
     /// hop; a hop that downgrades the scheme from `https` to `http` is rejected
     /// as defence-in-depth.
     ///
@@ -1040,7 +1048,7 @@ impl Client {
     /// override (the built-in resolve→validate→pin and scheme-downgrade guards
     /// always apply):
     ///
-    /// - by default, up to [`SSRF_SAFE_MAX_REDIRECTS`] hops are followed;
+    /// - by default, up to `SSRF_SAFE_MAX_REDIRECTS` hops are followed;
     /// - a chained [`no_redirect`](RequestBuilder::no_redirect) returns the
     ///   initial `3xx` verbatim — the initial URL is still resolved, validated
     ///   and pinned, but no redirect is followed;
@@ -1060,6 +1068,14 @@ impl Client {
     /// connector where the `resolve()` override applies, so a configured proxy
     /// would otherwise receive the request and re-resolve the host — reopening
     /// the DNS-rebinding / SSRF window this API closes.
+    ///
+    /// **Cannot be combined with [`pin_to`](RequestBuilder::pin_to).** This path
+    /// performs its own per-hop resolve→validate→pin and never reads the
+    /// `pin_to` address, so an explicit pin would be silently ignored. Chaining
+    /// the two is therefore rejected at send time with
+    /// [`ClientError::PinNotAllowedWithSsrfSafe`]. Use `pin_to` alone for a
+    /// caller-chosen fixed address, or `get_ssrf_safe` alone for guarded
+    /// automatic per-hop pinning.
     #[must_use]
     pub fn get_ssrf_safe(&self, url: impl Into<String>) -> RequestBuilder {
         let mut builder = self.build_request(Method::GET, url.into());
@@ -1522,6 +1538,24 @@ impl RequestBuilder {
 
     /// Dispatch to the appropriate custom send path. Consumes `self`.
     async fn send_custom(self) -> Result<Response, ClientError> {
+        // Reject the incompatible `get_ssrf_safe` + `pin_to` combination up
+        // front — deterministically, before any network I/O. `get_ssrf_safe`
+        // routes through `send_ssrf_safe`, which runs its OWN per-hop
+        // resolve→validate→pin and never reads `self.pin_addr`; a caller's
+        // explicit `pin_to(addr)` would therefore be silently ignored. Fail
+        // loudly instead so the mismatch is caught rather than masked. Use
+        // `pin_to` alone for a caller-chosen fixed address, or `get_ssrf_safe`
+        // alone for guarded automatic per-hop pinning.
+        if self.ssrf_safe && self.pin_addr.is_some() {
+            return Err(ClientError::PinNotAllowedWithSsrfSafe(
+                "get_ssrf_safe cannot be combined with pin_to: the SSRF-safe path \
+                 performs its own per-hop resolve/validate/pin and never reads the \
+                 pin_to address, so an explicit pin would be silently ignored. Use \
+                 pin_to alone for a caller-chosen address, or get_ssrf_safe alone \
+                 for guarded automatic per-hop pinning.",
+            ));
+        }
+
         // Reject the incompatible `pin_to` + `follow_redirects` combination up
         // front — deterministically, before issuing any request. A single pinned
         // `SocketAddr` only applies to hop 0 of `follow_loop`; later hops resolve
@@ -4007,6 +4041,25 @@ mod tests {
         assert!(
             matches!(result, Err(ClientError::PinRequiresDomainHost(_))),
             "expected PinRequiresDomainHost, got {result:?}"
+        );
+    }
+
+    // TEST 68b: get_ssrf_safe combined with pin_to is rejected at send time with
+    // PinNotAllowedWithSsrfSafe — deterministically, without touching the
+    // network. The SSRF-safe path runs its own per-hop resolve/validate/pin and
+    // never reads the pin_to address, so an explicit pin would be silently
+    // ignored; the guard fails loudly instead.
+    #[tokio::test]
+    async fn get_ssrf_safe_with_pin_to_is_rejected() {
+        let result = Client::new()
+            .get_ssrf_safe("http://example.com/")
+            .pin_to(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080))
+            .send()
+            .await;
+
+        assert!(
+            matches!(result, Err(ClientError::PinNotAllowedWithSsrfSafe(_))),
+            "expected PinNotAllowedWithSsrfSafe, got {result:?}"
         );
     }
 

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -969,6 +969,19 @@ impl Client {
     /// hop; a hop that downgrades the scheme from `https` to `http` is rejected
     /// as defence-in-depth.
     ///
+    /// The redirect count and per-hop validation honour a chained builder
+    /// override (the built-in resolve→validate→pin and scheme-downgrade guards
+    /// always apply):
+    ///
+    /// - by default, up to [`SSRF_SAFE_MAX_REDIRECTS`] hops are followed;
+    /// - a chained [`no_redirect`](RequestBuilder::no_redirect) returns the
+    ///   initial `3xx` verbatim — the initial URL is still resolved, validated
+    ///   and pinned, but no redirect is followed;
+    /// - a chained [`follow_redirects(max, validator)`](RequestBuilder::follow_redirects)
+    ///   caps following at `max` hops (so `max == 0` turns the first `3xx` into
+    ///   [`ClientError::TooManyRedirects`]) and additionally runs the caller's
+    ///   `validator(&next)` on every hop, on top of the built-in guards.
+    ///
     /// Like the test-mock path, this custom send path bypasses the process-wide
     /// circuit-breaker registry to avoid entangling per-URL SSRF fetches with
     /// the shared per-host breaker state.
@@ -1529,9 +1542,34 @@ impl RequestBuilder {
         unreachable!("redirect loop is bounded by `max` and always returns")
     }
 
+    /// Derive the SSRF-safe redirect plan `(follow, max)` from the builder's
+    /// [`RedirectMode`], so a chained `no_redirect()` / `follow_redirects(..)`
+    /// overrides the default hop cap on the SSRF-safe path:
+    ///
+    /// - [`RedirectMode::Default`] → `(true, SSRF_SAFE_MAX_REDIRECTS)`.
+    /// - [`RedirectMode::None`] (`no_redirect()`) → `(false, 0)` — the initial
+    ///   `3xx` is returned verbatim (the `max` is unused).
+    /// - [`RedirectMode::Follow { max, .. }`] (`follow_redirects(max, ..)`) →
+    ///   `(true, max)`. The caller's per-hop validator is pulled from
+    ///   `self.redirect_mode` separately inside the send loop.
+    const fn ssrf_redirect_plan(&self) -> (bool, usize) {
+        match &self.redirect_mode {
+            RedirectMode::Default => (true, SSRF_SAFE_MAX_REDIRECTS),
+            RedirectMode::None => (false, 0),
+            RedirectMode::Follow { max, .. } => (true, *max),
+        }
+    }
+
     /// Composed SSRF-safe send path (Features #1238 + #1239). Resolves and
     /// validates every hop, pins the connection, and rejects scheme downgrades.
+    ///
+    /// The follow/hop-cap behaviour comes from [`ssrf_redirect_plan`](Self::ssrf_redirect_plan),
+    /// so a chained `no_redirect()` / `follow_redirects(max, ..)` overrides the
+    /// default cap while every per-hop safety step (resolve→validate→pin,
+    /// https→http downgrade block, sensitive-header stripping, method/body
+    /// rewrite) still applies.
     async fn send_ssrf_safe(self, timeout: Duration) -> Result<Response, ClientError> {
+        let (follow, max) = self.ssrf_redirect_plan();
         let original =
             url::Url::parse(&self.url).map_err(|e| ClientError::InvalidUrl(e.to_string()))?;
         let mut current = self.url.clone();
@@ -1568,14 +1606,27 @@ impl RequestBuilder {
             let Some(next) = redirect_target(&resp, &current)? else {
                 return Ok(resp);
             };
-            if hop >= SSRF_SAFE_MAX_REDIRECTS {
-                return Err(ClientError::TooManyRedirects(SSRF_SAFE_MAX_REDIRECTS));
+            // Honour a chained `no_redirect()`: return the 3xx verbatim. The
+            // initial URL was still resolved / validated / pinned above.
+            if !follow {
+                return Ok(resp);
+            }
+            if hop >= max {
+                return Err(ClientError::TooManyRedirects(max));
             }
             // Defence-in-depth: reject an https→http downgrade on redirect.
             if scheme_is_https(&current)? && !scheme_is_https(&next)? {
                 return Err(ClientError::RedirectRejected(format!(
                     "https→http scheme downgrade on redirect to {next}"
                 )));
+            }
+            // Caller-supplied per-hop validator, present only in the
+            // `follow_redirects` override. It runs in ADDITION to the built-in
+            // resolve/validate/pin already applied at the top of the loop.
+            if let RedirectMode::Follow { validator, .. } = &self.redirect_mode
+                && !validator(&next)
+            {
+                return Err(ClientError::RedirectRejected(next));
             }
             // RFC 7231/7538 method+body rewriting before the next hop.
             rewrite_after_redirect(resp.status(), &mut method, &mut body);
@@ -1584,7 +1635,7 @@ impl RequestBuilder {
             // before connecting, so a redirect to a blocked address is rejected
             // there with `SsrfBlocked`.
         }
-        unreachable!("redirect loop is bounded by SSRF_SAFE_MAX_REDIRECTS")
+        unreachable!("redirect loop is bounded by the SSRF-safe redirect plan")
     }
 }
 
@@ -3540,6 +3591,45 @@ mod tests {
             &body[..],
             b"payload",
             "307 must preserve the request body verbatim"
+        );
+    }
+
+    // TEST 63: get_ssrf_safe derives its redirect follow/cap from the chained
+    // builder mode via ssrf_redirect_plan, so `no_redirect()` /
+    // `follow_redirects(max, ..)` override the SSRF-safe default hop cap.
+    //
+    // NOTE: the network-level follow behaviour of get_ssrf_safe cannot be
+    // exercised in-sandbox — the only reachable address here is loopback, which
+    // the SSRF guard blocks before connecting — so this deterministic unit test
+    // on the factored `ssrf_redirect_plan` helper stands in for it.
+    #[test]
+    fn ssrf_redirect_plan_honours_chained_override() {
+        let client = Client::new();
+
+        // Default get_ssrf_safe → follow up to the SSRF-safe hop cap.
+        let default = client.get_ssrf_safe("https://example.com/");
+        assert_eq!(
+            default.ssrf_redirect_plan(),
+            (true, SSRF_SAFE_MAX_REDIRECTS),
+            "default SSRF-safe path follows up to SSRF_SAFE_MAX_REDIRECTS"
+        );
+
+        // no_redirect() → do NOT follow.
+        let none = client.get_ssrf_safe("https://example.com/").no_redirect();
+        let (follow, _max) = none.ssrf_redirect_plan();
+        assert!(
+            !follow,
+            "no_redirect() must disable following on the safe path"
+        );
+
+        // follow_redirects(3, ..) → follow up to the caller's max.
+        let follow3 = client
+            .get_ssrf_safe("https://example.com/")
+            .follow_redirects(3, |_| true);
+        assert_eq!(
+            follow3.ssrf_redirect_plan(),
+            (true, 3),
+            "follow_redirects(3, ..) must cap the safe path at 3 hops"
         );
     }
 }

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -1431,7 +1431,14 @@ impl RequestBuilder {
         validator: RedirectValidator,
         timeout: Duration,
     ) -> Result<Response, ClientError> {
+        let original =
+            url::Url::parse(&self.url).map_err(|e| ClientError::InvalidUrl(e.to_string()))?;
         let mut current = self.url.clone();
+        // Threaded across hops so cross-origin header stripping (Fix A) and
+        // RFC method/body rewriting (Fix B) accumulate correctly.
+        let mut method = self.method.clone();
+        let mut headers = self.extra_headers.clone();
+        let mut body = self.body.clone();
         for hop in 0.. {
             // Pin only applies to the first hop's original target.
             let resolve = if hop == 0 {
@@ -1442,15 +1449,18 @@ impl RequestBuilder {
             } else {
                 None
             };
+            // On any post-origin hop, drop credential-bearing headers if the
+            // current target is cross-origin (stays stripped once stripped).
+            if hop > 0 {
+                strip_sensitive_headers_if_cross_origin(&mut headers, &original, &current)?;
+            }
             let client = build_oneshot_client(resolve, reqwest::redirect::Policy::none(), timeout)?;
-            // Only send the body on the first hop; a redirect drops it.
-            let body = if hop == 0 { self.body.as_ref() } else { None };
             let resp = send_one(
                 &client,
-                &self.method,
+                &method,
                 &current,
-                &self.extra_headers,
-                body,
+                &headers,
+                body.as_ref(),
                 &self.retry_policy,
             )
             .await?;
@@ -1464,6 +1474,8 @@ impl RequestBuilder {
             if !validator(&next) {
                 return Err(ClientError::RedirectRejected(next));
             }
+            // RFC 7231/7538 method+body rewriting before the next hop.
+            rewrite_after_redirect(resp.status(), &mut method, &mut body);
             current = next;
         }
         unreachable!("redirect loop is bounded by `max` and always returns")
@@ -1472,7 +1484,14 @@ impl RequestBuilder {
     /// Composed SSRF-safe send path (Features #1238 + #1239). Resolves and
     /// validates every hop, pins the connection, and rejects scheme downgrades.
     async fn send_ssrf_safe(self, timeout: Duration) -> Result<Response, ClientError> {
+        let original =
+            url::Url::parse(&self.url).map_err(|e| ClientError::InvalidUrl(e.to_string()))?;
         let mut current = self.url.clone();
+        // Threaded across hops so cross-origin header stripping (Fix A) and
+        // RFC method/body rewriting (Fix B) accumulate correctly.
+        let mut method = self.method.clone();
+        let mut headers = self.extra_headers.clone();
+        let mut body = self.body.clone();
         for hop in 0.. {
             // Resolve host → validated address (rejects if ANY resolved IP is
             // blocked), then pin so reqwest cannot re-resolve.
@@ -1483,13 +1502,17 @@ impl RequestBuilder {
                 reqwest::redirect::Policy::none(),
                 timeout,
             )?;
-            let body = if hop == 0 { self.body.as_ref() } else { None };
+            // On any post-origin hop, drop credential-bearing headers if the
+            // current target is cross-origin (stays stripped once stripped).
+            if hop > 0 {
+                strip_sensitive_headers_if_cross_origin(&mut headers, &original, &current)?;
+            }
             let resp = send_one(
                 &client,
-                &self.method,
+                &method,
                 &current,
-                &self.extra_headers,
-                body,
+                &headers,
+                body.as_ref(),
                 &self.retry_policy,
             )
             .await?;
@@ -1506,6 +1529,8 @@ impl RequestBuilder {
                     "https→http scheme downgrade on redirect to {next}"
                 )));
             }
+            // RFC 7231/7538 method+body rewriting before the next hop.
+            rewrite_after_redirect(resp.status(), &mut method, &mut body);
             current = next;
             // The next loop iteration re-resolves + re-validates `current`
             // before connecting, so a redirect to a blocked address is rejected
@@ -1660,6 +1685,64 @@ fn redirect_target(resp: &Response, base: &str) -> Result<Option<String>, Client
         .join(location)
         .map_err(|e| ClientError::InvalidUrl(e.to_string()))?;
     Ok(Some(joined.to_string()))
+}
+
+/// Strip credential-bearing headers when a redirect hop crosses origins.
+///
+/// If `current`'s origin (scheme + host + port, per [`url::Url::origin`])
+/// differs from the `original` request URL's origin, the `Authorization`,
+/// `Cookie`, and `Proxy-Authorization` headers are removed from `headers` so
+/// they are never forwarded to a cross-origin target (credential leak).
+/// Because the caller threads a single mutable `headers` map across hops, once
+/// these headers are stripped on any hop they stay stripped for the remainder
+/// of the chain — the safe, conservative behaviour.
+fn strip_sensitive_headers_if_cross_origin(
+    headers: &mut HeaderMap,
+    original: &url::Url,
+    current: &str,
+) -> Result<(), ClientError> {
+    let current_url =
+        url::Url::parse(current).map_err(|e| ClientError::InvalidUrl(e.to_string()))?;
+    if current_url.origin() != original.origin() {
+        headers.remove(reqwest::header::AUTHORIZATION);
+        headers.remove(reqwest::header::COOKIE);
+        headers.remove(reqwest::header::PROXY_AUTHORIZATION);
+    }
+    Ok(())
+}
+
+/// Apply RFC 7231 §6.4 / RFC 7538 method-and-body rewriting after receiving a
+/// redirect `status`, before issuing the next hop. Mutates `method` and `body`
+/// in place.
+///
+/// - **303 See Other**: switch to `GET` (a `HEAD` stays `HEAD`) and drop the body.
+/// - **301 Moved Permanently / 302 Found**: a `POST` becomes a bodyless `GET`;
+///   every other method (and its body) is preserved — matching prevailing
+///   browser behaviour.
+/// - **307 Temporary Redirect / 308 Permanent Redirect**: preserve the method
+///   **and** the body verbatim (the RFC-correct behaviour — the body must NOT
+///   be dropped).
+/// - Any other redirect status: leave method and body untouched.
+fn rewrite_after_redirect(
+    status: reqwest::StatusCode,
+    method: &mut Method,
+    body: &mut Option<Bytes>,
+) {
+    match status.as_u16() {
+        303 => {
+            if *method != Method::HEAD {
+                *method = Method::GET;
+            }
+            *body = None;
+        }
+        301 | 302 => {
+            if *method == Method::POST {
+                *method = Method::GET;
+                *body = None;
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Resolve `url`'s host to a single validated [`SocketAddr`], rejecting with
@@ -2838,6 +2921,14 @@ mod tests {
             .unwrap()
     }
 
+    fn redirect_307(location: String) -> axum::response::Response {
+        axum::response::Response::builder()
+            .status(307)
+            .header("location", location)
+            .body(axum::body::Body::empty())
+            .unwrap()
+    }
+
     // TEST 48: no_redirect returns the 3xx verbatim without following it.
     #[tokio::test]
     async fn no_redirect_returns_3xx_unfollowed() {
@@ -3173,5 +3264,214 @@ mod tests {
                 "{raw} should be rejected with InvalidUrl, got {result:?}"
             );
         }
+    }
+
+    // TEST 59: a cross-origin redirect (different port ⇒ different origin) must
+    // NOT forward credential-bearing request headers to the new origin. This is
+    // the manual-redirect-loop version of reqwest's built-in strip-on-cross-host
+    // behaviour, closing a credential-leak hole (Fix A).
+    #[tokio::test]
+    async fn follow_redirects_strips_sensitive_headers_cross_origin() {
+        use axum::{Router, routing::get};
+
+        let seen: Arc<Mutex<Option<HeaderMap>>> = Arc::new(Mutex::new(None));
+        let seen2 = seen.clone();
+        // Listener B records the headers it received (different port = different
+        // origin from A).
+        let b_addr = spawn(Router::new().route(
+            "/dst",
+            get(move |headers: HeaderMap| {
+                let slot = seen2.clone();
+                async move {
+                    *slot.lock().unwrap() = Some(headers);
+                    "ok"
+                }
+            }),
+        ))
+        .await;
+        let b_port = b_addr.port();
+
+        // Listener A 302-redirects onto B.
+        let a_addr = spawn(Router::new().route(
+            "/",
+            get(move || async move { redirect_302(format!("http://127.0.0.1:{b_port}/dst")) }),
+        ))
+        .await;
+
+        let resp = Client::new()
+            .get(format!("http://127.0.0.1:{}/", a_addr.port()))
+            .header("authorization", "secret")
+            .header("cookie", "session=abc")
+            .header("proxy-authorization", "Basic zzz")
+            .follow_redirects(3, |_| true)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status().as_u16(), 200);
+        let headers = seen
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("listener B must have been reached");
+        assert!(
+            headers.get("authorization").is_none(),
+            "authorization must be stripped on a cross-origin redirect"
+        );
+        assert!(
+            headers.get("cookie").is_none(),
+            "cookie must be stripped on a cross-origin redirect"
+        );
+        assert!(
+            headers.get("proxy-authorization").is_none(),
+            "proxy-authorization must be stripped on a cross-origin redirect"
+        );
+    }
+
+    // TEST 60: a SAME-origin redirect (relative `Location`, same host:port) must
+    // keep credential-bearing headers — stripping only applies across origins.
+    #[tokio::test]
+    async fn follow_redirects_keeps_sensitive_headers_same_origin() {
+        use axum::{Router, routing::get};
+
+        let seen: Arc<Mutex<Option<HeaderMap>>> = Arc::new(Mutex::new(None));
+        let seen2 = seen.clone();
+        let addr = spawn(
+            Router::new()
+                .route("/", get(|| async { redirect_302("/next".to_owned()) }))
+                .route(
+                    "/next",
+                    get(move |headers: HeaderMap| {
+                        let slot = seen2.clone();
+                        async move {
+                            *slot.lock().unwrap() = Some(headers);
+                            "ok"
+                        }
+                    }),
+                ),
+        )
+        .await;
+
+        let resp = Client::new()
+            .get(format!("http://127.0.0.1:{}/", addr.port()))
+            .header("authorization", "secret")
+            .follow_redirects(3, |_| true)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status().as_u16(), 200);
+        let headers = seen
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("/next must have been reached");
+        assert_eq!(
+            headers.get("authorization").and_then(|v| v.to_str().ok()),
+            Some("secret"),
+            "authorization must be preserved on a same-origin redirect"
+        );
+    }
+
+    // TEST 61: RFC 7231 §6.4.3 — a 302 in response to a POST rewrites the next
+    // hop to a bodyless GET (Fix B).
+    #[tokio::test]
+    async fn follow_redirects_302_post_becomes_get() {
+        use axum::{
+            Router,
+            routing::{any, post},
+        };
+
+        let seen: Arc<Mutex<Option<(String, Bytes)>>> = Arc::new(Mutex::new(None));
+        let seen2 = seen.clone();
+        // B records the method + body it actually received, for any verb.
+        let b_addr = spawn(Router::new().route(
+            "/dst",
+            any(move |method: Method, body: Bytes| {
+                let slot = seen2.clone();
+                async move {
+                    *slot.lock().unwrap() = Some((method.to_string(), body));
+                    "ok"
+                }
+            }),
+        ))
+        .await;
+        let b_port = b_addr.port();
+
+        let a_addr = spawn(Router::new().route(
+            "/",
+            post(move || async move { redirect_302(format!("http://127.0.0.1:{b_port}/dst")) }),
+        ))
+        .await;
+
+        let resp = Client::new()
+            .post(format!("http://127.0.0.1:{}/", a_addr.port()))
+            .text_body("payload")
+            .follow_redirects(3, |_| true)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status().as_u16(), 200);
+        let (method, body) = seen
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("listener B must have been reached");
+        assert_eq!(method, "GET", "302 must rewrite POST → GET");
+        assert!(body.is_empty(), "302 POST→GET must drop the request body");
+    }
+
+    // TEST 62: RFC 7231 §6.4.7 — a 307 preserves BOTH the method and the body
+    // across the redirect (the review bot's drop-body-every-hop snippet was
+    // wrong here) (Fix B).
+    #[tokio::test]
+    async fn follow_redirects_307_preserves_method_and_body() {
+        use axum::{
+            Router,
+            routing::{any, post},
+        };
+
+        let seen: Arc<Mutex<Option<(String, Bytes)>>> = Arc::new(Mutex::new(None));
+        let seen2 = seen.clone();
+        let b_addr = spawn(Router::new().route(
+            "/dst",
+            any(move |method: Method, body: Bytes| {
+                let slot = seen2.clone();
+                async move {
+                    *slot.lock().unwrap() = Some((method.to_string(), body));
+                    "ok"
+                }
+            }),
+        ))
+        .await;
+        let b_port = b_addr.port();
+
+        let a_addr = spawn(Router::new().route(
+            "/",
+            post(move || async move { redirect_307(format!("http://127.0.0.1:{b_port}/dst")) }),
+        ))
+        .await;
+
+        let resp = Client::new()
+            .post(format!("http://127.0.0.1:{}/", a_addr.port()))
+            .text_body("payload")
+            .follow_redirects(3, |_| true)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status().as_u16(), 200);
+        let (method, body) = seen
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("listener B must have been reached");
+        assert_eq!(method, "POST", "307 must preserve the POST method");
+        assert_eq!(
+            &body[..],
+            b"payload",
+            "307 must preserve the request body verbatim"
+        );
     }
 }

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -156,9 +156,11 @@ impl Response {
 /// [`Client::get_ssrf_safe`]. Ranges are checked explicitly (rather than via the
 /// unstable `IpAddr::is_global` family) so the code compiles on stable Rust.
 ///
-/// IPv4-mapped (`::ffff:a.b.c.d`) and the deprecated IPv4-compatible
-/// (`::a.b.c.d`) IPv6 forms are unwrapped and re-checked as IPv4, so encodings
-/// such as `::ffff:169.254.169.254` are correctly blocked.
+/// IPv6 addresses that embed an IPv4 via a transition mechanism — IPv4-mapped
+/// (`::ffff:a.b.c.d`), the deprecated IPv4-compatible (`::a.b.c.d`), NAT64
+/// (`64:ff9b::/96`), and 6to4 (`2002::/16`) — are unwrapped and re-checked as
+/// IPv4, so encodings such as `::ffff:169.254.169.254`,
+/// `64:ff9b::a9fe:a9fe`, and `2002:a9fe:a9fe::` are all correctly blocked.
 #[must_use]
 pub fn is_blocked_ip(ip: IpAddr) -> bool {
     match ip {
@@ -208,6 +210,10 @@ fn is_blocked_ipv4(ip: Ipv4Addr) -> bool {
     if a == 192 && b == 0 && c == 2 {
         return true;
     }
+    // 192.88.99.0/24 (6to4 anycast relay, RFC 3068 / RFC 7526)
+    if a == 192 && b == 88 && c == 99 {
+        return true;
+    }
     // 192.168.0.0/16
     if a == 192 && b == 168 {
         return true;
@@ -231,15 +237,51 @@ fn is_blocked_ipv4(ip: Ipv4Addr) -> bool {
     false
 }
 
-fn is_blocked_ipv6(ip: Ipv6Addr) -> bool {
-    // Unwrap IPv4-mapped (::ffff:a.b.c.d) and deprecated IPv4-compatible
-    // (::a.b.c.d) forms and re-check as IPv4. `to_ipv4` covers both, but we try
-    // the mapped form first for clarity.
+/// Extract any IPv4 address embedded in an IPv6 address via a transition
+/// mechanism, so the IPv4 SSRF policy can be re-applied to it:
+///
+/// - IPv4-mapped `::ffff:a.b.c.d`
+/// - deprecated IPv4-compatible `::a.b.c.d`
+/// - NAT64 well-known prefix `64:ff9b::/96` (RFC 6052) — e.g.
+///   `64:ff9b::a9fe:a9fe` decodes to `169.254.169.254`
+/// - 6to4 `2002::/16` (RFC 3056) — e.g. `2002:a9fe:a9fe::` embeds
+///   `169.254.169.254`
+///
+/// Returns `None` for a genuinely-native IPv6 address (no embedded v4). Using
+/// `octets()` avoids any lossy `u16 -> u8` casts.
+fn embedded_ipv4(ip: Ipv6Addr) -> Option<Ipv4Addr> {
     if let Some(v4) = ip.to_ipv4_mapped() {
-        return is_blocked_ipv4(v4);
+        return Some(v4);
     }
-    if let Some(v4) = ip.to_ipv4() {
-        return is_blocked_ipv4(v4);
+    let o = ip.octets();
+    // NAT64 64:ff9b::/96 — embedded IPv4 in the last 32 bits (octets 12..16),
+    // with octets 4..12 all zero.
+    if o[0] == 0x00
+        && o[1] == 0x64
+        && o[2] == 0xff
+        && o[3] == 0x9b
+        && o[4..12].iter().all(|&b| b == 0)
+    {
+        return Some(Ipv4Addr::new(o[12], o[13], o[14], o[15]));
+    }
+    // 6to4 2002::/16 — embedded IPv4 in bits 16..48 (octets 2..6).
+    if o[0] == 0x20 && o[1] == 0x02 {
+        return Some(Ipv4Addr::new(o[2], o[3], o[4], o[5]));
+    }
+    // Deprecated IPv4-compatible ::a.b.c.d (upper 96 bits zero).
+    ip.to_ipv4()
+}
+
+fn is_blocked_ipv6(ip: Ipv6Addr) -> bool {
+    // Block any private / loopback / link-local / metadata IPv4 that is
+    // tunnelled inside this v6 address (IPv4-mapped, IPv4-compatible, NAT64, or
+    // 6to4) by re-running the IPv4 policy on the embedded address. A public
+    // embedded IPv4 (e.g. 6to4 `2002:0808:0808::` == 8.8.8.8) is NOT blocked
+    // here — it falls through to the native v6 range checks below.
+    if let Some(v4) = embedded_ipv4(ip)
+        && is_blocked_ipv4(v4)
+    {
+        return true;
     }
 
     let segs = ip.segments();
@@ -257,6 +299,10 @@ fn is_blocked_ipv6(ip: Ipv6Addr) -> bool {
     }
     // fe80::/10 (link-local)
     if segs[0] & 0xffc0 == 0xfe80 {
+        return true;
+    }
+    // fec0::/10 (deprecated site-local — defence-in-depth)
+    if segs[0] & 0xffc0 == 0xfec0 {
         return true;
     }
     // ff00::/8 (multicast)
@@ -1068,6 +1114,15 @@ impl RequestBuilder {
     /// [`ClientError::TooManyRedirects`] (so `max == 0` turns the first `3xx`
     /// into an error). Routes the request through the custom one-shot-client
     /// send path, which bypasses the process-wide circuit breaker.
+    ///
+    /// **TOCTOU / rebinding limitation.** The `validator` receives the redirect
+    /// target as a *string* (not a resolved IP), and the subsequent connection
+    /// re-resolves that host via normal DNS. So a validator that inspects IP
+    /// literals sees only literal hosts, has a connect-time TOCTOU window
+    /// against a hostname that re-resolves between check and connect, and
+    /// provides no address pinning. When you need pinned, rebind-safe following
+    /// that validates every resolved IP and pins the connection per hop, use
+    /// [`Client::get_ssrf_safe`] instead.
     #[must_use]
     pub fn follow_redirects<F>(mut self, max: usize, validator: F) -> Self
     where
@@ -1086,6 +1141,13 @@ impl RequestBuilder {
     /// address the socket connects to is overridden. This protects against
     /// DNS-rebinding / TOCTOU attacks where a hostname re-resolves to a
     /// different (private) address between validation and connection.
+    ///
+    /// **Pinning applies to the initial connection only.** Redirects are **not**
+    /// followed: a `3xx` is returned to the caller verbatim (as if
+    /// [`no_redirect`](Self::no_redirect) were set) rather than being
+    /// auto-followed to a possibly-different host that would be re-resolved via
+    /// normal DNS, silently escaping the pin. If you need pinned, rebind-safe
+    /// per-hop following, use [`Client::get_ssrf_safe`] instead.
     ///
     /// Implemented via a one-shot `reqwest::ClientBuilder::resolve(host, addr)`
     /// scoped to this request. Note that reqwest ignores the **port** in the
@@ -1332,15 +1394,15 @@ impl RequestBuilder {
             return self.follow_loop(max, validator, timeout).await;
         }
 
-        // `None`: single one-shot request with Policy::none() so a 3xx is
-        // returned verbatim. `Default` (pin_to only): keep reqwest's built-in
-        // auto-follow but pin the initial host's resolution.
-        let policy = match self.redirect_mode {
-            RedirectMode::None => reqwest::redirect::Policy::none(),
-            RedirectMode::Default | RedirectMode::Follow { .. } => {
-                reqwest::redirect::Policy::default()
-            }
-        };
+        // Only `RedirectMode::None` (explicit `no_redirect`) and the pin-only
+        // `RedirectMode::Default` reach here (`Follow` and `ssrf_safe` returned
+        // above). Both use `Policy::none()`: a 3xx is returned to the caller
+        // verbatim rather than being auto-followed. Critically, for the
+        // pin-only path this stops reqwest from silently following a cross-host
+        // redirect and re-resolving the new host via normal DNS — which would
+        // defeat the pin. Callers who want to follow redirects while staying
+        // pinned/rebind-safe use `get_ssrf_safe` (or `follow_redirects`).
+        let policy = reqwest::redirect::Policy::none();
         let resolve = self.pin_resolve()?;
         let client = build_oneshot_client(resolve, policy, timeout)?;
         send_one(
@@ -1609,6 +1671,16 @@ fn redirect_target(resp: &Response, base: &str) -> Result<Option<String>, Client
 /// and rejected if **any** resolved address is blocked.
 async fn resolve_and_validate(url: &str) -> Result<SocketAddr, ClientError> {
     let parsed = url::Url::parse(url).map_err(|e| ClientError::InvalidUrl(e.to_string()))?;
+    // Explicit scheme allowlist (defence-in-depth): only http/https may be
+    // resolved and connected on the safe path. Reject ftp://, gopher://,
+    // file://, etc. here — before any DNS lookup or connection — rather than
+    // relying on reqwest to reject them after the fact.
+    let scheme = parsed.scheme();
+    if !scheme.eq_ignore_ascii_case("http") && !scheme.eq_ignore_ascii_case("https") {
+        return Err(ClientError::InvalidUrl(format!(
+            "unsupported URL scheme `{scheme}` (only http/https are allowed): {url}"
+        )));
+    }
     let port = parsed.port_or_known_default().ok_or_else(|| {
         ClientError::InvalidUrl(format!("URL has no port and unknown scheme: {url}"))
     })?;
@@ -2632,6 +2704,7 @@ mod tests {
             "172.16.5.4",      // private
             "192.0.0.1",       // IETF
             "192.0.2.5",       // TEST-NET-1
+            "192.88.99.1",     // 6to4 anycast relay
             "192.168.1.1",     // private
             "198.18.0.1",      // benchmarking
             "198.51.100.7",    // TEST-NET-2
@@ -2667,6 +2740,7 @@ mod tests {
             "fc00::1",                // ULA
             "ff02::1",                // multicast
             "2001:db8::1",            // documentation
+            "fec0::1",                // deprecated site-local
             "::ffff:169.254.169.254", // IPv4-mapped metadata
             "::ffff:127.0.0.1",       // IPv4-mapped loopback
         ];
@@ -2687,6 +2761,38 @@ mod tests {
             is_public_ip(public),
             "2606:4700:4700::1111 should be public"
         );
+    }
+
+    // TEST 46b: SSRF policy blocks private / metadata IPv4 tunnelled inside an
+    // IPv6 literal via NAT64 (64:ff9b::/96) and 6to4 (2002::/16), while leaving
+    // a genuinely-public embedded IPv4 (and native public v6) public.
+    #[test]
+    fn ssrf_policy_blocks_tunnelled_ipv4() {
+        let blocked = [
+            "64:ff9b::a9fe:a9fe", // NAT64 → 169.254.169.254 (cloud metadata)
+            "64:ff9b::7f00:1",    // NAT64 → 127.0.0.1 (loopback)
+            "2002:a9fe:a9fe::",   // 6to4  → 169.254.169.254
+            "2002:7f00:1::",      // 6to4  → 127.0.0.1
+            "2002:0a00:0001::",   // 6to4  → 10.0.0.1
+        ];
+        for s in blocked {
+            let ip: IpAddr = s.parse().unwrap();
+            assert!(is_blocked_ip(ip), "{s} should be blocked");
+            assert!(!is_public_ip(ip), "{s} should not be public");
+        }
+
+        // 192.88.99.0/24 (6to4 anycast relay) is blocked as a plain IPv4 literal.
+        let anycast: IpAddr = "192.88.99.1".parse().unwrap();
+        assert!(is_blocked_ip(anycast), "192.88.99.1 should be blocked");
+
+        // A 6to4 address embedding a genuinely-public IPv4 (8.8.8.8) stays
+        // public (the embedded v4 is public, so it falls through to the native
+        // v6 checks, which do not match 2002::/16). So does a native public v6.
+        for s in ["2002:0808:0808::", "2606:4700::1111"] {
+            let ip: IpAddr = s.parse().unwrap();
+            assert!(is_public_ip(ip), "{s} should be public");
+            assert!(!is_blocked_ip(ip), "{s} should not be blocked");
+        }
     }
 
     // TEST 47: the `url` crate normalises decimal/hex IP-literal hosts to Ipv4,
@@ -2999,6 +3105,72 @@ mod tests {
             assert!(
                 matches!(err, Err(ClientError::SsrfBlocked(_))),
                 "{raw} should be SsrfBlocked, got {err:?}"
+            );
+        }
+    }
+
+    // TEST 57: pin_to alone does NOT auto-follow a cross-host redirect. reqwest
+    // would otherwise re-resolve the new host via normal DNS, silently escaping
+    // the pin. The 302 must be returned verbatim and the onward target must
+    // never be connected to.
+    #[tokio::test]
+    async fn pin_to_does_not_follow_redirect_unpinned() {
+        use axum::{Router, routing::get};
+        use std::sync::atomic::AtomicBool;
+
+        // The redirect target that must never be reached.
+        let touched = Arc::new(AtomicBool::new(false));
+        let touched2 = touched.clone();
+        let onward = spawn(Router::new().route(
+            "/onward",
+            get(move || {
+                let t = touched2.clone();
+                async move {
+                    t.store(true, Ordering::SeqCst);
+                    "REACHED"
+                }
+            }),
+        ))
+        .await;
+        let onward_port = onward.port();
+
+        let start =
+            spawn(Router::new().route(
+                "/start",
+                get(move || async move {
+                    redirect_302(format!("http://127.0.0.1:{onward_port}/onward"))
+                }),
+            ))
+            .await;
+        let start_port = start.port();
+
+        let resp = Client::new()
+            .get(format!("http://127.0.0.1:{start_port}/start"))
+            .pin_to(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), start_port))
+            .send()
+            .await
+            .expect("pinned request should return the 302 unfollowed");
+
+        assert_eq!(
+            resp.status().as_u16(),
+            302,
+            "pin_to must return the redirect unfollowed"
+        );
+        assert!(
+            !touched.load(Ordering::SeqCst),
+            "pin_to must not silently follow the redirect onward"
+        );
+    }
+
+    // TEST 58: get_ssrf_safe rejects a non-http(s) scheme up front with
+    // InvalidUrl, before any DNS resolution or connection.
+    #[tokio::test]
+    async fn get_ssrf_safe_rejects_non_http_scheme() {
+        for raw in ["ftp://public.example/resource", "gopher://public.example/"] {
+            let result = Client::new().get_ssrf_safe(raw).send().await;
+            assert!(
+                matches!(result, Err(ClientError::InvalidUrl(_))),
+                "{raw} should be rejected with InvalidUrl, got {result:?}"
             );
         }
     }

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -1735,11 +1735,9 @@ fn rewrite_after_redirect(
             }
             *body = None;
         }
-        301 | 302 => {
-            if *method == Method::POST {
-                *method = Method::GET;
-                *body = None;
-            }
+        301 | 302 if *method == Method::POST => {
+            *method = Method::GET;
+            *body = None;
         }
         _ => {}
     }

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -90,6 +90,16 @@ pub enum ClientError {
     /// while composing a custom (redirect / pin / SSRF-safe) request.
     #[error("invalid or unresolvable URL: {0}")]
     InvalidUrl(String),
+    /// [`pin_to`](RequestBuilder::pin_to) was combined with
+    /// [`follow_redirects`](RequestBuilder::follow_redirects) — an incompatible
+    /// pair. A single pinned `SocketAddr` only covers the first hop; later
+    /// redirect hops re-resolve via normal DNS, so following a cross-host `3xx`
+    /// would silently escape the pin and defeat its purpose. Use
+    /// [`Client::get_ssrf_safe`] for pinned, per-hop-revalidated redirect
+    /// following; `pin_to` alone (returns the `3xx` unfollowed); or
+    /// `follow_redirects` without `pin_to`.
+    #[error("{0}")]
+    IncompatiblePinRedirect(&'static str),
 }
 
 // ── Response ─────────────────────────────────────────────────────────────────
@@ -1198,11 +1208,20 @@ impl RequestBuilder {
     /// different (private) address between validation and connection.
     ///
     /// **Pinning applies to the initial connection only.** Redirects are **not**
-    /// followed: a `3xx` is returned to the caller verbatim (as if
+    /// followed under `pin_to`: a `3xx` is returned to the caller verbatim (as if
     /// [`no_redirect`](Self::no_redirect) were set) rather than being
     /// auto-followed to a possibly-different host that would be re-resolved via
     /// normal DNS, silently escaping the pin. If you need pinned, rebind-safe
     /// per-hop following, use [`Client::get_ssrf_safe`] instead.
+    ///
+    /// **Cannot be combined with [`follow_redirects`](Self::follow_redirects).**
+    /// Because the pin only covers the first hop while later hops would re-resolve
+    /// via DNS, chaining `pin_to` with `follow_redirects` (in either order) is
+    /// rejected at send time with [`ClientError::IncompatiblePinRedirect`] rather
+    /// than silently following a redirect off the pinned address. Use
+    /// [`Client::get_ssrf_safe`] for pinned, per-hop-revalidated redirect
+    /// following, `pin_to` alone (which returns the `3xx` unfollowed), or
+    /// `follow_redirects` without `pin_to`.
     ///
     /// Implemented via a one-shot `reqwest::ClientBuilder::resolve(host, addr)`
     /// scoped to this request. Note that reqwest ignores the **port** in the
@@ -1438,6 +1457,22 @@ impl RequestBuilder {
 
     /// Dispatch to the appropriate custom send path. Consumes `self`.
     async fn send_custom(self) -> Result<Response, ClientError> {
+        // Reject the incompatible `pin_to` + `follow_redirects` combination up
+        // front — deterministically, before issuing any request. A single pinned
+        // `SocketAddr` only applies to hop 0 of `follow_loop`; later hops resolve
+        // via normal DNS, so following a cross-host `3xx` would silently escape
+        // the pin and defeat its purpose. `get_ssrf_safe` never sets `pin_addr`,
+        // so its per-hop resolve→validate→pin path is unaffected by this guard.
+        if self.pin_addr.is_some() && matches!(self.redirect_mode, RedirectMode::Follow { .. }) {
+            return Err(ClientError::IncompatiblePinRedirect(
+                "pin_to cannot be combined with follow_redirects: the pin only \
+                 covers the first hop and later redirect hops re-resolve via DNS, \
+                 escaping the pin. Use get_ssrf_safe for pinned, per-hop-revalidated \
+                 redirect following; pin_to alone (which returns the 3xx unfollowed); \
+                 or follow_redirects without pin_to.",
+            ));
+        }
+
         let timeout = self
             .retry_policy
             .request_timeout
@@ -3681,6 +3716,70 @@ mod tests {
             follow3.ssrf_redirect_plan(),
             (true, 3),
             "follow_redirects(3, ..) must cap the safe path at 3 hops"
+        );
+    }
+
+    // TEST 64: pin_to + follow_redirects is rejected at send time with
+    // IncompatiblePinRedirect — deterministically, without touching the network.
+    // A single pinned SocketAddr only covers hop 0; later redirect hops re-resolve
+    // via normal DNS, so following would silently escape the pin.
+    #[tokio::test]
+    async fn pin_then_follow_redirects_is_rejected() {
+        let result = Client::new()
+            .get("http://example.com/")
+            .pin_to(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080))
+            .follow_redirects(2, |_| true)
+            .send()
+            .await;
+
+        assert!(
+            matches!(result, Err(ClientError::IncompatiblePinRedirect(_))),
+            "expected IncompatiblePinRedirect, got {result:?}"
+        );
+    }
+
+    // TEST 65: the rejection is order-independent — chaining follow_redirects
+    // before pin_to produces the same IncompatiblePinRedirect error.
+    #[tokio::test]
+    async fn follow_redirects_then_pin_is_rejected() {
+        let result = Client::new()
+            .get("http://example.com/")
+            .follow_redirects(2, |_| true)
+            .pin_to(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080))
+            .send()
+            .await;
+
+        assert!(
+            matches!(result, Err(ClientError::IncompatiblePinRedirect(_))),
+            "expected IncompatiblePinRedirect, got {result:?}"
+        );
+    }
+
+    // TEST 66: pin_to combined with no_redirect is NOT affected by the guard —
+    // the request proceeds and returns the 3xx verbatim (RedirectMode::None).
+    #[tokio::test]
+    async fn pin_with_no_redirect_is_allowed() {
+        use axum::{Router, routing::get};
+
+        let addr = spawn(Router::new().route(
+            "/start",
+            get(|| async { redirect_302("http://127.0.0.1:1/onward".to_owned()) }),
+        ))
+        .await;
+        let port = addr.port();
+
+        let resp = Client::new()
+            .get(format!("http://127.0.0.1:{port}/start"))
+            .pin_to(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port))
+            .no_redirect()
+            .send()
+            .await
+            .expect("pin_to + no_redirect must return the 3xx unfollowed, not error");
+
+        assert_eq!(
+            resp.status().as_u16(),
+            302,
+            "pin_to + no_redirect returns the redirect verbatim"
         );
     }
 }

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -1758,14 +1758,19 @@ impl RequestBuilder {
             )
             .await?;
 
-            let Some(next) = redirect_target(&resp, &current)? else {
-                return Ok(resp);
-            };
-            // Honour a chained `no_redirect()`: return the 3xx verbatim. The
-            // initial URL was still resolved / validated / pinned above.
+            // Honour a chained `no_redirect()`: return the response verbatim
+            // BEFORE parsing the `Location` header. The initial URL was still
+            // resolved / validated / pinned above. Parsing `Location` here (via
+            // `redirect_target`) would let an untrusted server force an
+            // `InvalidUrl` error out of a `no_redirect()` fetch by returning a
+            // followable 3xx with a malformed `Location`, violating the
+            // documented "return the initial 3xx verbatim" contract.
             if !follow {
                 return Ok(resp);
             }
+            let Some(next) = redirect_target(&resp, &current)? else {
+                return Ok(resp);
+            };
             if hop >= max {
                 return Err(ClientError::TooManyRedirects(max));
             }
@@ -3327,6 +3332,44 @@ mod tests {
         assert_eq!(
             resp.headers().get("location").and_then(|v| v.to_str().ok()),
             Some("http://127.0.0.1:1/never")
+        );
+    }
+
+    // TEST 48b: the non-ssrf `no_redirect()` path returns the 3xx verbatim even
+    // when `Location` is a MALFORMED URL. That path uses reqwest's
+    // `Policy::none()` and never parses `Location`, so a bad target cannot turn
+    // a `no_redirect()` fetch into an error. This guards the same "don't parse
+    // Location when not following" contract that `send_ssrf_safe` now enforces
+    // by returning the 3xx BEFORE calling `redirect_target`.
+    //
+    // NOTE: the SSRF-safe equivalent — `get_ssrf_safe(url).no_redirect()`
+    // against a listener returning a malformed `Location` — cannot be exercised
+    // end-to-end in-sandbox: the SSRF guard denies loopback (127.0.0.1), so the
+    // request is rejected during resolve→validate before any response is
+    // received. This testable-layer variant documents/guards the shared
+    // contract instead.
+    #[tokio::test]
+    async fn no_redirect_returns_3xx_with_malformed_location() {
+        use axum::{Router, routing::get};
+        let addr = spawn(Router::new().route(
+            "/start",
+            // `ht!tp://\bad` is not a parseable absolute URL (invalid scheme),
+            // but it is a valid HTTP header value, so the server can emit it.
+            get(|| async { redirect_302("ht!tp://\\bad".to_owned()) }),
+        ))
+        .await;
+
+        let resp = Client::new()
+            .get(format!("http://127.0.0.1:{}/start", addr.port()))
+            .no_redirect()
+            .send()
+            .await
+            .expect("no_redirect() must return the 3xx even with a malformed Location");
+
+        assert_eq!(resp.status().as_u16(), 302);
+        assert_eq!(
+            resp.headers().get("location").and_then(|v| v.to_str().ok()),
+            Some("ht!tp://\\bad")
         );
     }
 

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -100,6 +100,16 @@ pub enum ClientError {
     /// `follow_redirects` without `pin_to`.
     #[error("{0}")]
     IncompatiblePinRedirect(&'static str),
+    /// [`pin_to`](RequestBuilder::pin_to) was used on a request whose URL host is
+    /// an IP literal. reqwest/hyper treat an IP-literal host as already-resolved
+    /// and never consult the DNS resolver, so the `resolve_to_addrs` override
+    /// that installs the pin is skipped and the socket connects to the literal in
+    /// the URL — not the pinned address — silently bypassing the pin. `pin_to`
+    /// therefore requires a domain (hostname) host; put the desired IP directly
+    /// in the URL, or use a domain host. (`get_ssrf_safe` never sets a pin: it
+    /// validates the literal and connects to that same IP, so it is unaffected.)
+    #[error("{0}")]
+    PinRequiresDomainHost(&'static str),
 }
 
 // ── Response ─────────────────────────────────────────────────────────────────
@@ -1253,6 +1263,15 @@ impl RequestBuilder {
     /// DNS-rebinding / TOCTOU attacks where a hostname re-resolves to a
     /// different (private) address between validation and connection.
     ///
+    /// **Requires a domain (hostname) URL host.** The pin is enforced via a DNS
+    /// `resolve` override, but reqwest/hyper treat an IP-literal URL host as
+    /// already-resolved and never consult the resolver — so the override is
+    /// skipped and the socket would connect to the literal in the URL, not the
+    /// pinned address. A `pin_to` request whose URL host is an IP literal
+    /// (IPv4 or IPv6) is therefore **rejected at send time** with
+    /// [`ClientError::PinRequiresDomainHost`]. Put the desired IP directly in the
+    /// URL (no pin needed), or use a domain host.
+    ///
     /// **Pinning applies to the initial connection only.** Redirects are **not**
     /// followed under `pin_to`: a `3xx` is returned to the caller verbatim (as if
     /// [`no_redirect`](Self::no_redirect) were set) rather than being
@@ -1519,6 +1538,23 @@ impl RequestBuilder {
             ));
         }
 
+        // Reject `pin_to` on an IP-literal URL host up front — deterministically,
+        // before any network I/O. reqwest/hyper treat an IP-literal host as
+        // already-resolved and do NOT consult the DNS resolver, so the
+        // `resolve_to_addrs` override installed by `build_oneshot_client` (which
+        // is what enforces the pin) is skipped and the socket connects to the
+        // literal in the URL rather than the pinned address — silently violating
+        // `pin_to`'s documented guarantee. `get_ssrf_safe` never sets `pin_addr`
+        // (and validates+connects to the same literal, so it stays safe), so this
+        // guard targets only the explicit `pin_to` primitive.
+        if self.pin_addr.is_some() && url_host_is_ip_literal(&self.url)? {
+            return Err(ClientError::PinRequiresDomainHost(
+                "pin_to cannot be honored for an IP-literal URL host because the \
+                 HTTP stack connects to the literal directly and skips the pinned \
+                 address; put the desired IP directly in the URL, or use a domain host.",
+            ));
+        }
+
         let timeout = self
             .retry_policy
             .request_timeout
@@ -1620,7 +1656,7 @@ impl RequestBuilder {
                 return Err(ClientError::RedirectRejected(next));
             }
             // RFC 7231/7538 method+body rewriting before the next hop.
-            rewrite_after_redirect(resp.status(), &mut method, &mut body);
+            rewrite_after_redirect(resp.status(), &mut method, &mut body, &mut headers);
             current = next;
         }
         unreachable!("redirect loop is bounded by `max` and always returns")
@@ -1714,7 +1750,7 @@ impl RequestBuilder {
                 return Err(ClientError::RedirectRejected(next));
             }
             // RFC 7231/7538 method+body rewriting before the next hop.
-            rewrite_after_redirect(resp.status(), &mut method, &mut body);
+            rewrite_after_redirect(resp.status(), &mut method, &mut body, &mut headers);
             current = next;
             // The next loop iteration re-resolves + re-validates `current`
             // before connecting, so a redirect to a blocked address is rejected
@@ -1860,6 +1896,18 @@ fn host_of(url: &str) -> Result<String, ClientError> {
         .ok_or_else(|| ClientError::InvalidUrl(format!("URL has no host: {url}")))
 }
 
+/// `true` when the URL's host is an IP literal (IPv4 or IPv6) rather than a
+/// domain name. Uses the `url` crate's parsed [`url::Host`] so bracketed IPv6
+/// literals and decimal/octal/hex IPv4 encodings are classified correctly.
+fn url_host_is_ip_literal(url: &str) -> Result<bool, ClientError> {
+    let parsed = url::Url::parse(url).map_err(|e| ClientError::InvalidUrl(e.to_string()))?;
+    match parsed.host() {
+        Some(url::Host::Ipv4(_) | url::Host::Ipv6(_)) => Ok(true),
+        Some(url::Host::Domain(_)) => Ok(false),
+        None => Err(ClientError::InvalidUrl(format!("URL has no host: {url}"))),
+    }
+}
+
 /// `true` when the URL's scheme is `https` (case-insensitive).
 fn scheme_is_https(url: &str) -> Result<bool, ClientError> {
     let parsed = url::Url::parse(url).map_err(|e| ClientError::InvalidUrl(e.to_string()))?;
@@ -1923,10 +1971,18 @@ fn strip_sensitive_headers_if_cross_origin(
 ///   **and** the body verbatim (the RFC-correct behaviour — the body must NOT
 ///   be dropped).
 /// - Any other redirect status: leave method and body untouched.
+///
+/// Whenever the body is dropped (the POST→GET / 303→GET rewrites), the payload
+/// (entity) headers threaded across hops are also removed from `headers` so the
+/// bodyless follow-up hop does not carry a misleading `Content-Type` /
+/// `Content-Length` / `Transfer-Encoding` / `Content-Encoding` /
+/// `Content-Language` — matching reqwest's redirect layer. On 307/308 the body
+/// is preserved, so those headers are left intact.
 fn rewrite_after_redirect(
     status: reqwest::StatusCode,
     method: &mut Method,
     body: &mut Option<Bytes>,
+    headers: &mut HeaderMap,
 ) {
     match status.as_u16() {
         303 => {
@@ -1934,13 +1990,29 @@ fn rewrite_after_redirect(
                 *method = Method::GET;
             }
             *body = None;
+            strip_payload_headers(headers);
         }
         301 | 302 if *method == Method::POST => {
             *method = Method::GET;
             *body = None;
+            strip_payload_headers(headers);
         }
         _ => {}
     }
+}
+
+/// Remove payload (entity) headers from the threaded per-hop header map. Called
+/// when a redirect rewrite drops the request body so a bodyless GET does not
+/// keep carrying the original payload's `Content-Type` etc.
+fn strip_payload_headers(headers: &mut HeaderMap) {
+    use reqwest::header::{
+        CONTENT_ENCODING, CONTENT_LANGUAGE, CONTENT_LENGTH, CONTENT_TYPE, TRANSFER_ENCODING,
+    };
+    headers.remove(CONTENT_TYPE);
+    headers.remove(CONTENT_LENGTH);
+    headers.remove(TRANSFER_ENCODING);
+    headers.remove(CONTENT_ENCODING);
+    headers.remove(CONTENT_LANGUAGE);
 }
 
 /// Validate a set of resolved socket addresses against the built-in SSRF
@@ -3518,8 +3590,12 @@ mod tests {
             .await;
         let start_port = start.port();
 
+        // Use a DOMAIN host (`pinned.invalid`) so the pin's resolve override is
+        // actually consulted; pinning an IP-literal host is now rejected by the
+        // PinRequiresDomainHost guard. The non-resolvable domain reaches the
+        // loopback listener only via the pin.
         let resp = Client::new()
-            .get(format!("http://127.0.0.1:{start_port}/start"))
+            .get(format!("http://pinned.invalid:{start_port}/start"))
             .pin_to(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), start_port))
             .send()
             .await
@@ -3665,15 +3741,15 @@ mod tests {
             routing::{any, post},
         };
 
-        let seen: Arc<Mutex<Option<(String, Bytes)>>> = Arc::new(Mutex::new(None));
+        let seen: Arc<Mutex<Option<(String, HeaderMap, Bytes)>>> = Arc::new(Mutex::new(None));
         let seen2 = seen.clone();
-        // B records the method + body it actually received, for any verb.
+        // B records the method + headers + body it actually received, for any verb.
         let b_addr = spawn(Router::new().route(
             "/dst",
-            any(move |method: Method, body: Bytes| {
+            any(move |method: Method, headers: HeaderMap, body: Bytes| {
                 let slot = seen2.clone();
                 async move {
-                    *slot.lock().unwrap() = Some((method.to_string(), body));
+                    *slot.lock().unwrap() = Some((method.to_string(), headers, body));
                     "ok"
                 }
             }),
@@ -3687,22 +3763,34 @@ mod tests {
         ))
         .await;
 
+        // `.json(..)` sets a request body AND `Content-Type: application/json`.
+        // On the 302 POST→GET rewrite the body is dropped, and the payload
+        // headers must be dropped with it (Fix B) — otherwise the followed GET
+        // would carry a misleading `Content-Type` for a body it no longer has.
         let resp = Client::new()
             .post(format!("http://127.0.0.1:{}/", a_addr.port()))
-            .text_body("payload")
+            .json(&serde_json::json!({"payload": true}))
             .follow_redirects(3, |_| true)
             .send()
             .await
             .unwrap();
 
         assert_eq!(resp.status().as_u16(), 200);
-        let (method, body) = seen
+        let (method, headers, body) = seen
             .lock()
             .unwrap()
             .clone()
             .expect("listener B must have been reached");
         assert_eq!(method, "GET", "302 must rewrite POST → GET");
         assert!(body.is_empty(), "302 POST→GET must drop the request body");
+        assert!(
+            !headers.contains_key(reqwest::header::CONTENT_TYPE),
+            "302 POST→GET must drop the Content-Type payload header"
+        );
+        assert!(
+            !headers.contains_key(reqwest::header::CONTENT_LENGTH),
+            "302 POST→GET must drop the Content-Length payload header"
+        );
     }
 
     // TEST 62: RFC 7231 §6.4.7 — a 307 preserves BOTH the method and the body
@@ -3846,8 +3934,10 @@ mod tests {
         .await;
         let port = addr.port();
 
+        // Use a DOMAIN host so the pin's resolve override is consulted; pinning
+        // an IP-literal host is now rejected by the PinRequiresDomainHost guard.
         let resp = Client::new()
-            .get(format!("http://127.0.0.1:{port}/start"))
+            .get(format!("http://pinned.invalid:{port}/start"))
             .pin_to(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port))
             .no_redirect()
             .send()
@@ -3858,6 +3948,41 @@ mod tests {
             resp.status().as_u16(),
             302,
             "pin_to + no_redirect returns the redirect verbatim"
+        );
+    }
+
+    // TEST 67: pin_to on an IPv4-literal URL host is rejected at send time with
+    // PinRequiresDomainHost — deterministically, without touching the network.
+    // reqwest/hyper treat an IP-literal host as already-resolved and skip the
+    // resolve override that installs the pin, so the socket would connect to the
+    // literal in the URL (198.51.100.1), NOT the pinned 127.0.0.1 — silently
+    // bypassing the pin. The guard rejects it instead.
+    #[tokio::test]
+    async fn pin_to_ipv4_literal_host_is_rejected() {
+        let result = Client::new()
+            .get("http://198.51.100.1:8080/")
+            .pin_to(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080))
+            .send()
+            .await;
+
+        assert!(
+            matches!(result, Err(ClientError::PinRequiresDomainHost(_))),
+            "expected PinRequiresDomainHost, got {result:?}"
+        );
+    }
+
+    // TEST 68: the same rejection applies to an IPv6-literal URL host.
+    #[tokio::test]
+    async fn pin_to_ipv6_literal_host_is_rejected() {
+        let result = Client::new()
+            .get("http://[2606:4700::1111]/")
+            .pin_to(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080))
+            .send()
+            .await;
+
+        assert!(
+            matches!(result, Err(ClientError::PinRequiresDomainHost(_))),
+            "expected PinRequiresDomainHost, got {result:?}"
         );
     }
 }

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -1914,12 +1914,25 @@ fn scheme_is_https(url: &str) -> Result<bool, ClientError> {
     Ok(parsed.scheme().eq_ignore_ascii_case("https"))
 }
 
-/// If `resp` is a `3xx` carrying a `Location` header, resolve it to an absolute
-/// URL (joining relative locations against `base`). Returns `Ok(None)` when the
-/// response is not a followable redirect (non-3xx, or 3xx without `Location`).
+/// If `resp` is a followable redirect (status `301`, `302`, `303`, `307`, or
+/// `308`) carrying a `Location` header, resolve it to an absolute URL (joining
+/// relative locations against `base`). Returns `Ok(None)` when the response is
+/// not a followable redirect: any status outside that set (including non-3xx and
+/// the non-followable 3xx `300`/`304`/`305`/`306`), or a followable status
+/// missing its `Location` header.
 fn redirect_target(resp: &Response, base: &str) -> Result<Option<String>, ClientError> {
-    if !resp.status().is_redirection() {
-        return Ok(None);
+    // Only the statuses reqwest itself follows are treated as redirects. A
+    // response like `304 Not Modified` (or 300/305/306) can legitimately carry
+    // a `Location` header without being a followable redirect, so matching the
+    // entire 300–399 range via `is_redirection()` would wrongly issue an extra
+    // request instead of returning the response to the caller.
+    match resp.status() {
+        reqwest::StatusCode::MOVED_PERMANENTLY
+        | reqwest::StatusCode::FOUND
+        | reqwest::StatusCode::SEE_OTHER
+        | reqwest::StatusCode::TEMPORARY_REDIRECT
+        | reqwest::StatusCode::PERMANENT_REDIRECT => {}
+        _ => return Ok(None),
     }
     let Some(location) = resp
         .headers()
@@ -3248,6 +3261,17 @@ mod tests {
             .unwrap()
     }
 
+    // Build a response with an arbitrary status that carries a `Location`
+    // header — used to prove non-followable 3xx statuses (304/300/…) are NOT
+    // treated as redirects even when they advertise a `Location`.
+    fn response_with_location(status: u16, location: String) -> axum::response::Response {
+        axum::response::Response::builder()
+            .status(status)
+            .header("location", location)
+            .body(axum::body::Body::empty())
+            .unwrap()
+    }
+
     // TEST 48: no_redirect returns the 3xx verbatim without following it.
     #[tokio::test]
     async fn no_redirect_returns_3xx_unfollowed() {
@@ -3983,6 +4007,107 @@ mod tests {
         assert!(
             matches!(result, Err(ClientError::PinRequiresDomainHost(_))),
             "expected PinRequiresDomainHost, got {result:?}"
+        );
+    }
+
+    // TEST 69: a `304 Not Modified` that happens to carry a `Location` header is
+    // NOT a followable redirect. reqwest only follows 301/302/303/307/308, so
+    // `redirect_target` must return the 304 to the caller verbatim rather than
+    // issuing a second request against the `Location` target.
+    #[tokio::test]
+    async fn follow_redirects_does_not_follow_304_with_location() {
+        use axum::{Router, routing::get};
+        use std::sync::atomic::AtomicBool;
+
+        // Listener B must never be reached.
+        let touched = Arc::new(AtomicBool::new(false));
+        let touched2 = touched.clone();
+        let b_addr = spawn(Router::new().route(
+            "/dst",
+            get(move || {
+                let t = touched2.clone();
+                async move {
+                    t.store(true, Ordering::SeqCst);
+                    "SHOULD-NOT-BE-HIT"
+                }
+            }),
+        ))
+        .await;
+        let b_port = b_addr.port();
+
+        // Listener A returns 304 + Location pointing at B.
+        let a_addr = spawn(Router::new().route(
+            "/start",
+            get(move || async move {
+                response_with_location(304, format!("http://127.0.0.1:{b_port}/dst"))
+            }),
+        ))
+        .await;
+
+        let resp = Client::new()
+            .get(format!("http://127.0.0.1:{}/start", a_addr.port()))
+            .follow_redirects(5, |_| true)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status().as_u16(),
+            304,
+            "a 304 with a Location header must be returned verbatim, not followed"
+        );
+        assert!(
+            !touched.load(Ordering::SeqCst),
+            "the 304 Location target must never be requested"
+        );
+    }
+
+    // TEST 70: a `300 Multiple Choices` that carries a `Location` header is
+    // likewise not a followable redirect (only 301/302/303/307/308 are), so the
+    // 300 is returned to the caller and the `Location` target is never hit.
+    #[tokio::test]
+    async fn follow_redirects_does_not_follow_300_with_location() {
+        use axum::{Router, routing::get};
+        use std::sync::atomic::AtomicBool;
+
+        let touched = Arc::new(AtomicBool::new(false));
+        let touched2 = touched.clone();
+        let b_addr = spawn(Router::new().route(
+            "/dst",
+            get(move || {
+                let t = touched2.clone();
+                async move {
+                    t.store(true, Ordering::SeqCst);
+                    "SHOULD-NOT-BE-HIT"
+                }
+            }),
+        ))
+        .await;
+        let b_port = b_addr.port();
+
+        let a_addr = spawn(Router::new().route(
+            "/start",
+            get(move || async move {
+                response_with_location(300, format!("http://127.0.0.1:{b_port}/dst"))
+            }),
+        ))
+        .await;
+
+        let resp = Client::new()
+            .get(format!("http://127.0.0.1:{}/start", a_addr.port()))
+            .follow_redirects(5, |_| true)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status().as_u16(),
+            300,
+            "a 300 with a Location header must be returned verbatim, not followed"
+        );
+        assert!(
+            !touched.load(Ordering::SeqCst),
+            "the 300 Location target must never be requested"
         );
     }
 }

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -46,6 +46,7 @@
 //! ```
 
 use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -73,6 +74,22 @@ pub enum ClientError {
     /// The outbound circuit breaker is open.
     #[error("outbound circuit breaker is open")]
     CircuitBreakerOpen,
+    /// A resolved connection target (or redirect target) is a blocked
+    /// (private / link-local / loopback / reserved) IP address per the built-in
+    /// SSRF policy. See [`is_blocked_ip`].
+    #[error("SSRF policy blocked address: {0}")]
+    SsrfBlocked(String),
+    /// A redirect chain exceeded the configured maximum number of hops.
+    #[error("too many redirects (max {0})")]
+    TooManyRedirects(usize),
+    /// A redirect's absolute `Location` target was rejected by the caller's
+    /// validator (or by the built-in scheme-downgrade guard).
+    #[error("redirect rejected: {0}")]
+    RedirectRejected(String),
+    /// A URL could not be parsed, was missing a host, or DNS resolution failed
+    /// while composing a custom (redirect / pin / SSRF-safe) request.
+    #[error("invalid or unresolvable URL: {0}")]
+    InvalidUrl(String),
 }
 
 // ── Response ─────────────────────────────────────────────────────────────────
@@ -81,6 +98,7 @@ pub enum ClientError {
 ///
 /// Body is consumed once — call exactly one of [`json`](Self::json),
 /// [`text`](Self::text), or [`bytes`](Self::bytes).
+#[derive(Debug)]
 pub struct Response {
     status: reqwest::StatusCode,
     headers: HeaderMap,
@@ -126,6 +144,130 @@ impl Response {
     pub fn bytes(self) -> Bytes {
         self.body
     }
+}
+
+// ── SSRF address policy ──────────────────────────────────────────────────────
+
+/// Return `true` when `ip` must **not** be connected to because it belongs to a
+/// private, loopback, link-local, CGNAT, benchmarking, documentation, multicast
+/// or otherwise reserved range.
+///
+/// This is the built-in Server-Side Request Forgery (SSRF) deny-list used by
+/// [`Client::get_ssrf_safe`]. Ranges are checked explicitly (rather than via the
+/// unstable `IpAddr::is_global` family) so the code compiles on stable Rust.
+///
+/// IPv4-mapped (`::ffff:a.b.c.d`) and the deprecated IPv4-compatible
+/// (`::a.b.c.d`) IPv6 forms are unwrapped and re-checked as IPv4, so encodings
+/// such as `::ffff:169.254.169.254` are correctly blocked.
+#[must_use]
+pub fn is_blocked_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_blocked_ipv4(v4),
+        IpAddr::V6(v6) => is_blocked_ipv6(v6),
+    }
+}
+
+/// Return `true` when `ip` is safe to connect to — the exact negation of
+/// [`is_blocked_ip`].
+#[must_use]
+pub fn is_public_ip(ip: IpAddr) -> bool {
+    !is_blocked_ip(ip)
+}
+
+fn is_blocked_ipv4(ip: Ipv4Addr) -> bool {
+    let [a, b, c, _d] = ip.octets();
+    // 0.0.0.0/8 (incl. unspecified)
+    if a == 0 {
+        return true;
+    }
+    // 10.0.0.0/8
+    if a == 10 {
+        return true;
+    }
+    // 100.64.0.0/10 (CGNAT)
+    if a == 100 && (64..=127).contains(&b) {
+        return true;
+    }
+    // 127.0.0.0/8 (loopback)
+    if a == 127 {
+        return true;
+    }
+    // 169.254.0.0/16 (link-local, incl. 169.254.169.254 cloud metadata)
+    if a == 169 && b == 254 {
+        return true;
+    }
+    // 172.16.0.0/12
+    if a == 172 && (16..=31).contains(&b) {
+        return true;
+    }
+    // 192.0.0.0/24 (IETF protocol assignments)
+    if a == 192 && b == 0 && c == 0 {
+        return true;
+    }
+    // 192.0.2.0/24 (TEST-NET-1)
+    if a == 192 && b == 0 && c == 2 {
+        return true;
+    }
+    // 192.168.0.0/16
+    if a == 192 && b == 168 {
+        return true;
+    }
+    // 198.18.0.0/15 (benchmarking)
+    if a == 198 && (18..=19).contains(&b) {
+        return true;
+    }
+    // 198.51.100.0/24 (TEST-NET-2)
+    if a == 198 && b == 51 && c == 100 {
+        return true;
+    }
+    // 203.0.113.0/24 (TEST-NET-3)
+    if a == 203 && b == 0 && c == 113 {
+        return true;
+    }
+    // 224.0.0.0/4 (multicast) and 240.0.0.0/4 (reserved, incl. 255.255.255.255)
+    if a >= 224 {
+        return true;
+    }
+    false
+}
+
+fn is_blocked_ipv6(ip: Ipv6Addr) -> bool {
+    // Unwrap IPv4-mapped (::ffff:a.b.c.d) and deprecated IPv4-compatible
+    // (::a.b.c.d) forms and re-check as IPv4. `to_ipv4` covers both, but we try
+    // the mapped form first for clarity.
+    if let Some(v4) = ip.to_ipv4_mapped() {
+        return is_blocked_ipv4(v4);
+    }
+    if let Some(v4) = ip.to_ipv4() {
+        return is_blocked_ipv4(v4);
+    }
+
+    let segs = ip.segments();
+    // :: (unspecified)
+    if ip == Ipv6Addr::UNSPECIFIED {
+        return true;
+    }
+    // ::1 (loopback)
+    if ip == Ipv6Addr::LOCALHOST {
+        return true;
+    }
+    // fc00::/7 (unique local address)
+    if segs[0] & 0xfe00 == 0xfc00 {
+        return true;
+    }
+    // fe80::/10 (link-local)
+    if segs[0] & 0xffc0 == 0xfe80 {
+        return true;
+    }
+    // ff00::/8 (multicast)
+    if segs[0] & 0xff00 == 0xff00 {
+        return true;
+    }
+    // 2001:db8::/32 (documentation)
+    if segs[0] == 0x2001 && segs[1] == 0x0db8 {
+        return true;
+    }
+    false
 }
 
 // ── RetryPolicy ──────────────────────────────────────────────────────────────
@@ -698,6 +840,9 @@ impl Client {
             alias: self.alias.clone(),
             pending_error: None,
             resilience_config: self.resilience_config.clone(),
+            redirect_mode: RedirectMode::Default,
+            pin_addr: None,
+            ssrf_safe: false,
         }
     }
 
@@ -732,6 +877,28 @@ impl Client {
     pub fn head(&self, url: impl AsRef<str>) -> RequestBuilder {
         self.build_request(Method::HEAD, url)
     }
+
+    /// Build an SSRF-safe `GET` request.
+    ///
+    /// This is the composed safe path for fetching **untrusted** URLs. Before
+    /// connecting it resolves the host **once**, validates every resolved IP
+    /// against the built-in SSRF deny-list ([`is_blocked_ip`]) and rejects the
+    /// request if *any* address is blocked. The connection is then pinned to a
+    /// validated address so reqwest cannot re-resolve the host (closing the
+    /// DNS-rebinding / TOCTOU window). Redirects are followed manually up to
+    /// [`SSRF_SAFE_MAX_REDIRECTS`] hops, re-running resolve→validate→pin on each
+    /// hop; a hop that downgrades the scheme from `https` to `http` is rejected
+    /// as defence-in-depth.
+    ///
+    /// Like the test-mock path, this custom send path bypasses the process-wide
+    /// circuit-breaker registry to avoid entangling per-URL SSRF fetches with
+    /// the shared per-host breaker state.
+    #[must_use]
+    pub fn get_ssrf_safe(&self, url: impl Into<String>) -> RequestBuilder {
+        let mut builder = self.build_request(Method::GET, url.into());
+        builder.ssrf_safe = true;
+        builder
+    }
 }
 
 impl Default for Client {
@@ -753,6 +920,30 @@ impl axum::extract::FromRequestParts<crate::AppState> for Client {
 
 // ── RequestBuilder ───────────────────────────────────────────────────────────
 
+/// Type alias for a redirect-`Location` validator.
+type RedirectValidator = Arc<dyn Fn(&str) -> bool + Send + Sync>;
+
+/// Per-request redirect handling.
+///
+/// `Default` preserves the historical behaviour exactly (the shared-client fast
+/// path with reqwest's built-in auto-follow). `None` and `Follow` route the
+/// request through the custom one-shot-client send path.
+enum RedirectMode {
+    /// Historical behaviour: shared client, reqwest auto-follows up to 10 hops.
+    Default,
+    /// Never follow: a 3xx is returned to the caller verbatim.
+    None,
+    /// Follow up to `max` hops, calling `validator` on each absolute target
+    /// before following it.
+    Follow {
+        max: usize,
+        validator: RedirectValidator,
+    },
+}
+
+/// Default hop cap for the composed [`Client::get_ssrf_safe`] safe path.
+const SSRF_SAFE_MAX_REDIRECTS: usize = 5;
+
 /// Fluent outbound request builder produced by [`Client`] methods.
 pub struct RequestBuilder {
     client: reqwest::Client,
@@ -768,6 +959,14 @@ pub struct RequestBuilder {
     pending_error: Option<ClientError>,
     /// Resilience configuration for circuit breakers.
     resilience_config: Option<Arc<crate::config::ResilienceConfig>>,
+    /// Per-request redirect handling (see [`RedirectMode`]).
+    redirect_mode: RedirectMode,
+    /// When set, connect directly to this socket, skipping DNS resolution while
+    /// preserving the original `Host` header + SNI. See [`RequestBuilder::pin_to`].
+    pin_addr: Option<SocketAddr>,
+    /// When `true`, use the composed SSRF-safe send path (resolve→validate→pin
+    /// with per-hop redirect validation). Set by [`Client::get_ssrf_safe`].
+    ssrf_safe: bool,
 }
 
 impl RequestBuilder {
@@ -847,6 +1046,60 @@ impl RequestBuilder {
         self
     }
 
+    /// Disable redirect following for this request.
+    ///
+    /// A `3xx` response is returned to the caller verbatim (status, headers and
+    /// body) rather than being followed. Routes the request through the custom
+    /// one-shot-client send path, which bypasses the process-wide circuit
+    /// breaker.
+    #[must_use]
+    pub fn no_redirect(mut self) -> Self {
+        self.redirect_mode = RedirectMode::None;
+        self
+    }
+
+    /// Follow up to `max` redirects, validating each hop before following it.
+    ///
+    /// Before following a `3xx`, the `Location` header is resolved to an
+    /// absolute URL (relative locations are joined against the current URL) and
+    /// `validator(&absolute_location)` is called. If it returns `false` the
+    /// request fails with [`ClientError::RedirectRejected`]. If the chain would
+    /// exceed `max` hops the request fails with
+    /// [`ClientError::TooManyRedirects`] (so `max == 0` turns the first `3xx`
+    /// into an error). Routes the request through the custom one-shot-client
+    /// send path, which bypasses the process-wide circuit breaker.
+    #[must_use]
+    pub fn follow_redirects<F>(mut self, max: usize, validator: F) -> Self
+    where
+        F: Fn(&str) -> bool + Send + Sync + 'static,
+    {
+        self.redirect_mode = RedirectMode::Follow {
+            max,
+            validator: Arc::new(validator),
+        };
+        self
+    }
+
+    /// Pin the connection to `addr`, skipping DNS resolution.
+    ///
+    /// The original `Host` header and TLS SNI are preserved; only the
+    /// address the socket connects to is overridden. This protects against
+    /// DNS-rebinding / TOCTOU attacks where a hostname re-resolves to a
+    /// different (private) address between validation and connection.
+    ///
+    /// Implemented via a one-shot `reqwest::ClientBuilder::resolve(host, addr)`
+    /// scoped to this request. Note that reqwest ignores the **port** in the
+    /// resolve override and connects to the port from the request URL, so
+    /// `addr.port()` is only honoured when it matches the URL's port (which it
+    /// does for addresses obtained by resolving that same URL). Routes the
+    /// request through the custom one-shot-client send path, which bypasses the
+    /// process-wide circuit breaker.
+    #[must_use]
+    pub const fn pin_to(mut self, addr: SocketAddr) -> Self {
+        self.pin_addr = Some(addr);
+        self
+    }
+
     /// Send the request, applying retries and returning a [`Response`].
     ///
     /// # Errors
@@ -869,6 +1122,16 @@ impl RequestBuilder {
         // Bypassing circuit breaker if a mock registry is present.
         if self.mock.is_some() {
             return self.send_inner(false).await;
+        }
+
+        // Custom send path: any of no_redirect / follow_redirects / pin_to /
+        // get_ssrf_safe builds one-shot reqwest client(s) with Policy::none()
+        // (+ optional .resolve()) and does manual redirect handling. Like the
+        // mock path it deliberately BYPASSES the process-global circuit breaker
+        // to avoid entangling these one-off, per-URL requests with the shared
+        // per-host breaker registry.
+        if self.needs_custom_path() {
+            return self.send_custom().await;
         }
 
         // ── Resilience / Circuit Breaker ──────────────────────────────────
@@ -1041,6 +1304,153 @@ impl RequestBuilder {
         // The retry loop always returns inside the last attempt; this is unreachable.
         unreachable!("retry loop exited without returning a result — this is a bug")
     }
+
+    /// `true` when any security-hardening option requires the custom send path.
+    const fn needs_custom_path(&self) -> bool {
+        self.ssrf_safe
+            || self.pin_addr.is_some()
+            || !matches!(self.redirect_mode, RedirectMode::Default)
+    }
+
+    /// Dispatch to the appropriate custom send path. Consumes `self`.
+    async fn send_custom(self) -> Result<Response, ClientError> {
+        let timeout = self
+            .retry_policy
+            .request_timeout
+            .unwrap_or_else(|| Duration::from_secs(30));
+
+        if self.ssrf_safe {
+            return self.send_ssrf_safe(timeout).await;
+        }
+
+        // Extract the follow parameters (ending the borrow) before moving `self`.
+        let follow = match &self.redirect_mode {
+            RedirectMode::Follow { max, validator } => Some((*max, validator.clone())),
+            RedirectMode::None | RedirectMode::Default => None,
+        };
+        if let Some((max, validator)) = follow {
+            return self.follow_loop(max, validator, timeout).await;
+        }
+
+        // `None`: single one-shot request with Policy::none() so a 3xx is
+        // returned verbatim. `Default` (pin_to only): keep reqwest's built-in
+        // auto-follow but pin the initial host's resolution.
+        let policy = match self.redirect_mode {
+            RedirectMode::None => reqwest::redirect::Policy::none(),
+            RedirectMode::Default | RedirectMode::Follow { .. } => {
+                reqwest::redirect::Policy::default()
+            }
+        };
+        let resolve = self.pin_resolve()?;
+        let client = build_oneshot_client(resolve, policy, timeout)?;
+        send_one(
+            &client,
+            &self.method,
+            &self.url,
+            &self.extra_headers,
+            self.body.as_ref(),
+            &self.retry_policy,
+        )
+        .await
+    }
+
+    /// Compute the `(host, addr)` resolve override for a pinned request, if any.
+    fn pin_resolve(&self) -> Result<Option<(String, SocketAddr)>, ClientError> {
+        match self.pin_addr {
+            Some(addr) => Ok(Some((host_of(&self.url)?, addr))),
+            None => Ok(None),
+        }
+    }
+
+    /// Manual redirect-following loop with per-hop validation (Feature #1238).
+    async fn follow_loop(
+        self,
+        max: usize,
+        validator: RedirectValidator,
+        timeout: Duration,
+    ) -> Result<Response, ClientError> {
+        let mut current = self.url.clone();
+        for hop in 0.. {
+            // Pin only applies to the first hop's original target.
+            let resolve = if hop == 0 {
+                match self.pin_addr {
+                    Some(addr) => Some((host_of(&current)?, addr)),
+                    None => None,
+                }
+            } else {
+                None
+            };
+            let client = build_oneshot_client(resolve, reqwest::redirect::Policy::none(), timeout)?;
+            // Only send the body on the first hop; a redirect drops it.
+            let body = if hop == 0 { self.body.as_ref() } else { None };
+            let resp = send_one(
+                &client,
+                &self.method,
+                &current,
+                &self.extra_headers,
+                body,
+                &self.retry_policy,
+            )
+            .await?;
+
+            let Some(next) = redirect_target(&resp, &current)? else {
+                return Ok(resp);
+            };
+            if hop >= max {
+                return Err(ClientError::TooManyRedirects(max));
+            }
+            if !validator(&next) {
+                return Err(ClientError::RedirectRejected(next));
+            }
+            current = next;
+        }
+        unreachable!("redirect loop is bounded by `max` and always returns")
+    }
+
+    /// Composed SSRF-safe send path (Features #1238 + #1239). Resolves and
+    /// validates every hop, pins the connection, and rejects scheme downgrades.
+    async fn send_ssrf_safe(self, timeout: Duration) -> Result<Response, ClientError> {
+        let mut current = self.url.clone();
+        for hop in 0.. {
+            // Resolve host → validated address (rejects if ANY resolved IP is
+            // blocked), then pin so reqwest cannot re-resolve.
+            let addr = resolve_and_validate(&current).await?;
+            let host = host_of(&current)?;
+            let client = build_oneshot_client(
+                Some((host, addr)),
+                reqwest::redirect::Policy::none(),
+                timeout,
+            )?;
+            let body = if hop == 0 { self.body.as_ref() } else { None };
+            let resp = send_one(
+                &client,
+                &self.method,
+                &current,
+                &self.extra_headers,
+                body,
+                &self.retry_policy,
+            )
+            .await?;
+
+            let Some(next) = redirect_target(&resp, &current)? else {
+                return Ok(resp);
+            };
+            if hop >= SSRF_SAFE_MAX_REDIRECTS {
+                return Err(ClientError::TooManyRedirects(SSRF_SAFE_MAX_REDIRECTS));
+            }
+            // Defence-in-depth: reject an https→http downgrade on redirect.
+            if scheme_is_https(&current)? && !scheme_is_https(&next)? {
+                return Err(ClientError::RedirectRejected(format!(
+                    "https→http scheme downgrade on redirect to {next}"
+                )));
+            }
+            current = next;
+            // The next loop iteration re-resolves + re-validates `current`
+            // before connecting, so a redirect to a blocked address is rejected
+            // there with `SsrfBlocked`.
+        }
+        unreachable!("redirect loop is bounded by SSRF_SAFE_MAX_REDIRECTS")
+    }
 }
 
 // ── Internal helpers ─────────────────────────────────────────────────────────
@@ -1054,6 +1464,192 @@ const fn is_idempotent_method(method: &Method) -> bool {
 
 const fn is_retryable_status(status: u16) -> bool {
     matches!(status, 502..=504)
+}
+
+// ── Custom send-path helpers (redirect / pin / SSRF-safe) ─────────────────────
+
+/// Build a one-shot `reqwest::Client` for the custom send path, with the given
+/// redirect policy, per-request timeout, and optional DNS `resolve` override.
+fn build_oneshot_client(
+    resolve: Option<(String, SocketAddr)>,
+    policy: reqwest::redirect::Policy,
+    timeout: Duration,
+) -> Result<reqwest::Client, ClientError> {
+    let mut builder = reqwest::ClientBuilder::new()
+        .timeout(timeout)
+        .redirect(policy);
+    if let Some((host, addr)) = resolve {
+        builder = builder.resolve(&host, addr);
+    }
+    builder.build().map_err(ClientError::Request)
+}
+
+/// Send a single request through `client` (no manual redirect following — the
+/// client's redirect policy governs that) with the same transient-error and
+/// 429/5xx retry behaviour as the shared path, and collect the [`Response`].
+async fn send_one(
+    client: &reqwest::Client,
+    method: &Method,
+    url: &str,
+    extra_headers: &HeaderMap,
+    body: Option<&Bytes>,
+    retry_policy: &RetryPolicy,
+) -> Result<Response, ClientError> {
+    let start = Instant::now();
+    let max_attempts = if is_idempotent_method(method) || !retry_policy.retry_idempotent_only {
+        retry_policy.max_retries.saturating_add(1)
+    } else {
+        1
+    };
+
+    for attempt in 0..max_attempts {
+        if attempt > 0 {
+            let exp = (attempt - 1).min(10);
+            let delay = Duration::from_millis(100 * (1_u64 << exp));
+            tokio::time::sleep(delay).await;
+        }
+
+        let mut req = client.request(method.clone(), url);
+        req = inject_trace_context(req);
+        for (name, value) in extra_headers {
+            req = req.header(name.clone(), value.clone());
+        }
+        if let Some(body) = body {
+            req = req.body(body.clone());
+        }
+
+        match req.send().await {
+            Ok(resp) => {
+                let status = resp.status();
+                let headers = resp.headers().clone();
+                let url_used = resp.url().clone();
+
+                if status.as_u16() == 429 && attempt + 1 < max_attempts {
+                    let mut sleep_delay =
+                        parse_retry_after(&headers).unwrap_or(Duration::from_secs(1));
+                    sleep_delay = sleep_delay.min(retry_policy.max_retry_after);
+                    if let Some(req_timeout) = retry_policy.request_timeout {
+                        sleep_delay = sleep_delay.min(req_timeout);
+                    }
+                    tokio::time::sleep(sleep_delay).await;
+                    continue;
+                }
+                if is_retryable_status(status.as_u16()) && attempt + 1 < max_attempts {
+                    continue;
+                }
+
+                let body = resp
+                    .bytes()
+                    .await
+                    .map_err(|e| ClientError::Request(e.without_url()))?;
+                log_request(
+                    method.as_str(),
+                    &url_used,
+                    status.as_u16(),
+                    start.elapsed(),
+                    extra_headers,
+                );
+                return Ok(Response {
+                    status,
+                    headers,
+                    body,
+                    url: Some(url_used),
+                });
+            }
+            Err(e) if (e.is_connect() || e.is_timeout()) && attempt + 1 < max_attempts => {}
+            Err(e) => return Err(ClientError::Request(e.without_url())),
+        }
+    }
+
+    unreachable!("retry loop exited without returning a result — this is a bug")
+}
+
+/// Extract the host portion of a URL as an owned `String`.
+fn host_of(url: &str) -> Result<String, ClientError> {
+    let parsed = url::Url::parse(url).map_err(|e| ClientError::InvalidUrl(e.to_string()))?;
+    parsed
+        .host_str()
+        .map(str::to_owned)
+        .ok_or_else(|| ClientError::InvalidUrl(format!("URL has no host: {url}")))
+}
+
+/// `true` when the URL's scheme is `https` (case-insensitive).
+fn scheme_is_https(url: &str) -> Result<bool, ClientError> {
+    let parsed = url::Url::parse(url).map_err(|e| ClientError::InvalidUrl(e.to_string()))?;
+    Ok(parsed.scheme().eq_ignore_ascii_case("https"))
+}
+
+/// If `resp` is a `3xx` carrying a `Location` header, resolve it to an absolute
+/// URL (joining relative locations against `base`). Returns `Ok(None)` when the
+/// response is not a followable redirect (non-3xx, or 3xx without `Location`).
+fn redirect_target(resp: &Response, base: &str) -> Result<Option<String>, ClientError> {
+    if !resp.status().is_redirection() {
+        return Ok(None);
+    }
+    let Some(location) = resp
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .and_then(|v| v.to_str().ok())
+    else {
+        return Ok(None);
+    };
+    let base_url = url::Url::parse(base).map_err(|e| ClientError::InvalidUrl(e.to_string()))?;
+    let joined = base_url
+        .join(location)
+        .map_err(|e| ClientError::InvalidUrl(e.to_string()))?;
+    Ok(Some(joined.to_string()))
+}
+
+/// Resolve `url`'s host to a single validated [`SocketAddr`], rejecting with
+/// [`ClientError::SsrfBlocked`] if the host is (or resolves to) any blocked IP.
+///
+/// IP-literal hosts (including decimal/octal/hex encodings, which the `url`
+/// crate normalises to an `Ipv4Addr` at parse time) are validated directly with
+/// no DNS lookup. Domain hosts are resolved once via `tokio::net::lookup_host`
+/// and rejected if **any** resolved address is blocked.
+async fn resolve_and_validate(url: &str) -> Result<SocketAddr, ClientError> {
+    let parsed = url::Url::parse(url).map_err(|e| ClientError::InvalidUrl(e.to_string()))?;
+    let port = parsed.port_or_known_default().ok_or_else(|| {
+        ClientError::InvalidUrl(format!("URL has no port and unknown scheme: {url}"))
+    })?;
+    let host = parsed
+        .host()
+        .ok_or_else(|| ClientError::InvalidUrl(format!("URL has no host: {url}")))?;
+
+    match host {
+        url::Host::Ipv4(v4) => {
+            let ip = IpAddr::V4(v4);
+            if is_blocked_ip(ip) {
+                return Err(ClientError::SsrfBlocked(ip.to_string()));
+            }
+            Ok(SocketAddr::new(ip, port))
+        }
+        url::Host::Ipv6(v6) => {
+            let ip = IpAddr::V6(v6);
+            if is_blocked_ip(ip) {
+                return Err(ClientError::SsrfBlocked(ip.to_string()));
+            }
+            Ok(SocketAddr::new(ip, port))
+        }
+        url::Host::Domain(name) => {
+            let addrs: Vec<SocketAddr> = tokio::net::lookup_host((name, port))
+                .await
+                .map_err(|e| ClientError::InvalidUrl(format!("DNS lookup failed for {name}: {e}")))?
+                .collect();
+            if addrs.is_empty() {
+                return Err(ClientError::InvalidUrl(format!(
+                    "DNS lookup for {name} returned no addresses"
+                )));
+            }
+            // Reject if ANY resolved address is blocked (fail closed).
+            for addr in &addrs {
+                if is_blocked_ip(addr.ip()) {
+                    return Err(ClientError::SsrfBlocked(addr.ip().to_string()));
+                }
+            }
+            Ok(addrs[0])
+        }
+    }
 }
 
 fn parse_retry_after(headers: &HeaderMap) -> Option<Duration> {
@@ -2018,5 +2614,392 @@ mod tests {
         });
 
         let _client = Client::from_state(&state);
+    }
+
+    // ── Security-hardening tests (#1238 redirects, #1239 SSRF/pinning) ────────
+
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    // TEST 44: SSRF address policy — blocked ranges.
+    #[test]
+    fn ssrf_policy_blocks_private_and_reserved_ipv4() {
+        let blocked = [
+            "0.0.0.0",
+            "10.1.2.3",
+            "100.64.0.1",      // CGNAT
+            "127.0.0.1",       // loopback
+            "169.254.169.254", // cloud metadata
+            "172.16.5.4",      // private
+            "192.0.0.1",       // IETF
+            "192.0.2.5",       // TEST-NET-1
+            "192.168.1.1",     // private
+            "198.18.0.1",      // benchmarking
+            "198.51.100.7",    // TEST-NET-2
+            "203.0.113.9",     // TEST-NET-3
+            "224.0.0.1",       // multicast
+            "240.0.0.1",       // reserved
+            "255.255.255.255", // broadcast
+        ];
+        for s in blocked {
+            let ip: IpAddr = s.parse().unwrap();
+            assert!(is_blocked_ip(ip), "{s} should be blocked");
+            assert!(!is_public_ip(ip), "{s} should not be public");
+        }
+    }
+
+    // TEST 45: SSRF address policy — public IPv4 is allowed.
+    #[test]
+    fn ssrf_policy_allows_public_ipv4() {
+        for s in ["1.1.1.1", "8.8.8.8", "93.184.216.34"] {
+            let ip: IpAddr = s.parse().unwrap();
+            assert!(is_public_ip(ip), "{s} should be public");
+            assert!(!is_blocked_ip(ip), "{s} should not be blocked");
+        }
+    }
+
+    // TEST 46: SSRF address policy — IPv6 blocked ranges, mapped/compatible forms.
+    #[test]
+    fn ssrf_policy_ipv6_and_mapped_forms() {
+        let blocked = [
+            "::",                     // unspecified
+            "::1",                    // loopback
+            "fe80::1",                // link-local
+            "fc00::1",                // ULA
+            "ff02::1",                // multicast
+            "2001:db8::1",            // documentation
+            "::ffff:169.254.169.254", // IPv4-mapped metadata
+            "::ffff:127.0.0.1",       // IPv4-mapped loopback
+        ];
+        for s in blocked {
+            let ip: IpAddr = s.parse().unwrap();
+            assert!(is_blocked_ip(ip), "{s} should be blocked");
+        }
+        // IPv4-compatible ::7f00:1 == 127.0.0.1 (deprecated form) is blocked.
+        let compat = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0x7f00, 0x0001));
+        assert!(
+            is_blocked_ip(compat),
+            "::7f00:1 (127.0.0.1) should be blocked"
+        );
+
+        // A real public IPv6 (Cloudflare DNS) is allowed.
+        let public: IpAddr = "2606:4700:4700::1111".parse().unwrap();
+        assert!(
+            is_public_ip(public),
+            "2606:4700:4700::1111 should be public"
+        );
+    }
+
+    // TEST 47: the `url` crate normalises decimal/hex IP-literal hosts to Ipv4,
+    // so `http://2130706433/` (== 127.0.0.1) is recognised as a blocked IP.
+    #[test]
+    fn ssrf_policy_decimal_encoded_host_is_blocked() {
+        for raw in [
+            "http://2130706433/",
+            "http://0x7f000001/",
+            "http://127.0.0.1/",
+        ] {
+            let parsed = url::Url::parse(raw).unwrap();
+            match parsed.host() {
+                Some(url::Host::Ipv4(v4)) => {
+                    assert_eq!(
+                        v4,
+                        Ipv4Addr::LOCALHOST,
+                        "{raw} should normalise to 127.0.0.1"
+                    );
+                    assert!(
+                        is_blocked_ip(IpAddr::V4(v4)),
+                        "{raw} host should be blocked"
+                    );
+                }
+                other => panic!("{raw} did not parse to an Ipv4 host: {other:?}"),
+            }
+        }
+    }
+
+    // Small axum helper: spawn `app` on an ephemeral 127.0.0.1 port, return it.
+    async fn spawn(app: axum::Router) -> std::net::SocketAddr {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        addr
+    }
+
+    fn redirect_302(location: String) -> axum::response::Response {
+        axum::response::Response::builder()
+            .status(302)
+            .header("location", location)
+            .body(axum::body::Body::empty())
+            .unwrap()
+    }
+
+    // TEST 48: no_redirect returns the 3xx verbatim without following it.
+    #[tokio::test]
+    async fn no_redirect_returns_3xx_unfollowed() {
+        use axum::{Router, routing::get};
+        let addr = spawn(Router::new().route(
+            "/start",
+            get(|| async { redirect_302("http://127.0.0.1:1/never".to_owned()) }),
+        ))
+        .await;
+
+        let resp = Client::new()
+            .get(format!("http://127.0.0.1:{}/start", addr.port()))
+            .no_redirect()
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status().as_u16(), 302);
+        assert_eq!(
+            resp.headers().get("location").and_then(|v| v.to_str().ok()),
+            Some("http://127.0.0.1:1/never")
+        );
+    }
+
+    // TEST 49: follow_redirects follows a valid chain A→B and calls the validator.
+    #[tokio::test]
+    async fn follow_redirects_valid_chain_calls_validator() {
+        use axum::{Router, routing::get};
+
+        let b_addr = spawn(Router::new().route("/final", get(|| async { "final-body" }))).await;
+        let b_port = b_addr.port();
+        let a_addr = spawn(Router::new().route(
+            "/start",
+            get(move || async move { redirect_302(format!("http://127.0.0.1:{b_port}/final")) }),
+        ))
+        .await;
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls2 = calls.clone();
+        let resp = Client::new()
+            .get(format!("http://127.0.0.1:{}/start", a_addr.port()))
+            .follow_redirects(5, move |_loc| {
+                calls2.fetch_add(1, Ordering::SeqCst);
+                true
+            })
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status().as_u16(), 200);
+        assert_eq!(resp.text(), "final-body");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "validator called once per hop"
+        );
+    }
+
+    // TEST 50: follow_redirects rejects a redirect to a private/blocked target,
+    // and NEVER connects to that private address. Uses the SSRF IP policy as the
+    // validator — structurally the same guard get_ssrf_safe applies per hop.
+    #[tokio::test]
+    async fn follow_redirects_rejects_private_target() {
+        use axum::{Router, routing::get};
+        use std::sync::atomic::AtomicBool;
+
+        // A "private" server that must never be reached.
+        let touched = Arc::new(AtomicBool::new(false));
+        let touched2 = touched.clone();
+        let priv_addr = spawn(Router::new().route(
+            "/secret",
+            get(move || {
+                let t = touched2.clone();
+                async move {
+                    t.store(true, Ordering::SeqCst);
+                    "SECRET"
+                }
+            }),
+        ))
+        .await;
+        let priv_port = priv_addr.port();
+
+        // Public-ish entrypoint that 302s to the private loopback target.
+        let a_addr = spawn(Router::new().route(
+            "/start",
+            get(
+                move || async move { redirect_302(format!("http://127.0.0.1:{priv_port}/secret")) },
+            ),
+        ))
+        .await;
+
+        let validator = |u: &str| -> bool {
+            let Ok(p) = url::Url::parse(u) else {
+                return false;
+            };
+            match p.host() {
+                Some(url::Host::Ipv4(v4)) => is_public_ip(IpAddr::V4(v4)),
+                Some(url::Host::Ipv6(v6)) => is_public_ip(IpAddr::V6(v6)),
+                _ => true,
+            }
+        };
+
+        let result = Client::new()
+            .get(format!("http://127.0.0.1:{}/start", a_addr.port()))
+            .follow_redirects(5, validator)
+            .send()
+            .await;
+
+        assert!(
+            matches!(result, Err(ClientError::RedirectRejected(_))),
+            "expected RedirectRejected, got {result:?}"
+        );
+        assert!(
+            !touched.load(Ordering::SeqCst),
+            "the private target must never be connected to"
+        );
+    }
+
+    // TEST 51: follow_redirects with a chain longer than `max` → TooManyRedirects.
+    #[tokio::test]
+    async fn follow_redirects_cap_exceeded() {
+        use axum::{Router, routing::get};
+
+        // /loop always redirects back to itself → infinite chain.
+        let addr =
+            spawn(Router::new().route("/loop", get(|| async { redirect_302("/loop".to_owned()) })))
+                .await;
+
+        let result = Client::new()
+            .get(format!("http://127.0.0.1:{}/loop", addr.port()))
+            .follow_redirects(2, |_| true)
+            .send()
+            .await;
+
+        assert!(
+            matches!(result, Err(ClientError::TooManyRedirects(2))),
+            "expected TooManyRedirects(2), got {result:?}"
+        );
+    }
+
+    // TEST 52: follow_redirects(0, ..) turns the first 3xx into TooManyRedirects.
+    #[tokio::test]
+    async fn follow_redirects_zero_max_errors_on_first_3xx() {
+        use axum::{Router, routing::get};
+        let addr = spawn(Router::new().route(
+            "/start",
+            get(|| async { redirect_302("http://127.0.0.1:1/x".to_owned()) }),
+        ))
+        .await;
+
+        let result = Client::new()
+            .get(format!("http://127.0.0.1:{}/start", addr.port()))
+            .follow_redirects(0, |_| true)
+            .send()
+            .await;
+
+        assert!(matches!(result, Err(ClientError::TooManyRedirects(0))));
+    }
+
+    // TEST 53: pin_to bypasses DNS and connects to the URL's port.
+    //
+    // The host `pinned.invalid` is guaranteed non-resolvable (.invalid TLD), yet
+    // pinning to 127.0.0.1 reaches the listener — proving DNS was bypassed. The
+    // pinned SocketAddr uses port 1 (which nothing listens on) while the URL uses
+    // the real listener port; reaching the listener proves reqwest IGNORES the
+    // resolve SocketAddr's port and connects to the URL's port instead.
+    #[tokio::test]
+    async fn pin_to_bypasses_dns_and_uses_url_port() {
+        use axum::{Router, routing::get};
+        let addr = spawn(Router::new().route("/ping", get(|| async { "pong" }))).await;
+        let listener_port = addr.port();
+
+        let resp = Client::new()
+            .get(format!("http://pinned.invalid:{listener_port}/ping"))
+            // Deliberately-wrong port (1) to probe reqwest's port handling.
+            .pin_to(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1))
+            .send()
+            .await
+            .expect("pinned request should reach the loopback listener");
+
+        assert_eq!(resp.status().as_u16(), 200);
+        assert_eq!(resp.text(), "pong");
+    }
+
+    // TEST 54: get_ssrf_safe rejects a host that resolves to a blocked IP BEFORE
+    // connecting. `localhost` resolves to 127.0.0.1 (and/or ::1), both blocked.
+    // The listener's handler must never fire.
+    #[tokio::test]
+    async fn get_ssrf_safe_rejects_loopback_host_before_connecting() {
+        use axum::{Router, routing::get};
+        use std::sync::atomic::AtomicBool;
+
+        let touched = Arc::new(AtomicBool::new(false));
+        let touched2 = touched.clone();
+        let addr = spawn(Router::new().route(
+            "/x",
+            get(move || {
+                let t = touched2.clone();
+                async move {
+                    t.store(true, Ordering::SeqCst);
+                    "reached"
+                }
+            }),
+        ))
+        .await;
+
+        let result = Client::new()
+            .get_ssrf_safe(format!("http://localhost:{}/x", addr.port()))
+            .send()
+            .await;
+
+        assert!(
+            matches!(result, Err(ClientError::SsrfBlocked(_))),
+            "expected SsrfBlocked, got {result:?}"
+        );
+        assert!(
+            !touched.load(Ordering::SeqCst),
+            "SSRF guard must reject before any connection"
+        );
+    }
+
+    // TEST 55: get_ssrf_safe rejects a decimal-encoded loopback IP literal
+    // (http://2130706433/ == 127.0.0.1) with no DNS lookup.
+    #[tokio::test]
+    async fn get_ssrf_safe_rejects_decimal_encoded_loopback() {
+        let result = Client::new()
+            .get_ssrf_safe("http://2130706433/")
+            .send()
+            .await;
+        assert!(
+            matches!(result, Err(ClientError::SsrfBlocked(_))),
+            "expected SsrfBlocked, got {result:?}"
+        );
+    }
+
+    // TEST 56: resolve_and_validate — the resolve→validate core of get_ssrf_safe.
+    // A public IP literal validates (returning the URL's port); blocked literals
+    // and decimal-encoded loopback are rejected with SsrfBlocked. Exercising the
+    // actual network connect of the safe path against a public host is NOT
+    // reproducible in-sandbox (no reachable public server); it is covered
+    // structurally by the pin_to and follow_redirects tests. See the report.
+    #[tokio::test]
+    async fn resolve_and_validate_accepts_public_rejects_blocked() {
+        // Public literal with an explicit port → Ok, port preserved.
+        let ok = resolve_and_validate("http://8.8.8.8:8080/path")
+            .await
+            .unwrap();
+        assert_eq!(
+            ok,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 8080)
+        );
+
+        // https default port is inferred.
+        let ok_https = resolve_and_validate("https://1.1.1.1/").await.unwrap();
+        assert_eq!(ok_https.port(), 443);
+
+        // Blocked literals and decimal-encoded loopback → SsrfBlocked.
+        for raw in [
+            "http://127.0.0.1/",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://10.0.0.1/",
+            "http://2130706433/",
+        ] {
+            let err = resolve_and_validate(raw).await;
+            assert!(
+                matches!(err, Err(ClientError::SsrfBlocked(_))),
+                "{raw} should be SsrfBlocked, got {err:?}"
+            );
+        }
     }
 }

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -356,6 +356,52 @@ fn is_blocked_ipv6(ip: Ipv6Addr) -> bool {
     if segs[0] == 0x2001 && segs[1] == 0x0db8 {
         return true;
     }
+
+    // Remaining IANA IPv6 special-purpose prefixes with Globally Reachable =
+    // False. These are reserved / benchmarking / documentation / discard ranges
+    // that must never be dialled, matching the deny-list's reserved policy.
+    // Each check uses explicit masks so it cannot catch an adjacent *public*
+    // address (e.g. benchmarking 2001:2::/48 must not swallow Teredo 2001:0::/32
+    // where s[1] == 0, and documentation 2001:db8::/32 stays its own check).
+    //
+    //   Prefix               RFC        Purpose
+    //   100::/64             RFC 6666   Discard-Only address block
+    //   2001:2::/48          RFC 5180   Benchmarking
+    //   2001:10::/28         RFC 4843   ORCHID (deprecated)
+    //   2001:20::/28         RFC 7343   ORCHIDv2
+    //   3fff::/20            RFC 9637   Documentation
+    //   5f00::/16            RFC 9602   Segment Routing (SRv6) SIDs
+    //   2620:4f:8000::/48    RFC 7534   Direct Delegation AS112 service
+    let s = segs;
+    // 100::/64 (Discard-Only, RFC 6666)
+    if s[0] == 0x0100 && s[1] == 0 && s[2] == 0 && s[3] == 0 {
+        return true;
+    }
+    // 2001:2::/48 (Benchmarking, RFC 5180)
+    if s[0] == 0x2001 && s[1] == 0x0002 && s[2] == 0x0000 {
+        return true;
+    }
+    // 2001:10::/28 (ORCHID, deprecated RFC 4843)
+    if s[0] == 0x2001 && (s[1] & 0xFFF0) == 0x0010 {
+        return true;
+    }
+    // 2001:20::/28 (ORCHIDv2, RFC 7343)
+    if s[0] == 0x2001 && (s[1] & 0xFFF0) == 0x0020 {
+        return true;
+    }
+    // 3fff::/20 (Documentation, RFC 9637)
+    if s[0] == 0x3fff && (s[1] & 0xF000) == 0x0000 {
+        return true;
+    }
+    // 5f00::/16 (SRv6 SIDs, RFC 9602)
+    if s[0] == 0x5f00 {
+        return true;
+    }
+    // 2620:4f:8000::/48 (Direct Delegation AS112, RFC 7534)
+    if s[0] == 0x2620 && s[1] == 0x004f && s[2] == 0x8000 {
+        return true;
+    }
+
     false
 }
 
@@ -2983,6 +3029,19 @@ mod tests {
             "fec0::1",                // deprecated site-local
             "::ffff:169.254.169.254", // IPv4-mapped metadata
             "::ffff:127.0.0.1",       // IPv4-mapped loopback
+            // Remaining IANA special-purpose prefixes (Globally Reachable = False).
+            "100::1",          // Discard-Only 100::/64 (RFC 6666)
+            "100::dead:beef",  // Discard-Only 100::/64 (RFC 6666)
+            "2001:2::1",       // Benchmarking 2001:2::/48 (RFC 5180)
+            "2001:10::1",      // ORCHID 2001:10::/28 (RFC 4843)
+            "2001:20::1",      // ORCHIDv2 2001:20::/28 (RFC 7343)
+            "2001:20:abcd::1", // ORCHIDv2 within /28 (RFC 7343)
+            "2001:2f::1",      // ORCHIDv2 top of /28 (s[1]=0x002f, RFC 7343)
+            "3fff::1",         // Documentation 3fff::/20 (RFC 9637)
+            "3fff:0fff::1",    // Documentation top of /20 (s[1]=0x0fff, RFC 9637)
+            "5f00::1",         // SRv6 SIDs 5f00::/16 (RFC 9602)
+            "5f00:1234::1",    // SRv6 SIDs within /16 (RFC 9602)
+            "2620:4f:8000::1", // Direct Delegation AS112 (RFC 7534)
         ];
         for s in blocked {
             let ip: IpAddr = s.parse().unwrap();
@@ -3001,6 +3060,25 @@ mod tests {
             is_public_ip(public),
             "2606:4700:4700::1111 should be public"
         );
+
+        // Negative tests: real public addresses adjacent to the newly-blocked
+        // special-purpose prefixes must stay allowed (no over-blocking).
+        let public_addrs = [
+            "2001:4860:4860::8888", // Google DNS
+            "2606:4700:4700::1111", // Cloudflare DNS
+            "2400:cb00:2048::1",    // public 2400 (Cloudflare)
+            "2620:0:2d0:200::7",    // public 2620 NOT in AS112 2620:4f:8000::/48
+            "2001:2:1::1",          // just outside benchmarking /48 (s[2]=1, not ORCHID)
+            "3fff:abcd::1",         // outside documentation /20 (s[1]=0xabcd > 0x0fff)
+            "4000::1",              // outside documentation 3fff::/20
+            "5e00::1",              // outside SRv6 5f00::/16
+            "6000::1",              // outside SRv6 5f00::/16
+        ];
+        for s in public_addrs {
+            let ip: IpAddr = s.parse().unwrap();
+            assert!(is_public_ip(ip), "{s} should be public");
+            assert!(!is_blocked_ip(ip), "{s} should not be blocked");
+        }
     }
 
     // TEST 46b: SSRF policy blocks private / metadata IPv4 tunnelled inside an

--- a/autumn/src/http_client.rs
+++ b/autumn/src/http_client.rs
@@ -962,9 +962,10 @@ impl Client {
     /// This is the composed safe path for fetching **untrusted** URLs. Before
     /// connecting it resolves the host **once**, validates every resolved IP
     /// against the built-in SSRF deny-list ([`is_blocked_ip`]) and rejects the
-    /// request if *any* address is blocked. The connection is then pinned to a
-    /// validated address so reqwest cannot re-resolve the host (closing the
-    /// DNS-rebinding / TOCTOU window). Redirects are followed manually up to
+    /// request if *any* address is blocked. The connection is then pinned to the
+    /// full set of validated addresses so reqwest cannot re-resolve the host
+    /// (closing the DNS-rebinding / TOCTOU window) yet can still fall back across
+    /// them in order if the first is unreachable. Redirects are followed manually up to
     /// [`SSRF_SAFE_MAX_REDIRECTS`] hops, re-running resolve→validate→pin on each
     /// hop; a hop that downgrades the scheme from `https` to `http` is rejected
     /// as defence-in-depth.
@@ -1478,9 +1479,11 @@ impl RequestBuilder {
     }
 
     /// Compute the `(host, addr)` resolve override for a pinned request, if any.
-    fn pin_resolve(&self) -> Result<Option<(String, SocketAddr)>, ClientError> {
+    fn pin_resolve(&self) -> Result<Option<(String, Vec<SocketAddr>)>, ClientError> {
         match self.pin_addr {
-            Some(addr) => Ok(Some((host_of(&self.url)?, addr))),
+            // Single-address pin routed through the same set-based path as the
+            // multi-address SSRF-safe pin (a one-element slice).
+            Some(addr) => Ok(Some((host_of(&self.url)?, vec![addr]))),
             None => Ok(None),
         }
     }
@@ -1504,7 +1507,7 @@ impl RequestBuilder {
             // Pin only applies to the first hop's original target.
             let resolve = if hop == 0 {
                 match self.pin_addr {
-                    Some(addr) => Some((host_of(&current)?, addr)),
+                    Some(addr) => Some((host_of(&current)?, vec![addr])),
                     None => None,
                 }
             } else {
@@ -1579,12 +1582,13 @@ impl RequestBuilder {
         let mut headers = self.extra_headers.clone();
         let mut body = self.body.clone();
         for hop in 0.. {
-            // Resolve host → validated address (rejects if ANY resolved IP is
-            // blocked), then pin so reqwest cannot re-resolve.
-            let addr = resolve_and_validate(&current).await?;
+            // Resolve host → ALL validated addresses (rejects if ANY resolved IP
+            // is blocked), then pin the full set so reqwest cannot re-resolve but
+            // can still fall back across the validated addresses in order.
+            let addrs = resolve_and_validate(&current).await?;
             let host = host_of(&current)?;
             let client = build_oneshot_client(
-                Some((host, addr)),
+                Some((host, addrs)),
                 reqwest::redirect::Policy::none(),
                 timeout,
             )?;
@@ -1666,16 +1670,22 @@ const fn is_retryable_status(status: u16) -> bool {
 /// exact DNS-rebinding / SSRF window that pinning closes. Non-pinned callers
 /// (`resolve == None`) keep reqwest's default proxy behaviour untouched.
 fn build_oneshot_client(
-    resolve: Option<(String, SocketAddr)>,
+    resolve: Option<(String, Vec<SocketAddr>)>,
     policy: reqwest::redirect::Policy,
     timeout: Duration,
 ) -> Result<reqwest::Client, ClientError> {
     let mut builder = reqwest::ClientBuilder::new()
         .timeout(timeout)
         .redirect(policy);
-    if let Some((host, addr)) = resolve {
-        // A pinned request must never route through a re-resolving proxy.
-        builder = builder.no_proxy().resolve(&host, addr);
+    if let Some((host, addrs)) = resolve
+        && !addrs.is_empty()
+    {
+        // Pin to the FULL validated set: reqwest tries the addresses in order and
+        // falls back on connection failure, so an unreachable first address no
+        // longer dooms the request. Every pinned address was already validated,
+        // so the TOCTOU/SSRF guarantee is preserved. A pinned request must never
+        // route through a re-resolving proxy.
+        builder = builder.no_proxy().resolve_to_addrs(&host, &addrs);
     }
     builder.build().map_err(ClientError::Request)
 }
@@ -1852,14 +1862,35 @@ fn rewrite_after_redirect(
     }
 }
 
-/// Resolve `url`'s host to a single validated [`SocketAddr`], rejecting with
+/// Validate a set of resolved socket addresses against the built-in SSRF
+/// deny-list, failing closed.
+///
+/// Returns `Err(SsrfBlocked)` (naming the first blocked address) if **any**
+/// address's IP is blocked ([`is_blocked_ip`]); otherwise returns the whole set
+/// unchanged, preserving order. Factored out of [`resolve_and_validate`] as a
+/// pure, synchronous helper so the validation policy is unit-testable without
+/// real multi-record DNS.
+fn validate_resolved_addrs(addrs: Vec<SocketAddr>) -> Result<Vec<SocketAddr>, ClientError> {
+    for addr in &addrs {
+        if is_blocked_ip(addr.ip()) {
+            return Err(ClientError::SsrfBlocked(addr.ip().to_string()));
+        }
+    }
+    Ok(addrs)
+}
+
+/// Resolve `url`'s host to **all** validated [`SocketAddr`]s, rejecting with
 /// [`ClientError::SsrfBlocked`] if the host is (or resolves to) any blocked IP.
 ///
 /// IP-literal hosts (including decimal/octal/hex encodings, which the `url`
 /// crate normalises to an `Ipv4Addr` at parse time) are validated directly with
-/// no DNS lookup. Domain hosts are resolved once via `tokio::net::lookup_host`
-/// and rejected if **any** resolved address is blocked.
-async fn resolve_and_validate(url: &str) -> Result<SocketAddr, ClientError> {
+/// no DNS lookup. Domain hosts are resolved **once** via `tokio::net::lookup_host`
+/// (keeping the TOCTOU window closed) and rejected if **any** resolved address
+/// is blocked. Since the whole DNS response is rejected when any IP is blocked,
+/// it is safe to return the full validated set (order preserved) so a caller can
+/// pin all of them and let reqwest try them in order — an unreachable first
+/// address no longer dooms the request.
+async fn resolve_and_validate(url: &str) -> Result<Vec<SocketAddr>, ClientError> {
     let parsed = url::Url::parse(url).map_err(|e| ClientError::InvalidUrl(e.to_string()))?;
     // Explicit scheme allowlist (defence-in-depth): only http/https may be
     // resolved and connected on the safe path. Reject ftp://, gopher://,
@@ -1879,20 +1910,8 @@ async fn resolve_and_validate(url: &str) -> Result<SocketAddr, ClientError> {
         .ok_or_else(|| ClientError::InvalidUrl(format!("URL has no host: {url}")))?;
 
     match host {
-        url::Host::Ipv4(v4) => {
-            let ip = IpAddr::V4(v4);
-            if is_blocked_ip(ip) {
-                return Err(ClientError::SsrfBlocked(ip.to_string()));
-            }
-            Ok(SocketAddr::new(ip, port))
-        }
-        url::Host::Ipv6(v6) => {
-            let ip = IpAddr::V6(v6);
-            if is_blocked_ip(ip) {
-                return Err(ClientError::SsrfBlocked(ip.to_string()));
-            }
-            Ok(SocketAddr::new(ip, port))
-        }
+        url::Host::Ipv4(v4) => validate_resolved_addrs(vec![SocketAddr::new(IpAddr::V4(v4), port)]),
+        url::Host::Ipv6(v6) => validate_resolved_addrs(vec![SocketAddr::new(IpAddr::V6(v6), port)]),
         url::Host::Domain(name) => {
             let addrs: Vec<SocketAddr> = tokio::net::lookup_host((name, port))
                 .await
@@ -1903,13 +1922,9 @@ async fn resolve_and_validate(url: &str) -> Result<SocketAddr, ClientError> {
                     "DNS lookup for {name} returned no addresses"
                 )));
             }
-            // Reject if ANY resolved address is blocked (fail closed).
-            for addr in &addrs {
-                if is_blocked_ip(addr.ip()) {
-                    return Err(ClientError::SsrfBlocked(addr.ip().to_string()));
-                }
-            }
-            Ok(addrs[0])
+            // Reject if ANY resolved address is blocked (fail closed); otherwise
+            // return the whole validated set (order preserved from the lookup).
+            validate_resolved_addrs(addrs)
         }
     }
 }
@@ -3291,18 +3306,20 @@ mod tests {
     // structurally by the pin_to and follow_redirects tests. See the report.
     #[tokio::test]
     async fn resolve_and_validate_accepts_public_rejects_blocked() {
-        // Public literal with an explicit port → Ok, port preserved.
+        // Public literal with an explicit port → Ok, single-element validated
+        // set, port preserved.
         let ok = resolve_and_validate("http://8.8.8.8:8080/path")
             .await
             .unwrap();
         assert_eq!(
             ok,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 8080)
+            vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 8080)]
         );
 
         // https default port is inferred.
         let ok_https = resolve_and_validate("https://1.1.1.1/").await.unwrap();
-        assert_eq!(ok_https.port(), 443);
+        assert_eq!(ok_https.len(), 1);
+        assert_eq!(ok_https[0].port(), 443);
 
         // Blocked literals and decimal-encoded loopback → SsrfBlocked.
         for raw in [
@@ -3317,6 +3334,40 @@ mod tests {
                 "{raw} should be SsrfBlocked, got {err:?}"
             );
         }
+    }
+
+    // TEST 56b: validate_resolved_addrs — the pure validation core shared by the
+    // resolve→validate step. A set of public addrs returns ALL of them in order;
+    // a set mixing a public and a blocked addr is rejected with SsrfBlocked; an
+    // all-public IPv6+IPv4 mix returns everything in order. This exercises the
+    // multi-record path (pin to ALL validated addresses) without needing real
+    // multi-record DNS.
+    #[test]
+    fn validate_resolved_addrs_returns_all_public_rejects_any_blocked() {
+        let v4 = |a, b, c, d, p| SocketAddr::new(IpAddr::V4(Ipv4Addr::new(a, b, c, d)), p);
+
+        // Two public addrs → Ok with BOTH returned, order preserved.
+        let two = vec![v4(1, 1, 1, 1, 443), v4(8, 8, 8, 8, 443)];
+        assert_eq!(validate_resolved_addrs(two.clone()).unwrap(), two);
+
+        // Public + blocked (10.0.0.1, RFC1918) → Err(SsrfBlocked).
+        let mixed = vec![v4(1, 1, 1, 1, 443), v4(10, 0, 0, 1, 443)];
+        assert!(
+            matches!(
+                validate_resolved_addrs(mixed),
+                Err(ClientError::SsrfBlocked(_))
+            ),
+            "a set containing a blocked address must be rejected"
+        );
+
+        // All-public IPv6 (2606:4700:4700::1111, Cloudflare) + IPv4 mix → Ok,
+        // all preserved in order.
+        let v6 = SocketAddr::new(
+            IpAddr::V6(Ipv6Addr::new(0x2606, 0x4700, 0x4700, 0, 0, 0, 0, 0x1111)),
+            443,
+        );
+        let mix = vec![v6, v4(8, 8, 8, 8, 443)];
+        assert_eq!(validate_resolved_addrs(mix.clone()).unwrap(), mix);
     }
 
     // TEST 57: pin_to alone does NOT auto-follow a cross-host redirect. reqwest

--- a/autumn/tests/ssrf_proxy_bypass.rs
+++ b/autumn/tests/ssrf_proxy_bypass.rs
@@ -1,0 +1,77 @@
+//! Isolated integration test: pinned SSRF-safe clients must bypass environment
+//! proxies (`HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY`).
+//!
+//! This lives in its own test binary (not the consolidated suite) because it
+//! sets **process-wide** proxy environment variables. Those would race with the
+//! inline `http_client` network tests if set in-process; a dedicated binary runs
+//! in its own process, so the mutation is isolated. See CLAUDE.md
+//! ("Isolated Integration Tests"). Env vars are managed through
+//! `temp_env::async_with_vars` (the workspace forbids `unsafe_code`, so raw
+//! `std::env::set_var` is unavailable).
+//!
+//! Regression coverage for the Codex P1 finding: reqwest evaluates proxy
+//! interception BEFORE the connector where `ClientBuilder::resolve(host, addr)`
+//! applies. Without `.no_proxy()` on the pinned client, a configured env proxy
+//! would receive the request and re-resolve the target host, defeating the pin
+//! (reopening the DNS-rebinding / SSRF window). We point every proxy env var at
+//! a black-hole address and assert that a `pin_to` request STILL reaches its
+//! pinned loopback listener — proving the dead proxy was bypassed.
+
+#![cfg(feature = "http-client")]
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use autumn_web::http::Client;
+
+/// `pin_to` connects directly to the pinned address even when `HTTP_PROXY` /
+/// `HTTPS_PROXY` / `ALL_PROXY` point at a dead (black-hole) proxy. If the pinned
+/// client honoured the proxy the request would be routed to `127.0.0.1:1`
+/// (nothing listens there) and fail; success proves the proxy was bypassed.
+#[tokio::test]
+async fn pinned_request_bypasses_env_proxy() {
+    use axum::{Router, routing::get};
+
+    // Black-hole proxy: 127.0.0.1:1 has no listener, so any request that
+    // honoured it would fail to connect.
+    const DEAD_PROXY: &str = "http://127.0.0.1:1";
+
+    // Loopback listener on an ephemeral port.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let port = addr.port();
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            Router::new().route("/ping", get(|| async { "pong" })),
+        )
+        .await
+        .unwrap();
+    });
+
+    // The proxy env vars are only set for the duration of this future, then
+    // restored by `temp_env` — keeping the process-wide mutation scoped.
+    temp_env::async_with_vars(
+        [
+            ("HTTP_PROXY", Some(DEAD_PROXY)),
+            ("HTTPS_PROXY", Some(DEAD_PROXY)),
+            ("ALL_PROXY", Some(DEAD_PROXY)),
+        ],
+        async move {
+            // `pin_to` trusts the caller-supplied addr (it does NOT run the SSRF
+            // guard, so pinning to loopback is allowed). The host
+            // `pinned.invalid` never resolves (.invalid TLD), so reaching the
+            // listener proves DNS was bypassed via the pin — and, crucially,
+            // that the request did NOT go through the dead proxy set above.
+            let resp = Client::new()
+                .get(format!("http://pinned.invalid:{port}/ping"))
+                .pin_to(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port))
+                .send()
+                .await
+                .expect("pinned request must bypass the dead env proxy and reach the listener");
+
+            assert_eq!(resp.status().as_u16(), 200);
+            assert_eq!(resp.text(), "pong");
+        },
+    )
+    .await;
+}


### PR DESCRIPTION
## What changed

**Before:** `autumn_web::http::Client` always let reqwest auto-follow redirects (up to 10) and re-resolved hostnames on every connection. A public URL could `302` to `http://169.254.169.254/…` and the client followed it transparently, and a malicious DNS server could return a public IP for the validation lookup then a private IP for the actual connect (DNS rebinding). Implementing a safe server-side fetch (link preview, webhook caller) required reaching past `Client` into raw reqwest.

**After:** the client exposes SSRF-safe primitives, all abstracted inside `http::` — no raw reqwest at call sites:

- `RequestBuilder::no_redirect()` — return the `3xx` to the caller instead of following.
- `RequestBuilder::follow_redirects(max, validator)` — manual per-hop following; runs `validator(&location)` before each hop; returns `Err` if the validator rejects or the hop cap is exceeded.
- `RequestBuilder::pin_to(SocketAddr)` — connect to a caller-validated IP, bypassing DNS re-resolution, with the `Host` header and TLS SNI preserved. Redirects are not auto-followed in this mode (returned as `3xx`).
- `Client::get_ssrf_safe(url)` — the composed safe path: resolve once → validate every resolved IP against the built-in policy (fail-closed if any is blocked) → pin the connection to the validated address → follow redirects with per-hop resolve→validate→pin, blocking `https→http` downgrades. Closes the rebinding TOCTOU: the IP that is validated is the exact IP connected to.
- `http::is_public_ip` / `http::is_blocked_ip` — the built-in address policy. Blocks loopback, RFC1918 private, link-local (incl. `169.254.169.254` cloud metadata), CGNAT, benchmarking, documentation, reserved/multicast/broadcast, `0.0.0.0`; IPv6 ULA/link-local/site-local/multicast/documentation; and IPv4-mapped, IPv4-compatible, NAT64 (`64:ff9b::/96`) and 6to4 (`2002::/16`) IPv6 forms that embed a blocked IPv4. Decimal/hex/octal IP encodings are normalised by the `url` crate before the check.

## How

All in `autumn/src/http_client.rs`. When any of these options is set, `send()` takes a custom path that builds one-shot `reqwest::Client`s with `redirect::Policy::none()` + `.resolve()` and runs the manual redirect loop, reusing the existing 429/5xx retry semantics; this path bypasses the process-global circuit breaker (same as the mock path). The default request path (shared pooled client, reqwest auto-follow) is unchanged.

## Security review

Built via TDD and adversarially reviewed with an attacker lens. The review confirmed `get_ssrf_safe` validates-before-connect on every hop **including the initial URL**, uses a **single resolution** for both validate and connect (TOCTOU closed), fails closed on multi-record mixed-privacy answers, and preserves SNI. Four findings were then fixed: NAT64/6to4 IPv6 tunnels bypassing the deny-list; `pin_to` re-resolving cross-host redirects unpinned; a missing explicit http/https scheme allowlist; and an under-documented `follow_redirects` TOCTOU limitation.

## Tests

62 unit tests in `http_client.rs` (43 pre-existing + 19 new), all green; `cargo clippy -p autumn-web --all-targets -- -D warnings` clean. New coverage: IP policy across IPv4/IPv6 incl. mapped/NAT64/6to4/decimal-encoded forms; `no_redirect` returns `3xx`; valid redirect chain; redirect to private rejected; cap exceeded; pin bypasses DNS; pin does not follow redirects; ssrf-safe rejects loopback / decimal-encoded loopback / non-http scheme.

## AC audit — #1238

| Acceptance criterion | Status | Evidence |
|---|---|---|
| `RequestBuilder::no_redirect()` disables redirect following | ✅ | `no_redirect()`; test `no_redirect_returns_3xx_unfollowed` |
| `follow_redirects(max, validator)` — follows up to `max`, validator on each `Location`, `Err` if reject or cap exceeded | ✅ | `follow_redirects` + `follow_loop`; tests `follow_redirects_valid_chain_calls_validator`, `follow_redirects_rejects_private_target`, `follow_redirects_cap_exceeded`, `follow_redirects_zero_max_errors_on_first_3xx` |
| Default behaviour (auto-follow) unchanged | ✅ | shared-client fast path untouched; 43 pre-existing tests green |
| SSRF-safe link preview implementable with only `autumn_web::http` | ✅ | `get_ssrf_safe` + `follow_redirects` + `is_public_ip`, all under `http::`; no raw reqwest |
| Tests: private-IP redirect rejected / cap exceeded / valid chain passes | ✅ | the four `follow_redirects` tests above |

## AC audit — #1239

| Acceptance criterion | Status | Evidence |
|---|---|---|
| `pin_to(SocketAddr)` skips DNS re-resolution, connects to the addr, `Host`/SNI preserved | ✅ | `pin_to` via `ClientBuilder::resolve`; test `pin_to_bypasses_dns_and_uses_url_port`. Note: reqwest uses the URL's port, not the pinned `SocketAddr`'s port — documented on the method |
| OR `Client::get_ssrf_safe(url, guard)` convenience (resolve + guard + pin) | ✅ | `Client::get_ssrf_safe(url)` using the built-in address policy as the guard |
| No app code needs to touch `reqwest::ClientBuilder::resolve` | ✅ | fully abstracted inside `http_client.rs` |
| Tests: attacker DNS returns different IP on 2nd call → connection uses pinned addr; guard-rejected IP never connects | ⚠️ Partial | `pin_to_bypasses_dns_and_uses_url_port` proves re-resolution is impossible once pinned (unresolvable host still reaches the pinned loopback listener); `get_ssrf_safe_rejects_loopback_host_before_connecting` proves a guard-rejected host never connects. A live malicious-DNS second-resolution swap is untestable in-sandbox (no reachable public host) — mitigated structurally by single-resolution pinning |

## Not exercised in-sandbox

A live **successful** `get_ssrf_safe` fetch and a real DNS second-resolution swap can't be run: the only reachable host in-sandbox is loopback, which is correctly blocked. Mitigated structurally by pinning; `resolve_and_validate` and `pin_to` are unit-tested directly (an unresolvable host still reaches the pinned loopback listener).

## Follow-ups

- `follow_redirects` (the non-pinned primitive) validates the `Location` string but re-resolves at connect time, so a validator that checks IPs has a connect-time TOCTOU and does not pin — callers needing rebind-safety should use `get_ssrf_safe`. Documented on the method. A future enhancement could add a pinned `follow_redirects` variant accepting a custom guard.

Closes #1238
Closes #1239

---
_Generated by [Claude Code](https://claude.ai/code/session_0144RxG43LrezPaqTud4TWk2)_