### PR TITLE
chore(docs): fix pre-existing broken/private intra-doc links

### DIFF
--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -4217,7 +4217,7 @@ const TLS_ENV_VAR_NAMES: [&str; 4] = [
 ];
 
 /// Whether any `[server.tls]` env var is present in `env` (including a
-/// tuning-only var). Reads through the passed [`Env`], so a var supplied only
+/// tuning-only var). Reads through the passed [`Env`](autumn_web::config::Env), so a var supplied only
 /// via the `.env`/`.env.<profile>` overlay counts — the runtime materializes an
 /// (otherwise-empty) `[server.tls]` table for it, so doctor must grade it rather
 /// than emit a false Pass. Presence of any [`TLS_ENV_VAR_NAMES`] key marks
@@ -4595,7 +4595,7 @@ fn parse_acme_http_challenge_port(acme: &toml::Table) -> Result<u16, String> {
 
 /// The `FsAcmeStore` subdirectory label for a parsed `acme.directory`.
 ///
-/// Mirrors [`autumn_web::acme::directory_label`], replicated here because that
+/// Mirrors `autumn_web::acme::directory_label`, replicated here because that
 /// helper lives behind the `acme` feature while this doctor path also compiles
 /// in the feature-less build. Keep in sync with the store — see
 /// `autumn_web::acme::store::FsAcmeStore`, which reads/writes certificates only
@@ -4916,7 +4916,7 @@ fn resolve_acme_stored_cert_data(cert_dir: &std::path::Path, domains: &[String])
 
 /// Locate the stored `{cert_id}.chain.pem` + `{cert_id}.key.pem` pair for the
 /// CONFIGURED domains in `cert_dir`, where `cert_id` is derived from `domains`
-/// exactly as [`autumn_web::acme::store::CertId::from_domains`] does.
+/// exactly as `autumn_web::acme::store::CertId::from_domains` does.
 ///
 /// `cert_dir` MUST be the configured directory namespace
 /// (`{cache_dir}/{directory-label}/`) — the one the runtime's `FsAcmeStore`
@@ -4943,7 +4943,7 @@ fn configured_acme_cert_pair(
 }
 
 /// The stable certificate id for a domain set, replicating
-/// [`autumn_web::acme::store::CertId::from_domains`] (which lives behind the
+/// `autumn_web::acme::store::CertId::from_domains` (which lives behind the
 /// `acme` feature while this doctor path also compiles feature-less). Keep in
 /// EXACT sync with `store.rs`: sort + dedup the domains, SHA-256 each with a
 /// trailing NUL separator, and hex-encode the first 16 digest bytes. A

--- a/autumn-cli/src/generate/policy.rs
+++ b/autumn-cli/src/generate/policy.rs
@@ -28,7 +28,7 @@ use super::{GenerateError, ensure_project_root, read_or_empty};
 
 /// Compute the file actions for `autumn generate policy`.
 ///
-/// `for_destroy` selects the caller's [`super::ApplyMode`]: in generate mode the
+/// `for_destroy` selects the caller's `ApplyMode`: in generate mode the
 /// model-existence guard (AC5) fires when the target model is missing, but in
 /// destroy mode it is skipped so `autumn destroy policy` can still tear the
 /// policy down after the model was already destroyed (the plan's `revert` only

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -5667,7 +5667,7 @@ async fn __PLURAL___write_path_crud() {
 /// process-local stand-in for the persistence layer, no database required, so it
 /// runs green without Docker (unlike the `TestDb`-backed index/api smoke tests,
 /// which are `#[ignore]`d). It drives a zero-JS `multipart/form-data` create
-/// through the real [`Multipart`](autumn_web::extract::Multipart) extractor and
+/// through the real `Multipart` extractor and
 /// the real `save_to_blob_store` against a real
 /// [`LocalBlobStore`](autumn_web::storage::LocalBlobStore), binds the returned
 /// `Blob` on the record, then asserts the persisted record's attachment column

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -2806,7 +2806,7 @@ fn ensure_dep_feature_status_in_section(
 ///
 /// If the dependency isn't declared in `[dependencies]` at all, the input is
 /// returned unchanged — callers that need the dependency itself present must
-/// add it separately (e.g. via `plan_cargo_deps`/[`ensure_cargo_dependencies`]).
+/// add it separately (e.g. via `plan_cargo_deps`/`ensure_cargo_dependencies`).
 /// Idempotent: a second call is a no-op once the feature is present.
 #[must_use]
 pub(super) fn ensure_dependency_feature(existing: &str, dep_name: &str, feature: &str) -> String {

--- a/autumn/src/a11y.rs
+++ b/autumn/src/a11y.rs
@@ -11,23 +11,28 @@
 //! obligation** rather than a convention. Each one maps to a WCAG 2.1 success
 //! criterion and is constructed so that the inaccessible form does not compile:
 //!
-//! - [`Img`] — WCAG 1.1.1 Non-text Content. The alt text is a mandatory
-//!   positional argument of [`Img::new`]; there is no alt-less constructor.
-//!   Decorative images opt in explicitly with [`Img::decorative`].
-//! - [`Button`] — WCAG 4.1.2 Name, Role, Value. The accessible name is a
-//!   required argument; an icon-only button routes it to `aria-label` via
-//!   [`Button::icon`].
-//! - [`Link`] — WCAG 2.4.4 Link Purpose (In Context) / 4.1.2 Name, Role, Value.
-//!   The link text is a required argument of [`Link::new`]; an icon-only link
-//!   routes its name to `aria-label` via [`Link::icon`]. There is no text-less
-//!   constructor.
-//! - [`MenuItem`] — WCAG 4.1.2 Name, Role, Value. A menu item carries an
-//!   explicit `role="menuitem"` and a required accessible name from
-//!   [`MenuItem::new`]; an icon-only item routes that name to `aria-label`.
-//! - [`TextField`] — WCAG 1.3.1 Info and Relationships / 3.3.2 Labels or
-//!   Instructions / 4.1.2 Name, Role, Value. A [`TextField<NoLabel>`] has no
+//! - [`Img`](crate::a11y::Img) — WCAG 1.1.1 Non-text Content. The alt text is a
+//!   mandatory positional argument of [`Img::new`](crate::a11y::Img::new); there
+//!   is no alt-less constructor. Decorative images opt in explicitly with
+//!   [`Img::decorative`](crate::a11y::Img::decorative).
+//! - [`Button`](crate::a11y::Button) — WCAG 4.1.2 Name, Role, Value. The
+//!   accessible name is a required argument; an icon-only button routes it to
+//!   `aria-label` via [`Button::icon`](crate::a11y::Button::icon).
+//! - [`Link`](crate::a11y::Link) — WCAG 2.4.4 Link Purpose (In Context) / 4.1.2
+//!   Name, Role, Value. The link text is a required argument of
+//!   [`Link::new`](crate::a11y::Link::new); an icon-only link routes its name to
+//!   `aria-label` via [`Link::icon`](crate::a11y::Link::icon). There is no
+//!   text-less constructor.
+//! - [`MenuItem`](crate::a11y::MenuItem) — WCAG 4.1.2 Name, Role, Value. A menu
+//!   item carries an explicit `role="menuitem"` and a required accessible name
+//!   from [`MenuItem::new`](crate::a11y::MenuItem::new); an icon-only item routes
+//!   that name to `aria-label`.
+//! - [`TextField`](crate::a11y::TextField) — WCAG 1.3.1 Info and Relationships /
+//!   3.3.2 Labels or Instructions / 4.1.2 Name, Role, Value. A
+//!   [`TextField`](crate::a11y::TextField)`<NoLabel>` has no
 //!   way to render; only after a label is attached (producing a
-//!   [`TextField<Labeled>`]) does the type implement [`maud::Render`]. An
+//!   [`TextField`](crate::a11y::TextField)`<Labeled>`) does the type implement
+//!   [`maud::Render`]. An
 //!   unlabeled field is therefore unrepresentable as markup. The field can
 //!   still carry presentational and validation attributes — `class`,
 //!   `aria-invalid`/`aria-describedby` error wiring, and the HTML5 constraints

--- a/autumn/src/negotiate.rs
+++ b/autumn/src/negotiate.rs
@@ -1,8 +1,9 @@
 //! Content-negotiated success responder.
 //!
 //! One handler can serve HTML to browsers and JSON to API clients from a
-//! single source of truth. Declare the [`Negotiate`] extractor, then hand it a
-//! Maud closure and a serializable value via [`Negotiate::respond`]:
+//! single source of truth. Declare the [`Negotiate`](crate::negotiate::Negotiate)
+//! extractor, then hand it a Maud closure and a serializable value via
+//! [`Negotiate::respond`](crate::negotiate::Negotiate::respond):
 //!
 //! ```rust,ignore
 //! use autumn_web::prelude::*;
@@ -18,7 +19,7 @@
 //! ```
 //!
 //! The client's `Accept` header decides the representation, reusing the crate's
-//! one canonical `Accept` parser ([`accept_qualities`]) and resolving over
+//! one canonical `Accept` parser (`accept_qualities`) and resolving over
 //! *effective* q-values that honour the `*/*` wildcard per RFC 7231 content
 //! negotiation.
 //!
@@ -64,8 +65,10 @@
 //!
 //! When the client expresses no concrete preference — a missing/empty `Accept`,
 //! a bare `*/*`, or a wildcard-only tie where neither side is named directly —
-//! the default is [`Format::Html`] (browser-first); override it with
-//! [`Negotiate::default_format`]. Responses carry `Vary: Accept` so shared
+//! the default is [`Format::Html`](crate::negotiate::Format::Html)
+//! (browser-first); override it with
+//! [`Negotiate::default_format`](crate::negotiate::Negotiate::default_format).
+//! Responses carry `Vary: Accept` so shared
 //! caches key the two representations separately — including the `406` arm.
 
 use std::convert::Infallible;
@@ -109,7 +112,7 @@ impl Negotiate {
 
     /// The resolved representation, chosen by *effective* q-value.
     ///
-    /// A convenience view over [`Negotiate::resolve`] that collapses the
+    /// A convenience view over `Negotiate::resolve` that collapses the
     /// not-acceptable case onto the configured `default`: it answers the
     /// question "which representation would be served if one *must* be" and so
     /// cannot express a `406`. Prefer [`Negotiate::respond`] for the full
@@ -283,7 +286,7 @@ where
 /// The response produced by [`Negotiate::respond`].
 ///
 /// Renders the HTML closure or serializes the JSON value depending on the
-/// negotiated [`Resolution`], answers `406 Not Acceptable` when the client
+/// negotiated `Resolution`, answers `406 Not Acceptable` when the client
 /// forbade every producible representation, and always appends `Vary: Accept`.
 pub struct Negotiated<F, J> {
     resolution: Resolution,

--- a/autumn/src/security/config.rs
+++ b/autumn/src/security/config.rs
@@ -119,7 +119,7 @@ const DEMO_VALUES: &[&str] = &[
 ///
 /// Set `secret` via the `AUTUMN_SECURITY__SIGNING_SECRET` environment variable
 /// (or `[security.signing_secret] secret` in `autumn.toml`). The secret must be:
-/// - At least [`MIN_SECRET_LEN`] bytes long.
+/// - At least `MIN_SECRET_LEN` bytes long.
 /// - Not a known template/demo value.
 /// - Stable across restarts and identical on every replica.
 ///
@@ -166,7 +166,7 @@ pub enum SigningSecretError {
     TooShort {
         /// Actual byte length of the supplied secret.
         actual: usize,
-        /// Minimum required byte length ([`MIN_SECRET_LEN`]).
+        /// Minimum required byte length (`MIN_SECRET_LEN`).
         required: usize,
     },
     /// The secret matches a known insecure demo or template value.
@@ -202,7 +202,7 @@ impl std::fmt::Display for SigningSecretError {
 ///
 /// In production:
 /// - `None` → [`SigningSecretError::MissingInProduction`]
-/// - Shorter than [`MIN_SECRET_LEN`] bytes → [`SigningSecretError::TooShort`]
+/// - Shorter than `MIN_SECRET_LEN` bytes → [`SigningSecretError::TooShort`]
 /// - Matches a known demo/template string → [`SigningSecretError::KnownWeakValue`]
 ///
 /// # Errors


### PR DESCRIPTION
## Before / After

**Before:** the CI "Documentation build" job (`scripts/check-docs.sh`, `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links"`) failed on pre-existing intra-doc-link errors across **both** documented crates (`autumn-web` and `autumn-cli`), reddening every open PR's docs check on `trunk-dev`.

**After:** `scripts/check-docs.sh` exits 0 — all broken and private intra-doc links across both crates resolved (verified locally: `Documentation build OK — no broken intra-doc links.`, `EXIT=0`).

## What

**autumn-web**
- `autumn/src/a11y.rs` — module doc: rewrote unresolved links for `Img`/`Button`/`Link`/`MenuItem`/`TextField` (and their methods / generic forms) as fully-qualified working links (`crate::a11y::…`); generic forms like `TextField<NoLabel>` split into a link plus a plain code span (intra-doc links can't carry generics).
- `autumn/src/negotiate.rs` — module doc: fully-qualified `Negotiate`, `Format::Html`, `Negotiate::respond`, `Negotiate::default_format`; demoted `accept_qualities` (lives in a `pub(crate)` module, not publicly reachable) to a plain code span. Also demoted the public-item docs that linked private items: `Negotiate::resolve` (line 112) and `Resolution` (line 286).
- `autumn/src/security/config.rs` — demoted the three public-item links to the private `MIN_SECRET_LEN` const (lines 122, 169, 205) to plain code spans.

**autumn-cli**
- `autumn-cli/src/doctor.rs` — fully-qualified `Env` as `autumn_web::config::Env` (public, reachable); demoted the `autumn_web::acme::directory_label` / `autumn_web::acme::store::CertId::from_domains` cross-crate links (the `acme` module is behind an off-by-default feature, so not reachable in the CLI doc build).
- `autumn-cli/src/generate/policy.rs` — demoted `super::ApplyMode` (a private enum defined in `main.rs`, not on that path).
- `autumn-cli/src/generate/scaffold.rs` — demoted `autumn_web::extract::Multipart` (`multipart` feature off in the CLI doc build).
- `autumn-cli/src/generate/schema_edit.rs` — demoted `ensure_cargo_dependencies` (`pub(super)` helper).

Docs-only; no code behavior changes. Clears **all** pre-existing intra-doc-link errors across both crates on `trunk-dev` (verified `scripts/check-docs.sh` exits 0, `cargo fmt --all -- --check` clean), not just the originally-reported `autumn-web` subset. Unblocks the wave-13 Documentation build check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzSgFQRRBsQSoW9mJ61V15

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzSgFQRRBsQSoW9mJ61V15)_