### PR TITLE
Add agentic-DX habit-tracker benchmark harness

### DIFF
--- a/benchmarks/agentic-habit-tracker/.gitignore
+++ b/benchmarks/agentic-habit-tracker/.gitignore
@@ -1,0 +1,16 @@
+# The repo root .gitignore ignores *.py and *.sh (this is a Rust workspace).
+# The harness is Python, so re-include its checked-in scripts here.
+!acceptance/*.py
+!hidden/*.py
+!scripts/*.py
+
+# Generated per-run artifacts must never be committed.
+runs/*/app/
+runs/*/boot.log
+runs/*/visible.log
+runs/*/hidden.log
+runs/*/metrics.json
+runs/*/run.sh
+runs/*/README.md
+__pycache__/
+*.pyc

--- a/benchmarks/agentic-habit-tracker/.gitignore
+++ b/benchmarks/agentic-habit-tracker/.gitignore
@@ -2,6 +2,7 @@
 # The harness is Python, so re-include its checked-in scripts here.
 !acceptance/*.py
 !hidden/*.py
+!phase2/*.py
 !scripts/*.py
 
 # Generated per-run artifacts must never be committed.

--- a/benchmarks/agentic-habit-tracker/.gitignore
+++ b/benchmarks/agentic-habit-tracker/.gitignore
@@ -4,6 +4,7 @@
 !hidden/*.py
 !phase2/*.py
 !scripts/*.py
+!scripts/prepare_agent_workspace.sh
 
 # Generated per-run artifacts must never be committed.
 runs/*/app/

--- a/benchmarks/agentic-habit-tracker/README.md
+++ b/benchmarks/agentic-habit-tracker/README.md
@@ -27,6 +27,9 @@ acceptance/contract_test.py visible acceptance tests (run against a live server)
 hidden/
   HIDDEN_TESTS.md           high-level description of what the hidden suite probes
   hidden_test.py            the actual hidden checks (not shown to the agent)
+phase2/
+  archive_test.py           visible phase-2 archive acceptance tests
+  archive_hidden_test.py    hidden phase-2 archive checks (not shown to the agent)
 scripts/score.py            deterministic scorer (reads metrics.json)
 runs/                       one subdir per trial (see runs/README.md)
 ```
@@ -83,7 +86,20 @@ status codes, and streak semantics are pinned in `SPEC.md`.
    single number. It is deterministic: same `metrics.json` in, same output out.
 
 For phase 2, repeat steps 2-7 with `prompts/phase2_maintenance.md` against the
-phase-1 app, recording a second `metrics.json` with `"phase": 2`.
+phase-1 app, recording a second `metrics.json` with `"phase": 2`. Phase-2
+**correctness** is scored by the dedicated archive suites, not by the phase-1
+tests — run them against the modified app:
+
+```sh
+BASE_URL=http://localhost:8080 python3 phase2/archive_test.py         # visible
+BASE_URL=http://localhost:8080 python3 phase2/archive_hidden_test.py  # hidden
+```
+
+The `RESULT: X/Y passed` lines from these two suites feed the phase-2
+`visible_checks_*` / `hidden_checks_*` metrics. In **addition**, re-run the
+phase-1 suites (`acceptance/contract_test.py` and `hidden/hidden_test.py`) as a
+regression check — the maintenance change must not break any phase-1 behavior —
+but phase-2 correctness itself is measured by the archive suites above.
 
 ## Requirements
 

--- a/benchmarks/agentic-habit-tracker/README.md
+++ b/benchmarks/agentic-habit-tracker/README.md
@@ -54,6 +54,31 @@ status codes, and streak semantics are pinned in `SPEC.md`.
   (archived habits are hidden, not deleted). Measures how quickly and cleanly an
   agent extends an existing codebase.
 
+## Evaluator-only vs builder-visible
+
+The hidden suites decide 60% of the score, so the building agent must never see
+them. Because this harness is checked into the framework repos it evaluates, a
+raw checkout would hand the agent the *executable* hidden tests — letting it
+optimize against them. Keep the boundary explicit:
+
+- **Builder-visible** (safe to give the agent): `prompts/`, `SPEC.md`,
+  `acceptance/`, `phase2/archive_test.py`.
+- **Evaluator-only** (NEVER expose to the builder): `hidden/`,
+  `phase2/archive_hidden_test.py`, `scripts/score.py`, `rubric.md`,
+  `metrics-schema.json`.
+
+**Run trials from a prepared workspace, not the raw checkout.** Use
+`scripts/prepare_agent_workspace.sh <framework> <dest-dir>` to assemble only the
+builder-visible materials into a clean directory, and point the agent there.
+
+**Autumn caveat.** Autumn's app needs a path-dependency on the in-repo `autumn/`
+crate, so the agent works inside a clone of this framework repo rather than an
+isolated workspace. That clone MUST exclude
+`benchmarks/agentic-habit-tracker/hidden/` and
+`benchmarks/agentic-habit-tracker/phase2/archive_hidden_test.py` — e.g. use a
+git sparse-checkout that excludes those paths, or delete them from the agent's
+working copy — otherwise the evaluator boundary is defeated.
+
 ## Running a trial
 
 1. **Pick a run id and framework**, e.g. `autumn-p1-2026-07-12`. Create

--- a/benchmarks/agentic-habit-tracker/README.md
+++ b/benchmarks/agentic-habit-tracker/README.md
@@ -1,0 +1,92 @@
+# Agentic-DX benchmark: Habit Tracker
+
+A deterministic, framework-agnostic harness for measuring the developer
+experience of building a small web app **with a coding agent**. We point an
+agent at a build brief, time it while it builds a habit-tracker app, then score
+the result on three separate axes: **speed**, **correctness**, and
+**maintainability**.
+
+The core design constraint: the acceptance tests are **framework-agnostic**.
+They talk to a running HTTP server over HTTP only (`acceptance/contract_test.py`
+and `hidden/hidden_test.py` are stdlib-only Python), so the *same* test files
+work unchanged against Autumn, Django, Rails, Spring Boot, Phoenix, Loco, or
+anything else that satisfies the contract in `SPEC.md`.
+
+## Contents
+
+```
+SPEC.md                     app spec + precise JSON API contract (source of truth)
+rubric.md                   the three-axis scoring rubric
+metrics-schema.json         per-run metrics.json schema
+prompts/
+  _core.md                  framework-agnostic build brief
+  autumn.md django.md rails.md springboot.md phoenix.md loco.md
+                            core brief + per-framework bootstrapping notes
+  phase2_maintenance.md     the phase-2 "archived habits" maintenance brief
+acceptance/contract_test.py visible acceptance tests (run against a live server)
+hidden/
+  HIDDEN_TESTS.md           high-level description of what the hidden suite probes
+  hidden_test.py            the actual hidden checks (not shown to the agent)
+scripts/score.py            deterministic scorer (reads metrics.json)
+runs/                       one subdir per trial (see runs/README.md)
+```
+
+## The app being built
+
+A habit tracker: create/list/view/update/delete habits, mark a habit complete on
+a given day (with **backdated** completions supported so streaks are testable
+deterministically), and compute a per-habit **current streak** and completion
+history. Plus at least one server-rendered HTML view. The exact endpoints,
+status codes, and streak semantics are pinned in `SPEC.md`.
+
+## Phases
+
+- **Phase 1 — greenfield build.** The agent builds the app from
+  `prompts/<framework>.md`. Measures build speed, correctness, and the
+  maintainability of what it produced.
+- **Phase 2 — maintenance change.** The agent applies the "archived habits"
+  change in `prompts/phase2_maintenance.md` to the phase-1 app: add an
+  `archived` boolean, add `POST /api/habits/{id}/archive`, exclude archived
+  habits from `GET /api/habits`, and expose them at `GET /api/habits?archived=true`
+  (archived habits are hidden, not deleted). Measures how quickly and cleanly an
+  agent extends an existing codebase.
+
+## Running a trial
+
+1. **Pick a run id and framework**, e.g. `autumn-p1-2026-07-12`. Create
+   `runs/<run-id>/` and copy the chosen prompt into it as `prompt.md`.
+2. **Start the timer and point the agent** at `prompts/<framework>.md`. Have it
+   build the app under `runs/<run-id>/app`. Capture its transcript and count its
+   tool calls.
+3. **Boot the app**: `cd runs/<run-id>/app && PORT=8080 ./run.sh`. `run.sh` must
+   apply migrations, seed demo data, and start the server on `PORT` (default
+   8080), blocking while it runs.
+4. **Run the visible tests** against the live server. Record wall-clock time to
+   the first fully-green run:
+   ```sh
+   BASE_URL=http://localhost:8080 python3 acceptance/contract_test.py
+   ```
+   Both test scripts retry-connect for up to 30s, so you can start them right
+   after launching the server.
+5. **Run the hidden tests**:
+   ```sh
+   BASE_URL=http://localhost:8080 python3 hidden/hidden_test.py
+   ```
+6. **Fill in `runs/<run-id>/metrics.json`** per `metrics-schema.json` (the
+   `RESULT: X/Y passed` lines give the check counts; add the timing, tool-call,
+   LOC, and manual maintainability numbers).
+7. **Score it**:
+   ```sh
+   python3 scripts/score.py runs/<run-id>/metrics.json | tee runs/<run-id>/score.txt
+   ```
+   The scorer prints the three axes separately and never collapses them into a
+   single number. It is deterministic: same `metrics.json` in, same output out.
+
+For phase 2, repeat steps 2-7 with `prompts/phase2_maintenance.md` against the
+phase-1 app, recording a second `metrics.json` with `"phase": 2`.
+
+## Requirements
+
+- Python 3 (stdlib only — no `pip install` needed for the test harness).
+- Whatever toolchain the chosen framework needs (Rust, Python/Django, Ruby/Rails,
+  JVM, Elixir, ...), plus a database as described in that framework's prompt.

--- a/benchmarks/agentic-habit-tracker/SPEC.md
+++ b/benchmarks/agentic-habit-tracker/SPEC.md
@@ -1,0 +1,191 @@
+# Habit Tracker — Application Spec & API Contract
+
+This document is the single source of truth for the benchmark. Every framework
+implementation MUST satisfy the JSON API contract below **exactly**, because the
+acceptance tests are framework-agnostic: they talk to a running HTTP server over
+HTTP and make no assumptions about the language, framework, or ORM used.
+
+## 1. What the app is
+
+A small "habit tracker" web application. A user can:
+
+- Create named habits (with an optional description).
+- List, view, update, and delete habits.
+- Mark a habit as completed on a given calendar day.
+- See a per-habit **current streak** (consecutive days completed) and the full
+  completion **history**.
+- View a server-rendered HTML page listing the habits.
+
+The app MUST persist data in a database (not just in-memory), expose the JSON
+API described below, render at least one server-side HTML view, validate input,
+and ship with tests, seed/demo data, and a `run.sh` launcher.
+
+## 2. HTTP / JSON API contract
+
+- Base path: `/api`.
+- All request and response bodies are JSON (`Content-Type: application/json`),
+  **except** the HTML view at `GET /`.
+- IDs are stable for the lifetime of a record. They MAY be integers or strings;
+  tests treat the returned `id` opaquely and echo it back in subsequent URLs.
+- Timestamps (`created_at`) are ISO-8601 strings.
+- Calendar dates are ISO `YYYY-MM-DD` strings (no time component).
+
+### 2.1 Habit object
+
+```json
+{
+  "id": 1,
+  "name": "Meditate",
+  "description": "10 minutes every morning",
+  "created_at": "2026-07-12T08:00:00Z"
+}
+```
+
+`description` MAY be `null` when omitted at creation.
+
+### 2.2 Endpoints
+
+#### `POST /api/habits`
+
+Create a habit.
+
+- Request body: `{"name": string, "description": string?}`
+- Success: **201 Created** with the created habit object (must include `id`,
+  `name`, `description`, `created_at`).
+- Validation: an empty or missing `name` MUST return **422** (400 also
+  accepted). No habit is created in that case.
+
+#### `GET /api/habits`
+
+List habits.
+
+- Success: **200 OK** with a JSON **array** of habit objects.
+- Ordering is unspecified; tests do not rely on it.
+- (Phase 2 only) supports an `?archived=true` query parameter — see §4.
+
+#### `GET /api/habits/{id}`
+
+Fetch a single habit, enriched with streak + history.
+
+- Success: **200 OK** with the habit object plus two extra fields:
+  ```json
+  {
+    "id": 1,
+    "name": "Meditate",
+    "description": "10 minutes every morning",
+    "created_at": "2026-07-12T08:00:00Z",
+    "current_streak": 3,
+    "history": ["2026-07-12", "2026-07-11", "2026-07-10"]
+  }
+  ```
+- `current_streak`: integer, computed per §3.
+- `history`: array of ISO `YYYY-MM-DD` date strings, **sorted descending**
+  (most recent first), one entry per completed day, no duplicates.
+- Unknown `id`: **404 Not Found**.
+
+#### `PUT /api/habits/{id}`
+
+Update a habit's `name` and/or `description`.
+
+- Request body: `{"name": string, "description": string?}`
+- Success: **200 OK** with the updated habit object.
+- Unknown `id`: **404 Not Found**.
+- Empty `name`: **422** (400 accepted).
+
+#### `DELETE /api/habits/{id}`
+
+Delete a habit and all of its completions (cascade).
+
+- Success: **204 No Content** (empty body).
+- After deletion, `GET /api/habits/{id}` MUST return **404**.
+- Deleting an unknown `id` SHOULD return **404** (204 is tolerated by tests).
+
+#### `POST /api/habits/{id}/complete`
+
+Mark the habit as completed for a calendar day.
+
+- Request body: `{"date": "YYYY-MM-DD"?}` — `date` is **optional**; when omitted
+  it defaults to **today** (server date).
+- Success: **201 Created** with `{"date": "YYYY-MM-DD", "current_streak": int}`
+  where `date` is the completed day and `current_streak` is recomputed per §3
+  **as of the completed date is NOT used** — the streak returned here is the
+  current streak as of today (server date), consistent with `GET`.
+- Duplicate: completing the **same habit** for the **same date** twice MUST
+  return **409 Conflict**. This holds whether the two calls use an explicit
+  `date` or the default (today) — they collide if they resolve to the same day.
+- Validation: a malformed/invalid `date` string (e.g. `"2026-13-40"`,
+  `"not-a-date"`) MUST return **422** (400 accepted). No completion is recorded.
+- Unknown habit `id`: **404 Not Found**.
+- **Backdated completions MUST be supported.** Tests deliberately record
+  completions for past dates, in arbitrary insertion order, so that streak
+  behavior can be verified deterministically without depending on the real
+  calendar.
+
+#### `GET /` (HTML view)
+
+- Success: **200 OK** with `Content-Type: text/html` (charset suffix allowed).
+- The body is a server-rendered HTML page listing the current habits. Minimal
+  markup is fine; tests only assert status 200 and a `text/html` content type.
+
+## 3. Streak semantics (precise)
+
+This is the part hidden tests probe hardest. Implement it exactly.
+
+- A **completion** is a `(habit_id, date)` pair. At most one completion exists
+  per habit per calendar day (enforced by the 409 rule).
+- `current_streak` = the number of consecutive calendar days, counting
+  **backward from a reference "as-of" date**, on which the habit was completed,
+  stopping at the first missed day.
+- The reference "as-of" date for `GET /api/habits/{id}` (and for the
+  `current_streak` returned by the complete endpoint) is **today** (the server's
+  current date).
+- A streak is only "current" if it includes **today OR yesterday**:
+  - If there is a completion for today, count today, then yesterday, then the day
+    before, … until a day with no completion.
+  - If there is no completion for today but there is one for yesterday, start
+    counting at yesterday and walk backward.
+  - If the most recent completion is **older than yesterday** (i.e. two or more
+    days ago with nothing since), `current_streak = 0`.
+  - If there are no completions at all, `current_streak = 0`.
+
+### Worked examples (let `T` = today)
+
+| Completions present                     | current_streak |
+|-----------------------------------------|----------------|
+| `T`, `T-1`, `T-2`                       | 3              |
+| `T-1`, `T-2`, `T-3` (nothing on `T`)    | 3              |
+| `T-1` only                              | 1              |
+| `T-2` only                              | 0              |
+| `T`, `T-2`, `T-3` (gap at `T-1`)        | 1              |
+| `T-2`, `T-3`, `T-4` (skip `T-1`, `T`)   | 0              |
+| none                                    | 0              |
+
+Note the second row: because the most recent completion (`T-1`) is yesterday,
+the streak is "current" and counts the full consecutive run `T-1, T-2, T-3`.
+
+- `history` = every completed date for the habit, de-duplicated, formatted as
+  ISO `YYYY-MM-DD`, sorted **descending** (most recent first). Independent of the
+  streak's "as-of" cutoff — it lists all completions, not just the current run.
+
+## 4. Phase 2 maintenance change (archived habits)
+
+Not part of the initial build. Introduced as a follow-up maintenance brief (see
+`prompts/phase2_maintenance.md`):
+
+- Add an `archived` boolean to the habit (default `false`).
+- Add `POST /api/habits/{id}/archive` → archives the habit (idempotent; returns
+  the updated habit or 200/204).
+- `GET /api/habits` excludes archived habits by default.
+- `GET /api/habits?archived=true` returns **only** archived habits.
+- Archiving is a soft-delete/hide: the record and its completions are retained.
+
+## 5. Runtime requirements
+
+- Persistence via a real database.
+- At least one server-rendered HTML view (`GET /`).
+- Input validation for required fields and date formats (§2).
+- Automated tests covering core behavior.
+- Seed/demo data on first run.
+- A `run.sh` at the app root that starts the server listening on `PORT`
+  (environment variable, default **8080**), applies migrations, and seeds demo
+  data. `run.sh` MUST block while the server runs.

--- a/benchmarks/agentic-habit-tracker/SPEC.md
+++ b/benchmarks/agentic-habit-tracker/SPEC.md
@@ -107,9 +107,9 @@ Mark the habit as completed for a calendar day.
 - Request body: `{"date": "YYYY-MM-DD"?}` — `date` is **optional**; when omitted
   it defaults to **today** (server date).
 - Success: **201 Created** with `{"date": "YYYY-MM-DD", "current_streak": int}`
-  where `date` is the completed day and `current_streak` is recomputed per §3
-  **as of the completed date is NOT used** — the streak returned here is the
-  current streak as of today (server date), consistent with `GET`.
+  where `date` is the completed day and `current_streak` is the current streak
+  as of today (server date), consistent with `GET` (i.e., the completed date
+  itself is NOT used as the reference date for the streak calculation).
 - Duplicate: completing the **same habit** for the **same date** twice MUST
   return **409 Conflict**. This holds whether the two calls use an explicit
   `date` or the default (today) — they collide if they resolve to the same day.

--- a/benchmarks/agentic-habit-tracker/SPEC.md
+++ b/benchmarks/agentic-habit-tracker/SPEC.md
@@ -124,8 +124,12 @@ Mark the habit as completed for a calendar day.
 #### `GET /` (HTML view)
 
 - Success: **200 OK** with `Content-Type: text/html` (charset suffix allowed).
-- The body is a server-rendered HTML page listing the current habits. Minimal
-  markup is fine; tests only assert status 200 and a `text/html` content type.
+- The body MUST be a server-rendered HTML page that **lists the current
+  (non-archived) habits**: a created habit's name MUST appear in the page body.
+  Minimal markup is fine, but the acceptance suite asserts more than the status
+  and content type — it checks that a habit's name is actually rendered. Under
+  Phase 2 (§4), archived habits MUST be excluded from this view, so an archived
+  habit's name MUST NOT appear while active habits still do.
 
 ## 3. Streak semantics (precise)
 

--- a/benchmarks/agentic-habit-tracker/acceptance/contract_test.py
+++ b/benchmarks/agentic-habit-tracker/acceptance/contract_test.py
@@ -190,13 +190,24 @@ def run():
             server_today = None
     today = server_today or datetime.date.today()
     check(f"complete {iso(today)} -> 201", r0.status == 201, f"got {r0.status}")
+    complete_streak = None
     for delta in (1, 2):  # D-1, D-2 relative to the server's today
         d = today - datetime.timedelta(days=delta)
         rr = request("POST", f"/api/habits/{sid}/complete", {"date": iso(d)})
         check(f"complete {iso(d)} -> 201", rr.status == 201, f"got {rr.status}")
+        if rr.status == 201:
+            complete_streak = (rr.json() or {}).get("current_streak")
     r = request("GET", f"/api/habits/{sid}")
     streak = r.json().get("current_streak") if r.status == 200 else None
     check("streak of 3 consecutive days == 3", streak == 3, f"got {streak}")
+    # The streak the complete endpoint returns must agree with what GET reports
+    # immediately after (both are "as of server today" per SPEC). This is a
+    # value consistency check with no hardcoded number, so an implementation
+    # that computes the streak differently on POST vs GET can't get full credit.
+    # Fail-closed: if the final backdated completion returned no streak, fail.
+    check("complete-response current_streak agrees with GET",
+          complete_streak is not None and complete_streak == streak,
+          f"complete={complete_streak}, get={streak}")
     hist = r.json().get("history") if r.status == 200 else None
     expected_hist = [iso(today - datetime.timedelta(days=d)) for d in (0, 1, 2)]
     check("history is 3 dates descending", hist == expected_hist, f"got {hist}")

--- a/benchmarks/agentic-habit-tracker/acceptance/contract_test.py
+++ b/benchmarks/agentic-habit-tracker/acceptance/contract_test.py
@@ -41,11 +41,16 @@ class Resp:
         return self.headers.get("content-type", "")
 
 
-def request(method, path, body=None):
-    """Perform an HTTP request. `path` may be absolute or relative to BASE_URL."""
+def request(method, path, body=None, accept="application/json"):
+    """Perform an HTTP request. `path` may be absolute or relative to BASE_URL.
+
+    `accept` controls the Accept header: JSON endpoints keep the default, while
+    the server-rendered HTML view is fetched with ``accept="text/html"`` so a
+    content-negotiating server isn't wrongly asked for JSON on an HTML route.
+    """
     url = path if path.startswith("http") else BASE_URL + path
     data = None
-    headers = {"Accept": "application/json"}
+    headers = {"Accept": accept}
     if body is not None:
         data = json.dumps(body).encode("utf-8")
         headers["Content-Type"] = "application/json"
@@ -219,7 +224,7 @@ def run():
     check("GET after delete -> 404", r.status == 404, f"got {r.status}")
 
     # HTML view
-    r = request("GET", "/")
+    r = request("GET", "/", accept="text/html")
     check("GET / -> 200", r.status == 200, f"got {r.status}")
     check(
         "GET / is text/html",

--- a/benchmarks/agentic-habit-tracker/acceptance/contract_test.py
+++ b/benchmarks/agentic-habit-tracker/acceptance/contract_test.py
@@ -152,8 +152,10 @@ def run():
     check("complete returns date", "date" in comp)
     check("complete returns current_streak", "current_streak" in comp)
 
-    # duplicate same-day -> 409
-    r = request("POST", f"/api/habits/{hid}/complete", {"date": iso(datetime.date.today())})
+    # duplicate same-day -> 409 (reuse the server-returned completion date so
+    # we collide on the same day even across a midnight boundary)
+    completed_date = comp.get("date") if isinstance(comp, dict) and "date" in comp else iso(datetime.date.today())
+    r = request("POST", f"/api/habits/{hid}/complete", {"date": completed_date})
     check("POST duplicate same-day -> 409", r.status == 409, f"got {r.status}")
 
     # invalid date -> 4xx

--- a/benchmarks/agentic-habit-tracker/acceptance/contract_test.py
+++ b/benchmarks/agentic-habit-tracker/acceptance/contract_test.py
@@ -135,8 +135,14 @@ def run():
     check("GET single has current_streak", "current_streak" in got)
     check("GET single has history array", isinstance(got.get("history"), list))
 
-    # unknown id -> 404
-    r = request("GET", "/api/habits/999999999")
+    # unknown id -> 404. Use a real returned-ID shape: create a throwaway habit,
+    # capture its id, DELETE it, then look up the now-deleted id. SPEC allows
+    # opaque string/UUID ids, so a hard-coded numeric sentinel could be rejected
+    # as a malformed route param (400) before any not-found lookup happens.
+    r = request("POST", "/api/habits", {"name": "throwaway-404"})
+    deleted_id = r.json().get("id") if r.status == 201 else None
+    request("DELETE", f"/api/habits/{deleted_id}")
+    r = request("GET", f"/api/habits/{deleted_id}")
     check("GET unknown id -> 404", r.status == 404, f"got {r.status}")
 
     # update
@@ -162,8 +168,8 @@ def run():
     r = request("POST", f"/api/habits/{hid}/complete", {"date": "2026-13-40"})
     check("POST invalid date -> 4xx", r.status in (400, 422), f"got {r.status}")
 
-    # complete on unknown habit -> 404
-    r = request("POST", "/api/habits/999999999/complete", {})
+    # complete on unknown habit -> 404 (reuse the deleted real-shaped id above)
+    r = request("POST", f"/api/habits/{deleted_id}/complete", {})
     check("POST complete unknown habit -> 404", r.status == 404, f"got {r.status}")
 
     # basic streak: 3 consecutive backdated days ending today

--- a/benchmarks/agentic-habit-tracker/acceptance/contract_test.py
+++ b/benchmarks/agentic-habit-tracker/acceptance/contract_test.py
@@ -76,6 +76,28 @@ def request(method, path, body=None, accept="application/json"):
         return Resp(e.code, hdrs, raw)
 
 
+# ── shape coercion ──────────────────────────────────────────────────────────────
+#
+# A candidate can answer an expected status with a syntactically VALID JSON body
+# of the wrong shape (a list where an object is expected, a scalar, or null).
+# Feeding that straight into ``.get(...)`` / indexing / iteration would raise
+# AttributeError/TypeError and crash the suite before it prints its RESULT line.
+# These helpers coerce every parsed body to the shape the caller expects, so a
+# wrong shape degrades into a failed ``check(...)`` (empty dict / empty list)
+# rather than an exception. The happy path (correct shapes) is unaffected.
+
+def as_obj(r):
+    """Return the response body as a dict, or ``{}`` for any non-object shape."""
+    j = r.json()
+    return j if isinstance(j, dict) else {}
+
+
+def as_list(r):
+    """Return the response body as a list, or ``[]`` for any non-array shape."""
+    j = r.json()
+    return j if isinstance(j, list) else []
+
+
 # ── assertions ─────────────────────────────────────────────────────────────────
 
 def check(name, condition, detail=""):
@@ -119,7 +141,7 @@ def run():
     # create
     r = request("POST", "/api/habits", {"name": "Read", "description": "20 pages"})
     check("POST /api/habits -> 201", r.status == 201, f"got {r.status}")
-    habit = (r.json() or {}) if r.status == 201 else {}
+    habit = as_obj(r) if r.status == 201 else {}
     check("created habit has id", "id" in habit)
     check("created habit echoes name", habit.get("name") == "Read")
     check("created habit has created_at", "created_at" in habit)
@@ -136,17 +158,17 @@ def run():
     # list
     r = request("GET", "/api/habits")
     check("GET /api/habits -> 200", r.status == 200, f"got {r.status}")
-    listed = r.json() if r.status == 200 else None
-    check("GET /api/habits returns array", isinstance(listed, list))
+    listed = as_list(r) if r.status == 200 else []
+    check("GET /api/habits returns array", isinstance(r.json(), list))
     check(
         "created habit present in list",
-        isinstance(listed, list) and any(str(h.get("id")) == str(hid) for h in listed),
+        any(str(h.get("id")) == str(hid) for h in listed if isinstance(h, dict)),
     )
 
     # get single
     r = request("GET", f"/api/habits/{hid}")
     check("GET /api/habits/{id} -> 200", r.status == 200, f"got {r.status}")
-    got = (r.json() or {}) if r.status == 200 else {}
+    got = as_obj(r) if r.status == 200 else {}
     check("GET single has current_streak", "current_streak" in got)
     check("GET single has history array", isinstance(got.get("history"), list))
 
@@ -155,7 +177,7 @@ def run():
     # opaque string/UUID ids, so a hard-coded numeric sentinel could be rejected
     # as a malformed route param (400) before any not-found lookup happens.
     r = request("POST", "/api/habits", {"name": "throwaway-404"})
-    deleted_id = (r.json() or {}).get("id") if r.status == 201 else None
+    deleted_id = as_obj(r).get("id") if r.status == 201 else None
     request("DELETE", f"/api/habits/{deleted_id}")
     r = request("GET", f"/api/habits/{deleted_id}")
     check("GET unknown id -> 404", r.status == 404, f"got {r.status}")
@@ -163,13 +185,13 @@ def run():
     # update
     r = request("PUT", f"/api/habits/{hid}", {"name": "Read more", "description": "30 pages"})
     check("PUT /api/habits/{id} -> 200", r.status == 200, f"got {r.status}")
-    updated = (r.json() or {}) if r.status == 200 else {}
+    updated = as_obj(r) if r.status == 200 else {}
     check("PUT updates name", updated.get("name") == "Read more")
 
     # complete today (default date)
     r = request("POST", f"/api/habits/{hid}/complete", {})
     check("POST complete (default date) -> 201", r.status == 201, f"got {r.status}")
-    comp = (r.json() or {}) if r.status == 201 else {}
+    comp = as_obj(r) if r.status == 201 else {}
     check("complete returns date", "date" in comp)
     check("complete returns current_streak", "current_streak" in comp)
 
@@ -194,11 +216,11 @@ def run():
     # correct server across a timezone / midnight-boundary skew.
     r = request("POST", "/api/habits", {"name": "Streaker"})
     check("POST streak habit -> 201", r.status == 201, f"got {r.status}")
-    sid = (r.json() or {}).get("id") if r.status == 201 else None
+    sid = as_obj(r).get("id") if r.status == 201 else None
     r0 = request("POST", f"/api/habits/{sid}/complete", {})  # default = server today
     server_today = None
     if r0.status == 201:
-        ds = (r0.json() or {}).get("date")
+        ds = as_obj(r0).get("date")
         try:
             server_today = datetime.date.fromisoformat(ds) if ds else None
         except (ValueError, TypeError):
@@ -211,9 +233,9 @@ def run():
         rr = request("POST", f"/api/habits/{sid}/complete", {"date": iso(d)})
         check(f"complete {iso(d)} -> 201", rr.status == 201, f"got {rr.status}")
         if rr.status == 201:
-            complete_streak = (rr.json() or {}).get("current_streak")
+            complete_streak = as_obj(rr).get("current_streak")
     r = request("GET", f"/api/habits/{sid}")
-    streak = (r.json() or {}).get("current_streak") if r.status == 200 else None
+    streak = as_obj(r).get("current_streak") if r.status == 200 else None
     check("streak of 3 consecutive days == 3", streak == 3, f"got {streak}")
     # The streak the complete endpoint returns must agree with what GET reports
     # immediately after (both are "as of server today" per SPEC). This is a
@@ -223,7 +245,7 @@ def run():
     check("complete-response current_streak agrees with GET",
           complete_streak is not None and complete_streak == streak,
           f"complete={complete_streak}, get={streak}")
-    hist = (r.json() or {}).get("history") if r.status == 200 else None
+    hist = as_obj(r).get("history") if r.status == 200 else None
     expected_hist = [iso(today - datetime.timedelta(days=d)) for d in (0, 1, 2)]
     check("history is 3 dates descending", hist == expected_hist, f"got {hist}")
 

--- a/benchmarks/agentic-habit-tracker/acceptance/contract_test.py
+++ b/benchmarks/agentic-habit-tracker/acceptance/contract_test.py
@@ -35,7 +35,17 @@ class Resp:
         self.body_bytes = body_bytes
 
     def json(self):
-        return json.loads(self.body_bytes.decode("utf-8"))
+        """Parse the body as JSON, returning None on any decode failure.
+
+        A candidate can answer an otherwise-expected status with an empty or
+        HTML body; raising JSONDecodeError here would crash the suite before it
+        prints its RESULT line. Returning None instead lets callers fold a
+        non-JSON body into a recorded check failure (they treat it as ``{}``).
+        """
+        try:
+            return json.loads(self.body_bytes.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            return None
 
     def content_type(self):
         return self.headers.get("content-type", "")
@@ -109,7 +119,7 @@ def run():
     # create
     r = request("POST", "/api/habits", {"name": "Read", "description": "20 pages"})
     check("POST /api/habits -> 201", r.status == 201, f"got {r.status}")
-    habit = r.json() if r.status == 201 else {}
+    habit = (r.json() or {}) if r.status == 201 else {}
     check("created habit has id", "id" in habit)
     check("created habit echoes name", habit.get("name") == "Read")
     check("created habit has created_at", "created_at" in habit)
@@ -136,7 +146,7 @@ def run():
     # get single
     r = request("GET", f"/api/habits/{hid}")
     check("GET /api/habits/{id} -> 200", r.status == 200, f"got {r.status}")
-    got = r.json() if r.status == 200 else {}
+    got = (r.json() or {}) if r.status == 200 else {}
     check("GET single has current_streak", "current_streak" in got)
     check("GET single has history array", isinstance(got.get("history"), list))
 
@@ -145,7 +155,7 @@ def run():
     # opaque string/UUID ids, so a hard-coded numeric sentinel could be rejected
     # as a malformed route param (400) before any not-found lookup happens.
     r = request("POST", "/api/habits", {"name": "throwaway-404"})
-    deleted_id = r.json().get("id") if r.status == 201 else None
+    deleted_id = (r.json() or {}).get("id") if r.status == 201 else None
     request("DELETE", f"/api/habits/{deleted_id}")
     r = request("GET", f"/api/habits/{deleted_id}")
     check("GET unknown id -> 404", r.status == 404, f"got {r.status}")
@@ -153,13 +163,13 @@ def run():
     # update
     r = request("PUT", f"/api/habits/{hid}", {"name": "Read more", "description": "30 pages"})
     check("PUT /api/habits/{id} -> 200", r.status == 200, f"got {r.status}")
-    updated = r.json() if r.status == 200 else {}
+    updated = (r.json() or {}) if r.status == 200 else {}
     check("PUT updates name", updated.get("name") == "Read more")
 
     # complete today (default date)
     r = request("POST", f"/api/habits/{hid}/complete", {})
     check("POST complete (default date) -> 201", r.status == 201, f"got {r.status}")
-    comp = r.json() if r.status == 201 else {}
+    comp = (r.json() or {}) if r.status == 201 else {}
     check("complete returns date", "date" in comp)
     check("complete returns current_streak", "current_streak" in comp)
 
@@ -184,7 +194,7 @@ def run():
     # correct server across a timezone / midnight-boundary skew.
     r = request("POST", "/api/habits", {"name": "Streaker"})
     check("POST streak habit -> 201", r.status == 201, f"got {r.status}")
-    sid = r.json().get("id") if r.status == 201 else None
+    sid = (r.json() or {}).get("id") if r.status == 201 else None
     r0 = request("POST", f"/api/habits/{sid}/complete", {})  # default = server today
     server_today = None
     if r0.status == 201:
@@ -203,7 +213,7 @@ def run():
         if rr.status == 201:
             complete_streak = (rr.json() or {}).get("current_streak")
     r = request("GET", f"/api/habits/{sid}")
-    streak = r.json().get("current_streak") if r.status == 200 else None
+    streak = (r.json() or {}).get("current_streak") if r.status == 200 else None
     check("streak of 3 consecutive days == 3", streak == 3, f"got {streak}")
     # The streak the complete endpoint returns must agree with what GET reports
     # immediately after (both are "as of server today" per SPEC). This is a
@@ -213,7 +223,7 @@ def run():
     check("complete-response current_streak agrees with GET",
           complete_streak is not None and complete_streak == streak,
           f"complete={complete_streak}, get={streak}")
-    hist = r.json().get("history") if r.status == 200 else None
+    hist = (r.json() or {}).get("history") if r.status == 200 else None
     expected_hist = [iso(today - datetime.timedelta(days=d)) for d in (0, 1, 2)]
     check("history is 3 dates descending", hist == expected_hist, f"got {hist}")
 
@@ -223,13 +233,30 @@ def run():
     r = request("GET", f"/api/habits/{hid}")
     check("GET after delete -> 404", r.status == 404, f"got {r.status}")
 
-    # HTML view
+    # HTML view. Beyond content-type, SPEC requires the server-rendered index to
+    # actually LIST current habits, so a static empty page must not pass. Create
+    # a habit with a fixed, uncommon, HTML-greppable name (deterministic — no
+    # per-run randomness) and require it to appear in the rendered body. The name
+    # is unique enough not to collide with any habit created above. Fail-closed:
+    # if the habit can't be created or the page can't be fetched, the listing
+    # check is recorded as a failure rather than skipped.
+    HTML_HABIT_NAME = "ZzHtmlListed-Q9"
+    rc = request("POST", "/api/habits", {"name": HTML_HABIT_NAME})
+    html_habit_ok = rc.status == 201
     r = request("GET", "/", accept="text/html")
     check("GET / -> 200", r.status == 200, f"got {r.status}")
+    html_ok = r.status == 200 and "text/html" in r.content_type().lower()
     check(
         "GET / is text/html",
         "text/html" in r.content_type().lower(),
         f"content-type={r.content_type()!r}",
+    )
+    body_text = r.body_bytes.decode("utf-8", "replace") if html_ok else ""
+    check(
+        "GET / HTML view lists a created habit",
+        html_habit_ok and html_ok and HTML_HABIT_NAME in body_text,
+        f"created={html_habit_ok}, html_ok={html_ok}, "
+        f"present={HTML_HABIT_NAME in body_text}",
     )
 
     # Denominator is intentionally fixed: every check above runs unconditionally

--- a/benchmarks/agentic-habit-tracker/acceptance/contract_test.py
+++ b/benchmarks/agentic-habit-tracker/acceptance/contract_test.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Visible acceptance tests for the habit-tracker benchmark.
+
+Framework-agnostic: talks to a running HTTP server over HTTP only, so the same
+file works against Autumn, Django, Rails, Spring Boot, Phoenix, Loco, ...
+
+Stdlib only (urllib/json/datetime/sys/os). No external dependencies.
+
+Usage:
+    BASE_URL=http://localhost:8080 python3 contract_test.py
+
+Exits non-zero if any check fails.
+"""
+
+import datetime
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:8080").rstrip("/")
+
+_PASSED = 0
+_FAILED = 0
+
+
+# ── HTTP helper ────────────────────────────────────────────────────────────────
+
+class Resp:
+    def __init__(self, status, headers, body_bytes):
+        self.status = status
+        self.headers = headers  # dict, lowercased keys
+        self.body_bytes = body_bytes
+
+    def json(self):
+        return json.loads(self.body_bytes.decode("utf-8"))
+
+    def content_type(self):
+        return self.headers.get("content-type", "")
+
+
+def request(method, path, body=None):
+    """Perform an HTTP request. `path` may be absolute or relative to BASE_URL."""
+    url = path if path.startswith("http") else BASE_URL + path
+    data = None
+    headers = {"Accept": "application/json"}
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            raw = r.read()
+            hdrs = {k.lower(): v for k, v in r.headers.items()}
+            return Resp(r.status, hdrs, raw)
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        hdrs = {k.lower(): v for k, v in e.headers.items()} if e.headers else {}
+        return Resp(e.code, hdrs, raw)
+
+
+# ── assertions ─────────────────────────────────────────────────────────────────
+
+def check(name, condition, detail=""):
+    global _PASSED, _FAILED
+    if condition:
+        _PASSED += 1
+        print(f"PASS  {name}")
+    else:
+        _FAILED += 1
+        suffix = f" -- {detail}" if detail else ""
+        print(f"FAIL  {name}{suffix}")
+
+
+def wait_for_server(timeout_s=30):
+    """Retry connecting until the server answers or the timeout elapses."""
+    deadline = time.time() + timeout_s
+    last = None
+    while time.time() < deadline:
+        try:
+            r = request("GET", "/api/habits")
+            if r.status < 500:
+                return True
+        except Exception as e:  # connection refused, etc.
+            last = e
+        time.sleep(0.5)
+    print(f"FAIL  server did not become ready within {timeout_s}s ({last})")
+    return False
+
+
+def iso(d):
+    return d.isoformat()
+
+
+# ── tests ──────────────────────────────────────────────────────────────────────
+
+def run():
+    if not wait_for_server():
+        print("RESULT: 0/1 passed")
+        sys.exit(1)
+
+    # create
+    r = request("POST", "/api/habits", {"name": "Read", "description": "20 pages"})
+    check("POST /api/habits -> 201", r.status == 201, f"got {r.status}")
+    habit = r.json() if r.status == 201 else {}
+    check("created habit has id", "id" in habit)
+    check("created habit echoes name", habit.get("name") == "Read")
+    check("created habit has created_at", "created_at" in habit)
+    hid = habit.get("id")
+
+    # validation: empty name
+    r = request("POST", "/api/habits", {"name": ""})
+    check("POST empty name -> 4xx", r.status in (400, 422), f"got {r.status}")
+
+    # validation: missing name
+    r = request("POST", "/api/habits", {"description": "no name"})
+    check("POST missing name -> 4xx", r.status in (400, 422), f"got {r.status}")
+
+    # list
+    r = request("GET", "/api/habits")
+    check("GET /api/habits -> 200", r.status == 200, f"got {r.status}")
+    listed = r.json() if r.status == 200 else None
+    check("GET /api/habits returns array", isinstance(listed, list))
+    check(
+        "created habit present in list",
+        isinstance(listed, list) and any(str(h.get("id")) == str(hid) for h in listed),
+    )
+
+    # get single
+    r = request("GET", f"/api/habits/{hid}")
+    check("GET /api/habits/{id} -> 200", r.status == 200, f"got {r.status}")
+    got = r.json() if r.status == 200 else {}
+    check("GET single has current_streak", "current_streak" in got)
+    check("GET single has history array", isinstance(got.get("history"), list))
+
+    # unknown id -> 404
+    r = request("GET", "/api/habits/999999999")
+    check("GET unknown id -> 404", r.status == 404, f"got {r.status}")
+
+    # update
+    r = request("PUT", f"/api/habits/{hid}", {"name": "Read more", "description": "30 pages"})
+    check("PUT /api/habits/{id} -> 200", r.status == 200, f"got {r.status}")
+    updated = r.json() if r.status == 200 else {}
+    check("PUT updates name", updated.get("name") == "Read more")
+
+    # complete today (default date)
+    r = request("POST", f"/api/habits/{hid}/complete", {})
+    check("POST complete (default date) -> 201", r.status == 201, f"got {r.status}")
+    comp = r.json() if r.status == 201 else {}
+    check("complete returns date", "date" in comp)
+    check("complete returns current_streak", "current_streak" in comp)
+
+    # duplicate same-day -> 409
+    r = request("POST", f"/api/habits/{hid}/complete", {"date": iso(datetime.date.today())})
+    check("POST duplicate same-day -> 409", r.status == 409, f"got {r.status}")
+
+    # invalid date -> 4xx
+    r = request("POST", f"/api/habits/{hid}/complete", {"date": "2026-13-40"})
+    check("POST invalid date -> 4xx", r.status in (400, 422), f"got {r.status}")
+
+    # complete on unknown habit -> 404
+    r = request("POST", "/api/habits/999999999/complete", {})
+    check("POST complete unknown habit -> 404", r.status == 404, f"got {r.status}")
+
+    # basic streak: 3 consecutive backdated days ending today
+    r = request("POST", "/api/habits", {"name": "Streaker"})
+    check("POST streak habit -> 201", r.status == 201, f"got {r.status}")
+    sid = r.json().get("id") if r.status == 201 else None
+    today = datetime.date.today()
+    for delta in (2, 1, 0):  # T-2, T-1, T
+        d = today - datetime.timedelta(days=delta)
+        rr = request("POST", f"/api/habits/{sid}/complete", {"date": iso(d)})
+        check(f"complete {iso(d)} -> 201", rr.status == 201, f"got {rr.status}")
+    r = request("GET", f"/api/habits/{sid}")
+    streak = r.json().get("current_streak") if r.status == 200 else None
+    check("streak of 3 consecutive days == 3", streak == 3, f"got {streak}")
+    hist = r.json().get("history") if r.status == 200 else None
+    expected_hist = [iso(today - datetime.timedelta(days=d)) for d in (0, 1, 2)]
+    check("history is 3 dates descending", hist == expected_hist, f"got {hist}")
+
+    # delete
+    r = request("DELETE", f"/api/habits/{hid}")
+    check("DELETE /api/habits/{id} -> 204", r.status == 204, f"got {r.status}")
+    r = request("GET", f"/api/habits/{hid}")
+    check("GET after delete -> 404", r.status == 404, f"got {r.status}")
+
+    # HTML view
+    r = request("GET", "/")
+    check("GET / -> 200", r.status == 200, f"got {r.status}")
+    check(
+        "GET / is text/html",
+        "text/html" in r.content_type().lower(),
+        f"content-type={r.content_type()!r}",
+    )
+
+    total = _PASSED + _FAILED
+    print(f"RESULT: {_PASSED}/{total} passed")
+    sys.exit(0 if _FAILED == 0 else 1)
+
+
+if __name__ == "__main__":
+    run()

--- a/benchmarks/agentic-habit-tracker/acceptance/contract_test.py
+++ b/benchmarks/agentic-habit-tracker/acceptance/contract_test.py
@@ -172,12 +172,25 @@ def run():
     r = request("POST", f"/api/habits/{deleted_id}/complete", {})
     check("POST complete unknown habit -> 404", r.status == 404, f"got {r.status}")
 
-    # basic streak: 3 consecutive backdated days ending today
+    # basic streak: 3 consecutive backdated days ending today. Anchor the dates
+    # to the SERVER's today, not the evaluator's local date: SPEC computes
+    # current_streak relative to the server clock, so a default completion tells
+    # us the server's D. Backdating relative to the evaluator's date would fail a
+    # correct server across a timezone / midnight-boundary skew.
     r = request("POST", "/api/habits", {"name": "Streaker"})
     check("POST streak habit -> 201", r.status == 201, f"got {r.status}")
     sid = r.json().get("id") if r.status == 201 else None
-    today = datetime.date.today()
-    for delta in (2, 1, 0):  # T-2, T-1, T
+    r0 = request("POST", f"/api/habits/{sid}/complete", {})  # default = server today
+    server_today = None
+    if r0.status == 201:
+        ds = (r0.json() or {}).get("date")
+        try:
+            server_today = datetime.date.fromisoformat(ds) if ds else None
+        except (ValueError, TypeError):
+            server_today = None
+    today = server_today or datetime.date.today()
+    check(f"complete {iso(today)} -> 201", r0.status == 201, f"got {r0.status}")
+    for delta in (1, 2):  # D-1, D-2 relative to the server's today
         d = today - datetime.timedelta(days=delta)
         rr = request("POST", f"/api/habits/{sid}/complete", {"date": iso(d)})
         check(f"complete {iso(d)} -> 201", rr.status == 201, f"got {rr.status}")
@@ -203,6 +216,9 @@ def run():
         f"content-type={r.content_type()!r}",
     )
 
+    # Denominator is intentionally fixed: every check above runs unconditionally
+    # (no setup-guard skips a dependent check), so a broken implementation is
+    # always charged the same total and pass rates stay comparable across runs.
     total = _PASSED + _FAILED
     print(f"RESULT: {_PASSED}/{total} passed")
     sys.exit(0 if _FAILED == 0 else 1)

--- a/benchmarks/agentic-habit-tracker/hidden/HIDDEN_TESTS.md
+++ b/benchmarks/agentic-habit-tracker/hidden/HIDDEN_TESTS.md
@@ -1,0 +1,42 @@
+# Hidden tests (overview)
+
+A hidden acceptance suite runs against the same HTTP contract as the visible
+tests. Its exact input values are intentionally not published here — this file
+only describes the *categories* it probes so implementers know what correctness
+means without being able to hard-code answers. All checks are computed relative
+to the server's current date and use **backdated** completions, so they are
+deterministic on any calendar day.
+
+The hidden suite probes:
+
+1. **Streak reset after a gap.** A run of consecutive completions that ends
+   before the current window does not count toward the current streak.
+
+2. **Staleness cutoff.** When the most recent completion is older than
+   yesterday, the current streak is zero — a streak is only "current" if it
+   reaches today or yesterday (see `SPEC.md` §3).
+
+3. **Out-of-order backdated completions.** Completions inserted in arbitrary
+   chronological order (e.g. today before earlier days) must still yield the
+   correct streak — the calculation depends on the set of completed dates, not
+   insertion order.
+
+4. **Duplicate prevention across explicit vs default date.** Completing with the
+   default (today) date and then again with an explicit date that resolves to
+   the same day (or vice versa) is a conflict.
+
+5. **"Yesterday counts."** A single completion on the day before today still
+   produces a current streak (it is within the current window).
+
+6. **Timezone / date-boundary correctness.** Dates are treated as whole calendar
+   days; the current-window logic is consistent around the today/yesterday
+   boundary.
+
+7. **Delete cascade.** Deleting a habit removes it and its completions; the
+   habit is subsequently not found.
+
+8. **Malformed-date validation.** Structurally invalid date strings are rejected
+   with a 4xx before any completion is recorded.
+
+These are enforced by `hidden_test.py`, which is not provided to the building
+agent during a trial.

--- a/benchmarks/agentic-habit-tracker/hidden/HIDDEN_TESTS.md
+++ b/benchmarks/agentic-habit-tracker/hidden/HIDDEN_TESTS.md
@@ -40,3 +40,12 @@ The hidden suite probes:
 
 These are enforced by `hidden_test.py`, which is not provided to the building
 agent during a trial.
+
+## Phase-2 hidden checks (archived habits)
+
+A separate hidden suite (`phase2/archive_hidden_test.py`) probes the phase-2
+archive feature, again without publishing exact values. At a high level it checks
+that a newly created habit defaults to active, that archiving is idempotent, that
+the archived-vs-active listings stay consistent, and that streak computation
+still works correctly for an archived habit. Like the phase-1 hidden suite it is
+not shown to the building agent during a trial.

--- a/benchmarks/agentic-habit-tracker/hidden/hidden_test.py
+++ b/benchmarks/agentic-habit-tracker/hidden/hidden_test.py
@@ -145,7 +145,8 @@ def run():
     if hid is not None:
         r = request("POST", f"/api/habits/{hid}/complete", {})  # default = today
         check("(c) default complete -> 201", r.status == 201, f"got {r.status}")
-        r = request("POST", f"/api/habits/{hid}/complete", {"date": day(0)})  # explicit today
+        completed_date = r.json().get("date") if r.status == 201 else day(0)
+        r = request("POST", f"/api/habits/{hid}/complete", {"date": completed_date})  # explicit today
         check("(c) explicit-today duplicate -> 409", r.status == 409, f"got {r.status}")
 
     # (d) yesterday only -> streak 1 (yesterday counts as current)

--- a/benchmarks/agentic-habit-tracker/hidden/hidden_test.py
+++ b/benchmarks/agentic-habit-tracker/hidden/hidden_test.py
@@ -73,6 +73,27 @@ def request(method, path, body=None):
         return Resp(e.code, hdrs, raw)
 
 
+# ── shape coercion ──────────────────────────────────────────────────────────────
+#
+# A candidate can answer an expected status with a syntactically VALID JSON body
+# of the wrong shape (a list where an object is expected, a scalar, or null).
+# Feeding that into ``.get(...)`` / indexing / iteration would raise and crash the
+# suite before it prints its RESULT line. These helpers coerce every parsed body
+# to the expected shape, so a wrong shape degrades into a failed ``check(...)``
+# rather than an exception. The happy path (correct shapes) is unaffected.
+
+def as_obj(r):
+    """Return the response body as a dict, or ``{}`` for any non-object shape."""
+    j = r.json()
+    return j if isinstance(j, dict) else {}
+
+
+def as_list(r):
+    """Return the response body as a list, or ``[]`` for any non-array shape."""
+    j = r.json()
+    return j if isinstance(j, list) else []
+
+
 def check(name, condition, detail=""):
     global _PASSED, _FAILED
     if condition:
@@ -108,7 +129,7 @@ def new_habit(name):
     r = request("POST", "/api/habits", {"name": name})
     if r.status != 201:
         return None
-    return (r.json() or {}).get("id")
+    return as_obj(r).get("id")
 
 
 def complete(hid, delta, expect=201, label=None):
@@ -124,7 +145,7 @@ def streak_of(hid):
     r = request("GET", f"/api/habits/{hid}")
     if r.status != 200:
         return None
-    return (r.json() or {}).get("current_streak")
+    return as_obj(r).get("current_streak")
 
 
 # ── tests ──────────────────────────────────────────────────────────────────────
@@ -143,7 +164,7 @@ def run():
     if probe is not None:
         r = request("POST", f"/api/habits/{probe}/complete", {})
         if r.status == 201:
-            ds = (r.json() or {}).get("date")
+            ds = as_obj(r).get("date")
             try:
                 if ds:
                     SERVER_TODAY = datetime.date.fromisoformat(ds)
@@ -183,7 +204,7 @@ def run():
         # DESCENDING date order (SPEC). Fetch the habit and compare its history
         # to the same dates sorted newest-first: [D, D-1, D-2].
         rb = request("GET", f"/api/habits/{hid}")
-        hist = (rb.json() or {}).get("history") if rb.status == 200 else None
+        hist = as_obj(rb).get("history") if rb.status == 200 else None
         expected_desc = [day(0), day(1), day(2)]
         check("(b) history in descending date order after out-of-order inserts",
               hist == expected_desc, f"got {hist}")
@@ -201,7 +222,7 @@ def run():
     if hid is not None:
         r = request("POST", f"/api/habits/{hid}/complete", {})  # default = today
         check("(c) default complete -> 201", r.status == 201, f"got {r.status}")
-        completed_date = (r.json() or {}).get("date") if r.status == 201 else day(0)
+        completed_date = as_obj(r).get("date") if r.status == 201 else day(0)
         r = request("POST", f"/api/habits/{hid}/complete", {"date": completed_date})  # explicit today
         check("(c) explicit-today duplicate -> 409", r.status == 409, f"got {r.status}")
     else:

--- a/benchmarks/agentic-habit-tracker/hidden/hidden_test.py
+++ b/benchmarks/agentic-habit-tracker/hidden/hidden_test.py
@@ -169,10 +169,20 @@ def run():
         complete(hid, 1)   # then D-1
         s = streak_of(hid)
         check("(b) out-of-order backdated completions -> streak 3", s == 3, f"got {s}")
+        # Regardless of insertion order, history must come back in strictly
+        # DESCENDING date order (SPEC). Fetch the habit and compare its history
+        # to the same dates sorted newest-first: [D, D-1, D-2].
+        rb = request("GET", f"/api/habits/{hid}")
+        hist = rb.json().get("history") if rb.status == 200 else None
+        expected_desc = [day(0), day(1), day(2)]
+        check("(b) history in descending date order after out-of-order inserts",
+              hist == expected_desc, f"got {hist}")
     else:
         for delta in (0, 2, 1):
             check(f"complete D-{delta} ({day(delta)}) -> 201", False, "setup failed: no habit id")
         check("(b) out-of-order backdated completions -> streak 3", False,
+              "setup failed: no habit id")
+        check("(b) history in descending date order after out-of-order inserts", False,
               "setup failed: no habit id")
 
     # (c) duplicate via explicit today's date after default-complete -> 409

--- a/benchmarks/agentic-habit-tracker/hidden/hidden_test.py
+++ b/benchmarks/agentic-habit-tracker/hidden/hidden_test.py
@@ -41,7 +41,17 @@ class Resp:
         self.body_bytes = body_bytes
 
     def json(self):
-        return json.loads(self.body_bytes.decode("utf-8"))
+        """Parse the body as JSON, returning None on any decode failure.
+
+        A candidate can answer an otherwise-expected status with an empty or
+        HTML body; raising here would crash the suite before it prints its
+        RESULT line. Returning None lets callers fold a non-JSON body into a
+        recorded check failure (they treat it as ``{}``).
+        """
+        try:
+            return json.loads(self.body_bytes.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            return None
 
 
 def request(method, path, body=None):
@@ -98,7 +108,7 @@ def new_habit(name):
     r = request("POST", "/api/habits", {"name": name})
     if r.status != 201:
         return None
-    return r.json().get("id")
+    return (r.json() or {}).get("id")
 
 
 def complete(hid, delta, expect=201, label=None):
@@ -114,7 +124,7 @@ def streak_of(hid):
     r = request("GET", f"/api/habits/{hid}")
     if r.status != 200:
         return None
-    return r.json().get("current_streak")
+    return (r.json() or {}).get("current_streak")
 
 
 # ── tests ──────────────────────────────────────────────────────────────────────
@@ -173,7 +183,7 @@ def run():
         # DESCENDING date order (SPEC). Fetch the habit and compare its history
         # to the same dates sorted newest-first: [D, D-1, D-2].
         rb = request("GET", f"/api/habits/{hid}")
-        hist = rb.json().get("history") if rb.status == 200 else None
+        hist = (rb.json() or {}).get("history") if rb.status == 200 else None
         expected_desc = [day(0), day(1), day(2)]
         check("(b) history in descending date order after out-of-order inserts",
               hist == expected_desc, f"got {hist}")
@@ -191,7 +201,7 @@ def run():
     if hid is not None:
         r = request("POST", f"/api/habits/{hid}/complete", {})  # default = today
         check("(c) default complete -> 201", r.status == 201, f"got {r.status}")
-        completed_date = r.json().get("date") if r.status == 201 else day(0)
+        completed_date = (r.json() or {}).get("date") if r.status == 201 else day(0)
         r = request("POST", f"/api/habits/{hid}/complete", {"date": completed_date})  # explicit today
         check("(c) explicit-today duplicate -> 409", r.status == 409, f"got {r.status}")
     else:

--- a/benchmarks/agentic-habit-tracker/hidden/hidden_test.py
+++ b/benchmarks/agentic-habit-tracker/hidden/hidden_test.py
@@ -21,7 +21,12 @@ import urllib.error
 import urllib.request
 
 BASE_URL = os.environ.get("BASE_URL", "http://localhost:8080").rstrip("/")
-TODAY = datetime.date.today()
+# SERVER_TODAY anchors every backdated streak date to the SERVER's clock rather
+# than the evaluator's local date. It is established at runtime (see run()) by
+# POSTing a default completion and reading the returned date, so a correct
+# server is not failed by a timezone / midnight-boundary skew. The module-level
+# value is only a fallback used before the probe runs.
+SERVER_TODAY = datetime.date.today()
 
 _PASSED = 0
 _FAILED = 0
@@ -85,8 +90,8 @@ def wait_for_server(timeout_s=30):
 
 
 def day(delta):
-    """ISO date string for TODAY - delta days."""
-    return (TODAY - datetime.timedelta(days=delta)).isoformat()
+    """ISO date string for the SERVER's today - delta days."""
+    return (SERVER_TODAY - datetime.timedelta(days=delta)).isoformat()
 
 
 def new_habit(name):
@@ -119,6 +124,27 @@ def run():
         print("RESULT: 0/1 passed")
         sys.exit(1)
 
+    # Establish the SERVER's today from a default completion (no date) so every
+    # backdated streak date below is anchored to the server clock. This probe
+    # habit is isolated from the scenarios and adds no checks, so the denominator
+    # is unchanged.
+    global SERVER_TODAY
+    probe = new_habit("_server-date-probe")
+    if probe is not None:
+        r = request("POST", f"/api/habits/{probe}/complete", {})
+        if r.status == 201:
+            ds = (r.json() or {}).get("date")
+            try:
+                if ds:
+                    SERVER_TODAY = datetime.date.fromisoformat(ds)
+            except (ValueError, TypeError):
+                pass
+
+    # Denominator is intentionally fixed: each scenario contributes a constant
+    # number of checks. When a setup step (habit creation) fails, the dependent
+    # checks are recorded as explicit failures below instead of being skipped,
+    # so a broken implementation can never shrink the total.
+
     # (a) gap before today: complete D-4, D-3, D-2; skip D-1 and today -> streak 0
     hid = new_habit("a-gap")
     check("(a) create habit", hid is not None)
@@ -128,6 +154,11 @@ def run():
         complete(hid, 2)
         s = streak_of(hid)
         check("(a) streak 0 when last completion older than yesterday", s == 0, f"got {s}")
+    else:
+        for delta in (4, 3, 2):
+            check(f"complete D-{delta} ({day(delta)}) -> 201", False, "setup failed: no habit id")
+        check("(a) streak 0 when last completion older than yesterday", False,
+              "setup failed: no habit id")
 
     # (b) out-of-order insertion: today, then D-2, then D-1 -> streak 3
     hid = new_habit("b-unordered")
@@ -138,6 +169,11 @@ def run():
         complete(hid, 1)   # then D-1
         s = streak_of(hid)
         check("(b) out-of-order backdated completions -> streak 3", s == 3, f"got {s}")
+    else:
+        for delta in (0, 2, 1):
+            check(f"complete D-{delta} ({day(delta)}) -> 201", False, "setup failed: no habit id")
+        check("(b) out-of-order backdated completions -> streak 3", False,
+              "setup failed: no habit id")
 
     # (c) duplicate via explicit today's date after default-complete -> 409
     hid = new_habit("c-dup")
@@ -148,6 +184,9 @@ def run():
         completed_date = r.json().get("date") if r.status == 201 else day(0)
         r = request("POST", f"/api/habits/{hid}/complete", {"date": completed_date})  # explicit today
         check("(c) explicit-today duplicate -> 409", r.status == 409, f"got {r.status}")
+    else:
+        check("(c) default complete -> 201", False, "setup failed: no habit id")
+        check("(c) explicit-today duplicate -> 409", False, "setup failed: no habit id")
 
     # (d) yesterday only -> streak 1 (yesterday counts as current)
     hid = new_habit("d-yesterday")
@@ -156,6 +195,9 @@ def run():
         complete(hid, 1)
         s = streak_of(hid)
         check("(d) yesterday-only -> streak 1", s == 1, f"got {s}")
+    else:
+        check(f"complete D-1 ({day(1)}) -> 201", False, "setup failed: no habit id")
+        check("(d) yesterday-only -> streak 1", False, "setup failed: no habit id")
 
     # (e) D-3 only -> streak 0 (too old to be current)
     hid = new_habit("e-old")
@@ -164,6 +206,9 @@ def run():
         complete(hid, 3)
         s = streak_of(hid)
         check("(e) D-3-only -> streak 0", s == 0, f"got {s}")
+    else:
+        check(f"complete D-3 ({day(3)}) -> 201", False, "setup failed: no habit id")
+        check("(e) D-3-only -> streak 0", False, "setup failed: no habit id")
 
     # (f) malformed date -> 4xx
     hid = new_habit("f-baddate")
@@ -171,6 +216,8 @@ def run():
     if hid is not None:
         r = request("POST", f"/api/habits/{hid}/complete", {"date": "2026-13-40"})
         check("(f) malformed date -> 4xx", r.status in (400, 422), f"got {r.status}")
+    else:
+        check("(f) malformed date -> 4xx", False, "setup failed: no habit id")
 
     # (g) after DELETE, GET -> 404 (and completions gone with it)
     hid = new_habit("g-delete")
@@ -181,6 +228,10 @@ def run():
         check("(g) DELETE -> 204", r.status == 204, f"got {r.status}")
         r = request("GET", f"/api/habits/{hid}")
         check("(g) GET after delete -> 404", r.status == 404, f"got {r.status}")
+    else:
+        check(f"complete D-0 ({day(0)}) -> 201", False, "setup failed: no habit id")
+        check("(g) DELETE -> 204", False, "setup failed: no habit id")
+        check("(g) GET after delete -> 404", False, "setup failed: no habit id")
 
     total = _PASSED + _FAILED
     print(f"RESULT: {_PASSED}/{total} passed")

--- a/benchmarks/agentic-habit-tracker/hidden/hidden_test.py
+++ b/benchmarks/agentic-habit-tracker/hidden/hidden_test.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Hidden acceptance tests for the habit-tracker benchmark.
+
+Not shown to the building agent. Same framework-agnostic shape as
+acceptance/contract_test.py: HTTP-only, stdlib only, BASE_URL from env.
+
+Probes streak edge cases with concrete backdated dates computed relative to
+today, so results are deterministic regardless of the calendar day the trial is
+run.
+
+Usage:
+    BASE_URL=http://localhost:8080 python3 hidden_test.py
+"""
+
+import datetime
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:8080").rstrip("/")
+TODAY = datetime.date.today()
+
+_PASSED = 0
+_FAILED = 0
+
+
+# ── HTTP helper ────────────────────────────────────────────────────────────────
+
+class Resp:
+    def __init__(self, status, headers, body_bytes):
+        self.status = status
+        self.headers = headers
+        self.body_bytes = body_bytes
+
+    def json(self):
+        return json.loads(self.body_bytes.decode("utf-8"))
+
+
+def request(method, path, body=None):
+    url = path if path.startswith("http") else BASE_URL + path
+    data = None
+    headers = {"Accept": "application/json"}
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            raw = r.read()
+            hdrs = {k.lower(): v for k, v in r.headers.items()}
+            return Resp(r.status, hdrs, raw)
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        hdrs = {k.lower(): v for k, v in e.headers.items()} if e.headers else {}
+        return Resp(e.code, hdrs, raw)
+
+
+def check(name, condition, detail=""):
+    global _PASSED, _FAILED
+    if condition:
+        _PASSED += 1
+        print(f"PASS  {name}")
+    else:
+        _FAILED += 1
+        suffix = f" -- {detail}" if detail else ""
+        print(f"FAIL  {name}{suffix}")
+
+
+def wait_for_server(timeout_s=30):
+    deadline = time.time() + timeout_s
+    last = None
+    while time.time() < deadline:
+        try:
+            r = request("GET", "/api/habits")
+            if r.status < 500:
+                return True
+        except Exception as e:
+            last = e
+        time.sleep(0.5)
+    print(f"FAIL  server did not become ready within {timeout_s}s ({last})")
+    return False
+
+
+def day(delta):
+    """ISO date string for TODAY - delta days."""
+    return (TODAY - datetime.timedelta(days=delta)).isoformat()
+
+
+def new_habit(name):
+    r = request("POST", "/api/habits", {"name": name})
+    if r.status != 201:
+        return None
+    return r.json().get("id")
+
+
+def complete(hid, delta, expect=201, label=None):
+    """Backdate a completion TODAY-delta days; assert the status."""
+    d = day(delta)
+    r = request("POST", f"/api/habits/{hid}/complete", {"date": d})
+    lbl = label or f"complete D-{delta} ({d})"
+    check(f"{lbl} -> {expect}", r.status == expect, f"got {r.status}")
+    return r
+
+
+def streak_of(hid):
+    r = request("GET", f"/api/habits/{hid}")
+    if r.status != 200:
+        return None
+    return r.json().get("current_streak")
+
+
+# ── tests ──────────────────────────────────────────────────────────────────────
+
+def run():
+    if not wait_for_server():
+        print("RESULT: 0/1 passed")
+        sys.exit(1)
+
+    # (a) gap before today: complete D-4, D-3, D-2; skip D-1 and today -> streak 0
+    hid = new_habit("a-gap")
+    check("(a) create habit", hid is not None)
+    if hid is not None:
+        complete(hid, 4)
+        complete(hid, 3)
+        complete(hid, 2)
+        s = streak_of(hid)
+        check("(a) streak 0 when last completion older than yesterday", s == 0, f"got {s}")
+
+    # (b) out-of-order insertion: today, then D-2, then D-1 -> streak 3
+    hid = new_habit("b-unordered")
+    check("(b) create habit", hid is not None)
+    if hid is not None:
+        complete(hid, 0)   # insert today first
+        complete(hid, 2)   # then D-2
+        complete(hid, 1)   # then D-1
+        s = streak_of(hid)
+        check("(b) out-of-order backdated completions -> streak 3", s == 3, f"got {s}")
+
+    # (c) duplicate via explicit today's date after default-complete -> 409
+    hid = new_habit("c-dup")
+    check("(c) create habit", hid is not None)
+    if hid is not None:
+        r = request("POST", f"/api/habits/{hid}/complete", {})  # default = today
+        check("(c) default complete -> 201", r.status == 201, f"got {r.status}")
+        r = request("POST", f"/api/habits/{hid}/complete", {"date": day(0)})  # explicit today
+        check("(c) explicit-today duplicate -> 409", r.status == 409, f"got {r.status}")
+
+    # (d) yesterday only -> streak 1 (yesterday counts as current)
+    hid = new_habit("d-yesterday")
+    check("(d) create habit", hid is not None)
+    if hid is not None:
+        complete(hid, 1)
+        s = streak_of(hid)
+        check("(d) yesterday-only -> streak 1", s == 1, f"got {s}")
+
+    # (e) D-3 only -> streak 0 (too old to be current)
+    hid = new_habit("e-old")
+    check("(e) create habit", hid is not None)
+    if hid is not None:
+        complete(hid, 3)
+        s = streak_of(hid)
+        check("(e) D-3-only -> streak 0", s == 0, f"got {s}")
+
+    # (f) malformed date -> 4xx
+    hid = new_habit("f-baddate")
+    check("(f) create habit", hid is not None)
+    if hid is not None:
+        r = request("POST", f"/api/habits/{hid}/complete", {"date": "2026-13-40"})
+        check("(f) malformed date -> 4xx", r.status in (400, 422), f"got {r.status}")
+
+    # (g) after DELETE, GET -> 404 (and completions gone with it)
+    hid = new_habit("g-delete")
+    check("(g) create habit", hid is not None)
+    if hid is not None:
+        complete(hid, 0)
+        r = request("DELETE", f"/api/habits/{hid}")
+        check("(g) DELETE -> 204", r.status == 204, f"got {r.status}")
+        r = request("GET", f"/api/habits/{hid}")
+        check("(g) GET after delete -> 404", r.status == 404, f"got {r.status}")
+
+    total = _PASSED + _FAILED
+    print(f"RESULT: {_PASSED}/{total} passed")
+    sys.exit(0 if _FAILED == 0 else 1)
+
+
+if __name__ == "__main__":
+    run()

--- a/benchmarks/agentic-habit-tracker/metrics-schema.json
+++ b/benchmarks/agentic-habit-tracker/metrics-schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Habit-tracker benchmark per-run metrics",
+  "description": "Informal schema for runs/<run-id>/metrics.json. One file per trial (framework x phase). Consumed by scripts/score.py.",
+  "type": "object",
+  "required": [
+    "framework",
+    "prompt_version",
+    "phase",
+    "wall_clock_seconds",
+    "agent_tool_calls",
+    "visible_checks_passed",
+    "visible_checks_total",
+    "hidden_checks_passed",
+    "hidden_checks_total",
+    "generated_loc",
+    "has_tests"
+  ],
+  "properties": {
+    "framework": {
+      "type": "string",
+      "description": "Framework under test.",
+      "examples": ["autumn", "django", "rails", "springboot", "phoenix", "loco"]
+    },
+    "prompt_version": {
+      "type": "string",
+      "description": "Prompt-Version header from the prompt used.",
+      "examples": ["v1"]
+    },
+    "phase": {
+      "type": "integer",
+      "enum": [1, 2],
+      "description": "1 = greenfield build, 2 = archived-habits maintenance change."
+    },
+    "wall_clock_seconds": {
+      "type": "number",
+      "description": "Seconds from agent start to first green (visible tests all pass). Measured during the trial, not by score.py."
+    },
+    "agent_tool_calls": {
+      "type": "integer",
+      "description": "Total agent tool calls made to reach first green."
+    },
+    "agent_turns": {
+      "type": "integer",
+      "description": "Number of agent conversation turns (assistant messages) in the trial."
+    },
+    "failed_test_runs": {
+      "type": "integer",
+      "description": "How many times the acceptance suite was run and failed before first green."
+    },
+    "human_interventions": {
+      "type": "integer",
+      "description": "Count of manual nudges/corrections a human gave the agent. 0 for a clean autonomous run."
+    },
+    "generated_loc": {
+      "type": "integer",
+      "description": "Lines of application source the agent generated. Exclude vendored deps and lockfiles."
+    },
+    "visible_checks_passed": {
+      "type": "integer",
+      "description": "Passing checks from acceptance/contract_test.py (the X in its RESULT line)."
+    },
+    "visible_checks_total": {
+      "type": "integer",
+      "description": "Total checks from acceptance/contract_test.py (the Y in its RESULT line)."
+    },
+    "hidden_checks_passed": {
+      "type": "integer",
+      "description": "Passing checks from hidden/hidden_test.py."
+    },
+    "hidden_checks_total": {
+      "type": "integer",
+      "description": "Total checks from hidden/hidden_test.py."
+    },
+    "has_tests": {
+      "type": "boolean",
+      "description": "Did the agent ship automated tests for core behavior?"
+    },
+    "readme_quality": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 3,
+      "description": "Manual 0-3: quality/accuracy/sufficiency of run instructions."
+    },
+    "uses_conventions": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 3,
+      "description": "Manual 0-3: how idiomatically the code uses the framework's conventions."
+    },
+    "notes": {
+      "type": "string",
+      "description": "Free-form reviewer notes about the run."
+    }
+  },
+  "example": {
+    "framework": "autumn",
+    "prompt_version": "v1",
+    "phase": 1,
+    "wall_clock_seconds": 640.5,
+    "agent_tool_calls": 58,
+    "agent_turns": 22,
+    "failed_test_runs": 2,
+    "human_interventions": 0,
+    "generated_loc": 430,
+    "visible_checks_passed": 30,
+    "visible_checks_total": 30,
+    "hidden_checks_passed": 25,
+    "hidden_checks_total": 25,
+    "has_tests": true,
+    "readme_quality": 2,
+    "uses_conventions": 3,
+    "notes": "Copied examples/todo-app as a base; clean run."
+  }
+}

--- a/benchmarks/agentic-habit-tracker/metrics-schema.json
+++ b/benchmarks/agentic-habit-tracker/metrics-schema.json
@@ -58,19 +58,19 @@
     },
     "visible_checks_passed": {
       "type": "integer",
-      "description": "Passing checks from acceptance/contract_test.py (the X in its RESULT line)."
+      "description": "Passing checks (the X in the RESULT line) from the visible suite: phase 1 — acceptance/contract_test.py; phase 2 — phase2/archive_test.py."
     },
     "visible_checks_total": {
       "type": "integer",
-      "description": "Total checks from acceptance/contract_test.py (the Y in its RESULT line)."
+      "description": "Total checks (the Y in the RESULT line) from the visible suite: phase 1 — acceptance/contract_test.py; phase 2 — phase2/archive_test.py."
     },
     "hidden_checks_passed": {
       "type": "integer",
-      "description": "Passing checks from hidden/hidden_test.py."
+      "description": "Passing checks from the hidden suite: phase 1 — hidden/hidden_test.py; phase 2 — phase2/archive_hidden_test.py."
     },
     "hidden_checks_total": {
       "type": "integer",
-      "description": "Total checks from hidden/hidden_test.py."
+      "description": "Total checks from the hidden suite: phase 1 — hidden/hidden_test.py; phase 2 — phase2/archive_hidden_test.py."
     },
     "has_tests": {
       "type": "boolean",

--- a/benchmarks/agentic-habit-tracker/phase2/archive_hidden_test.py
+++ b/benchmarks/agentic-habit-tracker/phase2/archive_hidden_test.py
@@ -117,6 +117,12 @@ def run():
         print("RESULT: 0/1 passed")
         sys.exit(1)
 
+    # Denominator is intentionally fixed at 16: each scenario contributes a
+    # constant number of checks. When a setup step (habit creation or the
+    # default completion) fails, the dependent checks are recorded as explicit
+    # failures instead of being skipped, so a broken implementation can never
+    # shrink the total and inflate its pass rate.
+
     # (a) default-active: a newly created habit is active — present in the default
     #     list and absent from ?archived=true.
     _, active_hid = new_habit("h-default-active")
@@ -126,6 +132,9 @@ def run():
               contains(id_list("/api/habits"), active_hid))
         check("(a) new habit absent from ?archived=true",
               not contains(id_list("/api/habits?archived=true"), active_hid))
+    else:
+        check("(a) new habit present in default list", False, "setup failed: no habit id")
+        check("(a) new habit absent from ?archived=true", False, "setup failed: no habit id")
 
     # (b) archive idempotency: POST archive twice -> both 200/204; H appears
     #     exactly once in ?archived=true and never in the default list.
@@ -143,6 +152,12 @@ def run():
               f"count={count}")
         check("(b) archived habit never in default list",
               not contains(id_list("/api/habits"), hid))
+    else:
+        check("(b) first archive -> 200/204", False, "setup failed: no habit id")
+        check("(b) second archive (idempotent) -> 200/204", False, "setup failed: no habit id")
+        check("(b) archived habit appears exactly once in ?archived=true", False,
+              "setup failed: no habit id")
+        check("(b) archived habit never in default list", False, "setup failed: no habit id")
 
     # (c) explicit ?archived=false mirrors the default (active only). SPEC §4 says
     #     this param MAY be treated the same as no query, so explicit support is
@@ -160,6 +175,11 @@ def run():
         else:
             check("(c) ?archived=false optional param handled without server error",
                   r.status < 500, f"got {r.status}")
+    else:
+        # This scenario always contributes exactly one check; record it as a
+        # failure when the active/archived witnesses were never created.
+        check("(c) ?archived=false returns only active habits", False,
+              "setup failed: missing active or archived witness")
 
     # (d) an archived habit still computes its streak correctly. Complete today
     #     (default date, so we use the server-returned date) and yesterday, then
@@ -187,6 +207,27 @@ def run():
             check("(d) archived habit history contains both completed dates",
                   today_str in hist and yesterday_str in hist,
                   f"history={hist}")
+        else:
+            # No server date to anchor the backdated day: record the five
+            # server-date-dependent checks as failures to keep the total fixed.
+            for label in (
+                "(d) complete yesterday (backdated) -> 201",
+                "(d) archive habit -> 200/204",
+                "(d) GET archived habit -> 200",
+                "(d) archived habit current_streak == 2",
+                "(d) archived habit history contains both completed dates",
+            ):
+                check(label, False, "setup failed: no server date")
+    else:
+        for label in (
+            "(d) complete today (default) -> 201",
+            "(d) complete yesterday (backdated) -> 201",
+            "(d) archive habit -> 200/204",
+            "(d) GET archived habit -> 200",
+            "(d) archived habit current_streak == 2",
+            "(d) archived habit history contains both completed dates",
+        ):
+            check(label, False, "setup failed: no habit id")
 
     total = _PASSED + _FAILED
     print(f"RESULT: {_PASSED}/{total} passed")

--- a/benchmarks/agentic-habit-tracker/phase2/archive_hidden_test.py
+++ b/benchmarks/agentic-habit-tracker/phase2/archive_hidden_test.py
@@ -98,11 +98,32 @@ def wait_for_server(timeout_s=30):
     return False
 
 
+# ── shape coercion ──────────────────────────────────────────────────────────────
+#
+# A candidate can answer an expected status with a syntactically VALID JSON body
+# of the wrong shape (a list where an object is expected, a scalar, or null).
+# Feeding that into ``.get(...)`` / indexing / iteration would raise and crash the
+# suite before it prints its RESULT line. These helpers coerce every parsed body
+# to the expected shape, so a wrong shape degrades into a failed ``check(...)``
+# rather than an exception. The happy path (correct shapes) is unaffected.
+
+def as_obj(r):
+    """Return the response body as a dict, or ``{}`` for any non-object shape."""
+    j = r.json()
+    return j if isinstance(j, dict) else {}
+
+
+def as_list(r):
+    """Return the response body as a list, or ``[]`` for any non-array shape."""
+    j = r.json()
+    return j if isinstance(j, list) else []
+
+
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 def new_habit(name):
     r = request("POST", "/api/habits", {"name": name})
-    return r, ((r.json() or {}).get("id") if r.status == 201 else None)
+    return r, (as_obj(r).get("id") if r.status == 201 else None)
 
 
 def id_list(path):
@@ -113,7 +134,35 @@ def id_list(path):
     body = r.json()
     if not isinstance(body, list):
         return None
-    return [str(h.get("id")) for h in body]
+    return [str(h.get("id")) for h in body if isinstance(h, dict)]
+
+
+def list_objs(path):
+    """GET a listing and return its list of dict objects (or None on error).
+
+    Preserves the full objects so callers can assert on per-object fields (the
+    phase-2 ``archived`` boolean). None on a non-200 status or non-array body.
+    """
+    r = request("GET", path)
+    if r.status != 200:
+        return None
+    body = r.json()
+    if not isinstance(body, list):
+        return None
+    return body
+
+
+def all_archived_is(objs, expected):
+    """True iff ``objs`` is a non-empty list whose every element is a dict that
+    carries ``archived`` as the bool ``expected`` (present, correct type, correct
+    value). Fail-closed on None, empty list, non-dict element, or a missing /
+    non-bool / wrong-valued ``archived`` (``is expected`` rejects e.g. ``1``)."""
+    if not isinstance(objs, list) or not objs:
+        return False
+    for h in objs:
+        if not isinstance(h, dict) or h.get("archived") is not expected:
+            return False
+    return True
 
 
 def contains(ids, hid):
@@ -127,7 +176,7 @@ def run():
         print("RESULT: 0/1 passed")
         sys.exit(1)
 
-    # Denominator is intentionally fixed at 16: each scenario contributes a
+    # Denominator is intentionally fixed at 18: each scenario contributes a
     # constant number of checks. When a setup step (habit creation or the
     # default completion) fails, the dependent checks are recorded as explicit
     # failures instead of being skipped, so a broken implementation can never
@@ -142,9 +191,17 @@ def run():
               contains(id_list("/api/habits"), active_hid))
         check("(a) new habit absent from ?archived=true",
               not contains(id_list("/api/habits?archived=true"), active_hid))
+        # The default list is active-only, so every OBJECT it returns must carry
+        # archived == false. The id-only checks above can't catch an impl that
+        # omits `archived` from list objects; assert on the full objects here.
+        # Fail-closed (None / empty / non-dict element / missing / wrong value).
+        check("(a) every habit in default list carries archived == false",
+              all_archived_is(list_objs("/api/habits"), False))
     else:
         check("(a) new habit present in default list", False, "setup failed: no habit id")
         check("(a) new habit absent from ?archived=true", False, "setup failed: no habit id")
+        check("(a) every habit in default list carries archived == false", False,
+              "setup failed: no habit id")
 
     # (b) archive idempotency: POST archive twice -> both 200/204; H appears
     #     exactly once in ?archived=true and never in the default list.
@@ -162,12 +219,19 @@ def run():
               f"count={count}")
         check("(b) archived habit never in default list",
               not contains(id_list("/api/habits"), hid))
+        # H is archived, so the ?archived=true list is non-empty and every OBJECT
+        # it returns must carry archived == true (present, bool, correct value).
+        # Fail-closed mirror of the (a) default-list object check.
+        check("(b) every habit in ?archived=true list carries archived == true",
+              all_archived_is(list_objs("/api/habits?archived=true"), True))
     else:
         check("(b) first archive -> 200/204", False, "setup failed: no habit id")
         check("(b) second archive (idempotent) -> 200/204", False, "setup failed: no habit id")
         check("(b) archived habit appears exactly once in ?archived=true", False,
               "setup failed: no habit id")
         check("(b) archived habit never in default list", False, "setup failed: no habit id")
+        check("(b) every habit in ?archived=true list carries archived == true", False,
+              "setup failed: no habit id")
 
     # (c) explicit ?archived=false mirrors the default (active only). SPEC §4 says
     #     this param MAY be treated the same as no query, so explicit support is
@@ -178,7 +242,7 @@ def run():
     if active_hid is not None and hid is not None:
         r = request("GET", "/api/habits?archived=false")
         if r.status == 200 and isinstance(r.json(), list):
-            ids = [str(h.get("id")) for h in r.json()]
+            ids = [str(h.get("id")) for h in as_list(r) if isinstance(h, dict)]
             ok = str(active_hid) in ids and str(hid) not in ids
             check("(c) ?archived=false returns only active habits", ok,
                   f"active_present={str(active_hid) in ids}, archived_present={str(hid) in ids}")
@@ -199,7 +263,7 @@ def run():
     if h2 is not None:
         rc = request("POST", f"/api/habits/{h2}/complete", {})  # default = today
         check("(d) complete today (default) -> 201", rc.status == 201, f"got {rc.status}")
-        today_str = (rc.json() or {}).get("date") if rc.status == 201 else None
+        today_str = as_obj(rc).get("date") if rc.status == 201 else None
         # Guard the server-date parse (mirror acceptance/contract_test.py): a
         # candidate can return 201 with a non-ISO `date`, and an unguarded
         # datetime.date.fromisoformat would raise ValueError and crash the suite
@@ -222,7 +286,7 @@ def run():
             check("(d) archive habit -> 200/204", ra.status in (200, 204), f"got {ra.status}")
             r = request("GET", f"/api/habits/{h2}")
             check("(d) GET archived habit -> 200", r.status == 200, f"got {r.status}")
-            got = (r.json() or {}) if r.status == 200 else {}
+            got = as_obj(r) if r.status == 200 else {}
             check("(d) archived habit current_streak == 2", got.get("current_streak") == 2,
                   f"got {got.get('current_streak')}")
             hist = got.get("history") if isinstance(got.get("history"), list) else []

--- a/benchmarks/agentic-habit-tracker/phase2/archive_hidden_test.py
+++ b/benchmarks/agentic-habit-tracker/phase2/archive_hidden_test.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Hidden Phase-2 acceptance tests for the habit-tracker benchmark.
+
+Not shown to the building agent. Same framework-agnostic shape as
+acceptance/contract_test.py and hidden/hidden_test.py: HTTP-only, stdlib only,
+BASE_URL from env. Probes the archive edge cases (SPEC.md §4,
+prompts/phase2_maintenance.md): default-active, archive idempotency, the
+optional explicit `?archived=false` filter, and streak correctness for an
+archived habit. Dates are computed relative to the server's returned date so
+results are deterministic on any calendar day.
+
+Stdlib only (urllib/json/datetime/sys/os/time). No external dependencies.
+
+Usage:
+    BASE_URL=http://localhost:8080 python3 archive_hidden_test.py
+
+Exits non-zero if any check fails.
+"""
+
+import datetime
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:8080").rstrip("/")
+
+_PASSED = 0
+_FAILED = 0
+
+
+# ── HTTP helper ────────────────────────────────────────────────────────────────
+
+class Resp:
+    def __init__(self, status, headers, body_bytes):
+        self.status = status
+        self.headers = headers
+        self.body_bytes = body_bytes
+
+    def json(self):
+        return json.loads(self.body_bytes.decode("utf-8"))
+
+
+def request(method, path, body=None):
+    url = path if path.startswith("http") else BASE_URL + path
+    data = None
+    headers = {"Accept": "application/json"}
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            raw = r.read()
+            hdrs = {k.lower(): v for k, v in r.headers.items()}
+            return Resp(r.status, hdrs, raw)
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        hdrs = {k.lower(): v for k, v in e.headers.items()} if e.headers else {}
+        return Resp(e.code, hdrs, raw)
+
+
+def check(name, condition, detail=""):
+    global _PASSED, _FAILED
+    if condition:
+        _PASSED += 1
+        print(f"PASS  {name}")
+    else:
+        _FAILED += 1
+        suffix = f" -- {detail}" if detail else ""
+        print(f"FAIL  {name}{suffix}")
+
+
+def wait_for_server(timeout_s=30):
+    deadline = time.time() + timeout_s
+    last = None
+    while time.time() < deadline:
+        try:
+            r = request("GET", "/api/habits")
+            if r.status < 500:
+                return True
+        except Exception as e:
+            last = e
+        time.sleep(0.5)
+    print(f"FAIL  server did not become ready within {timeout_s}s ({last})")
+    return False
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def new_habit(name):
+    r = request("POST", "/api/habits", {"name": name})
+    return r, (r.json().get("id") if r.status == 201 else None)
+
+
+def id_list(path):
+    """GET a listing and return the list of stringified ids (preserving dups), or None."""
+    r = request("GET", path)
+    if r.status != 200:
+        return None
+    body = r.json()
+    if not isinstance(body, list):
+        return None
+    return [str(h.get("id")) for h in body]
+
+
+def contains(ids, hid):
+    return ids is not None and str(hid) in ids
+
+
+# ── tests ──────────────────────────────────────────────────────────────────────
+
+def run():
+    if not wait_for_server():
+        print("RESULT: 0/1 passed")
+        sys.exit(1)
+
+    # (a) default-active: a newly created habit is active — present in the default
+    #     list and absent from ?archived=true.
+    _, active_hid = new_habit("h-default-active")
+    check("(a) create habit", active_hid is not None)
+    if active_hid is not None:
+        check("(a) new habit present in default list",
+              contains(id_list("/api/habits"), active_hid))
+        check("(a) new habit absent from ?archived=true",
+              not contains(id_list("/api/habits?archived=true"), active_hid))
+
+    # (b) archive idempotency: POST archive twice -> both 200/204; H appears
+    #     exactly once in ?archived=true and never in the default list.
+    _, hid = new_habit("h-idempotent")
+    check("(b) create habit", hid is not None)
+    if hid is not None:
+        r1 = request("POST", f"/api/habits/{hid}/archive")
+        check("(b) first archive -> 200/204", r1.status in (200, 204), f"got {r1.status}")
+        r2 = request("POST", f"/api/habits/{hid}/archive")
+        check("(b) second archive (idempotent) -> 200/204", r2.status in (200, 204),
+              f"got {r2.status}")
+        archived = id_list("/api/habits?archived=true")
+        count = archived.count(str(hid)) if archived is not None else -1
+        check("(b) archived habit appears exactly once in ?archived=true", count == 1,
+              f"count={count}")
+        check("(b) archived habit never in default list",
+              not contains(id_list("/api/habits"), hid))
+
+    # (c) explicit ?archived=false mirrors the default (active only). SPEC §4 says
+    #     this param MAY be treated the same as no query, so explicit support is
+    #     optional: when the endpoint returns a 200 JSON list we require it to
+    #     behave like the default (an active witness present, the archived habit
+    #     absent); otherwise we only require it not to be a server error (don't
+    #     over-specify beyond SPEC). `active_hid` is still active; `hid` is archived.
+    if active_hid is not None and hid is not None:
+        r = request("GET", "/api/habits?archived=false")
+        if r.status == 200 and isinstance(r.json(), list):
+            ids = [str(h.get("id")) for h in r.json()]
+            ok = str(active_hid) in ids and str(hid) not in ids
+            check("(c) ?archived=false returns only active habits", ok,
+                  f"active_present={str(active_hid) in ids}, archived_present={str(hid) in ids}")
+        else:
+            check("(c) ?archived=false optional param handled without server error",
+                  r.status < 500, f"got {r.status}")
+
+    # (d) an archived habit still computes its streak correctly. Complete today
+    #     (default date, so we use the server-returned date) and yesterday, then
+    #     archive, then GET -> current_streak == 2 with both dates in history.
+    _, h2 = new_habit("h-archived-streak")
+    check("(d) create habit", h2 is not None)
+    if h2 is not None:
+        rc = request("POST", f"/api/habits/{h2}/complete", {})  # default = today
+        check("(d) complete today (default) -> 201", rc.status == 201, f"got {rc.status}")
+        today_str = rc.json().get("date") if rc.status == 201 else None
+        if today_str:
+            yesterday = datetime.date.fromisoformat(today_str) - datetime.timedelta(days=1)
+            yesterday_str = yesterday.isoformat()
+            rc2 = request("POST", f"/api/habits/{h2}/complete", {"date": yesterday_str})
+            check("(d) complete yesterday (backdated) -> 201", rc2.status == 201,
+                  f"got {rc2.status}")
+            ra = request("POST", f"/api/habits/{h2}/archive")
+            check("(d) archive habit -> 200/204", ra.status in (200, 204), f"got {ra.status}")
+            r = request("GET", f"/api/habits/{h2}")
+            check("(d) GET archived habit -> 200", r.status == 200, f"got {r.status}")
+            got = r.json() if r.status == 200 else {}
+            check("(d) archived habit current_streak == 2", got.get("current_streak") == 2,
+                  f"got {got.get('current_streak')}")
+            hist = got.get("history") if isinstance(got.get("history"), list) else []
+            check("(d) archived habit history contains both completed dates",
+                  today_str in hist and yesterday_str in hist,
+                  f"history={hist}")
+
+    total = _PASSED + _FAILED
+    print(f"RESULT: {_PASSED}/{total} passed")
+    sys.exit(0 if _FAILED == 0 else 1)
+
+
+if __name__ == "__main__":
+    run()

--- a/benchmarks/agentic-habit-tracker/phase2/archive_hidden_test.py
+++ b/benchmarks/agentic-habit-tracker/phase2/archive_hidden_test.py
@@ -40,7 +40,17 @@ class Resp:
         self.body_bytes = body_bytes
 
     def json(self):
-        return json.loads(self.body_bytes.decode("utf-8"))
+        """Parse the body as JSON, returning None on any decode failure.
+
+        A candidate can answer an otherwise-expected status with an empty or
+        HTML body; raising here would crash the suite before it prints its
+        RESULT line. Returning None lets callers fold a non-JSON body into a
+        recorded check failure (they treat it as ``{}``).
+        """
+        try:
+            return json.loads(self.body_bytes.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            return None
 
 
 def request(method, path, body=None):
@@ -92,7 +102,7 @@ def wait_for_server(timeout_s=30):
 
 def new_habit(name):
     r = request("POST", "/api/habits", {"name": name})
-    return r, (r.json().get("id") if r.status == 201 else None)
+    return r, ((r.json() or {}).get("id") if r.status == 201 else None)
 
 
 def id_list(path):
@@ -189,7 +199,7 @@ def run():
     if h2 is not None:
         rc = request("POST", f"/api/habits/{h2}/complete", {})  # default = today
         check("(d) complete today (default) -> 201", rc.status == 201, f"got {rc.status}")
-        today_str = rc.json().get("date") if rc.status == 201 else None
+        today_str = (rc.json() or {}).get("date") if rc.status == 201 else None
         # Guard the server-date parse (mirror acceptance/contract_test.py): a
         # candidate can return 201 with a non-ISO `date`, and an unguarded
         # datetime.date.fromisoformat would raise ValueError and crash the suite
@@ -212,7 +222,7 @@ def run():
             check("(d) archive habit -> 200/204", ra.status in (200, 204), f"got {ra.status}")
             r = request("GET", f"/api/habits/{h2}")
             check("(d) GET archived habit -> 200", r.status == 200, f"got {r.status}")
-            got = r.json() if r.status == 200 else {}
+            got = (r.json() or {}) if r.status == 200 else {}
             check("(d) archived habit current_streak == 2", got.get("current_streak") == 2,
                   f"got {got.get('current_streak')}")
             hist = got.get("history") if isinstance(got.get("history"), list) else []

--- a/benchmarks/agentic-habit-tracker/phase2/archive_hidden_test.py
+++ b/benchmarks/agentic-habit-tracker/phase2/archive_hidden_test.py
@@ -190,8 +190,20 @@ def run():
         rc = request("POST", f"/api/habits/{h2}/complete", {})  # default = today
         check("(d) complete today (default) -> 201", rc.status == 201, f"got {rc.status}")
         today_str = rc.json().get("date") if rc.status == 201 else None
+        # Guard the server-date parse (mirror acceptance/contract_test.py): a
+        # candidate can return 201 with a non-ISO `date`, and an unguarded
+        # datetime.date.fromisoformat would raise ValueError and crash the suite
+        # before the RESULT line is printed, leaving hidden_checks_* counts
+        # unstable. On a missing/None or unparseable date, record the five
+        # server-date-dependent checks as failures and still reach RESULT.
+        parsed_today = None
         if today_str:
-            yesterday = datetime.date.fromisoformat(today_str) - datetime.timedelta(days=1)
+            try:
+                parsed_today = datetime.date.fromisoformat(today_str)
+            except (ValueError, TypeError):
+                parsed_today = None
+        if parsed_today is not None:
+            yesterday = parsed_today - datetime.timedelta(days=1)
             yesterday_str = yesterday.isoformat()
             rc2 = request("POST", f"/api/habits/{h2}/complete", {"date": yesterday_str})
             check("(d) complete yesterday (backdated) -> 201", rc2.status == 201,
@@ -208,7 +220,8 @@ def run():
                   today_str in hist and yesterday_str in hist,
                   f"history={hist}")
         else:
-            # No server date to anchor the backdated day: record the five
+            # No usable server date to anchor the backdated day (missing/None or
+            # a non-ISO string that failed to parse): record the five
             # server-date-dependent checks as failures to keep the total fixed.
             for label in (
                 "(d) complete yesterday (backdated) -> 201",
@@ -217,7 +230,7 @@ def run():
                 "(d) archived habit current_streak == 2",
                 "(d) archived habit history contains both completed dates",
             ):
-                check(label, False, "setup failed: no server date")
+                check(label, False, "setup failed: missing or unparseable server date")
     else:
         for label in (
             "(d) complete today (default) -> 201",

--- a/benchmarks/agentic-habit-tracker/phase2/archive_test.py
+++ b/benchmarks/agentic-habit-tracker/phase2/archive_test.py
@@ -37,7 +37,17 @@ class Resp:
         self.body_bytes = body_bytes
 
     def json(self):
-        return json.loads(self.body_bytes.decode("utf-8"))
+        """Parse the body as JSON, returning None on any decode failure.
+
+        A candidate can answer an otherwise-expected status with an empty or
+        HTML body; raising here would crash the suite before it prints its
+        RESULT line. Returning None lets callers fold a non-JSON body into a
+        recorded check failure (they treat it as ``{}``).
+        """
+        try:
+            return json.loads(self.body_bytes.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            return None
 
     def content_type(self):
         return self.headers.get("content-type", "")
@@ -102,7 +112,7 @@ def wait_for_server(timeout_s=30):
 def new_habit(name):
     """Create a habit; return (response, id)."""
     r = request("POST", "/api/habits", {"name": name})
-    hid = r.json().get("id") if r.status == 201 else None
+    hid = (r.json() or {}).get("id") if r.status == 201 else None
     return r, hid
 
 
@@ -156,7 +166,7 @@ def run():
         total = _PASSED + _FAILED
         print(f"RESULT: {_PASSED}/{total} passed")
         sys.exit(1)
-    archived_field = r.json().get("archived")
+    archived_field = (r.json() or {}).get("archived")
     archived_ids = list_ids("/api/habits?archived=true")
     # Phase 2 (prompts/phase2_maintenance.md) requires an `archived` boolean on
     # the habit. A freshly created habit MUST carry archived == false: absent or
@@ -188,7 +198,7 @@ def run():
     # report archived == true (present and correct). Absent/None is a FAIL. The
     # streak + history must still be intact.
     r = request("GET", f"/api/habits/{hid}")
-    got = r.json() if r.status == 200 else {}
+    got = (r.json() or {}) if r.status == 200 else {}
     check("GET archived habit -> 200 with archived == true",
           r.status == 200 and got.get("archived") is True,
           f"got status {r.status}, archived={got.get('archived')!r}")

--- a/benchmarks/agentic-habit-tracker/phase2/archive_test.py
+++ b/benchmarks/agentic-habit-tracker/phase2/archive_test.py
@@ -128,7 +128,26 @@ def run():
     check("POST /api/habits -> 201", r.status == 201, f"got {r.status}")
     check("created habit has id", hid is not None)
     if hid is None:
-        print(f"RESULT: {_PASSED}/{_PASSED + _FAILED} passed")
+        # Denominator is intentionally fixed at 14: a failed setup must not
+        # shrink the total and inflate the pass rate. Record every dependent
+        # check as an explicit failure instead of exiting early and skipping them.
+        for label in (
+            "newly created habit is active (archived false/absent AND not in archived list)",
+            "created habit present in default list",
+            "POST /api/habits/{id}/archive -> 200/204",
+            "archived habit absent from default list",
+            "archived habit present in ?archived=true list",
+            "GET archived habit -> 200",
+            "archived habit still has current_streak",
+            "archived habit still has history array",
+            "POST archive unknown id -> 404",
+            "POST second habit -> 201",
+            "non-archived habit still present in default list after archiving another",
+            "archived habit still absent from default list (regression)",
+        ):
+            check(label, False, "setup failed: no habit id")
+        total = _PASSED + _FAILED
+        print(f"RESULT: {_PASSED}/{total} passed")
         sys.exit(1)
     archived_field = r.json().get("archived")
     archived_ids = list_ids("/api/habits?archived=true")

--- a/benchmarks/agentic-habit-tracker/phase2/archive_test.py
+++ b/benchmarks/agentic-habit-tracker/phase2/archive_test.py
@@ -161,8 +161,14 @@ def run():
     check("archived habit still has current_streak", "current_streak" in got)
     check("archived habit still has history array", isinstance(got.get("history"), list))
 
-    # archive unknown id -> 404
-    r = request("POST", "/api/habits/999999999/archive")
+    # archive unknown id -> 404. Use a real returned-ID shape: create a
+    # throwaway habit, capture its id, DELETE it, then archive the now-deleted
+    # id. SPEC allows opaque string/UUID ids, so a hard-coded numeric sentinel
+    # could be rejected as a malformed route param (400) before the not-found
+    # lookup happens.
+    _, deleted_id = new_habit("throwaway-404")
+    request("DELETE", f"/api/habits/{deleted_id}")
+    r = request("POST", f"/api/habits/{deleted_id}/archive")
     check("POST archive unknown id -> 404", r.status == 404, f"got {r.status}")
 
     # regression: a second, non-archived habit still shows up in the default list

--- a/benchmarks/agentic-habit-tracker/phase2/archive_test.py
+++ b/benchmarks/agentic-habit-tracker/phase2/archive_test.py
@@ -43,11 +43,16 @@ class Resp:
         return self.headers.get("content-type", "")
 
 
-def request(method, path, body=None):
-    """Perform an HTTP request. `path` may be absolute or relative to BASE_URL."""
+def request(method, path, body=None, accept="application/json"):
+    """Perform an HTTP request. `path` may be absolute or relative to BASE_URL.
+
+    `accept` controls the Accept header: JSON endpoints keep the default, while
+    the server-rendered HTML view is fetched with ``accept="text/html"`` so a
+    content-negotiating server isn't wrongly asked for JSON on an HTML route.
+    """
     url = path if path.startswith("http") else BASE_URL + path
     data = None
-    headers = {"Accept": "application/json"}
+    headers = {"Accept": accept}
     if body is not None:
         data = json.dumps(body).encode("utf-8")
         headers["Content-Type"] = "application/json"
@@ -216,7 +221,7 @@ def run():
         ar = request("POST", f"/api/habits/{hidden_hid}/archive")
         html_setup_ok = ar.status in (200, 204)
     if html_setup_ok:
-        r = request("GET", "/")
+        r = request("GET", "/", accept="text/html")
         html_ok = r.status == 200 and "text/html" in r.content_type().lower()
         body_text = r.body_bytes.decode("utf-8", "replace") if html_ok else ""
         check(

--- a/benchmarks/agentic-habit-tracker/phase2/archive_test.py
+++ b/benchmarks/agentic-habit-tracker/phase2/archive_test.py
@@ -137,12 +137,12 @@ def run():
         # shrink the total and inflate the pass rate. Record every dependent
         # check as an explicit failure instead of exiting early and skipping them.
         for label in (
-            "newly created habit is active (archived false/absent AND not in archived list)",
+            "newly created habit is active (archived == false AND not in archived list)",
             "created habit present in default list",
             "POST /api/habits/{id}/archive -> 200/204",
             "archived habit absent from default list",
             "archived habit present in ?archived=true list",
-            "GET archived habit -> 200",
+            "GET archived habit -> 200 with archived == true",
             "archived habit still has current_streak",
             "archived habit still has history array",
             "POST archive unknown id -> 404",
@@ -158,9 +158,13 @@ def run():
         sys.exit(1)
     archived_field = r.json().get("archived")
     archived_ids = list_ids("/api/habits?archived=true")
+    # Phase 2 (prompts/phase2_maintenance.md) requires an `archived` boolean on
+    # the habit. A freshly created habit MUST carry archived == false: absent or
+    # None is a FAIL, not a pass — an API that omits the field no longer earns
+    # phase-2 correctness credit.
     check(
-        "newly created habit is active (archived false/absent AND not in archived list)",
-        archived_field in (False, None) and not contains(archived_ids, hid),
+        "newly created habit is active (archived == false AND not in archived list)",
+        archived_field is False and not contains(archived_ids, hid),
         f"archived={archived_field!r}, in_archived_list={contains(archived_ids, hid)}",
     )
 
@@ -180,10 +184,14 @@ def run():
     archived_ids = list_ids("/api/habits?archived=true")
     check("archived habit present in ?archived=true list", contains(archived_ids, hid))
 
-    # GET single still works for the archived habit, with streak + history
+    # GET single still works for the archived habit, and the object MUST now
+    # report archived == true (present and correct). Absent/None is a FAIL. The
+    # streak + history must still be intact.
     r = request("GET", f"/api/habits/{hid}")
-    check("GET archived habit -> 200", r.status == 200, f"got {r.status}")
     got = r.json() if r.status == 200 else {}
+    check("GET archived habit -> 200 with archived == true",
+          r.status == 200 and got.get("archived") is True,
+          f"got status {r.status}, archived={got.get('archived')!r}")
     check("archived habit still has current_streak", "current_streak" in got)
     check("archived habit still has history array", isinstance(got.get("history"), list))
 

--- a/benchmarks/agentic-habit-tracker/phase2/archive_test.py
+++ b/benchmarks/agentic-habit-tracker/phase2/archive_test.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Visible Phase-2 acceptance tests for the habit-tracker benchmark.
+
+Phase 2 adds "archived habits" (soft-delete/hide). See SPEC.md §4 and
+prompts/phase2_maintenance.md. This suite exercises the archive endpoint and
+the list-filtering behavior over HTTP only, so — like acceptance/contract_test.py
+— the same file works against any framework that satisfies the contract.
+
+Stdlib only (urllib/json/datetime/sys/os/time). No external dependencies.
+
+Usage:
+    BASE_URL=http://localhost:8080 python3 archive_test.py
+
+Exits non-zero if any check fails.
+"""
+
+import datetime
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:8080").rstrip("/")
+
+_PASSED = 0
+_FAILED = 0
+
+
+# ── HTTP helper ────────────────────────────────────────────────────────────────
+
+class Resp:
+    def __init__(self, status, headers, body_bytes):
+        self.status = status
+        self.headers = headers  # dict, lowercased keys
+        self.body_bytes = body_bytes
+
+    def json(self):
+        return json.loads(self.body_bytes.decode("utf-8"))
+
+    def content_type(self):
+        return self.headers.get("content-type", "")
+
+
+def request(method, path, body=None):
+    """Perform an HTTP request. `path` may be absolute or relative to BASE_URL."""
+    url = path if path.startswith("http") else BASE_URL + path
+    data = None
+    headers = {"Accept": "application/json"}
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            raw = r.read()
+            hdrs = {k.lower(): v for k, v in r.headers.items()}
+            return Resp(r.status, hdrs, raw)
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        hdrs = {k.lower(): v for k, v in e.headers.items()} if e.headers else {}
+        return Resp(e.code, hdrs, raw)
+
+
+# ── assertions ─────────────────────────────────────────────────────────────────
+
+def check(name, condition, detail=""):
+    global _PASSED, _FAILED
+    if condition:
+        _PASSED += 1
+        print(f"PASS  {name}")
+    else:
+        _FAILED += 1
+        suffix = f" -- {detail}" if detail else ""
+        print(f"FAIL  {name}{suffix}")
+
+
+def wait_for_server(timeout_s=30):
+    """Retry connecting until the server answers or the timeout elapses."""
+    deadline = time.time() + timeout_s
+    last = None
+    while time.time() < deadline:
+        try:
+            r = request("GET", "/api/habits")
+            if r.status < 500:
+                return True
+        except Exception as e:  # connection refused, etc.
+            last = e
+        time.sleep(0.5)
+    print(f"FAIL  server did not become ready within {timeout_s}s ({last})")
+    return False
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def new_habit(name):
+    """Create a habit; return (response, id)."""
+    r = request("POST", "/api/habits", {"name": name})
+    hid = r.json().get("id") if r.status == 201 else None
+    return r, hid
+
+
+def list_ids(path):
+    """GET a habits listing and return the set of stringified ids (or None on error)."""
+    r = request("GET", path)
+    if r.status != 200:
+        return None
+    body = r.json()
+    if not isinstance(body, list):
+        return None
+    return {str(h.get("id")) for h in body}
+
+
+def contains(ids, hid):
+    return ids is not None and str(hid) in ids
+
+
+# ── tests ──────────────────────────────────────────────────────────────────────
+
+def run():
+    if not wait_for_server():
+        print("RESULT: 0/1 passed")
+        sys.exit(1)
+
+    # create habit H -> should be active (archived false or absent from archived list)
+    r, hid = new_habit("archive-me")
+    check("POST /api/habits -> 201", r.status == 201, f"got {r.status}")
+    check("created habit has id", hid is not None)
+    if hid is None:
+        print(f"RESULT: {_PASSED}/{_PASSED + _FAILED} passed")
+        sys.exit(1)
+    archived_field = r.json().get("archived")
+    archived_ids = list_ids("/api/habits?archived=true")
+    check(
+        "newly created habit is active (archived false/absent AND not in archived list)",
+        archived_field in (False, None) and not contains(archived_ids, hid),
+        f"archived={archived_field!r}, in_archived_list={contains(archived_ids, hid)}",
+    )
+
+    # H appears in default list
+    default_ids = list_ids("/api/habits")
+    check("created habit present in default list", contains(default_ids, hid))
+
+    # archive H -> 200 or 204 (SPEC allows either)
+    r = request("POST", f"/api/habits/{hid}/archive")
+    check("POST /api/habits/{id}/archive -> 200/204", r.status in (200, 204), f"got {r.status}")
+
+    # after archive: default list does NOT contain H
+    default_ids = list_ids("/api/habits")
+    check("archived habit absent from default list", not contains(default_ids, hid))
+
+    # after archive: ?archived=true DOES contain H
+    archived_ids = list_ids("/api/habits?archived=true")
+    check("archived habit present in ?archived=true list", contains(archived_ids, hid))
+
+    # GET single still works for the archived habit, with streak + history
+    r = request("GET", f"/api/habits/{hid}")
+    check("GET archived habit -> 200", r.status == 200, f"got {r.status}")
+    got = r.json() if r.status == 200 else {}
+    check("archived habit still has current_streak", "current_streak" in got)
+    check("archived habit still has history array", isinstance(got.get("history"), list))
+
+    # archive unknown id -> 404
+    r = request("POST", "/api/habits/999999999/archive")
+    check("POST archive unknown id -> 404", r.status == 404, f"got {r.status}")
+
+    # regression: a second, non-archived habit still shows up in the default list
+    r2, hid2 = new_habit("keep-me")
+    check("POST second habit -> 201", r2.status == 201, f"got {r2.status}")
+    default_ids = list_ids("/api/habits")
+    check("non-archived habit still present in default list after archiving another",
+          contains(default_ids, hid2))
+    check("archived habit still absent from default list (regression)",
+          not contains(default_ids, hid))
+
+    total = _PASSED + _FAILED
+    print(f"RESULT: {_PASSED}/{total} passed")
+    sys.exit(0 if _FAILED == 0 else 1)
+
+
+if __name__ == "__main__":
+    run()

--- a/benchmarks/agentic-habit-tracker/phase2/archive_test.py
+++ b/benchmarks/agentic-habit-tracker/phase2/archive_test.py
@@ -128,7 +128,7 @@ def run():
     check("POST /api/habits -> 201", r.status == 201, f"got {r.status}")
     check("created habit has id", hid is not None)
     if hid is None:
-        # Denominator is intentionally fixed at 14: a failed setup must not
+        # Denominator is intentionally fixed at 16: a failed setup must not
         # shrink the total and inflate the pass rate. Record every dependent
         # check as an explicit failure instead of exiting early and skipping them.
         for label in (
@@ -144,6 +144,8 @@ def run():
             "POST second habit -> 201",
             "non-archived habit still present in default list after archiving another",
             "archived habit still absent from default list (regression)",
+            "archived habit name absent from HTML GET / view",
+            "active habit name present in HTML GET / view",
         ):
             check(label, False, "setup failed: no habit id")
         total = _PASSED + _FAILED
@@ -198,6 +200,40 @@ def run():
           contains(default_ids, hid2))
     check("archived habit still absent from default list (regression)",
           not contains(default_ids, hid))
+
+    # HTML view must list only non-archived habits (phase-2 brief / SPEC §4).
+    # Create one habit to archive and one to keep active, both with unique,
+    # HTML-greppable names, then assert the archived name is absent from the
+    # server-rendered HTML body while the active name is present. Fail-closed:
+    # if either habit can't be created or the archive doesn't take, record both
+    # checks as failures rather than skipping (keeps the denominator at 16).
+    HIDDEN_NAME = "ZzArchivedHidden-Q7"
+    ACTIVE_NAME = "ZzActiveVisible-Q7"
+    _, hidden_hid = new_habit(HIDDEN_NAME)
+    _, active_hid = new_habit(ACTIVE_NAME)
+    html_setup_ok = hidden_hid is not None and active_hid is not None
+    if html_setup_ok:
+        ar = request("POST", f"/api/habits/{hidden_hid}/archive")
+        html_setup_ok = ar.status in (200, 204)
+    if html_setup_ok:
+        r = request("GET", "/")
+        html_ok = r.status == 200 and "text/html" in r.content_type().lower()
+        body_text = r.body_bytes.decode("utf-8", "replace") if html_ok else ""
+        check(
+            "archived habit name absent from HTML GET / view",
+            html_ok and HIDDEN_NAME not in body_text,
+            f"status={r.status}, ct={r.content_type()!r}, present={HIDDEN_NAME in body_text}",
+        )
+        check(
+            "active habit name present in HTML GET / view",
+            html_ok and ACTIVE_NAME in body_text,
+            f"status={r.status}, ct={r.content_type()!r}, present={ACTIVE_NAME in body_text}",
+        )
+    else:
+        check("archived habit name absent from HTML GET / view", False,
+              "setup failed: could not create/archive habits for HTML view check")
+        check("active habit name present in HTML GET / view", False,
+              "setup failed: could not create/archive habits for HTML view check")
 
     total = _PASSED + _FAILED
     print(f"RESULT: {_PASSED}/{total} passed")

--- a/benchmarks/agentic-habit-tracker/phase2/archive_test.py
+++ b/benchmarks/agentic-habit-tracker/phase2/archive_test.py
@@ -107,12 +107,33 @@ def wait_for_server(timeout_s=30):
     return False
 
 
+# ── shape coercion ──────────────────────────────────────────────────────────────
+#
+# A candidate can answer an expected status with a syntactically VALID JSON body
+# of the wrong shape (a list where an object is expected, a scalar, or null).
+# Feeding that into ``.get(...)`` / indexing / iteration would raise and crash the
+# suite before it prints its RESULT line. These helpers coerce every parsed body
+# to the expected shape, so a wrong shape degrades into a failed ``check(...)``
+# rather than an exception. The happy path (correct shapes) is unaffected.
+
+def as_obj(r):
+    """Return the response body as a dict, or ``{}`` for any non-object shape."""
+    j = r.json()
+    return j if isinstance(j, dict) else {}
+
+
+def as_list(r):
+    """Return the response body as a list, or ``[]`` for any non-array shape."""
+    j = r.json()
+    return j if isinstance(j, list) else []
+
+
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 def new_habit(name):
     """Create a habit; return (response, id)."""
     r = request("POST", "/api/habits", {"name": name})
-    hid = (r.json() or {}).get("id") if r.status == 201 else None
+    hid = as_obj(r).get("id") if r.status == 201 else None
     return r, hid
 
 
@@ -124,7 +145,38 @@ def list_ids(path):
     body = r.json()
     if not isinstance(body, list):
         return None
-    return {str(h.get("id")) for h in body}
+    return {str(h.get("id")) for h in body if isinstance(h, dict)}
+
+
+def list_objs(path):
+    """GET a habits listing and return its list of dict objects (or None on error).
+
+    Unlike ``list_ids`` this preserves the full objects so callers can assert on
+    per-object fields (e.g. the phase-2 ``archived`` boolean). Returns None on a
+    non-200 status or a non-array body; a valid-but-wrong shape thus becomes a
+    failed check rather than a crash.
+    """
+    r = request("GET", path)
+    if r.status != 200:
+        return None
+    body = r.json()
+    if not isinstance(body, list):
+        return None
+    return body
+
+
+def all_archived_is(objs, expected):
+    """True iff ``objs`` is a non-empty list whose every element is a dict that
+    carries ``archived`` as the bool ``expected`` (present, correct type, correct
+    value). Fail-closed: None (fetch/shape error), an empty list, a non-dict
+    element, a missing/None/non-bool ``archived``, or the wrong value all yield
+    False. ``is expected`` also rejects a truthy non-bool (e.g. ``1``)."""
+    if not isinstance(objs, list) or not objs:
+        return False
+    for h in objs:
+        if not isinstance(h, dict) or h.get("archived") is not expected:
+            return False
+    return True
 
 
 def contains(ids, hid):
@@ -143,15 +195,17 @@ def run():
     check("POST /api/habits -> 201", r.status == 201, f"got {r.status}")
     check("created habit has id", hid is not None)
     if hid is None:
-        # Denominator is intentionally fixed at 16: a failed setup must not
+        # Denominator is intentionally fixed at 18: a failed setup must not
         # shrink the total and inflate the pass rate. Record every dependent
         # check as an explicit failure instead of exiting early and skipping them.
         for label in (
             "newly created habit is active (archived == false AND not in archived list)",
             "created habit present in default list",
+            "every habit in default list carries archived == false",
             "POST /api/habits/{id}/archive -> 200/204",
             "archived habit absent from default list",
             "archived habit present in ?archived=true list",
+            "every habit in ?archived=true list carries archived == true",
             "GET archived habit -> 200 with archived == true",
             "archived habit still has current_streak",
             "archived habit still has history array",
@@ -166,7 +220,7 @@ def run():
         total = _PASSED + _FAILED
         print(f"RESULT: {_PASSED}/{total} passed")
         sys.exit(1)
-    archived_field = (r.json() or {}).get("archived")
+    archived_field = as_obj(r).get("archived")
     archived_ids = list_ids("/api/habits?archived=true")
     # Phase 2 (prompts/phase2_maintenance.md) requires an `archived` boolean on
     # the habit. A freshly created habit MUST carry archived == false: absent or
@@ -182,6 +236,16 @@ def run():
     default_ids = list_ids("/api/habits")
     check("created habit present in default list", contains(default_ids, hid))
 
+    # Every OBJECT in the default (active) list must itself carry archived ==
+    # false. The id-only filter checks above can't catch an impl that omits the
+    # `archived` field from list objects, so assert on the full objects here.
+    # Fail-closed: a fetch/shape error, a non-dict element, or a missing / non-
+    # bool / wrong-valued `archived` all fail this check.
+    default_objs = list_objs("/api/habits")
+    check("every habit in default list carries archived == false",
+          all_archived_is(default_objs, False),
+          f"objs={default_objs!r}")
+
     # archive H -> 200 or 204 (SPEC allows either)
     r = request("POST", f"/api/habits/{hid}/archive")
     check("POST /api/habits/{id}/archive -> 200/204", r.status in (200, 204), f"got {r.status}")
@@ -194,11 +258,19 @@ def run():
     archived_ids = list_ids("/api/habits?archived=true")
     check("archived habit present in ?archived=true list", contains(archived_ids, hid))
 
+    # Every OBJECT in the ?archived=true list must itself carry archived == true
+    # (present, bool, correct value) — mirror of the default-list check so an
+    # impl can't omit the field from archived list objects. Fail-closed.
+    archived_objs = list_objs("/api/habits?archived=true")
+    check("every habit in ?archived=true list carries archived == true",
+          all_archived_is(archived_objs, True),
+          f"objs={archived_objs!r}")
+
     # GET single still works for the archived habit, and the object MUST now
     # report archived == true (present and correct). Absent/None is a FAIL. The
     # streak + history must still be intact.
     r = request("GET", f"/api/habits/{hid}")
-    got = (r.json() or {}) if r.status == 200 else {}
+    got = as_obj(r) if r.status == 200 else {}
     check("GET archived habit -> 200 with archived == true",
           r.status == 200 and got.get("archived") is True,
           f"got status {r.status}, archived={got.get('archived')!r}")
@@ -229,7 +301,7 @@ def run():
     # HTML-greppable names, then assert the archived name is absent from the
     # server-rendered HTML body while the active name is present. Fail-closed:
     # if either habit can't be created or the archive doesn't take, record both
-    # checks as failures rather than skipping (keeps the denominator at 16).
+    # checks as failures rather than skipping (keeps the denominator at 18).
     HIDDEN_NAME = "ZzArchivedHidden-Q7"
     ACTIVE_NAME = "ZzActiveVisible-Q7"
     _, hidden_hid = new_habit(HIDDEN_NAME)

--- a/benchmarks/agentic-habit-tracker/prompts/_core.md
+++ b/benchmarks/agentic-habit-tracker/prompts/_core.md
@@ -1,0 +1,66 @@
+Prompt-Version: v1
+
+# Build brief: Habit Tracker (framework-agnostic core)
+
+You are being timed and scored while you build a small **habit tracker** web
+application. Build it end to end, get it running, and make the acceptance tests
+pass. Work inside the run directory you were given (e.g. `runs/<run-id>/app`).
+
+## What to build
+
+A habit tracker with a database, a JSON API, at least one server-rendered HTML
+view, input validation, tests, seed data, and a launcher script.
+
+Users can create habits, list/view/update/delete them, mark a habit complete on
+a given day, and see a per-habit **current streak** plus completion history.
+
+## Hard requirements
+
+1. **Persistence.** Store data in a real database (the framework's standard
+   database + migration story). No in-memory-only storage.
+2. **JSON API — exact contract.** Implement the endpoints in `SPEC.md` **exactly**
+   (status codes, shapes, validation, the 409-on-duplicate rule, backdated
+   completions). Read `SPEC.md` in full — the acceptance tests hit these routes
+   over HTTP and assert the documented status codes and JSON shapes. In
+   particular:
+   - `POST /api/habits`, `GET /api/habits`, `GET /api/habits/{id}`,
+     `PUT /api/habits/{id}`, `DELETE /api/habits/{id}`,
+     `POST /api/habits/{id}/complete`.
+   - The complete endpoint MUST accept an optional `{"date": "YYYY-MM-DD"}` so
+     completions can be **backdated**; duplicate `(habit, date)` → **409**.
+   - `GET /api/habits/{id}` returns `current_streak` and a descending `history`
+     array — implement the streak rules in `SPEC.md` §3 precisely.
+3. **Server-side HTML view.** `GET /` returns `text/html` (status 200) listing
+   the habits, rendered on the server.
+4. **Validation.** Reject empty/missing `name` and malformed dates with a 4xx
+   (422 preferred, 400 accepted). Reject unknown ids with 404.
+5. **Tests.** Include automated tests for the core behavior (create, complete,
+   streak calculation, validation, duplicate prevention).
+6. **Seed / demo data.** Seed a couple of demo habits (and some completions) on
+   first run so the HTML view and list endpoint aren't empty.
+7. **Run instructions.** Provide a `run.sh` at the app root that:
+   - starts the server on the port from the `PORT` env var (default **8080**),
+   - applies database migrations,
+   - seeds demo data,
+   - and **blocks** while the server runs.
+   Also provide a short `README` explaining how to run it.
+
+## The API contract
+
+The authoritative contract lives in `SPEC.md` (sibling of this prompt). Do not
+paraphrase it from memory — open it and implement it to the letter. The streak
+semantics and the exact status codes are what the tests check.
+
+## How you'll be evaluated
+
+- **Speed:** wall-clock time to first green (visible acceptance tests pass) and
+  the number of tool calls you make.
+- **Correctness:** visible acceptance tests + a hidden test suite that probes
+  streak edge cases (gaps, resets, out-of-order backdated completions,
+  duplicate prevention across explicit/default dates, malformed dates, delete
+  cascade).
+- **Maintainability:** lines of code, presence of tests, quality of run
+  instructions, and idiomatic use of the framework's conventions.
+
+Keep the implementation clean and idiomatic for your framework. No dead code, no
+TODOs. Get it running and prove it with the tests.

--- a/benchmarks/agentic-habit-tracker/prompts/autumn.md
+++ b/benchmarks/agentic-habit-tracker/prompts/autumn.md
@@ -11,13 +11,25 @@ Autumn-specific facts you need to build it.
 Autumn is a batteries-included Rust web framework (`autumn-web`) built on axum,
 Diesel/`diesel-async` (Postgres), and Maud for HTML.
 
-- **Dependency.** In-repo path dependency — in your app `Cargo.toml`:
+- **Dependency.** Depend on the in-repo Autumn crate. This benchmark lives at
+  `<repo-root>/benchmarks/agentic-habit-tracker/` and the crate is at
+  `<repo-root>/autumn`. Discover the repo root with
+  `git rev-parse --show-toplevel` — do **not** hardcode an absolute home path
+  such as one under `/home/.../autumn`. From
+  your app at `runs/<id>/app/`, that crate is five levels up
+  (`app` → `<id>` → `runs` → `agentic-habit-tracker` → `benchmarks` →
+  repo root, then into `autumn/`), so use the relative path
+  `path = "../../../../../autumn"`. You may instead use an **absolute** path to
+  this checkout's `autumn/` directory, or depend on the published crate
+  (`autumn-web = "0.6"`). In your app `Cargo.toml`:
   ```toml
   [package]
   edition = "2024"
 
   [dependencies]
-  autumn-web = { path = "/home/user/autumn/autumn", features = ["seed"] }
+  # Relative path from runs/<id>/app/ to <repo-root>/autumn (five levels up).
+  # Or use an absolute path from `git rev-parse --show-toplevel`, or `autumn-web = "0.6"`.
+  autumn-web = { path = "../../../../../autumn", features = ["seed"] }
   diesel = { version = "2", features = ["postgres", "chrono"] }
   diesel-async = { version = "0.9", features = ["postgres"] }
   diesel_migrations = "2"
@@ -29,7 +41,7 @@ Diesel/`diesel-async` (Postgres), and Maud for HTML.
   validator = { version = "0.20", features = ["derive"] }
 
   [dev-dependencies]
-  autumn-web = { path = "/home/user/autumn/autumn", features = ["test-support"] }
+  autumn-web = { path = "../../../../../autumn", features = ["test-support"] }
   ```
 
 - **Routes.** Handlers are annotated with `#[get("/path")]` / `#[post("/path")]`
@@ -107,18 +119,47 @@ Diesel/`diesel-async` (Postgres), and Maud for HTML.
   drives your router in-process so you can assert on JSON responses. Write
   integration tests under `tests/`.
 
-## Scaffolding options
+## Scaffolding (recommended first)
 
-- Fastest: **copy `/home/user/autumn/examples/todo-app`** as a starting point and
-  adapt it — it already wires migrations, a Diesel model, Maud HTML routes, JSON
-  API routes, `Json<T>`, validation, a `seed` bin, and `TestApp`/`TestDb` tests.
-  `/home/user/autumn/examples/bookmarks` is a second, simpler reference.
-- Or scaffold a fresh app with the CLI:
-  `cargo run -p autumn-cli -- new habit-tracker` (run from `/home/user/autumn`).
+**Fastest path — scaffold with the CLI, then fill in the streak logic and the
+JSON contract.** Hand-building by copying `examples/` is the fallback. All CLI
+commands can be run in-repo via `cargo run -p autumn-cli -- <args>` (run from the
+repo root — find it with `git rev-parse --show-toplevel`); if `autumn` is on your
+`PATH`, `autumn <args>` is equivalent.
+
+- **Create the app.** `autumn new habit-tracker` scaffolds a fresh project
+  (minimal base by default). Pass `--starter <name>` to start from a curated
+  starter, and `--list-starters` to see what's available. In-repo:
+  `cargo run -p autumn-cli -- new habit-tracker`.
+- **Scaffold a resource in one step.**
+  `autumn generate scaffold Habit name:String description:Text` generates the
+  `#[model]` struct, a Diesel migration, a `#[repository]`, HTML routes, and a
+  smoke test, and registers the new routes in `src/main.rs`. Field DSL supports
+  `name:Type`, `field:references` (FK), `field:Type:unique`, `enum{a,b,c}`, and
+  `Option<...>`; `--api` emits a JSON-only resource. Narrower generators exist
+  too: `autumn generate model|migration|task|job|mailer ...`. In-repo:
+  `cargo run -p autumn-cli -- generate scaffold Habit name:String description:Text`.
+- **Iterate and verify.** `autumn dev` runs the dev server with hot reload
+  (watch mode); `autumn migrate` runs pending migrations; `autumn test`
+  provisions the test database, migrates it, and runs `cargo test`.
+
+After scaffolding, adapt the generated code to match the exact JSON contract in
+`SPEC.md` (status codes, the `complete`/streak endpoints, and the
+`current_streak`/`history` computation are yours to implement — the scaffold
+won't produce them verbatim).
+
+## Reference examples (fallback: hand-build)
+
+- **Copy `examples/todo-app`** (at the repo root of this checkout —
+  `<repo-root>/examples/todo-app`; the repo root is discoverable via
+  `git rev-parse --show-toplevel`) as a starting point and adapt it — it already
+  wires migrations, a Diesel model, Maud HTML routes, JSON API routes, `Json<T>`,
+  validation, a `seed` bin, and `TestApp`/`TestDb` tests. `<repo-root>/examples/bookmarks`
+  is a second, simpler reference.
 
 Study those two examples — `todo-app` and `bookmarks` — for the canonical
 Autumn patterns before writing code. Do not invent APIs; mirror what the
-examples do.
+examples (and the CLI-generated scaffold) do.
 
 ## run.sh
 

--- a/benchmarks/agentic-habit-tracker/prompts/autumn.md
+++ b/benchmarks/agentic-habit-tracker/prompts/autumn.md
@@ -19,7 +19,10 @@ Diesel/`diesel-async` (Postgres), and Maud for HTML.
   your app at `runs/<id>/app/`, that crate is five levels up
   (`app` → `<id>` → `runs` → `agentic-habit-tracker` → `benchmarks` →
   repo root, then into `autumn/`), so use the relative path
-  `path = "../../../../../autumn"`. You may instead use an **absolute** path to
+  `path = "../../../../../autumn"`. Only read the Autumn crate and `examples/`;
+  do **not** read `benchmarks/agentic-habit-tracker/hidden/` or
+  `benchmarks/agentic-habit-tracker/phase2/archive_hidden_test.py` — they are
+  evaluator-only. You may instead use an **absolute** path to
   this checkout's `autumn/` directory, or depend on the published crate
   (`autumn-web = "0.6"`). In your app `Cargo.toml`:
   ```toml

--- a/benchmarks/agentic-habit-tracker/prompts/autumn.md
+++ b/benchmarks/agentic-habit-tracker/prompts/autumn.md
@@ -1,0 +1,128 @@
+Prompt-Version: v1
+
+# Build brief: Habit Tracker — Autumn
+
+Read `prompts/_core.md` and `SPEC.md` first; they define the app, the exact JSON
+API contract, and the streak semantics. Everything there applies. Below are the
+Autumn-specific facts you need to build it.
+
+## Framework facts
+
+Autumn is a batteries-included Rust web framework (`autumn-web`) built on axum,
+Diesel/`diesel-async` (Postgres), and Maud for HTML.
+
+- **Dependency.** In-repo path dependency — in your app `Cargo.toml`:
+  ```toml
+  [package]
+  edition = "2024"
+
+  [dependencies]
+  autumn-web = { path = "/home/user/autumn/autumn", features = ["seed"] }
+  diesel = { version = "2", features = ["postgres", "chrono"] }
+  diesel-async = { version = "0.9", features = ["postgres"] }
+  diesel_migrations = "2"
+  maud = { version = "0.27", features = ["axum"] }
+  serde = { version = "1", features = ["derive"] }
+  serde_json = "1"
+  chrono = { version = "0.4", features = ["serde"] }
+  tokio = { version = "1", features = ["full"] }
+  validator = { version = "0.20", features = ["derive"] }
+
+  [dev-dependencies]
+  autumn-web = { path = "/home/user/autumn/autumn", features = ["test-support"] }
+  ```
+
+- **Routes.** Handlers are annotated with `#[get("/path")]` / `#[post("/path")]`
+  / `#[put(...)]` / `#[delete(...)]` and collected with the `routes![...]` macro,
+  which is passed to the app builder:
+  ```rust
+  autumn_web::app()
+      .migrations(MIGRATIONS)
+      .routes(routes![
+          routes::web::index,
+          routes::api::create_habit,
+          routes::api::list_habits,
+          routes::api::get_habit,
+          routes::api::update_habit,
+          routes::api::delete_habit,
+          routes::api::complete_habit,
+      ])
+      .run()
+      .await;
+  ```
+  Use `#[autumn_web::main]` on `async fn main()`.
+
+- **JSON.** Extract request bodies with `Json<T>` (where `T: Deserialize`) and
+  return `AutumnResult<Json<T>>` / `impl IntoResponse`. Import
+  `use autumn_web::prelude::*;` — it re-exports `Json`, `State`, `AppState`,
+  `AutumnResult`, `StatusCode`, and the route attribute macros. To control the
+  status code, return a tuple like `(StatusCode::CREATED, Json(body))` or an
+  `impl IntoResponse`.
+
+- **Persistence (Diesel).** Define the schema with the `table!` macro in
+  `schema.rs`:
+  ```rust
+  diesel::table! {
+      habits (id) { id -> Int8, name -> Text, description -> Nullable<Text>, created_at -> Timestamp }
+  }
+  diesel::table! {
+      completions (id) { id -> Int8, habit_id -> Int8, day -> Date }
+  }
+  ```
+  Put a UNIQUE `(habit_id, day)` constraint in the migration so duplicate
+  completions can be detected → map the DB unique-violation to **409**. Models
+  are `#[derive(Queryable, Selectable, Serialize)]` structs; inserts use
+  `#[derive(Insertable, Deserialize, Validate)]` "New" structs. Get a DB handle
+  in a handler via the `Db` extractor, which yields an `AsyncPgConnection`:
+  ```rust
+  async fn list_habits(mut db: Db) -> AutumnResult<Json<Vec<Habit>>> { ... }
+  ```
+  Run queries with `diesel_async::RunQueryDsl` (`.load(&mut db).await`,
+  `.get_result(&mut db).await`, etc.).
+
+- **Migrations.** Embed them with
+  `const MIGRATIONS: EmbeddedMigrations = embed_migrations!();`
+  (`use autumn_web::migrate::{EmbeddedMigrations, embed_migrations};`) and register
+  with `.migrations(MIGRATIONS)`. Migration SQL lives under `migrations/`.
+  Higher-level `#[autumn_web::model]` / `#[repository]` macros also exist if you
+  prefer them, but plain Diesel as above is the most direct path.
+
+- **Server-side HTML (Maud).** Return `maud::Markup` from a handler; build markup
+  with the `html! { ... }` macro. Set the response content type to `text/html`
+  (Maud's axum integration does this for `Markup`). Example:
+  ```rust
+  #[get("/")]
+  async fn index(mut db: Db) -> AutumnResult<Markup> {
+      let habits = Habit::all(&mut db).await?;
+      Ok(html! { h1 { "Habits" } ul { @for h in &habits { li { (h.name) } } } })
+  }
+  ```
+
+- **Validation.** Use the `validator` crate derives (`#[validate(length(min = 1))]`
+  on `name`) and return **422** on failure. Parse dates with
+  `chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d")`; a parse error → 422/400.
+
+- **Tests.** `autumn_web::prelude` exposes `TestApp` and `TestDb` (needs the
+  `test-support` feature). `TestDb` spins up a throwaway Postgres; `TestApp`
+  drives your router in-process so you can assert on JSON responses. Write
+  integration tests under `tests/`.
+
+## Scaffolding options
+
+- Fastest: **copy `/home/user/autumn/examples/todo-app`** as a starting point and
+  adapt it — it already wires migrations, a Diesel model, Maud HTML routes, JSON
+  API routes, `Json<T>`, validation, a `seed` bin, and `TestApp`/`TestDb` tests.
+  `/home/user/autumn/examples/bookmarks` is a second, simpler reference.
+- Or scaffold a fresh app with the CLI:
+  `cargo run -p autumn-cli -- new habit-tracker` (run from `/home/user/autumn`).
+
+Study those two examples — `todo-app` and `bookmarks` — for the canonical
+Autumn patterns before writing code. Do not invent APIs; mirror what the
+examples do.
+
+## run.sh
+
+Provide `run.sh` that sets `DATABASE_URL` (Postgres) if unset, runs `cargo run`
+(migrations run automatically via `.migrations(...)`, seed via the `seed` bin or
+an `on_startup` hook), and binds the server to `PORT` (default 8080). It must
+block while the server runs.

--- a/benchmarks/agentic-habit-tracker/prompts/django.md
+++ b/benchmarks/agentic-habit-tracker/prompts/django.md
@@ -1,0 +1,51 @@
+Prompt-Version: v1
+
+# Build brief: Habit Tracker — Django
+
+Read `prompts/_core.md` and `SPEC.md` first; they define the app, the exact JSON
+API contract, and the streak semantics. Everything there applies. Below are the
+Django-specific bootstrapping notes.
+
+## Framework facts
+
+- Use **Django** (with **Django REST Framework** for the JSON API is fine, or
+  plain `JsonResponse` views — your choice, as long as the `SPEC.md` contract is
+  met exactly).
+- Scaffold: `django-admin startproject habittracker` then
+  `python manage.py startapp habits`.
+- **Models.** A `Habit` model (`name`, `description` nullable, `created_at`
+  `auto_now_add`) and a `Completion` model (`habit` FK with
+  `on_delete=CASCADE`, `date` a `DateField`). Add
+  `unique_together = ("habit", "date")` (or a `UniqueConstraint`) so a duplicate
+  `(habit, date)` completion raises `IntegrityError` → map to **409**.
+- **Migrations.** `python manage.py makemigrations && migrate`. SQLite is fine
+  for the benchmark; Postgres is also acceptable.
+- **URLs / views.**
+  - `POST /api/habits`, `GET /api/habits`, `GET /api/habits/<id>`,
+    `PUT /api/habits/<id>`, `DELETE /api/habits/<id>`,
+    `POST /api/habits/<id>/complete` — all JSON.
+  - Return the documented status codes explicitly (`status=201`, `204`, `409`,
+    `422`/`400`, `404`). DRF's `Response(status=...)` or `JsonResponse(status=...)`.
+  - `GET /` — a Django template view (`TemplateView` or a function view calling
+    `render(...)`) returning `text/html` listing habits.
+- **Validation.** Reject empty `name` (serializer/`clean`) and malformed dates
+  (`datetime.date.fromisoformat` raises `ValueError` → 422/400).
+- **Streak.** Compute `current_streak` per `SPEC.md` §3 in Python from the
+  completion dates. `history` = the dates sorted descending as ISO strings.
+- **Seed / demo data.** A data migration or a `manage.py` custom command (e.g.
+  `python manage.py seed`) creating a couple of demo habits with completions.
+- **Tests.** `python manage.py test` with Django's `TestCase` / DRF `APIClient`.
+
+## run.sh
+
+```sh
+#!/usr/bin/env sh
+set -e
+python -m pip install -r requirements.txt
+python manage.py migrate
+python manage.py seed        # your seed command
+exec python manage.py runserver 0.0.0.0:"${PORT:-8080}"
+```
+
+`runserver` blocks while the server runs — good. Make sure `ALLOWED_HOSTS`
+permits `localhost`/`127.0.0.1`.

--- a/benchmarks/agentic-habit-tracker/prompts/loco.md
+++ b/benchmarks/agentic-habit-tracker/prompts/loco.md
@@ -1,0 +1,54 @@
+Prompt-Version: v1
+
+# Build brief: Habit Tracker — Loco (Rust)
+
+Read `prompts/_core.md` and `SPEC.md` first; they define the app, the exact JSON
+API contract, and the streak semantics. Everything there applies. Below are the
+Loco-specific bootstrapping notes.
+
+## Framework facts
+
+- Use **Loco** (`loco-rs`), the Rails-inspired Rust framework built on axum +
+  SeaORM.
+- Scaffold: `cargo install loco` (or `loco-cli`), then
+  `loco new` and pick the **SaaS / server-side-rendered** starter (you need an
+  HTML view), backed by Postgres or SQLite.
+- **Models / migrations.**
+  - Generate a `habits` model (`name` string, `description` nullable text,
+    `created_at` timestamp) and a `completions` model (`habit_id` FK, `day` date)
+    via `cargo loco generate model ...` / migration files under `migration/`.
+  - Add a unique index on `(habit_id, day)` in the migration; a SeaORM insert
+    that violates it returns a DB error you map to **409**. Add an
+    `ON DELETE CASCADE` FK so completions are removed with their habit.
+  - Run migrations with `cargo loco db migrate`.
+- **Controllers / routes.** Loco controllers are axum handlers grouped into
+  `Routes` and registered in `app.rs`:
+  - JSON endpoints under `/api/habits` (create/list/get/update/delete/complete),
+    returning `Result<Response>` with explicit statuses via
+    `format::json(...)` and `axum::http::StatusCode` (`201`, `204`, `409`, `422`,
+    `404`).
+  - An HTML endpoint `GET /` returning a server-rendered view (Tera/`format::html`)
+    listing habits with `text/html`.
+- **Validation.** Use the `validator` crate on request structs (`#[validate(...)]`)
+  → 422. Parse the completion date with
+  `chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d")`; parse error → 422/400.
+- **Streak.** Compute `current_streak` per `SPEC.md` §3 in Rust from the
+  completion dates; `history` = dates sorted descending as ISO `YYYY-MM-DD`
+  strings.
+- **Seed / demo data.** Loco supports seeds (`src/fixtures` / a `seed` task or a
+  `cargo loco task`); insert a couple of demo habits with completions.
+- **Tests.** `cargo test` with Loco's `testing` helpers (`request` /
+  `boot_test`) hitting the endpoints.
+
+## run.sh
+
+```sh
+#!/usr/bin/env sh
+set -e
+cargo loco db migrate
+cargo loco task seed || true                # your seed task
+exec cargo loco start --server-and-worker --binding 0.0.0.0 --port "${PORT:-8080}"
+```
+
+`cargo loco start` blocks while the server runs. (Adjust flags to your Loco
+version; the key requirement is binding to `PORT`, default 8080.)

--- a/benchmarks/agentic-habit-tracker/prompts/phase2_maintenance.md
+++ b/benchmarks/agentic-habit-tracker/prompts/phase2_maintenance.md
@@ -1,0 +1,48 @@
+Prompt-Version: v1
+
+# Phase-2 maintenance brief: Archived habits
+
+This is a **follow-up** brief handed to the agent after the phase-1 app is built
+and green. It measures how quickly and cleanly an agent can extend an existing
+codebase (maintainability under change), not greenfield build speed.
+
+Work in the same app the phase-1 trial produced. Do not rewrite it — make the
+smallest correct change that satisfies the new requirement, keeping the existing
+API contract (`SPEC.md` §1-3) fully working.
+
+## The change: soft-delete / hide via an `archived` flag
+
+1. **Data.** Add an `archived` boolean to the habit, defaulting to `false`. Add a
+   migration (do not drop or recreate existing data).
+
+2. **New endpoint.** `POST /api/habits/{id}/archive`
+   - Sets `archived = true` for the habit.
+   - Idempotent: archiving an already-archived habit is not an error.
+   - Success: **200** (returning the updated habit) or **204**.
+   - Unknown `id`: **404**.
+
+3. **Listing behavior.**
+   - `GET /api/habits` (no query) now returns **only non-archived** habits.
+   - `GET /api/habits?archived=true` returns **only archived** habits.
+   - (`GET /api/habits?archived=false` MAY be treated the same as no query.)
+
+4. **Preserve everything else.**
+   - `GET /api/habits/{id}` still works for archived habits (still 200, still
+     shows streak + history). Archiving is a hide/soft-delete, not a delete —
+     the record and its completions are retained.
+   - The HTML view at `GET /` should list non-archived habits (matching the
+     default list behavior).
+   - All phase-1 endpoints, status codes, and streak semantics remain unchanged.
+
+5. **Tests.** Add tests covering: a newly created habit is not archived; after
+   `POST /archive` it disappears from the default list; it appears under
+   `?archived=true`; the archive endpoint is idempotent; `GET /api/habits/{id}`
+   still returns the archived habit.
+
+## How this phase is scored
+
+Same three axes as phase 1 (`rubric.md`): speed (time + tool calls to green),
+correctness (a phase-2 visible + hidden check set for the archive feature), and
+maintainability (diff size, whether existing tests still pass, whether the change
+follows the codebase's existing conventions rather than bolting on a parallel
+path).

--- a/benchmarks/agentic-habit-tracker/prompts/phoenix.md
+++ b/benchmarks/agentic-habit-tracker/prompts/phoenix.md
@@ -1,0 +1,52 @@
+Prompt-Version: v1
+
+# Build brief: Habit Tracker — Phoenix (Elixir)
+
+Read `prompts/_core.md` and `SPEC.md` first; they define the app, the exact JSON
+API contract, and the streak semantics. Everything there applies. Below are the
+Phoenix-specific bootstrapping notes.
+
+## Framework facts
+
+- Use the **Phoenix** web framework (Elixir) with **Ecto** for persistence.
+- Scaffold: `mix phx.new habit_tracker` (Postgres by default; SQLite via
+  `--database sqlite3` is also acceptable). This gives you a controller-rendered
+  HTML view out of the box for `GET /`.
+- **Schemas / migrations.**
+  - `Habit` (`name`, `description` nullable, `inserted_at` → expose as
+    `created_at`).
+  - `Completion` (`belongs_to :habit`, `date :date`) with a unique index on
+    `[:habit_id, :date]` in the migration. Insert via a changeset with
+    `unique_constraint(:date, name: :completions_habit_id_date_index)`; a
+    changeset error on the unique constraint → **409**. Configure the habit's
+    `has_many :completions` with `on_delete: :delete_all` (cascade).
+  - `mix ecto.create && mix ecto.migrate`.
+- **Router / controllers** (`lib/habit_tracker_web/router.ex`):
+  - A `:api` pipeline (`plug :accepts, ["json"]`) scoped at `/api` with a
+    `HabitController` implementing the JSON endpoints. Set statuses explicitly
+    with `put_status(conn, :created | :no_content | :conflict |
+    :unprocessable_entity | :not_found)` and `json/2` / `send_resp/3`.
+  - A `:browser` pipeline serving `GET /` → an HTML template (`text/html`)
+    listing habits (a controller + `.html.heex` template, or a LiveView).
+- **Validation.** Ecto changeset `validate_required([:name])` → 422. Parse the
+  completion date with `Date.from_iso8601/1`; an `:error` result → 422/400.
+- **Streak.** Compute `current_streak` per `SPEC.md` §3 in Elixir from the
+  completion dates; `history` = dates sorted descending as ISO `YYYY-MM-DD`
+  strings.
+- **Seed / demo data.** `priv/repo/seeds.exs` inserting a couple of demo habits
+  with completions; run via `mix run priv/repo/seeds.exs`.
+- **Tests.** `mix test` with `Phoenix.ConnTest` for the JSON + HTML endpoints.
+
+## run.sh
+
+```sh
+#!/usr/bin/env sh
+set -e
+mix deps.get
+mix ecto.setup                      # create + migrate + seed (aliases in mix.exs)
+PORT="${PORT:-8080}" exec mix phx.server
+```
+
+Ensure the endpoint reads `PORT` (Phoenix's generated `runtime.exs`/`config`
+supports `http: [port: String.to_integer(System.get_env("PORT") || "8080")]`).
+`mix phx.server` blocks while running.

--- a/benchmarks/agentic-habit-tracker/prompts/rails.md
+++ b/benchmarks/agentic-habit-tracker/prompts/rails.md
@@ -1,0 +1,55 @@
+Prompt-Version: v1
+
+# Build brief: Habit Tracker — Ruby on Rails
+
+Read `prompts/_core.md` and `SPEC.md` first; they define the app, the exact JSON
+API contract, and the streak semantics. Everything there applies. Below are the
+Rails-specific bootstrapping notes.
+
+## Framework facts
+
+- Use **Ruby on Rails** (a full app, not `--api`-only, since you need a
+  server-rendered HTML view).
+- Scaffold: `rails new habittracker` (SQLite default is fine; Postgres also ok).
+- **Models.**
+  - `rails g model Habit name:string description:text` (`created_at` is provided
+    by Rails timestamps).
+  - `rails g model Completion habit:references date:date` and add a unique index
+    on `[:habit_id, :date]` in the migration so a duplicate raises
+    `ActiveRecord::RecordNotUnique` → rescue and return **409**.
+  - `Habit has_many :completions, dependent: :destroy` (cascade on delete).
+- **Routes** (`config/routes.rb`):
+  ```ruby
+  root "habits#page"                       # GET / → HTML view
+  namespace :api do
+    resources :habits do
+      post :complete, on: :member          # POST /api/habits/:id/complete
+    end
+  end
+  ```
+- **Controllers.** `Api::HabitsController` renders JSON with explicit statuses:
+  `render json: habit, status: :created` (201), `head :no_content` (204),
+  `status: :conflict` (409), `status: :unprocessable_entity` (422),
+  `status: :not_found` (404). A separate `HabitsController#page` renders an
+  `.html.erb` view (`text/html`).
+- **Validation.** `validates :name, presence: true`. Parse the completion date
+  with `Date.iso8601(params[:date])` and rescue `ArgumentError` → 422/400.
+- **Streak.** Compute `current_streak` per `SPEC.md` §3 in Ruby from the ordered
+  completion dates; `history` = dates sorted descending as ISO strings.
+- **Seed / demo data.** `db/seeds.rb` creating a couple of demo habits with
+  completions; run via `rails db:seed`.
+- **Tests.** Minitest (`rails test`) or RSpec request specs covering the core
+  behavior.
+
+## run.sh
+
+```sh
+#!/usr/bin/env sh
+set -e
+bundle install
+bin/rails db:prepare        # create + migrate
+bin/rails db:seed
+exec bin/rails server -b 0.0.0.0 -p "${PORT:-8080}"
+```
+
+`rails server` blocks while running.

--- a/benchmarks/agentic-habit-tracker/prompts/springboot.md
+++ b/benchmarks/agentic-habit-tracker/prompts/springboot.md
@@ -1,0 +1,54 @@
+Prompt-Version: v1
+
+# Build brief: Habit Tracker — Spring Boot
+
+Read `prompts/_core.md` and `SPEC.md` first; they define the app, the exact JSON
+API contract, and the streak semantics. Everything there applies. Below are the
+Spring Boot-specific bootstrapping notes.
+
+## Framework facts
+
+- Use **Spring Boot** (Java or Kotlin) with **Spring Web**, **Spring Data JPA**,
+  and a template engine (**Thymeleaf**) for the HTML view.
+- Scaffold via Spring Initializr (`spring init` CLI or start.spring.io)
+  with dependencies: `web`, `data-jpa`, `thymeleaf`, plus a database driver
+  (H2 in-memory or Postgres — H2 file/mem is fine for the benchmark).
+- **Entities.**
+  - `Habit` (`id`, `name`, `description` nullable, `createdAt`).
+  - `Completion` (`id`, `@ManyToOne Habit`, `LocalDate date`) with a unique
+    constraint on `(habit_id, date)`
+    (`@Table(uniqueConstraints=@UniqueConstraint(columnNames={"habit_id","date"}))`).
+    A `DataIntegrityViolationException` on insert → **409**. Cascade delete of
+    completions when a habit is removed (`cascade = ALL, orphanRemoval = true`).
+- **Controllers.**
+  - `@RestController @RequestMapping("/api/habits")` with `@PostMapping`,
+    `@GetMapping`, `@GetMapping("/{id}")`, `@PutMapping("/{id}")`,
+    `@DeleteMapping("/{id}")`, `@PostMapping("/{id}/complete")`. Return
+    `ResponseEntity` with explicit statuses (`201`, `200`, `204`, `409`, `404`,
+    `422`/`400`).
+  - A separate `@Controller` with `@GetMapping("/")` returning a Thymeleaf
+    template name → `text/html` listing habits.
+- **DTOs.** Response DTOs matching `SPEC.md` field names (`created_at`,
+  `current_streak`, `history`). Configure Jackson snake_case for these fields
+  (e.g. `@JsonProperty("created_at")` or a `PropertyNamingStrategy`), since the
+  contract uses snake_case.
+- **Validation.** `@NotBlank` on `name` (via `@Valid`) → 422/400 (a
+  `@ControllerAdvice` mapping `MethodArgumentNotValidException` to 422). Parse
+  the date with `LocalDate.parse(...)`; catch `DateTimeParseException` → 422/400.
+- **Streak.** Compute `current_streak` per `SPEC.md` §3 from the completion
+  dates; `history` = dates sorted descending as ISO `YYYY-MM-DD` strings.
+- **Seed / demo data.** A `CommandLineRunner` bean (or `data.sql`) inserting a
+  couple of demo habits with completions on startup.
+- **Tests.** JUnit + `@SpringBootTest` / `MockMvc` or `TestRestTemplate`.
+
+## run.sh
+
+```sh
+#!/usr/bin/env sh
+set -e
+./mvnw -q package -DskipTests    # or ./gradlew bootJar
+exec java -jar target/*.jar --server.port="${PORT:-8080}"
+```
+
+(Or `./mvnw spring-boot:run -Dspring-boot.run.arguments=--server.port=${PORT:-8080}`.)
+The Java process blocks while the server runs.

--- a/benchmarks/agentic-habit-tracker/prompts/springboot.md
+++ b/benchmarks/agentic-habit-tracker/prompts/springboot.md
@@ -11,8 +11,16 @@ Spring Boot-specific bootstrapping notes.
 - Use **Spring Boot** (Java or Kotlin) with **Spring Web**, **Spring Data JPA**,
   and a template engine (**Thymeleaf**) for the HTML view.
 - Scaffold via Spring Initializr (`spring init` CLI or start.spring.io)
-  with dependencies: `web`, `data-jpa`, `thymeleaf`, plus a database driver
-  (H2 in-memory or Postgres — H2 file/mem is fine for the benchmark).
+  with dependencies: `web`, `data-jpa`, `thymeleaf`, plus a database driver.
+- **Persistence is a hard requirement (`_core.md` §1): no in-memory-only
+  storage.** H2 running in its default **in-memory** mode
+  (`jdbc:h2:mem:...`) is **NOT allowed** — its data is wiped when the JVM
+  exits, so it cannot satisfy the contract. Use a persistent relational store
+  whose data **survives a server restart**: either the benchmark **Postgres**
+  (`postgres://postgres:postgres@localhost:5432/...`,
+  `spring.datasource.url=jdbc:postgresql://localhost:5432/...`) or **H2 in
+  file mode** (on-disk, e.g. `jdbc:h2:file:./data/habits`). A file-backed H2
+  URL is fine; `jdbc:h2:mem:` is not.
 - **Entities.**
   - `Habit` (`id`, `name`, `description` nullable, `createdAt`).
   - `Completion` (`id`, `@ManyToOne Habit`, `LocalDate date`) with a unique

--- a/benchmarks/agentic-habit-tracker/rubric.md
+++ b/benchmarks/agentic-habit-tracker/rubric.md
@@ -62,8 +62,13 @@ Each framework can be run in two phases (see `README.md`):
   (archived habits) applied to the phase-1 app.
 
 Score each phase separately with its own `metrics.json` (the `phase` field
-distinguishes them). Phase 2 especially exercises the maintainability axis: how
-small and idiomatic the change is, and whether existing tests keep passing.
+distinguishes them). Phase-2 correctness is measured the same way as phase 1 —
+visible + hidden pass rates — but backed by the dedicated archive suites
+(`phase2/archive_test.py` visible, `phase2/archive_hidden_test.py` hidden), which
+actually exercise the archive endpoint and list filtering rather than only
+re-running the phase-1 tests. Phase 2 especially exercises the maintainability
+axis: how small and idiomatic the change is, and whether existing tests keep
+passing.
 
 ## Determinism
 

--- a/benchmarks/agentic-habit-tracker/rubric.md
+++ b/benchmarks/agentic-habit-tracker/rubric.md
@@ -1,0 +1,73 @@
+# Scoring rubric
+
+Three **separate** axes. They are reported independently and never collapsed
+into a single overall number — a framework can be fast but sloppy, or slow but
+rock-solid, and the benchmark is meant to surface that. `scripts/score.py`
+computes the speed and correctness numbers deterministically from a run's
+`metrics.json`; the two manual maintainability sub-scores are entered by a
+reviewer.
+
+## Axis 1 — SPEED
+
+Raw signals:
+
+- `wall_clock_seconds` — wall-clock time from the moment the agent starts until
+  the **first green** (all visible acceptance checks pass).
+- `agent_tool_calls` — number of tool calls the agent made to reach first green.
+
+Normalized (0-100, higher = faster), documented reference points in `score.py`:
+
+- **time_score**: 100 at `<= 120s`, 0 at `>= 3600s`, linear between.
+- **tool_call_score**: 100 at `<= 20` calls, 0 at `>= 300` calls, linear between.
+- **SPEED (normalized)** = mean of the two.
+
+Both raw and normalized values are reported.
+
+## Axis 2 — CORRECTNESS
+
+- `visible_pass_rate` = `visible_checks_passed / visible_checks_total`
+  (from `acceptance/contract_test.py`).
+- `hidden_pass_rate` = `hidden_checks_passed / hidden_checks_total`
+  (from `hidden/hidden_test.py`).
+
+Score (0-100):
+
+```
+CORRECTNESS = (0.40 * visible_pass_rate + 0.60 * hidden_pass_rate) * 100
+```
+
+Hidden checks are weighted higher because they probe the streak edge cases that
+distinguish a correct implementation from one that only passes the obvious happy
+path.
+
+## Axis 3 — MAINTAINABILITY
+
+Reported as a set of signals, not reduced to one score:
+
+- `generated_loc` — lines of code the agent generated for the app (lower is
+  better, but **not zero** — an empty app fails correctness). Count app source
+  only; exclude vendored dependencies and lockfiles.
+- `has_tests` — boolean: did the agent ship automated tests for core behavior?
+- `readme_quality` — manual 0-3: are the run instructions present, accurate, and
+  sufficient to boot + exercise the app? (0 none, 1 minimal, 2 good, 3 excellent).
+- `uses_conventions` — manual 0-3: does the code follow the framework's idioms
+  and layout rather than fighting them? (0 anti-idiomatic, 3 fully idiomatic).
+
+## Phases
+
+Each framework can be run in two phases (see `README.md`):
+
+- **Phase 1** — greenfield build from `prompts/<fw>.md`.
+- **Phase 2** — the maintenance change from `prompts/phase2_maintenance.md`
+  (archived habits) applied to the phase-1 app.
+
+Score each phase separately with its own `metrics.json` (the `phase` field
+distinguishes them). Phase 2 especially exercises the maintainability axis: how
+small and idiomatic the change is, and whether existing tests keep passing.
+
+## Determinism
+
+`score.py` is a pure function of `metrics.json` — same input, same output. It
+performs no timing, no network, and no filesystem discovery beyond reading the
+given metrics file. All wall-clock measurement happens during the trial and is
+recorded into `metrics.json`; scoring only reads it back.

--- a/benchmarks/agentic-habit-tracker/runs/README.md
+++ b/benchmarks/agentic-habit-tracker/runs/README.md
@@ -1,0 +1,24 @@
+# runs/
+
+One subdirectory per trial: `runs/<run-id>/`. A good `run-id` encodes the
+framework, phase, and date, e.g. `autumn-p1-2026-07-12` or
+`django-p2-2026-07-12`.
+
+Each run directory stores everything needed to reproduce and audit the trial:
+
+```
+runs/<run-id>/
+  prompt.md          # exact prompt handed to the agent (copy of prompts/<fw>.md
+                     # or prompts/phase2_maintenance.md, incl. its Prompt-Version)
+  transcript.md      # the agent's full transcript / tool-call log
+  app/               # the generated application (or a pointer/README if the app
+                     # lives elsewhere, e.g. a separate repo or worktree)
+  test-output.txt    # captured stdout of contract_test.py and hidden_test.py
+                     # (the PASS/FAIL lines and RESULT: X/Y summaries)
+  metrics.json       # per-run metrics (see ../metrics-schema.json)
+  score.txt          # captured output of scripts/score.py metrics.json
+```
+
+`runs/` is intentionally kept in the tree via `.gitkeep`. Whether to commit
+individual run artifacts (transcripts, generated apps) is up to the operator;
+large generated apps may be pointed to rather than committed.

--- a/benchmarks/agentic-habit-tracker/scripts/prepare_agent_workspace.sh
+++ b/benchmarks/agentic-habit-tracker/scripts/prepare_agent_workspace.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# prepare_agent_workspace.sh — assemble a builder-visible workspace for a trial.
+#
+# The habit-tracker harness lives inside the framework repos it evaluates, so a
+# raw checkout hands the building agent the *executable* hidden suites
+# (hidden/, phase2/archive_hidden_test.py) that decide 60% of the score. Running
+# a trial from a workspace prepared by this script — instead of the raw
+# checkout — walls those evaluator-only materials off: only the builder-visible
+# brief, spec, and visible suites are copied.
+#
+# Usage:
+#   prepare_agent_workspace.sh <framework> <dest-dir>
+#     <framework>  one of: autumn django rails springboot phoenix loco
+#     <dest-dir>   directory to populate (created if missing)
+#
+# Copies ONLY builder-visible materials:
+#   SPEC.md, prompts/_core.md, prompts/<framework>.md, acceptance/,
+#   phase2/archive_test.py
+# and NEVER copies hidden/, phase2/archive_hidden_test.py, scripts/score.py,
+# rubric.md, metrics-schema.json, or runs/.
+set -euo pipefail
+
+VALID_FRAMEWORKS="autumn django rails springboot phoenix loco"
+
+usage() {
+    echo "Usage: prepare_agent_workspace.sh <framework> <dest-dir>" >&2
+    echo "  <framework>  one of: ${VALID_FRAMEWORKS}" >&2
+    echo "  <dest-dir>   directory to populate (created if missing)" >&2
+}
+
+framework="${1:-}"
+dest="${2:-}"
+
+if [[ -z "${framework}" ]]; then
+    echo "error: missing <framework> argument" >&2
+    usage
+    exit 1
+fi
+
+valid=0
+for f in ${VALID_FRAMEWORKS}; do
+    if [[ "${framework}" == "${f}" ]]; then
+        valid=1
+        break
+    fi
+done
+if [[ "${valid}" -ne 1 ]]; then
+    echo "error: unknown framework '${framework}' (valid: ${VALID_FRAMEWORKS})" >&2
+    exit 1
+fi
+
+if [[ -z "${dest}" ]]; then
+    echo "error: missing <dest-dir> argument" >&2
+    usage
+    exit 1
+fi
+
+# Resolve the harness root (this script lives in <harness>/scripts/).
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+harness_root="$(cd "${script_dir}/.." && pwd)"
+
+framework_prompt="${harness_root}/prompts/${framework}.md"
+if [[ ! -f "${framework_prompt}" ]]; then
+    echo "error: no prompt found for framework '${framework}' at ${framework_prompt}" >&2
+    exit 1
+fi
+
+mkdir -p "${dest}/prompts" "${dest}/phase2"
+
+# Builder-visible materials only.
+cp "${harness_root}/SPEC.md" "${dest}/SPEC.md"
+cp "${harness_root}/prompts/_core.md" "${dest}/prompts/_core.md"
+cp "${framework_prompt}" "${dest}/prompts/${framework}.md"
+cp -R "${harness_root}/acceptance" "${dest}/acceptance"
+cp "${harness_root}/phase2/archive_test.py" "${dest}/phase2/archive_test.py"
+
+echo "Prepared builder-visible workspace for '${framework}' at: ${dest}"
+echo "Copied:"
+echo "  SPEC.md"
+echo "  prompts/_core.md"
+echo "  prompts/${framework}.md"
+echo "  acceptance/  (visible acceptance suite)"
+echo "  phase2/archive_test.py  (visible phase-2 suite)"
+echo
+echo "NOTE: hidden suites are evaluator-only and were deliberately NOT copied:"
+echo "  hidden/, phase2/archive_hidden_test.py, scripts/score.py,"
+echo "  rubric.md, metrics-schema.json, runs/"
+echo "Never expose those to the building agent."

--- a/benchmarks/agentic-habit-tracker/scripts/prepare_agent_workspace.sh
+++ b/benchmarks/agentic-habit-tracker/scripts/prepare_agent_workspace.sh
@@ -10,13 +10,16 @@
 # brief, spec, and visible suites are copied.
 #
 # Usage:
-#   prepare_agent_workspace.sh <framework> <dest-dir>
+#   prepare_agent_workspace.sh [--force] <framework> <dest-dir>
 #     <framework>  one of: autumn django rails springboot phoenix loco
-#     <dest-dir>   directory to populate (created if missing)
+#     <dest-dir>   directory to populate (created if missing, must be empty
+#                  unless --force is given)
+#     --force      if <dest-dir> exists and is non-empty, wipe it and recreate
+#                  it fresh before copying
 #
 # Copies ONLY builder-visible materials:
-#   SPEC.md, prompts/_core.md, prompts/<framework>.md, acceptance/,
-#   phase2/archive_test.py
+#   SPEC.md, prompts/_core.md, prompts/<framework>.md,
+#   prompts/phase2_maintenance.md, acceptance/, phase2/archive_test.py
 # and NEVER copies hidden/, phase2/archive_hidden_test.py, scripts/score.py,
 # rubric.md, metrics-schema.json, or runs/.
 set -euo pipefail
@@ -24,13 +27,29 @@ set -euo pipefail
 VALID_FRAMEWORKS="autumn django rails springboot phoenix loco"
 
 usage() {
-    echo "Usage: prepare_agent_workspace.sh <framework> <dest-dir>" >&2
+    echo "Usage: prepare_agent_workspace.sh [--force] <framework> <dest-dir>" >&2
     echo "  <framework>  one of: ${VALID_FRAMEWORKS}" >&2
-    echo "  <dest-dir>   directory to populate (created if missing)" >&2
+    echo "  <dest-dir>   directory to populate (created if missing, must be empty unless --force)" >&2
+    echo "  --force      wipe and recreate <dest-dir> if it exists and is non-empty" >&2
 }
 
-framework="${1:-}"
-dest="${2:-}"
+# Parse args: --force may appear in any position; the two positional args are
+# <framework> and <dest-dir> in order.
+force=0
+positionals=()
+for arg in "$@"; do
+    case "${arg}" in
+        --force)
+            force=1
+            ;;
+        *)
+            positionals+=("${arg}")
+            ;;
+    esac
+done
+
+framework="${positionals[0]:-}"
+dest="${positionals[1]:-}"
 
 if [[ -z "${framework}" ]]; then
     echo "error: missing <framework> argument" >&2
@@ -66,12 +85,35 @@ if [[ ! -f "${framework_prompt}" ]]; then
     exit 1
 fi
 
+# Make the destination provably clean before copying, so stale evaluator-only
+# files from a prior copy can never survive and be mislabeled as "not copied".
+if [[ -e "${dest}" ]]; then
+    if [[ ! -d "${dest}" ]]; then
+        echo "error: dest '${dest}' exists and is not a directory" >&2
+        exit 1
+    fi
+    if [[ -n "$(ls -A "${dest}" 2>/dev/null)" ]]; then
+        # Non-empty destination.
+        if [[ "${force}" -ne 1 ]]; then
+            echo "error: dest '${dest}' exists and is not empty; re-run with --force to overwrite" >&2
+            exit 1
+        fi
+        # --force: wipe and recreate. Guard rm -rf against empty/root paths.
+        if [[ -z "${dest}" || "${dest}" == "/" ]]; then
+            echo "error: refusing to 'rm -rf' unsafe dest path '${dest}'" >&2
+            exit 1
+        fi
+        rm -rf "${dest}"
+    fi
+fi
+
 mkdir -p "${dest}/prompts" "${dest}/phase2"
 
 # Builder-visible materials only.
 cp "${harness_root}/SPEC.md" "${dest}/SPEC.md"
 cp "${harness_root}/prompts/_core.md" "${dest}/prompts/_core.md"
 cp "${framework_prompt}" "${dest}/prompts/${framework}.md"
+cp "${harness_root}/prompts/phase2_maintenance.md" "${dest}/prompts/phase2_maintenance.md"
 cp -R "${harness_root}/acceptance" "${dest}/acceptance"
 cp "${harness_root}/phase2/archive_test.py" "${dest}/phase2/archive_test.py"
 
@@ -80,6 +122,7 @@ echo "Copied:"
 echo "  SPEC.md"
 echo "  prompts/_core.md"
 echo "  prompts/${framework}.md"
+echo "  prompts/phase2_maintenance.md  (visible phase-2 build brief)"
 echo "  acceptance/  (visible acceptance suite)"
 echo "  phase2/archive_test.py  (visible phase-2 suite)"
 echo

--- a/benchmarks/agentic-habit-tracker/scripts/score.py
+++ b/benchmarks/agentic-habit-tracker/scripts/score.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Deterministic scorer for the habit-tracker benchmark.
+
+Reads a run's metrics.json and prints three SEPARATE axis scores
+(speed / correctness / maintainability) plus a summary table. It never collapses
+them into a single number.
+
+Deterministic: the output is a pure function of metrics.json. There are NO
+wall-clock calls in this script — the elapsed time is read from the metrics
+file, not measured here.
+
+Usage:
+    python3 score.py runs/<run-id>/metrics.json
+    python3 score.py runs/<run-id>            # dir containing metrics.json
+"""
+
+import json
+import os
+import sys
+
+# Normalization reference points (documented, fixed -> deterministic).
+SPEED_FAST_SECONDS = 120.0     # <= this scores 100 on the time sub-axis
+SPEED_SLOW_SECONDS = 3600.0    # >= this scores 0 on the time sub-axis
+SPEED_FEW_CALLS = 20.0         # <= this scores 100 on the tool-call sub-axis
+SPEED_MANY_CALLS = 300.0       # >= this scores 0 on the tool-call sub-axis
+
+VISIBLE_WEIGHT = 0.40
+HIDDEN_WEIGHT = 0.60
+
+
+def clamp01(x):
+    return max(0.0, min(1.0, x))
+
+
+def linear_score(value, best, worst):
+    """Map value to 0..100; `best` -> 100, `worst` -> 0, clamped."""
+    if best == worst:
+        return 100.0
+    return 100.0 * clamp01((worst - value) / (worst - best))
+
+
+def safe_ratio(num, den):
+    if not den:
+        return 0.0
+    return num / den
+
+
+def load_metrics(path):
+    if os.path.isdir(path):
+        path = os.path.join(path, "metrics.json")
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f), path
+
+
+def score_speed(m):
+    secs = float(m.get("wall_clock_seconds", 0) or 0)
+    calls = float(m.get("agent_tool_calls", 0) or 0)
+    time_score = linear_score(secs, SPEED_FAST_SECONDS, SPEED_SLOW_SECONDS)
+    call_score = linear_score(calls, SPEED_FEW_CALLS, SPEED_MANY_CALLS)
+    normalized = round((time_score + call_score) / 2.0, 1)
+    return {
+        "wall_clock_seconds": secs,
+        "agent_tool_calls": calls,
+        "time_score": round(time_score, 1),
+        "tool_call_score": round(call_score, 1),
+        "normalized": normalized,
+    }
+
+
+def score_correctness(m):
+    vis = safe_ratio(
+        m.get("visible_checks_passed", 0), m.get("visible_checks_total", 0)
+    )
+    hid = safe_ratio(
+        m.get("hidden_checks_passed", 0), m.get("hidden_checks_total", 0)
+    )
+    score = round((VISIBLE_WEIGHT * vis + HIDDEN_WEIGHT * hid) * 100.0, 1)
+    return {
+        "visible_pass_rate": round(vis, 3),
+        "hidden_pass_rate": round(hid, 3),
+        "score": score,
+    }
+
+
+def score_maintainability(m):
+    return {
+        "generated_loc": int(m.get("generated_loc", 0) or 0),
+        "has_tests": bool(m.get("has_tests", False)),
+        "readme_quality": int(m.get("readme_quality", 0) or 0),      # 0-3 manual
+        "uses_conventions": int(m.get("uses_conventions", 0) or 0),  # 0-3 manual
+    }
+
+
+def bar(pct, width=20):
+    filled = int(round(clamp01(pct / 100.0) * width))
+    return "#" * filled + "-" * (width - filled)
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: score.py <runs/<run-id>/metrics.json | runs/<run-id>>")
+        sys.exit(2)
+
+    m, path = load_metrics(sys.argv[1])
+
+    speed = score_speed(m)
+    correctness = score_correctness(m)
+    maint = score_maintainability(m)
+
+    fw = m.get("framework", "?")
+    pv = m.get("prompt_version", "?")
+    phase = m.get("phase", "?")
+
+    print(f"metrics: {path}")
+    print(f"framework={fw}  prompt_version={pv}  phase={phase}")
+    print()
+
+    print("== SPEED ==")
+    print(f"  wall_clock_seconds : {speed['wall_clock_seconds']:.1f}")
+    print(f"  agent_tool_calls   : {int(speed['agent_tool_calls'])}")
+    print(f"  time_score         : {speed['time_score']:.1f} / 100")
+    print(f"  tool_call_score    : {speed['tool_call_score']:.1f} / 100")
+    print(f"  SPEED (normalized) : {speed['normalized']:.1f} / 100  [{bar(speed['normalized'])}]")
+    print()
+
+    print("== CORRECTNESS ==")
+    print(f"  visible_pass_rate  : {correctness['visible_pass_rate']:.3f}"
+          f"  ({m.get('visible_checks_passed', 0)}/{m.get('visible_checks_total', 0)})")
+    print(f"  hidden_pass_rate   : {correctness['hidden_pass_rate']:.3f}"
+          f"  ({m.get('hidden_checks_passed', 0)}/{m.get('hidden_checks_total', 0)})")
+    print(f"  weighting          : visible {int(VISIBLE_WEIGHT*100)}% / hidden {int(HIDDEN_WEIGHT*100)}%")
+    print(f"  CORRECTNESS        : {correctness['score']:.1f} / 100  [{bar(correctness['score'])}]")
+    print()
+
+    print("== MAINTAINABILITY (reported, not collapsed) ==")
+    print(f"  generated_loc      : {maint['generated_loc']}")
+    print(f"  has_tests          : {maint['has_tests']}")
+    print(f"  readme_quality     : {maint['readme_quality']} / 3  (manual)")
+    print(f"  uses_conventions   : {maint['uses_conventions']} / 3  (manual)")
+    print()
+
+    print("== SUMMARY ==")
+    print(f"  {'axis':<16}{'score':>10}")
+    print(f"  {'-'*16}{'-'*10:>10}")
+    print(f"  {'speed':<16}{speed['normalized']:>10.1f}")
+    print(f"  {'correctness':<16}{correctness['score']:>10.1f}")
+    print(f"  {'maintainability':<16}{'(see above)':>10}")
+    notes = m.get("notes")
+    if notes:
+        print()
+        print(f"notes: {notes}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/agentic-habit-tracker/scripts/score.py
+++ b/benchmarks/agentic-habit-tracker/scripts/score.py
@@ -69,10 +69,10 @@ def score_speed(m):
 
 def score_correctness(m):
     vis = safe_ratio(
-        m.get("visible_checks_passed", 0), m.get("visible_checks_total", 0)
+        m.get("visible_checks_passed") or 0, m.get("visible_checks_total") or 0
     )
     hid = safe_ratio(
-        m.get("hidden_checks_passed", 0), m.get("hidden_checks_total", 0)
+        m.get("hidden_checks_passed") or 0, m.get("hidden_checks_total") or 0
     )
     score = round((VISIBLE_WEIGHT * vis + HIDDEN_WEIGHT * hid) * 100.0, 1)
     return {
@@ -125,9 +125,9 @@ def main():
 
     print("== CORRECTNESS ==")
     print(f"  visible_pass_rate  : {correctness['visible_pass_rate']:.3f}"
-          f"  ({m.get('visible_checks_passed', 0)}/{m.get('visible_checks_total', 0)})")
+          f"  ({m.get('visible_checks_passed') or 0}/{m.get('visible_checks_total') or 0})")
     print(f"  hidden_pass_rate   : {correctness['hidden_pass_rate']:.3f}"
-          f"  ({m.get('hidden_checks_passed', 0)}/{m.get('hidden_checks_total', 0)})")
+          f"  ({m.get('hidden_checks_passed') or 0}/{m.get('hidden_checks_total') or 0})")
     print(f"  weighting          : visible {int(VISIBLE_WEIGHT*100)}% / hidden {int(HIDDEN_WEIGHT*100)}%")
     print(f"  CORRECTNESS        : {correctness['score']:.1f} / 100  [{bar(correctness['score'])}]")
     print()


### PR DESCRIPTION
## What

Adds a benchmark harness that measures **agentic developer experience**: how quickly and reliably an AI coding agent can build — and then modify — the same small-but-non-trivial habit-tracker app across web frameworks. It scores **speed, correctness, and maintainability on separate axes** rather than collapsing them into one number.

Before: Autumn had runtime benchmarks (server performance once an app exists) but no way to measure how well an agent can *build* in Autumn versus peer frameworks.

After: a framework-agnostic, reproducible harness under `benchmarks/agentic-habit-tracker/` — point an agent at a versioned per-framework prompt, let it build the app, run the shared HTTP acceptance suite + hidden tests against it, and score it deterministically.

## How

- `SPEC.md` — the habit-tracker app spec plus a precise JSON API contract and exact streak semantics (backdated completions, &#34;today/yesterday&#34; anchoring, gap resets), so implementations are deterministic across frameworks.
- `prompts/` — versioned per-framework build briefs (`_core.md` + `autumn`, `django`, `rails`, `springboot`, `phoenix`, `loco`) and a `phase2_maintenance.md` follow-up brief.
- `acceptance/contract_test.py` — the shared **visible** acceptance suite: stdlib-only, HTTP-only against `BASE_URL`, so the same file scores any framework.
- `hidden/` — a documented-but-vague description of hidden checks plus `hidden_test.py` implementing streak edge cases the build agent never sees.
- `scripts/score.py` — deterministic scorer, three separate axes (speed / correctness / maintainability); pure function of a run&#39;s `metrics.json`.
- `metrics-schema.json`, `rubric.md`, `runs/README.md` — the metrics contract, scoring rubric, and per-run artifact layout.

Generated app artifacts are **not** checked in; each run produces them under `runs//app/` (gitignored). A harness-level `.gitignore` re-includes the harness Python scripts (the repo-root `.gitignore` globally ignores `*.py`/`*.sh`) while keeping generated apps and run logs out.

## Trial results (run in this session)

Ran real trials with an AI coding agent building the app to green. Correctness was independently re-scored, including hidden streak-edge tests the build agents never saw.

| Metric | Autumn (2 runs) | Django | Rails |
|---|---|---|---|
| Wall-clock to green | 709 / 551s | 330s | 686s |
| Agent tool-calls | 90 / 50 | 38 | 44 |
| Failed acceptance runs before green | 0 / 0 | 2 | 1 |
| Core LOC | 551 / 532 | 321 | ~255 |
| Visible acceptance | 31/31 | 31/31 | 31/31 |
| Hidden acceptance | 25/25 | 25/25 | 25/25 |

All three frameworks produced a fully correct app. The differentiator was the *path* to correct: Autumn cost the most agent wall-clock and tool-calls (niche framework → more example-reading, plus Rust compile latency per iteration) but had **zero failed acceptance runs** — its type system converted mistakes into compile errors. Django (default non-UTC `TIME_ZONE` desyncing &#34;today&#34;) and Rails (406 on the HTML root under a JSON `Accept` header) each shipped a plausible-but-wrong first version caught only at the test stage. Phase-2 maintenance (add archived habits) was clean and localized in both Autumn and Django.

### Scaffolded vs hand-built Autumn

A third Autumn run used the scaffolding CLI (`autumn new` + `autumn generate scaffold Habit ...`) after the Autumn prompt was updated to surface it (the first two runs hand-built from examples). For this **contract-shaped** app the CLI was **slower, not faster**: ~1623s / 135 tool-calls / 1004 LOC versus hand-built ~551s / 50 tool-calls / ~550 LOC — both with zero failed runs and both fully correct (scaffolded independently scored 32/32 visible · 26/26 hidden on the hardened suite). `generate scaffold` emits an HTML-CRUD `#[repository]` whose auto JSON handlers return a plain `Habit` (no streak/history, no `complete`/409, wrong status codes), so ~300 generated LOC were discarded and the JSON contract + streak logic hand-written anyway; the scaffold's real win was the project skeleton + model/migration (a SETUP-only head start). Autumn's scaffolding shines for CRUD-shaped apps; for this benchmark the hand-built numbers remain Autumn's fair representation — an honest negative result.

> Harness hardened through automated review (Gemini + Codex): server-date anchoring for streak/duplicate checks, fixed-denominator scoring (skipped checks count as failures), an evaluator/builder boundary + `prepare_agent_workspace.sh` (builders never see the hidden suites), Phase-2 archive suites, and content-negotiation-correct HTML checks (`Accept: text/html`). Visible/hidden totals are now **32/26** (+ phase-2 16/16).

Caveats: same LLM agent for every trial; wall-clock is agent iteration time on a shared 4-core VM (directional, not a microbenchmark); n=1 for peers; Phoenix/Elixir absent and Spring Boot not run in this session (3 of 6 frameworks exercised).

## Acceptance criteria (#646)

- [x] Benchmark harness under a documented location (`benchmarks/agentic-habit-tracker/`)
- [x] Shared visible acceptance / contract test suite checked in
- [x] Hidden-test expectations documented at a high level without exposing exact checks
- [x] Framework-specific prompts checked in and versioned (`Prompt-Version: v1`)
- [x] Each run stores logs, commands, generated artifacts, and score metadata (under `runs/`)
- [x] Scoring rubric is deterministic and documented (`rubric.md` + `scripts/score.py`)
- [x] Phase 1 and Phase 2 both supported
- [x] Results separate speed, correctness, and maintainability

Closes #646

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4aiF3YACqsmsHu65auNYj)_