### PR TITLE
⚒️ Forge: [Refactor long functions in emit.rs and doctor.rs]

### DIFF
--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -5549,7 +5549,6 @@ fn resolve_compression_enabled() -> bool {
 ///    Results are joined back in display order.
 #[allow(clippy::too_many_lines)]
 pub fn run(opts: DoctorOptions) {
-    use std::thread;
     type Task = Box<dyn FnOnce() -> CheckResult + Send>;
 
     let cli_version = env!("CARGO_PKG_VERSION");
@@ -6043,9 +6042,13 @@ pub fn run(opts: DoctorOptions) {
     }));
 
     // ── Phase 3: spawn all tasks concurrently ────────────────────────────────
+    run_doctor_tasks(tasks, opts);
+}
+
+fn run_doctor_tasks(tasks: Vec<Box<dyn FnOnce() -> CheckResult + Send>>, opts: DoctorOptions) {
     #[allow(clippy::needless_collect)]
-    let handles: Vec<thread::JoinHandle<CheckResult>> =
-        tasks.into_iter().map(thread::spawn).collect();
+    let handles: Vec<std::thread::JoinHandle<CheckResult>> =
+        tasks.into_iter().map(std::thread::spawn).collect();
 
     // ── Phase 4: join in order (preserves display ordering) ──────────────────
     let results: Vec<CheckResult> = handles


### PR DESCRIPTION
🚮 Smell: "God Functions" containing nested logic across hundreds of lines in `autumn-cli/src/generate/emit.rs` (`compute_revert_plan`) and `autumn-cli/src/doctor.rs` (`run`).
✨ Solution: Used `replace_with_git_merge_diff` to extract `categorize_actions`, `resolve_normal_actions`, and `resolve_create_if_absent_actions` in `emit.rs`. Extracted `run_doctor_tasks` to decouple Phase 3/4 execution from Phase 1/2 setup in `doctor.rs`.
🧼 Benefit: Significantly flattens nesting, makes complex control flows linear and understandable, and creates clean boundaries between preparation/setup phases and execution phases without altering runtime behavior.
🛡️ Verification: `cargo fmt`, `cargo clippy -p autumn-cli --bin autumn -- -D warnings`, and `cargo test -p autumn-cli --bin autumn` all ran successfully. Pre-commit code review passed.

---
*PR created automatically by Jules for task [10359876170535636837](https://jules.google.com/task/10359876170535636837) started by @madmax983*