### PR TITLE
feat(macros): validate the effective merged model on the update path (#1778)

### DIFF
--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -2937,6 +2937,17 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             let ident = &f.ident;
             let ty = &f.ty;
             let attrs = user_attrs(f);
+            // #1778: keep the field's full `#[validate(...)]` rules on the read
+            // model so the *effective merged model* (existing row ∪ patch) can be
+            // validated on the update path via `from_patch`. The model's fields
+            // are concrete `T` (not `Patch<T>`), so every validator — including
+            // the ones the `Patch<T>` path cannot express (`ip` on `Option`,
+            // `does_not_contain`, and the cross-field `custom`/`must_match`/
+            // `nested`) — compiles and runs here without hitting the E0119
+            // trait-coherence walls that block them on `Patch<T>`. The struct
+            // only derives `validator::Validate` when `has_validation` is set
+            // (see below), so the attribute is always registered when present.
+            let val_attrs = validate_attrs(f);
             // Encrypted columns route through an AEAD wrapper transparently:
             // `serialize_as` encrypts on write, `deserialize_as` decrypts on read.
             // The public field stays a plain `String` (plaintext in Rust code).
@@ -2952,7 +2963,7 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             // `skip`) keeps `Deserialize` intact.
             let private = (field_hidden_from_json(f) && !field_already_skips_serialization(f))
                 .then(|| quote! { #[serde(skip_serializing)] });
-            quote! { #(#attrs)* #enc #private pub #ident: #ty }
+            quote! { #(#val_attrs)* #(#attrs)* #enc #private pub #ident: #ty }
         })
         .collect();
 
@@ -3043,6 +3054,30 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Conditional Validate derive
     let validate_derive = if has_validation {
         quote! { #[derive(::autumn_web::reexports::validator::Validate)] }
+    } else {
+        quote! {}
+    };
+
+    // #1778: statement that validates the effective *merged model* inside
+    // `from_patch` (existing row ∪ patch). Because `after` is a concrete `#name`
+    // — not `Patch<T>` — the model's `#[validate(...)]` rules run against real
+    // values, so the validators that hit E0119 coherence walls on `Patch<T>`
+    // (`ip` on `Option`, `does_not_contain`) and the cross-field ones
+    // (`custom`, `must_match`, `nested`) are all enforced on the update path,
+    // returning the same 422 field-error map as create. Runs before the
+    // `before_update` hook, mirroring create (where `validate_new` runs before
+    // `before_create`). Emitted only when the model declares validation; when it
+    // does not there is nothing to check and the model derives no `Validate`.
+    let merged_validate_stmt = if has_validation {
+        quote! {
+            {
+                #[allow(unused_imports)]
+                use ::autumn_web::validation::{
+                    MaybeValidateFallback as _, MaybeValidateViaValidator as _,
+                };
+                (&::autumn_web::validation::MaybeValidate(&after)).autumn_maybe_validate()?;
+            }
+        }
     } else {
         quote! {}
     };
@@ -4153,6 +4188,12 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         #[derive(#name_debug_derive Clone, ::diesel::Queryable, ::diesel::Selectable, ::diesel::AsChangeset, ::diesel::Insertable)]
         #[derive(::serde::Serialize, ::serde::Deserialize)]
+        // #1778: derive `validator::Validate` on the read model (gated on
+        // `has_validation`, symmetric with New*/Update*) so the merged model
+        // built by `from_patch` can be validated on the update path. See the
+        // `query_fields` comment for why concrete `T` fields dodge the E0119
+        // walls that block the same validators on `Patch<T>`.
+        #validate_derive
         #[diesel(table_name = #table_ident)]
         #(#filtered_outer_attrs)*
         #vis struct #name {
@@ -4371,6 +4412,11 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 // (before validation / persistence), so the DB observes the
                 // canonical value. No-op when no columns normalize.
                 #(#normalize_draft_stmts)*
+                // #1778: validate the effective merged model (existing row ∪
+                // patch, post-normalization) so the full `#[validate(...)]` set
+                // runs against concrete values. No-op when the model declares no
+                // validation.
+                #merged_validate_stmt
                 Ok(Self::new_with_changes(current.clone(), after))
             }
 
@@ -5678,6 +5724,83 @@ mod tests {
         assert!(
             !upd_section.contains("custom"),
             "UpdateUser must NOT carry the non-declarative `custom` validator: {upd_section}"
+        );
+    }
+
+    #[test]
+    fn read_model_keeps_full_validator_set_and_from_patch_validates_merged_model() {
+        // #1778: the read model retains EVERY `#[validate(...)]` rule (including
+        // the ones dropped from the `Patch<T>` update fields, e.g. `custom`) and
+        // derives `validator::Validate`, so `from_patch` can validate the
+        // effective merged model (existing row ∪ patch) on the update path.
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct User {
+                    #[id]
+                    pub id: i64,
+                    #[validate(length(min = 1), custom(function = "v"))]
+                    pub name: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+
+        // Slice the read-model `struct User` body (first occurrence, before
+        // `NewUser`/`UpdateUser`/`UserChangeset`).
+        let read_start = generated
+            .find("struct User")
+            .expect("read model struct must be generated");
+        let read_end = read_start
+            + generated[read_start..]
+                .find('}')
+                .expect("read model struct must close");
+        let read_section = &generated[read_start..read_end];
+        assert!(
+            read_section.contains("length") && read_section.contains("custom"),
+            "read model must keep the FULL validator set (incl. `custom`, which the \
+             Patch<T> update fields drop) so the merged model can enforce it: {read_section}"
+        );
+
+        // The read model now derives `Validate` too, so the derive appears three
+        // times (read model + NewUser + UpdateUser) rather than twice.
+        let derive_count = generated.matches("validator :: Validate").count();
+        assert_eq!(
+            derive_count, 3,
+            "read model, NewModel, and UpdateModel must each derive `validator::Validate`: {generated}"
+        );
+
+        // `from_patch` validates the merged concrete model via the autoref
+        // `MaybeValidate` specialization (same 422 mapping as create).
+        assert!(
+            generated.contains("from_patch") && generated.contains("autumn_maybe_validate"),
+            "from_patch must validate the merged model via autumn_maybe_validate: {generated}"
+        );
+    }
+
+    #[test]
+    fn read_model_without_validation_does_not_derive_validate_or_validate_on_merge() {
+        // Symmetric guard: a model with no `#[validate(...)]` rules must NOT gain
+        // a `Validate` derive on the read model nor a merged-model check in
+        // `from_patch` — the autoref no-op is only paid for by validated models.
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Plain {
+                    #[id]
+                    pub id: i64,
+                    pub name: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            !generated.contains("validator :: Validate"),
+            "an unvalidated model must not derive `validator::Validate`: {generated}"
+        );
+        assert!(
+            !generated.contains("autumn_maybe_validate"),
+            "an unvalidated model's from_patch must not emit a merged-model check: {generated}"
         );
     }
 

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -212,6 +212,8 @@ mod throttle_route;
 mod time_zone_integration;
 mod transactional_test_integration;
 mod tx_isolation_retry_integration;
+#[cfg(feature = "db")]
+mod validate_merged_model;
 mod validate_patch_option_ip;
 mod webhook_outbound;
 #[cfg(feature = "maud")]

--- a/autumn/tests/integration/validate_merged_model.rs
+++ b/autumn/tests/integration/validate_merged_model.rs
@@ -1,0 +1,180 @@
+//! #1778 — validate the effective *merged model* on the update path.
+//!
+//! `#[autumn_web::model]` now derives `validator::Validate` on the read model
+//! and keeps the field `#[validate(...)]` rules there. The generated
+//! `from_patch(current, patch)` merges the patch onto a clone of the existing
+//! row and validates the resulting *concrete* model before returning the draft.
+//!
+//! Because the merged model's fields are concrete `T` (not `Patch<T>`), this
+//! path enforces the validators that hit hard `E0119` trait-coherence walls on
+//! `Patch<T>` — `ip` on an `Option<_>` column and `does_not_contain` — and the
+//! cross-field / struct-level ones (`custom`) that no single-field `Patch<T>`
+//! trait can express. All of them are still (correctly) dropped from the
+//! `Update{Model}` `Patch<T>` fields by the denylist, so the *only* thing that
+//! rejects an invalid-once-merged patch here is the merged-model check.
+//!
+//! Living in the consolidated `integration_tests` binary makes
+//! `cargo build --tests -p autumn-web` the compile-time regression guard: the
+//! module wouldn't compile at all if the merged-model validators reintroduced
+//! the E0119 walls.
+
+#![cfg(feature = "db")]
+
+use validator::Validate;
+
+use autumn_web::hooks::{Patch, UpdateDraft};
+
+mod schema {
+    autumn_web::reexports::diesel::table! {
+        merged_hosts (id) {
+            id -> Int8,
+            ip -> Nullable<Text>,
+            blurb -> Text,
+            slug -> Text,
+        }
+    }
+}
+
+use schema::merged_hosts;
+
+/// Reject any value containing an uppercase letter — stands in for the
+/// cross-field / struct-level `custom` validators that have no `Patch<T>` impl
+/// and are therefore create-only on the patch-struct path, but run here against
+/// the concrete merged value.
+fn no_uppercase(value: &str) -> Result<(), validator::ValidationError> {
+    if value.chars().any(char::is_uppercase) {
+        return Err(validator::ValidationError::new("no_uppercase"));
+    }
+    Ok(())
+}
+
+#[autumn_web::model(table = "merged_hosts")]
+pub struct MergedHost {
+    #[id]
+    pub id: i64,
+    // `ip` on an `Option<String>` column: the E0119 wall. Dropped from the
+    // generated `UpdateMergedHost` patch field, enforced here on the merged
+    // concrete `Option<String>`.
+    #[validate(ip)]
+    pub ip: Option<String>,
+    // `does_not_contain`: blanket-inversion coherence wall on `Patch<T>`.
+    // Dropped from the patch field, enforced on the merged concrete `String`.
+    #[validate(does_not_contain(pattern = "bad"))]
+    pub blurb: String,
+    // `custom`: no `Patch<T>` impl (struct/cross-field class). Dropped from the
+    // patch field, enforced on the merged concrete value.
+    #[validate(custom(function = "no_uppercase"))]
+    pub slug: String,
+}
+
+fn valid_current() -> MergedHost {
+    MergedHost {
+        id: 1,
+        ip: Some("10.0.0.1".to_string()),
+        blurb: "all good".to_string(),
+        slug: "host-one".to_string(),
+    }
+}
+
+/// The `Update{Model}` still (correctly) drops these validators from its
+/// `Patch<T>` fields, so validating the *patch struct* on its own never rejects
+/// them — proving the merged-model path is what does the work below.
+#[test]
+fn update_model_patch_struct_still_drops_walled_validators() {
+    let patch = UpdateMergedHost {
+        ip: Patch::Set(Some("not-an-ip".to_string())),
+        blurb: Patch::Set("this is bad".to_string()),
+        slug: Patch::Set("SHOUTING".to_string()),
+    };
+    // On the patch struct alone every walled/cross-field validator is dropped,
+    // so it "passes". The merged model (below) is where they are enforced.
+    assert!(
+        patch.validate().is_ok(),
+        "patch-struct validation must remain create-only for the walled validators"
+    );
+}
+
+#[test]
+fn from_patch_accepts_a_valid_merged_model() {
+    let current = valid_current();
+    let patch = UpdateMergedHost {
+        ip: Patch::Set(Some("192.168.0.2".to_string())),
+        blurb: Patch::Set("still fine".to_string()),
+        slug: Patch::Set("host-two".to_string()),
+    };
+    let draft = <UpdateDraft<MergedHost> as MergedHostDraftExt>::from_patch(&current, &patch)
+        .expect("a valid merged model must pass validation");
+    assert_eq!(draft.after().ip.as_deref(), Some("192.168.0.2"));
+    assert_eq!(draft.after().slug, "host-two");
+}
+
+#[test]
+fn from_patch_rejects_ip_invalid_once_merged() {
+    // `ip` is dropped from the `Patch<Option<String>>` field (E0119), so this
+    // is caught *only* by validating the merged model.
+    let current = valid_current();
+    let patch = UpdateMergedHost {
+        ip: Patch::Set(Some("not-an-ip".to_string())),
+        ..Default::default()
+    };
+    let err = <UpdateDraft<MergedHost> as MergedHostDraftExt>::from_patch(&current, &patch)
+        .expect_err("an invalid merged `ip` must be rejected");
+    assert_eq!(
+        err.status(),
+        autumn_web::reexports::http::StatusCode::UNPROCESSABLE_ENTITY,
+        "merged-model validation failures must surface as 422"
+    );
+}
+
+#[test]
+fn from_patch_rejects_does_not_contain_invalid_once_merged() {
+    // `does_not_contain` is dropped from the patch field; the merged concrete
+    // `String` is what enforces it.
+    let current = valid_current();
+    let patch = UpdateMergedHost {
+        blurb: Patch::Set("contains a bad word".to_string()),
+        ..Default::default()
+    };
+    let err = <UpdateDraft<MergedHost> as MergedHostDraftExt>::from_patch(&current, &patch)
+        .expect_err("a merged `blurb` containing the forbidden pattern must be rejected");
+    assert_eq!(
+        err.status(),
+        autumn_web::reexports::http::StatusCode::UNPROCESSABLE_ENTITY
+    );
+}
+
+#[test]
+fn from_patch_rejects_custom_invalid_once_merged() {
+    // `custom` has no `Patch<T>` impl; only the merged model runs it.
+    let current = valid_current();
+    let patch = UpdateMergedHost {
+        slug: Patch::Set("Has-Uppercase".to_string()),
+        ..Default::default()
+    };
+    let err = <UpdateDraft<MergedHost> as MergedHostDraftExt>::from_patch(&current, &patch)
+        .expect_err("a merged `slug` failing the custom rule must be rejected");
+    assert_eq!(
+        err.status(),
+        autumn_web::reexports::http::StatusCode::UNPROCESSABLE_ENTITY
+    );
+}
+
+#[test]
+fn from_patch_validates_fields_left_untouched_by_the_patch() {
+    // The patch only touches `slug`; `blurb` keeps the existing (invalid) row
+    // value. Merged-model validation sees the whole record, so a pre-existing
+    // violation surfaces — proving we validate the *effective* model, not just
+    // the changed fields.
+    let mut current = valid_current();
+    current.blurb = "already bad".to_string();
+    let patch = UpdateMergedHost {
+        slug: Patch::Set("fresh-slug".to_string()),
+        ..Default::default()
+    };
+    let err = <UpdateDraft<MergedHost> as MergedHostDraftExt>::from_patch(&current, &patch)
+        .expect_err("an untouched-but-invalid field must still be caught on merge");
+    assert_eq!(
+        err.status(),
+        autumn_web::reexports::http::StatusCode::UNPROCESSABLE_ENTITY
+    );
+}


### PR DESCRIPTION
## Before / After

**Before.** Several validator kinds could not be enforced on the PATCH/PUT update path, only on create:
- `ip` on `Option<_>` fields and `does_not_contain` hit hard **E0119** trait-coherence walls when applied to a `Patch<T>` field under `validator` 0.20 (a concrete/inverting `Patch<T>` impl conflicts with validator's blanket impls). They were dropped from the generated `Update{Model}` and enforced create-only.
- The cross-field / struct-level rules `custom`, `must_match`, `nested` have **no** single-field `Patch<T>` trait at all, so they were also create-only.

A PATCH that would be invalid once applied to the row could therefore persist.

**After.** The update path validates the **effective merged model** — the existing row with the patch applied — instead of the sparse `Patch<T>` struct. Because the merged model's fields are concrete `T` (not `Patch<T>`), every validator compiles and runs: the E0119-walled ones (`ip` on `Option`, `does_not_contain`) and the cross-field ones (`custom`, `must_match`, `nested`) are all enforced, returning the same 422 field-error map as create. A valid patch still passes; absent/cleared fields behave as before.

## How

Two additive `#[model]` codegen changes (no `repository.rs` change, no behavior change to the existing `Patch<T>` validation or the UpdateModel denylist — this layers on top):

1. **Read model derives `validator::Validate`** and keeps the field's full `#[validate(...)]` set (previously stripped). Gated on `has_validation`, symmetric with `New*`/`Update*`. Concrete `T` fields dodge the coherence walls that block the same validators on `Patch<T>`.
2. **`from_patch` validates the merged model.** After merging the patch onto a clone of the loaded row and normalizing, it runs the model's `Validate` via the existing autoref `MaybeValidate` specialization (`?` → 422). This runs **before** `before_update`, mirroring create (where `validate_new` runs before `before_create`).

`from_patch` is the draft-building seam, so this uniformly covers every update path that builds a draft: repositories declared with `hooks = ...` (and `commit_hooks`), and their `--api` PATCH/PUT handlers.

### Coverage / scope (why "Part of", not "Closes")

Repositories generated **without** hooks emit a blind `changes.__to_changeset()` UPDATE and never call `from_patch`, so their update path (plain / `api` / `policy`) still runs only the patch-struct validators. Verified via macro codegen inspection:

| repo config | update path | merged-model validation |
|---|---|---|
| `hooks = ...` | `from_patch` draft | ✅ |
| plain / `api` / `policy` (no hooks) | blind `__to_changeset` | ❌ (tracked in #1801) |

Extending to the blind paths needs the loaded-row `SELECT` that #1778 flags as the architectural blocker (free for the `policy` handler which already loads the row; opt-in fetch for the plain non-policy path). Filed as **#1801**.

### Semantic note

Validating the whole merged model (not just changed fields) means a pre-existing violation on an untouched column surfaces on any update to that row — matching the "effective merged model" framing in #1778 and standard record-level validation. Called out for review; a test locks this behavior.

## Testing

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p autumn-macros -p autumn-web --all-targets --features db -- -D warnings` — clean
- `cargo test -p autumn-macros` — **458 passed** (incl. 2 new token-assertion tests: read-model `Validate` derive + `from_patch` merged check; and the unvalidated-model no-op guard)
- `cargo test -p autumn-web --features db --test integration_tests` — **1110 passed, 0 failed, 87 ignored**, incl. the new `validate_merged_model` module (6 tests: invalid-once-merged `ip`/`does_not_contain`/`custom` → 422, valid patch passes, untouched-invalid-field caught) and the existing `validate_patch_option_ip` boundary test (still green)
- trybuild `compile_fail` + `compile_pass` suites — pass; no `.stderr` drift (no compile-fail fixture uses validation, and `repository_api_validated` compile-pass still compiles with the new read-model `Validate` derive)

Part of #1778 (follow-up: #1801)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ErWNyJrf4kyjmVa1FJKYv2

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErWNyJrf4kyjmVa1FJKYv2)_