### PR TITLE
Emit DraftExt import for --live scaffolds so they compile

### DIFF
--- a/.github/workflows/generator-conformance.yml
+++ b/.github/workflows/generator-conformance.yml
@@ -175,6 +175,7 @@ jobs:
   #   sharded    -> generated_sharded_scaffold_cargo_checks
   #   searchable -> generated_searchable_scaffold_cargo_checks
   #   passkeys   -> generated_auth_passkeys_cargo_checks
+  #   live       -> generated_live_scaffold_cargo_checks
   app-variant-conformance:
     name: App-variant conformance (${{ matrix.variant.name }}, ${{ matrix.toolchain }})
     runs-on: ubuntu-latest
@@ -191,6 +192,8 @@ jobs:
             test: generated_searchable_scaffold_cargo_checks
           - name: passkeys
             test: generated_auth_passkeys_cargo_checks
+          - name: live
+            test: generated_live_scaffold_cargo_checks
     steps:
       - uses: actions/checkout@v7
 

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1304,6 +1304,18 @@ fn render_repository_file(
     let query_body = render_repository_queries(pascal_name, queries);
     let soft_delete_attr = if soft_delete { ", soft_delete" } else { "" };
     let broadcasts_attr = if live { ", broadcasts = true" } else { "" };
+    // When `broadcasts = true` is set, `#[repository]` synthesizes internal
+    // hooks whose generated `update` body expands an unqualified
+    // `{Pascal}DraftExt::from_patch(...)`. Import that trait alongside the other
+    // model types so the generated repository compiles (issue #1853). Gated on
+    // the same `live` boolean that drives `broadcasts_attr` — the default
+    // (non-broadcast) scaffold emits no hooks and no `from_patch`, so it keeps
+    // the plain three-name import.
+    let draft_ext_import = if live {
+        format!(", {pascal_name}DraftExt")
+    } else {
+        String::new()
+    };
     // Issue #1319: `searchable` opts the repository into the FTS `search()` /
     // `search_page(query, &PageRequest)` methods (backed by the model's
     // `#[searchable]` fields + the migration's `search_vector` column).
@@ -1411,7 +1423,7 @@ fn render_repository_file(
     };
     format!(
         "{doc_comment}\n\
-         use crate::models::{snake_name}::{{{pascal_name}, New{pascal_name}, Update{pascal_name}}};\n\
+         use crate::models::{snake_name}::{{{pascal_name}, New{pascal_name}, Update{pascal_name}{draft_ext_import}}};\n\
          use crate::schema::{plural};\n\
          \n\
          #[autumn_web::repository({pascal_name}, api = \"/api/{plural}\"{soft_delete_attr}{broadcasts_attr}{searchable_attr})]\n\

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -6225,6 +6225,48 @@ fn generated_searchable_scaffold_cargo_checks() {
     );
 }
 
+/// Slow end-to-end check: scaffold a `--live` project, patch Cargo.toml to the
+/// local autumn-web, and `cargo check --tests` the result. Regression coverage
+/// for issue #1853: `--live` sets `broadcasts = true` on the `#[repository]`,
+/// which makes the macro synthesize internal hooks whose generated `update`
+/// body expands an unqualified `{Pascal}DraftExt::from_patch(...)`. The
+/// generated repository file must import `{Pascal}DraftExt` alongside the other
+/// model types, or the scaffold fails to compile with
+/// `error[E0405]: cannot find trait PostDraftExt in this scope`.
+///
+/// Run with: `cargo test -p autumn-cli -- --ignored generated_live_scaffold_cargo_checks`
+#[test]
+#[ignore = "slow: cargo-checks a fresh live scaffold — run with `cargo test -p autumn-cli -- --ignored`"]
+fn generated_live_scaffold_cargo_checks() {
+    let (_tmp, project) = fresh_project("live-build");
+
+    patch_generated_cargo_toml(&project);
+
+    run_autumn(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Post",
+            "title:String",
+            "body:Text",
+            "--live",
+        ],
+    );
+
+    let check = Command::new("cargo")
+        .args(["check", "--tests"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    assert!(
+        check.status.success(),
+        "cargo check on generated live scaffold failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr),
+    );
+}
+
 /// Slow end-to-end check: scaffold a `--soft-delete` project, patch Cargo.toml
 /// to the local autumn-web, and `cargo check --tests` the result. Regression
 /// coverage for a bug where the generated model's `deleted_at` field lacked


### PR DESCRIPTION
## Before / After

**Before:** `autumn generate scaffold Post title:String body:Text --live` produced a project that fails `cargo check`:

```
error[E0405]: cannot find trait `PostDraftExt` in this scope
  --> src/repositories/post.rs
```

**After:** the `--live` scaffold compiles cleanly.

## Why

A `--live` scaffold sets `broadcasts = true` on the generated `#[repository]`. That makes `autumn-macros` synthesize internal hooks whose generated `update` body expands an **unqualified** `{Pascal}DraftExt::from_patch(...)`. But the generated repository file's import block only emitted:

```rust
use crate::models::post::{Post, NewPost, UpdatePost};
```

— it never imported `PostDraftExt`, so the trait was out of scope. The default (non-broadcast) scaffold synthesizes no hooks and no `from_patch`, so it compiled — only the `--live`/`broadcasts` path broke.

## How

- `autumn-cli/src/generate/scaffold.rs`: the repository import block now appends `, {Pascal}DraftExt` to the `use crate::models::{snake}::{...};` line, gated on the **same** `live` boolean that drives `broadcasts = true`. The default path's three-name import is unchanged.
- Added `generated_live_scaffold_cargo_checks` in `autumn-cli/tests/generate.rs`, mirroring the existing `generated_sharded_scaffold_cargo_checks` / `generated_searchable_scaffold_cargo_checks` conformance tests (`#[ignore]`d; scaffolds `--live`, patches `[patch.crates-io]` to the in-tree `autumn-web`, then `cargo check --tests`). This is why the bug hid — no `--live` variant was compile-gated.
- Added a `live` leg to the `app-variant-conformance` matrix in `.github/workflows/generator-conformance.yml` (both toolchains), following the #1856 matrix-widening pattern.

## Verification

- `cargo fmt --all -- --check` clean.
- `cargo clippy -p autumn-cli --all-targets -- -D warnings` clean.
- `generated_live_scaffold_cargo_checks` passes (previously would fail with E0405).
- `generated_scaffold_cargo_checks` (default, non-live) still passes.

Closes #1853


---
_Generated by [Claude Code](https://claude.ai/code/session_018i76m8A82tbXQvLD8Zsz9o)_