### PR TITLE
Add content-negotiated responses: one handler serves HTML and JSON

### DIFF
--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -345,6 +345,9 @@ pub(crate) mod logging;
 #[cfg(feature = "mcp")]
 pub mod mcp;
 pub mod middleware;
+/// Content-negotiated success responder (`Negotiate` / `Negotiated` / `Format`).
+#[cfg(feature = "maud")]
+pub mod negotiate;
 pub mod openapi;
 pub mod pagination;
 pub mod paths;

--- a/autumn/src/middleware/error_page_filter.rs
+++ b/autumn/src/middleware/error_page_filter.rs
@@ -343,8 +343,23 @@ pub fn accept_prefers_html(headers: &axum::http::HeaderMap) -> bool {
 pub struct AcceptQualities {
     /// Best match for `text/html`.
     pub html: Option<(f32, usize)>,
-    /// Best match for `application/json` / `application/problem+json`.
+    /// Best match for the success JSON type `application/json` (only).
+    ///
+    /// Kept separate from [`Self::problem_json`] so the
+    /// [`Negotiate`](crate::negotiate::Negotiate) responder can negotiate the
+    /// success `application/json` body without treating the error-only
+    /// `application/problem+json` signal as accepting it.
     pub json: Option<(f32, usize)>,
+    /// Best match for `application/problem+json`.
+    ///
+    /// `application/problem+json` is an **error-path** (Problem Details) signal,
+    /// not a success representation. The legacy
+    /// [`accept_preference`]/[`accept_prefers_html`] path folds it into the JSON
+    /// preference (so a client asking for problem+json still gets a JSON error
+    /// body rather than an HTML error page), but the `Negotiate` success
+    /// responder deliberately ignores it: advertising problem+json alone does
+    /// **not** count as accepting the `application/json` success body.
+    pub problem_json: Option<(f32, usize)>,
     /// Best match for the `text/*` subtype wildcard.
     ///
     /// A media range like `text/*` covers `text/html` per RFC 7231 §5.3.2 but is
@@ -369,9 +384,10 @@ pub struct AcceptQualities {
 /// The one canonical `Accept` parser.
 ///
 /// Scans the comma-separated `Accept` header once, recording the best
-/// `(q-value, list-index)` seen for `text/html`, for `application/json` /
-/// `application/problem+json`, for the `text/*` and `application/*` subtype
-/// wildcards, and for the `*/*` wildcard. Out-of-range
+/// `(q-value, list-index)` seen for `text/html`, for `application/json`, for
+/// `application/problem+json` (tracked in its own slot — an error-path signal
+/// that does not drive success JSON negotiation), for the `text/*` and
+/// `application/*` subtype wildcards, and for the `*/*` wildcard. Out-of-range
 /// q-values are clamped to `[0.0, 1.0]`. Entries with `q=0` are *retained*
 /// (recorded as `Some((0.0, index))`) so an explicit "not acceptable"
 /// exclusion survives; each consumer decides how to treat them.
@@ -420,10 +436,15 @@ pub fn accept_qualities(headers: &axum::http::HeaderMap) -> AcceptQualities {
             "text/html" if qualities.html.is_none_or(|(existing_q, _)| q > existing_q) => {
                 qualities.html = Some((q, index));
             }
-            "application/json" | "application/problem+json"
-                if qualities.json.is_none_or(|(existing_q, _)| q > existing_q) =>
-            {
+            "application/json" if qualities.json.is_none_or(|(existing_q, _)| q > existing_q) => {
                 qualities.json = Some((q, index));
+            }
+            "application/problem+json"
+                if qualities
+                    .problem_json
+                    .is_none_or(|(existing_q, _)| q > existing_q) =>
+            {
+                qualities.problem_json = Some((q, index));
             }
             "text/*"
                 if qualities
@@ -453,6 +474,30 @@ pub fn accept_qualities(headers: &axum::http::HeaderMap) -> AcceptQualities {
     qualities
 }
 
+/// Merge two `(q-value, list-index)` slots into the single best one — higher q
+/// wins, ties broken by the earlier list index — reproducing the behaviour of
+/// the original single-slot `accept_qualities`, where `application/json` and
+/// `application/problem+json` shared one slot updated by strictly-greater q.
+///
+/// Used by the legacy [`accept_preference`] path to fold the (now separate)
+/// `problem_json` slot back into the JSON signal. The `Negotiate` success
+/// responder does **not** call this: it negotiates on the `json` slot alone.
+fn combine_slots(a: Option<(f32, usize)>, b: Option<(f32, usize)>) -> Option<(f32, usize)> {
+    match (a, b) {
+        (Some((aq, ai)), Some((bq, bi))) => Some(if (aq - bq).abs() < f32::EPSILON {
+            // Equal q: the earlier list entry is the one the single-slot scan
+            // would have kept (it only replaced on strictly-greater q).
+            if ai <= bi { (aq, ai) } else { (bq, bi) }
+        } else if aq > bq {
+            (aq, ai)
+        } else {
+            (bq, bi)
+        }),
+        (a @ Some(_), None) => a,
+        (None, b) => b,
+    }
+}
+
 /// The one canonical q-value `Accept` negotiator (legacy enum resolution).
 ///
 /// Returns the client's concrete representation preference. Empty or missing
@@ -479,9 +524,18 @@ pub fn accept_preference(headers: &axum::http::HeaderMap) -> AcceptPreference {
     let AcceptQualities {
         html,
         json,
+        problem_json,
         wildcard,
         ..
     } = accept_qualities(headers);
+
+    // Legacy resolution treats `application/problem+json` as a JSON signal (a
+    // problem+json client wants a JSON error body, not an HTML page). The shared
+    // parser now records it in its own slot, so recombine the two into one
+    // effective JSON signal here — higher q wins, ties broken by earlier list
+    // index — reproducing the original single-slot `(q, index)` semantics
+    // exactly so this path stays byte-identical.
+    let json = combine_slots(json, problem_json);
 
     // Legacy resolution only cares about *positive* preference: a `q=0` slot
     // (now retained by the shared parser) is treated as absent here, exactly

--- a/autumn/src/middleware/error_page_filter.rs
+++ b/autumn/src/middleware/error_page_filter.rs
@@ -323,27 +323,46 @@ pub fn accept_prefers_html(headers: &axum::http::HeaderMap) -> bool {
     )
 }
 
-/// The one canonical q-value `Accept` negotiator.
+/// Best `(q-value, list-index)` seen for each media type the crate negotiates
+/// on, parsed from a request's `Accept` header by the one canonical parser
+/// [`accept_qualities`].
 ///
-/// Returns the client's concrete representation preference. Empty or missing
-/// `Accept` yields [`AcceptPreference::Unspecified`]; a `*/*`-only header
-/// yields [`AcceptPreference::Any`]. When both `text/html` and
-/// `application/json` are present, the higher q-value wins, ties broken by
-/// earlier list position.
-pub fn accept_preference(headers: &axum::http::HeaderMap) -> AcceptPreference {
+/// `index` is the position of the winning entry in the comma-separated header
+/// (0-based), used to break q-value ties in favour of the earlier entry. Each
+/// field is `None` when that media type was absent or fully demoted (`q=0`).
+/// Both [`accept_preference`] (legacy enum resolution) and the
+/// [`Negotiate`](crate::negotiate::Negotiate) responder (effective-q
+/// resolution) build on this shared parse, so the crate never forks its
+/// `Accept` parsing.
+// `pub` (not `pub(crate)`): the enclosing `error_page_filter` module is itself
+// `pub(crate)`, so these never escape the crate (clippy::redundant_pub_crate).
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct AcceptQualities {
+    /// Best match for `text/html`.
+    pub html: Option<(f32, usize)>,
+    /// Best match for `application/json` / `application/problem+json`.
+    pub json: Option<(f32, usize)>,
+    /// Best match for the `*/*` wildcard.
+    pub wildcard: Option<(f32, usize)>,
+}
+
+/// The one canonical `Accept` parser.
+///
+/// Scans the comma-separated `Accept` header once, recording the best
+/// `(q-value, list-index)` seen for `text/html`, for `application/json` /
+/// `application/problem+json`, and for the `*/*` wildcard. Entries demoted to
+/// `q=0` are dropped, and out-of-range q-values are clamped to `[0.0, 1.0]`.
+///
+/// This is the crate's single source of truth for `Accept` tokenisation; the
+/// two consumers apply their own *resolution policy* on top of the returned
+/// [`AcceptQualities`] (they differ only in policy, not parsing).
+pub fn accept_qualities(headers: &axum::http::HeaderMap) -> AcceptQualities {
     let accept = headers
         .get(axum::http::header::ACCEPT)
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
 
-    // If no Accept header, there is no concrete preference.
-    if accept.is_empty() {
-        return AcceptPreference::Unspecified;
-    }
-
-    let mut html: Option<(f32, usize)> = None;
-    let mut json: Option<(f32, usize)> = None;
-    let mut wildcard: Option<(f32, usize)> = None;
+    let mut qualities = AcceptQualities::default();
 
     for (index, raw_part) in accept.split(',').enumerate() {
         let part = raw_part.trim();
@@ -372,20 +391,53 @@ pub fn accept_preference(headers: &axum::http::HeaderMap) -> AcceptPreference {
         }
 
         match mime {
-            "text/html" if html.is_none_or(|(existing_q, _)| q > existing_q) => {
-                html = Some((q, index));
+            "text/html" if qualities.html.is_none_or(|(existing_q, _)| q > existing_q) => {
+                qualities.html = Some((q, index));
             }
             "application/json" | "application/problem+json"
-                if json.is_none_or(|(existing_q, _)| q > existing_q) =>
+                if qualities.json.is_none_or(|(existing_q, _)| q > existing_q) =>
             {
-                json = Some((q, index));
+                qualities.json = Some((q, index));
             }
-            "*/*" if wildcard.is_none_or(|(existing_q, _)| q > existing_q) => {
-                wildcard = Some((q, index));
+            "*/*"
+                if qualities
+                    .wildcard
+                    .is_none_or(|(existing_q, _)| q > existing_q) =>
+            {
+                qualities.wildcard = Some((q, index));
             }
             _ => {}
         }
     }
+
+    qualities
+}
+
+/// The one canonical q-value `Accept` negotiator (legacy enum resolution).
+///
+/// Returns the client's concrete representation preference. Empty or missing
+/// `Accept` yields [`AcceptPreference::Unspecified`]; a `*/*`-only header
+/// yields [`AcceptPreference::Any`]. When both `text/html` and
+/// `application/json` are present, the higher q-value wins, ties broken by
+/// earlier list position. Parsing is delegated to the shared
+/// [`accept_qualities`]; this function only applies the enum resolution policy.
+pub fn accept_preference(headers: &axum::http::HeaderMap) -> AcceptPreference {
+    // Distinguish a missing/empty `Accept` (no concrete preference at all) from
+    // one that is present but names no html/json/wildcard type. The shared
+    // parser collapses both to all-`None`, so the emptiness check stays here.
+    let accept = headers
+        .get(axum::http::header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    if accept.is_empty() {
+        return AcceptPreference::Unspecified;
+    }
+
+    let AcceptQualities {
+        html,
+        json,
+        wildcard,
+    } = accept_qualities(headers);
 
     match (html, json, wildcard) {
         (Some((hq, hidx)), Some((jq, jidx)), _) => {

--- a/autumn/src/middleware/error_page_filter.rs
+++ b/autumn/src/middleware/error_page_filter.rs
@@ -392,6 +392,10 @@ pub struct AcceptQualities {
 /// (recorded as `Some((0.0, index))`) so an explicit "not acceptable"
 /// exclusion survives; each consumer decides how to treat them.
 ///
+/// Media-range tokens and the quality parameter name are matched
+/// case-insensitively per RFC 7231 §3.1.1.1: `Application/JSON` records the
+/// same slot as `application/json`, and `Q=` is honoured like `q=`.
+///
 /// This is the crate's single source of truth for `Accept` tokenisation; the
 /// two consumers apply their own *resolution policy* on top of the returned
 /// [`AcceptQualities`] (they differ only in policy, not parsing).
@@ -419,7 +423,10 @@ pub fn accept_qualities(headers: &axum::http::HeaderMap) -> AcceptQualities {
                 continue;
             }
 
-            if let Some(value) = segment.strip_prefix("q=")
+            // Parameter names are case-insensitive (RFC 7231 §3.1.1.1), so the
+            // quality parameter may arrive as `q=` or `Q=`.
+            if let Some((name, value)) = segment.split_once('=')
+                && name.trim().eq_ignore_ascii_case("q")
                 && let Ok(parsed) = value.trim().parse::<f32>()
             {
                 q = parsed.clamp(0.0, 1.0);
@@ -432,42 +439,41 @@ pub fn accept_qualities(headers: &axum::http::HeaderMap) -> AcceptQualities {
         // legacy `accept_preference`/`accept_prefers_html` path) filter these
         // `q == 0` slots back out; the `Negotiate` responder honours them as
         // explicit exclusions.
-        match mime {
-            "text/html" if qualities.html.is_none_or(|(existing_q, _)| q > existing_q) => {
-                qualities.html = Some((q, index));
-            }
-            "application/json" if qualities.json.is_none_or(|(existing_q, _)| q > existing_q) => {
-                qualities.json = Some((q, index));
-            }
-            "application/problem+json"
-                if qualities
-                    .problem_json
-                    .is_none_or(|(existing_q, _)| q > existing_q) =>
-            {
-                qualities.problem_json = Some((q, index));
-            }
-            "text/*"
-                if qualities
-                    .text_star
-                    .is_none_or(|(existing_q, _)| q > existing_q) =>
-            {
-                qualities.text_star = Some((q, index));
-            }
-            "application/*"
-                if qualities
-                    .application_star
-                    .is_none_or(|(existing_q, _)| q > existing_q) =>
-            {
-                qualities.application_star = Some((q, index));
-            }
-            "*/*"
-                if qualities
-                    .wildcard
-                    .is_none_or(|(existing_q, _)| q > existing_q) =>
-            {
-                qualities.wildcard = Some((q, index));
-            }
-            _ => {}
+        // Media types and subtypes are case-insensitive (RFC 7231 §3.1.1.1), so
+        // `Application/JSON` must record the same slot as `application/json`.
+        // Compare without allocating a lowercased copy of the token.
+        if mime.eq_ignore_ascii_case("text/html")
+            && qualities.html.is_none_or(|(existing_q, _)| q > existing_q)
+        {
+            qualities.html = Some((q, index));
+        } else if mime.eq_ignore_ascii_case("application/json")
+            && qualities.json.is_none_or(|(existing_q, _)| q > existing_q)
+        {
+            qualities.json = Some((q, index));
+        } else if mime.eq_ignore_ascii_case("application/problem+json")
+            && qualities
+                .problem_json
+                .is_none_or(|(existing_q, _)| q > existing_q)
+        {
+            qualities.problem_json = Some((q, index));
+        } else if mime.eq_ignore_ascii_case("text/*")
+            && qualities
+                .text_star
+                .is_none_or(|(existing_q, _)| q > existing_q)
+        {
+            qualities.text_star = Some((q, index));
+        } else if mime.eq_ignore_ascii_case("application/*")
+            && qualities
+                .application_star
+                .is_none_or(|(existing_q, _)| q > existing_q)
+        {
+            qualities.application_star = Some((q, index));
+        } else if mime.eq_ignore_ascii_case("*/*")
+            && qualities
+                .wildcard
+                .is_none_or(|(existing_q, _)| q > existing_q)
+        {
+            qualities.wildcard = Some((q, index));
         }
     }
 
@@ -995,6 +1001,53 @@ mod tests {
         let json = header_map("application/json");
         assert_eq!(accept_preference(&json), AcceptPreference::Json);
         assert!(!accept_prefers_html(&json));
+    }
+
+    #[test]
+    fn accept_qualities_matches_media_types_case_insensitively() {
+        // Media types are case-insensitive (RFC 7231 §3.1.1.1): a mixed-case
+        // token must record the same slot as its lowercase form.
+        let json = accept_qualities(&header_map("Application/JSON"));
+        assert_eq!(json.json, Some((1.0, 0)));
+        assert_eq!(json.html, None);
+
+        let html = accept_qualities(&header_map("TEXT/HTML"));
+        assert_eq!(html.html, Some((1.0, 0)));
+        assert_eq!(html.json, None);
+
+        // Subtype wildcard is case-insensitive too.
+        let app_star = accept_qualities(&header_map("APPLICATION/*;q=1"));
+        assert_eq!(app_star.application_star, Some((1.0, 0)));
+    }
+
+    #[test]
+    fn accept_qualities_matches_q_parameter_case_insensitively() {
+        // Parameter names are case-insensitive: `Q=` must be honoured like `q=`.
+        let q = accept_qualities(&header_map("text/html;Q=0.9, application/json;Q=1.0"));
+        assert_eq!(q.html, Some((0.9, 0)));
+        assert_eq!(q.json, Some((1.0, 1)));
+    }
+
+    #[test]
+    fn accept_prefers_html_honours_case_insensitive_tokens() {
+        // Mixed-case JSON must not fall back to the HTML default.
+        assert!(!accept_prefers_html(&header_map("Application/JSON")));
+        assert_eq!(
+            accept_preference(&header_map("Application/JSON")),
+            AcceptPreference::Json
+        );
+
+        // Mixed-case HTML still prefers HTML.
+        assert!(accept_prefers_html(&header_map("TEXT/HTML")));
+        assert_eq!(
+            accept_preference(&header_map("TEXT/HTML")),
+            AcceptPreference::Html
+        );
+
+        // Uppercase Q honoured: JSON has the higher q and wins.
+        assert!(!accept_prefers_html(&header_map(
+            "text/html;Q=0.9, application/json;Q=1.0"
+        )));
     }
 
     // ── Integration tests with the full middleware pipeline ──────

--- a/autumn/src/middleware/error_page_filter.rs
+++ b/autumn/src/middleware/error_page_filter.rs
@@ -296,16 +296,49 @@ fn accepts_html<B>(req: &axum::http::Request<B>) -> bool {
     accept_prefers_html(req.headers())
 }
 
+/// Which representation the client's `Accept` header prefers.
+///
+/// Produced by the single canonical negotiator [`accept_preference`]; the
+/// public [`accept_prefers_html`] wrapper is defined in terms of it so all
+/// content negotiation in the crate shares one source of truth.
+// `pub` here is crate-visible only: the enclosing `error_page_filter` module is
+// itself `pub(crate)`, so this never escapes the crate (clippy::redundant_pub_crate).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AcceptPreference {
+    /// `text/html` wins (explicitly or via q-values).
+    Html,
+    /// `application/json` (or `application/problem+json`) wins.
+    Json,
+    /// Only `*/*` present — no concrete html/json preference.
+    Any,
+    /// No `Accept` header, or it was empty.
+    Unspecified,
+}
+
 /// Check whether an Accept header prefers an HTML response over JSON.
 pub fn accept_prefers_html(headers: &axum::http::HeaderMap) -> bool {
+    matches!(
+        accept_preference(headers),
+        AcceptPreference::Html | AcceptPreference::Any
+    )
+}
+
+/// The one canonical q-value `Accept` negotiator.
+///
+/// Returns the client's concrete representation preference. Empty or missing
+/// `Accept` yields [`AcceptPreference::Unspecified`]; a `*/*`-only header
+/// yields [`AcceptPreference::Any`]. When both `text/html` and
+/// `application/json` are present, the higher q-value wins, ties broken by
+/// earlier list position.
+pub fn accept_preference(headers: &axum::http::HeaderMap) -> AcceptPreference {
     let accept = headers
         .get(axum::http::header::ACCEPT)
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
 
-    // If no Accept header, default to JSON (API-first).
+    // If no Accept header, there is no concrete preference.
     if accept.is_empty() {
-        return false;
+        return AcceptPreference::Unspecified;
     }
 
     let mut html: Option<(f32, usize)> = None;
@@ -356,14 +389,20 @@ pub fn accept_prefers_html(headers: &axum::http::HeaderMap) -> bool {
 
     match (html, json, wildcard) {
         (Some((hq, hidx)), Some((jq, jidx)), _) => {
-            if (hq - jq).abs() < f32::EPSILON {
+            let html_wins = if (hq - jq).abs() < f32::EPSILON {
                 hidx < jidx
             } else {
                 hq > jq
+            };
+            if html_wins {
+                AcceptPreference::Html
+            } else {
+                AcceptPreference::Json
             }
         }
-        (Some(_), None, _) | (None, None, Some(_)) => true,
-        (None, Some(_), _) | (None, None, None) => false,
+        (Some(_), None, _) => AcceptPreference::Html,
+        (None, None, Some(_)) => AcceptPreference::Any,
+        (None, Some(_), _) | (None, None, None) => AcceptPreference::Json,
     }
 }
 
@@ -758,6 +797,48 @@ mod tests {
             .body(Body::empty())
             .unwrap();
         assert!(accepts_html(&req));
+    }
+
+    #[test]
+    fn prefers_html_for_ac_tie_case() {
+        // Acceptance-criteria case: html has the higher q-value and wins.
+        let headers = header_map("application/json;q=0.9, text/html;q=1.0");
+        assert!(accept_prefers_html(&headers));
+        assert_eq!(accept_preference(&headers), AcceptPreference::Html);
+    }
+
+    /// Build a `HeaderMap` with a single `Accept` header for direct
+    /// [`accept_preference`] / [`accept_prefers_html`] assertions.
+    fn header_map(accept: &str) -> axum::http::HeaderMap {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            axum::http::header::ACCEPT,
+            axum::http::HeaderValue::from_str(accept).unwrap(),
+        );
+        headers
+    }
+
+    #[test]
+    fn accept_preference_maps_cases_and_wrapper_is_unchanged() {
+        // Empty / missing header → Unspecified, wrapper → false.
+        let empty = axum::http::HeaderMap::new();
+        assert_eq!(accept_preference(&empty), AcceptPreference::Unspecified);
+        assert!(!accept_prefers_html(&empty));
+
+        // `*/*` only → Any, wrapper → true.
+        let any = header_map("*/*");
+        assert_eq!(accept_preference(&any), AcceptPreference::Any);
+        assert!(accept_prefers_html(&any));
+
+        // `text/html` → Html, wrapper → true.
+        let html = header_map("text/html");
+        assert_eq!(accept_preference(&html), AcceptPreference::Html);
+        assert!(accept_prefers_html(&html));
+
+        // `application/json` → Json, wrapper → false.
+        let json = header_map("application/json");
+        assert_eq!(accept_preference(&json), AcceptPreference::Json);
+        assert!(!accept_prefers_html(&json));
     }
 
     // ── Integration tests with the full middleware pipeline ──────

--- a/autumn/src/middleware/error_page_filter.rs
+++ b/autumn/src/middleware/error_page_filter.rs
@@ -345,6 +345,23 @@ pub struct AcceptQualities {
     pub html: Option<(f32, usize)>,
     /// Best match for `application/json` / `application/problem+json`.
     pub json: Option<(f32, usize)>,
+    /// Best match for the `text/*` subtype wildcard.
+    ///
+    /// A media range like `text/*` covers `text/html` per RFC 7231 §5.3.2 but is
+    /// less specific than a concrete `text/html`. Recorded like the other slots
+    /// (max-q including `q=0`, plus list index) so the `Negotiate` responder can
+    /// slot it between the concrete type and the `*/*` wildcard. The legacy
+    /// `accept_preference`/`accept_prefers_html` path ignores it.
+    pub text_star: Option<(f32, usize)>,
+    /// Best match for the `application/*` subtype wildcard.
+    ///
+    /// A media range like `application/*` covers `application/json` per RFC 7231
+    /// §5.3.2 but is less specific than a concrete `application/json`. Recorded
+    /// like the other slots (max-q including `q=0`, plus list index) so the
+    /// `Negotiate` responder can slot it between the concrete type and the `*/*`
+    /// wildcard. The legacy `accept_preference`/`accept_prefers_html` path
+    /// ignores it.
+    pub application_star: Option<(f32, usize)>,
     /// Best match for the `*/*` wildcard.
     pub wildcard: Option<(f32, usize)>,
 }
@@ -353,7 +370,8 @@ pub struct AcceptQualities {
 ///
 /// Scans the comma-separated `Accept` header once, recording the best
 /// `(q-value, list-index)` seen for `text/html`, for `application/json` /
-/// `application/problem+json`, and for the `*/*` wildcard. Out-of-range
+/// `application/problem+json`, for the `text/*` and `application/*` subtype
+/// wildcards, and for the `*/*` wildcard. Out-of-range
 /// q-values are clamped to `[0.0, 1.0]`. Entries with `q=0` are *retained*
 /// (recorded as `Some((0.0, index))`) so an explicit "not acceptable"
 /// exclusion survives; each consumer decides how to treat them.
@@ -407,6 +425,20 @@ pub fn accept_qualities(headers: &axum::http::HeaderMap) -> AcceptQualities {
             {
                 qualities.json = Some((q, index));
             }
+            "text/*"
+                if qualities
+                    .text_star
+                    .is_none_or(|(existing_q, _)| q > existing_q) =>
+            {
+                qualities.text_star = Some((q, index));
+            }
+            "application/*"
+                if qualities
+                    .application_star
+                    .is_none_or(|(existing_q, _)| q > existing_q) =>
+            {
+                qualities.application_star = Some((q, index));
+            }
             "*/*"
                 if qualities
                     .wildcard
@@ -441,10 +473,14 @@ pub fn accept_preference(headers: &axum::http::HeaderMap) -> AcceptPreference {
         return AcceptPreference::Unspecified;
     }
 
+    // The legacy enum negotiator predates type wildcards and intentionally does
+    // not consult the `text/*` / `application/*` slots — only the concrete types
+    // and the `*/*` wildcard — so `accept_prefers_html` stays byte-identical.
     let AcceptQualities {
         html,
         json,
         wildcard,
+        ..
     } = accept_qualities(headers);
 
     // Legacy resolution only cares about *positive* preference: a `q=0` slot

--- a/autumn/src/middleware/error_page_filter.rs
+++ b/autumn/src/middleware/error_page_filter.rs
@@ -329,8 +329,11 @@ pub fn accept_prefers_html(headers: &axum::http::HeaderMap) -> bool {
 ///
 /// `index` is the position of the winning entry in the comma-separated header
 /// (0-based), used to break q-value ties in favour of the earlier entry. Each
-/// field is `None` when that media type was absent or fully demoted (`q=0`).
-/// Both [`accept_preference`] (legacy enum resolution) and the
+/// field is `None` only when that media type was entirely absent from the
+/// header; a media type listed with `q=0` records `Some((0.0, index))` so an
+/// explicit "not acceptable" exclusion (RFC 7231 §5.3.1) stays distinguishable
+/// from a mere absence. Both [`accept_preference`] (legacy enum resolution) and
+/// the
 /// [`Negotiate`](crate::negotiate::Negotiate) responder (effective-q
 /// resolution) build on this shared parse, so the crate never forks its
 /// `Accept` parsing.
@@ -350,8 +353,10 @@ pub struct AcceptQualities {
 ///
 /// Scans the comma-separated `Accept` header once, recording the best
 /// `(q-value, list-index)` seen for `text/html`, for `application/json` /
-/// `application/problem+json`, and for the `*/*` wildcard. Entries demoted to
-/// `q=0` are dropped, and out-of-range q-values are clamped to `[0.0, 1.0]`.
+/// `application/problem+json`, and for the `*/*` wildcard. Out-of-range
+/// q-values are clamped to `[0.0, 1.0]`. Entries with `q=0` are *retained*
+/// (recorded as `Some((0.0, index))`) so an explicit "not acceptable"
+/// exclusion survives; each consumer decides how to treat them.
 ///
 /// This is the crate's single source of truth for `Accept` tokenisation; the
 /// two consumers apply their own *resolution policy* on top of the returned
@@ -386,10 +391,13 @@ pub fn accept_qualities(headers: &axum::http::HeaderMap) -> AcceptQualities {
                 q = parsed.clamp(0.0, 1.0);
             }
         }
-        if q <= 0.0 {
-            continue;
-        }
 
+        // Record the entry even when `q == 0`: an explicit `q=0` means the type
+        // is *not acceptable* (RFC 7231 §5.3.1), which is distinct from the type
+        // being absent. Consumers that only care about positive preference (the
+        // legacy `accept_preference`/`accept_prefers_html` path) filter these
+        // `q == 0` slots back out; the `Negotiate` responder honours them as
+        // explicit exclusions.
         match mime {
             "text/html" if qualities.html.is_none_or(|(existing_q, _)| q > existing_q) => {
                 qualities.html = Some((q, index));
@@ -438,6 +446,12 @@ pub fn accept_preference(headers: &axum::http::HeaderMap) -> AcceptPreference {
         json,
         wildcard,
     } = accept_qualities(headers);
+
+    // Legacy resolution only cares about *positive* preference: a `q=0` slot
+    // (now retained by the shared parser) is treated as absent here, exactly
+    // reproducing the pre-`q=0`-aware behaviour of this enum negotiator.
+    let positive = |slot: Option<(f32, usize)>| slot.filter(|&(q, _)| q > 0.0);
+    let (html, json, wildcard) = (positive(html), positive(json), positive(wildcard));
 
     match (html, json, wildcard) {
         (Some((hq, hidx)), Some((jq, jidx)), _) => {

--- a/autumn/src/negotiate.rs
+++ b/autumn/src/negotiate.rs
@@ -1,0 +1,136 @@
+//! Content-negotiated success responder.
+//!
+//! One handler can serve HTML to browsers and JSON to API clients from a
+//! single source of truth. Declare the [`Negotiate`] extractor, then hand it a
+//! Maud closure and a serializable value via [`Negotiate::respond`]:
+//!
+//! ```rust,ignore
+//! use autumn_web::prelude::*;
+//!
+//! #[get("/widgets/{id}")]
+//! async fn show(negotiate: Negotiate) -> impl IntoResponse {
+//!     let widget = Widget { id: 1, name: "spanner".into() };
+//!     negotiate.respond(
+//!         || html! { h1 { (widget.name) } },
+//!         widget,
+//!     )
+//! }
+//! ```
+//!
+//! The client's `Accept` header decides the representation, reusing the crate's
+//! one canonical q-value negotiator. When the client expresses no concrete
+//! preference (`*/*` or a missing `Accept`), the default is
+//! [`Format::Html`] (browser-first); override it with
+//! [`Negotiate::default_format`]. Responses carry `Vary: Accept` so shared
+//! caches key the two representations separately.
+
+use std::convert::Infallible;
+
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use axum::response::{IntoResponse, Response};
+use http::header::{HeaderValue, VARY};
+
+use crate::middleware::error_page_filter::{AcceptPreference, accept_preference};
+
+/// The representation a handler can produce.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Format {
+    /// An HTML document (`text/html`).
+    Html,
+    /// A JSON document (`application/json`).
+    Json,
+}
+
+/// Extractor capturing the request's `Accept` preference so one handler serves
+/// HTML or JSON from a single source of truth.
+///
+/// When the client has no concrete preference (`*/*` or a missing `Accept`),
+/// the default is [`Format::Html`] (browser-first); override it with
+/// [`Negotiate::default_format`].
+#[derive(Debug, Clone, Copy)]
+pub struct Negotiate {
+    preference: AcceptPreference,
+    default: Format,
+}
+
+impl Negotiate {
+    /// Override the format used when the client expresses no concrete
+    /// preference (`*/*` or a missing `Accept`). Defaults to [`Format::Html`].
+    #[must_use]
+    pub const fn default_format(mut self, default: Format) -> Self {
+        self.default = default;
+        self
+    }
+
+    /// The resolved representation: a direct `text/html` / `application/json`
+    /// preference maps straight through, while `*/*` or an unspecified
+    /// `Accept` falls back to the configured default.
+    #[must_use]
+    pub const fn format(&self) -> Format {
+        match self.preference {
+            AcceptPreference::Html => Format::Html,
+            AcceptPreference::Json => Format::Json,
+            AcceptPreference::Any | AcceptPreference::Unspecified => self.default,
+        }
+    }
+
+    /// Serve `html` to browser clients and `json` to API clients.
+    ///
+    /// The `html` closure runs only when HTML is the chosen representation, so
+    /// the markup is never rendered for an API response.
+    #[must_use]
+    pub const fn respond<F, J>(self, html: F, json: J) -> Negotiated<F, J>
+    where
+        F: FnOnce() -> maud::Markup,
+        J: serde::Serialize,
+    {
+        Negotiated {
+            format: self.format(),
+            html,
+            json,
+        }
+    }
+}
+
+impl<S> FromRequestParts<S> for Negotiate
+where
+    S: Send + Sync,
+{
+    type Rejection = Infallible;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(Self {
+            preference: accept_preference(&parts.headers),
+            default: Format::Html,
+        })
+    }
+}
+
+/// The response produced by [`Negotiate::respond`].
+///
+/// Renders the HTML closure or serializes the JSON value depending on the
+/// negotiated [`Format`], and always appends `Vary: Accept`.
+pub struct Negotiated<F, J> {
+    format: Format,
+    html: F,
+    json: J,
+}
+
+impl<F, J> IntoResponse for Negotiated<F, J>
+where
+    F: FnOnce() -> maud::Markup,
+    J: serde::Serialize,
+{
+    fn into_response(self) -> Response {
+        let mut response = match self.format {
+            Format::Html => (self.html)().into_response(),
+            Format::Json => axum::Json(self.json).into_response(),
+        };
+        // Append (never insert) so any existing Vary values are preserved.
+        response
+            .headers_mut()
+            .append(VARY, HeaderValue::from_static("Accept"));
+        response
+    }
+}

--- a/autumn/src/negotiate.rs
+++ b/autumn/src/negotiate.rs
@@ -27,7 +27,16 @@
 //! `type/subtype` > `type/*` > `*/*`: `text/html` is covered by
 //! `text/html.or(text/*).or(*/*)` and JSON by
 //! `application/json.or(application/*).or(*/*)`. The higher effective q wins; on
-//! a tie the earlier list entry wins. So `Accept: text/html;q=0.1, */*;q=1`
+//! a tie the earlier list entry wins.
+//!
+//! `application/problem+json` is deliberately **not** part of the JSON tier: it
+//! is an error-path (Problem Details) signal, not a success representation, so
+//! advertising it alone does not count as accepting the `application/json`
+//! success body. A request whose `Accept` names only `application/problem+json`
+//! leaves both HTML and JSON unmentioned and falls back to the configured
+//! default, exactly like any other unhandled type (e.g. `application/xml`).
+//!
+//! So `Accept: text/html;q=0.1, */*;q=1`
 //! serves **JSON** — `text/html` is explicitly demoted to `q=0.1` while
 //! `*/*;q=1` lifts JSON to `q=1` — rather than being fooled by the bare presence
 //! of `text/html`. Likewise `Accept: text/*;q=0, */*;q=1` serves **JSON**: the
@@ -503,6 +512,80 @@ mod tests {
         assert_eq!(
             negotiate(Some("text/html;q=0.1, */*;q=1")).resolve(),
             Resolution::Json,
+        );
+    }
+
+    // ── `application/problem+json` is an error-path signal, not success JSON ──
+
+    #[test]
+    fn problem_json_alone_uses_html_default() {
+        // `application/problem+json` is an error-path (Problem Details) signal,
+        // not the success `application/json` body. Alone it leaves both HTML and
+        // JSON unmentioned, so the HTML default applies — it must NOT select JSON.
+        assert_eq!(
+            negotiate(Some("application/problem+json")).resolve(),
+            Resolution::Html,
+        );
+        assert_eq!(
+            negotiate(Some("application/problem+json")).format(),
+            Format::Html,
+        );
+    }
+
+    #[test]
+    fn problem_json_alone_uses_json_default_via_default_not_match() {
+        // With a JSON default, problem+json alone still falls through to the
+        // default (both formats unmentioned) — JSON is served *because it is the
+        // default*, not because problem+json matched the success JSON slot.
+        assert_eq!(
+            negotiate(Some("application/problem+json"))
+                .default_format(Format::Json)
+                .resolve(),
+            Resolution::Json,
+        );
+        assert_eq!(
+            negotiate(Some("application/problem+json"))
+                .default_format(Format::Json)
+                .format(),
+            Format::Json,
+        );
+    }
+
+    #[test]
+    fn plain_json_serves_json() {
+        // Regression: the success `application/json` type still negotiates JSON.
+        assert_eq!(
+            negotiate(Some("application/json")).resolve(),
+            Resolution::Json,
+        );
+        assert_eq!(negotiate(Some("application/json")).format(), Format::Json);
+    }
+
+    #[test]
+    fn json_and_problem_json_serves_json() {
+        // `application/json` is present (alongside the problem+json error
+        // signal), so the success JSON body is negotiated.
+        assert_eq!(
+            negotiate(Some("application/json, application/problem+json")).resolve(),
+            Resolution::Json,
+        );
+        assert_eq!(
+            negotiate(Some("application/json, application/problem+json")).format(),
+            Format::Json,
+        );
+    }
+
+    #[test]
+    fn problem_json_with_html_serves_html() {
+        // problem+json does not lift the JSON tier, and text/html is present, so
+        // HTML wins outright.
+        assert_eq!(
+            negotiate(Some("application/problem+json, text/html")).resolve(),
+            Resolution::Html,
+        );
+        assert_eq!(
+            negotiate(Some("application/problem+json, text/html")).format(),
+            Format::Html,
         );
     }
 

--- a/autumn/src/negotiate.rs
+++ b/autumn/src/negotiate.rs
@@ -29,11 +29,27 @@
 //! explicitly demoted to `q=0.1` while `*/*;q=1` lifts JSON to `q=1` — rather
 //! than being fooled by the bare presence of `text/html`.
 //!
+//! ## `q=0` exclusions and `406 Not Acceptable`
+//!
+//! A media range listed with `q=0` means "**not acceptable**" (RFC 7231
+//! §5.3.1), not merely "less preferred". A format whose effective q is `0`
+//! (because it, or the `*/*` it would inherit from, was explicitly demoted to
+//! `q=0`) is *forbidden*: it is never served, not via the wildcard and not via
+//! the configured default. So `Accept: text/html;q=0, */*;q=1` serves **JSON**
+//! (HTML is forbidden; `*/*` still covers JSON), and `application/json;q=0`
+//! serves **HTML** even under `default_format(Format::Json)` (the default may
+//! not resurrect a forbidden format). When *both* HTML and JSON are forbidden
+//! (e.g. `text/html;q=0, application/json;q=0`, or a bare `*/*;q=0`) the
+//! responder answers **`406 Not Acceptable`** with a short plain-text body.
+//! Merely *unlisted* types are not exclusions — an `Accept` naming only, say,
+//! `application/xml` leaves both HTML and JSON unmentioned and falls back to the
+//! default, never a 406.
+//!
 //! When the client expresses no concrete preference — a missing/empty `Accept`,
 //! a bare `*/*`, or a wildcard-only tie where neither side is named directly —
 //! the default is [`Format::Html`] (browser-first); override it with
 //! [`Negotiate::default_format`]. Responses carry `Vary: Accept` so shared
-//! caches key the two representations separately.
+//! caches key the two representations separately — including the `406` arm.
 
 use std::convert::Infallible;
 
@@ -76,45 +92,115 @@ impl Negotiate {
 
     /// The resolved representation, chosen by *effective* q-value.
     ///
+    /// A convenience view over [`Negotiate::resolve`] that collapses the
+    /// not-acceptable case onto the configured `default`: it answers the
+    /// question "which representation would be served if one *must* be" and so
+    /// cannot express a `406`. Prefer [`Negotiate::respond`] for the full
+    /// behaviour — only it emits `406 Not Acceptable` when both formats are
+    /// forbidden.
+    ///
     /// Each candidate's effective quality folds in the `*/*` wildcard —
     /// `html.or(wildcard)` for HTML and `json.or(wildcard)` for JSON — so a
     /// high-q wildcard can outrank an explicitly demoted concrete type (RFC 7231
-    /// content negotiation). The higher effective q wins; on a tie the earlier
+    /// content negotiation). A format whose effective q is `0` is forbidden and
+    /// never chosen. The higher positive effective q wins; on a tie the earlier
     /// list entry wins. When neither side is named directly (both effective
     /// values come from the same `*/*` entry, or there is no `Accept` at all)
     /// there is no real preference, so the configured `default` applies.
     #[must_use]
     pub fn format(&self) -> Format {
+        match self.resolve() {
+            Resolution::Html => Format::Html,
+            Resolution::Json => Format::Json,
+            // Both formats are forbidden; there is no acceptable representation.
+            // Collapse onto the default for this lossy view — `respond` emits a
+            // real `406` for this case instead.
+            Resolution::NotAcceptable => self.default,
+        }
+    }
+
+    /// Resolve the request's `Accept` header into a concrete decision, honouring
+    /// `q=0` exclusions and reporting [`Resolution::NotAcceptable`] when every
+    /// format the handler can produce has been explicitly forbidden.
+    ///
+    /// For each format `F` in {HTML, JSON} the *effective* quality `q_F` is `F`'s
+    /// own explicit max-q if `F` was listed at all (**including `q=0`**), else
+    /// the `*/*` wildcard's explicit max-q if `*/*` was listed (including `q=0`),
+    /// else `None` (unmentioned). Then:
+    ///
+    /// * `q_F == Some(0.0)` → `F` is **forbidden** (never served — not via the
+    ///   wildcard, not via the default).
+    /// * Among non-forbidden formats, one with `q_F == Some(>0)` is a *positive
+    ///   candidate*; the higher positive q wins, ties broken by earlier list
+    ///   index. A tie at the *same* index means both derive from one `*/*` entry
+    ///   (no concrete preference) → the `default`, restricted to non-forbidden
+    ///   formats.
+    /// * If neither is positive but at least one non-forbidden format is
+    ///   unmentioned → the `default`, falling back to the other non-forbidden
+    ///   format if the default itself is forbidden.
+    /// * If **both** formats are forbidden → [`Resolution::NotAcceptable`].
+    fn resolve(&self) -> Resolution {
         let html_eff = self.qualities.html.or(self.qualities.wildcard);
         let json_eff = self.qualities.json.or(self.qualities.wildcard);
 
-        match (html_eff, json_eff) {
+        let html_forbidden = matches!(html_eff, Some((q, _)) if q <= 0.0);
+        let json_forbidden = matches!(json_eff, Some((q, _)) if q <= 0.0);
+
+        // No representation is acceptable to the client.
+        if html_forbidden && json_forbidden {
+            return Resolution::NotAcceptable;
+        }
+
+        // Positive candidates: listed (directly or via `*/*`) with q > 0.
+        let html_pos = html_eff.filter(|&(q, _)| q > 0.0);
+        let json_pos = json_eff.filter(|&(q, _)| q > 0.0);
+
+        match (html_pos, json_pos) {
             (Some((hq, hidx)), Some((jq, jidx))) => {
                 if (hq - jq).abs() < f32::EPSILON {
-                    // Equal effective q: the earlier list entry wins. Equal
-                    // index means both sides resolved to the *same* `*/*` entry,
-                    // i.e. no concrete preference — fall back to the default.
+                    // Equal effective q: earlier list entry wins. Equal index
+                    // means both sides resolved to the *same* `*/*` entry, i.e.
+                    // no concrete preference — fall back to the default.
                     match hidx.cmp(&jidx) {
-                        std::cmp::Ordering::Less => Format::Html,
-                        std::cmp::Ordering::Greater => Format::Json,
-                        std::cmp::Ordering::Equal => self.default,
+                        std::cmp::Ordering::Less => Resolution::Html,
+                        std::cmp::Ordering::Greater => Resolution::Json,
+                        std::cmp::Ordering::Equal => {
+                            self.default_resolution(html_forbidden, json_forbidden)
+                        }
                     }
                 } else if hq > jq {
-                    Format::Html
+                    Resolution::Html
                 } else {
-                    Format::Json
+                    Resolution::Json
                 }
             }
-            (Some(_), None) => Format::Html,
-            (None, Some(_)) => Format::Json,
-            (None, None) => self.default,
+            // The other side is forbidden or unmentioned; the positive one wins.
+            (Some(_), None) => Resolution::Html,
+            (None, Some(_)) => Resolution::Json,
+            // Neither is a positive candidate, but they are not both forbidden,
+            // so at least one is non-forbidden and unmentioned: use the default.
+            (None, None) => self.default_resolution(html_forbidden, json_forbidden),
+        }
+    }
+
+    /// The configured `default` as a [`Resolution`], but never a forbidden
+    /// format: if the default itself is forbidden, serve the other side (which
+    /// callers guarantee is non-forbidden in every context this is reached).
+    const fn default_resolution(&self, html_forbidden: bool, json_forbidden: bool) -> Resolution {
+        match self.default {
+            Format::Html if html_forbidden => Resolution::Json,
+            Format::Html => Resolution::Html,
+            Format::Json if json_forbidden => Resolution::Html,
+            Format::Json => Resolution::Json,
         }
     }
 
     /// Serve `html` to browser clients and `json` to API clients.
     ///
     /// The `html` closure runs only when HTML is the chosen representation, so
-    /// the markup is never rendered for an API response.
+    /// the markup is never rendered for an API response. When the client has
+    /// forbidden every representation the handler can produce (via `q=0`), the
+    /// response is `406 Not Acceptable` and neither branch runs.
     #[must_use]
     pub fn respond<F, J>(self, html: F, json: J) -> Negotiated<F, J>
     where
@@ -122,11 +208,26 @@ impl Negotiate {
         J: serde::Serialize,
     {
         Negotiated {
-            format: self.format(),
+            resolution: self.resolve(),
             html,
             json,
         }
     }
+}
+
+/// A resolved content-negotiation decision for the [`Negotiate`] responder.
+///
+/// Unlike [`Format`], this can express that the client forbade every
+/// representation the handler can produce, which the responder answers with
+/// `406 Not Acceptable`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Resolution {
+    /// Serve the HTML representation.
+    Html,
+    /// Serve the JSON representation.
+    Json,
+    /// Every producible format was forbidden (`q=0`) — answer `406`.
+    NotAcceptable,
 }
 
 impl<S> FromRequestParts<S> for Negotiate
@@ -146,9 +247,10 @@ where
 /// The response produced by [`Negotiate::respond`].
 ///
 /// Renders the HTML closure or serializes the JSON value depending on the
-/// negotiated [`Format`], and always appends `Vary: Accept`.
+/// negotiated [`Resolution`], answers `406 Not Acceptable` when the client
+/// forbade every producible representation, and always appends `Vary: Accept`.
 pub struct Negotiated<F, J> {
-    format: Format,
+    resolution: Resolution,
     html: F,
     json: J,
 }
@@ -159,11 +261,18 @@ where
     J: serde::Serialize,
 {
     fn into_response(self) -> Response {
-        let mut response = match self.format {
-            Format::Html => (self.html)().into_response(),
-            Format::Json => axum::Json(self.json).into_response(),
+        let mut response = match self.resolution {
+            Resolution::Html => (self.html)().into_response(),
+            Resolution::Json => axum::Json(self.json).into_response(),
+            Resolution::NotAcceptable => (
+                http::StatusCode::NOT_ACCEPTABLE,
+                "406 Not Acceptable: no acceptable representation for this resource",
+            )
+                .into_response(),
         };
-        // Append (never insert) so any existing Vary values are preserved.
+        // Append (never insert) so any existing Vary values are preserved. This
+        // is done on every arm, including the `406`, so shared caches still key
+        // the negotiated representations separately.
         response
             .headers_mut()
             .append(VARY, HeaderValue::from_static("Accept"));
@@ -242,5 +351,101 @@ mod tests {
             negotiate(None).default_format(Format::Json).format(),
             Format::Json,
         );
+    }
+
+    // ── `q=0` exclusions (RFC 7231 §5.3.1) and `406 Not Acceptable` ──────────
+
+    #[test]
+    fn forbidden_html_falls_through_to_wildcard_json() {
+        // `text/html;q=0` forbids HTML; `*/*;q=1` still covers JSON, so JSON is
+        // served rather than the default resurrecting the rejected HTML.
+        assert_eq!(
+            negotiate(Some("text/html;q=0, */*;q=1")).resolve(),
+            Resolution::Json,
+        );
+    }
+
+    #[test]
+    fn forbidden_json_not_resurrected_by_default() {
+        // JSON is explicitly forbidden; even a JSON default must not serve it,
+        // so the non-forbidden HTML is served instead.
+        assert_eq!(
+            negotiate(Some("application/json;q=0"))
+                .default_format(Format::Json)
+                .resolve(),
+            Resolution::Html,
+        );
+    }
+
+    #[test]
+    fn both_formats_forbidden_is_not_acceptable() {
+        assert_eq!(
+            negotiate(Some("text/html;q=0, application/json;q=0")).resolve(),
+            Resolution::NotAcceptable,
+        );
+    }
+
+    #[test]
+    fn wildcard_forbidden_is_not_acceptable() {
+        // A bare `*/*;q=0` forbids every representation the handler can produce.
+        assert_eq!(
+            negotiate(Some("*/*;q=0")).resolve(),
+            Resolution::NotAcceptable
+        );
+        // The JSON default cannot rescue it either.
+        assert_eq!(
+            negotiate(Some("*/*;q=0"))
+                .default_format(Format::Json)
+                .resolve(),
+            Resolution::NotAcceptable,
+        );
+    }
+
+    #[test]
+    fn unlisted_type_is_not_an_exclusion() {
+        // Naming only an unrelated type leaves HTML and JSON unmentioned (not
+        // forbidden): fall back to the default, never a 406.
+        assert_eq!(
+            negotiate(Some("application/xml")).resolve(),
+            Resolution::Html,
+        );
+        assert_eq!(
+            negotiate(Some("application/xml"))
+                .default_format(Format::Json)
+                .resolve(),
+            Resolution::Json,
+        );
+    }
+
+    #[test]
+    fn demoted_but_positive_html_still_loses_to_wildcard() {
+        // Regression: `q=0.1` is a demotion, not an exclusion, and JSON (lifted
+        // by `*/*;q=1`) still wins on effective q.
+        assert_eq!(
+            negotiate(Some("text/html;q=0.1, */*;q=1")).resolve(),
+            Resolution::Json,
+        );
+    }
+
+    #[test]
+    fn resolve_matches_format_for_non_forbidden_cases() {
+        // The lossy `format()` view agrees with `resolve()` whenever a
+        // representation is actually acceptable.
+        for accept in [
+            Some("text/html"),
+            Some("application/json"),
+            Some("application/json;q=0.9, text/html;q=1.0"),
+            Some("text/html;q=1, */*;q=1"),
+            Some("*/*"),
+            None,
+        ] {
+            let n = negotiate(accept);
+            let expected = match n.resolve() {
+                Resolution::Html => Format::Html,
+                Resolution::Json => Format::Json,
+                Resolution::NotAcceptable => unreachable!("no forbidden case here"),
+            };
+            assert_eq!(n.format(), expected, "accept={accept:?}");
+        }
     }
 }

--- a/autumn/src/negotiate.rs
+++ b/autumn/src/negotiate.rs
@@ -18,9 +18,20 @@
 //! ```
 //!
 //! The client's `Accept` header decides the representation, reusing the crate's
-//! one canonical q-value negotiator. When the client expresses no concrete
-//! preference (`*/*` or a missing `Accept`), the default is
-//! [`Format::Html`] (browser-first); override it with
+//! one canonical `Accept` parser ([`accept_qualities`]) and resolving over
+//! *effective* q-values that honour the `*/*` wildcard per RFC 7231 content
+//! negotiation.
+//!
+//! Each candidate's effective q-value is the better of its own explicit entry
+//! and any `*/*` wildcard: `text/html` is covered by `html.or(*/*)` and JSON by
+//! `json.or(*/*)`. The higher effective q wins; on a tie the earlier list entry
+//! wins. So `Accept: text/html;q=0.1, */*;q=1` serves **JSON** — `text/html` is
+//! explicitly demoted to `q=0.1` while `*/*;q=1` lifts JSON to `q=1` — rather
+//! than being fooled by the bare presence of `text/html`.
+//!
+//! When the client expresses no concrete preference — a missing/empty `Accept`,
+//! a bare `*/*`, or a wildcard-only tie where neither side is named directly —
+//! the default is [`Format::Html`] (browser-first); override it with
 //! [`Negotiate::default_format`]. Responses carry `Vary: Accept` so shared
 //! caches key the two representations separately.
 
@@ -31,7 +42,7 @@ use axum::http::request::Parts;
 use axum::response::{IntoResponse, Response};
 use http::header::{HeaderValue, VARY};
 
-use crate::middleware::error_page_filter::{AcceptPreference, accept_preference};
+use crate::middleware::error_page_filter::{AcceptQualities, accept_qualities};
 
 /// The representation a handler can produce.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -50,7 +61,7 @@ pub enum Format {
 /// [`Negotiate::default_format`].
 #[derive(Debug, Clone, Copy)]
 pub struct Negotiate {
-    preference: AcceptPreference,
+    qualities: AcceptQualities,
     default: Format,
 }
 
@@ -63,15 +74,40 @@ impl Negotiate {
         self
     }
 
-    /// The resolved representation: a direct `text/html` / `application/json`
-    /// preference maps straight through, while `*/*` or an unspecified
-    /// `Accept` falls back to the configured default.
+    /// The resolved representation, chosen by *effective* q-value.
+    ///
+    /// Each candidate's effective quality folds in the `*/*` wildcard —
+    /// `html.or(wildcard)` for HTML and `json.or(wildcard)` for JSON — so a
+    /// high-q wildcard can outrank an explicitly demoted concrete type (RFC 7231
+    /// content negotiation). The higher effective q wins; on a tie the earlier
+    /// list entry wins. When neither side is named directly (both effective
+    /// values come from the same `*/*` entry, or there is no `Accept` at all)
+    /// there is no real preference, so the configured `default` applies.
     #[must_use]
-    pub const fn format(&self) -> Format {
-        match self.preference {
-            AcceptPreference::Html => Format::Html,
-            AcceptPreference::Json => Format::Json,
-            AcceptPreference::Any | AcceptPreference::Unspecified => self.default,
+    pub fn format(&self) -> Format {
+        let html_eff = self.qualities.html.or(self.qualities.wildcard);
+        let json_eff = self.qualities.json.or(self.qualities.wildcard);
+
+        match (html_eff, json_eff) {
+            (Some((hq, hidx)), Some((jq, jidx))) => {
+                if (hq - jq).abs() < f32::EPSILON {
+                    // Equal effective q: the earlier list entry wins. Equal
+                    // index means both sides resolved to the *same* `*/*` entry,
+                    // i.e. no concrete preference — fall back to the default.
+                    match hidx.cmp(&jidx) {
+                        std::cmp::Ordering::Less => Format::Html,
+                        std::cmp::Ordering::Greater => Format::Json,
+                        std::cmp::Ordering::Equal => self.default,
+                    }
+                } else if hq > jq {
+                    Format::Html
+                } else {
+                    Format::Json
+                }
+            }
+            (Some(_), None) => Format::Html,
+            (None, Some(_)) => Format::Json,
+            (None, None) => self.default,
         }
     }
 
@@ -80,7 +116,7 @@ impl Negotiate {
     /// The `html` closure runs only when HTML is the chosen representation, so
     /// the markup is never rendered for an API response.
     #[must_use]
-    pub const fn respond<F, J>(self, html: F, json: J) -> Negotiated<F, J>
+    pub fn respond<F, J>(self, html: F, json: J) -> Negotiated<F, J>
     where
         F: FnOnce() -> maud::Markup,
         J: serde::Serialize,
@@ -101,7 +137,7 @@ where
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         Ok(Self {
-            preference: accept_preference(&parts.headers),
+            qualities: accept_qualities(&parts.headers),
             default: Format::Html,
         })
     }
@@ -132,5 +168,79 @@ where
             .headers_mut()
             .append(VARY, HeaderValue::from_static("Accept"));
         response
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a [`Negotiate`] as the extractor would, from an optional `Accept`
+    /// header value, so `format()` resolution can be asserted directly.
+    fn negotiate(accept: Option<&str>) -> Negotiate {
+        let mut headers = http::HeaderMap::new();
+        if let Some(value) = accept {
+            headers.insert(http::header::ACCEPT, HeaderValue::from_str(value).unwrap());
+        }
+        Negotiate {
+            qualities: accept_qualities(&headers),
+            default: Format::Html,
+        }
+    }
+
+    #[test]
+    fn wildcard_q_beats_demoted_html() {
+        // Codex P2 case: text/html is explicitly demoted to q=0.1 while */*;q=1
+        // covers application/json at q=1, so JSON must win.
+        assert_eq!(
+            negotiate(Some("text/html;q=0.1, */*;q=1")).format(),
+            Format::Json,
+        );
+    }
+
+    #[test]
+    fn html_wins_on_higher_q() {
+        // Acceptance-criteria case: html has the higher q-value and must win.
+        assert_eq!(
+            negotiate(Some("application/json;q=0.9, text/html;q=1.0")).format(),
+            Format::Html,
+        );
+    }
+
+    #[test]
+    fn explicit_html_ties_wildcard_earlier_index_wins() {
+        // text/html and */* tie at q=1; text/html appears first, so it wins.
+        assert_eq!(
+            negotiate(Some("text/html;q=1, */*;q=1")).format(),
+            Format::Html,
+        );
+    }
+
+    #[test]
+    fn explicit_json_beats_demoted_wildcard() {
+        // application/json at q=1 outranks the html-covering */*;q=0.1.
+        assert_eq!(
+            negotiate(Some("application/json, */*;q=0.1")).format(),
+            Format::Json,
+        );
+    }
+
+    #[test]
+    fn bare_wildcard_uses_default() {
+        // No concrete preference: the configured default applies.
+        assert_eq!(negotiate(Some("*/*")).format(), Format::Html);
+        assert_eq!(
+            negotiate(Some("*/*")).default_format(Format::Json).format(),
+            Format::Json,
+        );
+    }
+
+    #[test]
+    fn missing_accept_uses_default() {
+        assert_eq!(negotiate(None).format(), Format::Html);
+        assert_eq!(
+            negotiate(None).default_format(Format::Json).format(),
+            Format::Json,
+        );
     }
 }

--- a/autumn/src/negotiate.rs
+++ b/autumn/src/negotiate.rs
@@ -22,20 +22,28 @@
 //! *effective* q-values that honour the `*/*` wildcard per RFC 7231 content
 //! negotiation.
 //!
-//! Each candidate's effective q-value is the better of its own explicit entry
-//! and any `*/*` wildcard: `text/html` is covered by `html.or(*/*)` and JSON by
-//! `json.or(*/*)`. The higher effective q wins; on a tie the earlier list entry
-//! wins. So `Accept: text/html;q=0.1, */*;q=1` serves **JSON** — `text/html` is
-//! explicitly demoted to `q=0.1` while `*/*;q=1` lifts JSON to `q=1` — rather
-//! than being fooled by the bare presence of `text/html`.
+//! Each candidate's effective q-value is drawn from the most specific media
+//! range that names it, following RFC 7231 §5.3.2 precedence
+//! `type/subtype` > `type/*` > `*/*`: `text/html` is covered by
+//! `text/html.or(text/*).or(*/*)` and JSON by
+//! `application/json.or(application/*).or(*/*)`. The higher effective q wins; on
+//! a tie the earlier list entry wins. So `Accept: text/html;q=0.1, */*;q=1`
+//! serves **JSON** — `text/html` is explicitly demoted to `q=0.1` while
+//! `*/*;q=1` lifts JSON to `q=1` — rather than being fooled by the bare presence
+//! of `text/html`. Likewise `Accept: text/*;q=0, */*;q=1` serves **JSON**: the
+//! `text/*` range forbids every text format, so only JSON (covered by `*/*`)
+//! remains.
 //!
 //! ## `q=0` exclusions and `406 Not Acceptable`
 //!
 //! A media range listed with `q=0` means "**not acceptable**" (RFC 7231
 //! §5.3.1), not merely "less preferred". A format whose effective q is `0`
-//! (because it, or the `*/*` it would inherit from, was explicitly demoted to
-//! `q=0`) is *forbidden*: it is never served, not via the wildcard and not via
-//! the configured default. So `Accept: text/html;q=0, */*;q=1` serves **JSON**
+//! (because it, or the most specific range covering it — `text/*` /
+//! `application/*` or the bare `*/*` — was explicitly demoted to `q=0`) is
+//! *forbidden*: it is never served, not via a wildcard and not via the
+//! configured default. A more specific range overrides a broader one either way,
+//! so `text/html;q=0, text/*;q=1` still forbids HTML while `text/*;q=0, */*;q=1`
+//! forbids every text format. So `Accept: text/html;q=0, */*;q=1` serves **JSON**
 //! (HTML is forbidden; `*/*` still covers JSON), and `application/json;q=0`
 //! serves **HTML** even under `default_format(Format::Json)` (the default may
 //! not resurrect a forbidden format). When *both* HTML and JSON are forbidden
@@ -99,10 +107,11 @@ impl Negotiate {
     /// behaviour — only it emits `406 Not Acceptable` when both formats are
     /// forbidden.
     ///
-    /// Each candidate's effective quality folds in the `*/*` wildcard —
-    /// `html.or(wildcard)` for HTML and `json.or(wildcard)` for JSON — so a
-    /// high-q wildcard can outrank an explicitly demoted concrete type (RFC 7231
-    /// content negotiation). A format whose effective q is `0` is forbidden and
+    /// Each candidate's effective quality is drawn from the most specific media
+    /// range that names it — `text/html.or(text/*).or(*/*)` for HTML and
+    /// `application/json.or(application/*).or(*/*)` for JSON (RFC 7231 §5.3.2
+    /// precedence) — so a high-q wildcard can outrank an explicitly demoted
+    /// concrete type. A format whose effective q is `0` is forbidden and
     /// never chosen. The higher positive effective q wins; on a tie the earlier
     /// list entry wins. When neither side is named directly (both effective
     /// values come from the same `*/*` entry, or there is no `Accept` at all)
@@ -123,10 +132,14 @@ impl Negotiate {
     /// `q=0` exclusions and reporting [`Resolution::NotAcceptable`] when every
     /// format the handler can produce has been explicitly forbidden.
     ///
-    /// For each format `F` in {HTML, JSON} the *effective* quality `q_F` is `F`'s
-    /// own explicit max-q if `F` was listed at all (**including `q=0`**), else
-    /// the `*/*` wildcard's explicit max-q if `*/*` was listed (including `q=0`),
-    /// else `None` (unmentioned). Then:
+    /// For each format `F` in {HTML, JSON} the *effective* quality `q_F` is drawn
+    /// from the most specific media range that names it (RFC 7231 §5.3.2):
+    /// `F`'s own explicit max-q if `F` was listed at all (**including `q=0`**),
+    /// else its subtype wildcard (`text/*` for HTML, `application/*` for JSON) if
+    /// that was listed (including `q=0`), else the `*/*` wildcard's explicit max-q
+    /// if `*/*` was listed (including `q=0`), else `None` (unmentioned). A more
+    /// specific range with `q=0` therefore forbids `F` even when a broader range
+    /// below it is permissive. Then:
     ///
     /// * `q_F == Some(0.0)` → `F` is **forbidden** (never served — not via the
     ///   wildcard, not via the default).
@@ -140,8 +153,22 @@ impl Negotiate {
     ///   format if the default itself is forbidden.
     /// * If **both** formats are forbidden → [`Resolution::NotAcceptable`].
     fn resolve(&self) -> Resolution {
-        let html_eff = self.qualities.html.or(self.qualities.wildcard);
-        let json_eff = self.qualities.json.or(self.qualities.wildcard);
+        // Media-range precedence per RFC 7231 §5.3.2: `type/subtype` beats
+        // `type/*` beats `*/*`. `.or()` chaining picks the most-specific slot
+        // that is present, and because a present slot short-circuits even when
+        // it is `Some(0.0)`, a more-specific `q=0` exclusion (e.g. `text/html;q=0`
+        // or `text/*;q=0`) still forbids the format regardless of a permissive
+        // less-specific range below it.
+        let html_eff = self
+            .qualities
+            .html
+            .or(self.qualities.text_star)
+            .or(self.qualities.wildcard);
+        let json_eff = self
+            .qualities
+            .json
+            .or(self.qualities.application_star)
+            .or(self.qualities.wildcard);
 
         let html_forbidden = matches!(html_eff, Some((q, _)) if q <= 0.0);
         let json_forbidden = matches!(json_eff, Some((q, _)) if q <= 0.0);
@@ -349,6 +376,58 @@ mod tests {
         assert_eq!(negotiate(None).format(), Format::Html);
         assert_eq!(
             negotiate(None).default_format(Format::Json).format(),
+            Format::Json,
+        );
+    }
+
+    // ── Type-wildcard precedence (RFC 7231 §5.3.2): type/* between concrete and */* ──
+
+    #[test]
+    fn text_star_forbidden_falls_through_to_wildcard_json() {
+        // `text/*;q=0` forbids every text format (including text/html); `*/*;q=1`
+        // still covers JSON, so JSON is served rather than HTML resurfacing.
+        assert_eq!(
+            negotiate(Some("text/*;q=0, */*;q=1")).format(),
+            Format::Json,
+        );
+    }
+
+    #[test]
+    fn application_star_forbidden_not_resurrected_by_json_default() {
+        // `application/*;q=0` forbids JSON via the subtype wildcard; even a JSON
+        // default must not serve it, so HTML is served instead.
+        assert_eq!(
+            negotiate(Some("application/*;q=0"))
+                .default_format(Format::Json)
+                .format(),
+            Format::Html,
+        );
+    }
+
+    #[test]
+    fn text_star_positive_serves_html() {
+        // `text/*;q=1` lifts HTML (via the subtype wildcard) with nothing to beat
+        // it, so HTML wins.
+        assert_eq!(negotiate(Some("text/*;q=1")).format(), Format::Html);
+    }
+
+    #[test]
+    fn application_star_positive_serves_json() {
+        // `application/*;q=1` lifts JSON (via the subtype wildcard) with nothing
+        // to beat it, so JSON wins.
+        assert_eq!(negotiate(Some("application/*;q=1")).format(), Format::Json);
+    }
+
+    #[test]
+    fn concrete_type_beats_type_wildcard_forbidding_html() {
+        // Concrete `text/html;q=0` is more specific than `text/*;q=1`, so HTML is
+        // forbidden; JSON is unmentioned and non-forbidden, so it is served.
+        assert_eq!(
+            negotiate(Some("text/html;q=0, text/*;q=1")).resolve(),
+            Resolution::Json,
+        );
+        assert_eq!(
+            negotiate(Some("text/html;q=0, text/*;q=1")).format(),
             Format::Json,
         );
     }

--- a/autumn/src/prelude.rs
+++ b/autumn/src/prelude.rs
@@ -111,6 +111,11 @@ pub use crate::mail::{
     MailPreview, MailPreviewError, MailPreviewRegistry, MailTransport, Mailer, SmtpConfig, TlsMode,
     Transport,
 };
+/// Content-negotiated success responder: [`Negotiate`] extractor, its
+/// [`Negotiated`] response, and the [`Format`] it resolves to — serve HTML to
+/// browsers and JSON to API clients from one handler.
+#[cfg(feature = "maud")]
+pub use crate::negotiate::{Format, Negotiate, Negotiated};
 #[cfg(all(feature = "presence", feature = "maud"))]
 pub use crate::presence_badge;
 #[cfg(all(

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -119,6 +119,8 @@ mod middleware_pipeline;
 mod migrate_checksum_proptest;
 #[cfg(feature = "db")]
 mod model_field_attrs;
+#[cfg(feature = "maud")]
+mod negotiate;
 #[cfg(feature = "offline-sync")]
 mod offline_sync_conformance;
 #[cfg(feature = "offline-sync")]

--- a/autumn/tests/integration/negotiate.rs
+++ b/autumn/tests/integration/negotiate.rs
@@ -214,6 +214,55 @@ async fn concrete_html_exclusion_beats_text_star_and_serves_json() {
     assert_eq!(body_string(response).await, r#"{"id":7,"name":"spanner"}"#);
 }
 
+// ── `application/problem+json` is an error-path signal, not success JSON ─────
+
+#[tokio::test]
+async fn problem_json_alone_serves_html_default() {
+    // `application/problem+json` is a Problem Details (error-path) signal, not
+    // the success `application/json` body. Alone it leaves both formats
+    // unmentioned, so the HTML default applies — it must NOT select JSON.
+    let response = send(app(), Some("application/problem+json")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(header(&response, "content-type").starts_with("text/html"));
+    assert_eq!(header(&response, "vary"), "Accept");
+    assert!(body_string(response).await.contains("<h1>spanner</h1>"));
+}
+
+#[tokio::test]
+async fn problem_json_alone_serves_json_via_default_not_match() {
+    // With a JSON default, problem+json alone still falls through to the default
+    // (both formats unmentioned) — JSON is served because it is the default, not
+    // because problem+json matched the success JSON slot.
+    let app = Router::new().route("/widget", axum::routing::get(show_json_default));
+    let response = send(app, Some("application/problem+json")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(header(&response, "content-type"), "application/json");
+    assert_eq!(header(&response, "vary"), "Accept");
+    assert_eq!(body_string(response).await, r#"{"id":7,"name":"spanner"}"#);
+}
+
+#[tokio::test]
+async fn json_and_problem_json_serves_json() {
+    // `application/json` is present alongside the problem+json error signal, so
+    // the success JSON body is negotiated.
+    let response = send(app(), Some("application/json, application/problem+json")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(header(&response, "content-type"), "application/json");
+    assert_eq!(header(&response, "vary"), "Accept");
+    assert_eq!(body_string(response).await, r#"{"id":7,"name":"spanner"}"#);
+}
+
+#[tokio::test]
+async fn problem_json_with_html_serves_html() {
+    // problem+json does not lift the JSON tier, and text/html is present, so HTML
+    // wins outright.
+    let response = send(app(), Some("application/problem+json, text/html")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(header(&response, "content-type").starts_with("text/html"));
+    assert_eq!(header(&response, "vary"), "Accept");
+    assert!(body_string(response).await.contains("<h1>spanner</h1>"));
+}
+
 // ── `q=0` exclusions and `406 Not Acceptable` ───────────────────────────────
 
 #[tokio::test]

--- a/autumn/tests/integration/negotiate.rs
+++ b/autumn/tests/integration/negotiate.rs
@@ -159,6 +159,61 @@ async fn configurable_default_yields_json_when_accept_missing() {
     assert_eq!(body_string(response).await, r#"{"id":7,"name":"spanner"}"#);
 }
 
+// ── Type-wildcard precedence (RFC 7231 §5.3.2) ──────────────────────────────
+
+#[tokio::test]
+async fn text_star_forbidden_serves_wildcard_json() {
+    // `text/*;q=0` forbids every text format (including text/html); `*/*;q=1`
+    // still covers JSON, so JSON wins.
+    let response = send(app(), Some("text/*;q=0, */*;q=1")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(header(&response, "content-type"), "application/json");
+    assert_eq!(header(&response, "vary"), "Accept");
+    assert_eq!(body_string(response).await, r#"{"id":7,"name":"spanner"}"#);
+}
+
+#[tokio::test]
+async fn application_star_forbidden_not_resurrected_by_json_default() {
+    // `application/*;q=0` forbids JSON via the subtype wildcard; even under a
+    // JSON default, the non-forbidden HTML is served instead.
+    let app = Router::new().route("/widget", axum::routing::get(show_json_default));
+    let response = send(app, Some("application/*;q=0")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(header(&response, "content-type").starts_with("text/html"));
+    assert_eq!(header(&response, "vary"), "Accept");
+    assert!(body_string(response).await.contains("<h1>spanner</h1>"));
+}
+
+#[tokio::test]
+async fn text_star_positive_serves_html() {
+    // `text/*;q=1` lifts HTML with nothing to beat it.
+    let response = send(app(), Some("text/*;q=1")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(header(&response, "content-type").starts_with("text/html"));
+    assert!(body_string(response).await.contains("<h1>spanner</h1>"));
+}
+
+#[tokio::test]
+async fn application_star_positive_serves_json() {
+    // `application/*;q=1` lifts JSON with nothing to beat it.
+    let response = send(app(), Some("application/*;q=1")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(header(&response, "content-type"), "application/json");
+    assert_eq!(header(&response, "vary"), "Accept");
+    assert_eq!(body_string(response).await, r#"{"id":7,"name":"spanner"}"#);
+}
+
+#[tokio::test]
+async fn concrete_html_exclusion_beats_text_star_and_serves_json() {
+    // Concrete `text/html;q=0` is more specific than `text/*;q=1`, so HTML is
+    // forbidden; JSON is unmentioned and non-forbidden, so it is served.
+    let response = send(app(), Some("text/html;q=0, text/*;q=1")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(header(&response, "content-type"), "application/json");
+    assert_eq!(header(&response, "vary"), "Accept");
+    assert_eq!(body_string(response).await, r#"{"id":7,"name":"spanner"}"#);
+}
+
 // ── `q=0` exclusions and `406 Not Acceptable` ───────────────────────────────
 
 #[tokio::test]

--- a/autumn/tests/integration/negotiate.rs
+++ b/autumn/tests/integration/negotiate.rs
@@ -1,0 +1,111 @@
+//!
+//! Integration tests for the content-negotiated success responder.
+//!
+#![cfg(feature = "maud")]
+
+use autumn_web::prelude::*;
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde::Serialize;
+use tower::ServiceExt;
+
+#[derive(Serialize, Clone)]
+struct Widget {
+    id: u32,
+    name: &'static str,
+}
+
+const fn widget() -> Widget {
+    Widget {
+        id: 7,
+        name: "spanner",
+    }
+}
+
+async fn show(negotiate: Negotiate) -> impl IntoResponse {
+    let w = widget();
+    negotiate.respond(move || html! { h1 { (w.name) } }, w)
+}
+
+async fn show_json_default(negotiate: Negotiate) -> impl IntoResponse {
+    let w = widget();
+    negotiate
+        .default_format(Format::Json)
+        .respond(move || html! { h1 { (w.name) } }, w)
+}
+
+fn app() -> Router {
+    Router::new().route("/widget", axum::routing::get(show))
+}
+
+async fn send(app: Router, accept: Option<&str>) -> axum::response::Response {
+    let mut builder = Request::builder().uri("/widget");
+    if let Some(value) = accept {
+        builder = builder.header("accept", value);
+    }
+    app.oneshot(builder.body(Body::empty()).unwrap())
+        .await
+        .unwrap()
+}
+
+fn header(response: &axum::response::Response, name: &str) -> String {
+    response
+        .headers()
+        .get(name)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
+async fn body_string(response: axum::response::Response) -> String {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test]
+async fn serves_html_to_browser_clients() {
+    let response = send(app(), Some("text/html")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(header(&response, "content-type").starts_with("text/html"));
+    assert_eq!(header(&response, "vary"), "Accept");
+    assert!(body_string(response).await.contains("<h1>spanner</h1>"));
+}
+
+#[tokio::test]
+async fn serves_json_to_api_clients() {
+    let response = send(app(), Some("application/json")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(header(&response, "content-type"), "application/json");
+    assert_eq!(header(&response, "vary"), "Accept");
+    assert_eq!(body_string(response).await, r#"{"id":7,"name":"spanner"}"#);
+}
+
+#[tokio::test]
+async fn q_value_negotiation_prefers_html() {
+    let response = send(app(), Some("application/json;q=0.9, text/html;q=1.0")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(header(&response, "content-type").starts_with("text/html"));
+    assert!(body_string(response).await.contains("<h1>spanner</h1>"));
+}
+
+#[tokio::test]
+async fn missing_accept_defaults_to_html() {
+    let response = send(app(), None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(header(&response, "content-type").starts_with("text/html"));
+    assert!(body_string(response).await.contains("<h1>spanner</h1>"));
+}
+
+#[tokio::test]
+async fn configurable_default_yields_json_when_accept_missing() {
+    let app = Router::new().route("/widget", axum::routing::get(show_json_default));
+    let response = send(app, None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(header(&response, "content-type"), "application/json");
+    assert_eq!(header(&response, "vary"), "Accept");
+    assert_eq!(body_string(response).await, r#"{"id":7,"name":"spanner"}"#);
+}

--- a/autumn/tests/integration/negotiate.rs
+++ b/autumn/tests/integration/negotiate.rs
@@ -93,6 +93,55 @@ async fn q_value_negotiation_prefers_html() {
 }
 
 #[tokio::test]
+async fn wildcard_q_demotes_html_and_serves_json() {
+    // Codex P2 case: `text/html` is explicitly demoted to q=0.1 while `*/*;q=1`
+    // covers `application/json` at q=1, so JSON must win despite html appearing.
+    let response = send(app(), Some("text/html;q=0.1, */*;q=1")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(header(&response, "content-type"), "application/json");
+    assert_eq!(header(&response, "vary"), "Accept");
+    assert_eq!(body_string(response).await, r#"{"id":7,"name":"spanner"}"#);
+}
+
+#[tokio::test]
+async fn explicit_html_ties_wildcard_and_serves_html() {
+    // `text/html` and `*/*` tie at q=1; the earlier (html) entry wins.
+    let response = send(app(), Some("text/html;q=1, */*;q=1")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(header(&response, "content-type").starts_with("text/html"));
+    assert_eq!(header(&response, "vary"), "Accept");
+    assert!(body_string(response).await.contains("<h1>spanner</h1>"));
+}
+
+#[tokio::test]
+async fn explicit_json_beats_demoted_wildcard_and_serves_json() {
+    // `application/json` at q=1 outranks the html-covering `*/*;q=0.1`.
+    let response = send(app(), Some("application/json, */*;q=0.1")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(header(&response, "content-type"), "application/json");
+    assert_eq!(header(&response, "vary"), "Accept");
+    assert_eq!(body_string(response).await, r#"{"id":7,"name":"spanner"}"#);
+}
+
+#[tokio::test]
+async fn bare_wildcard_uses_default_html() {
+    let response = send(app(), Some("*/*")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(header(&response, "content-type").starts_with("text/html"));
+    assert!(body_string(response).await.contains("<h1>spanner</h1>"));
+}
+
+#[tokio::test]
+async fn bare_wildcard_honours_configured_json_default() {
+    let app = Router::new().route("/widget", axum::routing::get(show_json_default));
+    let response = send(app, Some("*/*")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(header(&response, "content-type"), "application/json");
+    assert_eq!(header(&response, "vary"), "Accept");
+    assert_eq!(body_string(response).await, r#"{"id":7,"name":"spanner"}"#);
+}
+
+#[tokio::test]
 async fn missing_accept_defaults_to_html() {
     let response = send(app(), None).await;
     assert_eq!(response.status(), StatusCode::OK);

--- a/autumn/tests/integration/negotiate.rs
+++ b/autumn/tests/integration/negotiate.rs
@@ -158,3 +158,42 @@ async fn configurable_default_yields_json_when_accept_missing() {
     assert_eq!(header(&response, "vary"), "Accept");
     assert_eq!(body_string(response).await, r#"{"id":7,"name":"spanner"}"#);
 }
+
+// ── `q=0` exclusions and `406 Not Acceptable` ───────────────────────────────
+
+#[tokio::test]
+async fn forbidden_html_serves_wildcard_json() {
+    // `text/html;q=0` forbids HTML; `*/*;q=1` still covers JSON, so JSON wins —
+    // the default must not resurrect the explicitly rejected HTML.
+    let response = send(app(), Some("text/html;q=0, */*;q=1")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(header(&response, "content-type"), "application/json");
+    assert_eq!(header(&response, "vary"), "Accept");
+    assert_eq!(body_string(response).await, r#"{"id":7,"name":"spanner"}"#);
+}
+
+#[tokio::test]
+async fn forbidden_json_not_resurrected_by_json_default() {
+    // JSON is explicitly forbidden; even under `default_format(Format::Json)`
+    // the non-forbidden HTML must be served instead.
+    let app = Router::new().route("/widget", axum::routing::get(show_json_default));
+    let response = send(app, Some("application/json;q=0")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(header(&response, "content-type").starts_with("text/html"));
+    assert_eq!(header(&response, "vary"), "Accept");
+    assert!(body_string(response).await.contains("<h1>spanner</h1>"));
+}
+
+#[tokio::test]
+async fn both_formats_forbidden_returns_406() {
+    let response = send(app(), Some("text/html;q=0, application/json;q=0")).await;
+    assert_eq!(response.status(), StatusCode::NOT_ACCEPTABLE);
+    assert_eq!(header(&response, "vary"), "Accept");
+}
+
+#[tokio::test]
+async fn wildcard_forbidden_returns_406() {
+    let response = send(app(), Some("*/*;q=0")).await;
+    assert_eq!(response.status(), StatusCode::NOT_ACCEPTABLE);
+    assert_eq!(header(&response, "vary"), "Accept");
+}


### PR DESCRIPTION
**Part of #1355.**

## Before / After
Before, serving the same resource as HTML to a browser and JSON to an API/mobile/htmx client meant either hand-branching `if accepts_json { Json(..) } else { html(..) }` in every handler, or maintaining two parallel route trees. After, a single route+handler returns the right representation from the request's `Accept` header with no hand-written branching:

```rust
async fn show(nego: Negotiate, /* ... */) -> impl IntoResponse {
    let post = /* load once */;
    nego.respond(|| layout("Post", html! { h1 { (post.title) } }), post)
}
```
`Accept: text/html` → `200 text/html` (rendered Maud); `Accept: application/json` → `200 application/json` (serialized body). The HTML closure only runs when HTML wins, so the view isn't rendered for API requests.

## How
- New `autumn-web` public surface (`autumn/src/negotiate.rs`, re-exported from the prelude): `Negotiate` (an `Accept`-reading `FromRequestParts` extractor), its `.respond(|| markup, json)` builder, the `Negotiated<F, J>` `IntoResponse`, and a `Format` enum. The responder appends `Vary: Accept` (via `append`, composing with existing `Vary` values) so shared/CDN caches don't cross-serve formats.
- Configurable default for `Accept: */*` and missing `Accept`: `Format::Html` (browser-first) by default, overridable per-handler with `.default_format(Format::Json)`.
- Reuses one canonical negotiator: the existing q-value Accept parser in `error_page_filter.rs` was refactored into an enum-returning `accept_preference`, with `accept_prefers_html` now a thin wrapper over it. Error-path behavior is byte-for-byte unchanged (all 51 pre-existing `error_page_filter` tests pass).

## Tests
`autumn/tests/integration/negotiate.rs`: one route driven with multiple `Accept` headers asserts status, `Content-Type`, and `Vary: Accept` for HTML and JSON, q-value negotiation (`application/json;q=0.9, text/html;q=1.0` → HTML), the HTML default for a missing `Accept`, and `.default_format(Format::Json)` yielding JSON for a missing `Accept`.

## Scope / follow-ups
Runtime primitive only, per the issue's stated scope. Out of scope here (candidate follow-ups): scaffold/codegen emitting dual-format handlers by default, XML/MessagePack, and URL-suffix format selection.

## Verification (local)
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (full workspace)
- `cargo test -p autumn-web --test integration_tests negotiate` — 5/5 pass
- `cargo test -p autumn-web --lib error_page_filter` — 51/51 pass (refactor safety)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AsrkBRDk656yAm3gqHTxQH)_