### PR TITLE
Prevent duplicate form submissions with one-time submit tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,7 @@ dependencies = [
  "tokio-postgres",
  "tokio-postgres-rustls",
  "toml 1.1.2+spec-1.1.0",
+ "toml_edit",
  "url",
  "whoami 2.1.2",
 ]
@@ -7803,6 +7804,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
+ "toml_writer",
  "winnow 1.0.3",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ serde_json = "1"
 thiserror = "2"
 maud = { version = "0.27", features = ["axum"] }
 toml = "1.1"
+toml_edit = "0.25"
 tower = "0.5"
 tower-http = { version = "0.7", features = ["cors", "fs", "trace", "compression-gzip", "compression-br"] }
 tracing = "0.1"

--- a/autumn-cli/Cargo.toml
+++ b/autumn-cli/Cargo.toml
@@ -47,6 +47,7 @@ tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
 tokio-postgres-rustls = "0.13"
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 toml = { workspace = true }
+toml_edit = { workspace = true }
 url = "2.5.8"
 whoami = "2"
 percent-encoding = "2.3"

--- a/autumn-cli/src/generate/emit.rs
+++ b/autumn-cli/src/generate/emit.rs
@@ -153,6 +153,11 @@ pub enum Revert {
     /// Remove the `[auth.webauthn]` stub block `autumn generate auth
     /// --passkeys` appended to `path` (`autumn.toml`).
     AuthWebauthnStub { path: PathBuf },
+    /// Remove `/{plural}/validate` from `[security.submit_token] exempt_paths`
+    /// in `path` (`autumn.toml`) — the submit-token exemption `autumn generate
+    /// scaffold --live-validation` appended for issue #1360 — dropping the
+    /// block if that empties a freshly-generated `exempt_paths` key.
+    SubmitTokenValidateExempt { path: PathBuf, plural: String },
     /// Remove the remember-me middleware layer + startup-hook calls
     /// `autumn generate auth` injected into the `AppBuilder` chain in `path`
     /// (`src/main.rs`) (issue #1397).
@@ -187,6 +192,7 @@ impl Revert {
             | Self::PwaMainRsInjection { path }
             | Self::AuthOAuthProviderStubs { path, .. }
             | Self::AuthWebauthnStub { path }
+            | Self::SubmitTokenValidateExempt { path, .. }
             | Self::RememberMiddleware { path }
             | Self::SeedBinLinks { path, .. } => path,
         }
@@ -216,6 +222,7 @@ impl Revert {
             | Self::PwaMainRsInjection { .. }
             | Self::AuthOAuthProviderStubs { .. }
             | Self::AuthWebauthnStub { .. }
+            | Self::SubmitTokenValidateExempt { .. }
             | Self::RememberMiddleware { .. } => None,
         }
     }
@@ -333,6 +340,9 @@ impl Revert {
                 super::auth::remove_oauth_provider_stubs(content, providers)
             }
             Self::AuthWebauthnStub { .. } => super::auth::remove_webauthn_stub(content),
+            Self::SubmitTokenValidateExempt { plural, .. } => {
+                super::scaffold::remove_submit_token_validate_exempt_from_toml(content, plural)
+            }
             Self::SeedBinLinks { .. } => super::schema_edit::unlink_models_from_seed_bin(content),
         }
     }

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -6838,9 +6838,11 @@ async fn main() {
 
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
 
-        // The constrained validated input keeps its inline-validation wiring...
+        // The constrained validated input keeps its inline-validation wiring,
+        // now routed through the typed path helper (#1823) rather than a
+        // hardcoded URL.
         assert!(
-            routes.contains("hx-post=\"/posts/validate/title\""),
+            routes.contains("hx-post=(paths::validate_title())"),
             "title must keep its htmx inline-validation wiring:\n{routes}"
         );
         // ...but filters the one-time submit token out of that POST so the

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -883,6 +883,32 @@ pub fn plan_scaffold_with_options(
         }
     }
 
+    // ── autumn.toml: exempt the live-validation routes from the submit-token
+    // guard (issue #1360). The generated `POST /{plural}/validate/{field}`
+    // inline-validation routes `hx-include` the whole form, so without this the
+    // one-time `_submit_token` is consumed by a validation POST and the real
+    // create/update submit replays a validation fragment instead of mutating.
+    // The `hx-params="not _submit_token"` markup filter mitigates this only for
+    // the DEFAULT field name; exempting the route by prefix makes it robust for
+    // ANY configured `security.submit_token.field_name`. Only meaningful for
+    // `--live-validation`, and only when the project actually has an
+    // `autumn.toml` to edit (a bare/hand-rolled project keeps the markup
+    // filter as its sole, still-effective default-field-name guard).
+    if options_with_key.live_validation {
+        let autumn_toml_path = project_root.join("autumn.toml");
+        if autumn_toml_path.exists() {
+            let toml_existing = read_or_empty(&autumn_toml_path);
+            let updated_toml = append_submit_token_validate_exempt_to_toml(&toml_existing, &plural);
+            if updated_toml != toml_existing {
+                plan.modify(autumn_toml_path.clone(), updated_toml);
+            }
+            plan.push_revert(Revert::SubmitTokenValidateExempt {
+                path: autumn_toml_path,
+                plural,
+            });
+        }
+    }
+
     Ok(plan)
 }
 
@@ -5471,6 +5497,188 @@ fn main_route_entries(
     }
 }
 
+/// The submit-token exempt-path prefix for a `--live-validation` resource.
+///
+/// The generated inline-validation routes are `POST /{plural}/validate/{field}`;
+/// this prefix exempts every one of them from the submit-token guard at once
+/// (the guard matches `exempt_paths` by prefix — an exact match, a prefix ending
+/// in `/`, or a prefix whose remainder begins with `/`, so `/{plural}/validate`
+/// covers `/{plural}/validate/title`, `/{plural}/validate/body`, … without
+/// touching the guarded `POST /{plural}` create route).
+fn submit_token_validate_exempt_prefix(plural: &str) -> String {
+    format!("/{plural}/validate")
+}
+
+/// The `(start, end)` line span of a top-level `[header]` TOML table — the
+/// header line through the last line before the next top-level `[...]` header
+/// or EOF. `None` when `header` is absent. Mirrors the auth generator's
+/// equivalent so submit-token exemptions merge into an existing block instead
+/// of emitting a duplicate table.
+fn toml_table_block_range(lines: &[&str], header: &str) -> Option<(usize, usize)> {
+    let start = lines.iter().position(|l| l.trim() == header)?;
+    let end = lines[start + 1..]
+        .iter()
+        .position(|l| l.trim_start().starts_with('['))
+        .map_or(lines.len(), |rel| start + 1 + rel);
+    Some((start, end))
+}
+
+/// Ensure `/{plural}/validate` is listed under `[security.submit_token]
+/// exempt_paths` so a `--live-validation` scaffold's inline-validation POSTs
+/// never consume the one-time submit token (issue #1360).
+///
+/// This is the route-based, field-name-agnostic half of the fix: the
+/// `hx-params="not _submit_token"` markup filter only strips the DEFAULT field
+/// name, so an app that customises `security.submit_token.field_name` would
+/// otherwise still leak the token into the validation POST and have the real
+/// create/update submit replay a validation fragment. Exempting the route makes
+/// it robust regardless of the configured field name.
+///
+/// Idempotent: a no-op when the prefix is already present in the block. Handles
+/// three shapes — no `[security.submit_token]` table (append a fresh one), a
+/// table without an `exempt_paths` key (insert the key after the header), and a
+/// table whose `exempt_paths` array is merged in place.
+fn append_submit_token_validate_exempt_to_toml(existing: &str, plural: &str) -> String {
+    const HEADER: &str = "[security.submit_token]";
+    let exempt = submit_token_validate_exempt_prefix(plural);
+    let quoted = format!("\"{exempt}\"");
+
+    let lines: Vec<&str> = existing.lines().collect();
+    let Some((start, end)) = toml_table_block_range(&lines, HEADER) else {
+        // No `[security.submit_token]` table yet — append a fresh one.
+        let mut out = existing.trim_end().to_owned();
+        if !out.is_empty() {
+            out.push_str("\n\n");
+        }
+        out.push_str(HEADER);
+        out.push('\n');
+        let _ = writeln!(out, "exempt_paths = [{quoted}]");
+        return out;
+    };
+
+    // The table exists. Idempotent if the prefix is already listed in the block.
+    if lines[start..end].iter().any(|l| l.contains(&quoted)) {
+        return existing.to_owned();
+    }
+
+    // Look for an existing `exempt_paths` key inside the block.
+    let key_pos = lines[start + 1..end]
+        .iter()
+        .position(|l| l.trim_start().starts_with("exempt_paths"))
+        .map(|rel| start + 1 + rel);
+
+    let mut out_lines: Vec<String> = lines.iter().map(|l| (*l).to_owned()).collect();
+
+    if let Some(key_idx) = key_pos {
+        // Merge into the existing array. Find its closing `]` (arrays here don't
+        // nest) starting at the key line, collapsing a multi-line array to a
+        // single line if necessary — correctness over formatting for this
+        // uncommon hand-configured case.
+        let close_idx = (key_idx..end)
+            .find(|&i| lines[i].contains(']'))
+            .unwrap_or(key_idx);
+        let joined: String = lines[key_idx..=close_idx].join("\n");
+        if let (Some(open), Some(close)) = (joined.find('['), joined.rfind(']')) {
+            let inner = joined[open + 1..close].trim().trim_end_matches(',').trim();
+            let new_inner = if inner.is_empty() {
+                quoted
+            } else {
+                format!("{inner}, {quoted}")
+            };
+            let rebuilt = format!("{}[{new_inner}]{}", &joined[..open], &joined[close + 1..]);
+            out_lines.splice(key_idx..=close_idx, std::iter::once(rebuilt));
+        }
+    } else {
+        // Table present but no `exempt_paths` key — insert it right after the
+        // header line.
+        out_lines.insert(start + 1, format!("exempt_paths = [{quoted}]"));
+    }
+
+    let mut out = out_lines.join("\n");
+    if existing.ends_with('\n') && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+/// Inverse of [`append_submit_token_validate_exempt_to_toml`] (`autumn
+/// destroy`, issue #1048): remove `/{plural}/validate` from
+/// `[security.submit_token] exempt_paths`, dropping the whole block if that
+/// leaves an empty freshly-generated `exempt_paths = [...]` as its only key.
+///
+/// Conservative: only touches an `exempt_paths` array that still contains the
+/// exact prefix this generator inserts, never a hand-edited value.
+pub(super) fn remove_submit_token_validate_exempt_from_toml(
+    existing: &str,
+    plural: &str,
+) -> String {
+    const HEADER: &str = "[security.submit_token]";
+    let exempt = submit_token_validate_exempt_prefix(plural);
+    let quoted = format!("\"{exempt}\"");
+
+    let lines: Vec<&str> = existing.lines().collect();
+    let Some((start, end)) = toml_table_block_range(&lines, HEADER) else {
+        return existing.to_owned();
+    };
+    let Some(key_idx) = lines[start + 1..end]
+        .iter()
+        .position(|l| l.trim_start().starts_with("exempt_paths"))
+        .map(|rel| start + 1 + rel)
+    else {
+        return existing.to_owned();
+    };
+    let close_idx = (key_idx..end)
+        .find(|&i| lines[i].contains(']'))
+        .unwrap_or(key_idx);
+    let joined: String = lines[key_idx..=close_idx].join("\n");
+    let (Some(open), Some(close)) = (joined.find('['), joined.rfind(']')) else {
+        return existing.to_owned();
+    };
+    let inner = &joined[open + 1..close];
+    if !inner.contains(&quoted) {
+        return existing.to_owned();
+    }
+    // Strip our element from the array's comma-separated items.
+    let remaining: Vec<String> = inner
+        .split(',')
+        .map(str::trim)
+        .filter(|item| !item.is_empty() && *item != quoted)
+        .map(str::to_owned)
+        .collect();
+
+    let mut out_lines: Vec<String> = lines.iter().map(|l| (*l).to_owned()).collect();
+    if remaining.is_empty() {
+        // The block only carried our exempt_paths line — remove the key, and the
+        // whole table too if the key was its sole content.
+        let block_only_our_key = (start + 1..end).all(|i| {
+            i == key_idx || (key_idx..=close_idx).contains(&i) || lines[i].trim().is_empty()
+        });
+        if block_only_our_key {
+            out_lines.splice(start..end, std::iter::empty::<String>());
+        } else {
+            out_lines.splice(key_idx..=close_idx, std::iter::empty::<String>());
+        }
+    } else {
+        let rebuilt = format!(
+            "{}[{}]{}",
+            &joined[..open],
+            remaining.join(", "),
+            &joined[close + 1..]
+        );
+        out_lines.splice(key_idx..=close_idx, std::iter::once(rebuilt));
+    }
+
+    let mut out = out_lines.join("\n");
+    // Collapse any doubled blank lines left by removing the block.
+    while out.contains("\n\n\n") {
+        out = out.replace("\n\n\n", "\n\n");
+    }
+    if existing.ends_with('\n') && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -9856,5 +10064,159 @@ async fn main() {
         assert!(!tmp.path().join("src/policies/post.rs").exists());
         assert!(!tmp.path().join("src/policies").exists());
         assert_eq!(fs::read_to_string(&main_path).unwrap(), original_main);
+    }
+
+    // ── submit-token live-validation exempt_paths (issue #1360) ──────────────
+
+    #[test]
+    fn submit_token_exempt_appends_fresh_block_when_absent() {
+        let existing = "[server]\nport = 3000\n";
+        let out = append_submit_token_validate_exempt_to_toml(existing, "posts");
+        assert!(out.contains("[security.submit_token]"), "{out}");
+        assert!(
+            out.contains("exempt_paths = [\"/posts/validate\"]"),
+            "{out}"
+        );
+        // The original content is preserved.
+        assert!(out.contains("[server]"), "{out}");
+    }
+
+    #[test]
+    fn submit_token_exempt_is_idempotent() {
+        let existing = "[security.submit_token]\nexempt_paths = [\"/posts/validate\"]\n";
+        let out = append_submit_token_validate_exempt_to_toml(existing, "posts");
+        assert_eq!(out, existing, "re-adding the same prefix must be a no-op");
+    }
+
+    #[test]
+    fn submit_token_exempt_merges_into_existing_array() {
+        let existing =
+            "[security.submit_token]\nttl_secs = 900\nexempt_paths = [\"/webhooks/x\"]\n";
+        let out = append_submit_token_validate_exempt_to_toml(existing, "posts");
+        assert!(out.contains("\"/webhooks/x\""), "{out}");
+        assert!(out.contains("\"/posts/validate\""), "{out}");
+        assert!(out.contains("ttl_secs = 900"), "{out}");
+        // No duplicate exempt_paths key.
+        assert_eq!(out.matches("exempt_paths").count(), 1, "{out}");
+    }
+
+    #[test]
+    fn submit_token_exempt_inserts_key_when_block_lacks_it() {
+        let existing = "[security.submit_token]\nttl_secs = 900\n";
+        let out = append_submit_token_validate_exempt_to_toml(existing, "posts");
+        assert!(
+            out.contains("exempt_paths = [\"/posts/validate\"]"),
+            "{out}"
+        );
+        assert!(out.contains("ttl_secs = 900"), "{out}");
+    }
+
+    #[test]
+    fn submit_token_exempt_prefix_covers_only_validation_routes() {
+        // Field-name-agnostic: the exemption is a route prefix, independent of
+        // `security.submit_token.field_name`. It must cover the per-field
+        // validation routes but never the guarded create route.
+        assert_eq!(
+            submit_token_validate_exempt_prefix("posts"),
+            "/posts/validate"
+        );
+    }
+
+    #[test]
+    fn remove_submit_token_exempt_drops_fresh_block() {
+        let existing = "[server]\nport = 3000\n";
+        let added = append_submit_token_validate_exempt_to_toml(existing, "posts");
+        let removed = remove_submit_token_validate_exempt_from_toml(&added, "posts");
+        assert!(!removed.contains("/posts/validate"), "{removed}");
+        assert!(!removed.contains("[security.submit_token]"), "{removed}");
+        assert!(removed.contains("[server]"), "{removed}");
+    }
+
+    #[test]
+    fn remove_submit_token_exempt_keeps_other_entries() {
+        let existing =
+            "[security.submit_token]\nexempt_paths = [\"/webhooks/x\", \"/posts/validate\"]\n";
+        let removed = remove_submit_token_validate_exempt_from_toml(existing, "posts");
+        assert!(removed.contains("\"/webhooks/x\""), "{removed}");
+        assert!(!removed.contains("/posts/validate"), "{removed}");
+        assert!(removed.contains("[security.submit_token]"), "{removed}");
+    }
+
+    #[test]
+    fn remove_submit_token_exempt_ignores_hand_edited_value() {
+        // Never touch an array that no longer carries our exact prefix.
+        let existing = "[security.submit_token]\nexempt_paths = [\"/custom/only\"]\n";
+        let removed = remove_submit_token_validate_exempt_from_toml(existing, "posts");
+        assert_eq!(removed, existing);
+    }
+
+    #[test]
+    fn live_validation_scaffold_exempts_validation_routes_in_autumn_toml() {
+        // End-to-end at plan level: a `--live-validation` scaffold with a
+        // CUSTOM submit-token field name still exempts the generated
+        // `/posts/validate/*` routes, because the exemption is route-based
+        // (field-name-agnostic) rather than relying on the `hx-params` filter,
+        // which only strips the default `_submit_token` name.
+        let tmp = project_with_main(default_main());
+        // A customised field name in autumn.toml — the exemption must not depend
+        // on it.
+        fs::write(
+            tmp.path().join("autumn.toml"),
+            "[security.submit_token]\nfield_name = \"_confirm\"\n",
+        )
+        .unwrap();
+        let plan = plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &["title:String".into()],
+            "20260712000000",
+            &ScaffoldOptions {
+                live_validation: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let toml_action = plan
+            .actions
+            .iter()
+            .rev()
+            .find_map(|a| match a {
+                Action::Modify { path, contents } if path.ends_with("autumn.toml") => {
+                    Some(contents.clone())
+                }
+                _ => None,
+            })
+            .expect("live-validation scaffold must modify autumn.toml");
+        assert!(
+            toml_action.contains("\"/posts/validate\""),
+            "autumn.toml must exempt the validation route prefix:\n{toml_action}"
+        );
+        // The custom field name is left untouched.
+        assert!(
+            toml_action.contains("field_name = \"_confirm\""),
+            "{toml_action}"
+        );
+    }
+
+    #[test]
+    fn non_live_validation_scaffold_does_not_touch_autumn_toml_exempt() {
+        let tmp = project_with_main(default_main());
+        fs::write(tmp.path().join("autumn.toml"), "[server]\nport = 3000\n").unwrap();
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &["title:String".into()],
+            "20260712000000",
+        )
+        .unwrap();
+        let touches_toml = plan
+            .actions
+            .iter()
+            .any(|a| a.path().ends_with("autumn.toml"));
+        assert!(
+            !touches_toml,
+            "a plain scaffold (no --live-validation) must not add submit-token exemptions"
+        );
     }
 }

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -939,6 +939,8 @@ const ROUTES_FILE_RESERVED_NAMES: &[&str] = &[
     "Bytes",
     "CsrfFormField",
     "CsrfToken",
+    "SubmitFormField",
+    "SubmitToken",
     "PagerOptions",
     "Flash",
     "ShardedDb",
@@ -5552,70 +5554,49 @@ fn toml_table_block_range(lines: &[&str], header: &str) -> Option<(usize, usize)
 /// one), a table without an `exempt_paths` key (insert the key after the
 /// header), and a table whose `exempt_paths` array is merged in place.
 fn append_submit_token_validate_exempt_to_toml(existing: &str, plural: &str) -> Option<String> {
-    const HEADER: &str = "[security.submit_token]";
+    use toml_edit::{Array, DocumentMut, Item, Table, Value};
+
     let exempt = submit_token_validate_exempt_prefix(plural);
-    let quoted = format!("\"{exempt}\"");
 
-    let lines: Vec<&str> = existing.lines().collect();
-    let Some((start, end)) = toml_table_block_range(&lines, HEADER) else {
-        // No `[security.submit_token]` table yet — append a fresh one.
-        let mut out = existing.trim_end().to_owned();
-        if !out.is_empty() {
-            out.push_str("\n\n");
-        }
-        out.push_str(HEADER);
-        out.push('\n');
-        let _ = writeln!(out, "exempt_paths = [{quoted}]");
-        return Some(out);
-    };
+    // Parse format-preservingly so comments, ordering, and hand-crafted array
+    // layout survive the edit. A config we can't parse is left untouched (and we
+    // claim no ownership) rather than risking corruption via raw string edits.
+    let mut doc = existing.parse::<DocumentMut>().ok()?;
 
-    // The table exists. No-op if the prefix is already listed in the block —
-    // return `None` so we don't claim ownership of a preexisting entry.
-    if lines[start..end].iter().any(|l| l.contains(&quoted)) {
+    // Navigate to — creating if absent — `[security.submit_token]`. A freshly
+    // created `[security]` parent is marked implicit so it renders as the dotted
+    // `[security.submit_token]` header (matching the hand-written convention)
+    // rather than emitting a bare, empty `[security]` table of its own.
+    let security_missing = !doc.as_table().contains_key("security");
+    let security = doc
+        .as_table_mut()
+        .entry("security")
+        .or_insert_with(|| Item::Table(Table::new()))
+        .as_table_mut()?;
+    if security_missing {
+        security.set_implicit(true);
+    }
+    let submit_token = security
+        .entry("submit_token")
+        .or_insert_with(|| Item::Table(Table::new()))
+        .as_table_mut()?;
+
+    // Get or create the `exempt_paths` array.
+    let array = submit_token
+        .entry("exempt_paths")
+        .or_insert_with(|| Item::Value(Value::Array(Array::new())))
+        .as_array_mut()?;
+
+    // Idempotent: if the prefix is already listed, return `None` so we don't
+    // claim ownership of (and later, on `autumn destroy`, delete) a preexisting,
+    // user-owned exemption.
+    if array.iter().any(|v| v.as_str() == Some(exempt.as_str())) {
         return None;
     }
 
-    // Look for an existing `exempt_paths` key inside the block.
-    let key_pos = lines[start + 1..end]
-        .iter()
-        .position(|l| l.trim_start().starts_with("exempt_paths"))
-        .map(|rel| start + 1 + rel);
+    array.push(exempt.as_str());
 
-    let mut out_lines: Vec<String> = lines.iter().map(|l| (*l).to_owned()).collect();
-
-    if let Some(key_idx) = key_pos {
-        // Merge into the existing array. Find its closing `]` (arrays here don't
-        // nest) starting at the key line, collapsing a multi-line array to a
-        // single line if necessary — correctness over formatting for this
-        // uncommon hand-configured case.
-        let close_idx = (key_idx..end)
-            .find(|&i| lines[i].contains(']'))
-            .unwrap_or(key_idx);
-        let joined: String = lines[key_idx..=close_idx].join("\n");
-        let (Some(open), Some(close)) = (joined.find('['), joined.rfind(']')) else {
-            // The `exempt_paths` array is malformed (no `[`/`]` to splice into).
-            // Leave the file untouched and claim no ownership.
-            return None;
-        };
-        let inner = joined[open + 1..close].trim().trim_end_matches(',').trim();
-        let new_inner = if inner.is_empty() {
-            quoted
-        } else {
-            format!("{inner}, {quoted}")
-        };
-        let rebuilt = format!("{}[{new_inner}]{}", &joined[..open], &joined[close + 1..]);
-        out_lines.splice(key_idx..=close_idx, std::iter::once(rebuilt));
-    } else {
-        // Table present but no `exempt_paths` key — insert it right after the
-        // header line.
-        out_lines.insert(start + 1, format!("exempt_paths = [{quoted}]"));
-    }
-
-    let mut out = out_lines.join("\n");
-    if existing.ends_with('\n') && !out.ends_with('\n') {
-        out.push('\n');
-    }
-    Some(out)
+    Some(doc.to_string())
 }
 
 /// Inverse of [`append_submit_token_validate_exempt_to_toml`] (`autumn
@@ -6426,6 +6407,32 @@ async fn main() {
         // duplicate `Changeset`/`IntoChangeset` import fails with E0252,
         // exactly like the pre-existing `Path`/`ToString` collisions above.
         for field_name in ["changeset", "into_changeset"] {
+            let tmp = project_with_main(default_main());
+            let err = plan_scaffold(
+                tmp.path(),
+                "Post",
+                &[format!("{field_name}:enum{{a,b}}")],
+                "20260427000000",
+            )
+            .unwrap_err();
+            assert!(
+                matches!(err, GenerateError::InvalidField { .. }),
+                "expected '{field_name}' to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn scaffold_enum_field_named_submit_token_is_rejected() {
+        // `submit_token:enum{a,b}` pascalizes to `SubmitToken` and
+        // `submit_form_field:enum{a,b}` to `SubmitFormField`, colliding with the
+        // `use autumn_web::security::{…, SubmitFormField, SubmitToken};` import
+        // every non-`--api` scaffold's routes file now carries (issue #1360) — a
+        // duplicate `SubmitToken`/`SubmitFormField` import fails with E0252,
+        // exactly like the `CsrfToken`/`Changeset` collisions above. Rejecting
+        // the field up front yields the actionable field-name error instead of a
+        // broken generated file.
+        for field_name in ["submit_token", "submit_form_field"] {
             let tmp = project_with_main(default_main());
             let err = plan_scaffold(
                 tmp.path(),
@@ -10120,6 +10127,40 @@ async fn main() {
         assert!(out.contains("\"/webhooks/x\""), "{out}");
         assert!(out.contains("\"/posts/validate\""), "{out}");
         assert!(out.contains("ttl_secs = 900"), "{out}");
+        // No duplicate exempt_paths key.
+        assert_eq!(out.matches("exempt_paths").count(), 1, "{out}");
+    }
+
+    #[test]
+    fn submit_token_exempt_merges_into_commented_multiline_array() {
+        // A hand-edited, multiline `exempt_paths` array with item comments must
+        // merge into VALID TOML: the format-preserving edit inserts the new path
+        // as a real array element before the closing bracket, never splicing it
+        // after a `#` comment (which would produce e.g.
+        // `[..., # api, "/posts/validate"]` — invalid TOML that corrupts the
+        // config).
+        let existing = "\
+[security.submit_token]
+exempt_paths = [
+    \"/api\", # public api, never guarded
+    \"/webhooks/x\",
+]
+";
+        let out = append_submit_token_validate_exempt_to_toml(existing, "posts")
+            .expect("a new prefix must be merged into the commented array");
+        // The merged output is valid TOML.
+        let parsed: toml::Value =
+            toml::from_str(&out).unwrap_or_else(|e| panic!("merged TOML must parse: {e}\n{out}"));
+        // Both preexisting entries and the new prefix are present.
+        let paths = parsed["security"]["submit_token"]["exempt_paths"]
+            .as_array()
+            .expect("exempt_paths must be an array");
+        let values: Vec<&str> = paths.iter().filter_map(toml::Value::as_str).collect();
+        assert!(values.contains(&"/api"), "{out}");
+        assert!(values.contains(&"/webhooks/x"), "{out}");
+        assert!(values.contains(&"/posts/validate"), "{out}");
+        // The item comment survives the edit.
+        assert!(out.contains("# public api, never guarded"), "{out}");
         // No duplicate exempt_paths key.
         assert_eq!(out.matches("exempt_paths").count(), 1, "{out}");
     }

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1837,13 +1837,13 @@ fn render_routes_file(
     let create_signature = create_signature.replacen(
         "flash: Flash",
         "flash: Flash, csrf: Option<CsrfToken>, csrf_field: Option<CsrfFormField>, \
-         submit_token: Option<SubmitToken>",
+         submit_token: Option<SubmitToken>, submit_field: Option<SubmitFormField>",
         1,
     );
     let update_signature = update_signature.replacen(
         "flash: Flash,",
         "flash: Flash,\n    csrf: Option<CsrfToken>,\n    csrf_field: Option<CsrfFormField>,\n    \
-         submit_token: Option<SubmitToken>,",
+         submit_token: Option<SubmitToken>,\n    submit_field: Option<SubmitFormField>,",
         1,
     );
 
@@ -1949,7 +1949,7 @@ fn render_routes_file(
              h1 {{ \"New {pascal_name}\" }}\n        \
              form action=(paths::create()) method=\"post\"{form_enctype} {{\n            \
              (csrf_input(csrf.as_ref(), csrf_field.as_ref()))\n            \
-             (submit_token_input(submit_token.as_ref()))\n{changeset_inputs}            \
+             (submit_token_input(submit_token.as_ref(), submit_field.as_ref()))\n{changeset_inputs}            \
              button type=\"submit\" {{ \"Create\" }}\n        \
              }}\n    \
              }})"
@@ -1959,7 +1959,7 @@ fn render_routes_file(
              h1 {{ \"Edit {pascal_name} #\" (*id) }}\n        \
              form action=(paths::update(*id)) method=\"post\"{form_enctype} {{\n            \
              (csrf_input(csrf.as_ref(), csrf_field.as_ref()))\n            \
-             (submit_token_input(submit_token.as_ref()))\n{changeset_inputs}            \
+             (submit_token_input(submit_token.as_ref(), submit_field.as_ref()))\n{changeset_inputs}            \
              button type=\"submit\" {{ \"Save\" }}\n        \
              }}\n        \
              form action=(paths::delete(*id)) method=\"post\" {{\n            \
@@ -2002,13 +2002,13 @@ fn render_routes_file(
         let new_form_layout = format!(
             "{layout_fn}(\"New {pascal_name}\", {cp_new}{flash_arg}, html! {{\n        \
              h1 {{ \"New {pascal_name}\" }}\n        \
-             ({snake_name}_form_for(&changeset, paths::create(), \"Create\", csrf.as_ref(), csrf_field.as_ref(), submit_token.as_ref(){option_args}))\n    \
+             ({snake_name}_form_for(&changeset, paths::create(), \"Create\", csrf.as_ref(), csrf_field.as_ref(), submit_token.as_ref(), submit_field.as_ref(){option_args}))\n    \
              }})"
         );
         let edit_form_layout = format!(
             "{layout_fn}(&format!(\"Edit {pascal_name} #{{}}\", *id), {cp_edit}{flash_arg}, html! {{\n        \
              h1 {{ \"Edit {pascal_name} #\" (*id) }}\n        \
-             ({snake_name}_form_for(&changeset, paths::update(*id), \"Save\", csrf.as_ref(), csrf_field.as_ref(), submit_token.as_ref(){option_args}))\n        \
+             ({snake_name}_form_for(&changeset, paths::update(*id), \"Save\", csrf.as_ref(), csrf_field.as_ref(), submit_token.as_ref(), submit_field.as_ref(){option_args}))\n        \
              form action=(paths::delete(*id)) method=\"post\" {{\n            \
              (csrf_input(csrf.as_ref(), csrf_field.as_ref()))\n            \
              button type=\"submit\" onclick=\"return confirm('Delete this {pascal_name}?')\" {{ \"Delete\" }}\n        \
@@ -2594,7 +2594,7 @@ use autumn_web::extract::Path;
 use autumn_web::pagination::{{Page, PageRequest}};
 use autumn_web::reexports::axum::body::Bytes;
 use autumn_web::reexports::serde_json;
-use autumn_web::security::{{CsrfFormField, CsrfToken, SubmitToken}};
+use autumn_web::security::{{CsrfFormField, CsrfToken, SubmitFormField, SubmitToken}};
 use autumn_web::ui::pagination::{{PagerOptions, pagination_nav}};
 {db_import}
 use diesel::prelude::*;
@@ -2687,11 +2687,14 @@ fn csrf_input(csrf: Option<&CsrfToken>, field: Option<&CsrfFormField>) -> Markup
 
 /// Emit the hidden one-time submit-token field (issue #1360). Consumed once by
 /// the framework's `SubmitTokenLayer`, so a double-click or Back→resubmit
-/// replays the first response instead of creating a duplicate row.
-fn submit_token_input(submit_token: Option<&SubmitToken>) -> Markup {{
+/// replays the first response instead of creating a duplicate row. The field
+/// name follows `security.submit_token.field_name` (default `_submit_token`) so
+/// a customised name still matches what the layer scans for.
+fn submit_token_input(submit_token: Option<&SubmitToken>, field: Option<&SubmitFormField>) -> Markup {{
+    let submit_field_name = field.map(|field| field.0.as_str()).unwrap_or("_submit_token");
     html! {{
         @if let Some(submit_token) = submit_token {{
-            input type="hidden" name="_submit_token" value=(submit_token.token());
+            input type="hidden" name=(submit_field_name) value=(submit_token.token());
         }}
     }}
 }}
@@ -2726,6 +2729,7 @@ pub async fn new_form(
     csrf: Option<CsrfToken>,
     csrf_field: Option<CsrfFormField>,
     submit_token: Option<SubmitToken>,
+    submit_field: Option<SubmitFormField>,
 ) -> AutumnResult<Markup> {{
     let changeset = Changeset::new({pascal_name}Form::default());
     Ok({new_form_body})
@@ -2744,7 +2748,8 @@ pub async fn edit_form(
     flash: Flash,
     csrf: Option<CsrfToken>,
     csrf_field: Option<CsrfFormField>,
-    submit_token: Option<SubmitToken>,{authz_params}
+    submit_token: Option<SubmitToken>,
+    submit_field: Option<SubmitFormField>,{authz_params}
 ) -> AutumnResult<Markup> {{
     let row: {pascal_name} = {plural}::table
         .find(*id)
@@ -3111,12 +3116,13 @@ fn render_form_for_helper(
          submit_label: &str,\n    \
          csrf: Option<&CsrfToken>,\n    \
          csrf_field: Option<&CsrfFormField>,\n    \
-         submit_token: Option<&SubmitToken>{extra_params},\n\
+         submit_token: Option<&SubmitToken>,\n    \
+         submit_field: Option<&SubmitFormField>{extra_params},\n\
          ) -> Markup {{\n\
          {preludes}    \
          let mut form = autumn_web::form::form_for(changeset, action, \"post\")\n        \
          .submit_label(submit_label){builder_calls}{appends};\n    \
-         form = form.append(submit_token_input(submit_token));\n    \
+         form = form.append(submit_token_input(submit_token, submit_field));\n    \
          if let Some(csrf) = csrf {{\n        \
          form = form.csrf(csrf.token());\n    \
          }}\n    \
@@ -5779,7 +5785,9 @@ async fn main() {
         );
         // The helper call threads the options through.
         assert!(
-            routes.contains("csrf_field.as_ref(), submit_token.as_ref(), &post_id_options))"),
+            routes.contains(
+                "csrf_field.as_ref(), submit_token.as_ref(), submit_field.as_ref(), &post_id_options))"
+            ),
             "view bodies must pass the loaded options to the helper: {routes}"
         );
     }
@@ -6356,9 +6364,9 @@ async fn main() {
         plan.execute(Flags::default()).unwrap();
 
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
-        assert!(
-            routes.contains("use autumn_web::security::{CsrfFormField, CsrfToken, SubmitToken};")
-        );
+        assert!(routes.contains(
+            "use autumn_web::security::{CsrfFormField, CsrfToken, SubmitFormField, SubmitToken};"
+        ));
         assert!(routes.contains("fn csrf_input("));
         assert!(routes.contains("input type=\"hidden\" name=(csrf_field_name"));
         assert!(routes.contains("value=(csrf.token());"));
@@ -6368,14 +6376,24 @@ async fn main() {
         assert!(routes.contains("(csrf_input(csrf.as_ref(), csrf_field.as_ref()))"));
         assert!(routes.contains("pub async fn edit_form("));
         // Issue #1360: one-time submit token embedded in create/update forms and
-        // threaded through the create/update handlers.
+        // threaded through the create/update handlers. The hidden field's `name`
+        // is bound at runtime to the configured `security.submit_token.field_name`
+        // (via the `SubmitFormField` extractor), not hardcoded — mirroring CSRF —
+        // so a custom field name still matches what `SubmitTokenLayer` scans for.
         assert!(routes.contains("fn submit_token_input("));
         assert!(routes.contains(
-            "input type=\"hidden\" name=\"_submit_token\" value=(submit_token.token());"
+            "let submit_field_name = field.map(|field| field.0.as_str()).unwrap_or(\"_submit_token\");"
         ));
+        assert!(routes.contains(
+            "input type=\"hidden\" name=(submit_field_name) value=(submit_token.token());"
+        ));
+        // The hidden field is never emitted under a hardcoded `_submit_token` name.
+        assert!(!routes.contains("name=\"_submit_token\""));
         assert!(routes.contains("submit_token: Option<SubmitToken>"));
+        assert!(routes.contains("submit_field: Option<SubmitFormField>"));
         assert!(routes.contains("submit_token.as_ref()"));
-        assert!(routes.contains("submit_token_input(submit_token)"));
+        assert!(routes.contains("submit_field.as_ref()"));
+        assert!(routes.contains("submit_token_input(submit_token, submit_field)"));
     }
 
     // ── Changeset validation round-trip (issue #1124) ──────────────────
@@ -6615,12 +6633,12 @@ async fn main() {
             "generated routes must be able to inspect raw form bytes: {routes}"
         );
         assert!(
-            routes.contains("pub async fn create(flash: Flash, csrf: Option<CsrfToken>, csrf_field: Option<CsrfFormField>, submit_token: Option<SubmitToken>, mut db: Db, body: Bytes)"),
+            routes.contains("pub async fn create(flash: Flash, csrf: Option<CsrfToken>, csrf_field: Option<CsrfFormField>, submit_token: Option<SubmitToken>, submit_field: Option<SubmitFormField>, mut db: Db, body: Bytes)"),
             "create must decode after blank nullable normalization: {routes}"
         );
         assert!(
             routes.contains(
-                "pub async fn update(\n    flash: Flash,\n    csrf: Option<CsrfToken>,\n    csrf_field: Option<CsrfFormField>,\n    submit_token: Option<SubmitToken>,\n    id: Path<i64>,\n    mut db: Db,\n    body: Bytes,\n)"
+                "pub async fn update(\n    flash: Flash,\n    csrf: Option<CsrfToken>,\n    csrf_field: Option<CsrfFormField>,\n    submit_token: Option<SubmitToken>,\n    submit_field: Option<SubmitFormField>,\n    id: Path<i64>,\n    mut db: Db,\n    body: Bytes,\n)"
             ),
             "update must decode after blank nullable normalization: {routes}"
         );

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1836,12 +1836,14 @@ fn render_routes_file(
     // must come before it.
     let create_signature = create_signature.replacen(
         "flash: Flash",
-        "flash: Flash, csrf: Option<CsrfToken>, csrf_field: Option<CsrfFormField>",
+        "flash: Flash, csrf: Option<CsrfToken>, csrf_field: Option<CsrfFormField>, \
+         submit_token: Option<SubmitToken>",
         1,
     );
     let update_signature = update_signature.replacen(
         "flash: Flash,",
-        "flash: Flash,\n    csrf: Option<CsrfToken>,\n    csrf_field: Option<CsrfFormField>,",
+        "flash: Flash,\n    csrf: Option<CsrfToken>,\n    csrf_field: Option<CsrfFormField>,\n    \
+         submit_token: Option<SubmitToken>,",
         1,
     );
 
@@ -1946,7 +1948,8 @@ fn render_routes_file(
             "{layout_fn}(\"New {pascal_name}\", {cp_new}{flash_arg}, html! {{\n        \
              h1 {{ \"New {pascal_name}\" }}\n        \
              form action=(paths::create()) method=\"post\"{form_enctype} {{\n            \
-             (csrf_input(csrf.as_ref(), csrf_field.as_ref()))\n{changeset_inputs}            \
+             (csrf_input(csrf.as_ref(), csrf_field.as_ref()))\n            \
+             (submit_token_input(submit_token.as_ref()))\n{changeset_inputs}            \
              button type=\"submit\" {{ \"Create\" }}\n        \
              }}\n    \
              }})"
@@ -1955,7 +1958,8 @@ fn render_routes_file(
             "{layout_fn}(&format!(\"Edit {pascal_name} #{{}}\", *id), {cp_edit}{flash_arg}, html! {{\n        \
              h1 {{ \"Edit {pascal_name} #\" (*id) }}\n        \
              form action=(paths::update(*id)) method=\"post\"{form_enctype} {{\n            \
-             (csrf_input(csrf.as_ref(), csrf_field.as_ref()))\n{changeset_inputs}            \
+             (csrf_input(csrf.as_ref(), csrf_field.as_ref()))\n            \
+             (submit_token_input(submit_token.as_ref()))\n{changeset_inputs}            \
              button type=\"submit\" {{ \"Save\" }}\n        \
              }}\n        \
              form action=(paths::delete(*id)) method=\"post\" {{\n            \
@@ -1998,13 +2002,13 @@ fn render_routes_file(
         let new_form_layout = format!(
             "{layout_fn}(\"New {pascal_name}\", {cp_new}{flash_arg}, html! {{\n        \
              h1 {{ \"New {pascal_name}\" }}\n        \
-             ({snake_name}_form_for(&changeset, paths::create(), \"Create\", csrf.as_ref(), csrf_field.as_ref(){option_args}))\n    \
+             ({snake_name}_form_for(&changeset, paths::create(), \"Create\", csrf.as_ref(), csrf_field.as_ref(), submit_token.as_ref(){option_args}))\n    \
              }})"
         );
         let edit_form_layout = format!(
             "{layout_fn}(&format!(\"Edit {pascal_name} #{{}}\", *id), {cp_edit}{flash_arg}, html! {{\n        \
              h1 {{ \"Edit {pascal_name} #\" (*id) }}\n        \
-             ({snake_name}_form_for(&changeset, paths::update(*id), \"Save\", csrf.as_ref(), csrf_field.as_ref(){option_args}))\n        \
+             ({snake_name}_form_for(&changeset, paths::update(*id), \"Save\", csrf.as_ref(), csrf_field.as_ref(), submit_token.as_ref(){option_args}))\n        \
              form action=(paths::delete(*id)) method=\"post\" {{\n            \
              (csrf_input(csrf.as_ref(), csrf_field.as_ref()))\n            \
              button type=\"submit\" onclick=\"return confirm('Delete this {pascal_name}?')\" {{ \"Delete\" }}\n        \
@@ -2590,7 +2594,7 @@ use autumn_web::extract::Path;
 use autumn_web::pagination::{{Page, PageRequest}};
 use autumn_web::reexports::axum::body::Bytes;
 use autumn_web::reexports::serde_json;
-use autumn_web::security::{{CsrfFormField, CsrfToken}};
+use autumn_web::security::{{CsrfFormField, CsrfToken, SubmitToken}};
 use autumn_web::ui::pagination::{{PagerOptions, pagination_nav}};
 {db_import}
 use diesel::prelude::*;
@@ -2680,6 +2684,17 @@ fn csrf_input(csrf: Option<&CsrfToken>, field: Option<&CsrfFormField>) -> Markup
         }}
     }}
 }}
+
+/// Emit the hidden one-time submit-token field (issue #1360). Consumed once by
+/// the framework's `SubmitTokenLayer`, so a double-click or Back→resubmit
+/// replays the first response instead of creating a duplicate row.
+fn submit_token_input(submit_token: Option<&SubmitToken>) -> Markup {{
+    html! {{
+        @if let Some(submit_token) = submit_token {{
+            input type="hidden" name="_submit_token" value=(submit_token.token());
+        }}
+    }}
+}}
 {private_layout}
 {index_handler}
 
@@ -2710,6 +2725,7 @@ pub async fn new_form(
     {new_form_db_param}flash: Flash,
     csrf: Option<CsrfToken>,
     csrf_field: Option<CsrfFormField>,
+    submit_token: Option<SubmitToken>,
 ) -> AutumnResult<Markup> {{
     let changeset = Changeset::new({pascal_name}Form::default());
     Ok({new_form_body})
@@ -2727,7 +2743,8 @@ pub async fn edit_form(
     mut db: {db_ty},
     flash: Flash,
     csrf: Option<CsrfToken>,
-    csrf_field: Option<CsrfFormField>,{authz_params}
+    csrf_field: Option<CsrfFormField>,
+    submit_token: Option<SubmitToken>,{authz_params}
 ) -> AutumnResult<Markup> {{
     let row: {pascal_name} = {plural}::table
         .find(*id)
@@ -3093,11 +3110,13 @@ fn render_form_for_helper(
          action: String,\n    \
          submit_label: &str,\n    \
          csrf: Option<&CsrfToken>,\n    \
-         csrf_field: Option<&CsrfFormField>{extra_params},\n\
+         csrf_field: Option<&CsrfFormField>,\n    \
+         submit_token: Option<&SubmitToken>{extra_params},\n\
          ) -> Markup {{\n\
          {preludes}    \
          let mut form = autumn_web::form::form_for(changeset, action, \"post\")\n        \
          .submit_label(submit_label){builder_calls}{appends};\n    \
+         form = form.append(submit_token_input(submit_token));\n    \
          if let Some(csrf) = csrf {{\n        \
          form = form.csrf(csrf.token());\n    \
          }}\n    \
@@ -5760,7 +5779,7 @@ async fn main() {
         );
         // The helper call threads the options through.
         assert!(
-            routes.contains("csrf_field.as_ref(), &post_id_options))"),
+            routes.contains("csrf_field.as_ref(), submit_token.as_ref(), &post_id_options))"),
             "view bodies must pass the loaded options to the helper: {routes}"
         );
     }
@@ -6337,7 +6356,9 @@ async fn main() {
         plan.execute(Flags::default()).unwrap();
 
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
-        assert!(routes.contains("use autumn_web::security::{CsrfFormField, CsrfToken};"));
+        assert!(
+            routes.contains("use autumn_web::security::{CsrfFormField, CsrfToken, SubmitToken};")
+        );
         assert!(routes.contains("fn csrf_input("));
         assert!(routes.contains("input type=\"hidden\" name=(csrf_field_name"));
         assert!(routes.contains("value=(csrf.token());"));
@@ -6346,6 +6367,15 @@ async fn main() {
         assert!(routes.contains("csrf_field: Option<CsrfFormField>"));
         assert!(routes.contains("(csrf_input(csrf.as_ref(), csrf_field.as_ref()))"));
         assert!(routes.contains("pub async fn edit_form("));
+        // Issue #1360: one-time submit token embedded in create/update forms and
+        // threaded through the create/update handlers.
+        assert!(routes.contains("fn submit_token_input("));
+        assert!(routes.contains(
+            "input type=\"hidden\" name=\"_submit_token\" value=(submit_token.token());"
+        ));
+        assert!(routes.contains("submit_token: Option<SubmitToken>"));
+        assert!(routes.contains("submit_token.as_ref()"));
+        assert!(routes.contains("submit_token_input(submit_token)"));
     }
 
     // ── Changeset validation round-trip (issue #1124) ──────────────────
@@ -6585,12 +6615,12 @@ async fn main() {
             "generated routes must be able to inspect raw form bytes: {routes}"
         );
         assert!(
-            routes.contains("pub async fn create(flash: Flash, csrf: Option<CsrfToken>, csrf_field: Option<CsrfFormField>, mut db: Db, body: Bytes)"),
+            routes.contains("pub async fn create(flash: Flash, csrf: Option<CsrfToken>, csrf_field: Option<CsrfFormField>, submit_token: Option<SubmitToken>, mut db: Db, body: Bytes)"),
             "create must decode after blank nullable normalization: {routes}"
         );
         assert!(
             routes.contains(
-                "pub async fn update(\n    flash: Flash,\n    csrf: Option<CsrfToken>,\n    csrf_field: Option<CsrfFormField>,\n    id: Path<i64>,\n    mut db: Db,\n    body: Bytes,\n)"
+                "pub async fn update(\n    flash: Flash,\n    csrf: Option<CsrfToken>,\n    csrf_field: Option<CsrfFormField>,\n    submit_token: Option<SubmitToken>,\n    id: Path<i64>,\n    mut db: Db,\n    body: Bytes,\n)"
             ),
             "update must decode after blank nullable normalization: {routes}"
         );

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -898,14 +898,21 @@ pub fn plan_scaffold_with_options(
         let autumn_toml_path = project_root.join("autumn.toml");
         if autumn_toml_path.exists() {
             let toml_existing = read_or_empty(&autumn_toml_path);
-            let updated_toml = append_submit_token_validate_exempt_to_toml(&toml_existing, &plural);
-            if updated_toml != toml_existing {
+            // Only record the modify *and* the destroy-time revert when this
+            // scaffold actually inserts the exemption. If `/{plural}/validate`
+            // is already present (a preexisting, user-owned entry), the append
+            // is a no-op and returns `None`; recording a revert then would let a
+            // later `autumn destroy` delete an exemption we never added,
+            // re-enabling submit-token guarding on live-validation routes.
+            if let Some(updated_toml) =
+                append_submit_token_validate_exempt_to_toml(&toml_existing, &plural)
+            {
                 plan.modify(autumn_toml_path.clone(), updated_toml);
+                plan.push_revert(Revert::SubmitTokenValidateExempt {
+                    path: autumn_toml_path,
+                    plural,
+                });
             }
-            plan.push_revert(Revert::SubmitTokenValidateExempt {
-                path: autumn_toml_path,
-                plural,
-            });
         }
     }
 
@@ -5534,11 +5541,17 @@ fn toml_table_block_range(lines: &[&str], header: &str) -> Option<(usize, usize)
 /// create/update submit replay a validation fragment. Exempting the route makes
 /// it robust regardless of the configured field name.
 ///
-/// Idempotent: a no-op when the prefix is already present in the block. Handles
-/// three shapes — no `[security.submit_token]` table (append a fresh one), a
-/// table without an `exempt_paths` key (insert the key after the header), and a
-/// table whose `exempt_paths` array is merged in place.
-fn append_submit_token_validate_exempt_to_toml(existing: &str, plural: &str) -> String {
+/// Returns `Some(updated_toml)` only when it actually inserts the exemption, and
+/// `None` when the file is left unchanged — the prefix is already present, or
+/// the `exempt_paths` array is too malformed to parse. Callers must gate BOTH
+/// the plan's modify action AND the destroy-time ownership revert on `Some`:
+/// recording a revert for a no-op would let `autumn destroy` delete a
+/// preexisting, user-owned exemption we never added.
+///
+/// Handles three shapes — no `[security.submit_token]` table (append a fresh
+/// one), a table without an `exempt_paths` key (insert the key after the
+/// header), and a table whose `exempt_paths` array is merged in place.
+fn append_submit_token_validate_exempt_to_toml(existing: &str, plural: &str) -> Option<String> {
     const HEADER: &str = "[security.submit_token]";
     let exempt = submit_token_validate_exempt_prefix(plural);
     let quoted = format!("\"{exempt}\"");
@@ -5553,12 +5566,13 @@ fn append_submit_token_validate_exempt_to_toml(existing: &str, plural: &str) -> 
         out.push_str(HEADER);
         out.push('\n');
         let _ = writeln!(out, "exempt_paths = [{quoted}]");
-        return out;
+        return Some(out);
     };
 
-    // The table exists. Idempotent if the prefix is already listed in the block.
+    // The table exists. No-op if the prefix is already listed in the block —
+    // return `None` so we don't claim ownership of a preexisting entry.
     if lines[start..end].iter().any(|l| l.contains(&quoted)) {
-        return existing.to_owned();
+        return None;
     }
 
     // Look for an existing `exempt_paths` key inside the block.
@@ -5578,16 +5592,19 @@ fn append_submit_token_validate_exempt_to_toml(existing: &str, plural: &str) -> 
             .find(|&i| lines[i].contains(']'))
             .unwrap_or(key_idx);
         let joined: String = lines[key_idx..=close_idx].join("\n");
-        if let (Some(open), Some(close)) = (joined.find('['), joined.rfind(']')) {
-            let inner = joined[open + 1..close].trim().trim_end_matches(',').trim();
-            let new_inner = if inner.is_empty() {
-                quoted
-            } else {
-                format!("{inner}, {quoted}")
-            };
-            let rebuilt = format!("{}[{new_inner}]{}", &joined[..open], &joined[close + 1..]);
-            out_lines.splice(key_idx..=close_idx, std::iter::once(rebuilt));
-        }
+        let (Some(open), Some(close)) = (joined.find('['), joined.rfind(']')) else {
+            // The `exempt_paths` array is malformed (no `[`/`]` to splice into).
+            // Leave the file untouched and claim no ownership.
+            return None;
+        };
+        let inner = joined[open + 1..close].trim().trim_end_matches(',').trim();
+        let new_inner = if inner.is_empty() {
+            quoted
+        } else {
+            format!("{inner}, {quoted}")
+        };
+        let rebuilt = format!("{}[{new_inner}]{}", &joined[..open], &joined[close + 1..]);
+        out_lines.splice(key_idx..=close_idx, std::iter::once(rebuilt));
     } else {
         // Table present but no `exempt_paths` key — insert it right after the
         // header line.
@@ -5598,7 +5615,7 @@ fn append_submit_token_validate_exempt_to_toml(existing: &str, plural: &str) -> 
     if existing.ends_with('\n') && !out.ends_with('\n') {
         out.push('\n');
     }
-    out
+    Some(out)
 }
 
 /// Inverse of [`append_submit_token_validate_exempt_to_toml`] (`autumn
@@ -10071,7 +10088,8 @@ async fn main() {
     #[test]
     fn submit_token_exempt_appends_fresh_block_when_absent() {
         let existing = "[server]\nport = 3000\n";
-        let out = append_submit_token_validate_exempt_to_toml(existing, "posts");
+        let out = append_submit_token_validate_exempt_to_toml(existing, "posts")
+            .expect("absent exemption must be inserted");
         assert!(out.contains("[security.submit_token]"), "{out}");
         assert!(
             out.contains("exempt_paths = [\"/posts/validate\"]"),
@@ -10085,14 +10103,18 @@ async fn main() {
     fn submit_token_exempt_is_idempotent() {
         let existing = "[security.submit_token]\nexempt_paths = [\"/posts/validate\"]\n";
         let out = append_submit_token_validate_exempt_to_toml(existing, "posts");
-        assert_eq!(out, existing, "re-adding the same prefix must be a no-op");
+        assert_eq!(
+            out, None,
+            "re-adding the same prefix must be a no-op returning None"
+        );
     }
 
     #[test]
     fn submit_token_exempt_merges_into_existing_array() {
         let existing =
             "[security.submit_token]\nttl_secs = 900\nexempt_paths = [\"/webhooks/x\"]\n";
-        let out = append_submit_token_validate_exempt_to_toml(existing, "posts");
+        let out = append_submit_token_validate_exempt_to_toml(existing, "posts")
+            .expect("a new prefix must be merged into the existing array");
         assert!(out.contains("\"/webhooks/x\""), "{out}");
         assert!(out.contains("\"/posts/validate\""), "{out}");
         assert!(out.contains("ttl_secs = 900"), "{out}");
@@ -10103,7 +10125,8 @@ async fn main() {
     #[test]
     fn submit_token_exempt_inserts_key_when_block_lacks_it() {
         let existing = "[security.submit_token]\nttl_secs = 900\n";
-        let out = append_submit_token_validate_exempt_to_toml(existing, "posts");
+        let out = append_submit_token_validate_exempt_to_toml(existing, "posts")
+            .expect("a block lacking the key must gain one");
         assert!(
             out.contains("exempt_paths = [\"/posts/validate\"]"),
             "{out}"
@@ -10125,7 +10148,8 @@ async fn main() {
     #[test]
     fn remove_submit_token_exempt_drops_fresh_block() {
         let existing = "[server]\nport = 3000\n";
-        let added = append_submit_token_validate_exempt_to_toml(existing, "posts");
+        let added = append_submit_token_validate_exempt_to_toml(existing, "posts")
+            .expect("fresh block must be added");
         let removed = remove_submit_token_validate_exempt_from_toml(&added, "posts");
         assert!(!removed.contains("/posts/validate"), "{removed}");
         assert!(!removed.contains("[security.submit_token]"), "{removed}");
@@ -10217,6 +10241,92 @@ async fn main() {
         assert!(
             !touches_toml,
             "a plain scaffold (no --live-validation) must not add submit-token exemptions"
+        );
+    }
+
+    #[test]
+    fn live_validation_scaffold_records_revert_only_when_exemption_inserted() {
+        // Absent exemption: the scaffold both modifies autumn.toml AND records a
+        // `SubmitTokenValidateExempt` revert so `autumn destroy` cleans up the
+        // entry it added.
+        let tmp = project_with_main(default_main());
+        fs::write(
+            tmp.path().join("autumn.toml"),
+            "[security.submit_token]\nfield_name = \"_confirm\"\n",
+        )
+        .unwrap();
+        let plan = plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &["title:String".into()],
+            "20260712000000",
+            &ScaffoldOptions {
+                live_validation: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let touches_toml = plan
+            .actions
+            .iter()
+            .any(|a| a.path().ends_with("autumn.toml"));
+        assert!(
+            touches_toml,
+            "an absent exemption must be inserted via a modify action"
+        );
+        let has_revert = plan.reverts.iter().any(|r| {
+            matches!(
+                r,
+                Revert::SubmitTokenValidateExempt { plural, .. } if plural == "posts"
+            )
+        });
+        assert!(
+            has_revert,
+            "inserting the exemption must record a SubmitTokenValidateExempt revert"
+        );
+    }
+
+    #[test]
+    fn live_validation_scaffold_skips_revert_when_exemption_preexists() {
+        // The exemption is ALREADY present (e.g. a user hand-added it, possibly
+        // with a custom field name). The scaffold must NOT modify autumn.toml and
+        // must NOT record a revert — otherwise a later `autumn destroy` would
+        // delete a user-owned entry, re-enabling submit-token guarding on the
+        // live-validation routes.
+        let tmp = project_with_main(default_main());
+        fs::write(
+            tmp.path().join("autumn.toml"),
+            "[security.submit_token]\nfield_name = \"_confirm\"\nexempt_paths = [\"/posts/validate\"]\n",
+        )
+        .unwrap();
+        let plan = plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &["title:String".into()],
+            "20260712000000",
+            &ScaffoldOptions {
+                live_validation: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let touches_toml = plan
+            .actions
+            .iter()
+            .any(|a| a.path().ends_with("autumn.toml"));
+        assert!(
+            !touches_toml,
+            "a preexisting exemption must not be re-modified"
+        );
+        let has_revert = plan
+            .reverts
+            .iter()
+            .any(|r| matches!(r, Revert::SubmitTokenValidateExempt { .. }));
+        assert!(
+            !has_revert,
+            "a preexisting, user-owned exemption must not be claimed via a revert"
         );
     }
 }

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -3122,7 +3122,11 @@ fn render_form_for_helper(
          {preludes}    \
          let mut form = autumn_web::form::form_for(changeset, action, \"post\")\n        \
          .submit_label(submit_label){builder_calls}{appends};\n    \
-         form = form.append(submit_token_input(submit_token, submit_field));\n    \
+         // Emit the one-time submit token at the FRONT of the form (issue #1360):\n    \
+         // `SubmitTokenLayer` only scans the first chunk of the URL-encoded body,\n    \
+         // so a large earlier textarea could otherwise push an appended token past\n    \
+         // the scan cap and leave duplicate submits unguarded.\n    \
+         form = form.prepend(submit_token_input(submit_token, submit_field));\n    \
          if let Some(csrf) = csrf {{\n        \
          form = form.csrf(csrf.token());\n    \
          }}\n    \
@@ -3611,9 +3615,13 @@ fn html5_constraint_spec(field: &Field) -> Option<(&'static str, String)> {
 /// (`minlength`/`maxlength`/`min`/`max`/`step`) from [`html5_constraint_spec`],
 /// exactly mirroring the standard `form_for` path's `.exclude()` + `.append()`
 /// output. When `validate_url` is `Some`, the htmx inline-validation wiring
-/// (`hx-post`/`hx-trigger`/`hx-target`/`hx-swap`/`hx-include` + the
-/// `data-autumn-field-wrapper` swap marker) is threaded on too, matching
-/// `required_text_input_htmx`. Shared by [`render_changeset_form_inputs`] and
+/// (`hx-post`/`hx-trigger`/`hx-target`/`hx-swap`/`hx-include` +
+/// `hx-params="not _submit_token"` + the `data-autumn-field-wrapper` swap
+/// marker) is threaded on too, matching `required_text_input_htmx`. The
+/// `hx-params` filter keeps the inline-validation POST (which `hx-include`s the
+/// whole form) from carrying the one-time `_submit_token`, so validation never
+/// consumes the token the real create/update submit needs (issue #1360). Shared
+/// by [`render_changeset_form_inputs`] and
 /// the inline-validate handlers so the initially-rendered field and the
 /// htmx-swapped fragment are byte-identical.
 fn render_live_constrained_field(
@@ -3650,7 +3658,8 @@ fn render_live_constrained_field(
                     "\n                    hx-post=({url})\n                    \
                      hx-trigger=\"change\"\n                    \
                      hx-target=\"closest [data-autumn-field-wrapper]\"\n                    \
-                     hx-swap=\"outerHTML\"\n                    hx-include=\"closest form\""
+                     hx-swap=\"outerHTML\"\n                    hx-include=\"closest form\"\n                    \
+                     hx-params=\"not _submit_token\""
                 ),
             )
         },
@@ -6394,6 +6403,19 @@ async fn main() {
         assert!(routes.contains("submit_token.as_ref()"));
         assert!(routes.contains("submit_field.as_ref()"));
         assert!(routes.contains("submit_token_input(submit_token, submit_field)"));
+        // Issue #1360 (finding G): the token must be emitted at the FRONT of the
+        // form via `.prepend(...)`, not appended after the derived fields —
+        // `SubmitTokenLayer` only scans the first chunk of the URL-encoded body,
+        // so a large earlier field could otherwise push an appended token past
+        // the scan cap and leave duplicate submits unguarded.
+        assert!(
+            routes.contains("form.prepend(submit_token_input(submit_token, submit_field))"),
+            "standard form must prepend the submit token, not append it:\n{routes}"
+        );
+        assert!(
+            !routes.contains("form.append(submit_token_input"),
+            "submit token must not be appended after derived fields:\n{routes}"
+        );
     }
 
     // ── Changeset validation round-trip (issue #1124) ──────────────────
@@ -6561,6 +6583,64 @@ async fn main() {
         assert!(
             !routes.contains(r#"input type="text" name="title""#),
             "standard fields must no longer be hand-rolled: {routes}"
+        );
+    }
+
+    #[test]
+    fn execute_live_validation_inline_posts_drop_the_submit_token() {
+        // Finding F (issue #1360): a `--live-validation` field posts its inline
+        // validation with `hx-include="closest form"`, so that POST would carry
+        // the hidden one-time `_submit_token` to the guarded `/validate/...`
+        // route and consume it — the real create submit would then replay the
+        // validation fragment instead of running the mutation. The generated
+        // htmx input must drop the token via `hx-params="not _submit_token"`,
+        // while the real create/update form still embeds it.
+        let tmp = project_with_main(default_main());
+        // A DSL-constrained `String` auto-derives a `length` rule, so `title` is
+        // validated and renders through the raw-markup htmx constrained control.
+        let plan = plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &["title:String{min=3,max=120}".into()],
+            "20260427000000",
+            &ScaffoldOptions {
+                live_validation: true,
+                ..ScaffoldOptions::default()
+            },
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+
+        // The constrained validated input keeps its inline-validation wiring...
+        assert!(
+            routes.contains("hx-post=\"/posts/validate/title\""),
+            "title must keep its htmx inline-validation wiring:\n{routes}"
+        );
+        // ...but filters the one-time submit token out of that POST so the
+        // inline validation never consumes it.
+        assert!(
+            routes.contains("hx-params=\"not _submit_token\""),
+            "live-validation inputs must drop _submit_token from the inline POST:\n{routes}"
+        );
+        // The inline-validate handler returns the SAME fragment (byte-identical
+        // for the htmx `outerHTML` swap), so it must carry the filter too.
+        let validate_title = &routes[routes
+            .find("pub async fn validate_title(")
+            .expect("validate_title handler")..];
+        assert!(
+            validate_title[..validate_title[1..]
+                .find("#[post(")
+                .map_or(validate_title.len(), |rel| rel + 1)]
+                .contains("hx-params=\"not _submit_token\""),
+            "the validate_title fragment must also drop the submit token:\n{validate_title}"
+        );
+        // The real create/update form still embeds the submit token so the
+        // mutation stays guarded against duplicate submits.
+        assert!(
+            routes.contains("submit_token_input(submit_token.as_ref(), submit_field.as_ref())"),
+            "the create/update form must still carry the submit token:\n{routes}"
         );
     }
 

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -778,9 +778,13 @@ fn generate_scaffold_full_e2e_post() {
         "pub async fn show",
         "pub async fn new_form(",
         "pub async fn update",
-        "use autumn_web::security::{CsrfFormField, CsrfToken};",
+        "use autumn_web::security::{CsrfFormField, CsrfToken, SubmitToken};",
         "input type=\"hidden\" name=(csrf_field_name)",
         "(csrf_input(csrf.as_ref(), csrf_field.as_ref()))",
+        // Issue #1360: one-time submit token wired into create/update forms.
+        "fn submit_token_input(",
+        "input type=\"hidden\" name=\"_submit_token\" value=(submit_token.token());",
+        "submit_token: Option<SubmitToken>",
     ] {
         assert!(routes.contains(needle), "routes file missing: {needle}");
     }
@@ -2748,7 +2752,7 @@ fn generate_scaffold_without_unique_field_omits_unique_constraints() {
     assert!(!routes.contains("UNIQUE_CONSTRAINTS"), "got:\n{routes}");
     assert!(
         routes.contains(
-            "pub async fn create(flash: Flash, csrf: Option<CsrfToken>, csrf_field: Option<CsrfFormField>, mut db: Db, body: Bytes) -> AutumnResult<autumn_web::reexports::axum::response::Response>"
+            "pub async fn create(flash: Flash, csrf: Option<CsrfToken>, csrf_field: Option<CsrfFormField>, submit_token: Option<SubmitToken>, mut db: Db, body: Bytes) -> AutumnResult<autumn_web::reexports::axum::response::Response>"
         ),
         "got:\n{routes}"
     );

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -778,12 +778,15 @@ fn generate_scaffold_full_e2e_post() {
         "pub async fn show",
         "pub async fn new_form(",
         "pub async fn update",
-        "use autumn_web::security::{CsrfFormField, CsrfToken, SubmitToken};",
+        "use autumn_web::security::{CsrfFormField, CsrfToken, SubmitFormField, SubmitToken};",
         "input type=\"hidden\" name=(csrf_field_name)",
         "(csrf_input(csrf.as_ref(), csrf_field.as_ref()))",
         // Issue #1360: one-time submit token wired into create/update forms.
+        // The hidden field name follows the configured
+        // `security.submit_token.field_name` (via the `SubmitFormField`
+        // extractor), not a hardcoded `_submit_token`.
         "fn submit_token_input(",
-        "input type=\"hidden\" name=\"_submit_token\" value=(submit_token.token());",
+        "input type=\"hidden\" name=(submit_field_name) value=(submit_token.token());",
         "submit_token: Option<SubmitToken>",
     ] {
         assert!(routes.contains(needle), "routes file missing: {needle}");
@@ -2752,7 +2755,7 @@ fn generate_scaffold_without_unique_field_omits_unique_constraints() {
     assert!(!routes.contains("UNIQUE_CONSTRAINTS"), "got:\n{routes}");
     assert!(
         routes.contains(
-            "pub async fn create(flash: Flash, csrf: Option<CsrfToken>, csrf_field: Option<CsrfFormField>, submit_token: Option<SubmitToken>, mut db: Db, body: Bytes) -> AutumnResult<autumn_web::reexports::axum::response::Response>"
+            "pub async fn create(flash: Flash, csrf: Option<CsrfToken>, csrf_field: Option<CsrfFormField>, submit_token: Option<SubmitToken>, submit_field: Option<SubmitFormField>, mut db: Db, body: Bytes) -> AutumnResult<autumn_web::reexports::axum::response::Response>"
         ),
         "got:\n{routes}"
     );

--- a/autumn-cli/tests/integration/scaffold_validation.rs
+++ b/autumn-cli/tests/integration/scaffold_validation.rs
@@ -483,6 +483,21 @@ fn live_validation_forms_carry_html5_constraints() {
         "the constrained title input must keep its htmx inline-validation wiring (via typed path helper):\n{routes}"
     );
 
+    // Issue #1360 (finding F): the inline-validation POST `hx-include`s the whole
+    // form, which carries the hidden one-time `_submit_token`. Without a filter
+    // the first field validation would consume the token on the guarded
+    // `/validate/...` route, and the real create submit would replay the
+    // validation fragment instead of running the mutation. The htmx input must
+    // drop the token via `hx-params`, while the real create form keeps it.
+    assert!(
+        routes.contains("hx-params=\"not _submit_token\""),
+        "live-validation inputs must drop _submit_token from the inline POST:\n{routes}"
+    );
+    assert!(
+        routes.contains("submit_token_input(submit_token.as_ref(), submit_field.as_ref())"),
+        "the create/update form must still carry the submit token:\n{routes}"
+    );
+
     // The inline-validate handler returns the SAME constrained fragment, so the
     // swapped-in field doesn't drop the client-side attributes on first change.
     let validate_title = slice_fn(&routes, "pub async fn validate_title(");

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -886,10 +886,17 @@ pub fn text_input<T: Serialize>(
 /// Render a labeled `<input type="text">` with htmx inline-validation attributes.
 ///
 /// Like [`text_input`] but adds `hx-post`, `hx-trigger="change"`,
-/// `hx-target="closest [data-autumn-field-wrapper]"`, `hx-swap="outerHTML"`, and
-/// `hx-include="closest form"` to the input element so htmx
-/// POSTs the whole form to `validate_url` after a changed value is committed
-/// and swaps the returned field wrapper in place — no JavaScript required.
+/// `hx-target="closest [data-autumn-field-wrapper]"`, `hx-swap="outerHTML"`,
+/// `hx-include="closest form"`, and `hx-params="not _submit_token"` to the input
+/// element so htmx POSTs the whole form to `validate_url` after a changed value
+/// is committed and swaps the returned field wrapper in place — no JavaScript
+/// required.
+///
+/// The `hx-params="not _submit_token"` filter drops the hidden one-time
+/// submit-token field (issue #1360) from the inline-validation POST: `SubmitTokenLayer`
+/// consumes any `_submit_token` a mutating POST carries, so without this filter
+/// the first field validation would spend the token and the real create/update
+/// submit would replay the validation fragment instead of running the mutation.
 ///
 /// The inline-validation handler should extract [`ChangesetForm<T>`],
 /// validate, and return `text_input_htmx(...)` for just the single field.
@@ -936,7 +943,8 @@ pub fn text_input_htmx<T: Serialize>(
                 hx-trigger="change"
                 hx-target=(target)
                 hx-swap="outerHTML"
-                hx-include="closest form";
+                hx-include="closest form"
+                hx-params="not _submit_token";
             @if has_errors {
                 div id=(error_id) role="alert" class="autumn-field__errors" {
                     @for error in errors {
@@ -988,7 +996,8 @@ pub fn required_text_input_htmx<T: Serialize>(
                 hx-trigger="change"
                 hx-target=(target)
                 hx-swap="outerHTML"
-                hx-include="closest form";
+                hx-include="closest form"
+                hx-params="not _submit_token";
             @if has_errors {
                 div id=(error_id) role="alert" class="autumn-field__errors" {
                     @for error in errors {
@@ -2237,6 +2246,7 @@ where
         excluded: Vec::new(),
         field_overrides: Vec::new(),
         label_overrides: Vec::new(),
+        prepended: Vec::new(),
         appended: Vec::new(),
         submit_label: "Save".to_string(),
         force_multipart: false,
@@ -2255,6 +2265,7 @@ pub struct FormFor<'a, T: Serialize + FormModel> {
     excluded: Vec<String>,
     field_overrides: Vec<(String, FieldControl)>,
     label_overrides: Vec<(String, String)>,
+    prepended: Vec<maud::Markup>,
     appended: Vec<maud::Markup>,
     submit_label: String,
     force_multipart: bool,
@@ -2306,6 +2317,20 @@ impl<T: Serialize + FormModel> FormFor<'_, T> {
         self
     }
 
+    /// Insert extra markup at the front of the form, immediately after the
+    /// hidden CSRF/method-override inputs and before every derived field.
+    ///
+    /// Use this for hidden control fields — such as a one-time
+    /// `_submit_token` — that a body-scanning middleware must find near the
+    /// start of the URL-encoded body. A large earlier field (e.g. a long
+    /// `<textarea>`) would otherwise push an appended token past the scan cap,
+    /// leaving the request effectively token-less.
+    #[must_use]
+    pub fn prepend(mut self, markup: maud::Markup) -> Self {
+        self.prepended.push(markup);
+        self
+    }
+
     /// Override the submit button label (default `"Save"`).
     #[must_use]
     pub fn submit_label(mut self, label: impl Into<String>) -> Self {
@@ -2333,6 +2358,7 @@ impl<T: Serialize + FormModel> FormFor<'_, T> {
             excluded,
             field_overrides,
             label_overrides,
+            prepended,
             appended,
             submit_label,
             force_multipart,
@@ -2345,6 +2371,9 @@ impl<T: Serialize + FormModel> FormFor<'_, T> {
                 .any(|f| matches!(f.control, FieldControl::File));
 
         let inner = maud::html! {
+            @for markup in prepended {
+                (markup)
+            }
             @for field in &fields {
                 (render_form_field(changeset, field))
             }
@@ -3520,6 +3549,34 @@ mod tests {
 
     #[cfg(feature = "maud")]
     #[test]
+    fn text_input_htmx_drops_submit_token_param() {
+        // The inline-validation POST `hx-include`s the whole form, which carries
+        // the hidden one-time `_submit_token` (issue #1360). `SubmitTokenLayer`
+        // consumes any `_submit_token` a mutating POST carries, so validation
+        // must filter it out via `hx-params` — otherwise the first field
+        // validation spends the token and the real submit replays the fragment.
+        #[derive(serde::Serialize)]
+        struct F {
+            name: String,
+        }
+        let cs = Changeset::new(F {
+            name: String::new(),
+        });
+        let plain = text_input_htmx(&cs, "name", "Name", "/validate/name").into_string();
+        assert!(
+            plain.contains(r#"hx-params="not _submit_token""#),
+            "{plain}"
+        );
+        let required =
+            required_text_input_htmx(&cs, "name", "Name", "/validate/name").into_string();
+        assert!(
+            required.contains(r#"hx-params="not _submit_token""#),
+            "{required}"
+        );
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
     fn text_input_htmx_valid_state_no_error_markup() {
         #[derive(serde::Serialize)]
         struct F {
@@ -4486,6 +4543,30 @@ mod tests {
             .find(r#"type="submit""#)
             .expect("submit button missing");
         assert!(append_idx < submit_idx, "{html}");
+    }
+
+    #[cfg(feature = "maud")]
+    #[test]
+    fn form_for_prepend_inserts_before_fields() {
+        // A prepended hidden field (e.g. a one-time submit token, issue #1360)
+        // must render at the FRONT of the form — after the CSRF input but before
+        // every derived field — so a body-scanning middleware finds it even when
+        // an earlier field carries a large value.
+        let cs = Changeset::new(blank_form_for_model());
+        let html = form_for(&cs, "/posts", "post")
+            .csrf("tok")
+            .prepend(maud::html! { input type="hidden" name="_submit_token" value="st"; })
+            .render()
+            .into_string();
+        let csrf_idx = html.find(r#"name="_csrf""#).expect("csrf input missing");
+        let prepend_idx = html
+            .find(r#"name="_submit_token""#)
+            .expect("prepend markup missing");
+        let first_field_idx = html.find(r#"name="title""#).expect("derived field missing");
+        assert!(
+            csrf_idx < prepend_idx && prepend_idx < first_field_idx,
+            "prepended token must sit after csrf and before the first derived field: {html}"
+        );
     }
 
     #[cfg(feature = "maud")]

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -898,6 +898,19 @@ pub fn text_input<T: Serialize>(
 /// the first field validation would spend the token and the real create/update
 /// submit would replay the validation fragment instead of running the mutation.
 ///
+/// # Custom `field_name` limitation
+///
+/// The `hx-params` filter hardcodes the **default** field name `_submit_token`.
+/// It excludes only that default from inline htmx validation posts. If you
+/// customize `[security.submit_token].field_name` **and** hand-write a
+/// live-validation form using these helpers, the filter will not exclude your
+/// custom field, so the token leaks into the validation POST and
+/// `SubmitTokenLayer` consumes it. Add your validation route(s) to
+/// `[security.submit_token].exempt_paths` so the one-time token is not consumed
+/// by validation requests. Generated scaffolds keep the default field name and
+/// wire their validation routes into `exempt_paths` automatically, so this only
+/// affects hand-written forms with a customized `field_name`.
+///
 /// The inline-validation handler should extract [`ChangesetForm<T>`],
 /// validate, and return `text_input_htmx(...)` for just the single field.
 ///
@@ -964,6 +977,12 @@ pub fn text_input_htmx<T: Serialize>(
 /// client-side "must fill this in" signal, and a server-side rule that
 /// happens to permit an empty string (e.g. a max-only `length` rule) would
 /// let a blank required field through silently.
+///
+/// Like [`text_input_htmx`], the emitted `hx-params="not _submit_token"` filter
+/// hardcodes the **default** submit-token field name. See
+/// [`text_input_htmx`](text_input_htmx#custom-field_name-limitation) for the
+/// custom `[security.submit_token].field_name` caveat and the `exempt_paths`
+/// workaround for hand-written live-validation forms.
 #[cfg(feature = "maud")]
 #[must_use]
 pub fn required_text_input_htmx<T: Serialize>(

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -41,6 +41,12 @@ pub enum RouterBuildError {
     #[error("invalid idempotency backend configuration: {0}")]
     #[allow(dead_code)] // constructed only in the `redis` feature path
     InvalidIdempotencyBackend(String),
+    /// The submit-token backend configuration is invalid for production — an
+    /// explicit `[security.submit_token].backend = "memory"` cannot safely
+    /// deduplicate submits across replicas. Mirrors the idempotency
+    /// production-memory fail-fast.
+    #[error("invalid submit-token backend configuration: {0}")]
+    InvalidSubmitTokenBackend(String),
     /// A user-defined route conflicts with a framework-provided route.
     #[error("framework route overlap at {path}: {existing} conflicts with {incoming}")]
     FrameworkRouteOverlap {
@@ -2199,6 +2205,7 @@ where
 fn apply_submit_token_middleware<S>(
     mut router: axum::Router<S>,
     config: &AutumnConfig,
+    is_production: bool,
 ) -> Result<axum::Router<S>, RouterBuildError>
 where
     S: Clone + Send + Sync + 'static,
@@ -2206,6 +2213,37 @@ where
     let cfg = &config.security.submit_token;
     if !cfg.enabled {
         return Ok(router);
+    }
+
+    // Production guard for the resolved consumed-token backend. Submit tokens
+    // are DEFAULT-ON, so the resolved backend can land on the per-process memory
+    // store in production — which cannot deduplicate submits across replicas.
+    // Mirrors the idempotency production-memory guard
+    // (`fail_fast_on_invalid_idempotency_config`): an EXPLICIT
+    // `[security.submit_token].backend = "memory"` in prod fails fast, while an
+    // INHERITED default only warns so upgrading Autumn never becomes
+    // "prod won't boot without Redis".
+    match cfg.production_memory_guard(config.idempotency.backend, is_production) {
+        crate::security::config::SubmitTokenMemoryGuard::Ok => {}
+        crate::security::config::SubmitTokenMemoryGuard::WarnInherited => {
+            tracing::warn!(
+                "[security.submit_token].backend resolved to the in-memory store in production \
+                 (inherited from [idempotency].backend, which is unset or memory). \
+                 Single-replica deployments are fine, but multi-replica deployments need a shared \
+                 backend: configure [idempotency] with backend = \"redis\" (or set \
+                 [security.submit_token].backend = \"redis\") so consumed tokens are shared across \
+                 replicas — otherwise a duplicate submit can slip through on a different replica."
+            );
+        }
+        crate::security::config::SubmitTokenMemoryGuard::FailExplicit => {
+            return Err(RouterBuildError::InvalidSubmitTokenBackend(
+                "the in-memory submit-token backend is not safe for multi-replica production use. \
+                 Set `[security.submit_token].backend = \"redis\"` in autumn.toml (it reuses the \
+                 [idempotency.redis] connection settings), or remove the explicit `backend` \
+                 override to inherit `[idempotency].backend`."
+                    .to_owned(),
+            ));
+        }
     }
 
     let ttl = Duration::from_secs(cfg.ttl_secs);
@@ -2848,7 +2886,7 @@ fn apply_middleware(
     // Applied before (i.e. inner to) the CSRF layer so CSRF is validated first
     // on the request path; a replayed `_submit_token` is still short-circuited
     // even when the request carries a valid `_csrf` (issue #1360, AC #4).
-    router = apply_submit_token_middleware(router, config)?;
+    router = apply_submit_token_middleware(router, config, is_production)?;
     router = apply_csrf_middleware(router, config, signing_keys_opt.clone());
     router = apply_bot_protection_middleware(router, config);
     // Method-override rejection filter. The outer `MethodOverrideLayer`
@@ -4290,6 +4328,42 @@ mod tests {
             clock: std::sync::Arc::new(crate::time::SystemClock),
             app_id: crate::state::AppState::next_app_id(),
         }
+    }
+
+    // ── submit-token production memory guard wiring (Finding O) ─────────────
+
+    #[test]
+    fn submit_token_explicit_memory_in_production_fails_router_build() {
+        // EXPLICIT `[security.submit_token].backend = "memory"` + production →
+        // hard fail at router build, mirroring the idempotency prod-memory guard.
+        let mut config = AutumnConfig::default();
+        config.security.submit_token.backend = Some(crate::config::IdempotencyBackend::Memory);
+        let err = apply_submit_token_middleware(axum::Router::<()>::new(), &config, true)
+            .expect_err("explicit memory submit-token backend in prod must fail router build");
+        assert!(
+            matches!(err, RouterBuildError::InvalidSubmitTokenBackend(_)),
+            "expected InvalidSubmitTokenBackend, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn submit_token_inherited_memory_in_production_builds() {
+        // INHERITED default (`backend = None`) resolving to Memory in prod must
+        // NOT fail — it only warns. Router build succeeds.
+        let mut config = AutumnConfig::default();
+        config.security.submit_token.backend = None;
+        config.idempotency.backend = crate::config::IdempotencyBackend::Memory;
+        let _router = apply_submit_token_middleware(axum::Router::<()>::new(), &config, true)
+            .expect("inherited memory submit-token backend in prod must still build (warn only)");
+    }
+
+    #[test]
+    fn submit_token_memory_outside_production_builds() {
+        // Non-production → no fail regardless of explicit memory.
+        let mut config = AutumnConfig::default();
+        config.security.submit_token.backend = Some(crate::config::IdempotencyBackend::Memory);
+        let _router = apply_submit_token_middleware(axum::Router::<()>::new(), &config, false)
+            .expect("memory submit-token backend outside production must build");
     }
 
     #[tokio::test]

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -2188,6 +2188,66 @@ where
     router
 }
 
+/// Apply the one-time submit-token guard (issue #1360).
+///
+/// Enabled by default. The layer is applied *inner* to the CSRF layer (it is
+/// registered before `apply_csrf_middleware`, so on the request path CSRF is
+/// validated first): a request bearing a valid `_csrf` but an already-consumed
+/// `_submit_token` is still short-circuited by this guard. The store backend
+/// mirrors [`build_idempotency_layers`]; the `redis` backend reuses the
+/// `[idempotency.redis]` connection settings.
+fn apply_submit_token_middleware<S>(
+    mut router: axum::Router<S>,
+    config: &AutumnConfig,
+) -> Result<axum::Router<S>, RouterBuildError>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    let cfg = &config.security.submit_token;
+    if !cfg.enabled {
+        return Ok(router);
+    }
+
+    let ttl = Duration::from_secs(cfg.ttl_secs);
+    let store: std::sync::Arc<dyn IdempotencyStore> = match cfg.backend {
+        crate::config::IdempotencyBackend::Memory => {
+            std::sync::Arc::new(MemoryIdempotencyStore::new(ttl))
+        }
+        #[cfg(feature = "redis")]
+        crate::config::IdempotencyBackend::Redis => {
+            match crate::idempotency::RedisIdempotencyStore::from_config(&config.idempotency) {
+                Ok(s) => std::sync::Arc::new(s),
+                Err(e) => return Err(RouterBuildError::InvalidIdempotencyBackend(e)),
+            }
+        }
+        #[cfg(not(feature = "redis"))]
+        crate::config::IdempotencyBackend::Redis => {
+            return Err(RouterBuildError::InvalidIdempotencyBackend(
+                "submit_token backend 'redis' requires the autumn-web 'redis' feature \
+                 flag; rebuild with --features redis or switch to backend = \"memory\""
+                    .to_owned(),
+            ));
+        }
+    };
+
+    let mut layer = crate::security::SubmitTokenLayer::new(store, cfg)
+        .with_max_scan_bytes(config.security.upload.max_request_size_bytes);
+    for endpoint in &config.security.webhooks.endpoints {
+        layer = layer.with_exempt_path(&endpoint.path);
+    }
+    #[cfg(feature = "mail")]
+    if config.mail.should_mount_unsubscribe_endpoint() {
+        layer = layer.with_exempt_path(crate::mail::UNSUBSCRIBE_PATH);
+    }
+    tracing::info!(
+        backend = ?cfg.backend,
+        ttl_secs = cfg.ttl_secs,
+        "One-time submit-token protection enabled"
+    );
+    router = router.layer(layer);
+    Ok(router)
+}
+
 fn apply_bot_protection_middleware<S>(
     mut router: axum::Router<S>,
     config: &AutumnConfig,
@@ -2777,6 +2837,10 @@ fn apply_middleware(
     router = router.layer(axum::middleware::from_fn(move |req, next| {
         trusted_host_middleware(req, next, trusted_host_policy.clone())
     }));
+    // Applied before (i.e. inner to) the CSRF layer so CSRF is validated first
+    // on the request path; a replayed `_submit_token` is still short-circuited
+    // even when the request carries a valid `_csrf` (issue #1360, AC #4).
+    router = apply_submit_token_middleware(router, config)?;
     router = apply_csrf_middleware(router, config, signing_keys_opt.clone());
     router = apply_bot_protection_middleware(router, config);
     // Method-override rejection filter. The outer `MethodOverrideLayer`

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -2209,7 +2209,14 @@ where
     }
 
     let ttl = Duration::from_secs(cfg.ttl_secs);
-    let store: std::sync::Arc<dyn IdempotencyStore> = match cfg.backend {
+    // Backend selection: an explicit `[security.submit_token].backend` wins;
+    // otherwise inherit `[idempotency].backend` so a Redis-configured app shares
+    // one consumed-token store across replicas by default (issue #1360), while a
+    // dev app on the default memory idempotency backend keeps memory tokens.
+    // `resolved_backend` is the single source of truth so this cannot drift from
+    // `build_idempotency_layers`.
+    let backend = cfg.resolved_backend(config.idempotency.backend);
+    let store: std::sync::Arc<dyn IdempotencyStore> = match backend {
         crate::config::IdempotencyBackend::Memory => {
             std::sync::Arc::new(MemoryIdempotencyStore::new(ttl))
         }
@@ -2240,7 +2247,8 @@ where
         layer = layer.with_exempt_path(crate::mail::UNSUBSCRIBE_PATH);
     }
     tracing::info!(
-        backend = ?cfg.backend,
+        backend = ?backend,
+        inherited = cfg.backend.is_none(),
         ttl_secs = cfg.ttl_secs,
         "One-time submit-token protection enabled"
     );

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -854,6 +854,65 @@ impl SubmitTokenConfig {
     ) -> crate::config::IdempotencyBackend {
         self.backend.unwrap_or(idempotency_backend)
     }
+
+    /// Decide the production safety action for the resolved consumed-token
+    /// backend.
+    ///
+    /// Submit tokens are DEFAULT-ON, so the resolved backend can silently land
+    /// on the in-memory store in production when neither `[idempotency]` nor
+    /// `[security.submit_token].backend` is configured. A per-process memory
+    /// store cannot deduplicate submits across replicas, so this mirrors the
+    /// idempotency production-memory guard
+    /// ([`fail_fast_on_invalid_idempotency_config`](crate::app)) — using the
+    /// same `prod`/`production` profile detection — while distinguishing an
+    /// EXPLICIT opt-in from an INHERITED default:
+    ///
+    /// - EXPLICIT `[security.submit_token].backend = "memory"` in production
+    ///   ([`Self::backend`] is `Some(Memory)`) → [`SubmitTokenMemoryGuard::FailExplicit`]:
+    ///   the operator deliberately chose an unsafe backend, so fail fast like
+    ///   idempotency's explicit enabled+memory prod guard.
+    /// - INHERITED default ([`Self::backend`] is `None`) that resolves to
+    ///   memory in production → [`SubmitTokenMemoryGuard::WarnInherited`]: only
+    ///   warn, so upgrading Autumn does not turn into "prod won't boot without
+    ///   Redis" for a single-replica app.
+    /// - Non-production, or a resolved backend that is not memory →
+    ///   [`SubmitTokenMemoryGuard::Ok`].
+    #[must_use]
+    pub(crate) fn production_memory_guard(
+        &self,
+        idempotency_backend: crate::config::IdempotencyBackend,
+        is_production: bool,
+    ) -> SubmitTokenMemoryGuard {
+        use crate::config::IdempotencyBackend;
+        if !is_production
+            || self.resolved_backend(idempotency_backend) != IdempotencyBackend::Memory
+        {
+            return SubmitTokenMemoryGuard::Ok;
+        }
+        // Resolved to the in-memory store in production. `backend == Some(Memory)`
+        // is an explicit opt-in (hard fail); `backend == None` inherited the
+        // memory idempotency backend (warn only). `Some(Redis)` cannot reach here
+        // because it would not resolve to memory.
+        match self.backend {
+            Some(IdempotencyBackend::Memory) => SubmitTokenMemoryGuard::FailExplicit,
+            _ => SubmitTokenMemoryGuard::WarnInherited,
+        }
+    }
+}
+
+/// Production safety decision for the resolved submit-token consumed-token
+/// backend. Produced by [`SubmitTokenConfig::production_memory_guard`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubmitTokenMemoryGuard {
+    /// No action: not production, or the resolved backend is not the in-memory
+    /// store.
+    Ok,
+    /// The default/inherited backend resolves to the in-memory store in
+    /// production. Boot proceeds, but an actionable startup warning is emitted.
+    WarnInherited,
+    /// An explicit `[security.submit_token].backend = "memory"` in production.
+    /// Boot must fail fast.
+    FailExplicit,
 }
 
 const fn default_submit_token_enabled() -> bool {
@@ -1512,6 +1571,70 @@ mod tests {
             cfg.resolved_backend(IdempotencyBackend::Memory),
             IdempotencyBackend::Redis,
             "an explicit redis override must win over an inherited Memory backend"
+        );
+    }
+
+    // ── submit-token production memory guard (Finding O) ────────────────────
+
+    #[test]
+    fn submit_token_explicit_memory_in_production_fails_fast() {
+        // EXPLICIT `[security.submit_token].backend = "memory"` in production
+        // is a deliberate unsafe opt-in → hard fail, mirroring idempotency's
+        // explicit enabled+memory prod guard.
+        let cfg: SubmitTokenConfig = toml::from_str("backend = \"memory\"").unwrap();
+        assert_eq!(cfg.backend, Some(IdempotencyBackend::Memory));
+        assert_eq!(
+            cfg.production_memory_guard(IdempotencyBackend::Redis, true),
+            SubmitTokenMemoryGuard::FailExplicit,
+        );
+        assert_eq!(
+            cfg.production_memory_guard(IdempotencyBackend::Memory, true),
+            SubmitTokenMemoryGuard::FailExplicit,
+        );
+    }
+
+    #[test]
+    fn submit_token_inherited_memory_in_production_only_warns() {
+        // INHERITED default (`backend = None`) resolving to Memory in production
+        // must NOT fail — upgrading Autumn must not turn into "prod won't boot
+        // without Redis". It only warns.
+        let cfg: SubmitTokenConfig = toml::from_str("").unwrap();
+        assert_eq!(cfg.backend, None);
+        assert_eq!(
+            cfg.production_memory_guard(IdempotencyBackend::Memory, true),
+            SubmitTokenMemoryGuard::WarnInherited,
+        );
+        // Inherited Redis resolves to Redis → no warning, no fail.
+        assert_eq!(
+            cfg.production_memory_guard(IdempotencyBackend::Redis, true),
+            SubmitTokenMemoryGuard::Ok,
+        );
+    }
+
+    #[test]
+    fn submit_token_memory_outside_production_is_ok() {
+        // Dev / non-production → no warn, no fail, regardless of explicit or
+        // inherited memory.
+        let explicit: SubmitTokenConfig = toml::from_str("backend = \"memory\"").unwrap();
+        assert_eq!(
+            explicit.production_memory_guard(IdempotencyBackend::Memory, false),
+            SubmitTokenMemoryGuard::Ok,
+        );
+        let inherited: SubmitTokenConfig = toml::from_str("").unwrap();
+        assert_eq!(
+            inherited.production_memory_guard(IdempotencyBackend::Memory, false),
+            SubmitTokenMemoryGuard::Ok,
+        );
+    }
+
+    #[test]
+    fn submit_token_explicit_redis_backend_never_triggers_guard() {
+        // An explicit Redis override never resolves to memory, so the guard is
+        // a no-op even in production.
+        let cfg: SubmitTokenConfig = toml::from_str("backend = \"redis\"").unwrap();
+        assert_eq!(
+            cfg.production_memory_guard(IdempotencyBackend::Memory, true),
+            SubmitTokenMemoryGuard::Ok,
         );
     }
 

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -759,7 +759,7 @@ impl Default for CsrfConfig {
 /// | `enabled` | `true` |
 /// | `field_name` | `"_submit_token"` |
 /// | `ttl_secs` | `600` (10 min) |
-/// | `backend` | `"memory"` |
+/// | `backend` | *inherits `[idempotency].backend`* (in-memory in dev, Redis in prod) |
 /// | `exempt_paths` | `[]` |
 ///
 /// # Examples
@@ -768,7 +768,7 @@ impl Default for CsrfConfig {
 /// [security.submit_token]
 /// enabled = true
 /// ttl_secs = 900
-/// backend = "redis"   # reuses the [idempotency.redis] connection settings
+/// backend = "redis"   # override; reuses the [idempotency.redis] connection settings
 /// ```
 #[derive(Debug, Clone, Deserialize)]
 pub struct SubmitTokenConfig {
@@ -785,12 +785,24 @@ pub struct SubmitTokenConfig {
     #[serde(default = "default_submit_token_ttl_secs")]
     pub ttl_secs: u64,
 
-    /// Storage backend for consumed submit tokens. Default: `"memory"`.
+    /// Storage backend for consumed submit tokens.
     ///
-    /// When `"redis"`, the store reuses the `[idempotency.redis]` connection
-    /// settings so a multi-replica deployment shares one token store.
+    /// When unset (the default, `None`), the submit-token store **inherits the
+    /// configured idempotency backend** (`[idempotency].backend`): a
+    /// Redis-configured app automatically shares one consumed-token store across
+    /// replicas, while a dev app on the default in-memory idempotency backend
+    /// keeps an in-memory token store. This matches issue #1360: the token store
+    /// is backed by the existing idempotency/session store backend (in-memory in
+    /// dev, Redis in prod), so a double-click load-balanced to a different
+    /// replica cannot re-run the mutation in production.
+    ///
+    /// Set explicitly to override the inherited backend for submit tokens only.
+    /// When it resolves to `"redis"`, the store reuses the `[idempotency.redis]`
+    /// connection settings so a multi-replica deployment shares one token store.
+    ///
+    /// Use [`Self::resolved_backend`] to obtain the effective backend.
     #[serde(default)]
-    pub backend: crate::config::IdempotencyBackend,
+    pub backend: Option<crate::config::IdempotencyBackend>,
 
     /// Request path prefixes that are exempt from submit-token guarding.
     /// Default: `[]`.
@@ -804,9 +816,26 @@ impl Default for SubmitTokenConfig {
             enabled: default_submit_token_enabled(),
             field_name: default_submit_token_field(),
             ttl_secs: default_submit_token_ttl_secs(),
-            backend: crate::config::IdempotencyBackend::default(),
+            backend: None,
             exempt_paths: Vec::new(),
         }
+    }
+}
+
+impl SubmitTokenConfig {
+    /// Resolve the effective consumed-token storage backend.
+    ///
+    /// Returns the explicit `backend` override when one is configured;
+    /// otherwise inherits `idempotency_backend` (the app's
+    /// `[idempotency].backend`) so submit tokens share the idempotency store by
+    /// default. This is the single source of truth for backend selection so the
+    /// idempotency layer and the submit-token layer cannot drift apart.
+    #[must_use]
+    pub fn resolved_backend(
+        &self,
+        idempotency_backend: crate::config::IdempotencyBackend,
+    ) -> crate::config::IdempotencyBackend {
+        self.backend.unwrap_or(idempotency_backend)
     }
 }
 
@@ -1420,6 +1449,50 @@ const fn default_max_file_size_bytes() -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::IdempotencyBackend;
+
+    // ── submit-token backend resolution (Finding D: inherit idempotency) ─────
+
+    #[test]
+    fn submit_token_backend_defaults_to_none_and_inherits_idempotency() {
+        // Unset `[security.submit_token].backend` deserializes to `None`.
+        let cfg: SubmitTokenConfig = toml::from_str("").unwrap();
+        assert_eq!(cfg.backend, None, "unset backend must deserialize to None");
+        // With idempotency on Redis, the resolved submit-token backend follows
+        // it — NOT the old hardcoded Memory default.
+        assert_eq!(
+            cfg.resolved_backend(IdempotencyBackend::Redis),
+            IdempotencyBackend::Redis,
+            "an unset submit-token backend must inherit the Redis idempotency backend"
+        );
+        // A dev app on the default Memory idempotency backend stays Memory.
+        assert_eq!(
+            cfg.resolved_backend(IdempotencyBackend::Memory),
+            IdempotencyBackend::Memory,
+            "an unset submit-token backend on a Memory idempotency app stays Memory"
+        );
+    }
+
+    #[test]
+    fn submit_token_explicit_backend_overrides_inherited_idempotency() {
+        // An explicit `backend = "memory"` wins even when idempotency is Redis.
+        let cfg: SubmitTokenConfig = toml::from_str("backend = \"memory\"").unwrap();
+        assert_eq!(cfg.backend, Some(IdempotencyBackend::Memory));
+        assert_eq!(
+            cfg.resolved_backend(IdempotencyBackend::Redis),
+            IdempotencyBackend::Memory,
+            "an explicit submit-token backend override must win over the inherited backend"
+        );
+
+        // An explicit `backend = "redis"` wins even when idempotency is Memory.
+        let cfg: SubmitTokenConfig = toml::from_str("backend = \"redis\"").unwrap();
+        assert_eq!(cfg.backend, Some(IdempotencyBackend::Redis));
+        assert_eq!(
+            cfg.resolved_backend(IdempotencyBackend::Memory),
+            IdempotencyBackend::Redis,
+            "an explicit redis override must win over an inherited Memory backend"
+        );
+    }
 
     // ── validate_signing_secret (RED phase) ─────────────────────────────────
 

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -364,6 +364,10 @@ pub struct SecurityConfig {
     #[serde(default)]
     pub csrf: CsrfConfig,
 
+    /// One-time submit tokens — at-most-once form submissions.
+    #[serde(default)]
+    pub submit_token: SubmitTokenConfig,
+
     /// Rate limiting (per-client-IP token bucket).
     #[serde(default)]
     pub rate_limit: RateLimitConfig,
@@ -732,6 +736,90 @@ impl Default for CsrfConfig {
             exempt_paths: Vec::new(),
         }
     }
+}
+
+/// One-time submit-token protection settings.
+///
+/// When enabled (the default), a per-render random token is exposed via the
+/// [`SubmitToken`](crate::security::SubmitToken) extractor and embedded as a
+/// hidden `_submit_token` field in scaffolded create/update forms. On the
+/// mutating POST the server consumes the token exactly once: a double-click,
+/// Back→resubmit, or browser retry carrying an already-consumed token replays
+/// the first response instead of re-running the handler, so no duplicate row is
+/// created — with no client-side JavaScript.
+///
+/// Unlike [`IdempotencyConfig`](crate::config::IdempotencyConfig), the guard is
+/// driven by a form field, not the `Idempotency-Key` header, so it protects
+/// bare browser form submits.
+///
+/// # Defaults
+///
+/// | Field | Default |
+/// |-------|---------|
+/// | `enabled` | `true` |
+/// | `field_name` | `"_submit_token"` |
+/// | `ttl_secs` | `600` (10 min) |
+/// | `backend` | `"memory"` |
+/// | `exempt_paths` | `[]` |
+///
+/// # Examples
+///
+/// ```toml
+/// [security.submit_token]
+/// enabled = true
+/// ttl_secs = 900
+/// backend = "redis"   # reuses the [idempotency.redis] connection settings
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+pub struct SubmitTokenConfig {
+    /// Enable one-time submit-token protection. Default: `true`.
+    #[serde(default = "default_submit_token_enabled")]
+    pub enabled: bool,
+
+    /// Hidden form field name carrying the token. Default: `"_submit_token"`.
+    #[serde(default = "default_submit_token_field")]
+    pub field_name: String,
+
+    /// Time-to-live in seconds for a consumed token's stored response.
+    /// Default: `600` (10 minutes).
+    #[serde(default = "default_submit_token_ttl_secs")]
+    pub ttl_secs: u64,
+
+    /// Storage backend for consumed submit tokens. Default: `"memory"`.
+    ///
+    /// When `"redis"`, the store reuses the `[idempotency.redis]` connection
+    /// settings so a multi-replica deployment shares one token store.
+    #[serde(default)]
+    pub backend: crate::config::IdempotencyBackend,
+
+    /// Request path prefixes that are exempt from submit-token guarding.
+    /// Default: `[]`.
+    #[serde(default)]
+    pub exempt_paths: Vec<String>,
+}
+
+impl Default for SubmitTokenConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_submit_token_enabled(),
+            field_name: default_submit_token_field(),
+            ttl_secs: default_submit_token_ttl_secs(),
+            backend: crate::config::IdempotencyBackend::default(),
+            exempt_paths: Vec::new(),
+        }
+    }
+}
+
+const fn default_submit_token_enabled() -> bool {
+    true
+}
+
+fn default_submit_token_field() -> String {
+    "_submit_token".to_owned()
+}
+
+const fn default_submit_token_ttl_secs() -> u64 {
+    600
 }
 
 /// Strategy for identifying which client a rate-limit bucket belongs to.

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -759,6 +759,7 @@ impl Default for CsrfConfig {
 /// | `enabled` | `true` |
 /// | `field_name` | `"_submit_token"` |
 /// | `ttl_secs` | `600` (10 min) |
+/// | `in_flight_ttl_secs` | `86_400` (24 h) |
 /// | `backend` | *inherits `[idempotency].backend`* (in-memory in dev, Redis in prod) |
 /// | `exempt_paths` | `[]` |
 ///
@@ -784,6 +785,21 @@ pub struct SubmitTokenConfig {
     /// Default: `600` (10 minutes).
     #[serde(default = "default_submit_token_ttl_secs")]
     pub ttl_secs: u64,
+
+    /// Maximum stale lifetime in seconds for an in-flight submission lock.
+    ///
+    /// While a mutating request is running, its token is locked so a concurrent
+    /// retry carrying the same token is excluded until the first request records
+    /// its consumed response. The lock is released as soon as that record is
+    /// stored, so this value is only the backend safety expiry for crashes or
+    /// lost unlocks — it must be comfortably longer than any supported mutating
+    /// request duration. Deliberately **independent of `ttl_secs`** (the replay
+    /// window): lowering `ttl_secs` must never shorten how long an active
+    /// submission is excluded from re-entry, which would let a slow request's
+    /// retry acquire a fresh lock and double-execute. Default: `86_400`
+    /// (24 hours), matching `[idempotency].in_flight_ttl_secs`.
+    #[serde(default = "default_submit_token_in_flight_ttl_secs")]
+    pub in_flight_ttl_secs: u64,
 
     /// Storage backend for consumed submit tokens.
     ///
@@ -816,6 +832,7 @@ impl Default for SubmitTokenConfig {
             enabled: default_submit_token_enabled(),
             field_name: default_submit_token_field(),
             ttl_secs: default_submit_token_ttl_secs(),
+            in_flight_ttl_secs: default_submit_token_in_flight_ttl_secs(),
             backend: None,
             exempt_paths: Vec::new(),
         }
@@ -849,6 +866,10 @@ fn default_submit_token_field() -> String {
 
 const fn default_submit_token_ttl_secs() -> u64 {
     600
+}
+
+const fn default_submit_token_in_flight_ttl_secs() -> u64 {
+    86_400
 }
 
 /// Strategy for identifying which client a rate-limit bucket belongs to.

--- a/autumn/src/security/mod.rs
+++ b/autumn/src/security/mod.rs
@@ -144,6 +144,7 @@ pub(crate) mod headers;
 pub(crate) mod path;
 pub mod proxy;
 pub mod rate_limit;
+pub(crate) mod submit_token;
 pub(crate) mod trusted_proxies;
 
 // Re-export commonly used types at the module level.
@@ -155,8 +156,8 @@ pub use captcha::{
 };
 pub use config::{
     CspNonceConfig, CsrfConfig, HeadersConfig, KeyStrategy, RateLimitBackend, RateLimitConfig,
-    RateLimitNamedConfig, RateLimitTierConfig, SecurityConfig, TrustedProxiesConfig, UploadConfig,
-    default_content_security_policy, hmac_sha256_hex,
+    RateLimitNamedConfig, RateLimitTierConfig, SecurityConfig, SubmitTokenConfig,
+    TrustedProxiesConfig, UploadConfig, default_content_security_policy, hmac_sha256_hex,
 };
 #[cfg(feature = "redis")]
 pub use config::{RateLimitBackendFailure, RateLimitRedisConfig};
@@ -169,4 +170,5 @@ pub use rate_limit::{
     RateLimitEnvelopeCounted, RateLimitExempt, RateLimitLayer, RateLimitOverride,
     RateLimitPrincipal, ThrottleSpec,
 };
+pub use submit_token::{SubmitFormField, SubmitToken, SubmitTokenLayer};
 pub use trusted_proxies::{ProxyResolver, ResolvedClientIdentity, TrustedProxiesLayer};

--- a/autumn/src/security/submit_token.rs
+++ b/autumn/src/security/submit_token.rs
@@ -507,12 +507,18 @@ impl SubmitTokenLayer {
     #[must_use]
     pub fn new(store: Arc<dyn IdempotencyStore>, config: &SubmitTokenConfig) -> Self {
         let ttl = Duration::from_secs(config.ttl_secs);
+        // The in-flight lock TTL is a SEPARATE knob from the replay `ttl`: it
+        // must outlast any active mutating request so a slow submission's retry
+        // stays excluded until the first request records its consumed token.
+        // Deriving it from `ttl_secs` would let lowering the replay window reopen
+        // the double-execute re-entry gap (issue #1360).
+        let in_flight_ttl = Duration::from_secs(config.in_flight_ttl_secs);
         Self {
             settings: Arc::new(SubmitTokenSettings {
                 store,
                 field_name: config.field_name.clone(),
                 ttl,
-                in_flight_ttl: ttl,
+                in_flight_ttl,
                 exempt_paths: config.exempt_paths.clone(),
                 max_scan_bytes: MAX_SCAN_BYTES_CAP,
             }),
@@ -1354,6 +1360,146 @@ mod tests {
             count.load(Ordering::SeqCst),
             0,
             "the handler must never see a truncated body when the stream errors mid-read"
+        );
+    }
+
+    /// Store that records the TTL handed to `try_lock` (the in-flight lock
+    /// duration) versus `set` (the consumed-record replay window), so a test can
+    /// assert the two are governed by SEPARATE config knobs. Locking and storage
+    /// otherwise behave like the in-memory store.
+    struct TtlRecordingStore {
+        inner: MemoryIdempotencyStore,
+        lock_ttl: std::sync::Mutex<Option<Duration>>,
+        set_ttl: std::sync::Mutex<Option<Duration>>,
+    }
+
+    impl TtlRecordingStore {
+        fn new() -> Self {
+            Self {
+                inner: MemoryIdempotencyStore::new(Duration::from_secs(600)),
+                lock_ttl: std::sync::Mutex::new(None),
+                set_ttl: std::sync::Mutex::new(None),
+            }
+        }
+    }
+
+    impl IdempotencyStore for TtlRecordingStore {
+        fn get(&self, key: &str) -> Option<IdempotencyEntry> {
+            self.inner.get(key)
+        }
+
+        fn set(&self, key: &str, record: IdempotencyRecord, body_hash: Vec<u8>, ttl: Duration) {
+            *self.set_ttl.lock().unwrap() = Some(ttl);
+            self.inner.set(key, record, body_hash, ttl);
+        }
+
+        fn try_lock(&self, key: &str, lock_ttl: Duration) -> bool {
+            *self.lock_ttl.lock().unwrap() = Some(lock_ttl);
+            self.inner.try_lock(key, lock_ttl)
+        }
+
+        fn unlock(&self, key: &str) {
+            self.inner.unlock(key);
+        }
+    }
+
+    /// Finding L (decouple in-flight lock TTL from replay TTL): the in-flight
+    /// submission lock must be governed by `in_flight_ttl_secs`, NOT by the
+    /// `ttl_secs` replay window. An operator who lowers `ttl_secs` must not
+    /// shorten how long an active submission is excluded from re-entry — else a
+    /// create/update that outruns the shrunken TTL would let a retry with the
+    /// same token acquire a FRESH lock before the consumed record lands and both
+    /// requests execute the mutation.
+    #[tokio::test]
+    async fn in_flight_lock_ttl_is_decoupled_from_replay_ttl() {
+        let store = Arc::new(TtlRecordingStore::new());
+        let store_dyn: Arc<dyn IdempotencyStore> = store.clone();
+        // A deliberately tiny replay window paired with a normal in-flight TTL.
+        let config = SubmitTokenConfig {
+            enabled: true,
+            ttl_secs: 1,
+            in_flight_ttl_secs: 86_400,
+            ..Default::default()
+        };
+        let app = Router::new()
+            .route("/submit", post(|| async { "created" }))
+            .layer(SubmitTokenLayer::new(store_dyn, &config));
+
+        let resp = app.oneshot(urlencoded_post("tok-decoupled")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // The lock excluding a concurrent retry lives for the full
+        // in_flight_ttl_secs — lowering ttl_secs does NOT open the re-entry gap.
+        let lock_ttl = store
+            .lock_ttl
+            .lock()
+            .unwrap()
+            .expect("the guard must acquire an in-flight lock");
+        assert_eq!(
+            lock_ttl,
+            Duration::from_secs(86_400),
+            "the in-flight lock TTL must come from in_flight_ttl_secs, not ttl_secs"
+        );
+        // ...while the consumed-record replay window still tracks ttl_secs.
+        let set_ttl = store
+            .set_ttl
+            .lock()
+            .unwrap()
+            .expect("the guard must record the consumed token");
+        assert_eq!(
+            set_ttl,
+            Duration::from_secs(1),
+            "the consumed-record replay TTL must still come from ttl_secs"
+        );
+    }
+
+    /// Finding L (behavioural): even with a tiny replay `ttl_secs`, a token whose
+    /// submission is still in-flight (lock held, consumed record not yet stored)
+    /// excludes a retry with a `409` rather than letting it re-run the mutation.
+    #[tokio::test]
+    async fn in_flight_token_excludes_retry_with_small_replay_ttl() {
+        let store = Arc::new(MemoryIdempotencyStore::new(Duration::from_secs(600)));
+        let store_dyn: Arc<dyn IdempotencyStore> = store.clone();
+        let config = SubmitTokenConfig {
+            enabled: true,
+            ttl_secs: 1,
+            in_flight_ttl_secs: 86_400,
+            ..Default::default()
+        };
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_inner = count.clone();
+        let app = Router::new()
+            .route(
+                "/submit",
+                post(move || {
+                    let count = count_inner.clone();
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        "created"
+                    }
+                }),
+            )
+            .layer(SubmitTokenLayer::new(store_dyn, &config));
+
+        // Simulate the first request being mid-flight: hold the in-flight lock
+        // for the token key with the normal in-flight TTL, without recording a
+        // consumed response yet.
+        let token = "tok-inflight";
+        let key = storage_key(token);
+        assert!(store.try_lock(&key, Duration::from_secs(86_400)));
+
+        // A concurrent retry with the same token is rejected in-flight and never
+        // reaches the handler.
+        let resp = app.oneshot(urlencoded_post(token)).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::CONFLICT,
+            "a retry against a still-in-flight token must be excluded, not re-run"
+        );
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            0,
+            "the handler must not run for a retry held out by the in-flight lock"
         );
     }
 }

--- a/autumn/src/security/submit_token.rs
+++ b/autumn/src/security/submit_token.rs
@@ -290,6 +290,12 @@ enum CollectedBody {
     /// already over-limit; `body` chains the full, unmodified body (every byte
     /// of every chunk) with the remaining stream for pass-through.
     Oversized { prefix: Bytes, body: Body },
+    /// The body stream yielded an error before EOF (and before crossing the
+    /// limit). The bytes read so far are discarded: buffering-then-rebuilding
+    /// them would hand a downstream handler a silently TRUNCATED form (a valid
+    /// leading `_submit_token` followed by missing tail fields), so the caller
+    /// must fail the request instead of pretending the short read succeeded.
+    Errored(axum::Error),
 }
 
 /// Buffer `body` up to `limit` bytes without corrupting oversized bodies.
@@ -298,10 +304,13 @@ async fn collect_body(body: Body, limit: usize) -> CollectedBody {
     let mut stream = body.into_data_stream();
     loop {
         match stream.next().await {
-            // End of stream, or a mid-stream error: return what we have. The
-            // token (if any) is emitted at the front of the form, so a truncated
-            // tail is harmless for scanning; the handler receives the prefix.
-            None | Some(Err(_)) => break,
+            // Clean end of stream: return everything buffered so far.
+            None => break,
+            // A mid-stream read error must be propagated, never swallowed into a
+            // truncated `Full`: the handler would otherwise receive a form whose
+            // tail fields were lost while the leading token still scanned and
+            // consumed, so the caller fails the request on this variant.
+            Some(Err(err)) => return CollectedBody::Errored(err),
             Some(Ok(chunk)) => {
                 let remaining = limit.saturating_sub(buf.len());
                 if chunk.len() > remaining {
@@ -336,11 +345,15 @@ async fn collect_body(body: Body, limit: usize) -> CollectedBody {
 
 /// Extract the submitted `_submit_token` from the request body, returning the
 /// token (if present) and a request whose body is preserved for the handler.
+///
+/// Returns `Err` when the body stream errors mid-read while scanning: the caller
+/// must reject the request rather than forward a truncated form (see
+/// [`CollectedBody::Errored`]).
 async fn extract_submitted_token(
     req: Request<Body>,
     field: &str,
     max_scan_bytes: usize,
-) -> (Option<String>, Request<Body>) {
+) -> Result<(Option<String>, Request<Body>), axum::Error> {
     let (parts, body) = req.into_parts();
 
     let content_type = parts
@@ -357,18 +370,19 @@ async fn extract_submitted_token(
     // content_type borrow ends here.
 
     if !is_urlencoded && boundary.is_none() {
-        return (None, Request::from_parts(parts, body));
+        return Ok((None, Request::from_parts(parts, body)));
     }
 
     match collect_body(body, max_scan_bytes).await {
         CollectedBody::Full(bytes) => {
             let token = scan_for_token(&bytes, is_urlencoded, boundary.as_deref(), field);
-            (token, Request::from_parts(parts, Body::from(bytes)))
+            Ok((token, Request::from_parts(parts, Body::from(bytes))))
         }
         CollectedBody::Oversized { prefix, body } => {
             let token = scan_for_token(&prefix, is_urlencoded, boundary.as_deref(), field);
-            (token, Request::from_parts(parts, body))
+            Ok((token, Request::from_parts(parts, body)))
         }
+        CollectedBody::Errored(err) => Err(err),
     }
 }
 
@@ -417,6 +431,27 @@ fn in_flight_conflict_response() -> Response<Body> {
         .body(Body::from(
             "this form submission is already being processed; retry after 1 second",
         ))
+        .unwrap_or_else(|_| Response::new(Body::empty()))
+}
+
+/// `400` returned when the request body stream errors mid-read while scanning
+/// for the token. Failing here is safer than forwarding a truncated form to the
+/// handler (missing tail fields) after a leading token has already been consumed.
+fn body_read_error_response() -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::BAD_REQUEST)
+        .body(Body::from("could not read the request body"))
+        .unwrap_or_else(|_| Response::new(Body::empty()))
+}
+
+/// `500` returned when the handler's response body stream errors while it is
+/// being buffered for replay caching. The token is not recorded and the
+/// in-flight lock is released, so we cannot cache or safely replay this
+/// response; surface an error rather than a truncated body.
+fn response_read_error_response() -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::INTERNAL_SERVER_ERROR)
+        .body(Body::from("could not read the response body"))
         .unwrap_or_else(|_| Response::new(Body::empty()))
 }
 
@@ -567,7 +602,22 @@ where
             }
 
             let (submitted, req) =
-                extract_submitted_token(req, &settings.field_name, settings.max_scan_bytes).await;
+                match extract_submitted_token(req, &settings.field_name, settings.max_scan_bytes)
+                    .await
+                {
+                    Ok(pair) => pair,
+                    Err(error) => {
+                        // A body-stream read error while scanning must reject the
+                        // request: forwarding the bytes read so far would hand the
+                        // handler a truncated form whose leading token we already
+                        // scanned, silently dropping tail fields.
+                        tracing::warn!(
+                            error = %error,
+                            "Submit-token body scan failed on a read error; rejecting the request"
+                        );
+                        return Ok(body_read_error_response());
+                    }
+                };
 
             let Some(token) = submitted.filter(|t| !t.is_empty()) else {
                 // No submit token present — pass through unchanged.
@@ -623,53 +673,73 @@ where
             }
 
             let response = inner.call(req).await?;
-            let (parts, body) = response.into_parts();
+            Ok(cache_consumed_token_response(response, &settings, &key).await)
+        })
+    }
+}
 
-            match collect_body(body, MAX_CACHEABLE_RESPONSE_BODY).await {
-                CollectedBody::Full(bytes) => {
-                    let status = parts.status.as_u16();
-                    // Cache successful (2xx) and redirect (3xx) responses so the
-                    // replayed submit returns the first response verbatim.
-                    if (200..400).contains(&status) {
-                        let record = IdempotencyRecord {
-                            status,
-                            headers: replay_headers(&parts.headers),
-                            body: bytes.to_vec(),
-                            metadata: Vec::new(),
-                        };
-                        // Persist the consumed-token record. If the store write
-                        // fails after the handler already committed its mutation
-                        // and returned a 2xx/3xx, fail closed exactly as
-                        // `IdempotencyLayer` does: keep the in-flight lock held
-                        // (by not unlocking, it expires via `in_flight_ttl`) so a
-                        // retry carrying the same token gets a `409` in-flight
-                        // conflict rather than silently re-running the
-                        // create/update, and surface `503` instead of an
-                        // un-recorded success.
-                        if let Err(error) =
-                            settings
-                                .store
-                                .try_set(&key, record, Vec::new(), settings.ttl)
-                        {
-                            tracing::error!(
-                                error = %error,
-                                "Submit-token persistence failed after handler success; failing closed"
-                            );
-                            return Ok(crate::idempotency::persistence_failed_response());
-                        }
-                    }
-                    settings.store.unlock(&key);
-                    Ok(Response::from_parts(parts, Body::from(bytes)))
-                }
-                CollectedBody::Oversized { body, .. } => {
-                    // Too large to cache — stream through. The lock is released;
-                    // a later retry re-runs (acceptable: form responses are tiny
-                    // redirects, so this path is not hit in practice).
-                    settings.store.unlock(&key);
-                    Ok(Response::from_parts(parts, body))
+/// Run the handler's response through the consumed-token replay cache: buffer it
+/// (up to [`MAX_CACHEABLE_RESPONSE_BODY`]), record 2xx/3xx responses under `key`
+/// so a replay returns them verbatim, and release the in-flight lock. Kept out
+/// of [`SubmitTokenService::call`] so that hot method stays under the line cap.
+async fn cache_consumed_token_response(
+    response: Response<Body>,
+    settings: &SubmitTokenSettings,
+    key: &str,
+) -> Response<Body> {
+    let (parts, body) = response.into_parts();
+    match collect_body(body, MAX_CACHEABLE_RESPONSE_BODY).await {
+        CollectedBody::Full(bytes) => {
+            let status = parts.status.as_u16();
+            // Cache successful (2xx) and redirect (3xx) responses so the
+            // replayed submit returns the first response verbatim.
+            if (200..400).contains(&status) {
+                let record = IdempotencyRecord {
+                    status,
+                    headers: replay_headers(&parts.headers),
+                    body: bytes.to_vec(),
+                    metadata: Vec::new(),
+                };
+                // Persist the consumed-token record. If the store write fails
+                // after the handler already committed its mutation and returned
+                // a 2xx/3xx, fail closed exactly as `IdempotencyLayer` does: keep
+                // the in-flight lock held (by not unlocking, it expires via
+                // `in_flight_ttl`) so a retry carrying the same token gets a
+                // `409` in-flight conflict rather than silently re-running the
+                // create/update, and surface `503` instead of an un-recorded
+                // success.
+                if let Err(error) = settings
+                    .store
+                    .try_set(key, record, Vec::new(), settings.ttl)
+                {
+                    tracing::error!(
+                        error = %error,
+                        "Submit-token persistence failed after handler success; failing closed"
+                    );
+                    return crate::idempotency::persistence_failed_response();
                 }
             }
-        })
+            settings.store.unlock(key);
+            Response::from_parts(parts, Body::from(bytes))
+        }
+        CollectedBody::Oversized { body, .. } => {
+            // Too large to cache — stream through. The lock is released; a later
+            // retry re-runs (acceptable: form responses are tiny redirects, so
+            // this path is not hit in practice).
+            settings.store.unlock(key);
+            Response::from_parts(parts, body)
+        }
+        CollectedBody::Errored(error) => {
+            // The response body errored while buffering for the replay cache. We
+            // can neither record the token nor replay a truncated body; release
+            // the lock and surface a 500.
+            tracing::error!(
+                error = %error,
+                "Submit-token response buffering failed on a read error"
+            );
+            settings.store.unlock(key);
+            response_read_error_response()
+        }
     }
 }
 
@@ -1233,6 +1303,57 @@ mod tests {
             count.load(Ordering::SeqCst),
             1,
             "the handler must not re-run when the consumed-token lookup fails"
+        );
+    }
+
+    /// Finding J (preserve body read errors): when the request body stream
+    /// yields an error mid-read while the guard is scanning for the token, the
+    /// request must FAIL (400) rather than reach the handler with a silently
+    /// truncated form. A leading `_submit_token` followed by a lost tail must
+    /// never be forwarded as if the short read had succeeded.
+    #[tokio::test]
+    async fn body_read_error_rejects_request_and_does_not_reach_handler() {
+        let store: Arc<dyn IdempotencyStore> =
+            Arc::new(MemoryIdempotencyStore::new(Duration::from_secs(600)));
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_inner = count.clone();
+        let app = Router::new()
+            .route(
+                "/submit",
+                post(move |_body: Bytes| {
+                    let count = count_inner.clone();
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        "created"
+                    }
+                }),
+            )
+            .layer(layer_with_store(store));
+
+        // A urlencoded body whose stream delivers a leading chunk (with the
+        // token near the front) and then errors before EOF.
+        let chunks: Vec<Result<Bytes, std::io::Error>> = vec![
+            Ok(Bytes::from("_submit_token=tok-read-err&ti")),
+            Err(std::io::Error::other("simulated body read failure")),
+        ];
+        let body = Body::from_stream(futures::stream::iter(chunks));
+        let req = Request::builder()
+            .method("POST")
+            .uri("/submit")
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .body(body)
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "a mid-read body-stream error must reject the request, not forward a truncated form"
+        );
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            0,
+            "the handler must never see a truncated body when the stream errors mid-read"
         );
     }
 }

--- a/autumn/src/security/submit_token.rs
+++ b/autumn/src/security/submit_token.rs
@@ -609,7 +609,26 @@ where
                             body: bytes.to_vec(),
                             metadata: Vec::new(),
                         };
-                        settings.store.set(&key, record, Vec::new(), settings.ttl);
+                        // Persist the consumed-token record. If the store write
+                        // fails after the handler already committed its mutation
+                        // and returned a 2xx/3xx, fail closed exactly as
+                        // `IdempotencyLayer` does: keep the in-flight lock held
+                        // (by not unlocking, it expires via `in_flight_ttl`) so a
+                        // retry carrying the same token gets a `409` in-flight
+                        // conflict rather than silently re-running the
+                        // create/update, and surface `503` instead of an
+                        // un-recorded success.
+                        if let Err(error) =
+                            settings
+                                .store
+                                .try_set(&key, record, Vec::new(), settings.ttl)
+                        {
+                            tracing::error!(
+                                error = %error,
+                                "Submit-token persistence failed after handler success; failing closed"
+                            );
+                            return Ok(crate::idempotency::persistence_failed_response());
+                        }
                     }
                     settings.store.unlock(&key);
                     Ok(Response::from_parts(parts, Body::from(bytes)))
@@ -629,7 +648,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::idempotency::MemoryIdempotencyStore;
+    use crate::idempotency::{IdempotencyEntry, IdempotencyStoreError, MemoryIdempotencyStore};
     use axum::Router;
     use axum::routing::{get, post};
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -988,6 +1007,104 @@ mod tests {
             count.load(Ordering::SeqCst),
             1,
             "handler must run exactly once"
+        );
+    }
+
+    /// Store stub whose consumed-token persistence always fails, while locking
+    /// and reads behave like the in-memory store. Mirrors the idempotency
+    /// layer's failing-backend tests so we can prove fail-closed semantics.
+    struct FailingSetStore {
+        inner: MemoryIdempotencyStore,
+    }
+
+    impl FailingSetStore {
+        fn new() -> Self {
+            Self {
+                inner: MemoryIdempotencyStore::new(Duration::from_secs(600)),
+            }
+        }
+    }
+
+    impl IdempotencyStore for FailingSetStore {
+        fn get(&self, key: &str) -> Option<IdempotencyEntry> {
+            self.inner.get(key)
+        }
+
+        fn set(&self, _key: &str, _record: IdempotencyRecord, _body_hash: Vec<u8>, _ttl: Duration) {
+            // No-op: the fallible `try_set` path is what the guard uses; this
+            // simulated backend never persists so retries cannot see a record.
+        }
+
+        fn try_set(
+            &self,
+            _key: &str,
+            _record: IdempotencyRecord,
+            _body_hash: Vec<u8>,
+            _ttl: Duration,
+        ) -> Result<(), IdempotencyStoreError> {
+            Err(IdempotencyStoreError::backend(
+                "simulated consumed-token persistence failure",
+            ))
+        }
+
+        fn try_lock(&self, key: &str, lock_ttl: Duration) -> bool {
+            self.inner.try_lock(key, lock_ttl)
+        }
+
+        fn unlock(&self, key: &str) {
+            self.inner.unlock(key);
+        }
+    }
+
+    /// Finding C (fail closed): when the store cannot persist the consumed-token
+    /// record after the handler already committed its mutation, the guard must
+    /// NOT return a bare success (which a retry would re-run). It fails closed
+    /// exactly like `IdempotencyLayer`: the first request surfaces `503`, and
+    /// the in-flight lock stays held so a retry with the same token is rejected
+    /// with an in-flight `409` instead of re-running the handler.
+    #[tokio::test]
+    async fn persistence_failure_fails_closed_and_holds_lock() {
+        let store: Arc<dyn IdempotencyStore> = Arc::new(FailingSetStore::new());
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_inner = count.clone();
+        let app = Router::new()
+            .route(
+                "/submit",
+                post(move || {
+                    let count = count_inner.clone();
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        "created"
+                    }
+                }),
+            )
+            .layer(layer_with_store(store));
+
+        let token = "tok-persist-fail";
+
+        // First submit: handler runs once, but the store write fails, so the
+        // guard fails closed with 503 instead of returning the 200 "created".
+        let first = app.clone().oneshot(urlencoded_post(token)).await.unwrap();
+        assert_eq!(
+            first.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "a persistence failure after handler success must fail closed, not return the success"
+        );
+
+        // Retry with the same token: the in-flight lock is still held (it was
+        // deliberately not released), so the retry is rejected in-flight and the
+        // handler does NOT run a second time.
+        let second = app.clone().oneshot(urlencoded_post(token)).await.unwrap();
+        assert_eq!(
+            second.status(),
+            StatusCode::CONFLICT,
+            "a retry after a persistence failure must be rejected in-flight, not re-run"
+        );
+
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "the handler must run at most once even when persistence fails"
         );
     }
 }

--- a/autumn/src/security/submit_token.rs
+++ b/autumn/src/security/submit_token.rs
@@ -284,9 +284,11 @@ fn scan_for_token(
 enum CollectedBody {
     /// The whole body fits within the limit and is fully buffered.
     Full(Bytes),
-    /// The body exceeded the limit. `prefix` is the bytes read before the
-    /// over-limit chunk (scanned for the token, which is always emitted early);
-    /// `body` chains the prefix with the remaining stream for pass-through.
+    /// The body exceeded the limit. `prefix` is the first `limit` bytes of the
+    /// body — including the leading bytes of the chunk that crossed the cap, so
+    /// a token near the front is scannable even when the very first chunk is
+    /// already over-limit; `body` chains the full, unmodified body (every byte
+    /// of every chunk) with the remaining stream for pass-through.
     Oversized { prefix: Bytes, body: Body },
 }
 
@@ -301,8 +303,22 @@ async fn collect_body(body: Body, limit: usize) -> CollectedBody {
             // tail is harmless for scanning; the handler receives the prefix.
             None | Some(Err(_)) => break,
             Some(Ok(chunk)) => {
-                if chunk.len() > limit.saturating_sub(buf.len()) {
-                    let prefix = Bytes::from(buf.clone());
+                let remaining = limit.saturating_sub(buf.len());
+                if chunk.len() > remaining {
+                    // Fill the scan prefix up to `limit` with the leading bytes
+                    // of the over-limit chunk, so a token at the front of the
+                    // form is still found even when the FIRST chunk already
+                    // exceeds the cap (e.g. an upstream middleware rebuilt the
+                    // buffered body as one `Body::from(bytes)`, leaving `buf`
+                    // empty here).
+                    let mut prefix_buf = buf.clone();
+                    prefix_buf.extend_from_slice(&chunk[..remaining]);
+                    let prefix = Bytes::from(prefix_buf);
+                    // Replay the FULL body unchanged: the buffered prefix bytes
+                    // followed by the *complete* over-limit chunk (not just its
+                    // scanned head) and the rest of the stream. The scan prefix
+                    // is only for locating the token; the handler must receive
+                    // every byte.
                     let mut leading = Vec::with_capacity(2);
                     if !buf.is_empty() {
                         leading.push(Ok::<Bytes, axum::Error>(Bytes::from(buf)));
@@ -896,6 +912,82 @@ mod tests {
         assert!(
             succeeded >= 1,
             "at least the first submission must succeed and be replayable"
+        );
+    }
+
+    /// Regression: when the FIRST body chunk already exceeds `max_scan_bytes`
+    /// (e.g. an upstream middleware rebuilt the buffered form as a single
+    /// `Body::from(bytes)`), the leading `_submit_token` must still be scanned
+    /// from that over-limit chunk — the guard fires — while the handler still
+    /// receives the complete, untruncated body.
+    #[tokio::test]
+    async fn over_limit_first_chunk_detects_leading_token_and_preserves_body() {
+        let store: Arc<dyn IdempotencyStore> =
+            Arc::new(MemoryIdempotencyStore::new(Duration::from_secs(600)));
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_inner = count.clone();
+        let seen_len = Arc::new(AtomicUsize::new(0));
+        let seen_len_inner = seen_len.clone();
+        // The handler consumes the whole body so we can assert nothing was
+        // truncated on its way through the scan.
+        let app = Router::new()
+            .route(
+                "/submit",
+                post(move |body: Bytes| {
+                    let count = count_inner.clone();
+                    let seen_len = seen_len_inner.clone();
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        seen_len.store(body.len(), Ordering::SeqCst);
+                        "created"
+                    }
+                }),
+            )
+            // A tiny scan cap the very first chunk already blows past.
+            .layer(layer_with_store(store).with_max_scan_bytes(64));
+
+        let token = "over-limit-token";
+        // `_submit_token` sits at the front (well within the 64-byte cap); a
+        // large filler pushes the single chunk far over the cap.
+        let filler = "x".repeat(4096);
+        let full_body = format!("_submit_token={token}&title={filler}");
+        let full_len = full_body.len();
+        assert!(full_len > 64, "body must exceed the scan cap for this test");
+        let make = || {
+            Request::builder()
+                .method("POST")
+                .uri("/submit")
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .body(Body::from(full_body.clone()))
+                .unwrap()
+        };
+
+        // First submit: the guard scans the leading bytes of the over-limit
+        // chunk, runs the handler once, and the handler sees the full body.
+        let first = app.clone().oneshot(make()).await.unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+        assert!(first.headers().get(SUBMIT_TOKEN_REPLAYED).is_none());
+        assert_eq!(
+            seen_len.load(Ordering::SeqCst),
+            full_len,
+            "handler must receive the complete body, not just the scanned prefix"
+        );
+
+        // Second submit with the same token replays — proving the leading token
+        // was detected despite the over-limit first chunk.
+        let second = app.clone().oneshot(make()).await.unwrap();
+        assert_eq!(
+            second
+                .headers()
+                .get(SUBMIT_TOKEN_REPLAYED)
+                .map(|v| v.to_str().unwrap()),
+            Some("true"),
+            "an over-limit first chunk with a leading token must still be guarded"
+        );
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "handler must run exactly once"
         );
     }
 }

--- a/autumn/src/security/submit_token.rs
+++ b/autumn/src/security/submit_token.rs
@@ -1,0 +1,901 @@
+//! One-time submit tokens — at-most-once form submissions with no client JS.
+//!
+//! A user who double-clicks **Submit** (or hits Back→resubmit, or whose
+//! browser silently retries a flaky POST) can otherwise create duplicate
+//! records. The two adjacent primitives don't close this hole on their own:
+//!
+//! - [`CsrfLayer`](crate::security::CsrfLayer) mints a *stable per-session*
+//!   token — a valid `_csrf` value submitted twice passes both times.
+//! - [`IdempotencyLayer`](crate::idempotency::IdempotencyLayer) is
+//!   *header-driven* on `Idempotency-Key`, which API clients send but browsers
+//!   never attach to a plain form POST.
+//!
+//! [`SubmitTokenLayer`] fuses the per-request token plumbing with the shared
+//! idempotency store to give every scaffolded form a **server-side, default-on**
+//! at-most-once guarantee:
+//!
+//! 1. On every render a fresh random token is made available via the
+//!    [`SubmitToken`] extractor, embeddable as a hidden `_submit_token` field.
+//! 2. On a mutating request the guard extracts `_submit_token` from the form
+//!    body and consumes it against the store. First use runs the handler and
+//!    records the response; a replayed token short-circuits and replays the
+//!    first response instead of re-running the handler.
+//! 3. No client header is required — this is the explicit difference from the
+//!    `Idempotency-Key` layer.
+//!
+//! # Examples
+//!
+//! ```rust,ignore
+//! use autumn_web::prelude::*;
+//! use autumn_web::security::SubmitToken;
+//!
+//! #[get("/form")]
+//! async fn form(submit_token: SubmitToken) -> Markup {
+//!     html! {
+//!         form method="POST" action="/submit" {
+//!             input type="hidden" name="_submit_token" value=(submit_token.token());
+//!             input type="text" name="title";
+//!             button { "Submit" }
+//!         }
+//!     }
+//! }
+//! ```
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use axum::body::{Body, Bytes};
+use axum::extract::{FromRequestParts, OptionalFromRequestParts};
+use axum::http::{HeaderMap, Method, Request, Response, StatusCode};
+use futures::StreamExt as _;
+use sha2::Digest as _;
+use tower::{Layer, Service};
+use uuid::Uuid;
+
+use super::config::SubmitTokenConfig;
+use crate::idempotency::{IdempotencyRecord, IdempotencyStore};
+
+/// Response header set on a replayed submit-token response.
+const SUBMIT_TOKEN_REPLAYED: &str = "x-submit-token-replayed";
+
+/// Maximum response body size cached for replay. Scaffold create/update
+/// handlers redirect (303) with tiny bodies; larger responses stream through
+/// without caching.
+const MAX_CACHEABLE_RESPONSE_BODY: usize = 10 * 1024 * 1024; // 10 MiB
+
+/// Hard cap on the request body bytes buffered while scanning for the token.
+const MAX_SCAN_BYTES_CAP: usize = 2 * 1024 * 1024; // 2 MiB
+
+/// The configured submit-token form field name.
+///
+/// Placed in request extensions by [`SubmitTokenLayer`] so templates emit the
+/// hidden input under the correct name even when
+/// `security.submit_token.field_name` is customised.
+#[derive(Clone, Debug)]
+pub struct SubmitFormField(pub String);
+
+/// A one-time submit token minted per render.
+///
+/// Use this as a handler parameter to embed the token in an HTML form's hidden
+/// `_submit_token` field. A fresh token is generated for every request (both
+/// the GET that renders the form and the 422 re-render on a rejected POST) and
+/// stored in request extensions by [`SubmitTokenLayer`].
+#[derive(Clone, Debug)]
+pub struct SubmitToken(String);
+
+impl SubmitToken {
+    /// Returns the submit-token value for embedding in forms.
+    #[must_use]
+    pub fn token(&self) -> &str {
+        &self.0
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn new(token: String) -> Self {
+        Self(token)
+    }
+}
+
+impl std::fmt::Display for SubmitToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl<S> FromRequestParts<S> for SubmitToken
+where
+    S: Send + Sync,
+{
+    type Rejection = (StatusCode, &'static str);
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        _state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        parts.extensions.get::<Self>().cloned().ok_or((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Submit token not found in request extensions. Is SubmitTokenLayer enabled?",
+        ))
+    }
+}
+
+impl<S> OptionalFromRequestParts<S> for SubmitToken
+where
+    S: Send + Sync,
+{
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        _state: &S,
+    ) -> Result<Option<Self>, Self::Rejection> {
+        Ok(parts.extensions.get::<Self>().cloned())
+    }
+}
+
+impl<S> FromRequestParts<S> for SubmitFormField
+where
+    S: Send + Sync,
+{
+    type Rejection = (StatusCode, &'static str);
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        _state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        parts.extensions.get::<Self>().cloned().ok_or((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Submit form field not found in request extensions. Is SubmitTokenLayer enabled?",
+        ))
+    }
+}
+
+impl<S> OptionalFromRequestParts<S> for SubmitFormField
+where
+    S: Send + Sync,
+{
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        _state: &S,
+    ) -> Result<Option<Self>, Self::Rejection> {
+        Ok(parts.extensions.get::<Self>().cloned())
+    }
+}
+
+const fn is_mutating_method(method: &Method) -> bool {
+    matches!(
+        *method,
+        Method::POST | Method::PUT | Method::PATCH | Method::DELETE
+    )
+}
+
+fn hex_lower(bytes: impl AsRef<[u8]>) -> String {
+    bytes.as_ref().iter().fold(
+        String::with_capacity(bytes.as_ref().len() * 2),
+        |mut out, byte| {
+            use std::fmt::Write as _;
+            let _ = write!(out, "{byte:02x}");
+            out
+        },
+    )
+}
+
+/// Derive the store key for a submitted token. The token is a per-render random
+/// UUID, so it is globally unique and needs no method/path/principal scoping —
+/// the token itself identifies the single logical submission.
+fn storage_key(token: &str) -> String {
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(b"autumn.submit_token:v1:");
+    hasher.update(token.as_bytes());
+    format!("submit:{}", hex_lower(hasher.finalize()))
+}
+
+// ── Multipart / body scanning helpers ─────────────────────────────────────────
+
+/// Extract the `boundary` parameter from a `multipart/form-data` Content-Type.
+fn extract_multipart_boundary(content_type: &str) -> Option<&str> {
+    content_type.split(';').find_map(|part| {
+        part.trim()
+            .strip_prefix("boundary=")
+            .map(|b| b.trim_matches('"'))
+    })
+}
+
+/// Return the byte position of the first occurrence of `needle` in `haystack`.
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(0);
+    }
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Scan a buffered `multipart/form-data` body for a named text field.
+fn scan_multipart_field<'a>(bytes: &'a [u8], boundary: &str, field_name: &str) -> Option<&'a str> {
+    let delimiter = format!("--{boundary}");
+    let delim = delimiter.as_bytes();
+    let end_marker = format!("\r\n{delimiter}");
+    let end_bytes = end_marker.as_bytes();
+    let mut pos = 0;
+
+    loop {
+        let rel = find_bytes(&bytes[pos..], delim)?;
+        pos += rel + delim.len();
+
+        match bytes.get(pos..pos + 2) {
+            Some(b"\r\n") => pos += 2,
+            _ => break,
+        }
+
+        let header_end = find_bytes(&bytes[pos..], b"\r\n\r\n")?;
+        let headers = std::str::from_utf8(&bytes[pos..pos + header_end]).ok()?;
+        let value_start = pos + header_end + 4;
+
+        let is_match = headers.lines().any(|line| {
+            if !line
+                .to_ascii_lowercase()
+                .starts_with("content-disposition:")
+            {
+                return false;
+            }
+            line.split(';').skip(1).any(|attr| {
+                attr.trim()
+                    .strip_prefix("name=")
+                    .map(|v| v.trim_matches('"'))
+                    == Some(field_name)
+            })
+        });
+
+        if is_match {
+            let end = find_bytes(&bytes[value_start..], end_bytes)
+                .map_or(bytes.len(), |i| value_start + i);
+            return std::str::from_utf8(&bytes[value_start..end]).ok();
+        }
+
+        let next = find_bytes(&bytes[value_start..], end_bytes)?;
+        pos = value_start + next + 2;
+    }
+
+    None
+}
+
+fn scan_for_token(
+    bytes: &[u8],
+    is_urlencoded: bool,
+    boundary: Option<&str>,
+    field: &str,
+) -> Option<String> {
+    if is_urlencoded {
+        url::form_urlencoded::parse(bytes)
+            .find(|(key, _)| key == field)
+            .map(|(_, value)| value.into_owned())
+    } else if let Some(boundary) = boundary {
+        scan_multipart_field(bytes, boundary, field).map(str::to_owned)
+    } else {
+        None
+    }
+}
+
+/// Body collected up to a scan/cache limit.
+enum CollectedBody {
+    /// The whole body fits within the limit and is fully buffered.
+    Full(Bytes),
+    /// The body exceeded the limit. `prefix` is the bytes read before the
+    /// over-limit chunk (scanned for the token, which is always emitted early);
+    /// `body` chains the prefix with the remaining stream for pass-through.
+    Oversized { prefix: Bytes, body: Body },
+}
+
+/// Buffer `body` up to `limit` bytes without corrupting oversized bodies.
+async fn collect_body(body: Body, limit: usize) -> CollectedBody {
+    let mut buf = Vec::<u8>::new();
+    let mut stream = body.into_data_stream();
+    loop {
+        match stream.next().await {
+            // End of stream, or a mid-stream error: return what we have. The
+            // token (if any) is emitted at the front of the form, so a truncated
+            // tail is harmless for scanning; the handler receives the prefix.
+            None | Some(Err(_)) => break,
+            Some(Ok(chunk)) => {
+                if chunk.len() > limit.saturating_sub(buf.len()) {
+                    let prefix = Bytes::from(buf.clone());
+                    let mut leading = Vec::with_capacity(2);
+                    if !buf.is_empty() {
+                        leading.push(Ok::<Bytes, axum::Error>(Bytes::from(buf)));
+                    }
+                    leading.push(Ok::<Bytes, axum::Error>(chunk));
+                    let body = Body::from_stream(futures::stream::iter(leading).chain(stream));
+                    return CollectedBody::Oversized { prefix, body };
+                }
+                buf.extend_from_slice(&chunk);
+            }
+        }
+    }
+    CollectedBody::Full(Bytes::from(buf))
+}
+
+/// Extract the submitted `_submit_token` from the request body, returning the
+/// token (if present) and a request whose body is preserved for the handler.
+async fn extract_submitted_token(
+    req: Request<Body>,
+    field: &str,
+    max_scan_bytes: usize,
+) -> (Option<String>, Request<Body>) {
+    let (parts, body) = req.into_parts();
+
+    let content_type = parts
+        .headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+    let is_urlencoded = content_type.starts_with("application/x-www-form-urlencoded");
+    let boundary = if content_type.starts_with("multipart/form-data") {
+        extract_multipart_boundary(content_type).map(str::to_owned)
+    } else {
+        None
+    };
+    // content_type borrow ends here.
+
+    if !is_urlencoded && boundary.is_none() {
+        return (None, Request::from_parts(parts, body));
+    }
+
+    match collect_body(body, max_scan_bytes).await {
+        CollectedBody::Full(bytes) => {
+            let token = scan_for_token(&bytes, is_urlencoded, boundary.as_deref(), field);
+            (token, Request::from_parts(parts, Body::from(bytes)))
+        }
+        CollectedBody::Oversized { prefix, body } => {
+            let token = scan_for_token(&prefix, is_urlencoded, boundary.as_deref(), field);
+            (token, Request::from_parts(parts, body))
+        }
+    }
+}
+
+/// Headers to strip when caching a response for replay: hop-by-hop headers plus
+/// `set-cookie` (never resurrect a stale cookie on a replay) and our own marker.
+fn replay_headers(headers: &HeaderMap) -> Vec<(String, Vec<u8>)> {
+    const SKIP: &[&str] = &[
+        "connection",
+        "transfer-encoding",
+        "keep-alive",
+        "upgrade",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "set-cookie",
+        SUBMIT_TOKEN_REPLAYED,
+    ];
+    headers
+        .iter()
+        .filter(|(name, _)| !SKIP.contains(&name.as_str()))
+        .map(|(name, value)| (name.to_string(), value.as_bytes().to_vec()))
+        .collect()
+}
+
+fn replay_response(record: &IdempotencyRecord) -> Response<Body> {
+    let mut builder = Response::builder().status(record.status);
+    for (name, value) in &record.headers {
+        builder = builder.header(name.as_str(), value.as_slice());
+    }
+    builder
+        .header(SUBMIT_TOKEN_REPLAYED, "true")
+        .body(Body::from(record.body.clone()))
+        .unwrap_or_else(|_| {
+            let mut resp = Response::new(Body::empty());
+            *resp.status_mut() =
+                StatusCode::from_u16(record.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            resp
+        })
+}
+
+fn in_flight_conflict_response() -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::CONFLICT)
+        .header("retry-after", "1")
+        .body(Body::from(
+            "this form submission is already being processed; retry after 1 second",
+        ))
+        .unwrap_or_else(|_| Response::new(Body::empty()))
+}
+
+// ── Layer / Service ───────────────────────────────────────────────────────────
+
+struct SubmitTokenSettings {
+    store: Arc<dyn IdempotencyStore>,
+    field_name: String,
+    ttl: Duration,
+    in_flight_ttl: Duration,
+    exempt_paths: Vec<String>,
+    max_scan_bytes: usize,
+}
+
+// `Arc::make_mut` in the builder methods requires `Clone` on the inner value.
+impl Clone for SubmitTokenSettings {
+    fn clone(&self) -> Self {
+        Self {
+            store: Arc::clone(&self.store),
+            field_name: self.field_name.clone(),
+            ttl: self.ttl,
+            in_flight_ttl: self.in_flight_ttl,
+            exempt_paths: self.exempt_paths.clone(),
+            max_scan_bytes: self.max_scan_bytes,
+        }
+    }
+}
+
+/// Tower [`Layer`] that enforces at-most-once form submissions via one-time
+/// submit tokens.
+///
+/// Applied automatically when `security.submit_token.enabled = true` in config
+/// (the default). Mints a fresh [`SubmitToken`] into request extensions on every
+/// request, and guards mutating requests that carry a `_submit_token` form
+/// field.
+#[derive(Clone)]
+pub struct SubmitTokenLayer {
+    settings: Arc<SubmitTokenSettings>,
+}
+
+impl std::fmt::Debug for SubmitTokenLayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SubmitTokenLayer")
+            .field("field_name", &self.settings.field_name)
+            .field("ttl", &self.settings.ttl)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SubmitTokenLayer {
+    /// Create a new submit-token layer backed by `store` and configured from
+    /// `config`.
+    #[must_use]
+    pub fn new(store: Arc<dyn IdempotencyStore>, config: &SubmitTokenConfig) -> Self {
+        let ttl = Duration::from_secs(config.ttl_secs);
+        Self {
+            settings: Arc::new(SubmitTokenSettings {
+                store,
+                field_name: config.field_name.clone(),
+                ttl,
+                in_flight_ttl: ttl,
+                exempt_paths: config.exempt_paths.clone(),
+                max_scan_bytes: MAX_SCAN_BYTES_CAP,
+            }),
+        }
+    }
+
+    /// Limit the form-body bytes read when scanning for the token field. The
+    /// effective limit is `min(n, 2 MiB)`.
+    #[must_use]
+    pub fn with_max_scan_bytes(mut self, n: usize) -> Self {
+        Arc::make_mut(&mut self.settings).max_scan_bytes = n.min(MAX_SCAN_BYTES_CAP);
+        self
+    }
+
+    /// Add a path prefix that is exempt from submit-token guarding.
+    #[must_use]
+    pub fn with_exempt_path(mut self, path: impl Into<String>) -> Self {
+        Arc::make_mut(&mut self.settings)
+            .exempt_paths
+            .push(path.into());
+        self
+    }
+}
+
+impl<S> Layer<S> for SubmitTokenLayer {
+    type Service = SubmitTokenService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        SubmitTokenService {
+            inner,
+            settings: Arc::clone(&self.settings),
+        }
+    }
+}
+
+/// Tower [`Service`] produced by [`SubmitTokenLayer`].
+#[derive(Clone)]
+pub struct SubmitTokenService<S> {
+    inner: S,
+    settings: Arc<SubmitTokenSettings>,
+}
+
+impl<S> Service<Request<Body>> for SubmitTokenService<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>, Error = std::convert::Infallible>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = Response<Body>;
+    type Error = std::convert::Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<Body>) -> Self::Future {
+        // Mint a fresh token for every request and expose it via extensions so
+        // GET renders and 422 re-renders can embed it in the next form.
+        let minted = Uuid::new_v4().to_string();
+        req.extensions_mut().insert(SubmitToken(minted));
+        req.extensions_mut()
+            .insert(SubmitFormField(self.settings.field_name.clone()));
+
+        let clean = crate::security::path::clean_path(req.uri().path());
+        let path = clean.as_str();
+        let is_exempt = self.settings.exempt_paths.iter().any(|prefix| {
+            if path == prefix {
+                true
+            } else if let Some(stripped) = path.strip_prefix(prefix) {
+                prefix.ends_with('/') || stripped.starts_with('/')
+            } else {
+                false
+            }
+        });
+        let is_guarded = !is_exempt && is_mutating_method(req.method());
+
+        let settings = Arc::clone(&self.settings);
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        Box::pin(async move {
+            if !is_guarded {
+                return inner.call(req).await;
+            }
+
+            let (submitted, req) =
+                extract_submitted_token(req, &settings.field_name, settings.max_scan_bytes).await;
+
+            let Some(token) = submitted.filter(|t| !t.is_empty()) else {
+                // No submit token present — pass through unchanged.
+                return inner.call(req).await;
+            };
+
+            let key = storage_key(&token);
+
+            // Already consumed — replay the stored first response.
+            if let Some(entry) = settings.store.get(&key) {
+                return Ok(replay_response(&entry.record));
+            }
+
+            // Acquire the in-flight lock. A concurrent duplicate that loses the
+            // race gets a 409 so it can never re-run the handler.
+            if !settings.store.try_lock(&key, settings.in_flight_ttl) {
+                return Ok(in_flight_conflict_response());
+            }
+
+            // Double-check after locking: a racing request may have completed
+            // and stored its response between our miss and the lock acquisition.
+            if let Some(entry) = settings.store.get(&key) {
+                settings.store.unlock(&key);
+                return Ok(replay_response(&entry.record));
+            }
+
+            let response = inner.call(req).await?;
+            let (parts, body) = response.into_parts();
+
+            match collect_body(body, MAX_CACHEABLE_RESPONSE_BODY).await {
+                CollectedBody::Full(bytes) => {
+                    let status = parts.status.as_u16();
+                    // Cache successful (2xx) and redirect (3xx) responses so the
+                    // replayed submit returns the first response verbatim.
+                    if (200..400).contains(&status) {
+                        let record = IdempotencyRecord {
+                            status,
+                            headers: replay_headers(&parts.headers),
+                            body: bytes.to_vec(),
+                            metadata: Vec::new(),
+                        };
+                        settings.store.set(&key, record, Vec::new(), settings.ttl);
+                    }
+                    settings.store.unlock(&key);
+                    Ok(Response::from_parts(parts, Body::from(bytes)))
+                }
+                CollectedBody::Oversized { body, .. } => {
+                    // Too large to cache — stream through. The lock is released;
+                    // a later retry re-runs (acceptable: form responses are tiny
+                    // redirects, so this path is not hit in practice).
+                    settings.store.unlock(&key);
+                    Ok(Response::from_parts(parts, body))
+                }
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::idempotency::MemoryIdempotencyStore;
+    use axum::Router;
+    use axum::routing::{get, post};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tower::ServiceExt;
+
+    fn default_config() -> SubmitTokenConfig {
+        SubmitTokenConfig {
+            enabled: true,
+            ..Default::default()
+        }
+    }
+
+    fn layer_with_store(store: Arc<dyn IdempotencyStore>) -> SubmitTokenLayer {
+        SubmitTokenLayer::new(store, &default_config())
+    }
+
+    fn urlencoded_post(token: &str) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/submit")
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .body(Body::from(format!("_submit_token={token}&title=hello")))
+            .unwrap()
+    }
+
+    #[test]
+    fn submit_token_extractor_exposes_value() {
+        let token = SubmitToken::new("abc-123".to_owned());
+        assert_eq!(token.token(), "abc-123");
+        assert_eq!(token.to_string(), "abc-123");
+    }
+
+    #[tokio::test]
+    async fn mints_token_available_to_extractor() {
+        async fn handler(submit_token: SubmitToken) -> String {
+            submit_token.token().to_owned()
+        }
+        let store: Arc<dyn IdempotencyStore> =
+            Arc::new(MemoryIdempotencyStore::new(Duration::from_secs(600)));
+        let app = Router::new()
+            .route("/", get(handler))
+            .layer(layer_with_store(store));
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let token = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            Uuid::parse_str(&token).is_ok(),
+            "minted token should be a uuid: {token}"
+        );
+    }
+
+    #[tokio::test]
+    async fn first_use_runs_handler_replay_short_circuits() {
+        let store: Arc<dyn IdempotencyStore> =
+            Arc::new(MemoryIdempotencyStore::new(Duration::from_secs(600)));
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_inner = count.clone();
+        let app = Router::new()
+            .route(
+                "/submit",
+                post(move || {
+                    let count = count_inner.clone();
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        "created"
+                    }
+                }),
+            )
+            .layer(layer_with_store(store));
+
+        let token = "tok-replay";
+        // First submit runs the handler.
+        let first = app.clone().oneshot(urlencoded_post(token)).await.unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+        assert!(first.headers().get(SUBMIT_TOKEN_REPLAYED).is_none());
+        let first_body = axum::body::to_bytes(first.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(&first_body[..], b"created");
+
+        // Second submit with the same token replays without re-running.
+        let second = app.clone().oneshot(urlencoded_post(token)).await.unwrap();
+        assert_eq!(second.status(), StatusCode::OK);
+        assert_eq!(
+            second
+                .headers()
+                .get(SUBMIT_TOKEN_REPLAYED)
+                .map(|v| v.to_str().unwrap()),
+            Some("true")
+        );
+        let second_body = axum::body::to_bytes(second.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(&second_body[..], b"created");
+
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "handler must run exactly once"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_token_passes_through() {
+        let store: Arc<dyn IdempotencyStore> =
+            Arc::new(MemoryIdempotencyStore::new(Duration::from_secs(600)));
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_inner = count.clone();
+        let app = Router::new()
+            .route(
+                "/submit",
+                post(move || {
+                    let count = count_inner.clone();
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        "ok"
+                    }
+                }),
+            )
+            .layer(layer_with_store(store));
+
+        // No `_submit_token` field — both requests run the handler.
+        for _ in 0..2 {
+            let req = Request::builder()
+                .method("POST")
+                .uri("/submit")
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .body(Body::from("title=hello"))
+                .unwrap();
+            let resp = app.clone().oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+        }
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn expired_token_re_runs_after_ttl() {
+        // A very short TTL means the stored record expires and a later submit
+        // re-runs rather than replaying.
+        let store = MemoryIdempotencyStore::new(Duration::from_millis(10));
+        let key = storage_key("ttl-token");
+        store.set(
+            &key,
+            IdempotencyRecord {
+                status: 200,
+                headers: Vec::new(),
+                body: b"first".to_vec(),
+                metadata: Vec::new(),
+            },
+            Vec::new(),
+            Duration::from_millis(10),
+        );
+        assert!(store.get(&key).is_some());
+        std::thread::sleep(Duration::from_millis(30));
+        assert!(
+            store.get(&key).is_none(),
+            "record must expire after its TTL"
+        );
+    }
+
+    #[tokio::test]
+    async fn distinct_from_csrf_replayed_submit_token_short_circuits() {
+        // Even a request that would pass CSRF is short-circuited when its
+        // submit token has already been consumed: the guard consults the store,
+        // not the CSRF cookie/token.
+        let store: Arc<dyn IdempotencyStore> =
+            Arc::new(MemoryIdempotencyStore::new(Duration::from_secs(600)));
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_inner = count.clone();
+        let app = Router::new()
+            .route(
+                "/submit",
+                post(move || {
+                    let count = count_inner.clone();
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        "created"
+                    }
+                }),
+            )
+            .layer(layer_with_store(store));
+
+        let token = "tok-csrf-distinct";
+        // Each submit carries a valid _csrf field alongside the submit token.
+        let build = || {
+            Request::builder()
+                .method("POST")
+                .uri("/submit")
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .body(Body::from(format!(
+                    "_csrf=valid-csrf&_submit_token={token}"
+                )))
+                .unwrap()
+        };
+        let first = app.clone().oneshot(build()).await.unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+        // A replay with the same submit token (and a still-valid _csrf) is
+        // short-circuited by the guard.
+        let second = app.clone().oneshot(build()).await.unwrap();
+        assert_eq!(
+            second
+                .headers()
+                .get(SUBMIT_TOKEN_REPLAYED)
+                .map(|v| v.to_str().unwrap()),
+            Some("true")
+        );
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+    }
+
+    /// Success metric (AC #7): 10 identical concurrent POSTs at a scaffolded
+    /// create endpoint persist exactly ONE row; the replays return the first
+    /// response without re-running the side effect.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn ten_concurrent_posts_persist_exactly_one_row() {
+        let store: Arc<dyn IdempotencyStore> =
+            Arc::new(MemoryIdempotencyStore::new(Duration::from_secs(600)));
+        // Simulates the durable side effect (a DB insert).
+        let rows = Arc::new(AtomicUsize::new(0));
+        let rows_inner = rows.clone();
+        let app = Router::new()
+            .route(
+                "/posts",
+                post(move || {
+                    let rows = rows_inner.clone();
+                    async move {
+                        // Simulate real work so requests genuinely overlap.
+                        tokio::time::sleep(Duration::from_millis(20)).await;
+                        rows.fetch_add(1, Ordering::SeqCst);
+                        (StatusCode::SEE_OTHER, [("location", "/posts")], "")
+                    }
+                }),
+            )
+            .layer(layer_with_store(store));
+
+        let token = "concurrent-token";
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            let app = app.clone();
+            handles.push(tokio::spawn(async move {
+                let req = Request::builder()
+                    .method("POST")
+                    .uri("/posts")
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .body(Body::from(format!("_submit_token={token}&title=hello")))
+                    .unwrap();
+                app.oneshot(req).await.unwrap().status()
+            }));
+        }
+
+        let mut succeeded = 0;
+        let mut conflicts = 0;
+        for h in handles {
+            let status = h.await.unwrap();
+            if status == StatusCode::SEE_OTHER {
+                succeeded += 1;
+            } else if status == StatusCode::CONFLICT {
+                conflicts += 1;
+            } else {
+                panic!("unexpected status: {status}");
+            }
+        }
+
+        assert_eq!(
+            rows.load(Ordering::SeqCst),
+            1,
+            "exactly one row must be persisted from 10 concurrent identical POSTs"
+        );
+        assert_eq!(
+            succeeded + conflicts,
+            10,
+            "every request must either return the first response or be rejected in-flight"
+        );
+        assert!(
+            succeeded >= 1,
+            "at least the first submission must succeed and be replayable"
+        );
+    }
+}

--- a/autumn/src/security/submit_token.rs
+++ b/autumn/src/security/submit_token.rs
@@ -576,9 +576,22 @@ where
 
             let key = storage_key(&token);
 
-            // Already consumed — replay the stored first response.
-            if let Some(entry) = settings.store.get(&key) {
-                return Ok(replay_response(&entry.record));
+            // Already consumed — replay the stored first response. Use the
+            // fallible `try_get` so a backend read/deserialization failure fails
+            // CLOSED (matching `IdempotencyService`'s lookup path) instead of
+            // collapsing to a cache miss: a swallowed error would fall through,
+            // acquire a fresh lock, and re-run the mutation for an
+            // already-consumed token. No lock is held yet, so surface `503`.
+            match settings.store.try_get(&key) {
+                Ok(Some(entry)) => return Ok(replay_response(&entry.record)),
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::error!(
+                        error = %error,
+                        "Submit-token consumed-token lookup failed; failing closed"
+                    );
+                    return Ok(crate::idempotency::persistence_failed_response());
+                }
             }
 
             // Acquire the in-flight lock. A concurrent duplicate that loses the
@@ -589,9 +602,24 @@ where
 
             // Double-check after locking: a racing request may have completed
             // and stored its response between our miss and the lock acquisition.
-            if let Some(entry) = settings.store.get(&key) {
-                settings.store.unlock(&key);
-                return Ok(replay_response(&entry.record));
+            // A read failure here must also fail closed. Because we now hold the
+            // in-flight lock, keep it held (do NOT unlock, letting it expire via
+            // `in_flight_ttl`) so a retry with the same token is rejected
+            // in-flight rather than re-running the handler — exactly as
+            // `IdempotencyService` does on a post-lock lookup error.
+            match settings.store.try_get(&key) {
+                Ok(Some(entry)) => {
+                    settings.store.unlock(&key);
+                    return Ok(replay_response(&entry.record));
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::error!(
+                        error = %error,
+                        "Submit-token consumed-token lookup failed after lock acquisition; failing closed"
+                    );
+                    return Ok(crate::idempotency::persistence_failed_response());
+                }
             }
 
             let response = inner.call(req).await?;
@@ -1105,6 +1133,106 @@ mod tests {
             count.load(Ordering::SeqCst),
             1,
             "the handler must run at most once even when persistence fails"
+        );
+    }
+
+    /// Store stub whose consumed-token lookups can be flipped to fail. Locking
+    /// and writes behave like the in-memory store so a token can first be
+    /// consumed, then have its lookup fail on replay. Mirrors the write-side
+    /// `FailingSetStore` to prove the READ path also fails closed.
+    struct FailingGetStore {
+        inner: MemoryIdempotencyStore,
+        fail_reads: std::sync::atomic::AtomicBool,
+    }
+
+    impl FailingGetStore {
+        fn new() -> Self {
+            Self {
+                inner: MemoryIdempotencyStore::new(Duration::from_secs(600)),
+                fail_reads: std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+    }
+
+    impl IdempotencyStore for FailingGetStore {
+        fn get(&self, key: &str) -> Option<IdempotencyEntry> {
+            // The infallible path collapses a read failure to a cache miss —
+            // exactly the fail-open behaviour the guard must NOT rely on. It
+            // uses `try_get` instead, so this stays here only for the trait.
+            if self.fail_reads.load(Ordering::SeqCst) {
+                None
+            } else {
+                self.inner.get(key)
+            }
+        }
+
+        fn try_get(&self, key: &str) -> Result<Option<IdempotencyEntry>, IdempotencyStoreError> {
+            if self.fail_reads.load(Ordering::SeqCst) {
+                Err(IdempotencyStoreError::backend(
+                    "simulated consumed-token lookup failure",
+                ))
+            } else {
+                self.inner.try_get(key)
+            }
+        }
+
+        fn set(&self, key: &str, record: IdempotencyRecord, body_hash: Vec<u8>, ttl: Duration) {
+            self.inner.set(key, record, body_hash, ttl);
+        }
+
+        fn try_lock(&self, key: &str, lock_ttl: Duration) -> bool {
+            self.inner.try_lock(key, lock_ttl)
+        }
+
+        fn unlock(&self, key: &str) {
+            self.inner.unlock(key);
+        }
+    }
+
+    /// Finding (fail closed on read): once a token has been consumed, a backend
+    /// read failure on the consumed-token lookup must NOT collapse to a cache
+    /// miss that acquires a fresh lock and re-runs the mutation. The guard uses
+    /// the fallible `try_get`, so a lookup error fails closed with `503` and the
+    /// handler is not re-run — matching `IdempotencyService`'s lookup path.
+    #[tokio::test]
+    async fn read_failure_fails_closed_and_does_not_rerun() {
+        let store = Arc::new(FailingGetStore::new());
+        let store_dyn: Arc<dyn IdempotencyStore> = store.clone();
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_inner = count.clone();
+        let app = Router::new()
+            .route(
+                "/submit",
+                post(move || {
+                    let count = count_inner.clone();
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        "created"
+                    }
+                }),
+            )
+            .layer(layer_with_store(store_dyn));
+
+        let token = "tok-read-fail";
+
+        // First submit consumes the token and records the response.
+        let first = app.clone().oneshot(urlencoded_post(token)).await.unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+
+        // Now make consumed-token lookups fail. A replay must fail closed with
+        // 503 rather than treating the errored lookup as a miss and re-running.
+        store.fail_reads.store(true, Ordering::SeqCst);
+        let second = app.clone().oneshot(urlencoded_post(token)).await.unwrap();
+        assert_eq!(
+            second.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "a consumed-token lookup failure must fail closed, not re-run the handler"
+        );
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "the handler must not re-run when the consumed-token lookup fails"
         );
     }
 }


### PR DESCRIPTION
## Before / After (plain language)

**Before:** Double-clicking **Submit** on a scaffolded form — or hitting Back→resubmit, or a browser silently retrying a flaky POST — created a duplicate row (a second order, comment, or signup). CSRF didn't help (a valid `_csrf` passes twice), and the `Idempotency-Key` layer is header-driven, which browsers never attach to a plain form POST.

**After:** Double-clicking Submit on a scaffolded form no longer creates duplicate rows — the second POST replays the first response instead of re-running the handler. This is a server-side, default-on guarantee with **no client-side JavaScript**.

## How

- **New `SubmitToken` extractor** (mirrors `CsrfToken::token()` ergonomics), `SubmitFormField`, and a `SubmitTokenLayer` (`autumn/src/security/submit_token.rs`) that **reuses the existing idempotency store** backend (in-memory in dev, Redis in prod). The layer mints a fresh per-render token into request extensions so forms can embed it, and on a mutating POST consumes the submitted `_submit_token`: first use runs the handler and caches the response; an already-consumed token short-circuits and replays the first response (or a concurrent duplicate gets `409`). Guarded by a **form field, not a header**, so it works on a bare browser submit. Configurable TTL (default 600s / 10 min), bounded memory.

- **Config + router wiring:** `[security.submit_token]` block (enabled by default). The layer is applied **inner to CSRF**, so a request carrying a valid `_csrf` but a replayed `_submit_token` is still short-circuited (AC #4).

- **Scaffold:** `autumn generate scaffold` embeds a hidden `_submit_token` field in the generated **create** and **update** forms (via a `submit_token_input()` helper beside `csrf_input`) and threads the `SubmitToken` extractor through the create/update handlers, making them idempotent under a double-click.

## Tests

- Unit coverage for mint / consume-once / replay / TTL / distinct-from-CSRF.
- **Success metric (AC #7):** a concurrency test fires **10 identical concurrent POSTs** at a scaffolded create endpoint and asserts **exactly 1 row** is persisted (the other 9 replay the first response or are rejected in-flight — no duplicate side effects).
- Scaffold string assertions and the generated-app cargo-check updated for the new hidden field and handler param.

Public API is additive; the workspace version is unchanged.

Closes #1360


---
_Generated by [Claude Code](https://claude.ai/code/session_01AR2sZELD9MSvAVkxhhLGHg)_