### PR TITLE
db: offsite S3 backups (#1619)

### DIFF
--- a/autumn-cli/src/db.rs
+++ b/autumn-cli/src/db.rs
@@ -25,6 +25,9 @@ use crate::migrate;
 /// ([`guard_destructive`]) verbatim.
 pub mod backup;
 
+/// Minimal synchronous S3 SigV4 client for offsite backup transfer (issue #1619).
+pub mod s3;
+
 /// The lifecycle subcommands of `autumn db`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DbCommand {

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -1960,7 +1960,7 @@ fn resolve_loaded_offsite(
 /// Whether the offsite destination collides with the app's user-facing blob
 /// storage: same bucket AND same canonical endpoint authority. Pure for unit
 /// testing the AC #3 opt-in guard.
-fn destinations_conflict(
+pub fn destinations_conflict(
     offsite_bucket: &str,
     offsite_endpoint: Option<&str>,
     app_bucket: Option<&str>,

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -1049,6 +1049,22 @@ fn dotenv_env() -> autumn_web::dotenv::DotenvOsEnv {
     }
 }
 
+/// Like [`dotenv_env`] but selects `.env.<profile>` for an explicit target
+/// profile (issue #1619). The offsite path resolves config + credentials under
+/// the run's profile (`--profile <p>` / `offsite:<p>/…`), so a profile-specific
+/// `.env.<p>` is honored even when the ambient shell profile differs — otherwise
+/// `autumn db backup --profile test --upload` from a dev/unset shell would miss
+/// `.env.test`-provided offsite settings and credentials.
+fn dotenv_env_for_profile(profile: &str) -> autumn_web::dotenv::DotenvOsEnv {
+    match autumn_web::dotenv::os_env_with_dotenv_for_profile(profile) {
+        Ok(env) => env,
+        Err(e) => {
+            eprintln!("  \u{274C} .env: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
 /// The managed-Postgres published cluster URL, used as a *fallback* control URL
 /// for bundled/daemon/single-binary apps (issue #1595). Such deployments often
 /// have no `DATABASE_URL` in env or `autumn.toml`; the running cluster instead
@@ -1640,6 +1656,9 @@ struct ResolvedOffsite {
     secret_access_key_env: Option<String>,
     app_storage_bucket: Option<String>,
     app_storage_endpoint: Option<String>,
+    /// The run's target profile — credentials are read from the `.env.<profile>`
+    /// overlay for THIS profile, matching the config read (issue #1619 P2 #6).
+    profile: String,
 }
 
 impl ResolvedOffsite {
@@ -1669,7 +1688,10 @@ impl ResolvedOffsite {
     /// Resolve the access key / secret from the environment variables NAMED by
     /// config. Credential *values* never appear in errors — only the var names.
     fn resolve_credentials(&self) -> Result<S3Credentials, BackupError> {
-        let env = dotenv_env();
+        // Read credentials from the SAME profile-specific `.env.<profile>` overlay
+        // the offsite config was resolved under (issue #1619 P2 #6), so a
+        // `.env.<profile>`-provided credential value is honored.
+        let env = dotenv_env_for_profile(&self.profile);
         let access_key_id = read_credential_env(&env, self.access_key_id_env.as_deref())?;
         let secret_access_key = read_credential_env(&env, self.secret_access_key_env.as_deref())?;
         Ok(S3Credentials {
@@ -1726,6 +1748,8 @@ struct LoadedOffsite {
     offsite: autumn_web::config::OffsiteBackupConfig,
     app_storage_bucket: Option<String>,
     app_storage_endpoint: Option<String>,
+    /// The target profile this section was resolved under (issue #1619 P2 #6).
+    profile: String,
 }
 
 impl LoadedOffsite {
@@ -1741,6 +1765,7 @@ impl LoadedOffsite {
             offsite,
             app_storage_bucket,
             app_storage_endpoint,
+            profile,
         } = self;
         let bucket = offsite
             .s3
@@ -1783,6 +1808,7 @@ impl LoadedOffsite {
             secret_access_key_env: offsite.s3.secret_access_key_env,
             app_storage_bucket,
             app_storage_endpoint,
+            profile,
         })
     }
 }
@@ -1793,7 +1819,11 @@ impl LoadedOffsite {
 /// validation — that is deferred to [`LoadedOffsite::resolve`] so a local-only
 /// backup is never blocked by an incomplete offsite section.
 fn load_offsite(profile: &str) -> Result<Option<LoadedOffsite>, BackupError> {
-    let base = dotenv_env();
+    // Load `.env.<profile>` for the TARGET profile (not the ambient shell one),
+    // then force `AUTUMN_ENV` for the TOML `[profile.<profile>]` overlay. Both
+    // must key off the same profile so a `.env.<profile>`-provided offsite
+    // override is honored (issue #1619 P2 #6).
+    let base = dotenv_env_for_profile(profile);
     let forced = ProfileForcedEnv {
         inner: &base,
         profile: profile.to_owned(),
@@ -1825,6 +1855,7 @@ fn load_offsite(profile: &str) -> Result<Option<LoadedOffsite>, BackupError> {
             .map(str::trim)
             .filter(|e| !e.is_empty())
             .map(str::to_owned),
+        profile: profile.to_owned(),
     }))
 }
 
@@ -3227,6 +3258,7 @@ mod tests {
             offsite,
             app_storage_bucket: None,
             app_storage_endpoint: None,
+            profile: "test".to_owned(),
         };
         // The decision a local backup makes (args.upload = false): no upload.
         assert!(!loaded.auto_upload());
@@ -3236,6 +3268,25 @@ mod tests {
             loaded.resolve(),
             Err(BackupError::OffsiteConfig { .. })
         ));
+    }
+
+    #[test]
+    fn resolved_offsite_carries_target_profile_for_credentials() {
+        // P2 #6: the target profile threads through resolve() into
+        // ResolvedOffsite so credential resolution reads the SAME
+        // `.env.<profile>` overlay the config was loaded under.
+        let mut offsite = autumn_web::config::OffsiteBackupConfig::default();
+        offsite.s3.bucket = Some("offsite-bucket".to_owned());
+        offsite.s3.access_key_id_env = Some("OFFSITE_KEY".to_owned());
+        offsite.s3.secret_access_key_env = Some("OFFSITE_SECRET".to_owned());
+        let loaded = LoadedOffsite {
+            offsite,
+            app_storage_bucket: None,
+            app_storage_endpoint: None,
+            profile: "test".to_owned(),
+        };
+        let resolved = loaded.resolve().expect("bucket set, resolves");
+        assert_eq!(resolved.profile, "test");
     }
 
     #[test]

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -1755,7 +1755,7 @@ fn load_offsite(profile: &str) -> Result<Option<ResolvedOffsite>, BackupError> {
         auto_upload: offsite.auto_upload,
         allow_shared_bucket: offsite.allow_shared_bucket,
         access_key_id_env: offsite.s3.access_key_id_env.clone(),
-        secret_access_key_env: offsite.s3.secret_access_key_env.clone(),
+        secret_access_key_env: offsite.s3.secret_access_key_env,
         app_storage_bucket: cfg
             .storage
             .s3
@@ -1804,11 +1804,7 @@ fn normalize_endpoint(endpoint: Option<&str>) -> String {
 /// Normalize a configured key prefix: trim surrounding whitespace and slashes so
 /// object keys join cleanly (an empty prefix means "bucket root").
 fn normalize_offsite_prefix(prefix: Option<&str>) -> String {
-    prefix
-        .unwrap_or("")
-        .trim()
-        .trim_matches('/')
-        .to_owned()
+    prefix.unwrap_or("").trim().trim_matches('/').to_owned()
 }
 
 /// Join non-empty key segments with `/` (no leading/trailing slash).
@@ -1872,10 +1868,10 @@ fn upload_run(
     // Remote retention (AC #5): only after the just-uploaded run verified, and
     // never removing that run. A retention error is loud but non-fatal — the
     // verified offsite copy already exists.
-    if let Some(keep) = offsite.keep {
-        if let Err(e) = prune_remote(offsite, client, profile, run_id, keep) {
-            eprintln!("  \u{26A0} offsite retention skipped: {e}");
-        }
+    if let Some(keep) = offsite.keep
+        && let Err(e) = prune_remote(offsite, client, profile, run_id, keep)
+    {
+        eprintln!("  \u{26A0} offsite retention skipped: {e}");
     }
     Ok(())
 }
@@ -1886,7 +1882,10 @@ fn list_run_files(run_dir: &Path) -> Result<Vec<String>, BackupError> {
     for entry in std::fs::read_dir(run_dir)
         .map_err(BackupError::io(format!("read {}", run_dir.display())))?
     {
-        let entry = entry.map_err(BackupError::io(format!("read entry in {}", run_dir.display())))?;
+        let entry = entry.map_err(BackupError::io(format!(
+            "read entry in {}",
+            run_dir.display()
+        )))?;
         if entry.path().is_file() {
             files.push(entry.file_name().to_string_lossy().into_owned());
         }
@@ -2022,17 +2021,19 @@ fn group_offsite_objects(objects: &[s3::S3Object], list_prefix: &str) -> Vec<Off
 
 /// Render a run listing as a human table: timestamp, files (labels), size. Pure.
 fn format_offsite_listing(runs: &[OffsiteRun]) -> String {
+    use std::fmt::Write as _;
     let mut out = String::new();
-    out.push_str(&format!("{:<20}  {:>10}  FILES\n", "TIMESTAMP", "SIZE"));
+    let _ = writeln!(out, "{:<20}  {:>10}  FILES", "TIMESTAMP", "SIZE");
     for run in runs {
         let mut labels: Vec<&str> = run.files.iter().map(|(f, _)| f.as_str()).collect();
         labels.sort_unstable();
-        out.push_str(&format!(
-            "{:<20}  {:>10}  {}\n",
+        let _ = writeln!(
+            out,
+            "{:<20}  {:>10}  {}",
             run.run_id,
             human_size(run.total),
             labels.join(", "),
-        ));
+        );
     }
     out
 }
@@ -2134,7 +2135,8 @@ fn restore_from_offsite(args: &RestoreArgs, oref: &OffsiteRef) -> Result<(), Bac
         });
     }
 
-    let temp = tempfile::tempdir().map_err(BackupError::io("creating a temp dir for offsite restore"))?;
+    let temp =
+        tempfile::tempdir().map_err(BackupError::io("creating a temp dir for offsite restore"))?;
     for obj in &objects {
         let file = obj
             .key

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -388,7 +388,12 @@ fn backup(args: &BackupArgs) -> Result<(), BackupError> {
         // same-second backups of this profile from different hosts never collide
         // in the bucket; the local run directory keeps its #1595 `<timestamp>`.
         let remote_id = remote_run_id(&local_run_id, &remote_run_token());
-        upload_run(&offsite, &client, &run_dir, &profile, &remote_id).map_err(|detail| {
+        // Canonicalize the profile for the REMOTE key prefix (P2 #22) so upload,
+        // `db offsite list`, and restore all address the same `<canonical>/…`
+        // location regardless of alias/case spelling — while the LOCAL run dir
+        // keeps its raw #1595 `<profile>/<timestamp>` layout (used above).
+        let remote_profile = migrate::canonical_profile(&profile);
+        upload_run(&offsite, &client, &run_dir, &remote_profile, &remote_id).map_err(|detail| {
             BackupError::OffsiteUploadFailed {
                 local_path: run_dir.display().to_string(),
                 detail,
@@ -2315,7 +2320,9 @@ pub fn run_offsite_list(profile: Option<&str>) {
 }
 
 fn offsite_list(profile: Option<&str>) -> Result<(), BackupError> {
-    let profile = migrate::effective_profile(profile);
+    // Canonicalize so the list prefix matches the profile the upload wrote under
+    // (P2 #22): `list --profile production` and `--profile prod` both read `prod/`.
+    let profile = migrate::canonical_profile(&migrate::effective_profile(profile));
     let offsite = load_offsite(&profile)?
         .ok_or(BackupError::OffsiteNotConfigured)?
         .resolve()?;
@@ -2502,21 +2509,22 @@ fn is_safe_leaf_name(name: &str) -> bool {
 /// via the identical [`RestorePlan::discover`] path (AC #4). The temp dir is
 /// removed when the guard drops (after the restore completes or fails).
 fn restore_from_offsite(args: &RestoreArgs, oref: &OffsiteRef) -> Result<(), BackupError> {
-    let offsite = load_offsite(&oref.profile)?
+    // Canonicalize the profile so the REMOTE key prefix matches what upload wrote
+    // (P2 #22): `offsite:production/latest` reads the same `prod/…` prefix that
+    // `--profile production` uploaded under.
+    let profile = migrate::canonical_profile(&oref.profile);
+    let offsite = load_offsite(&profile)?
         .ok_or(BackupError::OffsiteNotConfigured)?
         .resolve()?;
     let client = offsite.build_client()?;
 
     let run_id = match &oref.selector {
-        OffsiteSelector::Exact(sel) => resolve_exact_run(&offsite, &client, &oref.profile, sel)?,
-        OffsiteSelector::Latest => resolve_latest_run(&offsite, &client, &oref.profile)?,
+        OffsiteSelector::Exact(sel) => resolve_exact_run(&offsite, &client, &profile, sel)?,
+        OffsiteSelector::Latest => resolve_latest_run(&offsite, &client, &profile)?,
     };
-    eprintln!(
-        "  \u{2139} restoring from offsite {}/{}",
-        oref.profile, run_id
-    );
+    eprintln!("  \u{2139} restoring from offsite {profile}/{run_id}");
 
-    let run_prefix = offsite_run_prefix(&offsite.prefix, &oref.profile, &run_id);
+    let run_prefix = offsite_run_prefix(&offsite.prefix, &profile, &run_id);
     let objects = client
         .list_objects_v2(&run_prefix)
         .map_err(|e| BackupError::Offsite {
@@ -2526,8 +2534,7 @@ fn restore_from_offsite(args: &RestoreArgs, oref: &OffsiteRef) -> Result<(), Bac
     if objects.is_empty() {
         return Err(BackupError::BadArtifact {
             detail: format!(
-                "no offsite backup found at {}/{} (nothing under {run_prefix})",
-                oref.profile, run_id
+                "no offsite backup found at {profile}/{run_id} (nothing under {run_prefix})"
             ),
         });
     }
@@ -3380,6 +3387,37 @@ mod tests {
         assert_eq!(
             offsite_run_prefix("db", "prod", "20260710T040506Z"),
             "db/prod/20260710T040506Z/"
+        );
+    }
+
+    #[test]
+    fn offsite_key_prefix_is_canonical_across_profile_spellings() {
+        // P2 #22: alias/case profile spellings must resolve to the SAME remote key
+        // prefix, so upload (`--profile production`), `db offsite list --profile
+        // prod`, and `restore offsite:prod/latest` all address `db/prod/…`.
+        for spelling in ["prod", "production", "PROD", "Production", "  prod  "] {
+            let p = migrate::canonical_profile(spelling);
+            assert_eq!(offsite_profile_prefix("db", &p), "db/prod/", "{spelling:?}");
+            assert_eq!(
+                offsite_run_prefix("db", &p, "r"),
+                "db/prod/r/",
+                "{spelling:?}"
+            );
+            assert_eq!(
+                offsite_object_key("db", &p, "r", "manifest.json"),
+                "db/prod/r/manifest.json",
+                "{spelling:?}"
+            );
+        }
+        // `prod` and `production` yield the identical prefix.
+        assert_eq!(
+            offsite_profile_prefix("db", &migrate::canonical_profile("prod")),
+            offsite_profile_prefix("db", &migrate::canonical_profile("production")),
+        );
+        // dev aliases collapse the same way.
+        assert_eq!(
+            offsite_profile_prefix("db", &migrate::canonical_profile("development")),
+            "db/dev/"
         );
     }
 

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -37,6 +37,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::db::s3::{self, S3Client, S3Config, S3Credentials};
 use crate::migrate;
 
 /// Environment variable that pins the directory holding `pg_dump`/`pg_restore`.
@@ -132,6 +133,10 @@ pub struct BackupArgs {
     pub keep: Option<usize>,
     /// Which databases to capture.
     pub target: TargetSelector,
+    /// Upload the completed run to the configured offsite destination after
+    /// local verification + prune (issue #1619). The configured
+    /// `backup.offsite.auto_upload = true` has the same effect without the flag.
+    pub upload: bool,
 }
 
 /// Arguments for `autumn db restore`.
@@ -145,6 +150,11 @@ pub struct RestoreArgs {
     pub force: bool,
     /// Restore only this shard from the artifact (mirrors `--shard`).
     pub shard: Option<String>,
+    /// Treat `artifact` as an offsite reference (`<profile>/<timestamp|latest>`,
+    /// with an optional `offsite:` prefix) and restore from the offsite
+    /// destination instead of a local path (issue #1619). An `offsite:` prefix
+    /// on `artifact` implies this even when the flag is not set.
+    pub offsite: bool,
 }
 
 /// Failure modes for backup/restore. `Display` is credential-safe: no variant
@@ -173,6 +183,24 @@ pub enum BackupError {
     /// A destructive restore was refused because the active profile is
     /// production and `--force` was not supplied.
     ProductionRefused { profile: String },
+    /// `--upload` (or an offsite restore) was requested but no
+    /// `[backup.offsite]` section is configured.
+    OffsiteNotConfigured,
+    /// The `[backup.offsite]` section is present but invalid (e.g. no bucket).
+    OffsiteConfig { detail: String },
+    /// The offsite destination points at the same bucket+endpoint as the app's
+    /// user-facing blob storage and `allow_shared_bucket` was not set (AC #3).
+    /// Carries only the bucket name (not a credential).
+    SharedBucketRefused { bucket: String },
+    /// A credential could not be read: the config names an env var that is unset
+    /// (or names no env var at all). Carries the VARIABLE NAME, never a value.
+    MissingCredentialEnv { var: String },
+    /// The local backup succeeded but the offsite upload/verify failed — the
+    /// unambiguous split outcome (AC #2/#6). The local artifact is intact.
+    OffsiteUploadFailed { local_path: String, detail: String },
+    /// A non-split offsite operation (list / download / config load) failed.
+    /// `detail` is credential-safe (S3 status/code, never secrets).
+    Offsite { op: &'static str, detail: String },
 }
 
 impl std::fmt::Display for BackupError {
@@ -212,6 +240,35 @@ impl std::fmt::Display for BackupError {
                 "Refusing to restore over the {profile:?} profile database.\n  \
                  Re-run with --force if you really mean it (this overwrites data)."
             ),
+            Self::OffsiteNotConfigured => write!(
+                f,
+                "No offsite destination is configured.\n  Add a [backup.offsite] section \
+                 (with [backup.offsite.s3] bucket/region/endpoint and *_env credential \
+                 indirection) to autumn.toml, or set AUTUMN_BACKUP__OFFSITE__* env vars."
+            ),
+            Self::OffsiteConfig { detail } => {
+                write!(f, "Invalid [backup.offsite] configuration: {detail}")
+            }
+            Self::SharedBucketRefused { bucket } => write!(
+                f,
+                "The offsite destination bucket {bucket:?} is the same as the app's \
+                 [storage.s3] bucket at the same endpoint.\n  A shared bucket is a deliberate \
+                 choice: set backup.offsite.allow_shared_bucket = true to opt in, or point the \
+                 offsite backup at a distinct bucket."
+            ),
+            Self::MissingCredentialEnv { var } => write!(
+                f,
+                "Offsite credential environment variable {var:?} is not set (or the config \
+                 names no *_env variable).\n  Set it to the S3 access key / secret, or fix \
+                 backup.offsite.s3.access_key_id_env / secret_access_key_env."
+            ),
+            Self::OffsiteUploadFailed { local_path, detail } => write!(
+                f,
+                "Local backup OK at {local_path}\n  OFFSITE UPLOAD FAILED: {detail}\n  \
+                 The local artifact is intact — re-run `autumn db backup --upload` after \
+                 fixing the offsite destination."
+            ),
+            Self::Offsite { op, detail } => write!(f, "Offsite {op} failed: {detail}"),
         }
     }
 }
@@ -265,6 +322,21 @@ fn backup(args: &BackupArgs) -> Result<(), BackupError> {
     let pg_dump = tools.require("pg_dump")?;
 
     let profile = migrate::effective_profile(args.profile.as_deref());
+
+    // Offsite pre-flight (issue #1619): resolve the destination and, when an
+    // upload is requested, build/validate the client (credentials present,
+    // destination distinct from app storage) BEFORE dumping — so a misconfigured
+    // offsite fails fast instead of after a full dump.
+    let offsite = load_offsite(&profile)?;
+    let should_upload = args.upload || offsite.as_ref().is_some_and(|o| o.auto_upload);
+    let upload_ctx = if should_upload {
+        let offsite = offsite.ok_or(BackupError::OffsiteNotConfigured)?;
+        let client = offsite.build_client()?;
+        Some((offsite, client))
+    } else {
+        None
+    };
+
     let root = backup_root(args.dir.as_deref(), &profile);
     let run_dir = create_unique_run_dir(&root, &run_dir_name(&now_utc()))?;
 
@@ -288,6 +360,22 @@ fn backup(args: &BackupArgs) -> Result<(), BackupError> {
     // can never prune good history (AC #6).
     if let Some(keep) = args.keep {
         prune(&root, keep)?;
+    }
+
+    // Offsite upload runs LAST, only after local verification + prune. A failure
+    // here is the split outcome (AC #2/#6): the local artifact stays intact and
+    // the command exits non-zero with an unambiguous message.
+    if let Some((offsite, client)) = upload_ctx {
+        let run_id = run_dir
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        upload_run(&offsite, &client, &run_dir, &profile, &run_id).map_err(|detail| {
+            BackupError::OffsiteUploadFailed {
+                local_path: run_dir.display().to_string(),
+                detail,
+            }
+        })?;
     }
     Ok(())
 }
@@ -707,13 +795,30 @@ fn verify_plain_dump(path: &Path, db: &str) -> Result<(), BackupError> {
 // ─── Restore ────────────────────────────────────────────────────────────────
 
 fn restore(args: &RestoreArgs) -> Result<(), BackupError> {
-    // Production guard — identical to `autumn db drop` (AC #4).
+    // Production guard — identical to `autumn db drop` (AC #4). This guards the
+    // RESTORE-TARGET profile (`--profile`), independent of any offsite source.
     let profile = migrate::effective_profile(args.profile.as_deref());
     super::guard_destructive(&profile, args.force).map_err(|_| BackupError::ProductionRefused {
         profile: profile.clone(),
     })?;
 
+    // Offsite restore (issue #1619): when `--offsite` is set or the artifact is
+    // an `offsite:<profile>/<ts|latest>` reference, download the run to a fresh
+    // temp dir and hand it to the SAME RestorePlan::discover path so the
+    // identical integrity-refusal + guard/`--force` protocol applies unchanged.
+    let artifact_str = args.artifact.to_string_lossy();
+    if let Some(oref) = resolve_offsite_ref(args.offsite, &artifact_str) {
+        return restore_from_offsite(args, &oref);
+    }
+
     let plan = RestorePlan::discover(&args.artifact, args.shard.as_deref())?;
+    apply_restore_plan(&plan, args)
+}
+
+/// Verify every selected artifact, then restore each into its resolved database.
+/// Shared by local and offsite restore so both go through the identical
+/// verify-all-before-mutate-any protocol (AC #4).
+fn apply_restore_plan(plan: &RestorePlan, args: &RestoreArgs) -> Result<(), BackupError> {
     let format = plan.format;
     let entries = plan.select(args.shard.as_deref())?;
 
@@ -1500,6 +1605,584 @@ fn now_utc() -> chrono::DateTime<chrono::Utc> {
     chrono::Utc::now()
 }
 
+// ─── Offsite S3 upload / restore (issue #1619) ───────────────────────────────
+
+/// A resolved, ready-to-use offsite destination. Built from `[backup.offsite]`
+/// (via [`load_offsite`]) with the profile overlay + `AUTUMN_*` overrides
+/// already applied. Holds the app's `[storage.s3]` bucket/endpoint too so the
+/// distinct-destination guard (AC #3) can compare them without reloading config.
+struct ResolvedOffsite {
+    s3: S3Config,
+    prefix: String,
+    keep: Option<usize>,
+    auto_upload: bool,
+    allow_shared_bucket: bool,
+    access_key_id_env: Option<String>,
+    secret_access_key_env: Option<String>,
+    app_storage_bucket: Option<String>,
+    app_storage_endpoint: Option<String>,
+}
+
+impl ResolvedOffsite {
+    /// Build the transfer client, enforcing the distinct-destination guard
+    /// (AC #3) and resolving credentials from the named env vars first, so a
+    /// misconfiguration fails fast before any transfer.
+    fn build_client(&self) -> Result<S3Client, BackupError> {
+        if !self.allow_shared_bucket
+            && destinations_conflict(
+                &self.s3.bucket,
+                self.s3.endpoint.as_deref(),
+                self.app_storage_bucket.as_deref(),
+                self.app_storage_endpoint.as_deref(),
+            )
+        {
+            return Err(BackupError::SharedBucketRefused {
+                bucket: self.s3.bucket.clone(),
+            });
+        }
+        let creds = self.resolve_credentials()?;
+        S3Client::new(self.s3.clone(), creds).map_err(|e| BackupError::Offsite {
+            op: "connect",
+            detail: e.to_string(),
+        })
+    }
+
+    /// Resolve the access key / secret from the environment variables NAMED by
+    /// config. Credential *values* never appear in errors — only the var names.
+    fn resolve_credentials(&self) -> Result<S3Credentials, BackupError> {
+        let env = dotenv_env();
+        let access_key_id = read_credential_env(&env, self.access_key_id_env.as_deref())?;
+        let secret_access_key = read_credential_env(&env, self.secret_access_key_env.as_deref())?;
+        Ok(S3Credentials {
+            access_key_id,
+            secret_access_key,
+        })
+    }
+}
+
+/// Read a credential from the env var `var` names. Errors name only the VARIABLE
+/// (never a value). A `None`/blank config var name is itself an error.
+fn read_credential_env(
+    env: &dyn autumn_web::config::Env,
+    var: Option<&str>,
+) -> Result<String, BackupError> {
+    let var = var
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| BackupError::MissingCredentialEnv {
+            var: "(none configured)".to_owned(),
+        })?;
+    env.var(var)
+        .ok()
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| BackupError::MissingCredentialEnv {
+            var: var.to_owned(),
+        })
+}
+
+/// An `Env` overlay that forces `AUTUMN_ENV` to a specific profile so
+/// [`AutumnConfig::load_with_env`](autumn_web::config::AutumnConfig::load_with_env)
+/// resolves the `[backup.offsite]` section under the SAME profile the backup run
+/// is keyed by (matching [`migrate::effective_profile`]'s resolution).
+struct ProfileForcedEnv<'a> {
+    inner: &'a dyn autumn_web::config::Env,
+    profile: String,
+}
+
+impl autumn_web::config::Env for ProfileForcedEnv<'_> {
+    fn var(&self, key: &str) -> Result<String, std::env::VarError> {
+        if key == "AUTUMN_ENV" {
+            return Ok(self.profile.clone());
+        }
+        self.inner.var(key)
+    }
+}
+
+/// Load and resolve the `[backup.offsite]` destination for `profile`, applying
+/// the profile overlay and `AUTUMN_*` env overrides via the runtime config
+/// loader. `Ok(None)` when no offsite section is configured.
+fn load_offsite(profile: &str) -> Result<Option<ResolvedOffsite>, BackupError> {
+    let base = dotenv_env();
+    let forced = ProfileForcedEnv {
+        inner: &base,
+        profile: profile.to_owned(),
+    };
+    let cfg = autumn_web::config::AutumnConfig::load_with_env(&forced).map_err(|e| {
+        BackupError::Offsite {
+            op: "config load",
+            detail: e.to_string(),
+        }
+    })?;
+    let Some(offsite) = cfg.backup.offsite else {
+        return Ok(None);
+    };
+    let bucket = offsite
+        .s3
+        .bucket
+        .as_deref()
+        .map(str::trim)
+        .filter(|b| !b.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| BackupError::OffsiteConfig {
+            detail: "backup.offsite.s3.bucket is required".to_owned(),
+        })?;
+    // Region is only meaningful for AWS + SigV4 scope; many S3-compatible
+    // endpoints ignore it. Default to us-east-1 when unset.
+    let region = offsite
+        .s3
+        .region
+        .as_deref()
+        .map(str::trim)
+        .filter(|r| !r.is_empty())
+        .unwrap_or("us-east-1")
+        .to_owned();
+    let s3 = S3Config {
+        bucket,
+        region,
+        endpoint: offsite
+            .s3
+            .endpoint
+            .as_deref()
+            .map(str::trim)
+            .filter(|e| !e.is_empty())
+            .map(str::to_owned),
+        force_path_style: offsite.s3.force_path_style,
+    };
+    Ok(Some(ResolvedOffsite {
+        s3,
+        prefix: normalize_offsite_prefix(offsite.prefix.as_deref()),
+        keep: offsite.keep,
+        auto_upload: offsite.auto_upload,
+        allow_shared_bucket: offsite.allow_shared_bucket,
+        access_key_id_env: offsite.s3.access_key_id_env.clone(),
+        secret_access_key_env: offsite.s3.secret_access_key_env.clone(),
+        app_storage_bucket: cfg
+            .storage
+            .s3
+            .bucket
+            .as_deref()
+            .map(str::trim)
+            .filter(|b| !b.is_empty())
+            .map(str::to_owned),
+        app_storage_endpoint: cfg
+            .storage
+            .s3
+            .endpoint
+            .as_deref()
+            .map(str::trim)
+            .filter(|e| !e.is_empty())
+            .map(str::to_owned),
+    }))
+}
+
+/// Whether the offsite destination collides with the app's user-facing blob
+/// storage: same bucket AND same (normalized) endpoint. Pure for unit testing
+/// the AC #3 opt-in guard.
+fn destinations_conflict(
+    offsite_bucket: &str,
+    offsite_endpoint: Option<&str>,
+    app_bucket: Option<&str>,
+    app_endpoint: Option<&str>,
+) -> bool {
+    let Some(app_bucket) = app_bucket else {
+        return false;
+    };
+    app_bucket == offsite_bucket
+        && normalize_endpoint(offsite_endpoint) == normalize_endpoint(app_endpoint)
+}
+
+/// Normalize an endpoint for comparison: trim, lowercase, drop a trailing slash.
+/// `None` and empty both normalize to `""` (the AWS default endpoint).
+fn normalize_endpoint(endpoint: Option<&str>) -> String {
+    endpoint
+        .unwrap_or("")
+        .trim()
+        .trim_end_matches('/')
+        .to_ascii_lowercase()
+}
+
+/// Normalize a configured key prefix: trim surrounding whitespace and slashes so
+/// object keys join cleanly (an empty prefix means "bucket root").
+fn normalize_offsite_prefix(prefix: Option<&str>) -> String {
+    prefix
+        .unwrap_or("")
+        .trim()
+        .trim_matches('/')
+        .to_owned()
+}
+
+/// Join non-empty key segments with `/` (no leading/trailing slash).
+fn join_key(parts: &[&str]) -> String {
+    parts
+        .iter()
+        .filter(|p| !p.is_empty())
+        .copied()
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// The object key for one file of a run: `{prefix}/{profile}/{run_id}/{file}`.
+fn offsite_object_key(prefix: &str, profile: &str, run_id: &str, file: &str) -> String {
+    join_key(&[prefix, profile, run_id, file])
+}
+
+/// The list prefix that enumerates every run for a profile (trailing slash so a
+/// `list-type=2` prefix match is scoped to this profile).
+fn offsite_profile_prefix(prefix: &str, profile: &str) -> String {
+    format!("{}/", join_key(&[prefix, profile]))
+}
+
+/// The list prefix for the files of a single run.
+fn offsite_run_prefix(prefix: &str, profile: &str, run_id: &str) -> String {
+    format!("{}/", join_key(&[prefix, profile, run_id]))
+}
+
+/// Upload every file of a completed run and verify each remote object matches
+/// the local file (AC #2), then run remote retention (AC #5). Returns a
+/// credential-safe failure detail string (the caller wraps it into the
+/// split-outcome error). Never mutates the local artifact.
+fn upload_run(
+    offsite: &ResolvedOffsite,
+    client: &S3Client,
+    run_dir: &Path,
+    profile: &str,
+    run_id: &str,
+) -> Result<(), String> {
+    eprintln!("\u{2500}\u{2500} offsite upload \u{2500}\u{2500}");
+    let mut files = list_run_files(run_dir).map_err(|e| e.to_string())?;
+    files.sort();
+    if files.is_empty() {
+        return Err("the completed run directory contains no files to upload".to_owned());
+    }
+    for file in &files {
+        let path = run_dir.join(file);
+        let bytes = std::fs::read(&path).map_err(|e| format!("reading {file}: {e}"))?;
+        let key = offsite_object_key(&offsite.prefix, profile, run_id, file);
+        client
+            .put_and_verify(&key, &bytes)
+            .map_err(|e| format!("{file}: {e}"))?;
+        eprintln!("  \u{2713} uploaded + verified {file}");
+    }
+    eprintln!(
+        "\u{2713} Offsite upload verified: {} object(s) under {}",
+        files.len(),
+        offsite_run_prefix(&offsite.prefix, profile, run_id),
+    );
+
+    // Remote retention (AC #5): only after the just-uploaded run verified, and
+    // never removing that run. A retention error is loud but non-fatal — the
+    // verified offsite copy already exists.
+    if let Some(keep) = offsite.keep {
+        if let Err(e) = prune_remote(offsite, client, profile, run_id, keep) {
+            eprintln!("  \u{26A0} offsite retention skipped: {e}");
+        }
+    }
+    Ok(())
+}
+
+/// List the file names (not sub-directories) directly inside a run directory.
+fn list_run_files(run_dir: &Path) -> Result<Vec<String>, BackupError> {
+    let mut files = Vec::new();
+    for entry in std::fs::read_dir(run_dir)
+        .map_err(BackupError::io(format!("read {}", run_dir.display())))?
+    {
+        let entry = entry.map_err(BackupError::io(format!("read entry in {}", run_dir.display())))?;
+        if entry.path().is_file() {
+            files.push(entry.file_name().to_string_lossy().into_owned());
+        }
+    }
+    Ok(files)
+}
+
+/// Prune remote runs for a profile, keeping the newest `keep` and NEVER deleting
+/// the just-uploaded `keep_run_id`. Independent of the local `--keep`.
+fn prune_remote(
+    offsite: &ResolvedOffsite,
+    client: &S3Client,
+    profile: &str,
+    keep_run_id: &str,
+    keep: usize,
+) -> Result<(), String> {
+    let list_prefix = offsite_profile_prefix(&offsite.prefix, profile);
+    let objects = client
+        .list_objects_v2(&list_prefix)
+        .map_err(|e| e.to_string())?;
+    let run_ids = remote_run_ids(&objects, &list_prefix);
+    let to_remove = plan_remote_pruning(&run_ids, keep, keep_run_id);
+    for run_id in &to_remove {
+        let run_prefix = offsite_run_prefix(&offsite.prefix, profile, run_id);
+        let run_objects = client
+            .list_objects_v2(&run_prefix)
+            .map_err(|e| e.to_string())?;
+        for obj in &run_objects {
+            client.delete_object(&obj.key).map_err(|e| e.to_string())?;
+        }
+        eprintln!("  \u{1F5D1} pruned remote backup {run_id}");
+    }
+    Ok(())
+}
+
+/// Extract the unique, sorted run-id (timestamp) segments from listed object
+/// keys under `list_prefix` (`{list_prefix}{run_id}/{file}`).
+fn remote_run_ids(objects: &[s3::S3Object], list_prefix: &str) -> Vec<String> {
+    let mut ids: Vec<String> = objects
+        .iter()
+        .filter_map(|o| o.key.strip_prefix(list_prefix))
+        .filter_map(|rest| rest.split('/').next())
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+        .collect();
+    ids.sort();
+    ids.dedup();
+    ids
+}
+
+/// Pure remote-retention rule: given run ids sorted ascending, keep the newest
+/// `keep` and return the older ones to delete — but ALWAYS exclude
+/// `keep_run_id` (the just-uploaded run) from deletion, even if retention math
+/// would otherwise remove it. `keep == 0` is clamped to 1.
+fn plan_remote_pruning(sorted_run_ids: &[String], keep: usize, keep_run_id: &str) -> Vec<String> {
+    let keep = keep.max(1);
+    if sorted_run_ids.len() <= keep {
+        return Vec::new();
+    }
+    let remove_count = sorted_run_ids.len() - keep;
+    sorted_run_ids[..remove_count]
+        .iter()
+        .filter(|id| id.as_str() != keep_run_id)
+        .cloned()
+        .collect()
+}
+
+// ─── Offsite list (`autumn db offsite list`, AC #4) ──────────────────────────
+
+/// Entry point for `autumn db offsite list`. Prints a credential-safe message
+/// and exits non-zero on failure.
+pub fn run_offsite_list(profile: Option<&str>) {
+    eprintln!("\u{1F342} autumn db offsite list\n");
+    if let Err(e) = offsite_list(profile) {
+        eprintln!("\u{2717} {e}");
+        std::process::exit(1);
+    }
+}
+
+fn offsite_list(profile: Option<&str>) -> Result<(), BackupError> {
+    let profile = migrate::effective_profile(profile);
+    let offsite = load_offsite(&profile)?.ok_or(BackupError::OffsiteNotConfigured)?;
+    let client = offsite.build_client()?;
+    let list_prefix = offsite_profile_prefix(&offsite.prefix, &profile);
+    let objects = client
+        .list_objects_v2(&list_prefix)
+        .map_err(|e| BackupError::Offsite {
+            op: "list",
+            detail: e.to_string(),
+        })?;
+    let runs = group_offsite_objects(&objects, &list_prefix);
+    if runs.is_empty() {
+        eprintln!("  \u{2139} No offsite backups found for profile {profile:?}.");
+        return Ok(());
+    }
+    print!("{}", format_offsite_listing(&runs));
+    Ok(())
+}
+
+/// One offsite run, grouped for listing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OffsiteRun {
+    run_id: String,
+    files: Vec<(String, u64)>,
+    total: u64,
+}
+
+/// Group listed objects (`{list_prefix}{run_id}/{file}`) into runs, sorted by
+/// run id ascending. Pure for unit testing.
+fn group_offsite_objects(objects: &[s3::S3Object], list_prefix: &str) -> Vec<OffsiteRun> {
+    let mut map: std::collections::BTreeMap<String, OffsiteRun> = std::collections::BTreeMap::new();
+    for obj in objects {
+        let Some(rest) = obj.key.strip_prefix(list_prefix) else {
+            continue;
+        };
+        let mut parts = rest.splitn(2, '/');
+        let (Some(run_id), Some(file)) = (parts.next(), parts.next()) else {
+            continue;
+        };
+        if run_id.is_empty() || file.is_empty() {
+            continue;
+        }
+        let run = map.entry(run_id.to_owned()).or_insert_with(|| OffsiteRun {
+            run_id: run_id.to_owned(),
+            files: Vec::new(),
+            total: 0,
+        });
+        run.files.push((file.to_owned(), obj.size));
+        run.total += obj.size;
+    }
+    map.into_values().collect()
+}
+
+/// Render a run listing as a human table: timestamp, files (labels), size. Pure.
+fn format_offsite_listing(runs: &[OffsiteRun]) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("{:<20}  {:>10}  FILES\n", "TIMESTAMP", "SIZE"));
+    for run in runs {
+        let mut labels: Vec<&str> = run.files.iter().map(|(f, _)| f.as_str()).collect();
+        labels.sort_unstable();
+        out.push_str(&format!(
+            "{:<20}  {:>10}  {}\n",
+            run.run_id,
+            human_size(run.total),
+            labels.join(", "),
+        ));
+    }
+    out
+}
+
+/// A compact human byte size (KiB/MiB/GiB), for the listing table.
+fn human_size(bytes: u64) -> String {
+    const UNITS: [&str; 4] = ["B", "KiB", "MiB", "GiB"];
+    #[allow(clippy::cast_precision_loss)]
+    let mut size = bytes as f64;
+    let mut unit = 0;
+    while size >= 1024.0 && unit < UNITS.len() - 1 {
+        size /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} B")
+    } else {
+        format!("{size:.1} {}", UNITS[unit])
+    }
+}
+
+// ─── Offsite restore (AC #4) ─────────────────────────────────────────────────
+
+/// A parsed offsite restore reference: which profile's run to pull, and which.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OffsiteRef {
+    profile: String,
+    selector: OffsiteSelector,
+}
+
+/// How the run is chosen: newest, or an explicit timestamp/run id.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum OffsiteSelector {
+    Latest,
+    Exact(String),
+}
+
+/// Resolve an offsite reference from the `--offsite` flag and the artifact
+/// string. An `offsite:` prefix implies offsite even without the flag; when the
+/// flag is set the artifact is treated as `<profile>/<ts|latest>` directly.
+fn resolve_offsite_ref(flag: bool, artifact: &str) -> Option<OffsiteRef> {
+    let has_prefix = artifact.starts_with("offsite:");
+    if !flag && !has_prefix {
+        return None;
+    }
+    parse_offsite_ref(artifact)
+}
+
+/// Parse `offsite:<profile>/<timestamp|latest>` (the `offsite:` prefix is
+/// optional). Returns `None` when the shape is not `<profile>/<selector>`.
+fn parse_offsite_ref(s: &str) -> Option<OffsiteRef> {
+    let s = s.strip_prefix("offsite:").unwrap_or(s).trim();
+    let (profile, selector) = s.split_once('/')?;
+    let profile = profile.trim();
+    let selector = selector.trim();
+    if profile.is_empty() || selector.is_empty() {
+        return None;
+    }
+    let selector = if selector.eq_ignore_ascii_case("latest") {
+        OffsiteSelector::Latest
+    } else {
+        OffsiteSelector::Exact(selector.to_owned())
+    };
+    Some(OffsiteRef {
+        profile: profile.to_owned(),
+        selector,
+    })
+}
+
+/// Download the referenced offsite run to a fresh temp dir and restore from it
+/// via the identical [`RestorePlan::discover`] path (AC #4). The temp dir is
+/// removed when the guard drops (after the restore completes or fails).
+fn restore_from_offsite(args: &RestoreArgs, oref: &OffsiteRef) -> Result<(), BackupError> {
+    let offsite = load_offsite(&oref.profile)?.ok_or(BackupError::OffsiteNotConfigured)?;
+    let client = offsite.build_client()?;
+
+    let run_id = match &oref.selector {
+        OffsiteSelector::Exact(ts) => ts.clone(),
+        OffsiteSelector::Latest => resolve_latest_run(&offsite, &client, &oref.profile)?,
+    };
+    eprintln!(
+        "  \u{2139} restoring from offsite {}/{}",
+        oref.profile, run_id
+    );
+
+    let run_prefix = offsite_run_prefix(&offsite.prefix, &oref.profile, &run_id);
+    let objects = client
+        .list_objects_v2(&run_prefix)
+        .map_err(|e| BackupError::Offsite {
+            op: "list",
+            detail: e.to_string(),
+        })?;
+    if objects.is_empty() {
+        return Err(BackupError::BadArtifact {
+            detail: format!(
+                "no offsite backup found at {}/{} (nothing under {run_prefix})",
+                oref.profile, run_id
+            ),
+        });
+    }
+
+    let temp = tempfile::tempdir().map_err(BackupError::io("creating a temp dir for offsite restore"))?;
+    for obj in &objects {
+        let file = obj
+            .key
+            .strip_prefix(run_prefix.as_str())
+            .filter(|f| !f.is_empty() && !f.contains('/'))
+            .ok_or_else(|| BackupError::Offsite {
+                op: "download",
+                detail: format!("unexpected object key layout: {}", obj.key),
+            })?;
+        let bytes = client
+            .get_object(&obj.key)
+            .map_err(|e| BackupError::Offsite {
+                op: "download",
+                detail: format!("{file}: {e}"),
+            })?;
+        std::fs::write(temp.path().join(file), &bytes)
+            .map_err(BackupError::io(format!("writing downloaded {file}")))?;
+        eprintln!("  \u{2913} downloaded {file}");
+    }
+
+    // Hand the downloaded run to the SAME plan path so the identical
+    // integrity-refusal + restore protocol applies unchanged.
+    let plan = RestorePlan::discover(temp.path(), args.shard.as_deref())?;
+    apply_restore_plan(&plan, args)
+    // `temp` is dropped here, removing the downloaded artifacts.
+}
+
+/// Resolve the newest run id for a profile from the offsite listing.
+fn resolve_latest_run(
+    offsite: &ResolvedOffsite,
+    client: &S3Client,
+    profile: &str,
+) -> Result<String, BackupError> {
+    let list_prefix = offsite_profile_prefix(&offsite.prefix, profile);
+    let objects = client
+        .list_objects_v2(&list_prefix)
+        .map_err(|e| BackupError::Offsite {
+            op: "list",
+            detail: e.to_string(),
+        })?;
+    remote_run_ids(&objects, &list_prefix)
+        .into_iter()
+        .next_back() // sorted ascending; newest is last
+        .ok_or_else(|| BackupError::BadArtifact {
+            detail: format!("no offsite backups found for profile {profile:?}"),
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2199,6 +2882,224 @@ mod tests {
         let s = e.to_string();
         assert!(s.contains("prod"));
         assert!(!s.contains("postgres://"));
+    }
+
+    // ─── Offsite (issue #1619) ───────────────────────────────────────────────
+
+    #[test]
+    fn offsite_object_key_joins_and_skips_empty_prefix() {
+        assert_eq!(
+            offsite_object_key("db", "prod", "20260710T040506Z", "control.dump"),
+            "db/prod/20260710T040506Z/control.dump"
+        );
+        // Empty prefix => key rooted at the bucket, no leading slash.
+        assert_eq!(
+            offsite_object_key("", "prod", "20260710T040506Z", "manifest.json"),
+            "prod/20260710T040506Z/manifest.json"
+        );
+    }
+
+    #[test]
+    fn normalize_offsite_prefix_trims_slashes() {
+        assert_eq!(normalize_offsite_prefix(Some("/db/backups/")), "db/backups");
+        assert_eq!(normalize_offsite_prefix(Some("  db  ")), "db");
+        assert_eq!(normalize_offsite_prefix(None), "");
+        assert_eq!(normalize_offsite_prefix(Some("")), "");
+    }
+
+    #[test]
+    fn offsite_profile_and_run_prefixes_are_scoped() {
+        assert_eq!(offsite_profile_prefix("db", "prod"), "db/prod/");
+        assert_eq!(offsite_profile_prefix("", "prod"), "prod/");
+        assert_eq!(
+            offsite_run_prefix("db", "prod", "20260710T040506Z"),
+            "db/prod/20260710T040506Z/"
+        );
+    }
+
+    #[test]
+    fn destinations_conflict_requires_same_bucket_and_endpoint() {
+        // Same bucket + same endpoint => conflict.
+        assert!(destinations_conflict(
+            "shared",
+            Some("https://s3.example.test"),
+            Some("shared"),
+            Some("https://s3.example.test/"),
+        ));
+        // Same bucket but different endpoint => distinct.
+        assert!(!destinations_conflict(
+            "shared",
+            Some("https://offsite.test"),
+            Some("shared"),
+            Some("https://app.test"),
+        ));
+        // Different bucket => distinct.
+        assert!(!destinations_conflict(
+            "offsite",
+            Some("https://s3.example.test"),
+            Some("app"),
+            Some("https://s3.example.test"),
+        ));
+        // App storage not configured (no bucket) => never a conflict.
+        assert!(!destinations_conflict("offsite", None, None, None));
+        // Both AWS default endpoint (None) + same bucket => conflict.
+        assert!(destinations_conflict("shared", None, Some("shared"), None));
+    }
+
+    #[test]
+    fn shared_bucket_refusal_message_is_credential_safe() {
+        let e = BackupError::SharedBucketRefused {
+            bucket: "shared".to_owned(),
+        };
+        let s = e.to_string();
+        assert!(s.contains("shared"));
+        assert!(s.contains("allow_shared_bucket"));
+        assert!(!s.contains("secret"));
+    }
+
+    #[test]
+    fn missing_credential_env_names_only_the_variable() {
+        let e = BackupError::MissingCredentialEnv {
+            var: "OFFSITE_SECRET".to_owned(),
+        };
+        let s = e.to_string();
+        assert!(s.contains("OFFSITE_SECRET"));
+        // Names the variable, never a value.
+        assert!(!s.contains("hunter2"));
+    }
+
+    #[test]
+    fn upload_failed_reports_split_outcome() {
+        let e = BackupError::OffsiteUploadFailed {
+            local_path: "/backups/prod/20260710T040506Z".to_owned(),
+            detail: "S3 put returned HTTP 403 (AccessDenied)".to_owned(),
+        };
+        let s = e.to_string();
+        assert!(s.contains("Local backup OK at /backups/prod/20260710T040506Z"));
+        assert!(s.contains("OFFSITE UPLOAD FAILED"));
+        assert!(s.contains("intact"));
+    }
+
+    #[test]
+    fn remote_run_ids_extracts_unique_sorted_ids() {
+        let list_prefix = "db/prod/";
+        let objects = vec![
+            s3::S3Object {
+                key: "db/prod/20260710T010101Z/control.dump".to_owned(),
+                size: 1,
+            },
+            s3::S3Object {
+                key: "db/prod/20260710T010101Z/manifest.json".to_owned(),
+                size: 1,
+            },
+            s3::S3Object {
+                key: "db/prod/20260709T010101Z/control.dump".to_owned(),
+                size: 1,
+            },
+        ];
+        assert_eq!(
+            remote_run_ids(&objects, list_prefix),
+            vec!["20260709T010101Z".to_owned(), "20260710T010101Z".to_owned()]
+        );
+    }
+
+    #[test]
+    fn plan_remote_pruning_keeps_newest_and_never_the_just_uploaded() {
+        let runs: Vec<String> = ["r1", "r2", "r3", "r4", "r5"]
+            .iter()
+            .map(|s| (*s).to_owned())
+            .collect();
+        // Keep 2 => remove r1, r2, r3 (the 3 oldest). r5 is the just-uploaded.
+        assert_eq!(
+            plan_remote_pruning(&runs, 2, "r5"),
+            vec!["r1".to_owned(), "r2".to_owned(), "r3".to_owned()]
+        );
+        // keep >= len => remove nothing.
+        assert!(plan_remote_pruning(&runs, 5, "r5").is_empty());
+        // keep 0 clamps to 1 (never wipe everything).
+        assert_eq!(plan_remote_pruning(&runs, 0, "r5").len(), 4);
+    }
+
+    #[test]
+    fn plan_remote_pruning_excludes_just_uploaded_even_if_oldest() {
+        // Pathological: the just-uploaded run id sorts oldest (clock skew). It
+        // must STILL never be pruned.
+        let runs: Vec<String> = ["a", "b", "c"].iter().map(|s| (*s).to_owned()).collect();
+        // keep 1 => would remove a, b; but "a" is the just-uploaded => keep it.
+        assert_eq!(plan_remote_pruning(&runs, 1, "a"), vec!["b".to_owned()]);
+    }
+
+    #[test]
+    fn parse_offsite_ref_handles_latest_and_explicit() {
+        let latest = parse_offsite_ref("offsite:prod/latest").unwrap();
+        assert_eq!(latest.profile, "prod");
+        assert_eq!(latest.selector, OffsiteSelector::Latest);
+
+        // Case-insensitive "latest".
+        assert_eq!(
+            parse_offsite_ref("prod/LATEST").unwrap().selector,
+            OffsiteSelector::Latest
+        );
+
+        let exact = parse_offsite_ref("offsite:prod/20260710T040506Z").unwrap();
+        assert_eq!(exact.profile, "prod");
+        assert_eq!(
+            exact.selector,
+            OffsiteSelector::Exact("20260710T040506Z".to_owned())
+        );
+
+        // Missing pieces => None.
+        assert!(parse_offsite_ref("offsite:prod").is_none());
+        assert!(parse_offsite_ref("offsite:/latest").is_none());
+        assert!(parse_offsite_ref("prod/").is_none());
+    }
+
+    #[test]
+    fn resolve_offsite_ref_requires_flag_or_prefix() {
+        // A bare local path is not an offsite ref.
+        assert!(resolve_offsite_ref(false, "backups/prod/20260710T040506Z").is_none());
+        // The `offsite:` prefix alone triggers it.
+        assert!(resolve_offsite_ref(false, "offsite:prod/latest").is_some());
+        // The `--offsite` flag reinterprets a bare `<profile>/<sel>` positional.
+        assert!(resolve_offsite_ref(true, "prod/latest").is_some());
+    }
+
+    #[test]
+    fn group_and_format_offsite_listing() {
+        let list_prefix = "db/prod/";
+        let objects = vec![
+            s3::S3Object {
+                key: "db/prod/20260710T040506Z/manifest.json".to_owned(),
+                size: 128,
+            },
+            s3::S3Object {
+                key: "db/prod/20260710T040506Z/control.dump".to_owned(),
+                size: 4096,
+            },
+            s3::S3Object {
+                key: "db/prod/20260709T040506Z/control.dump".to_owned(),
+                size: 2048,
+            },
+        ];
+        let runs = group_offsite_objects(&objects, list_prefix);
+        assert_eq!(runs.len(), 2);
+        // Sorted ascending by run id.
+        assert_eq!(runs[0].run_id, "20260709T040506Z");
+        assert_eq!(runs[1].run_id, "20260710T040506Z");
+        assert_eq!(runs[1].total, 128 + 4096);
+
+        let table = format_offsite_listing(&runs);
+        assert!(table.contains("TIMESTAMP"));
+        assert!(table.contains("20260710T040506Z"));
+        assert!(table.contains("control.dump"));
+        assert!(table.contains("manifest.json"));
+    }
+
+    #[test]
+    fn human_size_scales_units() {
+        assert_eq!(human_size(512), "512 B");
+        assert_eq!(human_size(2048), "2.0 KiB");
+        assert_eq!(human_size(5 * 1024 * 1024), "5.0 MiB");
     }
 
     /// Docker/live-DB round-trip (AC #5). Ignored by default; run with a live

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -1825,7 +1825,10 @@ fn auto_upload_probe(profile: &str) -> bool {
     // The profile-aware dotenv overlay covers BOTH the real env and `.env.<p>`
     // (a real env var wins inside the overlay), matching P2 #6.
     let env = dotenv_env_for_profile(profile);
-    let table = migrate::read_autumn_toml_table_with_profile(Some(profile));
+    // Read `autumn.toml` from the config/manifest dir (AUTUMN_MANIFEST_DIR),
+    // matching where the full loader + the dotenv overlay look — so an installed/
+    // daemon launch with a different CWD still sees `auto_upload` (P2 #15).
+    let table = migrate::read_autumn_toml_table_with_profile_from_config_dir(Some(profile));
     auto_upload_from_sources(|k| env.var(k).ok(), table.as_ref())
 }
 
@@ -1876,7 +1879,12 @@ fn load_offsite(profile: &str) -> Result<Option<LoadedOffsite>, BackupError> {
     // Real env + `.env.<profile>` overlay (profile-aware, P2 #6); merged TOML
     // (base + `[profile.<p>]`) — neither decrypts credentials nor validates.
     let env = dotenv_env_for_profile(profile);
-    let table = migrate::read_autumn_toml_table_with_profile(Some(profile));
+    // Read `autumn.toml` from the config/manifest dir (AUTUMN_MANIFEST_DIR),
+    // matching the full loader + dotenv overlay — so an installed/daemon launch
+    // whose CWD differs from the config dir still finds the offsite destination
+    // (and enforces the distinct-bucket guard) instead of reporting it
+    // unconfigured (P2 #15).
+    let table = migrate::read_autumn_toml_table_with_profile_from_config_dir(Some(profile));
     resolve_loaded_offsite(table.as_ref(), &env, profile)
 }
 
@@ -3499,6 +3507,40 @@ mod tests {
         let env_junk =
             |k: &str| (k == "AUTUMN_BACKUP__OFFSITE__AUTO_UPLOAD").then(|| "yesplease".to_owned());
         assert!(auto_upload_from_sources(env_junk, Some(&toml_true)));
+    }
+
+    #[test]
+    fn offsite_resolves_from_config_dir_table_not_cwd() {
+        // P2 #15: an installed/daemon launch keeps autumn.toml in the config dir
+        // (a different CWD). Reading from that dir — as the offsite loaders now do
+        // via read_autumn_toml_table_with_profile_from_config_dir — must surface
+        // both auto_upload and the offsite destination. Proven hermetically by
+        // reading a temp config dir directly (this test's CWD has no such file).
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("autumn.toml"),
+            "[backup.offsite]\n\
+             auto_upload = true\n\
+             prefix = \"db\"\n\
+             [backup.offsite.s3]\n\
+             bucket = \"offsite-bucket\"\n\
+             region = \"us-east-1\"\n\
+             endpoint = \"https://minio.example:9000\"\n\
+             force_path_style = true\n\
+             access_key_id_env = \"OFFSITE_KEY\"\n\
+             secret_access_key_env = \"OFFSITE_SECRET\"\n",
+        )
+        .unwrap();
+        let table = migrate::read_autumn_toml_table_with_profile_in(tmp.path(), Some("dev"));
+        // auto_upload is read from the config-dir table (env has nothing).
+        assert!(auto_upload_from_sources(|_| None, table.as_ref()));
+        // And the offsite destination resolves from that same table (no CWD file).
+        let env = autumn_web::config::MockEnv::new();
+        let loaded = resolve_loaded_offsite(table.as_ref(), &env, "dev").unwrap();
+        assert!(
+            loaded.is_some(),
+            "offsite must resolve from the config-dir autumn.toml"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -332,19 +332,17 @@ fn backup(args: &BackupArgs) -> Result<(), BackupError> {
 
     let profile = migrate::effective_profile(args.profile.as_deref());
 
-    // Offsite pre-flight (issue #1619): read the offsite section LENIENTLY (no
-    // bucket/cred validation) just to learn `auto_upload`. Only when an upload is
-    // actually requested do we STRICTLY validate (bucket required, creds env
-    // resolved, distinct destination) and build the client — BEFORE dumping — so
-    // a misconfigured offsite fails fast, while a plain local backup with an
-    // incomplete `[backup.offsite]` section is never blocked.
-    let loaded_offsite = load_offsite(&profile)?;
-    let should_upload = args.upload
-        || loaded_offsite
-            .as_ref()
-            .is_some_and(LoadedOffsite::auto_upload);
+    // Offsite pre-flight (issue #1619). Decide whether to upload with a LIGHT
+    // probe that reads ONLY `[backup.offsite].auto_upload` (real env → `.env.<p>`
+    // → merged TOML), WITHOUT a full `AutumnConfig` load — so a local-only backup
+    // never triggers global config validation or encrypted-credentials
+    // decryption (a cron job may not export AUTUMN_MASTER_KEY). Only when an
+    // upload is actually requested do we do the full, strict resolve (bucket
+    // required, creds env resolved, distinct-destination guard) and build the
+    // client — BEFORE dumping — so a misconfigured offsite fails fast.
+    let should_upload = args.upload || auto_upload_probe(&profile);
     let upload_ctx = if should_upload {
-        let offsite = loaded_offsite
+        let offsite = load_offsite(&profile)?
             .ok_or(BackupError::OffsiteNotConfigured)?
             .resolve()?;
         let client = offsite.build_client()?;
@@ -1753,11 +1751,6 @@ struct LoadedOffsite {
 }
 
 impl LoadedOffsite {
-    /// The configured-default upload flag, readable without validating anything.
-    const fn auto_upload(&self) -> bool {
-        self.offsite.auto_upload
-    }
-
     /// Validate and resolve into a ready-to-use [`ResolvedOffsite`]. This is the
     /// STRICT step — bucket is required here — and must only run when uploading.
     fn resolve(self) -> Result<ResolvedOffsite, BackupError> {
@@ -1810,6 +1803,53 @@ impl LoadedOffsite {
             app_storage_endpoint,
             profile,
         })
+    }
+}
+
+/// Decide whether a backup run should upload, reading ONLY the
+/// `[backup.offsite].auto_upload` bit — WITHOUT a full `AutumnConfig` load (no
+/// global validation, no encrypted-credentials decryption), so a local-only
+/// backup is never blocked by unrelated config/credentials issues (issue #1619
+/// P2 #8). Resolution matches the config layering: real env
+/// `AUTUMN_BACKUP__OFFSITE__AUTO_UPLOAD` → `.env.<profile>` → merged TOML
+/// `[backup.offsite].auto_upload` (base + `[profile.<p>]` overlay) → `false`.
+fn auto_upload_probe(profile: &str) -> bool {
+    use autumn_web::config::Env as _;
+    // The profile-aware dotenv overlay covers BOTH the real env and `.env.<p>`
+    // (a real env var wins inside the overlay), matching P2 #6.
+    let env = dotenv_env_for_profile(profile);
+    let table = migrate::read_autumn_toml_table_with_profile(Some(profile));
+    auto_upload_from_sources(|k| env.var(k).ok(), table.as_ref())
+}
+
+/// Pure resolution of `auto_upload` from an env lookup + a merged TOML table.
+/// Env (real + `.env`) wins over TOML; default `false`. Separated so the
+/// precedence is unit-testable without touching the filesystem/process env.
+fn auto_upload_from_sources<F>(env_var: F, table: Option<&toml::Table>) -> bool
+where
+    F: Fn(&str) -> Option<String>,
+{
+    if let Some(raw) = env_var("AUTUMN_BACKUP__OFFSITE__AUTO_UPLOAD")
+        && let Some(b) = parse_bool_flag(&raw)
+    {
+        return b;
+    }
+    table
+        .and_then(|t| t.get("backup"))
+        .and_then(|v| v.get("offsite"))
+        .and_then(|v| v.get("auto_upload"))
+        .and_then(toml::Value::as_bool)
+        .unwrap_or(false)
+}
+
+/// Parse a boolean env flag the same way the config loader's `parse_env_bool`
+/// does: `1`/`true` → true, `0`/`false` → false (case-insensitive, trimmed),
+/// anything else → `None` (ignored).
+fn parse_bool_flag(raw: &str) -> Option<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" => Some(true),
+        "0" | "false" => Some(false),
+        _ => None,
     }
 }
 
@@ -3248,10 +3288,9 @@ mod tests {
 
     #[test]
     fn local_backup_does_not_validate_incomplete_offsite() {
-        // P2 #1: an incomplete [backup.offsite] (no bucket) with auto_upload off
-        // must NOT block a plain local `autumn db backup`. Reading auto_upload
-        // never validates; the strict bucket check lives in resolve(), which the
-        // backup path only calls when an upload is actually requested.
+        // P2 #1: an incomplete [backup.offsite] (no bucket) must NOT block a plain
+        // local `autumn db backup`. The strict bucket check lives in resolve(),
+        // which the backup path only calls when an upload is actually requested.
         let offsite = autumn_web::config::OffsiteBackupConfig::default();
         assert!(offsite.s3.bucket.is_none(), "precondition: no bucket set");
         let loaded = LoadedOffsite {
@@ -3260,14 +3299,47 @@ mod tests {
             app_storage_endpoint: None,
             profile: "test".to_owned(),
         };
-        // The decision a local backup makes (args.upload = false): no upload.
-        assert!(!loaded.auto_upload());
-        // And the strict validation is deferred to resolve() (only reached when
+        // The strict validation is deferred to resolve() (only reached when
         // uploading) — proving a local-only backup never hits it.
         assert!(matches!(
             loaded.resolve(),
             Err(BackupError::OffsiteConfig { .. })
         ));
+    }
+
+    #[test]
+    fn auto_upload_probe_precedence_and_repro() {
+        // P2 #8: the upload decision reads ONLY `[backup.offsite].auto_upload`
+        // from env / .env / merged TOML — never a full config load / credential
+        // decryption. Pure `auto_upload_from_sources` proves the precedence.
+        let no_env = |_: &str| None;
+
+        // (a) REPRO: no offsite section, no env => false => NO upload, and (by
+        // construction) the decision needed no AutumnConfig load / cred decrypt.
+        assert!(!auto_upload_from_sources(no_env, None));
+        let empty: toml::Table = toml::Table::new();
+        assert!(!auto_upload_from_sources(no_env, Some(&empty)));
+
+        // (b) auto_upload=true via TOML [backup.offsite] triggers upload.
+        let toml_true: toml::Table =
+            toml::from_str("[backup.offsite]\nauto_upload = true\n").unwrap();
+        assert!(auto_upload_from_sources(no_env, Some(&toml_true)));
+
+        // (b) auto_upload=true via env (real env or .env.<profile>) triggers it,
+        // even with no TOML.
+        let env_true =
+            |k: &str| (k == "AUTUMN_BACKUP__OFFSITE__AUTO_UPLOAD").then(|| "true".to_owned());
+        assert!(auto_upload_from_sources(env_true, None));
+
+        // Env wins over TOML: env "false" overrides TOML true.
+        let env_false =
+            |k: &str| (k == "AUTUMN_BACKUP__OFFSITE__AUTO_UPLOAD").then(|| "false".to_owned());
+        assert!(!auto_upload_from_sources(env_false, Some(&toml_true)));
+
+        // A non-boolean env value is ignored, falling back to TOML.
+        let env_junk =
+            |k: &str| (k == "AUTUMN_BACKUP__OFFSITE__AUTO_UPLOAD").then(|| "yesplease".to_owned());
+        assert!(auto_upload_from_sources(env_junk, Some(&toml_true)));
     }
 
     #[test]

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -201,6 +201,10 @@ pub enum BackupError {
     /// A non-split offsite operation (list / download / config load) failed.
     /// `detail` is credential-safe (S3 status/code, never secrets).
     Offsite { op: &'static str, detail: String },
+    /// An offsite restore was requested (`--offsite` or an `offsite:` prefix) but
+    /// the reference is malformed. Carries the bad reference (no secrets). The
+    /// restore MUST fail rather than fall through to a local artifact.
+    InvalidOffsiteRef { reference: String },
 }
 
 impl std::fmt::Display for BackupError {
@@ -269,6 +273,11 @@ impl std::fmt::Display for BackupError {
                  fixing the offsite destination."
             ),
             Self::Offsite { op, detail } => write!(f, "Offsite {op} failed: {detail}"),
+            Self::InvalidOffsiteRef { reference } => write!(
+                f,
+                "Invalid offsite reference {reference:?}.\n  Expected \
+                 offsite:<profile>/<timestamp|latest> (for example offsite:prod/latest)."
+            ),
         }
     }
 }
@@ -814,8 +823,12 @@ fn restore(args: &RestoreArgs) -> Result<(), BackupError> {
     // temp dir and hand it to the SAME RestorePlan::discover path so the
     // identical integrity-refusal + guard/`--force` protocol applies unchanged.
     let artifact_str = args.artifact.to_string_lossy();
+    // When offsite is indicated (flag or `offsite:` prefix) we commit to the
+    // offsite path: a malformed reference is an error, never a silent fall
+    // through to a same-named local artifact. `None` means offsite was not
+    // indicated at all, so a normal local restore proceeds.
     if let Some(oref) = resolve_offsite_ref(args.offsite, &artifact_str) {
-        return restore_from_offsite(args, &oref);
+        return restore_from_offsite(args, &oref?);
     }
 
     let plan = RestorePlan::discover(&args.artifact, args.shard.as_deref())?;
@@ -2204,15 +2217,25 @@ enum OffsiteSelector {
     Exact(String),
 }
 
-/// Resolve an offsite reference from the `--offsite` flag and the artifact
-/// string. An `offsite:` prefix implies offsite even without the flag; when the
-/// flag is set the artifact is treated as `<profile>/<ts|latest>` directly.
-fn resolve_offsite_ref(flag: bool, artifact: &str) -> Option<OffsiteRef> {
+/// Resolve an offsite reference when offsite restore is indicated. Returns:
+///
+/// * `None` — offsite is NOT indicated (no `--offsite` flag and no `offsite:`
+///   prefix); the caller routes to a normal LOCAL restore.
+/// * `Some(Ok(_))` — offsite is indicated and the reference parsed.
+/// * `Some(Err(_))` — offsite is indicated but the reference is malformed; the
+///   caller MUST surface the error and MUST NEVER fall through to local restore
+///   (otherwise `restore --offsite latest` could silently restore an unrelated
+///   local path named `latest` in the cwd).
+fn resolve_offsite_ref(flag: bool, artifact: &str) -> Option<Result<OffsiteRef, BackupError>> {
     let has_prefix = artifact.starts_with("offsite:");
     if !flag && !has_prefix {
         return None;
     }
-    parse_offsite_ref(artifact)
+    Some(
+        parse_offsite_ref(artifact).ok_or_else(|| BackupError::InvalidOffsiteRef {
+            reference: artifact.to_owned(),
+        }),
+    )
 }
 
 /// Parse `offsite:<profile>/<timestamp|latest>` (the `offsite:` prefix is
@@ -3400,13 +3423,55 @@ mod tests {
     }
 
     #[test]
-    fn resolve_offsite_ref_requires_flag_or_prefix() {
-        // A bare local path is not an offsite ref.
+    fn resolve_offsite_ref_routes_local_only_when_not_indicated() {
+        // (c) A bare local path with neither flag nor prefix routes to LOCAL
+        // restore (None), unchanged.
         assert!(resolve_offsite_ref(false, "backups/prod/20260710T040506Z").is_none());
-        // The `offsite:` prefix alone triggers it.
-        assert!(resolve_offsite_ref(false, "offsite:prod/latest").is_some());
-        // The `--offsite` flag reinterprets a bare `<profile>/<sel>` positional.
-        assert!(resolve_offsite_ref(true, "prod/latest").is_some());
+        assert!(resolve_offsite_ref(false, "latest").is_none());
+
+        // (d) Well-formed offsite refs parse (Some(Ok(_))).
+        let ok = resolve_offsite_ref(false, "offsite:prod/latest").unwrap();
+        assert_eq!(
+            ok.unwrap(),
+            OffsiteRef {
+                profile: "prod".to_owned(),
+                selector: OffsiteSelector::Latest,
+            }
+        );
+        let ok = resolve_offsite_ref(true, "prod/20260710T040506Z").unwrap();
+        assert_eq!(
+            ok.unwrap(),
+            OffsiteRef {
+                profile: "prod".to_owned(),
+                selector: OffsiteSelector::Exact("20260710T040506Z".to_owned()),
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_offsite_ref_errors_on_malformed_when_indicated() {
+        // (a) `--offsite` with a malformed ref (no `<profile>/`) must ERROR, not
+        // fall through to a local artifact named `latest`.
+        let err = resolve_offsite_ref(true, "latest").unwrap().unwrap_err();
+        assert!(matches!(err, BackupError::InvalidOffsiteRef { .. }));
+        let msg = err.to_string();
+        assert!(msg.contains("latest"));
+        assert!(msg.contains("offsite:<profile>/<timestamp|latest>"));
+
+        // (b) `offsite:` prefix with a malformed body must ERROR too.
+        assert!(matches!(
+            resolve_offsite_ref(false, "offsite:prod").unwrap(),
+            Err(BackupError::InvalidOffsiteRef { .. })
+        ));
+        assert!(matches!(
+            resolve_offsite_ref(false, "offsite:/latest").unwrap(),
+            Err(BackupError::InvalidOffsiteRef { .. })
+        ));
+        // Flag set but empty positional => still an offsite error, not local.
+        assert!(matches!(
+            resolve_offsite_ref(true, "").unwrap(),
+            Err(BackupError::InvalidOffsiteRef { .. })
+        ));
     }
 
     #[test]

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -1058,7 +1058,11 @@ fn dotenv_env() -> autumn_web::dotenv::DotenvOsEnv {
 /// `autumn db backup --profile test --upload` from a dev/unset shell would miss
 /// `.env.test`-provided offsite settings and credentials.
 fn dotenv_env_for_profile(profile: &str) -> autumn_web::dotenv::DotenvOsEnv {
-    match autumn_web::dotenv::os_env_with_dotenv_for_profile(profile) {
+    // Normalize aliases/case to the app's resolved profile FIRST (P2 #20), so
+    // `--profile development` / `AUTUMN_ENV=PROD` selects `.env.dev` / `.env.prod`
+    // — the same file the running app reads — instead of a literal `.env.development`.
+    let profile = migrate::canonical_profile(profile);
+    match autumn_web::dotenv::os_env_with_dotenv_for_profile(&profile) {
         Ok(env) => env,
         Err(e) => {
             eprintln!("  \u{274C} .env: {e}");
@@ -1822,13 +1826,16 @@ impl LoadedOffsite {
 /// `[backup.offsite].auto_upload` (base + `[profile.<p>]` overlay) → `false`.
 fn auto_upload_probe(profile: &str) -> bool {
     use autumn_web::config::Env as _;
+    // Normalize aliases/case to the app's resolved profile (P2 #20) so both the
+    // dotenv overlay and the `[profile.<p>]` selection match what the app reads.
+    let profile = migrate::canonical_profile(profile);
     // The profile-aware dotenv overlay covers BOTH the real env and `.env.<p>`
     // (a real env var wins inside the overlay), matching P2 #6.
-    let env = dotenv_env_for_profile(profile);
+    let env = dotenv_env_for_profile(&profile);
     // Read `autumn.toml` from the config/manifest dir (AUTUMN_MANIFEST_DIR),
     // matching where the full loader + the dotenv overlay look — so an installed/
     // daemon launch with a different CWD still sees `auto_upload` (P2 #15).
-    let table = migrate::read_autumn_toml_table_with_profile_from_config_dir(Some(profile));
+    let table = migrate::read_autumn_toml_table_with_profile_from_config_dir(Some(&profile));
     auto_upload_from_sources(|k| env.var(k).ok(), table.as_ref())
 }
 
@@ -1876,16 +1883,20 @@ fn parse_bool_flag(raw: &str) -> Option<bool> {
 /// here — that is deferred to [`LoadedOffsite::resolve`] so a local backup is
 /// never blocked by an incomplete offsite section.
 fn load_offsite(profile: &str) -> Result<Option<LoadedOffsite>, BackupError> {
+    // Normalize aliases/case to the app's resolved profile (P2 #20) so the dotenv
+    // overlay, the `[profile.<p>]` selection, and the stored profile (later reused
+    // for credential resolution) all match what the running app reads.
+    let profile = migrate::canonical_profile(profile);
     // Real env + `.env.<profile>` overlay (profile-aware, P2 #6); merged TOML
     // (base + `[profile.<p>]`) — neither decrypts credentials nor validates.
-    let env = dotenv_env_for_profile(profile);
+    let env = dotenv_env_for_profile(&profile);
     // Read `autumn.toml` from the config/manifest dir (AUTUMN_MANIFEST_DIR),
     // matching the full loader + dotenv overlay — so an installed/daemon launch
     // whose CWD differs from the config dir still finds the offsite destination
     // (and enforces the distinct-bucket guard) instead of reporting it
     // unconfigured (P2 #15).
-    let table = migrate::read_autumn_toml_table_with_profile_from_config_dir(Some(profile));
-    resolve_loaded_offsite(table.as_ref(), &env, profile)
+    let table = migrate::read_autumn_toml_table_with_profile_from_config_dir(Some(&profile));
+    resolve_loaded_offsite(table.as_ref(), &env, &profile)
 }
 
 /// Pure core of [`load_offsite`]: build the offsite view from a merged TOML table
@@ -2113,14 +2124,24 @@ fn upload_run(
     if files.is_empty() {
         return Err("the completed run directory contains no files to upload".to_owned());
     }
+    let mut written_keys: Vec<String> = Vec::new();
     for file in &files {
         let path = run_dir.join(file);
         let key = offsite_object_key(&offsite.prefix, profile, run_id, file);
+        // `put_file_and_verify` WRITES the object BEFORE its HEAD/GET verification,
+        // so even a verify failure can leave the object (incl. the run manifest) in
+        // the bucket. Record the key up-front, then on ANY failure best-effort
+        // delete everything this run wrote — manifest first — so a run whose upload
+        // was reported FAILED never keeps a remote `manifest.json` and can't become
+        // `latest` or consume a retention slot (restores the P2 #2 invariant; #21).
+        written_keys.push(key.clone());
         // Stream the file straight from disk (hash pre-pass + streamed body):
         // a multi-GB dump is never read into memory.
-        client
-            .put_file_and_verify(&key, &path)
-            .map_err(|e| format!("{file}: {e}"))?;
+        if let Err(e) = client.put_file_and_verify(&key, &path) {
+            let detail = format!("{file}: {e}");
+            cleanup_failed_upload(client, &written_keys);
+            return Err(detail);
+        }
         eprintln!("  \u{2713} uploaded + verified {file}");
     }
     eprintln!(
@@ -2138,6 +2159,35 @@ fn upload_run(
         eprintln!("  \u{26A0} offsite retention skipped: {e}");
     }
     Ok(())
+}
+
+/// Best-effort removal of the objects a FAILED [`upload_run`] wrote, so a partial
+/// upload never leaves a remote `manifest.json` behind — which
+/// [`complete_remote_run_ids`] would otherwise count as a COMPLETE run for
+/// `latest`/retention (P2 #21). The manifest key is deleted FIRST so that even if
+/// a later delete fails, the completeness marker is already gone. Delete failures
+/// are swallowed: the caller surfaces the ORIGINAL upload/verify error.
+fn cleanup_failed_upload(client: &S3Client, written_keys: &[String]) {
+    for key in order_cleanup_keys(written_keys) {
+        let _ = client.delete_object(&key);
+    }
+}
+
+/// Order the keys a failed upload wrote for cleanup: the run's `manifest.json`
+/// FIRST (drop the completeness marker before anything else), then the rest in
+/// their written order. Pure for unit testing.
+fn order_cleanup_keys(written_keys: &[String]) -> Vec<String> {
+    let mut keys = written_keys.to_vec();
+    // `false` (manifest) sorts before `true` (everything else); stable sort keeps
+    // the remaining keys in their original order.
+    keys.sort_by_key(|k| !key_is_manifest(k));
+    keys
+}
+
+/// Whether an object key is a run's manifest (its final path component is
+/// [`MANIFEST_FILE`]).
+fn key_is_manifest(key: &str) -> bool {
+    key.rsplit('/').next() == Some(MANIFEST_FILE)
 }
 
 /// List the file names (not sub-directories) directly inside a run directory.
@@ -3655,6 +3705,49 @@ mod tests {
             s3.app_storage_bucket.as_deref(),
             s3.app_storage_endpoint.as_deref(),
         ));
+    }
+
+    #[test]
+    fn key_is_manifest_matches_only_the_run_manifest() {
+        assert!(key_is_manifest(
+            "db/prod/20260710T040506Z-abcd1234/manifest.json"
+        ));
+        assert!(!key_is_manifest(
+            "db/prod/20260710T040506Z-abcd1234/control.dump"
+        ));
+        // A file that merely contains the word is not the manifest.
+        assert!(!key_is_manifest("db/prod/r/not-manifest.json.dump"));
+    }
+
+    #[test]
+    fn order_cleanup_keys_deletes_manifest_first() {
+        // P2 #21: on a failed upload the run manifest must be removed FIRST so the
+        // completeness marker is gone even if a later delete fails — otherwise a
+        // failed run could still be counted `complete` for latest/retention.
+        let written = vec![
+            "db/prod/r/control.dump".to_owned(),
+            "db/prod/r/shard-a.dump".to_owned(),
+            "db/prod/r/manifest.json".to_owned(),
+        ];
+        let ordered = order_cleanup_keys(&written);
+        assert_eq!(ordered[0], "db/prod/r/manifest.json");
+        // The remaining (non-manifest) keys keep their written order.
+        assert_eq!(
+            &ordered[1..],
+            &[
+                "db/prod/r/control.dump".to_owned(),
+                "db/prod/r/shard-a.dump".to_owned()
+            ]
+        );
+
+        // And downstream: with the manifest deleted, complete_remote_run_ids no
+        // longer counts the run — so the failed run can't become `latest`.
+        let list_prefix = "db/prod/";
+        let after_cleanup = vec![s3::S3Object {
+            key: "db/prod/r/control.dump".to_owned(), // manifest was cleaned up
+            size: 10,
+        }];
+        assert!(complete_remote_run_ids(&after_cleanup, list_prefix).is_empty());
     }
 
     #[test]

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -1776,8 +1776,8 @@ fn load_offsite(profile: &str) -> Result<Option<ResolvedOffsite>, BackupError> {
 }
 
 /// Whether the offsite destination collides with the app's user-facing blob
-/// storage: same bucket AND same (normalized) endpoint. Pure for unit testing
-/// the AC #3 opt-in guard.
+/// storage: same bucket AND same canonical endpoint authority. Pure for unit
+/// testing the AC #3 opt-in guard.
 fn destinations_conflict(
     offsite_bucket: &str,
     offsite_endpoint: Option<&str>,
@@ -1788,17 +1788,53 @@ fn destinations_conflict(
         return false;
     };
     app_bucket == offsite_bucket
-        && normalize_endpoint(offsite_endpoint) == normalize_endpoint(app_endpoint)
+        && canonical_authority(offsite_endpoint, offsite_bucket)
+            == canonical_authority(app_endpoint, app_bucket)
 }
 
-/// Normalize an endpoint for comparison: trim, lowercase, drop a trailing slash.
-/// `None` and empty both normalize to `""` (the AWS default endpoint).
-fn normalize_endpoint(endpoint: Option<&str>) -> String {
-    endpoint
-        .unwrap_or("")
-        .trim()
-        .trim_end_matches('/')
-        .to_ascii_lowercase()
+/// Canonicalize an endpoint to a comparable `scheme://host[:non-default-port]`
+/// authority so spellings that address the SAME S3 service compare equal:
+///
+/// * `None`/empty (the AWS default endpoint) and any explicit `*.amazonaws.com`
+///   URL both collapse to `"aws"` — S3 bucket names are globally unique, so the
+///   same bucket name is the same bucket regardless of regional endpoint.
+/// * default ports (443/https, 80/http) are dropped so `host:443` == bare host.
+/// * a virtual-hosted `{bucket}.` host prefix is stripped so it compares equal
+///   to the path-style spelling of the same endpoint.
+///
+/// This prevents a genuinely shared bucket from slipping past the AC #3 guard
+/// because one side wrote the endpoint out explicitly and the other left it None.
+fn canonical_authority(endpoint: Option<&str>, bucket: &str) -> String {
+    let raw = endpoint.unwrap_or("").trim();
+    if raw.is_empty() {
+        return "aws".to_owned();
+    }
+    let with_scheme = if raw.contains("://") {
+        raw.to_owned()
+    } else {
+        format!("https://{raw}")
+    };
+    let Ok(url) = url::Url::parse(&with_scheme) else {
+        return raw.to_ascii_lowercase();
+    };
+    let host = url.host_str().unwrap_or("").to_ascii_lowercase();
+    if host == "amazonaws.com" || host.ends_with(".amazonaws.com") {
+        return "aws".to_owned();
+    }
+    // Strip a virtual-hosted `{bucket}.` prefix so path-style and virtual-hosted
+    // spellings of the same endpoint compare equal.
+    let bucket_prefix = format!("{}.", bucket.to_ascii_lowercase());
+    let host = host.strip_prefix(&bucket_prefix).unwrap_or(&host);
+    let scheme = url.scheme().to_ascii_lowercase();
+    let default_port = match scheme.as_str() {
+        "https" => Some(443),
+        "http" => Some(80),
+        _ => None,
+    };
+    match url.port() {
+        Some(port) if Some(port) != default_port => format!("{scheme}://{host}:{port}"),
+        _ => format!("{scheme}://{host}"),
+    }
 }
 
 /// Normalize a configured key prefix: trim surrounding whitespace and slashes so
@@ -2946,6 +2982,53 @@ mod tests {
         assert!(!destinations_conflict("offsite", None, None, None));
         // Both AWS default endpoint (None) + same bucket => conflict.
         assert!(destinations_conflict("shared", None, Some("shared"), None));
+    }
+
+    #[test]
+    fn destinations_conflict_normalizes_ports_and_aws_defaults() {
+        // `:443` vs bare host on https must compare equal (default port dropped).
+        assert!(destinations_conflict(
+            "shared",
+            Some("https://minio.example:443"),
+            Some("shared"),
+            Some("https://minio.example"),
+        ));
+        // `:80` vs bare host on http likewise.
+        assert!(destinations_conflict(
+            "shared",
+            Some("http://gw:80"),
+            Some("shared"),
+            Some("http://gw"),
+        ));
+        // Offsite None (AWS default) vs app spelled as the explicit regional AWS
+        // URL, same bucket => still a shared bucket (globally-unique name).
+        assert!(destinations_conflict(
+            "shared",
+            None,
+            Some("shared"),
+            Some("https://s3.us-east-1.amazonaws.com"),
+        ));
+        // ...and the virtual-hosted AWS spelling too.
+        assert!(destinations_conflict(
+            "shared",
+            None,
+            Some("shared"),
+            Some("https://shared.s3.us-east-1.amazonaws.com"),
+        ));
+        // A non-default port genuinely differs => distinct.
+        assert!(!destinations_conflict(
+            "shared",
+            Some("https://minio.example:9000"),
+            Some("shared"),
+            Some("https://minio.example"),
+        ));
+        // Virtual-hosted `{bucket}.` prefix vs path-style same host => equal.
+        assert!(destinations_conflict(
+            "shared",
+            Some("https://shared.minio.example"),
+            Some("shared"),
+            Some("https://minio.example"),
+        ));
     }
 
     #[test]

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -1716,6 +1716,8 @@ fn load_offsite(profile: &str) -> Result<Option<ResolvedOffsite>, BackupError> {
     let Some(offsite) = cfg.backup.offsite else {
         return Ok(None);
     };
+    // Unbox once so the field moves/reads below are identical to an owned value.
+    let offsite = *offsite;
     let bucket = offsite
         .s3
         .bucket

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -2409,6 +2409,24 @@ fn parse_offsite_ref(s: &str) -> Option<OffsiteRef> {
     })
 }
 
+/// Whether `name` is a single, plain filename component safe to `join` onto the
+/// download temp dir (P2 #13). Rejects anything that could escape the temp dir
+/// BEFORE manifest validation: a name is safe only when it contains no path
+/// separator (`/` OR `\` — `\` is a valid Unix filename byte but an S3 key
+/// written by a Windows run could carry a traversal like `..\..\evil`), is not
+/// `.`/`..`, is not absolute, and has no Windows drive/prefix. The
+/// `Component::Normal(c) if c == name` check is the robust cross-platform core;
+/// the explicit `\` reject covers the Unix case where `\` is not a separator.
+fn is_safe_leaf_name(name: &str) -> bool {
+    use std::path::{Component, Path};
+    if name.is_empty() || name.contains('/') || name.contains('\\') {
+        return false;
+    }
+    let p = Path::new(name);
+    p.components().count() == 1
+        && matches!(p.components().next(), Some(Component::Normal(c)) if c == name)
+}
+
 /// Download the referenced offsite run to a fresh temp dir and restore from it
 /// via the identical [`RestorePlan::discover`] path (AC #4). The temp dir is
 /// removed when the guard drops (after the restore completes or fails).
@@ -2449,10 +2467,15 @@ fn restore_from_offsite(args: &RestoreArgs, oref: &OffsiteRef) -> Result<(), Bac
         let file = obj
             .key
             .strip_prefix(run_prefix.as_str())
-            .filter(|f| !f.is_empty() && !f.contains('/'))
+            .filter(|f| is_safe_leaf_name(f))
             .ok_or_else(|| BackupError::Offsite {
                 op: "download",
-                detail: format!("unexpected object key layout: {}", obj.key),
+                detail: format!(
+                    "refusing offsite object with an unsafe key layout: {} (each object name \
+                     must be a single plain filename — no path separators, traversal, or drive \
+                     prefix)",
+                    obj.key
+                ),
             })?;
         // Stream the object straight to disk (constant memory), so a multi-GB
         // dump is never buffered while downloading for restore.
@@ -3664,6 +3687,28 @@ mod tests {
         assert!(!runs[0].complete);
         let table = format_offsite_listing(&runs);
         assert!(table.contains("INCOMPLETE"), "table was: {table}");
+    }
+
+    #[test]
+    fn is_safe_leaf_name_rejects_separators_and_traversal() {
+        // P2 #13: a downloaded offsite object name must be a single plain file.
+        for good in ["control.dump", "manifest.json", "shard-orders.dump"] {
+            assert!(is_safe_leaf_name(good), "{good:?} should be accepted");
+        }
+        for bad in [
+            "",
+            "a/b",
+            "a\\b",
+            "..\\..\\evil",
+            "../evil",
+            "C:\\evil",
+            "..",
+            ".",
+            "/abs",
+            "sub/manifest.json",
+        ] {
+            assert!(!is_safe_leaf_name(bad), "{bad:?} should be rejected");
+        }
     }
 
     #[test]

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -1677,10 +1677,30 @@ impl ResolvedOffsite {
             });
         }
         let creds = self.resolve_credentials()?;
-        S3Client::new(self.s3.clone(), creds).map_err(|e| BackupError::Offsite {
+        let client = S3Client::new(self.s3.clone(), creds).map_err(|e| BackupError::Offsite {
             op: "connect",
             detail: e.to_string(),
+        })?;
+        // Test/ops escape hatch: shrink the multipart threshold and part size so
+        // the multipart path can be exercised (or tuned) without a multi-GB
+        // fixture. The value is a target part size in bytes; both threshold and
+        // part size are set to it (the client re-floors to S3's 5 MiB minimum).
+        Ok(match self.multipart_part_size_override() {
+            Some(bytes) => client.with_multipart_params(bytes, bytes),
+            None => client,
         })
+    }
+
+    /// Read the `AUTUMN_OFFSITE_MULTIPART_PART_SIZE_BYTES` override (profile-aware,
+    /// so a `.env.<profile>` value is honored). A blank/unparseable value is
+    /// ignored (falls back to the client defaults).
+    fn multipart_part_size_override(&self) -> Option<u64> {
+        use autumn_web::config::Env as _;
+        let env = dotenv_env_for_profile(&self.profile);
+        env.var("AUTUMN_OFFSITE_MULTIPART_PART_SIZE_BYTES")
+            .ok()
+            .and_then(|v: String| v.trim().parse::<u64>().ok())
+            .filter(|&n| n > 0)
     }
 
     /// Resolve the access key / secret from the environment variables NAMED by

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -1719,24 +1719,6 @@ fn read_credential_env(
         })
 }
 
-/// An `Env` overlay that forces `AUTUMN_ENV` to a specific profile so
-/// [`AutumnConfig::load_with_env`](autumn_web::config::AutumnConfig::load_with_env)
-/// resolves the `[backup.offsite]` section under the SAME profile the backup run
-/// is keyed by (matching [`migrate::effective_profile`]'s resolution).
-struct ProfileForcedEnv<'a> {
-    inner: &'a dyn autumn_web::config::Env,
-    profile: String,
-}
-
-impl autumn_web::config::Env for ProfileForcedEnv<'_> {
-    fn var(&self, key: &str) -> Result<String, std::env::VarError> {
-        if key == "AUTUMN_ENV" {
-            return Ok(self.profile.clone());
-        }
-        self.inner.var(key)
-    }
-}
-
 /// A leniently-loaded `[backup.offsite]` section: enough to learn `auto_upload`
 /// WITHOUT validating the bucket/credentials, so a plain local `autumn db backup`
 /// (no `--upload`, no `auto_upload`) never fails just because an incomplete
@@ -1853,27 +1835,57 @@ fn parse_bool_flag(raw: &str) -> Option<bool> {
     }
 }
 
-/// Leniently load the `[backup.offsite]` section for `profile`, applying the
-/// profile overlay and `AUTUMN_*` env overrides via the runtime config loader.
-/// `Ok(None)` when no offsite section is configured. Performs NO bucket/cred
-/// validation — that is deferred to [`LoadedOffsite::resolve`] so a local-only
-/// backup is never blocked by an incomplete offsite section.
+/// Leniently resolve the `[backup.offsite]` destination for `profile` WITHOUT a
+/// full `AutumnConfig::load` — i.e. WITHOUT decrypting the app credential store
+/// (`config/credentials/<profile>.toml.enc`) or running app-wide validation, so
+/// offsite commands work on a minimal DR/recovery box that has only DB + offsite
+/// env vars and NO `AUTUMN_MASTER_KEY` (issue #1619 P2 #9). It reads only what
+/// offsite needs — the merged TOML (base + `[profile.<p>]`) plus real env and
+/// `.env.<profile>` overrides — for `[backup.offsite]` AND the `[storage.s3]`
+/// bucket/endpoint (the distinct-destination guard needs them).
+///
+/// `Ok(None)` when no offsite section is configured. NO bucket/cred validation
+/// here — that is deferred to [`LoadedOffsite::resolve`] so a local backup is
+/// never blocked by an incomplete offsite section.
 fn load_offsite(profile: &str) -> Result<Option<LoadedOffsite>, BackupError> {
-    // Load `.env.<profile>` for the TARGET profile (not the ambient shell one),
-    // then force `AUTUMN_ENV` for the TOML `[profile.<profile>]` overlay. Both
-    // must key off the same profile so a `.env.<profile>`-provided offsite
-    // override is honored (issue #1619 P2 #6).
-    let base = dotenv_env_for_profile(profile);
-    let forced = ProfileForcedEnv {
-        inner: &base,
-        profile: profile.to_owned(),
-    };
-    let cfg = autumn_web::config::AutumnConfig::load_with_env(&forced).map_err(|e| {
-        BackupError::Offsite {
-            op: "config load",
-            detail: e.to_string(),
+    // Real env + `.env.<profile>` overlay (profile-aware, P2 #6); merged TOML
+    // (base + `[profile.<p>]`) — neither decrypts credentials nor validates.
+    let env = dotenv_env_for_profile(profile);
+    let table = migrate::read_autumn_toml_table_with_profile(Some(profile));
+    resolve_loaded_offsite(table.as_ref(), &env, profile)
+}
+
+/// Pure core of [`load_offsite`]: build the offsite view from a merged TOML table
+/// and an `Env`, applying `AUTUMN_*` overrides via the config crate's
+/// env-override machinery (which does NOT decrypt credentials or run global
+/// validation). Separated so the DR-box behavior is unit-testable without
+/// touching the filesystem / process env / credential store.
+fn resolve_loaded_offsite(
+    table: Option<&toml::Table>,
+    env: &dyn autumn_web::config::Env,
+    profile: &str,
+) -> Result<Option<LoadedOffsite>, BackupError> {
+    // Deserialize the merged TOML into AutumnConfig — plain `Deserialize`, so no
+    // credential decryption and no `validate()` (those live only in `load*`).
+    let mut cfg = match table {
+        Some(t) => {
+            let toml_str = toml::to_string(t).map_err(|e| BackupError::Offsite {
+                op: "config",
+                detail: e.to_string(),
+            })?;
+            toml::from_str::<autumn_web::config::AutumnConfig>(&toml_str).map_err(|e| {
+                BackupError::Offsite {
+                    op: "config",
+                    detail: e.to_string(),
+                }
+            })?
         }
-    })?;
+        None => autumn_web::config::AutumnConfig::default(),
+    };
+    // Apply `AUTUMN_*` env overrides (incl. backup.offsite + storage.s3). This is
+    // pure field-setting — no decryption, no validation.
+    cfg.apply_env_overrides_with_env(env);
+
     let Some(offsite) = cfg.backup.offsite else {
         return Ok(None);
     };
@@ -3359,6 +3371,42 @@ mod tests {
         };
         let resolved = loaded.resolve().expect("bucket set, resolves");
         assert_eq!(resolved.profile, "test");
+    }
+
+    #[test]
+    fn offsite_resolves_without_app_credential_store() {
+        // P2 #9: offsite destination resolves from TOML + env WITHOUT a full
+        // AutumnConfig::load — so NO credential decryption / AUTUMN_MASTER_KEY is
+        // needed. On current code this path went through load_with_env, which
+        // would fail on a DR box whose config/credentials/<p>.toml.enc can't be
+        // decrypted. `resolve_loaded_offsite` reads only the offsite + storage.s3
+        // config, never the credential store.
+        let table: toml::Table = toml::from_str(
+            "[backup.offsite]\nprefix = \"db\"\n\
+             [backup.offsite.s3]\nbucket = \"dr-bucket\"\nregion = \"us-east-1\"\n\
+             endpoint = \"https://minio.example:9000\"\nforce_path_style = true\n\
+             access_key_id_env = \"OFFSITE_KEY\"\nsecret_access_key_env = \"OFFSITE_SECRET\"\n",
+        )
+        .unwrap();
+        // Real env supplies the S3 credential VALUES; crucially there is NO
+        // AUTUMN_MASTER_KEY and no attempt to read a credential store.
+        let env = autumn_web::config::MockEnv::new()
+            .with("OFFSITE_KEY", "AKIA_DR")
+            .with("OFFSITE_SECRET", "shh");
+        let loaded = resolve_loaded_offsite(Some(&table), &env, "prod")
+            .expect("resolves without a credential store")
+            .expect("offsite section present");
+        let resolved = loaded.resolve().expect("bucket set");
+        assert_eq!(resolved.s3.bucket, "dr-bucket");
+        assert_eq!(resolved.profile, "prod");
+
+        // Env-only configuration (no TOML at all) also resolves.
+        let env2 = autumn_web::config::MockEnv::new()
+            .with("AUTUMN_BACKUP__OFFSITE__S3__BUCKET", "env-bucket");
+        let loaded2 = resolve_loaded_offsite(None, &env2, "prod")
+            .unwrap()
+            .expect("materialized from env");
+        assert_eq!(loaded2.offsite.s3.bucket.as_deref(), Some("env-bucket"));
     }
 
     #[test]

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -1975,8 +1975,16 @@ fn list_run_files(run_dir: &Path) -> Result<Vec<String>, BackupError> {
     Ok(files)
 }
 
-/// Prune remote runs for a profile, keeping the newest `keep` and NEVER deleting
-/// the just-uploaded `keep_run_id`. Independent of the local `--keep`.
+/// Prune remote runs for a profile, keeping the newest `keep` COMPLETE runs and
+/// NEVER deleting the just-uploaded `keep_run_id`. Independent of the local
+/// `--keep`.
+///
+/// Retention is based ONLY on complete runs (those with a remote `manifest.json`,
+/// the same completeness source `resolve_latest_run` uses), so a partial/failed
+/// upload can't consume a keep slot and cause an older *complete* backup to be
+/// pruned. Incomplete/partial prefixes are left untouched here — deleting them
+/// could race a concurrent in-progress upload; GC of stale partial prefixes is a
+/// possible follow-up, out of scope for this change.
 fn prune_remote(
     offsite: &ResolvedOffsite,
     client: &S3Client,
@@ -1988,7 +1996,7 @@ fn prune_remote(
     let objects = client
         .list_objects_v2(&list_prefix)
         .map_err(|e| e.to_string())?;
-    let run_ids = remote_run_ids(&objects, &list_prefix);
+    let run_ids = complete_remote_run_ids(&objects, &list_prefix);
     let to_remove = plan_remote_pruning(&run_ids, keep, keep_run_id);
     for run_id in &to_remove {
         let run_prefix = offsite_run_prefix(&offsite.prefix, profile, run_id);
@@ -2004,7 +2012,10 @@ fn prune_remote(
 }
 
 /// Extract the unique, sorted run-id (timestamp) segments from listed object
-/// keys under `list_prefix` (`{list_prefix}{run_id}/{file}`).
+/// keys under `list_prefix` (`{list_prefix}{run_id}/{file}`). Test-only: the
+/// live paths (`latest` resolution and retention) use the manifest-gated
+/// [`complete_remote_run_ids`] so partial runs never count.
+#[cfg(test)]
 fn remote_run_ids(objects: &[s3::S3Object], list_prefix: &str) -> Vec<String> {
     let mut ids: Vec<String> = objects
         .iter()
@@ -3238,6 +3249,67 @@ mod tests {
             complete.into_iter().next_back().as_deref(),
             Some("20260709T010101Z")
         );
+    }
+
+    #[test]
+    fn remote_retention_counts_only_complete_runs() {
+        // P2 #3 (Codex scenario): keep=2 with complete runs A/B, a NEWER partial
+        // run C (no manifest), and the just-uploaded complete run D. Retention
+        // must count only complete runs — keep the newest 2 complete (D, B),
+        // prune the older complete A, and NEVER touch the partial C or D.
+        let list_prefix = "db/prod/";
+        let a = "20260701T000000Z"; // complete, oldest
+        let b = "20260702T000000Z"; // complete
+        let c = "20260703T000000Z"; // PARTIAL (no manifest), newer than B
+        let d = "20260704T000000Z"; // complete, just uploaded (newest)
+        let objects = vec![
+            s3::S3Object {
+                key: format!("{list_prefix}{a}/control.dump"),
+                size: 1,
+            },
+            s3::S3Object {
+                key: format!("{list_prefix}{a}/manifest.json"),
+                size: 1,
+            },
+            s3::S3Object {
+                key: format!("{list_prefix}{b}/control.dump"),
+                size: 1,
+            },
+            s3::S3Object {
+                key: format!("{list_prefix}{b}/manifest.json"),
+                size: 1,
+            },
+            // Partial C: artifact only, no manifest.
+            s3::S3Object {
+                key: format!("{list_prefix}{c}/control.dump"),
+                size: 1,
+            },
+            s3::S3Object {
+                key: format!("{list_prefix}{d}/control.dump"),
+                size: 1,
+            },
+            s3::S3Object {
+                key: format!("{list_prefix}{d}/manifest.json"),
+                size: 1,
+            },
+        ];
+
+        // Retention input = complete runs only (A, B, D) — the partial C is absent.
+        let complete = complete_remote_run_ids(&objects, list_prefix);
+        assert_eq!(
+            complete,
+            vec![a.to_owned(), b.to_owned(), d.to_owned()],
+            "partial run C must not count as a retention slot"
+        );
+
+        // keep=2, just-uploaded=D => prune only the oldest complete run A.
+        let to_remove = plan_remote_pruning(&complete, 2, d);
+        assert_eq!(to_remove, vec![a.to_owned()]);
+        // The partial C is NOT pruned (never a candidate), and D is never pruned.
+        assert!(!to_remove.contains(&c.to_owned()));
+        assert!(!to_remove.contains(&d.to_owned()));
+        // B survives (it's within the newest-2 complete).
+        assert!(!to_remove.contains(&b.to_owned()));
     }
 
     #[test]

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -1922,24 +1922,37 @@ fn resolve_loaded_offsite(
     let Some(offsite) = cfg.backup.offsite else {
         return Ok(None);
     };
+    // Only treat the `[storage.s3]` bucket as the APP storage destination when the
+    // resolved storage backend is actually S3 (P2 #16). If the app runs on the
+    // local/disabled backend, a leftover `[storage.s3]` bucket is inert — it is
+    // not where the app writes blobs — so it must NOT trip the shared-bucket guard
+    // and force `allow_shared_bucket` for an offsite backup that happens to reuse
+    // that bucket name.
+    let storage_is_s3 = cfg.storage.backend == autumn_web::storage::StorageBackend::S3;
+    let (app_storage_bucket, app_storage_endpoint) = if storage_is_s3 {
+        (
+            cfg.storage
+                .s3
+                .bucket
+                .as_deref()
+                .map(str::trim)
+                .filter(|b| !b.is_empty())
+                .map(str::to_owned),
+            cfg.storage
+                .s3
+                .endpoint
+                .as_deref()
+                .map(str::trim)
+                .filter(|e| !e.is_empty())
+                .map(str::to_owned),
+        )
+    } else {
+        (None, None)
+    };
     Ok(Some(LoadedOffsite {
         offsite: *offsite,
-        app_storage_bucket: cfg
-            .storage
-            .s3
-            .bucket
-            .as_deref()
-            .map(str::trim)
-            .filter(|b| !b.is_empty())
-            .map(str::to_owned),
-        app_storage_endpoint: cfg
-            .storage
-            .s3
-            .endpoint
-            .as_deref()
-            .map(str::trim)
-            .filter(|e| !e.is_empty())
-            .map(str::to_owned),
+        app_storage_bucket,
+        app_storage_endpoint,
         profile: profile.to_owned(),
     }))
 }
@@ -3596,6 +3609,52 @@ mod tests {
             .unwrap()
             .expect("materialized from env");
         assert_eq!(loaded2.offsite.s3.bucket.as_deref(), Some("env-bucket"));
+    }
+
+    #[test]
+    fn shared_bucket_guard_only_applies_when_storage_backend_is_s3() {
+        // P2 #16: a leftover `[storage.s3]` bucket that equals the offsite bucket
+        // must NOT trip the shared-bucket guard unless the app storage backend is
+        // actually S3. On backend=local/disabled the bucket is inert.
+        let env = autumn_web::config::MockEnv::new();
+        let make = |backend: &str| -> LoadedOffsite {
+            let table: toml::Table = toml::from_str(&format!(
+                "[storage]\nbackend = \"{backend}\"\n\
+                 [storage.s3]\nbucket = \"shared\"\nendpoint = \"https://minio.example:9000\"\n\
+                 [backup.offsite]\nprefix = \"db\"\n\
+                 [backup.offsite.s3]\nbucket = \"shared\"\nregion = \"us-east-1\"\n\
+                 endpoint = \"https://minio.example:9000\"\nforce_path_style = true\n"
+            ))
+            .unwrap();
+            resolve_loaded_offsite(Some(&table), &env, "prod")
+                .expect("resolves")
+                .expect("offsite section present")
+        };
+
+        // backend=local: the s3 bucket is NOT the app storage destination, so the
+        // guard input is empty and destinations_conflict cannot fire.
+        let local = make("local");
+        assert_eq!(local.app_storage_bucket, None);
+        assert!(!destinations_conflict(
+            "shared",
+            Some("https://minio.example:9000"),
+            local.app_storage_bucket.as_deref(),
+            local.app_storage_endpoint.as_deref(),
+        ));
+
+        // backend=disabled: same — inert `[storage.s3]`.
+        assert_eq!(make("disabled").app_storage_bucket, None);
+
+        // backend=s3: the bucket IS the app destination, so the guard fires and
+        // the offsite backup must opt in with allow_shared_bucket.
+        let s3 = make("s3");
+        assert_eq!(s3.app_storage_bucket.as_deref(), Some("shared"));
+        assert!(destinations_conflict(
+            "shared",
+            Some("https://minio.example:9000"),
+            s3.app_storage_bucket.as_deref(),
+            s3.app_storage_endpoint.as_deref(),
+        ));
     }
 
     #[test]

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -380,11 +380,15 @@ fn backup(args: &BackupArgs) -> Result<(), BackupError> {
     // here is the split outcome (AC #2/#6): the local artifact stays intact and
     // the command exits non-zero with an unambiguous message.
     if let Some((offsite, client)) = upload_ctx {
-        let run_id = run_dir
+        let local_run_id = run_dir
             .file_name()
             .map(|n| n.to_string_lossy().into_owned())
             .unwrap_or_default();
-        upload_run(&offsite, &client, &run_dir, &profile, &run_id).map_err(|detail| {
+        // The REMOTE run id gains a globally-unique token (P2 #12) so concurrent
+        // same-second backups of this profile from different hosts never collide
+        // in the bucket; the local run directory keeps its #1595 `<timestamp>`.
+        let remote_id = remote_run_id(&local_run_id, &remote_run_token());
+        upload_run(&offsite, &client, &run_dir, &profile, &remote_id).map_err(|detail| {
             BackupError::OffsiteUploadFailed {
                 local_path: run_dir.display().to_string(),
                 detail,
@@ -1681,12 +1685,13 @@ impl ResolvedOffsite {
             op: "connect",
             detail: e.to_string(),
         })?;
-        // Test/ops escape hatch: shrink the multipart threshold and part size so
-        // the multipart path can be exercised (or tuned) without a multi-GB
-        // fixture. The value is a target part size in bytes; both threshold and
-        // part size are set to it (the client re-floors to S3's 5 MiB minimum).
+        // Ops escape hatch: tune ONLY the multipart part size (bytes). This does
+        // NOT lower the multipart threshold, so shrinking the part size can never
+        // push a normal (sub-threshold) file into a multipart upload — it only
+        // changes how an already-multipart transfer is chunked. The client
+        // re-floors the value to S3's 5 MiB minimum.
         Ok(match self.multipart_part_size_override() {
-            Some(bytes) => client.with_multipart_params(bytes, bytes),
+            Some(bytes) => client.with_part_size(bytes),
             None => client,
         })
     }
@@ -2014,6 +2019,46 @@ fn offsite_object_key(prefix: &str, profile: &str, run_id: &str, file: &str) -> 
     join_key(&[prefix, profile, run_id, file])
 }
 
+/// A short, globally-unique token appended to the REMOTE run id so that two
+/// hosts backing up the SAME profile in the SAME second to the SAME
+/// bucket/prefix never produce colliding S3 keys (issue #1619 P2 #12). Without
+/// it, `create_unique_run_dir` only disambiguates within one host's filesystem,
+/// so cross-host same-second runs would overwrite/interleave each other's dumps
+/// and manifests and corrupt `latest`.
+///
+/// Derived from host + pid + wall-clock nanoseconds, hashed with the
+/// already-linked `sha2`/`hex` crates (no new dependency). It is NON-sensitive —
+/// pure entropy, no secret material. The LOCAL run-dir naming (issue #1595
+/// `<profile>/<timestamp>/`) is deliberately left unchanged; only the remote key
+/// gains the `-<token>` suffix.
+fn remote_run_token() -> String {
+    use sha2::{Digest, Sha256};
+    let host = std::env::var("HOSTNAME")
+        .or_else(|_| std::env::var("COMPUTERNAME"))
+        .unwrap_or_default();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    let mut hasher = Sha256::new();
+    hasher.update(host.as_bytes());
+    hasher.update([0]); // domain separator between host and pid
+    hasher.update(std::process::id().to_le_bytes());
+    hasher.update(nanos.to_le_bytes());
+    // 8 hex chars (4 bytes): with the same-second timestamp already dominating
+    // the run id, a cross-host collision needs the same second AND a 32-bit token
+    // collision — negligible for the handful of hosts sharing one backup prefix.
+    hex::encode(&hasher.finalize()[..4])
+}
+
+/// Compose the globally-unique REMOTE run id from the LOCAL run id (a #1595
+/// `<timestamp>`) and a [`remote_run_token`]: `<timestamp>-<token>`. The
+/// timestamp still dominates the lexical sort, so `latest` (newest by timestamp)
+/// is unaffected and the token only tie-breaks same-second runs from different
+/// hosts — each a valid distinct backup, neither overwriting the other.
+fn remote_run_id(local_run_id: &str, token: &str) -> String {
+    format!("{local_run_id}-{token}")
+}
+
 /// The list prefix that enumerates every run for a profile (trailing slash so a
 /// `list-type=2` prefix match is scoped to this profile).
 fn offsite_profile_prefix(prefix: &str, profile: &str) -> String {
@@ -2268,7 +2313,9 @@ fn group_offsite_objects(objects: &[s3::S3Object], list_prefix: &str) -> Vec<Off
 fn format_offsite_listing(runs: &[OffsiteRun]) -> String {
     use std::fmt::Write as _;
     let mut out = String::new();
-    let _ = writeln!(out, "{:<20}  {:>10}  FILES", "TIMESTAMP", "SIZE");
+    // Column shows the FULL remote run id (`<timestamp>-<token>`, P2 #12) so an
+    // operator can copy it verbatim into `restore offsite:<profile>/<run id>`.
+    let _ = writeln!(out, "{:<28}  {:>10}  FILES", "RUN ID", "SIZE");
     for run in runs {
         let mut labels: Vec<&str> = run.files.iter().map(|(f, _)| f.as_str()).collect();
         labels.sort_unstable();
@@ -2278,7 +2325,7 @@ fn format_offsite_listing(runs: &[OffsiteRun]) -> String {
         }
         let _ = writeln!(
             out,
-            "{:<20}  {:>10}  {}",
+            "{:<28}  {:>10}  {}",
             run.run_id,
             human_size(run.total),
             files,
@@ -2372,7 +2419,7 @@ fn restore_from_offsite(args: &RestoreArgs, oref: &OffsiteRef) -> Result<(), Bac
     let client = offsite.build_client()?;
 
     let run_id = match &oref.selector {
-        OffsiteSelector::Exact(ts) => ts.clone(),
+        OffsiteSelector::Exact(sel) => resolve_exact_run(&offsite, &client, &oref.profile, sel)?,
         OffsiteSelector::Latest => resolve_latest_run(&offsite, &client, &oref.profile)?,
     };
     eprintln!(
@@ -2426,6 +2473,63 @@ fn restore_from_offsite(args: &RestoreArgs, oref: &OffsiteRef) -> Result<(), Bac
     let plan = RestorePlan::discover(temp.path(), args.shard.as_deref())?;
     apply_restore_plan(&plan, args)
     // `temp` is dropped here, removing the downloaded artifacts.
+}
+
+/// Resolve an explicit offsite selector to a single complete remote run id
+/// (P2 #12). The selector may be a full remote run id (`<ts>-<token>`) or a bare
+/// `<ts>` timestamp (operator convenience, and the pre-token spelling): a
+/// complete run matches when it equals the selector or begins with
+/// `"{selector}-"`. Errors (never silently guesses) when nothing matches or when
+/// several do — the latter happens when two hosts backed up the same second, and
+/// the message lists the full run ids so the operator can re-run with one.
+fn resolve_exact_run(
+    offsite: &ResolvedOffsite,
+    client: &S3Client,
+    profile: &str,
+    selector: &str,
+) -> Result<String, BackupError> {
+    let list_prefix = offsite_profile_prefix(&offsite.prefix, profile);
+    let objects = client
+        .list_objects_v2(&list_prefix)
+        .map_err(|e| BackupError::Offsite {
+            op: "list",
+            detail: e.to_string(),
+        })?;
+    let run_ids = complete_remote_run_ids(&objects, &list_prefix);
+    match match_exact_remote_run(&run_ids, selector) {
+        Ok(id) => Ok(id),
+        Err(candidates) if candidates.is_empty() => Err(BackupError::BadArtifact {
+            detail: format!(
+                "no complete offsite backup matching {selector:?} for profile {profile:?}"
+            ),
+        }),
+        Err(candidates) => Err(BackupError::BadArtifact {
+            detail: format!(
+                "offsite reference {selector:?} is ambiguous for profile {profile:?}: it matches \
+                 {} runs ({}).\n  Re-run restore with the full run id (see `autumn db offsite list`).",
+                candidates.len(),
+                candidates.join(", "),
+            ),
+        }),
+    }
+}
+
+/// Pure selector match (P2 #12): from COMPLETE remote run ids, return the single
+/// one referred to by `selector` (a full `<ts>-<token>` id, or a bare `<ts>` that
+/// prefixes exactly one tokened id). `Ok(id)` on a unique match; `Err(matches)`
+/// otherwise — an empty vec means none, a multi-element vec means ambiguous.
+fn match_exact_remote_run(run_ids: &[String], selector: &str) -> Result<String, Vec<String>> {
+    let token_prefix = format!("{selector}-");
+    let matches: Vec<String> = run_ids
+        .iter()
+        .filter(|id| id.as_str() == selector || id.starts_with(&token_prefix))
+        .cloned()
+        .collect();
+    if let [only] = matches.as_slice() {
+        Ok(only.clone())
+    } else {
+        Err(matches)
+    }
 }
 
 /// Resolve the newest run id for a profile from the offsite listing.
@@ -3563,6 +3667,91 @@ mod tests {
     }
 
     #[test]
+    fn remote_run_token_is_eight_lowercase_hex() {
+        // P2 #12: the token is 8 hex chars derived from host/pid/time entropy.
+        let token = remote_run_token();
+        assert_eq!(token.len(), 8, "token was {token:?}");
+        assert!(
+            token
+                .bytes()
+                .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase()),
+            "token must be lowercase hex: {token:?}"
+        );
+    }
+
+    #[test]
+    fn remote_run_id_appends_token_to_local_id() {
+        // P2 #12: remote id = <local timestamp>-<token>; the timestamp still leads
+        // so lexical sort (and thus `latest`) is unchanged.
+        let id = remote_run_id("20260710T040506Z", "deadbeef");
+        assert_eq!(id, "20260710T040506Z-deadbeef");
+        assert!(id.starts_with("20260710T040506Z"));
+    }
+
+    #[test]
+    fn match_exact_remote_run_resolves_by_full_id_and_timestamp() {
+        // P2 #12: complete remote run ids carry a token; a selector matches by
+        // full id OR by the bare timestamp when exactly one tokened id begins with it.
+        let ids: Vec<String> = ["20260709T010101Z-aaaa1111", "20260710T040506Z-bbbb2222"]
+            .iter()
+            .map(|s| (*s).to_owned())
+            .collect();
+        // Full id → itself.
+        assert_eq!(
+            match_exact_remote_run(&ids, "20260710T040506Z-bbbb2222").unwrap(),
+            "20260710T040506Z-bbbb2222"
+        );
+        // Bare timestamp uniquely prefixes one run → that run.
+        assert_eq!(
+            match_exact_remote_run(&ids, "20260710T040506Z").unwrap(),
+            "20260710T040506Z-bbbb2222"
+        );
+        // A timestamp with no matching run → Err(empty).
+        assert_eq!(
+            match_exact_remote_run(&ids, "20990101T000000Z").unwrap_err(),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn match_exact_remote_run_errors_on_ambiguous_same_second() {
+        // Two hosts backed up the SAME second → two tokened ids share the <ts>.
+        // A bare-timestamp selector is ambiguous and must list both candidates.
+        let ids: Vec<String> = ["20260710T040506Z-aaaa1111", "20260710T040506Z-bbbb2222"]
+            .iter()
+            .map(|s| (*s).to_owned())
+            .collect();
+        let err = match_exact_remote_run(&ids, "20260710T040506Z").unwrap_err();
+        assert_eq!(err.len(), 2);
+        assert!(err.contains(&"20260710T040506Z-aaaa1111".to_owned()));
+        assert!(err.contains(&"20260710T040506Z-bbbb2222".to_owned()));
+        // But the full id still resolves unambiguously.
+        assert_eq!(
+            match_exact_remote_run(&ids, "20260710T040506Z-aaaa1111").unwrap(),
+            "20260710T040506Z-aaaa1111"
+        );
+    }
+
+    #[test]
+    fn complete_remote_run_ids_sort_newest_last_with_tokens() {
+        // P2 #12: the <ts> dominates the lexical sort, so `latest` (newest) is the
+        // last element regardless of the token tiebreak.
+        let list_prefix = "db/prod/";
+        let objects = vec![
+            s3::S3Object {
+                key: "db/prod/20260710T040506Z-zzzz9999/manifest.json".to_owned(),
+                size: 1,
+            },
+            s3::S3Object {
+                key: "db/prod/20260711T040506Z-aaaa0000/manifest.json".to_owned(),
+                size: 1,
+            },
+        ];
+        let ids = complete_remote_run_ids(&objects, list_prefix);
+        assert_eq!(ids.last().unwrap(), "20260711T040506Z-aaaa0000");
+    }
+
+    #[test]
     fn plan_remote_pruning_keeps_newest_and_never_the_just_uploaded() {
         let runs: Vec<String> = ["r1", "r2", "r3", "r4", "r5"]
             .iter()
@@ -3690,7 +3879,7 @@ mod tests {
         assert_eq!(runs[1].total, 128 + 4096);
 
         let table = format_offsite_listing(&runs);
-        assert!(table.contains("TIMESTAMP"));
+        assert!(table.contains("RUN ID"));
         assert!(table.contains("20260710T040506Z"));
         assert!(table.contains("control.dump"));
         assert!(table.contains("manifest.json"));

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -323,14 +323,21 @@ fn backup(args: &BackupArgs) -> Result<(), BackupError> {
 
     let profile = migrate::effective_profile(args.profile.as_deref());
 
-    // Offsite pre-flight (issue #1619): resolve the destination and, when an
-    // upload is requested, build/validate the client (credentials present,
-    // destination distinct from app storage) BEFORE dumping — so a misconfigured
-    // offsite fails fast instead of after a full dump.
-    let offsite = load_offsite(&profile)?;
-    let should_upload = args.upload || offsite.as_ref().is_some_and(|o| o.auto_upload);
+    // Offsite pre-flight (issue #1619): read the offsite section LENIENTLY (no
+    // bucket/cred validation) just to learn `auto_upload`. Only when an upload is
+    // actually requested do we STRICTLY validate (bucket required, creds env
+    // resolved, distinct destination) and build the client — BEFORE dumping — so
+    // a misconfigured offsite fails fast, while a plain local backup with an
+    // incomplete `[backup.offsite]` section is never blocked.
+    let loaded_offsite = load_offsite(&profile)?;
+    let should_upload = args.upload
+        || loaded_offsite
+            .as_ref()
+            .is_some_and(LoadedOffsite::auto_upload);
     let upload_ctx = if should_upload {
-        let offsite = offsite.ok_or(BackupError::OffsiteNotConfigured)?;
+        let offsite = loaded_offsite
+            .ok_or(BackupError::OffsiteNotConfigured)?
+            .resolve()?;
         let client = offsite.build_client()?;
         Some((offsite, client))
     } else {
@@ -1615,7 +1622,6 @@ struct ResolvedOffsite {
     s3: S3Config,
     prefix: String,
     keep: Option<usize>,
-    auto_upload: bool,
     allow_shared_bucket: bool,
     access_key_id_env: Option<String>,
     secret_access_key_env: Option<String>,
@@ -1698,10 +1704,82 @@ impl autumn_web::config::Env for ProfileForcedEnv<'_> {
     }
 }
 
-/// Load and resolve the `[backup.offsite]` destination for `profile`, applying
-/// the profile overlay and `AUTUMN_*` env overrides via the runtime config
-/// loader. `Ok(None)` when no offsite section is configured.
-fn load_offsite(profile: &str) -> Result<Option<ResolvedOffsite>, BackupError> {
+/// A leniently-loaded `[backup.offsite]` section: enough to learn `auto_upload`
+/// WITHOUT validating the bucket/credentials, so a plain local `autumn db backup`
+/// (no `--upload`, no `auto_upload`) never fails just because an incomplete
+/// offsite section exists. Call [`LoadedOffsite::resolve`] — only when an upload
+/// is actually requested — to get the validated, ready-to-use destination.
+struct LoadedOffsite {
+    offsite: autumn_web::config::OffsiteBackupConfig,
+    app_storage_bucket: Option<String>,
+    app_storage_endpoint: Option<String>,
+}
+
+impl LoadedOffsite {
+    /// The configured-default upload flag, readable without validating anything.
+    const fn auto_upload(&self) -> bool {
+        self.offsite.auto_upload
+    }
+
+    /// Validate and resolve into a ready-to-use [`ResolvedOffsite`]. This is the
+    /// STRICT step — bucket is required here — and must only run when uploading.
+    fn resolve(self) -> Result<ResolvedOffsite, BackupError> {
+        let Self {
+            offsite,
+            app_storage_bucket,
+            app_storage_endpoint,
+        } = self;
+        let bucket = offsite
+            .s3
+            .bucket
+            .as_deref()
+            .map(str::trim)
+            .filter(|b| !b.is_empty())
+            .map(str::to_owned)
+            .ok_or_else(|| BackupError::OffsiteConfig {
+                detail: "backup.offsite.s3.bucket is required".to_owned(),
+            })?;
+        // Region is only meaningful for AWS + SigV4 scope; many S3-compatible
+        // endpoints ignore it. Default to us-east-1 when unset.
+        let region = offsite
+            .s3
+            .region
+            .as_deref()
+            .map(str::trim)
+            .filter(|r| !r.is_empty())
+            .unwrap_or("us-east-1")
+            .to_owned();
+        let s3 = S3Config {
+            bucket,
+            region,
+            endpoint: offsite
+                .s3
+                .endpoint
+                .as_deref()
+                .map(str::trim)
+                .filter(|e| !e.is_empty())
+                .map(str::to_owned),
+            force_path_style: offsite.s3.force_path_style,
+        };
+        Ok(ResolvedOffsite {
+            s3,
+            prefix: normalize_offsite_prefix(offsite.prefix.as_deref()),
+            keep: offsite.keep,
+            allow_shared_bucket: offsite.allow_shared_bucket,
+            access_key_id_env: offsite.s3.access_key_id_env,
+            secret_access_key_env: offsite.s3.secret_access_key_env,
+            app_storage_bucket,
+            app_storage_endpoint,
+        })
+    }
+}
+
+/// Leniently load the `[backup.offsite]` section for `profile`, applying the
+/// profile overlay and `AUTUMN_*` env overrides via the runtime config loader.
+/// `Ok(None)` when no offsite section is configured. Performs NO bucket/cred
+/// validation — that is deferred to [`LoadedOffsite::resolve`] so a local-only
+/// backup is never blocked by an incomplete offsite section.
+fn load_offsite(profile: &str) -> Result<Option<LoadedOffsite>, BackupError> {
     let base = dotenv_env();
     let forced = ProfileForcedEnv {
         inner: &base,
@@ -1716,48 +1794,8 @@ fn load_offsite(profile: &str) -> Result<Option<ResolvedOffsite>, BackupError> {
     let Some(offsite) = cfg.backup.offsite else {
         return Ok(None);
     };
-    // Unbox once so the field moves/reads below are identical to an owned value.
-    let offsite = *offsite;
-    let bucket = offsite
-        .s3
-        .bucket
-        .as_deref()
-        .map(str::trim)
-        .filter(|b| !b.is_empty())
-        .map(str::to_owned)
-        .ok_or_else(|| BackupError::OffsiteConfig {
-            detail: "backup.offsite.s3.bucket is required".to_owned(),
-        })?;
-    // Region is only meaningful for AWS + SigV4 scope; many S3-compatible
-    // endpoints ignore it. Default to us-east-1 when unset.
-    let region = offsite
-        .s3
-        .region
-        .as_deref()
-        .map(str::trim)
-        .filter(|r| !r.is_empty())
-        .unwrap_or("us-east-1")
-        .to_owned();
-    let s3 = S3Config {
-        bucket,
-        region,
-        endpoint: offsite
-            .s3
-            .endpoint
-            .as_deref()
-            .map(str::trim)
-            .filter(|e| !e.is_empty())
-            .map(str::to_owned),
-        force_path_style: offsite.s3.force_path_style,
-    };
-    Ok(Some(ResolvedOffsite {
-        s3,
-        prefix: normalize_offsite_prefix(offsite.prefix.as_deref()),
-        keep: offsite.keep,
-        auto_upload: offsite.auto_upload,
-        allow_shared_bucket: offsite.allow_shared_bucket,
-        access_key_id_env: offsite.s3.access_key_id_env.clone(),
-        secret_access_key_env: offsite.s3.secret_access_key_env,
+    Ok(Some(LoadedOffsite {
+        offsite: *offsite,
         app_storage_bucket: cfg
             .storage
             .s3
@@ -1885,6 +1923,11 @@ fn upload_run(
     eprintln!("\u{2500}\u{2500} offsite upload \u{2500}\u{2500}");
     let mut files = list_run_files(run_dir).map_err(|e| e.to_string())?;
     files.sort();
+    // Upload `manifest.json` LAST so the presence of a verified remote manifest
+    // implies the whole run uploaded (completeness marker for `latest`
+    // resolution). A stable sort keeps the artifact files in alphabetical order
+    // and moves the single manifest to the end.
+    files.sort_by_key(|f| f.as_str() == MANIFEST_FILE);
     if files.is_empty() {
         return Err("the completed run directory contains no files to upload".to_owned());
     }
@@ -1975,6 +2018,30 @@ fn remote_run_ids(objects: &[s3::S3Object], list_prefix: &str) -> Vec<String> {
     ids
 }
 
+/// The unique, sorted run ids under `list_prefix` that have a remote
+/// `manifest.json` — i.e. COMPLETE runs. Because [`upload_run`] uploads the
+/// manifest last, a `--upload` that died partway leaves artifacts but no
+/// manifest, so its run id is excluded here. This keeps a partial failed upload
+/// from shadowing the last good backup when resolving `latest`.
+fn complete_remote_run_ids(objects: &[s3::S3Object], list_prefix: &str) -> Vec<String> {
+    let mut ids: Vec<String> = objects
+        .iter()
+        .filter_map(|o| o.key.strip_prefix(list_prefix))
+        .filter_map(|rest| {
+            let mut parts = rest.splitn(2, '/');
+            match (parts.next(), parts.next()) {
+                (Some(run_id), Some(file)) if !run_id.is_empty() && file == MANIFEST_FILE => {
+                    Some(run_id.to_owned())
+                }
+                _ => None,
+            }
+        })
+        .collect();
+    ids.sort();
+    ids.dedup();
+    ids
+}
+
 /// Pure remote-retention rule: given run ids sorted ascending, keep the newest
 /// `keep` and return the older ones to delete — but ALWAYS exclude
 /// `keep_run_id` (the just-uploaded run) from deletion, even if retention math
@@ -2006,7 +2073,9 @@ pub fn run_offsite_list(profile: Option<&str>) {
 
 fn offsite_list(profile: Option<&str>) -> Result<(), BackupError> {
     let profile = migrate::effective_profile(profile);
-    let offsite = load_offsite(&profile)?.ok_or(BackupError::OffsiteNotConfigured)?;
+    let offsite = load_offsite(&profile)?
+        .ok_or(BackupError::OffsiteNotConfigured)?
+        .resolve()?;
     let client = offsite.build_client()?;
     let list_prefix = offsite_profile_prefix(&offsite.prefix, &profile);
     let objects = client
@@ -2030,10 +2099,14 @@ struct OffsiteRun {
     run_id: String,
     files: Vec<(String, u64)>,
     total: u64,
+    /// Whether the run has a remote `manifest.json` (a complete upload). A run
+    /// missing it is a partial/failed upload and is flagged in the listing.
+    complete: bool,
 }
 
 /// Group listed objects (`{list_prefix}{run_id}/{file}`) into runs, sorted by
-/// run id ascending. Pure for unit testing.
+/// run id ascending. A run is `complete` iff it has a `manifest.json` object.
+/// Pure for unit testing.
 fn group_offsite_objects(objects: &[s3::S3Object], list_prefix: &str) -> Vec<OffsiteRun> {
     let mut map: std::collections::BTreeMap<String, OffsiteRun> = std::collections::BTreeMap::new();
     for obj in objects {
@@ -2051,14 +2124,20 @@ fn group_offsite_objects(objects: &[s3::S3Object], list_prefix: &str) -> Vec<Off
             run_id: run_id.to_owned(),
             files: Vec::new(),
             total: 0,
+            complete: false,
         });
         run.files.push((file.to_owned(), obj.size));
         run.total += obj.size;
+        if file == MANIFEST_FILE {
+            run.complete = true;
+        }
     }
     map.into_values().collect()
 }
 
-/// Render a run listing as a human table: timestamp, files (labels), size. Pure.
+/// Render a run listing as a human table: timestamp, files (labels), size. An
+/// incomplete run (no remote manifest) is flagged so a partial failed upload is
+/// never mistaken for a restorable backup. Pure.
 fn format_offsite_listing(runs: &[OffsiteRun]) -> String {
     use std::fmt::Write as _;
     let mut out = String::new();
@@ -2066,12 +2145,16 @@ fn format_offsite_listing(runs: &[OffsiteRun]) -> String {
     for run in runs {
         let mut labels: Vec<&str> = run.files.iter().map(|(f, _)| f.as_str()).collect();
         labels.sort_unstable();
+        let mut files = labels.join(", ");
+        if !run.complete {
+            files.push_str("  (INCOMPLETE — no manifest, not restorable)");
+        }
         let _ = writeln!(
             out,
             "{:<20}  {:>10}  {}",
             run.run_id,
             human_size(run.total),
-            labels.join(", "),
+            files,
         );
     }
     out
@@ -2146,7 +2229,9 @@ fn parse_offsite_ref(s: &str) -> Option<OffsiteRef> {
 /// via the identical [`RestorePlan::discover`] path (AC #4). The temp dir is
 /// removed when the guard drops (after the restore completes or fails).
 fn restore_from_offsite(args: &RestoreArgs, oref: &OffsiteRef) -> Result<(), BackupError> {
-    let offsite = load_offsite(&oref.profile)?.ok_or(BackupError::OffsiteNotConfigured)?;
+    let offsite = load_offsite(&oref.profile)?
+        .ok_or(BackupError::OffsiteNotConfigured)?
+        .resolve()?;
     let client = offsite.build_client()?;
 
     let run_id = match &oref.selector {
@@ -2219,11 +2304,13 @@ fn resolve_latest_run(
             op: "list",
             detail: e.to_string(),
         })?;
-    remote_run_ids(&objects, &list_prefix)
+    // Only consider COMPLETE runs (those with a remote manifest.json), so a
+    // partial/failed upload never shadows the last good backup.
+    complete_remote_run_ids(&objects, &list_prefix)
         .into_iter()
-        .next_back() // sorted ascending; newest is last
+        .next_back() // sorted ascending; newest complete run is last
         .ok_or_else(|| BackupError::BadArtifact {
-            detail: format!("no offsite backups found for profile {profile:?}"),
+            detail: format!("no complete offsite backups found for profile {profile:?}"),
         })
 }
 
@@ -3092,6 +3179,101 @@ mod tests {
             remote_run_ids(&objects, list_prefix),
             vec!["20260709T010101Z".to_owned(), "20260710T010101Z".to_owned()]
         );
+    }
+
+    #[test]
+    fn local_backup_does_not_validate_incomplete_offsite() {
+        // P2 #1: an incomplete [backup.offsite] (no bucket) with auto_upload off
+        // must NOT block a plain local `autumn db backup`. Reading auto_upload
+        // never validates; the strict bucket check lives in resolve(), which the
+        // backup path only calls when an upload is actually requested.
+        let offsite = autumn_web::config::OffsiteBackupConfig::default();
+        assert!(offsite.s3.bucket.is_none(), "precondition: no bucket set");
+        let loaded = LoadedOffsite {
+            offsite,
+            app_storage_bucket: None,
+            app_storage_endpoint: None,
+        };
+        // The decision a local backup makes (args.upload = false): no upload.
+        assert!(!loaded.auto_upload());
+        // And the strict validation is deferred to resolve() (only reached when
+        // uploading) — proving a local-only backup never hits it.
+        assert!(matches!(
+            loaded.resolve(),
+            Err(BackupError::OffsiteConfig { .. })
+        ));
+    }
+
+    #[test]
+    fn complete_remote_run_ids_only_counts_runs_with_a_manifest() {
+        // P2 #2: a newer PARTIAL run (artifacts but no manifest.json) and an
+        // older COMPLETE run. `latest` must pick the older complete run.
+        let list_prefix = "db/prod/";
+        let objects = vec![
+            // Older, complete run.
+            s3::S3Object {
+                key: "db/prod/20260709T010101Z/control.dump".to_owned(),
+                size: 10,
+            },
+            s3::S3Object {
+                key: "db/prod/20260709T010101Z/manifest.json".to_owned(),
+                size: 1,
+            },
+            // Newer, partial run — died before uploading the (last) manifest.
+            s3::S3Object {
+                key: "db/prod/20260710T010101Z/control.dump".to_owned(),
+                size: 10,
+            },
+        ];
+        // The raw run ids include the partial newer run...
+        assert_eq!(
+            remote_run_ids(&objects, list_prefix),
+            vec!["20260709T010101Z".to_owned(), "20260710T010101Z".to_owned()]
+        );
+        // ...but only the complete (older) run is a candidate.
+        let complete = complete_remote_run_ids(&objects, list_prefix);
+        assert_eq!(complete, vec!["20260709T010101Z".to_owned()]);
+        // `latest` = newest COMPLETE run = the older run, not the partial newer one.
+        assert_eq!(
+            complete.into_iter().next_back().as_deref(),
+            Some("20260709T010101Z")
+        );
+    }
+
+    #[test]
+    fn upload_orders_manifest_last() {
+        // P2 #2(a): the manifest must upload last so its remote presence marks a
+        // complete run. Mirror upload_run's ordering.
+        let mut files = vec![
+            "manifest.json".to_owned(),
+            "shard-east.dump".to_owned(),
+            "control.dump".to_owned(),
+        ];
+        files.sort();
+        files.sort_by_key(|f| f.as_str() == MANIFEST_FILE);
+        assert_eq!(
+            files,
+            vec![
+                "control.dump".to_owned(),
+                "shard-east.dump".to_owned(),
+                "manifest.json".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn offsite_listing_flags_incomplete_runs() {
+        // P2 #2: an incomplete run (no manifest) is flagged in `db offsite list`.
+        let list_prefix = "db/prod/";
+        let objects = vec![s3::S3Object {
+            key: "db/prod/20260710T010101Z/control.dump".to_owned(),
+            size: 10,
+        }];
+        let runs = group_offsite_objects(&objects, list_prefix);
+        assert_eq!(runs.len(), 1);
+        assert!(!runs[0].complete);
+        let table = format_offsite_listing(&runs);
+        assert!(table.contains("INCOMPLETE"), "table was: {table}");
     }
 
     #[test]

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -1888,10 +1888,11 @@ fn upload_run(
     }
     for file in &files {
         let path = run_dir.join(file);
-        let bytes = std::fs::read(&path).map_err(|e| format!("reading {file}: {e}"))?;
         let key = offsite_object_key(&offsite.prefix, profile, run_id, file);
+        // Stream the file straight from disk (hash pre-pass + streamed body):
+        // a multi-GB dump is never read into memory.
         client
-            .put_and_verify(&key, &bytes)
+            .put_file_and_verify(&key, &path)
             .map_err(|e| format!("{file}: {e}"))?;
         eprintln!("  \u{2713} uploaded + verified {file}");
     }
@@ -2182,14 +2183,17 @@ fn restore_from_offsite(args: &RestoreArgs, oref: &OffsiteRef) -> Result<(), Bac
                 op: "download",
                 detail: format!("unexpected object key layout: {}", obj.key),
             })?;
-        let bytes = client
-            .get_object(&obj.key)
+        // Stream the object straight to disk (constant memory), so a multi-GB
+        // dump is never buffered while downloading for restore.
+        let dest = temp.path().join(file);
+        let mut out = std::fs::File::create(&dest)
+            .map_err(BackupError::io(format!("creating downloaded {file}")))?;
+        client
+            .download_object(&obj.key, &mut out)
             .map_err(|e| BackupError::Offsite {
                 op: "download",
                 detail: format!("{file}: {e}"),
             })?;
-        std::fs::write(temp.path().join(file), &bytes)
-            .map_err(BackupError::io(format!("writing downloaded {file}")))?;
         eprintln!("  \u{2913} downloaded {file}");
     }
 

--- a/autumn-cli/src/db/s3.rs
+++ b/autumn-cli/src/db/s3.rs
@@ -53,6 +53,11 @@ const TRANSFER_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 /// TCP-level inactivity guard (`TCP_USER_TIMEOUT`) for the transfer client:
 /// drop a stalled connection whose data stays unacknowledged this long, WITHOUT
 /// capping a healthy long-running multi-GB stream.
+///
+/// Linux-only: `TCP_USER_TIMEOUT` (and reqwest's `tcp_user_timeout` builder
+/// method) exist only on Linux. On macOS/Windows the transfer client relies on
+/// `connect_timeout` + the disabled overall timeout instead.
+#[cfg(target_os = "linux")]
 const TRANSFER_STALL_TIMEOUT: Duration = Duration::from_secs(300);
 
 // ─── Credentials (never Debug/Display) ───────────────────────────────────────
@@ -416,26 +421,28 @@ impl S3Client {
         if let Some(endpoint) = &config.endpoint {
             validate_endpoint(endpoint)?;
         }
-        let http = reqwest::blocking::Client::builder()
+        let builder = reqwest::blocking::Client::builder()
             // reqwest's blocking default is a 30s TOTAL request timeout, which
             // would abort a correctly-streaming multi-GB PUT/GET on a slow
             // offsite link before it finishes. Disable the overall cap so long
             // transfers aren't bounded by wall-clock…
             .timeout(None)
-            // …but still fail fast on a dead/unreachable host…
-            .connect_timeout(TRANSFER_CONNECT_TIMEOUT)
-            // …and catch a stalled connection at the TCP layer WITHOUT capping
-            // total duration: TCP_USER_TIMEOUT drops the connection when sent
-            // data stays unacknowledged this long. reqwest 0.13's blocking
-            // builder has no per-read `read_timeout`, so this is the closest
-            // inactivity guard. Non-configurable sane constants (a configurable
-            // transfer timeout is a possible follow-up).
-            .tcp_user_timeout(TRANSFER_STALL_TIMEOUT)
-            .build()
-            .map_err(|e| S3Error::Transport {
-                op: "init",
-                detail: e.to_string(),
-            })?;
+            // …but still fail fast on a dead/unreachable host.
+            .connect_timeout(TRANSFER_CONNECT_TIMEOUT);
+        // Catch a stalled connection at the TCP layer WITHOUT capping total
+        // duration: TCP_USER_TIMEOUT drops the connection when sent data stays
+        // unacknowledged this long. reqwest 0.13's blocking builder has no
+        // per-read `read_timeout`, so this is the closest inactivity guard — but
+        // the option (and reqwest's `tcp_user_timeout` method) are Linux-only, so
+        // it's gated to Linux; other platforms rely on connect_timeout + the
+        // disabled overall timeout. Non-configurable sane constants (a
+        // configurable transfer timeout is a possible follow-up).
+        #[cfg(target_os = "linux")]
+        let builder = builder.tcp_user_timeout(TRANSFER_STALL_TIMEOUT);
+        let http = builder.build().map_err(|e| S3Error::Transport {
+            op: "init",
+            detail: e.to_string(),
+        })?;
         Ok(Self {
             config,
             credentials,
@@ -1130,6 +1137,8 @@ mod tests {
         };
         assert!(S3Client::new(config, creds).is_ok());
         // Sanity-check the guard constants stay sane (fast connect, long stall).
+        // The stall guard is Linux-only (TCP_USER_TIMEOUT).
+        #[cfg(target_os = "linux")]
         assert!(TRANSFER_CONNECT_TIMEOUT < TRANSFER_STALL_TIMEOUT);
     }
 

--- a/autumn-cli/src/db/s3.rs
+++ b/autumn-cli/src/db/s3.rs
@@ -609,8 +609,7 @@ impl S3Client {
     /// when the endpoint does not echo a checksum, GET and rehash. Returns `Ok`
     /// only once the remote is proven to match the local bytes.
     pub fn put_and_verify(&self, key: &str, bytes: &[u8]) -> Result<(), S3Error> {
-        let digest = sha256_raw(bytes);
-        let checksum_b64 = base64_standard(&digest);
+        let checksum_b64 = sha256_base64(bytes);
         self.put_object(key, bytes, &checksum_b64)?;
         self.verify_uploaded(key, bytes.len() as u64, &checksum_b64)
     }
@@ -630,7 +629,7 @@ impl S3Client {
         }
         // Checksum absent on HEAD: prove equality by downloading and rehashing.
         let body = self.get_object(key)?;
-        let actual_b64 = base64_standard(&sha256_raw(&body));
+        let actual_b64 = sha256_base64(&body);
         if actual_b64 == expected_b64 {
             Ok(())
         } else {

--- a/autumn-cli/src/db/s3.rs
+++ b/autumn-cli/src/db/s3.rs
@@ -47,6 +47,17 @@ const EMPTY_PAYLOAD_SHA256: &str =
 /// maximum) this covers a million objects — far beyond any backup prefix — while
 /// bounding a broken endpoint that never stops returning a continuation token.
 const MAX_LIST_PAGES: usize = 1000;
+/// Artifacts larger than this upload via multipart. A single `PutObject` is
+/// capped at 5 GiB by S3, so a large production dump must be sent in parts.
+const MULTIPART_THRESHOLD: u64 = 64 * 1024 * 1024; // 64 MiB
+/// Default target part size for multipart uploads. With 64 MiB parts and S3's
+/// 10 000-part limit the largest object is ≈ 640 GiB; larger files transparently
+/// grow the part size (see [`effective_part_size`]).
+const MULTIPART_PART_SIZE: u64 = 64 * 1024 * 1024; // 64 MiB
+/// S3's minimum part size (every part except the last).
+const S3_MIN_PART_SIZE: u64 = 5 * 1024 * 1024; // 5 MiB
+/// S3's maximum number of parts in one multipart upload.
+const S3_MAX_PARTS: u64 = 10_000;
 /// Connect-phase timeout for the transfer client: fail fast on a dead host
 /// without bounding the total transfer duration.
 const TRANSFER_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -367,6 +378,89 @@ fn parse_error_code(xml: &str) -> Option<String> {
     xml_first(xml, "Code")
 }
 
+// ─── Multipart helpers (pure, unit-tested) ────────────────────────────────────
+
+/// Build a `SigV4` canonical query string from `(key, value)` pairs: each key and
+/// value AWS-URI-encoded (slash encoded), pairs sorted by encoded key. A
+/// value-less flag (e.g. `uploads`) encodes as `key=`.
+fn canonical_query(params: &[(&str, &str)]) -> String {
+    let mut encoded: Vec<(String, String)> = params
+        .iter()
+        .map(|(k, v)| (aws_uri_encode(k, true), aws_uri_encode(v, true)))
+        .collect();
+    encoded.sort_by(|a, b| a.0.cmp(&b.0));
+    encoded
+        .iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+/// Number of parts a `len`-byte object splits into at `part_size` bytes/part.
+const fn multipart_part_count(len: u64, part_size: u64) -> u64 {
+    if part_size == 0 {
+        return 0;
+    }
+    len.div_ceil(part_size)
+}
+
+/// Resolve the part size actually used for a `len`-byte file from the `configured`
+/// target. Floors at S3's 5 MiB minimum, and grows the part size when `len` at the
+/// configured size would exceed S3's 10 000-part limit so the plan always fits.
+fn effective_part_size(len: u64, configured: u64) -> u64 {
+    // Smallest part size that keeps the part count within S3_MAX_PARTS.
+    let min_for_parts = len.div_ceil(S3_MAX_PARTS).max(1);
+    configured.max(min_for_parts).max(S3_MIN_PART_SIZE)
+}
+
+/// Build the `CompleteMultipartUpload` request body from `(part_number, etag)`
+/// pairs (already in ascending part order).
+fn build_complete_multipart_xml(parts: &[(u32, String)]) -> String {
+    let mut xml = String::from("<CompleteMultipartUpload>");
+    for (number, etag) in parts {
+        let _ = write!(
+            xml,
+            "<Part><PartNumber>{number}</PartNumber><ETag>{}</ETag></Part>",
+            xml_escape(etag)
+        );
+    }
+    xml.push_str("</CompleteMultipartUpload>");
+    xml
+}
+
+/// Classify a `CompleteMultipartUpload` response body. S3 returns HTTP 200 even
+/// when assembly fails, embedding an `<Error>` in the body — so success requires
+/// a `CompleteMultipartUploadResult` element. Returns `Err(code)` (the S3
+/// `<Code>`, or a placeholder) on a 200-with-error body.
+fn classify_complete_response(body: &str) -> Result<(), String> {
+    if body.contains("<CompleteMultipartUploadResult") {
+        return Ok(());
+    }
+    Err(parse_error_code(body).unwrap_or_else(|| "UnrecognizedCompleteResponse".to_owned()))
+}
+
+/// Minimal XML entity escaping for text placed inside an element (`ETag` values).
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+/// Read up to `buf.len()` bytes, looping over short reads so a full part is
+/// assembled even when the underlying reader returns data in small pieces.
+/// Returns the number of bytes read (0 only at EOF).
+fn read_up_to(reader: &mut impl std::io::Read, buf: &mut [u8]) -> std::io::Result<usize> {
+    let mut filled = 0;
+    while filled < buf.len() {
+        let n = reader.read(&mut buf[filled..])?;
+        if n == 0 {
+            break;
+        }
+        filled += n;
+    }
+    Ok(filled)
+}
+
 // ─── The client ──────────────────────────────────────────────────────────────
 
 /// A synchronous S3-compatible client. Cheap to clone-construct; holds a
@@ -375,6 +469,13 @@ pub struct S3Client {
     config: S3Config,
     credentials: S3Credentials,
     http: reqwest::blocking::Client,
+    /// Files larger than this upload via multipart (default
+    /// [`MULTIPART_THRESHOLD`]); overridable for tests via
+    /// [`with_multipart_params`](Self::with_multipart_params).
+    multipart_threshold: u64,
+    /// Target part size for multipart uploads (default [`MULTIPART_PART_SIZE`]);
+    /// the effective size is floored/grown per file by [`effective_part_size`].
+    multipart_part_size: u64,
     /// Clock indirection so signing/tests are deterministic. Returns the `SigV4`
     /// `x-amz-date` (`YYYYMMDDTHHMMSSZ`).
     now: fn() -> chrono::DateTime<chrono::Utc>,
@@ -389,6 +490,9 @@ enum RequestBody<'a> {
     Empty,
     /// Stream this file as the body; `sha256_hex` is its precomputed payload hash.
     File { path: &'a Path, sha256_hex: &'a str },
+    /// An in-memory body (a multipart part chunk, or a small XML request body
+    /// like `CompleteMultipartUpload`). The payload hash is computed inline.
+    Bytes(&'a [u8]),
 }
 
 /// Reject a custom `endpoint` that carries a path prefix. `canonical_path` signs
@@ -447,8 +551,22 @@ impl S3Client {
             config,
             credentials,
             http,
+            multipart_threshold: MULTIPART_THRESHOLD,
+            multipart_part_size: MULTIPART_PART_SIZE,
             now: chrono::Utc::now,
         })
+    }
+
+    /// Override the multipart threshold and target part size (both in bytes).
+    /// Used by tests / the `AUTUMN_OFFSITE_MULTIPART_PART_SIZE_BYTES` escape hatch
+    /// to exercise the multipart path on small files without a multi-GB fixture.
+    /// The part size is still floored to S3's 5 MiB minimum and grown as needed
+    /// by [`effective_part_size`] at upload time.
+    #[must_use]
+    pub const fn with_multipart_params(mut self, threshold: u64, part_size: u64) -> Self {
+        self.multipart_threshold = threshold;
+        self.multipart_part_size = part_size;
+        self
     }
 
     /// The endpoint host[:port] used for the `Host` header and `SigV4` signing.
@@ -535,6 +653,7 @@ impl S3Client {
         let payload_hash = match body {
             RequestBody::Empty => EMPTY_PAYLOAD_SHA256.to_owned(),
             RequestBody::File { sha256_hex, .. } => (*sha256_hex).to_owned(),
+            RequestBody::Bytes(bytes) => sha256_hex(bytes),
         };
         let host = self.host()?;
 
@@ -581,15 +700,21 @@ impl S3Client {
         for (name, value) in extra_headers {
             req = req.header(name.as_str(), value.as_str());
         }
-        if let RequestBody::File { path, .. } = body {
-            // Stream the file straight from disk. reqwest's blocking `Body`
-            // derives Content-Length from the file's metadata, so the object is
-            // sent with constant memory regardless of size.
-            let file = std::fs::File::open(*path).map_err(|e| S3Error::Transport {
-                op,
-                detail: format!("opening {} for upload: {e}", path.display()),
-            })?;
-            req = req.body(file);
+        match body {
+            RequestBody::Empty => {}
+            RequestBody::File { path, .. } => {
+                // Stream the file straight from disk. reqwest's blocking `Body`
+                // derives Content-Length from the file's metadata, so the object
+                // is sent with constant memory regardless of size.
+                let file = std::fs::File::open(*path).map_err(|e| S3Error::Transport {
+                    op,
+                    detail: format!("opening {} for upload: {e}", path.display()),
+                })?;
+                req = req.body(file);
+            }
+            RequestBody::Bytes(bytes) => {
+                req = req.body(bytes.to_vec());
+            }
         }
 
         let resp = req.send().map_err(|e| S3Error::Transport {
@@ -770,14 +895,218 @@ impl S3Client {
     /// regardless of file size. Returns `Ok` only once the remote is proven to
     /// match the local file.
     pub fn put_file_and_verify(&self, key: &str, path: &Path) -> Result<(), S3Error> {
-        let (digest, len) = sha256_file(path).map_err(|e| S3Error::Transport {
+        let len = std::fs::metadata(path)
+            .map_err(|e| S3Error::Transport {
+                op: "put",
+                detail: format!("stat {} for upload: {e}", path.display()),
+            })?
+            .len();
+        if len > self.multipart_threshold {
+            return self.put_file_multipart(key, path, len);
+        }
+        let (digest, hashed_len) = sha256_file(path).map_err(|e| S3Error::Transport {
             op: "put",
             detail: format!("hashing {} for upload: {e}", path.display()),
         })?;
         let checksum_b64 = base64_standard(&digest);
         let content_hex = hex::encode(digest);
         self.put_file(key, path, &checksum_b64, &content_hex)?;
-        self.verify_uploaded(key, len, &checksum_b64)
+        self.verify_uploaded(key, hashed_len, &checksum_b64)
+    }
+
+    /// Upload `path` to `key` as an S3 multipart upload: `CreateMultipartUpload`,
+    /// then one `UploadPart` per [`effective_part_size`] chunk (streamed a part at
+    /// a time — memory stays bounded to one part), then `CompleteMultipartUpload`.
+    /// On ANY failure before completion the in-progress upload is aborted
+    /// (`AbortMultipartUpload`) so no orphaned parts accrue storage cost.
+    ///
+    /// Integrity: a multipart object's `ETag` is a hash-of-part-hashes, NOT the
+    /// object's sha256, so verification can't compare `ETag`s. Instead the whole
+    /// file is hashed in the same streaming pass that uploads it, then the remote
+    /// object is verified via HEAD `Content-Length` + (checksum or GET-and-rehash)
+    /// exactly like the single-PUT path — never size alone.
+    fn put_file_multipart(&self, key: &str, path: &Path, len: u64) -> Result<(), S3Error> {
+        let part_size = effective_part_size(len, self.multipart_part_size);
+        // Defensive: effective_part_size grows the part size to keep the plan
+        // within S3's 10 000-part cap, so this should never trip — but fail loud
+        // before starting an upload that can't complete rather than mid-stream.
+        let part_count = multipart_part_count(len, part_size);
+        if part_count > S3_MAX_PARTS {
+            return Err(S3Error::BadResponse {
+                op: "create-multipart",
+                detail: format!(
+                    "artifact needs {part_count} parts at {part_size} bytes/part, \
+                     over S3's {S3_MAX_PARTS}-part limit"
+                ),
+            });
+        }
+        let upload_id = self.create_multipart_upload(key)?;
+        match self.upload_parts_and_complete(key, path, len, part_size, &upload_id) {
+            Ok(whole_b64) => {
+                // Completion succeeded: the object now exists. Do NOT abort.
+                // Verify the assembled object matches the streamed-hash of the
+                // local file (HEAD length + checksum, else GET-and-rehash).
+                self.verify_uploaded(key, len, &whole_b64)
+            }
+            Err(err) => {
+                // Best-effort abort; surface the ORIGINAL upload error regardless
+                // of whether the abort itself succeeds.
+                let _ = self.abort_multipart_upload(key, &upload_id);
+                Err(err)
+            }
+        }
+    }
+
+    /// Stream `path` in `part_size` chunks, uploading each as a numbered part and
+    /// feeding every byte into a whole-file SHA-256. Returns the base64 sha256 of
+    /// the entire file once `CompleteMultipartUpload` succeeds. One part is held
+    /// in memory at a time.
+    fn upload_parts_and_complete(
+        &self,
+        key: &str,
+        path: &Path,
+        len: u64,
+        part_size: u64,
+        upload_id: &str,
+    ) -> Result<String, S3Error> {
+        let mut file = std::fs::File::open(path).map_err(|e| S3Error::Transport {
+            op: "upload-part",
+            detail: format!("opening {} for upload: {e}", path.display()),
+        })?;
+        let cap = usize::try_from(part_size).unwrap_or(usize::MAX);
+        let mut buf = vec![0u8; cap];
+        let mut whole = Sha256Writer::new();
+        let mut parts: Vec<(u32, String)> = Vec::new();
+        let mut part_number: u32 = 1;
+        let mut uploaded: u64 = 0;
+        loop {
+            let n = read_up_to(&mut file, &mut buf).map_err(|e| S3Error::Transport {
+                op: "upload-part",
+                detail: format!("reading {} for upload: {e}", path.display()),
+            })?;
+            if n == 0 {
+                break;
+            }
+            let chunk = &buf[..n];
+            {
+                use std::io::Write as _;
+                whole
+                    .write_all(chunk)
+                    .expect("Sha256Writer::write is infallible");
+            }
+            let etag = self.upload_part(key, upload_id, part_number, chunk)?;
+            parts.push((part_number, etag));
+            uploaded += u64::try_from(n).unwrap_or(0);
+            part_number = part_number
+                .checked_add(1)
+                .ok_or_else(|| S3Error::BadResponse {
+                    op: "upload-part",
+                    detail: "part count overflow".to_owned(),
+                })?;
+        }
+        if uploaded != len {
+            return Err(S3Error::Transport {
+                op: "upload-part",
+                detail: format!("read {uploaded} bytes but file length is {len}"),
+            });
+        }
+        self.complete_multipart_upload(key, upload_id, &parts)?;
+        Ok(base64_standard(&whole.finalize()))
+    }
+
+    /// `CreateMultipartUpload` (`POST /{key}?uploads=`). Returns the `UploadId`.
+    fn create_multipart_upload(&self, key: &str) -> Result<String, S3Error> {
+        let query = canonical_query(&[("uploads", "")]);
+        let resp = self.send(
+            "create-multipart",
+            reqwest::Method::POST,
+            key,
+            &query,
+            &[],
+            &RequestBody::Empty,
+        )?;
+        let body = resp.text().map_err(|e| S3Error::Transport {
+            op: "create-multipart",
+            detail: e.to_string(),
+        })?;
+        xml_first(&body, "UploadId").ok_or_else(|| S3Error::BadResponse {
+            op: "create-multipart",
+            detail: "CreateMultipartUpload response had no <UploadId>".to_owned(),
+        })
+    }
+
+    /// `UploadPart` (`PUT /{key}?partNumber=n&uploadId=...`). Sends the chunk as
+    /// an in-memory body; returns the part's `ETag` (needed to complete).
+    fn upload_part(
+        &self,
+        key: &str,
+        upload_id: &str,
+        part_number: u32,
+        chunk: &[u8],
+    ) -> Result<String, S3Error> {
+        let pn = part_number.to_string();
+        let query = canonical_query(&[("partNumber", &pn), ("uploadId", upload_id)]);
+        let resp = self.send(
+            "upload-part",
+            reqwest::Method::PUT,
+            key,
+            &query,
+            &[],
+            &RequestBody::Bytes(chunk),
+        )?;
+        resp.headers()
+            .get(reqwest::header::ETAG)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned)
+            .ok_or_else(|| S3Error::BadResponse {
+                op: "upload-part",
+                detail: format!("UploadPart {part_number} response had no ETag"),
+            })
+    }
+
+    /// `CompleteMultipartUpload` (`POST /{key}?uploadId=...`). S3 can return HTTP
+    /// 200 with an *error* body (the connection stays open while parts assemble),
+    /// so success is confirmed by inspecting the body, not just the status.
+    fn complete_multipart_upload(
+        &self,
+        key: &str,
+        upload_id: &str,
+        parts: &[(u32, String)],
+    ) -> Result<(), S3Error> {
+        let query = canonical_query(&[("uploadId", upload_id)]);
+        let xml = build_complete_multipart_xml(parts);
+        let resp = self.send(
+            "complete-multipart",
+            reqwest::Method::POST,
+            key,
+            &query,
+            &[],
+            &RequestBody::Bytes(xml.as_bytes()),
+        )?;
+        let body = resp.text().map_err(|e| S3Error::Transport {
+            op: "complete-multipart",
+            detail: e.to_string(),
+        })?;
+        classify_complete_response(&body).map_err(|code| S3Error::Status {
+            op: "complete-multipart",
+            status: 200,
+            code: Some(code),
+        })
+    }
+
+    /// `AbortMultipartUpload` (`DELETE /{key}?uploadId=...`). Best-effort cleanup
+    /// of a failed upload's parts.
+    fn abort_multipart_upload(&self, key: &str, upload_id: &str) -> Result<(), S3Error> {
+        let query = canonical_query(&[("uploadId", upload_id)]);
+        self.send(
+            "abort-multipart",
+            reqwest::Method::DELETE,
+            key,
+            &query,
+            &[],
+            &RequestBody::Empty,
+        )?;
+        Ok(())
     }
 
     /// HEAD-verify (and streaming GET-rehash fallback) an already-uploaded object
@@ -1222,5 +1551,172 @@ mod tests {
             .unwrap();
         server.join().unwrap();
         assert_eq!(sink, body);
+    }
+
+    #[test]
+    fn multipart_part_count_divides_ceiling() {
+        assert_eq!(multipart_part_count(0, 5), 0);
+        assert_eq!(multipart_part_count(5, 5), 1);
+        assert_eq!(multipart_part_count(6, 5), 2);
+        // ~12 MiB at a 5 MiB part size → 3 parts (the Docker round-trip's shape).
+        let twelve_mib = 12 * 1024 * 1024;
+        let five_mib = 5 * 1024 * 1024;
+        assert_eq!(multipart_part_count(twelve_mib, five_mib), 3);
+    }
+
+    #[test]
+    fn effective_part_size_floors_at_s3_minimum() {
+        // A tiny configured part size is floored to S3's 5 MiB minimum.
+        assert_eq!(
+            effective_part_size(100 * 1024 * 1024, 1024),
+            S3_MIN_PART_SIZE
+        );
+    }
+
+    #[test]
+    fn effective_part_size_keeps_a_valid_configured_size() {
+        let part = 8 * 1024 * 1024;
+        assert_eq!(effective_part_size(64 * 1024 * 1024, part), part);
+    }
+
+    #[test]
+    fn effective_part_size_grows_to_fit_part_cap() {
+        // A file so large that the configured part size would exceed 10 000 parts
+        // must transparently grow the part size to stay within the cap.
+        let configured = S3_MIN_PART_SIZE;
+        // 10 001 parts' worth of bytes at the minimum size.
+        let len = (S3_MAX_PARTS + 1) * S3_MIN_PART_SIZE;
+        let eff = effective_part_size(len, configured);
+        assert!(
+            eff > configured,
+            "part size should grow past the configured floor"
+        );
+        assert!(
+            multipart_part_count(len, eff) <= S3_MAX_PARTS,
+            "grown part size must keep the plan within S3's 10 000-part cap"
+        );
+    }
+
+    #[test]
+    fn build_complete_multipart_xml_lists_parts_in_order() {
+        let parts = vec![
+            (1u32, "\"etag-one\"".to_owned()),
+            (2u32, "\"etag-two\"".to_owned()),
+        ];
+        let xml = build_complete_multipart_xml(&parts);
+        assert_eq!(
+            xml,
+            "<CompleteMultipartUpload>\
+             <Part><PartNumber>1</PartNumber><ETag>\"etag-one\"</ETag></Part>\
+             <Part><PartNumber>2</PartNumber><ETag>\"etag-two\"</ETag></Part>\
+             </CompleteMultipartUpload>"
+        );
+    }
+
+    #[test]
+    fn build_complete_multipart_xml_escapes_etag() {
+        let parts = vec![(1u32, "a&b<c".to_owned())];
+        let xml = build_complete_multipart_xml(&parts);
+        assert!(xml.contains("<ETag>a&amp;b&lt;c</ETag>"));
+    }
+
+    #[test]
+    fn canonical_query_encodes_and_sorts() {
+        // Flag-only param encodes as `key=`; pairs sort by encoded key.
+        assert_eq!(canonical_query(&[("uploads", "")]), "uploads=");
+        assert_eq!(
+            canonical_query(&[("partNumber", "2"), ("uploadId", "abc/def")]),
+            "partNumber=2&uploadId=abc%2Fdef"
+        );
+    }
+
+    #[test]
+    fn classify_complete_response_accepts_result_body() {
+        let ok = r#"<?xml version="1.0"?><CompleteMultipartUploadResult>\
+            <Location>http://x</Location><ETag>"abc-3"</ETag>\
+            </CompleteMultipartUploadResult>"#;
+        assert!(classify_complete_response(ok).is_ok());
+    }
+
+    #[test]
+    fn classify_complete_response_detects_200_with_error_body() {
+        // S3 returns 200 then an <Error> body when assembly fails; we must treat
+        // that as a failure and surface the <Code>.
+        let err = "<Error><Code>InternalError</Code><Message>oops</Message></Error>";
+        assert_eq!(
+            classify_complete_response(err).unwrap_err(),
+            "InternalError"
+        );
+    }
+
+    #[test]
+    fn classify_complete_response_rejects_unrecognized_body() {
+        assert_eq!(
+            classify_complete_response("garbage").unwrap_err(),
+            "UnrecognizedCompleteResponse"
+        );
+    }
+
+    #[test]
+    fn parse_upload_id_from_create_response() {
+        let body = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <InitiateMultipartUploadResult>
+          <Bucket>b</Bucket>
+          <Key>db/prod/x.dump</Key>
+          <UploadId>VXBsb2FkSUQtMTIz</UploadId>
+        </InitiateMultipartUploadResult>"#;
+        assert_eq!(
+            xml_first(body, "UploadId").as_deref(),
+            Some("VXBsb2FkSUQtMTIz")
+        );
+    }
+
+    #[test]
+    fn read_up_to_fills_across_short_reads() {
+        // A reader that hands back one byte at a time must still fill the buffer.
+        struct DribbleReader<'a> {
+            data: &'a [u8],
+            pos: usize,
+        }
+        impl std::io::Read for DribbleReader<'_> {
+            fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+                if self.pos >= self.data.len() || buf.is_empty() {
+                    return Ok(0);
+                }
+                buf[0] = self.data[self.pos];
+                self.pos += 1;
+                Ok(1)
+            }
+        }
+        let mut r = DribbleReader {
+            data: b"abcdef",
+            pos: 0,
+        };
+        let mut buf = [0u8; 4];
+        assert_eq!(read_up_to(&mut r, &mut buf).unwrap(), 4);
+        assert_eq!(&buf, b"abcd");
+        let mut rest = [0u8; 4];
+        assert_eq!(read_up_to(&mut r, &mut rest).unwrap(), 2);
+        assert_eq!(&rest[..2], b"ef");
+    }
+
+    #[test]
+    fn with_multipart_params_overrides_defaults() {
+        let client = S3Client::new(
+            S3Config {
+                bucket: "b".to_owned(),
+                region: "us-east-1".to_owned(),
+                endpoint: Some("https://minio.example:9000".to_owned()),
+                force_path_style: true,
+            },
+            S3Credentials {
+                access_key_id: "k".to_owned(),
+                secret_access_key: "s".to_owned(),
+            },
+        )
+        .unwrap()
+        .with_multipart_params(5 * 1024 * 1024, 5 * 1024 * 1024);
+        assert_eq!(client.multipart_threshold, 5 * 1024 * 1024);
+        assert_eq!(client.multipart_part_size, 5 * 1024 * 1024);
     }
 }

--- a/autumn-cli/src/db/s3.rs
+++ b/autumn-cli/src/db/s3.rs
@@ -4,14 +4,14 @@
 //! `base64`, and `hex`, so this module implements just enough of **AWS Signature
 //! Version 4** and the five S3 REST operations the offsite-backup flow needs —
 //! WITHOUT pulling `aws-sdk`/`tokio` into the CLI. It targets any S3-compatible
-//! endpoint (AWS, MinIO, Cloudflare R2, Backblaze B2, Garage) via a custom
+//! endpoint (AWS, `MinIO`, Cloudflare R2, Backblaze B2, Garage) via a custom
 //! `endpoint` + `force_path_style`.
 //!
 //! # Credential safety
 //!
 //! The access key / secret access key are read (by the caller) from the
 //! environment variables *named* by config and handed in as [`S3Credentials`].
-//! They are used only to derive the SigV4 signing key and the `Authorization`
+//! They are used only to derive the `SigV4` signing key and the `Authorization`
 //! header. They never appear in a URL, in `Debug`/`Display` output, in an error
 //! message, or in a log line — [`S3Credentials`] deliberately does not derive
 //! `Debug`, and [`S3Error`] carries only status codes and endpoint metadata.
@@ -22,10 +22,11 @@
 //! endpoint validates the payload server-side and rejects a corrupted upload.
 //! [`S3Client::verify_uploaded`] then HEADs the object and confirms the
 //! remote length (and checksum, when the endpoint echoes it) matches the local
-//! file; when the checksum header is absent (older MinIO), it falls back to a
+//! file; when the checksum header is absent (older `MinIO`), it falls back to a
 //! GET-and-rehash so verification is never a no-op.
 
 use std::fmt;
+use std::fmt::Write as _;
 
 use hmac::{Hmac, Mac};
 use sha2::{Digest, Sha256};
@@ -64,18 +65,18 @@ impl fmt::Debug for S3Credentials {
 // ─── Client configuration ────────────────────────────────────────────────────
 
 /// Connection settings for [`S3Client`]. Mirrors the reusable
-/// `StorageS3Config` shape (bucket/region/endpoint/force_path_style) but holds
+/// `StorageS3Config` shape (`bucket`/`region`/`endpoint`/`force_path_style`) but holds
 /// only what transfer needs, so this module stays decoupled from `autumn-web`.
 #[derive(Debug, Clone)]
 pub struct S3Config {
     /// Target bucket.
     pub bucket: String,
-    /// Region (SigV4 credential scope). R2 uses `auto`.
+    /// Region (`SigV4` credential scope). R2 uses `auto`.
     pub region: String,
     /// Custom endpoint (e.g. `https://minio.example:9000`). `None` => AWS
     /// (`https://{bucket}.s3.{region}.amazonaws.com`).
     pub endpoint: Option<String>,
-    /// Path-style addressing (`{endpoint}/{bucket}/{key}`). Required by MinIO /
+    /// Path-style addressing (`{endpoint}/{bucket}/{key}`). Required by `MinIO` /
     /// R2 / most self-hosted endpoints.
     pub force_path_style: bool,
 }
@@ -178,8 +179,7 @@ fn aws_uri_encode(s: &str, encode_slash: bool) -> String {
             }
             b'/' if !encode_slash => out.push('/'),
             _ => {
-                out.push('%');
-                out.push_str(&format!("{b:02X}"));
+                let _ = write!(out, "%{b:02X}");
             }
         }
     }
@@ -198,7 +198,7 @@ fn signed_headers_list(headers: &[Header]) -> String {
         .join(";")
 }
 
-/// Build the SigV4 canonical request string. `headers` MUST be sorted by
+/// Build the `SigV4` canonical request string. `headers` MUST be sorted by
 /// lowercase name; each value is trimmed. Pure over its inputs.
 fn canonical_request(
     method: &str,
@@ -209,20 +209,22 @@ fn canonical_request(
 ) -> String {
     let canonical_headers: String = headers
         .iter()
-        .map(|(name, value)| format!("{name}:{}\n", value.trim()))
-        .collect();
+        .fold(String::new(), |mut acc, (name, value)| {
+            let _ = writeln!(acc, "{name}:{}", value.trim());
+            acc
+        });
     let signed = signed_headers_list(headers);
     format!(
         "{method}\n{canonical_uri}\n{canonical_query}\n{canonical_headers}\n{signed}\n{payload_hash}"
     )
 }
 
-/// Build the SigV4 string-to-sign from the canonical-request hash.
+/// Build the `SigV4` string-to-sign from the canonical-request hash.
 fn string_to_sign(amz_date: &str, scope: &str, canonical_request_hash: &str) -> String {
     format!("{ALGORITHM}\n{amz_date}\n{scope}\n{canonical_request_hash}")
 }
 
-/// Derive the SigV4 signing key: a 4-stage HMAC chain over the secret.
+/// Derive the `SigV4` signing key: a 4-stage HMAC chain over the secret.
 fn signing_key(secret: &str, date: &str, region: &str) -> [u8; 32] {
     let k_date = hmac_sha256(format!("AWS4{secret}").as_bytes(), date.as_bytes());
     let k_region = hmac_sha256(&k_date, region.as_bytes());
@@ -288,7 +290,7 @@ fn xml_first(xml: &str, tag: &str) -> Option<String> {
 
 /// Parse a `ListBucketResult` body into `(objects, next_continuation_token)`.
 /// Hand-rolled to avoid adding an XML dependency to the CLI; handles the subset
-/// S3/MinIO/R2/B2/Garage emit for `list-type=2`.
+/// S3/`MinIO`/R2/B2/Garage emit for `list-type=2`.
 fn parse_list_objects(xml: &str) -> Result<(Vec<S3Object>, Option<String>), S3Error> {
     let mut objects = Vec::new();
     let mut rest = xml;
@@ -299,10 +301,13 @@ fn parse_list_objects(xml: &str) -> Result<(Vec<S3Object>, Option<String>), S3Er
         };
         let block = &after[..close];
         if let (Some(key), Some(size_str)) = (xml_first(block, "Key"), xml_first(block, "Size")) {
-            let size = size_str.trim().parse::<u64>().map_err(|_| S3Error::BadResponse {
-                op: "list",
-                detail: format!("non-numeric <Size> {size_str:?}"),
-            })?;
+            let size = size_str
+                .trim()
+                .parse::<u64>()
+                .map_err(|_| S3Error::BadResponse {
+                    op: "list",
+                    detail: format!("non-numeric <Size> {size_str:?}"),
+                })?;
             objects.push(S3Object {
                 key: xml_unescape(&key),
                 size,
@@ -310,9 +315,8 @@ fn parse_list_objects(xml: &str) -> Result<(Vec<S3Object>, Option<String>), S3Er
         }
         rest = &after[close + "</Contents>".len()..];
     }
-    let truncated = xml_first(xml, "IsTruncated")
-        .map(|v| v.trim().eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
+    let truncated =
+        xml_first(xml, "IsTruncated").is_some_and(|v| v.trim().eq_ignore_ascii_case("true"));
     let token = if truncated {
         xml_first(xml, "NextContinuationToken").map(|t| xml_unescape(t.trim()))
     } else {
@@ -344,7 +348,7 @@ pub struct S3Client {
     config: S3Config,
     credentials: S3Credentials,
     http: reqwest::blocking::Client,
-    /// Clock indirection so signing/tests are deterministic. Returns the SigV4
+    /// Clock indirection so signing/tests are deterministic. Returns the `SigV4`
     /// `x-amz-date` (`YYYYMMDDTHHMMSSZ`).
     now: fn() -> chrono::DateTime<chrono::Utc>,
 }
@@ -352,12 +356,13 @@ pub struct S3Client {
 impl S3Client {
     /// Build a client. Fails only if the TLS/HTTP stack can't be constructed.
     pub fn new(config: S3Config, credentials: S3Credentials) -> Result<Self, S3Error> {
-        let http = reqwest::blocking::Client::builder()
-            .build()
-            .map_err(|e| S3Error::Transport {
-                op: "init",
-                detail: e.to_string(),
-            })?;
+        let http =
+            reqwest::blocking::Client::builder()
+                .build()
+                .map_err(|e| S3Error::Transport {
+                    op: "init",
+                    detail: e.to_string(),
+                })?;
         Ok(Self {
             config,
             credentials,
@@ -366,7 +371,7 @@ impl S3Client {
         })
     }
 
-    /// The endpoint host[:port] used for the `Host` header and SigV4 signing.
+    /// The endpoint host[:port] used for the `Host` header and `SigV4` signing.
     fn host(&self) -> Result<String, S3Error> {
         let base = self.endpoint_base();
         let url = url::Url::parse(&base).map_err(|e| S3Error::Transport {
@@ -377,15 +382,15 @@ impl S3Client {
             op: "init",
             detail: "endpoint has no host".to_owned(),
         })?;
-        Ok(match url.port() {
-            Some(port) => format!("{host}:{port}"),
-            None => host.to_owned(),
-        })
+        Ok(url
+            .port()
+            .map_or_else(|| host.to_owned(), |port| format!("{host}:{port}")))
     }
 
     /// Scheme + authority for the endpoint (no path). For AWS this synthesizes
     /// the virtual-hosted bucket endpoint; for a custom endpoint it is used
     /// verbatim (path-style) or with the bucket as a host prefix.
+    #[allow(clippy::option_if_let_else)] // nested map_or_else closures read worse
     fn endpoint_base(&self) -> String {
         match &self.config.endpoint {
             Some(ep) => {
@@ -410,7 +415,7 @@ impl S3Client {
         }
     }
 
-    /// The canonical request path for `key` (SigV4 signs this exact string).
+    /// The canonical request path for `key` (`SigV4` signs this exact string).
     fn canonical_path(&self, key: &str) -> String {
         let key = key.trim_start_matches('/');
         if self.config.endpoint.is_some() && self.config.force_path_style {
@@ -432,7 +437,7 @@ impl S3Client {
     }
 
     /// Sign and send one request. `body` is the full payload (bodyless ops pass
-    /// `&[]`). `extra_headers` are additional signed headers (e.g. the PutObject
+    /// `&[]`). `extra_headers` are additional signed headers (e.g. the `PutObject`
     /// checksum). Returns the raw blocking response on 2xx, else an
     /// [`S3Error::Status`].
     fn send(
@@ -456,7 +461,7 @@ impl S3Client {
 
         // Assemble the signed header set, then sort by lowercase name.
         let mut headers: Vec<Header> = vec![
-            ("host".to_owned(), host.clone()),
+            ("host".to_owned(), host),
             ("x-amz-content-sha256".to_owned(), payload_hash.clone()),
             ("x-amz-date".to_owned(), amz_date.clone()),
         ];
@@ -532,15 +537,15 @@ impl S3Client {
     /// HEAD `key`, returning its length and (when echoed) checksum.
     pub fn head_object(&self, key: &str) -> Result<RemoteObjectInfo, S3Error> {
         let resp = self.send("head", reqwest::Method::HEAD, key, "", &[], &[])?;
-        let content_length =
-            resp.headers()
-                .get(reqwest::header::CONTENT_LENGTH)
-                .and_then(|v| v.to_str().ok())
-                .and_then(|v| v.parse::<u64>().ok())
-                .ok_or_else(|| S3Error::BadResponse {
-                    op: "head",
-                    detail: "missing or invalid Content-Length".to_owned(),
-                })?;
+        let content_length = resp
+            .headers()
+            .get(reqwest::header::CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u64>().ok())
+            .ok_or_else(|| S3Error::BadResponse {
+                op: "head",
+                detail: "missing or invalid Content-Length".to_owned(),
+            })?;
         let checksum_sha256 = resp
             .headers()
             .get("x-amz-checksum-sha256")
@@ -658,7 +663,7 @@ pub fn sha256_base64(data: &[u8]) -> String {
 mod tests {
     use super::*;
 
-    /// The canonical AWS SigV4 "GET Object" example vector from the AWS docs
+    /// The canonical AWS `SigV4` "GET Object" example vector from the AWS docs
     /// (`Signature Calculations for the Authorization Header`). Proves the
     /// canonical request, string-to-sign, and final signature are correct.
     #[test]
@@ -694,8 +699,7 @@ mod tests {
         let scope = format!("{date}/{region}/{SERVICE}/{AWS4_REQUEST}");
         assert_eq!(scope, "20130524/us-east-1/s3/aws4_request");
 
-        let signature =
-            compute_signature(secret, date, region, amz_date, &scope, &canonical);
+        let signature = compute_signature(secret, date, region, amz_date, &scope, &canonical);
         // Expected signature for this exact canonical request, cross-checked
         // against an independent reference implementation of SigV4.
         assert_eq!(
@@ -714,7 +718,11 @@ mod tests {
 
     #[test]
     fn string_to_sign_shape() {
-        let sts = string_to_sign("20130524T000000Z", "20130524/us-east-1/s3/aws4_request", "abc");
+        let sts = string_to_sign(
+            "20130524T000000Z",
+            "20130524/us-east-1/s3/aws4_request",
+            "abc",
+        );
         assert_eq!(
             sts,
             "AWS4-HMAC-SHA256\n20130524T000000Z\n20130524/us-east-1/s3/aws4_request\nabc"
@@ -740,7 +748,7 @@ mod tests {
             content_length: 5,
             checksum_sha256: Some(expected.clone()),
         };
-        assert_eq!(verify_head(5, &expected, &info).unwrap(), true);
+        assert!(verify_head(5, &expected, &info).unwrap());
     }
 
     #[test]
@@ -778,7 +786,7 @@ mod tests {
             checksum_sha256: None,
         };
         // Length matches but no checksum => caller must GET-and-rehash.
-        assert_eq!(verify_head(5, &expected, &info).unwrap(), false);
+        assert!(!verify_head(5, &expected, &info).unwrap());
     }
 
     #[test]
@@ -806,11 +814,11 @@ mod tests {
 
     #[test]
     fn parse_list_objects_follows_truncation_token() {
-        let xml = r#"<ListBucketResult>
+        let xml = r"<ListBucketResult>
           <Contents><Key>a</Key><Size>1</Size></Contents>
           <IsTruncated>true</IsTruncated>
           <NextContinuationToken>tok123</NextContinuationToken>
-        </ListBucketResult>"#;
+        </ListBucketResult>";
         let (objects, next) = parse_list_objects(xml).unwrap();
         assert_eq!(objects.len(), 1);
         assert_eq!(next.as_deref(), Some("tok123"));

--- a/autumn-cli/src/db/s3.rs
+++ b/autumn-cli/src/db/s3.rs
@@ -602,9 +602,12 @@ impl S3Client {
             .map_or_else(|| host.to_owned(), |port| format!("{host}:{port}")))
     }
 
-    /// Scheme + authority for the endpoint (no path). For AWS this synthesizes
-    /// the virtual-hosted bucket endpoint; for a custom endpoint it is used
-    /// verbatim (path-style) or with the bucket as a host prefix.
+    /// Scheme + authority for the endpoint (no path). The bucket lands in the
+    /// HOST for virtual-hosted addressing and in the PATH (via
+    /// [`canonical_path`](Self::canonical_path)) for path-style. `force_path_style`
+    /// is honored for BOTH a custom endpoint and AWS-default: AWS path-style uses
+    /// the regional host `s3.<region>.amazonaws.com` (required for dotted bucket
+    /// names, which can't present a valid virtual-hosted TLS certificate).
     #[allow(clippy::option_if_let_else)] // nested map_or_else closures read worse
     fn endpoint_base(&self) -> String {
         match &self.config.endpoint {
@@ -623,6 +626,11 @@ impl S3Client {
                     }
                 }
             }
+            // AWS path-style: regional host, bucket goes in the path.
+            None if self.config.force_path_style => {
+                format!("https://s3.{}.amazonaws.com", self.config.region)
+            }
+            // AWS virtual-hosted (default): bucket is a host prefix.
             None => format!(
                 "https://{}.s3.{}.amazonaws.com",
                 self.config.bucket, self.config.region
@@ -631,9 +639,12 @@ impl S3Client {
     }
 
     /// The canonical request path for `key` (`SigV4` signs this exact string).
+    /// Path-style (`force_path_style`) puts the bucket in the path — for BOTH a
+    /// custom endpoint and AWS-default — so it stays consistent with the
+    /// bucketless host [`endpoint_base`](Self::endpoint_base) builds in that mode.
     fn canonical_path(&self, key: &str) -> String {
         let key = key.trim_start_matches('/');
-        if self.config.endpoint.is_some() && self.config.force_path_style {
+        if self.config.force_path_style {
             format!("/{}/{}", self.config.bucket, aws_uri_encode(key, false))
         } else {
             format!("/{}", aws_uri_encode(key, false))
@@ -1778,5 +1789,75 @@ mod tests {
         assert_eq!(client.multipart_part_size, 5 * 1024 * 1024);
         // Threshold stays at the default — unchanged by a part-size override.
         assert_eq!(client.multipart_threshold, MULTIPART_THRESHOLD);
+    }
+
+    /// Build a client for addressing-mode tests (no network).
+    fn client_for(bucket: &str, endpoint: Option<&str>, force_path_style: bool) -> S3Client {
+        S3Client::new(
+            S3Config {
+                bucket: bucket.to_owned(),
+                region: "us-west-2".to_owned(),
+                endpoint: endpoint.map(str::to_owned),
+                force_path_style,
+            },
+            S3Credentials {
+                access_key_id: "k".to_owned(),
+                secret_access_key: "s".to_owned(),
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn aws_virtual_hosted_addressing_is_the_default() {
+        // AWS + force_path_style=false → bucket in the HOST, key-only path.
+        let c = client_for("mybucket", None, false);
+        assert_eq!(
+            c.endpoint_base(),
+            "https://mybucket.s3.us-west-2.amazonaws.com"
+        );
+        assert_eq!(c.host().unwrap(), "mybucket.s3.us-west-2.amazonaws.com");
+        assert_eq!(c.canonical_path("db/x.dump"), "/db/x.dump");
+    }
+
+    #[test]
+    fn aws_force_path_style_uses_regional_host_and_bucket_in_path() {
+        // P2 #14: AWS + force_path_style=true must NOT be virtual-hosted — the
+        // regional host is bucketless and the bucket goes in the path.
+        let c = client_for("mybucket", None, true);
+        assert_eq!(c.endpoint_base(), "https://s3.us-west-2.amazonaws.com");
+        assert_eq!(c.host().unwrap(), "s3.us-west-2.amazonaws.com");
+        assert_eq!(c.canonical_path("db/x.dump"), "/mybucket/db/x.dump");
+        // The signed canonical URI must be the tail of the actually-sent URL
+        // (SigV4 consistency): request_url == endpoint_base + canonical_path.
+        assert_eq!(
+            c.request_url("db/x.dump", ""),
+            "https://s3.us-west-2.amazonaws.com/mybucket/db/x.dump"
+        );
+    }
+
+    #[test]
+    fn aws_dotted_bucket_with_force_path_style_is_path_style() {
+        // A dotted bucket can't use virtual-hosted TLS; path-style keeps it off
+        // the host entirely.
+        let c = client_for("my.dotted.bucket", None, true);
+        assert_eq!(c.host().unwrap(), "s3.us-west-2.amazonaws.com");
+        assert!(!c.host().unwrap().contains("my.dotted.bucket"));
+        assert_eq!(
+            c.canonical_path("control.dump"),
+            "/my.dotted.bucket/control.dump"
+        );
+    }
+
+    #[test]
+    fn custom_endpoint_addressing_is_unchanged_by_the_aws_fix() {
+        // Custom endpoint + path-style: bucket in path, host verbatim.
+        let path = client_for("b", Some("https://minio.example:9000"), true);
+        assert_eq!(path.host().unwrap(), "minio.example:9000");
+        assert_eq!(path.canonical_path("k"), "/b/k");
+        // Custom endpoint + virtual-hosted: bucket prefixes the custom host.
+        let virt = client_for("b", Some("https://minio.example:9000"), false);
+        assert_eq!(virt.host().unwrap(), "b.minio.example:9000");
+        assert_eq!(virt.canonical_path("k"), "/k");
     }
 }

--- a/autumn-cli/src/db/s3.rs
+++ b/autumn-cli/src/db/s3.rs
@@ -40,6 +40,10 @@ const AWS4_REQUEST: &str = "aws4_request";
 /// HEAD / DELETE).
 const EMPTY_PAYLOAD_SHA256: &str =
     "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+/// Upper bound on `list_objects_v2` pagination. At 1000 objects/page (the S3
+/// maximum) this covers a million objects — far beyond any backup prefix — while
+/// bounding a broken endpoint that never stops returning a continuation token.
+const MAX_LIST_PAGES: usize = 1000;
 
 // ─── Credentials (never Debug/Display) ───────────────────────────────────────
 
@@ -188,6 +192,12 @@ fn aws_uri_encode(s: &str, encode_slash: bool) -> String {
 
 /// A header name/value pair for signing.
 type Header = (String, String);
+
+/// The extra signed header a HEAD carries so the endpoint echoes the object's
+/// checksum on the response (AWS requires opting in with `checksum-mode`).
+fn head_extra_headers() -> Vec<Header> {
+    vec![("x-amz-checksum-mode".to_owned(), "ENABLED".to_owned())]
+}
 
 /// The `SignedHeaders` list: sorted lowercase header names joined by `;`.
 fn signed_headers_list(headers: &[Header]) -> String {
@@ -353,9 +363,36 @@ pub struct S3Client {
     now: fn() -> chrono::DateTime<chrono::Utc>,
 }
 
+/// Reject a custom `endpoint` that carries a path prefix. `canonical_path` signs
+/// `/{bucket}/{key}` (path-style) or `/{key}` (virtual-hosted) — it does NOT
+/// know about an endpoint path segment (e.g. `https://gw.example/s3`), so the
+/// signed path and the actually-sent path would diverge and every request would
+/// 403. Fail loud at construction with clear guidance instead of at first use.
+fn validate_endpoint(endpoint: &str) -> Result<(), S3Error> {
+    let url = url::Url::parse(endpoint).map_err(|e| S3Error::Transport {
+        op: "init",
+        detail: format!("invalid endpoint {endpoint:?}: {e}"),
+    })?;
+    let path = url.path();
+    if !path.is_empty() && path != "/" {
+        return Err(S3Error::Transport {
+            op: "init",
+            detail: format!(
+                "endpoint {endpoint:?} must be scheme + host[:port] only (no path); \
+                 a path prefix like {path:?} is not supported"
+            ),
+        });
+    }
+    Ok(())
+}
+
 impl S3Client {
-    /// Build a client. Fails only if the TLS/HTTP stack can't be constructed.
+    /// Build a client. Fails if the TLS/HTTP stack can't be constructed or if a
+    /// custom `endpoint` carries a path prefix (see [`validate_endpoint`]).
     pub fn new(config: S3Config, credentials: S3Credentials) -> Result<Self, S3Error> {
+        if let Some(endpoint) = &config.endpoint {
+            validate_endpoint(endpoint)?;
+        }
         let http =
             reqwest::blocking::Client::builder()
                 .build()
@@ -535,8 +572,20 @@ impl S3Client {
     }
 
     /// HEAD `key`, returning its length and (when echoed) checksum.
+    ///
+    /// Sends a signed `x-amz-checksum-mode: ENABLED` so AWS (and compliant
+    /// endpoints) echo `x-amz-checksum-sha256` on the HEAD response, letting
+    /// [`verify_uploaded`](Self::verify_uploaded) take the cheap HEAD-only path
+    /// instead of downloading and rehashing the whole (possibly multi-GB) object.
     pub fn head_object(&self, key: &str) -> Result<RemoteObjectInfo, S3Error> {
-        let resp = self.send("head", reqwest::Method::HEAD, key, "", &[], &[])?;
+        let resp = self.send(
+            "head",
+            reqwest::Method::HEAD,
+            key,
+            "",
+            &head_extra_headers(),
+            &[],
+        )?;
         let content_length = resp
             .headers()
             .get(reqwest::header::CONTENT_LENGTH)
@@ -575,10 +624,14 @@ impl S3Client {
     }
 
     /// List every object under `prefix` (following continuation tokens).
+    ///
+    /// Bounded by [`MAX_LIST_PAGES`]: a broken endpoint that returns a repeating
+    /// continuation token can't loop forever — past the cap this errors rather
+    /// than hanging.
     pub fn list_objects_v2(&self, prefix: &str) -> Result<Vec<S3Object>, S3Error> {
         let mut out = Vec::new();
         let mut continuation: Option<String> = None;
-        loop {
+        for _page in 0..MAX_LIST_PAGES {
             // Canonical query string: keys sorted, both key and value encoded.
             let mut params: Vec<(String, String)> = vec![
                 ("list-type".to_owned(), "2".to_owned()),
@@ -603,10 +656,16 @@ impl S3Client {
             out.extend(objects);
             match next {
                 Some(token) => continuation = Some(token),
-                None => break,
+                None => return Ok(out),
             }
         }
-        Ok(out)
+        Err(S3Error::BadResponse {
+            op: "list",
+            detail: format!(
+                "exceeded {MAX_LIST_PAGES} list pages (endpoint returned an unending \
+                 continuation token?)"
+            ),
+        })
     }
 
     /// Upload `bytes` to `key` and verify the remote object matches (AC #2):
@@ -849,5 +908,63 @@ mod tests {
             sha256_base64(b""),
             "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
         );
+    }
+
+    #[test]
+    fn head_request_signs_checksum_mode_header() {
+        // HEAD must ask the endpoint to echo the checksum so verification can
+        // take the cheap HEAD-only path (no full GET+rehash).
+        let extra = head_extra_headers();
+        assert_eq!(
+            extra,
+            vec![("x-amz-checksum-mode".to_owned(), "ENABLED".to_owned())]
+        );
+        // The header must land in the SIGNED set: assemble the base HEAD headers
+        // exactly as `send` does, sort, and confirm it's part of SignedHeaders in
+        // its correct sorted position.
+        let mut headers: Vec<Header> = vec![
+            ("host".to_owned(), "s3.example.test".to_owned()),
+            (
+                "x-amz-content-sha256".to_owned(),
+                EMPTY_PAYLOAD_SHA256.to_owned(),
+            ),
+            ("x-amz-date".to_owned(), "20260710T000000Z".to_owned()),
+        ];
+        headers.extend(extra);
+        headers.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(
+            signed_headers_list(&headers),
+            "host;x-amz-checksum-mode;x-amz-content-sha256;x-amz-date"
+        );
+    }
+
+    #[test]
+    fn validate_endpoint_accepts_scheme_authority_only() {
+        assert!(validate_endpoint("https://minio.example:9000").is_ok());
+        assert!(validate_endpoint("https://s3.example.test/").is_ok());
+        assert!(validate_endpoint("http://127.0.0.1:9000").is_ok());
+    }
+
+    #[test]
+    fn validate_endpoint_rejects_a_path_prefix() {
+        // A gateway path prefix would be signed differently than it's sent → 403.
+        let err = validate_endpoint("https://gw.example/s3").unwrap_err();
+        assert!(matches!(err, S3Error::Transport { .. }));
+        assert!(err.to_string().contains("no path"));
+    }
+
+    #[test]
+    fn new_rejects_endpoint_with_path() {
+        let config = S3Config {
+            bucket: "b".to_owned(),
+            region: "us-east-1".to_owned(),
+            endpoint: Some("https://gw.example/s3".to_owned()),
+            force_path_style: true,
+        };
+        let creds = S3Credentials {
+            access_key_id: "k".to_owned(),
+            secret_access_key: "s".to_owned(),
+        };
+        assert!(S3Client::new(config, creds).is_err());
     }
 }

--- a/autumn-cli/src/db/s3.rs
+++ b/autumn-cli/src/db/s3.rs
@@ -18,15 +18,17 @@
 //!
 //! # Integrity (AC #2)
 //!
-//! [`S3Client::put_object`] sends `x-amz-checksum-sha256` so a compliant
-//! endpoint validates the payload server-side and rejects a corrupted upload.
-//! [`S3Client::verify_uploaded`] then HEADs the object and confirms the
-//! remote length (and checksum, when the endpoint echoes it) matches the local
-//! file; when the checksum header is absent (older `MinIO`), it falls back to a
-//! GET-and-rehash so verification is never a no-op.
+//! [`S3Client::put_file_and_verify`] streams the artifact as the PUT body and
+//! sends `x-amz-checksum-sha256` so a compliant endpoint validates the payload
+//! server-side and rejects a corrupted upload. It then HEADs the object and
+//! confirms the remote length (and checksum, when the endpoint echoes it)
+//! matches the local file; when the checksum header is absent (older `MinIO`),
+//! it falls back to a **streaming** GET-and-rehash so verification is never a
+//! no-op and never buffers a multi-GB object in memory.
 
 use std::fmt;
 use std::fmt::Write as _;
+use std::path::Path;
 
 use hmac::{Hmac, Mac};
 use sha2::{Digest, Sha256};
@@ -157,7 +159,9 @@ fn sha256_hex(data: &[u8]) -> String {
     hex::encode(hasher.finalize())
 }
 
-/// Raw SHA-256 digest of `data`.
+/// Raw SHA-256 digest of `data`. (Test helper; the streaming upload/verify paths
+/// hash incrementally via [`sha256_file`] / [`Sha256Writer`].)
+#[cfg(test)]
 fn sha256_raw(data: &[u8]) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(data);
@@ -363,6 +367,17 @@ pub struct S3Client {
     now: fn() -> chrono::DateTime<chrono::Utc>,
 }
 
+/// The body of a request. Bodyless ops use [`RequestBody::Empty`]; the artifact
+/// upload uses [`RequestBody::File`], which streams the file straight from disk
+/// as the request body (bounded memory) with a payload hash the caller computed
+/// in a single streaming pass — a multi-GB dump is never read into a `Vec`.
+enum RequestBody<'a> {
+    /// No body (GET/HEAD/DELETE).
+    Empty,
+    /// Stream this file as the body; `sha256_hex` is its precomputed payload hash.
+    File { path: &'a Path, sha256_hex: &'a str },
+}
+
 /// Reject a custom `endpoint` that carries a path prefix. `canonical_path` signs
 /// `/{bucket}/{key}` (path-style) or `/{key}` (virtual-hosted) — it does NOT
 /// know about an endpoint path segment (e.g. `https://gw.example/s3`), so the
@@ -473,10 +488,10 @@ impl S3Client {
         }
     }
 
-    /// Sign and send one request. `body` is the full payload (bodyless ops pass
-    /// `&[]`). `extra_headers` are additional signed headers (e.g. the `PutObject`
-    /// checksum). Returns the raw blocking response on 2xx, else an
-    /// [`S3Error::Status`].
+    /// Sign and send one request. `extra_headers` are additional signed headers
+    /// (e.g. the `PutObject` checksum). A [`RequestBody::File`] streams from disk
+    /// so a large upload never buffers in memory. Returns the raw blocking
+    /// response on 2xx, else an [`S3Error::Status`].
     fn send(
         &self,
         op: &'static str,
@@ -484,15 +499,14 @@ impl S3Client {
         key: &str,
         canonical_query: &str,
         extra_headers: &[Header],
-        body: &[u8],
+        body: &RequestBody<'_>,
     ) -> Result<reqwest::blocking::Response, S3Error> {
         let now = (self.now)();
         let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
         let date = now.format("%Y%m%d").to_string();
-        let payload_hash = if body.is_empty() {
-            EMPTY_PAYLOAD_SHA256.to_owned()
-        } else {
-            sha256_hex(body)
+        let payload_hash = match body {
+            RequestBody::Empty => EMPTY_PAYLOAD_SHA256.to_owned(),
+            RequestBody::File { sha256_hex, .. } => (*sha256_hex).to_owned(),
         };
         let host = self.host()?;
 
@@ -539,8 +553,15 @@ impl S3Client {
         for (name, value) in extra_headers {
             req = req.header(name.as_str(), value.as_str());
         }
-        if !body.is_empty() {
-            req = req.body(body.to_vec());
+        if let RequestBody::File { path, .. } = body {
+            // Stream the file straight from disk. reqwest's blocking `Body`
+            // derives Content-Length from the file's metadata, so the object is
+            // sent with constant memory regardless of size.
+            let file = std::fs::File::open(*path).map_err(|e| S3Error::Transport {
+                op,
+                detail: format!("opening {} for upload: {e}", path.display()),
+            })?;
+            req = req.body(file);
         }
 
         let resp = req.send().map_err(|e| S3Error::Transport {
@@ -563,11 +584,30 @@ impl S3Client {
         }
     }
 
-    /// PUT `bytes` at `key`, sending `x-amz-checksum-sha256` (base64) so a
-    /// compliant endpoint validates the payload server-side.
-    pub fn put_object(&self, key: &str, bytes: &[u8], checksum_b64: &str) -> Result<(), S3Error> {
+    /// Stream the file at `path` to `key` as a PUT, sending `x-amz-checksum-sha256`
+    /// (base64) so a compliant endpoint validates the payload server-side.
+    /// `content_sha256_hex` is the file's hex payload hash (the caller computed
+    /// it in a single streaming pass) and the body streams from disk — the file
+    /// is never buffered in memory.
+    fn put_file(
+        &self,
+        key: &str,
+        path: &Path,
+        checksum_b64: &str,
+        content_sha256_hex: &str,
+    ) -> Result<(), S3Error> {
         let extra = vec![("x-amz-checksum-sha256".to_owned(), checksum_b64.to_owned())];
-        self.send("put", reqwest::Method::PUT, key, "", &extra, bytes)?;
+        self.send(
+            "put",
+            reqwest::Method::PUT,
+            key,
+            "",
+            &extra,
+            &RequestBody::File {
+                path,
+                sha256_hex: content_sha256_hex,
+            },
+        )?;
         Ok(())
     }
 
@@ -584,7 +624,7 @@ impl S3Client {
             key,
             "",
             &head_extra_headers(),
-            &[],
+            &RequestBody::Empty,
         )?;
         let content_length = resp
             .headers()
@@ -606,20 +646,39 @@ impl S3Client {
         })
     }
 
-    /// GET `key`, returning the full object body.
-    pub fn get_object(&self, key: &str) -> Result<Vec<u8>, S3Error> {
-        let resp = self.send("get", reqwest::Method::GET, key, "", &[], &[])?;
-        resp.bytes()
-            .map(|b| b.to_vec())
-            .map_err(|e| S3Error::Transport {
-                op: "get",
-                detail: e.to_string(),
-            })
+    /// GET `key`, streaming the response body straight into `writer` with
+    /// constant memory — used for restore downloads and the rehash-verify
+    /// fallback so a multi-GB object is never buffered in a `Vec`.
+    pub fn download_object(
+        &self,
+        key: &str,
+        mut writer: impl std::io::Write,
+    ) -> Result<(), S3Error> {
+        let mut resp = self.send(
+            "get",
+            reqwest::Method::GET,
+            key,
+            "",
+            &[],
+            &RequestBody::Empty,
+        )?;
+        std::io::copy(&mut resp, &mut writer).map_err(|e| S3Error::Transport {
+            op: "get",
+            detail: e.to_string(),
+        })?;
+        Ok(())
     }
 
     /// DELETE `key` (idempotent on S3).
     pub fn delete_object(&self, key: &str) -> Result<(), S3Error> {
-        self.send("delete", reqwest::Method::DELETE, key, "", &[], &[])?;
+        self.send(
+            "delete",
+            reqwest::Method::DELETE,
+            key,
+            "",
+            &[],
+            &RequestBody::Empty,
+        )?;
         Ok(())
     }
 
@@ -647,7 +706,14 @@ impl S3Client {
                 .collect::<Vec<_>>()
                 .join("&");
 
-            let resp = self.send("list", reqwest::Method::GET, "", &canonical_query, &[], &[])?;
+            let resp = self.send(
+                "list",
+                reqwest::Method::GET,
+                "",
+                &canonical_query,
+                &[],
+                &RequestBody::Empty,
+            )?;
             let body = resp.text().map_err(|e| S3Error::Transport {
                 op: "list",
                 detail: e.to_string(),
@@ -668,19 +734,28 @@ impl S3Client {
         })
     }
 
-    /// Upload `bytes` to `key` and verify the remote object matches (AC #2):
-    /// PUT with server-side checksum, HEAD, then compare length + checksum;
-    /// when the endpoint does not echo a checksum, GET and rehash. Returns `Ok`
-    /// only once the remote is proven to match the local bytes.
-    pub fn put_and_verify(&self, key: &str, bytes: &[u8]) -> Result<(), S3Error> {
-        let checksum_b64 = sha256_base64(bytes);
-        self.put_object(key, bytes, &checksum_b64)?;
-        self.verify_uploaded(key, bytes.len() as u64, &checksum_b64)
+    /// Stream the file at `path` to `key` and verify the remote object matches
+    /// (AC #2): a single streaming hash pre-pass computes the sha256 + length,
+    /// the file is streamed as the PUT body with a server-side checksum, then
+    /// HEAD confirms length + checksum (falling back to a streaming
+    /// GET-and-rehash when the endpoint omits the checksum). Memory stays bounded
+    /// regardless of file size. Returns `Ok` only once the remote is proven to
+    /// match the local file.
+    pub fn put_file_and_verify(&self, key: &str, path: &Path) -> Result<(), S3Error> {
+        let (digest, len) = sha256_file(path).map_err(|e| S3Error::Transport {
+            op: "put",
+            detail: format!("hashing {} for upload: {e}", path.display()),
+        })?;
+        let checksum_b64 = base64_standard(&digest);
+        let content_hex = hex::encode(digest);
+        self.put_file(key, path, &checksum_b64, &content_hex)?;
+        self.verify_uploaded(key, len, &checksum_b64)
     }
 
-    /// HEAD-verify (and GET-rehash-fallback) an already-uploaded object against
-    /// the expected length and base64 sha256. Split out so the comparison logic
-    /// is exercised by [`put_and_verify`] and directly testable.
+    /// HEAD-verify (and streaming GET-rehash fallback) an already-uploaded object
+    /// against the expected length and base64 sha256. Split out so the
+    /// comparison logic is exercised by [`put_file_and_verify`](Self::put_file_and_verify)
+    /// and directly testable.
     pub fn verify_uploaded(
         &self,
         key: &str,
@@ -691,9 +766,11 @@ impl S3Client {
         if verify_head(expected_len, expected_b64, &info)? {
             return Ok(());
         }
-        // Checksum absent on HEAD: prove equality by downloading and rehashing.
-        let body = self.get_object(key)?;
-        let actual_b64 = sha256_base64(&body);
+        // Checksum absent on HEAD: prove equality by streaming the object through
+        // a sha256 hasher (constant memory, never buffering the whole object).
+        let mut hasher = Sha256Writer::new();
+        self.download_object(key, &mut hasher)?;
+        let actual_b64 = base64_standard(&hasher.finalize());
         if actual_b64 == expected_b64 {
             Ok(())
         } else {
@@ -705,16 +782,64 @@ impl S3Client {
     }
 }
 
+/// A `std::io::Write` sink that feeds everything written into a running SHA-256
+/// digest, so an object can be hashed while streaming without buffering it.
+struct Sha256Writer {
+    hasher: Sha256,
+}
+
+impl Sha256Writer {
+    fn new() -> Self {
+        Self {
+            hasher: Sha256::new(),
+        }
+    }
+
+    fn finalize(self) -> [u8; 32] {
+        self.hasher.finalize().into()
+    }
+}
+
+impl std::io::Write for Sha256Writer {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.hasher.update(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Stream a file through SHA-256, returning its `(digest, byte length)` without
+/// loading it into memory. Reads in 64 KiB chunks.
+fn sha256_file(path: &Path) -> std::io::Result<([u8; 32], u64)> {
+    use std::io::Read as _;
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buf = vec![0u8; 64 * 1024];
+    let mut total: u64 = 0;
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+        total += u64::try_from(n).unwrap_or(u64::MAX);
+    }
+    Ok((hasher.finalize().into(), total))
+}
+
 /// Base64 (standard alphabet, padded) of `data`.
 fn base64_standard(data: &[u8]) -> String {
     use base64::Engine as _;
     base64::engine::general_purpose::STANDARD.encode(data)
 }
 
-/// Base64 standard-encode a hex-or-raw sha256 the caller already computed.
-/// Convenience for the backup module which computes the digest itself.
-#[must_use]
-pub fn sha256_base64(data: &[u8]) -> String {
+/// Base64 of SHA-256(`data`). Test helper for the verification unit tests; the
+/// streaming paths hash incrementally and base64 the digest directly.
+#[cfg(test)]
+fn sha256_base64(data: &[u8]) -> String {
     base64_standard(&sha256_raw(data))
 }
 
@@ -966,5 +1091,87 @@ mod tests {
             secret_access_key: "s".to_owned(),
         };
         assert!(S3Client::new(config, creds).is_err());
+    }
+
+    #[test]
+    fn sha256_writer_matches_one_shot_hash() {
+        use std::io::Write as _;
+        // Streaming the object through the Write sink (multiple chunks) yields the
+        // same digest as hashing the whole buffer — this is the rehash-verify path.
+        let mut w = Sha256Writer::new();
+        w.write_all(b"hello ").unwrap();
+        w.write_all(b"streamed ").unwrap();
+        w.write_all(b"world").unwrap();
+        assert_eq!(w.finalize(), sha256_raw(b"hello streamed world"));
+    }
+
+    #[test]
+    fn sha256_file_streams_length_and_digest() {
+        // A payload larger than the 64 KiB read buffer spans multiple chunks, so
+        // this exercises the streaming loop (constant memory) used before upload.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("blob.bin");
+        let data: Vec<u8> = (0..100_000u32)
+            .map(|i| u8::try_from(i % 256).unwrap())
+            .collect();
+        std::fs::write(&path, &data).unwrap();
+        let (digest, len) = sha256_file(&path).unwrap();
+        assert_eq!(len, u64::try_from(data.len()).unwrap());
+        assert_eq!(digest, sha256_raw(&data));
+    }
+
+    #[test]
+    fn download_object_streams_response_body_into_writer() {
+        use std::io::{Read as _, Write as _};
+        // A one-shot local HTTP server returns a canned body; `download_object`
+        // must stream it straight into the caller's writer.
+        let body = b"streamed-object-body-contents".to_vec();
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let body_for_server = body.clone();
+        let server = std::thread::spawn(move || {
+            let (mut sock, _) = listener.accept().unwrap();
+            // Consume the request headers so the client finishes sending.
+            let mut acc = Vec::new();
+            let mut buf = [0u8; 512];
+            loop {
+                let n = sock.read(&mut buf).unwrap();
+                if n == 0 {
+                    break;
+                }
+                acc.extend_from_slice(&buf[..n]);
+                if acc.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n",
+                body_for_server.len()
+            );
+            sock.write_all(head.as_bytes()).unwrap();
+            sock.write_all(&body_for_server).unwrap();
+            sock.flush().unwrap();
+        });
+
+        let client = S3Client::new(
+            S3Config {
+                bucket: "b".to_owned(),
+                region: "us-east-1".to_owned(),
+                endpoint: Some(format!("http://127.0.0.1:{port}")),
+                force_path_style: true,
+            },
+            S3Credentials {
+                access_key_id: "k".to_owned(),
+                secret_access_key: "s".to_owned(),
+            },
+        )
+        .unwrap();
+
+        let mut sink: Vec<u8> = Vec::new();
+        client
+            .download_object("prefix/obj.dump", &mut sink)
+            .unwrap();
+        server.join().unwrap();
+        assert_eq!(sink, body);
     }
 }

--- a/autumn-cli/src/db/s3.rs
+++ b/autumn-cli/src/db/s3.rs
@@ -10,15 +10,15 @@
 //! # Credential safety
 //!
 //! The access key / secret access key are read (by the caller) from the
-//! environment variables *named* by config and handed in as [`S3Credentials`].
+//! environment variables *named* by config and handed in as `S3Credentials`.
 //! They are used only to derive the `SigV4` signing key and the `Authorization`
 //! header. They never appear in a URL, in `Debug`/`Display` output, in an error
-//! message, or in a log line — [`S3Credentials`] deliberately does not derive
-//! `Debug`, and [`S3Error`] carries only status codes and endpoint metadata.
+//! message, or in a log line — `S3Credentials` deliberately does not derive
+//! `Debug`, and `S3Error` carries only status codes and endpoint metadata.
 //!
 //! # Integrity (AC #2)
 //!
-//! [`S3Client::put_file_and_verify`] streams the artifact as the PUT body and
+//! `S3Client::put_file_and_verify` streams the artifact as the PUT body and
 //! sends `x-amz-checksum-sha256` so a compliant endpoint validates the payload
 //! server-side and rejects a corrupted upload. It then HEADs the object and
 //! confirms the remote length (and checksum, when the endpoint echoes it)
@@ -488,7 +488,7 @@ pub struct S3Client {
     http: reqwest::blocking::Client,
     /// Files larger than this upload via multipart (default
     /// [`MULTIPART_THRESHOLD`]); overridable for tests via
-    /// [`with_multipart_params`](Self::with_multipart_params).
+    /// [`with_part_size`](Self::with_part_size).
     multipart_threshold: u64,
     /// Target part size for multipart uploads (default [`MULTIPART_PART_SIZE`]);
     /// the effective size is floored/grown per file by [`effective_part_size`].
@@ -586,7 +586,7 @@ impl S3Client {
         self
     }
 
-    /// The endpoint host[:port] used for the `Host` header and `SigV4` signing.
+    /// The endpoint `host[:port]` used for the `Host` header and `SigV4` signing.
     fn host(&self) -> Result<String, S3Error> {
         let base = self.endpoint_base();
         let url = url::Url::parse(&base).map_err(|e| S3Error::Transport {

--- a/autumn-cli/src/db/s3.rs
+++ b/autumn-cli/src/db/s3.rs
@@ -1,0 +1,846 @@
+//! Minimal synchronous S3 client for offsite backup transfer (issue #1619).
+//!
+//! Autumn's CLI already links `reqwest` (blocking, rustls), `hmac`, `sha2`,
+//! `base64`, and `hex`, so this module implements just enough of **AWS Signature
+//! Version 4** and the five S3 REST operations the offsite-backup flow needs —
+//! WITHOUT pulling `aws-sdk`/`tokio` into the CLI. It targets any S3-compatible
+//! endpoint (AWS, MinIO, Cloudflare R2, Backblaze B2, Garage) via a custom
+//! `endpoint` + `force_path_style`.
+//!
+//! # Credential safety
+//!
+//! The access key / secret access key are read (by the caller) from the
+//! environment variables *named* by config and handed in as [`S3Credentials`].
+//! They are used only to derive the SigV4 signing key and the `Authorization`
+//! header. They never appear in a URL, in `Debug`/`Display` output, in an error
+//! message, or in a log line — [`S3Credentials`] deliberately does not derive
+//! `Debug`, and [`S3Error`] carries only status codes and endpoint metadata.
+//!
+//! # Integrity (AC #2)
+//!
+//! [`S3Client::put_object`] sends `x-amz-checksum-sha256` so a compliant
+//! endpoint validates the payload server-side and rejects a corrupted upload.
+//! [`S3Client::verify_uploaded`] then HEADs the object and confirms the
+//! remote length (and checksum, when the endpoint echoes it) matches the local
+//! file; when the checksum header is absent (older MinIO), it falls back to a
+//! GET-and-rehash so verification is never a no-op.
+
+use std::fmt;
+
+use hmac::{Hmac, Mac};
+use sha2::{Digest, Sha256};
+
+type HmacSha256 = Hmac<Sha256>;
+
+const ALGORITHM: &str = "AWS4-HMAC-SHA256";
+const SERVICE: &str = "s3";
+const AWS4_REQUEST: &str = "aws4_request";
+/// SHA-256 of the empty string; the payload hash for bodyless requests (GET /
+/// HEAD / DELETE).
+const EMPTY_PAYLOAD_SHA256: &str =
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+// ─── Credentials (never Debug/Display) ───────────────────────────────────────
+
+/// Resolved S3 credentials. Intentionally does **not** derive `Debug` or
+/// `Clone`-print; the secret must never be formatted anywhere.
+pub struct S3Credentials {
+    /// Access key id.
+    pub access_key_id: String,
+    /// Secret access key. Never formatted.
+    pub secret_access_key: String,
+}
+
+impl fmt::Debug for S3Credentials {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Redact both fields so a stray `{:?}` can't leak the secret.
+        f.debug_struct("S3Credentials")
+            .field("access_key_id", &"<redacted>")
+            .field("secret_access_key", &"<redacted>")
+            .finish()
+    }
+}
+
+// ─── Client configuration ────────────────────────────────────────────────────
+
+/// Connection settings for [`S3Client`]. Mirrors the reusable
+/// `StorageS3Config` shape (bucket/region/endpoint/force_path_style) but holds
+/// only what transfer needs, so this module stays decoupled from `autumn-web`.
+#[derive(Debug, Clone)]
+pub struct S3Config {
+    /// Target bucket.
+    pub bucket: String,
+    /// Region (SigV4 credential scope). R2 uses `auto`.
+    pub region: String,
+    /// Custom endpoint (e.g. `https://minio.example:9000`). `None` => AWS
+    /// (`https://{bucket}.s3.{region}.amazonaws.com`).
+    pub endpoint: Option<String>,
+    /// Path-style addressing (`{endpoint}/{bucket}/{key}`). Required by MinIO /
+    /// R2 / most self-hosted endpoints.
+    pub force_path_style: bool,
+}
+
+// ─── Errors (credential-safe) ────────────────────────────────────────────────
+
+/// Failure modes for S3 transfer. `Display` never embeds credentials — only
+/// HTTP status, S3 error code, the operation, and a credential-free key.
+#[derive(Debug)]
+pub enum S3Error {
+    /// The HTTP request could not be built or sent.
+    Transport { op: &'static str, detail: String },
+    /// The endpoint returned a non-success status. Carries the S3 `<Code>`
+    /// when the body was parseable.
+    Status {
+        op: &'static str,
+        status: u16,
+        code: Option<String>,
+    },
+    /// A response was malformed (e.g. unparseable list XML or a missing header).
+    BadResponse { op: &'static str, detail: String },
+    /// Remote-vs-local verification failed (AC #2).
+    VerifyFailed { detail: String },
+}
+
+impl fmt::Display for S3Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Transport { op, detail } => {
+                write!(f, "S3 {op} request failed: {detail}")
+            }
+            Self::Status { op, status, code } => match code {
+                Some(code) => write!(f, "S3 {op} returned HTTP {status} ({code})"),
+                None => write!(f, "S3 {op} returned HTTP {status}"),
+            },
+            Self::BadResponse { op, detail } => {
+                write!(f, "S3 {op} returned an unexpected response: {detail}")
+            }
+            Self::VerifyFailed { detail } => {
+                write!(f, "remote object does not match local artifact: {detail}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for S3Error {}
+
+// ─── Object metadata ─────────────────────────────────────────────────────────
+
+/// One object returned by [`S3Client::list_objects_v2`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct S3Object {
+    /// Full object key.
+    pub key: String,
+    /// Object size in bytes.
+    pub size: u64,
+}
+
+/// Result of a HEAD: the fields verification compares against the local file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteObjectInfo {
+    /// `Content-Length` of the stored object.
+    pub content_length: u64,
+    /// Base64 `x-amz-checksum-sha256`, when the endpoint echoes it on HEAD.
+    pub checksum_sha256: Option<String>,
+}
+
+// ─── SigV4 signing (pure, unit-tested against the AWS example vector) ─────────
+
+/// Hex-encoded SHA-256 of `data`.
+fn sha256_hex(data: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hex::encode(hasher.finalize())
+}
+
+/// Raw SHA-256 digest of `data`.
+fn sha256_raw(data: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hasher.finalize().into()
+}
+
+/// HMAC-SHA256(`key`, `data`).
+fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
+    mac.update(data);
+    mac.finalize().into_bytes().into()
+}
+
+/// AWS URI-encode `s`. Unreserved characters (`A-Za-z0-9-._~`) pass through;
+/// everything else is percent-encoded uppercase. `/` is passed through when
+/// `encode_slash` is false (used for object-key path components).
+fn aws_uri_encode(s: &str, encode_slash: bool) -> String {
+    let mut out = String::with_capacity(s.len());
+    for &b in s.as_bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(b as char);
+            }
+            b'/' if !encode_slash => out.push('/'),
+            _ => {
+                out.push('%');
+                out.push_str(&format!("{b:02X}"));
+            }
+        }
+    }
+    out
+}
+
+/// A header name/value pair for signing.
+type Header = (String, String);
+
+/// The `SignedHeaders` list: sorted lowercase header names joined by `;`.
+fn signed_headers_list(headers: &[Header]) -> String {
+    headers
+        .iter()
+        .map(|(name, _)| name.as_str())
+        .collect::<Vec<_>>()
+        .join(";")
+}
+
+/// Build the SigV4 canonical request string. `headers` MUST be sorted by
+/// lowercase name; each value is trimmed. Pure over its inputs.
+fn canonical_request(
+    method: &str,
+    canonical_uri: &str,
+    canonical_query: &str,
+    headers: &[Header],
+    payload_hash: &str,
+) -> String {
+    let canonical_headers: String = headers
+        .iter()
+        .map(|(name, value)| format!("{name}:{}\n", value.trim()))
+        .collect();
+    let signed = signed_headers_list(headers);
+    format!(
+        "{method}\n{canonical_uri}\n{canonical_query}\n{canonical_headers}\n{signed}\n{payload_hash}"
+    )
+}
+
+/// Build the SigV4 string-to-sign from the canonical-request hash.
+fn string_to_sign(amz_date: &str, scope: &str, canonical_request_hash: &str) -> String {
+    format!("{ALGORITHM}\n{amz_date}\n{scope}\n{canonical_request_hash}")
+}
+
+/// Derive the SigV4 signing key: a 4-stage HMAC chain over the secret.
+fn signing_key(secret: &str, date: &str, region: &str) -> [u8; 32] {
+    let k_date = hmac_sha256(format!("AWS4{secret}").as_bytes(), date.as_bytes());
+    let k_region = hmac_sha256(&k_date, region.as_bytes());
+    let k_service = hmac_sha256(&k_region, SERVICE.as_bytes());
+    hmac_sha256(&k_service, AWS4_REQUEST.as_bytes())
+}
+
+/// Compute the lowercase hex signature for a fully-assembled canonical request.
+fn compute_signature(
+    secret: &str,
+    date: &str,
+    region: &str,
+    amz_date: &str,
+    scope: &str,
+    canonical_req: &str,
+) -> String {
+    let key = signing_key(secret, date, region);
+    let sts = string_to_sign(amz_date, scope, &sha256_hex(canonical_req.as_bytes()));
+    hex::encode(hmac_sha256(&key, sts.as_bytes()))
+}
+
+// ─── Verification comparator (pure, unit-tested without a live endpoint) ──────
+
+/// Compare a HEAD result against the local artifact. Returns `Ok(true)` when
+/// the remote is byte-for-byte the local file *and that was fully proven by the
+/// checksum*, `Ok(false)` when the length matches but the endpoint did not echo
+/// a checksum (so the caller must GET-and-rehash), and `Err` on any mismatch.
+///
+/// * checksum present  => must equal `expected_b64` AND length must match.
+/// * checksum absent   => length must match; caller falls back to GET+rehash.
+fn verify_head(
+    expected_len: u64,
+    expected_b64: &str,
+    info: &RemoteObjectInfo,
+) -> Result<bool, S3Error> {
+    if info.content_length != expected_len {
+        return Err(S3Error::VerifyFailed {
+            detail: format!(
+                "remote length {} != local length {expected_len}",
+                info.content_length
+            ),
+        });
+    }
+    match &info.checksum_sha256 {
+        Some(remote) if remote == expected_b64 => Ok(true),
+        Some(remote) => Err(S3Error::VerifyFailed {
+            detail: format!("remote sha256 checksum {remote} != local {expected_b64}"),
+        }),
+        None => Ok(false),
+    }
+}
+
+// ─── List XML parsing (pure, unit-tested) ─────────────────────────────────────
+
+/// Extract the text of the first `<tag>...</tag>` inside `xml`, if present.
+fn xml_first(xml: &str, tag: &str) -> Option<String> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let start = xml.find(&open)? + open.len();
+    let end = xml[start..].find(&close)? + start;
+    Some(xml[start..end].to_owned())
+}
+
+/// Parse a `ListBucketResult` body into `(objects, next_continuation_token)`.
+/// Hand-rolled to avoid adding an XML dependency to the CLI; handles the subset
+/// S3/MinIO/R2/B2/Garage emit for `list-type=2`.
+fn parse_list_objects(xml: &str) -> Result<(Vec<S3Object>, Option<String>), S3Error> {
+    let mut objects = Vec::new();
+    let mut rest = xml;
+    while let Some(open) = rest.find("<Contents>") {
+        let after = &rest[open + "<Contents>".len()..];
+        let Some(close) = after.find("</Contents>") else {
+            break;
+        };
+        let block = &after[..close];
+        if let (Some(key), Some(size_str)) = (xml_first(block, "Key"), xml_first(block, "Size")) {
+            let size = size_str.trim().parse::<u64>().map_err(|_| S3Error::BadResponse {
+                op: "list",
+                detail: format!("non-numeric <Size> {size_str:?}"),
+            })?;
+            objects.push(S3Object {
+                key: xml_unescape(&key),
+                size,
+            });
+        }
+        rest = &after[close + "</Contents>".len()..];
+    }
+    let truncated = xml_first(xml, "IsTruncated")
+        .map(|v| v.trim().eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    let token = if truncated {
+        xml_first(xml, "NextContinuationToken").map(|t| xml_unescape(t.trim()))
+    } else {
+        None
+    };
+    Ok((objects, token))
+}
+
+/// Minimal XML entity unescaping for key text.
+fn xml_unescape(s: &str) -> String {
+    s.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+}
+
+/// Extract the `<Code>` from an S3 error body, if present.
+fn parse_error_code(xml: &str) -> Option<String> {
+    xml_first(xml, "Code")
+}
+
+// ─── The client ──────────────────────────────────────────────────────────────
+
+/// A synchronous S3-compatible client. Cheap to clone-construct; holds a
+/// blocking `reqwest` client and the resolved credentials.
+pub struct S3Client {
+    config: S3Config,
+    credentials: S3Credentials,
+    http: reqwest::blocking::Client,
+    /// Clock indirection so signing/tests are deterministic. Returns the SigV4
+    /// `x-amz-date` (`YYYYMMDDTHHMMSSZ`).
+    now: fn() -> chrono::DateTime<chrono::Utc>,
+}
+
+impl S3Client {
+    /// Build a client. Fails only if the TLS/HTTP stack can't be constructed.
+    pub fn new(config: S3Config, credentials: S3Credentials) -> Result<Self, S3Error> {
+        let http = reqwest::blocking::Client::builder()
+            .build()
+            .map_err(|e| S3Error::Transport {
+                op: "init",
+                detail: e.to_string(),
+            })?;
+        Ok(Self {
+            config,
+            credentials,
+            http,
+            now: chrono::Utc::now,
+        })
+    }
+
+    /// The endpoint host[:port] used for the `Host` header and SigV4 signing.
+    fn host(&self) -> Result<String, S3Error> {
+        let base = self.endpoint_base();
+        let url = url::Url::parse(&base).map_err(|e| S3Error::Transport {
+            op: "init",
+            detail: format!("invalid endpoint: {e}"),
+        })?;
+        let host = url.host_str().ok_or_else(|| S3Error::Transport {
+            op: "init",
+            detail: "endpoint has no host".to_owned(),
+        })?;
+        Ok(match url.port() {
+            Some(port) => format!("{host}:{port}"),
+            None => host.to_owned(),
+        })
+    }
+
+    /// Scheme + authority for the endpoint (no path). For AWS this synthesizes
+    /// the virtual-hosted bucket endpoint; for a custom endpoint it is used
+    /// verbatim (path-style) or with the bucket as a host prefix.
+    fn endpoint_base(&self) -> String {
+        match &self.config.endpoint {
+            Some(ep) => {
+                let ep = ep.trim_end_matches('/');
+                if self.config.force_path_style {
+                    ep.to_owned()
+                } else {
+                    // Virtual-hosted on a custom endpoint: prefix the bucket.
+                    if let Some(rest) = ep.strip_prefix("https://") {
+                        format!("https://{}.{rest}", self.config.bucket)
+                    } else if let Some(rest) = ep.strip_prefix("http://") {
+                        format!("http://{}.{rest}", self.config.bucket)
+                    } else {
+                        ep.to_owned()
+                    }
+                }
+            }
+            None => format!(
+                "https://{}.s3.{}.amazonaws.com",
+                self.config.bucket, self.config.region
+            ),
+        }
+    }
+
+    /// The canonical request path for `key` (SigV4 signs this exact string).
+    fn canonical_path(&self, key: &str) -> String {
+        let key = key.trim_start_matches('/');
+        if self.config.endpoint.is_some() && self.config.force_path_style {
+            format!("/{}/{}", self.config.bucket, aws_uri_encode(key, false))
+        } else {
+            format!("/{}", aws_uri_encode(key, false))
+        }
+    }
+
+    /// Full request URL for `key` (+ optional canonical query string).
+    fn request_url(&self, key: &str, canonical_query: &str) -> String {
+        let base = self.endpoint_base();
+        let path = self.canonical_path(key);
+        if canonical_query.is_empty() {
+            format!("{base}{path}")
+        } else {
+            format!("{base}{path}?{canonical_query}")
+        }
+    }
+
+    /// Sign and send one request. `body` is the full payload (bodyless ops pass
+    /// `&[]`). `extra_headers` are additional signed headers (e.g. the PutObject
+    /// checksum). Returns the raw blocking response on 2xx, else an
+    /// [`S3Error::Status`].
+    fn send(
+        &self,
+        op: &'static str,
+        method: reqwest::Method,
+        key: &str,
+        canonical_query: &str,
+        extra_headers: &[Header],
+        body: &[u8],
+    ) -> Result<reqwest::blocking::Response, S3Error> {
+        let now = (self.now)();
+        let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
+        let date = now.format("%Y%m%d").to_string();
+        let payload_hash = if body.is_empty() {
+            EMPTY_PAYLOAD_SHA256.to_owned()
+        } else {
+            sha256_hex(body)
+        };
+        let host = self.host()?;
+
+        // Assemble the signed header set, then sort by lowercase name.
+        let mut headers: Vec<Header> = vec![
+            ("host".to_owned(), host.clone()),
+            ("x-amz-content-sha256".to_owned(), payload_hash.clone()),
+            ("x-amz-date".to_owned(), amz_date.clone()),
+        ];
+        for (name, value) in extra_headers {
+            headers.push((name.to_ascii_lowercase(), value.clone()));
+        }
+        headers.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let canonical = canonical_request(
+            method.as_str(),
+            &self.canonical_path(key),
+            canonical_query,
+            &headers,
+            &payload_hash,
+        );
+        let scope = format!("{date}/{}/{SERVICE}/{AWS4_REQUEST}", self.config.region);
+        let signature = compute_signature(
+            &self.credentials.secret_access_key,
+            &date,
+            &self.config.region,
+            &amz_date,
+            &scope,
+            &canonical,
+        );
+        let authorization = format!(
+            "{ALGORITHM} Credential={}/{scope}, SignedHeaders={}, Signature={signature}",
+            self.credentials.access_key_id,
+            signed_headers_list(&headers),
+        );
+
+        let url = self.request_url(key, canonical_query);
+        let mut req = self
+            .http
+            .request(method, &url)
+            .header("x-amz-date", &amz_date)
+            .header("x-amz-content-sha256", &payload_hash)
+            .header(reqwest::header::AUTHORIZATION, authorization);
+        for (name, value) in extra_headers {
+            req = req.header(name.as_str(), value.as_str());
+        }
+        if !body.is_empty() {
+            req = req.body(body.to_vec());
+        }
+
+        let resp = req.send().map_err(|e| S3Error::Transport {
+            op,
+            // reqwest error Display can include the URL (no credentials) but
+            // never the Authorization header, so this is credential-safe.
+            detail: e.to_string(),
+        })?;
+
+        let status = resp.status();
+        if status.is_success() {
+            Ok(resp)
+        } else {
+            let code = resp.text().ok().as_deref().and_then(parse_error_code);
+            Err(S3Error::Status {
+                op,
+                status: status.as_u16(),
+                code,
+            })
+        }
+    }
+
+    /// PUT `bytes` at `key`, sending `x-amz-checksum-sha256` (base64) so a
+    /// compliant endpoint validates the payload server-side.
+    pub fn put_object(&self, key: &str, bytes: &[u8], checksum_b64: &str) -> Result<(), S3Error> {
+        let extra = vec![("x-amz-checksum-sha256".to_owned(), checksum_b64.to_owned())];
+        self.send("put", reqwest::Method::PUT, key, "", &extra, bytes)?;
+        Ok(())
+    }
+
+    /// HEAD `key`, returning its length and (when echoed) checksum.
+    pub fn head_object(&self, key: &str) -> Result<RemoteObjectInfo, S3Error> {
+        let resp = self.send("head", reqwest::Method::HEAD, key, "", &[], &[])?;
+        let content_length =
+            resp.headers()
+                .get(reqwest::header::CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse::<u64>().ok())
+                .ok_or_else(|| S3Error::BadResponse {
+                    op: "head",
+                    detail: "missing or invalid Content-Length".to_owned(),
+                })?;
+        let checksum_sha256 = resp
+            .headers()
+            .get("x-amz-checksum-sha256")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+        Ok(RemoteObjectInfo {
+            content_length,
+            checksum_sha256,
+        })
+    }
+
+    /// GET `key`, returning the full object body.
+    pub fn get_object(&self, key: &str) -> Result<Vec<u8>, S3Error> {
+        let resp = self.send("get", reqwest::Method::GET, key, "", &[], &[])?;
+        resp.bytes()
+            .map(|b| b.to_vec())
+            .map_err(|e| S3Error::Transport {
+                op: "get",
+                detail: e.to_string(),
+            })
+    }
+
+    /// DELETE `key` (idempotent on S3).
+    pub fn delete_object(&self, key: &str) -> Result<(), S3Error> {
+        self.send("delete", reqwest::Method::DELETE, key, "", &[], &[])?;
+        Ok(())
+    }
+
+    /// List every object under `prefix` (following continuation tokens).
+    pub fn list_objects_v2(&self, prefix: &str) -> Result<Vec<S3Object>, S3Error> {
+        let mut out = Vec::new();
+        let mut continuation: Option<String> = None;
+        loop {
+            // Canonical query string: keys sorted, both key and value encoded.
+            let mut params: Vec<(String, String)> = vec![
+                ("list-type".to_owned(), "2".to_owned()),
+                ("prefix".to_owned(), prefix.to_owned()),
+            ];
+            if let Some(token) = &continuation {
+                params.push(("continuation-token".to_owned(), token.clone()));
+            }
+            params.sort_by(|a, b| a.0.cmp(&b.0));
+            let canonical_query = params
+                .iter()
+                .map(|(k, v)| format!("{}={}", aws_uri_encode(k, true), aws_uri_encode(v, true)))
+                .collect::<Vec<_>>()
+                .join("&");
+
+            let resp = self.send("list", reqwest::Method::GET, "", &canonical_query, &[], &[])?;
+            let body = resp.text().map_err(|e| S3Error::Transport {
+                op: "list",
+                detail: e.to_string(),
+            })?;
+            let (objects, next) = parse_list_objects(&body)?;
+            out.extend(objects);
+            match next {
+                Some(token) => continuation = Some(token),
+                None => break,
+            }
+        }
+        Ok(out)
+    }
+
+    /// Upload `bytes` to `key` and verify the remote object matches (AC #2):
+    /// PUT with server-side checksum, HEAD, then compare length + checksum;
+    /// when the endpoint does not echo a checksum, GET and rehash. Returns `Ok`
+    /// only once the remote is proven to match the local bytes.
+    pub fn put_and_verify(&self, key: &str, bytes: &[u8]) -> Result<(), S3Error> {
+        let digest = sha256_raw(bytes);
+        let checksum_b64 = base64_standard(&digest);
+        self.put_object(key, bytes, &checksum_b64)?;
+        self.verify_uploaded(key, bytes.len() as u64, &checksum_b64)
+    }
+
+    /// HEAD-verify (and GET-rehash-fallback) an already-uploaded object against
+    /// the expected length and base64 sha256. Split out so the comparison logic
+    /// is exercised by [`put_and_verify`] and directly testable.
+    pub fn verify_uploaded(
+        &self,
+        key: &str,
+        expected_len: u64,
+        expected_b64: &str,
+    ) -> Result<(), S3Error> {
+        let info = self.head_object(key)?;
+        if verify_head(expected_len, expected_b64, &info)? {
+            return Ok(());
+        }
+        // Checksum absent on HEAD: prove equality by downloading and rehashing.
+        let body = self.get_object(key)?;
+        let actual_b64 = base64_standard(&sha256_raw(&body));
+        if actual_b64 == expected_b64 {
+            Ok(())
+        } else {
+            Err(S3Error::VerifyFailed {
+                detail: "GET-and-rehash of the uploaded object did not match the local sha256"
+                    .to_owned(),
+            })
+        }
+    }
+}
+
+/// Base64 (standard alphabet, padded) of `data`.
+fn base64_standard(data: &[u8]) -> String {
+    use base64::Engine as _;
+    base64::engine::general_purpose::STANDARD.encode(data)
+}
+
+/// Base64 standard-encode a hex-or-raw sha256 the caller already computed.
+/// Convenience for the backup module which computes the digest itself.
+#[must_use]
+pub fn sha256_base64(data: &[u8]) -> String {
+    base64_standard(&sha256_raw(data))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The canonical AWS SigV4 "GET Object" example vector from the AWS docs
+    /// (`Signature Calculations for the Authorization Header`). Proves the
+    /// canonical request, string-to-sign, and final signature are correct.
+    #[test]
+    fn sigv4_matches_aws_get_object_example() {
+        let secret = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+        let access = "AKIDEXAMPLE";
+        let region = "us-east-1";
+        let date = "20130524";
+        let amz_date = "20130524T000000Z";
+
+        // Headers sorted by lowercase name, exactly as the example lists them.
+        let headers: Vec<Header> = vec![
+            (
+                "host".to_owned(),
+                "examplebucket.s3.amazonaws.com".to_owned(),
+            ),
+            ("range".to_owned(), "bytes=0-9".to_owned()),
+            (
+                "x-amz-content-sha256".to_owned(),
+                EMPTY_PAYLOAD_SHA256.to_owned(),
+            ),
+            ("x-amz-date".to_owned(), amz_date.to_owned()),
+        ];
+
+        let canonical = canonical_request("GET", "/test.txt", "", &headers, EMPTY_PAYLOAD_SHA256);
+
+        // Canonical request hash from the AWS documented example.
+        assert_eq!(
+            sha256_hex(canonical.as_bytes()),
+            "7344ae5b7ee6c3e7e6b0fe0640412a37625d1fbfff95c48bbb2dc43964946972"
+        );
+
+        let scope = format!("{date}/{region}/{SERVICE}/{AWS4_REQUEST}");
+        assert_eq!(scope, "20130524/us-east-1/s3/aws4_request");
+
+        let signature =
+            compute_signature(secret, date, region, amz_date, &scope, &canonical);
+        // Expected signature for this exact canonical request, cross-checked
+        // against an independent reference implementation of SigV4.
+        assert_eq!(
+            signature,
+            "67fe34c8530db585abddc51067328adfedb6e42487d2566dc7d927d6e2722900"
+        );
+
+        // And the signed-header list is stable/sorted.
+        assert_eq!(
+            signed_headers_list(&headers),
+            "host;range;x-amz-content-sha256;x-amz-date"
+        );
+        // Sanity-check the access key threads through to the auth header shape.
+        assert!(format!("Credential={access}/{scope}").contains("AKIDEXAMPLE/20130524"));
+    }
+
+    #[test]
+    fn string_to_sign_shape() {
+        let sts = string_to_sign("20130524T000000Z", "20130524/us-east-1/s3/aws4_request", "abc");
+        assert_eq!(
+            sts,
+            "AWS4-HMAC-SHA256\n20130524T000000Z\n20130524/us-east-1/s3/aws4_request\nabc"
+        );
+    }
+
+    #[test]
+    fn aws_uri_encode_preserves_key_slashes_but_encodes_specials() {
+        assert_eq!(
+            aws_uri_encode("db/prod/20260710T040506Z/control.dump", false),
+            "db/prod/20260710T040506Z/control.dump"
+        );
+        // A space and a plus must be encoded; slash preserved.
+        assert_eq!(aws_uri_encode("a b+c/d", false), "a%20b%2Bc/d");
+        // In query mode the slash IS encoded.
+        assert_eq!(aws_uri_encode("a/b", true), "a%2Fb");
+    }
+
+    #[test]
+    fn verify_head_matches_on_checksum() {
+        let expected = sha256_base64(b"hello");
+        let info = RemoteObjectInfo {
+            content_length: 5,
+            checksum_sha256: Some(expected.clone()),
+        };
+        assert_eq!(verify_head(5, &expected, &info).unwrap(), true);
+    }
+
+    #[test]
+    fn verify_head_length_mismatch_errors() {
+        let expected = sha256_base64(b"hello");
+        let info = RemoteObjectInfo {
+            content_length: 4,
+            checksum_sha256: Some(expected.clone()),
+        };
+        assert!(matches!(
+            verify_head(5, &expected, &info),
+            Err(S3Error::VerifyFailed { .. })
+        ));
+    }
+
+    #[test]
+    fn verify_head_checksum_mismatch_errors() {
+        let expected = sha256_base64(b"hello");
+        let wrong = sha256_base64(b"world");
+        let info = RemoteObjectInfo {
+            content_length: 5,
+            checksum_sha256: Some(wrong),
+        };
+        assert!(matches!(
+            verify_head(5, &expected, &info),
+            Err(S3Error::VerifyFailed { .. })
+        ));
+    }
+
+    #[test]
+    fn verify_head_absent_checksum_requests_rehash() {
+        let expected = sha256_base64(b"hello");
+        let info = RemoteObjectInfo {
+            content_length: 5,
+            checksum_sha256: None,
+        };
+        // Length matches but no checksum => caller must GET-and-rehash.
+        assert_eq!(verify_head(5, &expected, &info).unwrap(), false);
+    }
+
+    #[test]
+    fn parse_list_objects_extracts_keys_and_sizes() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult>
+          <Name>bucket</Name>
+          <Contents>
+            <Key>db/prod/20260710T040506Z/manifest.json</Key>
+            <Size>128</Size>
+          </Contents>
+          <Contents>
+            <Key>db/prod/20260710T040506Z/control.dump</Key>
+            <Size>4096</Size>
+          </Contents>
+          <IsTruncated>false</IsTruncated>
+        </ListBucketResult>"#;
+        let (objects, next) = parse_list_objects(xml).unwrap();
+        assert_eq!(objects.len(), 2);
+        assert_eq!(objects[0].key, "db/prod/20260710T040506Z/manifest.json");
+        assert_eq!(objects[0].size, 128);
+        assert_eq!(objects[1].size, 4096);
+        assert!(next.is_none());
+    }
+
+    #[test]
+    fn parse_list_objects_follows_truncation_token() {
+        let xml = r#"<ListBucketResult>
+          <Contents><Key>a</Key><Size>1</Size></Contents>
+          <IsTruncated>true</IsTruncated>
+          <NextContinuationToken>tok123</NextContinuationToken>
+        </ListBucketResult>"#;
+        let (objects, next) = parse_list_objects(xml).unwrap();
+        assert_eq!(objects.len(), 1);
+        assert_eq!(next.as_deref(), Some("tok123"));
+    }
+
+    #[test]
+    fn parse_error_code_reads_s3_code() {
+        let xml = "<Error><Code>NoSuchKey</Code><Message>nope</Message></Error>";
+        assert_eq!(parse_error_code(xml).as_deref(), Some("NoSuchKey"));
+    }
+
+    #[test]
+    fn credentials_debug_is_redacted() {
+        let creds = S3Credentials {
+            access_key_id: "AKIA_PUBLIC".to_owned(),
+            secret_access_key: "supersecret".to_owned(),
+        };
+        let rendered = format!("{creds:?}");
+        assert!(!rendered.contains("supersecret"));
+        assert!(!rendered.contains("AKIA_PUBLIC"));
+        assert!(rendered.contains("redacted"));
+    }
+
+    #[test]
+    fn sha256_base64_is_standard_padded() {
+        // SHA-256("") base64 == 47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
+        assert_eq!(
+            sha256_base64(b""),
+            "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
+        );
+    }
+}

--- a/autumn-cli/src/db/s3.rs
+++ b/autumn-cli/src/db/s3.rs
@@ -307,12 +307,27 @@ fn verify_head(
         });
     }
     match &info.checksum_sha256 {
+        // A COMPOSITE checksum (`<hash>-<n>`, echoed by some endpoints for a
+        // multipart object) is a hash-of-part-hashes, NOT the whole-object
+        // sha256, so it must not be compared to `expected_b64` — that would be a
+        // spurious mismatch. Ignore it and fall through to the GET-and-rehash path.
+        Some(remote) if is_composite_checksum(remote) => Ok(false),
         Some(remote) if remote == expected_b64 => Ok(true),
         Some(remote) => Err(S3Error::VerifyFailed {
             detail: format!("remote sha256 checksum {remote} != local {expected_b64}"),
         }),
         None => Ok(false),
     }
+}
+
+/// Whether an `x-amz-checksum-sha256` value is a COMPOSITE checksum — a
+/// base64 digest followed by a `-<partcount>` suffix (e.g. `AbCd...=-3`), which
+/// endpoints echo for multipart objects. Such a value is a hash of part hashes,
+/// not the object's sha256, so it can never equal the whole-file digest.
+fn is_composite_checksum(value: &str) -> bool {
+    value.rsplit_once('-').is_some_and(|(head, n)| {
+        !head.is_empty() && !n.is_empty() && n.bytes().all(|b| b.is_ascii_digit())
+    })
 }
 
 // ─── List XML parsing (pure, unit-tested) ─────────────────────────────────────
@@ -430,10 +445,12 @@ fn build_complete_multipart_xml(parts: &[(u32, String)]) -> String {
 
 /// Classify a `CompleteMultipartUpload` response body. S3 returns HTTP 200 even
 /// when assembly fails, embedding an `<Error>` in the body — so success requires
-/// a `CompleteMultipartUploadResult` element. Returns `Err(code)` (the S3
-/// `<Code>`, or a placeholder) on a 200-with-error body.
+/// a `CompleteMultipartUploadResult` element AND the absence of an `<Error>`
+/// element (an error body could conceivably embed the result tag as a
+/// substring). Returns `Err(code)` (the S3 `<Code>`, or a placeholder) on a
+/// 200-with-error body.
 fn classify_complete_response(body: &str) -> Result<(), String> {
-    if body.contains("<CompleteMultipartUploadResult") {
+    if body.contains("<CompleteMultipartUploadResult") && !body.contains("<Error") {
         return Ok(());
     }
     Err(parse_error_code(body).unwrap_or_else(|| "UnrecognizedCompleteResponse".to_owned()))
@@ -490,9 +507,11 @@ enum RequestBody<'a> {
     Empty,
     /// Stream this file as the body; `sha256_hex` is its precomputed payload hash.
     File { path: &'a Path, sha256_hex: &'a str },
-    /// An in-memory body (a multipart part chunk, or a small XML request body
-    /// like `CompleteMultipartUpload`). The payload hash is computed inline.
-    Bytes(&'a [u8]),
+    /// An owned in-memory body (a multipart part chunk, or a small XML request
+    /// body like `CompleteMultipartUpload`). The buffer is MOVED into the request
+    /// body — reqwest takes ownership without copying — so a part is held once,
+    /// not duplicated. The payload hash is computed inline.
+    Owned(Vec<u8>),
 }
 
 /// Reject a custom `endpoint` that carries a path prefix. `canonical_path` signs
@@ -557,14 +576,12 @@ impl S3Client {
         })
     }
 
-    /// Override the multipart threshold and target part size (both in bytes).
-    /// Used by tests / the `AUTUMN_OFFSITE_MULTIPART_PART_SIZE_BYTES` escape hatch
-    /// to exercise the multipart path on small files without a multi-GB fixture.
-    /// The part size is still floored to S3's 5 MiB minimum and grown as needed
-    /// by [`effective_part_size`] at upload time.
+    /// Override ONLY the target part size, leaving the multipart threshold at its
+    /// default. Shrinking the part size therefore never pushes a sub-threshold
+    /// file into a multipart upload — it only changes how an already-multipart
+    /// transfer is chunked. Floored to S3's 5 MiB minimum at upload time.
     #[must_use]
-    pub const fn with_multipart_params(mut self, threshold: u64, part_size: u64) -> Self {
-        self.multipart_threshold = threshold;
+    pub const fn with_part_size(mut self, part_size: u64) -> Self {
         self.multipart_part_size = part_size;
         self
     }
@@ -645,15 +662,15 @@ impl S3Client {
         key: &str,
         canonical_query: &str,
         extra_headers: &[Header],
-        body: &RequestBody<'_>,
+        body: RequestBody<'_>,
     ) -> Result<reqwest::blocking::Response, S3Error> {
         let now = (self.now)();
         let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
         let date = now.format("%Y%m%d").to_string();
-        let payload_hash = match body {
+        let payload_hash = match &body {
             RequestBody::Empty => EMPTY_PAYLOAD_SHA256.to_owned(),
             RequestBody::File { sha256_hex, .. } => (*sha256_hex).to_owned(),
-            RequestBody::Bytes(bytes) => sha256_hex(bytes),
+            RequestBody::Owned(bytes) => sha256_hex(bytes),
         };
         let host = self.host()?;
 
@@ -706,14 +723,15 @@ impl S3Client {
                 // Stream the file straight from disk. reqwest's blocking `Body`
                 // derives Content-Length from the file's metadata, so the object
                 // is sent with constant memory regardless of size.
-                let file = std::fs::File::open(*path).map_err(|e| S3Error::Transport {
+                let file = std::fs::File::open(path).map_err(|e| S3Error::Transport {
                     op,
                     detail: format!("opening {} for upload: {e}", path.display()),
                 })?;
                 req = req.body(file);
             }
-            RequestBody::Bytes(bytes) => {
-                req = req.body(bytes.to_vec());
+            RequestBody::Owned(bytes) => {
+                // Move the buffer into the request body — no extra copy.
+                req = req.body(bytes);
             }
         }
 
@@ -756,7 +774,7 @@ impl S3Client {
             key,
             "",
             &extra,
-            &RequestBody::File {
+            RequestBody::File {
                 path,
                 sha256_hex: content_sha256_hex,
             },
@@ -777,7 +795,7 @@ impl S3Client {
             key,
             "",
             &head_extra_headers(),
-            &RequestBody::Empty,
+            RequestBody::Empty,
         )?;
         let content_length = resp
             .headers()
@@ -813,7 +831,7 @@ impl S3Client {
             key,
             "",
             &[],
-            &RequestBody::Empty,
+            RequestBody::Empty,
         )?;
         std::io::copy(&mut resp, &mut writer).map_err(|e| S3Error::Transport {
             op: "get",
@@ -830,7 +848,7 @@ impl S3Client {
             key,
             "",
             &[],
-            &RequestBody::Empty,
+            RequestBody::Empty,
         )?;
         Ok(())
     }
@@ -865,7 +883,7 @@ impl S3Client {
                 "",
                 &canonical_query,
                 &[],
-                &RequestBody::Empty,
+                RequestBody::Empty,
             )?;
             let body = resp.text().map_err(|e| S3Error::Transport {
                 op: "list",
@@ -916,7 +934,8 @@ impl S3Client {
 
     /// Upload `path` to `key` as an S3 multipart upload: `CreateMultipartUpload`,
     /// then one `UploadPart` per [`effective_part_size`] chunk (streamed a part at
-    /// a time — memory stays bounded to one part), then `CompleteMultipartUpload`.
+    /// a time — peak memory ≈ one `part_size`, which for multi-TB files grows
+    /// above the configured floor), then `CompleteMultipartUpload`.
     /// On ANY failure before completion the in-progress upload is aborted
     /// (`AbortMultipartUpload`) so no orphaned parts accrue storage cost.
     ///
@@ -959,8 +978,10 @@ impl S3Client {
 
     /// Stream `path` in `part_size` chunks, uploading each as a numbered part and
     /// feeding every byte into a whole-file SHA-256. Returns the base64 sha256 of
-    /// the entire file once `CompleteMultipartUpload` succeeds. One part is held
-    /// in memory at a time.
+    /// the entire file once `CompleteMultipartUpload` succeeds. Peak memory is
+    /// ≈ one part (`part_size`, which grows above the configured floor for
+    /// multi-TB files); each chunk is read into an owned buffer and MOVED into the
+    /// request body, so a part is never duplicated.
     fn upload_parts_and_complete(
         &self,
         key: &str,
@@ -974,24 +995,26 @@ impl S3Client {
             detail: format!("opening {} for upload: {e}", path.display()),
         })?;
         let cap = usize::try_from(part_size).unwrap_or(usize::MAX);
-        let mut buf = vec![0u8; cap];
         let mut whole = Sha256Writer::new();
         let mut parts: Vec<(u32, String)> = Vec::new();
         let mut part_number: u32 = 1;
         let mut uploaded: u64 = 0;
         loop {
-            let n = read_up_to(&mut file, &mut buf).map_err(|e| S3Error::Transport {
+            // Read into a fresh owned buffer so it can be moved straight into the
+            // request body without a second copy (≈ one part in memory at a time).
+            let mut chunk = vec![0u8; cap];
+            let n = read_up_to(&mut file, &mut chunk).map_err(|e| S3Error::Transport {
                 op: "upload-part",
                 detail: format!("reading {} for upload: {e}", path.display()),
             })?;
             if n == 0 {
                 break;
             }
-            let chunk = &buf[..n];
+            chunk.truncate(n);
             {
                 use std::io::Write as _;
                 whole
-                    .write_all(chunk)
+                    .write_all(&chunk)
                     .expect("Sha256Writer::write is infallible");
             }
             let etag = self.upload_part(key, upload_id, part_number, chunk)?;
@@ -1023,7 +1046,7 @@ impl S3Client {
             key,
             &query,
             &[],
-            &RequestBody::Empty,
+            RequestBody::Empty,
         )?;
         let body = resp.text().map_err(|e| S3Error::Transport {
             op: "create-multipart",
@@ -1035,14 +1058,15 @@ impl S3Client {
         })
     }
 
-    /// `UploadPart` (`PUT /{key}?partNumber=n&uploadId=...`). Sends the chunk as
-    /// an in-memory body; returns the part's `ETag` (needed to complete).
+    /// `UploadPart` (`PUT /{key}?partNumber=n&uploadId=...`). Takes ownership of
+    /// the chunk and MOVES it into the request body (no extra copy); returns the
+    /// part's `ETag` (needed to complete).
     fn upload_part(
         &self,
         key: &str,
         upload_id: &str,
         part_number: u32,
-        chunk: &[u8],
+        chunk: Vec<u8>,
     ) -> Result<String, S3Error> {
         let pn = part_number.to_string();
         let query = canonical_query(&[("partNumber", &pn), ("uploadId", upload_id)]);
@@ -1052,7 +1076,7 @@ impl S3Client {
             key,
             &query,
             &[],
-            &RequestBody::Bytes(chunk),
+            RequestBody::Owned(chunk),
         )?;
         resp.headers()
             .get(reqwest::header::ETAG)
@@ -1081,7 +1105,7 @@ impl S3Client {
             key,
             &query,
             &[],
-            &RequestBody::Bytes(xml.as_bytes()),
+            RequestBody::Owned(xml.into_bytes()),
         )?;
         let body = resp.text().map_err(|e| S3Error::Transport {
             op: "complete-multipart",
@@ -1104,7 +1128,7 @@ impl S3Client {
             key,
             &query,
             &[],
-            &RequestBody::Empty,
+            RequestBody::Empty,
         )?;
         Ok(())
     }
@@ -1658,6 +1682,39 @@ mod tests {
     }
 
     #[test]
+    fn classify_complete_response_rejects_error_even_with_result_substring() {
+        // A 200 body that carries BOTH an <Error> and (defensively) the result tag
+        // as a substring must still be treated as a failure — the <Error> wins.
+        let tricky = "<Error><Code>SlowDown</Code></Error><CompleteMultipartUploadResult/>";
+        assert_eq!(classify_complete_response(tricky).unwrap_err(), "SlowDown");
+    }
+
+    #[test]
+    fn is_composite_checksum_detects_partcount_suffix() {
+        assert!(is_composite_checksum("AbCdEf0123456789=-3"));
+        assert!(is_composite_checksum("x-10000"));
+        // A whole-object base64 sha256 (no `-<n>` suffix) is NOT composite.
+        assert!(!is_composite_checksum(
+            "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
+        ));
+        // A trailing dash with no digits, or no head, is not a composite marker.
+        assert!(!is_composite_checksum("abc-"));
+        assert!(!is_composite_checksum("-3"));
+    }
+
+    #[test]
+    fn verify_head_ignores_composite_checksum_and_requests_rehash() {
+        // An endpoint that echoes a COMPOSITE checksum for a multipart object must
+        // NOT trip a spurious mismatch — length matches, so fall through to rehash.
+        let expected = sha256_base64(b"hello");
+        let info = RemoteObjectInfo {
+            content_length: 5,
+            checksum_sha256: Some(format!("{expected}-3")),
+        };
+        assert!(!verify_head(5, &expected, &info).unwrap());
+    }
+
+    #[test]
     fn parse_upload_id_from_create_response() {
         let body = r#"<?xml version="1.0" encoding="UTF-8"?>
         <InitiateMultipartUploadResult>
@@ -1701,7 +1758,9 @@ mod tests {
     }
 
     #[test]
-    fn with_multipart_params_overrides_defaults() {
+    fn with_part_size_overrides_only_part_size_not_threshold() {
+        // Low 3: shrinking the part size must NOT lower the multipart threshold,
+        // so a sub-threshold file is never forced into a multipart upload.
         let client = S3Client::new(
             S3Config {
                 bucket: "b".to_owned(),
@@ -1715,8 +1774,9 @@ mod tests {
             },
         )
         .unwrap()
-        .with_multipart_params(5 * 1024 * 1024, 5 * 1024 * 1024);
-        assert_eq!(client.multipart_threshold, 5 * 1024 * 1024);
+        .with_part_size(5 * 1024 * 1024);
         assert_eq!(client.multipart_part_size, 5 * 1024 * 1024);
+        // Threshold stays at the default — unchanged by a part-size override.
+        assert_eq!(client.multipart_threshold, MULTIPART_THRESHOLD);
     }
 }

--- a/autumn-cli/src/db/s3.rs
+++ b/autumn-cli/src/db/s3.rs
@@ -29,6 +29,7 @@
 use std::fmt;
 use std::fmt::Write as _;
 use std::path::Path;
+use std::time::Duration;
 
 use hmac::{Hmac, Mac};
 use sha2::{Digest, Sha256};
@@ -46,6 +47,13 @@ const EMPTY_PAYLOAD_SHA256: &str =
 /// maximum) this covers a million objects — far beyond any backup prefix — while
 /// bounding a broken endpoint that never stops returning a continuation token.
 const MAX_LIST_PAGES: usize = 1000;
+/// Connect-phase timeout for the transfer client: fail fast on a dead host
+/// without bounding the total transfer duration.
+const TRANSFER_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+/// TCP-level inactivity guard (`TCP_USER_TIMEOUT`) for the transfer client:
+/// drop a stalled connection whose data stays unacknowledged this long, WITHOUT
+/// capping a healthy long-running multi-GB stream.
+const TRANSFER_STALL_TIMEOUT: Duration = Duration::from_secs(300);
 
 // ─── Credentials (never Debug/Display) ───────────────────────────────────────
 
@@ -408,13 +416,26 @@ impl S3Client {
         if let Some(endpoint) = &config.endpoint {
             validate_endpoint(endpoint)?;
         }
-        let http =
-            reqwest::blocking::Client::builder()
-                .build()
-                .map_err(|e| S3Error::Transport {
-                    op: "init",
-                    detail: e.to_string(),
-                })?;
+        let http = reqwest::blocking::Client::builder()
+            // reqwest's blocking default is a 30s TOTAL request timeout, which
+            // would abort a correctly-streaming multi-GB PUT/GET on a slow
+            // offsite link before it finishes. Disable the overall cap so long
+            // transfers aren't bounded by wall-clock…
+            .timeout(None)
+            // …but still fail fast on a dead/unreachable host…
+            .connect_timeout(TRANSFER_CONNECT_TIMEOUT)
+            // …and catch a stalled connection at the TCP layer WITHOUT capping
+            // total duration: TCP_USER_TIMEOUT drops the connection when sent
+            // data stays unacknowledged this long. reqwest 0.13's blocking
+            // builder has no per-read `read_timeout`, so this is the closest
+            // inactivity guard. Non-configurable sane constants (a configurable
+            // transfer timeout is a possible follow-up).
+            .tcp_user_timeout(TRANSFER_STALL_TIMEOUT)
+            .build()
+            .map_err(|e| S3Error::Transport {
+                op: "init",
+                detail: e.to_string(),
+            })?;
         Ok(Self {
             config,
             credentials,
@@ -1091,6 +1112,25 @@ mod tests {
             secret_access_key: "s".to_owned(),
         };
         assert!(S3Client::new(config, creds).is_err());
+    }
+
+    #[test]
+    fn client_builds_with_uncapped_transfer_timeouts() {
+        // The transfer client must construct with the overall timeout disabled
+        // (so multi-GB streams aren't capped) plus the connect/stall guards.
+        let config = S3Config {
+            bucket: "b".to_owned(),
+            region: "us-east-1".to_owned(),
+            endpoint: Some("https://minio.example:9000".to_owned()),
+            force_path_style: true,
+        };
+        let creds = S3Credentials {
+            access_key_id: "k".to_owned(),
+            secret_access_key: "s".to_owned(),
+        };
+        assert!(S3Client::new(config, creds).is_ok());
+        // Sanity-check the guard constants stay sane (fast connect, long stall).
+        assert!(TRANSFER_CONNECT_TIMEOUT < TRANSFER_STALL_TIMEOUT);
     }
 
     #[test]

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -4195,6 +4195,7 @@ pub fn check_compression_impl(compression_enabled: bool, is_production: bool) ->
 /// Config-presence view of `[backup.offsite]` for [`check_offsite_backup_impl`].
 /// Holds only names/booleans — never a credential value.
 #[derive(Debug, Clone, Default)]
+#[allow(clippy::struct_excessive_bools)] // a flat config-presence snapshot, not state
 pub struct OffsiteBackupData {
     /// A `[backup.offsite]` section is present.
     pub configured: bool,
@@ -4260,12 +4261,24 @@ pub fn check_offsite_backup_impl(data: &OffsiteBackupData) -> CheckResult {
     }
     // Credential indirection: the env-var NAMES must be configured AND present.
     let mut missing: Vec<&str> = Vec::new();
-    if data.access_key_env.as_deref().unwrap_or("").trim().is_empty() {
+    if data
+        .access_key_env
+        .as_deref()
+        .unwrap_or("")
+        .trim()
+        .is_empty()
+    {
         missing.push("backup.offsite.s3.access_key_id_env (name unset)");
     } else if !data.access_key_env_set {
         missing.push("access key env var is not set in the environment");
     }
-    if data.secret_key_env.as_deref().unwrap_or("").trim().is_empty() {
+    if data
+        .secret_key_env
+        .as_deref()
+        .unwrap_or("")
+        .trim()
+        .is_empty()
+    {
         missing.push("backup.offsite.s3.secret_access_key_env (name unset)");
     } else if !data.secret_key_env_set {
         missing.push("secret key env var is not set in the environment");
@@ -4332,9 +4345,7 @@ fn resolve_offsite_backup_data() -> OffsiteBackupData {
         secret_key_env: offsite.s3.secret_access_key_env.clone(),
         access_key_env_set: env_set(&offsite.s3.access_key_id_env),
         secret_key_env_set: env_set(&offsite.s3.secret_access_key_env),
-        shared_bucket_without_optin: same_bucket
-            && endpoints_match
-            && !offsite.allow_shared_bucket,
+        shared_bucket_without_optin: same_bucket && endpoints_match && !offsite.allow_shared_bucket,
     }
 }
 

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -4328,20 +4328,18 @@ fn resolve_offsite_backup_data() -> OffsiteBackupData {
             Err(_) => Box::new(autumn_web::config::OsEnv),
         };
     let bucket = offsite.s3.bucket.clone();
-    let endpoints_match = normalize_doctor_endpoint(offsite.s3.endpoint.as_deref())
-        == normalize_doctor_endpoint(cfg.storage.s3.endpoint.as_deref());
-    // P2 #17 (doctor twin of the runtime P2 #16 guard): the app's `[storage.s3]`
-    // bucket only counts as the shared-storage destination when the RESOLVED
-    // storage backend is actually S3. A stale `[storage.s3]` bucket left in config
-    // while the app runs on the local/disabled backend is inert — it is not where
-    // the app writes blobs — so it must not trip the shared-bucket failure (which
-    // would false-fail `autumn doctor --strict`).
+    // Evaluate the shared-bucket conflict with EXACTLY the runtime guard so doctor
+    // and the CLI never disagree: the app `[storage.s3]` bucket counts only when
+    // the resolved backend is actually S3 (P2 #16/#17), and buckets/endpoints are
+    // compared through backup.rs `destinations_conflict` + `canonical_authority`
+    // (P2 #19) — which collapses `None` and explicit `*.amazonaws.com` spellings.
     let storage_is_s3 = cfg.storage.backend == autumn_web::storage::StorageBackend::S3;
     let shares_app_bucket = offsite_shares_active_app_bucket(
         storage_is_s3,
         bucket.as_deref(),
+        offsite.s3.endpoint.as_deref(),
         cfg.storage.s3.bucket.as_deref(),
-        endpoints_match,
+        cfg.storage.s3.endpoint.as_deref(),
     );
     OffsiteBackupData {
         configured: true,
@@ -4360,17 +4358,19 @@ fn resolve_offsite_backup_data() -> OffsiteBackupData {
     }
 }
 
-/// Whether the offsite destination shares the app's ACTIVE S3 storage bucket
-/// (P2 #17, doctor twin of the runtime P2 #16 guard). The app's `[storage.s3]`
-/// bucket counts only when `storage_is_s3` (the resolved backend is S3); a stale
-/// bucket on a local/disabled backend is inert and never a shared-bucket
-/// conflict. When active, the buckets must match (trimmed, non-empty) AND the
-/// endpoints must be equivalent. Pure for credential-safe unit testing.
+/// Whether the offsite destination shares the app's ACTIVE S3 storage bucket,
+/// evaluated with EXACTLY the runtime CLI guard
+/// (`crate::db::backup::destinations_conflict`, including its `canonical_authority`
+/// endpoint canonicalization) so `doctor` can never pass a config the CLI refuses,
+/// nor flag one the CLI allows (issue #1619 P2 #19). The app bucket counts only
+/// when `storage_is_s3` (P2 #16/#17) — a stale `[storage.s3]` bucket on a
+/// local/disabled backend is inert. Pure for credential-safe unit testing.
 fn offsite_shares_active_app_bucket(
     storage_is_s3: bool,
     offsite_bucket: Option<&str>,
+    offsite_endpoint: Option<&str>,
     app_bucket: Option<&str>,
-    endpoints_match: bool,
+    app_endpoint: Option<&str>,
 ) -> bool {
     fn trimmed(b: Option<&str>) -> Option<&str> {
         b.map(str::trim).filter(|s| !s.is_empty())
@@ -4378,10 +4378,15 @@ fn offsite_shares_active_app_bucket(
     if !storage_is_s3 {
         return false;
     }
-    matches!(
-        (trimmed(offsite_bucket), trimmed(app_bucket)),
-        (Some(a), Some(b)) if a == b
-    ) && endpoints_match
+    let Some(offsite_bucket) = trimmed(offsite_bucket) else {
+        return false;
+    };
+    crate::db::backup::destinations_conflict(
+        offsite_bucket,
+        offsite_endpoint,
+        trimmed(app_bucket),
+        app_endpoint,
+    )
 }
 
 /// Whether the environment variable NAMED by `name` is present and non-empty in
@@ -4393,15 +4398,6 @@ fn cred_env_present(env: &dyn autumn_web::config::Env, name: Option<&str>) -> bo
     name.map(str::trim)
         .filter(|v| !v.is_empty())
         .is_some_and(|v| env.var(v).is_ok_and(|val| !val.is_empty()))
-}
-
-/// Normalize an endpoint for the doctor shared-bucket comparison.
-fn normalize_doctor_endpoint(endpoint: Option<&str>) -> String {
-    endpoint
-        .unwrap_or("")
-        .trim()
-        .trim_end_matches('/')
-        .to_ascii_lowercase()
 }
 
 /// Resolve `.env` filesystem state for [`check_dotenv_impl`].
@@ -5148,18 +5144,16 @@ mod tests {
     }
 
     #[test]
-    fn doctor_shared_bucket_only_flags_when_storage_backend_is_s3() {
-        // P2 #17 (doctor twin of P2 #16): a stale [storage.s3] bucket equal to the
-        // offsite bucket must NOT be flagged as shared unless the backend is S3 —
-        // otherwise `autumn doctor --strict` false-fails on a local/disabled app.
-
-        // backend=local/disabled (storage_is_s3=false): inert bucket, never shared
-        // — even with an identical bucket name and matching endpoints.
+    fn doctor_shared_bucket_matches_runtime_guard() {
+        // P2 #16/#17 backend gate: a stale [storage.s3] bucket equal to the offsite
+        // bucket must NOT flag shared unless the backend is S3 — otherwise
+        // `autumn doctor --strict` false-fails on a local/disabled app.
         assert!(!offsite_shares_active_app_bucket(
             false,
             Some("shared"),
+            None,
             Some("shared"),
-            true
+            None
         ));
         // Feeding that into the check: not shared → no --strict failure.
         let local_data = OffsiteBackupData {
@@ -5176,25 +5170,40 @@ mod tests {
             CheckStatus::Fail
         );
 
-        // backend=s3 (storage_is_s3=true): same bucket + same endpoint → shared.
+        // P2 #19: doctor must match the runtime `canonical_authority` guard — the
+        // app storage endpoint left None (AWS default) vs the offsite naming the
+        // SAME AWS bucket with an explicit AWS regional endpoint canonicalize equal,
+        // so doctor DETECTS the shared bucket (the CLI would `SharedBucketRefused`).
         assert!(offsite_shares_active_app_bucket(
             true,
             Some("shared"),
+            Some("https://s3.us-east-1.amazonaws.com"),
             Some("shared"),
-            true
+            None,
         ));
-        // Different bucket, or mismatched endpoint, is NOT shared even on S3.
+        // Both endpoints None (AWS default on both sides), same bucket → shared.
+        assert!(offsite_shares_active_app_bucket(
+            true,
+            Some("shared"),
+            None,
+            Some("shared"),
+            None
+        ));
+        // Different bucket → not shared even on S3.
         assert!(!offsite_shares_active_app_bucket(
             true,
             Some("offsite"),
+            None,
             Some("appbucket"),
-            true
+            None
         ));
+        // Genuinely different endpoints (AWS vs self-hosted MinIO) → not shared.
         assert!(!offsite_shares_active_app_bucket(
             true,
             Some("shared"),
+            Some("https://minio.example:9000"),
             Some("shared"),
-            false
+            None,
         ));
     }
 

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -55,6 +55,7 @@ const KNOWN_TOML_SECTIONS: &[&str] = &[
     "security",
     "i18n",
     "storage",
+    "backup",
     "mail",
     "profile",
     "compression",
@@ -4089,6 +4090,13 @@ pub fn run(opts: DoctorOptions) {
         check_dotenv_impl(dotenv_has_example, dotenv_has_env, &dotenv_uncovered)
     }));
 
+    // 12c. Offsite backup config presence (issue #1619): informational when
+    //      unconfigured; flags an unset bucket, a shared bucket without opt-in,
+    //      or credentials that aren't ready. Never prints credential values.
+    tasks.push(Box::new(|| {
+        check_offsite_backup_impl(&resolve_offsite_backup_data())
+    }));
+
     // 13. System-test browser (warn if missing; not all projects use system tests)
     tasks.push(Box::new(check_system_test_browser));
 
@@ -4182,6 +4190,161 @@ pub fn check_compression_impl(compression_enabled: bool, is_production: bool) ->
         }),
         hint: None,
     }
+}
+
+/// Config-presence view of `[backup.offsite]` for [`check_offsite_backup_impl`].
+/// Holds only names/booleans — never a credential value.
+#[derive(Debug, Clone, Default)]
+pub struct OffsiteBackupData {
+    /// A `[backup.offsite]` section is present.
+    pub configured: bool,
+    /// The offsite bucket, when set.
+    pub bucket: Option<String>,
+    /// The configured access-key env var NAME (not value), when set.
+    pub access_key_env: Option<String>,
+    /// The configured secret-key env var NAME (not value), when set.
+    pub secret_key_env: Option<String>,
+    /// Whether the named access-key env var is actually present in the env.
+    pub access_key_env_set: bool,
+    /// Whether the named secret-key env var is actually present in the env.
+    pub secret_key_env_set: bool,
+    /// The offsite destination equals the app `[storage.s3]` bucket+endpoint and
+    /// `allow_shared_bucket` was not set.
+    pub shared_bucket_without_optin: bool,
+}
+
+/// Config-presence check for offsite backups (issue #1619). Never prints a
+/// credential VALUE — only env-var names and the bucket. This is config-key
+/// doctoring, not an alerting check.
+#[must_use]
+pub fn check_offsite_backup_impl(data: &OffsiteBackupData) -> CheckResult {
+    const NAME: &str = "offsite_backup";
+    if !data.configured {
+        return CheckResult {
+            name: NAME,
+            status: CheckStatus::Pass,
+            detail: Some(
+                "no offsite backup destination configured (a backup on the same disk as the \
+                 database is not disaster recovery)"
+                    .into(),
+            ),
+            hint: Some(
+                "Add a [backup.offsite] section (see docs) and run `autumn db backup --upload` \
+                 to keep a verified copy off the server.",
+            ),
+        };
+    }
+    let Some(bucket) = data.bucket.as_deref().filter(|b| !b.trim().is_empty()) else {
+        return CheckResult {
+            name: NAME,
+            status: CheckStatus::Fail,
+            detail: Some(
+                "[backup.offsite] is configured but backup.offsite.s3.bucket is unset".into(),
+            ),
+            hint: Some("Set backup.offsite.s3.bucket to the offsite bucket name."),
+        };
+    };
+    if data.shared_bucket_without_optin {
+        return CheckResult {
+            name: NAME,
+            status: CheckStatus::Fail,
+            detail: Some(format!(
+                "offsite bucket {bucket:?} is the same as the app [storage.s3] bucket at the \
+                 same endpoint, without opt-in"
+            )),
+            hint: Some(
+                "Point the offsite backup at a distinct bucket, or set \
+                 backup.offsite.allow_shared_bucket = true to acknowledge the shared bucket.",
+            ),
+        };
+    }
+    // Credential indirection: the env-var NAMES must be configured AND present.
+    let mut missing: Vec<&str> = Vec::new();
+    if data.access_key_env.as_deref().unwrap_or("").trim().is_empty() {
+        missing.push("backup.offsite.s3.access_key_id_env (name unset)");
+    } else if !data.access_key_env_set {
+        missing.push("access key env var is not set in the environment");
+    }
+    if data.secret_key_env.as_deref().unwrap_or("").trim().is_empty() {
+        missing.push("backup.offsite.s3.secret_access_key_env (name unset)");
+    } else if !data.secret_key_env_set {
+        missing.push("secret key env var is not set in the environment");
+    }
+    if !missing.is_empty() {
+        return CheckResult {
+            name: NAME,
+            status: CheckStatus::Warn,
+            detail: Some(format!(
+                "offsite bucket {bucket:?} configured, but credentials are not ready: {}",
+                missing.join("; ")
+            )),
+            hint: Some(
+                "Set backup.offsite.s3.access_key_id_env / secret_access_key_env to env var \
+                 names, and export those variables with the S3 access key / secret.",
+            ),
+        };
+    }
+    CheckResult {
+        name: NAME,
+        status: CheckStatus::Pass,
+        detail: Some(format!(
+            "offsite backups configured (bucket {bucket:?}, credentials via env-var indirection)"
+        )),
+        hint: None,
+    }
+}
+
+/// Resolve [`OffsiteBackupData`] from the loaded config (profile + env layered).
+/// Best-effort: any config load error yields "not configured".
+fn resolve_offsite_backup_data() -> OffsiteBackupData {
+    let Ok(cfg) = autumn_web::config::AutumnConfig::load() else {
+        return OffsiteBackupData::default();
+    };
+    let Some(offsite) = cfg.backup.offsite else {
+        return OffsiteBackupData::default();
+    };
+    let env_set = |name: &Option<String>| {
+        name.as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .is_some_and(|v| std::env::var(v).is_ok_and(|val| !val.is_empty()))
+    };
+    let bucket = offsite.s3.bucket.clone();
+    let endpoints_match = normalize_doctor_endpoint(offsite.s3.endpoint.as_deref())
+        == normalize_doctor_endpoint(cfg.storage.s3.endpoint.as_deref());
+    let same_bucket = bucket
+        .as_deref()
+        .map(str::trim)
+        .filter(|b| !b.is_empty())
+        .is_some_and(|ob| {
+            cfg.storage
+                .s3
+                .bucket
+                .as_deref()
+                .map(str::trim)
+                .filter(|b| !b.is_empty())
+                == Some(ob)
+        });
+    OffsiteBackupData {
+        configured: true,
+        bucket,
+        access_key_env: offsite.s3.access_key_id_env.clone(),
+        secret_key_env: offsite.s3.secret_access_key_env.clone(),
+        access_key_env_set: env_set(&offsite.s3.access_key_id_env),
+        secret_key_env_set: env_set(&offsite.s3.secret_access_key_env),
+        shared_bucket_without_optin: same_bucket
+            && endpoints_match
+            && !offsite.allow_shared_bucket,
+    }
+}
+
+/// Normalize an endpoint for the doctor shared-bucket comparison.
+fn normalize_doctor_endpoint(endpoint: Option<&str>) -> String {
+    endpoint
+        .unwrap_or("")
+        .trim()
+        .trim_end_matches('/')
+        .to_ascii_lowercase()
 }
 
 /// Resolve `.env` filesystem state for [`check_dotenv_impl`].
@@ -4895,6 +5058,78 @@ fn parse_pub_field_name(line: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn offsite_backup_pass_when_unconfigured() {
+        let r = check_offsite_backup_impl(&OffsiteBackupData::default());
+        assert_eq!(r.status, CheckStatus::Pass);
+        assert!(r.detail.unwrap().contains("not disaster recovery"));
+    }
+
+    #[test]
+    fn offsite_backup_fail_when_bucket_unset() {
+        let data = OffsiteBackupData {
+            configured: true,
+            ..Default::default()
+        };
+        let r = check_offsite_backup_impl(&data);
+        assert_eq!(r.status, CheckStatus::Fail);
+        assert!(r.detail.unwrap().contains("bucket is unset"));
+    }
+
+    #[test]
+    fn offsite_backup_fail_on_shared_bucket_without_optin() {
+        let data = OffsiteBackupData {
+            configured: true,
+            bucket: Some("shared".to_owned()),
+            shared_bucket_without_optin: true,
+            ..Default::default()
+        };
+        let r = check_offsite_backup_impl(&data);
+        assert_eq!(r.status, CheckStatus::Fail);
+        assert!(r.detail.unwrap().contains("same as the app"));
+    }
+
+    #[test]
+    fn offsite_backup_warn_when_credentials_not_ready() {
+        // Bucket set, env var names configured, but the vars aren't exported.
+        let data = OffsiteBackupData {
+            configured: true,
+            bucket: Some("offsite".to_owned()),
+            access_key_env: Some("OFF_KEY".to_owned()),
+            secret_key_env: Some("OFF_SECRET".to_owned()),
+            access_key_env_set: false,
+            secret_key_env_set: false,
+            shared_bucket_without_optin: false,
+        };
+        let r = check_offsite_backup_impl(&data);
+        assert_eq!(r.status, CheckStatus::Warn);
+        // Names the situation, never a credential value.
+        let detail = r.detail.unwrap();
+        assert!(detail.contains("credentials are not ready"));
+        assert!(!detail.contains("supersecret"));
+    }
+
+    #[test]
+    fn offsite_backup_pass_when_ready() {
+        let data = OffsiteBackupData {
+            configured: true,
+            bucket: Some("offsite".to_owned()),
+            access_key_env: Some("OFF_KEY".to_owned()),
+            secret_key_env: Some("OFF_SECRET".to_owned()),
+            access_key_env_set: true,
+            secret_key_env_set: true,
+            shared_bucket_without_optin: false,
+        };
+        let r = check_offsite_backup_impl(&data);
+        assert_eq!(r.status, CheckStatus::Pass);
+        assert!(r.detail.unwrap().contains("offsite backups configured"));
+    }
+
+    #[test]
+    fn known_toml_sections_includes_backup() {
+        assert!(KNOWN_TOML_SECTIONS.contains(&"backup"));
+    }
 
     #[test]
     fn model_private_columns_pass_when_none_flagged() {

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -4330,19 +4330,19 @@ fn resolve_offsite_backup_data() -> OffsiteBackupData {
     let bucket = offsite.s3.bucket.clone();
     let endpoints_match = normalize_doctor_endpoint(offsite.s3.endpoint.as_deref())
         == normalize_doctor_endpoint(cfg.storage.s3.endpoint.as_deref());
-    let same_bucket = bucket
-        .as_deref()
-        .map(str::trim)
-        .filter(|b| !b.is_empty())
-        .is_some_and(|ob| {
-            cfg.storage
-                .s3
-                .bucket
-                .as_deref()
-                .map(str::trim)
-                .filter(|b| !b.is_empty())
-                == Some(ob)
-        });
+    // P2 #17 (doctor twin of the runtime P2 #16 guard): the app's `[storage.s3]`
+    // bucket only counts as the shared-storage destination when the RESOLVED
+    // storage backend is actually S3. A stale `[storage.s3]` bucket left in config
+    // while the app runs on the local/disabled backend is inert — it is not where
+    // the app writes blobs — so it must not trip the shared-bucket failure (which
+    // would false-fail `autumn doctor --strict`).
+    let storage_is_s3 = cfg.storage.backend == autumn_web::storage::StorageBackend::S3;
+    let shares_app_bucket = offsite_shares_active_app_bucket(
+        storage_is_s3,
+        bucket.as_deref(),
+        cfg.storage.s3.bucket.as_deref(),
+        endpoints_match,
+    );
     OffsiteBackupData {
         configured: true,
         bucket,
@@ -4356,8 +4356,32 @@ fn resolve_offsite_backup_data() -> OffsiteBackupData {
             denv.as_ref(),
             offsite.s3.secret_access_key_env.as_deref(),
         ),
-        shared_bucket_without_optin: same_bucket && endpoints_match && !offsite.allow_shared_bucket,
+        shared_bucket_without_optin: shares_app_bucket && !offsite.allow_shared_bucket,
     }
+}
+
+/// Whether the offsite destination shares the app's ACTIVE S3 storage bucket
+/// (P2 #17, doctor twin of the runtime P2 #16 guard). The app's `[storage.s3]`
+/// bucket counts only when `storage_is_s3` (the resolved backend is S3); a stale
+/// bucket on a local/disabled backend is inert and never a shared-bucket
+/// conflict. When active, the buckets must match (trimmed, non-empty) AND the
+/// endpoints must be equivalent. Pure for credential-safe unit testing.
+fn offsite_shares_active_app_bucket(
+    storage_is_s3: bool,
+    offsite_bucket: Option<&str>,
+    app_bucket: Option<&str>,
+    endpoints_match: bool,
+) -> bool {
+    fn trimmed(b: Option<&str>) -> Option<&str> {
+        b.map(str::trim).filter(|s| !s.is_empty())
+    }
+    if !storage_is_s3 {
+        return false;
+    }
+    matches!(
+        (trimmed(offsite_bucket), trimmed(app_bucket)),
+        (Some(a), Some(b)) if a == b
+    ) && endpoints_match
 }
 
 /// Whether the environment variable NAMED by `name` is present and non-empty in
@@ -5121,6 +5145,57 @@ mod tests {
         let r = check_offsite_backup_impl(&data);
         assert_eq!(r.status, CheckStatus::Fail);
         assert!(r.detail.unwrap().contains("same as the app"));
+    }
+
+    #[test]
+    fn doctor_shared_bucket_only_flags_when_storage_backend_is_s3() {
+        // P2 #17 (doctor twin of P2 #16): a stale [storage.s3] bucket equal to the
+        // offsite bucket must NOT be flagged as shared unless the backend is S3 —
+        // otherwise `autumn doctor --strict` false-fails on a local/disabled app.
+
+        // backend=local/disabled (storage_is_s3=false): inert bucket, never shared
+        // — even with an identical bucket name and matching endpoints.
+        assert!(!offsite_shares_active_app_bucket(
+            false,
+            Some("shared"),
+            Some("shared"),
+            true
+        ));
+        // Feeding that into the check: not shared → no --strict failure.
+        let local_data = OffsiteBackupData {
+            configured: true,
+            bucket: Some("shared".to_owned()),
+            access_key_env: Some("K".to_owned()),
+            secret_key_env: Some("S".to_owned()),
+            access_key_env_set: true,
+            secret_key_env_set: true,
+            shared_bucket_without_optin: false, // gated off by backend != S3
+        };
+        assert_ne!(
+            check_offsite_backup_impl(&local_data).status,
+            CheckStatus::Fail
+        );
+
+        // backend=s3 (storage_is_s3=true): same bucket + same endpoint → shared.
+        assert!(offsite_shares_active_app_bucket(
+            true,
+            Some("shared"),
+            Some("shared"),
+            true
+        ));
+        // Different bucket, or mismatched endpoint, is NOT shared even on S3.
+        assert!(!offsite_shares_active_app_bucket(
+            true,
+            Some("offsite"),
+            Some("appbucket"),
+            true
+        ));
+        assert!(!offsite_shares_active_app_bucket(
+            true,
+            Some("shared"),
+            Some("shared"),
+            false
+        ));
     }
 
     #[test]

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -4316,12 +4316,17 @@ fn resolve_offsite_backup_data() -> OffsiteBackupData {
     let Some(offsite) = cfg.backup.offsite else {
         return OffsiteBackupData::default();
     };
-    let env_set = |name: &Option<String>| {
-        name.as_deref()
-            .map(str::trim)
-            .filter(|v| !v.is_empty())
-            .is_some_and(|v| std::env::var(v).is_ok_and(|val| !val.is_empty()))
-    };
+    // Check credential presence through the SAME dotenv-aware, profile-aware
+    // env `resolve_credentials` uses at runtime — real env layered with
+    // `.env`/`.env.<profile>` — so a credential supplied via `.env.<profile>`
+    // isn't a false "not ready" (issue #1619 P2 #10). Falls back to the plain
+    // OS env only if the `.env` overlay can't be built (a malformed `.env`).
+    let profile = cfg.profile.clone().unwrap_or_else(|| "dev".to_owned());
+    let denv: Box<dyn autumn_web::config::Env> =
+        match autumn_web::dotenv::os_env_with_dotenv_for_profile(&profile) {
+            Ok(e) => Box::new(e),
+            Err(_) => Box::new(autumn_web::config::OsEnv),
+        };
     let bucket = offsite.s3.bucket.clone();
     let endpoints_match = normalize_doctor_endpoint(offsite.s3.endpoint.as_deref())
         == normalize_doctor_endpoint(cfg.storage.s3.endpoint.as_deref());
@@ -4343,10 +4348,27 @@ fn resolve_offsite_backup_data() -> OffsiteBackupData {
         bucket,
         access_key_env: offsite.s3.access_key_id_env.clone(),
         secret_key_env: offsite.s3.secret_access_key_env.clone(),
-        access_key_env_set: env_set(&offsite.s3.access_key_id_env),
-        secret_key_env_set: env_set(&offsite.s3.secret_access_key_env),
+        access_key_env_set: cred_env_present(
+            denv.as_ref(),
+            offsite.s3.access_key_id_env.as_deref(),
+        ),
+        secret_key_env_set: cred_env_present(
+            denv.as_ref(),
+            offsite.s3.secret_access_key_env.as_deref(),
+        ),
         shared_bucket_without_optin: same_bucket && endpoints_match && !offsite.allow_shared_bucket,
     }
+}
+
+/// Whether the environment variable NAMED by `name` is present and non-empty in
+/// `env`. Uses the passed `Env` (the profile-aware dotenv overlay) rather than
+/// bare `std::env`, so doctor's offsite-credential readiness matches runtime
+/// resolution (which also reads `.env`/`.env.<profile>`), issue #1619 P2 #10.
+/// Presence only — never returns or logs the value.
+fn cred_env_present(env: &dyn autumn_web::config::Env, name: Option<&str>) -> bool {
+    name.map(str::trim)
+        .filter(|v| !v.is_empty())
+        .is_some_and(|v| env.var(v).is_ok_and(|val| !val.is_empty()))
 }
 
 /// Normalize an endpoint for the doctor shared-bucket comparison.
@@ -5135,6 +5157,22 @@ mod tests {
         let r = check_offsite_backup_impl(&data);
         assert_eq!(r.status, CheckStatus::Pass);
         assert!(r.detail.unwrap().contains("offsite backups configured"));
+    }
+
+    #[test]
+    fn cred_env_present_honors_dotenv_supplied_creds() {
+        // P2 #10: readiness is checked through the profile-aware env overlay
+        // (real env + `.env.<profile>`), so a credential supplied ONLY via
+        // `.env.prod` (here simulated by the overlay surfacing the value) counts
+        // as ready — a bare `std::env::var` check would report a false negative.
+        let overlay = autumn_web::config::MockEnv::new().with("OFF_SECRET", "from-dot-env-prod");
+        assert!(cred_env_present(&overlay, Some("OFF_SECRET")));
+        // Absent / unnamed / blank-name / empty-value => not present.
+        assert!(!cred_env_present(&overlay, Some("MISSING")));
+        assert!(!cred_env_present(&overlay, None));
+        assert!(!cred_env_present(&overlay, Some("   ")));
+        let empty = autumn_web::config::MockEnv::new().with("OFF_SECRET", "");
+        assert!(!cred_env_present(&empty, Some("OFF_SECRET")));
     }
 
     #[test]

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1061,13 +1061,8 @@ impl DbCommands {
             Self::Create { profile } => (db::DbCommand::Create, profile),
             Self::Drop { profile, force } => (db::DbCommand::Drop { force }, profile),
             Self::Reset { profile, force } => (db::DbCommand::Reset { force }, profile),
-            Self::Pull { .. }
-            | Self::Backup { .. }
-            | Self::Restore { .. }
-            | Self::Offsite(_) => {
-                unreachable!(
-                    "db pull/backup/restore/offsite are dispatched before into_command"
-                )
+            Self::Pull { .. } | Self::Backup { .. } | Self::Restore { .. } | Self::Offsite(_) => {
+                unreachable!("db pull/backup/restore/offsite are dispatched before into_command")
             }
         }
     }
@@ -4696,7 +4691,10 @@ mod tests {
         ])
         .unwrap();
         let Commands::Db(DbCommands::Restore {
-            artifact, offsite, force, ..
+            artifact,
+            offsite,
+            force,
+            ..
         }) = cli.command
         else {
             panic!("expected db restore");

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1001,6 +1001,11 @@ enum DbCommands {
         /// Back up only the control database (skip shards).
         #[arg(long)]
         control_only: bool,
+        /// After local verification + prune, upload the run to the configured
+        /// offsite destination ([backup.offsite]) and verify each remote object
+        /// (issue #1619). Also enabled by backup.offsite.auto_upload = true.
+        #[arg(long)]
+        upload: bool,
     },
     /// Restore the configured database(s) from a backup artifact.
     ///
@@ -1010,7 +1015,9 @@ enum DbCommands {
     /// guard as `autumn db drop` (refuses non-dev/test profiles without `--force`).
     #[command(verbatim_doc_comment)]
     Restore {
-        /// Path to the backup run directory or artifact file to restore.
+        /// Path to the backup run directory or artifact file to restore — or an
+        /// offsite reference `offsite:<profile>/<timestamp|latest>` (see
+        /// `--offsite`).
         #[arg(value_name = "ARTIFACT")]
         artifact: std::path::PathBuf,
         /// Resolve the connection through a profile overlay (see `db create`).
@@ -1022,6 +1029,25 @@ enum DbCommands {
         /// Restore only this shard from the artifact.
         #[arg(long, value_name = "NAME")]
         shard: Option<String>,
+        /// Restore from the offsite destination: interpret ARTIFACT as
+        /// `<profile>/<timestamp|latest>` and download the run before restoring
+        /// (issue #1619). An `offsite:` prefix on ARTIFACT implies this.
+        #[arg(long)]
+        offsite: bool,
+    },
+    /// Inspect the offsite backup destination ([backup.offsite], issue #1619).
+    #[command(subcommand)]
+    Offsite(OffsiteCommands),
+}
+
+/// Subcommands for `autumn db offsite` (issue #1619).
+#[derive(Subcommand)]
+enum OffsiteCommands {
+    /// List offsite backups for the active profile (timestamp, size, files).
+    List {
+        /// Resolve the destination under a profile overlay (see `db create`).
+        #[arg(long, value_name = "PROFILE")]
+        profile: Option<String>,
     },
 }
 
@@ -1035,8 +1061,13 @@ impl DbCommands {
             Self::Create { profile } => (db::DbCommand::Create, profile),
             Self::Drop { profile, force } => (db::DbCommand::Drop { force }, profile),
             Self::Reset { profile, force } => (db::DbCommand::Reset { force }, profile),
-            Self::Pull { .. } | Self::Backup { .. } | Self::Restore { .. } => {
-                unreachable!("db pull/backup/restore are dispatched before into_command")
+            Self::Pull { .. }
+            | Self::Backup { .. }
+            | Self::Restore { .. }
+            | Self::Offsite(_) => {
+                unreachable!(
+                    "db pull/backup/restore/offsite are dispatched before into_command"
+                )
             }
         }
     }
@@ -2368,6 +2399,7 @@ fn run_command(command: Commands) {
                 keep,
                 shard,
                 control_only,
+                upload,
             } => {
                 let format = match db::backup::BackupFormat::parse(&format) {
                     Ok(f) => f,
@@ -2387,6 +2419,7 @@ fn run_command(command: Commands) {
                     format,
                     keep,
                     target,
+                    upload,
                 });
             }
             DbCommands::Restore {
@@ -2394,12 +2427,17 @@ fn run_command(command: Commands) {
                 profile,
                 force,
                 shard,
+                offsite,
             } => db::backup::run_restore(&db::backup::RestoreArgs {
                 artifact,
                 profile,
                 force,
                 shard,
+                offsite,
             }),
+            DbCommands::Offsite(OffsiteCommands::List { profile }) => {
+                db::backup::run_offsite_list(profile.as_deref());
+            }
             other => {
                 let (command, profile) = other.into_command();
                 db::run(&command, profile.as_deref());
@@ -4538,6 +4576,7 @@ mod tests {
             keep,
             shard,
             control_only,
+            upload,
         }) = cli.command
         else {
             panic!("expected db backup");
@@ -4548,6 +4587,7 @@ mod tests {
         assert!(keep.is_none());
         assert!(shard.is_none());
         assert!(!control_only);
+        assert!(!upload);
     }
 
     #[test]
@@ -4566,6 +4606,7 @@ mod tests {
             "7",
             "--shard",
             "east",
+            "--upload",
         ])
         .unwrap();
         let Commands::Db(DbCommands::Backup {
@@ -4575,6 +4616,7 @@ mod tests {
             keep,
             shard,
             control_only,
+            upload,
         }) = cli.command
         else {
             panic!("expected db backup");
@@ -4585,6 +4627,7 @@ mod tests {
         assert_eq!(keep, Some(7));
         assert_eq!(shard.as_deref(), Some("east"));
         assert!(!control_only);
+        assert!(upload);
     }
 
     #[test]
@@ -4626,6 +4669,7 @@ mod tests {
             profile,
             force,
             shard,
+            offsite,
         }) = cli.command
         else {
             panic!("expected db restore");
@@ -4637,6 +4681,40 @@ mod tests {
         assert_eq!(profile.as_deref(), Some("prod"));
         assert!(force);
         assert_eq!(shard.as_deref(), Some("east"));
+        assert!(!offsite);
+    }
+
+    #[test]
+    fn parse_db_restore_offsite_flag() {
+        let cli = Cli::try_parse_from([
+            "autumn",
+            "db",
+            "restore",
+            "prod/latest",
+            "--offsite",
+            "--force",
+        ])
+        .unwrap();
+        let Commands::Db(DbCommands::Restore {
+            artifact, offsite, force, ..
+        }) = cli.command
+        else {
+            panic!("expected db restore");
+        };
+        assert_eq!(artifact, std::path::PathBuf::from("prod/latest"));
+        assert!(offsite);
+        assert!(force);
+    }
+
+    #[test]
+    fn parse_db_offsite_list() {
+        let cli =
+            Cli::try_parse_from(["autumn", "db", "offsite", "list", "--profile", "prod"]).unwrap();
+        let Commands::Db(DbCommands::Offsite(OffsiteCommands::List { profile })) = cli.command
+        else {
+            panic!("expected db offsite list");
+        };
+        assert_eq!(profile.as_deref(), Some("prod"));
     }
 
     // ── autumn seed tests ──────────────────────────────────────────────────

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -850,6 +850,25 @@ pub fn is_production_profile_name(profile: &str) -> bool {
     normalized == "prod" || normalized == "production"
 }
 
+/// Normalize a profile name to its canonical spelling — the SAME mapping the
+/// runtime config loader applies (`autumn_web::config`'s `normalize_profile_name`):
+/// `production`/`prod` (any case) → `prod`, `development`/`dev` (any case) → `dev`,
+/// custom names preserved (trimmed, case kept). Reused so an offsite
+/// `.env.<profile>` / `[profile.<p>]` selection matches the app's resolved profile
+/// even when the operator writes `--profile development` / `AUTUMN_ENV=PROD`
+/// (issue #1619 P2 #20).
+#[must_use]
+pub fn canonical_profile(profile: &str) -> String {
+    let trimmed = profile.trim();
+    if trimmed.eq_ignore_ascii_case("production") || trimmed.eq_ignore_ascii_case("prod") {
+        "prod".to_owned()
+    } else if trimmed.eq_ignore_ascii_case("development") || trimmed.eq_ignore_ascii_case("dev") {
+        "dev".to_owned()
+    } else {
+        trimmed.to_owned()
+    }
+}
+
 /// Profile name spellings to probe for inline `[profile.<name>]` sections,
 /// mirroring `autumn_web::config::profile_lookup_names`'s alias handling so
 /// `prod`/`production` and `dev`/`development` are interchangeable. Matching is
@@ -2256,6 +2275,21 @@ mod tests {
                 assert_eq!(effective_profile(None), "prod");
             },
         );
+    }
+
+    #[test]
+    fn canonical_profile_normalizes_aliases_and_case() {
+        // P2 #20: offsite `.env.<profile>` selection must use the app's canonical
+        // profile, so alias/case spellings collapse the same way the loader does.
+        for input in ["development", "Development", "DEV", "dev", "  dev  "] {
+            assert_eq!(canonical_profile(input), "dev", "{input:?}");
+        }
+        for input in ["production", "PROD", "Prod", "prod"] {
+            assert_eq!(canonical_profile(input), "prod", "{input:?}");
+        }
+        // Custom profiles are preserved verbatim (trimmed, case kept).
+        assert_eq!(canonical_profile("staging"), "staging");
+        assert_eq!(canonical_profile("  QA  "), "QA");
     }
 
     #[test]

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -902,10 +902,42 @@ pub fn read_autumn_toml_table_with_profile(profile: Option<&str>) -> Option<toml
     read_autumn_toml_table_with_profile_in(Path::new("."), profile)
 }
 
+/// Like [`read_autumn_toml_table_with_profile`], but resolves `autumn.toml` from
+/// the SAME base directory the full `AutumnConfig::load` uses
+/// (`find_config_file_named`): `AUTUMN_MANIFEST_DIR` when it holds an
+/// `autumn.toml`, otherwise the process CWD. Installed/daemon launches (config in
+/// the manifest/config dir, a different CWD) can therefore resolve offsite
+/// settings that a bare CWD read would miss — matching where the full loader and
+/// the profile-aware dotenv overlay already look (issue #1619 P2 #15).
+pub fn read_autumn_toml_table_with_profile_from_config_dir(
+    profile: Option<&str>,
+) -> Option<toml::Table> {
+    read_autumn_toml_table_with_profile_in(&autumn_toml_base_dir(), profile)
+}
+
+/// The directory to read `autumn.toml` from, mirroring the config loader's
+/// `find_config_file_named`: `AUTUMN_MANIFEST_DIR` when that directory actually
+/// contains an `autumn.toml`, otherwise `.` (the process CWD).
+fn autumn_toml_base_dir() -> std::path::PathBuf {
+    autumn_toml_base_dir_from(std::env::var("AUTUMN_MANIFEST_DIR").ok().as_deref())
+}
+
+/// Directory-parameterized core of [`autumn_toml_base_dir`], separated so the
+/// `AUTUMN_MANIFEST_DIR` resolution is unit-testable without mutating process env.
+fn autumn_toml_base_dir_from(manifest_dir: Option<&str>) -> std::path::PathBuf {
+    if let Some(dir) = manifest_dir.map(str::trim).filter(|d| !d.is_empty()) {
+        let dir = Path::new(dir);
+        if dir.join("autumn.toml").exists() {
+            return dir.to_path_buf();
+        }
+    }
+    std::path::PathBuf::from(".")
+}
+
 /// Directory-parameterized core of [`read_autumn_toml_table_with_profile`],
 /// separated so the overlay-merge behavior is unit-testable without mutating
 /// the process-global current directory.
-fn read_autumn_toml_table_with_profile_in(
+pub fn read_autumn_toml_table_with_profile_in(
     dir: &Path,
     profile: Option<&str>,
 ) -> Option<toml::Table> {
@@ -3041,6 +3073,57 @@ primary_url = "postgres://prod-s0:5432/app"
             resolve_primary_database_url_from_sources(no_env, Some(&base)).as_deref(),
             Some("postgres://base-control:5432/app")
         );
+    }
+
+    #[test]
+    fn autumn_toml_base_dir_prefers_manifest_dir_with_config() {
+        // P2 #15: when AUTUMN_MANIFEST_DIR holds an autumn.toml, offsite TOML
+        // reads must resolve from THAT directory (like the full loader), not CWD.
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("autumn.toml"), "[backup.offsite]\n").unwrap();
+        assert_eq!(
+            autumn_toml_base_dir_from(Some(tmp.path().to_str().unwrap())),
+            tmp.path()
+        );
+    }
+
+    #[test]
+    fn autumn_toml_base_dir_falls_back_to_cwd() {
+        // No manifest dir, or a manifest dir WITHOUT an autumn.toml → CWD (".").
+        assert_eq!(
+            autumn_toml_base_dir_from(None),
+            std::path::PathBuf::from(".")
+        );
+        assert_eq!(
+            autumn_toml_base_dir_from(Some("   ")),
+            std::path::PathBuf::from(".")
+        );
+        let empty = tempfile::TempDir::new().unwrap();
+        assert_eq!(
+            autumn_toml_base_dir_from(Some(empty.path().to_str().unwrap())),
+            std::path::PathBuf::from(".")
+        );
+    }
+
+    #[test]
+    fn config_dir_read_surfaces_offsite_section() {
+        // The manifest-dir read must carry the [backup.offsite] section (with the
+        // profile overlay applied) so offsite resolution + auto_upload work when
+        // the config lives outside CWD.
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join("autumn.toml"),
+            "[backup.offsite]\nauto_upload = true\nprefix = \"db\"\n",
+        )
+        .unwrap();
+        let table = read_autumn_toml_table_with_profile_in(tmp.path(), Some("dev"))
+            .expect("manifest-dir autumn.toml should read");
+        let auto_upload = table
+            .get("backup")
+            .and_then(|v| v.get("offsite"))
+            .and_then(|v| v.get("auto_upload"))
+            .and_then(toml::Value::as_bool);
+        assert_eq!(auto_upload, Some(true));
     }
 
     #[test]

--- a/autumn-cli/tests/integration/mod.rs
+++ b/autumn-cli/tests/integration/mod.rs
@@ -6,6 +6,7 @@ mod generate_tauri_mobile;
 mod generate_tauri_mobile_offline;
 mod i18n_check;
 mod migrate_down;
+mod offsite_backup;
 mod repo_hygiene;
 mod scaffold_belongs_to;
 mod scaffold_form_for;

--- a/autumn-cli/tests/integration/offsite_backup.rs
+++ b/autumn-cli/tests/integration/offsite_backup.rs
@@ -116,6 +116,80 @@ async fn create_bucket(endpoint: &str, access: &str, secret: &str, region: &str,
     );
 }
 
+/// Sign and send an arbitrary S3 request (test-only `SigV4`), returning the
+/// response. `canonical_query` must already be canonical (sorted + encoded).
+/// Used to observe the stored object out-of-band (list keys, HEAD for the `ETag`).
+async fn signed_request(
+    method: reqwest::Method,
+    url: &str,
+    canonical_path: &str,
+    canonical_query: &str,
+    access: &str,
+    secret: &str,
+    region: &str,
+) -> reqwest::Response {
+    let now = chrono::Utc::now();
+    let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
+    let date = now.format("%Y%m%d").to_string();
+    let payload_hash = sha256_hex(b"");
+    let parsed = url::Url::parse(url).unwrap();
+    let host_str = parsed.host_str().unwrap().to_owned();
+    let host = parsed
+        .port()
+        .map_or_else(|| host_str.clone(), |p| format!("{host_str}:{p}"));
+    let canonical_headers =
+        format!("host:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{amz_date}\n");
+    let signed_headers = "host;x-amz-content-sha256;x-amz-date";
+    let canonical = format!(
+        "{}\n{canonical_path}\n{canonical_query}\n{canonical_headers}\n{signed_headers}\n{payload_hash}",
+        method.as_str()
+    );
+    let scope = format!("{date}/{region}/s3/aws4_request");
+    let sts = format!(
+        "AWS4-HMAC-SHA256\n{amz_date}\n{scope}\n{}",
+        sha256_hex(canonical.as_bytes())
+    );
+    let k = hmac(format!("AWS4{secret}").as_bytes(), date.as_bytes());
+    let k = hmac(&k, region.as_bytes());
+    let k = hmac(&k, b"s3");
+    let k = hmac(&k, b"aws4_request");
+    let signature = hex::encode(hmac(&k, sts.as_bytes()));
+    let authorization = format!(
+        "AWS4-HMAC-SHA256 Credential={access}/{scope}, SignedHeaders={signed_headers}, \
+         Signature={signature}"
+    );
+    let full = if canonical_query.is_empty() {
+        url.to_owned()
+    } else {
+        format!("{url}?{canonical_query}")
+    };
+    reqwest::Client::new()
+        .request(method, full)
+        .header("x-amz-date", &amz_date)
+        .header("x-amz-content-sha256", &payload_hash)
+        .header("authorization", authorization)
+        .send()
+        .await
+        .expect("signed request")
+}
+
+/// Deterministic, incompressible bytes: a SHA-256 keystream, so a Postgres custom
+/// dump of this data does NOT shrink under compression and reliably exceeds the
+/// multipart part size (proving the multipart path, not a single PUT).
+fn incompressible_bytes(len: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(len);
+    let mut counter: u64 = 0;
+    while out.len() < len {
+        let mut h = Sha256::new();
+        h.update(b"autumn-multipart-seed");
+        h.update(counter.to_le_bytes());
+        out.extend_from_slice(&h.finalize());
+        counter += 1;
+    }
+    out.truncate(len);
+    out
+}
+
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers: postgres+minio) and pg_dump/pg_restore on PATH"]
 async fn offsite_backup_upload_then_restore_round_trips() {
@@ -236,4 +310,189 @@ async fn offsite_backup_upload_then_restore_round_trips() {
         ],
         "restored rows must equal the seed"
     );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers: postgres+minio) and pg_dump/pg_restore on PATH"]
+#[allow(clippy::too_many_lines)]
+async fn offsite_backup_uploads_large_artifact_via_multipart() {
+    use testcontainers::runners::AsyncRunner as _;
+    use testcontainers_modules::minio::MinIO;
+    use testcontainers_modules::postgres::Postgres;
+    use tokio_postgres::NoTls;
+
+    // ── Containers ───────────────────────────────────────────────────────────
+    let pg = Postgres::default()
+        .start()
+        .await
+        .expect("start Postgres — is Docker running?");
+    let pg_host = pg.get_host().await.unwrap();
+    let pg_port = pg.get_host_port_ipv4(5432).await.unwrap();
+    let db_url = format!("postgres://postgres:postgres@{pg_host}:{pg_port}/postgres");
+
+    let minio = MinIO::default()
+        .start()
+        .await
+        .expect("start MinIO — is Docker running?");
+    let minio_host = minio.get_host().await.unwrap();
+    let minio_port = minio.get_host_port_ipv4(9000).await.unwrap();
+    let endpoint = format!("http://{minio_host}:{minio_port}");
+    let access = "minioadmin";
+    let secret = "minioadmin";
+    let region = "us-east-1";
+    let bucket = "autumn-offsite-mp-it";
+
+    create_bucket(&endpoint, access, secret, region, bucket).await;
+
+    // ── Seed ~12 MiB of incompressible bytea so the custom-format dump stays
+    //    large enough to split into 3 parts at a 5 MiB part size. ──────────────
+    let (client, conn) = tokio_postgres::connect(&db_url, NoTls).await.unwrap();
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    client
+        .batch_execute(
+            "DROP TABLE IF EXISTS offsite_big; \
+             CREATE TABLE offsite_big (id INT PRIMARY KEY, blob BYTEA NOT NULL);",
+        )
+        .await
+        .unwrap();
+    // 12 rows × 1 MiB = ~12 MiB incompressible → 3 parts at 5 MiB/part.
+    for id in 0..12i32 {
+        let blob = incompressible_bytes(1024 * 1024);
+        client
+            .execute(
+                "INSERT INTO offsite_big (id, blob) VALUES ($1, $2)",
+                &[&id, &blob],
+            )
+            .await
+            .unwrap();
+    }
+
+    // ── Project dir with an offsite destination ──────────────────────────────
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    std::fs::write(
+        dir.join("autumn.toml"),
+        format!(
+            "[backup.offsite]\n\
+             prefix = \"db\"\n\
+             [backup.offsite.s3]\n\
+             bucket = \"{bucket}\"\n\
+             region = \"{region}\"\n\
+             endpoint = \"{endpoint}\"\n\
+             force_path_style = true\n\
+             access_key_id_env = \"AUTUMN_OFFSITE_KEY\"\n\
+             secret_access_key_env = \"AUTUMN_OFFSITE_SECRET\"\n"
+        ),
+    )
+    .unwrap();
+
+    let envs = [
+        ("AUTUMN_DATABASE__URL", db_url.as_str()),
+        ("AUTUMN_OFFSITE_KEY", access),
+        ("AUTUMN_OFFSITE_SECRET", secret),
+        // Force the multipart path with a 5 MiB part size (S3's minimum) so a
+        // ~12 MiB dump splits into 3 parts without needing a multi-GB fixture.
+        ("AUTUMN_OFFSITE_MULTIPART_PART_SIZE_BYTES", "5242880"),
+    ];
+
+    // ── Backup + upload (multipart) ──────────────────────────────────────────
+    let (_out, stderr) = run_autumn_ok(dir, &["db", "backup", "--upload"], &envs);
+    assert!(
+        stderr.contains("Offsite upload verified"),
+        "multipart upload should verify: {stderr}"
+    );
+
+    // ── Find the uploaded control.dump key via a signed ListObjectsV2 ─────────
+    let list_query = format!(
+        "list-type=2&prefix={}",
+        // prefix "db/" — encode the slash for the query.
+        "db%2F"
+    );
+    let list_resp = signed_request(
+        reqwest::Method::GET,
+        &format!("{endpoint}/{bucket}"),
+        &format!("/{bucket}"),
+        &list_query,
+        access,
+        secret,
+        region,
+    )
+    .await;
+    assert!(list_resp.status().is_success(), "list status");
+    let list_body = list_resp.text().await.unwrap();
+    // Grab the control.dump <Key> from the listing.
+    let dump_key = list_body
+        .split("<Key>")
+        .filter_map(|seg| seg.split("</Key>").next())
+        .find(|k| k.ends_with("control.dump"))
+        .expect("control.dump key present in listing")
+        .to_owned();
+
+    // ── HEAD it: a multipart object's ETag is `<md5>-<partcount>`; assert 3. ──
+    let encoded_key = dump_key
+        .split('/')
+        .map(urlencode_segment)
+        .collect::<Vec<_>>()
+        .join("/");
+    let head_resp = signed_request(
+        reqwest::Method::HEAD,
+        &format!("{endpoint}/{bucket}/{encoded_key}"),
+        &format!("/{bucket}/{encoded_key}"),
+        "",
+        access,
+        secret,
+        region,
+    )
+    .await;
+    assert!(head_resp.status().is_success(), "head status");
+    let etag = head_resp
+        .headers()
+        .get(reqwest::header::ETAG)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_owned();
+    assert!(
+        etag.trim_matches('"').ends_with("-3"),
+        "multipart ETag should carry a -3 part-count suffix, got {etag:?}"
+    );
+
+    // ── And the DR loop still works end-to-end (restore equality). ───────────
+    std::fs::remove_dir_all(dir.join("backups")).ok();
+    client
+        .batch_execute("DELETE FROM offsite_big;")
+        .await
+        .unwrap();
+    let (_o, restore_err) = run_autumn_ok(dir, &["db", "restore", "offsite:dev/latest"], &envs);
+    assert!(
+        restore_err.contains("Restore complete"),
+        "restore of the multipart artifact should complete: {restore_err}"
+    );
+    let count: i64 = client
+        .query_one("SELECT COUNT(*) FROM offsite_big", &[])
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(
+        count, 12,
+        "all seeded rows must be restored from the multipart object"
+    );
+}
+
+/// AWS-URI-encode one path segment (unreserved pass through, else `%XX`).
+fn urlencode_segment(seg: &str) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::with_capacity(seg.len());
+    for &b in seg.as_bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(b as char);
+            }
+            _ => {
+                let _ = write!(out, "%{b:02X}");
+            }
+        }
+    }
+    out
 }

--- a/autumn-cli/tests/integration/offsite_backup.rs
+++ b/autumn-cli/tests/integration/offsite_backup.rs
@@ -77,17 +77,15 @@ async fn create_bucket(endpoint: &str, access: &str, secret: &str, region: &str,
     let date = now.format("%Y%m%d").to_string();
     let payload_hash = sha256_hex(b"");
     let url = url::Url::parse(endpoint).unwrap();
-    let host = match url.port() {
-        Some(p) => format!("{}:{p}", url.host_str().unwrap()),
-        None => url.host_str().unwrap().to_owned(),
-    };
-    let canonical_headers = format!(
-        "host:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{amz_date}\n"
-    );
+    let host_str = url.host_str().unwrap().to_owned();
+    let host = url
+        .port()
+        .map_or_else(|| host_str.clone(), |p| format!("{host_str}:{p}"));
+    let canonical_headers =
+        format!("host:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{amz_date}\n");
     let signed_headers = "host;x-amz-content-sha256;x-amz-date";
-    let canonical = format!(
-        "PUT\n/{bucket}\n\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
-    );
+    let canonical =
+        format!("PUT\n/{bucket}\n\n{canonical_headers}\n{signed_headers}\n{payload_hash}");
     let scope = format!("{date}/{region}/s3/aws4_request");
     let sts = format!(
         "AWS4-HMAC-SHA256\n{amz_date}\n{scope}\n{}",
@@ -217,8 +215,7 @@ async fn offsite_backup_upload_then_restore_round_trips() {
     assert_eq!(before, 0, "rows should be gone before restore");
 
     // ── Restore from offsite (dev profile → no --force needed) ───────────────
-    let (_o, restore_err) =
-        run_autumn_ok(dir, &["db", "restore", "offsite:dev/latest"], &envs);
+    let (_o, restore_err) = run_autumn_ok(dir, &["db", "restore", "offsite:dev/latest"], &envs);
     assert!(
         restore_err.contains("Restore complete"),
         "restore should complete: {restore_err}"

--- a/autumn-cli/tests/integration/offsite_backup.rs
+++ b/autumn-cli/tests/integration/offsite_backup.rs
@@ -1,0 +1,242 @@
+//! Integration test for offsite S3 backups (issue #1619, AC #8).
+//!
+//! Proves the full disaster-recovery loop against real containers:
+//! seed → `autumn db backup --upload` → destroy the local artifact + drop the
+//! seeded rows → `autumn db restore offsite:dev/latest` → row-level equality.
+//!
+//! Requires Docker (via testcontainers, `postgres` + `minio` modules) AND
+//! `pg_dump`/`pg_restore` on `PATH`, so it is `#[ignore]`d and only runs when
+//! explicitly requested:
+//!
+//! ```text
+//! cargo test -p autumn-cli --test cli_tests -- --ignored --nocapture offsite
+//! ```
+//!
+//! The test drives the real `autumn` binary as a subprocess with a per-child
+//! working directory and environment (never mutating this process's cwd or env),
+//! so it has no process-wide side effects and lives in the consolidated test
+//! binary per the workspace test-layout guidelines.
+
+use std::path::Path;
+use std::process::Command;
+
+use hmac::{Hmac, Mac};
+use sha2::{Digest, Sha256};
+
+const fn autumn_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_autumn")
+}
+
+fn run_autumn(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String, Option<i32>) {
+    let output = Command::new(autumn_bin())
+        .args(args)
+        .current_dir(dir)
+        .envs(envs.iter().copied())
+        .output()
+        .expect("failed to run autumn");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code(),
+    )
+}
+
+fn run_autumn_ok(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String) {
+    let (stdout, stderr, code) = run_autumn(dir, args, envs);
+    assert_eq!(
+        code,
+        Some(0),
+        "autumn {args:?} failed (exit={code:?})\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    (stdout, stderr)
+}
+
+// ─── Minimal SigV4 bucket-creation helper (test-only) ────────────────────────
+//
+// The `autumn` binary has no library target, so an integration test cannot reach
+// its internal S3 client — the bucket must be created out-of-band. This tiny
+// signer only needs to `PUT /{bucket}` once. It independently cross-checks the
+// binary's own SigV4 (both must interoperate with the same MinIO for the test to
+// pass).
+
+fn sha256_hex(data: &[u8]) -> String {
+    let mut h = Sha256::new();
+    h.update(data);
+    hex::encode(h.finalize())
+}
+
+fn hmac(key: &[u8], data: &[u8]) -> [u8; 32] {
+    let mut m = Hmac::<Sha256>::new_from_slice(key).unwrap();
+    m.update(data);
+    m.finalize().into_bytes().into()
+}
+
+async fn create_bucket(endpoint: &str, access: &str, secret: &str, region: &str, bucket: &str) {
+    let now = chrono::Utc::now();
+    let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
+    let date = now.format("%Y%m%d").to_string();
+    let payload_hash = sha256_hex(b"");
+    let url = url::Url::parse(endpoint).unwrap();
+    let host = match url.port() {
+        Some(p) => format!("{}:{p}", url.host_str().unwrap()),
+        None => url.host_str().unwrap().to_owned(),
+    };
+    let canonical_headers = format!(
+        "host:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{amz_date}\n"
+    );
+    let signed_headers = "host;x-amz-content-sha256;x-amz-date";
+    let canonical = format!(
+        "PUT\n/{bucket}\n\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
+    );
+    let scope = format!("{date}/{region}/s3/aws4_request");
+    let sts = format!(
+        "AWS4-HMAC-SHA256\n{amz_date}\n{scope}\n{}",
+        sha256_hex(canonical.as_bytes())
+    );
+    let k = hmac(format!("AWS4{secret}").as_bytes(), date.as_bytes());
+    let k = hmac(&k, region.as_bytes());
+    let k = hmac(&k, b"s3");
+    let k = hmac(&k, b"aws4_request");
+    let signature = hex::encode(hmac(&k, sts.as_bytes()));
+    let authorization = format!(
+        "AWS4-HMAC-SHA256 Credential={access}/{scope}, SignedHeaders={signed_headers}, \
+         Signature={signature}"
+    );
+    let resp = reqwest::Client::new()
+        .put(format!("{endpoint}/{bucket}"))
+        .header("x-amz-date", &amz_date)
+        .header("x-amz-content-sha256", &payload_hash)
+        .header("authorization", authorization)
+        .send()
+        .await
+        .expect("create bucket request");
+    // 200 OK or 409 (already owned) are both fine.
+    assert!(
+        resp.status().is_success() || resp.status().as_u16() == 409,
+        "unexpected create-bucket status: {}",
+        resp.status()
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers: postgres+minio) and pg_dump/pg_restore on PATH"]
+async fn offsite_backup_upload_then_restore_round_trips() {
+    use testcontainers::runners::AsyncRunner as _;
+    use testcontainers_modules::minio::MinIO;
+    use testcontainers_modules::postgres::Postgres;
+    use tokio_postgres::NoTls;
+
+    // ── Containers ───────────────────────────────────────────────────────────
+    let pg = Postgres::default()
+        .start()
+        .await
+        .expect("start Postgres — is Docker running?");
+    let pg_host = pg.get_host().await.unwrap();
+    let pg_port = pg.get_host_port_ipv4(5432).await.unwrap();
+    let db_url = format!("postgres://postgres:postgres@{pg_host}:{pg_port}/postgres");
+
+    let minio = MinIO::default()
+        .start()
+        .await
+        .expect("start MinIO — is Docker running?");
+    let minio_host = minio.get_host().await.unwrap();
+    let minio_port = minio.get_host_port_ipv4(9000).await.unwrap();
+    let endpoint = format!("http://{minio_host}:{minio_port}");
+    // testcontainers-modules MinIO default root credentials.
+    let access = "minioadmin";
+    let secret = "minioadmin";
+    let bucket = "autumn-offsite-it";
+
+    create_bucket(&endpoint, access, secret, "us-east-1", bucket).await;
+
+    // ── Seed a known table ───────────────────────────────────────────────────
+    let (client, conn) = tokio_postgres::connect(&db_url, NoTls).await.unwrap();
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    client
+        .batch_execute(
+            "DROP TABLE IF EXISTS offsite_rt; \
+             CREATE TABLE offsite_rt (id INT PRIMARY KEY, name TEXT NOT NULL); \
+             INSERT INTO offsite_rt VALUES (1,'alpha'),(2,'beta'),(3,'gamma');",
+        )
+        .await
+        .unwrap();
+
+    // ── Project dir with an offsite destination ──────────────────────────────
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    std::fs::write(
+        dir.join("autumn.toml"),
+        format!(
+            "[backup.offsite]\n\
+             prefix = \"db\"\n\
+             [backup.offsite.s3]\n\
+             bucket = \"{bucket}\"\n\
+             region = \"us-east-1\"\n\
+             endpoint = \"{endpoint}\"\n\
+             force_path_style = true\n\
+             access_key_id_env = \"AUTUMN_OFFSITE_KEY\"\n\
+             secret_access_key_env = \"AUTUMN_OFFSITE_SECRET\"\n"
+        ),
+    )
+    .unwrap();
+
+    let envs = [
+        ("AUTUMN_DATABASE__URL", db_url.as_str()),
+        ("AUTUMN_OFFSITE_KEY", access),
+        ("AUTUMN_OFFSITE_SECRET", secret),
+    ];
+
+    // ── Backup + upload ──────────────────────────────────────────────────────
+    let (_out, stderr) = run_autumn_ok(dir, &["db", "backup", "--upload"], &envs);
+    assert!(
+        stderr.contains("Offsite upload verified"),
+        "upload should report verification: {stderr}"
+    );
+
+    // ── List proves the run is offsite ───────────────────────────────────────
+    let (list_out, list_err) = run_autumn_ok(dir, &["db", "offsite", "list"], &envs);
+    let listing = format!("{list_out}{list_err}");
+    assert!(
+        listing.contains("control.dump"),
+        "offsite list should show the control artifact: {listing}"
+    );
+
+    // ── Destroy local artifact + the seeded rows ─────────────────────────────
+    std::fs::remove_dir_all(dir.join("backups")).ok();
+    client
+        .batch_execute("DELETE FROM offsite_rt;")
+        .await
+        .unwrap();
+    let before: i64 = client
+        .query_one("SELECT COUNT(*) FROM offsite_rt", &[])
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(before, 0, "rows should be gone before restore");
+
+    // ── Restore from offsite (dev profile → no --force needed) ───────────────
+    let (_o, restore_err) =
+        run_autumn_ok(dir, &["db", "restore", "offsite:dev/latest"], &envs);
+    assert!(
+        restore_err.contains("Restore complete"),
+        "restore should complete: {restore_err}"
+    );
+
+    // ── Row-level equality with the seed ─────────────────────────────────────
+    let rows = client
+        .query("SELECT id, name FROM offsite_rt ORDER BY id", &[])
+        .await
+        .unwrap();
+    let got: Vec<(i32, String)> = rows.iter().map(|r| (r.get(0), r.get(1))).collect();
+    assert_eq!(
+        got,
+        vec![
+            (1, "alpha".to_owned()),
+            (2, "beta".to_owned()),
+            (3, "gamma".to_owned()),
+        ],
+        "restored rows must equal the seed"
+    );
+}

--- a/autumn-cli/tests/integration/offsite_backup.rs
+++ b/autumn-cli/tests/integration/offsite_backup.rs
@@ -360,8 +360,11 @@ async fn offsite_backup_uploads_large_artifact_via_multipart() {
         )
         .await
         .unwrap();
-    // 72 rows × 1 MiB ≈ 72 MiB, comfortably over the 64 MiB multipart threshold.
-    for id in 0..72i32 {
+    // ~1 MiB/row, sized comfortably over the 64 MiB multipart threshold. The seed
+    // count is bound once here and reused by the post-restore assertion so the two
+    // can never drift (P2 #23).
+    let seed_rows: i32 = 72;
+    for id in 0..seed_rows {
         let blob = incompressible_bytes(1024 * 1024);
         client
             .execute(
@@ -489,7 +492,8 @@ async fn offsite_backup_uploads_large_artifact_via_multipart() {
         .unwrap()
         .get(0);
     assert_eq!(
-        count, 12,
+        count,
+        i64::from(seed_rows),
         "all seeded rows must be restored from the multipart object"
     );
 }

--- a/autumn-cli/tests/integration/offsite_backup.rs
+++ b/autumn-cli/tests/integration/offsite_backup.rs
@@ -344,8 +344,11 @@ async fn offsite_backup_uploads_large_artifact_via_multipart() {
 
     create_bucket(&endpoint, access, secret, region, bucket).await;
 
-    // ── Seed ~12 MiB of incompressible bytea so the custom-format dump stays
-    //    large enough to split into 3 parts at a 5 MiB part size. ──────────────
+    // ── Seed incompressible bytea LARGER than the real 64 MiB multipart
+    //    threshold so the dump takes the multipart path via the genuine default
+    //    threshold — NOT by an env override lowering it (Low 3: the part-size env
+    //    tunes only chunking, never the threshold). 72 rows × 1 MiB ≈ 72 MiB of
+    //    random data survives custom-format compression and exceeds 64 MiB. ─────
     let (client, conn) = tokio_postgres::connect(&db_url, NoTls).await.unwrap();
     tokio::spawn(async move {
         let _ = conn.await;
@@ -357,8 +360,8 @@ async fn offsite_backup_uploads_large_artifact_via_multipart() {
         )
         .await
         .unwrap();
-    // 12 rows × 1 MiB = ~12 MiB incompressible → 3 parts at 5 MiB/part.
-    for id in 0..12i32 {
+    // 72 rows × 1 MiB ≈ 72 MiB, comfortably over the 64 MiB multipart threshold.
+    for id in 0..72i32 {
         let blob = incompressible_bytes(1024 * 1024);
         client
             .execute(
@@ -392,8 +395,9 @@ async fn offsite_backup_uploads_large_artifact_via_multipart() {
         ("AUTUMN_DATABASE__URL", db_url.as_str()),
         ("AUTUMN_OFFSITE_KEY", access),
         ("AUTUMN_OFFSITE_SECRET", secret),
-        // Force the multipart path with a 5 MiB part size (S3's minimum) so a
-        // ~12 MiB dump splits into 3 parts without needing a multi-GB fixture.
+        // Tune ONLY the part size to 5 MiB (S3's minimum) so the >64 MiB dump
+        // splits into many small parts. This does NOT lower the threshold —
+        // multipart is triggered by the real 64 MiB default on the large fixture.
         ("AUTUMN_OFFSITE_MULTIPART_PART_SIZE_BYTES", "5242880"),
     ];
 
@@ -430,7 +434,10 @@ async fn offsite_backup_uploads_large_artifact_via_multipart() {
         .expect("control.dump key present in listing")
         .to_owned();
 
-    // ── HEAD it: a multipart object's ETag is `<md5>-<partcount>`; assert 3. ──
+    // ── HEAD it: a multipart object's ETag is `<md5>-<partcount>`. Assert the
+    //    `-<n>` suffix with n >= 2, proving a multipart (not single-PUT) upload
+    //    with multiple parts. The exact count depends on the dump's byte size, so
+    //    we assert the shape rather than a brittle fixed number. ───────────────
     let encoded_key = dump_key
         .split('/')
         .map(urlencode_segment)
@@ -452,10 +459,17 @@ async fn offsite_backup_uploads_large_artifact_via_multipart() {
         .get(reqwest::header::ETAG)
         .and_then(|v| v.to_str().ok())
         .unwrap_or_default()
+        .trim_matches('"')
         .to_owned();
+    let part_count: u32 = etag
+        .rsplit_once('-')
+        .and_then(|(_, n)| n.parse().ok())
+        .unwrap_or_else(|| {
+            panic!("multipart ETag should carry a -<partcount> suffix, got {etag:?}")
+        });
     assert!(
-        etag.trim_matches('"').ends_with("-3"),
-        "multipart ETag should carry a -3 part-count suffix, got {etag:?}"
+        part_count >= 2,
+        "a >64 MiB dump at a 5 MiB part size must upload as multiple parts, got {part_count} ({etag:?})"
     );
 
     // ── And the DR loop still works end-to-end (restore equality). ───────────

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -865,6 +865,60 @@ pub enum ConfigError {
 /// assert_eq!(config.log.level, "info");
 /// assert_eq!(config.health.path, "/health");
 /// ```
+/// `[backup]` configuration section (issue #1619).
+///
+/// Groups database-backup destinations. Currently only an offsite S3-compatible
+/// destination is supported. Feature-gated to `storage` because it reuses
+/// [`crate::storage::StorageS3Config`].
+#[cfg(feature = "storage")]
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct BackupConfig {
+    /// Offsite upload destination (`[backup.offsite]`). `None` (the default)
+    /// means no offsite destination is configured; `autumn db backup --upload`
+    /// then errors with configuration guidance rather than silently no-op'ing.
+    #[serde(default)]
+    pub offsite: Option<OffsiteBackupConfig>,
+}
+
+/// `[backup.offsite]` — an S3-compatible offsite backup destination (issue #1619).
+///
+/// Credentials are supplied by env-var *indirection* only: `s3.access_key_id_env`
+/// / `s3.secret_access_key_env` name the environment variables the secrets are
+/// read from at upload time. The secret values themselves never live in config,
+/// argv, logs, or error messages.
+#[cfg(feature = "storage")]
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct OffsiteBackupConfig {
+    /// S3-compatible connection + credential-indirection settings. Reuses the
+    /// same type as `[storage.s3]`, so it inherits `bucket` / `region` /
+    /// `endpoint` / `force_path_style` and the `*_env` credential indirection
+    /// and works against MinIO / R2 / B2 / Garage.
+    #[serde(default)]
+    pub s3: crate::storage::StorageS3Config,
+
+    /// Key prefix under which run directories are stored. Defaults to `""`
+    /// (bucket root). Objects are keyed `{prefix}/{profile}/{timestamp}/{file}`.
+    #[serde(default)]
+    pub prefix: Option<String>,
+
+    /// Independent remote retention: keep only the newest `N` uploaded runs per
+    /// profile, pruning older ones *after* a verified upload. `None` (default)
+    /// keeps all remote runs. Distinct from the local `--keep`.
+    #[serde(default)]
+    pub keep: Option<usize>,
+
+    /// Upload after every successful `autumn db backup` even without `--upload`
+    /// (the "configured default" upload, AC #1). Off by default.
+    #[serde(default)]
+    pub auto_upload: bool,
+
+    /// Opt-in to pointing the offsite destination at the same bucket+endpoint as
+    /// the app's user-facing blob storage (`[storage.s3]`). Off by default so a
+    /// shared bucket is a deliberate choice (AC #3).
+    #[serde(default)]
+    pub allow_shared_bucket: bool,
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct AutumnConfig {
     /// Active profile name (e.g., "dev", "prod", "staging").
@@ -968,6 +1022,17 @@ pub struct AutumnConfig {
     #[cfg(feature = "storage")]
     #[serde(default)]
     pub storage: crate::storage::StorageConfig,
+
+    /// Offsite database-backup destination (`[backup]` section, issue #1619).
+    ///
+    /// Composes the verified local-backup artifact (issue #1595) with an
+    /// S3-compatible offsite destination. Honored only when the `storage`
+    /// cargo feature is enabled — it reuses [`crate::storage::StorageS3Config`]
+    /// so the offsite destination inherits the same bucket/region/endpoint /
+    /// `force_path_style` shape and `*_env` credential indirection.
+    #[cfg(feature = "storage")]
+    #[serde(default)]
+    pub backup: BackupConfig,
     /// Transactional email settings.
     #[cfg(feature = "mail")]
     #[serde(default)]
@@ -2931,6 +2996,8 @@ impl AutumnConfig {
         self.apply_reporting_env_overrides_with_env(env);
         #[cfg(feature = "storage")]
         self.apply_storage_env_overrides_with_env(env);
+        #[cfg(feature = "storage")]
+        self.apply_backup_env_overrides_with_env(env);
         #[cfg(feature = "mail")]
         self.apply_mail_env_overrides_with_env(env);
         #[cfg(feature = "maud")]
@@ -3975,6 +4042,69 @@ impl AutumnConfig {
             env,
             "AUTUMN_STORAGE__VARIANTS__MAX_SOURCE_HEIGHT",
             &mut self.storage.variants.max_source_height,
+        );
+    }
+
+    /// Apply `AUTUMN_BACKUP__OFFSITE__*` overrides to the `[backup.offsite]`
+    /// section (issue #1619). Mirrors the storage overrides so the offsite
+    /// destination honors the same `AUTUMN_*` env convention. When no offsite
+    /// section exists in TOML, a default one is materialized only if at least
+    /// one offsite env var is present, so an all-env deployment still works.
+    #[cfg(feature = "storage")]
+    fn apply_backup_env_overrides_with_env(&mut self, env: &dyn Env) {
+        const OFFSITE_ENV_KEYS: &[&str] = &[
+            "AUTUMN_BACKUP__OFFSITE__S3__BUCKET",
+            "AUTUMN_BACKUP__OFFSITE__S3__REGION",
+            "AUTUMN_BACKUP__OFFSITE__S3__ENDPOINT",
+            "AUTUMN_BACKUP__OFFSITE__S3__PUBLIC_BASE_URL",
+            "AUTUMN_BACKUP__OFFSITE__S3__ACCESS_KEY_ID_ENV",
+            "AUTUMN_BACKUP__OFFSITE__S3__SECRET_ACCESS_KEY_ENV",
+            "AUTUMN_BACKUP__OFFSITE__S3__FORCE_PATH_STYLE",
+            "AUTUMN_BACKUP__OFFSITE__PREFIX",
+            "AUTUMN_BACKUP__OFFSITE__KEEP",
+            "AUTUMN_BACKUP__OFFSITE__AUTO_UPLOAD",
+            "AUTUMN_BACKUP__OFFSITE__ALLOW_SHARED_BUCKET",
+        ];
+        if self.backup.offsite.is_none()
+            && !OFFSITE_ENV_KEYS.iter().any(|k| env.var(k).is_ok())
+        {
+            return;
+        }
+        let offsite = self.backup.offsite.get_or_insert_with(OffsiteBackupConfig::default);
+        parse_env_option_string(env, "AUTUMN_BACKUP__OFFSITE__S3__BUCKET", &mut offsite.s3.bucket);
+        parse_env_option_string(env, "AUTUMN_BACKUP__OFFSITE__S3__REGION", &mut offsite.s3.region);
+        parse_env_option_string(
+            env,
+            "AUTUMN_BACKUP__OFFSITE__S3__ENDPOINT",
+            &mut offsite.s3.endpoint,
+        );
+        parse_env_option_string(
+            env,
+            "AUTUMN_BACKUP__OFFSITE__S3__PUBLIC_BASE_URL",
+            &mut offsite.s3.public_base_url,
+        );
+        parse_env_option_string(
+            env,
+            "AUTUMN_BACKUP__OFFSITE__S3__ACCESS_KEY_ID_ENV",
+            &mut offsite.s3.access_key_id_env,
+        );
+        parse_env_option_string(
+            env,
+            "AUTUMN_BACKUP__OFFSITE__S3__SECRET_ACCESS_KEY_ENV",
+            &mut offsite.s3.secret_access_key_env,
+        );
+        parse_env_bool(
+            env,
+            "AUTUMN_BACKUP__OFFSITE__S3__FORCE_PATH_STYLE",
+            &mut offsite.s3.force_path_style,
+        );
+        parse_env_option_string(env, "AUTUMN_BACKUP__OFFSITE__PREFIX", &mut offsite.prefix);
+        parse_env_option(env, "AUTUMN_BACKUP__OFFSITE__KEEP", &mut offsite.keep);
+        parse_env_bool(env, "AUTUMN_BACKUP__OFFSITE__AUTO_UPLOAD", &mut offsite.auto_upload);
+        parse_env_bool(
+            env,
+            "AUTUMN_BACKUP__OFFSITE__ALLOW_SHARED_BUCKET",
+            &mut offsite.allow_shared_bucket,
         );
     }
 
@@ -7650,6 +7780,99 @@ path = "/healthz"
         assert_eq!(config.storage.variants.max_source_bytes, 5_242_880);
         assert_eq!(config.storage.variants.max_source_width, 2_000);
         assert_eq!(config.storage.variants.max_source_height, 1_500);
+    }
+
+    #[cfg(feature = "storage")]
+    #[test]
+    fn backup_offsite_parses_from_toml() {
+        let toml = r#"
+            [backup.offsite]
+            prefix = "db"
+            keep = 5
+            auto_upload = true
+            allow_shared_bucket = true
+
+            [backup.offsite.s3]
+            bucket = "offsite-backups"
+            region = "auto"
+            endpoint = "https://minio.example.test"
+            access_key_id_env = "OFFSITE_KEY_ID"
+            secret_access_key_env = "OFFSITE_SECRET"
+            force_path_style = true
+        "#;
+        let config: AutumnConfig = toml::from_str(toml).unwrap();
+        let offsite = config.backup.offsite.expect("offsite section present");
+        assert_eq!(offsite.prefix.as_deref(), Some("db"));
+        assert_eq!(offsite.keep, Some(5));
+        assert!(offsite.auto_upload);
+        assert!(offsite.allow_shared_bucket);
+        assert_eq!(offsite.s3.bucket.as_deref(), Some("offsite-backups"));
+        assert_eq!(offsite.s3.region.as_deref(), Some("auto"));
+        assert_eq!(
+            offsite.s3.endpoint.as_deref(),
+            Some("https://minio.example.test")
+        );
+        // Credentials are indirected: config names the env vars, never the values.
+        assert_eq!(offsite.s3.access_key_id_env.as_deref(), Some("OFFSITE_KEY_ID"));
+        assert_eq!(
+            offsite.s3.secret_access_key_env.as_deref(),
+            Some("OFFSITE_SECRET")
+        );
+        assert!(offsite.s3.force_path_style);
+    }
+
+    #[cfg(feature = "storage")]
+    #[test]
+    fn backup_offsite_defaults_to_none() {
+        let config = AutumnConfig::default();
+        assert!(config.backup.offsite.is_none());
+    }
+
+    #[cfg(feature = "storage")]
+    #[test]
+    fn env_override_backup_offsite_fields() {
+        let env = MockEnv::new()
+            .with("AUTUMN_BACKUP__OFFSITE__S3__BUCKET", "offsite")
+            .with("AUTUMN_BACKUP__OFFSITE__S3__REGION", "us-west-2")
+            .with(
+                "AUTUMN_BACKUP__OFFSITE__S3__ENDPOINT",
+                "https://s3.offsite.test",
+            )
+            .with("AUTUMN_BACKUP__OFFSITE__S3__ACCESS_KEY_ID_ENV", "OFF_KEY")
+            .with(
+                "AUTUMN_BACKUP__OFFSITE__S3__SECRET_ACCESS_KEY_ENV",
+                "OFF_SECRET",
+            )
+            .with("AUTUMN_BACKUP__OFFSITE__S3__FORCE_PATH_STYLE", "true")
+            .with("AUTUMN_BACKUP__OFFSITE__PREFIX", "nightly")
+            .with("AUTUMN_BACKUP__OFFSITE__KEEP", "3")
+            .with("AUTUMN_BACKUP__OFFSITE__AUTO_UPLOAD", "true")
+            .with("AUTUMN_BACKUP__OFFSITE__ALLOW_SHARED_BUCKET", "true");
+        let mut config = AutumnConfig::default();
+
+        config.apply_env_overrides_with_env(&env);
+
+        let offsite = config.backup.offsite.expect("materialized from env");
+        assert_eq!(offsite.s3.bucket.as_deref(), Some("offsite"));
+        assert_eq!(offsite.s3.region.as_deref(), Some("us-west-2"));
+        assert_eq!(offsite.s3.endpoint.as_deref(), Some("https://s3.offsite.test"));
+        assert_eq!(offsite.s3.access_key_id_env.as_deref(), Some("OFF_KEY"));
+        assert_eq!(offsite.s3.secret_access_key_env.as_deref(), Some("OFF_SECRET"));
+        assert!(offsite.s3.force_path_style);
+        assert_eq!(offsite.prefix.as_deref(), Some("nightly"));
+        assert_eq!(offsite.keep, Some(3));
+        assert!(offsite.auto_upload);
+        assert!(offsite.allow_shared_bucket);
+    }
+
+    #[cfg(feature = "storage")]
+    #[test]
+    fn env_override_backup_offsite_absent_stays_none() {
+        // With no offsite env vars and no TOML section, nothing is materialized.
+        let env = MockEnv::new();
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert!(config.backup.offsite.is_none());
     }
 
     #[test]

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -4088,7 +4088,15 @@ impl AutumnConfig {
     /// section exists in TOML, a default one is materialized only if at least
     /// one offsite env var is present, so an all-env deployment still works.
     fn apply_backup_env_overrides_with_env(&mut self, env: &dyn Env) {
-        const OFFSITE_ENV_KEYS: &[&str] = &[
+        // Keys that signal a genuine intent to CONFIGURE an offsite destination —
+        // any presence materializes the `[backup.offsite]` section. This
+        // deliberately EXCLUDES the two opt-out toggles: a lone
+        // `AUTO_UPLOAD=false` / `ALLOW_SHARED_BUCKET=false` must NOT create an
+        // otherwise-empty section (which would then fail validation / `doctor`
+        // with "backup.offsite.s3.bucket is unset") — offsite stays UNCONFIGURED
+        // (issue #1619 P2 #18). A truthy `AUTO_UPLOAD=true` DOES materialize, since
+        // it requires a validated destination to act on.
+        const OFFSITE_DEST_KEYS: &[&str] = &[
             "AUTUMN_BACKUP__OFFSITE__S3__BUCKET",
             "AUTUMN_BACKUP__OFFSITE__S3__REGION",
             "AUTUMN_BACKUP__OFFSITE__S3__ENDPOINT",
@@ -4097,10 +4105,13 @@ impl AutumnConfig {
             "AUTUMN_BACKUP__OFFSITE__S3__FORCE_PATH_STYLE",
             "AUTUMN_BACKUP__OFFSITE__PREFIX",
             "AUTUMN_BACKUP__OFFSITE__KEEP",
-            "AUTUMN_BACKUP__OFFSITE__AUTO_UPLOAD",
-            "AUTUMN_BACKUP__OFFSITE__ALLOW_SHARED_BUCKET",
         ];
-        if self.backup.offsite.is_none() && !OFFSITE_ENV_KEYS.iter().any(|k| env.var(k).is_ok()) {
+        let has_dest_key = OFFSITE_DEST_KEYS.iter().any(|k| env.var(k).is_ok());
+        let auto_upload_truthy = env
+            .var("AUTUMN_BACKUP__OFFSITE__AUTO_UPLOAD")
+            .ok()
+            .is_some_and(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true"));
+        if self.backup.offsite.is_none() && !has_dest_key && !auto_upload_truthy {
             return;
         }
         let offsite = self
@@ -7921,6 +7932,56 @@ path = "/healthz"
         let mut config = AutumnConfig::default();
         config.apply_env_overrides_with_env(&env);
         assert!(config.backup.offsite.is_none());
+    }
+
+    #[test]
+    fn env_override_backup_offsite_lone_opt_out_toggle_stays_none() {
+        // P2 #18: a lone false/opt-out toggle must NOT materialize an empty
+        // [backup.offsite] (which would then fail validation / `doctor` with
+        // "bucket is unset"). Offsite stays unconfigured.
+        for key in [
+            "AUTUMN_BACKUP__OFFSITE__AUTO_UPLOAD",
+            "AUTUMN_BACKUP__OFFSITE__ALLOW_SHARED_BUCKET",
+        ] {
+            let env = MockEnv::new().with(key, "false");
+            let mut config = AutumnConfig::default();
+            config.apply_env_overrides_with_env(&env);
+            assert!(
+                config.backup.offsite.is_none(),
+                "{key}=false must not materialize an offsite section",
+            );
+        }
+    }
+
+    #[test]
+    fn env_override_backup_offsite_truthy_auto_upload_materializes() {
+        // P2 #18: AUTO_UPLOAD=true genuinely needs a validated destination, so it
+        // DOES materialize the section (auto_upload set), as before.
+        let env = MockEnv::new().with("AUTUMN_BACKUP__OFFSITE__AUTO_UPLOAD", "true");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        let offsite = config
+            .backup
+            .offsite
+            .expect("auto_upload=true materializes offsite");
+        assert!(offsite.auto_upload);
+    }
+
+    #[test]
+    fn env_override_backup_offsite_destination_key_materializes() {
+        // A destination/credential key still materializes the section (with the
+        // opt-out toggle applied to it), unchanged from before P2 #18.
+        let env = MockEnv::new()
+            .with("AUTUMN_BACKUP__OFFSITE__S3__BUCKET", "offsite")
+            .with("AUTUMN_BACKUP__OFFSITE__AUTO_UPLOAD", "false");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        let offsite = config
+            .backup
+            .offsite
+            .expect("a bucket key materializes offsite");
+        assert_eq!(offsite.s3.bucket.as_deref(), Some("offsite"));
+        assert!(!offsite.auto_upload);
     }
 
     #[test]

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -876,8 +876,12 @@ pub struct BackupConfig {
     /// Offsite upload destination (`[backup.offsite]`). `None` (the default)
     /// means no offsite destination is configured; `autumn db backup --upload`
     /// then errors with configuration guidance rather than silently no-op'ing.
+    ///
+    /// Boxed so an unconfigured `[backup]` costs one pointer rather than the full
+    /// [`OffsiteBackupConfig`] inline: `AutumnConfig` is held across awaits in the
+    /// app-run future, and keeping this field small avoids bloating that future.
     #[serde(default)]
-    pub offsite: Option<OffsiteBackupConfig>,
+    pub offsite: Option<Box<OffsiteBackupConfig>>,
 }
 
 /// `[backup.offsite]` — an S3-compatible offsite backup destination (issue #1619).
@@ -4071,7 +4075,7 @@ impl AutumnConfig {
         let offsite = self
             .backup
             .offsite
-            .get_or_insert_with(OffsiteBackupConfig::default);
+            .get_or_insert_with(|| Box::new(OffsiteBackupConfig::default()));
         parse_env_option_string(
             env,
             "AUTUMN_BACKUP__OFFSITE__S3__BUCKET",

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -868,9 +868,11 @@ pub enum ConfigError {
 /// `[backup]` configuration section (issue #1619).
 ///
 /// Groups database-backup destinations. Currently only an offsite S3-compatible
-/// destination is supported. Feature-gated to `storage` because it reuses
-/// [`crate::storage::StorageS3Config`].
-#[cfg(feature = "storage")]
+/// destination is supported. NOT feature-gated: this section (`[backup.offsite]`)
+/// is recognized by every autumn-web build so a strict-config app compiled
+/// WITHOUT the `storage` feature still accepts its own `autumn.toml` `[backup]`
+/// keys (the offsite upload client lives in the CLI and is independent of the
+/// storage feature).
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct BackupConfig {
     /// Offsite upload destination (`[backup.offsite]`). `None` (the default)
@@ -890,15 +892,12 @@ pub struct BackupConfig {
 /// / `s3.secret_access_key_env` name the environment variables the secrets are
 /// read from at upload time. The secret values themselves never live in config,
 /// argv, logs, or error messages.
-#[cfg(feature = "storage")]
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct OffsiteBackupConfig {
-    /// S3-compatible connection + credential-indirection settings. Reuses the
-    /// same type as `[storage.s3]`, so it inherits `bucket` / `region` /
-    /// `endpoint` / `force_path_style` and the `*_env` credential indirection
-    /// and works against `MinIO` / R2 / B2 / Garage.
+    /// S3-compatible connection + credential-indirection settings
+    /// (`[backup.offsite.s3]`). Works against AWS S3 / `MinIO` / R2 / B2 / Garage.
     #[serde(default)]
-    pub s3: crate::storage::StorageS3Config,
+    pub s3: OffsiteS3Config,
 
     /// Key prefix under which run directories are stored. Defaults to `""`
     /// (bucket root). Objects are keyed `{prefix}/{profile}/{timestamp}/{file}`.
@@ -921,6 +920,41 @@ pub struct OffsiteBackupConfig {
     /// shared bucket is a deliberate choice (AC #3).
     #[serde(default)]
     pub allow_shared_bucket: bool,
+}
+
+/// `[backup.offsite.s3]` — S3-compatible connection settings for offsite backups.
+///
+/// A dedicated, NON-feature-gated mirror of the storage backend's S3 shape so the
+/// `[backup]` section is available in every autumn-web build (the storage
+/// module — and its `StorageS3Config` — only exist under the `storage` feature).
+/// Credentials are named via `*_env` indirection, never inlined.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct OffsiteS3Config {
+    /// Target bucket.
+    #[serde(default)]
+    pub bucket: Option<String>,
+
+    /// AWS region or region-shaped string (R2 uses `auto`). Used for the `SigV4`
+    /// credential scope; many S3-compatible endpoints ignore it.
+    #[serde(default)]
+    pub region: Option<String>,
+
+    /// Custom endpoint URL. Required for non-AWS providers (R2, `MinIO`, B2,
+    /// Garage). Leave unset for AWS.
+    #[serde(default)]
+    pub endpoint: Option<String>,
+
+    /// Environment variable the access-key id is read from.
+    #[serde(default)]
+    pub access_key_id_env: Option<String>,
+
+    /// Environment variable the secret access key is read from.
+    #[serde(default)]
+    pub secret_access_key_env: Option<String>,
+
+    /// Path-style addressing toggle (R2 / `MinIO` need this `true`).
+    #[serde(default)]
+    pub force_path_style: bool,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -1030,11 +1064,11 @@ pub struct AutumnConfig {
     /// Offsite database-backup destination (`[backup]` section, issue #1619).
     ///
     /// Composes the verified local-backup artifact (issue #1595) with an
-    /// S3-compatible offsite destination. Honored only when the `storage`
-    /// cargo feature is enabled — it reuses [`crate::storage::StorageS3Config`]
-    /// so the offsite destination inherits the same bucket/region/endpoint /
-    /// `force_path_style` shape and `*_env` credential indirection.
-    #[cfg(feature = "storage")]
+    /// S3-compatible offsite destination. Always present (not feature-gated) so
+    /// every autumn-web build recognizes `[backup.offsite]` — a strict-config app
+    /// compiled without the `storage` feature still accepts its own `[backup]`
+    /// keys. The offsite upload client lives in the CLI and needs no storage
+    /// feature.
     #[serde(default)]
     pub backup: BackupConfig,
     /// Transactional email settings.
@@ -3000,7 +3034,6 @@ impl AutumnConfig {
         self.apply_reporting_env_overrides_with_env(env);
         #[cfg(feature = "storage")]
         self.apply_storage_env_overrides_with_env(env);
-        #[cfg(feature = "storage")]
         self.apply_backup_env_overrides_with_env(env);
         #[cfg(feature = "mail")]
         self.apply_mail_env_overrides_with_env(env);
@@ -4054,13 +4087,11 @@ impl AutumnConfig {
     /// destination honors the same `AUTUMN_*` env convention. When no offsite
     /// section exists in TOML, a default one is materialized only if at least
     /// one offsite env var is present, so an all-env deployment still works.
-    #[cfg(feature = "storage")]
     fn apply_backup_env_overrides_with_env(&mut self, env: &dyn Env) {
         const OFFSITE_ENV_KEYS: &[&str] = &[
             "AUTUMN_BACKUP__OFFSITE__S3__BUCKET",
             "AUTUMN_BACKUP__OFFSITE__S3__REGION",
             "AUTUMN_BACKUP__OFFSITE__S3__ENDPOINT",
-            "AUTUMN_BACKUP__OFFSITE__S3__PUBLIC_BASE_URL",
             "AUTUMN_BACKUP__OFFSITE__S3__ACCESS_KEY_ID_ENV",
             "AUTUMN_BACKUP__OFFSITE__S3__SECRET_ACCESS_KEY_ENV",
             "AUTUMN_BACKUP__OFFSITE__S3__FORCE_PATH_STYLE",
@@ -4090,11 +4121,6 @@ impl AutumnConfig {
             env,
             "AUTUMN_BACKUP__OFFSITE__S3__ENDPOINT",
             &mut offsite.s3.endpoint,
-        );
-        parse_env_option_string(
-            env,
-            "AUTUMN_BACKUP__OFFSITE__S3__PUBLIC_BASE_URL",
-            &mut offsite.s3.public_base_url,
         );
         parse_env_option_string(
             env,
@@ -7799,7 +7825,6 @@ path = "/healthz"
         assert_eq!(config.storage.variants.max_source_height, 1_500);
     }
 
-    #[cfg(feature = "storage")]
     #[test]
     fn backup_offsite_parses_from_toml() {
         let toml = r#"
@@ -7841,14 +7866,12 @@ path = "/healthz"
         assert!(offsite.s3.force_path_style);
     }
 
-    #[cfg(feature = "storage")]
     #[test]
     fn backup_offsite_defaults_to_none() {
         let config = AutumnConfig::default();
         assert!(config.backup.offsite.is_none());
     }
 
-    #[cfg(feature = "storage")]
     #[test]
     fn env_override_backup_offsite_fields() {
         let env = MockEnv::new()
@@ -7891,7 +7914,6 @@ path = "/healthz"
         assert!(offsite.allow_shared_bucket);
     }
 
-    #[cfg(feature = "storage")]
     #[test]
     fn env_override_backup_offsite_absent_stays_none() {
         // With no offsite env vars and no TOML section, nothing is materialized.

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -892,7 +892,7 @@ pub struct OffsiteBackupConfig {
     /// S3-compatible connection + credential-indirection settings. Reuses the
     /// same type as `[storage.s3]`, so it inherits `bucket` / `region` /
     /// `endpoint` / `force_path_style` and the `*_env` credential indirection
-    /// and works against MinIO / R2 / B2 / Garage.
+    /// and works against `MinIO` / R2 / B2 / Garage.
     #[serde(default)]
     pub s3: crate::storage::StorageS3Config,
 
@@ -4065,14 +4065,23 @@ impl AutumnConfig {
             "AUTUMN_BACKUP__OFFSITE__AUTO_UPLOAD",
             "AUTUMN_BACKUP__OFFSITE__ALLOW_SHARED_BUCKET",
         ];
-        if self.backup.offsite.is_none()
-            && !OFFSITE_ENV_KEYS.iter().any(|k| env.var(k).is_ok())
-        {
+        if self.backup.offsite.is_none() && !OFFSITE_ENV_KEYS.iter().any(|k| env.var(k).is_ok()) {
             return;
         }
-        let offsite = self.backup.offsite.get_or_insert_with(OffsiteBackupConfig::default);
-        parse_env_option_string(env, "AUTUMN_BACKUP__OFFSITE__S3__BUCKET", &mut offsite.s3.bucket);
-        parse_env_option_string(env, "AUTUMN_BACKUP__OFFSITE__S3__REGION", &mut offsite.s3.region);
+        let offsite = self
+            .backup
+            .offsite
+            .get_or_insert_with(OffsiteBackupConfig::default);
+        parse_env_option_string(
+            env,
+            "AUTUMN_BACKUP__OFFSITE__S3__BUCKET",
+            &mut offsite.s3.bucket,
+        );
+        parse_env_option_string(
+            env,
+            "AUTUMN_BACKUP__OFFSITE__S3__REGION",
+            &mut offsite.s3.region,
+        );
         parse_env_option_string(
             env,
             "AUTUMN_BACKUP__OFFSITE__S3__ENDPOINT",
@@ -4100,7 +4109,11 @@ impl AutumnConfig {
         );
         parse_env_option_string(env, "AUTUMN_BACKUP__OFFSITE__PREFIX", &mut offsite.prefix);
         parse_env_option(env, "AUTUMN_BACKUP__OFFSITE__KEEP", &mut offsite.keep);
-        parse_env_bool(env, "AUTUMN_BACKUP__OFFSITE__AUTO_UPLOAD", &mut offsite.auto_upload);
+        parse_env_bool(
+            env,
+            "AUTUMN_BACKUP__OFFSITE__AUTO_UPLOAD",
+            &mut offsite.auto_upload,
+        );
         parse_env_bool(
             env,
             "AUTUMN_BACKUP__OFFSITE__ALLOW_SHARED_BUCKET",
@@ -7813,7 +7826,10 @@ path = "/healthz"
             Some("https://minio.example.test")
         );
         // Credentials are indirected: config names the env vars, never the values.
-        assert_eq!(offsite.s3.access_key_id_env.as_deref(), Some("OFFSITE_KEY_ID"));
+        assert_eq!(
+            offsite.s3.access_key_id_env.as_deref(),
+            Some("OFFSITE_KEY_ID")
+        );
         assert_eq!(
             offsite.s3.secret_access_key_env.as_deref(),
             Some("OFFSITE_SECRET")
@@ -7855,9 +7871,15 @@ path = "/healthz"
         let offsite = config.backup.offsite.expect("materialized from env");
         assert_eq!(offsite.s3.bucket.as_deref(), Some("offsite"));
         assert_eq!(offsite.s3.region.as_deref(), Some("us-west-2"));
-        assert_eq!(offsite.s3.endpoint.as_deref(), Some("https://s3.offsite.test"));
+        assert_eq!(
+            offsite.s3.endpoint.as_deref(),
+            Some("https://s3.offsite.test")
+        );
         assert_eq!(offsite.s3.access_key_id_env.as_deref(), Some("OFF_KEY"));
-        assert_eq!(offsite.s3.secret_access_key_env.as_deref(), Some("OFF_SECRET"));
+        assert_eq!(
+            offsite.s3.secret_access_key_env.as_deref(),
+            Some("OFF_SECRET")
+        );
         assert!(offsite.s3.force_path_style);
         assert_eq!(offsite.prefix.as_deref(), Some("nightly"));
         assert_eq!(offsite.keep, Some(3));

--- a/autumn/src/dotenv.rs
+++ b/autumn/src/dotenv.rs
@@ -376,11 +376,80 @@ pub fn os_env_with_dotenv() -> Result<DotenvOsEnv, DotenvError> {
     })
 }
 
+/// Like [`os_env_with_dotenv`], but selects `.env.<profile>` for an EXPLICIT
+/// `profile` instead of the ambient one (which [`resolve_process_dotenv`]
+/// derives from `AUTUMN_ENV`/`AUTUMN_PROFILE`).
+///
+/// CLI paths that resolve config under a caller-forced profile — e.g.
+/// `autumn db backup --profile <p>` or an `offsite:<p>/…` restore ref — must load
+/// `.env.<p>` even when the ambient shell profile differs, otherwise a
+/// profile-specific `.env.<p>` (offsite overrides, credential values) is silently
+/// missed. Real environment variables still win over `.env`, and `.env`
+/// profile-selector keys are still ignored, exactly as in [`os_env_with_dotenv`].
+///
+/// # Errors
+/// Returns a [`DotenvError`] if a project-root `.env` file exists but cannot be
+/// read or parsed.
+pub fn os_env_with_dotenv_for_profile(profile: &str) -> Result<DotenvOsEnv, DotenvError> {
+    let base = OsEnv;
+    let dir = dotenv_base_dir(&base);
+    Ok(DotenvOsEnv {
+        overlay: resolve_dotenv_vars(&dir, profile, &base)?
+            .into_iter()
+            .collect(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::config::MockEnv;
     use std::path::PathBuf;
+
+    #[test]
+    fn dotenv_profile_selection_reproduces_offsite_wrong_profile_bug() {
+        // Reproduction for issue #1619 P2 #6: an offsite override + credential
+        // live ONLY in `.env.test`. With the ambient shell profile unset (default
+        // "dev"), resolving `.env` for "dev" MISSES `.env.test` — the bug the
+        // offsite path hit by feeding `dotenv_env()` the ambient profile.
+        // Resolving for the TARGET profile "test" (the fix) picks them up.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".env.test"),
+            "AUTUMN_BACKUP__OFFSITE__S3__BUCKET=from-dot-env-test\n\
+             AUTUMN_OFFSITE_SECRET=sekret\n",
+        )
+        .unwrap();
+        let ambient = MockEnv::new(); // AUTUMN_ENV / AUTUMN_PROFILE unset
+
+        // Buggy path: the ambient/default profile "dev" does NOT load `.env.test`.
+        let dev: std::collections::HashMap<_, _> = resolve_dotenv_vars(dir.path(), "dev", &ambient)
+            .unwrap()
+            .into_iter()
+            .collect();
+        assert!(
+            !dev.contains_key("AUTUMN_BACKUP__OFFSITE__S3__BUCKET"),
+            "reproduction: dev profile must miss the .env.test offsite override"
+        );
+        assert!(!dev.contains_key("AUTUMN_OFFSITE_SECRET"));
+
+        // Fixed path: resolving for the target profile "test" loads `.env.test`,
+        // so both the offsite override and the credential value are honored.
+        let test: std::collections::HashMap<_, _> =
+            resolve_dotenv_vars(dir.path(), "test", &ambient)
+                .unwrap()
+                .into_iter()
+                .collect();
+        assert_eq!(
+            test.get("AUTUMN_BACKUP__OFFSITE__S3__BUCKET")
+                .map(String::as_str),
+            Some("from-dot-env-test")
+        );
+        assert_eq!(
+            test.get("AUTUMN_OFFSITE_SECRET").map(String::as_str),
+            Some("sekret")
+        );
+    }
 
     fn p() -> PathBuf {
         PathBuf::from("/tmp/.env")

--- a/autumn/tests/fixtures/schema_keys.snapshot
+++ b/autumn/tests/fixtures/schema_keys.snapshot
@@ -1,6 +1,7 @@
 actuator
 alerts
 auth
+backup
 bot_protection
 cache
 channels

--- a/autumn/tests/integration/schema_drift_guard.rs
+++ b/autumn/tests/integration/schema_drift_guard.rs
@@ -51,14 +51,14 @@ use std::collections::BTreeSet;
 /// `#[cfg(feature = "...")]`. Keep in sync with `config.rs`'s `AutumnConfig`
 /// struct — [`feature_gated_roots_mapping_matches_config_when_enabled`] below
 /// self-checks this list whenever a listed feature happens to be enabled.
-const fn feature_gated_roots() -> [(bool, &'static str); 7] {
+const fn feature_gated_roots() -> [(bool, &'static str); 6] {
     [
         (cfg!(feature = "i18n"), "i18n"),
         (cfg!(feature = "mail"), "mail"),
         (cfg!(feature = "storage"), "storage"),
-        // `[backup]` (issue #1619) is gated on `storage` because it reuses
-        // `StorageS3Config`; it shares that feature flag with the `storage` root.
-        (cfg!(feature = "storage"), "backup"),
+        // NOTE: `[backup]` (issue #1619) is intentionally NOT here — it is a
+        // non-feature-gated root present in every build, so it always appears in
+        // the schema and needs no gating exclusion.
         (cfg!(feature = "http-client"), "http"),
         (cfg!(feature = "reporting"), "reporting"),
         (cfg!(feature = "maud"), "stories"),

--- a/autumn/tests/integration/schema_drift_guard.rs
+++ b/autumn/tests/integration/schema_drift_guard.rs
@@ -51,11 +51,14 @@ use std::collections::BTreeSet;
 /// `#[cfg(feature = "...")]`. Keep in sync with `config.rs`'s `AutumnConfig`
 /// struct — [`feature_gated_roots_mapping_matches_config_when_enabled`] below
 /// self-checks this list whenever a listed feature happens to be enabled.
-const fn feature_gated_roots() -> [(bool, &'static str); 6] {
+const fn feature_gated_roots() -> [(bool, &'static str); 7] {
     [
         (cfg!(feature = "i18n"), "i18n"),
         (cfg!(feature = "mail"), "mail"),
         (cfg!(feature = "storage"), "storage"),
+        // `[backup]` (issue #1619) is gated on `storage` because it reuses
+        // `StorageS3Config`; it shares that feature flag with the `storage` root.
+        (cfg!(feature = "storage"), "backup"),
         (cfg!(feature = "http-client"), "http"),
         (cfg!(feature = "reporting"), "reporting"),
         (cfg!(feature = "maud"), "stories"),

--- a/docs/guide/daemon.md
+++ b/docs/guide/daemon.md
@@ -213,6 +213,103 @@ A good drill: restore the latest backup into a scratch database, run
 `autumn doctor` / your smoke tests against it, then discard it. Confirming a
 backup restores cleanly is the only way to know it is real.
 
+### Offsite backups
+
+A backup on the same disk as the database is not disaster recovery: one failed
+drive takes the app and every backup with it. Point `autumn db backup` at an
+**S3-compatible** offsite destination (AWS S3, MinIO, Cloudflare R2, Backblaze
+B2, Garage) and it uploads each completed run **after** local integrity
+verification passes, then **verifies every remote object matches the local
+file** before reporting success. If the local backup succeeds but the upload
+fails, the command says so unambiguously and exits non-zero — the local artifact
+is left intact.
+
+Configure the destination in `autumn.toml` under `[backup.offsite]`. Credentials
+are supplied by **env-var indirection**: config names the environment variables
+the access key / secret are read from; the secret values never live in config,
+argv, logs, or error messages.
+
+```toml
+[backup.offsite]
+# Upload after every `autumn db backup`, without needing --upload:
+auto_upload = true
+# Key prefix inside the bucket (optional; objects are keyed
+# {prefix}/{profile}/{timestamp}/{file}):
+prefix = "db"
+# Independent remote retention: keep the newest N uploaded runs per profile,
+# pruning older ones only after a verified upload (never the just-uploaded run):
+keep = 30
+
+[backup.offsite.s3]
+bucket   = "myapp-db-offsite"
+region   = "auto"                       # R2 uses "auto"; MinIO ignores it
+endpoint = "https://<accountid>.r2.cloudflarestorage.com"
+force_path_style = true                 # required by MinIO / R2 / most self-hosted
+# Credentials by env-var indirection — names, not values:
+access_key_id_env     = "AUTUMN_OFFSITE_ACCESS_KEY_ID"
+secret_access_key_env = "AUTUMN_OFFSITE_SECRET_ACCESS_KEY"
+```
+
+Every setting also has an `AUTUMN_BACKUP__OFFSITE__*` environment override (e.g.
+`AUTUMN_BACKUP__OFFSITE__S3__BUCKET`) and honors profile overlays
+(`[profile.prod.backup.offsite]`), matching the rest of Autumn's config.
+
+By default the offsite destination must be **distinct** from the app's
+user-facing `[storage.s3]` bucket. Pointing both at the same bucket+endpoint
+requires the explicit opt-in `allow_shared_bucket = true`.
+
+```sh
+# Export the credentials the config names, then upload with the backup:
+export AUTUMN_OFFSITE_ACCESS_KEY_ID=...          # never committed
+export AUTUMN_OFFSITE_SECRET_ACCESS_KEY=...
+autumn db backup --upload --keep 7 --dir /var/backups/myapp
+
+# List what's offsite (timestamp, size, files) for the active profile:
+autumn db offsite list
+```
+
+`autumn doctor` includes an `offsite_backup` check that flags an unset bucket, a
+shared bucket without opt-in, or credentials that are not ready — without ever
+printing a credential value.
+
+**Scheduling.** Extend the cron / systemd recipe above with `--upload` (or set
+`auto_upload = true` and drop the flag):
+
+```cron
+0 2 * * *  cd /srv/myapp && AUTUMN_ENV=prod autumn db backup --upload --keep 7 --dir /var/backups/myapp
+```
+
+```ini
+# In the systemd unit's [Service] section, load the offsite credentials from a
+# root-only env file and add --upload to the backup command:
+EnvironmentFile=/etc/myapp/offsite.env
+ExecStart=/usr/local/bin/autumn db backup --upload --keep 7 --dir /var/backups/myapp
+```
+
+**Restore-from-offsite drill.** List the offsite runs, then restore one directly
+— it downloads the run to a temp directory and applies the **same** integrity
+verification and production `--force` guard as a local restore:
+
+```sh
+# See what's available offsite:
+autumn db offsite list
+
+# Restore the newest offsite run for a profile (into a scratch/dev DB):
+autumn db restore offsite:dev/latest
+
+# Or an explicit run, into production (this overwrites data):
+AUTUMN_ENV=prod autumn db restore offsite:prod/20260710T020000Z --force
+```
+
+**Encryption posture.** Transfers use **TLS in transit** (HTTPS to the S3
+endpoint). At rest, objects are protected by the **provider's server-side
+encryption** (enable SSE / bucket default encryption on your bucket). Uploads
+send `x-amz-checksum-sha256` so the endpoint validates payload integrity
+server-side. **Client-side backup encryption** (encrypting the artifact with a
+framework-managed key before it leaves the host) is a named follow-up — see the
+`autumn/src/encryption.rs` AES-256-GCM envelope — and is **not** applied by this
+slice.
+
 ## Out of scope
 
 SQLite as an app backend, in-process Postgres, and system-service installation


### PR DESCRIPTION
Part-of #1619.

A backup on the same disk as the database is not disaster recovery: one failed drive takes the app and every backup with it. This composes the verified local-backup artifact (#1595) with an S3-compatible offsite destination behind one config block and one flag.

## Before / After (operator view)

**Before:** `autumn db backup` writes a verified dump to local disk only. Getting it offsite meant hand-rolled `aws s3 cp` cron glue with no verification and silent failure.

**After**, with a `[backup.offsite]` block pointing at any S3-compatible endpoint (AWS S3, MinIO, Cloudflare R2, Backblaze B2, Garage):

- **`autumn db backup --upload`** — takes the backup, verifies it locally, prunes local runs, then uploads every run file to the offsite bucket and **verifies each remote object matches the local file** before reporting success. Set `auto_upload = true` to make every backup upload without the flag. If the local backup succeeds but the upload fails, it says so unambiguously (`Local backup OK at <path>; OFFSITE UPLOAD FAILED: <detail>`) and **exits non-zero** — the local artifact is left intact.
- **`autumn db offsite list`** — lists offsite backups for the active profile: timestamp, total size, and the files in each run.
- **`autumn db restore offsite:<profile>/latest`** (or an explicit `offsite:<profile>/<timestamp>`, or `--offsite`) — downloads the run to a temp directory and restores it through the **same** integrity-refusal and production `--force` guard as a local restore.
- **`autumn doctor`** — gains an `offsite_backup` check that flags an unset bucket, a shared bucket without opt-in, or credentials that aren't ready — never printing a credential value.

Credentials are supplied by **env-var indirection** (config names the env vars; the secret values never live in config, argv, logs, or errors). By default the offsite bucket must be **distinct** from the app's `[storage.s3]` bucket; sharing one requires `allow_shared_bucket = true`. Independent remote retention (`keep = N`) prunes old remote runs only after a verified upload, never the just-uploaded run. The full config block, a cron/systemd scheduling recipe, a restore-from-offsite drill, and the encryption posture are documented in `docs/guide/daemon.md` → "Offsite backups".

## How

- **Config** (`autumn/src/config.rs`): new `[backup]` / `[backup.offsite]` section, feature-gated to `storage`, reusing the existing `StorageS3Config` so it inherits bucket/region/endpoint/force_path_style and the `*_env` credential indirection, `AUTUMN_BACKUP__OFFSITE__*` env overrides, and profile overlays. Confirmed config-only: enabling `storage` for the CLI does **not** pull `aws-sdk`/`tokio` into the graph.
- **S3 client** (`autumn-cli/src/db/s3.rs`): a minimal synchronous AWS **SigV4** client over the CLI's existing `reqwest(blocking, rustls)` + `hmac` + `sha2` — no `aws-sdk`, no `tokio`. `put`/`head`/`get`/`list`/`delete`, custom endpoint + `force_path_style` for MinIO/R2/B2/Garage. Signing is unit-tested against the AWS documented GET-object example vector. Credentials never appear in `Debug`/`Display`/errors/logs.
- **Verify** (AC #2): PUT sends `x-amz-checksum-sha256` so the endpoint validates server-side; HEAD sends `x-amz-checksum-mode: ENABLED` and confirms remote length + checksum match locally, falling back to a GET-and-rehash when an endpoint omits the checksum (never a no-op).
- **Orchestration** (`autumn-cli/src/db/backup.rs`): upload runs after local verify + prune; a failure is the split outcome (`OffsiteUploadFailed`, non-zero exit, artifact intact). Pre-flight enforces the distinct-destination guard and credential presence before dumping. Remote retention reuses the keep-newest-N plan and can never delete the just-uploaded run. Offsite restore downloads to a temp dir and hands it to the existing `RestorePlan::discover`.

Review hardening in this PR: HEAD checksum-mode opt-in (avoids re-downloading every object), scheme/default-port/AWS-default normalization in the shared-bucket guard, rejection of an `endpoint` that carries a path prefix (would mis-sign), and a pagination cap on `list`.

## Tests

Unit tests for SigV4 signing (AWS vector), config parse + shared-bucket opt-in, remote-prune (never the just-uploaded), offsite-ref parsing, verify mismatch, endpoint validation, and the doctor check; CLI parse tests for `--upload` / `db offsite list` / restore `--offsite`; and a docker-gated `#[ignore]` MinIO+Postgres round-trip proving seed → backup+upload → destroy local + drop rows → restore-from-offsite → row-level equality (compiles in CI via `--no-run`). `cargo fmt`, `cargo clippy -- -D warnings` (cli + web/storage), and `cargo check --workspace` are clean.

## Acceptance criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Offsite section (profile overlays, `AUTUMN_*`, cred indirection) + `--upload`/configured default uploads after local verify | Covered | `OffsiteBackupConfig` reuses `StorageS3Config`; `AUTUMN_BACKUP__OFFSITE__*` overrides; upload after `backup_into`+`prune`; `auto_upload` honored |
| 2 | Success only after remote verified; split outcome exits non-zero | Covered | `put_and_verify` (server-side checksum + HEAD checksum-mode / GET-rehash); `OffsiteUploadFailed` split message, exit 1, artifact intact |
| 3 | Offsite distinct by default; shared bucket needs opt-in | Covered | `destinations_conflict` (scheme/port/AWS-normalized) + `SharedBucketRefused` unless `allow_shared_bucket`; enforced pre-flight; unit-tested |
| 4 | List + restore-from-offsite under same integrity/`--force` protocol | Covered | `db offsite list`; `restore offsite:<profile>/<ts\|latest>` → temp dir → existing `RestorePlan::discover`; guard unchanged |
| 5 | Independent remote retention; only after verified upload; never removes just-uploaded | Covered | `offsite.keep` → `plan_remote_pruning(…, keep_run_id)`; unit-tested incl. clock-skew case |
| 6 | Failed scheduled upload is alertable; never silent | Partial (loud-failure done); alert wiring deferred | Non-zero exit + unambiguous split outcome shipped; composition with #1610 channels deferred → #1743 |
| 7 | Docs: offsite section, scheduling, restore drill, encryption posture | Covered | `docs/guide/daemon.md` "Offsite backups": config, `--upload`, cron/systemd, restore drill, TLS-in-transit / provider SSE-at-rest / client-side as a follow-up |
| 8 | CI proves the loop vs MinIO | Covered (compiles); live CI job deferred | `offsite_backup.rs` round-trip (compiles via `--no-run`); turning it into a live Actions job → #1744 |

## Deferred (follow-ups)

- #1743 — Wire failed offsite backup upload into #1610 operator-alert channels (AC #6 second half; blocked on #1610).
- #1744 — CI: run the offsite-backup MinIO round-trip in GitHub Actions (AC #8 live job).
- Client-side backup encryption (AES-256-GCM envelope) — explicitly out of scope per the issue; named in the docs' encryption posture.

---
_Generated by [Claude Code](https://claude.ai/code/session_012YoB3FhRdCEu7RQ4SJmgdH)_