### PR TITLE
Owner-scoped search_page/list codegen + lift the owner-searchable rejection

### DIFF
--- a/.github/workflows/generator-conformance.yml
+++ b/.github/workflows/generator-conformance.yml
@@ -179,6 +179,8 @@ jobs:
   #   live-owner       -> generated_live_owner_scaffold_cargo_checks
   #   sharded-owner    -> generated_sharded_owner_scaffold_cargo_checks
   #   attachment-owner -> generated_attachment_owner_scaffold_cargo_checks
+  #   owner-searchable          -> generated_owner_searchable_scaffold_cargo_checks
+  #   nullable-owner-searchable -> generated_nullable_owner_searchable_scaffold_cargo_checks
   app-variant-conformance:
     name: App-variant conformance (${{ matrix.variant.name }}, ${{ matrix.toolchain }})
     runs-on: ubuntu-latest
@@ -203,6 +205,13 @@ jobs:
             test: generated_sharded_owner_scaffold_cargo_checks
           - name: attachment-owner
             test: generated_attachment_owner_scaffold_cargo_checks
+          # Issue #1841: owner-scoped `--searchable` (previously REJECTED) now
+          # emits owner-filtered `list_scoped`/`search_page_scoped` and a scoped
+          # index/search. Proves the lifted rejection produces a compiling app.
+          - name: owner-searchable
+            test: generated_owner_searchable_scaffold_cargo_checks
+          - name: nullable-owner-searchable
+            test: generated_nullable_owner_searchable_scaffold_cargo_checks
     steps:
       - uses: actions/checkout@v7
 

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -486,29 +486,35 @@ fn plan_scaffold_with_options_impl(
         && !options_with_key.live
         && !options_with_key.live_validation;
 
-    // Issue #1319 security guard: the generated `GET /{plural}/search` handler calls
-    // the repository's UNSCOPED `search_page`, which returns rows for ALL users. When
-    // the model is owner-scoped, the index view is `#[secured]` and filters to the
-    // current user's rows — so pairing `--searchable` with owner scoping would leak
-    // other users' rows through the search endpoint that the list view prevents.
-    // Owner-scoped FTS needs a scoped `search_page` in the repository macro (framework
-    // work, tracked in #1841); until then, refuse the unsafe combination. Returns
-    // before the plan is built, so no files are written.
-    // The leak exists wherever an owner-scoped index coexists with the search
-    // box; search is force-disabled for `--live`/`--live-validation` (see
-    // `search_enabled`), so this covers the standard and `--sharded` owner paths.
+    // Issue #1841: owner-scoped full-text search is now supported on the STANDARD
+    // (non-live, non-sharded) Db path. The `#[repository(..., owner = <col>)]`
+    // attr makes the macro emit an owner-filtered `search_page_scoped` (and
+    // `list_scoped`), and the generated `GET /{plural}/search` + owner-scoped
+    // index call ONLY those scoped methods — never the unscoped `search_page`/
+    // `page`. So `--searchable` + owner scoping is safe there and no longer
+    // refused.
+    //
+    // The `--sharded` owner path is NOT yet wired: its index/search still run
+    // through per-shard raw diesel / the unscoped `search_page`, and a scoped
+    // cross-shard FTS is out of scope here (follow-up). Search is force-disabled
+    // for `--live`/`--live-validation` (see `search_enabled`), so the only
+    // remaining unsafe combination is owner-scoped `--sharded` `--searchable` —
+    // keep refusing exactly that. Returns before the plan is built, so no files
+    // are written.
     if !options_with_key.model.searchable.is_empty()
         && owner_authorizes
+        && options_with_key.model.sharded
         && !options_with_key.live
         && !options_with_key.live_validation
     {
         return Err(GenerateError::Config(format!(
-            "`--searchable` is not yet supported for owner-scoped models: full-text search \
-             (`search_page`) is not owner-scoped, so the generated `GET /{plural}/search` \
-             endpoint would expose other users' rows that the `#[secured]` index view \
-             filters out (owner column `{owner}`). Remove `--searchable`, drop the owner \
-             column, or pass `--no-policy` to opt out of owner scoping. Track: framework \
-             support for owner-scoped FTS (issue #1841).",
+            "`--searchable` is not yet supported for owner-scoped `--sharded` models: the \
+             sharded index/search run per-shard through the UNSCOPED `search_page`, so the \
+             generated `GET /{plural}/search` endpoint would expose other users' rows in the \
+             same shard that the `#[secured]` index view filters out (owner column `{owner}`). \
+             Drop `--sharded` (the standard Db path supports owner-scoped search), remove \
+             `--searchable`, drop the owner column, or pass `--no-policy` to opt out of owner \
+             scoping. Track: owner-scoped FTS for sharded repositories (follow-up to #1841).",
             owner = owner_column.as_ref().map_or("user_id", |o| o.name.as_str()),
         )));
     }
@@ -615,6 +621,15 @@ fn plan_scaffold_with_options_impl(
             options_with_key.model.sharded,
             options_with_key.live,
             !options_with_key.model.searchable.is_empty(),
+            // Issue #1841: emit `owner = <col>` (→ the macro's `list_scoped` /
+            // `search_page_scoped` codegen) only on the standard owner-scoped Db
+            // path — `authorize_wiring` is exactly `owner present && policy on &&
+            // !sharded && !live && !live_validation`, the path whose index/search
+            // this PR wires to the scoped methods. Live/sharded owner indexes are
+            // left as #1830 emitted them (follow-up), so they get no `owner =`.
+            authorize_wiring
+                .then(|| owner_column.as_ref().map(|o| o.name.as_str()))
+                .flatten(),
         ),
     );
     let repo_mod_path = repos_dir.join("mod.rs");
@@ -1320,6 +1335,7 @@ fn render_repository_file(
     sharded: bool,
     live: bool,
     searchable: bool,
+    owner_column: Option<&str>,
 ) -> String {
     let plural = pluralize(snake_name);
     let query_body = render_repository_queries(pascal_name, queries);
@@ -1341,6 +1357,13 @@ fn render_repository_file(
     // `search_page(query, &PageRequest)` methods (backed by the model's
     // `#[searchable]` fields + the migration's `search_vector` column).
     let searchable_attr = if searchable { ", searchable" } else { "" };
+    // Issue #1841: `owner = <col>` makes `#[repository]` emit owner-filtered
+    // `list_scoped` / `search_page_scoped` methods that the owner-scoped index +
+    // `/search` handlers call so they never return another user's rows. Only the
+    // caller's in-scope standard Db path passes `Some`; every other scaffold
+    // (no owner column, `--no-policy`, `--live`, `--sharded`) passes `None` and
+    // the attr — and the scoped methods — are omitted.
+    let owner_attr = owner_column.map_or(String::new(), |col| format!(", owner = {col}"));
     let sharded_note = if sharded {
         format!(
             "//!\n\
@@ -1447,7 +1470,7 @@ fn render_repository_file(
          use crate::models::{snake_name}::{{{pascal_name}, New{pascal_name}, Update{pascal_name}{draft_ext_import}}};\n\
          use crate::schema::{plural};\n\
          \n\
-         #[autumn_web::repository({pascal_name}, api = \"/api/{plural}\"{soft_delete_attr}{broadcasts_attr}{searchable_attr})]\n\
+         #[autumn_web::repository({pascal_name}, api = \"/api/{plural}\"{soft_delete_attr}{broadcasts_attr}{searchable_attr}{owner_attr})]\n\
          pub trait {pascal_name}Repository {{\n\
 {query_body}\
          }}\n\
@@ -1834,6 +1857,14 @@ fn render_routes_file(
     // is set), but its index cannot filter by owner, so it keeps the unscoped
     // listing.
     let owner_scoped_index = authorize && owner.is_some();
+    // Issue #1841: the STANDARD (non-live, non-live-validation, non-sharded) Db
+    // owner path is the only one whose repository carries `owner = <col>` (see
+    // `render_repository_file`), so it is the only one whose index/search can call
+    // the macro's owner-filtered `list_scoped` / `search_page_scoped`. That path
+    // gets the sort/filter data_table + the search box, both safely scoped to the
+    // current user. The `--sharded`/`--live`/`--live-validation` owner indexes
+    // keep the #1830 manual owner-filtered query (no scoped repo methods emitted).
+    let owner_scoped_standard = owner_scoped_index && !sharded && !live && !live_validation;
     // The full extractor pair the authorize wiring needs on handlers that do not
     // already carry a `state:` wrapper. No trailing comma — each insertion site
     // supplies its own delimiter.
@@ -2704,12 +2735,12 @@ fn render_routes_file(
     // headers are opted-in per column by `render_columns_vec`.
     let table_render = if live {
         String::new()
-    } else if owner_scoped_index {
-        // #1125 owner-scoped index: the handler runs a manual owner-filtered
-        // query (not `repo.list`) and does not extract `ListQuery`, so its
-        // data_table stays on the plain (non-sort/filter) config. #1126's
-        // allowlisted sort/filter is not owner-scoped — the same limitation the
-        // `--searchable` guard documents for owner-scoped FTS.
+    } else if owner_scoped_index && !owner_scoped_standard {
+        // #1830 owner-scoped `--sharded`/`--live-validation` index: the handler
+        // runs a manual owner-filtered query (not a scoped repo method) and does
+        // not extract `ListQuery`, so its data_table stays on the plain
+        // (non-sort/filter) config. Wiring owner-scoped sort/filter there is a
+        // follow-up (issue #1841 covers the standard Db path only).
         format!(
             r#"(autumn_web::widgets::data_table(&page_data.content, &columns, &autumn_web::widgets::DataTableConfig::new("No {plural} yet.").base_path(&paths::index())))"#
         )
@@ -2769,13 +2800,57 @@ fn render_routes_file(
     } else {
         "mut db: Db"
     };
-    let index_handler = if owner_scoped_index {
-        // Issue #1125/#1830: owner-scoped index for every variant with an owner
-        // column. Pagination is preserved by running a `COUNT(*)` + `LIMIT/OFFSET`
-        // query filtered to the current user's rows, then wrapping the result in
-        // `Page::new`. `{list_render}` keeps the `--live` SSE `<ul>` island (a
-        // data_table for the non-live variants), so the SSE broadcast contract is
-        // unaffected — only the *initial* server-rendered list is owner-scoped.
+    let index_handler = if owner_scoped_standard {
+        // Issue #1841: standard owner-scoped index. Delegates to the macro's
+        // owner-filtered `list_scoped(owner_id, &list_query, &page_req)` — the
+        // SECURITY INVARIANT is that this branch NEVER calls the unscoped
+        // `repo.list`/`repo.page`, so the allowlisted sort/filter and (when
+        // searchable) the search box can be exposed while every row stays scoped
+        // to the current user. `owner_id` is resolved from the same
+        // `PolicyContext` the mutating handlers authorize against.
+        format!(
+            r#"/// `GET /{plural}` — paginated, sortable, filterable list of the {snake_name}s
+/// the current user owns.
+///
+/// Accepts `?page=N&size=M` paging plus allowlisted `?sort=col&dir=asc|desc`
+/// and `?filter[col]=val` params (the [`ListQuery`] extractor). Unknown or
+/// malicious sort/filter keys are ignored against the model's column allowlist,
+/// so this never 400s and can never inject SQL. Filtered to the authenticated
+/// user's rows (owner column `{owner_col}`) via the repository's owner-scoped
+/// `list_scoped` — the same rule the registered `{pascal_name}Scope` enforces
+/// for `#[repository(scope = ...)]` index routes. This handler never calls the
+/// unscoped `list`/`page`, so it cannot return another user's rows.
+#[secured]
+#[get("/{plural}")]
+pub async fn index(
+    list_query: ListQuery,
+    RawQuery(raw_query): RawQuery,
+    page_req: PageRequest,
+    autumn_web::extract::State(state): autumn_web::extract::State<autumn_web::AppState>,
+    session: autumn_web::session::Session,
+    repo: Pg{pascal_name}Repository,
+    {index_db_param}flash: Flash,
+) -> AutumnResult<Markup> {{
+    let ctx = autumn_web::authorization::PolicyContext::from_request(&state, &session).await;
+    let owner_id = ctx.user_id_i64().unwrap_or(-1);
+    let page_data: Page<{pascal_name}> = repo.list_scoped(owner_id, &list_query, &page_req).await?;
+    let pager_query = raw_query.as_deref().unwrap_or("");
+{index_label_loads}{index_columns_labeled}    Ok({layout_fn}("{pascal_name} index", {cp_index}{flash_arg}, html! {{
+        h1 {{ "{pascal_name}s" }}
+        a href=(paths::new()) {{ "New {pascal_name}" }}
+        {index_list_block}
+    }}))
+}}"#
+        )
+    } else if owner_scoped_index {
+        // Issue #1125/#1830: owner-scoped index for the `--sharded`/`--live`/
+        // `--live-validation` variants (whose repositories carry no `owner =`
+        // attr, so no scoped repo method exists). Pagination is preserved by
+        // running a `COUNT(*)` + `LIMIT/OFFSET` query filtered to the current
+        // user's rows, then wrapping the result in `Page::new`. `{list_render}`
+        // keeps the `--live` SSE `<ul>` island (a data_table for the non-live
+        // variants), so the SSE broadcast contract is unaffected — only the
+        // *initial* server-rendered list is owner-scoped.
         format!(
             r#"/// `GET /{plural}` — paginated list of {snake_name}s the current user owns.
 ///
@@ -3095,7 +3170,74 @@ pub async fn index(
     // The pager preserves the request's raw query string (stripping `page`/
     // `size`) via `PagerOptions::query`, so `q` survives pagination without any
     // hand-rolled percent-encoding.
-    let search_handler = if search_enabled {
+    let search_handler = if search_enabled && owner_scoped_standard {
+        // Issue #1841: owner-scoped FTS handler for the standard Db path. The
+        // SECURITY INVARIANT is that this branch calls ONLY the owner-filtered
+        // repository methods — `repo.search_page_scoped(owner_id, ..)` for a
+        // query, and `repo.list_scoped(owner_id, ..)` for the empty-query
+        // fallback — NEVER the unscoped `repo.search_page`/`repo.page`, so the
+        // `/search` endpoint can never surface another user's rows (the exact
+        // leak the pre-#1841 rejection guarded against). `owner_id` comes from
+        // the same `PolicyContext` the mutating handlers authorize against.
+        let field_list = searchable.join(", ");
+        format!(
+            r#"
+
+/// `GET /{plural}/search` — owner-scoped full-text search over {field_list}.
+///
+/// Powers the `active_search` box on the index list. Ranked by relevance via
+/// the repository's owner-scoped `search_page_scoped`; an empty `q` falls back
+/// to the owner-scoped `list_scoped` listing. htmx requests get only the
+/// results fragment; non-htmx navigations (a bookmarked search URL, or a pager
+/// link) get a full page so search still works without JavaScript. Every result
+/// is filtered to the authenticated user (owner column `{owner_col}`); this
+/// handler never calls the unscoped `search_page`/`page`.
+#[derive(serde::Deserialize)]
+pub struct {pascal_name}SearchQuery {{
+    #[serde(default)]
+    pub q: String,
+}}
+
+#[secured]
+#[get("/{plural}/search")]
+pub async fn search(
+    autumn_web::extract::Query(query): autumn_web::extract::Query<{pascal_name}SearchQuery>,
+    autumn_web::reexports::axum::extract::RawQuery(raw_query): autumn_web::reexports::axum::extract::RawQuery,
+    list_query: ListQuery,
+    page_req: PageRequest,
+    hx: autumn_web::htmx::HxRequest,
+    autumn_web::extract::State(state): autumn_web::extract::State<autumn_web::AppState>,
+    session: autumn_web::session::Session,
+    repo: Pg{pascal_name}Repository,
+    {index_db_param}flash: Flash,
+) -> AutumnResult<Markup> {{
+    let ctx = autumn_web::authorization::PolicyContext::from_request(&state, &session).await;
+    let owner_id = ctx.user_id_i64().unwrap_or(-1);
+    let q = query.q.trim();
+    // Preserve the request's raw query string (already percent-encoded) on pager
+    // links so `q` survives pagination; `PagerOptions::query` strips the stale
+    // `page`/`size` params and re-adds them per link.
+    let pager_query = raw_query.as_deref().unwrap_or("");
+    let page_data: Page<{pascal_name}> = if q.is_empty() {{
+        repo.list_scoped(owner_id, &list_query, &page_req).await?
+    }} else {{
+        repo.search_page_scoped(owner_id, q, &page_req).await?
+    }};
+{index_label_loads}{index_columns_labeled}    let results = html! {{
+        (autumn_web::widgets::data_table(&page_data.content, &columns, &autumn_web::widgets::DataTableConfig::new("No {plural} found.").base_path("/{plural}/search")))
+        (pagination_nav(&page_data, &PagerOptions::new("/{plural}/search").query(pager_query)))
+    }};
+    if hx.is_htmx {{
+        return Ok(results);
+    }}
+    Ok({layout_fn}("Search {pascal_name}s", {cp_index}{flash_arg}, html! {{
+        h1 {{ "Search {pascal_name}s" }}
+        a href="/{plural}" {{ "Back to list" }}
+        div id="{plural}-search-results" {{ (results) }}
+    }}))
+}}"#
+        )
+    } else if search_enabled {
         let field_list = searchable.join(", ");
         let (repo_extractor, repo_bind) = if sharded {
             (
@@ -9523,8 +9665,17 @@ async fn main() {
 
     #[test]
     fn repository_notes_sharded() {
-        let rendered =
-            render_repository_file("Account", "account", &[], false, false, true, false, false);
+        let rendered = render_repository_file(
+            "Account",
+            "account",
+            &[],
+            false,
+            false,
+            true,
+            false,
+            false,
+            None,
+        );
         assert!(
             rendered.contains("shard-aware"),
             "sharded repository doc must mention shard-aware: {rendered}"
@@ -9537,8 +9688,17 @@ async fn main() {
 
     #[test]
     fn repository_notes_api_sharded_caveat() {
-        let rendered =
-            render_repository_file("Account", "account", &[], false, true, true, false, false);
+        let rendered = render_repository_file(
+            "Account",
+            "account",
+            &[],
+            false,
+            true,
+            true,
+            false,
+            false,
+            None,
+        );
         assert!(
             rendered.contains("control pool"),
             "sharded api repository doc must note control pool: {rendered}"
@@ -9548,7 +9708,7 @@ async fn main() {
     #[test]
     fn repository_no_sharded_note_when_not_sharded() {
         let rendered =
-            render_repository_file("Post", "post", &[], false, false, false, false, false);
+            render_repository_file("Post", "post", &[], false, false, false, false, false, None);
         assert!(
             !rendered.contains("shard-aware"),
             "non-sharded repository must not mention shard-aware: {rendered}"
@@ -9791,17 +9951,19 @@ async fn main() {
         );
     }
 
-    /// Issue #1319 security guard: `--searchable` on an owner-scoped model is
-    /// rejected before any files are written. The owner-scoped index is
-    /// `#[secured]` and filters to the current user, but the FTS `search_page`
-    /// is unscoped, so the `/search` endpoint would leak other users' rows.
+    /// Issue #1841: `--searchable` on a standard owner-scoped model is now
+    /// ALLOWED (was rejected pre-#1841). The repository macro carries the
+    /// `owner = <col>` attr so it emits owner-filtered `list_scoped` /
+    /// `search_page_scoped`, and the generated index + `/search` handlers call
+    /// ONLY those scoped methods — never the unscoped `page`/`search_page` — so
+    /// no cross-user leak. This test asserts that safe wiring is emitted.
     #[test]
-    fn searchable_with_owner_scoped_model_is_rejected() {
+    fn searchable_with_owner_scoped_model_emits_scoped_wiring() {
         let tmp = project_with_main(default_main());
         // `user_id` is an owner column, so the default policy makes the index
         // owner-scoped (`authorize_wiring`). Pairing that with `--searchable`
-        // must be refused.
-        let err = plan_scaffold_with_options(
+        // is now supported via the macro's owner-scoped codegen.
+        let plan = plan_scaffold_with_options(
             tmp.path(),
             "Post",
             &[
@@ -9818,23 +9980,74 @@ async fn main() {
                 ..Default::default()
             },
         )
-        .unwrap_err();
-        let msg = err.to_string();
+        .expect("standard owner-scoped + searchable must be allowed (#1841)");
+        plan.execute(Flags::default()).unwrap();
+
+        // The repository declares `owner = user_id` so the macro generates the
+        // scoped methods.
+        let repo = fs::read_to_string(tmp.path().join("src/repositories/post.rs")).unwrap();
         assert!(
-            matches!(err, GenerateError::Config(_)),
-            "expected Config error, got: {err:?}"
+            repo.contains(", owner = user_id)"),
+            "owner-scoped repository must carry `owner = user_id` on the attr: {repo}"
         );
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        // The `/search` route uses the scoped method (and its empty-query
+        // fallback the scoped list) — never the unscoped `search_page`/`page`.
         assert!(
-            msg.contains("--searchable")
-                && msg.contains("owner-scoped")
-                && msg.contains("search_page"),
-            "error must explain the owner-scoped FTS leak: {msg}"
+            routes.contains("repo.search_page_scoped(owner_id, q, &page_req)"),
+            "owner-scoped /search must call search_page_scoped: {routes}"
         );
-        // No files written: the scaffold plan fails before touching the tree.
+        // The owner-scoped index uses the scoped list with sort/filter.
         assert!(
-            !tmp.path().join("src/models/post.rs").exists()
-                && !tmp.path().join("src/repositories/post.rs").exists(),
-            "rejected owner-scoped +searchable scaffold must not write any files"
+            routes.contains("repo.list_scoped(owner_id, &list_query, &page_req)"),
+            "owner-scoped index/search must call list_scoped: {routes}"
+        );
+        // Sort/filter data_table wiring is present on the owner-scoped standard
+        // index (active_sort / query), closing the #1854 gap.
+        assert!(
+            routes.contains(".active_sort(list_query.sort().unwrap_or_default())"),
+            "owner-scoped standard index must render the sort/filter data_table: {routes}"
+        );
+        // The search box is rendered on the owner-scoped index.
+        assert!(
+            routes.contains("active_search_input"),
+            "owner-scoped searchable index must render the search box: {routes}"
+        );
+    }
+
+    /// Issue #1841 security invariant: the owner-scoped `/search` and index
+    /// branches must NEVER call the unscoped repository methods, or they would
+    /// re-open the pre-#1841 cross-user leak. This is the regression guard: the
+    /// `search`/`index` handler bodies must not contain a bare
+    /// `repo.search_page(`/`repo.page(` call.
+    #[test]
+    fn owner_scoped_searchable_never_calls_unscoped_repo_methods() {
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold_with_options(
+            tmp.path(),
+            "Post",
+            &[
+                "user_id:i64".into(),
+                "title:String".into(),
+                "body:Text".into(),
+            ],
+            "20260427000000",
+            &ScaffoldOptions {
+                model: ModelOptions {
+                    searchable: vec!["title".into(), "body".into()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        assert!(
+            !routes.contains("repo.search_page(") && !routes.contains("repo.page("),
+            "owner-scoped searchable routes must NEVER call the unscoped \
+             repo.search_page(/repo.page( (cross-user leak): {routes}"
         );
     }
 
@@ -11221,10 +11434,17 @@ async fn main() {
             "create must authorize_create: {routes}"
         );
         assert!(routes.contains("pub async fn create("), "{routes}");
-        // Index applies the owner scope through a filtered paginated query.
+        // Issue #1841: the standard owner-scoped index now applies the owner
+        // scope through the repository's owner-filtered `list_scoped` (which also
+        // brings allowlisted sort/filter), not a hand-rolled diesel query — and
+        // it must NEVER fall back to the unscoped `repo.list`/`repo.page`.
         assert!(
-            routes.contains("posts::user_id.eq(owner_id)"),
-            "index must filter by owner: {routes}"
+            routes.contains("repo.list_scoped(owner_id, &list_query, &page_req)"),
+            "index must scope through list_scoped: {routes}"
+        );
+        assert!(
+            !routes.contains("repo.list(&list_query") && !routes.contains("repo.page("),
+            "owner-scoped index must not call the unscoped list/page: {routes}"
         );
         assert!(
             routes.contains("PolicyContext::from_request(&state, &session)"),
@@ -11400,10 +11620,17 @@ async fn main() {
             ),
             "attachment create/update must not inject a duplicate State extractor: {routes}"
         );
-        // Owner-scoped index still emitted for the attachment path.
+        // Owner-scoped index still emitted for the attachment path. Issue #1841:
+        // the standard Db owner index now scopes via the repository's
+        // owner-filtered `list_scoped` (with sort/filter) rather than a manual
+        // diesel query — and never falls back to the unscoped list/page.
         assert!(
-            routes.contains("posts::author_id.eq(owner_id)"),
-            "attachment index must filter by owner: {routes}"
+            routes.contains("repo.list_scoped(owner_id, &list_query, &page_req)"),
+            "attachment index must scope through list_scoped: {routes}"
+        );
+        assert!(
+            routes.contains("PolicyContext::from_request(&state, &session)"),
+            "attachment index must resolve owner_id from the policy context: {routes}"
         );
     }
 

--- a/autumn-cli/tests/generate.rs
+++ b/autumn-cli/tests/generate.rs
@@ -6373,8 +6373,9 @@ fn generated_sharded_scaffold_cargo_checks() {
 /// the generated `{Model}SearchQuery` extractor type, and the `search_vector`
 /// migration all typecheck against this workspace's `autumn-web`.
 ///
-/// Uses a plain searchable model (no owner scoping — the generator rejects the
-/// owner-scoped + search combination).
+/// Uses a plain searchable model (no owner scoping). The owner-scoped +
+/// searchable combination is covered separately by
+/// [`generated_owner_searchable_scaffold_cargo_checks`] (issue #1841).
 ///
 /// Run with: `cargo test -p autumn-cli -- --ignored generated_searchable_scaffold_cargo_checks`
 #[test]
@@ -6405,6 +6406,133 @@ fn generated_searchable_scaffold_cargo_checks() {
     assert!(
         check.status.success(),
         "cargo check on generated searchable scaffold failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr),
+    );
+}
+
+/// Issue #1841: the critical proof that lifting the owner-scoped `--searchable`
+/// rejection produces a COMPILING app whose search/index are safely owner-scoped.
+///
+/// Scaffolds `Post title:String body:Text author_id:i64 --searchable` — an owner
+/// column (`author_id`) AND full-text search, the exact combination the
+/// generator REJECTED before #1841. The repository macro now emits owner-filtered
+/// `list_scoped` / `search_page_scoped`, and the generated owner-scoped index +
+/// `/search` handlers call ONLY those scoped methods. `cargo check --tests`
+/// proves the whole owner-scoped FTS codegen (the macro's three-phase
+/// owner-filtered `search_page_scoped`, `list_scoped`, and the scoped handlers)
+/// type-checks against this workspace's `autumn-web`.
+///
+/// The security invariant — the owner branch never calls the unscoped
+/// `repo.search_page`/`repo.page` — is asserted directly on the generated source
+/// here and in the `scaffold.rs` unit tests; this test proves it also COMPILES.
+///
+/// Run with:
+/// `cargo test -p autumn-cli --test generate generated_owner_searchable_scaffold_cargo_checks -- --ignored --exact`
+#[test]
+#[ignore = "slow: cargo-checks a fresh owner-scoped searchable project — run with `cargo test -p autumn-cli -- --ignored`"]
+fn generated_owner_searchable_scaffold_cargo_checks() {
+    let (_tmp, project) = fresh_project("owner-searchable-build");
+
+    patch_generated_cargo_toml(&project);
+
+    run_autumn(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Post",
+            "title:String",
+            "body:Text",
+            "author_id:i64",
+            "--searchable",
+            "title,body",
+        ],
+    );
+
+    // The repository carries `owner = author_id` (→ the macro's scoped codegen).
+    let repo = fs::read_to_string(project.join("src/repositories/post.rs")).unwrap();
+    assert!(
+        repo.contains(", owner = author_id)"),
+        "owner-scoped searchable repository must carry `owner = author_id`:\n{repo}"
+    );
+
+    // The owner-scoped /search + index call ONLY the scoped methods — never the
+    // unscoped `repo.search_page(`/`repo.page(` (the cross-user leak guard).
+    let routes = fs::read_to_string(project.join("src/routes/posts.rs")).unwrap();
+    assert!(
+        routes.contains("repo.search_page_scoped(owner_id, q, &page_req)")
+            && routes.contains("repo.list_scoped(owner_id, &list_query, &page_req)"),
+        "owner-scoped search/index must call the scoped repository methods:\n{routes}"
+    );
+    assert!(
+        !routes.contains("repo.search_page(") && !routes.contains("repo.page("),
+        "SECURITY: owner-scoped searchable routes must NEVER call the unscoped \
+         repo.search_page(/repo.page( (cross-user leak):\n{routes}"
+    );
+
+    let check = Command::new("cargo")
+        .args(["check", "--tests"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    assert!(
+        check.status.success(),
+        "cargo check on generated owner-scoped searchable scaffold failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr),
+    );
+}
+
+/// Issue #1841 companion proving the *nullable* owner-column + searchable path
+/// compiles: a `user:references?` owner is `Option<i64>`, so the macro's scoped
+/// `.eq(owner_id)` filter (typed hydration) and the raw-SQL owner bind must
+/// compile against a `Nullable<BigInt>` column. A nullable owner never matches
+/// NULL (unowned) rows — semantically correct (unowned rows stay hidden).
+///
+/// Run with:
+/// `cargo test -p autumn-cli --test generate generated_nullable_owner_searchable_scaffold_cargo_checks -- --ignored --exact`
+#[test]
+#[ignore = "slow: cargo-checks a fresh nullable-owner searchable project — run with `cargo test -p autumn-cli -- --ignored`"]
+fn generated_nullable_owner_searchable_scaffold_cargo_checks() {
+    let (_tmp, project) = fresh_project("nullable-owner-searchable-build");
+
+    patch_generated_cargo_toml(&project);
+
+    run_autumn(
+        &project,
+        &[
+            "generate",
+            "scaffold",
+            "Note",
+            "title:String",
+            "body:Text",
+            "user:references?",
+            "--searchable",
+            "title,body",
+        ],
+    );
+
+    let repo = fs::read_to_string(project.join("src/repositories/note.rs")).unwrap();
+    assert!(
+        repo.contains(", owner = user_id)"),
+        "nullable-owner searchable repository must carry `owner = user_id`:\n{repo}"
+    );
+    let routes = fs::read_to_string(project.join("src/routes/notes.rs")).unwrap();
+    assert!(
+        !routes.contains("repo.search_page(") && !routes.contains("repo.page("),
+        "SECURITY: nullable-owner searchable routes must NEVER call the unscoped \
+         repo.search_page(/repo.page(:\n{routes}"
+    );
+
+    let check = Command::new("cargo")
+        .args(["check", "--tests"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    assert!(
+        check.status.success(),
+        "cargo check on generated nullable-owner searchable scaffold failed:\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&check.stdout),
         String::from_utf8_lossy(&check.stderr),
     );

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -225,6 +225,15 @@ struct RepoConfig {
     /// otherwise-blind no-lock sub-branches. When `false` (default) the blind
     /// path stays byte-for-byte as before: no extra SELECT, no validation.
     validate_on_update_fetch: bool,
+    /// Name of the per-record owner column (a `users` foreign key such as
+    /// `user_id`/`author_id`) when the repository is owner-scoped (issue #1841).
+    /// `None` (the default) emits nothing extra: every existing `#[repository]`
+    /// is unaffected. `Some(col)` additionally emits owner-filtered
+    /// `list_scoped(owner_id, ..)` and (when `searchable`) `search_page_scoped(
+    /// owner_id, ..)` methods so an owner-scoped index/search never returns other
+    /// users' rows. The column may be `BigInt` or `Nullable<BigInt>`; a nullable
+    /// owner never matches NULL (unowned) rows, which is the intended semantics.
+    owner_column: Option<String>,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -254,6 +263,7 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
     let mut broadcast_container: Option<String> = None;
     let mut dependents: Vec<DependentSpec> = Vec::new();
     let mut validate_on_update_fetch = false;
+    let mut owner_column: Option<String> = None;
 
     syn::meta::parser(|meta| {
         // `hooks = Ident` must be checked before the catch-all model_name case,
@@ -336,6 +346,13 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
         } else if meta.path.is_ident("scope") {
             let value: Ident = meta.value()?.parse()?;
             scope_type = Some(value);
+            Ok(())
+        } else if meta.path.is_ident("owner") {
+            // `owner = <column ident>` (issue #1841): opts the repository into
+            // owner-scoped list/search codegen. The value is a bare column ident
+            // (e.g. `user_id`, `author_id`) matching a `users` foreign key.
+            let value: Ident = meta.value()?.parse()?;
+            owner_column = Some(value.to_string());
             Ok(())
         } else if meta.path.is_ident("cursor_key") {
             let value: Ident = meta.value()?.parse()?;
@@ -455,7 +472,7 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
             Ok(())
         } else {
             Err(meta.error(
-                "expected model name, table = \"...\", hooks = Type, commit_hooks = true, api = \"/path\", mcp, mcp = \"read\", policy = Type, scope = Type, cursor_key = field, cursor_key_type = Type, soft_delete, tenant_scoped, no_upsert_trait, searchable, versioned = true, no_versioned_record_impl, primary_reads, sharded, validate_on_update = fetch, dependent(ChildRepository, fk = \"...\", on_delete = ...), broadcasts = true, topic = \"...\", render = fn, or container = \"...\"",
+                "expected model name, table = \"...\", hooks = Type, commit_hooks = true, api = \"/path\", mcp, mcp = \"read\", policy = Type, scope = Type, owner = column, cursor_key = field, cursor_key_type = Type, soft_delete, tenant_scoped, no_upsert_trait, searchable, versioned = true, no_versioned_record_impl, primary_reads, sharded, validate_on_update = fetch, dependent(ChildRepository, fk = \"...\", on_delete = ...), broadcasts = true, topic = \"...\", render = fn, or container = \"...\"",
             ))
         }
     })
@@ -515,6 +532,7 @@ fn parse_repo_args(attr: TokenStream) -> syn::Result<RepoConfig> {
         generated_internal_hooks,
         dependents,
         validate_on_update_fetch,
+        owner_column,
     })
 }
 
@@ -1155,6 +1173,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     } else {
         quote! {}
     };
+
+    // #1841 owner-scoping: when the repository declares `owner = <column>`, we
+    // emit owner-filtered `list_scoped` / `search_page_scoped` methods so the
+    // generated `#[secured]` index/search never returns other users' rows. The
+    // column ident is bound here once; `owner_column.is_some()` gates every scoped
+    // emission below so an ordinary `#[repository]` (no `owner =`) is unaffected.
+    let owner_col_ident = config.owner_column.as_ref().map(|c| format_ident!("{c}"));
 
     // ── #1369 dependent destroy/nullify ─────────────────────────────
     //
@@ -10148,6 +10173,115 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
+    // ── #1841: owner-scoped list method ─────────────────────────────────
+    //
+    // `list_scoped(owner_id, ..)` is `list(..)` with an unconditional
+    // `owner_column = owner_id` filter applied to BOTH the COUNT and the page
+    // query *before* the allowlisted sort/filter helpers run, so `total` and the
+    // returned rows agree and neither can be widened by a request-supplied
+    // filter. Emitted only when `owner =` is declared; otherwise both fragments
+    // are empty and every existing `#[repository]` is byte-for-byte unchanged.
+    // The owner filter composes with tenant scoping (both are `.filter(..)` on
+    // the boxed query) so a repository that is both tenant- and owner-scoped
+    // narrows by tenant AND owner.
+    let (list_scoped_trait_method, list_scoped_impl_method) = if let Some(ref owner_col) =
+        owner_col_ident
+    {
+        let trait_method = quote! {
+            /// Fetch one page of records **owned by `owner_id`** applying the same
+            /// allowlisted sort + equality filters as [`list`](Self::list).
+            ///
+            /// The `owner_id` filter is applied to both the COUNT and the page
+            /// query and cannot be overridden by a request-supplied `filter[..]`
+            /// key, so an owner-scoped index/search can never return another
+            /// user's rows (issue #1841). A nullable owner column never matches
+            /// NULL (unowned) rows.
+            fn list_scoped(
+                &self,
+                owner_id: i64,
+                query: &::autumn_web::pagination::ListQuery,
+                req: &::autumn_web::pagination::PageRequest,
+            ) -> impl ::std::future::Future<Output = ::autumn_web::AutumnResult<::autumn_web::pagination::Page<#model_name>>> + Send;
+        };
+        // Optional tenant setup + per-query tenant filters, mirroring `list`.
+        let scoped_tenant_setup = if config.tenant_scoped {
+            quote! {
+                let __tenant = if self.across_tenants {
+                    ::core::option::Option::None
+                } else {
+                    let t = ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
+                        .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg("Query scoped to tenant, but no tenant context was established"))?;
+                    ::core::option::Option::Some(t)
+                };
+            }
+        } else {
+            quote! {}
+        };
+        let scoped_tenant_count_filter = if config.tenant_scoped {
+            quote! {
+                if let ::core::option::Option::Some(ref t) = __tenant {
+                    __count_q = __count_q.filter(#table_ident::tenant_id.eq(t.clone()));
+                }
+            }
+        } else {
+            quote! {}
+        };
+        let scoped_tenant_page_filter = if config.tenant_scoped {
+            quote! {
+                if let ::core::option::Option::Some(ref t) = __tenant {
+                    __page_q = __page_q.filter(#table_ident::tenant_id.eq(t.clone()));
+                }
+            }
+        } else {
+            quote! {}
+        };
+        let impl_method = quote! {
+            async fn list_scoped(
+                &self,
+                owner_id: i64,
+                query: &::autumn_web::pagination::ListQuery,
+                req: &::autumn_web::pagination::PageRequest,
+            ) -> ::autumn_web::AutumnResult<::autumn_web::pagination::Page<#model_name>> {
+                #page_cross_shard_guard
+                use ::autumn_web::reexports::diesel::prelude::*;
+                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                #[allow(unused_imports)]
+                use ::autumn_web::pagination::AutumnListable as _;
+                #scoped_tenant_setup
+                let mut conn = self.__autumn_acquire_read_conn().await?;
+
+                let mut __count_q = #table_ident::table.into_boxed() #sd_filter;
+                #scoped_tenant_count_filter
+                // #1841: owner filter applied BEFORE the allowlisted helpers so a
+                // request `filter[..]` can only narrow, never widen, the owner set.
+                __count_q = __count_q.filter(#table_ident::#owner_col.eq(owner_id));
+                let __count_q = #model_name::__autumn_list_apply_filters(__count_q, query);
+                let total: i64 = __count_q
+                    .count()
+                    .get_result::<i64>(&mut conn)
+                    .await
+                    .map_err(::autumn_web::AutumnError::from)?;
+
+                let mut __page_q = #table_ident::table.into_boxed() #sd_filter;
+                #scoped_tenant_page_filter
+                __page_q = __page_q.filter(#table_ident::#owner_col.eq(owner_id));
+                let __page_q = #model_name::__autumn_list_apply_filters(__page_q, query);
+                let __page_q = #model_name::__autumn_list_apply_order(__page_q, query);
+                let items: ::std::vec::Vec<#model_name> = __page_q
+                    .limit(req.limit())
+                    .offset(req.offset())
+                    .select(#model_name::as_select())
+                    .load::<#model_name>(&mut conn)
+                    .await
+                    .map_err(::autumn_web::AutumnError::from)?;
+                ::core::result::Result::Ok(::autumn_web::pagination::Page::new(items, total, req))
+            }
+        };
+        (trait_method, impl_method)
+    } else {
+        (quote! {}, quote! {})
+    };
+
     // `cursor_page` is only generated when the user declares `cursor_key = field`.
     //
     // Two modes depending on whether `cursor_key_type` is also declared:
@@ -13428,6 +13562,254 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         (quote! {}, quote! {})
     };
 
+    // ── #1841: owner-scoped full-text search (`search_page_scoped`) ──────
+    //
+    // Emitted only when the repository is BOTH `searchable` AND `owner =`
+    // scoped. It clones `search_page` and adds the owner filter to ALL THREE
+    // query phases — the COUNT raw SQL, the id-SELECT raw SQL, and the typed
+    // hydration query — so `total`, the paged id set, and the hydrated rows all
+    // agree and none can leak another user's rows. The owner id is bound as a
+    // positional parameter (never string-interpolated); the parameter index
+    // shifts by one when tenant scoping already occupies `$3`, mirroring the
+    // tenant code's `$3/$4/$5` arity handling.
+    let (search_page_scoped_trait_method, search_page_scoped_impl_method) = if let (
+        true,
+        ::core::option::Option::Some(owner_col),
+        ::core::option::Option::Some(owner_col_name),
+    ) = (
+        config.searchable,
+        owner_col_ident.as_ref(),
+        config.owner_column.as_deref(),
+    ) {
+        // Owner clause literals for the two positional slots the runtime SQL
+        // builder can land the owner filter on: `$3` (no tenant param) or
+        // `$4` (tenant occupies `$3`). Built at macro-expansion time from the
+        // trusted column ident, so the runtime string only ever concatenates
+        // a fixed, developer-declared identifier — never request input.
+        let owner_and_p3 = format!(" AND {owner_col_name} = $3");
+        let owner_and_p4 = format!(" AND {owner_col_name} = $4");
+
+        let tenant_id_setup = if config.tenant_scoped {
+            quote! {
+                let tenant_id = if self.across_tenants {
+                    ::core::option::Option::None
+                } else {
+                    let t = ::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone()).ok().flatten()
+                        .ok_or_else(|| ::autumn_web::AutumnError::internal_server_error_msg("Query scoped to tenant, but no tenant context was established"))?;
+                    ::core::option::Option::Some(t)
+                };
+            }
+        } else {
+            quote! {
+                let tenant_id = ::core::option::Option::None::<::std::string::String>;
+            }
+        };
+        let search_page_cross_shard_guard = if config.sharded && config.tenant_scoped {
+            quote! {
+                if self.across_tenants && self.__autumn_shards.is_some() {
+                    return ::core::result::Result::Err(
+                        ::autumn_web::AutumnError::bad_request_msg(
+                            "cross-shard search_page is not supported: \
+                             across_tenants() fans out unpaginated reads only; \
+                             page a specific shard instead"
+                        )
+                    );
+                }
+            }
+        } else {
+            quote! {}
+        };
+        let second_stage_owner_filter = quote! {
+            records_query = records_query.filter(#table_ident::#owner_col.eq(owner_id));
+        };
+
+        let trait_method = quote! {
+            /// Owner-scoped full-text search: like [`search_page`](Self::search_page)
+            /// but every phase (`COUNT`, the ranked id `SELECT`, and the typed
+            /// hydration) is filtered to rows owned by `owner_id`, so an
+            /// owner-scoped `/search` endpoint can never return another user's
+            /// rows (issue #1841). A nullable owner column never matches NULL
+            /// (unowned) rows.
+            fn search_page_scoped(
+                &self,
+                owner_id: i64,
+                query: &str,
+                req: &::autumn_web::pagination::PageRequest,
+            ) -> impl ::std::future::Future<Output = ::autumn_web::AutumnResult<::autumn_web::pagination::Page<#model_name>>> + Send;
+        };
+
+        let impl_method = quote! {
+            async fn search_page_scoped(
+                &self,
+                owner_id: i64,
+                query: &str,
+                req: &::autumn_web::pagination::PageRequest,
+            ) -> ::autumn_web::AutumnResult<::autumn_web::pagination::Page<#model_name>> {
+                use ::autumn_web::reexports::diesel::prelude::*;
+                use ::autumn_web::reexports::diesel_async::RunQueryDsl;
+                #search_page_cross_shard_guard
+
+                if query.trim().is_empty() {
+                    return Ok(::autumn_web::pagination::Page::new(Vec::new(), 0, req));
+                }
+
+                #[derive(::autumn_web::reexports::diesel::QueryableByName)]
+                struct SearchId {
+                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::BigInt)]
+                    id: i64,
+                }
+
+                #[derive(::autumn_web::reexports::diesel::QueryableByName)]
+                struct SearchCount {
+                    #[diesel(sql_type = ::autumn_web::reexports::diesel::sql_types::BigInt)]
+                    count: i64,
+                }
+
+                #tenant_id_setup
+                let mut conn = self.__autumn_acquire_read_conn().await?;
+                let language = <#model_name as ::autumn_web::repository::AutumnSearchableModel>::SEARCH_LANGUAGE;
+                let limit = req.limit();
+                let offset = req.offset();
+
+                // ── COUNT (owner-filtered) ──
+                let mut count_sql = format!(
+                    "SELECT COUNT(*) AS count FROM \"{}\" WHERE search_vector @@ websearch_to_tsquery($1::regconfig, $2)",
+                    #table_name
+                );
+                if #config_soft_delete {
+                    count_sql.push_str(" AND deleted_at IS NULL");
+                }
+                if #config_tenant_scoped {
+                    if let ::core::option::Option::Some(ref _t) = tenant_id {
+                        count_sql.push_str(" AND tenant_id = $3");
+                        count_sql.push_str(#owner_and_p4);
+                    } else {
+                        count_sql.push_str(#owner_and_p3);
+                    }
+                } else {
+                    count_sql.push_str(#owner_and_p3);
+                }
+
+                let total = if #config_tenant_scoped {
+                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                        ::autumn_web::reexports::diesel::sql_query(count_sql)
+                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(language)
+                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(query)
+                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(t)
+                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(owner_id)
+                            .get_result::<SearchCount>(&mut conn)
+                            .await?
+                            .count
+                    } else {
+                        ::autumn_web::reexports::diesel::sql_query(count_sql)
+                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(language)
+                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(query)
+                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(owner_id)
+                            .get_result::<SearchCount>(&mut conn)
+                            .await?
+                            .count
+                    }
+                } else {
+                    ::autumn_web::reexports::diesel::sql_query(count_sql)
+                        .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(language)
+                        .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(query)
+                        .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(owner_id)
+                        .get_result::<SearchCount>(&mut conn)
+                        .await?
+                        .count
+                };
+
+                // ── ranked id SELECT (owner-filtered) ──
+                let mut select_sql = format!(
+                    "SELECT id FROM \"{}\" WHERE search_vector @@ websearch_to_tsquery($1::regconfig, $2)",
+                    #table_name
+                );
+                if #config_soft_delete {
+                    select_sql.push_str(" AND deleted_at IS NULL");
+                }
+                if #config_tenant_scoped {
+                    if let ::core::option::Option::Some(ref _t) = tenant_id {
+                        select_sql.push_str(" AND tenant_id = $3");
+                        select_sql.push_str(#owner_and_p4);
+                        select_sql.push_str(" ORDER BY ts_rank_cd(search_vector, websearch_to_tsquery($1::regconfig, $2)) DESC, id DESC");
+                        select_sql.push_str(" LIMIT $5 OFFSET $6");
+                    } else {
+                        select_sql.push_str(#owner_and_p3);
+                        select_sql.push_str(" ORDER BY ts_rank_cd(search_vector, websearch_to_tsquery($1::regconfig, $2)) DESC, id DESC");
+                        select_sql.push_str(" LIMIT $4 OFFSET $5");
+                    }
+                } else {
+                    select_sql.push_str(#owner_and_p3);
+                    select_sql.push_str(" ORDER BY ts_rank_cd(search_vector, websearch_to_tsquery($1::regconfig, $2)) DESC, id DESC");
+                    select_sql.push_str(" LIMIT $4 OFFSET $5");
+                }
+
+                let ids = if #config_tenant_scoped {
+                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                        ::autumn_web::reexports::diesel::sql_query(select_sql)
+                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(language)
+                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(query)
+                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(t)
+                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(owner_id)
+                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(limit)
+                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(offset)
+                            .load::<SearchId>(&mut conn)
+                            .await?
+                    } else {
+                        ::autumn_web::reexports::diesel::sql_query(select_sql)
+                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(language)
+                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(query)
+                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(owner_id)
+                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(limit)
+                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(offset)
+                            .load::<SearchId>(&mut conn)
+                            .await?
+                    }
+                } else {
+                    ::autumn_web::reexports::diesel::sql_query(select_sql)
+                        .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(language)
+                        .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(query)
+                        .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(owner_id)
+                        .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(limit)
+                        .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(offset)
+                        .load::<SearchId>(&mut conn)
+                        .await?
+                };
+
+                let id_list: Vec<i64> = ids.into_iter().map(|s| s.id).collect();
+                if id_list.is_empty() {
+                    return Ok(::autumn_web::pagination::Page::new(Vec::new(), total, req));
+                }
+
+                // ── typed hydration (owner-filtered) ──
+                let mut records_query = #table_ident::table
+                    .filter(#table_ident::id.eq_any(&id_list))
+                    .into_boxed();
+                #second_stage_soft_delete_filter
+                #second_stage_tenant_filter
+                #second_stage_owner_filter
+                let records = records_query
+                    .load::<#model_name>(&mut conn)
+                    .await?;
+
+                let mut record_map: ::std::collections::HashMap<i64, #model_name> = records
+                    .into_iter()
+                    .map(|r| (r.id, r))
+                    .collect();
+
+                let sorted_records: Vec<#model_name> = id_list
+                    .iter()
+                    .filter_map(|id| record_map.remove(id))
+                    .collect();
+
+                Ok(::autumn_web::pagination::Page::new(sorted_records, total, req))
+            }
+        };
+        (trait_method, impl_method)
+    } else {
+        (quote! {}, quote! {})
+    };
+
     let upsert_set_ext_impl = quote! {};
     let upsert_execution_ext_impl = quote! {};
     let correlate_ext_impl = quote! {};
@@ -13876,11 +14258,13 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             fn exists_by_id(&self, id: i64) -> impl ::std::future::Future<Output = ::autumn_web::AutumnResult<bool>> + Send;
             #pagination_trait_method
             #list_trait_method
+            #list_scoped_trait_method
             #cursor_page_trait_method
             #(#derived_trait_methods)*
             #soft_delete_trait_methods
             #bulk_trait_methods
             #search_trait_methods
+            #search_page_scoped_trait_method
         }
 
         // Bridges this repository's tenant/soft-delete config to the model's
@@ -13964,6 +14348,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
             #pagination_impl_method
             #list_impl_method
+            #list_scoped_impl_method
             #cursor_page_impl_method
             #(#derived_impl_methods)*
             #soft_delete_impl_methods
@@ -13997,6 +14382,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
             #upsert_many_impl_method
             #search_impl_methods
+            #search_page_scoped_impl_method
         }
 
         #[allow(clippy::useless_let_if_seq)]
@@ -17177,6 +17563,100 @@ mod tests {
         assert!(
             !list_body.contains("ORDER BY") && !list_body.contains("sql_query"),
             "list() must not interpolate request-derived ORDER BY / raw SQL: {list_body}"
+        );
+        // #1841: without `owner =`, no scoped methods are emitted (zero impact
+        // on ordinary repositories).
+        assert!(
+            !generated.contains("list_scoped") && !generated.contains("search_page_scoped"),
+            "no `owner =` attr must emit no owner-scoped methods: {generated}"
+        );
+    }
+
+    #[test]
+    fn parse_repo_args_with_owner() {
+        // #1841: `owner = <column>` is parsed onto `RepoConfig::owner_column`.
+        let tokens: proc_macro2::TokenStream =
+            r#"Post, api = "/api/posts", owner = author_id"#.parse().unwrap();
+        let config = parse_repo_args(tokens).unwrap();
+        assert_eq!(
+            config.owner_column.as_deref(),
+            Some("author_id"),
+            "owner attribute must be stored on RepoConfig"
+        );
+    }
+
+    #[test]
+    fn repository_owner_scoped_list_filters_owner_in_count_and_page() {
+        // #1841: `owner =` emits `list_scoped(owner_id, ..)` whose owner filter is
+        // applied to BOTH the COUNT and the page query, before the allowlisted
+        // sort/filter helpers, so `total` and the returned rows can never be
+        // widened past the owner's rows.
+        let generated = repository_macro(
+            quote! { Post, api = "/api/posts", owner = author_id },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+        assert!(
+            generated.contains("fn list_scoped"),
+            "owner-scoped repository must declare `list_scoped`: {generated}"
+        );
+        let pos = generated
+            .find("async fn list_scoped")
+            .expect("list_scoped impl present");
+        let body = &generated[pos..(pos + 3000).min(generated.len())];
+        // The owner filter must appear twice — once on the count query and once
+        // on the page query (`__count_q` / `__page_q` each gain a `.filter`).
+        let owner_filters = body.matches("posts :: author_id . eq (owner_id)").count();
+        assert!(
+            owner_filters >= 2,
+            "list_scoped must filter by owner on both the count and page query \
+             (found {owner_filters}): {body}"
+        );
+        assert!(
+            body.contains("__count_q = __count_q . filter (posts :: author_id . eq (owner_id))")
+                && body
+                    .contains("__page_q = __page_q . filter (posts :: author_id . eq (owner_id))"),
+            "list_scoped must filter both __count_q and __page_q by owner: {body}"
+        );
+    }
+
+    #[test]
+    fn repository_owner_scoped_search_filters_all_three_phases() {
+        // #1841: `owner =` + `searchable` emits `search_page_scoped(owner_id, ..)`
+        // that filters the COUNT raw SQL, the id-SELECT raw SQL, AND the typed
+        // hydration query by owner — all three, or `total`/rows would disagree
+        // and the endpoint could leak another user's rows.
+        let generated = repository_macro(
+            quote! { Post, api = "/api/posts", owner = author_id, searchable },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+        assert!(
+            generated.contains("fn search_page_scoped"),
+            "owner-scoped searchable repository must declare `search_page_scoped`: {generated}"
+        );
+        let pos = generated
+            .find("async fn search_page_scoped")
+            .expect("search_page_scoped impl present");
+        let body = &generated[pos..(pos + 9000).min(generated.len())];
+        // (a) COUNT raw SQL owner clause, (b) id-SELECT raw SQL owner clause —
+        // both go through the `" AND author_id = $3"` literal appended to
+        // count_sql / select_sql.
+        assert!(
+            body.contains("\" AND author_id = $3\""),
+            "search_page_scoped raw SQL (count + select) must filter by owner: {body}"
+        );
+        // owner id is bound positionally, never string-interpolated.
+        assert!(
+            body.contains(". bind :: < :: autumn_web :: reexports :: diesel :: sql_types :: BigInt , _ > (owner_id)"),
+            "search_page_scoped must bind owner_id as a positional BigInt param: {body}"
+        );
+        // (c) typed hydration owner filter.
+        assert!(
+            body.contains(
+                "records_query = records_query . filter (posts :: author_id . eq (owner_id))"
+            ),
+            "search_page_scoped hydration query must filter by owner: {body}"
         );
     }
 


### PR DESCRIPTION
> **Stacked PR.** Stacked on #1830 → #1853. Base is `1830-authorize-scaffold-variants`; it retargets to `trunk-dev` as the parents merge. Review the last two commits on this branch.

Closes #1841.

## Before

An owner-scoped scaffold (a model with a `user_id`/`author_id`/`users` FK + the default policy) rendered a `#[secured]` index filtered to the current user — but the repository's `search_page`/`list` returned **every user's** rows. So:

- `autumn generate scaffold … --searchable` on an owner-scoped model was **rejected** outright, because the generated `GET /{plural}/search` would call the unscoped `search_page` and leak other users' rows through the search box that the list view carefully hides (the P1 leak that made PR #1825 refuse the combination).
- Even without search, the owner-scoped index used a hand-rolled owner-filtered diesel query with **no sort/filter** (the plain `DataTableConfig`), because `repo.list` wasn't owner-scoped either (the #1854 gap).

## After

- The repository macro learns an `owner = <column>` attr and emits owner-filtered `list_scoped(owner_id, …)` and `search_page_scoped(owner_id, …)`.
- Owner-scoped scaffolds (standard Db path) now get the **search box + sort/filter index**, both safely scoped to the current user. `--searchable` + owner scoping is allowed again.
- **Security invariant:** the owner-scoped `/search` and index branches call **only** the scoped repository methods — they never call the unscoped `repo.search_page`/`repo.page`.

## How

**Macro (`autumn-macros`)**
- New `owner = <ident>` attr on `RepoConfig`; default `None` → no scoped methods emitted → every existing `#[repository]` is byte-for-byte unchanged.
- `list_scoped` clones `list` and adds `owner_column = owner_id` to **both** the count and page boxed queries, before the allowlisted sort/filter helpers, so `total` and rows agree and a request `filter[..]` can only narrow the owner set.
- `search_page_scoped` clones `search_page` and owner-filters **all three phases** — the COUNT raw SQL, the ranked id-SELECT raw SQL, and the typed hydration query — binding `owner_id` as a **positional param** (never string-interpolated), handling the `$3/$4` arity shift when tenant scoping is on. Composes with tenant scoping; a nullable owner column never matches NULL (unowned) rows.

**Generator (`autumn-cli`)**
- Emits `owner = <col>` on the generated `#[repository]` attr for the standard Db owner path only.
- Lifts the `--searchable` + owner rejection for that path; keeps refusing only the still-unwired `--sharded` owner + searchable case.
- Owner-scoped index → `repo.list_scoped(owner_id, &list_query, &page_req)` with the sort/filter `DataTableConfig`; `/search` → `repo.search_page_scoped(owner_id, q, &page_req)` with the empty-query fallback going to `repo.list_scoped(…)`.

## Out of scope (follow-up)

Owner-scoped search/sort for `--live`/`--sharded` indexes is left exactly as #1830 emitted them (the sharded FTS path still lacks a cross-shard scoped `search_page`; live has no searchable/sort UI). The `--sharded` owner + searchable combination stays rejected with an updated message.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy -p autumn-macros -p autumn-cli --all-targets -- -D warnings` — clean.
- Macro token tests (`list_scoped` filters count + page; `search_page_scoped` filters count + select + hydration; no `owner =` → no scoped methods) and scaffold unit tests (scoped wiring emitted; owner routes **never** call unscoped repo methods) — pass.
- New `#[ignore]` conformance tests `generated_owner_searchable_scaffold_cargo_checks` (owner + searchable, previously rejected) and `generated_nullable_owner_searchable_scaffold_cargo_checks` `cargo check --tests` the generated apps green, and are wired into the `generator-conformance.yml` matrix.
- Grep of the generated owner-scoped routes confirms `search_page_scoped`/`list_scoped` only, with **zero** unscoped `repo.search_page(`/`repo.page(` calls in the owner branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018i76m8A82tbXQvLD8Zsz9o

---
_Generated by [Claude Code](https://claude.ai/code/session_018i76m8A82tbXQvLD8Zsz9o)_