### PR TITLE
⚡ Bolt: [performance improvement] remove vector allocations in catch-all path encoding

### DIFF
--- a/autumn/src/mcp.rs
+++ b/autumn/src/mcp.rs
@@ -1826,11 +1826,7 @@ fn build_request(
         // Use the same full segment encoder the typed path helpers use, so an
         // MCP call accepts the same values a direct HTTP caller could pass.
         let encoded = if is_catch_all {
-            value
-                .split('/')
-                .map(crate::paths::encode_path_segment)
-                .collect::<Vec<_>>()
-                .join("/")
+            crate::paths::encode_catch_all_param(&value)
         } else {
             crate::paths::encode_path_segment(&value)
         };

--- a/autumn/src/paths.rs
+++ b/autumn/src/paths.rs
@@ -58,18 +58,26 @@ pub fn encode_path_segment(value: impl std::fmt::Display) -> String {
 #[must_use]
 pub fn encode_catch_all_param(value: impl std::fmt::Display) -> String {
     let s = value.to_string();
-    s.split('/')
-        .map(|segment| {
-            if segment == "." {
-                "%2E".to_string()
-            } else if segment == ".." {
-                "%2E%2E".to_string()
-            } else {
-                percent_encode(segment)
-            }
-        })
-        .collect::<Vec<String>>()
-        .join("/")
+    let mut out = String::with_capacity(s.len() + s.len() / 4);
+    let mut iter = s.split('/').map(|segment| {
+        if segment == "." {
+            "%2E".to_string()
+        } else if segment == ".." {
+            "%2E%2E".to_string()
+        } else {
+            percent_encode(segment)
+        }
+    });
+
+    if let Some(first) = iter.next() {
+        out.push_str(&first);
+        for item in iter {
+            out.push('/');
+            out.push_str(&item);
+        }
+    }
+
+    out
 }
 
 /// Percent-encode a query component per RFC 3986.


### PR DESCRIPTION
💡 What:
Optimized `encode_catch_all_param` in `autumn/src/paths.rs` to append path segments directly into a pre-allocated `String` buffer instead of collecting an intermediate `Vec<String>` and then joining. Additionally, reused this optimized function in `autumn/src/mcp.rs` for `build_request` to handle MCP catch-all paths instead of duplicating the `.collect::<Vec<_>>().join("/")` pattern.

🎯 Why:
The `.collect::<Vec<_>>().join("/")` pattern requires multiple heap allocations: one for each segment string (during mapping) and one for the intermediate `Vec` holding them, which is immediately discarded after the `.join("/")` allocates the final string. Removing intermediate collections on string operations is a canonical zero-cost abstraction improvement.

📊 Impact:
Reduces heap allocations during the encoding of catch-all parameters. The exact number of allocations saved depends on the number of path segments, but it eliminates the `Vec` allocation entirely.

🔭 Measurement:
Run `cargo bench` if available for routing path encoding, or review the allocations in a memory profiler for MCP routing calls. Run `cargo test -p autumn-web --lib` to ensure no regressions in behavior.

---
*PR created automatically by Jules for task [2922191217707296986](https://jules.google.com/task/2922191217707296986) started by @madmax983*