### PR TITLE
Fix broken rustdoc intra-doc links in autumn-cli (unblocks Documentation build)

### DIFF
--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -8,7 +8,7 @@
 //! captures precisely the databases the running app uses — control plus every
 //! configured shard — under the active profile/env overlay. The destructive
 //! `restore` is gated by the same production guard as `autumn db drop`
-//! ([`super::guard_destructive`]).
+//! (`guard_destructive`).
 //!
 //! # Artifact layout (S3-bolt-on friendly — issue #1619)
 //!
@@ -27,7 +27,8 @@
 //!
 //! # Zero-external-tools for managed Postgres (AC #2)
 //!
-//! [`PgTools::locate`] resolves `pg_dump`/`pg_restore` from, in order: an
+//! [`PgTools::locate`](crate::db::backup::PgTools::locate) resolves
+//! `pg_dump`/`pg_restore` from, in order: an
 //! explicit `AUTUMN_PG_BIN_DIR`, the managed-Postgres bundle's `bin` directory
 //! (derived from `AUTUMN_MANAGED_PG_DATA_DIR`, which `autumn serve --bundled-pg`
 //! sets), then the `PATH`. A managed-pg daemon therefore needs no externally
@@ -39,7 +40,7 @@ use std::process::Command;
 use crate::migrate;
 
 /// Environment variable that pins the directory holding `pg_dump`/`pg_restore`.
-/// Highest precedence in [`PgTools::locate`]; lets an operator point at a
+/// Highest precedence in [`PgTools::locate`](crate::db::backup::PgTools::locate); lets an operator point at a
 /// specific client-tools install.
 const PG_BIN_DIR_ENV: &str = "AUTUMN_PG_BIN_DIR";
 

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -965,17 +965,17 @@ enum DbCommands {
     /// systemd timer:
     ///
     ///   # myapp-backup.service
-    ///   [Service]
+    ///   `[Service]`
     ///   Type=oneshot
     ///   Environment=AUTUMN_ENV=prod
     ///   WorkingDirectory=/srv/myapp
     ///   ExecStart=/usr/local/bin/autumn db backup --keep 7
     ///
     ///   # myapp-backup.timer
-    ///   [Timer]
+    ///   `[Timer]`
     ///   OnCalendar=*-*-* 02:00:00
     ///   Persistent=true
-    ///   [Install]
+    ///   `[Install]`
     ///   WantedBy=timers.target
     // The scheduling recipe above is shell/unit-file text shown verbatim in
     // `--help`; backticking every `KEY=value` token would leak into that output.


### PR DESCRIPTION
## What

Fixes 5 pre-existing broken rustdoc intra-doc links in `autumn-cli` that fail the Documentation build (`scripts/check-docs.sh`, run with `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links"`) on every PR into `trunk-dev`.

## Background

These broken links were introduced by #1711 but stayed masked on trunk: `check-docs.sh` builds `autumn-web` first under `set -e`, and an earlier `autumn-web` failure (in `fake.rs`) aborted the script before it ever reached `autumn-cli`. Once #1730 fixed that earlier `autumn-web` failure, the script proceeds to `autumn-cli` — where these links now surface and fail the build. So they are trunk-wide red and block all PRs into `trunk-dev`.

## The 5 links

**`autumn-cli/src/db/backup.rs`**
- `` [`super::guard_destructive`] `` — `guard_destructive` is a private `fn` in `crate::db` (`db.rs:217`), so rustdoc rejects it as a private/unresolved intra-doc link. De-linked to plain inline code `` `guard_destructive` ``.
- `` [`PgTools::locate`] `` (two occurrences) — `PgTools` (`pub struct`) and `locate` (`pub fn`) live in `pub mod backup`, but the bare `PgTools::locate` path didn't resolve from the doc context ("no item named `PgTools` in scope"). Repointed to the resolvable fully-qualified path `` [`PgTools::locate`](crate::db::backup::PgTools::locate) ``.

**`autumn-cli/src/main.rs`**
- `[Service]`, `[Timer]`, `[Install]` — these are systemd unit-file INI section names shown verbatim in a `--help` doc comment. rustdoc misreads the `[...]` as intra-doc links. Escaped as inline code: `` `[Service]` ``, `` `[Timer]` ``, `` `[Install]` ``.

No `#[allow]` / lint suppression, no version bump, no other files touched.

## Verification

`./scripts/check-docs.sh` passes end-to-end (builds `autumn-web` then `autumn-cli` and the other publishable crates under `set -e`), exiting 0 with `Documentation build OK — no broken intra-doc links.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144RxG43LrezPaqTud4TWk2

---
_Generated by [Claude Code](https://claude.ai/code/session_0144RxG43LrezPaqTud4TWk2)_