### PR TITLE
ci: run offsite-backup MinIO round-trip in GitHub Actions (#1744)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,21 @@ jobs:
         continue-on-error: true
       - name: Run tests
         run: cargo test --workspace
+      - name: Install Postgres client tools (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          # The offsite-backup round-trip below drives `autumn db backup`, which
+          # shells out to the HOST `pg_dump`/`pg_restore`. ubuntu-latest does not
+          # guarantee these on PATH, so install the client package explicitly.
+          # (postgresql-client installs pg_dump/pg_restore into /usr/bin via the
+          # pg_wrapper symlinks, so no extra PATH tweak is needed.)
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+          pg_dump --version
+          pg_restore --version
       - name: Run Docker-dependent tests
         if: runner.os == 'Linux'
+        timeout-minutes: 30
         run: |
           cargo test -p autumn-web --test db_hooks_lifecycle -- --ignored
           cargo test -p autumn-web --test repository_shard_replica_routing -- --ignored
@@ -74,6 +87,14 @@ jobs:
           cargo test -p autumn-cli --test flags -- --ignored
           cargo test -p autumn-cli --test config -- --ignored
           cargo test -p autumn-cli --test experiments -- --ignored
+          # Offsite-backup DR round-trip (#1744): seed -> `autumn db backup
+          # --upload` -> restore from offsite -> row-level equality, against real
+          # MinIO + Postgres testcontainers. The `offsite` filter selects both
+          # ignored tests in autumn-cli/tests/integration/offsite_backup.rs.
+          # Needs Docker (testcontainers) + host pg_dump/pg_restore (installed
+          # above). Runs in the existing Docker-dependent Linux step rather than a
+          # separate required gate.
+          cargo test -p autumn-cli --test cli_tests -- --ignored offsite
           # offline-sync is not a default feature, so the workspace test run
           # above compiles these out; run them (plus the Docker-gated PG
           # conformance suite) here.


### PR DESCRIPTION
## Before

The offsite S3 backup disaster-recovery round-trip lives in `autumn-cli/tests/integration/offsite_backup.rs` — two `#[ignore]` tests that prove the full loop against real containers: seed → `autumn db backup --upload` → destroy the local artifact + drop the seeded rows → restore from `offsite:dev/latest` → row-level equality. CI compiles the binary (`--no-run`) but **never executes** these tests, so the DR loop only ever runs locally on a developer's machine, never in CI. The loop is not continuously proven.

## After

CI runs the round-trip against **real MinIO on a Docker-capable ubuntu runner** on every push/PR, inside the existing `test` job's "Run Docker-dependent tests" Linux step. The tests use testcontainers to start MinIO + Postgres themselves via the Docker socket, so no GitHub `services:` block is needed — a Docker-capable runner is sufficient.

## How

Edits `.github/workflows/ci.yml` only:

- **Invocation**: added `cargo test -p autumn-cli --test cli_tests -- --ignored offsite` to the existing Docker-dependent Linux step. `cli_tests` is the consolidated autumn-cli test binary (per CLAUDE.md); the `offsite` name filter selects **both** ignored tests in the file (`offsite_backup_upload_then_restore_round_trips` and `offsite_backup_uploads_large_artifact_via_multipart`).
- **postgresql-client install**: `autumn db backup` shells out to the **host** `pg_dump`/`pg_restore`, which ubuntu-latest does not guarantee on PATH. Added a Linux-gated "Install Postgres client tools" step (`sudo apt-get install -y postgresql-client`) before the Docker step. The package installs `pg_dump`/`pg_restore` into `/usr/bin` via pg_wrapper symlinks, so no extra PATH manipulation is needed; the step also prints their `--version` as a sanity check. The other Docker tests already in this step don't need host pg tools — this one does, so this install is new.
- **timeout**: added `timeout-minutes: 30` to the Docker-dependent step to bound the two extra container starts (MinIO + Postgres, ~30–60s), mirroring the `loom` job's timeout style.
- **Not a new required gate**: kept in the **existing** Docker-dependent Linux step rather than a standalone job, so the default PR lane is not gated on a whole new required job. The step already runs many `-- --ignored` Docker tests on Linux, so this is consistent with existing behavior and adds only one test invocation (plus one apt install) to that lane.

## Verification

- YAML validated with `yaml.safe_load` — well-formed.
- Confirmed the invocation targets the consolidated binary name `cli_tests` and that the `offsite` filter matches both `#[ignore]` tests in `autumn-cli/tests/integration/offsite_backup.rs`.
- Could **not** run the actual CI job locally (requires the GitHub Actions runner + Docker). The real execution is exercised when this lands.

Closes #1744

---
_Generated by [Claude Code](https://claude.ai/code/session_01NT15Vm2Gq3zgnRWG1wBm7L)_