### PR TITLE
🌟 Nova: CSV Export for Routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm",
+ "csv",
  "ctrlc",
  "diesel",
  "directories",

--- a/autumn-cli/Cargo.toml
+++ b/autumn-cli/Cargo.toml
@@ -35,6 +35,7 @@ notify-debouncer-mini = "0.7"
 ratatui = "0.30"
 reqwest = { version = "0.13", features = ["blocking", "json", "rustls", "multipart", "cookies"], default-features = false }
 chrono = { workspace = true }
+csv = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10"

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -5036,6 +5036,17 @@ mod tests {
     }
 
     #[test]
+    fn parse_routes_format_csv() {
+        let cli = Cli::try_parse_from(["autumn", "routes", "--format", "csv"]).unwrap();
+        match cli.command {
+            Commands::Routes { format, .. } => {
+                assert_eq!(format, "csv");
+            }
+            _ => panic!("expected Routes command"),
+        }
+    }
+
+    #[test]
     fn parse_routes_with_package() {
         let cli = Cli::try_parse_from(["autumn", "routes", "-p", "blog"]).unwrap();
         match cli.command {

--- a/autumn-cli/src/routes.rs
+++ b/autumn-cli/src/routes.rs
@@ -17,6 +17,7 @@ use crate::text_width::display_width;
 pub enum OutputFormat {
     Table,
     Json,
+    Csv,
 }
 
 impl std::str::FromStr for OutputFormat {
@@ -26,8 +27,9 @@ impl std::str::FromStr for OutputFormat {
         match s.to_lowercase().as_str() {
             "table" => Ok(Self::Table),
             "json" => Ok(Self::Json),
+            "csv" => Ok(Self::Csv),
             other => Err(format!(
-                "unknown format '{other}'; expected 'table' or 'json'"
+                "unknown format '{other}'; expected 'table', 'json', or 'csv'"
             )),
         }
     }
@@ -97,6 +99,7 @@ pub fn run(opts: &RoutesOptions<'_>) {
     match &opts.format {
         OutputFormat::Table => print_table(&routes),
         OutputFormat::Json => print_json(&routes),
+        OutputFormat::Csv => print_csv(&routes),
     }
 }
 
@@ -251,6 +254,50 @@ pub fn print_json(routes: &[RouteInfo]) {
     let json =
         serde_json::to_string_pretty(routes).unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"));
     println!("{json}");
+}
+
+/// Build the CSV string (extracted for testability).
+pub fn format_csv(routes: &[RouteInfo]) -> String {
+    let mut wtr = csv::Writer::from_writer(vec![]);
+
+    // Write header
+    let _ = wtr.write_record([
+        "Method",
+        "Path",
+        "Handler",
+        "Version",
+        "Status",
+        "Source",
+        "Middleware",
+    ]);
+
+    // Write rows
+    for route in routes {
+        let middleware = if route.middleware.is_empty() {
+            String::new()
+        } else {
+            route.middleware.join(", ")
+        };
+        let version = route.api_version.as_deref().unwrap_or("-");
+        let status = route.status.as_deref().unwrap_or("-");
+
+        let _ = wtr.write_record([
+            &route.method,
+            &route.path,
+            &route.handler,
+            version,
+            status,
+            &route.source,
+            &middleware,
+        ]);
+    }
+
+    String::from_utf8(wtr.into_inner().unwrap_or_default()).unwrap_or_default()
+}
+
+pub fn print_csv(routes: &[RouteInfo]) {
+    let csv_str = format_csv(routes);
+    print!("{csv_str}");
 }
 
 // ── Binary discovery (mirrored from build.rs) ──────────────────────────────
@@ -447,6 +494,12 @@ mod tests {
     }
 
     #[test]
+    fn parse_format_csv() {
+        let f: OutputFormat = "csv".parse().unwrap();
+        assert_eq!(f, OutputFormat::Csv);
+    }
+
+    #[test]
     fn parse_format_json() {
         let f: OutputFormat = "json".parse().unwrap();
         assert_eq!(f, OutputFormat::Json);
@@ -575,6 +628,31 @@ mod tests {
         assert_eq!(routes[1].method, "GET");
         assert_eq!(routes[2].path, "/posts");
         assert_eq!(routes[2].method, "POST");
+    }
+
+    // ── format_csv ──────────────────────────────────────────────────────
+
+    #[test]
+    fn format_csv_produces_valid_csv() {
+        let routes = sample_routes();
+        let csv_str = crate::routes::format_csv(&routes);
+        let mut reader = csv::Reader::from_reader(csv_str.as_bytes());
+        let headers = reader.headers().unwrap();
+        assert_eq!(headers.len(), 7);
+        assert_eq!(&headers[0], "Method");
+        assert_eq!(&headers[1], "Path");
+        assert_eq!(&headers[2], "Handler");
+        assert_eq!(&headers[3], "Version");
+        assert_eq!(&headers[4], "Status");
+        assert_eq!(&headers[5], "Source");
+        assert_eq!(&headers[6], "Middleware");
+
+        let mut count = 0;
+        for result in reader.records() {
+            let _record: csv::StringRecord = result.unwrap();
+            count += 1;
+        }
+        assert_eq!(count, routes.len());
     }
 
     // ── format_table ──────────────────────────────────────────────────────


### PR DESCRIPTION
💡 **The Spark:** "Users currently have table and JSON output for `autumn routes`. Can we make it easier to load route definitions into spreadsheets and data processing tools?"
🚀 **The Feature:** "Implemented a new `--format csv` option for the `autumn routes` command."
🔭 **The Potential:** "Could be used by administrators to easily audit their application routes inside external tools like Excel, or ingest it into scripts that process CSV out of the box."
⚠️ **Risk:** "Low. Purely an additive CLI feature that introduces a new enum variant and rendering path without changing existing behaviors."

---
*PR created automatically by Jules for task [2243782179752710633](https://jules.google.com/task/2243782179752710633) started by @madmax983*