### PR TITLE
fix(cli): deploy sets the production profile by default (Part of #1607)

### DIFF
--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -107,6 +107,9 @@ pub struct ResolvedDeployConfig {
     pub readiness_timeout_secs: u64,
     /// Prior releases retained on the host.
     pub keep_releases: u32,
+    /// Profile the deployed app runs under (written to the host env file as
+    /// `AUTUMN_ENV`). Defaults to the production profile (`"prod"`).
+    pub profile: String,
 }
 
 impl ResolvedDeployConfig {
@@ -133,6 +136,7 @@ impl ResolvedDeployConfig {
             service_name,
             readiness_timeout_secs: cfg.readiness_timeout_secs,
             keep_releases: cfg.keep_releases,
+            profile: cfg.profile.clone(),
         }
     }
 
@@ -866,11 +870,17 @@ fn print_plan(resolved: &ResolvedDeployConfig) {
 }
 
 /// Build the secret env-file body sourced by the systemd unit's
-/// `EnvironmentFile`. Only the values the app needs at runtime (the signing
-/// secret and the writable database URL) are emitted, and the result is wrapped
-/// in [`exec::Secret`] so it is never logged (AC-5).
-fn build_env_file(config: &AutumnConfig) -> exec::Secret {
+/// `EnvironmentFile`. Emits the runtime profile selector (`AUTUMN_ENV`, from the
+/// resolved `[deploy] profile`, default `prod`) so the deployed app never
+/// silently boots under the `dev` fallback, alongside the values the app needs
+/// at runtime (the signing secret and the writable database URL). The result is
+/// wrapped in [`exec::Secret`] so it is never logged (AC-5). The profile is a
+/// plain non-secret value; secret handling is unchanged.
+fn build_env_file(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> exec::Secret {
     let mut body = String::new();
+    body.push_str("AUTUMN_ENV=");
+    body.push_str(&resolved.profile);
+    body.push('\n');
     if let Some(secret) = config
         .security
         .signing_secret
@@ -946,7 +956,7 @@ fn run_up(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(), 
     let target = exec::SshTarget::from_resolved(resolved)
         .ok_or_else(|| DeployError::Config(DEPLOY_HOST_MISSING_DETAIL.to_owned()))?;
     let binary = resolve_release_binary(resolved)?;
-    let env_file = build_env_file(config);
+    let env_file = build_env_file(config, resolved);
     let release_id = default_release_id();
     let public_port = config.server.port;
     let proxy = proxy::KamalProxyController::new(resolved.readiness_timeout_secs);
@@ -1100,6 +1110,40 @@ mod tests {
         assert_eq!(resolved.readiness_timeout_secs, 60);
         assert_eq!(resolved.keep_releases, 3);
         assert_eq!(resolved.host, None);
+        assert_eq!(resolved.profile, "prod");
+    }
+
+    #[test]
+    fn build_env_file_sets_production_profile_by_default() {
+        // With no `[deploy] profile` set, the host env file must pin the app to
+        // the production profile so the deployed service never silently boots
+        // under the `dev` fallback.
+        let config = AutumnConfig::default();
+        let resolved = ResolvedDeployConfig::resolve(&DeployConfig::default(), "myapp");
+        let env_file = build_env_file(&config, &resolved);
+        assert!(
+            env_file.expose().lines().any(|l| l == "AUTUMN_ENV=prod"),
+            "env file should pin AUTUMN_ENV=prod by default, got: {:?}",
+            env_file.expose()
+        );
+    }
+
+    #[test]
+    fn build_env_file_honors_deploy_profile_override() {
+        // A non-prod target (e.g. staging) sets `[deploy] profile` and the host
+        // env file carries that value verbatim.
+        let config = AutumnConfig::default();
+        let cfg = DeployConfig {
+            profile: "staging".to_owned(),
+            ..DeployConfig::default()
+        };
+        let resolved = ResolvedDeployConfig::resolve(&cfg, "myapp");
+        let env_file = build_env_file(&config, &resolved);
+        assert!(
+            env_file.expose().lines().any(|l| l == "AUTUMN_ENV=staging"),
+            "env file should honor the [deploy] profile override, got: {:?}",
+            env_file.expose()
+        );
     }
 
     #[test]

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -124,7 +124,13 @@ pub struct ResolvedDeployConfig {
 /// value falls back to the deploy default `"prod"` (matching
 /// `autumn_web::config::default_deploy_profile`). Keep this in sync if the
 /// runtime rules ever change.
-fn canonicalize_deploy_profile(raw: &str) -> String {
+// `pub(crate)` (not `pub`): reachable from `doctor` so it grades the deploy
+// signing secret against the same normalized deploy profile, but kept
+// crate-internal. In this bin-only crate `deploy` is a private module, so clippy
+// flags the `pub(crate)` as redundant; we keep it to document the intended
+// visibility rather than widening to `pub`.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn canonicalize_deploy_profile(raw: &str) -> String {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return "prod".to_owned();
@@ -144,6 +150,26 @@ fn canonicalize_deploy_profile(raw: &str) -> String {
     }
 
     // Preserve user-specified case for custom profile names.
+    trimmed.to_owned()
+}
+
+/// Trim a deploy profile string, preserving the operator's raw spelling.
+///
+/// This is what gets stored on [`ResolvedDeployConfig::profile`] and written to
+/// `AUTUMN_ENV`, so the host's runtime override-file lookup
+/// (`autumn_web::config::profile_override_file_lookup_names`) sees the exact
+/// selector the operator wrote — e.g. `autumn-production.toml` is preferred over
+/// `autumn-prod.toml` when the raw input was `production`. Alias folding here
+/// would flip that precedence, so we deliberately do NOT fold: trims whitespace;
+/// for a blank/empty value falls back to the deploy default `"prod"` (matching
+/// `autumn_web::config::default_deploy_profile`); otherwise returns the trimmed
+/// string verbatim (no alias folding, no case change). Grading normalizes
+/// separately via [`canonicalize_deploy_profile`] at the grade site.
+fn trimmed_deploy_profile(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return "prod".to_owned();
+    }
     trimmed.to_owned()
 }
 
@@ -171,7 +197,7 @@ impl ResolvedDeployConfig {
             service_name,
             readiness_timeout_secs: cfg.readiness_timeout_secs,
             keep_releases: cfg.keep_releases,
-            profile: canonicalize_deploy_profile(&cfg.profile),
+            profile: trimmed_deploy_profile(&cfg.profile),
         }
     }
 
@@ -828,7 +854,11 @@ fn collect_preflight(
         grade_signing_secret(
             config.security.signing_secret.secret.as_deref(),
             &config.security.signing_secret.previous_secrets,
-            is_production_profile(Some(&resolved.profile)),
+            // `resolved.profile` holds the operator's trimmed RAW spelling (so the
+            // AUTUMN_ENV value preserves override-file precedence). Normalize it to
+            // the canonical profile only here, for grading, so `PROD`/`Production`/
+            // ` production ` are still held to the production strength rules.
+            is_production_profile(Some(&canonicalize_deploy_profile(&resolved.profile))),
         ),
         grade_database_url(
             resolve_writable_db_url(&config.database),
@@ -844,7 +874,11 @@ fn collect_preflight(
 /// path uses in `fail_fast_on_invalid_signing_secret`
 /// (`matches!(config.profile.as_deref(), Some("prod" | "production"))`).
 #[must_use]
-fn is_production_profile(profile: Option<&str>) -> bool {
+// `pub(crate)` (not `pub`): reachable from `doctor` for deploy-profile grading
+// but kept crate-internal. See the note on `canonicalize_deploy_profile` re: the
+// clippy allow (private module in a bin-only crate).
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn is_production_profile(profile: Option<&str>) -> bool {
     matches!(profile, Some("prod" | "production"))
 }
 
@@ -1250,17 +1284,19 @@ mod tests {
     }
 
     #[test]
-    fn resolve_canonicalizes_non_canonical_production_profile_spellings() {
+    fn resolve_preserves_raw_profile_alias_while_grading_normalized() {
         // Regression: the app's runtime resolver
         // (`autumn_web::config::normalize_profile_name`) trims and case-folds
         // profile aliases, so `PROD`, `Production`, and ` production ` all boot
-        // under the canonical `prod`. If deploy stored the raw spelling, preflight
-        // graded it NON-production (exact/case-sensitive `is_production_profile`)
-        // and a weak secret sailed through — but `build_env_file` wrote that same
-        // raw string to `AUTUMN_ENV`, the host normalized it to `prod`, and the
-        // app rejected the weak secret at boot (fail AFTER touching the host). The
-        // fix canonicalizes the profile at resolve time so both the grade and the
-        // env-file value use one spelling.
+        // under the canonical `prod`. But the host's override-file lookup
+        // (`profile_override_file_lookup_names`) keys off the RAW selector
+        // spelling — it prefers `autumn-production.toml` over `autumn-prod.toml`
+        // when the raw input was `production`. So `resolved.profile` (and the
+        // `AUTUMN_ENV` value written from it) must preserve the operator's trimmed
+        // raw spelling, NOT the alias-folded form, or override-file precedence
+        // flips on hosts that have both files. Grading is normalized separately
+        // (canonicalize at the grade site) so a weak secret under `PROD`/
+        // `Production`/` production ` still FAILS preflight locally.
         let find_signing = |checks: &[PreflightCheck]| {
             checks
                 .iter()
@@ -1272,9 +1308,14 @@ mod tests {
         let mut config = AutumnConfig::default();
         config.security.signing_secret.secret = Some("changeme".to_owned());
 
-        // Non-canonical production spellings must canonicalize to `prod`, be
-        // graded as production, and thus FAIL the weak secret locally.
-        for raw in ["PROD", "Production", " production "] {
+        // Non-canonical production spellings preserve the operator's trimmed raw
+        // spelling in `resolved.profile` / AUTUMN_ENV, yet still grade as
+        // production (canonicalize-at-grade) and thus FAIL the weak secret.
+        for (raw, expected) in [
+            ("PROD", "PROD"),
+            ("Production", "Production"),
+            (" production ", "production"),
+        ] {
             let resolved = ResolvedDeployConfig::resolve(
                 &DeployConfig {
                     profile: raw.to_owned(),
@@ -1283,20 +1324,23 @@ mod tests {
                 "myapp",
             );
             assert_eq!(
-                resolved.profile, "prod",
-                "profile {raw:?} should canonicalize to `prod`"
+                resolved.profile, expected,
+                "profile {raw:?} should preserve the trimmed raw spelling"
             );
-            // The value written to AUTUMN_ENV is the same canonical profile.
+            // The value written to AUTUMN_ENV is that same trimmed raw spelling,
+            // so the host's override-file precedence is preserved.
+            let expected_env = format!("AUTUMN_ENV={expected}");
             assert!(
                 build_env_file(&config, &resolved)
                     .expose()
                     .lines()
-                    .any(|l| l == "AUTUMN_ENV=prod"),
-                "env file should pin AUTUMN_ENV=prod for raw profile {raw:?}"
+                    .any(|l| l == expected_env),
+                "env file should pin {expected_env:?} for raw profile {raw:?}"
             );
+            // Grading normalizes the raw spelling, so it still grades production.
             assert!(
-                is_production_profile(Some(&resolved.profile)),
-                "canonical `prod` must grade as production for raw profile {raw:?}"
+                is_production_profile(Some(&canonicalize_deploy_profile(&resolved.profile))),
+                "normalized profile must grade as production for raw profile {raw:?}"
             );
             let check = find_signing(&collect_preflight(&config, &resolved));
             assert!(

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -112,6 +112,41 @@ pub struct ResolvedDeployConfig {
     pub profile: String,
 }
 
+/// Canonicalize a deploy profile string to the value the app's runtime resolver
+/// would produce, so the preflight grade and the `AUTUMN_ENV` written to the
+/// host env file agree on a single spelling.
+///
+/// Mirrors `autumn_web::config::normalize_profile_name` (the source of truth) so
+/// non-canonical spellings can't slip past preflight and then be rejected at
+/// host boot: trims whitespace; case-insensitively folds `production`/`prod` →
+/// `"prod"` and `development`/`dev` → `"dev"`; preserves any other non-empty
+/// value verbatim (custom profiles like `staging`/`QA`); and for a blank/empty
+/// value falls back to the deploy default `"prod"` (matching
+/// `autumn_web::config::default_deploy_profile`). Keep this in sync if the
+/// runtime rules ever change.
+fn canonicalize_deploy_profile(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return "prod".to_owned();
+    }
+
+    if trimmed.eq_ignore_ascii_case("production") {
+        return "prod".to_owned();
+    }
+    if trimmed.eq_ignore_ascii_case("development") {
+        return "dev".to_owned();
+    }
+    if trimmed.eq_ignore_ascii_case("prod") {
+        return "prod".to_owned();
+    }
+    if trimmed.eq_ignore_ascii_case("dev") {
+        return "dev".to_owned();
+    }
+
+    // Preserve user-specified case for custom profile names.
+    trimmed.to_owned()
+}
+
 impl ResolvedDeployConfig {
     /// Resolve a [`DeployConfig`] against the project name, filling in the
     /// `app_name` → `app_dir` → `service_name` default chain.
@@ -136,7 +171,7 @@ impl ResolvedDeployConfig {
             service_name,
             readiness_timeout_secs: cfg.readiness_timeout_secs,
             keep_releases: cfg.keep_releases,
-            profile: cfg.profile.clone(),
+            profile: canonicalize_deploy_profile(&cfg.profile),
         }
     }
 
@@ -1210,6 +1245,83 @@ mod tests {
             staging_check.passed,
             "weak secret should pass preflight under a non-production deploy \
              profile: {}",
+            staging_check.detail
+        );
+    }
+
+    #[test]
+    fn resolve_canonicalizes_non_canonical_production_profile_spellings() {
+        // Regression: the app's runtime resolver
+        // (`autumn_web::config::normalize_profile_name`) trims and case-folds
+        // profile aliases, so `PROD`, `Production`, and ` production ` all boot
+        // under the canonical `prod`. If deploy stored the raw spelling, preflight
+        // graded it NON-production (exact/case-sensitive `is_production_profile`)
+        // and a weak secret sailed through — but `build_env_file` wrote that same
+        // raw string to `AUTUMN_ENV`, the host normalized it to `prod`, and the
+        // app rejected the weak secret at boot (fail AFTER touching the host). The
+        // fix canonicalizes the profile at resolve time so both the grade and the
+        // env-file value use one spelling.
+        let find_signing = |checks: &[PreflightCheck]| {
+            checks
+                .iter()
+                .find(|c| c.name == "signing_secret")
+                .expect("preflight includes a signing_secret check")
+                .clone()
+        };
+
+        let mut config = AutumnConfig::default();
+        config.security.signing_secret.secret = Some("changeme".to_owned());
+
+        // Non-canonical production spellings must canonicalize to `prod`, be
+        // graded as production, and thus FAIL the weak secret locally.
+        for raw in ["PROD", "Production", " production "] {
+            let resolved = ResolvedDeployConfig::resolve(
+                &DeployConfig {
+                    profile: raw.to_owned(),
+                    ..DeployConfig::default()
+                },
+                "myapp",
+            );
+            assert_eq!(
+                resolved.profile, "prod",
+                "profile {raw:?} should canonicalize to `prod`"
+            );
+            // The value written to AUTUMN_ENV is the same canonical profile.
+            assert!(
+                build_env_file(&config, &resolved)
+                    .expose()
+                    .lines()
+                    .any(|l| l == "AUTUMN_ENV=prod"),
+                "env file should pin AUTUMN_ENV=prod for raw profile {raw:?}"
+            );
+            assert!(
+                is_production_profile(Some(&resolved.profile)),
+                "canonical `prod` must grade as production for raw profile {raw:?}"
+            );
+            let check = find_signing(&collect_preflight(&config, &resolved));
+            assert!(
+                !check.passed,
+                "weak secret must fail preflight for production spelling {raw:?}: {}",
+                check.detail
+            );
+            assert!(!check.detail.contains("changeme"));
+        }
+
+        // A custom profile is preserved verbatim and grades non-production, so
+        // the same weak secret passes (custom deploys aren't held to prod rules).
+        let staging = ResolvedDeployConfig::resolve(
+            &DeployConfig {
+                profile: "staging".to_owned(),
+                ..DeployConfig::default()
+            },
+            "myapp",
+        );
+        assert_eq!(staging.profile, "staging");
+        assert!(!is_production_profile(Some(&staging.profile)));
+        let staging_check = find_signing(&collect_preflight(&config, &staging));
+        assert!(
+            staging_check.passed,
+            "weak secret should pass preflight under the custom `staging` profile: {}",
             staging_check.detail
         );
     }

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -782,10 +782,18 @@ fn collect_preflight(
             resolved.ssh_port,
             SSH_PROBE_TIMEOUT,
         ),
+        // Grade the signing secret against the SAME profile that will be written
+        // to the host env file (`AUTUMN_ENV=<resolved.profile>`, default `prod`),
+        // not the local CLI runtime profile (`config.profile`, dev/None on a dev
+        // box). Otherwise a weak/demo secret passes preflight locally but the
+        // uploaded unit boots under `prod` and exits in
+        // `fail_fast_on_invalid_signing_secret` — failing the deploy only AFTER
+        // touching the host. Keeping the grader and env-file profile coherent
+        // catches the weak secret locally, before any remote call.
         grade_signing_secret(
             config.security.signing_secret.secret.as_deref(),
             &config.security.signing_secret.previous_secrets,
-            is_production_profile(config.profile.as_deref()),
+            is_production_profile(Some(&resolved.profile)),
         ),
         grade_database_url(
             resolve_writable_db_url(&config.database),
@@ -1143,6 +1151,66 @@ mod tests {
             env_file.expose().lines().any(|l| l == "AUTUMN_ENV=staging"),
             "env file should honor the [deploy] profile override, got: {:?}",
             env_file.expose()
+        );
+    }
+
+    #[test]
+    fn preflight_grades_signing_secret_against_resolved_deploy_profile() {
+        // Regression: preflight must grade the signing secret against the SAME
+        // profile that `build_env_file` writes to the host env file
+        // (`AUTUMN_ENV=<resolved.profile>`, default `prod`), NOT the local CLI
+        // runtime profile (`config.profile`, dev/None on a dev box). Otherwise a
+        // weak/demo secret sails through `deploy check`/`deploy up` locally, but
+        // the uploaded unit boots under `prod` and exits in
+        // `fail_fast_on_invalid_signing_secret` — failing the deploy only AFTER
+        // touching the host. The fix catches the weak secret locally.
+        let find_signing = |checks: &[PreflightCheck]| {
+            checks
+                .iter()
+                .find(|c| c.name == "signing_secret")
+                .expect("preflight includes a signing_secret check")
+                .clone()
+        };
+
+        // A weak/demo secret on a dev box: `config.profile` is None (non-prod),
+        // so the OLD behavior (grading against `config.profile`) would PASS.
+        let mut config = AutumnConfig::default();
+        config.security.signing_secret.secret = Some("changeme".to_owned());
+        assert!(
+            !is_production_profile(config.profile.as_deref()),
+            "guard: the local runtime profile is non-production in this test"
+        );
+
+        // Default deploy profile is `prod` (what the env file will pin), so the
+        // weak secret must FAIL preflight locally, before any remote call.
+        let prod_resolved = ResolvedDeployConfig::resolve(&DeployConfig::default(), "myapp");
+        assert_eq!(prod_resolved.profile, "prod");
+        let prod_check = find_signing(&collect_preflight(&config, &prod_resolved));
+        assert!(
+            !prod_check.passed,
+            "weak secret must fail preflight under the default (prod) deploy \
+             profile: {}",
+            prod_check.detail
+        );
+        // Never echo the secret value, even a known demo one.
+        assert!(!prod_check.detail.contains("changeme"));
+
+        // With a non-production deploy profile (e.g. staging) the same weak
+        // secret still passes — a dev/staging deploy is not held to the
+        // production strength rules, and the env file pins that same profile.
+        let staging_resolved = ResolvedDeployConfig::resolve(
+            &DeployConfig {
+                profile: "staging".to_owned(),
+                ..DeployConfig::default()
+            },
+            "myapp",
+        );
+        let staging_check = find_signing(&collect_preflight(&config, &staging_resolved));
+        assert!(
+            staging_check.passed,
+            "weak secret should pass preflight under a non-production deploy \
+             profile: {}",
+            staging_check.detail
         );
     }
 

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -6345,6 +6345,19 @@ pub fn run(opts: DoctorOptions) {
         let deploy_db_backed_runtime =
             resolve_deploy_db_backed_runtime(&merged_deploy_toml, deploy_denv.as_ref());
 
+        // Grade DEPLOY-target checks against the resolved `[deploy] profile`
+        // (default `prod`), NOT the ambient CLI runtime profile (`is_production`,
+        // read from AUTUMN_ENV/AUTUMN_PROFILE, dev/false on a dev box). Otherwise
+        // `autumn doctor --strict` green-lights a weak deploy signing secret that
+        // `autumn deploy check`/`deploy up` FAIL, since those grade against the
+        // deploy profile the uploaded unit boots under. Normalize the profile the
+        // same way `deploy check` does so alias spellings (`PROD`/`Production`)
+        // still grade as production. Ambient (non-deploy) checks keep using
+        // `is_production` unchanged.
+        let deploy_is_production = crate::deploy::is_production_profile(Some(
+            &crate::deploy::canonicalize_deploy_profile(&deploy_cfg.profile),
+        ));
+
         // Host presence is validated OFFLINE (always, whenever `[deploy]` is
         // configured): a `[deploy]` table with a missing/blank `host` makes
         // `autumn deploy check` fail immediately, so default/offline `doctor
@@ -6383,7 +6396,7 @@ pub fn run(opts: DoctorOptions) {
                         crate::deploy::grade_signing_secret(
                             deploy_signing.as_deref(),
                             &deploy_previous_signing,
-                            is_production,
+                            deploy_is_production,
                         ),
                     )
                 }));

--- a/autumn-cli/tests/integration/deploy.rs
+++ b/autumn-cli/tests/integration/deploy.rs
@@ -223,6 +223,49 @@ fn doctor_fails_on_malformed_previous_secrets() {
 }
 
 #[test]
+fn doctor_grades_deploy_signing_secret_against_deploy_profile() {
+    // Regression: doctor must grade the DEPLOY signing secret against the resolved
+    // `[deploy] profile` (default `prod`), NOT the ambient CLI runtime profile.
+    // On a dev box with the ambient profile dev (no `AUTUMN_ENV=production`) and a
+    // WEAK/demo deploy signing secret, the OLD behavior graded `deploy_signing_secret`
+    // with the ambient (non-production) flag and PASSED it — even though
+    // `autumn deploy check`/`deploy up` grade against the deploy profile (`prod`)
+    // and FAIL the same weak secret. Doctor and `deploy check` must agree: the
+    // check must FAIL here.
+    let dir = project("host = \"deploy.example.test\"\n");
+    // A known demo/template value ("changeme") — invalid under production grading.
+    // Delivered via the process env (resolved env-first like `deploy check`).
+    // Crucially, `AUTUMN_ENV=production` is NOT set, so the ambient profile is dev:
+    // only the deploy-profile-aware grade can catch this weak secret.
+    let (stdout, stderr, code) = run_autumn(
+        dir.path(),
+        &["doctor"],
+        &[("AUTUMN_SECURITY__SIGNING_SECRET", "changeme")],
+    );
+    let combined = format!("{stdout}{stderr}");
+    assert_ne!(
+        code,
+        Some(0),
+        "doctor must fail on a weak deploy signing secret under the default (prod) \
+         deploy profile, even with an ambient dev profile\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        combined.contains("deploy_signing_secret"),
+        "doctor must surface the deploy_signing_secret check\n{combined}"
+    );
+    assert!(
+        combined.contains("known demo/template value not allowed in production"),
+        "doctor must fail the deploy signing secret as a known demo value under the \
+         deploy profile\n{combined}"
+    );
+    // The demo secret value must never be echoed.
+    assert!(
+        !combined.contains("changeme"),
+        "doctor must not echo the demo secret value\n{combined}"
+    );
+}
+
+#[test]
 fn doctor_flags_dotenv_db_backed_runtime_without_db() {
     // Regression: `.env`-only postgres backend must make doctor require a deploy
     // DB, matching `deploy check` (Codex P2 on 2dc71f7); bare OsEnv wrongly

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -1248,6 +1248,7 @@ pub struct AutumnConfig {
 /// service_name = "myapp"     # systemd unit name; default: {app_name}
 /// readiness_timeout_secs = 60 # readiness window before rollback (default: 60)
 /// keep_releases = 3          # releases retained on the host (default: 3)
+/// profile = "prod"           # profile the deployed app runs under (default: "prod")
 /// ```
 #[derive(Debug, Clone, Deserialize)]
 pub struct DeployConfig {
@@ -1290,6 +1291,13 @@ pub struct DeployConfig {
     /// Number of prior releases retained on the host for rollback. Default: `3`.
     #[serde(default = "default_deploy_keep_releases")]
     pub keep_releases: u32,
+
+    /// The profile the deployed app runs under (written into the host env file
+    /// as `AUTUMN_ENV`). Defaults to the production profile (`"prod"`) so a
+    /// deploy never silently runs the `dev` profile; set to e.g. `"staging"`
+    /// for non-prod targets.
+    #[serde(default = "default_deploy_profile")]
+    pub profile: String,
 }
 
 impl Default for DeployConfig {
@@ -1303,6 +1311,7 @@ impl Default for DeployConfig {
             service_name: None,
             readiness_timeout_secs: default_deploy_readiness_timeout_secs(),
             keep_releases: default_deploy_keep_releases(),
+            profile: default_deploy_profile(),
         }
     }
 }
@@ -6521,7 +6530,7 @@ pub struct CompressionConfig {
 // Exposed for autumn-cli's `autumn deploy` preflight (doctor) to reuse the deploy env-override logic; not yet a stable public API.
 #[doc(hidden)]
 pub fn apply_deploy_env_overrides(deploy: &mut Option<DeployConfig>, env: &dyn Env) {
-    const KEYS: [&str; 8] = [
+    const KEYS: [&str; 9] = [
         "AUTUMN_DEPLOY__HOST",
         "AUTUMN_DEPLOY__USER",
         "AUTUMN_DEPLOY__SSH_PORT",
@@ -6530,6 +6539,7 @@ pub fn apply_deploy_env_overrides(deploy: &mut Option<DeployConfig>, env: &dyn E
         "AUTUMN_DEPLOY__SERVICE_NAME",
         "AUTUMN_DEPLOY__READINESS_TIMEOUT_SECS",
         "AUTUMN_DEPLOY__KEEP_RELEASES",
+        "AUTUMN_DEPLOY__PROFILE",
     ];
     if !KEYS.iter().any(|key| env.var(key).is_ok()) {
         return;
@@ -6551,6 +6561,7 @@ pub fn apply_deploy_env_overrides(deploy: &mut Option<DeployConfig>, env: &dyn E
         "AUTUMN_DEPLOY__KEEP_RELEASES",
         &mut deploy.keep_releases,
     );
+    parse_env_string(env, "AUTUMN_DEPLOY__PROFILE", &mut deploy.profile);
 }
 
 /// Parse an environment variable into a typed target, logging a warning on failure.
@@ -6730,6 +6741,12 @@ const fn default_deploy_readiness_timeout_secs() -> u64 {
 /// Default number of prior releases retained on the host for rollback.
 const fn default_deploy_keep_releases() -> u32 {
     3
+}
+
+/// Default profile the deployed app runs under. Defaults to the production
+/// profile so an `autumn deploy` never silently boots under the `dev` profile.
+fn default_deploy_profile() -> String {
+    "prod".to_owned()
 }
 
 /// Default directory for the ACME account key and issued certificates
@@ -10552,7 +10569,8 @@ path = "/healthz"
             .with("AUTUMN_DEPLOY__APP_DIR", "/srv/myapp")
             .with("AUTUMN_DEPLOY__SERVICE_NAME", "myapp-web")
             .with("AUTUMN_DEPLOY__READINESS_TIMEOUT_SECS", "90")
-            .with("AUTUMN_DEPLOY__KEEP_RELEASES", "5");
+            .with("AUTUMN_DEPLOY__KEEP_RELEASES", "5")
+            .with("AUTUMN_DEPLOY__PROFILE", "staging");
         let mut config = AutumnConfig::default();
         assert!(config.deploy.is_none());
         config.apply_env_overrides_with_env(&env);
@@ -10565,7 +10583,44 @@ path = "/healthz"
         assert_eq!(deploy.service_name.as_deref(), Some("myapp-web"));
         assert_eq!(deploy.readiness_timeout_secs, 90);
         assert_eq!(deploy.keep_releases, 5);
+        assert_eq!(deploy.profile, "staging");
         assert!(deploy.validate().is_ok());
+    }
+
+    #[test]
+    fn deploy_profile_defaults_to_production() {
+        // A bare `[deploy]` table (or one omitting `profile`) resolves to the
+        // production profile so a deploy never silently runs the `dev` profile.
+        let config: AutumnConfig = toml::from_str(
+            r#"
+            [deploy]
+            host = "203.0.113.10"
+            "#,
+        )
+        .unwrap();
+        let deploy = config.deploy.expect("deploy configured");
+        assert_eq!(deploy.profile, "prod");
+        // The type default matches the serde default.
+        assert_eq!(DeployConfig::default().profile, "prod");
+    }
+
+    #[test]
+    fn deploy_profile_honors_toml_and_env_override() {
+        // TOML sets a non-prod profile...
+        let mut config: AutumnConfig = toml::from_str(
+            r#"
+            [deploy]
+            host = "toml-host"
+            profile = "staging"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(config.deploy.as_ref().unwrap().profile, "staging");
+
+        // ...and `AUTUMN_DEPLOY__PROFILE` wins over the TOML value.
+        let env = MockEnv::new().with("AUTUMN_DEPLOY__PROFILE", "prod");
+        config.apply_env_overrides_with_env(&env);
+        assert_eq!(config.deploy.unwrap().profile, "prod");
     }
 
     #[test]

--- a/autumn/tests/fixtures/schema_keys.snapshot
+++ b/autumn/tests/fixtures/schema_keys.snapshot
@@ -116,6 +116,7 @@ deploy.app_dir
 deploy.app_name
 deploy.host
 deploy.keep_releases
+deploy.profile
 deploy.readiness_timeout_secs
 deploy.service_name
 deploy.ssh_port


### PR DESCRIPTION
**Before:** `autumn deploy` sent no `AUTUMN_ENV` to the deployed systemd service, so `AutumnConfig::resolve_profile` fell back to the **dev** profile — a production VPS ran dev smart-defaults (permissive CORS, detailed actuators, dev CSRF/session).
**After:** `build_env_file` writes `AUTUMN_ENV=` into the `0600` host env file, defaulting to `prod` via a new `[deploy] profile` config key (overridable with `AUTUMN_DEPLOY__PROFILE`, e.g. `staging` for non-prod targets).
Tests cover the prod default and the override. Verification: `cargo fmt`, `cargo +1.97.0 clippy --workspace --all-targets -D warnings`, `cargo test -p autumn-web --lib` (3870 passed), `-p autumn-cli --test cli_tests` (209), `-p autumn-cli --bin autumn` (3904) — all green. No CHANGELOG/version change. Addresses the Codex P1 on #1950.

## Follow-up

Known gap (follow-up PR incoming): values that live only under `[profile.prod]` or `.env.prod` aren't yet used by `autumn deploy` — it currently grades and uploads the database URL and signing secret from config resolved under the operator's ambient profile, while writing `AUTUMN_ENV=<deploy profile>`. A dedicated follow-up will resolve the deploy preflight/env-file config under the target deploy profile so profile-scoped prod values are loaded, graded, and uploaded.