### PR TITLE
docs: changelog + skills for 2026-07-11 merged feature waves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1279,7 +1279,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   running it unsharded (issue #1692).
 - **scaffold:** scaffolded views now render through the shared application
   layout instead of a bare standalone page, and flash rendering was migrated to
-  the shared flash helper (issue #1130).
+  the shared flash helper (issues #1130, #1240).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1124,6 +1124,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.create_many`. `autumn seed --count N --model <Name>` (used together)
   generates and inserts N faked rows via the model's factory instead of running
   the hand-written seed body (issue #1343).
+- **alerts:** operator alerts on critical production failures — email and
+  signed-webhook notifications delivered through your existing mailer and
+  outbound-webhook machinery with no application code. Configure a destination
+  under `[alerts]` (`email` / `webhook_url` + `webhook_secret`) and every
+  built-in condition fires, deduplicated with a recovery notice when it clears:
+  a dead-lettered job, a health indicator down past `health_grace_secs`, the
+  rolling 5xx rate crossing `error_rate_threshold`, or a framework-scheduled
+  task failing. Each alert carries a stable `dedup_key`, a `critical`/`recovery`
+  severity, the host/replica, and a "where to look" actuator pointer; webhooks
+  are always signed (`webhook_secret` required). Custom transports plug in via
+  `AlertChannel` + `AppBuilder::with_alert_channel`, and `autumn doctor` warns
+  (in production) on a missing or unusable destination (issue #1610).
+- **macros:** `#[validate(...)]` rules declared on an `UpdateModel` are now
+  enforced on `PUT`/`PATCH` updates, not only on create, so a partial update
+  rejects invalid input the same way a create does (issue #1719).
+- **jobs:** per-queue reserved/concurrency worker pools — a `[jobs.queues]`
+  value can be a table with `reserved = N` (dedicated slots no other queue may
+  consume) and `concurrency = N` (a hard cap on a queue's share of
+  `jobs.workers`), plus `jobs.pin` (or `AUTUMN_JOBS__PIN`) to pin a
+  `worker`-role process to a subset of queues, and per-queue actuator gauges (a
+  `queues` key with `depth` / `oldest_waiting_age_ms`) on
+  `<actuator-prefix>/jobs` (issue #1623). The resolved `ProcessRole` is exposed
+  on `AppState` via `state.role()` (`serves_http()` / `runs_workers()`), so
+  app-owned background loops can self-gate to the right tier (issue #1726).
+- **cli:** authenticated account-management flows scaffolded by
+  `autumn generate auth` — change-password (`/account/password`) and
+  change-email (`/account/email`), both `#[secured]` and behind a fresh
+  `#[step_up]` claim, verifying the current password and re-rendering at **422**
+  on bad input, with the current device kept signed in (issue #1396) — plus
+  `--magic-link` passwordless email login, which adds a `magic_link_token`
+  model + `magic_link_tokens` table and single-use, expiring login-link routes
+  (issue #1328).
+- **scaffold:** richer `autumn generate scaffold` output — a `belongs_to`
+  foreign key (`post:references`) renders as a populated `<select>` dropdown
+  labeled by the parent's display column (overridable with `{label:col}`), with
+  index/show views showing the parent's display value instead of the raw `*_id`
+  (issue #1146); a trailing `{…}` block on a field declares a constraint once
+  and emits **both** a server-side `#[validate(...)]` rule and the matching
+  HTML5 input attribute — `{min=N,max=N}`, `{email}`, `{url}` (issue #1388); and
+  when a `src/bin/seed.rs` exists the generator idempotently links the
+  `schema`/`models` modules into it so `autumn seed --count/--model` resolves
+  the model's factory (issue #1718).
+- **http:** SSRF hardening for the outbound HTTP client, all opt-in — the
+  default path (shared client, reqwest auto-follow) is unchanged.
+  `RequestBuilder::no_redirect()` returns a 3xx verbatim and
+  `follow_redirects(max, validator)` follows a bounded number of hops, resolving
+  each `Location` to an absolute URL and calling the validator before following
+  (rejecting with `RedirectRejected` / `TooManyRedirects`) (issue #1238);
+  `RequestBuilder::pin_to(addr)` pins the connection to a validated socket
+  address (skipping DNS while preserving Host/SNI) to close DNS-rebinding/TOCTOU
+  gaps (issue #1239). `Client::get_ssrf_safe(url)` composes the safe path —
+  resolve once, validate every resolved IP against the built-in SSRF deny-list
+  (public `is_blocked_ip` / `is_public_ip` helpers, IPv4-mapped/compat and
+  NAT64/6to4-tunnelled forms unwrapped and re-checked), pin to a validated
+  address, then follow redirects with per-hop resolve→validate→pin and an
+  https→http downgrade guard. New `ClientError` variants `SsrfBlocked`,
+  `TooManyRedirects`, `RedirectRejected`, `InvalidUrl` (issues #1238, #1239).
 
 ### Fixed
 
@@ -1216,6 +1273,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   layout, and honors `SOURCE_DATE_EPOCH` for a deterministic build timestamp on
   reproducible builds. Non-git builds still degrade gracefully (fields `null`,
   build never fails).
+- **macros:** `has_many(dependent = …)` now emits a directed compile error for
+  unsupported values instead of a confusing generic parse failure (issue #1702);
+  `across_tenants()` rejects a query with no shard set instead of silently
+  running it unsharded (issue #1692).
+- **scaffold:** scaffolded views now render through the shared application
+  layout instead of a bare standalone page, and flash rendering was migrated to
+  the shared flash helper (issue #1130).
 
 ### Changed
 

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -1078,6 +1078,67 @@ app-code change) via `role = "web"|"worker"|"combined"` in config or the
   generated **docker-compose** output and sets the web-tier role on the `app`
   service (#1613). See `docs/guide/cloud-native.md`.
 
+### Per-queue worker pools, pinning & `ProcessRole` on `AppState` (unreleased — trunk-dev)
+
+Carve the per-process worker pool up per queue and dedicate a worker tier to a
+subset of queues — all config-only, no app-code change:
+
+- **Reserved / capped pools** — make a `[jobs.queues]` value a table:
+  `critical = { weight = 4, reserved = 2 }` keeps 2 slots that no other queue may
+  ever consume; `bulk = { weight = 1, concurrency = 4 }` caps a queue at 4 of the
+  process's `jobs.workers` slots. A bare integer is still just a weight. Total
+  capacity stays `jobs.workers`; the rules only redistribute it and are enforced
+  on every backend (local/Postgres/Redis).
+- **Worker pinning** — `jobs.pin = ["critical"]` (or `AUTUMN_JOBS__PIN=bulk,default`,
+  comma-separated) makes a `worker`-role process claim *only* those queues,
+  preserving weighted/strict order within the subset; empty/unset drains every
+  queue. A worker leaving a configured queue uncovered logs a startup `WARN`
+  (an `ERROR` if it would claim nothing); `autumn doctor --strict` reports
+  coverage informationally (`jobs_queue_coverage`) without failing (issue #1623).
+- **Per-queue actuator gauges** — `<actuator-prefix>/jobs` adds a `queues` key
+  with per-queue `depth` and `oldest_waiting_age_ms` alongside the existing
+  per-job-type gauges (per-process approximations on multi-process backends).
+- **`ProcessRole` on `AppState`** — `state.role()` returns the resolved
+  `ProcessRole` (exported at `autumn_web::ProcessRole`) with `serves_http()` /
+  `runs_workers()` predicates, so app-owned background loops in `on_startup`
+  self-gate to the right tier instead of re-reading `AUTUMN_ROLE` (issue #1726).
+  See `docs/guide/jobs.md`.
+
+## Operator alerts (unreleased — trunk-dev, issue #1610)
+
+Connect Autumn's built-in failure signals to email + a signed webhook with **no
+app code** — configure a destination under `[alerts]` and every built-in
+condition is delivered, deduplicated, with a recovery notice when it clears:
+
+```toml
+[alerts]
+email = "oncall@example.com"        # AUTUMN_ALERTS__EMAIL
+webhook_url = "https://alerts.example.com/hooks/autumn"
+webhook_secret = "…"                # REQUIRED with webhook_url; alerts are always
+                                    # signed (prefer AUTUMN_ALERTS__WEBHOOK_SECRET)
+```
+
+Built-in conditions — each carries a stable `dedup_key`, a `severity`
+(`critical` on trigger, `recovery` on resolve), the host/replica, and a "where
+to look" actuator pointer:
+
+- **Dead-lettered job** — a job exhausts its retries (deduped per job type).
+- **Health indicator down** — an indicator stays non-healthy past
+  `health_grace_secs` (default 60).
+- **High 5xx rate** — the rolling 5xx rate crosses `error_rate_threshold`
+  (default `0.05`, a fraction in `(0, 1]`) over ≥ `error_rate_min_requests`.
+- **Scheduled-task failure** — a `#[scheduled]`/framework task returns an error.
+
+Delivery is best-effort and off the request path (background tick every
+`eval_interval_secs`, default 30), reuses your existing mailer + outbound-webhook
+machinery, and the webhook is signed exactly like other Autumn webhooks
+(`Autumn-Signature: t=…,v1=<hmac-sha256>`). `enabled = false` is the master off
+switch (also silences custom channels). Add your own transport (PagerDuty,
+Slack, …) by implementing `AlertChannel` and registering it with
+`AppBuilder::with_alert_channel`. `autumn doctor` warns (in production) on a
+missing or unusable destination — see the `doctor` skill. See
+`docs/guide/operator-alerts.md`.
+
 ## Observability defaults
 
 Published 0.5.0 behavior:

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -69,6 +69,19 @@ These names match what `autumn doctor --json` actually emits in the `name` field
 | `version_compat` | Upgrade `autumn-cli` to match the framework version: `cargo install autumn-cli --version 0.5.0` |
 | `dotenv` | Copy `.env.example` to `.env` and fill in local values, or add every present secret dotenv file (`.env`, `.env.local`, and any `.env.<profile>.local`) to `.gitignore` if it is not already ignored — committable `.env.<profile>` files are left alone (warns only; never fails) |
 
+## Operator alert checks (unreleased — trunk-dev)
+
+On trunk-dev, `autumn doctor` adds production-only **operator-alert** warnings
+(issue #1610). It warns when `[alerts]` configures no destination (no `email`
+and no `webhook_url`), when an `email` destination is paired with a disabled
+`[mail]` transport or an SMTP transport missing/invalid `[mail] from`, when
+`webhook_url` is set without a `webhook_secret` or is not an absolute `http(s)`
+URL, when `error_rate_threshold` is outside `(0, 1]`, and when `[alerts]
+enabled = false` despite a configured destination. If you register an
+`AlertChannel` in code via `AppBuilder::with_alert_channel`, declare
+`[alerts] custom_channel = true` so `--strict` passes without a `[alerts]`
+destination. See `docs/guide/operator-alerts.md`.
+
 ## Secrets redaction
 
 Before displaying any output, redact values that look like secrets:

--- a/skills/generate/SKILL.md
+++ b/skills/generate/SKILL.md
@@ -32,7 +32,7 @@ them; on 0.5.0 fall back to the documented manual alternative.
 | `migration` | `migration add_slug_to_posts` | Empty timestamped migration file |
 | `mailer` | `mailer User` | Mailer struct + email templates (generator appends `Mailer` → produces `UserMailer`) |
 | `task` | `task RecalculateCounts` | `#[task]` operational command |
-| `auth` | `auth User --oauth github,google` | Full auth scaffold (login/register/password reset/OAuth); **(trunk-dev)** also scaffolds a configurable password policy and persistent "remember me" login by default |
+| `auth` | `auth User --oauth github,google` | Full auth scaffold (login/register/password reset/OAuth); **(trunk-dev)** also scaffolds a configurable password policy and persistent "remember me" login by default, authenticated change-password/change-email flows, and `--magic-link` passwordless login |
 | `admin` | `admin Post title:String body:Text` | Admin plugin resource page — fields must be supplied explicitly; generator does not read the model |
 | `system-test` | `system-test checkout_flow` | System test fixture (name must be `snake_case` or `PascalCase` — no hyphens) |
 | `pwa` | `pwa` | PWA scaffolding — manifest, service worker, offline shell, icons, route handlers, smoke test |
@@ -111,6 +111,30 @@ disables CSRF, so the same-origin form `POST`s carry no `_csrf` token (the real
 `form_for`-rendered forms inject one for the browser; the in-process harness
 does not require it). Emitted for HTML scaffolds only — `--api` scaffolds get
 the JSON read test but no write-path suite.
+
+**Scaffold `{…}` validation, belongs_to dropdowns & seed linking (trunk-dev)**:
+three additive scaffold behaviors (issues #1388, #1146, #1718):
+
+- **Inline `{…}` validation + HTML5 constraints** — a trailing `{…}` block on a
+  field declares a constraint once and enforces it on both sides: the model
+  field gets a `#[validate(...)]` rule and the form input gets the matching HTML5
+  attribute. `title:String{min=3,max=120}` → `length(min,max)` +
+  `minlength`/`maxlength`; numeric `{min,max}` → `range` + `min`/`max`;
+  `{email}` → `email` + `type="email"`; `{url}` → `url` + `type="url"`. A bad
+  submission is a 422 with inline per-field errors; a misspelled modifier (e.g.
+  `{maxx=5}`) fails the scaffold naming the token. Quote the whole token in
+  bash/zsh so the shell doesn't brace-expand the comma.
+- **belongs_to dropdowns** — when a `post:references` parent model exists, the
+  new/edit form renders the FK as a populated `<select>` (one `<option>` per
+  parent row) and index/show render the parent's display value instead of the
+  raw `*_id`. The display column is `name`/`title` → first string column → id;
+  override with `'post:references{label:slug}'`. A nullable `post:references?`
+  gets a blank "— Unset —" first option.
+- **Seed-binary model linking** — when a `src/bin/seed.rs` exists, the generator
+  idempotently splices `#[path = "../schema.rs"] mod schema;` +
+  `#[path = "../models/mod.rs"] mod models;` into it so `autumn seed
+  --count/--model` resolves the model's factory; `autumn destroy` removes those
+  links again. See `docs/guide/generators.md`.
 
 ## Execution flow
 
@@ -303,6 +327,15 @@ Next steps:
 2. Run: autumn migrate   (applies the sessions + remember-token migrations)
 3. --oauth / --totp / --passkeys still apply; there is no --remember or
    --password-policy flag — both are on by default (#1345, #1397).
+4. Authenticated account flows are scaffolded too (issue #1396): a
+   change-password form at `GET`/`POST /account/password` (verifies the current
+   password, applies the password policy, keeps the current device signed in)
+   and a change-email flow at `GET`/`POST /account/email` — both `#[secured]`
+   and behind a fresh `#[step_up]` claim, re-rendering at 422 on bad input.
+5. Pass `--magic-link` for passwordless email login (issue #1328): the
+   generator adds a `magic_link_token` model + `magic_link_tokens` table and the
+   single-use, expiring login-link routes (do not name the auth resource
+   `magic_link_token`).
 ```
 
 ## Flags


### PR DESCRIPTION
## What changed

Brings `CHANGELOG.md`'s `## [Unreleased]` section and the plugin `skills/` files up to date for the feature waves merged to `trunk-dev` on 2026-07-11. Docs-only — no source or Cargo changes, no version bump. Continues the pattern from the prior docs PR #1728 (which covered the earlier waves); no entries are duplicated from it.

**Before:** the day's merged features had landed in code but were absent from the changelog and the plugin skill guides. **After:** each is documented under the existing `[Unreleased]` section, and the newly merged features are mirrored into the relevant skill files with `(unreleased — trunk-dev)` tags.

### CHANGELOG — new bullets (all cite underlying issue numbers, matching existing style)
Added:
- **alerts:** operator alerts on critical production failures — email + signed-webhook notifications for dead-letter jobs, health-down, 5xx spikes, and failed scheduled ops, with `autumn doctor` checks (#1610, PR #1713)
- **macros:** `#[validate]` enforced on `UpdateModel` PUT/PATCH (#1719, PR #1742)
- **jobs:** per-queue reserved/concurrency pools + `jobs.pin` worker pinning + per-queue actuator gauges (#1623); `ProcessRole` on `AppState` (#1726) — PR #1746
- **cli:** change-password / change-email flows (#1396) and `--magic-link` passwordless login (#1328) — PR #1736
- **scaffold:** `belongs_to` dropdowns (#1146), validation + HTML5 constraints (#1388), seed-binary linking (#1718) — PR #1734
- **http:** outbound HTTP client SSRF hardening (#1238, #1239, PR #1731)

Fixed:
- **macros:** `has_many(dependent = …)` directed error (#1702); `across_tenants()` no-shard rejection (#1692) — PR #1742
- **scaffold:** scaffolded views render through the shared app layout; flash migrated to the shared helper (#1130, #1240, PR #1708)

### skills/ updates
- `skills/autumn-web/SKILL.md` — per-queue pools/pinning + `ProcessRole` block; new Operator alerts section
- `skills/doctor/SKILL.md` — operator alert checks note
- `skills/generate/SKILL.md` — auth flows (change-password/email, magic-link) + scaffold validation/belongs_to/seed-linking notes

## Verification
- `cargo fmt --all -- --check` passes
- Only 4 docs files changed (`CHANGELOG.md` + 3 `skills/*.md`); no source/Cargo files

## Notes
- The "Documentation build" CI check may be red trunk-wide (unrelated doc-link issues); the fix is tracked in PR #1773. Cite as known-red — not caused by this docs-only change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChpwYZZ3MbsFCQfKrXomQM)_