### PR TITLE
Macros follow-ups: Validate on UpdateModel (#1719) + has_many(dependent=…) parser guard (#1702) + across_tenants() no-shard-set fix (#1692)

### DIFF
--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -966,9 +966,11 @@ fn validate_attrs(field: &Field) -> Vec<&syn::Attribute> {
         .collect()
 }
 
-/// `validator` validators that have NO `Patch<T>` per-field trait impl (or are
-/// struct-level / cross-field rules), so they cannot be enforced on the
-/// generated `UpdateModel` `Patch<T>` fields (see `validate_attrs_for_patch`).
+/// `validator` validators that cannot be soundly enforced on the generated
+/// `UpdateModel` `Patch<T>` fields: either they have NO `Patch<T>` per-field
+/// trait impl (struct-level / cross-field rules), or their `Patch<T>` impl
+/// inverts our absent-field skip semantics (`does_not_contain`). See
+/// `validate_attrs_for_patch` for the full rationale.
 const NON_PATCH_VALIDATORS: &[&str] = &[
     "custom",
     "must_match",
@@ -976,6 +978,7 @@ const NON_PATCH_VALIDATORS: &[&str] = &[
     "required",
     "credit_card",
     "non_control_character",
+    "does_not_contain",
 ];
 
 /// Like [`validate_attrs`], but tailored for the `UpdateModel` `Patch<T>` fields
@@ -984,20 +987,34 @@ const NON_PATCH_VALIDATORS: &[&str] = &[
 /// `NewModel` fields carry the bare `T` and derive `validator::Validate`
 /// directly, so they keep every validator verbatim. `UpdateModel` fields are
 /// `Patch<T>`, which only implements validator's per-field *declarative* traits
-/// (`length`, `email`, `url`, `range`, `contains`, `does_not_contain`, `ip`,
-/// `regex`, …). The validators in [`NON_PATCH_VALIDATORS`] (`custom`,
-/// `must_match`, `nested`, `required`, `credit_card`, `non_control_character`)
-/// have no `Patch<T>` impl, so propagating them verbatim would break
-/// `UpdateModel` compilation even though `NewModel` still compiles — a latent
-/// footgun for a user who adds e.g. `#[validate(custom(...))]` to a model field.
+/// (`length`, `email`, `url`, `range`, `contains`, `ip`, `regex`, …). The
+/// validators in [`NON_PATCH_VALIDATORS`] (`custom`, `must_match`, `nested`,
+/// `required`, `credit_card`, `non_control_character`) have no `Patch<T>` impl,
+/// so propagating them verbatim would break `UpdateModel` compilation even
+/// though `NewModel` still compiles — a latent footgun for a user who adds e.g.
+/// `#[validate(custom(...))]` to a model field.
+///
+/// `does_not_contain` is also filtered, for a subtler reason: it does compile
+/// on `Patch<T>` (validator supplies it via the blanket
+/// `impl<T: ValidateContains> ValidateDoesNotContain for T`, defined as
+/// `!validate_contains(...)`), but that inverts our skip semantics. Our
+/// `ValidateContains for Patch<T>` returns `true` for an absent field so
+/// `contains` is *skipped*; the blanket flips that to `false`, so an OMITTED
+/// `does_not_contain` field would spuriously *fail* with 422. Since one
+/// `ValidateContains` value can't satisfy both skip directions (and coherence
+/// blocks a direct `ValidateDoesNotContain for Patch<T>` impl), we drop
+/// `does_not_contain` from the PATCH path and enforce it on create only.
+/// `contains` itself stays on the PATCH path — its absent→pass behaviour is
+/// correct.
 ///
 /// This is a *denylist* (not an allowlist): unknown/future validators pass
 /// through untouched, so a newly-supported declarative validator is never
 /// silently dropped.
 ///
-/// Documented limitation: `custom`/`must_match`/`nested`/`required`/etc. are
-/// enforced on create (via `NewModel`) but NOT on the PATCH update path; a
-/// follow-up may add merged-model validation for cross-field/custom rules.
+/// Documented limitation: `custom`/`must_match`/`nested`/`required`/
+/// `does_not_contain`/etc. are enforced on create (via `NewModel`) but NOT on
+/// the PATCH update path; a follow-up may add merged-model validation for
+/// cross-field/custom rules.
 fn validate_attrs_for_patch(field: &Field) -> Vec<syn::Attribute> {
     let mut out = Vec::new();
     for attr in field.attrs.iter().filter(|a| a.path().is_ident("validate")) {
@@ -5434,6 +5451,76 @@ mod tests {
         assert!(
             !upd_section.contains("custom"),
             "UpdateUser must NOT carry the non-declarative `custom` validator: {upd_section}"
+        );
+    }
+
+    #[test]
+    fn update_model_drops_does_not_contain_but_new_model_keeps_it() {
+        // #1719 follow-up: `does_not_contain` reaches `Patch<T>` through
+        // validator's blanket `impl<T: ValidateContains> ValidateDoesNotContain`,
+        // which computes `!validate_contains(...)`. Our `ValidateContains for
+        // Patch<T>` returns `true` for an absent field (so `contains` passes),
+        // which inverts to `false` for `does_not_contain` — an OMITTED patch
+        // field would then spuriously fail with 422. So `does_not_contain` must
+        // be dropped from the `UpdateModel` `Patch<T>` fields (enforced on create
+        // via `NewModel` only), while `contains`/`length` must be RETAINED.
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Doc {
+                    #[id]
+                    pub id: i64,
+                    #[validate(length(min = 1), contains(pattern = "ok"), does_not_contain(pattern = "bad"))]
+                    pub name: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+
+        // Slice the `NewDoc` struct body (up to its closing brace).
+        let new_start = generated
+            .find("struct NewDoc")
+            .expect("NewDoc struct must be generated");
+        let new_end = new_start
+            + generated[new_start..]
+                .find('}')
+                .expect("NewDoc struct must close");
+        let new_section = &generated[new_start..new_end];
+        assert!(
+            new_section.contains("does_not_contain"),
+            "NewDoc must keep the `does_not_contain` validator: {new_section}"
+        );
+        assert!(
+            new_section.contains("contains"),
+            "NewDoc must keep the `contains` validator: {new_section}"
+        );
+        assert!(
+            new_section.contains("length"),
+            "NewDoc must keep the `length` validator: {new_section}"
+        );
+
+        // Slice the `UpdateDoc` struct body (up to its closing brace).
+        let upd_start = generated
+            .find("struct UpdateDoc")
+            .expect("UpdateDoc struct must be generated");
+        let upd_end = upd_start
+            + generated[upd_start..]
+                .find('}')
+                .expect("UpdateDoc struct must close");
+        let upd_section = &generated[upd_start..upd_end];
+        assert!(
+            !upd_section.contains("does_not_contain"),
+            "UpdateDoc must NOT carry `does_not_contain` (inverts the Patch skip \
+             value into a spurious 422 for omitted fields): {upd_section}"
+        );
+        // Not over-filtered: `contains` and `length` are still valid on Patch<T>.
+        assert!(
+            upd_section.contains("contains"),
+            "UpdateDoc must keep the declarative `contains` validator: {upd_section}"
+        );
+        assert!(
+            upd_section.contains("length"),
+            "UpdateDoc must keep the declarative `length` validator: {upd_section}"
         );
     }
 

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -1018,7 +1018,7 @@ fn validate_attrs_for_patch(field: &Field) -> Vec<syn::Attribute> {
             .filter(|m| {
                 !m.path()
                     .get_ident()
-                    .is_some_and(|id| NON_PATCH_VALIDATORS.contains(&id.to_string().as_str()))
+                    .is_some_and(|id| NON_PATCH_VALIDATORS.iter().any(|v| id == *v))
             })
             .collect();
         if kept.is_empty() {

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -2788,8 +2788,14 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         .collect();
 
     // Build UpdateX fields:
-    // - Regular mutable fields: Patch<T> (no #[validate] — validation only
-    //   applies to NewX and the merged model)
+    // - Regular mutable fields: Patch<T>, propagating the field's `#[validate]`
+    //   attributes (#1719). The struct derives `validator::Validate` below, and
+    //   `Patch<T>` implements validator's per-field traits (see
+    //   `autumn/src/hooks.rs`), so a failing declarative rule (`length`, `email`,
+    //   `url`, `range`, `contains`, …) on a `Set` value surfaces as a 422 on
+    //   PATCH/PUT, while an absent (`Unchanged`/`Clear`) field is skipped —
+    //   mirroring the create path. Attributes pass through verbatim, exactly as
+    //   for `NewX`; only declarative validators appear on model fields.
     // - #[lock_version] field: plain required T (the client supplies the
     //   version they read; the framework increments it atomically)
     let mut update_fields: Vec<TokenStream> = fields_for_new
@@ -2797,7 +2803,9 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         .map(|f| {
             let ident = &f.ident;
             let ty = &f.ty;
+            let val_attrs = validate_attrs(f);
             quote! {
+                #(#val_attrs)*
                 #[serde(default)]
                 pub #ident: ::autumn_web::hooks::Patch<#ty>
             }
@@ -3957,6 +3965,7 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         #[derive(#update_debug_derive Clone, Default)]
         #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #validate_derive
         #vis struct #update_name {
             #(#update_fields,)*
         }

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -966,6 +966,70 @@ fn validate_attrs(field: &Field) -> Vec<&syn::Attribute> {
         .collect()
 }
 
+/// `validator` validators that have NO `Patch<T>` per-field trait impl (or are
+/// struct-level / cross-field rules), so they cannot be enforced on the
+/// generated `UpdateModel` `Patch<T>` fields (see `validate_attrs_for_patch`).
+const NON_PATCH_VALIDATORS: &[&str] = &[
+    "custom",
+    "must_match",
+    "nested",
+    "required",
+    "credit_card",
+    "non_control_character",
+];
+
+/// Like [`validate_attrs`], but tailored for the `UpdateModel` `Patch<T>` fields
+/// (#1719): drop the nested validators that `Patch<T>` cannot enforce.
+///
+/// `NewModel` fields carry the bare `T` and derive `validator::Validate`
+/// directly, so they keep every validator verbatim. `UpdateModel` fields are
+/// `Patch<T>`, which only implements validator's per-field *declarative* traits
+/// (`length`, `email`, `url`, `range`, `contains`, `does_not_contain`, `ip`,
+/// `regex`, …). The validators in [`NON_PATCH_VALIDATORS`] (`custom`,
+/// `must_match`, `nested`, `required`, `credit_card`, `non_control_character`)
+/// have no `Patch<T>` impl, so propagating them verbatim would break
+/// `UpdateModel` compilation even though `NewModel` still compiles — a latent
+/// footgun for a user who adds e.g. `#[validate(custom(...))]` to a model field.
+///
+/// This is a *denylist* (not an allowlist): unknown/future validators pass
+/// through untouched, so a newly-supported declarative validator is never
+/// silently dropped.
+///
+/// Documented limitation: `custom`/`must_match`/`nested`/`required`/etc. are
+/// enforced on create (via `NewModel`) but NOT on the PATCH update path; a
+/// follow-up may add merged-model validation for cross-field/custom rules.
+fn validate_attrs_for_patch(field: &Field) -> Vec<syn::Attribute> {
+    let mut out = Vec::new();
+    for attr in field.attrs.iter().filter(|a| a.path().is_ident("validate")) {
+        let syn::Meta::List(list) = &attr.meta else {
+            // A bare `#[validate]` with no nested items — nothing to filter.
+            out.push(attr.clone());
+            continue;
+        };
+        let parser = syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated;
+        let Ok(nested) = parser.parse2(list.tokens.clone()) else {
+            // If the nested metas don't parse, fall back to verbatim
+            // pass-through rather than silently dropping validation.
+            out.push(attr.clone());
+            continue;
+        };
+        let kept: Vec<syn::Meta> = nested
+            .into_iter()
+            .filter(|m| {
+                !m.path()
+                    .get_ident()
+                    .is_some_and(|id| NON_PATCH_VALIDATORS.contains(&id.to_string().as_str()))
+            })
+            .collect();
+        if kept.is_empty() {
+            // Filtering emptied the `#[validate(...)]` — drop the attr entirely.
+            continue;
+        }
+        out.push(syn::parse_quote!(#[validate(#(#kept),*)]));
+    }
+    out
+}
+
 /// Filter out framework-specific attributes (`#[id]`, `#[indexed]`, `#[validate]`,
 /// `#[default]`, `#[factory_assoc]`, `#[lock_version]`, `#[searchable]`,
 /// `#[state_machine]`) that shouldn't be on the query struct
@@ -2838,8 +2902,11 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     //   `autumn/src/hooks.rs`), so a failing declarative rule (`length`, `email`,
     //   `url`, `range`, `contains`, …) on a `Set` value surfaces as a 422 on
     //   PATCH/PUT, while an absent (`Unchanged`/`Clear`) field is skipped —
-    //   mirroring the create path. Attributes pass through verbatim, exactly as
-    //   for `NewX`; only declarative validators appear on model fields.
+    //   mirroring the create path. Non-declarative/struct-level validators
+    //   (`custom`, `must_match`, `nested`, `required`, `credit_card`,
+    //   `non_control_character`) have no `Patch<T>` impl and are filtered out
+    //   here by `validate_attrs_for_patch` (they still run on `NewX`); see that
+    //   helper for the documented create-vs-update limitation.
     // - #[lock_version] field: plain required T (the client supplies the
     //   version they read; the framework increments it atomically)
     let mut update_fields: Vec<TokenStream> = fields_for_new
@@ -2847,7 +2914,11 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         .map(|f| {
             let ident = &f.ident;
             let ty = &f.ty;
-            let val_attrs = validate_attrs(f);
+            // #1719: `Patch<T>` only implements validator's per-field
+            // declarative traits, so non-declarative/struct-level validators
+            // (`custom`, `must_match`, `nested`, …) must be stripped here or the
+            // `UpdateModel` would fail to compile. `NewModel` keeps them all.
+            let val_attrs = validate_attrs_for_patch(f);
             quote! {
                 #(#val_attrs)*
                 #[serde(default)]
@@ -5286,6 +5357,62 @@ mod tests {
         assert!(
             generated.contains("normalize :: trim") && generated.contains("normalize :: downcase"),
             "must chain the trim+downcase builtins: {generated}"
+        );
+    }
+
+    #[test]
+    fn update_model_drops_non_declarative_validators_but_new_model_keeps_them() {
+        // #1719: `Patch<T>` implements validator's per-field declarative traits
+        // (length/email/…) but NOT `custom`/`must_match`/`nested`/etc. The
+        // `UpdateModel` fields must therefore drop the non-declarative validators
+        // (or they'd fail to compile), while the `NewModel` keeps every validator.
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct User {
+                    #[id]
+                    pub id: i64,
+                    #[validate(length(min = 1), custom(function = "v"))]
+                    pub name: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+
+        // Slice the `NewUser` struct body (up to its closing brace).
+        let new_start = generated
+            .find("struct NewUser")
+            .expect("NewUser struct must be generated");
+        let new_end = new_start
+            + generated[new_start..]
+                .find('}')
+                .expect("NewUser struct must close");
+        let new_section = &generated[new_start..new_end];
+        assert!(
+            new_section.contains("length"),
+            "NewUser must keep the `length` validator: {new_section}"
+        );
+        assert!(
+            new_section.contains("custom"),
+            "NewUser must keep the `custom` validator: {new_section}"
+        );
+
+        // Slice the `UpdateUser` struct body (up to its closing brace).
+        let upd_start = generated
+            .find("struct UpdateUser")
+            .expect("UpdateUser struct must be generated");
+        let upd_end = upd_start
+            + generated[upd_start..]
+                .find('}')
+                .expect("UpdateUser struct must close");
+        let upd_section = &generated[upd_start..upd_end];
+        assert!(
+            upd_section.contains("length"),
+            "UpdateUser must keep the declarative `length` validator: {upd_section}"
+        );
+        assert!(
+            !upd_section.contains("custom"),
+            "UpdateUser must NOT carry the non-declarative `custom` validator: {upd_section}"
         );
     }
 

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -125,6 +125,48 @@ fn resolve_fk_and_name(
 /// associations can target the same model without colliding (e.g.
 /// `#[has_many(Post, fk = author_id, name = authored)]` plus
 /// `#[has_many(Post, fk = approver_id, name = approved)]`).
+/// Diagnose a `dependent = <action>` / `on_delete = <action>` key on a model
+/// association attribute.
+///
+/// Faithfully wiring this model-declared spelling to the cascade machinery
+/// needs a runtime type-erased dispatch refactor (the model spelling names the
+/// child *model*, whereas the cascade needs the child *repository* type), so it
+/// is deferred (#1702). Until then we must not silently accept-and-ignore it:
+/// recognize the spelling, validate the action, and return a directed error —
+/// an unknown-action error for a bad spelling, otherwise guidance toward the
+/// repository-attribute cascade (or, on `#[belongs_to]`, that the key is
+/// meaningless there because the child foreign key lives on that side).
+fn dependent_attr_error(kind: AssocKind, key: &syn::Ident, action: &str) -> syn::Error {
+    if kind == AssocKind::BelongsTo {
+        return syn::Error::new_spanned(
+            key,
+            "`dependent`/`on_delete` is not valid on `#[belongs_to]`: the child \
+             foreign key lives on this (belongs_to) side, so there is no \
+             dependent to cascade — declare the cascade on the parent's \
+             `#[has_many]`/`#[has_one]` (and, for now, on the repository \
+             attribute) instead",
+        );
+    }
+    // Accept exactly the actions the repository-attribute `dependent(...)`
+    // parser accepts (see repository.rs).
+    match action {
+        "destroy" | "delete_all" | "nullify" | "restrict" => syn::Error::new_spanned(
+            key,
+            "`dependent = <action>` on `#[has_many]`/`#[has_one]` is not yet \
+             wired; declare the dependent cascade on the repository instead, \
+             e.g. `#[autumn_web::repository(Model, dependent(PgChildRepository, \
+             fk = \"...\", on_delete = <action>))]` (see issue #1702)",
+        ),
+        other => syn::Error::new_spanned(
+            key,
+            format!(
+                "unknown dependent action `{other}`; expected one of \
+                 `destroy`, `delete_all`, `nullify`, `restrict`"
+            ),
+        ),
+    }
+}
+
 fn parse_assoc_attr(
     attr: &syn::Attribute,
     kind: AssocKind,
@@ -160,6 +202,8 @@ fn parse_assoc_attr(
                     explicit_through = Some(value);
                 } else if key == "target_fk" {
                     explicit_target_fk = Some(value);
+                } else if key == "dependent" || key == "on_delete" {
+                    return Err(dependent_attr_error(kind, &key, &value));
                 } else {
                     return Err(syn::Error::new_spanned(
                         &key,
@@ -4617,6 +4661,105 @@ mod tests {
         let attrs: Vec<syn::Attribute> =
             vec![syn::parse_quote!(#[belongs_to(User, bogus = author_id)])];
         assert!(resolve_associations(&model, &attrs).is_err());
+    }
+
+    // ── `dependent` / `on_delete` on model associations (#1702) ──────────
+    // The full model-declared cascade wiring is deferred (it needs a
+    // runtime type-erased dispatch refactor). Until then the parser must
+    // RECOGNIZE the `dependent = <action>` / `on_delete = <action>` spelling,
+    // validate the action, and emit a DIRECTED error pointing users at the
+    // repository-attribute cascade — never silently accept-and-ignore it.
+
+    #[test]
+    fn has_many_dependent_destroy_directs_to_repository() {
+        let model: syn::Ident = syn::parse_quote!(Post);
+        let attrs: Vec<syn::Attribute> =
+            vec![syn::parse_quote!(#[has_many(Comment, dependent = destroy)])];
+        let Err(err) = resolve_associations(&model, &attrs) else {
+            panic!("expected an error");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("repository"),
+            "expected directed guidance toward the repository attribute, got: {msg}"
+        );
+        assert!(
+            msg.contains("#1702"),
+            "expected the issue reference #1702, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn has_many_dependent_unknown_action_is_rejected() {
+        let model: syn::Ident = syn::parse_quote!(Post);
+        let attrs: Vec<syn::Attribute> =
+            vec![syn::parse_quote!(#[has_many(Comment, dependent = bogus)])];
+        let Err(err) = resolve_associations(&model, &attrs) else {
+            panic!("expected an error");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("bogus"),
+            "expected the unknown action named, got: {msg}"
+        );
+        assert!(
+            msg.contains("destroy")
+                && msg.contains("delete_all")
+                && msg.contains("nullify")
+                && msg.contains("restrict"),
+            "expected the valid actions listed, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn has_one_dependent_nullify_directs_to_repository() {
+        let model: syn::Ident = syn::parse_quote!(User);
+        let attrs: Vec<syn::Attribute> =
+            vec![syn::parse_quote!(#[has_one(Profile, dependent = nullify)])];
+        let Err(err) = resolve_associations(&model, &attrs) else {
+            panic!("expected an error");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("repository"),
+            "expected directed guidance toward the repository attribute, got: {msg}"
+        );
+        assert!(
+            msg.contains("#1702"),
+            "expected the issue reference #1702, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn belongs_to_dependent_is_rejected_as_meaningless() {
+        // The child FK lives on the belongs_to side, so there is no dependent
+        // to cascade — `dependent`/`on_delete` here is meaningless.
+        let model: syn::Ident = syn::parse_quote!(Post);
+        let attrs: Vec<syn::Attribute> =
+            vec![syn::parse_quote!(#[belongs_to(User, dependent = destroy)])];
+        let Err(err) = resolve_associations(&model, &attrs) else {
+            panic!("expected an error");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("belongs_to"),
+            "expected a belongs_to-specific rejection, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn has_many_without_dependent_still_parses() {
+        // Regression guard: recognizing `dependent` must not disturb normal
+        // `#[has_many]` parsing.
+        let model: syn::Ident = syn::parse_quote!(Post);
+        let attrs: Vec<syn::Attribute> = vec![
+            syn::parse_quote!(#[has_many(Comment)]),
+            syn::parse_quote!(#[has_many(Comment, fk = "post_id")]),
+        ];
+        let assocs = resolve_associations(&model, &attrs).expect("parse ok");
+        assert_eq!(assocs.len(), 2);
+        assert_eq!(assocs[0].fk, "post_id");
+        assert_eq!(assocs[1].fk, "post_id");
     }
 
     #[test]

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -975,7 +975,6 @@ const NON_PATCH_VALIDATORS: &[&str] = &[
     "custom",
     "must_match",
     "nested",
-    "required",
     "credit_card",
     "non_control_character",
     "does_not_contain",
@@ -1018,12 +1017,22 @@ const OPTION_INCOMPATIBLE_VALIDATORS: &[&str] = &["ip"];
 /// `NewModel` fields carry the bare `T` and derive `validator::Validate`
 /// directly, so they keep every validator verbatim. `UpdateModel` fields are
 /// `Patch<T>`, which only implements validator's per-field *declarative* traits
-/// (`length`, `email`, `url`, `range`, `contains`, `ip`, `regex`, …). The
-/// validators in [`NON_PATCH_VALIDATORS`] (`custom`, `must_match`, `nested`,
-/// `required`, `credit_card`, `non_control_character`) have no `Patch<T>` impl,
+/// (`length`, `email`, `url`, `range`, `contains`, `ip`, `regex`, `required`,
+/// …). The validators in [`NON_PATCH_VALIDATORS`] (`custom`, `must_match`,
+/// `nested`, `credit_card`, `non_control_character`) have no `Patch<T>` impl,
 /// so propagating them verbatim would break `UpdateModel` compilation even
 /// though `NewModel` still compiles — a latent footgun for a user who adds e.g.
 /// `#[validate(custom(...))]` to a model field.
+///
+/// `required` is deliberately NOT in the denylist (#1719 / Codex P2): it must
+/// propagate so the `UpdateModel` rejects an explicit `null` on a required
+/// field. `Patch<T>` implements `ValidateRequired` with tri-state semantics
+/// (`Unchanged` skips, `Clear`/`Set(None)` fail); see the impl in
+/// `autumn/src/hooks.rs`. `required` is only sensible on `Option`-typed fields,
+/// whose patch field is `Patch<Option<T>>` and satisfies the impl's
+/// `Option<T>: ValidateRequired` bound. (`required` on a non-`Option` field
+/// never compiles even on `NewModel`, since `validator` supplies
+/// `ValidateRequired` only for `Option<T>`, so no filtering is needed for it.)
 ///
 /// `does_not_contain` is also filtered, for a subtler reason: it does compile
 /// on `Patch<T>` (validator supplies it via the blanket
@@ -1056,10 +1065,10 @@ const OPTION_INCOMPATIBLE_VALIDATORS: &[&str] = &["ip"];
 /// Limitation: a type *alias* to `Option` is not detected (no worse than the
 /// derive's own behaviour, which also inspects the syntactic type).
 ///
-/// Documented limitation: `custom`/`must_match`/`nested`/`required`/
-/// `does_not_contain`/etc. are enforced on create (via `NewModel`) but NOT on
-/// the PATCH update path; a follow-up may add merged-model validation for
-/// cross-field/custom rules.
+/// Documented limitation: `custom`/`must_match`/`nested`/`does_not_contain`/etc.
+/// are enforced on create (via `NewModel`) but NOT on the PATCH update path; a
+/// follow-up may add merged-model validation for cross-field/custom rules.
+/// (`required` IS enforced on the PATCH path via the tri-state `Patch<T>` impl.)
 fn validate_attrs_for_patch(field: &Field) -> Vec<syn::Attribute> {
     let field_is_option = is_option_type(&field.ty);
     let mut out = Vec::new();
@@ -2974,11 +2983,13 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     //   `autumn/src/hooks.rs`), so a failing declarative rule (`length`, `email`,
     //   `url`, `range`, `contains`, …) on a `Set` value surfaces as a 422 on
     //   PATCH/PUT, while an absent (`Unchanged`/`Clear`) field is skipped —
-    //   mirroring the create path. Non-declarative/struct-level validators
-    //   (`custom`, `must_match`, `nested`, `required`, `credit_card`,
-    //   `non_control_character`) have no `Patch<T>` impl and are filtered out
-    //   here by `validate_attrs_for_patch` (they still run on `NewX`); see that
-    //   helper for the documented create-vs-update limitation.
+    //   mirroring the create path. `required` is the one non-skip rule: its
+    //   `Patch<T>` impl fails `Clear`/`Set(None)` so a PATCH can't null a
+    //   required column. Non-declarative/struct-level validators (`custom`,
+    //   `must_match`, `nested`, `credit_card`, `non_control_character`) have no
+    //   `Patch<T>` impl and are filtered out here by `validate_attrs_for_patch`
+    //   (they still run on `NewX`); see that helper for the documented
+    //   create-vs-update limitation.
     // - #[lock_version] field: plain required T (the client supplies the
     //   version they read; the framework increments it atomically)
     let mut update_fields: Vec<TokenStream> = fields_for_new
@@ -5576,6 +5587,59 @@ mod tests {
         assert!(
             upd_section.contains("length"),
             "UpdateDoc must keep the declarative `length` validator: {upd_section}"
+        );
+    }
+
+    #[test]
+    fn update_model_retains_required_on_patch_fields() {
+        // #1719 / Codex P2: `required` MUST propagate to the `UpdateModel`
+        // `Patch<Option<T>>` fields. A PATCH/PUT sending explicit JSON `null`
+        // deserializes to `Patch::Clear`; if `required` were dropped the update
+        // would silently write SQL `NULL`, violating the model's `required`
+        // contract (create still rejects `None`). The tri-state
+        // `impl ValidateRequired for Patch<T>` (autumn/src/hooks.rs) enforces it:
+        // `Unchanged` skips, `Clear`/`Set(None)` fail (422). So both `NewUser`
+        // and `UpdateUser` must carry `required`.
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct User {
+                    #[id]
+                    pub id: i64,
+                    #[validate(required)]
+                    pub nickname: Option<String>,
+                }
+            },
+        );
+        let generated = output.to_string();
+
+        // Slice the `NewUser` struct body (up to its closing brace).
+        let new_start = generated
+            .find("struct NewUser")
+            .expect("NewUser struct must be generated");
+        let new_end = new_start
+            + generated[new_start..]
+                .find('}')
+                .expect("NewUser struct must close");
+        let new_section = &generated[new_start..new_end];
+        assert!(
+            new_section.contains("required"),
+            "NewUser must keep the `required` validator: {new_section}"
+        );
+
+        // Slice the `UpdateUser` struct body (up to its closing brace).
+        let upd_start = generated
+            .find("struct UpdateUser")
+            .expect("UpdateUser struct must be generated");
+        let upd_end = upd_start
+            + generated[upd_start..]
+                .find('}')
+                .expect("UpdateUser struct must close");
+        let upd_section = &generated[upd_start..upd_end];
+        assert!(
+            upd_section.contains("required"),
+            "UpdateUser must RETAIN the `required` validator so a PATCH sending \
+             `null` (Patch::Clear) is rejected with 422: {upd_section}"
         );
     }
 

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -4761,6 +4761,27 @@ mod tests {
     }
 
     #[test]
+    fn has_many_on_delete_destroy_directs_to_repository() {
+        // The `on_delete = <action>` spelling is an accepted alias for
+        // `dependent = <action>` and must be directed the same way (#1702).
+        let model: syn::Ident = syn::parse_quote!(Post);
+        let attrs: Vec<syn::Attribute> =
+            vec![syn::parse_quote!(#[has_many(Comment, on_delete = destroy)])];
+        let Err(err) = resolve_associations(&model, &attrs) else {
+            panic!("expected an error");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("repository"),
+            "expected directed guidance toward the repository attribute, got: {msg}"
+        );
+        assert!(
+            msg.contains("#1702"),
+            "expected the issue reference #1702, got: {msg}"
+        );
+    }
+
+    #[test]
     fn has_many_dependent_unknown_action_is_rejected() {
         let model: syn::Ident = syn::parse_quote!(Post);
         let attrs: Vec<syn::Attribute> =

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -981,6 +981,37 @@ const NON_PATCH_VALIDATORS: &[&str] = &[
     "does_not_contain",
 ];
 
+/// `validator` validators whose `Patch<T>` per-field impl (in `autumn/src/hooks.rs`)
+/// delegates to `T`, but for which `validator` provides **no `impl … for
+/// Option<T>`** — so they cannot be enforced on an `Option<_>`-typed model
+/// field's `UpdateModel` `Patch<T>` field.
+///
+/// Background (#1719 / Codex P2): the `#[derive(Validate)]` on `NewModel`
+/// syntactically unwraps `Option<Inner>` and calls the validator on the inner
+/// `Inner` (e.g. `String`), so `#[validate(ip)] ip: Option<String>` compiles
+/// on create. But `UpdateModel`'s field is `Patch<Option<String>>`; the derive
+/// does NOT recognise `Patch<…>` as an `Option`, so it calls the validator on
+/// the whole `Patch<Option<String>>`. Our `impl<T: ValidateIp> ValidateIp for
+/// Patch<T>` then requires `Option<String>: ValidateIp`. In `validator` 0.20,
+/// `ValidateIp` is supplied ONLY by the blanket `impl<T: ToString> ValidateIp
+/// for T` (validation/ip.rs:13) — there is NO `impl ValidateIp for Option<T>`
+/// and `Option<String>` is not `ToString`/`Display`, so `Option<String>:
+/// ValidateIp` is unsatisfied and `UpdateModel` **fails to compile**.
+///
+/// The other per-field validators our `Patch<T>` block implements are NOT
+/// affected because `validator` 0.20 DOES ship an `Option<T>` impl for each:
+/// `length` (validation/length.rs:115), `range` (validation/range.rs:65),
+/// `email` (validation/email.rs:99), `url` (validation/urls.rs:56), `contains`
+/// (validation/contains.rs:15), and even `regex` (validation/regex.rs:76). So
+/// `ip` is the sole Option-incompatible validator in our supported set.
+///
+/// These are filtered from the PATCH path **only when the field is
+/// `Option<…>`-typed**: on a non-`Option` field (e.g. `#[validate(ip)] ip:
+/// String`) `Patch<String>: ValidateIp` holds via the `ToString` blanket, so
+/// `ip` must stay enforced on update there. On create, `ip` still runs for the
+/// `Option` field via the derive's `Option`-unwrap on `NewModel`.
+const OPTION_INCOMPATIBLE_VALIDATORS: &[&str] = &["ip"];
+
 /// Like [`validate_attrs`], but tailored for the `UpdateModel` `Patch<T>` fields
 /// (#1719): drop the nested validators that `Patch<T>` cannot enforce.
 ///
@@ -1011,11 +1042,26 @@ const NON_PATCH_VALIDATORS: &[&str] = &[
 /// through untouched, so a newly-supported declarative validator is never
 /// silently dropped.
 ///
+/// Additionally, when the model field is syntactically `Option<…>`, the
+/// [`OPTION_INCOMPATIBLE_VALIDATORS`] (e.g. `ip`) are ALSO dropped: `validator`
+/// ships no `impl … for Option<T>` for them, so `Patch<Option<T>>` would not
+/// implement the corresponding per-field trait and `UpdateModel` would fail to
+/// compile. They still run on create (the `NewModel` derive unwraps the
+/// `Option`) and remain enforced on non-`Option` update fields. See
+/// [`OPTION_INCOMPATIBLE_VALIDATORS`] for the full derivation.
+///
+/// `Option<…>` is detected the same way `validator` itself detects it — by the
+/// last path segment's ident being `Option` (via [`is_option_type`]) — which
+/// also matches fully-qualified `std::option::Option` / `core::option::Option`.
+/// Limitation: a type *alias* to `Option` is not detected (no worse than the
+/// derive's own behaviour, which also inspects the syntactic type).
+///
 /// Documented limitation: `custom`/`must_match`/`nested`/`required`/
 /// `does_not_contain`/etc. are enforced on create (via `NewModel`) but NOT on
 /// the PATCH update path; a follow-up may add merged-model validation for
 /// cross-field/custom rules.
 fn validate_attrs_for_patch(field: &Field) -> Vec<syn::Attribute> {
+    let field_is_option = is_option_type(&field.ty);
     let mut out = Vec::new();
     for attr in field.attrs.iter().filter(|a| a.path().is_ident("validate")) {
         let syn::Meta::List(list) = &attr.meta else {
@@ -1033,9 +1079,18 @@ fn validate_attrs_for_patch(field: &Field) -> Vec<syn::Attribute> {
         let kept: Vec<syn::Meta> = nested
             .into_iter()
             .filter(|m| {
-                !m.path()
-                    .get_ident()
-                    .is_some_and(|id| NON_PATCH_VALIDATORS.iter().any(|v| id == *v))
+                let Some(id) = m.path().get_ident() else {
+                    return true;
+                };
+                if NON_PATCH_VALIDATORS.iter().any(|v| id == *v) {
+                    return false;
+                }
+                // Option-incompatible validators (e.g. `ip`) only break the
+                // PATCH path on `Option<…>`-typed fields; keep them otherwise.
+                if field_is_option && OPTION_INCOMPATIBLE_VALIDATORS.iter().any(|v| id == *v) {
+                    return false;
+                }
+                true
             })
             .collect();
         if kept.is_empty() {
@@ -5521,6 +5576,103 @@ mod tests {
         assert!(
             upd_section.contains("length"),
             "UpdateDoc must keep the declarative `length` validator: {upd_section}"
+        );
+    }
+
+    #[test]
+    fn update_model_drops_ip_only_on_option_fields_new_model_keeps_all() {
+        // #1719 / Codex P2: `validator` provides no `impl ValidateIp for
+        // Option<T>` (only the `impl<T: ToString> ValidateIp for T` blanket),
+        // so `Patch<Option<String>>: ValidateIp` is unsatisfied and the
+        // generated `UpdateModel` would fail to compile for an `Option<String>`
+        // + `#[validate(ip)]` field. We therefore drop `ip` from the PATCH
+        // fields ONLY when the field is `Option<…>`, while:
+        //   * keeping `ip` on a non-`Option` field (`Patch<String>: ValidateIp`
+        //     holds via the `ToString` blanket),
+        //   * keeping `length` on the `Option` field (validator ships an
+        //     `Option<T>` impl for it, so it must NOT be over-filtered),
+        //   * keeping every validator on `NewModel` (its derive unwraps Option).
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Server {
+                    #[id]
+                    pub id: i64,
+                    #[validate(ip, length(min = 1))]
+                    pub ip: Option<String>,
+                    #[validate(ip)]
+                    pub ip2: String,
+                    #[validate(length(min = 1))]
+                    pub name: Option<String>,
+                }
+            },
+        );
+        let generated = output.to_string();
+
+        // Slice the `NewServer` struct body (up to its closing brace).
+        let new_start = generated
+            .find("struct NewServer")
+            .expect("NewServer struct must be generated");
+        let new_end = new_start
+            + generated[new_start..]
+                .find('}')
+                .expect("NewServer struct must close");
+        let new_section = &generated[new_start..new_end];
+        // NewServer keeps `ip` on BOTH ip fields (the derive unwraps Option):
+        // the combined attr on the Option field and the bare attr on ip2.
+        assert!(
+            new_section.contains("validate (ip , length"),
+            "NewServer must keep the `ip` (and `length`) validator on the \
+             Option<String> field: {new_section}"
+        );
+        assert!(
+            new_section.contains("validate (ip)"),
+            "NewServer must keep the `ip` validator on the non-Option field: {new_section}"
+        );
+
+        // Slice the `UpdateServer` struct body (up to its closing brace).
+        let upd_start = generated
+            .find("struct UpdateServer")
+            .expect("UpdateServer struct must be generated");
+        let upd_end = upd_start
+            + generated[upd_start..]
+                .find('}')
+                .expect("UpdateServer struct must close");
+        let upd_section = &generated[upd_start..upd_end];
+
+        // A `#[validate(ip)]` attr renders as `validate (ip)`; the pre-fix
+        // combined attr on the Option field would render `validate (ip ,
+        // length (min = 1))`. After the fix, the ONLY surviving `ip` validator
+        // in UpdateServer is the non-Option `ip2` field, so `validate (ip`
+        // must appear exactly once.
+        assert_eq!(
+            upd_section.matches("validate (ip").count(),
+            1,
+            "UpdateServer must retain `ip` on ONLY the non-Option `ip2` field \
+             (the Option<String> `ip` field must drop it — no `impl ValidateIp \
+             for Option<T>`): {upd_section}"
+        );
+        // The retained one is exactly `validate (ip)` (bare), i.e. ip2's attr.
+        assert!(
+            upd_section.contains("validate (ip)"),
+            "UpdateServer's non-Option `ip2` field must RETAIN the `ip` \
+             validator (Patch<String>: ValidateIp holds via the ToString \
+             blanket): {upd_section}"
+        );
+        // The Option `ip` field's combined attr must NOT survive with `ip`.
+        assert!(
+            !upd_section.contains("validate (ip ,"),
+            "UpdateServer's Option<String> `ip` field must DROP the `ip` \
+             validator: {upd_section}"
+        );
+        // `length` on the Option fields must NOT be over-filtered (validator
+        // ships an `Option<T>` impl for it): both the `ip` field's leftover
+        // `length` and the `name` field's `length` remain.
+        assert_eq!(
+            upd_section.matches("length (min = 1)").count(),
+            2,
+            "UpdateServer must KEEP `length` on both Option fields (`ip` \
+             leftover after dropping ip, and `name`): {upd_section}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -9153,17 +9153,21 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     // of scope per #1395); a single routed shard iterates normally.
     let batch_cross_shard_guard = if config.sharded && config.tenant_scoped {
         quote! {
+            // Reject on the runtime `across_tenants` flag alone — independent of
+            // whether a live shard set (`__autumn_shards`) is loaded. Gating on
+            // `__autumn_shards.is_some()` missed the no-shard-set case (e.g. a
+            // repo built via `with_pool_untracked`, where `__autumn_shards` is
+            // `None`), which slipped past the guard and silently streamed a
+            // PARTIAL result over only the current pool (#1692).
             if self.across_tenants {
-                if self.__autumn_shards.is_some() {
-                    return ::core::result::Result::Err(
-                        ::autumn_web::AutumnError::bad_request_msg(
-                            "cross-shard batched iteration is not supported: \
-                             across_tenants() cannot fan find_in_batches/\
-                             find_each out across shards; iterate each shard \
-                             separately via from_shard(...) instead"
-                        )
-                    );
-                }
+                return ::core::result::Result::Err(
+                    ::autumn_web::AutumnError::bad_request_msg(
+                        "cross-shard batched iteration is not supported: \
+                         across_tenants() cannot fan find_in_batches/\
+                         find_each out across shards; iterate each shard \
+                         separately via from_shard(...) instead"
+                    )
+                );
             }
         }
     } else {
@@ -11621,6 +11625,12 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         let base = count_impl;
         let dispatch = quote! {
             // Fan out before acquiring a parent-shard connection (see find_all).
+            // count is legitimately mergeable across shards, so with a shard set
+            // present we sum per-shard counts. Without one (e.g. a repo built via
+            // `with_pool_untracked`, where `__autumn_shards` is `None`), an
+            // across-tenant count would bind a NULL tenant predicate and silently
+            // return a PARTIAL result over only the current pool, so we reject
+            // rather than fall through to the single-pool count (#1692).
             if self.across_tenants {
                 if let ::core::option::Option::Some(ref __shards) = self.__autumn_shards {
                     let __counts = __shards.fan_out_shards(|__shard| {
@@ -11628,6 +11638,17 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         async move { __sub.__autumn_count_one_shard().await }
                     }).await?;
                     return ::core::result::Result::Ok(__counts.into_iter().sum());
+                } else {
+                    return ::core::result::Result::Err(
+                        ::autumn_web::AutumnError::bad_request_msg(
+                            "cross-shard count requires a configured shard set: \
+                             across_tenants() cannot fan count out across shards \
+                             without a shard set (the repository was built \
+                             without shard context, e.g. via \
+                             with_pool_untracked); build it with shard context \
+                             instead"
+                        )
+                    );
                 }
             }
             let mut conn = self.__autumn_acquire_read_conn().await?;
@@ -13293,6 +13314,86 @@ mod tests {
             !guard_cond.contains("__autumn_shards . is_some")
                 && !guard_cond.contains("__autumn_shards.is_some"),
             "aggregate guard condition must not depend on __autumn_shards being Some: {guard_cond}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_find_in_batches_rejects_across_tenants_without_shard_set() {
+        // §1692: a sharded + tenant-scoped `find_in_batches`/`find_each` must
+        // reject `across_tenants()` batched iteration purely on the runtime
+        // `across_tenants` flag — NOT on a live shard set being present. Gating on
+        // `__autumn_shards.is_some()` missed the no-shard-set case (e.g. a repo
+        // built via `with_pool_untracked`, where `__autumn_shards` is `None`),
+        // which slipped past the guard and silently streamed a PARTIAL result over
+        // only the current pool instead of rejecting.
+        let generated = repository_macro(
+            quote! { Post, tenant_scoped, sharded },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+
+        // Isolate the generated `fetch_batch_after` body so the assertions below
+        // target the batch guard specifically.
+        let pos = generated
+            .find("async fn fetch_batch_after")
+            .expect("sharded+tenant_scoped batched iteration must be generated");
+        let section = &generated[pos..];
+
+        // The rejection guard must be present in the batch body.
+        assert!(
+            section.contains("cross-shard batched iteration is not supported"),
+            "sharded+tenant_scoped find_in_batches must reject across_tenants: {section}"
+        );
+        // The guard must key off the runtime `across_tenants` flag.
+        assert!(
+            section.contains("across_tenants"),
+            "batch guard must reference the across_tenants flag: {section}"
+        );
+        // The guard condition must NOT depend on a shard set being loaded —
+        // `__autumn_shards.is_some()` gating is exactly the no-shard-set hole this
+        // fix closes. Check the tokens up to the rejection so we assert on the
+        // guard condition, not on unrelated fan-out code elsewhere.
+        let guard_end = section
+            .find("cross-shard batched iteration is not supported")
+            .expect("rejection message must be present");
+        let guard_cond = &section[..guard_end];
+        assert!(
+            !guard_cond.contains("__autumn_shards . is_some")
+                && !guard_cond.contains("__autumn_shards.is_some"),
+            "batch guard condition must not depend on __autumn_shards being Some: {guard_cond}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_count_rejects_across_tenants_without_shard_set() {
+        // §1692: a sharded + tenant-scoped `count` fans out across shards when a
+        // shard set is loaded (count is legitimately mergeable). But when
+        // `across_tenants()` is set and NO shard set is configured (e.g. a repo
+        // built via `with_pool_untracked`, where `__autumn_shards` is `None`), the
+        // old `if let Some(..)` gate fell through to a single-pool count and
+        // silently returned a PARTIAL result. It must instead reject.
+        let generated = repository_macro(
+            quote! { Post, tenant_scoped, sharded },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+
+        // Isolate the generated `count` dispatch body.
+        let pos = generated
+            .find("async fn count")
+            .expect("sharded+tenant_scoped count must be generated");
+        let section = &generated[pos..pos + 900];
+
+        // The fan-out path (shard set present) must be preserved.
+        assert!(
+            section.contains("fan_out_shards"),
+            "sharded+tenant_scoped count must still fan out across shards: {section}"
+        );
+        // The no-shard-set case must reject rather than fall through to a
+        // single-pool count.
+        assert!(
+            section.contains("cross-shard count requires a configured shard set"),
+            "sharded+tenant_scoped count must reject across_tenants without a shard set: {section}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -10602,7 +10602,6 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         };
         let update_body = if has_policy {
             quote! {
-                #validate_patch_idempotency
                 let __existing = match repo.on_primary().find_by_id(id).await {
                     ::core::result::Result::Ok(::core::option::Option::Some(existing)) => existing,
                     ::core::result::Result::Ok(::core::option::Option::None) => {
@@ -10630,6 +10629,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         ::core::result::Result::Err(err)
                     );
                 }
+                // #1719 follow-up (Codex P2): validate the patch only after the
+                // existence load (404) and the `__check_policy_scoped` gate
+                // (403), so a policy-gated PUT/PATCH with an invalid body still
+                // reports missing/unauthorized before unprocessable. Validation
+                // is a pure check on the already-decoded `patch` and, like the
+                // policy gate above, sits before the pure `__replay_response`
+                // read, so it cannot affect idempotency replay semantics.
+                #validate_patch_idempotency
                 if let ::core::option::Option::Some(response) =
                     ::autumn_web::idempotency::__replay_response(&__autumn_idempotency_replay)
                 {
@@ -13899,6 +13906,41 @@ mod tests {
         assert!(
             section.contains("MaybeValidate (& patch)"),
             "update handler must validate the patch payload: {section}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_api_policy_update_validates_after_policy_check() {
+        // #1719 follow-up: on the policy-backed update handler, payload
+        // validation (422) must run *after* the existence load (404) and the
+        // `__check_policy_scoped` authorization gate (403), so a policy-gated
+        // PUT/PATCH with an invalid body still returns 404/403 before 422.
+        // Validation-first here regressed the ordering (Codex P2).
+        let generated = repository_macro(
+            quote! { Post, api = "/api/posts", policy = PostPolicy },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+
+        let start = generated
+            .find("async fn post_api_update")
+            .expect("policy update handler must be generated");
+        let rest = &generated[start..];
+        let end = rest
+            .find("fn __autumn_route_info_post_api_update")
+            .unwrap_or(rest.len());
+        let section = &rest[..end];
+
+        let policy_at = section
+            .find("__check_policy_scoped")
+            .expect("policy update handler must run the scoped policy check");
+        let validate_at = section
+            .find("autumn_maybe_validate")
+            .expect("policy update handler must validate the patch payload");
+        assert!(
+            policy_at < validate_at,
+            "policy check (403) and existence load (404) must run before \
+             patch validation (422): {section}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -11632,13 +11632,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             // return a PARTIAL result over only the current pool, so we reject
             // rather than fall through to the single-pool count (#1692).
             if self.across_tenants {
-                if let ::core::option::Option::Some(ref __shards) = self.__autumn_shards {
-                    let __counts = __shards.fan_out_shards(|__shard| {
-                        let __sub = self.__autumn_for_shard(__shard);
-                        async move { __sub.__autumn_count_one_shard().await }
-                    }).await?;
-                    return ::core::result::Result::Ok(__counts.into_iter().sum());
-                } else {
+                let ::core::option::Option::Some(ref __shards) = self.__autumn_shards else {
                     return ::core::result::Result::Err(
                         ::autumn_web::AutumnError::bad_request_msg(
                             "cross-shard count requires a configured shard set: \
@@ -11649,7 +11643,12 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                              instead"
                         )
                     );
-                }
+                };
+                let __counts = __shards.fan_out_shards(|__shard| {
+                    let __sub = self.__autumn_for_shard(__shard);
+                    async move { __sub.__autumn_count_one_shard().await }
+                }).await?;
+                return ::core::result::Result::Ok(__counts.into_iter().sum());
             }
             let mut conn = self.__autumn_acquire_read_conn().await?;
             #base

--- a/autumn/src/hooks.rs
+++ b/autumn/src/hooks.rs
@@ -54,6 +54,8 @@
 //! - [`MutationContext`] -- carries actor identity, request ID, and
 //!   timestamp into every hook invocation.
 
+use std::borrow::Cow;
+
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 
@@ -422,6 +424,115 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for Patch<T> {
     }
 }
 
+// ── `Patch<T>` validator per-field trait impls (#1719) ───────────────
+//
+// The `#[repository(api = ...)]` macro generates an `UpdateModel` whose mutable
+// fields are `Patch<T>`. So that the model's declarative `#[validate(...)]`
+// rules are enforced on PATCH/PUT (returning a 422 with the same per-field
+// error map as create), the generated `UpdateModel` derives
+// `validator::Validate` and carries the field `#[validate]` attributes. That
+// derive expands to per-field calls like `self.title.validate_length(..)`,
+// so `Patch<T>` must implement validator's per-field traits.
+//
+// These impls mirror validator's own `Option<T>` impls: an absent field
+// (`Unchanged`/`Clear`) is skipped — it behaves like `None` and always passes —
+// while `Set(v)` delegates to the inner value's rule. `Patch` is a local type,
+// so implementing these foreign traits raises no orphan-rule issue.
+//
+// Only the *declarative, single-field* validators are implemented.
+// `required`/`must_match`/`nested`/`custom` are intentionally omitted: they are
+// meaningless or ill-typed on a tri-state patch field. `ValidateDoesNotContain`
+// is deliberately NOT implemented here — validator provides it automatically via
+// its blanket `impl<T: ValidateContains> ValidateDoesNotContain for T`, which
+// covers `Patch<T>` through the `ValidateContains` impl below (a manual impl
+// would collide with that blanket). `ValidateCreditCard` (validator's `card`
+// feature) and `ValidateNonControlCharacter` (its `unic` feature) are not
+// exported under this workspace's `validator` feature set, so they are omitted.
+
+impl<T: validator::ValidateLength<u64>> validator::ValidateLength<u64> for Patch<T> {
+    fn length(&self) -> Option<u64> {
+        match self {
+            Self::Set(v) => validator::ValidateLength::length(v),
+            _ => None,
+        }
+    }
+}
+
+impl<N, T: validator::ValidateRange<N>> validator::ValidateRange<N> for Patch<T> {
+    fn greater_than(&self, max: N) -> Option<bool> {
+        match self {
+            Self::Set(v) => validator::ValidateRange::greater_than(v, max),
+            _ => None,
+        }
+    }
+
+    fn less_than(&self, min: N) -> Option<bool> {
+        match self {
+            Self::Set(v) => validator::ValidateRange::less_than(v, min),
+            _ => None,
+        }
+    }
+}
+
+impl<T: validator::ValidateEmail> validator::ValidateEmail for Patch<T> {
+    fn as_email_string(&self) -> Option<Cow<'_, str>> {
+        match self {
+            Self::Set(v) => validator::ValidateEmail::as_email_string(v),
+            _ => None,
+        }
+    }
+}
+
+impl<T: validator::ValidateUrl> validator::ValidateUrl for Patch<T> {
+    fn as_url_string(&self) -> Option<Cow<'_, str>> {
+        match self {
+            Self::Set(v) => validator::ValidateUrl::as_url_string(v),
+            _ => None,
+        }
+    }
+}
+
+impl<T: validator::ValidateContains> validator::ValidateContains for Patch<T> {
+    fn validate_contains(&self, needle: &str) -> bool {
+        match self {
+            Self::Set(v) => validator::ValidateContains::validate_contains(v, needle),
+            _ => true,
+        }
+    }
+}
+
+impl<T: validator::ValidateIp> validator::ValidateIp for Patch<T> {
+    fn validate_ipv4(&self) -> bool {
+        match self {
+            Self::Set(v) => validator::ValidateIp::validate_ipv4(v),
+            _ => true,
+        }
+    }
+
+    fn validate_ipv6(&self) -> bool {
+        match self {
+            Self::Set(v) => validator::ValidateIp::validate_ipv6(v),
+            _ => true,
+        }
+    }
+
+    fn validate_ip(&self) -> bool {
+        match self {
+            Self::Set(v) => validator::ValidateIp::validate_ip(v),
+            _ => true,
+        }
+    }
+}
+
+impl<T: validator::ValidateRegex> validator::ValidateRegex for Patch<T> {
+    fn validate_regex(&self, regex: impl validator::AsRegex) -> bool {
+        match self {
+            Self::Set(v) => validator::ValidateRegex::validate_regex(v, regex),
+            _ => true,
+        }
+    }
+}
+
 /// Per-field before/after diff accessor for mutation hooks.
 ///
 /// `FieldDiff<T>` holds the previous and proposed values for a single field,
@@ -708,6 +819,30 @@ mod tests {
     #[test]
     fn patch_into_option_unchanged() {
         assert_eq!(Patch::<i32>::Unchanged.into_option(), None);
+    }
+
+    // ── Patch validator-trait tests (#1719) ─────────────────────
+    //
+    // `Patch<T>` mirrors validator's `Option<T>` impls: an absent field
+    // (`Unchanged`/`Clear`) always passes; a `Set(v)` field delegates to the
+    // inner value's rule. This lets the generated `UpdateModel` derive
+    // `validator::Validate` and enforce `#[validate(...)]` on PATCH/PUT.
+
+    #[test]
+    fn patch_validate_length_set_delegates_to_inner() {
+        use validator::ValidateLength;
+        // `Set` with an empty string fails a `length(min = 1)` rule …
+        assert!(!Patch::Set(String::new()).validate_length(Some(1), None, None));
+        // … while a `Set` with a satisfying value passes.
+        assert!(Patch::Set(String::from("ok")).validate_length(Some(1), None, None));
+    }
+
+    #[test]
+    fn patch_validate_length_absent_passes() {
+        use validator::ValidateLength;
+        // Absent variants behave like `None`: the rule is skipped (passes).
+        assert!(Patch::<String>::Unchanged.validate_length(Some(1), None, None));
+        assert!(Patch::<String>::Clear.validate_length(Some(1), None, None));
     }
 
     // ── FieldDiff tests ──────────────────────────────────────────

--- a/autumn/src/hooks.rs
+++ b/autumn/src/hooks.rs
@@ -440,8 +440,12 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for Patch<T> {
 // so implementing these foreign traits raises no orphan-rule issue.
 //
 // Only the *declarative, single-field* validators are implemented.
-// `required`/`must_match`/`nested`/`custom` are intentionally omitted: they are
-// meaningless or ill-typed on a tri-state patch field. `ValidateDoesNotContain`
+// `must_match`/`nested`/`custom` are intentionally omitted: they are
+// meaningless or ill-typed on a tri-state patch field. `required` IS implemented
+// (below), but with distinct, non-skip semantics: unlike the other rules, an
+// absent field is not uniformly "pass" — `Clear` (explicit null on a required
+// field) must FAIL so a PATCH/PUT cannot violate the model's `required` contract
+// by nulling the column. `ValidateDoesNotContain`
 // is deliberately NOT implemented here — validator provides it automatically via
 // its blanket `impl<T: ValidateContains> ValidateDoesNotContain for T`, which
 // covers `Patch<T>` through the `ValidateContains` impl below (a manual impl
@@ -529,6 +533,34 @@ impl<T: validator::ValidateRegex> validator::ValidateRegex for Patch<T> {
         match self {
             Self::Set(v) => validator::ValidateRegex::validate_regex(v, regex),
             _ => true,
+        }
+    }
+}
+
+// `required` has *tri-state* semantics that differ from the skip-on-absent rules
+// above (#1719 / Codex P2). `required` is meaningful only on `Option`-typed model
+// fields, whose `UpdateModel` field is `Patch<Option<T>>`, so the bound is
+// `T: ValidateRequired` (satisfied by validator's `impl<T> ValidateRequired for
+// Option<T>`). The derive calls `self.field.validate_required()`:
+//   - `Unchanged` -> `true`: the field was omitted from the patch, so the
+//     existing (non-null) value is kept — nothing to reject.
+//   - `Clear`     -> `false`: an explicit JSON `null` on a required field would
+//     write SQL `NULL`, violating the `required` contract — reject (422).
+//   - `Set(v)`    -> delegate to the inner `Option<T>`: `Set(Some)` passes,
+//     `Set(None)` fails (same as create).
+impl<T: validator::ValidateRequired> validator::ValidateRequired for Patch<T> {
+    fn validate_required(&self) -> bool {
+        match self {
+            Self::Unchanged => true,
+            Self::Clear => false,
+            Self::Set(v) => validator::ValidateRequired::validate_required(v),
+        }
+    }
+
+    fn is_some(&self) -> bool {
+        match self {
+            Self::Set(v) => validator::ValidateRequired::is_some(v),
+            _ => false,
         }
     }
 }
@@ -843,6 +875,33 @@ mod tests {
         // Absent variants behave like `None`: the rule is skipped (passes).
         assert!(Patch::<String>::Unchanged.validate_length(Some(1), None, None));
         assert!(Patch::<String>::Clear.validate_length(Some(1), None, None));
+    }
+
+    // `required` has tri-state semantics (#1719 / Codex P2): unlike the
+    // skip-on-absent rules, `Clear` and `Set(None)` must FAIL so a PATCH/PUT
+    // cannot null a `#[validate(required)]` column; `Unchanged` skips.
+    #[test]
+    fn patch_validate_required_unchanged_passes() {
+        use validator::ValidateRequired;
+        assert!(Patch::<Option<String>>::Unchanged.validate_required());
+    }
+
+    #[test]
+    fn patch_validate_required_clear_fails() {
+        use validator::ValidateRequired;
+        assert!(!Patch::<Option<String>>::Clear.validate_required());
+    }
+
+    #[test]
+    fn patch_validate_required_set_some_passes() {
+        use validator::ValidateRequired;
+        assert!(Patch::Set(Some(String::from("x"))).validate_required());
+    }
+
+    #[test]
+    fn patch_validate_required_set_none_fails() {
+        use validator::ValidateRequired;
+        assert!(!Patch::<Option<String>>::Set(None).validate_required());
     }
 
     // ── FieldDiff tests ──────────────────────────────────────────

--- a/autumn/src/validation.rs
+++ b/autumn/src/validation.rs
@@ -317,6 +317,42 @@ mod tests {
     }
 
     #[test]
+    fn update_patch_field_validates_via_derive() {
+        // #1719: a generated `UpdateModel` derives `validator::Validate` and
+        // carries `#[validate(...)]` on `Patch<T>` fields. A `Set` value runs
+        // the rule (and surfaces a per-field error keyed by the field name),
+        // while an absent (`Unchanged`/`Clear`) field is skipped.
+        use crate::hooks::Patch;
+
+        #[derive(validator::Validate)]
+        struct UpdatePost {
+            #[validate(length(min = 1))]
+            title: Patch<String>,
+        }
+
+        // `Set("")` violates `length(min = 1)` → 422-shaped field error map.
+        let bad = UpdatePost {
+            title: Patch::Set(String::new()),
+        };
+        let errors = validator::Validate::validate(&bad).unwrap_err();
+        let map = validation_errors_to_map(&errors);
+        assert!(map.contains_key("title"));
+        assert_eq!(map["title"][0], "validation failed: length");
+
+        // Absent field → rule skipped → passes.
+        let unchanged = UpdatePost {
+            title: Patch::Unchanged,
+        };
+        assert!(validator::Validate::validate(&unchanged).is_ok());
+
+        // `Set` with a satisfying value → passes.
+        let good = UpdatePost {
+            title: Patch::Set("hello".into()),
+        };
+        assert!(validator::Validate::validate(&good).is_ok());
+    }
+
+    #[test]
     fn validate_ext_ok() {
         #[derive(validator::Validate)]
         struct GoodInput {

--- a/autumn/tests/compile-pass/repository_api_validated.rs
+++ b/autumn/tests/compile-pass/repository_api_validated.rs
@@ -8,6 +8,7 @@ mod schema {
         articles (id) {
             id -> Int8,
             title -> Text,
+            subtitle -> Nullable<Text>,
         }
     }
 }
@@ -20,6 +21,13 @@ pub struct Article {
     pub id: i64,
     #[validate(length(min = 1, max = 200))]
     pub title: String,
+    // #1719 / Codex P2: `#[validate(required)]` on an `Option` field must
+    // propagate to the generated `UpdateArticle`'s `Patch<Option<String>>`
+    // field. This exercises the tri-state `ValidateRequired for Patch<T>` impl
+    // at compile time — `Patch<Option<String>>: ValidateRequired` must hold
+    // (via `Option<String>: ValidateRequired`), or `UpdateArticle` won't build.
+    #[validate(required)]
+    pub subtitle: Option<String>,
 }
 
 #[autumn_web::repository(Article, api = "/api/articles")]

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -207,6 +207,7 @@ mod throttle_route;
 mod time_zone_integration;
 mod transactional_test_integration;
 mod tx_isolation_retry_integration;
+mod validate_patch_option_ip;
 mod webhook_outbound;
 #[cfg(feature = "maud")]
 mod widget_css_coverage;

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -180,6 +180,8 @@ mod security;
 mod seo;
 mod server_timing;
 #[cfg(feature = "db")]
+mod shard_across_tenants_no_shard_set;
+#[cfg(feature = "db")]
 mod shard_map_guard;
 #[cfg(feature = "db")]
 mod sharding_across_tenants;

--- a/autumn/tests/integration/repository_authorization.rs
+++ b/autumn/tests/integration/repository_authorization.rs
@@ -48,6 +48,10 @@ diesel::table! {
 pub struct Note {
     #[id]
     pub id: i64,
+    // `#[validate(length(min = 1))]` is a declarative per-field validator that
+    // `Patch<String>` implements, so it is enforced on the generated `--api`
+    // update handler too (#1719); see `update_via_api_rejects_invalid_title`.
+    #[validate(length(min = 1))]
     pub title: String,
     pub author_id: i64,
 }
@@ -261,6 +265,61 @@ async fn ac_9b_admin_can_update_via_repository_endpoint() {
         .await
         .unwrap();
     assert_eq!(updated.title, "Edited by admin");
+}
+
+// #1719: the generated `--api` update handler must enforce the model's
+// declarative per-field validators and surface a 422 Problem Details field-error
+// map, exactly like the create/extractor path. Authorization passes (admin
+// session) so the request reaches validation.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn update_via_api_rejects_invalid_title() {
+    let (pool, _container) = setup_pool().await;
+    let note_id = seed_note(&pool, "Owner's note", 42).await;
+
+    let store = MemoryStore::new();
+    seed_session(&store, "sess-admin", "999", Some("admin")).await;
+    let client = build_app(pool.clone(), store, ForbiddenResponse::default());
+
+    // Empty title violates `#[validate(length(min = 1))]` → 422 + field errors.
+    let bad = client
+        .put(&format!("/api/notes/{note_id}"))
+        .header("Cookie", "autumn.sid=sess-admin")
+        .header("accept", "application/json")
+        .json(&serde_json::json!({"title": ""}))
+        .send()
+        .await;
+
+    assert_eq!(bad.status, StatusCode::UNPROCESSABLE_ENTITY);
+    let json: serde_json::Value = bad.json();
+    assert_eq!(json["status"], 422);
+    assert_eq!(json["code"], "autumn.validation_failed");
+    let errors = json["errors"]
+        .as_array()
+        .expect("Problem Details must carry a field-error array");
+    assert!(
+        errors.iter().any(|e| e["field"] == "title"),
+        "expected a field-level error for `title`, got: {json}"
+    );
+
+    // A valid title round-trips to a successful update.
+    let good = client
+        .put(&format!("/api/notes/{note_id}"))
+        .header("Cookie", "autumn.sid=sess-admin")
+        .header("accept", "application/json")
+        .json(&serde_json::json!({"title": "A valid title"}))
+        .send()
+        .await;
+
+    assert_eq!(good.status, StatusCode::OK);
+
+    let mut conn = pool.get().await.unwrap();
+    let updated: Note = test_notes::table
+        .find(note_id)
+        .first(&mut conn)
+        .await
+        .unwrap();
+    assert_eq!(updated.title, "A valid title");
 }
 
 #[tokio::test]

--- a/autumn/tests/integration/shard_across_tenants_no_shard_set.rs
+++ b/autumn/tests/integration/shard_across_tenants_no_shard_set.rs
@@ -1,0 +1,117 @@
+//! §1692: cross-shard `across_tenants()` guards must fire in the no-shard-set
+//! case for a `#[repository(tenant_scoped, sharded)]`.
+//!
+//! A repo built via `with_pool_untracked(pool)` carries `__autumn_shards: None`.
+//! Under `across_tenants()`:
+//!  - `find_in_batches` / `find_each` must REJECT (batched iteration cannot fan
+//!    out across shards), rather than silently streaming a PARTIAL result over
+//!    only the current pool.
+//!  - `count` (legitimately mergeable across shards) must REJECT when no shard
+//!    set is configured, rather than falling through to a partial single-pool
+//!    count.
+//!
+//! Both guards return before acquiring any database connection, so — like the
+//! read-routing test in `repository_find_in_batches.rs` — no live database is
+//! needed and these assertions run without Docker.
+
+#![cfg(feature = "db")]
+
+use autumn_web::config::DatabaseConfig;
+use autumn_web::db;
+use autumn_web::reexports::diesel_async::AsyncPgConnection;
+use autumn_web::reexports::diesel_async::pooled_connection::deadpool::Pool;
+
+mod schema {
+    autumn_web::reexports::diesel::table! {
+        no_shard_set_posts (id) {
+            id -> Int8,
+            tenant_id -> Text,
+            title -> Text,
+        }
+    }
+}
+
+use schema::no_shard_set_posts;
+
+/// A minimal model living on a tenant-scoped, sharded table.
+#[autumn_web::model(table = "no_shard_set_posts")]
+pub struct NoShardSetPost {
+    #[id]
+    pub id: i64,
+    pub tenant_id: String,
+    pub title: String,
+}
+
+/// tenant_scoped so `across_tenants()` is generated; sharded so the cross-shard
+/// batch/count guards are emitted.
+#[autumn_web::repository(NoShardSetPost, table = "no_shard_set_posts", tenant_scoped, sharded)]
+pub trait NoShardSetPostRepository {}
+
+fn make_pool() -> Pool<AsyncPgConnection> {
+    let config = DatabaseConfig {
+        url: Some("postgres://localhost/no_shard_set_test".to_owned()),
+        pool_size: 2,
+        ..Default::default()
+    };
+    db::create_pool(&config)
+        .expect("pool config must be valid")
+        .expect("url must be set")
+}
+
+/// `across_tenants()` on a `with_pool_untracked` repo has `__autumn_shards =
+/// None`; batched iteration must reject rather than silently returning a partial
+/// single-pool result. The guard fires before any connection is acquired, so no
+/// live database is required.
+#[tokio::test]
+async fn find_in_batches_across_tenants_without_shard_set_rejects() {
+    let pool = make_pool();
+    let repo = PgNoShardSetPostRepository::with_pool_untracked(pool).across_tenants();
+    assert!(
+        repo.__autumn_shards.is_none(),
+        "with_pool_untracked must yield __autumn_shards = None"
+    );
+
+    let mut batches = repo.find_in_batches(50);
+    let err = batches
+        .next_batch()
+        .await
+        .expect_err("across_tenants batched iteration without a shard set must reject");
+    assert!(
+        err.to_string()
+            .contains("cross-shard batched iteration is not supported"),
+        "batch guard must reject cross-shard iteration, got: {err}"
+    );
+
+    // `find_each` shares the same BatchSource and must reject identically.
+    let mut each = repo.find_each(50);
+    let err = each
+        .next()
+        .await
+        .expect_err("across_tenants find_each without a shard set must reject");
+    assert!(
+        err.to_string()
+            .contains("cross-shard batched iteration is not supported"),
+        "find_each must reject cross-shard iteration, got: {err}"
+    );
+}
+
+/// `across_tenants().count()` on a `with_pool_untracked` repo (no shard set)
+/// must reject rather than falling through to a partial single-pool count. The
+/// guard fires before any connection is acquired, so no live database is
+/// required.
+#[tokio::test]
+async fn count_across_tenants_without_shard_set_rejects() {
+    let pool = make_pool();
+    let repo = PgNoShardSetPostRepository::with_pool_untracked(pool).across_tenants();
+    assert!(repo.__autumn_shards.is_none());
+
+    let err = repo
+        .count()
+        .await
+        .expect_err("across_tenants count without a shard set must reject");
+    assert!(
+        err.to_string()
+            .contains("cross-shard count requires a configured shard set"),
+        "count guard must reject cross-shard count without a shard set, got: {err}"
+    );
+}

--- a/autumn/tests/integration/validate_patch_option_ip.rs
+++ b/autumn/tests/integration/validate_patch_option_ip.rs
@@ -7,7 +7,7 @@
 //! blanket `impl<T: ToString> ValidateIp for T` (validation/ip.rs) — there is no
 //! `impl ValidateIp for Option<T>` — so `Patch<Option<String>>: ValidateIp` is
 //! unsatisfiable and, before the macro fix, this module FAILED TO COMPILE with
-//! `the trait bound `Option<String>: ValidateIp` is not satisfied`.
+//! the trait bound `Option<String>: ValidateIp` not satisfied.
 //!
 //! The macro now drops `ip` from the generated PATCH fields for `Option<…>`
 //! columns only, so this module compiles. Because it lives in the consolidated

--- a/autumn/tests/integration/validate_patch_option_ip.rs
+++ b/autumn/tests/integration/validate_patch_option_ip.rs
@@ -1,0 +1,98 @@
+//! Compiled regression guard for #1719 / Codex P2.
+//!
+//! `#[autumn_web::model]` generates an `Update{Model}` whose fields are
+//! `Patch<T>` and which `#[derive(validator::Validate)]`. For a field like
+//! `#[validate(ip)] ip: Option<String>`, the update field is
+//! `Patch<Option<String>>`. `validator` 0.20 provides `ValidateIp` ONLY via the
+//! blanket `impl<T: ToString> ValidateIp for T` (validation/ip.rs) — there is no
+//! `impl ValidateIp for Option<T>` — so `Patch<Option<String>>: ValidateIp` is
+//! unsatisfiable and, before the macro fix, this module FAILED TO COMPILE with
+//! `the trait bound `Option<String>: ValidateIp` is not satisfied`.
+//!
+//! The macro now drops `ip` from the generated PATCH fields for `Option<…>`
+//! columns only, so this module compiles. Because it lives in the consolidated
+//! `integration_tests` binary, `cargo build --tests -p autumn-web` is the real
+//! build-time regression guard.
+
+#![cfg(feature = "db")]
+
+use validator::Validate;
+
+use autumn_web::hooks::Patch;
+
+mod schema {
+    autumn_web::reexports::diesel::table! {
+        patch_ip_hosts (id) {
+            id -> Int8,
+            ip -> Nullable<Text>,
+            ip2 -> Text,
+            name -> Nullable<Text>,
+        }
+    }
+}
+
+use schema::patch_ip_hosts;
+
+#[autumn_web::model(table = "patch_ip_hosts")]
+pub struct PatchIpHost {
+    #[id]
+    pub id: i64,
+    // Breaking case: Option<String> + ip. `ip` is dropped from the generated
+    // `UpdatePatchIpHost` patch field (no `impl ValidateIp for Option<T>`).
+    #[validate(ip)]
+    pub ip: Option<String>,
+    // Non-Option + ip: `ip` stays enforced on the update path
+    // (`Patch<String>: ValidateIp` holds via the `ToString` blanket).
+    #[validate(ip)]
+    pub ip2: String,
+    // Option + length: `length` must NOT be over-filtered (validator ships an
+    // `Option<T>` impl for `ValidateLength`).
+    #[validate(length(min = 1))]
+    pub name: Option<String>,
+}
+
+#[test]
+fn update_model_compiles_and_validates_expected_fields() {
+    // A fully valid patch validates cleanly.
+    let ok = UpdatePatchIpHost {
+        ip: Patch::Set(Some("192.168.0.1".to_string())),
+        ip2: Patch::Set("::1".to_string()),
+        name: Patch::Set(Some("db".to_string())),
+    };
+    assert!(ok.validate().is_ok(), "valid patch must pass validation");
+
+    // `ip` on the non-Option `ip2` field is STILL enforced on the update path.
+    let bad_ip2 = UpdatePatchIpHost {
+        ip: Patch::Unchanged,
+        ip2: Patch::Set("not-an-ip".to_string()),
+        name: Patch::Unchanged,
+    };
+    assert!(
+        bad_ip2.validate().is_err(),
+        "an invalid `ip2` (non-Option ip column) must fail validation on update"
+    );
+
+    // `length` on the Option `name` column is NOT over-filtered.
+    let bad_name = UpdatePatchIpHost {
+        ip: Patch::Unchanged,
+        ip2: Patch::Unchanged,
+        name: Patch::Set(Some(String::new())),
+    };
+    assert!(
+        bad_name.validate().is_err(),
+        "an empty `name` (Option length column) must fail validation on update"
+    );
+
+    // Documented tradeoff: `ip` is dropped from the Option `ip` patch field, so
+    // an invalid value there is NOT caught on the update path (it is still
+    // enforced on create, where the derive unwraps the Option).
+    let unenforced_ip = UpdatePatchIpHost {
+        ip: Patch::Set(Some("not-an-ip".to_string())),
+        ip2: Patch::Unchanged,
+        name: Patch::Unchanged,
+    };
+    assert!(
+        unenforced_ip.validate().is_ok(),
+        "`ip` is intentionally not enforced on the Option<String> update field"
+    );
+}


### PR DESCRIPTION
## Before / After

**Before.** Three real gaps in the autumn-macros model/repository codegen:
- **PUT/PATCH `--api` validation was a no-op.** `#[validate(length(min=1))]` on a `title` field enforced create-time (a `POST` with `{&#34;title&#34;:&#34;&#34;}` returned 422), but the same rule on `PUT`/`PATCH` was silently ignored — the row persisted with an empty title.
- **`#[has_many(Comment, dependent = destroy)]` on the model wasn&#39;t recognized.** The dependent-cascade machinery from #1701/#1705 exists but was only reachable via the repository-attribute spelling `#[repository(..., dependent(PgCommentRepository, fk=&#34;...&#34;, on_delete=destroy))]`. Writing the ergonomic model spelling produced a generic &#34;unknown key&#34; error with no path forward.
- **`across_tenants()` silently returned partial single-pool results in `find_in_batches`/`count`** when the repository was built without a shard set (e.g. via `with_pool_untracked`). The guards for the rejection/fan-out only fired when a shard set was loaded, so this legitimate misuse looked like a valid answer.

**After.**
- **PUT/PATCH now returns 422** with the same Problem Details field-error map shape as create. Absent (`Unchanged`) and cleared (`Clear`) patch fields still pass — untouched or intentionally-cleared fields never produce false positives.
- **`#[has_many(Comment, dependent = destroy)]` on the model now emits a directed compile error** with a copy-pasteable example: declare the cascade on the repository attribute. Recognizes both `dependent =` and `on_delete =` keys, validates the action spelling, and rejects it on `#[belongs_to]` as meaningless.
- **`across_tenants()` `find_in_batches`/`find_each` now reject on `across_tenants` alone**, and `count()` errors when `across_tenants()` is set and no shard set is configured — matching the corrected #1687 grouped-aggregate guard.

## How

Six commits on `feature/macros-followups-batch`:

- `e21f6ff` **#1692** — In `autumn-macros/src/repository.rs`, drop the inner `if self.__autumn_shards.is_some()` from the `find_in_batches` cross-shard guard so it rejects on `self.across_tenants` alone. In the `count` dispatch, add an `else` branch that returns `bad_request_msg(&#34;cross-shard count requires a configured shard set: …&#34;)` when `across_tenants` is set with no shard set; fan-out path preserved byte-for-byte. New macro unit tests + a non-`#[ignore]` integration test `autumn/tests/integration/shard_across_tenants_no_shard_set.rs` (guards return before any DB access, no Docker needed) that would fail on pre-fix code.

- `5de88f6` **#1719** — In `autumn/src/hooks.rs`, implement validator 0.20&#39;s per-field traits on `Patch` (`ValidateLength`, `ValidateRange`, `ValidateEmail`, `ValidateUrl`, `ValidateContains`, `ValidateIp`, `ValidateRegex`), mirroring validator&#39;s own `Option` impls: `Unchanged`/`Clear` behave like `None` (pass); `Set(v)` delegates. In `autumn-macros/src/model.rs`, propagate the field&#39;s `#[validate(...)]` attrs onto the generated UpdateModel `Patch` fields and apply the existing `#validate_derive` token to the Update struct (both gated on `has_validation`, symmetric with NewModel). No `autumn-macros/src/repository.rs` change: the existing `(&amp;MaybeValidate(&amp;patch)).autumn_maybe_validate()?` autoref specialization selects the validating branch once `UpdateModel: Validate`. Unit tests + a derive-wiring test cover Set-invalid-fails / Unchanged-Clear-pass / Set-valid-pass and the field-error-map key shape.

- `eed85c6` **#1702** *(partial — recognition and directed error only; see follow-ups below)* — In `autumn-macros/src/model.rs`, teach `parse_assoc_attr` to recognize `dependent =` and `on_delete =` on `#[has_many]`/`#[has_one]`, validate the action against the same four spellings the repository attribute accepts (`destroy | delete_all | nullify | restrict`), and emit a directed compile error pointing to the working repository-attribute spelling. On `#[belongs_to]`, reject it as meaningless (FK lives on this side). Purely additive to the error surface — no `Association` field or codegen change.

- `07c0eb4` — Removed the orphaned `use diesel::prelude::*;` in `autumn/tests/integration/factory_fake.rs:12` surfaced by `--all-targets` workspace clippy. Not touched by any of the feature commits; unblocks the CI gate.

- `2b02d4f` **#1719 hardening** — Added a **denylist filter** so non-declarative validators (`custom`, `must_match`, `nested`, `required`, `credit_card`, `non_control_character`) are stripped from the propagated UpdateModel patch-field attrs while NewModel keeps them all. Prevents a latent compile-break footgun if a user adds one of these to a model field (NewModel would still compile; UpdateModel would not). Includes a token-assertion unit test proving the split, and a Docker-gated `#[ignore]` end-to-end test in `autumn/tests/integration/repository_authorization.rs` that drives the generated `--api` PUT handler to a 422 for `{&#34;title&#34;:&#34;&#34;}` and asserts the Problem Details field-error map.

- `68bc99c` **#1702 hardening** — Added a parser test for the `on_delete =` key path, ensuring the second recognized spelling is covered.

## Notes / scope

- **Full wiring of `#[has_many(dependent=…)]`** on the model is intentionally deferred — see #1738. Faithfully wiring the model spelling to the cascade machinery requires a runtime type-erased dispatch trait, a naming convention linking model → repository type, and making dependent-deletes transactional-by-default across the codebase. Out of this lane; not shippable as an in-lane change. The parser guard here is the non-footgun placeholder: recognize + directed error, never silent accept-and-ignore.
- **Recursive grandchild cascade** and **`delete_many` bulk cascade** — the two extra scope items from #1702&#39;s comments — are deferred as #1739 and #1740. Both are self-contained enhancements to the existing cascade machinery independent of the model-spelling question.
- **`across_tenants()` sibling reads** — the identical silent-partial-result hole exists in `exists_by_id`, `find_all`, `find_by_*`, `with_deleted`, `only_deleted`. Out of #1692&#39;s stated scope but the same class of bug; tracked as #1741.

## Testing

- `cargo test -p autumn-macros`: **445 passed, 0 failed** (includes the new #1692 macro unit tests, #1719 token-assertion test, #1702 parser tests).
- `cargo fmt --all --check`: clean.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean (final gate).
- `cargo build --tests -p autumn-web`: clean; new integration modules compile. DB-dependent end-to-end tests are Docker-`#[ignore]`d — CI is the runtime authority.

Closes #1719
Part of #1702 (follow-ups: #1738, #1739, #1740)
Part of #1369
Part of #1692 (follow-up: #1741)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkxnUCTV2qqK89iK7P7qZn)_

## CI note: pre-existing Lint red (not this PR)

The `Lint` check is red on a **pre-existing** `clippy::map_unwrap_or` error at `autumn-cli/src/db/backup.rs:1267` (introduced by the merged `db backup` PR #1711). That code is byte-identical on `trunk-dev`'s current tip — this branch does not touch `autumn-cli`. The fix is already in flight in **#1730** (`fix/trunk-lint-197`), where Lint is verified green; this PR's Lint clears once #1730 merges and this branch rebases. All other CI checks that exercise this PR's diff pass. (This branch separately removed an unrelated pre-existing unused import in `autumn/tests/integration/factory_fake.rs` because it shares a compile target with the new test module here; that overlaps harmlessly with #1730's second half and reconciles identically on rebase.)