### PR TITLE
feat(scaffold): route --live-validation fields through a11y primitives + .hx() (Closes #1951)

### DIFF
--- a/autumn-cli/src/generate/scaffold.rs
+++ b/autumn-cli/src/generate/scaffold.rs
@@ -3227,11 +3227,10 @@ pub async fn index(
             // shed those client-side guards. The swapped-in field re-wires its
             // own htmx trigger from the identical `validate_url`.
             let constrained = field.and_then(|f| {
-                html5_constraint_spec(f).and_then(|(input_type, attrs)| {
+                html5_constraint_spec(f).and_then(|(input_type, _attrs)| {
                     // Numerics don't take the htmx path (no wrapper to swap), so
                     // only the text-family constrained controls need a fragment.
-                    matches!(f.kind, FieldKind::String | FieldKind::Text)
-                        .then_some((f, input_type, attrs))
+                    matches!(f.kind, FieldKind::String | FieldKind::Text).then_some((f, input_type))
                 })
             });
             let _ = write!(
@@ -3254,12 +3253,11 @@ pub async fn index(
             vh.push_str("        return autumn_web::html! {};\n");
             vh.push_str("    };\n");
             vh.push_str("    let changeset = form.into_changeset();\n");
-            if let Some((f, input_type, attrs)) = constrained {
+            if let Some((f, input_type)) = constrained {
                 // The validate endpoint URL is emitted as a typed path-helper
-                // call expression (issue #1133), spliced into `hx-post=(…)`.
+                // call expression (issue #1133), spliced into `.hx("post", …)`.
                 let url = format!("paths::validate_{field_name}()");
-                let markup =
-                    render_live_constrained_field(f, "changeset", input_type, &attrs, Some(&url));
+                let markup = render_live_constrained_field(f, "changeset", input_type, Some(&url));
                 let _ = writeln!(vh, "    autumn_web::html! {{\n        {markup}\n    }}");
             } else {
                 // Match `render_changeset_form_inputs`'s helper choice: a
@@ -3305,7 +3303,7 @@ pub async fn index(
             names.push("events".to_owned());
         }
         // One inline-validation endpoint per validated field (live-validation
-        // only), each linked from the form's `hx-post=(paths::validate_{f}())`.
+        // only), each linked from the form's `.hx("post", paths::validate_{f}())`.
         if live_validation {
             for field_name in validations.keys() {
                 names.push(format!("validate_{field_name}"));
@@ -4424,8 +4422,12 @@ fn resolve_reference_display(
 /// `role="alert"`) come for free — and the identical markup is emitted by
 /// `new_form`, `edit_form`, and both 422 re-render branches. `FieldKind` maps to
 /// the matching helper (`text_input`, `number_input`, `datetime_input`,
-/// `checkbox_input`, `select_input`); attachments stay a plain `<input
-/// type="file">` (a file input can't be repopulated).
+/// `checkbox_input`, `select_input`). DSL-constrained text/textarea fields, the
+/// `belongs_to` parent `<select>`, and attachments route through the typed
+/// accessible `a11y::TextField`/`TextArea`/`Select`/`FileField` primitives
+/// (issues #1750/#1951), so the inline-validation controls keep the
+/// compile-time label obligation; a file input still can't be repopulated
+/// (browser security).
 #[allow(clippy::too_many_lines)]
 fn render_changeset_form_inputs(
     fields: &[Field],
@@ -4454,17 +4456,17 @@ fn render_changeset_form_inputs(
             // belongs_to parent dropdown (issue #1146), restored in the
             // `--live-validation` per-field path (issue #1750).
             render_live_reference_select(f, cv)
-        } else if let (true, Some((input_type, attrs))) = (
+        } else if let (true, Some((input_type, _attrs))) = (
             matches!(
                 f.kind,
                 FieldKind::I32 | FieldKind::I64 | FieldKind::F32 | FieldKind::F64
             ),
             &constraint,
         ) {
-            // A constrained numeric renders a raw number input carrying its
+            // A constrained numeric renders a number input carrying its
             // `min`/`max` (and `step="any"` for floats). Numerics don't take the
             // htmx inline-validation path, so no `validate_url`.
-            render_live_constrained_field(f, cv, input_type, attrs, None)
+            render_live_constrained_field(f, cv, input_type, None)
         } else if f.kind.is_attachment() {
             // Issue #1236: a plain file input, no hidden key. The enclosing
             // `<form>` carries `enctype="multipart/form-data"` so the browser
@@ -4472,7 +4474,13 @@ fn render_changeset_form_inputs(
             // re-upload preserves the current attachment server-side (the
             // handler binds `streamed.or(current)`). A file input itself can't be
             // repopulated — browser security.
-            format!("label {{ \"{label}\" }} input type=\"file\" name=\"{name}\";")
+            //
+            // Issue #1951: route it through the typed accessible `a11y::FileField`
+            // primitive so the file input carries a programmatically-associated
+            // `<label for>` (the previous raw `label { … } input;` had an
+            // unassociated label). No htmx wiring — attachments never take the
+            // inline-validation path.
+            format!("(autumn_web::a11y::FileField::new(\"{name}\").label(\"{label}\"))")
         } else {
             // A required (non-nullable) field uses the framework's
             // `required_*` sibling helper — `required` + `aria-required="true"`
@@ -4550,27 +4558,22 @@ fn render_changeset_form_inputs(
                     // `length` rule) doesn't leave a blank required field with
                     // no client-side guard at all.
                     let validated_htmx = live_validation && validated.contains(&name.as_str());
-                    if let Some((input_type, attrs)) = &constraint {
+                    if let Some((input_type, _attrs)) = &constraint {
                         // Issue #1750: a DSL-constrained `String`/`Text` field
                         // carries the #1388 client-side HTML5 attributes
                         // (`minlength`/`maxlength`, `type="email"`/`url`, and a
                         // `<textarea>` for long-form `Text`) the shipped helpers
-                        // can't express. Render it as raw markup mirroring the
-                        // standard `form_for` path, threading the htmx
-                        // inline-validation wiring on when the field is validated
-                        // so real-time validation keeps working alongside the
-                        // static constraints. (A constrained field always has a
-                        // validator rule, so this is the validated path; the
-                        // `validate_url` is threaded only when `live_validation`.)
+                        // can't express. Route it through the typed a11y
+                        // primitives mirroring the standard `form_for` path
+                        // (issue #1951), threading the htmx inline-validation
+                        // wiring on via `.hx()` when the field is validated so
+                        // real-time validation keeps working alongside the static
+                        // constraints. (A constrained field always has a validator
+                        // rule, so this is the validated path; the `validate_url`
+                        // is threaded only when `live_validation`.)
                         let validate_url =
                             validated_htmx.then(|| format!("paths::validate_{name}()"));
-                        render_live_constrained_field(
-                            f,
-                            cv,
-                            input_type,
-                            attrs,
-                            validate_url.as_deref(),
-                        )
+                        render_live_constrained_field(f, cv, input_type, validate_url.as_deref())
                     } else if validated_htmx {
                         let helper = if f.nullable {
                             "text_input_htmx"
@@ -4759,43 +4762,54 @@ fn html5_constraint_builder_calls(field: &Field) -> Option<(&'static str, String
     Some((input_type, calls))
 }
 
-/// Render the raw maud markup for a DSL-constrained (issue #1388)
+/// Render the maud markup for a DSL-constrained (issue #1388)
 /// `String`/`Text`/numeric field in the `--live-validation` per-field path
 /// (issue #1750).
 ///
-/// The shipped `autumn_web::form::*` helpers take no HTML5-constraint params,
-/// so the live path renders the constrained control as raw markup instead —
-/// the same inline-error/ARIA skeleton those helpers emit, plus the
-/// `input_type` override and `constraint_attrs`
-/// (`minlength`/`maxlength`/`min`/`max`/`step`) from [`html5_constraint_spec`],
-/// exactly mirroring the standard `form_for` path's `.exclude()` + `.append()`
-/// output. When `validate_url` is `Some`, the htmx inline-validation wiring
-/// (`hx-post`/`hx-trigger`/`hx-target`/`hx-swap`/`hx-include` +
-/// `hx-params="not _submit_token"` + the `data-autumn-field-wrapper` swap
-/// marker) is threaded on too, matching `required_text_input_htmx`. The
-/// `hx-params` filter keeps the inline-validation POST (which `hx-include`s the
-/// whole form) from carrying the one-time `_submit_token`, so validation never
-/// consumes the token the real create/update submit needs (issue #1360). Shared
-/// by [`render_changeset_form_inputs`] and
-/// the inline-validate handlers so the initially-rendered field and the
+/// The control is routed through the typed accessible `a11y::TextField` /
+/// `a11y::TextArea` primitives (issue #1951): the raw wrapper `<div>` and the
+/// inline-error `<div>` skeleton stay as maud lines (mirroring the shipped
+/// `autumn_web::form::*` helpers and the standard `form_for` path's
+/// `.exclude()` + `.append()` output), but the labelled control itself is a
+/// primitive builder chain, so the inline-validation field keeps the
+/// compile-time label obligation instead of dropping to raw markup. The
+/// `input_type` override and the HTML5 constraints
+/// (`minlength`/`maxlength`/`min`/`max`/`step`) become typed builder calls from
+/// the same [`html5_constraint_builder_calls`] source the standard path uses.
+///
+/// When `validate_url` is `Some`, the htmx inline-validation wiring is threaded
+/// on too — the `data-autumn-field-wrapper` swap marker stays a raw attribute
+/// on the wrapper `<div>`, and the control carries the
+/// `hx-post`/`hx-trigger`/`hx-target`/`hx-swap`/`hx-include` +
+/// `hx-params="not _submit_token"` attributes via the primitive's `.hx()`
+/// escape hatch. The `hx-params` filter keeps the inline-validation POST (which
+/// `hx-include`s the whole form) from carrying the one-time `_submit_token`, so
+/// validation never consumes the token the real create/update submit needs
+/// (issue #1360). Shared by [`render_changeset_form_inputs`] and the
+/// inline-validate handlers so the initially-rendered field and the
 /// htmx-swapped fragment are byte-identical.
 fn render_live_constrained_field(
     field: &Field,
     changeset_var: &str,
     input_type: &str,
-    constraint_attrs: &str,
     // A Rust expression (as source text) producing the inline-validation URL —
     // the typed path helper `paths::validate_{field}()` (issue #1133). Spliced
-    // into `hx-post=(…)` so the URL has a single source of truth.
+    // into `.hx("post", …)` so the URL has a single source of truth.
     validate_url: Option<&str>,
 ) -> String {
     let name = &field.name;
     let label = humanize_label(name);
     let cv = changeset_var;
-    let required_attr = if field.nullable {
+    // Typed HTML5-constraint builder calls (`.minlength(3u32)`, `.min("0")`,
+    // `.step("any")`, …) from the same `html5_constraint_parts` source the
+    // standard `form_for` input path uses, so the two paths can't drift.
+    let constraint_builders = html5_constraint_builder_calls(field)
+        .map(|(_, calls)| calls)
+        .unwrap_or_default();
+    let required_builders = if field.nullable {
         ""
     } else {
-        " required aria-required=\"true\""
+        ".required().aria_required()"
     };
     // A constrained `Text` column is long-form (Postgres `TEXT`), so it renders
     // a `<textarea>` (matching the derived `FieldControl::Textarea` and the
@@ -4803,18 +4817,21 @@ fn render_live_constrained_field(
     // single-line (its `input_type` is `email`/`url`), so it takes the `<input>`
     // branch — a textarea can't carry those types.
     let is_textarea = matches!(field.kind, FieldKind::Text) && input_type == "text";
-    // htmx inline-validation wiring + the swap-target marker on the wrapper.
-    let (wrapper_marker, htmx_attrs) = validate_url.map_or_else(
+    // htmx inline-validation wiring: the swap-target marker stays a raw
+    // attribute on the wrapper `<div>`, while the control carries the htmx
+    // attributes through the primitive's `.hx()` escape hatch (issue #1951).
+    let (wrapper_marker, hx_builders) = validate_url.map_or_else(
         || (String::new(), String::new()),
         |url| {
             (
                 format!(" data-autumn-field-wrapper=\"{name}\""),
                 format!(
-                    "\n                    hx-post=({url})\n                    \
-                     hx-trigger=\"change\"\n                    \
-                     hx-target=\"closest [data-autumn-field-wrapper]\"\n                    \
-                     hx-swap=\"outerHTML\"\n                    hx-include=\"closest form\"\n                    \
-                     hx-params=\"not _submit_token\""
+                    "\n                    .hx(\"post\", {url})\n                    \
+                     .hx(\"trigger\", \"change\")\n                    \
+                     .hx(\"target\", \"closest [data-autumn-field-wrapper]\")\n                    \
+                     .hx(\"swap\", \"outerHTML\")\n                    \
+                     .hx(\"include\", \"closest form\")\n                    \
+                     .hx(\"params\", \"not _submit_token\")"
                 ),
             )
         },
@@ -4831,36 +4848,44 @@ fn render_live_constrained_field(
         format!(
             "div id=\"{name}-field\" class=\"autumn-field\"{wrapper_marker} {{\n                \
              @let errors = {cv}.errors_for(\"{name}\");\n                \
-             label for=\"{name}\" class=\"autumn-field__label\" {{ \"{label}\" }}\n                \
-             textarea id=\"{name}\" name=\"{name}\"{constraint_attrs}{required_attr}\n                    \
-             class=(if errors.is_empty() {{ \"autumn-field__input\" }} else {{ \"autumn-field__input autumn-field__input--invalid\" }})\n                    \
-             aria-invalid=(if errors.is_empty() {{ \"false\" }} else {{ \"true\" }})\n                    \
-             aria-describedby=(if errors.is_empty() {{ \"\" }} else {{ \"{name}-error\" }}){htmx_attrs} {{\n                        \
-             ({cv}.field_value(\"{name}\").unwrap_or_default())\n                    \
-             }}{errors_tail}"
+             (autumn_web::a11y::TextArea::new(\"{name}\")\n                    \
+             .label(\"{label}\")\n                    \
+             .label_class(\"autumn-field__label\")\n                    \
+             .value({cv}.field_value(\"{name}\").unwrap_or_default())\n                    \
+             {constraint_builders}{required_builders}\n                    \
+             .class(if errors.is_empty() {{ \"autumn-field__input\" }} else {{ \"autumn-field__input autumn-field__input--invalid\" }})\n                    \
+             .aria_invalid(!errors.is_empty())\n                    \
+             .described_by(if errors.is_empty() {{ \"\" }} else {{ \"{name}-error\" }}){hx_builders}){errors_tail}"
         )
     } else {
         format!(
             "div id=\"{name}-field\" class=\"autumn-field\"{wrapper_marker} {{\n                \
              @let errors = {cv}.errors_for(\"{name}\");\n                \
-             label for=\"{name}\" class=\"autumn-field__label\" {{ \"{label}\" }}\n                \
-             input type=\"{input_type}\" id=\"{name}\" name=\"{name}\"\n                    \
-             value=({cv}.field_value(\"{name}\").unwrap_or_default()){constraint_attrs}{required_attr}\n                    \
-             class=(if errors.is_empty() {{ \"autumn-field__input\" }} else {{ \"autumn-field__input autumn-field__input--invalid\" }})\n                    \
-             aria-invalid=(if errors.is_empty() {{ \"false\" }} else {{ \"true\" }})\n                    \
-             aria-describedby=(if errors.is_empty() {{ \"\" }} else {{ \"{name}-error\" }}){htmx_attrs};{errors_tail}"
+             (autumn_web::a11y::TextField::new(\"{name}\")\n                    \
+             .label(\"{label}\")\n                    \
+             .label_class(\"autumn-field__label\")\n                    \
+             .input_type(\"{input_type}\")\n                    \
+             .value({cv}.field_value(\"{name}\").unwrap_or_default())\n                    \
+             {constraint_builders}{required_builders}\n                    \
+             .class(if errors.is_empty() {{ \"autumn-field__input\" }} else {{ \"autumn-field__input autumn-field__input--invalid\" }})\n                    \
+             .aria_invalid(!errors.is_empty())\n                    \
+             .described_by(if errors.is_empty() {{ \"\" }} else {{ \"{name}-error\" }}){hx_builders}){errors_tail}"
         )
     }
 }
 
-/// Render the raw maud markup for a `belongs_to` parent `<select>` in the
+/// Render the maud markup for a `belongs_to` parent `<select>` in the
 /// `--live-validation` per-field path (issue #1750). The standard path renders
 /// this through a `form_for` `FieldControl::Select` override, but the per-field
-/// path has no `form_for`, so it emits a raw `<select>` populated at request
-/// time from the `{name}_options` loader (a `Vec<(String, String)>` of
-/// id/display pairs) — a blank placeholder plus `selected` driven by the
-/// changeset value so a 422 re-render keeps the chosen parent. The
-/// `{name}_options` binding is loaded into scope by the calling handler.
+/// path has no `form_for`, so it routes the control through the typed
+/// accessible `a11y::Select` primitive (issue #1951) — the raw wrapper `<div>`
+/// and inline-error `<div>` skeleton stay as maud lines, while the labelled
+/// `<select>` is a primitive builder chain populated at request time from the
+/// `{name}_options` loader (a `Vec<(String, String)>` of id/display pairs). A
+/// blank placeholder plus `selected_value` driven by the changeset value keeps
+/// the chosen parent through a 422 re-render. The `{name}_options` binding is
+/// loaded into scope by the calling handler. (There is no htmx wiring here — the
+/// `belongs_to` select carries no inline-validation attributes.)
 fn render_live_reference_select(field: &Field, changeset_var: &str) -> String {
     let name = &field.name;
     let label = humanize_label(name);
@@ -4870,24 +4895,24 @@ fn render_live_reference_select(field: &Field, changeset_var: &str) -> String {
     } else {
         "— Select —"
     };
-    let required_attr = if field.nullable {
+    let required_builders = if field.nullable {
         ""
     } else {
-        " required aria-required=\"true\""
+        ".required().aria_required()"
     };
     format!(
         "div id=\"{name}-field\" class=\"autumn-field\" {{\n                \
          @let errors = {cv}.errors_for(\"{name}\");\n                \
-         label for=\"{name}\" class=\"autumn-field__label\" {{ \"{label}\" }}\n                \
-         select id=\"{name}\" name=\"{name}\"{required_attr}\n                    \
-         class=(if errors.is_empty() {{ \"autumn-field__input\" }} else {{ \"autumn-field__input autumn-field__input--invalid\" }})\n                    \
-         aria-invalid=(if errors.is_empty() {{ \"false\" }} else {{ \"true\" }})\n                    \
-         aria-describedby=(if errors.is_empty() {{ \"\" }} else {{ \"{name}-error\" }}) {{\n                        \
-         option value=\"\" {{ \"{placeholder}\" }}\n                        \
-         @for (opt_value, opt_label) in {name}_options.iter() {{\n                            \
-         option value=(opt_value) selected[{cv}.field_value(\"{name}\").as_deref() == Some(opt_value.as_str())] {{ (opt_label) }}\n                        \
-         }}\n                    \
-         }}\n                \
+         (autumn_web::a11y::Select::new(\"{name}\")\n                    \
+         .label(\"{label}\")\n                    \
+         .label_class(\"autumn-field__label\")\n                    \
+         {required_builders}\n                    \
+         .class(if errors.is_empty() {{ \"autumn-field__input\" }} else {{ \"autumn-field__input autumn-field__input--invalid\" }})\n                    \
+         .aria_invalid(!errors.is_empty())\n                    \
+         .described_by(if errors.is_empty() {{ \"\" }} else {{ \"{name}-error\" }})\n                    \
+         .option(\"\", \"{placeholder}\")\n                    \
+         .options({name}_options.iter().map(|(opt_value, opt_label)| autumn_web::a11y::SelectOption::new(opt_value.as_str(), opt_label.as_str())))\n                    \
+         .selected_value({cv}.field_value(\"{name}\").unwrap_or_default()))\n                \
          @if !errors.is_empty() {{\n                    \
          div id=\"{name}-error\" role=\"alert\" class=\"autumn-field__errors\" {{\n                        \
          @for error in errors {{ p class=\"autumn-field__error\" {{ (error) }} }}\n                    \
@@ -8170,7 +8195,8 @@ async fn main() {
         // while the real create/update form still embeds it.
         let tmp = project_with_main(default_main());
         // A DSL-constrained `String` auto-derives a `length` rule, so `title` is
-        // validated and renders through the raw-markup htmx constrained control.
+        // validated and renders through the typed `a11y::TextField` primitive
+        // carrying the htmx wiring via `.hx()` (issue #1951).
         let plan = plan_scaffold_with_options(
             tmp.path(),
             "Post",
@@ -8187,16 +8213,16 @@ async fn main() {
         let routes = fs::read_to_string(tmp.path().join("src/routes/posts.rs")).unwrap();
 
         // The constrained validated input keeps its inline-validation wiring,
-        // now routed through the typed path helper (#1823) rather than a
-        // hardcoded URL.
+        // now threaded through the primitive's `.hx()` escape hatch and the
+        // typed path helper (#1823/#1951) rather than a raw `hx-post` attribute.
         assert!(
-            routes.contains("hx-post=(paths::validate_title())"),
-            "title must keep its htmx inline-validation wiring:\n{routes}"
+            routes.contains(".hx(\"post\", paths::validate_title())"),
+            "title must keep its htmx inline-validation wiring via `.hx()`:\n{routes}"
         );
         // ...but filters the one-time submit token out of that POST so the
         // inline validation never consumes it.
         assert!(
-            routes.contains("hx-params=\"not _submit_token\""),
+            routes.contains(".hx(\"params\", \"not _submit_token\")"),
             "live-validation inputs must drop _submit_token from the inline POST:\n{routes}"
         );
         // The inline-validate handler returns the SAME fragment (byte-identical
@@ -8208,7 +8234,7 @@ async fn main() {
             validate_title[..validate_title[1..]
                 .find("#[post(")
                 .map_or(validate_title.len(), |rel| rel + 1)]
-                .contains("hx-params=\"not _submit_token\""),
+                .contains(".hx(\"params\", \"not _submit_token\")"),
             "the validate_title fragment must also drop the submit token:\n{validate_title}"
         );
         // The real create/update form still embeds the submit token so the
@@ -8216,6 +8242,53 @@ async fn main() {
         assert!(
             routes.contains("submit_token_input(submit_token.as_ref(), submit_field.as_ref())"),
             "the create/update form must still carry the submit token:\n{routes}"
+        );
+
+        // Issue #1951 byte-identity guarantee: htmx swaps `outerHTML` on the
+        // whole `[data-autumn-field-wrapper]`, so the field the form first
+        // renders and the fragment the `validate_title` handler returns must be
+        // byte-identical. Both are emitted by the shared
+        // `render_live_constrained_field`, so extract the `title-field` wrapper
+        // block from the first (form) occurrence and from the validate handler
+        // and assert they match after normalizing insignificant leading
+        // whitespace (which maud does not render).
+        let extract_block = |src: &str, start: usize| -> String {
+            let open = src[start..].find('{').expect("wrapper `{`") + start;
+            let mut depth = 0usize;
+            for (i, ch) in src[open..].char_indices() {
+                match ch {
+                    '{' => depth += 1,
+                    '}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            return src[start..=open + i].to_owned();
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            panic!("unbalanced wrapper block");
+        };
+        let normalize =
+            |block: &str| -> String { block.lines().map(str::trim).collect::<Vec<_>>().join("\n") };
+        let form_start = routes
+            .find("div id=\"title-field\"")
+            .expect("form title-field");
+        let form_block = extract_block(&routes, form_start);
+        let frag_offset = routes
+            .find("pub async fn validate_title(")
+            .expect("validate_title handler");
+        let frag_start = frag_offset
+            + routes[frag_offset..]
+                .find("div id=\"title-field\"")
+                .expect("fragment title-field");
+        let frag_block = extract_block(&routes, frag_start);
+        assert_eq!(
+            normalize(&form_block),
+            normalize(&frag_block),
+            "the initial-rendered field and the validate_title fragment must be \
+             byte-identical (modulo insignificant whitespace) for the htmx \
+             outerHTML swap"
         );
     }
 

--- a/autumn-cli/tests/integration/scaffold_belongs_to.rs
+++ b/autumn-cli/tests/integration/scaffold_belongs_to.rs
@@ -336,16 +336,17 @@ fn live_validation_keeps_parent_display_on_index_and_show() {
     );
     // Issue #1750: the in-FORM belongs_to `<select>` is now rendered in
     // live-validation too — the FK no longer leaks out as a raw per-field text
-    // input. The per-field path emits a raw `<select>` (not a `form_for`
+    // input. The per-field path emits the `<select>` (not a `form_for`
     // `.override_field` override, which live-validation never uses) populated
-    // from the runtime option loader.
+    // from the runtime option loader. Issue #1951 routes it through the typed
+    // `a11y::Select` primitive.
     assert!(
         routes.contains("let post_id_options = post_id_select_options(&mut db).await?;"),
         "live-validation must load the belongs_to select options in the form handler:\n{routes}"
     );
     assert!(
-        routes.contains("select id=\"post_id\" name=\"post_id\""),
-        "the FK form control must be a populated <select> in live-validation:\n{routes}"
+        routes.contains("autumn_web::a11y::Select::new(\"post_id\")"),
+        "the FK form control must be a populated a11y::Select in live-validation:\n{routes}"
     );
     assert!(
         !routes.contains("required_text_input(&changeset, \"post_id\", \"Post Id\")"),
@@ -385,19 +386,27 @@ fn live_validation_renders_populated_belongs_to_select() {
         routes.contains("let post_id_options = post_id_select_options(&mut db).await?;"),
         "the options must be loaded in the form handler:\n{routes}"
     );
-    // The `<select>` is populated from those options with changeset `selected`.
+    // Issue #1951: the `<select>` is routed through the typed `a11y::Select`
+    // primitive, populated from those options with changeset-driven selection.
     assert!(
-        routes.contains("select id=\"post_id\" name=\"post_id\""),
-        "a <select> must be rendered for the belongs_to parent:\n{routes}"
+        routes.contains("autumn_web::a11y::Select::new(\"post_id\")"),
+        "an a11y::Select must be rendered for the belongs_to parent:\n{routes}"
     );
     assert!(
-        routes.contains("@for (opt_value, opt_label) in post_id_options.iter()"),
-        "the <select> options must come from the runtime loader:\n{routes}"
+        routes.contains(
+            "post_id_options.iter().map(|(opt_value, opt_label)| \
+             autumn_web::a11y::SelectOption::new(opt_value.as_str(), opt_label.as_str()))"
+        ),
+        "the <select> options must come from the runtime loader (mapped to SelectOption):\n{routes}"
     );
     assert!(
-        routes
-            .contains("changeset.field_value(\"post_id\").as_deref() == Some(opt_value.as_str())"),
+        routes.contains(".selected_value(changeset.field_value(\"post_id\").unwrap_or_default())"),
         "the selected option must be driven by the changeset value (422 re-render):\n{routes}"
+    );
+    // The placeholder is the first option on the primitive.
+    assert!(
+        routes.contains(".option(\"\", \"— Select —\")"),
+        "the belongs_to select must carry a blank placeholder option:\n{routes}"
     );
 }
 

--- a/autumn-cli/tests/integration/scaffold_validation.rs
+++ b/autumn-cli/tests/integration/scaffold_validation.rs
@@ -565,44 +565,58 @@ fn live_validation_forms_carry_html5_constraints() {
     );
     let routes = fs::read_to_string(project.join("src/routes/posts.rs")).unwrap();
 
-    // The string length constraint on the htmx-validated `title` input.
+    // Issue #1951: the constrained fields now route through the typed
+    // `a11y::TextField`/`TextArea` primitives, so the HTML5 constraints are
+    // typed builder calls (`.minlength(3u32)`), not raw attributes. The title
+    // input carries its length rule via the `TextField` primitive.
     assert!(
-        routes.contains("minlength=\"3\" maxlength=\"120\""),
-        "title must render minlength/maxlength in live-validation mode:\n{routes}"
+        routes.contains("autumn_web::a11y::TextField::new(\"title\")")
+            && routes.contains(".minlength(3u32).maxlength(120u32)"),
+        "title must render minlength/maxlength via the TextField primitive in live-validation mode:\n{routes}"
     );
-    // Typed inputs (email/url) instead of a bare text input.
+    // Typed inputs (email/url) instead of a bare text input — now via
+    // `.input_type(..)` on the primitive.
     assert!(
-        routes.contains("type=\"email\" id=\"contact\""),
-        "contact must render type=email in live-validation mode:\n{routes}"
+        routes.contains("autumn_web::a11y::TextField::new(\"contact\")")
+            && routes.contains(".input_type(\"email\")"),
+        "contact must render type=email via the TextField primitive in live-validation mode:\n{routes}"
     );
     assert!(
-        routes.contains("type=\"url\" id=\"homepage\""),
-        "homepage must render type=url in live-validation mode:\n{routes}"
+        routes.contains("autumn_web::a11y::TextField::new(\"homepage\")")
+            && routes.contains(".input_type(\"url\")"),
+        "homepage must render type=url via the TextField primitive in live-validation mode:\n{routes}"
     );
-    // Numeric min/max on the number input.
+    // Numeric min/max on the number input (numerics take no htmx path, so no
+    // `.hx(..)` — but they still route through `TextField`).
     assert!(
-        routes.contains("type=\"number\"") && routes.contains("min=\"0\" max=\"130\""),
-        "age must render type=number with min/max in live-validation mode:\n{routes}"
+        routes.contains("autumn_web::a11y::TextField::new(\"age\")")
+            && routes.contains(".input_type(\"number\")")
+            && routes.contains(".min(\"0\").max(\"130\")"),
+        "age must render type=number with min/max via the TextField primitive in live-validation mode:\n{routes}"
     );
-    // A constrained `Text` column becomes a <textarea> carrying its length rule.
+    // A constrained `Text` column becomes a `TextArea` primitive carrying its
+    // length rule.
     assert!(
-        routes.contains("textarea id=\"notes\" name=\"notes\"")
-            && routes.contains("maxlength=\"500\""),
-        "constrained Text `notes` must render a <textarea> with maxlength:\n{routes}"
+        routes.contains("autumn_web::a11y::TextArea::new(\"notes\")")
+            && routes.contains(".maxlength(500u32)"),
+        "constrained Text `notes` must render an a11y::TextArea with maxlength:\n{routes}"
     );
-    // The nullable `bio` keeps its maxlength.
+    // The nullable `bio` keeps its maxlength via the primitive.
     assert!(
-        routes.contains("maxlength=\"200\""),
-        "bio must render maxlength in live-validation mode:\n{routes}"
+        routes.contains("autumn_web::a11y::TextField::new(\"bio\")")
+            && routes.contains(".maxlength(200u32)"),
+        "bio must render maxlength via the TextField primitive in live-validation mode:\n{routes}"
     );
 
-    // The htmx inline-validation wiring survives on a constrained validated
-    // input (real-time validation still works alongside the static constraints),
-    // and its swap wrapper marker is present.
+    // Issue #1951: the htmx inline-validation wiring survives on a constrained
+    // validated input, now threaded through the primitive's `.hx()` escape
+    // hatch (real-time validation still works alongside the static
+    // constraints), and its swap wrapper marker stays a raw attribute on the
+    // wrapper `<div>`.
     assert!(
-        routes.contains("hx-post=(paths::validate_title())")
+        routes.contains(".hx(\"post\", paths::validate_title())")
             && routes.contains("data-autumn-field-wrapper=\"title\""),
-        "the constrained title input must keep its htmx inline-validation wiring (via typed path helper):\n{routes}"
+        "the constrained title input must keep its htmx inline-validation wiring (via `.hx()` + typed path helper):\n{routes}"
     );
 
     // Issue #1360 (finding F): the inline-validation POST `hx-include`s the whole
@@ -610,10 +624,11 @@ fn live_validation_forms_carry_html5_constraints() {
     // the first field validation would consume the token on the guarded
     // `/validate/...` route, and the real create submit would replay the
     // validation fragment instead of running the mutation. The htmx input must
-    // drop the token via `hx-params`, while the real create form keeps it.
+    // drop the token via `hx-params` (now `.hx("params", ..)`), while the real
+    // create form keeps it.
     assert!(
-        routes.contains("hx-params=\"not _submit_token\""),
-        "live-validation inputs must drop _submit_token from the inline POST:\n{routes}"
+        routes.contains(".hx(\"params\", \"not _submit_token\")"),
+        "live-validation inputs must drop _submit_token from the inline POST via `.hx()`:\n{routes}"
     );
     assert!(
         routes.contains("submit_token_input(submit_token.as_ref(), submit_field.as_ref())"),
@@ -624,11 +639,11 @@ fn live_validation_forms_carry_html5_constraints() {
     // swapped-in field doesn't drop the client-side attributes on first change.
     let validate_title = slice_fn(&routes, "pub async fn validate_title(");
     assert!(
-        validate_title.contains("minlength=\"3\" maxlength=\"120\""),
+        validate_title.contains(".minlength(3u32).maxlength(120u32)"),
         "the validate_title fragment must also carry the HTML5 constraints:\n{validate_title}"
     );
     assert!(
-        !validate_title.contains("type=\"email\""),
+        !validate_title.contains(".input_type(\"email\")"),
         "sanity: the validate_title slice must be bounded to its own handler:\n{validate_title}"
     );
 }


### PR DESCRIPTION
Part of #1706. Closes #1951. (The parent epic #1933 is already closed, so no `Closes #1933` here.)

Deferred slice 3c of #1933: the last scaffold field kind still emitting raw `html!` in the generated app — the `--live-validation` per-field path — now routes through the typed, label-obligated `autumn_web::a11y` primitives, carrying its htmx inline-validation attributes through the primitives' `.hx(name, value)` escape hatch (PR #1946). This was deferred as the highest byte-identity risk because the initial render and the `validate_{name}` htmx fragment share one helper and must stay byte-identical for htmx's `outerHTML` swap.

## Before / After (rendered)

The constrained `title` field, **before** — raw `html!` bypassing the typed label obligation:

```
label for="title" class="autumn-field__label" { "Title" }
input type="text" id="title" name="title"
    value=(changeset.field_value("title").unwrap_or_default()) minlength="3" maxlength="120" required aria-required="true"
    class=(…) aria-invalid=(…) aria-describedby=(…)
    hx-post=(paths::validate_title()) hx-trigger="change"
    hx-target="closest [data-autumn-field-wrapper]" hx-swap="outerHTML"
    hx-include="closest form" hx-params="not _submit_token";
```

**After** — routed through `a11y::TextField`, htmx via `.hx()` (wrapper `<div>` + inline-error `<div>` skeleton unchanged; `data-autumn-field-wrapper` stays a raw attr on the wrapper):

```
(autumn_web::a11y::TextField::new("title")
    .label("Title")
    .label_class("autumn-field__label")
    .input_type("text")
    .value(changeset.field_value("title").unwrap_or_default())
    .minlength(3u32).maxlength(120u32).required().aria_required()
    .class(if errors.is_empty() { "autumn-field__input" } else { "autumn-field__input autumn-field__input--invalid" })
    .aria_invalid(!errors.is_empty())
    .described_by(if errors.is_empty() { "" } else { "title-error" })
    .hx("post", paths::validate_title())
    .hx("trigger", "change")
    .hx("target", "closest [data-autumn-field-wrapper]")
    .hx("swap", "outerHTML")
    .hx("include", "closest form")
    .hx("params", "not _submit_token"))
```

Textarea (`bio:Text`) → `a11y::TextArea`; belongs_to parent (`post:references`) → `a11y::Select` (placeholder `.option("", "— Select —")` + `.options(post_id_options.iter().map(|(v, l)| SelectOption::new(v.as_str(), l.as_str())))` + `.selected_value(changeset.field_value("post_id").unwrap_or_default())`); attachment (`avatar:Attachment`) → `a11y::FileField`.

## Byte-identity (verified, not inspected)

htmx swaps `outerHTML` on the whole `[data-autumn-field-wrapper]`, so the field the form first renders and the fragment `validate_{name}` returns must be byte-identical. Both are emitted by the single shared `render_live_constrained_field`, kept shared. The `execute_live_validation_inline_posts_drop_the_submit_token` unit test now **extracts the `title-field` wrapper block from the form body and from the `validate_title` handler and `assert_eq!`s them** after normalizing insignificant leading whitespace (which maud does not render) — proving runtime identity, not just source similarity. Confirmed independently on a real generated app: the two normalized blocks are equal.

## a11y-verify on the generated app (the key acceptance)

- `autumn new` + `generate scaffold --live-validation Thing "title:String{min=3,max=120}" "bio:Text{max=500}" "notes:Option<String>{max=200}" "post:references"` → `autumn a11y verify .` → **PASS, exit 0**.
- The constrained text/textarea/select fields already passed verify (they carried associated `<label for>`), so for those this is a **construction-guarantee upgrade** (compile-time label obligation), exactly as the issue frames it. The one field that previously **failed** verify was the live **attachment** file input (raw `label { … } input type="file"` with an unassociated label, WCAG 1.3.1/3.3.2/4.1.2 Serious): a `--live-validation` scaffold with `avatar:Attachment` failed verify before and now **passes** (routed to `FileField`).

## cargo-check on the generated app

Patched `[patch.crates-io] autumn-web = { path = … }` and `cargo check --tests` on the generated `--live-validation` app → **Finished, exit 0** (only pre-existing unused-import warnings), proving the emitted primitive + `.hx()` chains compile.

## How

- `render_live_constrained_field` kept as the single shared helper (its `constraint_attrs` param dropped in favour of the shared `html5_constraint_builder_calls`); `render_live_reference_select` routes the belongs_to `<select>` through `a11y::Select`; the live attachment routes through `a11y::FileField`.
- The framework `*_input` helpers (`text_input_htmx`, `checkbox_input`, `select_input`, …) are untouched — the bool/enum/numeric-non-constrained live paths still call those (their raw `html!` lives inside `autumn_web`, not the generated app, so out of scope).

## Verification

- `cargo fmt --all -- --check` clean.
- `cargo clippy -p autumn-cli --all-targets -- -D warnings` clean.
- `autumn a11y verify autumn-cli/src` → exit 0.
- Updated goldens all green: `live_validation_forms_carry_html5_constraints`, `live_validation_renders_populated_belongs_to_select`, `live_validation_keeps_parent_display_on_index_and_show`, and the `execute_live_validation_inline_posts_drop_the_submit_token` unit test (now with the byte-identity assert).