### PR TITLE
feat(cli): autumn deploy zero-downtime cutover — kamal-proxy flip + migrate-before-cutover (Slice 2 of #1607)

### DIFF
--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -20,6 +20,7 @@
 //! with `autumn doctor`.
 
 pub mod exec;
+pub mod proxy;
 
 use std::net::{TcpStream, ToSocketAddrs};
 use std::path::{Path, PathBuf};
@@ -504,6 +505,46 @@ pub fn render_systemd_unit(cfg: &ResolvedDeployConfig) -> String {
     )
 }
 
+/// Render the systemd unit for a specific blue/green *slot* release (issue #1607,
+/// Slice 2).
+///
+/// Unlike [`render_systemd_unit`] (which execs the `current` symlink), a slot unit
+/// pins its own `release_dir` and binds a PRIVATE loopback `app_port`, so the blue
+/// and green slots can run different releases side by side across a cutover while
+/// the reverse proxy owns the public port. The unit is named
+/// `{service}-{slot}.service` (see [`exec::slot_unit_name`]).
+#[must_use]
+pub fn render_app_unit(
+    cfg: &ResolvedDeployConfig,
+    release_dir: &str,
+    app_port: u16,
+    slot: &str,
+) -> String {
+    format!(
+        "[Unit]\n\
+         Description=Autumn application: {app} ({slot})\n\
+         After=network-online.target\n\
+         Wants=network-online.target\n\
+         \n\
+         [Service]\n\
+         Type=simple\n\
+         User={user}\n\
+         WorkingDirectory={release_dir}\n\
+         EnvironmentFile={env_file}\n\
+         Environment=AUTUMN_SERVER__HOST=127.0.0.1\n\
+         Environment=AUTUMN_SERVER__PORT={app_port}\n\
+         ExecStart={release_dir}/{app}\n\
+         Restart=on-failure\n\
+         RestartSec=2\n\
+         \n\
+         [Install]\n\
+         WantedBy=multi-user.target\n",
+        app = cfg.app_name,
+        user = cfg.user,
+        env_file = cfg.env_file(),
+    )
+}
+
 /// Build the ordered, zero-downtime deploy plan (AC-2/3/4).
 ///
 /// The sequence encodes the framework's `/live`-`/ready`-drain contract:
@@ -841,17 +882,24 @@ fn default_release_id() -> String {
     chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string()
 }
 
-/// Perform a real FIRST deploy (issue #1607, Slice 1).
+/// Perform a real deploy (issue #1607, Slices 1–2).
 ///
 /// Runs the same preflight as `check` and aborts before touching the server if
-/// anything fails (AC-6), then drives the ordered host-prep + first-deploy
-/// sequence against a real [`exec::SshExecutor`].
+/// anything fails (AC-6). It then probes the target ([`exec::detect_deploy_mode`])
+/// to choose between:
 ///
-/// Scope guard: this is a first-deploy path only. On a redeploy it re-points
-/// `current` at the new release the same way; zero-downtime cutover and rollback
-/// are follow-up slices and are deliberately NOT performed here.
+/// - **first deploy** ([`exec::first_deploy_ops`]) — install the reverse proxy on
+///   the public port and stand the initial release up on a private loopback slot
+///   behind it, or
+/// - **zero-downtime redeploy** ([`exec::cutover_ops`]) — stand the candidate up
+///   on the idle slot, run migrations before cutover, gate on `/ready`, then have
+///   the proxy flip live traffic to it and drain the old release (AC-2/AC-3).
+///
+/// Rollback execution and auto-rollback on a failed gate remain a follow-up slice
+/// (Slice 3): here a failed migration or readiness timeout aborts before the flip
+/// with the old release still serving.
 fn run_up(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(), DeployError> {
-    eprintln!("\u{1F342} autumn deploy up (first deploy)\n");
+    eprintln!("\u{1F342} autumn deploy up\n");
 
     // Fail fast: run the full preflight and abort BEFORE any remote call.
     let checks = collect_preflight(config, resolved);
@@ -864,30 +912,72 @@ fn run_up(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(), 
     let target = exec::SshTarget::from_resolved(resolved)
         .ok_or_else(|| DeployError::Config(DEPLOY_HOST_MISSING_DETAIL.to_owned()))?;
     let binary = resolve_release_binary(resolved)?;
-    let unit = render_systemd_unit(resolved);
     let env_file = build_env_file(config);
     let release_id = default_release_id();
-
-    let ops = exec::first_deploy_ops(
-        resolved,
-        &unit,
-        env_file,
-        &binary,
-        &release_id,
-        config.server.port,
-    );
+    let public_port = config.server.port;
+    let proxy = proxy::KamalProxyController::new(resolved.readiness_timeout_secs);
     let executor = exec::SshExecutor::new(target);
+    let release_dir = format!("{}/{release_id}", resolved.releases_dir());
 
-    eprintln!(
-        "Deploying release {release_id} to {}\u{2026}\n",
-        resolved.host.as_deref().unwrap_or_default()
-    );
-    exec::execute_first_deploy(&checks, &ops, &executor)
+    // Probe the target to choose first-deploy vs zero-downtime redeploy.
+    let mode = exec::detect_deploy_mode(resolved, &executor)
         .map_err(|e| DeployError::Exec(e.to_string()))?;
 
+    let (ops, banner) = match mode {
+        exec::DeployMode::First => {
+            let plan = exec::SlotPlan::first(public_port);
+            let unit = render_app_unit(
+                resolved,
+                &release_dir,
+                plan.candidate_port,
+                plan.candidate_slot,
+            );
+            let ops = exec::first_deploy_ops(
+                resolved,
+                &proxy,
+                &unit,
+                env_file,
+                &binary,
+                &release_id,
+                &plan,
+            );
+            (ops, "first deploy".to_owned())
+        }
+        exec::DeployMode::Redeploy { live_slot } => {
+            let plan = exec::SlotPlan::redeploy(public_port, live_slot);
+            let unit = render_app_unit(
+                resolved,
+                &release_dir,
+                plan.candidate_port,
+                plan.candidate_slot,
+            );
+            let ops = exec::cutover_ops(
+                resolved,
+                &proxy,
+                &unit,
+                env_file,
+                &binary,
+                &release_id,
+                &plan,
+            );
+            (
+                ops,
+                format!(
+                    "zero-downtime redeploy ({} \u{2192} {})",
+                    plan.live_slot, plan.candidate_slot
+                ),
+            )
+        }
+    };
+
     eprintln!(
-        "\n\u{2705} First deploy complete. Zero-downtime cutover and rollback land in later slices."
+        "Deploying release {release_id} to {} ({banner})\u{2026}\n",
+        resolved.host.as_deref().unwrap_or_default()
     );
+    exec::execute_redeploy(&checks, &ops, &executor)
+        .map_err(|e| DeployError::Exec(e.to_string()))?;
+
+    eprintln!("\n\u{2705} Deploy complete. Rollback execution lands in a later slice.");
     Ok(())
 }
 

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -1,47 +1,65 @@
-//! Injectable remote-execution layer for `autumn deploy` (issue #1607, Slice 1).
+//! Injectable remote-execution layer for `autumn deploy` (issue #1607, Slices 1–2).
 //!
-//! This module turns the previously-dry-run first-deploy plan into REAL
-//! execution behind an injectable [`DeployExecutor`], so the command-construction
-//! and execution paths are unit-testable without a live host.
+//! This module turns the dry-run deploy plan into REAL execution behind an
+//! injectable [`DeployExecutor`], so the command-construction and execution paths
+//! are unit-testable without a live host.
 //!
 //! ## What is real here
 //!
-//! - **Pure command construction:** [`first_deploy_ops`] turns a resolved deploy
-//!   config into an ordered `Vec<DeployOp>` (prepare dirs → upload binary → write
-//!   env file → write unit → link `current` → `daemon-reload` → `enable --now` →
-//!   readiness poll). It performs no I/O, so tests assert the exact ordered
-//!   sequence and the env-file mode.
-//! - **Execution:** [`run_ops`] / [`execute_first_deploy`] iterate the ops and
-//!   drive a [`DeployExecutor`]; [`execute_first_deploy`] additionally refuses to
-//!   run if any preflight check failed (AC-6 fail-fast — abort *before* touching
-//!   the server).
+//! - **First deploy (Slice 1, proxy-fronted in Slice 2):** [`first_deploy_ops`]
+//!   installs the reverse proxy on the public port, stands the initial release up
+//!   on a PRIVATE loopback slot port, and routes the proxy at it — so a later
+//!   redeploy has a live upstream to flip away from.
+//! - **Zero-downtime redeploy (Slice 2, AC-2/AC-3):** [`cutover_ops`] is the pure,
+//!   ordered cutover sequence: upload → write the candidate's env (0600) + unit on
+//!   a SEPARATE loopback port → start the candidate (old release keeps serving) →
+//!   run pending migrations BEFORE cutover → bounded `/ready` gate on the
+//!   candidate → health-gated proxy flip old→candidate → promote `current` → drain
+//!   the old release → prune. Because [`run_ops`] stops at the first failure, a
+//!   failed migration or a readiness timeout aborts BEFORE the flip with the old
+//!   release still serving (AC-3 / AC-2 safety).
+//! - **Blue/green slots:** the candidate always takes the slot the live release is
+//!   NOT using (see [`SlotPlan`]), so the candidate never binds the live port and
+//!   the two releases run side by side across the cutover.
+//! - **Execution:** [`run_ops`] / [`execute_first_deploy`] / [`execute_redeploy`]
+//!   iterate the ops and drive a [`DeployExecutor`]; the `execute_*` entrypoints
+//!   refuse to run if any preflight check failed (AC-6 fail-fast). [`DeployMode`]
+//!   / [`detect_deploy_mode`] pick first-vs-redeploy from a remote probe.
+//! - **Proxy:** the kamal-proxy CLI lives entirely in
+//!   [`KamalProxyController`](super::proxy::KamalProxyController); the cutover
+//!   orchestration here talks only to the [`ProxyController`] trait, so a Caddy
+//!   controller could replace it without touching this file.
 //! - **Real ssh/scp:** [`SshExecutor`] shells out to the system `ssh`/`scp`
 //!   binaries via [`std::process::Command`] (no ssh crate is pulled in). The argv
-//!   builders [`ssh_argv`]/[`scp_argv`] are pure functions so tests assert the
-//!   exact argument vector without executing anything.
+//!   builders [`ssh_argv`]/[`scp_argv`] are pure functions.
 //! - **Secret redaction:** the env-file contents travel as a [`Secret`] whose
 //!   `Debug`/`Display` are redacted, and secrets are only ever written to a
-//!   `0600` file — never placed on a command line or into an error message.
+//!   `0600` file — never placed on a command line or into an error message. The
+//!   migrate one-shot sources secrets via a systemd `EnvironmentFile`, not argv.
 //!
 //! ## What is deferred (NOT implemented in this slice)
 //!
-//! - Zero-downtime cutover — reverse-proxy upstream swap or systemd
-//!   socket-activation handoff (later slice).
-//! - Migration execution ordering against the live host (later slice).
-//! - Rollback execution and auto-rollback on a failed readiness gate — a
-//!   first-deploy readiness timeout here just fails loudly (later slice).
-//! - The CI end-to-end container harness that exercises the real `ssh` path
-//!   (later slice).
+//! - **Rollback execution** and auto-rollback on a failed readiness gate — a
+//!   readiness timeout or failed migration here fails loudly with the OLD release
+//!   still serving; automatically re-pointing traffic back is Slice 3.
+//! - The **CI end-to-end container harness** that exercises the real `ssh` path is
+//!   Slice 4 — live ssh is not exercised by these unit tests.
+//! - A **Caddy** [`ProxyController`](super::proxy::ProxyController) — kamal-proxy
+//!   is the confirmed proxy; Caddy is only the documented swappable alternative.
 //!
-//! On a *re*deploy (a `current` release already exists) this slice deliberately
-//! takes the same first-deploy path (re-pointing `current` at the new release);
-//! zero-downtime cutover and rollback are follow-up slices.
+//! The migrate step is fully real: the one-shot runs the uploaded release with
+//! `AUTUMN_MIGRATE=1`, which the app runtime honors (alongside its other
+//! env-gated one-shot modes such as `AUTUMN_BUILD_STATIC=1`) by applying pending
+//! embedded migrations with the same locked applier a normal boot uses and
+//! exiting 0/non-zero WITHOUT starting the server — so a failed migration aborts
+//! before cutover (AC-3).
 
 use std::fmt;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use super::proxy::ProxyController;
 use super::{PreflightCheck, ResolvedDeployConfig};
 
 /// A secret string (e.g. the env-file body carrying the signing secret and
@@ -114,7 +132,7 @@ pub struct RemoteCommand {
 }
 
 impl RemoteCommand {
-    fn new(label: &'static str, shell: impl Into<String>) -> Self {
+    pub(crate) fn new(label: &'static str, shell: impl Into<String>) -> Self {
         Self {
             label,
             shell: shell.into(),
@@ -308,42 +326,142 @@ pub fn scp_argv(target: &SshTarget, local: &Path, remote_path: &str) -> Vec<Stri
 }
 
 /// Single-quote a path for safe interpolation into a remote shell line.
-fn shell_quote(value: &str) -> String {
+pub fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
 
-/// Build the ordered first-deploy operation sequence from a resolved config.
+/// The blue deploy slot.
+pub const SLOT_BLUE: &str = "blue";
+/// The green deploy slot.
+pub const SLOT_GREEN: &str = "green";
+
+/// The PRIVATE loopback port a slot's app release binds. The public port is owned
+/// by the reverse proxy; blue takes `public + 1`, green `public + 2`, so the
+/// candidate never collides with the proxy's public port or the live slot's port.
+#[must_use]
+pub fn slot_app_port(public_port: u16, slot: &str) -> u16 {
+    let offset = if slot == SLOT_GREEN { 2 } else { 1 };
+    public_port.saturating_add(offset)
+}
+
+/// The other slot (blue ↔ green).
+#[must_use]
+pub fn other_slot(slot: &str) -> &'static str {
+    if slot == SLOT_BLUE {
+        SLOT_GREEN
+    } else {
+        SLOT_BLUE
+    }
+}
+
+/// Normalize an arbitrary slot string to one of the two known slots (defaulting
+/// to blue) so a corrupt marker can never name a third slot.
+fn canonical_slot(slot: &str) -> &'static str {
+    if slot.trim() == SLOT_GREEN {
+        SLOT_GREEN
+    } else {
+        SLOT_BLUE
+    }
+}
+
+/// systemd unit name for a slot's app release (without the `.service` suffix).
+#[must_use]
+pub fn slot_unit_name(service: &str, slot: &str) -> String {
+    format!("{service}-{slot}")
+}
+
+/// Remote marker file recording which slot currently serves live traffic, so the
+/// next redeploy can pick the OTHER slot for the candidate.
+fn live_slot_marker(cfg: &ResolvedDeployConfig) -> String {
+    format!("{}/shared/live-slot", cfg.app_dir)
+}
+
+/// The resolved blue/green slot layout for a deploy.
 ///
-/// Pure — performs no I/O. The `release_id` and `server_port` are injected so the
-/// output is deterministic for tests. The sequence is:
+/// The candidate always takes the slot the live release is NOT using, so both
+/// releases run side by side across the cutover and the candidate never binds the
+/// live port.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlotPlan {
+    /// Public port fronted by the proxy (the app's configured `server.port`).
+    pub public_port: u16,
+    /// Slot the candidate release takes.
+    pub candidate_slot: &'static str,
+    /// Loopback port the candidate binds.
+    pub candidate_port: u16,
+    /// Slot the currently-live release uses (equals `candidate_slot` on a first
+    /// deploy, where there is nothing to drain yet).
+    pub live_slot: &'static str,
+    /// Loopback port the currently-live release binds.
+    pub live_port: u16,
+}
+
+impl SlotPlan {
+    /// First deploy: the initial release takes the blue slot.
+    #[must_use]
+    pub fn first(public_port: u16) -> Self {
+        Self {
+            public_port,
+            candidate_slot: SLOT_BLUE,
+            candidate_port: slot_app_port(public_port, SLOT_BLUE),
+            live_slot: SLOT_BLUE,
+            live_port: slot_app_port(public_port, SLOT_BLUE),
+        }
+    }
+
+    /// Redeploy: the candidate takes the slot the live release is NOT using.
+    #[must_use]
+    pub fn redeploy(public_port: u16, live_slot: &str) -> Self {
+        let live_slot = canonical_slot(live_slot);
+        let candidate_slot = other_slot(live_slot);
+        Self {
+            public_port,
+            candidate_slot,
+            candidate_port: slot_app_port(public_port, candidate_slot),
+            live_slot,
+            live_port: slot_app_port(public_port, live_slot),
+        }
+    }
+}
+
+/// Build the ordered FIRST-deploy operation sequence (Slice 1 + proxy front).
 ///
-/// 1. prepare remote dirs (`mkdir -p {releases}/{id} {app_dir}/shared`),
-/// 2. upload the release binary (mode `0755`),
-/// 3. write the secret env file (mode `0600`, AC-5 — not world-readable),
-/// 4. write the systemd unit,
-/// 5. point `current` at the new release (first-deploy promotion; zero-downtime
-///    cutover is a later slice),
-/// 6. `systemctl daemon-reload`,
-/// 7. `systemctl enable --now`,
-/// 8. a bounded remote readiness poll of `/ready` (fails loudly on timeout — no
-///    auto-rollback in this slice).
+/// Pure — performs no I/O; `release_id` and the [`SlotPlan`] are injected for
+/// determinism. The initial release takes the blue slot on a private loopback
+/// port and the proxy is installed on the public port and routed at it, so a
+/// later redeploy has a live upstream to flip away from. The sequence:
+///
+/// 1. install + supervise the proxy on the public port,
+/// 2. prepare remote dirs,
+/// 3. upload the release binary (`0755`),
+/// 4. write the secret env file (`0600`, AC-5),
+/// 5. write the blue slot's systemd unit (binds `127.0.0.1:{blue_port}`),
+/// 6. point `current` at the new release,
+/// 7. `systemctl daemon-reload`,
+/// 8. `systemctl enable --now {service}-blue.service`,
+/// 9. record the live slot marker,
+/// 10. bounded `/ready` poll on the blue loopback port,
+/// 11. route the proxy at `127.0.0.1:{blue_port}`.
 #[must_use]
 pub fn first_deploy_ops(
     cfg: &ResolvedDeployConfig,
+    proxy: &impl ProxyController,
     unit: &str,
     env_file: Secret,
     binary_local: &Path,
     release_id: &str,
-    server_port: u16,
+    plan: &SlotPlan,
 ) -> Vec<DeployOp> {
     let release_dir = format!("{}/{release_id}", cfg.releases_dir());
     let remote_binary = format!("{release_dir}/{}", cfg.app_name);
     let shared_dir = format!("{}/shared", cfg.app_dir);
     let env_path = cfg.env_file();
     let current = cfg.current_symlink();
-    let unit_path = format!("/etc/systemd/system/{}.service", cfg.service_name);
+    let unit_name = slot_unit_name(&cfg.service_name, plan.candidate_slot);
+    let unit_path = format!("/etc/systemd/system/{unit_name}.service");
 
-    vec![
+    let mut ops = proxy.ensure_installed_ops(plan.public_port);
+    ops.extend([
         DeployOp::Run(RemoteCommand::new(
             "prepare-dirs",
             format!(
@@ -385,13 +503,221 @@ pub fn first_deploy_ops(
         )),
         DeployOp::Run(RemoteCommand::new(
             "enable-now",
-            format!("systemctl enable --now {}.service", cfg.service_name),
+            format!("systemctl enable --now {unit_name}.service"),
         )),
+        DeployOp::Run(record_live_slot(cfg, plan.candidate_slot)),
         DeployOp::Run(RemoteCommand::new(
             "readiness-gate",
-            readiness_poll_shell(server_port, cfg.readiness_timeout_secs),
+            readiness_poll_shell(plan.candidate_port, cfg.readiness_timeout_secs),
+        )),
+    ]);
+    // Route the proxy at the freshly-ready initial release (first deploy has no
+    // prior upstream to flip away from).
+    ops.push(proxy.route_op(&cfg.service_name, &loopback_upstream(plan.candidate_port)));
+    ops
+}
+
+/// Build the ordered zero-downtime REDEPLOY cutover sequence (Slice 2, AC-2/AC-3).
+///
+/// Pure — performs no I/O; `release_id` and the redeploy [`SlotPlan`] are injected
+/// for determinism. The candidate is stood up on the idle slot's separate
+/// loopback port while the live release keeps serving; migrations run BEFORE the
+/// flip; the proxy flip only swaps traffic after the candidate passes its
+/// readiness gate. Because [`run_ops`] stops at the first failure, a failed
+/// migration or readiness timeout aborts here with the old release still serving
+/// (no flip, no drain, no promote). The sequence:
+///
+/// 1. prepare remote dirs,
+/// 2. upload the release binary (`0755`),
+/// 3. write the secret env file (`0600`, AC-5),
+/// 4. write the candidate slot's systemd unit (binds `127.0.0.1:{candidate_port}`),
+/// 5. `systemctl daemon-reload`,
+/// 6. start the candidate (old release untouched),
+/// 7. run pending migrations BEFORE cutover (`AUTUMN_MIGRATE=1` one-shot),
+/// 8. bounded `/ready` poll on the candidate's separate loopback port,
+/// 9. health-gated proxy flip old→candidate (THE cutover),
+/// 10. promote `current` to the new release,
+/// 11. record the live slot marker,
+/// 12. drain (stop) the old release,
+/// 13. prune old releases beyond `keep_releases`.
+#[must_use]
+pub fn cutover_ops(
+    cfg: &ResolvedDeployConfig,
+    proxy: &impl ProxyController,
+    unit: &str,
+    env_file: Secret,
+    binary_local: &Path,
+    release_id: &str,
+    plan: &SlotPlan,
+) -> Vec<DeployOp> {
+    let release_dir = format!("{}/{release_id}", cfg.releases_dir());
+    let remote_binary = format!("{release_dir}/{}", cfg.app_name);
+    let shared_dir = format!("{}/shared", cfg.app_dir);
+    let env_path = cfg.env_file();
+    let current = cfg.current_symlink();
+    let candidate_unit = slot_unit_name(&cfg.service_name, plan.candidate_slot);
+    let candidate_unit_path = format!("/etc/systemd/system/{candidate_unit}.service");
+    let live_unit = slot_unit_name(&cfg.service_name, plan.live_slot);
+
+    vec![
+        DeployOp::Run(RemoteCommand::new(
+            "prepare-dirs",
+            format!(
+                "mkdir -p {} {}",
+                shell_quote(&release_dir),
+                shell_quote(&shared_dir)
+            ),
+        )),
+        DeployOp::UploadFile {
+            label: "upload-binary",
+            local: binary_local.to_path_buf(),
+            remote_path: remote_binary,
+            mode: Some(0o755),
+        },
+        DeployOp::WriteFile {
+            label: "write-env",
+            contents: FileContents::Secret(env_file),
+            remote_path: env_path,
+            mode: Some(0o600),
+        },
+        DeployOp::WriteFile {
+            label: "write-candidate-unit",
+            contents: FileContents::Plain(unit.to_owned()),
+            remote_path: candidate_unit_path,
+            mode: Some(0o644),
+        },
+        DeployOp::Run(RemoteCommand::new(
+            "daemon-reload",
+            "systemctl daemon-reload",
+        )),
+        DeployOp::Run(RemoteCommand::new(
+            "start-candidate",
+            format!("systemctl enable --now {candidate_unit}.service"),
+        )),
+        // Migrations run BEFORE the flip. `systemd-run --wait` returns the
+        // child's exit status, so a failed migration surfaces a non-zero error
+        // that stops run_ops before the flip — old release still serving (AC-3).
+        DeployOp::Run(release_migrate_command(cfg, &release_dir)),
+        DeployOp::Run(RemoteCommand::new(
+            "readiness-gate",
+            readiness_poll_shell(plan.candidate_port, cfg.readiness_timeout_secs),
+        )),
+        // THE cutover: the proxy health-checks the candidate then atomically swaps
+        // live traffic to it and drains the old target. Only reached after a
+        // passing readiness gate (AC-2).
+        proxy.flip_op(&cfg.service_name, &loopback_upstream(plan.candidate_port)),
+        DeployOp::Run(RemoteCommand::new(
+            "link-current",
+            format!(
+                "ln -sfn {} {}",
+                shell_quote(&release_dir),
+                shell_quote(&current)
+            ),
+        )),
+        DeployOp::Run(record_live_slot(cfg, plan.candidate_slot)),
+        DeployOp::Run(RemoteCommand::new(
+            "drain-old",
+            format!("systemctl disable --now {live_unit}.service"),
+        )),
+        DeployOp::Run(RemoteCommand::new(
+            "prune",
+            prune_releases_shell(&cfg.releases_dir(), cfg.keep_releases),
         )),
     ]
+}
+
+/// The `host:port` loopback upstream string the proxy routes at.
+fn loopback_upstream(port: u16) -> String {
+    format!("127.0.0.1:{port}")
+}
+
+/// Command that records which slot now serves live traffic (read by the next
+/// redeploy's [`detect_deploy_mode`]).
+fn record_live_slot(cfg: &ResolvedDeployConfig, slot: &str) -> RemoteCommand {
+    RemoteCommand::new(
+        "record-live-slot",
+        format!(
+            "printf '%s' {} > {}",
+            shell_quote(slot),
+            shell_quote(&live_slot_marker(cfg))
+        ),
+    )
+}
+
+/// Command that runs the uploaded release's pending migrations as a one-shot,
+/// BEFORE cutover.
+///
+/// Uses `systemd-run --wait` so (a) the migration's exit status propagates (a
+/// failure aborts the deploy before the flip — AC-3), and (b) secrets reach the
+/// process via the systemd `EnvironmentFile`, never on the command line. The
+/// `AUTUMN_MIGRATE=1` trigger is honored by the app runtime
+/// (`AppBuilder::run` → `run_migrate_only_mode`), which applies pending embedded
+/// migrations with the same locked applier a normal boot uses and exits without
+/// starting the server.
+fn release_migrate_command(cfg: &ResolvedDeployConfig, release_dir: &str) -> RemoteCommand {
+    let bin = format!("{release_dir}/{}", cfg.app_name);
+    RemoteCommand::new(
+        "migrate",
+        format!(
+            "systemd-run --wait --collect --quiet --unit={service}-migrate \
+             --property=EnvironmentFile={env} --setenv=AUTUMN_MIGRATE=1 {bin}",
+            service = cfg.service_name,
+            env = shell_quote(&cfg.env_file()),
+            bin = shell_quote(&bin),
+        ),
+    )
+}
+
+/// Prune shell: keep the newest `keep` release dirs, delete the rest. `ls -1dt`
+/// lists dirs newest-first; `tail -n +{keep+1}` skips the newest `keep`.
+#[must_use]
+fn prune_releases_shell(releases_dir: &str, keep: u32) -> String {
+    format!(
+        "cd {} && ls -1dt */ 2>/dev/null | tail -n +{} | xargs -r rm -rf",
+        shell_quote(releases_dir),
+        keep + 1,
+    )
+}
+
+/// Whether the target is a first deploy or a redeploy (and, if so, which slot is
+/// currently live).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeployMode {
+    /// No promoted `current` release yet — take the first-deploy path.
+    First,
+    /// A `current` release already exists — take the zero-downtime cutover path.
+    Redeploy {
+        /// Slot the currently-live release serves on.
+        live_slot: &'static str,
+    },
+}
+
+/// Probe the target over the executor to decide first-vs-redeploy: a redeploy is
+/// signalled by an existing `current` symlink, and the live slot is read from the
+/// marker (defaulting to blue if the marker is missing).
+///
+/// # Errors
+///
+/// Returns the executor's error if the probe command cannot run.
+pub fn detect_deploy_mode(
+    cfg: &ResolvedDeployConfig,
+    exec: &impl DeployExecutor,
+) -> Result<DeployMode, DeployExecError> {
+    let shell = format!(
+        "if [ -L {current} ]; then printf 'redeploy:'; cat {marker} 2>/dev/null || printf '{blue}'; \
+         else printf 'first'; fi",
+        current = shell_quote(&cfg.current_symlink()),
+        marker = shell_quote(&live_slot_marker(cfg)),
+        blue = SLOT_BLUE,
+    );
+    let out = exec.run(&RemoteCommand::new("detect-current", shell))?;
+    Ok(out
+        .stdout
+        .trim()
+        .strip_prefix("redeploy:")
+        .map_or(DeployMode::First, |slot| DeployMode::Redeploy {
+            live_slot: canonical_slot(slot),
+        }))
 }
 
 /// Build the bounded remote readiness-poll shell line: loop on
@@ -428,6 +754,25 @@ pub fn execute_first_deploy(
         return Err(DeployExecError::PreflightAborted { failed });
     }
     run_ops(ops, exec)
+}
+
+/// Execute a zero-downtime redeploy cutover sequence, gated on preflight exactly
+/// like [`execute_first_deploy`].
+///
+/// The safety of the cutover comes from [`run_ops`] stopping at the first
+/// failure: a failed migration or a readiness timeout returns before the proxy
+/// flip, leaving the old release serving (AC-2/AC-3). Auto-rollback is Slice 3.
+///
+/// # Errors
+///
+/// Returns [`DeployExecError::PreflightAborted`] when any preflight check failed,
+/// or the first executor error otherwise.
+pub fn execute_redeploy(
+    checks: &[PreflightCheck],
+    ops: &[DeployOp],
+    exec: &impl DeployExecutor,
+) -> Result<(), DeployExecError> {
+    execute_first_deploy(checks, ops, exec)
 }
 
 /// Drive an op sequence against an executor, stopping at the first failure.
@@ -593,6 +938,8 @@ mod tests {
         /// Labels whose `run` should return a scripted failure (e.g. to simulate
         /// a readiness-gate timeout).
         fail_labels: Vec<&'static str>,
+        /// Scripted stdout returned for a given command label.
+        stdout_by_label: Vec<(&'static str, String)>,
     }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -619,8 +966,35 @@ mod tests {
             }
         }
 
+        /// Script the stdout returned for a given command label (used to drive
+        /// [`detect_deploy_mode`]'s first-vs-redeploy probe).
+        fn with_stdout(mut self, label: &'static str, stdout: impl Into<String>) -> Self {
+            self.stdout_by_label.push((label, stdout.into()));
+            self
+        }
+
         fn calls(&self) -> Vec<RecordedCall> {
             self.calls.borrow().clone()
+        }
+
+        /// Labels of the recorded `Run` calls, in order (upload calls excluded).
+        fn run_labels(&self) -> Vec<&'static str> {
+            self.calls
+                .borrow()
+                .iter()
+                .filter_map(|c| match c {
+                    RecordedCall::Run { label, .. } => Some(*label),
+                    RecordedCall::Upload { .. } => None,
+                })
+                .collect()
+        }
+
+        /// The shell recorded for the first `Run` with `label`, if any.
+        fn shell_for(&self, label: &str) -> Option<String> {
+            self.calls.borrow().iter().find_map(|c| match c {
+                RecordedCall::Run { label: l, shell } if *l == label => Some(shell.clone()),
+                _ => None,
+            })
         }
     }
 
@@ -636,8 +1010,14 @@ mod tests {
                     message: "scripted failure".to_owned(),
                 });
             }
+            let stdout = self
+                .stdout_by_label
+                .iter()
+                .find(|(l, _)| *l == cmd.label)
+                .map(|(_, out)| out.clone())
+                .unwrap_or_default();
             Ok(CommandOutput {
-                stdout: String::new(),
+                stdout,
                 stderr: String::new(),
             })
         }
@@ -666,85 +1046,306 @@ mod tests {
         )
     }
 
+    const RELEASE_ID: &str = "20260714T120000Z";
+    const RELEASE_DIR: &str = "/srv/autumn/myapp/releases/20260714T120000Z";
+
+    fn proxy() -> super::super::proxy::KamalProxyController {
+        super::super::proxy::KamalProxyController::new(60)
+    }
+
+    /// First-deploy ops: initial release on the blue slot (loopback 3001) behind
+    /// the proxy on the public port 3000.
     fn sample_ops(env: Secret) -> Vec<DeployOp> {
         let cfg = resolved();
-        let unit = super::super::render_systemd_unit(&cfg);
+        let plan = SlotPlan::first(3000);
+        let unit = super::super::render_app_unit(
+            &cfg,
+            RELEASE_DIR,
+            plan.candidate_port,
+            plan.candidate_slot,
+        );
         first_deploy_ops(
             &cfg,
+            &proxy(),
             &unit,
             env,
             Path::new("/local/target/release/myapp"),
-            "20260714T120000Z",
-            3000,
+            RELEASE_ID,
+            &plan,
+        )
+    }
+
+    /// Redeploy cutover ops: the live release is on blue, so the candidate takes
+    /// green (loopback 3002).
+    fn sample_cutover_ops(env: Secret) -> Vec<DeployOp> {
+        let cfg = resolved();
+        let plan = SlotPlan::redeploy(3000, SLOT_BLUE);
+        let unit = super::super::render_app_unit(
+            &cfg,
+            RELEASE_DIR,
+            plan.candidate_port,
+            plan.candidate_slot,
+        );
+        cutover_ops(
+            &cfg,
+            &proxy(),
+            &unit,
+            env,
+            Path::new("/local/target/release/myapp"),
+            RELEASE_ID,
+            &plan,
         )
     }
 
     #[test]
-    fn first_deploy_produces_exact_ordered_sequence() {
+    fn first_deploy_installs_and_routes_proxy() {
         let ops = sample_ops(Secret::new("AUTUMN_SECURITY__SIGNING_SECRET=topsecret\n"));
         let exec = RecordingExecutor::new();
         run_ops(&ops, &exec).expect("recording executor never fails");
+        let labels = exec.run_labels();
 
-        let calls = exec.calls();
-        // mkdir → upload binary → write env → write unit → link current →
-        // daemon-reload → enable --now → readiness poll.
-        assert_eq!(calls.len(), 8, "unexpected call sequence: {calls:#?}");
+        // The proxy is installed (host-prep) and, once the app is ready, the
+        // proxy is routed at the initial release — so a later redeploy has a live
+        // upstream to flip away from.
+        let install = labels
+            .iter()
+            .position(|&l| l == "proxy-install")
+            .expect("proxy is installed on first deploy");
+        let route = labels
+            .iter()
+            .position(|&l| l == "proxy-route")
+            .expect("proxy is routed at the initial release");
+        let readiness = labels
+            .iter()
+            .position(|&l| l == "readiness-gate")
+            .expect("readiness gate");
+        assert!(install < route, "proxy is installed before it is routed");
+        assert!(
+            readiness < route,
+            "proxy is routed only after the app reports /ready"
+        );
 
+        // The proxy unit is written to the public port; the app unit is a
+        // slot-scoped unit on a SEPARATE loopback port (never the public port).
+        let proxy_unit = exec.shell_for("proxy-install").expect("proxy-install ran");
+        assert!(proxy_unit.contains("enable --now kamal-proxy.service"));
         assert!(
-            matches!(&calls[0], RecordedCall::Run { label: "prepare-dirs", shell }
-                if shell.contains("mkdir -p") && shell.contains("/srv/autumn/myapp/releases/20260714T120000Z")
-                    && shell.contains("/srv/autumn/myapp/shared")),
-            "call 0: {:?}",
-            calls[0]
+            exec.calls().iter().any(|c| matches!(
+                c,
+                RecordedCall::Upload { remote_path, .. }
+                    if remote_path == "/etc/systemd/system/kamal-proxy.service"
+            )),
+            "the proxy systemd unit is written"
         );
+        let enable = exec.shell_for("enable-now").expect("enable-now ran");
+        assert!(
+            enable.contains("myapp-blue.service"),
+            "the app runs as a slot-scoped unit: {enable}"
+        );
+        // Blue binds public+1 = 3001 (loopback), not the public 3000.
+        let gate = exec.shell_for("readiness-gate").expect("gate ran");
+        assert!(gate.contains("127.0.0.1:3001/ready"), "gate: {gate}");
+        let route_cmd = exec.shell_for("proxy-route").expect("route ran");
+        assert!(
+            route_cmd.contains("--target 127.0.0.1:3001"),
+            "proxy routes at the blue loopback port: {route_cmd}"
+        );
+    }
+
+    #[test]
+    fn redeploy_produces_exact_zero_downtime_sequence() {
+        let ops = sample_cutover_ops(Secret::new("AUTUMN_SECURITY__SIGNING_SECRET=topsecret\n"));
+        let exec = RecordingExecutor::new();
+        run_ops(&ops, &exec).expect("recording executor never fails");
+
+        // The full ordered run sequence (uploads interleave; asserted separately).
         assert_eq!(
-            calls[1],
-            RecordedCall::Upload {
-                remote_path: "/srv/autumn/myapp/releases/20260714T120000Z/myapp".to_owned(),
-                mode: Some(0o755),
-            },
-            "call 1 uploads the release binary (0755)"
+            exec.run_labels(),
+            vec![
+                "prepare-dirs",
+                "daemon-reload",
+                "start-candidate",
+                "migrate",
+                "readiness-gate",
+                "proxy-flip",
+                "link-current",
+                "record-live-slot",
+                "drain-old",
+                "prune",
+            ],
+            "unexpected cutover sequence"
         );
+
+        // The candidate's env (0600) and unit are written on a SEPARATE loopback
+        // port before it starts.
+        assert!(
+            exec.calls().iter().any(|c| matches!(
+                c,
+                RecordedCall::Upload { remote_path, mode }
+                    if remote_path == "/srv/autumn/myapp/shared/autumn.env" && *mode == Some(0o600)
+            )),
+            "candidate env written 0600"
+        );
+        assert!(
+            exec.calls().iter().any(|c| matches!(
+                c,
+                RecordedCall::Upload { remote_path, .. }
+                    if remote_path == "/etc/systemd/system/myapp-green.service"
+            )),
+            "candidate unit is the idle (green) slot"
+        );
+        // The candidate binds green = public+2 = 3002 and the flip targets it.
+        let gate = exec.shell_for("readiness-gate").expect("gate ran");
+        assert!(gate.contains("127.0.0.1:3002/ready"), "gate: {gate}");
+        let flip = exec.shell_for("proxy-flip").expect("flip ran");
+        assert!(
+            flip.contains("kamal-proxy deploy") && flip.contains("--target 127.0.0.1:3002"),
+            "flip targets the candidate: {flip}"
+        );
+        // The old (blue) release is drained; current is promoted to the new dir.
+        let drain = exec.shell_for("drain-old").expect("drain ran");
+        assert!(
+            drain.contains("disable --now myapp-blue.service"),
+            "{drain}"
+        );
+        let promote = exec.shell_for("link-current").expect("promote ran");
+        assert!(promote.contains(RELEASE_DIR) && promote.contains("/srv/autumn/myapp/current"));
+
+        // Ordering invariants: migrate BEFORE the flip; the flip ONLY after a
+        // passing readiness gate.
+        let labels = exec.run_labels();
+        let pos = |l: &str| labels.iter().position(|&x| x == l).unwrap();
+        assert!(pos("migrate") < pos("proxy-flip"), "migrate before flip");
+        assert!(
+            pos("readiness-gate") < pos("proxy-flip"),
+            "flip only after a passing readiness gate"
+        );
+        assert!(
+            pos("proxy-flip") < pos("link-current"),
+            "flip before promote"
+        );
+        assert!(
+            pos("link-current") < pos("drain-old"),
+            "promote before drain"
+        );
+        assert!(pos("drain-old") < pos("prune"), "drain before prune");
+    }
+
+    #[test]
+    fn failed_migration_aborts_before_cutover_leaving_old_serving() {
+        let ops = sample_cutover_ops(Secret::new("AUTUMN_SECURITY__SIGNING_SECRET=x\n"));
+        // The migrate one-shot fails (as a bad migration would on the host).
+        let exec = RecordingExecutor::failing_on("migrate");
+        let err = run_ops(&ops, &exec).expect_err("a failed migration must abort the deploy");
+        assert!(
+            matches!(
+                err,
+                DeployExecError::CommandFailed {
+                    label: "migrate",
+                    ..
+                }
+            ),
+            "expected a migrate CommandFailed, got {err:?}"
+        );
+        // AC-3: no cutover happened — no flip, no drain, no promote — so the old
+        // release is untouched and still serving.
+        let labels = exec.run_labels();
+        assert!(
+            !labels.contains(&"proxy-flip"),
+            "no flip after a failed migration"
+        );
+        assert!(!labels.contains(&"drain-old"), "old release not drained");
+        assert!(!labels.contains(&"link-current"), "current not repointed");
+        assert!(!labels.contains(&"prune"), "nothing pruned");
+    }
+
+    #[test]
+    fn readiness_timeout_before_cutover_does_not_flip() {
+        let ops = sample_cutover_ops(Secret::new("AUTUMN_SECURITY__SIGNING_SECRET=x\n"));
+        // The candidate never reports /ready within the window.
+        let exec = RecordingExecutor::failing_on("readiness-gate");
+        let err = run_ops(&ops, &exec).expect_err("a readiness timeout must abort the deploy");
+        assert!(
+            matches!(
+                err,
+                DeployExecError::CommandFailed {
+                    label: "readiness-gate",
+                    ..
+                }
+            ),
+            "expected a readiness-gate CommandFailed, got {err:?}"
+        );
+        // AC-2 safety: traffic never flips to an unhealthy candidate. Auto-rollback
+        // itself is Slice 3; here the old release simply keeps serving.
+        let labels = exec.run_labels();
+        assert!(
+            !labels.contains(&"proxy-flip"),
+            "no flip on readiness timeout"
+        );
+        assert!(!labels.contains(&"drain-old"), "old release not drained");
+        assert!(!labels.contains(&"link-current"), "current not repointed");
+    }
+
+    #[test]
+    fn prune_keeps_exactly_keep_releases() {
+        let cfg = resolved();
+        assert_eq!(cfg.keep_releases, 3, "default keep_releases");
+        let ops = sample_cutover_ops(Secret::new("AUTUMN_SECURITY__SIGNING_SECRET=x\n"));
+        let exec = RecordingExecutor::new();
+        run_ops(&ops, &exec).expect("run ok");
+        let prune = exec.shell_for("prune").expect("prune ran");
+        // `tail -n +4` keeps the newest 3 release dirs and deletes the rest.
+        assert!(
+            prune.contains("ls -1dt */") && prune.contains("tail -n +4"),
+            "prune must keep exactly keep_releases (3): {prune}"
+        );
+        assert!(
+            prune.contains("/srv/autumn/myapp/releases"),
+            "prune operates on the releases dir: {prune}"
+        );
+    }
+
+    #[test]
+    fn detect_deploy_mode_picks_first_vs_redeploy() {
+        let cfg = resolved();
+        // No `current` symlink → first deploy.
+        let first = RecordingExecutor::new().with_stdout("detect-current", "first");
+        assert_eq!(detect_deploy_mode(&cfg, &first).unwrap(), DeployMode::First);
+        // `current` present + marker says green → redeploy onto blue candidate.
+        let redeploy = RecordingExecutor::new().with_stdout("detect-current", "redeploy:green");
         assert_eq!(
-            calls[2],
-            RecordedCall::Upload {
-                remote_path: "/srv/autumn/myapp/shared/autumn.env".to_owned(),
-                mode: Some(0o600),
-            },
-            "call 2 writes the env file with mode 0600 (AC-5)"
+            detect_deploy_mode(&cfg, &redeploy).unwrap(),
+            DeployMode::Redeploy {
+                live_slot: SLOT_GREEN
+            }
         );
+        // A missing/blank marker on a redeploy defaults the live slot to blue.
+        let default_blue = RecordingExecutor::new().with_stdout("detect-current", "redeploy:");
         assert_eq!(
-            calls[3],
-            RecordedCall::Upload {
-                remote_path: "/etc/systemd/system/myapp.service".to_owned(),
-                mode: Some(0o644),
-            },
-            "call 3 writes the systemd unit"
+            detect_deploy_mode(&cfg, &default_blue).unwrap(),
+            DeployMode::Redeploy {
+                live_slot: SLOT_BLUE
+            }
         );
-        assert!(
-            matches!(&calls[4], RecordedCall::Run { label: "link-current", shell }
-                if shell.contains("ln -sfn") && shell.contains("/srv/autumn/myapp/current")),
-            "call 4: {:?}",
-            calls[4]
-        );
-        assert!(
-            matches!(&calls[5], RecordedCall::Run { label: "daemon-reload", shell }
-                if shell.contains("systemctl daemon-reload")),
-            "call 5: {:?}",
-            calls[5]
-        );
-        assert!(
-            matches!(&calls[6], RecordedCall::Run { label: "enable-now", shell }
-                if shell.contains("systemctl enable --now myapp.service")),
-            "call 6: {:?}",
-            calls[6]
-        );
-        assert!(
-            matches!(&calls[7], RecordedCall::Run { label: "readiness-gate", shell }
-                if shell.contains("/ready") && shell.contains("curl")),
-            "call 7: {:?}",
-            calls[7]
-        );
+    }
+
+    #[test]
+    fn slot_plan_puts_candidate_on_the_idle_slot() {
+        let plan = SlotPlan::redeploy(3000, SLOT_BLUE);
+        assert_eq!(plan.candidate_slot, SLOT_GREEN);
+        assert_eq!(plan.candidate_port, 3002);
+        assert_eq!(plan.live_slot, SLOT_BLUE);
+        assert_eq!(plan.live_port, 3001);
+        // The candidate never binds the public port.
+        assert_ne!(plan.candidate_port, plan.public_port);
+
+        let flipped = SlotPlan::redeploy(3000, SLOT_GREEN);
+        assert_eq!(flipped.candidate_slot, SLOT_BLUE);
+        assert_eq!(flipped.candidate_port, 3001);
+
+        let first = SlotPlan::first(3000);
+        assert_eq!(first.candidate_slot, SLOT_BLUE);
+        assert_eq!(first.candidate_port, 3001);
     }
 
     #[test]
@@ -873,7 +1474,8 @@ mod tests {
         let exec = RecordingExecutor::new();
         let checks = vec![PreflightCheck::pass("ssh_reachability", "reachable")];
         execute_first_deploy(&checks, &ops, &exec).expect("all checks pass → deploy runs");
-        assert_eq!(exec.calls().len(), 8, "the full op sequence should run");
+        // 2 proxy ops + 9 first-deploy ops + 1 proxy route = 12.
+        assert_eq!(exec.calls().len(), 12, "the full op sequence should run");
     }
 
     #[test]
@@ -893,8 +1495,11 @@ mod tests {
             ),
             "expected a readiness-gate CommandFailed, got {err:?}"
         );
-        // Everything up to and including the readiness gate ran (8 calls); no
-        // auto-rollback is attempted in this slice.
-        assert_eq!(exec.calls().len(), 8);
+        // The deploy stopped at the readiness gate: the proxy is never routed at
+        // an unhealthy first release (no auto-rollback in this slice).
+        assert!(
+            !exec.run_labels().contains(&"proxy-route"),
+            "proxy must not be routed after a failed readiness gate"
+        );
     }
 }

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -656,10 +656,14 @@ fn record_live_slot(cfg: &ResolvedDeployConfig, slot: &str) -> RemoteCommand {
 /// starting the server.
 fn release_migrate_command(cfg: &ResolvedDeployConfig, release_dir: &str) -> RemoteCommand {
     let bin = format!("{release_dir}/{}", cfg.app_name);
+    // Scope the transient unit to this release so overlapping deploys (or a prior
+    // run whose unit was not yet collected) never collide on "Unit already
+    // exists". The release id is the final path component of the release dir.
+    let release_id = release_dir.rsplit('/').next().unwrap_or(release_dir);
     RemoteCommand::new(
         "migrate",
         format!(
-            "systemd-run --wait --collect --quiet --unit={service}-migrate \
+            "systemd-run --wait --collect --quiet --unit={service}-migrate-{release_id} \
              --property=EnvironmentFile={env} --setenv=AUTUMN_MIGRATE=1 {bin}",
             service = cfg.service_name,
             env = shell_quote(&cfg.env_file()),
@@ -670,8 +674,12 @@ fn release_migrate_command(cfg: &ResolvedDeployConfig, release_dir: &str) -> Rem
 
 /// Prune shell: keep the newest `keep` release dirs, delete the rest. `ls -1dt`
 /// lists dirs newest-first; `tail -n +{keep+1}` skips the newest `keep`.
+///
+/// `keep` is clamped to at least 1: a `keep` of 0 would make `tail -n +1` list
+/// EVERY release — including the just-deployed active one — and `rm -rf` it.
 #[must_use]
 fn prune_releases_shell(releases_dir: &str, keep: u32) -> String {
+    let keep = keep.max(1);
     format!(
         "cd {} && ls -1dt */ 2>/dev/null | tail -n +{} | xargs -r rm -rf",
         shell_quote(releases_dir),
@@ -1147,7 +1155,7 @@ mod tests {
         assert!(gate.contains("127.0.0.1:3001/ready"), "gate: {gate}");
         let route_cmd = exec.shell_for("proxy-route").expect("route ran");
         assert!(
-            route_cmd.contains("--target 127.0.0.1:3001"),
+            route_cmd.contains("--target '127.0.0.1:3001'"),
             "proxy routes at the blue loopback port: {route_cmd}"
         );
     }
@@ -1199,7 +1207,7 @@ mod tests {
         assert!(gate.contains("127.0.0.1:3002/ready"), "gate: {gate}");
         let flip = exec.shell_for("proxy-flip").expect("flip ran");
         assert!(
-            flip.contains("kamal-proxy deploy") && flip.contains("--target 127.0.0.1:3002"),
+            flip.contains("kamal-proxy deploy") && flip.contains("--target '127.0.0.1:3002'"),
             "flip targets the candidate: {flip}"
         );
         // The old (blue) release is drained; current is promoted to the new dir.

--- a/autumn-cli/src/deploy/proxy.rs
+++ b/autumn-cli/src/deploy/proxy.rs
@@ -1,0 +1,235 @@
+//! Reverse-proxy control for zero-downtime cutover (issue #1607, Slice 2).
+//!
+//! The public port is fronted by a reverse proxy; each app release binds a
+//! PRIVATE loopback port. A redeploy stands the new release up on a *separate*
+//! loopback port, health-checks it, then asks the proxy to atomically swap live
+//! traffic from the old upstream to the new one and drain the old — this is the
+//! cutover.
+//!
+//! ## What is real here
+//!
+//! - The [`ProxyController`] trait names the three operations the cutover
+//!   orchestration needs — install the proxy, route it at an upstream (first
+//!   deploy), and health-gated flip to a new upstream (redeploy). Each returns
+//!   ordered [`DeployOp`]s that are driven over the injectable
+//!   [`DeployExecutor`](super::exec::DeployExecutor) by
+//!   [`run_ops`](super::exec::run_ops), so the exact remote command sequence is
+//!   unit-testable without a live host.
+//! - [`KamalProxyController`] keeps the exact `kamal-proxy` CLI invocations in
+//!   ONE place: install prepares a supervised `kamal-proxy run` on the public
+//!   port, and both the initial route and the health-gated flip are the same
+//!   `kamal-proxy deploy <service> --target host:port` command — kamal-proxy
+//!   blocks until the target passes its health check (pointed at the candidate's
+//!   `/ready`), then atomically swaps and drains the old target.
+//!
+//! ## Swapping the proxy later (Caddy)
+//!
+//! The proxy is CONFIRMED as kamal-proxy for this slice, but the boundary is
+//! drawn so a `CaddyController` could replace it without touching the cutover
+//! orchestration in [`super::exec`]: it would implement the same
+//! [`ProxyController`] trait with Caddy admin-API calls instead —
+//! `route`/`flip` become `POST`/`PATCH` against `/config/...` (a `curl` op to
+//! `http://127.0.0.1:2019/...`) and `ensure_installed` provisions the Caddy
+//! service. Nothing outside this module encodes a kamal-proxy-specific shape.
+//!
+//! ## What is deferred
+//!
+//! - The exact `kamal-proxy` binary provisioning (download/version pin) is left
+//!   to host bootstrap; [`KamalProxyController::ensure_installed_ops`] supervises
+//!   it via systemd and assumes the binary is on `PATH`/`/usr/local/bin`.
+//! - Live ssh is not exercised here (Slice 4's CI container harness).
+
+use super::exec::{DeployOp, FileContents, RemoteCommand, shell_quote};
+
+/// Absolute path the proxy binary is expected at on the target.
+const KAMAL_PROXY_BIN: &str = "/usr/local/bin/kamal-proxy";
+
+/// Systemd unit path supervising the proxy process.
+const KAMAL_PROXY_UNIT_PATH: &str = "/etc/systemd/system/kamal-proxy.service";
+
+/// Controls the reverse proxy that fronts the public port.
+///
+/// The methods return ordered [`DeployOp`]s (rather than driving the executor
+/// directly) so the proxy steps slot into the same recorded op sequence as the
+/// rest of the deploy — the health-gated swap ([`Self::flip_op`]) is the core of
+/// the cutover and must be assertable in-order against the recording fake.
+///
+/// A `CaddyController` is the swappable alternative (admin-API PATCH); see the
+/// [module docs](self).
+pub trait ProxyController {
+    /// Ordered ops that make the proxy installed and supervised on
+    /// `public_port` (idempotent — safe to run on every deploy).
+    fn ensure_installed_ops(&self, public_port: u16) -> Vec<DeployOp>;
+
+    /// Op that points `service`'s public port at `upstream` (`host:port`) for the
+    /// first time (first deploy — there is nothing to swap yet).
+    fn route_op(&self, service: &str, upstream: &str) -> DeployOp;
+
+    /// Op that health-gates the candidate at `new_upstream` and, once it passes,
+    /// atomically swaps live traffic to it and drains the old target. This is the
+    /// cutover.
+    fn flip_op(&self, service: &str, new_upstream: &str) -> DeployOp;
+}
+
+/// [`ProxyController`] backed by [kamal-proxy](https://github.com/basecamp/kamal-proxy).
+///
+/// The health-gated upstream swap is `kamal-proxy deploy`, which blocks until the
+/// target passes its health check before swapping — so a candidate that never
+/// reports `/ready` never receives live traffic.
+#[derive(Debug, Clone)]
+pub struct KamalProxyController {
+    /// Path kamal-proxy health-checks on the candidate before swapping.
+    health_check_path: String,
+    /// How long the flip waits for the candidate to become healthy.
+    deploy_timeout_secs: u64,
+    /// How long the old target is drained after the swap.
+    drain_timeout_secs: u64,
+}
+
+/// Default drain window for the old target after a swap.
+const DEFAULT_DRAIN_TIMEOUT_SECS: u64 = 30;
+
+impl KamalProxyController {
+    /// Build a controller whose flip health-check points at the candidate's
+    /// `/ready` and whose deploy timeout matches the deploy's readiness window.
+    #[must_use]
+    pub fn new(readiness_timeout_secs: u64) -> Self {
+        Self {
+            health_check_path: "/ready".to_owned(),
+            deploy_timeout_secs: readiness_timeout_secs,
+            drain_timeout_secs: DEFAULT_DRAIN_TIMEOUT_SECS,
+        }
+    }
+
+    /// The single `kamal-proxy deploy` invocation shared by the initial route and
+    /// the health-gated flip. Centralized so the exact CLI contract lives in one
+    /// place (a Caddy controller would replace THIS with an admin-API call).
+    fn deploy_shell(&self, service: &str, target: &str) -> String {
+        format!(
+            "kamal-proxy deploy {service} --target {target} \
+             --health-check-path {path} --deploy-timeout {deploy}s --drain-timeout {drain}s",
+            service = shell_quote(service),
+            target = target,
+            path = self.health_check_path,
+            deploy = self.deploy_timeout_secs,
+            drain = self.drain_timeout_secs,
+        )
+    }
+
+    /// Render the systemd unit that supervises `kamal-proxy run` on the public
+    /// port. Pure — exposed for unit assertions.
+    #[must_use]
+    pub fn render_proxy_unit(public_port: u16) -> String {
+        format!(
+            "[Unit]\n\
+             Description=kamal-proxy (Autumn deploy front)\n\
+             After=network-online.target\n\
+             Wants=network-online.target\n\
+             \n\
+             [Service]\n\
+             Type=simple\n\
+             ExecStart={KAMAL_PROXY_BIN} run --http-port {public_port}\n\
+             Restart=on-failure\n\
+             RestartSec=2\n\
+             \n\
+             [Install]\n\
+             WantedBy=multi-user.target\n",
+        )
+    }
+}
+
+impl ProxyController for KamalProxyController {
+    fn ensure_installed_ops(&self, public_port: u16) -> Vec<DeployOp> {
+        vec![
+            DeployOp::WriteFile {
+                label: "proxy-write-unit",
+                contents: FileContents::Plain(Self::render_proxy_unit(public_port)),
+                remote_path: KAMAL_PROXY_UNIT_PATH.to_owned(),
+                mode: Some(0o644),
+            },
+            DeployOp::Run(RemoteCommand::new(
+                "proxy-install",
+                "systemctl daemon-reload && systemctl enable --now kamal-proxy.service",
+            )),
+        ]
+    }
+
+    fn route_op(&self, service: &str, upstream: &str) -> DeployOp {
+        DeployOp::Run(RemoteCommand::new(
+            "proxy-route",
+            self.deploy_shell(service, upstream),
+        ))
+    }
+
+    fn flip_op(&self, service: &str, new_upstream: &str) -> DeployOp {
+        DeployOp::Run(RemoteCommand::new(
+            "proxy-flip",
+            self.deploy_shell(service, new_upstream),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kamal_proxy_flip_command_is_correct() {
+        let proxy = KamalProxyController::new(60);
+        let DeployOp::Run(cmd) = proxy.flip_op("myapp", "127.0.0.1:3002") else {
+            panic!("flip_op must be a Run op");
+        };
+        assert_eq!(cmd.label, "proxy-flip");
+        // Exact kamal-proxy CLI contract — the health check points at the
+        // candidate's /ready and the deploy timeout is the readiness window.
+        assert_eq!(
+            cmd.shell,
+            "kamal-proxy deploy 'myapp' --target 127.0.0.1:3002 \
+             --health-check-path /ready --deploy-timeout 60s --drain-timeout 30s",
+        );
+    }
+
+    #[test]
+    fn route_and_flip_share_the_same_kamal_deploy_contract() {
+        // For kamal-proxy the initial route and the health-gated flip are the
+        // same `kamal-proxy deploy` command (only the label differs); a Caddy
+        // controller is where they would diverge.
+        let proxy = KamalProxyController::new(45);
+        let (DeployOp::Run(route), DeployOp::Run(flip)) = (
+            proxy.route_op("svc", "127.0.0.1:9001"),
+            proxy.flip_op("svc", "127.0.0.1:9001"),
+        ) else {
+            panic!("route/flip must be Run ops");
+        };
+        assert_eq!(route.label, "proxy-route");
+        assert_eq!(flip.label, "proxy-flip");
+        assert_eq!(route.shell, flip.shell);
+        assert!(flip.shell.contains("--deploy-timeout 45s"));
+    }
+
+    #[test]
+    fn ensure_installed_supervises_proxy_on_public_port() {
+        let proxy = KamalProxyController::new(60);
+        let ops = proxy.ensure_installed_ops(8080);
+        assert_eq!(ops.len(), 2);
+        // First writes the proxy systemd unit bound to the public port…
+        match &ops[0] {
+            DeployOp::WriteFile {
+                label,
+                contents,
+                remote_path,
+                ..
+            } => {
+                assert_eq!(*label, "proxy-write-unit");
+                assert_eq!(remote_path, KAMAL_PROXY_UNIT_PATH);
+                let FileContents::Plain(unit) = contents else {
+                    panic!("proxy unit must be plain text");
+                };
+                assert!(unit.contains("kamal-proxy run --http-port 8080"));
+            }
+            other => panic!("op 0 should write the proxy unit, got {other:?}"),
+        }
+        // …then daemon-reloads and enables it.
+        assert_eq!(ops[1].label(), "proxy-install");
+    }
+}

--- a/autumn-cli/src/deploy/proxy.rs
+++ b/autumn-cli/src/deploy/proxy.rs
@@ -105,12 +105,15 @@ impl KamalProxyController {
     /// the health-gated flip. Centralized so the exact CLI contract lives in one
     /// place (a Caddy controller would replace THIS with an admin-API call).
     fn deploy_shell(&self, service: &str, target: &str) -> String {
+        // Every string parameter is shell-quoted so a service name, upstream, or
+        // health-check path carrying query params / special chars can't break out
+        // of the command. The numeric timeouts need no quoting.
         format!(
             "kamal-proxy deploy {service} --target {target} \
              --health-check-path {path} --deploy-timeout {deploy}s --drain-timeout {drain}s",
             service = shell_quote(service),
-            target = target,
-            path = self.health_check_path,
+            target = shell_quote(target),
+            path = shell_quote(&self.health_check_path),
             deploy = self.deploy_timeout_secs,
             drain = self.drain_timeout_secs,
         )
@@ -184,8 +187,8 @@ mod tests {
         // candidate's /ready and the deploy timeout is the readiness window.
         assert_eq!(
             cmd.shell,
-            "kamal-proxy deploy 'myapp' --target 127.0.0.1:3002 \
-             --health-check-path /ready --deploy-timeout 60s --drain-timeout 30s",
+            "kamal-proxy deploy 'myapp' --target '127.0.0.1:3002' \
+             --health-check-path '/ready' --deploy-timeout 60s --drain-timeout 30s",
         );
     }
 

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -2682,6 +2682,19 @@ impl AppBuilder {
             return;
         }
 
+        // ── Migrate one-shot mode ──────────────────────────────────────
+        // When AUTUMN_MIGRATE=1, apply pending embedded migrations to the
+        // configured database(s) and EXIT — never start the HTTP server or bind
+        // a port. Triggered by `autumn deploy`'s redeploy cutover, which runs
+        // migrations BEFORE flipping traffic (issue #1607): a non-zero exit here
+        // aborts the deploy with the old release still serving (AC-3). Unlike the
+        // startup auto-migration path it applies regardless of profile, because
+        // the deploy invokes it explicitly.
+        if is_migrate_only_mode() {
+            self.run_migrate_only_mode().await;
+            return;
+        }
+
         let Self {
             routes,
             api_versions,
@@ -4838,6 +4851,107 @@ impl AppBuilder {
         std::process::exit(0);
     }
 
+    /// Apply pending embedded migrations and exit (the `AUTUMN_MIGRATE=1`
+    /// one-shot), WITHOUT starting the HTTP server or binding a port.
+    ///
+    /// Reuses the exact applier the startup auto-migration path uses
+    /// ([`run_pending_locked`](crate::migrate::run_pending_locked), the public
+    /// wrapper over the same locked engine `auto_migrate` drives) and the same
+    /// framework-migration fold ([`migrations_with_repository_framework_migrations`]),
+    /// so the applied set matches a normal boot. Unlike that path it applies
+    /// regardless of profile — the deploy invokes it explicitly — and it targets
+    /// the writable primary(ies) only (control primary + each shard primary),
+    /// exactly like `autumn migrate` / the deploy DB preflight; replicas are never
+    /// migration targets. The framework-internal directory / shard-map guard
+    /// tables are deliberately NOT applied here: the app applies them
+    /// unconditionally at startup, so the candidate's own boot creates them.
+    ///
+    /// Exits 0 after applying (printing a redacted count — never a URL or secret)
+    /// and 1 on the first failure, so a failed migration aborts the deploy before
+    /// cutover with the old release still serving (AC-3).
+    #[cfg(feature = "db")]
+    async fn run_migrate_only_mode(self) {
+        let Self {
+            migrations,
+            config_loader_factory,
+            telemetry_provider,
+            ..
+        } = self;
+
+        // The telemetry guard is dropped at end of scope; a migrate-only run does
+        // not need tracing wired, but loading config the same way keeps env/profile
+        // resolution identical to a normal boot.
+        let (config, _telemetry_guard) =
+            load_config_and_telemetry(config_loader_factory, telemetry_provider).await;
+
+        // Fold in the framework migration sets a normal boot would apply, using the
+        // SAME helper as `setup_database`, so the applied set is identical.
+        let migrations = migrations_with_repository_framework_migrations(
+            migrations,
+            crate::repository_commit_hooks::has_repository_commit_hook_descriptors(),
+            crate::version_history::has_versioned_repository_descriptors(),
+            RepositoryCommitHookQueueMigrationMode::Runtime,
+        );
+
+        // Writable targets only: the control primary, then each shard primary.
+        let control_url = config.database.effective_primary_url().map(str::to_owned);
+        let shard_targets: Vec<(String, String)> = config
+            .database
+            .shards
+            .iter()
+            .map(|shard| (format!("shard:{}", shard.name), shard.primary_url.clone()))
+            .collect();
+
+        if migrations.is_empty() || (control_url.is_none() && shard_targets.is_empty()) {
+            eprintln!(
+                "autumn migrate: no database configured or no migrations registered — nothing to apply"
+            );
+            std::process::exit(0);
+        }
+
+        // The diesel harness and the advisory-lock poll block, so apply off the
+        // Tokio worker threads. Each target's failure exits non-zero from inside.
+        let applied_total = tokio::task::spawn_blocking(move || {
+            let mut total = 0_usize;
+            if let Some(url) = &control_url {
+                for mig in &migrations {
+                    total += apply_pending_or_exit(url, mig, "control");
+                }
+            }
+            // Shards hold tenant data, not the control-plane schema; skip the
+            // control framework set for shard targets (mirrors `run_startup_migrations`).
+            for (label, url) in &shard_targets {
+                for mig in migrations
+                    .iter()
+                    .filter(|mig| !migration_set_is_control_framework(mig))
+                {
+                    total += apply_pending_or_exit(url, mig, label);
+                }
+            }
+            total
+        })
+        .await
+        .unwrap_or_else(|error| {
+            eprintln!("autumn migrate: migration task panicked: {error}");
+            std::process::exit(1);
+        });
+
+        eprintln!(
+            "autumn migrate: applied {applied_total} pending migration(s); database is up to date"
+        );
+        std::process::exit(0);
+    }
+
+    /// The `AUTUMN_MIGRATE=1` one-shot on a build compiled WITHOUT database
+    /// support: there is nothing to migrate, so report and exit 0 (never starting
+    /// the server) so a DB-free app's deploy still runs the step harmlessly.
+    #[cfg(not(feature = "db"))]
+    #[allow(clippy::unused_async)]
+    async fn run_migrate_only_mode(self) {
+        eprintln!("autumn migrate: this build has no database support — nothing to migrate");
+        std::process::exit(0);
+    }
+
     /// Run a registered one-off task with full application context and exit.
     ///
     /// Triggered by `AUTUMN_RUN_TASK=<name>` from `autumn task <name>`.
@@ -5221,6 +5335,14 @@ pub(crate) fn is_dump_jobs_mode() -> bool {
 
 pub(crate) fn is_list_one_off_tasks_mode() -> bool {
     std::env::var("AUTUMN_LIST_TASKS").as_deref() == Ok("1")
+}
+
+/// Whether `AUTUMN_MIGRATE=1` requests the migrate-only one-shot: apply pending
+/// embedded migrations and exit without starting the HTTP server. Set by
+/// `autumn deploy`'s redeploy cutover (issue #1607) so migrations land before
+/// traffic is flipped to the new release.
+pub(crate) fn is_migrate_only_mode() -> bool {
+    std::env::var("AUTUMN_MIGRATE").as_deref() == Ok("1")
 }
 
 fn one_off_task_name_from_env() -> Option<String> {
@@ -7169,6 +7291,45 @@ async fn setup_database(
 /// `run_pending_locked` polls with `std::thread::sleep` (up to 60 s under
 /// contention), so the whole sequence runs off the Tokio worker threads in
 /// one blocking task that owns the embedded migration sets.
+/// Apply pending migrations for one target in the `AUTUMN_MIGRATE=1` one-shot,
+/// returning the number applied — or exiting non-zero on failure.
+///
+/// Uses the same locked applier the startup path uses
+/// ([`run_pending_locked`](crate::migrate::run_pending_locked)). Failure messages
+/// are REDACTED to a value-free reason plus the target label (`control` /
+/// `shard:<name>`): the underlying [`MigrationError`](crate::migrate::MigrationError)
+/// can wrap a driver string that embeds the connection URL, and the deploy path
+/// must never print a DB URL or secret.
+#[cfg(feature = "db")]
+fn apply_pending_or_exit(
+    database_url: &str,
+    migrations: &crate::migrate::EmbeddedMigrations,
+    target: &str,
+) -> usize {
+    match crate::migrate::run_pending_locked(
+        database_url,
+        crate::migrate::EmbeddedMigrationsRef(migrations),
+        None,
+    ) {
+        Ok(result) => result.applied.len(),
+        Err(error) => {
+            let reason = match error {
+                crate::migrate::MigrationError::Connection(_) => {
+                    "could not connect to the database"
+                }
+                crate::migrate::MigrationError::Migration(_) => "a migration failed to apply",
+                _ => "migration error",
+            };
+            eprintln!("autumn migrate: {reason} (target {target})");
+            // `process::exit` skips `on_shutdown`/`Drop`; stop any managed
+            // Postgres child first so a failure doesn't orphan the data dir/port.
+            #[cfg(feature = "managed-pg")]
+            crate::managed_pg::emergency_stop();
+            std::process::exit(1);
+        }
+    }
+}
+
 #[cfg(feature = "db")]
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 async fn run_startup_migrations(
@@ -9298,6 +9459,81 @@ mod tests {
         assert!(
             state_initializer < router_build,
             "static builds must install state-initialized resources before rendering routes"
+        );
+    }
+
+    #[test]
+    fn migrate_only_one_shot_applies_and_exits_without_serving() {
+        // The runtime effect (applying against Postgres, exiting without binding a
+        // port) needs a DB + a subprocess harness because `run()` ends in
+        // `process::exit`; that live apply is exercised by the shared
+        // `run_pending_locked` engine's own DB-backed tests. Here we lock the
+        // *dispatch decision* and the *reuse/exit contract* structurally: with
+        // AUTUMN_MIGRATE=1 the migrate-and-exit path is chosen and the
+        // server-start path is NOT taken.
+        let source = include_str!("app.rs").replace("\r\n", "\n");
+        let run_start = source.find("pub async fn run(self)").expect("run() exists");
+        let run_end = source
+            .find("async fn run_build_mode(self)")
+            .expect("build mode follows run()");
+        let run_body = &source[run_start..run_end];
+
+        // The AUTUMN_MIGRATE=1 dispatch is an early one-shot: it sits BEFORE the
+        // server-start machinery (the `let Self {` destructure that begins the
+        // serving path) and returns, so a migrate run never binds a port.
+        let dispatch = run_body
+            .find("if is_migrate_only_mode() {")
+            .expect("run() dispatches the migrate one-shot");
+        let server_start = run_body
+            .find("let Self {")
+            .expect("run() destructures self to start the server");
+        assert!(
+            dispatch < server_start,
+            "AUTUMN_MIGRATE must be handled before the server-start path"
+        );
+        let migrate_branch = &run_body[dispatch..server_start];
+        assert!(
+            migrate_branch.contains("self.run_migrate_only_mode().await;")
+                && migrate_branch.contains("return;"),
+            "the migrate one-shot must run then return before server start"
+        );
+
+        // The handler applies per target and exits — never starting the server.
+        let handler_start = source
+            .find("async fn run_migrate_only_mode(self)")
+            .expect("migrate handler exists");
+        let handler_end = source
+            .find("async fn run_one_off_task_mode(self, requested_name: String)")
+            .expect("one-off task handler follows the migrate handler");
+        let handler = &source[handler_start..handler_end];
+        assert!(
+            handler.contains("apply_pending_or_exit"),
+            "the migrate handler applies pending migrations per target"
+        );
+        assert!(
+            handler.contains("std::process::exit(0)"),
+            "the migrate handler exits after applying"
+        );
+        assert!(
+            !handler.contains("initialize_job_runtime")
+                && !handler.contains("try_build_router_inner"),
+            "the migrate one-shot must not start the server"
+        );
+
+        // The per-target applier reuses `run_pending_locked` (the exact engine
+        // `auto_migrate` drives — no duplicated migration logic) and exits
+        // non-zero on failure so a bad migration aborts before cutover (AC-3).
+        let helper_start = source
+            .find("fn apply_pending_or_exit(")
+            .expect("apply_pending_or_exit exists");
+        let helper = &source[helper_start..helper_start + 1200];
+        assert!(
+            helper.contains("crate::migrate::run_pending_locked("),
+            "must reuse the shared locked applier, not duplicate migration logic"
+        );
+        assert!(
+            helper.contains("std::process::exit(1)"),
+            "a failed migration must exit non-zero (abort before cutover)"
         );
     }
 


### PR DESCRIPTION
## Slice 2 of the #1607 deploy execution work
Builds on the merged Slice 1 (#1912). Realizes the deploy plan's **cutover** as live execution: a zero-downtime redeploy with a health-gated reverse-proxy upstream flip and migrate-before-cutover.

**Before:** `autumn deploy up` (Slice 1) did a real first deploy but had no cutover — a redeploy just re-ran the first-deploy path with a brief restart.
**After:** on a host that already has a release, `deploy up` runs the new release as a candidate on an idle blue/green loopback slot **beside** the old one, applies pending migrations, gates on the candidate's `/ready`, flips the proxy upstream old→candidate, promotes `current`, drains the old release, and prunes to `keep_releases` — no dropped requests.

### How
- **ProxyController** trait + **KamalProxyController** (`autumn-cli/src/deploy/proxy.rs`): drives kamal-proxy's health-gated atomic upstream swap (`kamal-proxy deploy … --health-check-path /ready`). kamal-proxy is installed on the target during host prep — it's a **target-host binary, not a cargo/build dependency**. Caddy (admin-API PATCH) is documented as the swappable alternative behind the same trait.
- **Blue/green slots**: the proxy owns the public port; releases bind private loopback ports (public+1 / public+2). The candidate always takes the slot the live release isn't using, so old + candidate run side-by-side; the candidate never binds the live port.
- **Migrate-before-cutover (AC-3):** a new `AUTUMN_MIGRATE=1` app one-shot applies pending embedded migrations via the *same* `run_pending_locked` engine a normal boot uses, then exits without starting the server (secrets via the systemd EnvironmentFile, redacted in output). A failed migration aborts **before** the flip — old release still serving.
- `deploy up` now probes for an existing `current` release to dispatch first-deploy vs redeploy-cutover; first deploy installs + routes the proxy so redeploys have a live upstream to flip.

### Scope — deferred to later slices
- **Rollback execution / auto-rollback** on a failed gate (Slice 3) — a failed migrate or readiness timeout here fails loudly with the old release still serving; automatic re-pointing is next.
- **Real ssh e2e** — the recording-fake unit tests prove the exact ordered remote command sequence (incl. the kamal-proxy and `systemd-run` migrate invocations); the live ssh path is exercised by the CI container harness (Slice 4).
- **Caddy** ProxyController impl (kamal-proxy is the chosen component; Caddy is only documented).

### Verification (targeted `-p` builds; full-workspace test skipped for the ~17GB trybuild ENOSPC risk; clippy run with CI's 1.97 toolchain)
| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo +1.97.0 clippy --workspace --all-targets -- -D warnings` | clean (CI-matching clippy) |
| `cargo test -p autumn-web --lib` | 3800 passed, 0 failed |
| `cargo test -p autumn-cli --test cli_tests` | 194 passed, 0 failed, 30 ignored |
| `cargo test -p autumn-cli --bin autumn` | 3791 passed, 0 failed |

New unit tests (recording fake): exact zero-downtime ordered sequence (migrate<flip, readiness<flip, flip<promote<drain<prune); failed-migration-aborts-before-cutover-leaving-old-serving; readiness-timeout-does-not-flip; first-deploy-installs-and-routes-proxy; exact kamal-proxy flip command; prune keeps keep_releases; plus an app-side test that AUTUMN_MIGRATE=1 dispatches to migrate-and-exit (never starts the server).

Part of #1607. No new dependencies. No CHANGELOG/skills/version changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_014ee9hUf7PA7p4SYdWNk8AU)_