### PR TITLE
docs: changelog + skills for merged feature waves since #1775

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1226,8 +1226,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (or `--offsite`) downloads a run to a temp dir and applies the same integrity
   verification and production `--force` guard as a local restore. Transfers use a
   dependency-light synchronous SigV4 S3 client streamed end-to-end to bound memory
-  (multipart above 64 MiB — S3 caps a single `PutObject` at 5 GiB — sending a
-  server-side `x-amz-checksum-sha256`); pointing the offsite bucket at the app's
+  (a single `PutObject` sends a server-side `x-amz-checksum-sha256`; above 64 MiB —
+  S3 caps a single `PutObject` at 5 GiB — the artifact uploads via multipart, hashed
+  locally and verified after `CompleteMultipartUpload` via HEAD/GET); pointing the
+  offsite bucket at the app's
   own `[storage.s3]` bucket requires the explicit `allow_shared_bucket = true`
   opt-in (issue #1619).
 - **doctor:** new `offsite_backup` check (never prints a credential value — only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1219,12 +1219,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   errors), with `AUTUMN_BACKUP__OFFSITE__*` env overrides (e.g.
   `AUTUMN_BACKUP__OFFSITE__S3__BUCKET`) and profile overlays
   (`[profile.prod.backup.offsite]`). Objects are keyed
-  `{prefix}/{profile}/{timestamp}/{file}`; independent remote retention
+  `{prefix}/{profile}/{timestamp}-{token}/{file}` — the remote run id appends a
+  short unique token to the timestamp so same-second backups of one profile from
+  different hosts never collide; independent remote retention
   (`keep = N`) prunes older uploaded runs only after a verified upload (never the
   just-uploaded run). New `autumn db offsite list` shows the offsite runs for the
-  active profile, and `autumn db restore offsite:<profile>/<timestamp|latest>`
-  (or `--offsite`) downloads a run to a temp dir and applies the same integrity
-  verification and production `--force` guard as a local restore. Transfers use a
+  active profile (printing the full `{timestamp}-{token}` run id), and `autumn db
+  restore offsite:<profile>/<run-id|latest>` (or `--offsite`) downloads a run to a
+  temp dir and applies the same integrity verification and production `--force`
+  guard as a local restore. The selector accepts the full `{timestamp}-{token}`
+  run id (exact), a bare `{timestamp}` (works only when it uniquely identifies one
+  run — otherwise it errors and lists the candidates), or `latest` (newest
+  complete run). Transfers use a
   dependency-light synchronous SigV4 S3 client streamed end-to-end to bound memory
   (a single `PutObject` sends a server-side `x-amz-checksum-sha256`; above 64 MiB —
   S3 caps a single `PutObject` at 5 GiB — the artifact uploads via multipart, hashed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1230,21 +1230,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   server-side `x-amz-checksum-sha256`); pointing the offsite bucket at the app's
   own `[storage.s3]` bucket requires the explicit `allow_shared_bucket = true`
   opt-in (issue #1619).
-- **doctor:** new `offsite_backup` check — informational (never a hard failure,
-  never prints a credential value). It notes when no `[backup.offsite]`
-  destination is configured, and once one is, flags an unset
-  `backup.offsite.s3.bucket`, a destination that shares the app's `[storage.s3]`
-  bucket without `backup.offsite.allow_shared_bucket = true`, or named credential
-  env vars that are not ready (issue #1619).
+- **doctor:** new `offsite_backup` check (never prints a credential value — only
+  env-var names / booleans). It Passes when no `[backup.offsite]` destination is
+  configured, or when a configured destination is complete. It **Fails** on an
+  invalid configured destination — `[backup.offsite]` set without
+  `backup.offsite.s3.bucket`, or a destination that reuses the app's
+  `[storage.s3]` bucket at the same endpoint without
+  `backup.offsite.allow_shared_bucket = true`. It **Warns** when the bucket is set
+  but the named credential env vars are not ready (unset name, or the variable is
+  not exported) (issue #1619).
 - **alerts:** a failed `autumn db backup` offsite upload now raises a
   `ScheduledTaskFailure` operator alert (dedup key
   `scheduled_task_failure:db-backup-offsite-upload`, title "Offsite backup upload
-  failed") through the configured `[alerts]` channels (PagerDuty / Slack / Discord
-  + signed webhook), so an unattended/cron backup never fails its upload silently.
-  Delivery is best-effort on a short-lived runtime and can never change the
-  command's exit code; with no `[alerts]` destination configured no channels are
-  built, so the interactive case (message + non-zero exit) is unchanged
-  (issue #1743).
+  failed") through the outbound-HTTP `[alerts]` channels only (PagerDuty / Slack /
+  Discord + signed webhook), so an unattended/cron backup never fails its upload
+  silently. Email is intentionally excluded — an email-only `[alerts]` config
+  builds no channels here and is not notified. Delivery is best-effort on a
+  short-lived runtime and can never change the command's exit code; with no
+  outbound-HTTP `[alerts]` channel configured no channels are built, so the
+  interactive case (message + non-zero exit) is unchanged (issue #1743).
 - **ci:** the offsite-backup disaster-recovery round-trip
   (`autumn-cli/tests/integration/offsite_backup.rs`) now runs in GitHub Actions —
   `cargo test -p autumn-cli --test cli_tests -- --ignored offsite` drives

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1071,6 +1071,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `on_delete` = `destroy` (soft-delete-aware, fires child hooks) | `delete_all` |
   `nullify` | `restrict` (probes for referencing rows before mutating and errors if
   any still exist) (issue #1369).
+- **macros:** `dependent(...)` cascade delete is now recursive, bulk-aware, and
+  declarable model-side. Deleting a parent that declares dependents cascades
+  into grandchildren and deeper in the same transaction — each destroyed child
+  runs its own `dependent(...)` cascade before its row is removed, with a
+  `(table, id)` cycle guard so self- or mutually-referential graphs terminate
+  instead of looping (`delete_all` stays single-level by design) (issue #1739).
+  The generated `delete_many` bulk path runs the same
+  destroy/`delete_all`/`nullify`/`restrict` cascade per affected parent inside
+  its existing transaction — restrict probes first (a `409` rolls the whole
+  batch back), then children, then the bulk parent delete — so bulk-deleting
+  parents with dependent children no longer orphans or FK-errors those rows
+  (issues #1740, #1787). Cascades can now be declared on the model with
+  `#[has_many(Child, dependent = <action>)]` / `#[has_one(...)]` (equivalently
+  `on_delete = <action>`) instead of the repository attribute: the model derive
+  emits a runtime `Model::dependents()` that the repository codegen consults
+  when no repository-side `dependent(...)` is present (the repository attribute
+  still wins when both are declared), so `#[has_many(Child, dependent =
+  destroy)]` drives the same transactional cascade — grandchild recursion and
+  the `delete_many` bulk path included — with no repository attribute required.
+  This model form ships for `destroy`, `delete_all`, and `restrict`; `dependent
+  = nullify` and both-sites conflict diagnostics are deferred follow-ups, and a
+  `dependent`/`on_delete` on a `through = <join_table>` association is a directed
+  compile error rather than a mis-targeted cascade (issue #1738). See
+  `docs/guide/repositories.md`.
 - **audit:** version/audit writes are auto-attributed to the current actor. A new
   `autumn_web::current` module carries a request-scoped actor
   (`Current::set_actor` / `Current::actor`, plus `Current::set_default_actor` for
@@ -1181,6 +1205,163 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   address, then follow redirects with per-hop resolve→validate→pin and an
   https→http downgrade guard. New `ClientError` variants `SsrfBlocked`,
   `TooManyRedirects`, `RedirectRejected`, `InvalidUrl` (issues #1238, #1239).
+- **db:** offsite S3 backups — `autumn db backup --upload` (or
+  `[backup.offsite] auto_upload = true`) now uploads each completed local run to
+  an S3-compatible offsite destination (AWS S3, MinIO, Cloudflare R2, Backblaze
+  B2, Garage) *after* local integrity verification passes, then HEAD/GET-verifies
+  every remote object matches the local file before reporting success; a
+  local-good / upload-failed run exits non-zero with an unambiguous split-outcome
+  message and leaves the local artifact intact. Configure the destination in
+  `autumn.toml` under `[backup.offsite]` / `[backup.offsite.s3]` (`bucket`,
+  `region`, `endpoint`, `force_path_style`, `prefix`, `keep`,
+  `allow_shared_bucket`, and credential *indirection* via `access_key_id_env` /
+  `secret_access_key_env` — the secret values never live in config, argv, logs, or
+  errors), with `AUTUMN_BACKUP__OFFSITE__*` env overrides (e.g.
+  `AUTUMN_BACKUP__OFFSITE__S3__BUCKET`) and profile overlays
+  (`[profile.prod.backup.offsite]`). Objects are keyed
+  `{prefix}/{profile}/{timestamp}/{file}`; independent remote retention
+  (`keep = N`) prunes older uploaded runs only after a verified upload (never the
+  just-uploaded run). New `autumn db offsite list` shows the offsite runs for the
+  active profile, and `autumn db restore offsite:<profile>/<timestamp|latest>`
+  (or `--offsite`) downloads a run to a temp dir and applies the same integrity
+  verification and production `--force` guard as a local restore. Transfers use a
+  dependency-light synchronous SigV4 S3 client streamed end-to-end to bound memory
+  (multipart above 64 MiB — S3 caps a single `PutObject` at 5 GiB — sending a
+  server-side `x-amz-checksum-sha256`); pointing the offsite bucket at the app's
+  own `[storage.s3]` bucket requires the explicit `allow_shared_bucket = true`
+  opt-in (issue #1619).
+- **doctor:** new `offsite_backup` check — informational (never a hard failure,
+  never prints a credential value). It notes when no `[backup.offsite]`
+  destination is configured, and once one is, flags an unset
+  `backup.offsite.s3.bucket`, a destination that shares the app's `[storage.s3]`
+  bucket without `backup.offsite.allow_shared_bucket = true`, or named credential
+  env vars that are not ready (issue #1619).
+- **alerts:** a failed `autumn db backup` offsite upload now raises a
+  `ScheduledTaskFailure` operator alert (dedup key
+  `scheduled_task_failure:db-backup-offsite-upload`, title "Offsite backup upload
+  failed") through the configured `[alerts]` channels (PagerDuty / Slack / Discord
+  + signed webhook), so an unattended/cron backup never fails its upload silently.
+  Delivery is best-effort on a short-lived runtime and can never change the
+  command's exit code; with no `[alerts]` destination configured no channels are
+  built, so the interactive case (message + non-zero exit) is unchanged
+  (issue #1743).
+- **ci:** the offsite-backup disaster-recovery round-trip
+  (`autumn-cli/tests/integration/offsite_backup.rs`) now runs in GitHub Actions —
+  `cargo test -p autumn-cli --test cli_tests -- --ignored offsite` drives
+  seed → `autumn db backup --upload` → restore-from-offsite → row-level equality
+  against real MinIO + Postgres testcontainers. The Docker-dependent Linux step
+  installs `postgresql-client` (so the host `pg_dump`/`pg_restore` that `autumn db
+  backup` shells out to are on PATH) and gains `timeout-minutes: 30`; the
+  round-trip stays in the existing Docker-dependent step rather than a new
+  required gate (issue #1744).
+- **scaffold:** a scaffolded required numeric field carrying a `{min,max}` range
+  constraint (issue #1388) is now emitted as `Option<T>` on the generated
+  `*Form` struct with `#[validate(required, range(...))]` instead of the native
+  `i32`/`i64`/`f32`/`f64`. A native numeric defaults to `0`, which pre-fills the
+  input, so a blank submission used to pass both the HTML `required` attribute
+  and the server-side `range` rule whenever the declared range spans the type's
+  zero default (e.g. `age:i32{min=0,max=130}`), silently coercing the field to
+  `0`. `Option<T>::default()` is `None`, so the input renders blank; `required`
+  rejects `None` with a **422** inline error and `range` still validates the
+  inner value when `Some`. `into_new` unwraps the validated `Some(_)` (a missing
+  value is a bad request naming the field), `from_row` wraps a persisted native
+  value in `Some`, and the empty `field=` pair is dropped by the form decoder so
+  a blank non-browser submit surfaces the 422 rather than a `400` from parsing
+  `""`. The `required` rule lands only on the form struct, never on the
+  native-typed model field (issue #1748).
+- **scaffold:** `--live-validation` scaffolds now emit the client-side HTML5
+  constraint attributes (`minlength`/`maxlength`, `type="email"`/`type="url"`,
+  numeric `min`/`max`, `step="any"`, and a `<textarea>` for a constrained `Text`
+  column) and the `belongs_to` parent `<select>`, both of which the per-field
+  live path previously dropped — the #1388 client-side hints were only emitted on
+  the standard `form_for` path, and `reference_fields` was zeroed out under
+  `--live-validation`, so a `references` field leaked out as a plain text input.
+  The live path now renders DSL-constrained `String`/`Text`/numeric fields and
+  the reference dropdown as raw maud markup carrying the same HTML5 attributes and
+  ARIA/inline-error skeleton the standard path produces; the reference option
+  loaders are threaded into the new/edit form bodies (and the 422 re-render
+  branches) so the `<select>` is populated at request time with changeset-driven
+  `selected` state, and the inline-validate handlers return the identical
+  constrained fragment so an htmx `outerHTML` swap on `change` no longer sheds the
+  client-side guards. Server-side `#[validate(...)]` was already applied under
+  `--live-validation`; this restores only the client-side HTML5 hints and the
+  parent dropdown (issue #1750).
+- **actuator:** backend-derived `/actuator/jobs` queue gauges on the durable
+  backends. On Postgres/Redis the per-queue `depth` / `oldest_waiting_age_ms`
+  and the per-job-type `queued` counters are now surveyed from the durable store
+  and wholesale-replace this process's local enqueue marks each tick, so an
+  enqueue-only `web` replica reports the true shared backlog instead of its own
+  ever-growing local marks; a queue absent from the latest survey resets to
+  `depth` 0, so stale backlog never leaks between ticks. The Redis survey runs
+  every 2s (the interval doubles as the gauge cache TTL) and pages the entire
+  due-delayed ZSET so scheduled/retry bursts are counted exactly, emitting a
+  single `warn!` if a pathological backlog is truncated at the scan cap. The
+  `local` backend keeps its in-process mark path unchanged (issue #1752).
+- **doctor:** topology-aware `autumn doctor --strict` queue-coverage
+  (`jobs_queue_coverage`). Declare the fleet's worker tiers under
+  `[jobs.fleet] tiers = [["critical"], ["bulk", "default"]]` (each inner array is
+  one `worker` tier's `jobs.pin`; an empty array is an unpinned tier that drains
+  every queue) and doctor proves coverage topology-wide, hard-failing only when a
+  needed queue — the configured `[jobs.queues]` unioned with the
+  `#[job(queue = "…")]`-declared set — is drained by no tier anywhere, so a valid
+  multi-tier subset split no longer false-positives. The job-declared set is
+  resolved from `[jobs.fleet] manifest = "<path>"` (a `queues = [...]` manifest
+  the app emits) or an inline `[jobs.fleet] declared_queues = ["…"]`. Absent
+  `[jobs.fleet]` the check stays informational-only, exactly as before, so no
+  existing deployment regresses (issue #1756).
+- **cli:** `autumn jobs manifest <path>` emits the running app's effective
+  drained-queue manifest. It compiles the app (debug profile) and runs it under
+  `AUTUMN_DUMP_JOBS=1` to capture the ground-truth drained-queue set — the
+  configured `[jobs.queues]` unioned with every `#[job(queue = "…")]`-declared
+  queue, including synthesized durable-listener queues — without binding a port
+  or touching a database, then writes a TOML `queues = [...]` document to
+  `<path>`. `autumn doctor` consumes it via `[jobs.fleet] manifest = "<path>"`,
+  so the topology coverage check sees exactly what the runtime drains rather than
+  a hand-maintained list. `--package` / `--bin` select the target in a
+  workspace, and the captured stdout is validated as a TOML `queues` string
+  array before it is written (issue #1756).
+- **tenancy:** per-tenant in-process memory cells — each resolved tenant gets a
+  `TenantCell`, a byte-accounting boundary with a soft memory quota and an owned
+  scratch buffer, minted lazily by the process-wide `TenantCellRegistry` on the
+  first call to `current_tenant_cell()`, so routes that never touch tenant
+  memory allocate no cell. `try_charge(n)` reserves bytes against the quota and
+  returns a `Charge` RAII guard that releases them on drop; the per-tenant
+  scratch store (`scratch_insert`/`scratch_get`/`scratch_remove`) is charged by
+  allocation capacity plus a fixed per-entry overhead. A charge that would
+  exceed the quota fails only the offending tenant's request with `QuotaExceeded`
+  → HTTP **503 Service Unavailable**, leaving every other tenant's independent
+  counter untouched; `TenantCellRegistry::evict` deterministically reclaims a
+  cell's tracked footprint on `Drop` while an in-flight request keeps its cached
+  cell to completion. Configure under `[tenancy]` with `quota_bytes` (`0`, the
+  default, disables the quota). Follow-ups add bounded (`max_cells`, LRU) and
+  idle (`idle_ttl_secs`) registry eviction, enforced lazily on cell insert, plus
+  a reusable `evict_idle_older_than` primitive (issue #1792); store the soft
+  quota atomically and refresh a resident cell from the configured value on every
+  access via `set_quota_bytes`, so a future config-reload path can retune it
+  without rebuilding cells (issue #1783); and make the entire `[tenancy]` section
+  settable from the environment through `AUTUMN_TENANCY__*` — including
+  `AUTUMN_TENANCY__QUOTA_BYTES`, `AUTUMN_TENANCY__MAX_CELLS`,
+  `AUTUMN_TENANCY__IDLE_TTL_SECS`, and `AUTUMN_TENANCY__JWT_SECRET` (issue #1793)
+  (issues #1766, #1792, #1783, #1793).
+- **alerts:** native `PagerDuty` / Slack / Discord alert transports, built on
+  the `AlertChannel` fan-out seam from #1610 with no change to the core alert
+  pipeline. Configure any of them under `[alerts]`: `pagerduty_routing_key`
+  (Events API v2 integration key; optional `pagerduty_url` to target a
+  PagerDuty-Events-compatible endpoint), `slack_webhook_url`, and
+  `discord_webhook_url` (delivered via Discord's Slack-compatible endpoint —
+  append `/slack`), each with an `AUTUMN_ALERTS__*` env override. PagerDuty
+  events correlate on the alert's stable `dedup_key`, so a repeating condition
+  folds into one incident and an autumn-side recovery auto-resolves it.
+  Per-channel severity routing via `pagerduty_severities` / `slack_severities` /
+  `discord_severities` (`"all"`, the default, or `"critical"` to page on failure
+  but stay quiet on recovery); an alert below a channel's threshold is never
+  delivered to it. All outbound calls reuse the SSRF-hardened HTTP client and
+  Slack/Discord webhooks require absolute `https`. `autumn alert test
+  [--channel <name>]` fires a synthetic alert through each configured
+  outbound-HTTP channel and reports per-channel success/error, and `autumn
+  doctor` gained an `alert_transports` check that (in production) flags a
+  whitespace-mangled routing key, a non-absolute `pagerduty_url`, or a
+  non-absolute-`https` Slack/Discord URL (issue #1630).
 
 ### Fixed
 
@@ -1277,9 +1458,91 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unsupported values instead of a confusing generic parse failure (issue #1702);
   `across_tenants()` rejects a query with no shard set instead of silently
   running it unsharded (issue #1692).
+- **repository:** a sharded, tenant-scoped repository built without a shard set
+  (e.g. via `with_pool_untracked`) now rejects `across_tenants()` reads across
+  the whole read family instead of silently returning a partial single-pool
+  result. `find_all`, `find_by_id`, `exists_by_id`, the derived `find_by_*`,
+  `with_deleted`, and `only_deleted` previously fanned out only when a shard set
+  was present and otherwise bound a `NULL` tenant predicate against just the
+  current pool, returning an incomplete result; each now returns a "requires a
+  configured shard set" `bad_request`, matching the `count`/batch guard from
+  #1692 (covers both the owned- and borrowed-param derived-read branches)
+  (issue #1741).
 - **scaffold:** scaffolded views now render through the shared application
   layout instead of a bare standalone page, and flash rendering was migrated to
   the shared flash helper (issues #1130, #1240).
+- **config:** `[backup.offsite]` is no longer materialized from optional-only
+  environment keys. A bare `AUTUMN_BACKUP__OFFSITE__S3__REGION` (or `ENDPOINT`,
+  `FORCE_PATH_STYLE`, `PREFIX`, `KEEP`) with no bucket or credential-env names
+  used to create an otherwise-empty section that then failed validation /
+  `autumn doctor --strict` with "backup.offsite.s3.bucket is unset". The
+  materializing trigger set is now limited to the keys a working upload genuinely
+  requires — `BUCKET`, `ACCESS_KEY_ID_ENV`, `SECRET_ACCESS_KEY_ENV` (plus a truthy
+  `AUTO_UPLOAD`) — while the optional keys are still applied once the section is
+  materialized by a required key (issue #1791).
+- **db:** offsite upload now deletes a just-written remote object when its
+  post-upload verification fails. Because `put_file_and_verify` writes the object
+  *before* its HEAD/GET verification, a verify failure (or a transient read during
+  verify) could leave a corrupt/partial object in the bucket; both the single-
+  `PutObject` and multipart paths now route their final verify through a shared
+  `verify_or_delete` helper that best-effort `DeleteObject`s the key on any verify
+  error before returning the original (loud, non-zero) verify error — a failed
+  delete is logged but never masks it (issue #1760).
+- **security:** the generated magic-link verify handler (`POST
+  /login/magic/verify`) now re-checks the account lock before establishing a
+  session. A magic link minted before an account was locked previously bypassed
+  the lockout policy — the handler consumed the single-use token and logged the
+  user in without re-checking `locked_at`. It now runs a fresh guarded `UPDATE`
+  on `locked_at` (the same time-bounded `[auth.lockout]` cool-off semantics as
+  password login, gated on `lockout_enabled`, a no-op when lockout is disabled)
+  that re-reads the current lock state at the DB — closing the concurrent-lock
+  TOCTOU against the earlier in-memory row — and rejects when the account is
+  actively locked. The recheck sits before the TOTP branch, covering both
+  `--magic-link` and `--magic-link --totp`, and a locked account renders the
+  same generic failure page as an expired/consumed/unknown token, so there is
+  no oracle distinguishing "locked" from "bad link" (issue #1777).
+- **macros:** `#[autumn_web::model]` / `#[repository]` now derive table
+  names with rule-based English inflection instead of naively appending
+  `s`, so `Category` maps to `categories` (matching the CLI scaffold's
+  `pluralize_word`) rather than a nonexistent `categorys` schema module
+  that failed to compile (E0433). Only the last snake_case segment is
+  pluralized (`blog_post` → `blog_posts`), irregulars
+  (`person` → `people`), sibilant endings (`+es`) and consonant-`y`
+  (`+ies`) are handled, and the `has_many` default accessor plus the
+  `add_`/`remove_` m2m helpers use the same rule — the latter derived from
+  the target type's singular so `categories` still yields `add_category`,
+  not `add_categorie`. The `#[model(table = "...")]` escape hatch is
+  unchanged (issue #1753).
+- **security:** the generated auth scaffold no longer grants step-up
+  "sudo mode" when a session is restored from a remember-me cookie. A
+  long-lived persistent cookie is not strong authentication, so
+  `establish_remember_login` no longer stamps `set_last_strong_auth_at`,
+  and because `rotate_id()` preserves session data it now actively clears
+  any stale elevation carried over from a prior authenticated state in the
+  same browser — both `last_strong_auth_at` (`STEP_UP_SESSION_KEY`) and the
+  reauth flow's `reauth_pw_ok` marker. This forces `#[step_up]` routes
+  (e.g. account deletion) to redirect to `/reauth` for a fresh password
+  check, closing a path where a stolen or unattended remember cookie could
+  silently pass elevated routes (issue #1397).
+- **openapi:** `extract_path_params` no longer emits phantom or
+  brace-carrying parameter names for escaped, regex-constrained, or
+  unbalanced-brace route patterns during spec generation. Escaped literal
+  braces (`{{hello}}`) now yield no parameter, `:constraint` suffixes are
+  stripped to the bare name (`{id:[0-9]{1,3}}` → `id`), and a brace-free
+  guard drops malformed candidates (`{a{b}` → none), keeping the emitted
+  list brace-free. This path is `openapi`-only; routing is unaffected since
+  matchit rejects such patterns at registration (issue #1721).
+- **http:** htmx positional and `innerHTML` out-of-band swaps now render a
+  `<div>` carrier instead of `<template>`, so `HtmxFragments` fragments
+  sent via `oob_with_strategy` with `OobSwap::{BeforeBegin, AfterBegin,
+  BeforeEnd, AfterEnd, InnerHTML}` actually land in the DOM. htmx applies
+  these swaps by iterating the carrier's `childNodes`, which are empty for
+  a `<template>` (its children live in `.content`); element-replacing swaps
+  (`true` / `outerHTML`) keep the `<template>` carrier htmx unwraps by id.
+  A fragment passed to a child-node-inserting swap must be a valid direct
+  child of a `<div>` — a bare `<tr>`/`<td>`/`<tbody>`/`<option>`/`<col>` is
+  foster-parented out and vanishes; use the element-replacing path with the
+  id on the row for table-row swaps (issue #1688).
 
 ### Changed
 
@@ -1339,6 +1602,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compiler diagnostics when a rebuild fails, instead of leaving a blank or stale
   page — injected under the strict nonce-based CSP and cleared on the next
   successful rebuild (issue #1115).
+- **macros:** partial updates now validate the effective **merged model** (the
+  existing row ∪ the patch, after normalization) on the `from_patch` update path,
+  not only the patch struct's own fields. `#[model]` derives `validator::Validate`
+  on the read model (gated on `has_validation`, symmetric with the `New*`/
+  `Update*` models) and keeps the full field `#[validate(...)]` set there, and the
+  generated `from_patch` validates the reconstructed concrete model before
+  returning the draft — before `before_update`, mirroring create (validate before
+  `before_create`). Because the merged model's fields are concrete `T` rather than
+  `Patch<T>`, validators that cannot be enforced on `Patch<T>` — `ip` on `Option`
+  fields and `does_not_contain` (E0119 trait-coherence walls under validator
+  `0.20`) and the cross-field `custom`/`must_match`/`nested` (no single-field
+  `Patch<T>` trait) — are now enforced on update too, returning the same **422**
+  field-error map as create. This covers every update path that builds a draft via
+  `from_patch` (repositories with `hooks = ...` and their `--api` handlers); the
+  blind `__to_changeset` paths (plain/`api`/`policy` repositories without hooks)
+  still run only the patch-struct validators (follow-up: issue #1801). The
+  `Patch<T>` per-field impls and the `UpdateModel` denylist are unchanged, so the
+  change is backward compatible (issue #1778).
+- **cli:** the magic-link login flow scaffolded by `autumn generate auth
+  --magic-link` now sources its token lifetime and per-email cooldown from
+  `autumn.toml` instead of hard-coded `const`s, so operators can tune them
+  without editing the generated handler. New `[auth.magic_link]` section on
+  `AuthConfig`: `ttl_minutes` (default `15`; keep it ≤ 15 to bound a leaked
+  link's blast radius) and `email_cooldown_secs` (default `60`; the per-email
+  re-mint throttle). Both are unsigned, so a negative value in `autumn.toml`
+  now fails deserialization rather than silently minting expired tokens or
+  defeating the email-bomb throttle (issue #1737).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1309,18 +1309,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   due-delayed ZSET so scheduled/retry bursts are counted exactly, emitting a
   single `warn!` if a pathological backlog is truncated at the scan cap. The
   `local` backend keeps its in-process mark path unchanged (issue #1752).
-- **doctor:** topology-aware `autumn doctor --strict` queue-coverage
-  (`jobs_queue_coverage`). Declare the fleet's worker tiers under
+- **doctor:** topology-aware queue-coverage (`jobs_queue_coverage`). Declare the
+  fleet's worker tiers under
   `[jobs.fleet] tiers = [["critical"], ["bulk", "default"]]` (each inner array is
   one `worker` tier's `jobs.pin`; an empty array is an unpinned tier that drains
-  every queue) and doctor proves coverage topology-wide, hard-failing only when a
-  needed queue — the configured `[jobs.queues]` unioned with the
-  `#[job(queue = "…")]`-declared set — is drained by no tier anywhere, so a valid
-  multi-tier subset split no longer false-positives. The job-declared set is
-  resolved from `[jobs.fleet] manifest = "<path>"` (a `queues = [...]` manifest
-  the app emits) or an inline `[jobs.fleet] declared_queues = ["…"]`. Absent
-  `[jobs.fleet]` the check stays informational-only, exactly as before, so no
-  existing deployment regresses (issue #1756).
+  every queue) and doctor proves coverage topology-wide. When a needed queue —
+  the configured `[jobs.queues]` unioned with the `#[job(queue = "…")]`-declared
+  set — is drained by no tier anywhere, the check is a hard `Fail`, so a normal
+  `autumn doctor` run exits non-zero on that gap (not only `--strict`, which is
+  the stricter mode that also escalates warnings). A valid multi-tier subset
+  split no longer false-positives. The job-declared set is resolved from
+  `[jobs.fleet] manifest = "<path>"` (a `queues = [...]` manifest the app emits)
+  or an inline `[jobs.fleet] declared_queues = ["…"]`. Absent `[jobs.fleet]` the
+  check stays informational-only, exactly as before, so no existing deployment
+  regresses (issue #1756).
 - **cli:** `autumn jobs manifest <path>` emits the running app's effective
   drained-queue manifest. It compiles the app (debug profile) and runs it under
   `AUTUMN_DUMP_JOBS=1` to capture the ground-truth drained-queue set — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1277,7 +1277,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the standard `form_for` path, and `reference_fields` was zeroed out under
   `--live-validation`, so a `references` field leaked out as a plain text input.
   The live path now renders DSL-constrained `String`/`Text`/numeric fields and
-  the reference dropdown as raw maud markup carrying the same HTML5 attributes and
+  the reference dropdown as raw Maud markup carrying the same HTML5 attributes and
   ARIA/inline-error skeleton the standard path produces; the reference option
   loaders are threaded into the new/edit form bodies (and the 422 re-render
   branches) so the `<select>` is populated at request time with changeset-driven

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1090,11 +1090,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   still wins when both are declared), so `#[has_many(Child, dependent =
   destroy)]` drives the same transactional cascade — grandchild recursion and
   the `delete_many` bulk path included — with no repository attribute required.
-  This model form ships for `destroy`, `delete_all`, and `restrict`; `dependent
-  = nullify` and both-sites conflict diagnostics are deferred follow-ups, and a
-  `dependent`/`on_delete` on a `through = <join_table>` association is a directed
-  compile error rather than a mis-targeted cascade (issue #1738). See
-  `docs/guide/repositories.md`.
+  This model form ships for `destroy`, `delete_all`, `nullify`, and `restrict`
+  (grandchild recursion and the `delete_many` bulk path included), driving the
+  same runtime cascade as the repository attribute; only both-sites conflict
+  diagnostics are a deferred follow-up — when both a repository-side
+  `dependent(...)` and a model-side `dependent`/`on_delete` are declared the
+  repository attribute silently wins — and a `dependent`/`on_delete` on a
+  `through = <join_table>` association is a directed compile error rather than a
+  mis-targeted cascade (issue #1738). See `docs/guide/repositories.md`.
 - **audit:** version/audit writes are auto-attributed to the current actor. A new
   `autumn_web::current` module carries a request-scoped actor
   (`Current::set_actor` / `Current::actor`, plus `Current::set_default_actor` for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1372,8 +1372,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Per-channel severity routing via `pagerduty_severities` / `slack_severities` /
   `discord_severities` (`"all"`, the default, or `"critical"` to page on failure
   but stay quiet on recovery); an alert below a channel's threshold is never
-  delivered to it. All outbound calls reuse the SSRF-hardened HTTP client and
-  Slack/Discord webhooks require absolute `https`. `autumn alert test
+  delivered to it. Slack/Discord webhook URLs must be absolute `https`
+  (validated at config load and by `autumn doctor`); the outbound alert sends
+  only validate URL shape and do not run through the SSRF deny-list, so restrict
+  alert destinations to trusted operator-configured URLs. `autumn alert test
   [--channel <name>]` fires a synthetic alert through each configured
   outbound-HTTP channel and reports per-channel success/error, and `autumn
   doctor` gained an `alert_transports` check that (in production) flags a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1236,8 +1236,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   S3 caps a single `PutObject` at 5 GiB — the artifact uploads via multipart, hashed
   locally and verified after `CompleteMultipartUpload` via HEAD/GET); pointing the
   offsite bucket at the app's
-  own `[storage.s3]` bucket requires the explicit `allow_shared_bucket = true`
-  opt-in (issue #1619).
+  own `[storage.s3]` bucket at the same endpoint requires the explicit
+  `allow_shared_bucket = true` opt-in (issue #1619).
 - **doctor:** new `offsite_backup` check (never prints a credential value — only
   env-var names / booleans). It Passes when no `[backup.offsite]` destination is
   configured, or when a configured destination is complete. It **Fails** on an

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -1624,7 +1624,7 @@ message and leaves the local artifact intact. Configure it in `autumn.toml`:
 ```toml
 [backup.offsite]
 auto_upload = true          # upload after every `autumn db backup`, no --upload
-prefix = "db"               # objects keyed {prefix}/{profile}/{timestamp}/{file}
+prefix = "db"               # objects keyed {prefix}/{profile}/{timestamp}-{token}/{file}
 keep = 30                   # independent remote retention (prune after verify)
 # allow_shared_bucket = true  # opt-in to reuse the app's [storage.s3] bucket
 
@@ -1641,11 +1641,16 @@ Every key has an `AUTUMN_BACKUP__OFFSITE__*` override (e.g.
 `AUTUMN_BACKUP__OFFSITE__S3__BUCKET`) and honors profile overlays
 (`[profile.prod.backup.offsite]`). Credentials are **env-var indirection** only
 — config names the env vars the secrets are read from; the values never live in
-config, argv, logs, or errors. `autumn db offsite list [--profile P]` shows the
-offsite runs for the active profile; `autumn db restore
-offsite:<profile>/<timestamp|latest>` (or `--offsite`) downloads a run to a temp
-dir and applies the same integrity verification and production `--force` guard as
-a local restore. The transfer client is a dependency-light synchronous `SigV4`
+config, argv, logs, or errors. The remote run id appends a short unique token to
+the timestamp (`{timestamp}-{token}`) so same-second backups of one profile from
+different hosts never collide in the bucket. `autumn db offsite list [--profile
+P]` shows the offsite runs for the active profile (printing the full
+`{timestamp}-{token}` run id); `autumn db restore
+offsite:<profile>/<run-id|latest>` (or `--offsite`) downloads a run to a temp dir
+and applies the same integrity verification and production `--force` guard as a
+local restore. The selector accepts the full `{timestamp}-{token}` run id, a bare
+`{timestamp}` (only when it uniquely matches one run — otherwise it errors and
+lists the candidates), or `latest` (newest complete run). The transfer client is a dependency-light synchronous `SigV4`
 client streamed end-to-end (a single `PutObject` sends a server-side
 `x-amz-checksum-sha256`; above 64 MiB — S3 caps a single `PutObject` at 5 GiB —
 the artifact uploads via multipart, hashed locally and verified after

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -1646,8 +1646,10 @@ offsite runs for the active profile; `autumn db restore
 offsite:<profile>/<timestamp|latest>` (or `--offsite`) downloads a run to a temp
 dir and applies the same integrity verification and production `--force` guard as
 a local restore. The transfer client is a dependency-light synchronous `SigV4`
-client streamed end-to-end (multipart above 64 MiB — S3 caps a single
-`PutObject` at 5 GiB — with a server-side `x-amz-checksum-sha256`). `autumn
+client streamed end-to-end (a single `PutObject` sends a server-side
+`x-amz-checksum-sha256`; above 64 MiB — S3 caps a single `PutObject` at 5 GiB —
+the artifact uploads via multipart, hashed locally and verified after
+`CompleteMultipartUpload` via HEAD/GET). `autumn
 doctor` adds an `offsite_backup` check that fails on an invalid configured
 destination and warns on unready credentials (see the `doctor` skill),
 and a failed upload raises a `ScheduledTaskFailure` operator alert only when an

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -366,13 +366,40 @@ child cleanup **(unreleased — trunk-dev)**:
 pub trait PostRepository {}
 ```
 
-`on_delete` = `destroy` (soft-delete-aware, fires each child's hooks — does
-**not** recurse into the child's own `dependent`) | `delete_all` (bulk delete,
-no child hooks) | `nullify` (set the FK null) | `restrict` (probe for
-referencing rows *before* mutating; errors `cannot delete: dependent N row(s) …`
-if any still exist). The generated `delete_by_id` loads and locks the parent,
-applies every declared action, then deletes the parent — all in a single
-transaction (Part of #1369). See `docs/guide/repositories.md`.
+`on_delete` = `destroy` (soft-delete-aware, fires each child's hooks; on
+trunk-dev this **now recurses** into each child's own `dependent`, cascading
+into grandchildren — see the recursive/bulk/model-side note below) |
+`delete_all` (bulk delete, no child hooks) | `nullify` (set the FK null) |
+`restrict` (probe for referencing rows *before* mutating; errors `cannot delete:
+dependent N row(s) …` if any still exist). The generated `delete_by_id` loads and
+locks the parent, applies every declared action, then deletes the parent — all in
+a single transaction (Part of #1369). See `docs/guide/repositories.md`.
+
+On trunk-dev the cascade is recursive and bulk-aware, and can be declared on
+the model instead of the repository **(unreleased — trunk-dev, issues #1738,
+#1739, #1740)**:
+
+- **Grandchildren cascade.** `destroy` now recurses — each destroyed child runs
+  its OWN `dependent(...)` before its row is removed, so a `Post -> Comment ->
+  Reply` graph clears `Reply` rows too, all in one transaction. A self- or
+  mutually-referential graph terminates via a `(table, id)` cycle guard rather
+  than looping; `delete_all` stays single-level by design (issue #1739).
+- **Bulk `delete_many`.** The generated `delete_many` runs the same
+  restrict/destroy/`delete_all`/`nullify` cascade per affected parent inside its
+  transaction — restrict probes first (a `409` rolls the whole batch back) — so
+  bulk-deleting parents no longer orphans or FK-errors dependent children
+  (issues #1740, #1787).
+- **Model-side declaration.** Declare the cascade on the association instead of
+  the repository attribute: `#[has_many(Comment, dependent = destroy)]` (or
+  `on_delete = destroy`). The repository codegen consults this at run time (via
+  a generated `Model::dependents()`) when no repository-side `dependent(...)` is
+  present; the repository attribute wins when both are declared. Ships for
+  `destroy`, `delete_all`, and `restrict`, grandchild recursion and the
+  `delete_many` bulk path included; `dependent = nullify` is a deferred
+  follow-up, and `dependent`/`on_delete` on a `through = <join_table>`
+  association is a compile error (issue #1738).
+
+See `docs/guide/repositories.md`.
 
 ### Model state machines — `#[state_machine]`
 
@@ -474,6 +501,29 @@ create/update handlers validate the decoded payload before touching the DB:
   `Validate` derive compile to a no-op via the autoref `MaybeValidate`
   specialization (no migration burden), and this applies to plain and
   policy-backed handlers (#1237, #1253). See `docs/guide/pagination.md`.
+
+### Partial-update validation — the effective merged model (unreleased — trunk-dev, issue #1778)
+
+On a repository with `hooks = ...`, a `PATCH`/`PUT` update now validates the
+**effective merged model** — the existing row ∪ the patch, after normalization —
+not only the patch struct's own fields. `#[model]` derives `validator::Validate`
+on the read model (gated on `has_validation`, symmetric with the `New*`/`Update*`
+models) and keeps the full `#[validate(...)]` set there; the generated
+`from_patch` validates the reconstructed concrete model before returning the
+draft, running before `before_update` (mirroring create, where validation runs
+before `before_create`). Because the merged model's fields are concrete `T`
+rather than `Patch<T>`, validators that cannot be expressed on `Patch<T>` — `ip`
+on `Option` fields and `does_not_contain` (E0119 trait-coherence walls under
+validator `0.20`), plus the cross-field `custom`/`must_match`/`nested` (no
+single-field `Patch<T>` trait) — are now enforced on update, returning the same
+**422** field-error map as create.
+
+This covers every update path that builds a draft via `from_patch` (hooked
+repositories and their `--api` handlers). The blind `__to_changeset` update paths
+(plain/`api`/`policy` repositories without hooks) still run only the patch-struct
+validators (follow-up: issue #1801). The `Patch<T>` per-field impls and the
+`UpdateModel` denylist are unchanged, so this is backward compatible (issue
+#1778). See `docs/guide/repositories.md`.
 
 ### Transactions
 
@@ -1098,6 +1148,15 @@ subset of queues — all config-only, no app-code change:
 - **Per-queue actuator gauges** — `<actuator-prefix>/jobs` adds a `queues` key
   with per-queue `depth` and `oldest_waiting_age_ms` alongside the existing
   per-job-type gauges (per-process approximations on multi-process backends).
+- **Backend-derived queue gauges (unreleased — trunk-dev, issue #1752)** — on
+  the durable backends (Postgres/Redis) those `queues` gauges and the
+  per-job-type `queued` counter are no longer per-process approximations: a
+  periodic survey of the durable store (Redis every 2s, the interval doubling as
+  the gauge cache TTL) wholesale-replaces this process's local enqueue marks each
+  tick, so an enqueue-only `web` replica reports the true shared backlog and a
+  queue absent from the latest survey resets to `depth` 0. The Redis survey pages
+  the whole due-delayed ZSET so scheduled/retry bursts count exactly. The `local`
+  backend keeps the in-process mark path. See `docs/guide/jobs.md`.
 - **`ProcessRole` on `AppState`** — `state.role()` returns the resolved
   `ProcessRole` (exported at `autumn_web::ProcessRole`) with `serves_http()` /
   `runs_workers()` predicates, so app-owned background loops in `on_startup`
@@ -1128,6 +1187,8 @@ to look" actuator pointer:
 - **High 5xx rate** — the rolling 5xx rate crosses `error_rate_threshold`
   (default `0.05`, a fraction in `(0, 1]`) over ≥ `error_rate_min_requests`.
 - **Scheduled-task failure** — a `#[scheduled]`/framework task returns an error.
+  A failed `autumn db backup` offsite upload also raises this condition
+  **(unreleased — trunk-dev, issue #1743)**.
 
 Delivery is best-effort and off the request path (background tick every
 `eval_interval_secs`, default 30), reuses your existing mailer + outbound-webhook
@@ -1138,6 +1199,42 @@ Slack, …) by implementing `AlertChannel` and registering it with
 `AppBuilder::with_alert_channel`. `autumn doctor` warns (in production) on a
 missing or unusable destination — see the `doctor` skill. See
 `docs/guide/operator-alerts.md`.
+
+### Native transports (unreleased — trunk-dev, issue #1630)
+
+PagerDuty, Slack, and Discord now ship as built-in `AlertChannel`s — no code,
+just `[alerts]` keys (each with an `AUTUMN_ALERTS__*` env override):
+
+```toml
+[alerts]
+pagerduty_routing_key = "…"   # Events API v2 integration key; enables PagerDuty
+pagerduty_url = "https://events.pagerduty.com/v2/enqueue"  # optional override
+pagerduty_severities = "all"  # "all" (default) | "critical"
+slack_webhook_url = "https://hooks.slack.com/services/…"
+slack_severities = "all"
+discord_webhook_url = "https://discord.com/api/webhooks/…/slack"  # append /slack
+discord_severities = "all"
+```
+
+- **PagerDuty** delivers each alert as an Events API v2 event correlated on the
+  alert's stable `dedup_key`, so a repeating condition folds into one incident
+  and a `recovery` auto-resolves it — keep `pagerduty_severities = "all"` so the
+  `resolve` event reaches PagerDuty. `pagerduty_url` targets any
+  PagerDuty-Events-compatible endpoint.
+- **Slack / Discord** post a human-readable message; Discord reuses Slack's
+  payload dialect via its `/slack`-suffixed endpoint. Both require an absolute
+  `https` webhook URL (enforced at runtime and by `autumn doctor`).
+- **Per-channel severity routing** — `*_severities = "critical"` sends only
+  firing alerts (recoveries suppressed); `"all"` (default) sends both. An alert
+  below a channel's threshold is never delivered to it (`AlertChannel::accepts_severity`).
+- All outbound calls reuse the SSRF-hardened HTTP client and stay off the
+  request path. A native transport counts as a destination, so configuring one
+  satisfies `autumn doctor --strict` without `[alerts] email`/`webhook_url`.
+- `autumn alert test [--channel <name>]` fires a synthetic alert through each
+  configured outbound-HTTP channel (email is excluded) and reports per-channel
+  success/error.
+
+(issue #1630). See `docs/guide/operator-alerts.md`.
 
 ## Observability defaults
 
@@ -1261,6 +1358,60 @@ bounded `each_shard` fan-out); install custom routing with
 There are no cross-shard queries or transactions by design. See
 `docs/guide/sharding.md` and `examples/bookmarks-sharded`.
 
+## Per-tenant memory cells (unreleased — trunk-dev, issue #1766)
+
+Row-level tenancy scopes a tenant's *rows*; per-tenant memory cells bound a
+tenant's *in-process memory*. Each resolved tenant gets a `TenantCell` — a
+byte-accounting boundary with a soft quota and an owned scratch buffer — minted
+lazily by the process-wide `TenantCellRegistry` on the first call to
+`current_tenant_cell()` (returns `Option<Arc<TenantCell>>`; `None` when tenancy
+is disabled or no tenant is bound, so a route outside a tenant context degrades
+gracefully). Reach for it in a handler, charge the memory you want bounded, and
+let the RAII guard release it:
+
+```rust
+use autumn_web::prelude::*;
+use autumn_web::tenant_cell::current_tenant_cell;
+
+#[post("/reports")]
+async fn build_report() -> AutumnResult<String> {
+    // Over-quota tenants get a 503 here via `?`; the charge releases on drop.
+    let _charge = match current_tenant_cell() {
+        Some(cell) => Some(cell.try_charge(512 * 1024)?),
+        None => None, // tenancy disabled / no tenant bound
+    };
+    Ok(expensive_render().await?)
+}
+```
+
+- `try_charge(n)` reserves *before* you allocate and hands back a `Charge`
+  guard; the per-tenant scratch store
+  (`scratch_insert`/`scratch_get`/`scratch_remove`) is charged by allocation
+  **capacity** (not length) plus a fixed per-entry overhead
+  (`TenantCell::scratch_entry_overhead()`).
+- A charge over quota fails **only that tenant's** request — `QuotaExceeded`
+  converts to `AutumnError` as HTTP **503**; every other tenant's counter is
+  independent, so one whale degrades only its own traffic.
+- Configure under `[tenancy]`: `quota_bytes` (soft quota; `0`, the default,
+  disables it), `max_cells` (LRU cap on resident cells) and `idle_ttl_secs`
+  (idle eviction) — both `0` by default, both enforced lazily on cell insert.
+  The quota is stored atomically and refreshed on every access (retune-ready;
+  no config-reload path exists yet).
+- The whole `[tenancy]` section is settable from the environment via
+  `AUTUMN_TENANCY__*` (e.g. `AUTUMN_TENANCY__QUOTA_BYTES`,
+  `AUTUMN_TENANCY__MAX_CELLS`, `AUTUMN_TENANCY__IDLE_TTL_SECS`).
+- Eviction — manual `TenantCellRegistry::evict(tenant_id)` or automatic
+  (`max_cells`/`idle_ttl_secs`) — reclaims tracked bytes on `Drop`; an in-flight
+  request keeps its own cached `Arc<TenantCell>` to completion, so evicting
+  mid-request never resets a running request's state. This is a tracked-bytes
+  accounting boundary via `tracked_bytes()` / `total_tracked_bytes()`, **not**
+  RSS — allocations made outside the cell API are invisible by design.
+
+`TenantCell`/`TenantCellRegistry`/`current_tenant_cell` live in
+`autumn_web::tenant_cell` (not in the prelude). Orthogonal to sharding: sharding
+picks the *database*, cells bound *process memory*. See
+docs/guide/tenant-cells.md (issue #1766).
+
 ## Error handling
 
 JSON errors are standardized as RFC 7807-style Problem Details.
@@ -1372,6 +1523,7 @@ autumn i18n check                # compare t!/t(...) keys vs i18n/*.ftl; --stric
 autumn test                      # provision/target an isolated *_test DB, migrate, then cargo test
 autumn test --reset -- --nocapture   # drop+recreate the test DB; forward args to the harness
 autumn db backup --keep 7        # dump control DB + shards to ./backups/<profile>/<ts>/; db restore <artifact> reverses it
+autumn db backup --upload --keep 7   # + upload each verified run offsite (S3/MinIO/R2); db offsite list; db restore offsite:<profile>/latest  # (unreleased — trunk-dev)
 autumn seed --count 50 --model Post  # generate+insert 50 faked rows via the model's factory (both flags together)
 autumn serve --role worker       # run only workers + scheduler (web/worker split); also --role web|combined
 ```
@@ -1458,6 +1610,48 @@ prunes to the newest N runs. `autumn db restore <ARTIFACT> [--shard NAME]
 [--force]` verifies every artifact before touching a database and is gated by the
 same production guard as `db drop` (refuses non-dev/test without `--force`). See
 `docs/guide/deployment.md`.
+
+### Offsite S3 backups (unreleased — trunk-dev, issue #1619)
+
+`autumn db backup --upload` (or `[backup.offsite] auto_upload = true`) uploads
+each completed local run to an S3-compatible offsite destination (AWS S3,
+`MinIO`, Cloudflare R2, Backblaze B2, Garage) **after** local verification
+passes, then HEAD/GET-verifies every remote object matches before reporting
+success; a local-good / upload-failed run exits non-zero with a split-outcome
+message and leaves the local artifact intact. Configure it in `autumn.toml`:
+
+```toml
+[backup.offsite]
+auto_upload = true          # upload after every `autumn db backup`, no --upload
+prefix = "db"               # objects keyed {prefix}/{profile}/{timestamp}/{file}
+keep = 30                   # independent remote retention (prune after verify)
+# allow_shared_bucket = true  # opt-in to reuse the app's [storage.s3] bucket
+
+[backup.offsite.s3]
+bucket   = "myapp-db-offsite"
+region   = "auto"
+endpoint = "https://<accountid>.r2.cloudflarestorage.com"
+force_path_style = true
+access_key_id_env     = "AUTUMN_OFFSITE_ACCESS_KEY_ID"    # names, not values
+secret_access_key_env = "AUTUMN_OFFSITE_SECRET_ACCESS_KEY"
+```
+
+Every key has an `AUTUMN_BACKUP__OFFSITE__*` override (e.g.
+`AUTUMN_BACKUP__OFFSITE__S3__BUCKET`) and honors profile overlays
+(`[profile.prod.backup.offsite]`). Credentials are **env-var indirection** only
+— config names the env vars the secrets are read from; the values never live in
+config, argv, logs, or errors. `autumn db offsite list [--profile P]` shows the
+offsite runs for the active profile; `autumn db restore
+offsite:<profile>/<timestamp|latest>` (or `--offsite`) downloads a run to a temp
+dir and applies the same integrity verification and production `--force` guard as
+a local restore. The transfer client is a dependency-light synchronous `SigV4`
+client streamed end-to-end (multipart above 64 MiB — S3 caps a single
+`PutObject` at 5 GiB — with a server-side `x-amz-checksum-sha256`). `autumn
+doctor` adds an informational `offsite_backup` check (see the `doctor` skill),
+and a failed upload raises a `ScheduledTaskFailure` operator alert when
+`[alerts]` is configured (issue #1743). Pointing the offsite bucket at the app's
+own `[storage.s3]` bucket needs `allow_shared_bucket = true`. See
+`docs/guide/daemon.md`.
 
 `autumn destroy` mirrors `autumn generate` argument-for-argument and never
 touches a database — it only reverses generated files/migrations.

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -1229,8 +1229,11 @@ discord_severities = "all"
 - **Per-channel severity routing** — `*_severities = "critical"` sends only
   firing alerts (recoveries suppressed); `"all"` (default) sends both. An alert
   below a channel's threshold is never delivered to it (`AlertChannel::accepts_severity`).
-- All outbound calls reuse the SSRF-hardened HTTP client and stay off the
-  request path. A native transport counts as a destination, so configuring one
+- Outbound alert sends stay off the request path (dispatched best-effort on a
+  background runtime task). Slack/Discord webhook URLs must be absolute `https`,
+  but the sends only validate URL shape and do not run through the SSRF
+  deny-list, so restrict alert destinations to trusted operator-configured URLs.
+  A native transport counts as a destination, so configuring one
   satisfies `autumn doctor --strict` without `[alerts] email`/`webhook_url`.
 - `autumn alert test [--channel <name>]` fires a synthetic alert through each
   configured outbound-HTTP channel (email is excluded) and reports per-channel

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -1648,7 +1648,8 @@ dir and applies the same integrity verification and production `--force` guard a
 a local restore. The transfer client is a dependency-light synchronous `SigV4`
 client streamed end-to-end (multipart above 64 MiB — S3 caps a single
 `PutObject` at 5 GiB — with a server-side `x-amz-checksum-sha256`). `autumn
-doctor` adds an informational `offsite_backup` check (see the `doctor` skill),
+doctor` adds an `offsite_backup` check that fails on an invalid configured
+destination and warns on unready credentials (see the `doctor` skill),
 and a failed upload raises a `ScheduledTaskFailure` operator alert only when an
 outbound-HTTP `[alerts]` channel (PagerDuty / Slack / Discord / signed webhook)
 is configured — an email-only `[alerts]` config is not notified (issue #1743).

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -1661,7 +1661,7 @@ and a failed upload raises a `ScheduledTaskFailure` operator alert only when an
 outbound-HTTP `[alerts]` channel (PagerDuty / Slack / Discord / signed webhook)
 is configured — an email-only `[alerts]` config is not notified (issue #1743).
 Pointing the offsite bucket at the app's
-own `[storage.s3]` bucket needs `allow_shared_bucket = true`. See
+own `[storage.s3]` bucket at the same endpoint needs `allow_shared_bucket = true`. See
 `docs/guide/daemon.md`.
 
 `autumn destroy` mirrors `autumn generate` argument-for-argument and never

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -394,9 +394,10 @@ the model instead of the repository **(unreleased — trunk-dev, issues #1738,
   `on_delete = destroy`). The repository codegen consults this at run time (via
   a generated `Model::dependents()`) when no repository-side `dependent(...)` is
   present; the repository attribute wins when both are declared. Ships for
-  `destroy`, `delete_all`, and `restrict`, grandchild recursion and the
-  `delete_many` bulk path included; `dependent = nullify` is a deferred
-  follow-up, and `dependent`/`on_delete` on a `through = <join_table>`
+  `destroy`, `delete_all`, `nullify`, and `restrict`, grandchild recursion and
+  the `delete_many` bulk path included; only both-sites conflict diagnostics are
+  a deferred follow-up (when both sites declare, the repository attribute
+  silently wins), and `dependent`/`on_delete` on a `through = <join_table>`
   association is a compile error (issue #1738).
 
 See `docs/guide/repositories.md`.

--- a/skills/autumn-web/SKILL.md
+++ b/skills/autumn-web/SKILL.md
@@ -1187,7 +1187,8 @@ to look" actuator pointer:
 - **High 5xx rate** — the rolling 5xx rate crosses `error_rate_threshold`
   (default `0.05`, a fraction in `(0, 1]`) over ≥ `error_rate_min_requests`.
 - **Scheduled-task failure** — a `#[scheduled]`/framework task returns an error.
-  A failed `autumn db backup` offsite upload also raises this condition
+  A failed `autumn db backup` offsite upload also raises this condition,
+  delivered via the outbound-HTTP alert channels only (not email)
   **(unreleased — trunk-dev, issue #1743)**.
 
 Delivery is best-effort and off the request path (background tick every
@@ -1648,8 +1649,10 @@ a local restore. The transfer client is a dependency-light synchronous `SigV4`
 client streamed end-to-end (multipart above 64 MiB — S3 caps a single
 `PutObject` at 5 GiB — with a server-side `x-amz-checksum-sha256`). `autumn
 doctor` adds an informational `offsite_backup` check (see the `doctor` skill),
-and a failed upload raises a `ScheduledTaskFailure` operator alert when
-`[alerts]` is configured (issue #1743). Pointing the offsite bucket at the app's
+and a failed upload raises a `ScheduledTaskFailure` operator alert only when an
+outbound-HTTP `[alerts]` channel (PagerDuty / Slack / Discord / signed webhook)
+is configured — an email-only `[alerts]` config is not notified (issue #1743).
+Pointing the offsite bucket at the app's
 own `[storage.s3]` bucket needs `allow_shared_bucket = true`. See
 `docs/guide/daemon.md`.
 

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -68,6 +68,7 @@ These names match what `autumn doctor --json` actually emits in the `name` field
 | `rate_limit_key_strategy` | Set `rate_limit.key_strategy` to `"ip"`, `"api_token"`, or `"authenticated_principal"` |
 | `version_compat` | Upgrade `autumn-cli` to match the framework version: `cargo install autumn-cli --version 0.5.0` |
 | `dotenv` | Copy `.env.example` to `.env` and fill in local values, or add every present secret dotenv file (`.env`, `.env.local`, and any `.env.<profile>.local`) to `.gitignore` if it is not already ignored — committable `.env.<profile>` files are left alone (warns only; never fails) |
+| `jobs_queue_coverage` **(trunk-dev)** | Add the uncovered queue(s) to a tier's `jobs.pin` in `[jobs.fleet].tiers`, or run an unpinned tier that drains everything (only fails under `--strict` once `[jobs.fleet]` is declared) |
 
 ## Operator alert checks (unreleased — trunk-dev)
 
@@ -81,6 +82,56 @@ enabled = false` despite a configured destination. If you register an
 `AlertChannel` in code via `AppBuilder::with_alert_channel`, declare
 `[alerts] custom_channel = true` so `--strict` passes without a `[alerts]`
 destination. See `docs/guide/operator-alerts.md`.
+
+### Native alert transports (unreleased — trunk-dev, issue #1630)
+
+On trunk-dev, a configured native transport (a `[alerts] pagerduty_routing_key`,
+`slack_webhook_url`, or `discord_webhook_url`) now counts as an alert
+destination, so the production-only `alert_destination` no-destination warning
+no longer fires when only a native transport is set (no `email`/`webhook_url`
+needed). A separate production-only `alert_transports` check validates their
+delivery-worthiness: it warns on a `pagerduty_routing_key` containing whitespace
+(a malformed Events API v2 key), a set-but-non-absolute `pagerduty_url` override,
+a `pagerduty_url` set with no routing key, and a `slack_webhook_url` /
+`discord_webhook_url` that is not an absolute `https` URL (Slack and Discord only
+expose `https` webhook endpoints). Each `AUTUMN_ALERTS__*` env override is
+accepted in place of the TOML key (issue #1630). See
+`docs/guide/operator-alerts.md`.
+
+## Offsite-backup check (unreleased — trunk-dev, issue #1619)
+
+`autumn doctor` adds an informational `offsite_backup` check for the offsite S3
+backup destination (`[backup.offsite]`). It is never a hard failure and never
+prints a credential value: it notes when no offsite destination is configured,
+and — once one is — flags an unset `backup.offsite.s3.bucket`, a destination that
+shares the app's `[storage.s3]` bucket without
+`backup.offsite.allow_shared_bucket = true`, or named credential env vars
+(`backup.offsite.s3.access_key_id_env` / `secret_access_key_env`) that are not
+ready. Remedy: add a `[backup.offsite]` section and run `autumn db backup
+--upload`, or set the specific key the check names. See `docs/guide/daemon.md`.
+
+## Topology-aware queue coverage (unreleased — trunk-dev, issue #1756)
+
+On trunk-dev, `autumn doctor --strict` can hard-fail on a genuine job-queue
+coverage gap once the operator declares the fleet topology. Declare every worker
+tier's pin under `[jobs.fleet]`:
+
+```toml
+[jobs.fleet]
+tiers = [["critical"], ["bulk", "default"]]  # each inner array = one worker
+                                             # tier's jobs.pin; [] = unpinned
+                                             # (drains every queue)
+manifest = "target/jobs-manifest.toml"       # OR: declared_queues = ["…"]
+```
+
+The `jobs_queue_coverage` check then reasons about the **union** of all tier
+pins: it FAILS (exit 1 under `--strict`) only when a needed queue — the
+configured `[jobs.queues]` unioned with the compiled `#[job(queue = "…")]`-declared
+set — is drained by no tier anywhere, so a valid multi-tier subset split no
+longer false-positives. The declared set comes from a `[jobs.fleet] manifest`
+emitted by `autumn jobs manifest` (a TOML `queues = [...]` document) or an inline
+`[jobs.fleet] declared_queues` list. Without `[jobs.fleet]` the check stays
+informational-only (Pass), exactly as before (issue #1756).
 
 ## Secrets redaction
 

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -69,6 +69,7 @@ These names match what `autumn doctor --json` actually emits in the `name` field
 | `version_compat` | Upgrade `autumn-cli` to match the framework version: `cargo install autumn-cli --version 0.5.0` |
 | `dotenv` | Copy `.env.example` to `.env` and fill in local values, or add every present secret dotenv file (`.env`, `.env.local`, and any `.env.<profile>.local`) to `.gitignore` if it is not already ignored — committable `.env.<profile>` files are left alone (warns only; never fails) |
 | `jobs_queue_coverage` **(trunk-dev)** | Add the uncovered queue(s) to a tier's `jobs.pin` in `[jobs.fleet].tiers`, or run an unpinned tier that drains everything (only fails under `--strict` once `[jobs.fleet]` is declared) |
+| `offsite_backup` **(trunk-dev)** | Set `backup.offsite.s3.bucket`, or set `backup.offsite.allow_shared_bucket = true` if intentionally reusing the app `[storage.s3]` bucket |
 
 ## Operator alert checks (unreleased — trunk-dev)
 
@@ -100,15 +101,22 @@ accepted in place of the TOML key (issue #1630). See
 
 ## Offsite-backup check (unreleased — trunk-dev, issue #1619)
 
-`autumn doctor` adds an informational `offsite_backup` check for the offsite S3
-backup destination (`[backup.offsite]`). It is never a hard failure and never
-prints a credential value: it notes when no offsite destination is configured,
-and — once one is — flags an unset `backup.offsite.s3.bucket`, a destination that
-shares the app's `[storage.s3]` bucket without
-`backup.offsite.allow_shared_bucket = true`, or named credential env vars
-(`backup.offsite.s3.access_key_id_env` / `secret_access_key_env`) that are not
-ready. Remedy: add a `[backup.offsite]` section and run `autumn db backup
---upload`, or set the specific key the check names. See `docs/guide/daemon.md`.
+`autumn doctor` adds an `offsite_backup` check for the offsite S3 backup
+destination (`[backup.offsite]`). It never prints a credential value (only
+env-var names / booleans), but it **can hard-fail** on an invalid configured
+destination:
+
+- **Pass** — no offsite destination is configured, or a configured destination
+  is complete (bucket set + credential env vars ready).
+- **Warn** — the bucket is set but the named credential env vars
+  (`backup.offsite.s3.access_key_id_env` / `secret_access_key_env`) are not ready
+  (unset name, or the variable is not exported).
+- **Fail** — an invalid configured destination: `[backup.offsite]` is set without
+  `backup.offsite.s3.bucket`, or the destination reuses the app's `[storage.s3]`
+  bucket at the same endpoint without `backup.offsite.allow_shared_bucket = true`.
+
+Remedy: add a `[backup.offsite]` section and run `autumn db backup --upload`, or
+set the specific key the check names. See `docs/guide/daemon.md`.
 
 ## Topology-aware queue coverage (unreleased — trunk-dev, issue #1756)
 

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -68,7 +68,7 @@ These names match what `autumn doctor --json` actually emits in the `name` field
 | `rate_limit_key_strategy` | Set `rate_limit.key_strategy` to `"ip"`, `"api_token"`, or `"authenticated_principal"` |
 | `version_compat` | Upgrade `autumn-cli` to match the framework version: `cargo install autumn-cli --version 0.5.0` |
 | `dotenv` | Copy `.env.example` to `.env` and fill in local values, or add every present secret dotenv file (`.env`, `.env.local`, and any `.env.<profile>.local`) to `.gitignore` if it is not already ignored — committable `.env.<profile>` files are left alone (warns only; never fails) |
-| `jobs_queue_coverage` **(trunk-dev)** | Add the uncovered queue(s) to a tier's `jobs.pin` in `[jobs.fleet].tiers`, or run an unpinned tier that drains everything (only fails under `--strict` once `[jobs.fleet]` is declared) |
+| `jobs_queue_coverage` **(trunk-dev)** | Add the uncovered queue(s) to a tier's `jobs.pin` in `[jobs.fleet].tiers`, or run an unpinned tier that drains everything (fails once `[jobs.fleet]` is declared and a needed queue is uncovered; informational when `[jobs.fleet]` is absent) |
 | `offsite_backup` **(trunk-dev)** | Set `backup.offsite.s3.bucket`, or set `backup.offsite.allow_shared_bucket = true` if intentionally reusing the app `[storage.s3]` bucket |
 
 ## Operator alert checks (unreleased — trunk-dev)
@@ -120,9 +120,9 @@ set the specific key the check names. See `docs/guide/daemon.md`.
 
 ## Topology-aware queue coverage (unreleased — trunk-dev, issue #1756)
 
-On trunk-dev, `autumn doctor --strict` can hard-fail on a genuine job-queue
-coverage gap once the operator declares the fleet topology. Declare every worker
-tier's pin under `[jobs.fleet]`:
+On trunk-dev, `autumn doctor` hard-fails on a genuine job-queue coverage gap
+once the operator declares the fleet topology. Declare every worker tier's pin
+under `[jobs.fleet]`:
 
 ```toml
 [jobs.fleet]
@@ -133,13 +133,16 @@ manifest = "target/jobs-manifest.toml"       # OR: declared_queues = ["…"]
 ```
 
 The `jobs_queue_coverage` check then reasons about the **union** of all tier
-pins: it FAILS (exit 1 under `--strict`) only when a needed queue — the
-configured `[jobs.queues]` unioned with the compiled `#[job(queue = "…")]`-declared
-set — is drained by no tier anywhere, so a valid multi-tier subset split no
-longer false-positives. The declared set comes from a `[jobs.fleet] manifest`
-emitted by `autumn jobs manifest` (a TOML `queues = [...]` document) or an inline
-`[jobs.fleet] declared_queues` list. Without `[jobs.fleet]` the check stays
-informational-only (Pass), exactly as before (issue #1756).
+pins: it returns a hard `Fail` when a needed queue — the configured
+`[jobs.queues]` unioned with the compiled `#[job(queue = "…")]`-declared set —
+is drained by no tier anywhere, so a valid multi-tier subset split no longer
+false-positives. Because a `Fail` counts toward the exit code regardless of
+mode, ANY `autumn doctor` run (not just `--strict`) exits non-zero on that gap;
+`--strict` additionally escalates warnings to a non-zero exit. The declared set
+comes from a `[jobs.fleet] manifest` emitted by `autumn jobs manifest` (a TOML
+`queues = [...]` document) or an inline `[jobs.fleet] declared_queues` list.
+Without `[jobs.fleet]` the check stays informational-only (Pass), exactly as
+before (issue #1756).
 
 ## Secrets redaction
 

--- a/skills/generate/SKILL.md
+++ b/skills/generate/SKILL.md
@@ -136,6 +136,30 @@ three additive scaffold behaviors (issues #1388, #1146, #1718):
   --count/--model` resolves the model's factory; `autumn destroy` removes those
   links again. See `docs/guide/generators.md`.
 
+**Constrained-required numerics & `--live-validation` parity (unreleased — trunk-dev, issues #1748, #1750)**: two refinements to the `{…}` block above:
+
+- **Blank-state for constrained required numerics** — a required numeric field
+  with a `{min,max}` range (e.g. `age:i32{min=0,max=130}`) is emitted as
+  `Option<T>` on the generated `*Form` struct with `#[validate(required,
+  range(...))]`, not the native `i32`/`i64`/`f32`/`f64`. A native numeric
+  defaults to `0` and pre-fills the input, so a blank submit used to pass both
+  `required` and `range` when the range spans zero and silently persist `0`;
+  `Option<T>` defaults to `None`, renders blank, and `required` rejects it with a
+  **422** inline error. The empty `field=` pair is also dropped by the form
+  decoder, so a blank non-browser submit yields the 422 rather than a `400`. The
+  `required` rule sits on the form struct only, never the model field; a nullable
+  numeric is already `Option<T>` and is unaffected (issue #1748).
+- **`--live-validation` HTML5 + belongs_to parity** — `--live-validation`
+  scaffolds now emit the same client-side HTML5 constraint attributes
+  (`minlength`/`maxlength`, `type="email"`/`type="url"`, numeric `min`/`max`,
+  `step="any"`, and a `<textarea>` for a constrained `Text`) and the `belongs_to`
+  parent `<select>` as the standard `form_for` path; both were previously dropped
+  on the per-field live path. Server-side `#[validate(...)]` was already enforced
+  under `--live-validation` — this only restores the client-side hints and the
+  request-time populated dropdown (with changeset-driven `selected` state), and
+  the inline-validate fragment returns identical markup so an htmx `outerHTML`
+  swap on `change` keeps the guards (issue #1750). See `docs/guide/generators.md`.
+
 ## Execution flow
 
 1. Parse the subcommand and arguments from user input.
@@ -337,6 +361,19 @@ Next steps:
    single-use, expiring login-link routes (do not name the auth resource
    `magic_link_token`).
 ```
+
+**Magic-link account-lock recheck (trunk-dev)**: the generated `POST
+/login/magic/verify` handler re-checks the account lock **(unreleased —
+trunk-dev, issue #1777)** after consuming the single-use token and before
+establishing a session, so a magic link minted before an account was locked can
+no longer complete a login after lockout. The recheck is a fresh guarded
+`UPDATE` on `locked_at` (same time-bounded `[auth.lockout]` cool-off semantics
+as password login, gated on the same `lockout_enabled` predicate — a no-op when
+lockout is disabled), re-reading the current lock state at the DB to close the
+concurrent-lock TOCTOU. It sits before the TOTP branch, so it covers both
+`--magic-link` and `--magic-link --totp`; a locked account renders the same
+generic failure page as an expired/consumed/unknown token, so there is no
+oracle.
 
 ## Flags
 


### PR DESCRIPTION
## Summary

Brings `CHANGELOG.md`'s `## [Unreleased]` section and the plugin `skills/` files up to date for feature work merged to `trunk-dev` since the previous docs batch (#1775). Documentation only — no source changes, no version bump, every bullet lands under the existing `## [Unreleased]` (no new dated section).

**Before:** 17 merged PRs (offsite backups, per-tenant memory cells, dependent cascades, native alert transports, jobs observability, and more) had shipped to `trunk-dev` with no changelog or skills entry.
**After:** each is documented — 22 changelog bullets plus mirrored `skills/` sections — with config keys, flags, env vars, and issue references grounded in the actual merged diffs.

## Documented work

- **Offsite S3 backups** (#1619) + follow-ups: CI MinIO round-trip (#1744), env-materialization fix (#1791), verify-failure remote cleanup (#1760), upload-failure operator alert (#1743).
- **Scaffold**: `Option<T>` blank-state for constrained required numerics (#1748); HTML5 constraints + `belongs_to` `<select>` under `--live-validation` (#1750).
- **Jobs observability**: backend-derived `/actuator/jobs` queue gauges (#1752); topology-aware `doctor --strict` coverage via `[jobs.fleet]` (#1756); `autumn jobs manifest` (#1756).
- **Per-tenant memory cells** `TenantCell` (#1766) + registry eviction / dynamic quota / `AUTUMN_TENANCY__*` env overrides (#1792, #1783, #1793).
- **Cascades**: recursive + bulk + model-side `dependent` (#1738, #1739, #1740, #1787); `across_tenants` no-shard-set read guard (#1741).
- **Auth / security**: magic-link `locked_at` recheck (#1777), config-sourced TTL/cooldown via `[auth.magic_link]` (#1737), no step-up elevation on remember-cookie restore (#1397).
- **Macros**: merged-model validation on the update path (#1778); irregular-plural table names (#1753).
- **Alerts**: native PagerDuty / Slack / Discord transports (#1630).
- **Fixes**: OpenAPI path-param extraction (#1721); htmx positional/`innerHTML` OOB `<div>` carrier (#1688).

Beyond the originally-scoped set, a `git log` completeness sweep surfaced 5 more merged-but-undocumented user-facing PRs — #1780 (alerts, #1630), #1776 (magic-link config, #1737), #1779 (plurals, #1753), #1727 (step-up, #1397), #1732 (OpenAPI #1721 + htmx #1688) — which are folded in here.

## Scope

- `CHANGELOG.md` (+290): 12 Added, 8 Fixed, 2 Changed bullets under `## [Unreleased]`.
- `skills/autumn-web/SKILL.md`, `skills/doctor/SKILL.md`, `skills/generate/SKILL.md`: mirror the features with `(unreleased — trunk-dev)` tags, and correct a now-stale "does not recurse" cascade note that #1739 invalidated.

Test-only / docs-only / CI-only merges and still-unmerged PRs are intentionally excluded.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9P87SckwQXBtBHkbRNHTC)_