### PR TITLE
feat(cli): opt-in TLS termination for the deploy-managed kamal-proxy

### DIFF
--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -231,20 +231,11 @@ impl ResolvedDeployConfig {
         })
     }
 
-    /// Persistent per-app dir shared across releases (holds the secret env file
-    /// and, since #1952, the uploaded config manifest[s]). The deployed systemd
-    /// unit sets `AUTUMN_MANIFEST_DIR` to this path so the app's config loader
-    /// reads the uploaded `autumn.toml` here at boot.
-    #[must_use]
-    pub fn shared_dir(&self) -> String {
-        format!("{}/shared", self.app_dir)
-    }
-
     /// Remote path to the `EnvironmentFile` holding secrets (mode `0600`), kept
     /// out of the world-readable systemd unit.
     #[must_use]
     pub fn env_file(&self) -> String {
-        format!("{}/autumn.env", self.shared_dir())
+        format!("{}/shared/autumn.env", self.app_dir)
     }
 
     /// Directory holding timestamped release dirs.
@@ -599,7 +590,6 @@ pub fn render_systemd_unit(cfg: &ResolvedDeployConfig) -> String {
          User={user}\n\
          WorkingDirectory={current}\n\
          EnvironmentFile={env_file}\n\
-         Environment=AUTUMN_MANIFEST_DIR={manifest_dir}\n\
          ExecStart={current}/{app}\n\
          Restart=on-failure\n\
          RestartSec=2\n\
@@ -610,11 +600,6 @@ pub fn render_systemd_unit(cfg: &ResolvedDeployConfig) -> String {
         user = cfg.user,
         current = cfg.current_symlink(),
         env_file = cfg.env_file(),
-        // Point the app's config loader at the shared dir where the uploaded
-        // autumn.toml lives, so the deployed app loads the intended config
-        // instead of built-in defaults (#1952). Non-secret, so it lives in the
-        // unit's Environment= (not the 0600 env file).
-        manifest_dir = cfg.shared_dir(),
     )
 }
 
@@ -644,7 +629,6 @@ pub fn render_app_unit(
          User={user}\n\
          WorkingDirectory={release_dir}\n\
          EnvironmentFile={env_file}\n\
-         Environment=AUTUMN_MANIFEST_DIR={manifest_dir}\n\
          Environment=AUTUMN_SERVER__HOST=127.0.0.1\n\
          Environment=AUTUMN_SERVER__PORT={app_port}\n\
          ExecStart={release_dir}/{app}\n\
@@ -656,11 +640,6 @@ pub fn render_app_unit(
         app = cfg.app_name,
         user = cfg.user,
         env_file = cfg.env_file(),
-        // Point the app's config loader at the shared dir where the uploaded
-        // autumn.toml lives, so the deployed app loads the intended config
-        // instead of built-in defaults (#1952). Non-secret → unit Environment=,
-        // not the 0600 env file.
-        manifest_dir = cfg.shared_dir(),
     )
 }
 
@@ -1154,93 +1133,6 @@ fn default_release_id() -> String {
     chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string()
 }
 
-/// Resolve the local project directory the deploy reads config from.
-///
-/// Mirrors autumn-web's `find_config_file_named`: `AUTUMN_MANIFEST_DIR` wins when
-/// set (so an operator who redirects config loading also has that dir uploaded),
-/// otherwise the current working directory — the project root the rest of the
-/// deploy already treats as authoritative (the release binary is resolved as
-/// `target/release/<app>`).
-fn manifest_project_dir() -> PathBuf {
-    if let Ok(dir) = std::env::var("AUTUMN_MANIFEST_DIR")
-        && !dir.trim().is_empty()
-    {
-        return PathBuf::from(dir);
-    }
-    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
-}
-
-/// Locate the RAW project config manifest file(s) to upload for #1952: the base
-/// `autumn.toml` plus, when present, the profile-override sibling
-/// `autumn-<profile>.toml` for the target deploy profile.
-///
-/// Pure over the passed `dir`/`profile` so it is unit-testable against a temp
-/// dir. We upload the raw files (NOT a flattened/merged config) because the app
-/// applies its `[profile.<AUTUMN_ENV>]` overlay at runtime — `AUTUMN_ENV` is already
-/// set in the uploaded env file — so shipping the raw manifest(s) preserves the
-/// profile structure and matches the repo exactly.
-///
-/// Both the operator's raw spelling and its canonical form are checked for the
-/// sibling (e.g. `[deploy] profile = "production"` uploads whichever of
-/// `autumn-production.toml` / `autumn-prod.toml` exist), matching the runtime's
-/// own profile-override-file lookup so the deployed app resolves config identically.
-fn manifest_uploads_in(dir: &Path, profile: &str) -> Vec<exec::ManifestUpload> {
-    let mut uploads = Vec::new();
-
-    let base = dir.join("autumn.toml");
-    if base.exists() {
-        uploads.push(exec::ManifestUpload {
-            local: base,
-            remote_basename: "autumn.toml".to_owned(),
-        });
-    }
-
-    let mut sibling_names = vec![profile.trim().to_owned()];
-    let canonical = canonicalize_deploy_profile(profile);
-    if !sibling_names.contains(&canonical) {
-        sibling_names.push(canonical);
-    }
-    for name in sibling_names {
-        if name.is_empty() {
-            continue;
-        }
-        let basename = format!("autumn-{name}.toml");
-        if uploads.iter().any(|u| u.remote_basename == basename) {
-            continue;
-        }
-        let sibling = dir.join(&basename);
-        if sibling.exists() {
-            uploads.push(exec::ManifestUpload {
-                local: sibling,
-                remote_basename: basename,
-            });
-        }
-    }
-
-    uploads
-}
-
-/// Locate the config manifest(s) to upload for the resolved deploy, reading from
-/// the local project directory ([`manifest_project_dir`]).
-fn locate_manifest_uploads(resolved: &ResolvedDeployConfig) -> Vec<exec::ManifestUpload> {
-    manifest_uploads_in(&manifest_project_dir(), &resolved.profile)
-}
-
-/// Format the operator-facing preflight line for the config-manifest upload
-/// (#1952). Pure/testable: either a LOUD no-manifest warning (kills the previous
-/// silent-defaults footgun) or a confirming line naming the uploaded file(s).
-fn manifest_preflight_notice(uploads: &[exec::ManifestUpload]) -> String {
-    if uploads.is_empty() {
-        return "\u{26A0}\u{FE0F}  warning: no autumn.toml found in the project directory; the \
-                deployed app will run built-in defaults for all non-secret settings (secrets \
-                still come from the env file). Add an autumn.toml to control the deployed \
-                configuration."
-            .to_owned();
-    }
-    let names: Vec<&str> = uploads.iter().map(|u| u.remote_basename.as_str()).collect();
-    format!("Uploading project config to shared/: {}", names.join(", "))
-}
-
 /// Perform a real deploy (issue #1607, Slices 1–3).
 ///
 /// Runs the same preflight as `check` and aborts before touching the server if
@@ -1274,12 +1166,6 @@ fn run_up(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(), 
         .ok_or_else(|| DeployError::Config(DEPLOY_HOST_MISSING_DETAIL.to_owned()))?;
     let binary = resolve_release_binary(resolved)?;
     let env_file = build_env_file(config, resolved);
-    // Locate the project config manifest(s) to upload so the deployed app loads
-    // the intended config rather than silent built-in defaults (#1952), and print
-    // a loud line either confirming the upload or warning when there is no
-    // autumn.toml to ship.
-    let manifests = locate_manifest_uploads(resolved);
-    eprintln!("{}", manifest_preflight_notice(&manifests));
     let release_id = default_release_id();
     let public_port = config.server.port;
     let proxy = proxy::KamalProxyController::new(resolved.readiness_timeout_secs)
@@ -1306,7 +1192,6 @@ fn run_up(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(), 
                 &unit,
                 env_file,
                 &binary,
-                &manifests,
                 &release_id,
                 &plan,
             );
@@ -1331,7 +1216,6 @@ fn run_up(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(), 
                 &unit,
                 env_file,
                 &binary,
-                &manifests,
                 &release_id,
                 &plan,
             );
@@ -1881,104 +1765,6 @@ mod tests {
         // Secrets come from an EnvironmentFile, never inlined into the unit.
         assert!(unit.contains("EnvironmentFile=/srv/autumn/shop/shared/autumn.env"));
         assert!(!unit.contains("Environment=SECRET"));
-        // #1952: the unit points config loading at the shared dir where the
-        // uploaded autumn.toml lives.
-        assert!(unit.contains("Environment=AUTUMN_MANIFEST_DIR=/srv/autumn/shop/shared"));
-    }
-
-    #[test]
-    fn app_unit_sets_manifest_dir_to_shared_for_uploaded_config() {
-        // #1952: the deployed slot unit (the one actually written by a deploy)
-        // sets AUTUMN_MANIFEST_DIR to the persistent shared dir so the app's
-        // config loader reads the uploaded autumn.toml instead of built-in
-        // defaults. Non-secret → an `Environment=` line, not the 0600 env file.
-        let cfg = ResolvedDeployConfig::resolve(
-            &DeployConfig {
-                app_name: Some("shop".to_owned()),
-                ..DeployConfig::default()
-            },
-            "shop",
-        )
-        .expect("deploy config resolves");
-        let unit = render_app_unit(&cfg, "/srv/autumn/shop/releases/r1", 3001, "blue");
-        assert!(
-            unit.contains("Environment=AUTUMN_MANIFEST_DIR=/srv/autumn/shop/shared"),
-            "slot unit must set AUTUMN_MANIFEST_DIR to the shared dir: {unit}"
-        );
-        // The env file (secrets) still lives in the same shared dir at 0600.
-        assert!(unit.contains("EnvironmentFile=/srv/autumn/shop/shared/autumn.env"));
-    }
-
-    #[test]
-    fn manifest_uploads_base_only_when_no_profile_sibling() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::write(dir.path().join("autumn.toml"), "[server]\nport = 8080\n")
-            .expect("write autumn.toml");
-        let uploads = manifest_uploads_in(dir.path(), "prod");
-        assert_eq!(uploads.len(), 1, "only autumn.toml is present");
-        assert_eq!(uploads[0].remote_basename, "autumn.toml");
-        assert_eq!(uploads[0].local, dir.path().join("autumn.toml"));
-    }
-
-    #[test]
-    fn manifest_uploads_include_profile_sibling_when_present() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::write(dir.path().join("autumn.toml"), "[server]\n").expect("write base");
-        std::fs::write(dir.path().join("autumn-prod.toml"), "[server]\n").expect("write sibling");
-        let uploads = manifest_uploads_in(dir.path(), "prod");
-        let names: Vec<&str> = uploads.iter().map(|u| u.remote_basename.as_str()).collect();
-        assert_eq!(names, vec!["autumn.toml", "autumn-prod.toml"]);
-    }
-
-    #[test]
-    fn manifest_uploads_check_canonical_profile_sibling() {
-        // `[deploy] profile = "production"` should still ship the canonical
-        // `autumn-prod.toml` if that is what the repo carries, matching the
-        // runtime's own override-file lookup.
-        let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::write(dir.path().join("autumn.toml"), "[server]\n").expect("write base");
-        std::fs::write(dir.path().join("autumn-prod.toml"), "[server]\n").expect("write sibling");
-        let uploads = manifest_uploads_in(dir.path(), "production");
-        assert!(
-            uploads
-                .iter()
-                .any(|u| u.remote_basename == "autumn-prod.toml"),
-            "canonical prod sibling is uploaded for raw profile `production`"
-        );
-    }
-
-    #[test]
-    fn manifest_uploads_empty_when_no_manifest() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let uploads = manifest_uploads_in(dir.path(), "prod");
-        assert!(uploads.is_empty(), "no autumn.toml → nothing to upload");
-    }
-
-    #[test]
-    fn manifest_notice_warns_loudly_when_no_manifest() {
-        let notice = manifest_preflight_notice(&[]);
-        assert!(
-            notice.contains("no autumn.toml") && notice.contains("built-in defaults"),
-            "no-manifest notice must loudly warn about silent defaults: {notice}"
-        );
-    }
-
-    #[test]
-    fn manifest_notice_confirms_uploaded_files() {
-        let uploads = vec![
-            exec::ManifestUpload {
-                local: PathBuf::from("/x/autumn.toml"),
-                remote_basename: "autumn.toml".to_owned(),
-            },
-            exec::ManifestUpload {
-                local: PathBuf::from("/x/autumn-prod.toml"),
-                remote_basename: "autumn-prod.toml".to_owned(),
-            },
-        ];
-        let notice = manifest_preflight_notice(&uploads);
-        assert!(notice.contains("autumn.toml"));
-        assert!(notice.contains("autumn-prod.toml"));
-        assert!(!notice.contains("no autumn.toml"));
     }
 
     #[test]

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -205,17 +205,13 @@ impl ResolvedDeployConfig {
         // the render/deploy commands changes. When enabled, a non-blank `host` is
         // mandatory (the certificate is issued for it).
         let tls_host = if cfg.tls.enabled {
-            match non_blank(&cfg.tls.host) {
-                Some(host) => Some(host),
-                None => {
-                    return Err(
-                        "[deploy.tls] requires a non-empty `host` when enabled: set \
-                         `[deploy.tls] host = \"<public-hostname>\"` in autumn.toml to the DNS \
-                         name the TLS certificate should be issued for"
-                            .to_owned(),
-                    );
-                }
-            }
+            let host = non_blank(&cfg.tls.host).ok_or_else(|| {
+                "[deploy.tls] requires a non-empty `host` when enabled: set \
+                 `[deploy.tls] host = \"<public-hostname>\"` in autumn.toml to the DNS \
+                 name the TLS certificate should be issued for"
+                    .to_owned()
+            })?;
+            Some(host)
         } else {
             None
         };

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -1151,34 +1151,31 @@ fn default_release_id() -> String {
 /// release serving ([`exec::execute_redeploy`]); a first deploy has no previous
 /// release and fails loudly after tearing the candidate down
 /// ([`exec::execute_first_deploy`]).
-/// The HTTPS port kamal-proxy binds unconditionally. Kept in lock-step with
-/// `proxy::DEFAULT_HTTPS_PORT`; a public/HTTP port equal to it collides.
+/// The HTTPS port kamal-proxy binds by default (and cannot disable). A
+/// public/HTTP port — or a blue/green slot port derived from it — equal to this
+/// collides with the always-bound HTTPS listener.
 const PROXY_HTTPS_PORT: u16 = 443;
-
-/// The public/HTTP port automatic TLS requires. Let's Encrypt HTTP-01 validation
-/// arrives on port 80, and kamal-proxy's HTTP→HTTPS redirect expects HTTP on 80,
-/// so `[deploy.tls]` deployments must serve HTTP on 80.
-const ACME_HTTP_PORT: u16 = 80;
 
 /// Reject a deploy public/HTTP port that cannot work with the proxy topology.
 ///
-/// Two independent guards run here, before any remote work:
+/// One guard runs here, before any remote work, and it is **unconditional** (it
+/// does not depend on whether TLS is enabled): kamal-proxy `run` binds its
+/// `--https-port 443` listener by DEFAULT and that listener cannot be disabled,
+/// and each blue/green slot binds a private loopback port derived from the
+/// public port ([`exec::slot_app_port`]: blue = `public + 1`, green =
+/// `public + 2`). If the proxy's HTTP port *or* either slot port lands on 443 it
+/// collides with the always-bound HTTPS listener and the proxy can never start.
+/// With blue/green at `+1`/`+2`, that rejects `public ∈ {441, 442, 443}`.
 ///
-/// 1. **443 collision (unconditional).** kamal-proxy `run` always establishes
-///    both its `--http-port` (the deploy public port) and `--https-port 443`
-///    listeners, and each blue/green slot binds a private loopback port derived
-///    from the public port ([`exec::slot_app_port`]: blue = `public + 1`, green =
-///    `public + 2`). If the proxy's HTTP port *or* either slot port lands on 443
-///    it collides with the always-bound HTTPS listener and the proxy can never
-///    start. With blue/green at `+1`/`+2`, that rejects `public ∈ {441, 442,
-///    443}`. This is unconditional because 443 is always bound, TLS or not.
-/// 2. **Automatic-TLS requires port 80 (TLS-gated).** When `[deploy.tls]` is
-///    enabled the public HTTP port must be 80, or ACME HTTP-01 validation and the
-///    HTTP→HTTPS redirect can't reliably work.
-fn validate_public_port(public_port: u16, tls_enabled: bool) -> Result<(), String> {
-    // Guard 1: no port (proxy HTTP or a blue/green slot) may land on 443. Compute
-    // the slot ports from the same offsets the deploy uses so the guard tracks the
-    // real arithmetic instead of a hardcoded {441, 442, 443} set.
+/// There is deliberately **no** TLS-gated port-80 requirement: per-app TLS is
+/// provisioned by kamal-proxy on its always-bound 443 via `deploy --host --tls`
+/// (TLS-ALPN-01, no port 80 needed), so enabling `[deploy.tls]` works on any
+/// non-colliding public port — on both first deploy and redeploy — without a
+/// proxy HTTP-port change.
+fn validate_public_port(public_port: u16) -> Result<(), String> {
+    // No port (proxy HTTP or a blue/green slot) may land on 443. Compute the slot
+    // ports from the same offsets the deploy uses so the guard tracks the real
+    // arithmetic instead of a hardcoded {441, 442, 443} set.
     let blue_port = exec::slot_app_port(public_port, exec::SLOT_BLUE);
     let green_port = exec::slot_app_port(public_port, exec::SLOT_GREEN);
     let collision = if public_port == PROXY_HTTPS_PORT {
@@ -1197,16 +1194,6 @@ fn validate_public_port(public_port: u16, tls_enabled: bool) -> Result<(), Strin
              (blue/green app slots bind `public+1`/`public+2`); use 80 (the default) or \
              another port outside {}\u{2013}{PROXY_HTTPS_PORT}",
             PROXY_HTTPS_PORT - 2,
-        ));
-    }
-
-    // Guard 2: automatic TLS needs the public HTTP port on 80 for ACME/redirect.
-    if tls_enabled && public_port != ACME_HTTP_PORT {
-        return Err(format!(
-            "automatic TLS (`[deploy.tls]`) requires the deploy public HTTP port to be \
-             {ACME_HTTP_PORT} — Let's Encrypt HTTP-01 validation and the HTTP\u{2192}HTTPS \
-             redirect use port {ACME_HTTP_PORT}; set `server.port = {ACME_HTTP_PORT}` \
-             (currently {public_port})",
         ));
     }
     Ok(())
@@ -1229,13 +1216,13 @@ fn run_up(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(), 
     let env_file = build_env_file(config, resolved);
     let release_id = default_release_id();
     let public_port = config.server.port;
-    // kamal-proxy `run` ALWAYS binds 443 for its HTTPS listener (regardless of any
-    // app's TLS flag), so a public/HTTP port whose proxy-HTTP or blue/green slot
-    // port lands on 443 would collide and the proxy would fail to start. And when
-    // `[deploy.tls]` is enabled the public HTTP port must be 80 for ACME HTTP-01
-    // validation and the HTTP→HTTPS redirect. Reject both up front with actionable
-    // messages instead of a cryptic runtime bind/validation failure on the host.
-    validate_public_port(public_port, resolved.tls_enabled).map_err(DeployError::Config)?;
+    // kamal-proxy `run` binds 443 for its HTTPS listener BY DEFAULT (regardless of
+    // any app's TLS flag, and it cannot be disabled), so a public/HTTP port whose
+    // proxy-HTTP or blue/green slot port lands on 443 would collide and the proxy
+    // would fail to start. Reject that up front with an actionable message instead
+    // of a cryptic runtime bind failure on the host. TLS imposes no port-80
+    // requirement — it is provisioned per app on the always-bound 443.
+    validate_public_port(public_port).map_err(DeployError::Config)?;
     let proxy = proxy::KamalProxyController::new(resolved.readiness_timeout_secs)
         .with_tls_host(resolved.tls_host.clone());
     let executor = exec::SshExecutor::new(target);
@@ -1381,10 +1368,11 @@ mod tests {
 
     #[test]
     fn public_port_443_is_rejected_as_a_proxy_https_collision() {
-        // kamal-proxy always binds 443 for HTTPS, so a public/HTTP port of 443
-        // collides and the proxy can't start — the guard rejects it up front with
-        // an actionable message. It is unconditional (not TLS-gated).
-        let err = validate_public_port(443, false).expect_err("port 443 must be rejected");
+        // kamal-proxy binds 443 for HTTPS by default (and can't disable it), so a
+        // public/HTTP port of 443 collides and the proxy can't start — the guard
+        // rejects it up front with an actionable message. It is unconditional (not
+        // TLS-gated).
+        let err = validate_public_port(443).expect_err("port 443 must be rejected");
         assert!(
             err.contains("443")
                 && err.contains("HTTPS listener")
@@ -1392,8 +1380,8 @@ mod tests {
             "collision message must name 443/the HTTPS listener/the proxy HTTP port, got: {err}",
         );
         // A normal public port (the default 80, or any other) is accepted.
-        assert!(validate_public_port(80, false).is_ok());
-        assert!(validate_public_port(8080, false).is_ok());
+        assert!(validate_public_port(80).is_ok());
+        assert!(validate_public_port(8080).is_ok());
     }
 
     #[test]
@@ -1401,39 +1389,33 @@ mod tests {
         // Blue/green slots bind `public+1`/`public+2`, so 441 (green slot → 443)
         // and 442 (blue slot → 443) collide with the proxy's always-bound HTTPS
         // listener just as 443 itself does. All three are rejected unconditionally.
-        let green = validate_public_port(441, false).expect_err("441 (green slot=443) rejected");
+        let green = validate_public_port(441).expect_err("441 (green slot=443) rejected");
         assert!(
             green.contains("green app slot") && green.contains("443"),
             "441 message must name the green slot landing on 443, got: {green}",
         );
-        let blue = validate_public_port(442, false).expect_err("442 (blue slot=443) rejected");
+        let blue = validate_public_port(442).expect_err("442 (blue slot=443) rejected");
         assert!(
             blue.contains("blue app slot") && blue.contains("443"),
             "442 message must name the blue slot landing on 443, got: {blue}",
         );
-        // The collision guard is TLS-independent — it fires with TLS on too.
-        assert!(validate_public_port(443, true).is_err());
-        // A safe non-{441,442,443} port is accepted (with TLS off).
-        assert!(validate_public_port(440, false).is_ok());
-        assert!(validate_public_port(444, false).is_ok());
-        assert!(validate_public_port(8080, false).is_ok());
+        assert!(validate_public_port(443).is_err());
+        // A safe non-{441,442,443} port is accepted — regardless of TLS, since the
+        // guard is TLS-independent and TLS imposes no port requirement.
+        assert!(validate_public_port(440).is_ok());
+        assert!(validate_public_port(444).is_ok());
+        assert!(validate_public_port(8080).is_ok());
     }
 
     #[test]
-    fn automatic_tls_requires_public_port_80() {
-        // With `[deploy.tls]` enabled, the public HTTP port must be 80 for ACME
-        // HTTP-01 validation and the HTTP→HTTPS redirect; anything else is rejected
-        // with a message naming port 80 and the ACME/redirect reason.
-        let err = validate_public_port(3000, true).expect_err("TLS + port 3000 must be rejected");
-        assert!(
-            err.contains("automatic TLS") && err.contains("80") && err.contains("HTTP-01"),
-            "TLS message must name port 80 and ACME HTTP-01, got: {err}",
-        );
-        // Port 80 with TLS enabled is accepted.
-        assert!(validate_public_port(80, true).is_ok());
-        // With TLS disabled, 80 and other non-collision ports stay accepted.
-        assert!(validate_public_port(80, false).is_ok());
-        assert!(validate_public_port(3000, false).is_ok());
+    fn tls_does_not_gate_the_public_port() {
+        // There is NO TLS-gated port-80 requirement: per-app TLS is provisioned by
+        // kamal-proxy on its always-bound 443 (TLS-ALPN-01), so a normal public
+        // port is accepted whether or not `[deploy.tls]` is enabled. Only the
+        // unconditional 443 collision applies.
+        assert!(validate_public_port(80).is_ok());
+        assert!(validate_public_port(3000).is_ok());
+        assert!(validate_public_port(8080).is_ok());
     }
 
     #[test]

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -1155,16 +1155,58 @@ fn default_release_id() -> String {
 /// `proxy::DEFAULT_HTTPS_PORT`; a public/HTTP port equal to it collides.
 const PROXY_HTTPS_PORT: u16 = 443;
 
-/// Reject a deploy public/HTTP port that collides with the proxy's fixed HTTPS
-/// listener. kamal-proxy `run` always establishes both its `--http-port` (the
-/// deploy public port) and `--https-port 443` listeners, so a public port of 443
-/// makes the two collide and the proxy can never start. The guard is
-/// unconditional (not TLS-gated) because 443 is always bound.
-fn validate_public_port(public_port: u16) -> Result<(), String> {
-    if public_port == PROXY_HTTPS_PORT {
+/// The public/HTTP port automatic TLS requires. Let's Encrypt HTTP-01 validation
+/// arrives on port 80, and kamal-proxy's HTTP→HTTPS redirect expects HTTP on 80,
+/// so `[deploy.tls]` deployments must serve HTTP on 80.
+const ACME_HTTP_PORT: u16 = 80;
+
+/// Reject a deploy public/HTTP port that cannot work with the proxy topology.
+///
+/// Two independent guards run here, before any remote work:
+///
+/// 1. **443 collision (unconditional).** kamal-proxy `run` always establishes
+///    both its `--http-port` (the deploy public port) and `--https-port 443`
+///    listeners, and each blue/green slot binds a private loopback port derived
+///    from the public port ([`exec::slot_app_port`]: blue = `public + 1`, green =
+///    `public + 2`). If the proxy's HTTP port *or* either slot port lands on 443
+///    it collides with the always-bound HTTPS listener and the proxy can never
+///    start. With blue/green at `+1`/`+2`, that rejects `public ∈ {441, 442,
+///    443}`. This is unconditional because 443 is always bound, TLS or not.
+/// 2. **Automatic-TLS requires port 80 (TLS-gated).** When `[deploy.tls]` is
+///    enabled the public HTTP port must be 80, or ACME HTTP-01 validation and the
+///    HTTP→HTTPS redirect can't reliably work.
+fn validate_public_port(public_port: u16, tls_enabled: bool) -> Result<(), String> {
+    // Guard 1: no port (proxy HTTP or a blue/green slot) may land on 443. Compute
+    // the slot ports from the same offsets the deploy uses so the guard tracks the
+    // real arithmetic instead of a hardcoded {441, 442, 443} set.
+    let blue_port = exec::slot_app_port(public_port, exec::SLOT_BLUE);
+    let green_port = exec::slot_app_port(public_port, exec::SLOT_GREEN);
+    let collision = if public_port == PROXY_HTTPS_PORT {
+        Some("the proxy's HTTP listener")
+    } else if blue_port == PROXY_HTTPS_PORT {
+        Some("the blue app slot")
+    } else if green_port == PROXY_HTTPS_PORT {
+        Some("the green app slot")
+    } else {
+        None
+    };
+    if let Some(which) = collision {
         return Err(format!(
-            "deploy public/HTTP port cannot be {PROXY_HTTPS_PORT} — kamal-proxy reserves \
-             {PROXY_HTTPS_PORT} for its HTTPS listener; use 80 (the default) or another port",
+            "deploy public/HTTP port {public_port} is invalid — {which} would land on \
+             {PROXY_HTTPS_PORT}, which kamal-proxy reserves for its HTTPS listener \
+             (blue/green app slots bind `public+1`/`public+2`); use 80 (the default) or \
+             another port outside {}\u{2013}{PROXY_HTTPS_PORT}",
+            PROXY_HTTPS_PORT - 2,
+        ));
+    }
+
+    // Guard 2: automatic TLS needs the public HTTP port on 80 for ACME/redirect.
+    if tls_enabled && public_port != ACME_HTTP_PORT {
+        return Err(format!(
+            "automatic TLS (`[deploy.tls]`) requires the deploy public HTTP port to be \
+             {ACME_HTTP_PORT} — Let's Encrypt HTTP-01 validation and the HTTP\u{2192}HTTPS \
+             redirect use port {ACME_HTTP_PORT}; set `server.port = {ACME_HTTP_PORT}` \
+             (currently {public_port})",
         ));
     }
     Ok(())
@@ -1188,11 +1230,12 @@ fn run_up(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(), 
     let release_id = default_release_id();
     let public_port = config.server.port;
     // kamal-proxy `run` ALWAYS binds 443 for its HTTPS listener (regardless of any
-    // app's TLS flag), so a public/HTTP port of 443 would render
-    // `run --http-port 443 --https-port 443` and the proxy would fail to start.
-    // Reject it up front with an actionable message instead of a cryptic runtime
-    // bind failure on the host. Unconditional — 443 is always bound.
-    validate_public_port(public_port).map_err(DeployError::Config)?;
+    // app's TLS flag), so a public/HTTP port whose proxy-HTTP or blue/green slot
+    // port lands on 443 would collide and the proxy would fail to start. And when
+    // `[deploy.tls]` is enabled the public HTTP port must be 80 for ACME HTTP-01
+    // validation and the HTTP→HTTPS redirect. Reject both up front with actionable
+    // messages instead of a cryptic runtime bind/validation failure on the host.
+    validate_public_port(public_port, resolved.tls_enabled).map_err(DeployError::Config)?;
     let proxy = proxy::KamalProxyController::new(resolved.readiness_timeout_secs)
         .with_tls_host(resolved.tls_host.clone());
     let executor = exec::SshExecutor::new(target);
@@ -1341,14 +1384,56 @@ mod tests {
         // kamal-proxy always binds 443 for HTTPS, so a public/HTTP port of 443
         // collides and the proxy can't start — the guard rejects it up front with
         // an actionable message. It is unconditional (not TLS-gated).
-        let err = validate_public_port(443).expect_err("port 443 must be rejected");
+        let err = validate_public_port(443, false).expect_err("port 443 must be rejected");
         assert!(
-            err.contains("cannot be 443") && err.contains("kamal-proxy reserves 443"),
-            "collision message must be actionable, got: {err}",
+            err.contains("443")
+                && err.contains("HTTPS listener")
+                && err.contains("proxy's HTTP listener"),
+            "collision message must name 443/the HTTPS listener/the proxy HTTP port, got: {err}",
         );
         // A normal public port (the default 80, or any other) is accepted.
-        assert!(validate_public_port(80).is_ok());
-        assert!(validate_public_port(8080).is_ok());
+        assert!(validate_public_port(80, false).is_ok());
+        assert!(validate_public_port(8080, false).is_ok());
+    }
+
+    #[test]
+    fn public_ports_whose_slots_reach_443_are_rejected() {
+        // Blue/green slots bind `public+1`/`public+2`, so 441 (green slot → 443)
+        // and 442 (blue slot → 443) collide with the proxy's always-bound HTTPS
+        // listener just as 443 itself does. All three are rejected unconditionally.
+        let green = validate_public_port(441, false).expect_err("441 (green slot=443) rejected");
+        assert!(
+            green.contains("green app slot") && green.contains("443"),
+            "441 message must name the green slot landing on 443, got: {green}",
+        );
+        let blue = validate_public_port(442, false).expect_err("442 (blue slot=443) rejected");
+        assert!(
+            blue.contains("blue app slot") && blue.contains("443"),
+            "442 message must name the blue slot landing on 443, got: {blue}",
+        );
+        // The collision guard is TLS-independent — it fires with TLS on too.
+        assert!(validate_public_port(443, true).is_err());
+        // A safe non-{441,442,443} port is accepted (with TLS off).
+        assert!(validate_public_port(440, false).is_ok());
+        assert!(validate_public_port(444, false).is_ok());
+        assert!(validate_public_port(8080, false).is_ok());
+    }
+
+    #[test]
+    fn automatic_tls_requires_public_port_80() {
+        // With `[deploy.tls]` enabled, the public HTTP port must be 80 for ACME
+        // HTTP-01 validation and the HTTP→HTTPS redirect; anything else is rejected
+        // with a message naming port 80 and the ACME/redirect reason.
+        let err = validate_public_port(3000, true).expect_err("TLS + port 3000 must be rejected");
+        assert!(
+            err.contains("automatic TLS") && err.contains("80") && err.contains("HTTP-01"),
+            "TLS message must name port 80 and ACME HTTP-01, got: {err}",
+        );
+        // Port 80 with TLS enabled is accepted.
+        assert!(validate_public_port(80, true).is_ok());
+        // With TLS disabled, 80 and other non-collision ports stay accepted.
+        assert!(validate_public_port(80, false).is_ok());
+        assert!(validate_public_port(3000, false).is_ok());
     }
 
     #[test]

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -231,11 +231,20 @@ impl ResolvedDeployConfig {
         })
     }
 
+    /// Persistent per-app dir shared across releases (holds the secret env file
+    /// and, since #1952, the uploaded config manifest[s]). The deployed systemd
+    /// unit sets `AUTUMN_MANIFEST_DIR` to this path so the app's config loader
+    /// reads the uploaded `autumn.toml` here at boot.
+    #[must_use]
+    pub fn shared_dir(&self) -> String {
+        format!("{}/shared", self.app_dir)
+    }
+
     /// Remote path to the `EnvironmentFile` holding secrets (mode `0600`), kept
     /// out of the world-readable systemd unit.
     #[must_use]
     pub fn env_file(&self) -> String {
-        format!("{}/shared/autumn.env", self.app_dir)
+        format!("{}/autumn.env", self.shared_dir())
     }
 
     /// Directory holding timestamped release dirs.
@@ -590,6 +599,7 @@ pub fn render_systemd_unit(cfg: &ResolvedDeployConfig) -> String {
          User={user}\n\
          WorkingDirectory={current}\n\
          EnvironmentFile={env_file}\n\
+         Environment=AUTUMN_MANIFEST_DIR={manifest_dir}\n\
          ExecStart={current}/{app}\n\
          Restart=on-failure\n\
          RestartSec=2\n\
@@ -600,6 +610,11 @@ pub fn render_systemd_unit(cfg: &ResolvedDeployConfig) -> String {
         user = cfg.user,
         current = cfg.current_symlink(),
         env_file = cfg.env_file(),
+        // Point the app's config loader at the shared dir where the uploaded
+        // autumn.toml lives, so the deployed app loads the intended config
+        // instead of built-in defaults (#1952). Non-secret, so it lives in the
+        // unit's Environment= (not the 0600 env file).
+        manifest_dir = cfg.shared_dir(),
     )
 }
 
@@ -629,6 +644,7 @@ pub fn render_app_unit(
          User={user}\n\
          WorkingDirectory={release_dir}\n\
          EnvironmentFile={env_file}\n\
+         Environment=AUTUMN_MANIFEST_DIR={manifest_dir}\n\
          Environment=AUTUMN_SERVER__HOST=127.0.0.1\n\
          Environment=AUTUMN_SERVER__PORT={app_port}\n\
          ExecStart={release_dir}/{app}\n\
@@ -640,6 +656,11 @@ pub fn render_app_unit(
         app = cfg.app_name,
         user = cfg.user,
         env_file = cfg.env_file(),
+        // Point the app's config loader at the shared dir where the uploaded
+        // autumn.toml lives, so the deployed app loads the intended config
+        // instead of built-in defaults (#1952). Non-secret → unit Environment=,
+        // not the 0600 env file.
+        manifest_dir = cfg.shared_dir(),
     )
 }
 
@@ -1133,6 +1154,93 @@ fn default_release_id() -> String {
     chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string()
 }
 
+/// Resolve the local project directory the deploy reads config from.
+///
+/// Mirrors autumn-web's `find_config_file_named`: `AUTUMN_MANIFEST_DIR` wins when
+/// set (so an operator who redirects config loading also has that dir uploaded),
+/// otherwise the current working directory — the project root the rest of the
+/// deploy already treats as authoritative (the release binary is resolved as
+/// `target/release/<app>`).
+fn manifest_project_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("AUTUMN_MANIFEST_DIR")
+        && !dir.trim().is_empty()
+    {
+        return PathBuf::from(dir);
+    }
+    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+}
+
+/// Locate the RAW project config manifest file(s) to upload for #1952: the base
+/// `autumn.toml` plus, when present, the profile-override sibling
+/// `autumn-<profile>.toml` for the target deploy profile.
+///
+/// Pure over the passed `dir`/`profile` so it is unit-testable against a temp
+/// dir. We upload the raw files (NOT a flattened/merged config) because the app
+/// applies its `[profile.<AUTUMN_ENV>]` overlay at runtime — `AUTUMN_ENV` is already
+/// set in the uploaded env file — so shipping the raw manifest(s) preserves the
+/// profile structure and matches the repo exactly.
+///
+/// Both the operator's raw spelling and its canonical form are checked for the
+/// sibling (e.g. `[deploy] profile = "production"` uploads whichever of
+/// `autumn-production.toml` / `autumn-prod.toml` exist), matching the runtime's
+/// own profile-override-file lookup so the deployed app resolves config identically.
+fn manifest_uploads_in(dir: &Path, profile: &str) -> Vec<exec::ManifestUpload> {
+    let mut uploads = Vec::new();
+
+    let base = dir.join("autumn.toml");
+    if base.exists() {
+        uploads.push(exec::ManifestUpload {
+            local: base,
+            remote_basename: "autumn.toml".to_owned(),
+        });
+    }
+
+    let mut sibling_names = vec![profile.trim().to_owned()];
+    let canonical = canonicalize_deploy_profile(profile);
+    if !sibling_names.contains(&canonical) {
+        sibling_names.push(canonical);
+    }
+    for name in sibling_names {
+        if name.is_empty() {
+            continue;
+        }
+        let basename = format!("autumn-{name}.toml");
+        if uploads.iter().any(|u| u.remote_basename == basename) {
+            continue;
+        }
+        let sibling = dir.join(&basename);
+        if sibling.exists() {
+            uploads.push(exec::ManifestUpload {
+                local: sibling,
+                remote_basename: basename,
+            });
+        }
+    }
+
+    uploads
+}
+
+/// Locate the config manifest(s) to upload for the resolved deploy, reading from
+/// the local project directory ([`manifest_project_dir`]).
+fn locate_manifest_uploads(resolved: &ResolvedDeployConfig) -> Vec<exec::ManifestUpload> {
+    manifest_uploads_in(&manifest_project_dir(), &resolved.profile)
+}
+
+/// Format the operator-facing preflight line for the config-manifest upload
+/// (#1952). Pure/testable: either a LOUD no-manifest warning (kills the previous
+/// silent-defaults footgun) or a confirming line naming the uploaded file(s).
+fn manifest_preflight_notice(uploads: &[exec::ManifestUpload]) -> String {
+    if uploads.is_empty() {
+        return "\u{26A0}\u{FE0F}  warning: no autumn.toml found in the project directory; the \
+                deployed app will run built-in defaults for all non-secret settings (secrets \
+                still come from the env file). Add an autumn.toml to control the deployed \
+                configuration."
+            .to_owned();
+    }
+    let names: Vec<&str> = uploads.iter().map(|u| u.remote_basename.as_str()).collect();
+    format!("Uploading project config to shared/: {}", names.join(", "))
+}
+
 /// Perform a real deploy (issue #1607, Slices 1–3).
 ///
 /// Runs the same preflight as `check` and aborts before touching the server if
@@ -1166,6 +1274,12 @@ fn run_up(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(), 
         .ok_or_else(|| DeployError::Config(DEPLOY_HOST_MISSING_DETAIL.to_owned()))?;
     let binary = resolve_release_binary(resolved)?;
     let env_file = build_env_file(config, resolved);
+    // Locate the project config manifest(s) to upload so the deployed app loads
+    // the intended config rather than silent built-in defaults (#1952), and print
+    // a loud line either confirming the upload or warning when there is no
+    // autumn.toml to ship.
+    let manifests = locate_manifest_uploads(resolved);
+    eprintln!("{}", manifest_preflight_notice(&manifests));
     let release_id = default_release_id();
     let public_port = config.server.port;
     let proxy = proxy::KamalProxyController::new(resolved.readiness_timeout_secs)
@@ -1192,6 +1306,7 @@ fn run_up(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(), 
                 &unit,
                 env_file,
                 &binary,
+                &manifests,
                 &release_id,
                 &plan,
             );
@@ -1216,6 +1331,7 @@ fn run_up(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(), 
                 &unit,
                 env_file,
                 &binary,
+                &manifests,
                 &release_id,
                 &plan,
             );
@@ -1765,6 +1881,104 @@ mod tests {
         // Secrets come from an EnvironmentFile, never inlined into the unit.
         assert!(unit.contains("EnvironmentFile=/srv/autumn/shop/shared/autumn.env"));
         assert!(!unit.contains("Environment=SECRET"));
+        // #1952: the unit points config loading at the shared dir where the
+        // uploaded autumn.toml lives.
+        assert!(unit.contains("Environment=AUTUMN_MANIFEST_DIR=/srv/autumn/shop/shared"));
+    }
+
+    #[test]
+    fn app_unit_sets_manifest_dir_to_shared_for_uploaded_config() {
+        // #1952: the deployed slot unit (the one actually written by a deploy)
+        // sets AUTUMN_MANIFEST_DIR to the persistent shared dir so the app's
+        // config loader reads the uploaded autumn.toml instead of built-in
+        // defaults. Non-secret → an `Environment=` line, not the 0600 env file.
+        let cfg = ResolvedDeployConfig::resolve(
+            &DeployConfig {
+                app_name: Some("shop".to_owned()),
+                ..DeployConfig::default()
+            },
+            "shop",
+        )
+        .expect("deploy config resolves");
+        let unit = render_app_unit(&cfg, "/srv/autumn/shop/releases/r1", 3001, "blue");
+        assert!(
+            unit.contains("Environment=AUTUMN_MANIFEST_DIR=/srv/autumn/shop/shared"),
+            "slot unit must set AUTUMN_MANIFEST_DIR to the shared dir: {unit}"
+        );
+        // The env file (secrets) still lives in the same shared dir at 0600.
+        assert!(unit.contains("EnvironmentFile=/srv/autumn/shop/shared/autumn.env"));
+    }
+
+    #[test]
+    fn manifest_uploads_base_only_when_no_profile_sibling() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("autumn.toml"), "[server]\nport = 8080\n")
+            .expect("write autumn.toml");
+        let uploads = manifest_uploads_in(dir.path(), "prod");
+        assert_eq!(uploads.len(), 1, "only autumn.toml is present");
+        assert_eq!(uploads[0].remote_basename, "autumn.toml");
+        assert_eq!(uploads[0].local, dir.path().join("autumn.toml"));
+    }
+
+    #[test]
+    fn manifest_uploads_include_profile_sibling_when_present() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("autumn.toml"), "[server]\n").expect("write base");
+        std::fs::write(dir.path().join("autumn-prod.toml"), "[server]\n").expect("write sibling");
+        let uploads = manifest_uploads_in(dir.path(), "prod");
+        let names: Vec<&str> = uploads.iter().map(|u| u.remote_basename.as_str()).collect();
+        assert_eq!(names, vec!["autumn.toml", "autumn-prod.toml"]);
+    }
+
+    #[test]
+    fn manifest_uploads_check_canonical_profile_sibling() {
+        // `[deploy] profile = "production"` should still ship the canonical
+        // `autumn-prod.toml` if that is what the repo carries, matching the
+        // runtime's own override-file lookup.
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("autumn.toml"), "[server]\n").expect("write base");
+        std::fs::write(dir.path().join("autumn-prod.toml"), "[server]\n").expect("write sibling");
+        let uploads = manifest_uploads_in(dir.path(), "production");
+        assert!(
+            uploads
+                .iter()
+                .any(|u| u.remote_basename == "autumn-prod.toml"),
+            "canonical prod sibling is uploaded for raw profile `production`"
+        );
+    }
+
+    #[test]
+    fn manifest_uploads_empty_when_no_manifest() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let uploads = manifest_uploads_in(dir.path(), "prod");
+        assert!(uploads.is_empty(), "no autumn.toml → nothing to upload");
+    }
+
+    #[test]
+    fn manifest_notice_warns_loudly_when_no_manifest() {
+        let notice = manifest_preflight_notice(&[]);
+        assert!(
+            notice.contains("no autumn.toml") && notice.contains("built-in defaults"),
+            "no-manifest notice must loudly warn about silent defaults: {notice}"
+        );
+    }
+
+    #[test]
+    fn manifest_notice_confirms_uploaded_files() {
+        let uploads = vec![
+            exec::ManifestUpload {
+                local: PathBuf::from("/x/autumn.toml"),
+                remote_basename: "autumn.toml".to_owned(),
+            },
+            exec::ManifestUpload {
+                local: PathBuf::from("/x/autumn-prod.toml"),
+                remote_basename: "autumn-prod.toml".to_owned(),
+            },
+        ];
+        let notice = manifest_preflight_notice(&uploads);
+        assert!(notice.contains("autumn.toml"));
+        assert!(notice.contains("autumn-prod.toml"));
+        assert!(!notice.contains("no autumn.toml"));
     }
 
     #[test]

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -110,6 +110,13 @@ pub struct ResolvedDeployConfig {
     /// Profile the deployed app runs under (written to the host env file as
     /// `AUTUMN_ENV`). Defaults to the production profile (`"prod"`).
     pub profile: String,
+    /// Whether the deploy-managed proxy terminates TLS on 443 (`[deploy.tls]
+    /// enabled`). `false` (unchanged HTTP-only behavior) unless opted in.
+    pub tls_enabled: bool,
+    /// Public hostname the proxy's TLS certificate is issued for. `Some` ONLY
+    /// when TLS is enabled and a non-blank host was configured; `None` when TLS
+    /// is disabled.
+    pub tls_host: Option<String>,
 }
 
 /// Canonicalize a deploy profile string to the value the app's runtime resolver
@@ -176,8 +183,14 @@ fn trimmed_deploy_profile(raw: &str) -> String {
 impl ResolvedDeployConfig {
     /// Resolve a [`DeployConfig`] against the project name, filling in the
     /// `app_name` → `app_dir` → `service_name` default chain.
-    #[must_use]
-    pub fn resolve(cfg: &DeployConfig, project_name: &str) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns a message when `[deploy.tls] enabled = true` but no non-blank
+    /// `host` is configured — TLS cannot be provisioned without a hostname for
+    /// the certificate, so the misconfiguration is rejected before any remote
+    /// command runs.
+    pub fn resolve(cfg: &DeployConfig, project_name: &str) -> Result<Self, String> {
         let non_blank = |s: &Option<String>| {
             s.as_ref()
                 .map(|v| v.trim().to_owned())
@@ -188,7 +201,26 @@ impl ResolvedDeployConfig {
         let app_dir = non_blank(&cfg.app_dir).unwrap_or_else(|| format!("/srv/autumn/{app_name}"));
         let service_name = non_blank(&cfg.service_name).unwrap_or_else(|| app_name.clone());
 
-        Self {
+        // TLS is opt-in: when disabled, `tls_host` stays `None` and nothing about
+        // the render/deploy commands changes. When enabled, a non-blank `host` is
+        // mandatory (the certificate is issued for it).
+        let tls_host = if cfg.tls.enabled {
+            match non_blank(&cfg.tls.host) {
+                Some(host) => Some(host),
+                None => {
+                    return Err(
+                        "[deploy.tls] requires a non-empty `host` when enabled: set \
+                         `[deploy.tls] host = \"<public-hostname>\"` in autumn.toml to the DNS \
+                         name the TLS certificate should be issued for"
+                            .to_owned(),
+                    );
+                }
+            }
+        } else {
+            None
+        };
+
+        Ok(Self {
             host: non_blank(&cfg.host),
             user: cfg.user.clone(),
             ssh_port: cfg.ssh_port,
@@ -198,7 +230,9 @@ impl ResolvedDeployConfig {
             readiness_timeout_secs: cfg.readiness_timeout_secs,
             keep_releases: cfg.keep_releases,
             profile: trimmed_deploy_profile(&cfg.profile),
-        }
+            tls_enabled: cfg.tls.enabled,
+            tls_host,
+        })
     }
 
     /// Remote path to the `EnvironmentFile` holding secrets (mode `0600`), kept
@@ -780,7 +814,8 @@ pub fn run(action: DeployAction) -> Result<(), DeployError> {
     // the profile the deployed service will actually boot under (default `prod`).
     let ambient_config = AutumnConfig::load().map_err(|e| DeployError::Config(e.to_string()))?;
     let deploy_cfg = ambient_config.deploy.unwrap_or_default();
-    let resolved = ResolvedDeployConfig::resolve(&deploy_cfg, &resolve_project_name());
+    let resolved = ResolvedDeployConfig::resolve(&deploy_cfg, &resolve_project_name())
+        .map_err(DeployError::Config)?;
 
     match action {
         // `plan` is a pure dry-run over `resolved` alone — it never grades or
@@ -1137,7 +1172,8 @@ fn run_up(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(), 
     let env_file = build_env_file(config, resolved);
     let release_id = default_release_id();
     let public_port = config.server.port;
-    let proxy = proxy::KamalProxyController::new(resolved.readiness_timeout_secs);
+    let proxy = proxy::KamalProxyController::new(resolved.readiness_timeout_secs)
+        .with_tls_host(resolved.tls_host.clone());
     let executor = exec::SshExecutor::new(target);
     let release_dir = format!("{}/{release_id}", resolved.releases_dir());
 
@@ -1244,7 +1280,8 @@ fn run_rollback(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Resul
     let target = exec::SshTarget::from_resolved(resolved)
         .ok_or_else(|| DeployError::Config(DEPLOY_HOST_MISSING_DETAIL.to_owned()))?;
     let public_port = config.server.port;
-    let proxy = proxy::KamalProxyController::new(resolved.readiness_timeout_secs);
+    let proxy = proxy::KamalProxyController::new(resolved.readiness_timeout_secs)
+        .with_tls_host(resolved.tls_host.clone());
     let executor = exec::SshExecutor::new(target);
 
     // Resolve the previous release to roll back to (non-zero error if none).
@@ -1275,6 +1312,7 @@ mod tests {
 
     fn resolved_defaults() -> ResolvedDeployConfig {
         ResolvedDeployConfig::resolve(&DeployConfig::default(), "myapp")
+            .expect("deploy config resolves")
     }
 
     #[test]
@@ -1289,6 +1327,54 @@ mod tests {
         assert_eq!(resolved.keep_releases, 3);
         assert_eq!(resolved.host, None);
         assert_eq!(resolved.profile, "prod");
+        // TLS is opt-in: an absent `[deploy.tls]` table leaves it disabled.
+        assert!(!resolved.tls_enabled);
+        assert_eq!(resolved.tls_host, None);
+    }
+
+    #[test]
+    fn tls_absent_table_leaves_tls_disabled() {
+        // The default `DeployConfig` (no `[deploy.tls]`) resolves to TLS off with
+        // no host — byte-for-byte the historical HTTP-only behavior.
+        let resolved = resolved_defaults();
+        assert!(!resolved.tls_enabled);
+        assert_eq!(resolved.tls_host, None);
+    }
+
+    #[test]
+    fn tls_enabled_with_host_resolves_tls_host() {
+        let cfg = DeployConfig {
+            tls: autumn_web::config::DeployTlsConfig {
+                enabled: true,
+                host: Some("app.example.com".to_owned()),
+            },
+            ..DeployConfig::default()
+        };
+        let resolved =
+            ResolvedDeployConfig::resolve(&cfg, "myapp").expect("enabled + host resolves");
+        assert!(resolved.tls_enabled);
+        assert_eq!(resolved.tls_host.as_deref(), Some("app.example.com"));
+    }
+
+    #[test]
+    fn tls_enabled_without_host_is_a_resolve_error() {
+        // Enabling TLS without a hostname cannot provision a certificate — a hard
+        // resolve-time error, before any remote command runs.
+        for host in [None, Some(String::new()), Some("   ".to_owned())] {
+            let cfg = DeployConfig {
+                tls: autumn_web::config::DeployTlsConfig {
+                    enabled: true,
+                    host,
+                },
+                ..DeployConfig::default()
+            };
+            let err = ResolvedDeployConfig::resolve(&cfg, "myapp")
+                .expect_err("enabled TLS without a host must be rejected");
+            assert!(
+                err.contains("[deploy.tls]") && err.contains("host"),
+                "error should name the section and the missing key, got: {err}",
+            );
+        }
     }
 
     #[test]
@@ -1297,7 +1383,8 @@ mod tests {
         // the production profile so the deployed service never silently boots
         // under the `dev` fallback.
         let config = AutumnConfig::default();
-        let resolved = ResolvedDeployConfig::resolve(&DeployConfig::default(), "myapp");
+        let resolved = ResolvedDeployConfig::resolve(&DeployConfig::default(), "myapp")
+            .expect("deploy config resolves");
         let env_file = build_env_file(&config, &resolved);
         assert!(
             env_file.expose().lines().any(|l| l == "AUTUMN_ENV=prod"),
@@ -1315,7 +1402,8 @@ mod tests {
             profile: "staging".to_owned(),
             ..DeployConfig::default()
         };
-        let resolved = ResolvedDeployConfig::resolve(&cfg, "myapp");
+        let resolved =
+            ResolvedDeployConfig::resolve(&cfg, "myapp").expect("deploy config resolves");
         let env_file = build_env_file(&config, &resolved);
         assert!(
             env_file.expose().lines().any(|l| l == "AUTUMN_ENV=staging"),
@@ -1368,7 +1456,8 @@ mod tests {
         // Deploy profile defaults to `prod`; no host so the ssh_reachability
         // grader fails fast without any network I/O (we only assert on the
         // signing-secret grade below).
-        let resolved = ResolvedDeployConfig::resolve(&DeployConfig::default(), "demoapp");
+        let resolved =
+            ResolvedDeployConfig::resolve(&DeployConfig::default(), "demoapp").expect("resolves");
         assert_eq!(resolved.profile, "prod");
 
         // Force `AUTUMN_ENV=prod` (as `load_runtime_config` does) and point config
@@ -1502,7 +1591,8 @@ mod tests {
 
         // Default deploy profile is `prod` (what the env file will pin), so the
         // weak secret must FAIL preflight locally, before any remote call.
-        let prod_resolved = ResolvedDeployConfig::resolve(&DeployConfig::default(), "myapp");
+        let prod_resolved =
+            ResolvedDeployConfig::resolve(&DeployConfig::default(), "myapp").expect("resolves");
         assert_eq!(prod_resolved.profile, "prod");
         let prod_check = find_signing(&collect_preflight(&config, &prod_resolved));
         assert!(
@@ -1523,7 +1613,8 @@ mod tests {
                 ..DeployConfig::default()
             },
             "myapp",
-        );
+        )
+        .expect("deploy config resolves");
         let staging_check = find_signing(&collect_preflight(&config, &staging_resolved));
         assert!(
             staging_check.passed,
@@ -1572,7 +1663,8 @@ mod tests {
                     ..DeployConfig::default()
                 },
                 "myapp",
-            );
+            )
+            .expect("deploy config resolves");
             assert_eq!(
                 resolved.profile, expected,
                 "profile {raw:?} should preserve the trimmed raw spelling"
@@ -1609,7 +1701,8 @@ mod tests {
                 ..DeployConfig::default()
             },
             "myapp",
-        );
+        )
+        .expect("deploy config resolves");
         assert_eq!(staging.profile, "staging");
         assert!(!is_production_profile(Some(&staging.profile)));
         let staging_check = find_signing(&collect_preflight(&config, &staging));
@@ -1629,7 +1722,8 @@ mod tests {
             service_name: Some("web-svc".to_owned()),
             ..DeployConfig::default()
         };
-        let resolved = ResolvedDeployConfig::resolve(&cfg, "ignored");
+        let resolved =
+            ResolvedDeployConfig::resolve(&cfg, "ignored").expect("deploy config resolves");
         assert_eq!(resolved.app_name, "web");
         assert_eq!(resolved.app_dir, "/opt/web");
         assert_eq!(resolved.service_name, "web-svc");
@@ -1643,7 +1737,8 @@ mod tests {
             app_dir: Some(String::new()),
             ..DeployConfig::default()
         };
-        let resolved = ResolvedDeployConfig::resolve(&cfg, "fallback");
+        let resolved =
+            ResolvedDeployConfig::resolve(&cfg, "fallback").expect("deploy config resolves");
         assert_eq!(resolved.app_name, "fallback");
         assert_eq!(resolved.app_dir, "/srv/autumn/fallback");
     }
@@ -1658,7 +1753,8 @@ mod tests {
                 ..DeployConfig::default()
             },
             "shop",
-        );
+        )
+        .expect("deploy config resolves");
         let unit = render_systemd_unit(&cfg);
         assert!(unit.contains("Description=Autumn application: shop"));
         assert!(unit.contains("User=deploy"));

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -1151,6 +1151,25 @@ fn default_release_id() -> String {
 /// release serving ([`exec::execute_redeploy`]); a first deploy has no previous
 /// release and fails loudly after tearing the candidate down
 /// ([`exec::execute_first_deploy`]).
+/// The HTTPS port kamal-proxy binds unconditionally. Kept in lock-step with
+/// `proxy::DEFAULT_HTTPS_PORT`; a public/HTTP port equal to it collides.
+const PROXY_HTTPS_PORT: u16 = 443;
+
+/// Reject a deploy public/HTTP port that collides with the proxy's fixed HTTPS
+/// listener. kamal-proxy `run` always establishes both its `--http-port` (the
+/// deploy public port) and `--https-port 443` listeners, so a public port of 443
+/// makes the two collide and the proxy can never start. The guard is
+/// unconditional (not TLS-gated) because 443 is always bound.
+fn validate_public_port(public_port: u16) -> Result<(), String> {
+    if public_port == PROXY_HTTPS_PORT {
+        return Err(format!(
+            "deploy public/HTTP port cannot be {PROXY_HTTPS_PORT} — kamal-proxy reserves \
+             {PROXY_HTTPS_PORT} for its HTTPS listener; use 80 (the default) or another port",
+        ));
+    }
+    Ok(())
+}
+
 fn run_up(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(), DeployError> {
     eprintln!("\u{1F342} autumn deploy up\n");
 
@@ -1168,6 +1187,12 @@ fn run_up(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(), 
     let env_file = build_env_file(config, resolved);
     let release_id = default_release_id();
     let public_port = config.server.port;
+    // kamal-proxy `run` ALWAYS binds 443 for its HTTPS listener (regardless of any
+    // app's TLS flag), so a public/HTTP port of 443 would render
+    // `run --http-port 443 --https-port 443` and the proxy would fail to start.
+    // Reject it up front with an actionable message instead of a cryptic runtime
+    // bind failure on the host. Unconditional — 443 is always bound.
+    validate_public_port(public_port).map_err(DeployError::Config)?;
     let proxy = proxy::KamalProxyController::new(resolved.readiness_timeout_secs)
         .with_tls_host(resolved.tls_host.clone());
     let executor = exec::SshExecutor::new(target);
@@ -1309,6 +1334,21 @@ mod tests {
     fn resolved_defaults() -> ResolvedDeployConfig {
         ResolvedDeployConfig::resolve(&DeployConfig::default(), "myapp")
             .expect("deploy config resolves")
+    }
+
+    #[test]
+    fn public_port_443_is_rejected_as_a_proxy_https_collision() {
+        // kamal-proxy always binds 443 for HTTPS, so a public/HTTP port of 443
+        // collides and the proxy can't start — the guard rejects it up front with
+        // an actionable message. It is unconditional (not TLS-gated).
+        let err = validate_public_port(443).expect_err("port 443 must be rejected");
+        assert!(
+            err.contains("cannot be 443") && err.contains("kamal-proxy reserves 443"),
+            "collision message must be actionable, got: {err}",
+        );
+        // A normal public port (the default 80, or any other) is accepted.
+        assert!(validate_public_port(80).is_ok());
+        assert!(validate_public_port(8080).is_ok());
     }
 
     #[test]

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -202,47 +202,6 @@ impl DeployOp {
     }
 }
 
-/// A project config manifest file to upload into the persistent `shared/` dir so
-/// the deployed app loads the intended (non-secret) config instead of silently
-/// falling back to built-in defaults (issue #1952).
-///
-/// `local` is the on-disk source in the project directory (e.g. `./autumn.toml`
-/// or a profile sibling `./autumn-prod.toml`); `remote_basename` is the file name
-/// written under `{app_dir}/shared/`. The systemd unit sets `AUTUMN_MANIFEST_DIR`
-/// to that shared dir so the app's config loader reads these files at boot.
-///
-/// The RAW manifest is uploaded, NOT a flattened/merged config: the app applies
-/// its `[profile.<AUTUMN_ENV>]` overlay at runtime (`AUTUMN_ENV` is set in the env
-/// file), so shipping the raw manifest(s) preserves profile structure and matches
-/// the repo exactly.
-#[derive(Debug, Clone)]
-pub struct ManifestUpload {
-    /// Local source path in the project directory.
-    pub local: PathBuf,
-    /// File name to write under `{app_dir}/shared/`.
-    pub remote_basename: String,
-}
-
-/// Build the config-manifest upload ops (issue #1952).
-///
-/// Each manifest is uploaded at mode `0644` (world-readable is acceptable for
-/// non-secret project config — a repo `autumn.toml` is not a secret; secrets stay
-/// exclusively in the `0600` env file, which overrides the toml at load time).
-/// Re-uploaded on every deploy (both first deploy and cutover) so the config on
-/// the server always matches the shipped binary.
-fn manifest_upload_ops(shared_dir: &str, manifests: &[ManifestUpload]) -> Vec<DeployOp> {
-    manifests
-        .iter()
-        .map(|m| DeployOp::UploadFile {
-            label: "upload-config",
-            local: m.local.clone(),
-            remote_path: format!("{shared_dir}/{}", m.remote_basename),
-            // 0644: non-secret project config. Secrets never live here.
-            mode: Some(0o644),
-        })
-        .collect()
-}
-
 /// Errors surfaced by the deploy executor. None of these variants ever embeds a
 /// secret value — messages carry labels, remote paths, and redacted transport
 /// stderr only.
@@ -558,48 +517,39 @@ impl SlotPlan {
 /// 11. bounded `/ready` poll on the blue loopback port,
 /// 12. route the proxy at `127.0.0.1:{blue_port}`.
 #[must_use]
-// One cohesive op-plan builder; each param is a distinct injected input
-// (config, proxy, unit text, secret env, binary path, config manifests, release
-// id, slot plan) kept as parameters for pure/testable determinism.
-#[allow(clippy::too_many_arguments)]
 pub fn first_deploy_ops(
     cfg: &ResolvedDeployConfig,
     proxy: &impl ProxyController,
     unit: &str,
     env_file: Secret,
     binary_local: &Path,
-    manifests: &[ManifestUpload],
     release_id: &str,
     plan: &SlotPlan,
 ) -> Vec<DeployOp> {
     let release_dir = format!("{}/{release_id}", cfg.releases_dir());
     let remote_binary = format!("{release_dir}/{}", cfg.app_name);
-    let shared_dir = cfg.shared_dir();
+    let shared_dir = format!("{}/shared", cfg.app_dir);
     let env_path = cfg.env_file();
     let current = cfg.current_symlink();
     let unit_name = slot_unit_name(&cfg.service_name, plan.candidate_slot);
     let unit_path = format!("/etc/systemd/system/{unit_name}.service");
 
     let mut ops = proxy.ensure_installed_ops(plan.public_port);
-    ops.push(DeployOp::Run(RemoteCommand::new(
-        "prepare-dirs",
-        format!(
-            "mkdir -p {} {}",
-            shell_quote(&release_dir),
-            shell_quote(&shared_dir)
-        ),
-    )));
-    ops.push(DeployOp::UploadFile {
-        label: "upload-binary",
-        local: binary_local.to_path_buf(),
-        remote_path: remote_binary,
-        mode: Some(0o755),
-    });
-    // Upload the project config manifest(s) into the persistent shared dir so the
-    // deployed app loads the intended config instead of silent built-in defaults
-    // (#1952). The systemd unit points AUTUMN_MANIFEST_DIR here.
-    ops.extend(manifest_upload_ops(&shared_dir, manifests));
     ops.extend([
+        DeployOp::Run(RemoteCommand::new(
+            "prepare-dirs",
+            format!(
+                "mkdir -p {} {}",
+                shell_quote(&release_dir),
+                shell_quote(&shared_dir)
+            ),
+        )),
+        DeployOp::UploadFile {
+            label: "upload-binary",
+            local: binary_local.to_path_buf(),
+            remote_path: remote_binary,
+            mode: Some(0o755),
+        },
         DeployOp::WriteFile {
             label: "write-env",
             contents: FileContents::Secret(env_file),
@@ -689,29 +639,25 @@ pub fn first_deploy_ops(
 /// 14. prune old releases beyond `keep_releases`, always protecting the releases
 ///     `current` and the previous-release marker point at (rollback targets).
 #[must_use]
-// One cohesive op-plan builder; each param is a distinct injected input kept as a
-// parameter for pure/testable determinism (mirrors `first_deploy_ops`).
-#[allow(clippy::too_many_arguments)]
 pub fn cutover_ops(
     cfg: &ResolvedDeployConfig,
     proxy: &impl ProxyController,
     unit: &str,
     env_file: Secret,
     binary_local: &Path,
-    manifests: &[ManifestUpload],
     release_id: &str,
     plan: &SlotPlan,
 ) -> Vec<DeployOp> {
     let release_dir = format!("{}/{release_id}", cfg.releases_dir());
     let remote_binary = format!("{release_dir}/{}", cfg.app_name);
-    let shared_dir = cfg.shared_dir();
+    let shared_dir = format!("{}/shared", cfg.app_dir);
     let env_path = cfg.env_file();
     let current = cfg.current_symlink();
     let candidate_unit = slot_unit_name(&cfg.service_name, plan.candidate_slot);
     let candidate_unit_path = format!("/etc/systemd/system/{candidate_unit}.service");
     let live_unit = slot_unit_name(&cfg.service_name, plan.live_slot);
 
-    let mut ops = vec![
+    vec![
         DeployOp::Run(RemoteCommand::new(
             "prepare-dirs",
             format!(
@@ -726,11 +672,6 @@ pub fn cutover_ops(
             remote_path: remote_binary,
             mode: Some(0o755),
         },
-    ];
-    // Re-upload the project config manifest(s) on every redeploy so the config on
-    // the server always matches the shipped binary (#1952).
-    ops.extend(manifest_upload_ops(&shared_dir, manifests));
-    ops.extend([
         DeployOp::WriteFile {
             label: "write-env",
             contents: FileContents::Secret(env_file),
@@ -804,8 +745,7 @@ pub fn cutover_ops(
                 cfg.keep_releases,
             ),
         )),
-    ]);
-    ops
+    ]
 }
 
 /// Ops that tear down a failed candidate so a retry starts clean (Slice 3,
@@ -1824,25 +1764,9 @@ mod tests {
             &unit,
             env,
             Path::new("/local/target/release/myapp"),
-            &sample_manifests(),
             RELEASE_ID,
             &plan,
         )
-    }
-
-    /// A representative config-manifest set (base + a prod profile sibling) whose
-    /// local paths need not exist — op building never touches the filesystem.
-    fn sample_manifests() -> Vec<ManifestUpload> {
-        vec![
-            ManifestUpload {
-                local: PathBuf::from("/local/autumn.toml"),
-                remote_basename: "autumn.toml".to_owned(),
-            },
-            ManifestUpload {
-                local: PathBuf::from("/local/autumn-prod.toml"),
-                remote_basename: "autumn-prod.toml".to_owned(),
-            },
-        ]
     }
 
     /// Redeploy cutover ops: the live release is on blue, so the candidate takes
@@ -1862,7 +1786,6 @@ mod tests {
             &unit,
             env,
             Path::new("/local/target/release/myapp"),
-            &sample_manifests(),
             RELEASE_ID,
             &plan,
         )
@@ -3194,96 +3117,6 @@ mod tests {
         );
     }
 
-    /// #1952: the project config manifest is uploaded into the persistent shared
-    /// dir at 0644 on a FIRST deploy, so the app loads the intended config instead
-    /// of silent built-in defaults.
-    #[test]
-    fn first_deploy_uploads_config_manifest_to_shared_at_0644() {
-        let ops = sample_ops(Secret::new("AUTUMN_SECURITY__SIGNING_SECRET=x\n"));
-        let base = ops
-            .iter()
-            .find(|op| {
-                matches!(op, DeployOp::UploadFile { label: "upload-config", remote_path, .. }
-                    if remote_path == "/srv/autumn/myapp/shared/autumn.toml")
-            })
-            .expect("base autumn.toml is uploaded to shared/");
-        match base {
-            DeployOp::UploadFile { mode, .. } => {
-                assert_eq!(
-                    *mode,
-                    Some(0o644),
-                    "config manifest must be world-readable 0644"
-                );
-            }
-            other => panic!("upload-config should be an UploadFile op, got {other:?}"),
-        }
-        // The prod profile sibling is uploaded alongside it.
-        assert!(
-            ops.iter().any(|op| matches!(
-                op,
-                DeployOp::UploadFile { label: "upload-config", remote_path, mode: Some(0o644), .. }
-                    if remote_path == "/srv/autumn/myapp/shared/autumn-prod.toml"
-            )),
-            "profile sibling autumn-prod.toml is uploaded to shared/"
-        );
-        // The manifest lands before the unit is written / daemon-reloaded.
-        let cfg_idx = ops
-            .iter()
-            .position(|op| op.label() == "upload-config")
-            .expect("upload-config present");
-        let reload_idx = ops
-            .iter()
-            .position(|op| op.label() == "daemon-reload")
-            .expect("daemon-reload present");
-        assert!(
-            cfg_idx < reload_idx,
-            "config is uploaded before daemon-reload"
-        );
-    }
-
-    /// #1952: the manifest is re-uploaded on every redeploy so the server config
-    /// always matches the shipped binary.
-    #[test]
-    fn cutover_uploads_config_manifest_to_shared_at_0644() {
-        let ops = sample_cutover_ops(Secret::new("AUTUMN_SECURITY__SIGNING_SECRET=x\n"));
-        assert!(
-            ops.iter().any(|op| matches!(
-                op,
-                DeployOp::UploadFile { label: "upload-config", remote_path, mode: Some(0o644), .. }
-                    if remote_path == "/srv/autumn/myapp/shared/autumn.toml"
-            )),
-            "redeploy re-uploads autumn.toml to shared/ at 0644"
-        );
-    }
-
-    /// #1952: with no manifests to ship, no upload-config op is emitted (the loud
-    /// operator warning is handled at the call site, not in the op list).
-    #[test]
-    fn no_manifest_means_no_config_upload_op() {
-        let cfg = resolved();
-        let plan = SlotPlan::first(3000);
-        let unit = super::super::render_app_unit(
-            &cfg,
-            RELEASE_DIR,
-            plan.candidate_port,
-            plan.candidate_slot,
-        );
-        let ops = first_deploy_ops(
-            &cfg,
-            &proxy(),
-            &unit,
-            Secret::new("AUTUMN_SECURITY__SIGNING_SECRET=x\n"),
-            Path::new("/local/target/release/myapp"),
-            &[],
-            RELEASE_ID,
-            &plan,
-        );
-        assert!(
-            !ops.iter().any(|op| op.label() == "upload-config"),
-            "no manifest → no upload-config op"
-        );
-    }
-
     #[test]
     fn secret_debug_and_display_are_redacted() {
         let secret = Secret::new("hunter2");
@@ -3367,10 +3200,8 @@ mod tests {
         let exec = RecordingExecutor::new();
         let checks = vec![PreflightCheck::pass("ssh_reachability", "reachable")];
         execute_first_deploy(&checks, &ops, &[], &exec).expect("all checks pass → deploy runs");
-        // 2 proxy ops + 10 first-deploy ops (incl. clear-previous) + 2 config-manifest
-        // uploads (sample_manifests: autumn.toml + autumn-prod.toml, #1952) + 1 proxy
-        // route = 15.
-        assert_eq!(exec.calls().len(), 15, "the full op sequence should run");
+        // 2 proxy ops + 10 first-deploy ops (incl. clear-previous) + 1 proxy route = 13.
+        assert_eq!(exec.calls().len(), 13, "the full op sequence should run");
     }
 
     #[test]

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -202,6 +202,47 @@ impl DeployOp {
     }
 }
 
+/// A project config manifest file to upload into the persistent `shared/` dir so
+/// the deployed app loads the intended (non-secret) config instead of silently
+/// falling back to built-in defaults (issue #1952).
+///
+/// `local` is the on-disk source in the project directory (e.g. `./autumn.toml`
+/// or a profile sibling `./autumn-prod.toml`); `remote_basename` is the file name
+/// written under `{app_dir}/shared/`. The systemd unit sets `AUTUMN_MANIFEST_DIR`
+/// to that shared dir so the app's config loader reads these files at boot.
+///
+/// The RAW manifest is uploaded, NOT a flattened/merged config: the app applies
+/// its `[profile.<AUTUMN_ENV>]` overlay at runtime (`AUTUMN_ENV` is set in the env
+/// file), so shipping the raw manifest(s) preserves profile structure and matches
+/// the repo exactly.
+#[derive(Debug, Clone)]
+pub struct ManifestUpload {
+    /// Local source path in the project directory.
+    pub local: PathBuf,
+    /// File name to write under `{app_dir}/shared/`.
+    pub remote_basename: String,
+}
+
+/// Build the config-manifest upload ops (issue #1952).
+///
+/// Each manifest is uploaded at mode `0644` (world-readable is acceptable for
+/// non-secret project config — a repo `autumn.toml` is not a secret; secrets stay
+/// exclusively in the `0600` env file, which overrides the toml at load time).
+/// Re-uploaded on every deploy (both first deploy and cutover) so the config on
+/// the server always matches the shipped binary.
+fn manifest_upload_ops(shared_dir: &str, manifests: &[ManifestUpload]) -> Vec<DeployOp> {
+    manifests
+        .iter()
+        .map(|m| DeployOp::UploadFile {
+            label: "upload-config",
+            local: m.local.clone(),
+            remote_path: format!("{shared_dir}/{}", m.remote_basename),
+            // 0644: non-secret project config. Secrets never live here.
+            mode: Some(0o644),
+        })
+        .collect()
+}
+
 /// Errors surfaced by the deploy executor. None of these variants ever embeds a
 /// secret value — messages carry labels, remote paths, and redacted transport
 /// stderr only.
@@ -517,39 +558,48 @@ impl SlotPlan {
 /// 11. bounded `/ready` poll on the blue loopback port,
 /// 12. route the proxy at `127.0.0.1:{blue_port}`.
 #[must_use]
+// One cohesive op-plan builder; each param is a distinct injected input
+// (config, proxy, unit text, secret env, binary path, config manifests, release
+// id, slot plan) kept as parameters for pure/testable determinism.
+#[allow(clippy::too_many_arguments)]
 pub fn first_deploy_ops(
     cfg: &ResolvedDeployConfig,
     proxy: &impl ProxyController,
     unit: &str,
     env_file: Secret,
     binary_local: &Path,
+    manifests: &[ManifestUpload],
     release_id: &str,
     plan: &SlotPlan,
 ) -> Vec<DeployOp> {
     let release_dir = format!("{}/{release_id}", cfg.releases_dir());
     let remote_binary = format!("{release_dir}/{}", cfg.app_name);
-    let shared_dir = format!("{}/shared", cfg.app_dir);
+    let shared_dir = cfg.shared_dir();
     let env_path = cfg.env_file();
     let current = cfg.current_symlink();
     let unit_name = slot_unit_name(&cfg.service_name, plan.candidate_slot);
     let unit_path = format!("/etc/systemd/system/{unit_name}.service");
 
     let mut ops = proxy.ensure_installed_ops(plan.public_port);
+    ops.push(DeployOp::Run(RemoteCommand::new(
+        "prepare-dirs",
+        format!(
+            "mkdir -p {} {}",
+            shell_quote(&release_dir),
+            shell_quote(&shared_dir)
+        ),
+    )));
+    ops.push(DeployOp::UploadFile {
+        label: "upload-binary",
+        local: binary_local.to_path_buf(),
+        remote_path: remote_binary,
+        mode: Some(0o755),
+    });
+    // Upload the project config manifest(s) into the persistent shared dir so the
+    // deployed app loads the intended config instead of silent built-in defaults
+    // (#1952). The systemd unit points AUTUMN_MANIFEST_DIR here.
+    ops.extend(manifest_upload_ops(&shared_dir, manifests));
     ops.extend([
-        DeployOp::Run(RemoteCommand::new(
-            "prepare-dirs",
-            format!(
-                "mkdir -p {} {}",
-                shell_quote(&release_dir),
-                shell_quote(&shared_dir)
-            ),
-        )),
-        DeployOp::UploadFile {
-            label: "upload-binary",
-            local: binary_local.to_path_buf(),
-            remote_path: remote_binary,
-            mode: Some(0o755),
-        },
         DeployOp::WriteFile {
             label: "write-env",
             contents: FileContents::Secret(env_file),
@@ -639,25 +689,29 @@ pub fn first_deploy_ops(
 /// 14. prune old releases beyond `keep_releases`, always protecting the releases
 ///     `current` and the previous-release marker point at (rollback targets).
 #[must_use]
+// One cohesive op-plan builder; each param is a distinct injected input kept as a
+// parameter for pure/testable determinism (mirrors `first_deploy_ops`).
+#[allow(clippy::too_many_arguments)]
 pub fn cutover_ops(
     cfg: &ResolvedDeployConfig,
     proxy: &impl ProxyController,
     unit: &str,
     env_file: Secret,
     binary_local: &Path,
+    manifests: &[ManifestUpload],
     release_id: &str,
     plan: &SlotPlan,
 ) -> Vec<DeployOp> {
     let release_dir = format!("{}/{release_id}", cfg.releases_dir());
     let remote_binary = format!("{release_dir}/{}", cfg.app_name);
-    let shared_dir = format!("{}/shared", cfg.app_dir);
+    let shared_dir = cfg.shared_dir();
     let env_path = cfg.env_file();
     let current = cfg.current_symlink();
     let candidate_unit = slot_unit_name(&cfg.service_name, plan.candidate_slot);
     let candidate_unit_path = format!("/etc/systemd/system/{candidate_unit}.service");
     let live_unit = slot_unit_name(&cfg.service_name, plan.live_slot);
 
-    vec![
+    let mut ops = vec![
         DeployOp::Run(RemoteCommand::new(
             "prepare-dirs",
             format!(
@@ -672,6 +726,11 @@ pub fn cutover_ops(
             remote_path: remote_binary,
             mode: Some(0o755),
         },
+    ];
+    // Re-upload the project config manifest(s) on every redeploy so the config on
+    // the server always matches the shipped binary (#1952).
+    ops.extend(manifest_upload_ops(&shared_dir, manifests));
+    ops.extend([
         DeployOp::WriteFile {
             label: "write-env",
             contents: FileContents::Secret(env_file),
@@ -745,7 +804,8 @@ pub fn cutover_ops(
                 cfg.keep_releases,
             ),
         )),
-    ]
+    ]);
+    ops
 }
 
 /// Ops that tear down a failed candidate so a retry starts clean (Slice 3,
@@ -1764,9 +1824,25 @@ mod tests {
             &unit,
             env,
             Path::new("/local/target/release/myapp"),
+            &sample_manifests(),
             RELEASE_ID,
             &plan,
         )
+    }
+
+    /// A representative config-manifest set (base + a prod profile sibling) whose
+    /// local paths need not exist — op building never touches the filesystem.
+    fn sample_manifests() -> Vec<ManifestUpload> {
+        vec![
+            ManifestUpload {
+                local: PathBuf::from("/local/autumn.toml"),
+                remote_basename: "autumn.toml".to_owned(),
+            },
+            ManifestUpload {
+                local: PathBuf::from("/local/autumn-prod.toml"),
+                remote_basename: "autumn-prod.toml".to_owned(),
+            },
+        ]
     }
 
     /// Redeploy cutover ops: the live release is on blue, so the candidate takes
@@ -1786,6 +1862,7 @@ mod tests {
             &unit,
             env,
             Path::new("/local/target/release/myapp"),
+            &sample_manifests(),
             RELEASE_ID,
             &plan,
         )
@@ -3107,6 +3184,96 @@ mod tests {
         );
     }
 
+    /// #1952: the project config manifest is uploaded into the persistent shared
+    /// dir at 0644 on a FIRST deploy, so the app loads the intended config instead
+    /// of silent built-in defaults.
+    #[test]
+    fn first_deploy_uploads_config_manifest_to_shared_at_0644() {
+        let ops = sample_ops(Secret::new("AUTUMN_SECURITY__SIGNING_SECRET=x\n"));
+        let base = ops
+            .iter()
+            .find(|op| {
+                matches!(op, DeployOp::UploadFile { label: "upload-config", remote_path, .. }
+                    if remote_path == "/srv/autumn/myapp/shared/autumn.toml")
+            })
+            .expect("base autumn.toml is uploaded to shared/");
+        match base {
+            DeployOp::UploadFile { mode, .. } => {
+                assert_eq!(
+                    *mode,
+                    Some(0o644),
+                    "config manifest must be world-readable 0644"
+                );
+            }
+            other => panic!("upload-config should be an UploadFile op, got {other:?}"),
+        }
+        // The prod profile sibling is uploaded alongside it.
+        assert!(
+            ops.iter().any(|op| matches!(
+                op,
+                DeployOp::UploadFile { label: "upload-config", remote_path, mode: Some(0o644), .. }
+                    if remote_path == "/srv/autumn/myapp/shared/autumn-prod.toml"
+            )),
+            "profile sibling autumn-prod.toml is uploaded to shared/"
+        );
+        // The manifest lands before the unit is written / daemon-reloaded.
+        let cfg_idx = ops
+            .iter()
+            .position(|op| op.label() == "upload-config")
+            .expect("upload-config present");
+        let reload_idx = ops
+            .iter()
+            .position(|op| op.label() == "daemon-reload")
+            .expect("daemon-reload present");
+        assert!(
+            cfg_idx < reload_idx,
+            "config is uploaded before daemon-reload"
+        );
+    }
+
+    /// #1952: the manifest is re-uploaded on every redeploy so the server config
+    /// always matches the shipped binary.
+    #[test]
+    fn cutover_uploads_config_manifest_to_shared_at_0644() {
+        let ops = sample_cutover_ops(Secret::new("AUTUMN_SECURITY__SIGNING_SECRET=x\n"));
+        assert!(
+            ops.iter().any(|op| matches!(
+                op,
+                DeployOp::UploadFile { label: "upload-config", remote_path, mode: Some(0o644), .. }
+                    if remote_path == "/srv/autumn/myapp/shared/autumn.toml"
+            )),
+            "redeploy re-uploads autumn.toml to shared/ at 0644"
+        );
+    }
+
+    /// #1952: with no manifests to ship, no upload-config op is emitted (the loud
+    /// operator warning is handled at the call site, not in the op list).
+    #[test]
+    fn no_manifest_means_no_config_upload_op() {
+        let cfg = resolved();
+        let plan = SlotPlan::first(3000);
+        let unit = super::super::render_app_unit(
+            &cfg,
+            RELEASE_DIR,
+            plan.candidate_port,
+            plan.candidate_slot,
+        );
+        let ops = first_deploy_ops(
+            &cfg,
+            &proxy(),
+            &unit,
+            Secret::new("AUTUMN_SECURITY__SIGNING_SECRET=x\n"),
+            Path::new("/local/target/release/myapp"),
+            &[],
+            RELEASE_ID,
+            &plan,
+        );
+        assert!(
+            !ops.iter().any(|op| op.label() == "upload-config"),
+            "no manifest → no upload-config op"
+        );
+    }
+
     #[test]
     fn secret_debug_and_display_are_redacted() {
         let secret = Secret::new("hunter2");
@@ -3190,8 +3357,10 @@ mod tests {
         let exec = RecordingExecutor::new();
         let checks = vec![PreflightCheck::pass("ssh_reachability", "reachable")];
         execute_first_deploy(&checks, &ops, &[], &exec).expect("all checks pass → deploy runs");
-        // 2 proxy ops + 10 first-deploy ops (incl. clear-previous) + 1 proxy route = 13.
-        assert_eq!(exec.calls().len(), 13, "the full op sequence should run");
+        // 2 proxy ops + 10 first-deploy ops (incl. clear-previous) + 2 config-manifest
+        // uploads (sample_manifests: autumn.toml + autumn-prod.toml, #1952) + 1 proxy
+        // route = 15.
+        assert_eq!(exec.calls().len(), 15, "the full op sequence should run");
     }
 
     #[test]

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -1822,24 +1822,21 @@ mod tests {
         // The proxy unit is written to the public port; the app unit is a
         // slot-scoped unit on a SEPARATE loopback port (never the public port).
         let proxy_unit = exec.shell_for("proxy-install").expect("proxy-install ran");
-        assert!(proxy_unit.contains("enable --now kamal-proxy.service"));
-        // The proxy unit is STAGED next to the live unit (`.new` suffix), then the
-        // proxy-install op commits it into place with `mv` only when it differs —
-        // so the shared proxy is restarted only when its listener actually changed.
+        assert_eq!(
+            proxy_unit,
+            "systemctl daemon-reload && systemctl enable --now kamal-proxy.service",
+        );
+        // The proxy unit is written directly to its FINAL path — no `.new` staging
+        // path, so concurrent shared-host deploys can't race on a fixed staging
+        // file (the reworked unit is invariant to per-app TLS, so there is nothing
+        // to diff/restart to adopt).
         assert!(
             exec.calls().iter().any(|c| matches!(
                 c,
                 RecordedCall::Upload { remote_path, .. }
-                    if remote_path == "/etc/systemd/system/kamal-proxy.service.new"
+                    if remote_path == "/etc/systemd/system/kamal-proxy.service"
             )),
-            "the proxy systemd unit is staged for a diff"
-        );
-        assert!(
-            proxy_unit.contains(
-                "mv '/etc/systemd/system/kamal-proxy.service.new' \
-                '/etc/systemd/system/kamal-proxy.service'"
-            ),
-            "proxy-install commits the staged unit into place: {proxy_unit}"
+            "the proxy systemd unit is written to its final path"
         );
         let enable = exec.shell_for("enable-now").expect("enable-now ran");
         assert!(

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -1900,13 +1900,23 @@ mod tests {
         // slot-scoped unit on a SEPARATE loopback port (never the public port).
         let proxy_unit = exec.shell_for("proxy-install").expect("proxy-install ran");
         assert!(proxy_unit.contains("enable --now kamal-proxy.service"));
+        // The proxy unit is STAGED next to the live unit (`.new` suffix), then the
+        // proxy-install op commits it into place with `mv` only when it differs —
+        // so the shared proxy is restarted only when its listener actually changed.
         assert!(
             exec.calls().iter().any(|c| matches!(
                 c,
                 RecordedCall::Upload { remote_path, .. }
-                    if remote_path == "/etc/systemd/system/kamal-proxy.service"
+                    if remote_path == "/etc/systemd/system/kamal-proxy.service.new"
             )),
-            "the proxy systemd unit is written"
+            "the proxy systemd unit is staged for a diff"
+        );
+        assert!(
+            proxy_unit.contains(
+                "mv '/etc/systemd/system/kamal-proxy.service.new' \
+                '/etc/systemd/system/kamal-proxy.service'"
+            ),
+            "proxy-install commits the staged unit into place: {proxy_unit}"
         );
         let enable = exec.shell_for("enable-now").expect("enable-now ran");
         assert!(

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -1737,6 +1737,7 @@ mod tests {
             },
             "myapp",
         )
+        .expect("deploy config resolves")
     }
 
     const RELEASE_ID: &str = "20260714T120000Z";

--- a/autumn-cli/src/deploy/proxy.rs
+++ b/autumn-cli/src/deploy/proxy.rs
@@ -47,6 +47,14 @@ const KAMAL_PROXY_BIN: &str = "/usr/local/bin/kamal-proxy";
 /// Systemd unit path supervising the proxy process.
 const KAMAL_PROXY_UNIT_PATH: &str = "/etc/systemd/system/kamal-proxy.service";
 
+/// Staging path the freshly-rendered proxy unit is written to first, so
+/// [`KamalProxyController::ensure_installed_ops`] can diff it against the live
+/// unit and restart the shared proxy ONLY when its listener actually changed.
+/// It sits on the same filesystem as [`KAMAL_PROXY_UNIT_PATH`] so committing it
+/// is an atomic `mv`, and its `.new` suffix (not `.service`) keeps systemd from
+/// ever loading it as a unit.
+const KAMAL_PROXY_UNIT_STAGING_PATH: &str = "/etc/systemd/system/kamal-proxy.service.new";
+
 /// Controls the reverse proxy that fronts the public port.
 ///
 /// The methods return ordered [`DeployOp`]s (rather than driving the executor
@@ -183,18 +191,42 @@ impl KamalProxyController {
 impl ProxyController for KamalProxyController {
     fn ensure_installed_ops(&self, public_port: u16) -> Vec<DeployOp> {
         vec![
+            // Stage the freshly-rendered unit next to the live one so the install
+            // op can diff the two before committing.
             DeployOp::WriteFile {
                 label: "proxy-write-unit",
                 contents: FileContents::Plain(Self::render_proxy_unit(
                     public_port,
                     self.tls_host.is_some(),
                 )),
-                remote_path: KAMAL_PROXY_UNIT_PATH.to_owned(),
+                remote_path: KAMAL_PROXY_UNIT_STAGING_PATH.to_owned(),
                 mode: Some(0o644),
             },
+            // The proxy is SHARED ingress for every app on the host, so restarting
+            // it blips them all — it must be (re)started ONLY when its unit actually
+            // changed. `enable --now` alone is insufficient: it starts a stopped
+            // proxy but will NOT restart an already-running one, so an operator who
+            // enables TLS (which rewrites the unit to open `--https-port 443`) on a
+            // proxy that is already up would keep serving the old HTTP-only process
+            // and never bind 443. So: if the staged unit matches the live one, drop
+            // the staging copy and just make sure the proxy is enabled+running
+            // (idempotent, no restart, no blip); otherwise commit the new unit
+            // atomically, `daemon-reload`, and restart so the new listener takes
+            // effect. `restart` also cleanly covers the first-ever install, where
+            // the live unit is absent (cmp differs) and there is no running process
+            // yet — it simply starts.
             DeployOp::Run(RemoteCommand::new(
                 "proxy-install",
-                "systemctl daemon-reload && systemctl enable --now kamal-proxy.service",
+                format!(
+                    "if cmp -s {staging} {unit}; then \
+                     rm -f {staging}; systemctl enable --now kamal-proxy.service; \
+                     else \
+                     mv {staging} {unit}; systemctl daemon-reload; \
+                     systemctl enable kamal-proxy.service; \
+                     systemctl restart kamal-proxy.service; fi",
+                    staging = shell_quote(KAMAL_PROXY_UNIT_STAGING_PATH),
+                    unit = shell_quote(KAMAL_PROXY_UNIT_PATH),
+                ),
             )),
         ]
     }
@@ -298,7 +330,8 @@ mod tests {
         let proxy = KamalProxyController::new(60);
         let ops = proxy.ensure_installed_ops(8080);
         assert_eq!(ops.len(), 2);
-        // First writes the proxy systemd unit bound to the public port…
+        // First stages the proxy systemd unit (bound to the public port) next to
+        // the live unit, so the install op can diff before committing.
         match &ops[0] {
             DeployOp::WriteFile {
                 label,
@@ -307,7 +340,7 @@ mod tests {
                 ..
             } => {
                 assert_eq!(*label, "proxy-write-unit");
-                assert_eq!(remote_path, KAMAL_PROXY_UNIT_PATH);
+                assert_eq!(remote_path, KAMAL_PROXY_UNIT_STAGING_PATH);
                 let FileContents::Plain(unit) = contents else {
                     panic!("proxy unit must be plain text");
                 };
@@ -315,7 +348,81 @@ mod tests {
             }
             other => panic!("op 0 should write the proxy unit, got {other:?}"),
         }
-        // …then daemon-reloads and enables it.
+        // …then diffs it against the live unit and daemon-reloads/(re)starts it.
         assert_eq!(ops[1].label(), "proxy-install");
+    }
+
+    /// Extract the (identical-unit, changed-unit) branch bodies of the
+    /// `proxy-install` op's `if cmp -s … ; then … else … fi` shell, so a test can
+    /// assert which systemctl actions each branch performs.
+    fn proxy_install_branches(proxy: &KamalProxyController) -> (String, String) {
+        let ops = proxy.ensure_installed_ops(8080);
+        let DeployOp::Run(cmd) = &ops[1] else {
+            panic!("op 1 must be the proxy-install Run op");
+        };
+        assert_eq!(cmd.label, "proxy-install");
+        // Guard the restart on an actual unit diff so shared ingress is not blipped
+        // on every deploy.
+        assert!(
+            cmd.shell.contains("cmp -s"),
+            "install must diff staged vs live unit, got: {}",
+            cmd.shell,
+        );
+        let after_then = cmd
+            .shell
+            .split_once("; then ")
+            .expect("install shell must have a then-branch")
+            .1;
+        let (then_branch, else_branch) = after_then
+            .split_once(" else ")
+            .expect("install shell must have an else-branch");
+        (then_branch.to_owned(), else_branch.to_owned())
+    }
+
+    #[test]
+    fn proxy_restart_only_fires_when_the_unit_changed() {
+        // The changed-unit branch commits the new unit, reloads, and RESTARTS so a
+        // changed listener (e.g. TLS opening 443) actually takes effect; the
+        // no-change branch must NOT restart the shared proxy (no blip).
+        let (then_branch, else_branch) = proxy_install_branches(&KamalProxyController::new(60));
+
+        // No-change branch: never restarts.
+        assert!(
+            !then_branch.contains("restart"),
+            "no-change branch must not restart the shared proxy, got: {then_branch}",
+        );
+        // Changed branch: commit + daemon-reload BEFORE restart, so the restart
+        // loads the freshly written unit.
+        assert!(
+            else_branch.contains("mv") && else_branch.contains("systemctl daemon-reload"),
+            "changed branch must commit the unit and daemon-reload, got: {else_branch}",
+        );
+        assert!(
+            else_branch.contains("systemctl restart kamal-proxy.service"),
+            "changed branch must restart the proxy, got: {else_branch}",
+        );
+        let reload = else_branch
+            .find("systemctl daemon-reload")
+            .expect("daemon-reload present");
+        let restart = else_branch
+            .find("systemctl restart")
+            .expect("restart present");
+        assert!(
+            reload < restart,
+            "daemon-reload must precede restart, got: {else_branch}",
+        );
+    }
+
+    #[test]
+    fn proxy_install_no_change_branch_keeps_proxy_enabled_and_running() {
+        // When the unit is unchanged the proxy is left untouched apart from an
+        // idempotent `enable --now` (starts it if a reboot left it down, no-op —
+        // never a restart — when it is already up), matching the prior guarantee
+        // that the proxy is up after install without blipping a running one.
+        let (then_branch, _else_branch) = proxy_install_branches(&KamalProxyController::new(60));
+        assert!(
+            then_branch.contains("systemctl enable --now kamal-proxy.service"),
+            "no-change branch must keep the proxy enabled and running, got: {then_branch}",
+        );
     }
 }

--- a/autumn-cli/src/deploy/proxy.rs
+++ b/autumn-cli/src/deploy/proxy.rs
@@ -94,16 +94,21 @@ pub struct KamalProxyController {
     drain_timeout_secs: u64,
     /// Public hostname to terminate TLS for. `Some` ONLY when `[deploy.tls]` is
     /// enabled with a valid host: the deploy commands then carry `--host <host>
-    /// --tls` and the supervised `run` unit opens the HTTPS port. `None` (the
-    /// default) leaves every command byte-for-byte HTTP-only.
+    /// --tls`, which is what actually turns TLS on for the app (kamal-proxy
+    /// provisions a Let's Encrypt cert on-demand for that host). `None` (the
+    /// default) leaves the per-app deploy commands byte-for-byte HTTP-only. This
+    /// does NOT affect the shared `run` unit, which always binds both listeners
+    /// (see [`Self::render_proxy_unit`]).
     tls_host: Option<String>,
 }
 
 /// Default drain window for the old target after a swap.
 const DEFAULT_DRAIN_TIMEOUT_SECS: u64 = 30;
 
-/// HTTPS port the proxy terminates TLS on when `[deploy.tls]` is enabled
-/// (kamal-proxy provisions the certificate via Let's Encrypt / ACME).
+/// HTTPS port kamal-proxy binds. kamal-proxy `run` establishes both its HTTP
+/// (80/`--http-port`) and HTTPS (443/`--https-port`) listeners unconditionally,
+/// regardless of whether any app has TLS enabled; per-app TLS is turned on at
+/// `deploy` time via `--host <h> --tls`.
 const DEFAULT_HTTPS_PORT: u16 = 443;
 
 impl KamalProxyController {
@@ -159,17 +164,15 @@ impl KamalProxyController {
     /// Render the systemd unit that supervises `kamal-proxy run` on the public
     /// port. Pure — exposed for unit assertions.
     ///
-    /// When `tls_enabled`, the `run` command also opens `--https-port 443` so the
-    /// proxy terminates TLS there (automatic Let's Encrypt via kamal-proxy's
-    /// built-in `--tls`). When disabled the `ExecStart` is byte-for-byte the
-    /// HTTP-only form.
+    /// The `run` command ALWAYS opens both `--http-port {public_port}` and
+    /// `--https-port 443`: kamal-proxy establishes both listeners unconditionally
+    /// regardless of any app's TLS state, so the shared/global proxy unit is
+    /// identical whether or not any single app opts into TLS — a non-TLS app
+    /// deploy therefore never rewrites (and never restarts) the shared proxy.
+    /// Per-app TLS is enabled separately at `deploy` time via `--host <h> --tls`
+    /// (see [`Self::deploy_shell`]).
     #[must_use]
-    pub fn render_proxy_unit(public_port: u16, tls_enabled: bool) -> String {
-        let https = if tls_enabled {
-            format!(" --https-port {DEFAULT_HTTPS_PORT}")
-        } else {
-            String::new()
-        };
+    pub fn render_proxy_unit(public_port: u16) -> String {
         format!(
             "[Unit]\n\
              Description=kamal-proxy (Autumn deploy front)\n\
@@ -178,7 +181,7 @@ impl KamalProxyController {
              \n\
              [Service]\n\
              Type=simple\n\
-             ExecStart={KAMAL_PROXY_BIN} run --http-port {public_port}{https}\n\
+             ExecStart={KAMAL_PROXY_BIN} run --http-port {public_port} --https-port {DEFAULT_HTTPS_PORT}\n\
              Restart=on-failure\n\
              RestartSec=2\n\
              \n\
@@ -195,24 +198,23 @@ impl ProxyController for KamalProxyController {
             // op can diff the two before committing.
             DeployOp::WriteFile {
                 label: "proxy-write-unit",
-                contents: FileContents::Plain(Self::render_proxy_unit(
-                    public_port,
-                    self.tls_host.is_some(),
-                )),
+                contents: FileContents::Plain(Self::render_proxy_unit(public_port)),
                 remote_path: KAMAL_PROXY_UNIT_STAGING_PATH.to_owned(),
                 mode: Some(0o644),
             },
             // The proxy is SHARED ingress for every app on the host, so restarting
             // it blips them all — it must be (re)started ONLY when its unit actually
             // changed. `enable --now` alone is insufficient: it starts a stopped
-            // proxy but will NOT restart an already-running one, so an operator who
-            // enables TLS (which rewrites the unit to open `--https-port 443`) on a
-            // proxy that is already up would keep serving the old HTTP-only process
-            // and never bind 443. So: if the staged unit matches the live one, drop
-            // the staging copy and just make sure the proxy is enabled+running
-            // (idempotent, no restart, no blip); otherwise commit the new unit
-            // atomically, `daemon-reload`, and restart so the new listener takes
-            // effect. `restart` also cleanly covers the first-ever install, where
+            // proxy but will NOT restart an already-running one, so a change to the
+            // listener ports (e.g. bumping the public `--http-port`) on a proxy that
+            // is already up would keep serving the old process. So: if the staged
+            // unit matches the live one, drop the staging copy and just make sure
+            // the proxy is enabled+running (idempotent, no restart, no blip);
+            // otherwise commit the new unit atomically, `daemon-reload`, and restart
+            // so the new listener takes effect. Because the unit no longer varies
+            // with any app's TLS state (both listeners are always bound), a plain
+            // non-TLS app deploy renders an identical unit and takes the no-restart
+            // branch. `restart` also cleanly covers the first-ever install, where
             // the live unit is absent (cmp differs) and there is no running process
             // yet — it simply starts.
             DeployOp::Run(RemoteCommand::new(
@@ -309,8 +311,10 @@ mod tests {
             "route and flip share the TLS contract"
         );
 
-        // The supervised `run` unit opens the HTTPS port alongside the HTTP port so
-        // the proxy actually terminates TLS on 443.
+        // The supervised `run` unit opens the HTTPS port alongside the HTTP port.
+        // (This is unconditional — see `run_unit_always_binds_both_ports` — so
+        // enabling TLS does not change the shared unit; it is asserted here only to
+        // document that a TLS app is served on 443 by the always-bound listener.)
         let ops = proxy.ensure_installed_ops(8080);
         let DeployOp::WriteFile {
             contents: FileContents::Plain(unit),
@@ -321,7 +325,41 @@ mod tests {
         };
         assert!(
             unit.contains("kamal-proxy run --http-port 8080 --https-port 443"),
-            "TLS run unit must open both ports, got: {unit}",
+            "run unit must open both ports, got: {unit}",
+        );
+    }
+
+    #[test]
+    fn run_unit_always_binds_both_ports_regardless_of_tls() {
+        // kamal-proxy `run` establishes BOTH its HTTP and HTTPS listeners
+        // unconditionally, so the shared/global proxy unit is byte-for-byte
+        // identical whether or not any app has TLS enabled — a non-TLS app deploy
+        // never rewrites (and so never restarts) the shared proxy.
+        let http_only = KamalProxyController::new(60);
+        let with_tls =
+            KamalProxyController::new(60).with_tls_host(Some("app.example.com".to_owned()));
+
+        let unit_for = |proxy: &KamalProxyController| {
+            let ops = proxy.ensure_installed_ops(8080);
+            let DeployOp::WriteFile {
+                contents: FileContents::Plain(unit),
+                ..
+            } = &ops[0]
+            else {
+                panic!("op 0 must write the proxy unit");
+            };
+            unit.clone()
+        };
+
+        let http_only_unit = unit_for(&http_only);
+        assert!(
+            http_only_unit.contains("kamal-proxy run --http-port 8080 --https-port 443"),
+            "run unit must ALWAYS open both ports even with no app TLS, got: {http_only_unit}",
+        );
+        assert_eq!(
+            http_only_unit,
+            unit_for(&with_tls),
+            "the shared run unit must be identical regardless of any app's TLS flag",
         );
     }
 
@@ -344,7 +382,7 @@ mod tests {
                 let FileContents::Plain(unit) = contents else {
                     panic!("proxy unit must be plain text");
                 };
-                assert!(unit.contains("kamal-proxy run --http-port 8080"));
+                assert!(unit.contains("kamal-proxy run --http-port 8080 --https-port 443"));
             }
             other => panic!("op 0 should write the proxy unit, got {other:?}"),
         }
@@ -382,8 +420,8 @@ mod tests {
     #[test]
     fn proxy_restart_only_fires_when_the_unit_changed() {
         // The changed-unit branch commits the new unit, reloads, and RESTARTS so a
-        // changed listener (e.g. TLS opening 443) actually takes effect; the
-        // no-change branch must NOT restart the shared proxy (no blip).
+        // changed listener (e.g. a bumped public `--http-port`) actually takes
+        // effect; the no-change branch must NOT restart the shared proxy (no blip).
         let (then_branch, else_branch) = proxy_install_branches(&KamalProxyController::new(60));
 
         // No-change branch: never restarts.

--- a/autumn-cli/src/deploy/proxy.rs
+++ b/autumn-cli/src/deploy/proxy.rs
@@ -89,19 +89,14 @@ pub struct KamalProxyController {
     /// --tls`, which is what actually turns TLS on for the app (kamal-proxy
     /// provisions a Let's Encrypt cert on-demand for that host). `None` (the
     /// default) leaves the per-app deploy commands byte-for-byte HTTP-only. This
-    /// does NOT affect the shared `run` unit, which always binds both listeners
-    /// (see [`Self::render_proxy_unit`]).
+    /// does NOT affect the shared `run` unit, which is TLS-invariant — 443 is
+    /// bound by kamal-proxy's default HTTPS listener either way (see
+    /// [`Self::render_proxy_unit`]).
     tls_host: Option<String>,
 }
 
 /// Default drain window for the old target after a swap.
 const DEFAULT_DRAIN_TIMEOUT_SECS: u64 = 30;
-
-/// HTTPS port kamal-proxy binds. kamal-proxy `run` establishes both its HTTP
-/// (80/`--http-port`) and HTTPS (443/`--https-port`) listeners unconditionally,
-/// regardless of whether any app has TLS enabled; per-app TLS is turned on at
-/// `deploy` time via `--host <h> --tls`.
-const DEFAULT_HTTPS_PORT: u16 = 443;
 
 impl KamalProxyController {
     /// Build a controller whose flip health-check points at the candidate's
@@ -156,13 +151,16 @@ impl KamalProxyController {
     /// Render the systemd unit that supervises `kamal-proxy run` on the public
     /// port. Pure — exposed for unit assertions.
     ///
-    /// The `run` command ALWAYS opens both `--http-port {public_port}` and
-    /// `--https-port 443`: kamal-proxy establishes both listeners unconditionally
-    /// regardless of any app's TLS state, so the shared/global proxy unit is
-    /// identical whether or not any single app opts into TLS — a non-TLS app
-    /// deploy therefore never rewrites (and never restarts) the shared proxy.
-    /// Per-app TLS is enabled separately at `deploy` time via `--host <h> --tls`
-    /// (see [`Self::deploy_shell`]).
+    /// The `run` command passes only `--http-port {public_port}`. kamal-proxy
+    /// binds its HTTPS listener on 443 BY DEFAULT and that listener cannot be
+    /// disabled, so 443 is served with no explicit `--https-port` — the flag
+    /// would change no ports and only make the unit differ cosmetically. The
+    /// unit is therefore TLS-invariant: it is byte-for-byte identical whether or
+    /// not any app opts into TLS, so a non-TLS app deploy never rewrites (and
+    /// never restarts) the shared proxy. Per-app TLS is enabled separately at
+    /// `deploy` time via `--host <h> --tls` (see [`Self::deploy_shell`]), which
+    /// makes kamal-proxy provision a Let's Encrypt cert on-demand for that host
+    /// on the always-bound 443.
     #[must_use]
     pub fn render_proxy_unit(public_port: u16) -> String {
         format!(
@@ -173,7 +171,7 @@ impl KamalProxyController {
              \n\
              [Service]\n\
              Type=simple\n\
-             ExecStart={KAMAL_PROXY_BIN} run --http-port {public_port} --https-port {DEFAULT_HTTPS_PORT}\n\
+             ExecStart={KAMAL_PROXY_BIN} run --http-port {public_port}\n\
              Restart=on-failure\n\
              RestartSec=2\n\
              \n\
@@ -264,13 +262,16 @@ mod tests {
     }
 
     #[test]
-    fn tls_host_wires_host_and_tls_into_deploy_and_https_port_into_run() {
+    fn tls_host_wires_host_and_tls_into_deploy_and_leaves_run_unit_unchanged() {
         // Opt-in TLS (#1969): `[deploy.tls] enabled = true, host = "app.example.com"`
         // resolves to a controller with `tls_host = Some(..)`.
         let proxy = KamalProxyController::new(60).with_tls_host(Some("app.example.com".to_owned()));
 
         // The flip (and the identical route) carry `--host '<host>' --tls` in the
-        // STABLE position between the health-check path and the timeouts.
+        // STABLE position between the health-check path and the timeouts. This is
+        // the ONLY place TLS shows up — it turns TLS on for the app by making
+        // kamal-proxy provision a Let's Encrypt cert on-demand for that host on
+        // the always-bound 443.
         let DeployOp::Run(flip) = proxy.flip_op("myapp", "127.0.0.1:3002") else {
             panic!("flip_op must be a Run op");
         };
@@ -288,10 +289,10 @@ mod tests {
             "route and flip share the TLS contract"
         );
 
-        // The supervised `run` unit opens the HTTPS port alongside the HTTP port.
-        // (This is unconditional — see `run_unit_always_binds_both_ports` — so
-        // enabling TLS does not change the shared unit; it is asserted here only to
-        // document that a TLS app is served on 443 by the always-bound listener.)
+        // The supervised `run` unit passes ONLY `--http-port` — 443 is bound by
+        // kamal-proxy's default HTTPS listener, so no explicit `--https-port` is
+        // rendered. Enabling TLS therefore does not change the shared unit (see
+        // `run_unit_is_tls_invariant`).
         let ops = proxy.ensure_installed_ops(8080);
         let DeployOp::WriteFile {
             contents: FileContents::Plain(unit),
@@ -301,17 +302,22 @@ mod tests {
             panic!("op 0 must write the proxy unit");
         };
         assert!(
-            unit.contains("kamal-proxy run --http-port 8080 --https-port 443"),
-            "run unit must open both ports, got: {unit}",
+            unit.contains("ExecStart=/usr/local/bin/kamal-proxy run --http-port 8080\n"),
+            "run unit must pass only --http-port (443 is kamal-proxy's default), got: {unit}",
+        );
+        assert!(
+            !unit.contains("--https-port"),
+            "run unit must NOT pass an explicit --https-port, got: {unit}",
         );
     }
 
     #[test]
-    fn run_unit_always_binds_both_ports_regardless_of_tls() {
-        // kamal-proxy `run` establishes BOTH its HTTP and HTTPS listeners
-        // unconditionally, so the shared/global proxy unit is byte-for-byte
-        // identical whether or not any app has TLS enabled — a non-TLS app deploy
-        // never rewrites (and so never restarts) the shared proxy.
+    fn run_unit_is_tls_invariant() {
+        // The `run` unit passes only `--http-port` (443 is kamal-proxy's default
+        // HTTPS listener, always bound), so the shared/global proxy unit is
+        // byte-for-byte identical whether or not any app has TLS enabled — a
+        // non-TLS app deploy never rewrites (and so never restarts) the shared
+        // proxy.
         let http_only = KamalProxyController::new(60);
         let with_tls =
             KamalProxyController::new(60).with_tls_host(Some("app.example.com".to_owned()));
@@ -330,8 +336,12 @@ mod tests {
 
         let http_only_unit = unit_for(&http_only);
         assert!(
-            http_only_unit.contains("kamal-proxy run --http-port 8080 --https-port 443"),
-            "run unit must ALWAYS open both ports even with no app TLS, got: {http_only_unit}",
+            http_only_unit.contains("ExecStart=/usr/local/bin/kamal-proxy run --http-port 8080\n"),
+            "run unit must pass only --http-port, got: {http_only_unit}",
+        );
+        assert!(
+            !http_only_unit.contains("--https-port"),
+            "run unit must NOT pass an explicit --https-port, got: {http_only_unit}",
         );
         assert_eq!(
             http_only_unit,
@@ -360,7 +370,10 @@ mod tests {
                 let FileContents::Plain(unit) = contents else {
                     panic!("proxy unit must be plain text");
                 };
-                assert!(unit.contains("kamal-proxy run --http-port 8080 --https-port 443"));
+                assert!(
+                    unit.contains("ExecStart=/usr/local/bin/kamal-proxy run --http-port 8080\n")
+                );
+                assert!(!unit.contains("--https-port"));
             }
             other => panic!("op 0 should write the proxy unit, got {other:?}"),
         }

--- a/autumn-cli/src/deploy/proxy.rs
+++ b/autumn-cli/src/deploy/proxy.rs
@@ -84,21 +84,43 @@ pub struct KamalProxyController {
     deploy_timeout_secs: u64,
     /// How long the old target is drained after the swap.
     drain_timeout_secs: u64,
+    /// Public hostname to terminate TLS for. `Some` ONLY when `[deploy.tls]` is
+    /// enabled with a valid host: the deploy commands then carry `--host <host>
+    /// --tls` and the supervised `run` unit opens the HTTPS port. `None` (the
+    /// default) leaves every command byte-for-byte HTTP-only.
+    tls_host: Option<String>,
 }
 
 /// Default drain window for the old target after a swap.
 const DEFAULT_DRAIN_TIMEOUT_SECS: u64 = 30;
 
+/// HTTPS port the proxy terminates TLS on when `[deploy.tls]` is enabled
+/// (kamal-proxy provisions the certificate via Let's Encrypt / ACME).
+const DEFAULT_HTTPS_PORT: u16 = 443;
+
 impl KamalProxyController {
     /// Build a controller whose flip health-check points at the candidate's
     /// `/ready` and whose deploy timeout matches the deploy's readiness window.
+    ///
+    /// TLS is off by default (`tls_host = None`); opt in with
+    /// [`Self::with_tls_host`].
     #[must_use]
     pub fn new(readiness_timeout_secs: u64) -> Self {
         Self {
             health_check_path: "/ready".to_owned(),
             deploy_timeout_secs: readiness_timeout_secs,
             drain_timeout_secs: DEFAULT_DRAIN_TIMEOUT_SECS,
+            tls_host: None,
         }
+    }
+
+    /// Set the public hostname the proxy terminates TLS for (`[deploy.tls]`
+    /// opt-in). Pass `Some(host)` only when TLS is enabled and the host is valid;
+    /// `None` (the default) keeps the proxy HTTP-only with unchanged commands.
+    #[must_use]
+    pub fn with_tls_host(mut self, tls_host: Option<String>) -> Self {
+        self.tls_host = tls_host;
+        self
     }
 
     /// The single `kamal-proxy deploy` invocation shared by the initial route and
@@ -108,9 +130,16 @@ impl KamalProxyController {
         // Every string parameter is shell-quoted so a service name, upstream, or
         // health-check path carrying query params / special chars can't break out
         // of the command. The numeric timeouts need no quoting.
+        //
+        // TLS (opt-in): `--host <host> --tls` sits in a STABLE position between
+        // the health-check path and the timeouts. When `tls_host` is `None` the
+        // segment is empty and the command is byte-for-byte the HTTP-only form.
+        let tls = self.tls_host.as_deref().map_or_else(String::new, |host| {
+            format!("--host {host} --tls ", host = shell_quote(host))
+        });
         format!(
             "kamal-proxy deploy {service} --target {target} \
-             --health-check-path {path} --deploy-timeout {deploy}s --drain-timeout {drain}s",
+             --health-check-path {path} {tls}--deploy-timeout {deploy}s --drain-timeout {drain}s",
             service = shell_quote(service),
             target = shell_quote(target),
             path = shell_quote(&self.health_check_path),
@@ -121,8 +150,18 @@ impl KamalProxyController {
 
     /// Render the systemd unit that supervises `kamal-proxy run` on the public
     /// port. Pure — exposed for unit assertions.
+    ///
+    /// When `tls_enabled`, the `run` command also opens `--https-port 443` so the
+    /// proxy terminates TLS there (automatic Let's Encrypt via kamal-proxy's
+    /// built-in `--tls`). When disabled the `ExecStart` is byte-for-byte the
+    /// HTTP-only form.
     #[must_use]
-    pub fn render_proxy_unit(public_port: u16) -> String {
+    pub fn render_proxy_unit(public_port: u16, tls_enabled: bool) -> String {
+        let https = if tls_enabled {
+            format!(" --https-port {DEFAULT_HTTPS_PORT}")
+        } else {
+            String::new()
+        };
         format!(
             "[Unit]\n\
              Description=kamal-proxy (Autumn deploy front)\n\
@@ -131,7 +170,7 @@ impl KamalProxyController {
              \n\
              [Service]\n\
              Type=simple\n\
-             ExecStart={KAMAL_PROXY_BIN} run --http-port {public_port}\n\
+             ExecStart={KAMAL_PROXY_BIN} run --http-port {public_port}{https}\n\
              Restart=on-failure\n\
              RestartSec=2\n\
              \n\
@@ -146,7 +185,10 @@ impl ProxyController for KamalProxyController {
         vec![
             DeployOp::WriteFile {
                 label: "proxy-write-unit",
-                contents: FileContents::Plain(Self::render_proxy_unit(public_port)),
+                contents: FileContents::Plain(Self::render_proxy_unit(
+                    public_port,
+                    self.tls_host.is_some(),
+                )),
                 remote_path: KAMAL_PROXY_UNIT_PATH.to_owned(),
                 mode: Some(0o644),
             },
@@ -208,6 +250,47 @@ mod tests {
         assert_eq!(flip.label, "proxy-flip");
         assert_eq!(route.shell, flip.shell);
         assert!(flip.shell.contains("--deploy-timeout 45s"));
+    }
+
+    #[test]
+    fn tls_host_wires_host_and_tls_into_deploy_and_https_port_into_run() {
+        // Opt-in TLS (#1969): `[deploy.tls] enabled = true, host = "app.example.com"`
+        // resolves to a controller with `tls_host = Some(..)`.
+        let proxy = KamalProxyController::new(60).with_tls_host(Some("app.example.com".to_owned()));
+
+        // The flip (and the identical route) carry `--host '<host>' --tls` in the
+        // STABLE position between the health-check path and the timeouts.
+        let DeployOp::Run(flip) = proxy.flip_op("myapp", "127.0.0.1:3002") else {
+            panic!("flip_op must be a Run op");
+        };
+        assert_eq!(
+            flip.shell,
+            "kamal-proxy deploy 'myapp' --target '127.0.0.1:3002' \
+             --health-check-path '/ready' --host 'app.example.com' --tls \
+             --deploy-timeout 60s --drain-timeout 30s",
+        );
+        let DeployOp::Run(route) = proxy.route_op("myapp", "127.0.0.1:3002") else {
+            panic!("route_op must be a Run op");
+        };
+        assert_eq!(
+            route.shell, flip.shell,
+            "route and flip share the TLS contract"
+        );
+
+        // The supervised `run` unit opens the HTTPS port alongside the HTTP port so
+        // the proxy actually terminates TLS on 443.
+        let ops = proxy.ensure_installed_ops(8080);
+        let DeployOp::WriteFile {
+            contents: FileContents::Plain(unit),
+            ..
+        } = &ops[0]
+        else {
+            panic!("op 0 must write the proxy unit");
+        };
+        assert!(
+            unit.contains("kamal-proxy run --http-port 8080 --https-port 443"),
+            "TLS run unit must open both ports, got: {unit}",
+        );
     }
 
     #[test]

--- a/autumn-cli/src/deploy/proxy.rs
+++ b/autumn-cli/src/deploy/proxy.rs
@@ -47,14 +47,6 @@ const KAMAL_PROXY_BIN: &str = "/usr/local/bin/kamal-proxy";
 /// Systemd unit path supervising the proxy process.
 const KAMAL_PROXY_UNIT_PATH: &str = "/etc/systemd/system/kamal-proxy.service";
 
-/// Staging path the freshly-rendered proxy unit is written to first, so
-/// [`KamalProxyController::ensure_installed_ops`] can diff it against the live
-/// unit and restart the shared proxy ONLY when its listener actually changed.
-/// It sits on the same filesystem as [`KAMAL_PROXY_UNIT_PATH`] so committing it
-/// is an atomic `mv`, and its `.new` suffix (not `.service`) keeps systemd from
-/// ever loading it as a unit.
-const KAMAL_PROXY_UNIT_STAGING_PATH: &str = "/etc/systemd/system/kamal-proxy.service.new";
-
 /// Controls the reverse proxy that fronts the public port.
 ///
 /// The methods return ordered [`DeployOp`]s (rather than driving the executor
@@ -194,41 +186,26 @@ impl KamalProxyController {
 impl ProxyController for KamalProxyController {
     fn ensure_installed_ops(&self, public_port: u16) -> Vec<DeployOp> {
         vec![
-            // Stage the freshly-rendered unit next to the live one so the install
-            // op can diff the two before committing.
+            // Write the freshly-rendered unit directly to its final path. The unit
+            // is invariant to any app's TLS state — `run` always binds both the
+            // HTTP and HTTPS listeners (see [`Self::render_proxy_unit`]) — so it
+            // does not change when an app opts into TLS, and there is nothing to
+            // "restart to adopt". Writing straight to the final path (rather than a
+            // fixed staging path + diff/`mv`) also avoids a concurrent-deploy race:
+            // kamal-proxy is SHARED ingress, and two `deploy up` runs against the
+            // same host would otherwise interleave on one fixed staging file.
             DeployOp::WriteFile {
                 label: "proxy-write-unit",
                 contents: FileContents::Plain(Self::render_proxy_unit(public_port)),
-                remote_path: KAMAL_PROXY_UNIT_STAGING_PATH.to_owned(),
+                remote_path: KAMAL_PROXY_UNIT_PATH.to_owned(),
                 mode: Some(0o644),
             },
-            // The proxy is SHARED ingress for every app on the host, so restarting
-            // it blips them all — it must be (re)started ONLY when its unit actually
-            // changed. `enable --now` alone is insufficient: it starts a stopped
-            // proxy but will NOT restart an already-running one, so a change to the
-            // listener ports (e.g. bumping the public `--http-port`) on a proxy that
-            // is already up would keep serving the old process. So: if the staged
-            // unit matches the live one, drop the staging copy and just make sure
-            // the proxy is enabled+running (idempotent, no restart, no blip);
-            // otherwise commit the new unit atomically, `daemon-reload`, and restart
-            // so the new listener takes effect. Because the unit no longer varies
-            // with any app's TLS state (both listeners are always bound), a plain
-            // non-TLS app deploy renders an identical unit and takes the no-restart
-            // branch. `restart` also cleanly covers the first-ever install, where
-            // the live unit is absent (cmp differs) and there is no running process
-            // yet — it simply starts.
+            // Reload systemd so the (possibly first-ever) unit is picked up, then
+            // `enable --now` to make sure the shared proxy is enabled and running.
+            // Idempotent and safe on every deploy.
             DeployOp::Run(RemoteCommand::new(
                 "proxy-install",
-                format!(
-                    "if cmp -s {staging} {unit}; then \
-                     rm -f {staging}; systemctl enable --now kamal-proxy.service; \
-                     else \
-                     mv {staging} {unit}; systemctl daemon-reload; \
-                     systemctl enable kamal-proxy.service; \
-                     systemctl restart kamal-proxy.service; fi",
-                    staging = shell_quote(KAMAL_PROXY_UNIT_STAGING_PATH),
-                    unit = shell_quote(KAMAL_PROXY_UNIT_PATH),
-                ),
+                "systemctl daemon-reload && systemctl enable --now kamal-proxy.service".to_owned(),
             )),
         ]
     }
@@ -368,8 +345,9 @@ mod tests {
         let proxy = KamalProxyController::new(60);
         let ops = proxy.ensure_installed_ops(8080);
         assert_eq!(ops.len(), 2);
-        // First stages the proxy systemd unit (bound to the public port) next to
-        // the live unit, so the install op can diff before committing.
+        // Writes the proxy systemd unit (bound to the public port) directly to its
+        // FINAL path — no staging path, no diff/`mv`, so concurrent shared-host
+        // deploys can't race on a fixed staging file.
         match &ops[0] {
             DeployOp::WriteFile {
                 label,
@@ -378,7 +356,7 @@ mod tests {
                 ..
             } => {
                 assert_eq!(*label, "proxy-write-unit");
-                assert_eq!(remote_path, KAMAL_PROXY_UNIT_STAGING_PATH);
+                assert_eq!(remote_path, KAMAL_PROXY_UNIT_PATH);
                 let FileContents::Plain(unit) = contents else {
                     panic!("proxy unit must be plain text");
                 };
@@ -386,81 +364,16 @@ mod tests {
             }
             other => panic!("op 0 should write the proxy unit, got {other:?}"),
         }
-        // …then diffs it against the live unit and daemon-reloads/(re)starts it.
-        assert_eq!(ops[1].label(), "proxy-install");
-    }
-
-    /// Extract the (identical-unit, changed-unit) branch bodies of the
-    /// `proxy-install` op's `if cmp -s … ; then … else … fi` shell, so a test can
-    /// assert which systemctl actions each branch performs.
-    fn proxy_install_branches(proxy: &KamalProxyController) -> (String, String) {
-        let ops = proxy.ensure_installed_ops(8080);
+        // …then a single idempotent daemon-reload + enable --now — no change-gated
+        // restart (the unit is invariant to per-app TLS, so there is nothing to
+        // restart to adopt).
         let DeployOp::Run(cmd) = &ops[1] else {
             panic!("op 1 must be the proxy-install Run op");
         };
         assert_eq!(cmd.label, "proxy-install");
-        // Guard the restart on an actual unit diff so shared ingress is not blipped
-        // on every deploy.
-        assert!(
-            cmd.shell.contains("cmp -s"),
-            "install must diff staged vs live unit, got: {}",
+        assert_eq!(
             cmd.shell,
-        );
-        let after_then = cmd
-            .shell
-            .split_once("; then ")
-            .expect("install shell must have a then-branch")
-            .1;
-        let (then_branch, else_branch) = after_then
-            .split_once(" else ")
-            .expect("install shell must have an else-branch");
-        (then_branch.to_owned(), else_branch.to_owned())
-    }
-
-    #[test]
-    fn proxy_restart_only_fires_when_the_unit_changed() {
-        // The changed-unit branch commits the new unit, reloads, and RESTARTS so a
-        // changed listener (e.g. a bumped public `--http-port`) actually takes
-        // effect; the no-change branch must NOT restart the shared proxy (no blip).
-        let (then_branch, else_branch) = proxy_install_branches(&KamalProxyController::new(60));
-
-        // No-change branch: never restarts.
-        assert!(
-            !then_branch.contains("restart"),
-            "no-change branch must not restart the shared proxy, got: {then_branch}",
-        );
-        // Changed branch: commit + daemon-reload BEFORE restart, so the restart
-        // loads the freshly written unit.
-        assert!(
-            else_branch.contains("mv") && else_branch.contains("systemctl daemon-reload"),
-            "changed branch must commit the unit and daemon-reload, got: {else_branch}",
-        );
-        assert!(
-            else_branch.contains("systemctl restart kamal-proxy.service"),
-            "changed branch must restart the proxy, got: {else_branch}",
-        );
-        let reload = else_branch
-            .find("systemctl daemon-reload")
-            .expect("daemon-reload present");
-        let restart = else_branch
-            .find("systemctl restart")
-            .expect("restart present");
-        assert!(
-            reload < restart,
-            "daemon-reload must precede restart, got: {else_branch}",
-        );
-    }
-
-    #[test]
-    fn proxy_install_no_change_branch_keeps_proxy_enabled_and_running() {
-        // When the unit is unchanged the proxy is left untouched apart from an
-        // idempotent `enable --now` (starts it if a reboot left it down, no-op —
-        // never a restart — when it is already up), matching the prior guarantee
-        // that the proxy is up after install without blipping a running one.
-        let (then_branch, _else_branch) = proxy_install_branches(&KamalProxyController::new(60));
-        assert!(
-            then_branch.contains("systemctl enable --now kamal-proxy.service"),
-            "no-change branch must keep the proxy enabled and running, got: {then_branch}",
+            "systemctl daemon-reload && systemctl enable --now kamal-proxy.service",
         );
     }
 }

--- a/autumn-cli/tests/deploy_e2e.rs
+++ b/autumn-cli/tests/deploy_e2e.rs
@@ -567,34 +567,6 @@ fn deploy_e2e_full_lifecycle() {
     );
     eprintln!("[e2e]    (simulated reboot survival: {APP_NAME}-blue.service is enabled)");
 
-    // AC (#1952): the project `autumn.toml` is uploaded into the persistent
-    // shared dir and the slot unit points AUTUMN_MANIFEST_DIR at it, so the
-    // deployed app loads the intended config instead of silent built-in defaults.
-    let manifest_present = ws.ssh(
-        ssh_port,
-        &format!(
-            "test -f /srv/autumn/{APP_NAME}/shared/autumn.toml && echo present || echo missing"
-        ),
-    );
-    assert_eq!(
-        String::from_utf8_lossy(&manifest_present.stdout).trim(),
-        "present",
-        "the project autumn.toml should be uploaded to the shared dir (#1952)"
-    );
-    let unit_has_manifest_dir = ws.ssh(
-        ssh_port,
-        &format!("grep -c 'AUTUMN_MANIFEST_DIR=/srv/autumn/{APP_NAME}/shared' /etc/systemd/system/{APP_NAME}-blue.service || true"),
-    );
-    assert!(
-        String::from_utf8_lossy(&unit_has_manifest_dir.stdout)
-            .trim()
-            .parse::<u32>()
-            .unwrap_or(0)
-            >= 1,
-        "the slot unit should set AUTUMN_MANIFEST_DIR to the shared dir (#1952)"
-    );
-    eprintln!("[e2e]    (#1952: autumn.toml uploaded to shared/ and AUTUMN_MANIFEST_DIR set)");
-
     // ── 2. Zero-downtime redeploy (v2) under load (AC-2) ────────────────────
     thread::sleep(Duration::from_millis(1200)); // distinct per-second release id
     ws.stage_release(&ws.app_v2);

--- a/autumn-cli/tests/deploy_e2e.rs
+++ b/autumn-cli/tests/deploy_e2e.rs
@@ -567,6 +567,34 @@ fn deploy_e2e_full_lifecycle() {
     );
     eprintln!("[e2e]    (simulated reboot survival: {APP_NAME}-blue.service is enabled)");
 
+    // AC (#1952): the project `autumn.toml` is uploaded into the persistent
+    // shared dir and the slot unit points AUTUMN_MANIFEST_DIR at it, so the
+    // deployed app loads the intended config instead of silent built-in defaults.
+    let manifest_present = ws.ssh(
+        ssh_port,
+        &format!(
+            "test -f /srv/autumn/{APP_NAME}/shared/autumn.toml && echo present || echo missing"
+        ),
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&manifest_present.stdout).trim(),
+        "present",
+        "the project autumn.toml should be uploaded to the shared dir (#1952)"
+    );
+    let unit_has_manifest_dir = ws.ssh(
+        ssh_port,
+        &format!("grep -c 'AUTUMN_MANIFEST_DIR=/srv/autumn/{APP_NAME}/shared' /etc/systemd/system/{APP_NAME}-blue.service || true"),
+    );
+    assert!(
+        String::from_utf8_lossy(&unit_has_manifest_dir.stdout)
+            .trim()
+            .parse::<u32>()
+            .unwrap_or(0)
+            >= 1,
+        "the slot unit should set AUTUMN_MANIFEST_DIR to the shared dir (#1952)"
+    );
+    eprintln!("[e2e]    (#1952: autumn.toml uploaded to shared/ and AUTUMN_MANIFEST_DIR set)");
+
     // ── 2. Zero-downtime redeploy (v2) under load (AC-2) ────────────────────
     thread::sleep(Duration::from_millis(1200)); // distinct per-second release id
     ws.stage_release(&ws.app_v2);

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -6570,7 +6570,7 @@ pub struct CompressionConfig {
 // Exposed for autumn-cli's `autumn deploy` preflight (doctor) to reuse the deploy env-override logic; not yet a stable public API.
 #[doc(hidden)]
 pub fn apply_deploy_env_overrides(deploy: &mut Option<DeployConfig>, env: &dyn Env) {
-    const KEYS: [&str; 9] = [
+    const KEYS: [&str; 11] = [
         "AUTUMN_DEPLOY__HOST",
         "AUTUMN_DEPLOY__USER",
         "AUTUMN_DEPLOY__SSH_PORT",
@@ -6580,6 +6580,8 @@ pub fn apply_deploy_env_overrides(deploy: &mut Option<DeployConfig>, env: &dyn E
         "AUTUMN_DEPLOY__READINESS_TIMEOUT_SECS",
         "AUTUMN_DEPLOY__KEEP_RELEASES",
         "AUTUMN_DEPLOY__PROFILE",
+        "AUTUMN_DEPLOY__TLS__ENABLED",
+        "AUTUMN_DEPLOY__TLS__HOST",
     ];
     if !KEYS.iter().any(|key| env.var(key).is_ok()) {
         return;
@@ -6602,6 +6604,10 @@ pub fn apply_deploy_env_overrides(deploy: &mut Option<DeployConfig>, env: &dyn E
         &mut deploy.keep_releases,
     );
     parse_env_string(env, "AUTUMN_DEPLOY__PROFILE", &mut deploy.profile);
+    // Opt-in TLS for the deploy-managed proxy (#1969). Env wins over TOML, matching
+    // every other deploy override above.
+    parse_env_bool(env, "AUTUMN_DEPLOY__TLS__ENABLED", &mut deploy.tls.enabled);
+    parse_env_option_string(env, "AUTUMN_DEPLOY__TLS__HOST", &mut deploy.tls.host);
 }
 
 /// Parse an environment variable into a typed target, logging a warning on failure.
@@ -10625,6 +10631,49 @@ path = "/healthz"
         assert_eq!(deploy.keep_releases, 5);
         assert_eq!(deploy.profile, "staging");
         assert!(deploy.validate().is_ok());
+    }
+
+    #[test]
+    fn env_override_sets_deploy_tls_enabled_and_host() {
+        // Opt-in TLS (#1969) can be driven entirely from the environment: setting
+        // both keys materializes `[deploy]` with TLS on and the host — the exact
+        // precondition under which the CLI resolves `tls_host == Some(host)`.
+        let env = MockEnv::new()
+            .with("AUTUMN_DEPLOY__TLS__ENABLED", "true")
+            .with("AUTUMN_DEPLOY__TLS__HOST", "app.example.com");
+        let mut config = AutumnConfig::default();
+        assert!(config.deploy.is_none());
+        config.apply_env_overrides_with_env(&env);
+        let deploy = config.deploy.expect("env should materialize deploy");
+        assert!(deploy.tls.enabled);
+        assert_eq!(deploy.tls.host.as_deref(), Some("app.example.com"));
+    }
+
+    #[test]
+    fn env_override_wins_over_toml_deploy_tls_host() {
+        // TOML configures a TLS host...
+        let mut config: AutumnConfig = toml::from_str(
+            r#"
+            [deploy]
+            host = "203.0.113.10"
+
+            [deploy.tls]
+            enabled = true
+            host = "toml.example.com"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(
+            config.deploy.as_ref().unwrap().tls.host.as_deref(),
+            Some("toml.example.com"),
+        );
+
+        // ...and the env var overrides it, matching every other deploy override.
+        let env = MockEnv::new().with("AUTUMN_DEPLOY__TLS__HOST", "env.example.com");
+        config.apply_env_overrides_with_env(&env);
+        let deploy = config.deploy.unwrap();
+        assert!(deploy.tls.enabled);
+        assert_eq!(deploy.tls.host.as_deref(), Some("env.example.com"));
     }
 
     #[test]

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -1228,6 +1228,39 @@ pub struct AutumnConfig {
     pub alerts: Box<crate::alerts::AlertConfig>,
 }
 
+/// Opt-in TLS termination at the deploy-managed reverse proxy (`[deploy.tls]`
+/// table, issue #1969).
+///
+/// Absent/disabled by default, so a deploy without this table is byte-for-byte
+/// the historical HTTP-only behavior. When `enabled = true`, `autumn deploy`
+/// wires the public `host` into kamal-proxy (`--host`/`--tls`) so the proxy
+/// terminates TLS on 443 with an automatic Let's Encrypt certificate.
+///
+/// TLS terminates at the PROXY only — the app itself keeps serving plain HTTP on
+/// its private loopback port, and its readiness/health probes are unaffected. Do
+/// NOT also enable in-process `[server.tls]`/ACME on a deploy-managed app.
+///
+/// # `autumn.toml` example
+///
+/// ```toml
+/// [deploy.tls]
+/// enabled = true
+/// host = "app.example.com"
+/// ```
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct DeployTlsConfig {
+    /// Whether the deploy-managed proxy terminates TLS on 443. Default: `false`
+    /// (HTTP-only, unchanged behavior).
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Public hostname the certificate is issued for (the DNS name pointing at
+    /// the server). Required when `enabled = true`; enforced at resolve time by
+    /// the CLI's `ResolvedDeployConfig::resolve`.
+    #[serde(default)]
+    pub host: Option<String>,
+}
+
 /// Push-button VPS deploy settings (`[deploy]` section, issue #1607).
 ///
 /// Describes the SSH-reachable target server and the remote install layout for
@@ -1298,6 +1331,12 @@ pub struct DeployConfig {
     /// for non-prod targets.
     #[serde(default = "default_deploy_profile")]
     pub profile: String,
+
+    /// Opt-in TLS termination at the deploy-managed reverse proxy
+    /// (`[deploy.tls]`). Disabled by default — an absent table is byte-for-byte
+    /// the historical HTTP-only behavior. See [`DeployTlsConfig`].
+    #[serde(default)]
+    pub tls: DeployTlsConfig,
 }
 
 impl Default for DeployConfig {
@@ -1312,6 +1351,7 @@ impl Default for DeployConfig {
             readiness_timeout_secs: default_deploy_readiness_timeout_secs(),
             keep_releases: default_deploy_keep_releases(),
             profile: default_deploy_profile(),
+            tls: DeployTlsConfig::default(),
         }
     }
 }

--- a/autumn/tests/fixtures/schema_keys.snapshot
+++ b/autumn/tests/fixtures/schema_keys.snapshot
@@ -120,6 +120,9 @@ deploy.profile
 deploy.readiness_timeout_secs
 deploy.service_name
 deploy.ssh_port
+deploy.tls
+deploy.tls.enabled
+deploy.tls.host
 deploy.user
 dev
 dev.inspector_capacity

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -155,24 +155,26 @@ AUTUMN_DATABASE__URL=postgres://user:pass@db-host:5432/myapp_prod
 > profile = "staging"` in `autumn.toml` (or `AUTUMN_DEPLOY__PROFILE=staging`);
 > the deploy writes that value as `AUTUMN_ENV` instead.
 
-> **Your `autumn.toml` is deployed alongside the binary.** `autumn deploy up`
-> uploads your project's `autumn.toml` (and, when present, the profile sibling
-> `autumn-<profile>.toml`) into `app_dir/shared/` and sets
-> `AUTUMN_MANIFEST_DIR=app_dir/shared` in the systemd unit, so at startup the app
-> loads the same non-secret configuration you tested locally — auth, the jobs and
+> **Your `autumn.toml` is not deployed — non-secret settings fall back to
+> defaults on the host.** `autumn deploy up` uploads the release binary and
+> writes the host env file, but it does **not** copy your project's
+> `autumn.toml`. The systemd unit runs the binary with its working directory set
+> to the release dir (which holds only the binary), so at startup the app finds
+> no `autumn.toml` and every non-secret runtime setting — auth, the jobs and
 > scheduler backends, health/telemetry paths, CORS, signing-secret rotation
-> (`security.signing_secret.previous_secrets`), and so on — instead of falling
-> back to built-in defaults (fixes
-> [#1952](https://github.com/madmax983/autumn/issues/1952)). The raw manifest is
-> uploaded, not a flattened copy, so the app still applies its
-> `[profile.<AUTUMN_ENV>]` overlay at runtime; the manifest is re-uploaded on
-> every `deploy up` so the config on the server always matches the shipped binary.
-> If no `autumn.toml` is found in the project directory, the deploy prints a loud
-> warning and the app runs built-in defaults for all non-secret settings.
-> **Secrets never go in the manifest** — the manifest is world-readable (`0644`),
-> while the signing secret, database URL, and `AUTUMN_ENV` continue to travel only
-> in the `0600` host env file (`app_dir/shared/autumn.env`), which overrides the
-> `autumn.toml` at load time.
+> (`security.signing_secret.previous_secrets`), and so on — resolves to its
+> **default**, regardless of what you configured and tested locally (the `prod`
+> profile still applies its smart-defaults). Only the three values in the host
+> env file (`AUTUMN_SECURITY__SIGNING_SECRET`; for database-backed apps,
+> `AUTUMN_DATABASE__URL`; and `AUTUMN_ENV`, the profile selector) make the trip.
+> This is a known gap tracked in
+> [#1952](https://github.com/madmax983/autumn/issues/1952). Do **not** try to
+> work around it by hand-editing `app_dir/shared/autumn.env`: the deploy
+> **rebuilds that file from scratch on every `deploy up`** (writing exactly the
+> signing secret, database URL, and `AUTUMN_ENV`), so any overrides you add there
+> are overwritten on the next deploy. Until #1952 lands, re-apply the non-secret
+> configuration you need out of band on the host after each deploy. Otherwise the
+> deployed app can run a different configuration than the one you tested locally.
 
 Generate the signing secret once and store it somewhere durable:
 
@@ -336,18 +338,18 @@ or error messages.
   default); any other runtime secret (OAuth/SMTP/Redis/storage/etc.) must be
   provisioned on the target separately. The file is rebuilt on every `deploy
   up`, so hand-added entries do not persist.
-- **Your project's `autumn.toml` is deployed**
+- **Your project's `autumn.toml` is not deployed**
   ([#1952](https://github.com/madmax983/autumn/issues/1952)). `autumn deploy up`
-  uploads your `autumn.toml` (and the profile sibling `autumn-<profile>.toml`
-  when present) into `app_dir/shared/` at mode `0644` and sets
-  `AUTUMN_MANIFEST_DIR=app_dir/shared` in the systemd unit, so the app loads the
-  same non-secret configuration (auth, jobs and scheduler backends,
-  health/telemetry paths, CORS, signing-secret rotation `previous_secrets`, etc.)
-  you tested locally rather than falling back to built-in defaults. The manifest
-  is re-uploaded on every `deploy up`; secrets never go in it — they stay in the
-  `0600` host env file, which overrides `autumn.toml` at load time. When no
-  `autumn.toml` is found locally the deploy prints a loud warning and the app
-  runs built-in defaults.
+  uploads the release binary and writes the host env file (signing secret +
+  database URL + `AUTUMN_ENV`) but does not copy `autumn.toml`, and the app runs
+  from the release dir where none is present — so every non-secret runtime
+  setting (auth, jobs and scheduler backends, health/telemetry paths, CORS,
+  signing-secret rotation `previous_secrets`, etc.) resolves to its **default**
+  on the server. Hand-editing `app_dir/shared/autumn.env` is not a workaround —
+  the file is rebuilt on every `deploy up` — so until #1952 lands, re-apply any
+  non-secret config you need out of band on the host after each deploy.
+  Otherwise the deployed app can run a different configuration than the one you
+  tested locally.
 - **Migrations run on redeploys, not on the very first deploy.** The pre-cutover
   migration one-shot is part of the zero-downtime redeploy path; the initial
   `deploy up` stands the release up and health-gates it. For a database-backed

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -50,24 +50,25 @@ below and are better fits in specific cases:
   portable OCI image you run on Kubernetes, ECS, Nomad, or any Docker host.
 
 > **HTTPS/TLS.** kamal-proxy fronts your app and listens on your configured
-> public HTTP port (`server.port`) and **443**. **For automatic TLS, set
-> `server.port = 80`** so Let's Encrypt HTTP-01 validation and the HTTP→HTTPS
-> redirect (both of which use port 80) work — the deploy enforces this when
-> `[deploy.tls]` is enabled. By default `autumn deploy` provisions no
-> certificate for your app, so nothing is served over HTTPS until you opt in. Set
-> `[deploy.tls] enabled = true` and `host = "app.example.com"` in `autumn.toml`
-> to have `autumn deploy` pass `--host`/`--tls` on your app's kamal-proxy
-> route/flip, so kamal-proxy provisions an **automatic Let's Encrypt** certificate
-> for that host on-demand and terminates TLS for it on the already-bound 443
-> listener. (An external TLS terminator in front of the proxy — a load balancer or
-> reverse proxy that owns the certificate and forwards plain HTTP — remains a
-> valid alternative when a platform already handles certificates.) Either way TLS
-> terminates at the **proxy**: don't enable in-process
-> `[server.tls]`/ACME on a deploy-managed app — deploy binds each slot to a
-> private loopback HTTP port that the readiness gate and kamal-proxy target over
-> plain HTTP, so a TLS listener there breaks its health checks. See the [TLS &
-> HTTPS guide](./tls.md) for the full picture, including in-process TLS for
-> self-run apps.
+> public HTTP port (`server.port`) and, **by default, 443** — its HTTPS listener
+> is always bound and cannot be disabled. By default `autumn deploy` provisions
+> no certificate for your app, so nothing is served over HTTPS until you opt in.
+> Set `[deploy.tls] enabled = true` and `host = "app.example.com"` in
+> `autumn.toml` to have `autumn deploy` pass `--host`/`--tls` on your app's
+> kamal-proxy route/flip, so kamal-proxy provisions an **automatic Let's
+> Encrypt** certificate for that host on-demand and terminates TLS for it on its
+> always-bound 443 listener. This needs **no `server.port` change** — issuance
+> uses TLS-ALPN-01 on the already-bound 443, so it works on both the first deploy
+> and a later redeploy. Setting `server.port = 80` is **recommended** (it is the
+> default) so the proxy also serves HTTP on 80 for the HTTP→HTTPS redirect, but
+> it is not required. An external TLS terminator sharing the same host is **not**
+> supported (kamal-proxy always binds 443 and cannot release it); run such a
+> terminator on a separate host in front of the deploy host instead. Either way
+> TLS terminates at the **proxy**: don't enable in-process `[server.tls]`/ACME on
+> a deploy-managed app — deploy binds each slot to a private loopback HTTP port
+> that the readiness gate and kamal-proxy target over plain HTTP, so a TLS
+> listener there breaks its health checks. See the [TLS & HTTPS guide](./tls.md)
+> for the full picture, including in-process TLS for self-run apps.
 
 > **Version.** The `autumn deploy` subcommands (`check` / `plan` / `up` /
 > `rollback`) are newer than the `autumn-cli 0.5.0` pinned under

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -155,26 +155,24 @@ AUTUMN_DATABASE__URL=postgres://user:pass@db-host:5432/myapp_prod
 > profile = "staging"` in `autumn.toml` (or `AUTUMN_DEPLOY__PROFILE=staging`);
 > the deploy writes that value as `AUTUMN_ENV` instead.
 
-> **Your `autumn.toml` is not deployed — non-secret settings fall back to
-> defaults on the host.** `autumn deploy up` uploads the release binary and
-> writes the host env file, but it does **not** copy your project's
-> `autumn.toml`. The systemd unit runs the binary with its working directory set
-> to the release dir (which holds only the binary), so at startup the app finds
-> no `autumn.toml` and every non-secret runtime setting — auth, the jobs and
+> **Your `autumn.toml` is deployed alongside the binary.** `autumn deploy up`
+> uploads your project's `autumn.toml` (and, when present, the profile sibling
+> `autumn-<profile>.toml`) into `app_dir/shared/` and sets
+> `AUTUMN_MANIFEST_DIR=app_dir/shared` in the systemd unit, so at startup the app
+> loads the same non-secret configuration you tested locally — auth, the jobs and
 > scheduler backends, health/telemetry paths, CORS, signing-secret rotation
-> (`security.signing_secret.previous_secrets`), and so on — resolves to its
-> **default**, regardless of what you configured and tested locally (the `prod`
-> profile still applies its smart-defaults). Only the three values in the host
-> env file (`AUTUMN_SECURITY__SIGNING_SECRET`; for database-backed apps,
-> `AUTUMN_DATABASE__URL`; and `AUTUMN_ENV`, the profile selector) make the trip.
-> This is a known gap tracked in
-> [#1952](https://github.com/madmax983/autumn/issues/1952). Do **not** try to
-> work around it by hand-editing `app_dir/shared/autumn.env`: the deploy
-> **rebuilds that file from scratch on every `deploy up`** (writing exactly the
-> signing secret, database URL, and `AUTUMN_ENV`), so any overrides you add there
-> are overwritten on the next deploy. Until #1952 lands, re-apply the non-secret
-> configuration you need out of band on the host after each deploy. Otherwise the
-> deployed app can run a different configuration than the one you tested locally.
+> (`security.signing_secret.previous_secrets`), and so on — instead of falling
+> back to built-in defaults (fixes
+> [#1952](https://github.com/madmax983/autumn/issues/1952)). The raw manifest is
+> uploaded, not a flattened copy, so the app still applies its
+> `[profile.<AUTUMN_ENV>]` overlay at runtime; the manifest is re-uploaded on
+> every `deploy up` so the config on the server always matches the shipped binary.
+> If no `autumn.toml` is found in the project directory, the deploy prints a loud
+> warning and the app runs built-in defaults for all non-secret settings.
+> **Secrets never go in the manifest** — the manifest is world-readable (`0644`),
+> while the signing secret, database URL, and `AUTUMN_ENV` continue to travel only
+> in the `0600` host env file (`app_dir/shared/autumn.env`), which overrides the
+> `autumn.toml` at load time.
 
 Generate the signing secret once and store it somewhere durable:
 
@@ -338,18 +336,18 @@ or error messages.
   default); any other runtime secret (OAuth/SMTP/Redis/storage/etc.) must be
   provisioned on the target separately. The file is rebuilt on every `deploy
   up`, so hand-added entries do not persist.
-- **Your project's `autumn.toml` is not deployed**
+- **Your project's `autumn.toml` is deployed**
   ([#1952](https://github.com/madmax983/autumn/issues/1952)). `autumn deploy up`
-  uploads the release binary and writes the host env file (signing secret +
-  database URL + `AUTUMN_ENV`) but does not copy `autumn.toml`, and the app runs
-  from the release dir where none is present — so every non-secret runtime
-  setting (auth, jobs and scheduler backends, health/telemetry paths, CORS,
-  signing-secret rotation `previous_secrets`, etc.) resolves to its **default**
-  on the server. Hand-editing `app_dir/shared/autumn.env` is not a workaround —
-  the file is rebuilt on every `deploy up` — so until #1952 lands, re-apply any
-  non-secret config you need out of band on the host after each deploy.
-  Otherwise the deployed app can run a different configuration than the one you
-  tested locally.
+  uploads your `autumn.toml` (and the profile sibling `autumn-<profile>.toml`
+  when present) into `app_dir/shared/` at mode `0644` and sets
+  `AUTUMN_MANIFEST_DIR=app_dir/shared` in the systemd unit, so the app loads the
+  same non-secret configuration (auth, jobs and scheduler backends,
+  health/telemetry paths, CORS, signing-secret rotation `previous_secrets`, etc.)
+  you tested locally rather than falling back to built-in defaults. The manifest
+  is re-uploaded on every `deploy up`; secrets never go in it — they stay in the
+  `0600` host env file, which overrides `autumn.toml` at load time. When no
+  `autumn.toml` is found locally the deploy prints a loud warning and the app
+  runs built-in defaults.
 - **Migrations run on redeploys, not on the very first deploy.** The pre-cutover
   migration one-shot is part of the zero-downtime redeploy path; the initial
   `deploy up` stands the release up and health-gates it. For a database-backed

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -49,8 +49,11 @@ below and are better fits in specific cases:
   [How the production image works](#how-the-production-image-works)) — a
   portable OCI image you run on Kubernetes, ECS, Nomad, or any Docker host.
 
-> **HTTPS/TLS.** kamal-proxy fronts your app and always listens on both 80 and
-> **443** (its defaults), but by default `autumn deploy` provisions no
+> **HTTPS/TLS.** kamal-proxy fronts your app and listens on your configured
+> public HTTP port (`server.port`) and **443**. **For automatic TLS, set
+> `server.port = 80`** so Let's Encrypt HTTP-01 validation and the HTTP→HTTPS
+> redirect (both of which use port 80) work — the deploy enforces this when
+> `[deploy.tls]` is enabled. By default `autumn deploy` provisions no
 > certificate for your app, so nothing is served over HTTPS until you opt in. Set
 > `[deploy.tls] enabled = true` and `host = "app.example.com"` in `autumn.toml`
 > to have `autumn deploy` pass `--host`/`--tls` on your app's kamal-proxy

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -49,17 +49,16 @@ below and are better fits in specific cases:
   [How the production image works](#how-the-production-image-works)) — a
   portable OCI image you run on Kubernetes, ECS, Nomad, or any Docker host.
 
-> **HTTPS/TLS.** kamal-proxy fronts your app on the public port, but as
-> configured by `autumn deploy` today it listens on plain **HTTP** and does
-> **not** provision a TLS certificate — so following this path as shipped serves
-> HTTP on the public port. To serve HTTPS on the deploy path, place an
-> **external TLS terminator in front of** the deploy-managed kamal-proxy: a
-> TLS-terminating load balancer or reverse proxy that owns the certificate and
-> forwards plain HTTP to the kamal-proxy public port. The deploy-managed
-> kamal-proxy is HTTP-only — `autumn deploy` runs it as `kamal-proxy run
-> --http-port` and issues `kamal-proxy deploy --target --health-check-path` with
-> no `--host`/`--tls`, so it can't create or preserve TLS on that proxy. Don't
-> enable in-process
+> **HTTPS/TLS.** kamal-proxy fronts your app on the public port. By default
+> `autumn deploy` listens on plain **HTTP** and provisions no certificate, so the
+> path serves HTTP until you opt in. Set `[deploy.tls] enabled = true` and
+> `host = "app.example.com"` in `autumn.toml` to have `autumn deploy` wire
+> `--host`/`--tls` into kamal-proxy (and open `--https-port 443`), so the proxy
+> terminates TLS on 443 with an **automatic Let's Encrypt** certificate. (An
+> external TLS terminator in front of the HTTP proxy — a load balancer or reverse
+> proxy that owns the certificate and forwards plain HTTP — remains a valid
+> alternative when a platform already handles certificates.) Either way TLS
+> terminates at the **proxy**: don't enable in-process
 > `[server.tls]`/ACME on a deploy-managed app — deploy binds each slot to a
 > private loopback HTTP port that the readiness gate and kamal-proxy target over
 > plain HTTP, so a TLS listener there breaks its health checks. See the [TLS &

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -49,15 +49,16 @@ below and are better fits in specific cases:
   [How the production image works](#how-the-production-image-works)) — a
   portable OCI image you run on Kubernetes, ECS, Nomad, or any Docker host.
 
-> **HTTPS/TLS.** kamal-proxy fronts your app on the public port. By default
-> `autumn deploy` listens on plain **HTTP** and provisions no certificate, so the
-> path serves HTTP until you opt in. Set `[deploy.tls] enabled = true` and
-> `host = "app.example.com"` in `autumn.toml` to have `autumn deploy` wire
-> `--host`/`--tls` into kamal-proxy (and open `--https-port 443`), so the proxy
-> terminates TLS on 443 with an **automatic Let's Encrypt** certificate. (An
-> external TLS terminator in front of the HTTP proxy — a load balancer or reverse
-> proxy that owns the certificate and forwards plain HTTP — remains a valid
-> alternative when a platform already handles certificates.) Either way TLS
+> **HTTPS/TLS.** kamal-proxy fronts your app and always listens on both 80 and
+> **443** (its defaults), but by default `autumn deploy` provisions no
+> certificate for your app, so nothing is served over HTTPS until you opt in. Set
+> `[deploy.tls] enabled = true` and `host = "app.example.com"` in `autumn.toml`
+> to have `autumn deploy` pass `--host`/`--tls` on your app's kamal-proxy
+> route/flip, so kamal-proxy provisions an **automatic Let's Encrypt** certificate
+> for that host on-demand and terminates TLS for it on the already-bound 443
+> listener. (An external TLS terminator in front of the proxy — a load balancer or
+> reverse proxy that owns the certificate and forwards plain HTTP — remains a
+> valid alternative when a platform already handles certificates.) Either way TLS
 > terminates at the **proxy**: don't enable in-process
 > `[server.tls]`/ACME on a deploy-managed app — deploy binds each slot to a
 > private loopback HTTP port that the readiness gate and kamal-proxy target over

--- a/docs/guide/tls.md
+++ b/docs/guide/tls.md
@@ -311,11 +311,14 @@ let the app serve plain HTTP behind it. This is the right choice for the managed
 balancer.
 
 The push-button [`autumn deploy`](./deployment.md#push-button-deploy-to-your-own-server-autumn-deploy)
-path installs **kamal-proxy** in front of your app. kamal-proxy always listens on
-both 80 and **443** (its defaults) — the supervised `run` unit binds both ports
-regardless of any app's TLS setting — but by default `autumn deploy` provisions
-**no** certificate for your app, so nothing is served over HTTPS until you opt
-in. You enable TLS termination **at the deploy-managed proxy** with an opt-in
+path installs **kamal-proxy** in front of your app. kamal-proxy listens on your
+configured public HTTP port (`server.port`) and **443** — the supervised `run`
+unit binds both ports regardless of any app's TLS setting. **For automatic TLS,
+set `server.port = 80`** so Let's Encrypt HTTP-01 validation and the HTTP→HTTPS
+redirect (both of which use port 80) work; the deploy enforces this when
+`[deploy.tls]` is enabled. By default `autumn deploy` provisions **no**
+certificate for your app, so nothing is served over HTTPS until you opt in. You
+enable TLS termination **at the deploy-managed proxy** with an opt-in
 `[deploy.tls]` table:
 
 ```toml

--- a/docs/guide/tls.md
+++ b/docs/guide/tls.md
@@ -311,21 +311,30 @@ let the app serve plain HTTP behind it. This is the right choice for the managed
 balancer.
 
 The push-button [`autumn deploy`](./deployment.md#push-button-deploy-to-your-own-server-autumn-deploy)
-path installs **kamal-proxy** in front of your app, but as shipped it configures
-the proxy on the plain **HTTP** public port and does **not** provision a
-certificate — so that path serves HTTP, not HTTPS, until you add termination
-(see the deployment guide's [HTTPS/TLS note](./deployment.md#push-button-deploy-to-your-own-server-autumn-deploy)).
-To get HTTPS on the `autumn deploy` path, place an **external TLS terminator in
-front of** the deploy-managed kamal-proxy — a **TLS-terminating load balancer or
-reverse proxy** (nginx, Caddy, a cloud load balancer) that owns the certificate
-and forwards plain HTTP to the kamal-proxy public port. The deploy-managed
-kamal-proxy is **HTTP-only**: `autumn deploy` rewrites its systemd unit as
-`kamal-proxy run --http-port {port}` and issues every route/flip as
-`kamal-proxy deploy … --target … --health-check-path …` with **no** `--host` or
-`--tls`, so it neither creates nor preserves TLS on that proxy — configuring TLS
-directly on the deploy-managed kamal-proxy is not an option here (it would be
-overwritten on the next deploy). Do **not** enable in-process `[server.tls]`/ACME on
-a deploy-managed app: `autumn deploy` binds each app slot to a private loopback
+path installs **kamal-proxy** in front of your app. By default it configures the
+proxy on the plain **HTTP** public port and does **not** provision a
+certificate — so that path serves HTTP until you opt in to TLS. You can enable
+TLS termination **at the deploy-managed proxy** with an opt-in `[deploy.tls]`
+table:
+
+```toml
+[deploy.tls]
+enabled = true
+host = "app.example.com"   # public DNS name the certificate is issued for
+```
+
+With `[deploy.tls] enabled = true`, `autumn deploy` wires `--host <host> --tls`
+into every kamal-proxy `route`/`flip` and opens `--https-port 443` on the
+supervised `run` unit, so kamal-proxy terminates TLS on 443 with an **automatic
+Let's Encrypt** certificate for `host`. With the table absent (the default) the
+proxy stays **HTTP-only** — `kamal-proxy run --http-port {port}` and every
+route/flip with **no** `--host`/`--tls`, byte-for-byte the historical behavior.
+(An external TLS terminator in front of the HTTP proxy — nginx, Caddy, a cloud
+load balancer — remains a valid alternative, e.g. when a platform already owns
+the certificate.)
+
+Either way TLS terminates at the **proxy**, not the app. Do **not** enable
+in-process `[server.tls]`/ACME on a deploy-managed app: `autumn deploy` binds each app slot to a private loopback
 **HTTP** port (the slot systemd unit sets `AUTUMN_SERVER__HOST=127.0.0.1`), the
 readiness gate probes it over plain HTTP (`curl http://127.0.0.1:{port}/ready`),
 and kamal-proxy routes to a plain `127.0.0.1:{port}` target — so putting a TLS

--- a/docs/guide/tls.md
+++ b/docs/guide/tls.md
@@ -311,11 +311,12 @@ let the app serve plain HTTP behind it. This is the right choice for the managed
 balancer.
 
 The push-button [`autumn deploy`](./deployment.md#push-button-deploy-to-your-own-server-autumn-deploy)
-path installs **kamal-proxy** in front of your app. By default it configures the
-proxy on the plain **HTTP** public port and does **not** provision a
-certificate — so that path serves HTTP until you opt in to TLS. You can enable
-TLS termination **at the deploy-managed proxy** with an opt-in `[deploy.tls]`
-table:
+path installs **kamal-proxy** in front of your app. kamal-proxy always listens on
+both 80 and **443** (its defaults) — the supervised `run` unit binds both ports
+regardless of any app's TLS setting — but by default `autumn deploy` provisions
+**no** certificate for your app, so nothing is served over HTTPS until you opt
+in. You enable TLS termination **at the deploy-managed proxy** with an opt-in
+`[deploy.tls]` table:
 
 ```toml
 [deploy.tls]
@@ -323,15 +324,14 @@ enabled = true
 host = "app.example.com"   # public DNS name the certificate is issued for
 ```
 
-With `[deploy.tls] enabled = true`, `autumn deploy` wires `--host <host> --tls`
-into every kamal-proxy `route`/`flip` and opens `--https-port 443` on the
-supervised `run` unit, so kamal-proxy terminates TLS on 443 with an **automatic
-Let's Encrypt** certificate for `host`. With the table absent (the default) the
-proxy stays **HTTP-only** — `kamal-proxy run --http-port {port}` and every
-route/flip with **no** `--host`/`--tls`, byte-for-byte the historical behavior.
-(An external TLS terminator in front of the HTTP proxy — nginx, Caddy, a cloud
-load balancer — remains a valid alternative, e.g. when a platform already owns
-the certificate.)
+With `[deploy.tls] enabled = true`, `autumn deploy` passes `--host <host> --tls`
+on every kamal-proxy `route`/`flip` for your app, so kamal-proxy provisions an
+**automatic Let's Encrypt** certificate for `host` on-demand and terminates TLS
+for it on the already-bound 443 listener. With the table absent (the default)
+the route/flip commands carry **no** `--host`/`--tls`, so the proxy serves your
+app over plain HTTP only — byte-for-byte the historical behavior. (An external
+TLS terminator in front of the proxy — nginx, Caddy, a cloud load balancer —
+remains a valid alternative, e.g. when a platform already owns the certificate.)
 
 Either way TLS terminates at the **proxy**, not the app. Do **not** enable
 in-process `[server.tls]`/ACME on a deploy-managed app: `autumn deploy` binds each app slot to a private loopback

--- a/docs/guide/tls.md
+++ b/docs/guide/tls.md
@@ -312,14 +312,11 @@ balancer.
 
 The push-button [`autumn deploy`](./deployment.md#push-button-deploy-to-your-own-server-autumn-deploy)
 path installs **kamal-proxy** in front of your app. kamal-proxy listens on your
-configured public HTTP port (`server.port`) and **443** — the supervised `run`
-unit binds both ports regardless of any app's TLS setting. **For automatic TLS,
-set `server.port = 80`** so Let's Encrypt HTTP-01 validation and the HTTP→HTTPS
-redirect (both of which use port 80) work; the deploy enforces this when
-`[deploy.tls]` is enabled. By default `autumn deploy` provisions **no**
-certificate for your app, so nothing is served over HTTPS until you opt in. You
-enable TLS termination **at the deploy-managed proxy** with an opt-in
-`[deploy.tls]` table:
+configured public HTTP port (`server.port`) and, **by default, 443** — its HTTPS
+listener is always bound and cannot be disabled, regardless of any app's TLS
+setting. By default `autumn deploy` provisions **no** certificate for your app,
+so nothing is served over HTTPS until you opt in. You enable TLS termination
+**at the deploy-managed proxy** with an opt-in `[deploy.tls]` table:
 
 ```toml
 [deploy.tls]
@@ -330,11 +327,23 @@ host = "app.example.com"   # public DNS name the certificate is issued for
 With `[deploy.tls] enabled = true`, `autumn deploy` passes `--host <host> --tls`
 on every kamal-proxy `route`/`flip` for your app, so kamal-proxy provisions an
 **automatic Let's Encrypt** certificate for `host` on-demand and terminates TLS
-for it on the already-bound 443 listener. With the table absent (the default)
+for it on its always-bound 443 listener. This needs **no `server.port` change**
+— issuance uses TLS-ALPN-01 on the already-bound 443, so it works on both the
+first deploy and a later redeploy (enabling TLS on an already-deployed app never
+restarts or reconfigures the shared proxy). With the table absent (the default)
 the route/flip commands carry **no** `--host`/`--tls`, so the proxy serves your
-app over plain HTTP only — byte-for-byte the historical behavior. (An external
-TLS terminator in front of the proxy — nginx, Caddy, a cloud load balancer —
-remains a valid alternative, e.g. when a platform already owns the certificate.)
+app over plain HTTP only — byte-for-byte the historical behavior.
+
+**Setting `server.port = 80` is recommended** (it is the default) so the proxy
+also serves plain HTTP on 80 and can offer the HTTP→HTTPS redirect for visitors
+who hit `http://`. It is **not required** for certificate issuance.
+
+> **An external TLS terminator sharing the same host is not supported.** Because
+> kamal-proxy always binds 443 and its HTTPS listener cannot be disabled, you
+> cannot put your own nginx/Caddy/load-balancer TLS terminator on 443 on the
+> same host as the deploy-managed proxy — the two would collide. Terminate TLS
+> at kamal-proxy via `[deploy.tls]`, or run the terminator on a **separate**
+> host/load balancer in front of the deploy host.
 
 Either way TLS terminates at the **proxy**, not the app. Do **not** enable
 in-process `[server.tls]`/ACME on a deploy-managed app: `autumn deploy` binds each app slot to a private loopback


### PR DESCRIPTION
**Before:** the managed `autumn deploy` path stood up kamal-proxy but never issued `--host`/`--tls`, so an app was served plain HTTP with no certificate. HTTPS required an external terminating LB or in-process `[server.tls]` (incompatible with the loopback-HTTP deploy model).

**After:** an opt-in `[deploy.tls]` knob:
```toml
[deploy.tls]
enabled = true
host = "app.example.com"
```
When enabled, `autumn deploy` passes `--host <host> --tls` per app on the kamal-proxy route/flip, so kamal-proxy provisions an automatic Let's Encrypt certificate for that host on its always-bound 443 listener (via TLS-ALPN-01). This works on both first deploy and redeploy with no proxy restart. Default (table absent / `enabled = false`) is unchanged plain-HTTP behavior. TLS terminates at the shared proxy — the app stays loopback-HTTP and its readiness/health probes are unaffected, so the "don't enable in-process `[server.tls]` on a deploy-managed app" guidance still holds.

**How:**
- `DeployTlsConfig { enabled, host }` on `[deploy]` (with `AUTUMN_DEPLOY__TLS__ENABLED` / `AUTUMN_DEPLOY__TLS__HOST` env overrides), resolved into `KamalProxyController`; `deploy_shell` (route/flip) appends `--host … --tls` per app. Resolve-time host validation (enabled requires a non-empty host).
- The supervised `kamal-proxy run` unit is unchanged from baseline (`run --http-port {server.port}`). kamal-proxy binds both 80 and 443 by default and its HTTPS listener can't be disabled, so no `--https-port` flag or per-app unit change is needed — the run unit is TLS-invariant (no shared-proxy flapping or restart machinery).
- Guard: reject a deploy public/HTTP port where the proxy's HTTP port or a blue/green app slot (`public+1`/`public+2`) would land on 443 (the port kamal-proxy reserves for HTTPS).
- `server.port = 80` is **recommended** (so the proxy also serves HTTP on 80 for the HTTP→HTTPS redirect), not required. An external TLS terminator sharing the same host is **not supported** — kamal-proxy always binds 443 and can't disable it.
- Render/unit tests pin the generated kamal-proxy command strings (the ACME flow itself can't run in CI).
- Corrected the specific TLS sentences in `docs/guide/tls.md` and `docs/guide/deployment.md`.

_Design note: an interim revision required `server.port = 80` for TLS; that was dropped after verifying kamal-proxy binds 443 by default and provisions via TLS-ALPN-01, so no port-80 requirement is needed and TLS works on redeploys too._

_Note: this branch briefly carried an unrelated commit from #1952 (deploy config-manifest upload) that landed here by mistake. It is reverted in-branch (add + revert are net-zero; the #1952 work now lives on its own branch), so a squash-merge lands #1969-only._

**CI note:** the earlier `Test (ubuntu-latest)` red was a trunk-wide `--all-features` compile break in the `autumn-web` DB layer (`sqlite` feature, #1978), fixed by #1997 — unrelated to this diff and now merged into this branch. Default-feature legs (ubuntu `cargo test --workspace`, the full `Test (macos-latest)` job) pass.

Closes #1969. Part of #1607.