### PR TITLE
fix: tenant-scoped update loads return 404 (not 500) on foreign/missing ids; bulk upsert cross-tenant scoping

### DIFF
--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -7007,16 +7007,24 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         } else {
             quote! {}
         };
+        // Shared not-found→404 tail spliced into both merged-validation knobs
+        // (non-tenant and tenant): map any load error to an `AutumnError` and
+        // turn a missing row into the correct 404 rather than a foreign-row 422.
+        // `#model_name` and `id` are in scope here (same fn), so the interpolated
+        // tokens match what was previously inlined identically in both knobs.
+        let not_found_to_404 = quote! {
+            .optional()
+            .map_err(::autumn_web::AutumnError::from)?
+            .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
+                format!("{} with id {} not found", stringify!(#model_name), id)
+            ))
+        };
         let knob_load_and_validate = if config.validate_on_update_fetch {
             quote! {
                 let __merged_current = #table_ident::table.find(id)
                     .first::<#model_name>(&mut conn)
                     .await
-                    .optional()
-                    .map_err(::autumn_web::AutumnError::from)?
-                    .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
-                        format!("{} with id {} not found", stringify!(#model_name), id)
-                    ))?;
+                    #not_found_to_404 ?;
                 { let _ = <::autumn_web::hooks::UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&__merged_current, changes)?; }
             }
         } else {
@@ -7032,11 +7040,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 } else {
                     #table_ident::table.find(id).first::<#model_name>(&mut conn).await
                 }
-                .optional()
-                .map_err(::autumn_web::AutumnError::from)?
-                .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
-                    format!("{} with id {} not found", stringify!(#model_name), id)
-                ))?;
+                #not_found_to_404 ?;
                 { let _ = <::autumn_web::hooks::UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&__merged_current, changes)?; }
             }
         } else {
@@ -18417,18 +18421,22 @@ mod tests {
     }
 
     #[test]
-    fn repository_macro_tenant_scoped_upsert_many_filters_cross_tenant_silently() {
+    fn repository_macro_tenant_scoped_upsert_many_filters_cross_tenant_silently_for_non_versioned()
+    {
         let generated = repository_macro(
             quote! { Post, tenant_scoped },
             quote! { pub trait PostRepository {} },
         )
         .to_string();
 
-        // A tenant-scoped upsert_many silently filters cross-tenant rows (the SQL
-        // ON CONFLICT ... WHERE tenant_id = $t never touches them), matching
+        // Silent cross-tenant filtering applies to the NON-versioned tenant-scoped
+        // path only (this `Post, tenant_scoped` repo has no lock): the SQL
+        // ON CONFLICT ... WHERE tenant_id = $t never touches cross-tenant rows, so
+        // it must NOT emit the old `!has_lock` partial rejection — matching
         // single-op cross-tenant scoping and sibling bulk update_many/delete_many.
-        // It must NOT emit the old `!has_lock` partial rejection; only a versioned
-        // optimistic-lock conflict stays loud.
+        // A versioned (`has_lock`) repo is intentionally different: its
+        // optimistic-lock conflict check stays loud (still 409s), so the retained
+        // `has_lock && ...` branch below must remain present.
         assert!(
             !generated.contains("! has_lock && upserted . len () != records . len ()"),
             "tenant-scoped upsert_many must not loudly reject cross-tenant-filtered partial upserts: {generated}"

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -7009,7 +7009,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         };
         let knob_load_and_validate = if config.validate_on_update_fetch {
             quote! {
-                let __merged_current = #table_ident::table.find(id).first::<#model_name>(&mut conn).await.map_err(::autumn_web::AutumnError::from)?;
+                let __merged_current = #table_ident::table.find(id)
+                    .first::<#model_name>(&mut conn)
+                    .await
+                    .optional()
+                    .map_err(::autumn_web::AutumnError::from)?
+                    .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
+                        format!("{} with id {} not found", stringify!(#model_name), id)
+                    ))?;
                 { let _ = <::autumn_web::hooks::UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&__merged_current, changes)?; }
             }
         } else {
@@ -7025,7 +7032,11 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 } else {
                     #table_ident::table.find(id).first::<#model_name>(&mut conn).await
                 }
-                .map_err(::autumn_web::AutumnError::from)?;
+                .optional()
+                .map_err(::autumn_web::AutumnError::from)?
+                .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
+                    format!("{} with id {} not found", stringify!(#model_name), id)
+                ))?;
                 { let _ = <::autumn_web::hooks::UpdateDraft<#model_name> as #draft_ext_trait>::from_patch(&__merged_current, changes)?; }
             }
         } else {
@@ -8617,18 +8628,15 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
             let size_check = if config.tenant_scoped {
                 quote! {
+                    // A tenant-scoped upsert silently filters rows belonging to
+                    // another tenant (the ON CONFLICT ... WHERE tenant_id = $t
+                    // upsert never touches them), mirroring single-op cross-tenant
+                    // scoping and the sibling bulk update_many/delete_many. Only a
+                    // genuine optimistic-lock conflict on a versioned record is loud.
                     if has_lock && upserted.len() != records.len() {
                         return Err(::autumn_web::AutumnError::conflict_msg(
                             format!(
                                 "Conflict: only {} of {} records were upserted (potential lock-version/optimistic lock or tenant conflict)",
-                                upserted.len(),
-                                records.len()
-                            )
-                        ));
-                    } else if !has_lock && upserted.len() != records.len() {
-                        return Err(::autumn_web::AutumnError::bad_request_msg(
-                            format!(
-                                "Tenant conflict: only {} of {} records were upserted (potential cross-tenant conflict)",
                                 upserted.len(),
                                 records.len()
                             )
@@ -18409,16 +18417,25 @@ mod tests {
     }
 
     #[test]
-    fn repository_macro_tenant_scoped_upsert_many_rejects_partial() {
+    fn repository_macro_tenant_scoped_upsert_many_filters_cross_tenant_silently() {
         let generated = repository_macro(
             quote! { Post, tenant_scoped },
             quote! { pub trait PostRepository {} },
         )
         .to_string();
 
+        // A tenant-scoped upsert_many silently filters cross-tenant rows (the SQL
+        // ON CONFLICT ... WHERE tenant_id = $t never touches them), matching
+        // single-op cross-tenant scoping and sibling bulk update_many/delete_many.
+        // It must NOT emit the old `!has_lock` partial rejection; only a versioned
+        // optimistic-lock conflict stays loud.
         assert!(
-            generated.contains("! has_lock && upserted . len () != records . len ()"),
-            "tenant-scoped upsert_many must reject partial upserts when lock versioning is absent: {generated}"
+            !generated.contains("! has_lock && upserted . len () != records . len ()"),
+            "tenant-scoped upsert_many must not loudly reject cross-tenant-filtered partial upserts: {generated}"
+        );
+        assert!(
+            generated.contains("has_lock && upserted . len () != records . len ()"),
+            "tenant-scoped upsert_many must still reject genuine optimistic-lock conflicts: {generated}"
         );
     }
 

--- a/autumn/tests/integration/job_tracking_stores_integration.rs
+++ b/autumn/tests/integration/job_tracking_stores_integration.rs
@@ -119,6 +119,7 @@ async fn redis_backend_persists_tracked_job_and_expires_it() {
 #[cfg(feature = "db")]
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
+#[allow(clippy::too_many_lines)]
 async fn postgres_backend_persists_tracked_job_and_expires_it() {
     use diesel_async::pooled_connection::AsyncDieselConnectionManager;
     use diesel_async::pooled_connection::deadpool::Pool;

--- a/autumn/tests/integration/repository_bulk_operations.rs
+++ b/autumn/tests/integration/repository_bulk_operations.rs
@@ -664,7 +664,7 @@ async fn test_zero_col_bulk_insert() {
 
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
-async fn test_tenant_scoped_upsert_many_mismatch() {
+async fn test_tenant_scoped_upsert_many_filters_cross_tenant_silently() {
     use autumn_web::tenancy::with_tenant;
 
     let (pool, _container) = setup_pool().await;
@@ -680,25 +680,51 @@ async fn test_tenant_scoped_upsert_many_mismatch() {
     })
     .await;
 
-    // 2. Try to upsert the same ID under tenant-b context
-    let stale_or_mismatched = with_tenant("tenant-b".to_string(), async {
+    // 2. Try to upsert that same ID under tenant-b context.
+    //
+    //    A NON-versioned (`!has_lock`) tenant-scoped repo SILENTLY FILTERS a
+    //    cross-tenant row: the SQL `WHERE tenant_id` scoping simply never matches
+    //    the tenant-a row, so it is left out of the result rather than provoking a
+    //    loud `bad_request` "Tenant conflict" error. This mirrors single-op tenant
+    //    scoping and the sibling bulk `update_many` / `delete_many` contract
+    //    (`tenancy::test_bulk_ops_tenant_scoping`). Isolation is still fully
+    //    enforced — the foreign-tenant row is neither returned nor mutated.
+    //    (The loud 409 path is only for a *versioned* repo hitting a genuine
+    //    optimistic-lock conflict; see `test_lock_version_upsert_many_conflict`.)
+    let upserted = with_tenant("tenant-b".to_string(), async {
         let mut to_upsert = record_a.clone();
-        to_upsert.name = "B".to_string(); // Try to overwrite it or update it
-
+        to_upsert.name = "B".to_string(); // Attempt to overwrite the tenant-a row
         repo.upsert_many(&[to_upsert]).await
     })
-    .await;
+    .await
+    .expect(
+        "non-versioned tenant-scoped upsert_many must silently filter a cross-tenant row (Ok, not Err)",
+    );
 
-    // This must return a conflict/bad_request error due to tenant mismatch
+    // The cross-tenant row must NOT be upserted: nothing was in scope for
+    // tenant-b, so the returned vec excludes it (and is empty here).
     assert!(
-        stale_or_mismatched.is_err(),
-        "Expected tenant mismatch error, but it succeeded!"
+        !upserted.iter().any(|r| r.name == "B"),
+        "cross-tenant row must not appear in the upserted result, got: {upserted:?}"
     );
-    let err_str = stale_or_mismatched.unwrap_err().to_string();
     assert!(
-        err_str.contains("Tenant conflict") || err_str.contains("potential cross-tenant conflict"),
-        "Expected cross-tenant conflict error, got: {err_str}"
+        upserted.is_empty(),
+        "no in-scope rows existed for tenant-b, so nothing should be upserted, got: {upserted:?}"
     );
+
+    // Security property (unchanged): the foreign tenant-a row is UNTOUCHED — the
+    // tenant-b upsert never hijacked it to name "B".
+    let tenant_a_row = repo
+        .across_tenants()
+        .find_by_id(record_a.id)
+        .await
+        .unwrap()
+        .expect("tenant-a row still exists");
+    assert_eq!(
+        tenant_a_row.name, "A",
+        "tenant-a row must remain unchanged (no cross-tenant hijack)"
+    );
+    assert_eq!(tenant_a_row.tenant_id, "tenant-a");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

Two tenant-isolation bugs in the `#[repository]` codegen, surfaced by the #1923 Docker sweep and now on trunk.

### Bug 1 — Update with a foreign-tenant / missing id returned 500

**Before:** When merged-validation is on (`validate_on_update_fetch`), the update path loaded the current row with Diesel `.first()` and mapped a missing row straight through `AutumnError::from`. A tenant-scoped update for an id owned by another tenant (filtered out by the `tenant_id` predicate) — or an id that simply doesn&#39;t exist — produced a `NotFound` diesel error that surfaced as a **500 Internal Server Error**.

**After:** Updating with a foreign-tenant or missing id now returns a clean **404 &#34;not found&#34;**, so a caller can&#39;t tell a foreign row from a missing one, and it&#39;s no longer a server error.

### Bug 2 — Bulk upsert with a cross-tenant row returned 400

**Before:** A tenant-scoped `upsert_many` that included a row belonging to another tenant loudly failed with a **400 &#34;Tenant conflict&#34;** whenever fewer rows came back than went in (on non-versioned records).

**After:** A tenant-scoped bulk upsert now **silently filters** the cross-tenant row and returns the in-scope rows — consistent with single-record ops and the sibling bulk `update_many` / `delete_many`. Only a genuine optimistic-lock (version) conflict remains loud.

## How

- **Bug 1:** In both merged-validation load knobs — the non-tenant `knob_load_and_validate` and the tenant-filtered `knob_load_and_validate_tenant` — the generated load changes from `.first(...)` + `map_err(AutumnError::from)?` to `.first(...)` + `.optional()` + `not_found_msg(...)`, so a missing row becomes a 404 instead of a 500. This mirrors the pattern the versioned lock-load branch already uses.
- **Bug 2:** The tenant `upsert_many` size-check drops the non-versioned `!has_lock … =&gt; bad_request_msg(&#34;Tenant conflict…&#34;)` branch. Cross-tenant isolation is enforced by the SQL `ON CONFLICT … WHERE tenant_id = $t`, not by the returned-row count, so the count check no longer needs to reject a filtered partial upsert. The retained branch still raises a `conflict_msg` on a real optimistic-lock mismatch. The companion codegen unit test was flipped to pin the new behavior (no `!has_lock` reject; the versioned `has_lock` reject stays).

## Coverage

Surfaced by #1923. Its regression coverage — the `validate_on_update_blind` and `tenancy::test_bulk_ops_tenant_scoping` sweep tests — is re-run by this PR&#39;s CI. The macro-crate codegen unit test `repository_macro_tenant_scoped_upsert_many_filters_cross_tenant_silently` passes locally, as do the `validate_on_update` codegen tests.

No version bump, no CHANGELOG edit.

---
_Generated by [Claude Code](https://claude.ai/code/session_014KA9PKkuNMTkayCWTTJbM7)_

---
### CI self-sufficiency

This PR now also carries the one-line `#[allow(clippy::too_many_lines)]` on the `postgres_backend_persists_tracked_job_and_expires_it` seed test in `autumn/tests/integration/job_tracking_stores_integration.rs` — identical to chore #1961, which is being closed as superseded. That folds the trunk-pre-existing `too_many_lines` lint fix into this branch so the PR is fully self-sufficient: Lint goes green → the #1923 Docker sweep runs → `validate_on_update_blind` + `tenancy::test_bulk_ops_tenant_scoping` prove the tenant-isolation fix on this same PR, all landing atomically on one fully-green PR.

---
### Known limitation (follow-up)

This PR makes the **non-versioned** tenant-scoped `upsert_many` silently filter cross-tenant rows (the path the `tenancy::test_bulk_ops_tenant_scoping` sweep test exercises). A **versioned** (`has_lock`) tenant repo still returns a 409 when a cross-tenant row is filtered, because the retained optimistic-lock check can&#39;t currently distinguish &#34;row dropped by the `WHERE tenant_id` filter&#34; from &#34;row dropped by a lock-version conflict&#34; — the upsert SQL doesn&#39;t report per-row drop reasons. This is pre-existing behavior (not a regression from this change) and tenant isolation still holds via the SQL `WHERE tenant_id`; making the versioned path also silently filter cross-tenant rows (while still catching genuine lock conflicts) needs more plumbing and is intentionally left as a follow-up, tracked in #1963. (Raised by the automated reviewer.)