### PR TITLE
Field-level #[state_machine] can reference a #[lifecycle] enum (#1911)

### DIFF
--- a/autumn-macros/src/lifecycle.rs
+++ b/autumn-macros/src/lifecycle.rs
@@ -318,6 +318,17 @@ fn build_metadata(item_enum: &ItemEnum, args: &LifecycleArgs, variants: &[&Ident
         })
         .collect::<Vec<_>>();
 
+    // String-keyed transition table for `#[state_machine(lifecycle = ...)]`
+    // derivation (issue #1911). Each edge is `(from_name, to_name, None)` — the
+    // variant names as strings (matching the model's `String` column value),
+    // with an always-`None` guard slot since lifecycle transitions are
+    // unguarded. Shape mirrors the field-level inline table exactly.
+    let transition_name_triples = args.transitions.iter().map(|tr| {
+        let from = variant_name_str(&tr.from);
+        let to = variant_name_str(&tr.to);
+        quote!((#from, #to, ::core::option::Option::None))
+    });
+
     let match_arms = args.transitions.iter().map(|tr| {
         let from = &tr.from;
         let to = &tr.to;
@@ -345,7 +356,25 @@ fn build_metadata(item_enum: &ItemEnum, args: &LifecycleArgs, variants: &[&Ident
                 }
             }
         }
+
+        impl ::autumn_web::Lifecycle for #enum_ident {
+            const STATE_MACHINE_TRANSITIONS: &'static [(
+                &'static str,
+                &'static str,
+                ::core::option::Option<&'static str>,
+            )] = &[
+                #(#transition_name_triples),*
+            ];
+        }
     }
+}
+
+/// Render a variant ident as the string used in the derived state-machine
+/// table (raw-identifier `r#` prefix stripped), matching the typestate
+/// module's `State::NAME`.
+fn variant_name_str(ident: &Ident) -> String {
+    let name = ident.to_string();
+    name.strip_prefix("r#").unwrap_or(&name).to_string()
 }
 
 /// Build the typestate transition module named after the enum in `snake_case`.
@@ -512,6 +541,47 @@ mod tests {
             out.contains(
                 "& [ArticleState :: Draft , ArticleState :: Published , ArticleState :: Archived]"
             ),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn emits_lifecycle_trait_impl_with_string_transition_table() {
+        let out = expand_ok(sample_attr(), sample_enum());
+        // Implements the marker trait used by `#[state_machine(lifecycle = ...)]`.
+        assert!(
+            out.contains("impl :: autumn_web :: Lifecycle for ArticleState"),
+            "{out}"
+        );
+        assert!(out.contains("const STATE_MACHINE_TRANSITIONS"), "{out}");
+        // Edges rendered as (from_name, to_name, None) string triples.
+        assert!(
+            out.contains("(\"Draft\" , \"Published\" , :: core :: option :: Option :: None)"),
+            "{out}"
+        );
+        assert!(
+            out.contains("(\"Published\" , \"Archived\" , :: core :: option :: Option :: None)"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn lifecycle_transition_table_strips_raw_identifier_prefix() {
+        let item = quote! {
+            pub enum KindState {
+                Draft,
+                r#type,
+            }
+        };
+        let attr = quote! {
+            initial = Draft,
+            terminal(r#type),
+            transitions(Draft -> r#type)
+        };
+        let out = expand_ok(attr, item);
+        // The stored string uses the bare `type`, not `r#type`.
+        assert!(
+            out.contains("(\"Draft\" , \"type\" , :: core :: option :: Option :: None)"),
             "{out}"
         );
     }

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -2612,23 +2612,29 @@ struct StateMachineTransition {
     guard: Option<String>,
 }
 
-/// Parsed `#[state_machine(transitions(...))]` spec for one field.
-struct StateMachineSpec {
-    field_ident: syn::Ident,
-    transitions: Vec<StateMachineTransition>,
+/// The declared source of a field's transition table: either an inline
+/// `transitions(...)` list (the original shorthand) or a reference to a
+/// `#[lifecycle]` enum whose typed edges are the source of truth (issue #1911).
+enum StateMachineSource {
+    /// `#[state_machine(transitions(a -> b, ...))]`.
+    Inline(Vec<StateMachineTransition>),
+    /// `#[state_machine(lifecycle = SomeEnum)]` — transitions derived from the
+    /// referenced `#[lifecycle]` enum's `Lifecycle::STATE_MACHINE_TRANSITIONS`.
+    Lifecycle(syn::Path),
 }
 
-/// Parse the inner `transitions(a -> b, b -> c: "guard", ...)` token tree.
-fn parse_transitions(
-    input: syn::parse::ParseStream<'_>,
-) -> syn::Result<Vec<StateMachineTransition>> {
-    let kw: syn::Ident = input.parse()?;
-    if kw != "transitions" {
-        return Err(syn::Error::new(kw.span(), "expected `transitions(...)`"));
-    }
-    let content;
-    syn::parenthesized!(content in input);
+/// Parsed `#[state_machine(...)]` spec for one field.
+struct StateMachineSpec {
+    field_ident: syn::Ident,
+    source: StateMachineSource,
+}
 
+/// Parse the inner `a -> b, b -> c: "guard", ...` edge list of a
+/// `transitions(...)` group (the surrounding `transitions(` / `)` already
+/// consumed by the caller).
+fn parse_transition_list(
+    content: syn::parse::ParseStream<'_>,
+) -> syn::Result<Vec<StateMachineTransition>> {
     let mut transitions = Vec::new();
     while !content.is_empty() {
         let from: syn::Ident = content.parse()?;
@@ -2665,7 +2671,32 @@ fn parse_transitions(
     Ok(transitions)
 }
 
-/// Parse `#[state_machine(transitions(...))]` from a field, returning the spec when present.
+/// Parse the `#[state_machine(...)]` argument as either `transitions(...)` or
+/// `lifecycle = <Path>`.
+fn parse_state_machine_source(
+    input: syn::parse::ParseStream<'_>,
+) -> syn::Result<StateMachineSource> {
+    let key: syn::Ident = input.parse()?;
+    if key == "transitions" {
+        let content;
+        syn::parenthesized!(content in input);
+        Ok(StateMachineSource::Inline(parse_transition_list(&content)?))
+    } else if key == "lifecycle" {
+        input.parse::<syn::Token![=]>()?;
+        let path: syn::Path = input.parse()?;
+        Ok(StateMachineSource::Lifecycle(path))
+    } else {
+        Err(syn::Error::new(
+            key.span(),
+            "expected `transitions(...)` or `lifecycle = <Enum>`",
+        ))
+    }
+}
+
+/// Parse `#[state_machine(...)]` from a field, returning the spec when present.
+///
+/// Accepts either the inline `transitions(...)` shorthand or a
+/// `lifecycle = <Enum>` reference to a `#[lifecycle]` enum (issue #1911).
 ///
 /// Validates:
 /// - Only `String` fields are supported (the generated `.as_str()` call requires it).
@@ -2691,32 +2722,74 @@ fn parse_state_machine_spec(field: &syn::Field) -> syn::Result<Option<StateMachi
                     "`#[state_machine]` is only supported on `String` fields",
                 ));
             }
-            let transitions = attr.parse_args_with(parse_transitions)?;
+            let source = attr.parse_args_with(parse_state_machine_source)?;
             spec = Some(StateMachineSpec {
                 field_ident: ident.clone(),
-                transitions,
+                source,
             });
         }
     }
     Ok(spec)
 }
 
-/// Emit the three state machine items for one field: a transitions constant,
-/// a `can_transition_{field}_to` predicate, and a `transition_{field}_to` method.
-fn emit_state_machine_impl(model_name: &syn::Ident, spec: &StateMachineSpec) -> TokenStream {
-    let field = &spec.field_ident;
+/// Names of the three generated state-machine items for a field.
+struct StateMachineNames {
+    const_name: syn::Ident,
+    can_fn: syn::Ident,
+    transition_fn: syn::Ident,
+    /// The raw-prefix-stripped field name, for use in generated messages.
+    field_str: String,
+}
+
+fn state_machine_names(field: &syn::Ident) -> StateMachineNames {
     let raw_field_str = field.to_string();
     // Strip the raw-identifier prefix so `r#type` produces `type`-derived names
     // rather than trying to create identifiers like `can_transition_r#type_to`.
-    let field_str = raw_field_str.strip_prefix("r#").unwrap_or(&raw_field_str);
+    let field_str = raw_field_str
+        .strip_prefix("r#")
+        .unwrap_or(&raw_field_str)
+        .to_string();
     let field_upper = field_str.to_uppercase();
+    StateMachineNames {
+        const_name: format_ident!("__AUTUMN_SM_{field_upper}_TRANSITIONS"),
+        can_fn: format_ident!("can_transition_{field_str}_to"),
+        transition_fn: format_ident!("transition_{field_str}_to"),
+        field_str,
+    }
+}
 
-    let const_name = format_ident!("__AUTUMN_SM_{field_upper}_TRANSITIONS");
-    let can_fn = format_ident!("can_transition_{field_str}_to");
-    let transition_fn = format_ident!("transition_{field_str}_to");
+/// Emit the three state machine items for one field: a transitions constant,
+/// a `can_transition_{field}_to` predicate, and a `transition_{field}_to` method.
+///
+/// Dispatches on the declared [`StateMachineSource`]: an inline
+/// `transitions(...)` list generates a literal table + match arms (guards
+/// supported), while a `lifecycle = <Enum>` reference derives its table from the
+/// enum's `Lifecycle::STATE_MACHINE_TRANSITIONS` const (issue #1911).
+fn emit_state_machine_impl(model_name: &syn::Ident, spec: &StateMachineSpec) -> TokenStream {
+    match &spec.source {
+        StateMachineSource::Inline(transitions) => {
+            emit_state_machine_inline(model_name, &spec.field_ident, transitions)
+        }
+        StateMachineSource::Lifecycle(path) => {
+            emit_state_machine_lifecycle(model_name, &spec.field_ident, path)
+        }
+    }
+}
 
-    let const_entries: Vec<TokenStream> = spec
-        .transitions
+/// Emit the state-machine items for an inline `transitions(...)` list.
+fn emit_state_machine_inline(
+    model_name: &syn::Ident,
+    field: &syn::Ident,
+    transitions: &[StateMachineTransition],
+) -> TokenStream {
+    let StateMachineNames {
+        const_name,
+        can_fn,
+        transition_fn,
+        field_str,
+    } = state_machine_names(field);
+
+    let const_entries: Vec<TokenStream> = transitions
         .iter()
         .map(|t| {
             let from = &t.from;
@@ -2728,8 +2801,7 @@ fn emit_state_machine_impl(model_name: &syn::Ident, spec: &StateMachineSpec) -> 
         })
         .collect();
 
-    let match_arms: Vec<TokenStream> = spec
-        .transitions
+    let match_arms: Vec<TokenStream> = transitions
         .iter()
         .map(|t| {
             let from = &t.from;
@@ -2764,6 +2836,74 @@ fn emit_state_machine_impl(model_name: &syn::Ident, spec: &StateMachineSpec) -> 
             /// Attempts to transition `{field}` to `target`, returning the new state value.
             ///
             /// Returns `Err` if the transition is not defined or a guard rejects it.
+            pub fn #transition_fn(&self, target: &str) -> ::autumn_web::AutumnResult<::std::string::String> {
+                if self.#can_fn(target) {
+                    ::core::result::Result::Ok(::std::string::String::from(target))
+                } else {
+                    ::core::result::Result::Err(::autumn_web::AutumnError::bad_request_msg(
+                        ::std::format!(
+                            "Cannot transition `{}` from `{}` to `{}`",
+                            #field_str,
+                            self.#field,
+                            target,
+                        ),
+                    ))
+                }
+            }
+        }
+    }
+}
+
+/// Emit the state-machine items for a `lifecycle = <Enum>` reference (#1911).
+///
+/// The transitions constant is an alias of the referenced enum's
+/// `<#path as ::autumn_web::Lifecycle>::STATE_MACHINE_TRANSITIONS`, so the table
+/// lives in exactly one place and stays typed. Because the concrete edge strings
+/// are not known at macro-expansion time (they come from the enum in another
+/// module/crate), the predicate iterates that table at runtime rather than
+/// emitting literal match arms — producing an allowed/denied set identical to the
+/// equivalent inline table. Referencing a type that does not implement
+/// `Lifecycle` (i.e. is not a `#[lifecycle]` enum) fails to compile with an
+/// unsatisfied trait bound.
+///
+/// Lifecycle transitions are unguarded (every table `guard` slot is `None`), and
+/// a runtime string table cannot dispatch a named guard method anyway, so the
+/// predicate requires the guard slot to be absent — guards remain an
+/// inline-only shorthand feature (see the `Lifecycle` trait docs for the
+/// rationale).
+fn emit_state_machine_lifecycle(
+    model_name: &syn::Ident,
+    field: &syn::Ident,
+    path: &syn::Path,
+) -> TokenStream {
+    let StateMachineNames {
+        const_name,
+        can_fn,
+        transition_fn,
+        field_str,
+    } = state_machine_names(field);
+
+    quote! {
+        impl #model_name {
+            #[doc(hidden)]
+            pub const #const_name: &'static [(&'static str, &'static str, ::core::option::Option<&'static str>)] =
+                <#path as ::autumn_web::Lifecycle>::STATE_MACHINE_TRANSITIONS;
+
+            /// Returns `true` when this record's `{field}` can transition to `target`.
+            ///
+            /// Derived from the referenced `#[lifecycle]` enum's transition table.
+            pub fn #can_fn(&self, target: &str) -> bool {
+                let __current: &str = &self.#field;
+                Self::#const_name
+                    .iter()
+                    .any(|&(__from, __to, __guard)| {
+                        __from == __current && __to == target && __guard.is_none()
+                    })
+            }
+
+            /// Attempts to transition `{field}` to `target`, returning the new state value.
+            ///
+            /// Returns `Err` if the transition is not defined by the referenced lifecycle.
             pub fn #transition_fn(&self, target: &str) -> ::autumn_web::AutumnResult<::std::string::String> {
                 if self.#can_fn(target) {
                     ::core::result::Result::Ok(::std::string::String::from(target))
@@ -7400,6 +7540,139 @@ mod tests {
         assert!(
             generated.contains("__AUTUMN_SM_TYPE_TRANSITIONS"),
             "raw identifier field must strip r# prefix for generated const name: {generated}"
+        );
+    }
+
+    // ── #[state_machine(lifecycle = Enum)] derivation (#1911) ─────────────────
+
+    #[test]
+    fn state_machine_lifecycle_const_aliases_trait_table() {
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(lifecycle = OrderState)]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        // The transitions const is an alias of the enum's Lifecycle trait const,
+        // so the table is defined once on the enum and stays typed.
+        assert!(
+            generated.contains("__AUTUMN_SM_STATUS_TRANSITIONS"),
+            "lifecycle SM must emit the transitions const: {generated}"
+        );
+        assert!(
+            generated.contains(
+                "< OrderState as :: autumn_web :: Lifecycle > :: STATE_MACHINE_TRANSITIONS"
+            ),
+            "lifecycle SM const must alias the enum's Lifecycle trait table: {generated}"
+        );
+        // No inline string edges are baked into the model — the source of truth
+        // is the enum.
+        assert!(
+            !generated.contains("(\"pending\""),
+            "lifecycle SM must not inline literal edge strings: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_lifecycle_emits_predicate_and_transition_methods() {
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(lifecycle = OrderState)]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("can_transition_status_to"),
+            "lifecycle SM must emit `can_transition_status_to`: {generated}"
+        );
+        assert!(
+            generated.contains("transition_status_to"),
+            "lifecycle SM must emit `transition_status_to`: {generated}"
+        );
+        assert!(
+            generated.contains("AutumnResult"),
+            "lifecycle SM `transition_*_to` must return AutumnResult: {generated}"
+        );
+        // The predicate iterates the derived table (no literal match arms are
+        // possible — the edge strings live on the enum).
+        assert!(
+            generated.contains(". iter ()") && generated.contains(". any"),
+            "lifecycle SM predicate must iterate the derived table: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_lifecycle_accepts_path_reference() {
+        // A module-qualified path to the lifecycle enum is accepted.
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(lifecycle = crate::states::OrderState)]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains(
+                "< crate :: states :: OrderState as :: autumn_web :: Lifecycle > :: STATE_MACHINE_TRANSITIONS"
+            ),
+            "lifecycle SM must accept a qualified path to the enum: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_lifecycle_on_non_string_field_is_rejected() {
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(lifecycle = OrderState)]
+                    pub amount: i64,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("only supported on `String` fields"),
+            "lifecycle SM on a non-String field must be rejected: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_unknown_argument_is_rejected() {
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(bogus(pending -> processing))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("expected `transitions(...)` or `lifecycle = <Enum>`"),
+            "an unknown #[state_machine] argument must be rejected: {generated}"
         );
     }
 

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -348,6 +348,13 @@ path = "tests/actuator_live_logger_reload.rs"
 name = "db_hooks_lifecycle"
 path = "tests/db_hooks_lifecycle.rs"
 
+# #1911: field-level `#[state_machine(lifecycle = Enum)]` ≡ inline equivalence.
+# Pure in-memory unit tests over the generated validation logic — no DB
+# connection, runs without Docker. Isolated so it is cheap to compile/run alone.
+[[test]]
+name = "state_machine_lifecycle"
+path = "tests/state_machine_lifecycle.rs"
+
 [[test]]
 name = "repository_shard_replica_routing"
 path = "tests/repository_shard_replica_routing.rs"

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -1268,6 +1268,37 @@ pub use autumn_macros::static_get;
 /// ```
 pub use autumn_macros::lifecycle;
 
+/// Marker trait implemented by every `#[lifecycle]` enum, exposing that
+/// lifecycle's transition edges as a string-keyed table.
+///
+/// This is the bridge that lets a field-level `#[state_machine(lifecycle = X)]`
+/// on a `#[model]` derive its runtime transitions table from a `#[lifecycle]`
+/// enum `X` instead of an inline `transitions(...)` list — "transitions defined
+/// once, typed" (issue #1911). The `#[lifecycle]` macro is the *only* thing that
+/// implements this trait; referencing a type that is not a `#[lifecycle]` enum in
+/// `#[state_machine(lifecycle = ...)]` therefore fails to compile with an
+/// unsatisfied `T: Lifecycle` trait bound rather than a cryptic
+/// "no associated const" error.
+///
+/// [`STATE_MACHINE_TRANSITIONS`](Lifecycle::STATE_MACHINE_TRANSITIONS) has the
+/// exact `(from, to, guard)` shape the field-level `#[state_machine]` inline
+/// table uses, so a lifecycle-derived state machine is byte-for-byte the same
+/// runtime construct as the equivalent inline one. Lifecycle transitions carry
+/// no guards, so every `guard` slot is `None` (see the `#[state_machine]` docs
+/// for the guards rationale).
+pub trait Lifecycle {
+    /// This lifecycle's declared transition edges as
+    /// `(from_variant_name, to_variant_name, guard)` triples, where the variant
+    /// names are the enum variants rendered as strings (matching the value
+    /// stored in the model's `String` column). The `guard` slot is always
+    /// `None` — lifecycle transitions are unguarded.
+    const STATE_MACHINE_TRANSITIONS: &'static [(
+        &'static str,
+        &'static str,
+        ::core::option::Option<&'static str>,
+    )];
+}
+
 // ── Maud re-exports ────────────────────────────────────────────────
 
 /// Rendered HTML fragment produced by the [`html!`] macro.

--- a/autumn/tests/compile-fail/state_machine_lifecycle_not_lifecycle.rs
+++ b/autumn/tests/compile-fail/state_machine_lifecycle_not_lifecycle.rs
@@ -1,0 +1,31 @@
+//! Issue #1911: `#[state_machine(lifecycle = T)]` where `T` is NOT a
+//! `#[lifecycle]` enum must be a compile error. The derived transitions const
+//! reads `<T as ::autumn_web::Lifecycle>::STATE_MACHINE_TRANSITIONS`, so a type
+//! that does not implement `Lifecycle` fails with an unsatisfied trait bound —
+//! a comprehensible error, not a cryptic "no associated const".
+
+use autumn_web::model;
+
+// A plain enum WITHOUT `#[lifecycle]` — it does not implement `Lifecycle`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotALifecycle {
+    A,
+    B,
+}
+
+diesel::table! {
+    orders (id) {
+        id -> BigInt,
+        status -> Text,
+    }
+}
+
+#[model(table = "orders")]
+pub struct Order {
+    #[id]
+    pub id: i64,
+    #[state_machine(lifecycle = NotALifecycle)]
+    pub status: String,
+}
+
+fn main() {}

--- a/autumn/tests/compile-fail/state_machine_lifecycle_not_lifecycle.stderr
+++ b/autumn/tests/compile-fail/state_machine_lifecycle_not_lifecycle.stderr
@@ -1,0 +1,11 @@
+error[E0277]: the trait bound `NotALifecycle: Lifecycle` is not satisfied
+  --> tests/compile-fail/state_machine_lifecycle_not_lifecycle.rs:27:33
+   |
+27 |     #[state_machine(lifecycle = NotALifecycle)]
+   |                                 ^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `Lifecycle` is not implemented for `NotALifecycle`
+  --> tests/compile-fail/state_machine_lifecycle_not_lifecycle.rs:11:1
+   |
+11 | pub enum NotALifecycle {
+   | ^^^^^^^^^^^^^^^^^^^^^^

--- a/autumn/tests/compile-pass/model_state_machine_lifecycle.rs
+++ b/autumn/tests/compile-pass/model_state_machine_lifecycle.rs
@@ -1,0 +1,55 @@
+//! Issue #1911: a field-level `#[state_machine(lifecycle = Enum)]` derives its
+//! transitions table from a `#[lifecycle]` enum. This is the "happy path"
+//! compile-pass companion to the inline `model_state_machine.rs` case.
+
+use autumn_web::{lifecycle, model};
+
+#[lifecycle(
+    initial = Pending,
+    terminal(Delivered, Cancelled),
+    transitions(
+        Pending -> Paid,
+        Pending -> Cancelled,
+        Paid -> Shipped,
+        Paid -> Cancelled,
+        Shipped -> Delivered,
+    )
+)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrderState {
+    Pending,
+    Paid,
+    Shipped,
+    Delivered,
+    Cancelled,
+}
+
+diesel::table! {
+    orders (id) {
+        id -> BigInt,
+        status -> Text,
+    }
+}
+
+// The lifecycle enum is the single source of truth for the column's transitions.
+#[model(table = "orders")]
+pub struct Order {
+    #[id]
+    pub id: i64,
+    #[state_machine(lifecycle = OrderState)]
+    pub status: String,
+}
+
+fn _assert_methods_compile(order: &Order) {
+    let _ = order.can_transition_status_to("Paid");
+    let _ = order.transition_status_to("Paid");
+}
+
+fn _assert_const_is_the_enum_table() {
+    // The model's transitions const is exactly the enum's typed table.
+    let _: &[(&str, &str, Option<&str>)] = Order::__AUTUMN_SM_STATUS_TRANSITIONS;
+    let _: &[(&str, &str, Option<&str>)] =
+        <OrderState as autumn_web::Lifecycle>::STATE_MACHINE_TRANSITIONS;
+}
+
+fn main() {}

--- a/autumn/tests/integration/compile_fail.rs
+++ b/autumn/tests/integration/compile_fail.rs
@@ -39,6 +39,11 @@ fn compile_fail_tests() {
     #[cfg(feature = "db")]
     t.compile_fail("tests/compile-fail/model_m2m_helper_collision.rs");
 
+    // #1911: `#[state_machine(lifecycle = T)]` where `T` is not a `#[lifecycle]`
+    // enum fails with an unsatisfied `T: Lifecycle` trait bound.
+    #[cfg(feature = "db")]
+    t.compile_fail("tests/compile-fail/state_machine_lifecycle_not_lifecycle.rs");
+
     // Repository hooks failures (require db feature)
     #[cfg(feature = "db")]
     compile_repository_hooks_not_default(&t);
@@ -193,6 +198,11 @@ fn compile_pass_tests() {
     // Declarative state machines: #[state_machine(transitions(...))] (requires db feature)
     #[cfg(feature = "db")]
     t.pass("tests/compile-pass/model_state_machine.rs");
+
+    // #1911: `#[state_machine(lifecycle = Enum)]` derives its table from a
+    // `#[lifecycle]` enum.
+    #[cfg(feature = "db")]
+    t.pass("tests/compile-pass/model_state_machine_lifecycle.rs");
 
     // Soft delete (requires db feature)
     #[cfg(feature = "db")]

--- a/autumn/tests/state_machine_lifecycle.rs
+++ b/autumn/tests/state_machine_lifecycle.rs
@@ -1,0 +1,193 @@
+//! Issue #1911: a field-level `#[state_machine(lifecycle = Enum)]` derives its
+//! runtime transitions table from a `#[lifecycle]` enum, and must behave
+//! IDENTICALLY to the equivalent inline `#[state_machine(transitions(...))]`.
+//!
+//! These are pure in-memory unit tests over the generated validation logic —
+//! they construct model structs by hand and call the generated
+//! `can_transition_*_to` / `transition_*_to` methods. No database connection is
+//! opened, so the suite runs WITHOUT Docker:
+//!
+//! ```text
+//! cargo test -p autumn-web --test state_machine_lifecycle
+//! ```
+
+#![cfg(feature = "db")]
+
+use autumn_web::{Lifecycle, lifecycle, model};
+
+// ── The single, typed source of truth ────────────────────────────────────────
+
+#[lifecycle(
+    initial = Pending,
+    terminal(Delivered, Cancelled),
+    transitions(
+        Pending -> Paid,
+        Pending -> Cancelled,
+        Paid -> Shipped,
+        Paid -> Cancelled,
+        Shipped -> Delivered,
+    )
+)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrderState {
+    Pending,
+    Paid,
+    Shipped,
+    Delivered,
+    Cancelled,
+}
+
+// ── Two models with the SAME edges, declared two different ways ───────────────
+
+diesel::table! {
+    orders_inline (id) {
+        id -> BigInt,
+        status -> Text,
+    }
+}
+
+/// Inline shorthand: edges written out with the same `PascalCase` state strings
+/// the lifecycle enum's variant names render to.
+#[model(table = "orders_inline")]
+pub struct OrderInline {
+    #[id]
+    pub id: i64,
+    #[state_machine(transitions(
+        Pending -> Paid,
+        Pending -> Cancelled,
+        Paid -> Shipped,
+        Paid -> Cancelled,
+        Shipped -> Delivered,
+    ))]
+    pub status: String,
+}
+
+diesel::table! {
+    orders_lifecycle (id) {
+        id -> BigInt,
+        status -> Text,
+    }
+}
+
+/// Lifecycle-derived: transitions come from `OrderState` — defined once, typed.
+#[model(table = "orders_lifecycle")]
+pub struct OrderLifecycle {
+    #[id]
+    pub id: i64,
+    #[state_machine(lifecycle = OrderState)]
+    pub status: String,
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Every state string plus a bogus target that is in neither table.
+const STATES: &[&str] = &[
+    "Pending",
+    "Paid",
+    "Shipped",
+    "Delivered",
+    "Cancelled",
+    "Nowhere", // not a declared state — must always be denied
+];
+
+fn inline(status: &str) -> OrderInline {
+    OrderInline {
+        id: 1,
+        status: status.to_string(),
+    }
+}
+
+fn lifecycle_model(status: &str) -> OrderLifecycle {
+    OrderLifecycle {
+        id: 1,
+        status: status.to_string(),
+    }
+}
+
+// ── AC3: identical allowed/denied set ─────────────────────────────────────────
+
+#[test]
+fn lifecycle_and_inline_agree_on_every_transition() {
+    for &from in STATES {
+        for &to in STATES {
+            let inline_can = inline(from).can_transition_status_to(to);
+            let lifecycle_can = lifecycle_model(from).can_transition_status_to(to);
+            assert_eq!(
+                inline_can, lifecycle_can,
+                "disagreement on `{from}` -> `{to}`: inline={inline_can}, lifecycle={lifecycle_can}"
+            );
+        }
+    }
+}
+
+#[test]
+fn lifecycle_and_inline_agree_on_transition_result() {
+    for &from in STATES {
+        for &to in STATES {
+            let inline_res = inline(from).transition_status_to(to);
+            let lifecycle_res = lifecycle_model(from).transition_status_to(to);
+            match (inline_res, lifecycle_res) {
+                (Ok(a), Ok(b)) => assert_eq!(
+                    a, b,
+                    "both accept `{from}` -> `{to}` but yield different values"
+                ),
+                (Err(_), Err(_)) => {}
+                (a, b) => panic!(
+                    "Ok/Err mismatch on `{from}` -> `{to}`: inline={:?}, lifecycle={:?}",
+                    a.is_ok(),
+                    b.is_ok()
+                ),
+            }
+        }
+    }
+}
+
+#[test]
+fn lifecycle_derived_allows_exactly_the_declared_edges() {
+    // Spot-check the concrete edge set so a silent all-true / all-false
+    // regression can't hide behind the cross-check above.
+    let m = lifecycle_model("Pending");
+    assert!(m.can_transition_status_to("Paid"));
+    assert!(m.can_transition_status_to("Cancelled"));
+    assert!(!m.can_transition_status_to("Shipped"));
+    assert!(!m.can_transition_status_to("Delivered"));
+
+    assert!(lifecycle_model("Paid").can_transition_status_to("Shipped"));
+    assert!(lifecycle_model("Shipped").can_transition_status_to("Delivered"));
+
+    // Terminal states have no outgoing edges.
+    assert!(!lifecycle_model("Delivered").can_transition_status_to("Pending"));
+    assert!(!lifecycle_model("Cancelled").can_transition_status_to("Pending"));
+}
+
+#[test]
+fn lifecycle_derived_table_equals_the_enum_trait_table() {
+    // The model's transitions const is a direct alias of the enum's typed table,
+    // so the "defined once" guarantee is structural, not a copy.
+    assert_eq!(
+        OrderLifecycle::__AUTUMN_SM_STATUS_TRANSITIONS,
+        <OrderState as Lifecycle>::STATE_MACHINE_TRANSITIONS
+    );
+    // And it equals the inline model's table entry-for-entry.
+    assert_eq!(
+        OrderLifecycle::__AUTUMN_SM_STATUS_TRANSITIONS,
+        OrderInline::__AUTUMN_SM_STATUS_TRANSITIONS
+    );
+}
+
+#[test]
+fn transition_error_names_field_and_states() {
+    let err = lifecycle_model("Pending")
+        .transition_status_to("Delivered")
+        .expect_err("Pending -> Delivered is not a declared edge");
+    let msg = err.to_string();
+    assert!(msg.contains("status"), "error should name the field: {msg}");
+    assert!(
+        msg.contains("Pending"),
+        "error should name the from-state: {msg}"
+    );
+    assert!(
+        msg.contains("Delivered"),
+        "error should name the to-state: {msg}"
+    );
+}


### PR DESCRIPTION
Closes #1911.

Converges the two state constructs: the field-level `#[state_machine]` attribute on `#[model]` (a runtime transitions table over a `String` column) can now take its transitions from an enum-level `#[lifecycle]` primitive (#1916) — "transitions defined once, typed." The inline table stays fully supported as shorthand (no breaking change).

## Exact syntax accepted

```rust
#[lifecycle(
    initial = Pending,
    terminal(Delivered, Cancelled),
    transitions(
        Pending -> Paid,
        Pending -> Cancelled,
        Paid    -> Shipped,
        Paid    -> Cancelled,
        Shipped -> Delivered,
    )
)]
#[derive(Debug, Clone, Copy, PartialEq, Eq)]
pub enum OrderState { Pending, Paid, Shipped, Delivered, Cancelled }

#[model(table = "orders")]
pub struct Order {
    #[id] pub id: i64,
    // NEW: derive the transitions table from the lifecycle enum…
    #[state_machine(lifecycle = OrderState)]
    pub status: String,
}
```

- `#[state_machine(lifecycle = OrderState)]` and `#[state_machine(lifecycle = crate::states::OrderState)]` (a path) are both accepted.
- The existing `#[state_machine(transitions(a -> b, b -> c: "guard"))]` inline form is **unchanged**.

The generated API is identical to the inline form: `Order::__AUTUMN_SM_STATUS_TRANSITIONS`, `order.can_transition_status_to(&str) -> bool`, `order.transition_status_to(&str) -> AutumnResult<String>`.

## Derive mechanism

1. **New `autumn_web::Lifecycle` marker trait** (`autumn/src/lib.rs`) exposing
   `const STATE_MACHINE_TRANSITIONS: &'static [(&'static str, &'static str, Option<&'static str>)]` — the *exact* `(from, to, guard)` shape the inline field-level table already uses.
2. The **`#[lifecycle]` macro is the sole implementor**: alongside its existing `LIFECYCLE_INITIAL` / `LIFECYCLE_TERMINALS` / `LIFECYCLE_STATES` / `LIFECYCLE_TRANSITIONS` metadata it now emits `impl ::autumn_web::Lifecycle for <Enum>`, rendering each declared edge as a `(from_variant_name, to_variant_name, None)` string triple (variant names rendered exactly like the typestate module's `State::NAME`, raw-ident `r#` stripped). It is the same edge set as the typed `LIFECYCLE_TRANSITIONS` const, projected to strings so it can key a `String` column.
3. **`#[state_machine(lifecycle = X)]`** aliases its transitions const directly to `<X as ::autumn_web::Lifecycle>::STATE_MACHINE_TRANSITIONS` (one source of truth — the table is not copied), and generates a `can_transition_*_to` that **iterates that table at runtime**. Iteration (rather than literal `match` arms) is necessary because the concrete edge strings live on the enum in another module/crate and aren't known at the model's macro-expansion time; the resulting allowed/denied set is identical to the equivalent inline table.

The inline path's codegen is left **byte-for-byte unchanged** (literal table + `match` arms, guards supported), so all pre-existing `state_machine` tests stay green.

## "Not a `#[lifecycle]` enum" → clear compile error

Because the derived const reads `<T as ::autumn_web::Lifecycle>::STATE_MACHINE_TRANSITIONS`, a `T` that isn't a `#[lifecycle]` enum (so doesn't `impl Lifecycle`) fails with an **unsatisfied trait bound**, not a cryptic "no associated const". Covered by `tests/compile-fail/state_machine_lifecycle_not_lifecycle.rs`:

```
error[E0277]: the trait bound `NotALifecycle: Lifecycle` is not satisfied
  --> tests/compile-fail/state_machine_lifecycle_not_lifecycle.rs:27:33
   |
27 |     #[state_machine(lifecycle = NotALifecycle)]
   |                                 ^^^^^^^^^^^^^ unsatisfied trait bound
   |
help: the trait `Lifecycle` is not implemented for `NotALifecycle`
```

(Also structurally asserted version-independently by the macro-level unit test `state_machine_lifecycle_const_aliases_trait_table`, which pins the generated `<… as ::autumn_web::Lifecycle>::STATE_MACHINE_TRANSITIONS` reference. The `.stderr` was generated on rustc 1.94.1; if CI's 1.97 phrasing differs, regenerate with `TRYBUILD=overwrite` — the macro-level test is the version-robust guarantee.)

## Guards decision + rationale

**Lifecycle-derived state machines are always unguarded** (every derived table `guard` slot is `None`); the predicate additionally requires the guard slot to be absent, so this stays safe if guards are ever added to lifecycle. Rationale:

- The `#[lifecycle]` primitive (#1916) has **no guard syntax** — its transitions are bare `From -> To`. So a referenced lifecycle enum can never *declare* guards; there is nothing to "scope out," and no guard-conflict is possible.
- A guard is a **named `&self` bool method** dispatched via a generated literal `match` arm (`(from, to) => self.can_ship()`). The lifecycle path resolves edges from a runtime *string* table and cannot dispatch a method by string name — so guards are inherently an inline-only feature.

Named-string guards therefore remain available via the inline shorthand (`b -> c: "can_ship"`); a creator who needs a guarded edge writes it inline. This is documented on the `Lifecycle` trait and the emit function.

## Equivalence evidence (inline ≡ lifecycle)

`autumn/tests/state_machine_lifecycle.rs` (new isolated `[[test]]`, **Docker-free** — pure in-memory model structs, no DB connection) defines one `#[lifecycle]` enum plus two models with the same edges (one inline, one `lifecycle = OrderState`) and proves:

- `lifecycle_and_inline_agree_on_every_transition` — `can_transition_status_to` agrees across the **full cartesian product** of states (incl. a bogus target).
- `lifecycle_and_inline_agree_on_transition_result` — `transition_status_to` Ok/Err (and Ok value) agree across all pairs.
- `lifecycle_derived_table_equals_the_enum_trait_table` — the model's const **is** `<OrderState as Lifecycle>::STATE_MACHINE_TRANSITIONS` and equals the inline model's table entry-for-entry.
- plus concrete edge spot-checks and the error-message contract.

```
running 5 tests
test lifecycle_and_inline_agree_on_every_transition ... ok
test lifecycle_and_inline_agree_on_transition_result ... ok
test lifecycle_derived_allows_exactly_the_declared_edges ... ok
test lifecycle_derived_table_equals_the_enum_trait_table ... ok
test transition_error_names_field_and_states ... ok
test result: ok. 5 passed; 0 failed
```

## Verification

- `cargo fmt --all -- --check` → clean (exit 0)
- `cargo clippy --workspace --all-targets -- -D warnings` → clean (exit 0), 5m05s
- `cargo test -p autumn-macros` (state_machine + lifecycle) → **36 passed** (existing inline + new lifecycle)
- `cargo test -p autumn-web --test state_machine_lifecycle` → **5 passed** (no Docker)
- trybuild compile-pass (`model_state_machine_lifecycle.rs`) + compile-fail (`state_machine_lifecycle_not_lifecycle.rs`) → both ok
- Hand-scanned the diff for `map_unwrap_or` / `missing_const_for_fn` / `use_self` / `format_push_string` / `manual_contains` / `redundant_clone` (workspace enables clippy pedantic+nursery); clean.

## Files changed

| File | Change |
|---|---|
| `autumn/src/lib.rs` | New `Lifecycle` marker trait (the derive bridge). |
| `autumn-macros/src/lifecycle.rs` | Emit `impl Lifecycle` with the string transition table; `variant_name_str` helper; 2 unit tests. |
| `autumn-macros/src/model.rs` | Accept `lifecycle = <Path>`; `StateMachineSource` enum; split inline/lifecycle codegen (inline unchanged); 5 unit tests. |
| `autumn/Cargo.toml` | Register the isolated `state_machine_lifecycle` test target. |
| `autumn/tests/state_machine_lifecycle.rs` | New Docker-free runtime equivalence suite. |
| `autumn/tests/compile-pass/model_state_machine_lifecycle.rs` | trybuild happy path. |
| `autumn/tests/compile-fail/state_machine_lifecycle_not_lifecycle.rs` (+`.stderr`) | trybuild "not a lifecycle enum" error UX. |
| `autumn/tests/integration/compile_fail.rs` | Register the two trybuild cases. |

**`autumn-cli/src/generate/scaffold.rs` was NOT edited** (confirmed clean via `git status`); the feature is entirely in `autumn-macros` + `autumn/src` and did not require it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KA9PKkuNMTkayCWTTJbM7

---
_Generated by [Claude Code](https://claude.ai/code/session_014KA9PKkuNMTkayCWTTJbM7)_