### PR TITLE
Fix null git provenance in scaffolded Docker images (#1676)

### DIFF
--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -1258,6 +1258,115 @@ mod tests {
     }
 
     #[test]
+    fn generated_build_rs_reports_unknown_dirty_as_absent_not_false() {
+        // Codex P2 / issue #1676 regression: a container build supplies
+        // `AUTUMN_BUILD_GIT_SHA` but leaves `AUTUMN_BUILD_GIT_DIRTY` blank, and
+        // the Dockerfile excludes `/.git` so `git status` cannot run. The dirty
+        // state is then genuinely UNKNOWN and must be reported as absent/null on
+        // `/actuator/info`, NOT collapsed to a misleading `false`.
+        //
+        // Prove it end-to-end at the producer: compile the generated `build.rs`
+        // (which is verbatim Rust, no placeholders) and run its provenance
+        // emitter under a controlled environment. Env is passed to the child
+        // process (never mutated in-process), so this is isolated from other
+        // concurrently running tests.
+        let tmp = TempDir::new().unwrap();
+        generate("dirty-unknown-check", tmp.path()).unwrap();
+        let project = tmp.path().join("dirty-unknown-check");
+        let build_rs = project.join("build.rs");
+
+        // Compile the generated build.rs to a standalone binary. `--cap-lints
+        // allow` keeps a stray warning from failing under a strict RUSTFLAGS,
+        // and RUSTFLAGS is cleared for the same reason.
+        let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string());
+        let bin = project.join("provenance_probe");
+        let compile = std::process::Command::new(&rustc)
+            .arg(&build_rs)
+            .arg("--edition")
+            .arg("2021")
+            .arg("--cap-lints")
+            .arg("allow")
+            .arg("-o")
+            .arg(&bin)
+            .env_remove("RUSTFLAGS")
+            .output()
+            .expect("failed to spawn rustc");
+        assert!(
+            compile.status.success(),
+            "generated build.rs failed to compile:\n{}",
+            String::from_utf8_lossy(&compile.stderr)
+        );
+
+        // Run the emitter with a cleared environment (so `PATH` is unset and no
+        // `git` binary is reachable → git is genuinely unavailable), plus only
+        // the provenance env vars under test. Returns the emitted stdout.
+        let run = |vars: &[(&str, &str)]| -> String {
+            let mut cmd = std::process::Command::new(&bin);
+            cmd.current_dir(&project).env_clear();
+            for (k, v) in vars {
+                cmd.env(k, v);
+            }
+            let out = cmd.output().expect("failed to run provenance probe");
+            assert!(
+                out.status.success(),
+                "provenance probe exited non-zero:\n{}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            String::from_utf8(out.stdout).unwrap()
+        };
+
+        let has_dirty = |stdout: &str, value: &str| {
+            stdout
+                .lines()
+                .any(|l| l == format!("cargo:rustc-env=AUTUMN_BUILD_GIT_DIRTY={value}"))
+        };
+        let emits_any_dirty = |stdout: &str| {
+            stdout
+                .lines()
+                .any(|l| l.starts_with("cargo:rustc-env=AUTUMN_BUILD_GIT_DIRTY="))
+        };
+
+        // 1. SHA passthrough, dirty blank, no git → dirty is UNKNOWN → the var
+        //    is omitted entirely (consumer renders `git.dirty` as null).
+        let unknown = run(&[
+            (
+                "AUTUMN_BUILD_GIT_SHA",
+                "0123456789abcdef0123456789abcdef01234567",
+            ),
+            ("AUTUMN_BUILD_GIT_DIRTY", ""),
+        ]);
+        assert!(
+            unknown.lines().any(|l| l
+                == "cargo:rustc-env=AUTUMN_BUILD_GIT_SHA=0123456789abcdef0123456789abcdef01234567"),
+            "SHA passthrough should still be emitted:\n{unknown}"
+        );
+        assert!(
+            !emits_any_dirty(&unknown),
+            "unknown dirty state must NOT emit AUTUMN_BUILD_GIT_DIRTY (would render as `false`):\n{unknown}"
+        );
+
+        // 2. Explicit dirty=true round-trips even with no git.
+        let dirty_true = run(&[
+            ("AUTUMN_BUILD_GIT_SHA", "abc123"),
+            ("AUTUMN_BUILD_GIT_DIRTY", "true"),
+        ]);
+        assert!(
+            has_dirty(&dirty_true, "true"),
+            "explicit dirty=true must round-trip:\n{dirty_true}"
+        );
+
+        // 3. Explicit dirty=false round-trips (a genuinely clean, known build).
+        let dirty_false = run(&[
+            ("AUTUMN_BUILD_GIT_SHA", "abc123"),
+            ("AUTUMN_BUILD_GIT_DIRTY", "false"),
+        ]);
+        assert!(
+            has_dirty(&dirty_false, "false"),
+            "explicit dirty=false must round-trip:\n{dirty_false}"
+        );
+    }
+
+    #[test]
     fn no_unsubstituted_placeholders() {
         let tmp = TempDir::new().unwrap();
         generate("placeholder-check", tmp.path()).unwrap();

--- a/autumn-cli/src/new.rs
+++ b/autumn-cli/src/new.rs
@@ -1230,6 +1230,34 @@ mod tests {
     }
 
     #[test]
+    fn generated_build_rs_prefers_build_arg_provenance_over_git() {
+        // Issue #1676: containerized builds exclude `/.git` from the build
+        // context, so the generated build.rs must prefer `AUTUMN_BUILD_*` build
+        // args (Docker `--build-arg`/`ENV` passthrough) when set, falling back
+        // to git only for local checkout builds. Without this, production images
+        // report `git.*` as `null` on `/actuator/info`.
+        let tmp = TempDir::new().unwrap();
+        generate("build-arg-provenance-check", tmp.path()).unwrap();
+
+        let content =
+            fs::read_to_string(tmp.path().join("build-arg-provenance-check/build.rs")).unwrap();
+        // A dedicated helper reads the passthrough env vars.
+        assert!(content.contains("fn build_arg("));
+        // Each git field prefers the build arg, then falls back to git.
+        assert!(content.contains("build_arg(\"AUTUMN_BUILD_GIT_SHA\").or_else(|| git("));
+        assert!(content.contains("build_arg(\"AUTUMN_BUILD_GIT_SHA_SHORT\")"));
+        assert!(content.contains("build_arg(\"AUTUMN_BUILD_GIT_BRANCH\")"));
+        assert!(content.contains("build_arg(\"AUTUMN_BUILD_GIT_DIRTY\")"));
+        // Timestamp passthrough wins over the computed timestamp.
+        assert!(
+            content
+                .contains("build_arg(\"AUTUMN_BUILD_TIMESTAMP\").unwrap_or_else(build_timestamp)")
+        );
+        // Re-run when a passthrough build arg changes so deploys re-bake it.
+        assert!(content.contains("cargo:rerun-if-env-changed={var}"));
+    }
+
+    #[test]
     fn no_unsubstituted_placeholders() {
         let tmp = TempDir::new().unwrap();
         generate("placeholder-check", tmp.path()).unwrap();

--- a/autumn-cli/src/release.rs
+++ b/autumn-cli/src/release.rs
@@ -435,6 +435,49 @@ mod tests {
     }
 
     #[test]
+    fn dockerfile_passes_through_git_provenance_build_args() {
+        // Issue #1676: the build context excludes `/.git`, so the release
+        // Dockerfile must surface the `AUTUMN_BUILD_*` provenance as build-arg
+        // ENV before the build step. Otherwise the generated build.rs finds no
+        // git repo and the container reports `git.*` as `null` on
+        // `/actuator/info`, defeating deploy/rollback verification.
+        let tmp = TempDir::new().unwrap();
+        let dir = make_project(&tmp, "my-app");
+        init(&dir, "my-app", false, Target::Default, false).unwrap();
+        let content = fs::read_to_string(dir.join("Dockerfile")).unwrap();
+
+        for arg in [
+            "AUTUMN_BUILD_GIT_SHA",
+            "AUTUMN_BUILD_GIT_SHA_SHORT",
+            "AUTUMN_BUILD_GIT_BRANCH",
+            "AUTUMN_BUILD_GIT_DIRTY",
+            "AUTUMN_BUILD_TIMESTAMP",
+        ] {
+            assert!(
+                content.contains(&format!("ARG {arg}")),
+                "Dockerfile must declare `ARG {arg}` for git provenance passthrough: {content}"
+            );
+            assert!(
+                content.contains(&format!("{arg}=${{{arg}}}")),
+                "Dockerfile must surface `{arg}` as ENV so build.rs bakes it: {content}"
+            );
+        }
+
+        // The provenance ENV must precede the build step so the compile sees it.
+        let env_pos = content.find("AUTUMN_BUILD_GIT_SHA=${AUTUMN_BUILD_GIT_SHA}");
+        let build_pos = content.find("{{build_step}}").or_else(|| {
+            // `{{build_step}}` is already substituted; both variants run cargo.
+            content
+                .find("cargo build --release")
+                .or_else(|| content.find("autumn build --embed"))
+        });
+        assert!(
+            matches!((env_pos, build_pos), (Some(e), Some(b)) if e < b),
+            "provenance ENV must appear before the build step: {content}"
+        );
+    }
+
+    #[test]
     fn dockerfile_has_three_stages() {
         let tmp = TempDir::new().unwrap();
         let dir = make_project(&tmp, "my-app");

--- a/autumn-cli/src/templates/Dockerfile.tmpl
+++ b/autumn-cli/src/templates/Dockerfile.tmpl
@@ -18,6 +18,28 @@ COPY src ./src
 COPY static ./static
 COPY migrations ./migrations
 
+# Git/build provenance passthrough. The build context excludes `/.git` (see
+# .dockerignore), so the generated build.rs cannot shell out to git here.
+# Supply provenance explicitly and surface it as ENV, which build.rs prefers
+# over git and bakes into the binary for `/actuator/info`. Populate from CI, e.g:
+#   docker build \
+#     --build-arg AUTUMN_BUILD_GIT_SHA=$(git rev-parse HEAD) \
+#     --build-arg AUTUMN_BUILD_GIT_SHA_SHORT=$(git rev-parse --short HEAD) \
+#     --build-arg AUTUMN_BUILD_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) \
+#     --build-arg AUTUMN_BUILD_GIT_DIRTY=false \
+#     --build-arg AUTUMN_BUILD_TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ) .
+# Unset args stay empty and are ignored, so `/actuator/info` reports `null`.
+ARG AUTUMN_BUILD_GIT_SHA=
+ARG AUTUMN_BUILD_GIT_SHA_SHORT=
+ARG AUTUMN_BUILD_GIT_BRANCH=
+ARG AUTUMN_BUILD_GIT_DIRTY=
+ARG AUTUMN_BUILD_TIMESTAMP=
+ENV AUTUMN_BUILD_GIT_SHA=${AUTUMN_BUILD_GIT_SHA} \
+    AUTUMN_BUILD_GIT_SHA_SHORT=${AUTUMN_BUILD_GIT_SHA_SHORT} \
+    AUTUMN_BUILD_GIT_BRANCH=${AUTUMN_BUILD_GIT_BRANCH} \
+    AUTUMN_BUILD_GIT_DIRTY=${AUTUMN_BUILD_GIT_DIRTY} \
+    AUTUMN_BUILD_TIMESTAMP=${AUTUMN_BUILD_TIMESTAMP}
+
 RUN cargo build --release
 
 FROM debian:bookworm-slim AS runtime

--- a/autumn-cli/src/templates/build.rs.tmpl
+++ b/autumn-cli/src/templates/build.rs.tmpl
@@ -55,6 +55,11 @@ fn main() {
 /// The build timestamp is always emitted (passthrough `AUTUMN_BUILD_TIMESTAMP`
 /// wins, else `SOURCE_DATE_EPOCH` for reproducible builds, else wall clock).
 ///
+/// The `dirty` flag is three-state: an explicit `AUTUMN_BUILD_GIT_DIRTY` build
+/// arg wins; else the real `git status` (a *clean* tree is `false`); else — no
+/// arg and no git — it is genuinely UNKNOWN and no var is emitted, so
+/// `/actuator/info` reports `null` instead of a misleading `false`.
+///
 /// Note: the git-derived `dirty` flag is a best-effort snapshot taken when this
 /// script last re-ran. Cargo only re-runs it on the declared `rerun-if-changed`
 /// inputs, so after an edit that doesn't touch a watched path the baked flag may
@@ -84,15 +89,20 @@ fn emit_build_provenance() {
         let branch = build_arg("AUTUMN_BUILD_GIT_BRANCH")
             .or_else(|| git(&["rev-parse", "--abbrev-ref", "HEAD"]))
             .unwrap_or_else(|| "unknown".into());
-        let dirty = build_arg("AUTUMN_BUILD_GIT_DIRTY").unwrap_or_else(|| {
-            git(&["status", "--porcelain"])
-                .is_some_and(|out| !out.trim().is_empty())
-                .to_string()
-        });
+        // Dirty is a THREE-state value: an explicit passthrough arg wins;
+        // otherwise the real `git status` result (a *clean* tree is `false`, not
+        // unknown); otherwise — no arg AND no git, the common case for a
+        // container build with `/.git` excluded — the dirty state is genuinely
+        // UNKNOWN. In that case emit no `AUTUMN_BUILD_GIT_DIRTY` at all, so
+        // `/actuator/info` reports `null` rather than a misleading `false`.
+        let dirty =
+            build_arg("AUTUMN_BUILD_GIT_DIRTY").or_else(|| git_dirty().map(|d| d.to_string()));
         println!("cargo:rustc-env=AUTUMN_BUILD_GIT_SHA={sha}");
         println!("cargo:rustc-env=AUTUMN_BUILD_GIT_SHA_SHORT={short}");
         println!("cargo:rustc-env=AUTUMN_BUILD_GIT_BRANCH={branch}");
-        println!("cargo:rustc-env=AUTUMN_BUILD_GIT_DIRTY={dirty}");
+        if let Some(dirty) = dirty {
+            println!("cargo:rustc-env=AUTUMN_BUILD_GIT_DIRTY={dirty}");
+        }
     }
 
     // Re-run when the ref is checked out (HEAD), the index changes (staging /
@@ -177,6 +187,28 @@ fn emit_git_rerun_triggers() {
         }
         seen.push(path);
     }
+}
+
+/// Best-effort working-tree dirtiness, distinguishing *clean* from *unknown*.
+///
+/// Returns `Some(true)`/`Some(false)` only when `git status` actually ran — a
+/// clean tree is `Some(false)`, uncommitted changes are `Some(true)`. Returns
+/// `None` when git is absent or the command fails (e.g. a container build with
+/// `/.git` excluded), so the caller can represent an *unknown* dirty state as
+/// absent (`/actuator/info` → `null`) rather than a misleading `false`.
+///
+/// This cannot reuse `git()`, which collapses empty stdout to `None` and would
+/// make a clean tree indistinguishable from git being unavailable.
+fn git_dirty() -> Option<bool> {
+    let output = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(output.stdout).ok()?;
+    Some(!text.trim().is_empty())
 }
 
 /// Run a git subcommand, returning trimmed stdout on success.

--- a/autumn-cli/src/templates/build.rs.tmpl
+++ b/autumn-cli/src/templates/build.rs.tmpl
@@ -40,23 +40,55 @@ fn main() {
 /// Emit `AUTUMN_BUILD_*` compile-time env vars consumed by
 /// `#[autumn_web::main]` and surfaced on `/actuator/info`.
 ///
-/// The build timestamp is always emitted (honoring `SOURCE_DATE_EPOCH` for
-/// reproducible builds). Git fields are best-effort: outside a git checkout
-/// (tarball / CI cache) they are simply omitted and the framework reports them
-/// as `null` rather than failing the build.
+/// Provenance is sourced with a two-tier strategy so both local checkouts and
+/// containerized (production) builds report real values:
 ///
-/// Note: the `dirty` flag is a best-effort snapshot taken when this script last
-/// re-ran. Cargo only re-runs it on the declared `rerun-if-changed` inputs, so
-/// after an edit that doesn't touch a watched path the baked flag may lag until
-/// the next rebuild of a watched input.
+/// 1. **Build-arg passthrough** — if the corresponding `AUTUMN_BUILD_*` env var
+///    is set (e.g. Docker `--build-arg` surfaced as `ENV`), it wins. The
+///    scaffolded Dockerfile deliberately excludes `/.git` from the build
+///    context, so a container build has no repository to inspect; the deploy/CI
+///    supplies the SHA/branch/etc. explicitly instead.
+/// 2. **Git fallback** — otherwise fields are best-effort from `git`. Outside a
+///    checkout (tarball / CI cache with no passthrough) they are simply omitted
+///    and the framework reports them as `null` rather than failing the build.
+///
+/// The build timestamp is always emitted (passthrough `AUTUMN_BUILD_TIMESTAMP`
+/// wins, else `SOURCE_DATE_EPOCH` for reproducible builds, else wall clock).
+///
+/// Note: the git-derived `dirty` flag is a best-effort snapshot taken when this
+/// script last re-ran. Cargo only re-runs it on the declared `rerun-if-changed`
+/// inputs, so after an edit that doesn't touch a watched path the baked flag may
+/// lag until the next rebuild of a watched input.
 fn emit_build_provenance() {
-    println!("cargo:rustc-env=AUTUMN_BUILD_TIMESTAMP={}", build_timestamp());
+    // Re-run whenever a passthrough build arg changes so a new deploy re-bakes
+    // the provenance instead of reusing a cached, stale value.
+    for var in [
+        "AUTUMN_BUILD_GIT_SHA",
+        "AUTUMN_BUILD_GIT_SHA_SHORT",
+        "AUTUMN_BUILD_GIT_BRANCH",
+        "AUTUMN_BUILD_GIT_DIRTY",
+        "AUTUMN_BUILD_TIMESTAMP",
+    ] {
+        println!("cargo:rerun-if-env-changed={var}");
+    }
 
-    if let Some(sha) = git(&["rev-parse", "HEAD"]) {
-        let short = git(&["rev-parse", "--short", "HEAD"])
+    let timestamp = build_arg("AUTUMN_BUILD_TIMESTAMP").unwrap_or_else(build_timestamp);
+    println!("cargo:rustc-env=AUTUMN_BUILD_TIMESTAMP={timestamp}");
+
+    // Prefer the passthrough SHA (container build); fall back to git (local
+    // checkout). If neither yields a SHA, emit no git fields → reported `null`.
+    if let Some(sha) = build_arg("AUTUMN_BUILD_GIT_SHA").or_else(|| git(&["rev-parse", "HEAD"])) {
+        let short = build_arg("AUTUMN_BUILD_GIT_SHA_SHORT")
+            .or_else(|| git(&["rev-parse", "--short", "HEAD"]))
             .unwrap_or_else(|| sha.chars().take(7).collect());
-        let branch = git(&["rev-parse", "--abbrev-ref", "HEAD"]).unwrap_or_else(|| "unknown".into());
-        let dirty = git(&["status", "--porcelain"]).is_some_and(|out| !out.trim().is_empty());
+        let branch = build_arg("AUTUMN_BUILD_GIT_BRANCH")
+            .or_else(|| git(&["rev-parse", "--abbrev-ref", "HEAD"]))
+            .unwrap_or_else(|| "unknown".into());
+        let dirty = build_arg("AUTUMN_BUILD_GIT_DIRTY").unwrap_or_else(|| {
+            git(&["status", "--porcelain"])
+                .is_some_and(|out| !out.trim().is_empty())
+                .to_string()
+        });
         println!("cargo:rustc-env=AUTUMN_BUILD_GIT_SHA={sha}");
         println!("cargo:rustc-env=AUTUMN_BUILD_GIT_SHA_SHORT={short}");
         println!("cargo:rustc-env=AUTUMN_BUILD_GIT_BRANCH={branch}");
@@ -70,6 +102,20 @@ fn emit_build_provenance() {
 
     // Reproducible builds: re-run if the source date is pinned or changed.
     println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+}
+
+/// Read a provenance build arg passed through the environment (Docker
+/// `ARG`/`ENV`), trimming surrounding whitespace. Unset or blank values return
+/// `None` so detection falls through to git — an unpopulated `ARG` surfaces as
+/// an empty string, which must not shadow the git fallback.
+fn build_arg(name: &str) -> Option<String> {
+    let value = std::env::var(name).ok()?;
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
 }
 
 /// Register `rerun-if-changed` triggers on the git ref state so a commit /

--- a/autumn-cli/src/templates/release/Dockerfile.tmpl
+++ b/autumn-cli/src/templates/release/Dockerfile.tmpl
@@ -43,6 +43,28 @@ RUN cargo install diesel_cli \
     --no-default-features \
     --features postgres
 
+# Git/build provenance passthrough. The build context excludes `/.git` (see
+# .dockerignore), so the generated build.rs cannot shell out to git here.
+# Supply provenance explicitly and surface it as ENV, which build.rs prefers
+# over git and bakes into the binary for `/actuator/info`. Populate from CI, e.g:
+#   docker build \
+#     --build-arg AUTUMN_BUILD_GIT_SHA=$(git rev-parse HEAD) \
+#     --build-arg AUTUMN_BUILD_GIT_SHA_SHORT=$(git rev-parse --short HEAD) \
+#     --build-arg AUTUMN_BUILD_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) \
+#     --build-arg AUTUMN_BUILD_GIT_DIRTY=false \
+#     --build-arg AUTUMN_BUILD_TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ) .
+# Unset args stay empty and are ignored, so `/actuator/info` reports `null`.
+ARG AUTUMN_BUILD_GIT_SHA=
+ARG AUTUMN_BUILD_GIT_SHA_SHORT=
+ARG AUTUMN_BUILD_GIT_BRANCH=
+ARG AUTUMN_BUILD_GIT_DIRTY=
+ARG AUTUMN_BUILD_TIMESTAMP=
+ENV AUTUMN_BUILD_GIT_SHA=${AUTUMN_BUILD_GIT_SHA} \
+    AUTUMN_BUILD_GIT_SHA_SHORT=${AUTUMN_BUILD_GIT_SHA_SHORT} \
+    AUTUMN_BUILD_GIT_BRANCH=${AUTUMN_BUILD_GIT_BRANCH} \
+    AUTUMN_BUILD_GIT_DIRTY=${AUTUMN_BUILD_GIT_DIRTY} \
+    AUTUMN_BUILD_TIMESTAMP=${AUTUMN_BUILD_TIMESTAMP}
+
 COPY . .
 {{build_step}}
 


### PR DESCRIPTION
Fixes #1676.

## Before

Apps deployed via the scaffolded Dockerfile reported `git.commit`, `git.branch`, and `git.dirty` as `null` on `/actuator/info`. The scaffolded `.dockerignore` excludes `/.git` and the Dockerfile copies only manifests/sources before compiling, so the generated `build.rs` found no git repository at build time and baked no provenance. Local/checkout builds were fine — only the containerized (production) artifact lost provenance, undercutting deploy/rollback verification.

## After

A container image built with the provenance build args reports real values on `/actuator/info` (e.g. `git.commit`, `git.commit_short`, `git.branch`, `git.dirty`, and the build timestamp). With no build args supplied the fields stay `null` (unchanged, no failure). Local checkout builds are unaffected and still read provenance straight from git.

Populate the args from CI, for example:

```
docker build \
  --build-arg AUTUMN_BUILD_GIT_SHA=$(git rev-parse HEAD) \
  --build-arg AUTUMN_BUILD_GIT_SHA_SHORT=$(git rev-parse --short HEAD) \
  --build-arg AUTUMN_BUILD_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) \
  --build-arg AUTUMN_BUILD_GIT_DIRTY=false \
  --build-arg AUTUMN_BUILD_TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ) .
```

## How

Option A (env-var passthrough) from the issue:

- **Generated `build.rs`** now prefers the `AUTUMN_BUILD_*` env vars over shelling out to git, and only falls back to git for local checkout builds. A small `build_arg` helper treats unset/blank args as absent (so an unpopulated `ARG` doesn't shadow the git fallback), and `rerun-if-env-changed` triggers ensure a new deploy re-bakes the provenance.
- **Both scaffolded Dockerfiles** (`Dockerfile.tmpl` and `release/Dockerfile.tmpl`) declare `ARG`/`ENV` passthrough for the five provenance vars, placed before the build step so the compile sees them, with the documented `docker build --build-arg` example inline. `.git` stays out of the build context (Option B rejected — no image/context bloat).

## Tests

- `generated_build_rs_prefers_build_arg_provenance_over_git` — asserts the generated `build.rs` prefers each build arg then falls back to git.
- `dockerfile_passes_through_git_provenance_build_args` — asserts the rendered Dockerfile declares the `ARG`s, surfaces them as `ENV`, and orders them before the build step.

Targeted `autumn-cli` unit tests pass; `cargo fmt --all -- --check` and `cargo clippy -p autumn-cli --all-targets -- -D warnings` are clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nw3vA8FWZqRukfZYj1VaYv)_