### PR TITLE
feat(jobs): backend-derived actuator queue gauges (#1752) + sound topology-aware doctor --strict coverage (#1756)

### DIFF
--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -6,7 +6,7 @@
 
 use autumn_web::config::ProcessRole;
 use serde::Serialize;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 // ── Signing secret validation constants (mirrored from autumn-web) ────────────
 
@@ -2075,6 +2075,123 @@ fn check_queue_coverage(
     }
 }
 
+/// A declared fleet topology (#1756): the `jobs.pin` of every worker tier in the
+/// deployment. Each inner `Vec` is one tier's pin; an **empty** inner `Vec` is an
+/// *unpinned* tier that drains every queue. Declared by the operator under
+/// `[jobs.fleet] tiers = [["critical"], ["bulk", "default"]]`.
+///
+/// This is the input that makes a `--strict` hard-fail SOUND: with every tier's
+/// pin known, doctor reasons about **topology-wide** (union) coverage instead of
+/// a single process, so a valid multi-tier subset split is no longer mistaken for
+/// a gap. Absent this declaration the coverage check stays informational-only.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct FleetTopology {
+    tiers: Vec<Vec<String>>,
+}
+
+impl FleetTopology {
+    /// At least one declared tier runs job workers. A topology with no tiers
+    /// declares nothing coverable, so it cannot prove a gap.
+    const fn runs_any_worker(&self) -> bool {
+        !self.tiers.is_empty()
+    }
+
+    /// `true` when any tier is unpinned (empty pin) — such a tier drains every
+    /// queue, so union coverage is total.
+    fn has_unpinned_tier(&self) -> bool {
+        self.tiers.iter().any(Vec::is_empty)
+    }
+
+    /// The union of all pinned queue names across every tier.
+    fn pinned_union(&self) -> BTreeSet<String> {
+        self.tiers.iter().flatten().cloned().collect()
+    }
+}
+
+/// Topology-aware queue-coverage check (#1756). Restores a **sound** `--strict`
+/// hard-fail on top of the informational-only per-process report.
+///
+/// When the operator declares the fleet topology (`[jobs.fleet] tiers`) — and,
+/// via a jobs manifest or inline list, the compiled `#[job(queue = "…")]` set —
+/// doctor can PROVE a genuine zero-coverage gap: it computes the queues that must
+/// be drained (configured `[jobs.queues]` ∪ job-declared) and the queues covered
+/// by the union of all tier pins, then FAILS only if some needed queue is drained
+/// by no tier anywhere. This has zero false positives on valid deployments:
+///
+/// * a valid multi-tier subset split (one tier `critical`, another
+///   `bulk,default`) has full union coverage → Pass;
+/// * a queue named in a pin but absent from `[jobs.queues]` (a job-declared
+///   queue) is in the needed set only when the manifest surfaces it, and is
+///   covered by the pinning tier either way → never a false fail.
+///
+/// **Regression guard:** when no fleet topology is declared (`fleet == None`)
+/// this delegates verbatim to the informational-only [`check_queue_coverage`],
+/// so absent the topology input the check behaves exactly as it does today.
+fn check_queue_coverage_topology(
+    role: ProcessRole,
+    configured_queues: &[String],
+    pin: &[String],
+    declared_queues: &[String],
+    fleet: Option<&FleetTopology>,
+) -> CheckResult {
+    // No topology declared → informational-only, exactly as today. The hard-fail
+    // only activates once the operator supplies the topology that makes coverage
+    // provable, so existing deployments never regress.
+    let Some(fleet) = fleet.filter(|f| f.runs_any_worker()) else {
+        return check_queue_coverage(role, configured_queues, pin);
+    };
+
+    // Needed = configured `[jobs.queues]` ∪ job-declared queues. Declared queues
+    // only ADD to the needed set, so a missing/partial manifest can only shrink
+    // it — never manufacture a gap (keeps the check zero-false-positive).
+    let needed: BTreeSet<String> = configured_queues
+        .iter()
+        .chain(declared_queues.iter())
+        .cloned()
+        .collect();
+
+    // Covered = union of every tier's pin. An unpinned tier drains everything, so
+    // union coverage is total.
+    let gap: Vec<String> = if fleet.has_unpinned_tier() {
+        Vec::new()
+    } else {
+        let covered = fleet.pinned_union();
+        needed
+            .iter()
+            .filter(|q| !covered.contains(*q))
+            .cloned()
+            .collect()
+    };
+
+    let tier_count = fleet.tiers.len();
+    if gap.is_empty() {
+        CheckResult {
+            name: "jobs_queue_coverage",
+            status: CheckStatus::Pass,
+            detail: Some(format!(
+                "declared fleet topology ({tier_count} tier(s)) drains every needed queue {:?} \
+                 (configured + #[job(queue)]-declared); coverage is provable topology-wide",
+                needed.iter().collect::<Vec<_>>()
+            )),
+            hint: None,
+        }
+    } else {
+        CheckResult {
+            name: "jobs_queue_coverage",
+            status: CheckStatus::Fail,
+            detail: Some(format!(
+                "declared fleet topology ({tier_count} tier(s)) leaves queue(s) {} drained by no \
+                 worker tier; jobs enqueued to them will accumulate forever",
+                gap.join(", ")
+            )),
+            hint: Some(
+                "Add the uncovered queue(s) to a tier's jobs.pin in [jobs.fleet].tiers, or run an \
+                 unpinned tier that drains everything",
+            ),
+        }
+    }
+}
+
 fn check_replica_migration_versions(
     primary_latest: Option<&str>,
     replica_latest: Option<&str>,
@@ -2983,6 +3100,101 @@ where
     (queues, pin)
 }
 
+/// Resolve the declared fleet topology (#1756) from `[jobs.fleet] tiers`. Each
+/// entry is one worker tier's pin (a TOML array of queue names); an empty array
+/// is an unpinned tier that drains every queue. Returns `None` when the section
+/// is absent or declares no tiers, keeping the coverage check informational-only.
+///
+/// Chosen as a config section (rather than a repeatable CLI flag) because doctor
+/// already resolves `jobs.queues` / `jobs.pin` from the merged active-profile
+/// table, so the topology lives beside them, is profile-aware, and is checked
+/// into the repo as one source of truth for the fleet.
+fn resolve_fleet_topology(table: Option<&toml::Table>) -> Option<FleetTopology> {
+    let fleet = table
+        .and_then(|t| t.get("jobs"))
+        .and_then(toml::Value::as_table)
+        .and_then(|j| j.get("fleet"))
+        .and_then(toml::Value::as_table)?;
+    let tiers: Vec<Vec<String>> = fleet
+        .get("tiers")
+        .and_then(toml::Value::as_array)?
+        .iter()
+        .filter_map(toml::Value::as_array)
+        .map(|tier| {
+            tier.iter()
+                .filter_map(toml::Value::as_str)
+                .map(str::to_owned)
+                .collect::<Vec<String>>()
+        })
+        .collect();
+    if tiers.is_empty() {
+        return None;
+    }
+    Some(FleetTopology { tiers })
+}
+
+/// Resolve the compiled `#[job(queue = "…")]`-declared queue set for the
+/// coverage check (#1756), so doctor's view of "queues that must be drained"
+/// matches what the runtime actually drains. Two sources, in precedence order:
+///
+/// 1. `[jobs.fleet] manifest = "path"` — a jobs manifest the app emits (reusing
+///    `effective_drained_queues` on the runtime side), a TOML file with a
+///    `queues = [...]` array. This is the ground-truth set the runtime drains.
+/// 2. `[jobs.fleet] declared_queues = ["…"]` — an inline list the operator
+///    maintains by hand (the MVP path when no manifest is emitted).
+///
+/// Returns an empty `Vec` when neither is present; an unknown declared set only
+/// shrinks the needed set, so it can never cause a false failure.
+fn resolve_declared_queues(table: Option<&toml::Table>) -> Vec<String> {
+    resolve_declared_queues_from_sources(|p| std::fs::read_to_string(p).ok(), table)
+}
+
+fn resolve_declared_queues_from_sources<F>(read_file: F, table: Option<&toml::Table>) -> Vec<String>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let Some(fleet) = table
+        .and_then(|t| t.get("jobs"))
+        .and_then(toml::Value::as_table)
+        .and_then(|j| j.get("fleet"))
+        .and_then(toml::Value::as_table)
+    else {
+        return Vec::new();
+    };
+
+    // 1. A jobs manifest the app emits: TOML `queues = [...]`.
+    if let Some(path) = fleet.get("manifest").and_then(toml::Value::as_str)
+        && let Some(contents) = read_file(path)
+        && let Ok(manifest) = toml::from_str::<toml::Table>(&contents)
+    {
+        let queues: Vec<String> = manifest
+            .get("queues")
+            .and_then(toml::Value::as_array)
+            .map(|a| {
+                a.iter()
+                    .filter_map(toml::Value::as_str)
+                    .map(str::to_owned)
+                    .collect()
+            })
+            .unwrap_or_default();
+        if !queues.is_empty() {
+            return queues;
+        }
+    }
+
+    // 2. Inline declared-queues list (MVP).
+    fleet
+        .get("declared_queues")
+        .and_then(toml::Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(toml::Value::as_str)
+                .map(str::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn first_env<F>(env_var: &F, keys: &[&str]) -> Option<String>
 where
     F: Fn(&str) -> Option<String>,
@@ -3870,8 +4082,22 @@ pub fn run(opts: DoctorOptions) {
     // mirrors the runtime exactly (`AUTUMN_ROLE` env > merged-table `role` >
     // `Combined`), reusing the shared resolver on the merged table.
     let (queue_coverage_role, _) = resolve_process_role_and_backend(Some(&merged_jobs_toml));
+    // Topology/registry inputs (#1756) that let the coverage check restore a
+    // SOUND `--strict` hard-fail: the declared fleet topology (all worker tiers'
+    // pins) and the compiled `#[job(queue)]` set (from a jobs manifest or an
+    // inline list). Absent both, `check_queue_coverage_topology` delegates to the
+    // informational-only per-process report, so existing deployments never
+    // regress.
+    let fleet_topology = resolve_fleet_topology(Some(&merged_jobs_toml));
+    let declared_queues = resolve_declared_queues(Some(&merged_jobs_toml));
     tasks.push(Box::new(move || {
-        check_queue_coverage(queue_coverage_role, &configured_queues, &jobs_pin)
+        check_queue_coverage_topology(
+            queue_coverage_role,
+            &configured_queues,
+            &jobs_pin,
+            &declared_queues,
+            fleet_topology.as_ref(),
+        )
     }));
 
     if let Some(url) = db_topology.primary_url.clone() {
@@ -8088,6 +8314,288 @@ foo = "bar"
             failed: 0,
         };
         assert_eq!(exit_code(&summary, true), 0);
+    }
+
+    // ── #1756: sound, topology/registry-aware `--strict` hard-fail ──────────────
+
+    #[test]
+    fn topology_absent_delegates_to_informational_pass() {
+        // Regression guard: with NO fleet topology declared the topology-aware
+        // check must behave exactly like the informational-only per-process
+        // report — a subset pin Passes and never fails `--strict`.
+        let queues = vec!["critical".to_string(), "bulk".to_string()];
+        let pin = vec!["critical".to_string()];
+        let result = check_queue_coverage_topology(
+            ProcessRole::Combined,
+            &queues,
+            &pin,
+            &[],  // no declared queues
+            None, // no fleet topology → informational fallback
+        );
+        assert_eq!(result.status, CheckStatus::Pass);
+        // Same detail the informational-only path produces (names the unclaimed).
+        assert!(result.detail.unwrap().contains("bulk"));
+        let summary = Summary {
+            passed: 1,
+            warned: 0,
+            failed: 0,
+        };
+        assert_eq!(exit_code(&summary, true), 0);
+    }
+
+    #[test]
+    fn topology_with_full_union_coverage_passes() {
+        // The union of all declared tiers covers every needed queue → Pass.
+        let queues = vec![
+            "critical".to_string(),
+            "bulk".to_string(),
+            "default".to_string(),
+        ];
+        let fleet = FleetTopology {
+            tiers: vec![
+                vec!["critical".to_string()],
+                vec!["bulk".to_string(), "default".to_string()],
+            ],
+        };
+        let result = check_queue_coverage_topology(
+            ProcessRole::Combined,
+            &queues,
+            &["critical".to_string()],
+            &[],
+            Some(&fleet),
+        );
+        assert_eq!(result.status, CheckStatus::Pass, "{:?}", result.detail);
+        let summary = Summary {
+            passed: 1,
+            warned: 0,
+            failed: 0,
+        };
+        assert_eq!(exit_code(&summary, true), 0);
+    }
+
+    #[test]
+    fn topology_valid_multi_tier_subset_split_does_not_fail() {
+        // The #1746 false-positive case: two tiers split the queues between them.
+        // A single process sees only its own pin (`critical`), which looks like a
+        // gap — but with the fleet topology declared the union covers everything,
+        // so `--strict` must NOT fail.
+        let queues = vec![
+            "critical".to_string(),
+            "bulk".to_string(),
+            "default".to_string(),
+        ];
+        let fleet = FleetTopology {
+            tiers: vec![
+                vec!["critical".to_string()],
+                vec!["bulk".to_string(), "default".to_string()],
+            ],
+        };
+        // Run doctor as the critical tier (pin = critical): still Pass.
+        let result = check_queue_coverage_topology(
+            ProcessRole::Worker,
+            &queues,
+            &["critical".to_string()],
+            &[],
+            Some(&fleet),
+        );
+        assert_ne!(
+            result.status,
+            CheckStatus::Fail,
+            "a valid multi-tier subset split must not fail: {:?}",
+            result.detail
+        );
+        assert_eq!(result.status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn topology_with_genuine_gap_fails_strict() {
+        // A configured queue drained by NO declared tier is a provable gap → Fail,
+        // which `--strict` promotes to exit 1.
+        let queues = vec![
+            "critical".to_string(),
+            "bulk".to_string(),
+            "default".to_string(),
+        ];
+        let fleet = FleetTopology {
+            // No tier drains `bulk`.
+            tiers: vec![vec!["critical".to_string()], vec!["default".to_string()]],
+        };
+        let result = check_queue_coverage_topology(
+            ProcessRole::Worker,
+            &queues,
+            &["critical".to_string()],
+            &[],
+            Some(&fleet),
+        );
+        assert_eq!(result.status, CheckStatus::Fail, "{:?}", result.detail);
+        assert!(
+            result.detail.unwrap().contains("bulk"),
+            "the failure must name the uncovered queue"
+        );
+        assert!(result.hint.is_some());
+        let summary = Summary {
+            passed: 0,
+            warned: 0,
+            failed: 1,
+        };
+        assert_eq!(exit_code(&summary, true), 1);
+    }
+
+    #[test]
+    fn topology_unpinned_tier_covers_everything() {
+        // An unpinned tier (empty pin) drains every queue, so union coverage is
+        // total even when other tiers are narrow subsets → Pass.
+        let queues = vec!["critical".to_string(), "bulk".to_string()];
+        let fleet = FleetTopology {
+            tiers: vec![
+                vec!["critical".to_string()],
+                Vec::new(), // unpinned tier: drains everything
+            ],
+        };
+        let result = check_queue_coverage_topology(
+            ProcessRole::Worker,
+            &queues,
+            &["critical".to_string()],
+            &[],
+            Some(&fleet),
+        );
+        assert_eq!(result.status, CheckStatus::Pass, "{:?}", result.detail);
+    }
+
+    #[test]
+    fn topology_job_declared_queue_pinned_but_absent_from_config_passes() {
+        // The #1756 blindspot RESOLVED, not failed: a queue named in a tier's pin
+        // that is a `#[job(queue = "email")]`-declared queue (absent from
+        // [jobs.queues]) must Pass. With the declared set surfaced, `email` is in
+        // the needed set AND covered by the pinning tier → no gap; even without
+        // the declared set it is simply not needed → no gap.
+        let queues = vec!["default".to_string()];
+        let declared = vec!["email".to_string()];
+        let fleet = FleetTopology {
+            tiers: vec![vec!["default".to_string(), "email".to_string()]],
+        };
+        let result = check_queue_coverage_topology(
+            ProcessRole::Worker,
+            &queues,
+            &["default".to_string(), "email".to_string()],
+            &declared,
+            Some(&fleet),
+        );
+        assert_eq!(result.status, CheckStatus::Pass, "{:?}", result.detail);
+
+        // And with the declared set UNKNOWN (empty), still Pass — the job-declared
+        // pin never manufactures a gap.
+        let result_no_manifest = check_queue_coverage_topology(
+            ProcessRole::Worker,
+            &queues,
+            &["default".to_string(), "email".to_string()],
+            &[],
+            Some(&fleet),
+        );
+        assert_eq!(
+            result_no_manifest.status,
+            CheckStatus::Pass,
+            "{:?}",
+            result_no_manifest.detail
+        );
+    }
+
+    #[test]
+    fn topology_declared_gap_on_job_declared_queue_fails() {
+        // Once the declared set is known, a job-declared queue that NO tier drains
+        // is a provable gap the runtime would strand → Fail. This is the blindspot
+        // being *resolved* (surfaced as a real gap), not a false positive.
+        let queues = vec!["default".to_string()];
+        let declared = vec!["email".to_string()];
+        let fleet = FleetTopology {
+            // No tier pins `email`.
+            tiers: vec![vec!["default".to_string()]],
+        };
+        let result = check_queue_coverage_topology(
+            ProcessRole::Worker,
+            &queues,
+            &["default".to_string()],
+            &declared,
+            Some(&fleet),
+        );
+        assert_eq!(result.status, CheckStatus::Fail, "{:?}", result.detail);
+        assert!(result.detail.unwrap().contains("email"));
+    }
+
+    #[test]
+    fn topology_empty_tiers_stays_informational() {
+        // A `[jobs.fleet]` with no tiers declares nothing coverable, so it must
+        // not fail — it falls back to informational Pass.
+        let queues = vec!["critical".to_string(), "bulk".to_string()];
+        let fleet = FleetTopology { tiers: Vec::new() };
+        let result = check_queue_coverage_topology(
+            ProcessRole::Worker,
+            &queues,
+            &["critical".to_string()],
+            &[],
+            Some(&fleet),
+        );
+        assert_eq!(result.status, CheckStatus::Pass, "{:?}", result.detail);
+    }
+
+    #[test]
+    fn resolve_fleet_topology_reads_tiers_array() {
+        let table: toml::Table =
+            toml::from_str("[jobs.fleet]\ntiers = [[\"critical\"], [\"bulk\", \"default\"], []]\n")
+                .expect("parse toml");
+        let fleet = resolve_fleet_topology(Some(&table)).expect("topology declared");
+        assert_eq!(
+            fleet.tiers,
+            vec![
+                vec!["critical".to_string()],
+                vec!["bulk".to_string(), "default".to_string()],
+                Vec::<String>::new(),
+            ]
+        );
+        assert!(fleet.has_unpinned_tier());
+    }
+
+    #[test]
+    fn resolve_fleet_topology_absent_is_none() {
+        let table: toml::Table =
+            toml::from_str("[jobs]\nqueues = [\"critical\"]\n").expect("parse toml");
+        assert!(resolve_fleet_topology(Some(&table)).is_none());
+        // Present but empty tiers → still None (nothing declared).
+        let empty: toml::Table = toml::from_str("[jobs.fleet]\ntiers = []\n").expect("parse toml");
+        assert!(resolve_fleet_topology(Some(&empty)).is_none());
+    }
+
+    #[test]
+    fn resolve_declared_queues_reads_inline_list_and_manifest() {
+        // Inline list (MVP).
+        let inline: toml::Table = toml::from_str(
+            "[jobs.fleet]\ntiers = [[\"default\"]]\ndeclared_queues = [\"email\", \"sms\"]\n",
+        )
+        .expect("parse toml");
+        let declared = resolve_declared_queues_from_sources(|_| None, Some(&inline));
+        assert_eq!(declared, vec!["email".to_string(), "sms".to_string()]);
+
+        // Emitted manifest takes precedence over the inline list.
+        let with_manifest: toml::Table = toml::from_str(
+            "[jobs.fleet]\nmanifest = \"target/jobs-manifest.toml\"\ndeclared_queues = [\"stale\"]\n",
+        )
+        .expect("parse toml");
+        let declared_from_manifest = resolve_declared_queues_from_sources(
+            |path| {
+                (path == "target/jobs-manifest.toml")
+                    .then(|| "queues = [\"critical\", \"email\"]\n".to_string())
+            },
+            Some(&with_manifest),
+        );
+        assert_eq!(
+            declared_from_manifest,
+            vec!["critical".to_string(), "email".to_string()]
+        );
+
+        // No `[jobs.fleet]` → empty.
+        let none: toml::Table =
+            toml::from_str("[jobs]\nqueues = [\"critical\"]\n").expect("parse toml");
+        assert!(resolve_declared_queues_from_sources(|_| None, Some(&none)).is_empty());
     }
 
     #[test]

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -738,14 +738,17 @@ impl JobStatus {
 }
 
 /// Per-queue observability gauges for the actuator jobs endpoint (issue #1623,
-/// AC7): approximate queue depth and the age of the oldest still-waiting job.
+/// AC7): queue depth and the age of the oldest still-waiting job.
 ///
-/// Like the per-job [`JobStatus`] gauges, these reflect enqueue/start events
-/// observed **in this process**; on the durable backends a queue also drained
-/// by other replicas reads as this replica's share of the traffic.
+/// On the **local** backend (single process, single registry) these reflect
+/// enqueue/start events observed in this process via the `record_*` marks.
+/// On the **durable** backends (Postgres/Redis) they are backend-derived and
+/// authoritative (issue #1752): a periodic survey of the durable store
+/// wholesale-replaces this snapshot each tick, so an enqueue-only web replica
+/// reports the true shared backlog rather than its own local enqueue marks.
 #[derive(Debug, Clone, Serialize)]
 pub struct QueueStatus {
-    /// Approximate jobs waiting to run on this queue.
+    /// Jobs waiting to run on this queue.
     pub depth: u64,
     /// Age in milliseconds of the oldest still-waiting job on this queue
     /// (`0` when the queue is empty).
@@ -761,7 +764,18 @@ struct QueueGaugeState {
     /// A mark whose ready-at is in the future belongs to a scheduled (delayed)
     /// job that is not yet claimable, so it is excluded from ready depth/age
     /// until its ready-at time passes.
+    ///
+    /// Only authoritative on the local backend. On the durable backends this
+    /// still records marks (harmless) but [`Self::surveyed`] overrides them.
     waiting: HashMap<String, std::collections::VecDeque<u64>>,
+    /// Backend-derived per-queue gauges from the durable survey (issue #1752).
+    /// When `Some`, this authoritative snapshot — refreshed each survey tick
+    /// from the durable store — backs [`JobRegistry::queue_snapshot`] instead
+    /// of the per-process `waiting` marks. `None` on the local backend, which
+    /// keeps the in-memory mark path. Each value is `(ready depth, oldest
+    /// ready-at epoch ms)`; the reported age is derived from the timestamp at
+    /// snapshot time so it stays fresh between surveys.
+    surveyed: Option<HashMap<String, (u64, Option<u64>)>>,
 }
 
 fn now_epoch_ms() -> u64 {
@@ -816,12 +830,45 @@ impl JobRegistry {
     }
 
     /// Snapshot per-queue depth and oldest-waiting-job age.
+    ///
+    /// On the durable backends a periodic survey has populated an authoritative
+    /// snapshot (via [`Self::set_queue_depth_gauges`]); it takes precedence over
+    /// the per-process `waiting` marks so an enqueue-only replica reports the
+    /// true shared backlog. On the local backend the survey is absent and the
+    /// in-memory marks drive the gauges.
     #[must_use]
     pub fn queue_snapshot(&self) -> HashMap<String, QueueStatus> {
         let now = now_epoch_ms();
         self.queues
             .read()
             .map(|g| {
+                if let Some(surveyed) = &g.surveyed {
+                    // Durable backend: the survey is authoritative. Report every
+                    // known queue (registered locally or seen in the survey);
+                    // queues absent from the latest survey reset to depth 0 so
+                    // stale backlog never leaks between ticks.
+                    return g
+                        .waiting
+                        .keys()
+                        .chain(surveyed.keys())
+                        .cloned()
+                        .collect::<std::collections::HashSet<String>>()
+                        .into_iter()
+                        .map(|queue| {
+                            let (depth, oldest_ready_at) =
+                                surveyed.get(&queue).copied().unwrap_or((0, None));
+                            let oldest_waiting_age_ms =
+                                oldest_ready_at.map_or(0, |ts| now.saturating_sub(ts));
+                            (
+                                queue,
+                                QueueStatus {
+                                    depth,
+                                    oldest_waiting_age_ms,
+                                },
+                            )
+                        })
+                        .collect();
+                }
                 g.waiting
                     .iter()
                     .map(|(queue, waiting)| {
@@ -946,6 +993,40 @@ impl JobRegistry {
         if let Ok(mut guard) = self.inner.write() {
             for (name, status) in guard.iter_mut() {
                 status.blocked_on_concurrency = counts.get(name).copied().unwrap_or(0);
+            }
+        }
+    }
+
+    /// Replace the per-queue depth/oldest-age gauges from a backend-wide survey
+    /// (issue #1752).
+    ///
+    /// On the durable backends (Postgres/Redis) a queue is drained by other
+    /// processes, so the authoritative ready depth and oldest-waiting age come
+    /// from a periodic survey of the durable store rather than this process's
+    /// local enqueue marks. This wholesale-replaces the snapshot each tick:
+    /// queues absent from `per_queue` reset to depth 0 (no leaks). Each value
+    /// is `(ready depth, oldest ready-at epoch ms)`; the reported age is
+    /// derived from the timestamp at [`Self::queue_snapshot`] time so it stays
+    /// fresh between surveys. Once called, the survey overrides the in-memory
+    /// `record_*` marks for the `queues` gauge family.
+    pub fn set_queue_depth_gauges(&self, per_queue: &HashMap<String, (u64, Option<u64>)>) {
+        if let Ok(mut guard) = self.queues.write() {
+            guard.surveyed = Some(per_queue.clone());
+        }
+    }
+
+    /// Replace the per-job-type `queued` gauge from a backend-wide survey
+    /// (issue #1752).
+    ///
+    /// Names absent from `counts` reset to zero, mirroring
+    /// [`Self::set_concurrency_blocked_counts`]. Used by the durable backends
+    /// whose ready depth is observed periodically rather than tracked per
+    /// enqueue/start event, so the reported `jobs.<name>.queued` reflects the
+    /// shared durable backlog instead of this process's local enqueue marks.
+    pub fn set_queued_counts(&self, counts: &HashMap<String, u64>) {
+        if let Ok(mut guard) = self.inner.write() {
+            for (name, status) in guard.iter_mut() {
+                status.queued = counts.get(name).copied().unwrap_or(0);
             }
         }
     }
@@ -3740,6 +3821,83 @@ mod tests {
         assert_eq!(drained.get("critical").unwrap().depth, 0);
         assert_eq!(drained.get("critical").unwrap().oldest_waiting_age_ms, 0);
         assert_eq!(drained.get("bulk").unwrap().depth, 0);
+    }
+
+    #[test]
+    fn survey_setter_overwrites_queue_gauges_and_resets_absent_queues() {
+        let registry = JobRegistry::new();
+        registry.register_on_queue("reset_email", "critical");
+        registry.register_on_queue("reindex", "bulk");
+
+        // Local marks exist, but once a survey is published it is authoritative:
+        // the durable backend, not this process's enqueue marks, drives the
+        // reported depth/age (issue #1752).
+        registry.record_enqueue("reset_email");
+
+        let now = now_epoch_ms();
+        let mut survey = HashMap::new();
+        // `critical` has 4 ready jobs; oldest became ready 5s ago.
+        survey.insert(
+            "critical".to_string(),
+            (4_u64, Some(now.saturating_sub(5_000))),
+        );
+        // `bulk` is empty in the survey (absent oldest → age 0).
+        survey.insert("bulk".to_string(), (0_u64, None));
+        registry.set_queue_depth_gauges(&survey);
+
+        let snap = registry.queue_snapshot();
+        assert_eq!(
+            snap.get("critical").unwrap().depth,
+            4,
+            "survey depth overrides the local enqueue mark"
+        );
+        let age = snap.get("critical").unwrap().oldest_waiting_age_ms;
+        assert!(
+            (5_000..=6_000).contains(&age),
+            "age is derived from the surveyed oldest ready-at timestamp, got {age}"
+        );
+        assert_eq!(snap.get("bulk").unwrap().depth, 0);
+        assert_eq!(snap.get("bulk").unwrap().oldest_waiting_age_ms, 0);
+
+        // A later survey that omits `critical` resets it to 0 (no leak), even
+        // though a known/registered queue keeps appearing in the snapshot.
+        let mut survey2 = HashMap::new();
+        survey2.insert("bulk".to_string(), (2_u64, Some(now)));
+        registry.set_queue_depth_gauges(&survey2);
+        let snap2 = registry.queue_snapshot();
+        assert_eq!(
+            snap2.get("critical").unwrap().depth,
+            0,
+            "a queue absent from the newest survey resets to 0"
+        );
+        assert_eq!(snap2.get("bulk").unwrap().depth, 2);
+    }
+
+    #[test]
+    fn survey_setter_overwrites_per_job_queued_and_resets_absent_names() {
+        let registry = JobRegistry::new();
+        registry.register("reset_email");
+        registry.register("reindex");
+
+        registry.record_enqueue("reset_email");
+        registry.record_enqueue("reset_email");
+
+        let mut counts = HashMap::new();
+        counts.insert("reset_email".to_string(), 7_u64);
+        registry.set_queued_counts(&counts);
+        assert_eq!(
+            registry.snapshot()["reset_email"].queued,
+            7,
+            "survey overwrites the local enqueue-driven queued count"
+        );
+        assert_eq!(
+            registry.snapshot()["reindex"].queued,
+            0,
+            "a name absent from the survey resets to 0"
+        );
+
+        registry.set_queued_counts(&HashMap::new());
+        assert_eq!(registry.snapshot()["reset_email"].queued, 0);
     }
 
     #[test]

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -3743,6 +3743,28 @@ fn collect_declared_queues(jobs_by_name: &Arc<RwLock<HashMap<String, JobInfo>>>)
     queues
 }
 
+/// The full set of queue names this worker actually drains: the configured
+/// `[jobs.queues]` plus every `#[job(queue = "…")]`-declared queue the runtime
+/// appends to the effective schedule at lowest priority (#1756).
+///
+/// This is the ground-truth "must be drained" set that a fleet manifest emits so
+/// a topology-aware `autumn doctor --strict` coverage check sees exactly what the
+/// runtime drains — never a stale config-only view that false-positives on
+/// job-declared queues. It reuses [`QueueSchedule::effective`] and
+/// [`collect_declared_queues`] so it can never drift from the real drain plan.
+///
+/// follow-up (#1756): expose this through an `autumn jobs manifest` subcommand
+/// that writes these names to the manifest path doctor consumes; today an app can
+/// emit them itself (or declare them inline under `[jobs.fleet]`).
+#[cfg_attr(not(test), allow(dead_code))]
+fn effective_drained_queues(
+    cfg: &crate::config::JobQueuesConfig,
+    jobs_by_name: &Arc<RwLock<HashMap<String, JobInfo>>>,
+) -> Vec<String> {
+    let declared = collect_declared_queues(jobs_by_name);
+    QueueSchedule::effective(cfg, &declared).0.names()
+}
+
 const LOCAL_QUEUE_WARN_THRESHOLD: usize = 10_000;
 
 /// Shared, priority-ordered job buffer for the in-process backend.
@@ -5404,6 +5426,188 @@ async fn update_redis_blocked_gauges(
     Ok(())
 }
 
+/// Cadence for the durable Redis queue-depth/`queued` gauge survey (issue
+/// #1752). Slower than the 1s blocked survey because it scans every queue list
+/// (LLEN + a bounded LRANGE/MGET tally) plus the due-delayed ZSET; the interval
+/// doubles as the actuator gauge cache TTL.
+#[cfg(feature = "redis")]
+const REDIS_QUEUE_DEPTH_SURVEY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Maximum records sampled per queue (and from the due-delayed set) when
+/// tallying the per-job-type `queued` gauge, matching the blocked survey's
+/// bounded `MGET` approach so the survey stays cheap on deep queues. Per-queue
+/// `depth` still comes from the exact `LLEN`, so only the per-name tally is
+/// bounded.
+#[cfg(feature = "redis")]
+const REDIS_QUEUE_DEPTH_SAMPLE: isize = 1024;
+
+/// Survey the durable Redis store for both actuator gauge families (issue
+/// #1752): per-queue ready `depth` + oldest-waiting age, and per-job-type
+/// `queued` depth. Mirrors [`update_redis_blocked_gauges`]'s MGET-and-tally
+/// approach so the `jobs`/`queues` gauges are backend-derived and authoritative
+/// on every replica — including enqueue-only web replicas that never pop.
+///
+/// Per-queue `depth` is the exact `LLEN` of each queue list plus any due
+/// (ready-at `<= now`) entries still parked in the delayed ZSET; oldest-waiting
+/// age comes from the tail record's enqueue time (enqueue `LPUSH`es to the head
+/// and claim `RPOP`s from the tail, so the tail is the next job to run) and/or
+/// the min due-delayed score. The per-name `queued` tally reads a bounded sample
+/// of records per queue.
+#[cfg(feature = "redis")]
+async fn update_redis_queue_depth_gauges(
+    connection: &mut redis::aio::ConnectionManager,
+    key_prefix: &str,
+    queue_names: &[String],
+    delayed_key: &str,
+    record_prefix: &str,
+    state: &AppState,
+) -> Result<(), redis::RedisError> {
+    let now = now_unix_ms();
+    let mut per_queue: HashMap<String, (u64, Option<u64>)> = HashMap::new();
+    let mut per_name: HashMap<String, u64> = HashMap::new();
+
+    for queue in queue_names {
+        let list_key = redis_queue_key(key_prefix, queue);
+        let len: u64 = redis::cmd("LLEN")
+            .arg(&list_key)
+            .query_async(connection)
+            .await?;
+        let mut oldest_ready_at: Option<u64> = None;
+        if len > 0 {
+            // The oldest still-waiting job is at the tail (LPUSH head / RPOP
+            // tail), so its enqueue time is the queue's oldest-waiting age.
+            let oldest_id: Option<String> = redis::cmd("LINDEX")
+                .arg(&list_key)
+                .arg(-1)
+                .query_async(connection)
+                .await?;
+            if let Some(id) = oldest_id {
+                let body: Option<String> = redis::cmd("GET")
+                    .arg(redis_record_key(record_prefix, &id))
+                    .query_async(connection)
+                    .await?;
+                if let Some(record) = body
+                    .as_deref()
+                    .and_then(|b| serde_json::from_str::<RedisJobRecord>(b).ok())
+                {
+                    oldest_ready_at = record.enqueued_at_ms;
+                }
+            }
+            // Bounded per-name tally from the head of the list (consistent with
+            // the blocked survey's sampling).
+            let ids: Vec<String> = redis::cmd("LRANGE")
+                .arg(&list_key)
+                .arg(0)
+                .arg(REDIS_QUEUE_DEPTH_SAMPLE - 1)
+                .query_async(connection)
+                .await?;
+            if !ids.is_empty() {
+                let keys: Vec<String> = ids
+                    .iter()
+                    .map(|id| redis_record_key(record_prefix, id))
+                    .collect();
+                let bodies: Vec<Option<String>> =
+                    redis::cmd("MGET").arg(keys).query_async(connection).await?;
+                for body in bodies.into_iter().flatten() {
+                    if let Ok(record) = serde_json::from_str::<RedisJobRecord>(&body) {
+                        *per_name.entry(record.name).or_insert(0) += 1;
+                    }
+                }
+            }
+        }
+        let entry = per_queue.entry(queue.clone()).or_insert((0, None));
+        entry.0 = entry.0.saturating_add(len);
+        if let Some(ts) = oldest_ready_at {
+            entry.1 = Some(entry.1.map_or(ts, |cur| cur.min(ts)));
+        }
+    }
+
+    // Due-delayed entries (scheduled/retry jobs whose ready-at has arrived but
+    // that a worker has not yet promoted to a queue list) are ready backlog too.
+    // Only entries scored `<= now` count; the score is the ready-at time.
+    let due: Vec<(String, f64)> = redis::cmd("ZRANGEBYSCORE")
+        .arg(delayed_key)
+        .arg("-inf")
+        .arg(now)
+        .arg("WITHSCORES")
+        .arg("LIMIT")
+        .arg(0)
+        .arg(REDIS_QUEUE_DEPTH_SAMPLE)
+        .query_async(connection)
+        .await?;
+    if !due.is_empty() {
+        let keys: Vec<String> = due
+            .iter()
+            .map(|(id, _)| redis_record_key(record_prefix, id))
+            .collect();
+        let bodies: Vec<Option<String>> =
+            redis::cmd("MGET").arg(keys).query_async(connection).await?;
+        let scores: HashMap<String, f64> = due.into_iter().collect();
+        for body in bodies.into_iter().flatten() {
+            if let Ok(record) = serde_json::from_str::<RedisJobRecord>(&body) {
+                // ZSET scores are ready-at in ms; clamp the f64 back to u64.
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                let ready_at = scores.get(&record.id).map(|s| s.max(0.0) as u64);
+                *per_name.entry(record.name.clone()).or_insert(0) += 1;
+                let entry = per_queue.entry(record.queue.clone()).or_insert((0, None));
+                entry.0 = entry.0.saturating_add(1);
+                if let Some(ts) = ready_at {
+                    entry.1 = Some(entry.1.map_or(ts, |cur| cur.min(ts)));
+                }
+            }
+        }
+    }
+
+    state.job_registry.set_queue_depth_gauges(&per_queue);
+    state.job_registry.set_queued_counts(&per_name);
+    Ok(())
+}
+
+/// Read-only survey loop that refreshes the actuator queue-depth/`queued`
+/// gauges from Redis on a fixed interval (issue #1752).
+///
+/// Spawned on **every** role — including enqueue-only web replicas that run no
+/// worker loop — so the `/actuator/jobs` gauges reflect the shared durable
+/// backlog rather than a web replica's ever-growing local enqueue marks. The
+/// survey interval doubles as the gauge cache TTL.
+#[cfg(feature = "redis")]
+fn spawn_redis_queue_depth_survey(
+    client: &redis::Client,
+    state: AppState,
+    shutdown: tokio_util::sync::CancellationToken,
+    key_prefix: String,
+    queue_names: Vec<String>,
+    delayed_key: String,
+    record_prefix: String,
+) -> Result<(), AutumnError> {
+    let mut connection =
+        new_redis_connection_manager(client, "jobs redis queue-depth survey connection manager")?;
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(REDIS_QUEUE_DEPTH_SURVEY_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    if let Err(error) = update_redis_queue_depth_gauges(
+                        &mut connection,
+                        &key_prefix,
+                        &queue_names,
+                        &delayed_key,
+                        &record_prefix,
+                        &state,
+                    )
+                    .await
+                    {
+                        tracing::warn!(error = %error, "redis queue-depth survey failed");
+                    }
+                }
+                () = shutdown.cancelled() => break,
+            }
+        }
+    });
+    Ok(())
+}
+
 #[cfg(feature = "redis")]
 fn expected_claim_args(record: &RedisJobRecord) -> Option<(&str, u64)> {
     Some((record.claimed_by.as_deref()?, record.claimed_at_ms?))
@@ -6360,6 +6564,10 @@ fn start_redis_runtime(
         .iter()
         .map(|queue| redis_queue_key(&config.redis.key_prefix, queue))
         .collect();
+    // Full queue-name set (before pinning) for the actuator queue-depth survey:
+    // web replicas serve /actuator/jobs for every queue, so the survey must
+    // cover all of them, not just this process's pinned worker subset (#1752).
+    let survey_queue_names: Vec<String> = schedule.names();
     // Queue pinning (#1623, AC3): this worker process only drains the pinned
     // subset. Warn about any configured queue left uncovered (AC6).
     let uncovered = schedule.retain_pinned(&config.pin);
@@ -6438,6 +6646,21 @@ fn start_redis_runtime(
                 .map(|c| Arc::new(c.resilience.clone())),
         },
     );
+
+    // Backend-derived actuator gauges (issue #1752): survey Redis for per-queue
+    // depth/age and per-job-type `queued` on a fixed interval. Spawned for ALL
+    // roles — before the web-role early return below — so an enqueue-only web
+    // replica reports the true shared backlog instead of its own ever-growing
+    // local enqueue marks.
+    spawn_redis_queue_depth_survey(
+        &client,
+        state.clone(),
+        shutdown.clone(),
+        config.redis.key_prefix.clone(),
+        survey_queue_names,
+        delayed_key.clone(),
+        record_prefix.clone(),
+    )?;
 
     // Web role installs the enqueue client above but runs no worker loops:
     // another (worker/combined) replica drains the durable Redis queue. Bypass
@@ -7156,6 +7379,43 @@ async fn pg_claim_next_job(
     })
 }
 
+/// Aggregated durable job gauges surveyed from the backend (issue #1752): the
+/// two `/actuator/jobs` gauge families derived from one pass over the ready
+/// enqueued rows.
+#[cfg(feature = "db")]
+#[derive(Debug, Default)]
+struct SurveyedJobGauges {
+    /// Queue → (ready depth, oldest ready-at epoch ms).
+    per_queue: HashMap<String, (u64, Option<u64>)>,
+    /// Job name → ready `queued` depth.
+    per_name: HashMap<String, u64>,
+}
+
+/// Fold surveyed `(queue, name, ready-count, oldest ready-at ms)` rows into the
+/// per-queue and per-job-type actuator gauges.
+///
+/// Pure (no I/O) so the row→gauge mapping is unit-testable without a live
+/// backend. Callers pass rows already filtered to ready work (`run_at <= now`
+/// on Postgres); this only sums the per-queue and per-name depths and keeps the
+/// oldest ready-at per queue.
+#[cfg(feature = "db")]
+fn aggregate_surveyed_job_gauges<I>(rows: I) -> SurveyedJobGauges
+where
+    I: IntoIterator<Item = (String, String, u64, Option<u64>)>,
+{
+    let mut gauges = SurveyedJobGauges::default();
+    for (queue, name, count, oldest_ready_at) in rows {
+        let queue_entry = gauges.per_queue.entry(queue).or_insert((0, None));
+        queue_entry.0 = queue_entry.0.saturating_add(count);
+        if let Some(ts) = oldest_ready_at {
+            queue_entry.1 = Some(queue_entry.1.map_or(ts, |cur| cur.min(ts)));
+        }
+        let name_entry = gauges.per_name.entry(name).or_insert(0);
+        *name_entry = name_entry.saturating_add(count);
+    }
+    gauges
+}
+
 /// Row shape for per-name aggregate count queries.
 #[cfg(feature = "db")]
 #[derive(diesel::QueryableByName)]
@@ -7201,6 +7461,67 @@ async fn pg_update_concurrency_blocked_gauges(pool: &PgPool, state: &AppState) {
         }
         Err(error) => {
             tracing::warn!(error = %error, "postgres blocked-concurrency survey failed");
+        }
+    }
+}
+
+/// Row shape for the per-(queue, name) ready-depth survey.
+#[cfg(feature = "db")]
+#[derive(diesel::QueryableByName)]
+struct PgQueueDepthRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    queue: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    name: String,
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    count: i64,
+    /// `MIN(run_at)` of the group as epoch milliseconds, `NULL` for an empty
+    /// group (never returned by a `GROUP BY` with matching rows, but modelled
+    /// nullable for safety).
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::BigInt>)]
+    oldest_run_at_ms: Option<i64>,
+}
+
+/// Survey ready (claimable) enqueued jobs grouped by queue and name and publish
+/// both actuator gauge families from the durable store (issue #1752).
+///
+/// One `GROUP BY queue, name` query (backed by `idx_autumn_jobs_queue_ready`)
+/// feeds: per-queue ready depth + oldest-waiting age (the `queues` family) and
+/// per-job-type `queued` depth (the `jobs` family). This makes the
+/// `/actuator/jobs` gauges backend-derived and authoritative on every replica —
+/// including enqueue-only web replicas, which previously reported ever-growing
+/// phantom depth from their local enqueue marks.
+#[cfg(feature = "db")]
+async fn pg_update_queue_depth_gauges(pool: &PgPool, state: &AppState) {
+    use diesel_async::RunQueryDsl as _;
+
+    let Ok(mut conn) = pool.get().await else {
+        return;
+    };
+    let rows = diesel::sql_query(
+        "SELECT queue, name, COUNT(*) AS count, \
+                CAST(EXTRACT(EPOCH FROM MIN(run_at)) * 1000 AS BIGINT) AS oldest_run_at_ms \
+         FROM autumn_jobs \
+         WHERE status = 'enqueued' AND run_at <= NOW() \
+         GROUP BY queue, name",
+    )
+    .load::<PgQueueDepthRow>(&mut *conn)
+    .await;
+    match rows {
+        Ok(rows) => {
+            let gauges = aggregate_surveyed_job_gauges(rows.into_iter().map(|row| {
+                (
+                    row.queue,
+                    row.name,
+                    u64::try_from(row.count).unwrap_or(0),
+                    row.oldest_run_at_ms.and_then(|ms| u64::try_from(ms).ok()),
+                )
+            }));
+            state.job_registry.set_queue_depth_gauges(&gauges.per_queue);
+            state.job_registry.set_queued_counts(&gauges.per_name);
+        }
+        Err(error) => {
+            tracing::warn!(error = %error, "postgres queue-depth survey failed");
         }
     }
 }
@@ -7628,6 +7949,33 @@ async fn pg_maintenance_loop(
             }
             _ = tracking_cleanup_interval.tick() => {
                 pg_cleanup_expired_tracking_rows(&pool).await;
+            }
+            () = shutdown.cancelled() => break,
+        }
+    }
+}
+
+/// Dedicated read-only survey task: refreshes the actuator queue-depth and
+/// per-job-type `queued` gauges from the durable store on a fixed interval.
+///
+/// Spawned on **every** role — including enqueue-only web replicas that run no
+/// worker or maintenance loop (issue #1752) — so the `/actuator/jobs` gauges on
+/// a web replica reflect the shared durable backlog rather than that process's
+/// local enqueue marks (which only grow, since it never pops). The survey
+/// interval doubles as the gauge cache TTL: the endpoint reads the last surveyed
+/// snapshot and never queries the backend per request.
+#[cfg(feature = "db")]
+async fn pg_queue_depth_survey_loop(
+    pool: PgPool,
+    state: AppState,
+    shutdown: tokio_util::sync::CancellationToken,
+) {
+    let mut interval = tokio::time::interval(PG_MAINTENANCE_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                pg_update_queue_depth_gauges(&pool, &state).await;
             }
             () = shutdown.cancelled() => break,
         }
@@ -8278,6 +8626,20 @@ fn start_postgres_runtime(
                 .map(|c| Arc::new(c.resilience.clone())),
         },
     );
+
+    // Backend-derived actuator gauges (issue #1752): survey the durable store
+    // for per-queue depth/age and per-job-type `queued` on a fixed interval.
+    // Spawned for ALL roles — before the web-role early return below — so an
+    // enqueue-only web replica reports the true shared backlog instead of its
+    // own ever-growing local enqueue marks.
+    {
+        let pool = pool.clone();
+        let state = state.clone();
+        let shutdown = shutdown.clone();
+        tokio::spawn(async move {
+            pg_queue_depth_survey_loop(pool, state, shutdown).await;
+        });
+    }
 
     // Web role installs the enqueue client above but runs no worker loops and
     // no maintenance loop: another (worker/combined) replica drains the durable
@@ -16611,6 +16973,68 @@ mod uniqueness_concurrency_tests {
         assert_eq!(JobAdminStatus::Deduplicated.label(), "deduplicated");
     }
 
+    #[cfg(feature = "db")]
+    #[test]
+    fn aggregate_surveyed_job_gauges_maps_rows_to_both_families() {
+        // Empty survey → empty gauges (a fully-drained backend reports nothing,
+        // and the setters then reset every known queue/name to 0).
+        let empty = aggregate_surveyed_job_gauges(std::iter::empty());
+        assert!(empty.per_queue.is_empty());
+        assert!(empty.per_name.is_empty());
+
+        // Single queue, single name.
+        let single = aggregate_surveyed_job_gauges([(
+            "critical".to_string(),
+            "reset_email".to_string(),
+            3_u64,
+            Some(1_000_u64),
+        )]);
+        assert_eq!(single.per_queue["critical"], (3, Some(1_000)));
+        assert_eq!(single.per_name["reset_email"], 3);
+
+        // Multi-queue, multi-name: per-queue depth sums every name on the queue,
+        // the per-name family stays split by name, and the oldest ready-at per
+        // queue is the MIN across its groups.
+        let multi = aggregate_surveyed_job_gauges([
+            (
+                "critical".to_string(),
+                "reset_email".to_string(),
+                2_u64,
+                Some(5_000_u64),
+            ),
+            (
+                "critical".to_string(),
+                "send_sms".to_string(),
+                4_u64,
+                Some(2_000_u64),
+            ),
+            (
+                "bulk".to_string(),
+                "reindex".to_string(),
+                1_u64,
+                Some(9_000_u64),
+            ),
+        ]);
+        assert_eq!(
+            multi.per_queue["critical"],
+            (6, Some(2_000)),
+            "queue depth sums both names; oldest ready-at is the earliest group"
+        );
+        assert_eq!(multi.per_queue["bulk"], (1, Some(9_000)));
+        assert_eq!(multi.per_name["reset_email"], 2);
+        assert_eq!(multi.per_name["send_sms"], 4);
+        assert_eq!(multi.per_name["reindex"], 1);
+
+        // A missing oldest ready-at (None) does not clobber a present one and
+        // leaves the queue's age unset when every group is None.
+        let none_age = aggregate_surveyed_job_gauges([
+            ("q".to_string(), "a".to_string(), 1_u64, None),
+            ("q".to_string(), "b".to_string(), 2_u64, Some(7_000_u64)),
+            ("q".to_string(), "c".to_string(), 1_u64, None),
+        ]);
+        assert_eq!(none_age.per_queue["q"], (4, Some(7_000)));
+    }
+
     // ── local backend: uniqueness ────────────────────────────────────────────
 
     static UNIQUE_BURST_CALLS: AtomicUsize = AtomicUsize::new(0);
@@ -17653,6 +18077,38 @@ mod queue_schedule_tests {
         let declared = vec!["default".to_string(), "critical".to_string()];
         let (_schedule, warnings) = QueueSchedule::effective(&cfg, &declared);
         assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn effective_drained_queues_appends_job_declared_queues() {
+        // The manifest ground-truth set (#1756): configured queues PLUS every
+        // `#[job(queue = "…")]`-declared queue the runtime appends to the drain
+        // plan. A topology-aware `doctor --strict` consuming this set must see
+        // the job-declared `email` so it never false-fails when a tier pins it.
+        fn handler(
+            _state: AppState,
+            _payload: Value,
+        ) -> Pin<Box<dyn Future<Output = AutumnResult<()>> + Send + 'static>> {
+            Box::pin(async move { Ok(()) })
+        }
+        let mut jobs = HashMap::new();
+        jobs.insert(
+            "emailer".to_string(),
+            JobInfo {
+                version: 1,
+                name: "emailer".to_string(),
+                max_attempts: 1,
+                initial_backoff_ms: 1,
+                queue: "email".to_string(),
+                uniqueness: None,
+                concurrency: None,
+                handler,
+            },
+        );
+        let registry = Arc::new(RwLock::new(jobs));
+        let cfg = JobQueuesConfig::strict_list(["critical"]);
+        let drained = effective_drained_queues(&cfg, &registry);
+        assert_eq!(drained, vec!["critical".to_string(), "email".to_string()]);
     }
 
     // ── Queue pinning (#1623, AC3/AC4) ──────────────────────────────────────

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -5433,13 +5433,50 @@ async fn update_redis_blocked_gauges(
 #[cfg(feature = "redis")]
 const REDIS_QUEUE_DEPTH_SURVEY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
 
-/// Maximum records sampled per queue (and from the due-delayed set) when
-/// tallying the per-job-type `queued` gauge, matching the blocked survey's
-/// bounded `MGET` approach so the survey stays cheap on deep queues. Per-queue
-/// `depth` still comes from the exact `LLEN`, so only the per-name tally is
-/// bounded.
+/// Maximum records sampled per queue when tallying the per-job-type `queued`
+/// gauge, matching the blocked survey's bounded `MGET` approach so the survey
+/// stays cheap on deep queues. Per-queue `depth` still comes from the exact
+/// `LLEN`, so only the per-name tally is bounded for queue lists.
+///
+/// This same value doubles as the **page size** (not a hard cap) for the
+/// due-delayed ZSET scan: that scan pages through the entire ready backlog one
+/// `REDIS_QUEUE_DEPTH_SAMPLE`-sized window at a time so per-queue depth,
+/// per-name, and oldest-age stay exact across a large delayed/retry burst,
+/// while per-page memory stays bounded to a single page.
 #[cfg(feature = "redis")]
 const REDIS_QUEUE_DEPTH_SAMPLE: isize = 1024;
+
+/// Safety bound on the total number of due-delayed entries scanned in a single
+/// queue-depth survey. The due scan pages through the ready backlog exactly
+/// (see [`REDIS_QUEUE_DEPTH_SAMPLE`]); this cap (64 pages) keeps a pathological
+/// burst from turning that scan into an unbounded hammer on Redis. If the scan
+/// reaches this cap with a full final page (more may remain), it stops and logs
+/// a single `warn!` so the reported depth is never silently truncated.
+#[cfg(feature = "redis")]
+const REDIS_QUEUE_DEPTH_DUE_SCAN_CAP: usize = 65_536;
+
+/// Fold a page of due-delayed records into the running per-queue depth/oldest
+/// and per-name tallies. Pure and I/O-free (the async survey does the Redis
+/// `ZRANGEBYSCORE`/`MGET`/JSON parse and feeds parsed rows here), so the
+/// multi-page counting can be unit-tested directly.
+///
+/// Each record is `(queue, name, ready_at_ms)`; `ready_at_ms` is the ZSET score
+/// (ready-at time) already clamped to `u64`, or `None` when unavailable.
+#[cfg(feature = "redis")]
+fn fold_due_delayed_records(
+    records: impl IntoIterator<Item = (String, String, Option<u64>)>,
+    per_queue: &mut HashMap<String, (u64, Option<u64>)>,
+    per_name: &mut HashMap<String, u64>,
+) {
+    for (queue, name, ready_at) in records {
+        *per_name.entry(name).or_insert(0) += 1;
+        let entry = per_queue.entry(queue).or_insert((0, None));
+        entry.0 = entry.0.saturating_add(1);
+        if let Some(ts) = ready_at {
+            entry.1 = Some(entry.1.map_or(ts, |cur| cur.min(ts)));
+        }
+    }
+}
 
 /// Survey the durable Redis store for both actuator gauge families (issue
 /// #1752): per-queue ready `depth` + oldest-waiting age, and per-job-type
@@ -5524,42 +5561,95 @@ async fn update_redis_queue_depth_gauges(
 
     // Due-delayed entries (scheduled/retry jobs whose ready-at has arrived but
     // that a worker has not yet promoted to a queue list) are ready backlog too.
-    // Only entries scored `<= now` count; the score is the ready-at time.
-    let due: Vec<(String, f64)> = redis::cmd("ZRANGEBYSCORE")
-        .arg(delayed_key)
-        .arg("-inf")
-        .arg(now)
-        .arg("WITHSCORES")
-        .arg("LIMIT")
-        .arg(0)
-        .arg(REDIS_QUEUE_DEPTH_SAMPLE)
-        .query_async(connection)
-        .await?;
-    if !due.is_empty() {
-        let keys: Vec<String> = due
-            .iter()
-            .map(|(id, _)| redis_record_key(record_prefix, id))
-            .collect();
-        let bodies: Vec<Option<String>> =
-            redis::cmd("MGET").arg(keys).query_async(connection).await?;
-        let scores: HashMap<String, f64> = due.into_iter().collect();
-        for body in bodies.into_iter().flatten() {
-            if let Ok(record) = serde_json::from_str::<RedisJobRecord>(&body) {
-                // ZSET scores are ready-at in ms; clamp the f64 back to u64.
-                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                let ready_at = scores.get(&record.id).map(|s| s.max(0.0) as u64);
-                *per_name.entry(record.name.clone()).or_insert(0) += 1;
-                let entry = per_queue.entry(record.queue.clone()).or_insert((0, None));
-                entry.0 = entry.0.saturating_add(1);
-                if let Some(ts) = ready_at {
-                    entry.1 = Some(entry.1.map_or(ts, |cur| cur.min(ts)));
-                }
-            }
-        }
-    }
+    survey_due_delayed_gauges(
+        connection,
+        delayed_key,
+        record_prefix,
+        now,
+        &mut per_queue,
+        &mut per_name,
+    )
+    .await?;
 
     state.job_registry.set_queue_depth_gauges(&per_queue);
     state.job_registry.set_queued_counts(&per_name);
+    Ok(())
+}
+
+/// Fold the whole due-delayed (`score <= now`) ZSET backlog into the running
+/// per-queue depth/oldest and per-name tallies.
+///
+/// Pages through the due range one `REDIS_QUEUE_DEPTH_SAMPLE`-sized window at a
+/// time (rather than sampling only the first page) so per-queue depth, per-name,
+/// and oldest-age are exact across a large delayed/retry backlog while per-page
+/// memory stays bounded to a single page. `ZRANGEBYSCORE` returns ascending by
+/// score, so the very first entry is the global minimum ready-at and the running
+/// `.min()` in [`fold_due_delayed_records`] keeps oldest-age exact regardless of
+/// paging. Total scanned entries are capped at `REDIS_QUEUE_DEPTH_DUE_SCAN_CAP`;
+/// hitting the cap with a full final page emits a single `warn!` rather than
+/// silently under-counting.
+#[cfg(feature = "redis")]
+async fn survey_due_delayed_gauges(
+    connection: &mut redis::aio::ConnectionManager,
+    delayed_key: &str,
+    record_prefix: &str,
+    now: u64,
+    per_queue: &mut HashMap<String, (u64, Option<u64>)>,
+    per_name: &mut HashMap<String, u64>,
+) -> Result<(), redis::RedisError> {
+    let page_size = REDIS_QUEUE_DEPTH_SAMPLE.max(1).cast_unsigned();
+    let mut offset: isize = 0;
+    let mut scanned: usize = 0;
+    loop {
+        // Only entries scored `<= now` count; the score is the ready-at time.
+        let due: Vec<(String, f64)> = redis::cmd("ZRANGEBYSCORE")
+            .arg(delayed_key)
+            .arg("-inf")
+            .arg(now)
+            .arg("WITHSCORES")
+            .arg("LIMIT")
+            .arg(offset)
+            .arg(REDIS_QUEUE_DEPTH_SAMPLE)
+            .query_async(connection)
+            .await?;
+        let page_len = due.len();
+        if !due.is_empty() {
+            let keys: Vec<String> = due
+                .iter()
+                .map(|(id, _)| redis_record_key(record_prefix, id))
+                .collect();
+            let bodies: Vec<Option<String>> =
+                redis::cmd("MGET").arg(keys).query_async(connection).await?;
+            let scores: HashMap<String, f64> = due.into_iter().collect();
+            let records = bodies.into_iter().flatten().filter_map(|body| {
+                serde_json::from_str::<RedisJobRecord>(&body)
+                    .ok()
+                    .map(|record| {
+                        // ZSET scores are ready-at in ms; clamp the f64 to u64.
+                        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                        let ready_at = scores.get(&record.id).map(|s| s.max(0.0) as u64);
+                        (record.queue, record.name, ready_at)
+                    })
+            });
+            fold_due_delayed_records(records, per_queue, per_name);
+        }
+        scanned += page_len;
+        // A short page means the due range is exhausted — stop cleanly.
+        if page_len < page_size {
+            break;
+        }
+        // Full final page at the safety bound: stop, but disclose the possible
+        // under-count rather than silently truncating.
+        if scanned >= REDIS_QUEUE_DEPTH_DUE_SCAN_CAP {
+            tracing::warn!(
+                scanned,
+                cap = REDIS_QUEUE_DEPTH_DUE_SCAN_CAP,
+                "due-delayed queue-depth scan truncated at cap; reported ready depth may under-count"
+            );
+            break;
+        }
+        offset += REDIS_QUEUE_DEPTH_SAMPLE;
+    }
     Ok(())
 }
 
@@ -17033,6 +17123,61 @@ mod uniqueness_concurrency_tests {
             ("q".to_string(), "c".to_string(), 1_u64, None),
         ]);
         assert_eq!(none_age.per_queue["q"], (4, Some(7_000)));
+    }
+
+    #[cfg(feature = "redis")]
+    #[test]
+    fn fold_due_delayed_records_counts_all_pages_across_queues() {
+        // Build a due backlog larger than one page (REDIS_QUEUE_DEPTH_SAMPLE =
+        // 1024) spread across three queues, then fold it page-by-page exactly as
+        // the paginated survey loop does. This proves per-queue depth, per-name,
+        // and oldest-age stay exact across a multi-page scan rather than being
+        // capped at the first 1024-record sample.
+        const TOTAL: usize = 2500;
+        let queues = ["alpha", "beta", "gamma"];
+        let mut records: Vec<(String, String, Option<u64>)> = Vec::with_capacity(TOTAL);
+        let mut expected_depth: HashMap<String, u64> = HashMap::new();
+        let mut expected_oldest: HashMap<String, u64> = HashMap::new();
+        let mut expected_name: HashMap<String, u64> = HashMap::new();
+        for i in 0..TOTAL {
+            let queue = queues[i % queues.len()];
+            let name = format!("job_{}", i % 5);
+            // Descending ready-at so each queue's minimum lands at its highest
+            // index — deep in a later page — exercising the cross-page min.
+            let ready_at = (TOTAL - i) as u64;
+            records.push((queue.to_string(), name.clone(), Some(ready_at)));
+            *expected_depth.entry(queue.to_string()).or_insert(0) += 1;
+            let slot = expected_oldest.entry(queue.to_string()).or_insert(ready_at);
+            *slot = (*slot).min(ready_at);
+            *expected_name.entry(name).or_insert(0) += 1;
+        }
+
+        let mut per_queue: HashMap<String, (u64, Option<u64>)> = HashMap::new();
+        let mut per_name: HashMap<String, u64> = HashMap::new();
+
+        let page_size = REDIS_QUEUE_DEPTH_SAMPLE.max(1).cast_unsigned();
+        assert!(TOTAL > page_size, "test must span multiple pages");
+        for page in records.chunks(page_size) {
+            fold_due_delayed_records(page.iter().cloned(), &mut per_queue, &mut per_name);
+        }
+
+        for queue in queues {
+            let (depth, oldest) = per_queue[queue];
+            assert_eq!(depth, expected_depth[queue], "exact depth for {queue}");
+            assert_eq!(
+                oldest,
+                Some(expected_oldest[queue]),
+                "exact oldest ready-at for {queue}"
+            );
+        }
+        assert_eq!(
+            per_queue.values().map(|(d, _)| *d).sum::<u64>(),
+            TOTAL as u64,
+            "every due record counted exactly once across all pages"
+        );
+        for (name, count) in &expected_name {
+            assert_eq!(per_name[name], *count, "exact per-name count for {name}");
+        }
     }
 
     // ── local backend: uniqueness ────────────────────────────────────────────


### PR DESCRIPTION
Wave-7 jobs-observability lane: implements the two deliberate deferrals from #1746.

## #1752 — actuator queue gauges derived from the durable backend

**Before:** `/actuator/jobs` reported per-queue `depth` / `oldest_waiting_age_ms` and per-job-type `queued` from an in-memory per-process mark store (`record_enqueue`/`record_start`). In a split `AUTUMN_ROLE=web` + worker topology the enqueue mark was pushed in the enqueuing process but the pop happened in a different worker process's registry, so enqueue-only `web` replicas reported ever-growing **phantom depth**, multi-worker setups misattributed counts, and cancel/dedup popped marks by ready/scheduled *category* rather than the exact instance.

**After:** on durable backends both gauge families are derived from a periodic read-only survey of the authoritative store, wholesale-replacing the snapshot each tick (absent queues/names reset to 0), so every process — including enqueue-only web replicas — reports the same true depth. The local backend (single process) keeps its exact in-memory path.

**How:** mirrors the existing `set_concurrency_blocked_counts` pattern.
- `JobRegistry` gains `set_queue_depth_gauges` + `set_queued_counts`; `queue_snapshot()` prefers the surveyed snapshot when present (age derived from the stored oldest-ready-at timestamp at read time), else falls back to in-memory marks.
- Postgres: `pg_update_queue_depth_gauges` runs `SELECT queue, name, COUNT(*), MIN(run_at) … WHERE status='enqueued' AND run_at<=NOW() GROUP BY queue, name` (backed by `idx_autumn_jobs_queue_ready`), aggregated via the pure `aggregate_surveyed_job_gauges` helper; scheduled on `pg_queue_depth_survey_loop`.
- Redis: `update_redis_queue_depth_gauges` — per-queue depth = `LLEN` + due-delayed ZSET entries; oldest age from the tail record's `enqueued_at_ms` and/or min due-delayed score; per-name `queued` via a bounded `LRANGE`+`MGET` tally (consistent with the blocked survey).
- The survey ticker is spawned on **all** roles (web / worker / combined), before the worker-only early return, so read-only depth reporting runs everywhere. The survey interval doubles as the gauge cache TTL — the endpoint just reads the last-surveyed snapshot, so the backend isn't hammered per request.

## #1756 — sound, opt-in `doctor --strict` queue-coverage hard-fail

**Before:** #1746 demoted the doctor queue-coverage check to informational-only (always `Pass`) because a config-only, per-process CLI can't see sibling worker tiers or `#[job(queue="…")]`-declared queues, so every hard-fail false-positived on valid multi-tier deployments.

**After:** `doctor --strict` can again hard-fail on a genuine zero-coverage gap — but only when the operator gives it the two inputs that make coverage provable, so there is **zero regression** when they aren't declared (it delegates to the existing informational path).
- **Fleet topology:** a `[jobs.fleet] tiers = [["critical"], ["bulk","default"], []]` config section (each inner array = one worker tier's pin; `[]` = an unpinned tier that drains everything). Coverage = union of all tier pins.
- **Declared-queue awareness:** `[jobs.fleet] manifest = "path"` (a jobs manifest the app emits) or inline `declared_queues = [...]`. The runtime-side ground truth is `effective_drained_queues(cfg, registry)`, reusing `QueueSchedule::effective` + `collect_declared_queues`.

**How:** new `check_queue_coverage_topology` wraps the existing `check_queue_coverage` (signature unchanged, all prior call sites/tests untouched). With ≥1 declared tier: `needed = configured ∪ declared`, `covered = union(tier pins)`; returns `Fail` only when a needed queue is drained by no tier. Declared queues only ever *add* to `needed`, so a missing/partial manifest can never manufacture a false gap.

## Verification
- `cargo fmt --all -- --check` → clean
- `cargo clippy --workspace --all-targets -- -D warnings` and `--features redis,db` → clean
- `cargo build --workspace` → ok
- `cargo test -p autumn-web --features redis,db --lib actuator` → 131 passed; `aggregate_surveyed_job_gauges` → 1; `effective_drained_queues` → 1
- `cargo test -p autumn-cli --bin autumn queue_coverage` → 11 passed; `topology` → 25 passed

## Notes / follow-ups
- Redis per-name `queued` tally is bounded (sample per queue, consistent with the blocked survey); per-queue `depth` is exact via `LLEN`. Deeper-than-sample queues under-count the per-name tally while depth stays exact.
- The only deferred piece of #1756 is the `autumn jobs manifest` subcommand that *writes* the manifest file; the manifest-consuming path and the runtime computation are both implemented and tested, and doctor also accepts the inline `declared_queues` list.
- Docker-gated Redis/PG integration tests were not run in this environment (no testcontainers).

Part of #1752
Part of #1756

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDNMCJhT13RHsrJPva3txV)_