### PR TITLE
test: de-flake three macOS/Windows CI timing tests (#1757, #1758, #1763)

### DIFF
--- a/autumn/tests/integration/cache_stampede.rs
+++ b/autumn/tests/integration/cache_stampede.rs
@@ -376,7 +376,17 @@ async fn swr_serves_stale_and_refreshes_in_background() {
     // no wall-clock ceiling on the load-sensitive scheduling + 200ms compute.
     // (`notify_one` stores a permit if it fires before this await, so there is
     // no lost-wakeup even when the background task wins the race.)
-    refresh_done.notified().await;
+    //
+    // The timeout here is a generous hang-guard, mirroring the 30s bound on the
+    // publish loop below: it exists only to convert a genuine never-fires hang
+    // (e.g. the detached refresh task is dropped when the global refresh
+    // semaphore is exhausted, or a regression stops it ever reaching the fill
+    // closure) into a clean test failure instead of dangling until the CI
+    // runner's global timeout. It is deliberately NOT a tight, schedule-
+    // sensitive value, so it never reintroduces load-dependent flakiness.
+    tokio::time::timeout(Duration::from_secs(30), refresh_done.notified())
+        .await
+        .expect("background refresh never signalled completion (task dropped or never started)");
 
     // The refreshed value is published in `finish_fill` synchronously right
     // after the fill closure returns, so re-read until it is visible. This

--- a/autumn/tests/integration/cache_stampede.rs
+++ b/autumn/tests/integration/cache_stampede.rs
@@ -318,6 +318,13 @@ async fn different_keys_do_not_coalesce() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn swr_serves_stale_and_refreshes_in_background() {
+    // Floor-not-ceiling hang-guard for the two waits below (refresh-notify and
+    // publish-visibility poll). Deliberately generous: it must never trip on a
+    // slow/oversubscribed runner — only on a genuine never-publishes hang. A
+    // real windows-latest run starved the detached refresh past 30s (PR #1764),
+    // so this is set well above any plausible scheduling-starvation window.
+    const HANG_GUARD: Duration = Duration::from_secs(120);
+
     let _guard = METRICS_LOCK.lock().await;
     let cache = fresh_cache();
     let key = unique_key("swr_serves_stale_and_refreshes_in_background");
@@ -377,23 +384,41 @@ async fn swr_serves_stale_and_refreshes_in_background() {
     // (`notify_one` stores a permit if it fires before this await, so there is
     // no lost-wakeup even when the background task wins the race.)
     //
-    // The timeout here is a generous hang-guard, mirroring the 30s bound on the
+    // The timeout here is a generous hang-guard, mirroring the bound on the
     // publish loop below: it exists only to convert a genuine never-fires hang
     // (e.g. the detached refresh task is dropped when the global refresh
     // semaphore is exhausted, or a regression stops it ever reaching the fill
     // closure) into a clean test failure instead of dangling until the CI
     // runner's global timeout. It is deliberately NOT a tight, schedule-
     // sensitive value, so it never reintroduces load-dependent flakiness.
-    tokio::time::timeout(Duration::from_secs(30), refresh_done.notified())
+    tokio::time::timeout(HANG_GUARD, refresh_done.notified())
         .await
         .expect("background refresh never signalled completion (task dropped or never started)");
 
-    // The refreshed value is published in `finish_fill` synchronously right
-    // after the fill closure returns, so re-read until it is visible. This
-    // converges immediately once the background task's publish runs and is NOT
-    // gated on any load-sensitive sleep, so the generous hang-guard below only
-    // trips on a genuine hang — never on a merely slow runner.
-    let refreshed = tokio::time::timeout(Duration::from_secs(30), async {
+    // Confirm the refreshed value becomes visible, by POLLING (re-read, short
+    // sleep, repeat) rather than reading once — never collapse this back to a
+    // single-shot read or a tight ceiling.
+    //
+    // WHY A POLL IS REQUIRED: the `Notify` above is fired from *inside* the
+    // fill closure, but publication (`finish_fill` -> `insert_cached`) runs in
+    // product code *after* the closure returns, on the detached refresh task —
+    // concurrently with this woken test task. So the instant we wake on the
+    // notify, "v2" may not yet be visible to a fresh read; and until the stale
+    // "v1" envelope ages past `ttl + stale_while_revalidate` (~10s) each read
+    // instead blocks as a single-flight waiter on that same detached task's
+    // channel. Either way, test progress is coupled to the detached refresh
+    // being *scheduled* to run its publish — which a heavily oversubscribed CI
+    // runner can starve for many seconds (a real windows-latest run starved it
+    // past 30s; see PR #1764).
+    //
+    // WHY THE 120s BOUND IS A FLOOR, NOT A CEILING: under any sane load this
+    // converges in well under a second (the refresh computes in 200ms), so 120s
+    // must never trip on a merely slow/loaded runner — it exists solely to turn
+    // a genuine "publish never happens" bug (dropped/hung refresh task) into a
+    // clean failure instead of dangling until the job-level timeout. It is
+    // deliberately generous precisely so it is not schedule-sensitive; do not
+    // shrink it back toward the observed starvation window.
+    let refreshed = tokio::time::timeout(HANG_GUARD, async {
         loop {
             let fc = fill_count.clone();
             let v: String = get_or_compute_with(&cache, &key, opts.clone(), move || async move {
@@ -405,7 +430,7 @@ async fn swr_serves_stale_and_refreshes_in_background() {
             if v == "v2" {
                 break v;
             }
-            tokio::time::sleep(Duration::from_millis(5)).await;
+            tokio::time::sleep(Duration::from_millis(25)).await;
         }
     })
     .await

--- a/autumn/tests/integration/cache_stampede.rs
+++ b/autumn/tests/integration/cache_stampede.rs
@@ -342,12 +342,23 @@ async fn swr_serves_stale_and_refreshes_in_background() {
     // the grace period).
     tokio::time::sleep(Duration::from_millis(80)).await;
 
+    // A deterministic signal the background refresh's fill closure fires the
+    // moment it finishes computing the new value. Waiting on this — rather than
+    // a fixed wall-clock timeout — absorbs however long a slow/loaded runner
+    // takes to schedule and run the detached background task.
+    let refresh_done = Arc::new(tokio::sync::Notify::new());
+
     let start = std::time::Instant::now();
     let fc = fill_count.clone();
+    let done = refresh_done.clone();
     let v: String = get_or_compute_with(&cache, &key, opts.clone(), move || async move {
         fc.fetch_add(1, Ordering::SeqCst);
         tokio::time::sleep(Duration::from_millis(200)).await;
-        Ok::<String, String>("v2".to_string())
+        let out = Ok::<String, String>("v2".to_string());
+        // Publication (`insert_cached`) happens synchronously right after this
+        // closure returns; signal now that the compute is done.
+        done.notify_one();
+        out
     })
     .await
     .unwrap();
@@ -361,8 +372,18 @@ async fn swr_serves_stale_and_refreshes_in_background() {
         "serving stale must not wait on the slow background refresh, took {elapsed:?}"
     );
 
-    // Poll until the background refresh completes and the fresh value is visible.
-    let refreshed = tokio::time::timeout(Duration::from_secs(2), async {
+    // Wait deterministically for the background refresh to finish computing —
+    // no wall-clock ceiling on the load-sensitive scheduling + 200ms compute.
+    // (`notify_one` stores a permit if it fires before this await, so there is
+    // no lost-wakeup even when the background task wins the race.)
+    refresh_done.notified().await;
+
+    // The refreshed value is published in `finish_fill` synchronously right
+    // after the fill closure returns, so re-read until it is visible. This
+    // converges immediately once the background task's publish runs and is NOT
+    // gated on any load-sensitive sleep, so the generous hang-guard below only
+    // trips on a genuine hang — never on a merely slow runner.
+    let refreshed = tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             let fc = fill_count.clone();
             let v: String = get_or_compute_with(&cache, &key, opts.clone(), move || async move {
@@ -374,11 +395,11 @@ async fn swr_serves_stale_and_refreshes_in_background() {
             if v == "v2" {
                 break v;
             }
-            tokio::time::sleep(Duration::from_millis(20)).await;
+            tokio::time::sleep(Duration::from_millis(5)).await;
         }
     })
     .await
-    .expect("background refresh must eventually publish the new value");
+    .expect("background refresh must publish the new value after it finishes computing");
     assert_eq!(refreshed, "v2");
 
     let after = read_through_metrics().snapshot();

--- a/autumn/tests/integration/mcp_streaming.rs
+++ b/autumn/tests/integration/mcp_streaming.rs
@@ -361,24 +361,42 @@ async fn first_progress_arrives_before_the_slow_tool_completes() {
     // "done" bytes cannot exist until that tail elapses: an incrementally
     // streamed response necessarily surfaces the first frame ahead of
     // completion, while a buffered response would collapse both into one chunk.
-    let mut first_at = None;
-    let mut done_at = None;
-    let mut buf = String::new();
-    while let Some(chunk) = body.next().await {
-        let bytes = chunk.unwrap();
-        if bytes.is_empty() {
-            continue;
+    //
+    // The 30s bound wrapping this read loop is a generous hang-guard, mirroring
+    // the hang-guards elsewhere in this PR: if a regression drops the final MCP
+    // progress/result frame while leaving the SSE response OPEN (e.g. via
+    // keep-alives), `body.next().await` would otherwise dangle waiting for a
+    // `done` frame that never arrives, hanging until the suite-wide timeout
+    // instead of failing locally here. It is a FLOOR-not-ceiling value: the read
+    // loop finishes in ~300ms under normal load (gated only on the handler's
+    // fixed sleep, never on load-sensitive scheduling), so this bound only ever
+    // trips on a genuine never-arrives hang — never on a merely slow runner.
+    let (first_at, done_at) = tokio::time::timeout(Duration::from_secs(30), async {
+        let mut first_at = None;
+        let mut done_at = None;
+        let mut buf = String::new();
+        while let Some(chunk) = body.next().await {
+            let bytes = chunk.unwrap();
+            if bytes.is_empty() {
+                continue;
+            }
+            let at = start.elapsed();
+            if first_at.is_none() {
+                first_at = Some(at);
+            }
+            buf.push_str(&String::from_utf8_lossy(&bytes));
+            if buf.contains("done") {
+                done_at = Some(at);
+                break;
+            }
         }
-        let at = start.elapsed();
-        if first_at.is_none() {
-            first_at = Some(at);
-        }
-        buf.push_str(&String::from_utf8_lossy(&bytes));
-        if buf.contains("done") {
-            done_at = Some(at);
-            break;
-        }
-    }
+        (first_at, done_at)
+    })
+    .await
+    .expect(
+        "MCP stream never delivered a `done` frame within the hang-guard \
+         (final frame dropped while SSE stayed open?)",
+    );
     let first_at = first_at.expect("a first frame");
     let done_at = done_at.expect("a completion frame carrying the slow tail");
     // Cheap ordering check documents intent, but on its own it is too weak: a

--- a/autumn/tests/integration/mcp_streaming.rs
+++ b/autumn/tests/integration/mcp_streaming.rs
@@ -355,18 +355,38 @@ async fn first_progress_arrives_before_the_slow_tool_completes() {
     let start = std::time::Instant::now();
     let response = tower::ServiceExt::oneshot(router, request).await.unwrap();
     let mut body = response.into_body().into_data_stream();
-    // Pull the first non-empty chunk.
+    // Record when the first streamed signal arrives versus when the completion
+    // frame (carrying the slow tail's "done" payload) arrives. The handler
+    // sleeps 300ms *between* emitting the first event and the final one, so the
+    // "done" bytes cannot exist until that tail elapses: an incrementally
+    // streamed response necessarily surfaces the first frame ahead of
+    // completion, while a buffered response would collapse both into one chunk.
     let mut first_at = None;
+    let mut done_at = None;
+    let mut buf = String::new();
     while let Some(chunk) = body.next().await {
         let bytes = chunk.unwrap();
-        if !bytes.is_empty() {
-            first_at = Some(start.elapsed());
+        if bytes.is_empty() {
+            continue;
+        }
+        let at = start.elapsed();
+        if first_at.is_none() {
+            first_at = Some(at);
+        }
+        buf.push_str(&String::from_utf8_lossy(&bytes));
+        if buf.contains("done") {
+            done_at = Some(at);
             break;
         }
     }
-    let elapsed = first_at.expect("a first frame");
+    let first_at = first_at.expect("a first frame");
+    let done_at = done_at.expect("a completion frame carrying the slow tail");
+    // Assert ORDERING, not a fixed wall-clock budget: the first signal must
+    // arrive strictly before completion. This holds no matter how slow or
+    // loaded the runner is, because the 300ms tail is produced only after the
+    // first frame is already on the wire.
     assert!(
-        elapsed < Duration::from_millis(250),
-        "first signal should precede the 300ms tail; took {elapsed:?}"
+        first_at < done_at,
+        "first signal must precede completion (first at {first_at:?}, done at {done_at:?})"
     );
 }

--- a/autumn/tests/integration/mcp_streaming.rs
+++ b/autumn/tests/integration/mcp_streaming.rs
@@ -381,12 +381,34 @@ async fn first_progress_arrives_before_the_slow_tool_completes() {
     }
     let first_at = first_at.expect("a first frame");
     let done_at = done_at.expect("a completion frame carrying the slow tail");
-    // Assert ORDERING, not a fixed wall-clock budget: the first signal must
-    // arrive strictly before completion. This holds no matter how slow or
-    // loaded the runner is, because the 300ms tail is produced only after the
-    // first frame is already on the wire.
+    // Cheap ordering check documents intent, but on its own it is too weak: a
+    // buffered regression that stalled the inner handler until it finished would
+    // still emit the `started` progress frame and the final `done` frame as two
+    // back-to-back outer chunks *after* the sleep, and `first_at < done_at`
+    // would still pass even though no signal arrived before the slow tail.
     assert!(
         first_at < done_at,
         "first signal must precede completion (first at {first_at:?}, done at {done_at:?})"
+    );
+    // The real discriminator is the GAP: the handler sleeps 300ms between the
+    // first frame and the `done` frame, so a genuinely streamed response forces
+    // at least ~300ms between the two timestamps, while a buffered response
+    // collapses that gap to ~0.
+    //
+    // Why asserting a floor (>= 250ms) is robust and NOT runner-flaky: the gap
+    // is dominated by the handler's fixed `tokio::time::sleep`, which is a
+    // FLOOR, never a ceiling. `tokio::time::sleep` never fires early, and a
+    // slow/loaded runner only pushes *both* timestamps later together, keeping
+    // the gap >= the sleep. A buffered regression is the only thing that drives
+    // the gap toward zero. Do NOT "simplify" this back to bare ordering, and do
+    // NOT reintroduce an absolute ceiling like `first_at < 250ms` — that would
+    // be the runner-sensitive assertion this test was de-flaked to remove.
+    let gap = done_at.saturating_sub(first_at);
+    assert!(
+        gap >= Duration::from_millis(250),
+        "progress must arrive before the slow tail completes: gap between first \
+         frame and done was {gap:?}, expected >= 250ms (handler sleeps 300ms \
+         between progress and completion; a near-zero gap means the response was \
+         buffered rather than streamed)"
     );
 }

--- a/autumn/tests/integration/sse_replay.rs
+++ b/autumn/tests/integration/sse_replay.rs
@@ -680,37 +680,63 @@ async fn stream_resumable_cold_serializes_only_live_events() {
 async fn concurrent_publish_around_resume_has_no_dup_or_skip() {
     use std::sync::{Arc, Barrier};
 
-    // Track that the interleaving genuinely lands the boundary message in BOTH
-    // the replay snapshot and the live tail across trials — otherwise one branch
-    // is dead code and the test proves nothing.
-    let mut saw_replay = false;
-    let mut saw_live = false;
+    // Which side of the seam the boundary message (m11) is forced onto for a
+    // trial. The two deterministic orderings prove BOTH branches are exercised
+    // regardless of runner scheduling; `Race` additionally stresses the real
+    // lock contention that a barrier releases both threads into at once.
+    enum SeamOrdering {
+        /// Publish m11 *before* resuming: it is already in the replay buffer, so
+        /// the snapshot must include it (replay branch).
+        PublishThenResume,
+        /// Resume *before* m11 exists: the snapshot is empty and m11 must arrive
+        /// on the live subscriber (live-tail branch).
+        ResumeThenPublish,
+        /// Genuine race: a barrier releases publisher and resumer together so
+        /// their contention for the replay lock is real; whichever wins, the
+        /// exactly-once correctness assertions below must still hold.
+        Race,
+    }
 
-    // Run many trials; a barrier releases the publisher and the resumer at the
-    // same instant so their contention for the replay lock is a real race.
-    for _ in 0..256 {
+    // Run one seam trial under `ordering`. Publishes m11 around a
+    // resume-from-seq-10 and asserts m11 is delivered exactly once — either in
+    // the replay snapshot OR as the first live event, never both, never neither,
+    // with a consistent `next_live_id`. Returns `true` when m11 landed in the
+    // replay snapshot (replay branch), `false` when it arrived live (live-tail
+    // branch), so the caller can prove both branches are covered.
+    async fn run_seam_trial(ordering: &SeamOrdering) -> bool {
         let channels = Channels::new(256);
         let topic = "seam";
         for i in 1..=10 {
             publish(&channels, topic, &format!("m{i}"));
         }
-
-        // Publish m11 (the boundary message) concurrently with resume-from-10.
-        // The barrier makes both threads reach the contended replay lock together
-        // so which one wins varies from trial to trial.
-        let barrier = Arc::new(Barrier::new(2));
-        let bg = {
-            let channels = channels.clone();
-            let barrier = Arc::clone(&barrier);
-            tokio::task::spawn_blocking(move || {
-                barrier.wait();
-                publish(&channels, topic, "m11");
-            })
-        };
         let epoch = topic_epoch(&channels, topic);
-        barrier.wait();
-        let mut handle = channels.resume(topic, Some(EventId { epoch, seq: 10 }));
-        bg.await.unwrap();
+
+        let mut handle = match ordering {
+            SeamOrdering::PublishThenResume => {
+                publish(&channels, topic, "m11");
+                channels.resume(topic, Some(EventId { epoch, seq: 10 }))
+            }
+            SeamOrdering::ResumeThenPublish => {
+                let handle = channels.resume(topic, Some(EventId { epoch, seq: 10 }));
+                publish(&channels, topic, "m11");
+                handle
+            }
+            SeamOrdering::Race => {
+                let barrier = Arc::new(Barrier::new(2));
+                let bg = {
+                    let channels = channels.clone();
+                    let barrier = Arc::clone(&barrier);
+                    tokio::task::spawn_blocking(move || {
+                        barrier.wait();
+                        publish(&channels, topic, "m11");
+                    })
+                };
+                barrier.wait();
+                let handle = channels.resume(topic, Some(EventId { epoch, seq: 10 }));
+                bg.await.unwrap();
+                handle
+            }
+        };
 
         // m11 is delivered exactly once: either in the replay snapshot OR as the
         // first live event — never both, never neither.
@@ -721,13 +747,12 @@ async fn concurrent_publish_around_resume_has_no_dup_or_skip() {
         );
 
         if in_replay.contains(&11) {
-            saw_replay = true;
             // Delivered via replay; the live subscriber must not repeat it.
             assert_eq!(handle.next_live_id, 12);
             publish(&channels, topic, "m12");
             assert_eq!(handle.subscriber.recv().await.unwrap().as_str(), "m12");
+            true
         } else {
-            saw_live = true;
             // Not in replay → must arrive live as the very next event, id 11.
             assert_eq!(handle.next_live_id, 11);
             let live = tokio::time::timeout(Duration::from_secs(1), handle.subscriber.recv())
@@ -735,16 +760,28 @@ async fn concurrent_publish_around_resume_has_no_dup_or_skip() {
                 .expect("m11 must arrive live")
                 .unwrap();
             assert_eq!(live.as_str(), "m11");
+            false
         }
     }
 
-    // The whole point of the race: over the trials the boundary message must
-    // have landed on BOTH sides of the seam, so neither branch is dead.
+    // Deterministically exercise BOTH sides of the seam — no reliance on runner
+    // scheduling to hit each branch (the old flaky guard).
+    let saw_replay = run_seam_trial(&SeamOrdering::PublishThenResume).await;
+    let saw_live = !run_seam_trial(&SeamOrdering::ResumeThenPublish).await;
     assert!(
-        saw_replay && saw_live,
-        "interleaving must exercise both the replay and the live-tail branch \
-         (saw_replay={saw_replay}, saw_live={saw_live})"
+        saw_replay,
+        "publish-then-resume must land m11 in the replay snapshot"
     );
+    assert!(
+        saw_live,
+        "resume-then-publish must deliver m11 on the live tail"
+    );
+
+    // Additional genuine-race trials stress the contended replay lock; the
+    // exactly-once assertions inside each trial hold whichever side wins.
+    for _ in 0..256 {
+        run_seam_trial(&SeamOrdering::Race).await;
+    }
 }
 
 // ── AC#1/AC#2: monotonic ids, bounded buffer ──────────────────────────────────


### PR DESCRIPTION
## Before

Three integration tests passed locally but intermittently failed on loaded CI runners because they asserted against wall-clock timing / a nondeterministic thread race rather than the behavior they actually guard:

- **`sse_replay::concurrent_publish_around_resume_has_no_dup_or_skip`** (#1757) — relied on a barrier race to land the boundary message on *both* sides of the replay/live seam across trials, then asserted both branches were seen. On slow macOS runners the race only ever hit the replay branch, so the test's own guard panicked (`saw_replay=true, saw_live=false`).
- **`mcp_streaming::first_progress_arrives_before_the_slow_tool_completes`** (#1758) — asserted the first streamed frame arrived within a fixed **300ms** wall-clock budget. Under macOS runner load the first frame legitimately arrived at ~447ms and tripped the absolute bound.
- **`cache_stampede::swr_serves_stale_and_refreshes_in_background`** (#1763) — polled for the stale-while-revalidate background refresh to publish inside a tight **2s** `tokio::time::timeout`. On a very slow/loaded Windows runner the refresh hadn't published in time and the timeout elapsed (`Elapsed(())`).

## After

All three assert the guaranteed behavior deterministically and no longer depend on runner speed:

- **#1757** — both sides of the seam are exercised by two **deterministic orderings** (publish-then-resume forces the replay branch; resume-then-publish forces the live-tail branch), so branch coverage no longer depends on scheduling. The genuine barrier-race trials are kept as extra stress, and every exactly-once (no-dup / no-skip) assertion is preserved.
- **#1758** — asserts **ordering** (the first streamed frame arrives strictly before the completion frame carrying the 300ms tail) instead of a fixed budget. This still proves progress-before-completion and holds on any runner.
- **#1763** — waits on a **`Notify`** fired by the background refresh's fill closure (no wall-clock ceiling on the load-sensitive schedule + compute), followed by a hang-guarded confirm-read for publish visibility. Both guarantees — stale value served immediately, refresh eventually publishes — are preserved.

## How

Each test's timing-fragile step was replaced with an explicit happens-before edge:

- For **sse_replay**, a `SeamOrdering` enum parameterizes one trial helper; the two deterministic orderings sequence `publish` and `resume` so the boundary message provably lands in the replay snapshot in one and on the live tail in the other. `Race` trials remain for lock-contention stress but no longer gate branch coverage.
- For **mcp_streaming**, the raw response body is read chunk-by-chunk, recording the arrival of the first frame and of the frame that first carries the `"done"` payload; since the handler sleeps 300ms *between* emitting them, an incrementally streamed response necessarily surfaces the first frame before completion, and the test asserts exactly that ordering.
- For **cache_stampede**, the background refresh's fill closure calls `Notify::notify_one()` the moment it finishes computing (publication via `insert_cached` is synchronous immediately after the closure returns, so no `.await` intervenes). The test `notified().await`s that signal — which stores a permit if it fires first, so there's no lost wakeup — then re-reads until the fresh value is visible under a generous hang-guard that can only trip on a real hang.

All changes are **test-only**; no SSE replay, MCP streaming, or SWR/cache product code was modified.

Closes #1757
Closes #1758
Closes #1763

### Verification
- Each fixed test looped **25/25 passing** locally (`--exact`, full module path).
- Full consolidated integration target green: `1223 passed; 0 failed; 91 ignored`.
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.

> Known-red: the "Documentation build" CI check is red trunk-wide (pre-existing, tracked in #1759) — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ubru2Hp76EHVZezmvfe94F)_