### PR TITLE
feat(cli): wire state-machine transitions into the generated scaffold

### DIFF
--- a/autumn-cli/src/generate/dsl.rs
+++ b/autumn-cli/src/generate/dsl.rs
@@ -42,6 +42,32 @@ impl FieldConstraints {
     }
 }
 
+/// A single allowed edge in a field's state machine (issue #1326).
+///
+/// Mirrors the `from -> to[: guard]` grammar the `#[state_machine(transitions(…))]`
+/// attribute macro accepts (see `autumn-macros`): `from`/`to` are bare state
+/// identifiers and `guard`, when present, is the plain name of a `&self -> bool`
+/// method that must return `true` for the edge to be taken.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StateTransition {
+    /// The state this edge starts from.
+    pub from: String,
+    /// The state this edge ends at.
+    pub to: String,
+    /// Optional guard: the name of a `&self` bool method gating the edge.
+    pub guard: Option<String>,
+}
+
+/// The parsed state machine declared on a field via the DSL's trailing
+/// `:states(…)` modifier (issue #1326). Carries the ordered set of allowed
+/// [`StateTransition`] edges, which the model generator re-emits as a
+/// `#[state_machine(transitions(…))]` attribute on the field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StateMachine {
+    /// The allowed transitions, in declaration order.
+    pub transitions: Vec<StateTransition>,
+}
+
 /// A single field parsed from the command line.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Field {
@@ -63,6 +89,11 @@ pub struct Field {
     /// Constraint modifiers from a trailing `{…}` block (issue #1388 /
     /// #1146). Empty ([`FieldConstraints::is_empty`]) for a bare `name:Type`.
     pub constraints: FieldConstraints,
+    /// The state machine declared via a trailing `:states(…)` modifier
+    /// (issue #1326), or `None` for an ordinary field. Only valid on a
+    /// non-nullable `String`/`Text` field — the model generator re-emits it
+    /// as a `#[state_machine(transitions(…))]` attribute.
+    pub state_machine: Option<StateMachine>,
 }
 
 impl Field {
@@ -500,6 +531,23 @@ pub fn parse_field(token: &str) -> Result<Field, GenerateError> {
     // the colon inside the braces — stays unambiguous. Any other stray
     // colon outside the braces is caught as an unknown modifier below.
     let rest = rest.trim();
+    // Peel a trailing `:states(from -> to, …)` state-machine modifier (issue
+    // #1326) *before* the `:unique` split below, so its internal `->`, `,`,
+    // and guard `:` tokens are never mistaken for a `:unique` suffix. The
+    // clause is paren-delimited (like the `{…}` constraint block is
+    // brace-delimited), so it stays unambiguous against the other modifiers.
+    let (rest, state_machine_body) = split_state_machine_modifier(rest);
+    let state_machine = match state_machine_body {
+        Some(body) => {
+            Some(
+                parse_state_machine(body).map_err(|reason| GenerateError::InvalidField {
+                    token: token.to_owned(),
+                    reason,
+                })?,
+            )
+        }
+        None => None,
+    };
     let (ty, unique) = match rest.rsplit_once(':') {
         // A trailing `:unique` (whitespace-tolerant) is the UNIQUE-index
         // modifier. Its colon is always the last one — a `references`
@@ -537,6 +585,12 @@ pub fn parse_field(token: &str) -> Result<Field, GenerateError> {
             reason,
         })?
     {
+        if state_machine.is_some() {
+            return Err(GenerateError::InvalidField {
+                token: token.to_owned(),
+                reason: STATE_MACHINE_STRING_ONLY.to_owned(),
+            });
+        }
         return Ok(Field {
             name: name.to_owned(),
             kind: FieldKind::Enum,
@@ -544,6 +598,7 @@ pub fn parse_field(token: &str) -> Result<Field, GenerateError> {
             variants,
             unique,
             constraints: FieldConstraints::default(),
+            state_machine: None,
         });
     }
 
@@ -553,6 +608,12 @@ pub fn parse_field(token: &str) -> Result<Field, GenerateError> {
             reason,
         })?
     {
+        if state_machine.is_some() {
+            return Err(GenerateError::InvalidField {
+                token: token.to_owned(),
+                reason: STATE_MACHINE_STRING_ONLY.to_owned(),
+            });
+        }
         return Ok(Field {
             name: name.to_owned(),
             kind: FieldKind::Decimal { precision, scale },
@@ -560,6 +621,7 @@ pub fn parse_field(token: &str) -> Result<Field, GenerateError> {
             variants: Vec::new(),
             unique,
             constraints: FieldConstraints::default(),
+            state_machine: None,
         });
     }
 
@@ -611,6 +673,19 @@ pub fn parse_field(token: &str) -> Result<Field, GenerateError> {
         None => FieldConstraints::default(),
     };
 
+    // A state machine (issue #1326) is only meaningful on a plain, non-nullable
+    // `String`/`Text` column — the `#[state_machine]` macro requires the field's
+    // Rust type to be exactly `String`, and the generated `transition_*` methods
+    // operate on `&str`. Reject it anywhere else with a clear message rather than
+    // emitting an attribute the macro will refuse to compile.
+    if state_machine.is_some() && (nullable || !matches!(kind, FieldKind::String | FieldKind::Text))
+    {
+        return Err(GenerateError::InvalidField {
+            token: token.to_owned(),
+            reason: STATE_MACHINE_STRING_ONLY.to_owned(),
+        });
+    }
+
     // `references` fields always end in `_id` — `post:references` resolves to
     // the column `post_id`. Tolerate an already-suffixed name (`post_id:references`)
     // rather than doubling the suffix.
@@ -627,6 +702,7 @@ pub fn parse_field(token: &str) -> Result<Field, GenerateError> {
         variants: Vec::new(),
         unique,
         constraints,
+        state_machine,
     })
 }
 
@@ -645,6 +721,96 @@ fn split_constraint_modifier(ty: &str) -> (&str, Option<&str>) {
         }
     }
     (ty, None)
+}
+
+/// The single error message used when a `:states(…)` state-machine modifier
+/// (issue #1326) is declared on anything but a plain, non-nullable
+/// `String`/`Text` field. Shared so the enum, decimal, and scalar branches of
+/// [`parse_field`] can never drift.
+const STATE_MACHINE_STRING_ONLY: &str =
+    "a `states(…)` state machine is only supported on a non-nullable `String`/`Text` field";
+
+/// Split a field's post-`name:` remainder into its leading part and the body of
+/// a trailing `:states(…)` state-machine modifier (issue #1326), if present.
+///
+/// `"String:states(a -> b)"` -> `("String", Some("a -> b"))`;
+/// `"String:unique:states(a -> b)"` -> `("String:unique", Some("a -> b"))`;
+/// a remainder with no such clause yields `(rest, None)`. The clause is
+/// paren-delimited and must be the final modifier (the `)` closes the token),
+/// mirroring the trailing-modifier style of `:unique` and the `{…}` block.
+fn split_state_machine_modifier(rest: &str) -> (&str, Option<&str>) {
+    let rest = rest.trim();
+    if let Some(pos) = rest.find(":states(")
+        && rest.ends_with(')')
+    {
+        let before = rest[..pos].trim_end();
+        let inner = rest[pos + ":states(".len()..rest.len() - 1].trim();
+        return (before, Some(inner));
+    }
+    (rest, None)
+}
+
+/// Parse the inner body of a `:states(…)` modifier — a comma-separated list of
+/// `from -> to` edges, each with an optional `: guard` plain-identifier suffix
+/// (issue #1326). Mirrors the `#[state_machine(transitions(…))]` macro grammar
+/// so the generator can re-emit the parsed set verbatim.
+///
+/// # Errors
+/// Returns a human-readable message when the list is empty, an edge is missing
+/// its `->`, or any state/guard token is not a valid `snake_case` identifier.
+fn parse_state_machine(body: &str) -> Result<StateMachine, String> {
+    let mut transitions = Vec::new();
+    for segment in body.split(',') {
+        let segment = segment.trim();
+        // Tolerate a trailing comma (`a -> b,`) exactly like the macro grammar.
+        if segment.is_empty() {
+            continue;
+        }
+        let (from, to_and_guard) = segment.split_once("->").ok_or_else(|| {
+            format!("malformed transition '{segment}'; expected `from -> to` (missing `->`)")
+        })?;
+        // Split an optional `: guard` off the right-hand side. The states clause
+        // is peeled whole before any `:unique` handling, so this colon is
+        // unambiguously the guard separator.
+        let (to, guard) = match to_and_guard.split_once(':') {
+            Some((to, guard)) => (to.trim(), Some(guard.trim())),
+            None => (to_and_guard.trim(), None),
+        };
+        let from = from.trim();
+        validate_state_token(from, "state")?;
+        validate_state_token(to, "state")?;
+        if let Some(guard) = guard {
+            validate_state_token(guard, "guard")?;
+        }
+        transitions.push(StateTransition {
+            from: from.to_owned(),
+            to: to.to_owned(),
+            guard: guard.map(str::to_owned),
+        });
+    }
+    if transitions.is_empty() {
+        return Err(
+            "empty `states(…)` modifier; declare at least one `from -> to` transition".to_owned(),
+        );
+    }
+    Ok(StateMachine { transitions })
+}
+
+/// Validate one state name or guard name from a `:states(…)` modifier: it must
+/// be a non-empty `snake_case` identifier and not a Rust keyword, since the
+/// generator emits states as bare identifiers (and guards as method names)
+/// inside the `#[state_machine(transitions(…))]` attribute.
+fn validate_state_token(token: &str, kind: &str) -> Result<(), String> {
+    if token.is_empty() {
+        return Err(format!("empty {kind} name in `states(…)` modifier"));
+    }
+    if !is_valid_ident(token) || is_rust_keyword(token) {
+        return Err(format!(
+            "'{token}' is not a valid {kind} name; expected a plain snake_case identifier such \
+             as `draft` or `can_publish`"
+        ));
+    }
+    Ok(())
 }
 
 /// Format the `min = …, max = …` argument list shared by `length(…)` and
@@ -1116,6 +1282,14 @@ fn parse_decimal_type(ty: &str) -> Result<Option<(u32, u32, bool)>, String> {
 }
 
 /// Parse a list of `name:Type` tokens.
+///
+/// Each token is `name:Type` with optional trailing modifiers: `:unique`
+/// (issue #1032), a `{…}` constraint block (issue #1388 / #1146), and — for a
+/// non-nullable `String`/`Text` field — a `:states(…)` state-machine modifier
+/// (issue #1326). The state-machine clause lists `from -> to` edges, each with
+/// an optional `: guard` method name, e.g.
+/// `status:String:states(draft -> published: can_publish, published -> archived)`.
+/// It re-emits as a `#[state_machine(transitions(…))]` attribute on the field.
 ///
 /// # Errors
 /// Bubbles up the first failed token, and rejects duplicate field names —
@@ -2233,6 +2407,94 @@ mod tests {
             SUPPORTED_TYPES.contains("unique"),
             "SUPPORTED_TYPES must document the :unique modifier"
         );
+    }
+
+    // ── state machine modifier (issue #1326) ────────────────────────────────
+
+    #[test]
+    fn parse_field_without_state_machine_defaults_to_none() {
+        let f = parse_field("title:String").unwrap();
+        assert!(f.state_machine.is_none());
+    }
+
+    #[test]
+    fn parse_state_machine_modifier_captures_transitions() {
+        let f = parse_field(
+            "status:String:states(draft -> published: can_publish, published -> archived)",
+        )
+        .unwrap();
+        assert_eq!(f.kind, FieldKind::String);
+        assert!(!f.nullable);
+        let sm = f.state_machine.expect("state machine should be parsed");
+        assert_eq!(
+            sm.transitions,
+            vec![
+                StateTransition {
+                    from: "draft".to_owned(),
+                    to: "published".to_owned(),
+                    guard: Some("can_publish".to_owned()),
+                },
+                StateTransition {
+                    from: "published".to_owned(),
+                    to: "archived".to_owned(),
+                    guard: None,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_state_machine_tolerates_trailing_comma_and_whitespace() {
+        let f = parse_field("status:String:states( draft -> published , )").unwrap();
+        let sm = f.state_machine.unwrap();
+        assert_eq!(sm.transitions.len(), 1);
+        assert_eq!(sm.transitions[0].from, "draft");
+        assert_eq!(sm.transitions[0].to, "published");
+        assert!(sm.transitions[0].guard.is_none());
+    }
+
+    #[test]
+    fn state_machine_composes_with_unique_and_text() {
+        let f = parse_field("stage:Text:unique:states(a -> b)").unwrap();
+        assert_eq!(f.kind, FieldKind::Text);
+        assert!(f.unique);
+        assert_eq!(f.state_machine.unwrap().transitions.len(), 1);
+    }
+
+    #[test]
+    fn state_machine_on_nullable_string_is_rejected() {
+        let err = parse_field("status:Option<String>:states(a -> b)").unwrap_err();
+        assert!(err.to_string().contains("non-nullable"), "got: {err}");
+    }
+
+    #[test]
+    fn state_machine_on_non_string_field_is_rejected() {
+        let err = parse_field("count:i64:states(a -> b)").unwrap_err();
+        assert!(err.to_string().contains("String"), "got: {err}");
+    }
+
+    #[test]
+    fn state_machine_on_enum_field_is_rejected() {
+        let err = parse_field("status:enum{a,b}:states(a -> b)").unwrap_err();
+        assert!(err.to_string().contains("String"), "got: {err}");
+    }
+
+    #[test]
+    fn empty_state_machine_modifier_is_rejected() {
+        let err = parse_field("status:String:states()").unwrap_err();
+        assert!(err.to_string().contains("at least one"), "got: {err}");
+    }
+
+    #[test]
+    fn state_machine_missing_arrow_is_rejected() {
+        let err = parse_field("status:String:states(draft published)").unwrap_err();
+        assert!(err.to_string().contains("->"), "got: {err}");
+    }
+
+    #[test]
+    fn state_machine_invalid_state_name_is_rejected() {
+        let err = parse_field("status:String:states(Draft -> published)").unwrap_err();
+        assert!(err.to_string().contains("state name"), "got: {err}");
     }
 
     // ── decimal field kind (issue #1038) ────────────────────────────────────

--- a/autumn-cli/src/generate/introspect.rs
+++ b/autumn-cli/src/generate/introspect.rs
@@ -1532,6 +1532,7 @@ mod tests {
                 variants: Vec::new(),
                 unique: false,
                 constraints: FieldConstraints::default(),
+                state_machine: None,
             },
             Field {
                 name: "body".into(),
@@ -1540,6 +1541,7 @@ mod tests {
                 variants: Vec::new(),
                 unique: false,
                 constraints: FieldConstraints::default(),
+                state_machine: None,
             },
             Field {
                 name: "published".into(),
@@ -1548,6 +1550,7 @@ mod tests {
                 variants: Vec::new(),
                 unique: false,
                 constraints: FieldConstraints::default(),
+                state_machine: None,
             },
         ];
         let greenfield = render_model_file_for_test("Post", "posts", &fields);

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -675,6 +675,7 @@ pub(super) fn augment_fields_for_soft_delete(
         variants: Vec::new(),
         unique: false,
         constraints: FieldConstraints::default(),
+        state_machine: None,
     });
     Ok(std::borrow::Cow::Owned(augmented))
 }
@@ -2055,6 +2056,25 @@ fn render_model_file(
         if metadata.defaults.contains_key(&f.name) {
             out.push_str("    #[default]\n");
         }
+        // A `:states(…)` DSL modifier (issue #1326) re-emits as a
+        // `#[state_machine(transitions(…))]` attribute, in the exact grammar the
+        // `autumn_web::model` macro accepts: bare-ident states, an optional
+        // `: "guard"` string. Absent when the field declared no state machine —
+        // that no-op path is what keeps the non-state-machine output
+        // byte-identical to before this feature.
+        if let Some(sm) = &f.state_machine {
+            let mut inner = String::new();
+            for (i, t) in sm.transitions.iter().enumerate() {
+                if i > 0 {
+                    inner.push_str(", ");
+                }
+                let _ = write!(inner, "{} -> {}", t.from, t.to);
+                if let Some(guard) = &t.guard {
+                    let _ = write!(inner, ": \"{guard}\"");
+                }
+            }
+            let _ = writeln!(out, "    #[state_machine(transitions({inner}))]");
+        }
         let _ = writeln!(out, "    pub {}: {},", f.name, f.rust_type());
     }
     if soft_delete {
@@ -2425,6 +2445,47 @@ mod tests {
         assert!(model.contains("Published,"), "got:\n{model}");
         assert!(model.contains("Archived,"), "got:\n{model}");
         assert!(model.contains("pub status: Status,"), "got:\n{model}");
+    }
+
+    // ── state machine field emission (issue #1326) ──────────────────────────
+
+    /// AC5: a model with no state-machine field must render exactly as before
+    /// this feature — no `#[state_machine]` attribute leaks into the no-SM path.
+    /// (The unchanged pre-existing golden/model tests are the primary
+    /// byte-identical proof; this is the explicit no-leak assertion.)
+    #[test]
+    fn model_file_without_state_machine_emits_no_attribute() {
+        let fields = crate::generate::dsl::parse_fields(&[
+            "title:String".into(),
+            "body:Text".into(),
+            "published:bool".into(),
+        ])
+        .unwrap();
+        let model = render_model_file_for_test("Post", "posts", &fields);
+        assert!(
+            !model.contains("#[state_machine"),
+            "no state machine declared, so no attribute should render; got:\n{model}"
+        );
+    }
+
+    /// A `:states(…)` field renders a `#[state_machine(transitions(…))]`
+    /// attribute in the exact grammar the `autumn_web::model` macro accepts
+    /// (bare-ident states, an optional `: \"guard\"` string), on a `String` field.
+    #[test]
+    fn model_file_emits_state_machine_attribute() {
+        let fields = crate::generate::dsl::parse_fields(&[
+            "status:String:states(draft -> published: can_publish, published -> archived)".into(),
+        ])
+        .unwrap();
+        let model = render_model_file_for_test("Page", "pages", &fields);
+        assert!(
+            model.contains(
+                "#[state_machine(transitions(draft -> published: \"can_publish\", \
+                 published -> archived))]"
+            ),
+            "got:\n{model}"
+        );
+        assert!(model.contains("pub status: String,"), "got:\n{model}");
     }
 
     #[test]

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -1839,6 +1839,15 @@ fn render_routes_file(
     let search_enabled = !searchable.is_empty() && !live && !live_validation;
     let validated_fields: Vec<&str> = validations.keys().map(String::as_str).collect();
     let unique_fields: Vec<&Field> = fields.iter().filter(|f| f.unique).collect();
+    // Issue #1326: fields carrying a `:states(…)` state machine. Only these
+    // scaffolds emit a `show_view` helper, per-field `transition_controls`, and a
+    // `POST /{plural}/{{id}}/transitions/{field}` handler. A scaffold with none
+    // (the overwhelming common case) keeps the pre-#1326 output byte-identical.
+    let sm_fields: Vec<&Field> = fields
+        .iter()
+        .filter(|f| f.state_machine.is_some())
+        .collect();
+    let has_state_machine = !sm_fields.is_empty();
     let update_columns = render_update_columns(plural, fields);
     let nullable_field_match = render_nullable_field_match(fields);
     let has_attachments = has_attachment_fields(fields);
@@ -3272,6 +3281,13 @@ pub async fn index(
                 names.push(format!("validate_{field_name}"));
             }
         }
+        // Issue #1326: one transition endpoint per state-machine field, linked
+        // from the show page's `transition_controls` form actions
+        // (`paths::transition_{field}(id)`).
+        for f in &sm_fields {
+            let field = &f.name;
+            names.push(format!("transition_{field}"));
+        }
         let mut out = String::from("\n\nautumn_web::paths![\n");
         for name in &names {
             let _ = writeln!(out, "    {name},");
@@ -3527,6 +3543,157 @@ fn layout(title: &str, flash: Markup, content: Markup) -> Markup {{
 "#
             )
         };
+        // Issue #1326: the `show` detail section. Without a state machine this is
+        // exactly the pre-#1326 inline `show` handler (byte-identical output).
+        // With one or more `:states(…)` fields it becomes a shared `show_view`
+        // helper (rendered by `show` AND each transition handler's 422 re-render),
+        // a `show` handler threading CSRF for the transition forms, and one
+        // `POST /{plural}/{{id}}/transitions/{field}` handler per state-machine
+        // field.
+        let show_section = if has_state_machine {
+            // `show_view` only touches the DB when it must resolve reference
+            // display labels (issue #1146); otherwise the connection is unused, so
+            // name it `_db` (and drop `mut`) to keep the generated crate
+            // warning-free.
+            let show_view_db_param = if show_label_loads.trim().is_empty() {
+                format!("_db: {db_ty}")
+            } else {
+                format!("mut db: {db_ty}")
+            };
+            let mut show_transition_controls = String::new();
+            for f in &sm_fields {
+                let field = &f.name;
+                let field_upper = f.name.to_uppercase();
+                let _ = writeln!(
+                    show_transition_controls,
+                    "        (autumn_web::widgets::transition_controls(&paths::transition_{field}(row.id), \"{field}\", &row.{field}, {pascal_name}::__AUTUMN_SM_{field_upper}_TRANSITIONS, |to| row.can_transition_{field}_to(to), csrf, csrf_field))"
+                );
+            }
+            let show_view_fn = format!(
+                r#"/// Render the {snake_name} detail page — shared by the `show` handler and
+/// each state-machine transition handler's 422 re-render, so the detail-page
+/// markup has a single source of truth (issue #1326).
+async fn show_view(
+    {show_view_db_param},
+    row: &{pascal_name},
+    flash: Markup,
+    csrf: Option<&CsrfToken>,
+    csrf_field: Option<&CsrfFormField>,
+) -> AutumnResult<Markup> {{
+{show_label_loads}    let props: Vec<(&str, maud::Markup)> = vec![
+{show_rows}    ];
+    Ok({layout_fn}(&format!("{pascal_name} #{{}}", row.id), {cp_show}flash, html! {{
+        h1 {{ "{pascal_name} #" (row.id) }}
+        (autumn_web::widgets::property_list(&props))
+{show_transition_controls}        (autumn_web::a11y::Link::new(paths::index(), "Back to list"))
+        " "
+        (autumn_web::a11y::Link::new(paths::edit(row.id), "Edit"))
+    }}))
+}}"#
+            );
+            let show_handler = format!(
+                r#"/// `GET /{plural}/{{id}}` — show one {snake_name}.
+#[get("/{plural}/{{id}}")]
+pub async fn show(
+    id: Path<{id_rust}>,
+    mut db: {db_ty},
+    flash: Flash,
+    csrf: Option<CsrfToken>,
+    csrf_field: Option<CsrfFormField>,
+) -> AutumnResult<Markup> {{
+    let row: {pascal_name} = {plural}::table
+        .find(*id)
+        .select({pascal_name}::as_select())
+        .first(&mut *db)
+        .await
+        .map_err(AutumnError::not_found)?;
+    show_view(db, &row, {flash_arg}, csrf.as_ref(), csrf_field.as_ref()).await
+}}"#
+            );
+            let mut transition_handlers = String::new();
+            for f in &sm_fields {
+                let field = &f.name;
+                let handler = format!(
+                    r#"/// `POST /{plural}/{{id}}/transitions/{field}` — apply a `{field}` state
+/// transition (issue #1326). A legal edge persists the new `{field}` value and
+/// redirects to the detail page; an illegal edge (or a rejected guard)
+/// re-renders that page at 422 with the record left unchanged.
+#[secured]
+#[post("/{plural}/{{id}}/transitions/{field}")]
+pub async fn transition_{field}(
+    id: Path<{id_rust}>,
+    mut db: {db_ty},
+    flash: Flash,
+    csrf: Option<CsrfToken>,
+    csrf_field: Option<CsrfFormField>,
+    body: Bytes,
+) -> AutumnResult<autumn_web::reexports::axum::response::Response> {{
+    use autumn_web::reexports::axum::response::IntoResponse as _;
+    let row: {pascal_name} = {plural}::table
+        .find(*id)
+        .select({pascal_name}::as_select())
+        .first(&mut *db)
+        .await
+        .map_err(AutumnError::not_found)?;
+    let submitted: std::collections::HashMap<String, String> =
+        url::form_urlencoded::parse(body.as_ref()).into_owned().collect();
+    let target = submitted.get("{field}").cloned().unwrap_or_default();
+    match row.transition_{field}_to(&target) {{
+        Ok(new_state) => {{
+            diesel::update({plural}::table.find(*id))
+                .set({plural}::{field}.eq(new_state))
+                .execute(&mut *db)
+                .await?;
+            flash.success("{pascal_name} {field} updated").await;
+            Ok(autumn_web::Redirect::to(&paths::show(*id)).into_response())
+        }}
+        Err(err) => {{
+            flash.error(err.to_string()).await;
+            let view = show_view(
+                db,
+                &row,
+                flash_messages(&flash.consume().await),
+                csrf.as_ref(),
+                csrf_field.as_ref(),
+            )
+            .await?;
+            Ok((autumn_web::reexports::http::StatusCode::UNPROCESSABLE_ENTITY, view).into_response())
+        }}
+    }}
+}}"#
+                );
+                if !transition_handlers.is_empty() {
+                    transition_handlers.push_str("\n\n");
+                }
+                transition_handlers.push_str(&handler);
+            }
+            format!("\n\n{show_view_fn}\n\n{show_handler}\n\n{transition_handlers}\n")
+        } else {
+            format!(
+                r#"
+
+/// `GET /{plural}/{{id}}` — show one {snake_name}.
+#[get("/{plural}/{{id}}")]
+pub async fn show(id: Path<{id_rust}>, mut db: {db_ty}, flash: Flash) -> AutumnResult<Markup> {{
+    let row: {pascal_name} = {plural}::table
+        .find(*id)
+        .select({pascal_name}::as_select())
+        .first(&mut *db)
+        .await
+        .map_err(AutumnError::not_found)?;
+{show_label_loads}    let props: Vec<(&str, maud::Markup)> = vec![
+{show_rows}    ];
+    Ok({layout_fn}(&format!("{pascal_name} #{{}}", row.id), {cp_show}{flash_arg}, html! {{
+        h1 {{ "{pascal_name} #" (row.id) }}
+        (autumn_web::widgets::property_list(&props))
+        (autumn_web::a11y::Link::new(paths::index(), "Back to list"))
+        " "
+        (autumn_web::a11y::Link::new(paths::edit(row.id), "Edit"))
+    }}))
+}}
+"#
+            )
+        };
         format!(
             r#"
 
@@ -3553,28 +3720,7 @@ fn submit_token_input(submit_token: Option<&SubmitToken>, field: Option<&SubmitF
     }}
 }}
 {private_layout}
-{index_handler}
-
-/// `GET /{plural}/{{id}}` — show one {snake_name}.
-#[get("/{plural}/{{id}}")]
-pub async fn show(id: Path<{id_rust}>, mut db: {db_ty}, flash: Flash) -> AutumnResult<Markup> {{
-    let row: {pascal_name} = {plural}::table
-        .find(*id)
-        .select({pascal_name}::as_select())
-        .first(&mut *db)
-        .await
-        .map_err(AutumnError::not_found)?;
-{show_label_loads}    let props: Vec<(&str, maud::Markup)> = vec![
-{show_rows}    ];
-    Ok({layout_fn}(&format!("{pascal_name} #{{}}", row.id), {cp_show}{flash_arg}, html! {{
-        h1 {{ "{pascal_name} #" (row.id) }}
-        (autumn_web::widgets::property_list(&props))
-        (autumn_web::a11y::Link::new(paths::index(), "Back to list"))
-        " "
-        (autumn_web::a11y::Link::new(paths::edit(row.id), "Edit"))
-    }}))
-}}
-
+{index_handler}{show_section}
 /// `GET /{plural}/new` — render the new-{snake_name} form.
 #[secured]
 #[get("/{plural}/new", name = "new")]
@@ -10757,6 +10903,105 @@ async fn main() {
         assert!(
             routes.contains("\"Views\""),
             "show must include defaulted field 'views': {routes}"
+        );
+    }
+
+    // ── state-machine transitions scaffold conformance (issue #1326) ──────
+
+    #[test]
+    fn scaffold_without_state_machine_emits_no_transition_wiring() {
+        // AC5: a model WITHOUT any `:states(…)` field keeps the pre-#1326 `show`
+        // handler and route set byte-for-byte — no `show_view` helper, no
+        // `/transitions/` route, and the original three-arg `show` signature.
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "body:Text".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+        assert!(
+            !routes.contains("/transitions/"),
+            "no-state-machine scaffold must not emit any transition route: {routes}"
+        );
+        assert!(
+            !routes.contains("fn show_view"),
+            "no-state-machine scaffold must not extract a show_view helper: {routes}"
+        );
+        assert!(
+            !routes.contains("transition_controls"),
+            "no-state-machine scaffold must not render transition controls: {routes}"
+        );
+        // The original inline `show` signature is unchanged (no CSRF params).
+        assert!(
+            routes.contains(
+                "pub async fn show(id: Path<i64>, mut db: Db, flash: Flash) -> AutumnResult<Markup> {"
+            ),
+            "no-state-machine `show` signature must be unchanged: {routes}"
+        );
+    }
+
+    #[test]
+    fn scaffold_with_state_machine_emits_transition_route_and_controls() {
+        // A model WITH a `:states(…)` field generates the transition route, the
+        // `transition_{field}_to` call, both the 303 success and 422 error
+        // branches, a shared `show_view`, and a `transition_controls(` call.
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Order",
+            &[
+                "status:String:states(draft -> published: can_publish, published -> archived)"
+                    .into(),
+            ],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let routes = fs::read_to_string(tmp.path().join("src/routes/orders.rs")).unwrap();
+        // The transition route: `POST /orders/{id}/transitions/status`.
+        assert!(
+            routes.contains("#[post(\"/orders/{id}/transitions/status\")]"),
+            "must emit the transition POST route: {routes}"
+        );
+        assert!(
+            routes.contains("pub async fn transition_status("),
+            "must emit the transition handler: {routes}"
+        );
+        // The handler drives the macro-emitted state-machine method.
+        assert!(
+            routes.contains("row.transition_status_to(&target)"),
+            "transition handler must call transition_status_to: {routes}"
+        );
+        // Success branch: 303 redirect to the show page.
+        assert!(
+            routes.contains("Ok(autumn_web::Redirect::to(&paths::show(*id)).into_response())"),
+            "transition handler must 303-redirect on a legal edge: {routes}"
+        );
+        // Error branch: 422 re-render of the detail page, record unchanged.
+        assert!(
+            routes.contains("autumn_web::reexports::http::StatusCode::UNPROCESSABLE_ENTITY"),
+            "transition handler must 422 on an illegal edge: {routes}"
+        );
+        // The detail page markup is shared through `show_view`.
+        assert!(
+            routes.contains("async fn show_view("),
+            "must extract a shared show_view helper: {routes}"
+        );
+        // The show view renders transition controls fed by the macro const.
+        assert!(
+            routes.contains("autumn_web::widgets::transition_controls(&paths::transition_status(row.id), \"status\", &row.status, Order::__AUTUMN_SM_STATUS_TRANSITIONS,"),
+            "show view must render transition_controls for the state-machine field: {routes}"
+        );
+        // The transition endpoint is registered in the paths! module.
+        assert!(
+            routes.contains("transition_status,"),
+            "paths! must register the transition route name: {routes}"
         );
     }
 

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -3610,6 +3610,30 @@ pub async fn show(
     show_view(db, &row, {flash_arg}, csrf.as_ref(), csrf_field.as_ref()).await
 }}"#
             );
+            // Issue #1326 security fix (IDOR): a transition mutates an existing
+            // row, so when record-policy wiring is on (the default for non-`--api`
+            // scaffolds) the transition handler must record-authorize the actor
+            // against the loaded row *before* writing — using the SAME `"update"`
+            // action the `update` handler uses. Without this, any authenticated
+            // user who knows another row's id could POST a transition and change
+            // its state, bypassing the record policy. Mirrors the `update`/`destroy`
+            // authorize preamble: the full `State(state)` + `session: Session`
+            // extractor pair (a transition handler never carries a multipart
+            // `state`, so there is no attachment-reuse concern) and `&state` as the
+            // `AppState` receiver. When policy wiring is off it emits nothing, so
+            // the handler is exactly `id/db/flash/csrf/body` as before.
+            let transition_authz_params = if authorize {
+                "    autumn_web::extract::State(state): autumn_web::extract::State<autumn_web::AppState>,\n    session: autumn_web::session::Session,\n"
+            } else {
+                ""
+            };
+            let transition_authz_call = if authorize {
+                format!(
+                    "    autumn_web::authorization::authorize::<{pascal_name}>(&state, &session, \"update\", &row).await?;\n"
+                )
+            } else {
+                String::new()
+            };
             let mut transition_handlers = String::new();
             for f in &sm_fields {
                 let field = &f.name;
@@ -3626,7 +3650,7 @@ pub async fn transition_{field}(
     flash: Flash,
     csrf: Option<CsrfToken>,
     csrf_field: Option<CsrfFormField>,
-    body: Bytes,
+{transition_authz_params}    body: Bytes,
 ) -> AutumnResult<autumn_web::reexports::axum::response::Response> {{
     use autumn_web::reexports::axum::response::IntoResponse as _;
     let row: {pascal_name} = {plural}::table
@@ -3635,7 +3659,7 @@ pub async fn transition_{field}(
         .first(&mut *db)
         .await
         .map_err(AutumnError::not_found)?;
-    let submitted: std::collections::HashMap<String, String> =
+{transition_authz_call}    let submitted: std::collections::HashMap<String, String> =
         url::form_urlencoded::parse(body.as_ref()).into_owned().collect();
     let target = submitted.get("{field}").cloned().unwrap_or_default();
     match row.transition_{field}_to(&target) {{
@@ -11002,6 +11026,65 @@ async fn main() {
         assert!(
             routes.contains("transition_status,"),
             "paths! must register the transition route name: {routes}"
+        );
+        // Security (issue #1326 IDOR fix): with record-policy wiring on (the
+        // default for non-`--api` scaffolds), the transition handler threads the
+        // same `State` + `Session` pair as `update` and record-authorizes the
+        // actor against the loaded row with the `"update"` action BEFORE writing,
+        // so a transition cannot bypass the record policy.
+        assert!(
+            routes.contains(
+                "autumn_web::extract::State(state): autumn_web::extract::State<autumn_web::AppState>,"
+            ),
+            "transition handler must thread the State extractor when policy wiring is on: {routes}"
+        );
+        assert!(
+            routes.contains("session: autumn_web::session::Session,"),
+            "transition handler must thread the Session extractor when policy wiring is on: {routes}"
+        );
+        assert!(
+            routes.contains(
+                "autumn_web::authorization::authorize::<Order>(&state, &session, \"update\", &row).await?;"
+            ),
+            "transition handler must record-authorize the actor against the loaded row: {routes}"
+        );
+    }
+
+    #[test]
+    fn scaffold_with_state_machine_no_policy_emits_no_authz_preamble() {
+        // AC5 / IDOR-fix gating: a `--no-policy` scaffold still emits the
+        // transition route, but WITHOUT the authorize preamble — exactly the
+        // pre-fix `id/db/flash/csrf/body` handler. The authz preamble must appear
+        // only in the state-machine transition route AND only when policy is on.
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold_with_options(
+            tmp.path(),
+            "Order",
+            &[
+                "status:String:states(draft -> published: can_publish, published -> archived)"
+                    .into(),
+            ],
+            "20260427000000",
+            &ScaffoldOptions {
+                no_policy: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let routes = action_contents(&plan, "src/routes/orders.rs");
+        // The transition route is still generated…
+        assert!(
+            routes.contains("pub async fn transition_status("),
+            "--no-policy state-machine scaffold must still emit the transition handler: {routes}"
+        );
+        // …but with no record-policy authorization wiring.
+        assert!(
+            !routes.contains("authorize::<Order>"),
+            "--no-policy transition handler must not wire authorize: {routes}"
+        );
+        assert!(
+            !routes.contains("session: autumn_web::session::Session"),
+            "--no-policy transition handler must not thread a Session extractor: {routes}"
         );
     }
 

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -783,6 +783,18 @@ fn plan_scaffold_with_options_impl(
     let search_enabled = !options_with_key.model.searchable.is_empty()
         && !options_with_key.live
         && !options_with_key.live_validation;
+    // Issue #1326: the state-machine fields whose `transition_{field}` handler
+    // the generated `routes::{plural}` module emits and `main.rs` must mount.
+    // Only the HTML surface emits these handlers, so this stays empty for `--api`.
+    let sm_field_names: Vec<String> = if options_with_key.api {
+        Vec::new()
+    } else {
+        fields
+            .iter()
+            .filter(|f| f.state_machine.is_some())
+            .map(|f| f.name.clone())
+            .collect()
+    };
     let route_entries = main_route_entries(
         &plural,
         &snake_name,
@@ -790,6 +802,7 @@ fn plan_scaffold_with_options_impl(
         options_with_key.live,
         search_enabled && !options_with_key.api,
         &validated_field_names,
+        &sm_field_names,
     );
     let mut mods = vec!["models", "schema", "repositories"];
     if !options_with_key.api {
@@ -1747,6 +1760,16 @@ fn render_model_form(
             );
             let _ = writeln!(from_row, "            {name}: row.{name}.to_string(),");
         } else {
+            // Issue #1326: a `:states(…)` state-machine column is transition-only,
+            // so the EDIT form omits its input (see `render_form_for_helper`) and
+            // the update submit carries no value for it. `#[serde(default)]` maps
+            // that absence to an empty string instead of a "missing field" 400 —
+            // harmless because the update `.set((…))` tuple excludes the column
+            // (`render_update_columns`), and the create form still submits the
+            // real initial state.
+            if f.state_machine.is_some() {
+                let _ = writeln!(struct_fields, "    #[serde(default)]");
+            }
             // Plain scalars (String/Text, and any nullable numeric/Uuid/Decimal)
             // keep their native type — `Option<T>::default()` is already blank.
             let _ = writeln!(
@@ -2506,16 +2529,23 @@ fn render_routes_file(
             );
             let _ = write!(option_args, ", &{name}_options");
         }
+        // Issue #1326: the shared `{snake}_form_for` helper gains an
+        // `exclude_state_fields` flag only when the model has a state-machine
+        // column; the create form keeps the column (initial state) while the
+        // edit form drops it (transition-only). A no-state-machine model passes
+        // no extra argument, keeping the pre-#1326 call byte-identical.
+        let form_exclude_create = if has_state_machine { ", false" } else { "" };
+        let form_exclude_edit = if has_state_machine { ", true" } else { "" };
         let new_form_layout = format!(
             "{layout_fn}(\"New {pascal_name}\", {cp_new}{flash_arg}, html! {{\n        \
              h1 {{ \"New {pascal_name}\" }}\n        \
-             ({snake_name}_form_for(&changeset, paths::create(), \"Create\", csrf.as_ref(), csrf_field.as_ref(), submit_token.as_ref(), submit_field.as_ref(){option_args}))\n    \
+             ({snake_name}_form_for(&changeset, paths::create(), \"Create\", csrf.as_ref(), csrf_field.as_ref(), submit_token.as_ref(), submit_field.as_ref(){option_args}{form_exclude_create}))\n    \
              }})"
         );
         let edit_form_layout = format!(
             "{layout_fn}(&format!(\"Edit {pascal_name} #{{}}\", *id), {cp_edit}{flash_arg}, html! {{\n        \
              h1 {{ \"Edit {pascal_name} #\" (*id) }}\n        \
-             ({snake_name}_form_for(&changeset, paths::update(*id), \"Save\", csrf.as_ref(), csrf_field.as_ref(), submit_token.as_ref(), submit_field.as_ref(){option_args}))\n        \
+             ({snake_name}_form_for(&changeset, paths::update(*id), \"Save\", csrf.as_ref(), csrf_field.as_ref(), submit_token.as_ref(), submit_field.as_ref(){option_args}{form_exclude_edit}))\n        \
              form action=(paths::delete(*id)) method=\"post\" {{\n            \
              (csrf_input(csrf.as_ref(), csrf_field.as_ref()))\n            \
              button type=\"submit\" onclick=\"return confirm('Delete this {pascal_name}?')\" {{ \"Delete\" }}\n        \
@@ -4131,6 +4161,29 @@ fn render_form_for_helper(
             }
         }
     }
+    // Issue #1326: a `:states(…)` state-machine column is transition-only. The
+    // create form keeps it (initial state), but the EDIT form must not offer it
+    // as an editable input — status changes flow only through the dedicated
+    // `POST /{plural}/{{id}}/transitions/{field}` route. The helper is shared by
+    // both forms, so it takes an `exclude_state_fields` flag: the edit call
+    // passes `true` and the create call `false`. A model with no state-machine
+    // field emits neither the parameter nor the block, keeping the pre-#1326
+    // helper byte-identical.
+    let sm_field_names: Vec<&str> = fields
+        .iter()
+        .filter(|f| f.state_machine.is_some())
+        .map(|f| f.name.as_str())
+        .collect();
+    let sm_exclude_block = if sm_field_names.is_empty() {
+        String::new()
+    } else {
+        let _ = write!(extra_params, ",\n    exclude_state_fields: bool");
+        let mut excludes = String::new();
+        for name in &sm_field_names {
+            let _ = write!(excludes, "\n        form = form.exclude(\"{name}\");");
+        }
+        format!("\n    if exclude_state_fields {{{excludes}\n    }}\n    ")
+    };
     format!(
         "/// Render the create/edit form in a single `form_for` call (issue #1135).\n\
          ///\n\
@@ -4150,7 +4203,7 @@ fn render_form_for_helper(
          ) -> Markup {{\n\
          {preludes}    \
          let mut form = autumn_web::form::form_for(changeset, action, \"post\")\n        \
-         .submit_label(submit_label){builder_calls}{appends};\n    \
+         .submit_label(submit_label){builder_calls}{appends};\n{sm_exclude_block}    \
          // Emit the one-time submit token at the FRONT of the form (issue #1360):\n    \
          // `SubmitTokenLayer` only scans the first chunk of the URL-encoded body,\n    \
          // so a large earlier textarea could otherwise push an appended token past\n    \
@@ -5133,7 +5186,19 @@ fn render_update_columns(plural: &str, fields: &[Field]) -> String {
     use std::fmt::Write;
     // Estimate 50 chars per field
     let mut out = String::with_capacity(fields.len() * 50);
-    for (i, f) in fields.iter().enumerate() {
+    // Issue #1326: a `:states(…)` state-machine column is transition-only — it is
+    // mutated exclusively through the dedicated `POST /{plural}/{{id}}/transitions/
+    // {field}` handler (a direct `diesel::update(...).set({field}.eq(new_state))`),
+    // never the ordinary update path. Excluding it from the update `.set((…))`
+    // tuple (and, in `render_form_for_helper`, from the edit form) stops a plain
+    // `POST /{plural}/{{id}}/update` from setting `status=<anything>` and bypassing
+    // `transition_{field}_to` / its guards. A model with no state-machine field
+    // emits the exact pre-#1326 column set.
+    for (i, f) in fields
+        .iter()
+        .filter(|f| f.state_machine.is_none())
+        .enumerate()
+    {
         if i > 0 {
             out.push_str(", ");
         }
@@ -6722,6 +6787,7 @@ fn main_route_entries(
     live: bool,
     search: bool,
     validated_field_names: &[String],
+    sm_field_names: &[String],
 ) -> Vec<String> {
     if api {
         let mut entries = vec![
@@ -6755,6 +6821,14 @@ fn main_route_entries(
         }
         for field_name in validated_field_names {
             entries.push(format!("routes::{plural}::validate_{field_name}"));
+        }
+        // Issue #1326: mount the `POST /{plural}/{{id}}/transitions/{field}`
+        // handler emitted for each state-machine field, so the show page's
+        // `transition_controls` form actions resolve to a real route rather than
+        // 404ing. A scaffold with no state-machine field pushes nothing here and
+        // keeps the pre-#1326 mounted route set byte-identical.
+        for field_name in sm_field_names {
+            entries.push(format!("routes::{plural}::transition_{field_name}"));
         }
         entries.push(format!("repositories::{snake_name}::{snake_name}_api_list"));
         entries.push(format!("repositories::{snake_name}::{snake_name}_api_get"));
@@ -11085,6 +11159,167 @@ async fn main() {
         assert!(
             !routes.contains("session: autumn_web::session::Session"),
             "--no-policy transition handler must not thread a Session extractor: {routes}"
+        );
+    }
+
+    #[test]
+    fn scaffold_with_state_machine_mounts_transition_route_in_main() {
+        // P1 (issue #1326): the generated `main.rs` router must actually MOUNT
+        // each state-machine field's `transition_{field}` handler — otherwise the
+        // show page's `transition_controls` form POSTs to an unmounted route and
+        // 404s. The handler being present in the `routes::{plural}` module and in
+        // the name-only `paths!` helper is not enough; it must be in the router's
+        // `routes![…]` set.
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Order",
+            &[
+                "status:String:states(draft -> published, published -> archived)".into(),
+                "title:String".into(),
+            ],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let main = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert!(
+            main.contains("routes::orders::transition_status"),
+            "main.rs must MOUNT the transition handler, not just declare it in paths!: {main}"
+        );
+        // Mounted alongside the standard CRUD handlers.
+        assert!(
+            main.contains("routes::orders::update") && main.contains("routes::orders::destroy"),
+            "standard CRUD handlers must still be mounted: {main}"
+        );
+    }
+
+    #[test]
+    fn scaffold_without_state_machine_mounts_no_transition_route_in_main() {
+        // AC5: a model with no `:states(…)` field mounts exactly the pre-#1326
+        // route set — no `transition_` entry, no `/transitions/` path.
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "body:Text".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+
+        let main = fs::read_to_string(tmp.path().join("src/main.rs")).unwrap();
+        assert!(
+            !main.contains("transition_"),
+            "no-state-machine scaffold must mount no transition route: {main}"
+        );
+        assert!(
+            !main.contains("/transitions/"),
+            "no-state-machine scaffold must reference no transition path: {main}"
+        );
+    }
+
+    #[test]
+    fn scaffold_state_machine_field_is_transition_only_on_update() {
+        // P2 (issue #1326): a `:states(…)` column is transition-only. It must be
+        // EXCLUDED from the ordinary update surfaces — the edit-form input and the
+        // update handler's `.set((…))` tuple — so a plain `POST /{plural}/{id}/
+        // update` (or a JSON body) cannot set `status=<anything>` and bypass
+        // `transition_status_to` / its guards. It must be KEPT on the create
+        // surface (initial state), the `New{Model}` insert path, and the show
+        // page's transition controls.
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Order",
+            &[
+                "status:String:states(draft -> published, published -> archived)".into(),
+                "title:String".into(),
+            ],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let routes = fs::read_to_string(tmp.path().join("src/routes/orders.rs")).unwrap();
+
+        // ── excluded from the ordinary UPDATE path ───────────────────────────
+        // The update handler's `.set((…))` tuple must NOT set the state column
+        // (that form — `orders::status.eq(new.status.clone())` — is the bypass;
+        // the transition route instead sets `orders::status.eq(new_state)`).
+        assert!(
+            !routes.contains("orders::status.eq(new.status.clone())"),
+            "the update `.set((…))` tuple must exclude the state-machine column: {routes}"
+        );
+        assert!(
+            routes.contains("orders::title.eq(new.title.clone())"),
+            "the update `.set((…))` tuple must still set non-state columns: {routes}"
+        );
+        // The edit form drops the state input; the shared helper takes the flag
+        // and the edit call passes `true`.
+        assert!(
+            routes.contains("exclude_state_fields: bool"),
+            "the shared form helper must take an exclude_state_fields flag: {routes}"
+        );
+        assert!(
+            routes.contains("form = form.exclude(\"status\");"),
+            "the form helper must exclude the state column when asked: {routes}"
+        );
+        assert!(
+            routes.contains(
+                "order_form_for(&changeset, paths::update(*id), \"Save\", csrf.as_ref(), csrf_field.as_ref(), submit_token.as_ref(), submit_field.as_ref(), true)"
+            ),
+            "the EDIT form call must exclude the state field (pass `true`): {routes}"
+        );
+
+        // ── kept on the CREATE path + New{Model} insert ──────────────────────
+        assert!(
+            routes.contains(
+                "order_form_for(&changeset, paths::create(), \"Create\", csrf.as_ref(), csrf_field.as_ref(), submit_token.as_ref(), submit_field.as_ref(), false)"
+            ),
+            "the CREATE form call must keep the state field (pass `false`): {routes}"
+        );
+        // `OrderForm` keeps the column (serde-defaulted so an update submit that
+        // omits it still decodes) and `into_new` seeds the initial state.
+        assert!(
+            routes.contains("#[serde(default)]\n    pub status: String,"),
+            "OrderForm must keep a serde-defaulted state column: {routes}"
+        );
+        assert!(
+            routes.contains("status: form.status.clone(),"),
+            "into_new must seed the initial state on create: {routes}"
+        );
+
+        // ── kept on the SHOW page's transition controls ──────────────────────
+        assert!(
+            routes.contains("transition_controls(&paths::transition_status(row.id), \"status\""),
+            "the show view must still render the state column's transition controls: {routes}"
+        );
+    }
+
+    #[test]
+    fn scaffold_without_state_machine_keeps_field_on_update_surfaces() {
+        // AC5: a no-state-machine model's update form/handler are unchanged — no
+        // exclude flag, every field set on the update path.
+        let tmp = project_with_main(default_main());
+        let plan = plan_scaffold(
+            tmp.path(),
+            "Post",
+            &["title:String".into(), "body:Text".into()],
+            "20260427000000",
+        )
+        .unwrap();
+        plan.execute(Flags::default()).unwrap();
+        let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
+
+        assert!(
+            !routes.contains("exclude_state_fields"),
+            "no-state-machine form helper must not gain an exclude flag: {routes}"
+        );
+        assert!(
+            routes.contains("posts::title.eq(new.title.clone())")
+                && routes.contains("posts::body.eq(new.body.clone())"),
+            "no-state-machine update must set every column: {routes}"
         );
     }
 

--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -11328,6 +11328,7 @@ async fn main() {
                 variants: Vec::new(),
                 unique: false,
                 constraints: FieldConstraints::default(),
+                state_machine: None,
             },
             Field {
                 name: "author_id".to_string(),
@@ -11336,6 +11337,7 @@ async fn main() {
                 variants: Vec::new(),
                 unique: false,
                 constraints: FieldConstraints::default(),
+                state_machine: None,
             },
         ];
         assert_eq!(
@@ -11383,6 +11385,7 @@ async fn main() {
                 variants: Vec::new(),
                 unique: false,
                 constraints: FieldConstraints::default(),
+                state_machine: None,
             },
             Field {
                 name: "author_id".to_string(),
@@ -11391,6 +11394,7 @@ async fn main() {
                 variants: Vec::new(),
                 unique: false,
                 constraints: FieldConstraints::default(),
+                state_machine: None,
             },
         ];
         let sql = render_reference_stub_tables_sql(&fields, "unrelated_table");
@@ -11493,6 +11497,7 @@ async fn main() {
             variants: vec!["a".to_string(), "b".to_string()],
             unique: false,
             constraints: FieldConstraints::default(),
+            state_machine: None,
         };
         let weight = Field {
             name: "weight".to_string(),
@@ -11504,6 +11509,7 @@ async fn main() {
             variants: Vec::new(),
             unique: false,
             constraints: FieldConstraints::default(),
+            state_machine: None,
         };
         let fields = vec![status.clone(), weight];
         let sql = enum_rejection_insert_sql("items", &fields, &status, &BTreeMap::new());

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -512,6 +512,7 @@ fn fields_with_existing_schema_columns(
                 variants: Vec::new(),
                 unique: false,
                 constraints: FieldConstraints::default(),
+                state_machine: None,
             });
         }
     }

--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -1922,12 +1922,20 @@ enum GenerateCommands {
     /// `--index`/`--unique` output. `--unique FIELD` is the flag-based
     /// equivalent, mirroring `--index`'s ergonomics.
     ///
+    /// `field:String:states(from -> to, from -> to: guard, ...)` declares a
+    /// state machine on a non-nullable `String`/`Text` field: it emits a
+    /// `#[state_machine(transitions(...))]` attribute so the model gains
+    /// `transition_field_to`/`can_transition_field_to` guard-checked methods.
+    /// Each `from -> to` edge may carry an optional `: guard` plain method
+    /// name. Quote the token in bash/zsh so the shell doesn't split it.
+    ///
     /// Examples:
     ///
     ///   autumn generate model Post title:String body:Text published:bool
     ///   autumn generate model Comment body:Text post:references
     ///   autumn generate model Post 'status:enum{draft,published,archived}'
     ///   autumn generate model User email:String:unique
+    ///   autumn generate model Page 'status:String:states(draft -> published, published -> archived)'
     #[command(verbatim_doc_comment)]
     Model {
         /// Resource name (`PascalCase` or `snake_case`, e.g. `Post`).

--- a/autumn/src/stories/builtin.rs
+++ b/autumn/src/stories/builtin.rs
@@ -403,5 +403,32 @@ pub(super) fn builtin_stories() -> Vec<Story> {
                 }
             }
         },
+        story! {
+            "Forms",
+            "Transition controls",
+            {
+                use autumn_web::widgets::transition_controls;
+
+                // A `#[state_machine]` field emits a `(from, to, Option<guard>)`
+                // transitions constant and a `can_transition_<field>_to`
+                // predicate; pass those two straight through. Here they are
+                // inlined so the story is self-contained.
+                let transitions: &[(&str, &str, Option<&str>)] = &[
+                    ("draft", "published", None),
+                    ("published", "archived", None),
+                ];
+                // Only edges leaving `current` ("draft") render, so this shows
+                // the single `draft -> published` action button.
+                transition_controls(
+                    "/orders/1/transitions/status",
+                    "status",
+                    "draft",
+                    transitions,
+                    |_to| true, // |to| order.can_transition_status_to(to)
+                    None,
+                    None,
+                )
+            }
+        },
     ]
 }

--- a/autumn/src/ui/widgets.css
+++ b/autumn/src/ui/widgets.css
@@ -1239,6 +1239,37 @@
     border-radius: var(--radius);
 }
 
+/* ── Transition controls (autumn-transition-controls, autumn-transition) ──── */
+
+/* The grouping container holds one no-JS POST form per legal edge leaving the
+   current state; lay them out in a wrapping row of action buttons. */
+.autumn-transition-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+/* Each transition is its own inline form so the buttons sit side by side. */
+.autumn-transition {
+    display: inline-flex;
+    margin: 0;
+}
+
+.autumn-transition button {
+    padding: 0.5rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background-color: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+}
+
+.autumn-transition button[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 /* Visually hidden but still exposed to assistive technology — the standard
    clip pattern (never `display:none`, which removes it from the a11y tree). */
 .autumn-visually-hidden {

--- a/autumn/tests/compile-fail/lifecycle_start_only_on_initial.stderr
+++ b/autumn/tests/compile-fail/lifecycle_start_only_on_initial.stderr
@@ -1,4 +1,4 @@
-error[E0599]: no function or associated item named `start` found for struct `Machine<Paid>` in the current scope
+error[E0599]: no associated function or constant named `start` found for struct `Machine<Paid>` in the current scope
   --> tests/compile-fail/lifecycle_start_only_on_initial.rs:28:56
    |
  6 | / #[lifecycle(
@@ -7,16 +7,17 @@ error[E0599]: no function or associated item named `start` found for struct `Mac
  9 | |     transitions(
 ...  |
 16 | | )]
-   | |__- function or associated item `start` not found for this struct
+   | |__- associated function or constant `start` not found for this struct
 ...
 28 |       let _ = order_state::Machine::<order_state::Paid>::start();
-   |                                                          ^^^^^ function or associated item not found in `Machine<Paid>`
+   |                                                          ^^^^^ associated function or constant not found in `Machine<Paid>`
    |
-   = note: the function or associated item was found for
-           - `Machine<order_state::Pending>`
+   = note: the associated function or constant was found for `Machine<order_state::Pending>`
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following traits define an item `start`, perhaps you need to implement one of them:
-           candidate #1: `regex_syntax::ast::visitor::Visitor`
-           candidate #2: `regex_syntax::hir::visitor::Visitor`
-           candidate #3: `rustls::crypto::SupportedKxGroup`
-           candidate #4: `rustls::crypto::hash::Hash`
+           candidate #1: `opentelemetry::trace::tracer::Tracer`
+           candidate #2: `regex_syntax::ast::visitor::Visitor`
+           candidate #3: `regex_syntax::hir::visitor::Visitor`
+           candidate #4: `rustls::crypto::SupportedKxGroup`
+           candidate #5: `rustls::crypto::hash::Hash`
+           candidate #6: `testcontainers::runners::async_runner::AsyncRunner`

--- a/autumn/tests/compile-fail/lifecycle_terminal_has_no_exit.stderr
+++ b/autumn/tests/compile-fail/lifecycle_terminal_has_no_exit.stderr
@@ -12,5 +12,4 @@ error[E0599]: no method named `to_paid` found for struct `Machine<Delivered>` in
 34 |       let _ = machine.to_paid();
    |                       ^^^^^^^ method not found in `Machine<Delivered>`
    |
-   = note: the method was found for
-           - `Machine<order_state::Pending>`
+   = note: the method was found for `Machine<order_state::Pending>`

--- a/autumn/tests/compile-fail/lifecycle_undeclared_transition.stderr
+++ b/autumn/tests/compile-fail/lifecycle_undeclared_transition.stderr
@@ -12,5 +12,4 @@ error[E0599]: no method named `to_delivered` found for struct `Machine<order_sta
 28 |       let _ = order_state::Machine::start().to_delivered();
    |                                             ^^^^^^^^^^^^ method not found in `Machine<order_state::Pending>`
    |
-   = note: the method was found for
-           - `Machine<Shipped>`
+   = note: the method was found for `Machine<Shipped>`

--- a/autumn/tests/integration/stories.rs
+++ b/autumn/tests/integration/stories.rs
@@ -239,6 +239,7 @@ const EXPECTED_STORY_SLUGS: &[&str] = &[
     "stat-card",
     "tabs",
     "toast",
+    "transition-controls",
 ];
 
 #[test]

--- a/examples/wiki/src/hooks.rs
+++ b/examples/wiki/src/hooks.rs
@@ -56,11 +56,24 @@ impl MutationHooks for PageHooks {
             draft.after.slug = slugify(&draft.after.title);
         }
 
-        // State-machine transitions are no longer enforced here: status changes
-        // flow through the dedicated `POST /pages/{slug}/transitions/status`
-        // route, which calls the macro-generated `Page::transition_status_to`.
-        // The edit form only edits title/body, so `draft.after.status` always
-        // equals `draft.before.status` on this path.
+        // Enforce state-machine transitions on EVERY update path. The HTML edit
+        // form only edits title/body (status changes flow through the dedicated
+        // `POST /pages/{slug}/transitions/status` route), so `draft.after.status`
+        // normally equals `draft.before.status` here. But the JSON API /
+        // repository path (`page_api_update`, mounted in `main.rs`) can set
+        // `UpdatePage.status` directly — e.g. `published -> draft` — which would
+        // otherwise bypass the state machine. When the incoming update changes
+        // `status`, validate it is a legal edge by driving the macro-generated
+        // `Page::transition_status_to` (DRY with the state machine, no hand-rolled
+        // match): build the proposed row (new content, OLD status) so the
+        // `can_publish` guard evaluates against the proposed content, then
+        // propagate the transition's `Err` — an illegal edge or a rejected guard
+        // is a 400 and the write is refused.
+        if draft.after.status != draft.before.status {
+            let mut proposed = draft.after.clone();
+            proposed.status.clone_from(&draft.before.status);
+            proposed.transition_status_to(&draft.after.status)?;
+        }
 
         // Maintain the published-page content invariant even when status is
         // unchanged; an edit that clears title/body on an already-published
@@ -286,6 +299,77 @@ mod tests {
 
         let mut draft = UpdateDraft { before, after };
         hooks.before_update(&mut ctx, &mut draft).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn before_update_allows_legal_draft_to_published_transition() {
+        // The API/repository update path can change status directly. A legal
+        // edge (draft -> published) with publishable content must pass through
+        // `before_update` — proving the hook enforces the state machine, not just
+        // the HTML transition route.
+        let hooks = PageHooks;
+        let mut ctx = MutationContext::new(MutationOp::Update);
+        let before = page_with("draft", "Some content");
+        let mut after = before.clone();
+        after.status = "published".into();
+
+        let mut draft = UpdateDraft { before, after };
+        hooks.before_update(&mut ctx, &mut draft).await.unwrap();
+        assert_eq!(draft.after.status, "published");
+    }
+
+    #[tokio::test]
+    async fn before_update_allows_legal_published_to_archived_transition() {
+        // published -> archived is an unguarded defined edge, completing the
+        // draft -> published -> archived chain through the update hook path.
+        let hooks = PageHooks;
+        let mut ctx = MutationContext::new(MutationOp::Update);
+        let before = page_with("published", "Some content");
+        let mut after = before.clone();
+        after.status = "archived".into();
+
+        let mut draft = UpdateDraft { before, after };
+        hooks.before_update(&mut ctx, &mut draft).await.unwrap();
+        assert_eq!(draft.after.status, "archived");
+    }
+
+    #[tokio::test]
+    async fn before_update_rejects_illegal_transition_via_api_path() {
+        // Regression (issue #1326): `page_api_update` can set `status` directly.
+        // An illegal edge (published -> draft) that never goes through the HTML
+        // transition route must still be REJECTED by `before_update`, so the API
+        // cannot bypass the state machine.
+        let hooks = PageHooks;
+        let mut ctx = MutationContext::new(MutationOp::Update);
+        let before = page_with("published", "Some content");
+        let mut after = before.clone();
+        after.status = "draft".into(); // illegal: no published -> draft edge
+
+        let mut draft = UpdateDraft { before, after };
+        let result = hooks.before_update(&mut ctx, &mut draft).await;
+        assert!(
+            result.is_err(),
+            "an illegal published -> draft transition via the API path must be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn before_update_transition_guard_rejects_publishing_empty_body() {
+        // The can_publish guard must be enforced on the update-hook transition
+        // path too: draft -> published with an empty body is a rejected guard.
+        let hooks = PageHooks;
+        let mut ctx = MutationContext::new(MutationOp::Update);
+        let before = page_with("draft", "Some content");
+        let mut after = before.clone();
+        after.body = String::new();
+        after.status = "published".into();
+
+        let mut draft = UpdateDraft { before, after };
+        let result = hooks.before_update(&mut ctx, &mut draft).await;
+        assert!(
+            result.is_err(),
+            "publishing with an empty body via the update hook must be rejected by the guard"
+        );
     }
 
     #[tokio::test]

--- a/examples/wiki/src/hooks.rs
+++ b/examples/wiki/src/hooks.rs
@@ -56,16 +56,11 @@ impl MutationHooks for PageHooks {
             draft.after.slug = slugify(&draft.after.title);
         }
 
-        // Enforce state machine transitions; returns 400 for invalid edges or
-        // when the can_publish guard rejects draft -> published.
-        // Evaluate guards against the proposed (after) content by cloning the
-        // new record and restoring the current status, so can_publish sees the
-        // title/body the user is submitting, not the old values.
-        if draft.after.status != draft.before.status {
-            let mut proposed = draft.after.clone();
-            proposed.status = draft.before.status.clone();
-            proposed.transition_status_to(&draft.after.status)?;
-        }
+        // State-machine transitions are no longer enforced here: status changes
+        // flow through the dedicated `POST /pages/{slug}/transitions/status`
+        // route, which calls the macro-generated `Page::transition_status_to`.
+        // The edit form only edits title/body, so `draft.after.status` always
+        // equals `draft.before.status` on this path.
 
         // Maintain the published-page content invariant even when status is
         // unchanged; an edit that clears title/body on an already-published
@@ -183,78 +178,65 @@ mod tests {
         assert!(err.to_string().contains("3"));
     }
 
-    #[tokio::test]
-    async fn test_before_update_allows_valid_status_transition() {
-        let hooks = PageHooks;
-        let mut ctx = MutationContext::new(MutationOp::Update);
-        let before = Page {
+    fn page_with(status: &str, body: &str) -> Page {
+        Page {
             id: 1,
             title: "My Page".into(),
             slug: "my-page".into(),
-            body: "Some content".into(),
-            status: "draft".into(),
+            body: body.into(),
+            status: status.into(),
             lock_version: 0,
             created_at: Utc::now().naive_utc(),
             updated_at: Utc::now().naive_utc(),
-        };
-        let mut after = before.clone();
-        after.status = "published".into();
-
-        let mut draft = UpdateDraft { before, after };
-        hooks.before_update(&mut ctx, &mut draft).await.unwrap();
-
-        assert_eq!(draft.after.status, "published");
+        }
     }
 
-    #[tokio::test]
-    async fn test_before_update_rejects_invalid_status_transition() {
-        let hooks = PageHooks;
-        let mut ctx = MutationContext::new(MutationOp::Update);
-        let before = Page {
-            id: 1,
-            title: "My Page".into(),
-            slug: "my-page".into(),
-            body: "Some content".into(),
-            status: "published".into(),
-            lock_version: 0,
-            created_at: Utc::now().naive_utc(),
-            updated_at: Utc::now().naive_utc(),
-        };
-        let mut after = before.clone();
-        after.status = "draft".into(); // published -> draft is not a defined edge
-
-        let mut draft = UpdateDraft { before, after };
-        let result = hooks.before_update(&mut ctx, &mut draft).await;
-
-        assert!(result.is_err());
+    #[test]
+    fn transition_status_to_allows_draft_to_published() {
+        // draft -> published is a defined edge and the can_publish guard passes
+        // on non-empty content. Enforcement now lives in the macro-generated
+        // state machine, exercised by the transitions route.
+        let page = page_with("draft", "Some content");
+        assert!(page.can_transition_status_to("published"));
+        assert_eq!(page.transition_status_to("published").unwrap(), "published");
     }
 
-    #[tokio::test]
-    async fn test_before_update_guard_sees_proposed_content() {
-        // Updating status AND clearing body in the same request must be rejected —
-        // the guard should evaluate the body being submitted, not the old body.
-        let hooks = PageHooks;
-        let mut ctx = MutationContext::new(MutationOp::Update);
-        let before = Page {
-            id: 1,
-            title: "My Page".into(),
-            slug: "my-page".into(),
-            body: "Has content".into(),
-            status: "draft".into(),
-            lock_version: 0,
-            created_at: Utc::now().naive_utc(),
-            updated_at: Utc::now().naive_utc(),
-        };
-        let mut after = before.clone();
-        after.status = "published".into();
-        after.body = String::new(); // clearing body in the same update
+    #[test]
+    fn transition_status_to_allows_published_to_archived() {
+        // published -> archived is an unguarded defined edge, completing the
+        // draft -> published -> archived chain.
+        let page = page_with("published", "Some content");
+        assert!(page.can_transition_status_to("archived"));
+        assert_eq!(page.transition_status_to("archived").unwrap(), "archived");
+    }
 
-        let mut draft = UpdateDraft { before, after };
-        let result = hooks.before_update(&mut ctx, &mut draft).await;
+    #[test]
+    fn transition_status_to_rejects_invalid_edge() {
+        // published -> draft is not a defined edge, so the state machine rejects
+        // it with a 400.
+        let page = page_with("published", "Some content");
+        assert!(!page.can_transition_status_to("draft"));
+        assert!(page.transition_status_to("draft").is_err());
+    }
 
+    #[test]
+    fn transition_status_to_guard_rejects_publishing_empty_body() {
+        // The can_publish guard blocks draft -> published when body is empty.
+        let page = page_with("draft", "");
+        assert!(!page.can_transition_status_to("published"));
         assert!(
-            result.is_err(),
+            page.transition_status_to("published").is_err(),
             "guard must reject publishing with empty body"
+        );
+    }
+
+    #[test]
+    fn transition_status_to_guard_rejects_whitespace_only_body() {
+        // Whitespace-only body is treated as empty by the can_publish guard.
+        let page = page_with("draft", "   ");
+        assert!(
+            page.transition_status_to("published").is_err(),
+            "guard must reject publishing with whitespace-only body"
         );
     }
 
@@ -334,32 +316,6 @@ mod tests {
         assert!(
             result.is_err(),
             "creating a page with status=archived must fail"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_before_update_rejects_whitespace_only_publish() {
-        let hooks = PageHooks;
-        let mut ctx = MutationContext::new(MutationOp::Update);
-        let before = Page {
-            id: 1,
-            title: "My Page".into(),
-            slug: "my-page".into(),
-            body: "Some content".into(),
-            status: "draft".into(),
-            lock_version: 0,
-            created_at: Utc::now().naive_utc(),
-            updated_at: Utc::now().naive_utc(),
-        };
-        let mut after = before.clone();
-        after.status = "published".into();
-        after.body = "   ".into(); // whitespace-only
-
-        let mut draft = UpdateDraft { before, after };
-        let result = hooks.before_update(&mut ctx, &mut draft).await;
-        assert!(
-            result.is_err(),
-            "guard must reject publishing with whitespace-only body"
         );
     }
 

--- a/examples/wiki/src/main.rs
+++ b/examples/wiki/src/main.rs
@@ -26,6 +26,7 @@ async fn main() {
             routes::pages::create,
             routes::pages::edit_form,
             routes::pages::update,
+            routes::pages::transition_status,
             routes::pages::history,
             routes::pages::search,
             repositories::page_api_list,

--- a/examples/wiki/src/routes/pages.rs
+++ b/examples/wiki/src/routes/pages.rs
@@ -153,6 +153,22 @@ pub async fn show(
                           class="text-sm text-gray-500 hover:underline" { "History" }
                     }
                 }
+                // State-machine transition buttons, generated from the same
+                // `#[state_machine(...)]` declaration on `Page::status` that the
+                // `transition_status` route enforces. Only edges leaving the
+                // current state render; the `can_transition_status_to` guard
+                // disables an edge (e.g. publishing an empty page). No CSRF token
+                // is threaded here — the wiki example runs without CSRF, like its
+                // other forms.
+                (autumn_web::widgets::transition_controls(
+                    &paths::transition_status(page.slug.clone()),
+                    "status",
+                    &page.status,
+                    Page::__AUTUMN_SM_STATUS_TRANSITIONS,
+                    |to| page.can_transition_status_to(to),
+                    None,
+                    None,
+                ))
                 div class="prose bg-white rounded shadow p-6" {
                     @for para in page.body.split("\n\n") {
                         @if !para.trim().is_empty() {
@@ -281,13 +297,11 @@ pub async fn edit_form(Path(slug): Path<String>, repo: PgPageRepository) -> Autu
                     textarea id="body" name="body" rows="10"
                              class="w-full border rounded p-2 mt-1" { (page.body) }
                 }
-                div {
-                    label for="status" class="block text-sm font-medium" { "Status" }
-                    select id="status" name="status" class="border rounded p-2 mt-1" {
-                        option value="draft" selected[page.status == "draft"] { "Draft" }
-                        option value="published" selected[page.status == "published"] { "Published" }
-                        option value="archived" selected[page.status == "archived"] { "Archived" }
-                    }
+                p class="text-sm text-gray-500" {
+                    "Status: " (status_badge(&page.status))
+                    " — change it from the "
+                    a href=(paths::show(page.slug.clone())) class="text-emerald-600 hover:underline" { "page" }
+                    " using the status controls."
                 }
                 input type="hidden" name="lock_version" value=(page.lock_version);
                 button type="submit"
@@ -307,6 +321,10 @@ pub async fn edit_form(Path(slug): Path<String>, repo: PgPageRepository) -> Autu
 pub struct PageForm {
     pub title: String,
     pub body: String,
+    // Only the create form submits an initial status; the edit form edits
+    // title/body and leaves status untouched (status changes flow through the
+    // dedicated transitions route), so this defaults when absent.
+    #[serde(default)]
     pub status: String,
     #[serde(default)]
     pub lock_version: i32,
@@ -327,10 +345,19 @@ impl PageForm {
             title: Patch::Set(self.title),
             slug: Patch::Unchanged,
             body: Patch::Set(self.body),
-            status: Patch::Set(self.status),
+            // Status transitions go through `transition_status`, never the edit
+            // form, so an edit leaves the stored status unchanged.
+            status: Patch::Unchanged,
             lock_version: self.lock_version,
         }
     }
+}
+
+/// Form body posted by the `transition_controls` widget on the show page: the
+/// target state under the field name (`status`).
+#[derive(serde::Deserialize)]
+pub struct TransitionForm {
+    pub status: String,
 }
 
 pub(crate) fn generate_update_summary(
@@ -358,6 +385,54 @@ pub async fn update(
     let page = find_page_by_slug(&repo, &slug).await?;
     let update_page = form.0.into_update();
     let updated = repo.update(page.id, &update_page).await?;
+
+    let summary =
+        generate_update_summary(&page.status, &updated.status, &page.title, &updated.title);
+
+    diesel::insert_into(revisions::table)
+        .values(&NewRevision {
+            page_id: updated.id,
+            op: "update".into(),
+            title: updated.title.clone(),
+            body: updated.body.clone(),
+            status: updated.status.clone(),
+            changed_by: None,
+            summary,
+        })
+        .execute(&mut *db)
+        .await?;
+
+    Ok(Redirect::to(&paths::show(updated.slug)))
+}
+
+/// `POST /pages/{slug}/transitions/status` — apply a state-machine transition.
+///
+/// The `transition_controls` widget on the show page posts the target state
+/// under the field name (`status`). Enforcement is the macro-generated
+/// `Page::transition_status_to`, which returns a 400 for an undefined edge or a
+/// rejected `can_publish` guard — surfaced here by `?`, matching the wiki's
+/// error-propagation convention (no Flash layer is configured).
+#[post("/pages/{slug}/transitions/status")]
+pub async fn transition_status(
+    Path(slug): Path<String>,
+    repo: PgPageRepository,
+    mut db: Db,
+    form: Form<TransitionForm>,
+) -> AutumnResult<Redirect> {
+    let page = find_page_by_slug(&repo, &slug).await?;
+
+    // The state machine is the single source of truth: illegal edges and
+    // guard rejections become a 400 here.
+    let new_status = page.transition_status_to(&form.0.status)?;
+
+    let update = crate::models::UpdatePage {
+        title: Patch::Unchanged,
+        slug: Patch::Unchanged,
+        body: Patch::Unchanged,
+        status: Patch::Set(new_status),
+        lock_version: page.lock_version,
+    };
+    let updated = repo.update(page.id, &update).await?;
 
     let summary =
         generate_update_summary(&page.status, &updated.status, &page.title, &updated.title);
@@ -448,7 +523,15 @@ pub async fn history(
 }
 
 autumn_web::paths![
-    list, show, new_form, create, edit_form, update, history, search
+    list,
+    show,
+    new_form,
+    create,
+    edit_form,
+    update,
+    transition_status,
+    history,
+    search
 ];
 
 /// Look up a page by slug, returning 404 if not found.


### PR DESCRIPTION
**Closes #1326.** Teaches `autumn generate` to see and wire up `#[state_machine]` fields end-to-end.

## Before / After
**Before:** the scaffold generator was blind to `#[state_machine]` — you could hand-write a state-machine field on a model, but the generated CRUD had no way to declare one and no transition UI or endpoint; enforcing a legal state change meant hand-rolling a `before_update` hook and a bespoke ``.
**After:** a scaffold field can declare a state machine in the DSL, and the generator emits the `#[state_machine(...)]` model attribute plus a transition route and show-page controls that only allow legal transitions.

## What&#39;s in this PR
- **Field DSL** — `name:String:states(from -&gt; to, from -&gt; to: guard, ...)` → `dsl::Field.state_machine`; the model generator emits `#[state_machine(transitions(...))]`. Gated on `state_machine.is_some()`, so a model with no state-machine field renders byte-identical output.
- **Transition route (AC1/AC2)** — generated `POST /{plural}/{id}/transitions/{field}`: reads the target state from the form body (the field-named key `transition_controls` posts), calls `row.transition_{field}_to(&amp;target)` → on `Ok` a single-column persist + `flash.success` + 303 to show; on `Err` (illegal edge) `flash.error` + 422 re-render of the detail page with the record unchanged.
- **Show view (AC3/AC4)** — the show body is extracted into a shared `show_view(...)` (CSRF-threaded) and `autumn_web::widgets::transition_controls(...)` is spliced in after the property list. Everything is gated on `has_state_machine`, so a no-SM model&#39;s generated `show`/routes are byte-identical and contain no `/transitions/`.
- **Wiki example (AC6)** — `examples/wiki` switches from its hand-rolled `before_update` enforcement + `` to the generated route + `transition_controls`; its `hooks.rs` `#[tokio::test]`s are retargeted to the state machine and still verify draft→published→archived.

## AC5 — no-op safety (byte-identical)
A model without a state-machine field produces byte-identical generator output and generated routes contain no `/transitions/`. All pre-existing scaffold/model/introspect golden tests pass unchanged; a new `scaffold_without_state_machine_emits_no_transition_wiring` test asserts no `/transitions/`, no `fn show_view`, no `transition_controls`, and the unchanged three-arg `show` signature.

## Local verification (all green)
- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (full scope), plus a manual clippy-1.97 sweep of each diff.
- `cargo test -p autumn-cli` — 177 passed; `--bins` 3799 passed (incl. new SM tests); `cli_tests -- scaffold` 82, `-- generate` 48 — all golden tests unchanged.
- `cargo test -p wiki` — 33 passed, draft→published→archived green.
- **Heavy gate — generated app compiles against in-tree `autumn-web`:** the CI generated-app gate `generated_scaffold_cargo_checks` passes locally (84.69s), and a manual `:states(...)` SM scaffold `cargo check`s clean with **zero SM-introduced warnings** (proven against a non-SM baseline scaffold — the only warnings are pre-existing `serde_json`/`Update{Model}` unused-import noise emitted for every scaffold).

## Commits
- `2321159a` — field DSL + `dsl::Field.state_machine` + model emission.
- `a84b5133` — transition route + `show_view` + `transition_controls` splice.
- `e4974f0a` — wiki example rewired to the generated mechanism.
- `8b04f5bf` — record-policy authorization on the generated transition route (closes the transition-route IDOR flagged in review).
- `4e9a6360` — enforce state-machine transitions on the wiki example's API update path.