### PR TITLE
⚡ Bolt: [performance improvement] Optimize squish by avoiding Vec allocation

### DIFF
--- a/autumn/src/normalize.rs
+++ b/autumn/src/normalize.rs
@@ -47,9 +47,21 @@ pub fn upcase(s: &str) -> String {
 }
 
 /// Trim and collapse every internal run of whitespace to a single ASCII space.
+///
+/// ⚡ Bolt: Optimization - Avoids an intermediate `Vec` allocation by pushing words
+/// directly into a pre-allocated `String` buffer.
 #[must_use]
 pub fn squish(s: &str) -> String {
-    s.split_whitespace().collect::<Vec<_>>().join(" ")
+    let mut out = String::with_capacity(s.len());
+    let mut words = s.split_whitespace();
+    if let Some(w) = words.next() {
+        out.push_str(w);
+    }
+    for w in words {
+        out.push(' ');
+        out.push_str(w);
+    }
+    out
 }
 
 /// A type whose `#[normalize]` columns can be canonicalized in place.


### PR DESCRIPTION
💡 What: Replaced the intermediate `Vec` allocation in the `squish` normalization function with a more direct iteration that pushes words straight into a pre-allocated `String` buffer using `String::with_capacity()`.
🎯 Why: `squish` is used heavily in `autumn-web` for text normalization in models (`#\[normalize(squish)]`). The original implementation `s.split_whitespace().collect::<Vec<_>>().join(" ")` unnecessarily allocated a `Vec` on the heap to store intermediate string slices for every invocation.
📊 Impact: Completely eliminates one unnecessary heap allocation per call to `squish`, providing a direct zero-cost speed boost to all data processing paths invoking it.
🔬 Measurement: Run `cargo test -p autumn-web --lib normalize` and `cargo bench` to confirm correctness and improved performance.

---
*PR created automatically by Jules for task [11199656783453750870](https://jules.google.com/task/11199656783453750870) started by @madmax983*