### PR TITLE
👺 Havoc: Prevent panic on jittered_ttl overflow

### DIFF
--- a/autumn/src/cache/read_through.rs
+++ b/autumn/src/cache/read_through.rs
@@ -287,8 +287,14 @@ pub fn jittered_ttl(base: Duration, fraction: f64) -> Duration {
     }
     let unit = f64::from(u32::from_le_bytes(buf)) / f64::from(u32::MAX);
     // factor is uniform in [1 - fraction, 1 + fraction].
-    let factor = fraction.mul_add(2.0f64.mul_add(unit, -1.0), 1.0);
-    base.mul_f64(factor)
+    let factor = fraction.mul_add(2.0f64.mul_add(unit, -1.0), 1.0).max(0.0);
+    #[allow(clippy::cast_precision_loss)]
+    let max_secs = u64::MAX as f64;
+    if base.as_secs_f64() * factor >= max_secs {
+        Duration::MAX
+    } else {
+        base.mul_f64(factor)
+    }
 }
 
 // ── In-flight registry (single-flight) ──────────────────────────────

--- a/autumn/tests/integration/chaos_cache_jitter_proptest.rs
+++ b/autumn/tests/integration/chaos_cache_jitter_proptest.rs
@@ -1,0 +1,16 @@
+use autumn_web::cache::jittered_ttl;
+use proptest::prelude::*;
+use std::time::Duration;
+
+proptest! {
+    #[test]
+    fn test_jittered_ttl_no_panic(
+        secs in 0u64..u64::MAX,
+        nanos in 0u32..1_000_000_000,
+        fraction in 0.0f64..2.0f64
+    ) {
+        let base = Duration::new(secs, nanos);
+        // This will panic if base is very large and the random factor > 1.0
+        let _ = jittered_ttl(base, fraction);
+    }
+}

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -15,6 +15,7 @@ mod boundary_hooks_integration;
 mod broadcast_recorder;
 #[cfg(feature = "cache-moka")]
 mod cache_stampede;
+mod chaos_cache_jitter_proptest;
 #[cfg(feature = "ws")]
 mod chaos_channels;
 #[cfg(feature = "ws")]


### PR DESCRIPTION
🧊 **The Trigger:**
Passing a very large `Duration` (e.g. `Duration::MAX`) to `jittered_ttl` with a fraction that results in a randomized jitter factor `> 1.0`.

📉 **The Stack Trace:**
```
thread 'integration::chaos_cache_jitter_proptest::test_jittered_ttl_no_panic' panicked at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/core/src/time.rs:964:23:
cannot convert float seconds to Duration: value is either too big or NaN
```

🧪 **Reproduction:**
Run the new proptest harness located at `autumn/tests/integration/chaos_cache_jitter_proptest.rs`. The fuzzer hits this edge case by feeding extreme ranges into `jittered_ttl`.

😈 **Comment:**
"You assumed `Duration::mul_f64` was infallible and would never overflow when multiplying large durations by random jitter. You were wrong."

---
*PR created automatically by Jules for task [257098097593059716](https://jules.google.com/task/257098097593059716) started by @madmax983*