### PR TITLE
chore: fix clippy::too_many_lines on trunk (job_tracking seed test)

### DIFF
--- a/autumn/tests/integration/job_tracking_stores_integration.rs
+++ b/autumn/tests/integration/job_tracking_stores_integration.rs
@@ -119,6 +119,7 @@ async fn redis_backend_persists_tracked_job_and_expires_it() {
 #[cfg(feature = "db")]
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
+#[allow(clippy::too_many_lines)]
 async fn postgres_backend_persists_tracked_job_and_expires_it() {
     use diesel_async::pooled_connection::AsyncDieselConnectionManager;
     use diesel_async::pooled_connection::deadpool::Pool;


### PR DESCRIPTION
#1941's test edit pushed `postgres_backend_persists_tracked_job_and_expires_it` to 105 lines, tripping `clippy::too_many_lines` (105/100) and reddening the Lint job on every trunk-based PR; this adds a test-only `#[allow(clippy::too_many_lines)]` to un-red trunk. Test-only change, no production code touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_014KA9PKkuNMTkayCWTTJbM7)_