### PR TITLE
Offsite-backup follow-ups: env materialization, verify-failure cleanup, upload-failure alerting

### DIFF
--- a/autumn-cli/src/alert.rs
+++ b/autumn-cli/src/alert.rs
@@ -115,7 +115,11 @@ pub fn run_test(channel_filter: Option<&str>) {
 /// `config`: the native providers (`PagerDuty` / Slack / Discord) plus the
 /// generic signed webhook. Prints a note when a webhook URL is set without the
 /// signing secret (alert webhooks are always signed, so it is skipped).
-fn configured_http_channels(
+///
+/// Shared with `db::backup` (issue #1743) so a failed offsite upload alert and
+/// `autumn alert test` build the EXACT same channel set. Email is intentionally
+/// not included — it needs a configured mailer.
+pub fn configured_http_channels(
     config: &autumn_web::alerts::AlertConfig,
     client: &Client,
 ) -> Vec<Arc<dyn AlertChannel>> {

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -2133,12 +2133,13 @@ fn upload_run(
     for file in &files {
         let path = run_dir.join(file);
         let key = offsite_object_key(&offsite.prefix, profile, run_id, file);
-        // `put_file_and_verify` WRITES the object BEFORE its HEAD/GET verification,
-        // so even a verify failure can leave the object (incl. the run manifest) in
-        // the bucket. Record the key up-front, then on ANY failure best-effort
-        // delete everything this run wrote — manifest first — so a run whose upload
-        // was reported FAILED never keeps a remote `manifest.json` and can't become
-        // `latest` or consume a retention slot (restores the P2 #2 invariant; #21).
+        // `put_file_and_verify` now self-cleans the single key it just wrote on a
+        // verify failure (#1760). This run-level cleanup is still needed for the
+        // OTHER keys written EARLIER in the run: record every key up-front, then on
+        // ANY failure best-effort delete everything this run wrote — manifest first
+        // — so a run whose upload was reported FAILED never keeps a remote
+        // `manifest.json` and can't become `latest` or consume a retention slot
+        // (restores the P2 #2 invariant; #21).
         written_keys.push(key.clone());
         // Stream the file straight from disk (hash pre-pass + streamed body):
         // a multi-GB dump is never read into memory.

--- a/autumn-cli/src/db/backup.rs
+++ b/autumn-cli/src/db/backup.rs
@@ -36,6 +36,9 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Arc;
+
+use autumn_web::alerts::{Alert, AlertChannel, AlertCondition};
 
 use crate::db::s3::{self, S3Client, S3Config, S3Credentials};
 use crate::migrate;
@@ -393,14 +396,90 @@ fn backup(args: &BackupArgs) -> Result<(), BackupError> {
         // location regardless of alias/case spelling — while the LOCAL run dir
         // keeps its raw #1595 `<profile>/<timestamp>` layout (used above).
         let remote_profile = migrate::canonical_profile(&profile);
-        upload_run(&offsite, &client, &run_dir, &remote_profile, &remote_id).map_err(|detail| {
-            BackupError::OffsiteUploadFailed {
-                local_path: run_dir.display().to_string(),
-                detail,
-            }
-        })?;
+        if let Err(detail) = upload_run(&offsite, &client, &run_dir, &remote_profile, &remote_id) {
+            let local_path = run_dir.display().to_string();
+            // #1743: raise an operator alert so an unattended/cron backup with
+            // [alerts] configured never fails its upload silently. Best-effort —
+            // never changes the exit code; the `?`-equivalent return below still
+            // exits non-zero with the same split-outcome message as before.
+            emit_offsite_upload_failure_alert(&local_path, &detail);
+            return Err(BackupError::OffsiteUploadFailed { local_path, detail });
+        }
     }
     Ok(())
+}
+
+/// Best-effort operator alert for a failed offsite upload (#1743).
+///
+/// Discriminator (chosen design): fire on ANY upload failure when `[alerts]`
+/// channels are configured. Interactive users with no `[alerts]` destination
+/// build zero channels, so this is a no-op for them — the interactive case
+/// (message + non-zero exit) is unchanged. Loading the config here is
+/// acceptable: we are already on the failure path and about to exit non-zero.
+fn emit_offsite_upload_failure_alert(local_path: &str, detail: &str) {
+    let config = match autumn_web::config::AutumnConfig::load() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("  \u{26A0} offsite-upload-failed alert skipped: could not load config: {e}");
+            return;
+        }
+    };
+    let client = autumn_web::http::Client::from_config(&config.http.client);
+    let channels = crate::alert::configured_http_channels(&config.alerts, &client);
+    deliver_offsite_upload_alert(&channels, local_path, detail);
+}
+
+/// Build the `ScheduledTaskFailure` alert raised when an offsite upload fails.
+/// Pure (no I/O) so it can be asserted directly in tests.
+fn build_offsite_upload_alert(local_path: &str, detail: &str) -> Alert {
+    Alert::trigger(
+        AlertCondition::ScheduledTaskFailure,
+        "scheduled_task_failure:db-backup-offsite-upload",
+    )
+    .title("Offsite backup upload failed")
+    .summary(detail)
+    .detail("local_path", local_path)
+    .detail("error", detail)
+    .build()
+}
+
+/// Deliver the offsite-upload-failure alert through every configured channel on
+/// a short-lived current-thread runtime (mirrors `autumn alert test`).
+/// Best-effort: a per-channel delivery error is logged but never propagated, so
+/// alerting can NEVER change the command's exit code. A no-op when `channels`
+/// is empty. Takes `&[Arc<dyn AlertChannel>]` so a test can inject a capturing
+/// mock channel and assert the alert that a failed upload raises.
+fn deliver_offsite_upload_alert(
+    channels: &[Arc<dyn AlertChannel>],
+    local_path: &str,
+    detail: &str,
+) {
+    if channels.is_empty() {
+        return;
+    }
+    let alert = build_offsite_upload_alert(local_path, detail);
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!(
+                "  \u{26A0} offsite-upload-failed alert not sent: could not start runtime: {e}"
+            );
+            return;
+        }
+    };
+    runtime.block_on(async {
+        for channel in channels {
+            if let Err(error) = channel.deliver(&alert).await {
+                eprintln!(
+                    "  \u{26A0} offsite-upload-failed alert not delivered via {}: {error}",
+                    channel.name()
+                );
+            }
+        }
+    });
 }
 
 /// Dump every target into `run_dir`, verify each artifact, and write the
@@ -3530,6 +3609,77 @@ mod tests {
         assert!(s.contains("Local backup OK at /backups/prod/20260710T040506Z"));
         assert!(s.contains("OFFSITE UPLOAD FAILED"));
         assert!(s.contains("intact"));
+    }
+
+    // ── #1743: failed offsite upload raises an operator alert ─────────────────
+
+    #[derive(Default)]
+    struct CapturingChannel {
+        received: Arc<std::sync::Mutex<Vec<Alert>>>,
+    }
+
+    impl AlertChannel for CapturingChannel {
+        fn name(&self) -> &'static str {
+            "capturing"
+        }
+        fn deliver<'a>(&'a self, alert: &'a Alert) -> autumn_web::alerts::AlertDeliveryFuture<'a> {
+            let received = Arc::clone(&self.received);
+            let cloned = alert.clone();
+            Box::pin(async move {
+                received.lock().expect("lock").push(cloned);
+                Ok(())
+            })
+        }
+    }
+
+    #[test]
+    fn build_offsite_upload_alert_is_scheduled_task_failure() {
+        let alert = build_offsite_upload_alert(
+            "/backups/prod/20260710T040506Z",
+            "S3 put returned HTTP 403 (AccessDenied)",
+        );
+        assert_eq!(alert.condition, AlertCondition::ScheduledTaskFailure);
+        assert_eq!(alert.title, "Offsite backup upload failed");
+        assert_eq!(alert.summary, "S3 put returned HTTP 403 (AccessDenied)");
+        assert_eq!(
+            alert.dedup_key,
+            "scheduled_task_failure:db-backup-offsite-upload"
+        );
+    }
+
+    #[test]
+    fn deliver_offsite_upload_alert_reaches_configured_channel() {
+        // Failure-injection: the upload-failure path delivers a
+        // ScheduledTaskFailure alert to every configured channel. A capturing
+        // mock channel records what a failed upload would raise.
+        let capture = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let channel = Arc::new(CapturingChannel {
+            received: Arc::clone(&capture),
+        });
+        let channels: Vec<Arc<dyn AlertChannel>> = vec![channel];
+
+        deliver_offsite_upload_alert(
+            &channels,
+            "/backups/prod/20260710T040506Z",
+            "S3 put returned HTTP 403 (AccessDenied)",
+        );
+
+        let delivered = {
+            let received = capture.lock().expect("lock");
+            received.clone()
+        };
+        assert_eq!(delivered.len(), 1, "exactly one alert must be delivered");
+        let alert = &delivered[0];
+        assert_eq!(alert.condition, AlertCondition::ScheduledTaskFailure);
+        assert_eq!(alert.title, "Offsite backup upload failed");
+        assert_eq!(alert.summary, "S3 put returned HTTP 403 (AccessDenied)");
+    }
+
+    #[test]
+    fn deliver_offsite_upload_alert_is_noop_without_channels() {
+        // Interactive case (no [alerts] configured → no channels): must be a
+        // no-op so behavior is unchanged. No panic, nothing delivered.
+        deliver_offsite_upload_alert(&[], "/backups/prod/run", "boom");
     }
 
     #[test]

--- a/autumn-cli/src/db/s3.rs
+++ b/autumn-cli/src/db/s3.rs
@@ -916,6 +916,27 @@ impl S3Client {
         })
     }
 
+    /// Verify the just-written object matches, deleting the remote object on a
+    /// verification failure (#1760). `put_file*` WRITES the object BEFORE
+    /// verifying it, so a mismatch (or a transient read failure during verify)
+    /// can leave a corrupt/partial object behind. On any verify error we
+    /// best-effort `DeleteObject` the key so `put_file_and_verify` is
+    /// self-cleaning for every caller and leaves nothing behind even
+    /// transiently. The delete is cleanup only: its own failure must NEVER mask
+    /// the original verify error, which stays loud and non-zero.
+    fn verify_or_delete(&self, key: &str, len: u64, checksum_b64: &str) -> Result<(), S3Error> {
+        if let Err(e) = self.verify_uploaded(key, len, checksum_b64) {
+            if let Err(del_err) = self.delete_object(key) {
+                eprintln!(
+                    "  \u{26A0} failed to delete {key} after post-upload verification \
+                     failed: {del_err}"
+                );
+            }
+            return Err(e);
+        }
+        Ok(())
+    }
+
     /// Stream the file at `path` to `key` and verify the remote object matches
     /// (AC #2): a single streaming hash pre-pass computes the sha256 + length,
     /// the file is streamed as the PUT body with a server-side checksum, then
@@ -940,7 +961,7 @@ impl S3Client {
         let checksum_b64 = base64_standard(&digest);
         let content_hex = hex::encode(digest);
         self.put_file(key, path, &checksum_b64, &content_hex)?;
-        self.verify_uploaded(key, hashed_len, &checksum_b64)
+        self.verify_or_delete(key, hashed_len, &checksum_b64)
     }
 
     /// Upload `path` to `key` as an S3 multipart upload: `CreateMultipartUpload`,
@@ -975,8 +996,10 @@ impl S3Client {
             Ok(whole_b64) => {
                 // Completion succeeded: the object now exists. Do NOT abort.
                 // Verify the assembled object matches the streamed-hash of the
-                // local file (HEAD length + checksum, else GET-and-rehash).
-                self.verify_uploaded(key, len, &whole_b64)
+                // local file (HEAD length + checksum, else GET-and-rehash). On a
+                // verify failure the completed object is deleted (#1760) so a
+                // corrupt object is never left behind.
+                self.verify_or_delete(key, len, &whole_b64)
             }
             Err(err) => {
                 // Best-effort abort; surface the ORIGINAL upload error regardless
@@ -1586,6 +1609,138 @@ mod tests {
             .unwrap();
         server.join().unwrap();
         assert_eq!(sink, body);
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn put_file_and_verify_deletes_object_on_verify_failure() {
+        // #1760: `put_file_and_verify` WRITES the object BEFORE verifying it, so a
+        // post-upload verify failure must best-effort DELETE the just-written key
+        // — leaving no corrupt/partial object behind. A one-connection local S3
+        // stub accepts the PUT, then answers the verify HEAD with a WRONG
+        // Content-Length (forcing a length-mismatch `VerifyFailed`), and records
+        // that a DELETE for the same key follows. The multipart path funnels
+        // through the same `verify_or_delete` helper, so proving the single-PUT
+        // path proves the shared cleanup.
+        use std::io::{Read as _, Write as _};
+        use std::time::Duration;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("artifact.dump");
+        let payload = b"verify-failure-cleanup-body";
+        std::fs::write(&path, payload).unwrap();
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let payload_len = payload.len();
+
+        let server = std::thread::spawn(move || {
+            let mut methods: Vec<String> = Vec::new();
+            // reqwest's blocking client reuses one keep-alive connection for the
+            // PUT/HEAD/DELETE sequence; the outer loop tolerates a fresh
+            // connection per request too. Read timeouts stop a stray idle
+            // connection from hanging the test.
+            'accept: for _conn in 0..8 {
+                let Ok((mut sock, _)) = listener.accept() else {
+                    break;
+                };
+                sock.set_read_timeout(Some(Duration::from_secs(5))).ok();
+                loop {
+                    // Read the request head (up to CRLFCRLF).
+                    let mut acc: Vec<u8> = Vec::new();
+                    let mut buf = [0u8; 1024];
+                    let header_end = loop {
+                        if let Some(p) = acc.windows(4).position(|w| w == b"\r\n\r\n") {
+                            break Some(p + 4);
+                        }
+                        match sock.read(&mut buf) {
+                            Ok(0) | Err(_) => break None,
+                            Ok(n) => acc.extend_from_slice(&buf[..n]),
+                        }
+                    };
+                    let Some(header_end) = header_end else {
+                        break; // connection closed / idle — try the next one
+                    };
+                    let head = String::from_utf8_lossy(&acc[..header_end]).into_owned();
+                    let method = head
+                        .lines()
+                        .next()
+                        .and_then(|l| l.split_whitespace().next())
+                        .unwrap_or_default()
+                        .to_owned();
+                    let content_length: usize = head
+                        .lines()
+                        .find_map(|l| {
+                            let (k, v) = l.split_once(':')?;
+                            k.trim()
+                                .eq_ignore_ascii_case("content-length")
+                                .then(|| v.trim().parse().ok())
+                                .flatten()
+                        })
+                        .unwrap_or(0);
+                    // Consume any request body (the PUT streams the file).
+                    let mut remaining = content_length.saturating_sub(acc.len() - header_end);
+                    while remaining > 0 {
+                        match sock.read(&mut buf) {
+                            Ok(0) | Err(_) => break,
+                            Ok(n) => remaining = remaining.saturating_sub(n),
+                        }
+                    }
+                    methods.push(method.clone());
+                    match method.as_str() {
+                        "HEAD" => {
+                            // A wrong length forces verify_head's length-mismatch
+                            // VerifyFailed BEFORE any checksum/GET fallback.
+                            let resp = format!(
+                                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n",
+                                payload_len + 999
+                            );
+                            sock.write_all(resp.as_bytes()).ok();
+                        }
+                        "DELETE" => {
+                            sock.write_all(b"HTTP/1.1 204 No Content\r\n\r\n").ok();
+                            sock.flush().ok();
+                            break 'accept;
+                        }
+                        _ => {
+                            sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+                                .ok();
+                        }
+                    }
+                    sock.flush().ok();
+                }
+            }
+            methods
+        });
+
+        let client = S3Client::new(
+            S3Config {
+                bucket: "b".to_owned(),
+                region: "us-east-1".to_owned(),
+                endpoint: Some(format!("http://127.0.0.1:{port}")),
+                force_path_style: true,
+            },
+            S3Credentials {
+                access_key_id: "k".to_owned(),
+                secret_access_key: "s".to_owned(),
+            },
+        )
+        .unwrap();
+
+        let err = client
+            .put_file_and_verify("prefix/artifact.dump", &path)
+            .expect_err("verify must fail on the mismatched HEAD length");
+        assert!(
+            matches!(err, S3Error::VerifyFailed { .. }),
+            "expected VerifyFailed, got {err:?}"
+        );
+
+        let methods = server.join().unwrap();
+        assert_eq!(
+            methods,
+            vec!["PUT".to_owned(), "HEAD".to_owned(), "DELETE".to_owned()],
+            "on a verify failure the object must be PUT, verified via HEAD, then DELETEd",
+        );
     }
 
     #[test]

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -4136,22 +4136,25 @@ impl AutumnConfig {
     /// one offsite env var is present, so an all-env deployment still works.
     fn apply_backup_env_overrides_with_env(&mut self, env: &dyn Env) {
         // Keys that signal a genuine intent to CONFIGURE an offsite destination —
-        // any presence materializes the `[backup.offsite]` section. This
-        // deliberately EXCLUDES the two opt-out toggles: a lone
+        // presence of any REQUIRED destination/credential key materializes the
+        // `[backup.offsite]` section (issue #1791). This is limited to the keys
+        // that a working upload genuinely requires — a bucket, or the access /
+        // secret key-env names. Optional-only keys (`region`,
+        // `force_path_style`, `endpoint`, `prefix`, `keep`) do NOT materialize
+        // the section on their own: a bare `AUTUMN_BACKUP__OFFSITE__S3__REGION`
+        // (or endpoint) with no bucket cannot upload, so it must leave offsite
+        // UNCONFIGURED rather than produce an empty section that then fails
+        // validation / `doctor` with "backup.offsite.s3.bucket is unset". Those
+        // optional keys are still APPLIED below once the section IS materialized
+        // by a required key. This also EXCLUDES the two opt-out toggles: a lone
         // `AUTO_UPLOAD=false` / `ALLOW_SHARED_BUCKET=false` must NOT create an
-        // otherwise-empty section (which would then fail validation / `doctor`
-        // with "backup.offsite.s3.bucket is unset") — offsite stays UNCONFIGURED
-        // (issue #1619 P2 #18). A truthy `AUTO_UPLOAD=true` DOES materialize, since
-        // it requires a validated destination to act on.
+        // otherwise-empty section (issue #1619 P2 #18). A truthy
+        // `AUTO_UPLOAD=true` DOES materialize, since it requires a validated
+        // destination to act on.
         const OFFSITE_DEST_KEYS: &[&str] = &[
             "AUTUMN_BACKUP__OFFSITE__S3__BUCKET",
-            "AUTUMN_BACKUP__OFFSITE__S3__REGION",
-            "AUTUMN_BACKUP__OFFSITE__S3__ENDPOINT",
             "AUTUMN_BACKUP__OFFSITE__S3__ACCESS_KEY_ID_ENV",
             "AUTUMN_BACKUP__OFFSITE__S3__SECRET_ACCESS_KEY_ENV",
-            "AUTUMN_BACKUP__OFFSITE__S3__FORCE_PATH_STYLE",
-            "AUTUMN_BACKUP__OFFSITE__PREFIX",
-            "AUTUMN_BACKUP__OFFSITE__KEEP",
         ];
         let has_dest_key = OFFSITE_DEST_KEYS.iter().any(|k| env.var(k).is_ok());
         let auto_upload_truthy = env
@@ -8068,6 +8071,78 @@ path = "/healthz"
             .expect("a bucket key materializes offsite");
         assert_eq!(offsite.s3.bucket.as_deref(), Some("offsite"));
         assert!(!offsite.auto_upload);
+    }
+
+    #[test]
+    fn env_override_backup_offsite_lone_optional_key_stays_none() {
+        // #1791: optional-only keys (region, force_path_style, endpoint, prefix,
+        // keep) must NOT materialize [backup.offsite] on their own — a bare
+        // region with no bucket/credentials cannot upload, so offsite stays
+        // UNCONFIGURED rather than producing an empty section that then fails
+        // `doctor` with "bucket is unset".
+        for (key, val) in [
+            ("AUTUMN_BACKUP__OFFSITE__S3__REGION", "us-east-1"),
+            ("AUTUMN_BACKUP__OFFSITE__S3__ENDPOINT", "https://s3.test"),
+            ("AUTUMN_BACKUP__OFFSITE__S3__FORCE_PATH_STYLE", "true"),
+            ("AUTUMN_BACKUP__OFFSITE__PREFIX", "nightly"),
+            ("AUTUMN_BACKUP__OFFSITE__KEEP", "3"),
+        ] {
+            let env = MockEnv::new().with(key, val);
+            let mut config = AutumnConfig::default();
+            config.apply_env_overrides_with_env(&env);
+            assert!(
+                config.backup.offsite.is_none(),
+                "{key} is optional-only and must not materialize an offsite section",
+            );
+        }
+    }
+
+    #[test]
+    fn env_override_backup_offsite_credential_key_materializes() {
+        // #1791: the access/secret key-env names are REQUIRED signals, so either
+        // one still materializes the section.
+        for key in [
+            "AUTUMN_BACKUP__OFFSITE__S3__ACCESS_KEY_ID_ENV",
+            "AUTUMN_BACKUP__OFFSITE__S3__SECRET_ACCESS_KEY_ENV",
+        ] {
+            let env = MockEnv::new().with(key, "SOME_ENV_NAME");
+            let mut config = AutumnConfig::default();
+            config.apply_env_overrides_with_env(&env);
+            assert!(
+                config.backup.offsite.is_some(),
+                "{key} is a required credential signal and must materialize offsite",
+            );
+        }
+    }
+
+    #[test]
+    fn env_override_backup_offsite_bucket_only_materializes() {
+        // #1791: a lone bucket (required destination signal) still materializes.
+        let env = MockEnv::new().with("AUTUMN_BACKUP__OFFSITE__S3__BUCKET", "offsite");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        let offsite = config
+            .backup
+            .offsite
+            .expect("a bucket key materializes offsite");
+        assert_eq!(offsite.s3.bucket.as_deref(), Some("offsite"));
+    }
+
+    #[test]
+    fn env_override_backup_offsite_region_only_applied_when_materialized() {
+        // #1791: region no longer TRIGGERS materialization, but it is still
+        // APPLIED when a required key materializes the section.
+        let env = MockEnv::new()
+            .with("AUTUMN_BACKUP__OFFSITE__S3__BUCKET", "offsite")
+            .with("AUTUMN_BACKUP__OFFSITE__S3__REGION", "us-west-2")
+            .with("AUTUMN_BACKUP__OFFSITE__PREFIX", "nightly")
+            .with("AUTUMN_BACKUP__OFFSITE__KEEP", "5");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        let offsite = config.backup.offsite.expect("bucket materializes offsite");
+        assert_eq!(offsite.s3.region.as_deref(), Some("us-west-2"));
+        assert_eq!(offsite.prefix.as_deref(), Some("nightly"));
+        assert_eq!(offsite.keep, Some(5));
     }
 
     #[test]


### PR DESCRIPTION
Three related offsite-backup follow-ups, one commit each.

## #1791 — don't materialize `[backup.offsite]` from optional-only env keys

**Before:** any offsite env key materialized the `[backup.offsite]` section. Setting only `AUTUMN_BACKUP__OFFSITE__S3__REGION` (or `ENDPOINT`, `PREFIX`, `KEEP`, `FORCE_PATH_STYLE`) — with no bucket or credentials — created an otherwise-empty section that then failed validation / `doctor --strict` with "backup.offsite.s3.bucket is unset", even though such a config can never upload.

**After:** only a REQUIRED destination/credential signal materializes the section: `BUCKET`, `ACCESS_KEY_ID_ENV`, or `SECRET_ACCESS_KEY_ENV` (plus a truthy `AUTO_UPLOAD`, unchanged). Optional-only keys are still APPLIED once the section is materialized by a required key — they just no longer trigger materialization. A lone region/endpoint now leaves offsite `None` (unconfigured), so `doctor` reports the Info "no offsite backup destination configured" arm instead of a strict Fail. No `doctor.rs` change is needed — the fix is entirely in `config.rs`.

Note on `ENDPOINT`: the issue's required list is "a bucket, or the access/secret key-env names" and its optional-only list is region/force_path_style/prefix/keep — `ENDPOINT` is named in neither. A bare endpoint with no bucket also cannot upload, so `ENDPOINT` is dropped from the materializing set too (matches "required = bucket or cred-env names" exactly).

## #1760 — delete the remote object when post-upload verify fails

**Before:** `put_file_and_verify` WRITES the object BEFORE its HEAD/GET verification, so a post-upload verify failure (or a transient read during verify) could leave a corrupt/partial object in the bucket at the s3-client layer.

**After:** both the single-PUT path and the multipart post-Complete path route their final verify through a shared `verify_or_delete` helper that, on any verify error, best-effort `DeleteObject`s the just-written key before returning the ORIGINAL verify error. The error stays loud and non-zero; a delete failure is logged but never masks it. The multipart pre-Complete abort path is unchanged. This makes the s3 client self-cleaning for every caller; `backup.rs`'s run-level `cleanup_failed_upload` still handles the OTHER keys written earlier in a failed run (its comment is updated to reflect the new division of responsibility).

## #1743 — alert operator channels when an offsite upload fails

**Before:** a failed `autumn db backup` offsite upload exited non-zero with a split-outcome message, but raised no operator alert — an unattended/cron backup could fail its upload silently.

**After:** the upload-failure site raises a `ScheduledTaskFailure` operator alert through the #1610 alert channels, in addition to the existing message + non-zero exit. The CLI has no Alerter/AppState, so this reuses the `autumn alert test` seam: `configured_http_channels` is promoted to a shared helper in `alert.rs` so the backup alert and `alert test` build the exact same channel set (PagerDuty/Slack/Discord + signed webhook). Delivery runs on a short-lived current-thread runtime, best-effort — per-channel failures are logged and never change the exit code.

**Discriminator (design decision):** fire on ANY upload failure when `[alerts]` channels are configured. Interactive users with no `[alerts]` destination build zero channels, so it is a no-op for them and the interactive case (message + non-zero exit) is unchanged. This is the most robust reading of "zero silent upload failures".

**Email is deferred:** `configured_http_channels` covers the outbound-HTTP transports only; email needs a configured Mailer, which the CLI does not construct — matching what `autumn alert test` already does.

## How

- `#1791`: shrank `OFFSITE_DEST_KEYS` in `apply_backup_env_overrides_with_env` to the 3 required keys and updated the doc comment. Unit tests in `config.rs`: lone optional key → `None`; each credential key materializes; bucket-only materializes; region/prefix/keep still applied when a required key materializes.
- `#1760`: added the private `verify_or_delete` helper in `s3.rs`; both upload paths call it. Docker-free unit test drives a local S3 stub that accepts the PUT, forces a length-mismatch HEAD, and asserts the PUT/HEAD/DELETE sequence. (A black-box `db backup` e2e cannot isolate this — the backup-layer `cleanup_failed_upload` would mask the s3-layer delete — and needs Docker; the stub test isolates and needs neither.)
- `#1743`: `emit_offsite_upload_failure_alert` loads config, builds channels via the shared helper, and delivers via `deliver_offsite_upload_alert(&[Arc<dyn AlertChannel>], …)`; a `build_offsite_upload_alert` pure builder is unit-asserted, and a capturing mock `AlertChannel` proves a forced failure raises a `ScheduledTaskFailure` with the expected title/summary.

## Testing

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p autumn-cli` — 3404 + 151 + 176 (…) passed, 0 failed (includes the 4 new tests)
- `cargo test -p autumn-web --lib` — 3634 passed, 0 failed (includes 9 offsite config tests). The full `-p autumn-web` run also compiles many DB-backed integration binaries that need Postgres/Docker; the change here is config-only so the lib suite is the relevant gate.

`#1760`'s object-absent assertion is proven by the Docker-free stub unit test; the MinIO e2e (validated in CI by #1744) additionally exercises the real round-trip.

Closes #1791
Closes #1760
Closes #1743

---
_Generated by [Claude Code](https://claude.ai/code/session_01NT15Vm2Gq3zgnRWG1wBm7L)_