### PR TITLE
fix(cli): module-qualify lifecycle diagram ids so same-named enums don't collide

### DIFF
--- a/autumn-cli/src/lifecycle.rs
+++ b/autumn-cli/src/lifecycle.rs
@@ -197,7 +197,11 @@ impl Parse for LifecycleArgs {
 /// declaration order), and the parsed `#[lifecycle]` metadata.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LifecycleDef {
-    /// Enum identifier (e.g. `OrderState`).
+    /// Module-qualified identity (e.g. `orders::State`), unique across the scan.
+    /// Used to namespace diagram cluster/node ids so two same-named enums in
+    /// separate modules never collide. Equals `name` for a top-level enum.
+    pub id: String,
+    /// Enum identifier (e.g. `OrderState`) — the human-readable label.
     pub name: String,
     /// Declared variants, in enum declaration order.
     pub states: Vec<String>,
@@ -517,7 +521,8 @@ fn scan_source(src: &str, file: &str, scan: &mut Scan) {
     // with an empty inherited set; each module extends it with its own renames
     // (see `scan_items`) and passes that extended set only to its descendants, so
     // a `use` inside a child module never leaks to a parent or sibling module.
-    scan_items(&ast.items, file, scan, &BTreeSet::new());
+    let mut module_path = Vec::new();
+    scan_items(&ast.items, file, scan, &BTreeSet::new(), &mut module_path);
 }
 
 /// Walk a `use` tree, recording the rename target of any `lifecycle as <alias>`.
@@ -556,6 +561,7 @@ fn scan_items(
     file: &str,
     scan: &mut Scan,
     inherited_aliases: &BTreeSet<String>,
+    module_path: &mut Vec<String>,
 ) {
     // A `use` is visible throughout its module regardless of textual position, so
     // gather this module's own lifecycle renames before scanning any enum here.
@@ -568,11 +574,19 @@ fn scan_items(
     for item in items {
         match item {
             syn::Item::Enum(item_enum) => {
-                collect_lifecycle_enum(item_enum, file, scan, &local_aliases);
+                collect_lifecycle_enum(
+                    item_enum,
+                    file,
+                    scan,
+                    &local_aliases,
+                    module_path.as_slice(),
+                );
             }
             syn::Item::Mod(item_mod) => {
                 if let Some((_, inner)) = &item_mod.content {
-                    scan_items(inner, file, scan, &local_aliases);
+                    module_path.push(item_mod.ident.to_string());
+                    scan_items(inner, file, scan, &local_aliases, module_path);
+                    module_path.pop();
                 }
             }
             _ => {}
@@ -592,6 +606,7 @@ fn collect_lifecycle_enum(
     file: &str,
     scan: &mut Scan,
     aliases: &BTreeSet<String>,
+    module_path: &[String],
 ) {
     // Recognize the attribute as `#[lifecycle]` when it is:
     //  - a single-segment path `lifecycle`, or a same-file alias of it
@@ -612,12 +627,18 @@ fn collect_lifecycle_enum(
     let name = item_enum.ident.to_string();
     match attr.parse_args::<LifecycleArgs>() {
         Ok(args) => {
+            let id = if module_path.is_empty() {
+                name.clone()
+            } else {
+                format!("{}::{}", module_path.join("::"), name)
+            };
             let states = item_enum
                 .variants
                 .iter()
                 .map(|v| v.ident.to_string())
                 .collect();
             scan.lifecycles.push(LifecycleDef {
+                id,
                 name,
                 states,
                 initial: args.initial.to_string(),
@@ -795,7 +816,7 @@ fn render_mermaid_document(lifecycles: &[LifecycleDef]) -> String {
     let mut out = String::new();
     out.push_str("stateDiagram-v2\n");
     for wf in lifecycles {
-        let ns = sanitize_ident(&wf.name);
+        let ns = sanitize_ident(&wf.id);
         let sid = |state: &str| format!("{ns}_{}", sanitize_ident(state));
         let _ = writeln!(out, "    state \"{}\" as {ns} {{", wf.name);
         for state in &wf.states {
@@ -858,7 +879,7 @@ fn render_dot_document(lifecycles: &[LifecycleDef]) -> String {
 /// global namespace, so an un-namespaced state shared across lifecycles would
 /// collapse into one node), and each carries a `label` of its bare state name.
 fn write_dot_cluster(out: &mut String, wf: &LifecycleDef) {
-    let ns = sanitize_ident(&wf.name);
+    let ns = sanitize_ident(&wf.id);
     let nid = |state: &str| dot_id(&format!("{ns}.{state}"));
     let start = dot_id(&format!("{ns}.__start"));
     let _ = writeln!(out, "    subgraph cluster_{ns} {{");

--- a/autumn-cli/tests/integration/lifecycle_check.rs
+++ b/autumn-cli/tests/integration/lifecycle_check.rs
@@ -645,3 +645,78 @@ pub enum PostState {
         "the DOT document must have balanced braces\n{stdout}"
     );
 }
+
+#[test]
+fn dot_diagram_same_named_enums_in_separate_modules_do_not_collide() {
+    // Two lifecycle enums with the SAME identifier (`State`) declared in two
+    // separate modules must be namespaced by their module-qualified id, so their
+    // clusters and nodes stay distinct instead of merging under a shared
+    // `cluster_State`.
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "src/domain.rs",
+        r"
+mod orders {
+    #[lifecycle(
+        initial = Open,
+        terminal(Closed),
+        transitions(
+            Open -> Closed,
+        )
+    )]
+    pub enum State {
+        Open,
+        Closed,
+    }
+}
+
+mod invoices {
+    #[lifecycle(
+        initial = Draft,
+        terminal(Paid),
+        transitions(
+            Draft -> Paid,
+        )
+    )]
+    pub enum State {
+        Draft,
+        Paid,
+    }
+}
+",
+    );
+    let output = run_lifecycle(dir.path(), &["diagram", "--format", "dot"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "dot render of same-named lifecycles should exit 0\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        stdout.matches("digraph").count(),
+        1,
+        "multiple lifecycles must be one single digraph document\n{stdout}"
+    );
+    assert_eq!(
+        stdout.matches("subgraph cluster_").count(),
+        2,
+        "each lifecycle should be its own cluster subgraph\n{stdout}"
+    );
+    // The module-qualified id `orders::State` sanitizes to `orders__State`
+    // (`::` -> `__`), so the two clusters get DISTINCT ids and never collapse
+    // into a shared `cluster_State`.
+    assert!(
+        stdout.contains("cluster_orders__State"),
+        "the orders lifecycle should be namespaced by its module\n{stdout}"
+    );
+    assert!(
+        stdout.contains("cluster_invoices__State"),
+        "the invoices lifecycle should be namespaced by its module\n{stdout}"
+    );
+    // Their state nodes are namespaced apart, so no id is shared between them.
+    assert!(
+        stdout.contains("\"orders__State.Open\"") && stdout.contains("\"invoices__State.Draft\""),
+        "state nodes must be namespaced by module-qualified id\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Before / After
**Before:** running `autumn lifecycle diagram` on a project with two `#[lifecycle]` enums that share an identifier in different modules (e.g. `orders::State` and `invoices::State`) rendered them as one merged state machine — both were namespaced as `cluster_State`, so their nodes collided and merged.
**After:** each lifecycle carries a module-qualified id (`orders::State`), so the DOT and Mermaid renderers namespace them apart (`cluster_orders__State`, `cluster_invoices__State`) while still labelling each with its bare enum name.

## How
- `LifecycleDef` gains an `id` field (module-qualified identity); `name` stays the human-readable label.
- `scan_items` / `collect_lifecycle_enum` thread the module path through the recursive source walk and build the qualified id.
- The multi-lifecycle DOT (`write_dot_cluster`) and Mermaid (`render_mermaid_document`) renderers namespace by `id` instead of `name`; labels are unchanged. Check text/JSON output and single-lifecycle rendering are untouched.
- New CLI test `dot_diagram_same_named_enums_in_separate_modules_do_not_collide` asserts a single `digraph` with two distinct `cluster_orders__State` / `cluster_invoices__State` blocks and non-colliding nodes.

Follow-up to #1916 / Part of #1675 — fixes the diagram id collision flagged in #1916's Codex review.

Local gates green: `cargo fmt --all -- --check`, `cargo test -p autumn-cli --test cli_tests -- lifecycle_check` (15 passed), `cargo clippy -p autumn-cli --bin autumn -- -D warnings`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KytTiM2yVuGkHCnxparS2h)_