### PR TITLE
fix(router): user route wins at an auto-mounted probe path instead of panicking (#1971)

### DIFF
--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -2010,6 +2010,14 @@ where
                 "a user route already owns this path; the built-in probe was \
                  not auto-mounted (the user handler wins)"
             );
+            // Still record the ceded path: `mount_actuator_endpoints` keys its
+            // overlap guard off this set, and a configured probe path stays a
+            // collision hazard for the actuator even when a user route (not the
+            // built-in probe) owns it. Dropping it here would let an actuator at
+            // prefix "/" merge its own `GET /health` onto the user's `GET
+            // /health` and axum would panic during construction instead of
+            // returning a checked `FrameworkRouteOverlap` (issue #1971 P2).
+            mounted_probe_paths.insert(path.to_owned());
             return router;
         }
         if mounted_probe_paths.insert(path.to_owned()) {
@@ -5040,6 +5048,68 @@ mod tests {
         assert!(
             result.unwrap().is_err(),
             "route overlap should be reported as a checked router build error"
+        );
+    }
+
+    /// Regression for issue #1971 P2: when a user route already owns `/health`,
+    /// the built-in probe cedes that path (#1971) — but a root-prefix actuator
+    /// still normalizes its own `GET /health` onto it. The ceded probe path must
+    /// remain visible to the actuator overlap guard so this surfaces as a checked
+    /// `FrameworkRouteOverlap` rather than an axum construction panic (matching
+    /// the no-user-route case in
+    /// `try_build_router_returns_error_for_probe_actuator_path_overlap`).
+    #[test]
+    fn probe_actuator_overlap_detected_when_user_route_owns_probe_path() {
+        async fn user_health() -> &'static str {
+            "user-health-handler"
+        }
+
+        let mut config = AutumnConfig::default();
+        config.actuator.prefix = "/".to_owned();
+        // Precondition: the user route, the ceded probe, and the actuator all
+        // land on exactly `/health`.
+        assert_eq!(config.health.path, "/health");
+
+        let route = Route {
+            method: http::Method::GET,
+            path: "/health",
+            handler: axum::routing::get(user_health),
+            name: "user_health",
+            api_doc: crate::openapi::ApiDoc {
+                method: "GET",
+                path: "/health",
+                operation_id: "user_health",
+                success_status: 200,
+                ..Default::default()
+            },
+            repository: None,
+            idempotency: crate::route::RouteIdempotency::Direct,
+            timeout: crate::route::RouteTimeout::Inherit,
+            api_version: None,
+            sunset_opt_out: false,
+        };
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            try_build_router(vec![route], &config, test_state())
+        }));
+
+        assert!(
+            result.is_ok(),
+            "try_build_router panicked instead of returning a checked overlap error"
+        );
+        let build = result.unwrap();
+        assert!(
+            matches!(
+                &build,
+                Err(RouterBuildError::FrameworkRouteOverlap {
+                    path,
+                    incoming: "actuator endpoint",
+                    ..
+                }) if path == "/health"
+            ),
+            "root-prefix actuator over a user-owned probe path must yield a checked \
+             FrameworkRouteOverlap for /health, got: {:?}",
+            build.as_ref().map(|_| "Ok(router)"),
         );
     }
 

--- a/autumn/src/router.rs
+++ b/autumn/src/router.rs
@@ -396,8 +396,10 @@ pub fn try_build_probe_only_router(
     state: AppState,
 ) -> Result<axum::Router, RouterBuildError> {
     let barrier_state = state.clone();
+    // A worker replica serves no user routes, so nothing can shadow a probe.
+    let no_user_routes = std::collections::HashSet::new();
     let (mounted_probe_paths, router) =
-        mount_probe_endpoints(axum::Router::<AppState>::new(), config);
+        mount_probe_endpoints(axum::Router::<AppState>::new(), config, &no_user_routes);
     let router = mount_actuator_endpoints(router, config, &mounted_probe_paths)?;
     let router = router.with_state(state);
     Ok(apply_startup_barrier(router, config, &barrier_state))
@@ -564,6 +566,11 @@ fn build_router_pre_state(
         custom_layers_require_fail_closed_idempotency(&ctx.custom_layers)
             || custom_layers_require_fail_closed_idempotency(&ctx.static_gate_layers)
     });
+    // Capture the paths a user handler already owns BEFORE `route_list` is
+    // consumed below, so the auto-mounted probes can yield to a user route at
+    // the same path instead of panicking on an overlapping `GET` (issue #1971).
+    let user_get_paths = collect_user_get_paths(&route_list, &ctx.scoped_groups);
+
     let mut router = group_and_mount_routes(
         route_list,
         idempotency_layers.as_ref(),
@@ -575,7 +582,8 @@ fn build_router_pre_state(
 
     router = mount_framework_routes(router, config, dev_reload_enabled);
 
-    let (mounted_probe_paths, router_with_probes) = mount_probe_endpoints(router, config);
+    let (mounted_probe_paths, router_with_probes) =
+        mount_probe_endpoints(router, config, &user_get_paths);
     router = router_with_probes;
 
     router = mount_actuator_endpoints(router, config, &mounted_probe_paths)?;
@@ -1151,6 +1159,40 @@ fn validate_route_path(field: &'static str, value: &str) -> Result<(), RouterBui
         return reject("(OpenAPI mount paths must be static; `{…}` captures are not allowed)");
     }
     Ok(())
+}
+
+/// Collect the exact `GET`/`WS` paths owned by the user's *typed* route table
+/// (top-level routes plus scoped-group routes, after scope-prefix resolution).
+///
+/// Unlike [`collect_claimed_get_paths`], this deliberately excludes every
+/// framework-mounted path: its sole purpose is to let the auto-mounted probe
+/// endpoints ([`mount_probe_endpoints`]) detect when a *user* handler already
+/// owns a probe path and yield to it, rather than panicking inside
+/// `axum::Router::route` on an overlapping `GET` (issue #1971). A `WS` route is
+/// a `GET` under the hood, so it claims the path too (mirroring
+/// [`collect_claimed_get_paths`]). Opaque routers registered via
+/// [`AppBuilder::merge`](crate::app::AppBuilder::merge) /
+/// [`AppBuilder::nest`](crate::app::AppBuilder::nest) are not introspectable
+/// and so are not covered here — the same limitation the OpenAPI/MCP collision
+/// preflights carry.
+fn collect_user_get_paths(
+    route_list: &[Route],
+    scoped_groups: &[ScopedGroup],
+) -> std::collections::HashSet<String> {
+    let mut owned: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for route in route_list {
+        if route.method == http::Method::GET || route.method.as_str() == "WS" {
+            owned.insert(route.path.to_owned());
+        }
+    }
+    for group in scoped_groups {
+        for route in &group.routes {
+            if route.method == http::Method::GET || route.method.as_str() == "WS" {
+                owned.insert(join_nested_path(&group.prefix, route.path));
+            }
+        }
+    }
+    owned
 }
 
 /// Gather every path that a `GET` (or `WS`, which mounts as a `GET`) handler
@@ -1942,38 +1984,64 @@ fn mount_framework_routes(
 fn mount_probe_endpoints<S>(
     mut router: axum::Router<S>,
     config: &AutumnConfig,
+    user_get_paths: &std::collections::HashSet<String>,
 ) -> (std::collections::HashSet<String>, axum::Router<S>)
 where
     S: Clone + Send + Sync + 'static,
     AppState: axum::extract::FromRef<S>,
 {
-    // Probe endpoints (auto-mounted)
+    // Probe endpoints (auto-mounted). Each probe is a `GET`; when a user route
+    // already owns that exact path, yield to the user handler instead of
+    // handing axum a second `GET` for the same path — which panics at startup
+    // with a raw "Overlapping method route" message that names none of the
+    // user's code (issue #1971). A user who hand-writes `GET /health` clearly
+    // wants their handler, so the built-in steps aside and logs the override.
     let mut mounted_probe_paths = std::collections::HashSet::new();
 
-    if mounted_probe_paths.insert(config.health.live_path.clone()) {
-        router = router.route(
-            &config.health.live_path,
-            axum::routing::get(crate::probe::live_handler::<AppState>),
-        );
-    }
-    if mounted_probe_paths.insert(config.health.ready_path.clone()) {
-        router = router.route(
-            &config.health.ready_path,
-            axum::routing::get(crate::probe::ready_handler::<AppState>),
-        );
-    }
-    if mounted_probe_paths.insert(config.health.startup_path.clone()) {
-        router = router.route(
-            &config.health.startup_path,
-            axum::routing::get(crate::probe::startup_handler::<AppState>),
-        );
-    }
-    if mounted_probe_paths.insert(config.health.path.clone()) {
-        router = router.route(
-            &config.health.path,
-            axum::routing::get(crate::health::handler::<AppState>),
-        );
-    }
+    let mut mount_probe = |mut router: axum::Router<S>,
+                           path: &str,
+                           label: &'static str,
+                           handler: axum::routing::MethodRouter<S>|
+     -> axum::Router<S> {
+        if user_get_paths.contains(path) {
+            tracing::info!(
+                probe = label,
+                path,
+                "a user route already owns this path; the built-in probe was \
+                 not auto-mounted (the user handler wins)"
+            );
+            return router;
+        }
+        if mounted_probe_paths.insert(path.to_owned()) {
+            router = router.route(path, handler);
+        }
+        router
+    };
+
+    router = mount_probe(
+        router,
+        &config.health.live_path,
+        "liveness",
+        axum::routing::get(crate::probe::live_handler::<AppState>),
+    );
+    router = mount_probe(
+        router,
+        &config.health.ready_path,
+        "readiness",
+        axum::routing::get(crate::probe::ready_handler::<AppState>),
+    );
+    router = mount_probe(
+        router,
+        &config.health.startup_path,
+        "startup",
+        axum::routing::get(crate::probe::startup_handler::<AppState>),
+    );
+    router = mount_probe(
+        router,
+        &config.health.path,
+        "health",
+        axum::routing::get(crate::health::handler::<AppState>),
+    );
     tracing::debug!(
         health = %config.health.path,
         live = %config.health.live_path,
@@ -4457,6 +4525,81 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// Issue #1971: a user route registered at the auto-mounted health path
+    /// must WIN. The router build succeeds — no raw axum "Overlapping method
+    /// route. Handler for GET /health already exists" panic — the user's own
+    /// handler serves `/health`, and the remaining built-in probes (`/live`,
+    /// `/ready`, `/startup`) still mount and respond.
+    #[tokio::test]
+    async fn user_route_at_health_path_overrides_builtin_probe() {
+        async fn user_health() -> &'static str {
+            "user-health-handler"
+        }
+
+        let config = AutumnConfig::default();
+        // Precondition: the default health alias is exactly the path we shadow.
+        assert_eq!(config.health.path, "/health");
+
+        let route = Route {
+            method: http::Method::GET,
+            path: "/health",
+            handler: axum::routing::get(user_health),
+            name: "user_health",
+            api_doc: crate::openapi::ApiDoc {
+                method: "GET",
+                path: "/health",
+                operation_id: "user_health",
+                success_status: 200,
+                ..Default::default()
+            },
+            repository: None,
+            idempotency: crate::route::RouteIdempotency::Direct,
+            timeout: crate::route::RouteTimeout::Inherit,
+            api_version: None,
+            sunset_opt_out: false,
+        };
+
+        // Before the fix this panicked inside `axum::Router::route`; now it
+        // builds cleanly (`build_router` panics on any RouterBuildError, so a
+        // successful return also proves no structured error is raised).
+        let app = build_router(vec![route], &config, test_state());
+
+        // `/health` is served by the USER handler, not the framework probe.
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(
+            &body[..],
+            b"user-health-handler",
+            "user route must win at the health path"
+        );
+
+        // The other built-in probes are untouched and still respond.
+        for path in ["/live", "/ready", "/startup"] {
+            let resp = app
+                .clone()
+                .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_ne!(
+                resp.status(),
+                StatusCode::NOT_FOUND,
+                "built-in probe {path} should still be mounted"
+            );
+        }
     }
 
     /// The framework-owned widget stylesheet (#1215) is served the same way


### PR DESCRIPTION
## Before / after

**Before** — an app that already hand-wrote its own `GET /health` (or `/live` / `/ready` / `/startup`) route aborted at startup with axum's raw panic:

```
Overlapping method route. Handler for GET /health already exists
```

That message names none of the builder's code and gives no hint that autumn's own auto-mounted compatibility probe is the other party. The only workaround was to discover that `health.path` exists and re-point it (e.g. to `/healthz`).

**After** — the app boots. The auto-mounted probe **yields to the user's handler** at that path (a builder who hand-writes `GET /health` clearly wants their own handler), logs an `INFO` that the built-in was overridden, and serves the user handler. The other built-in probes are unaffected.

This closes the last remaining direction of a failure mode the framework already handles everywhere else: `RouterBuildError::FrameworkRouteOverlap` (probe-vs-actuator) and the OpenAPI/MCP mount preflights both already reserve `health.path`. Only the user-route-vs-auto-mounted-probe direction still fell through to the axum panic.

## How

- `mount_probe_endpoints` now receives the set of `GET`/`WS` paths owned by the *typed* user route table. For each probe (`live` / `ready` / `startup` / `health`), if a user route already owns that exact path the built-in is skipped (and an `info!` override line is logged) instead of calling `Router::route` a second time on the same `GET`.
- New `collect_user_get_paths(route_list, scoped_groups)` gathers those paths (top-level + scope-prefixed group routes; a `WS` route mounts as a `GET`, so it counts). It is captured in `build_router_pre_state` **before** `group_and_mount_routes` consumes the route list. The worker probe-only router passes an empty set (it serves no user routes).
- Deliberately mirrors the existing OpenAPI/MCP preflight limitation: opaque routers registered via `AppBuilder::merge`/`nest` aren't introspectable and so aren't covered (unchanged behavior for that escape hatch).

This implements option 1 (“let the user route win”) — the maintainer's stated first preference — which fully resolves the reported startup panic.

## Tests

Added `router::tests::user_route_at_health_path_overrides_builtin_probe`: builds a full router with a user `GET /health`, asserts the build succeeds (no panic), that `/health` is served by the user handler, and that `/live` / `/ready` / `/startup` still mount. `cargo test -p autumn-web` passes; the existing `probe_only_router_mounts_probes_and_actuator_but_no_user_routes` still passes. `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` are clean.

## Deferred (why "Part of", not "Closes")

The issue also suggests, as optional additions, (a) option 2 — raising a named `RouterBuildError` instead of letting the user win — and (b) a `health.enabled = false` / per-path opt-out on `HealthConfig` so single-purpose apps can drop the built-ins entirely. Neither is required to resolve the reported startup panic, and the `enabled` flag is an additive config surface (env override + smart defaults + drift tests); both are left as follow-ups.

Part of #1971

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1kjhJB6QjfaNMMjKhtDfb)_