### PR TITLE
docs(alerts): correct "SSRF-hardened" claims on native alert transports

### DIFF
--- a/autumn/src/alerts.rs
+++ b/autumn/src/alerts.rs
@@ -1271,8 +1271,16 @@ pub fn pagerduty_event_payload(alert: &Alert, routing_key: &str) -> serde_json::
 /// [`Alert::dedup_key`], so a repeating condition folds into a single incident
 /// and a recovery emits a `resolve` event that auto-resolves it. Works against
 /// PagerDuty-Events-compatible endpoints offered by other paging services (set
-/// `[alerts] pagerduty_url`). Uses the SSRF-hardened
-/// [`http_client::Client`](crate::http_client::Client) for the outbound call.
+/// `[alerts] pagerduty_url`).
+///
+/// The endpoint URL is validated only for *shape* — an absolute `http(s)` URL —
+/// at config load and by `autumn doctor`'s `alert_transports` check. The
+/// outbound POST does NOT apply the
+/// [`http_client::Client`](crate::http_client::Client)'s SSRF deny-list /
+/// address pinning (that guard is only enabled via
+/// [`Client::get_ssrf_safe`](crate::http_client::Client::get_ssrf_safe)). Alert
+/// URLs are treated as trusted operator configuration and are intentionally
+/// exempt so operators can page internal endpoints.
 #[cfg(feature = "http-client")]
 pub struct PagerDutyAlertChannel {
     client: crate::http_client::Client,
@@ -1380,8 +1388,16 @@ pub fn slack_message_payload(alert: &Alert) -> serde_json::Value {
 ///
 /// POSTs a human-readable message to a Slack incoming-webhook URL, or to a
 /// Discord webhook's Slack-compatible endpoint (append `/slack`), using one
-/// payload dialect for both. Uses the SSRF-hardened
-/// [`http_client::Client`](crate::http_client::Client) for the outbound call.
+/// payload dialect for both.
+///
+/// The webhook URL is validated only for *shape* — an absolute `https` URL — at
+/// config load and by `autumn doctor`'s `alert_transports` check. The outbound
+/// POST does NOT apply the
+/// [`http_client::Client`](crate::http_client::Client)'s SSRF deny-list /
+/// address pinning (that guard is only enabled via
+/// [`Client::get_ssrf_safe`](crate::http_client::Client::get_ssrf_safe)). Alert
+/// URLs are treated as trusted operator configuration and are intentionally
+/// exempt so operators can alert to internal chat endpoints.
 #[cfg(feature = "http-client")]
 pub struct SlackAlertChannel {
     client: crate::http_client::Client,
@@ -1467,8 +1483,16 @@ impl AlertChannel for SlackAlertChannel {
 /// actually delivers.
 ///
 /// Shared by [`install_from_config`] (runtime wiring) and the CLI `autumn alert
-/// test` command so both agree on exactly which transports are usable. All
-/// outbound calls go through the passed SSRF-hardened `client`.
+/// test` command so both agree on exactly which transports are usable.
+///
+/// All outbound calls go through the passed `client`, but only the transport
+/// URL *shape* is validated (absolute `https` for Slack/Discord; absolute
+/// `http(s)` for `PagerDuty`) — at config load and by `autumn doctor`'s
+/// `alert_transports` check. Dispatch does NOT apply the client's SSRF deny-list
+/// / address pinning (that guard is only enabled via
+/// [`Client::get_ssrf_safe`](crate::http_client::Client::get_ssrf_safe)); alert
+/// URLs are trusted operator configuration and are intentionally exempt so
+/// operators can alert to internal endpoints.
 #[cfg(feature = "http-client")]
 #[must_use]
 pub fn native_transport_channels(
@@ -1711,7 +1735,13 @@ fn build_mail_alert_channel(
 
 /// Append the native provider channels (issue #1630, `PagerDuty` / Slack /
 /// Discord) to `channels`, built through [`native_transport_channels`] with the
-/// SSRF-hardened shared HTTP client.
+/// shared HTTP client.
+///
+/// Alert dispatch validates only the transport URL's *shape*; it does NOT apply
+/// the client's SSRF deny-list / address pinning (see
+/// [`native_transport_channels`]). Alert URLs are trusted operator
+/// configuration and are intentionally exempt so operators can alert to
+/// internal endpoints.
 ///
 /// Compiled to a warn-only no-op when the `http-client` feature is off, so a
 /// PagerDuty/Slack/Discord-only config does not silently deliver nothing.


### PR DESCRIPTION
Closes #1833

## Summary

Documentation-correctness fix. Four docstrings in `autumn/src/alerts.rs` claimed the native alert channels (generic webhook, PagerDuty, Slack, Discord) were "SSRF-hardened". They are not: those channels dispatch via `self.client.named(&url).post(&url).send()`, and the HTTP client's SSRF deny-list / per-hop address pinning is only enabled through `Client::get_ssrf_safe(...)` (which sets `builder.ssrf_safe = true`). The default builder has `ssrf_safe: false`, so `send()` never routes through the guarded path for these channels. The only protection on this path is a URL *shape* check (absolute `https` for Slack/Discord; absolute `http(s)` for PagerDuty/webhook), enforced at config load and by `autumn doctor`'s `alert_transports` check — that is shape validation, not an SSRF deny-list.

This PR is docs-only. No `.post()` / `.send()` call or dispatch behavior changes.

## Before / After

**Before:** the docstrings at `alerts.rs:1274`, `:1384`, `:1471`, `:1714` claimed the alert dispatch path uses the "SSRF-hardened" HTTP client — implying the alert URLs are checked against the blocked-IP / private-range deny-list. That is false.

**After:** the docstrings accurately state that only the URL *shape* is validated (absolute `https` for Slack/Discord; absolute `http(s)` for PagerDuty and the generic webhook) at config load and via `autumn doctor`, and that dispatch intentionally does NOT apply the client's SSRF deny-list / address pinning (only `Client::get_ssrf_safe` enables that). They document that alert URLs are trusted operator configuration and are intentionally exempt.

## Design decision

We correct the docs rather than route alert dispatch through `get_ssrf_safe`. Alert destination URLs are trusted operator configuration — set in the app's config file alongside DB URLs and other infrastructure secrets — and self-hosted deployments legitimately point alerts at INTERNAL endpoints (internal Alertmanager, LAN webhook receivers, internal chat). `get_ssrf_safe` blocks private/loopback IP ranges, so routing alerts through it would break those legitimate internal-alerting setups. The accurate fix is to describe the real guarantee and the intentional exemption, not to change behavior.

## Gate output

`cargo fmt --all -- --check`:
```
(no output; exit 0)
```

`cargo clippy --workspace --all-targets -- -D warnings`:
```
    Checking autumn-web v0.6.0 (/home/user/autumn/autumn)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 09s
CLIPPY_EXIT=0
```

`cargo doc -p autumn-web --no-deps --lib` (intra-doc link sanity — 0 warnings on the edited lines after fixing two links I introduced):
```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 00s
   Generated /workspace/target/doc/autumn_web/index.html
DOC_EXIT=0
```

`cargo test -p autumn-web --test integration_tests alert`:
```
test result: ok. 34 passed; 0 failed; 0 ignored; 0 measured; 1214 filtered out; finished in 0.12s
TEST_EXIT=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9uehBWRkPbZC8PjUjPRUT

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9uehBWRkPbZC8PjUjPRUT)_