### PR TITLE
🍎 Eris: [XSS in channels::inject_oob_attr]

### DIFF
--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -536,8 +536,9 @@ pub(crate) fn inject_oob_attr(html: &str, value: &str) -> String {
         let after_lt = &html[lt + 1..];
         if let Some(pos) = after_lt.find([' ', '>']) {
             let insert_at = lt + 1 + pos;
+            let escaped_val = crate::htmx::escape_attribute_string(value);
             return format!(
-                "{} hx-swap-oob=\"{value}\"{}",
+                "{} hx-swap-oob=\"{escaped_val}\"{}",
                 &html[..insert_at],
                 &html[insert_at..]
             );
@@ -2283,5 +2284,17 @@ mod tests {
     fn inject_oob_attr_fallback_no_boundary() {
         let result = inject_oob_attr("<", "true");
         assert_eq!(result, "<", "fallback must return html unchanged");
+    }
+}
+
+#[cfg(test)]
+mod security_tests {
+    use super::*;
+
+    #[test]
+    fn test_inject_oob_attr_escapes_input() {
+        let result = inject_oob_attr("<div></div>", "\"><script>alert(1)</script>");
+        assert!(!result.contains("<script>alert(1)</script>"), "channels::inject_oob_attr is vulnerable!");
+        assert!(result.contains("&lt;script&gt;alert(1)&lt;/script&gt;"));
     }
 }


### PR DESCRIPTION
Reconnaissance:
Found `inject_oob_attr` in `autumn/src/channels.rs` which dynamically constructs a `hx-swap-oob` attribute from its arguments without escaping.

Hypothesis:
Injecting an unescaped value like `"><script>alert(1)</script>` into `inject_oob_attr` will break out of the HTML attribute and execute XSS payloads.

Exploit development:
Created `test_inject_oob_attr_escapes_input` demonstrating that providing `"><script>alert(1)</script>` directly returned `<div hx-swap-oob=""><script>alert(1)</script>"></div>`.

Verification:
Tested via `cargo test -p autumn-web --features ws --lib channels::security_tests`, proving the payload was rendered unchanged. Added a regression test there.

Severity assessment:
Moderate to High. Depends on attacker-controlled inputs ending up in Out-Of-Band (OOB) swap ids or fallback paths when communicating via channels/Live.

Remediation recommendation:
Use `crate::htmx::escape_attribute_string(value)` in `inject_oob_attr` to properly escape all injected values.

---
*PR created automatically by Jules for task [4061334727994461469](https://jules.google.com/task/4061334727994461469) started by @madmax983*