### PR TITLE
Part of #1706: typed accessible UI primitives (compile-time accessible-name obligation)

### DIFF
--- a/autumn/src/a11y.rs
+++ b/autumn/src/a11y.rs
@@ -1,0 +1,494 @@
+//! Typed accessible UI primitives — accessibility conformance by construction
+//! (issue #1706).
+//!
+//! Autumn renders every view through Maud, which means an inaccessible page is
+//! usually just a missing attribute away: an `<img>` with no `alt`, an
+//! icon-only `<button>` with no accessible name, an `<input>` with no
+//! associated `<label>`. Those omissions compile cleanly and only surface in an
+//! audit (or, worse, for a user relying on assistive technology).
+//!
+//! The primitives in this module make the accessible name a **type-level
+//! obligation** rather than a convention. Each one maps to a WCAG 2.1 success
+//! criterion and is constructed so that the inaccessible form does not compile:
+//!
+//! - [`Img`] — WCAG 1.1.1 Non-text Content. The alt text is a mandatory
+//!   positional argument of [`Img::new`]; there is no alt-less constructor.
+//!   Decorative images opt in explicitly with [`Img::decorative`].
+//! - [`Button`] — WCAG 4.1.2 Name, Role, Value. The accessible name is a
+//!   required argument; an icon-only button routes it to `aria-label` via
+//!   [`Button::icon`].
+//! - [`TextField`] — WCAG 1.3.1 Info and Relationships / 3.3.2 Labels or
+//!   Instructions / 4.1.2 Name, Role, Value. A [`TextField<NoLabel>`] has no
+//!   way to render; only after a label is attached (producing a
+//!   [`TextField<Labeled>`]) does the type implement [`maud::Render`]. An
+//!   unlabeled field is therefore unrepresentable as markup.
+//!
+//! All three implement [`maud::Render`], so they splice directly into an
+//! `html!` block:
+//!
+//! ```rust
+//! use autumn_web::a11y::{Button, Img, TextField};
+//! use autumn_web::html;
+//!
+//! let page = html! {
+//!     (Img::new("/logo.svg", "Autumn logo"))
+//!     (TextField::new("email").input_type("email").label("Email address"))
+//!     (Button::new("Save").submit())
+//! };
+//! assert!(page.into_string().contains("alt=\"Autumn logo\""));
+//! ```
+
+use maud::{Markup, Render, html};
+
+/// An informative or decorative image with a mandatory accessible name
+/// (WCAG 1.1.1 Non-text Content).
+///
+/// Construct an informative image with [`Img::new`], which requires the `alt`
+/// text as a positional argument — there is no way to build an `Img` without
+/// one. Purely decorative images use [`Img::decorative`], which sets an
+/// explicit empty `alt=""` so assistive technology skips them.
+#[derive(Debug, Clone)]
+pub struct Img {
+    src: String,
+    alt: String,
+    class: Option<String>,
+    width: Option<u32>,
+    height: Option<u32>,
+}
+
+impl Img {
+    /// Build an informative image. The accessible name (`alt`) is required.
+    ///
+    /// ```rust
+    /// use autumn_web::a11y::Img;
+    /// use maud::Render;
+    ///
+    /// let markup = Img::new("/hero.png", "A field at sunrise").render();
+    /// assert!(markup.into_string().contains("alt=\"A field at sunrise\""));
+    /// ```
+    pub fn new(src: impl Into<String>, alt: impl Into<String>) -> Self {
+        Self {
+            src: src.into(),
+            alt: alt.into(),
+            class: None,
+            width: None,
+            height: None,
+        }
+    }
+
+    /// Build a decorative image with an explicit empty `alt=""`.
+    ///
+    /// This documents intent: the image conveys no information, so assistive
+    /// technology should ignore it. An empty `alt` is the WCAG-valid marker
+    /// for a decorative image — distinct from a *missing* `alt`.
+    pub fn decorative(src: impl Into<String>) -> Self {
+        Self {
+            src: src.into(),
+            alt: String::new(),
+            class: None,
+            width: None,
+            height: None,
+        }
+    }
+
+    /// Set the `class` attribute.
+    #[must_use]
+    pub fn class(mut self, class: impl Into<String>) -> Self {
+        self.class = Some(class.into());
+        self
+    }
+
+    /// Set the `width` attribute (in pixels).
+    #[must_use]
+    pub const fn width(mut self, width: u32) -> Self {
+        self.width = Some(width);
+        self
+    }
+
+    /// Set the `height` attribute (in pixels).
+    #[must_use]
+    pub const fn height(mut self, height: u32) -> Self {
+        self.height = Some(height);
+        self
+    }
+}
+
+impl Render for Img {
+    fn render(&self) -> Markup {
+        html! {
+            img
+                src=(self.src)
+                alt=(self.alt)
+                class=[self.class.as_deref()]
+                width=[self.width]
+                height=[self.height];
+        }
+    }
+}
+
+/// The `type` of a [`Button`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ButtonType {
+    /// `type="button"` — an inert button driven by JavaScript/htmx.
+    #[default]
+    Button,
+    /// `type="submit"` — submits the enclosing form.
+    Submit,
+    /// `type="reset"` — resets the enclosing form.
+    Reset,
+}
+
+impl ButtonType {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Button => "button",
+            Self::Submit => "submit",
+            Self::Reset => "reset",
+        }
+    }
+}
+
+/// A button with a mandatory accessible name (WCAG 4.1.2 Name, Role, Value).
+///
+/// [`Button::new`] takes the visible text label as a required argument.
+/// [`Button::icon`] builds an icon-only button whose accessible name becomes an
+/// `aria-label`, so an icon button can never ship without a name. There is no
+/// name-less constructor.
+#[derive(Debug, Clone)]
+pub struct Button {
+    accessible_name: String,
+    icon: Option<Markup>,
+    kind: ButtonType,
+    class: Option<String>,
+}
+
+impl Button {
+    /// Build a button with a visible text label, which is also its accessible
+    /// name. The label is required.
+    ///
+    /// ```rust
+    /// use autumn_web::a11y::Button;
+    /// use maud::Render;
+    ///
+    /// assert!(Button::new("Save").render().into_string().contains("Save"));
+    /// ```
+    pub fn new(accessible_name: impl Into<String>) -> Self {
+        Self {
+            accessible_name: accessible_name.into(),
+            icon: None,
+            kind: ButtonType::default(),
+            class: None,
+        }
+    }
+
+    /// Build an icon-only button. The `accessible_name` becomes the button's
+    /// `aria-label`, since the icon carries no text for assistive technology.
+    ///
+    /// ```rust
+    /// use autumn_web::a11y::Button;
+    /// use autumn_web::html;
+    /// use maud::Render;
+    ///
+    /// let trash = html! { span aria-hidden="true" { "🗑" } };
+    /// let markup = Button::icon(trash, "Delete item").render().into_string();
+    /// assert!(markup.contains("aria-label=\"Delete item\""));
+    /// ```
+    pub fn icon(icon: Markup, accessible_name: impl Into<String>) -> Self {
+        Self {
+            accessible_name: accessible_name.into(),
+            icon: Some(icon),
+            kind: ButtonType::default(),
+            class: None,
+        }
+    }
+
+    /// Set the button `type` explicitly.
+    #[must_use]
+    pub const fn kind(mut self, kind: ButtonType) -> Self {
+        self.kind = kind;
+        self
+    }
+
+    /// Shorthand for `type="submit"`.
+    #[must_use]
+    pub const fn submit(mut self) -> Self {
+        self.kind = ButtonType::Submit;
+        self
+    }
+
+    /// Shorthand for `type="button"` (the default).
+    #[must_use]
+    pub const fn button(mut self) -> Self {
+        self.kind = ButtonType::Button;
+        self
+    }
+
+    /// Set the `class` attribute.
+    #[must_use]
+    pub fn class(mut self, class: impl Into<String>) -> Self {
+        self.class = Some(class.into());
+        self
+    }
+}
+
+impl Render for Button {
+    fn render(&self) -> Markup {
+        self.icon.as_ref().map_or_else(
+            || {
+                html! {
+                    button type=(self.kind.as_str()) class=[self.class.as_deref()] {
+                        (self.accessible_name)
+                    }
+                }
+            },
+            |icon| {
+                html! {
+                    button
+                        type=(self.kind.as_str())
+                        aria-label=(self.accessible_name)
+                        class=[self.class.as_deref()] {
+                        (icon)
+                    }
+                }
+            },
+        )
+    }
+}
+
+/// Typestate marker: a [`TextField`] with no label attached yet. This state
+/// does **not** implement [`maud::Render`], so it cannot be turned into markup.
+#[derive(Debug, Clone, Copy)]
+pub struct NoLabel;
+
+/// Typestate marker: a [`TextField`] whose label has been attached. Only this
+/// state implements [`maud::Render`].
+#[derive(Debug, Clone, Copy)]
+pub struct Labeled;
+
+/// How a [`TextField`]'s accessible name is provided.
+#[derive(Debug, Clone)]
+enum LabelSource {
+    /// A visible `<label for=…>` element.
+    Visible(String),
+    /// An `aria-label` attribute (no visible label).
+    Aria(String),
+    /// An `aria-labelledby` reference to an existing element's `id`.
+    LabelledBy(String),
+}
+
+/// A text input whose label association is enforced by the type system
+/// (WCAG 1.3.1 Info and Relationships, 3.3.2 Labels or Instructions,
+/// 4.1.2 Name, Role, Value).
+///
+/// [`TextField::new`] returns a `TextField<NoLabel>`, which has no way to
+/// render. Attaching a label with [`label`](TextField::label),
+/// [`aria_label`](TextField::aria_label), or
+/// [`labelled_by`](TextField::labelled_by) consumes it and returns a
+/// `TextField<Labeled>`, the only state that implements [`maud::Render`]. An
+/// unlabeled field therefore cannot be turned into markup — the accessible
+/// name obligation is discharged at compile time.
+///
+/// The value/type/required attributes are chainable in either state.
+#[derive(Debug, Clone)]
+pub struct TextField<State> {
+    name: String,
+    input_type: String,
+    value: Option<String>,
+    required: bool,
+    label: Option<LabelSource>,
+    _state: std::marker::PhantomData<State>,
+}
+
+impl TextField<NoLabel> {
+    /// Start building a text field with the given form `name`. The returned
+    /// value has no label yet and cannot be rendered until one is attached.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            input_type: "text".to_owned(),
+            value: None,
+            required: false,
+            label: None,
+            _state: std::marker::PhantomData,
+        }
+    }
+
+    /// Attach a visible `<label for=…>` and transition to the renderable
+    /// [`Labeled`] state.
+    #[must_use]
+    pub fn label(self, text: impl Into<String>) -> TextField<Labeled> {
+        self.with_label(LabelSource::Visible(text.into()))
+    }
+
+    /// Attach an `aria-label` (no visible label) and transition to the
+    /// renderable [`Labeled`] state.
+    #[must_use]
+    pub fn aria_label(self, text: impl Into<String>) -> TextField<Labeled> {
+        self.with_label(LabelSource::Aria(text.into()))
+    }
+
+    /// Reference an existing element's `id` via `aria-labelledby` and
+    /// transition to the renderable [`Labeled`] state.
+    #[must_use]
+    pub fn labelled_by(self, id: impl Into<String>) -> TextField<Labeled> {
+        self.with_label(LabelSource::LabelledBy(id.into()))
+    }
+
+    fn with_label(self, label: LabelSource) -> TextField<Labeled> {
+        TextField {
+            name: self.name,
+            input_type: self.input_type,
+            value: self.value,
+            required: self.required,
+            label: Some(label),
+            _state: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<State> TextField<State> {
+    /// Set the input `type` (e.g. `"email"`, `"password"`). Available before or
+    /// after a label is attached.
+    #[must_use]
+    pub fn input_type(mut self, input_type: impl Into<String>) -> Self {
+        self.input_type = input_type.into();
+        self
+    }
+
+    /// Set the input's initial `value`.
+    #[must_use]
+    pub fn value(mut self, value: impl Into<String>) -> Self {
+        self.value = Some(value.into());
+        self
+    }
+
+    /// Mark the input as `required`.
+    #[must_use]
+    pub const fn required(mut self) -> Self {
+        self.required = true;
+        self
+    }
+}
+
+impl Render for TextField<Labeled> {
+    fn render(&self) -> Markup {
+        // `label` is always `Some` in the `Labeled` state — it is set on every
+        // transition out of `NoLabel` — but match defensively rather than
+        // unwrap.
+        match &self.label {
+            Some(LabelSource::Visible(text)) => html! {
+                label for=(self.name) { (text) }
+                input
+                    type=(self.input_type)
+                    id=(self.name)
+                    name=(self.name)
+                    value=[self.value.as_deref()]
+                    required[self.required];
+            },
+            Some(LabelSource::Aria(text)) => html! {
+                input
+                    type=(self.input_type)
+                    id=(self.name)
+                    name=(self.name)
+                    aria-label=(text)
+                    value=[self.value.as_deref()]
+                    required[self.required];
+            },
+            Some(LabelSource::LabelledBy(id)) => html! {
+                input
+                    type=(self.input_type)
+                    id=(self.name)
+                    name=(self.name)
+                    aria-labelledby=(id)
+                    value=[self.value.as_deref()]
+                    required[self.required];
+            },
+            None => html! {},
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn img_new_requires_and_renders_alt() {
+        let markup = Img::new("/logo.png", "Company logo").render().into_string();
+        assert!(markup.contains("src=\"/logo.png\""));
+        assert!(markup.contains("alt=\"Company logo\""));
+    }
+
+    #[test]
+    fn img_decorative_sets_empty_alt() {
+        let markup = Img::decorative("/divider.png").render().into_string();
+        assert!(markup.contains("alt=\"\""));
+    }
+
+    #[test]
+    fn img_escapes_alt_text() {
+        let markup = Img::new("/x.png", "a \"quoted\" & <tagged> name")
+            .render()
+            .into_string();
+        assert!(!markup.contains("<tagged>"));
+        assert!(markup.contains("&lt;tagged&gt;"));
+    }
+
+    #[test]
+    fn button_new_renders_visible_label() {
+        let markup = Button::new("Save").submit().render().into_string();
+        assert!(markup.contains("type=\"submit\""));
+        assert!(markup.contains(">Save<"));
+        assert!(!markup.contains("aria-label"));
+    }
+
+    #[test]
+    fn button_icon_uses_aria_label() {
+        let icon = html! { span aria-hidden="true" { "x" } };
+        let markup = Button::icon(icon, "Close dialog").render().into_string();
+        assert!(markup.contains("aria-label=\"Close dialog\""));
+    }
+
+    #[test]
+    fn text_field_visible_label_is_associated() {
+        let markup = TextField::new("email")
+            .input_type("email")
+            .label("Email address")
+            .render()
+            .into_string();
+        assert!(markup.contains("<label for=\"email\">Email address</label>"));
+        assert!(markup.contains("id=\"email\""));
+        assert!(markup.contains("name=\"email\""));
+        assert!(markup.contains("type=\"email\""));
+    }
+
+    #[test]
+    fn text_field_aria_label_variant() {
+        let markup = TextField::new("q")
+            .aria_label("Search")
+            .render()
+            .into_string();
+        assert!(markup.contains("aria-label=\"Search\""));
+    }
+
+    #[test]
+    fn text_field_labelled_by_variant() {
+        let markup = TextField::new("q")
+            .labelled_by("search-heading")
+            .render()
+            .into_string();
+        assert!(markup.contains("aria-labelledby=\"search-heading\""));
+    }
+
+    #[test]
+    fn text_field_required_and_value() {
+        let markup = TextField::new("name")
+            .value("Ada")
+            .required()
+            .label("Name")
+            .render()
+            .into_string();
+        assert!(markup.contains("value=\"Ada\""));
+        assert!(markup.contains("required"));
+    }
+}

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -66,6 +66,11 @@
 #[allow(unused_extern_crates)]
 extern crate self as autumn_web;
 
+/// Typed accessible UI primitives (issue #1706).
+///
+/// These make the accessible name a compile-time obligation. See [`mod@a11y`].
+#[cfg(feature = "maud")]
+pub mod a11y;
 pub mod actuator;
 pub mod aggregate;
 /// Operator alerts for built-in failure conditions.

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -39,6 +39,10 @@ pub use autumn_macros::{
 pub use autumn_macros::{mail_previews, mailer, mailer_preview};
 
 // ── Rendering ────────────────────────────────────────────────────
+/// Typed accessible UI primitives — accessible name enforced at compile time.
+/// See [`crate::a11y`] for the full API.
+#[cfg(feature = "maud")]
+pub use crate::a11y::{Button, ButtonType, Img, TextField};
 /// Resolve a logical static asset path to a fingerprinted URL in release builds.
 pub use crate::assets::asset_url;
 /// Render a `<script>` tag with SRI integrity for a named vendored JS dependency.

--- a/autumn/tests/compile-fail/a11y_button_missing_name.rs
+++ b/autumn/tests/compile-fail/a11y_button_missing_name.rs
@@ -1,0 +1,9 @@
+//! Issue #1706: a `Button` without an accessible name does not compile.
+//! WCAG 4.1.2 — the name is a required argument, so a name-less button is
+//! unrepresentable.
+
+use autumn_web::a11y::Button;
+
+fn main() {
+    let _button = Button::new();
+}

--- a/autumn/tests/compile-fail/a11y_button_missing_name.stderr
+++ b/autumn/tests/compile-fail/a11y_button_missing_name.stderr
@@ -1,0 +1,15 @@
+error[E0061]: this function takes 1 argument but 0 arguments were supplied
+ --> tests/compile-fail/a11y_button_missing_name.rs:8:19
+  |
+8 |     let _button = Button::new();
+  |                   ^^^^^^^^^^^-- argument #1 is missing
+  |
+note: associated function defined here
+ --> src/a11y.rs
+  |
+  |     pub fn new(accessible_name: impl Into<String>) -> Self {
+  |            ^^^
+help: provide the argument
+  |
+8 |     let _button = Button::new(/* accessible_name */);
+  |                               +++++++++++++++++++++

--- a/autumn/tests/compile-fail/a11y_img_missing_alt.rs
+++ b/autumn/tests/compile-fail/a11y_img_missing_alt.rs
@@ -1,0 +1,9 @@
+//! Issue #1706: an `Img` without alt text does not compile. WCAG 1.1.1 — the
+//! accessible name is a mandatory positional argument, so an alt-less image is
+//! unrepresentable.
+
+use autumn_web::a11y::Img;
+
+fn main() {
+    let _img = Img::new("/logo.png");
+}

--- a/autumn/tests/compile-fail/a11y_img_missing_alt.stderr
+++ b/autumn/tests/compile-fail/a11y_img_missing_alt.stderr
@@ -1,0 +1,15 @@
+error[E0061]: this function takes 2 arguments but 1 argument was supplied
+ --> tests/compile-fail/a11y_img_missing_alt.rs:8:16
+  |
+8 |     let _img = Img::new("/logo.png");
+  |                ^^^^^^^^------------- argument #2 is missing
+  |
+note: associated function defined here
+ --> src/a11y.rs
+  |
+  |     pub fn new(src: impl Into<String>, alt: impl Into<String>) -> Self {
+  |            ^^^
+help: provide the argument
+  |
+8 |     let _img = Img::new("/logo.png", /* alt */);
+  |                                    +++++++++++

--- a/autumn/tests/compile-fail/a11y_textfield_unlabeled.rs
+++ b/autumn/tests/compile-fail/a11y_textfield_unlabeled.rs
@@ -1,0 +1,11 @@
+//! Issue #1706: an unlabeled `TextField` cannot be rendered. WCAG 1.3.1 /
+//! 3.3.2 / 4.1.2 — only `TextField<Labeled>` implements `Render`, so calling
+//! `.render()` on a `TextField<NoLabel>` (no `.label(..)`/`.aria_label(..)`/
+//! `.labelled_by(..)`) is a compile error.
+
+use autumn_web::a11y::TextField;
+use maud::Render;
+
+fn main() {
+    let _markup = TextField::new("email").render();
+}

--- a/autumn/tests/compile-fail/a11y_textfield_unlabeled.stderr
+++ b/autumn/tests/compile-fail/a11y_textfield_unlabeled.stderr
@@ -1,0 +1,5 @@
+error[E0599]: no method named `render` found for struct `TextField<State>` in the current scope
+  --> tests/compile-fail/a11y_textfield_unlabeled.rs:10:43
+   |
+10 |     let _markup = TextField::new("email").render();
+   |                                           ^^^^^^ method not found in `TextField<NoLabel>`

--- a/autumn/tests/compile-pass/a11y_primitives.rs
+++ b/autumn/tests/compile-pass/a11y_primitives.rs
@@ -1,0 +1,38 @@
+//! Issue #1706: the accessible forms of the typed a11y primitives compile.
+//!
+//! Each primitive can only be constructed with an accessible name, and only a
+//! labeled `TextField` can be rendered — these are exactly those forms.
+
+use autumn_web::a11y::{Button, ButtonType, Img, TextField};
+use autumn_web::html;
+use maud::Render;
+
+fn main() {
+    // Informative image: alt is a required positional argument.
+    let _informative = Img::new("/logo.png", "Company logo")
+        .class("logo")
+        .width(120)
+        .height(40)
+        .render();
+
+    // Decorative image: explicit empty alt, opt-in.
+    let _decorative = Img::decorative("/divider.png").render();
+
+    // Text button carries its own accessible name.
+    let _save = Button::new("Save").submit().render();
+
+    // Icon button routes the accessible name to aria-label.
+    let icon = html! { span aria-hidden="true" { "x" } };
+    let _close = Button::icon(icon, "Close").kind(ButtonType::Button).render();
+
+    // A labeled text field is renderable; the label is associated with the input.
+    let _email = TextField::new("email")
+        .input_type("email")
+        .required()
+        .label("Email address")
+        .render();
+
+    // aria-label and aria-labelledby are equally valid labeling strategies.
+    let _search = TextField::new("q").aria_label("Search").render();
+    let _named = TextField::new("q").labelled_by("search-heading").render();
+}

--- a/autumn/tests/integration/a11y.rs
+++ b/autumn/tests/integration/a11y.rs
@@ -1,0 +1,90 @@
+//!
+//! Integration tests for the typed accessible UI primitives (issue #1706).
+//!
+//! These assert the *rendered* markup carries the accessible-name attributes
+//! each primitive is responsible for. The compile-time obligation (that an
+//! inaccessible primitive cannot be constructed or rendered at all) is proven
+//! separately by the trybuild fixtures in `tests/compile-fail/a11y_*.rs`.
+//!
+#![cfg(feature = "maud")]
+
+use autumn_web::a11y::{Button, Img, TextField};
+use autumn_web::html;
+use maud::Render;
+
+#[test]
+fn img_renders_required_alt() {
+    let markup = Img::new("/logo.png", "Company logo").render().into_string();
+    assert!(markup.contains("src=\"/logo.png\""), "{markup}");
+    assert!(markup.contains("alt=\"Company logo\""), "{markup}");
+}
+
+#[test]
+fn img_decorative_has_empty_alt() {
+    let markup = Img::decorative("/divider.png").render().into_string();
+    assert!(markup.contains("alt=\"\""), "{markup}");
+}
+
+#[test]
+fn button_text_label_has_no_aria_label() {
+    let markup = Button::new("Save").submit().render().into_string();
+    assert!(markup.contains("type=\"submit\""), "{markup}");
+    assert!(markup.contains(">Save<"), "{markup}");
+    assert!(!markup.contains("aria-label"), "{markup}");
+}
+
+#[test]
+fn icon_button_uses_aria_label() {
+    let icon = html! { span aria-hidden="true" { "x" } };
+    let markup = Button::icon(icon, "Close dialog").render().into_string();
+    assert!(markup.contains("aria-label=\"Close dialog\""), "{markup}");
+}
+
+#[test]
+fn labeled_text_field_associates_label_and_input() {
+    let markup = TextField::new("email")
+        .input_type("email")
+        .required()
+        .label("Email address")
+        .render()
+        .into_string();
+    assert!(
+        markup.contains("<label for=\"email\">Email address</label>"),
+        "{markup}"
+    );
+    assert!(markup.contains("id=\"email\""), "{markup}");
+    assert!(markup.contains("name=\"email\""), "{markup}");
+    assert!(markup.contains("type=\"email\""), "{markup}");
+    assert!(markup.contains("required"), "{markup}");
+}
+
+#[test]
+fn text_field_aria_label_and_labelled_by_variants() {
+    let aria = TextField::new("q")
+        .aria_label("Search")
+        .render()
+        .into_string();
+    assert!(aria.contains("aria-label=\"Search\""), "{aria}");
+
+    let by = TextField::new("q")
+        .labelled_by("search-heading")
+        .render()
+        .into_string();
+    assert!(by.contains("aria-labelledby=\"search-heading\""), "{by}");
+}
+
+#[test]
+fn splices_inside_html_block() {
+    let page = html! {
+        (Img::new("/logo.svg", "Autumn logo"))
+        (TextField::new("email").input_type("email").label("Email address"))
+        (Button::new("Save").submit())
+    };
+    let s = page.into_string();
+    assert!(s.contains("alt=\"Autumn logo\""), "{s}");
+    assert!(
+        s.contains("<label for=\"email\">Email address</label>"),
+        "{s}"
+    );
+    assert!(s.contains(">Save<"), "{s}");
+}

--- a/autumn/tests/integration/compile_fail.rs
+++ b/autumn/tests/integration/compile_fail.rs
@@ -50,6 +50,15 @@ fn compile_fail_tests() {
     // (issue #1526).
     #[cfg(feature = "maud")]
     t.compile_fail("tests/compile-fail/story_captures_environment.rs");
+
+    // Typed accessible UI primitives (#1706): an accessible name is a
+    // compile-time obligation, so inaccessible construction does not build.
+    #[cfg(feature = "maud")]
+    t.compile_fail("tests/compile-fail/a11y_img_missing_alt.rs");
+    #[cfg(feature = "maud")]
+    t.compile_fail("tests/compile-fail/a11y_button_missing_name.rs");
+    #[cfg(feature = "maud")]
+    t.compile_fail("tests/compile-fail/a11y_textfield_unlabeled.rs");
 }
 
 #[test]
@@ -69,6 +78,10 @@ fn compile_pass_tests() {
     // Maud + form/json handlers (require maud feature)
     #[cfg(feature = "maud")]
     t.pass("tests/compile-pass/json_form_handlers.rs");
+
+    // Typed accessible UI primitives (#1706): the accessible forms build.
+    #[cfg(feature = "maud")]
+    t.pass("tests/compile-pass/a11y_primitives.rs");
 
     // Model derive (requires db feature)
     #[cfg(feature = "db")]

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "maud")]
+mod a11y;
 mod access_log;
 mod acting_as_integration;
 mod after_commit_integration;

--- a/docs/guide/accessibility.md
+++ b/docs/guide/accessibility.md
@@ -421,6 +421,73 @@ accessibility posture hasn't regressed.
 
 ---
 
+## Typed accessible primitives (`autumn_web::a11y`)
+
+The form helpers above make the *right* thing easy. The primitives in
+`autumn_web::a11y` go one step further and make the *wrong* thing impossible:
+they encode the accessible name as a **type-level obligation**, so an image
+without alt text, a button without a name, or an input without a label does not
+compile. This is accessibility conformance by construction, proven at build
+time by the framework's compile-fail test harness.
+
+Each primitive implements `maud::Render`, so it splices straight into an
+`html!` block, and maps to a specific WCAG 2.1 success criterion:
+
+| Primitive    | WCAG SC                                                      | Obligation                                       |
+| ------------ | ----------------------------------------------------------- | ------------------------------------------------ |
+| `Img`        | 1.1.1 Non-text Content                                      | `alt` is a required constructor argument         |
+| `Button`     | 4.1.2 Name, Role, Value                                     | accessible name is a required constructor argument |
+| `TextField`  | 1.3.1 Info and Relationships / 3.3.2 Labels / 4.1.2         | only a *labeled* field can be rendered (typestate) |
+
+```rust
+use autumn_web::a11y::{Button, Img, TextField};
+use autumn_web::html;
+
+let page = html! {
+    (Img::new("/logo.svg", "Autumn logo"))                 // alt required
+    (Img::decorative("/divider.svg"))                       // explicit alt=""
+    (TextField::new("email").input_type("email").label("Email address"))
+    (Button::icon(html! { span aria-hidden="true" { "🗑" } }, "Delete"))
+    (Button::new("Save").submit())
+};
+```
+
+### Red build → fix → green build
+
+**Red** — an alt-less image or an unlabeled input used to compile clean. With
+the typed primitives it does not:
+
+```rust
+// error[E0061]: this function takes 2 arguments but 1 argument was supplied
+let _ = Img::new("/logo.png");
+
+// error: no method named `render` found for `TextField<NoLabel>`
+//        — an unlabeled field cannot be turned into markup
+let _ = TextField::new("email").render();
+```
+
+**Fix** — supply the accessible name / attach a label:
+
+```rust
+let _ = Img::new("/logo.png", "Company logo");            // ✅ compiles
+let _ = TextField::new("email").label("Email").render();  // ✅ compiles
+```
+
+**Green** — the build passes only once every primitive carries its accessible
+name. `TextField::new(..)` returns a `TextField<NoLabel>`; attaching a label
+with `.label(..)`, `.aria_label(..)`, or `.labelled_by(..)` transitions it to
+`TextField<Labeled>`, the only state that implements `Render`. There is no
+`.render()`/`.build()` on the unlabeled state, so an unlabeled field is
+literally unrepresentable as markup.
+
+What this proves at compile time: the *presence* of an accessible name on every
+image, button, and text field. What still belongs to runtime/authoring review:
+whether that name is *meaningful* (a helpful `alt`, not `"image"`), plus page
+structure, contrast, and focus order — the checklist and audit tooling above
+cover those.
+
+---
+
 ## Further reading
 
 - [WCAG 2.1 Quick Reference](https://www.w3.org/WAI/WCAG21/quickref/)


### PR DESCRIPTION
Slice A of #1706. Introduces `autumn_web::a11y` — typed UI primitives that make the accessible name a **compile-time obligation** rather than a convention.

## Before / After

**Before:** an inaccessible view compiles clean and only surfaces in an audit (or for a user on assistive technology):

```rust
html! { img src="/logo.png"; }              // no alt — compiles fine
html! { input type="email" name="email"; }  // no label — compiles fine
html! { button { (icon) } }                 // icon-only, no name — compiles fine
```

**After:** using the typed primitives, the inaccessible form does **not build**:

```rust
Img::new("/logo.png");                       // error[E0061]: alt argument missing
Button::new();                               // error[E0061]: accessible name missing
TextField::new("email").render();            // error[E0599]: no `render` on TextField<NoLabel>
```

## How

- **Typed constructors** — `Img::new(src, alt)` and `Button::new(name)` take the accessible name as a required argument; there is no name-less constructor. Decorative images opt in explicitly with `Img::decorative(src)` (explicit `alt=""`); icon buttons use `Button::icon(icon, name)`, routing the name to `aria-label`.
- **Typestate** — `TextField::new(name)` returns a `TextField<NoLabel>`. Attaching a label via `.label(..)` / `.aria_label(..)` / `.labelled_by(..)` consumes it and returns a `TextField<Labeled>`. Only `TextField<Labeled>` implements `maud::Render`, so an unlabeled field is unrepresentable as markup.
- All three implement `maud::Render` and splice directly into `html!` blocks; re-exported from the prelude.
- **trybuild proof** — compile-fail fixtures (`a11y_img_missing_alt`, `a11y_button_missing_name`, `a11y_textfield_unlabeled`) assert the inaccessible forms fail to build, and a compile-pass fixture (`a11y_primitives`) asserts the accessible forms compile. Unit + integration tests assert the rendered markup carries the expected attributes.

## WCAG success criteria

| Primitive   | WCAG SC                                              | Obligation                                       |
| ----------- | --------------------------------------------------- | ------------------------------------------------ |
| `Img`       | 1.1.1 Non-text Content                              | `alt` is a required constructor argument         |
| `Button`    | 4.1.2 Name, Role, Value                             | accessible name is a required constructor argument |
| `TextField` | 1.3.1 Info and Relationships / 3.3.2 Labels / 4.1.2 | only a labeled field can be rendered (typestate) |

## Proven at compile time vs. still runtime

**Proven at compile time:** the *presence* of an accessible name on every image, button, and text field — an alt-less image, name-less button, or unlabeled input cannot be constructed or rendered.

**Still runtime / authoring review (NOT proven):** whether the name is *meaningful* (a helpful `alt`, not `"image"`); a decorative image's empty alt being genuinely appropriate; color contrast; and any markup written by hand in a raw `html!` block, which bypasses these primitives entirely.

## Follow-ons

- Adopt the primitives in scaffold codegen so generated views are accessible by default.
- Add more primitives (links, form groups, disclosure/dialog patterns).
- An `autumn a11y verify` pass to flag hand-written `html!` that sidesteps the typed primitives.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pf5JUv54F6Bxo8KzErU9sz)_