### PR TITLE
Clean up orphaned upload blobs on scaffold handler early returns

### DIFF
--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -2117,9 +2117,14 @@ fn render_routes_file(
     // Issue #1872: the create/update handlers stream each uploaded file to the
     // blob store *before* changeset validation and the DB write, so any early
     // return after the save would orphan the just-uploaded blob. We record only
-    // the freshly-saved `<field>_blob`s (into `saved_blob_keys`) and best-effort
-    // delete them before every early-return path — never a preserved existing
-    // blob. This snippet is spliced before each such `return`.
+    // the freshly-saved `<field>_blob`s (into `saved_blob_keys`) — pushed at the
+    // point of each save, so the key set is populated incrementally as blobs are
+    // persisted — and best-effort delete them before every early-return path that
+    // can occur after the first save: a later attachment field's save failure,
+    // `decode_form` on malformed scalar input, changeset validation, the
+    // unique-violation 422, the generic DB error, and (update) the current-row
+    // load / not-found. A preserved existing blob is never enrolled. This snippet
+    // is spliced before each such `return`.
     let blob_cleanup = if has_attachments {
         "for key in &saved_blob_keys {\n        let _ = store.delete(key).await;\n    }\n    "
     } else {
@@ -2128,19 +2133,19 @@ fn render_routes_file(
     let form_decode_block = if has_attachments {
         let mut blob_decls = String::new();
         let mut match_arms = String::new();
-        let mut key_captures = String::new();
         for f in &attachment_fields {
             let name = &f.name;
             let _ = writeln!(
                 blob_decls,
                 "    let mut {name}_blob: Option<autumn_web::storage::Blob> = None;"
             );
-            let _ = write!(
-                key_captures,
-                "\n    if let Some(blob) = &{name}_blob {{\n        \
-                 saved_blob_keys.push(blob.key.clone());\n    \
-                 }}"
-            );
+            // Issue #1872: record the freshly-saved blob's key into
+            // `saved_blob_keys` *immediately* after each successful save, so any
+            // later fallible early return (a subsequent attachment field's save,
+            // `decode_form`, validation, the DB write) can best-effort delete it.
+            // The save's own `?` is expanded into an explicit `match` that runs
+            // the cleanup first, covering the case where an earlier attachment
+            // field was already persisted when a later one fails to save.
             let _ = write!(
                 match_arms,
                 "            Some(\"{name}\") => {{\n                \
@@ -2150,7 +2155,14 @@ fn render_routes_file(
                  chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default(),\n                        \
                  uuid::Uuid::new_v4()\n                    \
                  );\n                    \
-                 {name}_blob = Some(field.save_to_blob_store(&*store, key).await?);\n                \
+                 let blob = match field.save_to_blob_store(&*store, key).await {{\n                        \
+                 Ok(blob) => blob,\n                        \
+                 Err(err) => {{\n                            \
+                 {blob_cleanup}return Err(err);\n                        \
+                 }}\n                    \
+                 }};\n                    \
+                 saved_blob_keys.push(blob.key.clone());\n                    \
+                 {name}_blob = Some(blob);\n                \
                  }}\n            \
                  }}\n"
             );
@@ -2161,7 +2173,8 @@ fn render_routes_file(
              .ok_or_else(|| AutumnError::internal_server_error_msg(\"storage not configured\"))?\n        \
              .store()\n        \
              .clone();\n    \
-             let mut form_pairs: Vec<(String, String)> = Vec::new();\n\
+             let mut form_pairs: Vec<(String, String)> = Vec::new();\n    \
+             let mut saved_blob_keys: Vec<String> = Vec::new();\n\
              {blob_decls}    \
              while let Some(field) = multipart.next_field().await? {{\n        \
              let field_name = field.name().map(str::to_owned);\n        \
@@ -2175,13 +2188,15 @@ fn render_routes_file(
              None => {{}}\n        \
              }}\n    \
              }}\n    \
-             let form = {{\n        \
-             let encoded = url::form_urlencoded::Serializer::new(String::new())\n            \
-             .extend_pairs(form_pairs.iter().map(|(key, value)| (key.as_str(), value.as_str())))\n            \
-             .finish();\n        \
-             decode_form(Bytes::from(encoded))?\n    \
-             }};\n    \
-             let mut saved_blob_keys: Vec<String> = Vec::new();{key_captures}"
+             let encoded = url::form_urlencoded::Serializer::new(String::new())\n        \
+             .extend_pairs(form_pairs.iter().map(|(key, value)| (key.as_str(), value.as_str())))\n        \
+             .finish();\n    \
+             let form = match decode_form(Bytes::from(encoded)) {{\n        \
+             Ok(form) => form,\n        \
+             Err(err) => {{\n            \
+             {blob_cleanup}return Err(err);\n        \
+             }}\n    \
+             }};"
         )
     } else {
         format!("let form = {decode_call};")

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -2120,11 +2120,20 @@ fn render_routes_file(
     // the freshly-saved `<field>_blob`s (into `saved_blob_keys`) — pushed at the
     // point of each save, so the key set is populated incrementally as blobs are
     // persisted — and best-effort delete them before every early-return path that
-    // can occur after the first save: a later attachment field's save failure,
-    // `decode_form` on malformed scalar input, changeset validation, the
-    // unique-violation 422, the generic DB error, and (update) the current-row
-    // load / not-found. A preserved existing blob is never enrolled. This snippet
-    // is spliced before each such `return`.
+    // can occur after the first save.
+    //
+    // Codex P2 (centralized): the *whole* fallible multipart-parse-and-decode
+    // span — `next_field()?`, each `save_to_blob_store()?`, `bytes_limited()?`,
+    // the UTF-8 `map_err(…)?`, and `decode_form(…)?` — runs inside one
+    // `async { … }.await` block typed to the handler's `AutumnError`, whose `Err`
+    // is funneled through a single cleanup path (`form_decode_block`). That covers
+    // every `?` in the span (current and future) without per-line wrapping, so a
+    // malformed boundary / oversized text field / invalid UTF-8 arriving *after* a
+    // blob was saved can no longer leak it. The remaining post-parse early returns
+    // (changeset validation, `into_new`, the unique-violation 422, the generic DB
+    // error, and the update's current-row load / not-found) sit *outside* that
+    // block and keep splicing `{blob_cleanup}` before their `return`. A preserved
+    // existing blob is never enrolled.
     let blob_cleanup = if has_attachments {
         "for key in &saved_blob_keys {\n        let _ = store.delete(key).await;\n    }\n    "
     } else {
@@ -2143,9 +2152,11 @@ fn render_routes_file(
             // `saved_blob_keys` *immediately* after each successful save, so any
             // later fallible early return (a subsequent attachment field's save,
             // `decode_form`, validation, the DB write) can best-effort delete it.
-            // The save's own `?` is expanded into an explicit `match` that runs
-            // the cleanup first, covering the case where an earlier attachment
-            // field was already persisted when a later one fails to save.
+            // The save's own `?` (and every other fallible `?` in the parse span)
+            // is covered centrally: the whole multipart-parse-and-decode section
+            // runs inside a single `async {…}` block whose `Err` is funneled
+            // through one cleanup path (see `form_decode_block`), so a failed save
+            // cleans up any earlier-saved sibling blobs without per-line wrapping.
             let _ = write!(
                 match_arms,
                 "            Some(\"{name}\") => {{\n                \
@@ -2155,12 +2166,7 @@ fn render_routes_file(
                  chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default(),\n                        \
                  uuid::Uuid::new_v4()\n                    \
                  );\n                    \
-                 let blob = match field.save_to_blob_store(&*store, key).await {{\n                        \
-                 Ok(blob) => blob,\n                        \
-                 Err(err) => {{\n                            \
-                 {blob_cleanup}return Err(err);\n                        \
-                 }}\n                    \
-                 }};\n                    \
+                 let blob = field.save_to_blob_store(&*store, key).await?;\n                    \
                  saved_blob_keys.push(blob.key.clone());\n                    \
                  {name}_blob = Some(blob);\n                \
                  }}\n            \
@@ -2173,11 +2179,12 @@ fn render_routes_file(
              .ok_or_else(|| AutumnError::internal_server_error_msg(\"storage not configured\"))?\n        \
              .store()\n        \
              .clone();\n    \
-             let mut form_pairs: Vec<(String, String)> = Vec::new();\n    \
              let mut saved_blob_keys: Vec<String> = Vec::new();\n\
              {blob_decls}    \
-             while let Some(field) = multipart.next_field().await? {{\n        \
-             let field_name = field.name().map(str::to_owned);\n        \
+             let __parse_result: AutumnResult<{pascal_name}Form> = async {{\n        \
+             let mut form_pairs: Vec<(String, String)> = Vec::new();\n        \
+             while let Some(field) = multipart.next_field().await? {{\n            \
+             let field_name = field.name().map(str::to_owned);\n            \
              match field_name.as_deref() {{\n\
              {match_arms}            \
              Some(other) => {{\n                \
@@ -2186,12 +2193,16 @@ fn render_routes_file(
              form_pairs.push((other.to_owned(), value));\n            \
              }}\n            \
              None => {{}}\n        \
+             }}\n        \
+             }}\n        \
+             let encoded = url::form_urlencoded::Serializer::new(String::new())\n            \
+             .extend_pairs(form_pairs.iter().map(|(key, value)| (key.as_str(), value.as_str())))\n            \
+             .finish();\n        \
+             let form = decode_form(Bytes::from(encoded))?;\n        \
+             Ok(form)\n    \
              }}\n    \
-             }}\n    \
-             let encoded = url::form_urlencoded::Serializer::new(String::new())\n        \
-             .extend_pairs(form_pairs.iter().map(|(key, value)| (key.as_str(), value.as_str())))\n        \
-             .finish();\n    \
-             let form = match decode_form(Bytes::from(encoded)) {{\n        \
+             .await;\n    \
+             let form = match __parse_result {{\n        \
              Ok(form) => form,\n        \
              Err(err) => {{\n            \
              {blob_cleanup}return Err(err);\n        \

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -2114,14 +2114,32 @@ fn render_routes_file(
     // splice into the handler templates in place of the plain `let form = …` /
     // `let new = …` lines.
     let attachment_fields: Vec<&Field> = fields.iter().filter(|f| f.kind.is_attachment()).collect();
+    // Issue #1872: the create/update handlers stream each uploaded file to the
+    // blob store *before* changeset validation and the DB write, so any early
+    // return after the save would orphan the just-uploaded blob. We record only
+    // the freshly-saved `<field>_blob`s (into `saved_blob_keys`) and best-effort
+    // delete them before every early-return path — never a preserved existing
+    // blob. This snippet is spliced before each such `return`.
+    let blob_cleanup = if has_attachments {
+        "for key in &saved_blob_keys {\n        let _ = store.delete(key).await;\n    }\n    "
+    } else {
+        ""
+    };
     let form_decode_block = if has_attachments {
         let mut blob_decls = String::new();
         let mut match_arms = String::new();
+        let mut key_captures = String::new();
         for f in &attachment_fields {
             let name = &f.name;
             let _ = writeln!(
                 blob_decls,
                 "    let mut {name}_blob: Option<autumn_web::storage::Blob> = None;"
+            );
+            let _ = write!(
+                key_captures,
+                "\n    if let Some(blob) = &{name}_blob {{\n        \
+                 saved_blob_keys.push(blob.key.clone());\n    \
+                 }}"
             );
             let _ = write!(
                 match_arms,
@@ -2162,11 +2180,24 @@ fn render_routes_file(
              .extend_pairs(form_pairs.iter().map(|(key, value)| (key.as_str(), value.as_str())))\n            \
              .finish();\n        \
              decode_form(Bytes::from(encoded))?\n    \
-             }};"
+             }};\n    \
+             let mut saved_blob_keys: Vec<String> = Vec::new();{key_captures}"
         )
     } else {
         format!("let form = {decode_call};")
     };
+    // Issue #1872: for attachment scaffolds `into_new` runs *after* the blob save,
+    // so its fallible parse (`?`) must first clean up the just-saved blob(s). We
+    // emit an explicit `match` that runs the cleanup then returns the same error
+    // the `?` would have produced.
+    let into_new_bind = format!(
+        "let mut new = match into_new(changeset.data()) {{\n        \
+         Ok(new) => new,\n        \
+         Err(err) => {{\n            \
+         {blob_cleanup}return Err(err);\n        \
+         }}\n    \
+         }};"
+    );
     // Create: build `New{Pascal}` then bind each streamed blob (a `None` blob
     // means no file was submitted — the column stays NULL, satisfying the
     // optional-empty-as-NULL acceptance criterion).
@@ -2176,7 +2207,7 @@ fn render_routes_file(
             let name = &f.name;
             let _ = write!(binds, "\n    new.{name} = {name}_blob;");
         }
-        format!("let mut new = {into_new_call};{binds}")
+        format!("{into_new_bind}{binds}")
     } else {
         format!("let new = {into_new_call};")
     };
@@ -2186,24 +2217,45 @@ fn render_routes_file(
     // through the same handle the update statement uses (repository on the live
     // path, sharded repo on the sharded path, diesel otherwise).
     let update_new_block = if has_attachments {
+        // Issue #1872: loading the current row also happens after the blob save,
+        // so its fallible steps clean up the just-saved blob(s) before returning.
         let load_current = if live && !sharded {
             format!(
-                "let current = repo.find_by_id(*id).await?\n        \
-                 .ok_or_else(|| AutumnError::not_found_msg(format!(\"{pascal_name} with id {{}} not found\", *id)))?;\n    "
+                "let current = match repo.find_by_id(*id).await {{\n        \
+                 Ok(Some(current)) => current,\n        \
+                 Ok(None) => {{\n            \
+                 {blob_cleanup}return Err(AutumnError::not_found_msg(format!(\"{pascal_name} with id {{}} not found\", *id)));\n        \
+                 }}\n        \
+                 Err(err) => {{\n            \
+                 {blob_cleanup}return Err(err);\n        \
+                 }}\n    \
+                 }};\n    "
             )
         } else if sharded {
             format!(
-                "let current = Pg{pascal_name}Repository::from_shard(&db).find_by_id(*id).await?\n        \
-                 .ok_or_else(|| AutumnError::not_found_msg(format!(\"{pascal_name} with id {{}} not found\", *id)))?;\n    "
+                "let current = match Pg{pascal_name}Repository::from_shard(&db).find_by_id(*id).await {{\n        \
+                 Ok(Some(current)) => current,\n        \
+                 Ok(None) => {{\n            \
+                 {blob_cleanup}return Err(AutumnError::not_found_msg(format!(\"{pascal_name} with id {{}} not found\", *id)));\n        \
+                 }}\n        \
+                 Err(err) => {{\n            \
+                 {blob_cleanup}return Err(err);\n        \
+                 }}\n    \
+                 }};\n    "
             )
         } else {
             format!(
-                "let current: {pascal_name} = {plural}::table\n        \
+                "let current: {pascal_name} = match {plural}::table\n        \
                  .find(*id)\n        \
                  .select({pascal_name}::as_select())\n        \
                  .first(&mut *db)\n        \
-                 .await\n        \
-                 .map_err(AutumnError::not_found)?;\n    "
+                 .await\n    \
+                 {{\n        \
+                 Ok(current) => current,\n        \
+                 Err(err) => {{\n            \
+                 {blob_cleanup}return Err(AutumnError::not_found(err));\n        \
+                 }}\n    \
+                 }};\n    "
             )
         };
         let mut binds = String::new();
@@ -2211,7 +2263,7 @@ fn render_routes_file(
             let name = &f.name;
             let _ = write!(binds, "\n    new.{name} = {name}_blob.or(current.{name});");
         }
-        format!("{load_current}let mut new = {into_new_call};{binds}")
+        format!("{load_current}{into_new_bind}{binds}")
     } else {
         format!("let new = {into_new_call};")
     };
@@ -2359,13 +2411,10 @@ fn render_routes_file(
         render_unique_constraints_const(plural, &unique_fields, all_fields)
     };
 
-    let create_insert_block = if unique_fields.is_empty() {
-        format!(
-            "{create_stmt}\n    \
-             flash.success(\"{pascal_name} created\").await;\n    \
-             Ok(autumn_web::Redirect::to(&paths::index()).into_response())"
-        )
-    } else {
+    let create_insert_block = if !unique_fields.is_empty() {
+        // Issue #1872: `{blob_cleanup}` (empty unless the scaffold has attachment
+        // fields) best-effort deletes the just-saved blob(s) on both the
+        // unique-violation 422 and the generic DB-error early returns.
         format!(
             "let result: AutumnResult<()> = async {{\n        \
              {create_stmt}\n        \
@@ -2376,10 +2425,30 @@ fn render_routes_file(
              let mut errors = std::collections::HashMap::new();\n            \
              errors.insert(field.to_string(), vec![message.to_string()]);\n            \
              let changeset = Changeset::from_errors(changeset.into_inner(), errors);\n            \
-             return Ok((autumn_web::reexports::http::StatusCode::UNPROCESSABLE_ENTITY, {new_form_body}).into_response());\n        \
+             {blob_cleanup}return Ok((autumn_web::reexports::http::StatusCode::UNPROCESSABLE_ENTITY, {new_form_body}).into_response());\n        \
              }}\n        \
-             return Err(err);\n    \
+             {blob_cleanup}return Err(err);\n    \
              }}\n    \
+             flash.success(\"{pascal_name} created\").await;\n    \
+             Ok(autumn_web::Redirect::to(&paths::index()).into_response())"
+        )
+    } else if has_attachments {
+        // Issue #1872: no unique constraints to classify, but the DB write can
+        // still fail after the blob save — clean up before returning the error.
+        format!(
+            "let result: AutumnResult<()> = async {{\n        \
+             {create_stmt}\n        \
+             Ok(())\n    \
+             }}.await;\n    \
+             if let Err(err) = result {{\n        \
+             {blob_cleanup}return Err(err);\n    \
+             }}\n    \
+             flash.success(\"{pascal_name} created\").await;\n    \
+             Ok(autumn_web::Redirect::to(&paths::index()).into_response())"
+        )
+    } else {
+        format!(
+            "{create_stmt}\n    \
              flash.success(\"{pascal_name} created\").await;\n    \
              Ok(autumn_web::Redirect::to(&paths::index()).into_response())"
         )
@@ -2405,25 +2474,17 @@ fn render_routes_file(
          {form_decode_block}\n    \
          let changeset = form.into_changeset();\n    \
          if !changeset.is_valid() {{\n        \
-         return Ok((autumn_web::reexports::http::StatusCode::UNPROCESSABLE_ENTITY, {new_form_body}).into_response());\n    \
+         {blob_cleanup}return Ok((autumn_web::reexports::http::StatusCode::UNPROCESSABLE_ENTITY, {new_form_body}).into_response());\n    \
          }}\n    \
          {create_new_block}\n    \
          {create_insert_block}\n\
          }}\n"
     );
 
-    let update_apply_block = if unique_fields.is_empty() {
-        format!(
-            "{update_stmt}\n    \
-             if updated == 0 {{\n        \
-             return Err(AutumnError::not_found_msg(format!(\n            \
-             \"{pascal_name} with id {{}} not found\", *id\n        \
-             )));\n    \
-             }}\n    \
-             flash.success(\"{pascal_name} updated\").await;\n    \
-             Ok(autumn_web::Redirect::to(&paths::show(*id)).into_response())"
-        )
-    } else {
+    let update_apply_block = if !unique_fields.is_empty() {
+        // Issue #1872: `{blob_cleanup}` (empty unless the scaffold has attachment
+        // fields) best-effort deletes the just-saved blob(s) on the
+        // unique-violation 422, the generic DB-error, and the not-found returns.
         format!(
             "let result: AutumnResult<usize> = async {{\n        \
              {update_stmt}\n        \
@@ -2436,11 +2497,44 @@ fn render_routes_file(
              let mut errors = std::collections::HashMap::new();\n                \
              errors.insert(field.to_string(), vec![message.to_string()]);\n                \
              let changeset = Changeset::from_errors(changeset.into_inner(), errors);\n                \
-             return Ok((autumn_web::reexports::http::StatusCode::UNPROCESSABLE_ENTITY, {edit_form_body}).into_response());\n            \
+             {blob_cleanup}return Ok((autumn_web::reexports::http::StatusCode::UNPROCESSABLE_ENTITY, {edit_form_body}).into_response());\n            \
              }}\n            \
-             return Err(err);\n        \
+             {blob_cleanup}return Err(err);\n        \
              }}\n    \
              }};\n    \
+             if updated == 0 {{\n        \
+             {blob_cleanup}return Err(AutumnError::not_found_msg(format!(\n            \
+             \"{pascal_name} with id {{}} not found\", *id\n        \
+             )));\n    \
+             }}\n    \
+             flash.success(\"{pascal_name} updated\").await;\n    \
+             Ok(autumn_web::Redirect::to(&paths::show(*id)).into_response())"
+        )
+    } else if has_attachments {
+        // Issue #1872: no unique constraints, but the update write and the
+        // not-found guard both early-return after the blob save — clean up first.
+        format!(
+            "let result: AutumnResult<usize> = async {{\n        \
+             {update_stmt}\n        \
+             Ok(updated)\n    \
+             }}.await;\n    \
+             let updated = match result {{\n        \
+             Ok(updated) => updated,\n        \
+             Err(err) => {{\n            \
+             {blob_cleanup}return Err(err);\n        \
+             }}\n    \
+             }};\n    \
+             if updated == 0 {{\n        \
+             {blob_cleanup}return Err(AutumnError::not_found_msg(format!(\n            \
+             \"{pascal_name} with id {{}} not found\", *id\n        \
+             )));\n    \
+             }}\n    \
+             flash.success(\"{pascal_name} updated\").await;\n    \
+             Ok(autumn_web::Redirect::to(&paths::show(*id)).into_response())"
+        )
+    } else {
+        format!(
+            "{update_stmt}\n    \
              if updated == 0 {{\n        \
              return Err(AutumnError::not_found_msg(format!(\n            \
              \"{pascal_name} with id {{}} not found\", *id\n        \
@@ -2495,7 +2589,7 @@ fn render_routes_file(
          {form_decode_block}\n    \
          let changeset = form.into_changeset();\n    \
          if !changeset.is_valid() {{\n        \
-         return Ok((autumn_web::reexports::http::StatusCode::UNPROCESSABLE_ENTITY, {edit_form_body}).into_response());\n    \
+         {blob_cleanup}return Ok((autumn_web::reexports::http::StatusCode::UNPROCESSABLE_ENTITY, {edit_form_body}).into_response());\n    \
          }}\n    \
          {update_new_block}\n    \
          {update_apply_block}\n\

--- a/autumn-cli/tests/integration/scaffold_form_for.rs
+++ b/autumn-cli/tests/integration/scaffold_form_for.rs
@@ -492,3 +492,99 @@ fn generated_attachment_scaffold_cargo_checks() {
     );
     assert_project_cargo_checks(&project);
 }
+
+/// Issue #1872: the create/update handlers stream each uploaded file to the
+/// blob store *during* multipart parsing — before changeset validation and the
+/// DB write. Every early return after that save (invalid changeset,
+/// unique-violation 422, `into_new` parse failure, generic DB `Err`, the
+/// update's row-load and not-found guard) must best-effort delete the
+/// just-saved blob so an ordinary invalid submission doesn't orphan its upload.
+/// The success path must *not* delete, and a preserved existing blob
+/// (`current.<field>`) is never touched — only the freshly-saved
+/// `<field>_blob`, recorded via `saved_blob_keys`, is cleaned up.
+#[test]
+fn scaffold_attachment_cleans_up_saved_blob_on_early_return() {
+    // `email:String:unique` gives us the unique-violation 422 branch too, so all
+    // four create early returns and all of the update early returns are present.
+    let (_tmp, project) = scaffold_project(
+        "attach-cleanup-app",
+        "Photo",
+        &["caption:String", "image:Attachment", "email:String:unique"],
+    );
+    let routes = fs::read_to_string(project.join("src/routes/photos.rs")).unwrap();
+
+    // Only the freshly-saved blob keys are recorded for cleanup; preserved
+    // existing blobs are never enrolled.
+    assert!(
+        routes.contains("let mut saved_blob_keys: Vec<String> = Vec::new();"),
+        "{routes}"
+    );
+    assert!(
+        routes.contains("saved_blob_keys.push(blob.key.clone());"),
+        "{routes}"
+    );
+    // The cleanup snippet best-effort deletes each saved blob, ignoring the
+    // result so a cleanup failure never masks the original error/response.
+    assert!(
+        routes.contains("for key in &saved_blob_keys {")
+            && routes.contains("let _ = store.delete(key).await;"),
+        "{routes}"
+    );
+
+    let create = handler_body(&routes, "pub async fn create(", "pub async fn update(");
+    // Split create at the success tail: everything up to `flash.success` is the
+    // early-return region, everything after is the success path.
+    let create_success_at = create
+        .find("flash.success(\"Photo created\")")
+        .unwrap_or_else(|| panic!("missing create success in:\n{create}"));
+    let (create_early, create_success) = create.split_at(create_success_at);
+
+    // Cleanup guards every create early return: validation 422, `into_new`
+    // parse failure, the unique-violation 422, and the generic DB `Err`.
+    assert_eq!(
+        create_early
+            .matches("let _ = store.delete(key).await;")
+            .count(),
+        4,
+        "create must clean up the saved blob on all four early returns \
+         (validation, into_new, unique-violation, DB error):\n{create}"
+    );
+    // The success path must NOT delete the blob it just persisted.
+    assert!(
+        !create_success.contains("store.delete("),
+        "create success path must not delete the persisted blob:\n{create_success}"
+    );
+
+    let update = handler_body(&routes, "pub async fn update(", "pub async fn destroy(");
+    let update_success_at = update
+        .find("flash.success(\"Photo updated\")")
+        .unwrap_or_else(|| panic!("missing update success in:\n{update}"));
+    let (update_early, update_success) = update.split_at(update_success_at);
+    // Cleanup guards every update early return: validation 422, the current-row
+    // load, `into_new`, the unique-violation 422, the generic DB `Err`, and the
+    // not-found (`updated == 0`) guard.
+    assert_eq!(
+        update_early
+            .matches("let _ = store.delete(key).await;")
+            .count(),
+        6,
+        "update must clean up the saved blob on all six early returns:\n{update}"
+    );
+    assert!(
+        !update_success.contains("store.delete("),
+        "update success path must not delete the persisted blob:\n{update_success}"
+    );
+
+    // The preserve-on-update bind is untouched: only `image_blob` (the freshly
+    // saved upload) is ever deleted, never the preserved `current.image`.
+    assert!(
+        routes.contains("new.image = image_blob.or(current.image);"),
+        "{routes}"
+    );
+
+    // A plain (non-attachment) scaffold gets none of the cleanup machinery.
+    let (_tmp2, plain) = scaffold_project("plain-cleanup-app", "Article", &["title:String"]);
+    let plain_routes = fs::read_to_string(plain.join("src/routes/articles.rs")).unwrap();
+    assert!(!plain_routes.contains("saved_blob_keys"), "{plain_routes}");
+    assert!(!plain_routes.contains("store.delete("), "{plain_routes}");
+}

--- a/autumn-cli/tests/integration/scaffold_form_for.rs
+++ b/autumn-cli/tests/integration/scaffold_form_for.rs
@@ -390,8 +390,11 @@ fn scaffold_attachment_emits_zero_js_multipart_handlers() {
         routes.contains("mut multipart: autumn_web::extract::Multipart"),
         "{routes}"
     );
+    // Issue #1872: the save's `?` is expanded into an explicit `match` so the
+    // just-saved blob can be cleaned up on a later early return, so the call now
+    // ends in `.await` (no trailing `?`) followed by the `match` arms.
     assert!(
-        routes.contains(".save_to_blob_store(&*store, key).await?"),
+        routes.contains(".save_to_blob_store(&*store, key).await {"),
         "{routes}"
     );
     assert!(routes.contains("multipart.next_field().await?"), "{routes}");
@@ -531,7 +534,34 @@ fn scaffold_attachment_cleans_up_saved_blob_on_early_return() {
         "{routes}"
     );
 
+    // Issue #1872 (codex P2): the save's `?` is expanded into an explicit match
+    // so a *later* early return can clean up an already-saved blob, and the
+    // `decode_form` `?` is likewise expanded so malformed scalar input on the
+    // same request cleans up the just-saved upload.
+    assert!(
+        routes.contains("let blob = match field.save_to_blob_store(&*store, key).await {"),
+        "the multipart save must be a match so a later early return can clean up:\n{routes}"
+    );
+    assert!(
+        routes.contains("let form = match decode_form(Bytes::from(encoded)) {"),
+        "decode_form must be a match so malformed input cleans up the saved blob:\n{routes}"
+    );
+
     let create = handler_body(&routes, "pub async fn create(", "pub async fn update(");
+
+    // The cleanup keys are recorded at save-time — the `saved_blob_keys.push`
+    // must appear *before* the `decode_form(` call in the emitted handler, so the
+    // decode_form early return has the keys available to clean up.
+    let push_at = create
+        .find("saved_blob_keys.push(blob.key.clone());")
+        .unwrap_or_else(|| panic!("missing saved_blob_keys.push in create:\n{create}"));
+    let decode_at = create
+        .find("decode_form(")
+        .unwrap_or_else(|| panic!("missing decode_form( in create:\n{create}"));
+    assert!(
+        push_at < decode_at,
+        "saved_blob_keys must be populated before decode_form in create:\n{create}"
+    );
     // Split create at the success tail: everything up to `flash.success` is the
     // early-return region, everything after is the success path.
     let create_success_at = create
@@ -539,15 +569,17 @@ fn scaffold_attachment_cleans_up_saved_blob_on_early_return() {
         .unwrap_or_else(|| panic!("missing create success in:\n{create}"));
     let (create_early, create_success) = create.split_at(create_success_at);
 
-    // Cleanup guards every create early return: validation 422, `into_new`
-    // parse failure, the unique-violation 422, and the generic DB `Err`.
+    // Cleanup guards every create early return that can occur after the first
+    // blob is saved: the mid-loop subsequent-field save failure, `decode_form` on
+    // malformed scalar input, validation 422, `into_new` parse failure, the
+    // unique-violation 422, and the generic DB `Err`.
     assert_eq!(
         create_early
             .matches("let _ = store.delete(key).await;")
             .count(),
-        4,
-        "create must clean up the saved blob on all four early returns \
-         (validation, into_new, unique-violation, DB error):\n{create}"
+        6,
+        "create must clean up the saved blob on all six early returns \
+         (mid-loop save, decode_form, validation, into_new, unique-violation, DB error):\n{create}"
     );
     // The success path must NOT delete the blob it just persisted.
     assert!(
@@ -560,15 +592,17 @@ fn scaffold_attachment_cleans_up_saved_blob_on_early_return() {
         .find("flash.success(\"Photo updated\")")
         .unwrap_or_else(|| panic!("missing update success in:\n{update}"));
     let (update_early, update_success) = update.split_at(update_success_at);
-    // Cleanup guards every update early return: validation 422, the current-row
-    // load, `into_new`, the unique-violation 422, the generic DB `Err`, and the
-    // not-found (`updated == 0`) guard.
+    // Cleanup guards every update early return that can occur after the first
+    // blob is saved: the mid-loop subsequent-field save failure, `decode_form` on
+    // malformed scalar input, validation 422, the current-row load, `into_new`,
+    // the unique-violation 422, the generic DB `Err`, and the not-found
+    // (`updated == 0`) guard.
     assert_eq!(
         update_early
             .matches("let _ = store.delete(key).await;")
             .count(),
-        6,
-        "update must clean up the saved blob on all six early returns:\n{update}"
+        8,
+        "update must clean up the saved blob on all eight early returns:\n{update}"
     );
     assert!(
         !update_success.contains("store.delete("),

--- a/autumn-cli/tests/integration/scaffold_form_for.rs
+++ b/autumn-cli/tests/integration/scaffold_form_for.rs
@@ -390,14 +390,21 @@ fn scaffold_attachment_emits_zero_js_multipart_handlers() {
         routes.contains("mut multipart: autumn_web::extract::Multipart"),
         "{routes}"
     );
-    // Issue #1872: the save's `?` is expanded into an explicit `match` so the
-    // just-saved blob can be cleaned up on a later early return, so the call now
-    // ends in `.await` (no trailing `?`) followed by the `match` arms.
+    // Issue #1872 (codex P2, centralized): the whole multipart-parse-and-decode
+    // span runs inside one `async {…}.await` block whose `Err` is funneled through
+    // a single cleanup path, so each save is a plain `?` (its failure — and every
+    // other `?` in the span — is covered centrally, no per-line `match` wrapper).
     assert!(
-        routes.contains(".save_to_blob_store(&*store, key).await {"),
+        routes.contains(".save_to_blob_store(&*store, key).await?;"),
         "{routes}"
     );
     assert!(routes.contains("multipart.next_field().await?"), "{routes}");
+    // The parse span is wrapped in a single fallible block funneling every `?`
+    // (next_field, save, bytes_limited, utf8, decode_form) to one cleanup path.
+    assert!(
+        routes.contains("let __parse_result: AutumnResult<PhotoForm> = async {"),
+        "the multipart parse span must run inside a single cleanup-on-error block:\n{routes}"
+    );
     // Default path does not CALL the presign helper (the header note may still
     // mention it as an advanced opt-in), so match the invocation.
     assert!(!routes.contains("complete_direct_upload(&"), "{routes}");
@@ -496,6 +503,42 @@ fn generated_attachment_scaffold_cargo_checks() {
     assert_project_cargo_checks(&project);
 }
 
+/// Issue #1872 (codex P2, centralized): the entire fallible parse span —
+/// `next_field()?`, each `save_to_blob_store()?`, `bytes_limited()?`, the UTF-8
+/// `map_err(…)?`, and `decode_form(…)?` — runs inside one `async {…}.await`
+/// block whose `Err` is funneled through a single cleanup path. So each save and
+/// the decode are plain `?` (no per-line `match`), and a malformed boundary /
+/// oversized text field / invalid UTF-8 arriving *after* a save is cleaned up
+/// too, not just the save and decode failures.
+fn assert_parse_span_centralized(routes: &str) {
+    assert!(
+        routes.contains("let __parse_result: AutumnResult<PhotoForm> = async {"),
+        "the parse span must run inside a single cleanup-on-error block:\n{routes}"
+    );
+    assert!(
+        routes.contains("let blob = field.save_to_blob_store(&*store, key).await?;"),
+        "the multipart save is a plain `?` covered by the central cleanup block:\n{routes}"
+    );
+    assert!(
+        routes.contains("let form = decode_form(Bytes::from(encoded))?;"),
+        "decode_form is a plain `?` covered by the central cleanup block:\n{routes}"
+    );
+    assert!(
+        routes.contains("while let Some(field) = multipart.next_field().await? {"),
+        "next_field must be a `?` inside the covered parse block:\n{routes}"
+    );
+    assert!(
+        routes.contains("let value = String::from_utf8(field.bytes_limited().await?)"),
+        "bytes_limited must be a `?` inside the covered parse block:\n{routes}"
+    );
+    // The block's single `Err` arm runs the cleanup then re-returns the exact
+    // error the `?` produced, preserving the original error->response mapping.
+    assert!(
+        routes.contains("let form = match __parse_result {") && routes.contains("Err(err) => {"),
+        "the parse block funnels every `?` failure through one cleanup+return:\n{routes}"
+    );
+}
+
 /// Issue #1872: the create/update handlers stream each uploaded file to the
 /// blob store *during* multipart parsing — before changeset validation and the
 /// DB write. Every early return after that save (invalid changeset,
@@ -534,24 +577,23 @@ fn scaffold_attachment_cleans_up_saved_blob_on_early_return() {
         "{routes}"
     );
 
-    // Issue #1872 (codex P2): the save's `?` is expanded into an explicit match
-    // so a *later* early return can clean up an already-saved blob, and the
-    // `decode_form` `?` is likewise expanded so malformed scalar input on the
-    // same request cleans up the just-saved upload.
-    assert!(
-        routes.contains("let blob = match field.save_to_blob_store(&*store, key).await {"),
-        "the multipart save must be a match so a later early return can clean up:\n{routes}"
-    );
-    assert!(
-        routes.contains("let form = match decode_form(Bytes::from(encoded)) {"),
-        "decode_form must be a match so malformed input cleans up the saved blob:\n{routes}"
-    );
+    assert_parse_span_centralized(&routes);
 
     let create = handler_body(&routes, "pub async fn create(", "pub async fn update(");
 
-    // The cleanup keys are recorded at save-time — the `saved_blob_keys.push`
-    // must appear *before* the `decode_form(` call in the emitted handler, so the
-    // decode_form early return has the keys available to clean up.
+    // `saved_blob_keys` is declared *before* the parse span (outside the `async`
+    // block, so the block borrows it mutably and the post-block cleanup can read
+    // it), and the push happens at save-time — both before `decode_form(`.
+    let decl_at = create
+        .find("let mut saved_blob_keys: Vec<String> = Vec::new();")
+        .unwrap_or_else(|| panic!("missing saved_blob_keys decl in create:\n{create}"));
+    let parse_at = create
+        .find("let __parse_result: AutumnResult<PhotoForm> = async {")
+        .unwrap_or_else(|| panic!("missing parse block in create:\n{create}"));
+    assert!(
+        decl_at < parse_at,
+        "saved_blob_keys must be declared before the parse span in create:\n{create}"
+    );
     let push_at = create
         .find("saved_blob_keys.push(blob.key.clone());")
         .unwrap_or_else(|| panic!("missing saved_blob_keys.push in create:\n{create}"));
@@ -570,16 +612,21 @@ fn scaffold_attachment_cleans_up_saved_blob_on_early_return() {
     let (create_early, create_success) = create.split_at(create_success_at);
 
     // Cleanup guards every create early return that can occur after the first
-    // blob is saved: the mid-loop subsequent-field save failure, `decode_form` on
-    // malformed scalar input, validation 422, `into_new` parse failure, the
-    // unique-violation 422, and the generic DB `Err`.
+    // blob is saved. Codex P2 centralized the parse span: the mid-loop save
+    // failure, `next_field`, `bytes_limited`, the UTF-8 conversion, and
+    // `decode_form` on malformed scalar input all funnel through ONE cleanup
+    // inside the parse block — so those five formerly-separate (and two
+    // previously-uncovered) returns collapse to a single `store.delete` loop. The
+    // four post-parse returns keep their own cleanup: validation 422, `into_new`
+    // parse failure, the unique-violation 422, and the generic DB `Err`.
     assert_eq!(
         create_early
             .matches("let _ = store.delete(key).await;")
             .count(),
-        6,
-        "create must clean up the saved blob on all six early returns \
-         (mid-loop save, decode_form, validation, into_new, unique-violation, DB error):\n{create}"
+        5,
+        "create must clean up the saved blob on all five early-return sites \
+         (one central parse-span cleanup covering save/next_field/bytes_limited/utf8/decode_form, \
+         plus validation, into_new, unique-violation, DB error):\n{create}"
     );
     // The success path must NOT delete the blob it just persisted.
     assert!(
@@ -593,16 +640,20 @@ fn scaffold_attachment_cleans_up_saved_blob_on_early_return() {
         .unwrap_or_else(|| panic!("missing update success in:\n{update}"));
     let (update_early, update_success) = update.split_at(update_success_at);
     // Cleanup guards every update early return that can occur after the first
-    // blob is saved: the mid-loop subsequent-field save failure, `decode_form` on
-    // malformed scalar input, validation 422, the current-row load, `into_new`,
-    // the unique-violation 422, the generic DB `Err`, and the not-found
-    // (`updated == 0`) guard.
+    // blob is saved. Codex P2 centralized the parse span: the mid-loop save
+    // failure, `next_field`, `bytes_limited`, the UTF-8 conversion, and
+    // `decode_form` collapse to ONE cleanup inside the parse block. The six
+    // post-parse returns keep their own cleanup: validation 422, the current-row
+    // load, `into_new`, the unique-violation 422, the generic DB `Err`, and the
+    // not-found (`updated == 0`) guard.
     assert_eq!(
         update_early
             .matches("let _ = store.delete(key).await;")
             .count(),
-        8,
-        "update must clean up the saved blob on all eight early returns:\n{update}"
+        7,
+        "update must clean up the saved blob on all seven early-return sites \
+         (one central parse-span cleanup, plus validation, current-row load, into_new, \
+         unique-violation, DB error, not-found):\n{update}"
     );
     assert!(
         !update_success.contains("store.delete("),


### PR DESCRIPTION
Closes #1872

## Before / After

**Before:** the scaffold generator emits create/update handlers that stream each uploaded file to the blob store *during* multipart parsing — before changeset validation and before the DB write. So a user submitting an invalid create/edit with a file attached — a validation error, a duplicate/unique violation, or a DB error — leaves the just-uploaded file orphaned in the blob store. This leaks on **every ordinary invalid submission**, not just rare error paths.

**After:** the generated handler best-effort-deletes the just-saved file on those failure paths, so invalid submits don't leak blobs. The store already holds a `delete` (a no-op when the key is absent), so cleanup is cheap and safe.

## How

Generator restructure (`autumn-cli/src/generate/scaffold.rs`):

- The handlers record the keys of the freshly-saved uploads into `saved_blob_keys` right after the multipart save, and splice a best-effort cleanup (`for key in &saved_blob_keys { let _ = store.delete(key).await; }`) before every early return that follows the save.
- The `into_new(...)?` parse and the update's current-row load `?` are converted into explicit `match`es that run cleanup, then return the exact same error/response the `?` would have produced.
- **Only the newly-saved `<field>_blob` is ever deleted** — the update path binds `new.<field> = <field>_blob.or(current.<field>)`, and only the fresh `<field>_blob` keys are enrolled, so a **preserved existing blob is never touched**.
- Covers validation (422), `into_new` failure, unique-violation (422), the generic DB `Err`, and the update's row-load / not-found guard — on **both** create and update.
- The **success path is unchanged** and never deletes. Multiple attachment fields are supported (each saved blob is cleaned up).

## Scope

The successful-replacement orphan — the *old* blob left behind when an update successfully swaps in a new file — is intentionally **out of scope** and left to the periodic sweep, consistent with how the direct-upload path deliberately tolerates orphans (bind-step promotion + sweep). This fix targets only the leak on *failed* submissions.

## Gate output (verbatim)

**1. `cargo fmt --all -- --check`**
```
fmt: clean (exit 0)
```

**2. `cargo clippy --workspace --all-targets -- -D warnings`**
```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 52s
```
(no warnings; only unrelated "Tailwind CSS CLI not found" build-script notices)

**3. `cargo test -p autumn-cli --test cli_tests scaffold_form_for`**
```
running 12 tests
test ...::generated_attachment_scaffold_cargo_checks ... ignored
test ...::generated_form_for_scaffold_cargo_checks ... ignored
test ...::generated_scaffold_with_missing_reference_target_cargo_checks ... ignored
test ...::scaffold_attachment_emits_zero_js_multipart_handlers ... ok
test ...::scaffold_attachment_cleans_up_saved_blob_on_early_return ... ok
test ...::scaffold_attachment_emits_generated_multipart_write_path_test ... ok
test ...::scaffold_create_and_edit_views_use_single_form_for_call ... ok
test ...::rescaffold_with_added_column_leaves_view_form_call_unchanged ... ok
test ...::scaffold_decimal_column_overrides_number_step ... ok
test ...::scaffold_enum_column_overrides_to_select ... ok
test ...::scaffold_references_column_with_missing_target_falls_back_to_number_input ... ok
test ...::scaffold_references_column_overrides_to_select_and_loads_options ... ok

test result: ok. 9 passed; 0 failed; 3 ignored; 0 measured; 194 filtered out
```

**Generated-code compile proof** — `cargo test -p autumn-cli --test cli_tests generated_attachment_scaffold_cargo_checks -- --ignored`
```
running 1 test
test ...::generated_attachment_scaffold_cargo_checks ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 205 filtered out; finished in 69.22s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9uehBWRkPbZC8PjUjPRUT

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9uehBWRkPbZC8PjUjPRUT)_