### PR TITLE
feat(macros): validate the merged model on blind (plain/api/policy) update paths (#1801)

### DIFF
--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -479,6 +479,13 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
             "mcp requires api = \"/path\": MCP tools are derived from the generated CRUD routes",
         ));
     }
+    if validate_on_update_fetch && no_upsert_trait {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "validate_on_update = fetch requires the generated update draft (from_patch), \
+             which no_upsert_trait repositories do not have; remove one of the two",
+        ));
+    }
     let table = table_name.unwrap_or_else(|| infer_table_name(&model));
     let generated_internal_hooks = false;
 
@@ -15081,6 +15088,25 @@ mod tests {
         assert!(
             err.to_string().contains("validate_on_update"),
             "error must name the knob: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_repo_args_rejects_validate_on_update_fetch_with_no_upsert_trait() {
+        // #1801: `validate_on_update = fetch` emits `from_patch` on the generated
+        // update draft, but `no_upsert_trait` repositories have no such scaffold.
+        // The combination must be rejected at parse time rather than producing a
+        // downstream compile error.
+        let tokens: proc_macro2::TokenStream = "Post, validate_on_update = fetch, no_upsert_trait"
+            .parse()
+            .unwrap();
+        let err = parse_repo_args(tokens)
+            .err()
+            .expect("fetch validation with no_upsert_trait must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("validate_on_update") && msg.contains("no_upsert_trait"),
+            "error must name both knobs: {err}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -218,6 +218,13 @@ struct RepoConfig {
     /// `delete_by_id` runs a transactional, soft-delete-aware, hook-firing
     /// cascade over these child associations before deleting the parent.
     dependents: Vec<DependentSpec>,
+    /// Opt-in (`validate_on_update = fetch`) merged-model validation on the
+    /// no-hooks blind update path (issue #1801). When `true`, the generated
+    /// `update` validates the effective merged model (existing row ∪ patch)
+    /// via `from_patch` in every branch, loading the current row first on the
+    /// otherwise-blind no-lock sub-branches. When `false` (default) the blind
+    /// path stays byte-for-byte as before: no extra SELECT, no validation.
+    validate_on_update_fetch: bool,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -246,6 +253,7 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
     let mut broadcast_render: Option<syn::Path> = None;
     let mut broadcast_container: Option<String> = None;
     let mut dependents: Vec<DependentSpec> = Vec::new();
+    let mut validate_on_update_fetch = false;
 
     syn::meta::parser(|meta| {
         // `hooks = Ident` must be checked before the catch-all model_name case,
@@ -362,6 +370,24 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
         } else if meta.path.is_ident("sharded") {
             sharded = true;
             Ok(())
+        } else if meta.path.is_ident("validate_on_update") {
+            // `validate_on_update = fetch` (issue #1801): opt into merged-model
+            // validation on the no-hooks blind update path. Only the bare ident
+            // `fetch` is accepted as the value (it fetches the current row when
+            // the blind path would otherwise skip the SELECT).
+            let value: Ident = meta.value()?.parse()?;
+            if value == "fetch" {
+                validate_on_update_fetch = true;
+                Ok(())
+            } else {
+                Err(syn::Error::new(
+                    value.span(),
+                    format!(
+                        "unknown validate_on_update mode `{value}`; expected \
+                         `validate_on_update = fetch`"
+                    ),
+                ))
+            }
         } else if meta.path.is_ident("dependent") {
             // `dependent(ChildRepository, fk = "col", on_delete = <action>)`
             let mut child_repo: Option<syn::Path> = None;
@@ -429,7 +455,7 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
             Ok(())
         } else {
             Err(meta.error(
-                "expected model name, table = \"...\", hooks = Type, commit_hooks = true, api = \"/path\", mcp, mcp = \"read\", policy = Type, scope = Type, cursor_key = field, cursor_key_type = Type, soft_delete, tenant_scoped, no_upsert_trait, searchable, versioned = true, no_versioned_record_impl, primary_reads, sharded, dependent(ChildRepository, fk = \"...\", on_delete = ...), broadcasts = true, topic = \"...\", render = fn, or container = \"...\"",
+                "expected model name, table = \"...\", hooks = Type, commit_hooks = true, api = \"/path\", mcp, mcp = \"read\", policy = Type, scope = Type, cursor_key = field, cursor_key_type = Type, soft_delete, tenant_scoped, no_upsert_trait, searchable, versioned = true, no_versioned_record_impl, primary_reads, sharded, validate_on_update = fetch, dependent(ChildRepository, fk = \"...\", on_delete = ...), broadcasts = true, topic = \"...\", render = fn, or container = \"...\"",
             ))
         }
     })
@@ -481,6 +507,7 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
         broadcast_container,
         generated_internal_hooks,
         dependents,
+        validate_on_update_fetch,
     })
 }
 
@@ -6764,6 +6791,32 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         };
 
+        // #1801: opt-in merged-model validation on the no-hooks update path.
+        // `#knob_validate_current` is spliced into branches where `current`
+        // (the loaded row) is already in scope — it borrows the row, validates
+        // the merged model via `from_patch`, and discards the draft (we only
+        // want its 422 side-effect; the blind write below is unchanged).
+        // `#knob_load_and_validate` is spliced into the otherwise-blind no-lock
+        // sub-branches: it first SELECTs the current row (only when the knob is
+        // set — no unconditional extra query), then validates. Both expand to
+        // nothing when the knob is off, keeping the blind path byte-for-byte.
+        let draft_ext_trait = format_ident!("{}DraftExt", model_name);
+        let knob_validate_current = if config.validate_on_update_fetch {
+            quote! {
+                { let _ = <::autumn_web::hooks::UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&current, changes)?; }
+            }
+        } else {
+            quote! {}
+        };
+        let knob_load_and_validate = if config.validate_on_update_fetch {
+            quote! {
+                let __merged_current = #table_ident::table.find(id).first::<#model_name>(&mut conn).await.map_err(::autumn_web::AutumnError::from)?;
+                { let _ = <::autumn_web::hooks::UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&__merged_current, changes)?; }
+            }
+        } else {
+            quote! {}
+        };
+
         let update_body = if config.tenant_scoped && config.versioned {
             let vh_insert = vh_insert_ts(
                 table_name,
@@ -6828,6 +6881,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 format!("{} with id {} not found", stringify!(#model_name), id)
                             ))?
                         };
+                        #knob_validate_current
                         let mut diesel_changeset = changes.__to_changeset();
                         if let ::core::option::Option::Some(ref t) = tenant_id {
                             diesel_changeset.set_tenant_id(t.clone());
@@ -6903,6 +6957,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 }
                             }
 
+                            #knob_validate_current
                             let mut diesel_changeset = changes.__to_changeset();
                             if let ::core::option::Option::Some(ref t) = tenant_id {
                                 use ::autumn_web::repository::CanSetTenantId as _;
@@ -6926,6 +6981,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     })
                     .await
                 } else {
+                    #knob_load_and_validate
                     let mut diesel_changeset = changes.__to_changeset();
                     if let ::core::option::Option::Some(ref t) = tenant_id {
                         use ::autumn_web::repository::CanSetTenantId as _;
@@ -6998,6 +7054,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     format!("{} with id {} not found", stringify!(#model_name), id)
                                 ))?
                         };
+                        #knob_validate_current
                         let diesel_changeset = changes.__to_changeset();
                         let update_target = #table_ident::table.find(id);
                         let record = ::autumn_web::reexports::diesel::update(update_target)
@@ -7049,6 +7106,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 }
                             }
 
+                            #knob_validate_current
                             let diesel_changeset = changes.__to_changeset();
                             let update_target = #table_ident::table.find(id);
                             ::autumn_web::reexports::diesel::update(update_target)
@@ -7061,6 +7119,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     })
                     .await
                 } else {
+                    #knob_load_and_validate
                     let diesel_changeset = changes.__to_changeset();
                     let update_target = #table_ident::table.find(id);
                     ::autumn_web::reexports::diesel::update(update_target)
@@ -11336,6 +11395,37 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         };
         let update_body = if has_policy {
+            // #1801: merged-model validation via `from_patch` structurally needs
+            // the `#[model]`-generated `<Model>DraftExt` trait (and `Model:
+            // Clone`, required by `UpdateDraft`). Hand-written models opt out of
+            // the generated DTO scaffolding with `no_upsert_trait` and supply
+            // their own changeset, so they have no `DraftExt`; skip the merged
+            // check for them (the patch-level `#validate_patch_idempotency` above
+            // still runs). Regression: repository_policy_non_serialize_new.rs.
+            let merged_validate = if config.no_upsert_trait {
+                quote! {}
+            } else {
+                let draft_ext_trait = format_ident!("{}DraftExt", model_name);
+                quote! {
+                    // #1801: also validate the effective merged model (existing
+                    // row ∪ patch) so the full validator set runs against
+                    // concrete values, matching the hooked-repo precedent
+                    // (#1804). Runs after 404/403/patch-422 and reuses the
+                    // already-loaded `__existing` (no extra query). We only want
+                    // the 422 side-effect, so the draft is discarded and the
+                    // blind `repo.update` below is unchanged. Wrapped (not `?`)
+                    // because this handler returns `IdempotencyReplayOr`; sits
+                    // with the other pure pre-replay checks so it cannot affect
+                    // idempotency replay semantics.
+                    if let ::core::result::Result::Err(err) =
+                        <::autumn_web::hooks::UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&__existing, &patch)
+                    {
+                        return ::autumn_web::idempotency::IdempotencyReplayOr::Inner(
+                            ::core::result::Result::Err(err)
+                        );
+                    }
+                }
+            };
             quote! {
                 let __existing = match repo.on_primary().find_by_id(id).await {
                     ::core::result::Result::Ok(::core::option::Option::Some(existing)) => existing,
@@ -11372,6 +11462,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 // policy gate above, sits before the pure `__replay_response`
                 // read, so it cannot affect idempotency replay semantics.
                 #validate_patch_idempotency
+                #merged_validate
                 if let ::core::option::Option::Some(response) =
                     ::autumn_web::idempotency::__replay_response(&__autumn_idempotency_replay)
                 {
@@ -14743,6 +14834,79 @@ mod tests {
     }
 
     #[test]
+    fn repository_macro_no_hooks_validate_on_update_emits_from_patch() {
+        // #1801: with `validate_on_update = fetch` on a plain no-hooks repo, the
+        // generated single-record `update` body validates the effective merged
+        // model via `from_patch` (existing row ∪ patch), surfacing the standard
+        // 422 for a patch that only becomes invalid once merged.
+        let generated = repository_macro(
+            quote! { Post, validate_on_update = fetch },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+        let section = update_section(&generated);
+        assert!(
+            section.contains("from_patch"),
+            "validate_on_update = fetch must emit a from_patch merged-model check \
+             on the no-hooks update path: {section}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_no_hooks_without_knob_has_no_from_patch() {
+        // #1801 AC #2: without the opt-in knob, the blind no-hooks update path
+        // stays byte-for-byte as before — no `from_patch` call, so no
+        // unconditional extra SELECT or merged validation.
+        let generated =
+            repository_macro(quote! { Post }, quote! { pub trait PostRepository {} }).to_string();
+        let section = update_section(&generated);
+        assert!(
+            !section.contains("from_patch"),
+            "a no-hooks repo without validate_on_update must not emit a from_patch \
+             merged-model check on the update path: {section}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_api_policy_update_validates_merged_model() {
+        // #1801 sub-case 1: the policy `--api` update handler unconditionally
+        // validates the effective merged model via `from_patch` on the already
+        // loaded `__existing` row (zero extra query), independent of the knob.
+        let generated = repository_macro(
+            quote! { Post, api = "/api/posts", policy = PostPolicy },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+
+        let start = generated
+            .find("async fn post_api_update")
+            .expect("policy update handler must be generated");
+        let rest = &generated[start..];
+        let end = rest
+            .find("fn __autumn_route_info_post_api_update")
+            .unwrap_or(rest.len());
+        let section = &rest[..end];
+
+        assert!(
+            section.contains("from_patch (& __existing"),
+            "policy update handler must validate the merged model via from_patch on \
+             the loaded __existing row (zero extra query): {section}"
+        );
+        let from_patch_at = section
+            .find("from_patch")
+            .expect("policy update handler must validate the merged model via from_patch");
+        // The merged validation must run after the policy gate (403) so ordering
+        // stays 404 -> 403 -> patch-422 -> merged-422.
+        let policy_at = section
+            .find("__check_policy_scoped")
+            .expect("policy update handler must run the scoped policy check");
+        assert!(
+            policy_at < from_patch_at,
+            "merged-model validation must run after the policy check: {section}"
+        );
+    }
+
+    #[test]
     fn repository_macro_api_policy_create_validates_before_persist() {
         // #1253 AC: the policy-backed create branch validates before persisting
         // so authorization and validation both run.
@@ -14791,6 +14955,41 @@ mod tests {
         assert!(
             !config.primary_reads,
             "reads route to the replica by default"
+        );
+    }
+
+    #[test]
+    fn parse_repo_args_validate_on_update_fetch() {
+        // #1801: `validate_on_update = fetch` opts the no-hooks blind update
+        // path into merged-model validation.
+        let tokens: proc_macro2::TokenStream = "Post, validate_on_update = fetch".parse().unwrap();
+        let config = parse_repo_args(tokens).unwrap();
+        assert!(
+            config.validate_on_update_fetch,
+            "validate_on_update = fetch must set validate_on_update_fetch"
+        );
+    }
+
+    #[test]
+    fn parse_repo_args_validate_on_update_defaults_off() {
+        let tokens: proc_macro2::TokenStream = "Post".parse().unwrap();
+        let config = parse_repo_args(tokens).unwrap();
+        assert!(
+            !config.validate_on_update_fetch,
+            "the blind update path skips merged validation by default"
+        );
+    }
+
+    #[test]
+    fn parse_repo_args_validate_on_update_rejects_unknown_mode() {
+        // Only the bare ident `fetch` is a valid value.
+        let tokens: proc_macro2::TokenStream = "Post, validate_on_update = eager".parse().unwrap();
+        let err = parse_repo_args(tokens)
+            .err()
+            .expect("unknown mode must be rejected");
+        assert!(
+            err.to_string().contains("validate_on_update"),
+            "error must name the knob: {err}"
         );
     }
 
@@ -15351,6 +15550,19 @@ mod tests {
             .find("async fn delete_many")
             .expect("repository must generate delete_many");
         let rest = &generated[start + "async fn delete_many".len()..];
+        let end = rest.find("async fn ").map_or(rest.len(), |p| p);
+        &rest[..end]
+    }
+
+    /// Helper: slice the generated `update` trait-impl body (up to the next
+    /// `async fn`) so assertions target the single-record update path. Anchors
+    /// on `async fn update (` so it does not match `async fn update_many (`.
+    fn update_section(generated: &str) -> &str {
+        let needle = "async fn update (";
+        let start = generated
+            .find(needle)
+            .expect("repository must generate update");
+        let rest = &generated[start + needle.len()..];
         let end = rest.find("async fn ").map_or(rest.len(), |p| p);
         &rest[..end]
     }

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -6796,10 +6796,23 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         // (the loaded row) is already in scope — it borrows the row, validates
         // the merged model via `from_patch`, and discards the draft (we only
         // want its 422 side-effect; the blind write below is unchanged).
-        // `#knob_load_and_validate` is spliced into the otherwise-blind no-lock
-        // sub-branches: it first SELECTs the current row (only when the knob is
-        // set — no unconditional extra query), then validates. Both expand to
+        // `#knob_load_and_validate` (plain, no tenant filter) and
+        // `#knob_load_and_validate_tenant` (tenant-filtered) are spliced into the
+        // otherwise-blind no-lock sub-branches: each first SELECTs the current row
+        // (only when the knob is set — no unconditional extra query), then
+        // validates. The tenant variant is used in the tenant_scoped blind branch
+        // so its SELECT matches that branch's own tenant-filtered UPDATE and the
+        // sibling version-checked load — otherwise a cross-tenant `id` would load a
+        // foreign row and surface 422 instead of the correct 404. All expand to
         // nothing when the knob is off, keeping the blind path byte-for-byte.
+        //
+        // Note (normalize-vs-persist asymmetry): `from_patch` normalizes the merged
+        // model before validating, but the blind path deliberately persists the
+        // un-normalized `changes.__to_changeset()` (the validation here is
+        // side-effect-only — we keep only its 422). So a value that passes only
+        // because normalization cleaned it up is stored raw. This is a known,
+        // deliberate limitation of the opt-in blind path; the hooked/#1804 path
+        // persists the normalized draft instead.
         let draft_ext_trait = format_ident!("{}DraftExt", model_name);
         let knob_validate_current = if config.validate_on_update_fetch {
             quote! {
@@ -6811,6 +6824,22 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         let knob_load_and_validate = if config.validate_on_update_fetch {
             quote! {
                 let __merged_current = #table_ident::table.find(id).first::<#model_name>(&mut conn).await.map_err(::autumn_web::AutumnError::from)?;
+                { let _ = <::autumn_web::hooks::UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&__merged_current, changes)?; }
+            }
+        } else {
+            quote! {}
+        };
+        // Tenant-scoped variant: mirror the branch's own UPDATE and sibling load,
+        // which filter by `#table_ident::tenant_id.eq(t)` when a tenant is in scope
+        // and fall back to the bare PK lookup only for across-tenants queries.
+        let knob_load_and_validate_tenant = if config.validate_on_update_fetch {
+            quote! {
+                let __merged_current = if let ::core::option::Option::Some(ref t) = tenant_id {
+                    #table_ident::table.find(id).filter(#table_ident::tenant_id.eq(t)).first::<#model_name>(&mut conn).await
+                } else {
+                    #table_ident::table.find(id).first::<#model_name>(&mut conn).await
+                }
+                .map_err(::autumn_web::AutumnError::from)?;
                 { let _ = <::autumn_web::hooks::UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&__merged_current, changes)?; }
             }
         } else {
@@ -6981,7 +7010,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     })
                     .await
                 } else {
-                    #knob_load_and_validate
+                    #knob_load_and_validate_tenant
                     let mut diesel_changeset = changes.__to_changeset();
                     if let ::core::option::Option::Some(ref t) = tenant_id {
                         use ::autumn_web::repository::CanSetTenantId as _;
@@ -14849,6 +14878,49 @@ mod tests {
             section.contains("from_patch"),
             "validate_on_update = fetch must emit a from_patch merged-model check \
              on the no-hooks update path: {section}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_tenant_scoped_validate_on_update_tenant_filters_load() {
+        // #1801 follow-up: on a `tenant_scoped` no-hooks repo WITH the knob, the
+        // blind (no version-check) sub-branch must load the current row for
+        // merged validation through the SAME tenant filter its own blind UPDATE
+        // uses — otherwise a cross-tenant `id` would load a foreign row and
+        // surface 422 instead of the correct 404. Assert the update body both
+        // emits the `from_patch` merged check and tenant-filters the load.
+        let generated = repository_macro(
+            quote! { Post, tenant_scoped, validate_on_update = fetch },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+        let section = update_section(&generated);
+        assert!(
+            section.contains("from_patch"),
+            "tenant_scoped + validate_on_update = fetch must emit a from_patch \
+             merged-model check: {section}"
+        );
+        assert!(
+            section.contains("tenant_id . eq"),
+            "the tenant_scoped blind merged-validation load must be tenant-filtered \
+             (tenant_id.eq), matching its own blind UPDATE: {section}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_versioned_validate_on_update_emits_from_patch() {
+        // #1801 follow-up: a `versioned` no-hooks repo WITH the knob emits the
+        // merged-model `from_patch` check on its update body too.
+        let generated = repository_macro(
+            quote! { Post, versioned = true, validate_on_update = fetch },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+        let section = update_section(&generated);
+        assert!(
+            section.contains("from_patch"),
+            "versioned + validate_on_update = fetch must emit a from_patch \
+             merged-model check: {section}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -6813,6 +6813,18 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         // because normalization cleaned it up is stored raw. This is a known,
         // deliberate limitation of the opt-in blind path; the hooked/#1804 path
         // persists the normalized draft instead.
+        //
+        // Concurrency (known, deliberate): this merged validation is point-in-time
+        // against a non-locked snapshot (a plain SELECT, no `FOR UPDATE`). It
+        // reliably rejects a single request that is invalid once merged (the #1801
+        // acceptance criterion), but does not provide a serializable cross-field
+        // invariant under concurrent partial writes to different fields — two
+        // concurrent requests can each validate against the same old row and then
+        // persist a combination the validator would reject. This matches the blind
+        // path's intentionally non-transactional, last-write-wins-per-column
+        // semantics; callers needing atomic cross-field enforcement should use a
+        // versioned or `hooks = ...` repository, whose update runs
+        // `SELECT ... FOR UPDATE` inside the mutation transaction.
         let draft_ext_trait = format_ident!("{}DraftExt", model_name);
         let knob_validate_current = if config.validate_on_update_fetch {
             quote! {
@@ -11446,6 +11458,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     // because this handler returns `IdempotencyReplayOr`; sits
                     // with the other pure pre-replay checks so it cannot affect
                     // idempotency replay semantics.
+                    //
+                    // Concurrency (known, deliberate): this is point-in-time —
+                    // it validates against the `__existing` snapshot loaded for
+                    // the 404/policy gate, not under a row lock held through
+                    // `repo.update`, so it is best-effort under concurrent writes
+                    // for the same reason as the blind path above (deliberate,
+                    // given the always-on zero-extra-query design).
                     if let ::core::result::Result::Err(err) =
                         <::autumn_web::hooks::UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&__existing, &patch)
                     {

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -214,6 +214,8 @@ mod transactional_test_integration;
 mod tx_isolation_retry_integration;
 #[cfg(feature = "db")]
 mod validate_merged_model;
+#[cfg(feature = "db")]
+mod validate_on_update_blind;
 mod validate_patch_option_ip;
 mod webhook_outbound;
 #[cfg(feature = "maud")]

--- a/autumn/tests/integration/validate_on_update_blind.rs
+++ b/autumn/tests/integration/validate_on_update_blind.rs
@@ -23,6 +23,7 @@
 #![allow(clippy::must_use_candidate, clippy::missing_const_for_fn)]
 
 use autumn_web::hooks::Patch;
+use autumn_web::tenancy::with_tenant;
 use diesel_async::pooled_connection::AsyncDieselConnectionManager;
 use diesel_async::pooled_connection::deadpool::Pool;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
@@ -96,6 +97,45 @@ pub struct LaxHost {
 #[autumn_web::repository(LaxHost, table = "lax_hosts")]
 pub trait LaxHostRepository {}
 
+// ── Tenant-scoped opt-in repo (`tenant_scoped` + `validate_on_update = fetch`) ─
+//
+// This exists to force the `integration_tests` binary to COMPILE the macro
+// expansion of a tenant_scoped repo WITH the knob — the only configuration that
+// instantiates the tenant-filtered merged-validation SELECT. A typo in that
+// tenant-filtered token would fail to type-check here even before Docker runs.
+
+mod tenant_validated_schema {
+    autumn_web::reexports::diesel::table! {
+        tenant_blind_hosts (id) {
+            id -> Int8,
+            blurb -> Text,
+            slug -> Text,
+            tenant_id -> Text,
+        }
+    }
+}
+use tenant_validated_schema::tenant_blind_hosts;
+
+#[autumn_web::model(table = "tenant_blind_hosts")]
+pub struct TenantBlindHost {
+    #[id]
+    pub id: i64,
+    #[validate(does_not_contain(pattern = "bad"))]
+    pub blurb: String,
+    #[validate(custom(function = "no_uppercase"))]
+    pub slug: String,
+    #[default]
+    pub tenant_id: String,
+}
+
+#[autumn_web::repository(
+    TenantBlindHost,
+    table = "tenant_blind_hosts",
+    tenant_scoped,
+    validate_on_update = fetch
+)]
+pub trait TenantBlindHostRepository {}
+
 // ── Setup & helpers ──────────────────────────────────────────────────────────
 
 async fn setup_pool() -> (
@@ -129,6 +169,14 @@ async fn setup_pool() -> (
     .execute(&mut conn)
     .await
     .expect("create lax_hosts");
+    diesel::sql_query(
+        "CREATE TABLE IF NOT EXISTS tenant_blind_hosts \
+         (id BIGSERIAL PRIMARY KEY, blurb TEXT NOT NULL, slug TEXT NOT NULL, \
+          tenant_id TEXT NOT NULL)",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("create tenant_blind_hosts");
 
     (pool, container)
 }
@@ -146,6 +194,17 @@ fn build_blind_repo(pool: Pool<AsyncPgConnection>) -> PgBlindHostRepository {
 fn build_lax_repo(pool: Pool<AsyncPgConnection>) -> PgLaxHostRepository {
     PgLaxHostRepository {
         pool,
+        __autumn_read_route: autumn_web::repository::ReadRoute::Primary,
+        __autumn_statement_timeout_ms: 0,
+        __autumn_slow_threshold: std::time::Duration::from_millis(500),
+        __autumn_route: None,
+    }
+}
+
+fn build_tenant_blind_repo(pool: Pool<AsyncPgConnection>) -> PgTenantBlindHostRepository {
+    PgTenantBlindHostRepository {
+        pool,
+        across_tenants: false,
         __autumn_read_route: autumn_web::repository::ReadRoute::Primary,
         __autumn_statement_timeout_ms: 0,
         __autumn_slow_threshold: std::time::Duration::from_millis(500),
@@ -302,5 +361,49 @@ async fn plain_repo_without_knob_skips_merged_validation() {
     assert_eq!(
         updated.blurb, "this is bad",
         "the blind write must persist the patch unchanged when the knob is off"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn tenant_scoped_blind_merged_validation_stays_tenant_isolated() {
+    // #1801 follow-up: the tenant_scoped blind merged-validation SELECT must be
+    // tenant-filtered like its own blind UPDATE. Updating tenant-a's row from
+    // tenant-b's context must load NO row and surface 404 — not load the foreign
+    // row and validate the patch against it (which would surface 422).
+    //
+    // (This test is Docker-gated; its primary job in CI-without-Docker is to make
+    // the integration_tests binary COMPILE the tenant_scoped + knob macro
+    // expansion, type-checking the tenant-filtered token.)
+    let (pool, _container) = setup_pool().await;
+    let repo = build_tenant_blind_repo(pool);
+
+    let created = with_tenant("tenant-a".to_string(), async {
+        repo.save(&NewTenantBlindHost {
+            blurb: "all good".to_string(),
+            slug: "host-one".to_string(),
+        })
+        .await
+        .expect("insert a valid row under tenant-a")
+    })
+    .await;
+
+    let err = with_tenant("tenant-b".to_string(), async {
+        repo.update(
+            created.id,
+            &UpdateTenantBlindHost {
+                blurb: Patch::Set("this is bad".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("a cross-tenant id must not be found from another tenant's context")
+    })
+    .await;
+    assert_eq!(
+        err.status(),
+        autumn_web::reexports::http::StatusCode::NOT_FOUND,
+        "the tenant-filtered merged-validation load must yield 404 for a foreign \
+         tenant's id, never a 422 from validating the wrong row"
     );
 }

--- a/autumn/tests/integration/validate_on_update_blind.rs
+++ b/autumn/tests/integration/validate_on_update_blind.rs
@@ -1,0 +1,306 @@
+//! #1801 — validate the effective *merged model* on the plain / no-hooks blind
+//! update path, opt-in via `validate_on_update = fetch`.
+//!
+//! A no-hooks repo without `hooks = ...` normally does a blind
+//! `changes.__to_changeset()` UPDATE and never builds a draft, so it skips the
+//! merged-model validation that #1804 wired into the hooked `from_patch` path.
+//! With `validate_on_update = fetch` the generated `update` loads the current
+//! row (only on the otherwise-blind branches) and runs `from_patch` purely for
+//! its 422 side-effect before the unchanged blind write.
+//!
+//! These exercise the write path end-to-end against Postgres:
+//! - a patch that only becomes invalid once merged → 422 (blurb / slug rules);
+//! - a valid patch → Ok;
+//! - an untouched-but-invalid field on merge → 422 (whole-merged-model
+//!   semantic, matching #1804);
+//! - a second plain repo on a distinct model *without* the knob still accepts
+//!   the invalid-once-merged patch (locks the opt-in AC — no merged validation
+//!   without the knob).
+//!
+//! **Requires Docker** to be running.
+
+#![cfg(feature = "db")]
+#![allow(clippy::must_use_candidate, clippy::missing_const_for_fn)]
+
+use autumn_web::hooks::Patch;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::pooled_connection::deadpool::Pool;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+/// Reject any value containing an uppercase letter — stands in for the
+/// cross-field / struct-level `custom` validators that have no `Patch<T>` impl
+/// and are therefore create-only on the patch-struct path, but run here against
+/// the concrete merged value.
+fn no_uppercase(value: &str) -> Result<(), validator::ValidationError> {
+    if value.chars().any(char::is_uppercase) {
+        return Err(validator::ValidationError::new("no_uppercase"));
+    }
+    Ok(())
+}
+
+// ── Opt-in repo (`validate_on_update = fetch`) ────────────────────────────────
+
+mod validated_schema {
+    autumn_web::reexports::diesel::table! {
+        blind_hosts (id) {
+            id -> Int8,
+            blurb -> Text,
+            slug -> Text,
+        }
+    }
+}
+use validated_schema::blind_hosts;
+
+#[autumn_web::model(table = "blind_hosts")]
+pub struct BlindHost {
+    #[id]
+    pub id: i64,
+    // `does_not_contain`: blanket-inversion coherence wall on `Patch<T>`.
+    // Dropped from the patch field, enforced only on the merged concrete `String`.
+    #[validate(does_not_contain(pattern = "bad"))]
+    pub blurb: String,
+    // `custom`: no `Patch<T>` impl (struct/cross-field class). Dropped from the
+    // patch field, enforced on the merged concrete value.
+    #[validate(custom(function = "no_uppercase"))]
+    pub slug: String,
+}
+
+#[autumn_web::repository(BlindHost, table = "blind_hosts", validate_on_update = fetch)]
+pub trait BlindHostRepository {}
+
+// ── Control repo on a distinct model WITHOUT the knob ─────────────────────────
+
+mod lax_schema {
+    autumn_web::reexports::diesel::table! {
+        lax_hosts (id) {
+            id -> Int8,
+            blurb -> Text,
+            slug -> Text,
+        }
+    }
+}
+use lax_schema::lax_hosts;
+
+#[autumn_web::model(table = "lax_hosts")]
+pub struct LaxHost {
+    #[id]
+    pub id: i64,
+    #[validate(does_not_contain(pattern = "bad"))]
+    pub blurb: String,
+    #[validate(custom(function = "no_uppercase"))]
+    pub slug: String,
+}
+
+#[autumn_web::repository(LaxHost, table = "lax_hosts")]
+pub trait LaxHostRepository {}
+
+// ── Setup & helpers ──────────────────────────────────────────────────────────
+
+async fn setup_pool() -> (
+    Pool<AsyncPgConnection>,
+    testcontainers::ContainerAsync<Postgres>,
+) {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start postgres container");
+
+    let host = container.get_host().await.expect("host");
+    let port = container.get_host_port_ipv4(5432).await.expect("port");
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(&url);
+    let pool = Pool::builder(manager).max_size(5).build().expect("pool");
+
+    let mut conn = pool.get().await.expect("conn");
+    diesel::sql_query(
+        "CREATE TABLE IF NOT EXISTS blind_hosts \
+         (id BIGSERIAL PRIMARY KEY, blurb TEXT NOT NULL, slug TEXT NOT NULL)",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("create blind_hosts");
+    diesel::sql_query(
+        "CREATE TABLE IF NOT EXISTS lax_hosts \
+         (id BIGSERIAL PRIMARY KEY, blurb TEXT NOT NULL, slug TEXT NOT NULL)",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("create lax_hosts");
+
+    (pool, container)
+}
+
+fn build_blind_repo(pool: Pool<AsyncPgConnection>) -> PgBlindHostRepository {
+    PgBlindHostRepository {
+        pool,
+        __autumn_read_route: autumn_web::repository::ReadRoute::Primary,
+        __autumn_statement_timeout_ms: 0,
+        __autumn_slow_threshold: std::time::Duration::from_millis(500),
+        __autumn_route: None,
+    }
+}
+
+fn build_lax_repo(pool: Pool<AsyncPgConnection>) -> PgLaxHostRepository {
+    PgLaxHostRepository {
+        pool,
+        __autumn_read_route: autumn_web::repository::ReadRoute::Primary,
+        __autumn_statement_timeout_ms: 0,
+        __autumn_slow_threshold: std::time::Duration::from_millis(500),
+        __autumn_route: None,
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn blind_update_rejects_patch_invalid_once_merged() {
+    let (pool, _container) = setup_pool().await;
+    let repo = build_blind_repo(pool);
+
+    let created = repo
+        .save(&NewBlindHost {
+            blurb: "all good".to_string(),
+            slug: "host-one".to_string(),
+        })
+        .await
+        .expect("insert a valid row");
+
+    // `does_not_contain` is dropped from the `Patch<String>` field, so the
+    // patch struct validates fine; only the merged-model check catches this.
+    let err = repo
+        .update(
+            created.id,
+            &UpdateBlindHost {
+                blurb: Patch::Set("this is bad".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("a patch that only becomes invalid once merged must be rejected");
+    assert_eq!(
+        err.status(),
+        autumn_web::reexports::http::StatusCode::UNPROCESSABLE_ENTITY,
+        "merged-model validation failures on the blind path must surface as 422"
+    );
+
+    // `custom` (no uppercase) is likewise dropped from the patch field.
+    let err = repo
+        .update(
+            created.id,
+            &UpdateBlindHost {
+                slug: Patch::Set("Has-Uppercase".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("a merged slug failing the custom rule must be rejected");
+    assert_eq!(
+        err.status(),
+        autumn_web::reexports::http::StatusCode::UNPROCESSABLE_ENTITY
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn blind_update_accepts_valid_patch() {
+    let (pool, _container) = setup_pool().await;
+    let repo = build_blind_repo(pool);
+
+    let created = repo
+        .save(&NewBlindHost {
+            blurb: "all good".to_string(),
+            slug: "host-one".to_string(),
+        })
+        .await
+        .expect("insert a valid row");
+
+    let updated = repo
+        .update(
+            created.id,
+            &UpdateBlindHost {
+                blurb: Patch::Set("still fine".to_string()),
+                slug: Patch::Set("host-two".to_string()),
+            },
+        )
+        .await
+        .expect("a valid merged model must pass and persist");
+    assert_eq!(updated.blurb, "still fine");
+    assert_eq!(updated.slug, "host-two");
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn blind_update_rejects_untouched_but_invalid_field() {
+    // Whole-merged-model semantic (#1804 precedent): a field the patch never
+    // touches but that already violates a rule must still surface on merge.
+    let (pool, _container) = setup_pool().await;
+    let repo = build_blind_repo(pool.clone());
+
+    // Seed a row whose `blurb` already contains the forbidden pattern, bypassing
+    // any create-path checks by inserting directly.
+    let mut conn = pool.get().await.expect("conn");
+    diesel::sql_query("INSERT INTO blind_hosts (blurb, slug) VALUES ('already bad', 'ok-slug')")
+        .execute(&mut conn)
+        .await
+        .expect("seed an already-invalid row");
+    let id: i64 = {
+        use diesel::prelude::*;
+        let query = blind_hosts::table.select(blind_hosts::id);
+        diesel_async::RunQueryDsl::first(query, &mut conn)
+            .await
+            .expect("seeded row id")
+    };
+
+    // The patch only touches `slug`; `blurb` keeps the pre-existing invalid
+    // value. Merged validation sees the whole record, so it is rejected.
+    let err = repo
+        .update(
+            id,
+            &UpdateBlindHost {
+                slug: Patch::Set("fresh-slug".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("an untouched-but-invalid field must still be caught on merge");
+    assert_eq!(
+        err.status(),
+        autumn_web::reexports::http::StatusCode::UNPROCESSABLE_ENTITY
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn plain_repo_without_knob_skips_merged_validation() {
+    // AC #2: without `validate_on_update = fetch` the blind path stays blind —
+    // no merged validation, so an invalid-once-merged patch is persisted.
+    let (pool, _container) = setup_pool().await;
+    let repo = build_lax_repo(pool);
+
+    let created = repo
+        .save(&NewLaxHost {
+            blurb: "all good".to_string(),
+            slug: "host-one".to_string(),
+        })
+        .await
+        .expect("insert a valid row");
+
+    let updated = repo
+        .update(
+            created.id,
+            &UpdateLaxHost {
+                blurb: Patch::Set("this is bad".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("a repo without the opt-in must skip merged validation and persist");
+    assert_eq!(
+        updated.blurb, "this is bad",
+        "the blind write must persist the patch unchanged when the knob is off"
+    );
+}


### PR DESCRIPTION
## Before / After

**Before.** #1804 made the update path validate the *effective merged model* (existing row ∪ patch) — enforcing the validators that can't be expressed on the sparse `Patch` struct (`ip` on `Option`, `does_not_contain`, and the cross-field `custom`/`must_match`/`nested`). But it only reached repositories that build a draft via `from_patch`, i.e. those declared with `hooks = ...`. Repositories generated **without** hooks (plain `#[repository(M)]`, `api = "…"`, `policy = …`) emit a blind `changes.__to_changeset()` UPDATE with no `SELECT`, never call `from_patch`, so a PATCH/PUT that was invalid once merged still persisted.

**After.** Two additive paths close the gap, matching #1801's cost analysis:

1. **`policy` `--api` handler** — validates the merged model using the `__existing` row it *already* loads for the 404 + policy-scope gate. **Zero extra query, always on** (for `#[model]`-derived repos), mirroring the unconditional precedent #1804 set for hooked repos. Runs after the 404/403/patch-422 checks and before `repo.update`, so ordering is 404 → 403 → patch-422 → merged-422.
2. **Plain / `api` (no-hooks) path** — gated behind a new opt-in knob `#[repository(M, validate_on_update = fetch)]`. Only when set does the blind update path load the row and validate the merged model (reusing an already-loaded row on versioned/tenant-locked branches; adding a single `SELECT` only in the truly-blind branches). Off by default → the blind path is byte-for-byte unchanged, so there is **no unconditional extra `SELECT`** on the plain non-policy path.

An invalid-once-merged PATCH/PUT on these paths now returns the **same 422 field-error map as create**; a valid patch still passes.

## How

- New `RepoConfig.validate_on_update_fetch`, parsed from `validate_on_update = fetch` in `parse_repo_args` (unknown modes rejected with a span-anchored error).
- In the no-hooks `update` body, two gated token fragments splice merged validation into all four branches: reuse `current` where a lock/versioned `SELECT` already happens; `SELECT` via `.find(id).first::()` in the blind sub-branches. The tenant_scoped blind branch's load is **tenant-filtered** (`.filter(tenant_id.eq(t))`, with the `across_tenants` `None` fallback) to match the branch's own UPDATE and avoid validating a foreign tenant's row. Both fragments fall to `quote!{}` when the knob is off.
- Validation is **side-effect-only**: `from_patch(&row, changes)?` is called for its 422 and the draft discarded; the persisted blind `__to_changeset()` write is unchanged.
- Policy-handler validation is gated on `!no_upsert_trait` (hand-written non-`#[model]` repos have no generated `DraftExt`/`from_patch`/`Clone`).

## Performance (the documented cost of correctness)

Sub-case 1 (policy) is **free** — it reuses the already-loaded row. Sub-case 2 adds a `SELECT` to a previously blind UPDATE, which is exactly why it is **opt-in** (`validate_on_update = fetch`), per #1801's requirement that the extra round-trip be deliberate. On versioned/tenant-locked branches the row is already loaded, so even with the knob there is no *additional* query there.

## Known limitations / follow-ups

- **Normalize-vs-persist asymmetry:** `from_patch` normalizes the merged model before validating, but the blind path deliberately persists the un-normalized `__to_changeset()` (validation is side-effect-only). A value that passes only because normalization cleaned it up is stored raw. The hooked/#1804 path persists the normalized draft; documented inline.
- **`no_upsert_trait` proxy:** a `#[model]`-derived repo that also sets `no_upsert_trait` + policy silently skips the policy-handler merged check (fails safe — no compile error).
- **Double validation:** a repo with both `policy`/`api` and the knob validates twice (free in the handler, one `SELECT` in the update body). Redundant but correct.
- **Concurrency / atomicity (point-in-time validation):** on the blind (`validate_on_update = fetch`) and policy paths the merged model is validated against a non-locked snapshot, then the UPDATE runs separately — so it reliably rejects a single invalid-once-merged request but is not a serializable cross-field invariant under concurrent partial writes (two requests can each validate against the old row and persist an invalid combination). This matches the blind path's intentionally non-transactional, last-write-wins-per-column semantics; callers needing atomic cross-field enforcement should use a `versioned` or `hooks = ...` repository (which already runs `SELECT ... FOR UPDATE` in the mutation transaction). Making the opt-in `fetch` knob a hard guarantee is a scoped follow-up. (Codex P2, threads on `repository.rs` 6827 / 11450.)

## Semantic note

Validating the whole merged model (not just changed fields) means a pre-existing violation on an untouched column surfaces on any update to that row — matching #1778's "effective merged model" framing and #1804's blessed precedent. Locked by a test.

## Testing

- `cargo test -p autumn-macros` — **477 passed** (new token-assertion tests: knob-present emits `from_patch`; knob-absent does not; policy handler validates `__existing` after the policy gate; tenant_scoped knob load is tenant-filtered; versioned knob emits `from_patch`).
- `cargo test -p autumn-web --features db --test integration_tests` — **1125 passed, 0 failed**. The new `validate_on_update_blind` module (plain-repo accept / reject-once-merged / untouched-invalid-field, no-knob-skips-validation, and a tenant-scoped isolation test) is testcontainers-gated (ignored without Docker, same as #1804's DB-backed tests); its compilation type-checks the generated code including the tenant-filtered token.
- `cargo fmt --all -- --check` — clean. `cargo clippy -p autumn-macros -p autumn-web --all-targets --features db -- -D warnings` — clean.

Closes #1801. Completes the blind-path coverage that #1804 deferred under #1778.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmMHYrUWkVVg42QXqjLgTb)_