### PR TITLE
scaffold: constrained-numeric blank-state (#1748) + HTML5 constraints & belongs_to select under --live-validation (#1750)

### DIFF
--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1226,12 +1226,7 @@ fn render_model_form(
         // `required` (HTML) and `range` when the range spans the zero default,
         // silently accepting a value the user never typed. `Option<T>` defaults
         // to `None` (renders blank), and the `required` rule below rejects it.
-        let is_constrained_required_numeric = !f.nullable
-            && matches!(
-                f.kind,
-                FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64
-            )
-            && (f.constraints.min.is_some() || f.constraints.max.is_some());
+        let is_constrained_required_numeric = is_constrained_required_numeric(f);
         if is_constrained_required_numeric {
             // Emitted alongside the `range` rule so `None` is rejected
             // server-side (a 422 with an inline error) rather than parsed as `0`.
@@ -3676,10 +3671,36 @@ fn title_case(s: &str) -> String {
         .join(" ")
 }
 
+/// A required numeric carrying a `{min,max}` range (issue #1388) that is
+/// represented as `Option<T>` on the form struct (issue #1748). Extracted so
+/// both the struct/`into_new` emission in [`render_model_form`] and the
+/// empty-pair drop set in [`render_nullable_field_match`] agree on which fields
+/// are the synthetic Options.
+const fn is_constrained_required_numeric(f: &Field) -> bool {
+    !f.nullable
+        && matches!(
+            f.kind,
+            FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64
+        )
+        && (f.constraints.min.is_some() || f.constraints.max.is_some())
+}
+
+/// Render the body of the generated `is_nullable_form_field` helper — the set
+/// of fields whose empty `field=` pair the decoder drops so it deserializes as
+/// missing (`None`) rather than being handed to `serde_urlencoded` as `""`.
+///
+/// This includes the genuinely nullable fields AND the synthetic
+/// constrained-required-`Option<T>` numerics (issue #1748): those are
+/// `Option<T>` on the form struct but have `nullable == false`, so without this
+/// a blank `age=` pair (from curl, a non-browser client, or disabled JS) would
+/// reach `serde_urlencoded`, which parses `""` into the inner numeric and
+/// returns a **400** *before* `#[validate(required)]` can render the intended
+/// **422** inline error. Dropping the empty pair makes the field decode as
+/// `None`, so `required` fires and produces the 422 (the #1748 intent).
 fn render_nullable_field_match(fields: &[Field]) -> String {
     let names = fields
         .iter()
-        .filter(|field| field.nullable)
+        .filter(|field| field.nullable || is_constrained_required_numeric(field))
         .map(|field| format!("\"{}\"", field.name))
         .collect::<Vec<_>>();
     if names.is_empty() {

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1220,6 +1220,23 @@ fn render_model_form(
 
     for f in fields {
         let name = &f.name;
+        // A required numeric carrying a `{min,max}` range (issue #1388) is
+        // represented as `Option<T>` on the form struct (issue #1748): a native
+        // `T` defaults to `0`, which pre-fills the input and passes both
+        // `required` (HTML) and `range` when the range spans the zero default,
+        // silently accepting a value the user never typed. `Option<T>` defaults
+        // to `None` (renders blank), and the `required` rule below rejects it.
+        let is_constrained_required_numeric = !f.nullable
+            && matches!(
+                f.kind,
+                FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64
+            )
+            && (f.constraints.min.is_some() || f.constraints.max.is_some());
+        if is_constrained_required_numeric {
+            // Emitted alongside the `range` rule so `None` is rejected
+            // server-side (a 422 with an inline error) rather than parsed as `0`.
+            let _ = writeln!(struct_fields, "    #[validate(required)]");
+        }
         if let Some(rules) = validations.get(name) {
             for rule in rules {
                 let _ = writeln!(struct_fields, "    #[validate({rule})]");
@@ -1359,6 +1376,23 @@ fn render_model_form(
                     "            {name}: match &row.{name} {{ {arms}}},"
                 );
             }
+        } else if is_constrained_required_numeric {
+            // A required numeric with a `{min,max}` range (issue #1388) is
+            // `Option<T>` on the form struct (issue #1748). `validator`'s
+            // `range` rule applies to the inner value only when `Some`, so the
+            // range is still enforced server-side; `None` (the blank default)
+            // is rejected by the `#[validate(required)]` emitted above rather
+            // than parsed as `T::default()` (`0`). A native `T` here would
+            // pre-fill `0` and silently pass both `required` and a range that
+            // spans the zero default. `into_new` unwraps the validated
+            // `Some(_)`; `from_row` wraps a persisted native value in `Some`.
+            let rust_type = f.rust_type();
+            let _ = writeln!(struct_fields, "    pub {name}: Option<{rust_type}>,");
+            let _ = writeln!(
+                into_new,
+                "        {name}: form.{name}.ok_or_else(|| autumn_web::AutumnError::bad_request_msg(\"{name}: is required\"))?,"
+            );
+            let _ = writeln!(from_row, "            {name}: Some(row.{name}),");
         } else if !f.nullable
             && matches!(
                 f.kind,
@@ -1370,21 +1404,6 @@ fn render_model_form(
                     | FieldKind::Decimal { .. }
                     | FieldKind::References
             )
-            // A numeric field carrying a `{min,max}` range constraint (issue
-            // #1388) must keep its NATIVE type on the form struct, not the
-            // String representation below: `validator`'s `range` rule only
-            // applies to numeric types, so `#[validate(range(...))]` on a
-            // `String` field fails to compile — and the whole point of the
-            // constraint is that the range is rejected server-side through the
-            // changeset (a 422 with an inline error), which needs the rule on
-            // the form the changeset validates. The `T::default()` pre-fill
-            // trade-off the String representation avoids is moot here: the
-            // field is `required` and range-bounded, so a deliberate value is
-            // forced anyway.
-            && !(matches!(
-                f.kind,
-                FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64
-            ) && (f.constraints.min.is_some() || f.constraints.max.is_some()))
         {
             // Represented as a `String` on the form, exactly like a required
             // enum/datetime field: `T::default()` for these kinds (`0`, the nil

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1803,7 +1803,7 @@ fn render_routes_file(
         // standard path — the new/edit form bodies load the options before the
         // markup. The block wraps the `layout(...)` call so it splices into the
         // GET handlers and the 422 re-render branches unchanged.
-        let mut option_loads = String::new();
+        let mut option_loads = String::with_capacity(reference_fields.len() * 80);
         for f in &reference_fields {
             let name = &f.name;
             let _ = writeln!(
@@ -3063,7 +3063,7 @@ fn render_changeset_form_inputs(
     // it keeps the derived per-field control instead.
     let reference_select_names: BTreeSet<&str> =
         reference_selects.iter().map(|f| f.name.as_str()).collect();
-    let mut out = String::new();
+    let mut out = String::with_capacity(fields.len() * 150);
     for f in fields {
         let name = &f.name;
         let label = humanize_label(name);

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1530,17 +1530,13 @@ fn render_routes_file(
         .filter(|f| f.kind.is_reference() && !missing_reference_targets.contains(&f.name))
         .collect();
     // The subset that also renders an in-FORM `<select>` of the referenced
-    // table's ids (issue #1135 AC 2) plus its runtime option loaders.
-    // `--live-validation` renders the form through the per-field path (no
-    // `form_for`, and `select_input` takes only static options, so a
-    // runtime-option belongs_to `<select>` can't be wired through it without
-    // the same cross-crate form-helper change #1750 tracks): skip the dropdown
-    // + loaders there, but KEEP the index/show display rendering above.
-    let reference_fields: Vec<&Field> = if live_validation {
-        Vec::new()
-    } else {
-        display_reference_fields.clone()
-    };
+    // table's ids (issue #1135 AC 2) plus its runtime option loaders. Issue
+    // #1750: `--live-validation` renders the form through the per-field path
+    // (no `form_for`), which used to drop the dropdown — the per-field path now
+    // emits a raw runtime-populated `<select>` (see
+    // `render_live_reference_select`), so every mode gets the belongs_to
+    // dropdown.
+    let reference_fields: Vec<&Field> = display_reference_fields.clone();
     let has_reference_selects = !reference_fields.is_empty();
 
     // Issue #1130: standard scaffolds render every view through the
@@ -1799,8 +1795,23 @@ fn render_routes_file(
             plural,
             live_validation,
             &validated_fields,
+            &reference_fields,
         );
-        let new_form_body = format!(
+        // Issue #1750: the belongs_to parent `<select>` (rendered inline by
+        // `render_changeset_form_inputs` via `render_live_reference_select`)
+        // reads a request-time `{name}_options` binding, so — exactly like the
+        // standard path — the new/edit form bodies load the options before the
+        // markup. The block wraps the `layout(...)` call so it splices into the
+        // GET handlers and the 422 re-render branches unchanged.
+        let mut option_loads = String::new();
+        for f in &reference_fields {
+            let name = &f.name;
+            let _ = writeln!(
+                option_loads,
+                "        let {name}_options = {name}_select_options(&mut db).await?;"
+            );
+        }
+        let new_form_layout = format!(
             "{layout_fn}(\"New {pascal_name}\", {cp_new}{flash_arg}, html! {{\n        \
              h1 {{ \"New {pascal_name}\" }}\n        \
              form action=\"/{plural}\" method=\"post\"{form_enctype} {{\n            \
@@ -1809,7 +1820,7 @@ fn render_routes_file(
              }}\n    \
              }})"
         );
-        let edit_form_body = format!(
+        let edit_form_layout = format!(
             "{layout_fn}(&format!(\"Edit {pascal_name} #{{}}\", *id), {cp_edit}{flash_arg}, html! {{\n        \
              h1 {{ \"Edit {pascal_name} #\" (*id) }}\n        \
              form action=(format!(\"/{plural}/{{}}/update\", *id)) method=\"post\"{form_enctype} {{\n            \
@@ -1822,12 +1833,18 @@ fn render_routes_file(
              }}\n    \
              }})"
         );
-        // The in-form belongs_to `<select>` is deferred in `--live-validation`
-        // (#1750), but the referenced-row option loaders are still emitted: the
-        // issue #1146 index parent-label map is built by collecting each
-        // `{name}_select_options(...)` into a `HashMap` (see
-        // `render_index_reference_label_loads`), so the loaders are a live
-        // dependency of the restored index display, not dead code.
+        let (new_form_body, edit_form_body) = if has_reference_selects {
+            (
+                format!("{{\n{option_loads}        {new_form_layout}\n    }}"),
+                format!("{{\n{option_loads}        {edit_form_layout}\n    }}"),
+            )
+        } else {
+            (new_form_layout, edit_form_layout)
+        };
+        // The referenced-row option loaders are emitted regardless: they
+        // populate the in-form `<select>` (issue #1750) AND the issue #1146
+        // index parent-label map (`render_index_reference_label_loads` collects
+        // each `{name}_select_options(...)` into a `HashMap`).
         let option_loaders =
             render_reference_option_loaders(&display_reference_fields, db_ty, &reference_displays);
         (new_form_body, edit_form_body, option_loaders)
@@ -2243,19 +2260,22 @@ pub async fn index(
         for (field_name, rules) in validations {
             let rule_comment = rules.join(", ");
             let label = humanize_label(field_name);
-            // Match `render_changeset_form_inputs`'s helper choice: a
-            // non-nullable field keeps `required`/`aria-required` through the
-            // htmx round-trip too, otherwise the attribute would vanish from
-            // the DOM the moment the field's wrapper gets swapped in.
-            let is_nullable = fields
-                .iter()
-                .find(|f| f.name == *field_name)
-                .is_some_and(|f| f.nullable);
-            let helper = if is_nullable {
-                "text_input_htmx"
-            } else {
-                "required_text_input_htmx"
-            };
+            let field = fields.iter().find(|f| f.name == *field_name);
+            // Issue #1750: a DSL-constrained `String`/`Text` field renders in
+            // the form through the raw-markup constrained control (carrying the
+            // #1388 HTML5 attributes `minlength`/`maxlength`/`type="email"`), so
+            // its inline-validation fragment must return the SAME markup —
+            // otherwise the htmx `outerHTML` swap on the first `change` would
+            // shed those client-side guards. The swapped-in field re-wires its
+            // own htmx trigger from the identical `validate_url`.
+            let constrained = field.and_then(|f| {
+                html5_constraint_spec(f).and_then(|(input_type, attrs)| {
+                    // Numerics don't take the htmx path (no wrapper to swap), so
+                    // only the text-family constrained controls need a fragment.
+                    matches!(f.kind, FieldKind::String | FieldKind::Text)
+                        .then_some((f, input_type, attrs))
+                })
+            });
             let _ = write!(
                 vh,
                 "\n\n/// `POST /{plural}/validate/{field_name}` — inline validation fragment.\n"
@@ -2276,10 +2296,26 @@ pub async fn index(
             vh.push_str("        return autumn_web::html! {};\n");
             vh.push_str("    };\n");
             vh.push_str("    let changeset = form.into_changeset();\n");
-            let _ = writeln!(
-                vh,
-                "    autumn_web::form::{helper}(&changeset, \"{field_name}\", \"{label}\", \"/{plural}/validate/{field_name}\")"
-            );
+            if let Some((f, input_type, attrs)) = constrained {
+                let url = format!("/{plural}/validate/{field_name}");
+                let markup =
+                    render_live_constrained_field(f, "changeset", input_type, &attrs, Some(&url));
+                let _ = writeln!(vh, "    autumn_web::html! {{\n        {markup}\n    }}");
+            } else {
+                // Match `render_changeset_form_inputs`'s helper choice: a
+                // non-nullable field keeps `required`/`aria-required` through the
+                // htmx round-trip too, otherwise the attribute would vanish from
+                // the DOM the moment the field's wrapper gets swapped in.
+                let helper = if field.is_some_and(|f| f.nullable) {
+                    "text_input_htmx"
+                } else {
+                    "required_text_input_htmx"
+                };
+                let _ = writeln!(
+                    vh,
+                    "    autumn_web::form::{helper}(&changeset, \"{field_name}\", \"{label}\", \"/{plural}/validate/{field_name}\")"
+                );
+            }
             vh.push_str("}\n");
         }
         vh
@@ -3010,20 +3046,47 @@ fn resolve_reference_display(
 /// the matching helper (`text_input`, `number_input`, `datetime_input`,
 /// `checkbox_input`, `select_input`); attachments stay a plain `<input
 /// type="file">` (a file input can't be repopulated).
+#[allow(clippy::too_many_lines)]
 fn render_changeset_form_inputs(
     fields: &[Field],
     changeset_var: &str,
     plural: &str,
     live_validation: bool,
     validated: &[&str],
+    reference_selects: &[&Field],
 ) -> String {
     use std::fmt::Write as _;
     let cv = changeset_var;
+    // The reference fields that render an in-form `<select>` (issue #1750): the
+    // present, non-missing `references` columns whose runtime option loader the
+    // handler threads into scope. A missing-target reference has no loader, so
+    // it keeps the derived per-field control instead.
+    let reference_select_names: BTreeSet<&str> =
+        reference_selects.iter().map(|f| f.name.as_str()).collect();
     let mut out = String::new();
     for f in fields {
         let name = &f.name;
         let label = humanize_label(name);
-        let line = if f.kind.is_attachment() {
+        // A DSL-constrained field (issue #1388) carries HTML5 attributes the
+        // shipped `autumn_web::form` helpers can't express; render it as raw
+        // markup instead so the live path matches the standard path (#1750).
+        let constraint = html5_constraint_spec(f);
+        let line = if f.kind.is_reference() && reference_select_names.contains(name.as_str()) {
+            // belongs_to parent dropdown (issue #1146), restored in the
+            // `--live-validation` per-field path (issue #1750).
+            render_live_reference_select(f, cv)
+        } else if let (true, Some((input_type, attrs))) = (
+            matches!(
+                f.kind,
+                FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64
+            ),
+            &constraint,
+        ) {
+            // A constrained numeric renders a raw number input carrying its
+            // `min`/`max` (and `step="any"` for floats). Numerics don't take the
+            // htmx inline-validation path, so no `validate_url`.
+            render_live_constrained_field(f, cv, input_type, attrs, None)
+        } else if f.kind.is_attachment() {
             // Attachment fields render a plain file input plus a hidden field
             // carrying the existing blob key (from the changeset), so an edit
             // that doesn't re-upload keeps the current attachment. A file input
@@ -3108,16 +3171,29 @@ fn render_changeset_form_inputs(
                     // that happens to permit an empty string (e.g. a max-only
                     // `length` rule) doesn't leave a blank required field with
                     // no client-side guard at all.
-                    //
-                    // Known limitation (#1750): the #1388 client-side HTML5
-                    // constraint attributes (`minlength`/`maxlength`,
-                    // `type="email"`/`url`) are only emitted on the standard
-                    // `form_for` path (`html5_constraint_spec`), not through
-                    // these cross-crate `autumn_web::form` htmx helpers, which
-                    // take no constraint params. Server-side `#[validate]` still
-                    // applies in `--live-validation`; only the static HTML5
-                    // hints are absent here.
-                    if live_validation && validated.contains(&name.as_str()) {
+                    let validated_htmx = live_validation && validated.contains(&name.as_str());
+                    if let Some((input_type, attrs)) = &constraint {
+                        // Issue #1750: a DSL-constrained `String`/`Text` field
+                        // carries the #1388 client-side HTML5 attributes
+                        // (`minlength`/`maxlength`, `type="email"`/`url`, and a
+                        // `<textarea>` for long-form `Text`) the shipped helpers
+                        // can't express. Render it as raw markup mirroring the
+                        // standard `form_for` path, threading the htmx
+                        // inline-validation wiring on when the field is validated
+                        // so real-time validation keeps working alongside the
+                        // static constraints. (A constrained field always has a
+                        // validator rule, so this is the validated path; the
+                        // `validate_url` is threaded only when `live_validation`.)
+                        let validate_url =
+                            validated_htmx.then(|| format!("/{plural}/validate/{name}"));
+                        render_live_constrained_field(
+                            f,
+                            cv,
+                            input_type,
+                            attrs,
+                            validate_url.as_deref(),
+                        )
+                    } else if validated_htmx {
                         let helper = if f.nullable {
                             "text_input_htmx"
                         } else {
@@ -3240,6 +3316,136 @@ fn html5_constraint_spec(field: &Field) -> Option<(&'static str, String)> {
         return None;
     }
     Some((input_type, attrs))
+}
+
+/// Render the raw maud markup for a DSL-constrained (issue #1388)
+/// `String`/`Text`/numeric field in the `--live-validation` per-field path
+/// (issue #1750).
+///
+/// The shipped `autumn_web::form::*` helpers take no HTML5-constraint params,
+/// so the live path renders the constrained control as raw markup instead —
+/// the same inline-error/ARIA skeleton those helpers emit, plus the
+/// `input_type` override and `constraint_attrs`
+/// (`minlength`/`maxlength`/`min`/`max`/`step`) from [`html5_constraint_spec`],
+/// exactly mirroring the standard `form_for` path's `.exclude()` + `.append()`
+/// output. When `validate_url` is `Some`, the htmx inline-validation wiring
+/// (`hx-post`/`hx-trigger`/`hx-target`/`hx-swap`/`hx-include` + the
+/// `data-autumn-field-wrapper` swap marker) is threaded on too, matching
+/// `required_text_input_htmx`. Shared by [`render_changeset_form_inputs`] and
+/// the inline-validate handlers so the initially-rendered field and the
+/// htmx-swapped fragment are byte-identical.
+fn render_live_constrained_field(
+    field: &Field,
+    changeset_var: &str,
+    input_type: &str,
+    constraint_attrs: &str,
+    validate_url: Option<&str>,
+) -> String {
+    let name = &field.name;
+    let label = humanize_label(name);
+    let cv = changeset_var;
+    let required_attr = if field.nullable {
+        ""
+    } else {
+        " required aria-required=\"true\""
+    };
+    // A constrained `Text` column is long-form (Postgres `TEXT`), so it renders
+    // a `<textarea>` (matching the derived `FieldControl::Textarea` and the
+    // standard path). A `text{email}`/`text{url}` field is inherently
+    // single-line (its `input_type` is `email`/`url`), so it takes the `<input>`
+    // branch — a textarea can't carry those types.
+    let is_textarea = matches!(field.kind, FieldKind::Text) && input_type == "text";
+    // htmx inline-validation wiring + the swap-target marker on the wrapper.
+    let (wrapper_marker, htmx_attrs) = validate_url.map_or_else(
+        || (String::new(), String::new()),
+        |url| {
+            (
+                format!(" data-autumn-field-wrapper=\"{name}\""),
+                format!(
+                    "\n                    hx-post=\"{url}\"\n                    \
+                     hx-trigger=\"change\"\n                    \
+                     hx-target=\"closest [data-autumn-field-wrapper]\"\n                    \
+                     hx-swap=\"outerHTML\"\n                    hx-include=\"closest form\""
+                ),
+            )
+        },
+    );
+    let errors_tail = format!(
+        "\n                @if !errors.is_empty() {{\n                    \
+         div id=\"{name}-error\" role=\"alert\" class=\"autumn-field__errors\" {{\n                        \
+         @for error in errors {{ p class=\"autumn-field__error\" {{ (error) }} }}\n                    \
+         }}\n                \
+         }}\n            \
+         }}"
+    );
+    if is_textarea {
+        format!(
+            "div id=\"{name}-field\" class=\"autumn-field\"{wrapper_marker} {{\n                \
+             @let errors = {cv}.errors_for(\"{name}\");\n                \
+             label for=\"{name}\" class=\"autumn-field__label\" {{ \"{label}\" }}\n                \
+             textarea id=\"{name}\" name=\"{name}\"{constraint_attrs}{required_attr}\n                    \
+             class=(if errors.is_empty() {{ \"autumn-field__input\" }} else {{ \"autumn-field__input autumn-field__input--invalid\" }})\n                    \
+             aria-invalid=(if errors.is_empty() {{ \"false\" }} else {{ \"true\" }})\n                    \
+             aria-describedby=(if errors.is_empty() {{ \"\" }} else {{ \"{name}-error\" }}){htmx_attrs} {{\n                        \
+             ({cv}.field_value(\"{name}\").unwrap_or_default())\n                    \
+             }}{errors_tail}"
+        )
+    } else {
+        format!(
+            "div id=\"{name}-field\" class=\"autumn-field\"{wrapper_marker} {{\n                \
+             @let errors = {cv}.errors_for(\"{name}\");\n                \
+             label for=\"{name}\" class=\"autumn-field__label\" {{ \"{label}\" }}\n                \
+             input type=\"{input_type}\" id=\"{name}\" name=\"{name}\"\n                    \
+             value=({cv}.field_value(\"{name}\").unwrap_or_default()){constraint_attrs}{required_attr}\n                    \
+             class=(if errors.is_empty() {{ \"autumn-field__input\" }} else {{ \"autumn-field__input autumn-field__input--invalid\" }})\n                    \
+             aria-invalid=(if errors.is_empty() {{ \"false\" }} else {{ \"true\" }})\n                    \
+             aria-describedby=(if errors.is_empty() {{ \"\" }} else {{ \"{name}-error\" }}){htmx_attrs};{errors_tail}"
+        )
+    }
+}
+
+/// Render the raw maud markup for a `belongs_to` parent `<select>` in the
+/// `--live-validation` per-field path (issue #1750). The standard path renders
+/// this through a `form_for` `FieldControl::Select` override, but the per-field
+/// path has no `form_for`, so it emits a raw `<select>` populated at request
+/// time from the `{name}_options` loader (a `Vec<(String, String)>` of
+/// id/display pairs) — a blank placeholder plus `selected` driven by the
+/// changeset value so a 422 re-render keeps the chosen parent. The
+/// `{name}_options` binding is loaded into scope by the calling handler.
+fn render_live_reference_select(field: &Field, changeset_var: &str) -> String {
+    let name = &field.name;
+    let label = humanize_label(name);
+    let cv = changeset_var;
+    let placeholder = if field.nullable {
+        "— Unset —"
+    } else {
+        "— Select —"
+    };
+    let required_attr = if field.nullable {
+        ""
+    } else {
+        " required aria-required=\"true\""
+    };
+    format!(
+        "div id=\"{name}-field\" class=\"autumn-field\" {{\n                \
+         @let errors = {cv}.errors_for(\"{name}\");\n                \
+         label for=\"{name}\" class=\"autumn-field__label\" {{ \"{label}\" }}\n                \
+         select id=\"{name}\" name=\"{name}\"{required_attr}\n                    \
+         class=(if errors.is_empty() {{ \"autumn-field__input\" }} else {{ \"autumn-field__input autumn-field__input--invalid\" }})\n                    \
+         aria-invalid=(if errors.is_empty() {{ \"false\" }} else {{ \"true\" }})\n                    \
+         aria-describedby=(if errors.is_empty() {{ \"\" }} else {{ \"{name}-error\" }}) {{\n                        \
+         option value=\"\" {{ \"{placeholder}\" }}\n                        \
+         @for (opt_value, opt_label) in {name}_options.iter() {{\n                            \
+         option value=(opt_value) selected[{cv}.field_value(\"{name}\").as_deref() == Some(opt_value.as_str())] {{ (opt_label) }}\n                        \
+         }}\n                    \
+         }}\n                \
+         @if !errors.is_empty() {{\n                    \
+         div id=\"{name}-error\" role=\"alert\" class=\"autumn-field__errors\" {{\n                        \
+         @for error in errors {{ p class=\"autumn-field__error\" {{ (error) }} }}\n                    \
+         }}\n                \
+         }}\n            \
+         }}"
+    )
 }
 
 /// Produce the cell-body expression for a `data_table` column closure.

--- a/autumn-cli/tests/integration/scaffold_belongs_to.rs
+++ b/autumn-cli/tests/integration/scaffold_belongs_to.rs
@@ -334,16 +334,70 @@ fn live_validation_keeps_parent_display_on_index_and_show() {
         routes.contains("async fn post_id_select_options"),
         "the option loader must be emitted (the index label map depends on it):\n{routes}"
     );
-    // The in-FORM belongs_to `<select>` is what's deferred in live-validation
-    // (#1750): the FK renders through the per-field text-input path, not a
-    // dropdown / `form_for` select override.
+    // Issue #1750: the in-FORM belongs_to `<select>` is now rendered in
+    // live-validation too — the FK no longer leaks out as a raw per-field text
+    // input. The per-field path emits a raw `<select>` (not a `form_for`
+    // `.override_field` override, which live-validation never uses) populated
+    // from the runtime option loader.
     assert!(
-        routes.contains("required_text_input(&changeset, \"post_id\", \"Post Id\")"),
-        "the FK form control is the per-field text input (select deferred):\n{routes}"
+        routes.contains("let post_id_options = post_id_select_options(&mut db).await?;"),
+        "live-validation must load the belongs_to select options in the form handler:\n{routes}"
+    );
+    assert!(
+        routes.contains("select id=\"post_id\" name=\"post_id\""),
+        "the FK form control must be a populated <select> in live-validation:\n{routes}"
+    );
+    assert!(
+        !routes.contains("required_text_input(&changeset, \"post_id\", \"Post Id\")"),
+        "the FK must no longer render as a per-field text input:\n{routes}"
     );
     assert!(
         !routes.contains(".override_field(\"post_id\""),
         "no `form_for` select override is emitted in live-validation:\n{routes}"
+    );
+}
+
+#[test]
+fn live_validation_renders_populated_belongs_to_select() {
+    // Issue #1750 (belongs_to half): the in-form parent `<select>` must render
+    // in `--live-validation` mode, populated from the same runtime option loader
+    // the standard path uses, with a blank placeholder and changeset-driven
+    // `selected` state so a 422 re-render keeps the chosen parent.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", "bt-live-select-app"]);
+    let project = tmp.path().join("bt-live-select-app");
+    run_autumn_ok(&project, &["generate", "model", "Post", "title:String"]);
+    run_autumn_ok(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Comment",
+            "body:Text",
+            "post:references",
+            "--live-validation",
+        ],
+    );
+    let routes = fs::read_to_string(project.join("src/routes/comments.rs")).unwrap();
+
+    // The new-form handler gains `db` and loads the options before rendering.
+    assert!(
+        routes.contains("let post_id_options = post_id_select_options(&mut db).await?;"),
+        "the options must be loaded in the form handler:\n{routes}"
+    );
+    // The `<select>` is populated from those options with changeset `selected`.
+    assert!(
+        routes.contains("select id=\"post_id\" name=\"post_id\""),
+        "a <select> must be rendered for the belongs_to parent:\n{routes}"
+    );
+    assert!(
+        routes.contains("@for (opt_value, opt_label) in post_id_options.iter()"),
+        "the <select> options must come from the runtime loader:\n{routes}"
+    );
+    assert!(
+        routes
+            .contains("changeset.field_value(\"post_id\").as_deref() == Some(opt_value.as_str())"),
+        "the selected option must be driven by the changeset value (422 re-render):\n{routes}"
     );
 }
 

--- a/autumn-cli/tests/integration/scaffold_validation.rs
+++ b/autumn-cli/tests/integration/scaffold_validation.rs
@@ -81,6 +81,54 @@ fn model_carries_validate_attributes_from_dsl_constraints() {
     );
 }
 
+/// Issue #1748: a required numeric with a `{min,max}` range that spans the
+/// type's zero default (`age:i32{min=0,max=130}`) must NOT keep its native
+/// `i32` on the form struct — a native field defaults to `0`, which pre-fills
+/// the input and passes both `required` (the HTML attribute) and the
+/// `range(0,130)` rule, so a blank submission silently becomes `0`. The fix
+/// represents it as `Option<i32>` with `#[validate(required, range(...))]`:
+/// the default is `None` (renders blank, forces deliberate input), `range`
+/// validates the inner value only when `Some`, and `required` rejects `None`
+/// server-side. The `into_new` path must unwrap the `Option`, never coerce a
+/// missing value to `0`.
+#[test]
+fn constrained_required_numeric_spanning_zero_is_optional_not_native() {
+    let (_tmp, project) = constrained_project("validate-optnum-app");
+    let routes = fs::read_to_string(project.join("src/routes/posts.rs")).unwrap();
+
+    // The form-struct field is `Option<i32>` (blank -> None), carrying both the
+    // `required` and `range` validators.
+    assert!(
+        routes.contains(
+            "    #[validate(required)]\n    #[validate(range(min = 0, max = 130))]\n    pub age: Option<i32>,"
+        ),
+        "constrained required `age` must be `Option<i32>` with #[validate(required, range(...))]:\n{routes}"
+    );
+
+    // The native-typed representation (which pre-fills `0`) must be gone.
+    assert!(
+        !routes.contains("pub age: i32,"),
+        "constrained required `age` must not keep its native `i32` type:\n{routes}"
+    );
+
+    // `into_new` must unwrap the Option and reject a missing value, never
+    // silently coerce a blank submission to `0` via a native clone.
+    assert!(
+        routes.contains("age: form.age.ok_or_else("),
+        "into_new must unwrap the Option and error on a missing value:\n{routes}"
+    );
+    assert!(
+        !routes.contains("age: form.age.clone(),") && !routes.contains("age: form.age,"),
+        "into_new must not pass the native field straight through:\n{routes}"
+    );
+
+    // The edit-form seed maps a persisted row's native value back into `Some`.
+    assert!(
+        routes.contains("age: Some(row.age),"),
+        "from_row must wrap the persisted native value in Some:\n{routes}"
+    );
+}
+
 #[test]
 fn cargo_toml_pulls_in_validator_dependency() {
     let (_tmp, project) = constrained_project("validate-cargo-app");

--- a/autumn-cli/tests/integration/scaffold_validation.rs
+++ b/autumn-cli/tests/integration/scaffold_validation.rs
@@ -372,6 +372,101 @@ fn slice_textarea_attrs<'a>(routes: &'a str, marker: &str) -> &'a str {
     &rest[..end]
 }
 
+/// Issue #1750: a `--live-validation` scaffold renders its form through the
+/// per-field path (not `form_for`), which historically dropped the #1388
+/// client-side HTML5 constraint attributes. The live path must now carry the
+/// SAME attributes the standard path emits — `minlength`/`maxlength`,
+/// `type="email"`/`type="url"`, numeric `min`/`max`, and a `<textarea>` for
+/// constrained `Text` — threaded through the htmx inline-validation wiring, and
+/// the inline-validate handler fragment must carry them too so the swapped-in
+/// field doesn't shed its client-side guards on the first `change`.
+#[test]
+fn live_validation_forms_carry_html5_constraints() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", "live-validate-html5-app"]);
+    let project = tmp.path().join("live-validate-html5-app");
+    run_autumn_ok(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Post",
+            "title:String{min=3,max=120}",
+            "contact:String{email}",
+            "homepage:String{url}",
+            "age:i32{min=0,max=130}",
+            "notes:Text{min=10,max=500}",
+            "bio:Option<String>{max=200}",
+            "--live-validation",
+        ],
+    );
+    let routes = fs::read_to_string(project.join("src/routes/posts.rs")).unwrap();
+
+    // The string length constraint on the htmx-validated `title` input.
+    assert!(
+        routes.contains("minlength=\"3\" maxlength=\"120\""),
+        "title must render minlength/maxlength in live-validation mode:\n{routes}"
+    );
+    // Typed inputs (email/url) instead of a bare text input.
+    assert!(
+        routes.contains("type=\"email\" id=\"contact\""),
+        "contact must render type=email in live-validation mode:\n{routes}"
+    );
+    assert!(
+        routes.contains("type=\"url\" id=\"homepage\""),
+        "homepage must render type=url in live-validation mode:\n{routes}"
+    );
+    // Numeric min/max on the number input.
+    assert!(
+        routes.contains("type=\"number\"") && routes.contains("min=\"0\" max=\"130\""),
+        "age must render type=number with min/max in live-validation mode:\n{routes}"
+    );
+    // A constrained `Text` column becomes a <textarea> carrying its length rule.
+    assert!(
+        routes.contains("textarea id=\"notes\" name=\"notes\"")
+            && routes.contains("maxlength=\"500\""),
+        "constrained Text `notes` must render a <textarea> with maxlength:\n{routes}"
+    );
+    // The nullable `bio` keeps its maxlength.
+    assert!(
+        routes.contains("maxlength=\"200\""),
+        "bio must render maxlength in live-validation mode:\n{routes}"
+    );
+
+    // The htmx inline-validation wiring survives on a constrained validated
+    // input (real-time validation still works alongside the static constraints),
+    // and its swap wrapper marker is present.
+    assert!(
+        routes.contains("hx-post=\"/posts/validate/title\"")
+            && routes.contains("data-autumn-field-wrapper=\"title\""),
+        "the constrained title input must keep its htmx inline-validation wiring:\n{routes}"
+    );
+
+    // The inline-validate handler returns the SAME constrained fragment, so the
+    // swapped-in field doesn't drop the client-side attributes on first change.
+    let validate_title = slice_fn(&routes, "pub async fn validate_title(");
+    assert!(
+        validate_title.contains("minlength=\"3\" maxlength=\"120\""),
+        "the validate_title fragment must also carry the HTML5 constraints:\n{validate_title}"
+    );
+    assert!(
+        !validate_title.contains("type=\"email\""),
+        "sanity: the validate_title slice must be bounded to its own handler:\n{validate_title}"
+    );
+}
+
+/// Slice a generated handler body from its `fn` marker to the next handler's
+/// `#[post(` attribute (or end of file), so an assertion scoped to one
+/// inline-validate handler can't accidentally match a sibling's fragment.
+fn slice_fn<'a>(routes: &'a str, marker: &str) -> &'a str {
+    let start = routes
+        .find(marker)
+        .unwrap_or_else(|| panic!("missing {marker} in:\n{routes}"));
+    let rest = &routes[start..];
+    let end = rest[1..].find("#[post(").map_or(rest.len(), |rel| rel + 1);
+    &rest[..end]
+}
+
 #[test]
 fn unknown_constraint_modifier_fails_the_scaffold() {
     // AC5: a misspelled modifier fails loudly, naming the offending token,

--- a/autumn-cli/tests/integration/scaffold_validation.rs
+++ b/autumn-cli/tests/integration/scaffold_validation.rs
@@ -129,6 +129,47 @@ fn constrained_required_numeric_spanning_zero_is_optional_not_native() {
     );
 }
 
+/// Issue #1748 (Codex follow-up): the synthetic constrained-required-`Option<T>`
+/// numeric (`age:i32{min=0,max=130}`) must be dropped from the request body when
+/// its `field=` pair is present-but-empty, exactly like a genuinely nullable
+/// field. The decoder strips empty pairs only for fields matching
+/// `is_nullable_form_field`; that field is `Option<i32>` but has
+/// `nullable == false`, so without including it a blank `age=` (from curl, a
+/// non-browser client, or disabled JS) reaches `serde_urlencoded`, which parses
+/// `""` into the inner numeric and returns a **400** *before*
+/// `#[validate(required)]` can render the intended **422** inline error.
+/// Dropping the empty pair makes `age` decode as `None`, so `required` fires and
+/// produces the 422 (the #1748 intent). Asserts the generated
+/// `is_nullable_form_field` set includes `age` alongside the nullable `bio`.
+#[test]
+fn constrained_required_numeric_empty_pair_is_dropped_like_nullable() {
+    let (_tmp, project) = constrained_project("validate-blankdrop-app");
+    let routes = fs::read_to_string(project.join("src/routes/posts.rs")).unwrap();
+
+    // The decoder gates its empty-pair drop on `is_nullable_form_field`.
+    assert!(
+        routes.contains("!(value.is_empty() && is_nullable_form_field(key))"),
+        "decoder must drop empty pairs for the nullable/drop set:\n{routes}"
+    );
+
+    // The synthetic `Option<i32>` `age` must be part of that drop set so a blank
+    // `age=` decodes as `None` (-> 422 via `required`) rather than being parsed
+    // as `""` by serde_urlencoded (-> 400). It appears alongside nullable `bio`.
+    let helper = routes
+        .split_once("fn is_nullable_form_field(name: &str) -> bool {")
+        .and_then(|(_, rest)| rest.split_once('}'))
+        .map(|(body, _)| body)
+        .expect("generated routes must define is_nullable_form_field");
+    assert!(
+        helper.contains("\"age\""),
+        "constrained required `age` must be in the empty-pair drop set (is_nullable_form_field):\n{helper}"
+    );
+    assert!(
+        helper.contains("\"bio\""),
+        "nullable `bio` must remain in the empty-pair drop set:\n{helper}"
+    );
+}
+
 #[test]
 fn cargo_toml_pulls_in_validator_dependency() {
     let (_tmp, project) = constrained_project("validate-cargo-app");


### PR DESCRIPTION
## Summary

Two deferrals from the merged scaffold batch-2 PR #1734.

## #1748 — constrained required numerics no longer silently become 0

- **Before:** scaffolding a required numeric with a range that spans the type's zero default (e.g. `age:i32{min=0,max=130}`) let a user submit the form blank — the field pre-filled `0`, which passed both HTML `required` and `#[validate(range)]`, silently persisting 0.
- **After:** such fields scaffold as `pub age: Option<i32>` with `#[validate(required, range(...))]`, so a blank submission fails validation instead of becoming 0. The `into_new` path unwraps with a `bad_request` error and `from_row` wraps the persisted value in `Some(...)`.
- **How:** new `is_constrained_required_numeric` branch in `render_model_form` (autumn-cli `scaffold.rs`); emits the `Option<T>` form field + `#[validate(required)]` alongside the existing range rule. `dsl.rs` `validation_attrs` intentionally unchanged (would wrongly land `required` on the native model field).

## #1750 — HTML5 constraints + belongs_to select now render under --live-validation

- **Before:** forms generated with `--live-validation` dropped the DSL HTML5 constraint attributes (`minlength`/`maxlength`/`type="email"`/`type="url"`/`min`/`max`/`step`) that the plain scaffold path emits, and rendered belongs_to parent fields with no populated `<select>` dropdown.
- **After:** `--live-validation` forms carry the same HTML5 constraint attributes (including inside the htmx inline-validate swap fragments) and render a populated belongs_to `<select>`.
- **How:** threaded the constraint spec + belongs_to option-loading and `<select>` rendering into `render_changeset_form_inputs` (autumn-cli `scaffold.rs`) via generator-side maud markup helpers; no change to the public `autumn-web` form API (avoids a semver-relevant signature change).

## Testing

- New consolidated tests in `autumn-cli/tests/integration/scaffold_validation.rs` and `scaffold_belongs_to.rs` (TDD: each fails without the fix, passes with it).
- `cargo fmt --all -- --check`, `cargo clippy -p autumn-cli --all-targets -D warnings`, `cargo clippy -p autumn-web --all-targets -D warnings`, and `cargo test -p autumn-cli --test cli_tests scaffold` (53 passed, 4 ignored) all green after rebase onto trunk.
- The `#[ignore]` generated-app e2e gates (`constrained_scaffold_cargo_checks`, `belongs_to_scaffold_cargo_checks`, Scaffold Postgres e2e) are the CI authority and validate the generated app compiles/serves.

Closes #1748
Closes #1750

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeeMnoMWH1AJXaXruTdAMF)_