### PR TITLE
feat(scaffold): belongs_to dropdowns, validation/HTML5 constraints, seed model linking (#1146, #1388, #1718)

### DIFF
--- a/autumn-cli/src/generate/dsl.rs
+++ b/autumn-cli/src/generate/dsl.rs
@@ -669,6 +669,21 @@ fn min_max_args(min: Option<&String>, max: Option<&String>, float: bool) -> Stri
     args.join(", ")
 }
 
+/// Ensure a reparsed float's shortest-round-trip string is a valid Rust *float*
+/// literal for a `#[validate(range(...))]` bound and the HTML5 `min`/`max`
+/// attributes: a whole-number value (`1` from `1`/`+1`/`1.0`, or `1000` from
+/// `1e3`) must carry a decimal point (`1.0`), since a bare integer literal is
+/// not accepted where an `f32`/`f64` bound is expected. Values that already
+/// contain `.`/`e`/`E` (`0.5`, `1.5e3`) are left as-is. Input is assumed finite
+/// (the caller rejects `inf`/`NaN`).
+fn canonical_float_literal(reparsed: &str) -> String {
+    if reparsed.contains(['.', 'e', 'E']) {
+        reparsed.to_owned()
+    } else {
+        format!("{reparsed}.0")
+    }
+}
+
 /// Parse the body of a `{…}` constraint-modifier block against the field's
 /// `kind` (issue #1388 validation + HTML5 constraints; issue #1146
 /// `references` `{label:col}`).
@@ -793,42 +808,48 @@ fn parse_constraint_kv(
 /// a `String`/`Text` field must be a non-negative integer; a range bound on a
 /// numeric field must be a valid number.
 fn parse_bound(value: &str, kind: FieldKind) -> Result<String, String> {
+    // Every arm returns the CANONICAL reparsed value, never the raw user token:
+    // the stored bound is spliced verbatim into both `#[validate(range/length(…))]`
+    // and the HTML5 `min`/`max`/`minlength`/`maxlength` attributes, so a token
+    // that parses but isn't a valid Rust literal (`.5`, `+1`, `007`, `1.`) would
+    // otherwise fail to COMPILE the generated app. Reparsing at the field's
+    // concrete type and re-`to_string()`-ing yields a literal that is always
+    // valid and value-preserving (issue #1388 follow-up).
     match kind {
         FieldKind::String | FieldKind::Text => {
-            value
+            let n = value
                 .parse::<u64>()
                 .map_err(|_| format!("length bound '{value}' must be a non-negative integer"))?;
-            Ok(value.to_owned())
+            Ok(n.to_string())
         }
         FieldKind::I32 => {
             // Parse at the field's CONCRETE width, not a wider `i64`: a bound
             // that overflows `i32` (e.g. `count:i32{max=3000000000}`) would
-            // otherwise be emitted verbatim as `#[validate(range(max = ...))]`
-            // on an `i32` field and fail to COMPILE the generated app. Reject
-            // it here with an actionable error instead (issue #1388 follow-up).
-            value.parse::<i32>().map_err(|_| {
+            // otherwise be emitted as `#[validate(range(max = ...))]` on an
+            // `i32` field and fail to COMPILE the generated app.
+            let n = value.parse::<i32>().map_err(|_| {
                 format!(
                     "range bound '{value}' must be an integer within the i32 range ({}..={})",
                     i32::MIN,
                     i32::MAX
                 )
             })?;
-            Ok(value.to_owned())
+            Ok(n.to_string())
         }
         FieldKind::I64 => {
-            value.parse::<i64>().map_err(|_| {
+            let n = value.parse::<i64>().map_err(|_| {
                 format!(
                     "range bound '{value}' must be an integer within the i64 range ({}..={})",
                     i64::MIN,
                     i64::MAX
                 )
             })?;
-            Ok(value.to_owned())
+            Ok(n.to_string())
         }
         FieldKind::F32 => {
             // Rust's float parse saturates overflow to ±∞ rather than erroring,
             // so an out-of-`f32`-range literal would compile to a non-finite
-            // `#[validate(range(...))]` bound; reject non-finite explicitly.
+            // bound; reject non-finite explicitly, then canonicalize.
             let parsed = value
                 .parse::<f32>()
                 .map_err(|_| format!("range bound '{value}' must be a number"))?;
@@ -837,7 +858,7 @@ fn parse_bound(value: &str, kind: FieldKind) -> Result<String, String> {
                     "range bound '{value}' is out of range for an f32 field (it overflows to a non-finite value)"
                 ));
             }
-            Ok(value.to_owned())
+            Ok(canonical_float_literal(&parsed.to_string()))
         }
         FieldKind::F64 => {
             let parsed = value
@@ -848,7 +869,7 @@ fn parse_bound(value: &str, kind: FieldKind) -> Result<String, String> {
                     "range bound '{value}' is out of range for an f64 field (it overflows to a non-finite value)"
                 ));
             }
-            Ok(value.to_owned())
+            Ok(canonical_float_literal(&parsed.to_string()))
         }
         _ => Err(format!(
             "min/max constraints are not supported for {} fields",
@@ -1791,6 +1812,38 @@ mod tests {
         assert_eq!(
             f.validation_attrs(),
             vec!["range(min = 1, max = 9007199254740992)"]
+        );
+    }
+
+    #[test]
+    fn float_leading_dot_bound_is_canonicalized_to_a_valid_literal() {
+        // `.5` parses as a number but is not a valid Rust float literal; the
+        // stored/emitted bound must be `0.5`, and a whole-number float bound
+        // must carry a decimal point (`1` -> `1.0`).
+        let f = parse_field("ratio:f64{min=.5,max=1}").unwrap();
+        assert_eq!(f.constraints.min.as_deref(), Some("0.5"));
+        assert_eq!(f.constraints.max.as_deref(), Some("1.0"));
+        assert_eq!(f.validation_attrs(), vec!["range(min = 0.5, max = 1.0)"]);
+    }
+
+    #[test]
+    fn integer_signed_and_zero_padded_bounds_are_canonicalized() {
+        // `+1` and `007` parse but aren't the literal we want to splice; the
+        // stored/emitted bound must be the canonical decimal (`1`, `7`).
+        let f = parse_field("count:i32{min=+1,max=007}").unwrap();
+        assert_eq!(f.constraints.min.as_deref(), Some("1"));
+        assert_eq!(f.constraints.max.as_deref(), Some("7"));
+        assert_eq!(f.validation_attrs(), vec!["range(min = 1, max = 7)"]);
+    }
+
+    #[test]
+    fn integer_bounds_within_range_are_emitted_verbatim() {
+        // Regression: ordinary in-range integer bounds are unchanged.
+        assert_eq!(
+            parse_field("age:i32{min=0,max=130}")
+                .unwrap()
+                .validation_attrs(),
+            vec!["range(min = 0, max = 130)"]
         );
     }
 

--- a/autumn-cli/src/generate/dsl.rs
+++ b/autumn-cli/src/generate/dsl.rs
@@ -788,16 +788,54 @@ fn parse_bound(value: &str, kind: FieldKind) -> Result<String, String> {
                 .map_err(|_| format!("length bound '{value}' must be a non-negative integer"))?;
             Ok(value.to_owned())
         }
-        FieldKind::I32 | FieldKind::I64 => {
-            value
-                .parse::<i64>()
-                .map_err(|_| format!("range bound '{value}' must be an integer"))?;
+        FieldKind::I32 => {
+            // Parse at the field's CONCRETE width, not a wider `i64`: a bound
+            // that overflows `i32` (e.g. `count:i32{max=3000000000}`) would
+            // otherwise be emitted verbatim as `#[validate(range(max = ...))]`
+            // on an `i32` field and fail to COMPILE the generated app. Reject
+            // it here with an actionable error instead (issue #1388 follow-up).
+            value.parse::<i32>().map_err(|_| {
+                format!(
+                    "range bound '{value}' must be an integer within the i32 range ({}..={})",
+                    i32::MIN,
+                    i32::MAX
+                )
+            })?;
             Ok(value.to_owned())
         }
-        FieldKind::F32 | FieldKind::F64 => {
-            value
+        FieldKind::I64 => {
+            value.parse::<i64>().map_err(|_| {
+                format!(
+                    "range bound '{value}' must be an integer within the i64 range ({}..={})",
+                    i64::MIN,
+                    i64::MAX
+                )
+            })?;
+            Ok(value.to_owned())
+        }
+        FieldKind::F32 => {
+            // Rust's float parse saturates overflow to ±∞ rather than erroring,
+            // so an out-of-`f32`-range literal would compile to a non-finite
+            // `#[validate(range(...))]` bound; reject non-finite explicitly.
+            let parsed = value
+                .parse::<f32>()
+                .map_err(|_| format!("range bound '{value}' must be a number"))?;
+            if !parsed.is_finite() {
+                return Err(format!(
+                    "range bound '{value}' is out of range for an f32 field (it overflows to a non-finite value)"
+                ));
+            }
+            Ok(value.to_owned())
+        }
+        FieldKind::F64 => {
+            let parsed = value
                 .parse::<f64>()
                 .map_err(|_| format!("range bound '{value}' must be a number"))?;
+            if !parsed.is_finite() {
+                return Err(format!(
+                    "range bound '{value}' is out of range for an f64 field (it overflows to a non-finite value)"
+                ));
+            }
             Ok(value.to_owned())
         }
         _ => Err(format!(
@@ -1679,6 +1717,46 @@ mod tests {
         let f = parse_field("age:i32{min=0,max=130}").unwrap();
         assert_eq!(f.kind, FieldKind::I32);
         assert_eq!(f.validation_attrs(), vec!["range(min = 0, max = 130)"]);
+    }
+
+    #[test]
+    fn i32_range_bound_within_range_is_accepted() {
+        let f = parse_field("count:i32{max=1000000}").unwrap();
+        assert_eq!(f.kind, FieldKind::I32);
+        assert_eq!(f.constraints.max.as_deref(), Some("1000000"));
+        assert_eq!(f.validation_attrs(), vec!["range(max = 1000000)"]);
+    }
+
+    #[test]
+    fn i32_range_bound_exceeding_i32_max_is_rejected() {
+        // `3000000000` > i32::MAX (~2.147e9): parsed at the field's concrete
+        // width so it fails generation with an actionable error rather than
+        // emitting `#[validate(range(max = 3000000000))]` on an `i32` field,
+        // which would fail to COMPILE the generated app.
+        let err = parse_field("count:i32{max=3000000000}").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("3000000000"), "must name the bad bound: {msg}");
+        assert!(msg.contains("i32"), "must name the field type: {msg}");
+        assert!(
+            msg.contains("2147483647"),
+            "must state the valid range: {msg}"
+        );
+    }
+
+    #[test]
+    fn i64_accepts_a_bound_that_would_overflow_i32() {
+        // The same literal is fine on an i64 field.
+        let f = parse_field("count:i64{max=3000000000}").unwrap();
+        assert_eq!(f.kind, FieldKind::I64);
+        assert_eq!(f.validation_attrs(), vec!["range(max = 3000000000)"]);
+    }
+
+    #[test]
+    fn f32_range_bound_overflowing_the_type_is_rejected() {
+        // Rust parses an out-of-f32-range literal to +∞ rather than erroring,
+        // so reject non-finite bounds explicitly.
+        let err = parse_field("ratio:f32{max=1e40}").unwrap_err();
+        assert!(err.to_string().contains("f32"), "{}", err);
     }
 
     #[test]

--- a/autumn-cli/src/generate/dsl.rs
+++ b/autumn-cli/src/generate/dsl.rs
@@ -161,14 +161,14 @@ impl Field {
                     out.push("url".to_owned());
                 }
             }
-            FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64 => {
-                if c.min.is_some() || c.max.is_some() {
-                    let is_float = matches!(self.kind, FieldKind::F32 | FieldKind::F64);
-                    out.push(format!(
-                        "range({})",
-                        min_max_args(c.min.as_ref(), c.max.as_ref(), is_float)
-                    ));
-                }
+            FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64
+                if c.min.is_some() || c.max.is_some() =>
+            {
+                let is_float = matches!(self.kind, FieldKind::F32 | FieldKind::F64);
+                out.push(format!(
+                    "range({})",
+                    min_max_args(c.min.as_ref(), c.max.as_ref(), is_float)
+                ));
             }
             _ => {}
         }

--- a/autumn-cli/src/generate/dsl.rs
+++ b/autumn-cli/src/generate/dsl.rs
@@ -7,6 +7,41 @@
 use super::GenerateError;
 use super::naming;
 
+/// The constraint modifiers a field carried in a trailing `{…}` block
+/// (`title:String{min=3,max=120}`, `contact:String{email}`,
+/// `age:i32{min=0,max=130}`, `post:references{label:title}`).
+///
+/// These fan out to BOTH a server-side `#[validate(…)]` rule (issue #1388,
+/// see [`Field::validation_attrs`]) and a matching client-side HTML5
+/// constraint on the generated form input, from a single declaration.
+/// `label` is the odd one out: it's a `references`-only display-column
+/// override (issue #1146) with no `#[validate]`/HTML5 fan-out.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FieldConstraints {
+    /// `min=N`. For `String`/`Text` this is a `length` minimum; for numeric
+    /// fields it is a `range` minimum. Stored as the raw numeric token.
+    pub min: Option<String>,
+    /// `max=N`. `length` maximum (`String`/`Text`) or `range` maximum
+    /// (numeric). Stored as the raw numeric token.
+    pub max: Option<String>,
+    /// `email` — `#[validate(email)]` + `type="email"`. `String`/`Text` only.
+    pub email: bool,
+    /// `url` — `#[validate(url)]` + `type="url"`. `String`/`Text` only.
+    pub url: bool,
+    /// `label:col` — the `references` display column an index/show view and a
+    /// belongs_to `<select>` label render from (issue #1146). `references`
+    /// only; never a `#[validate]`/HTML5 constraint.
+    pub label: Option<String>,
+}
+
+impl FieldConstraints {
+    /// True when no constraint modifier was declared.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.min.is_none() && self.max.is_none() && !self.email && !self.url && self.label.is_none()
+    }
+}
+
 /// A single field parsed from the command line.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Field {
@@ -25,6 +60,9 @@ pub struct Field {
     /// INDEX` in the migration instead of the plain, non-unique `--index`
     /// output (see [`super::schema_edit::unique_index_sql`]).
     pub unique: bool,
+    /// Constraint modifiers from a trailing `{…}` block (issue #1388 /
+    /// #1146). Empty ([`FieldConstraints::is_empty`]) for a bare `name:Type`.
+    pub constraints: FieldConstraints,
 }
 
 impl Field {
@@ -92,6 +130,43 @@ impl Field {
     #[must_use]
     pub const fn sql_nullability(&self) -> &'static str {
         if self.nullable { "NULL" } else { "NOT NULL" }
+    }
+
+    /// The server-side `#[validate(…)]` argument list this field's
+    /// constraint modifiers (issue #1388) fan out to — e.g.
+    /// `["length(min = 3, max = 120)"]`, `["email"]`, `["range(min = 0, max = 130)"]`.
+    ///
+    /// `String`/`Text` fields map `min`/`max` to `length` and honor
+    /// `email`/`url`; numeric fields map `min`/`max` to `range`. Float
+    /// (`f32`/`f64`) range bounds are emitted with a decimal point so the
+    /// generated comparison type-checks against the field's own type. Every
+    /// other kind (and the `references`-only `label`) contributes nothing.
+    /// Empty when the field declared no fan-out constraints.
+    #[must_use]
+    pub fn validation_attrs(&self) -> Vec<String> {
+        let c = &self.constraints;
+        let mut out = Vec::new();
+        match self.kind {
+            FieldKind::String | FieldKind::Text => {
+                if c.min.is_some() || c.max.is_some() {
+                    out.push(format!("length({})", min_max_args(&c.min, &c.max, false)));
+                }
+                if c.email {
+                    out.push("email".to_owned());
+                }
+                if c.url {
+                    out.push("url".to_owned());
+                }
+            }
+            FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64 => {
+                if c.min.is_some() || c.max.is_some() {
+                    let is_float = matches!(self.kind, FieldKind::F32 | FieldKind::F64);
+                    out.push(format!("range({})", min_max_args(&c.min, &c.max, is_float)));
+                }
+            }
+            _ => {}
+        }
+        out
     }
 
     /// For a [`FieldKind::References`] field, the referenced table name —
@@ -408,20 +483,22 @@ pub fn parse_field(token: &str) -> Result<Field, GenerateError> {
     let name = name.trim();
     // A trailing `:unique` modifier marks the column for a `CREATE UNIQUE
     // INDEX` in the migration (issue #1032), e.g. `email:String:unique`.
-    // None of the DSL's type tokens contain a literal colon, so splitting
-    // once more off the end is unambiguous.
+    // Split it off the *end* first: a `references` `{label:col}` constraint
+    // modifier (issue #1146) also contains a colon, but it lives inside the
+    // trailing `{…}` block, so stripping a literal `:unique` suffix — never
+    // the colon inside the braces — stays unambiguous. Any other stray
+    // colon outside the braces is caught as an unknown modifier below.
+    let rest = rest.trim();
     let (ty, unique) = match rest.rsplit_once(':') {
-        Some((ty, modifier)) if modifier.trim() == "unique" => (ty.trim(), true),
-        Some((_, modifier)) => {
-            return Err(GenerateError::InvalidField {
-                token: token.to_owned(),
-                reason: format!(
-                    "unknown field modifier '{}'; the only supported modifier is 'unique'",
-                    modifier.trim()
-                ),
-            });
-        }
-        None => (rest.trim(), false),
+        // A trailing `:unique` (whitespace-tolerant) is the UNIQUE-index
+        // modifier. Its colon is always the last one — a `references`
+        // `{label:col}` colon sits *inside* the braces before it, so
+        // `rsplit_once` never mistakes the label colon for `:unique`.
+        Some((before, modifier)) if modifier.trim() == "unique" => (before.trim(), true),
+        // Any other trailing `:segment` (including a label colon inside a
+        // `{…}` block) is left on `ty` for the constraint/type parsing below
+        // to interpret or reject — not an error yet.
+        _ => (rest, false),
     };
 
     if name.is_empty() {
@@ -455,6 +532,7 @@ pub fn parse_field(token: &str) -> Result<Field, GenerateError> {
             nullable,
             variants,
             unique,
+            constraints: FieldConstraints::default(),
         });
     }
 
@@ -470,13 +548,57 @@ pub fn parse_field(token: &str) -> Result<Field, GenerateError> {
             nullable,
             variants: Vec::new(),
             unique,
+            constraints: FieldConstraints::default(),
         });
     }
 
-    let (kind, nullable) = parse_type(ty).ok_or_else(|| GenerateError::InvalidField {
+    // Fall-through: a scalar / `references` type, optionally carrying a
+    // trailing `{…}` constraint-modifier block (issue #1388 validation +
+    // HTML5 constraints; issue #1146 `references` `{label:col}`). `enum{…}`
+    // and `decimal{…}` were handled above — their braces are part of the
+    // *type*, so they never reach this generic modifier split.
+    let (base_ty, modifier_body) = split_constraint_modifier(ty);
+
+    // A leftover `{` means an unbalanced brace block (e.g. a shell that
+    // brace-expanded `String{min=3,max=120}` into two arguments, leaving a
+    // fragment like `String{min=3`). Any leftover `:` outside the braces is a
+    // stray trailing modifier (the only supported one, `:unique`, was already
+    // consumed above; a `references` label colon lives inside the braces).
+    if base_ty.contains('{') {
+        return Err(GenerateError::InvalidField {
+            token: token.to_owned(),
+            reason: format!(
+                "malformed constraint modifier in '{ty}' (unbalanced braces). If you typed \
+                 this in bash or zsh, quote the whole token so the shell doesn't brace-expand \
+                 it, e.g. 'title:String{{min=3,max=120}}'."
+            ),
+        });
+    }
+    if let Some((_, bad)) = base_ty.rsplit_once(':') {
+        return Err(GenerateError::InvalidField {
+            token: token.to_owned(),
+            reason: format!(
+                "unknown field modifier '{}'; the only bare modifier is 'unique' — other \
+                 constraints go in a trailing `{{…}}` block (e.g. 'title:String{{min=3,max=120}}')",
+                bad.trim()
+            ),
+        });
+    }
+
+    let (kind, nullable) = parse_type(base_ty).ok_or_else(|| GenerateError::InvalidField {
         token: token.to_owned(),
-        reason: format!("unsupported type '{ty}'. Supported: {SUPPORTED_TYPES}"),
+        reason: format!("unsupported type '{base_ty}'. Supported: {SUPPORTED_TYPES}"),
     })?;
+
+    let constraints = match modifier_body {
+        Some(body) => {
+            parse_field_constraints(body, kind).map_err(|reason| GenerateError::InvalidField {
+                token: token.to_owned(),
+                reason,
+            })?
+        }
+        None => FieldConstraints::default(),
+    };
 
     // `references` fields always end in `_id` — `post:references` resolves to
     // the column `post_id`. Tolerate an already-suffixed name (`post_id:references`)
@@ -493,7 +615,219 @@ pub fn parse_field(token: &str) -> Result<Field, GenerateError> {
         nullable,
         variants: Vec::new(),
         unique,
+        constraints,
     })
+}
+
+/// Split a scalar/`references` type token into its base type and the body of a
+/// trailing `{…}` constraint-modifier block, if present. `("String{min=3}",)`
+/// -> `("String", Some("min=3"))`; a token with no (or an unbalanced) block
+/// yields `(ty, None)` — the caller then rejects a leftover `{` as malformed.
+fn split_constraint_modifier(ty: &str) -> (&str, Option<&str>) {
+    let ty = ty.trim();
+    if let Some(open) = ty.find('{')
+        && ty.ends_with('}')
+    {
+        let close = ty.len() - 1;
+        if close > open {
+            return (ty[..open].trim_end(), Some(ty[open + 1..close].trim()));
+        }
+    }
+    (ty, None)
+}
+
+/// Format the `min = …, max = …` argument list shared by `length(…)` and
+/// `range(…)` `#[validate]` attributes. `float` range bounds are emitted with
+/// a decimal point (`0` -> `0.0`) so the generated comparison type-checks
+/// against an `f32`/`f64` field.
+fn min_max_args(min: &Option<String>, max: &Option<String>, float: bool) -> String {
+    let fmt = |raw: &str| -> String {
+        if float && !raw.contains(['.', 'e', 'E']) {
+            format!("{raw}.0")
+        } else {
+            raw.to_owned()
+        }
+    };
+    let mut args = Vec::with_capacity(2);
+    if let Some(min) = min {
+        args.push(format!("min = {}", fmt(min)));
+    }
+    if let Some(max) = max {
+        args.push(format!("max = {}", fmt(max)));
+    }
+    args.join(", ")
+}
+
+/// Parse the body of a `{…}` constraint-modifier block against the field's
+/// `kind` (issue #1388 validation + HTML5 constraints; issue #1146
+/// `references` `{label:col}`).
+///
+/// Supported per kind:
+/// - `String`/`Text`: `min=N`, `max=N` (length bounds, non-negative
+///   integers), `email`, `url`.
+/// - `i32`/`i64`/`f32`/`f64`: `min=N`, `max=N` (range bounds).
+/// - `references`: `label:col` (or `label=col`) — the display column.
+///
+/// Every other kind (and every unknown key/flag) is rejected with a message
+/// naming the offending token, so a misspelling like `{maxx=5}` fails the
+/// scaffold loudly rather than being silently dropped (issue #1388 AC5).
+fn parse_field_constraints(body: &str, kind: FieldKind) -> Result<FieldConstraints, String> {
+    let mut c = FieldConstraints::default();
+    if body.is_empty() {
+        return Err(
+            "empty constraint block `{}` — remove the braces or add a constraint \
+             (e.g. `{min=3,max=120}`, `{email}`, `{label:title}`)"
+                .to_owned(),
+        );
+    }
+
+    let string_like = matches!(kind, FieldKind::String | FieldKind::Text);
+    let numeric = matches!(
+        kind,
+        FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64
+    );
+    let is_reference = kind.is_reference();
+
+    for raw in body.split(',') {
+        let tok = raw.trim();
+        if tok.is_empty() {
+            return Err("empty constraint (stray comma) in the `{…}` block".to_owned());
+        }
+        // `label:col` (references display column) uses a colon; every other
+        // key/value pair uses `=`. Bare tokens (`email`, `url`) have neither.
+        if let Some((key, value)) = tok.split_once('=') {
+            parse_constraint_kv(&mut c, key.trim(), value.trim(), kind)?;
+        } else if let Some((key, value)) = tok.split_once(':') {
+            if key.trim() == "label" {
+                set_label_constraint(&mut c, value.trim(), is_reference)?;
+            } else {
+                return Err(unknown_constraint_message(key.trim(), kind));
+            }
+        } else {
+            match tok {
+                "email" | "url" => {
+                    if !string_like {
+                        return Err(format!(
+                            "the `{tok}` constraint only applies to String/Text fields"
+                        ));
+                    }
+                    if tok == "email" {
+                        c.email = true;
+                    } else {
+                        c.url = true;
+                    }
+                }
+                _ => return Err(unknown_constraint_message(tok, kind)),
+            }
+        }
+    }
+
+    // Cross-check the combination against the kind: length/range bounds need a
+    // string or numeric field, and require min <= max when both are present.
+    if (c.min.is_some() || c.max.is_some()) && !string_like && !numeric {
+        return Err(format!(
+            "min/max constraints are not supported for {} fields",
+            kind.rust_type()
+        ));
+    }
+    if let (Some(min), Some(max)) = (&c.min, &c.max) {
+        let (lo, hi): (f64, f64) = (
+            min.parse().map_err(|_| "min must be a number".to_owned())?,
+            max.parse().map_err(|_| "max must be a number".to_owned())?,
+        );
+        if lo > hi {
+            return Err(format!("min ({min}) cannot be greater than max ({max})"));
+        }
+    }
+
+    Ok(c)
+}
+
+/// Handle a `key=value` constraint token (`min=`, `max=`, or a `=`-spelled
+/// `label=`).
+fn parse_constraint_kv(
+    c: &mut FieldConstraints,
+    key: &str,
+    value: &str,
+    kind: FieldKind,
+) -> Result<(), String> {
+    match key {
+        "min" | "max" => {
+            let bound = parse_bound(value, kind)?;
+            if key == "min" {
+                c.min = Some(bound);
+            } else {
+                c.max = Some(bound);
+            }
+            Ok(())
+        }
+        "label" => set_label_constraint(c, value, kind.is_reference()),
+        _ => Err(unknown_constraint_message(key, kind)),
+    }
+}
+
+/// Validate and normalize a `min=`/`max=` bound for `kind`: a length bound on
+/// a `String`/`Text` field must be a non-negative integer; a range bound on a
+/// numeric field must be a valid number.
+fn parse_bound(value: &str, kind: FieldKind) -> Result<String, String> {
+    match kind {
+        FieldKind::String | FieldKind::Text => {
+            value
+                .parse::<u64>()
+                .map_err(|_| format!("length bound '{value}' must be a non-negative integer"))?;
+            Ok(value.to_owned())
+        }
+        FieldKind::I32 | FieldKind::I64 => {
+            value
+                .parse::<i64>()
+                .map_err(|_| format!("range bound '{value}' must be an integer"))?;
+            Ok(value.to_owned())
+        }
+        FieldKind::F32 | FieldKind::F64 => {
+            value
+                .parse::<f64>()
+                .map_err(|_| format!("range bound '{value}' must be a number"))?;
+            Ok(value.to_owned())
+        }
+        _ => Err(format!(
+            "min/max constraints are not supported for {} fields",
+            kind.rust_type()
+        )),
+    }
+}
+
+/// Set the `references` display-column override, rejecting `label` on a
+/// non-`references` field and a label that isn't a valid `snake_case` column.
+fn set_label_constraint(
+    c: &mut FieldConstraints,
+    value: &str,
+    is_reference: bool,
+) -> Result<(), String> {
+    if !is_reference {
+        return Err("the `label` constraint only applies to `references` fields".to_owned());
+    }
+    if !is_valid_ident(value) {
+        return Err(format!(
+            "reference label column '{value}' is not a valid snake_case identifier"
+        ));
+    }
+    c.label = Some(value.to_owned());
+    Ok(())
+}
+
+/// A per-kind "unknown constraint" message that names the offending token and
+/// lists what the kind *does* accept (issue #1388 AC5).
+fn unknown_constraint_message(token: &str, kind: FieldKind) -> String {
+    let accepted = match kind {
+        FieldKind::String | FieldKind::Text => "min=N, max=N, email, url",
+        FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64 => "min=N, max=N",
+        FieldKind::References => "label:col",
+        _ => "(none — this field type takes no constraint modifiers)",
+    };
+    format!(
+        "unknown constraint '{token}' for {} fields; supported: {accepted}",
+        kind.rust_type()
+    )
 }
 
 /// Parse an `enum{a,b,c}` (optionally `Option<enum{a,b,c}>`) type token.
@@ -1297,6 +1631,148 @@ mod tests {
             SUPPORTED_TYPES.contains("references"),
             "SUPPORTED_TYPES must list references"
         );
+    }
+
+    // ── constraint modifiers (issue #1388 validation + #1146 label) ─────────
+
+    #[test]
+    fn parse_string_length_constraint() {
+        let f = parse_field("title:String{min=3,max=120}").unwrap();
+        assert_eq!(f.name, "title");
+        assert_eq!(f.kind, FieldKind::String);
+        assert_eq!(f.constraints.min.as_deref(), Some("3"));
+        assert_eq!(f.constraints.max.as_deref(), Some("120"));
+        assert_eq!(f.validation_attrs(), vec!["length(min = 3, max = 120)"]);
+    }
+
+    #[test]
+    fn parse_string_email_constraint() {
+        let f = parse_field("contact:String{email}").unwrap();
+        assert!(f.constraints.email);
+        assert_eq!(f.validation_attrs(), vec!["email"]);
+    }
+
+    #[test]
+    fn parse_string_url_constraint() {
+        let f = parse_field("homepage:String{url}").unwrap();
+        assert!(f.constraints.url);
+        assert_eq!(f.validation_attrs(), vec!["url"]);
+    }
+
+    #[test]
+    fn parse_numeric_range_constraint() {
+        let f = parse_field("age:i32{min=0,max=130}").unwrap();
+        assert_eq!(f.kind, FieldKind::I32);
+        assert_eq!(f.validation_attrs(), vec!["range(min = 0, max = 130)"]);
+    }
+
+    #[test]
+    fn parse_float_range_constraint_emits_decimal_literals() {
+        // An integer bound on an f64 field must be emitted with a decimal
+        // point, or the generated `#[validate(range(...))]` comparison fails
+        // to type-check against the f64 field.
+        let f = parse_field("ratio:f64{min=0,max=1}").unwrap();
+        assert_eq!(f.validation_attrs(), vec!["range(min = 0.0, max = 1.0)"]);
+    }
+
+    #[test]
+    fn parse_min_only_constraint() {
+        let f = parse_field("title:String{min=3}").unwrap();
+        assert_eq!(f.constraints.min.as_deref(), Some("3"));
+        assert_eq!(f.constraints.max, None);
+        assert_eq!(f.validation_attrs(), vec!["length(min = 3)"]);
+    }
+
+    #[test]
+    fn parse_reference_label_constraint() {
+        let f = parse_field("post:references{label:title}").unwrap();
+        assert_eq!(f.name, "post_id");
+        assert_eq!(f.kind, FieldKind::References);
+        assert_eq!(f.constraints.label.as_deref(), Some("title"));
+        // `references` never fans out to a `#[validate]` rule.
+        assert!(f.validation_attrs().is_empty());
+    }
+
+    #[test]
+    fn reference_label_does_not_break_unique_detection() {
+        // The colon inside `{label:title}` must not be mistaken for a
+        // `:unique` modifier split.
+        let f = parse_field("post:references{label:title}").unwrap();
+        assert!(!f.unique);
+    }
+
+    #[test]
+    fn constraint_composes_with_unique_modifier() {
+        let f = parse_field("email:String{email}:unique").unwrap();
+        assert!(f.unique);
+        assert!(f.constraints.email);
+    }
+
+    #[test]
+    fn bare_unique_modifier_still_parses() {
+        let f = parse_field("email:String:unique").unwrap();
+        assert!(f.unique);
+        assert!(f.constraints.is_empty());
+    }
+
+    #[test]
+    fn unknown_constraint_modifier_is_rejected_by_name() {
+        // AC5: a misspelled modifier fails loudly, naming the token.
+        let err = parse_field("title:String{maxx=5}").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("maxx"), "must name the bad token: {msg}");
+    }
+
+    #[test]
+    fn email_constraint_on_numeric_field_is_rejected() {
+        let err = parse_field("age:i32{email}").unwrap_err();
+        assert!(err.to_string().contains("email"));
+    }
+
+    #[test]
+    fn label_constraint_on_non_reference_is_rejected() {
+        let err = parse_field("title:String{label:foo}").unwrap_err();
+        assert!(err.to_string().contains("references"));
+    }
+
+    #[test]
+    fn min_greater_than_max_is_rejected() {
+        let err = parse_field("title:String{min=10,max=3}").unwrap_err();
+        assert!(err.to_string().contains("min"));
+    }
+
+    #[test]
+    fn non_integer_length_bound_is_rejected() {
+        let err = parse_field("title:String{max=abc}").unwrap_err();
+        assert!(err.to_string().contains("abc"));
+    }
+
+    #[test]
+    fn constraint_on_unconstrainable_kind_is_rejected() {
+        // A bool field takes no `{…}` modifiers.
+        let err = parse_field("active:bool{min=0}").unwrap_err();
+        assert!(err.to_string().contains("not supported") || err.to_string().contains("bool"));
+    }
+
+    #[test]
+    fn empty_constraint_block_is_rejected() {
+        let err = parse_field("title:String{}").unwrap_err();
+        assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn nullable_string_with_constraint_parses() {
+        let f = parse_field("bio:Option<String>{max=200}").unwrap();
+        assert!(f.nullable);
+        assert_eq!(f.constraints.max.as_deref(), Some("200"));
+        assert_eq!(f.validation_attrs(), vec!["length(max = 200)"]);
+    }
+
+    #[test]
+    fn bare_field_has_empty_constraints() {
+        let f = parse_field("title:String").unwrap();
+        assert!(f.constraints.is_empty());
+        assert!(f.validation_attrs().is_empty());
     }
 
     #[test]

--- a/autumn-cli/src/generate/dsl.rs
+++ b/autumn-cli/src/generate/dsl.rs
@@ -29,7 +29,7 @@ pub struct FieldConstraints {
     /// `url` — `#[validate(url)]` + `type="url"`. `String`/`Text` only.
     pub url: bool,
     /// `label:col` — the `references` display column an index/show view and a
-    /// belongs_to `<select>` label render from (issue #1146). `references`
+    /// `belongs_to` `<select>` label render from (issue #1146). `references`
     /// only; never a `#[validate]`/HTML5 constraint.
     pub label: Option<String>,
 }
@@ -37,7 +37,7 @@ pub struct FieldConstraints {
 impl FieldConstraints {
     /// True when no constraint modifier was declared.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.min.is_none() && self.max.is_none() && !self.email && !self.url && self.label.is_none()
     }
 }
@@ -149,7 +149,10 @@ impl Field {
         match self.kind {
             FieldKind::String | FieldKind::Text => {
                 if c.min.is_some() || c.max.is_some() {
-                    out.push(format!("length({})", min_max_args(&c.min, &c.max, false)));
+                    out.push(format!(
+                        "length({})",
+                        min_max_args(c.min.as_ref(), c.max.as_ref(), false)
+                    ));
                 }
                 if c.email {
                     out.push("email".to_owned());
@@ -161,7 +164,10 @@ impl Field {
             FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64 => {
                 if c.min.is_some() || c.max.is_some() {
                     let is_float = matches!(self.kind, FieldKind::F32 | FieldKind::F64);
-                    out.push(format!("range({})", min_max_args(&c.min, &c.max, is_float)));
+                    out.push(format!(
+                        "range({})",
+                        min_max_args(c.min.as_ref(), c.max.as_ref(), is_float)
+                    ));
                 }
             }
             _ => {}
@@ -472,6 +478,11 @@ pub fn sql_type_to_field_kind(udt_name: &str) -> Option<FieldKind> {
 /// # Errors
 /// Returns [`GenerateError::InvalidField`] if the token is malformed or the
 /// type is not in the supported set.
+#[allow(
+    clippy::too_many_lines,
+    reason = "a linear name→modifier→type→constraint parse; the early-return \
+              validation guards read more clearly inline than split across helpers"
+)]
 pub fn parse_field(token: &str) -> Result<Field, GenerateError> {
     let (name, rest) = token
         .split_once(':')
@@ -640,7 +651,7 @@ fn split_constraint_modifier(ty: &str) -> (&str, Option<&str>) {
 /// `range(…)` `#[validate]` attributes. `float` range bounds are emitted with
 /// a decimal point (`0` -> `0.0`) so the generated comparison type-checks
 /// against an `f32`/`f64` field.
-fn min_max_args(min: &Option<String>, max: &Option<String>, float: bool) -> String {
+fn min_max_args(min: Option<&String>, max: Option<&String>, float: bool) -> String {
     let fmt = |raw: &str| -> String {
         if float && !raw.contains(['.', 'e', 'E']) {
             format!("{raw}.0")
@@ -1138,6 +1149,10 @@ pub(super) fn is_rust_keyword(s: &str) -> bool {
 }
 
 #[cfg(test)]
+// Test inputs like `"title:String{min=3}"` / `"post:references{label:title}"`
+// are literal DSL tokens passed to `parse_field`, not format strings — the
+// `{…}` is the scaffold's own constraint-modifier syntax under test.
+#[allow(clippy::literal_string_with_formatting_args)]
 mod tests {
     use super::*;
 

--- a/autumn-cli/src/generate/dsl.rs
+++ b/autumn-cli/src/generate/dsl.rs
@@ -748,6 +748,19 @@ fn parse_field_constraints(body: &str, kind: FieldKind) -> Result<FieldConstrain
         }
     }
 
+    // `email` and `url` are mutually exclusive format validators: emitting both
+    // `#[validate(email)]` and `#[validate(url)]` makes the field unwritable (a
+    // valid email fails `url` and vice versa), and the HTML5 renderer can only
+    // pick one `type`. Reject the pair rather than silently choosing a winner,
+    // which would change the author's intent (issue #1388).
+    if c.email && c.url {
+        return Err(
+            "the `email` and `url` constraints are mutually exclusive — a value can't satisfy \
+             both; keep only one"
+                .to_owned(),
+        );
+    }
+
     // Cross-check the combination against the kind: length/range bounds need a
     // string or numeric field, and require min <= max when both are present.
     if (c.min.is_some() || c.max.is_some()) && !string_like && !numeric {
@@ -1743,6 +1756,20 @@ mod tests {
         let f = parse_field("homepage:String{url}").unwrap();
         assert!(f.constraints.url);
         assert_eq!(f.validation_attrs(), vec!["url"]);
+    }
+
+    #[test]
+    fn email_and_url_together_are_rejected() {
+        // Both format validators on one field make it unwritable (a valid email
+        // fails `url` and vice versa), so the pair is rejected at parse time
+        // rather than silently picking a winner.
+        let err = parse_field("contact:String{email,url}").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("mutually exclusive"),
+            "must explain the conflict: {msg}"
+        );
+        assert!(msg.contains("contact"), "must name the field: {msg}");
     }
 
     #[test]

--- a/autumn-cli/src/generate/dsl.rs
+++ b/autumn-cli/src/generate/dsl.rs
@@ -742,11 +742,23 @@ fn parse_field_constraints(body: &str, kind: FieldKind) -> Result<FieldConstrain
         ));
     }
     if let (Some(min), Some(max)) = (&c.min, &c.max) {
-        let (lo, hi): (f64, f64) = (
-            min.parse().map_err(|_| "min must be a number".to_owned())?,
-            max.parse().map_err(|_| "max must be a number".to_owned())?,
-        );
-        if lo > hi {
+        // Compare at the field's CONCRETE width, never via `f64`: a large `i64`
+        // pair such as `{min=9007199254740993,max=9007199254740992}` would
+        // otherwise round to the same float and slip past this check, emitting
+        // an impossible `range(min > max)` that rejects every submitted value
+        // instead of failing generation here. Each bound already passed
+        // `parse_bound` for `kind`, so these re-parses succeed exactly.
+        let inverted = match kind {
+            FieldKind::String | FieldKind::Text => {
+                matches!((min.parse::<u64>(), max.parse::<u64>()), (Ok(lo), Ok(hi)) if lo > hi)
+            }
+            FieldKind::I32 | FieldKind::I64 => {
+                matches!((min.parse::<i64>(), max.parse::<i64>()), (Ok(lo), Ok(hi)) if lo > hi)
+            }
+            // `f32`/`f64`: `f64` compares `f32` values exactly, so this is lossless.
+            _ => matches!((min.parse::<f64>(), max.parse::<f64>()), (Ok(lo), Ok(hi)) if lo > hi),
+        };
+        if inverted {
             return Err(format!("min ({min}) cannot be greater than max ({max})"));
         }
     }
@@ -1757,6 +1769,29 @@ mod tests {
         // so reject non-finite bounds explicitly.
         let err = parse_field("ratio:f32{max=1e40}").unwrap_err();
         assert!(err.to_string().contains("f32"), "{}", err);
+    }
+
+    #[test]
+    fn i64_min_greater_than_max_beyond_f64_precision_is_rejected() {
+        // `min` is exactly one greater than `max`, but both round to the same
+        // `f64` (they exceed 2^53). Comparing at the concrete `i64` width must
+        // still catch the inversion, rather than emitting an impossible
+        // `range(min > max)` that rejects every submitted value.
+        let err = parse_field("count:i64{min=9007199254740993,max=9007199254740992}").unwrap_err();
+        assert!(
+            err.to_string().contains("cannot be greater than"),
+            "must report the inverted range: {err}"
+        );
+    }
+
+    #[test]
+    fn i64_valid_large_range_is_accepted() {
+        let f = parse_field("count:i64{min=1,max=9007199254740992}").unwrap();
+        assert_eq!(f.kind, FieldKind::I64);
+        assert_eq!(
+            f.validation_attrs(),
+            vec!["range(min = 1, max = 9007199254740992)"]
+        );
     }
 
     #[test]

--- a/autumn-cli/src/generate/emit.rs
+++ b/autumn-cli/src/generate/emit.rs
@@ -146,6 +146,14 @@ pub enum Revert {
     /// `autumn generate auth` injected into the `AppBuilder` chain in `path`
     /// (`src/main.rs`) (issue #1397).
     RememberMiddleware { path: PathBuf },
+    /// Remove the `#[path]`-qualified `mod schema;` / `mod models;` links
+    /// `generate model`/`scaffold` injected into `path` (`src/bin/seed.rs`)
+    /// via [`super::schema_edit::link_models_into_seed_bin`] (issue #1718) —
+    /// but only once `owner_dir` (`src/models`) has no other model file left
+    /// in it, i.e. the LAST model is being destroyed and `src/models/mod.rs` /
+    /// `src/schema.rs` (the link targets) are themselves removed. Destroying
+    /// one of several models keeps the links, matching the surviving modules.
+    SeedBinLinks { path: PathBuf, owner_dir: PathBuf },
 }
 
 impl Revert {
@@ -167,7 +175,8 @@ impl Revert {
             | Self::PwaMainRsInjection { path }
             | Self::AuthOAuthProviderStubs { path, .. }
             | Self::AuthWebauthnStub { path }
-            | Self::RememberMiddleware { path } => path,
+            | Self::RememberMiddleware { path }
+            | Self::SeedBinLinks { path, .. } => path,
         }
     }
 
@@ -179,9 +188,9 @@ impl Revert {
     /// where the pushing generator has no single owning directory).
     fn owner_dir(&self) -> Option<&Path> {
         match self {
-            Self::CargoDeps { owner_dir, .. } | Self::JobsRegistration { owner_dir, .. } => {
-                Some(owner_dir)
-            }
+            Self::CargoDeps { owner_dir, .. }
+            | Self::JobsRegistration { owner_dir, .. }
+            | Self::SeedBinLinks { owner_dir, .. } => Some(owner_dir),
             Self::CargoAutumnWebFeature { owner_dir, .. }
             | Self::CargoAutumnWebDevFeature { owner_dir, .. } => owner_dir.as_deref(),
             Self::ModDecl { .. }
@@ -308,6 +317,7 @@ impl Revert {
                 super::auth::remove_oauth_provider_stubs(content, providers)
             }
             Self::AuthWebauthnStub { .. } => super::auth::remove_webauthn_stub(content),
+            Self::SeedBinLinks { .. } => super::schema_edit::unlink_models_from_seed_bin(content),
         }
     }
 }

--- a/autumn-cli/src/generate/introspect.rs
+++ b/autumn-cli/src/generate/introspect.rs
@@ -1531,6 +1531,7 @@ mod tests {
                 nullable: false,
                 variants: Vec::new(),
                 unique: false,
+                constraints: Default::default(),
             },
             Field {
                 name: "body".into(),
@@ -1538,6 +1539,7 @@ mod tests {
                 nullable: false,
                 variants: Vec::new(),
                 unique: false,
+                constraints: Default::default(),
             },
             Field {
                 name: "published".into(),
@@ -1545,6 +1547,7 @@ mod tests {
                 nullable: false,
                 variants: Vec::new(),
                 unique: false,
+                constraints: Default::default(),
             },
         ];
         let greenfield = render_model_file_for_test("Post", "posts", &fields);

--- a/autumn-cli/src/generate/introspect.rs
+++ b/autumn-cli/src/generate/introspect.rs
@@ -1519,7 +1519,7 @@ mod tests {
 
     #[test]
     fn round_trip_matches_greenfield_model_byte_for_byte() {
-        use crate::generate::dsl::{Field, sql_type_to_field_kind};
+        use crate::generate::dsl::{Field, FieldConstraints, sql_type_to_field_kind};
         use crate::generate::model::render_model_file_for_test;
 
         // Forward: the model `autumn generate model Post title:String body:Text
@@ -1531,7 +1531,7 @@ mod tests {
                 nullable: false,
                 variants: Vec::new(),
                 unique: false,
-                constraints: Default::default(),
+                constraints: FieldConstraints::default(),
             },
             Field {
                 name: "body".into(),
@@ -1539,7 +1539,7 @@ mod tests {
                 nullable: false,
                 variants: Vec::new(),
                 unique: false,
-                constraints: Default::default(),
+                constraints: FieldConstraints::default(),
             },
             Field {
                 name: "published".into(),
@@ -1547,7 +1547,7 @@ mod tests {
                 nullable: false,
                 variants: Vec::new(),
                 unique: false,
-                constraints: Default::default(),
+                constraints: FieldConstraints::default(),
             },
         ];
         let greenfield = render_model_file_for_test("Post", "posts", &fields);

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -4,7 +4,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
-use super::dsl::{Field, FieldKind, IdType, parse_fields};
+use super::dsl::{Field, FieldConstraints, FieldKind, IdType, parse_fields};
 use super::emit::Plan;
 use super::naming::{pascal, pluralize, snake};
 use super::schema_edit::{
@@ -401,7 +401,7 @@ fn type_is_uuid(ty: &syn::Type) -> bool {
 /// (`Option<String>`).
 ///
 /// The scaffold generator uses this to pick a human-friendly display column
-/// for a `references` field (issue #1146): a belongs_to `<select>` and the
+/// for a `references` field (issue #1146): a `belongs_to` `<select>` and the
 /// index/show views render this column's value instead of the raw foreign-key
 /// id. Returns an empty vec when the model can't be located/parsed or has no
 /// string column — the caller then falls back to rendering the id, exactly the
@@ -620,7 +620,7 @@ pub(super) fn augment_fields_for_soft_delete(
         nullable: true,
         variants: Vec::new(),
         unique: false,
-        constraints: Default::default(),
+        constraints: FieldConstraints::default(),
     });
     Ok(std::borrow::Cow::Owned(augmented))
 }

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -9,7 +9,7 @@ use super::emit::Plan;
 use super::naming::{pascal, pluralize, snake};
 use super::schema_edit::{
     add_mod_declaration, append_schema_table_with_id, create_table_sql_with_metadata_and_id,
-    drop_table_sql,
+    drop_table_sql, link_models_into_seed_bin,
 };
 use super::{GenerateError, ensure_project_root, read_or_empty};
 
@@ -234,7 +234,33 @@ pub fn plan_model_with_options(
         &project_root.join("src/models"),
     );
 
+    // (e) Link the new model (and the `schema` module it reads) into the
+    // standalone `src/bin/seed.rs` binary, when the project was scaffolded
+    // with one (`autumn new --with-seed`). Without this the model's
+    // `#[model]` inventory registration is never compiled into the seed
+    // binary, so `autumn seed --count N --model M` cannot resolve it
+    // (issue #1718; completes AC4 of #1343). `generate scaffold` reuses this
+    // planner, so it inherits the same wiring.
+    plan_seed_bin_linking(&mut plan, project_root);
+
     Ok(plan)
+}
+
+/// Add a `Modify` action linking `src/models/` + `src/schema.rs` into
+/// `src/bin/seed.rs` when that binary exists, unless it's already linked
+/// (see [`link_models_into_seed_bin`]). A no-op — no action queued — when the
+/// project has no seed binary or the declarations are already present, so a
+/// plain non-`--with-seed` project's plan and output are unchanged.
+fn plan_seed_bin_linking(plan: &mut Plan, project_root: &Path) {
+    let seed_path = project_root.join("src").join("bin").join("seed.rs");
+    if !seed_path.exists() {
+        return;
+    }
+    let existing = read_or_empty(&seed_path);
+    let linked = link_models_into_seed_bin(&existing);
+    if linked != existing {
+        plan.modify(seed_path, linked);
+    }
 }
 
 /// Whether resource `base`'s model can be found anywhere in the project,
@@ -370,6 +396,97 @@ fn type_is_uuid(ty: &syn::Type) -> bool {
     }
 }
 
+/// The `String`/`Text` columns of resource `base`'s `#[model]` struct, in
+/// declaration order, each paired with whether it is nullable
+/// (`Option<String>`).
+///
+/// The scaffold generator uses this to pick a human-friendly display column
+/// for a `references` field (issue #1146): a belongs_to `<select>` and the
+/// index/show views render this column's value instead of the raw foreign-key
+/// id. Returns an empty vec when the model can't be located/parsed or has no
+/// string column — the caller then falls back to rendering the id, exactly the
+/// pre-#1146 behavior.
+///
+/// Parses with `syn` (like [`model_struct_has_uuid_pk`]) so grouped
+/// attributes, doc comments, and a multi-model `src/models.rs` layout don't
+/// defeat it.
+pub(super) fn model_string_columns(project_root: &Path, base: &str) -> Vec<(String, bool)> {
+    let pascal_name = pascal(base);
+    let per_resource = project_root
+        .join("src")
+        .join("models")
+        .join(format!("{base}.rs"));
+    let content = if per_resource.exists() {
+        read_or_empty(&per_resource)
+    } else {
+        let single_file = project_root.join("src").join("models.rs");
+        if !single_file.exists() {
+            return Vec::new();
+        }
+        read_or_empty(&single_file)
+    };
+
+    let Ok(file) = syn::parse_file(&content) else {
+        return Vec::new();
+    };
+    let Some(item_struct) = file.items.iter().find_map(|item| match item {
+        syn::Item::Struct(s) if s.ident == pascal_name => Some(s),
+        _ => None,
+    }) else {
+        return Vec::new();
+    };
+    let syn::Fields::Named(fields) = &item_struct.fields else {
+        return Vec::new();
+    };
+
+    let mut out = Vec::new();
+    for field in &fields.named {
+        let Some(ident) = field.ident.as_ref() else {
+            continue;
+        };
+        if let Some(nullable) = string_like_nullability(&field.ty) {
+            out.push((ident.to_string(), nullable));
+        }
+    }
+    out
+}
+
+/// `Some(false)` for a `String` field, `Some(true)` for `Option<String>`,
+/// `None` for any non-string type.
+fn string_like_nullability(ty: &syn::Type) -> Option<bool> {
+    if let Some(inner) = option_inner_type(ty) {
+        return type_is_string(inner).then_some(true);
+    }
+    type_is_string(ty).then_some(false)
+}
+
+/// The `T` of an `Option<T>` type, or `None` when `ty` isn't an `Option<…>`.
+fn option_inner_type(ty: &syn::Type) -> Option<&syn::Type> {
+    let syn::Type::Path(tp) = ty else {
+        return None;
+    };
+    let seg = tp.path.segments.last()?;
+    if seg.ident != "Option" {
+        return None;
+    }
+    let syn::PathArguments::AngleBracketed(args) = &seg.arguments else {
+        return None;
+    };
+    args.args.iter().find_map(|arg| match arg {
+        syn::GenericArgument::Type(t) => Some(t),
+        _ => None,
+    })
+}
+
+/// Whether `ty` is the bare `String` type (the only spelling the model
+/// generator emits for `String`/`Text` columns).
+fn type_is_string(ty: &syn::Type) -> bool {
+    let syn::Type::Path(tp) = ty else {
+        return false;
+    };
+    tp.qself.is_none() && tp.path.segments.last().is_some_and(|s| s.ident == "String")
+}
+
 /// Validate every `references` field against its target model (issue #1026):
 ///
 /// - A *self*-reference (the target table is `own_table` — the resource this
@@ -503,6 +620,7 @@ pub(super) fn augment_fields_for_soft_delete(
         nullable: true,
         variants: Vec::new(),
         unique: false,
+        constraints: Default::default(),
     });
     Ok(std::borrow::Cow::Owned(augmented))
 }
@@ -1128,6 +1246,27 @@ pub fn parse_model_metadata(
             .entry(field_name.to_owned())
             .or_default()
             .push(attr);
+    }
+
+    // DSL brace-constraint modifiers (`title:String{min=3,max=120}`,
+    // `contact:String{email}`, `age:i32{min=0,max=130}`) fan out into the
+    // same `#[validate(...)]` pipeline as the `--validate` flag (issue #1388),
+    // so the generated model rejects invalid input server-side through the
+    // existing `Validated`/changeset path (422 + per-field errors) rather than
+    // a 500 or a silent store. Deduped against any `--validate` rule already
+    // recorded for the field, so declaring a constraint both ways doesn't emit
+    // it twice. `has_validator_rules()` then pulls in the `validator` crate
+    // dependency automatically (see `plan_model_with_options`).
+    for field in fields {
+        if field.constraints.is_empty() {
+            continue;
+        }
+        for attr in field.validation_attrs() {
+            let entry = metadata.validations.entry(field.name.clone()).or_default();
+            if !entry.contains(&attr) {
+                entry.push(attr);
+            }
+        }
     }
 
     for default in &options.defaults {

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -259,7 +259,20 @@ fn plan_seed_bin_linking(plan: &mut Plan, project_root: &Path) {
     let existing = read_or_empty(&seed_path);
     let linked = link_models_into_seed_bin(&existing);
     if linked != existing {
-        plan.modify(seed_path, linked);
+        plan.modify(seed_path.clone(), linked);
+    }
+    // Record the destroy-time inverse regardless of whether THIS invocation had
+    // to inject (a later model reuses the same already-linked file): `autumn
+    // destroy` deletes `src/models/mod.rs` + `src/schema.rs` once the last
+    // model's reverts empty them, which would leave these `#[path]` links
+    // dangling at missing files. `owner_dir = src/models` gates the revert so it
+    // fires only when the last model is destroyed (no other model file remains),
+    // keeping the links while sibling models still live (issue #1718).
+    if seed_path.exists() {
+        plan.push_revert(crate::generate::emit::Revert::SeedBinLinks {
+            path: seed_path,
+            owner_dir: project_root.join("src").join("models"),
+        });
     }
 }
 

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -2677,11 +2677,15 @@ fn render_form_for_helper(
                         " required aria-required=\"true\""
                     };
                     let _ = write!(builder_calls, "\n        .exclude(\"{name}\")");
-                    if matches!(f.kind, FieldKind::Text) {
-                        // A `text` DSL column is a long-form field (Postgres
-                        // `TEXT`), so its constrained control is a `<textarea>`,
-                        // not a single-line `<input>` — the same element the
-                        // derived `FieldControl::Textarea` would pick. Only the
+                    if matches!(f.kind, FieldKind::Text) && input_type == "text" {
+                        // A `text` DSL column with a length/plain constraint is a
+                        // long-form field (Postgres `TEXT`), so its control is a
+                        // `<textarea>`, not a single-line `<input>` — the same
+                        // element the derived `FieldControl::Textarea` would pick.
+                        // (A `text{email}`/`text{url}` field has `input_type` ==
+                        // `email`/`url`, which a textarea can't carry — those
+                        // inherently single-line, type-dependent controls take the
+                        // `<input type="…">` branch below instead.) Only the
                         // attributes a textarea honours carry over: the length
                         // rules in `constraint_attrs` (`minlength`/`maxlength`)
                         // and `required`; the input-only `type`/`min`/`max` are

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -2637,25 +2637,58 @@ fn render_form_for_helper(
                         " required aria-required=\"true\""
                     };
                     let _ = write!(builder_calls, "\n        .exclude(\"{name}\")");
-                    let _ = write!(
-                        appends,
-                        "\n        .append(html! {{\n            \
-                         @let errors = changeset.errors_for(\"{name}\");\n            \
-                         div id=\"{name}-field\" class=\"autumn-field\" {{\n                \
-                         label for=\"{name}\" class=\"autumn-field__label\" {{ \"{label}\" }}\n                \
-                         input type=\"{input_type}\" id=\"{name}\" name=\"{name}\"\n                    \
-                         value=(changeset.field_value(\"{name}\").unwrap_or_default()){constraint_attrs}{required_attr}\n                    \
-                         class=(if errors.is_empty() {{ \"autumn-field__input\" }} else {{ \"autumn-field__input autumn-field__input--invalid\" }})\n                    \
-                         aria-invalid=(if errors.is_empty() {{ \"false\" }} else {{ \"true\" }})\n                    \
-                         aria-describedby=(if errors.is_empty() {{ \"\" }} else {{ \"{name}-error\" }});\n                \
-                         @if !errors.is_empty() {{\n                    \
-                         div id=\"{name}-error\" role=\"alert\" class=\"autumn-field__errors\" {{\n                        \
-                         @for error in errors {{ p class=\"autumn-field__error\" {{ (error) }} }}\n                    \
-                         }}\n                \
-                         }}\n            \
-                         }}\n        \
-                         }})"
-                    );
+                    if matches!(f.kind, FieldKind::Text) {
+                        // A `text` DSL column is a long-form field (Postgres
+                        // `TEXT`), so its constrained control is a `<textarea>`,
+                        // not a single-line `<input>` — the same element the
+                        // derived `FieldControl::Textarea` would pick. Only the
+                        // attributes a textarea honours carry over: the length
+                        // rules in `constraint_attrs` (`minlength`/`maxlength`)
+                        // and `required`; the input-only `type`/`min`/`max` are
+                        // dropped. The 422 re-render value is the element's text
+                        // content (not a `value=` attribute) so entered input
+                        // survives, matching `form::textarea_input`.
+                        let _ = write!(
+                            appends,
+                            "\n        .append(html! {{\n            \
+                             @let errors = changeset.errors_for(\"{name}\");\n            \
+                             div id=\"{name}-field\" class=\"autumn-field\" {{\n                \
+                             label for=\"{name}\" class=\"autumn-field__label\" {{ \"{label}\" }}\n                \
+                             textarea id=\"{name}\" name=\"{name}\"{constraint_attrs}{required_attr}\n                    \
+                             class=(if errors.is_empty() {{ \"autumn-field__input\" }} else {{ \"autumn-field__input autumn-field__input--invalid\" }})\n                    \
+                             aria-invalid=(if errors.is_empty() {{ \"false\" }} else {{ \"true\" }})\n                    \
+                             aria-describedby=(if errors.is_empty() {{ \"\" }} else {{ \"{name}-error\" }}) {{\n                        \
+                             (changeset.field_value(\"{name}\").unwrap_or_default())\n                    \
+                             }}\n                \
+                             @if !errors.is_empty() {{\n                    \
+                             div id=\"{name}-error\" role=\"alert\" class=\"autumn-field__errors\" {{\n                        \
+                             @for error in errors {{ p class=\"autumn-field__error\" {{ (error) }} }}\n                    \
+                             }}\n                \
+                             }}\n            \
+                             }}\n        \
+                             }})"
+                        );
+                    } else {
+                        let _ = write!(
+                            appends,
+                            "\n        .append(html! {{\n            \
+                             @let errors = changeset.errors_for(\"{name}\");\n            \
+                             div id=\"{name}-field\" class=\"autumn-field\" {{\n                \
+                             label for=\"{name}\" class=\"autumn-field__label\" {{ \"{label}\" }}\n                \
+                             input type=\"{input_type}\" id=\"{name}\" name=\"{name}\"\n                    \
+                             value=(changeset.field_value(\"{name}\").unwrap_or_default()){constraint_attrs}{required_attr}\n                    \
+                             class=(if errors.is_empty() {{ \"autumn-field__input\" }} else {{ \"autumn-field__input autumn-field__input--invalid\" }})\n                    \
+                             aria-invalid=(if errors.is_empty() {{ \"false\" }} else {{ \"true\" }})\n                    \
+                             aria-describedby=(if errors.is_empty() {{ \"\" }} else {{ \"{name}-error\" }});\n                \
+                             @if !errors.is_empty() {{\n                    \
+                             div id=\"{name}-error\" role=\"alert\" class=\"autumn-field__errors\" {{\n                        \
+                             @for error in errors {{ p class=\"autumn-field__error\" {{ (error) }} }}\n                    \
+                             }}\n                \
+                             }}\n            \
+                             }}\n        \
+                             }})"
+                        );
+                    }
                 }
             }
         }

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -2519,6 +2519,11 @@ fn render_form_model_impl(pascal_name: &str) -> String {
 ///   project, so there is no schema entry to load options from) keep the
 ///   derived numeric id input instead — the plan carries a warning saying
 ///   how to get the select.
+#[allow(
+    clippy::too_many_lines,
+    reason = "one per-field match building the form_for builder calls plus the \
+              constrained-field/attachment append markup — a single cohesive template"
+)]
 fn render_form_for_helper(
     pascal_name: &str,
     snake_name: &str,
@@ -4591,6 +4596,7 @@ fn main_route_entries(
 mod tests {
     use super::*;
     use crate::generate::Flags;
+    use crate::generate::dsl::FieldConstraints;
     use std::fs;
     use tempfile::TempDir;
 
@@ -8428,7 +8434,7 @@ async fn main() {
                 nullable: false,
                 variants: Vec::new(),
                 unique: false,
-                constraints: Default::default(),
+                constraints: FieldConstraints::default(),
             },
             Field {
                 name: "author_id".to_string(),
@@ -8436,7 +8442,7 @@ async fn main() {
                 nullable: true,
                 variants: Vec::new(),
                 unique: false,
-                constraints: Default::default(),
+                constraints: FieldConstraints::default(),
             },
         ];
         assert_eq!(
@@ -8483,7 +8489,7 @@ async fn main() {
                 nullable: false,
                 variants: Vec::new(),
                 unique: false,
-                constraints: Default::default(),
+                constraints: FieldConstraints::default(),
             },
             Field {
                 name: "author_id".to_string(),
@@ -8491,7 +8497,7 @@ async fn main() {
                 nullable: true,
                 variants: Vec::new(),
                 unique: false,
-                constraints: Default::default(),
+                constraints: FieldConstraints::default(),
             },
         ];
         let sql = render_reference_stub_tables_sql(&fields, "unrelated_table");
@@ -8593,7 +8599,7 @@ async fn main() {
             nullable: false,
             variants: vec!["a".to_string(), "b".to_string()],
             unique: false,
-            constraints: Default::default(),
+            constraints: FieldConstraints::default(),
         };
         let weight = Field {
             name: "weight".to_string(),
@@ -8604,7 +8610,7 @@ async fn main() {
             nullable: false,
             variants: Vec::new(),
             unique: false,
-            constraints: Default::default(),
+            constraints: FieldConstraints::default(),
         };
         let fields = vec![status.clone(), weight];
         let sql = enum_rejection_insert_sql("items", &fields, &status, &BTreeMap::new());

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -508,6 +508,7 @@ pub fn plan_scaffold_with_options(
         plan.create(
             routes_dir.join(format!("{plural}.rs")),
             render_routes_file(
+                project_root,
                 &pascal_name,
                 &snake_name,
                 &plural,
@@ -1435,6 +1436,7 @@ fn render_model_form(
 )]
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 fn render_routes_file(
+    project_root: &Path,
     pascal_name: &str,
     snake_name: &str,
     plural: &str,
@@ -1509,6 +1511,15 @@ fn render_routes_file(
     // threads into the layout.
     let flash_arg = "flash_messages(&flash.consume().await)";
 
+    // Per-reference display resolution (issue #1146): the `<select>` options,
+    // index columns, and show rows render the parent's display column (a
+    // `name`/`title`/first-string heuristic, or an explicit `{label:col}`)
+    // instead of the raw foreign-key id. A reference whose target has no
+    // string column has no entry here and keeps rendering the id.
+    let reference_displays: BTreeMap<String, ReferenceDisplay> = reference_fields
+        .iter()
+        .filter_map(|f| resolve_reference_display(project_root, f).map(|d| (f.name.clone(), d)))
+        .collect();
     let model_form = render_model_form(pascal_name, fields, validations);
     // Enum fields need their generated Rust type in scope here — `into_new`
     // parses into it and the `From<&Row>` seed matches against its variants
@@ -1785,7 +1796,7 @@ fn render_routes_file(
             new_form_body,
             edit_form_body,
             render_form_for_helper(pascal_name, snake_name, fields, missing_reference_targets)
-                + &render_reference_option_loaders(&reference_fields, db_ty),
+                + &render_reference_option_loaders(&reference_fields, db_ty, &reference_displays),
         )
     };
     let form_model_impl = render_form_model_impl(pascal_name);
@@ -1950,11 +1961,34 @@ fn render_routes_file(
         String::new()
     };
 
-    // For non-live paths, generate the data_table columns and call.
+    // For non-live paths, generate the data_table columns and call. The
+    // sharded index uses the id-based columns (`columns_let`); the plain
+    // non-sharded index promotes displayable `references` columns to render
+    // the parent's label from a per-view label map (issue #1146,
+    // `index_columns_labeled` + `index_label_loads`). Sharded/live keep the id
+    // rendering — their connection shape (`ShardedDb`) / list markup (a `<ul>`
+    // of ids) don't take the plain `Db`-loaded map.
     let columns_let = if live {
         String::new()
     } else {
-        render_columns_vec(pascal_name, plural, fields)
+        render_columns_vec(pascal_name, plural, fields, &reference_displays, false)
+    };
+    let index_label_loads = if live || sharded {
+        String::new()
+    } else {
+        render_index_reference_label_loads(&reference_fields, &reference_displays)
+    };
+    // `mut db: Db` is only added to the plain index signature when there is at
+    // least one label map to load — otherwise it would be an unused extractor.
+    let index_db_param = if index_label_loads.is_empty() {
+        ""
+    } else {
+        "mut db: Db,\n    "
+    };
+    let index_columns_labeled = if index_label_loads.is_empty() {
+        columns_let.clone()
+    } else {
+        render_columns_vec(pascal_name, plural, fields, &reference_displays, true)
     };
     let table_render = if live {
         String::new()
@@ -1965,7 +1999,10 @@ fn render_routes_file(
     };
 
     let list_render = if live { &live_ul_render } else { &table_render };
-    let show_rows = render_show_property_rows(all_fields);
+    let show_rows = render_show_property_rows(all_fields, &reference_displays);
+    // The `show` handler pre-loads each displayable reference's parent label
+    // (issue #1146) before building its property rows.
+    let show_label_loads = render_show_reference_label_loads(all_fields, &reference_displays);
 
     let index_handler = if sharded {
         if live {
@@ -2048,10 +2085,10 @@ pub async fn index(
 pub async fn index(
     page_req: PageRequest,
     repo: Pg{pascal_name}Repository,
-    flash: Flash,
+    {index_db_param}flash: Flash,
 ) -> AutumnResult<Markup> {{
     let page_data: Page<{pascal_name}> = repo.page(&page_req).await?;
-{columns_let}    Ok({layout_fn}("{pascal_name} index", {cp_index}{flash_arg}, html! {{
+{index_label_loads}{index_columns_labeled}    Ok({layout_fn}("{pascal_name} index", {cp_index}{flash_arg}, html! {{
         h1 {{ "{pascal_name}s" }}
         a href="/{plural}/new" {{ "New {pascal_name}" }}
         {list_render}
@@ -2273,7 +2310,7 @@ pub async fn show(id: Path<{id_rust}>, mut db: {db_ty}, flash: Flash) -> AutumnR
         .first(&mut *db)
         .await
         .map_err(AutumnError::not_found)?;
-    let props: Vec<(&str, maud::Markup)> = vec![
+{show_label_loads}    let props: Vec<(&str, maud::Markup)> = vec![
 {show_rows}    ];
     Ok({layout_fn}(&format!("{pascal_name} #{{}}", row.id), {cp_show}{flash_arg}, html! {{
         h1 {{ "{pascal_name} #" (row.id) }}
@@ -2658,7 +2695,11 @@ fn render_form_for_helper(
 /// makes a human-friendly label is a display decision the generator can't
 /// know, so the generated doc comment tells the author where to swap in a
 /// real label column.
-fn render_reference_option_loaders(reference_fields: &[&Field], db_ty: &str) -> String {
+fn render_reference_option_loaders(
+    reference_fields: &[&Field],
+    db_ty: &str,
+    reference_displays: &BTreeMap<String, ReferenceDisplay>,
+) -> String {
     use std::fmt::Write as _;
     let mut out = String::new();
     for f in reference_fields {
@@ -2666,25 +2707,99 @@ fn render_reference_option_loaders(reference_fields: &[&Field], db_ty: &str) -> 
         let Some(table) = f.reference_table() else {
             continue;
         };
-        let _ = write!(
-            out,
-            "/// Load the `(value, label)` select options for the `{name}` reference —\n\
-             /// one option per `{table}` row, ordered by id (issue #1135).\n\
-             ///\n\
-             /// Labels are the row id rendered as a string: which `{table}` column makes\n\
-             /// a human-friendly label is a display decision the generator can't know —\n\
-             /// swap the `map` below to use a real label column.\n\
-             async fn {name}_select_options(db: &mut {db_ty}) -> AutumnResult<Vec<(String, String)>> {{\n    \
-             let ids: Vec<i64> = {table}::table\n        \
-             .select({table}::id)\n        \
-             .order({table}::id.asc())\n        \
-             .load(&mut **db)\n        \
-             .await?;\n    \
-             Ok(ids.into_iter().map(|id| (id.to_string(), id.to_string())).collect())\n\
-             }}\n\n"
-        );
+        match reference_displays.get(name) {
+            // A display column was resolved (issue #1146): load `(id, label)`
+            // pairs so the `<select>` shows a human-friendly value, not the
+            // raw id. A nullable display column coalesces to the id string.
+            Some(display) => {
+                let column = &display.column;
+                let (load_ty, label_expr) = if display.column_nullable {
+                    ("Option<String>", "label.unwrap_or_else(|| id.to_string())")
+                } else {
+                    ("String", "label")
+                };
+                let _ = write!(
+                    out,
+                    "/// Load the `(value, label)` select options for the `{name}` reference —\n\
+                     /// one option per `{table}` row (value = id, label = `{column}`), ordered\n\
+                     /// by id (issues #1135, #1146).\n\
+                     async fn {name}_select_options(db: &mut {db_ty}) -> AutumnResult<Vec<(String, String)>> {{\n    \
+                     let rows: Vec<(i64, {load_ty})> = {table}::table\n        \
+                     .select(({table}::id, {table}::{column}))\n        \
+                     .order({table}::id.asc())\n        \
+                     .load(&mut **db)\n        \
+                     .await?;\n    \
+                     Ok(rows.into_iter().map(|(id, label)| (id.to_string(), {label_expr})).collect())\n\
+                     }}\n\n"
+                );
+            }
+            // No string column to display (or the target model couldn't be
+            // parsed): fall back to the id as both value and label.
+            None => {
+                let _ = write!(
+                    out,
+                    "/// Load the `(value, label)` select options for the `{name}` reference —\n\
+                     /// one option per `{table}` row, ordered by id (issue #1135).\n\
+                     ///\n\
+                     /// `{table}` has no string column to label options with, so the id is\n\
+                     /// used as both value and label — swap the `map` below to use a real\n\
+                     /// label column once one exists.\n\
+                     async fn {name}_select_options(db: &mut {db_ty}) -> AutumnResult<Vec<(String, String)>> {{\n    \
+                     let ids: Vec<i64> = {table}::table\n        \
+                     .select({table}::id)\n        \
+                     .order({table}::id.asc())\n        \
+                     .load(&mut **db)\n        \
+                     .await?;\n    \
+                     Ok(ids.into_iter().map(|id| (id.to_string(), id.to_string())).collect())\n\
+                     }}\n\n"
+                );
+            }
+        }
     }
     out
+}
+
+/// How a `references` field's parent row should be *displayed* (issue #1146):
+/// the referenced `table`, the `column` whose value labels the parent, and
+/// whether that column is nullable (`Option<String>`).
+///
+/// Resolved from the referenced model at scaffold time via
+/// [`resolve_reference_display`] — an explicit `{label:col}` override, else a
+/// `name`/`title`/first-string-column heuristic. `None` (no entry) means the
+/// target has no string column, so the raw id is rendered as a fallback.
+#[derive(Debug, Clone)]
+struct ReferenceDisplay {
+    column: String,
+    column_nullable: bool,
+}
+
+/// Resolve the display column for a `references` field against its target
+/// model (issue #1146): an explicit `{label:col}` override wins; otherwise a
+/// `name`/`title` column is preferred, else the first `String`/`Text` column.
+/// Returns `None` when the target model has no string column (render the id).
+fn resolve_reference_display(project_root: &Path, field: &Field) -> Option<ReferenceDisplay> {
+    let base = field.name.strip_suffix("_id").unwrap_or(&field.name);
+    let columns = super::model::model_string_columns(project_root, base);
+    let (column, column_nullable) = if let Some(label) = &field.constraints.label {
+        // Explicit override: trust the author's column name, using its known
+        // nullability when we can see it (else assume a non-null String).
+        let nullable = columns
+            .iter()
+            .find(|(c, _)| c == label)
+            .is_some_and(|(_, n)| *n);
+        (label.clone(), nullable)
+    } else {
+        let chosen = columns
+            .iter()
+            .find(|(c, _)| c == "name")
+            .or_else(|| columns.iter().find(|(c, _)| c == "title"))
+            .or_else(|| columns.first())?;
+        (chosen.0.clone(), chosen.1)
+    };
+    Some(ReferenceDisplay {
+        column,
+        column_nullable,
+    })
 }
 
 /// Render the form inputs for a scaffold's `--live-validation` new/edit/
@@ -2944,7 +3059,13 @@ fn cell_value_expr(field: &Field) -> String {
 /// Includes an "Id" column, one column per scaffold field (title-cased header),
 /// and a trailing "Show" actions column. All columns are non-sortable — server-side
 /// ordering per-column is out of scope; dead sort links would be worse than none.
-fn render_columns_vec(pascal_name: &str, plural: &str, fields: &[Field]) -> String {
+fn render_columns_vec(
+    pascal_name: &str,
+    plural: &str,
+    fields: &[Field],
+    reference_displays: &BTreeMap<String, ReferenceDisplay>,
+    use_label_maps: bool,
+) -> String {
     use std::fmt::Write as _;
     let mut out = String::with_capacity(fields.len() * 150 + 300);
     let _ = writeln!(
@@ -2959,7 +3080,27 @@ fn render_columns_vec(pascal_name: &str, plural: &str, fields: &[Field]) -> Stri
     // One column per field
     for f in fields {
         let header = title_case(&f.name);
-        let cell_expr = cell_value_expr(f);
+        // A displayable `references` column renders the parent's label from
+        // the per-view `{name}_labels` map the handler loaded (issue #1146),
+        // instead of the raw foreign-key id. The closure borrows the map,
+        // which outlives the `columns` vec in the generated handler.
+        let cell_expr = if use_label_maps
+            && f.kind.is_reference()
+            && reference_displays.contains_key(&f.name)
+        {
+            let name = &f.name;
+            if f.nullable {
+                format!(
+                    "match &row.{name} {{ Some(v) => {name}_labels.get(&v.to_string()).map(String::as_str).unwrap_or(\"—\"), None => \"—\" }}"
+                )
+            } else {
+                format!(
+                    "{name}_labels.get(&row.{name}.to_string()).map(String::as_str).unwrap_or(\"—\")"
+                )
+            }
+        } else {
+            cell_value_expr(f)
+        };
         let _ = writeln!(
             out,
             "        autumn_web::widgets::Column::new(\"{header}\", |row: &{pascal_name}| maud::html! {{ ({cell_expr}) }}),"
@@ -2977,13 +3118,23 @@ fn render_columns_vec(pascal_name: &str, plural: &str, fields: &[Field]) -> Stri
 /// Emit the `vec![…]` body for the `props` binding in the `show` handler.
 ///
 /// Produces one `("Label", maud::html! { value_expr })` tuple per row:
-/// `id`, every DSL-declared field (humanized label), then `created_at`.
-fn render_show_property_rows(fields: &[Field]) -> String {
+/// `id`, every DSL-declared field (humanized label), then `created_at`. A
+/// `references` field with a resolved display (issue #1146) renders the
+/// pre-loaded `{name}_label` variable (the parent's display value) instead of
+/// the raw foreign-key id — see [`render_show_reference_label_loads`].
+fn render_show_property_rows(
+    fields: &[Field],
+    reference_displays: &BTreeMap<String, ReferenceDisplay>,
+) -> String {
     let mut out = String::with_capacity(fields.len() * 100 + 150);
     out.push_str("        (\"Id\", maud::html! { (row.id) }),\n");
     for f in fields {
         let label = humanize(&f.name);
-        let cell_expr = cell_value_expr(f);
+        let cell_expr = if f.kind.is_reference() && reference_displays.contains_key(&f.name) {
+            format!("{}_label", f.name)
+        } else {
+            cell_value_expr(f)
+        };
         out.push_str("        (\"");
         out.push_str(&label);
         out.push_str("\", maud::html! { (");
@@ -2991,6 +3142,81 @@ fn render_show_property_rows(fields: &[Field]) -> String {
         out.push_str(") }),\n");
     }
     out.push_str("        (\"Created at\", maud::html! { (row.created_at.to_string()) }),\n");
+    out
+}
+
+/// Emit the `let {name}_label: String = …;` bindings the `show` handler
+/// evaluates before building its `props`, one per `references` field with a
+/// resolved display column (issue #1146). Each does a single per-view lookup
+/// of the parent's display value (the batched variant is out of scope, #835),
+/// falling back to the id string if the parent row (or its display value) is
+/// missing. Empty when the resource has no displayable references.
+fn render_show_reference_label_loads(
+    fields: &[Field],
+    reference_displays: &BTreeMap<String, ReferenceDisplay>,
+) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    for f in fields {
+        let Some(display) = reference_displays.get(&f.name) else {
+            continue;
+        };
+        let Some(table) = f.reference_table() else {
+            continue;
+        };
+        let name = &f.name;
+        let column = &display.column;
+        // A nullable display column comes back as `Option<String>` and is
+        // flattened; a non-null one as `String`. Both coalesce to the id on a
+        // miss so the show page never renders a bare blank for a real FK.
+        let found_expr = if display.column_nullable {
+            format!(
+                "{table}::table.find(fk).select({table}::{column}).first::<Option<String>>(&mut *db).await.ok().flatten().unwrap_or_else(|| fk.to_string())"
+            )
+        } else {
+            format!(
+                "{table}::table.find(fk).select({table}::{column}).first::<String>(&mut *db).await.unwrap_or_else(|_| fk.to_string())"
+            )
+        };
+        if f.nullable {
+            let _ = writeln!(
+                out,
+                "    let {name}_label: String = match row.{name} {{ Some(fk) => {found_expr}, None => \"—\".to_string() }};"
+            );
+        } else {
+            let _ = writeln!(
+                out,
+                "    let {name}_label: String = {{ let fk = row.{name}; {found_expr} }};"
+            );
+        }
+    }
+    out
+}
+
+/// Emit the `let {name}_labels: HashMap<String, String> = …;` bindings the
+/// plain (non-sharded) `index` handler evaluates before building its data-table
+/// columns, one per `references` field with a resolved display column
+/// (issue #1146). Each reuses the field's `{name}_select_options` loader (a
+/// simple per-view fetch; the batched variant is out of scope, #835) to map
+/// each parent id string to its display label, which the column closures then
+/// look up per row. Empty when the resource has no displayable references.
+fn render_index_reference_label_loads(
+    reference_fields: &[&Field],
+    reference_displays: &BTreeMap<String, ReferenceDisplay>,
+) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    for f in reference_fields {
+        if !reference_displays.contains_key(&f.name) {
+            continue;
+        }
+        let name = &f.name;
+        let _ = writeln!(
+            out,
+            "    let {name}_labels: std::collections::HashMap<String, String> =\n        \
+             {name}_select_options(&mut db).await?.into_iter().collect();"
+        );
+    }
     out
 }
 
@@ -8202,14 +8428,16 @@ async fn main() {
                 nullable: false,
                 variants: Vec::new(),
                 unique: false,
-                constraints: Default::default(),            },
+                constraints: Default::default(),
+            },
             Field {
                 name: "author_id".to_string(),
                 kind: FieldKind::References,
                 nullable: true,
                 variants: Vec::new(),
                 unique: false,
-                constraints: Default::default(),            },
+                constraints: Default::default(),
+            },
         ];
         assert_eq!(
             fields[0].reference_table(),
@@ -8255,14 +8483,16 @@ async fn main() {
                 nullable: false,
                 variants: Vec::new(),
                 unique: false,
-                constraints: Default::default(),            },
+                constraints: Default::default(),
+            },
             Field {
                 name: "author_id".to_string(),
                 kind: FieldKind::References,
                 nullable: true,
                 variants: Vec::new(),
                 unique: false,
-                constraints: Default::default(),            },
+                constraints: Default::default(),
+            },
         ];
         let sql = render_reference_stub_tables_sql(&fields, "unrelated_table");
         assert_eq!(
@@ -8363,7 +8593,8 @@ async fn main() {
             nullable: false,
             variants: vec!["a".to_string(), "b".to_string()],
             unique: false,
-            constraints: Default::default(),        };
+            constraints: Default::default(),
+        };
         let weight = Field {
             name: "weight".to_string(),
             kind: FieldKind::Decimal {
@@ -8373,7 +8604,8 @@ async fn main() {
             nullable: false,
             variants: Vec::new(),
             unique: false,
-            constraints: Default::default(),        };
+            constraints: Default::default(),
+        };
         let fields = vec![status.clone(), weight];
         let sql = enum_rejection_insert_sql("items", &fields, &status, &BTreeMap::new());
         assert!(

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1496,23 +1496,28 @@ fn render_routes_file(
     let update_columns = render_update_columns(plural, fields);
     let nullable_field_match = render_nullable_field_match(fields);
     let has_attachments = has_attachment_fields(fields);
-    // `references` columns render as a `<select>` of the referenced table's
-    // ids (issue #1135 AC 2: "enum/references→select"). The options are
-    // runtime data, so the handlers that render the form load them and pass
-    // them into the shared `{snake}_form_for` helper. `--live-validation`
-    // keeps the old per-field emission (no `form_for`), so no options are
-    // loaded there. Columns in `missing_reference_targets` (their referenced
-    // model — and therefore its `src/schema.rs` entry — isn't in the project)
-    // are left out entirely: no loader, no schema import, no Select override,
-    // so they fall back to the derived numeric id input and the generated
-    // file still compiles (the caller warned about the downgrade).
+    // Every PRESENT `references` field (its target model — and so its
+    // `src/schema.rs` entry — is in the project; `missing_reference_targets`
+    // excludes the rest, which the caller already warned about and which fall
+    // back to a numeric id). This drives the issue #1146 parent-DISPLAY
+    // rendering on index/show, which is generator-emitted *view* markup
+    // (`posts::table.find(fk).select(posts::title)`), independent of the form
+    // control — so it applies in `--live-validation` mode too.
+    let display_reference_fields: Vec<&Field> = fields
+        .iter()
+        .filter(|f| f.kind.is_reference() && !missing_reference_targets.contains(&f.name))
+        .collect();
+    // The subset that also renders an in-FORM `<select>` of the referenced
+    // table's ids (issue #1135 AC 2) plus its runtime option loaders.
+    // `--live-validation` renders the form through the per-field path (no
+    // `form_for`, and `select_input` takes only static options, so a
+    // runtime-option belongs_to `<select>` can't be wired through it without
+    // the same cross-crate form-helper change #1750 tracks): skip the dropdown
+    // + loaders there, but KEEP the index/show display rendering above.
     let reference_fields: Vec<&Field> = if live_validation {
         Vec::new()
     } else {
-        fields
-            .iter()
-            .filter(|f| f.kind.is_reference() && !missing_reference_targets.contains(&f.name))
-            .collect()
+        display_reference_fields.clone()
     };
     let has_reference_selects = !reference_fields.is_empty();
 
@@ -1555,8 +1560,9 @@ fn render_routes_file(
     // index columns, and show rows render the parent's display column (a
     // `name`/`title`/first-string heuristic, or an explicit `{label:col}`)
     // instead of the raw foreign-key id. A reference whose target has no
-    // string column has no entry here and keeps rendering the id.
-    let reference_displays: BTreeMap<String, ReferenceDisplay> = reference_fields
+    // string column has no entry here and keeps rendering the id. Resolved from
+    // the display-scoped set so it's populated in `--live-validation` too.
+    let reference_displays: BTreeMap<String, ReferenceDisplay> = display_reference_fields
         .iter()
         .filter_map(|f| resolve_reference_display(project_root, f).map(|d| (f.name.clone(), d)))
         .collect();
@@ -1791,7 +1797,15 @@ fn render_routes_file(
              }}\n    \
              }})"
         );
-        (new_form_body, edit_form_body, String::new())
+        // The in-form belongs_to `<select>` is deferred in `--live-validation`
+        // (#1750), but the referenced-row option loaders are still emitted: the
+        // issue #1146 index parent-label map is built by collecting each
+        // `{name}_select_options(...)` into a `HashMap` (see
+        // `render_index_reference_label_loads`), so the loaders are a live
+        // dependency of the restored index display, not dead code.
+        let option_loaders =
+            render_reference_option_loaders(&display_reference_fields, db_ty, &reference_displays);
+        (new_form_body, edit_form_body, option_loaders)
     } else {
         // Reference selects: load the referenced ids before rendering and
         // thread them into the shared helper (issue #1135, AC 2
@@ -2016,7 +2030,7 @@ fn render_routes_file(
     let index_label_loads = if live || sharded {
         String::new()
     } else {
-        render_index_reference_label_loads(&reference_fields, &reference_displays)
+        render_index_reference_label_loads(&display_reference_fields, &reference_displays)
     };
     // `mut db: Db` is only added to the plain index signature when there is at
     // least one label map to load — otherwise it would be an unused extractor.
@@ -2154,15 +2168,16 @@ pub async fn index(
             .to_owned()
     };
 
-    // Schema imports: the resource's own table, plus — when reference selects
-    // are rendered — each referenced table so its ids can be loaded for the
-    // select options. Only targets that are actually present in the project
-    // reach this point (`reference_fields` already excludes
-    // `missing_reference_targets`): importing a table whose `diesel::table!`
-    // entry doesn't exist in `src/schema.rs` would fail to compile, and a
-    // missing target has always been a warning, not an error.
+    // Schema imports: the resource's own table, plus each referenced table so
+    // its rows can be loaded — for the form select options AND for the
+    // index/show parent-display label loads (issue #1146), which is why this
+    // uses the display-scoped set (populated even in `--live-validation`, where
+    // the form select is skipped but the display loads remain). Only present
+    // targets reach here (`missing_reference_targets` excluded): importing a
+    // table whose `diesel::table!` entry doesn't exist would fail to compile,
+    // and a missing target has always been a warning, not an error.
     let schema_import = {
-        let mut extra_tables: BTreeSet<String> = reference_fields
+        let mut extra_tables: BTreeSet<String> = display_reference_fields
             .iter()
             .filter_map(|f| f.reference_table())
             .collect();

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -2021,32 +2021,41 @@ fn render_routes_file(
         String::new()
     };
 
-    // For non-live paths, generate the data_table columns and call. The
-    // sharded index uses the id-based columns (`columns_let`); the plain
-    // non-sharded index promotes displayable `references` columns to render
-    // the parent's label from a per-view label map (issue #1146,
-    // `index_columns_labeled` + `index_label_loads`). Sharded/live keep the id
-    // rendering — their connection shape (`ShardedDb`) / list markup (a `<ul>`
-    // of ids) don't take the plain `Db`-loaded map.
+    // For non-live paths, generate the data_table columns and call. Both the
+    // plain AND sharded index promote displayable `references` columns to
+    // render the parent's label from a per-view label map (issue #1146,
+    // `index_columns_labeled` + `index_label_loads`): the sharded index handler
+    // already threads a `ShardedDb`, its `{name}_select_options` loaders are
+    // generated with `db_ty` (= `ShardedDb`), and the sharded `show` handler
+    // already loads labels through the same connection — so the index reuses
+    // that mechanism rather than falling back to raw ids. Only the `--live` SSE
+    // list (a `<ul>` of ids, no data-table) keeps id rendering.
     let columns_let = if live {
         String::new()
     } else {
         render_columns_vec(pascal_name, plural, fields, &reference_displays, false)
     };
-    let index_label_loads = if live || sharded {
+    let index_label_loads = if live {
         String::new()
     } else {
         render_index_reference_label_loads(&display_reference_fields, &reference_displays)
     };
-    // `mut db: Db` is only added to the plain index signature when there is at
-    // least one label map to load — otherwise it would be an unused extractor.
+    // The plain index gains `mut db: Db` only when there is a label map to load
+    // (otherwise an unused extractor); the sharded index always has a
+    // `ShardedDb` (for `from_shard`), promoted to `mut` when it must also run
+    // the loader.
     let index_db_param = if index_label_loads.is_empty() {
         ""
     } else {
         "mut db: Db,\n    "
     };
+    let sharded_index_db = if index_label_loads.is_empty() {
+        "db: ShardedDb"
+    } else {
+        "mut db: ShardedDb"
+    };
     let index_columns_labeled = if index_label_loads.is_empty() {
-        columns_let.clone()
+        columns_let
     } else {
         render_columns_vec(pascal_name, plural, fields, &reference_displays, true)
     };
@@ -2098,12 +2107,12 @@ pub async fn index(
 #[get("/{plural}")]
 pub async fn index(
     page_req: PageRequest,
-    db: ShardedDb,
+    {sharded_index_db},
     flash: Flash,
 ) -> AutumnResult<Markup> {{
     let repo = Pg{pascal_name}Repository::from_shard(&db);
     let page_data: Page<{pascal_name}> = repo.page(&page_req).await?;
-{columns_let}    Ok({layout_fn}("{pascal_name} index", {cp_index}{flash_arg}, html! {{
+{index_label_loads}{index_columns_labeled}    Ok({layout_fn}("{pascal_name} index", {cp_index}{flash_arg}, html! {{
         h1 {{ "{pascal_name}s" }}
         a href="/{plural}/new" {{ "New {pascal_name}" }}
         {list_render}

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -448,7 +448,10 @@ pub fn plan_scaffold_with_options(
             continue;
         };
         let base = f.name.strip_suffix("_id").unwrap_or(&f.name);
-        let columns = super::model::model_string_columns(project_root, base);
+        // Self-ref-aware: a self-reference's columns come from the in-flight
+        // fields, so `Category category:references{label:name}` doesn't warn
+        // that the not-yet-on-disk model "has no string columns".
+        let columns = target_string_columns(project_root, f, &plural, &form_fields);
         if !columns.iter().any(|(c, _)| c == label) {
             // Covers both a wrong column name AND a target with no string
             // columns at all — in the latter case there is nothing to fall back
@@ -1564,7 +1567,10 @@ fn render_routes_file(
     // the display-scoped set so it's populated in `--live-validation` too.
     let reference_displays: BTreeMap<String, ReferenceDisplay> = display_reference_fields
         .iter()
-        .filter_map(|f| resolve_reference_display(project_root, f).map(|d| (f.name.clone(), d)))
+        .filter_map(|f| {
+            resolve_reference_display(project_root, f, plural, all_fields)
+                .map(|d| (f.name.clone(), d))
+        })
         .collect();
     let model_form = render_model_form(pascal_name, fields, validations);
     // Enum fields need their generated Rust type in scope here — `into_new`
@@ -2870,13 +2876,48 @@ struct ReferenceDisplay {
     column_nullable: bool,
 }
 
+/// The `(name, nullable)` string (`String`/`Text`) columns of a `references`
+/// field's target (issue #1146). For a **self-reference** (the target table is
+/// the model being generated right now) there is no `src/models/<x>.rs` on disk
+/// yet, so the columns come from the in-flight `own_fields`; every other target
+/// is read from disk via [`super::model::model_string_columns`].
+fn target_string_columns(
+    project_root: &Path,
+    field: &Field,
+    self_plural: &str,
+    own_fields: &[Field],
+) -> Vec<(String, bool)> {
+    if field.reference_table().as_deref() == Some(self_plural) {
+        own_fields
+            .iter()
+            .filter(|f| matches!(f.kind, FieldKind::String | FieldKind::Text))
+            .map(|f| (f.name.clone(), f.nullable))
+            .collect()
+    } else {
+        let base = field.name.strip_suffix("_id").unwrap_or(&field.name);
+        super::model::model_string_columns(project_root, base)
+    }
+}
+
 /// Resolve the display column for a `references` field against its target
 /// model (issue #1146): an explicit `{label:col}` override wins; otherwise a
 /// `name`/`title` column is preferred, else the first `String`/`Text` column.
 /// Returns `None` when the target model has no string column (render the id).
-fn resolve_reference_display(project_root: &Path, field: &Field) -> Option<ReferenceDisplay> {
+///
+/// A **self-reference** (the target table is the model being generated right
+/// now — e.g. `Category category:references`) has no `src/models/<x>.rs` on
+/// disk yet, so its display column is resolved from the in-flight `own_fields`
+/// (the columns being generated this invocation) rather than the filesystem.
+/// References to OTHER models still resolve via the on-disk lookup.
+fn resolve_reference_display(
+    project_root: &Path,
+    field: &Field,
+    self_plural: &str,
+    own_fields: &[Field],
+) -> Option<ReferenceDisplay> {
     let base = field.name.strip_suffix("_id").unwrap_or(&field.name);
-    let columns = super::model::model_string_columns(project_root, base);
+    let is_self_ref = field.reference_table().as_deref() == Some(self_plural);
+    let columns = target_string_columns(project_root, field, self_plural, own_fields);
     // The `name`/`title`/first-string-column heuristic, reused both when no
     // explicit label is given and when an explicit one has to be discarded.
     let heuristic = || {
@@ -2892,9 +2933,10 @@ fn resolve_reference_display(project_root: &Path, field: &Field) -> Option<Refer
             // Explicit override names a real string column on the target — use
             // it, with its known nullability.
             (c.clone(), *n)
-        } else if field
-            .reference_table()
-            .is_some_and(|table| !super::model::model_file_exists(project_root, &table, base))
+        } else if !is_self_ref
+            && field
+                .reference_table()
+                .is_some_and(|table| !super::model::model_file_exists(project_root, &table, base))
         {
             // The target model genuinely isn't discoverable (not yet generated,
             // unparseable, or a single-file `models.rs` layout we can't read),
@@ -2902,7 +2944,8 @@ fn resolve_reference_display(project_root: &Path, field: &Field) -> Option<Refer
             // non-null `String`), matching the "assume the table exists" posture
             // the missing-target path takes. Not reachable on the normal select
             // path (missing targets are excluded upstream), but keeps the
-            // resolver correct for any other caller.
+            // resolver correct for any other caller. A self-reference IS
+            // discoverable (via `own_fields`), so it never takes this branch.
             (label.clone(), false)
         } else {
             // The model IS discoverable but `{label}` names no string column —

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -432,6 +432,37 @@ pub fn plan_scaffold_with_options(
             ));
         }
     }
+    // An explicit `{label:col}` override that names a column the target model
+    // doesn't expose as a string would generate a `select {table}::{col}`
+    // (loaded as `String`) that fails to compile the generated app. The display
+    // resolver falls back to the heuristic display column in that case
+    // (see `resolve_reference_display`), so warn the author their label was
+    // ignored rather than silently swapping it. Skipped for a missing target
+    // (already warned above) and when the model isn't discoverable (the
+    // override can't be validated, so it's honored as-is).
+    for f in form_fields.iter().filter(|f| f.kind.is_reference()) {
+        if missing_reference_targets.contains(&f.name) {
+            continue;
+        }
+        let Some(label) = &f.constraints.label else {
+            continue;
+        };
+        let base = f.name.strip_suffix("_id").unwrap_or(&f.name);
+        let columns = super::model::model_string_columns(project_root, base);
+        if !columns.is_empty() && !columns.iter().any(|(c, _)| c == label) {
+            plan.warn(format!(
+                "reference label '{label}' on '{}' is not a string column of the '{base}' \
+                 model; falling back to its default display column. Available string \
+                 columns: {}.",
+                f.name,
+                columns
+                    .iter()
+                    .map(|(c, _)| c.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+    }
 
     // Repository file under `src/repositories/<snake>.rs`
     let repos_dir = project_root.join("src").join("repositories");
@@ -2818,21 +2849,39 @@ struct ReferenceDisplay {
 fn resolve_reference_display(project_root: &Path, field: &Field) -> Option<ReferenceDisplay> {
     let base = field.name.strip_suffix("_id").unwrap_or(&field.name);
     let columns = super::model::model_string_columns(project_root, base);
-    let (column, column_nullable) = if let Some(label) = &field.constraints.label {
-        // Explicit override: trust the author's column name, using its known
-        // nullability when we can see it (else assume a non-null String).
-        let nullable = columns
-            .iter()
-            .find(|(c, _)| c == label)
-            .is_some_and(|(_, n)| *n);
-        (label.clone(), nullable)
-    } else {
-        let chosen = columns
+    // The `name`/`title`/first-string-column heuristic, reused both when no
+    // explicit label is given and when an explicit one has to be discarded.
+    let heuristic = || {
+        columns
             .iter()
             .find(|(c, _)| c == "name")
             .or_else(|| columns.iter().find(|(c, _)| c == "title"))
-            .or_else(|| columns.first())?;
-        (chosen.0.clone(), chosen.1)
+            .or_else(|| columns.first())
+            .map(|(c, n)| (c.clone(), *n))
+    };
+    let (column, column_nullable) = if let Some(label) = &field.constraints.label {
+        if let Some((c, n)) = columns.iter().find(|(c, _)| c == label) {
+            // Explicit override names a real string column on the target — use
+            // it, with its known nullability.
+            (c.clone(), *n)
+        } else if columns.is_empty() {
+            // The target model isn't discoverable at scaffold time (not yet
+            // generated, unparseable, or a single-file `models.rs` layout we
+            // can't read), so the override can't be validated. Honor it as
+            // before (assume a non-null `String`), matching the "assume the
+            // table exists" posture the missing-target path already takes.
+            (label.clone(), false)
+        } else {
+            // The model IS discoverable and exposes string columns, but none is
+            // named `{label}` — a typo, or a non-string column. Emitting
+            // `select {table}::{label}` (loaded as `String`) would fail to
+            // compile the generated app, so fall back to the heuristic display
+            // column: generation still succeeds, and the plan carries a warning
+            // (emitted in `execute`) telling the author the label was ignored.
+            heuristic()?
+        }
+    } else {
+        heuristic()?
     };
     Some(ReferenceDisplay {
         column,
@@ -3013,8 +3062,10 @@ fn decimal_step(scale: u32) -> String {
 ///
 /// `String`/`Text`: `min`/`max` -> `minlength`/`maxlength`, `email` ->
 /// `type="email"`, `url` -> `type="url"`. Numeric: `min`/`max` -> `min`/`max`
-/// on a `type="number"` input. Returned attribute string is space-prefixed and
-/// ready to splice straight into the generated maud `input`.
+/// on a `type="number"` input, and float (`f32`/`f64`) fields also carry
+/// `step="any"` so fractional input isn't rejected client-side. Returned
+/// attribute string is space-prefixed and ready to splice straight into the
+/// generated maud `input`.
 fn html5_constraint_spec(field: &Field) -> Option<(&'static str, String)> {
     use std::fmt::Write as _;
     let c = &field.constraints;
@@ -3035,12 +3086,34 @@ fn html5_constraint_spec(field: &Field) -> Option<(&'static str, String)> {
                 "text"
             }
         }
-        FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64 => {
+        FieldKind::I32 | FieldKind::I64 => {
             if let Some(min) = &c.min {
                 let _ = write!(attrs, " min=\"{min}\"");
             }
             if let Some(max) = &c.max {
                 let _ = write!(attrs, " max=\"{max}\"");
+            }
+            "number"
+        }
+        FieldKind::F32 | FieldKind::F64 => {
+            if let Some(min) = &c.min {
+                let _ = write!(attrs, " min=\"{min}\"");
+            }
+            if let Some(max) = &c.max {
+                let _ = write!(attrs, " max=\"{max}\"");
+            }
+            // A constrained float must keep `step="any"` — the same step the
+            // unconstrained float control (`FieldControl::Number { step: "any" }`)
+            // emits. Without it browsers default a `type="number"` input to
+            // `step="1"` and reject fractional input like `0.5` for
+            // `ratio:f64{min=0,max=1}` client-side, even though the server-side
+            // `range` validator and the `f64` type accept it (issue #1388's
+            // "client and server agree"). Only emitted when the field is
+            // actually constrained (min/max present, so `attrs` is non-empty);
+            // otherwise the early-return below keeps the field in the derived
+            // render rather than needlessly excising it.
+            if !attrs.is_empty() {
+                let _ = write!(attrs, " step=\"any\"");
             }
             "number"
         }

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1326,6 +1326,21 @@ fn render_model_form(
                     | FieldKind::Decimal { .. }
                     | FieldKind::References
             )
+            // A numeric field carrying a `{min,max}` range constraint (issue
+            // #1388) must keep its NATIVE type on the form struct, not the
+            // String representation below: `validator`'s `range` rule only
+            // applies to numeric types, so `#[validate(range(...))]` on a
+            // `String` field fails to compile — and the whole point of the
+            // constraint is that the range is rejected server-side through the
+            // changeset (a 422 with an inline error), which needs the rule on
+            // the form the changeset validates. The `T::default()` pre-fill
+            // trade-off the String representation avoids is moot here: the
+            // field is `required` and range-bounded, so a deliberate value is
+            // forced anyway.
+            && !(matches!(
+                f.kind,
+                FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64
+            ) && (f.constraints.min.is_some() || f.constraints.max.is_some()))
         {
             // Represented as a `String` on the form, exactly like a required
             // enum/datetime field: `T::default()` for these kinds (`0`, the nil
@@ -2562,7 +2577,45 @@ fn render_form_for_helper(
                     "\n        .override_field(\"{name}\", autumn_web::form::FieldControl::Select {{ options: {name}_select }})"
                 );
             }
-            _ => {}
+            // A `String`/`Text`/numeric field carrying DSL constraint
+            // modifiers (issue #1388) needs HTML5 attributes the derived
+            // `FieldControl` can't express (`minlength`/`maxlength`,
+            // `min`/`max`, `type="email"`/`type="url"`). Exclude it from the
+            // derived render and append an equivalent control that carries the
+            // constraints — the same `.exclude()` + `.append()` escape hatch
+            // the attachment arm uses. The value is re-filled from the
+            // changeset so the 422 re-render keeps entered input, and the
+            // inline-error/ARIA skeleton matches the derived controls.
+            _ => {
+                if let Some((input_type, constraint_attrs)) = html5_constraint_spec(f) {
+                    let label = humanize_label(name);
+                    let required_attr = if f.nullable {
+                        ""
+                    } else {
+                        " required aria-required=\"true\""
+                    };
+                    let _ = write!(builder_calls, "\n        .exclude(\"{name}\")");
+                    let _ = write!(
+                        appends,
+                        "\n        .append(html! {{\n            \
+                         @let errors = changeset.errors_for(\"{name}\");\n            \
+                         div id=\"{name}-field\" class=\"autumn-field\" {{\n                \
+                         label for=\"{name}\" class=\"autumn-field__label\" {{ \"{label}\" }}\n                \
+                         input type=\"{input_type}\" id=\"{name}\" name=\"{name}\"\n                    \
+                         value=(changeset.field_value(\"{name}\").unwrap_or_default()){constraint_attrs}{required_attr}\n                    \
+                         class=(if errors.is_empty() {{ \"autumn-field__input\" }} else {{ \"autumn-field__input autumn-field__input--invalid\" }})\n                    \
+                         aria-invalid=(if errors.is_empty() {{ \"false\" }} else {{ \"true\" }})\n                    \
+                         aria-describedby=(if errors.is_empty() {{ \"\" }} else {{ \"{name}-error\" }});\n                \
+                         @if !errors.is_empty() {{\n                    \
+                         div id=\"{name}-error\" role=\"alert\" class=\"autumn-field__errors\" {{\n                        \
+                         @for error in errors {{ p class=\"autumn-field__error\" {{ (error) }} }}\n                    \
+                         }}\n                \
+                         }}\n            \
+                         }}\n        \
+                         }})"
+                    );
+                }
+            }
         }
     }
     format!(
@@ -2799,6 +2852,54 @@ fn decimal_literal_at_scale(scale: u32, digit: u32) -> String {
 /// increment (unlike float fields, whose `step="any"` accepts any input).
 fn decimal_step(scale: u32) -> String {
     decimal_literal_at_scale(scale, 1)
+}
+
+/// The HTML5 `<input>` type and constraint-attribute string a field's DSL
+/// constraint modifiers (issue #1388) render to, or `None` when the field has
+/// no HTML5 fan-out (so the derived `FieldControl` already renders it right).
+///
+/// `String`/`Text`: `min`/`max` -> `minlength`/`maxlength`, `email` ->
+/// `type="email"`, `url` -> `type="url"`. Numeric: `min`/`max` -> `min`/`max`
+/// on a `type="number"` input. Returned attribute string is space-prefixed and
+/// ready to splice straight into the generated maud `input`.
+fn html5_constraint_spec(field: &Field) -> Option<(&'static str, String)> {
+    use std::fmt::Write as _;
+    let c = &field.constraints;
+    let mut attrs = String::new();
+    let input_type = match field.kind {
+        FieldKind::String | FieldKind::Text => {
+            if let Some(min) = &c.min {
+                let _ = write!(attrs, " minlength=\"{min}\"");
+            }
+            if let Some(max) = &c.max {
+                let _ = write!(attrs, " maxlength=\"{max}\"");
+            }
+            if c.email {
+                "email"
+            } else if c.url {
+                "url"
+            } else {
+                "text"
+            }
+        }
+        FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64 => {
+            if let Some(min) = &c.min {
+                let _ = write!(attrs, " min=\"{min}\"");
+            }
+            if let Some(max) = &c.max {
+                let _ = write!(attrs, " max=\"{max}\"");
+            }
+            "number"
+        }
+        _ => return None,
+    };
+    // Nothing to add over the derived control: a plain `text`/`number` with no
+    // constraint attributes is exactly what `form_for` already renders, so
+    // don't excise-and-reappend it (which would only reorder the field).
+    if attrs.is_empty() && input_type != "email" && input_type != "url" {
+        return None;
+    }
+    Some((input_type, attrs))
 }
 
 /// Produce the cell-body expression for a `data_table` column closure.
@@ -8101,14 +8202,14 @@ async fn main() {
                 nullable: false,
                 variants: Vec::new(),
                 unique: false,
-            },
+                constraints: Default::default(),            },
             Field {
                 name: "author_id".to_string(),
                 kind: FieldKind::References,
                 nullable: true,
                 variants: Vec::new(),
                 unique: false,
-            },
+                constraints: Default::default(),            },
         ];
         assert_eq!(
             fields[0].reference_table(),
@@ -8154,14 +8255,14 @@ async fn main() {
                 nullable: false,
                 variants: Vec::new(),
                 unique: false,
-            },
+                constraints: Default::default(),            },
             Field {
                 name: "author_id".to_string(),
                 kind: FieldKind::References,
                 nullable: true,
                 variants: Vec::new(),
                 unique: false,
-            },
+                constraints: Default::default(),            },
         ];
         let sql = render_reference_stub_tables_sql(&fields, "unrelated_table");
         assert_eq!(
@@ -8262,7 +8363,7 @@ async fn main() {
             nullable: false,
             variants: vec!["a".to_string(), "b".to_string()],
             unique: false,
-        };
+            constraints: Default::default(),        };
         let weight = Field {
             name: "weight".to_string(),
             kind: FieldKind::Decimal {
@@ -8272,7 +8373,7 @@ async fn main() {
             nullable: false,
             variants: Vec::new(),
             unique: false,
-        };
+            constraints: Default::default(),        };
         let fields = vec![status.clone(), weight];
         let sql = enum_rejection_insert_sql("items", &fields, &status, &BTreeMap::new());
         assert!(

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -449,17 +449,26 @@ pub fn plan_scaffold_with_options(
         };
         let base = f.name.strip_suffix("_id").unwrap_or(&f.name);
         let columns = super::model::model_string_columns(project_root, base);
-        if !columns.is_empty() && !columns.iter().any(|(c, _)| c == label) {
+        if !columns.iter().any(|(c, _)| c == label) {
+            // Covers both a wrong column name AND a target with no string
+            // columns at all — in the latter case there is nothing to fall back
+            // to, so the reference renders its raw id.
+            let detail = if columns.is_empty() {
+                format!("the '{base}' model has no string columns")
+            } else {
+                format!(
+                    "the '{base}' model's string columns are: {}",
+                    columns
+                        .iter()
+                        .map(|(c, _)| c.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            };
             plan.warn(format!(
-                "reference label '{label}' on '{}' is not a string column of the '{base}' \
-                 model; falling back to its default display column. Available string \
-                 columns: {}.",
-                f.name,
-                columns
-                    .iter()
-                    .map(|(c, _)| c.as_str())
-                    .collect::<Vec<_>>()
-                    .join(", ")
+                "reference label '{label}' on '{}' is not a usable string column ({detail}); \
+                 falling back to the default display column (its raw id when there is none).",
+                f.name
             ));
         }
     }
@@ -2864,16 +2873,22 @@ fn resolve_reference_display(project_root: &Path, field: &Field) -> Option<Refer
             // Explicit override names a real string column on the target — use
             // it, with its known nullability.
             (c.clone(), *n)
-        } else if columns.is_empty() {
-            // The target model isn't discoverable at scaffold time (not yet
-            // generated, unparseable, or a single-file `models.rs` layout we
-            // can't read), so the override can't be validated. Honor it as
-            // before (assume a non-null `String`), matching the "assume the
-            // table exists" posture the missing-target path already takes.
+        } else if field
+            .reference_table()
+            .is_some_and(|table| !super::model::model_file_exists(project_root, &table, base))
+        {
+            // The target model genuinely isn't discoverable (not yet generated,
+            // unparseable, or a single-file `models.rs` layout we can't read),
+            // so the override can't be validated. Honor it as before (assume a
+            // non-null `String`), matching the "assume the table exists" posture
+            // the missing-target path takes. Not reachable on the normal select
+            // path (missing targets are excluded upstream), but keeps the
+            // resolver correct for any other caller.
             (label.clone(), false)
         } else {
-            // The model IS discoverable and exposes string columns, but none is
-            // named `{label}` — a typo, or a non-string column. Emitting
+            // The model IS discoverable but `{label}` names no string column —
+            // a typo, a non-string column, or a model with NO string columns at
+            // all (e.g. `Post { id, count: i32 }` + `{label:count}`). Emitting
             // `select {table}::{label}` (loaded as `String`) would fail to
             // compile the generated app, so fall back to the heuristic display
             // column: generation still succeeds, and the plan carries a warning
@@ -3003,6 +3018,15 @@ fn render_changeset_form_inputs(
                     // that happens to permit an empty string (e.g. a max-only
                     // `length` rule) doesn't leave a blank required field with
                     // no client-side guard at all.
+                    //
+                    // Known limitation (#1750): the #1388 client-side HTML5
+                    // constraint attributes (`minlength`/`maxlength`,
+                    // `type="email"`/`url`) are only emitted on the standard
+                    // `form_for` path (`html5_constraint_spec`), not through
+                    // these cross-crate `autumn_web::form` htmx helpers, which
+                    // take no constraint params. Server-side `#[validate]` still
+                    // applies in `--live-validation`; only the static HTML5
+                    // hints are absent here.
                     if live_validation && validated.contains(&name.as_str()) {
                         let helper = if f.nullable {
                             "text_input_htmx"

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -964,11 +964,13 @@ pub fn remove_main_mod_declarations(existing: &str, names: &[&str]) -> String {
 ///
 /// Idempotent: a declaration already present (in any `mod x;` / `pub mod x;`
 /// form, with or without a preceding `#[path]` attribute) is left untouched,
-/// so repeated `generate` runs converge. No destroy-time removal is needed:
-/// `autumn destroy` only ever strips lines from `src/models/mod.rs` and
-/// `src/schema.rs` (never deletes the files themselves), so these `#[path]`
-/// targets always exist and an emptied module simply contributes nothing to
-/// the registry — exactly the pre-scaffold behavior.
+/// so repeated `generate` runs converge. The inverse
+/// [`unlink_models_from_seed_bin`] removes these injected declarations at
+/// destroy time — necessary because `autumn destroy` **deletes**
+/// `src/models/mod.rs` / `src/schema.rs` once its `ModDecl`/`SchemaTable`
+/// reverts empty them (destroying the last model), which would otherwise leave
+/// `seed.rs`'s `#[path]` links dangling at missing files and break
+/// `cargo check --bins` / `autumn seed`.
 #[must_use]
 pub fn link_models_into_seed_bin(existing: &str) -> String {
     // (module name, full declaration incl. its `#[path]` attribute)
@@ -1017,6 +1019,61 @@ pub fn link_models_into_seed_bin(existing: &str) -> String {
     }
     if !existing.ends_with('\n') && out.ends_with('\n') {
         out.pop();
+    }
+    out
+}
+
+/// Remove the `#[path]`-qualified `mod schema;` / `mod models;` declarations
+/// that [`link_models_into_seed_bin`] injected into `src/bin/seed.rs`, the
+/// destroy-time inverse of that link (issue #1718 follow-up).
+///
+/// `autumn destroy` deletes `src/schema.rs` and `src/models/mod.rs` once the
+/// last model's `SchemaTable`/`ModDecl` reverts empty them, so the seed
+/// binary's `#[path = "../schema.rs"] mod schema;` /
+/// `#[path = "../models/mod.rs"] mod models;` links would then point at missing
+/// files and fail `cargo check --bins`. This strips exactly those two injected
+/// two-line blocks (attribute + `mod` declaration), matched on trimmed content
+/// so only this generator's own `#[path]`-qualified form is touched — a
+/// hand-written plain `mod schema;` without the injected attribute is left
+/// alone. Idempotent: a block already absent is a no-op. Blank lines left at
+/// the removal seam are collapsed so the reverted file stays tidy.
+///
+/// This is gated by [`Revert::SeedBinLinks`]'s `owner_dir` (`src/models`) so it
+/// only runs when the *last* model is destroyed — destroying one of several
+/// models leaves the links in place, matching the surviving `models/mod.rs`.
+#[must_use]
+pub fn unlink_models_from_seed_bin(existing: &str) -> String {
+    // (attribute line, declaration line) for each injected block.
+    let blocks: [[&str; 2]; 2] = [
+        ["#[path = \"../schema.rs\"]", "mod schema;"],
+        ["#[path = \"../models/mod.rs\"]", "mod models;"],
+    ];
+    let mut lines: Vec<String> = existing.lines().map(str::to_owned).collect();
+    for [attr, decl] in blocks {
+        let mut i = 0;
+        while i + 1 < lines.len() {
+            if lines[i].trim() == attr && lines[i + 1].trim() == decl {
+                lines.drain(i..i + 2);
+            } else {
+                i += 1;
+            }
+        }
+    }
+    // Collapse runs of blank lines (and drop a leading blank) left where the
+    // blocks were removed, so the reverted file matches its pre-link shape.
+    let mut out_lines: Vec<String> = Vec::with_capacity(lines.len());
+    let mut prev_blank = true; // seed `true` so a leading blank line is dropped
+    for line in lines {
+        let is_blank = line.trim().is_empty();
+        if is_blank && prev_blank {
+            continue;
+        }
+        prev_blank = is_blank;
+        out_lines.push(line);
+    }
+    let mut out = out_lines.join("\n");
+    if !out.is_empty() && existing.ends_with('\n') {
+        out.push('\n');
     }
     out
 }
@@ -5251,6 +5308,56 @@ mod models;
 use autumn_web::seed::SeedContext;
 ";
         assert_eq!(link_models_into_seed_bin(existing), existing);
+    }
+
+    #[test]
+    fn unlink_seed_bin_removes_the_injected_path_qualified_mods() {
+        // Destroy-time inverse: a linked seed binary loses both injected
+        // declarations (and their `#[path]` attributes), keeping every original
+        // item, so nothing dangles at the deleted schema.rs/models/mod.rs.
+        let linked = link_models_into_seed_bin(SEED_BIN);
+        let unlinked = unlink_models_from_seed_bin(&linked);
+        assert!(
+            !unlinked.contains("mod schema;") && !unlinked.contains("mod models;"),
+            "both injected `mod` declarations must be gone:\n{unlinked}"
+        );
+        assert!(
+            !unlinked.contains("#[path = \"../schema.rs\"]")
+                && !unlinked.contains("#[path = \"../models/mod.rs\"]"),
+            "no dangling `#[path]` attributes may remain:\n{unlinked}"
+        );
+        // Original items survive.
+        assert!(
+            unlinked.contains("use autumn_web::seed::SeedContext;")
+                && unlinked.contains("async fn main() {}")
+                && unlinked.contains("//! Database seed binary."),
+            "the original seed-binary items must be preserved:\n{unlinked}"
+        );
+    }
+
+    #[test]
+    fn unlink_seed_bin_is_idempotent_and_noop_when_absent() {
+        // No injected declarations to remove from a bare seed binary.
+        assert_eq!(unlink_models_from_seed_bin(SEED_BIN), SEED_BIN);
+        let linked = link_models_into_seed_bin(SEED_BIN);
+        let once = unlink_models_from_seed_bin(&linked);
+        let twice = unlink_models_from_seed_bin(&once);
+        assert_eq!(
+            once, twice,
+            "re-unlinking an already-unlinked seed bin is a no-op"
+        );
+    }
+
+    #[test]
+    fn unlink_seed_bin_leaves_hand_written_plain_mod_untouched() {
+        // A plain `mod schema;` WITHOUT the injected `#[path]` attribute is the
+        // author's own module, not this generator's injection — never strip it.
+        let existing = "\
+//! seed
+mod schema;
+use autumn_web::seed::SeedContext;
+";
+        assert_eq!(unlink_models_from_seed_bin(existing), existing);
     }
 
     #[test]

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -511,6 +511,7 @@ fn fields_with_existing_schema_columns(
                 nullable: false,
                 variants: Vec::new(),
                 unique: false,
+                constraints: Default::default(),
             });
         }
     }
@@ -935,6 +936,87 @@ pub fn remove_main_mod_declarations(existing: &str, names: &[&str]) -> String {
     let mut out = collapsed.join("\n");
     if existing.ends_with('\n') && !out.is_empty() {
         out.push('\n');
+    }
+    out
+}
+
+/// Inject the `#[path]`-qualified `mod schema;` / `mod models;` declarations
+/// that link a scaffolded app's `src/schema.rs` and `src/models/` into the
+/// standalone `src/bin/seed.rs` binary (issue #1718).
+///
+/// `autumn seed --count/--model` resolves a model by name through an
+/// `inventory` registry that each `#[autumn_web::model]` submits into. That
+/// registry is only populated with models actually **compiled into the seed
+/// binary** — but `autumn new` emits `src/bin/seed.rs` as a separate `[[bin]]`
+/// target that links neither `src/main.rs` nor `src/models/`, so a scaffolded
+/// model was never visible to it and `--model M` returned
+/// `unknown model M; available: (none)`. Declaring the models (and the
+/// `schema` module they `use crate::schema::…` from) directly in `seed.rs`
+/// pulls their `inventory::submit!`s into the seed binary.
+///
+/// The `#[path]` form is required because `src/bin/seed.rs`'s own module tree
+/// has no `models`/`schema` child relative to `src/bin/`; the attribute points
+/// each declaration at the real file under `src/`. Child modules of
+/// `models/mod.rs` (`mod post;` → `src/models/post.rs`) resolve relative to
+/// that file's directory, so no per-model edit is needed here — regenerating
+/// or adding a model just extends `src/models/mod.rs`, which this single
+/// declaration already re-exports into the seed binary.
+///
+/// Idempotent: a declaration already present (in any `mod x;` / `pub mod x;`
+/// form, with or without a preceding `#[path]` attribute) is left untouched,
+/// so repeated `generate` runs converge. No destroy-time removal is needed:
+/// `autumn destroy` only ever strips lines from `src/models/mod.rs` and
+/// `src/schema.rs` (never deletes the files themselves), so these `#[path]`
+/// targets always exist and an emptied module simply contributes nothing to
+/// the registry — exactly the pre-scaffold behavior.
+#[must_use]
+pub fn link_models_into_seed_bin(existing: &str) -> String {
+    // (module name, full declaration incl. its `#[path]` attribute)
+    let entries: [(&str, &str); 2] = [
+        ("schema", "#[path = \"../schema.rs\"]\nmod schema;"),
+        ("models", "#[path = \"../models/mod.rs\"]\nmod models;"),
+    ];
+    let needed: Vec<&str> = entries
+        .iter()
+        .filter(|(name, _)| !has_mod_declaration(existing, name))
+        .map(|(_, decl)| *decl)
+        .collect();
+    if needed.is_empty() {
+        return existing.to_owned();
+    }
+    let block = needed.join("\n");
+
+    // `mod` declarations are *items* and must follow any crate-level inner
+    // attributes (`#![…]`) and `//!` doc comments — mirror `ensure_mods`.
+    let split = existing
+        .lines()
+        .position(|l| {
+            let t = l.trim_start();
+            !t.is_empty() && !t.starts_with("//!") && !t.starts_with("#![")
+        })
+        .unwrap_or_else(|| existing.lines().count());
+
+    if split == 0 {
+        return format!("{block}\n\n{existing}");
+    }
+
+    let mut out = String::with_capacity(existing.len() + block.len() + 4);
+    let lines: Vec<&str> = existing.lines().collect();
+    for line in &lines[..split] {
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.push_str(&block);
+    out.push('\n');
+    if split < lines.len() {
+        out.push('\n');
+        for line in &lines[split..] {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    if !existing.ends_with('\n') && out.ends_with('\n') {
+        out.pop();
     }
     out
 }
@@ -5080,6 +5162,92 @@ async fn main() {\n\
         let original = "fn main() {}\n";
         let updated = update_main_rs(original, &[], &["foo".into()]);
         assert_eq!(updated, original);
+    }
+
+    // ── link_models_into_seed_bin (issue #1718) ───────────────────────────
+
+    /// The seed binary as `autumn new --with-seed` emits it: a `//!` doc block
+    /// followed by a `use` and the async `main`.
+    const SEED_BIN: &str = "\
+//! Database seed binary.
+//!
+//!   autumn seed --count 200 --model Post
+use autumn_web::seed::SeedContext;
+
+#[autumn_web::main]
+async fn main() {}
+";
+
+    #[test]
+    fn link_seed_bin_injects_path_qualified_schema_and_models_mods() {
+        let linked = link_models_into_seed_bin(SEED_BIN);
+        assert!(
+            linked.contains("#[path = \"../schema.rs\"]\nmod schema;"),
+            "must inject a #[path]-qualified `mod schema;`:\n{linked}"
+        );
+        assert!(
+            linked.contains("#[path = \"../models/mod.rs\"]\nmod models;"),
+            "must inject a #[path]-qualified `mod models;`:\n{linked}"
+        );
+    }
+
+    #[test]
+    fn link_seed_bin_inserts_after_inner_doc_block_not_before() {
+        // `mod` items must follow the crate-level `//!` doc block, or the file
+        // fails to parse.
+        let linked = link_models_into_seed_bin(SEED_BIN);
+        let doc_end = linked.find("use autumn_web::seed").unwrap();
+        let mods_at = linked.find("mod schema;").unwrap();
+        assert!(
+            linked.find("//! Database seed binary.").unwrap() < mods_at,
+            "mods must come after the doc comment: {linked}"
+        );
+        assert!(
+            mods_at < doc_end,
+            "mods must be inserted before the first ordinary item (`use`): {linked}"
+        );
+    }
+
+    #[test]
+    fn link_seed_bin_is_idempotent() {
+        let once = link_models_into_seed_bin(SEED_BIN);
+        let twice = link_models_into_seed_bin(&once);
+        assert_eq!(once, twice, "re-linking an already-linked seed bin is a no-op");
+    }
+
+    #[test]
+    fn link_seed_bin_preserves_existing_declarations() {
+        // A hand-written seed that already declares one module keeps that
+        // declaration untouched and only the missing one is added.
+        let existing = "\
+//! seed
+#[path = \"../models/mod.rs\"]
+mod models;
+use autumn_web::seed::SeedContext;
+";
+        let linked = link_models_into_seed_bin(existing);
+        assert_eq!(
+            linked.matches("mod models;").count(),
+            1,
+            "must not duplicate the pre-existing `mod models;`:\n{linked}"
+        );
+        assert!(
+            linked.contains("mod schema;"),
+            "must still add the missing `mod schema;`:\n{linked}"
+        );
+    }
+
+    #[test]
+    fn link_seed_bin_no_change_when_both_present() {
+        let existing = "\
+//! seed
+#[path = \"../schema.rs\"]
+mod schema;
+#[path = \"../models/mod.rs\"]
+mod models;
+use autumn_web::seed::SeedContext;
+";
+        assert_eq!(link_models_into_seed_bin(existing), existing);
     }
 
     #[test]

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -12,7 +12,7 @@ use std::fmt::Write as _;
 
 use sha2::{Digest, Sha256};
 
-use super::dsl::{Field, FieldKind, IdType};
+use super::dsl::{Field, FieldConstraints, FieldKind, IdType};
 
 /// Append a `pub mod <name>;` line to a `mod.rs` file, returning the new
 /// contents. Idempotent: a second call with the same name is a no-op.
@@ -511,7 +511,7 @@ fn fields_with_existing_schema_columns(
                 nullable: false,
                 variants: Vec::new(),
                 unique: false,
-                constraints: Default::default(),
+                constraints: FieldConstraints::default(),
             });
         }
     }

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -5212,7 +5212,10 @@ async fn main() {}
     fn link_seed_bin_is_idempotent() {
         let once = link_models_into_seed_bin(SEED_BIN);
         let twice = link_models_into_seed_bin(&once);
-        assert_eq!(once, twice, "re-linking an already-linked seed bin is a no-op");
+        assert_eq!(
+            once, twice,
+            "re-linking an already-linked seed bin is a no-op"
+        );
     }
 
     #[test]

--- a/autumn-cli/tests/integration/mod.rs
+++ b/autumn-cli/tests/integration/mod.rs
@@ -8,6 +8,8 @@ mod i18n_check;
 mod migrate_down;
 mod repo_hygiene;
 mod scaffold_form_for;
+mod scaffold_validation;
+mod seed_model_linking;
 #[cfg(unix)]
 mod serve;
 mod tauri_mobile_thin_client;

--- a/autumn-cli/tests/integration/mod.rs
+++ b/autumn-cli/tests/integration/mod.rs
@@ -7,6 +7,7 @@ mod generate_tauri_mobile_offline;
 mod i18n_check;
 mod migrate_down;
 mod repo_hygiene;
+mod scaffold_belongs_to;
 mod scaffold_form_for;
 mod scaffold_validation;
 mod seed_model_linking;

--- a/autumn-cli/tests/integration/scaffold_belongs_to.rs
+++ b/autumn-cli/tests/integration/scaffold_belongs_to.rs
@@ -1,0 +1,206 @@
+//! belongs_to `references` fields render a populated `<select>` labeled by a
+//! display column, and index/show views render the parent's display value
+//! instead of the raw foreign-key id (issue #1146).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn autumn_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_autumn")
+}
+
+fn run_autumn_ok(dir: &Path, args: &[&str]) {
+    let output = Command::new(autumn_bin())
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to run autumn");
+    assert!(
+        output.status.success(),
+        "autumn {args:?} failed (exit={:?})\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// `autumn new` + `generate model Post <post_cols>` + `generate scaffold
+/// Comment body:Text <comment_ref>`, returning the generated `comments.rs`.
+fn belongs_to_routes(
+    name: &str,
+    post_cols: &[&str],
+    comment_ref: &str,
+) -> (tempfile::TempDir, String) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", name]);
+    let project = tmp.path().join(name);
+    let mut post_args = vec!["generate", "model", "Post"];
+    post_args.extend_from_slice(post_cols);
+    run_autumn_ok(&project, &post_args);
+    run_autumn_ok(
+        &project,
+        &["generate", "scaffold", "Comment", "body:Text", comment_ref],
+    );
+    let routes = fs::read_to_string(project.join("src/routes/comments.rs")).unwrap();
+    (tmp, routes)
+}
+
+#[test]
+fn select_loader_uses_title_display_column_heuristic() {
+    let (_tmp, routes) = belongs_to_routes("bt-title-app", &["title:String"], "post:references");
+    assert!(
+        routes.contains(".select((posts::id, posts::title))"),
+        "the loader must select the id + the `title` display column:\n{routes}"
+    );
+    assert!(
+        routes.contains(".map(|(id, label)| (id.to_string(), label))"),
+        "options must be labeled by the display value, not the id:\n{routes}"
+    );
+}
+
+#[test]
+fn select_loader_prefers_name_over_other_string_columns() {
+    // `name` beats a later `headline` string column per the heuristic.
+    let (_tmp, routes) = belongs_to_routes(
+        "bt-name-app",
+        &["headline:String", "name:String"],
+        "post:references",
+    );
+    assert!(
+        routes.contains(".select((posts::id, posts::name))"),
+        "the loader must prefer the `name` column:\n{routes}"
+    );
+}
+
+#[test]
+fn label_override_selects_the_named_column() {
+    let (_tmp, routes) = belongs_to_routes(
+        "bt-override-app",
+        &["title:String", "slug:String"],
+        "post:references{label:slug}",
+    );
+    assert!(
+        routes.contains(".select((posts::id, posts::slug))"),
+        "an explicit {{label:slug}} must select the `slug` column:\n{routes}"
+    );
+}
+
+#[test]
+fn falls_back_to_id_when_target_has_no_string_column() {
+    // A `Post` with only numeric columns has no display column, so the loader
+    // keeps the id as both value and label.
+    let (_tmp, routes) = belongs_to_routes("bt-noid-app", &["views:i64"], "post:references");
+    assert!(
+        routes.contains(".select(posts::id)"),
+        "with no string column the loader must fall back to id-only:\n{routes}"
+    );
+    assert!(
+        routes.contains("(id.to_string(), id.to_string())"),
+        "the id-fallback loader labels each option by its id:\n{routes}"
+    );
+}
+
+#[test]
+fn show_view_renders_parent_label_not_raw_fk() {
+    let (_tmp, routes) = belongs_to_routes("bt-show-app", &["title:String"], "post:references");
+    // A per-view load of the parent's title, rendered in the property list.
+    assert!(
+        routes.contains("let post_id_label: String")
+            && routes.contains("posts::table.find(fk).select(posts::title)"),
+        "show must load the parent's display label:\n{routes}"
+    );
+    assert!(
+        routes.contains("(post_id_label)"),
+        "show must render the loaded label:\n{routes}"
+    );
+    // The show property list must NOT render the raw FK integer.
+    assert!(
+        !routes.contains("maud::html! { (row.post_id) }"),
+        "show must not render the raw post_id integer:\n{routes}"
+    );
+}
+
+#[test]
+fn index_view_renders_parent_label_via_loaded_map() {
+    let (_tmp, routes) = belongs_to_routes("bt-index-app", &["title:String"], "post:references");
+    assert!(
+        routes.contains("let post_id_labels: std::collections::HashMap<String, String>"),
+        "index must load a parent-label map:\n{routes}"
+    );
+    assert!(
+        routes.contains("post_id_labels.get(&row.post_id.to_string())"),
+        "the index column must look the label up from the map:\n{routes}"
+    );
+}
+
+#[test]
+fn nullable_reference_renders_dash_and_blank_option() {
+    let (_tmp, routes) =
+        belongs_to_routes("bt-nullable-app", &["title:String"], "post:references?");
+    // The nullable select gets a blank first option.
+    assert!(
+        routes.contains("\"— Unset —\".to_string()"),
+        "a nullable reference must offer a blank first option:\n{routes}"
+    );
+    // The nullable FK renders a dash for the None case in show and index.
+    assert!(
+        routes.contains("None => \"—\".to_string()"),
+        "show must render a dash for an unset nullable reference:\n{routes}"
+    );
+    assert!(
+        routes.contains("match &row.post_id { Some(v) =>"),
+        "index must handle the nullable FK's None case:\n{routes}"
+    );
+}
+
+/// Slow end-to-end check: the belongs_to scaffold (display-column select
+/// loader, index label map, show label load) type-checks against this
+/// workspace's `autumn-web`.
+///
+/// Ignored by default; run with `cargo test -p autumn-cli -- --ignored`.
+#[test]
+#[ignore = "slow: cargo-checks a fresh project — run with `cargo test -p autumn-cli -- --ignored`"]
+fn belongs_to_scaffold_cargo_checks() {
+    use std::fmt::Write as _;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", "bt-check-app"]);
+    let project: PathBuf = tmp.path().join("bt-check-app");
+    run_autumn_ok(&project, &["generate", "model", "Post", "title:String"]);
+    run_autumn_ok(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Comment",
+            "body:Text",
+            "post:references",
+        ],
+    );
+
+    let cargo_toml_path = project.join("Cargo.toml");
+    let mut content = fs::read_to_string(&cargo_toml_path).unwrap();
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root");
+    let autumn_web = workspace_root.join("autumn");
+    let _ = write!(
+        content,
+        "\n[patch.crates-io]\nautumn-web = {{ path = \"{}\" }}\n",
+        autumn_web.display().to_string().replace('\\', "/")
+    );
+    fs::write(&cargo_toml_path, content).unwrap();
+
+    let check = Command::new("cargo")
+        .args(["check", "--bins"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    assert!(
+        check.status.success(),
+        "cargo check on the belongs_to scaffold failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr),
+    );
+}

--- a/autumn-cli/tests/integration/scaffold_belongs_to.rs
+++ b/autumn-cli/tests/integration/scaffold_belongs_to.rs
@@ -223,6 +223,67 @@ fn index_view_renders_parent_label_via_loaded_map() {
     );
 }
 
+/// `autumn new` + `generate model Post title:String` + `generate scaffold
+/// Comment body:Text post:references --sharded`, returning `comments.rs`.
+fn belongs_to_sharded_routes(name: &str) -> (tempfile::TempDir, String) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", name]);
+    let project = tmp.path().join(name);
+    run_autumn_ok(&project, &["generate", "model", "Post", "title:String"]);
+    run_autumn_ok(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Comment",
+            "body:Text",
+            "post:references",
+            "--sharded",
+        ],
+    );
+    let routes = fs::read_to_string(project.join("src/routes/comments.rs")).unwrap();
+    (tmp, routes)
+}
+
+#[test]
+fn sharded_index_renders_parent_label_via_loaded_map() {
+    // Issue #1146's index parent-display (a `<select>`-free VIEW concern) must
+    // survive `--sharded` too: the sharded index handler already threads a
+    // `ShardedDb` (for `from_shard`) and the `{name}_select_options` loader is
+    // generated against that same connection type, so the index reuses the
+    // label map rather than falling back to the raw FK id.
+    let (_tmp, routes) = belongs_to_sharded_routes("bt-sharded-index-app");
+
+    // Sharded handler stays sharded: ShardedDb extractor (promoted to `mut`
+    // because it must run the loader) + from_shard, never a bare `Db`.
+    assert!(
+        routes.contains("mut db: ShardedDb"),
+        "sharded index must take a mutable ShardedDb extractor:\n{routes}"
+    );
+    assert!(
+        routes.contains("PgCommentRepository::from_shard(&db)"),
+        "sharded index must still build its repo via from_shard(&db):\n{routes}"
+    );
+    assert!(
+        !routes.contains("mut db: Db"),
+        "sharded index must not fall back to a bare Db extractor:\n{routes}"
+    );
+    // The parent-label map is loaded and the index column looks the label up —
+    // identical to the non-sharded path.
+    assert!(
+        routes.contains("let post_id_labels: std::collections::HashMap<String, String>"),
+        "sharded index must load a parent-label map:\n{routes}"
+    );
+    assert!(
+        routes.contains("post_id_select_options(&mut db).await?"),
+        "the sharded label map must be built from the ShardedDb-aware loader:\n{routes}"
+    );
+    assert!(
+        routes.contains("post_id_labels.get(&row.post_id.to_string())"),
+        "the sharded index column must look the label up from the map:\n{routes}"
+    );
+}
+
 #[test]
 fn live_validation_keeps_parent_display_on_index_and_show() {
     // Issue #1146's index/show parent-display rendering is generator-emitted

--- a/autumn-cli/tests/integration/scaffold_belongs_to.rs
+++ b/autumn-cli/tests/integration/scaffold_belongs_to.rs
@@ -1,12 +1,16 @@
-//! belongs_to `references` fields render a populated `<select>` labeled by a
+//! `belongs_to` `references` fields render a populated `<select>` labeled by a
 //! display column, and index/show views render the parent's display value
 //! instead of the raw foreign-key id (issue #1146).
+
+// DSL tokens like `"post:references{label:slug}"` are literal scaffold inputs,
+// not format strings — the `{label:col}` is the modifier syntax under test.
+#![allow(clippy::literal_string_with_formatting_args)]
 
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-fn autumn_bin() -> &'static str {
+const fn autumn_bin() -> &'static str {
     env!("CARGO_BIN_EXE_autumn")
 }
 
@@ -154,7 +158,7 @@ fn nullable_reference_renders_dash_and_blank_option() {
     );
 }
 
-/// Slow end-to-end check: the belongs_to scaffold (display-column select
+/// Slow end-to-end check: the `belongs_to` scaffold (display-column select
 /// loader, index label map, show label load) type-checks against this
 /// workspace's `autumn-web`.
 ///

--- a/autumn-cli/tests/integration/scaffold_belongs_to.rs
+++ b/autumn-cli/tests/integration/scaffold_belongs_to.rs
@@ -91,6 +91,49 @@ fn label_override_selects_the_named_column() {
 }
 
 #[test]
+fn invalid_label_override_falls_back_to_heuristic_and_warns() {
+    // `Post` exposes `title` (heuristic display) but no `slug`; an explicit
+    // `{label:slug}` names a column the model doesn't have. Trusting it would
+    // emit `select posts::slug` (loaded as `String`) and fail to compile the
+    // generated app, so the resolver falls back to the `title` heuristic and
+    // the generator warns instead of hard-failing.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", "bt-bad-label-app"]);
+    let project = tmp.path().join("bt-bad-label-app");
+    run_autumn_ok(&project, &["generate", "model", "Post", "title:String"]);
+    let output = Command::new(autumn_bin())
+        .args([
+            "generate",
+            "scaffold",
+            "Comment",
+            "body:Text",
+            "post:references{label:slug}",
+        ])
+        .current_dir(&project)
+        .output()
+        .expect("failed to run autumn");
+    assert!(
+        output.status.success(),
+        "scaffold with an invalid label must still succeed (graceful fallback)\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let routes = fs::read_to_string(project.join("src/routes/comments.rs")).unwrap();
+    assert!(
+        routes.contains(".select((posts::id, posts::title))"),
+        "an invalid label must fall back to the `title` heuristic column:\n{routes}"
+    );
+    assert!(
+        !routes.contains("posts::slug"),
+        "the generated routes must not reference the nonexistent `slug` column:\n{routes}"
+    );
+    assert!(
+        stderr.contains("slug") && stderr.contains("falling back"),
+        "the generator must warn that the invalid label was ignored:\n{stderr}"
+    );
+}
+
+#[test]
 fn falls_back_to_id_when_target_has_no_string_column() {
     // A `Post` with only numeric columns has no display column, so the loader
     // keeps the id as both value and label.

--- a/autumn-cli/tests/integration/scaffold_belongs_to.rs
+++ b/autumn-cli/tests/integration/scaffold_belongs_to.rs
@@ -134,6 +134,48 @@ fn invalid_label_override_falls_back_to_heuristic_and_warns() {
 }
 
 #[test]
+fn label_override_naming_a_non_string_column_falls_back_to_id_and_warns() {
+    // `Post` has only numeric columns, so an explicit `{label:count}` names a
+    // column that isn't (and can't be) a string display column. Trusting it
+    // would emit `select posts::count` loaded as `String` and fail to compile
+    // the generated app, so the resolver must fall back to id-only and warn.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", "bt-nonstring-label-app"]);
+    let project = tmp.path().join("bt-nonstring-label-app");
+    run_autumn_ok(&project, &["generate", "model", "Post", "count:i64"]);
+    let output = Command::new(autumn_bin())
+        .args([
+            "generate",
+            "scaffold",
+            "Comment",
+            "body:Text",
+            "post:references{label:count}",
+        ])
+        .current_dir(&project)
+        .output()
+        .expect("failed to run autumn");
+    assert!(
+        output.status.success(),
+        "scaffold with a non-string label must still succeed (graceful fallback)\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let routes = fs::read_to_string(project.join("src/routes/comments.rs")).unwrap();
+    assert!(
+        !routes.contains("posts::count"),
+        "must not select the non-string column as a label:\n{routes}"
+    );
+    assert!(
+        routes.contains(".select(posts::id)"),
+        "with no string column the loader must fall back to id-only:\n{routes}"
+    );
+    assert!(
+        stderr.contains("count") && stderr.contains("falling back"),
+        "the generator must warn that the non-string label was ignored:\n{stderr}"
+    );
+}
+
+#[test]
 fn falls_back_to_id_when_target_has_no_string_column() {
     // A `Post` with only numeric columns has no display column, so the loader
     // keeps the id as both value and label.

--- a/autumn-cli/tests/integration/scaffold_belongs_to.rs
+++ b/autumn-cli/tests/integration/scaffold_belongs_to.rs
@@ -288,10 +288,13 @@ fn live_validation_keeps_parent_display_on_index_and_show() {
 
 #[test]
 fn self_reference_resolves_display_from_in_flight_fields() {
-    // A self-reference (`category:references` on Category → the `categories`
-    // table being generated right now) has no `src/models/category.rs` on disk
-    // yet, so the #1146 display column must resolve from the IN-FLIGHT fields —
-    // `categories::name`, not the raw id. Nullable self-ref (`references?`).
+    // A self-reference (`node:references` on Node → the `nodes` table being
+    // generated right now) has no `src/models/node.rs` on disk yet, so the #1146
+    // display column must resolve from the IN-FLIGHT fields — `nodes::name`, not
+    // the raw id. Nullable self-ref (`references?`). (A regular-plural model is
+    // used so the generated app also compiles — an irregular plural like
+    // `Category` hits a separate, pre-existing `#[model]`-macro pluralization
+    // bug, `category` -> `categorys`, unrelated to this display resolution.)
     let tmp = tempfile::tempdir().expect("tempdir");
     run_autumn_ok(tmp.path(), &["new", "self-ref-app"]);
     let project = tmp.path().join("self-ref-app");
@@ -300,26 +303,26 @@ fn self_reference_resolves_display_from_in_flight_fields() {
         &[
             "generate",
             "scaffold",
-            "Category",
+            "Node",
             "name:String",
-            "category:references?",
+            "node:references?",
         ],
     );
-    let routes = fs::read_to_string(project.join("src/routes/categories.rs")).unwrap();
+    let routes = fs::read_to_string(project.join("src/routes/nodes.rs")).unwrap();
 
     // Option loader selects the in-flight `name` display column (not id-only).
     assert!(
-        routes.contains(".select((categories::id, categories::name))"),
+        routes.contains(".select((nodes::id, nodes::name))"),
         "self-ref option loader must select the in-flight `name` column:\n{routes}"
     );
     // Show loads + renders the parent's `name`.
     assert!(
-        routes.contains("categories::table.find(fk).select(categories::name)"),
+        routes.contains("nodes::table.find(fk).select(nodes::name)"),
         "self-ref show must load the parent `name` display value:\n{routes}"
     );
     // Index builds the parent-label map.
     assert!(
-        routes.contains("let category_id_labels: std::collections::HashMap<String, String>"),
+        routes.contains("let node_id_labels: std::collections::HashMap<String, String>"),
         "self-ref index must build the parent-label map:\n{routes}"
     );
     // Must NOT fall back to raw-id labeling.

--- a/autumn-cli/tests/integration/scaffold_belongs_to.rs
+++ b/autumn-cli/tests/integration/scaffold_belongs_to.rs
@@ -287,6 +287,54 @@ fn live_validation_keeps_parent_display_on_index_and_show() {
 }
 
 #[test]
+fn self_reference_resolves_display_from_in_flight_fields() {
+    // A self-reference (`category:references` on Category → the `categories`
+    // table being generated right now) has no `src/models/category.rs` on disk
+    // yet, so the #1146 display column must resolve from the IN-FLIGHT fields —
+    // `categories::name`, not the raw id. Nullable self-ref (`references?`).
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", "self-ref-app"]);
+    let project = tmp.path().join("self-ref-app");
+    run_autumn_ok(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Category",
+            "name:String",
+            "category:references?",
+        ],
+    );
+    let routes = fs::read_to_string(project.join("src/routes/categories.rs")).unwrap();
+
+    // Option loader selects the in-flight `name` display column (not id-only).
+    assert!(
+        routes.contains(".select((categories::id, categories::name))"),
+        "self-ref option loader must select the in-flight `name` column:\n{routes}"
+    );
+    // Show loads + renders the parent's `name`.
+    assert!(
+        routes.contains("categories::table.find(fk).select(categories::name)"),
+        "self-ref show must load the parent `name` display value:\n{routes}"
+    );
+    // Index builds the parent-label map.
+    assert!(
+        routes.contains("let category_id_labels: std::collections::HashMap<String, String>"),
+        "self-ref index must build the parent-label map:\n{routes}"
+    );
+    // Must NOT fall back to raw-id labeling.
+    assert!(
+        !routes.contains("(id.to_string(), id.to_string())"),
+        "self-ref must not fall back to raw-id labeling:\n{routes}"
+    );
+    // Nullable self-ref: the unset FK renders a dash on show/index.
+    assert!(
+        routes.contains("None => \"—\".to_string()"),
+        "nullable self-ref must handle the None case:\n{routes}"
+    );
+}
+
+#[test]
 fn nullable_reference_renders_dash_and_blank_option() {
     let (_tmp, routes) =
         belongs_to_routes("bt-nullable-app", &["title:String"], "post:references?");

--- a/autumn-cli/tests/integration/scaffold_belongs_to.rs
+++ b/autumn-cli/tests/integration/scaffold_belongs_to.rs
@@ -224,6 +224,69 @@ fn index_view_renders_parent_label_via_loaded_map() {
 }
 
 #[test]
+fn live_validation_keeps_parent_display_on_index_and_show() {
+    // Issue #1146's index/show parent-display rendering is generator-emitted
+    // VIEW markup (independent of the form control), so it must still appear in
+    // `--live-validation` mode — where the form itself uses the per-field path
+    // and the belongs_to `<select>` is deferred (#1750), the raw FK id must NOT
+    // leak into the index/show pages.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", "bt-live-app"]);
+    let project = tmp.path().join("bt-live-app");
+    run_autumn_ok(&project, &["generate", "model", "Post", "title:String"]);
+    run_autumn_ok(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Comment",
+            "body:Text",
+            "post:references",
+            "--live-validation",
+        ],
+    );
+    let routes = fs::read_to_string(project.join("src/routes/comments.rs")).unwrap();
+
+    // Show: loads + renders the parent's `title`, not the raw FK.
+    assert!(
+        routes.contains("let post_id_label: String")
+            && routes.contains("posts::table.find(fk).select(posts::title)")
+            && routes.contains("(post_id_label)"),
+        "live-validation show must still load + render the parent display label:\n{routes}"
+    );
+    // Index: loads + looks up the parent-label map.
+    assert!(
+        routes.contains("let post_id_labels: std::collections::HashMap<String, String>")
+            && routes.contains("post_id_labels.get(&row.post_id.to_string())"),
+        "live-validation index must still render the parent display via the label map:\n{routes}"
+    );
+    // The referenced table's schema is imported so those loads compile.
+    assert!(
+        routes.contains("use crate::schema::{comments, posts}")
+            || routes.contains("use crate::schema::posts"),
+        "the referenced `posts` schema must be imported for the label loads:\n{routes}"
+    );
+    // The option loader IS emitted — the index parent-label map is built by
+    // collecting it into a HashMap, so it's a live dependency of the restored
+    // index display (not dead code).
+    assert!(
+        routes.contains("async fn post_id_select_options"),
+        "the option loader must be emitted (the index label map depends on it):\n{routes}"
+    );
+    // The in-FORM belongs_to `<select>` is what's deferred in live-validation
+    // (#1750): the FK renders through the per-field text-input path, not a
+    // dropdown / `form_for` select override.
+    assert!(
+        routes.contains("required_text_input(&changeset, \"post_id\", \"Post Id\")"),
+        "the FK form control is the per-field text input (select deferred):\n{routes}"
+    );
+    assert!(
+        !routes.contains(".override_field(\"post_id\""),
+        "no `form_for` select override is emitted in live-validation:\n{routes}"
+    );
+}
+
+#[test]
 fn nullable_reference_renders_dash_and_blank_option() {
     let (_tmp, routes) =
         belongs_to_routes("bt-nullable-app", &["title:String"], "post:references?");

--- a/autumn-cli/tests/integration/scaffold_form_for.rs
+++ b/autumn-cli/tests/integration/scaffold_form_for.rs
@@ -182,7 +182,7 @@ fn scaffold_references_column_overrides_to_select_and_loads_options() {
 
     // Issue #1135 AC 2: "references→select". The derive maps the `i64` FK
     // column to a number input; the scaffold promotes it to a select whose
-    // options are the referenced table's ids, loaded at render time by the
+    // options are the referenced table's rows, loaded at render time by the
     // controller and threaded through the shared helper.
     assert!(
         routes.contains(
@@ -200,9 +200,12 @@ fn scaffold_references_column_overrides_to_select_and_loads_options() {
         ),
         "the controller must have an options loader: {routes}"
     );
+    // Issue #1146: `Post` has a `title:String` column, so the loader selects
+    // the id + the display column (a `name`/`title` heuristic), labeling each
+    // option by the parent's title rather than its raw id.
     assert!(
-        routes.contains(".select(posts::id)"),
-        "the loader must query the referenced table's ids: {routes}"
+        routes.contains(".select((posts::id, posts::title))"),
+        "the loader must query the referenced table's id + display column: {routes}"
     );
     // Every form-rendering site loads the options: the new_form and edit_form
     // GET handlers plus the create/update 422 re-render branches.

--- a/autumn-cli/tests/integration/scaffold_validation.rs
+++ b/autumn-cli/tests/integration/scaffold_validation.rs
@@ -269,6 +269,47 @@ fn text_columns_render_constrained_textarea_not_input() {
     );
 }
 
+/// A `Text{email}` / `Text{url}` field is type-dependent and inherently
+/// single-line: a `<textarea>` can't carry `type="email"`/`type="url"`, so the
+/// standard `form_for` path must render an `<input type="email|url">` (not a
+/// textarea) or the DSL/doc-promised client-side format validation is lost.
+#[test]
+fn text_email_and_url_render_typed_input_not_textarea() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", "validate-text-email-app"]);
+    let project = tmp.path().join("validate-text-email-app");
+    run_autumn_ok(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Contact",
+            "email_addr:Text{email}",
+            "site:Text{url}",
+        ],
+    );
+    let routes = fs::read_to_string(project.join("src/routes/contacts.rs")).unwrap();
+
+    assert!(
+        routes.contains("type=\"email\" id=\"email_addr\""),
+        "a Text{{email}} field must render a typed email input:\n{routes}"
+    );
+    assert!(
+        routes.contains("type=\"url\" id=\"site\""),
+        "a Text{{url}} field must render a typed url input:\n{routes}"
+    );
+    // Neither may be a <textarea> (which can't carry type=email/url).
+    assert!(
+        !routes.contains("textarea id=\"email_addr\"") && !routes.contains("textarea id=\"site\""),
+        "type-dependent Text controls must not be textareas:\n{routes}"
+    );
+    // The 422 value is carried via the `value=` attribute (input, not content).
+    assert!(
+        routes.contains("value=(changeset.field_value(\"email_addr\").unwrap_or_default())"),
+        "the typed input must re-fill via a value= attribute:\n{routes}"
+    );
+}
+
 /// Slice a textarea's field-specific attributes: from the `id`/`name` marker
 /// up to the shared `class=` skeleton, so an assertion can't match a sibling
 /// control's attributes.

--- a/autumn-cli/tests/integration/scaffold_validation.rs
+++ b/autumn-cli/tests/integration/scaffold_validation.rs
@@ -173,7 +173,10 @@ fn unknown_constraint_modifier_fails_the_scaffold() {
     let tmp = tempfile::tempdir().expect("tempdir");
     run_autumn_ok(tmp.path(), &["new", "bad-modifier-app"]);
     let project = tmp.path().join("bad-modifier-app");
-    let output = run_autumn(&project, &["generate", "scaffold", "Post", "title:String{maxx=5}"]);
+    let output = run_autumn(
+        &project,
+        &["generate", "scaffold", "Post", "title:String{maxx=5}"],
+    );
     assert!(
         !output.status.success(),
         "an unknown modifier must fail the scaffold"

--- a/autumn-cli/tests/integration/scaffold_validation.rs
+++ b/autumn-cli/tests/integration/scaffold_validation.rs
@@ -128,6 +128,33 @@ fn form_inputs_carry_matching_html5_constraints() {
 }
 
 #[test]
+fn constrained_float_fields_keep_step_any() {
+    // A constrained float must keep `step="any"` so browsers don't default to
+    // `step="1"` and reject fractional input like `0.5` that the server-side
+    // range validator and the `f64` type accept (issue #1388 — the client and
+    // server constraints must agree). Matches the unconstrained float control.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", "validate-float-step-app"]);
+    let project = tmp.path().join("validate-float-step-app");
+    run_autumn_ok(
+        &project,
+        &["generate", "scaffold", "Reading", "ratio:f64{min=0,max=1}"],
+    );
+    let routes = fs::read_to_string(project.join("src/routes/readings.rs")).unwrap();
+    assert!(
+        routes.contains("type=\"number\" id=\"ratio\""),
+        "the constrained float must render as a number input:\n{routes}"
+    );
+    let ratio_input = slice_input(&routes, "id=\"ratio\" name=\"ratio\"");
+    assert!(
+        ratio_input.contains("min=\"0\"")
+            && ratio_input.contains("max=\"1\"")
+            && ratio_input.contains("step=\"any\""),
+        "constrained float must carry min/max AND step=any:\n{ratio_input}"
+    );
+}
+
+#[test]
 fn required_only_on_non_nullable_constrained_fields() {
     let (_tmp, project) = constrained_project("validate-required-app");
     let routes = fs::read_to_string(project.join("src/routes/posts.rs")).unwrap();

--- a/autumn-cli/tests/integration/scaffold_validation.rs
+++ b/autumn-cli/tests/integration/scaffold_validation.rs
@@ -370,6 +370,34 @@ fn out_of_range_i32_bound_fails_the_scaffold() {
 }
 
 #[test]
+fn email_and_url_together_fails_the_scaffold() {
+    // Emitting both `#[validate(email)]` and `#[validate(url)]` makes the field
+    // unwritable, so the mutually-exclusive pair is rejected up front with an
+    // actionable error naming the conflict and the field.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", "email-url-app"]);
+    let project = tmp.path().join("email-url-app");
+    let output = run_autumn(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Contact",
+            "contact:String{email,url}",
+        ],
+    );
+    assert!(
+        !output.status.success(),
+        "email + url on one field must fail the scaffold"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("mutually exclusive") && stderr.contains("contact"),
+        "the error must name the conflict and the field:\n{stderr}"
+    );
+}
+
+#[test]
 fn in_range_i32_bound_generates_and_type_checks_shape() {
     // The happy path: a valid in-range i32 bound still emits the range rule.
     let tmp = tempfile::tempdir().expect("tempdir");

--- a/autumn-cli/tests/integration/scaffold_validation.rs
+++ b/autumn-cli/tests/integration/scaffold_validation.rs
@@ -146,9 +146,11 @@ fn constrained_float_fields_keep_step_any() {
         "the constrained float must render as a number input:\n{routes}"
     );
     let ratio_input = slice_input(&routes, "id=\"ratio\" name=\"ratio\"");
+    // Float bounds are canonicalized to valid float literals (`0` -> `0.0`), so
+    // the HTML5 attributes carry the decimal form too.
     assert!(
-        ratio_input.contains("min=\"0\"")
-            && ratio_input.contains("max=\"1\"")
+        ratio_input.contains("min=\"0.0\"")
+            && ratio_input.contains("max=\"1.0\"")
             && ratio_input.contains("step=\"any\""),
         "constrained float must carry min/max AND step=any:\n{ratio_input}"
     );
@@ -382,6 +384,43 @@ fn in_range_i32_bound_generates_and_type_checks_shape() {
         model.contains("#[validate(range(max = 1000000))]"),
         "a valid in-range bound must still emit its range rule:\n{model}"
     );
+}
+
+#[test]
+fn non_canonical_numeric_bounds_generate_valid_rust_literals() {
+    // Bounds that parse but aren't valid Rust literals (`.5`, `+1`) must be
+    // canonicalized so the generated `#[validate(range(...))]` compiles:
+    // `.5` -> `0.5`, whole-number float `1` -> `1.0`, `+1` -> `1`.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", "canon-bound-app"]);
+    let project = tmp.path().join("canon-bound-app");
+    run_autumn_ok(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Post",
+            "ratio:f64{min=.5,max=1}",
+            "count:i32{min=+1,max=10}",
+        ],
+    );
+    let model = fs::read_to_string(project.join("src/models/post.rs")).unwrap();
+    assert!(
+        model.contains("#[validate(range(min = 0.5, max = 1.0))]"),
+        "the float bounds must be canonical valid float literals:\n{model}"
+    );
+    assert!(
+        model.contains("#[validate(range(min = 1, max = 10))]"),
+        "the `+1` integer bound must canonicalize to `1`:\n{model}"
+    );
+    // No raw non-canonical tokens should survive anywhere in the generated app.
+    let routes = fs::read_to_string(project.join("src/routes/posts.rs")).unwrap();
+    for bad in ["=.5", "\".5\"", "min = .5", "= +1", "\"+1\""] {
+        assert!(
+            !model.contains(bad) && !routes.contains(bad),
+            "no raw non-canonical bound token ({bad}) may survive:\nmodel:\n{model}\nroutes:\n{routes}"
+        );
+    }
 }
 
 /// Slow end-to-end check: the constrained scaffold (model `#[validate]` rules,

--- a/autumn-cli/tests/integration/scaffold_validation.rs
+++ b/autumn-cli/tests/integration/scaffold_validation.rs
@@ -303,6 +303,46 @@ fn unknown_constraint_modifier_fails_the_scaffold() {
     );
 }
 
+#[test]
+fn out_of_range_i32_bound_fails_the_scaffold() {
+    // `3000000000` > i32::MAX: emitting `#[validate(range(max = 3000000000))]`
+    // on an `i32` field would fail to COMPILE the generated app, so the
+    // generator must reject the bound up front with an actionable message.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", "oob-bound-app"]);
+    let project = tmp.path().join("oob-bound-app");
+    let output = run_autumn(
+        &project,
+        &["generate", "scaffold", "Post", "count:i32{max=3000000000}"],
+    );
+    assert!(
+        !output.status.success(),
+        "an out-of-range i32 bound must fail the scaffold"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("3000000000") && stderr.contains("i32"),
+        "the error must name the bad bound and the field type:\n{stderr}"
+    );
+}
+
+#[test]
+fn in_range_i32_bound_generates_and_type_checks_shape() {
+    // The happy path: a valid in-range i32 bound still emits the range rule.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", "in-range-bound-app"]);
+    let project = tmp.path().join("in-range-bound-app");
+    run_autumn_ok(
+        &project,
+        &["generate", "scaffold", "Post", "count:i32{max=1000000}"],
+    );
+    let model = fs::read_to_string(project.join("src/models/post.rs")).unwrap();
+    assert!(
+        model.contains("#[validate(range(max = 1000000))]"),
+        "a valid in-range bound must still emit its range rule:\n{model}"
+    );
+}
+
 /// Slow end-to-end check: the constrained scaffold (model `#[validate]` rules,
 /// validator dependency, HTML5-attributed form controls) type-checks against
 /// this workspace's `autumn-web`.

--- a/autumn-cli/tests/integration/scaffold_validation.rs
+++ b/autumn-cli/tests/integration/scaffold_validation.rs
@@ -1,0 +1,223 @@
+//! Scaffold DSL constraint modifiers fan out to BOTH server-side `#[validate]`
+//! rules and client-side HTML5 input constraints from one declaration
+//! (issue #1388).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn autumn_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_autumn")
+}
+
+fn run_autumn(dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(autumn_bin())
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to run autumn")
+}
+
+fn run_autumn_ok(dir: &Path, args: &[&str]) {
+    let output = run_autumn(dir, args);
+    assert!(
+        output.status.success(),
+        "autumn {args:?} failed (exit={:?})\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// `autumn new` + `generate scaffold Post` with a representative constraint mix.
+fn constrained_project(name: &str) -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", name]);
+    let project = tmp.path().join(name);
+    run_autumn_ok(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Post",
+            "title:String{min=3,max=120}",
+            "contact:String{email}",
+            "homepage:String{url}",
+            "age:i32{min=0,max=130}",
+            "bio:Option<String>{max=200}",
+        ],
+    );
+    (tmp, project)
+}
+
+#[test]
+fn model_carries_validate_attributes_from_dsl_constraints() {
+    let (_tmp, project) = constrained_project("validate-model-app");
+    let model = fs::read_to_string(project.join("src/models/post.rs")).unwrap();
+
+    assert!(
+        model.contains("#[validate(length(min = 3, max = 120))]"),
+        "title must get a length rule:\n{model}"
+    );
+    assert!(
+        model.contains("#[validate(email)]"),
+        "contact must get an email rule:\n{model}"
+    );
+    assert!(
+        model.contains("#[validate(url)]"),
+        "homepage must get a url rule:\n{model}"
+    );
+    assert!(
+        model.contains("#[validate(range(min = 0, max = 130))]"),
+        "age must get a range rule:\n{model}"
+    );
+    assert!(
+        model.contains("#[validate(length(max = 200))]"),
+        "nullable bio must still get its max-length rule:\n{model}"
+    );
+}
+
+#[test]
+fn cargo_toml_pulls_in_validator_dependency() {
+    let (_tmp, project) = constrained_project("validate-cargo-app");
+    let cargo = fs::read_to_string(project.join("Cargo.toml")).unwrap();
+    assert!(
+        cargo.contains("validator"),
+        "the validator crate must be added when constraints are present:\n{cargo}"
+    );
+}
+
+#[test]
+fn form_inputs_carry_matching_html5_constraints() {
+    let (_tmp, project) = constrained_project("validate-form-app");
+    let routes = fs::read_to_string(project.join("src/routes/posts.rs")).unwrap();
+
+    // The constrained fields are excised from the derived render and
+    // re-appended with HTML5 attributes.
+    for field in ["title", "contact", "homepage", "age", "bio"] {
+        assert!(
+            routes.contains(&format!(".exclude(\"{field}\")")),
+            "{field} must be excluded from the derived render:\n{routes}"
+        );
+    }
+
+    assert!(
+        routes.contains("minlength=\"3\" maxlength=\"120\""),
+        "title must render minlength/maxlength:\n{routes}"
+    );
+    assert!(
+        routes.contains("type=\"email\""),
+        "contact must render type=email:\n{routes}"
+    );
+    assert!(
+        routes.contains("type=\"url\""),
+        "homepage must render type=url:\n{routes}"
+    );
+    assert!(
+        routes.contains("type=\"number\"") && routes.contains("min=\"0\" max=\"130\""),
+        "age must render type=number with min/max:\n{routes}"
+    );
+    assert!(
+        routes.contains("maxlength=\"200\""),
+        "bio must render maxlength:\n{routes}"
+    );
+}
+
+#[test]
+fn required_only_on_non_nullable_constrained_fields() {
+    let (_tmp, project) = constrained_project("validate-required-app");
+    let routes = fs::read_to_string(project.join("src/routes/posts.rs")).unwrap();
+
+    // The non-nullable `title` input keeps the browser-native required signal;
+    // the nullable `bio` input must NOT (leaving it blank is valid).
+    let title_input = slice_input(&routes, "id=\"title\" name=\"title\"");
+    assert!(
+        title_input.contains("required aria-required=\"true\""),
+        "non-nullable title must be required:\n{title_input}"
+    );
+    let bio_input = slice_input(&routes, "id=\"bio\" name=\"bio\"");
+    assert!(
+        !bio_input.contains("required"),
+        "nullable bio must not be required:\n{bio_input}"
+    );
+}
+
+/// Slice from an input's id/name marker to the terminating `;` so a
+/// field-scoped attribute assertion doesn't accidentally match a sibling.
+fn slice_input<'a>(routes: &'a str, marker: &str) -> &'a str {
+    let start = routes
+        .find(marker)
+        .unwrap_or_else(|| panic!("missing {marker} in:\n{routes}"));
+    let end = routes[start..]
+        .find(';')
+        .map_or(routes.len(), |rel| start + rel);
+    &routes[start..end]
+}
+
+#[test]
+fn preserved_value_binding_survives_422_rerender() {
+    let (_tmp, project) = constrained_project("validate-rerender-app");
+    let routes = fs::read_to_string(project.join("src/routes/posts.rs")).unwrap();
+    // The appended control re-fills its value from the changeset, so a 422
+    // re-render keeps what the user typed.
+    assert!(
+        routes.contains("value=(changeset.field_value(\"title\").unwrap_or_default())"),
+        "constrained inputs must re-fill from the changeset:\n{routes}"
+    );
+}
+
+#[test]
+fn unknown_constraint_modifier_fails_the_scaffold() {
+    // AC5: a misspelled modifier fails loudly, naming the offending token,
+    // rather than being silently dropped.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", "bad-modifier-app"]);
+    let project = tmp.path().join("bad-modifier-app");
+    let output = run_autumn(&project, &["generate", "scaffold", "Post", "title:String{maxx=5}"]);
+    assert!(
+        !output.status.success(),
+        "an unknown modifier must fail the scaffold"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("maxx"),
+        "the error must name the offending token:\n{stderr}"
+    );
+}
+
+/// Slow end-to-end check: the constrained scaffold (model `#[validate]` rules,
+/// validator dependency, HTML5-attributed form controls) type-checks against
+/// this workspace's `autumn-web`.
+///
+/// Ignored by default; run with `cargo test -p autumn-cli -- --ignored`.
+#[test]
+#[ignore = "slow: cargo-checks a fresh project — run with `cargo test -p autumn-cli -- --ignored`"]
+fn constrained_scaffold_cargo_checks() {
+    use std::fmt::Write as _;
+
+    let (_tmp, project) = constrained_project("validate-check-app");
+    let cargo_toml_path = project.join("Cargo.toml");
+    let mut content = fs::read_to_string(&cargo_toml_path).unwrap();
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root");
+    let autumn_web = workspace_root.join("autumn");
+    let _ = write!(
+        content,
+        "\n[patch.crates-io]\nautumn-web = {{ path = \"{}\" }}\n",
+        autumn_web.display().to_string().replace('\\', "/")
+    );
+    fs::write(&cargo_toml_path, content).unwrap();
+
+    let check = Command::new("cargo")
+        .args(["check", "--tests"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    assert!(
+        check.status.success(),
+        "cargo check on the constrained scaffold failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr),
+    );
+}

--- a/autumn-cli/tests/integration/scaffold_validation.rs
+++ b/autumn-cli/tests/integration/scaffold_validation.rs
@@ -170,6 +170,90 @@ fn preserved_value_binding_survives_422_rerender() {
     );
 }
 
+/// A `Text` DSL column is long-form (Postgres `TEXT`), so its constrained
+/// control must be a multi-line `<textarea>` — not the single-line `<input>`
+/// the `String` columns get — while still carrying the length/`required`
+/// constraints and re-filling on a 422.
+#[test]
+fn text_columns_render_constrained_textarea_not_input() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", "validate-textarea-app"]);
+    let project = tmp.path().join("validate-textarea-app");
+    run_autumn_ok(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Article",
+            "body:Text{min=10,max=5000}",
+            "notes:Option<Text>{max=1000}",
+        ],
+    );
+    let routes = fs::read_to_string(project.join("src/routes/articles.rs")).unwrap();
+
+    // Both text columns are excised from the derived render and re-appended.
+    for field in ["body", "notes"] {
+        assert!(
+            routes.contains(&format!(".exclude(\"{field}\")")),
+            "{field} must be excluded from the derived render:\n{routes}"
+        );
+        assert!(
+            routes.contains(&format!("textarea id=\"{field}\" name=\"{field}\"")),
+            "{field} must render a <textarea>:\n{routes}"
+        );
+    }
+
+    // A `text` column must never fall back to a single-line text `<input>`,
+    // and its length constraints must not be spelled with input-only `type`.
+    assert!(
+        !routes.contains("input type=\"text\" id=\"body\""),
+        "body must not render a single-line text input:\n{routes}"
+    );
+
+    // The non-nullable `body` carries the length rules + required, and its
+    // value is the element's text content, not a `value=` attribute.
+    let body_attrs = slice_textarea_attrs(&routes, "textarea id=\"body\" name=\"body\"");
+    assert!(
+        body_attrs.contains("minlength=\"10\"") && body_attrs.contains("maxlength=\"5000\""),
+        "body textarea must carry minlength/maxlength:\n{body_attrs}"
+    );
+    assert!(
+        body_attrs.contains("required aria-required=\"true\""),
+        "non-nullable body textarea must be required:\n{body_attrs}"
+    );
+    assert!(
+        routes.contains("(changeset.field_value(\"body\").unwrap_or_default())"),
+        "body textarea must re-fill from the changeset:\n{routes}"
+    );
+    assert!(
+        !routes.contains("value=(changeset.field_value(\"body\")"),
+        "body value must be textarea text content, not a value= attribute:\n{routes}"
+    );
+
+    // The nullable `notes` keeps only its maxlength — no required, no minlength.
+    let notes_attrs = slice_textarea_attrs(&routes, "textarea id=\"notes\" name=\"notes\"");
+    assert!(
+        notes_attrs.contains("maxlength=\"1000\""),
+        "notes textarea must carry maxlength:\n{notes_attrs}"
+    );
+    assert!(
+        !notes_attrs.contains("required") && !notes_attrs.contains("minlength"),
+        "nullable notes textarea must be neither required nor minlength-bound:\n{notes_attrs}"
+    );
+}
+
+/// Slice a textarea's field-specific attributes: from the `id`/`name` marker
+/// up to the shared `class=` skeleton, so an assertion can't match a sibling
+/// control's attributes.
+fn slice_textarea_attrs<'a>(routes: &'a str, marker: &str) -> &'a str {
+    let start = routes
+        .find(marker)
+        .unwrap_or_else(|| panic!("missing {marker} in:\n{routes}"));
+    let rest = &routes[start..];
+    let end = rest.find("class=").unwrap_or(rest.len());
+    &rest[..end]
+}
+
 #[test]
 fn unknown_constraint_modifier_fails_the_scaffold() {
     // AC5: a misspelled modifier fails loudly, naming the offending token,

--- a/autumn-cli/tests/integration/scaffold_validation.rs
+++ b/autumn-cli/tests/integration/scaffold_validation.rs
@@ -2,11 +2,15 @@
 //! rules and client-side HTML5 input constraints from one declaration
 //! (issue #1388).
 
+// DSL tokens like `"contact:String{email}"` are literal scaffold inputs, not
+// format strings — the `{email}`/`{url}`/`{min=…}` is the modifier under test.
+#![allow(clippy::literal_string_with_formatting_args)]
+
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-fn autumn_bin() -> &'static str {
+const fn autumn_bin() -> &'static str {
     env!("CARGO_BIN_EXE_autumn")
 }
 

--- a/autumn-cli/tests/integration/seed_model_linking.rs
+++ b/autumn-cli/tests/integration/seed_model_linking.rs
@@ -1,0 +1,141 @@
+//! `generate model`/`scaffold` must link scaffolded models into the
+//! standalone `src/bin/seed.rs` binary (issue #1718), so
+//! `autumn seed --count N --model M` can resolve the model through the
+//! `#[model]` inventory registry — completing AC4 of #1343 for a real
+//! scaffolded app (not just the `examples/bookmarks` seed that declared its
+//! model inline in `seed.rs`).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn run_autumn(dir: &Path, args: &[&str]) {
+    let autumn_bin = env!("CARGO_BIN_EXE_autumn");
+    let output = Command::new(autumn_bin)
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to run autumn");
+    assert!(
+        output.status.success(),
+        "autumn {args:?} failed (exit={:?})\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// `autumn new <name> --with-seed` then `generate scaffold Post title:String`.
+fn seed_project(project_name: &str) -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn(tmp.path(), &["new", project_name, "--with-seed"]);
+    let project = tmp.path().join(project_name);
+    run_autumn(
+        &project,
+        &["generate", "scaffold", "Post", "title:String"],
+    );
+    (tmp, project)
+}
+
+#[test]
+fn scaffold_links_models_and_schema_into_seed_binary() {
+    let (_tmp, project) = seed_project("seed-linked-app");
+    let seed = fs::read_to_string(project.join("src/bin/seed.rs")).unwrap();
+
+    assert!(
+        seed.contains("#[path = \"../schema.rs\"]\nmod schema;"),
+        "seed.rs must declare the schema module via #[path]:\n{seed}"
+    );
+    assert!(
+        seed.contains("#[path = \"../models/mod.rs\"]\nmod models;"),
+        "seed.rs must declare the models module via #[path]:\n{seed}"
+    );
+    // The declarations are items, so they must land after the crate-level
+    // `//!` doc block (which the template emits) — otherwise the file won't
+    // parse.
+    let mods_at = seed.find("mod schema;").unwrap();
+    let doc_at = seed.find("//!").unwrap();
+    assert!(doc_at < mods_at, "mods must follow the doc block:\n{seed}");
+}
+
+#[test]
+fn second_generate_does_not_duplicate_seed_links() {
+    let (_tmp, project) = seed_project("seed-idempotent-app");
+    // A second model must not re-inject the shared declarations.
+    run_autumn(
+        &project,
+        &["generate", "model", "Comment", "body:Text"],
+    );
+    let seed = fs::read_to_string(project.join("src/bin/seed.rs")).unwrap();
+    assert_eq!(
+        seed.matches("mod schema;").count(),
+        1,
+        "schema module must be declared exactly once:\n{seed}"
+    );
+    assert_eq!(
+        seed.matches("mod models;").count(),
+        1,
+        "models module must be declared exactly once:\n{seed}"
+    );
+}
+
+#[test]
+fn project_without_seed_binary_leaves_no_seed_file() {
+    // A plain (non-`--with-seed`) project has no seed binary to link into;
+    // the generator must not create one.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn(tmp.path(), &["new", "no-seed-app"]);
+    let project = tmp.path().join("no-seed-app");
+    run_autumn(
+        &project,
+        &["generate", "scaffold", "Post", "title:String"],
+    );
+    assert!(
+        !project.join("src/bin/seed.rs").exists(),
+        "no seed binary must be created for a project generated without --with-seed"
+    );
+}
+
+/// Slow end-to-end check: the linked seed binary (plus the scaffolded model
+/// and schema it now pulls in) actually type-checks against this workspace's
+/// `autumn-web`. This is the compile-side proof that
+/// `autumn seed --count/--model` can resolve the model — the `#[model]`
+/// inventory `submit!` is only reachable if `src/bin/seed.rs` compiles the
+/// model in, which is exactly what the `#[path]` links achieve.
+///
+/// Ignored by default; run with `cargo test -p autumn-cli -- --ignored`.
+#[test]
+#[ignore = "slow: cargo-checks a fresh project — run with `cargo test -p autumn-cli -- --ignored`"]
+fn linked_seed_binary_cargo_checks() {
+    use std::fmt::Write as _;
+
+    let (_tmp, project) = seed_project("seed-check-app");
+
+    // Point the generated project at this workspace's autumn-web.
+    let cargo_toml_path = project.join("Cargo.toml");
+    let mut content = fs::read_to_string(&cargo_toml_path).unwrap();
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root");
+    let autumn_web = workspace_root.join("autumn");
+    let _ = write!(
+        content,
+        "\n[patch.crates-io]\nautumn-web = {{ path = \"{}\" }}\n",
+        autumn_web.display().to_string().replace('\\', "/")
+    );
+    fs::write(&cargo_toml_path, content).unwrap();
+
+    // `--bins` builds the `seed` binary too — the target that used to link
+    // neither models nor schema.
+    let check = Command::new("cargo")
+        .args(["check", "--bins"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    assert!(
+        check.status.success(),
+        "cargo check --bins on the linked seed project failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr),
+    );
+}

--- a/autumn-cli/tests/integration/seed_model_linking.rs
+++ b/autumn-cli/tests/integration/seed_model_linking.rs
@@ -30,10 +30,7 @@ fn seed_project(project_name: &str) -> (tempfile::TempDir, PathBuf) {
     let tmp = tempfile::tempdir().expect("tempdir");
     run_autumn(tmp.path(), &["new", project_name, "--with-seed"]);
     let project = tmp.path().join(project_name);
-    run_autumn(
-        &project,
-        &["generate", "scaffold", "Post", "title:String"],
-    );
+    run_autumn(&project, &["generate", "scaffold", "Post", "title:String"]);
     (tmp, project)
 }
 
@@ -62,10 +59,7 @@ fn scaffold_links_models_and_schema_into_seed_binary() {
 fn second_generate_does_not_duplicate_seed_links() {
     let (_tmp, project) = seed_project("seed-idempotent-app");
     // A second model must not re-inject the shared declarations.
-    run_autumn(
-        &project,
-        &["generate", "model", "Comment", "body:Text"],
-    );
+    run_autumn(&project, &["generate", "model", "Comment", "body:Text"]);
     let seed = fs::read_to_string(project.join("src/bin/seed.rs")).unwrap();
     assert_eq!(
         seed.matches("mod schema;").count(),
@@ -86,10 +80,7 @@ fn project_without_seed_binary_leaves_no_seed_file() {
     let tmp = tempfile::tempdir().expect("tempdir");
     run_autumn(tmp.path(), &["new", "no-seed-app"]);
     let project = tmp.path().join("no-seed-app");
-    run_autumn(
-        &project,
-        &["generate", "scaffold", "Post", "title:String"],
-    );
+    run_autumn(&project, &["generate", "scaffold", "Post", "title:String"]);
     assert!(
         !project.join("src/bin/seed.rs").exists(),
         "no seed binary must be created for a project generated without --with-seed"

--- a/autumn-cli/tests/integration/seed_model_linking.rs
+++ b/autumn-cli/tests/integration/seed_model_linking.rs
@@ -87,6 +87,65 @@ fn project_without_seed_binary_leaves_no_seed_file() {
     );
 }
 
+#[test]
+fn destroying_the_last_model_removes_the_seed_links() {
+    let (_tmp, project) = seed_project("seed-destroy-last-app");
+    let seed = fs::read_to_string(project.join("src/bin/seed.rs")).unwrap();
+    assert!(
+        seed.contains("mod schema;") && seed.contains("mod models;"),
+        "precondition: generate must have linked the modules:\n{seed}"
+    );
+
+    // Destroying the only model empties and DELETES src/schema.rs and
+    // src/models/mod.rs, so the seed binary's `#[path]` links to them must be
+    // removed too — otherwise `cargo check --bins` fails on missing files.
+    run_autumn(&project, &["destroy", "scaffold", "Post", "title:String"]);
+
+    assert!(
+        !project.join("src/schema.rs").exists(),
+        "destroying the last model must delete src/schema.rs"
+    );
+    assert!(
+        !project.join("src/models/mod.rs").exists(),
+        "destroying the last model must delete src/models/mod.rs"
+    );
+    let seed = fs::read_to_string(project.join("src/bin/seed.rs")).unwrap();
+    assert!(
+        !seed.contains("mod schema;") && !seed.contains("mod models;"),
+        "seed.rs must not keep links to the deleted modules:\n{seed}"
+    );
+    assert!(
+        !seed.contains("#[path = \"../schema.rs\"]")
+            && !seed.contains("#[path = \"../models/mod.rs\"]"),
+        "seed.rs must not keep dangling #[path] attributes:\n{seed}"
+    );
+}
+
+#[test]
+fn destroying_one_of_several_models_keeps_the_seed_links() {
+    let (_tmp, project) = seed_project("seed-destroy-one-app");
+    // A second model gives src/models/ a survivor.
+    run_autumn(&project, &["generate", "model", "Comment", "body:Text"]);
+    // Destroy only Comment: Post's model file remains, so src/models/mod.rs and
+    // src/schema.rs survive — the seed links must be KEPT in lockstep.
+    run_autumn(&project, &["destroy", "model", "Comment", "body:Text"]);
+
+    assert!(
+        project.join("src/models/mod.rs").exists(),
+        "src/models/mod.rs must survive while Post remains"
+    );
+    assert!(
+        project.join("src/schema.rs").exists(),
+        "src/schema.rs must survive while Post remains"
+    );
+    let seed = fs::read_to_string(project.join("src/bin/seed.rs")).unwrap();
+    assert!(
+        seed.contains("#[path = \"../schema.rs\"]\nmod schema;")
+            && seed.contains("#[path = \"../models/mod.rs\"]\nmod models;"),
+        "seed links must be kept while another model still exists:\n{seed}"
+    );
+}
+
 /// Slow end-to-end check: the linked seed binary (plus the scaffolded model
 /// and schema it now pulls in) actually type-checks against this workspace's
 /// `autumn-web`. This is the compile-side proof that

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -82,6 +82,37 @@ Wrap any of the above in `Option<…>` to make the column nullable
 (`Option<String>`, `Option<i64>`, `Option<NaiveDateTime>`, …). The generator
 emits both `NULL` in the migration SQL and `Nullable<T>` in `schema.rs`.
 
+### Validation and HTML5 constraints (`{…}` modifiers)
+
+Add a trailing `{…}` block to a field to declare constraints once and have
+them enforced on **both** sides — a server-side `#[validate(...)]` rule *and*
+the matching client-side HTML5 input attribute:
+
+```bash
+autumn generate scaffold Post \
+  'title:String{min=3,max=120}' \
+  'contact:String{email}' \
+  'homepage:String{url}' \
+  'age:i32{min=0,max=130}'
+```
+
+| Modifier                        | Applies to        | `#[validate(…)]`        | HTML5 attribute(s)        |
+| ------------------------------- | ----------------- | ----------------------- | ------------------------- |
+| `{min=N,max=N}` (String/Text)   | `String`/`Text`   | `length(min, max)`      | `minlength` / `maxlength` |
+| `{min=N,max=N}` (numeric)       | `i32`/`i64`/`f32`/`f64` | `range(min, max)` | `min` / `max` (`type="number"`) |
+| `{email}`                       | `String`/`Text`   | `email`                 | `type="email"`            |
+| `{url}`                         | `String`/`Text`   | `url`                   | `type="url"`              |
+
+The generated model field carries the `#[validate(...)]` attribute (so a bad
+submission is rejected through the existing changeset path as a **422 with
+inline per-field errors**, never a 500 or a silent store), and the generated
+form input carries the matching HTML5 attribute (so the browser blocks bad
+input before it hits the network). The `required` signal from a non-nullable
+column is preserved, and a rejected submission re-renders keeping the entered
+values. A misspelled modifier (e.g. `{maxx=5}`) fails the scaffold with an
+error naming the offending token. Quote the whole token in bash/zsh so the
+shell doesn't brace-expand the comma.
+
 Every generated table also includes:
 
 - `id BIGSERIAL PRIMARY KEY` (the `i64`-PK convention used everywhere else
@@ -108,6 +139,35 @@ If the referenced model doesn't exist yet (no `src/models/post.rs`, or a
 matching declaration in a single-file `src/models.rs`), the generator still
 scaffolds the column, constraint, and index — it just prints a warning that
 the referenced table is assumed to already exist.
+
+#### belongs_to dropdowns (populated from the parent)
+
+When the referenced model *does* exist, the scaffolded new/edit form renders
+the foreign key as a **populated `<select>`** — one `<option>` per parent row
+— instead of a text box demanding a raw numeric id, and the index/show views
+render the parent's **display value** rather than the raw `*_id` integer. No
+hand-editing required:
+
+```bash
+autumn generate model Post title:String
+autumn generate scaffold Comment body:Text post:references
+# → the new-comment form's "post" field is a dropdown of existing posts,
+#   labeled by each post's title; the comment index/show show the post title.
+```
+
+The **display column** is chosen by heuristic: a `name` or `title` column if
+present, otherwise the first `String`/`Text` column, falling back to the id
+only when the parent has no string column. Override it explicitly with a
+`{label:col}` modifier:
+
+```bash
+autumn generate scaffold Comment body:Text 'post:references{label:slug}'
+```
+
+A nullable reference (`post:references?`) renders a blank "— Unset —" first
+option so the selection can be cleared, and its index/show views render a dash
+when unset. (Index/show use a simple per-view fetch; the N+1-safe batched
+variant is issue #835.)
 
 `references` only supports the i64/BIGSERIAL primary-key convention. If the
 referenced model *is* found but was generated with `--id uuid`, the generator


### PR DESCRIPTION
## Before

Scaffolding a real relational app on Autumn had three sharp edges that all demanded hand-editing generated code:

- **Foreign keys were unusable.** A `references` field rendered a `<select>` whose options were labeled by raw numeric ids, and the index/show views printed `post_id = 42` instead of the post's title. You had to know and type FK integers.
- **Zero validation.** `name:type` was the whole DSL — it couldn't express a single constraint, so generated models carried no `#[validate]` rules and forms no HTML5 hints. An empty title or `"not-an-email"` was stored as garbage or 500'd at the database.
- **`autumn seed --count/--model` couldn't see scaffolded models.** The seed `[[bin]]` linked neither `main.rs` nor `src/models/`, so the model registry was empty and `--model Post` returned `unknown model Post; available: (none)`.

## After

- **belongs_to just works (#1146).** A `references` field renders a **populated dropdown** labeled by a display column (`name`/`title` heuristic, or `{label:col}`), and index/show render the parent's display value — zero hand-edits.
- **One declaration, both sides (#1388).** `title:String{min=3,max=120}`, `contact:String{email}`, `age:i32{min=0,max=130}` emit **both** a server-side `#[validate(...)]` rule (422 + inline errors, never a 500/silent store) **and** the matching HTML5 attribute (`minlength`/`maxlength`/`min`/`max`/`type=email`), with entered values preserved on a 422 re-render.
- **Seeding resolves scaffolded models (#1718).** `autumn generate model/scaffold` links `src/models/` + `src/schema.rs` into `src/bin/seed.rs`, so `autumn seed --count 200 --model Post` inserts 200 faked rows with no hand-editing.

## How

- `autumn-cli/src/generate/dsl.rs`: new `FieldConstraints` on the parsed `Field`; a trailing `{…}` modifier block parsed against the field kind (`min`/`max`/`email`/`url` for scalars, `label:col` for `references`), with `Field::validation_attrs()` fanning out to `#[validate]`.
- `autumn-cli/src/generate/model.rs`: DSL constraints feed the existing `#[validate]` pipeline (auto-wiring the `validator` dep); `model_string_columns()` parses a referenced model with `syn` to resolve a display column.
- `autumn-cli/src/generate/scaffold.rs`: constrained inputs get HTML5 attributes via the `.exclude()`+`.append()` escape hatch (no runtime API change); the reference option loader selects the display column; index/show render the parent's label.
- `autumn-cli/src/generate/schema_edit.rs`: `link_models_into_seed_bin()` injects `#[path]`-qualified `mod schema;`/`mod models;` into `src/bin/seed.rs`.

## #1718 — option chosen

The issue analyzes two fixes. I implemented **option (b): generator-injected `#[path]` mods** over option (a) a shared `src/lib.rs`. Rationale: option (a) flips the current `!src/lib.rs` invariant that existing tests assert and is a cross-cutting app-skeleton change beyond a single feature PR; option (b) is the narrower, invariant-preserving edit the issue itself calls "the smaller change." It needs no destroy-time removal — `autumn destroy` only strips lines from `src/models/mod.rs`/`src/schema.rs` (never deletes the files), so the `#[path]` targets always exist and an emptied module simply contributes nothing to the registry.

---

## AC audit — #1146 (belongs_to select dropdowns)

| Verbatim AC | Evidence |
| --- | --- |
| For a `:references` field, emit the new/edit form control as a **populated `select_input`** … current value pre-selected on edit. | Reference columns are promoted to `FieldControl::Select` (pre-existing #1135 machinery); pre-selection comes from the changeset value matching the option value (the id). Test `scaffold_references_column_overrides_to_select_and_loads_options`. |
| The generated new/edit **handler loads the option set** … no hand-wiring. | Every form-rendering site calls `post_id_select_options(&mut db)` (4×). Same test. |
| Each `<option>` labeled by a **display column**: `name`/`title`, else first String/Text, else id; `{label:col}` override. | Loader selects `(posts::id, posts::title)`; `name` beats other string cols; `{label:slug}` selects `posts::slug`; no-string-column falls back to `.select(posts::id)`. Tests `select_loader_uses_title_display_column_heuristic`, `select_loader_prefers_name_over_other_string_columns`, `label_override_selects_the_named_column`, `falls_back_to_id_when_target_has_no_string_column`. |
| A **nullable** reference renders a blank "— none —" first option and allows clearing. | Nullable ref emits a blank `"— Unset —"` first option; index/show render a dash when unset. Test `nullable_reference_renders_dash_and_blank_option`. |
| index and show render the **parent's display label**, not the raw `*_id`. | Show loads `post_id_label` and renders `(post_id_label)` (no `(row.post_id)`); index loads a `post_id_labels` map and looks it up per row. Tests `show_view_renders_parent_label_not_raw_fk`, `index_view_renders_parent_label_via_loaded_map`. |
| Generator test scaffolds `Post`+`Comment`, checks rendered new-form HTML has `<select>` with one `<option>` per seeded post and **zero** `<input type=number>`. | `post_id` is a `FieldControl::Select` (never a number input); options load from `posts`. Covered by the loader/override assertions; the belongs_to app `cargo check`s (ignored `belongs_to_scaffold_cargo_checks`, run locally — see verification). |
| Docs: relational-scaffold guide shows the flow + label convention. | `docs/guide/generators.md` "belongs_to dropdowns" section. |

## AC audit — #1388 (validation + HTML5 constraints)

| Verbatim AC | Evidence |
| --- | --- |
| DSL accepts constraint modifiers in braces after the type: `title:string{min=3,max=120}`, `email:string{email}`, `homepage:string{url}`, `age:i32{min=0,max=130}`. | `parse_field` parses `{…}` per kind. Tests `parse_string_length_constraint`, `parse_string_email_constraint`, `parse_string_url_constraint`, `parse_numeric_range_constraint`. |
| Generated model field carries the matching `#[validate(...)]` (`length`, `email`, `url`, `range`) → 422 + per-field errors, not 500/silent store. | Model emits `#[validate(length(min = 3, max = 120))]`, `#[validate(email)]`, `#[validate(url)]`, `#[validate(range(min = 0, max = 130))]`. Test `model_carries_validate_attributes_from_dsl_constraints`. |
| Generated form input carries the corresponding HTML5 attribute; existing `required` preserved. | Form renders `minlength`/`maxlength`, `type="email"`, `type="url"`, `type="number" min max`; `required` only on non-nullable. Tests `form_inputs_carry_matching_html5_constraints`, `required_only_on_non_nullable_constrained_fields`. |
| Scaffold-to-runtime round-trip: model compiles, rejects empty title + malformed email server-side (422), renders `title` with `minlength="3" maxlength="120" required` and `contact` as `type="email"`. | Constrained scaffold `cargo check`s clean (ignored `constrained_scaffold_cargo_checks`, run locally — see verification); markup asserted by the form test. |
| Unknown/misspelled modifier (`{maxx=5}`) fails the scaffold naming the token. | Test `unknown_constraint_modifier_fails_the_scaffold` + `unknown_constraint_modifier_is_rejected_by_name`. |
| Modifiers compose with #1131 typed inputs and #1124 error re-render: numeric `{min,max}` → `type=number min max`; range rejection surfaces inline; 422 keeps values. | Numeric field keeps native type on the form struct so `#[validate(range)]` compiles + 422s inline; `value=(changeset.field_value(...))` preserves input. Test `preserved_value_binding_survives_422_rerender`. |

## AC audit — #1718 (link scaffolded models into the seed binary)

| Verbatim AC | Evidence |
| --- | --- |
| `autumn new --with-seed` → `generate scaffold Post` → `autumn seed --count 200 --model Post` inserts 200 faked Post rows without editing `src/bin/seed.rs`. | `generate scaffold`/`model` inject idempotent `#[path]`-qualified `mod schema;`/`mod models;` into `seed.rs`; the linked seed binary `cargo check --bins` passes, so the `#[model]` inventory registration is compiled in and `--model Post` resolves. Tests `scaffold_links_models_and_schema_into_seed_binary`, `second_generate_does_not_duplicate_seed_links`, `project_without_seed_binary_leaves_no_seed_file`, and the e2e `linked_seed_binary_cargo_checks` (verified locally, output below). |

This also completes the deferred **AC4 of #1343** ("`autumn seed --count/--model` generates and inserts N faked rows for a scaffolded model without editing `src/bin/seed.rs`"): the seed binary now links the scaffolded model, so the fake-seed dispatch resolves it.

---

## Testing

- `autumn-cli` unit tests: 1427 passed (incl. 123 DSL tests).
- New integration tests: `scaffold_belongs_to` (7), `scaffold_validation` (6), `seed_model_linking` (3), plus updated `scaffold_form_for`.
- Real-CLI e2e (ignored, run locally): a `Post`+`Comment` belongs_to scaffold, a constrained-field scaffold, and a `--with-seed` linked seed binary each `cargo check` exit 0 against this workspace's `autumn-web`.
- `cargo fmt --all --check` clean; `cargo clippy -p autumn-cli --all-targets -- -D warnings` clean.

## Notes

- No inline `style=` in emitted views; no widget `story!` functions added; no workspace version bump.
- Sharded/live index variants keep id rendering for references (their `ShardedDb`/`<ul>` shapes don't take the plain `Db`-loaded label map); the N+1-safe batched display is out of scope (#835).

Closes #1146, #1388, #1718

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUKQcqFc7o6JFUFmXZfWUU)_