### PR TITLE
Part of #1706: typed accessible Link and MenuItem primitives

### DIFF
--- a/autumn/src/a11y.rs
+++ b/autumn/src/a11y.rs
@@ -17,6 +17,13 @@
 //! - [`Button`] — WCAG 4.1.2 Name, Role, Value. The accessible name is a
 //!   required argument; an icon-only button routes it to `aria-label` via
 //!   [`Button::icon`].
+//! - [`Link`] — WCAG 2.4.4 Link Purpose (In Context) / 4.1.2 Name, Role, Value.
+//!   The link text is a required argument of [`Link::new`]; an icon-only link
+//!   routes its name to `aria-label` via [`Link::icon`]. There is no text-less
+//!   constructor.
+//! - [`MenuItem`] — WCAG 4.1.2 Name, Role, Value. A menu item carries an
+//!   explicit `role="menuitem"` and a required accessible name from
+//!   [`MenuItem::new`]; an icon-only item routes that name to `aria-label`.
 //! - [`TextField`] — WCAG 1.3.1 Info and Relationships / 3.3.2 Labels or
 //!   Instructions / 4.1.2 Name, Role, Value. A [`TextField<NoLabel>`] has no
 //!   way to render; only after a label is attached (producing a
@@ -248,6 +255,209 @@ impl Render for Button {
                         aria-label=(self.accessible_name)
                         class=[self.class.as_deref()] {
                         (icon)
+                    }
+                }
+            },
+        )
+    }
+}
+
+/// A hyperlink with a mandatory accessible name (WCAG 2.4.4 Link Purpose (In
+/// Context) / 4.1.2 Name, Role, Value).
+///
+/// [`Link::new`] takes the visible link text as a required positional argument,
+/// so a text-less link cannot be built. [`Link::icon`] builds an icon-only link
+/// whose accessible name becomes an `aria-label`. There is no name-less
+/// constructor.
+#[derive(Debug, Clone)]
+pub struct Link {
+    href: String,
+    accessible_name: String,
+    icon: Option<Markup>,
+    class: Option<String>,
+    new_tab: bool,
+}
+
+impl Link {
+    /// Build a link with visible text, which is also its accessible name. Both
+    /// the `href` and the `text` are required.
+    ///
+    /// ```rust
+    /// use autumn_web::a11y::Link;
+    /// use maud::Render;
+    ///
+    /// let markup = Link::new("/about", "About us").render().into_string();
+    /// assert!(markup.contains("href=\"/about\""));
+    /// assert!(markup.contains(">About us<"));
+    /// ```
+    pub fn new(href: impl Into<String>, text: impl Into<String>) -> Self {
+        Self {
+            href: href.into(),
+            accessible_name: text.into(),
+            icon: None,
+            class: None,
+            new_tab: false,
+        }
+    }
+
+    /// Build an icon-only link. The `accessible_name` becomes the link's
+    /// `aria-label`, since the icon carries no text for assistive technology.
+    ///
+    /// ```rust
+    /// use autumn_web::a11y::Link;
+    /// use autumn_web::html;
+    /// use maud::Render;
+    ///
+    /// let glyph = html! { span aria-hidden="true" { "gh" } };
+    /// let markup = Link::icon("https://example.com", glyph, "GitHub")
+    ///     .render()
+    ///     .into_string();
+    /// assert!(markup.contains("aria-label=\"GitHub\""));
+    /// ```
+    pub fn icon(href: impl Into<String>, icon: Markup, accessible_name: impl Into<String>) -> Self {
+        Self {
+            href: href.into(),
+            accessible_name: accessible_name.into(),
+            icon: Some(icon),
+            class: None,
+            new_tab: false,
+        }
+    }
+
+    /// Open the link in a new browsing context (`target="_blank"`), adding
+    /// `rel="noopener noreferrer"` so the opened page cannot reach back through
+    /// `window.opener`.
+    #[must_use]
+    pub const fn new_tab(mut self) -> Self {
+        self.new_tab = true;
+        self
+    }
+
+    /// Set the `class` attribute.
+    #[must_use]
+    pub fn class(mut self, class: impl Into<String>) -> Self {
+        self.class = Some(class.into());
+        self
+    }
+}
+
+impl Render for Link {
+    fn render(&self) -> Markup {
+        let target = self.new_tab.then_some("_blank");
+        let rel = self.new_tab.then_some("noopener noreferrer");
+        self.icon.as_ref().map_or_else(
+            || {
+                html! {
+                    a href=(self.href) target=[target] rel=[rel] class=[self.class.as_deref()] {
+                        (self.accessible_name)
+                    }
+                }
+            },
+            |icon| {
+                html! {
+                    a
+                        href=(self.href)
+                        aria-label=(self.accessible_name)
+                        target=[target]
+                        rel=[rel]
+                        class=[self.class.as_deref()] {
+                        (icon)
+                    }
+                }
+            },
+        )
+    }
+}
+
+/// An interactive menu item with a mandatory accessible name and an explicit
+/// `role="menuitem"` (WCAG 4.1.2 Name, Role, Value).
+///
+/// [`MenuItem::new`] takes the visible label as a required argument. By default
+/// the item renders as a `<button type="button" role="menuitem">`; attaching an
+/// [`href`](MenuItem::href) renders it as an `<a role="menuitem">` instead.
+/// Adding an [`icon`](MenuItem::icon) routes the accessible name to
+/// `aria-label`, so an icon-only item can never ship without a name. There is
+/// no name-less constructor.
+#[derive(Debug, Clone)]
+pub struct MenuItem {
+    accessible_name: String,
+    href: Option<String>,
+    icon: Option<Markup>,
+    class: Option<String>,
+}
+
+impl MenuItem {
+    /// Build a menu item with a visible label, which is also its accessible
+    /// name. The label is required.
+    ///
+    /// ```rust
+    /// use autumn_web::a11y::MenuItem;
+    /// use maud::Render;
+    ///
+    /// let markup = MenuItem::new("Settings").render().into_string();
+    /// assert!(markup.contains("role=\"menuitem\""));
+    /// assert!(markup.contains(">Settings<"));
+    /// ```
+    pub fn new(accessible_name: impl Into<String>) -> Self {
+        Self {
+            accessible_name: accessible_name.into(),
+            href: None,
+            icon: None,
+            class: None,
+        }
+    }
+
+    /// Render the item as a link (`<a role="menuitem" href=…>`) rather than the
+    /// default button.
+    #[must_use]
+    pub fn href(mut self, href: impl Into<String>) -> Self {
+        self.href = Some(href.into());
+        self
+    }
+
+    /// Add a leading icon. The visible label from [`MenuItem::new`] moves to
+    /// `aria-label`, keeping the accessible name intact for icon-only items.
+    #[must_use]
+    pub fn icon(mut self, icon: Markup) -> Self {
+        self.icon = Some(icon);
+        self
+    }
+
+    /// Set the `class` attribute.
+    #[must_use]
+    pub fn class(mut self, class: impl Into<String>) -> Self {
+        self.class = Some(class.into());
+        self
+    }
+}
+
+impl Render for MenuItem {
+    fn render(&self) -> Markup {
+        // An icon-only item routes its accessible name to `aria-label`; a text
+        // item renders the name as visible content.
+        let aria_label = self.icon.is_some().then_some(self.accessible_name.as_str());
+        self.href.as_deref().map_or_else(
+            || {
+                html! {
+                    button
+                        type="button"
+                        role="menuitem"
+                        aria-label=[aria_label]
+                        class=[self.class.as_deref()] {
+                        @match &self.icon {
+                            Some(icon) => (icon),
+                            None => (self.accessible_name),
+                        }
+                    }
+                }
+            },
+            |href| {
+                html! {
+                    a href=(href) role="menuitem" aria-label=[aria_label] class=[self.class.as_deref()] {
+                        @match &self.icon {
+                            Some(icon) => (icon),
+                            None => (self.accessible_name),
+                        }
                     }
                 }
             },

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -42,7 +42,7 @@ pub use autumn_macros::{mail_previews, mailer, mailer_preview};
 /// Typed accessible UI primitives — accessible name enforced at compile time.
 /// See [`crate::a11y`] for the full API.
 #[cfg(feature = "maud")]
-pub use crate::a11y::{Button, ButtonType, Img, TextField};
+pub use crate::a11y::{Button, ButtonType, Img, Link, MenuItem, TextField};
 /// Resolve a logical static asset path to a fingerprinted URL in release builds.
 pub use crate::assets::asset_url;
 /// Render a `<script>` tag with SRI integrity for a named vendored JS dependency.

--- a/autumn/tests/compile-fail/a11y_link_missing_text.rs
+++ b/autumn/tests/compile-fail/a11y_link_missing_text.rs
@@ -1,0 +1,9 @@
+//! Issue #1706: a `Link` without link text does not compile. WCAG 2.4.4 /
+//! 4.1.2 — the accessible name (link text) is a mandatory positional argument,
+//! so a text-less link is unrepresentable.
+
+use autumn_web::a11y::Link;
+
+fn main() {
+    let _link = Link::new("/about");
+}

--- a/autumn/tests/compile-fail/a11y_link_missing_text.stderr
+++ b/autumn/tests/compile-fail/a11y_link_missing_text.stderr
@@ -1,0 +1,15 @@
+error[E0061]: this function takes 2 arguments but 1 argument was supplied
+ --> tests/compile-fail/a11y_link_missing_text.rs:8:17
+  |
+8 |     let _link = Link::new("/about");
+  |                 ^^^^^^^^^---------- argument #2 is missing
+  |
+note: associated function defined here
+ --> src/a11y.rs
+  |
+  |     pub fn new(href: impl Into<String>, text: impl Into<String>) -> Self {
+  |            ^^^
+help: provide the argument
+  |
+8 |     let _link = Link::new("/about", /* text */);
+  |                                   ++++++++++++

--- a/autumn/tests/compile-fail/a11y_menuitem_missing_name.rs
+++ b/autumn/tests/compile-fail/a11y_menuitem_missing_name.rs
@@ -1,0 +1,9 @@
+//! Issue #1706: a `MenuItem` without an accessible name does not compile.
+//! WCAG 4.1.2 — the name is a required argument, so a name-less menu item is
+//! unrepresentable.
+
+use autumn_web::a11y::MenuItem;
+
+fn main() {
+    let _item = MenuItem::new();
+}

--- a/autumn/tests/compile-fail/a11y_menuitem_missing_name.stderr
+++ b/autumn/tests/compile-fail/a11y_menuitem_missing_name.stderr
@@ -1,0 +1,15 @@
+error[E0061]: this function takes 1 argument but 0 arguments were supplied
+ --> tests/compile-fail/a11y_menuitem_missing_name.rs:8:17
+  |
+8 |     let _item = MenuItem::new();
+  |                 ^^^^^^^^^^^^^-- argument #1 is missing
+  |
+note: associated function defined here
+ --> src/a11y.rs
+  |
+  |     pub fn new(accessible_name: impl Into<String>) -> Self {
+  |            ^^^
+help: provide the argument
+  |
+8 |     let _item = MenuItem::new(/* accessible_name */);
+  |                               +++++++++++++++++++++

--- a/autumn/tests/compile-pass/a11y_primitives.rs
+++ b/autumn/tests/compile-pass/a11y_primitives.rs
@@ -3,7 +3,7 @@
 //! Each primitive can only be constructed with an accessible name, and only a
 //! labeled `TextField` can be rendered — these are exactly those forms.
 
-use autumn_web::a11y::{Button, ButtonType, Img, TextField};
+use autumn_web::a11y::{Button, ButtonType, Img, Link, MenuItem, TextField};
 use autumn_web::html;
 use maud::Render;
 
@@ -35,4 +35,25 @@ fn main() {
     // aria-label and aria-labelledby are equally valid labeling strategies.
     let _search = TextField::new("q").aria_label("Search").render();
     let _named = TextField::new("q").labelled_by("search-heading").render();
+
+    // Link carries its visible text as the accessible name; href + text are both
+    // required.
+    let _about = Link::new("/about", "About us").class("nav").render();
+
+    // A link opening in a new tab sets rel="noopener noreferrer".
+    let _docs = Link::new("https://example.com", "Docs").new_tab().render();
+
+    // Icon-only link routes the accessible name to aria-label.
+    let glyph = html! { span aria-hidden="true" { "gh" } };
+    let _github = Link::icon("https://example.com", glyph, "GitHub").render();
+
+    // Menu item defaults to a button with role="menuitem".
+    let _settings = MenuItem::new("Settings").render();
+
+    // A menu item with an href renders as a link-style item.
+    let _home = MenuItem::new("Home").href("/").render();
+
+    // Icon-only menu item keeps its accessible name via aria-label.
+    let cog = html! { span aria-hidden="true" { "*" } };
+    let _icon_item = MenuItem::new("Settings").icon(cog).class("item").render();
 }

--- a/autumn/tests/integration/a11y.rs
+++ b/autumn/tests/integration/a11y.rs
@@ -8,7 +8,7 @@
 //!
 #![cfg(feature = "maud")]
 
-use autumn_web::a11y::{Button, Img, TextField};
+use autumn_web::a11y::{Button, Img, Link, MenuItem, TextField};
 use autumn_web::html;
 use maud::Render;
 
@@ -71,6 +71,59 @@ fn text_field_aria_label_and_labelled_by_variants() {
         .render()
         .into_string();
     assert!(by.contains("aria-labelledby=\"search-heading\""), "{by}");
+}
+
+#[test]
+fn link_renders_href_and_visible_text() {
+    let markup = Link::new("/about", "About us").render().into_string();
+    assert!(markup.contains("href=\"/about\""), "{markup}");
+    assert!(markup.contains(">About us<"), "{markup}");
+    assert!(!markup.contains("aria-label"), "{markup}");
+}
+
+#[test]
+fn link_new_tab_sets_rel_noopener() {
+    let markup = Link::new("https://example.com", "Docs")
+        .new_tab()
+        .render()
+        .into_string();
+    assert!(markup.contains("target=\"_blank\""), "{markup}");
+    assert!(markup.contains("rel=\"noopener noreferrer\""), "{markup}");
+}
+
+#[test]
+fn icon_link_uses_aria_label() {
+    let glyph = html! { span aria-hidden="true" { "gh" } };
+    let markup = Link::icon("https://example.com", glyph, "GitHub")
+        .render()
+        .into_string();
+    assert!(markup.contains("href=\"https://example.com\""), "{markup}");
+    assert!(markup.contains("aria-label=\"GitHub\""), "{markup}");
+}
+
+#[test]
+fn menu_item_defaults_to_button_with_role() {
+    let markup = MenuItem::new("Settings").render().into_string();
+    assert!(markup.contains("role=\"menuitem\""), "{markup}");
+    assert!(markup.contains("type=\"button\""), "{markup}");
+    assert!(markup.contains(">Settings<"), "{markup}");
+    assert!(!markup.contains("aria-label"), "{markup}");
+}
+
+#[test]
+fn menu_item_with_href_renders_link() {
+    let markup = MenuItem::new("Home").href("/").render().into_string();
+    assert!(markup.contains("role=\"menuitem\""), "{markup}");
+    assert!(markup.contains("href=\"/\""), "{markup}");
+    assert!(markup.contains(">Home<"), "{markup}");
+}
+
+#[test]
+fn icon_menu_item_uses_aria_label() {
+    let cog = html! { span aria-hidden="true" { "*" } };
+    let markup = MenuItem::new("Settings").icon(cog).render().into_string();
+    assert!(markup.contains("role=\"menuitem\""), "{markup}");
+    assert!(markup.contains("aria-label=\"Settings\""), "{markup}");
 }
 
 #[test]

--- a/autumn/tests/integration/compile_fail.rs
+++ b/autumn/tests/integration/compile_fail.rs
@@ -59,6 +59,10 @@ fn compile_fail_tests() {
     t.compile_fail("tests/compile-fail/a11y_button_missing_name.rs");
     #[cfg(feature = "maud")]
     t.compile_fail("tests/compile-fail/a11y_textfield_unlabeled.rs");
+    #[cfg(feature = "maud")]
+    t.compile_fail("tests/compile-fail/a11y_link_missing_text.rs");
+    #[cfg(feature = "maud")]
+    t.compile_fail("tests/compile-fail/a11y_menuitem_missing_name.rs");
 }
 
 #[test]

--- a/docs/guide/accessibility.md
+++ b/docs/guide/accessibility.md
@@ -437,10 +437,12 @@ Each primitive implements `maud::Render`, so it splices straight into an
 | ------------ | ----------------------------------------------------------- | ------------------------------------------------ |
 | `Img`        | 1.1.1 Non-text Content                                      | `alt` is a required constructor argument         |
 | `Button`     | 4.1.2 Name, Role, Value                                     | accessible name is a required constructor argument |
+| `Link`       | 2.4.4 Link Purpose (In Context) / 4.1.2 Name, Role, Value  | link text is a required constructor argument     |
+| `MenuItem`   | 4.1.2 Name, Role, Value                                     | accessible name is a required constructor argument (renders `role="menuitem"`) |
 | `TextField`  | 1.3.1 Info and Relationships / 3.3.2 Labels / 4.1.2         | only a *labeled* field can be rendered (typestate) |
 
 ```rust
-use autumn_web::a11y::{Button, Img, TextField};
+use autumn_web::a11y::{Button, Img, Link, MenuItem, TextField};
 use autumn_web::html;
 
 let page = html! {
@@ -449,8 +451,17 @@ let page = html! {
     (TextField::new("email").input_type("email").label("Email address"))
     (Button::icon(html! { span aria-hidden="true" { "🗑" } }, "Delete"))
     (Button::new("Save").submit())
+    (Link::new("/about", "About us"))                       // link text required
+    (Link::new("https://example.com", "Docs").new_tab())    // rel="noopener noreferrer"
+    (MenuItem::new("Settings"))                             // role="menuitem", name required
+    (MenuItem::new("Home").href("/"))                       // link-style menu item
 };
 ```
+
+`Link::new` takes the visible link text as a required argument (an icon-only
+link routes its name to `aria-label` via `Link::icon`), and `MenuItem::new`
+requires the accessible name, emitting `role="menuitem"` on a `<button>` by
+default or an `<a>` when an `.href(..)` is attached.
 
 ### Red build → fix → green build
 
@@ -461,6 +472,14 @@ the typed primitives it does not:
 // error[E0061]: this function takes 2 arguments but 1 argument was supplied
 let _ = Img::new("/logo.png");
 
+// error[E0061]: this function takes 2 arguments but 1 argument was supplied
+//        — a link with no text has no accessible name
+let _ = Link::new("/about");
+
+// error[E0061]: this function takes 1 argument but 0 arguments were supplied
+//        — a menu item must carry an accessible name
+let _ = MenuItem::new();
+
 // error: no method named `render` found for `TextField<NoLabel>`
 //        — an unlabeled field cannot be turned into markup
 let _ = TextField::new("email").render();
@@ -470,6 +489,8 @@ let _ = TextField::new("email").render();
 
 ```rust
 let _ = Img::new("/logo.png", "Company logo");            // ✅ compiles
+let _ = Link::new("/about", "About us");                  // ✅ compiles
+let _ = MenuItem::new("Settings");                        // ✅ compiles
 let _ = TextField::new("email").label("Email").render();  // ✅ compiles
 ```
 


### PR DESCRIPTION
## Before / After

**Before:** a link with no text and a menu item with no accessible name compile cleanly — the missing name only surfaces in an audit or for a user on assistive technology.

```rust
let _ = Link::new("/about");   // compiles — no link text, no accessible name
let _ = MenuItem::new();        // compiles — nameless interactive control
```

**After:** both fail to build. The accessible name is a type-level obligation, so a nameless interactive element is unrepresentable.

```rust
let _ = Link::new("/about", "About us");  // ✅ link text required
let _ = MenuItem::new("Settings");         // ✅ accessible name required, role="menuitem"
```

## How

This extends the already-merged `autumn_web::a11y` module (PR #1840) and mirrors its Img/Button/TextField approach exactly:

- **`Link`** — `Link::new(href, text)` takes the link text as a mandatory positional argument (no text-less constructor); `Link::icon(href, icon, name)` routes an icon-only link's name to `aria-label`. `.new_tab()` sets `target="_blank"` + `rel="noopener noreferrer"`, `.class(..)` chains a class. Implements `maud::Render`.
- **`MenuItem`** — `MenuItem::new(name)` requires the accessible name and renders `role="menuitem"` on a `<button type="button">` by default, or an `<a role="menuitem">` when `.href(..)` is attached. `.icon(..)` routes the name to `aria-label` for icon-only items. Implements `maud::Render`.

Both are re-exported from the prelude alongside `Img`/`Button`/`TextField`. The compile-time obligation is proven with the existing trybuild harness: two new compile-fail fixtures (`a11y_link_missing_text.rs`, `a11y_menuitem_missing_name.rs`) each with an `E0061` golden, plus extended compile-pass and rendered-markup unit-test coverage. Documented in `docs/guide/accessibility.md`.

## WCAG mapping

| Primitive  | WCAG SC                                                     | Obligation                                           |
| ---------- | ---------------------------------------------------------- | ---------------------------------------------------- |
| `Link`     | 2.4.4 Link Purpose (In Context) / 4.1.2 Name, Role, Value  | link text is a required constructor argument         |
| `MenuItem` | 4.1.2 Name, Role, Value                                    | accessible name required; renders `role="menuitem"`  |

## Scope

- Extends merged PR #1840 (does not modify it).
- Does **not** touch scaffold codegen (`autumn-cli/src/generate/scaffold.rs`) or any serialized-merge-queue paths.
- No version bump, no changelog edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pf5JUv54F6Bxo8KzErU9sz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pf5JUv54F6Bxo8KzErU9sz)_