### PR TITLE
fix(csrf): bounded-prefix token scan + stream remainder (no full body buffering)

### DIFF
--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -3928,6 +3928,11 @@ impl AutumnConfig {
             "AUTUMN_SECURITY__CSRF__COOKIE_NAME",
             &mut self.security.csrf.cookie_name,
         );
+        parse_env(
+            env,
+            "AUTUMN_SECURITY__CSRF__TOKEN_SCAN_BYTES",
+            &mut self.security.csrf.token_scan_bytes,
+        );
 
         self.apply_rate_limit_env_overrides_with_env(env);
 
@@ -10908,6 +10913,25 @@ path = "/healthz"
         config.security.allow_unauthorized_repository_api = true;
         config.apply_env_overrides_with_env(&env);
         assert!(!config.security.allow_unauthorized_repository_api);
+    }
+
+    #[test]
+    fn env_override_csrf_token_scan_bytes() {
+        let env = MockEnv::new().with("AUTUMN_SECURITY__CSRF__TOKEN_SCAN_BYTES", "8388608");
+        let mut config = AutumnConfig::default();
+        // Default is 2 MiB; the env override must raise it.
+        assert_eq!(config.security.csrf.token_scan_bytes, 2 * 1024 * 1024);
+        config.apply_env_overrides_with_env(&env);
+        assert_eq!(config.security.csrf.token_scan_bytes, 8_388_608);
+    }
+
+    #[test]
+    fn env_override_csrf_token_scan_bytes_invalid_is_ignored() {
+        let env = MockEnv::new().with("AUTUMN_SECURITY__CSRF__TOKEN_SCAN_BYTES", "not-a-number");
+        let mut config = AutumnConfig::default();
+        config.apply_env_overrides_with_env(&env);
+        // Invalid values are ignored, leaving the default intact.
+        assert_eq!(config.security.csrf.token_scan_bytes, 2 * 1024 * 1024);
     }
 
     // ── [openapi] config section tests (RED phase) ─────────────────────────

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -2178,7 +2178,22 @@ where
         // remainder through, so the cap comes from CSRF config — NOT from
         // `upload.max_request_size_bytes` (which would force whole uploads into
         // memory and defeat the streaming upload path).
-        let mut csrf_layer = crate::security::CsrfLayer::from_config(&config.security.csrf);
+        //
+        // Clamp the effective prefix to the global body limit: the CSRF layer
+        // must never buffer more than `upload.max_request_size_bytes`. In the
+        // normal/high-upload case the small `token_scan_bytes` prefix wins (the
+        // `min` keeps it at 2 MiB — it is *not* raised to the upload limit).
+        // Only when an operator deliberately lowers the global limit *below* the
+        // prefix cap does the upload limit clamp the scan down — the whole body
+        // is ≤ that limit anyway, so an early `_csrf` token is still in range,
+        // and anything larger is rejected downstream by `DefaultBodyLimit`.
+        let effective_scan_bytes = config
+            .security
+            .csrf
+            .token_scan_bytes
+            .min(config.security.upload.max_request_size_bytes);
+        let mut csrf_layer = crate::security::CsrfLayer::from_config(&config.security.csrf)
+            .with_max_scan_bytes(effective_scan_bytes);
         if let Some(keys) = signing_keys {
             csrf_layer = csrf_layer.with_signing_keys(keys);
         }

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -2173,8 +2173,12 @@ where
 {
     // CSRF middleware (only applied when enabled)
     if config.security.csrf.enabled {
-        let mut csrf_layer = crate::security::CsrfLayer::from_config(&config.security.csrf)
-            .with_max_scan_bytes(config.security.upload.max_request_size_bytes);
+        // The CSRF token scan reads only a bounded prefix of the body
+        // (`security.csrf.token_scan_bytes`, 2 MiB default) and streams the
+        // remainder through, so the cap comes from CSRF config — NOT from
+        // `upload.max_request_size_bytes` (which would force whole uploads into
+        // memory and defeat the streaming upload path).
+        let mut csrf_layer = crate::security::CsrfLayer::from_config(&config.security.csrf);
         if let Some(keys) = signing_keys {
             csrf_layer = csrf_layer.with_signing_keys(keys);
         }

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -39,6 +39,7 @@
 //! | `AUTUMN_SECURITY__HEADERS__CONTENT_SECURITY_POLICY` | `security.headers.content_security_policy` | `String` |
 //! | `AUTUMN_SECURITY__HEADERS__CSP_NONCE__ENABLED` | `security.headers.csp_nonce.enabled` | `bool` |
 //! | `AUTUMN_SECURITY__CSRF__ENABLED` | `security.csrf.enabled` | `bool` |
+//! | `AUTUMN_SECURITY__CSRF__TOKEN_SCAN_BYTES` | `security.csrf.token_scan_bytes` | `usize` |
 //! | `AUTUMN_SECURITY__RATE_LIMIT__ENABLED` | `security.rate_limit.enabled` | `bool` |
 //! | `AUTUMN_SECURITY__RATE_LIMIT__REQUESTS_PER_SECOND` | `security.rate_limit.requests_per_second` | `f64` |
 //! | `AUTUMN_SECURITY__RATE_LIMIT__BURST` | `security.rate_limit.burst` | `u32` |
@@ -679,6 +680,7 @@ impl Default for HeadersConfig {
 /// | `cookie_name` | `"autumn-csrf"` |
 /// | `safe_methods` | `["GET", "HEAD", "OPTIONS", "TRACE"]` |
 /// | `exempt_paths` | `[]` |
+/// | `token_scan_bytes` | `2_097_152` (2 MiB) |
 ///
 /// # Examples
 ///
@@ -723,6 +725,29 @@ pub struct CsrfConfig {
     /// under `/api/`.
     #[serde(default)]
     pub exempt_paths: Vec<String>,
+
+    /// Maximum number of leading request-body bytes scanned for the `_csrf`
+    /// form field on a urlencoded / multipart POST. Default: `2 MiB`
+    /// (`2 * 1024 * 1024`).
+    ///
+    /// The token scan reads at most this many bytes of the body into a prefix
+    /// buffer and looks for the `_csrf` field there. The rest of the body is
+    /// **streamed through unbuffered** to the handler, so a large file upload
+    /// is never fully copied into memory by the CSRF layer. This deliberately
+    /// does **not** track `upload.max_request_size_bytes`: buffering a whole
+    /// 32 MiB upload per request (× concurrency) just to locate a token would
+    /// be a DoS-shaped memory cost and would defeat the streaming upload path.
+    ///
+    /// **Token-early constraint:** because only this prefix is scanned, the
+    /// `_csrf` token must appear within the first `token_scan_bytes` of the
+    /// body. Scaffolded forms emit the hidden `_csrf` field *before* any file
+    /// field, so they are always safe. Hand-written forms that place large
+    /// fields ahead of `_csrf` should either move the token earlier or raise
+    /// this cap (the escape hatch). A genuinely oversized body whose token is
+    /// beyond the prefix is not found and is rejected downstream (403 missing
+    /// token, or the natural 413 from the upload/body limit).
+    #[serde(default = "default_csrf_token_scan_bytes")]
+    pub token_scan_bytes: usize,
 }
 
 impl Default for CsrfConfig {
@@ -734,6 +759,7 @@ impl Default for CsrfConfig {
             cookie_name: default_csrf_cookie(),
             safe_methods: default_safe_methods(),
             exempt_paths: Vec::new(),
+            token_scan_bytes: default_csrf_token_scan_bytes(),
         }
     }
 }
@@ -1499,6 +1525,14 @@ fn default_csrf_field() -> String {
 
 fn default_csrf_cookie() -> String {
     "autumn-csrf".to_owned()
+}
+
+/// Default CSRF token-scan prefix cap: 2 MiB.
+///
+/// Deliberately independent of `upload.max_request_size_bytes` — only the
+/// leading prefix is buffered to locate `_csrf`; the remainder streams through.
+const fn default_csrf_token_scan_bytes() -> usize {
+    2 * 1024 * 1024
 }
 
 fn default_safe_methods() -> Vec<String> {

--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -318,6 +318,19 @@ impl CsrfLayer {
             .push(path.into());
         self
     }
+
+    /// Override the effective body-token scan cap (`max_scan_bytes`).
+    ///
+    /// The primary bound stays the small `security.csrf.token_scan_bytes`
+    /// prefix (2 MiB by default). The router uses this to *clamp* that prefix to
+    /// `min(token_scan_bytes, upload.max_request_size_bytes)` so the CSRF scan
+    /// never buffers more than the global body limit when an operator lowers
+    /// that limit below the prefix cap. See the call site in `router.rs`.
+    #[must_use]
+    pub fn with_max_scan_bytes(mut self, max_scan_bytes: usize) -> Self {
+        Arc::make_mut(&mut self.settings).max_scan_bytes = max_scan_bytes;
+        self
+    }
 }
 
 impl<S> Layer<S> for CsrfLayer {
@@ -1436,6 +1449,36 @@ mod tests {
         assert_eq!(layer.settings.safe_methods.len(), 2);
         assert!(layer.settings.safe_methods.contains(&http::Method::GET));
         assert!(layer.settings.safe_methods.contains(&http::Method::POST));
+    }
+
+    #[test]
+    fn with_max_scan_bytes_clamps_effective_scan_cap_below_prefix() {
+        // Operator lowered the global body limit (64 KiB) below the CSRF prefix
+        // cap (2 MiB default). The router clamps the effective scan cap to
+        // min(token_scan_bytes, max_request_size_bytes) = 64 KiB, so the CSRF
+        // layer never buffers more than the global body limit.
+        let token_scan_bytes = default_csrf_config().token_scan_bytes; // 2 MiB
+        let max_request_size_bytes = 64 * 1024; // 64 KiB
+        let effective = token_scan_bytes.min(max_request_size_bytes);
+
+        let layer = CsrfLayer::from_config(&default_csrf_config()).with_max_scan_bytes(effective);
+
+        assert_eq!(layer.settings.max_scan_bytes, 64 * 1024);
+    }
+
+    #[test]
+    fn with_max_scan_bytes_preserves_small_prefix_in_normal_case() {
+        // Normal/high-upload case: a large max_request_size_bytes (32 MiB
+        // default) must NOT raise the effective cap — the small token_scan_bytes
+        // prefix (2 MiB) stays the primary bound via `min`.
+        let token_scan_bytes = default_csrf_config().token_scan_bytes; // 2 MiB
+        let max_request_size_bytes = 32 * 1024 * 1024; // 32 MiB
+        let effective = token_scan_bytes.min(max_request_size_bytes);
+
+        let layer = CsrfLayer::from_config(&default_csrf_config()).with_max_scan_bytes(effective);
+
+        assert_eq!(layer.settings.max_scan_bytes, token_scan_bytes);
+        assert_eq!(layer.settings.max_scan_bytes, 2 * 1024 * 1024);
     }
 
     #[test]

--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -262,11 +262,19 @@ impl CsrfLayer {
     }
 
     /// Limit the form-body bytes read when scanning for the CSRF token field.
-    /// The effective limit is `min(n, 2 MiB)`.
+    ///
+    /// Honors the caller-supplied `n` verbatim. The router passes the configured
+    /// `security.upload.max_request_size_bytes` here so the token scan cap tracks
+    /// the request body limit: a zero-JS multipart upload up to that size can
+    /// still have its `_csrf` field located (see issue #1866). The request body
+    /// is already bounded upstream by the global `DefaultBodyLimit` (also derived
+    /// from `max_request_size_bytes`), so buffering up to `n` here introduces no
+    /// new unbounded-memory exposure. When this method is not called the default
+    /// from [`Self::from_config`] (2 MiB) applies.
     #[must_use]
     pub(crate) fn with_max_scan_bytes(mut self, n: usize) -> Self {
         let settings = Arc::make_mut(&mut self.settings);
-        settings.max_scan_bytes = n.min(2 * 1024 * 1024);
+        settings.max_scan_bytes = n;
         self
     }
 
@@ -1623,6 +1631,101 @@ mod tests {
                     .method("POST")
                     .uri("/upload")
                     .header("Cookie", "autumn-csrf=correct-token")
+                    .header(http::header::ACCEPT, "text/html")
+                    .header(
+                        "Content-Type",
+                        format!("multipart/form-data; boundary={boundary}"),
+                    )
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// Build a multipart body larger than the legacy 2 MiB scan cap: a valid
+    /// `_csrf` field positioned first, followed by a padded binary file field.
+    fn large_multipart_body(boundary: &str, token: &str, pad_bytes: usize) -> Vec<u8> {
+        let mut body = format!(
+            "--{boundary}\r\nContent-Disposition: form-data; name=\"_csrf\"\r\n\r\n{token}\r\n"
+        )
+        .into_bytes();
+        body.extend_from_slice(
+            format!(
+                "--{boundary}\r\nContent-Disposition: form-data; name=\"avatar\"; \
+                 filename=\"photo.bin\"\r\nContent-Type: application/octet-stream\r\n\r\n"
+            )
+            .as_bytes(),
+        );
+        body.extend(std::iter::repeat_n(b'A', pad_bytes));
+        body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+        body
+    }
+
+    /// Regression test for issue #1866. A zero-JS multipart upload larger than the
+    /// legacy hard-clamped 2 MiB scan window — but within the configured scan cap —
+    /// must still have its `_csrf` field located, so it is NOT rejected with 403.
+    #[tokio::test]
+    async fn post_large_multipart_within_scan_cap_finds_token_passes() {
+        let token = "test-csrf-token-uuid-1866";
+        let boundary = "----WebKitFormBoundary1866PASS";
+        // 3 MiB of padding => whole body exceeds the legacy 2 MiB clamp.
+        let body = large_multipart_body(boundary, token, 3 * 1024 * 1024);
+        assert!(body.len() > 2 * 1024 * 1024);
+
+        // Router wires `with_max_scan_bytes(upload.max_request_size_bytes)`; here we
+        // model a configured 4 MiB request-body limit (> the legacy 2 MiB clamp).
+        let app = Router::new()
+            .route("/upload", post(|| async { "ok" }))
+            .layer(
+                CsrfLayer::from_config(&default_csrf_config()).with_max_scan_bytes(4 * 1024 * 1024),
+            );
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/upload")
+                    .header("Cookie", format!("autumn-csrf={token}"))
+                    .header(http::header::ACCEPT, "text/html")
+                    .header(
+                        "Content-Type",
+                        format!("multipart/form-data; boundary={boundary}"),
+                    )
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    /// Contrast for issue #1866: with the scan cap left at the 2 MiB default, the
+    /// same >2 MiB body cannot be buffered, so `to_bytes` errors, the token is not
+    /// found, and the request is rejected with 403 — the pre-fix behavior. This
+    /// documents that the effective ceiling is the scan cap, which the fix now
+    /// aligns to `max_request_size_bytes`.
+    #[tokio::test]
+    async fn post_large_multipart_exceeding_scan_cap_rejected() {
+        let token = "test-csrf-token-uuid-1866b";
+        let boundary = "----WebKitFormBoundary1866FAIL";
+        let body = large_multipart_body(boundary, token, 3 * 1024 * 1024);
+        assert!(body.len() > 2 * 1024 * 1024);
+
+        // Default cap is 2 MiB (from_config, no with_max_scan_bytes override).
+        let app = Router::new()
+            .route("/upload", post(|| async { "ok" }))
+            .layer(CsrfLayer::from_config(&default_csrf_config()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/upload")
+                    .header("Cookie", format!("autumn-csrf={token}"))
                     .header(http::header::ACCEPT, "text/html")
                     .header(
                         "Content-Type",

--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -13,6 +13,25 @@
 //!    `_csrf` form field).
 //! 3. Safe methods (GET, HEAD, OPTIONS, TRACE) are exempt.
 //!
+//! # Body-token scanning
+//!
+//! When the token is carried in a urlencoded / multipart **form body** (rather
+//! than the header or query string), the layer scans only a bounded **prefix**
+//! of the body — at most `security.csrf.token_scan_bytes` (2 MiB by default) —
+//! to locate the `_csrf` field. The remainder of the body is **streamed
+//! through unbuffered** to the handler, so a large file upload is never fully
+//! copied into memory by this layer (which would otherwise be a DoS-shaped
+//! memory cost and would defeat the streaming upload path).
+//!
+//! **Token-early constraint:** the `_csrf` token must therefore appear within
+//! the first `token_scan_bytes` of the body. Scaffolded forms emit the hidden
+//! `_csrf` field *before* any file field, so they are always safe. Hand-written
+//! forms that place large fields ahead of `_csrf` should move the token earlier
+//! or raise the cap. A body whose token sits beyond the prefix is treated as a
+//! missing token (403); a genuinely oversized upload is rejected downstream by
+//! the real body / upload limits (the natural `413`), which is where that
+//! belongs.
+//!
 //! # Configuration
 //!
 //! See [`CsrfConfig`] for available settings.
@@ -47,8 +66,10 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use axum::body::{Body, Bytes};
 use axum::extract::{FromRequestParts, OptionalFromRequestParts};
 use axum::http::{Request, Response, StatusCode};
+use futures::StreamExt as _;
 use http::header::HeaderName;
 
 use tower::{Layer, Service};
@@ -59,43 +80,18 @@ use super::config::CsrfConfig;
 /// Error body returned with a `403 Forbidden` when CSRF validation fails.
 const CSRF_FORBIDDEN_MESSAGE: &str = "CSRF token missing or invalid";
 
-/// Error body returned with a `413 Payload Too Large` when the form body carrying
-/// the `_csrf` token exceeds the configured scan cap (see [`CsrfVerdict`]).
-const CSRF_PAYLOAD_TOO_LARGE_MESSAGE: &str = "Request body exceeds the maximum allowed size";
-
 /// Outcome of CSRF verification for a mutating request.
 enum CsrfVerdict {
     /// A matching token was found — allow the request through.
     Valid,
     /// No valid token was presented — reject with `403 Forbidden`.
+    ///
+    /// This also covers the case where a form-body token exists but sits beyond
+    /// the scanned prefix (`max_scan_bytes`): the token is simply not observed,
+    /// so the request is rejected like any other missing token. A genuinely
+    /// oversized body streams through and is bounded downstream by the real
+    /// body / upload limits.
     Missing,
-    /// The urlencoded/multipart form body carrying the token exceeded
-    /// `max_scan_bytes`, so `to_bytes` could not buffer it to locate the
-    /// `_csrf` field. Reject with `413 Payload Too Large` rather than a
-    /// misleading `403` "missing token": the body genuinely is over the
-    /// request-size limit, and the intended `413` would otherwise be
-    /// unobservable because this CSRF layer short-circuits before the upload
-    /// extractor/body-limit can surface it (see issue #1866).
-    BodyTooLarge,
-}
-
-/// Return `true` when `err` (from [`axum::body::to_bytes`]) was caused by the
-/// scan-cap length limit being exceeded, as opposed to some other body read
-/// error (e.g. a client disconnect mid-body).
-///
-/// `to_bytes` wraps the limit failure as an [`http_body_util::LengthLimitError`]
-/// in the error's source chain (see the axum `to_bytes` docs). We walk the whole
-/// chain and downcast so the detection stays robust even if axum adds wrapping
-/// layers.
-fn is_body_length_limit_error(err: &axum::Error) -> bool {
-    let mut source: Option<&(dyn std::error::Error + 'static)> = Some(err);
-    while let Some(err) = source {
-        if err.is::<http_body_util::LengthLimitError>() {
-            return true;
-        }
-        source = err.source();
-    }
-    false
 }
 
 /// The configured CSRF form field name, placed in request extensions by [`CsrfLayer`].
@@ -295,26 +291,9 @@ impl CsrfLayer {
                 safe_methods,
                 exempt_paths: config.exempt_paths.clone(),
                 signing_keys: None,
-                max_scan_bytes: 2 * 1024 * 1024,
+                max_scan_bytes: config.token_scan_bytes,
             }),
         }
-    }
-
-    /// Limit the form-body bytes read when scanning for the CSRF token field.
-    ///
-    /// Honors the caller-supplied `n` verbatim. The router passes the configured
-    /// `security.upload.max_request_size_bytes` here so the token scan cap tracks
-    /// the request body limit: a zero-JS multipart upload up to that size can
-    /// still have its `_csrf` field located (see issue #1866). The request body
-    /// is already bounded upstream by the global `DefaultBodyLimit` (also derived
-    /// from `max_request_size_bytes`), so buffering up to `n` here introduces no
-    /// new unbounded-memory exposure. When this method is not called the default
-    /// from [`Self::from_config`] (2 MiB) applies.
-    #[must_use]
-    pub(crate) fn with_max_scan_bytes(mut self, n: usize) -> Self {
-        let settings = Arc::make_mut(&mut self.settings);
-        settings.max_scan_bytes = n;
-        self
     }
 
     /// Attach signing keys so CSRF tokens are HMAC-signed.
@@ -511,22 +490,17 @@ where
                     let instance = Some(req.uri().path().to_owned());
                     let prefers_problem = wants_problem_details(req.headers());
 
-                    // Oversized form body → 413; anything else (missing/invalid
-                    // token, unreadable body) → 403.
-                    let (status, message) = match verdict {
-                        CsrfVerdict::BodyTooLarge => (
-                            StatusCode::PAYLOAD_TOO_LARGE,
-                            CSRF_PAYLOAD_TOO_LARGE_MESSAGE,
-                        ),
-                        _ => (StatusCode::FORBIDDEN, CSRF_FORBIDDEN_MESSAGE),
-                    };
+                    // Missing/invalid token (including a token beyond the scanned
+                    // prefix) → 403. Genuinely oversized bodies stream through and
+                    // are rejected downstream by the real body / upload limits.
+                    let message = CSRF_FORBIDDEN_MESSAGE;
 
                     if prefers_problem {
-                        return Ok(csrf_problem_response(status, message, request_id, instance));
+                        return Ok(csrf_problem_response(message, request_id, instance));
                     }
 
                     let mut response = Response::new(ResBody::from(message));
-                    *response.status_mut() = status;
+                    *response.status_mut() = StatusCode::FORBIDDEN;
                     response.headers_mut().insert(
                         http::header::CONTENT_TYPE,
                         http::HeaderValue::from_static("text/plain; charset=utf-8"),
@@ -554,32 +528,24 @@ fn wants_problem_details(headers: &http::HeaderMap) -> bool {
 }
 
 fn csrf_problem_response<ResBody: From<String> + Default>(
-    status: StatusCode,
     message: &str,
     request_id: Option<String>,
     instance: Option<String>,
 ) -> Response<ResBody> {
-    // The 403 case keeps the CSRF-specific problem type/code; the 413 case
-    // (oversized form body, see issue #1866) uses the module-wide
-    // payload-too-large mapping derived from the status.
-    let explicit_type =
-        (status == StatusCode::FORBIDDEN).then_some("https://autumn.dev/problems/csrf");
     let mut problem = crate::error::problem_details(
-        status,
+        StatusCode::FORBIDDEN,
         message.to_owned(),
         None,
-        explicit_type,
+        Some("https://autumn.dev/problems/csrf"),
         request_id,
         instance,
         true,
     );
-    if status == StatusCode::FORBIDDEN {
-        "autumn.csrf".clone_into(&mut problem.code);
-    }
+    "autumn.csrf".clone_into(&mut problem.code);
     let body = crate::error::problem_details_to_json_string(&problem);
 
     Response::builder()
-        .status(status)
+        .status(StatusCode::FORBIDDEN)
         .header(http::header::CONTENT_TYPE, "application/problem+json")
         .body(ResBody::from(body))
         .unwrap_or_default()
@@ -739,31 +705,32 @@ async fn verify_csrf_token(
         return CsrfVerdict::Missing;
     }
 
-    // Temporarily take ownership of the body
+    // Take the body, buffer at most `max_scan_bytes` of it into a scan prefix,
+    // and reconstruct the full, unmodified body so downstream handlers still
+    // receive every byte. When the body is larger than the cap, the tail is
+    // *streamed* through rather than buffered — the CSRF layer never forces a
+    // large upload into memory.
     let body = std::mem::replace(req.body_mut(), axum::body::Body::empty());
 
-    // Limit body size to avoid DoS when extracting form field.
-    let bytes = match axum::body::to_bytes(body, settings.max_scan_bytes).await {
-        Ok(bytes) => bytes,
-        Err(err) if is_body_length_limit_error(&err) => {
-            // The form body carrying `_csrf` is larger than the scan cap (which
-            // tracks `upload.max_request_size_bytes`). Surface this as
-            // `413 Payload Too Large` instead of falling through to a misleading
-            // `403` "missing token" — the token isn't absent, the body is simply
-            // over the request-size limit (see issue #1866).
-            return CsrfVerdict::BodyTooLarge;
+    let (prefix, rebuilt) = match collect_body_prefix(body, settings.max_scan_bytes).await {
+        CollectedBody::Full(bytes) => {
+            let rebuilt = Body::from(bytes.clone());
+            (bytes, rebuilt)
         }
-        Err(_) => {
-            // A non-length body read error (e.g. the client disconnected
-            // mid-body). This module has no dedicated malformed-body path, so we
-            // preserve the pre-existing behavior of treating an unreadable body
-            // as a missing token (→ 403) rather than inventing a new 400 here.
+        CollectedBody::Oversized { prefix, body } => (prefix, body),
+        CollectedBody::Errored(err) => {
+            // The body stream errored mid-read (e.g. a client disconnect). We
+            // cannot losslessly reconstruct it, and a token cannot be confirmed,
+            // so we preserve the pre-existing behavior of treating an unreadable
+            // body as a missing token (→ 403). The request is rejected and the
+            // handler never runs, so the discarded body is immaterial.
+            tracing::debug!(error = %err, "CSRF token scan: body read error, treating as missing token");
             return CsrfVerdict::Missing;
         }
     };
 
     if is_urlencoded {
-        for (key, value) in url::form_urlencoded::parse(&bytes) {
+        for (key, value) in url::form_urlencoded::parse(&prefix) {
             if key == settings.form_field {
                 if let Some(c) = cookie_token
                     && !c.is_empty()
@@ -778,7 +745,7 @@ async fn verify_csrf_token(
         }
     } else if let Some(ref boundary) = multipart_boundary {
         #[allow(clippy::collapsible_if)]
-        if let Some(value) = scan_multipart_field(&bytes, boundary, &settings.form_field) {
+        if let Some(value) = scan_multipart_field(&prefix, boundary, &settings.form_field) {
             if let Some(c) = cookie_token
                 && !c.is_empty()
                 && !value.is_empty()
@@ -790,14 +757,73 @@ async fn verify_csrf_token(
         }
     }
 
-    // Restore request body so downstream handlers (e.g. Multipart extractor) can read it.
-    *req.body_mut() = axum::body::Body::from(bytes);
+    // Restore the full body so downstream handlers (e.g. the Multipart
+    // extractor) read it intact — identical bytes and framing.
+    *req.body_mut() = rebuilt;
 
     if token_found {
         CsrfVerdict::Valid
     } else {
         CsrfVerdict::Missing
     }
+}
+
+/// Body buffered up to a bounded scan prefix, plus a reconstruction of the full
+/// body for downstream handlers. Mirrors the `collect_body` pattern in
+/// [`submit_token`](crate::security::submit_token) so both middlewares scan a
+/// bounded prefix and stream the remainder identically.
+enum CollectedBody {
+    /// The whole body fit within the cap and is fully buffered. The same bytes
+    /// serve as both the scan prefix and the rebuilt body.
+    Full(Bytes),
+    /// The body exceeded the cap. `prefix` is the first `limit` bytes (the scan
+    /// window); `body` replays the complete, unmodified body — the buffered
+    /// prefix bytes plus the over-limit chunk and the remaining stream — so the
+    /// handler receives every byte with the tail streamed rather than buffered.
+    Oversized { prefix: Bytes, body: Body },
+    /// The body stream errored before EOF. The bytes read so far are discarded:
+    /// the caller rejects the request rather than forward a truncated body.
+    Errored(axum::Error),
+}
+
+/// Buffer `body` up to `limit` bytes into a scan prefix without failing when the
+/// body is larger, reconstructing the full body for pass-through.
+async fn collect_body_prefix(body: Body, limit: usize) -> CollectedBody {
+    let mut buf = Vec::<u8>::new();
+    let mut stream = body.into_data_stream();
+    loop {
+        match stream.next().await {
+            None => break,
+            Some(Err(err)) => return CollectedBody::Errored(err),
+            Some(Ok(chunk)) => {
+                let remaining = limit.saturating_sub(buf.len());
+                if chunk.len() > remaining {
+                    // Fill the scan prefix up to `limit` with the leading bytes
+                    // of the over-limit chunk, so a token at the front of the
+                    // form is still found even when the FIRST chunk already
+                    // exceeds the cap (e.g. an upstream middleware rebuilt the
+                    // body as one `Body::from(bytes)`, leaving `buf` empty here).
+                    let mut prefix_buf = buf.clone();
+                    prefix_buf.extend_from_slice(&chunk[..remaining]);
+                    let prefix = Bytes::from(prefix_buf);
+                    // Replay the FULL body unchanged: the buffered prefix bytes
+                    // followed by the *complete* over-limit chunk (not just its
+                    // scanned head) and the rest of the stream. The prefix is
+                    // only for locating the token; the handler must receive every
+                    // byte, and the tail streams through unbuffered.
+                    let mut leading = Vec::with_capacity(2);
+                    if !buf.is_empty() {
+                        leading.push(Ok::<Bytes, axum::Error>(Bytes::from(buf)));
+                    }
+                    leading.push(Ok::<Bytes, axum::Error>(chunk));
+                    let body = Body::from_stream(futures::stream::iter(leading).chain(stream));
+                    return CollectedBody::Oversized { prefix, body };
+                }
+                buf.extend_from_slice(&chunk);
+            }
+        }
+    }
+    CollectedBody::Full(Bytes::from(buf))
 }
 
 #[cfg(test)]
@@ -859,6 +885,17 @@ mod tests {
     fn default_csrf_config() -> CsrfConfig {
         CsrfConfig {
             enabled: true,
+            ..Default::default()
+        }
+    }
+
+    /// An enabled CSRF config with a custom body-token scan-prefix cap, used to
+    /// exercise the bounded-prefix scan boundary without allocating multi-MiB
+    /// bodies.
+    fn csrf_config_with_scan_bytes(n: usize) -> CsrfConfig {
+        CsrfConfig {
+            enabled: true,
+            token_scan_bytes: n,
             ..Default::default()
         }
     }
@@ -1292,17 +1329,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn post_with_large_body_returns_413() {
-        let token = Uuid::new_v4().to_string();
-        let app = Router::new()
-            .route("/submit", post(|| async { "created" }))
-            .layer(CsrfLayer::from_config(&default_csrf_config()));
+    async fn post_with_large_urlencoded_body_token_first_streams_and_passes() {
+        // A urlencoded body far larger than the scan prefix, with `_csrf` FIRST.
+        // The token is located in the prefix (→ pass) and the full body still
+        // reaches the handler intact — the tail streams through unbuffered.
+        async fn echo_len(body: Body) -> String {
+            let bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
+            bytes.len().to_string()
+        }
 
-        // Create a body just over the 2 MiB default scan cap. `to_bytes` cannot
-        // buffer it to locate `_csrf`, so the CSRF layer now returns 413 Payload
-        // Too Large (the token isn't missing — the body is oversized; see #1866).
-        let large_padding = "a".repeat(2 * 1024 * 1024 + 10);
+        let token = Uuid::new_v4().to_string();
+        let large_padding = "a".repeat(256 * 1024);
         let body_content = format!("_csrf={token}&pad={large_padding}");
+        let full_len = body_content.len();
+
+        // 4 KiB prefix cap: `_csrf=...` is well within it, the body is not.
+        let app = Router::new()
+            .route("/submit", post(echo_len))
+            .layer(CsrfLayer::from_config(&csrf_config_with_scan_bytes(4096)));
 
         let response = app
             .oneshot(
@@ -1317,7 +1361,15 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(response.status(), StatusCode::OK);
+        let echoed = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let received: usize = std::str::from_utf8(&echoed).unwrap().parse().unwrap();
+        assert_eq!(
+            received, full_len,
+            "handler must receive the full, unmodified body (tail streamed through)"
+        );
     }
 
     #[tokio::test]
@@ -1748,24 +1800,50 @@ mod tests {
         body
     }
 
-    /// Regression test for issue #1866. A zero-JS multipart upload larger than the
-    /// legacy hard-clamped 2 MiB scan window — but within the configured scan cap —
-    /// must still have its `_csrf` field located, so it is NOT rejected with 403.
-    #[tokio::test]
-    async fn post_large_multipart_within_scan_cap_finds_token_passes() {
-        let token = "test-csrf-token-uuid-1866";
-        let boundary = "----WebKitFormBoundary1866PASS";
-        // 3 MiB of padding => whole body exceeds the legacy 2 MiB clamp.
-        let body = large_multipart_body(boundary, token, 3 * 1024 * 1024);
-        assert!(body.len() > 2 * 1024 * 1024);
+    /// Build a multipart body with a large filler field placed BEFORE `_csrf`,
+    /// so the token sits `lead_bytes`+ into the body (used to push it past a
+    /// scan prefix). Returns `(body, full_len)`.
+    fn multipart_token_after_filler(boundary: &str, token: &str, lead_bytes: usize) -> Vec<u8> {
+        let mut body =
+            format!("--{boundary}\r\nContent-Disposition: form-data; name=\"filler\"\r\n\r\n")
+                .into_bytes();
+        body.extend(std::iter::repeat_n(b'x', lead_bytes));
+        body.extend_from_slice(
+            format!(
+                "\r\n--{boundary}\r\nContent-Disposition: form-data; \
+                 name=\"_csrf\"\r\n\r\n{token}\r\n--{boundary}--\r\n"
+            )
+            .as_bytes(),
+        );
+        body
+    }
 
-        // Router wires `with_max_scan_bytes(upload.max_request_size_bytes)`; here we
-        // model a configured 4 MiB request-body limit (> the legacy 2 MiB clamp).
+    /// Stream-through regression (issue #1866 redesign). A multipart body far
+    /// larger than the scan prefix, with `_csrf` as the FIRST field, must:
+    ///   1. PASS CSRF — the token is located within the bounded prefix; and
+    ///   2. deliver the FULL, unmodified body to the handler — proving the
+    ///      remainder streamed through and the reconstruction is lossless.
+    /// The scan itself stops at the cap by construction: the 4 KiB prefix cap is
+    /// far smaller than the body, yet the request still passes and streams, so
+    /// the layer cannot have buffered the whole body to find the token.
+    #[tokio::test]
+    async fn post_large_multipart_token_first_streams_full_body_and_passes() {
+        async fn echo_len(body: Body) -> String {
+            let bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
+            bytes.len().to_string()
+        }
+
+        let token = "test-csrf-token-uuid-stream";
+        let boundary = "----WebKitFormBoundarySTREAM";
+        // _csrf first, then a ~256 KiB file field — body far exceeds the cap.
+        let body = large_multipart_body(boundary, token, 256 * 1024);
+        let full_len = body.len();
+        assert!(full_len > 4096);
+
+        // 4 KiB prefix cap: the leading `_csrf` field is well within it.
         let app = Router::new()
-            .route("/upload", post(|| async { "ok" }))
-            .layer(
-                CsrfLayer::from_config(&default_csrf_config()).with_max_scan_bytes(4 * 1024 * 1024),
-            );
+            .route("/upload", post(echo_len))
+            .layer(CsrfLayer::from_config(&csrf_config_with_scan_bytes(4096)));
 
         let response = app
             .oneshot(
@@ -1785,22 +1863,28 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
+        let echoed = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let received: usize = std::str::from_utf8(&echoed).unwrap().parse().unwrap();
+        assert_eq!(
+            received, full_len,
+            "handler must receive the full, unmodified body (tail streamed through)"
+        );
     }
 
-    /// Issue #1866: when the form body carrying `_csrf` exceeds the scan cap, the
-    /// token cannot be buffered, so it must NOT be misreported as a missing token
-    /// (403). The body is genuinely over the request-size limit, so the CSRF layer
-    /// now returns `413 Payload Too Large` — the response issue #1866 wanted to be
-    /// observable, rather than a misleading 403. Here the scan cap is left at the
-    /// 2 MiB default (no `with_max_scan_bytes` override) and the body is > 2 MiB.
+    /// Token-early constraint. When `_csrf` sits AFTER more than `max_scan_bytes`
+    /// of preceding data, it is not observed in the prefix and the request is
+    /// rejected as a missing token (403) — NOT a 413. A genuinely oversized body
+    /// is left to the downstream body / upload limits.
     #[tokio::test]
-    async fn post_large_multipart_exceeding_scan_cap_returns_413() {
-        let token = "test-csrf-token-uuid-1866b";
-        let boundary = "----WebKitFormBoundary1866FAIL";
-        let body = large_multipart_body(boundary, token, 3 * 1024 * 1024);
+    async fn post_multipart_token_beyond_scan_prefix_returns_403() {
+        let token = "test-csrf-token-uuid-beyond";
+        let boundary = "----WebKitFormBoundaryBEYOND";
+        // Default 2 MiB cap; place `_csrf` after > 2 MiB of filler.
+        let body = multipart_token_after_filler(boundary, token, 2 * 1024 * 1024 + 1024);
         assert!(body.len() > 2 * 1024 * 1024);
 
-        // Default cap is 2 MiB (from_config, no with_max_scan_bytes override).
         let app = Router::new()
             .route("/upload", post(|| async { "ok" }))
             .layer(CsrfLayer::from_config(&default_csrf_config()));
@@ -1822,47 +1906,48 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 
-    /// The overflow is classified before token presence: a form body over the scan
-    /// cap that carries NO `_csrf` field still returns 413 (not the 403 a genuinely
-    /// missing token would produce), confirming the size limit is evaluated first.
+    /// Configurable cap moves the scan boundary. The SAME body — with `_csrf`
+    /// ~8 KiB into it — is rejected under a 4 KiB cap (token beyond the prefix)
+    /// but accepted under a 64 KiB cap (token within the prefix).
     #[tokio::test]
-    async fn post_large_multipart_over_cap_without_token_returns_413() {
-        let boundary = "----WebKitFormBoundary1866NOTOK";
-        // Build an oversized body with a file field but no `_csrf` part.
-        let mut body = format!(
-            "--{boundary}\r\nContent-Disposition: form-data; name=\"avatar\"; \
-             filename=\"photo.bin\"\r\nContent-Type: application/octet-stream\r\n\r\n"
-        )
-        .into_bytes();
-        body.extend(std::iter::repeat_n(b'A', 3 * 1024 * 1024));
-        body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
-        assert!(body.len() > 2 * 1024 * 1024);
+    async fn configurable_scan_cap_moves_token_boundary() {
+        let token = "test-csrf-token-uuid-cap";
+        let boundary = "----WebKitFormBoundaryCAP";
+        let body = multipart_token_after_filler(boundary, token, 8 * 1024);
 
-        // Default cap is 2 MiB (from_config, no with_max_scan_bytes override).
-        let app = Router::new()
+        let make_request = || {
+            Request::builder()
+                .method("POST")
+                .uri("/upload")
+                .header("Cookie", format!("autumn-csrf={token}"))
+                .header(http::header::ACCEPT, "text/html")
+                .header(
+                    "Content-Type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                )
+                .body(Body::from(body.clone()))
+                .unwrap()
+        };
+
+        // Small 4 KiB cap: `_csrf` sits beyond the prefix → not found → 403.
+        let small = Router::new()
             .route("/upload", post(|| async { "ok" }))
-            .layer(CsrfLayer::from_config(&default_csrf_config()));
+            .layer(CsrfLayer::from_config(&csrf_config_with_scan_bytes(
+                4 * 1024,
+            )));
+        let resp = small.oneshot(make_request()).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/upload")
-                    .header("Cookie", "autumn-csrf=sometoken")
-                    .header(http::header::ACCEPT, "text/html")
-                    .header(
-                        "Content-Type",
-                        format!("multipart/form-data; boundary={boundary}"),
-                    )
-                    .body(Body::from(body))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        // Larger 64 KiB cap: the same `_csrf` now falls within the prefix → 200.
+        let large = Router::new()
+            .route("/upload", post(|| async { "ok" }))
+            .layer(CsrfLayer::from_config(&csrf_config_with_scan_bytes(
+                64 * 1024,
+            )));
+        let resp = large.oneshot(make_request()).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 }

--- a/autumn/src/security/csrf.rs
+++ b/autumn/src/security/csrf.rs
@@ -59,6 +59,45 @@ use super::config::CsrfConfig;
 /// Error body returned with a `403 Forbidden` when CSRF validation fails.
 const CSRF_FORBIDDEN_MESSAGE: &str = "CSRF token missing or invalid";
 
+/// Error body returned with a `413 Payload Too Large` when the form body carrying
+/// the `_csrf` token exceeds the configured scan cap (see [`CsrfVerdict`]).
+const CSRF_PAYLOAD_TOO_LARGE_MESSAGE: &str = "Request body exceeds the maximum allowed size";
+
+/// Outcome of CSRF verification for a mutating request.
+enum CsrfVerdict {
+    /// A matching token was found — allow the request through.
+    Valid,
+    /// No valid token was presented — reject with `403 Forbidden`.
+    Missing,
+    /// The urlencoded/multipart form body carrying the token exceeded
+    /// `max_scan_bytes`, so `to_bytes` could not buffer it to locate the
+    /// `_csrf` field. Reject with `413 Payload Too Large` rather than a
+    /// misleading `403` "missing token": the body genuinely is over the
+    /// request-size limit, and the intended `413` would otherwise be
+    /// unobservable because this CSRF layer short-circuits before the upload
+    /// extractor/body-limit can surface it (see issue #1866).
+    BodyTooLarge,
+}
+
+/// Return `true` when `err` (from [`axum::body::to_bytes`]) was caused by the
+/// scan-cap length limit being exceeded, as opposed to some other body read
+/// error (e.g. a client disconnect mid-body).
+///
+/// `to_bytes` wraps the limit failure as an [`http_body_util::LengthLimitError`]
+/// in the error's source chain (see the axum `to_bytes` docs). We walk the whole
+/// chain and downcast so the detection stays robust even if axum adds wrapping
+/// layers.
+fn is_body_length_limit_error(err: &axum::Error) -> bool {
+    let mut source: Option<&(dyn std::error::Error + 'static)> = Some(err);
+    while let Some(err) = source {
+        if err.is::<http_body_util::LengthLimitError>() {
+            return true;
+        }
+        source = err.source();
+    }
+    false
+}
+
 /// The configured CSRF form field name, placed in request extensions by [`CsrfLayer`].
 ///
 /// [`ChangesetForm`](crate::form::ChangesetForm) reads this so `form_tag` emits the
@@ -462,23 +501,38 @@ where
         std::mem::swap(&mut self.inner, &mut inner);
 
         Box::pin(async move {
-            if !is_safe && !verify_csrf_token(&mut req, &settings, cookie_token.as_deref()).await {
-                let request_id = req
-                    .extensions()
-                    .get::<crate::middleware::RequestId>()
-                    .map(std::string::ToString::to_string);
-                let instance = Some(req.uri().path().to_owned());
-                if wants_problem_details(req.headers()) {
-                    return Ok(csrf_problem_response(request_id, instance));
-                }
+            if !is_safe {
+                let verdict = verify_csrf_token(&mut req, &settings, cookie_token.as_deref()).await;
+                if !matches!(verdict, CsrfVerdict::Valid) {
+                    let request_id = req
+                        .extensions()
+                        .get::<crate::middleware::RequestId>()
+                        .map(std::string::ToString::to_string);
+                    let instance = Some(req.uri().path().to_owned());
+                    let prefers_problem = wants_problem_details(req.headers());
 
-                let mut response = Response::new(ResBody::from(CSRF_FORBIDDEN_MESSAGE));
-                *response.status_mut() = StatusCode::FORBIDDEN;
-                response.headers_mut().insert(
-                    http::header::CONTENT_TYPE,
-                    http::HeaderValue::from_static("text/plain; charset=utf-8"),
-                );
-                return Ok(response);
+                    // Oversized form body → 413; anything else (missing/invalid
+                    // token, unreadable body) → 403.
+                    let (status, message) = match verdict {
+                        CsrfVerdict::BodyTooLarge => (
+                            StatusCode::PAYLOAD_TOO_LARGE,
+                            CSRF_PAYLOAD_TOO_LARGE_MESSAGE,
+                        ),
+                        _ => (StatusCode::FORBIDDEN, CSRF_FORBIDDEN_MESSAGE),
+                    };
+
+                    if prefers_problem {
+                        return Ok(csrf_problem_response(status, message, request_id, instance));
+                    }
+
+                    let mut response = Response::new(ResBody::from(message));
+                    *response.status_mut() = status;
+                    response.headers_mut().insert(
+                        http::header::CONTENT_TYPE,
+                        http::HeaderValue::from_static("text/plain; charset=utf-8"),
+                    );
+                    return Ok(response);
+                }
             }
 
             // Validation passed (or method is safe)
@@ -500,23 +554,32 @@ fn wants_problem_details(headers: &http::HeaderMap) -> bool {
 }
 
 fn csrf_problem_response<ResBody: From<String> + Default>(
+    status: StatusCode,
+    message: &str,
     request_id: Option<String>,
     instance: Option<String>,
 ) -> Response<ResBody> {
+    // The 403 case keeps the CSRF-specific problem type/code; the 413 case
+    // (oversized form body, see issue #1866) uses the module-wide
+    // payload-too-large mapping derived from the status.
+    let explicit_type =
+        (status == StatusCode::FORBIDDEN).then_some("https://autumn.dev/problems/csrf");
     let mut problem = crate::error::problem_details(
-        StatusCode::FORBIDDEN,
-        CSRF_FORBIDDEN_MESSAGE.to_owned(),
+        status,
+        message.to_owned(),
         None,
-        Some("https://autumn.dev/problems/csrf"),
+        explicit_type,
         request_id,
         instance,
         true,
     );
-    "autumn.csrf".clone_into(&mut problem.code);
+    if status == StatusCode::FORBIDDEN {
+        "autumn.csrf".clone_into(&mut problem.code);
+    }
     let body = crate::error::problem_details_to_json_string(&problem);
 
     Response::builder()
-        .status(StatusCode::FORBIDDEN)
+        .status(status)
         .header(http::header::CONTENT_TYPE, "application/problem+json")
         .body(ResBody::from(body))
         .unwrap_or_default()
@@ -615,7 +678,7 @@ async fn verify_csrf_token(
     req: &mut Request<axum::body::Body>,
     settings: &CsrfSettings,
     cookie_token: Option<&str>,
-) -> bool {
+) -> CsrfVerdict {
     let mut token_found = false;
 
     // 1. Check header
@@ -634,7 +697,7 @@ async fn verify_csrf_token(
     }
 
     if token_found {
-        return true;
+        return CsrfVerdict::Valid;
     }
 
     // 1b. Check query parameter (e.g. `_csrf`) before falling back to body
@@ -654,7 +717,7 @@ async fn verify_csrf_token(
     }
 
     if token_found {
-        return true;
+        return CsrfVerdict::Valid;
     }
 
     // 2. Check form field (if not found in header)
@@ -673,16 +736,31 @@ async fn verify_csrf_token(
     // NLL: content_type borrow ends here; req.body_mut() is safe to call below.
 
     if !is_urlencoded && multipart_boundary.is_none() {
-        return false;
+        return CsrfVerdict::Missing;
     }
 
     // Temporarily take ownership of the body
     let body = std::mem::replace(req.body_mut(), axum::body::Body::empty());
 
-    // Limit body size to avoid DoS when extracting form field
-    let bytes = axum::body::to_bytes(body, settings.max_scan_bytes)
-        .await
-        .unwrap_or_else(|_| axum::body::Bytes::new());
+    // Limit body size to avoid DoS when extracting form field.
+    let bytes = match axum::body::to_bytes(body, settings.max_scan_bytes).await {
+        Ok(bytes) => bytes,
+        Err(err) if is_body_length_limit_error(&err) => {
+            // The form body carrying `_csrf` is larger than the scan cap (which
+            // tracks `upload.max_request_size_bytes`). Surface this as
+            // `413 Payload Too Large` instead of falling through to a misleading
+            // `403` "missing token" — the token isn't absent, the body is simply
+            // over the request-size limit (see issue #1866).
+            return CsrfVerdict::BodyTooLarge;
+        }
+        Err(_) => {
+            // A non-length body read error (e.g. the client disconnected
+            // mid-body). This module has no dedicated malformed-body path, so we
+            // preserve the pre-existing behavior of treating an unreadable body
+            // as a missing token (→ 403) rather than inventing a new 400 here.
+            return CsrfVerdict::Missing;
+        }
+    };
 
     if is_urlencoded {
         for (key, value) in url::form_urlencoded::parse(&bytes) {
@@ -715,7 +793,11 @@ async fn verify_csrf_token(
     // Restore request body so downstream handlers (e.g. Multipart extractor) can read it.
     *req.body_mut() = axum::body::Body::from(bytes);
 
-    token_found
+    if token_found {
+        CsrfVerdict::Valid
+    } else {
+        CsrfVerdict::Missing
+    }
 }
 
 #[cfg(test)]
@@ -1210,13 +1292,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn post_with_large_body_fails_csrf() {
+    async fn post_with_large_body_returns_413() {
         let token = Uuid::new_v4().to_string();
         let app = Router::new()
             .route("/submit", post(|| async { "created" }))
             .layer(CsrfLayer::from_config(&default_csrf_config()));
 
-        // Create a body just slightly over 2MB. The CSRF extractor limits to 2MB.
+        // Create a body just over the 2 MiB default scan cap. `to_bytes` cannot
+        // buffer it to locate `_csrf`, so the CSRF layer now returns 413 Payload
+        // Too Large (the token isn't missing — the body is oversized; see #1866).
         let large_padding = "a".repeat(2 * 1024 * 1024 + 10);
         let body_content = format!("_csrf={token}&pad={large_padding}");
 
@@ -1233,7 +1317,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 
     #[tokio::test]
@@ -1703,13 +1787,14 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
     }
 
-    /// Contrast for issue #1866: with the scan cap left at the 2 MiB default, the
-    /// same >2 MiB body cannot be buffered, so `to_bytes` errors, the token is not
-    /// found, and the request is rejected with 403 — the pre-fix behavior. This
-    /// documents that the effective ceiling is the scan cap, which the fix now
-    /// aligns to `max_request_size_bytes`.
+    /// Issue #1866: when the form body carrying `_csrf` exceeds the scan cap, the
+    /// token cannot be buffered, so it must NOT be misreported as a missing token
+    /// (403). The body is genuinely over the request-size limit, so the CSRF layer
+    /// now returns `413 Payload Too Large` — the response issue #1866 wanted to be
+    /// observable, rather than a misleading 403. Here the scan cap is left at the
+    /// 2 MiB default (no `with_max_scan_bytes` override) and the body is > 2 MiB.
     #[tokio::test]
-    async fn post_large_multipart_exceeding_scan_cap_rejected() {
+    async fn post_large_multipart_exceeding_scan_cap_returns_413() {
         let token = "test-csrf-token-uuid-1866b";
         let boundary = "----WebKitFormBoundary1866FAIL";
         let body = large_multipart_body(boundary, token, 3 * 1024 * 1024);
@@ -1737,6 +1822,47 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    /// The overflow is classified before token presence: a form body over the scan
+    /// cap that carries NO `_csrf` field still returns 413 (not the 403 a genuinely
+    /// missing token would produce), confirming the size limit is evaluated first.
+    #[tokio::test]
+    async fn post_large_multipart_over_cap_without_token_returns_413() {
+        let boundary = "----WebKitFormBoundary1866NOTOK";
+        // Build an oversized body with a file field but no `_csrf` part.
+        let mut body = format!(
+            "--{boundary}\r\nContent-Disposition: form-data; name=\"avatar\"; \
+             filename=\"photo.bin\"\r\nContent-Type: application/octet-stream\r\n\r\n"
+        )
+        .into_bytes();
+        body.extend(std::iter::repeat_n(b'A', 3 * 1024 * 1024));
+        body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+        assert!(body.len() > 2 * 1024 * 1024);
+
+        // Default cap is 2 MiB (from_config, no with_max_scan_bytes override).
+        let app = Router::new()
+            .route("/upload", post(|| async { "ok" }))
+            .layer(CsrfLayer::from_config(&default_csrf_config()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/upload")
+                    .header("Cookie", "autumn-csrf=sometoken")
+                    .header(http::header::ACCEPT, "text/html")
+                    .header(
+                        "Content-Type",
+                        format!("multipart/form-data; boundary={boundary}"),
+                    )
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 }


### PR DESCRIPTION
Closes #1866

> **Approach changed (codex P2, approved).** This PR no longer *raises* the full-body buffer cap — that would make the CSRF layer buffer whole uploads (up to 32 MiB × concurrency) into memory. It now does a **bounded-prefix scan + stream-remainder**: scan only a small, configurable prefix for the `_csrf` token and stream the rest of the body through untouched. See "Why the redesign" below.

## Problem

With CSRF enforcement on (the prod-profile default), scaffolded forms carry the `_csrf` token in the request **body**. The middleware located it by fully buffering the body via `to_bytes(body, max_scan_bytes)`.

The earlier commits on this branch made `max_scan_bytes` track `security.upload.max_request_size_bytes` (32 MiB default) and returned a `413` on overflow. That fixed the spurious-403 symptom but introduced a worse problem.

## Why the redesign (codex P2 — valid)

Aligning the scan cap to `max_request_size_bytes` makes the CSRF layer **fully buffer every body-token upload into memory** — up to 32 MiB × concurrency — *before the handler runs*. `DefaultBodyLimit` is only a marker extension, so nothing else bounds this `to_bytes` copy. This:

- **Defeats the streaming upload path** — the scaffold's `save_to_blob_store` streams a multipart field-by-field to the blob store; full buffering in the CSRF layer forces the whole upload into RAM first.
- Is a **DoS-shaped memory cost** — concurrent large uploads can pin tens/hundreds of MiB each.

## The fix: bounded-prefix scan + stream remainder

1. **Bounded, configurable prefix cap.** New `security.csrf.token_scan_bytes` (**2 MiB default**), sourced from CSRF config and **deliberately independent** of `upload.max_request_size_bytes`. `CsrfLayer::from_config` threads it into settings; the router no longer feeds `max_request_size_bytes` in (the `with_max_scan_bytes` builder is removed).
2. **Prefix scan without erroring on overflow.** `collect_body_prefix` reads at most `token_scan_bytes` of the body into a prefix buffer **without failing** when the body is larger, then scans that prefix for `_csrf` (same urlencoded / multipart scanners as before). This mirrors the existing `collect_body` pattern in `submit_token.rs` for consistency.
3. **Stream the remainder.** The full body is reconstructed for the handler: if it ended within the cap, rebuilt as a sized body from the prefix; otherwise the prefix is **chained** with the remaining (partially-consumed) original stream via `http-body-util` / `Body::from_stream`, so the tail **streams through** rather than being buffered. Downstream multipart/urlencoded extractors see identical bytes and framing (a regression test asserts the handler receives the full, unmodified body).
4. **No CSRF-layer 413.** `CsrfVerdict::BodyTooLarge`, the `LengthLimitError` detection, and the payload-too-large mapping are removed. The token is either found in the prefix (proceed) or not (existing **403** missing-token). Genuinely-oversized bodies now **stream through** and are rejected **downstream** by the real body/upload limits (`DefaultBodyLimit` → natural `413` at the extractor) — where that belongs.

## Token-early constraint (+ escape hatch)

Because only the prefix is scanned, `_csrf` must appear within the first `token_scan_bytes` of the body. **Scaffolded forms already emit the hidden `_csrf` field before the file field** (same precedent as the submit-token hidden fields), so scaffolds are always safe. Hand-written forms that place large fields ahead of `_csrf` should move the token earlier or **raise `security.csrf.token_scan_bytes`** — documented on the config field and the layer doc comment.

## Tests

In `autumn/src/security/csrf.rs` (`#[cfg(test)] mod tests`):

- **Stream-through regression** — a multipart body far larger than the prefix cap with `_csrf` **first**: CSRF **passes** (token found in prefix) **and** the inner handler receives the **full body intact** (handler echoes the received byte count; asserted equal to the original length), proving the remainder streamed through and reconstruction is lossless. A urlencoded variant covers the same.
- **Token beyond the cap → 403** — `_csrf` placed after `> token_scan_bytes` of preceding data is not found → 403 (documents the constraint).
- **Configurable cap** — the *same* body flips 403 → 200 as `token_scan_bytes` moves (4 KiB vs 64 KiB).
- Removed the three CSRF-layer-413 tests (`post_with_large_body_returns_413`, `post_large_multipart_exceeding_scan_cap_returns_413`, `post_large_multipart_over_cap_without_token_returns_413`) since that behavior is reverted. Existing valid/missing-token tests unchanged.

## Gate output (verbatim)

**`cargo fmt --all -- --check`** — clean (no diff)

**`cargo clippy -p autumn-web --all-targets -- -D warnings`**
```
    Checking autumn-web v0.6.0 (/home/user/autumn/autumn)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 07s
```

**`cargo test -p autumn-web --lib security::csrf::`**
```
running 37 tests
...
test security::csrf::tests::post_large_multipart_token_first_streams_full_body_and_passes ... ok
test security::csrf::tests::post_with_large_urlencoded_body_token_first_streams_and_passes ... ok
test security::csrf::tests::post_multipart_token_beyond_scan_prefix_returns_403 ... ok
test security::csrf::tests::configurable_scan_cap_moves_token_boundary ... ok

test result: ok. 37 passed; 0 failed; 0 ignored; 0 measured; 3723 filtered out; finished in 0.05s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9uehBWRkPbZC8PjUjPRUT

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9uehBWRkPbZC8PjUjPRUT)_