### PR TITLE
feat(cli): autumn deploy foundation — config, preflight, dry-run plan (Part of #1607)

### DIFF
--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -503,6 +503,22 @@ fn resolve_project_name() -> String {
         .unwrap_or_else(|| "app".to_owned())
 }
 
+/// Resolve the first database URL a deploy/migration would actually act on,
+/// honoring shard-only deployments.
+///
+/// `autumn migrate` treats a shard-only app (one or more `[[database.shards]]`
+/// with no control `primary_url`/`url`) as a valid shape and migrates each
+/// shard's `primary_url` (see `migrate::build_targets`). The DB-URL preflight
+/// must agree, so it considers the app to have a usable database when a control
+/// primary, a replica, OR at least one shard primary URL resolves — returning
+/// the first such URL (control primary → replica → first shard primary). The
+/// grader never prints the value, so surfacing a shard URL here is safe.
+fn resolve_preflight_db_url(db: &autumn_web::config::DatabaseConfig) -> Option<&str> {
+    db.effective_primary_url()
+        .or(db.replica_url.as_deref())
+        .or_else(|| db.shards.first().map(|shard| shard.primary_url.as_str()))
+}
+
 /// Collect all preflight graders for the resolved config against the loaded
 /// runtime configuration.
 fn collect_preflight(
@@ -510,13 +526,15 @@ fn collect_preflight(
     resolved: &ResolvedDeployConfig,
 ) -> Vec<PreflightCheck> {
     // A `[database]` is considered configured when any connection URL is set on
-    // the loaded config (primary/compat `url` or a replica-only role). Combined
-    // with the migrations-dir presence check inside `grade_database_url`, this
-    // marks the app as database-backed so a missing URL fails preflight — while a
-    // DB-free app (no URLs, no migrations) passes.
+    // the loaded config (primary/compat `url`, a replica-only role, or any
+    // `[[database.shards]]` entry). Combined with the migrations-dir presence
+    // check inside `grade_database_url`, this marks the app as database-backed
+    // so a missing URL fails preflight — while a DB-free app (no URLs, no
+    // shards, no migrations) passes.
     let database_configured = config.database.url.is_some()
         || config.database.primary_url.is_some()
-        || config.database.replica_url.is_some();
+        || config.database.replica_url.is_some()
+        || config.database.has_shards();
     vec![
         grade_ssh_reachability(
             resolved.host.as_deref(),
@@ -525,7 +543,7 @@ fn collect_preflight(
         ),
         grade_signing_secret(config.security.signing_secret.secret.as_deref()),
         grade_database_url(
-            config.database.effective_primary_url(),
+            resolve_preflight_db_url(&config.database),
             Path::new(MIGRATIONS_DIR),
             database_configured,
         ),
@@ -801,6 +819,41 @@ mod tests {
             check.hint.is_some(),
             "the failure should carry an actionable remediation hint"
         );
+    }
+
+    #[test]
+    fn shard_only_config_resolves_a_usable_db_url() {
+        use autumn_web::config::{DatabaseConfig, ShardConfig};
+
+        // A shard-only app: no control `primary_url`/`url`/`replica_url`, but one
+        // `[[database.shards]]` entry with a `primary_url`. `autumn migrate` would
+        // target that shard, so the preflight must treat the app as having a
+        // usable database and PASS even with a migrations directory present.
+        let db = DatabaseConfig {
+            shards: vec![ShardConfig {
+                name: "shard0".to_owned(),
+                primary_url: "postgres://user:pw@shard0/app".to_owned(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        assert!(db.effective_primary_url().is_none());
+
+        let url = resolve_preflight_db_url(&db);
+        assert_eq!(url, Some("postgres://user:pw@shard0/app"));
+
+        // Migrations dir present + database configured (has_shards) → DB-backed.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let migrations = tmp.path().join("migrations");
+        std::fs::create_dir(&migrations).unwrap();
+        let check = grade_database_url(url, &migrations, true);
+        assert!(
+            check.passed,
+            "shard-only app with migrations should pass the DB-URL preflight: {}",
+            check.detail
+        );
+        // The grader must never echo the shard credentials.
+        assert!(!check.detail.contains("pw"));
     }
 
     #[test]

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -285,8 +285,19 @@ pub fn grade_ssh_reachability(
 /// missing/too-short/known-demo secret, so preflight reuses that exact validator
 /// to reject the same values here — otherwise `deploy check` would greenlight a
 /// release that immediately fails to boot (or ships a known demo secret).
+///
+/// The app boot path (`fail_fast_on_invalid_signing_secret`) also validates every
+/// `previous_secrets` rotation entry with the same validator and exits if any is
+/// weak, so preflight validates them too: a strong current secret paired with a
+/// `previous_secrets = ["changeme"]` entry would otherwise pass `deploy check`
+/// and then fail to boot. The rejection message names the offending rotation
+/// entry by position without printing its value.
 #[must_use]
-pub fn grade_signing_secret(secret: Option<&str>, is_production: bool) -> PreflightCheck {
+pub fn grade_signing_secret(
+    secret: Option<&str>,
+    previous_secrets: &[String],
+    is_production: bool,
+) -> PreflightCheck {
     let Some(value) = secret.map(str::trim).filter(|s| !s.is_empty()) else {
         return PreflightCheck::fail(
             "signing_secret",
@@ -319,6 +330,32 @@ pub fn grade_signing_secret(secret: Option<&str>, is_production: bool) -> Prefli
                 detail,
                 "Set a strong AUTUMN_SECURITY__SIGNING_SECRET (generate with `openssl rand -hex 32`)",
             );
+        }
+
+        // Rotation secrets accepted during a grace window must clear the same
+        // bar as the current secret; the app boot path validates each
+        // `previous_secrets` entry with the same validator and exits on the
+        // first weak one. Report by 1-based position without printing the value.
+        for (index, previous) in previous_secrets.iter().enumerate() {
+            if let Err(error) = validate_signing_secret(Some(previous.as_str()), true) {
+                let position = index + 1;
+                let detail = match error {
+                    SigningSecretError::MissingInProduction => format!(
+                        "previous (rotation) signing secret #{position} is empty and not allowed in production"
+                    ),
+                    SigningSecretError::TooShort { actual, required } => format!(
+                        "previous (rotation) signing secret #{position} is too short ({actual} bytes, minimum {required}) for production"
+                    ),
+                    SigningSecretError::KnownWeakValue(_) => format!(
+                        "previous (rotation) signing secret #{position} is a known demo/template value not allowed in production"
+                    ),
+                };
+                return PreflightCheck::fail(
+                    "signing_secret",
+                    detail,
+                    "Remove or rotate out the weak entry in security.signing_secret.previous_secrets (each must be as strong as the current secret)",
+                );
+            }
         }
     }
 
@@ -643,6 +680,7 @@ fn collect_preflight(
         ),
         grade_signing_secret(
             config.security.signing_secret.secret.as_deref(),
+            &config.security.signing_secret.previous_secrets,
             is_production_profile(config.profile.as_deref()),
         ),
         grade_database_url(
@@ -965,21 +1003,23 @@ mod tests {
 
     #[test]
     fn signing_secret_grader_never_echoes_value() {
-        let present = grade_signing_secret(Some("super-secret-value"), false);
+        let present = grade_signing_secret(Some("super-secret-value"), &[], false);
         assert!(present.passed);
         assert!(!present.detail.contains("super-secret-value"));
 
-        let missing = grade_signing_secret(None, false);
+        let missing = grade_signing_secret(None, &[], false);
         assert!(!missing.passed);
-        assert!(!grade_signing_secret(Some("   "), false).passed);
+        assert!(!grade_signing_secret(Some("   "), &[], false).passed);
     }
 
     #[test]
     fn signing_secret_grader_non_production_accepts_weak_secret() {
         // Outside production, a present, non-empty secret is enough: a dev/staging
         // deploy must not be blocked by the production strength rules.
-        assert!(grade_signing_secret(Some("changeme"), false).passed);
-        assert!(grade_signing_secret(Some("short"), false).passed);
+        assert!(grade_signing_secret(Some("changeme"), &[], false).passed);
+        assert!(grade_signing_secret(Some("short"), &[], false).passed);
+        // A weak rotation secret is likewise fine outside production.
+        assert!(grade_signing_secret(Some("changeme"), &["also-weak".to_owned()], false).passed);
     }
 
     #[test]
@@ -989,13 +1029,13 @@ mod tests {
         // path also runs before binding. A known demo value and a too-short
         // secret must both FAIL preflight so `deploy check` never greenlights a
         // release that would exit on startup.
-        let demo = grade_signing_secret(Some("changeme"), true);
+        let demo = grade_signing_secret(Some("changeme"), &[], true);
         assert!(!demo.passed, "demo value must fail in production");
         assert!(demo.hint.is_some());
         // Never echo the secret value, even a known demo one.
         assert!(!demo.detail.contains("changeme"));
 
-        let short = grade_signing_secret(Some("too-short"), true);
+        let short = grade_signing_secret(Some("too-short"), &[], true);
         assert!(!short.passed, "too-short secret must fail in production");
         assert!(!short.detail.contains("too-short"));
     }
@@ -1005,7 +1045,7 @@ mod tests {
         // A 64-hex-char secret (openssl rand -hex 32) clears the runtime
         // validator's minimum length and is not a demo value.
         let strong = "a".repeat(64);
-        let check = grade_signing_secret(Some(&strong), true);
+        let check = grade_signing_secret(Some(&strong), &[], true);
         assert!(
             check.passed,
             "strong production secret should pass: {}",
@@ -1016,9 +1056,51 @@ mod tests {
 
     #[test]
     fn signing_secret_grader_production_missing_fails() {
-        let check = grade_signing_secret(None, true);
+        let check = grade_signing_secret(None, &[], true);
         assert!(!check.passed);
         assert!(check.hint.is_some());
+    }
+
+    #[test]
+    fn signing_secret_grader_production_rejects_weak_previous_secret() {
+        // The app boot path validates each `previous_secrets` entry with the same
+        // rule and exits if any is weak, so a strong CURRENT secret paired with a
+        // weak rotation entry must FAIL preflight rather than boot-crash later.
+        let strong = "a".repeat(64);
+        let check = grade_signing_secret(Some(&strong), &["changeme".to_owned()], true);
+        assert!(
+            !check.passed,
+            "weak previous_secrets entry must fail in production"
+        );
+        assert!(check.hint.is_some());
+        // Never echo the rotation secret value.
+        assert!(!check.detail.contains("changeme"));
+        // The message identifies it as a previous/rotation secret.
+        assert!(
+            check.detail.contains("previous"),
+            "detail should name the rotation secret: {}",
+            check.detail
+        );
+    }
+
+    #[test]
+    fn signing_secret_grader_production_accepts_strong_previous_secrets() {
+        // Strong current + strong rotation entries pass.
+        let strong = "a".repeat(64);
+        let previous = vec!["b".repeat(64), "c".repeat(64)];
+        let check = grade_signing_secret(Some(&strong), &previous, true);
+        assert!(
+            check.passed,
+            "strong current + strong previous should pass: {}",
+            check.detail
+        );
+    }
+
+    #[test]
+    fn signing_secret_grader_non_production_ignores_weak_previous_secret() {
+        // Outside production, rotation entries are not strength-checked.
+        let check = grade_signing_secret(Some("dev-secret"), &["changeme".to_owned()], false);
+        assert!(check.passed);
     }
 
     #[test]

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -216,17 +216,32 @@ pub fn grade_ssh_reachability(
         );
     }
 
-    match TcpStream::connect_timeout(&addrs[0], timeout) {
-        Ok(_) => PreflightCheck::pass(
-            "ssh_reachability",
-            format!("SSH port reachable at {host}:{ssh_port}"),
-        ),
-        Err(e) => PreflightCheck::fail(
-            "ssh_reachability",
-            format!("cannot reach {host}:{ssh_port}: {e}"),
-            "Confirm the server is up, the SSH port is open, and any firewall allows your IP",
-        ),
+    // Probe every resolved address, not just the first. A dual-stack host may
+    // resolve to an IPv6 address first that an IPv4-only client cannot reach
+    // (or vice versa); the port is reachable as long as ANY address connects.
+    // Fail only when all of them fail, reporting the last error.
+    let mut last_err = None;
+    for addr in &addrs {
+        match TcpStream::connect_timeout(addr, timeout) {
+            Ok(_) => {
+                return PreflightCheck::pass(
+                    "ssh_reachability",
+                    format!("SSH port reachable at {host}:{ssh_port}"),
+                );
+            }
+            Err(e) => last_err = Some(e),
+        }
     }
+
+    let detail = last_err.map_or_else(
+        || format!("cannot reach {host}:{ssh_port}"),
+        |e| format!("cannot reach {host}:{ssh_port}: {e}"),
+    );
+    PreflightCheck::fail(
+        "ssh_reachability",
+        detail,
+        "Confirm the server is up, the SSH port is open, and any firewall allows your IP",
+    )
 }
 
 /// Grade signing-secret presence. Never prints the secret value.
@@ -302,10 +317,17 @@ pub fn grade_migrate_check(migrations_dir: &Path) -> PreflightCheck {
 
 /// Render the systemd service unit that supervises the deployed app.
 ///
-/// The unit runs `autumn serve --release` from the release directory, restarts
-/// on failure, comes back after reboot (`WantedBy=multi-user.target`), and
-/// sources secrets from an `EnvironmentFile` so they are never inlined into the
-/// world-readable unit (AC-5).
+/// An autumn app compiled with `autumn build --embed` is a standalone server
+/// binary (the generated Dockerfile launches it directly as
+/// `CMD ["/usr/local/bin/<app>"]`, with no `serve` subcommand). The deploy flow
+/// uploads that pre-built binary into a timestamped release dir fronted by the
+/// `current` symlink, so the unit execs the deployed binary at
+/// `{app_dir}/current/{app_name}` directly — it must NOT run
+/// `autumn serve --release`, which would rebuild the project from source.
+///
+/// The unit restarts on failure, comes back after reboot
+/// (`WantedBy=multi-user.target`), and sources secrets from an `EnvironmentFile`
+/// so they are never inlined into the world-readable unit (AC-5).
 #[must_use]
 pub fn render_systemd_unit(cfg: &ResolvedDeployConfig) -> String {
     format!(
@@ -319,7 +341,7 @@ pub fn render_systemd_unit(cfg: &ResolvedDeployConfig) -> String {
          User={user}\n\
          WorkingDirectory={current}\n\
          EnvironmentFile={env_file}\n\
-         ExecStart=autumn serve --release\n\
+         ExecStart={current}/{app}\n\
          Restart=on-failure\n\
          RestartSec=2\n\
          \n\
@@ -598,7 +620,11 @@ mod tests {
         assert!(unit.contains("Description=Autumn application: shop"));
         assert!(unit.contains("User=deploy"));
         assert!(unit.contains("WorkingDirectory=/srv/autumn/shop/current"));
-        assert!(unit.contains("ExecStart=autumn serve --release"));
+        // The unit execs the uploaded standalone app binary at the `current`
+        // symlink directly — never `autumn serve --release` (which would rebuild
+        // from source rather than run the pre-built release binary).
+        assert!(unit.contains("ExecStart=/srv/autumn/shop/current/shop"));
+        assert!(!unit.contains("autumn serve --release"));
         assert!(unit.contains("Restart=on-failure"));
         assert!(unit.contains("WantedBy=multi-user.target"));
         // Secrets come from an EnvironmentFile, never inlined into the unit.
@@ -679,6 +705,18 @@ mod tests {
         // A blank host is treated the same as unset.
         let blank = grade_ssh_reachability(Some("   "), 22, Duration::from_millis(50));
         assert!(!blank.passed);
+    }
+
+    #[test]
+    fn ssh_reachability_fails_when_all_addresses_unreachable() {
+        // Offline + deterministic: the loopback with a port nothing listens on
+        // refuses the connect on every resolved address, so the grader must FAIL
+        // (not pass). Using a literal IP avoids DNS so the test never depends on
+        // the resolver; port 1 is privileged and never bound by a test harness.
+        let check = grade_ssh_reachability(Some("127.0.0.1"), 1, Duration::from_millis(100));
+        assert!(!check.passed, "closed port should fail: {}", check.detail);
+        assert_eq!(check.name, "ssh_reachability");
+        assert!(check.detail.contains("cannot reach"));
     }
 
     #[test]

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -1,0 +1,713 @@
+//! `autumn deploy` — push-button, zero-downtime deploys to a VPS (issue #1607).
+//!
+//! This slice implements the locally-verifiable spine of the command:
+//!
+//! - **`check`** runs a preflight (SSH reachability, signing secret, database
+//!   URL, and a `migrate check`) and reports pass/fail, exiting non-zero if any
+//!   grader fails.
+//! - **`plan`** renders the systemd service unit and the ordered zero-downtime
+//!   rollout plan as a pure dry-run — it touches nothing remote.
+//! - **`rollback`** prints the rollback plan (also a dry-run in this slice).
+//!
+//! Real remote SSH execution, live cutover/rollback, and the CI end-to-end
+//! harness land in follow-ups. The plan/unit generators here are pure functions
+//! so they can be unit-tested without a server, and the preflight graders are
+//! shared with `autumn doctor`.
+
+use std::net::{TcpStream, ToSocketAddrs};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use autumn_web::config::{AutumnConfig, DeployConfig};
+
+/// Bounded timeout for the SSH-reachability preflight probe. Kept short so the
+/// check fails fast on an unreachable host instead of hanging on a dropped SYN.
+const SSH_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Default migrations directory scanned by the `migrate check` preflight grader.
+const MIGRATIONS_DIR: &str = "migrations";
+
+/// Errors surfaced by `autumn deploy`.
+#[derive(Debug, thiserror::Error)]
+pub enum DeployError {
+    /// The project configuration could not be loaded.
+    #[error("failed to load configuration: {0}")]
+    Config(String),
+
+    /// One or more preflight graders failed.
+    #[error(
+        "preflight failed: {0} check(s) did not pass — resolve the issues above and re-run \
+         `autumn deploy check`"
+    )]
+    PreflightFailed(usize),
+}
+
+/// Which `autumn deploy` subcommand to run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeployAction {
+    /// Run the preflight and report pass/fail.
+    Check,
+    /// Print the systemd unit and the ordered deploy plan (dry-run).
+    Plan,
+    /// Print the rollback plan (dry-run).
+    Rollback,
+}
+
+/// A `[deploy]` section with all defaults resolved to concrete values.
+///
+/// `app_name`, `app_dir`, and `service_name` are resolved here (from the
+/// project's package name) rather than during deserialization, matching the
+/// documented "resolved at deploy time" behavior of [`DeployConfig`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedDeployConfig {
+    /// SSH-reachable target host, if configured.
+    pub host: Option<String>,
+    /// SSH user.
+    pub user: String,
+    /// SSH port.
+    pub ssh_port: u16,
+    /// Resolved application name.
+    pub app_name: String,
+    /// Resolved remote install directory.
+    pub app_dir: String,
+    /// Resolved systemd unit name.
+    pub service_name: String,
+    /// Readiness window (seconds) before rollback.
+    pub readiness_timeout_secs: u64,
+    /// Prior releases retained on the host.
+    pub keep_releases: u32,
+}
+
+impl ResolvedDeployConfig {
+    /// Resolve a [`DeployConfig`] against the project name, filling in the
+    /// `app_name` → `app_dir` → `service_name` default chain.
+    #[must_use]
+    pub fn resolve(cfg: &DeployConfig, project_name: &str) -> Self {
+        let non_blank = |s: &Option<String>| {
+            s.as_ref()
+                .map(|v| v.trim().to_owned())
+                .filter(|v| !v.is_empty())
+        };
+
+        let app_name = non_blank(&cfg.app_name).unwrap_or_else(|| project_name.to_owned());
+        let app_dir = non_blank(&cfg.app_dir).unwrap_or_else(|| format!("/srv/autumn/{app_name}"));
+        let service_name = non_blank(&cfg.service_name).unwrap_or_else(|| app_name.clone());
+
+        Self {
+            host: non_blank(&cfg.host),
+            user: cfg.user.clone(),
+            ssh_port: cfg.ssh_port,
+            app_name,
+            app_dir,
+            service_name,
+            readiness_timeout_secs: cfg.readiness_timeout_secs,
+            keep_releases: cfg.keep_releases,
+        }
+    }
+
+    /// Remote path to the `EnvironmentFile` holding secrets (mode `0600`), kept
+    /// out of the world-readable systemd unit.
+    #[must_use]
+    pub fn env_file(&self) -> String {
+        format!("{}/shared/autumn.env", self.app_dir)
+    }
+
+    /// Directory holding timestamped release dirs.
+    #[must_use]
+    pub fn releases_dir(&self) -> String {
+        format!("{}/releases", self.app_dir)
+    }
+
+    /// Symlink pointing at the currently-serving release.
+    #[must_use]
+    pub fn current_symlink(&self) -> String {
+        format!("{}/current", self.app_dir)
+    }
+}
+
+/// A single ordered step in a deploy or rollback plan. Purely descriptive — a
+/// plan is rendered, never executed, in this slice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeployStep {
+    /// Short label (a few words) naming the step.
+    pub label: &'static str,
+    /// One-line description of what the step does.
+    pub description: String,
+}
+
+impl DeployStep {
+    fn new(label: &'static str, description: impl Into<String>) -> Self {
+        Self {
+            label,
+            description: description.into(),
+        }
+    }
+}
+
+/// Result of a single preflight grader. Shared by `autumn deploy check` and
+/// `autumn doctor` so both surfaces grade identically.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreflightCheck {
+    /// Short stable identifier for the check.
+    pub name: &'static str,
+    /// Whether the check passed.
+    pub passed: bool,
+    /// Human-readable detail (what was found).
+    pub detail: String,
+    /// One-line remediation hint shown on failure.
+    pub hint: Option<&'static str>,
+}
+
+impl PreflightCheck {
+    fn pass(name: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            name,
+            passed: true,
+            detail: detail.into(),
+            hint: None,
+        }
+    }
+
+    fn fail(name: &'static str, detail: impl Into<String>, hint: &'static str) -> Self {
+        Self {
+            name,
+            passed: false,
+            detail: detail.into(),
+            hint: Some(hint),
+        }
+    }
+}
+
+// ── Preflight graders (AC-6) ─────────────────────────────────────────────────
+
+/// Grade SSH reachability: a bounded, non-interactive TCP connect to the SSH
+/// port. This slice does not shell out to `ssh` (that lands with real remote
+/// execution) — an honest "the port is reachable" probe is sufficient here.
+#[must_use]
+pub fn grade_ssh_reachability(
+    host: Option<&str>,
+    ssh_port: u16,
+    timeout: Duration,
+) -> PreflightCheck {
+    let Some(host) = host.map(str::trim).filter(|h| !h.is_empty()) else {
+        return PreflightCheck::fail(
+            "ssh_reachability",
+            "no target host configured",
+            "Set `[deploy] host` in autumn.toml to your server's SSH-reachable address",
+        );
+    };
+
+    let addrs = match (host, ssh_port).to_socket_addrs() {
+        Ok(addrs) => addrs.collect::<Vec<_>>(),
+        Err(e) => {
+            return PreflightCheck::fail(
+                "ssh_reachability",
+                format!("could not resolve {host}:{ssh_port}: {e}"),
+                "Check that `[deploy] host` is a resolvable hostname or a valid IP address",
+            );
+        }
+    };
+
+    if addrs.is_empty() {
+        return PreflightCheck::fail(
+            "ssh_reachability",
+            format!("{host}:{ssh_port} resolved to no addresses"),
+            "Check that `[deploy] host` is a resolvable hostname or a valid IP address",
+        );
+    }
+
+    match TcpStream::connect_timeout(&addrs[0], timeout) {
+        Ok(_) => PreflightCheck::pass(
+            "ssh_reachability",
+            format!("SSH port reachable at {host}:{ssh_port}"),
+        ),
+        Err(e) => PreflightCheck::fail(
+            "ssh_reachability",
+            format!("cannot reach {host}:{ssh_port}: {e}"),
+            "Confirm the server is up, the SSH port is open, and any firewall allows your IP",
+        ),
+    }
+}
+
+/// Grade signing-secret presence. Never prints the secret value.
+#[must_use]
+pub fn grade_signing_secret(secret: Option<&str>) -> PreflightCheck {
+    match secret.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(_) => PreflightCheck::pass("signing_secret", "signing secret is configured"),
+        None => PreflightCheck::fail(
+            "signing_secret",
+            "no signing secret configured",
+            "Set AUTUMN_SECURITY__SIGNING_SECRET (generate with `openssl rand -hex 32`)",
+        ),
+    }
+}
+
+/// Grade database-URL presence. Never prints the URL (it may embed credentials).
+#[must_use]
+pub fn grade_database_url(url: Option<&str>) -> PreflightCheck {
+    match url.map(str::trim).filter(|u| !u.is_empty()) {
+        Some(_) => PreflightCheck::pass("database_url", "database URL is configured"),
+        None => PreflightCheck::fail(
+            "database_url",
+            "no database URL configured",
+            "Set database.primary_url (or database.url) in autumn.toml, or AUTUMN_DATABASE__URL",
+        ),
+    }
+}
+
+/// Grade `migrate check`: reuse the migration safety classifier and fail when a
+/// pending migration is unsafe for a live rolling deploy. A project with no
+/// migrations directory passes (there is nothing to check).
+#[must_use]
+pub fn grade_migrate_check(migrations_dir: &Path) -> PreflightCheck {
+    if !migrations_dir.exists() {
+        return PreflightCheck::pass(
+            "migrate_check",
+            "no migrations directory (nothing to check)",
+        );
+    }
+
+    match crate::migrate::check_migrations_in_dir(migrations_dir) {
+        Ok(reports) => {
+            let unsafe_names: Vec<&str> = reports
+                .iter()
+                .filter(|r| crate::migrate::safety::has_unsafe_findings(&r.up))
+                .map(|r| r.name.as_str())
+                .collect();
+            if unsafe_names.is_empty() {
+                PreflightCheck::pass(
+                    "migrate_check",
+                    format!("{} migration(s) safe for a rolling deploy", reports.len()),
+                )
+            } else {
+                PreflightCheck::fail(
+                    "migrate_check",
+                    format!(
+                        "migration(s) unsafe for a rolling deploy: {}",
+                        unsafe_names.join(", ")
+                    ),
+                    "Run `autumn migrate check` and apply the expand/contract pattern before deploying",
+                )
+            }
+        }
+        Err(e) => PreflightCheck::fail(
+            "migrate_check",
+            format!("could not scan migrations: {e}"),
+            "Run `autumn migrate check` to see the full report",
+        ),
+    }
+}
+
+// ── Artifact / plan generators (pure) ────────────────────────────────────────
+
+/// Render the systemd service unit that supervises the deployed app.
+///
+/// The unit runs `autumn serve --release` from the release directory, restarts
+/// on failure, comes back after reboot (`WantedBy=multi-user.target`), and
+/// sources secrets from an `EnvironmentFile` so they are never inlined into the
+/// world-readable unit (AC-5).
+#[must_use]
+pub fn render_systemd_unit(cfg: &ResolvedDeployConfig) -> String {
+    format!(
+        "[Unit]\n\
+         Description=Autumn application: {app}\n\
+         After=network-online.target\n\
+         Wants=network-online.target\n\
+         \n\
+         [Service]\n\
+         Type=simple\n\
+         User={user}\n\
+         WorkingDirectory={current}\n\
+         EnvironmentFile={env_file}\n\
+         ExecStart=autumn serve --release\n\
+         Restart=on-failure\n\
+         RestartSec=2\n\
+         \n\
+         [Install]\n\
+         WantedBy=multi-user.target\n",
+        app = cfg.app_name,
+        user = cfg.user,
+        current = cfg.current_symlink(),
+        env_file = cfg.env_file(),
+    )
+}
+
+/// Build the ordered, zero-downtime deploy plan (AC-2/3/4).
+///
+/// The sequence encodes the framework's `/live`-`/ready`-drain contract:
+/// migrations run *before* cutover (a failed migration leaves the old version
+/// serving), the new release must report `/ready` within the bounded window
+/// (else roll back), traffic flips only after readiness, and the old release is
+/// drained and pruned last.
+#[must_use]
+pub fn build_deploy_plan(cfg: &ResolvedDeployConfig) -> Vec<DeployStep> {
+    vec![
+        DeployStep::new(
+            "build",
+            "Build the embedded single-binary release locally (`autumn build --embed`)",
+        ),
+        DeployStep::new(
+            "upload",
+            format!(
+                "Upload the binary to a new timestamped release dir under {}",
+                cfg.releases_dir()
+            ),
+        ),
+        DeployStep::new(
+            "migrate",
+            "Run pending migrations BEFORE cutover — abort here leaves the current version serving",
+        ),
+        DeployStep::new(
+            "start",
+            "Start the new release as a candidate (old version still serving traffic)",
+        ),
+        DeployStep::new(
+            "readiness-gate",
+            format!(
+                "Poll the new release's /ready within {}s — roll back on timeout",
+                cfg.readiness_timeout_secs
+            ),
+        ),
+        DeployStep::new(
+            "cutover",
+            format!(
+                "Flip the {} symlink to the new release and reload the {} service",
+                cfg.current_symlink(),
+                cfg.service_name
+            ),
+        ),
+        DeployStep::new(
+            "drain",
+            "Drain and stop the old release once cutover completes",
+        ),
+        DeployStep::new(
+            "prune",
+            format!(
+                "Prune old releases, retaining the most recent {}",
+                cfg.keep_releases
+            ),
+        ),
+    ]
+}
+
+/// Build the rollback plan: point `current` back at the previous release,
+/// restart the service, and re-probe `/ready`.
+#[must_use]
+pub fn build_rollback_plan(cfg: &ResolvedDeployConfig) -> Vec<DeployStep> {
+    vec![
+        DeployStep::new(
+            "select-previous",
+            format!(
+                "Select the previous release under {} to roll back to",
+                cfg.releases_dir()
+            ),
+        ),
+        DeployStep::new(
+            "repoint",
+            format!(
+                "Point the {} symlink back at the previous release",
+                cfg.current_symlink()
+            ),
+        ),
+        DeployStep::new(
+            "restart",
+            format!(
+                "Restart the {} service on the previous release",
+                cfg.service_name
+            ),
+        ),
+        DeployStep::new(
+            "readiness-gate",
+            format!(
+                "Re-probe /ready within {}s to confirm the rollback is healthy",
+                cfg.readiness_timeout_secs
+            ),
+        ),
+    ]
+}
+
+// ── Command entrypoint ───────────────────────────────────────────────────────
+
+/// Run the requested `autumn deploy` subcommand.
+///
+/// # Errors
+///
+/// Returns [`DeployError::Config`] when the project config cannot be loaded and
+/// [`DeployError::PreflightFailed`] when `check` finds a failing grader.
+pub fn run(action: DeployAction) -> Result<(), DeployError> {
+    let config = AutumnConfig::load().map_err(|e| DeployError::Config(e.to_string()))?;
+    let deploy_cfg = config.deploy.clone().unwrap_or_default();
+    let resolved = ResolvedDeployConfig::resolve(&deploy_cfg, &resolve_project_name());
+
+    match action {
+        DeployAction::Check => run_check(&config, &resolved),
+        DeployAction::Plan => {
+            print_plan(&resolved);
+            Ok(())
+        }
+        DeployAction::Rollback => {
+            print_rollback(&resolved);
+            Ok(())
+        }
+    }
+}
+
+/// Resolve the project's package name (for the `app_name` default), falling back
+/// to the current directory name and finally to `"app"`.
+fn resolve_project_name() -> String {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    crate::release::read_project_name(&cwd)
+        .ok()
+        .or_else(|| {
+            cwd.file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .filter(|n| !n.is_empty())
+        })
+        .unwrap_or_else(|| "app".to_owned())
+}
+
+/// Collect all preflight graders for the resolved config against the loaded
+/// runtime configuration.
+fn collect_preflight(
+    config: &AutumnConfig,
+    resolved: &ResolvedDeployConfig,
+) -> Vec<PreflightCheck> {
+    vec![
+        grade_ssh_reachability(
+            resolved.host.as_deref(),
+            resolved.ssh_port,
+            SSH_PROBE_TIMEOUT,
+        ),
+        grade_signing_secret(config.security.signing_secret.secret.as_deref()),
+        grade_database_url(config.database.effective_primary_url()),
+        grade_migrate_check(Path::new(MIGRATIONS_DIR)),
+    ]
+}
+
+fn run_check(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(), DeployError> {
+    eprintln!("\u{1F342} autumn deploy check\n");
+
+    let checks = collect_preflight(config, resolved);
+    let mut failed = 0_usize;
+    for check in &checks {
+        if check.passed {
+            eprintln!("\u{2705} {}: {}", check.name, check.detail);
+        } else {
+            failed += 1;
+            eprintln!("\u{274C} {}: {}", check.name, check.detail);
+            if let Some(hint) = check.hint {
+                eprintln!("   \u{2192} {hint}");
+            }
+        }
+    }
+    eprintln!();
+
+    if failed == 0 {
+        eprintln!("\u{2705} All {} preflight check(s) passed.", checks.len());
+        Ok(())
+    } else {
+        eprintln!(
+            "\u{274C} {failed} of {} preflight check(s) failed.",
+            checks.len()
+        );
+        Err(DeployError::PreflightFailed(failed))
+    }
+}
+
+fn print_plan(resolved: &ResolvedDeployConfig) {
+    println!("\u{1F342} autumn deploy plan (dry-run)\n");
+    println!("systemd unit ({}.service):\n", resolved.service_name);
+    println!("{}", render_systemd_unit(resolved));
+
+    println!("Deploy steps (zero-downtime):");
+    for (i, step) in build_deploy_plan(resolved).iter().enumerate() {
+        println!("  {}. [{}] {}", i + 1, step.label, step.description);
+    }
+}
+
+fn print_rollback(resolved: &ResolvedDeployConfig) {
+    println!("\u{1F342} autumn deploy rollback plan (dry-run)\n");
+    println!("Live rollback lands in a follow-up; this prints the plan only.\n");
+    println!("Rollback steps:");
+    for (i, step) in build_rollback_plan(resolved).iter().enumerate() {
+        println!("  {}. [{}] {}", i + 1, step.label, step.description);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn resolved_defaults() -> ResolvedDeployConfig {
+        ResolvedDeployConfig::resolve(&DeployConfig::default(), "myapp")
+    }
+
+    #[test]
+    fn resolve_fills_default_chain_from_project_name() {
+        let resolved = resolved_defaults();
+        assert_eq!(resolved.app_name, "myapp");
+        assert_eq!(resolved.app_dir, "/srv/autumn/myapp");
+        assert_eq!(resolved.service_name, "myapp");
+        assert_eq!(resolved.user, "root");
+        assert_eq!(resolved.ssh_port, 22);
+        assert_eq!(resolved.readiness_timeout_secs, 60);
+        assert_eq!(resolved.keep_releases, 3);
+        assert_eq!(resolved.host, None);
+    }
+
+    #[test]
+    fn resolve_honors_explicit_overrides() {
+        let cfg = DeployConfig {
+            host: Some("203.0.113.10".to_owned()),
+            app_name: Some("web".to_owned()),
+            app_dir: Some("/opt/web".to_owned()),
+            service_name: Some("web-svc".to_owned()),
+            ..DeployConfig::default()
+        };
+        let resolved = ResolvedDeployConfig::resolve(&cfg, "ignored");
+        assert_eq!(resolved.app_name, "web");
+        assert_eq!(resolved.app_dir, "/opt/web");
+        assert_eq!(resolved.service_name, "web-svc");
+        assert_eq!(resolved.host.as_deref(), Some("203.0.113.10"));
+    }
+
+    #[test]
+    fn resolve_blank_overrides_fall_back_to_defaults() {
+        let cfg = DeployConfig {
+            app_name: Some("   ".to_owned()),
+            app_dir: Some(String::new()),
+            ..DeployConfig::default()
+        };
+        let resolved = ResolvedDeployConfig::resolve(&cfg, "fallback");
+        assert_eq!(resolved.app_name, "fallback");
+        assert_eq!(resolved.app_dir, "/srv/autumn/fallback");
+    }
+
+    #[test]
+    fn systemd_unit_contains_service_paths_and_env_file() {
+        let cfg = ResolvedDeployConfig::resolve(
+            &DeployConfig {
+                app_name: Some("shop".to_owned()),
+                service_name: Some("shop-web".to_owned()),
+                user: "deploy".to_owned(),
+                ..DeployConfig::default()
+            },
+            "shop",
+        );
+        let unit = render_systemd_unit(&cfg);
+        assert!(unit.contains("Description=Autumn application: shop"));
+        assert!(unit.contains("User=deploy"));
+        assert!(unit.contains("WorkingDirectory=/srv/autumn/shop/current"));
+        assert!(unit.contains("ExecStart=autumn serve --release"));
+        assert!(unit.contains("Restart=on-failure"));
+        assert!(unit.contains("WantedBy=multi-user.target"));
+        // Secrets come from an EnvironmentFile, never inlined into the unit.
+        assert!(unit.contains("EnvironmentFile=/srv/autumn/shop/shared/autumn.env"));
+        assert!(!unit.contains("Environment=SECRET"));
+    }
+
+    #[test]
+    fn deploy_plan_runs_migrations_before_cutover_with_bounded_readiness_gate() {
+        let resolved = resolved_defaults();
+        let plan = build_deploy_plan(&resolved);
+        let labels: Vec<&str> = plan.iter().map(|s| s.label).collect();
+
+        let migrate = labels
+            .iter()
+            .position(|&l| l == "migrate")
+            .expect("migrate step");
+        let readiness = labels
+            .iter()
+            .position(|&l| l == "readiness-gate")
+            .expect("readiness-gate step");
+        let cutover = labels
+            .iter()
+            .position(|&l| l == "cutover")
+            .expect("cutover step");
+
+        // Migrations run before the readiness gate, which runs before cutover.
+        assert!(
+            migrate < readiness,
+            "migrations must precede the readiness gate"
+        );
+        assert!(readiness < cutover, "readiness gate must precede cutover");
+
+        // The readiness gate is bounded by the configured timeout and mentions
+        // rollback on timeout (AC-4).
+        let gate = &plan[readiness].description;
+        assert!(
+            gate.contains("60s"),
+            "readiness gate should be bounded: {gate}"
+        );
+        assert!(
+            gate.to_lowercase().contains("roll back"),
+            "gate should roll back on timeout: {gate}"
+        );
+
+        // The plan ends by pruning to keep_releases.
+        assert_eq!(plan.last().expect("non-empty plan").label, "prune");
+        assert!(plan.last().unwrap().description.contains('3'));
+    }
+
+    #[test]
+    fn rollback_plan_repoints_restarts_and_reprobes() {
+        let resolved = resolved_defaults();
+        let plan = build_rollback_plan(&resolved);
+        let labels: Vec<&str> = plan.iter().map(|s| s.label).collect();
+        assert!(labels.contains(&"repoint"));
+        let restart = labels
+            .iter()
+            .position(|&l| l == "restart")
+            .expect("restart step");
+        let reprobe = labels
+            .iter()
+            .position(|&l| l == "readiness-gate")
+            .expect("re-probe step");
+        assert!(
+            restart < reprobe,
+            "restart must precede the /ready re-probe"
+        );
+    }
+
+    #[test]
+    fn ssh_reachability_fails_fast_without_host() {
+        let check = grade_ssh_reachability(None, 22, Duration::from_millis(50));
+        assert!(!check.passed);
+        assert_eq!(check.name, "ssh_reachability");
+        assert!(check.hint.unwrap().contains("[deploy] host"));
+
+        // A blank host is treated the same as unset.
+        let blank = grade_ssh_reachability(Some("   "), 22, Duration::from_millis(50));
+        assert!(!blank.passed);
+    }
+
+    #[test]
+    fn signing_secret_grader_never_echoes_value() {
+        let present = grade_signing_secret(Some("super-secret-value"));
+        assert!(present.passed);
+        assert!(!present.detail.contains("super-secret-value"));
+
+        let missing = grade_signing_secret(None);
+        assert!(!missing.passed);
+        assert!(!grade_signing_secret(Some("   ")).passed);
+    }
+
+    #[test]
+    fn database_url_grader_never_echoes_value() {
+        let present = grade_database_url(Some("postgres://user:pw@host/db"));
+        assert!(present.passed);
+        assert!(!present.detail.contains("pw"));
+        assert!(!grade_database_url(None).passed);
+    }
+
+    #[test]
+    fn migrate_check_passes_when_no_migrations_dir() {
+        let dir = std::env::temp_dir().join("autumn-deploy-no-such-migrations-dir-xyz");
+        let check = grade_migrate_check(&dir);
+        assert!(
+            check.passed,
+            "absent migrations dir should pass: {}",
+            check.detail
+        );
+    }
+}

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -258,10 +258,25 @@ pub fn grade_signing_secret(secret: Option<&str>) -> PreflightCheck {
 }
 
 /// Grade database-URL presence. Never prints the URL (it may embed credentials).
+///
+/// The URL is only *required* when the app is database-backed — either a
+/// migrations directory exists (the same presence check [`grade_migrate_check`]
+/// uses, so the two graders agree) or a `[database]` section is configured. A
+/// zero-dependency, daemon-style app with neither has nothing to connect to, so
+/// the grader passes with a "no database configured" note instead of failing
+/// preflight unconditionally.
 #[must_use]
-pub fn grade_database_url(url: Option<&str>) -> PreflightCheck {
+pub fn grade_database_url(
+    url: Option<&str>,
+    migrations_dir: &Path,
+    database_configured: bool,
+) -> PreflightCheck {
     match url.map(str::trim).filter(|u| !u.is_empty()) {
         Some(_) => PreflightCheck::pass("database_url", "database URL is configured"),
+        None if !migrations_dir.exists() && !database_configured => PreflightCheck::pass(
+            "database_url",
+            "no database configured (nothing to connect to)",
+        ),
         None => PreflightCheck::fail(
             "database_url",
             "no database URL configured",
@@ -494,6 +509,14 @@ fn collect_preflight(
     config: &AutumnConfig,
     resolved: &ResolvedDeployConfig,
 ) -> Vec<PreflightCheck> {
+    // A `[database]` is considered configured when any connection URL is set on
+    // the loaded config (primary/compat `url` or a replica-only role). Combined
+    // with the migrations-dir presence check inside `grade_database_url`, this
+    // marks the app as database-backed so a missing URL fails preflight — while a
+    // DB-free app (no URLs, no migrations) passes.
+    let database_configured = config.database.url.is_some()
+        || config.database.primary_url.is_some()
+        || config.database.replica_url.is_some();
     vec![
         grade_ssh_reachability(
             resolved.host.as_deref(),
@@ -501,7 +524,11 @@ fn collect_preflight(
             SSH_PROBE_TIMEOUT,
         ),
         grade_signing_secret(config.security.signing_secret.secret.as_deref()),
-        grade_database_url(config.database.effective_primary_url()),
+        grade_database_url(
+            config.database.effective_primary_url(),
+            Path::new(MIGRATIONS_DIR),
+            database_configured,
+        ),
         grade_migrate_check(Path::new(MIGRATIONS_DIR)),
     ]
 }
@@ -732,10 +759,48 @@ mod tests {
 
     #[test]
     fn database_url_grader_never_echoes_value() {
-        let present = grade_database_url(Some("postgres://user:pw@host/db"));
+        // Force the DB-backed path so the missing-URL case still fails: a
+        // configured `[database]` marks the app as database-backed.
+        let absent = Path::new("autumn-deploy-no-such-migrations-dir-echo-guard");
+        let present = grade_database_url(Some("postgres://user:pw@host/db"), absent, true);
         assert!(present.passed);
         assert!(!present.detail.contains("pw"));
-        assert!(!grade_database_url(None).passed);
+        assert!(!grade_database_url(None, absent, true).passed);
+    }
+
+    #[test]
+    fn database_url_grader_passes_for_db_free_app() {
+        // No migrations directory and no configured `[database]`: a
+        // zero-dependency daemon app has nothing to connect to, so preflight
+        // must pass rather than require a URL.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let absent_migrations = tmp.path().join("migrations");
+        assert!(!absent_migrations.exists());
+        let check = grade_database_url(None, &absent_migrations, false);
+        assert!(
+            check.passed,
+            "DB-free app should pass the DB-URL preflight: {}",
+            check.detail
+        );
+    }
+
+    #[test]
+    fn database_url_grader_fails_for_db_backed_app_without_url() {
+        // A migrations directory (the same presence check `grade_migrate_check`
+        // uses) marks the app as database-backed, so a missing URL must fail
+        // with an actionable hint.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let migrations = tmp.path().join("migrations");
+        std::fs::create_dir(&migrations).unwrap();
+        let check = grade_database_url(None, &migrations, false);
+        assert!(
+            !check.passed,
+            "DB-backed app without a URL should fail preflight"
+        );
+        assert!(
+            check.hint.is_some(),
+            "the failure should carry an actionable remediation hint"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -276,44 +276,91 @@ pub fn grade_ssh_reachability(
     )
 }
 
-/// Grade signing-secret presence. Never prints the secret value.
+/// Grade signing-secret presence and, in production, strength. Never prints the
+/// secret value.
+///
+/// In a non-production profile a present, non-empty secret is enough. In a
+/// production profile the app boot path runs
+/// [`autumn_web::security::validate_signing_secret`] and *exits* on a
+/// missing/too-short/known-demo secret, so preflight reuses that exact validator
+/// to reject the same values here — otherwise `deploy check` would greenlight a
+/// release that immediately fails to boot (or ships a known demo secret).
 #[must_use]
-pub fn grade_signing_secret(secret: Option<&str>) -> PreflightCheck {
-    match secret.map(str::trim).filter(|s| !s.is_empty()) {
-        Some(_) => PreflightCheck::pass("signing_secret", "signing secret is configured"),
-        None => PreflightCheck::fail(
+pub fn grade_signing_secret(secret: Option<&str>, is_production: bool) -> PreflightCheck {
+    let Some(value) = secret.map(str::trim).filter(|s| !s.is_empty()) else {
+        return PreflightCheck::fail(
             "signing_secret",
             "no signing secret configured",
             "Set AUTUMN_SECURITY__SIGNING_SECRET (generate with `openssl rand -hex 32`)",
-        ),
+        );
+    };
+
+    if is_production {
+        // Reuse the exact runtime validator so preflight and app boot agree on
+        // what counts as a valid production secret. The error's `Display`
+        // embeds the (demo) secret value for `KnownWeakValue`, so we translate
+        // each variant into a value-free message rather than formatting it.
+        use autumn_web::security::{SigningSecretError, validate_signing_secret};
+        if let Err(error) = validate_signing_secret(Some(value), true) {
+            let detail = match error {
+                SigningSecretError::MissingInProduction => {
+                    "signing secret is required in production".to_owned()
+                }
+                SigningSecretError::TooShort { actual, required } => format!(
+                    "signing secret is too short ({actual} bytes, minimum {required}) for production"
+                ),
+                SigningSecretError::KnownWeakValue(_) => {
+                    "signing secret is a known demo/template value not allowed in production"
+                        .to_owned()
+                }
+            };
+            return PreflightCheck::fail(
+                "signing_secret",
+                detail,
+                "Set a strong AUTUMN_SECURITY__SIGNING_SECRET (generate with `openssl rand -hex 32`)",
+            );
+        }
     }
+
+    PreflightCheck::pass("signing_secret", "signing secret is configured")
 }
 
 /// Grade database-URL presence. Never prints the URL (it may embed credentials).
 ///
-/// The URL is only *required* when the app is database-backed — either a
-/// migrations directory exists (the same presence check [`grade_migrate_check`]
-/// uses, so the two graders agree) or a `[database]` section is configured. A
-/// zero-dependency, daemon-style app with neither has nothing to connect to, so
-/// the grader passes with a "no database configured" note instead of failing
-/// preflight unconditionally.
+/// The URL is only *required* when the app is database-backed — any of:
+/// - a migrations directory exists (the same presence check [`grade_migrate_check`]
+///   uses, so the two graders agree), or
+/// - a `[database]` section is configured, or
+/// - a DB-backed runtime feature is enabled (`db_backed_runtime`) — e.g.
+///   `jobs.backend = "postgres"` or `scheduler.backend = "postgres"`, whose
+///   startup paths (`job::start_postgres_runtime` /
+///   `scheduler::coordinator_from_config`) require a configured pool.
+///
+/// A zero-dependency, daemon-style app with none of these has nothing to connect
+/// to, so the grader passes with a "no database configured" note instead of
+/// failing preflight unconditionally.
 #[must_use]
 pub fn grade_database_url(
     url: Option<&str>,
     migrations_dir: &Path,
     database_configured: bool,
+    db_backed_runtime: bool,
 ) -> PreflightCheck {
     match url.map(str::trim).filter(|u| !u.is_empty()) {
         Some(_) => PreflightCheck::pass("database_url", "database URL is configured"),
-        None if !migrations_dir.exists() && !database_configured => PreflightCheck::pass(
-            "database_url",
-            "no database configured (nothing to connect to)",
-        ),
+        None if !migrations_dir.exists() && !database_configured && !db_backed_runtime => {
+            PreflightCheck::pass(
+                "database_url",
+                "no database configured (nothing to connect to)",
+            )
+        }
         None => PreflightCheck::fail(
             "database_url",
-            "no writable database URL: `autumn migrate` needs a primary/control \
+            "no writable database URL: this app is database-backed (migrations, a \
+             `[database]` section, or a Postgres-backed runtime feature such as \
+             `jobs.backend`/`scheduler.backend`) and needs a primary/control \
              (`database.primary_url`) or shard-primary URL; `database.replica_url` \
-             alone can't run migrations",
+             alone is not a writable target",
             "Set database.primary_url (or database.url) in autumn.toml, or AUTUMN_DATABASE__URL",
         ),
     }
@@ -594,14 +641,42 @@ fn collect_preflight(
             resolved.ssh_port,
             SSH_PROBE_TIMEOUT,
         ),
-        grade_signing_secret(config.security.signing_secret.secret.as_deref()),
+        grade_signing_secret(
+            config.security.signing_secret.secret.as_deref(),
+            is_production_profile(config.profile.as_deref()),
+        ),
         grade_database_url(
             resolve_writable_db_url(&config.database),
             Path::new(MIGRATIONS_DIR),
             database_configured,
+            requires_database_pool(config),
         ),
         grade_migrate_check(Path::new(MIGRATIONS_DIR)),
     ]
+}
+
+/// Whether the active profile is production, matching the exact rule the app boot
+/// path uses in `fail_fast_on_invalid_signing_secret`
+/// (`matches!(config.profile.as_deref(), Some("prod" | "production"))`).
+#[must_use]
+fn is_production_profile(profile: Option<&str>) -> bool {
+    matches!(profile, Some("prod" | "production"))
+}
+
+/// Whether any enabled runtime feature requires a configured Postgres pool at
+/// startup, mirroring the exact backend conditions the runtime enforces:
+/// - `jobs.backend = "postgres"` → `job::start_postgres_runtime` calls
+///   `state.pool().ok_or(...)` and errors without a pool.
+/// - `scheduler.backend = "postgres"` → `scheduler::coordinator_from_config`
+///   calls `state.pool().ok_or(...)` and errors without a pool.
+///
+/// Cache, channels, and idempotency have only in-memory/Redis backends (no
+/// Postgres variant), so they never require a DB pool and are deliberately not
+/// included here.
+#[must_use]
+fn requires_database_pool(config: &AutumnConfig) -> bool {
+    config.jobs.backend == "postgres"
+        || config.scheduler.backend == autumn_web::config::SchedulerBackend::Postgres
 }
 
 fn run_check(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(), DeployError> {
@@ -890,13 +965,60 @@ mod tests {
 
     #[test]
     fn signing_secret_grader_never_echoes_value() {
-        let present = grade_signing_secret(Some("super-secret-value"));
+        let present = grade_signing_secret(Some("super-secret-value"), false);
         assert!(present.passed);
         assert!(!present.detail.contains("super-secret-value"));
 
-        let missing = grade_signing_secret(None);
+        let missing = grade_signing_secret(None, false);
         assert!(!missing.passed);
-        assert!(!grade_signing_secret(Some("   ")).passed);
+        assert!(!grade_signing_secret(Some("   "), false).passed);
+    }
+
+    #[test]
+    fn signing_secret_grader_non_production_accepts_weak_secret() {
+        // Outside production, a present, non-empty secret is enough: a dev/staging
+        // deploy must not be blocked by the production strength rules.
+        assert!(grade_signing_secret(Some("changeme"), false).passed);
+        assert!(grade_signing_secret(Some("short"), false).passed);
+    }
+
+    #[test]
+    fn signing_secret_grader_production_rejects_weak_secret() {
+        // In production the grader reuses the runtime validator
+        // (`autumn_web::security::validate_signing_secret`), which the app boot
+        // path also runs before binding. A known demo value and a too-short
+        // secret must both FAIL preflight so `deploy check` never greenlights a
+        // release that would exit on startup.
+        let demo = grade_signing_secret(Some("changeme"), true);
+        assert!(!demo.passed, "demo value must fail in production");
+        assert!(demo.hint.is_some());
+        // Never echo the secret value, even a known demo one.
+        assert!(!demo.detail.contains("changeme"));
+
+        let short = grade_signing_secret(Some("too-short"), true);
+        assert!(!short.passed, "too-short secret must fail in production");
+        assert!(!short.detail.contains("too-short"));
+    }
+
+    #[test]
+    fn signing_secret_grader_production_accepts_strong_secret() {
+        // A 64-hex-char secret (openssl rand -hex 32) clears the runtime
+        // validator's minimum length and is not a demo value.
+        let strong = "a".repeat(64);
+        let check = grade_signing_secret(Some(&strong), true);
+        assert!(
+            check.passed,
+            "strong production secret should pass: {}",
+            check.detail
+        );
+        assert!(!check.detail.contains(&strong));
+    }
+
+    #[test]
+    fn signing_secret_grader_production_missing_fails() {
+        let check = grade_signing_secret(None, true);
+        assert!(!check.passed);
+        assert!(check.hint.is_some());
     }
 
     #[test]
@@ -904,10 +1026,10 @@ mod tests {
         // Force the DB-backed path so the missing-URL case still fails: a
         // configured `[database]` marks the app as database-backed.
         let absent = Path::new("autumn-deploy-no-such-migrations-dir-echo-guard");
-        let present = grade_database_url(Some("postgres://user:pw@host/db"), absent, true);
+        let present = grade_database_url(Some("postgres://user:pw@host/db"), absent, true, false);
         assert!(present.passed);
         assert!(!present.detail.contains("pw"));
-        assert!(!grade_database_url(None, absent, true).passed);
+        assert!(!grade_database_url(None, absent, true, false).passed);
     }
 
     #[test]
@@ -918,12 +1040,53 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let absent_migrations = tmp.path().join("migrations");
         assert!(!absent_migrations.exists());
-        let check = grade_database_url(None, &absent_migrations, false);
+        let check = grade_database_url(None, &absent_migrations, false, false);
         assert!(
             check.passed,
             "DB-free app should pass the DB-URL preflight: {}",
             check.detail
         );
+    }
+
+    #[test]
+    fn database_url_grader_fails_for_db_backed_runtime_without_url() {
+        // No migrations dir and no `[database]` section, but a DB-backed runtime
+        // feature (e.g. `jobs.backend = "postgres"` or `scheduler.backend =
+        // "postgres"`) is enabled. Its startup path requires a configured pool,
+        // so a missing writable URL must FAIL preflight rather than taking the
+        // DB-free pass branch and failing at boot.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let absent_migrations = tmp.path().join("migrations");
+        assert!(!absent_migrations.exists());
+        let check = grade_database_url(None, &absent_migrations, false, true);
+        assert!(
+            !check.passed,
+            "DB-backed runtime feature without a URL must fail preflight"
+        );
+        assert!(
+            check.hint.is_some(),
+            "the failure should carry an actionable remediation hint"
+        );
+    }
+
+    #[test]
+    fn database_url_grader_passes_for_db_backed_runtime_with_url() {
+        // The same DB-backed runtime feature WITH a writable primary URL passes.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let absent_migrations = tmp.path().join("migrations");
+        assert!(!absent_migrations.exists());
+        let check = grade_database_url(
+            Some("postgres://user:pw@host/db"),
+            &absent_migrations,
+            false,
+            true,
+        );
+        assert!(
+            check.passed,
+            "DB-backed runtime feature with a URL should pass: {}",
+            check.detail
+        );
+        assert!(!check.detail.contains("pw"));
     }
 
     #[test]
@@ -934,7 +1097,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let migrations = tmp.path().join("migrations");
         std::fs::create_dir(&migrations).unwrap();
-        let check = grade_database_url(None, &migrations, false);
+        let check = grade_database_url(None, &migrations, false, false);
         assert!(
             !check.passed,
             "DB-backed app without a URL should fail preflight"
@@ -970,7 +1133,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let migrations = tmp.path().join("migrations");
         std::fs::create_dir(&migrations).unwrap();
-        let check = grade_database_url(url, &migrations, true);
+        let check = grade_database_url(url, &migrations, true, false);
         assert!(
             check.passed,
             "shard-only app with migrations should pass the DB-URL preflight: {}",
@@ -1008,7 +1171,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let migrations = tmp.path().join("migrations");
         std::fs::create_dir(&migrations).unwrap();
-        let check = grade_database_url(url, &migrations, true);
+        let check = grade_database_url(url, &migrations, true, false);
         assert!(
             !check.passed,
             "replica-only app with migrations must fail the DB-URL preflight"
@@ -1030,5 +1193,37 @@ mod tests {
             "absent migrations dir should pass: {}",
             check.detail
         );
+    }
+
+    #[test]
+    fn is_production_profile_matches_runtime_rule() {
+        assert!(is_production_profile(Some("prod")));
+        assert!(is_production_profile(Some("production")));
+        assert!(!is_production_profile(Some("dev")));
+        assert!(!is_production_profile(Some("staging")));
+        assert!(!is_production_profile(None));
+    }
+
+    #[test]
+    fn requires_database_pool_detects_postgres_backends() {
+        use autumn_web::config::{AutumnConfig, SchedulerBackend};
+
+        // Default (local jobs, in-process scheduler): no pool required.
+        let mut config = AutumnConfig::default();
+        assert!(!requires_database_pool(&config));
+
+        // jobs.backend = "postgres" → pool required.
+        config.jobs.backend = "postgres".to_owned();
+        assert!(requires_database_pool(&config));
+
+        // scheduler.backend = postgres → pool required.
+        let mut config = AutumnConfig::default();
+        config.scheduler.backend = SchedulerBackend::Postgres;
+        assert!(requires_database_pool(&config));
+
+        // A non-postgres jobs backend (redis/local) does not require a PG pool.
+        let mut config = AutumnConfig::default();
+        config.jobs.backend = "redis".to_owned();
+        assert!(!requires_database_pool(&config));
     }
 }

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -279,7 +279,9 @@ pub fn grade_database_url(
         ),
         None => PreflightCheck::fail(
             "database_url",
-            "no database URL configured",
+            "no writable database URL: `autumn migrate` needs a primary/control \
+             (`database.primary_url`) or shard-primary URL; `database.replica_url` \
+             alone can't run migrations",
             "Set database.primary_url (or database.url) in autumn.toml, or AUTUMN_DATABASE__URL",
         ),
     }
@@ -503,19 +505,20 @@ fn resolve_project_name() -> String {
         .unwrap_or_else(|| "app".to_owned())
 }
 
-/// Resolve the first database URL a deploy/migration would actually act on,
-/// honoring shard-only deployments.
+/// Resolve the first *writable* database URL a deploy/migration would actually
+/// act on, honoring shard-only deployments.
 ///
-/// `autumn migrate` treats a shard-only app (one or more `[[database.shards]]`
-/// with no control `primary_url`/`url`) as a valid shape and migrates each
-/// shard's `primary_url` (see `migrate::build_targets`). The DB-URL preflight
-/// must agree, so it considers the app to have a usable database when a control
-/// primary, a replica, OR at least one shard primary URL resolves — returning
-/// the first such URL (control primary → replica → first shard primary). The
-/// grader never prints the value, so surfacing a shard URL here is safe.
-fn resolve_preflight_db_url(db: &autumn_web::config::DatabaseConfig) -> Option<&str> {
+/// `autumn migrate` only ever targets a writable primary: the control
+/// `primary_url`/`url`, or — for a shard-only app (one or more
+/// `[[database.shards]]` with no control primary) — each shard's `primary_url`
+/// (see `migrate::build_targets`). It never migrates against
+/// `database.replica_url`. The DB-URL preflight must agree, so it returns the
+/// first writable URL that resolves (control primary → first shard primary);
+/// replicas are excluded because `autumn migrate` cannot migrate against a
+/// replica. The grader never prints the value, so surfacing a shard URL here is
+/// safe.
+fn resolve_writable_db_url(db: &autumn_web::config::DatabaseConfig) -> Option<&str> {
     db.effective_primary_url()
-        .or(db.replica_url.as_deref())
         .or_else(|| db.shards.first().map(|shard| shard.primary_url.as_str()))
 }
 
@@ -543,7 +546,7 @@ fn collect_preflight(
         ),
         grade_signing_secret(config.security.signing_secret.secret.as_deref()),
         grade_database_url(
-            resolve_preflight_db_url(&config.database),
+            resolve_writable_db_url(&config.database),
             Path::new(MIGRATIONS_DIR),
             database_configured,
         ),
@@ -839,7 +842,7 @@ mod tests {
         };
         assert!(db.effective_primary_url().is_none());
 
-        let url = resolve_preflight_db_url(&db);
+        let url = resolve_writable_db_url(&db);
         assert_eq!(url, Some("postgres://user:pw@shard0/app"));
 
         // Migrations dir present + database configured (has_shards) → DB-backed.
@@ -853,6 +856,47 @@ mod tests {
             check.detail
         );
         // The grader must never echo the shard credentials.
+        assert!(!check.detail.contains("pw"));
+    }
+
+    #[test]
+    fn replica_only_config_resolves_no_writable_url_and_fails_with_migrations() {
+        use autumn_web::config::DatabaseConfig;
+
+        // A replica-only app: only `database.replica_url` is set — no control
+        // `primary_url`/`url` and no `[[database.shards]]`. `autumn migrate` only
+        // ever targets a writable primary/control or shard-primary URL (see
+        // `migrate::build_targets`); it can never migrate against a replica. So
+        // the writable-URL resolver must return None, and a project with a
+        // `migrations/` dir must FAIL the DB-URL preflight rather than passing on
+        // a replica the migration step can't use.
+        let db = DatabaseConfig {
+            replica_url: Some("postgres://user:pw@replica/app".to_owned()),
+            ..Default::default()
+        };
+        assert!(db.effective_primary_url().is_none());
+
+        let url = resolve_writable_db_url(&db);
+        assert_eq!(
+            url, None,
+            "replica_url alone is not a writable migration target"
+        );
+
+        // Migrations dir present + database configured (replica_url set) →
+        // DB-backed, but no writable URL → FAIL with an actionable hint.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let migrations = tmp.path().join("migrations");
+        std::fs::create_dir(&migrations).unwrap();
+        let check = grade_database_url(url, &migrations, true);
+        assert!(
+            !check.passed,
+            "replica-only app with migrations must fail the DB-URL preflight"
+        );
+        assert!(
+            check.hint.is_some(),
+            "the failure should carry an actionable remediation hint"
+        );
+        // The grader must never echo the replica credentials.
         assert!(!check.detail.contains("pw"));
     }
 

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -27,6 +27,16 @@ const SSH_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 /// Default migrations directory scanned by the `migrate check` preflight grader.
 const MIGRATIONS_DIR: &str = "migrations";
 
+/// Detail shown when no deploy target host is configured. Shared by the offline
+/// host-present grader and the online SSH-reachability probe so `autumn deploy
+/// check` and `autumn doctor` report the missing-host case identically.
+const DEPLOY_HOST_MISSING_DETAIL: &str = "no target host configured";
+
+/// Remediation hint for a missing/blank `[deploy] host`. Shared so every surface
+/// (offline `doctor`, online `deploy check`) points at the same fix.
+const DEPLOY_HOST_MISSING_HINT: &str =
+    "Set `[deploy] host` in autumn.toml to your server's SSH-reachable address";
+
 /// Errors surfaced by `autumn deploy`.
 #[derive(Debug, thiserror::Error)]
 pub enum DeployError {
@@ -180,9 +190,31 @@ impl PreflightCheck {
 
 // ── Preflight graders (AC-6) ─────────────────────────────────────────────────
 
+/// Grade that a deploy target host is configured — a pure, OFFLINE check with no
+/// network I/O. This is deliberately split out from [`grade_ssh_reachability`]
+/// (which performs a TCP probe) so `autumn doctor` can validate host presence
+/// unconditionally — even without `--online` — while keeping the actual TCP
+/// connect behind `--online`. A `[deploy]` table with a missing/blank `host`
+/// makes `autumn deploy check` fail immediately, so `doctor` must fail on it too
+/// rather than green-lighting a config the deploy path rejects.
+#[must_use]
+pub fn grade_deploy_host_present(host: Option<&str>) -> PreflightCheck {
+    match host.map(str::trim).filter(|h| !h.is_empty()) {
+        Some(_) => PreflightCheck::pass("deploy_host", "deploy target host is configured"),
+        None => PreflightCheck::fail(
+            "deploy_host",
+            DEPLOY_HOST_MISSING_DETAIL,
+            DEPLOY_HOST_MISSING_HINT,
+        ),
+    }
+}
+
 /// Grade SSH reachability: a bounded, non-interactive TCP connect to the SSH
 /// port. This slice does not shell out to `ssh` (that lands with real remote
 /// execution) — an honest "the port is reachable" probe is sufficient here.
+///
+/// The missing-host case reuses the same detail/hint as the offline
+/// [`grade_deploy_host_present`] grader so the two surfaces stay consistent.
 #[must_use]
 pub fn grade_ssh_reachability(
     host: Option<&str>,
@@ -192,8 +224,8 @@ pub fn grade_ssh_reachability(
     let Some(host) = host.map(str::trim).filter(|h| !h.is_empty()) else {
         return PreflightCheck::fail(
             "ssh_reachability",
-            "no target host configured",
-            "Set `[deploy] host` in autumn.toml to your server's SSH-reachable address",
+            DEPLOY_HOST_MISSING_DETAIL,
+            DEPLOY_HOST_MISSING_HINT,
         );
     };
 
@@ -375,9 +407,23 @@ pub fn render_systemd_unit(cfg: &ResolvedDeployConfig) -> String {
 ///
 /// The sequence encodes the framework's `/live`-`/ready`-drain contract:
 /// migrations run *before* cutover (a failed migration leaves the old version
-/// serving), the new release must report `/ready` within the bounded window
-/// (else roll back), traffic flips only after readiness, and the old release is
-/// drained and pruned last.
+/// serving), the candidate must report `/ready` within the bounded window (else
+/// roll back), traffic is handed over only after readiness, and the old release
+/// is drained and pruned last.
+///
+/// **The candidate never binds the live `server.port`.** For the default TCP
+/// serving config the running app binds `server.host:server.port`, so starting
+/// the candidate on that same port while the old release is still serving would
+/// fail with "address already in use" *before* the readiness gate could ever
+/// run — the plan would not be executable. The candidate is therefore started on
+/// a SEPARATE listener (a distinct port/socket from the live service), and a
+/// later explicit handoff step switches live traffic to it.
+///
+/// **The concrete handoff mechanism is an open design decision for the execution
+/// follow-up.** This slice emits a mechanism-neutral PLAN: the cutover is
+/// described as a "reverse-proxy upstream swap or systemd socket-activation
+/// handoff" without committing to either in code. Whatever is chosen, the plan
+/// must never imply the candidate binds the live `server.port`.
 #[must_use]
 pub fn build_deploy_plan(cfg: &ResolvedDeployConfig) -> Vec<DeployStep> {
     vec![
@@ -397,27 +443,31 @@ pub fn build_deploy_plan(cfg: &ResolvedDeployConfig) -> Vec<DeployStep> {
             "Run pending migrations BEFORE cutover — abort here leaves the current version serving",
         ),
         DeployStep::new(
-            "start",
-            "Start the new release as a candidate (old version still serving traffic)",
+            "start-candidate",
+            "Start the new release as a candidate on a SEPARATE listener (a distinct \
+             port/socket from the live service) — it does NOT bind the live \
+             `server.port`, so the old release keeps serving traffic uninterrupted",
         ),
         DeployStep::new(
             "readiness-gate",
             format!(
-                "Poll the new release's /ready within {}s — roll back on timeout",
+                "Poll the candidate's /ready on its separate listener within {}s — roll back on \
+                 timeout",
                 cfg.readiness_timeout_secs
             ),
         ),
         DeployStep::new(
             "cutover",
             format!(
-                "Flip the {} symlink to the new release and reload the {} service",
+                "Hand live traffic over to the candidate — reverse-proxy upstream swap or systemd \
+                 socket-activation handoff (mechanism finalized in the execution slice) — then \
+                 promote it by pointing the {} symlink at the new release",
                 cfg.current_symlink(),
-                cfg.service_name
             ),
         ),
         DeployStep::new(
             "drain",
-            "Drain and stop the old release once cutover completes",
+            "Drain and stop the previous release once traffic has moved to the candidate",
         ),
         DeployStep::new(
             "prune",
@@ -690,6 +740,10 @@ mod tests {
             .iter()
             .position(|&l| l == "migrate")
             .expect("migrate step");
+        let candidate = labels
+            .iter()
+            .position(|&l| l == "start-candidate")
+            .expect("start-candidate step");
         let readiness = labels
             .iter()
             .position(|&l| l == "readiness-gate")
@@ -698,13 +752,53 @@ mod tests {
             .iter()
             .position(|&l| l == "cutover")
             .expect("cutover step");
+        let drain = labels
+            .iter()
+            .position(|&l| l == "drain")
+            .expect("drain step");
 
-        // Migrations run before the readiness gate, which runs before cutover.
+        // (c) Migrations run before the readiness gate, which runs before cutover.
         assert!(
             migrate < readiness,
             "migrations must precede the readiness gate"
         );
+        assert!(
+            migrate < cutover,
+            "migrations must precede cutover (a failed migration leaves the old version serving)"
+        );
         assert!(readiness < cutover, "readiness gate must precede cutover");
+
+        // (a) The candidate is started on a SEPARATE/distinct listener and the
+        // step must NOT claim it binds the live `server.port` — starting on the
+        // live port while the old release still serves would fail with
+        // address-in-use before the readiness gate could run.
+        let candidate_desc = &plan[candidate].description;
+        let candidate_lc = candidate_desc.to_lowercase();
+        assert!(
+            candidate_lc.contains("separate") || candidate_lc.contains("distinct"),
+            "candidate must start on a separate/distinct listener: {candidate_desc}"
+        );
+        assert!(
+            candidate_lc.contains("does not bind") || candidate_lc.contains("not bind"),
+            "candidate step must state it does NOT bind the live port: {candidate_desc}"
+        );
+
+        // (b) An explicit traffic-handoff/cutover step runs AFTER the readiness
+        // gate and BEFORE draining the old release.
+        assert!(
+            readiness < cutover,
+            "handoff must follow the readiness gate"
+        );
+        assert!(
+            cutover < drain,
+            "traffic handoff must precede draining the old release"
+        );
+        let cutover_desc = &plan[cutover].description.to_lowercase();
+        assert!(
+            cutover_desc.contains("hand") || cutover_desc.contains("traffic"),
+            "cutover must describe a traffic handoff: {}",
+            plan[cutover].description
+        );
 
         // The readiness gate is bounded by the configured timeout and mentions
         // rollback on timeout (AC-4).
@@ -741,6 +835,33 @@ mod tests {
             restart < reprobe,
             "restart must precede the /ready re-probe"
         );
+    }
+
+    #[test]
+    fn deploy_host_present_grader_is_offline_and_flags_missing_host() {
+        // Present, non-blank host → passes with no network I/O.
+        let ok = grade_deploy_host_present(Some("203.0.113.10"));
+        assert!(ok.passed);
+        assert_eq!(ok.name, "deploy_host");
+
+        // Missing host → fails offline with the actionable `[deploy] host` hint,
+        // matching the message `deploy check` uses.
+        let missing = grade_deploy_host_present(None);
+        assert!(!missing.passed, "missing host must fail offline");
+        assert_eq!(missing.name, "deploy_host");
+        assert_eq!(missing.detail, DEPLOY_HOST_MISSING_DETAIL);
+        assert!(missing.hint.unwrap().contains("[deploy] host"));
+
+        // Blank/whitespace host is treated the same as unset.
+        let blank = grade_deploy_host_present(Some("   "));
+        assert!(!blank.passed, "blank host must fail offline");
+        assert_eq!(blank.detail, DEPLOY_HOST_MISSING_DETAIL);
+
+        // Consistency: the offline host-present grader and the online SSH probe
+        // report the missing-host case identically.
+        let probe = grade_ssh_reachability(None, 22, Duration::from_millis(50));
+        assert_eq!(probe.detail, missing.detail);
+        assert_eq!(probe.hint, missing.hint);
     }
 
     #[test]

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -5558,6 +5558,40 @@ fn deploy_preflight_result(
     }
 }
 
+/// Resolve the `[deploy]` doctor branch from the merged active-profile runtime
+/// table.
+///
+/// Returns `(Some(cfg), None)` when `[deploy]` is present and parses (run the
+/// preflight graders), `(None, None)` when `[deploy]` is absent (skip the
+/// preflight gracefully), and `(None, Some(fail))` when `[deploy]` is present
+/// but a field has the wrong type. That last case is the important one: dropping
+/// the parse error with `.ok()` would silently skip every deploy check while
+/// `autumn deploy` (which loads the same `[deploy]` via `AutumnConfig::load()`)
+/// fails on it — so `doctor --strict` would greenlight a config the deploy path
+/// cannot parse. The `[deploy]` schema carries no secrets, so echoing the serde
+/// error into the check detail is safe.
+fn resolve_deploy_doctor_config(
+    merged: &toml::Table,
+) -> (Option<DeployConfig>, Option<CheckResult>) {
+    merged.get("deploy").cloned().map_or((None, None), |value| {
+        match value.try_into::<DeployConfig>() {
+            Ok(cfg) => (Some(cfg), None),
+            Err(err) => (
+                None,
+                Some(CheckResult {
+                    name: "deploy_config",
+                    status: CheckStatus::Fail,
+                    detail: Some(format!("[deploy] is present but invalid: {err}")),
+                    hint: Some(
+                        "Fix the [deploy] section in autumn.toml so its fields match the \
+                         expected types (see `autumn deploy check`)",
+                    ),
+                }),
+            ),
+        }
+    })
+}
+
 // ─── Main entry point ─────────────────────────────────────────────────────────
 
 /// Run all doctor checks and report results.
@@ -5739,11 +5773,18 @@ pub fn run(opts: DoctorOptions) {
     // effective target) — grading a deploy config the runtime never loads.
     let (deploy_canonical, deploy_selected, _) = resolve_active_profiles();
     let merged_deploy_toml = get_merged_toml_table_runtime(&deploy_canonical, &deploy_selected);
-    if let Some(deploy_cfg) = merged_deploy_toml
-        .get("deploy")
-        .cloned()
-        .and_then(|v| v.try_into::<DeployConfig>().ok())
-    {
+    // Distinguish "[deploy] absent" (skip the preflight gracefully) from
+    // "[deploy] present but malformed". Swallowing the parse error with `.ok()`
+    // would silently drop EVERY deploy check when a field has the wrong type
+    // (e.g. `ssh_port = "22"`, `keep_releases = -1`) — yet `autumn deploy` loads
+    // `AutumnConfig` and fails on the same table, so `doctor --strict` would
+    // greenlight a config the deploy path cannot parse. Surface a failing
+    // `deploy_config` check instead.
+    let (deploy_cfg, deploy_config_check) = resolve_deploy_doctor_config(&merged_deploy_toml);
+    if let Some(check) = deploy_config_check {
+        tasks.push(Box::new(move || check));
+    }
+    if let Some(deploy_cfg) = deploy_cfg {
         let deploy_signing = resolve_optional_signing_secret();
         // Derive the deploy DB-URL preflight input from the SAME merged
         // active-profile table used for `deploy_cfg` (base autumn.toml +
@@ -13717,6 +13758,65 @@ redirect_uri = "http://localhost/callback"
         assert!(
             json.contains("security.rate_limit.trusted_proxies"),
             "JSON must contain the deprecated key path"
+        );
+    }
+
+    #[test]
+    fn deploy_doctor_config_absent_is_skipped() {
+        // No [deploy] table → no config parsed, no failing check (graceful skip).
+        let table: toml::Table = "".parse().unwrap();
+        let (cfg, check) = resolve_deploy_doctor_config(&table);
+        assert!(cfg.is_none(), "absent [deploy] must not yield a config");
+        assert!(
+            check.is_none(),
+            "absent [deploy] must not emit a failing check"
+        );
+    }
+
+    #[test]
+    fn deploy_doctor_config_valid_parses() {
+        let table: toml::Table = "[deploy]\nhost = \"203.0.113.10\"\nssh_port = 2222\n"
+            .parse()
+            .unwrap();
+        let (cfg, check) = resolve_deploy_doctor_config(&table);
+        assert!(check.is_none(), "valid [deploy] must not emit a fail check");
+        let cfg = cfg.expect("valid [deploy] must parse into a config");
+        assert_eq!(cfg.host.as_deref(), Some("203.0.113.10"));
+        assert_eq!(cfg.ssh_port, 2222);
+    }
+
+    #[test]
+    fn deploy_doctor_config_bad_type_fails_not_skipped() {
+        // `ssh_port` as a string is a present-but-invalid table: the old `.ok()`
+        // path silently skipped ALL deploy checks; now it must FAIL loudly.
+        let table: toml::Table = "[deploy]\nhost = \"h\"\nssh_port = \"22\"\n"
+            .parse()
+            .unwrap();
+        let (cfg, check) = resolve_deploy_doctor_config(&table);
+        assert!(
+            cfg.is_none(),
+            "an invalid [deploy] must not yield a config to preflight"
+        );
+        let check = check.expect("an invalid [deploy] must emit a failing check");
+        assert_eq!(check.name, "deploy_config");
+        assert_eq!(check.status, CheckStatus::Fail);
+        assert!(
+            check.detail.unwrap().contains("present but invalid"),
+            "detail must explain the [deploy] table is present but invalid"
+        );
+    }
+
+    #[test]
+    fn deploy_doctor_config_negative_keep_releases_fails() {
+        // `keep_releases = -1` cannot deserialize into u32 → fail, not skip.
+        let table: toml::Table = "[deploy]\nhost = \"h\"\nkeep_releases = -1\n"
+            .parse()
+            .unwrap();
+        let (cfg, check) = resolve_deploy_doctor_config(&table);
+        assert!(cfg.is_none());
+        assert_eq!(
+            check.expect("negative keep_releases must fail").status,
+            CheckStatus::Fail
         );
     }
 }

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -5756,7 +5756,21 @@ pub fn run(opts: DoctorOptions) {
         // and `autumn deploy check` see it. Env-var precedence is preserved
         // (`resolve_database_topology` reads env first, then the merged table).
         let deploy_db_topology = resolve_database_topology(Some(&merged_deploy_toml));
-        let deploy_db_url = deploy_db_topology.primary_url;
+        // Shard-only apps declare no control `primary_url`/`url` but still have a
+        // usable database: `autumn migrate` targets each `[[database.shards]]`
+        // entry (see `migrate::build_targets`). Resolve the shard URLs from the
+        // SAME merged active-profile table, reusing the exact migrate resolver so
+        // preflight and the real migration step agree, and fall back to the first
+        // shard's primary URL when no control primary/replica resolves. The grader
+        // never prints the value.
+        let deploy_shards = crate::migrate::resolve_shard_database_urls_from_sources(
+            |key| std::env::var(key),
+            Some(&merged_deploy_toml),
+        );
+        let deploy_db_url = deploy_db_topology
+            .primary_url
+            .or(deploy_db_topology.replica_url)
+            .or_else(|| deploy_shards.into_iter().next().map(|(_, url)| url));
         // A `[database]` present in the merged runtime table marks the app as
         // database-backed even without a migrations directory, so `grade_database_url`
         // requires a URL. A DB-free app (no `[database]`, no migrations dir) passes.

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -5802,15 +5802,16 @@ pub fn run(opts: DoctorOptions) {
         // entry (see `migrate::build_targets`). Resolve the shard URLs from the
         // SAME merged active-profile table, reusing the exact migrate resolver so
         // preflight and the real migration step agree, and fall back to the first
-        // shard's primary URL when no control primary/replica resolves. The grader
-        // never prints the value.
+        // shard's primary URL when no control primary resolves. Only writable
+        // targets count — `database.replica_url` is excluded because `autumn
+        // migrate` cannot migrate against a replica. The grader never prints the
+        // value.
         let deploy_shards = crate::migrate::resolve_shard_database_urls_from_sources(
             |key| std::env::var(key),
             Some(&merged_deploy_toml),
         );
         let deploy_db_url = deploy_db_topology
             .primary_url
-            .or(deploy_db_topology.replica_url)
             .or_else(|| deploy_shards.into_iter().next().map(|(_, url)| url));
         // A `[database]` present in the merged runtime table marks the app as
         // database-backed even without a migrations directory, so `grade_database_url`

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -4069,8 +4069,11 @@ fn resolve_optional_signing_secret() -> Option<String> {
 /// `AutumnConfig::load()` and `autumn deploy check` see it. Never returns/prints
 /// the value except to the (secret-safe) grader. Env-var precedence matches the
 /// runtime loader.
-fn resolve_deploy_signing_secret(merged: &toml::Table) -> Option<String> {
-    if let Ok(val) = std::env::var("AUTUMN_SECURITY__SIGNING_SECRET")
+fn resolve_deploy_signing_secret(
+    merged: &toml::Table,
+    env: &dyn autumn_web::config::Env,
+) -> Option<String> {
+    if let Ok(val) = env.var("AUTUMN_SECURITY__SIGNING_SECRET")
         && !val.is_empty()
     {
         return Some(val);
@@ -4115,8 +4118,11 @@ fn resolve_deploy_previous_signing_secrets(merged: &toml::Table) -> Vec<String> 
 ///
 /// Cache, channels, and idempotency have only in-memory/Redis backends (no
 /// Postgres variant), so they never require a DB pool.
-fn resolve_deploy_db_backed_runtime(merged: &toml::Table) -> bool {
-    let env_var = |key: &str| std::env::var(key).ok().filter(|value| !value.is_empty());
+fn resolve_deploy_db_backed_runtime(
+    merged: &toml::Table,
+    env: &dyn autumn_web::config::Env,
+) -> bool {
+    let env_var = |key: &str| env.var(key).ok().filter(|value| !value.is_empty());
 
     let jobs = merged.get("jobs").and_then(toml::Value::as_table);
     let jobs_postgres = first_env(&env_var, &["AUTUMN_JOBS__BACKEND"])
@@ -5903,7 +5909,8 @@ pub fn run(opts: DoctorOptions) {
         // secret supplied only by the active profile is invisible to the raw
         // table, so a raw lookup would report it MISSING even though
         // `AutumnConfig::load()` and `autumn deploy check` see it.
-        let deploy_signing = resolve_deploy_signing_secret(&merged_deploy_toml);
+        let deploy_signing =
+            resolve_deploy_signing_secret(&merged_deploy_toml, deploy_denv.as_ref());
         // Rotation secrets accepted during a grace window are validated at boot
         // with the same rule as the current secret, so grade them here from the
         // same merged table (no env override exists for `previous_secrets`).
@@ -5954,7 +5961,8 @@ pub fn run(opts: DoctorOptions) {
         // even with no migrations dir and no `[database]` section. Resolved from
         // the SAME merged active-profile table so `doctor` and `deploy check`
         // apply the identical DB-required rule.
-        let deploy_db_backed_runtime = resolve_deploy_db_backed_runtime(&merged_deploy_toml);
+        let deploy_db_backed_runtime =
+            resolve_deploy_db_backed_runtime(&merged_deploy_toml, deploy_denv.as_ref());
 
         // Host presence is validated OFFLINE (always, whenever `[deploy]` is
         // configured): a `[deploy]` table with a missing/blank `host` makes

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -5818,8 +5818,23 @@ pub fn run(opts: DoctorOptions) {
         // requires a URL. A DB-free app (no `[database]`, no migrations dir) passes.
         let deploy_db_configured = merged_deploy_toml.get("database").is_some();
 
+        // Host presence is validated OFFLINE (always, whenever `[deploy]` is
+        // configured): a `[deploy]` table with a missing/blank `host` makes
+        // `autumn deploy check` fail immediately, so default/offline `doctor
+        // --strict` must fail on it too rather than green-lighting a config the
+        // deploy path rejects. Only the actual TCP connect probe is gated behind
+        // `--online`.
+        let host = deploy_cfg.host.clone();
+        tasks.push(Box::new({
+            let host = host.clone();
+            move || {
+                deploy_preflight_result(
+                    "deploy_host",
+                    crate::deploy::grade_deploy_host_present(host.as_deref()),
+                )
+            }
+        }));
         if opts.online {
-            let host = deploy_cfg.host.clone();
             let ssh_port = deploy_cfg.ssh_port;
             tasks.push(Box::new(move || {
                 deploy_preflight_result(

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -5881,8 +5881,17 @@ pub fn run(opts: DoctorOptions) {
     // `AutumnConfig::load()` so doctor grades the same target as `deploy check`
     // for an env-only or env-overridden deploy — instead of skipping or probing
     // a stale/base host.
+    // Read AUTUMN_DEPLOY__* through the profile-aware `.env` overlay so doctor
+    // resolves the same deploy target as `autumn deploy check` (AutumnConfig::load
+    // layers dotenv). Real OS env still wins; fall back to bare OS env only if the
+    // overlay can't be built (a malformed `.env`), matching the TLS/offsite-backup checks.
+    let deploy_denv: Box<dyn autumn_web::config::Env> =
+        match autumn_web::dotenv::os_env_with_dotenv_for_profile(&deploy_canonical) {
+            Ok(e) => Box::new(e),
+            Err(_) => Box::new(autumn_web::config::OsEnv),
+        };
     let (deploy_cfg, deploy_config_check) =
-        resolve_deploy_doctor_config(&merged_deploy_toml, &autumn_web::config::OsEnv);
+        resolve_deploy_doctor_config(&merged_deploy_toml, deploy_denv.as_ref());
     if let Some(check) = deploy_config_check {
         tasks.push(Box::new(move || check));
     }

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -4059,6 +4059,60 @@ fn resolve_optional_signing_secret() -> Option<String> {
         })
 }
 
+/// Resolve the signing secret the deploy preflight should grade, from the SAME
+/// merged active-profile runtime table used for the deploy config and DB URL
+/// (base autumn.toml + `[profile.<env>]` + autumn-<env>.toml), env first. A
+/// secret supplied only in an active profile
+/// (`[profile.<env>].security.signing_secret` / autumn-<env>.toml) is invisible
+/// to the raw top-level `autumn.toml` that [`resolve_optional_signing_secret`]
+/// reads, so a raw-table lookup would report it MISSING even though
+/// `AutumnConfig::load()` and `autumn deploy check` see it. Never returns/prints
+/// the value except to the (secret-safe) grader. Env-var precedence matches the
+/// runtime loader.
+fn resolve_deploy_signing_secret(merged: &toml::Table) -> Option<String> {
+    if let Ok(val) = std::env::var("AUTUMN_SECURITY__SIGNING_SECRET")
+        && !val.is_empty()
+    {
+        return Some(val);
+    }
+    merged
+        .get("security")
+        .and_then(|s| s.get("signing_secret"))
+        .and_then(|ss| ss.get("secret"))
+        .and_then(toml::Value::as_str)
+        .filter(|v| !v.is_empty())
+        .map(std::borrow::ToOwned::to_owned)
+}
+
+/// Whether any enabled runtime feature requires a configured Postgres pool at
+/// startup, resolved from the merged active-profile runtime table (env first).
+/// Mirrors the exact backend conditions the runtime enforces:
+/// - `jobs.backend = "postgres"` → `job::start_postgres_runtime` requires a pool.
+/// - `scheduler.backend = "postgres"` → `scheduler::coordinator_from_config`
+///   requires a pool.
+///
+/// Cache, channels, and idempotency have only in-memory/Redis backends (no
+/// Postgres variant), so they never require a DB pool.
+fn resolve_deploy_db_backed_runtime(merged: &toml::Table) -> bool {
+    let env_var = |key: &str| std::env::var(key).ok().filter(|value| !value.is_empty());
+
+    let jobs = merged.get("jobs").and_then(toml::Value::as_table);
+    let jobs_postgres = first_env(&env_var, &["AUTUMN_JOBS__BACKEND"])
+        .or_else(|| first_toml_string(jobs, &["backend"]))
+        .as_deref()
+        .map(str::trim)
+        == Some("postgres");
+
+    let scheduler = merged.get("scheduler").and_then(toml::Value::as_table);
+    let scheduler_postgres = first_env(&env_var, &["AUTUMN_SCHEDULER__BACKEND"])
+        .or_else(|| first_toml_string(scheduler, &["backend"]))
+        .as_deref()
+        .and_then(autumn_web::config::SchedulerBackend::from_env_value)
+        .is_some_and(|backend| backend == autumn_web::config::SchedulerBackend::Postgres);
+
+    jobs_postgres || scheduler_postgres
+}
+
 fn resolve_trusted_hosts() -> Vec<String> {
     if let Ok(val) = std::env::var("AUTUMN_SECURITY__TRUSTED_HOSTS__HOSTS") {
         return val
@@ -5785,7 +5839,14 @@ pub fn run(opts: DoctorOptions) {
         tasks.push(Box::new(move || check));
     }
     if let Some(deploy_cfg) = deploy_cfg {
-        let deploy_signing = resolve_optional_signing_secret();
+        // Resolve the deploy signing secret from the SAME merged active-profile
+        // table used for `deploy_cfg` and the DB URL (env first, then
+        // `merged_deploy_toml`'s `security.signing_secret.secret`) — NOT the raw
+        // top-level `autumn.toml` that `resolve_optional_signing_secret` reads. A
+        // secret supplied only by the active profile is invisible to the raw
+        // table, so a raw lookup would report it MISSING even though
+        // `AutumnConfig::load()` and `autumn deploy check` see it.
+        let deploy_signing = resolve_deploy_signing_secret(&merged_deploy_toml);
         // Derive the deploy DB-URL preflight input from the SAME merged
         // active-profile table used for `deploy_cfg` (base autumn.toml +
         // [profile.<env>] + autumn-<env>.toml), exactly like the sibling
@@ -5817,6 +5878,12 @@ pub fn run(opts: DoctorOptions) {
         // database-backed even without a migrations directory, so `grade_database_url`
         // requires a URL. A DB-free app (no `[database]`, no migrations dir) passes.
         let deploy_db_configured = merged_deploy_toml.get("database").is_some();
+        // A DB-backed runtime feature (jobs.backend/scheduler.backend = postgres)
+        // requires a configured pool at startup, so a writable DB URL is required
+        // even with no migrations dir and no `[database]` section. Resolved from
+        // the SAME merged active-profile table so `doctor` and `deploy check`
+        // apply the identical DB-required rule.
+        let deploy_db_backed_runtime = resolve_deploy_db_backed_runtime(&merged_deploy_toml);
 
         // Host presence is validated OFFLINE (always, whenever `[deploy]` is
         // configured): a `[deploy]` table with a missing/blank `host` makes
@@ -5851,7 +5918,7 @@ pub fn run(opts: DoctorOptions) {
         tasks.push(Box::new(move || {
             deploy_preflight_result(
                 "deploy_signing_secret",
-                crate::deploy::grade_signing_secret(deploy_signing.as_deref()),
+                crate::deploy::grade_signing_secret(deploy_signing.as_deref(), is_production),
             )
         }));
         tasks.push(Box::new(move || {
@@ -5861,6 +5928,7 @@ pub fn run(opts: DoctorOptions) {
                     deploy_db_url.as_deref(),
                     std::path::Path::new("migrations"),
                     deploy_db_configured,
+                    deploy_db_backed_runtime,
                 ),
             )
         }));

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -4,7 +4,7 @@
 //! reports each as ✅/⚠️/❌ with a one-line remediation hint, and exits with
 //! code 0 (all clear) or 1 (any failure detected).
 
-use autumn_web::config::ProcessRole;
+use autumn_web::config::{DeployConfig, ProcessRole};
 use serde::Serialize;
 use std::collections::{BTreeSet, HashMap, HashSet};
 
@@ -5537,6 +5537,27 @@ fn resolve_compression_enabled() -> bool {
     parse_enabled(&table).unwrap_or(false)
 }
 
+/// Map a shared `autumn deploy` preflight grader result into a doctor
+/// [`CheckResult`] under the given (deploy-namespaced) name. A passing grader
+/// becomes a `Pass`; a failing one becomes a `Fail` so `doctor --strict` treats
+/// a broken deploy target as a hard error, consistent with the other
+/// config-gated checks.
+fn deploy_preflight_result(
+    name: &'static str,
+    check: crate::deploy::PreflightCheck,
+) -> CheckResult {
+    CheckResult {
+        name,
+        status: if check.passed {
+            CheckStatus::Pass
+        } else {
+            CheckStatus::Fail
+        },
+        detail: Some(check.detail),
+        hint: check.hint,
+    }
+}
+
 // ─── Main entry point ─────────────────────────────────────────────────────────
 
 /// Run all doctor checks and report results.
@@ -5700,6 +5721,55 @@ pub fn run(opts: DoctorOptions) {
     tasks.push(Box::new(move || {
         check_trusted_hosts_impl(&trusted_hosts, is_production)
     }));
+
+    // 8-deploy. Deploy preflight (issue #1607). Config-gated: only runs when a
+    // `[deploy]` section is present, and skips gracefully otherwise. Reuses the
+    // exact graders behind `autumn deploy check`. The offline graders (signing
+    // secret, database URL, migrate check) always run when deploy is configured;
+    // the SSH-reachability network probe is gated behind `--online` so `doctor`
+    // stays offline and non-flaky by default, matching the ACME probes.
+    if let Some(deploy_cfg) = toml_table
+        .as_ref()
+        .and_then(|t| t.get("deploy").cloned())
+        .and_then(|v| v.try_into::<DeployConfig>().ok())
+    {
+        let deploy_signing = resolve_optional_signing_secret();
+        let deploy_db_url = db_topology.primary_url;
+
+        if opts.online {
+            let host = deploy_cfg.host.clone();
+            let ssh_port = deploy_cfg.ssh_port;
+            tasks.push(Box::new(move || {
+                deploy_preflight_result(
+                    "deploy_ssh_reachability",
+                    crate::deploy::grade_ssh_reachability(
+                        host.as_deref(),
+                        ssh_port,
+                        std::time::Duration::from_secs(5),
+                    ),
+                )
+            }));
+        }
+
+        tasks.push(Box::new(move || {
+            deploy_preflight_result(
+                "deploy_signing_secret",
+                crate::deploy::grade_signing_secret(deploy_signing.as_deref()),
+            )
+        }));
+        tasks.push(Box::new(move || {
+            deploy_preflight_result(
+                "deploy_database_url",
+                crate::deploy::grade_database_url(deploy_db_url.as_deref()),
+            )
+        }));
+        tasks.push(Box::new(|| {
+            deploy_preflight_result(
+                "deploy_migrate_check",
+                crate::deploy::grade_migrate_check(std::path::Path::new("migrations")),
+            )
+        }));
+    }
 
     // 8a. Direct-HTTPS certificate readiness (issue #1603): validate
     // [server.tls] cert/key and warn on near-expiry / fail on expired.

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -5728,9 +5728,20 @@ pub fn run(opts: DoctorOptions) {
     // secret, database URL, migrate check) always run when deploy is configured;
     // the SSH-reachability network probe is gated behind `--online` so `doctor`
     // stays offline and non-flaky by default, matching the ACME probes.
-    if let Some(deploy_cfg) = toml_table
-        .as_ref()
-        .and_then(|t| t.get("deploy").cloned())
+    //
+    // Resolve `[deploy]` from the MERGED active-profile runtime table (base
+    // autumn.toml + [profile.<env>] + autumn-<env>.toml), exactly like the
+    // sibling profile-aware checks (queue pinning, ACME) and the runtime config
+    // loader — NOT the raw top-level `toml_table`. A `[deploy]` block supplied
+    // only by an active profile (`autumn-<env>.toml` / `[profile.<env>].deploy`)
+    // is invisible to the raw table, so a raw-table lookup would skip the deploy
+    // preflight entirely (or `--online` would probe the base host instead of the
+    // effective target) — grading a deploy config the runtime never loads.
+    let (deploy_canonical, deploy_selected, _) = resolve_active_profiles();
+    let merged_deploy_toml = get_merged_toml_table_runtime(&deploy_canonical, &deploy_selected);
+    if let Some(deploy_cfg) = merged_deploy_toml
+        .get("deploy")
+        .cloned()
         .and_then(|v| v.try_into::<DeployConfig>().ok())
     {
         let deploy_signing = resolve_optional_signing_secret();

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -5745,7 +5745,22 @@ pub fn run(opts: DoctorOptions) {
         .and_then(|v| v.try_into::<DeployConfig>().ok())
     {
         let deploy_signing = resolve_optional_signing_secret();
-        let deploy_db_url = db_topology.primary_url;
+        // Derive the deploy DB-URL preflight input from the SAME merged
+        // active-profile table used for `deploy_cfg` (base autumn.toml +
+        // [profile.<env>] + autumn-<env>.toml), exactly like the sibling
+        // profile-aware checks above — NOT the pre-merge `db_topology` built from
+        // the raw top-level `toml_table`. A database URL supplied only by the
+        // active profile (`[profile.<env>].database` / `autumn-<env>.toml`) is
+        // invisible to the raw table, so a raw-table lookup would fail
+        // `deploy_database_url` under `--strict` even though `AutumnConfig::load()`
+        // and `autumn deploy check` see it. Env-var precedence is preserved
+        // (`resolve_database_topology` reads env first, then the merged table).
+        let deploy_db_topology = resolve_database_topology(Some(&merged_deploy_toml));
+        let deploy_db_url = deploy_db_topology.primary_url;
+        // A `[database]` present in the merged runtime table marks the app as
+        // database-backed even without a migrations directory, so `grade_database_url`
+        // requires a URL. A DB-free app (no `[database]`, no migrations dir) passes.
+        let deploy_db_configured = merged_deploy_toml.get("database").is_some();
 
         if opts.online {
             let host = deploy_cfg.host.clone();
@@ -5771,7 +5786,11 @@ pub fn run(opts: DoctorOptions) {
         tasks.push(Box::new(move || {
             deploy_preflight_result(
                 "deploy_database_url",
-                crate::deploy::grade_database_url(deploy_db_url.as_deref()),
+                crate::deploy::grade_database_url(
+                    deploy_db_url.as_deref(),
+                    std::path::Path::new("migrations"),
+                    deploy_db_configured,
+                ),
             )
         }));
         tasks.push(Box::new(|| {

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -5924,17 +5924,25 @@ pub fn run(opts: DoctorOptions) {
         // invisible to the raw table, so a raw-table lookup would fail
         // `deploy_database_url` under `--strict` even though `AutumnConfig::load()`
         // and `autumn deploy check` see it. Env-var precedence is preserved
-        // (`resolve_database_topology` reads env first, then the merged table).
-        let deploy_db_topology = resolve_database_topology(Some(&merged_deploy_toml));
+        // (`resolve_database_topology_from_sources` reads the overlay first, then
+        // the merged table). Resolve through `deploy_denv` — the profile-aware
+        // `.env` overlay — so a URL set only in `.env`/`.env.<profile>` is seen
+        // by doctor exactly as `AutumnConfig::load()`/`deploy check` see it,
+        // instead of the bare process env.
+        let deploy_db_topology = resolve_database_topology_from_sources(
+            |key| deploy_denv.var(key).ok().filter(|value| !value.is_empty()),
+            Some(&merged_deploy_toml),
+        );
         // Shard-only apps declare no control `primary_url`/`url` but still have a
         // usable database: `autumn migrate` targets each `[[database.shards]]`
-        // entry (see `migrate::build_targets`). Resolve the shard URLs from the
-        // SAME merged active-profile table, reusing the exact migrate resolver so
-        // preflight and the real migration step agree, and fall back to the first
-        // shard's primary URL when no control primary resolves. Only writable
-        // targets count — `database.replica_url` is excluded because `autumn
-        // migrate` cannot migrate against a replica. The grader never prints the
-        // value.
+        // entry (see `migrate::build_targets`). Resolve the shard URLs through the
+        // SAME `deploy_denv` overlay + merged active-profile table, reusing the
+        // exact migrate resolver so preflight and the real migration step agree,
+        // and fall back to the first shard's primary URL when no control primary
+        // resolves. Only writable targets count — `database.replica_url` is
+        // excluded because `autumn migrate` cannot migrate against a replica. The
+        // grader never prints the value.
+        //
         // Use the FALLIBLE shard resolver here: the exiting
         // `resolve_shard_database_urls_from_sources` calls `std::process::exit(1)`
         // on a malformed `[[database.shards]]` entry, which — running while
@@ -5943,19 +5951,31 @@ pub fn run(opts: DoctorOptions) {
         // Instead map an `Err` to a failing `deploy_database_url` check below so
         // doctor still produces valid output. `autumn migrate` keeps its
         // print-and-exit behavior via the thin wrapper.
-        let deploy_db_url_result = crate::migrate::try_resolve_shard_database_urls_from_sources(
-            |key| std::env::var(key),
+        //
+        // Lift the resolver into its own binding so it feeds BOTH the
+        // db-configured flag (shard presence) and the writable URL below.
+        let deploy_shards_result = crate::migrate::try_resolve_shard_database_urls_from_sources(
+            |key| deploy_denv.var(key),
             Some(&merged_deploy_toml),
-        )
-        .map(|deploy_shards| {
+        );
+        // Derive db-configured from resolved URL/shard presence, mirroring
+        // `deploy.rs` `collect_preflight` (`url || primary_url || replica_url ||
+        // has_shards()`) — NOT mere `[database]` table presence, which flips true
+        // on a tuning-only table (e.g. `pool_size`) and would falsely fail
+        // `deploy_database_url` for a config `deploy check` accepts. `primary_url`
+        // here folds `url`+`primary_url`. Computed BEFORE the writable-URL `.map()`
+        // below moves `primary_url` (this only borrows it via `.is_some()`).
+        let deploy_db_configured = deploy_db_topology.primary_url.is_some()
+            || deploy_db_topology.replica_url.is_some()
+            || deploy_shards_result
+                .as_ref()
+                .map(|shards| !shards.is_empty())
+                .unwrap_or(false);
+        let deploy_db_url_result = deploy_shards_result.map(|deploy_shards| {
             deploy_db_topology
                 .primary_url
                 .or_else(|| deploy_shards.into_iter().next().map(|(_, url)| url))
         });
-        // A `[database]` present in the merged runtime table marks the app as
-        // database-backed even without a migrations directory, so `grade_database_url`
-        // requires a URL. A DB-free app (no `[database]`, no migrations dir) passes.
-        let deploy_db_configured = merged_deploy_toml.get("database").is_some();
         // A DB-backed runtime feature (jobs.backend/scheduler.backend = postgres)
         // requires a configured pool at startup, so a writable DB URL is required
         // even with no migrations dir and no `[database]` section. Resolved from

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -5648,24 +5648,43 @@ fn deploy_preflight_result(
 /// error into the check detail is safe.
 fn resolve_deploy_doctor_config(
     merged: &toml::Table,
+    env: &dyn autumn_web::config::Env,
 ) -> (Option<DeployConfig>, Option<CheckResult>) {
-    merged.get("deploy").cloned().map_or((None, None), |value| {
-        match value.try_into::<DeployConfig>() {
-            Ok(cfg) => (Some(cfg), None),
-            Err(err) => (
-                None,
-                Some(CheckResult {
-                    name: "deploy_config",
-                    status: CheckStatus::Fail,
-                    detail: Some(format!("[deploy] is present but invalid: {err}")),
-                    hint: Some(
-                        "Fix the [deploy] section in autumn.toml so its fields match the \
-                         expected types (see `autumn deploy check`)",
-                    ),
-                }),
-            ),
-        }
-    })
+    // First resolve the merged-profile `[deploy]` table (base autumn.toml +
+    // [profile.<env>] + autumn-<env>.toml). A present-but-malformed table is a
+    // hard fail regardless of env, because `AutumnConfig::load()` also fails to
+    // deserialize it, so `autumn deploy` cannot run — surface it loudly instead
+    // of silently skipping.
+    let mut deploy_cfg = match merged.get("deploy").cloned() {
+        Some(value) => match value.try_into::<DeployConfig>() {
+            Ok(cfg) => Some(cfg),
+            Err(err) => {
+                return (
+                    None,
+                    Some(CheckResult {
+                        name: "deploy_config",
+                        status: CheckStatus::Fail,
+                        detail: Some(format!("[deploy] is present but invalid: {err}")),
+                        hint: Some(
+                            "Fix the [deploy] section in autumn.toml so its fields match the \
+                             expected types (see `autumn deploy check`)",
+                        ),
+                    }),
+                );
+            }
+        },
+        None => None,
+    };
+    // Apply `AUTUMN_DEPLOY__*` env overrides on top of the merged-profile value,
+    // exactly like `AutumnConfig::load()` does before `autumn deploy check`
+    // grades `config.deploy`. This makes doctor grade the SAME deploy target as
+    // `deploy check` for the same env + profile + TOML: an env-only
+    // `AUTUMN_DEPLOY__HOST` materializes `Some(DeployConfig)` (so the preflight
+    // runs instead of being skipped), and env values win over TOML. When no
+    // `[deploy]` TOML and no `AUTUMN_DEPLOY__*` env exist, this stays `None` and
+    // the preflight skips gracefully.
+    autumn_web::config::apply_deploy_env_overrides(&mut deploy_cfg, env);
+    (deploy_cfg, None)
 }
 
 // ─── Main entry point ─────────────────────────────────────────────────────────
@@ -5856,7 +5875,14 @@ pub fn run(opts: DoctorOptions) {
     // `AutumnConfig` and fails on the same table, so `doctor --strict` would
     // greenlight a config the deploy path cannot parse. Surface a failing
     // `deploy_config` check instead.
-    let (deploy_cfg, deploy_config_check) = resolve_deploy_doctor_config(&merged_deploy_toml);
+    //
+    // `AUTUMN_DEPLOY__*` env overrides are then applied on top (env wins over
+    // TOML, and an env-only host materializes a deploy config), matching
+    // `AutumnConfig::load()` so doctor grades the same target as `deploy check`
+    // for an env-only or env-overridden deploy — instead of skipping or probing
+    // a stale/base host.
+    let (deploy_cfg, deploy_config_check) =
+        resolve_deploy_doctor_config(&merged_deploy_toml, &autumn_web::config::OsEnv);
     if let Some(check) = deploy_config_check {
         tasks.push(Box::new(move || check));
     }
@@ -5893,13 +5919,23 @@ pub fn run(opts: DoctorOptions) {
         // targets count — `database.replica_url` is excluded because `autumn
         // migrate` cannot migrate against a replica. The grader never prints the
         // value.
-        let deploy_shards = crate::migrate::resolve_shard_database_urls_from_sources(
+        // Use the FALLIBLE shard resolver here: the exiting
+        // `resolve_shard_database_urls_from_sources` calls `std::process::exit(1)`
+        // on a malformed `[[database.shards]]` entry, which — running while
+        // BUILDING doctor tasks — would terminate `autumn doctor --json` before it
+        // emits its JSON result/summary, bypassing normal `CheckResult` reporting.
+        // Instead map an `Err` to a failing `deploy_database_url` check below so
+        // doctor still produces valid output. `autumn migrate` keeps its
+        // print-and-exit behavior via the thin wrapper.
+        let deploy_db_url_result = crate::migrate::try_resolve_shard_database_urls_from_sources(
             |key| std::env::var(key),
             Some(&merged_deploy_toml),
-        );
-        let deploy_db_url = deploy_db_topology
-            .primary_url
-            .or_else(|| deploy_shards.into_iter().next().map(|(_, url)| url));
+        )
+        .map(|deploy_shards| {
+            deploy_db_topology
+                .primary_url
+                .or_else(|| deploy_shards.into_iter().next().map(|(_, url)| url))
+        });
         // A `[database]` present in the merged runtime table marks the app as
         // database-backed even without a migrations directory, so `grade_database_url`
         // requires a URL. A DB-free app (no `[database]`, no migrations dir) passes.
@@ -5951,17 +5987,35 @@ pub fn run(opts: DoctorOptions) {
                 ),
             )
         }));
-        tasks.push(Box::new(move || {
-            deploy_preflight_result(
-                "deploy_database_url",
-                crate::deploy::grade_database_url(
-                    deploy_db_url.as_deref(),
-                    std::path::Path::new("migrations"),
-                    deploy_db_configured,
-                    deploy_db_backed_runtime,
-                ),
-            )
-        }));
+        match deploy_db_url_result {
+            Ok(deploy_db_url) => {
+                tasks.push(Box::new(move || {
+                    deploy_preflight_result(
+                        "deploy_database_url",
+                        crate::deploy::grade_database_url(
+                            deploy_db_url.as_deref(),
+                            std::path::Path::new("migrations"),
+                            deploy_db_configured,
+                            deploy_db_backed_runtime,
+                        ),
+                    )
+                }));
+            }
+            Err(msg) => {
+                // A malformed `[[database.shards]]` entry: surface it as a FAILING
+                // check instead of exiting the process, so `autumn doctor --json`
+                // still emits valid JSON with a clear, actionable failure.
+                tasks.push(Box::new(move || CheckResult {
+                    name: "deploy_database_url",
+                    status: CheckStatus::Fail,
+                    detail: Some(format!("[[database.shards]] is present but invalid: {msg}")),
+                    hint: Some(
+                        "Fix the [[database.shards]] entries in autumn.toml so each has a string \
+                         `name` and `primary_url` with unique names (see `autumn deploy check`)",
+                    ),
+                }));
+            }
+        }
         tasks.push(Box::new(|| {
             deploy_preflight_result(
                 "deploy_migrate_check",
@@ -13877,9 +13931,11 @@ redirect_uri = "http://localhost/callback"
 
     #[test]
     fn deploy_doctor_config_absent_is_skipped() {
-        // No [deploy] table → no config parsed, no failing check (graceful skip).
+        use autumn_web::config::MockEnv;
+        // No [deploy] table and no AUTUMN_DEPLOY__* env → no config parsed, no
+        // failing check (graceful skip).
         let table: toml::Table = "".parse().unwrap();
-        let (cfg, check) = resolve_deploy_doctor_config(&table);
+        let (cfg, check) = resolve_deploy_doctor_config(&table, &MockEnv::new());
         assert!(cfg.is_none(), "absent [deploy] must not yield a config");
         assert!(
             check.is_none(),
@@ -13889,10 +13945,11 @@ redirect_uri = "http://localhost/callback"
 
     #[test]
     fn deploy_doctor_config_valid_parses() {
+        use autumn_web::config::MockEnv;
         let table: toml::Table = "[deploy]\nhost = \"203.0.113.10\"\nssh_port = 2222\n"
             .parse()
             .unwrap();
-        let (cfg, check) = resolve_deploy_doctor_config(&table);
+        let (cfg, check) = resolve_deploy_doctor_config(&table, &MockEnv::new());
         assert!(check.is_none(), "valid [deploy] must not emit a fail check");
         let cfg = cfg.expect("valid [deploy] must parse into a config");
         assert_eq!(cfg.host.as_deref(), Some("203.0.113.10"));
@@ -13900,13 +13957,56 @@ redirect_uri = "http://localhost/callback"
     }
 
     #[test]
+    fn deploy_doctor_config_env_only_host_materializes_config() {
+        use autumn_web::config::MockEnv;
+        // No [deploy] in TOML, but AUTUMN_DEPLOY__HOST is set: doctor must
+        // materialize a deploy config (Some) so the preflight runs against that
+        // host instead of being skipped — matching `autumn deploy check`, which
+        // grades `AutumnConfig::load().deploy` (env applied).
+        let table: toml::Table = "".parse().unwrap();
+        let env = MockEnv::new()
+            .with("AUTUMN_DEPLOY__HOST", "203.0.113.99")
+            .with("AUTUMN_DEPLOY__SSH_PORT", "2201");
+        let (cfg, check) = resolve_deploy_doctor_config(&table, &env);
+        assert!(
+            check.is_none(),
+            "env-only deploy must not emit a fail check"
+        );
+        let cfg = cfg.expect("env-only AUTUMN_DEPLOY__HOST must materialize a config");
+        assert_eq!(cfg.host.as_deref(), Some("203.0.113.99"));
+        assert_eq!(cfg.ssh_port, 2201);
+    }
+
+    #[test]
+    fn deploy_doctor_config_env_overrides_toml_host() {
+        use autumn_web::config::MockEnv;
+        // A TOML host is present, but AUTUMN_DEPLOY__HOST wins — doctor grades
+        // the same effective target as `autumn deploy check`.
+        let table: toml::Table = "[deploy]\nhost = \"toml.example\"\nssh_port = 22\n"
+            .parse()
+            .unwrap();
+        let env = MockEnv::new().with("AUTUMN_DEPLOY__HOST", "env.example");
+        let (cfg, check) = resolve_deploy_doctor_config(&table, &env);
+        assert!(check.is_none());
+        let cfg = cfg.expect("config must be present");
+        assert_eq!(
+            cfg.host.as_deref(),
+            Some("env.example"),
+            "AUTUMN_DEPLOY__HOST must override the TOML host"
+        );
+        // Unset env fields fall back to the TOML value.
+        assert_eq!(cfg.ssh_port, 22);
+    }
+
+    #[test]
     fn deploy_doctor_config_bad_type_fails_not_skipped() {
+        use autumn_web::config::MockEnv;
         // `ssh_port` as a string is a present-but-invalid table: the old `.ok()`
         // path silently skipped ALL deploy checks; now it must FAIL loudly.
         let table: toml::Table = "[deploy]\nhost = \"h\"\nssh_port = \"22\"\n"
             .parse()
             .unwrap();
-        let (cfg, check) = resolve_deploy_doctor_config(&table);
+        let (cfg, check) = resolve_deploy_doctor_config(&table, &MockEnv::new());
         assert!(
             cfg.is_none(),
             "an invalid [deploy] must not yield a config to preflight"
@@ -13922,11 +14022,12 @@ redirect_uri = "http://localhost/callback"
 
     #[test]
     fn deploy_doctor_config_negative_keep_releases_fails() {
+        use autumn_web::config::MockEnv;
         // `keep_releases = -1` cannot deserialize into u32 → fail, not skip.
         let table: toml::Table = "[deploy]\nhost = \"h\"\nkeep_releases = -1\n"
             .parse()
             .unwrap();
-        let (cfg, check) = resolve_deploy_doctor_config(&table);
+        let (cfg, check) = resolve_deploy_doctor_config(&table, &MockEnv::new());
         assert!(cfg.is_none());
         assert_eq!(
             check.expect("negative keep_releases must fail").status,

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -4084,6 +4084,28 @@ fn resolve_deploy_signing_secret(merged: &toml::Table) -> Option<String> {
         .map(std::borrow::ToOwned::to_owned)
 }
 
+/// Resolve the `previous_secrets` rotation entries the deploy preflight should
+/// grade, from the SAME merged active-profile runtime table used for the current
+/// signing secret. `previous_secrets` has no env override in the runtime loader
+/// (only `AUTUMN_SECURITY__SIGNING_SECRET` sets the current secret), so it is
+/// read from the merged table alone — matching what `AutumnConfig::load()` and
+/// `autumn deploy check` see. Never returns/prints the values except to the
+/// (secret-safe) grader.
+fn resolve_deploy_previous_signing_secrets(merged: &toml::Table) -> Vec<String> {
+    merged
+        .get("security")
+        .and_then(|s| s.get("signing_secret"))
+        .and_then(|ss| ss.get("previous_secrets"))
+        .and_then(toml::Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(toml::Value::as_str)
+                .map(std::borrow::ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// Whether any enabled runtime feature requires a configured Postgres pool at
 /// startup, resolved from the merged active-profile runtime table (env first).
 /// Mirrors the exact backend conditions the runtime enforces:
@@ -5847,6 +5869,10 @@ pub fn run(opts: DoctorOptions) {
         // table, so a raw lookup would report it MISSING even though
         // `AutumnConfig::load()` and `autumn deploy check` see it.
         let deploy_signing = resolve_deploy_signing_secret(&merged_deploy_toml);
+        // Rotation secrets accepted during a grace window are validated at boot
+        // with the same rule as the current secret, so grade them here from the
+        // same merged table (no env override exists for `previous_secrets`).
+        let deploy_previous_signing = resolve_deploy_previous_signing_secrets(&merged_deploy_toml);
         // Derive the deploy DB-URL preflight input from the SAME merged
         // active-profile table used for `deploy_cfg` (base autumn.toml +
         // [profile.<env>] + autumn-<env>.toml), exactly like the sibling
@@ -5918,7 +5944,11 @@ pub fn run(opts: DoctorOptions) {
         tasks.push(Box::new(move || {
             deploy_preflight_result(
                 "deploy_signing_secret",
-                crate::deploy::grade_signing_secret(deploy_signing.as_deref(), is_production),
+                crate::deploy::grade_signing_secret(
+                    deploy_signing.as_deref(),
+                    &deploy_previous_signing,
+                    is_production,
+                ),
             )
         }));
         tasks.push(Box::new(move || {

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -12,6 +12,7 @@ mod credentials;
 mod data;
 mod db;
 mod db_pull;
+mod deploy;
 mod dev;
 mod dev_loop_bench;
 mod dev_loop_scaling;
@@ -524,6 +525,20 @@ enum Commands {
     ///   autumn release init --target docker-compose
     #[command(subcommand, verbatim_doc_comment)]
     Release(ReleaseCommands),
+
+    /// Push-button, zero-downtime deploys to a VPS (issue #1607).
+    ///
+    /// Run from the project root. `check` runs a local preflight, `plan` and
+    /// `rollback` print dry-run plans. Real remote execution lands in a
+    /// follow-up; configure the target under `[deploy]` in autumn.toml.
+    ///
+    /// # Examples
+    ///
+    ///   autumn deploy check
+    ///   autumn deploy plan
+    ///   autumn deploy rollback
+    #[command(subcommand, verbatim_doc_comment)]
+    Deploy(DeployCommands),
 
     /// Simulate a signed webhook request to the local application.
     #[command(subcommand, verbatim_doc_comment)]
@@ -1793,6 +1808,27 @@ enum ReleaseCommands {
     },
 }
 
+/// Subcommands for `autumn deploy`.
+#[derive(Subcommand)]
+enum DeployCommands {
+    /// Run the deploy preflight and report pass/fail.
+    ///
+    /// Checks SSH reachability, signing-secret presence, database URL, and that
+    /// `migrate check` is clean. Exits non-zero if any check fails. Also runs
+    /// (config-gated) as a section of `autumn doctor`.
+    Check,
+
+    /// Print the systemd unit and the ordered zero-downtime deploy plan.
+    ///
+    /// Pure dry-run — renders the plan without touching anything remote.
+    Plan,
+
+    /// Print the rollback plan (dry-run).
+    ///
+    /// Live rollback lands in a follow-up; this slice prints the plan only.
+    Rollback,
+}
+
 /// Subcommands for `autumn generate`.
 #[derive(Subcommand)]
 enum GenerateCommands {
@@ -2848,6 +2884,7 @@ fn run_command(command: Commands) {
             ),
         },
         Commands::Release(cmd) => run_release_command(cmd),
+        Commands::Deploy(cmd) => run_deploy_command(&cmd),
         Commands::Token(cmd) => match cmd {
             TokenCommands::Issue {
                 principal_id,
@@ -3320,6 +3357,18 @@ fn run_release_command(cmd: ReleaseCommands) {
                 split_workers,
             });
         }
+    }
+}
+
+fn run_deploy_command(cmd: &DeployCommands) {
+    let action = match cmd {
+        DeployCommands::Check => deploy::DeployAction::Check,
+        DeployCommands::Plan => deploy::DeployAction::Plan,
+        DeployCommands::Rollback => deploy::DeployAction::Rollback,
+    };
+    if let Err(e) = deploy::run(action) {
+        eprintln!("autumn deploy: {e}");
+        std::process::exit(1);
     }
 }
 

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -1109,50 +1109,69 @@ pub fn resolve_shard_database_urls_from_sources<F>(
 where
     F: Fn(&str) -> Result<String, std::env::VarError>,
 {
+    // Thin wrapper over the fallible core: preserve the historical
+    // print-and-exit behavior for command paths (`autumn migrate`, `db backup`,
+    // …) that expect a `Vec` and abort on a malformed shard. Callers that must
+    // NOT exit the process (e.g. `autumn doctor`, which needs to emit a JSON
+    // `CheckResult` instead) call `try_resolve_shard_database_urls_from_sources`
+    // directly and map the `Err` to a failing check.
+    try_resolve_shard_database_urls_from_sources(env_var, table).unwrap_or_else(|msg| {
+        eprintln!("\u{2717} {msg}");
+        std::process::exit(1);
+    })
+}
+
+/// Fallible core of [`resolve_shard_database_urls_from_sources`].
+///
+/// Resolves `(name, primary_url)` for every `[[database.shards]]` entry (TOML +
+/// `AUTUMN_DATABASE__SHARDS__*` env overrides), returning `Err(message)` on a
+/// malformed shard (non-table entry, missing `name`/`primary_url`, or a
+/// duplicate shard name) instead of printing and exiting the process. The
+/// message carries no leading `✗` marker so callers can render it however they
+/// like; the exiting wrapper prepends the marker to keep its stderr output
+/// byte-identical.
+pub fn try_resolve_shard_database_urls_from_sources<F>(
+    env_var: F,
+    table: Option<&toml::Table>,
+) -> Result<Vec<(String, String)>, String>
+where
+    F: Fn(&str) -> Result<String, std::env::VarError>,
+{
     const MAX_ENV_SHARDS: usize = 64;
 
-    let mut shards: Vec<(String, String)> = table
+    let mut shards: Vec<(String, String)> = Vec::new();
+    if let Some(entries) = table
         .and_then(|table| table.get("database"))
         .and_then(toml::Value::as_table)
         .and_then(|database| database.get("shards"))
         .and_then(toml::Value::as_array)
-        .map(|entries| {
-            // Fail fast on a malformed `[[database.shards]]` entry rather than
-            // silently dropping it: the runtime config loader rejects the same
-            // config, so skipping a misspelled shard here would let `autumn
-            // migrate` "succeed" while leaving that shard unmigrated.
-            entries
-                .iter()
-                .enumerate()
-                .map(|(i, entry)| {
-                    let shard = entry.as_table().unwrap_or_else(|| {
-                        eprintln!("\u{2717} [[database.shards]] entry {i} is not a table.");
-                        std::process::exit(1);
-                    });
-                    let name = shard
-                        .get("name")
-                        .and_then(toml::Value::as_str)
-                        .unwrap_or_else(|| {
-                            eprintln!(
-                                "\u{2717} [[database.shards]] entry {i} is missing a string `name`."
-                            );
-                            std::process::exit(1);
-                        });
-                    let url = shard
-                        .get("primary_url")
-                        .and_then(toml::Value::as_str)
-                        .unwrap_or_else(|| {
-                            eprintln!(
-                                "\u{2717} [[database.shards]] entry {i} ({name:?}) is missing a \
-                                 string `primary_url`."
-                            );
-                            std::process::exit(1);
-                        });
-                    (name.to_owned(), url.to_owned())
-                })
-                .collect()
-        })
-        .unwrap_or_default();
+    {
+        // Fail on a malformed `[[database.shards]]` entry rather than silently
+        // dropping it: the runtime config loader rejects the same config, so
+        // skipping a misspelled shard here would let `autumn migrate` "succeed"
+        // while leaving that shard unmigrated.
+        for (i, entry) in entries.iter().enumerate() {
+            let shard = entry
+                .as_table()
+                .ok_or_else(|| format!("[[database.shards]] entry {i} is not a table."))?;
+            let name = shard
+                .get("name")
+                .and_then(toml::Value::as_str)
+                .ok_or_else(|| {
+                    format!("[[database.shards]] entry {i} is missing a string `name`.")
+                })?;
+            let url = shard
+                .get("primary_url")
+                .and_then(toml::Value::as_str)
+                .ok_or_else(|| {
+                    format!(
+                        "[[database.shards]] entry {i} ({name:?}) is missing a string \
+                         `primary_url`."
+                    )
+                })?;
+            shards.push((name.to_owned(), url.to_owned()));
+        }
+    }
 
     for i in 0..MAX_ENV_SHARDS {
         let name_var = format!("AUTUMN_DATABASE__SHARDS__{i}__NAME");
@@ -1178,15 +1197,14 @@ where
     let mut seen = std::collections::HashSet::new();
     for (name, _) in &shards {
         if !seen.insert(name.as_str()) {
-            eprintln!(
-                "\u{2717} Duplicate shard name {name:?} in [[database.shards]] / \
+            return Err(format!(
+                "Duplicate shard name {name:?} in [[database.shards]] / \
                  AUTUMN_DATABASE__SHARDS__* — shard names must be unique."
-            );
-            std::process::exit(1);
+            ));
         }
     }
 
-    shards
+    Ok(shards)
 }
 
 /// Resolve `database.startup_wait_secs` from env and config, mirroring the
@@ -2988,6 +3006,67 @@ primary_url = "postgres://toml:5432/app"
     #[test]
     fn shard_urls_empty_without_shards() {
         assert!(resolve_shard_database_urls_from_sources(no_env, None).is_empty());
+    }
+
+    #[test]
+    fn try_shard_urls_ok_matches_exiting_variant() {
+        let table = toml::from_str::<toml::Table>(
+            r#"
+[[database.shards]]
+name = "shard0"
+primary_url = "postgres://shard0:5432/app"
+"#,
+        )
+        .unwrap();
+        // The fallible core returns the same successful result the exiting wrapper
+        // does, so command paths keep identical behavior.
+        assert_eq!(
+            try_resolve_shard_database_urls_from_sources(no_env, Some(&table)).unwrap(),
+            vec![("shard0".to_owned(), "postgres://shard0:5432/app".to_owned())],
+        );
+    }
+
+    #[test]
+    fn try_shard_urls_missing_primary_url_returns_err_not_exit() {
+        // A malformed `[[database.shards]]` entry (missing `primary_url`) makes the
+        // exiting variant `std::process::exit(1)`. The fallible core must instead
+        // return `Err` so `autumn doctor` can render a failing check rather than
+        // terminating before emitting JSON.
+        let table = toml::from_str::<toml::Table>(
+            r#"
+[[database.shards]]
+name = "shard0"
+"#,
+        )
+        .unwrap();
+        let err = try_resolve_shard_database_urls_from_sources(no_env, Some(&table))
+            .expect_err("a shard missing primary_url must be an Err, not a process exit");
+        assert!(
+            err.contains("primary_url"),
+            "error must name the missing field: {err}"
+        );
+    }
+
+    #[test]
+    fn try_shard_urls_duplicate_name_returns_err() {
+        let table = toml::from_str::<toml::Table>(
+            r#"
+[[database.shards]]
+name = "dup"
+primary_url = "postgres://a:5432/app"
+
+[[database.shards]]
+name = "dup"
+primary_url = "postgres://b:5432/app"
+"#,
+        )
+        .unwrap();
+        let err = try_resolve_shard_database_urls_from_sources(no_env, Some(&table))
+            .expect_err("duplicate shard names must be an Err");
+        assert!(
+            err.contains("Duplicate shard name"),
+            "error must flag the duplicate: {err}"
+        );
     }
 
     // ── deep_merge_toml / profile overlay ──────────────────────────────────

--- a/autumn-cli/tests/integration/deploy.rs
+++ b/autumn-cli/tests/integration/deploy.rs
@@ -110,6 +110,45 @@ fn doctor_fails_offline_on_deploy_without_host() {
 }
 
 #[test]
+fn doctor_reads_deploy_host_from_dotenv() {
+    // Regression: doctor must layer .env like `deploy check` (Codex round-10 P2)
+    // — bare OsEnv would skip this. With NO `[deploy]` in autumn.toml and the
+    // deploy host supplied ONLY via `AUTUMN_DEPLOY__HOST` in a `.env` file, the
+    // profile-aware dotenv overlay must materialize the deploy config so the
+    // `deploy_host` preflight RUNS (and passes) instead of being skipped — which
+    // is exactly what happens if doctor resolves through a bare `OsEnv`.
+    let dir = tempfile::tempdir().expect("create temp project dir");
+    // Package name for the app-name default; deliberately NO `[deploy]` section
+    // in autumn.toml so that, absent dotenv, the deploy preflight is skipped.
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"demoapp\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .expect("write Cargo.toml");
+    fs::write(dir.path().join("autumn.toml"), "").expect("write autumn.toml");
+    // Host arrives ONLY through `.env` — never the process env — so the test
+    // proves the dotenv overlay path, not an OS-env read.
+    fs::write(
+        dir.path().join(".env"),
+        "AUTUMN_DEPLOY__HOST=deploy.example.test\n",
+    )
+    .expect("write .env");
+
+    // `AUTUMN_DOTENV=1` force-loads `.env` regardless of the resolved profile so
+    // the test is deterministic; it does NOT carry the deploy host itself.
+    let (stdout, stderr, _code) = run_autumn(dir.path(), &["doctor"], &[("AUTUMN_DOTENV", "1")]);
+    let combined = format!("{stdout}{stderr}");
+    // Passing check renders as `✅ deploy_host — deploy target host is configured`
+    // (see `format_check_line` / `grade_deploy_host_present`). Its presence means
+    // the env-only host materialized a deploy config and the preflight ran.
+    assert!(
+        combined.contains("deploy_host — deploy target host is configured"),
+        "doctor must resolve the .env-only deploy host and run the deploy_host \
+         check (bare OsEnv would skip it)\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
 fn deploy_help_lists_subcommands() {
     let dir = tempfile::tempdir().expect("temp dir");
     let (stdout, stderr, code) = run_autumn(dir.path(), &["deploy", "--help"], &[]);

--- a/autumn-cli/tests/integration/deploy.rs
+++ b/autumn-cli/tests/integration/deploy.rs
@@ -1,0 +1,104 @@
+//! Integration tests for `autumn deploy` (issue #1607).
+//!
+//! Exercise the locally-verifiable spine: `deploy plan` renders the systemd
+//! unit and the ordered step list, `deploy check` fails fast with an actionable
+//! message when `[deploy] host` is unset, and the group exposes `--help`.
+
+use std::fs;
+
+use crate::common::{run_autumn, run_autumn_fail};
+use tempfile::TempDir;
+
+/// A minimal project directory with a `Cargo.toml` (for the package-name
+/// default) and an `autumn.toml` containing the given `[deploy]` body.
+fn project(deploy_body: &str) -> TempDir {
+    let dir = tempfile::tempdir().expect("create temp project dir");
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"demoapp\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .expect("write Cargo.toml");
+    fs::write(
+        dir.path().join("autumn.toml"),
+        format!("[deploy]\n{deploy_body}"),
+    )
+    .expect("write autumn.toml");
+    dir
+}
+
+#[test]
+fn deploy_plan_prints_unit_and_steps() {
+    let dir = project("host = \"203.0.113.10\"\n");
+    let (stdout, stderr, code) = run_autumn(dir.path(), &["deploy", "plan"], &[]);
+    assert_eq!(
+        code,
+        Some(0),
+        "deploy plan should succeed\nstderr:\n{stderr}"
+    );
+
+    // Renders the systemd unit with the resolved paths and an EnvironmentFile
+    // (secrets are never inlined into the unit).
+    assert!(
+        stdout.contains("ExecStart=autumn serve --release"),
+        "stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("WantedBy=multi-user.target"),
+        "stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("EnvironmentFile=/srv/autumn/demoapp/shared/autumn.env"),
+        "stdout:\n{stdout}"
+    );
+
+    // Renders the ordered deploy steps, with migrations before cutover.
+    let migrate = stdout.find("[migrate]").expect("migrate step present");
+    let cutover = stdout.find("[cutover]").expect("cutover step present");
+    assert!(
+        migrate < cutover,
+        "migrations must precede cutover\nstdout:\n{stdout}"
+    );
+    assert!(stdout.contains("[readiness-gate]"), "stdout:\n{stdout}");
+    assert!(stdout.contains("[prune]"), "stdout:\n{stdout}");
+}
+
+#[test]
+fn deploy_check_fails_fast_without_host() {
+    // A bare [deploy] table has no host; check must fail with an actionable
+    // message naming the key to set, and exit non-zero.
+    let dir = project("");
+    let (stdout, stderr) = run_autumn_fail(dir.path(), &["deploy", "check"], &[]);
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("host"),
+        "check should mention the missing host\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        combined.contains("[deploy] host"),
+        "check should name the config key\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn deploy_help_lists_subcommands() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let (stdout, stderr, code) = run_autumn(dir.path(), &["deploy", "--help"], &[]);
+    assert_eq!(
+        code,
+        Some(0),
+        "deploy --help should succeed\nstderr:\n{stderr}"
+    );
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("check"),
+        "help should list check\n{combined}"
+    );
+    assert!(
+        combined.contains("plan"),
+        "help should list plan\n{combined}"
+    );
+    assert!(
+        combined.contains("rollback"),
+        "help should list rollback\n{combined}"
+    );
+}

--- a/autumn-cli/tests/integration/deploy.rs
+++ b/autumn-cli/tests/integration/deploy.rs
@@ -214,6 +214,79 @@ fn doctor_flags_dotenv_db_backed_runtime_without_db() {
 }
 
 #[test]
+fn doctor_reads_deploy_db_url_from_dotenv() {
+    // Regression: doctor must read the .env-only deploy DB URL like `deploy check`
+    // (Codex P2 on 5a12eb3); bare OsEnv reported it missing. With a `[deploy]`
+    // host (so the deploy preflight runs), a Postgres-backed jobs runtime AND the
+    // writable database URL supplied ONLY via `.env` — never the process env —
+    // the `deploy_database_url` grader must PASS, resolving the URL through the
+    // profile-aware dotenv overlay just as `AutumnConfig::load()`/`deploy check`
+    // do. A bare `OsEnv` would see no URL and fail the check.
+    let dir = project("host = \"deploy.example.test\"\n");
+    // Postgres jobs backend makes the app db-backed; the URL is the writable
+    // target. BOTH arrive only through `.env`, never the process env.
+    fs::write(
+        dir.path().join(".env"),
+        "AUTUMN_JOBS__BACKEND=postgres\n\
+         AUTUMN_DATABASE__URL=postgres://u:p@db.example.test/app\n",
+    )
+    .expect("write .env");
+
+    // `AUTUMN_DOTENV=1` force-loads `.env`; the DB URL itself is NOT in the
+    // process env, so a pass proves the dotenv overlay path.
+    let (stdout, stderr, _code) = run_autumn(dir.path(), &["doctor"], &[("AUTUMN_DOTENV", "1")]);
+    let combined = format!("{stdout}{stderr}");
+    // Passing check renders as `✅ deploy_database_url — database URL is
+    // configured` (see `format_check_line` / `grade_database_url`).
+    assert!(
+        combined.contains("deploy_database_url — database URL is configured"),
+        "doctor must resolve the .env-only deploy DB URL and pass \
+         deploy_database_url (bare OsEnv would report it missing)\nstdout:\n\
+         {stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn doctor_ignores_tuning_only_deploy_database_table() {
+    // Regression: a tuning-only `[database]` (no url/shards/migrations) must pass
+    // deploy_database_url, matching `deploy check` (Codex P2 on 5a12eb3); mere
+    // `[database]` table presence wrongly failed. doctor now derives
+    // db-configured from resolved URL/shard presence (like `deploy.rs`
+    // `collect_preflight`), so a `[database]` carrying only tuning keys
+    // (`pool_size`) with no writable URL and no migrations dir is treated as
+    // DB-free and PASSES.
+    let dir = tempfile::tempdir().expect("create temp project dir");
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"demoapp\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .expect("write Cargo.toml");
+    // `[deploy]` host so the preflight runs; `[database]` with ONLY a tuning key,
+    // no url/primary_url/replica_url/shards, and no migrations dir.
+    fs::write(
+        dir.path().join("autumn.toml"),
+        "[deploy]\nhost = \"deploy.example.test\"\n\n[database]\npool_size = 10\n",
+    )
+    .expect("write autumn.toml");
+
+    let (stdout, stderr, _code) = run_autumn(dir.path(), &["doctor"], &[]);
+    let combined = format!("{stdout}{stderr}");
+    // DB-free pass renders as `✅ deploy_database_url — no database configured
+    // (nothing to connect to)` (see `format_check_line` / `grade_database_url`).
+    assert!(
+        combined.contains("deploy_database_url — no database configured (nothing to connect to)"),
+        "a tuning-only [database] must pass deploy_database_url as DB-free, \
+         matching deploy check\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    // And it must NOT surface the missing-URL failure.
+    assert!(
+        !combined.contains("deploy_database_url — no writable database URL"),
+        "a tuning-only [database] must not trigger the missing-URL failure\n\
+         stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
 fn deploy_help_lists_subcommands() {
     let dir = tempfile::tempdir().expect("temp dir");
     let (stdout, stderr, code) = run_autumn(dir.path(), &["deploy", "--help"], &[]);

--- a/autumn-cli/tests/integration/deploy.rs
+++ b/autumn-cli/tests/integration/deploy.rs
@@ -37,9 +37,15 @@ fn deploy_plan_prints_unit_and_steps() {
     );
 
     // Renders the systemd unit with the resolved paths and an EnvironmentFile
-    // (secrets are never inlined into the unit).
+    // (secrets are never inlined into the unit). ExecStart runs the uploaded
+    // standalone app binary at the `current` symlink directly — NOT
+    // `autumn serve --release` (which would rebuild from source).
     assert!(
-        stdout.contains("ExecStart=autumn serve --release"),
+        stdout.contains("ExecStart=/srv/autumn/demoapp/current/demoapp"),
+        "stdout:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("autumn serve --release"),
         "stdout:\n{stdout}"
     );
     assert!(

--- a/autumn-cli/tests/integration/deploy.rs
+++ b/autumn-cli/tests/integration/deploy.rs
@@ -149,6 +149,71 @@ fn doctor_reads_deploy_host_from_dotenv() {
 }
 
 #[test]
+fn doctor_reads_deploy_signing_secret_from_dotenv() {
+    // Regression: doctor must read the deploy signing secret through .env like
+    // `deploy check` (Codex P2 on 2dc71f7); bare OsEnv would report it missing
+    // under --strict. With a `[deploy]` host (so the deploy preflight runs) and
+    // a STRONG `AUTUMN_SECURITY__SIGNING_SECRET` supplied ONLY via `.env`, the
+    // production-mode `deploy_signing_secret` grader must PASS — resolving the
+    // secret through the profile-aware dotenv overlay, not a bare `OsEnv` that
+    // would see no secret and fail the check.
+    let dir = project("host = \"deploy.example.test\"\n");
+    // 64 hex chars (>= MIN_SECRET_LEN, not a known demo value): a valid
+    // production secret. Delivered ONLY through `.env`, never the process env.
+    fs::write(
+        dir.path().join(".env"),
+        "AUTUMN_SECURITY__SIGNING_SECRET=\
+         0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n",
+    )
+    .expect("write .env");
+
+    // `AUTUMN_ENV=production` (a profile selector, allowed only from the real
+    // env) puts the signing-secret grader in production mode where a strong
+    // secret is required; `AUTUMN_DOTENV=1` force-loads `.env`. The secret
+    // itself is NOT in the process env.
+    let (stdout, stderr, _code) = run_autumn(
+        dir.path(),
+        &["doctor"],
+        &[("AUTUMN_ENV", "production"), ("AUTUMN_DOTENV", "1")],
+    );
+    let combined = format!("{stdout}{stderr}");
+    // Passing check renders as `✅ deploy_signing_secret — signing secret is
+    // configured` (see `format_check_line` / `grade_signing_secret`).
+    assert!(
+        combined.contains("deploy_signing_secret — signing secret is configured"),
+        "doctor must resolve the .env-only deploy signing secret and pass the \
+         production deploy_signing_secret check (bare OsEnv would report it \
+         missing)\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn doctor_flags_dotenv_db_backed_runtime_without_db() {
+    // Regression: `.env`-only postgres backend must make doctor require a deploy
+    // DB, matching `deploy check` (Codex P2 on 2dc71f7); bare OsEnv wrongly
+    // passed. With a `[deploy]` host, `AUTUMN_JOBS__BACKEND=postgres` supplied
+    // ONLY via `.env`, and NO database URL / `[database]` / migrations dir
+    // anywhere, the db-backed runtime must be detected from `.env` so the
+    // `deploy_database_url` grader FAILS (a Postgres-backed jobs runtime needs a
+    // writable pool). A bare `OsEnv` would miss the `.env` backend and pass.
+    let dir = project("host = \"deploy.example.test\"\n");
+    fs::write(dir.path().join(".env"), "AUTUMN_JOBS__BACKEND=postgres\n").expect("write .env");
+
+    // `AUTUMN_DOTENV=1` force-loads `.env`; no DATABASE_URL / AUTUMN_DATABASE__URL
+    // is set anywhere, so the grader has no writable target.
+    let (stdout, stderr, _code) = run_autumn(dir.path(), &["doctor"], &[("AUTUMN_DOTENV", "1")]);
+    let combined = format!("{stdout}{stderr}");
+    // Failing check renders as `❌ deploy_database_url — no writable database
+    // URL: ...` (see `format_check_line` / `grade_database_url`).
+    assert!(
+        combined.contains("deploy_database_url — no writable database URL"),
+        "the .env-only postgres jobs backend must make doctor require a deploy \
+         DB and fail deploy_database_url (bare OsEnv would pass)\nstdout:\n\
+         {stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
 fn deploy_help_lists_subcommands() {
     let dir = tempfile::tempdir().expect("temp dir");
     let (stdout, stderr, code) = run_autumn(dir.path(), &["deploy", "--help"], &[]);

--- a/autumn-cli/tests/integration/deploy.rs
+++ b/autumn-cli/tests/integration/deploy.rs
@@ -86,6 +86,30 @@ fn deploy_check_fails_fast_without_host() {
 }
 
 #[test]
+fn doctor_fails_offline_on_deploy_without_host() {
+    // A `[deploy]` table with no host makes `autumn deploy check` fail
+    // immediately, so default/OFFLINE `autumn doctor` (no `--online`) must fail
+    // on it too — the host-present validation runs offline, only the TCP probe
+    // is gated behind `--online`.
+    let dir = project("");
+    let (stdout, stderr, code) = run_autumn(dir.path(), &["doctor"], &[]);
+    let combined = format!("{stdout}{stderr}");
+    assert_ne!(
+        code,
+        Some(0),
+        "offline doctor must fail on a hostless [deploy]\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        combined.contains("deploy_host"),
+        "doctor must surface the offline deploy_host check\n{combined}"
+    );
+    assert!(
+        combined.contains("[deploy] host"),
+        "doctor must name the config key to set\n{combined}"
+    );
+}
+
+#[test]
 fn deploy_help_lists_subcommands() {
     let dir = tempfile::tempdir().expect("temp dir");
     let (stdout, stderr, code) = run_autumn(dir.path(), &["deploy", "--help"], &[]);

--- a/autumn-cli/tests/integration/mod.rs
+++ b/autumn-cli/tests/integration/mod.rs
@@ -2,6 +2,7 @@ mod api_scaffold;
 mod cloud_native_scaffold;
 mod db;
 mod db_pull;
+mod deploy;
 mod generate_references_postgres;
 mod generate_tauri_mobile;
 mod generate_tauri_mobile_offline;

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -968,6 +968,36 @@ pub struct AutumnConfig {
     #[serde(default)]
     pub server: ServerConfig,
 
+    /// Push-button VPS deploy settings (`[deploy]` section, issue #1607).
+    ///
+    /// Operator-facing configuration for `autumn deploy` — the SSH-reachable
+    /// target host plus the remote install layout and rollout tuning knobs.
+    /// Top-level (not nested under `[server]`) because it describes *where and
+    /// how* the app is deployed, not how the running server behaves.
+    ///
+    /// Absent by default (`None`), so an app that never runs `autumn deploy`
+    /// is unaffected. A bare `[deploy]` table is valid at rest — `host` is only
+    /// required when a deploy actually runs, enforced by
+    /// [`DeployConfig::validate`].
+    ///
+    /// # Field ordering (load-bearing — do not move below `database`)
+    ///
+    /// `deploy` is declared here, before [`database`](Self::database), so that
+    /// [`get_schema_keys`](Self::get_schema_keys)'s `SchemaDeserializer`
+    /// traversal recurses into [`DeployConfig`]'s child keys and the strict
+    /// unknown-key validator (`validate_toml` / `server.strict_config` /
+    /// `autumn check --config`) rejects a typo like `[deploy] app_dr = "…"`.
+    /// `DatabaseConfig` has a `deserialize_with` duration field
+    /// (`statement_timeout`, via the untagged [`deserialize_duration`] parser)
+    /// whose parser rejects the `SchemaDeserializer`'s placeholder value and
+    /// returns an error, which aborts the remainder of `AutumnConfig`'s field
+    /// traversal — so any section declared *after* `database` is recorded only
+    /// as an opaque root leaf, never descended into. Keeping `deploy` ahead of
+    /// `database` sidesteps that abort. The regression guard
+    /// `deploy_child_keys_are_strictly_validated` fails if this ordering breaks.
+    #[serde(default)]
+    pub deploy: Option<DeployConfig>,
+
     /// Database connection settings (URL, pool size, timeouts).
     #[serde(default)]
     pub database: DatabaseConfig,
@@ -1196,20 +1226,6 @@ pub struct AutumnConfig {
     /// reads/writes still work through `Deref`/`DerefMut`.
     #[serde(default)]
     pub alerts: Box<crate::alerts::AlertConfig>,
-
-    /// Push-button VPS deploy settings (`[deploy]` section, issue #1607).
-    ///
-    /// Operator-facing configuration for `autumn deploy` — the SSH-reachable
-    /// target host plus the remote install layout and rollout tuning knobs.
-    /// Top-level (not nested under `[server]`) because it describes *where and
-    /// how* the app is deployed, not how the running server behaves.
-    ///
-    /// Absent by default (`None`), so an app that never runs `autumn deploy`
-    /// is unaffected. A bare `[deploy]` table is valid at rest — `host` is only
-    /// required when a deploy actually runs, enforced by
-    /// [`DeployConfig::validate`].
-    #[serde(default)]
-    pub deploy: Option<DeployConfig>,
 }
 
 /// Push-button VPS deploy settings (`[deploy]` section, issue #1607).

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -3142,6 +3142,7 @@ impl AutumnConfig {
     /// Apply environment overrides using the provided env abstraction.
     pub fn apply_env_overrides_with_env(&mut self, env: &dyn Env) {
         self.apply_server_env_overrides_with_env(env);
+        self.apply_deploy_env_overrides_with_env(env);
         self.apply_database_env_overrides_with_env(env);
         self.apply_log_env_overrides_with_env(env);
         self.apply_telemetry_env_overrides_with_env(env);
@@ -3501,6 +3502,44 @@ impl AutumnConfig {
                 tls.handshake_timeout_secs = handshake;
             }
         }
+    }
+
+    fn apply_deploy_env_overrides_with_env(&mut self, env: &dyn Env) {
+        // `[deploy]` is a top-level optional section. Materialize it from the
+        // environment when any of its keys are set (seeding the documented
+        // defaults if the TOML section was absent), so a CI/VPS deploy can keep
+        // the target host out of `autumn.toml` and drive it entirely through
+        // `AUTUMN_DEPLOY__*`. Env overrides win over any TOML-provided values.
+        const KEYS: [&str; 8] = [
+            "AUTUMN_DEPLOY__HOST",
+            "AUTUMN_DEPLOY__USER",
+            "AUTUMN_DEPLOY__SSH_PORT",
+            "AUTUMN_DEPLOY__APP_NAME",
+            "AUTUMN_DEPLOY__APP_DIR",
+            "AUTUMN_DEPLOY__SERVICE_NAME",
+            "AUTUMN_DEPLOY__READINESS_TIMEOUT_SECS",
+            "AUTUMN_DEPLOY__KEEP_RELEASES",
+        ];
+        if !KEYS.iter().any(|key| env.var(key).is_ok()) {
+            return;
+        }
+        let deploy = self.deploy.get_or_insert_with(DeployConfig::default);
+        parse_env_option_string(env, "AUTUMN_DEPLOY__HOST", &mut deploy.host);
+        parse_env_string(env, "AUTUMN_DEPLOY__USER", &mut deploy.user);
+        parse_env(env, "AUTUMN_DEPLOY__SSH_PORT", &mut deploy.ssh_port);
+        parse_env_option_string(env, "AUTUMN_DEPLOY__APP_NAME", &mut deploy.app_name);
+        parse_env_option_string(env, "AUTUMN_DEPLOY__APP_DIR", &mut deploy.app_dir);
+        parse_env_option_string(env, "AUTUMN_DEPLOY__SERVICE_NAME", &mut deploy.service_name);
+        parse_env(
+            env,
+            "AUTUMN_DEPLOY__READINESS_TIMEOUT_SECS",
+            &mut deploy.readiness_timeout_secs,
+        );
+        parse_env(
+            env,
+            "AUTUMN_DEPLOY__KEEP_RELEASES",
+            &mut deploy.keep_releases,
+        );
     }
 
     fn apply_database_env_overrides_with_env(&mut self, env: &dyn Env) {
@@ -9769,6 +9808,91 @@ path = "/healthz"
             ..DeployConfig::default()
         };
         assert!(ok.validate().is_ok());
+    }
+
+    #[test]
+    fn env_override_materializes_deploy() {
+        // A CI/VPS deploy can keep the target host out of autumn.toml and drive
+        // the whole [deploy] section through AUTUMN_DEPLOY__* env vars.
+        let env = MockEnv::new()
+            .with("AUTUMN_DEPLOY__HOST", "203.0.113.10")
+            .with("AUTUMN_DEPLOY__USER", "deploy")
+            .with("AUTUMN_DEPLOY__SSH_PORT", "2222")
+            .with("AUTUMN_DEPLOY__APP_NAME", "myapp")
+            .with("AUTUMN_DEPLOY__APP_DIR", "/srv/myapp")
+            .with("AUTUMN_DEPLOY__SERVICE_NAME", "myapp-web")
+            .with("AUTUMN_DEPLOY__READINESS_TIMEOUT_SECS", "90")
+            .with("AUTUMN_DEPLOY__KEEP_RELEASES", "5");
+        let mut config = AutumnConfig::default();
+        assert!(config.deploy.is_none());
+        config.apply_env_overrides_with_env(&env);
+        let deploy = config.deploy.expect("env should materialize deploy");
+        assert_eq!(deploy.host.as_deref(), Some("203.0.113.10"));
+        assert_eq!(deploy.user, "deploy");
+        assert_eq!(deploy.ssh_port, 2222);
+        assert_eq!(deploy.app_name.as_deref(), Some("myapp"));
+        assert_eq!(deploy.app_dir.as_deref(), Some("/srv/myapp"));
+        assert_eq!(deploy.service_name.as_deref(), Some("myapp-web"));
+        assert_eq!(deploy.readiness_timeout_secs, 90);
+        assert_eq!(deploy.keep_releases, 5);
+        assert!(deploy.validate().is_ok());
+    }
+
+    #[test]
+    fn env_override_materializes_deploy_from_single_host() {
+        // Setting only AUTUMN_DEPLOY__HOST with no [deploy] in TOML seeds the
+        // section with defaults and fills in the host.
+        let env = MockEnv::new().with("AUTUMN_DEPLOY__HOST", "198.51.100.7");
+        let mut config = AutumnConfig::default();
+        assert!(config.deploy.is_none());
+        config.apply_env_overrides_with_env(&env);
+        let deploy = config.deploy.expect("env should materialize deploy");
+        assert_eq!(deploy.host.as_deref(), Some("198.51.100.7"));
+        // Remaining fields fall back to their documented defaults.
+        assert_eq!(deploy.user, "root");
+        assert_eq!(deploy.ssh_port, 22);
+        assert_eq!(deploy.readiness_timeout_secs, 60);
+        assert_eq!(deploy.keep_releases, 3);
+    }
+
+    #[test]
+    fn env_override_updates_existing_deploy_host() {
+        // An env var overrides just the host of a TOML-configured section,
+        // leaving the other keys intact.
+        let mut config: AutumnConfig = toml::from_str(
+            r#"
+            [deploy]
+            host = "toml-host"
+            user = "deploy"
+            ssh_port = 2200
+            "#,
+        )
+        .unwrap();
+        let env = MockEnv::new().with("AUTUMN_DEPLOY__HOST", "env-host");
+        config.apply_env_overrides_with_env(&env);
+        let deploy = config.deploy.expect("deploy configured");
+        assert_eq!(deploy.host.as_deref(), Some("env-host"));
+        assert_eq!(deploy.user, "deploy");
+        assert_eq!(deploy.ssh_port, 2200);
+    }
+
+    #[test]
+    fn env_override_parses_deploy_ssh_port_u16() {
+        let env = MockEnv::new()
+            .with("AUTUMN_DEPLOY__HOST", "example.com")
+            .with("AUTUMN_DEPLOY__SSH_PORT", "65535");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        let deploy = config.deploy.expect("env should materialize deploy");
+        assert_eq!(deploy.ssh_port, 65_535_u16);
+    }
+
+    #[test]
+    fn no_deploy_env_leaves_deploy_none() {
+        let env = MockEnv::new().with("AUTUMN_SERVER__PORT", "8080");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        assert!(config.deploy.is_none());
     }
 
     // ── server.tls.acme (#1608) ───────────────────────────────────

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -3505,41 +3505,7 @@ impl AutumnConfig {
     }
 
     fn apply_deploy_env_overrides_with_env(&mut self, env: &dyn Env) {
-        // `[deploy]` is a top-level optional section. Materialize it from the
-        // environment when any of its keys are set (seeding the documented
-        // defaults if the TOML section was absent), so a CI/VPS deploy can keep
-        // the target host out of `autumn.toml` and drive it entirely through
-        // `AUTUMN_DEPLOY__*`. Env overrides win over any TOML-provided values.
-        const KEYS: [&str; 8] = [
-            "AUTUMN_DEPLOY__HOST",
-            "AUTUMN_DEPLOY__USER",
-            "AUTUMN_DEPLOY__SSH_PORT",
-            "AUTUMN_DEPLOY__APP_NAME",
-            "AUTUMN_DEPLOY__APP_DIR",
-            "AUTUMN_DEPLOY__SERVICE_NAME",
-            "AUTUMN_DEPLOY__READINESS_TIMEOUT_SECS",
-            "AUTUMN_DEPLOY__KEEP_RELEASES",
-        ];
-        if !KEYS.iter().any(|key| env.var(key).is_ok()) {
-            return;
-        }
-        let deploy = self.deploy.get_or_insert_with(DeployConfig::default);
-        parse_env_option_string(env, "AUTUMN_DEPLOY__HOST", &mut deploy.host);
-        parse_env_string(env, "AUTUMN_DEPLOY__USER", &mut deploy.user);
-        parse_env(env, "AUTUMN_DEPLOY__SSH_PORT", &mut deploy.ssh_port);
-        parse_env_option_string(env, "AUTUMN_DEPLOY__APP_NAME", &mut deploy.app_name);
-        parse_env_option_string(env, "AUTUMN_DEPLOY__APP_DIR", &mut deploy.app_dir);
-        parse_env_option_string(env, "AUTUMN_DEPLOY__SERVICE_NAME", &mut deploy.service_name);
-        parse_env(
-            env,
-            "AUTUMN_DEPLOY__READINESS_TIMEOUT_SECS",
-            &mut deploy.readiness_timeout_secs,
-        );
-        parse_env(
-            env,
-            "AUTUMN_DEPLOY__KEEP_RELEASES",
-            &mut deploy.keep_releases,
-        );
+        apply_deploy_env_overrides(&mut self.deploy, env);
     }
 
     fn apply_database_env_overrides_with_env(&mut self, env: &dyn Env) {
@@ -6169,6 +6135,50 @@ pub struct CompressionConfig {
     /// already carry `Content-Encoding` are passed through unchanged.
     #[serde(default)]
     pub enabled: bool,
+}
+
+/// Apply `AUTUMN_DEPLOY__*` environment overrides to an optional deploy config.
+///
+/// `[deploy]` is a top-level optional section. This materializes it from the
+/// environment when any of its keys are set (seeding the documented defaults if
+/// the section was absent/`None`), so a CI/VPS deploy can keep the target host
+/// out of `autumn.toml` and drive it entirely through `AUTUMN_DEPLOY__*`. Env
+/// overrides win over any TOML-provided values.
+///
+/// Shared by [`AutumnConfig::load`] and `autumn doctor`'s deploy preflight so
+/// both surfaces resolve the identical deploy target (host, `ssh_port`, …) for the
+/// same environment + profile + TOML.
+pub fn apply_deploy_env_overrides(deploy: &mut Option<DeployConfig>, env: &dyn Env) {
+    const KEYS: [&str; 8] = [
+        "AUTUMN_DEPLOY__HOST",
+        "AUTUMN_DEPLOY__USER",
+        "AUTUMN_DEPLOY__SSH_PORT",
+        "AUTUMN_DEPLOY__APP_NAME",
+        "AUTUMN_DEPLOY__APP_DIR",
+        "AUTUMN_DEPLOY__SERVICE_NAME",
+        "AUTUMN_DEPLOY__READINESS_TIMEOUT_SECS",
+        "AUTUMN_DEPLOY__KEEP_RELEASES",
+    ];
+    if !KEYS.iter().any(|key| env.var(key).is_ok()) {
+        return;
+    }
+    let deploy = deploy.get_or_insert_with(DeployConfig::default);
+    parse_env_option_string(env, "AUTUMN_DEPLOY__HOST", &mut deploy.host);
+    parse_env_string(env, "AUTUMN_DEPLOY__USER", &mut deploy.user);
+    parse_env(env, "AUTUMN_DEPLOY__SSH_PORT", &mut deploy.ssh_port);
+    parse_env_option_string(env, "AUTUMN_DEPLOY__APP_NAME", &mut deploy.app_name);
+    parse_env_option_string(env, "AUTUMN_DEPLOY__APP_DIR", &mut deploy.app_dir);
+    parse_env_option_string(env, "AUTUMN_DEPLOY__SERVICE_NAME", &mut deploy.service_name);
+    parse_env(
+        env,
+        "AUTUMN_DEPLOY__READINESS_TIMEOUT_SECS",
+        &mut deploy.readiness_timeout_secs,
+    );
+    parse_env(
+        env,
+        "AUTUMN_DEPLOY__KEEP_RELEASES",
+        &mut deploy.keep_releases,
+    );
 }
 
 /// Parse an environment variable into a typed target, logging a warning on failure.

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -1196,6 +1196,121 @@ pub struct AutumnConfig {
     /// reads/writes still work through `Deref`/`DerefMut`.
     #[serde(default)]
     pub alerts: Box<crate::alerts::AlertConfig>,
+
+    /// Push-button VPS deploy settings (`[deploy]` section, issue #1607).
+    ///
+    /// Operator-facing configuration for `autumn deploy` — the SSH-reachable
+    /// target host plus the remote install layout and rollout tuning knobs.
+    /// Top-level (not nested under `[server]`) because it describes *where and
+    /// how* the app is deployed, not how the running server behaves.
+    ///
+    /// Absent by default (`None`), so an app that never runs `autumn deploy`
+    /// is unaffected. A bare `[deploy]` table is valid at rest — `host` is only
+    /// required when a deploy actually runs, enforced by
+    /// [`DeployConfig::validate`].
+    #[serde(default)]
+    pub deploy: Option<DeployConfig>,
+}
+
+/// Push-button VPS deploy settings (`[deploy]` section, issue #1607).
+///
+/// Describes the SSH-reachable target server and the remote install layout for
+/// `autumn deploy`'s zero-downtime rollout. Everything except `host` has a
+/// sensible default, and `app_name`/`app_dir`/`service_name` are resolved from
+/// the project's package name at deploy time (not during deserialization) so an
+/// unset value stays `None` here.
+///
+/// # `autumn.toml` example
+///
+/// ```toml
+/// [deploy]
+/// host = "203.0.113.10"      # required at deploy time; SSH-reachable address
+/// user = "deploy"            # SSH user (default: "root")
+/// ssh_port = 22              # SSH port (default: 22)
+/// app_name = "myapp"         # default: the crate's package name
+/// app_dir = "/srv/myapp"     # default: /srv/autumn/{app_name}
+/// service_name = "myapp"     # systemd unit name; default: {app_name}
+/// readiness_timeout_secs = 60 # readiness window before rollback (default: 60)
+/// keep_releases = 3          # releases retained on the host (default: 3)
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+pub struct DeployConfig {
+    /// SSH-reachable address (hostname or IP) of the target server.
+    ///
+    /// Required when a deploy actually runs (`autumn deploy`), but `None` is
+    /// valid at rest so a bare `[deploy]` table parses. Enforced by
+    /// [`validate`](Self::validate).
+    #[serde(default)]
+    pub host: Option<String>,
+
+    /// SSH user to connect as. Default: `"root"`.
+    #[serde(default = "default_deploy_user")]
+    pub user: String,
+
+    /// SSH port on the target host. Default: `22`.
+    #[serde(default = "default_deploy_ssh_port")]
+    pub ssh_port: u16,
+
+    /// Application name used to derive remote paths and the service unit.
+    /// Resolved to the project's package name when unset (at deploy time, not
+    /// during deserialization).
+    #[serde(default)]
+    pub app_name: Option<String>,
+
+    /// Remote install directory. Resolved to `/srv/autumn/{app_name}` when
+    /// unset (at deploy time).
+    #[serde(default)]
+    pub app_dir: Option<String>,
+
+    /// systemd unit name. Resolved to `{app_name}` when unset (at deploy time).
+    #[serde(default)]
+    pub service_name: Option<String>,
+
+    /// Bounded readiness window, in seconds, the new release has to report
+    /// `/ready` before the deploy rolls back. Default: `60`.
+    #[serde(default = "default_deploy_readiness_timeout_secs")]
+    pub readiness_timeout_secs: u64,
+
+    /// Number of prior releases retained on the host for rollback. Default: `3`.
+    #[serde(default = "default_deploy_keep_releases")]
+    pub keep_releases: u32,
+}
+
+impl Default for DeployConfig {
+    fn default() -> Self {
+        Self {
+            host: None,
+            user: default_deploy_user(),
+            ssh_port: default_deploy_ssh_port(),
+            app_name: None,
+            app_dir: None,
+            service_name: None,
+            readiness_timeout_secs: default_deploy_readiness_timeout_secs(),
+            keep_releases: default_deploy_keep_releases(),
+        }
+    }
+}
+
+impl DeployConfig {
+    /// Validate the `[deploy]` section for a context that actually runs a deploy.
+    ///
+    /// A bare `[deploy]` table is valid at rest, but a deploy needs a target:
+    /// this rejects a missing or blank `host` with an actionable message so the
+    /// operator knows exactly which key to set.
+    ///
+    /// # Errors
+    ///
+    /// Returns a message when `host` is unset or empty.
+    pub fn validate(&self) -> Result<(), String> {
+        match self.host.as_deref() {
+            Some(host) if !host.trim().is_empty() => Ok(()),
+            _ => Err(
+                "[deploy] requires a target host: set `[deploy] host = \"<address>\"` in \
+                      autumn.toml to the SSH-reachable hostname or IP of your server"
+                    .to_owned(),
+            ),
+        }
+    }
 }
 
 /// Observability configuration (`[observability]` section in `autumn.toml`).
@@ -6160,6 +6275,26 @@ const fn default_tls_handshake_timeout_secs() -> u64 {
     10
 }
 
+/// Default SSH user for `[deploy]`.
+fn default_deploy_user() -> String {
+    "root".to_owned()
+}
+
+/// Default SSH port for `[deploy]`.
+const fn default_deploy_ssh_port() -> u16 {
+    22
+}
+
+/// Default readiness window (seconds) before an `autumn deploy` rolls back.
+const fn default_deploy_readiness_timeout_secs() -> u64 {
+    60
+}
+
+/// Default number of prior releases retained on the host for rollback.
+const fn default_deploy_keep_releases() -> u32 {
+    3
+}
+
 /// Default directory for the ACME account key and issued certificates
 /// (`[server.tls.acme] cache_dir`).
 fn default_acme_cache_dir() -> PathBuf {
@@ -9533,6 +9668,91 @@ path = "/healthz"
         let mut config = AutumnConfig::default();
         config.apply_env_overrides_with_env(&env);
         assert!(config.server.tls.is_none());
+    }
+
+    // ── deploy (#1607) ────────────────────────────────────────────
+
+    #[test]
+    fn deploy_absent_is_none() {
+        // No [deploy] section → the field stays None so existing apps are
+        // unaffected.
+        let config = AutumnConfig::default();
+        assert!(config.deploy.is_none());
+        let parsed: AutumnConfig = toml::from_str("[server]\nport = 3000\n")
+            .expect("config without [deploy] should parse");
+        assert!(parsed.deploy.is_none());
+    }
+
+    #[test]
+    fn deploy_defaults_from_bare_table() {
+        // A bare [deploy] table materializes the section with every optional
+        // field at its documented default.
+        let config: AutumnConfig =
+            toml::from_str("[deploy]\n").expect("bare [deploy] table should parse");
+        let deploy = config.deploy.expect("deploy configured");
+        assert_eq!(deploy.host, None);
+        assert_eq!(deploy.user, "root");
+        assert_eq!(deploy.ssh_port, 22);
+        assert_eq!(deploy.app_name, None);
+        assert_eq!(deploy.app_dir, None);
+        assert_eq!(deploy.service_name, None);
+        assert_eq!(deploy.readiness_timeout_secs, 60);
+        assert_eq!(deploy.keep_releases, 3);
+    }
+
+    #[test]
+    fn deploy_full_table_parses() {
+        let config: AutumnConfig = toml::from_str(
+            r#"
+            [deploy]
+            host = "203.0.113.10"
+            user = "deploy"
+            ssh_port = 2222
+            app_name = "myapp"
+            app_dir = "/srv/myapp"
+            service_name = "myapp-web"
+            readiness_timeout_secs = 90
+            keep_releases = 5
+            "#,
+        )
+        .expect("full [deploy] table should parse");
+        let deploy = config.deploy.expect("deploy configured");
+        assert_eq!(deploy.host.as_deref(), Some("203.0.113.10"));
+        assert_eq!(deploy.user, "deploy");
+        assert_eq!(deploy.ssh_port, 2222);
+        assert_eq!(deploy.app_name.as_deref(), Some("myapp"));
+        assert_eq!(deploy.app_dir.as_deref(), Some("/srv/myapp"));
+        assert_eq!(deploy.service_name.as_deref(), Some("myapp-web"));
+        assert_eq!(deploy.readiness_timeout_secs, 90);
+        assert_eq!(deploy.keep_releases, 5);
+        assert!(deploy.validate().is_ok());
+    }
+
+    #[test]
+    fn deploy_validate_rejects_missing_host() {
+        // Missing host: a bare table is valid at rest but validate() rejects it.
+        let missing = DeployConfig::default();
+        let err = missing
+            .validate()
+            .expect_err("missing host must be rejected");
+        assert!(
+            err.contains("host"),
+            "error should name the missing key: {err}"
+        );
+
+        // Present-but-blank host is also rejected.
+        let blank = DeployConfig {
+            host: Some("   ".to_owned()),
+            ..DeployConfig::default()
+        };
+        assert!(blank.validate().is_err());
+
+        // A real host passes.
+        let ok = DeployConfig {
+            host: Some("example.com".to_owned()),
+            ..DeployConfig::default()
+        };
+        assert!(ok.validate().is_ok());
     }
 
     // ── server.tls.acme (#1608) ───────────────────────────────────

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -6148,6 +6148,8 @@ pub struct CompressionConfig {
 /// Shared by [`AutumnConfig::load`] and `autumn doctor`'s deploy preflight so
 /// both surfaces resolve the identical deploy target (host, `ssh_port`, …) for the
 /// same environment + profile + TOML.
+// Exposed for autumn-cli's `autumn deploy` preflight (doctor) to reuse the deploy env-override logic; not yet a stable public API.
+#[doc(hidden)]
 pub fn apply_deploy_env_overrides(deploy: &mut Option<DeployConfig>, env: &dyn Env) {
     const KEYS: [&str; 8] = [
         "AUTUMN_DEPLOY__HOST",

--- a/autumn/src/security/mod.rs
+++ b/autumn/src/security/mod.rs
@@ -156,12 +156,14 @@ pub use captcha::{
 };
 pub use config::{
     CspNonceConfig, CsrfConfig, HeadersConfig, KeyStrategy, RateLimitBackend, RateLimitConfig,
-    RateLimitNamedConfig, RateLimitTierConfig, SecurityConfig, SigningSecretError,
-    SubmitTokenConfig, TrustedProxiesConfig, UploadConfig, default_content_security_policy,
-    hmac_sha256_hex, validate_signing_secret,
+    RateLimitNamedConfig, RateLimitTierConfig, SecurityConfig, SubmitTokenConfig,
+    TrustedProxiesConfig, UploadConfig, default_content_security_policy, hmac_sha256_hex,
 };
 #[cfg(feature = "redis")]
 pub use config::{RateLimitBackendFailure, RateLimitRedisConfig};
+// Exposed for autumn-cli's `autumn deploy` preflight to reuse the single source of truth for signing-secret validation; not yet a stable public API (may be promoted deliberately later).
+#[doc(hidden)]
+pub use config::{SigningSecretError, validate_signing_secret};
 pub use csrf::{CsrfFormField, CsrfLayer, CsrfToken, CsrfTokenHeader};
 pub use headers::{CspNonce, SecurityHeadersLayer};
 pub use proxy::TrustedProxy;

--- a/autumn/src/security/mod.rs
+++ b/autumn/src/security/mod.rs
@@ -156,8 +156,9 @@ pub use captcha::{
 };
 pub use config::{
     CspNonceConfig, CsrfConfig, HeadersConfig, KeyStrategy, RateLimitBackend, RateLimitConfig,
-    RateLimitNamedConfig, RateLimitTierConfig, SecurityConfig, SubmitTokenConfig,
-    TrustedProxiesConfig, UploadConfig, default_content_security_policy, hmac_sha256_hex,
+    RateLimitNamedConfig, RateLimitTierConfig, SecurityConfig, SigningSecretError,
+    SubmitTokenConfig, TrustedProxiesConfig, UploadConfig, default_content_security_policy,
+    hmac_sha256_hex, validate_signing_secret,
 };
 #[cfg(feature = "redis")]
 pub use config::{RateLimitBackendFailure, RateLimitRedisConfig};

--- a/autumn/tests/fixtures/schema_keys.snapshot
+++ b/autumn/tests/fixtures/schema_keys.snapshot
@@ -26,6 +26,14 @@ database.startup_wait_secs
 database.statement_timeout
 database.url
 deploy
+deploy.app_dir
+deploy.app_name
+deploy.host
+deploy.keep_releases
+deploy.readiness_timeout_secs
+deploy.service_name
+deploy.ssh_port
+deploy.user
 dev
 health
 http

--- a/autumn/tests/fixtures/schema_keys.snapshot
+++ b/autumn/tests/fixtures/schema_keys.snapshot
@@ -25,6 +25,7 @@ database.slow_query_threshold
 database.startup_wait_secs
 database.statement_timeout
 database.url
+deploy
 dev
 health
 http

--- a/autumn/tests/integration/schema_drift_guard.rs
+++ b/autumn/tests/integration/schema_drift_guard.rs
@@ -223,3 +223,42 @@ fn schema_leaf_paths_contains_known_paths() {
          if this changed, revisit the guard's coverage assumptions"
     );
 }
+
+/// Regression guard for the `[deploy]` strict-validation fix.
+///
+/// `DeployConfig` is a config.rs-internal struct with a fixed, known schema, so
+/// the strict unknown-key validator MUST descend into `[deploy]` and reject a
+/// typo like `[deploy] app_dr = "…"`. This only holds because `deploy` is
+/// declared before `database` in `AutumnConfig` — `DatabaseConfig`'s
+/// `deserialize_with` duration field aborts the `SchemaDeserializer` traversal
+/// for every field after it (see the doc comment on `AutumnConfig::deploy`). If
+/// someone moves `deploy` below `database`, its child keys silently vanish from
+/// the schema and this test fails.
+#[test]
+fn deploy_child_keys_are_strictly_validated() {
+    let leaves = AutumnConfig::schema_leaf_paths();
+    for key in [
+        "deploy.host",
+        "deploy.user",
+        "deploy.ssh_port",
+        "deploy.app_name",
+        "deploy.app_dir",
+        "deploy.service_name",
+        "deploy.readiness_timeout_secs",
+        "deploy.keep_releases",
+    ] {
+        assert!(
+            leaves.contains(key),
+            "{key} must be a schema leaf so strict validation descends into [deploy]; \
+             if this fails, `deploy` was likely moved below `database` in AutumnConfig"
+        );
+    }
+
+    // End-to-end: the strict validator flags an unknown child key under [deploy].
+    let schema = AutumnConfig::get_schema_keys();
+    let errors = AutumnConfig::validate_toml("[deploy]\napp_dr = \"/srv/app\"\n", &schema);
+    assert!(
+        errors.iter().any(|(path, _)| path == "deploy.app_dr"),
+        "a bogus [deploy] child key must be rejected by strict validation, got: {errors:?}"
+    );
+}


### PR DESCRIPTION
**Before:** the CLI had `new`/`dev`/`build`/`migrate`/`release`/`serve`/`doctor` and no way to ship an app — self-hosting a `$5` VPS deploy meant hand-rolling SSH, systemd, migration ordering, and cutover.

**After:** `autumn deploy` exists as the locally-verifiable spine of the push-button flow:
- `autumn deploy check` — preflight (AC-6), reported locally, never printing secrets; also surfaced in `autumn doctor`:
  - SSH port reachability (tries all resolved addresses; host-presence validated offline, TCP probe under `--online`)
  - signing secret present — and in **production** the app's real `validate_signing_secret` is reused, rejecting weak/`changeme`/short secrets **and** weak `previous_secrets` rotation keys (so preflight can't greenlight a release that would exit on boot)
  - database URL — required for DB-backed apps (a `migrations/` dir, a `[database]`, **or** a Postgres runtime backend like `jobs.backend`/`scheduler.backend = "postgres"`); a **writable** primary/control or shard-primary URL (replica-only rejected — migrations can't run on a replica); genuine DB-free apps pass
  - `migrate check` clean
- `autumn deploy plan` / `rollback` — emits the systemd unit + the ordered zero-downtime plan as **unit-tested pure functions**: build embedded binary → upload timestamped release → **migrate before cutover** → start candidate on a **separate listener** → bounded `/ready` gate (rollback on timeout) → **traffic handoff** (reverse-proxy or socket-activation; finalized in the execution slice) → drain old → prune to `keep_releases`.
- New `[deploy]` config section in `autumn.toml` (`host`, `user`, `ssh_port`, `app_name`/`app_dir`/`service_name`, `readiness_timeout_secs`, `keep_releases`), profile-merge aware and honoring `AUTUMN_DEPLOY__*` env overrides; strict-config validates its child keys.

**How:** new `autumn-cli/src/deploy.rs` (shared graders + pure `render_systemd_unit`/`build_deploy_plan`/`build_rollback_plan` + `run`), wired into `main.rs` like the `release` group; `DeployConfig` in `autumn/src/config.rs` (profile+env aware; declared before `database` so the schema walker validates its keys); the same graders reused by `doctor` (which now honors env overrides and reports malformed shards as a failing check instead of exiting).

### ⚠️ Scope — honest first slice (Part of #1607), opened as DRAFT
**Deferred to follow-up slices:** real remote **SSH execution + live cutover/rollback** (this slice generates + validates the plan; it does not touch a remote host); the **AC-7 CI e2e harness** (SSH-host stand-in: first-deploy → probed redeploy → forced rollback) — the reason live execution is deferred; the **AC-8 deployment-guide rewrite** in `docs/guide/deployment.md` (coordinated with docs issue #1860). The zero-downtime **cutover mechanism** (reverse proxy vs systemd socket activation) is an explicit wave-13 product decision; the emitted plan stays mechanism-neutral.

### 📦 Dependencies & public surface
**No new crate dependencies.** SSH reachability uses `std::net::TcpStream`; the eventual remote path shells out to system `ssh`/`scp` (Kamal-style) rather than a Rust SSH crate. Two small `autumn-web` items were exposed **`#[doc(hidden)]`** purely so the CLI preflight reuses a single source of truth (no logic duplicated): `validate_signing_secret`/`SigningSecretError` and `apply_deploy_env_overrides`.

### 🐞 Discovered & filed
While adding strict `[deploy]` validation, found that `AutumnConfig`'s schema walker aborts at `DatabaseConfig`'s custom duration deserializer, so ~30 config sections after `[database]` silently skip strict validation — filed as #1890 (fixed for `[deploy]` here via field ordering + a regression test; the general fix is deferred as it would newly strict-validate ~30 sections).

### Verification (local — the merge gate)
`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p autumn-web`, `cargo test -p autumn-cli --test cli_tests`, and `cargo test -p autumn-cli --bin autumn` all green. Real remote execution and the AC-7 harness are follow-ups, so the remote path is unverified pending a real host.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnonMoZ51UfZg9Ahmm25CP