### PR TITLE
👹 Havoc: Fix presence event ordering race condition

### DIFF
--- a/autumn/src/presence.rs
+++ b/autumn/src/presence.rs
@@ -250,16 +250,22 @@ impl Presence {
         let meta = meta.into();
         let connection_id = next_connection_id();
 
-        {
-            let mut inner = self.inner.lock().expect("presence lock poisoned");
-            inner.add(&topic, &key, connection_id, meta.clone());
-        }
-
         let event = PresenceEvent::Join {
             key: key.clone(),
-            meta,
+            meta: meta.clone(),
         };
-        self.publish_event(&topic, &event);
+
+        let json = serde_json::to_string(&event).unwrap_or_default();
+        let publish_channel = format!("presence:{}", topic);
+
+        {
+            let mut inner = self.inner.lock().expect("presence lock poisoned");
+            inner.add(&topic, &key, connection_id, meta);
+
+            if let Err(e) = self.channels.publish(&publish_channel, json) {
+                tracing::warn!(topic = %topic, error = ?e, "presence: failed to publish event");
+            }
+        }
 
         PresenceHandle {
             topic,
@@ -303,19 +309,17 @@ impl Presence {
     ///
     /// Panics if the internal presence store mutex is poisoned.
     pub fn sweep_expired(&self) {
-        let removed = {
-            let mut inner = self.inner.lock().expect("presence lock poisoned");
-            inner.sweep_expired()
-        };
-        for (topic, key) in removed {
-            self.publish_event(&topic, &PresenceEvent::Leave { key });
-        }
-    }
+        let mut inner = self.inner.lock().expect("presence lock poisoned");
+        let removed = inner.sweep_expired();
 
-    fn publish_event(&self, topic: &str, event: &PresenceEvent) {
-        let json = serde_json::to_string(event).unwrap_or_default();
-        if let Err(e) = self.channels.publish(&format!("presence:{topic}"), json) {
-            tracing::warn!(topic, error = ?e, "presence: failed to publish event");
+        // Publish events while still holding the lock to preserve exact ordering
+        // relative to other track/drop events.
+        for (topic, key) in removed {
+            let event = PresenceEvent::Leave { key };
+            let json = serde_json::to_string(&event).unwrap_or_default();
+            if let Err(e) = self.channels.publish(&format!("presence:{topic}"), json) {
+                tracing::warn!(topic = %topic, error = ?e, "presence: failed to publish sweep event");
+            }
         }
     }
 }
@@ -360,10 +364,8 @@ impl PresenceHandle {
 
 impl Drop for PresenceHandle {
     fn drop(&mut self) {
-        let key_fully_removed = {
-            let mut inner = self.inner.lock().expect("presence lock poisoned");
-            inner.remove(&self.topic, &self.key, self.connection_id)
-        };
+        let mut inner = self.inner.lock().expect("presence lock poisoned");
+        let key_fully_removed = inner.remove(&self.topic, &self.key, self.connection_id);
 
         // Only broadcast Leave when this was the last connection for the key.
         // If the same user still has other tabs open their key remains present,

--- a/autumn/tests/loom_models.rs
+++ b/autumn/tests/loom_models.rs
@@ -342,3 +342,82 @@ fn metrics_active_gauge_balance() {
         );
     });
 }
+
+#[test]
+fn presence_event_ordering_race() {
+    let show_bug = std::env::var_os("_LOOM_SHOW_BUG").is_some();
+
+    loom::model(move || {
+        // State represents the number of active connections for a user.
+        // 1 means user is present, 0 means user has left.
+        let state = Arc::new(Mutex::new(1));
+        let events = Arc::new(Mutex::new(Vec::new()));
+
+        let t1 = {
+            let state = state.clone();
+            let events = events.clone();
+            thread::spawn(move || {
+                // Thread 1: drop(PresenceHandle) for the LAST connection
+                if show_bug {
+                    // BUGGY: update state, release lock, then publish
+                    let fully_removed = {
+                        let mut st = state.lock().unwrap();
+                        if *st == 1 {
+                            *st = 0;
+                            true
+                        } else {
+                            false
+                        }
+                    };
+                    if fully_removed {
+                        events.lock().unwrap().push("Leave");
+                    }
+                } else {
+                    // CORRECT: publish while holding the state lock
+                    let mut st = state.lock().unwrap();
+                    if *st == 1 {
+                        *st = 0;
+                        events.lock().unwrap().push("Leave");
+                    }
+                }
+            })
+        };
+
+        let t2 = {
+            let state = state.clone();
+            let events = events.clone();
+            thread::spawn(move || {
+                // Thread 2: track() a NEW connection
+                if show_bug {
+                    // BUGGY: update state, release lock, then publish
+                    {
+                        let mut st = state.lock().unwrap();
+                        *st = 1;
+                    }
+                    events.lock().unwrap().push("Join");
+                } else {
+                    // CORRECT: publish while holding the state lock
+                    let mut st = state.lock().unwrap();
+                    *st = 1;
+                    events.lock().unwrap().push("Join");
+                }
+            })
+        };
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+
+        let final_state = *state.lock().unwrap();
+        let evs = events.lock().unwrap();
+
+        // The sequence of events must be consistent with the final state.
+        if !evs.is_empty() {
+            let last_event = evs.last().unwrap();
+            if final_state == 1 {
+                assert_eq!(*last_event, "Join", "state is 1 (present) but last event is {}", last_event);
+            } else {
+                assert_eq!(*last_event, "Leave", "state is 0 (absent) but last event is {}", last_event);
+            }
+        }
+    });
+}

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,18 @@
+👹 Havoc: Fix presence event ordering race condition
+
+🧨 **The Trigger:**
+Concurrent connection `track` (Join) and `drop` (Leave) operations on the same key could release the internal presence state `Mutex` before publishing their respective events to the broadcast channel. This allowed a `Leave` event from an expiring connection to be published *after* a `Join` event from a new connection, even though the internal state reflected the new connection as active. Clients would process the `Leave` last and incorrectly display the user as offline.
+
+📉 **The Stack Trace:**
+```
+thread 'presence_event_ordering_race' panicked at autumn/tests/loom_models.rs:417:17:
+assertion `left == right` failed: state is 1 (present) but last event is Leave
+  left: "Leave"
+ right: "Join"
+```
+
+🧪 **Reproduction:**
+Run `_LOOM_SHOW_BUG=1 RUSTFLAGS="--cfg loom_models" cargo test -p autumn-web --test loom_models presence_event_ordering_race`.
+
+😈 **Comment:**
+You assumed that releasing the lock early was a clever performance optimization. You were wrong. Event emission must be strictly serialized with the state mutation it represents. Welcome to the wonderful world of distributed state.


### PR DESCRIPTION
🧨 **The Trigger:** 
Concurrent connection `track` (Join) and `drop` (Leave) operations on the same key could release the internal presence state `Mutex` before publishing their respective events to the broadcast channel. This allowed a `Leave` event from an expiring connection to be published *after* a `Join` event from a new connection, even though the internal state reflected the new connection as active. Clients would process the `Leave` last and incorrectly display the user as offline.

📉 **The Stack Trace:**
```
thread 'presence_event_ordering_race' panicked at autumn/tests/loom_models.rs:417:17:
assertion `left == right` failed: state is 1 (present) but last event is Leave
  left: "Leave"
 right: "Join"
```

🧪 **Reproduction:**
Run `_LOOM_SHOW_BUG=1 RUSTFLAGS="--cfg loom_models" cargo test -p autumn-web --test loom_models presence_event_ordering_race`.

😈 **Comment:** 
You assumed that releasing the lock early was a clever performance optimization. You were wrong. Event emission must be strictly serialized with the state mutation it represents. Welcome to the wonderful world of distributed state.

---
*PR created automatically by Jules for task [15395497866760111664](https://jules.google.com/task/15395497866760111664) started by @madmax983*