### PR TITLE
⚒️ Forge: Refactor inline match blocks in run_command

### DIFF
--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1053,6 +1053,16 @@ enum ServeCommands {
     Restart,
 }
 
+impl From<ServeCommands> for serve::ServeAction {
+    fn from(cmd: ServeCommands) -> Self {
+        match cmd {
+            ServeCommands::Stop => Self::Stop,
+            ServeCommands::Status => Self::Status,
+            ServeCommands::Restart => Self::Restart,
+        }
+    }
+}
+
 /// Process role selector for `autumn serve --role`.
 ///
 /// Mirrors `autumn_web::config::ProcessRole`: `web` serves HTTP only, `worker`
@@ -1167,6 +1177,27 @@ enum MigrateCommands {
         #[arg(long = "force", value_name = "VERSION")]
         force: Option<String>,
     },
+}
+
+impl MigrateCommands {
+    fn into_action(self) -> migrate::MigrateAction {
+        match self {
+            Self::Status => migrate::MigrateAction::Status,
+            Self::Check => migrate::MigrateAction::Check,
+            Self::Down {
+                steps,
+                to,
+                yes_i_mean_prod,
+            } => migrate::MigrateAction::Down(migrate::DownArgs {
+                steps,
+                to,
+                yes_i_mean_prod,
+            }),
+            Self::Baseline { force } => migrate::MigrateAction::Baseline(migrate::BaselineArgs {
+                force_version: force,
+            }),
+        }
+    }
 }
 
 /// Subcommands for `autumn shard`.
@@ -2283,11 +2314,7 @@ fn run_command(command: Commands) {
             package,
             role,
         } => {
-            let action = action.map(|a| match a {
-                ServeCommands::Stop => serve::ServeAction::Stop,
-                ServeCommands::Status => serve::ServeAction::Status,
-                ServeCommands::Restart => serve::ServeAction::Restart,
-            });
+            let action = action.map(Into::into);
             serve::run(
                 action,
                 &serve::ServeOptions {
@@ -2313,25 +2340,7 @@ fn run_command(command: Commands) {
             profile,
             wait,
         } => {
-            let action = match action {
-                Some(MigrateCommands::Status) => migrate::MigrateAction::Status,
-                Some(MigrateCommands::Check) => migrate::MigrateAction::Check,
-                Some(MigrateCommands::Down {
-                    steps,
-                    to,
-                    yes_i_mean_prod,
-                }) => migrate::MigrateAction::Down(migrate::DownArgs {
-                    steps,
-                    to,
-                    yes_i_mean_prod,
-                }),
-                Some(MigrateCommands::Baseline { force }) => {
-                    migrate::MigrateAction::Baseline(migrate::BaselineArgs {
-                        force_version: force,
-                    })
-                }
-                None => migrate::MigrateAction::Run,
-            };
+            let action = action.map_or(migrate::MigrateAction::Run, MigrateCommands::into_action);
             let target = match (shard, control_only) {
                 (Some(name), _) => migrate::MigrateTarget::Shard(name),
                 (None, true) => migrate::MigrateTarget::ControlOnly,


### PR DESCRIPTION
🚮 Smell: The `run_command` function in `autumn-cli/src/main.rs` was massive (~600 lines) and suffered from the 'Pyramid of Doom'. It contained inline `match` statements to convert CLI subcommands (like `ServeCommands` and `MigrateCommands`) into their corresponding internal action enums. This increased nesting depth and made the core routing logic hard to read.

✨ Solution: Extracted the conversion logic for `ServeCommands` into an `impl From<ServeCommands> for serve::ServeAction` block, and the logic for `MigrateCommands` into an `impl MigrateCommands { fn into_action(self) -> migrate::MigrateAction }` block. Used `action.map(Into::into)` and `action.map_or(..., MigrateCommands::into_action)` to flatten the routing arms.

🧼 Benefit: Reduces cognitive load by flattening nesting inside the top-level command router. `run_command` is shorter and delegating cleanly to Rust idioms (`From`/`Into`).

🛡️ Verification: Ran `cargo clippy -p autumn-cli --bin autumn -- -D warnings`, `cargo fmt --all`, and `cargo test -p autumn-cli --bin autumn` successfully. No logic changed.

---
*PR created automatically by Jules for task [9211288941631704182](https://jules.google.com/task/9211288941631704182) started by @madmax983*