### PR TITLE
Part of #1611: request-path panic gate (CI robustness)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Panic-free request-path gate
+        run: ./scripts/check-panic-gate.sh
 
   test:
     name: Test (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,16 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Clippy (autumn-web, gated request-path features — panic gate)
+        # The default-feature Clippy above does not compile the feature-gated
+        # request-path modules (channels→ws, mail→mail, sync/*→offline-sync,
+        # session_redis→redis), so their `#![cfg_attr(not(test), deny(clippy::…))]`
+        # panic-gate lints never fire. Lint them with their features enabled so an
+        # unannotated `.unwrap()` in those production paths fails CI. (`--all-features`
+        # is unusable here: `managed-pg-bundled` pulls in `postgresql_embedded`, whose
+        # build script downloads Postgres binaries; this explicit list covers exactly
+        # the gated modules with no new services.)
+        run: cargo clippy -p autumn-web --features "ws,mail,offline-sync,redis" --all-targets -- -D warnings
       - name: Panic-free request-path gate
         run: ./scripts/check-panic-gate.sh
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,84 @@ The tests capture and print the full `cargo build` / `cargo check`
 stdout+stderr on failure, so the breakage is diagnosable directly from the
 CI summary.
 
+## Request-path panic gate
+
+Autumn enforces a [#1611][issue-1611] invariant: **request-path modules must not
+panic on the production code path.** A request that reaches a runtime module
+should never be able to bring the process down through an `unwrap`, `expect`,
+`panic!`, out-of-bounds index, or an unfinished `todo!`/`unimplemented!`.
+
+### What counts as "request path"
+
+Per AC2, the gate covers modules that run **per request** or in
+**framework-owned background loops** — extractors, form/body decoding, session
+and idempotency stores, the scheduler and job queues, channels, and the
+per-request middleware stack. These are the files listed in the
+`REQUEST_PATH_MODULES` array in `scripts/check-panic-gate.sh`.
+
+Explicitly **exempt** surfaces (a panic there cannot take down a live request):
+
+- `#[cfg(test)]` code, benches, and examples;
+- build scripts;
+- the `autumn-cli` crate (a short-lived operator tool);
+- application-author code (your route handlers are yours to write).
+
+### What the gate checks
+
+Each gated module carries a header that opts its **production** target into a
+set of panic-class clippy denials:
+
+```rust
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+#![cfg_attr(not(test), deny(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::unreachable,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::indexing_slicing,
+))]
+```
+
+The `cfg_attr(not(test), …)` scope means the denials apply to the library build
+but auto-exempt the module's own `#[cfg(test)] mod tests`. Enforcement happens
+in the CI `lint` job (same workflow as `fmt`/`clippy`, no new services):
+
+- `cargo clippy --workspace --all-targets -- -D warnings` fails on any un-justified
+  panic-class site in a gated module; and
+- `scripts/check-panic-gate.sh` verifies every module in the canonical manifest
+  still exists and still carries the gate header, so the gate cannot be silently
+  removed.
+
+Run the manifest check locally with `./scripts/check-panic-gate.sh`.
+
+### Justifying an exception
+
+When a site is provably infallible or a misconfiguration you want surfaced
+eagerly, annotate it at the **narrowest** scope with a `reason`:
+
+```rust
+#[allow(clippy::expect_used, reason = "infallible: HMAC accepts any key length")]
+```
+
+For lock poisoning, do **not** annotate — **recover** instead, so one panicking
+lock holder can't poison shared state for every later request:
+
+```rust
+let guard = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+```
+
+This `unwrap_or_else(PoisonError::into_inner)` idiom is the established
+lock-poisoning recovery contract (AC4); see `circuit_breaker.rs`.
+
+### Deferred: arithmetic
+
+Unchecked time/duration/integer arithmetic (`clippy::arithmetic_side_effects`)
+is a deferred follow-up and is **not** in the automated lint set yet. It is
+currently guarded by the saturating-arithmetic idiom (e.g. `saturating_deadline`
+in `idempotency.rs`) plus review rather than by the gate.
+
 ## Fuzzing
 
 Autumn coverage-guides a set of [cargo-fuzz][cargo-fuzz] (libFuzzer) harnesses

--- a/autumn/src/channels.rs
+++ b/autumn/src/channels.rs
@@ -17,6 +17,22 @@
 //! # // In async context: let msg = rx.recv().await.expect("should receive");
 //! ```
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::future::Future;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -253,26 +269,38 @@ struct ChannelMetricCounters {
 
 impl ChannelMetrics {
     fn ensure_topic(&self, topic: &str) {
-        let mut counters = self.counters.lock().expect("channel metrics lock poisoned");
+        let mut counters = self
+            .counters
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         counters.entry(topic.to_owned()).or_default();
     }
 
     fn record_publish(&self, topic: &str) {
-        let mut counters = self.counters.lock().expect("channel metrics lock poisoned");
+        let mut counters = self
+            .counters
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let stats = counters.entry(topic.to_owned()).or_default();
         stats.publishes = stats.publishes.saturating_add(1);
         drop(counters);
     }
 
     fn record_dropped(&self, topic: &str, count: u64) {
-        let mut counters = self.counters.lock().expect("channel metrics lock poisoned");
+        let mut counters = self
+            .counters
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let stats = counters.entry(topic.to_owned()).or_default();
         stats.drops = stats.drops.saturating_add(count);
         drop(counters);
     }
 
     fn record_lagged(&self, topic: &str, count: u64) {
-        let mut counters = self.counters.lock().expect("channel metrics lock poisoned");
+        let mut counters = self
+            .counters
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let stats = counters.entry(topic.to_owned()).or_default();
         stats.lags = stats.lags.saturating_add(count);
         drop(counters);
@@ -281,7 +309,7 @@ impl ChannelMetrics {
     fn snapshot(&self) -> HashMap<String, ChannelMetricCounters> {
         self.counters
             .lock()
-            .expect("channel metrics lock poisoned")
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone()
     }
 
@@ -290,7 +318,10 @@ impl ChannelMetrics {
             return;
         }
 
-        let mut counters = self.counters.lock().expect("channel metrics lock poisoned");
+        let mut counters = self
+            .counters
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         counters.retain(|topic, _| !topics.contains(topic));
         drop(counters);
     }
@@ -659,7 +690,11 @@ impl LocalChannelsBackend {
     }
 
     fn get_or_create_topic(&self, topic: &str) -> Arc<TopicState> {
-        let mut registry = self.inner.registry.lock().expect("channels lock poisoned");
+        let mut registry = self
+            .inner
+            .registry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         #[allow(clippy::option_if_let_else)]
         if let Some(state) = registry.get(topic) {
@@ -699,7 +734,10 @@ impl LocalChannelsBackend {
         // every message a resumed subscriber receives is published strictly
         // after its snapshot, keeping the replay/live seam gapless. The id is
         // assigned even when there are zero receivers so ids stay dense.
-        let mut replay = state.replay.lock().expect("channel replay lock poisoned");
+        let mut replay = state
+            .replay
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let id = replay.next_id;
         replay.next_id = replay.next_id.saturating_add(1);
         replay.buf.push_back((id, msg.clone()));
@@ -728,7 +766,10 @@ impl LocalChannelsBackend {
         // `rx` can only ever observe messages published strictly after this
         // point (seqs `start_seq + 1, start_seq + 2, ...`), none of which are in
         // the snapshot below.
-        let replay_guard = state.replay.lock().expect("channel replay lock poisoned");
+        let replay_guard = state
+            .replay
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let rx = state.sender.subscribe();
         let start_seq = replay_guard.next_id.saturating_sub(1);
         let oldest = replay_guard.buf.front().map(|(seq, _)| *seq);
@@ -830,7 +871,11 @@ impl ChannelsBackend for LocalChannelsBackend {
     }
 
     fn channel_count(&self) -> usize {
-        let registry = self.inner.registry.lock().expect("channels lock poisoned");
+        let registry = self
+            .inner
+            .registry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         registry.len()
     }
 
@@ -839,7 +884,11 @@ impl ChannelsBackend for LocalChannelsBackend {
         // topic kept alive only by transient SSE subscribers can lose its
         // replay history during a disconnect window (resumable-SSE is in-process
         // best-effort — see docs/guide/realtime.md, issue #1356).
-        let mut registry = self.inner.registry.lock().expect("channels lock poisoned");
+        let mut registry = self
+            .inner
+            .registry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut removed_topics = HashSet::new();
         registry.retain(|topic, state| {
             // Keep topics with live receivers, or with outstanding keepalive
@@ -861,7 +910,11 @@ impl ChannelsBackend for LocalChannelsBackend {
         // subscribe paths touch metrics before registry, so snapshot must never
         // hold the registry mutex while reading metrics.
         let subscriber_counts: HashMap<String, usize> = {
-            let registry = self.inner.registry.lock().expect("channels lock poisoned");
+            let registry = self
+                .inner
+                .registry
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             registry
                 .iter()
                 .map(|(topic, state)| (topic.clone(), state.sender.receiver_count()))
@@ -1188,6 +1241,10 @@ impl InterceptedChannelsBackend {
 }
 
 #[cfg(feature = "ws")]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "idx < interceptors.len() is checked immediately before the index"
+)]
 fn run_chain(
     topic: &str,
     msg: &ChannelMessage,

--- a/autumn/src/extract.rs
+++ b/autumn/src/extract.rs
@@ -17,6 +17,22 @@
 //! For the full set of Axum extractors, use
 //! `autumn_web::reexports::axum::extract`.
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use axum::extract::{FromRequest, FromRequestParts};
 use axum::response::{IntoResponse, Response};
 
@@ -284,11 +300,7 @@ fn content_type_essence(raw: &str) -> &str {
 #[cfg(feature = "multipart")]
 fn prefix_looks_like_markup(prefix: &[u8]) -> bool {
     let bytes = prefix.strip_prefix(&[0xEF, 0xBB, 0xBF]).unwrap_or(prefix);
-    let trimmed = bytes
-        .iter()
-        .position(|byte| !byte.is_ascii_whitespace())
-        .map_or(&[][..], |idx| &bytes[idx..]);
-    trimmed.first() == Some(&b'<')
+    bytes.iter().find(|byte| !byte.is_ascii_whitespace()) == Some(&b'<')
 }
 
 /// Bound a content-type value before echoing it into an error message, so a

--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -141,6 +141,22 @@
 //! inline.  For a redirect-after-post pattern, serialise `cs.errors()` into
 //! the flash store and redirect; restore on the next GET.
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::collections::HashMap;
 
 use axum::extract::{FromRequest, Request};

--- a/autumn/src/idempotency.rs
+++ b/autumn/src/idempotency.rs
@@ -1834,17 +1834,42 @@ where
 
 #[allow(
     clippy::unwrap_used,
-    reason = "infallible: response built from stored record status/headers/body"
+    reason = "infallible: response built from static status/body"
 )]
+fn corrupted_replay_record_response() -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::INTERNAL_SERVER_ERROR)
+        .body(Body::from(
+            "stored idempotency replay record is invalid or corrupted",
+        ))
+        .unwrap()
+}
+
 fn response_from_record(record: IdempotencyRecord) -> Response<Body> {
     let mut builder = Response::builder().status(record.status);
     for (name, value) in &record.headers {
         builder = builder.header(name.as_str(), value.as_slice());
     }
-    builder
+    // The status, header names/values, and body all originate from the
+    // idempotency store, which may be a custom or corrupted backend. An
+    // invalid stored status (e.g. `0` or `> 999`) or invalid header bytes
+    // makes the builder stash an error that surfaces here. A corrupted replay
+    // record must not crash request handling: fall back to an internal-error
+    // response instead of panicking.
+    match builder
         .header(X_IDEMPOTENT_REPLAYED, "true")
         .body(Body::from(record.body))
-        .unwrap()
+    {
+        Ok(response) => response,
+        Err(error) => {
+            tracing::error!(
+                error = %error,
+                "Stored idempotency replay record produced an invalid response; \
+                 returning 500 instead of replaying"
+            );
+            corrupted_replay_record_response()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -2287,5 +2312,47 @@ mod tests {
             observed.1,
             expected_storage_key("POST", "/payments", None, "pay-once")
         );
+    }
+
+    #[test]
+    fn corrupted_stored_record_does_not_panic_on_replay() {
+        // A store backend (custom or corrupted) can hand back a record whose
+        // stored status is out of the valid HTTP range and whose headers carry
+        // invalid bytes. Replaying it must not panic — it must surface an
+        // internal-error response instead.
+        let corrupted = IdempotencyRecord {
+            status: 1000,
+            headers: vec![("inv\nalid".to_owned(), vec![0x00, 0x0a])],
+            body: b"stored body".to_vec(),
+            metadata: Vec::new(),
+        };
+
+        let response = IdempotencyReplayResponse { record: corrupted }.into_response();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "a corrupted replay record must fall back to a 500 recovery response"
+        );
+        assert!(
+            response.headers().get(X_IDEMPOTENT_REPLAYED).is_none(),
+            "the recovery response must not masquerade as a successful replay"
+        );
+    }
+
+    #[test]
+    fn invalid_stored_status_alone_does_not_panic_on_replay() {
+        // Even with otherwise-valid headers, an out-of-range status byte must
+        // not crash replay handling.
+        let corrupted = IdempotencyRecord {
+            status: 0,
+            headers: vec![("content-type".to_owned(), b"text/plain".to_vec())],
+            body: b"stored body".to_vec(),
+            metadata: Vec::new(),
+        };
+
+        let response = response_from_record(corrupted);
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/autumn/src/idempotency.rs
+++ b/autumn/src/idempotency.rs
@@ -1,3 +1,19 @@
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use bytes::Bytes;
 use futures::StreamExt as FuturesStreamExt;
 
@@ -5,7 +21,7 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex, PoisonError, RwLock};
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
@@ -482,7 +498,12 @@ impl MemoryIdempotencyStore {
 impl IdempotencyStore for MemoryIdempotencyStore {
     fn get(&self, key: &str) -> Option<IdempotencyEntry> {
         // Release the read lock immediately after cloning.
-        let entry = self.entries.read().unwrap().get(key).cloned();
+        let entry = self
+            .entries
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(key)
+            .cloned();
         entry.filter(|e| e.expires_at > Instant::now())
     }
 
@@ -492,7 +513,7 @@ impl IdempotencyStore for MemoryIdempotencyStore {
             body_hash,
             expires_at: saturating_deadline(ttl),
         };
-        let mut entries = self.entries.write().unwrap();
+        let mut entries = self.entries.write().unwrap_or_else(PoisonError::into_inner);
         entries.insert(key.to_owned(), entry);
         // Periodically evict expired entries to bound memory growth for
         // long-running processes. O(N) scan is amortised over every 128 writes.
@@ -509,7 +530,10 @@ impl IdempotencyStore for MemoryIdempotencyStore {
 
     fn try_lock_owned(&self, key: &str, owner: &str, lock_ttl: Duration) -> bool {
         let now = Instant::now();
-        let mut in_flight = self.in_flight.write().unwrap();
+        let mut in_flight = self
+            .in_flight
+            .write()
+            .unwrap_or_else(PoisonError::into_inner);
         // Check only the requested key's active in-flight marker.
         if let Some(lock) = in_flight.get(key)
             && lock.expires_at > now
@@ -534,11 +558,17 @@ impl IdempotencyStore for MemoryIdempotencyStore {
     }
 
     fn unlock(&self, key: &str) {
-        self.in_flight.write().unwrap().remove(key);
+        self.in_flight
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(key);
     }
 
     fn unlock_owned(&self, key: &str, owner: &str) {
-        let mut in_flight = self.in_flight.write().unwrap();
+        let mut in_flight = self
+            .in_flight
+            .write()
+            .unwrap_or_else(PoisonError::into_inner);
         if in_flight
             .get(key)
             .is_some_and(|lock| lock.owner.as_str() == owner)
@@ -1081,6 +1111,10 @@ where
     }
 }
 
+#[allow(
+    clippy::unwrap_used,
+    reason = "infallible: response built from static status/body"
+)]
 fn request_body_too_large_response() -> Response<Body> {
     Response::builder()
         .status(StatusCode::PAYLOAD_TOO_LARGE)
@@ -1090,6 +1124,10 @@ fn request_body_too_large_response() -> Response<Body> {
         .unwrap()
 }
 
+#[allow(
+    clippy::unwrap_used,
+    reason = "infallible: response built from static status/body"
+)]
 fn in_flight_conflict_response() -> Response<Body> {
     Response::builder()
         .status(StatusCode::CONFLICT)
@@ -1101,6 +1139,10 @@ fn in_flight_conflict_response() -> Response<Body> {
         .unwrap()
 }
 
+#[allow(
+    clippy::unwrap_used,
+    reason = "infallible: response built from static status/body"
+)]
 fn replay_requires_inner_stop_response() -> Response<Body> {
     Response::builder()
         .status(StatusCode::CONFLICT)
@@ -1110,6 +1152,10 @@ fn replay_requires_inner_stop_response() -> Response<Body> {
         .unwrap()
 }
 
+#[allow(
+    clippy::unwrap_used,
+    reason = "infallible: response built from static status/body"
+)]
 pub(crate) fn persistence_failed_response() -> Response<Body> {
     Response::builder()
         .status(StatusCode::SERVICE_UNAVAILABLE)
@@ -1209,7 +1255,7 @@ impl DeferredIdempotencyCommit {
         let Some(mut state) = self
             .inner
             .lock()
-            .expect("deferred idempotency commit lock poisoned")
+            .unwrap_or_else(PoisonError::into_inner)
             .take()
         else {
             return Ok(());
@@ -1258,10 +1304,7 @@ impl DeferredIdempotencyCommit {
     }
 
     fn add_session_alias(&self, session_id: Option<&str>, primary_replay_after_guard_denial: bool) {
-        let mut guard = self
-            .inner
-            .lock()
-            .expect("deferred idempotency commit lock poisoned");
+        let mut guard = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
         let Some(state) = guard.as_mut() else {
             return;
         };
@@ -1285,7 +1328,7 @@ impl DeferredIdempotencyCommit {
         let Some(mut state) = self
             .inner
             .lock()
-            .expect("deferred idempotency commit lock poisoned")
+            .unwrap_or_else(PoisonError::into_inner)
             .take()
         else {
             return;
@@ -1747,10 +1790,15 @@ where
             idempotency.key = %idempotency_key,
             "Idempotency payload mismatch — returning 422"
         );
-        return Ok(Response::builder()
+        #[allow(
+            clippy::unwrap_used,
+            reason = "infallible: response built from static status/body"
+        )]
+        let response = Response::builder()
             .status(StatusCode::UNPROCESSABLE_ENTITY)
             .body(Body::from("idempotency key reused with different payload"))
-            .unwrap());
+            .unwrap();
+        return Ok(response);
     }
 
     if fail_closed_on_replay {
@@ -1784,6 +1832,10 @@ where
     Ok(replay.into_response())
 }
 
+#[allow(
+    clippy::unwrap_used,
+    reason = "infallible: response built from stored record status/headers/body"
+)]
 fn response_from_record(record: IdempotencyRecord) -> Response<Body> {
     let mut builder = Response::builder().status(record.status);
     for (name, value) in &record.headers {
@@ -1843,6 +1895,49 @@ mod tests {
         fn unlock(&self, key: &str) {
             self.record_key(key);
         }
+    }
+
+    #[test]
+    fn poisoned_lock_does_not_break_subsequent_requests() {
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+
+        let store = MemoryIdempotencyStore::new(Duration::from_secs(60));
+
+        // Simulate a request handler that panics while holding one of the
+        // store's internal locks, poisoning it. Without poison recovery this
+        // would make every later request that touches `entries` panic too.
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let _guard = store
+                .entries
+                .write()
+                .expect("first acquisition is not poisoned");
+            panic!("simulated handler panic while holding the idempotency lock");
+        }));
+        assert!(result.is_err(), "the induced panic should have unwound");
+        assert!(
+            store.entries.is_poisoned(),
+            "holding the write lock across a panic must poison it",
+        );
+
+        // A subsequent normal store round-trip must still succeed, proving the
+        // `unwrap_or_else(PoisonError::into_inner)` recovery keeps shared state
+        // usable for later requests (AC4 lock-poisoning recovery contract).
+        let record = IdempotencyRecord {
+            status: 200,
+            headers: Vec::new(),
+            body: b"ok".to_vec(),
+            metadata: Vec::new(),
+        };
+        store.set("k", record, b"body-hash".to_vec(), Duration::from_secs(60));
+        let fetched = store.get("k");
+        assert!(
+            fetched.is_some(),
+            "store must remain usable after a poisoned lock (into_inner recovery)",
+        );
+        assert_eq!(
+            fetched.expect("entry present after recovery").record.body,
+            b"ok",
+        );
     }
 
     fn idempotent_post(path: &str, key: &str, body: &'static str) -> Request<Body> {

--- a/autumn/src/job.rs
+++ b/autumn/src/job.rs
@@ -3,6 +3,22 @@
 //! Provides [`JobInfo`] metadata used by `#[job]` and `jobs![]`, plus local
 //! and Redis-backed queue backends.
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::pin::Pin;
@@ -251,6 +267,10 @@ impl QueueCursor {
     /// Ordered queue names to attempt for this claim iteration. The first entry
     /// is the queue to serve now; the rest follow (so a worker never idles while
     /// any queue has work).
+    #[allow(
+        clippy::indexing_slicing,
+        reason = "names, weights, and current are maintained at equal length; all indices come from 0..names.len() or best < names.len()"
+    )]
     pub(crate) fn next_order(&mut self) -> Arc<Vec<String>> {
         if self.strict || self.names.len() <= 1 {
             return Arc::clone(&self.names);
@@ -491,7 +511,10 @@ impl QueueSlots {
         if self.limits.is_empty() {
             return order.to_vec();
         }
-        let guard = self.running.lock().expect("queue slot lock poisoned");
+        let guard = self
+            .running
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let (running, total) = &*guard;
         order
             .iter()
@@ -505,7 +528,10 @@ impl QueueSlots {
     #[allow(clippy::significant_drop_tightening)]
     pub(crate) fn acquire(self: &Arc<Self>, queue: &str) -> QueueSlotGuard {
         {
-            let mut guard = self.running.lock().expect("queue slot lock poisoned");
+            let mut guard = self
+                .running
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             let (running, total) = &mut *guard;
             *running.entry(queue.to_string()).or_insert(0) += 1;
             *total += 1;
@@ -536,7 +562,10 @@ impl QueueSlots {
         if self.limits.is_empty() {
             return Some(self.acquire(queue));
         }
-        let mut guard = self.running.lock().expect("queue slot lock poisoned");
+        let mut guard = self
+            .running
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let (running, total) = &mut *guard;
         // Hard ceiling first: never let total in-flight reach the worker count,
         // even via a queue drawing on its own reserved slots.
@@ -564,7 +593,11 @@ pub(crate) struct QueueSlotGuard {
 impl Drop for QueueSlotGuard {
     #[allow(clippy::significant_drop_tightening)]
     fn drop(&mut self) {
-        let mut guard = self.slots.running.lock().expect("queue slot lock poisoned");
+        let mut guard = self
+            .slots
+            .running
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let (running, total) = &mut *guard;
         if let Some(count) = running.get_mut(&self.queue) {
             *count = count.saturating_sub(1);
@@ -2938,11 +2971,18 @@ impl JobClient {
         #[cfg(feature = "db")]
         crate::db::AFTER_COMMIT_REGISTRY
             .try_with(|registry| {
+                #[allow(
+                    clippy::expect_used,
+                    reason = "unreachable: try_with closure body runs at most once"
+                )]
                 let f = f_opt.take().expect("closure only entered once");
                 let span = enqueue_span.clone();
                 let boxed: crate::db::CommitCallback =
                     Box::new(move || Box::pin(tracing::Instrument::instrument(f(), span)));
-                registry.lock().expect("registry lock").push(boxed);
+                registry
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .push(boxed);
             })
             .ok();
 
@@ -3525,7 +3565,9 @@ pub(crate) fn start_local_runtime_inner(
     ));
 
     {
-        let guard = jobs_by_name.read().expect("job registry lock poisoned");
+        let guard = jobs_by_name
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         for job in guard.values() {
             state
                 .job_registry
@@ -3750,7 +3792,9 @@ fn collect_declared_queues_from_jobs<'a>(
 
 /// Distinct queue names declared by the registered jobs.
 fn collect_declared_queues(jobs_by_name: &Arc<RwLock<HashMap<String, JobInfo>>>) -> Vec<String> {
-    let guard = jobs_by_name.read().expect("job registry lock poisoned");
+    let guard = jobs_by_name
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     collect_declared_queues_from_jobs(guard.values())
 }
 
@@ -3783,6 +3827,10 @@ fn effective_drained_queues_from_jobs(
 /// `autumn doctor` consumes: a single top-level `queues = [...]` array, ordered
 /// highest priority first exactly as the runtime drains. Emitted to stdout by
 /// `AUTUMN_DUMP_JOBS=1` and read back by doctor's `resolve_declared_queues`.
+#[allow(
+    clippy::expect_used,
+    reason = "infallible: manifest is a plain string array; TOML serialization cannot fail"
+)]
 pub(crate) fn render_jobs_manifest(
     cfg: &crate::config::JobQueuesConfig,
     jobs: &[JobInfo],
@@ -3821,7 +3869,10 @@ impl LocalQueueBuffer {
     #[allow(clippy::significant_drop_tightening)]
     fn push(&self, job: QueuedJob) {
         {
-            let mut map = self.inner.lock().expect("local job buffer lock poisoned");
+            let mut map = self
+                .inner
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             let bucket = map.entry(normalize_queue_name(&job.queue)).or_default();
             if bucket.len() == LOCAL_QUEUE_WARN_THRESHOLD {
                 tracing::warn!(
@@ -3848,7 +3899,10 @@ impl LocalQueueBuffer {
         order: &[String],
         allowed: Option<&std::collections::HashSet<String>>,
     ) -> Option<QueuedJob> {
-        let mut map = self.inner.lock().expect("local job buffer lock poisoned");
+        let mut map = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         for name in order {
             if let Some(job) = map.get_mut(name).and_then(VecDeque::pop_front) {
                 return Some(job);
@@ -3873,7 +3927,10 @@ impl LocalQueueBuffer {
     /// queue rather than sweeping the whole priority order.
     #[allow(clippy::significant_drop_tightening)]
     fn try_pop_from(&self, queue: &str) -> Option<QueuedJob> {
-        let mut map = self.inner.lock().expect("local job buffer lock poisoned");
+        let mut map = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         map.get_mut(queue).and_then(VecDeque::pop_front)
     }
 }
@@ -3889,7 +3946,7 @@ async fn execute_local_job(
 ) {
     let maybe_info = jobs_by_name
         .read()
-        .expect("job registry lock poisoned")
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .get(&job.name)
         .map(|info| {
             (
@@ -6506,7 +6563,9 @@ async fn process_redis_job_record(
     state.job_registry.record_start(&record.name);
 
     let maybe_info = {
-        let guard = jobs_by_name.read().expect("job registry lock poisoned");
+        let guard = jobs_by_name
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         guard
             .get(&record.name)
             .map(|info| (info.handler, info.max_attempts, info.initial_backoff_ms))
@@ -6734,7 +6793,9 @@ fn start_redis_runtime(
     ));
 
     {
-        let guard = jobs_by_name.read().expect("job registry lock poisoned");
+        let guard = jobs_by_name
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         for job in guard.values() {
             state
                 .job_registry
@@ -7956,7 +8017,7 @@ async fn pg_execute_job(
     let payload = serde_json::from_str::<Value>(&row.payload).unwrap_or(Value::Null);
     let job_info_snapshot = jobs_by_name
         .read()
-        .expect("job registry lock poisoned")
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .get(&row.name)
         .map(|info| (info.handler, info.uniqueness.clone()));
     let pending_unique_key = job_info_snapshot
@@ -8688,7 +8749,9 @@ fn start_postgres_runtime(
     ));
 
     {
-        let guard = jobs_by_name.read().expect("job registry lock poisoned");
+        let guard = jobs_by_name
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         for job in guard.values() {
             state
                 .job_registry

--- a/autumn/src/job_tracking.rs
+++ b/autumn/src/job_tracking.rs
@@ -7,6 +7,22 @@
 //! result or a user-safe error. A [`JobTrackingStore`] persists that state,
 //! keyed by a hash of the token, with a configurable TTL.
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
@@ -267,7 +283,7 @@ impl JobContext {
             *inner
                 .result
                 .lock()
-                .expect("job context result lock poisoned") = Some(result);
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(result);
         }
     }
 
@@ -284,7 +300,7 @@ impl JobContext {
             *inner
                 .user_error
                 .lock()
-                .expect("job context error lock poisoned") = Some(message.into());
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(message.into());
         }
     }
 
@@ -296,7 +312,7 @@ impl JobContext {
         let result = inner
             .result
             .lock()
-            .expect("job context result lock poisoned")
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .take()
             .unwrap_or(Value::Null);
         let _ = inner.store.complete(&inner.key, result).await;
@@ -312,7 +328,7 @@ impl JobContext {
         let message = inner
             .user_error
             .lock()
-            .expect("job context error lock poisoned")
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .take()
             .unwrap_or_else(|| default_message.to_owned());
         let _ = inner.store.fail(&inner.key, message).await;
@@ -972,7 +988,7 @@ impl InMemoryJobTrackingStore {
     fn raw_entry_count(&self) -> usize {
         self.entries
             .read()
-            .expect("job tracking store lock poisoned")
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .len()
     }
 
@@ -981,7 +997,7 @@ impl InMemoryJobTrackingStore {
         let mut guard = self
             .entries
             .write()
-            .expect("job tracking store lock poisoned");
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         guard.insert(
             key.to_owned(),
             MemoryEntry {
@@ -1006,7 +1022,7 @@ impl InMemoryJobTrackingStore {
         let mut guard = self
             .entries
             .write()
-            .expect("job tracking store lock poisoned");
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let now = self.clock.now();
         if let Some(entry) = guard.get_mut(key)
             && self.is_live(entry)
@@ -1028,7 +1044,7 @@ impl InMemoryJobTrackingStore {
         let mut guard = self
             .entries
             .write()
-            .expect("job tracking store lock poisoned");
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         if let Some(entry) = guard.get(key)
             && self.is_live(entry)
             && entry.record.updated_at == expected_updated_at
@@ -1121,7 +1137,7 @@ impl JobTrackingStore for InMemoryJobTrackingStore {
             let guard = self
                 .entries
                 .read()
-                .expect("job tracking store lock poisoned");
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             Ok(guard
                 .get(key)
                 .filter(|entry| self.is_live(entry))

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -4,6 +4,22 @@
 //! through the cloneable [`Mailer`] extractor, and swap transports through the
 //! [`MailTransport`] trait when SMTP is not the right coffin lining.
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
@@ -1198,6 +1214,10 @@ pub mod unsubscribe {
 
     /// Derive a 32-byte AES-256 key from a signing key via HMAC-SHA256 with a
     /// domain-separation label.
+    #[allow(
+        clippy::expect_used,
+        reason = "infallible: HMAC accepts any key length"
+    )]
     fn derive_key(signing_key: &[u8]) -> [u8; 32] {
         let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(signing_key)
             .expect("HMAC accepts any key length");
@@ -1226,6 +1246,10 @@ pub mod unsubscribe {
     ///
     /// Panics if the OS RNG is unavailable.
     #[must_use]
+    #[allow(
+        clippy::expect_used,
+        reason = "infallible crypto: AES-256-GCM over a 32-byte derived key; an OS RNG failure is an unrecoverable environment fault surfaced as a documented panic"
+    )]
     pub fn sign_token(
         keys: &ResolvedSigningKeys,
         subscriber: &str,
@@ -1256,6 +1280,10 @@ pub mod unsubscribe {
     ///
     /// Returns [`TokenError`] when the token is malformed, its signature is
     /// invalid, or it has expired relative to `now_unix`.
+    #[allow(
+        clippy::indexing_slicing,
+        reason = "blob.len() is checked to be >= 1 + NONCE_LEN above, so these indices are in bounds"
+    )]
     pub fn verify_token(
         keys: &ResolvedSigningKeys,
         token: &str,
@@ -1398,7 +1426,7 @@ impl SuppressionStore for InMemorySuppressionStore {
             let suppressed = self
                 .suppressed
                 .lock()
-                .expect("suppression lock")
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .contains(&key);
             Ok(suppressed)
         })
@@ -1413,7 +1441,7 @@ impl SuppressionStore for InMemorySuppressionStore {
             let key = (subscriber.to_owned(), list_id.to_owned());
             self.suppressed
                 .lock()
-                .expect("suppression lock")
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .insert(key);
             Ok(())
         })
@@ -1881,6 +1909,10 @@ impl Mailer {
 
             crate::db::AFTER_COMMIT_REGISTRY
                 .try_with(|registry| {
+                    #[allow(
+                        clippy::expect_used,
+                        reason = "unreachable: try_with closure body runs at most once"
+                    )]
                     let (m, m_mail) = f_opt.take().expect("once");
                     let span = deliver_span.clone();
                     let boxed: crate::db::CommitCallback = Box::new(move || {
@@ -1899,7 +1931,10 @@ impl Mailer {
                             span,
                         ))
                     });
-                    registry.lock().expect("registry lock").push(boxed);
+                    registry
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .push(boxed);
                 })
                 .ok();
 
@@ -2354,7 +2389,12 @@ fn base64_wrap76(bytes: &[u8]) -> String {
         if !wrapped.is_empty() {
             wrapped.push('\n');
         }
-        wrapped.push_str(std::str::from_utf8(chunk).expect("base64 output is always ASCII"));
+        #[allow(
+            clippy::expect_used,
+            reason = "infallible: base64 output is always ASCII"
+        )]
+        let chunk_str = std::str::from_utf8(chunk).expect("base64 output is always ASCII");
+        wrapped.push_str(chunk_str);
     }
     wrapped
 }
@@ -3227,6 +3267,10 @@ fn lettre_attachment_part(attachment: &MailAttachment) -> Result<SinglePart, Mai
     // Force base64 regardless of content: lettre's automatic encoder picks
     // `7bit` for short ASCII byte buffers, but attachments must always carry
     // a `base64` Content-Transfer-Encoding per the framework's contract.
+    #[allow(
+        clippy::expect_used,
+        reason = "infallible: base64 encoding is always valid for any byte buffer"
+    )]
     let body =
         LettreBody::new_with_encoding(attachment.bytes.clone(), ContentTransferEncoding::Base64)
             .expect("base64 encoding is always valid for any byte buffer");
@@ -3849,7 +3893,7 @@ pub mod suppression {
                 Ok(self
                     .entries
                     .lock()
-                    .expect("suppression lock")
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
                     .contains_key(&key))
             })
         }
@@ -3863,7 +3907,7 @@ pub mod suppression {
                 let key = canonical_subscriber(address);
                 self.entries
                     .lock()
-                    .expect("suppression lock")
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
                     .insert(key, reason);
                 Ok(())
             })
@@ -3875,7 +3919,10 @@ pub mod suppression {
         ) -> Pin<Box<dyn Future<Output = Result<(), MailError>> + Send + 'a>> {
             Box::pin(async move {
                 let key = canonical_subscriber(address);
-                self.entries.lock().expect("suppression lock").remove(&key);
+                self.entries
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .remove(&key);
                 Ok(())
             })
         }
@@ -6382,7 +6429,9 @@ mod tests {
         registry: &std::sync::Arc<std::sync::Mutex<Vec<crate::db::CommitCallback>>>,
     ) {
         let callbacks: Vec<crate::db::CommitCallback> = {
-            let mut reg = registry.lock().expect("registry lock");
+            let mut reg = registry
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             std::mem::take(&mut *reg)
         };
 

--- a/autumn/src/middleware/access_log.rs
+++ b/autumn/src/middleware/access_log.rs
@@ -43,6 +43,22 @@
 //! logged `status` reflects the handler's response in that narrow case. The
 //! built-in filters preserve status.
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;

--- a/autumn/src/middleware/error_page_filter.rs
+++ b/autumn/src/middleware/error_page_filter.rs
@@ -8,6 +8,22 @@
 //! In dev mode, a Next.js-style error badge is injected into the HTML
 //! response for quick debugging.
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use axum::response::{IntoResponse, Response};
 
 #[cfg(feature = "maud")]
@@ -454,10 +470,16 @@ fn form_pairs_to_nested_json(pairs: Vec<(String, String)>) -> serde_json::Value 
 /// `"user.password"` → `["user", "password"]`
 /// `"a[b][c]"` → `["a", "b", "c"]`
 /// `"simple"` → `["simple"]`
+#[allow(
+    clippy::indexing_slicing,
+    reason = "pos is a valid byte index returned by str::find('['); both slices split on that boundary"
+)]
 fn bracket_key_segments(key: &str) -> Vec<String> {
     // Dot notation: split on '.' first (only if no brackets present)
     if key.contains('[') {
-        let pos = key.find('[').unwrap();
+        let Some(pos) = key.find('[') else {
+            return vec![key.to_owned()];
+        };
         let mut parts = vec![key[..pos].to_owned()];
         for seg in key[pos + 1..].split('[') {
             let seg = seg.trim_end_matches(']');
@@ -476,6 +498,10 @@ fn bracket_key_segments(key: &str) -> Vec<String> {
     }
 }
 
+#[allow(
+    clippy::indexing_slicing,
+    reason = "path is guaranteed non-empty here and len >= 2 past the length guards below"
+)]
 fn form_insert_at_path(
     map: &mut serde_json::Map<String, serde_json::Value>,
     path: &[String],

--- a/autumn/src/middleware/exception_filter.rs
+++ b/autumn/src/middleware/exception_filter.rs
@@ -47,6 +47,22 @@
 //! # }
 //! ```
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;

--- a/autumn/src/middleware/load_shed.rs
+++ b/autumn/src/middleware/load_shed.rs
@@ -20,6 +20,22 @@
 //! graceful-shutdown drain accounting, so shedding cannot double-count,
 //! deadlock, or extend the drain budget.
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -289,6 +305,10 @@ where
 {
     type Output = Result<Response<Body>, E>;
 
+    #[allow(
+        clippy::expect_used,
+        reason = "unreachable: future not polled after Ready"
+    )]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.project() {
             LoadShedFutureProj::ShortCircuit { response } => Poll::Ready(Ok(response

--- a/autumn/src/middleware/maintenance.rs
+++ b/autumn/src/middleware/maintenance.rs
@@ -25,6 +25,22 @@
 //! 4. **Read-only mode** – when `readonly = true`, `GET`, `HEAD`, and
 //!    `OPTIONS` requests pass through; write methods are gated.
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::future::Future;
 use std::net::IpAddr;
 use std::pin::Pin;
@@ -272,6 +288,10 @@ where
 {
     type Output = Result<Response<Body>, E>;
 
+    #[allow(
+        clippy::expect_used,
+        reason = "unreachable: future not polled after Ready"
+    )]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.project() {
             MaintenanceFutureProj::ShortCircuit { response } => Poll::Ready(Ok(response
@@ -324,6 +344,7 @@ fn extract_client_ip<B>(req: &Request<B>) -> Option<IpAddr> {
 }
 
 /// Build a 503 response with the appropriate content type.
+#[allow(clippy::expect_used, reason = "infallible: static 503 response")]
 fn build_503_response<B>(req: &Request<B>, config: &MaintenanceConfig) -> Response<Body> {
     let message = config
         .message

--- a/autumn/src/middleware/method_override.rs
+++ b/autumn/src/middleware/method_override.rs
@@ -115,6 +115,22 @@
 //! async fn update(/* extractors */) -> Markup { html! { "updated" } }
 //! ```
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;

--- a/autumn/src/middleware/metrics.rs
+++ b/autumn/src/middleware/metrics.rs
@@ -6,6 +6,22 @@
 //!
 //! Metrics are exposed via the `/actuator/metrics` endpoint.
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::pin::Pin;
@@ -214,6 +230,10 @@ impl MetricsCollector {
         }
     }
 
+    #[allow(
+        clippy::indexing_slicing,
+        reason = "shard_idx is hash % SHARD_COUNT so always in bounds; buf slice length is <= 256, the buffer size"
+    )]
     fn record_route(&self, method: &str, route: &str, latency_ms: u64) {
         // ⚡ Bolt Optimization:
         // FNV-1a hash is faster than DefaultHasher (SipHash) for short strings like routes.
@@ -273,6 +293,10 @@ impl MetricsCollector {
     }
 
     /// Record a database query's duration.
+    #[allow(
+        clippy::indexing_slicing,
+        reason = "shard_idx is hash % SHARD_COUNT so always in bounds"
+    )]
     pub fn record_db_query(&self, key: &str, latency_ms: u64) {
         // Hash key to determine shard index using FNV-1a
         let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
@@ -492,6 +516,10 @@ struct Percentiles {
     p99: u64,
 }
 
+#[allow(
+    clippy::indexing_slicing,
+    reason = "p95_idx <= p99_idx <= len - 1, so the inclusive ranges stay within data's bounds"
+)]
 fn compute_percentiles(latencies: &VecDeque<u64>) -> Percentiles {
     let len = latencies.len();
     if len == 0 {

--- a/autumn/src/middleware/request_id.rs
+++ b/autumn/src/middleware/request_id.rs
@@ -23,6 +23,22 @@
 //! }
 //! ```
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;

--- a/autumn/src/middleware/trace_context.rs
+++ b/autumn/src/middleware/trace_context.rs
@@ -15,6 +15,22 @@
 //! Installed automatically by the framework when the `telemetry-otlp`
 //! feature is enabled — you do not need to register it manually.
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/autumn/src/scheduler.rs
+++ b/autumn/src/scheduler.rs
@@ -4,6 +4,22 @@
 //! The Postgres backend uses advisory locks so each fleet-wide task tick is
 //! claimed by at most one replica under normal operation.
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -320,7 +336,12 @@ pub fn advisory_lock_key(key_prefix: &str, task_name: &str, tick_key: &str) -> i
     hasher.update(tick_key.as_bytes());
     let digest = hasher.finalize();
     let mut bytes = [0_u8; 8];
-    bytes.copy_from_slice(&digest[..8]);
+    #[allow(
+        clippy::indexing_slicing,
+        reason = "infallible: SHA-256 digest is always 32 bytes, so [..8] is in bounds"
+    )]
+    let head = &digest[..8];
+    bytes.copy_from_slice(head);
     i64::from_be_bytes(bytes)
 }
 

--- a/autumn/src/security/trusted_proxies.rs
+++ b/autumn/src/security/trusted_proxies.rs
@@ -36,6 +36,22 @@
 //! are the only blessed way to obtain real client identity from request
 //! handlers and middleware.
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::future::Future;
 use std::net::{IpAddr, SocketAddr};
 use std::pin::Pin;

--- a/autumn/src/session.rs
+++ b/autumn/src/session.rs
@@ -61,6 +61,22 @@
 //! `AUTUMN_SESSION__COOKIE_NAME`, `AUTUMN_SESSION__MAX_AGE_SECS`,
 //! `AUTUMN_SESSION__REDIS__URL`, etc.
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
@@ -238,6 +254,10 @@ where
         parts: &mut Parts,
         _state: &S,
     ) -> impl Future<Output = Result<Self, Self::Rejection>> + Send {
+        #[allow(
+            clippy::expect_used,
+            reason = "misconfiguration: missing SessionLayer is a setup error, surfaced eagerly"
+        )]
         let session = parts
             .extensions
             .get::<Self>()

--- a/autumn/src/session_redis.rs
+++ b/autumn/src/session_redis.rs
@@ -3,6 +3,22 @@
 //! Provides the [`RedisStore`] implementation for the [`SessionStore`] trait,
 //! using the `redis` crate to persist session data in a Redis database.
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::collections::HashMap;
 
 use redis::AsyncCommands;

--- a/autumn/src/storage/blob.rs
+++ b/autumn/src/storage/blob.rs
@@ -9,6 +9,22 @@
 //! `#[model]` as a single Postgres `JSONB` column without any extra
 //! glue.
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use serde::{Deserialize, Serialize};
 
 /// A reference to a stored blob.

--- a/autumn/src/storage/direct_upload.rs
+++ b/autumn/src/storage/direct_upload.rs
@@ -38,6 +38,22 @@
 //! model. The bind step is always your own CSRF- and session-protected route.
 //! See [`complete_direct_upload`] for how to enforce this.
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::time::Duration;
 
 use super::{Blob, BlobMeta, BlobStore, BlobStoreError};

--- a/autumn/src/sync/engine.rs
+++ b/autumn/src/sync/engine.rs
@@ -1,5 +1,21 @@
 //! Client sync loop: push pending changes, pull newer rows.
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -111,6 +127,10 @@ impl SyncEngine {
     /// Panics if the HTTP client's TLS backend cannot be initialized
     /// (`reqwest::Client` construction).
     #[must_use]
+    #[allow(
+        clippy::expect_used,
+        reason = "infallible: reqwest client built from static config; a TLS-backend init failure is an unrecoverable environment fault surfaced as a documented panic"
+    )]
     pub fn new(store: SyncStore, config: SyncConfig) -> Self {
         let client = reqwest::Client::builder()
             .timeout(config.request_timeout)

--- a/autumn/src/sync/server.rs
+++ b/autumn/src/sync/server.rs
@@ -16,6 +16,22 @@
 //! # }
 //! ```
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex};
 

--- a/autumn/src/sync/store.rs
+++ b/autumn/src/sync/store.rs
@@ -1,5 +1,21 @@
 //! Local offline store: `SQLite` rows + write-through pending journal.
 
+// autumn-panic-gate: request-path module — production code path must be panic-free.
+// See CONTRIBUTING.md "Request-path panic gate". Justify exceptions with
+// #[allow(clippy::<lint>, reason = "…")] at the narrowest scope.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+    )
+)]
+
 use std::path::Path;
 use std::sync::{Arc, Mutex, MutexGuard};
 

--- a/scripts/check-panic-gate.sh
+++ b/scripts/check-panic-gate.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Verify that every canonical request-path module still carries the #1611
+# panic-free gate header. The header opts each module into the panic-class
+# clippy denials (unwrap/expect/panic/unreachable/todo/unimplemented/
+# indexing_slicing) on the production code path via `cfg_attr(not(test), …)`.
+#
+# This script only guards the *manifest*: it fails if a gated module is missing
+# or has lost its gate header, so the gate cannot be silently dropped. The
+# actual panic detection is performed by `cargo clippy` in the same `lint` job.
+#
+# Called from the `lint` job in ci.yml. Run locally with:
+#
+#     ./scripts/check-panic-gate.sh
+
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+# Canonical request-path module set. Every file listed here must be panic-free
+# on the production code path and carry the gate header. Keep this list in sync
+# with CONTRIBUTING.md "Request-path panic gate".
+REQUEST_PATH_MODULES=(
+  autumn/src/form.rs
+  autumn/src/extract.rs
+  autumn/src/idempotency.rs
+  autumn/src/mail.rs
+  autumn/src/channels.rs
+  autumn/src/job.rs
+  autumn/src/job_tracking.rs
+  autumn/src/session.rs
+  autumn/src/session_redis.rs
+  autumn/src/scheduler.rs
+  autumn/src/security/trusted_proxies.rs
+  autumn/src/storage/blob.rs
+  autumn/src/storage/direct_upload.rs
+  autumn/src/sync/store.rs
+  autumn/src/sync/server.rs
+  autumn/src/sync/engine.rs
+  autumn/src/middleware/access_log.rs
+  autumn/src/middleware/exception_filter.rs
+  autumn/src/middleware/request_id.rs
+  autumn/src/middleware/method_override.rs
+  autumn/src/middleware/metrics.rs
+  autumn/src/middleware/trace_context.rs
+  autumn/src/middleware/maintenance.rs
+  autumn/src/middleware/error_page_filter.rs
+  autumn/src/middleware/load_shed.rs
+)
+
+for module in "${REQUEST_PATH_MODULES[@]}"; do
+  [[ -f "$module" ]] || die "gated request-path module is missing: $module"
+  grep -q 'autumn-panic-gate:' "$module" \
+    || die "missing gate marker 'autumn-panic-gate:' in $module"
+  # The deny header is `#![cfg_attr(not(test), deny(clippy::unwrap_used, …))]`.
+  # rustfmt may wrap it across several lines, so match its stable tokens
+  # individually rather than as one literal string.
+  grep -q '#!\[cfg_attr(' "$module" \
+    && grep -q 'not(test)' "$module" \
+    && grep -q 'deny(' "$module" \
+    && grep -q 'clippy::unwrap_used' "$module" \
+    && grep -q 'clippy::indexing_slicing' "$module" \
+    || die "missing or incomplete gate deny header (cfg_attr(not(test), deny(…))) in $module"
+done
+
+echo "panic-gate: ${#REQUEST_PATH_MODULES[@]} request-path modules gated"

--- a/scripts/check-panic-gate.sh
+++ b/scripts/check-panic-gate.sh
@@ -53,19 +53,39 @@ REQUEST_PATH_MODULES=(
   autumn/src/middleware/load_shed.rs
 )
 
+# Canonical panic-class lints every gated module must deny on the production
+# code path. The header spells each as a fully-qualified `clippy::<lint>` token
+# (that is how rustfmt normalizes it), so match the qualified form to prevent a
+# bare `unwrap_used` elsewhere in the file from spoofing the check. If a gated
+# module drops any one of these while keeping the rest, the gate is silently
+# weakened — so we require the COMPLETE set, not a subset.
+REQUIRED_PANIC_LINTS=(
+  clippy::unwrap_used
+  clippy::expect_used
+  clippy::panic
+  clippy::unreachable
+  clippy::todo
+  clippy::unimplemented
+  clippy::indexing_slicing
+)
+
 for module in "${REQUEST_PATH_MODULES[@]}"; do
   [[ -f "$module" ]] || die "gated request-path module is missing: $module"
   grep -q 'autumn-panic-gate:' "$module" \
     || die "missing gate marker 'autumn-panic-gate:' in $module"
   # The deny header is `#![cfg_attr(not(test), deny(clippy::unwrap_used, …))]`.
-  # rustfmt may wrap it across several lines, so match its stable tokens
-  # individually rather than as one literal string.
+  # rustfmt wraps it across several lines, so match its stable tokens
+  # individually rather than as one literal block.
   grep -q '#!\[cfg_attr(' "$module" \
     && grep -q 'not(test)' "$module" \
     && grep -q 'deny(' "$module" \
-    && grep -q 'clippy::unwrap_used' "$module" \
-    && grep -q 'clippy::indexing_slicing' "$module" \
-    || die "missing or incomplete gate deny header (cfg_attr(not(test), deny(…))) in $module"
+    || die "missing gate deny header opener '#![cfg_attr(not(test), deny(' in $module"
+  # Require every canonical panic lint by its fully-qualified token so no
+  # gated module can quietly drop one while keeping the others.
+  for lint in "${REQUIRED_PANIC_LINTS[@]}"; do
+    grep -qF "$lint" "$module" \
+      || die "gate header in $module is missing required panic lint '$lint'"
+  done
 done
 
 echo "panic-gate: ${#REQUEST_PATH_MODULES[@]} request-path modules gated"

--- a/scripts/check-panic-gate.sh
+++ b/scripts/check-panic-gate.sh
@@ -73,17 +73,42 @@ for module in "${REQUEST_PATH_MODULES[@]}"; do
   [[ -f "$module" ]] || die "gated request-path module is missing: $module"
   grep -q 'autumn-panic-gate:' "$module" \
     || die "missing gate marker 'autumn-panic-gate:' in $module"
-  # The deny header is `#![cfg_attr(not(test), deny(clippy::unwrap_used, …))]`.
-  # rustfmt wraps it across several lines, so match its stable tokens
-  # individually rather than as one literal block.
-  grep -q '#!\[cfg_attr(' "$module" \
-    && grep -q 'not(test)' "$module" \
-    && grep -q 'deny(' "$module" \
+  # Extract ONLY the crate-level panic-gate deny attribute. rustfmt wraps it
+  # across several lines:
+  #
+  #     #![cfg_attr(
+  #         not(test),
+  #         deny(
+  #             clippy::unwrap_used,
+  #             …
+  #             clippy::indexing_slicing,
+  #         )
+  #     )]
+  #
+  # Capture the region from the `#![cfg_attr(` opener through its closing `)]`
+  # and validate the required lints INSIDE that block only. The block is
+  # buffered and emitted solely once the closer is seen, so an unterminated
+  # header yields an empty block (and a hard failure below) rather than a run
+  # to EOF. Scoping to the block matters: gated modules now carry legitimate
+  # per-site `#[allow(clippy::expect_used, reason = "…")]` annotations, and a
+  # whole-file scan would let such an `#[allow(...)]` spoof a lint that was
+  # actually dropped from the deny header.
+  deny_block="$(awk '
+    /#!\[cfg_attr\(/       { capturing = 1 }
+    capturing             { buf = buf $0 ORS }
+    capturing && /\)\]/    { printf "%s", buf; exit }
+  ' "$module")"
+
+  [[ -n "$deny_block" ]] \
+    || die "could not locate a terminated '#![cfg_attr(not(test), deny(…))]' gate header in $module"
+  grep -q 'not(test)' <<<"$deny_block" \
+    && grep -q 'deny(' <<<"$deny_block" \
     || die "missing gate deny header opener '#![cfg_attr(not(test), deny(' in $module"
-  # Require every canonical panic lint by its fully-qualified token so no
-  # gated module can quietly drop one while keeping the others.
+  # Require every canonical panic lint by its fully-qualified token, matched
+  # WITHIN the extracted deny block so no gated module can quietly drop one from
+  # the header while a per-site `#[allow(...)]` keeps the token alive elsewhere.
   for lint in "${REQUIRED_PANIC_LINTS[@]}"; do
-    grep -qF "$lint" "$module" \
+    grep -qF "$lint" <<<"$deny_block" \
       || die "gate header in $module is missing required panic lint '$lint'"
   done
 done


### PR DESCRIPTION
## Before / After
**Before:** a `.unwrap()` / `.expect()` / `panic!` added to a request-path module (middleware, extractors, stores, scheduler/jobs, channels) compiled and passed CI silently — nothing enforced the "panic-free request path" invariant that CONTRIBUTING.md already described. A poisoned lock in one request permanently broke framework-owned shared state for every later request.

**After:** production code in 25 request-path modules is gated by clippy restriction lints in the existing CI `lint` job — an unannotated panic-capable call turns CI red. Poison-prone locks now recover instead of propagating (`unwrap_or_else(PoisonError::into_inner)`), and a regression test proves an induced panic no longer breaks the idempotency store for subsequent requests.

## How
- Gate header `#[cfg_attr(not(test), deny(clippy::unwrap_used, expect_used, panic, unreachable, todo, unimplemented, indexing_slicing))]` on each gated module — scopes the deny to the production (lib) target, auto-exempting tests/benches.
- `scripts/check-panic-gate.sh` enforces the canonical request-path module manifest (fails if a gated module loses its header); wired as a step in the `lint` job alongside fmt/clippy — no new external services.
- Burn-down: poison locks → `PoisonError::into_inner` (the established `circuit_breaker` idiom); provably-infallible builder/crypto/bounds-checked sites → narrow `#[allow(…, reason="…")]`; two real fixes (`error_page_filter` `find('[')` → let-else fallback, `extract` markup sniff rewritten to avoid slicing).
- CONTRIBUTING.md documents the invariant, the "request path" definition vs exempt surfaces, the denied lint set, and the per-site justification syntax.

## Acceptance criteria (#1611)
- **AC1** CI reddens on a new unannotated panic-capable call — done; verified by injecting an unannotated `.unwrap()` into a gated module and confirming clippy fails, then reverting.
- **AC2** request path defined + documented — done (manifest script + CONTRIBUTING).
- **AC3** existing findings burned down — done for `idempotency` (the named module, incl. the near-`Duration::MAX` TTL path already fixed on trunk) + 23 other modules; `inbound_mail` deferred (below).
- **AC4** lock-poisoning contract — done: `idempotency::tests::poisoned_lock_does_not_break_subsequent_requests` + `into_inner` conversions.
- **AC5** contributor docs — done.
- **AC6** same workflow as fmt/clippy, no new services — done (step in the `lint` job).

## Deferred (why "Part of" not "Closes")
- `inbound_mail.rs` — its MIME parser has ~57 index/slice sites over untrusted input; blanket-annotating them as safe would be unsound. Needs a dedicated audit. Header removed; excluded from the manifest.
- `arithmetic_side_effects` (unchecked time/duration/integer arithmetic named in AC1) — too noisy to enable now; currently guarded by the saturating-arithmetic idiom (see `idempotency::saturating_deadline`) + review.
- Feature-gated modules (`mail`/`channels`/`offline-sync`/`ws`) carry the gate header and were burned down + verified with their features enabled, but the default CI `lint` job doesn't build those features, so clippy actively enforces them only when built with features. The manifest script still enforces header presence unconditionally.

## Test evidence
- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` green
- `./scripts/check-panic-gate.sh` → `panic-gate: 25 request-path modules gated`
- `cargo test -p autumn-web --lib idempotency` → 16 passed (incl. the new poison-recovery test)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyNTftPYWdWMJZrxdXFPgH)_