### PR TITLE
ci(conformance): add passkeys leg to app-variant matrix

### DIFF
--- a/.github/workflows/generator-conformance.yml
+++ b/.github/workflows/generator-conformance.yml
@@ -174,8 +174,7 @@ jobs:
   #   totp       -> generated_auth_totp_cargo_checks
   #   sharded    -> generated_sharded_scaffold_cargo_checks
   #   searchable -> generated_searchable_scaffold_cargo_checks
-  #
-  # TODO: add passkeys once #1851 merges — tracked in #1856.
+  #   passkeys   -> generated_auth_passkeys_cargo_checks
   app-variant-conformance:
     name: App-variant conformance (${{ matrix.variant.name }}, ${{ matrix.toolchain }})
     runs-on: ubuntu-latest
@@ -190,6 +189,8 @@ jobs:
             test: generated_sharded_scaffold_cargo_checks
           - name: searchable
             test: generated_searchable_scaffold_cargo_checks
+          - name: passkeys
+            test: generated_auth_passkeys_cargo_checks
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## Before / After

**Before:** the `app-variant-conformance` matrix covered `totp`, `sharded`, and `searchable` but not `passkeys` — the variant whose #1822 break motivated the matrix widening in #1856. A TODO in the workflow noted passkeys was deferred until #1851 merged.

**After:** the `passkeys` leg is added. All four generated-app variants (`totp`, `sharded`, `searchable`, `passkeys`) now build in CI at the `cargo check --tests` level across the toolchain axis (`stable`, `1.88.0`) → 8 matrix jobs. The obsolete "passkeys deferred" TODO is removed.

## How

Added the matrix leg `passkeys -> generated_auth_passkeys_cargo_checks`, mirroring the existing legs' `name -> test` mapping. The passkeys generated app's deps (`webauthn-rs` 0.5.5, `base64` 0.22.1) are already present in the workspace `Cargo.lock` and covered by `rust-cache`, so — matching the `sharded`/`searchable` legs — no per-variant dep-prefetch is added. The `totp` leg keeps its prefetch only because `totp-rs` is absent from the workspace lock, which is that step's documented justification.

Now that #1822/#1851 (the passkeys generator fix) has merged and the conformance test passes on trunk, this adds the last deferred variant and completes the matrix widening.

Closes #1856

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjBMk5ZKywnEPGGW6Gf9SC)_