### PR TITLE
Scaffold a full-text search box wired to FTS in list views

### DIFF
--- a/autumn-cli/src/generate/config.rs
+++ b/autumn-cli/src/generate/config.rs
@@ -76,6 +76,11 @@ pub struct ScaffoldConfigEntry {
     /// (issue #1125).
     #[serde(default)]
     pub no_policy: bool,
+    /// Text field names to make full-text searchable (issue #1319): emits
+    /// `#[searchable]` on the model, `searchable` on the repository, the
+    /// `search_vector` migration, and a wired search box in the index view.
+    #[serde(default)]
+    pub searchable: Vec<String>,
 }
 
 /// Project-level generator defaults, read from `[generate]` in the config file.
@@ -295,6 +300,7 @@ pub fn merge_config_with_cli(
     cli_id: Option<&str>,
     cli_live_validation: bool,
     cli_no_policy: bool,
+    cli_searchable: &[String],
 ) -> Result<(Vec<String>, ScaffoldOptions), GenerateError> {
     let pick = |cli: &[String], toml: Vec<String>| -> Vec<String> {
         if cli.is_empty() { toml } else { cli.to_vec() }
@@ -305,6 +311,7 @@ pub fn merge_config_with_cli(
     let validations = pick(cli_validations, config.validations);
     let defaults = pick(cli_defaults, config.defaults);
     let queries = pick(cli_queries, config.queries);
+    let searchable = pick(cli_searchable, config.searchable);
     // CLI flag wins; TOML config enables it when present.
     let soft_delete = cli_soft_delete || config.soft_delete;
     let api = cli_api || config.api;
@@ -333,6 +340,7 @@ pub fn merge_config_with_cli(
                 sharded,
                 shard_key,
                 id_type,
+                searchable,
             },
             queries,
             api,
@@ -634,6 +642,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             id: None,
             live_validation: false,
             no_policy: false,
+            searchable: vec![],
         }
     }
 
@@ -654,6 +663,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             None,
             false,
             false,
+            &[],
         )
         .unwrap()
     }
@@ -686,6 +696,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             None,
             false,
             false,
+            &[],
         )
         .unwrap();
         assert_eq!(fields, vec!["title:String", "body:Text"]);
@@ -709,6 +720,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             None,
             false,
             false,
+            &[],
         )
         .unwrap();
         assert_eq!(opts.model.indexes, vec!["tag"]);
@@ -732,6 +744,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             None,
             false,
             false,
+            &[],
         )
         .unwrap();
         assert_eq!(opts.model.validations, vec!["url=email"]);
@@ -757,6 +770,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             None,
             false,
             false,
+            &[],
         )
         .unwrap();
         assert_eq!(opts.model.defaults, vec!["tag=general"]);
@@ -780,6 +794,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             None,
             false,
             false,
+            &[],
         )
         .unwrap();
         assert_eq!(opts.queries, vec!["find_by_tag:tag"]);
@@ -804,6 +819,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             None,
             false,
             false,
+            &[],
         )
         .unwrap();
         assert!(fields.is_empty());
@@ -831,6 +847,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             None,
             false,
             false,
+            &[],
         )
         .unwrap();
         assert!(
@@ -893,6 +910,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             None,
             false,
             false,
+            &[],
         )
         .unwrap();
         assert!(opts.api);
@@ -940,6 +958,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             None,
             false,
             false,
+            &[],
         )
         .unwrap();
         assert!(
@@ -979,6 +998,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             None,
             false,
             false,
+            &[],
         )
         .unwrap();
         assert_eq!(
@@ -1041,6 +1061,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             Some("uuid"),
             false,
             false,
+            &[],
         )
         .unwrap();
         assert_eq!(
@@ -1082,6 +1103,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             Some("bigint"),
             false,
             false,
+            &[],
         )
         .unwrap();
         assert_eq!(
@@ -1119,6 +1141,7 @@ queries     = ["find_by_tag:tag", "find_by_alive:alive"]
             Some("guid"),
             false,
             false,
+            &[],
         )
         .unwrap_err();
         let msg = err.to_string();

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -1359,6 +1359,22 @@ pub fn parse_model_metadata(
         metadata.defaults.insert(field_name.to_owned(), sql);
     }
 
+    // Full-text search's generated `search_page` (in the repository macro)
+    // hardcodes an `i64`/`BigInt` primary key: it collects `SearchId { id: i64 }`
+    // rows into a `Vec<i64>`, filters with `id.eq_any(&ids)`, and dedups through
+    // a `HashMap<i64, _>`. A non-`i64` primary key (e.g. `--id uuid`) would make
+    // those `id` operations type-mismatch, so the generated repository would fail
+    // to compile. Reject the combination up front — before any files are written
+    // — rather than emitting broken code.
+    if !options.searchable.is_empty() && options.id_type != IdType::BigSerial {
+        return Err(GenerateError::Config(format!(
+            "`--searchable` requires an i64 (bigint) primary key; full-text search does not \
+             yet support `{}` ids (the repository's `search_page` is hardcoded to `i64`). \
+             Re-run without `--searchable`, or use the default `--id bigint` primary key.",
+            options.id_type.rust_type()
+        )));
+    }
+
     // Full-text search config (issue #1319). Only text (`String`/`Text`) fields
     // can populate a `tsvector`; a non-text field would emit a model that fails
     // to compile against the `#[searchable]` macro and a migration Postgres
@@ -1381,7 +1397,7 @@ pub fn parse_model_metadata(
                 field.rust_type()
             )));
         }
-        let weight = [b'A', b'B', b'C', b'D'][i.min(3)] as char;
+        let weight = b"ABCD"[i.min(3)] as char;
         metadata.searchable.push((field_name.to_owned(), weight));
     }
     if !metadata.searchable.is_empty() {
@@ -2438,6 +2454,53 @@ mod tests {
             metadata.defaults().get("amount").map(String::as_str),
             Some("1.500")
         );
+    }
+
+    /// Issue #1319: the repository macro's `search_page` is hardcoded to an
+    /// `i64`/`BigInt` primary key (`SearchId { id: i64 }`, `Vec<i64>`,
+    /// `id.eq_any(&ids)`, `HashMap<i64, _>`), so pairing `--searchable` with a
+    /// non-i64 (uuid) key would emit a repository that fails to compile.
+    /// `parse_model_metadata` rejects the combination directly, independent of
+    /// the scaffold command's broader uuid gate.
+    #[test]
+    fn searchable_with_uuid_primary_key_is_rejected() {
+        let fields = parse_fields(&["title:String".into(), "body:Text".into()]).unwrap();
+        let err = parse_model_metadata(
+            &fields,
+            &ModelOptions {
+                searchable: vec!["title".into(), "body".into()],
+                id_type: IdType::Uuid,
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            matches!(err, GenerateError::Config(_)),
+            "expected Config error, got: {err:?}"
+        );
+        assert!(
+            msg.contains("--searchable")
+                && (msg.contains("i64") || msg.contains("bigint"))
+                && msg.contains("uuid::Uuid"),
+            "error must explain the i64-primary-key requirement and name the uuid type: {msg}"
+        );
+    }
+
+    /// A uuid primary key WITHOUT `--searchable` stays valid (the guard only
+    /// fires when full-text search is requested).
+    #[test]
+    fn uuid_primary_key_without_searchable_is_accepted() {
+        let fields = parse_fields(&["title:String".into()]).unwrap();
+        let metadata = parse_model_metadata(
+            &fields,
+            &ModelOptions {
+                id_type: IdType::Uuid,
+                ..Default::default()
+            },
+        )
+        .expect("uuid without --searchable must be accepted");
+        assert!(metadata.searchable().is_empty());
     }
 
     #[test]

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -1271,6 +1271,7 @@ fn validate_enum_field_collisions(
     Ok(())
 }
 
+#[allow(clippy::too_many_lines)]
 pub fn parse_model_metadata(
     fields: &[Field],
     options: &ModelOptions,
@@ -1372,6 +1373,28 @@ pub fn parse_model_metadata(
              yet support `{}` ids (the repository's `search_page` is hardcoded to `i64`). \
              Re-run without `--searchable`, or use the default `--id bigint` primary key.",
             options.id_type.rust_type()
+        )));
+    }
+
+    // `search_vector` is the generated FTS column name, hardcoded by the
+    // repository macro (`ADD COLUMN search_vector tsvector` in the appended
+    // migration, and the `search_vector @@ …` queries in `search_page`). If the
+    // model also declares its own field named `search_vector`, the create-table
+    // SQL emits that column first and the FTS migration then fails to add it
+    // (duplicate column) at `autumn migrate`. Reserve the name for searchable
+    // models and reject up front (case-insensitive; only relevant with
+    // `--searchable` — a `search_vector` field is harmless otherwise).
+    if !options.searchable.is_empty()
+        && let Some(field) = fields
+            .iter()
+            .find(|f| f.name.eq_ignore_ascii_case("search_vector"))
+    {
+        return Err(GenerateError::Config(format!(
+            "`{}` is a reserved column name for `--searchable` models: `search_vector` is \
+             the generated tsvector column the FTS migration adds, so a model field of the \
+             same name collides with it (duplicate column at `autumn migrate`). Rename the \
+             field, or drop `--searchable`.",
+            field.name
         )));
     }
 
@@ -2485,6 +2508,43 @@ mod tests {
                 && msg.contains("uuid::Uuid"),
             "error must explain the i64-primary-key requirement and name the uuid type: {msg}"
         );
+    }
+
+    /// Issue #1319: a model field named `search_vector` collides with the
+    /// generated tsvector column the FTS migration adds, so pairing it with
+    /// `--searchable` is rejected up front. (Field names parse as lowercase
+    /// `snake_case`, so the guard's `eq_ignore_ascii_case` is defensive; the
+    /// reachable case is a lowercase `search_vector` field.)
+    #[test]
+    fn searchable_with_search_vector_field_is_rejected() {
+        let fields = parse_fields(&["title:String".into(), "search_vector:String".into()]).unwrap();
+        let err = parse_model_metadata(
+            &fields,
+            &ModelOptions {
+                searchable: vec!["title".into()],
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            matches!(err, GenerateError::Config(_)),
+            "expected Config error, got: {err:?}"
+        );
+        assert!(
+            msg.contains("search_vector") && msg.contains("reserved"),
+            "error must flag `search_vector` as reserved: {msg}"
+        );
+    }
+
+    /// A `search_vector` field WITHOUT `--searchable` is harmless and accepted
+    /// (the name is only reserved for full-text-search models).
+    #[test]
+    fn search_vector_field_without_searchable_is_accepted() {
+        let fields = parse_fields(&["title:String".into(), "search_vector:String".into()]).unwrap();
+        let metadata = parse_model_metadata(&fields, &ModelOptions::default())
+            .expect("search_vector without --searchable must be accepted");
+        assert!(metadata.searchable().is_empty());
     }
 
     /// A uuid primary key WITHOUT `--searchable` stays valid (the guard only

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -8,8 +8,8 @@ use super::dsl::{Field, FieldConstraints, FieldKind, IdType, parse_fields};
 use super::emit::Plan;
 use super::naming::{pascal, pluralize, snake};
 use super::schema_edit::{
-    add_mod_declaration, append_schema_table_with_id, create_table_sql_with_metadata_and_id,
-    drop_table_sql, link_models_into_seed_bin,
+    add_mod_declaration, add_search_down_sql, add_search_up_sql, append_schema_table_with_id,
+    create_table_sql_with_metadata_and_id, drop_table_sql, link_models_into_seed_bin,
 };
 use super::{GenerateError, ensure_project_root, read_or_empty};
 
@@ -38,6 +38,12 @@ pub struct ModelOptions {
     /// Primary-key type emitted for the `id` column. Defaults to `BigSerial`
     /// (`BIGSERIAL`/`i64`); set to `Uuid` for non-enumerable identifiers.
     pub id_type: IdType,
+    /// Text field names (`String`/`Text`) to make full-text searchable
+    /// (issue #1319). Emits a struct-level `#[searchable(language = "english")]`
+    /// plus per-field `#[searchable(weight = "…")]`, and a `search_vector`
+    /// generated column + GIN index in the migration. Empty by default (the
+    /// flag is purely additive; when unset, output is byte-for-byte identical).
+    pub searchable: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -45,12 +51,30 @@ pub struct ModelMetadata {
     indexes: BTreeSet<String>,
     validations: BTreeMap<String, Vec<String>>,
     defaults: BTreeMap<String, String>,
+    /// Full-text search config (issue #1319): the FTS dictionary language and
+    /// the ordered `(field, weight)` list. `search_language` is `Some` iff any
+    /// field is searchable.
+    search_language: Option<String>,
+    searchable: Vec<(String, char)>,
 }
 
 impl ModelMetadata {
     #[must_use]
     pub fn has_validator_rules(&self) -> bool {
         !self.validations.is_empty()
+    }
+
+    /// The FTS dictionary language when the model has searchable fields.
+    #[must_use]
+    pub fn search_language(&self) -> Option<&str> {
+        self.search_language.as_deref()
+    }
+
+    /// The ordered `(field, weight)` pairs the `search_vector` column is built
+    /// from (issue #1319). Empty when the model is not searchable.
+    #[must_use]
+    pub fn searchable(&self) -> &[(String, char)] {
+        &self.searchable
     }
 
     #[must_use]
@@ -188,8 +212,25 @@ pub fn plan_model_with_options(
     } else {
         table_sql
     };
+    // Full-text search (issue #1319): the `search_vector` generated column + GIN
+    // index are what `#[repository(..., searchable)]`'s `search_page` queries.
+    // Emitted in the same create-table migration so `autumn migrate` yields a
+    // working search with zero manual SQL. The column is a stored generated
+    // column, so it is intentionally NOT added to the model struct or schema.rs
+    // (the macro loads matched rows by id via raw SQL).
+    let (up_sql, down_sql) = if metadata.searchable().is_empty() {
+        (up_sql, drop_table_sql(&table))
+    } else {
+        let language = metadata.search_language().unwrap_or("english");
+        let search_up = add_search_up_sql(&table, language, metadata.searchable());
+        let search_down = add_search_down_sql(&table);
+        (
+            format!("{up_sql}\n{search_up}"),
+            format!("{search_down}{}", drop_table_sql(&table)),
+        )
+    };
     plan.create(migration_dir.join("up.sql"), up_sql);
-    plan.create(migration_dir.join("down.sql"), drop_table_sql(&table));
+    plan.create(migration_dir.join("down.sql"), down_sql);
 
     // (c) `src/schema.rs` entry
     let schema_path = project_root.join("src").join("schema.rs");
@@ -1318,6 +1359,37 @@ pub fn parse_model_metadata(
         metadata.defaults.insert(field_name.to_owned(), sql);
     }
 
+    // Full-text search config (issue #1319). Only text (`String`/`Text`) fields
+    // can populate a `tsvector`; a non-text field would emit a model that fails
+    // to compile against the `#[searchable]` macro and a migration Postgres
+    // rejects, so reject it here with an actionable, field-naming error (AC5).
+    // Weights follow the `search_page`/wiki convention: the first field gets the
+    // highest `A` weight, the rest `B`/`C`/`D` (capped), in the order given.
+    for (i, name) in options.searchable.iter().enumerate() {
+        let field_name = name.trim();
+        let field = field_by_name(fields, field_name).ok_or_else(|| {
+            GenerateError::Config(format!(
+                "--searchable names '{field_name}', which is not a field of this model. \
+                 Only declared text fields can be full-text searchable."
+            ))
+        })?;
+        if !is_string_like(field) {
+            return Err(GenerateError::Config(format!(
+                "--searchable field '{field_name}' is `{}`, but only text fields \
+                 (`String`/`Text`) can be full-text searchable. Remove it from \
+                 --searchable (numbers, bools, dates, and references are not text).",
+                field.rust_type()
+            )));
+        }
+        let weight = [b'A', b'B', b'C', b'D'][i.min(3)] as char;
+        metadata.searchable.push((field_name.to_owned(), weight));
+    }
+    if !metadata.searchable.is_empty() {
+        // `english` matches the `wiki` example and is the most common default;
+        // the FTS dictionary is otherwise out of scope for this slice.
+        metadata.search_language = Some("english".to_owned());
+    }
+
     Ok(metadata)
 }
 
@@ -1744,6 +1816,12 @@ fn render_model_file(
         }
     }
     out.push_str("#[autumn_web::model]\n");
+    // Struct-level `#[searchable(language = "…")]` (issue #1319) opts the model
+    // into full-text search; the per-field `#[searchable(weight = "…")]` below
+    // declare which columns feed the `search_vector` and at what rank weight.
+    if let Some(language) = metadata.search_language() {
+        let _ = writeln!(out, "#[searchable(language = \"{language}\")]");
+    }
     if let Some(key) = shard_key {
         let _ = writeln!(out, "#[shard_key = \"{key}\"]");
     }
@@ -1753,6 +1831,9 @@ fn render_model_file(
     for f in fields {
         if metadata.indexes.contains(&f.name) {
             out.push_str("    #[indexed]\n");
+        }
+        if let Some((_, weight)) = metadata.searchable().iter().find(|(n, _)| n == &f.name) {
+            let _ = writeln!(out, "    #[searchable(weight = \"{weight}\")]");
         }
         if let Some(validations) = metadata.validations.get(&f.name) {
             for validation in validations {

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -2365,12 +2365,15 @@ fn render_routes_file(
 
     let list_render = if live { &live_ul_render } else { &table_render };
     // The list + pager block the index handler renders. When searchable (AC3),
-    // this becomes an `active_search` box wired to `GET /{plural}/search`, with
-    // the plain data_table list kept in a `<noscript>` so the page still shows
-    // its rows and search still works without JavaScript. The shared
-    // `crate::layout` does not load htmx, so an htmx `<script>` is inlined here.
-    // When not searchable (or a live variant), it is exactly the previous
-    // `{list_render}` + `pagination_nav` pair — byte-for-byte identical (AC4).
+    // this becomes an `active_search` box wired to `GET /{plural}/search` sitting
+    // above the live `#{plural}-search-results` container that htmx swaps into.
+    // The initial `{list_render}` + pager render server-side *inside* that
+    // container, so the first paint needs no extra AJAX round-trip (no
+    // `.initial_load()`) and non-JavaScript visitors still see the full list.
+    // The shared `crate::layout` does not load htmx, so an htmx `<script>` is
+    // inlined here. When not searchable (or a live variant), it is exactly the
+    // previous `{list_render}` + `pagination_nav` pair — byte-for-byte identical
+    // (AC4).
     let pager_line =
         format!(r#"(pagination_nav(&page_data, &PagerOptions::new(&paths::index())))"#);
     let index_list_block = if search_enabled {
@@ -2378,8 +2381,8 @@ fn render_routes_file(
             "script src=(autumn_web::htmx::HTMX_JS_PATH) {{}}\n        \
              (autumn_web::widgets::active_search(\"{snake_name}-search\", \"Search {pascal_name}s\", \
              &autumn_web::widgets::ActiveSearchConfig::new(\"/{plural}/search\", \"#{plural}-search-results\")\
-             .placeholder(\"Search {pascal_name}s…\").initial_load()))\n        \
-             noscript {{\n            {list_render}\n            {pager_line}\n        }}"
+             .placeholder(\"Search {pascal_name}s…\")))\n        \
+             div id=\"{plural}-search-results\" {{\n            {list_render}\n            {pager_line}\n        }}"
         )
     } else {
         format!("{list_render}\n        {pager_line}")
@@ -2685,11 +2688,14 @@ pub async fn index(
 
     // Issue #1319: the FTS results handler backing the index `active_search`
     // box. For htmx requests it returns just the results fragment (swapped into
-    // `#{plural}-search-results`); for a plain navigation — the `<noscript>`
-    // fallback form, or a shared pager link — it returns the full page so search
-    // degrades gracefully without JavaScript. An empty `q` falls back to the
-    // standard `page(&page_req)` listing (AC3). Reuses the same `columns` and
+    // `#{plural}-search-results`); for a plain navigation — a bookmarked search
+    // URL, or a shared pager link — it returns the full page so search degrades
+    // gracefully without JavaScript. An empty `q` falls back to the standard
+    // `page(&page_req)` listing (AC3). Reuses the same `columns` and
     // reference-label loads the index builds so search rows render identically.
+    // The pager preserves the request's raw query string (stripping `page`/
+    // `size`) via `PagerOptions::query`, so `q` survives pagination without any
+    // hand-rolled percent-encoding.
     let search_handler = if search_enabled {
         let field_list = searchable.join(", ");
         let (repo_extractor, repo_bind) = if sharded {
@@ -2711,7 +2717,7 @@ pub async fn index(
 /// Powers the `active_search` box on the index list. Ranked by relevance via
 /// the repository's `search_page`; an empty `q` falls back to the plain
 /// `page(&page_req)` listing. htmx requests get only the results fragment;
-/// non-htmx navigations (the `<noscript>` form, or a pager link) get a full
+/// non-htmx navigations (a bookmarked search URL, or a pager link) get a full
 /// page so search still works without JavaScript.
 #[derive(serde::Deserialize)]
 pub struct SearchQuery {{
@@ -2722,11 +2728,16 @@ pub struct SearchQuery {{
 #[get("/{plural}/search")]
 pub async fn search(
     autumn_web::extract::Query(query): autumn_web::extract::Query<SearchQuery>,
+    autumn_web::reexports::axum::extract::RawQuery(raw_query): autumn_web::reexports::axum::extract::RawQuery,
     page_req: PageRequest,
     hx: autumn_web::htmx::HxRequest,
 {repo_extractor}    flash: Flash,
 ) -> AutumnResult<Markup> {{
 {repo_bind}    let q = query.q.trim();
+    // Preserve the request's raw query string (already percent-encoded) on pager
+    // links so `q` survives pagination; `PagerOptions::query` strips the stale
+    // `page`/`size` params and re-adds them per link.
+    let pager_query = raw_query.as_deref().unwrap_or("");
     let page_data: Page<{pascal_name}> = if q.is_empty() {{
         repo.page(&page_req).await?
     }} else {{
@@ -2734,7 +2745,7 @@ pub async fn search(
     }};
 {index_label_loads}{index_columns_labeled}    let results = html! {{
         (autumn_web::widgets::data_table(&page_data.content, &columns, &autumn_web::widgets::DataTableConfig::new("No {plural} found.").base_path("/{plural}/search")))
-        (pagination_nav(&page_data, &PagerOptions::new("/{plural}/search")))
+        (pagination_nav(&page_data, &PagerOptions::new("/{plural}/search").query(pager_query)))
     }};
     if hx.is_htmx {{
         return Ok(results);
@@ -9160,10 +9171,25 @@ async fn main() {
                 && routes.contains("\"/posts/search\", \"#posts-search-results\""),
             "index must render the search input wired to the results route: {routes}"
         );
+        // The `active_search` target must exist as a real element that renders
+        // the initial list server-side (no `.initial_load()` AJAX round-trip, no
+        // `<noscript>` fallback wrapper).
+        assert!(
+            routes.contains("div id=\"posts-search-results\"")
+                && !routes.contains(".initial_load(")
+                && !routes.contains("noscript"),
+            "index must render the results container server-side without initial_load/noscript: {routes}"
+        );
         assert!(
             routes.contains("pub async fn search(")
                 && routes.contains("repo.search_page(q, &page_req)"),
             "a search results handler must call search_page: {routes}"
+        );
+        // The results pager must preserve the request query (so `q` survives
+        // pagination) instead of pointing at a bare `/posts/search`.
+        assert!(
+            routes.contains("PagerOptions::new(\"/posts/search\").query(pager_query)"),
+            "search pager must preserve the query string across pages: {routes}"
         );
         assert!(
             routes.contains("repo.page(&page_req).await?"),

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -531,6 +531,7 @@ pub fn plan_scaffold_with_options(
             options_with_key.api,
             options_with_key.model.sharded,
             options_with_key.live,
+            !options_with_key.model.searchable.is_empty(),
         ),
     );
     let repo_mod_path = repos_dir.join("mod.rs");
@@ -609,6 +610,7 @@ pub fn plan_scaffold_with_options(
                 &missing_reference_targets,
                 authorize_wiring,
                 owner_column.as_ref().map(|o| o.name.as_str()),
+                &options_with_key.model.searchable,
             ),
         );
         let route_mod_path = routes_dir.join("mod.rs");
@@ -674,11 +676,17 @@ pub fn plan_scaffold_with_options(
     } else {
         Vec::new()
     };
+    // Issue #1319: the search box/route exist only for the standard (non-live)
+    // HTML index; the model/repository/migration get `searchable` regardless.
+    let search_enabled = !options_with_key.model.searchable.is_empty()
+        && !options_with_key.live
+        && !options_with_key.live_validation;
     let route_entries = main_route_entries(
         &plural,
         &snake_name,
         options_with_key.api,
         options_with_key.live,
+        search_enabled && !options_with_key.api,
         &validated_field_names,
     );
     let mut mods = vec!["models", "schema", "repositories"];
@@ -784,6 +792,33 @@ pub fn plan_scaffold_with_options(
         plan.push_revert(Revert::CargoAutumnWebFeature {
             path: cargo_path,
             feature: "maud".to_owned(),
+            owner_dir: Some(project_root.join("src").join("routes")),
+        });
+    }
+
+    // Issue #1319: a searchable (non-live) index inlines an htmx `<script>` and
+    // its results handler extracts `HxRequest`, both gated behind autumn-web's
+    // `htmx` feature — enable it. (Live variants enable `htmx` in the block
+    // below; api scaffolds have no HTML index, so no search box.)
+    if search_enabled && !options_with_key.api {
+        let cargo_path = project_root.join("Cargo.toml");
+        let base = plan
+            .actions
+            .iter()
+            .rev()
+            .find_map(|a| match a {
+                Action::Modify { path, contents } if path == &cargo_path => Some(contents.clone()),
+                _ => None,
+            })
+            .unwrap_or_else(|| read_or_empty(&cargo_path));
+        let updated = ensure_autumn_web_feature(&base, "htmx");
+        if updated != base {
+            plan.actions.retain(|a| a.path() != cargo_path);
+            plan.modify(cargo_path.clone(), updated);
+        }
+        plan.push_revert(Revert::CargoAutumnWebFeature {
+            path: cargo_path,
+            feature: "htmx".to_owned(),
             owner_dir: Some(project_root.join("src").join("routes")),
         });
     }
@@ -1138,7 +1173,7 @@ pub(super) fn render_repository_for_pull(
     )
 }
 
-#[allow(clippy::fn_params_excessive_bools)]
+#[allow(clippy::fn_params_excessive_bools, clippy::too_many_arguments)]
 fn render_repository_file(
     pascal_name: &str,
     snake_name: &str,
@@ -1147,11 +1182,16 @@ fn render_repository_file(
     api: bool,
     sharded: bool,
     live: bool,
+    searchable: bool,
 ) -> String {
     let plural = pluralize(snake_name);
     let query_body = render_repository_queries(pascal_name, queries);
     let soft_delete_attr = if soft_delete { ", soft_delete" } else { "" };
     let broadcasts_attr = if live { ", broadcasts = true" } else { "" };
+    // Issue #1319: `searchable` opts the repository into the FTS `search()` /
+    // `search_page(query, &PageRequest)` methods (backed by the model's
+    // `#[searchable]` fields + the migration's `search_vector` column).
+    let searchable_attr = if searchable { ", searchable" } else { "" };
     let sharded_note = if sharded {
         format!(
             "//!\n\
@@ -1258,7 +1298,7 @@ fn render_repository_file(
          use crate::models::{snake_name}::{{{pascal_name}, New{pascal_name}, Update{pascal_name}}};\n\
          use crate::schema::{plural};\n\
          \n\
-         #[autumn_web::repository({pascal_name}, api = \"/api/{plural}\"{soft_delete_attr}{broadcasts_attr})]\n\
+         #[autumn_web::repository({pascal_name}, api = \"/api/{plural}\"{soft_delete_attr}{broadcasts_attr}{searchable_attr})]\n\
          pub trait {pascal_name}Repository {{\n\
 {query_body}\
          }}\n\
@@ -1637,8 +1677,16 @@ fn render_routes_file(
     missing_reference_targets: &BTreeSet<String>,
     authorize: bool,
     owner: Option<&str>,
+    searchable: &[String],
 ) -> String {
     let id_rust = id_type.rust_type();
+    // Issue #1319: the full-text search box + results handler apply only to the
+    // standard (non-live) HTML index. The `--live`/`--live-validation` list is a
+    // `<ul>` with an SSE out-of-band swap contract that a `data_table` search
+    // fragment would break, so gate the search box off for those variants (the
+    // model/repository/migration still get `searchable`). Precedent: the label
+    // -map gating for the live index.
+    let search_enabled = !searchable.is_empty() && !live && !live_validation;
     let validated_fields: Vec<&str> = validations.keys().map(String::as_str).collect();
     let unique_fields: Vec<&Field> = fields.iter().filter(|f| f.unique).collect();
     let update_columns = render_update_columns(plural, fields);
@@ -2316,6 +2364,26 @@ fn render_routes_file(
     };
 
     let list_render = if live { &live_ul_render } else { &table_render };
+    // The list + pager block the index handler renders. When searchable (AC3),
+    // this becomes an `active_search` box wired to `GET /{plural}/search`, with
+    // the plain data_table list kept in a `<noscript>` so the page still shows
+    // its rows and search still works without JavaScript. The shared
+    // `crate::layout` does not load htmx, so an htmx `<script>` is inlined here.
+    // When not searchable (or a live variant), it is exactly the previous
+    // `{list_render}` + `pagination_nav` pair — byte-for-byte identical (AC4).
+    let pager_line =
+        format!(r#"(pagination_nav(&page_data, &PagerOptions::new(&paths::index())))"#);
+    let index_list_block = if search_enabled {
+        format!(
+            "script src=(autumn_web::htmx::HTMX_JS_PATH) {{}}\n        \
+             (autumn_web::widgets::active_search(\"{snake_name}-search\", \"Search {pascal_name}s\", \
+             &autumn_web::widgets::ActiveSearchConfig::new(\"/{plural}/search\", \"#{plural}-search-results\")\
+             .placeholder(\"Search {pascal_name}s…\").initial_load()))\n        \
+             noscript {{\n            {list_render}\n            {pager_line}\n        }}"
+        )
+    } else {
+        format!("{list_render}\n        {pager_line}")
+    };
     let show_rows = render_show_property_rows(all_fields, &reference_displays);
     // The `show` handler pre-loads each displayable reference's parent label
     // (issue #1146) before building its property rows.
@@ -2386,8 +2454,7 @@ pub async fn index(
     Ok({layout_fn}("{pascal_name} index", {cp_index}{flash_arg}, html! {{
         h1 {{ "{pascal_name}s" }}
         a href=(paths::new()) {{ "New {pascal_name}" }}
-        {list_render}
-        (pagination_nav(&page_data, &PagerOptions::new(&paths::index())))
+        {index_list_block}
     }}))
 }}"#
             )
@@ -2409,8 +2476,7 @@ pub async fn index(
 {index_label_loads}{index_columns_labeled}    Ok({layout_fn}("{pascal_name} index", {cp_index}{flash_arg}, html! {{
         h1 {{ "{pascal_name}s" }}
         a href=(paths::new()) {{ "New {pascal_name}" }}
-        {list_render}
-        (pagination_nav(&page_data, &PagerOptions::new(&paths::index())))
+        {index_list_block}
     }}))
 }}"#
             )
@@ -2432,8 +2498,7 @@ pub async fn index(
     Ok({layout_fn}("{pascal_name} index", {cp_index}{flash_arg}, html! {{
         h1 {{ "{pascal_name}s" }}
         a href=(paths::new()) {{ "New {pascal_name}" }}
-        {list_render}
-        (pagination_nav(&page_data, &PagerOptions::new(&paths::index())))
+        {index_list_block}
     }}))
 }}"#
         )
@@ -2454,8 +2519,7 @@ pub async fn index(
 {index_label_loads}{index_columns_labeled}    Ok({layout_fn}("{pascal_name} index", {cp_index}{flash_arg}, html! {{
         h1 {{ "{pascal_name}s" }}
         a href=(paths::new()) {{ "New {pascal_name}" }}
-        {list_render}
-        (pagination_nav(&page_data, &PagerOptions::new(&paths::index())))
+        {index_list_block}
     }}))
 }}"#
         )
@@ -2617,6 +2681,73 @@ pub async fn index(
         }
         out.push_str("];\n");
         out
+    };
+
+    // Issue #1319: the FTS results handler backing the index `active_search`
+    // box. For htmx requests it returns just the results fragment (swapped into
+    // `#{plural}-search-results`); for a plain navigation — the `<noscript>`
+    // fallback form, or a shared pager link — it returns the full page so search
+    // degrades gracefully without JavaScript. An empty `q` falls back to the
+    // standard `page(&page_req)` listing (AC3). Reuses the same `columns` and
+    // reference-label loads the index builds so search rows render identically.
+    let search_handler = if search_enabled {
+        let field_list = searchable.join(", ");
+        let (repo_extractor, repo_bind) = if sharded {
+            (
+                format!("    {sharded_index_db},\n"),
+                format!("    let repo = Pg{pascal_name}Repository::from_shard(&db);\n"),
+            )
+        } else {
+            (
+                format!("    repo: Pg{pascal_name}Repository,\n    {index_db_param}"),
+                String::new(),
+            )
+        };
+        format!(
+            r#"
+
+/// `GET /{plural}/search` — full-text search over {field_list}.
+///
+/// Powers the `active_search` box on the index list. Ranked by relevance via
+/// the repository's `search_page`; an empty `q` falls back to the plain
+/// `page(&page_req)` listing. htmx requests get only the results fragment;
+/// non-htmx navigations (the `<noscript>` form, or a pager link) get a full
+/// page so search still works without JavaScript.
+#[derive(serde::Deserialize)]
+pub struct SearchQuery {{
+    #[serde(default)]
+    pub q: String,
+}}
+
+#[get("/{plural}/search")]
+pub async fn search(
+    autumn_web::extract::Query(query): autumn_web::extract::Query<SearchQuery>,
+    page_req: PageRequest,
+    hx: autumn_web::htmx::HxRequest,
+{repo_extractor}    flash: Flash,
+) -> AutumnResult<Markup> {{
+{repo_bind}    let q = query.q.trim();
+    let page_data: Page<{pascal_name}> = if q.is_empty() {{
+        repo.page(&page_req).await?
+    }} else {{
+        repo.search_page(q, &page_req).await?
+    }};
+{index_label_loads}{index_columns_labeled}    let results = html! {{
+        (autumn_web::widgets::data_table(&page_data.content, &columns, &autumn_web::widgets::DataTableConfig::new("No {plural} found.").base_path("/{plural}/search")))
+        (pagination_nav(&page_data, &PagerOptions::new("/{plural}/search")))
+    }};
+    if hx.is_htmx {{
+        return Ok(results);
+    }}
+    Ok({layout_fn}("Search {pascal_name}s", {cp_index}{flash_arg}, html! {{
+        h1 {{ "Search {pascal_name}s" }}
+        a href="/{plural}" {{ "Back to list" }}
+        div id="{plural}-search-results" {{ (results) }}
+    }}))
+}}"#
+        )
+    } else {
+        String::new()
     };
 
     format!(
@@ -2862,6 +2993,7 @@ pub async fn events(
         String::new()
     } + &validate_handlers
         + &paths_macro
+        + &search_handler
 }
 
 /// The `UNIQUE_CONSTRAINTS` module-level const the generated `create`/
@@ -5470,6 +5602,7 @@ fn main_route_entries(
     snake_name: &str,
     api: bool,
     live: bool,
+    search: bool,
     validated_field_names: &[String],
 ) -> Vec<String> {
     if api {
@@ -5496,6 +5629,11 @@ fn main_route_entries(
         ];
         if live {
             entries.push(format!("routes::{plural}::events"));
+        }
+        // Issue #1319: register the FTS results route (non-live only; the box is
+        // gated off for live variants — see `render_routes_file`).
+        if search {
+            entries.push(format!("routes::{plural}::search"));
         }
         for field_name in validated_field_names {
             entries.push(format!("routes::{plural}::validate_{field_name}"));
@@ -8710,7 +8848,8 @@ async fn main() {
 
     #[test]
     fn repository_notes_sharded() {
-        let rendered = render_repository_file("Account", "account", &[], false, false, true, false);
+        let rendered =
+            render_repository_file("Account", "account", &[], false, false, true, false, false);
         assert!(
             rendered.contains("shard-aware"),
             "sharded repository doc must mention shard-aware: {rendered}"
@@ -8723,7 +8862,8 @@ async fn main() {
 
     #[test]
     fn repository_notes_api_sharded_caveat() {
-        let rendered = render_repository_file("Account", "account", &[], false, true, true, false);
+        let rendered =
+            render_repository_file("Account", "account", &[], false, true, true, false, false);
         assert!(
             rendered.contains("control pool"),
             "sharded api repository doc must note control pool: {rendered}"
@@ -8732,7 +8872,8 @@ async fn main() {
 
     #[test]
     fn repository_no_sharded_note_when_not_sharded() {
-        let rendered = render_repository_file("Post", "post", &[], false, false, false, false);
+        let rendered =
+            render_repository_file("Post", "post", &[], false, false, false, false, false);
         assert!(
             !rendered.contains("shard-aware"),
             "non-sharded repository must not mention shard-aware: {rendered}"
@@ -8850,6 +8991,257 @@ async fn main() {
         assert!(
             !routes.contains("ul id=\"posts-list\""),
             "still uses ul: {routes}"
+        );
+    }
+
+    /// Issue #1319 AC4: with `--searchable` omitted, threading an empty
+    /// `searchable` set through the generator produces output byte-for-byte
+    /// identical to today's default scaffold (the flag is purely additive).
+    #[test]
+    fn searchable_omitted_is_byte_identical_to_default() {
+        let fields = ["title:String".to_string(), "body:Text".to_string()];
+
+        let tmp_default = project_with_main(default_main());
+        plan_scaffold(tmp_default.path(), "Post", &fields, "20260427000000")
+            .unwrap()
+            .execute(Flags::default())
+            .unwrap();
+
+        let tmp_empty = project_with_main(default_main());
+        plan_scaffold_with_options(
+            tmp_empty.path(),
+            "Post",
+            &fields,
+            "20260427000000",
+            &ScaffoldOptions {
+                model: ModelOptions {
+                    searchable: Vec::new(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .execute(Flags::default())
+        .unwrap();
+
+        for rel in [
+            "src/routes/posts.rs",
+            "src/models/post.rs",
+            "src/repositories/post.rs",
+            "migrations/20260427000000_create_posts/up.sql",
+            "migrations/20260427000000_create_posts/down.sql",
+            "src/main.rs",
+        ] {
+            let a = fs::read_to_string(tmp_default.path().join(rel)).unwrap();
+            let b = fs::read_to_string(tmp_empty.path().join(rel)).unwrap();
+            assert_eq!(a, b, "empty --searchable must not change `{rel}`");
+            assert!(
+                !b.contains("searchable")
+                    && !b.contains("active_search")
+                    && !b.contains("search_vector"),
+                "non-searchable `{rel}` must carry no FTS artifacts:\n{b}"
+            );
+        }
+    }
+
+    /// Issue #1319 AC5: naming a non-text field in `--searchable` fails
+    /// generation with a clear, field-naming error rather than emitting a model
+    /// that won't compile.
+    #[test]
+    fn searchable_non_text_field_is_rejected() {
+        let tmp = project_with_main(default_main());
+        let err = plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "views:i64".into()],
+            "20260427000000",
+            &ScaffoldOptions {
+                model: ModelOptions {
+                    searchable: vec!["views".into()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            matches!(err, GenerateError::Config(_)),
+            "expected Config error, got: {err:?}"
+        );
+        assert!(
+            msg.contains("views") && (msg.contains("text") || msg.contains("String")),
+            "error must name the offending field and mention text-only: {msg}"
+        );
+    }
+
+    /// Issue #1319 AC5: naming a field that does not exist in `--searchable`
+    /// fails generation with a clear error.
+    #[test]
+    fn searchable_unknown_field_is_rejected() {
+        let tmp = project_with_main(default_main());
+        let err = plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &["title:String".into()],
+            "20260427000000",
+            &ScaffoldOptions {
+                model: ModelOptions {
+                    searchable: vec!["nope".into()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, GenerateError::Config(_)),
+            "expected Config error, got: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("nope"),
+            "must name the field: {err}"
+        );
+    }
+
+    /// Issue #1319 AC1/AC3/AC6: a `--searchable` scaffold wires the model,
+    /// repository, migration, and index/search route coherently.
+    #[test]
+    fn searchable_scaffold_wires_model_repo_and_index() {
+        let tmp = project_with_main(default_main());
+        plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "body:Text".into()],
+            "20260427000000",
+            &ScaffoldOptions {
+                model: ModelOptions {
+                    searchable: vec!["title".into(), "body".into()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .execute(Flags::default())
+        .unwrap();
+
+        let model = fs::read_to_string(tmp.path().join("src/models/post.rs")).unwrap();
+        assert!(
+            model.contains("#[searchable(language = \"english\")]"),
+            "model must opt into search: {model}"
+        );
+        assert!(
+            model.contains("#[searchable(weight = \"A\")]")
+                && model.contains("#[searchable(weight = \"B\")]"),
+            "each named text field must be weighted: {model}"
+        );
+
+        let repo = fs::read_to_string(tmp.path().join("src/repositories/post.rs")).unwrap();
+        assert!(
+            repo.contains("api = \"/api/posts\", searchable)"),
+            "repository must carry `searchable`: {repo}"
+        );
+
+        let up = fs::read_to_string(
+            tmp.path()
+                .join("migrations/20260427000000_create_posts/up.sql"),
+        )
+        .unwrap();
+        assert!(
+            up.contains("search_vector tsvector") && up.contains("USING gin(search_vector)"),
+            "migration must add the generated column + GIN index: {up}"
+        );
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        assert!(
+            routes.contains("active_search(\"post-search\"")
+                && routes.contains("\"/posts/search\", \"#posts-search-results\""),
+            "index must render the search input wired to the results route: {routes}"
+        );
+        assert!(
+            routes.contains("pub async fn search(")
+                && routes.contains("repo.search_page(q, &page_req)"),
+            "a search results handler must call search_page: {routes}"
+        );
+        assert!(
+            routes.contains("repo.page(&page_req).await?"),
+            "empty q must fall back to page(): {routes}"
+        );
+
+        let main_rs = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert!(
+            main_rs.contains("routes::posts::search"),
+            "search route must be registered in main.rs: {main_rs}"
+        );
+    }
+
+    /// Issue #1319: `search_vector` is a stored generated column, so it must NOT
+    /// leak into `schema.rs` or the model struct (the macro loads rows by id).
+    #[test]
+    fn searchable_column_is_not_in_schema_or_struct() {
+        let tmp = project_with_main(default_main());
+        plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "body:Text".into()],
+            "20260427000000",
+            &ScaffoldOptions {
+                model: ModelOptions {
+                    searchable: vec!["title".into(), "body".into()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .execute(Flags::default())
+        .unwrap();
+        let schema = fs::read_to_string(tmp.path().join("src/schema.rs")).unwrap();
+        let model = fs::read_to_string(tmp.path().join("src/models/post.rs")).unwrap();
+        assert!(
+            !schema.contains("search_vector"),
+            "search_vector must not be in schema.rs: {schema}"
+        );
+        assert!(
+            !model.contains("pub search_vector"),
+            "search_vector must not be a struct field: {model}"
+        );
+    }
+
+    /// Issue #1319: the search box is gated off for `--live` variants (the SSE
+    /// `<ul>` OOB contract differs), but the model/repository/migration still
+    /// receive `searchable`.
+    #[test]
+    fn searchable_search_box_gated_off_for_live() {
+        let tmp = project_with_main(default_main());
+        plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "body:Text".into()],
+            "20260427000000",
+            &ScaffoldOptions {
+                model: ModelOptions {
+                    searchable: vec!["title".into(), "body".into()],
+                    ..Default::default()
+                },
+                live: true,
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .execute(Flags::default())
+        .unwrap();
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        assert!(
+            !routes.contains("active_search(") && !routes.contains("pub async fn search("),
+            "live variant must not emit a search box: {routes}"
+        );
+        let repo = fs::read_to_string(tmp.path().join("src/repositories/post.rs")).unwrap();
+        assert!(
+            repo.contains(", searchable)"),
+            "live repo must still carry searchable: {repo}"
         );
     }
 

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -430,6 +430,26 @@ pub fn plan_scaffold_with_options(
         && !options_with_key.live
         && !options_with_key.live_validation;
 
+    // Issue #1319 security guard: the generated `GET /{plural}/search` handler calls
+    // the repository's UNSCOPED `search_page`, which returns rows for ALL users. When
+    // the model is owner-scoped, the index view is `#[secured]` and filters to the
+    // current user's rows — so pairing `--searchable` with owner scoping would leak
+    // other users' rows through the search endpoint that the list view prevents.
+    // Owner-scoped FTS needs a scoped `search_page` in the repository macro (framework
+    // work, tracked in #1841); until then, refuse the unsafe combination. Returns
+    // before the plan is built, so no files are written.
+    if !options_with_key.model.searchable.is_empty() && authorize_wiring {
+        return Err(GenerateError::Config(format!(
+            "`--searchable` is not yet supported for owner-scoped models: full-text search \
+             (`search_page`) is not owner-scoped, so the generated `GET /{plural}/search` \
+             endpoint would expose other users' rows that the `#[secured]` index view \
+             filters out (owner column `{owner}`). Remove `--searchable`, drop the owner \
+             column, or pass `--no-policy` to opt out of owner scoping. Track: framework \
+             support for owner-scoped FTS (issue #1841).",
+            owner = owner_column.as_ref().map_or("user_id", |o| o.name.as_str()),
+        )));
+    }
+
     // `references` columns whose target model can't be found in the project
     // (same presence test `check_reference_targets` used for its warning —
     // the table presumably exists out-of-band, or gets generated later).
@@ -9126,6 +9146,84 @@ async fn main() {
             !tmp.path().join("src/models/post.rs").exists()
                 && !tmp.path().join("src/repositories/post.rs").exists(),
             "rejected uuid+searchable scaffold must not write any files"
+        );
+    }
+
+    /// Issue #1319 security guard: `--searchable` on an owner-scoped model is
+    /// rejected before any files are written. The owner-scoped index is
+    /// `#[secured]` and filters to the current user, but the FTS `search_page`
+    /// is unscoped, so the `/search` endpoint would leak other users' rows.
+    #[test]
+    fn searchable_with_owner_scoped_model_is_rejected() {
+        let tmp = project_with_main(default_main());
+        // `user_id` is an owner column, so the default policy makes the index
+        // owner-scoped (`authorize_wiring`). Pairing that with `--searchable`
+        // must be refused.
+        let err = plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &[
+                "user_id:i64".into(),
+                "title:String".into(),
+                "body:Text".into(),
+            ],
+            "20260427000000",
+            &ScaffoldOptions {
+                model: ModelOptions {
+                    searchable: vec!["title".into(), "body".into()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            matches!(err, GenerateError::Config(_)),
+            "expected Config error, got: {err:?}"
+        );
+        assert!(
+            msg.contains("--searchable")
+                && msg.contains("owner-scoped")
+                && msg.contains("search_page"),
+            "error must explain the owner-scoped FTS leak: {msg}"
+        );
+        // No files written: the scaffold plan fails before touching the tree.
+        assert!(
+            !tmp.path().join("src/models/post.rs").exists()
+                && !tmp.path().join("src/repositories/post.rs").exists(),
+            "rejected owner-scoped +searchable scaffold must not write any files"
+        );
+    }
+
+    /// The owner-scoped guard is scoped to owner scoping: `--no-policy` opts out
+    /// of the secured index, so `--searchable` with an owner column is allowed
+    /// (index and search are both unscoped — consistent, no leak relative to the
+    /// list view).
+    #[test]
+    fn searchable_with_owner_column_but_no_policy_is_allowed() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &[
+                "user_id:i64".into(),
+                "title:String".into(),
+                "body:Text".into(),
+            ],
+            "20260427000000",
+            &ScaffoldOptions {
+                model: ModelOptions {
+                    searchable: vec!["title".into(), "body".into()],
+                    ..Default::default()
+                },
+                no_policy: true,
+                ..Default::default()
+            },
+        );
+        assert!(
+            plan.is_ok(),
+            "--searchable + owner column + --no-policy must be allowed: {plan:?}"
         );
     }
 

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -2365,21 +2365,23 @@ fn render_routes_file(
 
     let list_render = if live { &live_ul_render } else { &table_render };
     // The list + pager block the index handler renders. When searchable (AC3),
-    // this becomes an `active_search` box wired to `GET /{plural}/search` sitting
-    // above the live `#{plural}-search-results` container that htmx swaps into.
-    // The initial `{list_render}` + pager render server-side *inside* that
-    // container, so the first paint needs no extra AJAX round-trip (no
-    // `.initial_load()`) and non-JavaScript visitors still see the full list.
-    // The shared `crate::layout` does not load htmx, so an htmx `<script>` is
-    // inlined here. When not searchable (or a live variant), it is exactly the
-    // previous `{list_render}` + `pagination_nav` pair — byte-for-byte identical
-    // (AC4).
+    // this becomes an `active_search_input` box wired to `GET /{plural}/search`
+    // sitting above the single `#{plural}-search-results` container that htmx
+    // swaps into. We use the input-only `active_search_input` (not the composite
+    // `active_search`, which would render its OWN empty `#{plural}-search-results`
+    // container and produce a duplicate id) and render one container ourselves,
+    // seeded with the initial `{list_render}` + pager server-side — so the first
+    // paint needs no extra AJAX round-trip (no `.initial_load()`) and
+    // non-JavaScript visitors still see the full list. The shared `crate::layout`
+    // does not load htmx, so an htmx `<script>` is inlined here. When not
+    // searchable (or a live variant), it is exactly the previous `{list_render}`
+    // + `pagination_nav` pair — byte-for-byte identical (AC4).
     let pager_line =
-        format!(r#"(pagination_nav(&page_data, &PagerOptions::new(&paths::index())))"#);
+        r"(pagination_nav(&page_data, &PagerOptions::new(&paths::index())))".to_string();
     let index_list_block = if search_enabled {
         format!(
             "script src=(autumn_web::htmx::HTMX_JS_PATH) {{}}\n        \
-             (autumn_web::widgets::active_search(\"{snake_name}-search\", \"Search {pascal_name}s\", \
+             (autumn_web::widgets::active_search_input(\"{snake_name}-search\", \"Search {pascal_name}s\", \
              &autumn_web::widgets::ActiveSearchConfig::new(\"/{plural}/search\", \"#{plural}-search-results\")\
              .placeholder(\"Search {pascal_name}s…\")))\n        \
              div id=\"{plural}-search-results\" {{\n            {list_render}\n            {pager_line}\n        }}"
@@ -9087,6 +9089,46 @@ async fn main() {
         );
     }
 
+    /// Issue #1319: a `--searchable` scaffold with a uuid primary key is
+    /// rejected before any files are written. The scaffold command already gates
+    /// off ALL uuid primary keys (the `#[repository]` REST API is i64-only), so
+    /// this combination surfaces that broader gate; a metadata-layer guard in
+    /// `parse_model_metadata` (see `model.rs`) is the defense-in-depth backstop
+    /// specific to the FTS `search_page` i64 hardcoding.
+    #[test]
+    fn searchable_with_uuid_primary_key_is_rejected() {
+        let tmp = project_with_main(default_main());
+        let err = plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "body:Text".into()],
+            "20260427000000",
+            &ScaffoldOptions {
+                model: ModelOptions {
+                    searchable: vec!["title".into(), "body".into()],
+                    id_type: IdType::Uuid,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, GenerateError::Config(_)),
+            "expected Config error, got: {err:?}"
+        );
+        assert!(
+            err.to_string().to_lowercase().contains("uuid"),
+            "error must name uuid as unsupported: {err}"
+        );
+        // No files written: the scaffold plan fails before touching the tree.
+        assert!(
+            !tmp.path().join("src/models/post.rs").exists()
+                && !tmp.path().join("src/repositories/post.rs").exists(),
+            "rejected uuid+searchable scaffold must not write any files"
+        );
+    }
+
     /// Issue #1319 AC5: naming a field that does not exist in `--searchable`
     /// fails generation with a clear error.
     #[test]
@@ -9166,19 +9208,32 @@ async fn main() {
         );
 
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        // Input-only `active_search_input` (the composite `active_search` would
+        // render its own empty results container — a duplicate id).
         assert!(
-            routes.contains("active_search(\"post-search\"")
+            routes.contains("active_search_input(\"post-search\"")
+                && !routes.contains("widgets::active_search(\"post-search\"")
                 && routes.contains("\"/posts/search\", \"#posts-search-results\""),
-            "index must render the search input wired to the results route: {routes}"
+            "index must render the input-only search box wired to the results route: {routes}"
         );
         // The `active_search` target must exist as a real element that renders
         // the initial list server-side (no `.initial_load()` AJAX round-trip, no
-        // `<noscript>` fallback wrapper).
+        // `<noscript>` fallback wrapper), exactly once on the index page.
         assert!(
             routes.contains("div id=\"posts-search-results\"")
                 && !routes.contains(".initial_load(")
                 && !routes.contains("noscript"),
             "index must render the results container server-side without initial_load/noscript: {routes}"
+        );
+        let index_fn = routes
+            .split("pub async fn index(")
+            .nth(1)
+            .and_then(|s| s.split("pub async fn ").next())
+            .expect("an index handler must be emitted");
+        assert_eq!(
+            index_fn.matches("id=\"posts-search-results\"").count(),
+            1,
+            "the index page must render the results container exactly once: {index_fn}"
         );
         assert!(
             routes.contains("pub async fn search(")
@@ -9261,7 +9316,9 @@ async fn main() {
         .unwrap();
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
         assert!(
-            !routes.contains("active_search(") && !routes.contains("pub async fn search("),
+            !routes.contains("active_search(")
+                && !routes.contains("active_search_input(")
+                && !routes.contains("pub async fn search("),
             "live variant must not emit a search box: {routes}"
         );
         let repo = fs::read_to_string(tmp.path().join("src/repositories/post.rs")).unwrap();

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -2742,14 +2742,14 @@ pub async fn index(
 /// non-htmx navigations (a bookmarked search URL, or a pager link) get a full
 /// page so search still works without JavaScript.
 #[derive(serde::Deserialize)]
-pub struct SearchQuery {{
+pub struct {pascal_name}SearchQuery {{
     #[serde(default)]
     pub q: String,
 }}
 
 #[get("/{plural}/search")]
 pub async fn search(
-    autumn_web::extract::Query(query): autumn_web::extract::Query<SearchQuery>,
+    autumn_web::extract::Query(query): autumn_web::extract::Query<{pascal_name}SearchQuery>,
     autumn_web::reexports::axum::extract::RawQuery(raw_query): autumn_web::reexports::axum::extract::RawQuery,
     page_req: PageRequest,
     hx: autumn_web::htmx::HxRequest,

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -2342,6 +2342,12 @@ enum GenerateCommands {
         /// `--api` scaffolds, which never generate a policy.
         #[arg(long)]
         no_policy: bool,
+        /// Make these text fields full-text searchable (issue #1319): comma-
+        /// separated or repeatable, e.g. `--searchable title,body`. Adds
+        /// `#[searchable]` to the model, `searchable` to the repository, a
+        /// `search_vector` migration, and a wired search box in the index view.
+        #[arg(long, value_name = "FIELD,FIELD", value_delimiter = ',')]
+        searchable: Vec<String>,
         /// Print the file plan and exit without writing anything.
         #[arg(long)]
         dry_run: bool,
@@ -3610,6 +3616,7 @@ fn run_generate_command(cmd: GenerateCommands, mode: ApplyMode) {
             live,
             live_validation,
             no_policy,
+            searchable,
             dry_run,
             force,
         } => {
@@ -3667,6 +3674,7 @@ fn run_generate_command(cmd: GenerateCommands, mode: ApplyMode) {
                 id.as_deref(),
                 live_validation,
                 no_policy,
+                &searchable,
             ) {
                 Ok(result) => result,
                 Err(e) => {

--- a/autumn-cli/tests/integration/mod.rs
+++ b/autumn-cli/tests/integration/mod.rs
@@ -10,6 +10,7 @@ mod offsite_backup;
 mod repo_hygiene;
 mod scaffold_belongs_to;
 mod scaffold_form_for;
+mod scaffold_search;
 mod scaffold_validation;
 mod seed_model_linking;
 #[cfg(unix)]

--- a/autumn-cli/tests/integration/scaffold_search.rs
+++ b/autumn-cli/tests/integration/scaffold_search.rs
@@ -145,10 +145,18 @@ fn index_renders_search_box_wired_to_results_route() {
         "search input must target the generated results route/container:\n{routes}"
     );
     // htmx isn't loaded by the shared layout, so the index inlines the script
-    // and keeps a <noscript> plain listing for graceful degradation.
+    // and renders the initial list server-side inside the `active_search`
+    // target container — so htmx swaps have somewhere to land, the first paint
+    // needs no extra AJAX round-trip, and non-JS visitors still see the list.
     assert!(
-        routes.contains("HTMX_JS_PATH") && routes.contains("noscript"),
-        "search index must inline htmx and degrade without JS:\n{routes}"
+        routes.contains("HTMX_JS_PATH") && routes.contains("id=\"posts-search-results\""),
+        "search index must inline htmx and render the results container:\n{routes}"
+    );
+    // The broken `.initial_load()` + `<noscript>` combination (target-less swap
+    // plus a duplicate DB query) must be gone.
+    assert!(
+        !routes.contains(".initial_load(") && !routes.contains("noscript"),
+        "search index must not use initial_load/noscript:\n{routes}"
     );
 }
 
@@ -167,6 +175,12 @@ fn search_handler_calls_search_page_with_empty_fallback() {
     assert!(
         routes.contains("repo.page(&page_req).await?"),
         "an empty query must fall back to page():\n{routes}"
+    );
+    // The results pager preserves the request's raw query string so `q` survives
+    // pagination (via PagerOptions::query, no hand-rolled percent-encoding).
+    assert!(
+        routes.contains("PagerOptions::new(\"/posts/search\").query(pager_query)"),
+        "search pager must preserve the query string across pages:\n{routes}"
     );
 }
 

--- a/autumn-cli/tests/integration/scaffold_search.rs
+++ b/autumn-cli/tests/integration/scaffold_search.rs
@@ -136,9 +136,12 @@ fn search_vector_is_not_in_schema_or_struct() {
 fn index_renders_search_box_wired_to_results_route() {
     let (_tmp, project) = searchable_project();
     let routes = fs::read_to_string(project.join("src/routes/posts.rs")).unwrap();
+    // The input-only `active_search_input` is used (not the composite
+    // `active_search`, which renders its own results container — a duplicate id).
     assert!(
-        routes.contains("active_search(\"post-search\""),
-        "index must render the active_search widget:\n{routes}"
+        routes.contains("active_search_input(\"post-search\"")
+            && !routes.contains("widgets::active_search(\"post-search\""),
+        "index must render the input-only active_search widget:\n{routes}"
     );
     assert!(
         routes.contains("ActiveSearchConfig::new(\"/posts/search\", \"#posts-search-results\")"),
@@ -157,6 +160,19 @@ fn index_renders_search_box_wired_to_results_route() {
     assert!(
         !routes.contains(".initial_load(") && !routes.contains("noscript"),
         "search index must not use initial_load/noscript:\n{routes}"
+    );
+    // The results container id must appear EXACTLY ONCE on the index page: the
+    // composite `active_search` widget rendered a second, empty one, so htmx
+    // swapped into that stale container instead of the seeded list.
+    let index_fn = routes
+        .split("pub async fn index(")
+        .nth(1)
+        .and_then(|s| s.split("pub async fn ").next())
+        .expect("an index handler must be emitted");
+    assert_eq!(
+        index_fn.matches("id=\"posts-search-results\"").count(),
+        1,
+        "the index page must render the results container exactly once:\n{index_fn}"
     );
 }
 

--- a/autumn-cli/tests/integration/scaffold_search.rs
+++ b/autumn-cli/tests/integration/scaffold_search.rs
@@ -1,0 +1,265 @@
+//! `autumn generate scaffold … --searchable title,body` wires a full-text
+//! search box into the generated list view (issue #1319): `#[searchable]` on
+//! the model, `searchable` on the repository, a `search_vector` migration, and
+//! an `active_search` widget targeting a `search_page`-backed results route.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const fn autumn_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_autumn")
+}
+
+fn run_autumn_ok(dir: &Path, args: &[&str]) {
+    let output = Command::new(autumn_bin())
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to run autumn");
+    assert!(
+        output.status.success(),
+        "autumn {args:?} failed (exit={:?})\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn run_autumn_expect_fail(dir: &Path, args: &[&str]) -> String {
+    let output = Command::new(autumn_bin())
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to run autumn");
+    assert!(
+        !output.status.success(),
+        "autumn {args:?} unexpectedly succeeded\nstdout: {}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+/// `autumn new` + `generate scaffold Post title:String body:Text --searchable
+/// title,body`, returning the project root of the fresh app.
+fn searchable_project() -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", "search-app"]);
+    let project = tmp.path().join("search-app");
+    run_autumn_ok(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Post",
+            "title:String",
+            "body:Text",
+            "--searchable",
+            "title,body",
+        ],
+    );
+    (tmp, project)
+}
+
+#[test]
+fn model_carries_searchable_attributes() {
+    let (_tmp, project) = searchable_project();
+    let model = fs::read_to_string(project.join("src/models/post.rs")).unwrap();
+    assert!(
+        model.contains("#[searchable(language = \"english\")]"),
+        "model must opt into full-text search:\n{model}"
+    );
+    assert!(
+        model.contains("#[searchable(weight = \"A\")]"),
+        "first searchable field must carry the `A` weight:\n{model}"
+    );
+    assert!(
+        model.contains("#[searchable(weight = \"B\")]"),
+        "second searchable field must carry the `B` weight:\n{model}"
+    );
+}
+
+#[test]
+fn repository_carries_searchable() {
+    let (_tmp, project) = searchable_project();
+    let repo = fs::read_to_string(project.join("src/repositories/post.rs")).unwrap();
+    assert!(
+        repo.contains("api = \"/api/posts\", searchable)"),
+        "repository attribute must carry `searchable`:\n{repo}"
+    );
+}
+
+#[test]
+fn migration_adds_search_vector_and_gin_index() {
+    let (_tmp, project) = searchable_project();
+    let migrations = project.join("migrations");
+    let up = fs::read_dir(&migrations)
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|e| e.path().join("up.sql"))
+        .find(|p| p.exists())
+        .and_then(|p| fs::read_to_string(p).ok())
+        .expect("an up.sql migration must exist");
+    assert!(
+        up.contains("ADD COLUMN search_vector tsvector GENERATED ALWAYS AS"),
+        "migration must add the generated tsvector column:\n{up}"
+    );
+    assert!(
+        up.contains("USING gin(search_vector)"),
+        "migration must add the GIN index:\n{up}"
+    );
+    // Consistent with what the `#[repository(..., searchable)]` macro queries.
+    assert!(
+        up.contains("to_tsvector('english'::regconfig")
+            && up.contains("coalesce(\"title\"::text, '')")
+            && up.contains("coalesce(\"body\"::text, '')"),
+        "migration weights must cover both searchable fields:\n{up}"
+    );
+}
+
+#[test]
+fn search_vector_is_not_in_schema_or_struct() {
+    let (_tmp, project) = searchable_project();
+    let schema = fs::read_to_string(project.join("src/schema.rs")).unwrap();
+    let model = fs::read_to_string(project.join("src/models/post.rs")).unwrap();
+    assert!(
+        !schema.contains("search_vector"),
+        "search_vector is a generated column and must not appear in schema.rs:\n{schema}"
+    );
+    assert!(
+        !model.contains("search_vector"),
+        "search_vector is a generated column and must not appear in the model struct:\n{model}"
+    );
+}
+
+#[test]
+fn index_renders_search_box_wired_to_results_route() {
+    let (_tmp, project) = searchable_project();
+    let routes = fs::read_to_string(project.join("src/routes/posts.rs")).unwrap();
+    assert!(
+        routes.contains("active_search(\"post-search\""),
+        "index must render the active_search widget:\n{routes}"
+    );
+    assert!(
+        routes.contains("ActiveSearchConfig::new(\"/posts/search\", \"#posts-search-results\")"),
+        "search input must target the generated results route/container:\n{routes}"
+    );
+    // htmx isn't loaded by the shared layout, so the index inlines the script
+    // and keeps a <noscript> plain listing for graceful degradation.
+    assert!(
+        routes.contains("HTMX_JS_PATH") && routes.contains("noscript"),
+        "search index must inline htmx and degrade without JS:\n{routes}"
+    );
+}
+
+#[test]
+fn search_handler_calls_search_page_with_empty_fallback() {
+    let (_tmp, project) = searchable_project();
+    let routes = fs::read_to_string(project.join("src/routes/posts.rs")).unwrap();
+    assert!(
+        routes.contains("#[get(\"/posts/search\")]") && routes.contains("pub async fn search("),
+        "a search results handler must be emitted:\n{routes}"
+    );
+    assert!(
+        routes.contains("repo.search_page(q, &page_req)"),
+        "search handler must call search_page:\n{routes}"
+    );
+    assert!(
+        routes.contains("repo.page(&page_req).await?"),
+        "an empty query must fall back to page():\n{routes}"
+    );
+}
+
+#[test]
+fn search_route_registered_in_main() {
+    let (_tmp, project) = searchable_project();
+    let main_rs = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    assert!(
+        main_rs.contains("routes::posts::search"),
+        "the search route must be registered in main.rs:\n{main_rs}"
+    );
+}
+
+#[test]
+fn omitting_searchable_is_purely_additive() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", "plain-app"]);
+    let project = tmp.path().join("plain-app");
+    run_autumn_ok(
+        &project,
+        &["generate", "scaffold", "Post", "title:String", "body:Text"],
+    );
+    for rel in [
+        "src/models/post.rs",
+        "src/repositories/post.rs",
+        "src/routes/posts.rs",
+    ] {
+        let content = fs::read_to_string(project.join(rel)).unwrap();
+        assert!(
+            !content.contains("searchable") && !content.contains("active_search"),
+            "a plain scaffold must carry no FTS artifacts in `{rel}`:\n{content}"
+        );
+    }
+}
+
+#[test]
+fn searchable_non_text_field_fails_generation() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", "reject-app"]);
+    let project = tmp.path().join("reject-app");
+    let stderr = run_autumn_expect_fail(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Post",
+            "title:String",
+            "views:i64",
+            "--searchable",
+            "views",
+        ],
+    );
+    assert!(
+        stderr.contains("views"),
+        "error must name the offending field: {stderr}"
+    );
+}
+
+/// Slow end-to-end check: the `--searchable` scaffold type-checks against this
+/// workspace's `autumn-web`.
+///
+/// Ignored by default; run with `cargo test -p autumn-cli -- --ignored`.
+#[test]
+#[ignore = "slow: cargo-checks a fresh project — run with `cargo test -p autumn-cli -- --ignored`"]
+fn searchable_scaffold_cargo_checks() {
+    use std::fmt::Write as _;
+
+    let (_tmp, project) = searchable_project();
+
+    let cargo_toml_path = project.join("Cargo.toml");
+    let mut content = fs::read_to_string(&cargo_toml_path).unwrap();
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root");
+    let autumn_web = workspace_root.join("autumn");
+    let autumn_macros = workspace_root.join("autumn-macros");
+    let _ = write!(
+        content,
+        "\n[patch.crates-io]\nautumn-web = {{ path = \"{}\" }}\nautumn-macros = {{ path = \"{}\" }}\n",
+        autumn_web.display().to_string().replace('\\', "/"),
+        autumn_macros.display().to_string().replace('\\', "/"),
+    );
+    fs::write(&cargo_toml_path, content).unwrap();
+
+    let check = Command::new("cargo")
+        .args(["check", "--bins"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    assert!(
+        check.status.success(),
+        "generated --searchable app failed to compile\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr),
+    );
+}


### PR DESCRIPTION
Closes #1319

## Before/After

**Before** — `autumn generate scaffold` produced list views with no search. App authors had to hand-wire all three FTS layers themselves (~40 lines across 4 files, exactly like the `wiki` example): the model field attributes, the repository search method, the `tsvector` migration, and the search UI + route.

**After** — `autumn generate scaffold Post title:String body:Text --searchable title,body` emits, end to end:
- `#[searchable]` on the named model fields,
- `searchable` on the repository,
- a `search_vector tsvector` generated column plus GIN index migration,
- an `active_search` box in the index view wired to `GET /posts/search`, backed by `search_page` (an empty query falls back to `page`).

Omitting `--searchable` leaves the generated output byte-for-byte identical to before.

## How

- **CLI flag** threaded through `main.rs` → `config.rs` → `ModelOptions`.
- **Model + migration emit** in `model.rs`: the `search_vector` generated column is deliberately kept out of `schema.rs` and out of the struct (it is a DB-generated column, not a settable field).
- **Repository + view + route** in `scaffold.rs`: the repository gains the `searchable` attribute; the index view gains the `active_search` widget with an inlined htmx `<script>` and a `<noscript>` fallback; a search route is added.
- **Live variants** gate the search box off.
- **Sharded** uses `from_shard`.
- **Validation**: non-text fields passed to `--searchable` fail generation with a clear error.

## Testing

- Gates green: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p autumn-cli` (searchable unit + integration tests pass).
- Real-generation smoke: `autumn new` + scaffold + generated-app `cargo check` compiles.

## Known limitation / follow-up

`--sharded --searchable` can't be cargo-check-verified because plain `--sharded` scaffolds already fail to compile on `trunk-dev` independent of this change — identical `can't compare i64 with String` errors from the model macro's shard-key handling, present with no `--searchable`. This change adds zero new errors to that path. Tracked in #1824.

---
_Generated by [Claude Code](https://claude.ai/code/session_012CMReMk2hrKvkzNvPQNsEg)_