### PR TITLE
test(a11y): red→green fixture demonstrating `a11y verify` (Closes #1932)

### DIFF
--- a/autumn-cli/tests/fixtures/a11y/green/dashboard.rs
+++ b/autumn-cli/tests/fixtures/a11y/green/dashboard.rs
@@ -1,0 +1,48 @@
+//! GREEN a11y fixture — the SAME dashboard view as `../red/dashboard.rs`, with
+//! every accessibility defect fixed, so `autumn a11y verify` reports ZERO
+//! findings and exits 0 (issue #1932, part of #1706).
+//!
+//! This file is NOT compiled by cargo; it only has to tokenize (the verifier
+//! scans token streams). The corrections are made in raw `maud::html!` here so
+//! the red→green diff is the clearest possible teaching artifact:
+//!
+//!   - input:  add an associated `<label for="email">` + matching `id="email"`.
+//!   - button: give it visible text content ("Save").
+//!   - img:    add a descriptive `alt="Company logo"`.
+//!   - select: add an associated `<label for="role">` + matching `id="role"`.
+//!
+//! The very same clean result is achievable via the typed
+//! `autumn_web::a11y` primitives (`Img::new(src, alt)`, `Button::new(name)`,
+//! `TextField::new(..).label(..)`), which discharge each accessible-name
+//! obligation at COMPILE time. The verifier intentionally does NOT re-scan code
+//! written through those primitives — it only nets the raw-`html!` escape hatch
+//! exercised here.
+
+use maud::{html, Markup};
+
+pub fn view() -> Markup {
+    html! {
+        main {
+            h1 { "Account settings" }
+
+            // `label` fixed — the input now has an associated `<label for>`.
+            form {
+                label for="email" { "Email address" }
+                input type="text" name="email" id="email";
+
+                // `button-name` fixed — the button has visible text content.
+                button type="submit" { "Save" }
+            }
+
+            // `image-alt` fixed — the image now has descriptive alt text.
+            img src="/logo.png" alt="Company logo";
+
+            // `label` fixed — the select now has an associated `<label for>`.
+            label for="role" { "Role" }
+            select name="role" id="role" {
+                option value="admin" { "Admin" }
+                option value="viewer" { "Viewer" }
+            }
+        }
+    }
+}

--- a/autumn-cli/tests/fixtures/a11y/red/dashboard.rs
+++ b/autumn-cli/tests/fixtures/a11y/red/dashboard.rs
@@ -1,0 +1,43 @@
+//! RED a11y fixture — a small dashboard view written in raw `maud::html!`
+//! markup with four **genuine, static** accessibility defects that
+//! `autumn a11y verify` reliably flags (issue #1932, part of #1706).
+//!
+//! This file is NOT compiled by cargo (`tests/fixtures` is not an auto-target);
+//! it only has to be valid Rust that `proc_macro2::TokenStream::from_str` can
+//! tokenize, because the verifier scans token streams, not a type-resolved AST.
+//! The GREEN sibling (`../green/dashboard.rs`) is the same UI with every defect
+//! fixed, so the pair is a clear red→green diff.
+//!
+//! Every defect below is a fully static, literal-attribute element that steps
+//! around every one of the verifier's conservative skips (no splices, no
+//! dynamic `id`/`for`, no dynamic `type`, no sibling `(expr)` fragments), so
+//! all four rules fire deterministically. All four live in ONE `html!` block.
+
+use maud::{html, Markup};
+
+pub fn view() -> Markup {
+    html! {
+        main {
+            h1 { "Account settings" }
+
+            // `label` (WCAG 1.3.1 / 3.3.2 / 4.1.2) — a text input with no
+            // associated `<label for=…>`, `aria-label`, or `aria-labelledby`.
+            form {
+                input type="text" name="email" id="email";
+
+                // `button-name` (WCAG 4.1.2) — a button with an empty static
+                // body and no accessible name.
+                button type="submit" {}
+            }
+
+            // `image-alt` (WCAG 1.1.1) — an `<img>` with no `alt`/aria/title.
+            img src="/logo.png";
+
+            // `label` (again) — a `<select>` with no associated label.
+            select name="role" {
+                option value="admin" { "Admin" }
+                option value="viewer" { "Viewer" }
+            }
+        }
+    }
+}

--- a/autumn-cli/tests/integration/a11y_verify.rs
+++ b/autumn-cli/tests/integration/a11y_verify.rs
@@ -1,0 +1,113 @@
+//! Integration tests for `autumn a11y verify` (issue #1932, part of #1706).
+//!
+//! Drives the real `autumn` binary over a committed red→green fixture pair
+//! under `tests/fixtures/a11y/`:
+//!
+//!   - `red/dashboard.rs`  — raw `html!` markup with four genuine, static
+//!     accessibility defects (a labelless `<input>`, a text-less `<button>`,
+//!     an `<img>` with no `alt`, and a labelless `<select>`). The verifier must
+//!     flag them and exit non-zero.
+//!   - `green/dashboard.rs` — the same UI with every defect fixed. The verifier
+//!     must report zero findings and exit 0.
+//!
+//! The fixtures live under `tests/fixtures/` (NOT `src/`) on purpose: CI's a11y
+//! gate scans only `autumn/src` + `autumn-cli/src`, so the deliberately-broken
+//! RED half never trips the workspace's own accessibility check. The fixture
+//! `.rs` files are only ever *tokenized* by the scanner, so they need to be
+//! valid Rust that parses but need not compile or link.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const fn autumn_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_autumn")
+}
+
+/// Absolute path to a fixture half (`red` or `green`).
+fn fixture_dir(half: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("a11y")
+        .join(half)
+}
+
+/// Run `autumn a11y verify <path> [args...]` and capture its output.
+fn run_verify(path: &Path, args: &[&str]) -> Output {
+    Command::new(autumn_bin())
+        .arg("a11y")
+        .arg("verify")
+        .arg(path)
+        .args(args)
+        .output()
+        .expect("failed to run autumn a11y verify")
+}
+
+/// The RED fixture must fail: a non-zero exit code and JSON findings that
+/// include each defect's rule id (with two `label` findings for the input and
+/// the select).
+#[test]
+fn red_fixture_is_flagged_with_expected_rules() {
+    let out = run_verify(&fixture_dir("red"), &["--format", "json"]);
+
+    assert!(
+        !out.status.success(),
+        "RED fixture must exit non-zero; got {:?}\nstdout:\n{}\nstderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let report: serde_json::Value = serde_json::from_slice(&out.stdout)
+        .expect("`a11y verify --format json` must emit parseable JSON on stdout");
+    let findings = report["findings"]
+        .as_array()
+        .expect("report must carry a `findings` array");
+
+    let rule_ids: Vec<&str> = findings
+        .iter()
+        .filter_map(|f| f["rule_id"].as_str())
+        .collect();
+
+    // The expected rules are PRESENT (line numbers are intentionally not
+    // asserted, so cosmetic fixture edits don't churn the test).
+    assert!(
+        rule_ids.contains(&"image-alt"),
+        "expected an `image-alt` finding; got {rule_ids:?}",
+    );
+    assert!(
+        rule_ids.contains(&"button-name"),
+        "expected a `button-name` finding; got {rule_ids:?}",
+    );
+    let label_findings = rule_ids.iter().filter(|id| **id == "label").count();
+    assert!(
+        label_findings >= 2,
+        "expected at least two `label` findings (input + select); got {rule_ids:?}",
+    );
+}
+
+/// The GREEN fixture is the same UI with every defect fixed, so `a11y verify`
+/// must report no findings and exit 0.
+#[test]
+fn green_fixture_passes_clean() {
+    let out = run_verify(&fixture_dir("green"), &["--format", "json"]);
+
+    assert!(
+        out.status.success(),
+        "GREEN fixture must exit 0; got {:?}\nstdout:\n{}\nstderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let report: serde_json::Value = serde_json::from_slice(&out.stdout)
+        .expect("`a11y verify --format json` must emit parseable JSON on stdout");
+    let findings = report["findings"]
+        .as_array()
+        .expect("report must carry a `findings` array");
+
+    assert!(
+        findings.is_empty(),
+        "GREEN fixture must produce zero findings; got {findings:?}",
+    );
+}

--- a/autumn-cli/tests/integration/mod.rs
+++ b/autumn-cli/tests/integration/mod.rs
@@ -1,3 +1,4 @@
+mod a11y_verify;
 mod api_scaffold;
 mod cloud_native_scaffold;
 mod db;


### PR DESCRIPTION
## What

A committed **red→green** accessibility fixture pair plus an integration test that drives the real `autumn a11y verify` binary over both halves, demonstrating the verifier catching — then clearing — genuine raw-`html!` accessibility defects.

**Before (RED — `autumn-cli/tests/fixtures/a11y/red/dashboard.rs`):** a small dashboard view written in raw `maud::html!` with four real, static defects:
- a `<input>` with no associated `<label for>` → `label` (WCAG 1.3.1 / 3.3.2 / 4.1.2)
- a `<button>` with an empty body → `button-name` (WCAG 4.1.2)
- an `<img>` with no `alt` → `image-alt` (WCAG 1.1.1)
- a `<select>` with no associated label → a second `label` finding

`autumn a11y verify red` flags all four (4 Serious findings) and exits non-zero.

**After (GREEN — `autumn-cli/tests/fixtures/a11y/green/dashboard.rs`):** the same UI with every defect fixed (associated `<label for>` + matching `id` on the input and select, visible `"Save"` text on the button, `alt="Company logo"` on the image). `autumn a11y verify green` reports zero findings and exits 0.

## How

- The two fixture `.rs` files are valid Rust that `proc_macro2::TokenStream::from_str` tokenizes but are **not compiled** by cargo (`tests/fixtures` is not an auto-target); the verifier only scans token streams. Every RED defect is a fully static, literal-attribute element that steps around each of the verifier's conservative skips (no splices, no dynamic `id`/`for`/`type`, no sibling `(expr)` fragments), so all four rules fire deterministically from one `html!` block.
- The fixtures live under `autumn-cli/tests/fixtures/` on purpose: CI's a11y gate scans only `autumn/src` + `autumn-cli/src`, so the deliberately-broken RED half never trips the workspace's own accessibility check.
- A consolidated integration test (`autumn-cli/tests/integration/a11y_verify.rs`, registered in `tests/integration/mod.rs`) resolves the fixture dirs from `CARGO_MANIFEST_DIR`, spawns the built `autumn` binary via `env!("CARGO_BIN_EXE_autumn")` (matching the existing `i18n check` CLI tests), and asserts: RED → non-zero exit with `image-alt`, `button-name`, and ≥2 `label` rule ids present in the JSON report; GREEN → exit 0 with an empty `findings` array. Assertions target rule ids, not line numbers, to stay robust against cosmetic fixture edits.

## Notes

- Part of #1706
- Closes #1932
- CI may show pre-existing trunk reds until #1942 merges + a rebase.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcL5aB12Krn1HzL9cM6hYA)_