### PR TITLE
⚡ Bolt: [performance improvement] Remove intermediate Vec allocation in squish

### DIFF
--- a/autumn/src/normalize.rs
+++ b/autumn/src/normalize.rs
@@ -47,9 +47,21 @@ pub fn upcase(s: &str) -> String {
 }
 
 /// Trim and collapse every internal run of whitespace to a single ASCII space.
+///
+/// This implementation avoids allocating an intermediate `Vec` by pushing
+/// directly into a pre-allocated `String`.
 #[must_use]
 pub fn squish(s: &str) -> String {
-    s.split_whitespace().collect::<Vec<_>>().join(" ")
+    let mut iter = s.split_whitespace();
+    iter.next().map_or_else(String::new, |first| {
+        let mut result = String::with_capacity(s.len());
+        result.push_str(first);
+        for word in iter {
+            result.push(' ');
+            result.push_str(word);
+        }
+        result
+    })
 }
 
 /// A type whose `#[normalize]` columns can be canonicalized in place.


### PR DESCRIPTION
💡 What: Switched `squish` in `autumn/src/normalize.rs` to use a manual single-pass loop that pushes space-separated tokens directly into a pre-allocated `String::with_capacity(s.len())` instead of collecting into an intermediate `Vec<_>` and calling `.join(" ")`.

🎯 Why: Normalizing database fields is a hot path during lookups and saves. The previous implementation incurred unnecessary heap allocations for the intermediate `Vec` and slice copies before joining the final string.

📊 Impact: Reduces heap allocations by 1 for every call to `squish`, eliminating the vector allocation entirely and replacing it with a single, bounded string allocation.

🔭 Measurement: Run `cargo test -p autumn-web --lib normalize` to verify correctness. Benchmarks on database insert/lookup flows involving normalized text fields will show reduced memory allocation overhead.

---
*PR created automatically by Jules for task [4422420587924785002](https://jules.google.com/task/4422420587924785002) started by @madmax983*