### PR TITLE
⚒️ Forge: Refactor SelectSpec parsing using FromStr

### DIFF
--- a/autumn-cli/src/generate/admin.rs
+++ b/autumn-cli/src/generate/admin.rs
@@ -29,16 +29,10 @@ pub struct SelectSpec {
     pub values: Vec<String>,
 }
 
-/// Parse `--select` tokens of the form `field=val1,val2,...` or `field`.
-///
-/// The bare `field` form (no `=`) emits a `Select(vec![])` placeholder so the
-/// user can fill in options without editing generated internals.
-///
-/// # Errors
-/// Returns [`GenerateError::InvalidField`] if the token is blank.
-pub fn parse_select_specs(tokens: &[String]) -> Result<Vec<SelectSpec>, GenerateError> {
-    let mut out = Vec::with_capacity(tokens.len());
-    for token in tokens {
+impl std::str::FromStr for SelectSpec {
+    type Err = GenerateError;
+
+    fn from_str(token: &str) -> Result<Self, Self::Err> {
         let (field, values) = match token.split_once('=') {
             Some((f, v)) => (
                 f.trim().to_owned(),
@@ -51,13 +45,23 @@ pub fn parse_select_specs(tokens: &[String]) -> Result<Vec<SelectSpec>, Generate
         };
         if field.is_empty() {
             return Err(GenerateError::InvalidField {
-                token: token.clone(),
+                token: token.to_owned(),
                 reason: "field name is empty in --select spec".into(),
             });
         }
-        out.push(SelectSpec { field, values });
+        Ok(Self { field, values })
     }
-    Ok(out)
+}
+
+/// Parse `--select` tokens of the form `field=val1,val2,...` or `field`.
+///
+/// The bare `field` form (no `=`) emits a `Select(vec![])` placeholder so the
+/// user can fill in options without editing generated internals.
+///
+/// # Errors
+/// Returns [`GenerateError::InvalidField`] if the token is blank.
+pub fn parse_select_specs(tokens: &[String]) -> Result<Vec<SelectSpec>, GenerateError> {
+    tokens.iter().map(|t| t.parse()).collect()
 }
 
 /// Options specific to `autumn generate admin`.

--- a/pr_message.txt
+++ b/pr_message.txt
@@ -1,0 +1,13 @@
+⚒️ Forge: Refactor SelectSpec parsing using FromStr
+
+🚰 Smell:
+The `parse_select_specs` function in `autumn-cli/src/generate/admin.rs` contained business logic mixed with string parsing inside a mutable `for` loop, which violated Forge's readability guidelines and didn't use idiomatic Rust traits.
+
+✨ Solution:
+Extracted the string parsing logic into an idiomatic `std::str::FromStr` implementation for the `SelectSpec` struct. Refactored `parse_select_specs` to use a clean `.iter().map(|t| t.parse()).collect()` iterator chain.
+
+🧼 Benefit:
+Improves readability and separation of concerns by moving parsing logic out of the business layer and into a standardized trait, making the `parse_select_specs` function trivial.
+
+🛡️ Verification:
+Ran `cargo clippy -p autumn-cli --bin autumn -- -D warnings`, `cargo test -p autumn-cli --bin autumn`, and `cargo fmt --all`. Tests passed. No runtime logic was changed.


### PR DESCRIPTION
🚰 Smell:
The `parse_select_specs` function in `autumn-cli/src/generate/admin.rs` contained business logic mixed with string parsing inside a mutable `for` loop, which violated Forge's readability guidelines and didn't use idiomatic Rust traits.

✨ Solution:
Extracted the string parsing logic into an idiomatic `std::str::FromStr` implementation for the `SelectSpec` struct. Refactored `parse_select_specs` to use a clean `.iter().map(|t| t.parse()).collect()` iterator chain.

🧼 Benefit:
Improves readability and separation of concerns by moving parsing logic out of the business layer and into a standardized trait, making the `parse_select_specs` function trivial.

🛡️ Verification:
Ran `cargo clippy -p autumn-cli --bin autumn -- -D warnings`, `cargo test -p autumn-cli --bin autumn`, and `cargo fmt --all`. Tests passed. No runtime logic was changed.

---
*PR created automatically by Jules for task [17291903036361274066](https://jules.google.com/task/17291903036361274066) started by @madmax983*