### PR TITLE
Tenant cell registry eviction, dynamic quota, and tenancy env overrides

### DIFF
--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -3046,10 +3046,67 @@ impl AutumnConfig {
     }
 
     fn apply_tenancy_env_overrides_with_env(&mut self, env: &dyn Env) {
+        parse_env_bool(env, "AUTUMN_TENANCY__ENABLED", &mut self.tenancy.enabled);
+        parse_env_string(env, "AUTUMN_TENANCY__SOURCE", &mut self.tenancy.source);
+        parse_env_string(
+            env,
+            "AUTUMN_TENANCY__HEADER_NAME",
+            &mut self.tenancy.header_name,
+        );
+        parse_env_string(
+            env,
+            "AUTUMN_TENANCY__SESSION_KEY",
+            &mut self.tenancy.session_key,
+        );
+        parse_env_string(
+            env,
+            "AUTUMN_TENANCY__JWT_CLAIM",
+            &mut self.tenancy.jwt_claim,
+        );
+        parse_env_option_secret(
+            env,
+            "AUTUMN_TENANCY__JWT_SECRET",
+            &mut self.tenancy.jwt_secret,
+        );
+        parse_env_option_string(
+            env,
+            "AUTUMN_TENANCY__JWT_ISSUER",
+            &mut self.tenancy.jwt_issuer,
+        );
+        parse_env_option_string(
+            env,
+            "AUTUMN_TENANCY__JWT_AUDIENCE",
+            &mut self.tenancy.jwt_audience,
+        );
+        parse_env_option_string(
+            env,
+            "AUTUMN_TENANCY__BASE_DOMAIN",
+            &mut self.tenancy.base_domain,
+        );
+        parse_env_option_string(
+            env,
+            "AUTUMN_TENANCY__LOGIN_REDIRECT",
+            &mut self.tenancy.login_redirect,
+        );
+        parse_env_csv(
+            env,
+            "AUTUMN_TENANCY__PUBLIC_PATHS",
+            &mut self.tenancy.public_paths,
+        );
         parse_env(
             env,
             "AUTUMN_TENANCY__QUOTA_BYTES",
             &mut self.tenancy.quota_bytes,
+        );
+        parse_env(
+            env,
+            "AUTUMN_TENANCY__MAX_CELLS",
+            &mut self.tenancy.max_cells,
+        );
+        parse_env(
+            env,
+            "AUTUMN_TENANCY__IDLE_TTL_SECS",
+            &mut self.tenancy.idle_ttl_secs,
         );
     }
 
@@ -5635,6 +5692,21 @@ fn parse_env_option_string(env: &dyn Env, key: &str, target: &mut Option<String>
     }
 }
 
+/// Secret-aware variant of [`parse_env_option_string`]: an empty (after
+/// trimming) value clears the target, otherwise the trimmed value is wrapped in
+/// a [`secrecy::SecretString`] so it is redacted from `Debug` and zeroized on
+/// drop.
+fn parse_env_option_secret(env: &dyn Env, key: &str, target: &mut Option<secrecy::SecretString>) {
+    if let Ok(val) = env.var(key) {
+        let trimmed = val.trim();
+        *target = if trimmed.is_empty() {
+            None
+        } else {
+            Some(secrecy::SecretString::from(trimmed.to_owned()))
+        };
+    }
+}
+
 fn parse_env_option<T: std::str::FromStr>(env: &dyn Env, key: &str, target: &mut Option<T>) {
     if let Ok(val) = env.var(key) {
         if val.is_empty() {
@@ -6095,6 +6167,16 @@ pub struct TenancyConfig {
     /// `0` disables the quota (unlimited).
     #[serde(default)]
     pub quota_bytes: usize,
+
+    /// Maximum number of resident tenant cells; least-recently-used cells are
+    /// evicted above this. `0` = unbounded.
+    #[serde(default)]
+    pub max_cells: usize,
+
+    /// Evict a tenant cell whose last access exceeds this many seconds.
+    /// `0` = disabled.
+    #[serde(default)]
+    pub idle_ttl_secs: u64,
 }
 
 fn default_tenancy_source() -> String {
@@ -6128,6 +6210,8 @@ impl Default for TenancyConfig {
             public_paths: Vec::new(),
             login_redirect: None,
             quota_bytes: 0,
+            max_cells: 0,
+            idle_ttl_secs: 0,
         }
     }
 }
@@ -8595,6 +8679,103 @@ path = "/healthz"
         let mut config = AutumnConfig::default();
         config.apply_env_overrides_with_env(&env);
         assert_eq!(config.tenancy.quota_bytes, 1_048_576);
+    }
+
+    #[test]
+    fn env_override_tenancy_enabled() {
+        // Unset: default stays false.
+        let env = MockEnv::new();
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert!(!config.tenancy.enabled);
+
+        let env = MockEnv::new().with("AUTUMN_TENANCY__ENABLED", "true");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert!(config.tenancy.enabled);
+    }
+
+    #[test]
+    fn env_override_tenancy_string_fields() {
+        let env = MockEnv::new()
+            .with("AUTUMN_TENANCY__SOURCE", "jwt")
+            .with("AUTUMN_TENANCY__HEADER_NAME", "x-org")
+            .with("AUTUMN_TENANCY__SESSION_KEY", "org_id")
+            .with("AUTUMN_TENANCY__JWT_CLAIM", "org")
+            .with("AUTUMN_TENANCY__JWT_ISSUER", "https://issuer.example")
+            .with("AUTUMN_TENANCY__JWT_AUDIENCE", "autumn-api")
+            .with("AUTUMN_TENANCY__BASE_DOMAIN", "apps.example.com")
+            .with("AUTUMN_TENANCY__LOGIN_REDIRECT", "/login")
+            .with("AUTUMN_TENANCY__PUBLIC_PATHS", "/login, /signup ,/assets");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert_eq!(config.tenancy.source, "jwt");
+        assert_eq!(config.tenancy.header_name, "x-org");
+        assert_eq!(config.tenancy.session_key, "org_id");
+        assert_eq!(config.tenancy.jwt_claim, "org");
+        assert_eq!(
+            config.tenancy.jwt_issuer.as_deref(),
+            Some("https://issuer.example")
+        );
+        assert_eq!(config.tenancy.jwt_audience.as_deref(), Some("autumn-api"));
+        assert_eq!(
+            config.tenancy.base_domain.as_deref(),
+            Some("apps.example.com")
+        );
+        assert_eq!(config.tenancy.login_redirect.as_deref(), Some("/login"));
+        assert_eq!(
+            config.tenancy.public_paths,
+            vec!["/login", "/signup", "/assets"]
+        );
+    }
+
+    #[test]
+    fn env_override_tenancy_eviction_knobs() {
+        // Unset: defaults stay 0 (unbounded / disabled).
+        let env = MockEnv::new();
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert_eq!(config.tenancy.max_cells, 0);
+        assert_eq!(config.tenancy.idle_ttl_secs, 0);
+
+        let env = MockEnv::new()
+            .with("AUTUMN_TENANCY__MAX_CELLS", "512")
+            .with("AUTUMN_TENANCY__IDLE_TTL_SECS", "900");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert_eq!(config.tenancy.max_cells, 512);
+        assert_eq!(config.tenancy.idle_ttl_secs, 900);
+    }
+
+    #[test]
+    fn env_override_tenancy_secret() {
+        use secrecy::ExposeSecret;
+
+        // Unset: default stays None.
+        let env = MockEnv::new();
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert!(config.tenancy.jwt_secret.is_none());
+
+        // Set via env: wrapped as a SecretString, trimmed.
+        let env = MockEnv::new().with("AUTUMN_TENANCY__JWT_SECRET", "  s3cr3t-signing-key  ");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert_eq!(
+            config
+                .tenancy
+                .jwt_secret
+                .as_ref()
+                .map(|s| s.expose_secret().to_owned()),
+            Some("s3cr3t-signing-key".to_string())
+        );
+
+        // Empty value clears the secret.
+        let env = MockEnv::new().with("AUTUMN_TENANCY__JWT_SECRET", "   ");
+        let mut config = AutumnConfig::default();
+        config.tenancy.jwt_secret = Some(secrecy::SecretString::from("preexisting".to_string()));
+        config.apply_env_overrides_with_env(&env);
+        assert!(config.tenancy.jwt_secret.is_none());
     }
 
     #[test]

--- a/autumn/src/tenancy.rs
+++ b/autumn/src/tenancy.rs
@@ -461,7 +461,13 @@ pub async fn tenancy_middleware(
     // first accesses it via `current_tenant_cell()`. Requests to routes that
     // never touch tenant memory therefore leave the registry untouched, even
     // with request-controlled tenant ids.
-    let registry = state.extension_or_insert_with(crate::tenant_cell::TenantCellRegistry::new);
+    let registry = state.extension_or_insert_with(|| {
+        crate::tenant_cell::TenantCellRegistry::with_limits(
+            config.tenancy.max_cells,
+            (config.tenancy.idle_ttl_secs > 0)
+                .then(|| std::time::Duration::from_secs(config.tenancy.idle_ttl_secs)),
+        )
+    });
     let handle = crate::tenant_cell::TenantCellHandle::new(
         (*registry).clone(),
         tenant_id.clone(),

--- a/autumn/src/tenant_cell.rs
+++ b/autumn/src/tenant_cell.rs
@@ -272,12 +272,21 @@ impl TenantCell {
     /// registry's base `Instant`) together with a globally-monotonic access
     /// sequence number. Called by the registry on every lookup to drive
     /// idle-TTL (via the millisecond timestamp) and least-recently-used (via the
-    /// strictly-increasing sequence) eviction. Both are relaxed atomic stores,
-    /// so this is safe to call through a shared `&TenantCell` while the
-    /// registry's read guard is still held.
+    /// strictly-increasing sequence) eviction. Both are relaxed atomic
+    /// `fetch_max` updates, so this is safe to call through a shared
+    /// `&TenantCell` while the registry's read guard is still held.
+    ///
+    /// The stores are monotonic (`fetch_max`): a stale `now_millis` captured
+    /// before a lock wait, or an out-of-order concurrent `touch`, can never
+    /// regress a cell's recorded access time or sequence below a fresher value
+    /// already stamped by another accessor. This keeps a just-accessed tenant
+    /// from being seen as idle (and evicted, letting a duplicate cell form)
+    /// because of a lagging timestamp.
     pub fn touch(&self, now_millis: u64, seq: u64) {
-        self.inner.last_access.store(now_millis, Ordering::Relaxed);
-        self.inner.last_access_seq.store(seq, Ordering::Relaxed);
+        self.inner
+            .last_access
+            .fetch_max(now_millis, Ordering::Relaxed);
+        self.inner.last_access_seq.fetch_max(seq, Ordering::Relaxed);
     }
 
     /// The registry-relative timestamp of this cell's most recent access.
@@ -543,8 +552,6 @@ impl TenantCellRegistry {
     // opt out of the drop-tightening lint that would shrink the guard's scope.
     #[allow(clippy::significant_drop_tightening)]
     pub fn get(&self, tenant_id: &str) -> Option<Arc<TenantCell>> {
-        let now = self.now_millis();
-        let seq = self.next_seq();
         let guard = self
             .inner
             .cells
@@ -552,10 +559,13 @@ impl TenantCellRegistry {
             .expect("tenant cell registry lock poisoned");
         // Refresh the access time/sequence WHILE the read guard is still held,
         // so a concurrent writer cannot evict this cell in the gap between the
-        // lookup and the touch. `touch` is relaxed atomic stores through the
-        // shared `&Arc<TenantCell>`, safe under the read lock.
+        // lookup and the touch. Capture `now`/`seq` here, under the guard and
+        // immediately before the touch, so a stale timestamp taken before a
+        // lock wait can never stamp the cell. `touch` is relaxed atomic
+        // `fetch_max` stores through the shared `&Arc<TenantCell>`, safe under
+        // the read lock.
         if let Some(cell) = guard.get(tenant_id) {
-            cell.touch(now, seq);
+            cell.touch(self.now_millis(), self.next_seq());
             return Some(Arc::clone(cell));
         }
         None
@@ -580,7 +590,6 @@ impl TenantCellRegistry {
     /// Panics if the registry lock is poisoned.
     #[must_use]
     pub fn get_or_create(&self, tenant_id: &str, quota_bytes: usize) -> Arc<TenantCell> {
-        let now = self.now_millis();
         // Fast path: a resident cell just needs its access time and quota
         // refreshed under the cheaper read lock. Do the touch/quota-refresh
         // WHILE the read guard is still held so a concurrent writer cannot evict
@@ -593,7 +602,10 @@ impl TenantCellRegistry {
                 .read()
                 .expect("tenant cell registry lock poisoned");
             if let Some(cell) = guard.get(tenant_id) {
-                cell.touch(now, self.next_seq());
+                // Capture `now` here, under the guard and immediately before the
+                // touch, so a timestamp taken before a lock wait can never stamp
+                // a fresh access time as stale.
+                cell.touch(self.now_millis(), self.next_seq());
                 cell.set_quota_bytes(quota_bytes);
                 return Arc::clone(cell);
             }
@@ -607,7 +619,8 @@ impl TenantCellRegistry {
         // taking the write lock.
         if let Some(cell) = cells.get(tenant_id) {
             let cell = Arc::clone(cell);
-            cell.touch(now, self.next_seq());
+            // Fresh `now` under the write guard, right before the touch.
+            cell.touch(self.now_millis(), self.next_seq());
             cell.set_quota_bytes(quota_bytes);
             return cell;
         }
@@ -616,6 +629,11 @@ impl TenantCellRegistry {
             quota_bytes,
             Arc::clone(&self.inner.global_tracked),
         ));
+        // Capture `now` under the write guard, immediately before stamping the
+        // new cell and sweeping, so the age comparison in `enforce_limits_locked`
+        // uses a fresh wall-clock reading rather than one taken before the lock
+        // wait.
+        let now = self.now_millis();
         // Stamp the new cell's access sequence BEFORE enforcing limits, so it
         // holds the greatest sequence and is never chosen as the LRU victim.
         cell.touch(now, self.next_seq());
@@ -690,13 +708,15 @@ impl TenantCellRegistry {
     /// Panics if the registry lock is poisoned.
     #[must_use]
     pub fn evict_idle_older_than(&self, ttl: Duration) -> usize {
-        let now = self.now_millis();
         let ttl_millis = u64::try_from(ttl.as_millis()).unwrap_or(u64::MAX);
         let mut cells = self
             .inner
             .cells
             .write()
             .expect("tenant cell registry lock poisoned");
+        // Read the clock under the write guard, so a `now` captured before a
+        // lock wait cannot age out a cell another thread just touched.
+        let now = self.now_millis();
         let before = cells.len();
         cells.retain(|_, cell| now.saturating_sub(cell.last_access_millis()) <= ttl_millis);
         before - cells.len()

--- a/autumn/src/tenant_cell.rs
+++ b/autumn/src/tenant_cell.rs
@@ -130,7 +130,17 @@ impl TenantCellInner {
         }
         let mut current = self.tracked_bytes.load(Ordering::Relaxed);
         loop {
+            // Reload the quota each iteration and re-apply the `0 == unlimited`
+            // rule *before* the over-quota check: a concurrent `set_quota_bytes`
+            // can flip a finite quota to unlimited between the entry check above
+            // and a later CAS retry, and once unlimited every positive `next`
+            // must be accepted rather than compared against `0`.
             let quota = self.quota_bytes.load(Ordering::Relaxed);
+            if quota == 0 {
+                self.tracked_bytes.fetch_add(n, Ordering::Relaxed);
+                self.global_tracked.fetch_add(n, Ordering::Relaxed);
+                return Ok(());
+            }
             let next = current.saturating_add(n);
             if next > quota {
                 return Err(QuotaExceeded {

--- a/autumn/src/tenant_cell.rs
+++ b/autumn/src/tenant_cell.rs
@@ -33,8 +33,9 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
+use std::time::{Duration, Instant};
 
 /// Fixed bytes charged per scratch entry to cover the map's per-entry overhead:
 /// the `String` and `Vec` structs stored inline in the bucket array plus an
@@ -90,10 +91,17 @@ struct ScratchState {
 #[derive(Debug)]
 struct TenantCellInner {
     tenant_id: String,
-    /// Soft quota in bytes; `0` means unlimited.
-    quota_bytes: usize,
+    /// Soft quota in bytes; `0` means unlimited. Mutable at runtime via
+    /// [`TenantCell::set_quota_bytes`] so a resident cell can pick up a
+    /// reconfigured quota without being evicted and rebuilt.
+    quota_bytes: AtomicUsize,
     /// Bytes currently tracked for this tenant.
     tracked_bytes: AtomicUsize,
+    /// Registry-relative timestamp (milliseconds since the registry's `base`
+    /// `Instant`) of this cell's most recent access, used to drive idle-TTL and
+    /// least-recently-used eviction. Set by the registry on creation and on
+    /// every subsequent lookup.
+    last_access: AtomicU64,
     /// Owned per-tenant scratch buffer and its entry high-water mark. Dropped
     /// with the cell.
     scratch: Mutex<ScratchState>,
@@ -106,20 +114,23 @@ impl TenantCellInner {
     /// process-wide gauges. Fails without mutating state if it would exceed the
     /// quota.
     fn reserve(&self, n: usize) -> Result<(), QuotaExceeded> {
-        if self.quota_bytes == 0 {
+        // Reload the quota on entry (and on each CAS retry below) so a runtime
+        // change via `set_quota_bytes` is honored by the very next reservation.
+        if self.quota_bytes.load(Ordering::Relaxed) == 0 {
             self.tracked_bytes.fetch_add(n, Ordering::Relaxed);
             self.global_tracked.fetch_add(n, Ordering::Relaxed);
             return Ok(());
         }
         let mut current = self.tracked_bytes.load(Ordering::Relaxed);
         loop {
+            let quota = self.quota_bytes.load(Ordering::Relaxed);
             let next = current.saturating_add(n);
-            if next > self.quota_bytes {
+            if next > quota {
                 return Err(QuotaExceeded {
                     tenant_id: self.tenant_id.clone(),
                     requested: n,
                     in_use: current,
-                    quota: self.quota_bytes,
+                    quota,
                 });
             }
             match self.tracked_bytes.compare_exchange_weak(
@@ -217,8 +228,11 @@ impl TenantCell {
         Self {
             inner: Arc::new(TenantCellInner {
                 tenant_id: tenant_id.into(),
-                quota_bytes,
+                quota_bytes: AtomicUsize::new(quota_bytes),
                 tracked_bytes: AtomicUsize::new(0),
+                // The owning registry stamps the real access time immediately
+                // after construction; 0 is a placeholder until then.
+                last_access: AtomicU64::new(0),
                 scratch: Mutex::new(ScratchState::default()),
                 global_tracked,
             }),
@@ -234,7 +248,27 @@ impl TenantCell {
     /// The soft quota in bytes (`0` means unlimited).
     #[must_use]
     pub fn quota_bytes(&self) -> usize {
-        self.inner.quota_bytes
+        self.inner.quota_bytes.load(Ordering::Relaxed)
+    }
+
+    /// Update the soft quota in bytes (`0` means unlimited). The new value takes
+    /// effect on the next [`try_charge`](Self::try_charge)/`scratch_insert`
+    /// reservation; already-tracked bytes are never retroactively rejected.
+    pub fn set_quota_bytes(&self, quota_bytes: usize) {
+        self.inner.quota_bytes.store(quota_bytes, Ordering::Relaxed);
+    }
+
+    /// Record a registry-relative access timestamp (milliseconds since the
+    /// registry's base `Instant`). Called by the registry on every lookup to
+    /// drive least-recently-used and idle-TTL eviction.
+    pub fn touch(&self, now_millis: u64) {
+        self.inner.last_access.store(now_millis, Ordering::Relaxed);
+    }
+
+    /// The registry-relative timestamp of this cell's most recent access.
+    #[must_use]
+    pub fn last_access_millis(&self) -> u64 {
+        self.inner.last_access.load(Ordering::Relaxed)
     }
 
     /// Bytes currently tracked for this tenant.
@@ -405,6 +439,15 @@ pub struct TenantCellRegistry {
 struct RegistryInner {
     cells: RwLock<HashMap<String, Arc<TenantCell>>>,
     global_tracked: Arc<AtomicUsize>,
+    /// Maximum number of resident cells; least-recently-used cells are evicted
+    /// once the count exceeds this. `0` disables the bound (unlimited).
+    max_cells: usize,
+    /// Evict a cell whose last access is older than this. `None` disables
+    /// idle-TTL eviction.
+    idle_ttl: Option<Duration>,
+    /// Monotonic clock origin for the registry-relative millisecond timestamps
+    /// stored on each cell's `last_access`.
+    base: Instant,
 }
 
 impl fmt::Debug for TenantCellRegistry {
@@ -423,15 +466,33 @@ impl Default for TenantCellRegistry {
 }
 
 impl TenantCellRegistry {
-    /// Create an empty registry.
+    /// Create an empty registry with eviction disabled (unlimited resident
+    /// cells, no idle-TTL sweep).
     #[must_use]
     pub fn new() -> Self {
+        Self::with_limits(0, None)
+    }
+
+    /// Create an empty registry that evicts cells to stay within the given
+    /// limits: at most `max_cells` resident cells (`0` = unbounded, evicting the
+    /// least-recently-used above the bound), and evicting any cell idle for
+    /// longer than `idle_ttl` (`None` = no idle sweep).
+    #[must_use]
+    pub fn with_limits(max_cells: usize, idle_ttl: Option<Duration>) -> Self {
         Self {
             inner: Arc::new(RegistryInner {
                 cells: RwLock::new(HashMap::new()),
                 global_tracked: Arc::new(AtomicUsize::new(0)),
+                max_cells,
+                idle_ttl,
+                base: Instant::now(),
             }),
         }
+    }
+
+    /// Registry-relative "now" in milliseconds since `base`.
+    fn now_millis(&self) -> u64 {
+        u64::try_from(self.inner.base.elapsed().as_millis()).unwrap_or(u64::MAX)
     }
 
     /// Fetch the cell for `tenant_id`, if one is resident.
@@ -441,23 +502,53 @@ impl TenantCellRegistry {
     /// Panics if the registry lock is poisoned.
     #[must_use]
     pub fn get(&self, tenant_id: &str) -> Option<Arc<TenantCell>> {
-        self.inner
+        let now = self.now_millis();
+        let cell = self
+            .inner
             .cells
             .read()
             .expect("tenant cell registry lock poisoned")
             .get(tenant_id)
-            .cloned()
+            .cloned();
+        if let Some(cell) = &cell {
+            cell.touch(now);
+        }
+        cell
     }
 
     /// Fetch the cell for `tenant_id`, creating it with `quota_bytes` if absent.
     /// Atomic: concurrent first requests for the same tenant share one cell.
+    ///
+    /// A *resident* cell refreshes its soft quota from `quota_bytes` on every
+    /// call, so the latest configured value is applied without evicting and
+    /// rebuilding the cell. In practice this only changes anything once a
+    /// config-reload path swaps the resident [`crate::config::AutumnConfig`]
+    /// (the middleware passes `config.tenancy.quota_bytes` here); no such
+    /// hot-reload path exists today, so the refresh is currently a no-op — the
+    /// mechanism is in place for when hot-reload lands.
+    ///
+    /// Every call also stamps the cell's last-access time and, on a miss, may
+    /// evict idle or least-recently-used cells to honor the registry's limits.
     ///
     /// # Panics
     ///
     /// Panics if the registry lock is poisoned.
     #[must_use]
     pub fn get_or_create(&self, tenant_id: &str, quota_bytes: usize) -> Arc<TenantCell> {
-        if let Some(cell) = self.get(tenant_id) {
+        let now = self.now_millis();
+        // Fast path: a resident cell just needs its access time and quota
+        // refreshed under the cheaper read lock. Bind the lookup to a local so
+        // the read guard is released before we touch/refresh the cell.
+        let resident = self
+            .inner
+            .cells
+            .read()
+            .expect("tenant cell registry lock poisoned")
+            .get(tenant_id)
+            .cloned();
+        if let Some(cell) = resident {
+            cell.touch(now);
+            cell.set_quota_bytes(quota_bytes);
             return cell;
         }
         let mut cells = self
@@ -465,16 +556,55 @@ impl TenantCellRegistry {
             .cells
             .write()
             .expect("tenant cell registry lock poisoned");
+        // Another writer may have inserted between dropping the read lock and
+        // taking the write lock.
         if let Some(cell) = cells.get(tenant_id) {
-            return Arc::clone(cell);
+            let cell = Arc::clone(cell);
+            cell.touch(now);
+            cell.set_quota_bytes(quota_bytes);
+            return cell;
         }
         let cell = Arc::new(TenantCell::new(
             tenant_id.to_string(),
             quota_bytes,
             Arc::clone(&self.inner.global_tracked),
         ));
+        cell.touch(now);
         cells.insert(tenant_id.to_string(), Arc::clone(&cell));
+        // Enforce eviction limits while we already hold the write lock. The
+        // just-touched new cell has the newest access time, so it is never the
+        // idle or LRU victim.
+        self.enforce_limits_locked(&mut cells, now);
+        drop(cells);
         cell
+    }
+
+    /// Evict idle and over-capacity cells from an already write-locked map.
+    ///
+    /// Must be called while holding the `cells` write lock; it never re-locks,
+    /// so it is safe to invoke from inside [`get_or_create`]'s miss branch.
+    /// Removal is a plain `HashMap::remove`, which drops only the registry's
+    /// strong reference — any outstanding `Arc<TenantCell>` (e.g. one held by an
+    /// in-flight request) stays valid and reclaims deterministically on drop.
+    fn enforce_limits_locked(&self, cells: &mut HashMap<String, Arc<TenantCell>>, now: u64) {
+        if let Some(ttl) = self.inner.idle_ttl {
+            let ttl_millis = u64::try_from(ttl.as_millis()).unwrap_or(u64::MAX);
+            cells.retain(|_, cell| now.saturating_sub(cell.last_access_millis()) <= ttl_millis);
+        }
+        let max_cells = self.inner.max_cells;
+        if max_cells > 0 {
+            while cells.len() > max_cells {
+                // Evict the least-recently-used (smallest last-access) cell.
+                let Some(victim) = cells
+                    .iter()
+                    .min_by_key(|(_, cell)| cell.last_access_millis())
+                    .map(|(key, _)| key.clone())
+                else {
+                    break;
+                };
+                cells.remove(&victim);
+            }
+        }
     }
 
     /// Evict `tenant_id`'s cell, removing it from the registry and returning it.
@@ -491,6 +621,44 @@ impl TenantCellRegistry {
             .write()
             .expect("tenant cell registry lock poisoned")
             .remove(tenant_id)
+    }
+
+    /// Evict every resident cell whose most recent access is older than `ttl`
+    /// (measured against the registry's current clock), returning the number of
+    /// cells removed. A reusable ops/test primitive that applies the same
+    /// idle-sweep policy `get_or_create` runs automatically.
+    ///
+    /// Removal drops only the registry's strong reference; any outstanding
+    /// `Arc<TenantCell>` keeps its cell alive and reclaims deterministically on
+    /// drop.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the registry lock is poisoned.
+    #[must_use]
+    pub fn evict_idle_older_than(&self, ttl: Duration) -> usize {
+        let now = self.now_millis();
+        let ttl_millis = u64::try_from(ttl.as_millis()).unwrap_or(u64::MAX);
+        let mut cells = self
+            .inner
+            .cells
+            .write()
+            .expect("tenant cell registry lock poisoned");
+        let before = cells.len();
+        cells.retain(|_, cell| now.saturating_sub(cell.last_access_millis()) <= ttl_millis);
+        before - cells.len()
+    }
+
+    /// The configured maximum number of resident cells (`0` = unbounded).
+    #[must_use]
+    pub fn max_cells(&self) -> usize {
+        self.inner.max_cells
+    }
+
+    /// The configured idle-eviction TTL (`None` = disabled).
+    #[must_use]
+    pub fn idle_ttl(&self) -> Option<Duration> {
+        self.inner.idle_ttl
     }
 
     /// Number of resident cells.

--- a/autumn/src/tenant_cell.rs
+++ b/autumn/src/tenant_cell.rs
@@ -102,6 +102,13 @@ struct TenantCellInner {
     /// least-recently-used eviction. Set by the registry on creation and on
     /// every subsequent lookup.
     last_access: AtomicU64,
+    /// Globally-monotonic access sequence number (from the registry's `seq`
+    /// counter) of this cell's most recent access. Unlike `last_access`, which
+    /// has millisecond resolution and can tie when several tenants are created
+    /// in the same tick, `last_access_seq` is strictly increasing and unique
+    /// per access, so LRU victim selection has no ties and never evicts the
+    /// just-inserted cell. Idle-TTL still uses `last_access` (wall-clock age).
+    last_access_seq: AtomicU64,
     /// Owned per-tenant scratch buffer and its entry high-water mark. Dropped
     /// with the cell.
     scratch: Mutex<ScratchState>,
@@ -233,6 +240,9 @@ impl TenantCell {
                 // The owning registry stamps the real access time immediately
                 // after construction; 0 is a placeholder until then.
                 last_access: AtomicU64::new(0),
+                // Likewise a placeholder until the registry's first `touch`
+                // stamps a real, strictly-increasing sequence number.
+                last_access_seq: AtomicU64::new(0),
                 scratch: Mutex::new(ScratchState::default()),
                 global_tracked,
             }),
@@ -259,16 +269,30 @@ impl TenantCell {
     }
 
     /// Record a registry-relative access timestamp (milliseconds since the
-    /// registry's base `Instant`). Called by the registry on every lookup to
-    /// drive least-recently-used and idle-TTL eviction.
-    pub fn touch(&self, now_millis: u64) {
+    /// registry's base `Instant`) together with a globally-monotonic access
+    /// sequence number. Called by the registry on every lookup to drive
+    /// idle-TTL (via the millisecond timestamp) and least-recently-used (via the
+    /// strictly-increasing sequence) eviction. Both are relaxed atomic stores,
+    /// so this is safe to call through a shared `&TenantCell` while the
+    /// registry's read guard is still held.
+    pub fn touch(&self, now_millis: u64, seq: u64) {
         self.inner.last_access.store(now_millis, Ordering::Relaxed);
+        self.inner.last_access_seq.store(seq, Ordering::Relaxed);
     }
 
     /// The registry-relative timestamp of this cell's most recent access.
     #[must_use]
     pub fn last_access_millis(&self) -> u64 {
         self.inner.last_access.load(Ordering::Relaxed)
+    }
+
+    /// The globally-monotonic access sequence number of this cell's most recent
+    /// access. Strictly increases with every `touch`, so it breaks the
+    /// millisecond ties `last_access_millis` can produce when multiple tenants
+    /// are accessed in the same tick — used to pick the LRU eviction victim.
+    #[must_use]
+    pub fn last_access_seq(&self) -> u64 {
+        self.inner.last_access_seq.load(Ordering::Relaxed)
     }
 
     /// Bytes currently tracked for this tenant.
@@ -448,6 +472,11 @@ struct RegistryInner {
     /// Monotonic clock origin for the registry-relative millisecond timestamps
     /// stored on each cell's `last_access`.
     base: Instant,
+    /// Globally-monotonic access counter. Every lookup/insert draws a fresh,
+    /// strictly-greater value via [`next_seq`](Self::next_seq) and stamps it on
+    /// the touched cell's `last_access_seq`, giving LRU eviction a unique,
+    /// tie-free ordering so the just-inserted cell is never the victim.
+    seq: AtomicU64,
 }
 
 impl fmt::Debug for TenantCellRegistry {
@@ -486,6 +515,7 @@ impl TenantCellRegistry {
                 max_cells,
                 idle_ttl,
                 base: Instant::now(),
+                seq: AtomicU64::new(0),
             }),
         }
     }
@@ -495,25 +525,40 @@ impl TenantCellRegistry {
         u64::try_from(self.inner.base.elapsed().as_millis()).unwrap_or(u64::MAX)
     }
 
+    /// Draw the next globally-monotonic access sequence number. Each call
+    /// returns a strictly-greater value, so the most recent access always has
+    /// the greatest sequence and LRU victim selection is tie-free.
+    fn next_seq(&self) -> u64 {
+        self.inner.seq.fetch_add(1, Ordering::Relaxed)
+    }
+
     /// Fetch the cell for `tenant_id`, if one is resident.
     ///
     /// # Panics
     ///
     /// Panics if the registry lock is poisoned.
     #[must_use]
+    // The read guard is deliberately held across the `touch` below: refreshing
+    // the access time under the lock is what closes the eviction race, so we
+    // opt out of the drop-tightening lint that would shrink the guard's scope.
+    #[allow(clippy::significant_drop_tightening)]
     pub fn get(&self, tenant_id: &str) -> Option<Arc<TenantCell>> {
         let now = self.now_millis();
-        let cell = self
+        let seq = self.next_seq();
+        let guard = self
             .inner
             .cells
             .read()
-            .expect("tenant cell registry lock poisoned")
-            .get(tenant_id)
-            .cloned();
-        if let Some(cell) = &cell {
-            cell.touch(now);
+            .expect("tenant cell registry lock poisoned");
+        // Refresh the access time/sequence WHILE the read guard is still held,
+        // so a concurrent writer cannot evict this cell in the gap between the
+        // lookup and the touch. `touch` is relaxed atomic stores through the
+        // shared `&Arc<TenantCell>`, safe under the read lock.
+        if let Some(cell) = guard.get(tenant_id) {
+            cell.touch(now, seq);
+            return Some(Arc::clone(cell));
         }
-        cell
+        None
     }
 
     /// Fetch the cell for `tenant_id`, creating it with `quota_bytes` if absent.
@@ -537,19 +582,21 @@ impl TenantCellRegistry {
     pub fn get_or_create(&self, tenant_id: &str, quota_bytes: usize) -> Arc<TenantCell> {
         let now = self.now_millis();
         // Fast path: a resident cell just needs its access time and quota
-        // refreshed under the cheaper read lock. Bind the lookup to a local so
-        // the read guard is released before we touch/refresh the cell.
-        let resident = self
-            .inner
-            .cells
-            .read()
-            .expect("tenant cell registry lock poisoned")
-            .get(tenant_id)
-            .cloned();
-        if let Some(cell) = resident {
-            cell.touch(now);
-            cell.set_quota_bytes(quota_bytes);
-            return cell;
+        // refreshed under the cheaper read lock. Do the touch/quota-refresh
+        // WHILE the read guard is still held so a concurrent writer cannot evict
+        // this cell in the gap between the lookup and the refresh — `touch` and
+        // `set_quota_bytes` are relaxed atomic stores, safe under the read lock.
+        {
+            let guard = self
+                .inner
+                .cells
+                .read()
+                .expect("tenant cell registry lock poisoned");
+            if let Some(cell) = guard.get(tenant_id) {
+                cell.touch(now, self.next_seq());
+                cell.set_quota_bytes(quota_bytes);
+                return Arc::clone(cell);
+            }
         }
         let mut cells = self
             .inner
@@ -560,7 +607,7 @@ impl TenantCellRegistry {
         // taking the write lock.
         if let Some(cell) = cells.get(tenant_id) {
             let cell = Arc::clone(cell);
-            cell.touch(now);
+            cell.touch(now, self.next_seq());
             cell.set_quota_bytes(quota_bytes);
             return cell;
         }
@@ -569,11 +616,13 @@ impl TenantCellRegistry {
             quota_bytes,
             Arc::clone(&self.inner.global_tracked),
         ));
-        cell.touch(now);
+        // Stamp the new cell's access sequence BEFORE enforcing limits, so it
+        // holds the greatest sequence and is never chosen as the LRU victim.
+        cell.touch(now, self.next_seq());
         cells.insert(tenant_id.to_string(), Arc::clone(&cell));
         // Enforce eviction limits while we already hold the write lock. The
-        // just-touched new cell has the newest access time, so it is never the
-        // idle or LRU victim.
+        // just-touched new cell has the newest access time and the greatest
+        // access sequence, so it is never the idle or LRU victim.
         self.enforce_limits_locked(&mut cells, now);
         drop(cells);
         cell
@@ -594,10 +643,14 @@ impl TenantCellRegistry {
         let max_cells = self.inner.max_cells;
         if max_cells > 0 {
             while cells.len() > max_cells {
-                // Evict the least-recently-used (smallest last-access) cell.
+                // Evict the least-recently-used cell, chosen by the smallest
+                // access *sequence*. The sequence is globally unique and
+                // monotonic, so there are no ties (unlike millisecond
+                // timestamps) and the just-inserted cell — which drew the
+                // greatest sequence above — is never the victim.
                 let Some(victim) = cells
                     .iter()
-                    .min_by_key(|(_, cell)| cell.last_access_millis())
+                    .min_by_key(|(_, cell)| cell.last_access_seq())
                     .map(|(key, _)| key.clone())
                 else {
                     break;

--- a/autumn/tests/integration/app_builder.rs
+++ b/autumn/tests/integration/app_builder.rs
@@ -30,5 +30,8 @@ fn app_builder_multiple_route_calls() {
 #[tokio::test]
 #[should_panic(expected = "No routes registered")]
 async fn empty_routes_panics() {
-    autumn_web::app().run().await;
+    // `Box::pin` keeps this `run()` future off the stack frame: `AutumnConfig`
+    // is held by value across its await points and sits just under the
+    // `clippy::large_futures` threshold, so awaiting it inline trips the lint.
+    Box::pin(autumn_web::app().run()).await;
 }

--- a/autumn/tests/integration/tenant_cell_unit.rs
+++ b/autumn/tests/integration/tenant_cell_unit.rs
@@ -563,3 +563,32 @@ fn get_touch_raises_access_seq() {
         "get() must raise the resident cell's access sequence"
     );
 }
+
+/// `touch` stores its timestamp and sequence monotonically (`fetch_max`), so a
+/// later `touch` carrying an *older* time/sequence — e.g. one captured before a
+/// lock wait and applied out of order — can never regress the recorded access
+/// time or sequence below a fresher value already stamped. This is what keeps a
+/// just-accessed tenant from being seen as idle (and evicted) because of a
+/// lagging timestamp.
+#[test]
+fn touch_does_not_regress_timestamp() {
+    let registry = TenantCellRegistry::new();
+    let cell = registry.get_or_create("t", 0);
+
+    cell.touch(1000, 5);
+    assert_eq!(cell.last_access_millis(), 1000);
+    assert_eq!(cell.last_access_seq(), 5);
+
+    // A stale/out-of-order touch with older values must not lower either field.
+    cell.touch(500, 3);
+    assert_eq!(
+        cell.last_access_millis(),
+        1000,
+        "a stale timestamp must not regress the recorded access time"
+    );
+    assert_eq!(
+        cell.last_access_seq(),
+        5,
+        "an out-of-order sequence must not regress the recorded access sequence"
+    );
+}

--- a/autumn/tests/integration/tenant_cell_unit.rs
+++ b/autumn/tests/integration/tenant_cell_unit.rs
@@ -420,19 +420,18 @@ fn resident_cell_quota_refreshes_on_get_or_create() {
 }
 
 /// A bounded registry evicts the least-recently-used cell once resident cells
-/// exceed the cap (#1792). Inserting t1, t2, t3 into a cap-2 registry (natural
-/// touch order t1 < t2 < t3) drops t1 and keeps t2/t3.
+/// exceed the cap (#1792). Inserting t1, t2, t3 into a cap-2 registry drives the
+/// access order t1 < t2 < t3 via the globally-monotonic access sequence (no
+/// sleeps needed), so t1 is unambiguously the LRU victim and t2/t3 are kept.
 #[test]
 fn registry_bounded_capacity_evicts_lru() {
     let reg = TenantCellRegistry::with_limits(2, None);
     assert_eq!(reg.max_cells(), 2);
 
-    // Space the creations out so their millisecond-resolution access stamps are
-    // strictly ordered t1 < t2 < t3 (creations otherwise land in one tick).
+    // Each get_or_create draws a strictly-greater access sequence, so insertion
+    // order alone establishes t1 < t2 < t3 — no wall-clock spacing required.
     let _t1 = reg.get_or_create("t1", 0);
-    std::thread::sleep(Duration::from_millis(5));
     let _t2 = reg.get_or_create("t2", 0);
-    std::thread::sleep(Duration::from_millis(5));
     let _t3 = reg.get_or_create("t3", 0);
 
     // t3's insert pushed the count to 3 > 2, evicting the LRU cell (t1).
@@ -515,5 +514,52 @@ fn auto_eviction_preserves_in_flight_cell() {
         reg.total_tracked_bytes(),
         0,
         "held cell's bytes reclaim deterministically on drop"
+    );
+}
+
+/// Millisecond-resolution access stamps tie when several tenants are created in
+/// the same tick, which could let LRU eviction drop the cell `get_or_create`
+/// just inserted. The globally-monotonic access sequence breaks those ties so
+/// the newest cell is never the victim. A same-ms burst of 5 distinct tenants
+/// into a cap-2 registry (no sleeps) must keep exactly 2 cells, with the
+/// last-created tenant always resident and an early tenant evicted.
+#[test]
+fn registry_lru_tiebreak_keeps_newest_on_burst() {
+    let registry = TenantCellRegistry::with_limits(2, None);
+
+    // Rapid same-tick burst: no sleeps, so the cells' millisecond access stamps
+    // may all tie — only the access sequence disambiguates their LRU order.
+    for i in 0..5 {
+        let _ = registry.get_or_create(&format!("t{i}"), 0);
+    }
+
+    // The cap is honored exactly.
+    assert_eq!(registry.len(), 2);
+    // The just-inserted cell (t4 holds the greatest access sequence) is never
+    // chosen as the LRU victim, so the newest tenant stays resident.
+    assert!(
+        registry.get("t4").is_some(),
+        "the last-created tenant must remain resident under the cap"
+    );
+    // An early tenant was evicted as the least-recently-used.
+    assert!(
+        registry.get("t0").is_none(),
+        "an early tenant must be evicted under the cap"
+    );
+}
+
+/// A `get` on a resident cell refreshes its access sequence under the read lock
+/// (Fix 1's touch fires): the cell's `last_access_seq` strictly increases across
+/// the lookup, proving the access time is refreshed before the guard drops.
+#[test]
+fn get_touch_raises_access_seq() {
+    let registry = TenantCellRegistry::new();
+    let cell = registry.get_or_create("t", 0);
+    let before = cell.last_access_seq();
+
+    let fetched = registry.get("t").expect("cell is resident");
+    assert!(
+        fetched.last_access_seq() > before,
+        "get() must raise the resident cell's access sequence"
     );
 }

--- a/autumn/tests/integration/tenant_cell_unit.rs
+++ b/autumn/tests/integration/tenant_cell_unit.rs
@@ -4,6 +4,8 @@
 //! and need no HTTP or database scaffolding, so they carry no feature gate.
 
 use autumn_web::tenant_cell::{QuotaExceeded, TenantCell, TenantCellRegistry};
+use std::sync::Arc;
+use std::time::Duration;
 
 /// A charge raises both the per-tenant and process-wide gauges by exactly its
 /// size, and dropping it returns them to zero.
@@ -386,4 +388,132 @@ fn handle_caches_cell_across_mid_request_eviction() {
     assert!(std::sync::Arc::ptr_eq(&cell1, &cell2));
     assert_eq!(cell2.tracked_bytes(), tracked);
     assert_eq!(cell2.scratch_get("k").map(|v| v.len()), Some(100));
+}
+
+/// A resident cell refreshes its soft quota from the latest `get_or_create`
+/// value (#1783): the same cell is returned, its quota reflects the new value,
+/// and `reserve` honors the atomically-updated quota — a charge that overflowed
+/// the original quota succeeds once the quota is raised.
+#[test]
+fn resident_cell_quota_refreshes_on_get_or_create() {
+    let reg = TenantCellRegistry::new();
+    let cell_a = reg.get_or_create("t", 1000);
+
+    // 1500 exceeds the initial quota of 1000.
+    cell_a
+        .try_charge(1500)
+        .expect_err("1500 must exceed the initial quota of 1000");
+
+    // Re-fetching with a larger quota returns the SAME cell with its quota
+    // atomically refreshed — no eviction/rebuild.
+    let cell_b = reg.get_or_create("t", 2000);
+    assert!(Arc::ptr_eq(&cell_a, &cell_b));
+    assert_eq!(cell_b.quota_bytes(), 2000);
+
+    // The same charge now fits under the refreshed quota, proving `reserve`
+    // reads the atomic quota rather than a cached value.
+    let charge = cell_b
+        .try_charge(1500)
+        .expect("1500 fits under the refreshed quota of 2000");
+    assert_eq!(cell_b.tracked_bytes(), 1500);
+    drop(charge);
+}
+
+/// A bounded registry evicts the least-recently-used cell once resident cells
+/// exceed the cap (#1792). Inserting t1, t2, t3 into a cap-2 registry (natural
+/// touch order t1 < t2 < t3) drops t1 and keeps t2/t3.
+#[test]
+fn registry_bounded_capacity_evicts_lru() {
+    let reg = TenantCellRegistry::with_limits(2, None);
+    assert_eq!(reg.max_cells(), 2);
+
+    // Space the creations out so their millisecond-resolution access stamps are
+    // strictly ordered t1 < t2 < t3 (creations otherwise land in one tick).
+    let _t1 = reg.get_or_create("t1", 0);
+    std::thread::sleep(Duration::from_millis(5));
+    let _t2 = reg.get_or_create("t2", 0);
+    std::thread::sleep(Duration::from_millis(5));
+    let _t3 = reg.get_or_create("t3", 0);
+
+    // t3's insert pushed the count to 3 > 2, evicting the LRU cell (t1).
+    assert_eq!(reg.len(), 2);
+    assert!(
+        reg.get("t1").is_none(),
+        "t1 was the LRU and must be evicted"
+    );
+    assert!(reg.get("t2").is_some());
+    assert!(reg.get("t3").is_some());
+}
+
+/// An idle-TTL registry evicts a cell whose last access is older than the TTL
+/// (#1792). t1 goes stale across a sleep; creating t2 triggers the idle sweep
+/// (and `evict_idle_older_than` is the explicit equivalent), removing t1 while
+/// the freshly-touched t2 survives.
+#[test]
+fn registry_idle_ttl_evicts_stale() {
+    let reg = TenantCellRegistry::with_limits(0, Some(Duration::from_millis(40)));
+    assert_eq!(reg.idle_ttl(), Some(Duration::from_millis(40)));
+
+    let _t1 = reg.get_or_create("t1", 0);
+    // Let t1 age well past the 40ms TTL before touching the registry again.
+    std::thread::sleep(Duration::from_millis(60));
+
+    // Creating t2 runs the auto idle-sweep: t1 (idle > 40ms) is evicted, and the
+    // just-touched t2 is retained.
+    let _t2 = reg.get_or_create("t2", 0);
+    assert!(reg.get("t1").is_none(), "t1 aged past the idle TTL");
+    assert!(
+        reg.get("t2").is_some(),
+        "t2 was just touched and must survive"
+    );
+    assert_eq!(reg.len(), 1);
+}
+
+/// Auto-eviction removes only the registry's strong reference (#1792): a cell
+/// evicted to honor the capacity bound while a request still holds its
+/// `Arc<TenantCell>` stays fully usable, and its tracked bytes reclaim
+/// deterministically once that held reference drops — never mid-request.
+#[test]
+fn auto_eviction_preserves_in_flight_cell() {
+    let reg = TenantCellRegistry::with_limits(1, None);
+
+    // t1 is the "in-flight" cell: create it, charge some persistent scratch
+    // bytes, and keep its Arc as a request would.
+    let t1 = reg.get_or_create("t1", 1_000_000);
+    t1.scratch_insert("k", vec![0u8; 256])
+        .expect("insert under a generous quota");
+    let tracked = t1.tracked_bytes();
+    assert!(tracked > 0);
+    assert_eq!(reg.total_tracked_bytes(), tracked);
+
+    // Space the second creation out so t1 is unambiguously the LRU victim.
+    std::thread::sleep(Duration::from_millis(5));
+    let _t2 = reg.get_or_create("t2", 1_000_000);
+
+    // t1 was evicted from the registry (cap 1) but the held Arc keeps it alive.
+    assert!(reg.get("t1").is_none(), "t1 evicted from the registry");
+    assert_eq!(reg.len(), 1);
+
+    // The in-flight cell is still fully functional: its scratch, quota, and
+    // charging all work against the same accounting state.
+    assert_eq!(t1.tracked_bytes(), tracked);
+    assert_eq!(t1.quota_bytes(), 1_000_000);
+    assert_eq!(t1.scratch_get("k").map(|v| v.len()), Some(256));
+    let charge = t1
+        .try_charge(100)
+        .expect("the evicted-but-held cell still charges");
+    drop(charge);
+    assert_eq!(t1.tracked_bytes(), tracked);
+
+    // t1's bytes are still counted process-wide while the request holds it.
+    assert_eq!(reg.total_tracked_bytes(), tracked);
+
+    // Dropping the last strong reference reclaims t1's footprint; only the empty
+    // t2 remains resident, so the process-wide gauge returns to zero.
+    drop(t1);
+    assert_eq!(
+        reg.total_tracked_bytes(),
+        0,
+        "held cell's bytes reclaim deterministically on drop"
+    );
 }

--- a/autumn/tests/integration/tenant_cell_unit.rs
+++ b/autumn/tests/integration/tenant_cell_unit.rs
@@ -419,6 +419,48 @@ fn resident_cell_quota_refreshes_on_get_or_create() {
     drop(charge);
 }
 
+/// Dynamic quota (`set_quota_bytes`) with `0 == unlimited` must be honored on
+/// every `reserve` retry, not just on entry: flipping a resident cell's finite
+/// quota to `0` mid-life makes a subsequent charge that far exceeds the old
+/// finite quota succeed (unlimited), while a finite quota still gates an
+/// over-limit charge with `QuotaExceeded`.
+#[test]
+fn dynamic_quota_zero_is_unlimited_after_refresh() {
+    let reg = TenantCellRegistry::new();
+    let cell = reg.get_or_create("t", 100);
+
+    // Charge some bytes under the finite quota of 100.
+    let charge = cell.try_charge(50).expect("50 fits under the quota of 100");
+    assert_eq!(cell.tracked_bytes(), 50);
+
+    // A charge over the finite quota is still rejected while it is non-zero.
+    cell.try_charge(100)
+        .expect_err("50 + 100 = 150 must exceed the finite quota of 100");
+
+    // Flip the quota to unlimited at runtime.
+    cell.set_quota_bytes(0);
+    assert_eq!(cell.quota_bytes(), 0);
+
+    // A charge far exceeding the old finite quota (and current tracked) now
+    // succeeds — `reserve` re-applies `0 == unlimited` on the atomic reload
+    // rather than comparing against `0`.
+    let big = cell
+        .try_charge(10_000)
+        .expect("under an unlimited quota, a large charge must succeed");
+    assert_eq!(cell.tracked_bytes(), 10_050);
+    drop(big);
+    drop(charge);
+    assert_eq!(cell.tracked_bytes(), 0);
+
+    // Restoring a finite quota re-gates: an over-limit charge fails again.
+    cell.set_quota_bytes(1000);
+    let err = cell
+        .try_charge(1001)
+        .expect_err("1001 must exceed the restored finite quota of 1000");
+    assert_eq!(err.quota, 1000);
+    assert_eq!(cell.tracked_bytes(), 0);
+}
+
 /// A bounded registry evicts the least-recently-used cell once resident cells
 /// exceed the cap (#1792). Inserting t1, t2, t3 into a cap-2 registry drives the
 /// access order t1 < t2 < t3 via the globally-monotonic access sequence (no

--- a/docs/guide/tenant-cells.md
+++ b/docs/guide/tenant-cells.md
@@ -24,6 +24,8 @@ buys you.
 [tenancy]
 enabled = true
 quota_bytes = 1048576   # 1 MiB soft quota per tenant; 0 (the default) disables the quota
+max_cells = 10000       # cap resident tenant cells; LRU-evict above this. 0 (the default) = unbounded
+idle_ttl_secs = 3600    # evict a cell idle longer than this many seconds. 0 (the default) = disabled
 ```
 
 `quota_bytes` is the soft per-tenant quota applied to every cell the registry
@@ -31,15 +33,45 @@ mints. `0` — the default — disables the quota entirely: charges always succe
 and nothing is capped, while `tracked_bytes()` still accounts what flows
 through the cell.
 
+`max_cells` bounds how many tenant cells stay resident in the registry. When a
+new cell would push the map past this count, the least-recently-used cells are
+evicted until it fits. `0` — the default — leaves the registry unbounded. This
+matters whenever tenant IDs are high-cardinality or request-controlled: a
+tenant sourced from a header, JWT claim, or subdomain lets callers mint new IDs
+at will, and on an allocating route every distinct ID would otherwise grow the
+registry without bound. `max_cells` caps that growth to a fixed working set.
+
+`idle_ttl_secs` evicts a cell whose last access is older than this many seconds.
+`0` — the default — disables the idle sweep. Enforcement is lazy: the TTL is
+applied on cell insert rather than by a background timer (a reusable
+`evict_idle_older_than` primitive is also exposed for callers that want to run a
+sweep on their own cadence).
+
+Both limits reclaim memory the same way manual `evict` does — see
+[Eviction and lifecycle](#eviction-and-lifecycle).
+
 Environment overrides:
 
 | Variable | Field |
 |----------|-------|
+| `AUTUMN_TENANCY__ENABLED` | `tenancy.enabled` |
+| `AUTUMN_TENANCY__SOURCE` | `tenancy.source` |
+| `AUTUMN_TENANCY__HEADER_NAME` | `tenancy.header_name` |
+| `AUTUMN_TENANCY__SESSION_KEY` | `tenancy.session_key` |
+| `AUTUMN_TENANCY__JWT_CLAIM` | `tenancy.jwt_claim` |
+| `AUTUMN_TENANCY__JWT_SECRET` | `tenancy.jwt_secret` |
+| `AUTUMN_TENANCY__JWT_ISSUER` | `tenancy.jwt_issuer` |
+| `AUTUMN_TENANCY__JWT_AUDIENCE` | `tenancy.jwt_audience` |
+| `AUTUMN_TENANCY__BASE_DOMAIN` | `tenancy.base_domain` |
+| `AUTUMN_TENANCY__LOGIN_REDIRECT` | `tenancy.login_redirect` |
+| `AUTUMN_TENANCY__PUBLIC_PATHS` | `tenancy.public_paths` (comma-separated) |
 | `AUTUMN_TENANCY__QUOTA_BYTES` | `tenancy.quota_bytes` |
+| `AUTUMN_TENANCY__MAX_CELLS` | `tenancy.max_cells` |
+| `AUTUMN_TENANCY__IDLE_TTL_SECS` | `tenancy.idle_ttl_secs` |
 
-Among the `[tenancy]` fields, the environment currently overrides only
-`quota_bytes` (full tenancy-section env coverage is tracked in
-[#1793](https://github.com/madmax983/autumn/issues/1793)).
+The entire `[tenancy]` section is now settable from the environment via
+`AUTUMN_TENANCY__*`, so every field above can be supplied without an
+`autumn.toml`.
 
 ## Using the cell in a handler
 
@@ -138,13 +170,27 @@ app state. Two properties matter operationally:
   and all) is reclaimed, and its tracked bytes leave the process-wide gauge.
   This is ordinary Rust `Drop`, not a background sweep — reclaim is immediate
   and predictable.
+- **Automatic eviction.** With `max_cells` or `idle_ttl_secs` set (see
+  [Configuration](#configuration)), the registry evicts on its own — LRU cells
+  above the cap, and cells idle past the TTL — enforced lazily on cell insert.
+  Automatic eviction reclaims memory exactly like the manual `evict` above: it
+  drops only the registry's strong reference, so the same deterministic `Drop`
+  applies and an in-flight holder is never disturbed.
 
 Eviction is safe to do mid-request. Each in-flight request caches the cell it
 first materialized, so evicting a tenant while one of its requests is running
 does **not** reset that request's state or hand it a fresh empty cell: the
-running request keeps its stable cell to completion, and the eviction takes
-effect for subsequent requests. The registry also exposes `len()`,
-`is_empty()`, and `total_tracked_bytes()` for observability.
+running request keeps its own cached `Arc` and its stable cell to completion,
+its memory reclaiming on drop, and the eviction takes effect for subsequent
+requests. The registry also exposes `len()`, `is_empty()`, and
+`total_tracked_bytes()` for observability.
+
+**Dynamic quota.** A cell's `quota_bytes` is stored atomically rather than
+frozen at creation. Every access refreshes a resident cell's quota from the
+configured `quota_bytes`, so a future config-reload path could change the
+per-tenant quota without evicting and rebuilding cells. No such reload path
+exists today — the mechanism is in place for when one lands, and until then the
+refresh simply re-applies the same configured value.
 
 ## The accounting guarantee
 
@@ -175,12 +221,9 @@ are counted honestly and released deterministically.
 
 ## Limitations and roadmap
 
-- **Runtime-mutable quota** — the quota is fixed for a cell's lifetime today;
-  changing it at runtime is deferred to
+- **Config hot-reload** — resident cells already refresh their quota from
+  `quota_bytes` on every access (see [Dynamic quota](#eviction-and-lifecycle)),
+  but nothing re-reads `autumn.toml` at runtime to feed a new value, so the
+  quota is effectively fixed for a process's lifetime. Wiring up a reload path
+  is the remaining half of
   [#1783](https://github.com/madmax983/autumn/issues/1783).
-- **Bounded / idle registry eviction** — the registry does not yet evict idle
-  tenants automatically; call `evict` yourself. Tracked in
-  [#1792](https://github.com/madmax983/autumn/issues/1792).
-- **Full tenancy-section env overrides** — only `quota_bytes` is currently
-  overridable via the environment; the rest of `[tenancy]` is tracked in
-  [#1793](https://github.com/madmax983/autumn/issues/1793).


### PR DESCRIPTION
Implements three deferred tenant-cell follow-ups: runtime-mutable quota, bounded + idle-TTL registry eviction, and full tenancy env overrides.

## Task A — dynamic per-tenant quota (#1783)

**Before:** A tenant cell's soft quota (`quota_bytes`) was fixed at construction. A resident cell could only pick up a reconfigured quota by being evicted and rebuilt, losing its accounting state.

**After:** `TenantCellInner.quota_bytes` is an `AtomicUsize`. `reserve()` reloads it on entry and on each CAS retry, so the very next reservation honors a changed quota. `TenantCell::set_quota_bytes` updates it in place, and `TenantCellRegistry::get_or_create` refreshes a resident cell's quota from the latest configured value on every call. This is currently a no-op in production (no config hot-reload path swaps the resident `AutumnConfig` yet) — the mechanism is in place for when hot-reload lands.

## Task B — bounded + idle-TTL eviction (#1792)

**Before:** The registry grew unbounded. The only way to reclaim a cell was an explicit `evict(tenant_id)` call.

**After:** The registry tracks each cell's last-access time (`AtomicU64`, registry-relative millis) and can be constructed with limits via `TenantCellRegistry::with_limits(max_cells, idle_ttl)`:
- **Bounded capacity:** once resident cells exceed `max_cells`, the least-recently-used cell is evicted (`0` = unbounded).
- **Idle TTL:** cells idle longer than `idle_ttl` are swept (`None` = disabled).

Enforcement runs automatically on the miss branch of `get_or_create` (inside the single write-lock scope, via a `_locked` helper — no recursive locking). `evict_idle_older_than(ttl)` is exposed as a reusable ops/test primitive. Two new config knobs (`[tenancy].max_cells`, `[tenancy].idle_ttl_secs`) are wired into the middleware's registry construction.

**In-flight safety preserved:** eviction is only `HashMap::remove` of the registry's strong ref. `TenantCellHandle` caches its `Arc` in a `OnceLock`, so a request that already materialized its cell keeps a live `Arc` even after the registry drops the cell; memory reclaims deterministically when that last `Arc` drops. Covered by the existing `handle_caches_cell_across_mid_request_eviction` test plus a new `auto_eviction_preserves_in_flight_cell` test.

## Task C — full tenancy env overrides (#1793)

**Before:** Only `AUTUMN_TENANCY__QUOTA_BYTES` had an env override; every other `[tenancy]` field could be set only via TOML.

**After:** `apply_tenancy_env_overrides_with_env` covers the whole section: `ENABLED`, `SOURCE`, `HEADER_NAME`, `SESSION_KEY`, `JWT_CLAIM`, `JWT_SECRET`, `JWT_ISSUER`, `JWT_AUDIENCE`, `BASE_DOMAIN`, `LOGIN_REDIRECT`, `PUBLIC_PATHS` (CSV), `QUOTA_BYTES`, and the new `MAX_CELLS` / `IDLE_TTL_SECS`. `JWT_SECRET` uses a new `parse_env_option_secret` helper modeled on `parse_env_option_string` that wraps the trimmed non-empty value in `secrecy::SecretString` (empty → `None`).

## How

- `autumn/src/tenant_cell.rs`: `AtomicUsize` quota + `set_quota_bytes`; `last_access: AtomicU64` + `touch`/`last_access_millis`; `RegistryInner { max_cells, idle_ttl, base }`; `with_limits`, `now_millis`, `enforce_limits_locked`, `evict_idle_older_than`, `max_cells`/`idle_ttl` accessors; `get`/`get_or_create` touch + refresh.
- `autumn/src/config.rs`: `TenancyConfig::{max_cells, idle_ttl_secs}` (+ `Default`); `parse_env_option_secret`; extended `apply_tenancy_env_overrides_with_env`; new `#[cfg(test)]` env-override regression tests.
- `autumn/src/tenancy.rs`: registry built via `with_limits` from `config.tenancy.max_cells`/`idle_ttl_secs`.
- `autumn/tests/integration/tenant_cell_unit.rs`: 4 new behaviour tests (`resident_cell_quota_refreshes_on_get_or_create`, `registry_bounded_capacity_evicts_lru`, `registry_idle_ttl_evicts_stale`, `auto_eviction_preserves_in_flight_cell`).
- `autumn/tests/integration/app_builder.rs`: `Box::pin` the `app().run()` future in the empty-routes test — the two new config fields pushed `AutumnConfig` past the `clippy::large_futures` threshold at that await site.

## Gate

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (zero warnings)
- `cargo test -p autumn-web --lib env_override_tenancy` — 5 passed
- `cargo test -p autumn-web --test integration_tests tenant_cell` — 19 passed

## Docs

`docs/guide/tenant-cells.md` (merged in #1794) now documents the new eviction knobs (`max_cells`, `idle_ttl_secs`), the dynamic-quota refresh behavior, and the full `AUTUMN_TENANCY__*` env override set.

Closes #1792
Closes #1783
Closes #1793

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGDJj1nMa7cfNb1MYJ2R3y)_