### PR TITLE
feat(macros): m2m helper-name override for multiple relations to one target (#1785)

### DIFF
--- a/autumn-macros/src/lib.rs
+++ b/autumn-macros/src/lib.rs
@@ -419,6 +419,24 @@ pub fn story(input: TokenStream) -> TokenStream {
 /// repo.remove_tag(post_id, tag_id).await?;   // idempotent: no-op if unlinked
 /// repo.set_tags(post_id, &tag_ids).await?;   // replace-all, one transaction
 /// ```
+///
+/// The `add_`/`remove_` singular is derived from the target *type* name, so a
+/// model may declare at most one m2m association per target type by default —
+/// a second one to the same target would generate colliding helpers (a compile
+/// error). To declare two m2m associations to the same target (e.g. a
+/// self-referential `followers`/`following` pair through one `Friendship` join
+/// table), give each a distinct explicit `helper = "..."` override, which sets
+/// the singular used for its `add_`/`remove_` helpers:
+///
+/// ```ignore
+/// #[model]
+/// #[has_many(User, through = friendships, name = followers,
+///            fk = followed_id, target_fk = follower_id, helper = "follower")]
+/// #[has_many(User, through = friendships, name = following,
+///            fk = follower_id, target_fk = followed_id, helper = "following")]
+/// pub struct User { /* ... */ }
+/// // -> add_follower/remove_follower and add_following/remove_following
+/// ```
 #[proc_macro_attribute]
 pub fn model(attr: TokenStream, item: TokenStream) -> TokenStream {
     model::model_macro(attr.into(), item.into()).into()

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -116,6 +116,14 @@ struct Association {
     /// `delete_by_id` cascades this association without a repository-attribute
     /// `dependent(…)`.
     dependent: Option<DependentAction>,
+    /// Explicit override for the singular used to derive the many-to-many
+    /// `add_`/`remove_` mutation helper names (`helper = "follower"` →
+    /// `add_follower`/`remove_follower`). When absent, the singular is derived
+    /// from the target type name. Distinct overrides let a model declare two
+    /// m2m associations to the *same* target type (e.g. `followers` and
+    /// `following`, both through `Friendship` to `User`) without their
+    /// target-derived helpers colliding.
+    helper: Option<String>,
 }
 
 /// The join-table half of a many-to-many `has_many(..., through = ...)`
@@ -204,6 +212,10 @@ fn parse_dependent_action(
     })
 }
 
+// Accumulates per-feature parsing/validation for each association key (`fk`,
+// `name`, `through`, `target_fk`, `dependent`/`on_delete`, `helper`), so it
+// grows past the line lint as association options are added.
+#[allow(clippy::too_many_lines)]
 fn parse_assoc_attr(
     attr: &syn::Attribute,
     kind: AssocKind,
@@ -211,55 +223,66 @@ fn parse_assoc_attr(
 ) -> syn::Result<Association> {
     use syn::parse::ParseStream;
 
-    let (target, explicit_fk, explicit_name, explicit_through, explicit_target_fk, dependent) =
-        attr.parse_args_with(|input: ParseStream| {
-            let target: syn::Ident = input.parse()?;
-            let mut explicit_fk: Option<String> = None;
-            let mut explicit_name: Option<String> = None;
-            let mut explicit_through: Option<String> = None;
-            let mut explicit_target_fk: Option<String> = None;
-            let mut dependent: Option<DependentAction> = None;
-            // Zero or more trailing `, key = value` pairs (`fk`, `name`,
-            // `through`, `target_fk`), any order.
-            while input.peek(syn::Token![,]) {
-                input.parse::<syn::Token![,]>()?;
-                let key: syn::Ident = input.parse()?;
-                input.parse::<syn::Token![=]>()?;
-                // Accept either a bare identifier (`fk = author_id`) or a string
-                // literal (`fk = "author_id"`).
-                let value = if input.peek(LitStr) {
-                    input.parse::<LitStr>()?.value()
-                } else {
-                    input.parse::<syn::Ident>()?.to_string()
-                };
-                if key == "fk" {
-                    explicit_fk = Some(value);
-                } else if key == "name" {
-                    explicit_name = Some(value);
-                } else if key == "through" {
-                    explicit_through = Some(value);
-                } else if key == "target_fk" {
-                    explicit_target_fk = Some(value);
-                } else if key == "dependent" || key == "on_delete" {
-                    dependent = Some(parse_dependent_action(kind, &key, &value)?);
-                } else {
-                    return Err(syn::Error::new_spanned(
-                        &key,
-                        "expected `fk = <column>`, `name = <accessor>`, \
-                         `through = <join_table>`, or `target_fk = <column>` \
-                         in association attribute",
-                    ));
-                }
+    let (
+        target,
+        explicit_fk,
+        explicit_name,
+        explicit_through,
+        explicit_target_fk,
+        dependent,
+        explicit_helper,
+    ) = attr.parse_args_with(|input: ParseStream| {
+        let target: syn::Ident = input.parse()?;
+        let mut explicit_fk: Option<String> = None;
+        let mut explicit_name: Option<String> = None;
+        let mut explicit_through: Option<String> = None;
+        let mut explicit_target_fk: Option<String> = None;
+        let mut dependent: Option<DependentAction> = None;
+        let mut explicit_helper: Option<String> = None;
+        // Zero or more trailing `, key = value` pairs (`fk`, `name`,
+        // `through`, `target_fk`, `helper`), any order.
+        while input.peek(syn::Token![,]) {
+            input.parse::<syn::Token![,]>()?;
+            let key: syn::Ident = input.parse()?;
+            input.parse::<syn::Token![=]>()?;
+            // Accept either a bare identifier (`fk = author_id`) or a string
+            // literal (`fk = "author_id"`).
+            let value = if input.peek(LitStr) {
+                input.parse::<LitStr>()?.value()
+            } else {
+                input.parse::<syn::Ident>()?.to_string()
+            };
+            if key == "fk" {
+                explicit_fk = Some(value);
+            } else if key == "name" {
+                explicit_name = Some(value);
+            } else if key == "through" {
+                explicit_through = Some(value);
+            } else if key == "target_fk" {
+                explicit_target_fk = Some(value);
+            } else if key == "helper" {
+                explicit_helper = Some(value);
+            } else if key == "dependent" || key == "on_delete" {
+                dependent = Some(parse_dependent_action(kind, &key, &value)?);
+            } else {
+                return Err(syn::Error::new_spanned(
+                    &key,
+                    "expected `fk = <column>`, `name = <accessor>`, \
+                         `through = <join_table>`, `target_fk = <column>`, or \
+                         `helper = <singular>` in association attribute",
+                ));
             }
-            Ok((
-                target,
-                explicit_fk,
-                explicit_name,
-                explicit_through,
-                explicit_target_fk,
-                dependent,
-            ))
-        })?;
+        }
+        Ok((
+            target,
+            explicit_fk,
+            explicit_name,
+            explicit_through,
+            explicit_target_fk,
+            dependent,
+            explicit_helper,
+        ))
+    })?;
 
     if explicit_through.is_some() && kind != AssocKind::HasMany {
         return Err(syn::Error::new_spanned(
@@ -293,6 +316,15 @@ fn parse_assoc_attr(
              table directly",
         ));
     }
+    if explicit_helper.is_some() && explicit_through.is_none() {
+        return Err(syn::Error::new_spanned(
+            &target,
+            "`helper = <singular>` overrides the many-to-many `add_`/`remove_` \
+             mutation-helper names and therefore requires `through = \
+             <join_table>` (it has no effect on plain `belongs_to`/`has_one`/\
+             non-`through` `has_many` associations)",
+        ));
+    }
 
     let (fk, derived_name) =
         resolve_fk_and_name(kind, model_ident, &target, explicit_fk.as_deref());
@@ -311,6 +343,7 @@ fn parse_assoc_attr(
         name,
         through,
         dependent,
+        helper: explicit_helper,
     })
 }
 
@@ -352,6 +385,24 @@ fn m2m_mutation_singular(target: &syn::Ident) -> String {
     pascal_to_snake(&target.to_string())
 }
 
+/// The *resolved* singular for an association's `add_`/`remove_` mutation
+/// helpers: the explicit per-association `helper = "..."` override when present,
+/// otherwise the target-type-derived singular.
+///
+/// The override is the escape hatch (#1785) that lets a model declare more than
+/// one many-to-many association to the *same* target type — e.g. `followers`
+/// and `following`, both `#[has_many(User, through = Friendship, ...)]` — by
+/// giving each a distinct `helper` (`add_follower` vs. `add_following`) instead
+/// of the colliding target-derived `add_user`. It is opt-in and explicit: no
+/// inference/inverse-inflection (deliberately avoided as the fragile class of
+/// bug #1779 fixed).
+fn resolved_m2m_singular(assoc: &Association) -> String {
+    assoc
+        .helper
+        .clone()
+        .unwrap_or_else(|| m2m_mutation_singular(&assoc.target))
+}
+
 /// Reject a model whose many-to-many associations would generate colliding
 /// `add_*`/`remove_*`/`set_*` mutation helper names (e.g. two `through =`
 /// associations that both derive `add_tag`), rather than emitting a trait
@@ -362,19 +413,20 @@ fn check_m2m_mutation_name_collisions(assocs: &[Association]) -> syn::Result<()>
         if assoc.through.is_none() {
             continue;
         }
-        let singular = m2m_mutation_singular(&assoc.target);
+        let singular = resolved_m2m_singular(assoc);
         if seen.insert(singular.clone(), &assoc.target).is_some() {
             return Err(syn::Error::new_spanned(
                 &assoc.target,
                 format!(
                     "many-to-many association `{}` (target `{}`) resolves to the \
-                     same target-derived mutation helpers `add_{singular}`/\
-                     `remove_{singular}` as another `through =` association to \
-                     `{}` on this model; a model may currently declare at most \
-                     one many-to-many association per target type. The intended \
-                     fix is an explicit per-association helper-name override \
-                     (planned `helper = \"...\"`) so distinct m2m relations to \
-                     the same target get non-colliding helpers — tracked in \
+                     same mutation helpers `add_{singular}`/`remove_{singular}` \
+                     as another `through =` association on this model. Two m2m \
+                     associations to the same target type would otherwise \
+                     generate colliding helpers. Give at least one an explicit \
+                     per-association override, e.g. `#[has_many({}, through = \
+                     ..., helper = \"...\")]`, so each gets a distinct \
+                     `add_`/`remove_` name (the followers/following-through-a-\
+                     join pattern) — see \
                      https://github.com/madmax983/autumn/issues/1785",
                     assoc.name, assoc.target, assoc.target,
                 ),
@@ -892,7 +944,7 @@ fn emit_association_items(
                     // traits are both in scope.
                     let mutation_trait_ident =
                         format_ident!("{model_ident}{}Mutations", pascal_case(&assoc.name));
-                    let singular = m2m_mutation_singular(target);
+                    let singular = resolved_m2m_singular(assoc);
                     let add_ident = format_ident!("add_{singular}");
                     let remove_ident = format_ident!("remove_{singular}");
                     let set_ident = format_ident!("set_{}", assoc.name);
@@ -5339,6 +5391,109 @@ mod tests {
             syn::parse_quote!(#[has_many(Tag, through = featured_post_tags, name = featured_tags)]),
         ];
         assert!(resolve_associations(&model, &attrs).is_err());
+    }
+
+    #[test]
+    fn m2m_helper_override_re_enables_two_relations_to_same_target() {
+        // #1785 escape hatch: two m2m associations to the *same* target type
+        // (`User`, both through `friendships`) compile when each carries a
+        // distinct `helper = "..."` override, because the collision check keys
+        // on the *resolved* singular (the override) instead of the
+        // target-derived one.
+        let model: syn::Ident = syn::parse_quote!(User);
+        let attrs: Vec<syn::Attribute> = vec![
+            syn::parse_quote!(
+                #[has_many(User, through = friendships, name = followers,
+                           fk = followed_id, target_fk = follower_id,
+                           helper = follower)]
+            ),
+            syn::parse_quote!(
+                #[has_many(User, through = friendships, name = following,
+                           fk = follower_id, target_fk = followed_id,
+                           helper = following)]
+            ),
+        ];
+        assert!(
+            resolve_associations(&model, &attrs).is_ok(),
+            "distinct `helper = ...` overrides must re-enable dual m2m to one target"
+        );
+    }
+
+    #[test]
+    fn m2m_helper_override_matching_derived_still_collides() {
+        // A `helper` override that resolves to the same singular as another
+        // association's target-derived singular still collides — the check
+        // keys on the resolved name, override or not.
+        let model: syn::Ident = syn::parse_quote!(Post);
+        let attrs: Vec<syn::Attribute> = vec![
+            syn::parse_quote!(#[has_many(Tag, through = post_tags)]),
+            syn::parse_quote!(
+                #[has_many(Label, through = post_labels, name = labels, helper = tag)]
+            ),
+        ];
+        assert!(
+            resolve_associations(&model, &attrs).is_err(),
+            "an override colliding with a derived singular must still be rejected"
+        );
+    }
+
+    #[test]
+    fn m2m_helper_override_requires_through() {
+        // `helper = ...` only affects m2m mutation helpers, so it is rejected
+        // on a non-`through` association rather than silently ignored.
+        let model: syn::Ident = syn::parse_quote!(Post);
+        let attrs: Vec<syn::Attribute> =
+            vec![syn::parse_quote!(#[has_many(Comment, helper = commentary)])];
+        assert!(resolve_associations(&model, &attrs).is_err());
+    }
+
+    #[test]
+    fn model_macro_m2m_helper_override_generates_distinct_helpers() {
+        // End-to-end #1785: the followers/following-through-`Friendship`
+        // pattern generates distinct `add_follower`/`add_following` (and
+        // `remove_`) helpers keyed on the `helper = ...` override, not the
+        // colliding target-derived `add_user`.
+        let generated = model_macro(
+            quote! {},
+            quote! {
+                #[has_many(User, through = friendships, name = followers,
+                           fk = followed_id, target_fk = follower_id,
+                           helper = follower)]
+                #[has_many(User, through = friendships, name = following,
+                           fk = follower_id, target_fk = followed_id,
+                           helper = following)]
+                pub struct User {
+                    #[id]
+                    pub id: i64,
+                }
+            },
+        )
+        .to_string();
+
+        assert!(
+            generated.contains("add_follower"),
+            "expected add_follower helper, got: {generated}"
+        );
+        assert!(
+            generated.contains("remove_follower"),
+            "expected remove_follower helper"
+        );
+        assert!(
+            generated.contains("add_following"),
+            "expected add_following helper"
+        );
+        assert!(
+            generated.contains("remove_following"),
+            "expected remove_following helper"
+        );
+        assert!(
+            !generated.contains("add_user"),
+            "must not fall back to the colliding target-derived add_user"
+        );
+        assert!(
+            generated.contains("set_followers") && generated.contains("set_following"),
+            "the set_ (replace-all) helpers keep their per-association accessor names"
+        );
     }
 
     #[test]

--- a/autumn/tests/compile-fail/model_m2m_helper_collision.rs
+++ b/autumn/tests/compile-fail/model_m2m_helper_collision.rs
@@ -1,0 +1,25 @@
+//! #1785: two many-to-many associations to the same target type with NO
+//! `helper = "..."` override still collide on their target-derived
+//! `add_`/`remove_` mutation helpers, and the error points at the
+//! `helper = "..."` escape hatch as the fix.
+use autumn_web::model;
+
+diesel::table! {
+    users (id) {
+        id -> BigInt,
+        name -> Text,
+    }
+}
+
+#[model]
+#[has_many(User, through = friendships, name = followers,
+           fk = followed_id, target_fk = follower_id)]
+#[has_many(User, through = friendships, name = following,
+           fk = follower_id, target_fk = followed_id)]
+pub struct User {
+    #[id]
+    pub id: i64,
+    pub name: String,
+}
+
+fn main() {}

--- a/autumn/tests/compile-fail/model_m2m_helper_collision.stderr
+++ b/autumn/tests/compile-fail/model_m2m_helper_collision.stderr
@@ -1,0 +1,5 @@
+error: many-to-many association `following` (target `User`) resolves to the same mutation helpers `add_user`/`remove_user` as another `through =` association on this model. Two m2m associations to the same target type would otherwise generate colliding helpers. Give at least one an explicit per-association override, e.g. `#[has_many(User, through = ..., helper = "...")]`, so each gets a distinct `add_`/`remove_` name (the followers/following-through-a-join pattern) — see https://github.com/madmax983/autumn/issues/1785
+  --> tests/compile-fail/model_m2m_helper_collision.rs:17:12
+   |
+17 | #[has_many(User, through = friendships, name = following,
+   |            ^^^^

--- a/autumn/tests/compile-pass/model_m2m_helper_override.rs
+++ b/autumn/tests/compile-pass/model_m2m_helper_override.rs
@@ -1,0 +1,31 @@
+//! #1785 escape hatch: two many-to-many associations to the *same* target
+//! type compile when each carries a distinct `helper = "..."` override.
+//!
+//! This is the self-referential followers/following-through-`Friendship`
+//! pattern: a `User` follows many users and is followed by many users, both
+//! modeled as m2m through the same `friendships` join table. Without the
+//! `helper` override both associations would derive the target-type helper
+//! `add_user`/`remove_user` and collide (a compile error); the distinct
+//! `helper = follower` / `helper = following` overrides give
+//! `add_follower`/`remove_follower` and `add_following`/`remove_following`.
+use autumn_web::model;
+
+diesel::table! {
+    users (id) {
+        id -> BigInt,
+        name -> Text,
+    }
+}
+
+#[model]
+#[has_many(User, through = friendships, name = followers,
+           fk = followed_id, target_fk = follower_id, helper = follower)]
+#[has_many(User, through = friendships, name = following,
+           fk = follower_id, target_fk = followed_id, helper = following)]
+pub struct User {
+    #[id]
+    pub id: i64,
+    pub name: String,
+}
+
+fn main() {}

--- a/autumn/tests/integration/compile_fail.rs
+++ b/autumn/tests/integration/compile_fail.rs
@@ -24,6 +24,11 @@ fn compile_fail_tests() {
     #[cfg(feature = "db")]
     t.compile_fail("tests/compile-fail/model_shard_key_unknown.rs");
 
+    // Two m2m associations to the same target type with no `helper = "..."`
+    // override collide on their target-derived mutation helpers (#1785).
+    #[cfg(feature = "db")]
+    t.compile_fail("tests/compile-fail/model_m2m_helper_collision.rs");
+
     // Repository hooks failures (require db feature)
     #[cfg(feature = "db")]
     compile_repository_hooks_not_default(&t);
@@ -72,6 +77,11 @@ fn compile_pass_tests() {
     // Model field enum (requires db feature)
     #[cfg(feature = "db")]
     t.pass("tests/compile-pass/model_field_enum.rs");
+
+    // Two m2m associations to the same target type disambiguated by distinct
+    // `helper = "..."` overrides — the followers/following pattern (#1785).
+    #[cfg(feature = "db")]
+    t.pass("tests/compile-pass/model_m2m_helper_override.rs");
 
     // Model draft accessors (requires db feature)
     #[cfg(feature = "db")]


### PR DESCRIPTION
## Before

Since #1779, the many-to-many `add_`/`remove_` mutation helpers derive their singular from the target **type** name (`pascal_to_snake(Target)`). A useful consequence — deterministic helper names for irregular plurals — but it also meant a model could declare **at most one** `#[has_many(Target, through = ...)]` per target type. A second m2m association to the same target generated colliding `add_`/`remove_` helpers and was rejected as a compile error, with the error text promising a `helper = "..."` escape hatch that did not yet exist. This ruled out the self-referential followers/following pattern: a `User` who both follows and is followed by many users, both modeled as m2m through one `Friendship` join table.

## After

The m2m `has_many` attribute accepts an explicit per-association `helper = "..."` override that sets the singular used for that association's `add_`/`remove_` mutation helpers. Two m2m associations to the same target type are now expressible when they carry distinct overrides:

```rust
#[model]
#[has_many(User, through = friendships, name = followers,
           fk = followed_id, target_fk = follower_id, helper = "follower")]
#[has_many(User, through = friendships, name = following,
           fk = follower_id, target_fk = followed_id, helper = "following")]
pub struct User { /* ... */ }
// generates add_follower/remove_follower and add_following/remove_following
```

Absent the override, behavior is unchanged (target-type-derived singular). When two same-target m2m associations have no override, the collision still fires — and the error text now shows the `helper = "..."` fix.

## How

`Association` gains a `helper: Option<String>` field, and `parse_assoc_attr` accepts a `helper = <singular>` key (rejected on non-`through` associations, where it would be a silent no-op). A new `resolved_m2m_singular(assoc)` returns the override when present, else the existing target-derived `m2m_mutation_singular`. Both the duplicate-target collision check (`check_m2m_mutation_name_collisions`) and the mutation-helper codegen now key on that resolved singular, so distinct overrides yield non-colliding helpers and an override that resolves to an already-taken singular still collides.

## Testing

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p autumn-macros --all-targets -- -D warnings` — clean
- `cargo clippy -p autumn-web --all-targets --features db -- -D warnings` — clean
- `cargo test -p autumn-macros` — 460 passed (adds override unit tests)
- `cargo test -p autumn-web --test integration_tests --features db` compile-pass + compile-fail trybuild suites — pass (new `model_m2m_helper_override` compile-pass fixture; new `model_m2m_helper_collision` compile-fail fixture + regenerated `.stderr`)

Closes #1785.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErWNyJrf4kyjmVa1FJKYv2)_