### PR TITLE
Mirror New-project aria-label into examples/saas + relink #1915 private doc links (completes #1930, Part of #1706)

### DIFF
--- a/autumn-cli/src/generate/mod.rs
+++ b/autumn-cli/src/generate/mod.rs
@@ -312,7 +312,7 @@ pub fn read_or_empty(path: &Path) -> String {
 /// emitting Postgres DDL (`BIGSERIAL`, `TIMESTAMPTZ`, `NOW()`) for a `SQLite`
 /// app.
 ///
-/// Defaults to [`DatabaseBackend::Postgres`] when no URL can be resolved or its
+/// Defaults to [`DatabaseBackend::Postgres`](autumn_web::config::DatabaseBackend::Postgres) when no URL can be resolved or its
 /// shape is unrecognized, preserving today's Postgres-only generator behavior
 /// with no regression. The emitted DDL / diesel schema is then made
 /// backend-aware so no generator output compiles against Postgres but breaks on

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -62,7 +62,7 @@ pub fn schema_table_block_with_id(table: &str, fields: &[Field], id_type: IdType
     schema_table_block_with_id_for(DatabaseBackend::Postgres, table, fields, id_type)
 }
 
-/// [`schema_table_block_with_id`] for a specific database `backend` (`SQLite`
+/// `schema_table_block_with_id` for a specific database `backend` (`SQLite`
 /// foundation, issue #1614). The Postgres path is byte-for-byte identical to
 /// the historical output; the `SQLite` path uses the diesel sql-types that
 /// diesel's `SQLite` backend actually implements (`Text` for `Uuid`/`Jsonb`,
@@ -219,7 +219,7 @@ pub fn schema_has_table(schema: &str, table: &str) -> bool {
 /// as [`append_schema_table`] shapes it), or an empty `Vec` if `table` isn't
 /// declared there at all.
 ///
-/// Used by [`add_columns_up_sql`]/[`remove_columns_down_sql`] (issue #1032
+/// Used by `add_columns_up_sql`/`remove_columns_down_sql` (issue #1032
 /// review follow-up) to extend their unique-index collision check beyond the
 /// columns being added/removed in the current `AddXToY`/`RemoveXFromY`
 /// migration: a plain index on some *other*, already-existing column named
@@ -615,7 +615,7 @@ pub fn add_columns_up_sql(table: &str, fields: &[Field], existing_schema: &str) 
         .expect("Postgres ADD COLUMN generation never rejects")
 }
 
-/// [`add_columns_up_sql`] for a specific database `backend` (issue #1614). The
+/// `add_columns_up_sql` for a specific database `backend` (issue #1614). The
 /// Postgres path stays byte-for-byte identical; the `SQLite` path emits
 /// `SQLite`-valid column types via [`super::dsl::Field::sql_column_type_for`].
 ///
@@ -706,7 +706,7 @@ pub fn add_columns_down_sql(table: &str, fields: &[Field]) -> String {
     add_columns_down_sql_for(DatabaseBackend::Postgres, table, fields, "")
 }
 
-/// [`add_columns_down_sql`] for a specific database `backend` (issue #1614).
+/// `add_columns_down_sql` for a specific database `backend` (issue #1614).
 ///
 /// On `SQLite`, [`add_columns_up_sql_for`] emits a `CREATE INDEX` for an added
 /// nullable `references` field or a `unique` field, but `SQLite` refuses to
@@ -913,7 +913,7 @@ pub fn remove_columns_up_sql(table: &str, fields: &[Field]) -> String {
     remove_columns_up_sql_for(DatabaseBackend::Postgres, table, fields, "")
 }
 
-/// [`remove_columns_up_sql`] for a specific database `backend` (issue #1614).
+/// `remove_columns_up_sql` for a specific database `backend` (issue #1614).
 ///
 /// Prepends an `autumn-safety` comment for each `DROP COLUMN` to make the
 /// rolling-deploy risk visible at a glance and machine-parseable by
@@ -1002,7 +1002,7 @@ pub fn remove_columns_down_sql(table: &str, fields: &[Field], existing_schema: &
         .expect("Postgres ADD COLUMN generation never rejects")
 }
 
-/// [`remove_columns_down_sql`] for a specific database `backend` (issue #1614).
+/// `remove_columns_down_sql` for a specific database `backend` (issue #1614).
 /// The Postgres path stays byte-for-byte identical; the `SQLite` path restores
 /// the dropped column with a `SQLite`-valid type via
 /// [`super::dsl::Field::sql_column_type_for`].

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -5737,7 +5737,7 @@ pub fn check_stored_slot_map(
 /// The cross-backend consistency rule, as a single source of truth.
 ///
 /// Shared by boot-time validation ([`DatabaseConfig::validate`], via
-/// [`DatabaseConfig::validate_backend_consistency`]) and out-of-process callers
+/// `DatabaseConfig::validate_backend_consistency`) and out-of-process callers
 /// such as `autumn doctor`, so both agree for *every* role/backend mismatch
 /// without re-deriving the rule.
 ///

--- a/autumn/src/dotenv.rs
+++ b/autumn/src/dotenv.rs
@@ -275,13 +275,13 @@ pub(crate) fn resolve_dotenv_vars(
 /// Resolve the merged `.env` variable set for an EXPLICIT directory and profile,
 /// layered under `base` (real env wins).
 ///
-/// A public seam over [`resolve_dotenv_vars`] for CLI callers that resolve
+/// A public seam over `resolve_dotenv_vars` for CLI callers that resolve
 /// config for a specific project directory rather than the process manifest dir
 /// — e.g. `autumn generate`'s backend detection, which reads the profile-merged
 /// `autumn.toml` from a passed `project_root` and must consult the same `.env`
-/// the app / `autumn migrate` would. Same gating ([`should_load`] — only the
+/// the app / `autumn migrate` would. Same gating (`should_load` — only the
 /// `dev`/`test` profiles auto-load unless `AUTUMN_DOTENV=1`), same
-/// profile-selector exclusion ([`PROFILE_SELECTOR_KEYS`]), and same precedence
+/// profile-selector exclusion (`PROFILE_SELECTOR_KEYS`), and same precedence
 /// (`base` wins; the first candidate file to set a key wins over later ones) as
 /// the process-level [`resolve_process_dotenv`].
 ///

--- a/autumn/src/nested_form.rs
+++ b/autumn/src/nested_form.rs
@@ -814,7 +814,7 @@ impl<P, C: NestedChild> NestedChangesetForm<P, C> {
     ///
     /// The submit token starts `None`, so a bare `blank(..).form_tag(..)` emits
     /// **no** submit-token hidden input and the first submission is not protected
-    /// against double-submit ([`SubmitTokenLayer`](crate::security::submit_token)
+    /// against double-submit ([`SubmitTokenLayer`](crate::security::SubmitTokenLayer)
     /// passes tokenless mutating requests through). Supply the minted token on the
     /// initial GET with [`with_submit_token`](Self::with_submit_token) (and
     /// [`with_submit_field`](Self::with_submit_field) if the field name is
@@ -883,7 +883,7 @@ impl<P, C: NestedChild> NestedChangesetForm<P, C> {
     /// double-submit, not just later 422 re-renders.
     ///
     /// [`blank`](Self::blank) leaves this `None` (the initial page renders no
-    /// submit-token field otherwise), and [`SubmitTokenLayer`](crate::security::submit_token)
+    /// submit-token field otherwise), and [`SubmitTokenLayer`](crate::security::SubmitTokenLayer)
     /// passes tokenless mutating requests through unchanged — so without calling
     /// this the first create-form submit is unprotected. Source the token from a
     /// [`SubmitToken`](crate::security::SubmitToken) extractor on the GET handler.
@@ -1037,7 +1037,7 @@ impl<P, C: NestedChild> NestedChangesetForm<P, C> {
     /// [`with_submit_token`](Self::with_submit_token) so the **first** submit is
     /// protected against double-submit too — otherwise a bare
     /// `blank(..).form_tag(..)` create form carries no submit token and its first
-    /// submission passes through [`SubmitTokenLayer`](crate::security::submit_token)
+    /// submission passes through [`SubmitTokenLayer`](crate::security::SubmitTokenLayer)
     /// unprotected.
     #[must_use]
     #[allow(clippy::needless_pass_by_value)]

--- a/autumn/src/seed.rs
+++ b/autumn/src/seed.rs
@@ -149,7 +149,7 @@ impl SeedContext {
     ///
     /// Useful for APIs that take a `&Pool<AsyncPgConnection>` directly, such as
     /// factory `create_many(count, pool)` and
-    /// [`fake_seed_model`](crate::seed::fake_seed_model).
+    /// [`fake_seed_model`].
     #[must_use]
     pub const fn pool(&self) -> &Pool<AsyncPgConnection> {
         &self.pool

--- a/examples/saas/src/routes/dashboard.rs
+++ b/examples/saas/src/routes/dashboard.rs
@@ -36,7 +36,7 @@ pub async fn dashboard(
 
             form action="/dashboard/projects" method="post"
                  class="flex gap-2 mb-6 bg-white rounded-lg shadow p-4" {
-                input name="name" required placeholder="New project name"
+                input name="name" required placeholder="New project name" aria-label="New project name"
                       class="flex-1 border rounded px-3 py-2";
                 button type="submit"
                        class="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700" {


### PR DESCRIPTION
## Summary

A chore PR clearing **three independent trunk-based-PR reds** so the shared checks go green for everything that rebases on trunk. Part of #1706. **This is the trunk unblock — the branch everything else rebases on.**

### Red (a) — saas example aria-label drift (completes #1930)
#1930 added `aria-label=&#34;New project name&#34;` to the **embedded** saas starter dashboard (`autumn-cli/src/starters/saas/src/routes/dashboard.rs`) but missed the mirrored copy at `examples/saas/src/routes/dashboard.rs`. The drift-sync test `starters::tests::embedded_saas_matches_example_saas` does a byte-for-byte compare, so it failed on **every** trunk-based PR.

**Fix:** mirror the same `aria-label` into `examples/saas` so the two files are byte-identical again — the example also gains the a11y improvement. The aria-label is **not** removed from the embedded starter.

```
- input name=&#34;name&#34; required placeholder=&#34;New project name&#34;
+ input name=&#34;name&#34; required placeholder=&#34;New project name&#34; aria-label=&#34;New project name&#34;
```

Verified — the drift test now passes:
```
running 1 test
test starters::tests::embedded_saas_matches_example_saas ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3865 filtered out
```

### Red (b) — 7 `private_intra_doc_links` in autumn-web (from #1915)
#1915 added rustdoc intra-doc links from **public** items to **private** items, which red `scripts/check-docs.sh` (`-D private_intra_doc_links`) on every trunk PR. rustdoc aborts on the first crate, so this was the gate&#39;s blocker at `autumn-web`.

- `autumn/src/nested_form.rs` (3 sites) — relinked `crate::security::submit_token` (a `pub(crate)` module) to the **public re-export** `crate::security::SubmitTokenLayer`.
- `autumn/src/config.rs` (1) + `autumn/src/dotenv.rs` (3) — the referenced items (`DatabaseConfig::validate_backend_consistency`, `resolve_dotenv_vars`, `should_load`, `PROFILE_SELECTOR_KEYS`) are private with **no** public re-export, so demoted to plain code spans, matching the #1919 house style.
- Also demoted the non-gating `redundant_explicit_links` warning in `autumn/src/seed.rs`.

After this, **`autumn-web` documents cleanly** under `check-docs.sh` — all seven #1915 `private_intra_doc_links` errors are gone.

### Red (c) — 8 `broken_intra_doc_links` in autumn-cli
Once `autumn-web` documents cleanly, `check-docs.sh` proceeds to `autumn-cli` and surfaces a **pre-existing, different-class** failure that was previously masked by the `autumn-web` abort: **8 `broken_intra_doc_links`** in `autumn-cli/src/generate/schema_edit.rs` (7) and `autumn-cli/src/generate/mod.rs` (1).

- `generate/mod.rs` (1) — `[`DatabaseBackend::Postgres`]` had no crate-local path in the cli doc build; relinked to the public re-export `[`DatabaseBackend::Postgres`](autumn_web::config::DatabaseBackend::Postgres)`.
- `generate/schema_edit.rs` (7 links) — doc comments on the production `*_for` functions linked to their `#[cfg(test)]` sibling wrappers (`schema_table_block_with_id`, `add_columns_up_sql`, `remove_columns_down_sql`, `add_columns_down_sql`, `remove_columns_up_sql`), which don&#39;t exist in a non-test `cargo doc` build and have no public path. Each demoted to a plain code span, matching the #1919 house style. Links that live on the `#[cfg(test)]` items themselves are not documented by rustdoc and were left untouched.

With (c) fixed, **`check-docs.sh` now exits 0 across both documented crates** — the doc-build gate is fully green.

## Verification
- `cargo test -p autumn-cli --bins starters::tests::embedded_saas_matches_example_saas` → pass (above).
- `cargo fmt --all -- --check` → clean.
- `scripts/check-docs.sh` → **exit 0**; both `autumn-web` and `autumn-cli` document with no `broken_intra_doc_links` / `private_intra_doc_links`:
```
Documentation build OK — no broken intra-doc links.
EXIT=0
```

Docs-only + one mirrored a11y attribute; no code behavior changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcL5aB12Krn1HzL9cM6hYA)_