### PR TITLE
Cascade: model-side has_many(dependent), grandchild + delete_many cascade, cross-shard read guards

### DIFF
--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -432,7 +432,10 @@ fn emit_dependents_impl(model_ident: &syn::Ident, assocs: &[Association]) -> Tok
                 __conn: &'__a mut ::autumn_web::reexports::diesel_async::AsyncPgConnection,
                 __parent_id: i64,
                 __parent_soft: bool,
-                __visited: &'__a mut ::std::collections::HashSet<(&'static str, i64)>,
+                // Codex round-5-B: the active recursion path (cycle-break) and the
+                // monotonic actually-deleted set, threaded through separately.
+                __path: &'__a mut ::std::collections::HashSet<(&'static str, i64)>,
+                __deleted: &'__a mut ::std::collections::HashSet<(&'static str, i64)>,
             ) -> ::autumn_web::repository::RuntimeDependentCascadeFuture<'__a> {
                 ::std::boxed::Box::pin(async move {
                     // Own the child repository inside the async block so the
@@ -448,7 +451,8 @@ fn emit_dependents_impl(model_ident: &syn::Ident, assocs: &[Association]) -> Tok
                             __parent_id,
                             ::autumn_web::repository::DependentAction::#action_variant,
                             __parent_soft,
-                            __visited,
+                            __path,
+                            __deleted,
                         )
                         .await
                 })

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -274,6 +274,25 @@ fn parse_assoc_attr(
             "`target_fk = <column>` requires `through = <join_table>`",
         ));
     }
+    if explicit_through.is_some() && dependent.is_some() {
+        // A `through = <join_table>` association's `fk` names a column on the
+        // *join table*, not on the target model. The emitted cascade calls the
+        // target repository's `__autumn_apply_dependent_on_conn`, whose SQL
+        // treats `fk` as a column on the target table — so the cascade would
+        // hit e.g. `tags.post_id` (nonexistent) instead of the join table.
+        // Reject the combination directed rather than silently mis-cascading.
+        // (Generating a real join-table cascade is a possible future
+        // enhancement; a clean reject is the correct minimal behavior.)
+        return Err(syn::Error::new_spanned(
+            &target,
+            "`dependent`/`on_delete` cascade is not supported on a `through = \
+             <join_table>` (many-to-many) association: its foreign key names a \
+             column on the join table, not on the target model, so the cascade \
+             would delete/nullify the wrong rows — remove `dependent`/\
+             `on_delete`, or declare the cascade on a model that maps the join \
+             table directly",
+        ));
+    }
 
     let (fk, derived_name) =
         resolve_fk_and_name(kind, model_ident, &target, explicit_fk.as_deref());
@@ -5212,6 +5231,41 @@ mod tests {
         let has_one: Vec<syn::Attribute> =
             vec![syn::parse_quote!(#[has_one(Profile, through = post_profiles)])];
         assert!(resolve_associations(&model, &has_one).is_err());
+    }
+
+    #[test]
+    fn dependent_on_through_association_is_rejected() {
+        // A `through = <join_table>` association's fk names a column on the
+        // join table, not on the target model, so the emitted cascade would
+        // call the target repo's `__autumn_apply_dependent_on_conn` with a
+        // column that does not exist there (e.g. `tags.post_id`) — deleting /
+        // nullifying the wrong rows. Reject the combination directed rather
+        // than silently mis-cascading (Codex P2).
+        let model: syn::Ident = syn::parse_quote!(Post);
+        let attrs: Vec<syn::Attribute> =
+            vec![syn::parse_quote!(#[has_many(Tag, through = post_tags, dependent = destroy)])];
+        let Err(err) = resolve_associations(&model, &attrs) else {
+            panic!("expected an error");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("through"),
+            "expected a through-specific rejection, got: {msg}"
+        );
+        assert!(
+            msg.contains("dependent") || msg.contains("on_delete"),
+            "expected the cascade key named, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn on_delete_on_through_association_is_rejected() {
+        // The `on_delete =` alias is rejected on a `through =` association for
+        // the same reason as `dependent =` (Codex P2).
+        let model: syn::Ident = syn::parse_quote!(Post);
+        let attrs: Vec<syn::Attribute> =
+            vec![syn::parse_quote!(#[has_many(Tag, through = post_tags, on_delete = nullify)])];
+        assert!(resolve_associations(&model, &attrs).is_err());
     }
 
     #[test]

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -57,6 +57,42 @@ enum AssocKind {
     HasOne,
 }
 
+/// The `dependent = <action>` / `on_delete = <action>` cascade action declared
+/// on a model `#[has_many]` / `#[has_one]` association (#1738). Mirrors the
+/// repository-attribute `on_delete` actions one-for-one.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum DependentAction {
+    Destroy,
+    DeleteAll,
+    Nullify,
+    Restrict,
+}
+
+impl DependentAction {
+    /// Parse the spelling accepted after `dependent =` / `on_delete =`. Returns
+    /// `None` for an unknown action so the caller can emit a directed error.
+    fn parse(action: &str) -> Option<Self> {
+        match action {
+            "destroy" => Some(Self::Destroy),
+            "delete_all" => Some(Self::DeleteAll),
+            "nullify" => Some(Self::Nullify),
+            "restrict" => Some(Self::Restrict),
+            _ => None,
+        }
+    }
+
+    /// The `::autumn_web::repository::DependentAction` variant token.
+    fn variant_ident(self) -> proc_macro2::Ident {
+        let name = match self {
+            Self::Destroy => "Destroy",
+            Self::DeleteAll => "DeleteAll",
+            Self::Nullify => "Nullify",
+            Self::Restrict => "Restrict",
+        };
+        format_ident!("{name}")
+    }
+}
+
 /// A resolved association declaration: kind, target model, the (possibly
 /// inferred) foreign-key column, and the accessor/store name.
 struct Association {
@@ -74,6 +110,12 @@ struct Association {
     /// association: the join table this association is preloaded/mutated
     /// through, plus the join table's column pointing at the target model.
     through: Option<ThroughSpec>,
+    /// The `dependent = <action>` / `on_delete = <action>` cascade action, when
+    /// declared on a `#[has_many]` / `#[has_one]` (#1738). Drives the runtime
+    /// [`AutumnDependents`] impl `#[model]` emits so the parent repository's
+    /// `delete_by_id` cascades this association without a repository-attribute
+    /// `dependent(…)`.
+    dependent: Option<DependentAction>,
 }
 
 /// The join-table half of a many-to-many `has_many(..., through = ...)`
@@ -125,46 +167,41 @@ fn resolve_fk_and_name(
 /// associations can target the same model without colliding (e.g.
 /// `#[has_many(Post, fk = author_id, name = authored)]` plus
 /// `#[has_many(Post, fk = approver_id, name = approved)]`).
-/// Diagnose a `dependent = <action>` / `on_delete = <action>` key on a model
-/// association attribute.
+/// Resolve a `dependent = <action>` / `on_delete = <action>` key on a model
+/// association attribute into a validated [`DependentAction`], or a directed
+/// error (#1738).
 ///
-/// Faithfully wiring this model-declared spelling to the cascade machinery
-/// needs a runtime type-erased dispatch refactor (the model spelling names the
-/// child *model*, whereas the cascade needs the child *repository* type), so it
-/// is deferred (#1702). Until then we must not silently accept-and-ignore it:
-/// recognize the spelling, validate the action, and return a directed error —
-/// an unknown-action error for a bad spelling, otherwise guidance toward the
-/// repository-attribute cascade (or, on `#[belongs_to]`, that the key is
-/// meaningless there because the child foreign key lives on that side).
-fn dependent_attr_error(kind: AssocKind, key: &syn::Ident, action: &str) -> syn::Error {
+/// On `#[has_many]` / `#[has_one]` the spelling is now wired: `#[model]` emits a
+/// runtime [`AutumnDependents`] impl so the parent repository's `delete_by_id`
+/// cascades this association (resolving the child repository via the
+/// `Pg{Child}Repository` naming convention) — the same transactional cascade
+/// the repository-attribute `dependent(PgChildRepository, …)` form produces. An
+/// unknown action is still rejected. On `#[belongs_to]` the key remains an
+/// error: the child foreign key lives on that side, so there is no dependent to
+/// cascade.
+fn parse_dependent_action(
+    kind: AssocKind,
+    key: &syn::Ident,
+    action: &str,
+) -> syn::Result<DependentAction> {
     if kind == AssocKind::BelongsTo {
-        return syn::Error::new_spanned(
+        return Err(syn::Error::new_spanned(
             key,
             "`dependent`/`on_delete` is not valid on `#[belongs_to]`: the child \
              foreign key lives on this (belongs_to) side, so there is no \
              dependent to cascade — declare the cascade on the parent's \
-             `#[has_many]`/`#[has_one]` (and, for now, on the repository \
-             attribute) instead",
-        );
+             `#[has_many]`/`#[has_one]` instead",
+        ));
     }
-    // Accept exactly the actions the repository-attribute `dependent(...)`
-    // parser accepts (see repository.rs).
-    match action {
-        "destroy" | "delete_all" | "nullify" | "restrict" => syn::Error::new_spanned(
-            key,
-            "`dependent = <action>` on `#[has_many]`/`#[has_one]` is not yet \
-             wired; declare the dependent cascade on the repository instead, \
-             e.g. `#[autumn_web::repository(Model, dependent(PgChildRepository, \
-             fk = \"...\", on_delete = <action>))]` (see issue #1702)",
-        ),
-        other => syn::Error::new_spanned(
+    DependentAction::parse(action).ok_or_else(|| {
+        syn::Error::new_spanned(
             key,
             format!(
-                "unknown dependent action `{other}`; expected one of \
+                "unknown dependent action `{action}`; expected one of \
                  `destroy`, `delete_all`, `nullify`, `restrict`"
             ),
-        ),
-    }
+        )
+    })
 }
 
 fn parse_assoc_attr(
@@ -174,13 +211,14 @@ fn parse_assoc_attr(
 ) -> syn::Result<Association> {
     use syn::parse::ParseStream;
 
-    let (target, explicit_fk, explicit_name, explicit_through, explicit_target_fk) = attr
-        .parse_args_with(|input: ParseStream| {
+    let (target, explicit_fk, explicit_name, explicit_through, explicit_target_fk, dependent) =
+        attr.parse_args_with(|input: ParseStream| {
             let target: syn::Ident = input.parse()?;
             let mut explicit_fk: Option<String> = None;
             let mut explicit_name: Option<String> = None;
             let mut explicit_through: Option<String> = None;
             let mut explicit_target_fk: Option<String> = None;
+            let mut dependent: Option<DependentAction> = None;
             // Zero or more trailing `, key = value` pairs (`fk`, `name`,
             // `through`, `target_fk`), any order.
             while input.peek(syn::Token![,]) {
@@ -203,7 +241,7 @@ fn parse_assoc_attr(
                 } else if key == "target_fk" {
                     explicit_target_fk = Some(value);
                 } else if key == "dependent" || key == "on_delete" {
-                    return Err(dependent_attr_error(kind, &key, &value));
+                    dependent = Some(parse_dependent_action(kind, &key, &value)?);
                 } else {
                     return Err(syn::Error::new_spanned(
                         &key,
@@ -219,6 +257,7 @@ fn parse_assoc_attr(
                 explicit_name,
                 explicit_through,
                 explicit_target_fk,
+                dependent,
             ))
         })?;
 
@@ -252,6 +291,7 @@ fn parse_assoc_attr(
         fk,
         name,
         through,
+        dependent,
     })
 }
 
@@ -331,6 +371,96 @@ fn is_association_attr(attr: &syn::Attribute) -> bool {
     attr.path().is_ident("belongs_to")
         || attr.path().is_ident("has_many")
         || attr.path().is_ident("has_one")
+}
+
+/// Emit the inherent `dependents()` associated function on the model (#1738):
+/// the runtime dependent-cascade specs the parent repository's generated
+/// `delete_by_id` iterates. Only produced when at least one `#[has_many]` /
+/// `#[has_one]` association declares `dependent = <action>`; otherwise the
+/// blanket [`AutumnDependents`] impl supplies an empty slice and this emits
+/// nothing (so a model without dependents keeps its exact prior codegen).
+///
+/// Each dependent association resolves its child repository through the
+/// `Pg{Child}Repository` naming convention and generates a type-erased thunk
+/// into that repository's `__autumn_apply_dependent_on_conn` leaf executor. The
+/// thunk owns the child repository across the (immediately awaited) cascade,
+/// mirroring the repository-attribute cascade's inline call so the lifetimes of
+/// the borrowed connection / visited set line up.
+fn emit_dependents_impl(model_ident: &syn::Ident, assocs: &[Association]) -> TokenStream {
+    let deps: Vec<&Association> = assocs.iter().filter(|a| a.dependent.is_some()).collect();
+    if deps.is_empty() {
+        return quote! {};
+    }
+
+    let mut thunk_fns: Vec<TokenStream> = Vec::new();
+    let mut spec_entries: Vec<TokenStream> = Vec::new();
+    for (i, assoc) in deps.iter().enumerate() {
+        let action = assoc.dependent.expect("filtered to Some above");
+        let action_variant = action.variant_ident();
+        let fk = &assoc.fk;
+        // Naming convention: the child model `Comment` is served by
+        // `PgCommentRepository` (its `#[repository]` trait `CommentRepository`
+        // expands to `Pg{trait}`). A child whose repository does not follow this
+        // convention (or lives in another crate) uses the repository-attribute
+        // `dependent(...)` escape hatch instead.
+        let child_repo = format_ident!("Pg{}Repository", assoc.target);
+        let thunk_ident = format_ident!("__autumn_dependent_cascade_{}", i);
+        thunk_fns.push(quote! {
+            fn #thunk_ident<'__a>(
+                __pool: &'__a ::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Pool<
+                    ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                >,
+                __conn: &'__a mut ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                __parent_id: i64,
+                __parent_soft: bool,
+                __visited: &'__a mut ::std::collections::HashSet<(&'static str, i64)>,
+            ) -> ::autumn_web::repository::RuntimeDependentCascadeFuture<'__a> {
+                ::std::boxed::Box::pin(async move {
+                    // Own the child repository inside the async block so the
+                    // borrow `__autumn_apply_dependent_on_conn` takes of it stays
+                    // valid for the whole (immediately awaited) cascade.
+                    let __autumn_child_repo = #child_repo::with_pool_untracked(
+                        ::core::clone::Clone::clone(__pool),
+                    );
+                    __autumn_child_repo
+                        .__autumn_apply_dependent_on_conn(
+                            __conn,
+                            #fk,
+                            __parent_id,
+                            ::autumn_web::repository::DependentAction::#action_variant,
+                            __parent_soft,
+                            __visited,
+                        )
+                        .await
+                })
+            }
+        });
+        spec_entries.push(quote! {
+            ::autumn_web::repository::RuntimeDependentSpec {
+                fk: #fk,
+                action: ::autumn_web::repository::DependentAction::#action_variant,
+                cascade: #thunk_ident,
+            }
+        });
+    }
+
+    quote! {
+        impl #model_ident {
+            /// Runtime dependent-cascade specs consulted by the parent
+            /// repository's generated `delete_by_id` (#1738). An inherent shadow
+            /// of `AutumnDependents::dependents`; framework plumbing, not a
+            /// public API.
+            #[doc(hidden)]
+            #[must_use]
+            pub fn dependents() -> &'static [::autumn_web::repository::RuntimeDependentSpec] {
+                #(#thunk_fns)*
+                const __AUTUMN_DEPENDENTS: &[::autumn_web::repository::RuntimeDependentSpec] = &[
+                    #(#spec_entries),*
+                ];
+                __AUTUMN_DEPENDENTS
+            }
+        }
+    }
 }
 
 /// Generate everything needed to make a model's associations preloadable:
@@ -2610,6 +2740,7 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         Err(err) => return err.to_compile_error(),
     };
     let association_items = emit_association_items(name, &table_ident, vis, &associations);
+    let dependents_impl = emit_dependents_impl(name, &associations);
 
     let filtered_outer_attrs: Vec<&syn::Attribute> = outer_attrs
         .iter()
@@ -4611,6 +4742,9 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         // ── Associations + eager loading (belongs_to / has_many / has_one) ──
         #preload_retain_impl
         #association_items
+
+        // ── Model-declared dependent cascade specs (#1738) ──────────────────
+        #dependents_impl
     }
 }
 
@@ -4891,51 +5025,35 @@ mod tests {
         assert!(resolve_associations(&model, &attrs).is_err());
     }
 
-    // ── `dependent` / `on_delete` on model associations (#1702) ──────────
-    // The full model-declared cascade wiring is deferred (it needs a
-    // runtime type-erased dispatch refactor). Until then the parser must
-    // RECOGNIZE the `dependent = <action>` / `on_delete = <action>` spelling,
-    // validate the action, and emit a DIRECTED error pointing users at the
-    // repository-attribute cascade — never silently accept-and-ignore it.
+    // ── `dependent` / `on_delete` on model associations (#1738) ──────────
+    // The model-declared cascade is now wired: the parser RECOGNIZES the
+    // `dependent = <action>` / `on_delete = <action>` spelling on
+    // `#[has_many]` / `#[has_one]`, validates the action, and records it on the
+    // association so `#[model]` can emit the runtime `AutumnDependents` dispatch.
+    // An unknown action is still rejected; `#[belongs_to]` still errors.
 
     #[test]
-    fn has_many_dependent_destroy_directs_to_repository() {
+    fn has_many_dependent_destroy_is_recorded() {
         let model: syn::Ident = syn::parse_quote!(Post);
         let attrs: Vec<syn::Attribute> =
             vec![syn::parse_quote!(#[has_many(Comment, dependent = destroy)])];
-        let Err(err) = resolve_associations(&model, &attrs) else {
-            panic!("expected an error");
-        };
-        let msg = err.to_string();
-        assert!(
-            msg.contains("repository"),
-            "expected directed guidance toward the repository attribute, got: {msg}"
-        );
-        assert!(
-            msg.contains("#1702"),
-            "expected the issue reference #1702, got: {msg}"
-        );
+        let assocs = resolve_associations(&model, &attrs).expect("parse ok");
+        assert_eq!(assocs.len(), 1);
+        assert_eq!(assocs[0].kind, AssocKind::HasMany);
+        assert_eq!(assocs[0].fk, "post_id");
+        assert_eq!(assocs[0].dependent, Some(DependentAction::Destroy));
     }
 
     #[test]
-    fn has_many_on_delete_destroy_directs_to_repository() {
+    fn has_many_on_delete_destroy_is_recorded() {
         // The `on_delete = <action>` spelling is an accepted alias for
-        // `dependent = <action>` and must be directed the same way (#1702).
+        // `dependent = <action>` and records the same action (#1738).
         let model: syn::Ident = syn::parse_quote!(Post);
         let attrs: Vec<syn::Attribute> =
             vec![syn::parse_quote!(#[has_many(Comment, on_delete = destroy)])];
-        let Err(err) = resolve_associations(&model, &attrs) else {
-            panic!("expected an error");
-        };
-        let msg = err.to_string();
-        assert!(
-            msg.contains("repository"),
-            "expected directed guidance toward the repository attribute, got: {msg}"
-        );
-        assert!(
-            msg.contains("#1702"),
-            "expected the issue reference #1702, got: {msg}"
-        );
+        let assocs = resolve_associations(&model, &attrs).expect("parse ok");
+        assert_eq!(assocs.len(), 1);
+        assert_eq!(assocs[0].dependent, Some(DependentAction::Destroy));
     }
 
     #[test]
@@ -4961,21 +5079,46 @@ mod tests {
     }
 
     #[test]
-    fn has_one_dependent_nullify_directs_to_repository() {
+    fn has_one_dependent_nullify_is_recorded() {
         let model: syn::Ident = syn::parse_quote!(User);
         let attrs: Vec<syn::Attribute> =
             vec![syn::parse_quote!(#[has_one(Profile, dependent = nullify)])];
-        let Err(err) = resolve_associations(&model, &attrs) else {
-            panic!("expected an error");
+        let assocs = resolve_associations(&model, &attrs).expect("parse ok");
+        assert_eq!(assocs.len(), 1);
+        assert_eq!(assocs[0].kind, AssocKind::HasOne);
+        assert_eq!(assocs[0].dependent, Some(DependentAction::Nullify));
+    }
+
+    #[test]
+    fn model_emits_dependents_impl_for_declared_cascade() {
+        // The `#[model]` expansion must generate the runtime `AutumnDependents`
+        // dispatch (an inherent `dependents()` returning `RuntimeDependentSpec`s
+        // resolving the child repo via the `Pg{Child}Repository` convention)
+        // rather than erroring, once a `#[has_many(dependent = …)]` is declared.
+        let item: TokenStream = quote! {
+            #[has_many(Comment, dependent = destroy)]
+            struct Post {
+                #[id]
+                id: i64,
+                title: String,
+            }
         };
-        let msg = err.to_string();
+        let generated = model_macro(quote! {}, item).to_string();
         assert!(
-            msg.contains("repository"),
-            "expected directed guidance toward the repository attribute, got: {msg}"
+            generated.contains("fn dependents"),
+            "expected an inherent dependents() fn, got: {generated}"
         );
         assert!(
-            msg.contains("#1702"),
-            "expected the issue reference #1702, got: {msg}"
+            generated.contains("RuntimeDependentSpec"),
+            "expected RuntimeDependentSpec entries, got: {generated}"
+        );
+        assert!(
+            generated.contains("PgCommentRepository"),
+            "expected the child repo resolved by convention, got: {generated}"
+        );
+        assert!(
+            generated.contains("__autumn_apply_dependent_on_conn"),
+            "expected the cascade thunk to call the leaf executor, got: {generated}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -2317,11 +2317,32 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                          out a derived query with a borrowed parameter; declare the parameter as \
                          an owned type (e.g. String) to enable fan-out, or query a specific shard"
                     );
+                    // Same no-shard-set rejection the owned-param branch and the
+                    // count guard emit: without a shard set, an across-tenant read
+                    // would bind a NULL tenant predicate and silently return a
+                    // PARTIAL single-pool result, so reject rather than fall
+                    // through to `#body` (#1692, #1741).
+                    let no_shard_set_msg = format!(
+                        "cross-shard {fn_ident} requires a configured shard set: across_tenants() \
+                         cannot fan a derived query out across shards without a shard set (the \
+                         repository was built without shard context, e.g. via with_pool_untracked); \
+                         build it with shard context instead"
+                    );
                     derived_impl_methods.push(quote! {
                         async fn #fn_ident(&self, #(#params),*) -> ::autumn_web::AutumnResult<#return_type> {
                             use ::autumn_web::reexports::diesel::prelude::*;
                             use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                            if self.across_tenants && self.__autumn_shards.is_some() {
+                            if self.across_tenants {
+                                // No shard set → would fall through to a partial
+                                // single-pool read; reject like the owned-param
+                                // branch and the count guard (#1741).
+                                if self.__autumn_shards.is_none() {
+                                    return ::core::result::Result::Err(
+                                        ::autumn_web::AutumnError::bad_request_msg(#no_shard_set_msg)
+                                    );
+                                }
+                                // Shard set present, but a borrowed parameter can't
+                                // fan out across shards.
                                 return ::core::result::Result::Err(
                                     ::autumn_web::AutumnError::bad_request_msg(#msg)
                                 );

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1693,17 +1693,19 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
-    // #1740: bulk `delete_many` dependent cascade. `delete_many` historically
-    // bypassed `dependent(...)` entirely (a plain bulk parent delete), silently
-    // orphaning children. These tokens splice the SAME cascade the single-record
-    // delete path runs into both `delete_many_body` codegen branches (hooks and
-    // no-hooks). The whole cascade is gated on `config.dependents` so a repo with
-    // no dependents keeps its exact prior bulk codegen (AC: bulk semantics
-    // preserved). Correctness over raw throughput: children are cascaded per
-    // parent row via the shared `__autumn_apply_dependent_on_conn` helper (so
-    // `destroy` recurses into grandchildren for free, #1739), which is the "per
-    // row" tradeoff called out in the issue.
-    let delete_many_has_deps = !config.dependents.is_empty();
+    // #1740 + Codex P1: bulk `delete_many` dependent cascade. `delete_many`
+    // historically bypassed `dependent(...)` entirely (a plain bulk parent
+    // delete), silently orphaning children. These tokens splice the SAME cascade
+    // the single-record delete path runs into both `delete_many_body` codegen
+    // branches (hooks and no-hooks). A repository-attribute `dependent(...)`
+    // drives it at compile time; a model-declared `#[has_many(dependent = ...)]`
+    // drives it at run time via `Model::dependents()` (Codex P1). A model with no
+    // dependents at all keeps its exact prior bulk codegen (byte-identical plain
+    // path, `()` tx return). Correctness over raw throughput: children are
+    // cascaded per parent row via the shared `__autumn_apply_dependent_on_conn`
+    // helper (so `destroy` recurses into grandchildren for free, #1739), which is
+    // the "per row" tradeoff called out in the issue.
+    //
     // The parent's delete kind drives the child `destroy` cascade: soft when the
     // parent repo is `#[soft_delete]` (its bulk path soft-deletes), hard otherwise.
     let delete_many_parent_soft_lit = if config.soft_delete {
@@ -1779,9 +1781,10 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     .map_err(::autumn_web::AutumnError::from)?;
         }
     };
-    // The cascade block, spliced inside the transaction BEFORE the bulk parent
-    // delete. Restrict probes for every parent run first (a 409 rolls the whole
-    // transaction back before any mutating action), then the mutating dependents.
+    // Shared preamble: preload the affected (tenant/live-filtered, row-locked)
+    // parents and collect their ids, and declare the shared visited set +
+    // deferred-broadcast buffer. Used by BOTH the compile-time (repo-attribute)
+    // and runtime (Codex P1, model-declared) cascade blocks.
     //
     // Codex P2: the shared `__autumn_visited` (table, id) cycle set is NOT
     // pre-seeded with the bulk target ids. Pre-seeding a batch target marks it
@@ -1795,66 +1798,99 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     // it, never pre-skipped. Cycles still terminate (a row already on the destroy
     // path is skipped) and no row is double-deleted (the bulk `id = ANY` delete
     // tolerates a batch target the cascade already removed).
-    let delete_many_cascade = if delete_many_has_deps {
-        quote! {
-            let mut __autumn_visited: ::std::collections::HashSet<(&'static str, i64)> =
-                ::std::collections::HashSet::new();
-            let mut __autumn_dep_broadcasts: ::std::vec::Vec<(::std::string::String, ::std::string::String)> =
-                ::std::vec::Vec::new();
-            let mut __autumn_dep_parent_ids: ::std::vec::Vec<i64> = ::std::vec::Vec::new();
-            for chunk in ids.chunks(1000) {
-                #delete_many_preload_chunk
-                __autumn_dep_parent_ids.extend(__autumn_dep_rows.iter().map(|__r| __r.id));
-            }
-            // Phase 1: probe all `restrict` dependents for every parent first.
-            // (Codex P2: no `__autumn_visited` pre-seed here — see above.)
-            for &__autumn_pid in &__autumn_dep_parent_ids {
-                #(#delete_many_restrict_calls)*
-            }
-            // Phase 2: mutating dependents per parent, in declaration order.
-            for &__autumn_pid in &__autumn_dep_parent_ids {
-                #(#delete_many_mutating_calls)*
+    let delete_many_collect_parents = quote! {
+        let mut __autumn_visited: ::std::collections::HashSet<(&'static str, i64)> =
+            ::std::collections::HashSet::new();
+        let mut __autumn_dep_broadcasts: ::std::vec::Vec<(::std::string::String, ::std::string::String)> =
+            ::std::vec::Vec::new();
+        let mut __autumn_dep_parent_ids: ::std::vec::Vec<i64> = ::std::vec::Vec::new();
+        for chunk in ids.chunks(1000) {
+            #delete_many_preload_chunk
+            __autumn_dep_parent_ids.extend(__autumn_dep_rows.iter().map(|__r| __r.id));
+        }
+    };
+    // Compile-time (repository-attribute `dependent(...)`) bulk cascade, spliced
+    // inside the transaction BEFORE the bulk parent delete. Restrict probes for
+    // every parent run first (a 409 rolls the whole transaction back before any
+    // mutating action), then the mutating dependents.
+    let delete_many_compiletime_cascade = quote! {
+        #delete_many_collect_parents
+        // Phase 1: probe all `restrict` dependents for every parent first.
+        for &__autumn_pid in &__autumn_dep_parent_ids {
+            #(#delete_many_restrict_calls)*
+        }
+        // Phase 2: mutating dependents per parent, in declaration order.
+        for &__autumn_pid in &__autumn_dep_parent_ids {
+            #(#delete_many_mutating_calls)*
+        }
+    };
+    // Runtime (model-declared `#[has_many(dependent = ...)]`) bulk cascade
+    // (Codex P1). When the repository declares NO `dependent(...)`, `delete_many`
+    // must mirror the single-record `delete_by_id` runtime dispatch: walk the
+    // model's `Model::dependents()` specs per parent — restrict-probe first, then
+    // mutating — reusing the SAME leaf executor / boxed-future recursion /
+    // deferred-broadcast buffer as the compile-time path. Requires `__autumn_rt_deps`
+    // (the `Model::dependents()` slice) to be bound in the enclosing scope.
+    let delete_many_runtime_cascade = quote! {
+        #delete_many_collect_parents
+        // Phase 1: probe every parent's `restrict` dependents first.
+        for &__autumn_pid in &__autumn_dep_parent_ids {
+            for __autumn_spec in __autumn_rt_deps.iter().filter(|__s|
+                __s.action == ::autumn_web::repository::DependentAction::Restrict
+            ) {
+                __autumn_dep_broadcasts.extend(
+                    (__autumn_spec.cascade)(
+                        &self.pool,
+                        conn,
+                        __autumn_pid,
+                        #delete_many_parent_soft_lit,
+                        &mut __autumn_visited,
+                    )
+                    .await?
+                );
             }
         }
-    } else {
-        quote! {}
+        // Phase 2: mutating dependents per parent, in declaration order.
+        for &__autumn_pid in &__autumn_dep_parent_ids {
+            for __autumn_spec in __autumn_rt_deps.iter().filter(|__s|
+                __s.action != ::autumn_web::repository::DependentAction::Restrict
+            ) {
+                __autumn_dep_broadcasts.extend(
+                    (__autumn_spec.cascade)(
+                        &self.pool,
+                        conn,
+                        __autumn_pid,
+                        #delete_many_parent_soft_lit,
+                        &mut __autumn_visited,
+                    )
+                    .await?
+                );
+            }
+        }
     };
-    // When dependents exist the transaction returns the deferred child broadcasts
+    // When a cascade runs, the transaction returns the deferred child broadcasts
     // so they can be published post-commit (a rolled-back cascade publishes
-    // nothing); otherwise it returns `()` exactly as before.
-    let delete_many_tx_bind = if delete_many_has_deps {
-        quote! { let __autumn_dep_broadcasts = }
-    } else {
-        quote! {}
-    };
-    let delete_many_tx_ok = if delete_many_has_deps {
-        quote! { Ok(__autumn_dep_broadcasts) }
-    } else {
-        quote! { Ok(()) }
-    };
-    let delete_many_post_publish = if delete_many_has_deps {
-        quote! {
-            ::autumn_web::repository::publish_deferred_dependent_broadcasts(__autumn_dep_broadcasts);
-            // A cascaded `destroy` child may have enqueued a commit hook in the
-            // same transaction; kick the durable dispatcher (idempotent).
-            ::autumn_web::__private::kick_repository_commit_hook_dispatcher(&self.pool);
-        }
-    } else {
-        quote! {}
+    // nothing). These "cascade" variants of the tx bind / return / publish / tail
+    // tokens are shared by the compile-time and runtime cascade forms; the "plain"
+    // (no-cascade) forms return `()` exactly as before (byte-identical bulk
+    // codegen for a model with no dependents at all).
+    let delete_many_cascade_tx_bind = quote! { let __autumn_dep_broadcasts = };
+    let delete_many_cascade_tx_ok = quote! { Ok(__autumn_dep_broadcasts) };
+    let delete_many_cascade_post_publish = quote! {
+        ::autumn_web::repository::publish_deferred_dependent_broadcasts(__autumn_dep_broadcasts);
+        // A cascaded `destroy` child may have enqueued a commit hook in the
+        // same transaction; kick the durable dispatcher (idempotent).
+        ::autumn_web::__private::kick_repository_commit_hook_dispatcher(&self.pool);
     };
     // The no-hooks `delete_many` body ends with the transaction as its tail
-    // expression (`... .await`). With dependents it must instead await-and-bind,
-    // then publish the deferred broadcasts after commit; without dependents it
-    // keeps the exact prior `.await` tail (returning the transaction's Result).
-    let delete_many_no_hooks_tail = if delete_many_has_deps {
-        quote! {
-            ?;
-            ::core::mem::drop(conn);
-            #delete_many_post_publish
-            Ok(())
-        }
-    } else {
-        quote! {}
+    // expression (`... .await`). With a cascade it must instead await-and-bind,
+    // then publish the deferred broadcasts after commit; the plain form keeps the
+    // exact prior `.await` tail (returning the transaction's Result).
+    let delete_many_cascade_no_hooks_tail = quote! {
+        ?;
+        ::core::mem::drop(conn);
+        #delete_many_cascade_post_publish
+        Ok(())
     };
 
     // Parse derived query methods from trait body
@@ -6298,57 +6334,101 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 quote! {}
             };
 
-            quote! {
-                use ::autumn_web::reexports::diesel::prelude::*;
-                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                use ::autumn_web::reexports::diesel_async::AsyncConnection;
-                use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
-                use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks};
+            // The bulk delete body is parameterized on its cascade tokens so it
+            // can be emitted twice under runtime dispatch (Codex P1): a plain
+            // no-cascade form (tx returns `()`) and a runtime-cascade form (tx
+            // returns the deferred broadcasts). A repository-attribute
+            // `dependent(...)` instead emits it once with the compile-time cascade.
+            let build_delete_many_body =
+                |delete_many_cascade: &proc_macro2::TokenStream,
+                 delete_many_tx_bind: &proc_macro2::TokenStream,
+                 delete_many_tx_ok: &proc_macro2::TokenStream,
+                 delete_many_post_publish: &proc_macro2::TokenStream| {
+                    quote! {
+                        use ::autumn_web::reexports::diesel::prelude::*;
+                        use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                        use ::autumn_web::reexports::diesel_async::AsyncConnection;
+                        use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
+                        use ::autumn_web::hooks::{MutationContext, MutationOp, MutationHooks};
 
-                if ids.is_empty() {
-                    return Ok(());
-                }
-
-                #tenant_id_setup
-                let mut conn = self.__autumn_acquire_conn().await?;
-                let __now = ::autumn_web::reexports::chrono::Utc::now().naive_utc();
-
-                #delete_many_tx_bind ::autumn_web::__private::scoped_transaction::<_, ::autumn_web::AutumnError, _, _>(&mut *conn, |conn| {
-                    async move {
-                        let mut current_rows = Vec::new();
-                        for chunk in ids.chunks(1000) {
-                            let load_query = #table_ident::table.filter(#table_ident::id.eq_any(chunk))
-                                .order(#table_ident::id.asc());
-                            let chunk_rows = #load_expr
-                                .map_err(::autumn_web::AutumnError::from)?;
-                            current_rows.extend(chunk_rows);
+                        if ids.is_empty() {
+                            return Ok(());
                         }
 
-                        for record in &current_rows {
-                            let mut ctx = MutationContext::new(MutationOp::Delete);
-                            #idempotency_setup
-                            self.hooks.before_delete(&mut ctx, record).await?;
-                            #delete_commit_hook_setup
-                        }
+                        #tenant_id_setup
+                        let mut conn = self.__autumn_acquire_conn().await?;
+                        let __now = ::autumn_web::reexports::chrono::Utc::now().naive_utc();
 
-                        // #1740: cascade dependent actions for every parent BEFORE
-                        // the bulk parent delete, so no child is orphaned and the
-                        // parent delete never trips a foreign-key constraint.
-                        #delete_many_cascade
+                        #delete_many_tx_bind ::autumn_web::__private::scoped_transaction::<_, ::autumn_web::AutumnError, _, _>(&mut *conn, |conn| {
+                            async move {
+                                let mut current_rows = Vec::new();
+                                for chunk in ids.chunks(1000) {
+                                    let load_query = #table_ident::table.filter(#table_ident::id.eq_any(chunk))
+                                        .order(#table_ident::id.asc());
+                                    let chunk_rows = #load_expr
+                                        .map_err(::autumn_web::AutumnError::from)?;
+                                    current_rows.extend(chunk_rows);
+                                }
 
-                        #delete_execution
+                                for record in &current_rows {
+                                    let mut ctx = MutationContext::new(MutationOp::Delete);
+                                    #idempotency_setup
+                                    self.hooks.before_delete(&mut ctx, record).await?;
+                                    #delete_commit_hook_setup
+                                }
 
-                        #delete_many_tx_ok
+                                // #1740: cascade dependent actions for every parent BEFORE
+                                // the bulk parent delete, so no child is orphaned and the
+                                // parent delete never trips a foreign-key constraint.
+                                #delete_many_cascade
+
+                                #delete_execution
+
+                                #delete_many_tx_ok
+                            }
+                            .scope_boxed()
+                        })
+                        .await?;
+
+                        ::core::mem::drop(conn);
+                        #kick_dispatcher
+                        #delete_many_post_publish
+
+                        Ok(())
                     }
-                    .scope_boxed()
-                })
-                .await?;
-
-                ::core::mem::drop(conn);
-                #kick_dispatcher
-                #delete_many_post_publish
-
-                Ok(())
+                };
+            // Codex P1: with no repository-attribute `dependent(...)`, dispatch the
+            // bulk cascade at run time via the model's `Model::dependents()` — empty
+            // (blanket) for a model with no dependents, so the byte-identical plain
+            // path runs and the tx still returns `()`; non-empty for a model-declared
+            // `#[has_many(dependent = ...)]`, so the runtime cascade runs. A
+            // repository-attribute `dependent(...)` keeps its authoritative
+            // compile-time cascade (precedence, mirroring `delete_by_id`).
+            if config.dependents.is_empty() {
+                let __plain =
+                    build_delete_many_body(&quote! {}, &quote! {}, &quote! { Ok(()) }, &quote! {});
+                let __runtime = build_delete_many_body(
+                    &delete_many_runtime_cascade,
+                    &delete_many_cascade_tx_bind,
+                    &delete_many_cascade_tx_ok,
+                    &delete_many_cascade_post_publish,
+                );
+                quote! {
+                    use ::autumn_web::repository::AutumnDependents as _;
+                    let __autumn_rt_deps = #model_name::dependents();
+                    if __autumn_rt_deps.is_empty() {
+                        #__plain
+                    } else {
+                        #__runtime
+                    }
+                }
+            } else {
+                build_delete_many_body(
+                    &delete_many_compiletime_cascade,
+                    &delete_many_cascade_tx_bind,
+                    &delete_many_cascade_tx_ok,
+                    &delete_many_cascade_post_publish,
+                )
             }
         };
 
@@ -7920,35 +8000,79 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 (loop_ts, quote! {})
             };
 
-            quote! {
-                use ::autumn_web::reexports::diesel::prelude::*;
-                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-                use ::autumn_web::reexports::diesel_async::AsyncConnection;
-                use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
+            // Parameterized on its cascade tokens so it can be emitted twice under
+            // runtime dispatch (Codex P1): a plain no-cascade form whose tx tail
+            // returns `()`, and a runtime-cascade form that binds/publishes the
+            // deferred broadcasts. A repository-attribute `dependent(...)` emits it
+            // once with the compile-time cascade.
+            let build_delete_many_body =
+                |delete_many_cascade: &proc_macro2::TokenStream,
+                 delete_many_tx_bind: &proc_macro2::TokenStream,
+                 delete_many_tx_ok: &proc_macro2::TokenStream,
+                 delete_many_no_hooks_tail: &proc_macro2::TokenStream| {
+                    quote! {
+                        use ::autumn_web::reexports::diesel::prelude::*;
+                        use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                        use ::autumn_web::reexports::diesel_async::AsyncConnection;
+                        use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
 
-                if ids.is_empty() {
-                    return Ok(());
-                }
+                        if ids.is_empty() {
+                            return Ok(());
+                        }
 
-                #tenant_id_setup
-                let mut conn = self.__autumn_acquire_conn().await?;
-                let __now = ::autumn_web::reexports::chrono::Utc::now().naive_utc();
+                        #tenant_id_setup
+                        let mut conn = self.__autumn_acquire_conn().await?;
+                        let __now = ::autumn_web::reexports::chrono::Utc::now().naive_utc();
 
-                #delete_many_tx_bind ::autumn_web::__private::scoped_transaction::<_, ::autumn_web::AutumnError, _, _>(&mut *conn, |conn| {
-                    async move {
-                        // #1740: cascade dependent actions for every parent BEFORE
-                        // the bulk parent delete (empty for repos with no
-                        // dependents, preserving the prior bulk codegen).
-                        #delete_many_cascade
-                        #vh_delete_load_before
-                        #delete_loop
-                        #vh_delete_filter
-                        #vh_delete_write
-                        #delete_many_tx_ok
+                        #delete_many_tx_bind ::autumn_web::__private::scoped_transaction::<_, ::autumn_web::AutumnError, _, _>(&mut *conn, |conn| {
+                            async move {
+                                // #1740: cascade dependent actions for every parent BEFORE
+                                // the bulk parent delete (empty for repos with no
+                                // dependents, preserving the prior bulk codegen).
+                                #delete_many_cascade
+                                #vh_delete_load_before
+                                #delete_loop
+                                #vh_delete_filter
+                                #vh_delete_write
+                                #delete_many_tx_ok
+                            }
+                            .scope_boxed()
+                        })
+                        .await #delete_many_no_hooks_tail
                     }
-                    .scope_boxed()
-                })
-                .await #delete_many_no_hooks_tail
+                };
+            // Codex P1: with no repository-attribute `dependent(...)`, dispatch the
+            // bulk cascade at run time via `Model::dependents()` — empty (blanket)
+            // for a model with no dependents, so the byte-identical plain path runs
+            // (tx returns `()` as before); non-empty for a model-declared
+            // `#[has_many(dependent = ...)]`, so the runtime cascade runs. A
+            // repository-attribute `dependent(...)` keeps its authoritative
+            // compile-time cascade (precedence, mirroring `delete_by_id`).
+            if config.dependents.is_empty() {
+                let __plain =
+                    build_delete_many_body(&quote! {}, &quote! {}, &quote! { Ok(()) }, &quote! {});
+                let __runtime = build_delete_many_body(
+                    &delete_many_runtime_cascade,
+                    &delete_many_cascade_tx_bind,
+                    &delete_many_cascade_tx_ok,
+                    &delete_many_cascade_no_hooks_tail,
+                );
+                quote! {
+                    use ::autumn_web::repository::AutumnDependents as _;
+                    let __autumn_rt_deps = #model_name::dependents();
+                    if __autumn_rt_deps.is_empty() {
+                        #__plain
+                    } else {
+                        #__runtime
+                    }
+                }
+            } else {
+                build_delete_many_body(
+                    &delete_many_compiletime_cascade,
+                    &delete_many_cascade_tx_bind,
+                    &delete_many_cascade_tx_ok,
+                    &delete_many_cascade_no_hooks_tail,
+                )
             }
         };
 
@@ -15257,6 +15381,49 @@ mod tests {
         assert!(
             !section.contains("AutumnDependents"),
             "repository-attribute delete_by_id must not runtime-dispatch (repo-attr wins): {section}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_without_dependents_delete_many_dispatches_at_runtime() {
+        // Codex P1: with no repository-attribute `dependent(...)`, the bulk
+        // `delete_many` path must consult the model's runtime `dependents()`
+        // (empty for a model with no `#[has_many(dependent = ...)]`, so the plain
+        // bulk path runs) instead of emitting a compile-time cascade call. This
+        // mirrors the single-record `delete_by_id` runtime dispatch.
+        let generated =
+            repository_macro(quote! { Post }, quote! { pub trait PostRepository {} }).to_string();
+        let section = delete_many_section(&generated);
+        assert!(
+            !section.contains("__autumn_apply_dependent_on_conn"),
+            "delete_many must not emit a compile-time cascade call when no \
+             dependent(...) is declared: {section}"
+        );
+        assert!(
+            section.contains("dependents") && section.contains("AutumnDependents"),
+            "delete_many must consult the model's runtime dependents() for the \
+             model-declared bulk cascade (Codex P1): {section}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_with_dependents_delete_many_does_not_runtime_dispatch() {
+        // Precedence (Codex P1): a repository-attribute `dependent(...)` is the
+        // authoritative escape hatch. Its delete_many uses the compile-time
+        // cascade and must NOT also consult the model's runtime dependents().
+        let generated = repository_macro(
+            quote! { Post, dependent(PgCommentRepository, fk = "post_id", on_delete = destroy) },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+        let section = delete_many_section(&generated);
+        assert!(
+            section.contains("__autumn_apply_dependent_on_conn"),
+            "repository-attribute delete_many must emit the compile-time cascade: {section}"
+        );
+        assert!(
+            !section.contains("AutumnDependents"),
+            "repository-attribute delete_many must not runtime-dispatch (repo-attr wins): {section}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1782,6 +1782,19 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     // The cascade block, spliced inside the transaction BEFORE the bulk parent
     // delete. Restrict probes for every parent run first (a 409 rolls the whole
     // transaction back before any mutating action), then the mutating dependents.
+    //
+    // Codex P2: the shared `__autumn_visited` (table, id) cycle set is NOT
+    // pre-seeded with the bulk target ids. Pre-seeding a batch target marks it
+    // visited before it is actually processed, so for a self-referential
+    // `dependent = destroy` graph an ancestor's cascade would skip a descendant
+    // batch target that still references a not-yet-deleted intermediate node —
+    // and deleting that intermediate would then trip an IMMEDIATE foreign-key
+    // constraint mid-transaction. Instead the visited set is populated naturally
+    // AS each row is destroyed (by the Destroy arm), so a descendant referenced
+    // by an intermediate is cascaded — deepest first — when the ancestor reaches
+    // it, never pre-skipped. Cycles still terminate (a row already on the destroy
+    // path is skipped) and no row is double-deleted (the bulk `id = ANY` delete
+    // tolerates a batch target the cascade already removed).
     let delete_many_cascade = if delete_many_has_deps {
         quote! {
             let mut __autumn_visited: ::std::collections::HashSet<(&'static str, i64)> =
@@ -1794,8 +1807,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 __autumn_dep_parent_ids.extend(__autumn_dep_rows.iter().map(|__r| __r.id));
             }
             // Phase 1: probe all `restrict` dependents for every parent first.
+            // (Codex P2: no `__autumn_visited` pre-seed here — see above.)
             for &__autumn_pid in &__autumn_dep_parent_ids {
-                __autumn_visited.insert((#table_name, __autumn_pid));
                 #(#delete_many_restrict_calls)*
             }
             // Phase 2: mutating dependents per parent, in declaration order.
@@ -15059,6 +15072,17 @@ mod tests {
         &rest[..end]
     }
 
+    /// Helper: slice the generated `delete_many` trait-impl body (up to the next
+    /// `async fn`) so assertions target the bulk delete path.
+    fn delete_many_section(generated: &str) -> &str {
+        let start = generated
+            .find("async fn delete_many")
+            .expect("repository must generate delete_many");
+        let rest = &generated[start + "async fn delete_many".len()..];
+        let end = rest.find("async fn ").map_or(rest.len(), |p| p);
+        &rest[..end]
+    }
+
     /// Helper: slice the `Destroy` match arm of the generated
     /// `__autumn_apply_dependent_on_conn` helper, bounded to the helper method
     /// (which ends right before the always-generated `pub fn on_primary`), so
@@ -15233,6 +15257,34 @@ mod tests {
         assert!(
             !section.contains("AutumnDependents"),
             "repository-attribute delete_by_id must not runtime-dispatch (repo-attr wins): {section}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_delete_many_does_not_preseed_bulk_targets_in_visited() {
+        // Codex P2: the bulk `delete_many` cascade must NOT pre-seed the shared
+        // `__autumn_visited` cycle set with the batch target ids. Pre-seeding a
+        // descendant batch target makes an ancestor's cascade skip it, so for a
+        // self-referential `dependent = destroy` graph the still-referenced row is
+        // not removed before its intermediate parent is deleted → an immediate FK
+        // violation. The visited set must instead be populated naturally as each
+        // row is destroyed. Assert the bulk cascade issues NO `__autumn_visited`
+        // pre-insert (the only inserts happen inside the Destroy leaf executor).
+        let generated = repository_macro(
+            quote! { Node, dependent(PgNodeRepository, fk = "parent_id", on_delete = destroy) },
+            quote! { pub trait NodeRepository {} },
+        )
+        .to_string();
+        let section = delete_many_section(&generated);
+        assert!(
+            section.contains("__autumn_apply_dependent_on_conn"),
+            "the bulk delete_many path must cascade dependents: {section}"
+        );
+        assert!(
+            !section.contains("__autumn_visited . insert"),
+            "Codex P2: delete_many must not pre-seed batch target ids into the \
+             visited set (that skips still-referenced self-ref descendants and \
+             trips an immediate FK): {section}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1379,7 +1379,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             __cid,
                             ::autumn_web::repository::DependentAction::#action_variant,
                             #child_soft_for_grandchildren,
-                            __visited,
+                            __path,
+                            __deleted,
                         ).await?
                     );
                 }
@@ -1399,9 +1400,15 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             .collect();
         // #1739 (repo-attribute deps): compile-time recursion over
         // `config.dependents`. Emitted ONLY when this repo declares
-        // `dependent(...)`.
-        let compiletime_grandchild_cascade = quote! {
+        // `dependent(...)`. Codex round-5-A: the restrict PROBE and the mutating
+        // cascade are split into two token blocks so the caller can run the
+        // read-only restrict probe BEFORE the child's `before_delete` hook and
+        // the mutating (destroy/nullify) grandchildren AFTER it — see the Destroy
+        // arm below.
+        let compiletime_grandchild_restrict = quote! {
             #(#grandchild_restrict_calls)*
+        };
+        let compiletime_grandchild_mutating = quote! {
             #(#grandchild_mutating_calls)*
         };
         // Codex P1 (model-side deps): when this repo has NO repository-attribute
@@ -1419,7 +1426,12 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         // the `__ret_broadcasts` deferred-broadcast buffer for grandchild
         // broadcasts. For a model with no dependents this is a cheap no-op that
         // iterates an empty `&[]`, so the plain path stays behavior-equivalent.
-        let runtime_grandchild_cascade = quote! {
+        // Codex round-5-A: same restrict/mutating split as the compile-time path,
+        // for the model-declared runtime walk. `__autumn_gc_rt_deps` is bound in
+        // the restrict block and reused by the mutating block — the two are always
+        // emitted together (runtime pairing) and in that order in the Destroy arm,
+        // so the binding is in scope for the mutating loop.
+        let runtime_grandchild_restrict = quote! {
             // Inherent `dependents()` (real specs) shadows the blanket trait
             // method (empty); unqualified so the shadow wins, `&[]` otherwise.
             let __autumn_gc_rt_deps = #model_name::dependents();
@@ -1432,10 +1444,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         conn,
                         __cid,
                         #child_soft_for_grandchildren,
-                        __visited,
+                        __path,
+                        __deleted,
                     ).await?
                 );
             }
+        };
+        let runtime_grandchild_mutating = quote! {
             for __autumn_gc_spec in __autumn_gc_rt_deps.iter().filter(|__s|
                 __s.action != ::autumn_web::repository::DependentAction::Restrict
             ) {
@@ -1445,7 +1460,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         conn,
                         __cid,
                         #child_soft_for_grandchildren,
-                        __visited,
+                        __path,
+                        __deleted,
                     ).await?
                 );
             }
@@ -1454,11 +1470,18 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         // repository-attribute `config.dependents` WINS when present. So with
         // repo-attribute deps we emit the #1739 compile-time recursion ONLY; with
         // none we walk the runtime `Model::dependents()` ONLY. A grandchild is
-        // therefore never processed by both paths.
-        let grandchild_cascade = if has_dependents {
-            compiletime_grandchild_cascade
+        // therefore never processed by both paths. Codex round-5-A: the restrict
+        // probe and mutating cascade are chosen as a matching pair so the Destroy
+        // arm can bracket the child `before_delete` hook between them.
+        let grandchild_restrict_cascade = if has_dependents {
+            compiletime_grandchild_restrict
         } else {
-            runtime_grandchild_cascade
+            runtime_grandchild_restrict
+        };
+        let grandchild_mutating_cascade = if has_dependents {
+            compiletime_grandchild_mutating
+        } else {
+            runtime_grandchild_mutating
         };
         // `use AutumnDependents` brings the blanket `dependents()` fallback into
         // scope for the runtime walk (models without dependents), matching the
@@ -1543,6 +1566,10 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             // the recursive edge behind a trait object whose `Send` is axiomatic,
             // breaking the cycle while keeping the cascade `Send`.
             #[doc(hidden)]
+            // Codex round-5-B split the single cycle set into an active-path stack
+            // plus a monotonic deleted set, taking this framework-internal helper to
+            // 8 parameters; the extra guard is intentional (see the doc above).
+            #[allow(clippy::too_many_arguments)]
             pub fn __autumn_apply_dependent_on_conn<'__dep>(
                 &'__dep self,
                 conn: &'__dep mut ::autumn_web::reexports::diesel_async::AsyncPgConnection,
@@ -1550,10 +1577,19 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 __parent_id: i64,
                 __action: ::autumn_web::repository::DependentAction,
                 __parent_soft: bool,
-                // #1739: (table, id) rows already entered on the destroy path —
-                // threaded through the recursion to break self-/mutual-referential
-                // cycles. See the Destroy arm's cycle guard below.
-                __visited: &'__dep mut ::std::collections::HashSet<(&'static str, i64)>,
+                // Codex round-5-B: TWO guard sets threaded through the recursion.
+                // `__path` is the ACTIVE recursion stack — a (table, id) is pushed
+                // before descending into its children and popped once its subtree
+                // completes; it breaks self-/mutual-referential cycles ONLY.
+                // `__deleted` is a MONOTONIC set of rows actually removed; a row
+                // already in it is skipped (genuinely gone), so a row reached again
+                // as another root's descendant is neither re-deleted nor re-hooked.
+                // Separating them is what lets a batch process a descendant root
+                // before its ancestor without the ancestor's cascade pre-skipping a
+                // still-referenced intermediate (the removed monotonic-preseed's
+                // immediate-FK bug). See the Destroy arm's guards below.
+                __path: &'__dep mut ::std::collections::HashSet<(&'static str, i64)>,
+                __deleted: &'__dep mut ::std::collections::HashSet<(&'static str, i64)>,
             ) -> ::std::pin::Pin<::std::boxed::Box<
                 dyn ::std::future::Future<
                     Output = ::autumn_web::AutumnResult<
@@ -1650,12 +1686,22 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 .map_err(::autumn_web::AutumnError::from)?;
                         for __row in __ids {
                             let __cid = __row.id;
-                            // #1739 cycle guard: skip a (table, id) already on the
-                            // current destroy path. `insert` returns false when the
-                            // row is already present, so a self- or mutual-reference
-                            // (e.g. a grandchild pointing back at an ancestor) is not
-                            // re-entered and the traversal terminates.
-                            if !__visited.insert((#table_name, __cid)) {
+                            // Codex round-5-B: skip a row already DELETED (genuinely
+                            // gone) — dedup across independent batch roots / branches,
+                            // and prevents re-firing a row's hooks when it is reached
+                            // again as another root's descendant.
+                            if __deleted.contains(&(#table_name, __cid)) {
+                                continue;
+                            }
+                            // #1739 cycle guard (now the ACTIVE-path stack): skip a
+                            // (table, id) already on the current destroy path. `insert`
+                            // returns false when the row is already present, so a self-
+                            // or mutual-reference (e.g. a grandchild pointing back at an
+                            // ancestor) is not re-entered and the traversal terminates.
+                            // Pushed here before descending; popped after this row's
+                            // subtree completes (see the `__path.remove` below), so a
+                            // completed sibling/root never suppresses a later cascade.
+                            if !__path.insert((#table_name, __cid)) {
                                 continue;
                             }
                             // #1369: reload the EXACT id the (parent-soft-gated)
@@ -1675,15 +1721,31 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 .map_err(::autumn_web::AutumnError::from)?;
                             if let ::core::option::Option::Some(__record) = __record {
                                 #destroy_ctx_decl
+                                // Codex round-5-A: probe this child's own `restrict`
+                                // grandchildren (read-only 409) BEFORE firing the
+                                // child's `before_delete` hook — a blocked delete
+                                // then never leaves a non-transactional hook side
+                                // effect behind on a doomed transaction.
+                                #grandchild_restrict_cascade
                                 #destroy_before_delete
-                                // #1739: cascade this child's OWN dependents
+                                // #1739: mutate this child's OWN dependents
                                 // (grandchildren) before removing the child row, so
                                 // a hard delete never leaves an FK-dangling
                                 // grandchild and never FK-fails the child delete.
-                                #grandchild_cascade
+                                #grandchild_mutating_cascade
                                 #destroy_mutation
+                                // Codex round-5-B: the row is now truly removed —
+                                // record it so any later traversal that reaches it
+                                // (another batch root's descendant, a sibling cascade)
+                                // skips it instead of re-deleting / re-hooking.
+                                __deleted.insert((#table_name, __cid));
                                 #destroy_post_mutation
                             }
+                            // Codex round-5-B: pop this row off the ACTIVE path once
+                            // its whole subtree is processed, so it only ever blocks
+                            // re-entry WHILE on the recursion stack (cycle-break), never
+                            // afterwards. Runs whether or not the row was still present.
+                            __path.remove(&(#table_name, __cid));
                         }
                         ::core::result::Result::Ok(#destroy_ret_value)
                     }
@@ -1729,7 +1791,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         __autumn_pid,
                         ::autumn_web::repository::DependentAction::#action_variant,
                         #delete_many_parent_soft_lit,
-                        &mut __autumn_visited,
+                        &mut __autumn_path,
+                        &mut __autumn_deleted,
                     )
                     .await?
             );
@@ -1782,24 +1845,29 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
     // Shared preamble: preload the affected (tenant/live-filtered, row-locked)
-    // parents and collect their ids, and declare the shared visited set +
+    // parents and collect their ids, and declare the two cascade-guard sets +
     // deferred-broadcast buffer. Used by BOTH the compile-time (repo-attribute)
     // and runtime (Codex P1, model-declared) cascade blocks.
     //
-    // Codex P2: the shared `__autumn_visited` (table, id) cycle set is NOT
-    // pre-seeded with the bulk target ids. Pre-seeding a batch target marks it
-    // visited before it is actually processed, so for a self-referential
-    // `dependent = destroy` graph an ancestor's cascade would skip a descendant
-    // batch target that still references a not-yet-deleted intermediate node —
-    // and deleting that intermediate would then trip an IMMEDIATE foreign-key
-    // constraint mid-transaction. Instead the visited set is populated naturally
-    // AS each row is destroyed (by the Destroy arm), so a descendant referenced
-    // by an intermediate is cascaded — deepest first — when the ancestor reaches
-    // it, never pre-skipped. Cycles still terminate (a row already on the destroy
-    // path is skipped) and no row is double-deleted (the bulk `id = ANY` delete
-    // tolerates a batch target the cascade already removed).
+    // Codex round-5-B: the bulk cascade threads TWO guard sets, NOT one monotonic
+    // visited set. `__autumn_path` is the ACTIVE recursion stack (pushed before a
+    // node's own cascade, popped right after — cycle-break ONLY); `__autumn_deleted`
+    // is the monotonic set of rows actually removed. The removed round-2/round-4
+    // monotonic pre-seed marked a batch root visited BEFORE it was deleted, so a
+    // self-referential `dependent = destroy` batch that happened to process a
+    // descendant root before its ancestor made the ancestor's cascade skip that
+    // descendant while deleting the intermediate it still references — tripping an
+    // IMMEDIATE foreign-key constraint. With the split, a descendant root's own
+    // Phase-2 iteration pushes then pops itself on `__autumn_path`, so it is NOT on
+    // the path (and not yet in `__autumn_deleted`) when the ancestor's cascade later
+    // reaches it: the ancestor cascades it deepest-first (no FK), and once it is
+    // truly removed `__autumn_deleted` skips it everywhere after (no double delete,
+    // no double hook — including the bulk-root hook loop, which consults it too).
+    // Cycles still terminate via `__autumn_path`.
     let delete_many_collect_parents = quote! {
-        let mut __autumn_visited: ::std::collections::HashSet<(&'static str, i64)> =
+        let mut __autumn_path: ::std::collections::HashSet<(&'static str, i64)> =
+            ::std::collections::HashSet::new();
+        let mut __autumn_deleted: ::std::collections::HashSet<(&'static str, i64)> =
             ::std::collections::HashSet::new();
         let mut __autumn_dep_broadcasts: ::std::vec::Vec<(::std::string::String, ::std::string::String)> =
             ::std::vec::Vec::new();
@@ -1821,17 +1889,19 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
         // Phase 2: mutating dependents per parent, in declaration order.
         for &__autumn_pid in &__autumn_dep_parent_ids {
-            // Codex round-4: seed ONLY the current bulk root into the shared
-            // visited set IMMEDIATELY before its own mutating destroy cascade
-            // (mirroring how `delete_by_id` seeds its parent). Without this a
-            // self-referential 2-cycle (A.parent_id = B, B.parent_id = A) would
-            // re-enter A through a child's destroy executor and fire A's
-            // hooks/history/broadcasts as a cascaded child before the final bulk
-            // parent delete. Seeding one root at a time (NOT the whole batch — the
-            // removed all-target pre-seed) keeps the round-2 property: a descendant
-            // batch target not yet on the active path is still cascaded deepest-first.
-            __autumn_visited.insert((#table_name, __autumn_pid));
+            // Codex round-5-B: a root already cascade-deleted as ANOTHER root's
+            // descendant is genuinely gone — skip it (its whole subtree was already
+            // handled deepest-first by that ancestor). Do NOT monotonically pre-seed
+            // it; instead push it onto the ACTIVE path only for the span of its own
+            // cascade (cycle-break for a self-referential child pointing back at it),
+            // then pop. A later ancestor can then still cascade this root deepest-first
+            // instead of pre-skipping a still-referenced intermediate (immediate-FK).
+            if __autumn_deleted.contains(&(#table_name, __autumn_pid)) {
+                continue;
+            }
+            __autumn_path.insert((#table_name, __autumn_pid));
             #(#delete_many_mutating_calls)*
+            __autumn_path.remove(&(#table_name, __autumn_pid));
         }
     };
     // Runtime (model-declared `#[has_many(dependent = ...)]`) bulk cascade
@@ -1854,7 +1924,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         conn,
                         __autumn_pid,
                         #delete_many_parent_soft_lit,
-                        &mut __autumn_visited,
+                        &mut __autumn_path,
+                        &mut __autumn_deleted,
                     )
                     .await?
                 );
@@ -1862,16 +1933,15 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
         // Phase 2: mutating dependents per parent, in declaration order.
         for &__autumn_pid in &__autumn_dep_parent_ids {
-            // Codex round-4: seed ONLY the current bulk root into the shared
-            // visited set IMMEDIATELY before its own mutating destroy cascade
-            // (mirroring how `delete_by_id` seeds its parent). Without this a
-            // self-referential 2-cycle (A.parent_id = B, B.parent_id = A) would
-            // re-enter A through a child's destroy executor and fire A's
-            // hooks/history/broadcasts as a cascaded child before the final bulk
-            // parent delete. Seeding one root at a time (NOT the whole batch — the
-            // removed all-target pre-seed) keeps the round-2 property: a descendant
-            // batch target not yet on the active path is still cascaded deepest-first.
-            __autumn_visited.insert((#table_name, __autumn_pid));
+            // Codex round-5-B (mirrors the compile-time block): skip a root already
+            // cascade-deleted as another root's descendant; otherwise bracket its own
+            // cascade with an ACTIVE-path push/pop (cycle-break only), NOT a monotonic
+            // pre-seed — so a later ancestor can still cascade it deepest-first without
+            // pre-skipping a still-referenced intermediate (immediate-FK).
+            if __autumn_deleted.contains(&(#table_name, __autumn_pid)) {
+                continue;
+            }
+            __autumn_path.insert((#table_name, __autumn_pid));
             for __autumn_spec in __autumn_rt_deps.iter().filter(|__s|
                 __s.action != ::autumn_web::repository::DependentAction::Restrict
             ) {
@@ -1881,11 +1951,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         conn,
                         __autumn_pid,
                         #delete_many_parent_soft_lit,
-                        &mut __autumn_visited,
+                        &mut __autumn_path,
+                        &mut __autumn_deleted,
                     )
                     .await?
                 );
             }
+            __autumn_path.remove(&(#table_name, __autumn_pid));
         }
     };
     // When a cascade runs, the transaction returns the deferred child broadcasts
@@ -6384,7 +6456,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 |delete_many_cascade: &proc_macro2::TokenStream,
                  delete_many_tx_bind: &proc_macro2::TokenStream,
                  delete_many_tx_ok: &proc_macro2::TokenStream,
-                 delete_many_post_publish: &proc_macro2::TokenStream| {
+                 delete_many_post_publish: &proc_macro2::TokenStream,
+                 delete_many_root_skip: &proc_macro2::TokenStream| {
                     quote! {
                         use ::autumn_web::reexports::diesel::prelude::*;
                         use ::autumn_web::reexports::diesel_async::RunQueryDsl;
@@ -6411,17 +6484,25 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     current_rows.extend(chunk_rows);
                                 }
 
+                                // #1740: cascade dependent actions for every parent BEFORE
+                                // the bulk parent delete, so no child is orphaned and the
+                                // parent delete never trips a foreign-key constraint.
+                                // Codex round-5-B: the cascade runs FIRST so a batch root
+                                // that is also another root's descendant is deleted (and
+                                // recorded in `__autumn_deleted`) here — its `before_delete`
+                                // fires exactly once as that descendant; the root hook loop
+                                // below then skips it (`#delete_many_root_skip`), avoiding a
+                                // second firing, and the tolerant bulk `id = ANY` delete no
+                                // longer touches it.
+                                #delete_many_cascade
+
                                 for record in &current_rows {
+                                    #delete_many_root_skip
                                     let mut ctx = MutationContext::new(MutationOp::Delete);
                                     #idempotency_setup
                                     self.hooks.before_delete(&mut ctx, record).await?;
                                     #delete_commit_hook_setup
                                 }
-
-                                // #1740: cascade dependent actions for every parent BEFORE
-                                // the bulk parent delete, so no child is orphaned and the
-                                // parent delete never trips a foreign-key constraint.
-                                #delete_many_cascade
 
                                 #delete_execution
 
@@ -6438,6 +6519,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         Ok(())
                     }
                 };
+            // Codex round-5-B: in the cascade forms, a batch root already deleted as
+            // another root's cascaded descendant must be skipped by the root hook
+            // loop (its `before_delete`/commit-hook already fired during the cascade).
+            // The plain (no-cascade) form has no `__autumn_deleted` set, so its skip
+            // token is empty and the loop is byte-identical to the prior codegen.
+            let delete_many_cascade_root_skip = quote! {
+                if __autumn_deleted.contains(&(#table_name, record.id)) { continue; }
+            };
             // Codex P1: with no repository-attribute `dependent(...)`, dispatch the
             // bulk cascade at run time via the model's `Model::dependents()` — empty
             // (blanket) for a model with no dependents, so the byte-identical plain
@@ -6446,13 +6535,19 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             // repository-attribute `dependent(...)` keeps its authoritative
             // compile-time cascade (precedence, mirroring `delete_by_id`).
             if config.dependents.is_empty() {
-                let __plain =
-                    build_delete_many_body(&quote! {}, &quote! {}, &quote! { Ok(()) }, &quote! {});
+                let __plain = build_delete_many_body(
+                    &quote! {},
+                    &quote! {},
+                    &quote! { Ok(()) },
+                    &quote! {},
+                    &quote! {},
+                );
                 let __runtime = build_delete_many_body(
                     &delete_many_runtime_cascade,
                     &delete_many_cascade_tx_bind,
                     &delete_many_cascade_tx_ok,
                     &delete_many_cascade_post_publish,
+                    &delete_many_cascade_root_skip,
                 );
                 quote! {
                     use ::autumn_web::repository::AutumnDependents as _;
@@ -6469,6 +6564,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     &delete_many_cascade_tx_bind,
                     &delete_many_cascade_tx_ok,
                     &delete_many_cascade_post_publish,
+                    &delete_many_cascade_root_skip,
                 )
             }
         };
@@ -8713,12 +8809,16 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             // repository through the `Pg{Child}Repository` convention baked into
             // the spec's `cascade` thunk.
             let runtime_cascade_calls = quote! {
-                // #1739 cycle guard: one visited (table, id) set for the whole
-                // cascade, seeded with this parent row so a grandchild that
-                // references an ancestor terminates instead of looping.
-                let mut __autumn_visited: ::std::collections::HashSet<(&'static str, i64)> =
+                // Codex round-5-B cycle guard: the ACTIVE recursion path, seeded
+                // with this parent row so a grandchild that references an ancestor
+                // is skipped (cycle) instead of looping, plus a monotonic deleted
+                // set. The parent itself is deleted by `#parent_mutation` below, so
+                // it stays on the path for the whole cascade (never popped here).
+                let mut __autumn_path: ::std::collections::HashSet<(&'static str, i64)> =
                     ::std::collections::HashSet::new();
-                __autumn_visited.insert((#table_name, id));
+                let mut __autumn_deleted: ::std::collections::HashSet<(&'static str, i64)> =
+                    ::std::collections::HashSet::new();
+                __autumn_path.insert((#table_name, id));
                 // Phase 1: probe all `restrict` dependents first — a 409 here
                 // rolls back before any mutating action fires a child hook.
                 for __autumn_spec in __autumn_rt_deps.iter().filter(|__s|
@@ -8730,7 +8830,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             conn,
                             id,
                             #parent_soft_lit,
-                            &mut __autumn_visited,
+                            &mut __autumn_path,
+                            &mut __autumn_deleted,
                         )
                         .await?
                     );
@@ -8745,7 +8846,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             conn,
                             id,
                             #parent_soft_lit,
-                            &mut __autumn_visited,
+                            &mut __autumn_path,
+                            &mut __autumn_deleted,
                         )
                         .await?
                     );
@@ -8799,7 +8901,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 id,
                                 ::autumn_web::repository::DependentAction::#action_variant,
                                 #parent_soft_lit,
-                                &mut __autumn_visited,
+                                &mut __autumn_path,
+                                &mut __autumn_deleted,
                             )
                             .await?
                     );
@@ -8818,13 +8921,17 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 .map(&emit_cascade_call)
                 .collect();
             let cascade_calls = quote! {
-                // #1739 cycle guard: one visited (table, id) set for the whole
-                // cascade, seeded with this parent row so a grandchild that
-                // references an ancestor terminates instead of looping. Threaded
-                // by-ref into every `__autumn_apply_dependent_on_conn` call.
-                let mut __autumn_visited: ::std::collections::HashSet<(&'static str, i64)> =
+                // Codex round-5-B cycle guard: the ACTIVE recursion path (seeded
+                // with this parent row so a grandchild referencing an ancestor is
+                // skipped as a cycle, not looped) plus a monotonic deleted set,
+                // both threaded by-ref into every `__autumn_apply_dependent_on_conn`
+                // call. The parent is deleted by `#parent_mutation`, so it stays on
+                // the path for the whole cascade (not popped here).
+                let mut __autumn_path: ::std::collections::HashSet<(&'static str, i64)> =
                     ::std::collections::HashSet::new();
-                __autumn_visited.insert((#table_name, id));
+                let mut __autumn_deleted: ::std::collections::HashSet<(&'static str, i64)> =
+                    ::std::collections::HashSet::new();
+                __autumn_path.insert((#table_name, id));
                 // Phase 1: probe all `restrict` dependents first — a 409 here
                 // rolls back before any mutating action fires a child hook.
                 #(#restrict_calls)*
@@ -15469,22 +15576,17 @@ mod tests {
     }
 
     #[test]
-    fn repository_macro_delete_many_seeds_current_root_before_its_destroy_cascade() {
-        // Codex P2 + round-4: the bulk `delete_many` cascade must NOT pre-seed the
-        // shared `__autumn_visited` cycle set with the WHOLE batch of target ids
-        // (that would make an ancestor's cascade skip a still-referenced descendant
-        // batch target and trip an immediate FK). But it MUST seed the CURRENT root
-        // — one root at a time — immediately before that root's own mutating destroy
-        // cascade, mirroring how `delete_by_id` seeds its parent. Otherwise a
-        // self-referential 2-cycle (A.parent_id = B, B.parent_id = A) re-enters A
-        // through a child's destroy executor and fires A's hooks/history/broadcasts
-        // as a cascaded child before the final bulk parent delete.
-        //
-        // For a `destroy`-only model there is no restrict phase, so the ONLY visited
-        // insert in the bulk section is the per-root Phase-2 seed at the top of the
-        // mutating loop (`for & __autumn_pid ... { __autumn_visited . insert(...)`);
-        // asserting exactly one insert, located there, proves per-root seeding
-        // without the removed all-target pre-seed.
+    fn repository_macro_delete_many_uses_path_and_deleted_not_monotonic_preseed() {
+        // Codex round-5-B: the bulk `delete_many` cascade must NOT use a single
+        // monotonic visited set that pre-seeds a batch root before it is deleted
+        // (that made an ancestor's cascade skip a still-referenced descendant batch
+        // root and trip an IMMEDIATE FK). The old `__autumn_visited` set is gone,
+        // replaced by TWO structures: an ACTIVE-path stack (`__autumn_path`, pushed
+        // then popped around each root's own cascade — cycle-break only) and a
+        // monotonic `__autumn_deleted` set of rows actually removed. Phase 2 must
+        // (a) push the current root onto the path before its mutating cascade,
+        // (b) pop it right after, and (c) skip a root already in `__autumn_deleted`
+        // (cascade-deleted as another root's descendant) — never a pre-seed.
         let generated = repository_macro(
             quote! { Node, dependent(PgNodeRepository, fk = "parent_id", on_delete = destroy) },
             quote! { pub trait NodeRepository {} },
@@ -15495,19 +15597,66 @@ mod tests {
             section.contains("__autumn_apply_dependent_on_conn"),
             "the bulk delete_many path must cascade dependents: {section}"
         );
-        assert_eq!(
-            section.matches("__autumn_visited . insert").count(),
-            1,
-            "round-4: delete_many must seed EXACTLY the current root (one insert), \
-             not pre-seed the whole batch: {section}"
+        assert!(
+            !section.contains("__autumn_visited"),
+            "round-5-B: the monotonic pre-seeded visited set must be gone: {section}"
         );
+        // Phase 2 brackets each root's own cascade with a path push/pop (cycle-break
+        // only) — NOT a monotonic pre-seed.
         assert!(
             section.contains(
-                "for & __autumn_pid in & __autumn_dep_parent_ids { __autumn_visited . insert"
+                "if __autumn_deleted . contains (& (\"nodes\" , __autumn_pid)) { continue ; } \
+                 __autumn_path . insert ((\"nodes\" , __autumn_pid)) ;"
             ),
-            "round-4: the current bulk root must be seeded at the TOP of its own \
-             mutating (Phase 2) loop, before recursing into its destroy cascade: \
-             {section}"
+            "round-5-B: Phase 2 must skip an already-cascade-deleted root, then push \
+             the current root onto the ACTIVE path before its cascade: {section}"
+        );
+        assert!(
+            section.contains("__autumn_path . remove (& (\"nodes\" , __autumn_pid))"),
+            "round-5-B: the current bulk root must be popped off the ACTIVE path after \
+             its own cascade completes (so it never suppresses a later ancestor): {section}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_delete_many_hooked_root_loop_skips_already_deleted_roots() {
+        // Codex round-5-B: for a HOOKED bulk parent, the root `before_delete` loop
+        // must run AFTER the cascade and skip any root already cascade-deleted as
+        // another root's descendant (present in `__autumn_deleted`) — otherwise that
+        // root's `before_delete` would fire twice (once as the cascaded descendant,
+        // once as the batch root). A `destroy` self-reference exercises the case.
+        let generated = repository_macro(
+            quote! { Node, hooks = NodeHooks, dependent(PgNodeRepository, fk = "parent_id", on_delete = destroy) },
+            quote! { pub trait NodeRepository {} },
+        )
+        .to_string();
+        let section = delete_many_section(&generated);
+        assert!(
+            section.contains(
+                "if __autumn_deleted . contains (& (\"nodes\" , record . id)) { continue ; }"
+            ),
+            "round-5-B: the hooked bulk-root loop must skip a root already \
+             cascade-deleted before firing its before_delete: {section}"
+        );
+        // The skip guard must sit at the TOP of the root loop, before before_delete.
+        let skip_pos = section
+            .find("if __autumn_deleted . contains (& (\"nodes\" , record . id))")
+            .expect("root skip guard present");
+        let before_delete_pos = section
+            .find("before_delete")
+            .expect("root loop fires before_delete");
+        assert!(
+            skip_pos < before_delete_pos,
+            "round-5-B: the __autumn_deleted skip must precede the root before_delete: {section}"
+        );
+        // And the cascade must precede that loop so `__autumn_deleted` is populated.
+        let cascade_pos = section
+            .find("__autumn_apply_dependent_on_conn")
+            .expect("cascade present");
+        assert!(
+            cascade_pos < before_delete_pos,
+            "round-5-B: the cascade must run before the root before_delete loop so a \
+             cascade-deleted root is already recorded: {section}"
         );
     }
 
@@ -15837,6 +15986,56 @@ mod tests {
         assert!(
             destroy_arm.contains(". cascade"),
             "the runtime grandchild walk must invoke each spec's cascade thunk: {destroy_arm}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_destroy_arm_probes_grandchild_restrict_before_child_hook() {
+        // Codex round-5-A: in the shared Destroy arm, a child's own `restrict`
+        // grandchild must be probed (read-only 409) BEFORE the child's
+        // `before_delete` hook fires, and its mutating (`destroy`) grandchildren
+        // AFTER it. Otherwise deleting a `Post -> Comment(destroy) -> Reply(restrict)`
+        // graph fires `Comment::before_delete` and only then returns the restrict
+        // 409 — leaving a non-transactional hook side effect on a doomed tx.
+        // Order in the arm must be: grandchild-restrict probe < child before_delete
+        // < grandchild-mutating cascade < child row delete.
+        let generated = repository_macro(
+            quote! {
+                Comment,
+                hooks = CommentHooks,
+                dependent(PgReplyRepository, fk = "comment_id", on_delete = restrict),
+                dependent(PgLikeRepository, fk = "comment_id", on_delete = destroy)
+            },
+            quote! { pub trait CommentRepository {} },
+        )
+        .to_string();
+        let destroy_arm = dependent_destroy_arm(&generated);
+        let restrict_probe_pos = destroy_arm
+            .find("PgReplyRepository")
+            .expect("grandchild restrict probe (Reply) must be emitted");
+        let before_delete_pos = destroy_arm
+            .find("before_delete")
+            .expect("child before_delete hook must be emitted");
+        let mutating_pos = destroy_arm
+            .find("PgLikeRepository")
+            .expect("grandchild mutating cascade (Like) must be emitted");
+        let child_delete_pos = destroy_arm
+            .find("diesel :: delete")
+            .expect("child row DELETE must be emitted");
+        assert!(
+            restrict_probe_pos < before_delete_pos,
+            "round-5-A: the grandchild restrict probe must run BEFORE the child \
+             before_delete hook: {destroy_arm}"
+        );
+        assert!(
+            before_delete_pos < mutating_pos,
+            "round-5-A: mutating grandchildren must be cascaded AFTER the child \
+             before_delete hook: {destroy_arm}"
+        );
+        assert!(
+            mutating_pos < child_delete_pos,
+            "round-5-A: mutating grandchildren must still be removed BEFORE the child \
+             row delete (deepest-first, no FK dangle): {destroy_arm}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -8163,9 +8163,15 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     // `across_tenants()` delete is rejected rather than cascading across shards
     // from a single routed connection (honoring the #1592/#1664/#1687 guards; a
     // cascade cannot silently skip children living on other shards).
-    let delete_body = if config.dependents.is_empty() {
-        delete_body
-    } else {
+    let delete_body = {
+        // #1738: the parent-side cascade body is shared between the
+        // repository-attribute (compile-time `dependent(...)`) form and the
+        // model-declared `#[has_many(dependent = ...)]` form (dispatched at run
+        // time via `Model::dependents()`). The parent load/mutation/hook/version
+        // tokens below are identical for both; only the per-child cascade calls
+        // differ (a compile-time list vs a runtime `RuntimeDependentSpec` slice),
+        // so those are passed into `assemble_cascade_body`.
+        //
         // The parent's own delete kind (soft vs hard) drives the child `destroy`
         // cascade (#1369 P1): a soft-delete child is only soft-deleted alongside
         // a soft-deleted parent; a hard-deleted parent hard-deletes its children.
@@ -8173,65 +8179,6 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             quote! { true }
         } else {
             quote! { false }
-        };
-        // #1369 restrict ordering: probe every `restrict` dependent BEFORE
-        // running any mutating dependent (`destroy`/`delete_all`/`nullify`).
-        // Mutating actions fire child `before_delete` hooks (counters, cache
-        // invalidation, external calls) that are NOT commit hooks — a later
-        // `restrict` 409 rolls back the DB but cannot retract those side effects.
-        // Hoisting all restrict probes ahead of the mutating pass means a blocked
-        // delete never touches a child hook. Per-action semantics are unchanged;
-        // only the order within the single transaction changes. `restrict` probes
-        // keep their parent-soft gating and short-circuit via `AutumnError`.
-        let emit_cascade_call = |dep: &DependentSpec| {
-            let child_repo = &dep.child_repo;
-            let fk = &dep.fk;
-            let action_variant = dep.action.variant_ident();
-            quote! {
-                let __autumn_dep_repo = #child_repo::with_pool_untracked(
-                    ::core::clone::Clone::clone(&self.pool)
-                );
-                // Deferred delete broadcasts accumulate here; they are published
-                // only after the tx commits (see the post-commit region below).
-                __autumn_dep_broadcasts.extend(
-                    __autumn_dep_repo
-                        .__autumn_apply_dependent_on_conn(
-                            conn,
-                            #fk,
-                            id,
-                            ::autumn_web::repository::DependentAction::#action_variant,
-                            #parent_soft_lit,
-                            &mut __autumn_visited,
-                        )
-                        .await?
-                );
-            }
-        };
-        let restrict_calls: ::std::vec::Vec<_> = config
-            .dependents
-            .iter()
-            .filter(|dep| dep.action == DependentAction::Restrict)
-            .map(&emit_cascade_call)
-            .collect();
-        let mutating_calls: ::std::vec::Vec<_> = config
-            .dependents
-            .iter()
-            .filter(|dep| dep.action != DependentAction::Restrict)
-            .map(&emit_cascade_call)
-            .collect();
-        let cascade_calls = quote! {
-            // #1739 cycle guard: one visited (table, id) set for the whole
-            // cascade, seeded with this parent row so a grandchild that references
-            // an ancestor terminates instead of looping. Threaded by-ref into
-            // every `__autumn_apply_dependent_on_conn` call (direct + recursive).
-            let mut __autumn_visited: ::std::collections::HashSet<(&'static str, i64)> =
-                ::std::collections::HashSet::new();
-            __autumn_visited.insert((#table_name, id));
-            // Phase 1: probe all `restrict` dependents first — a 409 here rolls
-            // back before any mutating action fires a child hook.
-            #(#restrict_calls)*
-            // Phase 2: mutating dependents in declaration order.
-            #(#mutating_calls)*
         };
 
         let tenant_id_setup = if config.tenant_scoped {
@@ -8434,65 +8381,204 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         } else {
             quote! {}
         };
-        quote! {
-            use ::autumn_web::reexports::diesel::prelude::*;
-            use ::autumn_web::reexports::diesel_async::RunQueryDsl;
-            use ::autumn_web::reexports::diesel_async::AsyncConnection;
-            use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
-            #parent_hooks_use
+        // Assemble the full transactional delete body around a given
+        // per-child cascade block (`cascade_calls`). Shared by the
+        // repository-attribute and model-declared (#1738) cascade forms.
+        let assemble_cascade_body = |cascade_calls: proc_macro2::TokenStream| {
+            quote! {
+                use ::autumn_web::reexports::diesel::prelude::*;
+                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                use ::autumn_web::reexports::diesel_async::AsyncConnection;
+                use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
+                #parent_hooks_use
 
-            #parent_register
-            #tenant_id_setup
-            let mut conn = self.__autumn_acquire_conn().await?;
-            // Deferred OOB delete broadcasts for broadcasts-only cascaded children
-            // (#1369). Accumulated inside the tx and returned on commit, so a
-            // rollback drops them and no spurious client deletes are published.
-            let __autumn_dep_broadcasts: ::std::vec::Vec<(::std::string::String, ::std::string::String)> =
-                ::autumn_web::__private::scoped_transaction::<
-                    ::std::vec::Vec<(::std::string::String, ::std::string::String)>,
-                    ::autumn_web::AutumnError, _, _,
-                >(
-                    &mut *conn,
-                    |conn| {
-                        async move {
-                            let mut __autumn_dep_broadcasts: ::std::vec::Vec<(::std::string::String, ::std::string::String)> =
-                                ::std::vec::Vec::new();
-                            #parent_ctx_decl
-                            #parent_idempotency_setup
+                #parent_register
+                #tenant_id_setup
+                let mut conn = self.__autumn_acquire_conn().await?;
+                // Deferred OOB delete broadcasts for broadcasts-only cascaded children
+                // (#1369). Accumulated inside the tx and returned on commit, so a
+                // rollback drops them and no spurious client deletes are published.
+                let __autumn_dep_broadcasts: ::std::vec::Vec<(::std::string::String, ::std::string::String)> =
+                    ::autumn_web::__private::scoped_transaction::<
+                        ::std::vec::Vec<(::std::string::String, ::std::string::String)>,
+                        ::autumn_web::AutumnError, _, _,
+                    >(
+                        &mut *conn,
+                        |conn| {
+                            async move {
+                                let mut __autumn_dep_broadcasts: ::std::vec::Vec<(::std::string::String, ::std::string::String)> =
+                                    ::std::vec::Vec::new();
+                                #parent_ctx_decl
+                                #parent_idempotency_setup
 
-                            #parent_load
+                                #parent_load
 
-                            #parent_before_delete
+                                #parent_before_delete
 
-                            // Cascade to dependent children FIRST so the parent
-                            // delete never trips a foreign-key constraint and no
-                            // orphan can survive the transaction.
-                            #cascade_calls
+                                // Cascade to dependent children FIRST so the parent
+                                // delete never trips a foreign-key constraint and no
+                                // orphan can survive the transaction.
+                                #cascade_calls
 
-                            #parent_mutation
+                                #parent_mutation
 
-                            #parent_vh
+                                #parent_vh
 
-                            #parent_commit_enqueue
+                                #parent_commit_enqueue
 
-                            Ok(__autumn_dep_broadcasts)
-                        }
-                        .scope_boxed()
-                    },
-                )
-                .await?;
-            ::core::mem::drop(conn);
-            // Publish the cascaded children's OOB delete broadcasts only now that
-            // the transaction has committed (a rolled-back cascade published
-            // nothing). No-op when the buffer is empty / live channels are off.
-            ::autumn_web::repository::publish_deferred_dependent_broadcasts(__autumn_dep_broadcasts);
-            // Always kick the durable commit-hook dispatcher after a dependent
-            // delete: even when this parent has no commit hooks, a cascaded
-            // `dependent = destroy` child may have enqueued one in the same
-            // transaction. The kick is idempotent.
-            ::autumn_web::__private::kick_repository_commit_hook_dispatcher(&self.pool);
+                                Ok(__autumn_dep_broadcasts)
+                            }
+                            .scope_boxed()
+                        },
+                    )
+                    .await?;
+                ::core::mem::drop(conn);
+                // Publish the cascaded children's OOB delete broadcasts only now that
+                // the transaction has committed (a rolled-back cascade published
+                // nothing). No-op when the buffer is empty / live channels are off.
+                ::autumn_web::repository::publish_deferred_dependent_broadcasts(__autumn_dep_broadcasts);
+                // Always kick the durable commit-hook dispatcher after a dependent
+                // delete: even when this parent has no commit hooks, a cascaded
+                // `dependent = destroy` child may have enqueued one in the same
+                // transaction. The kick is idempotent.
+                ::autumn_web::__private::kick_repository_commit_hook_dispatcher(&self.pool);
 
-            Ok(())
+                Ok(())
+            }
+        };
+
+        if config.dependents.is_empty() {
+            // ── #1738: model-declared `#[has_many(dependent = ...)]` cascade ──
+            //
+            // No repository-attribute `dependent(...)` was declared, so consult
+            // the model's runtime `Model::dependents()` (an inherent shadow of
+            // `AutumnDependents::dependents`, emitted by `#[model]` only when the
+            // struct declares dependent associations; otherwise the blanket impl
+            // yields an empty slice). When empty this is exactly the prior plain
+            // delete body; when non-empty it drives the SAME transactional
+            // cascade as the repository-attribute form, resolving each child
+            // repository through the `Pg{Child}Repository` convention baked into
+            // the spec's `cascade` thunk.
+            let runtime_cascade_calls = quote! {
+                // #1739 cycle guard: one visited (table, id) set for the whole
+                // cascade, seeded with this parent row so a grandchild that
+                // references an ancestor terminates instead of looping.
+                let mut __autumn_visited: ::std::collections::HashSet<(&'static str, i64)> =
+                    ::std::collections::HashSet::new();
+                __autumn_visited.insert((#table_name, id));
+                // Phase 1: probe all `restrict` dependents first — a 409 here
+                // rolls back before any mutating action fires a child hook.
+                for __autumn_spec in __autumn_rt_deps.iter().filter(|__s|
+                    __s.action == ::autumn_web::repository::DependentAction::Restrict
+                ) {
+                    __autumn_dep_broadcasts.extend(
+                        (__autumn_spec.cascade)(
+                            &self.pool,
+                            conn,
+                            id,
+                            #parent_soft_lit,
+                            &mut __autumn_visited,
+                        )
+                        .await?
+                    );
+                }
+                // Phase 2: mutating dependents in declaration order.
+                for __autumn_spec in __autumn_rt_deps.iter().filter(|__s|
+                    __s.action != ::autumn_web::repository::DependentAction::Restrict
+                ) {
+                    __autumn_dep_broadcasts.extend(
+                        (__autumn_spec.cascade)(
+                            &self.pool,
+                            conn,
+                            id,
+                            #parent_soft_lit,
+                            &mut __autumn_visited,
+                        )
+                        .await?
+                    );
+                }
+            };
+            let runtime_body = assemble_cascade_body(runtime_cascade_calls);
+            let plain_delete_body = delete_body;
+            quote! {
+                use ::autumn_web::repository::AutumnDependents as _;
+                // Inherent `dependents()` (real specs) shadows the blanket trait
+                // method (empty) when the model declares dependents; unqualified
+                // call so the shadow wins. Cheap `&[]` for models without any.
+                let __autumn_rt_deps = #model_name::dependents();
+                if __autumn_rt_deps.is_empty() {
+                    #plain_delete_body
+                } else {
+                    #runtime_body
+                }
+            }
+        } else {
+            // ── #1369 repository-attribute `dependent(...)` cascade ──────────
+            //
+            // Precedence (#1738): a repository that declares `dependent(...)` is
+            // the explicit escape hatch (for children whose repository does not
+            // follow the `Pg{Child}Repository` convention, or lives in another
+            // crate). Its compile-time specs are authoritative; any model-side
+            // `#[has_many(dependent = ...)]` is ignored here.
+            //
+            // #1369 restrict ordering: probe every `restrict` dependent BEFORE
+            // running any mutating dependent (`destroy`/`delete_all`/`nullify`).
+            // Mutating actions fire child `before_delete` hooks (counters, cache
+            // invalidation, external calls) that are NOT commit hooks — a later
+            // `restrict` 409 rolls back the DB but cannot retract those side
+            // effects. Hoisting all restrict probes ahead of the mutating pass
+            // means a blocked delete never touches a child hook.
+            let emit_cascade_call = |dep: &DependentSpec| {
+                let child_repo = &dep.child_repo;
+                let fk = &dep.fk;
+                let action_variant = dep.action.variant_ident();
+                quote! {
+                    let __autumn_dep_repo = #child_repo::with_pool_untracked(
+                        ::core::clone::Clone::clone(&self.pool)
+                    );
+                    // Deferred delete broadcasts accumulate here; published only
+                    // after the tx commits (see the post-commit region above).
+                    __autumn_dep_broadcasts.extend(
+                        __autumn_dep_repo
+                            .__autumn_apply_dependent_on_conn(
+                                conn,
+                                #fk,
+                                id,
+                                ::autumn_web::repository::DependentAction::#action_variant,
+                                #parent_soft_lit,
+                                &mut __autumn_visited,
+                            )
+                            .await?
+                    );
+                }
+            };
+            let restrict_calls: ::std::vec::Vec<_> = config
+                .dependents
+                .iter()
+                .filter(|dep| dep.action == DependentAction::Restrict)
+                .map(&emit_cascade_call)
+                .collect();
+            let mutating_calls: ::std::vec::Vec<_> = config
+                .dependents
+                .iter()
+                .filter(|dep| dep.action != DependentAction::Restrict)
+                .map(&emit_cascade_call)
+                .collect();
+            let cascade_calls = quote! {
+                // #1739 cycle guard: one visited (table, id) set for the whole
+                // cascade, seeded with this parent row so a grandchild that
+                // references an ancestor terminates instead of looping. Threaded
+                // by-ref into every `__autumn_apply_dependent_on_conn` call.
+                let mut __autumn_visited: ::std::collections::HashSet<(&'static str, i64)> =
+                    ::std::collections::HashSet::new();
+                __autumn_visited.insert((#table_name, id));
+                // Phase 1: probe all `restrict` dependents first — a 409 here
+                // rolls back before any mutating action fires a child hook.
+                #(#restrict_calls)*
+                // Phase 2: mutating dependents in declaration order.
+                #(#mutating_calls)*
+            };
+            assemble_cascade_body(cascade_calls)
         }
     };
 
@@ -15033,15 +15119,45 @@ mod tests {
     }
 
     #[test]
-    fn repository_macro_without_dependents_delete_by_id_has_no_cascade() {
-        // AC7: default behavior unchanged — delete_by_id must not call the
-        // cascade helper when no dependents are declared.
+    fn repository_macro_without_dependents_delete_by_id_dispatches_at_runtime() {
+        // #1738: with no repository-attribute `dependent(...)`, delete_by_id no
+        // longer calls the cascade helper directly at compile time; instead it
+        // consults the model's runtime `dependents()` (empty for a model with no
+        // `#[has_many(dependent = ...)]`, so the plain delete path runs). The
+        // compile-time `__autumn_apply_dependent_on_conn` call site is gone.
         let generated =
             repository_macro(quote! { Post }, quote! { pub trait PostRepository {} }).to_string();
         let section = delete_by_id_section(&generated);
         assert!(
             !section.contains("__autumn_apply_dependent_on_conn"),
-            "delete_by_id must not cascade when no dependent(...) is declared: {section}"
+            "delete_by_id must not emit a compile-time cascade call when no \
+             dependent(...) is declared: {section}"
+        );
+        assert!(
+            section.contains("dependents") && section.contains("AutumnDependents"),
+            "delete_by_id must consult the model's runtime dependents() for the \
+             model-declared cascade (#1738): {section}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_with_dependents_delete_by_id_does_not_runtime_dispatch() {
+        // Precedence (#1738): a repository-attribute `dependent(...)` is the
+        // authoritative escape hatch. Its delete_by_id uses the compile-time
+        // cascade and must NOT also consult the model's runtime dependents().
+        let generated = repository_macro(
+            quote! { Post, dependent(PgCommentRepository, fk = "post_id", on_delete = destroy) },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+        let section = delete_by_id_section(&generated);
+        assert!(
+            section.contains("__autumn_apply_dependent_on_conn"),
+            "repository-attribute delete_by_id must emit the compile-time cascade: {section}"
+        );
+        assert!(
+            !section.contains("AutumnDependents"),
+            "repository-attribute delete_by_id must not runtime-dispatch (repo-attr wins): {section}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1962,22 +1962,34 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             #body
                         }
                     });
+                    let no_shard_set_msg = format!(
+                        "cross-shard {fn_ident} requires a configured shard set: across_tenants() \
+                         cannot fan a derived query out across shards without a shard set (the \
+                         repository was built without shard context, e.g. via with_pool_untracked); \
+                         build it with shard context instead"
+                    );
                     derived_impl_methods.push(quote! {
                         async fn #fn_ident(&self, #(#params),*) -> ::autumn_web::AutumnResult<#return_type> {
                             use ::autumn_web::reexports::diesel::prelude::*;
                             use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                            // Without a shard set, an across-tenant read would bind a NULL tenant
+                            // predicate and silently return a PARTIAL result over only the current
+                            // pool, so we reject rather than fall through (#1692, #1741).
                             if self.across_tenants {
-                                if let ::core::option::Option::Some(ref __shards) = self.__autumn_shards {
-                                    // Params are cloned once per shard (the fan-out closure is
-                                    // `Fn`); allow it for `Copy` params too (e.g. an i64 filter).
-                                    #[allow(clippy::clone_on_copy)]
-                                    let __results = __shards.fan_out_shards(|__shard| {
-                                        let __sub = self.__autumn_for_shard(__shard);
-                                        #(let #param_idents = ::core::clone::Clone::clone(&#param_idents);)*
-                                        async move { __sub.#one_shard_ident(#(#param_idents),*).await }
-                                    }).await?;
-                                    return ::core::result::Result::Ok(#merge);
-                                }
+                                let ::core::option::Option::Some(ref __shards) = self.__autumn_shards else {
+                                    return ::core::result::Result::Err(
+                                        ::autumn_web::AutumnError::bad_request_msg(#no_shard_set_msg)
+                                    );
+                                };
+                                // Params are cloned once per shard (the fan-out closure is
+                                // `Fn`); allow it for `Copy` params too (e.g. an i64 filter).
+                                #[allow(clippy::clone_on_copy)]
+                                let __results = __shards.fan_out_shards(|__shard| {
+                                    let __sub = self.__autumn_for_shard(__shard);
+                                    #(let #param_idents = ::core::clone::Clone::clone(&#param_idents);)*
+                                    async move { __sub.#one_shard_ident(#(#param_idents),*).await }
+                                }).await?;
+                                return ::core::result::Result::Ok(#merge);
                             }
                             #body
                         }
@@ -11105,30 +11117,51 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut soft_delete_one_shard_helpers: Vec<proc_macro2::TokenStream> = Vec::new();
     let (with_deleted_fan_out, only_deleted_fan_out, page_only_deleted_cross_shard_guard) =
         if config.soft_delete && config.sharded && config.tenant_scoped {
+            // Without a shard set, an across-tenant read would bind a NULL tenant
+            // predicate and silently return a PARTIAL result over only the current
+            // pool, so we reject rather than fall through (#1692, #1741).
             let with_deleted_fan_out = quote! {
                 if self.across_tenants {
-                    if let ::core::option::Option::Some(ref __shards) = self.__autumn_shards {
-                        let __vecs = __shards.fan_out_shards(|__shard| {
-                            let __sub = self.__autumn_for_shard(__shard);
-                            async move { __sub.__autumn_with_deleted_one_shard().await }
-                        }).await?;
-                        return ::core::result::Result::Ok(
-                            __vecs.into_iter().flatten().collect()
+                    let ::core::option::Option::Some(ref __shards) = self.__autumn_shards else {
+                        return ::core::result::Result::Err(
+                            ::autumn_web::AutumnError::bad_request_msg(
+                                "cross-shard with_deleted requires a configured shard set: \
+                                 across_tenants() cannot fan with_deleted out across shards \
+                                 without a shard set (the repository was built without \
+                                 shard context, e.g. via with_pool_untracked); build it \
+                                 with shard context instead"
+                            )
                         );
-                    }
+                    };
+                    let __vecs = __shards.fan_out_shards(|__shard| {
+                        let __sub = self.__autumn_for_shard(__shard);
+                        async move { __sub.__autumn_with_deleted_one_shard().await }
+                    }).await?;
+                    return ::core::result::Result::Ok(
+                        __vecs.into_iter().flatten().collect()
+                    );
                 }
             };
             let only_deleted_fan_out = quote! {
                 if self.across_tenants {
-                    if let ::core::option::Option::Some(ref __shards) = self.__autumn_shards {
-                        let __vecs = __shards.fan_out_shards(|__shard| {
-                            let __sub = self.__autumn_for_shard(__shard);
-                            async move { __sub.__autumn_only_deleted_one_shard().await }
-                        }).await?;
-                        return ::core::result::Result::Ok(
-                            __vecs.into_iter().flatten().collect()
+                    let ::core::option::Option::Some(ref __shards) = self.__autumn_shards else {
+                        return ::core::result::Result::Err(
+                            ::autumn_web::AutumnError::bad_request_msg(
+                                "cross-shard only_deleted requires a configured shard set: \
+                                 across_tenants() cannot fan only_deleted out across shards \
+                                 without a shard set (the repository was built without \
+                                 shard context, e.g. via with_pool_untracked); build it \
+                                 with shard context instead"
+                            )
                         );
-                    }
+                    };
+                    let __vecs = __shards.fan_out_shards(|__shard| {
+                        let __sub = self.__autumn_for_shard(__shard);
+                        async move { __sub.__autumn_only_deleted_one_shard().await }
+                    }).await?;
+                    return ::core::result::Result::Ok(
+                        __vecs.into_iter().flatten().collect()
+                    );
                 }
             };
             let page_only_deleted_cross_shard_guard = quote! {
@@ -11515,16 +11548,32 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             // no routed-shard connection is held here, so a dead parent replica
             // or exhausted parent pool can't fail the fan-out. Each shard's own
             // read route/fallback is chosen by `__autumn_for_shard` (#1d).
+            //
+            // Without a shard set (e.g. a repo built via `with_pool_untracked`,
+            // where `__autumn_shards` is `None`), an across-tenant read would
+            // bind a NULL tenant predicate and silently return a PARTIAL result
+            // over only the current pool, so we reject rather than fall through
+            // to the single-pool query — mirroring the `count` guard (#1692,
+            // #1741).
             if self.across_tenants {
-                if let ::core::option::Option::Some(ref __shards) = self.__autumn_shards {
-                    let __vecs = __shards.fan_out_shards(|__shard| {
-                        let __sub = self.__autumn_for_shard(__shard);
-                        async move { __sub.__autumn_find_all_one_shard().await }
-                    }).await?;
-                    return ::core::result::Result::Ok(
-                        __vecs.into_iter().flatten().collect()
+                let ::core::option::Option::Some(ref __shards) = self.__autumn_shards else {
+                    return ::core::result::Result::Err(
+                        ::autumn_web::AutumnError::bad_request_msg(
+                            "cross-shard find_all requires a configured shard set: \
+                             across_tenants() cannot fan find_all out across shards \
+                             without a shard set (the repository was built without \
+                             shard context, e.g. via with_pool_untracked); build it \
+                             with shard context instead"
+                        )
                     );
-                }
+                };
+                let __vecs = __shards.fan_out_shards(|__shard| {
+                    let __sub = self.__autumn_for_shard(__shard);
+                    async move { __sub.__autumn_find_all_one_shard().await }
+                }).await?;
+                return ::core::result::Result::Ok(
+                    __vecs.into_iter().flatten().collect()
+                );
             }
             let mut conn = self.__autumn_acquire_read_conn().await?;
             #base
@@ -11551,28 +11600,40 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         let base = find_by_id_impl;
         let dispatch = quote! {
             // Fan out before acquiring a parent-shard connection (see find_all).
+            // Without a shard set, an across-tenant read would bind a NULL tenant
+            // predicate and silently return a PARTIAL result over only the current
+            // pool, so we reject rather than fall through (#1692, #1741).
             if self.across_tenants {
-                if let ::core::option::Option::Some(ref __shards) = self.__autumn_shards {
-                    let __found = __shards.fan_out_shards(|__shard| {
-                        let __sub = self.__autumn_for_shard(__shard);
-                        async move { __sub.__autumn_find_by_id_one_shard(id).await }
-                    }).await?;
-                    // Ids are unique only within a shard: with per-shard
-                    // sequences two shards can hold the same id, so a match on
-                    // more than one shard is ambiguous. Reject rather than
-                    // silently returning whichever shard sorts first (#1d).
-                    let mut __hits = __found.into_iter().flatten();
-                    let __first = __hits.next();
-                    if __hits.next().is_some() {
-                        return ::core::result::Result::Err(
-                            ::autumn_web::AutumnError::internal_server_error_msg(
-                                "ambiguous cross-shard find_by_id: id matched rows on \
-                                 multiple shards; query a specific shard instead"
-                            )
-                        );
-                    }
-                    return ::core::result::Result::Ok(__first);
+                let ::core::option::Option::Some(ref __shards) = self.__autumn_shards else {
+                    return ::core::result::Result::Err(
+                        ::autumn_web::AutumnError::bad_request_msg(
+                            "cross-shard find_by_id requires a configured shard set: \
+                             across_tenants() cannot fan find_by_id out across shards \
+                             without a shard set (the repository was built without \
+                             shard context, e.g. via with_pool_untracked); build it \
+                             with shard context instead"
+                        )
+                    );
+                };
+                let __found = __shards.fan_out_shards(|__shard| {
+                    let __sub = self.__autumn_for_shard(__shard);
+                    async move { __sub.__autumn_find_by_id_one_shard(id).await }
+                }).await?;
+                // Ids are unique only within a shard: with per-shard
+                // sequences two shards can hold the same id, so a match on
+                // more than one shard is ambiguous. Reject rather than
+                // silently returning whichever shard sorts first (#1d).
+                let mut __hits = __found.into_iter().flatten();
+                let __first = __hits.next();
+                if __hits.next().is_some() {
+                    return ::core::result::Result::Err(
+                        ::autumn_web::AutumnError::internal_server_error_msg(
+                            "ambiguous cross-shard find_by_id: id matched rows on \
+                             multiple shards; query a specific shard instead"
+                        )
+                    );
                 }
+                return ::core::result::Result::Ok(__first);
             }
             let mut conn = self.__autumn_acquire_read_conn().await?;
             #base
@@ -11723,14 +11784,26 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         let base = exists_by_id_impl;
         let dispatch = quote! {
             // Fan out before acquiring a parent-shard connection (see find_all).
+            // Without a shard set, an across-tenant read would bind a NULL tenant
+            // predicate and silently return a PARTIAL result over only the current
+            // pool, so we reject rather than fall through (#1692, #1741).
             if self.across_tenants {
-                if let ::core::option::Option::Some(ref __shards) = self.__autumn_shards {
-                    let __results = __shards.fan_out_shards(|__shard| {
-                        let __sub = self.__autumn_for_shard(__shard);
-                        async move { __sub.__autumn_exists_by_id_one_shard(id).await }
-                    }).await?;
-                    return ::core::result::Result::Ok(__results.into_iter().any(|b| b));
-                }
+                let ::core::option::Option::Some(ref __shards) = self.__autumn_shards else {
+                    return ::core::result::Result::Err(
+                        ::autumn_web::AutumnError::bad_request_msg(
+                            "cross-shard exists_by_id requires a configured shard set: \
+                             across_tenants() cannot fan exists_by_id out across shards \
+                             without a shard set (the repository was built without \
+                             shard context, e.g. via with_pool_untracked); build it \
+                             with shard context instead"
+                        )
+                    );
+                };
+                let __results = __shards.fan_out_shards(|__shard| {
+                    let __sub = self.__autumn_for_shard(__shard);
+                    async move { __sub.__autumn_exists_by_id_one_shard(id).await }
+                }).await?;
+                return ::core::result::Result::Ok(__results.into_iter().any(|b| b));
             }
             let mut conn = self.__autumn_acquire_read_conn().await?;
             #base

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1821,6 +1821,16 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
         // Phase 2: mutating dependents per parent, in declaration order.
         for &__autumn_pid in &__autumn_dep_parent_ids {
+            // Codex round-4: seed ONLY the current bulk root into the shared
+            // visited set IMMEDIATELY before its own mutating destroy cascade
+            // (mirroring how `delete_by_id` seeds its parent). Without this a
+            // self-referential 2-cycle (A.parent_id = B, B.parent_id = A) would
+            // re-enter A through a child's destroy executor and fire A's
+            // hooks/history/broadcasts as a cascaded child before the final bulk
+            // parent delete. Seeding one root at a time (NOT the whole batch — the
+            // removed all-target pre-seed) keeps the round-2 property: a descendant
+            // batch target not yet on the active path is still cascaded deepest-first.
+            __autumn_visited.insert((#table_name, __autumn_pid));
             #(#delete_many_mutating_calls)*
         }
     };
@@ -1852,6 +1862,16 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
         // Phase 2: mutating dependents per parent, in declaration order.
         for &__autumn_pid in &__autumn_dep_parent_ids {
+            // Codex round-4: seed ONLY the current bulk root into the shared
+            // visited set IMMEDIATELY before its own mutating destroy cascade
+            // (mirroring how `delete_by_id` seeds its parent). Without this a
+            // self-referential 2-cycle (A.parent_id = B, B.parent_id = A) would
+            // re-enter A through a child's destroy executor and fire A's
+            // hooks/history/broadcasts as a cascaded child before the final bulk
+            // parent delete. Seeding one root at a time (NOT the whole batch — the
+            // removed all-target pre-seed) keeps the round-2 property: a descendant
+            // batch target not yet on the active path is still cascaded deepest-first.
+            __autumn_visited.insert((#table_name, __autumn_pid));
             for __autumn_spec in __autumn_rt_deps.iter().filter(|__s|
                 __s.action != ::autumn_web::repository::DependentAction::Restrict
             ) {
@@ -15449,15 +15469,22 @@ mod tests {
     }
 
     #[test]
-    fn repository_macro_delete_many_does_not_preseed_bulk_targets_in_visited() {
-        // Codex P2: the bulk `delete_many` cascade must NOT pre-seed the shared
-        // `__autumn_visited` cycle set with the batch target ids. Pre-seeding a
-        // descendant batch target makes an ancestor's cascade skip it, so for a
-        // self-referential `dependent = destroy` graph the still-referenced row is
-        // not removed before its intermediate parent is deleted → an immediate FK
-        // violation. The visited set must instead be populated naturally as each
-        // row is destroyed. Assert the bulk cascade issues NO `__autumn_visited`
-        // pre-insert (the only inserts happen inside the Destroy leaf executor).
+    fn repository_macro_delete_many_seeds_current_root_before_its_destroy_cascade() {
+        // Codex P2 + round-4: the bulk `delete_many` cascade must NOT pre-seed the
+        // shared `__autumn_visited` cycle set with the WHOLE batch of target ids
+        // (that would make an ancestor's cascade skip a still-referenced descendant
+        // batch target and trip an immediate FK). But it MUST seed the CURRENT root
+        // — one root at a time — immediately before that root's own mutating destroy
+        // cascade, mirroring how `delete_by_id` seeds its parent. Otherwise a
+        // self-referential 2-cycle (A.parent_id = B, B.parent_id = A) re-enters A
+        // through a child's destroy executor and fires A's hooks/history/broadcasts
+        // as a cascaded child before the final bulk parent delete.
+        //
+        // For a `destroy`-only model there is no restrict phase, so the ONLY visited
+        // insert in the bulk section is the per-root Phase-2 seed at the top of the
+        // mutating loop (`for & __autumn_pid ... { __autumn_visited . insert(...)`);
+        // asserting exactly one insert, located there, proves per-root seeding
+        // without the removed all-target pre-seed.
         let generated = repository_macro(
             quote! { Node, dependent(PgNodeRepository, fk = "parent_id", on_delete = destroy) },
             quote! { pub trait NodeRepository {} },
@@ -15468,11 +15495,19 @@ mod tests {
             section.contains("__autumn_apply_dependent_on_conn"),
             "the bulk delete_many path must cascade dependents: {section}"
         );
+        assert_eq!(
+            section.matches("__autumn_visited . insert").count(),
+            1,
+            "round-4: delete_many must seed EXACTLY the current root (one insert), \
+             not pre-seed the whole batch: {section}"
+        );
         assert!(
-            !section.contains("__autumn_visited . insert"),
-            "Codex P2: delete_many must not pre-seed batch target ids into the \
-             visited set (that skips still-referenced self-ref descendants and \
-             trips an immediate FK): {section}"
+            section.contains(
+                "for & __autumn_pid in & __autumn_dep_parent_ids { __autumn_visited . insert"
+            ),
+            "round-4: the current bulk root must be seeded at the TOP of its own \
+             mutating (Phase 2) loop, before recursing into its destroy cascade: \
+             {section}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1336,10 +1336,79 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         } else {
             quote! {}
         };
+        // #1739 grandchild recursion: within the Destroy arm, after selecting a
+        // child row but before removing it, recurse into THIS model's own
+        // `dependent(...)` cascade keyed on the child's id, so grandchildren (and
+        // deeper) are destroyed/nullified inside the SAME transaction. Only
+        // `destroy` recurses: `delete_all` stays single-level (#1739 scope), and
+        // `nullify`/`restrict` remove no rows that could themselves own children.
+        // Restrict grandchildren are probed before mutating ones (mirroring the
+        // single-record restrict-first ordering); a restrict 409 anywhere in the
+        // tree rolls the whole transaction back. Cycle guard: `__visited` holds
+        // every (table, id) already on the destroy path; an already-seen row is
+        // skipped (see the per-row guard in the loop), so self-/mutual-referential
+        // graphs terminate rather than looping forever.
+        let has_dependents = !config.dependents.is_empty();
+        // The grandchildren follow this child's delete kind: a soft-delete child
+        // is only soft-deleted when its parent is (`__parent_soft`), so its own
+        // children inherit `__parent_soft`; a non-soft-delete child is always hard
+        // deleted, so its children cascade as a hard delete (`false`).
+        let child_soft_for_grandchildren = if config.soft_delete {
+            quote! { __parent_soft }
+        } else {
+            quote! { false }
+        };
+        let emit_grandchild_call = |dep: &DependentSpec| {
+            let child_repo = &dep.child_repo;
+            let fk = &dep.fk;
+            let action_variant = dep.action.variant_ident();
+            quote! {
+                {
+                    let __autumn_gc_repo = #child_repo::with_pool_untracked(
+                        ::core::clone::Clone::clone(&self.pool)
+                    );
+                    // The helper already returns a boxed `dyn Future` (see its
+                    // definition), so the recursive edge is type-erased and this
+                    // call needs no further boxing. The connection and visited set
+                    // are reborrowed; the future is awaited immediately so it never
+                    // outlives `__autumn_gc_repo`.
+                    __ret_broadcasts.extend(
+                        __autumn_gc_repo.__autumn_apply_dependent_on_conn(
+                            conn,
+                            #fk,
+                            __cid,
+                            ::autumn_web::repository::DependentAction::#action_variant,
+                            #child_soft_for_grandchildren,
+                            __visited,
+                        ).await?
+                    );
+                }
+            }
+        };
+        let grandchild_restrict_calls: ::std::vec::Vec<_> = config
+            .dependents
+            .iter()
+            .filter(|dep| dep.action == DependentAction::Restrict)
+            .map(&emit_grandchild_call)
+            .collect();
+        let grandchild_mutating_calls: ::std::vec::Vec<_> = config
+            .dependents
+            .iter()
+            .filter(|dep| dep.action != DependentAction::Restrict)
+            .map(&emit_grandchild_call)
+            .collect();
+        let grandchild_cascade = quote! {
+            #(#grandchild_restrict_calls)*
+            #(#grandchild_mutating_calls)*
+        };
+
         // Declaration + return of the deferred-broadcast buffer for the Destroy
-        // arm. Only a broadcasts-only child accumulates; every other repo returns
-        // an empty buffer (zero-cost).
-        let destroy_ret_decl = if dep_needs_broadcast {
+        // arm. A broadcasts-only child accumulates its own OOB delete fragments;
+        // additionally, when this repo has dependents (#1739), grandchild cascades
+        // return their broadcasts here to propagate up to the top-level parent for
+        // post-commit publishing. Repos with neither return an empty buffer.
+        let needs_ret_buffer = dep_needs_broadcast || has_dependents;
+        let destroy_ret_decl = if needs_ret_buffer {
             quote! {
                 let mut __ret_broadcasts: ::std::vec::Vec<(::std::string::String, ::std::string::String)> =
                     ::std::vec::Vec::new();
@@ -1347,7 +1416,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         } else {
             quote! {}
         };
-        let destroy_ret_value = if dep_needs_broadcast {
+        let destroy_ret_value = if needs_ret_buffer {
             quote! { __ret_broadcasts }
         } else {
             quote! { ::std::vec::Vec::new() }
@@ -1378,24 +1447,47 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             /// Returns the `(topic, dom_id)` OOB delete broadcasts accumulated for
             /// `broadcasts = true` (non-commit-hook) children — the parent
             /// publishes them only AFTER its transaction commits, so a rolled-back
-            /// cascade broadcasts nothing. Empty for every other configuration.
+            /// cascade broadcasts nothing. Grandchild cascades (#1739) propagate
+            /// their broadcasts up through this same buffer. Empty for a repo with
+            /// no dependents and no broadcasting children.
             ///
-            /// NOTE (#1369 scope / see #1702): the `Destroy` cascade is
-            /// single-level — it applies this model's mutation to each child but
-            /// does NOT recursively invoke the child's own `dependent(...)`
-            /// cascade, so grandchildren are not handled. #1369's target graph is
-            /// single-level; recursive/multi-level cascade is a tracked follow-up.
+            /// #1739: the `Destroy` cascade is recursive — for each destroyed
+            /// child it invokes the child's OWN `dependent(...)` cascade against
+            /// the same connection, so grandchildren (and deeper) are handled in
+            /// one transaction. `__visited` carries the (table, id) rows already on
+            /// the destroy path; an already-seen row is skipped, so self- and
+            /// mutual-referential graphs terminate. `delete_all` remains
+            /// single-level by design (#1739 scope).
+            // #1739: returns an explicitly boxed `dyn Future` rather than being an
+            // `async fn`. The Destroy cascade is recursive and, for a self- or
+            // mutual-referential `dependent(...)` graph, calls back into an
+            // `__autumn_apply_dependent_on_conn` of this same type. An `async fn`'s
+            // anonymous future cannot then be proven `Send` (the auto-trait check
+            // is circular: the future's `Send`-ness depends on itself), so the
+            // whole cascade — and every `delete_by_id` that drives it — would fail
+            // its `+ Send` bound. Returning a `Pin<Box<dyn Future + Send>>` erases
+            // the recursive edge behind a trait object whose `Send` is axiomatic,
+            // breaking the cycle while keeping the cascade `Send`.
             #[doc(hidden)]
-            pub async fn __autumn_apply_dependent_on_conn(
-                &self,
-                conn: &mut ::autumn_web::reexports::diesel_async::AsyncPgConnection,
-                __fk_column: &str,
+            pub fn __autumn_apply_dependent_on_conn<'__dep>(
+                &'__dep self,
+                conn: &'__dep mut ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                __fk_column: &'__dep str,
                 __parent_id: i64,
                 __action: ::autumn_web::repository::DependentAction,
                 __parent_soft: bool,
-            ) -> ::autumn_web::AutumnResult<
-                ::std::vec::Vec<(::std::string::String, ::std::string::String)>,
-            > {
+                // #1739: (table, id) rows already entered on the destroy path —
+                // threaded through the recursion to break self-/mutual-referential
+                // cycles. See the Destroy arm's cycle guard below.
+                __visited: &'__dep mut ::std::collections::HashSet<(&'static str, i64)>,
+            ) -> ::std::pin::Pin<::std::boxed::Box<
+                dyn ::std::future::Future<
+                    Output = ::autumn_web::AutumnResult<
+                        ::std::vec::Vec<(::std::string::String, ::std::string::String)>,
+                    >,
+                > + ::core::marker::Send + '__dep,
+            >> {
+                ::std::boxed::Box::pin(async move {
                 use ::autumn_web::reexports::diesel::prelude::*;
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl;
                 #dep_hooks_use
@@ -1458,10 +1550,12 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         ::core::result::Result::Ok(::std::vec::Vec::new())
                     }
                     ::autumn_web::repository::DependentAction::Destroy => {
-                        // Single-level cascade (#1369 scope; recursion tracked in
-                        // #1702): each child's mutation is applied inline here; the
-                        // child's OWN `dependent(...)` cascade is NOT invoked, so
-                        // grandchildren are not recursively destroyed/nullified.
+                        // Recursive cascade (#1739): each child row's mutation is
+                        // applied inline, and BEFORE that mutation this repo's own
+                        // `dependent(...)` cascade is invoked against the child id,
+                        // so grandchildren (and deeper) are destroyed/nullified
+                        // within the same transaction. A `__visited` (table, id)
+                        // set breaks self-/mutual-referential cycles.
                         #destroy_register
                         #destroy_ret_decl
                         #[derive(::autumn_web::reexports::diesel::QueryableByName)]
@@ -1481,6 +1575,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 .map_err(::autumn_web::AutumnError::from)?;
                         for __row in __ids {
                             let __cid = __row.id;
+                            // #1739 cycle guard: skip a (table, id) already on the
+                            // current destroy path. `insert` returns false when the
+                            // row is already present, so a self- or mutual-reference
+                            // (e.g. a grandchild pointing back at an ancestor) is not
+                            // re-entered and the traversal terminates.
+                            if !__visited.insert((#table_name, __cid)) {
+                                continue;
+                            }
                             // #1369: reload the EXACT id the (parent-soft-gated)
                             // selection returned — do NOT re-apply `#sd_filter`
                             // (`deleted_at IS NULL`) here. On a hard parent delete
@@ -1499,6 +1601,11 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             if let ::core::option::Option::Some(__record) = __record {
                                 #destroy_ctx_decl
                                 #destroy_before_delete
+                                // #1739: cascade this child's OWN dependents
+                                // (grandchildren) before removing the child row, so
+                                // a hard delete never leaves an FK-dangling
+                                // grandchild and never FK-fails the child delete.
+                                #grandchild_cascade
                                 #destroy_mutation
                                 #destroy_post_mutation
                             }
@@ -1506,6 +1613,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         ::core::result::Result::Ok(#destroy_ret_value)
                     }
                 }
+                })
             }
         }
     };
@@ -7932,6 +8040,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             id,
                             ::autumn_web::repository::DependentAction::#action_variant,
                             #parent_soft_lit,
+                            &mut __autumn_visited,
                         )
                         .await?
                 );
@@ -7950,6 +8059,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             .map(&emit_cascade_call)
             .collect();
         let cascade_calls = quote! {
+            // #1739 cycle guard: one visited (table, id) set for the whole
+            // cascade, seeded with this parent row so a grandchild that references
+            // an ancestor terminates instead of looping. Threaded by-ref into
+            // every `__autumn_apply_dependent_on_conn` call (direct + recursive).
+            let mut __autumn_visited: ::std::collections::HashSet<(&'static str, i64)> =
+                ::std::collections::HashSet::new();
+            __autumn_visited.insert((#table_name, id));
             // Phase 1: probe all `restrict` dependents first — a 409 here rolls
             // back before any mutating action fires a child hook.
             #(#restrict_calls)*
@@ -14629,7 +14745,7 @@ mod tests {
         // parent's cascade *call* site inside `delete_by_id`. Bound to the method
         // (it ends right before the always-generated `pub fn on_primary`).
         let hstart = generated
-            .find("pub async fn __autumn_apply_dependent_on_conn")
+            .find("pub fn __autumn_apply_dependent_on_conn")
             .expect("dependent-apply helper definition present");
         let hrest = &generated[hstart..];
         let hend = hrest.find("pub fn on_primary").unwrap_or(hrest.len());

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1397,9 +1397,76 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             .filter(|dep| dep.action != DependentAction::Restrict)
             .map(&emit_grandchild_call)
             .collect();
-        let grandchild_cascade = quote! {
+        // #1739 (repo-attribute deps): compile-time recursion over
+        // `config.dependents`. Emitted ONLY when this repo declares
+        // `dependent(...)`.
+        let compiletime_grandchild_cascade = quote! {
             #(#grandchild_restrict_calls)*
             #(#grandchild_mutating_calls)*
+        };
+        // Codex P1 (model-side deps): when this repo has NO repository-attribute
+        // `dependent(...)`, its grandchildren may be declared ONLY on the child
+        // model (via `#[has_many(..., dependent = ...)]`), which populates the
+        // runtime `Model::dependents()` slice but leaves `config.dependents`
+        // empty. The #1739 compile-time recursion above is then empty, so without
+        // this the child row would be deleted while its own children still
+        // FK-reference it (FK failure on a hard delete, or silent orphans). So
+        // consult THIS model's runtime specs and recurse into each grandchild,
+        // mirroring the top-level model-side dispatch: restrict-probe first (a
+        // 409 rolls the whole tx back), then mutating. Reuses the existing
+        // `__visited` (table, id) cycle-guard set, the boxed-future `fn`
+        // recursion (the `Send` edge stays erased through the fn-pointer), and
+        // the `__ret_broadcasts` deferred-broadcast buffer for grandchild
+        // broadcasts. For a model with no dependents this is a cheap no-op that
+        // iterates an empty `&[]`, so the plain path stays behavior-equivalent.
+        let runtime_grandchild_cascade = quote! {
+            // Inherent `dependents()` (real specs) shadows the blanket trait
+            // method (empty); unqualified so the shadow wins, `&[]` otherwise.
+            let __autumn_gc_rt_deps = #model_name::dependents();
+            for __autumn_gc_spec in __autumn_gc_rt_deps.iter().filter(|__s|
+                __s.action == ::autumn_web::repository::DependentAction::Restrict
+            ) {
+                __ret_broadcasts.extend(
+                    (__autumn_gc_spec.cascade)(
+                        &self.pool,
+                        conn,
+                        __cid,
+                        #child_soft_for_grandchildren,
+                        __visited,
+                    ).await?
+                );
+            }
+            for __autumn_gc_spec in __autumn_gc_rt_deps.iter().filter(|__s|
+                __s.action != ::autumn_web::repository::DependentAction::Restrict
+            ) {
+                __ret_broadcasts.extend(
+                    (__autumn_gc_spec.cascade)(
+                        &self.pool,
+                        conn,
+                        __cid,
+                        #child_soft_for_grandchildren,
+                        __visited,
+                    ).await?
+                );
+            }
+        };
+        // Precedence (mirrors the top-level rule exactly to avoid double-cascade):
+        // repository-attribute `config.dependents` WINS when present. So with
+        // repo-attribute deps we emit the #1739 compile-time recursion ONLY; with
+        // none we walk the runtime `Model::dependents()` ONLY. A grandchild is
+        // therefore never processed by both paths.
+        let grandchild_cascade = if has_dependents {
+            compiletime_grandchild_cascade
+        } else {
+            runtime_grandchild_cascade
+        };
+        // `use AutumnDependents` brings the blanket `dependents()` fallback into
+        // scope for the runtime walk (models without dependents), matching the
+        // top-level dispatch. Emitted only where the runtime walk is.
+        let dep_autumn_dependents_use = if has_dependents {
+            quote! {}
+        } else {
+            quote! { use ::autumn_web::repository::AutumnDependents as _; }
         };
 
         // Declaration + return of the deferred-broadcast buffer for the Destroy
@@ -1407,7 +1474,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         // additionally, when this repo has dependents (#1739), grandchild cascades
         // return their broadcasts here to propagate up to the top-level parent for
         // post-commit publishing. Repos with neither return an empty buffer.
-        let needs_ret_buffer = dep_needs_broadcast || has_dependents;
+        // The Destroy arm always declares `__ret_broadcasts` now (hence `true`):
+        // with repo-attribute deps for the #1739 compile-time grandchild
+        // broadcasts (`has_dependents`), and without them for the Codex-P1
+        // runtime model-side grandchild walk, which always emits its
+        // `__ret_broadcasts.extend(...)` even though the loop is a no-op for a
+        // model with no dependents. `dep_needs_broadcast` still additionally
+        // drives this repo's own broadcasts-only child accumulation.
+        let needs_ret_buffer = true;
         let destroy_ret_decl = if needs_ret_buffer {
             quote! {
                 let mut __ret_broadcasts: ::std::vec::Vec<(::std::string::String, ::std::string::String)> =
@@ -1491,6 +1565,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 use ::autumn_web::reexports::diesel::prelude::*;
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl;
                 #dep_hooks_use
+                #dep_autumn_dependents_use
                 let __table: &str = #table_name;
                 match __action {
                     ::autumn_web::repository::DependentAction::Restrict => {
@@ -15453,6 +15528,65 @@ mod tests {
             hard_section.contains("__autumn_apply_dependent_on_conn")
                 && hard_section.contains(", false ,"),
             "a hard-delete parent must pass __parent_soft = false to the cascade: {hard_section}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_helper_destroy_arm_runtime_dispatches_grandchildren_without_repo_attr_deps()
+    {
+        // Codex P1: a repository with NO repository-attribute `dependent(...)`
+        // must, in its `__autumn_apply_dependent_on_conn` Destroy arm, consult
+        // the child model's runtime `dependents()` and recurse into each
+        // grandchild spec — so a FULLY model-declared `Post -> Comment -> Reply`
+        // graph cascades all the way down. Without this the arm would delete the
+        // child while its own children still FK-reference it (FK failure /
+        // orphans), because `config.dependents` is empty and the #1739
+        // compile-time recursion is a no-op.
+        let generated = repository_macro(
+            quote! { Comment },
+            quote! { pub trait CommentRepository {} },
+        )
+        .to_string();
+        // The `AutumnDependents` fallback is `use`d in the helper prelude (above
+        // the match); the runtime walk itself lives in the Destroy arm.
+        let helper = dependent_helper_body(&generated);
+        assert!(
+            helper.contains("AutumnDependents"),
+            "the helper must bring the AutumnDependents fallback into scope: {helper}"
+        );
+        let destroy_arm = dependent_destroy_arm(&generated);
+        assert!(
+            destroy_arm.contains("dependents ()"),
+            "no-repo-attr destroy arm must runtime-dispatch grandchildren via Model::dependents(): {destroy_arm}"
+        );
+        assert!(
+            destroy_arm.contains(". cascade"),
+            "the runtime grandchild walk must invoke each spec's cascade thunk: {destroy_arm}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_helper_destroy_arm_repo_attr_deps_do_not_runtime_dispatch() {
+        // Precedence (Codex P1, mirrors the top-level rule exactly to avoid
+        // double-cascade): a repository-attribute `dependent(...)` WINS — the
+        // Destroy arm keeps the #1739 compile-time grandchild recursion ONLY and
+        // must NOT also walk the runtime `Model::dependents()`, so a grandchild
+        // is never processed by both paths.
+        let generated = repository_macro(
+            quote! { Comment, dependent(PgReplyRepository, fk = "comment_id", on_delete = destroy) },
+            quote! { pub trait CommentRepository {} },
+        )
+        .to_string();
+        let helper = dependent_helper_body(&generated);
+        assert!(
+            !helper.contains("AutumnDependents"),
+            "a repo-attribute dependent(...) helper must not runtime-dispatch \
+             (repo-attr wins, no double-cascade): {helper}"
+        );
+        let destroy_arm = dependent_destroy_arm(&generated);
+        assert!(
+            destroy_arm.contains("__autumn_apply_dependent_on_conn"),
+            "the #1739 compile-time grandchild recursion must remain: {destroy_arm}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1618,6 +1618,157 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
+    // #1740: bulk `delete_many` dependent cascade. `delete_many` historically
+    // bypassed `dependent(...)` entirely (a plain bulk parent delete), silently
+    // orphaning children. These tokens splice the SAME cascade the single-record
+    // delete path runs into both `delete_many_body` codegen branches (hooks and
+    // no-hooks). The whole cascade is gated on `config.dependents` so a repo with
+    // no dependents keeps its exact prior bulk codegen (AC: bulk semantics
+    // preserved). Correctness over raw throughput: children are cascaded per
+    // parent row via the shared `__autumn_apply_dependent_on_conn` helper (so
+    // `destroy` recurses into grandchildren for free, #1739), which is the "per
+    // row" tradeoff called out in the issue.
+    let delete_many_has_deps = !config.dependents.is_empty();
+    // The parent's delete kind drives the child `destroy` cascade: soft when the
+    // parent repo is `#[soft_delete]` (its bulk path soft-deletes), hard otherwise.
+    let delete_many_parent_soft_lit = if config.soft_delete {
+        quote! { true }
+    } else {
+        quote! { false }
+    };
+    let emit_delete_many_cascade_call = |dep: &DependentSpec| {
+        let child_repo = &dep.child_repo;
+        let fk = &dep.fk;
+        let action_variant = dep.action.variant_ident();
+        quote! {
+            let __autumn_dep_repo = #child_repo::with_pool_untracked(
+                ::core::clone::Clone::clone(&self.pool)
+            );
+            __autumn_dep_broadcasts.extend(
+                __autumn_dep_repo
+                    .__autumn_apply_dependent_on_conn(
+                        conn,
+                        #fk,
+                        __autumn_pid,
+                        ::autumn_web::repository::DependentAction::#action_variant,
+                        #delete_many_parent_soft_lit,
+                        &mut __autumn_visited,
+                    )
+                    .await?
+            );
+        }
+    };
+    let delete_many_restrict_calls: ::std::vec::Vec<_> = config
+        .dependents
+        .iter()
+        .filter(|dep| dep.action == DependentAction::Restrict)
+        .map(&emit_delete_many_cascade_call)
+        .collect();
+    let delete_many_mutating_calls: ::std::vec::Vec<_> = config
+        .dependents
+        .iter()
+        .filter(|dep| dep.action != DependentAction::Restrict)
+        .map(&emit_delete_many_cascade_call)
+        .collect();
+    // The affected parents are (re)loaded, tenant- and live-filtered and
+    // row-locked, exactly as the single-record path locks its parent, so the
+    // cascade runs only for rows this call actually deletes (never for a
+    // wrong-tenant or already-soft-deleted id present in the input slice).
+    let delete_many_live_filter = if config.soft_delete {
+        quote! { .filter(#table_ident::deleted_at.is_null()) }
+    } else {
+        quote! {}
+    };
+    let delete_many_preload_chunk = if config.tenant_scoped {
+        quote! {
+            let __autumn_dep_q = #table_ident::table
+                .filter(#table_ident::id.eq_any(chunk))
+                #delete_many_live_filter;
+            let __autumn_dep_rows: ::std::vec::Vec<#model_name> =
+                if let ::core::option::Option::Some(t) = tenant_id {
+                    __autumn_dep_q.filter(#table_ident::tenant_id.eq(t)).for_update()
+                        .load::<#model_name>(conn).await
+                } else {
+                    __autumn_dep_q.for_update().load::<#model_name>(conn).await
+                }
+                .map_err(::autumn_web::AutumnError::from)?;
+        }
+    } else {
+        quote! {
+            let __autumn_dep_rows: ::std::vec::Vec<#model_name> =
+                #table_ident::table
+                    .filter(#table_ident::id.eq_any(chunk))
+                    #delete_many_live_filter
+                    .for_update()
+                    .load::<#model_name>(conn).await
+                    .map_err(::autumn_web::AutumnError::from)?;
+        }
+    };
+    // The cascade block, spliced inside the transaction BEFORE the bulk parent
+    // delete. Restrict probes for every parent run first (a 409 rolls the whole
+    // transaction back before any mutating action), then the mutating dependents.
+    let delete_many_cascade = if delete_many_has_deps {
+        quote! {
+            let mut __autumn_visited: ::std::collections::HashSet<(&'static str, i64)> =
+                ::std::collections::HashSet::new();
+            let mut __autumn_dep_broadcasts: ::std::vec::Vec<(::std::string::String, ::std::string::String)> =
+                ::std::vec::Vec::new();
+            let mut __autumn_dep_parent_ids: ::std::vec::Vec<i64> = ::std::vec::Vec::new();
+            for chunk in ids.chunks(1000) {
+                #delete_many_preload_chunk
+                __autumn_dep_parent_ids.extend(__autumn_dep_rows.iter().map(|__r| __r.id));
+            }
+            // Phase 1: probe all `restrict` dependents for every parent first.
+            for &__autumn_pid in &__autumn_dep_parent_ids {
+                __autumn_visited.insert((#table_name, __autumn_pid));
+                #(#delete_many_restrict_calls)*
+            }
+            // Phase 2: mutating dependents per parent, in declaration order.
+            for &__autumn_pid in &__autumn_dep_parent_ids {
+                #(#delete_many_mutating_calls)*
+            }
+        }
+    } else {
+        quote! {}
+    };
+    // When dependents exist the transaction returns the deferred child broadcasts
+    // so they can be published post-commit (a rolled-back cascade publishes
+    // nothing); otherwise it returns `()` exactly as before.
+    let delete_many_tx_bind = if delete_many_has_deps {
+        quote! { let __autumn_dep_broadcasts = }
+    } else {
+        quote! {}
+    };
+    let delete_many_tx_ok = if delete_many_has_deps {
+        quote! { Ok(__autumn_dep_broadcasts) }
+    } else {
+        quote! { Ok(()) }
+    };
+    let delete_many_post_publish = if delete_many_has_deps {
+        quote! {
+            ::autumn_web::repository::publish_deferred_dependent_broadcasts(__autumn_dep_broadcasts);
+            // A cascaded `destroy` child may have enqueued a commit hook in the
+            // same transaction; kick the durable dispatcher (idempotent).
+            ::autumn_web::__private::kick_repository_commit_hook_dispatcher(&self.pool);
+        }
+    } else {
+        quote! {}
+    };
+    // The no-hooks `delete_many` body ends with the transaction as its tail
+    // expression (`... .await`). With dependents it must instead await-and-bind,
+    // then publish the deferred broadcasts after commit; without dependents it
+    // keeps the exact prior `.await` tail (returning the transaction's Result).
+    let delete_many_no_hooks_tail = if delete_many_has_deps {
+        quote! {
+            ?;
+            ::core::mem::drop(conn);
+            #delete_many_post_publish
+            Ok(())
+        }
+    } else {
+        quote! {}
+    };
+
     // Parse derived query methods from trait body
     let mut derived_trait_methods = Vec::new();
     let mut derived_impl_methods = Vec::new();
@@ -6074,7 +6225,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 let mut conn = self.__autumn_acquire_conn().await?;
                 let __now = ::autumn_web::reexports::chrono::Utc::now().naive_utc();
 
-                ::autumn_web::__private::scoped_transaction::<_, ::autumn_web::AutumnError, _, _>(&mut *conn, |conn| {
+                #delete_many_tx_bind ::autumn_web::__private::scoped_transaction::<_, ::autumn_web::AutumnError, _, _>(&mut *conn, |conn| {
                     async move {
                         let mut current_rows = Vec::new();
                         for chunk in ids.chunks(1000) {
@@ -6092,9 +6243,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             #delete_commit_hook_setup
                         }
 
+                        // #1740: cascade dependent actions for every parent BEFORE
+                        // the bulk parent delete, so no child is orphaned and the
+                        // parent delete never trips a foreign-key constraint.
+                        #delete_many_cascade
+
                         #delete_execution
 
-                        Ok(())
+                        #delete_many_tx_ok
                     }
                     .scope_boxed()
                 })
@@ -6102,6 +6258,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
                 ::core::mem::drop(conn);
                 #kick_dispatcher
+                #delete_many_post_publish
 
                 Ok(())
             }
@@ -7689,17 +7846,21 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 let mut conn = self.__autumn_acquire_conn().await?;
                 let __now = ::autumn_web::reexports::chrono::Utc::now().naive_utc();
 
-                ::autumn_web::__private::scoped_transaction::<_, ::autumn_web::AutumnError, _, _>(&mut *conn, |conn| {
+                #delete_many_tx_bind ::autumn_web::__private::scoped_transaction::<_, ::autumn_web::AutumnError, _, _>(&mut *conn, |conn| {
                     async move {
+                        // #1740: cascade dependent actions for every parent BEFORE
+                        // the bulk parent delete (empty for repos with no
+                        // dependents, preserving the prior bulk codegen).
+                        #delete_many_cascade
                         #vh_delete_load_before
                         #delete_loop
                         #vh_delete_filter
                         #vh_delete_write
-                        Ok(())
+                        #delete_many_tx_ok
                     }
                     .scope_boxed()
                 })
-                .await
+                .await #delete_many_no_hooks_tail
             }
         };
 
@@ -11954,13 +12115,15 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         fn update_many(&self, ids: &[i64], changes: &#update_name) -> impl ::std::future::Future<Output = ::autumn_web::AutumnResult<Vec<#model_name>>> + Send;
         /// Bulk-delete the given ids in one statement.
         ///
-        /// NOTE (#1369 scope; see #1702): `dependent(...)` cascade actions are
-        /// NOT applied on this bulk path — AC2 scopes dependent actions to the
-        /// single-record `delete_by_id`/`destroy`. On a repository that declares
-        /// `dependent(...)`, `delete_many` issues a plain bulk parent
-        /// delete/soft-delete and does not cascade, so it can FK-fail or orphan
-        /// children. Callers who need the cascade must use `delete_by_id`. Bulk
-        /// cascade is a tracked follow-up.
+        /// #1740: `dependent(...)` cascade actions DO apply on this bulk path. On
+        /// a repository that declares `dependent(...)`, `delete_many` runs the same
+        /// destroy/delete_all/nullify/restrict cascade the single-record
+        /// `delete_by_id`/`destroy` runs — restrict probes first (a typed 409 rolls
+        /// the whole transaction back), then children, then the bulk parent delete,
+        /// all in one transaction — so no child is orphaned. Children are cascaded
+        /// per affected parent row (so `destroy` recurses into grandchildren,
+        /// #1739); set-based bulk child mutations are a possible future refinement.
+        /// Repositories with no dependents keep the plain bulk delete unchanged.
         fn delete_many(&self, ids: &[i64]) -> impl ::std::future::Future<Output = ::autumn_web::AutumnResult<()>> + Send;
         #upsert_many_trait_method
     };

--- a/autumn/src/repository.rs
+++ b/autumn/src/repository.rs
@@ -157,17 +157,27 @@ pub type RuntimeDependentCascadeFuture<'a> = ::std::pin::Pin<
 /// `#[has_many(Child, dependent = …)]` association, resolving the child
 /// repository through the `Pg{Child}Repository` naming convention. Given the
 /// parent repository's pool, its live connection/transaction, the parent id,
-/// the parent's soft-delete kind, and the shared cycle-guard visited set, it
+/// the parent's soft-delete kind, and the two shared cascade-guard sets, it
 /// constructs the child repository and applies this one association's cascade,
 /// returning any deferred OOB delete broadcasts to publish post-commit.
 ///
+/// The two guard sets serve distinct roles (Codex round-5-B): `__path` is the
+/// ACTIVE recursion stack (pushed before descending into a node's children,
+/// popped once that subtree completes) used only to break self-/mutual-referential
+/// cycles; `__deleted` is a monotonic set of rows actually removed, used to skip a
+/// row already gone (so a row reached again — e.g. as another batch root's
+/// descendant — is neither re-deleted nor re-hooked). Keeping them separate lets a
+/// batch process a descendant root before its ancestor without the ancestor's
+/// cascade skipping a still-referenced intermediate (immediate-FK failure).
+///
 /// All references share one lifetime so the returned future can borrow the
-/// connection and visited set for exactly as long as it is awaited.
+/// connection and both guard sets for exactly as long as it is awaited.
 pub type RuntimeDependentCascadeFn = for<'a> fn(
     &'a ::diesel_async::pooled_connection::deadpool::Pool<::diesel_async::AsyncPgConnection>,
     &'a mut ::diesel_async::AsyncPgConnection,
     i64,
     bool,
+    &'a mut ::std::collections::HashSet<(&'static str, i64)>,
     &'a mut ::std::collections::HashSet<(&'static str, i64)>,
 ) -> RuntimeDependentCascadeFuture<'a>;
 

--- a/autumn/src/repository.rs
+++ b/autumn/src/repository.rs
@@ -151,7 +151,7 @@ pub type RuntimeDependentCascadeFuture<'a> = ::std::pin::Pin<
 >;
 
 /// A type-erased entry point into one child repository's
-/// [`__autumn_apply_dependent_on_conn`] leaf executor (#1738).
+/// `__autumn_apply_dependent_on_conn` leaf executor (#1738).
 ///
 /// `#[model]` emits one of these per model-declared
 /// `#[has_many(Child, dependent = …)]` association, resolving the child

--- a/autumn/src/repository.rs
+++ b/autumn/src/repository.rs
@@ -140,6 +140,97 @@ pub enum DependentAction {
     Restrict,
 }
 
+/// The boxed, `Send` future a [`RuntimeDependentCascadeFn`] returns.
+///
+/// It resolves to the deferred `(topic, dom_id)` OOB delete broadcasts a single
+/// child association's cascade accumulated (empty for a non-broadcasting child).
+pub type RuntimeDependentCascadeFuture<'a> = ::std::pin::Pin<
+    ::std::boxed::Box<
+        dyn ::std::future::Future<Output = crate::AutumnResult<Vec<(String, String)>>> + Send + 'a,
+    >,
+>;
+
+/// A type-erased entry point into one child repository's
+/// [`__autumn_apply_dependent_on_conn`] leaf executor (#1738).
+///
+/// `#[model]` emits one of these per model-declared
+/// `#[has_many(Child, dependent = …)]` association, resolving the child
+/// repository through the `Pg{Child}Repository` naming convention. Given the
+/// parent repository's pool, its live connection/transaction, the parent id,
+/// the parent's soft-delete kind, and the shared cycle-guard visited set, it
+/// constructs the child repository and applies this one association's cascade,
+/// returning any deferred OOB delete broadcasts to publish post-commit.
+///
+/// All references share one lifetime so the returned future can borrow the
+/// connection and visited set for exactly as long as it is awaited.
+pub type RuntimeDependentCascadeFn = for<'a> fn(
+    &'a ::diesel_async::pooled_connection::deadpool::Pool<::diesel_async::AsyncPgConnection>,
+    &'a mut ::diesel_async::AsyncPgConnection,
+    i64,
+    bool,
+    &'a mut ::std::collections::HashSet<(&'static str, i64)>,
+) -> RuntimeDependentCascadeFuture<'a>;
+
+/// One model-declared dependent-cascade association, produced at compile time
+/// by `#[model]` and consulted at run time by the parent's `delete_by_id`
+/// (#1738).
+///
+/// The `#[model]` and `#[repository]` derives are separate proc-macro
+/// invocations, so the repository macro — which owns the `delete_by_id` cascade
+/// codegen — never sees the model struct's `#[has_many]` attributes. This spec
+/// bridges the two at run time: the parent iterates
+/// [`AutumnDependents::dependents`] and drives each spec's [`cascade`] inside
+/// its transaction, reproducing exactly the cascade the repository-attribute
+/// `dependent(PgChildRepository, …)` form produces.
+///
+/// Framework plumbing; not constructed by hand.
+///
+/// [`cascade`]: RuntimeDependentSpec::cascade
+pub struct RuntimeDependentSpec {
+    /// The child foreign-key column referencing the parent id. Informational:
+    /// the [`cascade`] thunk already binds it. Mirrors the repository-attribute
+    /// `fk = "…"`.
+    ///
+    /// [`cascade`]: RuntimeDependentSpec::cascade
+    pub fk: &'static str,
+    /// What to do with the children when the parent is deleted.
+    pub action: DependentAction,
+    /// Type-erased entry into the child repository's cascade leaf executor.
+    pub cascade: RuntimeDependentCascadeFn,
+}
+
+/// Exposes a model's runtime dependent-cascade specs to the parent
+/// repository's generated `delete_by_id` (#1738).
+///
+/// A blanket impl returns an empty slice for every type; `#[model]` emits an
+/// *inherent* `dependents()` associated function — which shadows this trait
+/// method under Rust's inherent-before-trait resolution, mirroring the
+/// [`AutumnLockVersionModelExt`] pattern — only when the model declares at
+/// least one `#[has_many(…, dependent = …)]` / `#[has_one(…, dependent = …)]`
+/// association. The generated repository calls `Model::dependents()`, so a
+/// model with no dependents (or one defined without `#[model]`) resolves to the
+/// empty blanket and keeps its exact prior delete codegen.
+///
+/// Precedence: the repository-attribute `dependent(…)` form is the explicit
+/// escape hatch (needed for child repositories that do not follow the
+/// `Pg{Child}Repository` convention, e.g. cross-crate children). When a
+/// repository declares `dependent(…)`, its compile-time specs are authoritative
+/// and the model-declared runtime specs are ignored; a repository with no
+/// `dependent(…)` drives the cascade from `Model::dependents()`.
+pub trait AutumnDependents {
+    /// The model's dependent-cascade specs, in declaration order. Defaults to
+    /// none; `#[model]` overrides via an inherent shadow when dependents exist.
+    #[must_use]
+    fn dependents() -> &'static [RuntimeDependentSpec] {
+        &[]
+    }
+}
+
+// Blanket fallback — any type without an inherent `dependents()` (i.e. a model
+// with no dependent associations, or a type not built through `#[model]`)
+// resolves to the empty slice.
+impl<T: ?Sized> AutumnDependents for T {}
+
 /// Publish a batch of deferred dependent-cascade OOB *delete* broadcasts,
 /// accumulated during a `dependent = destroy` cascade over `broadcasts = true`
 /// children and published **after** the parent transaction commits (#1369).

--- a/autumn/tests/integration/repository_dependent_destroy.rs
+++ b/autumn/tests/integration/repository_dependent_destroy.rs
@@ -375,6 +375,45 @@ pub struct DepNode {
 )]
 pub trait DepNodeRepository {}
 
+// ── #1740: a HOOKED parent that also declares a dependent ─────────────────────
+//
+// All the dependent-declaring parents above are hook-free, so they exercise the
+// no-hooks `delete_many` codegen branch. This one has `hooks = ...` AND a
+// dependent, so it monomorphizes the HOOKS-path bulk-cascade branch (#1740) —
+// otherwise that branch would never be type-checked. Used only by the codegen
+// surface test (no Docker graph test), so it reuses an existing child repo.
+
+#[derive(Clone, Default)]
+pub struct DepHookedPostHooks;
+
+impl MutationHooks for DepHookedPostHooks {
+    type Model = DepHookedPost;
+    type NewModel = NewDepHookedPost;
+    type UpdateModel = UpdateDepHookedPost;
+}
+
+diesel::table! {
+    dep_hooked_posts (id) {
+        id -> Int8,
+        title -> Text,
+    }
+}
+
+#[autumn_web::model(table = "dep_hooked_posts")]
+pub struct DepHookedPost {
+    #[id]
+    pub id: i64,
+    pub title: String,
+}
+
+#[autumn_web::repository(
+    DepHookedPost,
+    table = "dep_hooked_posts",
+    hooks = DepHookedPostHooks,
+    dependent(PgDepCommentRepository, fk = "post_id", on_delete = destroy)
+)]
+pub trait DepHookedPostRepository {}
+
 // ── Row-count helpers ─────────────────────────────────────────────────────────
 
 #[derive(diesel::QueryableByName)]
@@ -462,6 +501,14 @@ fn dependent_repository_surface_is_generated() {
     assert_is_fn(PgDep3ReplyRepository::__autumn_apply_dependent_on_conn);
     assert_is_fn(<PgDepNodeRepository as DepNodeRepository>::delete_by_id);
     assert_is_fn(PgDepNodeRepository::__autumn_apply_dependent_on_conn);
+    // #1740: the bulk `delete_many` path now carries the dependent cascade too;
+    // monomorphize it (hooks-child parent + restrict-only parent) to prove the
+    // bulk-cascade codegen type-checks without Docker.
+    assert_is_fn(<PgDepPostRepository as DepPostRepository>::delete_many);
+    assert_is_fn(<PgDepPostRestrictOnlyRepository as DepPostRestrictOnlyRepository>::delete_many);
+    // Hooks-path bulk cascade branch (#1740): a hooked parent with a dependent.
+    assert_is_fn(<PgDepHookedPostRepository as DepHookedPostRepository>::delete_many);
+    assert_is_fn(<PgDepHookedPostRepository as DepHookedPostRepository>::delete_by_id);
 }
 
 // ── Tests (require Docker) ────────────────────────────────────────────────────
@@ -555,6 +602,126 @@ async fn deleting_parent_cascades_and_leaves_no_orphans() {
     // AC4: each destroyed comment fired its before_delete hook.
     // (UFCS: `RunQueryDsl` is in scope, so disambiguate from diesel's `.load`.)
     assert_eq!(AtomicUsize::load(&DESTROYED_COMMENTS, Ordering::SeqCst), 3);
+}
+
+/// #1740: `delete_many` on parents with `dependent(...)` runs the SAME cascade
+/// as `delete_by_id` — `destroy`/`delete_all`/`nullify` per child association —
+/// for every parent, in one transaction, leaving no orphaned or FK-dangling rows.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn delete_many_cascades_dependents() {
+    let (pool, _c) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+
+    // Two parents, each with a comment (destroy), a vote (delete_all) and a
+    // bookmark (nullify).
+    for p in 1..=2 {
+        diesel::sql_query(format!(
+            "INSERT INTO dep_posts (id, title) VALUES ({p}, 'p{p}')"
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+        diesel::sql_query(format!(
+            "INSERT INTO dep_comments (id, post_id, body) VALUES ({p}, {p}, 'c{p}')"
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+        diesel::sql_query(format!(
+            "INSERT INTO dep_votes (id, post_id, value) VALUES ({p}, {p}, 1)"
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+        diesel::sql_query(format!(
+            "INSERT INTO dep_bookmarks (id, post_id, label) VALUES ({p}, {p}, 'b{p}')"
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    }
+
+    DESTROYED_COMMENTS.store(0, Ordering::SeqCst);
+
+    let repo = PgDepPostRepository::with_pool_untracked(pool.clone());
+    repo.delete_many(&[1, 2])
+        .await
+        .expect("bulk cascade delete must not FK-error");
+
+    assert_eq!(
+        count(&mut conn, "SELECT COUNT(*) AS n FROM dep_posts").await,
+        0,
+        "both parents deleted"
+    );
+    assert_eq!(
+        count(&mut conn, "SELECT COUNT(*) AS n FROM dep_comments").await,
+        0,
+        "#1740: destroy children cascaded on the bulk path"
+    );
+    assert_eq!(
+        count(&mut conn, "SELECT COUNT(*) AS n FROM dep_votes").await,
+        0,
+        "#1740: delete_all children cascaded on the bulk path"
+    );
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_bookmarks WHERE post_id IS NOT NULL"
+        )
+        .await,
+        0,
+        "#1740: nullify children detached on the bulk path"
+    );
+    // Both destroy children fired their before_delete hook during the bulk cascade.
+    assert_eq!(AtomicUsize::load(&DESTROYED_COMMENTS, Ordering::SeqCst), 2);
+}
+
+/// #1740: a `restrict` dependent still blocks a bulk `delete_many` with a typed
+/// 409 and rolls the whole transaction back (no parent or child removed).
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn delete_many_restrict_blocks_and_rolls_back() {
+    let (pool, _c) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+
+    diesel::sql_query("INSERT INTO dep_posts (id, title) VALUES (7, 'guarded'), (8, 'free')")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    // Only post 7 has a restrict child; the bulk delete of [7, 8] must still be
+    // blocked and rolled back wholesale (post 8 survives too).
+    diesel::sql_query("INSERT INTO dep_awards (id, post_id, name) VALUES (1, 7, 'gold')")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    let repo = PgDepPostRestrictOnlyRepository::with_pool_untracked(pool.clone());
+    let err = repo
+        .delete_many(&[7, 8])
+        .await
+        .expect_err("restrict child must block the bulk delete");
+    assert_eq!(
+        err.status(),
+        autumn_web::reexports::http::StatusCode::CONFLICT,
+        "a blocking restrict must surface a 409 on the bulk path"
+    );
+
+    // Whole transaction rolled back: both parents and the child survive.
+    assert_eq!(
+        count(&mut conn, "SELECT COUNT(*) AS n FROM dep_posts").await,
+        2,
+        "both parents survive a blocked bulk delete"
+    );
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_awards WHERE post_id = 7"
+        )
+        .await,
+        1,
+        "the restrict child survives"
+    );
 }
 
 /// #1739: deleting a `Dep3Post` with `dependent(Comment, destroy)` where

--- a/autumn/tests/integration/repository_dependent_destroy.rs
+++ b/autumn/tests/integration/repository_dependent_destroy.rs
@@ -513,6 +513,71 @@ pub struct DepImmNode {
 )]
 pub trait DepImmNodeRepository {}
 
+// ── Codex round-4: a HOOKED self-referential `destroy` (2-cycle re-entry) ──────
+//
+// `dep_cycle_nodes.parent_id` references the same table via a DEFERRABLE self-FK
+// (so a true 2-cycle can exist), the repository declares `dependent = destroy`
+// back onto itself, AND the model fires a `before_delete` hook that LOGS the id
+// of every row it deletes. For a 2-cycle A.parent_id = B, B.parent_id = A,
+// `delete_many([A])` must:
+//   1. fire A's `before_delete` hook EXACTLY ONCE (as the bulk parent delete) —
+//      NOT twice (it must not be re-entered as a cascaded child through B's
+//      destroy executor before the final bulk parent delete), and
+//   2. remove BOTH rows.
+// Before the round-4 fix the bulk loop never seeded the current root into the
+// shared visited set, so cascading A → child B → grandchild A re-entered A and
+// fired its hook a second time (as a cascaded child) before the bulk parent
+// delete. Seeding the current root immediately before its own destroy cascade
+// (mirroring `delete_by_id`) closes the re-entry.
+
+use std::sync::Mutex;
+
+// Records the id of every `DepCycleNode` whose `before_delete` hook fires, in
+// order. A row appearing twice means it was re-entered as a cascaded child.
+pub static CYCLE_DELETE_LOG: Mutex<Vec<i64>> = Mutex::new(Vec::new());
+
+#[derive(Clone, Default)]
+pub struct DepCycleNodeHooks;
+
+impl MutationHooks for DepCycleNodeHooks {
+    type Model = DepCycleNode;
+    type NewModel = NewDepCycleNode;
+    type UpdateModel = UpdateDepCycleNode;
+
+    async fn before_delete(
+        &self,
+        _ctx: &mut MutationContext,
+        record: &DepCycleNode,
+    ) -> AutumnResult<()> {
+        CYCLE_DELETE_LOG.lock().unwrap().push(record.id);
+        Ok(())
+    }
+}
+
+diesel::table! {
+    dep_cycle_nodes (id) {
+        id -> Int8,
+        parent_id -> Nullable<Int8>,
+        name -> Text,
+    }
+}
+
+#[autumn_web::model(table = "dep_cycle_nodes")]
+pub struct DepCycleNode {
+    #[id]
+    pub id: i64,
+    pub parent_id: Option<i64>,
+    pub name: String,
+}
+
+#[autumn_web::repository(
+    DepCycleNode,
+    table = "dep_cycle_nodes",
+    hooks = DepCycleNodeHooks,
+    dependent(PgDepCycleNodeRepository, fk = "parent_id", on_delete = destroy)
+)]
+pub trait DepCycleNodeRepository {}
+
 // ── #1740: a HOOKED parent that also declares a dependent ─────────────────────
 //
 // All the dependent-declaring parents above are hook-free, so they exercise the
@@ -610,6 +675,10 @@ async fn setup_pool() -> (
         // Codex P2: IMMEDIATE (non-deferrable) self-referential FK — the check
         // fires per-row, so the cascade cannot rely on deferral to COMMIT.
         "CREATE TABLE dep_imm_nodes (id BIGSERIAL PRIMARY KEY, parent_id BIGINT REFERENCES dep_imm_nodes(id), name TEXT NOT NULL)",
+        // Codex round-4: HOOKED self-referential FK, DEFERRABLE so a true 2-cycle
+        // (A.parent_id = B, B.parent_id = A) can exist — the bulk cascade must seed
+        // the current root before recursing so the root's hook fires exactly once.
+        "CREATE TABLE dep_cycle_nodes (id BIGSERIAL PRIMARY KEY, parent_id BIGINT REFERENCES dep_cycle_nodes(id) DEFERRABLE INITIALLY DEFERRED, name TEXT NOT NULL)",
     ] {
         diesel::sql_query(stmt)
             .execute(&mut conn)
@@ -650,6 +719,12 @@ fn dependent_repository_surface_is_generated() {
     // monomorphizes (its cascade must not pre-seed batch targets).
     assert_is_fn(<PgDepImmNodeRepository as DepImmNodeRepository>::delete_many);
     assert_is_fn(PgDepImmNodeRepository::__autumn_apply_dependent_on_conn);
+    // Codex round-4: the HOOKED self-referential parent's bulk delete_many
+    // monomorphizes the HOOKS-path bulk self-ref cascade (its Phase-2 loop seeds
+    // the current root before recursing, so a 2-cycle can't re-enter the root as a
+    // cascaded child and double-fire its hook).
+    assert_is_fn(<PgDepCycleNodeRepository as DepCycleNodeRepository>::delete_many);
+    assert_is_fn(PgDepCycleNodeRepository::__autumn_apply_dependent_on_conn);
     // #1740: the bulk `delete_many` path now carries the dependent cascade too;
     // monomorphize it (hooks-child parent + restrict-only parent) to prove the
     // bulk-cascade codegen type-checks without Docker.
@@ -1173,6 +1248,72 @@ async fn delete_many_self_referential_immediate_fk_removes_whole_subtree() {
         0,
         "Codex P2: the whole reachable subtree (ancestor, intermediate, \
          descendant) is destroyed with no immediate FK violation"
+    );
+}
+
+/// Codex round-4: `delete_many([A])` on a self-referential `dependent = destroy`
+/// graph that forms a TRUE 2-cycle (`A.parent_id` = B, `B.parent_id` = A) must fire
+/// A's `before_delete` hook EXACTLY ONCE (as the bulk parent delete) and remove
+/// BOTH rows. Before the fix the bulk cascade never seeded the current root into
+/// the shared visited set, so cascading A → child B → grandchild A re-entered A
+/// through B's destroy executor and fired A's hook a SECOND time (as a cascaded
+/// child) before the final bulk parent delete. Seeding the current root
+/// immediately before its own destroy cascade (mirroring `delete_by_id`) closes
+/// the re-entry while still cascading B deepest-first.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn delete_many_self_referential_two_cycle_fires_root_hook_once() {
+    let (pool, _c) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+
+    // Insert with NULL parents first (satisfy the deferrable FK), then wire the
+    // 2-cycle: node 1 (A).parent_id = 2 (B), node 2 (B).parent_id = 1 (A).
+    for id in 1..=2 {
+        diesel::sql_query(format!(
+            "INSERT INTO dep_cycle_nodes (id, parent_id, name) VALUES ({id}, NULL, 'n{id}')"
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    }
+    diesel::sql_query("UPDATE dep_cycle_nodes SET parent_id = 2 WHERE id = 1")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    diesel::sql_query("UPDATE dep_cycle_nodes SET parent_id = 1 WHERE id = 2")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    CYCLE_DELETE_LOG.lock().unwrap().clear();
+
+    let repo = PgDepCycleNodeRepository::with_pool_untracked(pool.clone());
+    // Bulk-delete only A (node 1). The cascade must reach B (node 2) but must NOT
+    // re-enter A as a cascaded child.
+    repo.delete_many(&[1])
+        .await
+        .expect("round-4: bulk self-ref 2-cycle delete must terminate without error");
+
+    // Both rows removed (the whole cyclic component reachable from A).
+    assert_eq!(
+        count(&mut conn, "SELECT COUNT(*) AS n FROM dep_cycle_nodes").await,
+        0,
+        "round-4: both rows of the 2-cycle are destroyed"
+    );
+
+    // The root A (id 1) fired its `before_delete` hook EXACTLY ONCE — it was not
+    // re-entered as a cascaded child. B (id 2) also fires once (cascaded child).
+    let log: Vec<i64> = CYCLE_DELETE_LOG.lock().unwrap().clone();
+    assert_eq!(
+        log.iter().filter(|&&id| id == 1).count(),
+        1,
+        "round-4: the bulk root's before_delete hook must fire EXACTLY ONCE \
+         (not re-entered as a cascaded child): log = {log:?}"
+    );
+    assert_eq!(
+        log.iter().filter(|&&id| id == 2).count(),
+        1,
+        "round-4: the cascaded child fires once: log = {log:?}"
     );
 }
 

--- a/autumn/tests/integration/repository_dependent_destroy.rs
+++ b/autumn/tests/integration/repository_dependent_destroy.rs
@@ -664,6 +664,10 @@ fn dependent_repository_surface_is_generated() {
     // from the model side with no repository-attribute `dependent(...)`)
     // type-checks against the same four cascade actions.
     assert_is_fn(<PgModelDepPostRepository as ModelDepPostRepository>::delete_by_id);
+    // Codex P1: the model-declared parent's bulk `delete_many` monomorphizes too —
+    // proving the runtime `RuntimeDependentSpec` dispatch on the BULK path (all
+    // four actions: destroy + delete_all + restrict) type-checks.
+    assert_is_fn(<PgModelDepPostRepository as ModelDepPostRepository>::delete_many);
     // The model exposes its runtime dependent specs (inherent shadow of
     // `AutumnDependents::dependents`): destroy + delete_all + restrict.
     assert_is_fn(ModelDepPost::dependents);
@@ -675,6 +679,9 @@ fn dependent_repository_surface_is_generated() {
     // dependent ONLY model-side (empty `config.dependents`). Referencing the
     // helper + both `delete_by_id`s type-checks that recursive runtime path.
     assert_is_fn(<PgM3PostRepository as M3PostRepository>::delete_by_id);
+    // Codex P1: the fully model-side parent's BULK delete_many must also
+    // runtime-dispatch (and recurse into model-side grandchildren).
+    assert_is_fn(<PgM3PostRepository as M3PostRepository>::delete_many);
     assert_is_fn(<PgM3CommentRepository as M3CommentRepository>::delete_by_id);
     assert_is_fn(PgM3CommentRepository::__autumn_apply_dependent_on_conn);
     assert_is_fn(PgM3ReplyRepository::__autumn_apply_dependent_on_conn);
@@ -1012,6 +1019,63 @@ async fn deleting_model_side_parent_recurses_into_model_side_grandchildren() {
         0,
         "Codex P1: all replies (grandchildren) must be recursively destroyed via \
          the child's runtime Model::dependents() — zero left"
+    );
+}
+
+/// Codex P1: bulk `delete_many` on a FULLY model-side parent (`M3Post`, whose
+/// `#[has_many(M3Comment, dependent = destroy)]` is declared only on the model
+/// struct, no repository-attribute `dependent(...)`) must cascade — the bulk
+/// path has to consult the runtime `M3Post::dependents()` just like `delete_by_id`
+/// does, otherwise the children are orphaned / FK-error. Deleting `[1, 2]` must
+/// leave zero comments AND zero (grandchild) replies, in one transaction.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn delete_many_model_side_parent_cascades_via_runtime_dispatch() {
+    let (pool, _c) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+
+    // Two posts, each with a comment, each comment with a reply (grandchild).
+    for p in 1..=2 {
+        diesel::sql_query(format!(
+            "INSERT INTO m3_posts (id, title) VALUES ({p}, 'p{p}')"
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+        diesel::sql_query(format!(
+            "INSERT INTO m3_comments (id, post_id, body) VALUES ({p}, {p}, 'c{p}')"
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+        diesel::sql_query(format!(
+            "INSERT INTO m3_replys (id, comment_id, body) VALUES ({p}, {p}, 'r{p}')"
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    }
+
+    let repo = PgM3PostRepository::with_pool_untracked(pool.clone());
+    repo.delete_many(&[1, 2])
+        .await
+        .expect("Codex P1: model-side bulk cascade must not FK-error / orphan");
+
+    assert_eq!(
+        count(&mut conn, "SELECT COUNT(*) AS n FROM m3_posts").await,
+        0,
+        "both parents deleted"
+    );
+    assert_eq!(
+        count(&mut conn, "SELECT COUNT(*) AS n FROM m3_comments").await,
+        0,
+        "Codex P1: model-declared destroy children cascaded on the BULK path — zero left"
+    );
+    assert_eq!(
+        count(&mut conn, "SELECT COUNT(*) AS n FROM m3_replys").await,
+        0,
+        "Codex P1: grandchildren recursively destroyed on the bulk path via the \
+         child's runtime Model::dependents() — zero left"
     );
 }
 

--- a/autumn/tests/integration/repository_dependent_destroy.rs
+++ b/autumn/tests/integration/repository_dependent_destroy.rs
@@ -273,6 +273,108 @@ pub struct DepHardSoftComment {
 #[autumn_web::repository(DepHardSoftComment, table = "dep_hard_soft_comments", soft_delete)]
 pub trait DepHardSoftCommentRepository {}
 
+// ── #1739: three-level grandchild destroy graph (Post → Comment → Reply) ──────
+//
+// Both `Dep3Post` and `Dep3Comment` declare `dependent = destroy`. Deleting a
+// post must recurse: destroy its comments AND each comment's replies, in one
+// transaction, leaving zero orphaned grandchildren. This is the exact #1739
+// acceptance graph.
+
+diesel::table! {
+    dep3_posts (id) {
+        id -> Int8,
+        title -> Text,
+    }
+}
+
+#[autumn_web::model(table = "dep3_posts")]
+pub struct Dep3Post {
+    #[id]
+    pub id: i64,
+    pub title: String,
+}
+
+#[autumn_web::repository(
+    Dep3Post,
+    table = "dep3_posts",
+    dependent(PgDep3CommentRepository, fk = "post_id", on_delete = destroy)
+)]
+pub trait Dep3PostRepository {}
+
+diesel::table! {
+    dep3_comments (id) {
+        id -> Int8,
+        post_id -> Int8,
+        body -> Text,
+    }
+}
+
+#[autumn_web::model(table = "dep3_comments")]
+pub struct Dep3Comment {
+    #[id]
+    pub id: i64,
+    pub post_id: i64,
+    pub body: String,
+}
+
+#[autumn_web::repository(
+    Dep3Comment,
+    table = "dep3_comments",
+    dependent(PgDep3ReplyRepository, fk = "comment_id", on_delete = destroy)
+)]
+pub trait Dep3CommentRepository {}
+
+diesel::table! {
+    dep3_replies (id) {
+        id -> Int8,
+        comment_id -> Int8,
+        body -> Text,
+    }
+}
+
+#[autumn_web::model(table = "dep3_replies")]
+pub struct Dep3Reply {
+    #[id]
+    pub id: i64,
+    pub comment_id: i64,
+    pub body: String,
+}
+
+#[autumn_web::repository(Dep3Reply, table = "dep3_replies")]
+pub trait Dep3ReplyRepository {}
+
+// ── #1739 cycle guard: a self-referential `destroy` dependent ─────────────────
+//
+// `dep_nodes.parent_id` references `dep_nodes.id`, and the repository declares a
+// `dependent = destroy` back onto itself. This is the self-referential cycle the
+// visited-set guard must survive: deleting a node destroys its children, which
+// recurse into THEIR children, etc.  Even with cyclic data (a descendant whose
+// FK points back at an ancestor) the traversal must terminate rather than
+// looping forever or overflowing the (boxed) recursive future.
+
+diesel::table! {
+    dep_nodes (id) {
+        id -> Int8,
+        parent_id -> Nullable<Int8>,
+        name -> Text,
+    }
+}
+
+#[autumn_web::model(table = "dep_nodes")]
+pub struct DepNode {
+    #[id]
+    pub id: i64,
+    pub parent_id: Option<i64>,
+    pub name: String,
+}
+
+#[autumn_web::repository(
+    DepNode,
+    table = "dep_nodes",
+    dependent(PgDepNodeRepository, fk = "parent_id", on_delete = destroy)
+)]
+pub trait DepNodeRepository {}
+
 // ── Row-count helpers ─────────────────────────────────────────────────────────
 
 #[derive(diesel::QueryableByName)]
@@ -315,6 +417,15 @@ async fn setup_pool() -> (
         "CREATE TABLE dep_soft_comments (id BIGSERIAL PRIMARY KEY, post_id BIGINT NOT NULL REFERENCES dep_soft_posts(id), body TEXT NOT NULL, deleted_at TIMESTAMP NULL)",
         "CREATE TABLE dep_hard_posts (id BIGSERIAL PRIMARY KEY, title TEXT NOT NULL)",
         "CREATE TABLE dep_hard_soft_comments (id BIGSERIAL PRIMARY KEY, post_id BIGINT NOT NULL REFERENCES dep_hard_posts(id), body TEXT NOT NULL, deleted_at TIMESTAMP NULL)",
+        "CREATE TABLE dep3_posts (id BIGSERIAL PRIMARY KEY, title TEXT NOT NULL)",
+        "CREATE TABLE dep3_comments (id BIGSERIAL PRIMARY KEY, post_id BIGINT NOT NULL REFERENCES dep3_posts(id), body TEXT NOT NULL)",
+        "CREATE TABLE dep3_replies (id BIGSERIAL PRIMARY KEY, comment_id BIGINT NOT NULL REFERENCES dep3_comments(id), body TEXT NOT NULL)",
+        // Self-referential FK: parent_id references the same table. The FK is
+        // DEFERRABLE INITIALLY DEFERRED so a *cyclic* component can be hard-deleted
+        // within one transaction (the constraint is checked at COMMIT, by which
+        // point every row in the cycle is gone). ON DELETE has no DB-level cascade
+        // — the framework cascade is what must clear the whole component.
+        "CREATE TABLE dep_nodes (id BIGSERIAL PRIMARY KEY, parent_id BIGINT REFERENCES dep_nodes(id) DEFERRABLE INITIALLY DEFERRED, name TEXT NOT NULL)",
     ] {
         diesel::sql_query(stmt)
             .execute(&mut conn)
@@ -343,6 +454,14 @@ fn dependent_repository_surface_is_generated() {
     assert_is_fn(<PgDepSoftPostRepository as DepSoftPostRepository>::delete_by_id);
     assert_is_fn(<PgDepHardPostRepository as DepHardPostRepository>::delete_by_id);
     assert_is_fn(PgDepHardSoftCommentRepository::__autumn_apply_dependent_on_conn);
+    // #1739: the grandchild graph and the self-referential cycle repo both
+    // monomorphize — proving the recursive (boxed-future) cascade codegen
+    // type-checks, including a repository that cascades onto its own type.
+    assert_is_fn(<PgDep3PostRepository as Dep3PostRepository>::delete_by_id);
+    assert_is_fn(PgDep3CommentRepository::__autumn_apply_dependent_on_conn);
+    assert_is_fn(PgDep3ReplyRepository::__autumn_apply_dependent_on_conn);
+    assert_is_fn(<PgDepNodeRepository as DepNodeRepository>::delete_by_id);
+    assert_is_fn(PgDepNodeRepository::__autumn_apply_dependent_on_conn);
 }
 
 // ── Tests (require Docker) ────────────────────────────────────────────────────
@@ -436,6 +555,112 @@ async fn deleting_parent_cascades_and_leaves_no_orphans() {
     // AC4: each destroyed comment fired its before_delete hook.
     // (UFCS: `RunQueryDsl` is in scope, so disambiguate from diesel's `.load`.)
     assert_eq!(AtomicUsize::load(&DESTROYED_COMMENTS, Ordering::SeqCst), 3);
+}
+
+/// #1739: deleting a `Dep3Post` with `dependent(Comment, destroy)` where
+/// `Comment` has `dependent(Reply, destroy)` must recurse — leaving zero
+/// `Dep3Reply` (grandchild) rows and zero orphaned comments, in one
+/// transaction, with no FK error.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn deleting_parent_recurses_into_grandchildren() {
+    let (pool, _c) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+
+    diesel::sql_query("INSERT INTO dep3_posts (id, title) VALUES (1, 'p')")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    // 2 comments, each with 2 replies → 4 grandchildren.
+    for c in 1..=2 {
+        diesel::sql_query(format!(
+            "INSERT INTO dep3_comments (id, post_id, body) VALUES ({c}, 1, 'c{c}')"
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+        for r in 1..=2 {
+            let rid = c * 10 + r;
+            diesel::sql_query(format!(
+                "INSERT INTO dep3_replies (id, comment_id, body) VALUES ({rid}, {c}, 'r{rid}')"
+            ))
+            .execute(&mut conn)
+            .await
+            .unwrap();
+        }
+    }
+
+    let repo = PgDep3PostRepository::with_pool_untracked(pool.clone());
+    repo.delete_by_id(1)
+        .await
+        .expect("recursive cascade must not FK-error");
+
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep3_posts WHERE id = 1"
+        )
+        .await,
+        0,
+        "parent gone"
+    );
+    assert_eq!(
+        count(&mut conn, "SELECT COUNT(*) AS n FROM dep3_comments").await,
+        0,
+        "all comments (children) destroyed"
+    );
+    assert_eq!(
+        count(&mut conn, "SELECT COUNT(*) AS n FROM dep3_replies").await,
+        0,
+        "#1739: all replies (grandchildren) must be recursively destroyed — zero left"
+    );
+}
+
+/// #1739 cycle guard: a self-referential `destroy` cascade over a cyclic graph
+/// (a descendant whose `parent_id` points back at an ancestor) must terminate,
+/// not infinite-loop, and remove the whole reachable component in one tx.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn self_referential_destroy_terminates_on_cycle() {
+    let (pool, _c) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+
+    // Chain 1 → 2 → 3, then create a cycle by pointing 1's parent at 3.
+    // (Insert with NULL parents first to satisfy the FK, then wire the edges.)
+    for id in 1..=3 {
+        diesel::sql_query(format!(
+            "INSERT INTO dep_nodes (id, parent_id, name) VALUES ({id}, NULL, 'n{id}')"
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    }
+    // 2's parent = 1, 3's parent = 2, 1's parent = 3 → a 3-cycle.
+    diesel::sql_query("UPDATE dep_nodes SET parent_id = 1 WHERE id = 2")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    diesel::sql_query("UPDATE dep_nodes SET parent_id = 2 WHERE id = 3")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    diesel::sql_query("UPDATE dep_nodes SET parent_id = 3 WHERE id = 1")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    let repo = PgDepNodeRepository::with_pool_untracked(pool.clone());
+    // Must return (not hang / overflow). The visited-set guard breaks the cycle.
+    repo.delete_by_id(1)
+        .await
+        .expect("self-referential cascade over a cycle must terminate without error");
+
+    // The entire cyclic component is reachable from node 1 and removed.
+    assert_eq!(
+        count(&mut conn, "SELECT COUNT(*) AS n FROM dep_nodes").await,
+        0,
+        "#1739 cycle guard: the whole reachable cyclic component is destroyed, no rows left"
+    );
 }
 
 /// AC5: `dependent = restrict` blocks the delete with a typed 409 Conflict when

--- a/autumn/tests/integration/repository_dependent_destroy.rs
+++ b/autumn/tests/integration/repository_dependent_destroy.rs
@@ -578,6 +578,149 @@ pub struct DepCycleNode {
 )]
 pub trait DepCycleNodeRepository {}
 
+// ── Codex round-5-A: grandchild `restrict` must probe BEFORE the child hook ────
+//
+// Graph: `ra_posts` → `ra_comments` (dependent = destroy, with a `before_delete`
+// hook) → `ra_replies` (dependent = restrict). Deleting a post cascades into the
+// comment `destroy`; because the comment has a `restrict` grandchild (a reply),
+// the delete must return 409 — and it must do so WITHOUT firing the comment's
+// `before_delete` hook, since a non-transactional hook side effect on a doomed
+// transaction cannot be undone. The Destroy arm therefore probes the grandchild
+// restrict (read-only) BEFORE running the child `before_delete`.
+
+// Counts how many times `RaComment::before_delete` fired. Must stay 0 when a
+// grandchild restrict blocks the delete (round-5-A).
+pub static RA_COMMENT_HOOK_FIRED: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Clone, Default)]
+pub struct RaCommentHooks;
+
+impl MutationHooks for RaCommentHooks {
+    type Model = RaComment;
+    type NewModel = NewRaComment;
+    type UpdateModel = UpdateRaComment;
+
+    async fn before_delete(
+        &self,
+        _ctx: &mut MutationContext,
+        _record: &RaComment,
+    ) -> AutumnResult<()> {
+        RA_COMMENT_HOOK_FIRED.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+diesel::table! {
+    ra_posts (id) { id -> Int8, title -> Text, }
+}
+diesel::table! {
+    ra_comments (id) { id -> Int8, post_id -> Int8, body -> Text, }
+}
+diesel::table! {
+    ra_replies (id) { id -> Int8, comment_id -> Int8, body -> Text, }
+}
+
+#[autumn_web::model(table = "ra_posts")]
+pub struct RaPost {
+    #[id]
+    pub id: i64,
+    pub title: String,
+}
+
+#[autumn_web::model(table = "ra_comments")]
+pub struct RaComment {
+    #[id]
+    pub id: i64,
+    pub post_id: i64,
+    pub body: String,
+}
+
+#[autumn_web::model(table = "ra_replies")]
+pub struct RaReply {
+    #[id]
+    pub id: i64,
+    pub comment_id: i64,
+    pub body: String,
+}
+
+#[autumn_web::repository(
+    RaPost,
+    table = "ra_posts",
+    dependent(PgRaCommentRepository, fk = "post_id", on_delete = destroy)
+)]
+pub trait RaPostRepository {}
+
+#[autumn_web::repository(
+    RaComment,
+    table = "ra_comments",
+    hooks = RaCommentHooks,
+    dependent(PgRaReplyRepository, fk = "comment_id", on_delete = restrict)
+)]
+pub trait RaCommentRepository {}
+
+#[autumn_web::repository(RaReply, table = "ra_replies")]
+pub trait RaReplyRepository {}
+
+// ── Codex round-5-B: HOOKED self-referential chain with an IMMEDIATE self-FK ───
+//
+// `chain_nodes.parent_id` references the same table with a NON-deferrable FK, and
+// the model logs every `before_delete`. Chain Anc(1) ← I(2) ← D(3) (child's
+// parent_id points at its parent). Bulk `delete_many([D, Anc])` — a descendant
+// and its ancestor, with the intermediate NOT in the batch — must:
+//   1. remove all three rows with NO immediate FK violation (the ancestor's
+//      cascade deletes D deepest-first, before the intermediate it references), and
+//   2. fire D's `before_delete` hook EXACTLY ONCE (not once as a cascaded
+//      descendant AND once as a batch root).
+// Under the round-4 monotonic per-root seed, processing the descendant root D
+// before its ancestor pre-marked D visited, so the ancestor's cascade skipped D
+// while deleting the intermediate it still references → immediate FK; and the
+// other processing order double-fired D's hook. The round-5-B split into an
+// active-path stack + a monotonic deleted set fixes both.
+
+pub static CHAIN_DELETE_LOG: Mutex<Vec<i64>> = Mutex::new(Vec::new());
+
+#[derive(Clone, Default)]
+pub struct ChainNodeHooks;
+
+impl MutationHooks for ChainNodeHooks {
+    type Model = ChainNode;
+    type NewModel = NewChainNode;
+    type UpdateModel = UpdateChainNode;
+
+    async fn before_delete(
+        &self,
+        _ctx: &mut MutationContext,
+        record: &ChainNode,
+    ) -> AutumnResult<()> {
+        CHAIN_DELETE_LOG.lock().unwrap().push(record.id);
+        Ok(())
+    }
+}
+
+diesel::table! {
+    chain_nodes (id) {
+        id -> Int8,
+        parent_id -> Nullable<Int8>,
+        name -> Text,
+    }
+}
+
+#[autumn_web::model(table = "chain_nodes")]
+pub struct ChainNode {
+    #[id]
+    pub id: i64,
+    pub parent_id: Option<i64>,
+    pub name: String,
+}
+
+#[autumn_web::repository(
+    ChainNode,
+    table = "chain_nodes",
+    hooks = ChainNodeHooks,
+    dependent(PgChainNodeRepository, fk = "parent_id", on_delete = destroy)
+)]
+pub trait ChainNodeRepository {}
+
 // ── #1740: a HOOKED parent that also declares a dependent ─────────────────────
 //
 // All the dependent-declaring parents above are hook-free, so they exercise the
@@ -679,6 +822,12 @@ async fn setup_pool() -> (
         // (A.parent_id = B, B.parent_id = A) can exist — the bulk cascade must seed
         // the current root before recursing so the root's hook fires exactly once.
         "CREATE TABLE dep_cycle_nodes (id BIGSERIAL PRIMARY KEY, parent_id BIGINT REFERENCES dep_cycle_nodes(id) DEFERRABLE INITIALLY DEFERRED, name TEXT NOT NULL)",
+        // Codex round-5-A: post → comment (destroy, hooked) → reply (restrict).
+        "CREATE TABLE ra_posts (id BIGSERIAL PRIMARY KEY, title TEXT NOT NULL)",
+        "CREATE TABLE ra_comments (id BIGSERIAL PRIMARY KEY, post_id BIGINT NOT NULL REFERENCES ra_posts(id), body TEXT NOT NULL)",
+        "CREATE TABLE ra_replies (id BIGSERIAL PRIMARY KEY, comment_id BIGINT NOT NULL REFERENCES ra_comments(id), body TEXT NOT NULL)",
+        // Codex round-5-B: HOOKED self-referential chain with an IMMEDIATE self-FK.
+        "CREATE TABLE chain_nodes (id BIGSERIAL PRIMARY KEY, parent_id BIGINT REFERENCES chain_nodes(id), name TEXT NOT NULL)",
     ] {
         diesel::sql_query(stmt)
             .execute(&mut conn)
@@ -725,6 +874,16 @@ fn dependent_repository_surface_is_generated() {
     // cascaded child and double-fire its hook).
     assert_is_fn(<PgDepCycleNodeRepository as DepCycleNodeRepository>::delete_many);
     assert_is_fn(PgDepCycleNodeRepository::__autumn_apply_dependent_on_conn);
+    // Codex round-5-A: the post→comment(destroy,hooked)→reply(restrict) graph
+    // monomorphizes — the Destroy arm's grandchild restrict probe runs before the
+    // child before_delete hook. All three repos' cascade surfaces must type-check.
+    assert_is_fn(<PgRaPostRepository as RaPostRepository>::delete_by_id);
+    assert_is_fn(PgRaCommentRepository::__autumn_apply_dependent_on_conn);
+    assert_is_fn(PgRaReplyRepository::__autumn_apply_dependent_on_conn);
+    // Codex round-5-B: the HOOKED immediate-FK self-referential chain's bulk
+    // delete_many monomorphizes the two-structure (path + deleted) cascade.
+    assert_is_fn(<PgChainNodeRepository as ChainNodeRepository>::delete_many);
+    assert_is_fn(PgChainNodeRepository::__autumn_apply_dependent_on_conn);
     // #1740: the bulk `delete_many` path now carries the dependent cascade too;
     // monomorphize it (hooks-child parent + restrict-only parent) to prove the
     // bulk-cascade codegen type-checks without Docker.
@@ -1314,6 +1473,147 @@ async fn delete_many_self_referential_two_cycle_fires_root_hook_once() {
         log.iter().filter(|&&id| id == 2).count(),
         1,
         "round-4: the cascaded child fires once: log = {log:?}"
+    );
+}
+
+/// Codex round-5-A: deleting a `Post -> Comment(destroy, hooked) -> Reply(restrict)`
+/// graph must return the restrict 409 WITHOUT firing the comment's `before_delete`
+/// hook. The Destroy arm probes the grandchild restrict (read-only) BEFORE running
+/// the child hook, so a doomed transaction never leaves a non-transactional hook
+/// side effect behind.
+///
+/// RED under the pre-fix ordering (grandchild cascade after `before_delete`):
+/// deleting the post fired `RaComment::before_delete` and only then hit the reply
+/// restrict 409 — the hook counter would read 1. GREEN: the probe precedes the
+/// hook, so the counter stays 0.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn grandchild_restrict_blocks_before_child_before_delete_hook_fires() {
+    let (pool, _c) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+
+    diesel::sql_query("INSERT INTO ra_posts (id, title) VALUES (1, 'p')")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    diesel::sql_query("INSERT INTO ra_comments (id, post_id, body) VALUES (1, 1, 'c')")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    // A reply exists → the comment's `restrict` grandchild must block the delete.
+    diesel::sql_query("INSERT INTO ra_replies (id, comment_id, body) VALUES (1, 1, 'r')")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    RA_COMMENT_HOOK_FIRED.store(0, Ordering::SeqCst);
+
+    let repo = PgRaPostRepository::with_pool_untracked(pool.clone());
+    let result = repo.delete_by_id(1).await;
+    assert!(
+        result.is_err(),
+        "round-5-A: the grandchild restrict must block the post delete with a 409"
+    );
+
+    // The whole transaction rolled back — post, comment and reply all survive.
+    assert_eq!(
+        count(&mut conn, "SELECT COUNT(*) AS n FROM ra_posts").await,
+        1
+    );
+    assert_eq!(
+        count(&mut conn, "SELECT COUNT(*) AS n FROM ra_comments").await,
+        1
+    );
+    assert_eq!(
+        count(&mut conn, "SELECT COUNT(*) AS n FROM ra_replies").await,
+        1
+    );
+
+    // The crux: the comment's before_delete hook must NOT have fired — the restrict
+    // probe ran first and returned the 409 before any child hook.
+    assert_eq!(
+        // Fully-qualified `load` — `RunQueryDsl::load` is in scope and would
+        // otherwise shadow the atomic's inherent method (see DESTROYED_COMMENTS).
+        AtomicUsize::load(&RA_COMMENT_HOOK_FIRED, Ordering::SeqCst),
+        0,
+        "round-5-A: RaComment::before_delete must NOT fire when a grandchild restrict \
+         blocks the delete (probe precedes the hook)"
+    );
+}
+
+/// Codex round-5-B: bulk `delete_many([D, Anc])` over a HOOKED self-referential
+/// chain Anc(1) ← I(2) ← D(3) with an IMMEDIATE self-FK (the intermediate I is
+/// NOT in the batch) must remove all three rows with NO immediate FK violation,
+/// and fire D's `before_delete` hook EXACTLY ONCE.
+///
+/// RED under the round-4 monotonic per-root seed: if the batch processed the
+/// descendant root D before its ancestor Anc, D was pre-marked visited, so Anc's
+/// cascade skipped D while deleting the intermediate I it still references →
+/// immediate FK failure; the opposite order double-fired D's hook (once as Anc's
+/// cascaded descendant, once as a batch root). GREEN with the two-structure model:
+/// the active-path stack only blocks re-entry while on the recursion stack (so a
+/// completed descendant root no longer suppresses the ancestor's cascade → D is
+/// deleted deepest-first, no FK), and the monotonic deleted set skips any row (or
+/// batch root) already removed (so D's hook fires exactly once).
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn delete_many_self_referential_immediate_fk_chain_no_double_hook() {
+    let (pool, _c) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+
+    // Insert with NULL parents first (immediate FK), then wire the chain
+    // Anc(1) ← I(2) ← D(3): each child's parent_id points at its parent.
+    for id in 1..=3 {
+        diesel::sql_query(format!(
+            "INSERT INTO chain_nodes (id, parent_id, name) VALUES ({id}, NULL, 'n{id}')"
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    }
+    diesel::sql_query("UPDATE chain_nodes SET parent_id = 1 WHERE id = 2")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    diesel::sql_query("UPDATE chain_nodes SET parent_id = 2 WHERE id = 3")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    CHAIN_DELETE_LOG.lock().unwrap().clear();
+
+    let repo = PgChainNodeRepository::with_pool_untracked(pool.clone());
+    // Batch the descendant D(3) and the ancestor Anc(1); the intermediate I(2) is
+    // deliberately absent from the id list.
+    repo.delete_many(&[3, 1])
+        .await
+        .expect("round-5-B: bulk self-ref immediate-FK chain delete must not trip the FK");
+
+    // All three rows (ancestor, intermediate, descendant) are gone.
+    assert_eq!(
+        count(&mut conn, "SELECT COUNT(*) AS n FROM chain_nodes").await,
+        0,
+        "round-5-B: the whole chain is removed with no immediate FK violation"
+    );
+
+    let log = CHAIN_DELETE_LOG.lock().unwrap().clone();
+    // Each of the three nodes fired before_delete exactly once — in particular the
+    // descendant root D(3), which is both a batch target and a cascaded descendant.
+    assert_eq!(
+        log.iter().filter(|&&id| id == 3).count(),
+        1,
+        "round-5-B: D's before_delete must fire EXACTLY once (not once-as-child + \
+         once-as-root): log = {log:?}"
+    );
+    assert_eq!(
+        log.iter().filter(|&&id| id == 2).count(),
+        1,
+        "round-5-B: the intermediate fires once: log = {log:?}"
+    );
+    assert_eq!(
+        log.iter().filter(|&&id| id == 1).count(),
+        1,
+        "round-5-B: the ancestor fires once: log = {log:?}"
     );
 }
 

--- a/autumn/tests/integration/repository_dependent_destroy.rs
+++ b/autumn/tests/integration/repository_dependent_destroy.rs
@@ -413,9 +413,10 @@ diesel::table! {
 
 // A model-side child that ITSELF declares a model-side dependent — this is what
 // exercises the new runtime-grandchild codegen inside its Destroy arm. The
-// grandchild table is `m3_replys` (autumn's naive `{snake}s` pluralization of
-// `M3Reply`) so the `#[has_many]` preload codegen resolves the Diesel table
-// module by convention, matching the other has_many targets in this file.
+// grandchild table is `m3_replies` (autumn's smart pluralization of `M3Reply`:
+// consonant + `y` → `ies`, per #1753) so the `#[has_many]` preload codegen
+// resolves the Diesel table module by convention, matching the other has_many
+// targets in this file.
 #[autumn_web::model(table = "m3_comments")]
 #[has_many(M3Reply, fk = "comment_id", dependent = destroy)]
 pub struct M3Comment {
@@ -429,14 +430,14 @@ pub struct M3Comment {
 pub trait M3CommentRepository {}
 
 diesel::table! {
-    m3_replys (id) {
+    m3_replies (id) {
         id -> Int8,
         comment_id -> Int8,
         body -> Text,
     }
 }
 
-#[autumn_web::model(table = "m3_replys")]
+#[autumn_web::model(table = "m3_replies")]
 pub struct M3Reply {
     #[id]
     pub id: i64,
@@ -444,7 +445,7 @@ pub struct M3Reply {
     pub body: String,
 }
 
-#[autumn_web::repository(M3Reply, table = "m3_replys")]
+#[autumn_web::repository(M3Reply, table = "m3_replies")]
 pub trait M3ReplyRepository {}
 
 // ── #1739 cycle guard: a self-referential `destroy` dependent ─────────────────
@@ -808,7 +809,7 @@ async fn setup_pool() -> (
         // Codex P1: fully model-side three-level grandchild graph.
         "CREATE TABLE m3_posts (id BIGSERIAL PRIMARY KEY, title TEXT NOT NULL)",
         "CREATE TABLE m3_comments (id BIGSERIAL PRIMARY KEY, post_id BIGINT NOT NULL REFERENCES m3_posts(id), body TEXT NOT NULL)",
-        "CREATE TABLE m3_replys (id BIGSERIAL PRIMARY KEY, comment_id BIGINT NOT NULL REFERENCES m3_comments(id), body TEXT NOT NULL)",
+        "CREATE TABLE m3_replies (id BIGSERIAL PRIMARY KEY, comment_id BIGINT NOT NULL REFERENCES m3_comments(id), body TEXT NOT NULL)",
         // Self-referential FK: parent_id references the same table. The FK is
         // DEFERRABLE INITIALLY DEFERRED so a *cyclic* component can be hard-deleted
         // within one transaction (the constraint is checked at COMMIT, by which
@@ -1225,7 +1226,7 @@ async fn deleting_model_side_parent_recurses_into_model_side_grandchildren() {
         for r in 1..=2 {
             let rid = c * 10 + r;
             diesel::sql_query(format!(
-                "INSERT INTO m3_replys (id, comment_id, body) VALUES ({rid}, {c}, 'r{rid}')"
+                "INSERT INTO m3_replies (id, comment_id, body) VALUES ({rid}, {c}, 'r{rid}')"
             ))
             .execute(&mut conn)
             .await
@@ -1249,7 +1250,7 @@ async fn deleting_model_side_parent_recurses_into_model_side_grandchildren() {
         "Codex P1: all comments (children) must be destroyed — zero left"
     );
     assert_eq!(
-        count(&mut conn, "SELECT COUNT(*) AS n FROM m3_replys").await,
+        count(&mut conn, "SELECT COUNT(*) AS n FROM m3_replies").await,
         0,
         "Codex P1: all replies (grandchildren) must be recursively destroyed via \
          the child's runtime Model::dependents() — zero left"
@@ -1283,7 +1284,7 @@ async fn delete_many_model_side_parent_cascades_via_runtime_dispatch() {
         .await
         .unwrap();
         diesel::sql_query(format!(
-            "INSERT INTO m3_replys (id, comment_id, body) VALUES ({p}, {p}, 'r{p}')"
+            "INSERT INTO m3_replies (id, comment_id, body) VALUES ({p}, {p}, 'r{p}')"
         ))
         .execute(&mut conn)
         .await
@@ -1306,7 +1307,7 @@ async fn delete_many_model_side_parent_cascades_via_runtime_dispatch() {
         "Codex P1: model-declared destroy children cascaded on the BULK path — zero left"
     );
     assert_eq!(
-        count(&mut conn, "SELECT COUNT(*) AS n FROM m3_replys").await,
+        count(&mut conn, "SELECT COUNT(*) AS n FROM m3_replies").await,
         0,
         "Codex P1: grandchildren recursively destroyed on the bulk path via the \
          child's runtime Model::dependents() — zero left"

--- a/autumn/tests/integration/repository_dependent_destroy.rs
+++ b/autumn/tests/integration/repository_dependent_destroy.rs
@@ -372,6 +372,81 @@ pub struct Dep3Reply {
 #[autumn_web::repository(Dep3Reply, table = "dep3_replies")]
 pub trait Dep3ReplyRepository {}
 
+// ── Codex P1: FULLY model-side three-level grandchild graph ───────────────────
+//
+// The same `Post → Comment → Reply` recursion as `Dep3*` above, but declared
+// ENTIRELY on the model structs via `#[has_many(..., dependent = destroy)]`,
+// with NO repository-attribute `dependent(...)` anywhere. Each parent's
+// `config.dependents` is therefore empty, so both the top-level `delete_by_id`
+// dispatch (#1738) AND the intermediate child's `__autumn_apply_dependent_on_conn`
+// Destroy arm (Codex P1) must consult the runtime `Model::dependents()` to reach
+// the grandchildren. Deleting an `M3Post` must leave zero `M3Reply` (grandchild)
+// AND zero `M3Comment` (child) rows — the exact P1 acceptance criterion. The
+// child repositories resolve by the `Pg{Child}Repository` convention
+// (`M3Comment` → `PgM3CommentRepository`, `M3Reply` → `PgM3ReplyRepository`).
+
+diesel::table! {
+    m3_posts (id) {
+        id -> Int8,
+        title -> Text,
+    }
+}
+
+#[autumn_web::model(table = "m3_posts")]
+#[has_many(M3Comment, fk = "post_id", dependent = destroy)]
+pub struct M3Post {
+    #[id]
+    pub id: i64,
+    pub title: String,
+}
+
+#[autumn_web::repository(M3Post, table = "m3_posts")]
+pub trait M3PostRepository {}
+
+diesel::table! {
+    m3_comments (id) {
+        id -> Int8,
+        post_id -> Int8,
+        body -> Text,
+    }
+}
+
+// A model-side child that ITSELF declares a model-side dependent — this is what
+// exercises the new runtime-grandchild codegen inside its Destroy arm. The
+// grandchild table is `m3_replys` (autumn's naive `{snake}s` pluralization of
+// `M3Reply`) so the `#[has_many]` preload codegen resolves the Diesel table
+// module by convention, matching the other has_many targets in this file.
+#[autumn_web::model(table = "m3_comments")]
+#[has_many(M3Reply, fk = "comment_id", dependent = destroy)]
+pub struct M3Comment {
+    #[id]
+    pub id: i64,
+    pub post_id: i64,
+    pub body: String,
+}
+
+#[autumn_web::repository(M3Comment, table = "m3_comments")]
+pub trait M3CommentRepository {}
+
+diesel::table! {
+    m3_replys (id) {
+        id -> Int8,
+        comment_id -> Int8,
+        body -> Text,
+    }
+}
+
+#[autumn_web::model(table = "m3_replys")]
+pub struct M3Reply {
+    #[id]
+    pub id: i64,
+    pub comment_id: i64,
+    pub body: String,
+}
+
+#[autumn_web::repository(M3Reply, table = "m3_replys")]
+pub trait M3ReplyRepository {}
+
 // ── #1739 cycle guard: a self-referential `destroy` dependent ─────────────────
 //
 // `dep_nodes.parent_id` references `dep_nodes.id`, and the repository declares a
@@ -488,6 +563,10 @@ async fn setup_pool() -> (
         "CREATE TABLE dep3_posts (id BIGSERIAL PRIMARY KEY, title TEXT NOT NULL)",
         "CREATE TABLE dep3_comments (id BIGSERIAL PRIMARY KEY, post_id BIGINT NOT NULL REFERENCES dep3_posts(id), body TEXT NOT NULL)",
         "CREATE TABLE dep3_replies (id BIGSERIAL PRIMARY KEY, comment_id BIGINT NOT NULL REFERENCES dep3_comments(id), body TEXT NOT NULL)",
+        // Codex P1: fully model-side three-level grandchild graph.
+        "CREATE TABLE m3_posts (id BIGSERIAL PRIMARY KEY, title TEXT NOT NULL)",
+        "CREATE TABLE m3_comments (id BIGSERIAL PRIMARY KEY, post_id BIGINT NOT NULL REFERENCES m3_posts(id), body TEXT NOT NULL)",
+        "CREATE TABLE m3_replys (id BIGSERIAL PRIMARY KEY, comment_id BIGINT NOT NULL REFERENCES m3_comments(id), body TEXT NOT NULL)",
         // Self-referential FK: parent_id references the same table. The FK is
         // DEFERRABLE INITIALLY DEFERRED so a *cyclic* component can be hard-deleted
         // within one transaction (the constraint is checked at COMMIT, by which
@@ -548,6 +627,19 @@ fn dependent_repository_surface_is_generated() {
     // `AutumnDependents::dependents`): destroy + delete_all + restrict.
     assert_is_fn(ModelDepPost::dependents);
     assert_eq!(ModelDepPost::dependents().len(), 3);
+    // Codex P1: the fully model-side three-level graph monomorphizes. The key
+    // new codegen is the intermediate `M3Comment`'s cascade leaf executor —
+    // its Destroy arm now runtime-dispatches into `M3Comment::dependents()`
+    // (the grandchild `M3Reply` spec) because `M3Comment` declares its
+    // dependent ONLY model-side (empty `config.dependents`). Referencing the
+    // helper + both `delete_by_id`s type-checks that recursive runtime path.
+    assert_is_fn(<PgM3PostRepository as M3PostRepository>::delete_by_id);
+    assert_is_fn(<PgM3CommentRepository as M3CommentRepository>::delete_by_id);
+    assert_is_fn(PgM3CommentRepository::__autumn_apply_dependent_on_conn);
+    assert_is_fn(PgM3ReplyRepository::__autumn_apply_dependent_on_conn);
+    // A model-side child (M3Comment) that itself has a model-side dependent.
+    assert_eq!(M3Post::dependents().len(), 1);
+    assert_eq!(M3Comment::dependents().len(), 1);
 }
 
 // ── Tests (require Docker) ────────────────────────────────────────────────────
@@ -819,6 +911,66 @@ async fn deleting_parent_recurses_into_grandchildren() {
         count(&mut conn, "SELECT COUNT(*) AS n FROM dep3_replies").await,
         0,
         "#1739: all replies (grandchildren) must be recursively destroyed — zero left"
+    );
+}
+
+/// Codex P1: deleting an `M3Post` whose graph is declared ENTIRELY model-side
+/// (`M3Post -> M3Comment -> M3Reply`, all via `#[has_many(..., dependent =
+/// destroy)]`, NO repository-attribute `dependent(...)`) must recurse all the
+/// way down. Because the intermediate `M3Comment` declares its dependent only
+/// model-side, its `config.dependents` is empty; the fix makes its Destroy arm
+/// consult the runtime `M3Comment::dependents()` so the grandchildren cascade
+/// too. Asserts **zero `M3Reply` rows AND zero `M3Comment` rows** remain (the
+/// exact acceptance criterion), in one transaction with no FK error.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn deleting_model_side_parent_recurses_into_model_side_grandchildren() {
+    let (pool, _c) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+
+    diesel::sql_query("INSERT INTO m3_posts (id, title) VALUES (1, 'p')")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    // 2 comments, each with 2 replies → 4 grandchildren.
+    for c in 1..=2 {
+        diesel::sql_query(format!(
+            "INSERT INTO m3_comments (id, post_id, body) VALUES ({c}, 1, 'c{c}')"
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+        for r in 1..=2 {
+            let rid = c * 10 + r;
+            diesel::sql_query(format!(
+                "INSERT INTO m3_replys (id, comment_id, body) VALUES ({rid}, {c}, 'r{rid}')"
+            ))
+            .execute(&mut conn)
+            .await
+            .unwrap();
+        }
+    }
+
+    let repo = PgM3PostRepository::with_pool_untracked(pool.clone());
+    repo.delete_by_id(1)
+        .await
+        .expect("model-side recursive cascade must not FK-error");
+
+    assert_eq!(
+        count(&mut conn, "SELECT COUNT(*) AS n FROM m3_posts WHERE id = 1").await,
+        0,
+        "parent gone"
+    );
+    assert_eq!(
+        count(&mut conn, "SELECT COUNT(*) AS n FROM m3_comments").await,
+        0,
+        "Codex P1: all comments (children) must be destroyed — zero left"
+    );
+    assert_eq!(
+        count(&mut conn, "SELECT COUNT(*) AS n FROM m3_replys").await,
+        0,
+        "Codex P1: all replies (grandchildren) must be recursively destroyed via \
+         the child's runtime Model::dependents() — zero left"
     );
 }
 

--- a/autumn/tests/integration/repository_dependent_destroy.rs
+++ b/autumn/tests/integration/repository_dependent_destroy.rs
@@ -172,6 +172,35 @@ pub struct DepAward {
 #[autumn_web::repository(DepAward, table = "dep_awards")]
 pub trait DepAwardRepository {}
 
+// ── #1738: model-declared `#[has_many(dependent = ...)]` cascade ──────────────
+//
+// The SAME cascade as `DepPost` above, but declared on the MODEL struct via
+// `#[has_many(Child, dependent = <action>)]` instead of the repository
+// attribute. The parent repository declares NO `dependent(...)`, so the cascade
+// is driven at run time by `ModelDepPost::dependents()`, resolving each child
+// repository through the `Pg{Child}Repository` naming convention (`DepComment`
+// → `PgDepCommentRepository`, etc.). Reuses the existing child tables/repos via
+// an explicit `fk = "post_id"` (the default would infer `model_dep_post_id`).
+//
+// `dependent = nullify` is intentionally omitted here: a nullify child has a
+// NULLABLE foreign key, and `#[has_many]` preload codegen does not yet support
+// a nullable child FK (it groups children into a `HashMap<i64, _>` keyed by the
+// non-`Option` FK). That is a pre-existing preload limitation, independent of
+// the cascade dispatch; tracked as a #1738 follow-up. destroy/delete_all/
+// restrict all target non-null-FK children and cascade from the model side.
+#[autumn_web::model(table = "dep_posts")]
+#[has_many(DepComment, fk = "post_id", name = md_comments, dependent = destroy)]
+#[has_many(DepVote, fk = "post_id", name = md_votes, dependent = delete_all)]
+#[has_many(DepAward, fk = "post_id", name = md_awards, dependent = restrict)]
+pub struct ModelDepPost {
+    #[id]
+    pub id: i64,
+    pub title: String,
+}
+
+#[autumn_web::repository(ModelDepPost, table = "dep_posts")]
+pub trait ModelDepPostRepository {}
+
 // ── AC3: both-soft destroy graph (soft parent + soft children) ────────────────
 //
 // The parent is `#[soft_delete]` too, so `delete_by_id` soft-deletes the parent
@@ -509,6 +538,16 @@ fn dependent_repository_surface_is_generated() {
     // Hooks-path bulk cascade branch (#1740): a hooked parent with a dependent.
     assert_is_fn(<PgDepHookedPostRepository as DepHookedPostRepository>::delete_many);
     assert_is_fn(<PgDepHookedPostRepository as DepHookedPostRepository>::delete_by_id);
+    // #1738: the model-declared `#[has_many(dependent = ...)]` parent's
+    // `delete_by_id` monomorphizes — proving the runtime `RuntimeDependentSpec`
+    // dispatch (fn-pointer thunks into each child's cascade leaf executor, wired
+    // from the model side with no repository-attribute `dependent(...)`)
+    // type-checks against the same four cascade actions.
+    assert_is_fn(<PgModelDepPostRepository as ModelDepPostRepository>::delete_by_id);
+    // The model exposes its runtime dependent specs (inherent shadow of
+    // `AutumnDependents::dependents`): destroy + delete_all + restrict.
+    assert_is_fn(ModelDepPost::dependents);
+    assert_eq!(ModelDepPost::dependents().len(), 3);
 }
 
 // ── Tests (require Docker) ────────────────────────────────────────────────────
@@ -1073,5 +1112,145 @@ async fn restrict_probes_before_destroy_fires_no_child_hooks() {
         .await,
         1,
         "the restrict child row must survive"
+    );
+}
+
+// ── #1738: model-declared cascade produces the same behavior ──────────────────
+
+/// #1738 primary AC: `#[has_many(Child, dependent = <action>)]` declared on the
+/// MODEL (no repository-attribute `dependent(...)`) produces the same
+/// transactional cascade the repository-attribute form produces. Deleting a
+/// `ModelDepPost` destroys its comments (firing their hooks) and bulk-deletes
+/// its votes — driven entirely by the runtime `ModelDepPost::dependents()`
+/// dispatch resolving `PgDepCommentRepository` / `PgDepVoteRepository` by
+/// convention. (No awards are inserted, since the model also declares
+/// `restrict(DepAward)`, exercised separately below.)
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn model_declared_dependent_cascades_like_repository_attribute() {
+    let (pool, _c) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+
+    diesel::sql_query("INSERT INTO dep_posts (id, title) VALUES (31, 'model-side')")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    for i in 1..=3 {
+        diesel::sql_query(format!(
+            "INSERT INTO dep_comments (id, post_id, body) VALUES ({}, 31, 'c{i}')",
+            100 + i
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+        diesel::sql_query(format!(
+            "INSERT INTO dep_votes (id, post_id, value) VALUES ({}, 31, 1)",
+            100 + i
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    }
+
+    DESTROYED_COMMENTS.store(0, Ordering::SeqCst);
+
+    let repo = PgModelDepPostRepository::with_pool_untracked(pool.clone());
+    repo.delete_by_id(31)
+        .await
+        .expect("model-declared cascade delete must not FK-error");
+
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_posts WHERE id = 31"
+        )
+        .await,
+        0,
+        "parent gone"
+    );
+    // destroy: comments hard-deleted, and each fired its before_delete hook.
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_comments WHERE post_id = 31"
+        )
+        .await,
+        0,
+        "destroy child rows removed via the model-declared cascade"
+    );
+    assert_eq!(
+        AtomicUsize::load(&DESTROYED_COMMENTS, Ordering::SeqCst),
+        3,
+        "each destroyed comment fired its before_delete hook (child lifecycle honored)"
+    );
+    // delete_all: votes bulk-removed.
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_votes WHERE post_id = 31"
+        )
+        .await,
+        0,
+        "delete_all child rows removed via the model-declared cascade"
+    );
+}
+
+/// #1738: model-declared `restrict` preserves the typed 409 + rollback, exactly
+/// as the repository-attribute form does. An award (restrict child) blocks the
+/// `ModelDepPost` delete, and the transaction rolls back leaving every row.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn model_declared_restrict_blocks_with_conflict_and_rolls_back() {
+    let (pool, _c) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+
+    diesel::sql_query("INSERT INTO dep_posts (id, title) VALUES (32, 'guarded-model')")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    diesel::sql_query("INSERT INTO dep_comments (id, post_id, body) VALUES (201, 32, 'c')")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    diesel::sql_query("INSERT INTO dep_awards (id, post_id, name) VALUES (11, 32, 'gold')")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    DESTROYED_COMMENTS.store(0, Ordering::SeqCst);
+
+    let repo = PgModelDepPostRepository::with_pool_untracked(pool.clone());
+    let err = repo
+        .delete_by_id(32)
+        .await
+        .expect_err("model-declared restrict child must block the delete");
+    assert_eq!(
+        err.status(),
+        autumn_web::reexports::http::StatusCode::CONFLICT,
+        "a blocking model-declared restrict must surface a 409"
+    );
+    // Restrict probed before destroy → the comment's before_delete never fired.
+    assert_eq!(
+        AtomicUsize::load(&DESTROYED_COMMENTS, Ordering::SeqCst),
+        0,
+        "restrict must be probed before destroy in the model-declared cascade too"
+    );
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_posts WHERE id = 32"
+        )
+        .await,
+        1,
+        "the parent must survive a blocked model-declared delete"
+    );
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_comments WHERE post_id = 32"
+        )
+        .await,
+        1,
+        "the destroy child rows must be untouched after a blocked delete"
     );
 }

--- a/autumn/tests/integration/repository_dependent_destroy.rs
+++ b/autumn/tests/integration/repository_dependent_destroy.rs
@@ -479,6 +479,40 @@ pub struct DepNode {
 )]
 pub trait DepNodeRepository {}
 
+// ── Codex P2: self-referential `destroy` with an IMMEDIATE self-FK ─────────────
+//
+// `dep_imm_nodes.parent_id` references the same table, but the FK is NOT
+// deferrable (checked immediately, per-row). Bulk-deleting `[ancestor,
+// descendant]` while an intermediate node is NOT in the id list must remove the
+// whole subtree without tripping an immediate FK constraint — which requires the
+// bulk cascade to NOT pre-seed the descendant into the visited set (otherwise the
+// ancestor's cascade skips it, the intermediate is deleted first, and the still-
+// present descendant's FK immediately fails). Distinct from `dep_nodes`, whose
+// DEFERRABLE FK would mask this by deferring the check to COMMIT.
+
+diesel::table! {
+    dep_imm_nodes (id) {
+        id -> Int8,
+        parent_id -> Nullable<Int8>,
+        name -> Text,
+    }
+}
+
+#[autumn_web::model(table = "dep_imm_nodes")]
+pub struct DepImmNode {
+    #[id]
+    pub id: i64,
+    pub parent_id: Option<i64>,
+    pub name: String,
+}
+
+#[autumn_web::repository(
+    DepImmNode,
+    table = "dep_imm_nodes",
+    dependent(PgDepImmNodeRepository, fk = "parent_id", on_delete = destroy)
+)]
+pub trait DepImmNodeRepository {}
+
 // ── #1740: a HOOKED parent that also declares a dependent ─────────────────────
 //
 // All the dependent-declaring parents above are hook-free, so they exercise the
@@ -573,6 +607,9 @@ async fn setup_pool() -> (
         // point every row in the cycle is gone). ON DELETE has no DB-level cascade
         // — the framework cascade is what must clear the whole component.
         "CREATE TABLE dep_nodes (id BIGSERIAL PRIMARY KEY, parent_id BIGINT REFERENCES dep_nodes(id) DEFERRABLE INITIALLY DEFERRED, name TEXT NOT NULL)",
+        // Codex P2: IMMEDIATE (non-deferrable) self-referential FK — the check
+        // fires per-row, so the cascade cannot rely on deferral to COMMIT.
+        "CREATE TABLE dep_imm_nodes (id BIGSERIAL PRIMARY KEY, parent_id BIGINT REFERENCES dep_imm_nodes(id), name TEXT NOT NULL)",
     ] {
         diesel::sql_query(stmt)
             .execute(&mut conn)
@@ -609,6 +646,10 @@ fn dependent_repository_surface_is_generated() {
     assert_is_fn(PgDep3ReplyRepository::__autumn_apply_dependent_on_conn);
     assert_is_fn(<PgDepNodeRepository as DepNodeRepository>::delete_by_id);
     assert_is_fn(PgDepNodeRepository::__autumn_apply_dependent_on_conn);
+    // Codex P2: the immediate-FK self-referential parent's bulk delete_many
+    // monomorphizes (its cascade must not pre-seed batch targets).
+    assert_is_fn(<PgDepImmNodeRepository as DepImmNodeRepository>::delete_many);
+    assert_is_fn(PgDepImmNodeRepository::__autumn_apply_dependent_on_conn);
     // #1740: the bulk `delete_many` path now carries the dependent cascade too;
     // monomorphize it (hooks-child parent + restrict-only parent) to prove the
     // bulk-cascade codegen type-checks without Docker.
@@ -1018,6 +1059,56 @@ async fn self_referential_destroy_terminates_on_cycle() {
         count(&mut conn, "SELECT COUNT(*) AS n FROM dep_nodes").await,
         0,
         "#1739 cycle guard: the whole reachable cyclic component is destroyed, no rows left"
+    );
+}
+
+/// Codex P2: bulk-deleting `[ancestor, descendant]` of a self-referential
+/// `dependent = destroy` graph with an IMMEDIATE (non-deferrable) self-FK, where
+/// an intermediate node is NOT in the id list, must remove the whole subtree
+/// without an FK error. Chain: node 1 (ancestor) ← node 2 (intermediate, NOT in
+/// ids) ← node 3 (descendant). `delete_many([1, 3])`.
+///
+/// With the pre-#P2 pre-seeding, node 3 was marked visited up front, so the
+/// ancestor's cascade skipped it; deleting the intermediate (node 2) then failed
+/// the immediate FK from the still-present node 3. The fix populates the visited
+/// set only as rows are actually destroyed, so node 3 is cascaded (deepest first)
+/// before node 2 is removed.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn delete_many_self_referential_immediate_fk_removes_whole_subtree() {
+    let (pool, _c) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+
+    // Insert with NULL parents first (immediate FK), then wire the chain.
+    for id in 1..=3 {
+        diesel::sql_query(format!(
+            "INSERT INTO dep_imm_nodes (id, parent_id, name) VALUES ({id}, NULL, 'n{id}')"
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    }
+    // 2's parent = 1 (ancestor), 3's parent = 2 (intermediate).
+    diesel::sql_query("UPDATE dep_imm_nodes SET parent_id = 1 WHERE id = 2")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    diesel::sql_query("UPDATE dep_imm_nodes SET parent_id = 2 WHERE id = 3")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    let repo = PgDepImmNodeRepository::with_pool_untracked(pool.clone());
+    // Intermediate node 2 is deliberately absent from the id list.
+    repo.delete_many(&[1, 3])
+        .await
+        .expect("Codex P2: bulk self-ref delete must not trip the immediate FK");
+
+    assert_eq!(
+        count(&mut conn, "SELECT COUNT(*) AS n FROM dep_imm_nodes").await,
+        0,
+        "Codex P2: the whole reachable subtree (ancestor, intermediate, \
+         descendant) is destroyed with no immediate FK violation"
     );
 }
 

--- a/autumn/tests/integration/shard_across_tenants_no_shard_set.rs
+++ b/autumn/tests/integration/shard_across_tenants_no_shard_set.rs
@@ -51,10 +51,18 @@ pub struct NoShardSetPost {
 
 /// tenant_scoped so `across_tenants()` is generated; sharded so the cross-shard
 /// batch/count guards are emitted. A derived `find_by_title` read exercises the
-/// derived `find_by_*` fan-out guard (#1741).
+/// derived `find_by_*` fan-out guard (#1741). A derived `find_by_tenant_id` with
+/// a BORROWED (`&str`) parameter exercises the `has_borrowed_param` branch of the
+/// derived-read guard (#1741 follow-up): it cannot fan out, but must still reject
+/// under `across_tenants()` with no shard set rather than returning a single-pool
+/// partial result.
 #[autumn_web::repository(NoShardSetPost, table = "no_shard_set_posts", tenant_scoped, sharded)]
 pub trait NoShardSetPostRepository {
     async fn find_by_title(&self, title: String) -> autumn_web::AutumnResult<Vec<NoShardSetPost>>;
+    async fn find_by_tenant_id(
+        &self,
+        tenant_id: &str,
+    ) -> autumn_web::AutumnResult<Vec<NoShardSetPost>>;
 }
 
 mod soft_schema {
@@ -231,6 +239,30 @@ async fn find_by_derived_across_tenants_without_shard_set_rejects() {
         err.to_string()
             .contains("cross-shard find_by_title requires a configured shard set"),
         "derived find_by_* guard must reject cross-shard read without a shard set, got: {err}"
+    );
+}
+
+/// §1741 follow-up: a derived `find_by_*` read whose parameter is BORROWED
+/// (`&str`) takes the `has_borrowed_param` branch, which cannot fan out. It must
+/// still REJECT under `across_tenants()` with no shard set — rather than falling
+/// through to a single-pool partial result — with the same "requires a
+/// configured shard set" rejection the owned-param branch and the count guard
+/// emit. The guard fires before any connection is acquired, so no live database
+/// is required.
+#[tokio::test]
+async fn find_by_borrowed_derived_across_tenants_without_shard_set_rejects() {
+    let pool = make_pool();
+    let repo = PgNoShardSetPostRepository::with_pool_untracked(pool).across_tenants();
+    assert!(repo.__autumn_shards.is_none());
+
+    let err = repo
+        .find_by_tenant_id("acme")
+        .await
+        .expect_err("across_tenants borrowed-param find_by_* without a shard set must reject");
+    assert!(
+        err.to_string()
+            .contains("cross-shard find_by_tenant_id requires a configured shard set"),
+        "borrowed-param derived find_by_* guard must reject cross-shard read without a shard set, got: {err}"
     );
 }
 

--- a/autumn/tests/integration/shard_across_tenants_no_shard_set.rs
+++ b/autumn/tests/integration/shard_across_tenants_no_shard_set.rs
@@ -10,6 +10,13 @@
 //!    set is configured, rather than falling through to a partial single-pool
 //!    count.
 //!
+//! §1741: the identical no-shard-set hole existed in the sibling read methods —
+//! `find_all`, `find_by_id`, `exists_by_id`, derived `find_by_*`, and the
+//! soft-delete readers `with_deleted` / `only_deleted`. Each fanned out only
+//! when a shard set was present and otherwise fell through to a single-pool
+//! query binding a NULL tenant predicate (a silent PARTIAL result). They now
+//! reject under `across_tenants()` with no shard set, matching the count guard.
+//!
 //! Both guards return before acquiring any database connection, so — like the
 //! read-routing test in `repository_find_in_batches.rs` — no live database is
 //! needed and these assertions run without Docker.
@@ -43,9 +50,46 @@ pub struct NoShardSetPost {
 }
 
 /// tenant_scoped so `across_tenants()` is generated; sharded so the cross-shard
-/// batch/count guards are emitted.
+/// batch/count guards are emitted. A derived `find_by_title` read exercises the
+/// derived `find_by_*` fan-out guard (#1741).
 #[autumn_web::repository(NoShardSetPost, table = "no_shard_set_posts", tenant_scoped, sharded)]
-pub trait NoShardSetPostRepository {}
+pub trait NoShardSetPostRepository {
+    async fn find_by_title(&self, title: String) -> autumn_web::AutumnResult<Vec<NoShardSetPost>>;
+}
+
+mod soft_schema {
+    autumn_web::reexports::diesel::table! {
+        soft_no_shard_set_posts (id) {
+            id -> Int8,
+            tenant_id -> Text,
+            title -> Text,
+            deleted_at -> Nullable<Timestamp>,
+        }
+    }
+}
+
+use soft_schema::soft_no_shard_set_posts;
+
+/// A model carrying `deleted_at` on a tenant-scoped, sharded table, so its
+/// repository can enable `soft_delete` and the `with_deleted` / `only_deleted`
+/// cross-shard readers are emitted (#1741).
+#[autumn_web::model(table = "soft_no_shard_set_posts")]
+pub struct SoftNoShardSetPost {
+    #[id]
+    pub id: i64,
+    pub tenant_id: String,
+    pub title: String,
+    pub deleted_at: Option<autumn_web::reexports::chrono::NaiveDateTime>,
+}
+
+#[autumn_web::repository(
+    SoftNoShardSetPost,
+    table = "soft_no_shard_set_posts",
+    tenant_scoped,
+    sharded,
+    soft_delete
+)]
+pub trait SoftNoShardSetPostRepository {}
 
 fn make_pool() -> Pool<AsyncPgConnection> {
     let config = DatabaseConfig {
@@ -113,5 +157,117 @@ async fn count_across_tenants_without_shard_set_rejects() {
         err.to_string()
             .contains("cross-shard count requires a configured shard set"),
         "count guard must reject cross-shard count without a shard set, got: {err}"
+    );
+}
+
+/// §1741: `find_all().across_tenants()` on a no-shard-set repo must reject
+/// rather than silently returning a single-pool partial result.
+#[tokio::test]
+async fn find_all_across_tenants_without_shard_set_rejects() {
+    let pool = make_pool();
+    let repo = PgNoShardSetPostRepository::with_pool_untracked(pool).across_tenants();
+    assert!(repo.__autumn_shards.is_none());
+
+    let err = repo
+        .find_all()
+        .await
+        .expect_err("across_tenants find_all without a shard set must reject");
+    assert!(
+        err.to_string()
+            .contains("cross-shard find_all requires a configured shard set"),
+        "find_all guard must reject cross-shard read without a shard set, got: {err}"
+    );
+}
+
+/// §1741: `find_by_id().across_tenants()` on a no-shard-set repo must reject.
+#[tokio::test]
+async fn find_by_id_across_tenants_without_shard_set_rejects() {
+    let pool = make_pool();
+    let repo = PgNoShardSetPostRepository::with_pool_untracked(pool).across_tenants();
+    assert!(repo.__autumn_shards.is_none());
+
+    let err = repo
+        .find_by_id(1)
+        .await
+        .expect_err("across_tenants find_by_id without a shard set must reject");
+    assert!(
+        err.to_string()
+            .contains("cross-shard find_by_id requires a configured shard set"),
+        "find_by_id guard must reject cross-shard read without a shard set, got: {err}"
+    );
+}
+
+/// §1741: `exists_by_id().across_tenants()` on a no-shard-set repo must reject.
+#[tokio::test]
+async fn exists_by_id_across_tenants_without_shard_set_rejects() {
+    let pool = make_pool();
+    let repo = PgNoShardSetPostRepository::with_pool_untracked(pool).across_tenants();
+    assert!(repo.__autumn_shards.is_none());
+
+    let err = repo
+        .exists_by_id(1)
+        .await
+        .expect_err("across_tenants exists_by_id without a shard set must reject");
+    assert!(
+        err.to_string()
+            .contains("cross-shard exists_by_id requires a configured shard set"),
+        "exists_by_id guard must reject cross-shard read without a shard set, got: {err}"
+    );
+}
+
+/// §1741: a derived `find_by_*` read with `across_tenants()` on a no-shard-set
+/// repo must reject rather than fanning out or returning a partial result.
+#[tokio::test]
+async fn find_by_derived_across_tenants_without_shard_set_rejects() {
+    let pool = make_pool();
+    let repo = PgNoShardSetPostRepository::with_pool_untracked(pool).across_tenants();
+    assert!(repo.__autumn_shards.is_none());
+
+    let err = repo
+        .find_by_title("hello".to_owned())
+        .await
+        .expect_err("across_tenants find_by_title without a shard set must reject");
+    assert!(
+        err.to_string()
+            .contains("cross-shard find_by_title requires a configured shard set"),
+        "derived find_by_* guard must reject cross-shard read without a shard set, got: {err}"
+    );
+}
+
+/// §1741: `with_deleted().across_tenants()` on a no-shard-set soft-delete repo
+/// must reject.
+#[tokio::test]
+async fn with_deleted_across_tenants_without_shard_set_rejects() {
+    let pool = make_pool();
+    let repo = PgSoftNoShardSetPostRepository::with_pool_untracked(pool).across_tenants();
+    assert!(repo.__autumn_shards.is_none());
+
+    let err = repo
+        .with_deleted()
+        .await
+        .expect_err("across_tenants with_deleted without a shard set must reject");
+    assert!(
+        err.to_string()
+            .contains("cross-shard with_deleted requires a configured shard set"),
+        "with_deleted guard must reject cross-shard read without a shard set, got: {err}"
+    );
+}
+
+/// §1741: `only_deleted().across_tenants()` on a no-shard-set soft-delete repo
+/// must reject.
+#[tokio::test]
+async fn only_deleted_across_tenants_without_shard_set_rejects() {
+    let pool = make_pool();
+    let repo = PgSoftNoShardSetPostRepository::with_pool_untracked(pool).across_tenants();
+    assert!(repo.__autumn_shards.is_none());
+
+    let err = repo
+        .only_deleted()
+        .await
+        .expect_err("across_tenants only_deleted without a shard set must reject");
+    assert!(
+        err.to_string()
+            .contains("cross-shard only_deleted requires a configured shard set"),
+        "only_deleted guard must reject cross-shard read without a shard set, got: {err}"
     );
 }


### PR DESCRIPTION
A four-commit cascade cluster. Each commit stands alone; together they close three issues and land the sound core of a fourth.

---

### #1741 — reject `across_tenants()` reads with no shard set (Closes)

**Before:** Sharded repositories silently read only the local shard for `find_all` / `find_by_id` / `exists_by_id` / `with_deleted` / `only_deleted` and derived `find_by_*` when `across_tenants()` was set but no shard set was configured — returning a partial, misleading result with no error.

**After:** Those calls return a clear `bad_request` telling the caller a shard set is required, mirroring the existing `count` guard. No more silent partial reads.

**How:** A let-else reject at the top of the affected read paths in `autumn-macros/src/repository.rs`, matching the shape of the pre-existing `count` guard.

---

### #1739 — recurse dependent destroy into grandchildren with a cycle guard (Closes)

**Before:** Dependent `destroy` cascades only removed direct children; grandchildren and deeper descendants were orphaned.

**After:** `destroy` recurses through grandchildren and arbitrarily deep, with a `(table, id)` visited-set cycle guard so self-references and mutual references terminate cleanly. `delete_all` stays single-level by design.

**How:** The `__autumn_apply_dependent_on_conn` Destroy arm recurses; the async helper became a boxed-future `fn` to erase the recursive `Send` edge that direct `async fn` recursion could not express.

---

### #1740 — apply cascade to the `delete_many` bulk path (Closes)

**Before:** Bulk `delete_many` skipped dependent handling entirely — children of bulk-deleted parents were left behind (or left dangling under restrict).

**After:** `delete_many` cascades per affected parent inside the existing transaction: restrict probes run first, so a violation returns 409 and rolls the whole bulk delete back; otherwise children are destroyed/nullified, and grandchildren follow via the #1739 recursion.

**How:** Cascade tokens spliced into both `delete_many` codegen branches; children are cascaded per-parent. (Set-based bulk child mutation is a noted future refinement.)

---

### #1738 — model-declared `#[has_many(dependent = …)]` runtime dispatch (Part of — sound core)

**Before:** A model-declared `#[has_many(dependent = …)]` emitted a directed compile error telling users to move the declaration to the repository-attribute form.

**After:** It wires the real transactional cascade (destroy / delete_all / restrict on `delete_by_id`) through a new runtime type-erased dispatch (`AutumnDependents` / `RuntimeDependentSpec` plus fn-pointers into the existing leaf executor), resolving the child repository by the `Pg{Child}Repository` naming convention. The repository-attribute `dependent(...)` form remains the precedence-winning explicit escape hatch (necessary for children whose repo doesn't follow the naming convention or lives in another crate).

**How:** New runtime plumbing in `autumn/src/repository.rs`; the model derive emits `Model::dependents()`; the repository derive consults it at runtime when no repo-attribute dependents are declared.

**Deferred (follow-up issues filed):**
- Model-side `nullify` — blocked by a pre-existing nullable-FK preload limitation — #1786
- `delete_many` runtime dispatch (model-declared) — #1787
- Both-sites conflict diagnostics — #1788

---

### Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --features db -- -D warnings` — exit 0
- `cargo test -p autumn-macros` — 451 passed
- `cargo test -p autumn-web --no-run --features db` — exit 0 (type-checks all generated cascade code together)

DB graph tests are Docker-ignored per repo convention, so CI is the runtime authority for the live cascade assertions.

---

> The "Documentation build" CI check is known-red trunk-wide (unrelated doc links); fix in flight as #1773. Not addressed here — outside this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_018gRU2FHW1GkqSbkoTYumLD)_