### PR TITLE
SQLite runtime lane PR1: RuntimeConnection alias + sqlite feature (no-op refactor)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ pq-sys = { version = "0.7", features = ["bundled_without_openssl"] }
 # diesel_migrations) over an async connection — used to run startup
 # migrations and wait checks through the rustls TLS connector, since the
 # bundled libpq (`pq-sys` below) has no SSL support.
-diesel-async = { version = "0.9", features = ["deadpool", "postgres", "async-connection-wrapper"] }
+diesel-async = { version = "0.9", features = ["deadpool", "postgres", "async-connection-wrapper", "sync-connection-wrapper"] }
 diesel_migrations = "2"
 http = "1"
 libsqlite3-sys = { version = "0.37", features = ["bundled"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ pq-sys = { version = "0.7", features = ["bundled_without_openssl"] }
 # diesel_migrations) over an async connection — used to run startup
 # migrations and wait checks through the rustls TLS connector, since the
 # bundled libpq (`pq-sys` below) has no SSL support.
-diesel-async = { version = "0.9", features = ["deadpool", "postgres", "async-connection-wrapper", "sync-connection-wrapper"] }
+diesel-async = { version = "0.9", features = ["deadpool", "postgres", "async-connection-wrapper"] }
 diesel_migrations = "2"
 http = "1"
 libsqlite3-sys = { version = "0.37", features = ["bundled"] }

--- a/autumn-admin-plugin/src/traits.rs
+++ b/autumn-admin-plugin/src/traits.rs
@@ -429,28 +429,28 @@ pub trait AdminModel: Send + Sync + 'static {
     /// List records with pagination, search, sort, and filters.
     fn list(
         &self,
-        pool: &diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::db::RuntimeConnection>,
         params: ListParams,
     ) -> AdminFuture<'_, ListResult>;
 
     /// Get a single record by ID.
     fn get(
         &self,
-        pool: &diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::db::RuntimeConnection>,
         id: i64,
     ) -> AdminFuture<'_, Option<Value>>;
 
     /// Create a new record from form data.
     fn create(
         &self,
-        pool: &diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::db::RuntimeConnection>,
         data: Value,
     ) -> AdminFuture<'_, Value>;
 
     /// Update an existing record.
     fn update(
         &self,
-        pool: &diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::db::RuntimeConnection>,
         id: i64,
         data: Value,
     ) -> AdminFuture<'_, Value>;
@@ -458,7 +458,7 @@ pub trait AdminModel: Send + Sync + 'static {
     /// Delete a record by ID.
     fn delete(
         &self,
-        pool: &diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::db::RuntimeConnection>,
         id: i64,
     ) -> AdminFuture<'_, ()>;
 
@@ -475,7 +475,9 @@ pub trait AdminModel: Send + Sync + 'static {
     /// `false`, so models that opt in must override this method.
     fn restore<'a>(
         &'a self,
-        _pool: &'a diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        _pool: &'a diesel_async::pooled_connection::deadpool::Pool<
+            ::autumn_web::db::RuntimeConnection,
+        >,
         _id: i64,
     ) -> AdminFuture<'a, ()> {
         Box::pin(async move {
@@ -493,7 +495,9 @@ pub trait AdminModel: Send + Sync + 'static {
     /// `false`.
     fn purge<'a>(
         &'a self,
-        _pool: &'a diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        _pool: &'a diesel_async::pooled_connection::deadpool::Pool<
+            ::autumn_web::db::RuntimeConnection,
+        >,
         _id: i64,
     ) -> AdminFuture<'a, ()> {
         Box::pin(async move {
@@ -511,7 +515,9 @@ pub trait AdminModel: Send + Sync + 'static {
     /// `false`.
     fn list_deleted<'a>(
         &'a self,
-        _pool: &'a diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        _pool: &'a diesel_async::pooled_connection::deadpool::Pool<
+            ::autumn_web::db::RuntimeConnection,
+        >,
         _params: ListParams,
     ) -> AdminFuture<'a, ListResult> {
         Box::pin(async move {
@@ -526,7 +532,7 @@ pub trait AdminModel: Send + Sync + 'static {
     /// Execute a bulk action on the given IDs.
     fn execute_action(
         &self,
-        pool: &diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::db::RuntimeConnection>,
         action: &str,
         ids: Vec<i64>,
     ) -> AdminFuture<'_, u64> {
@@ -596,7 +602,7 @@ pub trait AdminModel: Send + Sync + 'static {
     /// Override if the backend can count without materializing records.
     fn count(
         &self,
-        pool: &diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::db::RuntimeConnection>,
     ) -> AdminFuture<'_, u64> {
         let params = ListParams {
             page: 1,
@@ -689,7 +695,9 @@ pub trait AdminModel: Send + Sync + 'static {
     /// [`supports_csv_import`]: AdminModel::supports_csv_import
     fn import_csv_row<'a>(
         &'a self,
-        _pool: &'a diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        _pool: &'a diesel_async::pooled_connection::deadpool::Pool<
+            ::autumn_web::db::RuntimeConnection,
+        >,
         _line: u64,
         _row: std::collections::HashMap<String, String>,
         _mode: CsvImportMode,
@@ -711,7 +719,9 @@ pub trait AdminModel: Send + Sync + 'static {
     /// that do not opt in get a clear error instead of a silent no-op.
     fn get_history<'a>(
         &'a self,
-        _pool: &'a diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        _pool: &'a diesel_async::pooled_connection::deadpool::Pool<
+            ::autumn_web::db::RuntimeConnection,
+        >,
         _record_id: i64,
         _page: u64,
         _per_page: u64,

--- a/autumn-admin-plugin/src/traits.rs
+++ b/autumn-admin-plugin/src/traits.rs
@@ -429,28 +429,28 @@ pub trait AdminModel: Send + Sync + 'static {
     /// List records with pagination, search, sort, and filters.
     fn list(
         &self,
-        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::db::RuntimeConnection>,
+        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::RuntimeConnection>,
         params: ListParams,
     ) -> AdminFuture<'_, ListResult>;
 
     /// Get a single record by ID.
     fn get(
         &self,
-        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::db::RuntimeConnection>,
+        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::RuntimeConnection>,
         id: i64,
     ) -> AdminFuture<'_, Option<Value>>;
 
     /// Create a new record from form data.
     fn create(
         &self,
-        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::db::RuntimeConnection>,
+        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::RuntimeConnection>,
         data: Value,
     ) -> AdminFuture<'_, Value>;
 
     /// Update an existing record.
     fn update(
         &self,
-        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::db::RuntimeConnection>,
+        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::RuntimeConnection>,
         id: i64,
         data: Value,
     ) -> AdminFuture<'_, Value>;
@@ -458,7 +458,7 @@ pub trait AdminModel: Send + Sync + 'static {
     /// Delete a record by ID.
     fn delete(
         &self,
-        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::db::RuntimeConnection>,
+        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::RuntimeConnection>,
         id: i64,
     ) -> AdminFuture<'_, ()>;
 
@@ -475,9 +475,7 @@ pub trait AdminModel: Send + Sync + 'static {
     /// `false`, so models that opt in must override this method.
     fn restore<'a>(
         &'a self,
-        _pool: &'a diesel_async::pooled_connection::deadpool::Pool<
-            ::autumn_web::db::RuntimeConnection,
-        >,
+        _pool: &'a diesel_async::pooled_connection::deadpool::Pool<::autumn_web::RuntimeConnection>,
         _id: i64,
     ) -> AdminFuture<'a, ()> {
         Box::pin(async move {
@@ -495,9 +493,7 @@ pub trait AdminModel: Send + Sync + 'static {
     /// `false`.
     fn purge<'a>(
         &'a self,
-        _pool: &'a diesel_async::pooled_connection::deadpool::Pool<
-            ::autumn_web::db::RuntimeConnection,
-        >,
+        _pool: &'a diesel_async::pooled_connection::deadpool::Pool<::autumn_web::RuntimeConnection>,
         _id: i64,
     ) -> AdminFuture<'a, ()> {
         Box::pin(async move {
@@ -515,9 +511,7 @@ pub trait AdminModel: Send + Sync + 'static {
     /// `false`.
     fn list_deleted<'a>(
         &'a self,
-        _pool: &'a diesel_async::pooled_connection::deadpool::Pool<
-            ::autumn_web::db::RuntimeConnection,
-        >,
+        _pool: &'a diesel_async::pooled_connection::deadpool::Pool<::autumn_web::RuntimeConnection>,
         _params: ListParams,
     ) -> AdminFuture<'a, ListResult> {
         Box::pin(async move {
@@ -532,7 +526,7 @@ pub trait AdminModel: Send + Sync + 'static {
     /// Execute a bulk action on the given IDs.
     fn execute_action(
         &self,
-        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::db::RuntimeConnection>,
+        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::RuntimeConnection>,
         action: &str,
         ids: Vec<i64>,
     ) -> AdminFuture<'_, u64> {
@@ -602,7 +596,7 @@ pub trait AdminModel: Send + Sync + 'static {
     /// Override if the backend can count without materializing records.
     fn count(
         &self,
-        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::db::RuntimeConnection>,
+        pool: &diesel_async::pooled_connection::deadpool::Pool<::autumn_web::RuntimeConnection>,
     ) -> AdminFuture<'_, u64> {
         let params = ListParams {
             page: 1,
@@ -695,9 +689,7 @@ pub trait AdminModel: Send + Sync + 'static {
     /// [`supports_csv_import`]: AdminModel::supports_csv_import
     fn import_csv_row<'a>(
         &'a self,
-        _pool: &'a diesel_async::pooled_connection::deadpool::Pool<
-            ::autumn_web::db::RuntimeConnection,
-        >,
+        _pool: &'a diesel_async::pooled_connection::deadpool::Pool<::autumn_web::RuntimeConnection>,
         _line: u64,
         _row: std::collections::HashMap<String, String>,
         _mode: CsvImportMode,
@@ -719,9 +711,7 @@ pub trait AdminModel: Send + Sync + 'static {
     /// that do not opt in get a clear error instead of a silent no-op.
     fn get_history<'a>(
         &'a self,
-        _pool: &'a diesel_async::pooled_connection::deadpool::Pool<
-            ::autumn_web::db::RuntimeConnection,
-        >,
+        _pool: &'a diesel_async::pooled_connection::deadpool::Pool<::autumn_web::RuntimeConnection>,
         _record_id: i64,
         _page: u64,
         _per_page: u64,

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -479,9 +479,9 @@ fn emit_dependents_impl(model_ident: &syn::Ident, assocs: &[Association]) -> Tok
         thunk_fns.push(quote! {
             fn #thunk_ident<'__a>(
                 __pool: &'__a ::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Pool<
-                    ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                    ::autumn_web::RuntimeConnection,
                 >,
-                __conn: &'__a mut ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                __conn: &'__a mut ::autumn_web::RuntimeConnection,
                 __parent_id: i64,
                 __parent_soft: bool,
                 // Codex round-5-B: the active recursion path (cycle-break) and the
@@ -1163,7 +1163,7 @@ fn emit_association_items(
             fn load_associations<'__a>(
                 records: &'__a mut [::autumn_web::preload::Preloaded<Self>],
                 spec: &'__a Self::Spec,
-                conn: &'__a mut ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                conn: &'__a mut ::autumn_web::RuntimeConnection,
             ) -> ::autumn_web::preload::PreloadFuture<'__a> {
                 ::std::boxed::Box::pin(async move {
                     #[allow(unused_imports)]
@@ -4152,7 +4152,7 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             pub async fn create(
                 self,
                 pool: &::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Pool<
-                    ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                    ::autumn_web::RuntimeConnection,
                 >,
             ) -> #name {
                 let __depth = ::autumn_web::__private::FACTORY_DEPTH
@@ -4178,7 +4178,7 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             pub async fn create(
                 self,
                 pool: &::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Pool<
-                    ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                    ::autumn_web::RuntimeConnection,
                 >,
             ) -> #name {
                 #create_inner_body
@@ -4202,7 +4202,7 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             self,
             count: usize,
             pool: &::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Pool<
-                ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                ::autumn_web::RuntimeConnection,
             >,
         ) -> ::std::vec::Vec<#name> {
             let mut out = ::std::vec::Vec::with_capacity(count);
@@ -4800,7 +4800,7 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             pub async fn __autumn_execute_upsert(
                 chunk: &[Self],
                 tenant_id: ::core::option::Option<&str>,
-                conn: &mut ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                conn: &mut ::autumn_web::RuntimeConnection,
             ) -> ::core::result::Result<::std::vec::Vec<Self>, ::autumn_web::reexports::diesel::result::Error> {
                 use ::autumn_web::reexports::diesel::prelude::*;
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl;
@@ -4868,7 +4868,7 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             async fn __autumn_execute_upsert(
                 chunk: &[Self::Model],
                 tenant_id: ::core::option::Option<&str>,
-                conn: &mut ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                conn: &mut ::autumn_web::RuntimeConnection,
             ) -> ::core::result::Result<::std::vec::Vec<Self::Model>, ::autumn_web::reexports::diesel::result::Error> {
                 Self::__autumn_execute_upsert(chunk, tenant_id, conn).await
             }

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1683,7 +1683,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             #[allow(clippy::too_many_arguments)]
             pub fn __autumn_apply_dependent_on_conn<'__dep>(
                 &'__dep self,
-                conn: &'__dep mut ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                conn: &'__dep mut ::autumn_web::RuntimeConnection,
                 __fk_column: &'__dep str,
                 __parent_id: i64,
                 __action: ::autumn_web::repository::DependentAction,
@@ -2967,7 +2967,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 &self,
             ) -> ::autumn_web::AutumnResult<
                 ::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Object<
-                    ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                    ::autumn_web::RuntimeConnection,
                 >,
             > {
                 self.__autumn_acquire_conn().await
@@ -3049,7 +3049,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 #[must_use]
                 pub fn __autumn_test_with_broadcast(
                     pool: ::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Pool<
-                        ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                        ::autumn_web::RuntimeConnection,
                     >,
                     broadcast: ::autumn_web::channels::Broadcast,
                 ) -> Self {
@@ -3126,7 +3126,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             #[must_use]
             pub fn with_pool_untracked(
                 pool: ::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Pool<
-                    ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                    ::autumn_web::RuntimeConnection,
                 >,
             ) -> Self {
                 #register_hooks
@@ -3197,7 +3197,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         let struct_fields = quote! {
             pool: ::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Pool<
-                ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                ::autumn_web::RuntimeConnection,
             >,
             hooks: #hooks_ident,
             #idempotency_struct_field
@@ -6794,7 +6794,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         let struct_fields = quote! {
             pool: ::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Pool<
-                ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                ::autumn_web::RuntimeConnection,
             >,
             #tenant_struct_field
             #shards_struct_field
@@ -14551,7 +14551,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             pub fn __autumn_write_pool(
                 &self,
             ) -> &::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Pool<
-                ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                ::autumn_web::RuntimeConnection,
             > {
                 &self.pool
             }
@@ -14578,7 +14578,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 &self,
             ) -> ::autumn_web::AutumnResult<
                 ::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Object<
-                    ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                    ::autumn_web::RuntimeConnection,
                 >,
             > {
                 let result = self.__autumn_acquire_from(&self.pool).await;
@@ -14600,7 +14600,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 &self,
             ) -> ::autumn_web::AutumnResult<
                 ::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Object<
-                    ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                    ::autumn_web::RuntimeConnection,
                 >,
             > {
                 // Match by reference to avoid cloning `ReadRoute` on the common
@@ -14637,11 +14637,11 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             async fn __autumn_acquire_from(
                 &self,
                 pool: &::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Pool<
-                    ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                    ::autumn_web::RuntimeConnection,
                 >,
             ) -> ::autumn_web::AutumnResult<
                 ::autumn_web::reexports::diesel_async::pooled_connection::deadpool::Object<
-                    ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                    ::autumn_web::RuntimeConnection,
                 >,
             > {
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl as _;
@@ -14690,7 +14690,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             where
                 F: for<'c> ::core::ops::FnOnce(
                     #model_name,
-                    &'c mut ::autumn_web::reexports::diesel_async::AsyncPgConnection,
+                    &'c mut ::autumn_web::RuntimeConnection,
                 ) -> ::autumn_web::reexports::scoped_futures::ScopedBoxFuture<'c, 'c, ::autumn_web::AutumnResult<T>>
                     + ::core::marker::Send + 'static,
                 T: ::core::marker::Send + 'static,

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -81,7 +81,7 @@ offline-sync = ["db", "http-client"]
 # (`PoolError::UnsupportedBackend`); a working pool is PR2. Needs no extra deps
 # — diesel's sqlite backend and diesel-async's sync-connection-wrapper are
 # already in the graph.
-sqlite = []
+sqlite = ["diesel/sqlite", "diesel-async/sync-connection-wrapper"]
 test-support = ["dep:testcontainers", "dep:testcontainers-modules"]
 telemetry-otlp = [
     "dep:opentelemetry",

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -61,6 +61,27 @@ db = [
 # compile (diesel's sqlite backend and the bundled libsqlite3-sys are
 # already in the graph) — zero new dependencies.
 offline-sync = ["db", "http-client"]
+# SQLite runtime lane (issue #1614). Flips the `db::RuntimeConnection` alias
+# from Postgres (`AsyncPgConnection`) to a SQLite connection
+# (`SyncConnectionWrapper<SqliteConnection>`) for the whole build graph.
+#
+# ⚠️ FEATURE-UNIFICATION HAZARD — READ BEFORE ADDING ANY EDGE ⚠️
+# This feature must ONLY ever be enabled by an END APPLICATION or an explicit
+# `--features sqlite` build invocation. It must NEVER be enabled by an
+# inter-crate dependency edge or a dev-dependency anywhere in the workspace
+# (e.g. `autumn-web = { ..., features = ["sqlite"] }` in autumn-cli /
+# autumn-admin-plugin / autumn-macros / examples/*, or an autumn-web
+# dev-dependency). Cargo feature unification is global: a single such edge
+# flips `RuntimeConnection` to SQLite for EVERY consumer in the graph and
+# breaks the Postgres default build. Feature-on testing is done via explicit
+# `cargo build -p autumn-web --features sqlite` invocations only.
+#
+# PR1 is a no-op refactor: enabling it switches the connection *type alias* but
+# the SQLite pool CONSTRUCTION stays refused at runtime
+# (`PoolError::UnsupportedBackend`); a working pool is PR2. Needs no extra deps
+# — diesel's sqlite backend and diesel-async's sync-connection-wrapper are
+# already in the graph.
+sqlite = []
 test-support = ["dep:testcontainers", "dep:testcontainers-modules"]
 telemetry-otlp = [
     "dep:opentelemetry",

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -46,7 +46,7 @@ use crate::error::AutumnError;
 /// The database connection type the runtime is built against.
 ///
 /// Defaults to Postgres (`AsyncPgConnection`). Enabling the crate's `sqlite`
-/// feature flips it to a SQLite connection. Threading this alias (instead of a
+/// feature flips it to a `SQLite` connection. Threading this alias (instead of a
 /// hard-coded `AsyncPgConnection`) through the connection-typed surface — the
 /// pool, the pooled connection, the transaction/query helpers, and the
 /// `#[repository]`/`#[model]` generated code — is what lets the same codebase
@@ -60,7 +60,7 @@ use crate::error::AutumnError;
 #[cfg(not(feature = "sqlite"))]
 pub type RuntimeConnection = diesel_async::AsyncPgConnection;
 /// See [`RuntimeConnection`] (Postgres variant) for the full contract. Under
-/// the `sqlite` feature the runtime is built against a SQLite connection.
+/// the `sqlite` feature the runtime is built against a `SQLite` connection.
 #[cfg(feature = "sqlite")]
 pub type RuntimeConnection =
     diesel_async::sync_connection_wrapper::SyncConnectionWrapper<diesel::SqliteConnection>;

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -43,6 +43,28 @@ use tracing::Instrument as _;
 use crate::config::DatabaseConfig;
 use crate::error::AutumnError;
 
+/// The database connection type the runtime is built against.
+///
+/// Defaults to Postgres (`AsyncPgConnection`). Enabling the crate's `sqlite`
+/// feature flips it to a SQLite connection. Threading this alias (instead of a
+/// hard-coded `AsyncPgConnection`) through the connection-typed surface — the
+/// pool, the pooled connection, the transaction/query helpers, and the
+/// `#[repository]`/`#[model]` generated code — is what lets the same codebase
+/// target either backend.
+///
+/// FEATURE-UNIFICATION HAZARD: the `sqlite` feature must ONLY be enabled by an
+/// end application (or an explicit `--features sqlite` build). If any workspace
+/// crate or dev-dependency enables it, cargo feature unification flips this
+/// alias for every consumer in the graph and breaks the Postgres default. See
+/// the doc comment above `sqlite = []` in `autumn/Cargo.toml`.
+#[cfg(not(feature = "sqlite"))]
+pub type RuntimeConnection = diesel_async::AsyncPgConnection;
+/// See [`RuntimeConnection`] (Postgres variant) for the full contract. Under
+/// the `sqlite` feature the runtime is built against a SQLite connection.
+#[cfg(feature = "sqlite")]
+pub type RuntimeConnection =
+    diesel_async::sync_connection_wrapper::SyncConnectionWrapper<diesel::SqliteConnection>;
+
 // ── After-commit callback infrastructure ─────────────────────────────────────
 
 /// A boxed async callback registered for post-transaction execution.
@@ -558,7 +580,7 @@ where
 /// and the central `AppState`.
 pub trait DbState {
     /// Returns the database connection pool, if configured.
-    fn pool(&self) -> Option<&Pool<AsyncPgConnection>>;
+    fn pool(&self) -> Option<&Pool<RuntimeConnection>>;
 
     /// Returns the metrics collector, if configured.
     fn metrics(&self) -> Option<&crate::middleware::MetricsCollector> {
@@ -566,14 +588,14 @@ pub trait DbState {
     }
 
     /// Returns the read/replica connection pool, if configured.
-    fn replica_pool(&self) -> Option<&Pool<AsyncPgConnection>> {
+    fn replica_pool(&self) -> Option<&Pool<RuntimeConnection>> {
         None
     }
 
     /// Returns the pool used for read-only work.
     ///
     /// Defaults to the replica role when present, otherwise the primary role.
-    fn read_pool(&self) -> Option<&Pool<AsyncPgConnection>> {
+    fn read_pool(&self) -> Option<&Pool<RuntimeConnection>> {
         self.replica_pool().or_else(|| self.pool())
     }
 
@@ -973,8 +995,8 @@ pub enum PoolError {
 /// Primary plus optional read-replica database pools.
 #[derive(Clone)]
 pub struct DatabaseTopology {
-    primary: Pool<AsyncPgConnection>,
-    replica: Option<Pool<AsyncPgConnection>>,
+    primary: Pool<RuntimeConnection>,
+    replica: Option<Pool<RuntimeConnection>>,
     /// Connection URL to target with startup migrations, when the provider
     /// resolved one at runtime that the static config doesn't carry (e.g. the
     /// managed-Postgres provider whose socket URL is only known after boot).
@@ -989,8 +1011,8 @@ impl DatabaseTopology {
     /// need to create or decorate both roles themselves.
     #[must_use]
     pub const fn from_pools(
-        primary: Pool<AsyncPgConnection>,
-        replica: Option<Pool<AsyncPgConnection>>,
+        primary: Pool<RuntimeConnection>,
+        replica: Option<Pool<RuntimeConnection>>,
     ) -> Self {
         Self {
             primary,
@@ -1001,7 +1023,7 @@ impl DatabaseTopology {
 
     /// Build a topology from a primary pool only.
     #[must_use]
-    pub const fn primary_only(primary: Pool<AsyncPgConnection>) -> Self {
+    pub const fn primary_only(primary: Pool<RuntimeConnection>) -> Self {
         Self {
             primary,
             replica: None,
@@ -1029,19 +1051,19 @@ impl DatabaseTopology {
 
     /// Primary/write role pool.
     #[must_use]
-    pub const fn primary(&self) -> &Pool<AsyncPgConnection> {
+    pub const fn primary(&self) -> &Pool<RuntimeConnection> {
         &self.primary
     }
 
     /// Optional read/replica role pool.
     #[must_use]
-    pub const fn replica(&self) -> Option<&Pool<AsyncPgConnection>> {
+    pub const fn replica(&self) -> Option<&Pool<RuntimeConnection>> {
         self.replica.as_ref()
     }
 
     /// Pool used for read-only work.
     #[must_use]
-    pub fn read(&self) -> &Pool<AsyncPgConnection> {
+    pub fn read(&self) -> &Pool<RuntimeConnection> {
         self.replica.as_ref().unwrap_or(&self.primary)
     }
 }
@@ -1050,7 +1072,7 @@ fn build_pool(
     url: &str,
     pool_size: usize,
     connect_timeout_secs: u64,
-) -> Result<Pool<AsyncPgConnection>, PoolError> {
+) -> Result<Pool<RuntimeConnection>, PoolError> {
     // A SQLite target is recognized (issue #1614) but the runtime pool that
     // would serve it is not wired into this build yet — the pool below is a
     // Postgres pool (`Pool<AsyncPgConnection>`). Refuse here, at pool-build
@@ -1065,28 +1087,48 @@ fn build_pool(
         )));
     }
 
-    let timeout = Duration::from_secs(connect_timeout_secs);
-    // When the URL's `sslmode` asks for TLS, plug a rustls-backed connector
-    // into the pool via a custom setup callback — diesel-async's default
-    // establish path hardcodes `NoTls`, which cannot satisfy
-    // `sslmode=require` at all. `sslmode` absent/`disable`/`prefer` keeps the
-    // default (NoTls) path, so existing configurations behave exactly as
-    // before. See [`tls`] for the full posture table.
-    let manager = match tls::TlsPosture::from_database_url(url) {
-        tls::TlsPosture::Off => AsyncDieselConnectionManager::<AsyncPgConnection>::new(url),
-        posture => {
-            let mut config =
-                diesel_async::pooled_connection::ManagerConfig::<AsyncPgConnection>::default();
-            config.custom_setup = tls::setup_callback(posture);
-            AsyncDieselConnectionManager::<AsyncPgConnection>::new_with_config(url, config)
-        }
-    };
-    Ok(Pool::builder(manager)
-        .max_size(pool_size.max(1))
-        .wait_timeout(Some(timeout))
-        .create_timeout(Some(timeout))
-        .runtime(deadpool::Runtime::Tokio1)
-        .build()?)
+    // Under the `sqlite` feature `RuntimeConnection` is a SQLite connection, so
+    // the Postgres pool/manager built below does not type-check against
+    // `Pool<RuntimeConnection>` — and, per PR1 (issue #1614), no SQLite runtime
+    // pool is wired yet. Refuse all pool construction here so the alias can flip
+    // without a working backend; the real SQLite pool is PR2. This keeps the
+    // "SQLite pool construction stays refused at runtime" guarantee while
+    // letting the feature-on build compile.
+    #[cfg(feature = "sqlite")]
+    {
+        let _ = (pool_size, connect_timeout_secs);
+        return Err(PoolError::UnsupportedBackend(format!(
+            "the SQLite runtime pool is not yet wired into this build of \
+             autumn-web (built with --features sqlite); follow \
+             https://github.com/madmax983/autumn/issues/1905 for status (target: {url:?})"
+        )));
+    }
+
+    #[cfg(not(feature = "sqlite"))]
+    {
+        let timeout = Duration::from_secs(connect_timeout_secs);
+        // When the URL's `sslmode` asks for TLS, plug a rustls-backed connector
+        // into the pool via a custom setup callback — diesel-async's default
+        // establish path hardcodes `NoTls`, which cannot satisfy
+        // `sslmode=require` at all. `sslmode` absent/`disable`/`prefer` keeps the
+        // default (NoTls) path, so existing configurations behave exactly as
+        // before. See [`tls`] for the full posture table.
+        let manager = match tls::TlsPosture::from_database_url(url) {
+            tls::TlsPosture::Off => AsyncDieselConnectionManager::<AsyncPgConnection>::new(url),
+            posture => {
+                let mut config =
+                    diesel_async::pooled_connection::ManagerConfig::<AsyncPgConnection>::default();
+                config.custom_setup = tls::setup_callback(posture);
+                AsyncDieselConnectionManager::<AsyncPgConnection>::new_with_config(url, config)
+            }
+        };
+        Ok(Pool::builder(manager)
+            .max_size(pool_size.max(1))
+            .wait_timeout(Some(timeout))
+            .create_timeout(Some(timeout))
+            .runtime(deadpool::Runtime::Tokio1)
+            .build()?)
+    }
 }
 
 /// Create a connection pool from the database configuration.
@@ -1099,7 +1141,7 @@ fn build_pool(
 ///
 /// Returns [`PoolError`] if the pool cannot be built (e.g., invalid
 /// max-size configuration).
-pub fn create_pool(config: &DatabaseConfig) -> Result<Option<Pool<AsyncPgConnection>>, PoolError> {
+pub fn create_pool(config: &DatabaseConfig) -> Result<Option<Pool<RuntimeConnection>>, PoolError> {
     let Some(url) = config.effective_primary_url() else {
         return Ok(None);
     };
@@ -1572,7 +1614,7 @@ where
 // ── Db extractor ─────────────────────────────────────────────
 
 /// Connection type managed by the deadpool pool.
-pub type PooledConnection = diesel_async::pooled_connection::deadpool::Object<AsyncPgConnection>;
+pub type PooledConnection = diesel_async::pooled_connection::deadpool::Object<RuntimeConnection>;
 
 struct TxDepthGuard<'a> {
     depth: &'a mut usize,
@@ -1970,7 +2012,7 @@ impl Db {
 }
 
 impl std::ops::Deref for Db {
-    type Target = AsyncPgConnection;
+    type Target = RuntimeConnection;
     fn deref(&self) -> &Self::Target {
         assert!(
             !self.tx_poisoned,
@@ -1997,7 +2039,7 @@ impl std::ops::DerefMut for Db {
 /// span, interceptor, statement-timeout, and slow-query treatment.
 pub(crate) struct DbCheckoutParams<'a> {
     /// Pool to check the connection out of.
-    pub pool: &'a Pool<AsyncPgConnection>,
+    pub pool: &'a Pool<RuntimeConnection>,
     /// Role label surfaced to [`DbConnectionInterceptor`]s, e.g. `"primary"`
     /// or `"shard:<name>:primary"`.
     pub pool_name: &'a str,
@@ -2144,7 +2186,7 @@ impl Db {
     ///
     /// Returns [`AutumnError`] if a connection cannot be acquired from `pool`.
     #[cfg(feature = "test-support")]
-    pub async fn connect_for_test(pool: &Pool<AsyncPgConnection>) -> Result<Self, AutumnError> {
+    pub async fn connect_for_test(pool: &Pool<RuntimeConnection>) -> Result<Self, AutumnError> {
         Self::checkout(DbCheckoutParams {
             pool,
             pool_name: "test",
@@ -2311,7 +2353,7 @@ pub trait DatabasePoolProvider: Send + Sync + 'static {
     fn create_pool(
         &self,
         config: &DatabaseConfig,
-    ) -> impl std::future::Future<Output = Result<Option<Pool<AsyncPgConnection>>, PoolError>> + Send;
+    ) -> impl std::future::Future<Output = Result<Option<Pool<RuntimeConnection>>, PoolError>> + Send;
 
     /// Create primary and optional replica pools from the resolved
     /// [`DatabaseConfig`].
@@ -2386,7 +2428,7 @@ impl DatabasePoolProvider for DieselDeadpoolPoolProvider {
     async fn create_pool(
         &self,
         config: &DatabaseConfig,
-    ) -> Result<Option<Pool<AsyncPgConnection>>, PoolError> {
+    ) -> Result<Option<Pool<RuntimeConnection>>, PoolError> {
         create_pool(config)
     }
 }

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -586,7 +586,7 @@ pub use db::Db;
 #[cfg(feature = "db")]
 pub use db::{IsolationLevel, TxOptions, savepoint};
 
-/// The runtime database connection type (Postgres by default; SQLite under the
+/// The runtime database connection type (Postgres by default; `SQLite` under the
 /// `sqlite` feature). Named by generated `#[repository]`/`#[model]` code as
 /// `::autumn_web::RuntimeConnection`. See [`db::RuntimeConnection`].
 #[cfg(feature = "db")]

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -586,6 +586,12 @@ pub use db::Db;
 #[cfg(feature = "db")]
 pub use db::{IsolationLevel, TxOptions, savepoint};
 
+/// The runtime database connection type (Postgres by default; SQLite under the
+/// `sqlite` feature). Named by generated `#[repository]`/`#[model]` code as
+/// `::autumn_web::RuntimeConnection`. See [`db::RuntimeConnection`].
+#[cfg(feature = "db")]
+pub use db::RuntimeConnection;
+
 /// Framework error type and result alias.
 ///
 /// [`AutumnError`] wraps any `Error + Send + Sync` with an HTTP status code.

--- a/autumn/src/seed.rs
+++ b/autumn/src/seed.rs
@@ -58,8 +58,8 @@
 use std::path::Path;
 
 use crate::config::DatabaseConfig;
+use crate::db::RuntimeConnection;
 use crate::db::create_pool;
-use diesel_async::AsyncPgConnection;
 use diesel_async::pooled_connection::deadpool::{Object, Pool};
 use futures::future::BoxFuture;
 
@@ -100,7 +100,7 @@ pub enum SeedContextError {
 /// # }
 /// ```
 pub struct SeedContext {
-    pool: Pool<AsyncPgConnection>,
+    pool: Pool<RuntimeConnection>,
     profile: String,
 }
 
@@ -151,7 +151,7 @@ impl SeedContext {
     /// factory `create_many(count, pool)` and
     /// [`fake_seed_model`].
     #[must_use]
-    pub const fn pool(&self) -> &Pool<AsyncPgConnection> {
+    pub const fn pool(&self) -> &Pool<RuntimeConnection> {
         &self.pool
     }
 
@@ -165,7 +165,7 @@ impl SeedContext {
     ///
     /// Returns [`SeedContextError::Connection`] if the pool is exhausted or
     /// the connection cannot be established.
-    pub async fn conn(&self) -> Result<Object<AsyncPgConnection>, SeedContextError> {
+    pub async fn conn(&self) -> Result<Object<RuntimeConnection>, SeedContextError> {
         self.pool
             .get()
             .await
@@ -269,7 +269,7 @@ pub struct FakeSeeder {
     pub model: &'static str,
     /// Insert `count` faked rows via the model's factory and return how many
     /// were inserted.
-    pub run: fn(&Pool<AsyncPgConnection>, usize) -> BoxFuture<'_, usize>,
+    pub run: fn(&Pool<RuntimeConnection>, usize) -> BoxFuture<'_, usize>,
 }
 
 inventory::collect!(FakeSeeder);
@@ -330,7 +330,7 @@ fn find_fake_seeder(name: &str) -> Option<&'static FakeSeeder> {
 pub async fn fake_seed_model(
     name: &str,
     count: usize,
-    pool: &Pool<AsyncPgConnection>,
+    pool: &Pool<RuntimeConnection>,
 ) -> Result<usize, FakeSeedError> {
     if let Some(seeder) = find_fake_seeder(name) {
         return Ok((seeder.run)(pool, count).await);
@@ -370,7 +370,7 @@ pub async fn fake_seed_model(
 /// Returns [`FakeSeedError::InvalidCount`] when `AUTUMN_SEED_COUNT` is set but
 /// does not parse as a non-negative integer, or [`FakeSeedError::UnknownModel`]
 /// when `AUTUMN_SEED_MODEL` names no registered `#[model]`.
-pub async fn maybe_fake_seed(pool: &Pool<AsyncPgConnection>) -> Result<bool, FakeSeedError> {
+pub async fn maybe_fake_seed(pool: &Pool<RuntimeConnection>) -> Result<bool, FakeSeedError> {
     let (Ok(model), Ok(count)) = (
         std::env::var("AUTUMN_SEED_MODEL"),
         std::env::var("AUTUMN_SEED_COUNT"),
@@ -459,7 +459,7 @@ mod tests {
     /// A lazily-built pool (deadpool does not connect until first use), so these
     /// tests exercise `maybe_fake_seed`'s pre-connection branches without a live
     /// database.
-    fn lazy_pool() -> Pool<AsyncPgConnection> {
+    fn lazy_pool() -> Pool<RuntimeConnection> {
         crate::db::create_pool(&DatabaseConfig {
             primary_url: Some("postgres://localhost/unused".to_string()),
             ..DatabaseConfig::default()

--- a/autumn/src/sharding.rs
+++ b/autumn/src/sharding.rs
@@ -38,6 +38,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use crate::db::RuntimeConnection;
 use diesel_async::AsyncPgConnection;
 use diesel_async::pooled_connection::deadpool::Pool;
 
@@ -258,7 +259,7 @@ impl ShardRouter for HashShardRouter {
 /// Only string keys are looked up in the directory (tenants are strings);
 /// numeric/byte keys route straight through the fallback.
 pub struct DirectoryShardRouter {
-    control_pool: Pool<AsyncPgConnection>,
+    control_pool: Pool<RuntimeConnection>,
     fallback: Arc<dyn ShardRouter>,
     cache: std::sync::RwLock<HashMap<String, DirectoryCacheEntry>>,
     ttl: std::time::Duration,
@@ -336,7 +337,7 @@ impl DirectoryShardRouter {
     /// Build a directory router over the given control pool, falling back to
     /// [`HashShardRouter`] and using [`DEFAULT_DIRECTORY_CACHE_TTL`].
     #[must_use]
-    pub fn new(control_pool: Pool<AsyncPgConnection>) -> Self {
+    pub fn new(control_pool: Pool<RuntimeConnection>) -> Self {
         Self::with_fallback(control_pool, Arc::new(HashShardRouter))
     }
 
@@ -344,7 +345,7 @@ impl DirectoryShardRouter {
     /// default cache TTL.
     #[must_use]
     pub fn with_fallback(
-        control_pool: Pool<AsyncPgConnection>,
+        control_pool: Pool<RuntimeConnection>,
         fallback: Arc<dyn ShardRouter>,
     ) -> Self {
         Self {
@@ -759,13 +760,13 @@ impl Shard {
 
     /// This shard's primary/write pool.
     #[must_use]
-    pub const fn primary_pool(&self) -> &Pool<AsyncPgConnection> {
+    pub const fn primary_pool(&self) -> &Pool<RuntimeConnection> {
         self.topology.primary()
     }
 
     /// This shard's replica pool, when configured.
     #[must_use]
-    pub const fn replica_pool(&self) -> Option<&Pool<AsyncPgConnection>> {
+    pub const fn replica_pool(&self) -> Option<&Pool<RuntimeConnection>> {
         self.topology.replica()
     }
 
@@ -778,7 +779,7 @@ impl Shard {
     /// - replica unready, fallback `primary` → the primary pool;
     /// - replica unready, fallback `fail_readiness` → `None`.
     #[must_use]
-    pub fn read_pool(&self) -> Option<&Pool<AsyncPgConnection>> {
+    pub fn read_pool(&self) -> Option<&Pool<RuntimeConnection>> {
         self.read_pool_with_role().map(|(pool, _)| pool)
     }
 
@@ -822,7 +823,7 @@ impl Shard {
     /// Backs [`ShardedReadDb`], which always requires a healthy replica.
     ///
     /// [`read_pool`]: Self::read_pool
-    pub(crate) fn replica_read_pool(&self) -> Option<&Pool<AsyncPgConnection>> {
+    pub(crate) fn replica_read_pool(&self) -> Option<&Pool<RuntimeConnection>> {
         if self.runtime.replica_configured && self.runtime.replica_ready() {
             self.topology.replica()
         } else {
@@ -832,7 +833,7 @@ impl Shard {
 
     /// [`read_pool`](Self::read_pool) plus the role label of the returned
     /// pool, for interceptor/metric naming.
-    pub(crate) fn read_pool_with_role(&self) -> Option<(&Pool<AsyncPgConnection>, &'static str)> {
+    pub(crate) fn read_pool_with_role(&self) -> Option<(&Pool<RuntimeConnection>, &'static str)> {
         if !self.runtime.replica_configured {
             return Some((self.topology.primary(), "primary"));
         }
@@ -1760,7 +1761,7 @@ impl Shards {
     async fn checkout(
         &self,
         shard: &Shard,
-        pool: &Pool<AsyncPgConnection>,
+        pool: &Pool<RuntimeConnection>,
         role: &str,
     ) -> Result<crate::db::Db, AutumnError> {
         let ctx = self.ctx.clone();
@@ -1797,7 +1798,7 @@ impl Shards {
 #[doc(hidden)]
 #[derive(Clone)]
 pub struct ShardRepositorySeed {
-    pub pool: Pool<AsyncPgConnection>,
+    pub pool: Pool<RuntimeConnection>,
     /// Statement timeout in milliseconds (`0` = no limit, matching the
     /// Postgres `statement_timeout = 0` convention).  Capped at
     /// `i32::MAX` ms to match the Postgres signed-integer constraint.
@@ -1815,7 +1816,7 @@ pub struct ShardRepositorySeed {
 
 impl ShardRepositorySeed {
     pub(crate) fn from_ctx(
-        pool: &Pool<AsyncPgConnection>,
+        pool: &Pool<RuntimeConnection>,
         ctx: &crate::db::RequestDbContext,
         shard_name: &str,
         read_route: crate::repository::ReadRoute,
@@ -1983,7 +1984,7 @@ impl ShardedDb {
 }
 
 impl std::ops::Deref for ShardedDb {
-    type Target = AsyncPgConnection;
+    type Target = RuntimeConnection;
     fn deref(&self) -> &Self::Target {
         &self.db
     }
@@ -2120,7 +2121,7 @@ impl ShardedReadDb {
 }
 
 impl std::ops::Deref for ShardedReadDb {
-    type Target = AsyncPgConnection;
+    type Target = RuntimeConnection;
     fn deref(&self) -> &Self::Target {
         &self.db
     }

--- a/autumn/src/state.rs
+++ b/autumn/src/state.rs
@@ -64,12 +64,12 @@ pub struct AppState {
     /// `database.primary_url` or legacy `database.url` is configured.
     #[cfg(feature = "db")]
     pub(crate) pool:
-        Option<diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>,
+        Option<diesel_async::pooled_connection::deadpool::Pool<crate::db::RuntimeConnection>>,
 
     /// Read-replica connection pool, or `None` when no replica role is configured.
     #[cfg(feature = "db")]
     pub(crate) replica_pool:
-        Option<diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>,
+        Option<diesel_async::pooled_connection::deadpool::Pool<crate::db::RuntimeConnection>>,
 
     /// Configured shard set, or `None` when no `[[database.shards]]`
     /// entries exist. The `pool`/`replica_pool` roles above are the
@@ -195,7 +195,7 @@ impl crate::authorization::ProvideAuthorizationState for AppState {
     #[cfg(feature = "db")]
     fn pool(
         &self,
-    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<crate::db::RuntimeConnection>>
     {
         self.pool.as_ref()
     }
@@ -292,7 +292,7 @@ impl AppState {
     #[must_use]
     pub const fn pool(
         &self,
-    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<crate::db::RuntimeConnection>>
     {
         self.pool.as_ref()
     }
@@ -302,7 +302,7 @@ impl AppState {
     #[must_use]
     pub const fn replica_pool(
         &self,
-    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<crate::db::RuntimeConnection>>
     {
         self.replica_pool.as_ref()
     }
@@ -323,7 +323,7 @@ impl AppState {
     #[must_use]
     pub fn read_pool(
         &self,
-    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<crate::db::RuntimeConnection>>
     {
         if self.replica_pool.is_some() && self.probes.should_route_reads_to_replica() {
             self.replica_pool.as_ref()
@@ -428,7 +428,7 @@ impl AppState {
     #[must_use]
     pub fn with_pool(
         mut self,
-        pool: diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        pool: diesel_async::pooled_connection::deadpool::Pool<crate::db::RuntimeConnection>,
     ) -> Self {
         self.pool = Some(pool);
         self
@@ -439,7 +439,7 @@ impl AppState {
     #[must_use]
     pub fn with_replica_pool(
         mut self,
-        pool: diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>,
+        pool: diesel_async::pooled_connection::deadpool::Pool<crate::db::RuntimeConnection>,
     ) -> Self {
         self.replica_pool = Some(pool);
         self
@@ -754,21 +754,21 @@ impl DbState for AppState {
 
     fn pool(
         &self,
-    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<crate::db::RuntimeConnection>>
     {
         self.pool.as_ref()
     }
 
     fn replica_pool(
         &self,
-    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<crate::db::RuntimeConnection>>
     {
         self.replica_pool.as_ref()
     }
 
     fn read_pool(
         &self,
-    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<crate::db::RuntimeConnection>>
     {
         Self::read_pool(self)
     }
@@ -817,7 +817,7 @@ impl crate::probe::ProvideProbeState for AppState {
     #[cfg(feature = "db")]
     fn pool(
         &self,
-    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<crate::db::RuntimeConnection>>
     {
         self.pool.as_ref()
     }
@@ -825,7 +825,7 @@ impl crate::probe::ProvideProbeState for AppState {
     #[cfg(feature = "db")]
     fn replica_pool(
         &self,
-    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<crate::db::RuntimeConnection>>
     {
         self.replica_pool.as_ref()
     }
@@ -896,7 +896,7 @@ impl crate::actuator::ProvideActuatorState for AppState {
     #[cfg(feature = "db")]
     fn pool(
         &self,
-    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>>
+    ) -> Option<&diesel_async::pooled_connection::deadpool::Pool<crate::db::RuntimeConnection>>
     {
         self.pool.as_ref()
     }


### PR DESCRIPTION
## Before / After

**Before:** the runtime database connection type is hard-coded to Postgres (`diesel_async::AsyncPgConnection`) at every connection-typed site — the pool, the pooled connection, the transaction/query plumbing, the admin-plugin trait, and the `#[repository]`/`#[model]` generated code.

**After:** a single `db::RuntimeConnection` type alias sits in front of that surface. It resolves to `AsyncPgConnection` **by default** (Postgres, unchanged) and flips to `SyncConnectionWrapper<SqliteConnection>` only when the new `sqlite` cargo feature is enabled. This is a **pure no-op refactor for the default build** — that is the merge gate. Wiring an actual working SQLite pool is PR2; the runtime pool-construction refusal (`PoolError::UnsupportedBackend`) is deliberately retained.

## How

- **Alias** (`autumn/src/db.rs`): `pub type RuntimeConnection` is cfg-gated — `AsyncPgConnection` under `not(feature = "sqlite")`, `diesel_async::sync_connection_wrapper::SyncConnectionWrapper<diesel::SqliteConnection>` under `feature = "sqlite"`. Re-exported at the crate root (`autumn_web::RuntimeConnection`) so generated code and downstream crates can name it.
- **Feature wiring**: `sqlite = []` in `autumn/Cargo.toml`; `sync-connection-wrapper` added to `diesel-async` in the workspace root `Cargo.toml` (additive, no-op for Postgres — diesel's sqlite backend and bundled libsqlite3-sys were already in the graph).
- **Threaded to `RuntimeConnection`** (identical types under the default, so a pure no-op there): the db.rs pool types / `DatabasePools` / `create_pool` / `build_pool` return / `PooledConnection` / `Db` Deref target / pool-provider trait; the `#[repository]`/`#[model]` generated connection/pool/object params (so downstream repositories flip with the feature); the `AdminModel` trait's pool params; the `DatabaseState` pool accessors; the `SeedContext` pool surface; and the `ShardManager` pool accessors + `ShardedDb`/`ShardedReadDb` Deref targets.
- **Deliberately left `AsyncPgConnection` (inherently Postgres-only, PR2 to cfg-split)**: `Db::tx_with`'s `build_transaction`/isolation path; the advisory-lock module (`lock.rs`); the job-queue internals (`job.rs`); sharding's control-conn `establish`, the `create_shard_set_transactional` test-transaction pool builder, and its `tx_with` wrapper; the TLS establish helper; and admin-plugin impls / test provider impls (they satisfy the now-`RuntimeConnection` trait as-is under the default). `build_pool` is cfg-split so it compiles under the feature while keeping the pool refusal.

### Feature-unification hazard (guarded + documented)

`sqlite` flips the alias for **every** consumer in the build graph, so it must **only** be enabled by an end application or an explicit `--features sqlite` invocation — **never** on an inter-crate dependency edge or dev-dependency, or cargo feature unification would silently break the Postgres default for everyone. This warning is documented in a doc comment directly above the `sqlite = []` line in `autumn/Cargo.toml` and above the alias definition. No workspace edge enables it.

## Verification (default = merge gate)

- `cargo fmt --all -- --check` — clean
- `cargo build --workspace` — green (no-op)
- `cargo clippy --workspace --all-targets -- -D warnings` — green
- `cargo test -p autumn-web --lib` (3872), `-p autumn-admin-plugin` (229), `-p autumn-macros` (531) — all green
- `cargo build -p autumn-web --features sqlite` — the alias resolves correctly (the sqlite path + feature are right); ~25 remaining errors are all type-interop mismatches with still-Postgres-hardcoded modules (`app.rs`, `repository.rs`, `authorization.rs`, `probe.rs`, `actuator.rs`, `scheduler.rs`, `job.rs`, `repository_commit_hooks.rs`, …) plus the inherently-pg methods (`build_transaction`, advisory locks) that need cfg-splits. Finishing feature-on compilation is **PR2**.

## Deferred to PR2

- Thread `RuntimeConnection` through the remaining pg-hardcoded modules and cfg-split the genuinely-Postgres-only code (advisory locks, `build_transaction`, control-conn establish, test-tx pool builders) so `--features sqlite` fully compiles.
- Wire a real SQLite pool (replace the `UnsupportedBackend` refusal).
- The CI feature matrix (AC#11) is deferred — no `ci.yml` change here.

Part of #1614

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuoMnnmkhC2hsTmqm1inA6)_