### PR TITLE
test: de-flake two #1923-sweep tests (job_tracking JSONB cast, sharding fail-closed replay)

### DIFF
--- a/autumn/tests/integration/job_tracking_stores_integration.rs
+++ b/autumn/tests/integration/job_tracking_stores_integration.rs
@@ -231,11 +231,15 @@ async fn postgres_backend_persists_tracked_job_and_expires_it() {
 
     let key = autumn_web::auth::hash_api_token(&handle.token);
     let mut conn = pool.get().await.expect("get connection");
-    let row = diesel::sql_query("SELECT record FROM autumn_job_tracking WHERE key = $1")
-        .bind::<diesel::sql_types::Text, _>(&key)
-        .get_result::<RecordRow>(&mut *conn)
-        .await
-        .expect("tracked record should be persisted in postgres");
+    // Cast to ::TEXT to match the store's own read path (job_tracking.rs); this
+    // strips the binary JSONB header so `record` is proper JSON text, not a
+    // 0x01-prefixed blob that serde_json::from_str would reject.
+    let row =
+        diesel::sql_query("SELECT record::TEXT AS record FROM autumn_job_tracking WHERE key = $1")
+            .bind::<diesel::sql_types::Text, _>(&key)
+            .get_result::<RecordRow>(&mut *conn)
+            .await
+            .expect("tracked record should be persisted in postgres");
     let record: Value = serde_json::from_str(&row.record).expect("stored record is valid JSON");
     assert!(
         record["status"].is_string(),

--- a/autumn/tests/integration/sharding_commit_hooks.rs
+++ b/autumn/tests/integration/sharding_commit_hooks.rs
@@ -193,11 +193,11 @@ mod sharding_commit_hook_tests {
             .idempotent()
             .build();
 
-        // Idempotency keys must be unique per invocation: `TestDb::shared()`
-        // hands out one Postgres for the whole consolidated test binary, and the
-        // idempotency store lives in that shared DB. A fixed key can collide with
-        // a record left by another test (or an earlier run) and replay as a 409
-        // instead of running the handler. Derive fresh keys from a per-run UUID.
+        // The idempotency store is a per-instance in-memory `MemoryIdempotencyStore`
+        // (see `TestApp::idempotent` / `src/test.rs`), NOT the shared Postgres that
+        // `TestDb::shared()` hands out — so keys need not be unique for cross-test
+        // isolation, and step 2 below deliberately reuses `key_k1` to exercise the
+        // replay path. Per-run UUID keys are kept only as harmless belt-and-suspenders.
         let run_id = uuid::Uuid::new_v4();
         let key_k1 = format!("note-k1-{run_id}");
         let key_k2 = format!("note-k2-{run_id}");
@@ -236,8 +236,14 @@ mod sharding_commit_hook_tests {
             "the after-commit hook must be staged on the shard's commit-hook queue"
         );
 
-        // 2. Replay with the same idempotency key: the HTTP middleware replays
-        //    the cached 201 without re-running the handler, so no second write.
+        // 2. Replay with the same idempotency key. The opaque tenant `from_fn`
+        //    layer (installed above) forces fail-closed idempotency replay
+        //    (`src/router.rs`), so the cached mutation is NOT re-served to a
+        //    principal behind an opaque auth/tenant layer: the replay returns 409
+        //    ("idempotency replay requires an inner replay stop for this route")
+        //    and the inner handler is not re-executed. That is the intended secure
+        //    behavior, and it still proves the no-double-write acceptance criterion
+        //    via the count/history assertions immediately below.
         client
             .post("/notes")
             .header("X-Tenant", "tenant-a")
@@ -245,7 +251,7 @@ mod sharding_commit_hook_tests {
             .json(&serde_json::json!({"title": "first"}))
             .send()
             .await
-            .assert_status(201);
+            .assert_status(409);
 
         assert_eq!(
             count(db, "SELECT COUNT(*) AS n FROM sharded_notes").await,


### PR DESCRIPTION
Two deterministic test-hygiene fixes surfaced by the #1923 Docker sweep, which ran these previously-never-run testcontainer tests for the first time. Both changes are **test-only** — no product code is touched.

## Fix 1 — `job_tracking_stores_integration.rs` (missing `::TEXT` cast on a JSONB read)

**Before:** the test read `record JSONB` with `SELECT record FROM autumn_job_tracking …`, mapping it into `RecordRow { record: String }`. Postgres returns JSONB in its binary wire format (a `0x01`-prefixed blob), so `serde_json::from_str(&row.record)` failed with `Error("expected value", line 1, column 1)`.

**After:** the SELECT now casts — `SELECT record::TEXT AS record FROM autumn_job_tracking …` — matching the production store's own read path (`src/job_tracking.rs`), which always reads `record::TEXT`. The cast strips the binary JSONB header so `record` holds proper JSON text and parses. Only that query (plus an explanatory comment) changed.

## Fix 2 — `sharding_commit_hooks.rs` (assert the fail-closed replay)

Root cause: `sharded_save_records_history_and_hooks_on_shard` installs its own `inject_tenant` `from_fn` layer. The framework treats a custom `.layer(..)` as an **opaque app layer** and therefore forces **fail-closed** idempotency replay (`src/router.rs`: a cached mutation must not be served to a different principal behind an opaque auth/tenant layer). So the step-2 same-`idempotency-key` replay returns **409** ("idempotency replay requires an inner replay stop for this route") by design — the inner handler is not re-run, which still satisfies the no-double-write goal.

**Before:** step 2 asserted `.assert_status(201)` (expecting a cached-201 replay), which never happens under an opaque layer — the test would fail the moment it actually ran.

**After:** step 2 asserts `.assert_status(409)`, with a comment explaining that the opaque tenant `from_fn` layer forces fail-closed replay (intended secure behavior, inner handler not re-executed). The subsequent no-double-write assertions — `sharded_notes` count == 1 and exactly one version-history row — are **unchanged** and still prove the acceptance criterion.

Also corrected a misleading comment that claimed the idempotency store "lives in that shared DB". It is actually a per-instance in-memory `MemoryIdempotencyStore` (`src/test.rs`), not the shared Postgres — so keys need not be unique for cross-test isolation, and step 2 deliberately reuses `key_k1` to exercise replay. Asserting the correct secure 409 is a hygiene fix, not a weakening of the test.

## Verification
- `cargo build -p autumn-web --features "test-support,offline-sync" --test integration_tests` → compiles clean.
- `cargo fmt --all -- --check` → clean.
- The Docker sweep in CI will re-run both tests to prove them green (Docker not available in this environment).

Closes #1965

---
_Generated by [Claude Code](https://claude.ai/code/session_014KA9PKkuNMTkayCWTTJbM7)_