### PR TITLE
Security posture manifest v2: provenance envelope + CSRF/headers dimensions (Part of #1627)

### DIFF
--- a/autumn-cli/src/routes_audit.rs
+++ b/autumn-cli/src/routes_audit.rs
@@ -16,14 +16,21 @@
 
 use std::process::Command;
 
-use autumn_web::route_listing::OMITTED_ROUTES_MARKER;
+use autumn_web::route_listing::{
+    CsrfDump, HeadersDump, OMITTED_ROUTES_MARKER, SECURITY_CONFIG_MARKER, SecurityDump,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::routes;
 
 /// Schema version of the emitted manifest. Bumped only on breaking changes to
 /// the document shape.
-pub const MANIFEST_SCHEMA_VERSION: u32 = 1;
+///
+/// v2 (#1627) wraps each dimension in a provenance envelope
+/// (`{ provenance, source, entries }`), adds the `csrf` and `security_headers`
+/// dimensions, and adds a top-level `excluded` list. The `routes` entries keep
+/// their v1 shape, only wrapped in the envelope.
+pub const MANIFEST_SCHEMA_VERSION: u32 = 2;
 
 /// Options controlling `autumn routes audit`.
 pub struct AuditOptions<'a> {
@@ -78,23 +85,54 @@ impl AuditRoute {
     }
 }
 
-// ── Manifest document ───────────────────────────────────────────────────────
+// ── Manifest document (schema v2, #1627) ────────────────────────────────────
 
-/// Top-level security manifest.
+/// Provenance class of a manifest dimension. A small closed enum serialized to
+/// the exact lowercase tags used throughout the manifest.
+///
+/// - `provable` — derived from macro-expanded code; the manifest *proves* it.
+/// - `declared` — read from configuration; the manifest reports what was
+///   *configured*, not that the runtime honors it.
+/// - `runtime-only` — a boot/runtime fact that a build-time manifest cannot
+///   observe; listed only in `excluded`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Provenance {
+    Provable,
+    Declared,
+    #[serde(rename = "runtime-only")]
+    RuntimeOnly,
+}
+
+/// Top-level security manifest (schema v2).
 #[derive(Debug, Serialize)]
 pub struct Manifest {
     pub schema_version: u32,
     pub dimensions: Dimensions,
+    /// Dimensions deliberately not yet emitted, with the provenance class they
+    /// will eventually carry and why they are excluded from this build.
+    pub excluded: Vec<ExcludedDimension>,
 }
 
-/// Manifest dimensions. Only `routes` exists today; additional provable
-/// dimensions can be added here without breaking existing consumers.
+/// Manifest dimensions. Order is fixed (`routes`, then `csrf`, then
+/// `security_headers`) so the serialized document is diff-stable.
 #[derive(Debug, Serialize)]
 pub struct Dimensions {
-    pub routes: Vec<ManifestRoute>,
+    pub routes: RoutesDimension,
+    pub csrf: CsrfDimension,
+    pub security_headers: HeadersDimension,
 }
 
-/// One route entry in the manifest's `routes` dimension.
+/// The `routes` dimension: provable auth posture per mounted route.
+#[derive(Debug, Serialize)]
+pub struct RoutesDimension {
+    pub provenance: Provenance,
+    pub source: &'static str,
+    pub entries: Vec<ManifestRoute>,
+}
+
+/// One route entry in the manifest's `routes` dimension. Byte-for-byte
+/// identical to the v1 shape (only its container changed).
 #[derive(Debug, Serialize)]
 pub struct ManifestRoute {
     pub path: String,
@@ -110,12 +148,80 @@ pub struct ManifestRoute {
     pub provenance: &'static str,
 }
 
-/// Build a stable-ordered security manifest from the audited routes.
+/// The `csrf` dimension: declared CSRF enforcement per mutating route.
+#[derive(Debug, Serialize)]
+pub struct CsrfDimension {
+    pub provenance: Provenance,
+    pub source: &'static str,
+    /// Configured exempt path prefixes (sorted).
+    pub exempt_paths: Vec<String>,
+    pub entries: Vec<CsrfEntry>,
+}
+
+/// One CSRF entry: a single mutating route and whether CSRF is enforced on it.
+#[derive(Debug, Serialize)]
+pub struct CsrfEntry {
+    pub path: String,
+    pub method: String,
+    /// `enabled && !is_safe(method) && !is_exempt(path)`, mirroring the runtime
+    /// `CsrfLayer` predicate.
+    pub csrf_enforced: bool,
+    /// Whether this route's path matches a configured exemption prefix.
+    pub exempt: bool,
+}
+
+/// The `security_headers` dimension: declared response security headers.
+#[derive(Debug, Serialize)]
+pub struct HeadersDimension {
+    pub provenance: Provenance,
+    pub source: &'static str,
+    pub entries: Vec<HeaderEntry>,
+}
+
+/// One security-header entry. `emitted` is `!value.is_empty()`.
+#[derive(Debug, Serialize)]
+pub struct HeaderEntry {
+    pub header: String,
+    pub value: String,
+    pub emitted: bool,
+}
+
+/// A dimension deliberately not yet emitted in this manifest build.
+#[derive(Debug, Serialize)]
+pub struct ExcludedDimension {
+    pub dimension: &'static str,
+    pub eventual_provenance: Provenance,
+    pub reason: &'static str,
+}
+
+/// Whether `method` is in the configured safe-method set (case-sensitive; route
+/// methods and config defaults are both upper-case).
+fn method_is_safe(method: &str, safe_methods: &[String]) -> bool {
+    safe_methods.iter().any(|m| m == method)
+}
+
+/// Whether `path` matches one of the configured CSRF exemption prefixes.
 ///
-/// Routes are ordered by `(path, method)` so the manifest is diff-friendly and
-/// reproducible across runs.
-#[must_use]
-pub fn build_manifest(routes: &[AuditRoute]) -> Manifest {
+/// Mirrors the runtime `CsrfLayer` exemption predicate
+/// (`autumn/src/security/csrf.rs`): a prefix matches on an exact equality, or a
+/// prefix match whose boundary is a `/` (either the prefix ends with `/`, or the
+/// remainder starts with `/`). Route paths in the manifest are already
+/// normalized, so no dot-segment cleaning is required here.
+fn path_is_exempt(path: &str, exempt_paths: &[String]) -> bool {
+    exempt_paths.iter().any(|prefix| {
+        if path == prefix {
+            true
+        } else if let Some(stripped) = path.strip_prefix(prefix.as_str()) {
+            prefix.ends_with('/') || stripped.starts_with('/')
+        } else {
+            false
+        }
+    })
+}
+
+/// Build the `routes` dimension (provable) from the audited routes, ordered by
+/// `(path, method)`.
+fn build_routes_dimension(routes: &[AuditRoute]) -> RoutesDimension {
     let mut entries: Vec<ManifestRoute> = routes
         .iter()
         .map(|r| ManifestRoute {
@@ -131,11 +237,204 @@ pub fn build_manifest(routes: &[AuditRoute]) -> Manifest {
         })
         .collect();
     entries.sort_by(|a, b| a.path.cmp(&b.path).then_with(|| a.method.cmp(&b.method)));
+    RoutesDimension {
+        provenance: Provenance::Provable,
+        source: "macro:#[secured]/#[authorize]/#[public]",
+        entries,
+    }
+}
+
+/// Build the `csrf` dimension (declared): one entry per *mutating* route (method
+/// not in `safe_methods`), plus the sorted configured exemptions.
+fn build_csrf_dimension(routes: &[AuditRoute], csrf: &CsrfDump) -> CsrfDimension {
+    let mut exempt_paths = csrf.exempt_paths.clone();
+    exempt_paths.sort();
+    exempt_paths.dedup();
+
+    let mut entries: Vec<CsrfEntry> = routes
+        .iter()
+        .filter(|r| !method_is_safe(&r.method, &csrf.safe_methods))
+        .map(|r| {
+            let exempt = path_is_exempt(&r.path, &csrf.exempt_paths);
+            CsrfEntry {
+                path: r.path.clone(),
+                method: r.method.clone(),
+                // Mutating method here, so `is_safe` reduces to `is_exempt`.
+                csrf_enforced: csrf.enabled && !exempt,
+                exempt,
+            }
+        })
+        .collect();
+    entries.sort_by(|a, b| a.path.cmp(&b.path).then_with(|| a.method.cmp(&b.method)));
+
+    CsrfDimension {
+        provenance: Provenance::Declared,
+        source: "config:security.csrf",
+        exempt_paths,
+        entries,
+    }
+}
+
+/// Build the `security_headers` dimension (declared): one entry per header key,
+/// in sorted key order. `value` is the effective declared string (empty when
+/// the header is not emitted).
+fn build_headers_dimension(h: &HeadersDump) -> HeadersDimension {
+    let hsts_value = if h.strict_transport_security {
+        let mut v = format!("max-age={}", h.hsts_max_age_secs);
+        if h.hsts_include_subdomains {
+            v.push_str("; includeSubDomains");
+        }
+        v
+    } else {
+        String::new()
+    };
+    let bool_header = |on: bool, val: &str| if on { val.to_owned() } else { String::new() };
+
+    let mut entries = vec![
+        header_entry("content_security_policy", h.content_security_policy.clone()),
+        header_entry("csp_nonce", bool_header(h.csp_nonce, "enabled")),
+        header_entry("permissions_policy", h.permissions_policy.clone()),
+        header_entry("referrer_policy", h.referrer_policy.clone()),
+        header_entry("strict_transport_security", hsts_value),
+        header_entry(
+            "x_content_type_options",
+            bool_header(h.x_content_type_options, "nosniff"),
+        ),
+        header_entry("x_frame_options", h.x_frame_options.clone()),
+        header_entry(
+            "xss_protection",
+            bool_header(h.xss_protection, "1; mode=block"),
+        ),
+    ];
+    entries.sort_by(|a, b| a.header.cmp(&b.header));
+
+    HeadersDimension {
+        provenance: Provenance::Declared,
+        source: "config:security.headers",
+        entries,
+    }
+}
+
+fn header_entry(header: &str, value: String) -> HeaderEntry {
+    HeaderEntry {
+        header: header.to_owned(),
+        emitted: !value.is_empty(),
+        value,
+    }
+}
+
+/// The fixed, deterministically-ordered list of dimensions deliberately
+/// excluded from this manifest build (#1627 slice 1).
+fn excluded_dimensions() -> Vec<ExcludedDimension> {
+    vec![
+        ExcludedDimension {
+            dimension: "authorization_policies",
+            eventual_provenance: Provenance::Provable,
+            reason: "phase-1 follow-up: full #[authorize] action→policy-type binding needs new \
+                     macro metadata; boolean policy presence already ships in \
+                     routes.entries[].policy",
+        },
+        ExcludedDimension {
+            dimension: "sessions",
+            eventual_provenance: Provenance::Declared,
+            reason: "later phase",
+        },
+        ExcludedDimension {
+            dimension: "secrets",
+            eventual_provenance: Provenance::Declared,
+            reason: "later phase",
+        },
+        ExcludedDimension {
+            dimension: "encryption",
+            eventual_provenance: Provenance::Provable,
+            reason: "later phase (#[encrypted] fields provable; key config declared)",
+        },
+        ExcludedDimension {
+            dimension: "rate_limit",
+            eventual_provenance: Provenance::Declared,
+            reason: "later phase",
+        },
+        ExcludedDimension {
+            dimension: "submit_token",
+            eventual_provenance: Provenance::Declared,
+            reason: "later phase",
+        },
+        ExcludedDimension {
+            dimension: "outbound_http",
+            eventual_provenance: Provenance::Declared,
+            reason: "later phase; named-client base_urls allowlist is config, nothing proves every \
+                     outbound call routes through a named client",
+        },
+        ExcludedDimension {
+            dimension: "policy_registration",
+            eventual_provenance: Provenance::RuntimeOnly,
+            reason: "boot-time fact; excluded from a build-time manifest by design",
+        },
+    ]
+}
+
+/// The `csrf` dimension emitted when no security config was reported.
+const fn empty_csrf_dimension() -> CsrfDimension {
+    CsrfDimension {
+        provenance: Provenance::Declared,
+        source: "config:security.csrf",
+        exempt_paths: Vec::new(),
+        entries: Vec::new(),
+    }
+}
+
+/// The `security_headers` dimension emitted when no security config was reported.
+const fn empty_headers_dimension() -> HeadersDimension {
+    HeadersDimension {
+        provenance: Provenance::Declared,
+        source: "config:security.headers",
+        entries: Vec::new(),
+    }
+}
+
+/// Build a stable-ordered security manifest (schema v2) from the audited routes
+/// and the resolved security configuration.
+///
+/// When `security` is `None` (an older dump with no security-config marker) the
+/// declared dimensions are emitted empty rather than fabricated, keeping the
+/// schema stable without asserting configuration the dump did not report.
+///
+/// All dimensions are deterministically ordered so the manifest is diff-friendly
+/// and reproducible across runs.
+#[must_use]
+pub fn build_manifest(routes: &[AuditRoute], security: Option<&SecurityDump>) -> Manifest {
+    let routes_dim = build_routes_dimension(routes);
+    let (csrf, security_headers) = security.map_or_else(
+        || (empty_csrf_dimension(), empty_headers_dimension()),
+        |s| {
+            (
+                build_csrf_dimension(routes, &s.csrf),
+                build_headers_dimension(&s.headers),
+            )
+        },
+    );
 
     Manifest {
         schema_version: MANIFEST_SCHEMA_VERSION,
-        dimensions: Dimensions { routes: entries },
+        dimensions: Dimensions {
+            routes: routes_dim,
+            csrf,
+            security_headers,
+        },
+        excluded: excluded_dimensions(),
     }
+}
+
+/// Parse the security-config marker line ([`SECURITY_CONFIG_MARKER`]) from the
+/// child's stderr, if present. Takes the last matching line (the dump emits at
+/// most one per run).
+#[must_use]
+pub fn parse_security_config(stderr: &str) -> Option<SecurityDump> {
+    stderr
+        .lines()
+        .filter_map(|line| line.strip_prefix(SECURITY_CONFIG_MARKER))
+        .filter_map(|json| serde_json::from_str::<SecurityDump>(json.trim()).ok())
+        .next_back()
 }
 
 /// Serialize a manifest to pretty JSON.
@@ -256,6 +555,10 @@ pub fn run(opts: &AuditOptions<'_>) {
     // visible to the user.
     let output = Command::new(&binary)
         .env("AUTUMN_DUMP_ROUTES", "1")
+        // Ask the app to also dump its resolved security config (CSRF + headers)
+        // so we can build the `declared` manifest dimensions. Only `audit` sets
+        // this; plain `autumn routes` leaves the marker off its stderr.
+        .env("AUTUMN_DUMP_SECURITY", "1")
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .output()
@@ -265,8 +568,16 @@ pub fn run(opts: &AuditOptions<'_>) {
         });
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    eprint!("{stderr}");
+    // Forward the child's stderr verbatim, but hide the machine-readable
+    // security-config marker line (it carries a full JSON blob for us, not the
+    // user).
+    for line in stderr.lines() {
+        if !line.starts_with(SECURITY_CONFIG_MARKER) {
+            eprintln!("{line}");
+        }
+    }
     let omitted = parse_omitted_count(&stderr);
+    let security = parse_security_config(&stderr);
 
     if !output.status.success() {
         eprintln!(
@@ -283,7 +594,7 @@ pub fn run(opts: &AuditOptions<'_>) {
         std::process::exit(1);
     });
 
-    let manifest = build_manifest(&routes);
+    let manifest = build_manifest(&routes, security.as_ref());
     let json = manifest_json(&manifest);
 
     if let Some(path) = opts.manifest {
@@ -402,14 +713,14 @@ mod tests {
     #[test]
     fn manifest_is_schema_shaped_and_provable() {
         let routes = vec![route("GET", "/a", "a", "gated")];
-        let manifest = build_manifest(&routes);
+        let manifest = build_manifest(&routes, None);
         assert_eq!(manifest.schema_version, MANIFEST_SCHEMA_VERSION);
-        assert_eq!(manifest.dimensions.routes.len(), 1);
-        assert_eq!(manifest.dimensions.routes[0].provenance, "provable");
+        assert_eq!(manifest.dimensions.routes.entries.len(), 1);
+        assert_eq!(manifest.dimensions.routes.entries[0].provenance, "provable");
 
         let json: serde_json::Value = serde_json::from_str(&manifest_json(&manifest)).unwrap();
-        assert_eq!(json["schema_version"], 1);
-        let entry = &json["dimensions"]["routes"][0];
+        assert_eq!(json["schema_version"], 2);
+        let entry = &json["dimensions"]["routes"]["entries"][0];
         for key in [
             "path",
             "method",
@@ -432,10 +743,11 @@ mod tests {
             route("GET", "/posts", "list", "public"),
             route("GET", "/about", "about", "public"),
         ];
-        let manifest = build_manifest(&routes);
+        let manifest = build_manifest(&routes, None);
         let order: Vec<(&str, &str)> = manifest
             .dimensions
             .routes
+            .entries
             .iter()
             .map(|r| (r.path.as_str(), r.method.as_str()))
             .collect();
@@ -451,11 +763,258 @@ mod tests {
         r.roles = vec!["admin".to_owned()];
         r.scopes = vec!["posts:write".to_owned()];
         r.policy = true;
-        let manifest = build_manifest(&[r]);
-        let entry = &manifest.dimensions.routes[0];
+        let manifest = build_manifest(&[r], None);
+        let entry = &manifest.dimensions.routes.entries[0];
         assert_eq!(entry.roles, vec!["admin"]);
         assert_eq!(entry.scopes, vec!["posts:write"]);
         assert!(entry.policy);
+    }
+
+    // ── provenance envelope + declared dimensions (#1627) ────────────────────
+
+    /// Build a [`SecurityDump`] mirroring the app's `SecurityDump::from_config`
+    /// wire snapshot, with sensible defaults callers can override per-field.
+    fn security_dump(enabled: bool, exempt_paths: &[&str]) -> SecurityDump {
+        SecurityDump {
+            csrf: CsrfDump {
+                enabled,
+                safe_methods: vec![
+                    "GET".to_owned(),
+                    "HEAD".to_owned(),
+                    "OPTIONS".to_owned(),
+                    "TRACE".to_owned(),
+                ],
+                exempt_paths: exempt_paths.iter().map(|s| (*s).to_owned()).collect(),
+            },
+            headers: HeadersDump {
+                x_frame_options: "DENY".to_owned(),
+                x_content_type_options: true,
+                xss_protection: true,
+                content_security_policy: "default-src 'self'".to_owned(),
+                referrer_policy: "strict-origin-when-cross-origin".to_owned(),
+                permissions_policy: String::new(),
+                strict_transport_security: false,
+                hsts_max_age_secs: 31_536_000,
+                hsts_include_subdomains: true,
+                csp_nonce: false,
+            },
+        }
+    }
+
+    /// Serialize a manifest to a `serde_json::Value` for structural comparison.
+    fn manifest_value(m: &Manifest) -> serde_json::Value {
+        serde_json::from_str(&manifest_json(m)).unwrap()
+    }
+
+    /// AC-1: the top-level document is schema v2, carries the three dimensions
+    /// with the correct provenance labels, and the `excluded` list with its
+    /// closed provenance enum values.
+    #[test]
+    fn manifest_v2_envelope_shape_and_provenance_labels() {
+        let routes = vec![
+            route("GET", "/health", "health", "framework"),
+            route("POST", "/widgets", "create_widget", "gated"),
+        ];
+        let sec = security_dump(true, &[]);
+        let json = manifest_value(&build_manifest(&routes, Some(&sec)));
+
+        assert_eq!(json["schema_version"], 2);
+        assert_eq!(json["dimensions"]["routes"]["provenance"], "provable");
+        assert_eq!(
+            json["dimensions"]["routes"]["source"],
+            "macro:#[secured]/#[authorize]/#[public]"
+        );
+        assert_eq!(json["dimensions"]["csrf"]["provenance"], "declared");
+        assert_eq!(json["dimensions"]["csrf"]["source"], "config:security.csrf");
+        assert_eq!(
+            json["dimensions"]["security_headers"]["provenance"],
+            "declared"
+        );
+        assert_eq!(
+            json["dimensions"]["security_headers"]["source"],
+            "config:security.headers"
+        );
+
+        // Excluded list is present, ordered, and uses the closed enum values.
+        let excluded = json["excluded"].as_array().expect("excluded array");
+        assert_eq!(excluded.len(), 8);
+        assert_eq!(excluded[0]["dimension"], "authorization_policies");
+        assert_eq!(excluded[0]["eventual_provenance"], "provable");
+        let runtime_only = excluded
+            .iter()
+            .find(|e| e["dimension"] == "policy_registration")
+            .expect("policy_registration excluded");
+        assert_eq!(runtime_only["eventual_provenance"], "runtime-only");
+    }
+
+    /// AC-2 falsifiability: one CSRF entry per mutating route; a safe-method
+    /// (GET) route never appears in `csrf.entries`.
+    #[test]
+    fn csrf_dimension_only_covers_mutating_routes() {
+        let routes = vec![
+            route("GET", "/widgets", "list_widgets", "public"),
+            route("POST", "/widgets", "create_widget", "gated"),
+            route("DELETE", "/widgets/{id}", "delete_widget", "gated"),
+        ];
+        let sec = security_dump(true, &[]);
+        let manifest = build_manifest(&routes, Some(&sec));
+        let paths: Vec<(&str, &str)> = manifest
+            .dimensions
+            .csrf
+            .entries
+            .iter()
+            .map(|e| (e.path.as_str(), e.method.as_str()))
+            .collect();
+        assert_eq!(
+            paths,
+            vec![("/widgets", "POST"), ("/widgets/{id}", "DELETE")],
+            "only mutating routes, ordered by (path, method)"
+        );
+        assert!(
+            manifest
+                .dimensions
+                .csrf
+                .entries
+                .iter()
+                .all(|e| e.csrf_enforced)
+        );
+    }
+
+    /// AC-2 keystone: disabling CSRF flips exactly the affected `csrf.entries`
+    /// and leaves `routes` and `security_headers` byte-identical.
+    #[test]
+    fn disabling_csrf_flips_only_csrf_entries() {
+        let routes = vec![
+            route("GET", "/health", "health", "framework"),
+            route("POST", "/widgets", "create_widget", "gated"),
+        ];
+        let on = manifest_value(&build_manifest(&routes, Some(&security_dump(true, &[]))));
+        let off = manifest_value(&build_manifest(&routes, Some(&security_dump(false, &[]))));
+
+        // routes + security_headers untouched.
+        assert_eq!(on["dimensions"]["routes"], off["dimensions"]["routes"]);
+        assert_eq!(
+            on["dimensions"]["security_headers"],
+            off["dimensions"]["security_headers"]
+        );
+        // csrf.entries changed: enforced true → false for the mutating route.
+        assert_eq!(
+            on["dimensions"]["csrf"]["entries"][0]["csrf_enforced"],
+            true
+        );
+        assert_eq!(
+            off["dimensions"]["csrf"]["entries"][0]["csrf_enforced"],
+            false
+        );
+    }
+
+    /// AC-2 keystone: adding an exempt-path prefix flips exactly the entries
+    /// under that prefix and records the exemption, leaving other dimensions
+    /// byte-identical.
+    #[test]
+    fn adding_exempt_path_flips_only_affected_csrf_entries() {
+        let routes = vec![
+            route("POST", "/api/widgets", "api_create", "gated"),
+            route("POST", "/widgets", "create_widget", "gated"),
+        ];
+        let base = manifest_value(&build_manifest(&routes, Some(&security_dump(true, &[]))));
+        let exempt = manifest_value(&build_manifest(
+            &routes,
+            Some(&security_dump(true, &["/api/"])),
+        ));
+
+        assert_eq!(base["dimensions"]["routes"], exempt["dimensions"]["routes"]);
+        assert_eq!(
+            base["dimensions"]["security_headers"],
+            exempt["dimensions"]["security_headers"]
+        );
+
+        // /api/widgets (sorts first) is now exempt & unenforced; /widgets is not.
+        let e = &exempt["dimensions"]["csrf"]["entries"];
+        assert_eq!(e[0]["path"], "/api/widgets");
+        assert_eq!(e[0]["exempt"], true);
+        assert_eq!(e[0]["csrf_enforced"], false);
+        assert_eq!(e[1]["path"], "/widgets");
+        assert_eq!(e[1]["exempt"], false);
+        assert_eq!(e[1]["csrf_enforced"], true);
+        // The exemption is recorded once at the dimension level.
+        assert_eq!(exempt["dimensions"]["csrf"]["exempt_paths"][0], "/api/");
+    }
+
+    /// AC-3 keystone: weakening `x_frame_options` changes exactly that header
+    /// entry; emptying the CSP flips exactly its `emitted`/`value` and nothing
+    /// else. `routes` and `csrf` stay byte-identical.
+    #[test]
+    fn weakening_a_header_changes_only_that_entry() {
+        let routes = vec![route("POST", "/widgets", "create_widget", "gated")];
+        let base_sec = security_dump(true, &[]);
+        let base = manifest_value(&build_manifest(&routes, Some(&base_sec)));
+
+        // Weaken X-Frame-Options DENY → SAMEORIGIN.
+        let mut weak = security_dump(true, &[]);
+        weak.headers.x_frame_options = "SAMEORIGIN".to_owned();
+        let weak = manifest_value(&build_manifest(&routes, Some(&weak)));
+
+        assert_eq!(base["dimensions"]["routes"], weak["dimensions"]["routes"]);
+        assert_eq!(base["dimensions"]["csrf"], weak["dimensions"]["csrf"]);
+
+        let find = |v: &serde_json::Value, key: &str| -> serde_json::Value {
+            v["dimensions"]["security_headers"]["entries"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|e| e["header"] == key)
+                .unwrap()
+                .clone()
+        };
+        assert_eq!(find(&base, "x_frame_options")["value"], "DENY");
+        assert_eq!(find(&weak, "x_frame_options")["value"], "SAMEORIGIN");
+        // Every other header entry is unchanged.
+        for key in ["content_security_policy", "referrer_policy"] {
+            assert_eq!(
+                find(&base, key),
+                find(&weak, key),
+                "{key} must be untouched"
+            );
+        }
+
+        // Emptying the CSP flips emitted true → false and blanks the value.
+        let mut no_csp = security_dump(true, &[]);
+        no_csp.headers.content_security_policy = String::new();
+        let no_csp = manifest_value(&build_manifest(&routes, Some(&no_csp)));
+        assert_eq!(find(&base, "content_security_policy")["emitted"], true);
+        assert_eq!(find(&no_csp, "content_security_policy")["emitted"], false);
+        assert_eq!(find(&no_csp, "content_security_policy")["value"], "");
+    }
+
+    /// AC-6: two builds of identical source + config produce byte-identical
+    /// manifest JSON.
+    #[test]
+    fn manifest_rebuild_is_byte_identical() {
+        let routes = vec![
+            route("GET", "/health", "health", "framework"),
+            route("POST", "/widgets", "create_widget", "gated"),
+            route("DELETE", "/widgets/{id}", "delete_widget", "gated"),
+        ];
+        let sec = security_dump(true, &["/api/", "/webhooks/"]);
+        let a = manifest_json(&build_manifest(&routes, Some(&sec)));
+        let b = manifest_json(&build_manifest(&routes, Some(&sec)));
+        assert_eq!(a, b, "manifest must be reproducible byte-for-byte");
+    }
+
+    /// The `parse_security_config` reader recovers the dump from a stderr stream
+    /// containing the marker line amongst other output.
+    #[test]
+    fn parse_security_config_reads_the_marker() {
+        let sec = security_dump(true, &["/api/"]);
+        let line = serde_json::to_string(&sec).unwrap();
+        let stderr = format!(
+            "\u{1F342} autumn routes audit\n{SECURITY_CONFIG_MARKER}{line}\nsome trailing warning\n"
+        );
+        let parsed = parse_security_config(&stderr).expect("marker parsed");
+        assert!(parsed.csrf.enabled);
+        assert_eq!(parsed.csrf.exempt_paths, vec!["/api/"]);
+        assert!(parse_security_config("no marker here\n").is_none());
     }
 
     // ── falsifiability (#1604): red → green over the parsed dump ──────────────

--- a/autumn-cli/src/routes_audit.rs
+++ b/autumn-cli/src/routes_audit.rs
@@ -178,7 +178,9 @@ pub struct HeadersDimension {
     pub entries: Vec<HeaderEntry>,
 }
 
-/// One security-header entry. `emitted` is `!value.is_empty()`.
+/// One security-header entry. `emitted` is `true` only when `value` is non-empty
+/// *and* parses as a valid `HeaderValue`, mirroring the runtime layer which
+/// skips headers whose value `HeaderValue::from_str` rejects.
 #[derive(Debug, Serialize)]
 pub struct HeaderEntry {
     pub header: String,
@@ -197,6 +199,14 @@ pub struct ExcludedDimension {
 /// Whether `method` is in the configured safe-method set (case-sensitive; route
 /// methods and config defaults are both upper-case).
 fn method_is_safe(method: &str, safe_methods: &[String]) -> bool {
+    // `#[ws]` routes are listed with the synthetic method `WS`, but the router
+    // mounts them via `axum::routing::get`, so at runtime `CsrfLayer` checks the
+    // *real* GET method against `safe_methods` and the default GET exemption
+    // applies — no CSRF token is ever validated on a WebSocket upgrade. Treat
+    // WS-listed routes as CSRF-safe so the manifest matches runtime.
+    if method == "WS" {
+        return true;
+    }
     safe_methods.iter().any(|m| m == method)
 }
 
@@ -316,9 +326,16 @@ fn build_headers_dimension(h: &HeadersDump) -> HeadersDimension {
 }
 
 fn header_entry(header: &str, value: String) -> HeaderEntry {
+    // Mirror the runtime security-headers layer, which inserts a header only
+    // when `HeaderValue::from_str(value)` succeeds and otherwise skips it. A
+    // non-empty but invalid value (e.g. one containing a newline) is therefore
+    // NOT emitted — the manifest must expose that misconfiguration, not paper
+    // over it by reporting `emitted: true`.
+    use autumn_web::reexports::http::HeaderValue;
+    let emitted = !value.is_empty() && HeaderValue::from_str(&value).is_ok();
     HeaderEntry {
         header: header.to_owned(),
-        emitted: !value.is_empty(),
+        emitted,
         value,
     }
 }
@@ -985,6 +1002,92 @@ mod tests {
         assert_eq!(find(&base, "content_security_policy")["emitted"], true);
         assert_eq!(find(&no_csp, "content_security_policy")["emitted"], false);
         assert_eq!(find(&no_csp, "content_security_policy")["value"], "");
+    }
+
+    /// Finding C: `#[ws]` routes are listed with the synthetic method `WS` but
+    /// mounted as GET, so runtime never validates a CSRF token on them. They
+    /// must NOT appear as mutating `csrf_enforced: true` entries in the manifest.
+    #[test]
+    fn ws_routes_are_treated_as_csrf_safe() {
+        let routes = vec![
+            route("WS", "/live", "live_socket", "public"),
+            route("POST", "/widgets", "create_widget", "gated"),
+        ];
+        let manifest = build_manifest(&routes, Some(&security_dump(true, &[])));
+        let entries: Vec<(&str, &str)> = manifest
+            .dimensions
+            .csrf
+            .entries
+            .iter()
+            .map(|e| (e.path.as_str(), e.method.as_str()))
+            .collect();
+        assert_eq!(
+            entries,
+            vec![("/widgets", "POST")],
+            "WS routes are GET-safe at runtime and must not be listed as mutating"
+        );
+        assert!(
+            !manifest
+                .dimensions
+                .csrf
+                .entries
+                .iter()
+                .any(|e| e.method == "WS"),
+            "no WS entry may appear in the csrf dimension"
+        );
+    }
+
+    /// Finding D: runtime's security-headers layer inserts a header only when
+    /// `HeaderValue::from_str` succeeds. A non-empty but invalid value (e.g. one
+    /// containing a newline) must be reported `emitted: false`, exposing the
+    /// misconfiguration instead of overstating what responses send.
+    #[test]
+    fn invalid_header_value_is_not_emitted() {
+        let routes = vec![route("POST", "/widgets", "create_widget", "gated")];
+        let mut sec = security_dump(true, &[]);
+        // A newline is rejected by `HeaderValue::from_str`.
+        sec.headers.referrer_policy = "no-referrer\r\ninjected: 1".to_owned();
+        let json = manifest_value(&build_manifest(&routes, Some(&sec)));
+        let entry = json["dimensions"]["security_headers"]["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|e| e["header"] == "referrer_policy")
+            .unwrap()
+            .clone();
+        assert_eq!(
+            entry["emitted"], false,
+            "an invalid (unparseable) header value must not be reported as emitted"
+        );
+    }
+
+    /// Finding B (manifest side): a webhook endpoint path folded into the dump's
+    /// `csrf.exempt_paths` (as `SecurityDump::from_config` does at runtime) makes
+    /// a POST route on that path exempt and unenforced, and records the path in
+    /// the dimension's `exempt_paths`.
+    #[test]
+    fn webhook_exempt_path_marks_route_unenforced() {
+        let routes = vec![route("POST", "/webhooks/stripe", "stripe_hook", "public")];
+        // The webhook path is NOT in `security.csrf.exempt_paths`; it arrives via
+        // the webhook-endpoint fold performed by `SecurityDump::from_config`.
+        let sec = security_dump(true, &["/webhooks/stripe"]);
+        let manifest = build_manifest(&routes, Some(&sec));
+        let entry = &manifest.dimensions.csrf.entries[0];
+        assert_eq!(entry.path, "/webhooks/stripe");
+        assert!(entry.exempt, "webhook path must be exempt");
+        assert!(
+            !entry.csrf_enforced,
+            "runtime skips CSRF on webhook endpoints, so csrf_enforced must be false"
+        );
+        assert!(
+            manifest
+                .dimensions
+                .csrf
+                .exempt_paths
+                .iter()
+                .any(|p| p == "/webhooks/stripe"),
+            "dimension exempt_paths must record the webhook path"
+        );
     }
 
     /// AC-6: two builds of identical source + config produce byte-identical

--- a/autumn-cli/src/routes_audit.rs
+++ b/autumn-cli/src/routes_audit.rs
@@ -255,7 +255,7 @@ fn build_csrf_dimension(routes: &[AuditRoute], csrf: &CsrfDump) -> CsrfDimension
         .iter()
         .filter(|r| !method_is_safe(&r.method, &csrf.safe_methods))
         .map(|r| {
-            let exempt = path_is_exempt(&r.path, &csrf.exempt_paths);
+            let exempt = path_is_exempt(&r.path, &exempt_paths);
             CsrfEntry {
                 path: r.path.clone(),
                 method: r.method.clone(),

--- a/autumn-cli/src/routes_audit.rs
+++ b/autumn-cli/src/routes_audit.rs
@@ -196,17 +196,27 @@ pub struct ExcludedDimension {
     pub reason: &'static str,
 }
 
+/// Normalize a route's *listed* method to the method the runtime router actually
+/// mounts and dispatches on.
+///
+/// `#[ws]` routes are listed with the synthetic method `WS`, but the macro mounts
+/// them via `axum::routing::get` (see `autumn-macros/src/ws.rs`), so at runtime
+/// `CsrfService` sees a real `GET` and checks *that* against the configured
+/// `safe_methods` (`autumn/src/security/csrf.rs`). Deciding CSRF safety on the
+/// normalized `GET` keeps the manifest faithful to runtime in both the common
+/// case (default config: `GET` is safe → WS never CSRF-validated) and the
+/// customized case (an app removing `GET` from `safe_methods` → the WS upgrade,
+/// being a GET, *is* CSRF-validated and must show up as enforced).
+fn normalize_method(method: &str) -> &str {
+    if method == "WS" { "GET" } else { method }
+}
+
 /// Whether `method` is in the configured safe-method set (case-sensitive; route
-/// methods and config defaults are both upper-case).
+/// methods and config defaults are both upper-case). The listed method is first
+/// normalized to what the router mounts (see [`normalize_method`]) so the
+/// safe/exempt decision matches runtime, which only ever sees the mounted method.
 fn method_is_safe(method: &str, safe_methods: &[String]) -> bool {
-    // `#[ws]` routes are listed with the synthetic method `WS`, but the router
-    // mounts them via `axum::routing::get`, so at runtime `CsrfLayer` checks the
-    // *real* GET method against `safe_methods` and the default GET exemption
-    // applies — no CSRF token is ever validated on a WebSocket upgrade. Treat
-    // WS-listed routes as CSRF-safe so the manifest matches runtime.
-    if method == "WS" {
-        return true;
-    }
+    let method = normalize_method(method);
     safe_methods.iter().any(|m| m == method)
 }
 
@@ -1003,15 +1013,17 @@ mod tests {
         assert_eq!(find(&no_csp, "content_security_policy")["value"], "");
     }
 
-    /// Finding C: `#[ws]` routes are listed with the synthetic method `WS` but
-    /// mounted as GET, so runtime never validates a CSRF token on them. They
-    /// must NOT appear as mutating `csrf_enforced: true` entries in the manifest.
+    /// Finding C (default config): `#[ws]` routes are listed with the synthetic
+    /// method `WS` but mounted as GET, and the default `safe_methods` includes
+    /// GET, so runtime never validates a CSRF token on them. They must NOT appear
+    /// in `csrf.entries` under the default configuration.
     #[test]
-    fn ws_routes_are_treated_as_csrf_safe() {
+    fn ws_routes_are_csrf_safe_when_get_is_a_safe_method() {
         let routes = vec![
             route("WS", "/live", "live_socket", "public"),
             route("POST", "/widgets", "create_widget", "gated"),
         ];
+        // Default `safe_methods` includes GET (see `security_dump`).
         let manifest = build_manifest(&routes, Some(&security_dump(true, &[])));
         let entries: Vec<(&str, &str)> = manifest
             .dimensions
@@ -1023,7 +1035,7 @@ mod tests {
         assert_eq!(
             entries,
             vec![("/widgets", "POST")],
-            "WS routes are GET-safe at runtime and must not be listed as mutating"
+            "WS routes mount as GET; with GET safe they must not be listed as mutating"
         );
         assert!(
             !manifest
@@ -1032,7 +1044,53 @@ mod tests {
                 .entries
                 .iter()
                 .any(|e| e.method == "WS"),
-            "no WS entry may appear in the csrf dimension"
+            "no WS entry may appear in the csrf dimension when GET is safe"
+        );
+    }
+
+    /// Finding C (customized config): an app that removes GET from
+    /// `security.csrf.safe_methods` makes runtime CSRF-validate the WS upgrade
+    /// (a GET) unless its path is exempt. The manifest must reflect that: the WS
+    /// route now appears in `csrf.entries`, its displayed `method` stays the
+    /// route's listed `WS` (consistent with the `routes` dimension), and
+    /// `csrf_enforced` is computed via the normal exempt-path predicate
+    /// (enforced when the path isn't exempt, unenforced when it is).
+    #[test]
+    fn ws_routes_are_csrf_enforced_when_get_is_not_a_safe_method() {
+        let routes = vec![
+            route("WS", "/live", "live_socket", "public"),
+            route("WS", "/api/live", "api_socket", "public"),
+            route("POST", "/widgets", "create_widget", "gated"),
+        ];
+        // Customize config: drop GET, and exempt the `/api/` prefix.
+        let mut sec = security_dump(true, &["/api/"]);
+        sec.csrf.safe_methods = vec!["HEAD".to_owned(), "OPTIONS".to_owned()];
+        let manifest = build_manifest(&routes, Some(&sec));
+
+        let entries: Vec<(&str, &str, bool, bool)> = manifest
+            .dimensions
+            .csrf
+            .entries
+            .iter()
+            .map(|e| {
+                (
+                    e.path.as_str(),
+                    e.method.as_str(),
+                    e.csrf_enforced,
+                    e.exempt,
+                )
+            })
+            .collect();
+        // Ordered by (path, method): /api/live (WS), /live (WS), /widgets (POST).
+        assert_eq!(
+            entries,
+            vec![
+                ("/api/live", "WS", false, true),
+                ("/live", "WS", true, false),
+                ("/widgets", "POST", true, false),
+            ],
+            "WS routes appear as GET-mutating entries with the exempt-path predicate applied, \
+             while keeping their listed `WS` method for display"
         );
     }
 

--- a/autumn-cli/src/routes_audit.rs
+++ b/autumn-cli/src/routes_audit.rs
@@ -302,7 +302,6 @@ fn build_headers_dimension(h: &HeadersDump) -> HeadersDimension {
 
     let mut entries = vec![
         header_entry("content_security_policy", h.content_security_policy.clone()),
-        header_entry("csp_nonce", bool_header(h.csp_nonce, "enabled")),
         header_entry("permissions_policy", h.permissions_policy.clone()),
         header_entry("referrer_policy", h.referrer_policy.clone()),
         header_entry("strict_transport_security", hsts_value),
@@ -1058,6 +1057,48 @@ mod tests {
         assert_eq!(
             entry["emitted"], false,
             "an invalid (unparseable) header value must not be reported as emitted"
+        );
+    }
+
+    /// Finding E: `csp_nonce` is a config toggle that shapes the CSP *value*, not
+    /// a response header. Runtime stores the nonce in request extensions and
+    /// substitutes it into `Content-Security-Policy`; it never emits a `csp_nonce`
+    /// header. The `security_headers` dimension must therefore carry no
+    /// `csp_nonce` entry, while the nonce toggle's effect stays visible through
+    /// the nonce-aware `content_security_policy` value.
+    #[test]
+    fn csp_nonce_is_not_reported_as_an_emitted_header() {
+        let routes = vec![route("GET", "/page", "page", "public")];
+        // Mirror `SecurityDump::from_config` for a nonce-enabled app on the
+        // default CSP: `csp_nonce = true` and `content_security_policy` resolved
+        // to the nonce-aware template (see `resolved_content_security_policy`).
+        let mut sec = security_dump(true, &[]);
+        sec.headers.csp_nonce = true;
+        sec.headers.content_security_policy =
+            "style-src 'self' 'nonce-AUTUMN_CSP_NONCE'; script-src 'self' 'nonce-AUTUMN_CSP_NONCE'"
+                .to_owned();
+        let json = manifest_value(&build_manifest(&routes, Some(&sec)));
+
+        let entries = json["dimensions"]["security_headers"]["entries"]
+            .as_array()
+            .unwrap();
+        assert!(
+            !entries.iter().any(|e| e["header"] == "csp_nonce"),
+            "csp_nonce is not a response header and must not appear in security_headers"
+        );
+
+        // The nonce toggle's effect remains observable via the CSP entry value.
+        let csp = entries
+            .iter()
+            .find(|e| e["header"] == "content_security_policy")
+            .expect("content_security_policy entry present");
+        assert_eq!(csp["emitted"], true);
+        assert!(
+            csp["value"]
+                .as_str()
+                .unwrap()
+                .contains("'nonce-AUTUMN_CSP_NONCE'"),
+            "the nonce-aware CSP template must remain visible in the CSP value: {csp}"
         );
     }
 

--- a/autumn-cli/src/routes_audit.rs
+++ b/autumn-cli/src/routes_audit.rs
@@ -906,6 +906,38 @@ mod tests {
         );
     }
 
+    /// Codex P2 (issue #1627): a mutating framework route (the actuator's
+    /// `PUT {prefix}/loggers/{name}`) that previously never reached the listing
+    /// must, once enumerated, surface in `csrf.entries` with enforcement on.
+    #[test]
+    fn csrf_dimension_covers_mutating_framework_routes() {
+        let routes = vec![
+            route("GET", "/actuator/loggers", "loggers_get", "framework"),
+            route(
+                "PUT",
+                "/actuator/loggers/{name}",
+                "loggers_put",
+                "framework",
+            ),
+        ];
+        let dim = build_csrf_dimension(&routes, &security_dump(true, &[]).csrf);
+        let entry = dim
+            .entries
+            .iter()
+            .find(|e| e.method == "PUT" && e.path == "/actuator/loggers/{name}")
+            .expect("mutating framework route must appear in csrf.entries");
+        assert!(
+            entry.csrf_enforced && !entry.exempt,
+            "PUT loggers must be CSRF-enforced: {entry:?}"
+        );
+        // The safe-method GET listing route is never a csrf entry.
+        assert!(
+            !dim.entries.iter().any(|e| e.method == "GET"),
+            "safe-method routes must not appear: {:?}",
+            dim.entries
+        );
+    }
+
     /// AC-2 keystone: disabling CSRF flips exactly the affected `csrf.entries`
     /// and leaves `routes` and `security_headers` byte-identical.
     #[test]

--- a/autumn-cli/src/routes_audit.rs
+++ b/autumn-cli/src/routes_audit.rs
@@ -1221,6 +1221,44 @@ mod tests {
         );
     }
 
+    /// The framework-owned RFC 8058 one-click unsubscribe endpoint is mounted as
+    /// a GET + POST at `/_autumn/unsubscribe` and its path is folded into the
+    /// dump's `csrf.exempt_paths` (by `SecurityDump::from_config`). Once the POST
+    /// route is listed by `append_framework_routes`, the csrf dimension must show
+    /// it as present-but-exempt: `csrf_enforced == false && exempt == true`,
+    /// matching runtime (which exempts the path from CSRF). Underreporting it
+    /// would hide a mutating route from the posture manifest.
+    #[test]
+    fn unsubscribe_exempt_path_marks_post_unenforced() {
+        // Path literal mirrors `autumn_web::mail::UNSUBSCRIBE_PATH`; kept literal
+        // so this dimension-level test does not require the `mail` feature.
+        let routes = vec![route(
+            "POST",
+            "/_autumn/unsubscribe",
+            "unsubscribe",
+            "framework",
+        )];
+        let sec = security_dump(true, &["/_autumn/unsubscribe"]);
+        let manifest = build_manifest(&routes, Some(&sec));
+        let entry = &manifest.dimensions.csrf.entries[0];
+        assert_eq!(entry.path, "/_autumn/unsubscribe");
+        assert_eq!(entry.method, "POST");
+        assert!(entry.exempt, "mounted unsubscribe path must be exempt");
+        assert!(
+            !entry.csrf_enforced,
+            "runtime exempts the unsubscribe endpoint from CSRF, so csrf_enforced must be false"
+        );
+        assert!(
+            manifest
+                .dimensions
+                .csrf
+                .exempt_paths
+                .iter()
+                .any(|p| p == "/_autumn/unsubscribe"),
+            "dimension exempt_paths must record the unsubscribe path"
+        );
+    }
+
     /// AC-6: two builds of identical source + config produce byte-identical
     /// manifest JSON.
     #[test]

--- a/autumn-cli/src/routes_audit.rs
+++ b/autumn-cli/src/routes_audit.rs
@@ -396,6 +396,19 @@ fn excluded_dimensions() -> Vec<ExcludedDimension> {
             eventual_provenance: Provenance::RuntimeOnly,
             reason: "boot-time fact; excluded from a build-time manifest by design",
         },
+        ExcludedDimension {
+            dimension: "serve_path_routers",
+            // Provable once plumbed: these are real mounted routes that
+            // `autumn routes` would enumerate (like the routes dimension) if
+            // the dump path injected them into merge_routers.
+            eventual_provenance: Provenance::Provable,
+            reason: "opt-in serve-path HTTP surfaces (MCP, inbound-mail, storage, SEO) are \
+                     injected only on the serve path, after the dump early-exit, so they are not \
+                     enumerated by `autumn routes` at build time; their mutating POSTs (MCP, \
+                     inbound-mail) run outside the framework CSRF layer and self-protect (MCP: \
+                     origin + csrf_header + trusted-host; inbound-mail: provider signature \
+                     verification). Enumerating them is deferred to a dump-plumbing follow-up",
+        },
     ]
 }
 
@@ -863,7 +876,7 @@ mod tests {
 
         // Excluded list is present, ordered, and uses the closed enum values.
         let excluded = json["excluded"].as_array().expect("excluded array");
-        assert_eq!(excluded.len(), 8);
+        assert_eq!(excluded.len(), 9);
         assert_eq!(excluded[0]["dimension"], "authorization_policies");
         assert_eq!(excluded[0]["eventual_provenance"], "provable");
         let runtime_only = excluded
@@ -871,6 +884,15 @@ mod tests {
             .find(|e| e["dimension"] == "policy_registration")
             .expect("policy_registration excluded");
         assert_eq!(runtime_only["eventual_provenance"], "runtime-only");
+
+        // The serve-path routers (MCP, inbound-mail, storage, SEO) are injected
+        // only on the serve path (after the dump early-exit), so they are
+        // honestly disclosed as excluded rather than silently absent (#1627 AC).
+        let serve_path = excluded
+            .iter()
+            .find(|e| e["dimension"] == "serve_path_routers")
+            .expect("serve_path_routers excluded");
+        assert_eq!(serve_path["eventual_provenance"], "provable");
     }
 
     /// AC-2 falsifiability: one CSRF entry per mutating route; a safe-method

--- a/autumn-cli/tests/integration/manifest_posture.rs
+++ b/autumn-cli/tests/integration/manifest_posture.rs
@@ -1,0 +1,126 @@
+//! Security-posture manifest (#1627): dump-contract tests for the `declared`
+//! CSRF / security-headers dimensions.
+//!
+//! `autumn routes audit` builds those dimensions from the resolved security
+//! configuration the app emits across the `AUTUMN_DUMP_ROUTES` /
+//! `AUTUMN_DUMP_SECURITY` process boundary. The manifest-envelope assembly lives
+//! in the (binary-only) `autumn-cli` crate and is covered by unit tests next to
+//! `build_manifest`; these integration tests exercise the *other* half — the
+//! `autumn_web` side that snapshots the config into the wire
+//! [`SecurityDump`](autumn_web::route_listing::SecurityDump) and guarantees it is
+//! sorted and byte-deterministic (the property the whole manifest's determinism
+//! rests on).
+
+use autumn_web::config::AutumnConfig;
+use autumn_web::route_listing::SecurityDump;
+
+/// Serialize a dump the same way the app does before writing the marker line.
+fn wire(dump: &SecurityDump) -> String {
+    serde_json::to_string(dump).unwrap()
+}
+
+/// Baseline (AC-1/AC-3): a default config snapshots to the expected declared
+/// posture — CSRF disabled, DENY frame options, a non-empty resolved CSP.
+#[test]
+fn default_config_snapshots_expected_declared_posture() {
+    let dump = SecurityDump::from_config(&AutumnConfig::default());
+
+    assert!(!dump.csrf.enabled, "CSRF is off by default");
+    assert_eq!(dump.headers.x_frame_options, "DENY");
+    assert!(
+        dump.headers
+            .content_security_policy
+            .contains("default-src 'self'"),
+        "CSP must be the resolved template, not a sentinel: {:?}",
+        dump.headers.content_security_policy
+    );
+    // Default safe methods are present and sorted.
+    assert_eq!(
+        dump.csrf.safe_methods,
+        vec!["GET", "HEAD", "OPTIONS", "TRACE"]
+    );
+    assert!(dump.csrf.exempt_paths.is_empty());
+}
+
+/// AC-6 determinism: the wire snapshot is byte-identical across repeated builds
+/// and independent of config source ordering (lists are sorted on the way out).
+#[test]
+fn wire_snapshot_is_byte_deterministic_and_sorted() {
+    let mut a = AutumnConfig::default();
+    a.security.csrf.exempt_paths = vec!["/webhooks/".to_owned(), "/api/".to_owned()];
+    let mut b = AutumnConfig::default();
+    // Same set, opposite source order.
+    b.security.csrf.exempt_paths = vec!["/api/".to_owned(), "/webhooks/".to_owned()];
+
+    let da = SecurityDump::from_config(&a);
+    let db = SecurityDump::from_config(&b);
+
+    assert_eq!(da.csrf.exempt_paths, vec!["/api/", "/webhooks/"], "sorted");
+    assert_eq!(
+        wire(&da),
+        wire(&db),
+        "source ordering must not affect the wire snapshot"
+    );
+    // Repeated snapshot of the same config is identical.
+    assert_eq!(wire(&SecurityDump::from_config(&a)), wire(&da));
+}
+
+/// AC-2 falsifiability at the dump boundary: enabling CSRF and adding an exempt
+/// prefix are both visible, isolated changes in the wire snapshot.
+#[test]
+fn csrf_config_changes_are_visible_in_the_wire_snapshot() {
+    let base = SecurityDump::from_config(&AutumnConfig::default());
+
+    let mut enabled = AutumnConfig::default();
+    enabled.security.csrf.enabled = true;
+    let enabled = SecurityDump::from_config(&enabled);
+    assert!(!base.csrf.enabled && enabled.csrf.enabled);
+    // Only the flag moved; headers untouched.
+    assert_eq!(wire(&base.headers_only()), wire(&enabled.headers_only()));
+
+    let mut exempt = AutumnConfig::default();
+    exempt.security.csrf.exempt_paths = vec!["/api/".to_owned()];
+    let exempt = SecurityDump::from_config(&exempt);
+    assert_eq!(exempt.csrf.exempt_paths, vec!["/api/"]);
+    assert!(base.csrf.exempt_paths.is_empty());
+}
+
+/// AC-3 falsifiability at the dump boundary: weakening `x_frame_options` and
+/// emptying the CSP both surface in the wire snapshot without disturbing CSRF.
+#[test]
+fn header_config_changes_are_visible_in_the_wire_snapshot() {
+    let base = SecurityDump::from_config(&AutumnConfig::default());
+
+    let mut weak = AutumnConfig::default();
+    weak.security.headers.x_frame_options = "SAMEORIGIN".to_owned();
+    let weak = SecurityDump::from_config(&weak);
+    assert_eq!(base.headers.x_frame_options, "DENY");
+    assert_eq!(weak.headers.x_frame_options, "SAMEORIGIN");
+    // CSRF section unaffected.
+    assert_eq!(base.csrf, weak.csrf);
+
+    let mut no_csp = AutumnConfig::default();
+    no_csp.security.headers.content_security_policy = String::new();
+    let no_csp = SecurityDump::from_config(&no_csp);
+    assert!(!base.headers.content_security_policy.is_empty());
+    assert!(no_csp.headers.content_security_policy.is_empty());
+}
+
+/// Small local helper so the CSRF-isolation assertion above can compare just the
+/// headers half of two snapshots.
+trait HeadersOnly {
+    fn headers_only(&self) -> SecurityDump;
+}
+
+impl HeadersOnly for SecurityDump {
+    fn headers_only(&self) -> SecurityDump {
+        Self {
+            csrf: autumn_web::route_listing::CsrfDump {
+                enabled: false,
+                safe_methods: Vec::new(),
+                exempt_paths: Vec::new(),
+            },
+            headers: self.headers.clone(),
+        }
+    }
+}

--- a/autumn-cli/tests/integration/manifest_posture.rs
+++ b/autumn-cli/tests/integration/manifest_posture.rs
@@ -106,6 +106,36 @@ fn header_config_changes_are_visible_in_the_wire_snapshot() {
     assert!(no_csp.headers.content_security_policy.is_empty());
 }
 
+/// Finding B: runtime's `apply_csrf_middleware` exempts every configured webhook
+/// endpoint path, so the wire snapshot must fold those paths into
+/// `csrf.exempt_paths` (sorted + deduped) even when they are absent from
+/// `security.csrf.exempt_paths` — otherwise the manifest claims CSRF on a route
+/// runtime never enforces.
+#[test]
+fn webhook_endpoint_paths_are_folded_into_csrf_exempt_paths() {
+    let mut config = AutumnConfig::default();
+    config.security.webhooks.endpoints = vec![autumn_web::webhook::WebhookEndpointConfig {
+        path: "/webhooks/stripe".to_owned(),
+        ..Default::default()
+    }];
+    // The webhook path is deliberately NOT duplicated in csrf.exempt_paths.
+    assert!(config.security.csrf.exempt_paths.is_empty());
+
+    let dump = SecurityDump::from_config(&config);
+    assert!(
+        dump.csrf
+            .exempt_paths
+            .iter()
+            .any(|p| p == "/webhooks/stripe"),
+        "webhook endpoint path must be a CSRF exempt path: {:?}",
+        dump.csrf.exempt_paths
+    );
+    let mut sorted = dump.csrf.exempt_paths.clone();
+    sorted.sort();
+    sorted.dedup();
+    assert_eq!(dump.csrf.exempt_paths, sorted, "sorted + deduped");
+}
+
 /// Small local helper so the CSRF-isolation assertion above can compare just the
 /// headers half of two snapshots.
 trait HeadersOnly {

--- a/autumn-cli/tests/integration/mod.rs
+++ b/autumn-cli/tests/integration/mod.rs
@@ -6,6 +6,7 @@ mod generate_references_postgres;
 mod generate_tauri_mobile;
 mod generate_tauri_mobile_offline;
 mod i18n_check;
+mod manifest_posture;
 mod migrate_down;
 mod offsite_backup;
 mod repo_hygiene;

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -3521,9 +3521,17 @@ pub(crate) fn actuator_endpoint_paths(
         }
         #[cfg(feature = "http-client")]
         {
-            // Only the GET DLQ listing is enumerated here; `/webhooks/replay`
-            // is mounted as `POST` (see `actuator_mutating_routes`), not `GET`.
             paths.push(actuator_route_path(prefix, "/webhooks/dlq"));
+            // `/webhooks/replay` is mounted as `POST` (see
+            // `actuator_mutating_routes`), not `GET`, but it is included in this
+            // path set because the runtime startup barrier seeds its actuator
+            // allow-list from this helper (`StartupBarrierState::from_config`).
+            // Without it, the `POST {prefix}/webhooks/replay` mount would no
+            // longer bypass the startup barrier. The GET-only route listing
+            // (`append_framework_routes`) excludes any path also produced by
+            // `actuator_mutating_routes`, so this does not surface as a phantom
+            // GET there.
+            paths.push(actuator_route_path(prefix, "/webhooks/replay"));
         }
         #[cfg(feature = "ws")]
         {

--- a/autumn/src/actuator.rs
+++ b/autumn/src/actuator.rs
@@ -3521,8 +3521,9 @@ pub(crate) fn actuator_endpoint_paths(
         }
         #[cfg(feature = "http-client")]
         {
+            // Only the GET DLQ listing is enumerated here; `/webhooks/replay`
+            // is mounted as `POST` (see `actuator_mutating_routes`), not `GET`.
             paths.push(actuator_route_path(prefix, "/webhooks/dlq"));
-            paths.push(actuator_route_path(prefix, "/webhooks/replay"));
         }
         #[cfg(feature = "ws")]
         {
@@ -3532,6 +3533,31 @@ pub(crate) fn actuator_endpoint_paths(
     }
 
     paths
+}
+
+/// Enumerate the actuator's mutating (non-`GET`) framework routes, gated to
+/// match the mounts in [`actuator_router_with_prefix`].
+///
+/// Kept separate from [`actuator_endpoint_paths`] (which is `GET`-only and
+/// paths-only) so the route listing can classify these with their real HTTP
+/// method. Returns `(method, path)` pairs using the same
+/// [`actuator_route_path`] helper as the mounting code so paths match
+/// byte-for-byte.
+pub(crate) fn actuator_mutating_routes(
+    prefix: &str,
+    sensitive: bool,
+) -> Vec<(&'static str, String)> {
+    let mut routes: Vec<(&'static str, String)> = Vec::new();
+
+    if sensitive {
+        routes.push(("PUT", actuator_route_path(prefix, "/loggers/{name}")));
+        #[cfg(feature = "http-client")]
+        {
+            routes.push(("POST", actuator_route_path(prefix, "/webhooks/replay")));
+        }
+    }
+
+    routes
 }
 
 /// Build the actuator router with profile-aware endpoint exposure.

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -4504,6 +4504,21 @@ impl AppBuilder {
         let (config, _telemetry_guard) =
             load_config_and_telemetry(config_loader_factory, telemetry_provider).await;
 
+        // Emit the resolved security configuration for the manifest's `declared`
+        // dimensions (CSRF, security headers). Gated on `AUTUMN_DUMP_SECURITY`
+        // so only `autumn routes audit` sees it — kept off stdout so the
+        // routes-only JSON parse path stays byte-compatible.
+        if is_dump_security_mode() {
+            let security = crate::route_listing::SecurityDump::from_config(&config);
+            match serde_json::to_string(&security) {
+                Ok(json) => eprintln!(
+                    "{marker}{json}",
+                    marker = crate::route_listing::SECURITY_CONFIG_MARKER
+                ),
+                Err(e) => eprintln!("Failed to serialize security config: {e}"),
+            }
+        }
+
         let mut infos = match crate::route_listing::collect_route_infos(
             &routes,
             &route_sources,
@@ -4946,6 +4961,16 @@ fn exit_stop_managed_pg() {
 
 pub(crate) fn is_dump_routes_mode() -> bool {
     std::env::var("AUTUMN_DUMP_ROUTES").as_deref() == Ok("1")
+}
+
+/// Whether the dump should also emit the resolved security configuration
+/// ([`SECURITY_CONFIG_MARKER`](crate::route_listing::SECURITY_CONFIG_MARKER)).
+///
+/// Set by `autumn routes audit` (which needs the CSRF / headers config to build
+/// the `declared` manifest dimensions) but not by the plain `autumn routes`
+/// listing, so that command's stderr stays free of the marker line.
+pub(crate) fn is_dump_security_mode() -> bool {
+    std::env::var("AUTUMN_DUMP_SECURITY").as_deref() == Ok("1")
 }
 
 pub(crate) fn is_dump_jobs_mode() -> bool {

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -23,6 +23,112 @@ use crate::route::Route;
 /// auth posture, so a manifest that silently drops them would defeat the gate.
 pub const OMITTED_ROUTES_MARKER: &str = "[autumn:omitted-routes] ";
 
+/// Machine-readable stderr marker carrying the resolved security configuration
+/// (CSRF + headers) for the `declared` manifest dimensions built by
+/// `autumn routes audit`.
+///
+/// Emitted by the `AUTUMN_DUMP_ROUTES` dump only when `AUTUMN_DUMP_SECURITY=1`
+/// is *also* set — which `autumn routes audit` sets, but the plain
+/// `autumn routes` listing does not. A single compact JSON [`SecurityDump`]
+/// follows the marker on the same line. Kept off stdout so the routes-only JSON
+/// parse path (`autumn routes`, and older audit builds) stays byte-compatible.
+pub const SECURITY_CONFIG_MARKER: &str = "[autumn:security-config] ";
+
+/// Resolved CSRF configuration carried across the dump boundary for the
+/// `declared` CSRF manifest dimension.
+///
+/// Mirrors the runtime-relevant subset of
+/// [`CsrfConfig`](crate::security::config::CsrfConfig): the enable flag plus the
+/// two inputs to the runtime safe/exempt predicate.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CsrfDump {
+    /// Whether CSRF enforcement is enabled.
+    pub enabled: bool,
+    /// Methods that never require a CSRF token (sorted).
+    pub safe_methods: Vec<String>,
+    /// Path prefixes exempt from CSRF validation (sorted).
+    pub exempt_paths: Vec<String>,
+}
+
+/// Resolved security-headers configuration carried across the dump boundary for
+/// the `declared` security-headers manifest dimension.
+///
+/// Every string is the *effective* declared value — in particular
+/// `content_security_policy` is the resolved template
+/// ([`default_content_security_policy`](crate::security::config::default_content_security_policy)
+/// when unset), not an unresolved sentinel.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct HeadersDump {
+    /// `X-Frame-Options` value (empty = header not emitted).
+    pub x_frame_options: String,
+    /// Whether `X-Content-Type-Options: nosniff` is sent.
+    pub x_content_type_options: bool,
+    /// Whether `X-XSS-Protection: 1; mode=block` is sent.
+    pub xss_protection: bool,
+    /// Resolved `Content-Security-Policy` value (empty = header not emitted).
+    pub content_security_policy: String,
+    /// `Referrer-Policy` value (empty = header not emitted).
+    pub referrer_policy: String,
+    /// `Permissions-Policy` value (empty = header not emitted).
+    pub permissions_policy: String,
+    /// Whether `Strict-Transport-Security` (HSTS) is sent.
+    pub strict_transport_security: bool,
+    /// HSTS `max-age` in seconds.
+    pub hsts_max_age_secs: u64,
+    /// Whether HSTS includes subdomains.
+    pub hsts_include_subdomains: bool,
+    /// Whether per-request CSP nonce injection is enabled.
+    pub csp_nonce: bool,
+}
+
+/// Resolved security configuration snapshot emitted after
+/// [`SECURITY_CONFIG_MARKER`] for the manifest's `declared` dimensions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SecurityDump {
+    /// CSRF configuration.
+    pub csrf: CsrfDump,
+    /// Security-headers configuration.
+    pub headers: HeadersDump,
+}
+
+impl SecurityDump {
+    /// Snapshot the security-relevant configuration for the manifest dump.
+    ///
+    /// Every emitted list is sorted so the serialized snapshot is
+    /// byte-deterministic across runs, regardless of config source ordering.
+    #[must_use]
+    pub fn from_config(config: &crate::config::AutumnConfig) -> Self {
+        let csrf = &config.security.csrf;
+        let headers = &config.security.headers;
+
+        let mut safe_methods = csrf.safe_methods.clone();
+        safe_methods.sort();
+        let mut exempt_paths = csrf.exempt_paths.clone();
+        exempt_paths.sort();
+
+        Self {
+            csrf: CsrfDump {
+                enabled: csrf.enabled,
+                safe_methods,
+                exempt_paths,
+            },
+            headers: HeadersDump {
+                x_frame_options: headers.x_frame_options.clone(),
+                x_content_type_options: headers.x_content_type_options,
+                xss_protection: headers.xss_protection,
+                content_security_policy: headers.content_security_policy.clone(),
+                referrer_policy: headers.referrer_policy.clone(),
+                permissions_policy: headers.permissions_policy.clone(),
+                strict_transport_security: headers.strict_transport_security,
+                hsts_max_age_secs: headers.hsts_max_age_secs,
+                hsts_include_subdomains: headers.hsts_include_subdomains,
+                csp_nonce: headers.csp_nonce.enabled,
+            },
+        }
+    }
+}
+
 /// Where a route was registered: by the user application, by a named plugin,
 /// or by the framework itself (probes, actuator, htmx assets, dev reload).
 #[derive(Debug, Clone, PartialEq, Eq, Default)]

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -527,24 +527,38 @@ pub(crate) fn append_framework_routes(
         }
     }
 
+    // Mutating (non-GET) actuator routes are enumerated separately so they
+    // carry their real HTTP method (e.g. `PUT /actuator/loggers/{name}`,
+    // `POST /actuator/webhooks/replay`) rather than a phantom GET.
+    let mutating_routes = crate::actuator::actuator_mutating_routes(
+        &config.actuator.prefix,
+        config.actuator.sensitive,
+    );
+    // Some entries in `actuator_endpoint_paths` exist only to seed the runtime
+    // startup-barrier allow-list (`StartupBarrierState::from_config`) and are
+    // actually mounted with a mutating method (e.g. `/webhooks/replay` is a
+    // `POST`). Skip any path already covered by a mutating-method entry so the
+    // GET-only listing does not emit a phantom GET for it.
+    let mutating_paths: std::collections::HashSet<&str> = mutating_routes
+        .iter()
+        .map(|(_, path)| path.as_str())
+        .collect();
+
     for path in crate::actuator::actuator_endpoint_paths(
         &config.actuator.prefix,
         config.actuator.sensitive,
         config.actuator.prometheus,
     ) {
+        if mutating_paths.contains(path.as_str()) {
+            continue;
+        }
         infos.push(RouteInfo::framework_get(path, "actuator"));
     }
 
-    // Mutating (non-GET) actuator routes are enumerated separately so they
-    // carry their real HTTP method (e.g. `PUT /actuator/loggers/{name}`,
-    // `POST /actuator/webhooks/replay`) rather than a phantom GET.
-    for (route_method, route_path) in crate::actuator::actuator_mutating_routes(
-        &config.actuator.prefix,
-        config.actuator.sensitive,
-    ) {
+    for (route_method, route_path) in &mutating_routes {
         infos.push(RouteInfo::framework_route(
             route_method,
-            route_path,
+            route_path.clone(),
             "actuator",
         ));
     }
@@ -628,6 +642,17 @@ pub(crate) fn append_framework_routes(
         ] {
             infos.push(RouteInfo::framework_get(path.to_owned(), handler));
         }
+    }
+
+    // Tracked-job status endpoint (#1627): runtime mounts
+    // `GET /_autumn/jobs/{token}` when `jobs.tracking.route_enabled` (default
+    // true), gated identically to the router mount. List it so the manifest
+    // reflects the mounted route.
+    if config.jobs.tracking.route_enabled {
+        infos.push(RouteInfo::framework_get(
+            crate::job_tracking::JOB_STATUS_ROUTE_PATH.to_owned(),
+            "job_status",
+        ));
     }
 
     // Static file serving is unconditionally mounted at /static.
@@ -1334,6 +1359,82 @@ mod tests {
                 .iter()
                 .any(|i| i.method == "GET" && i.path == dlq_path),
             "expected GET {dlq_path} framework route: {infos:?}"
+        );
+    }
+
+    /// Regression guard (#1627): `/webhooks/replay` must stay in the runtime
+    /// path set (`actuator_endpoint_paths`) that seeds the startup-barrier
+    /// allow-list, while the GET-only route listing must NOT emit a phantom
+    /// GET for it (only the real `POST`). A prior fix dropped the path from
+    /// `actuator_endpoint_paths` entirely to kill the phantom GET, which also
+    /// silently removed it from the barrier bypass set — this asserts both
+    /// halves are decoupled: complete runtime set, clean listing.
+    #[cfg(feature = "http-client")]
+    #[test]
+    fn webhook_replay_in_runtime_set_but_not_a_phantom_get_listing() {
+        let mut config = AutumnConfig::default();
+        config.actuator.sensitive = true;
+        let prefix = config.actuator.prefix.clone();
+        let replay_path = format!("{prefix}/webhooks/replay");
+
+        // Runtime set (barrier allow-list source) still contains the path.
+        let runtime_paths = crate::actuator::actuator_endpoint_paths(
+            &prefix,
+            config.actuator.sensitive,
+            config.actuator.prometheus,
+        );
+        assert!(
+            runtime_paths.contains(&replay_path),
+            "runtime actuator_endpoint_paths must contain {replay_path} so the \
+             startup barrier bypasses the POST: {runtime_paths:?}"
+        );
+
+        // Listing: no phantom GET, but the real POST is present.
+        let mut infos = Vec::new();
+        append_framework_routes(&mut infos, &config);
+        assert!(
+            !infos
+                .iter()
+                .any(|i| i.method == "GET" && i.path == replay_path),
+            "listing must not contain a phantom GET {replay_path}: {infos:?}"
+        );
+        assert!(
+            infos
+                .iter()
+                .any(|i| i.method == "POST" && i.path == replay_path),
+            "listing must contain POST {replay_path}: {infos:?}"
+        );
+    }
+
+    /// #1627: the tracked-job status endpoint (`GET /_autumn/jobs/{token}`) is
+    /// mounted by default and must be enumerated; disabling
+    /// `jobs.tracking.route_enabled` (the same gate as the router mount) drops
+    /// both the mount and the listing.
+    #[test]
+    fn framework_routes_include_job_status_when_enabled() {
+        let mut config = AutumnConfig::default();
+        assert!(
+            config.jobs.tracking.route_enabled,
+            "job status route should default to enabled"
+        );
+        let mut infos = Vec::new();
+        append_framework_routes(&mut infos, &config);
+        assert!(
+            infos.iter().any(|i| i.method == "GET"
+                && i.path == crate::job_tracking::JOB_STATUS_ROUTE_PATH
+                && i.classification == RouteClassification::Framework),
+            "expected GET {} framework route when enabled: {infos:?}",
+            crate::job_tracking::JOB_STATUS_ROUTE_PATH
+        );
+
+        config.jobs.tracking.route_enabled = false;
+        let mut infos = Vec::new();
+        append_framework_routes(&mut infos, &config);
+        assert!(
+            !infos
+                .iter()
+                .any(|i| i.path == crate::job_tracking::JOB_STATUS_ROUTE_PATH),
+            "job status route must be absent when disabled: {infos:?}"
         );
     }
 

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -305,8 +305,14 @@ impl RouteInfo {
     /// Construct a framework-owned `GET` route entry. Framework routes are
     /// pre-classified and exempt from the audit gate.
     fn framework_get(path: String, handler: &str) -> Self {
+        Self::framework_route("GET", path, handler)
+    }
+
+    /// Construct a framework-owned route entry for an arbitrary HTTP method.
+    /// Framework routes are pre-classified and exempt from the audit gate.
+    fn framework_route(method: &str, path: String, handler: &str) -> Self {
         Self {
-            method: "GET".to_owned(),
+            method: method.to_owned(),
             path,
             handler: handler.to_owned(),
             source: RouteSource::Framework,
@@ -527,6 +533,20 @@ pub(crate) fn append_framework_routes(
         config.actuator.prometheus,
     ) {
         infos.push(RouteInfo::framework_get(path, "actuator"));
+    }
+
+    // Mutating (non-GET) actuator routes are enumerated separately so they
+    // carry their real HTTP method (e.g. `PUT /actuator/loggers/{name}`,
+    // `POST /actuator/webhooks/replay`) rather than a phantom GET.
+    for (route_method, route_path) in crate::actuator::actuator_mutating_routes(
+        &config.actuator.prefix,
+        config.actuator.sensitive,
+    ) {
+        infos.push(RouteInfo::framework_route(
+            route_method,
+            route_path,
+            "actuator",
+        ));
     }
 
     #[cfg(feature = "htmx")]
@@ -1238,6 +1258,65 @@ mod tests {
         assert!(
             paths.contains(&"/ping"),
             "custom health path missing: {paths:?}"
+        );
+    }
+
+    /// Codex P2 (issue #1627): mutating actuator routes must be enumerated with
+    /// their real HTTP method so the `csrf` posture dimension can see them.
+    /// `PUT {prefix}/loggers/{name}` is mounted at runtime when
+    /// `actuator.sensitive = true` but was previously absent from the listing.
+    #[test]
+    fn append_framework_routes_includes_mutating_actuator_routes() {
+        let mut config = AutumnConfig::default();
+        config.actuator.sensitive = true;
+        let prefix = config.actuator.prefix.clone();
+        let mut infos = Vec::new();
+        append_framework_routes(&mut infos, &config);
+
+        let loggers_path = format!("{prefix}/loggers/{{name}}");
+        assert!(
+            infos.iter().any(|i| i.method == "PUT"
+                && i.path == loggers_path
+                && i.classification == RouteClassification::Framework),
+            "expected PUT {loggers_path} framework route: {infos:?}"
+        );
+
+        // The `/webhooks/replay` route is mounted as POST only; it must never
+        // appear as a phantom GET.
+        let replay_path = format!("{prefix}/webhooks/replay");
+        assert!(
+            !infos
+                .iter()
+                .any(|i| i.method == "GET" && i.path == replay_path),
+            "phantom GET {replay_path} must not be listed: {infos:?}"
+        );
+    }
+
+    /// Companion to the above, guarded on `http-client`: the DLQ replay endpoint
+    /// is mounted as `POST` and must be enumerated as such.
+    #[cfg(feature = "http-client")]
+    #[test]
+    fn append_framework_routes_includes_webhook_replay_post() {
+        let mut config = AutumnConfig::default();
+        config.actuator.sensitive = true;
+        let prefix = config.actuator.prefix.clone();
+        let mut infos = Vec::new();
+        append_framework_routes(&mut infos, &config);
+
+        let replay_path = format!("{prefix}/webhooks/replay");
+        assert!(
+            infos.iter().any(|i| i.method == "POST"
+                && i.path == replay_path
+                && i.classification == RouteClassification::Framework),
+            "expected POST {replay_path} framework route: {infos:?}"
+        );
+        // `/webhooks/dlq` stays a GET listing.
+        let dlq_path = format!("{prefix}/webhooks/dlq");
+        assert!(
+            infos
+                .iter()
+                .any(|i| i.method == "GET" && i.path == dlq_path),
+            "expected GET {dlq_path} framework route: {infos:?}"
         );
     }
 

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -115,6 +115,14 @@ impl SecurityDump {
         for endpoint in &config.security.webhooks.endpoints {
             exempt_paths.push(endpoint.path.clone());
         }
+        // Runtime also exempts the framework-owned RFC 8058 one-click unsubscribe
+        // endpoint from CSRF (`apply_csrf_middleware`, `router.rs`) under the same
+        // `mail`-feature gate and `should_mount_unsubscribe_endpoint()` predicate,
+        // so fold that path in too when it applies.
+        #[cfg(feature = "mail")]
+        if config.mail.should_mount_unsubscribe_endpoint() {
+            exempt_paths.push(crate::mail::UNSUBSCRIBE_PATH.to_owned());
+        }
         exempt_paths.sort();
         exempt_paths.dedup();
 
@@ -1469,6 +1477,46 @@ mod tests {
         assert_eq!(
             dump.csrf.exempt_paths, sorted,
             "exempt_paths must stay sorted and deduped"
+        );
+    }
+
+    /// Runtime's `apply_csrf_middleware` exempts the framework-owned RFC 8058
+    /// one-click unsubscribe endpoint when the app opts in with a base URL, so
+    /// the dumped `csrf.exempt_paths` must include `UNSUBSCRIBE_PATH` for that
+    /// configuration and a mutating route there must read as CSRF-unenforced.
+    #[cfg(feature = "mail")]
+    #[test]
+    fn security_dump_exempts_mounted_unsubscribe_path() {
+        let mut config = AutumnConfig::default();
+        config.mail.mount_unsubscribe_endpoint = true;
+        config.mail.unsubscribe_base_url = Some("https://example.com".to_owned());
+        assert!(
+            config.mail.should_mount_unsubscribe_endpoint(),
+            "test precondition: unsubscribe endpoint must be mounted"
+        );
+
+        let dump = SecurityDump::from_config(&config);
+        assert!(
+            dump.csrf
+                .exempt_paths
+                .iter()
+                .any(|p| p == crate::mail::UNSUBSCRIBE_PATH),
+            "mounted unsubscribe path must be a CSRF exempt path: {:?}",
+            dump.csrf.exempt_paths
+        );
+
+        // When the endpoint is NOT mounted, the path must not be folded in.
+        let mut plain = AutumnConfig::default();
+        plain.mail.mount_unsubscribe_endpoint = false;
+        let plain_dump = SecurityDump::from_config(&plain);
+        assert!(
+            !plain_dump
+                .csrf
+                .exempt_paths
+                .iter()
+                .any(|p| p == crate::mail::UNSUBSCRIBE_PATH),
+            "unmounted unsubscribe path must not be exempt: {:?}",
+            plain_dump.csrf.exempt_paths
         );
     }
 }

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -56,7 +56,9 @@ pub struct CsrfDump {
 /// Every string is the *effective* declared value — in particular
 /// `content_security_policy` is the resolved template
 /// ([`default_content_security_policy`](crate::security::config::default_content_security_policy)
-/// when unset), not an unresolved sentinel.
+/// when unset), not an unresolved sentinel. When per-request CSP nonce injection
+/// is active it is the nonce-aware template (with a stable `AUTUMN_CSP_NONCE`
+/// placeholder), matching what responses actually send.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct HeadersDump {
@@ -106,6 +108,13 @@ impl SecurityDump {
         safe_methods.sort();
         safe_methods.dedup();
         let mut exempt_paths = csrf.exempt_paths.clone();
+        // Runtime's `apply_csrf_middleware` exempts every configured webhook
+        // endpoint path via `CsrfLayer::with_exempt_path`, so a webhook POST
+        // route not also listed in `csrf.exempt_paths` still skips CSRF at
+        // runtime. Fold those paths into the exempt set so the manifest matches.
+        for endpoint in &config.security.webhooks.endpoints {
+            exempt_paths.push(endpoint.path.clone());
+        }
         exempt_paths.sort();
         exempt_paths.dedup();
 
@@ -119,7 +128,9 @@ impl SecurityDump {
                 x_frame_options: headers.x_frame_options.clone(),
                 x_content_type_options: headers.x_content_type_options,
                 xss_protection: headers.xss_protection,
-                content_security_policy: headers.content_security_policy.clone(),
+                content_security_policy: crate::security::headers::resolved_content_security_policy(
+                    headers,
+                ),
                 referrer_policy: headers.referrer_policy.clone(),
                 permissions_policy: headers.permissions_policy.clone(),
                 strict_transport_security: headers.strict_transport_security,
@@ -1391,6 +1402,73 @@ mod tests {
         assert!(
             infos.is_empty(),
             "expected no dev routes when AUTUMN_DEV unset"
+        );
+    }
+
+    // ── SecurityDump::from_config (declared-vs-runtime honesty) ─────────────
+
+    /// Finding A: when CSP nonce injection is enabled and the CSP is the
+    /// framework default, runtime emits the nonce-aware template (not the raw
+    /// default), so the dumped CSP must be that template with the stable
+    /// `AUTUMN_CSP_NONCE` placeholder — never the raw default.
+    #[test]
+    fn security_dump_reports_nonce_aware_csp_when_nonce_enabled() {
+        let mut config = AutumnConfig::default();
+        // Default CSP is left in place; only the nonce flag flips.
+        config.security.headers.csp_nonce.enabled = true;
+
+        let dump = SecurityDump::from_config(&config);
+        let csp = &dump.headers.content_security_policy;
+        assert!(
+            csp.contains("'nonce-AUTUMN_CSP_NONCE'"),
+            "nonce-enabled default CSP must report the nonce-aware template: {csp}"
+        );
+        assert_eq!(
+            *csp,
+            crate::security::headers::resolved_content_security_policy(&config.security.headers),
+            "dump must mirror the runtime CSP resolution verbatim"
+        );
+
+        // With the nonce disabled the raw default is reported (no placeholder).
+        let mut plain = AutumnConfig::default();
+        plain.security.headers.csp_nonce.enabled = false;
+        let plain_dump = SecurityDump::from_config(&plain);
+        assert!(
+            !plain_dump
+                .headers
+                .content_security_policy
+                .contains("AUTUMN_CSP_NONCE"),
+            "nonce-disabled CSP must not carry the placeholder"
+        );
+    }
+
+    /// Finding B: runtime's `apply_csrf_middleware` exempts every configured
+    /// webhook endpoint path, so the dumped `csrf.exempt_paths` must include
+    /// them even when they are not duplicated in `security.csrf.exempt_paths`.
+    #[test]
+    fn security_dump_exempts_configured_webhook_paths() {
+        let mut config = AutumnConfig::default();
+        config.security.webhooks.endpoints = vec![crate::webhook::WebhookEndpointConfig {
+            path: "/webhooks/stripe".to_owned(),
+            ..Default::default()
+        }];
+
+        let dump = SecurityDump::from_config(&config);
+        assert!(
+            dump.csrf
+                .exempt_paths
+                .iter()
+                .any(|p| p == "/webhooks/stripe"),
+            "configured webhook path must be a CSRF exempt path: {:?}",
+            dump.csrf.exempt_paths
+        );
+        // Determinism: sorted and deduped.
+        let mut sorted = dump.csrf.exempt_paths.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(
+            dump.csrf.exempt_paths, sorted,
+            "exempt_paths must stay sorted and deduped"
         );
     }
 }

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -589,6 +589,23 @@ pub(crate) fn append_framework_routes(
         }
     }
 
+    // Framework-owned RFC 8058 one-click unsubscribe endpoint. Runtime merges
+    // `unsubscribe_router()` — a GET and a POST at `UNSUBSCRIBE_PATH` — under the
+    // same `mail`-feature gate and `should_mount_unsubscribe_endpoint()` predicate
+    // that folds the path into `csrf.exempt_paths`, so list both methods here to
+    // keep the manifest in lockstep. Without the POST listed, `build_csrf_dimension`
+    // would silently under-report the exempt (not-enforced) mutating route.
+    #[cfg(feature = "mail")]
+    if config.mail.should_mount_unsubscribe_endpoint() {
+        for http_method in ["GET", "POST"] {
+            infos.push(RouteInfo::framework_route(
+                http_method,
+                crate::mail::UNSUBSCRIBE_PATH.to_owned(),
+                "unsubscribe",
+            ));
+        }
+    }
+
     // Widget story gallery routes (#1526), listed iff the resolved config
     // enables them (same gating condition as the router mount).
     #[cfg(feature = "maud")]
@@ -1350,6 +1367,53 @@ mod tests {
         assert!(
             !paths.contains(&"/_stories/{slug}"),
             "disabled stories must not list the detail route: {paths:?}"
+        );
+    }
+
+    /// Codex P2 (issue #1627): when the RFC 8058 one-click unsubscribe endpoint
+    /// is mounted, runtime merges `unsubscribe_router()` — a GET and a POST at
+    /// `UNSUBSCRIBE_PATH` — and exempts the path from CSRF. `append_framework_routes`
+    /// must list both methods (matching the same `should_mount_unsubscribe_endpoint()`
+    /// predicate the exempt fold uses) so the csrf posture dimension can see the
+    /// mutating POST. When the endpoint is not mounted, neither route is listed.
+    #[cfg(feature = "mail")]
+    #[test]
+    fn append_framework_routes_includes_mounted_unsubscribe_routes() {
+        let mut config = AutumnConfig::default();
+        config.mail.mount_unsubscribe_endpoint = true;
+        config.mail.unsubscribe_base_url = Some("https://example.com".to_owned());
+        assert!(
+            config.mail.should_mount_unsubscribe_endpoint(),
+            "test precondition: unsubscribe endpoint must be mounted"
+        );
+        let mut infos = Vec::new();
+        append_framework_routes(&mut infos, &config);
+
+        assert!(
+            infos.iter().any(|i| i.method == "POST"
+                && i.path == crate::mail::UNSUBSCRIBE_PATH
+                && i.classification == RouteClassification::Framework),
+            "expected POST {} framework route: {infos:?}",
+            crate::mail::UNSUBSCRIBE_PATH
+        );
+        assert!(
+            infos.iter().any(|i| i.method == "GET"
+                && i.path == crate::mail::UNSUBSCRIBE_PATH
+                && i.classification == RouteClassification::Framework),
+            "expected GET {} framework route: {infos:?}",
+            crate::mail::UNSUBSCRIBE_PATH
+        );
+
+        // When the endpoint is NOT mounted, neither route is listed.
+        let plain = AutumnConfig::default();
+        assert!(!plain.mail.should_mount_unsubscribe_endpoint());
+        let mut infos = Vec::new();
+        append_framework_routes(&mut infos, &plain);
+        assert!(
+            !infos
+                .iter()
+                .any(|i| i.path == crate::mail::UNSUBSCRIBE_PATH),
+            "unmounted unsubscribe path must not be listed: {infos:?}"
         );
     }
 

--- a/autumn/src/route_listing.rs
+++ b/autumn/src/route_listing.rs
@@ -104,8 +104,10 @@ impl SecurityDump {
 
         let mut safe_methods = csrf.safe_methods.clone();
         safe_methods.sort();
+        safe_methods.dedup();
         let mut exempt_paths = csrf.exempt_paths.clone();
         exempt_paths.sort();
+        exempt_paths.dedup();
 
         Self {
             csrf: CsrfDump {

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -7990,6 +7990,27 @@ mod trusted_host_tests {
         }
     }
 
+    /// Regression guard (#1627): the `StartupBarrierState` allow-list, which is
+    /// seeded from `actuator_endpoint_paths`, must permit the mutating
+    /// `POST {prefix}/webhooks/replay` route to bypass the startup barrier. A
+    /// prior fix removed the path from `actuator_endpoint_paths` to kill a
+    /// phantom GET in the route listing, which also silently dropped it from
+    /// this bypass set.
+    #[cfg(feature = "http-client")]
+    #[test]
+    fn startup_barrier_allows_webhook_replay_post_path() {
+        let mut cfg = AutumnConfig::default();
+        cfg.actuator.sensitive = true;
+        let state = crate::state::AppState::for_test();
+        let barrier = StartupBarrierState::from_config(&cfg, &state);
+        let replay_path =
+            crate::actuator::actuator_route_path(&cfg.actuator.prefix, "/webhooks/replay");
+        assert!(
+            barrier.allows_path(&replay_path),
+            "startup barrier must allow {replay_path} to bypass admission"
+        );
+    }
+
     #[tokio::test]
     async fn trusted_host_release_rejects_loopback_unless_listed() {
         let mut cfg = AutumnConfig {

--- a/autumn/src/security/headers.rs
+++ b/autumn/src/security/headers.rs
@@ -154,6 +154,28 @@ fn nonce_aware_default_csp() -> String {
         .to_owned()
 }
 
+/// Resolve the effective `Content-Security-Policy` string that responses carry,
+/// mirroring the resolution in [`ComputedHeaders::from_config`].
+///
+/// When per-request nonce injection is active (nonce enabled AND the CSP is the
+/// framework default), this returns the nonce-aware template containing
+/// [`NONCE_PLACEHOLDER`] tokens — i.e. what responses send *before* the
+/// per-request nonce is substituted in. Otherwise it returns the configured CSP
+/// verbatim.
+///
+/// The security-posture manifest reports this value (placeholder intact, not a
+/// live nonce) so the declared CSP matches what nonce-enabled apps emit while
+/// staying byte-deterministic across runs.
+pub fn resolved_content_security_policy(config: &HeadersConfig) -> String {
+    if config.csp_nonce.enabled
+        && config.content_security_policy == default_content_security_policy()
+    {
+        nonce_aware_default_csp()
+    } else {
+        config.content_security_policy.clone()
+    }
+}
+
 /// Pre-computed header pairs to inject into every response.
 ///
 /// Created once from [`HeadersConfig`] and shared via `Arc` across
@@ -218,12 +240,16 @@ impl ComputedHeaders {
         // their custom value is used verbatim and the nonce is still generated
         // (for the extractor) but not written into the header.
         let using_default_csp = config.content_security_policy == default_content_security_policy();
+        // Single source of truth for the resolved CSP string (nonce-aware
+        // template when injection is active, configured value otherwise); the
+        // manifest dump reuses this same resolution.
+        let resolved_csp = resolved_content_security_policy(config);
         let nonce_csp_template = if config.csp_nonce.enabled && using_default_csp {
-            Some(Arc::from(nonce_aware_default_csp().as_str()))
+            Some(Arc::from(resolved_csp.as_str()))
         } else {
             // Static CSP (either custom, or nonce disabled).
-            if !config.content_security_policy.is_empty()
-                && let Ok(val) = HeaderValue::from_str(&config.content_security_policy)
+            if !resolved_csp.is_empty()
+                && let Ok(val) = HeaderValue::from_str(&resolved_csp)
             {
                 static_pairs.push((HeaderName::from_static("content-security-policy"), val));
             }

--- a/docs/guide/routes-cli.md
+++ b/docs/guide/routes-cli.md
@@ -173,3 +173,9 @@ enumerable and are omitted from this listing
 If your application relies heavily on merged/nested raw routers, use `autumn
 routes` output as a partial snapshot and supplement it with manual
 documentation for those routes.
+
+## See also
+
+- [Security Posture Manifest — Provenance Classes](security-posture-manifest.md)
+  — how `autumn routes audit` tags each manifest dimension as `provable`,
+  `declared`, or `runtime-only`.

--- a/docs/guide/security-posture-manifest.md
+++ b/docs/guide/security-posture-manifest.md
@@ -105,6 +105,14 @@ every dimension that is not yet emitted is named, with the class it will carry
 and why it is deferred — so a reader can tell the difference between "proven
 absent" and "not yet measured".
 
+That honesty also covers a runtime boundary: the `serve_path_routers` entry
+records that opt-in serve-path HTTP surfaces (MCP, inbound-mail, storage, SEO)
+are injected only when the server actually starts — after the route-dump
+early-exit — so `autumn routes` does not enumerate them at build time. Their
+mutating endpoints (MCP, inbound-mail) run outside the framework CSRF layer and
+rely on their own protections; enumerating them is deferred to a dump-plumbing
+follow-up.
+
 ## See also
 
 - [`autumn routes` — Route Inspection CLI](routes-cli.md) — the `audit`

--- a/docs/guide/security-posture-manifest.md
+++ b/docs/guide/security-posture-manifest.md
@@ -1,0 +1,111 @@
+# Security Posture Manifest — Provenance Classes
+
+`autumn routes audit` emits a machine-readable **security posture manifest**: a
+stable-ordered JSON document describing what the framework can say about your
+application's security posture at build time, and — crucially — *how it knows*.
+
+Every dimension in the manifest is tagged with a **provenance class**. The class
+is a promise about the strength of the claim: whether the manifest **proves** it
+from your code, merely **reports** what you configured, or has to defer to
+runtime. Reading the manifest starts with reading these tags.
+
+```json
+{
+  "schema_version": 2,
+  "dimensions": {
+    "routes":           { "provenance": "provable",  "source": "macro:#[secured]/#[authorize]/#[public]", "entries": [ … ] },
+    "csrf":             { "provenance": "declared",  "source": "config:security.csrf",     "entries": [ … ] },
+    "security_headers": { "provenance": "declared",  "source": "config:security.headers",  "entries": [ … ] }
+  },
+  "excluded": [
+    { "dimension": "policy_registration", "eventual_provenance": "runtime-only", "reason": "boot-time fact; excluded from a build-time manifest by design" }
+  ]
+}
+```
+
+There are exactly three provenance classes.
+
+## `provable`
+
+The claim is **derived from macro-expanded code**. The manifest does not take
+your word for it — the fact is a consequence of what you wrote, checked at build
+time. A `provable` dimension can back a CI gate that fails the build.
+
+**Example — a `#[secured]` route in the `routes` dimension.** When you guard a
+handler:
+
+```rust
+#[secured("admin")]
+async fn delete_widget(/* … */) -> impl IntoResponse { /* … */ }
+```
+
+the route surfaces in the manifest as a proven `gated` classification:
+
+```json
+{
+  "path": "/widgets/{id}",
+  "method": "DELETE",
+  "classification": "gated",
+  "roles": ["admin"],
+  "policy": false,
+  "provenance": "provable"
+}
+```
+
+Nothing about this can drift: the classification *is* the expansion of the
+macro. An unannotated mutating handler classifies `unclassified`, and the audit
+gate fails and names it.
+
+## `declared`
+
+The claim is **read from configuration**. The manifest reports what you
+*configured*, not that the runtime honors it. This is weaker than `provable` on
+purpose: config is the source of truth for intent, but the manifest is not
+re-deriving the middleware behaviour from the request path.
+
+**Example — the CSP string in the `security_headers` dimension.** Your
+`[security.headers]` config resolves to an effective
+`Content-Security-Policy` template, and the manifest records it verbatim:
+
+```json
+{
+  "header": "content_security_policy",
+  "value": "default-src 'self'; img-src 'self' data:; script-src 'self'; …",
+  "emitted": true
+}
+```
+
+Weakening the policy — say emptying it, which stops the header being sent —
+shows up as `"emitted": false` on exactly that entry. The `csrf` dimension is
+`declared` for the same reason: it mirrors the `CsrfLayer` predicate against
+your configured `enabled` flag and `exempt_paths`, but it is your configuration
+speaking, not a proof that every mutating request is checked.
+
+## `runtime-only`
+
+The claim is a **boot-time or per-request fact that a build-time manifest cannot
+observe**. Rather than fabricate it, the manifest lists the dimension in
+`excluded` with the provenance class it will *eventually* carry once (and if) it
+becomes observable.
+
+**Example — policy registration at boot.** Which authorization policies are
+actually registered in the `PolicyRegistry` is decided when the app boots, not
+when it compiles. It therefore appears only in the `excluded` block:
+
+```json
+{
+  "dimension": "policy_registration",
+  "eventual_provenance": "runtime-only",
+  "reason": "boot-time fact; excluded from a build-time manifest by design"
+}
+```
+
+The `excluded` list is how the manifest stays honest about its own boundaries:
+every dimension that is not yet emitted is named, with the class it will carry
+and why it is deferred — so a reader can tell the difference between "proven
+absent" and "not yet measured".
+
+## See also
+
+- [`autumn routes` — Route Inspection CLI](routes-cli.md) — the `audit`
+  subcommand that emits this manifest.


### PR DESCRIPTION
Part of #1627. Extends the merged #1850 route-audit manifest into a provenance-tagged, multi-dimension **security posture manifest** (first slice).

## Before / After — what the manifest proves

**Before (schema v1):** `autumn routes audit` emitted a single `routes` dimension — a flat list of routes tagged `provenance: "provable"`. That was the only security fact the manifest carried, and there was no vocabulary for facts that come from configuration rather than from code, nor any record of what was *not* yet covered.

```jsonc
// BEFORE (v1)
{
  "schema_version": 1,
  "dimensions": {
    "routes": [ { "path": "/widgets/{id}", "method": "DELETE", "classification": "gated", "provenance": "provable", ... } ]
  }
}
```

**After (schema v2):** every dimension is wrapped in a provenance envelope (`{ provenance, source, entries }`), two new **`declared`** dimensions describe CSRF and security-header posture read from config, and a top-level `excluded` list names every dimension deferred to a later slice with the provenance class it will eventually carry — so a reader can tell "proven absent" from "not yet measured".

```jsonc
// AFTER (v2)
{
  "schema_version": 2,
  "dimensions": {
    "routes":           { "provenance": "provable", "source": "macro:#[secured]/#[authorize]/#[public]",
      "entries": [ { "path": "/widgets/{id}", "method": "DELETE", "classification": "gated", "provenance": "provable", ... } ] },
    "csrf":             { "provenance": "declared", "source": "config:security.csrf", "exempt_paths": ["/api/"],
      "entries": [ { "path": "/widgets", "method": "POST", "csrf_enforced": true, "exempt": false } ] },
    "security_headers": { "provenance": "declared", "source": "config:security.headers",
      "entries": [ { "header": "x_frame_options", "value": "DENY", "emitted": true } ] }
  },
  "excluded": [
    { "dimension": "policy_registration", "eventual_provenance": "runtime-only", "reason": "boot-time fact; excluded from a build-time manifest by design" },
    ...
  ]
}
```

The `routes` entries are byte-for-byte identical to v1 — only their container changed.

## How

- **Envelope schema v2.** `Provenance` is a small closed enum (`provable` / `declared` / `runtime-only`). `Dimensions` has a fixed field order (`routes`, `csrf`, `security_headers`); every list is deterministically sorted. `excluded` is a fixed, stable-ordered list.
- **Config-dump plumbing (macro-free).** The `AUTUMN_DUMP_ROUTES` dump now also emits the resolved `CsrfConfig` + `HeadersConfig` as one compact JSON object on a stderr marker line (`[autumn:security-config] `, a new `SecurityDump` type in `autumn_web::route_listing`), gated on a new `AUTUMN_DUMP_SECURITY=1` env var that only `autumn routes audit` sets. `autumn routes` is unaffected and the routes-only stdout JSON parse path stays byte-compatible. Emitted lists are sorted for byte-determinism; the audit CLI hides the marker line from forwarded stderr.
- **CSRF predicate mirror.** One `csrf` entry per *mutating* route (method not in the configured `safe_methods`). `csrf_enforced = enabled && !is_safe(method) && !is_exempt(path)`, with `is_exempt` mirroring the runtime `CsrfLayer` prefix predicate (`autumn/src/security/csrf.rs`) exactly. Configured exemptions are recorded once at the dimension level.
- **Headers resolution.** One `security_headers` entry per header key, value = the effective declared string (the CSP is the resolved `default_content_security_policy()` template the runtime uses), `emitted = !value.is_empty()`, in sorted key order.

## Falsifiability tests (AC-6)

Genuine red→green fixtures driving the real `build_manifest` path (inline in `routes_audit.rs`, since `autumn-cli` is binary-only):

- `manifest_v2_envelope_shape_and_provenance_labels` — schema v2, three dimensions with correct provenance labels, full `excluded` list.
- `csrf_dimension_only_covers_mutating_routes` — safe (GET) routes never appear in `csrf.entries`.
- `disabling_csrf_flips_only_csrf_entries` — toggling `enabled` flips exactly the csrf entries; `routes`/`security_headers` byte-identical.
- `adding_exempt_path_flips_only_affected_csrf_entries` — an `/api/` prefix flips only the routes under it; other dimensions byte-identical.
- `weakening_a_header_changes_only_that_entry` — DENY→SAMEORIGIN and emptying the CSP each change exactly that header entry; `routes`/`csrf` byte-identical.
- `manifest_rebuild_is_byte_identical` — two builds of identical source+config are byte-for-byte equal.
- `parse_security_config_reads_the_marker` — the stderr marker round-trips.

Plus a consolidated `autumn-cli/tests/integration/manifest_posture.rs` module covering the `autumn-web` dump contract (`SecurityDump::from_config` sorting/determinism and CSRF/header falsifiability at the wire boundary).

Gates run green: `cargo fmt --all -- --check`, `cargo clippy -p autumn-web -p autumn-cli --all-targets -- -D warnings`, `cargo test -p autumn-cli routes_audit` (22 passed), `cargo test -p autumn-cli --test cli_tests manifest_posture` (4 passed), `cargo test -p autumn-web --lib route_listing` (44 passed).

Docs: new `docs/guide/security-posture-manifest.md` defining the three provenance classes with one example each (provable: a `#[secured]` route; declared: the resolved CSP string; runtime-only: policy registration at boot in `excluded`), cross-linked from `routes-cli.md`.

## Deferred to later slices

Listed in the manifest's `excluded` block, not implemented here:

- `authorization_policies` — full `#[authorize]` action→policy-type binding (needs new macro metadata; boolean policy presence already ships in `routes.entries[].policy`)
- `sessions`
- `secrets`
- `encryption` (`#[encrypted]` fields provable; key config declared)
- `rate_limit`
- `submit_token`
- `outbound_http`
- `policy_registration` (runtime-only boot fact)

## Notes

- **CHANGELOG intentionally not edited** and no workspace version bump, per repo guidelines (that is a separate, deliberate release step).
- No changes to `autumn-macros` — this slice is entirely macro-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjQWjvP71LMRPsQexcYPvi

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjQWjvP71LMRPsQexcYPvi)_