### PR TITLE
Fix broken/private rustdoc intra-doc links workspace-wide (unblock Documentation build)

### DIFF
--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -1172,7 +1172,7 @@ fn is_valid_mailto_address_doctor(value: &str) -> bool {
     }
 }
 
-/// Whether `value` parses as the SAME lettre [`Mailbox`](lettre::message::Mailbox)
+/// Whether `value` parses as the SAME lettre `Mailbox` (`lettre::message::Mailbox`)
 /// the alert mail send path requires of every recipient — EXACT parity with the
 /// runtime's `is_valid_alert_mailbox` (`autumn/src/alerts.rs`), which validates
 /// `[alerts] email` with `email.parse::<lettre::message::Mailbox>()`.

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -1038,7 +1038,7 @@ pub fn link_models_into_seed_bin(existing: &str) -> String {
 /// alone. Idempotent: a block already absent is a no-op. Blank lines left at
 /// the removal seam are collapsed so the reverted file stays tidy.
 ///
-/// This is gated by [`Revert::SeedBinLinks`]'s `owner_dir` (`src/models`) so it
+/// This is gated by [`Revert::SeedBinLinks`](crate::generate::emit::Revert::SeedBinLinks)'s `owner_dir` (`src/models`) so it
 /// only runs when the *last* model is destroyed — destroying one of several
 /// models leaves the links in place, matching the surviving `models/mod.rs`.
 #[must_use]

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -17,41 +17,41 @@
 //!
 //! | Condition | Fires when | Where to look |
 //! |-----------|------------|---------------|
-//! | [`AlertCondition::DeadLetteredJob`] | a background job exhausts its retries and is dead-lettered | `/actuator/jobs` † |
-//! | [`AlertCondition::HealthIndicatorDown`] | a registered health indicator reports `Down` past the grace period | `/actuator/health` |
-//! | [`AlertCondition::HighErrorRate`] | the rolling 5xx rate crosses the configured threshold | `/actuator/metrics` |
-//! | [`AlertCondition::ScheduledTaskFailure`] | a framework-scheduled task (backup, cert-renewal, cron/fixed-delay) fails | `/actuator/tasks` † |
+//! | [`AlertCondition::DeadLetteredJob`](crate::alerts::AlertCondition::DeadLetteredJob) | a background job exhausts its retries and is dead-lettered | `/actuator/jobs` † |
+//! | [`AlertCondition::HealthIndicatorDown`](crate::alerts::AlertCondition::HealthIndicatorDown) | a registered health indicator reports `Down` past the grace period | `/actuator/health` |
+//! | [`AlertCondition::HighErrorRate`](crate::alerts::AlertCondition::HighErrorRate) | the rolling 5xx rate crosses the configured threshold | `/actuator/metrics` |
+//! | [`AlertCondition::ScheduledTaskFailure`](crate::alerts::AlertCondition::ScheduledTaskFailure) | a framework-scheduled task (backup, cert-renewal, cron/fixed-delay) fails | `/actuator/tasks` † |
 //!
 //! † `/actuator/jobs` and `/actuator/tasks` are mounted only when `[actuator]
 //! sensitive = true` (default `false`). When it is off, those two alerts point at
 //! the always-mounted `/actuator/health` instead and note that the richer
-//! endpoint needs `sensitive = true` (see [`sensitive_gated_where_to_look`]).
+//! endpoint needs `sensitive = true` (see `sensitive_gated_where_to_look`).
 //!
 //! # Delivery is a trait (extension point)
 //!
-//! Every destination implements [`AlertChannel`]. The [`Alerter`] holds a
+//! Every destination implements [`AlertChannel`](crate::alerts::AlertChannel). The [`Alerter`](crate::alerts::Alerter) holds a
 //! fan-out list of channels and delivers each alert to all of them on a
 //! detached task — so a slow or unreachable channel never adds latency to a
 //! request or blocks the others. Two built-in channels ship:
-//! [`MailAlertChannel`] (reuses the app's [`Mailer`](crate::mail::Mailer)) and
-//! [`WebhookAlertChannel`] (a signed, Stripe-style HMAC POST reusing the same
+//! [`MailAlertChannel`](crate::alerts::MailAlertChannel) (reuses the app's [`Mailer`](crate::mail::Mailer)) and
+//! [`WebhookAlertChannel`](crate::alerts::WebhookAlertChannel) (a signed, Stripe-style HMAC POST reusing the same
 //! signing scheme as [`webhook_outbound`](crate::webhook_outbound)).
 //!
 //! **Design intent (follow-up #1630):** PagerDuty / Slack / Discord transports
-//! are added purely by implementing [`AlertChannel`] and registering them with
+//! are added purely by implementing [`AlertChannel`](crate::alerts::AlertChannel) and registering them with
 //! [`AppBuilder::with_alert_channel`](crate::app::AppBuilder::with_alert_channel);
-//! the core never changes. That is why every [`Alert`] carries a **stable dedup
-//! key** ([`Alert::dedup_key`], which PagerDuty correlates on), a **severity
-//! class** ([`Alert::severity`]), and a **trigger vs resolve** discriminator
-//! ([`Alert::event`]).
+//! the core never changes. That is why every [`Alert`](crate::alerts::Alert) carries a **stable dedup
+//! key** ([`Alert::dedup_key`](crate::alerts::Alert::dedup_key), which PagerDuty correlates on), a **severity
+//! class** ([`Alert::severity`](crate::alerts::Alert::severity)), and a **trigger vs resolve** discriminator
+//! ([`Alert::event`](crate::alerts::Alert::event)).
 //!
 //! # Deduplication and recovery
 //!
 //! A sustained or repeating condition does **not** produce one notification per
-//! occurrence. [`AlertDeduplicator`] bounds notifications to **at most one per
+//! occurrence. [`AlertDeduplicator`](crate::alerts::AlertDeduplicator) bounds notifications to **at most one per
 //! condition per dedup window** (default 15 minutes); the condition re-notifies
 //! once per window while it persists. When a previously-alerted condition
-//! clears, a single [`AlertEventKind::Resolve`] recovery notification is sent.
+//! clears, a single [`AlertEventKind::Resolve`](crate::alerts::AlertEventKind::Resolve) recovery notification is sent.
 //!
 //! # Fail-safe
 //!
@@ -108,9 +108,9 @@ impl AlertCondition {
     ///
     /// This is the builder default. When the app configures a custom
     /// `[actuator] prefix`, the emitted alert's `where_to_look` is rebuilt from
-    /// the effective prefix (see [`actuator_where_to_look`]) so it points at the
+    /// the effective prefix (see `actuator_where_to_look`) so it points at the
     /// real endpoint rather than a `/actuator/*` 404. Keep the suffixes here in
-    /// sync with [`Self::actuator_suffix`].
+    /// sync with `Self::actuator_suffix`.
     #[must_use]
     pub const fn where_to_look(self) -> &'static str {
         match self {
@@ -519,14 +519,14 @@ pub struct AlerterSettings {
     /// The effective actuator URL prefix (`[actuator] prefix`, default
     /// `/actuator`). Every alert's `where_to_look` pointer is built from this so
     /// operators are sent to the real actuator endpoint even when the prefix is
-    /// customized. Stored raw; normalization happens in [`actuator_where_to_look`].
+    /// customized. Stored raw; normalization happens in `actuator_where_to_look`.
     pub actuator_prefix: String,
     /// The effective `[actuator] sensitive` flag (default `false`). The `/jobs`
     /// and `/tasks` actuator endpoints are mounted ONLY when this is `true`
     /// (see `actuator_router_with_prefix`), so the dead-lettered-job and
     /// scheduled-task-failure alerts point at them only when they exist and fall
     /// back to an always-mounted endpoint otherwise (see
-    /// [`sensitive_gated_where_to_look`]).
+    /// `sensitive_gated_where_to_look`).
     pub actuator_sensitive: bool,
 }
 


### PR DESCRIPTION
## What

Fixes pre-existing broken and private rustdoc intra-doc links across the workspace so `./scripts/check-docs.sh` (the `publish-gate` Documentation build) passes end-to-end.

## Why they surface one crate at a time

`scripts/check-docs.sh` runs under `set -euo pipefail` and documents each publishable crate sequentially. The first crate that fails aborts the script, masking broken links in every crate built after it. Each prior fix has only unmasked the next crate:

- `fake.rs` was #1730
- `autumn-cli` was #1759
- this sweep clears the remaining backlog, starting with `alerts.rs` (introduced by commit 2230616 / #1713)

Rather than fix one crate at a time, this PR runs each crate's `cargo doc` invocation independently to enumerate the complete cross-crate error set, then fixes all of it in one pass.

## Crates / files fixed

- **autumn-web** — `autumn/src/alerts.rs` (20 errors; introduced by commit 2230616 / #1713)
  - Module-level `//!` doc links to public items (`AlertCondition::*`, `AlertChannel`, `Alerter`, `MailAlertChannel`, `WebhookAlertChannel`, `Alert`, `Alert::dedup_key`/`severity`/`event`, `AlertDeduplicator`, `AlertEventKind::Resolve`) were not resolving by bare name — rewritten as fully-qualified `crate::alerts::...` intra-doc paths.
  - Public-item doc links to the private helpers `actuator_where_to_look`, `Self::actuator_suffix`, and `sensitive_gated_where_to_look` (which triggered `private_intra_doc_links`) were de-linked to plain inline code (backticks).
- **autumn-cli**
  - `autumn-cli/src/doctor.rs` — link to `lettre::message::Mailbox` (lettre is not an `autumn-cli` dependency) de-linked to inline code.
  - `autumn-cli/src/generate/schema_edit.rs` — the `Revert::SeedBinLinks` link rewritten as the fully-qualified `crate::generate::emit::Revert::SeedBinLinks` intra-doc path.

`autumn-macros`, `autumn-admin-plugin`, `autumn-storage-s3`, and `autumn-cache-redis` documented cleanly and were not touched.

## Scope

Doc-comment changes only: intra-doc path corrections, de-links, and backticks. No behavioral or code changes, no `#[allow]` / global lint suppression, no version or changelog edits.

## Verification

`./scripts/check-docs.sh` now passes end-to-end:

```
Documentation build OK — no broken intra-doc links.
```

(exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144RxG43LrezPaqTud4TWk2

---
_Generated by [Claude Code](https://claude.ai/code/session_0144RxG43LrezPaqTud4TWk2)_