### PR TITLE
Support model-declared has_many(dependent = nullify)

### DIFF
--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -749,7 +749,17 @@ fn emit_association_items(
                         let mut __groups: ::std::collections::HashMap<i64, #stored_ty> =
                             ::std::collections::HashMap::new();
                         for __child in __children {
-                            __groups.entry(__child.#fk_ident).or_default().push(__child);
+                            // Normalize the child's FK (which may be `i64` or a
+                            // nullable `Option<i64>`, as every `dependent =
+                            // nullify` child has) to an `Option<i64>` key and
+                            // drop orphan (`None`-FK, detached) children — they
+                            // belong to no loaded parent. Non-null FKs are always
+                            // `Some`, so this is byte-identical for them.
+                            if let ::core::option::Option::Some(__k) =
+                                ::autumn_web::preload::FkKey::autumn_fk_key(&__child.#fk_ident)
+                            {
+                                __groups.entry(__k).or_default().push(__child);
+                            }
                         }
                         for __r in records.iter_mut() {
                             let __v: #stored_ty = __groups.remove(&__r.id).unwrap_or_default();

--- a/autumn/src/preload.rs
+++ b/autumn/src/preload.rs
@@ -252,6 +252,38 @@ pub trait AutumnPreloadScopeExt {
 
 impl<T: ?Sized> AutumnPreloadScopeExt for T {}
 
+/// Normalizes a `#[has_many]` child's foreign-key field to `Option<i64>` so the
+/// preload loader can group children uniformly whether the FK column is `NOT
+/// NULL` (`i64`) or nullable (`Option<i64>`, as every `dependent = nullify`
+/// child has).
+///
+/// The `#[has_many]` preload loader groups children into a `HashMap<i64, _>`
+/// keyed by the child's FK field, but the `#[model]` macro has no type
+/// information for that field at expansion time. Both FK shapes implement this
+/// trait, so the generated grouping can call [`FkKey::autumn_fk_key`] and skip
+/// `None` (orphan / detached) children without the macro needing to know the
+/// field's Rust type.
+///
+/// This is framework plumbing, not a public API.
+#[doc(hidden)]
+pub trait FkKey {
+    /// The grouping key, or `None` for a detached (nullified) child that
+    /// belongs to no parent.
+    fn autumn_fk_key(&self) -> ::core::option::Option<i64>;
+}
+
+impl FkKey for i64 {
+    fn autumn_fk_key(&self) -> ::core::option::Option<i64> {
+        ::core::option::Option::Some(*self)
+    }
+}
+
+impl FkKey for ::core::option::Option<i64> {
+    fn autumn_fk_key(&self) -> ::core::option::Option<i64> {
+        *self
+    }
+}
+
 #[cfg(feature = "db")]
 tokio::task_local! {
     /// Set by a repository's `preload` to the repository's `across_tenants`

--- a/autumn/tests/integration/repository_dependent_destroy.rs
+++ b/autumn/tests/integration/repository_dependent_destroy.rs
@@ -182,16 +182,18 @@ pub trait DepAwardRepository {}
 // → `PgDepCommentRepository`, etc.). Reuses the existing child tables/repos via
 // an explicit `fk = "post_id"` (the default would infer `model_dep_post_id`).
 //
-// `dependent = nullify` is intentionally omitted here: a nullify child has a
-// NULLABLE foreign key, and `#[has_many]` preload codegen does not yet support
-// a nullable child FK (it groups children into a `HashMap<i64, _>` keyed by the
-// non-`Option` FK). That is a pre-existing preload limitation, independent of
-// the cascade dispatch; tracked as a #1738 follow-up. destroy/delete_all/
-// restrict all target non-null-FK children and cascade from the model side.
+// #1786: `dependent = nullify` is declared model-side too. A nullify child has a
+// NULLABLE foreign key (`DepBookmark::post_id: Option<i64>`); the `#[has_many]`
+// preload loader now normalizes the child FK through `preload::FkKey` (grouping
+// on `Option<i64>` and dropping `None`-FK orphans), so declaring a nullable-FK
+// association compiles and its model-side cascade (`dependents()`) sets the
+// child FK to NULL. destroy/delete_all/restrict/nullify all cascade from the
+// model side.
 #[autumn_web::model(table = "dep_posts")]
 #[has_many(DepComment, fk = "post_id", name = md_comments, dependent = destroy)]
 #[has_many(DepVote, fk = "post_id", name = md_votes, dependent = delete_all)]
 #[has_many(DepAward, fk = "post_id", name = md_awards, dependent = restrict)]
+#[has_many(DepBookmark, fk = "post_id", name = md_bookmarks, dependent = nullify)]
 pub struct ModelDepPost {
     #[id]
     pub id: i64,
@@ -904,9 +906,12 @@ fn dependent_repository_surface_is_generated() {
     // four actions: destroy + delete_all + restrict) type-checks.
     assert_is_fn(<PgModelDepPostRepository as ModelDepPostRepository>::delete_many);
     // The model exposes its runtime dependent specs (inherent shadow of
-    // `AutumnDependents::dependents`): destroy + delete_all + restrict.
+    // `AutumnDependents::dependents`): destroy + delete_all + restrict + nullify.
+    // #1786: the `nullify` child (`DepBookmark`, nullable `post_id: Option<i64>`)
+    // is now declared model-side — the has_many preload loader groups the child
+    // through `preload::FkKey`, so a nullable-FK association compiles.
     assert_is_fn(ModelDepPost::dependents);
-    assert_eq!(ModelDepPost::dependents().len(), 3);
+    assert_eq!(ModelDepPost::dependents().len(), 4);
     // Codex P1: the fully model-side three-level graph monomorphizes. The key
     // new codegen is the intermediate `M3Comment`'s cascade leaf executor —
     // its Destroy arm now runtime-dispatches into `M3Comment::dependents()`
@@ -1941,6 +1946,68 @@ async fn model_declared_dependent_cascades_like_repository_attribute() {
         .await,
         0,
         "delete_all child rows removed via the model-declared cascade"
+    );
+}
+
+/// #1786: model-declared `#[has_many(dependent = nullify)]` sets the child FK to
+/// NULL from the MODEL side — the nullable-FK (`DepBookmark::post_id:
+/// Option<i64>`) association now compiles (`has_many` preload groups through
+/// `preload::FkKey`), and deleting the `ModelDepPost` detaches its bookmarks:
+/// the rows survive with `post_id IS NULL`, mirroring the repository-attribute
+/// nullify test but driven by `ModelDepPost::dependents()`.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn model_declared_nullify_detaches_children() {
+    let (pool, _c) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+
+    diesel::sql_query("INSERT INTO dep_posts (id, title) VALUES (33, 'model-nullify')")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    for i in 1..=3 {
+        diesel::sql_query(format!(
+            "INSERT INTO dep_bookmarks (id, post_id, label) VALUES ({}, 33, 'b{i}')",
+            300 + i
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    }
+
+    let repo = PgModelDepPostRepository::with_pool_untracked(pool.clone());
+    repo.delete_by_id(33)
+        .await
+        .expect("model-declared nullify cascade must not FK-error");
+
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_posts WHERE id = 33"
+        )
+        .await,
+        0,
+        "parent gone"
+    );
+    // nullify: bookmark rows survive but detached (FK set NULL) via the
+    // model-declared cascade.
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_bookmarks WHERE post_id = 33"
+        )
+        .await,
+        0,
+        "no bookmark still points at the deleted parent"
+    );
+    assert_eq!(
+        count(
+            &mut conn,
+            "SELECT COUNT(*) AS n FROM dep_bookmarks WHERE post_id IS NULL AND id IN (301, 302, 303)"
+        )
+        .await,
+        3,
+        "nullify child rows survive detached (post_id = NULL) via the model-declared cascade"
     );
 }
 


### PR DESCRIPTION
Closes #1786.

## Before
Declaring `#[has_many(Child, dependent = nullify)]` on a `#[model]` struct failed to compile. A `nullify` child has a nullable foreign key (`post_id: Option<i64>`), but declaring *any* `#[has_many]` emits a preload loader that groups children into a `HashMap<i64, _>` keyed directly on the child's FK field. For a nullable FK that grouping is an `expected i64, found Option<i64>` type error — so model-side nullify could not even be declared, despite the runtime cascade dispatch already handling the `nullify` action. Model-side nullify was left out of the fixtures for exactly this reason.

## After
`#[has_many(Child, fk = "...", dependent = nullify)]` compiles and cascades from the model side: deleting the parent sets each child's FK to `NULL`, and the child rows survive detached. Existing non-null `#[has_many]` associations are unaffected.

## How
- Added a framework-internal `preload::FkKey` trait implemented for both `i64` and `Option<i64>`, normalizing a child's FK to `Option<i64>`.
- Rewrote the has_many preload grouping (`autumn-macros/src/model.rs`) to route the key through `FkKey::autumn_fk_key`, skipping `None`-FK (orphan / detached) children. Non-null FKs are always `Some`, so the generated grouping is behavior-identical for existing associations. The m2m/`through` loader (non-null join FKs) is untouched.
- Test fixture `ModelDepPost` now declares `#[has_many(DepBookmark, dependent = nullify)]` (nullable `post_id`) — the compile-level acceptance test — with a bumped `dependents().len()` assertion (3 → 4) and a Docker-gated runtime test asserting the model-side delete detaches bookmarks (`post_id IS NULL`, rows survive).

---
_Generated by [Claude Code](https://claude.ai/code/session_016bcBbx7WE5P1J9WowpB8T9)_