### PR TITLE
fix(cli): doctor deploy check fails on malformed previous_secrets, matching `deploy check`

### DIFF
--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -4094,19 +4094,32 @@ fn resolve_deploy_signing_secret(
 /// read from the merged table alone — matching what `AutumnConfig::load()` and
 /// `autumn deploy check` see. Never returns/prints the values except to the
 /// (secret-safe) grader.
-fn resolve_deploy_previous_signing_secrets(merged: &toml::Table) -> Vec<String> {
-    merged
+///
+/// Returns `Err` on a MALFORMED value — a non-array `previous_secrets` or an
+/// array with any non-string element — to mirror `AutumnConfig::load()`, which
+/// deserializes this field as `Vec<String>` and hard-fails on the same shapes.
+/// An absent key yields `Ok(vec![])`. Empty strings are NOT rejected here
+/// (`load()` accepts them; production value-validation is downstream in the
+/// grader).
+fn resolve_deploy_previous_signing_secrets(merged: &toml::Table) -> Result<Vec<String>, String> {
+    let Some(value) = merged
         .get("security")
         .and_then(|s| s.get("signing_secret"))
         .and_then(|ss| ss.get("previous_secrets"))
-        .and_then(toml::Value::as_array)
-        .map(|arr| {
-            arr.iter()
-                .filter_map(toml::Value::as_str)
-                .map(std::borrow::ToOwned::to_owned)
-                .collect()
-        })
-        .unwrap_or_default()
+    else {
+        return Ok(vec![]);
+    };
+    let Some(arr) = value.as_array() else {
+        return Err("previous_secrets must be an array of strings".into());
+    };
+    let mut out = Vec::with_capacity(arr.len());
+    for (i, elem) in arr.iter().enumerate() {
+        let Some(s) = elem.as_str() else {
+            return Err(format!("previous_secrets[{i}] must be a string"));
+        };
+        out.push(s.to_owned());
+    }
+    Ok(out)
 }
 
 /// Whether any enabled runtime feature requires a configured Postgres pool at
@@ -5912,7 +5925,8 @@ pub fn run(opts: DoctorOptions) {
         // Rotation secrets accepted during a grace window are validated at boot
         // with the same rule as the current secret, so grade them here from the
         // same merged table (no env override exists for `previous_secrets`).
-        let deploy_previous_signing = resolve_deploy_previous_signing_secrets(&merged_deploy_toml);
+        let deploy_previous_signing_result =
+            resolve_deploy_previous_signing_secrets(&merged_deploy_toml);
         // Derive the deploy DB-URL preflight input from the SAME merged
         // active-profile table used for `deploy_cfg` (base autumn.toml +
         // [profile.<env>] + autumn-<env>.toml), exactly like the sibling
@@ -6012,16 +6026,40 @@ pub fn run(opts: DoctorOptions) {
             }));
         }
 
-        tasks.push(Box::new(move || {
-            deploy_preflight_result(
-                "deploy_signing_secret",
-                crate::deploy::grade_signing_secret(
-                    deploy_signing.as_deref(),
-                    &deploy_previous_signing,
-                    is_production,
-                ),
-            )
-        }));
+        match deploy_previous_signing_result {
+            Ok(deploy_previous_signing) => {
+                tasks.push(Box::new(move || {
+                    deploy_preflight_result(
+                        "deploy_signing_secret",
+                        crate::deploy::grade_signing_secret(
+                            deploy_signing.as_deref(),
+                            &deploy_previous_signing,
+                            is_production,
+                        ),
+                    )
+                }));
+            }
+            Err(msg) => {
+                // A non-array `previous_secrets` or a non-string element: surface
+                // it as a FAILING check on EVERY profile (not gated on
+                // production), because `AutumnConfig::load()` deserializes the
+                // field as `Vec<String>` and hard-fails the same config that
+                // `autumn deploy check` loads. Silently dropping it would let a
+                // strong current secret green-light a config the deploy path
+                // rejects.
+                tasks.push(Box::new(move || CheckResult {
+                    name: "deploy_signing_secret",
+                    status: CheckStatus::Fail,
+                    detail: Some(format!(
+                        "security.signing_secret.previous_secrets is present but invalid: {msg}"
+                    )),
+                    hint: Some(
+                        "Set security.signing_secret.previous_secrets to an array of strings \
+                         (see `autumn deploy check`).",
+                    ),
+                }));
+            }
+        }
         match deploy_db_url_result {
             Ok(deploy_db_url) => {
                 tasks.push(Box::new(move || {
@@ -14052,6 +14090,50 @@ redirect_uri = "http://localhost/callback"
         assert!(
             check.detail.unwrap().contains("present but invalid"),
             "detail must explain the [deploy] table is present but invalid"
+        );
+    }
+
+    #[test]
+    fn deploy_previous_secrets_non_string_element_is_malformed() {
+        // `previous_secrets = [123]` deserializes as `Vec<String>` failing in
+        // `AutumnConfig::load()`; doctor must treat it as malformed, not drop it.
+        let table: toml::Table = "[security.signing_secret]\nprevious_secrets = [123]\n"
+            .parse()
+            .unwrap();
+        assert!(
+            resolve_deploy_previous_signing_secrets(&table).is_err(),
+            "a non-string previous_secrets element must be malformed"
+        );
+    }
+
+    #[test]
+    fn deploy_previous_secrets_non_array_is_malformed() {
+        // A scalar `previous_secrets` cannot deserialize into `Vec<String>`.
+        let table: toml::Table = "[security.signing_secret]\nprevious_secrets = \"nope\"\n"
+            .parse()
+            .unwrap();
+        assert!(
+            resolve_deploy_previous_signing_secrets(&table).is_err(),
+            "a non-array previous_secrets must be malformed"
+        );
+    }
+
+    #[test]
+    fn deploy_previous_secrets_absent_or_strings_ok() {
+        // Absent key → empty vec.
+        let empty: toml::Table = toml::Table::new();
+        assert_eq!(
+            resolve_deploy_previous_signing_secrets(&empty).unwrap(),
+            Vec::<String>::new()
+        );
+        // Array of strings → collected; empty strings are NOT rejected (load()
+        // accepts them; value-validation is downstream in the grader).
+        let table: toml::Table = "[security.signing_secret]\nprevious_secrets = [\"a\", \"\"]\n"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            resolve_deploy_previous_signing_secrets(&table).unwrap(),
+            vec!["a".to_owned(), String::new()]
         );
     }
 

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -5981,8 +5981,7 @@ pub fn run(opts: DoctorOptions) {
             || deploy_db_topology.replica_url.is_some()
             || deploy_shards_result
                 .as_ref()
-                .map(|shards| !shards.is_empty())
-                .unwrap_or(false);
+                .is_ok_and(|shards| !shards.is_empty());
         let deploy_db_url_result = deploy_shards_result.map(|deploy_shards| {
             deploy_db_topology
                 .primary_url

--- a/autumn-cli/tests/integration/deploy.rs
+++ b/autumn-cli/tests/integration/deploy.rs
@@ -188,6 +188,41 @@ fn doctor_reads_deploy_signing_secret_from_dotenv() {
 }
 
 #[test]
+fn doctor_fails_on_malformed_previous_secrets() {
+    // Regression: doctor silently DROPPED a malformed
+    // `security.signing_secret.previous_secrets` (e.g. `[123]` or a non-array)
+    // via `as_array`/`filter_map`, so `deploy_signing_secret` PASSED with a
+    // strong current secret — but `autumn deploy check` loads via
+    // `AutumnConfig::load()`, which deserializes the field as `Vec<String>` and
+    // HARD-FAILS the same config on every profile. Doctor must surface a FAILING
+    // `deploy_signing_secret` check to match. A strong current secret is supplied
+    // via env so the failure is attributable to the malformed `previous_secrets`,
+    // not a missing current secret.
+    let dir =
+        project("host = \"203.0.113.10\"\n\n[security.signing_secret]\nprevious_secrets = [123]\n");
+    let secret = "a".repeat(64);
+    let (stdout, stderr, code) = run_autumn(
+        dir.path(),
+        &["doctor"],
+        &[("AUTUMN_SECURITY__SIGNING_SECRET", secret.as_str())],
+    );
+    let combined = format!("{stdout}{stderr}");
+    assert_ne!(
+        code,
+        Some(0),
+        "doctor must fail on a malformed previous_secrets\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        combined.contains("deploy_signing_secret"),
+        "doctor must surface the deploy_signing_secret check\n{combined}"
+    );
+    assert!(
+        combined.contains("previous_secrets is present but invalid"),
+        "doctor must report the malformed previous_secrets\n{combined}"
+    );
+}
+
+#[test]
 fn doctor_flags_dotenv_db_backed_runtime_without_db() {
     // Regression: `.env`-only postgres backend must make doctor require a deploy
     // DB, matching `deploy check` (Codex P2 on 2dc71f7); bare OsEnv wrongly


### PR DESCRIPTION
## What & why
Follow-up to #1884 (deploy foundation for #1607), which was merged before this last review item could land.

**Before:** `autumn doctor`'s deploy preflight silently dropped a malformed `security.signing_secret.previous_secrets` value — e.g. `previous_secrets = [123]` or a non-array — via `as_array`/`filter_map`, so `deploy_signing_secret` reported OK as long as the current secret was strong. `autumn deploy check`, which loads config through `AutumnConfig::load()` (deserializing the field as `Vec<String>`), hard-fails that same config on every profile. So `doctor --strict` passed a deployment `deploy check` rejects.

**After:** doctor surfaces a failing `deploy_signing_secret` check when `previous_secrets` is a non-array value or contains a non-string element, matching `deploy check`. Empty strings stay valid (serde/`load()` accepts them; production value-validation still handles them downstream).

This closes the last doctor↔`deploy check` parity gap Codex flagged on the #1884 branch.

## How
- `resolve_deploy_previous_signing_secrets` (autumn-cli/src/doctor.rs) now returns `Result<Vec<String>, String>`: absent → `Ok(vec[])`; non-array → `Err`; non-string element `i` → `Err("previous_secrets[{i}] must be a string")`.
- `doctor::run()` matches the result — the `Ok` arm keeps the existing `grade_signing_secret` task; the `Err` arm pushes a failing `deploy_signing_secret` `CheckResult` (detail: `security.signing_secret.previous_secrets is present but invalid: {msg}`) on every profile, mirroring the existing malformed-shard / invalid-`[deploy]`-table failing-check pattern.

## Tests
- Unit: `deploy_previous_secrets_non_array_is_malformed`, `deploy_previous_secrets_non_string_element_is_malformed`, `deploy_previous_secrets_absent_or_strings_ok`.
- Integration: `doctor_fails_on_malformed_previous_secrets` — `[deploy]` host + strong current secret via env + `previous_secrets = [123]`; asserts doctor exits non-zero and renders `deploy_signing_secret — ... previous_secrets is present but invalid`.

## Local verification (targeted `-p` builds; full-workspace test skipped for the ~17GB trybuild ENOSPC risk)
| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo test -p autumn-cli --test cli_tests` | 191 passed, 0 failed, 30 ignored |
| `cargo test -p autumn-cli --bin autumn` | 3774 passed, 0 failed, 5 ignored |

---

### CI note — clears trunk's clippy-1.97 `map_unwrap_or`

CI's Lint job runs clippy 1.97, which flags `clippy::map_unwrap_or` on a `Result` — a lint our older local clippy misses. That construct is pre-existing on `trunk-dev` (from the #1884 P2 work) on the deploy doctor path, so it red-Lints any branch built on trunk. This PR fixes it (`.map(...).unwrap_or(false)` → `.is_ok_and(...)`). Verified authoritatively on this PR's HEAD with `cargo +1.97.0 clippy --workspace --all-targets -- -D warnings` → **exit 0** (no remaining/sibling violations). Other branches inherit the fix by rebasing onto trunk after this merges.

---
