### PR TITLE
feat(scaffold): route constrained textarea through a11y::TextArea (Part of #1706)

### DIFF
--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -4074,15 +4074,9 @@ fn render_form_for_helper(
             // changeset so the 422 re-render keeps entered input, and the
             // inline-error/ARIA skeleton matches the derived controls.
             _ => {
-                if let Some((input_type, constraint_attrs)) = html5_constraint_spec(f) {
+                if let Some((input_type, _)) = html5_constraint_spec(f) {
                     let label = humanize_label(name);
-                    let required_attr = if f.nullable {
-                        ""
-                    } else {
-                        " required aria-required=\"true\""
-                    };
                     let _ = write!(builder_calls, "\n        .exclude(\"{name}\")");
-                    // Constrained textareas stay raw: a11y::TextField renders only <input> (see #1706 follow-up).
                     if matches!(f.kind, FieldKind::Text) && input_type == "text" {
                         // A `text` DSL column with a length/plain constraint is a
                         // long-form field (Postgres `TEXT`), so its control is a
@@ -4091,25 +4085,42 @@ fn render_form_for_helper(
                         // (A `text{email}`/`text{url}` field has `input_type` ==
                         // `email`/`url`, which a textarea can't carry — those
                         // inherently single-line, type-dependent controls take the
-                        // `<input type="…">` branch below instead.) Only the
-                        // attributes a textarea honours carry over: the length
-                        // rules in `constraint_attrs` (`minlength`/`maxlength`)
+                        // `<input type="…">` branch below instead.)
+                        //
+                        // Route the constrained multi-line `<textarea>` through the
+                        // typed accessible `a11y::TextArea` primitive (#1933): the
+                        // rendered element/attributes/values carry over unchanged
+                        // (the label now carries `autumn-field__label`), only
+                        // TextArea's attribute order differs. Only the attributes a
+                        // textarea honours apply — the length rules from
+                        // `html5_constraint_builder_calls` (`minlength`/`maxlength`)
                         // and `required`; the input-only `type`/`min`/`max` are
                         // dropped. The 422 re-render value is the element's text
                         // content (not a `value=` attribute) so entered input
-                        // survives, matching `form::textarea_input`.
+                        // survives, matching `form::textarea_input`. The wrapper
+                        // `<div>` and inline-error `<div>` skeleton stay raw and
+                        // identical to the single-line `<input>` branch below.
+                        let constraint_builders = html5_constraint_builder_calls(f)
+                            .map(|(_, calls)| calls)
+                            .unwrap_or_default();
+                        let required_builders = if f.nullable {
+                            ""
+                        } else {
+                            ".required().aria_required()"
+                        };
                         let _ = write!(
                             appends,
                             "\n        .append(html! {{\n            \
                              @let errors = changeset.errors_for(\"{name}\");\n            \
                              div id=\"{name}-field\" class=\"autumn-field\" {{\n                \
-                             label for=\"{name}\" class=\"autumn-field__label\" {{ \"{label}\" }}\n                \
-                             textarea id=\"{name}\" name=\"{name}\"{constraint_attrs}{required_attr}\n                    \
-                             class=(if errors.is_empty() {{ \"autumn-field__input\" }} else {{ \"autumn-field__input autumn-field__input--invalid\" }})\n                    \
-                             aria-invalid=(if errors.is_empty() {{ \"false\" }} else {{ \"true\" }})\n                    \
-                             aria-describedby=(if errors.is_empty() {{ \"\" }} else {{ \"{name}-error\" }}) {{\n                        \
-                             (changeset.field_value(\"{name}\").unwrap_or_default())\n                    \
-                             }}\n                \
+                             (autumn_web::a11y::TextArea::new(\"{name}\")\n                    \
+                             .label(\"{label}\")\n                    \
+                             .label_class(\"autumn-field__label\")\n                    \
+                             .value(changeset.field_value(\"{name}\").unwrap_or_default())\n                    \
+                             {constraint_builders}{required_builders}\n                    \
+                             .class(if errors.is_empty() {{ \"autumn-field__input\" }} else {{ \"autumn-field__input autumn-field__input--invalid\" }})\n                    \
+                             .aria_invalid(!errors.is_empty())\n                    \
+                             .described_by(if errors.is_empty() {{ \"\" }} else {{ \"{name}-error\" }}))\n                \
                              @if !errors.is_empty() {{\n                    \
                              div id=\"{name}-error\" role=\"alert\" class=\"autumn-field__errors\" {{\n                        \
                              @for error in errors {{ p class=\"autumn-field__error\" {{ (error) }} }}\n                    \

--- a/autumn-cli/tests/integration/scaffold_validation.rs
+++ b/autumn-cli/tests/integration/scaffold_validation.rs
@@ -410,15 +410,26 @@ fn text_columns_render_constrained_textarea_not_input() {
     );
     let routes = fs::read_to_string(project.join("src/routes/articles.rs")).unwrap();
 
-    // Both text columns are excised from the derived render and re-appended.
+    // Both text columns are excised from the derived render and re-appended,
+    // routed through the typed accessible `a11y::TextArea` primitive (#1933) —
+    // never a raw `<textarea>`, and never the single-line `a11y::TextField`
+    // (the multi-line control must stay a textarea).
     for field in ["body", "notes"] {
         assert!(
             routes.contains(&format!(".exclude(\"{field}\")")),
             "{field} must be excluded from the derived render:\n{routes}"
         );
         assert!(
-            routes.contains(&format!("textarea id=\"{field}\" name=\"{field}\"")),
-            "{field} must render a <textarea>:\n{routes}"
+            routes.contains(&format!("autumn_web::a11y::TextArea::new(\"{field}\")")),
+            "{field} must render through a11y::TextArea:\n{routes}"
+        );
+        assert!(
+            !routes.contains(&format!("textarea id=\"{field}\" name=\"{field}\"")),
+            "{field} must no longer emit a raw <textarea>:\n{routes}"
+        );
+        assert!(
+            !routes.contains(&format!("TextField::new(\"{field}\")")),
+            "the multi-line {field} must be a TextArea, not a single-line TextField:\n{routes}"
         );
     }
 
@@ -429,20 +440,22 @@ fn text_columns_render_constrained_textarea_not_input() {
         "body must not render a single-line text input:\n{routes}"
     );
 
-    // The non-nullable `body` carries the length rules + required, and its
-    // value is the element's text content, not a `value=` attribute.
-    let body_attrs = slice_textarea_attrs(&routes, "textarea id=\"body\" name=\"body\"");
+    // The non-nullable `body` carries the length rules + required as typed
+    // builder calls, and its value is the element's text content — TextArea
+    // renders `.value(...)` between `<textarea>…</textarea>`, not a `value=`
+    // attribute.
+    let body_attrs = slice_textarea_attrs(&routes, "body");
     assert!(
-        body_attrs.contains("minlength=\"10\"") && body_attrs.contains("maxlength=\"5000\""),
-        "body textarea must carry minlength/maxlength:\n{body_attrs}"
+        body_attrs.contains(".minlength(10u32)") && body_attrs.contains(".maxlength(5000u32)"),
+        "body textarea must carry minlength/maxlength builder calls:\n{body_attrs}"
     );
     assert!(
-        body_attrs.contains("required aria-required=\"true\""),
+        body_attrs.contains(".required().aria_required()"),
         "non-nullable body textarea must be required:\n{body_attrs}"
     );
     assert!(
-        routes.contains("(changeset.field_value(\"body\").unwrap_or_default())"),
-        "body textarea must re-fill from the changeset:\n{routes}"
+        body_attrs.contains(".value(changeset.field_value(\"body\").unwrap_or_default())"),
+        "body textarea must re-fill its value from the changeset:\n{body_attrs}"
     );
     assert!(
         !routes.contains("value=(changeset.field_value(\"body\")"),
@@ -450,9 +463,9 @@ fn text_columns_render_constrained_textarea_not_input() {
     );
 
     // The nullable `notes` keeps only its maxlength — no required, no minlength.
-    let notes_attrs = slice_textarea_attrs(&routes, "textarea id=\"notes\" name=\"notes\"");
+    let notes_attrs = slice_textarea_attrs(&routes, "notes");
     assert!(
-        notes_attrs.contains("maxlength=\"1000\""),
+        notes_attrs.contains(".maxlength(1000u32)"),
         "notes textarea must carry maxlength:\n{notes_attrs}"
     );
     assert!(
@@ -508,15 +521,17 @@ fn text_email_and_url_render_typed_input_not_textarea() {
     );
 }
 
-/// Slice a textarea's field-specific attributes: from the `id`/`name` marker
-/// up to the shared `class=` skeleton, so an assertion can't match a sibling
-/// control's attributes.
-fn slice_textarea_attrs<'a>(routes: &'a str, marker: &str) -> &'a str {
+/// Slice a routed `a11y::TextArea` call's field-specific builder calls: from
+/// the `TextArea::new("field")` marker up to the shared `.class(` skeleton, so
+/// a field-scoped assertion doesn't accidentally match a sibling. The
+/// value/constraint/`required` builders all precede `.class(`.
+fn slice_textarea_attrs<'a>(routes: &'a str, field: &str) -> &'a str {
+    let marker = format!("TextArea::new(\"{field}\")");
     let start = routes
-        .find(marker)
+        .find(&marker)
         .unwrap_or_else(|| panic!("missing {marker} in:\n{routes}"));
     let rest = &routes[start..];
-    let end = rest.find("class=").unwrap_or(rest.len());
+    let end = rest.find(".class(").unwrap_or(rest.len());
     &rest[..end]
 }
 


### PR DESCRIPTION
Part of #1706 / references #1933 — **NOT** `Closes` (scaffold's live-validation routing is deferred to follow-up #1951).

Slice 3a of the a11y-primitives migration: routes the scaffold generator's **constrained multi-line text** sub-case through the typed `autumn_web::a11y::TextArea` primitive, mirroring the #1913 `TextField` routing already landed for single-line inputs.

## Before / After (plain language)

**Before:** a generated scaffold's constrained multi-line text field emitted a raw `<textarea>`. That bypassed the typed label obligation — nothing at compile time guaranteed the field carried an associated `<label for=…>`.

**After:** it emits `autumn_web::a11y::TextArea` — semantically-identical HTML with a **compile-time label guarantee** (an unlabeled `TextArea<NoLabel>` has no `render()`, so omitting the visible label is a compile error).

Field used for the delta: `body:Text{min=10,max=5000}` (non-nullable), value `"hello"`, no errors.

BEFORE (raw `<textarea>`):
```html
<label for="body" class="autumn-field__label">Body</label><textarea id="body" name="body" minlength="10" maxlength="5000" required aria-required="true" class="autumn-field__input" aria-invalid="false" aria-describedby="">hello</textarea>
```

AFTER (`a11y::TextArea`):
```html
<label for="body" class="autumn-field__label">Body</label><textarea id="body" name="body" class="autumn-field__input" minlength="10" maxlength="5000" aria-invalid="false" aria-describedby="" aria-required="true" required>hello</textarea>
```

**Semantically identical.** Same `<label for="body">`↔`<textarea id="body" name="body">` association, same attribute set and values (`minlength="10"`, `maxlength="5000"`, `required`, `aria-required="true"`, `class="autumn-field__input"`, `aria-invalid="false"`, `aria-describedby=""`), same text content (`hello` rides as element text, never a `value=` attribute, in both). The only difference is attribute **order** (`TextArea` emits `class` early and `required` last), which is not observable to users or assistive technology. The a11y win is structural/compile-time, not in this happy-path HTML.

## How

- Reused the existing `html5_constraint_builder_calls` helper; only the constrained-textarea sub-case changed.
- Mirrors the #1913 `TextField` routing pattern.
- The `--live-validation` raw path is untouched (deferred — see below).

## Scope of change

`git diff trunk-dev --stat` touches exactly:
- `autumn-cli/src/generate/scaffold.rs`
- `autumn-cli/tests/integration/scaffold_validation.rs`

No `autumn/src/a11y.rs` (primitives already on trunk via #1946) and no other files.

## Evidence (against trunk's Codex-fixed primitives)

```
test integration::scaffold_validation::text_columns_render_constrained_textarea_not_input ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 240 filtered out; finished in 0.03s
```

Acceptance (`--ignored`) — proves the generated `TextArea` compiles against trunk `autumn-web`:
```
test integration::scaffold_validation::constrained_scaffold_cargo_checks ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 240 filtered out; finished in 8.22s
```

`cargo fmt --all -- --check` clean.

## Deferral

Routing the scaffold `--live-validation` raw path through the primitives is deferred to follow-up **#1951** — hence *Part of* #1933, not *Closes*.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcL5aB12Krn1HzL9cM6hYA)_