### PR TITLE
feat(form): route FieldControl rendering through a11y typed primitives (Part of #1706)

### DIFF
--- a/autumn/src/form.rs
+++ b/autumn/src/form.rs
@@ -2610,6 +2610,46 @@ impl<T: Serialize> Serialize for PrefillAlias<'_, T> {
     }
 }
 
+/// Wrap a primitive-rendered control (its own `<label>` + input) in the
+/// changeset field skeleton shared by every routed control: the stable
+/// `<div id="{field}-field" class="autumn-field">` htmx target and, when the
+/// field has errors, the `role="alert"` inline-error block keyed to
+/// `{field}-error`. This is the same wrapper/error markup the hand-written
+/// `*_input` helpers emit; only the inner control now comes from an
+/// `a11y` primitive.
+#[cfg(feature = "maud")]
+fn wrap_field_control(
+    field_name: &str,
+    control: impl maud::Render,
+    errors: &[String],
+) -> maud::Markup {
+    let error_id = format!("{field_name}-error");
+    let wrapper_id = format!("{field_name}-field");
+    maud::html! {
+        div id=(wrapper_id) class="autumn-field" {
+            (control)
+            @if !errors.is_empty() {
+                div id=(error_id) role="alert" class="autumn-field__errors" {
+                    @for error in errors {
+                        p class="autumn-field__error" { (error) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// The `class` a routed control carries, mirroring the `*_input` helpers:
+/// `autumn-field__input`, plus the `--invalid` modifier when the field errored.
+#[cfg(feature = "maud")]
+const fn field_control_class(has_errors: bool) -> &'static str {
+    if has_errors {
+        "autumn-field__input autumn-field__input--invalid"
+    } else {
+        "autumn-field__input"
+    }
+}
+
 /// Render a single [`FormField`], routing the pre-fill lookup through the
 /// field's serialized key ([`FormField::value_name`]) when it differs from
 /// the rendered input name — see [`PrefillAlias`]. Everything else (input
@@ -2645,7 +2685,21 @@ fn render_form_control<T: Serialize>(changeset: &Changeset<T>, field: &FormField
                 text_input(changeset, &field.name, &field.label)
             }
         }
-        FieldControl::Textarea => textarea_input(changeset, &field.name, &field.label),
+        FieldControl::Textarea => {
+            let errors = changeset.errors_for(&field.name);
+            let has_errors = !errors.is_empty();
+            let value = changeset.field_value(&field.name).unwrap_or_default();
+            let mut control = crate::a11y::TextArea::new(field.name.as_str())
+                .label(field.label.as_str())
+                .label_class("autumn-field__label")
+                .value(value)
+                .class(field_control_class(has_errors))
+                .aria_invalid(has_errors);
+            if has_errors {
+                control = control.described_by(format!("{}-error", field.name));
+            }
+            wrap_field_control(&field.name, control, errors)
+        }
         FieldControl::Password => password_input(changeset, &field.name, &field.label),
         FieldControl::Number { step } => {
             if field.required {
@@ -2654,7 +2708,22 @@ fn render_form_control<T: Serialize>(changeset: &Changeset<T>, field: &FormField
                 number_input(changeset, &field.name, &field.label, step.as_deref())
             }
         }
-        FieldControl::Checkbox => checkbox_input(changeset, &field.name, &field.label),
+        FieldControl::Checkbox => {
+            let errors = changeset.errors_for(&field.name);
+            let has_errors = !errors.is_empty();
+            let checked = changeset.field_value(&field.name).as_deref() == Some("true");
+            let mut control = crate::a11y::Checkbox::new(field.name.as_str())
+                .label(field.label.as_str())
+                .label_class("autumn-field__label")
+                .value("true")
+                .checked(checked)
+                .class(field_control_class(has_errors))
+                .aria_invalid(has_errors);
+            if has_errors {
+                control = control.described_by(format!("{}-error", field.name));
+            }
+            wrap_field_control(&field.name, control, errors)
+        }
         FieldControl::Date => {
             if field.required {
                 required_date_input(changeset, &field.name, &field.label)
@@ -2670,46 +2739,48 @@ fn render_form_control<T: Serialize>(changeset: &Changeset<T>, field: &FormField
             }
         }
         FieldControl::Select { options } => {
-            let opts: Vec<(&str, &str)> = options
-                .iter()
-                .map(|(v, l)| (v.as_str(), l.as_str()))
-                .collect();
-            if field.required {
-                required_select_input(changeset, &field.name, &field.label, &opts)
-            } else {
-                select_input(changeset, &field.name, &field.label, &opts)
-            }
-        }
-        FieldControl::File => {
-            // No dedicated file helper exists upstream, so this arm renders
-            // the same inline-error/ARIA/wrapper skeleton the changeset-aware
-            // helpers emit (a file input can't be value-prefilled — browser
-            // security — so only the value attribute is omitted).
             let errors = changeset.errors_for(&field.name);
             let has_errors = !errors.is_empty();
-            let error_id = format!("{}-error", field.name);
-            let wrapper_id = format!("{}-field", field.name);
-            maud::html! {
-                div id=(wrapper_id) class="autumn-field" {
-                    label for=(field.name) class="autumn-field__label" { (field.label) }
-                    input
-                        type="file"
-                        id=(field.name)
-                        name=(field.name)
-                        required[field.required]
-                        aria-required=[field.required.then_some("true")]
-                        class=(if has_errors { "autumn-field__input autumn-field__input--invalid" } else { "autumn-field__input" })
-                        aria-invalid=(if has_errors { "true" } else { "false" })
-                        aria-describedby=(if has_errors { error_id.as_str() } else { "" });
-                    @if has_errors {
-                        div id=(error_id) role="alert" class="autumn-field__errors" {
-                            @for error in errors {
-                                p class="autumn-field__error" { (error) }
-                            }
-                        }
-                    }
-                }
+            let current = changeset.field_value(&field.name).unwrap_or_default();
+            let mut control = crate::a11y::Select::new(field.name.as_str())
+                .label(field.label.as_str())
+                .label_class("autumn-field__label")
+                .options(options.iter().map(|(value, label)| {
+                    crate::a11y::SelectOption::new(value.as_str(), label.as_str())
+                }))
+                .selected_value(current)
+                .class(field_control_class(has_errors))
+                .aria_invalid(has_errors);
+            if field.required {
+                control = control.required().aria_required();
             }
+            if has_errors {
+                control = control.described_by(format!("{}-error", field.name));
+            }
+            wrap_field_control(&field.name, control, errors)
+        }
+        FieldControl::File => {
+            // A file input can't be value-prefilled (browser security), so the
+            // typed [`crate::a11y::FileField`] primitive — which deliberately
+            // carries no `value` — is a natural fit; it also drops the
+            // competing derived `aria-label` in favour of the visible
+            // `<label for=…>`. Multipart encoding is unchanged: the
+            // `FieldControl::File` variant (not its rendering) still drives the
+            // `is_multipart` gate on the parent form.
+            let errors = changeset.errors_for(&field.name);
+            let has_errors = !errors.is_empty();
+            let mut control = crate::a11y::FileField::new(field.name.as_str())
+                .label(field.label.as_str())
+                .label_class("autumn-field__label")
+                .class(field_control_class(has_errors))
+                .aria_invalid(has_errors);
+            if field.required {
+                control = control.required().aria_required();
+            }
+            if has_errors {
+                control = control.described_by(format!("{}-error", field.name));
+            }
+            wrap_field_control(&field.name, control, errors)
         }
     }
 }
@@ -4879,6 +4950,59 @@ mod tests {
         assert!(html.contains(r#"id="published-field""#), "{html}");
         assert!(html.contains(r#"aria-invalid="false""#), "{html}");
         assert!(!html.contains(r#"aria-required="true""#), "{html}");
+    }
+
+    /// Slice 3b (issue #1933): `render_form_control` routes the Textarea,
+    /// Checkbox, Select, and File arms through the typed `a11y` primitives
+    /// while preserving the `{field}-field` wrapper + `role="alert"` error
+    /// skeleton. This pins the two intentional accessibility improvements the
+    /// primitives introduce over the hand-written `*_input` helpers: (1) an
+    /// error-free control omits the old empty `aria-describedby=""` (an IDREF
+    /// referencing nothing), and (2) a visible-label checkbox emits the
+    /// `<input>` before its `<label for=…>` (the conventional checkbox layout;
+    /// the `for`/`id` association is unchanged).
+    #[cfg(feature = "maud")]
+    #[test]
+    fn form_for_routes_controls_through_a11y_primitives() {
+        // Error-free controls drop the empty `aria-describedby=""` no-op.
+        let cs = Changeset::new(blank_form_for_model());
+        let html = form_for(&cs, "/posts", "post")
+            .exclude("views")
+            .exclude("published")
+            .override_field("title", FieldControl::Textarea)
+            .render()
+            .into_string();
+        assert!(html.contains("<textarea"), "{html}");
+        assert!(html.contains(r#"aria-invalid="false""#), "{html}");
+        assert!(
+            !html.contains(r#"aria-describedby="""#),
+            "error-free textarea must not emit an empty aria-describedby: {html}"
+        );
+
+        // Checkbox: the visible label's `for`/`id` association is preserved and
+        // the `<input>` precedes the `<label>`.
+        let cs = Changeset::new(blank_form_for_model());
+        let html = form_for(&cs, "/posts", "post")
+            .exclude("views")
+            .exclude("title")
+            .render()
+            .into_string();
+        assert!(html.contains(r#"type="checkbox""#), "{html}");
+        assert!(html.contains(r#"<label for="published""#), "{html}");
+        let input_idx = html
+            .find(r#"type="checkbox""#)
+            .expect("checkbox input missing");
+        let label_idx = html
+            .find(r#"<label for="published""#)
+            .expect("checkbox label missing");
+        assert!(
+            input_idx < label_idx,
+            "checkbox input must precede its label (conventional layout): {html}"
+        );
+        assert!(
+            !html.contains(r#"aria-describedby="""#),
+            "error-free checkbox must not emit an empty aria-describedby: {html}"
+        );
     }
 
     /// Duplicate `.override_field`/`.override_label` calls on the same field


### PR DESCRIPTION
Part of #1706 / references #1933 — **NOT** `Closes` (scaffold's live-validation routing is deferred to follow-up #1951).

Slice 3b: `render_form_field` in `autumn/src/form.rs` now routes its `FieldControl` arms through the typed `a11y` primitives — `Textarea`→`TextArea`, `Checkbox`→`Checkbox`, `Select`→`Select`+`SelectOption`, `File`→`FileField` — so `form_for(...)`-rendered controls inherit the same compile-time label/accessibility guarantees.

## Before / After per kind

Representative field of each kind (with a value/selected/checked, and its error variant). Full evidence in the branch's HTML-delta workup.

| Kind | Case | Verdict |
|---|---|---|
| **Textarea** | value + error | semantically identical (byte-identical) |
| **Textarea** | value, no error | intentional a11y improvement: dropped empty `aria-describedby=""` |
| **Checkbox** | checked, no error | intentional a11y improvement: input-before-label layout (+ dropped empty `aria-describedby=""`) |
| **Checkbox** | checked, with error | intentional a11y improvement: input-before-label layout (`aria-describedby` present + identical value both) |
| **Select** (required) | selected + error | semantically identical (attribute order only) |
| **Select** (required) | selected, no error | attribute order + dropped empty `aria-describedby=""` |
| **File** | required + error | semantically identical (attribute order only) |
| **File** | non-required, no error | intentional a11y improvement: dropped empty `aria-describedby=""` |

The two deliberate a11y improvements: **(1)** empty `aria-describedby=""` (an IDREF pointing at nothing — a WAI-ARIA validity smell) is now omitted in the no-error case; in the error case `aria-describedby="{field}-error"` is present and identical. **(2)** `a11y::Checkbox` emits the conventional **input-before-label** layout; the `for`/`id` association (and thus the accessible name) is preserved, only DOM order changes. No attribute value emitted by the old helper is lost.

Representative Checkbox (checked, no error):
```html
<!-- BEFORE -->
<div id="published-field" class="autumn-field"><label for="published" class="autumn-field__label">Published</label><input type="checkbox" id="published" name="published" value="true" checked class="autumn-field__input" aria-invalid="false" aria-describedby=""></div>
<!-- AFTER -->
<div id="published-field" class="autumn-field"><input type="checkbox" id="published" name="published" value="true" class="autumn-field__input" aria-invalid="false" checked><label for="published" class="autumn-field__label">Published</label></div>
```

### Multipart preserved

The `is_multipart` gate keys on the `FieldControl::File` **variant**, not its rendering, so routing File through the primitive leaves the enctype intact — verified on the rendered `<form …>` opening tag (both required and non-required File fields):
```html
<!-- BEFORE --> <form action="/p" method="post" enctype="multipart/form-data">…</form>
<!-- AFTER  --> <form action="/p" method="post" enctype="multipart/form-data">…</form>
```

## How (Design A)

- Routed **inside** `render_form_field` (`Textarea`→`TextArea`, `Checkbox`→`Checkbox`, `Select`→`Select`+`SelectOption`, `File`→`FileField`), keeping the shared `<div id="{field}-field" class="autumn-field">` wrapper + `role="alert"` inline-error skeleton via a new `wrap_field_control` helper.
- The `FieldControl` enum and the multipart gate are **untouched**.
- All four public `*_input` helpers are **kept and still `pub`** (external callers in scaffold-generated code + their own unit tests).

### Design-A proof

The scaffold `.override_field(...)` source goldens are **unchanged** — `git diff trunk-dev --stat` touches only `autumn/src/form.rs` (1 file). No scaffold generator or golden file changed.

## Evidence (against trunk's Codex-fixed exclusive `selected_value`)

Library form tests incl. the lock-in test:
```
test form::tests::form_for_routes_controls_through_a11y_primitives ... ok
test result: ok. 191 passed; 0 failed; 0 ignored; 0 measured; 3698 filtered out; finished in 0.02s
```

a11y verify:
```
$ cargo run -p autumn-cli --bin autumn -- a11y verify autumn/src
Result: PASS — no accessibility violations in raw html! markup.   (exit 0)
```

Acceptance (`--ignored`) — Checkbox/Select/File render path compiles against trunk `autumn-web` incl. the Codex-fixed exclusive `selected_value`:
```
test integration::scaffold_form_for::generated_form_for_scaffold_cargo_checks ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 240 filtered out; finished in 18.81s
test integration::scaffold_form_for::generated_attachment_scaffold_cargo_checks ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 240 filtered out; finished in 15.59s
```

`cargo fmt --all -- --check` clean.

## Deferral

The scaffold `--live-validation` raw path is deferred to follow-up issue **#1951** — routing it through the primitives' `.hx()` escape hatch. Hence *Part of* #1933, not *Closes*.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcL5aB12Krn1HzL9cM6hYA)_