### PR TITLE
feat(a11y): typed TextArea/Select/Checkbox/FileField primitives + hx-* escape hatch (Part of #1706)

### DIFF
--- a/autumn/src/a11y.rs
+++ b/autumn/src/a11y.rs
@@ -522,6 +522,22 @@ enum LabelSource {
     LabelledBy(String),
 }
 
+/// Returns `true` when `name` is a valid `hx-*` attribute suffix: a non-empty
+/// run of ASCII lowercase letters, digits, or `-`.
+///
+/// This mirrors the attribute-name validation in [`crate::links`]
+/// (`is_valid_attr_name`) but narrows the alphabet to the `hx-*` suffix
+/// grammar. It deliberately excludes whitespace and `=` — which
+/// [`maud::Escaper`] does **not** escape — so a caller-supplied name can never
+/// break out of the `hx-{name}="…"` attribute into a separate, injected
+/// attribute.
+fn is_valid_hx_suffix(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+}
+
 /// Splice a dynamic set of `hx-*` attributes into an already-rendered element.
 ///
 /// maud requires a *static* attribute name (its `Named` attribute parses an
@@ -530,9 +546,14 @@ enum LabelSource {
 /// permitted in attribute position either. Because maud escapes every `>` in
 /// text and attribute values to `&gt;`, the first literal `>` in a rendered
 /// element is always the end of its opening tag, so inserting the attributes
-/// immediately before it is unambiguous. Each name and value is
-/// HTML-attribute-escaped via [`maud::Escaper`], preserving maud's own escaping
-/// guarantees. An empty set returns the element byte-for-byte unchanged.
+/// immediately before it is unambiguous. The value is HTML-attribute-escaped
+/// via [`maud::Escaper`], preserving maud's own escaping guarantees. An empty
+/// set returns the element byte-for-byte unchanged.
+///
+/// Each attribute name is validated against [`is_valid_hx_suffix`]: an invalid
+/// name trips a [`debug_assert`] (surfacing the developer error in debug
+/// builds) and is skipped in release builds, so a malformed or injected
+/// attribute is never emitted.
 fn with_hx_attrs(element: Markup, hx: &[(String, String)]) -> Markup {
     if hx.is_empty() {
         return element;
@@ -540,8 +561,19 @@ fn with_hx_attrs(element: Markup, hx: &[(String, String)]) -> Markup {
     let rendered = element.into_string();
     let mut attrs = String::new();
     for (name, value) in hx {
+        debug_assert!(
+            is_valid_hx_suffix(name),
+            "invalid hx-* attribute name {name:?}: only lowercase ASCII letters, \
+             digits, and '-' are permitted"
+        );
+        if !is_valid_hx_suffix(name) {
+            continue;
+        }
         attrs.push_str(" hx-");
-        let _ = write!(Escaper::new(&mut attrs), "{name}");
+        // `name` is validated to the safe `[a-z0-9-]` alphabet, so it needs no
+        // escaping (mirroring `links::push_attr`, which pushes the validated
+        // name verbatim); the value keeps maud's attribute escaping.
+        attrs.push_str(name);
         attrs.push_str("=\"");
         let _ = write!(Escaper::new(&mut attrs), "{value}");
         attrs.push('"');
@@ -1262,15 +1294,16 @@ impl<State> Select<State> {
         self
     }
 
-    /// Mark the option whose `value` matches as `selected` (all others are left
-    /// unchanged).
+    /// Authoritatively set the single selected option: the option whose `value`
+    /// matches is marked `selected` and every other option's `selected` flag is
+    /// cleared. `<select>` is single-select, so this guarantees at most one
+    /// `selected` option in the rendered markup — any prior selection (e.g. from
+    /// [`SelectOption::selected`]) is overridden.
     #[must_use]
     pub fn selected_value(mut self, value: impl Into<String>) -> Self {
         let value = value.into();
         for opt in &mut self.options {
-            if opt.value == value {
-                opt.selected = true;
-            }
+            opt.selected = opt.value == value;
         }
         self
     }
@@ -1982,5 +2015,23 @@ mod tests {
         assert!(markup.contains("aria-label=\"Search\""), "{markup}");
         assert!(markup.contains("class=\"search\""), "{markup}");
         assert!(markup.contains("aria-invalid=\"true\""), "{markup}");
+    }
+
+    #[test]
+    fn is_valid_hx_suffix_accepts_safe_alphabet_only() {
+        // Valid suffixes: lowercase letters, digits, and '-', non-empty.
+        assert!(is_valid_hx_suffix("post"));
+        assert!(is_valid_hx_suffix("trigger"));
+        assert!(is_valid_hx_suffix("on-2"));
+        assert!(is_valid_hx_suffix("swap-oob"));
+        // Invalid: empty, whitespace, '=', and other injection characters that
+        // `maud::Escaper` does not escape.
+        assert!(!is_valid_hx_suffix(""));
+        assert!(!is_valid_hx_suffix("post autofocus"));
+        assert!(!is_valid_hx_suffix("post=x"));
+        assert!(!is_valid_hx_suffix("Post"));
+        assert!(!is_valid_hx_suffix("po st"));
+        assert!(!is_valid_hx_suffix("post\"onload"));
+        assert!(!is_valid_hx_suffix("hx_post"));
     }
 }

--- a/autumn/src/a11y.rs
+++ b/autumn/src/a11y.rs
@@ -40,8 +40,31 @@
 //!   without weakening that obligation: those setters are available in both
 //!   states, but none of them supplies an accessible name, so a label is still
 //!   required before the field can render.
+//! - [`TextArea`](crate::a11y::TextArea) — WCAG 1.3.1 Info and Relationships /
+//!   3.3.2 Labels or Instructions / 4.1.2 Name, Role, Value. The multi-line
+//!   counterpart to [`TextField`](crate::a11y::TextField): only
+//!   [`TextArea`](crate::a11y::TextArea)`<Labeled>` implements
+//!   [`maud::Render`], and the value is carried as the element's text content
+//!   rather than a `value=` attribute.
+//! - [`Select`](crate::a11y::Select) (with [`SelectOption`](crate::a11y::SelectOption))
+//!   — WCAG 1.3.1 / 3.3.2 / 4.1.2. A `<select>` whose options are typed
+//!   [`SelectOption`](crate::a11y::SelectOption) values; only
+//!   [`Select`](crate::a11y::Select)`<Labeled>` implements
+//!   [`maud::Render`].
+//! - [`Checkbox`](crate::a11y::Checkbox) — WCAG 1.3.1 / 3.3.2 / 4.1.2. A
+//!   single boolean `<input type="checkbox">`; only
+//!   [`Checkbox`](crate::a11y::Checkbox)`<Labeled>` implements
+//!   [`maud::Render`].
+//! - [`FileField`](crate::a11y::FileField) — WCAG 1.3.1 / 3.3.2 / 4.1.2. A
+//!   typed, explicitly-labeled `<input type="file">`; only
+//!   [`FileField`](crate::a11y::FileField)`<Labeled>` implements
+//!   [`maud::Render`].
 //!
-//! All three implement [`maud::Render`], so they splice directly into an
+//! All five form primitives also accept arbitrary `hx-*` attributes through an
+//! `hx(name, value)` escape hatch, so the htmx (`--live-validation`) rendering
+//! path keeps the typed label obligation instead of dropping to raw markup.
+//!
+//! All of these implement [`maud::Render`], so they splice directly into an
 //! `html!` block:
 //!
 //! ```rust
@@ -56,7 +79,9 @@
 //! assert!(page.into_string().contains("alt=\"Autumn logo\""));
 //! ```
 
-use maud::{Markup, Render, html};
+use std::fmt::Write as _;
+
+use maud::{Escaper, Markup, PreEscaped, Render, html};
 
 /// An informative or decorative image with a mandatory accessible name
 /// (WCAG 1.1.1 Non-text Content).
@@ -497,6 +522,42 @@ enum LabelSource {
     LabelledBy(String),
 }
 
+/// Splice a dynamic set of `hx-*` attributes into an already-rendered element.
+///
+/// maud requires a *static* attribute name (its `Named` attribute parses an
+/// `HtmlName`, not a splice), so an arbitrary, caller-supplied `hx-{name}` set
+/// cannot be expressed inside the `html!` tag syntax and control flow is not
+/// permitted in attribute position either. Because maud escapes every `>` in
+/// text and attribute values to `&gt;`, the first literal `>` in a rendered
+/// element is always the end of its opening tag, so inserting the attributes
+/// immediately before it is unambiguous. Each name and value is
+/// HTML-attribute-escaped via [`maud::Escaper`], preserving maud's own escaping
+/// guarantees. An empty set returns the element byte-for-byte unchanged.
+fn with_hx_attrs(element: Markup, hx: &[(String, String)]) -> Markup {
+    if hx.is_empty() {
+        return element;
+    }
+    let rendered = element.into_string();
+    let mut attrs = String::new();
+    for (name, value) in hx {
+        attrs.push_str(" hx-");
+        let _ = write!(Escaper::new(&mut attrs), "{name}");
+        attrs.push_str("=\"");
+        let _ = write!(Escaper::new(&mut attrs), "{value}");
+        attrs.push('"');
+    }
+    match rendered.find('>') {
+        Some(idx) => {
+            let mut out = String::with_capacity(rendered.len() + attrs.len());
+            out.push_str(&rendered[..idx]);
+            out.push_str(&attrs);
+            out.push_str(&rendered[idx..]);
+            PreEscaped(out)
+        }
+        None => PreEscaped(rendered),
+    }
+}
+
 /// A text input whose label association is enforced by the type system
 /// (WCAG 1.3.1 Info and Relationships, 3.3.2 Labels or Instructions,
 /// 4.1.2 Name, Role, Value).
@@ -536,6 +597,7 @@ pub struct TextField<State> {
     min: Option<String>,
     max: Option<String>,
     step: Option<String>,
+    hx: Vec<(String, String)>,
     label: Option<LabelSource>,
     _state: std::marker::PhantomData<State>,
 }
@@ -559,6 +621,7 @@ impl TextField<NoLabel> {
             min: None,
             max: None,
             step: None,
+            hx: Vec::new(),
             label: None,
             _state: std::marker::PhantomData,
         }
@@ -601,6 +664,7 @@ impl TextField<NoLabel> {
             min: self.min,
             max: self.max,
             step: self.step,
+            hx: self.hx,
             label: Some(label),
             _state: std::marker::PhantomData,
         }
@@ -753,6 +817,32 @@ impl<State> TextField<State> {
         self.step = Some(step.into());
         self
     }
+
+    /// Attach an arbitrary `hx-*` attribute, preserving the typed label
+    /// obligation while opting into htmx behaviour (e.g. the scaffold
+    /// generator's `--live-validation` path). The `name` is the suffix after
+    /// `hx-`, so `.hx("post", "/validate")` renders `hx-post="/validate"`.
+    /// Multiple calls are emitted in insertion order. Available before or after
+    /// a label is attached.
+    ///
+    /// ```rust
+    /// use autumn_web::a11y::TextField;
+    /// use maud::Render;
+    ///
+    /// let markup = TextField::new("email")
+    ///     .hx("post", "/validate/email")
+    ///     .hx("trigger", "blur")
+    ///     .label("Email address")
+    ///     .render()
+    ///     .into_string();
+    /// assert!(markup.contains("hx-post=\"/validate/email\""));
+    /// assert!(markup.contains("hx-trigger=\"blur\""));
+    /// ```
+    #[must_use]
+    pub fn hx(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.hx.push((name.into(), value.into()));
+        self
+    }
 }
 
 impl Render for TextField<Labeled> {
@@ -773,10 +863,7 @@ impl Render for TextField<Labeled> {
             .aria_invalid
             .map(|invalid| if invalid { "true" } else { "false" });
         let aria_required = self.aria_required.then_some("true");
-        html! {
-            @if let Some(text) = visible_label {
-                label for=(self.name) class=[self.label_class.as_deref()] { (text) }
-            }
+        let input = html! {
             input
                 type=(self.input_type)
                 id=(self.name)
@@ -794,6 +881,897 @@ impl Render for TextField<Labeled> {
                 aria-describedby=[self.described_by.as_deref()]
                 aria-required=[aria_required]
                 required[self.required];
+        };
+        html! {
+            @if let Some(text) = visible_label {
+                label for=(self.name) class=[self.label_class.as_deref()] { (text) }
+            }
+            (with_hx_attrs(input, &self.hx))
+        }
+    }
+}
+
+/// A multi-line text input whose label association is enforced by the type
+/// system (WCAG 1.3.1 Info and Relationships, 3.3.2 Labels or Instructions,
+/// 4.1.2 Name, Role, Value).
+///
+/// [`TextArea::new`] returns a `TextArea<NoLabel>`, which has no way to render.
+/// Attaching a label with [`label`](TextArea::label),
+/// [`aria_label`](TextArea::aria_label), or
+/// [`labelled_by`](TextArea::labelled_by) consumes it and returns a
+/// `TextArea<Labeled>`, the only state that implements [`maud::Render`] — so an
+/// unlabeled `<textarea>` is unrepresentable as markup, exactly like
+/// [`TextField`].
+///
+/// Unlike [`TextField`], the current value is carried as the element's **text
+/// content** (`<textarea>…value…</textarea>`), never a `value=` attribute,
+/// matching HTML's model for a `<textarea>`.
+#[derive(Debug, Clone)]
+pub struct TextArea<State> {
+    name: String,
+    value: Option<String>,
+    required: bool,
+    aria_required: bool,
+    class: Option<String>,
+    label_class: Option<String>,
+    aria_invalid: Option<bool>,
+    described_by: Option<String>,
+    minlength: Option<u32>,
+    maxlength: Option<u32>,
+    rows: Option<u32>,
+    cols: Option<u32>,
+    hx: Vec<(String, String)>,
+    label: Option<LabelSource>,
+    _state: std::marker::PhantomData<State>,
+}
+
+impl TextArea<NoLabel> {
+    /// Start building a text area with the given form `name`. The returned value
+    /// has no label yet and cannot be rendered until one is attached.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            value: None,
+            required: false,
+            aria_required: false,
+            class: None,
+            label_class: None,
+            aria_invalid: None,
+            described_by: None,
+            minlength: None,
+            maxlength: None,
+            rows: None,
+            cols: None,
+            hx: Vec::new(),
+            label: None,
+            _state: std::marker::PhantomData,
+        }
+    }
+
+    /// Attach a visible `<label for=…>` and transition to the renderable
+    /// [`Labeled`] state.
+    #[must_use]
+    pub fn label(self, text: impl Into<String>) -> TextArea<Labeled> {
+        self.with_label(LabelSource::Visible(text.into()))
+    }
+
+    /// Attach an `aria-label` (no visible label) and transition to the
+    /// renderable [`Labeled`] state.
+    #[must_use]
+    pub fn aria_label(self, text: impl Into<String>) -> TextArea<Labeled> {
+        self.with_label(LabelSource::Aria(text.into()))
+    }
+
+    /// Reference an existing element's `id` via `aria-labelledby` and transition
+    /// to the renderable [`Labeled`] state.
+    #[must_use]
+    pub fn labelled_by(self, id: impl Into<String>) -> TextArea<Labeled> {
+        self.with_label(LabelSource::LabelledBy(id.into()))
+    }
+
+    fn with_label(self, label: LabelSource) -> TextArea<Labeled> {
+        TextArea {
+            name: self.name,
+            value: self.value,
+            required: self.required,
+            aria_required: self.aria_required,
+            class: self.class,
+            label_class: self.label_class,
+            aria_invalid: self.aria_invalid,
+            described_by: self.described_by,
+            minlength: self.minlength,
+            maxlength: self.maxlength,
+            rows: self.rows,
+            cols: self.cols,
+            hx: self.hx,
+            label: Some(label),
+            _state: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<State> TextArea<State> {
+    /// Set the text area's initial `value`, rendered as its text content.
+    #[must_use]
+    pub fn value(mut self, value: impl Into<String>) -> Self {
+        self.value = Some(value.into());
+        self
+    }
+
+    /// Mark the text area as `required`.
+    #[must_use]
+    pub const fn required(mut self) -> Self {
+        self.required = true;
+        self
+    }
+
+    /// Add a mirroring `aria-required="true"` alongside the native `required`
+    /// attribute. Available before or after a label is attached.
+    #[must_use]
+    pub const fn aria_required(mut self) -> Self {
+        self.aria_required = true;
+        self
+    }
+
+    /// Set the `class` attribute on the `<textarea>`.
+    #[must_use]
+    pub fn class(mut self, class: impl Into<String>) -> Self {
+        self.class = Some(class.into());
+        self
+    }
+
+    /// Set the `class` attribute on the visible `<label>` element. Only affects
+    /// rendering when a visible label was set via [`label`](Self::label).
+    #[must_use]
+    pub fn label_class(mut self, class: impl Into<String>) -> Self {
+        self.label_class = Some(class.into());
+        self
+    }
+
+    /// Set `aria-invalid` to `"true"` or `"false"`. When left unset the
+    /// attribute is omitted entirely.
+    #[must_use]
+    pub const fn aria_invalid(mut self, invalid: bool) -> Self {
+        self.aria_invalid = Some(invalid);
+        self
+    }
+
+    /// Reference the `id` of the element describing this field (typically an
+    /// inline error container) via `aria-describedby`.
+    #[must_use]
+    pub fn described_by(mut self, id: impl Into<String>) -> Self {
+        self.described_by = Some(id.into());
+        self
+    }
+
+    /// Set the HTML5 `minlength` validation constraint (minimum character
+    /// count).
+    #[must_use]
+    pub const fn minlength(mut self, minlength: u32) -> Self {
+        self.minlength = Some(minlength);
+        self
+    }
+
+    /// Set the HTML5 `maxlength` validation constraint (maximum character
+    /// count).
+    #[must_use]
+    pub const fn maxlength(mut self, maxlength: u32) -> Self {
+        self.maxlength = Some(maxlength);
+        self
+    }
+
+    /// Set the visible `rows` (height in text lines) of the text area.
+    #[must_use]
+    pub const fn rows(mut self, rows: u32) -> Self {
+        self.rows = Some(rows);
+        self
+    }
+
+    /// Set the visible `cols` (width in average character widths) of the text
+    /// area.
+    #[must_use]
+    pub const fn cols(mut self, cols: u32) -> Self {
+        self.cols = Some(cols);
+        self
+    }
+
+    /// Attach an arbitrary `hx-*` attribute (the `name` is the suffix after
+    /// `hx-`), preserving the typed label obligation. Emitted in insertion
+    /// order. Available before or after a label is attached.
+    #[must_use]
+    pub fn hx(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.hx.push((name.into(), value.into()));
+        self
+    }
+}
+
+impl Render for TextArea<Labeled> {
+    fn render(&self) -> Markup {
+        let (visible_label, aria_label, aria_labelledby) = match &self.label {
+            Some(LabelSource::Visible(text)) => (Some(text.as_str()), None, None),
+            Some(LabelSource::Aria(text)) => (None, Some(text.as_str()), None),
+            Some(LabelSource::LabelledBy(id)) => (None, None, Some(id.as_str())),
+            None => (None, None, None),
+        };
+        let aria_invalid = self
+            .aria_invalid
+            .map(|invalid| if invalid { "true" } else { "false" });
+        let aria_required = self.aria_required.then_some("true");
+        let textarea = html! {
+            textarea
+                id=(self.name)
+                name=(self.name)
+                aria-label=[aria_label]
+                aria-labelledby=[aria_labelledby]
+                class=[self.class.as_deref()]
+                minlength=[self.minlength]
+                maxlength=[self.maxlength]
+                rows=[self.rows]
+                cols=[self.cols]
+                aria-invalid=[aria_invalid]
+                aria-describedby=[self.described_by.as_deref()]
+                aria-required=[aria_required]
+                required[self.required] {
+                    @if let Some(v) = &self.value { (v) }
+                }
+        };
+        html! {
+            @if let Some(text) = visible_label {
+                label for=(self.name) class=[self.label_class.as_deref()] { (text) }
+            }
+            (with_hx_attrs(textarea, &self.hx))
+        }
+    }
+}
+
+/// A single `<option>` for a [`Select`].
+///
+/// Named `SelectOption` rather than `Option` deliberately: a public `Option`
+/// exported from this module would shadow [`std::option::Option`] at any call
+/// site that glob-imports `a11y`, so the primitive carries a qualified name.
+#[derive(Debug, Clone)]
+pub struct SelectOption {
+    value: String,
+    label: String,
+    selected: bool,
+    disabled: bool,
+}
+
+impl SelectOption {
+    /// Build an option with a submitted `value` and a human-visible `label`.
+    pub fn new(value: impl Into<String>, label: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+            label: label.into(),
+            selected: false,
+            disabled: false,
+        }
+    }
+
+    /// Mark this option `selected`.
+    #[must_use]
+    pub const fn selected(mut self) -> Self {
+        self.selected = true;
+        self
+    }
+
+    /// Mark this option `disabled`. Combined with an empty value this renders
+    /// the conventional `— Select —` placeholder.
+    #[must_use]
+    pub const fn disabled(mut self) -> Self {
+        self.disabled = true;
+        self
+    }
+}
+
+/// A `<select>` dropdown whose label association is enforced by the type system
+/// (WCAG 1.3.1 Info and Relationships, 3.3.2 Labels or Instructions, 4.1.2
+/// Name, Role, Value).
+///
+/// [`Select::new`] returns a `Select<NoLabel>`, which has no way to render.
+/// Attaching a label with [`label`](Select::label),
+/// [`aria_label`](Select::aria_label), or
+/// [`labelled_by`](Select::labelled_by) consumes it and returns a
+/// `Select<Labeled>`, the only state that implements [`maud::Render`]. A
+/// nullable/tri-state boolean field is modelled as a `Select` (an empty-value
+/// placeholder option), not a [`Checkbox`], which is bool-only.
+#[derive(Debug, Clone)]
+pub struct Select<State> {
+    name: String,
+    options: Vec<SelectOption>,
+    required: bool,
+    aria_required: bool,
+    class: Option<String>,
+    label_class: Option<String>,
+    aria_invalid: Option<bool>,
+    described_by: Option<String>,
+    hx: Vec<(String, String)>,
+    label: Option<LabelSource>,
+    _state: std::marker::PhantomData<State>,
+}
+
+impl Select<NoLabel> {
+    /// Start building a select with the given form `name`. The returned value
+    /// has no label yet and cannot be rendered until one is attached.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            options: Vec::new(),
+            required: false,
+            aria_required: false,
+            class: None,
+            label_class: None,
+            aria_invalid: None,
+            described_by: None,
+            hx: Vec::new(),
+            label: None,
+            _state: std::marker::PhantomData,
+        }
+    }
+
+    /// Attach a visible `<label for=…>` and transition to the renderable
+    /// [`Labeled`] state.
+    #[must_use]
+    pub fn label(self, text: impl Into<String>) -> Select<Labeled> {
+        self.with_label(LabelSource::Visible(text.into()))
+    }
+
+    /// Attach an `aria-label` (no visible label) and transition to the
+    /// renderable [`Labeled`] state.
+    #[must_use]
+    pub fn aria_label(self, text: impl Into<String>) -> Select<Labeled> {
+        self.with_label(LabelSource::Aria(text.into()))
+    }
+
+    /// Reference an existing element's `id` via `aria-labelledby` and transition
+    /// to the renderable [`Labeled`] state.
+    #[must_use]
+    pub fn labelled_by(self, id: impl Into<String>) -> Select<Labeled> {
+        self.with_label(LabelSource::LabelledBy(id.into()))
+    }
+
+    fn with_label(self, label: LabelSource) -> Select<Labeled> {
+        Select {
+            name: self.name,
+            options: self.options,
+            required: self.required,
+            aria_required: self.aria_required,
+            class: self.class,
+            label_class: self.label_class,
+            aria_invalid: self.aria_invalid,
+            described_by: self.described_by,
+            hx: self.hx,
+            label: Some(label),
+            _state: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<State> Select<State> {
+    /// Append a single option built from a `value` and visible `label`.
+    #[must_use]
+    pub fn option(mut self, value: impl Into<String>, label: impl Into<String>) -> Self {
+        self.options.push(SelectOption::new(value, label));
+        self
+    }
+
+    /// Append a batch of pre-built [`SelectOption`]s, preserving their order.
+    #[must_use]
+    pub fn options(mut self, options: impl IntoIterator<Item = SelectOption>) -> Self {
+        self.options.extend(options);
+        self
+    }
+
+    /// Mark the option whose `value` matches as `selected` (all others are left
+    /// unchanged).
+    #[must_use]
+    pub fn selected_value(mut self, value: impl Into<String>) -> Self {
+        let value = value.into();
+        for opt in &mut self.options {
+            if opt.value == value {
+                opt.selected = true;
+            }
+        }
+        self
+    }
+
+    /// Mark the select as `required`.
+    #[must_use]
+    pub const fn required(mut self) -> Self {
+        self.required = true;
+        self
+    }
+
+    /// Add a mirroring `aria-required="true"` alongside the native `required`
+    /// attribute. Available before or after a label is attached.
+    #[must_use]
+    pub const fn aria_required(mut self) -> Self {
+        self.aria_required = true;
+        self
+    }
+
+    /// Set the `class` attribute on the `<select>`.
+    #[must_use]
+    pub fn class(mut self, class: impl Into<String>) -> Self {
+        self.class = Some(class.into());
+        self
+    }
+
+    /// Set the `class` attribute on the visible `<label>` element. Only affects
+    /// rendering when a visible label was set via [`label`](Self::label).
+    #[must_use]
+    pub fn label_class(mut self, class: impl Into<String>) -> Self {
+        self.label_class = Some(class.into());
+        self
+    }
+
+    /// Set `aria-invalid` to `"true"` or `"false"`. When left unset the
+    /// attribute is omitted entirely.
+    #[must_use]
+    pub const fn aria_invalid(mut self, invalid: bool) -> Self {
+        self.aria_invalid = Some(invalid);
+        self
+    }
+
+    /// Reference the `id` of the element describing this field via
+    /// `aria-describedby`.
+    #[must_use]
+    pub fn described_by(mut self, id: impl Into<String>) -> Self {
+        self.described_by = Some(id.into());
+        self
+    }
+
+    /// Attach an arbitrary `hx-*` attribute (the `name` is the suffix after
+    /// `hx-`), preserving the typed label obligation. Emitted in insertion
+    /// order. Available before or after a label is attached.
+    #[must_use]
+    pub fn hx(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.hx.push((name.into(), value.into()));
+        self
+    }
+}
+
+impl Render for Select<Labeled> {
+    fn render(&self) -> Markup {
+        let (visible_label, aria_label, aria_labelledby) = match &self.label {
+            Some(LabelSource::Visible(text)) => (Some(text.as_str()), None, None),
+            Some(LabelSource::Aria(text)) => (None, Some(text.as_str()), None),
+            Some(LabelSource::LabelledBy(id)) => (None, None, Some(id.as_str())),
+            None => (None, None, None),
+        };
+        let aria_invalid = self
+            .aria_invalid
+            .map(|invalid| if invalid { "true" } else { "false" });
+        let aria_required = self.aria_required.then_some("true");
+        let select = html! {
+            select
+                id=(self.name)
+                name=(self.name)
+                aria-label=[aria_label]
+                aria-labelledby=[aria_labelledby]
+                class=[self.class.as_deref()]
+                aria-invalid=[aria_invalid]
+                aria-describedby=[self.described_by.as_deref()]
+                aria-required=[aria_required]
+                required[self.required] {
+                    @for opt in &self.options {
+                        option value=(opt.value) selected[opt.selected] disabled[opt.disabled] {
+                            (opt.label)
+                        }
+                    }
+                }
+        };
+        html! {
+            @if let Some(text) = visible_label {
+                label for=(self.name) class=[self.label_class.as_deref()] { (text) }
+            }
+            (with_hx_attrs(select, &self.hx))
+        }
+    }
+}
+
+/// A single boolean `<input type="checkbox">` whose label association is
+/// enforced by the type system (WCAG 1.3.1 / 3.3.2 / 4.1.2).
+///
+/// [`Checkbox::new`] returns a `Checkbox<NoLabel>`, which has no way to render.
+/// Attaching a label with [`label`](Checkbox::label),
+/// [`aria_label`](Checkbox::aria_label), or
+/// [`labelled_by`](Checkbox::labelled_by) consumes it and returns a
+/// `Checkbox<Labeled>`, the only state that implements [`maud::Render`].
+///
+/// A `Checkbox` models a plain `bool`. A nullable/tri-state boolean is **not** a
+/// checkbox — it reuses [`Select`] (with an empty-value placeholder option) —
+/// so this primitive stays strictly two-state.
+///
+/// For a visible label the `<input>` is emitted first, followed by a
+/// `<label for=…>` (the conventional checkbox layout); the `aria-label` /
+/// `aria-labelledby` variants place the accessible name on the input itself and
+/// render no `<label>`.
+#[derive(Debug, Clone)]
+pub struct Checkbox<State> {
+    name: String,
+    value: Option<String>,
+    checked: bool,
+    required: bool,
+    aria_required: bool,
+    class: Option<String>,
+    label_class: Option<String>,
+    aria_invalid: Option<bool>,
+    described_by: Option<String>,
+    hx: Vec<(String, String)>,
+    label: Option<LabelSource>,
+    _state: std::marker::PhantomData<State>,
+}
+
+impl Checkbox<NoLabel> {
+    /// Start building a checkbox with the given form `name`. The returned value
+    /// has no label yet and cannot be rendered until one is attached.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            value: None,
+            checked: false,
+            required: false,
+            aria_required: false,
+            class: None,
+            label_class: None,
+            aria_invalid: None,
+            described_by: None,
+            hx: Vec::new(),
+            label: None,
+            _state: std::marker::PhantomData,
+        }
+    }
+
+    /// Attach a visible `<label for=…>` and transition to the renderable
+    /// [`Labeled`] state.
+    #[must_use]
+    pub fn label(self, text: impl Into<String>) -> Checkbox<Labeled> {
+        self.with_label(LabelSource::Visible(text.into()))
+    }
+
+    /// Attach an `aria-label` (no visible label) and transition to the
+    /// renderable [`Labeled`] state.
+    #[must_use]
+    pub fn aria_label(self, text: impl Into<String>) -> Checkbox<Labeled> {
+        self.with_label(LabelSource::Aria(text.into()))
+    }
+
+    /// Reference an existing element's `id` via `aria-labelledby` and transition
+    /// to the renderable [`Labeled`] state.
+    #[must_use]
+    pub fn labelled_by(self, id: impl Into<String>) -> Checkbox<Labeled> {
+        self.with_label(LabelSource::LabelledBy(id.into()))
+    }
+
+    fn with_label(self, label: LabelSource) -> Checkbox<Labeled> {
+        Checkbox {
+            name: self.name,
+            value: self.value,
+            checked: self.checked,
+            required: self.required,
+            aria_required: self.aria_required,
+            class: self.class,
+            label_class: self.label_class,
+            aria_invalid: self.aria_invalid,
+            described_by: self.described_by,
+            hx: self.hx,
+            label: Some(label),
+            _state: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<State> Checkbox<State> {
+    /// Set the submitted `value` attribute (e.g. `"true"`). Omitted when unset.
+    #[must_use]
+    pub fn value(mut self, value: impl Into<String>) -> Self {
+        self.value = Some(value.into());
+        self
+    }
+
+    /// Set the initial `checked` state.
+    #[must_use]
+    pub const fn checked(mut self, checked: bool) -> Self {
+        self.checked = checked;
+        self
+    }
+
+    /// Mark the checkbox as `required` (the box must be ticked to submit).
+    #[must_use]
+    pub const fn required(mut self) -> Self {
+        self.required = true;
+        self
+    }
+
+    /// Add a mirroring `aria-required="true"` alongside the native `required`
+    /// attribute. Available before or after a label is attached.
+    #[must_use]
+    pub const fn aria_required(mut self) -> Self {
+        self.aria_required = true;
+        self
+    }
+
+    /// Set the `class` attribute on the `<input>`.
+    #[must_use]
+    pub fn class(mut self, class: impl Into<String>) -> Self {
+        self.class = Some(class.into());
+        self
+    }
+
+    /// Set the `class` attribute on the visible `<label>` element. Only affects
+    /// rendering when a visible label was set via [`label`](Self::label).
+    #[must_use]
+    pub fn label_class(mut self, class: impl Into<String>) -> Self {
+        self.label_class = Some(class.into());
+        self
+    }
+
+    /// Set `aria-invalid` to `"true"` or `"false"`. When left unset the
+    /// attribute is omitted entirely.
+    #[must_use]
+    pub const fn aria_invalid(mut self, invalid: bool) -> Self {
+        self.aria_invalid = Some(invalid);
+        self
+    }
+
+    /// Reference the `id` of the element describing this field via
+    /// `aria-describedby`.
+    #[must_use]
+    pub fn described_by(mut self, id: impl Into<String>) -> Self {
+        self.described_by = Some(id.into());
+        self
+    }
+
+    /// Attach an arbitrary `hx-*` attribute (the `name` is the suffix after
+    /// `hx-`), preserving the typed label obligation. Emitted in insertion
+    /// order. Available before or after a label is attached.
+    #[must_use]
+    pub fn hx(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.hx.push((name.into(), value.into()));
+        self
+    }
+}
+
+impl Render for Checkbox<Labeled> {
+    fn render(&self) -> Markup {
+        let (visible_label, aria_label, aria_labelledby) = match &self.label {
+            Some(LabelSource::Visible(text)) => (Some(text.as_str()), None, None),
+            Some(LabelSource::Aria(text)) => (None, Some(text.as_str()), None),
+            Some(LabelSource::LabelledBy(id)) => (None, None, Some(id.as_str())),
+            None => (None, None, None),
+        };
+        let aria_invalid = self
+            .aria_invalid
+            .map(|invalid| if invalid { "true" } else { "false" });
+        let aria_required = self.aria_required.then_some("true");
+        let input = html! {
+            input
+                type="checkbox"
+                id=(self.name)
+                name=(self.name)
+                value=[self.value.as_deref()]
+                aria-label=[aria_label]
+                aria-labelledby=[aria_labelledby]
+                class=[self.class.as_deref()]
+                aria-invalid=[aria_invalid]
+                aria-describedby=[self.described_by.as_deref()]
+                aria-required=[aria_required]
+                checked[self.checked]
+                required[self.required];
+        };
+        html! {
+            (with_hx_attrs(input, &self.hx))
+            @if let Some(text) = visible_label {
+                label for=(self.name) class=[self.label_class.as_deref()] { (text) }
+            }
+        }
+    }
+}
+
+/// A `<input type="file">` whose label association is enforced by the type
+/// system (WCAG 1.3.1 Info and Relationships, 3.3.2 Labels or Instructions,
+/// 4.1.2 Name, Role, Value).
+///
+/// [`FileField::new`] returns a `FileField<NoLabel>`, which has no way to
+/// render. Attaching a label with [`label`](FileField::label),
+/// [`aria_label`](FileField::aria_label), or
+/// [`labelled_by`](FileField::labelled_by) consumes it and returns a
+/// `FileField<Labeled>`, the only state that implements [`maud::Render`].
+///
+/// This is the typed, explicitly-labeled file input planned in issue #1933. It
+/// resolves the accessible-name caveat of the older
+/// `storage::form_helper::direct_upload_input` helper, whose *derived*
+/// `aria-label` takes ARIA precedence over a caller's visible `<label>`: with a
+/// visible label a `FileField` emits **no** competing `aria-label`, so the
+/// caller's `<label for=…>` is the control's accessible name.
+///
+/// A file input has no repopulate-on-error value (a browser will not let markup
+/// pre-fill a file control), so `FileField` deliberately carries no `value`.
+#[derive(Debug, Clone)]
+pub struct FileField<State> {
+    name: String,
+    accept: Option<String>,
+    multiple: bool,
+    required: bool,
+    aria_required: bool,
+    class: Option<String>,
+    label_class: Option<String>,
+    aria_invalid: Option<bool>,
+    described_by: Option<String>,
+    hx: Vec<(String, String)>,
+    label: Option<LabelSource>,
+    _state: std::marker::PhantomData<State>,
+}
+
+impl FileField<NoLabel> {
+    /// Start building a file input with the given form `name`. The returned
+    /// value has no label yet and cannot be rendered until one is attached.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            accept: None,
+            multiple: false,
+            required: false,
+            aria_required: false,
+            class: None,
+            label_class: None,
+            aria_invalid: None,
+            described_by: None,
+            hx: Vec::new(),
+            label: None,
+            _state: std::marker::PhantomData,
+        }
+    }
+
+    /// Attach a visible `<label for=…>` and transition to the renderable
+    /// [`Labeled`] state. With a visible label the field emits no `aria-label`,
+    /// so the visible label is the caller-controlled accessible name.
+    #[must_use]
+    pub fn label(self, text: impl Into<String>) -> FileField<Labeled> {
+        self.with_label(LabelSource::Visible(text.into()))
+    }
+
+    /// Attach an `aria-label` (no visible label) and transition to the
+    /// renderable [`Labeled`] state.
+    #[must_use]
+    pub fn aria_label(self, text: impl Into<String>) -> FileField<Labeled> {
+        self.with_label(LabelSource::Aria(text.into()))
+    }
+
+    /// Reference an existing element's `id` via `aria-labelledby` and transition
+    /// to the renderable [`Labeled`] state.
+    #[must_use]
+    pub fn labelled_by(self, id: impl Into<String>) -> FileField<Labeled> {
+        self.with_label(LabelSource::LabelledBy(id.into()))
+    }
+
+    fn with_label(self, label: LabelSource) -> FileField<Labeled> {
+        FileField {
+            name: self.name,
+            accept: self.accept,
+            multiple: self.multiple,
+            required: self.required,
+            aria_required: self.aria_required,
+            class: self.class,
+            label_class: self.label_class,
+            aria_invalid: self.aria_invalid,
+            described_by: self.described_by,
+            hx: self.hx,
+            label: Some(label),
+            _state: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<State> FileField<State> {
+    /// Set the `accept` attribute (a comma-separated list of MIME types or file
+    /// extensions the picker should filter to).
+    #[must_use]
+    pub fn accept(mut self, accept: impl Into<String>) -> Self {
+        self.accept = Some(accept.into());
+        self
+    }
+
+    /// Allow selecting more than one file (`multiple`).
+    #[must_use]
+    pub const fn multiple(mut self) -> Self {
+        self.multiple = true;
+        self
+    }
+
+    /// Mark the file input as `required`.
+    #[must_use]
+    pub const fn required(mut self) -> Self {
+        self.required = true;
+        self
+    }
+
+    /// Add a mirroring `aria-required="true"` alongside the native `required`
+    /// attribute. Available before or after a label is attached.
+    #[must_use]
+    pub const fn aria_required(mut self) -> Self {
+        self.aria_required = true;
+        self
+    }
+
+    /// Set the `class` attribute on the `<input>`.
+    #[must_use]
+    pub fn class(mut self, class: impl Into<String>) -> Self {
+        self.class = Some(class.into());
+        self
+    }
+
+    /// Set the `class` attribute on the visible `<label>` element. Only affects
+    /// rendering when a visible label was set via [`label`](Self::label).
+    #[must_use]
+    pub fn label_class(mut self, class: impl Into<String>) -> Self {
+        self.label_class = Some(class.into());
+        self
+    }
+
+    /// Set `aria-invalid` to `"true"` or `"false"`. When left unset the
+    /// attribute is omitted entirely.
+    #[must_use]
+    pub const fn aria_invalid(mut self, invalid: bool) -> Self {
+        self.aria_invalid = Some(invalid);
+        self
+    }
+
+    /// Reference the `id` of the element describing this field via
+    /// `aria-describedby`.
+    #[must_use]
+    pub fn described_by(mut self, id: impl Into<String>) -> Self {
+        self.described_by = Some(id.into());
+        self
+    }
+
+    /// Attach an arbitrary `hx-*` attribute (the `name` is the suffix after
+    /// `hx-`), preserving the typed label obligation. Emitted in insertion
+    /// order. Available before or after a label is attached.
+    #[must_use]
+    pub fn hx(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.hx.push((name.into(), value.into()));
+        self
+    }
+}
+
+impl Render for FileField<Labeled> {
+    fn render(&self) -> Markup {
+        // With a visible label we deliberately emit NO `aria-label`: the
+        // `<label for=…>` is the caller-controlled accessible name. This is the
+        // fix for the `direct_upload_input` derived-aria-label precedence caveat
+        // (issue #1933).
+        let (visible_label, aria_label, aria_labelledby) = match &self.label {
+            Some(LabelSource::Visible(text)) => (Some(text.as_str()), None, None),
+            Some(LabelSource::Aria(text)) => (None, Some(text.as_str()), None),
+            Some(LabelSource::LabelledBy(id)) => (None, None, Some(id.as_str())),
+            None => (None, None, None),
+        };
+        let aria_invalid = self
+            .aria_invalid
+            .map(|invalid| if invalid { "true" } else { "false" });
+        let aria_required = self.aria_required.then_some("true");
+        let input = html! {
+            input
+                type="file"
+                id=(self.name)
+                name=(self.name)
+                accept=[self.accept.as_deref()]
+                aria-label=[aria_label]
+                aria-labelledby=[aria_labelledby]
+                class=[self.class.as_deref()]
+                aria-invalid=[aria_invalid]
+                aria-describedby=[self.described_by.as_deref()]
+                aria-required=[aria_required]
+                multiple[self.multiple]
+                required[self.required];
+        };
+        html! {
+            @if let Some(text) = visible_label {
+                label for=(self.name) class=[self.label_class.as_deref()] { (text) }
+            }
+            (with_hx_attrs(input, &self.hx))
         }
     }
 }

--- a/autumn/tests/compile-fail/a11y_checkbox_unlabeled.rs
+++ b/autumn/tests/compile-fail/a11y_checkbox_unlabeled.rs
@@ -1,0 +1,11 @@
+//! Issue #1706: an unlabeled `Checkbox` cannot be rendered. WCAG 1.3.1 /
+//! 3.3.2 / 4.1.2 — only `Checkbox<Labeled>` implements `Render`, so calling
+//! `.render()` on a `Checkbox<NoLabel>` (no `.label(..)`/`.aria_label(..)`/
+//! `.labelled_by(..)`) is a compile error.
+
+use autumn_web::a11y::Checkbox;
+use maud::Render;
+
+fn main() {
+    let _markup = Checkbox::new("accept_terms").checked(true).render();
+}

--- a/autumn/tests/compile-fail/a11y_checkbox_unlabeled.stderr
+++ b/autumn/tests/compile-fail/a11y_checkbox_unlabeled.stderr
@@ -1,0 +1,5 @@
+error[E0599]: no method named `render` found for struct `autumn_web::a11y::Checkbox<State>` in the current scope
+  --> tests/compile-fail/a11y_checkbox_unlabeled.rs:10:63
+   |
+10 |     let _markup = Checkbox::new("accept_terms").checked(true).render();
+   |                                                               ^^^^^^ method not found in `autumn_web::a11y::Checkbox<NoLabel>`

--- a/autumn/tests/compile-fail/a11y_filefield_unlabeled.rs
+++ b/autumn/tests/compile-fail/a11y_filefield_unlabeled.rs
@@ -1,0 +1,11 @@
+//! Issue #1706: an unlabeled `FileField` cannot be rendered. WCAG 1.3.1 /
+//! 3.3.2 / 4.1.2 — only `FileField<Labeled>` implements `Render`, so calling
+//! `.render()` on a `FileField<NoLabel>` (no `.label(..)`/`.aria_label(..)`/
+//! `.labelled_by(..)`) is a compile error.
+
+use autumn_web::a11y::FileField;
+use maud::Render;
+
+fn main() {
+    let _markup = FileField::new("avatar").accept("image/*").render();
+}

--- a/autumn/tests/compile-fail/a11y_filefield_unlabeled.stderr
+++ b/autumn/tests/compile-fail/a11y_filefield_unlabeled.stderr
@@ -1,0 +1,5 @@
+error[E0599]: no method named `render` found for struct `FileField<State>` in the current scope
+  --> tests/compile-fail/a11y_filefield_unlabeled.rs:10:62
+   |
+10 |     let _markup = FileField::new("avatar").accept("image/*").render();
+   |                                                              ^^^^^^ method not found in `FileField<NoLabel>`

--- a/autumn/tests/compile-fail/a11y_select_unlabeled.rs
+++ b/autumn/tests/compile-fail/a11y_select_unlabeled.rs
@@ -1,0 +1,11 @@
+//! Issue #1706: an unlabeled `Select` cannot be rendered. WCAG 1.3.1 / 3.3.2 /
+//! 4.1.2 — only `Select<Labeled>` implements `Render`, so calling `.render()`
+//! on a `Select<NoLabel>` (no `.label(..)`/`.aria_label(..)`/`.labelled_by(..)`)
+//! is a compile error, even when options are present.
+
+use autumn_web::a11y::Select;
+use maud::Render;
+
+fn main() {
+    let _markup = Select::new("role").option("admin", "Admin").render();
+}

--- a/autumn/tests/compile-fail/a11y_select_unlabeled.stderr
+++ b/autumn/tests/compile-fail/a11y_select_unlabeled.stderr
@@ -1,0 +1,5 @@
+error[E0599]: no method named `render` found for struct `autumn_web::a11y::Select<State>` in the current scope
+  --> tests/compile-fail/a11y_select_unlabeled.rs:10:64
+   |
+10 |     let _markup = Select::new("role").option("admin", "Admin").render();
+   |                                                                ^^^^^^ method not found in `autumn_web::a11y::Select<NoLabel>`

--- a/autumn/tests/compile-fail/a11y_textarea_unlabeled.rs
+++ b/autumn/tests/compile-fail/a11y_textarea_unlabeled.rs
@@ -1,0 +1,11 @@
+//! Issue #1706: an unlabeled `TextArea` cannot be rendered. WCAG 1.3.1 /
+//! 3.3.2 / 4.1.2 — only `TextArea<Labeled>` implements `Render`, so calling
+//! `.render()` on a `TextArea<NoLabel>` (no `.label(..)`/`.aria_label(..)`/
+//! `.labelled_by(..)`) is a compile error.
+
+use autumn_web::a11y::TextArea;
+use maud::Render;
+
+fn main() {
+    let _markup = TextArea::new("bio").render();
+}

--- a/autumn/tests/compile-fail/a11y_textarea_unlabeled.stderr
+++ b/autumn/tests/compile-fail/a11y_textarea_unlabeled.stderr
@@ -1,0 +1,5 @@
+error[E0599]: no method named `render` found for struct `TextArea<State>` in the current scope
+  --> tests/compile-fail/a11y_textarea_unlabeled.rs:10:40
+   |
+10 |     let _markup = TextArea::new("bio").render();
+   |                                        ^^^^^^ method not found in `TextArea<NoLabel>`

--- a/autumn/tests/compile-pass/a11y_primitives.rs
+++ b/autumn/tests/compile-pass/a11y_primitives.rs
@@ -3,7 +3,10 @@
 //! Each primitive can only be constructed with an accessible name, and only a
 //! labeled `TextField` can be rendered — these are exactly those forms.
 
-use autumn_web::a11y::{Button, ButtonType, Img, Link, MenuItem, TextField};
+use autumn_web::a11y::{
+    Button, ButtonType, Checkbox, FileField, Img, Link, MenuItem, Select, SelectOption, TextArea,
+    TextField,
+};
 use autumn_web::html;
 use maud::Render;
 
@@ -78,4 +81,56 @@ fn main() {
     // Icon-only menu item keeps its accessible name via aria-label.
     let cog = html! { span aria-hidden="true" { "*" } };
     let _icon_item = MenuItem::new("Settings").icon(cog).class("item").render();
+
+    // A labeled text area is renderable; the value rides as text content.
+    let _bio = TextArea::new("bio")
+        .rows(6)
+        .cols(40)
+        .maxlength(500)
+        .value("Hello")
+        .label("Bio")
+        .render();
+
+    // A labeled select renders its typed options.
+    let _role = Select::new("role")
+        .option("", "— Select —")
+        .options([
+            SelectOption::new("admin", "Admin").selected(),
+            SelectOption::new("user", "User"),
+        ])
+        .selected_value("user")
+        .required()
+        .aria_required()
+        .label("Role")
+        .render();
+
+    // A labeled checkbox for a boolean field.
+    let _terms = Checkbox::new("accept_terms")
+        .value("true")
+        .checked(true)
+        .required()
+        .label("I accept the terms")
+        .render();
+
+    // A labeled file field — no derived aria-label competes with the visible label.
+    let _avatar = FileField::new("avatar")
+        .accept("image/*")
+        .multiple()
+        .label("Avatar")
+        .render();
+
+    // The hx-* escape hatch keeps the typed label obligation on the htmx path.
+    let _live = TextField::new("username")
+        .hx("post", "/validate/username")
+        .hx("trigger", "blur")
+        .label("Username")
+        .render();
+    let _live_area = TextArea::new("bio").hx("post", "/validate/bio").aria_label("Bio").render();
+    let _live_select = Select::new("role")
+        .option("user", "User")
+        .hx("get", "/roles")
+        .aria_label("Role")
+        .render();
+    let _live_check = Checkbox::new("subscribe").hx("post", "/toggle").aria_label("Subscribe").render();
+    let _live_file = FileField::new("doc").hx("post", "/scan").labelled_by("doc-heading").render();
 }

--- a/autumn/tests/integration/a11y.rs
+++ b/autumn/tests/integration/a11y.rs
@@ -8,7 +8,9 @@
 //!
 #![cfg(feature = "maud")]
 
-use autumn_web::a11y::{Button, Img, Link, MenuItem, TextField};
+use autumn_web::a11y::{
+    Button, Checkbox, FileField, Img, Link, MenuItem, Select, SelectOption, TextArea, TextField,
+};
 use autumn_web::html;
 use maud::Render;
 
@@ -178,6 +180,222 @@ fn icon_menu_item_uses_aria_label() {
     let markup = MenuItem::new("Settings").icon(cog).render().into_string();
     assert!(markup.contains("role=\"menuitem\""), "{markup}");
     assert!(markup.contains("aria-label=\"Settings\""), "{markup}");
+}
+
+#[test]
+fn text_area_carries_value_as_text_content_not_attribute() {
+    let markup = TextArea::new("bio")
+        .value("Hello world")
+        .rows(6)
+        .cols(40)
+        .maxlength(500)
+        .label("Bio")
+        .render()
+        .into_string();
+    assert!(
+        markup.contains("<label for=\"bio\">Bio</label>"),
+        "{markup}"
+    );
+    // The value rides as the element's text content, never a `value=` attribute.
+    assert!(
+        markup.contains("<textarea") && markup.contains(">Hello world</textarea>"),
+        "{markup}"
+    );
+    assert!(
+        !markup.contains("value="),
+        "value must not be an attribute: {markup}"
+    );
+    assert!(markup.contains("rows=\"6\""), "{markup}");
+    assert!(markup.contains("cols=\"40\""), "{markup}");
+    assert!(markup.contains("maxlength=\"500\""), "{markup}");
+}
+
+#[test]
+fn text_area_aria_label_variant() {
+    let markup = TextArea::new("note")
+        .aria_label("Note")
+        .render()
+        .into_string();
+    assert!(markup.contains("aria-label=\"Note\""), "{markup}");
+    assert!(!markup.contains("<label"), "{markup}");
+}
+
+#[test]
+fn select_renders_each_option_with_value_label_and_selected() {
+    let markup = Select::new("role")
+        .option("", "— Select —")
+        .options([
+            SelectOption::new("admin", "Admin"),
+            SelectOption::new("user", "User"),
+        ])
+        .selected_value("user")
+        .required()
+        .aria_required()
+        .label("Role")
+        .render()
+        .into_string();
+    assert!(
+        markup.contains("<label for=\"role\">Role</label>"),
+        "{markup}"
+    );
+    assert!(markup.contains("<select"), "{markup}");
+    assert!(markup.contains("id=\"role\""), "{markup}");
+    assert!(markup.contains("aria-required=\"true\""), "{markup}");
+    assert!(markup.contains("required"), "{markup}");
+    // Each option carries its value + visible label.
+    assert!(markup.contains("value=\"admin\""), "{markup}");
+    assert!(markup.contains(">Admin<"), "{markup}");
+    assert!(markup.contains("value=\"user\""), "{markup}");
+    assert!(markup.contains(">User<"), "{markup}");
+    // The matching option (and only it) is selected.
+    assert!(
+        markup.contains("value=\"user\" selected"),
+        "user option must be selected: {markup}"
+    );
+    assert!(
+        !markup.contains("value=\"admin\" selected"),
+        "admin option must not be selected: {markup}"
+    );
+}
+
+#[test]
+fn select_placeholder_option_can_be_disabled() {
+    let markup = Select::new("role")
+        .options([SelectOption::new("", "— Select —").disabled()])
+        .labelled_by("role-heading")
+        .render()
+        .into_string();
+    assert!(
+        markup.contains("aria-labelledby=\"role-heading\""),
+        "{markup}"
+    );
+    assert!(markup.contains("disabled"), "{markup}");
+}
+
+#[test]
+fn checkbox_renders_type_checked_and_label_association() {
+    let markup = Checkbox::new("accept_terms")
+        .value("true")
+        .checked(true)
+        .required()
+        .label("I accept the terms")
+        .render()
+        .into_string();
+    assert!(markup.contains("type=\"checkbox\""), "{markup}");
+    assert!(markup.contains("id=\"accept_terms\""), "{markup}");
+    assert!(markup.contains("value=\"true\""), "{markup}");
+    assert!(markup.contains("checked"), "{markup}");
+    assert!(markup.contains("required"), "{markup}");
+    // The `<label for>` associates with the input by id.
+    assert!(
+        markup.contains("<label for=\"accept_terms\">I accept the terms</label>"),
+        "{markup}"
+    );
+    // Layout: input precedes the label for a checkbox.
+    let input_pos = markup.find("<input").expect("input present");
+    let label_pos = markup.find("<label").expect("label present");
+    assert!(input_pos < label_pos, "input must precede label: {markup}");
+}
+
+#[test]
+fn checkbox_unchecked_by_default() {
+    let markup = Checkbox::new("subscribe")
+        .aria_label("Subscribe")
+        .render()
+        .into_string();
+    assert!(markup.contains("type=\"checkbox\""), "{markup}");
+    assert!(!markup.contains("checked"), "{markup}");
+    assert!(markup.contains("aria-label=\"Subscribe\""), "{markup}");
+}
+
+#[test]
+fn file_field_renders_type_accept_and_multiple() {
+    let markup = FileField::new("docs")
+        .accept("application/pdf")
+        .multiple()
+        .aria_label("Documents")
+        .render()
+        .into_string();
+    assert!(markup.contains("type=\"file\""), "{markup}");
+    assert!(markup.contains("accept=\"application/pdf\""), "{markup}");
+    assert!(markup.contains("multiple"), "{markup}");
+    assert!(markup.contains("aria-label=\"Documents\""), "{markup}");
+}
+
+#[test]
+fn visible_labeled_file_field_emits_no_competing_aria_label() {
+    // The key #1933 fix: a caller's visible `<label for>` is the accessible name,
+    // so the field emits NO derived `aria-label` to override it (the precedence
+    // caveat of `direct_upload_input`).
+    let markup = FileField::new("avatar")
+        .accept("image/*")
+        .label("Avatar")
+        .render()
+        .into_string();
+    assert!(
+        markup.contains("<label for=\"avatar\">Avatar</label>"),
+        "{markup}"
+    );
+    assert!(markup.contains("type=\"file\""), "{markup}");
+    assert!(
+        !markup.contains("aria-label"),
+        "a visible-labeled file field must not emit a competing aria-label: {markup}"
+    );
+}
+
+#[test]
+fn hx_escape_hatch_renders_attributes_in_order() {
+    let markup = TextField::new("username")
+        .hx("post", "/x")
+        .hx("params", "not _submit_token")
+        .label("Username")
+        .render()
+        .into_string();
+    assert!(markup.contains("hx-post=\"/x\""), "{markup}");
+    assert!(
+        markup.contains("hx-params=\"not _submit_token\""),
+        "{markup}"
+    );
+    // Insertion order is preserved.
+    let post_pos = markup.find("hx-post").expect("hx-post present");
+    let params_pos = markup.find("hx-params").expect("hx-params present");
+    assert!(
+        post_pos < params_pos,
+        "hx order must be preserved: {markup}"
+    );
+}
+
+#[test]
+fn hx_escape_hatch_is_a_noop_when_empty() {
+    // An empty hx set must render byte-identically to no escape hatch at all.
+    let with_hx = TextField::new("email")
+        .label("Email")
+        .render()
+        .into_string();
+    let plain = TextField::new("email")
+        .label("Email")
+        .render()
+        .into_string();
+    assert_eq!(with_hx, plain, "empty hx must not change output");
+    assert!(!with_hx.contains("hx-"), "{with_hx}");
+}
+
+#[test]
+fn hx_escape_hatch_escapes_attribute_values() {
+    let markup = Select::new("q")
+        .option("a", "A")
+        .hx("vals", "{\"x\": \"<b>&\"}")
+        .aria_label("Query")
+        .render()
+        .into_string();
+    // The value is HTML-attribute-escaped, never injected raw.
+    assert!(markup.contains("hx-vals="), "{markup}");
+    assert!(markup.contains("&lt;b&gt;"), "{markup}");
+    assert!(markup.contains("&amp;"), "{markup}");
+    assert!(
+        !markup.contains("<b>&\""),
+        "raw value must not leak: {markup}"
+    );
 }
 
 #[test]

--- a/autumn/tests/integration/a11y.rs
+++ b/autumn/tests/integration/a11y.rs
@@ -476,6 +476,103 @@ fn hx_lands_on_visible_labeled_control_not_the_label() {
 }
 
 #[test]
+fn selected_value_is_exclusive_and_clears_prior_selection() {
+    // FIX (PR #1946 review): `<select>` is single-select, so `selected_value`
+    // must authoritatively set exactly one selected option and clear any option
+    // previously marked via `SelectOption::selected()`. Otherwise the rendered
+    // markup carries two `selected` options (invalid HTML).
+    let markup = Select::new("role")
+        .options([
+            SelectOption::new("admin", "Admin").selected(),
+            SelectOption::new("user", "User"),
+            SelectOption::new("other", "Other"),
+        ])
+        .selected_value("other")
+        .aria_label("Role")
+        .render()
+        .into_string();
+    // Exactly one `selected` occurrence, on the "other" option.
+    assert_eq!(
+        markup.matches(" selected").count(),
+        1,
+        "exactly one option may be selected: {markup}"
+    );
+    assert!(
+        markup.contains("value=\"other\" selected"),
+        "the chosen option must be selected: {markup}"
+    );
+    assert!(
+        !markup.contains("value=\"admin\" selected"),
+        "the pre-marked option must no longer be selected: {markup}"
+    );
+}
+
+#[test]
+fn hx_valid_multi_attr_chain_renders_all_in_order() {
+    // A valid chain of `hx-*` attributes still renders every attribute, in
+    // insertion order, with escaped values.
+    let markup = Select::new("q")
+        .option("a", "A")
+        .hx("post", "/submit")
+        .hx("target", "#result")
+        .hx("swap", "outerHTML")
+        .aria_label("Query")
+        .render()
+        .into_string();
+    assert!(markup.contains("hx-post=\"/submit\""), "{markup}");
+    assert!(markup.contains("hx-target=\"#result\""), "{markup}");
+    assert!(markup.contains("hx-swap=\"outerHTML\""), "{markup}");
+    let post = markup.find("hx-post").expect("hx-post present");
+    let target = markup.find("hx-target").expect("hx-target present");
+    let swap = markup.find("hx-swap").expect("hx-swap present");
+    assert!(post < target && target < swap, "order preserved: {markup}");
+}
+
+#[test]
+fn hx_rejects_attribute_name_injection() {
+    // FIX (PR #1946 review): a name containing whitespace or `=` — which
+    // `maud::Escaper` does NOT escape — must never break out into a separate,
+    // injected attribute. In debug builds this trips a `debug_assert!`; in
+    // release builds the malformed attribute is dropped (fail-safe). Either way,
+    // no standalone `autofocus` / broken-out `="/v"` may appear in the output.
+    let build = || {
+        Select::new("q")
+            .option("a", "A")
+            .hx("post autofocus", "/v")
+            .aria_label("Query")
+            .render()
+            .into_string()
+    };
+
+    #[cfg(debug_assertions)]
+    {
+        // The debug_assert! surfaces the developer error as a panic.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(build));
+        assert!(
+            result.is_err(),
+            "an invalid hx name must trip debug_assert! in debug builds"
+        );
+    }
+
+    #[cfg(not(debug_assertions))]
+    {
+        let markup = build();
+        assert!(
+            !markup.contains("autofocus"),
+            "the injected attribute must not be emitted: {markup}"
+        );
+        assert!(
+            !markup.contains("=\"/v\""),
+            "the broken-out value must not be emitted: {markup}"
+        );
+        assert!(
+            !markup.contains("hx-post autofocus"),
+            "the malformed name must not be emitted: {markup}"
+        );
+    }
+}
+
+#[test]
 fn splices_inside_html_block() {
     let page = html! {
         (Img::new("/logo.svg", "Autumn logo"))

--- a/autumn/tests/integration/a11y.rs
+++ b/autumn/tests/integration/a11y.rs
@@ -399,6 +399,83 @@ fn hx_escape_hatch_escapes_attribute_values() {
 }
 
 #[test]
+fn hx_lands_on_visible_labeled_control_not_the_label() {
+    // Decisive regression guard (PR #1946 review). Every primitive renders a
+    // visible `<label>` as a *sibling* of the control, and `with_hx_attrs` is
+    // applied to the control sub-element ALONE — so the "first `>`" the splice
+    // targets is the control's own opening tag, never the preceding `<label>`.
+    // This pins that: with a visible label present, the `hx-*` attributes must
+    // land inside the CONTROL's opening tag and must NOT appear on the `<label>`.
+
+    // Returns the opening-tag substring `<tag …>` for the first `<tag` in `s`.
+    fn opening_tag<'a>(s: &'a str, tag: &str) -> &'a str {
+        let start = s
+            .find(tag)
+            .unwrap_or_else(|| panic!("{tag} present in: {s}"));
+        let rel_end = s[start..].find('>').expect("opening tag closes with >");
+        &s[start..=start + rel_end]
+    }
+
+    // `<label>` precedes `<textarea>` / `<select>` / file `<input>` / text
+    // `<input>`; the checkbox emits `<input>` before `<label>`. In every case
+    // the splice must target the control tag, not the label tag.
+    let cases: [(&str, String); 5] = [
+        (
+            "<textarea",
+            TextArea::new("bio")
+                .label("Bio")
+                .hx("post", "/v")
+                .render()
+                .into_string(),
+        ),
+        (
+            "<select",
+            Select::new("role")
+                .option("admin", "Admin")
+                .label("Role")
+                .hx("post", "/v")
+                .render()
+                .into_string(),
+        ),
+        (
+            "<input",
+            FileField::new("avatar")
+                .label("Avatar")
+                .hx("post", "/v")
+                .render()
+                .into_string(),
+        ),
+        (
+            "<input",
+            TextField::new("email")
+                .label("Email")
+                .hx("post", "/v")
+                .render()
+                .into_string(),
+        ),
+        (
+            "<input",
+            Checkbox::new("terms")
+                .label("I accept")
+                .hx("post", "/v")
+                .render()
+                .into_string(),
+        ),
+    ];
+
+    for (control_tag, markup) in &cases {
+        assert!(
+            opening_tag(markup, control_tag).contains("hx-post=\"/v\""),
+            "hx-post must be inside the {control_tag} opening tag: {markup}"
+        );
+        assert!(
+            !opening_tag(markup, "<label").contains("hx-post"),
+            "hx-post must NOT be spliced onto the <label>: {markup}"
+        );
+    }
+}
+
+#[test]
 fn splices_inside_html_block() {
     let page = html! {
         (Img::new("/logo.svg", "Autumn logo"))

--- a/autumn/tests/integration/compile_fail.rs
+++ b/autumn/tests/integration/compile_fail.rs
@@ -77,6 +77,17 @@ fn compile_fail_tests() {
     t.compile_fail("tests/compile-fail/a11y_link_missing_text.rs");
     #[cfg(feature = "maud")]
     t.compile_fail("tests/compile-fail/a11y_menuitem_missing_name.rs");
+    // The multi-line / dropdown / boolean / file-input form primitives carry the
+    // same type-level label obligation as `TextField`: an unlabeled one has no
+    // `.render()` and does not build.
+    #[cfg(feature = "maud")]
+    t.compile_fail("tests/compile-fail/a11y_textarea_unlabeled.rs");
+    #[cfg(feature = "maud")]
+    t.compile_fail("tests/compile-fail/a11y_select_unlabeled.rs");
+    #[cfg(feature = "maud")]
+    t.compile_fail("tests/compile-fail/a11y_checkbox_unlabeled.rs");
+    #[cfg(feature = "maud")]
+    t.compile_fail("tests/compile-fail/a11y_filefield_unlabeled.rs");
 }
 
 #[test]


### PR DESCRIPTION
Part of #1706. Implements the primitives portion of #1933.

## Before / After

**Before:** the scaffold generator emits a labeled, accessible control only for single-line text fields (`TextField`). Every other field kind — multi-line text, dropdowns, booleans, file uploads — falls back to raw `html!` markup, which bypasses the type-level accessible-name obligation. It is trivially possible to ship a `<textarea>`, `<select>`, `<input type="checkbox">`, or `<input type="file">` with no associated label, and nothing catches it until an audit (or a user relying on assistive technology). Separately, `storage::form_helper::direct_upload_input` derives an `aria-label` from the field name that, per the ARIA accessible-name computation, *overrides* a caller's visible `<label>` — a documented caveat awaiting a typed file-field primitive.

**After:** `TextArea`, `Select`, `Checkbox`, and `FileField` join `TextField` as label-obligated typed primitives. Each is a typestate builder: constructing one yields a `<Primitive><NoLabel>`, which does **not** implement `maud::Render`. Only after attaching a label (`.label(..)` / `.aria_label(..)` / `.labelled_by(..)`) does it become a `<Primitive><Labeled>` that can render. An unlabeled primitive therefore has no `.render()` method — building it is a compile error (`E0599`), so the accessible-name obligation (WCAG 1.3.1 / 3.3.2 / 4.1.2) is discharged at compile time. `FileField` with a visible label emits **no** competing derived `aria-label`, resolving the `direct_upload_input` precedence caveat.

## How

- Each primitive mirrors the existing `TextField<State>` pattern exactly: `PhantomData` typestate; constructor + `label`/`aria_label`/`labelled_by` in the `NoLabel` impl (each returning `Labeled`); presentational/validation setters in the state-generic impl; `impl Render` only for `Labeled`. The `LabelSource` / `NoLabel` / `Labeled` types are reused across all five primitives, not redefined.
- `TextArea` carries its value as the element's **text content** (`<textarea>…</textarea>`), never a `value=` attribute. `Select` uses a companion `SelectOption` struct (named to avoid shadowing `std::option::Option`). `Checkbox` is bool-only (a nullable/tri-state boolean reuses `Select`) and emits the input before its `<label for>`. `FileField` carries no `value` (a file input cannot be repopulated on error).
- An `hx(name, value)` escape hatch is added to all five form primitives (including `TextField`) so the htmx `--live-validation` path keeps the typed label obligation. maud 0.27 requires static attribute names (`Named` parses an `HtmlName`, not a splice) and forbids control flow in attribute position, so a dynamic `hx-*` set can't be expressed in `html!` tag syntax. It is spliced via one centralized helper: because maud escapes every `>` to `&gt;`, the first literal `>` in a rendered element is always the end of its opening tag, so the escaped attributes are inserted there. An empty `hx` set renders the element byte-for-byte unchanged (existing `TextField` output is untouched).
- New trybuild compile-fail goldens (one per new primitive) prove an unlabeled primitive has no `.render()`. The compile-pass fixture and the runtime render integration tests are extended: value-as-text-content, option value/label/`selected` rendering, checkbox label association, the no-competing-`aria-label` file-field fix, and ordered / escaped / no-op `hx` rendering.

## Scope

This is the **primitives only**. The scaffold routing that consumes them (#1933's routing boxes in `autumn-cli/src/generate/scaffold.rs`) is a separate follow-up slice gated on PR #1935, so this PR intentionally does **not** close #1933.

CI note: trunk-dev may currently show pre-existing reds (doc-build / saas drift) that are cleared by the separate chore PR #1942 until this branch is rebased.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LcL5aB12Krn1HzL9cM6hYA)_