### PR TITLE
Native PagerDuty / Slack / Discord alert transports

### DIFF
--- a/autumn-cli/src/alert.rs
+++ b/autumn-cli/src/alert.rs
@@ -1,0 +1,147 @@
+//! `autumn alert test` — fire a synthetic operator alert through each configured
+//! delivery channel to verify wiring before a real incident (issue #1630).
+//!
+//! Follows the `autumn webhook sim` precedent: it exercises the *same* channel
+//! implementations the runtime installs (built through
+//! [`autumn_web::alerts::native_transport_channels`] plus the generic signed
+//! webhook), so a green `autumn alert test` proves the exact delivery path a
+//! live alert would take. Only the outbound-HTTP transports (`PagerDuty`, Slack,
+//! Discord, and the signed webhook) are exercised — email delivery is validated
+//! by `autumn doctor` and a real mail send, since it needs a configured mailer.
+
+use std::sync::Arc;
+
+use autumn_web::alerts::{self, Alert, AlertChannel, AlertCondition, WebhookAlertChannel};
+use autumn_web::http::Client;
+
+/// Run `autumn alert test [--channel <name>]`.
+///
+/// Loads the effective configuration, builds every configured outbound-HTTP
+/// alert channel, and delivers a synthetic test alert through each, reporting
+/// per-channel success or an actionable error. Exits non-zero if any configured
+/// channel fails to deliver, or if `--channel` names a channel that is not
+/// configured.
+pub fn run_test(channel_filter: Option<&str>) {
+    let config = match autumn_web::config::AutumnConfig::load() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Error: failed to load configuration: {e}");
+            std::process::exit(1);
+        }
+    };
+    let client = Client::from_config(&config.http.client);
+    let mut channels = configured_http_channels(&config.alerts, &client);
+
+    if config
+        .alerts
+        .email
+        .as_deref()
+        .is_some_and(|s| !s.trim().is_empty())
+    {
+        println!(
+            "Note: an [alerts] email destination is configured; `autumn alert test` does not \
+             exercise email delivery (it needs a configured mailer). Verify it with `autumn \
+             doctor` and a real send."
+        );
+    }
+
+    // Filter to a single channel when requested; a name that is not configured
+    // is an actionable error (issue #1630: unknown/unconfigured provider name).
+    if let Some(want) = channel_filter {
+        let configured: Vec<&'static str> = channels.iter().map(|c| c.name()).collect();
+        channels.retain(|c| c.name() == want);
+        if channels.is_empty() {
+            eprintln!(
+                "Error: no configured alert channel named '{want}'. Configured channels: {configured:?}. \
+                 Supported names: pagerduty, slack, discord, webhook."
+            );
+            std::process::exit(1);
+        }
+    }
+
+    if channels.is_empty() {
+        println!(
+            "No outbound alert delivery channels are configured. Set a PagerDuty routing key \
+             ([alerts] pagerduty_routing_key), a Slack/Discord webhook URL ([alerts] \
+             slack_webhook_url / discord_webhook_url), or a signed webhook ([alerts] webhook_url \
+             + webhook_secret). See docs/guide/operator-alerts.md"
+        );
+        return;
+    }
+
+    let alert = Alert::trigger(AlertCondition::DeadLetteredJob, "alert-test:synthetic")
+        .title("Autumn test alert")
+        .summary(
+            "Synthetic alert fired by `autumn alert test` to verify operator-alert channel \
+             wiring. If you are seeing this, delivery works.",
+        )
+        .detail("source", "autumn alert test")
+        .build();
+
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("Error: failed to start async runtime: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    println!(
+        "Firing a synthetic test alert through {} channel(s)…",
+        channels.len()
+    );
+    let mut any_failed = false;
+    runtime.block_on(async {
+        for channel in &channels {
+            match channel.deliver(&alert).await {
+                Ok(()) => println!("  \u{2705} {}: delivered", channel.name()),
+                Err(error) => {
+                    any_failed = true;
+                    println!("  \u{274c} {}: {error}", channel.name());
+                }
+            }
+        }
+    });
+
+    if any_failed {
+        std::process::exit(1);
+    }
+}
+
+/// Build the outbound-HTTP alert channels the runtime would install from
+/// `config`: the native providers (`PagerDuty` / Slack / Discord) plus the
+/// generic signed webhook. Prints a note when a webhook URL is set without the
+/// signing secret (alert webhooks are always signed, so it is skipped).
+fn configured_http_channels(
+    config: &autumn_web::alerts::AlertConfig,
+    client: &Client,
+) -> Vec<Arc<dyn AlertChannel>> {
+    let mut channels = alerts::native_transport_channels(config, client);
+    if let Some(url) = config
+        .webhook_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        match config
+            .webhook_secret
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            Some(secret) => channels.push(Arc::new(WebhookAlertChannel::new(
+                client.clone(),
+                url.to_owned(),
+                Some(secret.to_owned()),
+            ))),
+            None => eprintln!(
+                "Note: [alerts] webhook_url is set but webhook_secret is not; alert webhooks are \
+                 always signed, so the generic webhook channel is skipped."
+            ),
+        }
+    }
+    channels
+}

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -599,15 +599,19 @@ fn alert_disabled_in_production_warning(has_destination: bool) -> CheckResult {
     }
 }
 
-// Five independent config booleans (alerting enabled, webhook is a usable signed
-// destination, mail transport usable, production, transport requires a `from`)
-// plus the resolved `[alerts] email`, `[alerts] webhook_url`, and `[mail] from`
-// strings each gate a distinct branch; grouping them into enums would obscure
-// rather than clarify the destination-resolution logic. The raw `webhook_url` is
-// used only to name a present-but-non-absolute value in its dedicated warning —
-// `webhook_configured` already folds in absoluteness and the signing-secret
-// requirement — and `mail_from` likewise names a present-but-invalid sender in
-// its dedicated warning while its presence+validity gate the email destination.
+// Independent config booleans (alerting enabled, webhook is a usable signed
+// destination, mail transport usable, production, transport requires a `from`,
+// a native transport is configured) plus the resolved `[alerts] email`, `[alerts]
+// webhook_url`, and `[mail] from` strings each gate a distinct branch; grouping
+// them into enums would obscure rather than clarify the destination-resolution
+// logic. The raw `webhook_url` is used only to name a present-but-non-absolute
+// value in its dedicated warning — `webhook_configured` already folds in
+// absoluteness and the signing-secret requirement — and `mail_from` likewise
+// names a present-but-invalid sender in its dedicated warning while its
+// presence+validity gate the email destination. `native_transport_configured`
+// (a PagerDuty routing key or a Slack/Discord webhook URL) counts as a
+// destination the same way the runtime's `AlertConfig::has_destination` does; its
+// delivery-worthiness is validated separately by `check_alert_transports_impl`.
 #[allow(clippy::fn_params_excessive_bools, clippy::too_many_arguments)]
 pub fn check_alert_destination_impl(
     alerts_enabled: bool,
@@ -619,6 +623,7 @@ pub fn check_alert_destination_impl(
     mail_from: &str,
     transport_requires_from: bool,
     custom_channel: bool,
+    native_transport_configured: bool,
 ) -> CheckResult {
     // Presence and syntactic validity of the resolved `[alerts] email`. lettre
     // parses the recipient only at SEND time (`lettre_message`), not when the
@@ -668,7 +673,9 @@ pub fn check_alert_destination_impl(
             // Name the disabled switch explicitly. Mention the (otherwise valid)
             // destination when one is configured so the operator understands the
             // deploy is blind despite it; keep the message accurate otherwise.
-            return alert_disabled_in_production_warning(email_destination || webhook_configured);
+            return alert_disabled_in_production_warning(
+                email_destination || webhook_configured || native_transport_configured,
+            );
         }
         return CheckResult {
             name: "alert_destination",
@@ -685,7 +692,13 @@ pub fn check_alert_destination_impl(
     // and `from` requirements — mirroring the runtime, which skips
     // MailAlertChannel when `mailer.is_disabled()` and whose SMTP send fails
     // without a `from`.
-    if email_destination || webhook_configured {
+    // A native transport (PagerDuty / Slack / Discord) counts as a destination
+    // exactly as the runtime's `AlertConfig::has_destination` does — the runtime
+    // registers the channel for a native-only config, so doctor must not warn
+    // "no destination". The transports' own delivery-worthiness (routing-key
+    // shape, absolute-https URL) is validated separately by
+    // `check_alert_transports_impl`.
+    if email_destination || webhook_configured || native_transport_configured {
         return CheckResult {
             name: "alert_destination",
             status: CheckStatus::Pass,
@@ -3700,6 +3713,25 @@ fn resolve_alert_transports() -> (String, String, String, String) {
     )
 }
 
+/// Whether any native alert transport (`PagerDuty` routing key, Slack or Discord
+/// webhook URL) is configured — the SAME predicate the runtime's
+/// `AlertConfig::has_destination` uses (non-empty after trim).
+///
+/// Counting this as a destination keeps doctor's `alert_destination` gate in
+/// lock-step with the runtime, which registers a native channel (and so
+/// `has_destination()`/`is_active()` return true) for a native-only config;
+/// without it a valid `pagerduty_routing_key`-only production config would fail
+/// `autumn doctor --strict` with a spurious "no operator alert destination".
+fn native_alert_transport_configured(
+    pagerduty_routing_key: &str,
+    slack_webhook_url: &str,
+    discord_webhook_url: &str,
+) -> bool {
+    !pagerduty_routing_key.trim().is_empty()
+        || !slack_webhook_url.trim().is_empty()
+        || !discord_webhook_url.trim().is_empty()
+}
+
 /// Resolve the effective `[alerts] custom_channel` flag the same way the runtime
 /// config merge and `AlertConfig::default().custom_channel` (default `false`)
 /// do.
@@ -4241,6 +4273,16 @@ pub fn run(opts: DoctorOptions) {
     // / effective transport the mail checks above resolved.
     let mail_from = resolve_mail_from(Some(&merged_mail_toml)).unwrap_or_default();
     let transport_requires_from = mail_transport_requires_from(&effective_transport);
+    // A native transport (PagerDuty / Slack / Discord) counts as a configured
+    // destination exactly as the runtime's `AlertConfig::has_destination` does, so
+    // a native-only config does not trip the "no operator alert destination"
+    // warning that would fail `autumn doctor --strict` while the runtime happily
+    // registers the channel.
+    let alert_native_configured = native_alert_transport_configured(
+        &alert_pd_routing_key,
+        &alert_slack_url,
+        &alert_discord_url,
+    );
     tasks.push(Box::new(move || {
         check_alert_destination_impl(
             alerts_enabled,
@@ -4252,6 +4294,7 @@ pub fn run(opts: DoctorOptions) {
             &mail_from,
             transport_requires_from,
             alert_custom_channel,
+            alert_native_configured,
         )
     }));
 
@@ -5877,10 +5920,78 @@ pub struct Vault {
             "noreply@example.com",
             true,
             false,
+            false,
         );
         assert_eq!(r.name, "alert_destination");
         assert!(matches!(r.status, CheckStatus::Warn));
         assert!(r.hint.is_some());
+    }
+
+    #[test]
+    fn alert_destination_passes_in_production_with_native_transport_only() {
+        // A native transport (PagerDuty routing key, or a Slack/Discord webhook)
+        // is a valid destination: the runtime registers the channel and
+        // `has_destination()` returns true, so doctor must NOT warn "no operator
+        // alert destination" — otherwise a native-only prod config fails
+        // `--strict` while it delivers fine at runtime. The only destination here
+        // is the native transport (email/webhook/custom all absent).
+        let r = check_alert_destination_impl(
+            true,  // alerts_enabled
+            "",    // email
+            false, // webhook_configured
+            "",    // webhook_url
+            true,  // mail_transport_usable
+            true,  // is_production
+            "noreply@example.com",
+            true,  // transport_requires_from
+            false, // custom_channel
+            true,  // native_transport_configured
+        );
+        assert!(
+            matches!(r.status, CheckStatus::Pass),
+            "a native-transport-only config must pass the destination gate"
+        );
+        assert!(
+            !r.detail
+                .as_deref()
+                .unwrap_or_default()
+                .contains("no operator alert destination"),
+            "must not warn about a missing destination when a native transport is configured"
+        );
+        // Sanity: with the native flag off and nothing else configured, the same
+        // production config DOES warn — proving the flag is what flips the gate.
+        let off = check_alert_destination_impl(
+            true,
+            "",
+            false,
+            "",
+            true,
+            true,
+            "noreply@example.com",
+            true,
+            false,
+            false,
+        );
+        assert!(matches!(off.status, CheckStatus::Warn));
+    }
+
+    #[test]
+    fn native_alert_transport_configured_matches_runtime_predicate() {
+        // Mirrors AlertConfig::has_destination for native transports: any of the
+        // three configs present (non-empty after trim) counts.
+        assert!(!native_alert_transport_configured("", "", ""));
+        assert!(!native_alert_transport_configured("  ", "\t", " "));
+        assert!(native_alert_transport_configured("R0UT1NGKEY", "", ""));
+        assert!(native_alert_transport_configured(
+            "",
+            "https://hooks.slack.com/services/x",
+            ""
+        ));
+        assert!(native_alert_transport_configured(
+            "",
+            "",
+            "https://discord.com/api/webhooks/x/slack"
+        ));
     }
 
     #[test]
@@ -5894,6 +6005,7 @@ pub struct Vault {
             true,
             "noreply@example.com",
             true,
+            false,
             false,
         );
         assert!(matches!(r.status, CheckStatus::Pass));
@@ -5911,6 +6023,7 @@ pub struct Vault {
             "noreply@example.com",
             true,
             false,
+            false,
         );
         assert!(matches!(r.status, CheckStatus::Pass));
     }
@@ -5926,6 +6039,7 @@ pub struct Vault {
             false,
             "noreply@example.com",
             true,
+            false,
             false,
         );
         assert!(matches!(r.status, CheckStatus::Pass));
@@ -5961,6 +6075,7 @@ pub struct Vault {
             "noreply@example.com",
             true,
             false,
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Warn),
@@ -5994,6 +6109,7 @@ pub struct Vault {
             true,
             "noreply@example.com",
             requires_from,
+            false,
             false,
         );
         assert!(
@@ -6040,6 +6156,7 @@ pub struct Vault {
             mail_from,
             requires_from,
             false,
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Pass),
@@ -6065,6 +6182,7 @@ pub struct Vault {
             true,
             mail_from,
             requires_from,
+            false,
             false,
         );
         assert!(
@@ -6102,6 +6220,7 @@ pub struct Vault {
             mail_from,
             requires_from,
             false,
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Pass),
@@ -6132,6 +6251,7 @@ pub struct Vault {
             true,
             "not-a-mailbox",
             requires_from,
+            false,
             false,
         );
         assert!(
@@ -6164,6 +6284,7 @@ pub struct Vault {
             "Ops <ops@example.com>",
             requires_from,
             false,
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Pass),
@@ -6186,6 +6307,7 @@ pub struct Vault {
             false, // dev
             "not-a-mailbox",
             requires_from,
+            false,
             false,
         );
         assert!(
@@ -6212,6 +6334,7 @@ pub struct Vault {
             true,
             "not-a-mailbox",
             requires_from,
+            false,
             false,
         );
         assert!(
@@ -6242,6 +6365,7 @@ pub struct Vault {
             "noreply@example.com", // [mail] from present
             true,                  // smtp requires from
             false,                 // custom_channel
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Warn),
@@ -6275,6 +6399,7 @@ pub struct Vault {
             "noreply@example.com",
             true,
             false,
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Pass),
@@ -6295,6 +6420,7 @@ pub struct Vault {
             true,
             "noreply@example.com",
             true,
+            false,
             false,
         );
         assert!(
@@ -6321,6 +6447,7 @@ pub struct Vault {
             "noreply@example.com", // [mail] from present
             true,                  // smtp requires from
             false,                 // custom_channel
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Warn),
@@ -6353,6 +6480,7 @@ pub struct Vault {
             true,
             "noreply@example.com",
             true,
+            false,
             false,
         );
         assert!(matches!(r.status, CheckStatus::Warn));
@@ -6387,6 +6515,7 @@ pub struct Vault {
             true,
             "noreply@example.com",
             true,
+            false,
             false,
         );
         assert!(
@@ -6434,6 +6563,7 @@ pub struct Vault {
             true,
             "noreply@example.com",
             true,
+            false,
             false,
         );
         assert!(matches!(r.status, CheckStatus::Warn));
@@ -6512,6 +6642,7 @@ pub struct Vault {
             "noreply@example.com",
             true,
             false,
+            false,
         );
         assert!(matches!(r.status, CheckStatus::Pass));
     }
@@ -6537,6 +6668,7 @@ pub struct Vault {
             true,
             "noreply@example.com",
             true,
+            false,
             false,
         );
         assert!(
@@ -6569,6 +6701,7 @@ pub struct Vault {
             true,
             "noreply@example.com",
             true,
+            false,
             false,
         );
         assert!(matches!(r.status, CheckStatus::Warn));
@@ -6604,6 +6737,7 @@ pub struct Vault {
             "noreply@example.com",
             true,
             false,
+            false,
         );
         assert!(matches!(r.status, CheckStatus::Pass));
     }
@@ -6631,6 +6765,7 @@ pub struct Vault {
             true,
             "noreply@example.com",
             true,
+            false,
             false,
         );
         assert!(matches!(r.status, CheckStatus::Pass));
@@ -6663,6 +6798,7 @@ pub struct Vault {
             "noreply@example.com",
             true,
             false,
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Warn),
@@ -6688,6 +6824,7 @@ pub struct Vault {
             false, // dev
             "noreply@example.com",
             true,
+            false,
             false,
         );
         assert!(matches!(r.status, CheckStatus::Pass));
@@ -6744,6 +6881,7 @@ pub struct Vault {
             "noreply@example.com",
             true,
             false,
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Warn),
@@ -6793,6 +6931,7 @@ pub struct Vault {
             "noreply@example.com",
             true,
             false,
+            false,
         );
         assert!(matches!(r.status, CheckStatus::Pass));
     }
@@ -6825,6 +6964,7 @@ pub struct Vault {
             true,
             "noreply@example.com",
             true,
+            false,
             false,
         );
         assert!(matches!(r.status, CheckStatus::Warn));
@@ -6920,6 +7060,7 @@ pub struct Vault {
             "noreply@example.com",
             true,
             false,
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Warn),
@@ -6951,6 +7092,7 @@ pub struct Vault {
             "noreply@example.com",
             true,
             false,
+            false,
         );
         assert!(matches!(r.status, CheckStatus::Warn));
     }
@@ -6974,6 +7116,7 @@ pub struct Vault {
             "noreply@example.com",
             true,
             false,
+            false,
         );
         assert!(matches!(r.status, CheckStatus::Pass));
     }
@@ -6995,6 +7138,7 @@ pub struct Vault {
             false,
             "noreply@example.com",
             true,
+            false,
             false,
         );
         assert!(
@@ -7024,6 +7168,7 @@ pub struct Vault {
             "noreply@example.com",
             true,
             /* custom_channel */ true,
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Pass),
@@ -7051,6 +7196,7 @@ pub struct Vault {
             "noreply@example.com",
             true,
             /* custom_channel */ false,
+            false,
         );
         assert!(matches!(r.status, CheckStatus::Warn));
         assert!(
@@ -7076,6 +7222,7 @@ pub struct Vault {
             "noreply@example.com",
             true,
             /* custom_channel */ true,
+            false,
         );
         assert!(
             matches!(r.status, CheckStatus::Warn),
@@ -7150,6 +7297,7 @@ pub struct Vault {
             "noreply@example.com",
             true,
             custom,
+            false,
         );
         assert!(matches!(r.status, CheckStatus::Pass));
     }

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -780,6 +780,141 @@ pub fn check_alert_destination_impl(
     }
 }
 
+/// Whether `url` is a non-empty ABSOLUTE `https` URL with a host — the form the
+/// Slack and Discord webhook endpoints require. Slack and Discord only expose
+/// `https` webhook endpoints, so a plaintext `http://` (or relative) value will
+/// not deliver. Stricter than [`is_absolute_http_url_doctor`], which also accepts
+/// `http://`.
+fn is_absolute_https_url_doctor(url: &str) -> bool {
+    url.starts_with("https://")
+        && ::url::Url::parse(url)
+            .ok()
+            .and_then(|parsed| parsed.host_str().map(|h| !h.is_empty()))
+            .unwrap_or(false)
+}
+
+/// Check that configured native alert transports (`PagerDuty` / Slack / Discord,
+/// issue #1630) carry the config values they need to deliver.
+///
+/// Mirrors the runtime `alerts::native_transport_channels`, which registers a
+/// transport only when its required config is usable and otherwise skips it with
+/// a warning:
+/// - **`PagerDuty`** needs a non-blank `pagerduty_routing_key`; a
+///   `pagerduty_routing_key` containing embedded whitespace is malformed (a
+///   copy-paste error), and a set-but-non-absolute `pagerduty_url` override is
+///   never dispatched by the SSRF-hardened HTTP client. A `pagerduty_url` set
+///   with no routing key configures nothing.
+/// - **Slack / Discord** need an absolute `https` webhook URL: the HTTP client
+///   cannot dispatch a relative value, and both providers only expose `https`
+///   endpoints, so a plaintext `http://` URL will not deliver.
+///
+/// Production warns on any of the above; dev/test passes quietly (these
+/// transports are optional locally). Returns the first problem found so the
+/// operator gets one actionable message. The returned check name is
+/// `"alert_transports"`.
+#[must_use]
+pub fn check_alert_transports_impl(
+    pagerduty_routing_key: &str,
+    pagerduty_url: &str,
+    slack_webhook_url: &str,
+    discord_webhook_url: &str,
+    is_production: bool,
+) -> CheckResult {
+    const NAME: &str = "alert_transports";
+    let pd_key = pagerduty_routing_key.trim();
+    let pd_url = pagerduty_url.trim();
+    let slack = slack_webhook_url.trim();
+    let discord = discord_webhook_url.trim();
+
+    let pass = |detail: &str| CheckResult {
+        name: NAME,
+        status: CheckStatus::Pass,
+        detail: Some(detail.to_owned()),
+        hint: None,
+    };
+    let warn = |detail: String, hint: &'static str| CheckResult {
+        name: NAME,
+        status: CheckStatus::Warn,
+        detail: Some(detail),
+        hint: Some(hint),
+    };
+
+    let configured =
+        !pd_key.is_empty() || !pd_url.is_empty() || !slack.is_empty() || !discord.is_empty();
+    if !is_production {
+        return pass(if configured {
+            "native alert transports configured (validated in production mode)"
+        } else {
+            "no native alert transports configured (optional outside production)"
+        });
+    }
+
+    // PagerDuty: routing key must be present and well-formed; the URL override,
+    // when set, must be absolute; a URL with no routing key delivers nothing.
+    if !pd_key.is_empty() && pd_key.contains(char::is_whitespace) {
+        return warn(
+            format!(
+                "`[alerts] pagerduty_routing_key` (\"{pd_key}\") contains whitespace, so it is a \
+                 malformed Events API v2 routing key and PagerDuty will reject the event"
+            ),
+            "Set [alerts] pagerduty_routing_key (or AUTUMN_ALERTS__PAGERDUTY_ROUTING_KEY) to your \
+             integration's routing key with no surrounding or embedded whitespace. See \
+             docs/guide/operator-alerts.md",
+        );
+    }
+    if pd_key.is_empty() && !pd_url.is_empty() {
+        return warn(
+            "`[alerts] pagerduty_url` is set but no `pagerduty_routing_key` is configured, so no \
+             PagerDuty events will be delivered"
+                .to_owned(),
+            "Set [alerts] pagerduty_routing_key (or AUTUMN_ALERTS__PAGERDUTY_ROUTING_KEY), or \
+             remove pagerduty_url. See docs/guide/operator-alerts.md",
+        );
+    }
+    if !pd_key.is_empty() && !pd_url.is_empty() && !is_absolute_http_url_doctor(pd_url) {
+        return warn(
+            format!(
+                "`[alerts] pagerduty_url` (\"{pd_url}\") is not an absolute http(s) URL, so the \
+                 SSRF-hardened HTTP client cannot dispatch it and no PagerDuty events will be \
+                 delivered"
+            ),
+            "Set [alerts] pagerduty_url (or AUTUMN_ALERTS__PAGERDUTY_URL) to an absolute URL like \
+             https://events.pagerduty.com/v2/enqueue, or remove it to use the default. See \
+             docs/guide/operator-alerts.md",
+        );
+    }
+    if !slack.is_empty() && !is_absolute_https_url_doctor(slack) {
+        return warn(
+            format!(
+                "`[alerts] slack_webhook_url` (\"{slack}\") is not an absolute https URL, so no \
+                 Slack alerts will be delivered; Slack only exposes https incoming-webhook \
+                 endpoints and the HTTP client cannot dispatch a relative value"
+            ),
+            "Set [alerts] slack_webhook_url (or AUTUMN_ALERTS__SLACK_WEBHOOK_URL) to your Slack \
+             incoming-webhook URL (https://hooks.slack.com/services/…). See \
+             docs/guide/operator-alerts.md",
+        );
+    }
+    if !discord.is_empty() && !is_absolute_https_url_doctor(discord) {
+        return warn(
+            format!(
+                "`[alerts] discord_webhook_url` (\"{discord}\") is not an absolute https URL, so no \
+                 Discord alerts will be delivered; use the Slack-compatible endpoint \
+                 (https://discord.com/api/webhooks/…/slack)"
+            ),
+            "Set [alerts] discord_webhook_url (or AUTUMN_ALERTS__DISCORD_WEBHOOK_URL) to your \
+             Discord webhook's Slack-compatible URL (append /slack). See \
+             docs/guide/operator-alerts.md",
+        );
+    }
+
+    pass(if configured {
+        "configured native alert transports (PagerDuty/Slack/Discord) look deliverable"
+    } else {
+        "no native alert transports configured"
+    })
+}
+
 /// Check that a configured `[alerts] error_rate_threshold` is a usable 5xx rate
 /// (issue #1610).
 ///
@@ -3523,6 +3658,48 @@ where
     true
 }
 
+/// Resolve the effective native-transport config strings (`pagerduty_routing_key`,
+/// `pagerduty_url`, `slack_webhook_url`, `discord_webhook_url`) the runtime boots
+/// with (issue #1630), honouring the same env `>` merged-base precedence as
+/// [`resolve_alert_destination`]: a PRESENT `AUTUMN_ALERTS__*` env var (even
+/// empty) wins and is terminal; otherwise the merged top-level `[alerts]` value
+/// is used (empty when unset). Returned as raw strings so
+/// [`check_alert_transports_impl`] can both validate and name a bad value.
+fn resolve_alert_transports() -> (String, String, String, String) {
+    let selected_input = std::env::var("AUTUMN_ENV")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| {
+            std::env::var("AUTUMN_PROFILE")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+        })
+        .unwrap_or_default()
+        .trim()
+        .to_owned();
+    let normalized_profile = normalize_alert_profile(&selected_input);
+    let merged = get_merged_toml_table_runtime(&normalized_profile, &selected_input);
+    let read = |env_key: &str, key: &str| -> String {
+        std::env::var(env_key).unwrap_or_else(|_| {
+            merged
+                .get("alerts")
+                .and_then(|a| a.get(key))
+                .and_then(toml::Value::as_str)
+                .unwrap_or("")
+                .to_owned()
+        })
+    };
+    (
+        read(
+            "AUTUMN_ALERTS__PAGERDUTY_ROUTING_KEY",
+            "pagerduty_routing_key",
+        ),
+        read("AUTUMN_ALERTS__PAGERDUTY_URL", "pagerduty_url"),
+        read("AUTUMN_ALERTS__SLACK_WEBHOOK_URL", "slack_webhook_url"),
+        read("AUTUMN_ALERTS__DISCORD_WEBHOOK_URL", "discord_webhook_url"),
+    )
+}
+
 /// Resolve the effective `[alerts] custom_channel` flag the same way the runtime
 /// config merge and `AlertConfig::default().custom_channel` (default `false`)
 /// do.
@@ -3813,6 +3990,8 @@ pub fn run(opts: DoctorOptions) {
     let alerts_enabled = resolve_alert_enabled();
     let alert_custom_channel = resolve_alert_custom_channel();
     let alert_error_rate_threshold = resolve_alert_error_rate_threshold();
+    let (alert_pd_routing_key, alert_pd_url, alert_slack_url, alert_discord_url) =
+        resolve_alert_transports();
     let proxy_conflict_data = resolve_proxy_conflict_data();
     let (dotenv_has_example, dotenv_has_env, dotenv_uncovered) = resolve_dotenv_state();
 
@@ -4081,6 +4260,21 @@ pub fn run(opts: DoctorOptions) {
     //       default). Warn in production so the operator fixes the config.
     tasks.push(Box::new(move || {
         check_alert_error_rate_threshold_impl(&alert_error_rate_threshold, is_production)
+    }));
+
+    // 12a3. Native alert transports (issue #1630): a configured PagerDuty /
+    //       Slack / Discord destination must carry the values it needs to
+    //       deliver (a well-formed routing key, an absolute pagerduty_url, an
+    //       absolute https Slack/Discord webhook URL). Warn in production so a
+    //       transport that *looks* configured actually pages.
+    tasks.push(Box::new(move || {
+        check_alert_transports_impl(
+            &alert_pd_routing_key,
+            &alert_pd_url,
+            &alert_slack_url,
+            &alert_discord_url,
+            is_production,
+        )
     }));
 
     // 12b. Local-dev `.env` handling (warn on `.env.example` without `.env`,
@@ -7099,6 +7293,121 @@ pub struct Vault {
             check_alert_error_rate_threshold_impl(&raw, true).status,
             CheckStatus::Pass
         ));
+    }
+
+    // ── check_alert_transports_impl (issue #1630) ────────────────────────────
+    // A configured native transport (PagerDuty / Slack / Discord) must carry the
+    // values it needs to deliver. Production warns on a malformed routing key, a
+    // non-absolute pagerduty_url, or a non-absolute-https Slack/Discord URL; dev
+    // passes quietly (these transports are optional locally).
+
+    #[test]
+    fn alert_transports_none_configured_passes() {
+        let r = check_alert_transports_impl("", "", "", "", true);
+        assert!(matches!(r.status, CheckStatus::Pass));
+    }
+
+    #[test]
+    fn alert_transports_all_valid_pass() {
+        let r = check_alert_transports_impl(
+            "R0UT1NGKEY0000000000000000000000",
+            "https://events.pagerduty.com/v2/enqueue",
+            "https://hooks.slack.com/services/T/B/x",
+            "https://discord.com/api/webhooks/1/abc/slack",
+            true,
+        );
+        assert!(matches!(r.status, CheckStatus::Pass), "{:?}", r.detail);
+        assert_eq!(r.name, "alert_transports");
+    }
+
+    #[test]
+    fn alert_transports_malformed_routing_key_warns_in_prod() {
+        let r = check_alert_transports_impl("bad key with spaces", "", "", "", true);
+        assert!(matches!(r.status, CheckStatus::Warn));
+        assert!(
+            r.detail
+                .as_deref()
+                .is_some_and(|d| d.contains("routing key")),
+            "must name the malformed routing key"
+        );
+    }
+
+    #[test]
+    fn alert_transports_pagerduty_url_without_key_warns() {
+        let r = check_alert_transports_impl(
+            "",
+            "https://events.pagerduty.com/v2/enqueue",
+            "",
+            "",
+            true,
+        );
+        assert!(matches!(r.status, CheckStatus::Warn));
+        assert!(
+            r.detail
+                .as_deref()
+                .is_some_and(|d| d.contains("routing_key"))
+        );
+    }
+
+    #[test]
+    fn alert_transports_non_absolute_pagerduty_url_warns() {
+        let r = check_alert_transports_impl(
+            "R0UT1NGKEY",
+            "events.pagerduty.com/v2/enqueue",
+            "",
+            "",
+            true,
+        );
+        assert!(matches!(r.status, CheckStatus::Warn));
+    }
+
+    #[test]
+    fn alert_transports_non_https_slack_url_warns() {
+        // Plaintext http is rejected — Slack only exposes https endpoints.
+        let r = check_alert_transports_impl("", "", "http://hooks.slack.com/services/x", "", true);
+        assert!(matches!(r.status, CheckStatus::Warn));
+        assert!(
+            r.detail
+                .as_deref()
+                .is_some_and(|d| d.contains("slack_webhook_url"))
+        );
+    }
+
+    #[test]
+    fn alert_transports_relative_discord_url_warns() {
+        let r = check_alert_transports_impl("", "", "", "/webhooks/x/slack", true);
+        assert!(matches!(r.status, CheckStatus::Warn));
+        assert!(
+            r.detail
+                .as_deref()
+                .is_some_and(|d| d.contains("discord_webhook_url"))
+        );
+    }
+
+    #[test]
+    fn alert_transports_invalid_is_lenient_outside_prod() {
+        // Every invalid case passes quietly in dev, like the other alert checks.
+        let r = check_alert_transports_impl(
+            "bad key",
+            "not-a-url",
+            "http://hooks.slack.com/x",
+            "/relative",
+            false,
+        );
+        assert!(matches!(r.status, CheckStatus::Pass));
+    }
+
+    #[test]
+    fn is_absolute_https_url_doctor_requires_https_and_host() {
+        assert!(is_absolute_https_url_doctor(
+            "https://hooks.slack.com/services/x"
+        ));
+        assert!(!is_absolute_https_url_doctor(
+            "http://hooks.slack.com/services/x"
+        ));
+        assert!(!is_absolute_https_url_doctor("hooks.slack.com/x"));
+        assert!(!is_absolute_https_url_doctor("https://"));
+        assert!(!is_absolute_https_url_doctor(""));
     }
 
     // ── compute_summary ──────────────────────────────────────────────────────

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, Subcommand, ValueEnum};
 
+mod alert;
 mod assets;
 mod build;
 mod canary;
@@ -442,6 +443,10 @@ enum Commands {
     /// Simulate a signed webhook request to the local application.
     #[command(subcommand, verbatim_doc_comment)]
     Webhook(WebhookCommands),
+
+    /// Fire a synthetic operator alert through configured delivery channels.
+    #[command(subcommand)]
+    Alert(AlertCommands),
     /// Issue and revoke API bearer tokens backed by the `api_tokens` table.
     ///
     /// Requires the `api_tokens` table to exist. Run `autumn migrate` first;
@@ -1359,7 +1364,24 @@ enum CanaryCommands {
     Status,
 }
 
-/// Subcommands for `autumn token`.
+/// Subcommands for `autumn alert`.
+#[derive(Subcommand)]
+enum AlertCommands {
+    /// Send a synthetic test alert through each configured delivery channel and
+    /// report per-channel success or an actionable error (issue #1630).
+    ///
+    /// Exercises the outbound-HTTP transports the runtime installs —
+    /// `PagerDuty`, Slack, Discord, and the generic signed webhook — using the
+    /// exact same channel implementations, so a green run proves real wiring
+    /// before an incident. Reads the effective `[alerts]` config (env vars and
+    /// profiles honoured, just like the server).
+    Test {
+        /// Only fire through the named channel (pagerduty, slack, discord,
+        /// webhook). Omit to fire through every configured channel.
+        #[arg(long)]
+        channel: Option<String>,
+    },
+}
 
 #[derive(Subcommand)]
 enum WebhookCommands {
@@ -2553,6 +2575,7 @@ fn run_command(command: Commands) {
             secret,
             payload,
         }) => webhook::run_sim(&provider, &url, &secret, &payload),
+        Commands::Alert(AlertCommands::Test { channel }) => alert::run_test(channel.as_deref()),
         Commands::Seed {
             profile,
             package,

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -1194,6 +1194,11 @@ const fn pagerduty_severity(severity: AlertSeverity) -> &'static str {
 #[cfg(feature = "http-client")]
 #[must_use]
 pub fn pagerduty_event_payload(alert: &Alert, routing_key: &str) -> serde_json::Value {
+    // Reserved standard-field names Autumn writes into `custom_details` below.
+    // PagerDuty routing/correlation depends on these carrying the authoritative
+    // values, so a user detail keyed with one of these must NOT clobber it — nor
+    // be clobbered by it. Colliding user keys are preserved under `custom_<key>`.
+    const RESERVED: &[&str] = &["condition", "where_to_look", "detail"];
     if alert.event == AlertEventKind::Resolve {
         return serde_json::json!({
             "routing_key": routing_key,
@@ -1206,7 +1211,12 @@ pub fn pagerduty_event_payload(alert: &Alert, routing_key: &str) -> serde_json::
     keys.sort();
     for k in keys {
         if let Some(v) = alert.details.get(k) {
-            custom.insert(k.clone(), serde_json::Value::String(v.clone()));
+            let key = if RESERVED.contains(&k.as_str()) {
+                format!("custom_{k}")
+            } else {
+                k.clone()
+            };
+            custom.insert(key, serde_json::Value::String(v.clone()));
         }
     }
     custom.insert(
@@ -1498,8 +1508,10 @@ pub fn native_transport_channels(
 }
 
 /// Register a Slack-compatible chat channel (`slack` or `discord`) from a
-/// configured webhook `url`, skipping (with a warning) a non-absolute URL that
-/// the HTTP client could never dispatch.
+/// configured webhook `url`, skipping (with a warning) a URL that is not an
+/// absolute `https` URL — Slack and Discord only expose `https` webhook
+/// endpoints, so a relative, malformed, or plaintext `http://` value would never
+/// deliver (mirrors `autumn doctor`'s `is_absolute_https_url_doctor`).
 #[cfg(feature = "http-client")]
 fn push_chat_channel(
     channels: &mut Vec<Arc<dyn AlertChannel>>,
@@ -1511,13 +1523,14 @@ fn push_chat_channel(
     let Some(url) = url.map(str::trim).filter(|s| !s.is_empty()) else {
         return;
     };
-    if !is_absolute_http_url(url) {
+    if !is_absolute_https_url(url) {
         tracing::warn!(
             provider,
             webhook_url = url,
             "alerts: the configured [alerts] {provider}_webhook_url ({url}) is not an absolute \
-             http(s) URL; no {provider} alerts will be delivered. Fix the URL (or the \
-             AUTUMN_ALERTS__{PROVIDER}_WEBHOOK_URL env var).",
+             https URL; no {provider} alerts will be delivered ({provider} only exposes https \
+             webhook endpoints). Fix the URL (or the AUTUMN_ALERTS__{PROVIDER}_WEBHOOK_URL env \
+             var).",
             PROVIDER = provider.to_uppercase(),
         );
         return;
@@ -1563,6 +1576,20 @@ fn is_absolute_http_url(url: &str) -> bool {
         .ok()
         .and_then(|parsed| parsed.host_str().map(|h| !h.is_empty()))
         .unwrap_or(false)
+}
+
+/// Whether `url` is a non-empty ABSOLUTE **`https`** URL with a host.
+///
+/// Stricter than [`is_absolute_http_url`]: it additionally requires the `https`
+/// scheme. Slack and Discord only expose `https` webhook endpoints, so a
+/// plaintext `http://` URL will never deliver (and would transmit insecurely) —
+/// the runtime must reject it just as `autumn doctor` does. Kept in lock-step
+/// with `autumn-cli`'s `is_absolute_https_url_doctor` (same rule) so doctor and
+/// the runtime agree on which Slack/Discord webhook URLs are usable and cannot
+/// drift.
+#[cfg(feature = "http-client")]
+fn is_absolute_https_url(url: &str) -> bool {
+    url.starts_with("https://") && is_absolute_http_url(url)
 }
 
 /// Whether `email` parses as the SAME lettre [`Mailbox`](lettre::message::Mailbox)
@@ -2841,6 +2868,33 @@ mod tests {
 
     #[cfg(feature = "http-client")]
     #[test]
+    fn pagerduty_custom_details_preserves_user_key_colliding_with_reserved_field() {
+        // A user detail keyed with a RESERVED standard-field name (`condition`,
+        // `where_to_look`, `detail`) must not silently clobber — nor be clobbered
+        // by — the authoritative standard field. The standard field keeps its
+        // canonical name (PagerDuty routing/correlation depends on it); the user's
+        // value is preserved under a `custom_`-prefixed key.
+        let alert = Alert::trigger(AlertCondition::DeadLetteredJob, "dead_lettered_job:emailer")
+            .title("Job 'emailer' was dead-lettered")
+            .summary("exhausted retries")
+            .detail("condition", "user-supplied-condition")
+            .detail("where_to_look", "user-supplied-pointer")
+            .detail("detail", "user-supplied-detail")
+            .build();
+        let v = pagerduty_event_payload(&alert, "R0UT1NGKEY");
+        let cd = &v["payload"]["custom_details"];
+        // Standard fields stay authoritative under their canonical names.
+        assert_eq!(cd["condition"], "dead_lettered_job");
+        assert_eq!(cd["where_to_look"], "/actuator/jobs");
+        assert_eq!(cd["detail"], "exhausted retries");
+        // The colliding user values are preserved under `custom_<key>`.
+        assert_eq!(cd["custom_condition"], "user-supplied-condition");
+        assert_eq!(cd["custom_where_to_look"], "user-supplied-pointer");
+        assert_eq!(cd["custom_detail"], "user-supplied-detail");
+    }
+
+    #[cfg(feature = "http-client")]
+    #[test]
     fn pagerduty_resolve_payload_is_minimal_and_correlates() {
         let alert = Alert::recovery(
             AlertCondition::ScheduledTaskFailure,
@@ -2964,6 +3018,38 @@ mod tests {
             channel_names(&config).is_empty(),
             "a non-absolute pagerduty_url must skip the PagerDuty channel"
         );
+    }
+
+    #[cfg(feature = "http-client")]
+    #[test]
+    fn native_transports_reject_non_https_slack_and_discord() {
+        // Slack and Discord only expose https webhook endpoints, so a plaintext
+        // http:// URL will not deliver (and would transmit insecurely). The
+        // runtime must reject it — mirroring `autumn doctor` — and register no
+        // channel. Prevents a config doctor rejects from silently "passing" at
+        // runtime.
+        let slack = AlertConfig {
+            slack_webhook_url: Some("http://hooks.slack.com/services/x".to_owned()),
+            ..AlertConfig::default()
+        };
+        assert!(
+            channel_names(&slack).is_empty(),
+            "a non-https slack_webhook_url must not register a Slack channel"
+        );
+        let discord = AlertConfig {
+            discord_webhook_url: Some("http://discord.com/api/webhooks/x/slack".to_owned()),
+            ..AlertConfig::default()
+        };
+        assert!(
+            channel_names(&discord).is_empty(),
+            "a non-https discord_webhook_url must not register a Discord channel"
+        );
+        // An absolute https URL is still accepted.
+        let ok = AlertConfig {
+            slack_webhook_url: Some("https://hooks.slack.com/services/x".to_owned()),
+            ..AlertConfig::default()
+        };
+        assert_eq!(channel_names(&ok), vec!["slack"]);
     }
 
     #[cfg(feature = "http-client")]

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -226,6 +226,23 @@ impl AlertRouting {
     }
 }
 
+impl std::str::FromStr for AlertRouting {
+    type Err = ();
+
+    /// Parse the same `all` / `critical` spellings the `[alerts]` TOML/serde path
+    /// accepts (see the `#[serde(rename_all = "snake_case")]` above), so the
+    /// `AUTUMN_ALERTS__*_SEVERITIES` env overrides and the config file agree on
+    /// the accepted values. Any other value is rejected (the env-override layer
+    /// then logs and ignores it, leaving the existing value).
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "all" => Ok(Self::All),
+            "critical" => Ok(Self::Critical),
+            _ => Err(()),
+        }
+    }
+}
+
 /// Whether this alert opens (trigger) or closes (resolve) a condition. This is
 /// the field an incident manager keys on to auto-resolve a correlated alert.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -2833,6 +2850,21 @@ mod tests {
         assert_eq!(all.r, AlertRouting::All);
         let crit: Holder = toml::from_str(r#"r = "critical""#).expect("parse critical");
         assert_eq!(crit.r, AlertRouting::Critical);
+    }
+
+    #[test]
+    fn routing_from_str_matches_toml_spellings() {
+        // The env-override path parses via FromStr; it must accept exactly the
+        // same `all` / `critical` spellings the TOML/serde path does, and reject
+        // anything else (the env layer then logs+ignores, keeping the default).
+        assert_eq!("all".parse::<AlertRouting>(), Ok(AlertRouting::All));
+        assert_eq!(
+            "critical".parse::<AlertRouting>(),
+            Ok(AlertRouting::Critical)
+        );
+        assert!("warning".parse::<AlertRouting>().is_err());
+        assert!("All".parse::<AlertRouting>().is_err());
+        assert!("".parse::<AlertRouting>().is_err());
     }
 
     // ── Native transport payloads (#1630) ────────────────────────────────────

--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -193,6 +193,39 @@ pub enum AlertSeverity {
     Recovery,
 }
 
+/// Which alert severities a transport receives (issue #1630, per-channel
+/// severity routing).
+///
+/// Every configured native transport (`PagerDutyAlertChannel`,
+/// `SlackAlertChannel`) declares this; the [`Alerter`] consults
+/// [`AlertChannel::accepts_severity`] before fanning an alert out, so an alert
+/// whose severity a destination does not accept is **never delivered to it**.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum AlertRouting {
+    /// Receive every severity — both firing ([`AlertSeverity::Critical`])
+    /// alerts and their ([`AlertSeverity::Recovery`]) recoveries. The default
+    /// for all channels. A pager-class channel (`PagerDuty`) needs this so a
+    /// `resolve` event reaches the provider and the incident auto-resolves.
+    #[default]
+    All,
+    /// Receive only firing ([`AlertSeverity::Critical`]) alerts; recoveries are
+    /// not delivered. Use for a chat channel that should page/notify on failure
+    /// but stay quiet on recovery.
+    Critical,
+}
+
+impl AlertRouting {
+    /// Whether a channel with this routing accepts an alert of `severity`.
+    #[must_use]
+    pub const fn accepts(self, severity: AlertSeverity) -> bool {
+        match self {
+            Self::All => true,
+            Self::Critical => matches!(severity, AlertSeverity::Critical),
+        }
+    }
+}
+
 /// Whether this alert opens (trigger) or closes (resolve) a condition. This is
 /// the field an incident manager keys on to auto-resolve a correlated alert.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -405,6 +438,19 @@ pub trait AlertChannel: Send + Sync + 'static {
 
     /// Deliver `alert` to this channel.
     fn deliver<'a>(&'a self, alert: &'a Alert) -> AlertDeliveryFuture<'a>;
+
+    /// Whether this channel receives an alert of the given `severity` (issue
+    /// #1630, per-channel severity routing).
+    ///
+    /// Defaults to accepting **every** severity, so an external channel that
+    /// does not override this behaves exactly as before. The built-in native
+    /// transports override it to honor the `[alerts]` `*_severities` routing —
+    /// a channel that declares [`AlertRouting::Critical`] returns `false` for a
+    /// [`AlertSeverity::Recovery`] alert, so the [`Alerter`] skips it and the
+    /// recovery is verifiably not delivered there.
+    fn accepts_severity(&self, _severity: AlertSeverity) -> bool {
+        true
+    }
 }
 
 // ── Deduplication ───────────────────────────────────────────────────────────
@@ -670,6 +716,14 @@ impl Alerter {
         };
         let alert = Arc::new(alert);
         for channel in &self.inner.channels {
+            // Per-channel severity routing (issue #1630): a destination that
+            // does not accept this alert's severity is skipped, so an alert
+            // below a channel's threshold (e.g. a recovery to a critical-only
+            // chat channel) is never delivered to it. Defaults to accept-all,
+            // so every existing channel is unaffected.
+            if !channel.accepts_severity(alert.severity) {
+                continue;
+            }
             let channel = Arc::clone(channel);
             let alert = Arc::clone(&alert);
             handle.spawn(async move {
@@ -782,7 +836,9 @@ pub fn notify_scheduled_task_recovered(state: &AppState, task_name: &str) {
     // still the closest correlation available). A real fix needs shared
     // active-alert state (Postgres/Redis) or an unconditional correlated resolve,
     // both out of scope for #1610 (fleet-level alert aggregation is listed as a
-    // non-goal); tracked for the shared-alert-state follow-up (#1630).
+    // non-goal). The native PagerDuty/Slack/Discord transports (#1630) do not
+    // change this process-local behaviour; shared active-alert state remains a
+    // separate future follow-up.
     let alert = Alert::recovery(
         AlertCondition::ScheduledTaskFailure,
         format!("scheduled_task_failure:{task_name}"),
@@ -822,6 +878,13 @@ const fn default_eval_interval_secs() -> u64 {
     30
 }
 
+/// Default `PagerDuty` Events API v2 enqueue endpoint.
+///
+/// Override via `[alerts] pagerduty_url` (or `AUTUMN_ALERTS__PAGERDUTY_URL`) to
+/// target a PagerDuty-Events-compatible endpoint offered by another paging
+/// service.
+pub const PAGERDUTY_EVENTS_URL: &str = "https://events.pagerduty.com/v2/enqueue";
+
 /// `[alerts]` configuration.
 ///
 /// Providing **only** a destination (an operator [`email`](Self::email) and/or
@@ -855,6 +918,41 @@ pub struct AlertConfig {
     /// HMAC signing secret for the webhook destination. Prefer the
     /// `AUTUMN_ALERTS__WEBHOOK_SECRET` env var over committing it.
     pub webhook_secret: Option<String>,
+    /// `PagerDuty` Events API v2 routing (integration) key. When set
+    /// (non-empty), the `PagerDuty` channel is enabled and every alert is
+    /// delivered as an Events API v2 event correlated on the alert's stable
+    /// [`Alert::dedup_key`], so a repeating condition folds into a single
+    /// incident and an [`AlertEventKind::Resolve`] event auto-resolves it.
+    /// Prefer the `AUTUMN_ALERTS__PAGERDUTY_ROUTING_KEY` env var over committing
+    /// it.
+    pub pagerduty_routing_key: Option<String>,
+    /// Override for the `PagerDuty` Events API v2 enqueue endpoint. Defaults to
+    /// [`PAGERDUTY_EVENTS_URL`]; set this to target a PagerDuty-Events-compatible
+    /// endpoint offered by another paging service.
+    pub pagerduty_url: Option<String>,
+    /// Which severities the `PagerDuty` channel receives (default
+    /// [`AlertRouting::All`], so a `resolve` event reaches `PagerDuty` and the
+    /// incident auto-resolves).
+    #[serde(default)]
+    pub pagerduty_severities: AlertRouting,
+    /// Slack incoming-webhook URL. When set (non-empty, absolute `http(s)`), the
+    /// Slack channel posts a human-readable message for each alert. Prefer the
+    /// `AUTUMN_ALERTS__SLACK_WEBHOOK_URL` env var over committing it.
+    pub slack_webhook_url: Option<String>,
+    /// Which severities the Slack channel receives (default
+    /// [`AlertRouting::All`]).
+    #[serde(default)]
+    pub slack_severities: AlertRouting,
+    /// Discord webhook URL. Delivered via Discord's Slack-compatible endpoint
+    /// (append `/slack` to a Discord webhook URL), reusing the exact same
+    /// payload dialect as Slack. When set (non-empty, absolute `http(s)`), the
+    /// Discord channel posts a human-readable message for each alert. Prefer the
+    /// `AUTUMN_ALERTS__DISCORD_WEBHOOK_URL` env var over committing it.
+    pub discord_webhook_url: Option<String>,
+    /// Which severities the Discord channel receives (default
+    /// [`AlertRouting::All`]).
+    #[serde(default)]
+    pub discord_severities: AlertRouting,
     /// Set true to tell `autumn doctor` you register an alert channel in code via
     /// `AppBuilder::with_alert_channel`; suppresses the no-destination warning.
     /// The runtime installs code-registered channels regardless of this flag.
@@ -880,6 +978,13 @@ impl Default for AlertConfig {
             email: None,
             webhook_url: None,
             webhook_secret: None,
+            pagerduty_routing_key: None,
+            pagerduty_url: None,
+            pagerduty_severities: AlertRouting::All,
+            slack_webhook_url: None,
+            slack_severities: AlertRouting::All,
+            discord_webhook_url: None,
+            discord_severities: AlertRouting::All,
             custom_channel: false,
             dedup_window_secs: default_dedup_window_secs(),
             health_grace_secs: default_health_grace_secs(),
@@ -891,14 +996,17 @@ impl Default for AlertConfig {
 }
 
 impl AlertConfig {
-    /// Whether a delivery destination is configured (email and/or webhook URL).
+    /// Whether a delivery destination is configured — an email, a generic
+    /// webhook URL, or any native transport (`PagerDuty` routing key, Slack or
+    /// Discord webhook URL).
     #[must_use]
     pub fn has_destination(&self) -> bool {
-        self.email.as_ref().is_some_and(|s| !s.trim().is_empty())
-            || self
-                .webhook_url
-                .as_ref()
-                .is_some_and(|s| !s.trim().is_empty())
+        let set = |v: &Option<String>| v.as_ref().is_some_and(|s| !s.trim().is_empty());
+        set(&self.email)
+            || set(&self.webhook_url)
+            || set(&self.pagerduty_routing_key)
+            || set(&self.slack_webhook_url)
+            || set(&self.discord_webhook_url)
     }
 
     /// Whether alerts should actually be active (enabled + a destination).
@@ -1061,6 +1169,375 @@ impl AlertChannel for WebhookAlertChannel {
     }
 }
 
+// ── Native transports (issue #1630) ─────────────────────────────────────────
+
+/// Map an [`AlertSeverity`] onto the `PagerDuty` Events API v2 `severity`
+/// taxonomy (`critical` / `error` / `warning` / `info`). Autumn's built-in
+/// conditions are all operator-critical, so a firing alert maps to `critical`;
+/// a recovery is informational (`info`) — though a `resolve` event carries no
+/// `payload`, this keeps the mapping total.
+#[cfg(feature = "http-client")]
+const fn pagerduty_severity(severity: AlertSeverity) -> &'static str {
+    match severity {
+        AlertSeverity::Critical => "critical",
+        AlertSeverity::Recovery => "info",
+    }
+}
+
+/// Build the `PagerDuty` Events API v2 request body for `alert`, correlated on
+/// the alert's stable [`Alert::dedup_key`] with `routing_key`.
+///
+/// A [`AlertEventKind::Trigger`] produces a full `trigger` event (with the
+/// `payload` block `PagerDuty` requires); a [`AlertEventKind::Resolve`] produces a
+/// minimal `resolve` event (only `routing_key`, `event_action`, and `dedup_key`,
+/// per the Events API v2 contract) that auto-resolves the correlated incident.
+#[cfg(feature = "http-client")]
+#[must_use]
+pub fn pagerduty_event_payload(alert: &Alert, routing_key: &str) -> serde_json::Value {
+    if alert.event == AlertEventKind::Resolve {
+        return serde_json::json!({
+            "routing_key": routing_key,
+            "event_action": "resolve",
+            "dedup_key": alert.dedup_key,
+        });
+    }
+    let mut custom = serde_json::Map::new();
+    let mut keys: Vec<&String> = alert.details.keys().collect();
+    keys.sort();
+    for k in keys {
+        if let Some(v) = alert.details.get(k) {
+            custom.insert(k.clone(), serde_json::Value::String(v.clone()));
+        }
+    }
+    custom.insert(
+        "condition".to_owned(),
+        serde_json::Value::String(alert.condition.as_str().to_owned()),
+    );
+    custom.insert(
+        "where_to_look".to_owned(),
+        serde_json::Value::String(alert.where_to_look.clone()),
+    );
+    if !alert.summary.is_empty() {
+        custom.insert(
+            "detail".to_owned(),
+            serde_json::Value::String(alert.summary.clone()),
+        );
+    }
+    serde_json::json!({
+        "routing_key": routing_key,
+        "event_action": "trigger",
+        "dedup_key": alert.dedup_key,
+        "payload": {
+            "summary": alert.title,
+            "source": alert.host,
+            "severity": pagerduty_severity(alert.severity),
+            "timestamp": alert.timestamp.to_rfc3339(),
+            "component": alert.condition.as_str(),
+            "custom_details": serde_json::Value::Object(custom),
+        },
+    })
+}
+
+/// `PagerDuty` Events API v2 alert channel (issue #1630).
+///
+/// POSTs each alert as an Events API v2 event correlated on the alert's stable
+/// [`Alert::dedup_key`], so a repeating condition folds into a single incident
+/// and a recovery emits a `resolve` event that auto-resolves it. Works against
+/// PagerDuty-Events-compatible endpoints offered by other paging services (set
+/// `[alerts] pagerduty_url`). Uses the SSRF-hardened
+/// [`http_client::Client`](crate::http_client::Client) for the outbound call.
+#[cfg(feature = "http-client")]
+pub struct PagerDutyAlertChannel {
+    client: crate::http_client::Client,
+    url: String,
+    routing_key: String,
+    routing: AlertRouting,
+}
+
+#[cfg(feature = "http-client")]
+impl PagerDutyAlertChannel {
+    /// Create a `PagerDuty` channel posting to `url` (typically
+    /// [`PAGERDUTY_EVENTS_URL`]) with the Events API v2 `routing_key`, receiving
+    /// the severities `routing` accepts.
+    #[must_use]
+    pub fn new(
+        client: crate::http_client::Client,
+        url: impl Into<String>,
+        routing_key: impl Into<String>,
+        routing: AlertRouting,
+    ) -> Self {
+        Self {
+            client,
+            url: url.into(),
+            routing_key: routing_key.into(),
+            routing,
+        }
+    }
+}
+
+#[cfg(feature = "http-client")]
+impl AlertChannel for PagerDutyAlertChannel {
+    fn name(&self) -> &'static str {
+        "pagerduty"
+    }
+
+    fn accepts_severity(&self, severity: AlertSeverity) -> bool {
+        self.routing.accepts(severity)
+    }
+
+    fn deliver<'a>(&'a self, alert: &'a Alert) -> AlertDeliveryFuture<'a> {
+        Box::pin(async move {
+            let payload = pagerduty_event_payload(alert, &self.routing_key);
+            let response = self
+                .client
+                .named(&self.url)
+                .post(&self.url)
+                .json(&payload)
+                .send()
+                .await
+                .map_err(|e| AlertDeliveryError::new("pagerduty", e.to_string()))?;
+            // The Events API v2 returns 202 Accepted on success.
+            if response.is_success() {
+                Ok(())
+            } else {
+                Err(AlertDeliveryError::new(
+                    "pagerduty",
+                    format!("endpoint returned status {}", response.status()),
+                ))
+            }
+        })
+    }
+}
+
+/// Build the Slack/Discord-compatible message text for `alert`, carrying the
+/// operator-actionable fields (#1610): what failed, when, host/replica, and
+/// where to look next, plus any structured details.
+#[cfg(feature = "http-client")]
+fn slack_message_text(alert: &Alert) -> String {
+    use std::fmt::Write as _;
+    let (icon, label) = match alert.event {
+        AlertEventKind::Trigger => ("\u{1f534}", "ALERT"),
+        AlertEventKind::Resolve => ("\u{2705}", "RECOVERED"),
+    };
+    let mut body = format!("{icon} *[{label}] {}*\n", alert.title);
+    let _ = writeln!(body, "*When:* {}", alert.timestamp.to_rfc3339());
+    let _ = writeln!(body, "*Host/replica:* {}", alert.host);
+    let _ = writeln!(body, "*Condition:* {}", alert.condition.as_str());
+    let _ = writeln!(body, "*Where to look:* {}", alert.where_to_look);
+    if !alert.summary.is_empty() {
+        let _ = write!(body, "\n{}", alert.summary);
+    }
+    if !alert.details.is_empty() {
+        body.push_str("\n\n*Details:*");
+        let mut keys: Vec<&String> = alert.details.keys().collect();
+        keys.sort();
+        for k in keys {
+            if let Some(v) = alert.details.get(k) {
+                let _ = write!(body, "\n• {k}: {v}");
+            }
+        }
+    }
+    body
+}
+
+/// Build the Slack (and Discord Slack-compatible) webhook request body for
+/// `alert`. Both accept a top-level `text` field, so one payload dialect covers
+/// both chat tools.
+#[cfg(feature = "http-client")]
+#[must_use]
+pub fn slack_message_payload(alert: &Alert) -> serde_json::Value {
+    serde_json::json!({ "text": slack_message_text(alert) })
+}
+
+/// Slack / Discord chat alert channel (issue #1630).
+///
+/// POSTs a human-readable message to a Slack incoming-webhook URL, or to a
+/// Discord webhook's Slack-compatible endpoint (append `/slack`), using one
+/// payload dialect for both. Uses the SSRF-hardened
+/// [`http_client::Client`](crate::http_client::Client) for the outbound call.
+#[cfg(feature = "http-client")]
+pub struct SlackAlertChannel {
+    client: crate::http_client::Client,
+    url: String,
+    name: &'static str,
+    routing: AlertRouting,
+}
+
+#[cfg(feature = "http-client")]
+impl SlackAlertChannel {
+    /// Create a Slack channel posting to the incoming-webhook `url`.
+    #[must_use]
+    pub fn slack(
+        client: crate::http_client::Client,
+        url: impl Into<String>,
+        routing: AlertRouting,
+    ) -> Self {
+        Self {
+            client,
+            url: url.into(),
+            name: "slack",
+            routing,
+        }
+    }
+
+    /// Create a Discord channel posting to a Discord webhook's Slack-compatible
+    /// endpoint (`.../slack`), reusing the Slack payload dialect.
+    #[must_use]
+    pub fn discord(
+        client: crate::http_client::Client,
+        url: impl Into<String>,
+        routing: AlertRouting,
+    ) -> Self {
+        Self {
+            client,
+            url: url.into(),
+            name: "discord",
+            routing,
+        }
+    }
+}
+
+#[cfg(feature = "http-client")]
+impl AlertChannel for SlackAlertChannel {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn accepts_severity(&self, severity: AlertSeverity) -> bool {
+        self.routing.accepts(severity)
+    }
+
+    fn deliver<'a>(&'a self, alert: &'a Alert) -> AlertDeliveryFuture<'a> {
+        Box::pin(async move {
+            let payload = slack_message_payload(alert);
+            let response = self
+                .client
+                .named(&self.url)
+                .post(&self.url)
+                .json(&payload)
+                .send()
+                .await
+                .map_err(|e| AlertDeliveryError::new(self.name, e.to_string()))?;
+            if response.is_success() {
+                Ok(())
+            } else {
+                Err(AlertDeliveryError::new(
+                    self.name,
+                    format!("endpoint returned status {}", response.status()),
+                ))
+            }
+        })
+    }
+}
+
+/// Build the native provider channels (`PagerDuty`, Slack, Discord) configured
+/// in `[alerts]` (issue #1630).
+///
+/// Skips any transport whose required config is missing or unusable (a blank
+/// routing key, or a non-absolute webhook URL that the HTTP client could never
+/// dispatch), with a dedicated `tracing::warn!` for each skip — mirroring the
+/// built-in webhook's skip-and-warn rigor so a transport that *looks* configured
+/// actually delivers.
+///
+/// Shared by [`install_from_config`] (runtime wiring) and the CLI `autumn alert
+/// test` command so both agree on exactly which transports are usable. All
+/// outbound calls go through the passed SSRF-hardened `client`.
+#[cfg(feature = "http-client")]
+#[must_use]
+pub fn native_transport_channels(
+    config: &AlertConfig,
+    client: &crate::http_client::Client,
+) -> Vec<Arc<dyn AlertChannel>> {
+    let mut channels: Vec<Arc<dyn AlertChannel>> = Vec::new();
+
+    if let Some(routing_key) = config
+        .pagerduty_routing_key
+        .as_ref()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+    {
+        let url = config
+            .pagerduty_url
+            .as_ref()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .unwrap_or(PAGERDUTY_EVENTS_URL);
+        if is_absolute_http_url(url) {
+            channels.push(Arc::new(PagerDutyAlertChannel::new(
+                client.clone(),
+                url.to_owned(),
+                routing_key.to_owned(),
+                config.pagerduty_severities,
+            )));
+        } else {
+            tracing::warn!(
+                pagerduty_url = url,
+                "alerts: the configured [alerts] pagerduty_url ({url}) is not an absolute \
+                 http(s) URL; no PagerDuty alerts will be delivered. Fix [alerts] pagerduty_url \
+                 (or the AUTUMN_ALERTS__PAGERDUTY_URL env var)."
+            );
+        }
+    }
+
+    push_chat_channel(
+        &mut channels,
+        client,
+        config.slack_webhook_url.as_deref(),
+        "slack",
+        config.slack_severities,
+    );
+    push_chat_channel(
+        &mut channels,
+        client,
+        config.discord_webhook_url.as_deref(),
+        "discord",
+        config.discord_severities,
+    );
+
+    channels
+}
+
+/// Register a Slack-compatible chat channel (`slack` or `discord`) from a
+/// configured webhook `url`, skipping (with a warning) a non-absolute URL that
+/// the HTTP client could never dispatch.
+#[cfg(feature = "http-client")]
+fn push_chat_channel(
+    channels: &mut Vec<Arc<dyn AlertChannel>>,
+    client: &crate::http_client::Client,
+    url: Option<&str>,
+    provider: &'static str,
+    routing: AlertRouting,
+) {
+    let Some(url) = url.map(str::trim).filter(|s| !s.is_empty()) else {
+        return;
+    };
+    if !is_absolute_http_url(url) {
+        tracing::warn!(
+            provider,
+            webhook_url = url,
+            "alerts: the configured [alerts] {provider}_webhook_url ({url}) is not an absolute \
+             http(s) URL; no {provider} alerts will be delivered. Fix the URL (or the \
+             AUTUMN_ALERTS__{PROVIDER}_WEBHOOK_URL env var).",
+            PROVIDER = provider.to_uppercase(),
+        );
+        return;
+    }
+    let channel: Arc<dyn AlertChannel> = if provider == "discord" {
+        Arc::new(SlackAlertChannel::discord(
+            client.clone(),
+            url.to_owned(),
+            routing,
+        ))
+    } else {
+        Arc::new(SlackAlertChannel::slack(
+            client.clone(),
+            url.to_owned(),
+            routing,
+        ))
+    };
+    channels.push(channel);
+}
+
 // ── Wiring ──────────────────────────────────────────────────────────────────
 
 /// Whether `url` is a non-empty ABSOLUTE `http(s)` URL that the outbound HTTP
@@ -1188,6 +1665,47 @@ fn build_mail_alert_channel(
     )))
 }
 
+/// Append the native provider channels (issue #1630, `PagerDuty` / Slack /
+/// Discord) to `channels`, built through [`native_transport_channels`] with the
+/// SSRF-hardened shared HTTP client.
+///
+/// Compiled to a warn-only no-op when the `http-client` feature is off, so a
+/// PagerDuty/Slack/Discord-only config does not silently deliver nothing.
+fn push_native_transport_channels(
+    state: &AppState,
+    config: &AlertConfig,
+    channels: &mut Vec<Arc<dyn AlertChannel>>,
+) {
+    #[cfg(feature = "http-client")]
+    {
+        let client = crate::http_client::Client::from_state(state);
+        channels.extend(native_transport_channels(config, &client));
+    }
+    #[cfg(not(feature = "http-client"))]
+    {
+        let _ = (state, channels);
+        if config
+            .pagerduty_routing_key
+            .as_ref()
+            .is_some_and(|s| !s.trim().is_empty())
+            || config
+                .slack_webhook_url
+                .as_ref()
+                .is_some_and(|s| !s.trim().is_empty())
+            || config
+                .discord_webhook_url
+                .as_ref()
+                .is_some_and(|s| !s.trim().is_empty())
+        {
+            tracing::warn!(
+                "operator-alerts: a PagerDuty/Slack/Discord transport is configured but the \
+                 `http-client` feature is not enabled; no such alerts will be delivered. Enable \
+                 the `http-client` feature or use an email destination."
+            );
+        }
+    }
+}
+
 /// Install the operator alerter from `config` plus any builder channels.
 ///
 /// Builds the built-in channels from `config`, combines them with any
@@ -1307,6 +1825,9 @@ pub fn install_from_config(
              feature or use an email destination."
         );
     }
+
+    // Native provider transports (issue #1630): PagerDuty / Slack / Discord.
+    push_native_transport_channels(state, config, &mut channels);
 
     channels.extend(extra_channels);
 
@@ -2256,5 +2777,269 @@ mod tests {
         assert_eq!(v["severity"], "critical");
         assert_eq!(v["event"], "trigger");
         assert_eq!(v["where_to_look"], "/actuator/jobs");
+    }
+
+    // ── Per-channel severity routing (#1630) ─────────────────────────────────
+
+    #[test]
+    fn alert_routing_accepts_matches_severity() {
+        // `All` receives both a firing alert and its recovery.
+        assert!(AlertRouting::All.accepts(AlertSeverity::Critical));
+        assert!(AlertRouting::All.accepts(AlertSeverity::Recovery));
+        // `Critical` receives only firing alerts; a recovery is NOT delivered.
+        assert!(AlertRouting::Critical.accepts(AlertSeverity::Critical));
+        assert!(!AlertRouting::Critical.accepts(AlertSeverity::Recovery));
+    }
+
+    #[test]
+    fn alert_routing_defaults_to_all() {
+        assert_eq!(AlertRouting::default(), AlertRouting::All);
+    }
+
+    #[test]
+    fn routing_deserializes_from_toml() {
+        #[derive(Deserialize)]
+        struct Holder {
+            r: AlertRouting,
+        }
+        let all: Holder = toml::from_str(r#"r = "all""#).expect("parse all");
+        assert_eq!(all.r, AlertRouting::All);
+        let crit: Holder = toml::from_str(r#"r = "critical""#).expect("parse critical");
+        assert_eq!(crit.r, AlertRouting::Critical);
+    }
+
+    // ── Native transport payloads (#1630) ────────────────────────────────────
+
+    #[cfg(feature = "http-client")]
+    #[test]
+    fn pagerduty_trigger_payload_is_events_v2_shaped() {
+        let alert = Alert::trigger(AlertCondition::DeadLetteredJob, "dead_lettered_job:emailer")
+            .title("Job 'emailer' was dead-lettered")
+            .summary("exhausted retries")
+            .detail("job", "emailer")
+            .build();
+        let v = pagerduty_event_payload(&alert, "R0UT1NGKEY");
+        assert_eq!(v["routing_key"], "R0UT1NGKEY");
+        assert_eq!(v["event_action"], "trigger");
+        // Stable dedup key correlates repeats into one incident.
+        assert_eq!(v["dedup_key"], "dead_lettered_job:emailer");
+        assert_eq!(v["payload"]["severity"], "critical");
+        assert_eq!(v["payload"]["source"], alert.host);
+        assert_eq!(v["payload"]["summary"], "Job 'emailer' was dead-lettered");
+        assert_eq!(v["payload"]["component"], "dead_lettered_job");
+        // Custom details carry the routing/where-to-look context.
+        assert_eq!(
+            v["payload"]["custom_details"]["condition"],
+            "dead_lettered_job"
+        );
+        assert_eq!(
+            v["payload"]["custom_details"]["where_to_look"],
+            "/actuator/jobs"
+        );
+        assert_eq!(v["payload"]["custom_details"]["job"], "emailer");
+    }
+
+    #[cfg(feature = "http-client")]
+    #[test]
+    fn pagerduty_resolve_payload_is_minimal_and_correlates() {
+        let alert = Alert::recovery(
+            AlertCondition::ScheduledTaskFailure,
+            "scheduled_task_failure:backup",
+        )
+        .title("Scheduled task 'backup' recovered")
+        .build();
+        let v = pagerduty_event_payload(&alert, "R0UT1NGKEY");
+        assert_eq!(v["event_action"], "resolve");
+        // Same dedup key as its trigger → the correlated incident auto-resolves.
+        assert_eq!(v["dedup_key"], "scheduled_task_failure:backup");
+        // A resolve carries no payload block per the Events API v2 contract.
+        assert!(v.get("payload").is_none(), "resolve must omit payload: {v}");
+    }
+
+    #[cfg(feature = "http-client")]
+    #[test]
+    fn slack_payload_carries_required_operator_fields() {
+        let alert = Alert::trigger(AlertCondition::HighErrorRate, "high_error_rate:5xx:h1")
+            .title("5xx error rate is 12.0%")
+            .summary("60 of the last 500 requests returned 5xx")
+            .where_to_look("/actuator/metrics")
+            .detail("rate", "0.1200")
+            .build();
+        let v = slack_message_payload(&alert);
+        let text = v["text"].as_str().expect("text field");
+        // #1610 required fields: what failed, when, host/replica, where to look.
+        assert!(text.contains("5xx error rate is 12.0%"), "title: {text}");
+        assert!(text.contains(&alert.host), "host: {text}");
+        assert!(text.contains("/actuator/metrics"), "where_to_look: {text}");
+        assert!(
+            text.contains(&alert.timestamp.to_rfc3339()),
+            "timestamp: {text}"
+        );
+        assert!(text.contains("rate: 0.1200"), "details: {text}");
+    }
+
+    #[cfg(feature = "http-client")]
+    #[test]
+    fn pagerduty_channel_accepts_severity_reflects_routing() {
+        let crit = PagerDutyAlertChannel::new(
+            crate::http_client::Client::new(),
+            PAGERDUTY_EVENTS_URL,
+            "k",
+            AlertRouting::Critical,
+        );
+        assert_eq!(crit.name(), "pagerduty");
+        assert!(crit.accepts_severity(AlertSeverity::Critical));
+        assert!(!crit.accepts_severity(AlertSeverity::Recovery));
+    }
+
+    #[cfg(feature = "http-client")]
+    #[test]
+    fn slack_and_discord_channels_name_and_route() {
+        let slack = SlackAlertChannel::slack(
+            crate::http_client::Client::new(),
+            "https://hooks.slack.com/services/x",
+            AlertRouting::Critical,
+        );
+        assert_eq!(slack.name(), "slack");
+        assert!(!slack.accepts_severity(AlertSeverity::Recovery));
+        let discord = SlackAlertChannel::discord(
+            crate::http_client::Client::new(),
+            "https://discord.com/api/webhooks/x/y/slack",
+            AlertRouting::All,
+        );
+        assert_eq!(discord.name(), "discord");
+        assert!(discord.accepts_severity(AlertSeverity::Recovery));
+    }
+
+    // ── native_transport_channels construction / skips (#1630) ───────────────
+
+    #[cfg(feature = "http-client")]
+    fn channel_names(config: &AlertConfig) -> Vec<&'static str> {
+        let client = crate::http_client::Client::new();
+        native_transport_channels(config, &client)
+            .iter()
+            .map(|c| c.name())
+            .collect()
+    }
+
+    #[cfg(feature = "http-client")]
+    #[test]
+    fn native_transports_build_all_three_when_configured() {
+        let config = AlertConfig {
+            pagerduty_routing_key: Some("R0UT1NGKEY".to_owned()),
+            slack_webhook_url: Some("https://hooks.slack.com/services/x".to_owned()),
+            discord_webhook_url: Some("https://discord.com/api/webhooks/x/y/slack".to_owned()),
+            ..AlertConfig::default()
+        };
+        let names = channel_names(&config);
+        assert!(names.contains(&"pagerduty"), "{names:?}");
+        assert!(names.contains(&"slack"), "{names:?}");
+        assert!(names.contains(&"discord"), "{names:?}");
+    }
+
+    #[cfg(feature = "http-client")]
+    #[test]
+    fn native_transports_skip_blank_routing_key_and_relative_urls() {
+        let config = AlertConfig {
+            pagerduty_routing_key: Some("   ".to_owned()),
+            slack_webhook_url: Some("hooks.slack/x".to_owned()),
+            discord_webhook_url: Some("/relative".to_owned()),
+            ..AlertConfig::default()
+        };
+        assert!(
+            channel_names(&config).is_empty(),
+            "a blank routing key and relative URLs must register no channel"
+        );
+    }
+
+    #[cfg(feature = "http-client")]
+    #[test]
+    fn native_transports_skip_non_absolute_pagerduty_url() {
+        let config = AlertConfig {
+            pagerduty_routing_key: Some("R0UT1NGKEY".to_owned()),
+            pagerduty_url: Some("events.pagerduty.com/v2/enqueue".to_owned()),
+            ..AlertConfig::default()
+        };
+        assert!(
+            channel_names(&config).is_empty(),
+            "a non-absolute pagerduty_url must skip the PagerDuty channel"
+        );
+    }
+
+    #[cfg(feature = "http-client")]
+    #[test]
+    fn has_destination_counts_native_transports() {
+        let pd = AlertConfig {
+            pagerduty_routing_key: Some("k".to_owned()),
+            ..AlertConfig::default()
+        };
+        assert!(pd.has_destination() && pd.is_active());
+        let slack = AlertConfig {
+            slack_webhook_url: Some("https://hooks.slack.com/x".to_owned()),
+            ..AlertConfig::default()
+        };
+        assert!(slack.has_destination());
+        assert!(!AlertConfig::default().has_destination());
+    }
+
+    // ── Delivery through the mocked SSRF-hardened client (#1630) ──────────────
+
+    #[cfg(feature = "http-client")]
+    #[tokio::test]
+    async fn pagerduty_channel_delivers_trigger_to_events_endpoint() {
+        use crate::http_client::{Client, MockEntry, MockRegistry};
+        use std::sync::atomic::AtomicUsize;
+
+        let registry = Arc::new(MockRegistry::new());
+        let calls = Arc::new(AtomicUsize::new(0));
+        registry.register(MockEntry {
+            method: Some(reqwest::Method::POST),
+            path: "/v2/enqueue".to_owned(),
+            alias: None,
+            status: 202,
+            body: Some(serde_json::json!({"status": "success"})),
+            call_count: calls.clone(),
+        });
+        let client = Client::new().with_mock(registry);
+        let channel = PagerDutyAlertChannel::new(
+            client,
+            PAGERDUTY_EVENTS_URL,
+            "R0UT1NGKEY",
+            AlertRouting::All,
+        );
+        let alert = Alert::trigger(AlertCondition::DeadLetteredJob, "dead_lettered_job:x")
+            .title("x failed")
+            .build();
+        channel.deliver(&alert).await.expect("delivered");
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    #[cfg(feature = "http-client")]
+    #[tokio::test]
+    async fn slack_channel_reports_non_2xx_as_delivery_error() {
+        use crate::http_client::{Client, MockEntry, MockRegistry};
+        use std::sync::atomic::AtomicUsize;
+
+        let registry = Arc::new(MockRegistry::new());
+        registry.register(MockEntry {
+            method: Some(reqwest::Method::POST),
+            path: "/services/x".to_owned(),
+            alias: None,
+            status: 500,
+            body: None,
+            call_count: Arc::new(AtomicUsize::new(0)),
+        });
+        let client = Client::new().with_mock(registry);
+        let channel = SlackAlertChannel::slack(
+            client,
+            "https://hooks.slack.com/services/x",
+            AlertRouting::All,
+        );
+        let alert = Alert::trigger(AlertCondition::HighErrorRate, "high_error_rate:5xx").build();
+        let err = channel
+            .deliver(&alert)
+            .await
+            .expect_err("must error on 500");
+        assert_eq!(err.channel, "slack");
     }
 }

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -2953,6 +2953,26 @@ impl AutumnConfig {
             "AUTUMN_ALERTS__WEBHOOK_SECRET",
             &mut self.alerts.webhook_secret,
         );
+        parse_env_option_string(
+            env,
+            "AUTUMN_ALERTS__PAGERDUTY_ROUTING_KEY",
+            &mut self.alerts.pagerduty_routing_key,
+        );
+        parse_env_option_string(
+            env,
+            "AUTUMN_ALERTS__PAGERDUTY_URL",
+            &mut self.alerts.pagerduty_url,
+        );
+        parse_env_option_string(
+            env,
+            "AUTUMN_ALERTS__SLACK_WEBHOOK_URL",
+            &mut self.alerts.slack_webhook_url,
+        );
+        parse_env_option_string(
+            env,
+            "AUTUMN_ALERTS__DISCORD_WEBHOOK_URL",
+            &mut self.alerts.discord_webhook_url,
+        );
         parse_env_bool(
             env,
             "AUTUMN_ALERTS__CUSTOM_CHANNEL",

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -2973,6 +2973,24 @@ impl AutumnConfig {
             "AUTUMN_ALERTS__DISCORD_WEBHOOK_URL",
             &mut self.alerts.discord_webhook_url,
         );
+        // Per-channel severity routing (`all` / `critical`). `AlertRouting`'s
+        // `FromStr` accepts the same spellings as the TOML/serde path; an invalid
+        // value is logged and ignored by `parse_env`, leaving the current value.
+        parse_env(
+            env,
+            "AUTUMN_ALERTS__PAGERDUTY_SEVERITIES",
+            &mut self.alerts.pagerduty_severities,
+        );
+        parse_env(
+            env,
+            "AUTUMN_ALERTS__SLACK_SEVERITIES",
+            &mut self.alerts.slack_severities,
+        );
+        parse_env(
+            env,
+            "AUTUMN_ALERTS__DISCORD_SEVERITIES",
+            &mut self.alerts.discord_severities,
+        );
         parse_env_bool(
             env,
             "AUTUMN_ALERTS__CUSTOM_CHANNEL",
@@ -6702,6 +6720,39 @@ pool_size = 7
 
         assert_eq!(config.time_zone.identifier, "America/New_York");
         assert!(config.time_zone.validate().is_ok());
+    }
+
+    #[test]
+    fn alerts_severities_env_overrides_apply() {
+        // Per-channel severity routing must be controllable via the documented
+        // AUTUMN_ALERTS__*_SEVERITIES overrides, using the same `all`/`critical`
+        // value parsing the TOML/file path uses.
+        let env = MockEnv::new()
+            .with("AUTUMN_ALERTS__SLACK_SEVERITIES", "critical")
+            .with("AUTUMN_ALERTS__PAGERDUTY_SEVERITIES", "all")
+            .with("AUTUMN_ALERTS__DISCORD_SEVERITIES", "critical");
+        let mut config = AutumnConfig::default();
+        // Defaults are `All` for every channel.
+        assert_eq!(
+            config.alerts.slack_severities,
+            crate::alerts::AlertRouting::All
+        );
+
+        config.apply_env_overrides_with_env(&env);
+
+        assert_eq!(
+            config.alerts.slack_severities,
+            crate::alerts::AlertRouting::Critical,
+            "AUTUMN_ALERTS__SLACK_SEVERITIES=critical must set the Slack channel routing"
+        );
+        assert_eq!(
+            config.alerts.discord_severities,
+            crate::alerts::AlertRouting::Critical
+        );
+        assert_eq!(
+            config.alerts.pagerduty_severities,
+            crate::alerts::AlertRouting::All
+        );
     }
 
     #[test]

--- a/autumn/tests/integration/alerts.rs
+++ b/autumn/tests/integration/alerts.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex};
 
 use autumn_web::alerts::{
     Alert, AlertChannel, AlertCondition, AlertConfig, AlertDeliveryError, AlertDeliveryFuture,
-    AlertEventKind, AlertSeverity, Alerter, AlerterSettings,
+    AlertEventKind, AlertRouting, AlertSeverity, Alerter, AlerterSettings,
 };
 use autumn_web::test::TestApp;
 
@@ -967,4 +967,167 @@ async fn unreachable_channel_does_not_break_the_caller() {
     );
     // Give the detached task a chance to run and swallow its error.
     tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+}
+
+// ── Native transports: PagerDuty / Slack / Discord (issue #1630) ─────────────
+
+/// AC #1/#2 (#1630): a `[alerts] pagerduty_routing_key` (with a mock enqueue
+/// endpoint) installs the `PagerDuty` channel, and a dead-lettered job is
+/// delivered as an Events API v2 `trigger` to that endpoint — proving the
+/// config-only, zero-app-code path fires against a stub in-process.
+#[cfg(feature = "http-client")]
+#[tokio::test]
+async fn pagerduty_transport_registers_and_delivers_events_v2() {
+    let url = "https://events.pagerduty.test/v2/enqueue";
+    let mut app = TestApp::new();
+    // The channel names its client with the (full) URL, so the mock alias must
+    // equal that URL for the outbound POST to match.
+    let mock = app
+        .http_mock(url)
+        .post("/v2/enqueue")
+        .respond_with_status(202);
+    let client = app.build();
+
+    let config = AlertConfig {
+        pagerduty_routing_key: Some("R0UT1NGKEY".to_owned()),
+        pagerduty_url: Some(url.to_owned()),
+        ..AlertConfig::default()
+    };
+    autumn_web::alerts::install_from_config(client.state(), &config, Vec::new());
+    assert!(
+        client.state().extension::<Alerter>().is_some(),
+        "a PagerDuty routing key must install the PagerDuty channel"
+    );
+
+    autumn_web::alerts::notify_dead_lettered_job(client.state(), "emailer", "job-1", "boom");
+    // Give the detached delivery task a chance to hit the mock endpoint.
+    for _ in 0..50 {
+        if mock.call_count() >= 1 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    mock.expect_called(1);
+}
+
+/// AC #3 (#1630): a Slack webhook URL installs the Slack channel and a condition
+/// is posted to the Slack-compatible endpoint. Discord uses the same channel
+/// type against its Slack-compatible endpoint.
+#[cfg(feature = "http-client")]
+#[tokio::test]
+async fn slack_transport_registers_and_delivers_message() {
+    let url = "https://hooks.slack.test/services/T/B/x";
+    let mut app = TestApp::new();
+    let mock = app
+        .http_mock(url)
+        .post("/services/T/B/x")
+        .respond_with_status(200);
+    let client = app.build();
+
+    let config = AlertConfig {
+        slack_webhook_url: Some(url.to_owned()),
+        ..AlertConfig::default()
+    };
+    autumn_web::alerts::install_from_config(client.state(), &config, Vec::new());
+    assert!(client.state().extension::<Alerter>().is_some());
+
+    autumn_web::alerts::notify_scheduled_task_failure(client.state(), "nightly_backup", "boom");
+    for _ in 0..50 {
+        if mock.call_count() >= 1 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    mock.expect_called(1);
+}
+
+/// A relative/malformed native-transport URL must NOT register a channel — the
+/// SSRF-hardened HTTP client could never dispatch it. With it as the only
+/// destination, no alerter is installed (mirrors the generic-webhook rigor).
+#[cfg(feature = "http-client")]
+#[tokio::test]
+async fn native_transport_with_relative_url_does_not_register_channel() {
+    let client = TestApp::new().build();
+    let config = AlertConfig {
+        slack_webhook_url: Some("hooks.slack/x".to_owned()),
+        ..AlertConfig::default()
+    };
+    autumn_web::alerts::install_from_config(client.state(), &config, Vec::new());
+    assert!(
+        client.state().extension::<Alerter>().is_none(),
+        "a relative slack_webhook_url must not install a non-delivering channel"
+    );
+}
+
+/// AC #4 (#1630, per-channel severity routing): a chat channel declaring
+/// `slack_severities = "critical"` receives the firing trigger but NOT the
+/// recovery — the recovery is verifiably not delivered to it. Proven by the
+/// endpoint being called exactly once across a trigger→recover cycle.
+#[cfg(feature = "http-client")]
+#[tokio::test]
+async fn critical_only_chat_channel_does_not_receive_recovery() {
+    let url = "https://hooks.slack.test/services/crit/only/x";
+    let mut app = TestApp::new();
+    let mock = app
+        .http_mock(url)
+        .post("/services/crit/only/x")
+        .respond_with_status(200);
+    let client = app.build();
+
+    let config = AlertConfig {
+        slack_webhook_url: Some(url.to_owned()),
+        slack_severities: AlertRouting::Critical,
+        ..AlertConfig::default()
+    };
+    autumn_web::alerts::install_from_config(client.state(), &config, Vec::new());
+
+    // Trigger (critical) then recover (recovery) the same scheduled task.
+    autumn_web::alerts::notify_scheduled_task_failure(client.state(), "nightly_backup", "boom");
+    for _ in 0..50 {
+        if mock.call_count() >= 1 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    autumn_web::alerts::notify_scheduled_task_recovered(client.state(), "nightly_backup");
+    // Give any (erroneous) recovery delivery a chance to land.
+    tokio::time::sleep(std::time::Duration::from_millis(60)).await;
+    mock.expect_called(1);
+}
+
+/// AC #5 (#1630, fan-out): the same alert pages `PagerDuty` AND posts to Slack
+/// simultaneously when both are configured.
+#[cfg(feature = "http-client")]
+#[tokio::test]
+async fn alert_fans_out_to_pagerduty_and_slack_simultaneously() {
+    let pd_url = "https://events.pagerduty.test/fanout/enqueue";
+    let slack_url = "https://hooks.slack.test/fanout/x";
+    let mut app = TestApp::new();
+    let pd = app
+        .http_mock(pd_url)
+        .post("/fanout/enqueue")
+        .respond_with_status(202);
+    let slack = app
+        .http_mock(slack_url)
+        .post("/fanout/x")
+        .respond_with_status(200);
+    let client = app.build();
+
+    let config = AlertConfig {
+        pagerduty_routing_key: Some("R0UT1NGKEY".to_owned()),
+        pagerduty_url: Some(pd_url.to_owned()),
+        slack_webhook_url: Some(slack_url.to_owned()),
+        ..AlertConfig::default()
+    };
+    autumn_web::alerts::install_from_config(client.state(), &config, Vec::new());
+
+    autumn_web::alerts::notify_dead_lettered_job(client.state(), "emailer", "job-1", "boom");
+    for _ in 0..50 {
+        if pd.call_count() >= 1 && slack.call_count() >= 1 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    pd.expect_called(1);
+    slack.expect_called(1);
 }

--- a/docs/guide/operator-alerts.md
+++ b/docs/guide/operator-alerts.md
@@ -147,6 +147,18 @@ webhook_url = "https://…"      # signed webhook destination
 webhook_secret = "…"           # REQUIRED with webhook_url; alerts are always
                                # signed (prefer AUTUMN_ALERTS__WEBHOOK_SECRET)
 
+# Native provider transports (see "Native alerting transports" below)
+pagerduty_routing_key = "…"    # PagerDuty Events API v2 routing key
+                               # (prefer AUTUMN_ALERTS__PAGERDUTY_ROUTING_KEY)
+pagerduty_url = "https://events.pagerduty.com/v2/enqueue"  # override for a
+                               # PagerDuty-Events-compatible endpoint (optional)
+pagerduty_severities = "all"   # "all" (default) or "critical"
+slack_webhook_url = "https://hooks.slack.com/services/…"   # Slack incoming webhook
+slack_severities = "all"       # "all" (default) or "critical"
+discord_webhook_url = "https://discord.com/api/webhooks/…/slack"  # Discord (Slack-
+                               # compatible endpoint — append /slack)
+discord_severities = "all"     # "all" (default) or "critical"
+
 # Deduplication
 dedup_window_secs = 900        # at most one notice per condition per 15 min
 
@@ -240,8 +252,9 @@ has no outstanding failure to clear, so the recovery notice is skipped and the
 original failure alert may linger until it ages out. **Single-VPS deployments
 (the common case) are unaffected**, since there is only one replica; only
 multi-replica fleets can hit this after a leader handoff. Cross-app or
-fleet-level alert aggregation and shared active-alert state are tracked as a
-follow-up (#1630) and are out of scope here.
+fleet-level alert aggregation and shared active-alert state remain a separate
+future follow-up (the native PagerDuty/Slack/Discord transports do not change
+this process-local behaviour) and are out of scope here.
 
 ---
 
@@ -317,11 +330,126 @@ The host/replica identity is read from `AUTUMN_REPLICA_ID`, falling back to
 
 ---
 
-## Adding your own destination (PagerDuty, Slack, Discord, …)
+## Native alerting transports (PagerDuty, Slack, Discord)
 
-Delivery is a trait. Implement [`AlertChannel`] and register it — the built-in
-mail/webhook channels stay active alongside yours. This is the extension seam
-for additional transports; the framework core never changes.
+Autumn delivers its built-in alerts natively to the paging and chat tools most
+teams already run — **config-only, zero app code**. Add a routing key or a
+webhook URL under `[alerts]` and the provider is wired up, correlated, and
+fail-safe, alongside any email/webhook destination.
+
+All three use the SSRF-hardened outbound HTTP client and deliver off the request
+path exactly like the built-in webhook: a provider outage or a rejected event
+never affects request serving and adds no request latency; failures are logged.
+
+### PagerDuty (and PagerDuty-Events-compatible pagers)
+
+```toml
+[alerts]
+pagerduty_routing_key = "…"    # prefer AUTUMN_ALERTS__PAGERDUTY_ROUTING_KEY
+```
+
+Each alert is delivered as a **PagerDuty Events API v2** event correlated on the
+alert's stable `dedup_key`, so a repeating condition folds into a **single
+incident** instead of a page storm. When the condition clears, Autumn sends a
+`resolve` event with the same `dedup_key` and the incident **auto-resolves**. A
+firing alert maps to PagerDuty severity `critical`; the event carries the
+summary, source (host/replica), timestamp, condition component, and the alert's
+`where_to_look` plus structured details in `custom_details`.
+
+Point `pagerduty_url` at a PagerDuty-Events-compatible enqueue endpoint offered
+by another paging service to reuse this same channel:
+
+```toml
+pagerduty_url = "https://events.eu.pagerduty.com/v2/enqueue"
+```
+
+### Slack (and Discord via its Slack-compatible endpoint)
+
+```toml
+[alerts]
+slack_webhook_url  = "https://hooks.slack.com/services/T…/B…/…"
+discord_webhook_url = "https://discord.com/api/webhooks/…/…/slack"   # append /slack
+```
+
+The Slack channel posts a human-readable message carrying the required fields —
+what failed, when, on which host/replica, and where to look next — plus any
+structured details. **Discord** is supported through its **Slack-compatible
+webhook endpoint**: append `/slack` to a Discord webhook URL and Autumn sends
+the exact same payload dialect, so one message format covers both chat tools.
+
+Both webhook URLs must be **absolute `https` URLs** (Slack and Discord only
+expose `https` endpoints). A relative or non-`https` value is skipped with a
+startup `warn`, and `autumn doctor` flags it in production.
+
+### Multiple destinations fan out
+
+Every configured destination receives the same alert. Set a PagerDuty routing
+key **and** a Slack webhook and a critical condition pages the on-call phone and
+posts to the incident channel simultaneously; add the generic webhook and email
+and all four fire.
+
+### Per-channel severity routing
+
+Each native destination declares which severities it receives via its
+`*_severities` key — `"all"` (the default) or `"critical"`:
+
+```toml
+[alerts]
+pagerduty_routing_key = "…"
+pagerduty_severities  = "all"       # page on failure AND auto-resolve
+slack_webhook_url     = "https://hooks.slack.com/services/…"
+slack_severities      = "critical"  # notify chat on failure, stay quiet on recovery
+```
+
+A channel set to `"critical"` receives only firing (`critical`) alerts;
+recovery/informational (`recovery`) alerts are **verifiably not delivered** to
+it. The recommended pattern is to page a human on critical conditions while a
+chat channel merely notifies. Leave **PagerDuty on `"all"`** (the default) so the
+`resolve` event reaches it and incidents auto-resolve — setting it to
+`"critical"` suppresses the resolve and incidents stay open until they age out.
+
+Severity routing applies only to Autumn's built-in transports; a custom
+[`AlertChannel`] you register in code receives every severity unless it overrides
+`accepts_severity`.
+
+### Verify wiring before an incident: `autumn alert test`
+
+Fire a synthetic alert through every configured outbound-HTTP channel and see
+per-channel success or an actionable error — before you are relying on it:
+
+```bash
+autumn alert test                 # every configured channel
+autumn alert test --channel slack # just one (pagerduty | slack | discord | webhook)
+```
+
+It reads your effective `[alerts]` config (env vars and profiles honoured) and
+uses the same channel implementations the server installs, so a green run proves
+the real delivery path. (Email is validated by `autumn doctor` and a real send,
+since it needs a configured mailer.)
+
+### Acknowledge / resolve stance
+
+This is a **one-directional** integration: Autumn → provider. Acknowledging or
+resolving an incident **in the provider** does not silence Autumn's re-alerts —
+Autumn's own dedup / re-alert windows (`dedup_window_secs`) bound notification
+volume, and an Autumn-side recovery is what emits the `resolve` event. Inbound
+ack/resolve synchronization (provider → Autumn silencing) is out of scope.
+
+### Unsupported providers: the generic webhook fallback
+
+A provider without native support (Opsgenie's own API, Microsoft Teams, Telegram,
+SMS, …) is served either by its PagerDuty-Events- or Slack-compatible endpoint
+where offered, or by the **generic signed webhook** (`webhook_url` +
+`webhook_secret`, documented above) pointed at a small translation shim, or by a
+custom [`AlertChannel`] in code (next section).
+
+---
+
+## Adding your own destination (a custom `AlertChannel`)
+
+PagerDuty, Slack, and Discord are built in (above); this seam is for **any other
+sink**. Delivery is a trait: implement [`AlertChannel`] and register it — the
+built-in channels stay active alongside yours. The framework core never changes.
 
 > Custom channels are still governed by the master switch: with
 > `enabled = false` your channel is not installed and receives nothing, exactly


### PR DESCRIPTION
## Before / After

**Before**, an operator could only receive autumn's operational alerts via email or a single generic signed webhook.

**After**, autumn ships native **PagerDuty**, **Slack**, and **Discord** alert channels configured in `autumn.toml`, each with per-channel severity routing — a PagerDuty incident auto-triggers and auto-resolves, a Slack/Discord message posts the failure details — and `autumn doctor` refuses to greenlight a config that won't deliver.

## How

- New `AlertChannel` implementations in `autumn/src/alerts.rs` built on #1713's fan-out seam (no core pipeline changes):
  - `PagerDutyAlertChannel` — Events API v2, correlated on the alert's stable dedup key; a trigger sends the full payload, a recovery sends the minimal `resolve` event to auto-close the incident.
  - `SlackAlertChannel` — also serves Discord via its Slack-compatible endpoint; `{"text": …}` payload carrying the required failure fields (what failed, when, host/replica, where to look, details).
- **Per-channel severity routing** via a non-breaking `AlertChannel::accepts_severity` default method plus an `AlertRouting` (`all` | `critical`) config value; `Alerter::dispatch` skips a channel that doesn't accept an alert's severity. External channels are unaffected (default accepts all).
- All outbound calls go through the SSRF-hardened `http_client::Client`; delivery stays on the detached fan-out task — **fail-safe and off the request path**.
- `autumn doctor` gains an `alert_transports` check that warns (in production / `--strict`) on: a malformed routing key, a routing key absent while a PagerDuty URL is set, a non-absolute PagerDuty URL, and a non-https Slack/Discord URL.
- New `autumn alert test` CLI subcommand fires a test alert through the configured outbound channels.
- Docs: new "Native alerting transports" section in `docs/guide/operator-alerts.md`.
- Config: flat fields mirroring the existing email/webhook shape, with `AUTUMN_ALERTS__*` env overrides.

## Testing

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- Targeted tests pass: 45 lib + 29 integration alerts tests, 73 CLI alert tests

## Notes

The "fleet scheduled-task-recovery gap" from #1713 is **out of scope** for #1630 — its ACs cover transports / severity routing / CLI / doctor, while inbound ack-sync and shared active-alert state are explicitly out of scope. It's left documented as a future follow-up; two stale `(#1630)` references that implied it would be fixed here were corrected.

Closes #1630

---
_Generated by [Claude Code](https://claude.ai/code/session_01QExw7x7UkZLeUZQ4vtyBvy)_