### PR TITLE
feat(macros): OpenApiSchema derive for real MCP tool inputSchemas (part of #1972)

### DIFF
--- a/autumn-macros/src/lib.rs
+++ b/autumn-macros/src/lib.rs
@@ -34,6 +34,7 @@ mod model;
 mod oauth2_callback;
 mod one_off_task;
 mod one_off_tasks_macro;
+mod openapi_schema;
 mod param_helpers;
 mod parse;
 mod paths_macro;
@@ -442,6 +443,38 @@ pub fn story(input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn model(attr: TokenStream, item: TokenStream) -> TokenStream {
     model::model_macro(attr.into(), item.into()).into()
+}
+
+/// Derive a field-accurate `OpenApiSchema` impl for a plain struct with named
+/// fields (issue #1972).
+///
+/// Use it on a handler-arg struct — a `Query<T>` param struct or a
+/// non-`#[model]` `Json<T>` request body — so its `OpenAPI` component schema and
+/// MCP tool `inputSchema` describe the real fields instead of degrading to a
+/// generic `{"type":"object"}` placeholder, without a hand-written impl or an
+/// `OpenApiConfig::register_schema` call.
+///
+/// Each field becomes a JSON-schema property (nullable `Option<T>`, `Vec<T>`
+/// arrays, inline primitives, `$ref`s for other named types) and every
+/// non-`Option` field is `required` — mirroring the schema `#[model]` already
+/// generates. The derive also registers the schema in the compile-time
+/// inventory the spec/MCP back-fill consults, so the referencing route resolves
+/// it automatically.
+///
+/// # Examples
+///
+/// ```ignore
+/// use autumn_web::openapi::OpenApiSchema;
+///
+/// #[derive(serde::Deserialize, OpenApiSchema)]
+/// struct SearchParams {
+///     q: String,
+///     limit: Option<i32>,
+/// }
+/// ```
+#[proc_macro_derive(OpenApiSchema)]
+pub fn derive_openapi_schema(input: TokenStream) -> TokenStream {
+    openapi_schema::derive_openapi_schema(input)
 }
 
 /// Derive a repository with CRUD operations and derived queries.

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -2534,7 +2534,7 @@ fn emit_json_schema_tokens(ty: &syn::Type) -> TokenStream {
 ///
 /// `all_optional` is `true` for `UpdateX` structs where every field is
 /// conceptually optional (backed by `Patch<T>`).
-fn emit_schema_fn_body(fields: &[&&Field], all_optional: bool) -> TokenStream {
+pub fn emit_schema_fn_body(fields: &[&&Field], all_optional: bool) -> TokenStream {
     emit_schema_fn_body_ext(fields, all_optional, &[])
 }
 

--- a/autumn-macros/src/openapi_schema.rs
+++ b/autumn-macros/src/openapi_schema.rs
@@ -1,0 +1,88 @@
+//! `#[derive(OpenApiSchema)]` — a standalone derive that gives a plain struct a
+//! field-accurate `OpenApiSchema` impl (issue #1972).
+//!
+//! Before this derive, the only automatic `OpenApiSchema` impls came from
+//! `#[model]` codegen and the primitive macro impls, so any other handler-arg
+//! struct (a `Query<T>` param struct or a non-`#[model]` `Json<T>` body) had to
+//! carry a hand-written impl plus an `OpenApiConfig::register_schema` call — or
+//! its `OpenAPI` / MCP `inputSchema` degraded to a generic
+//! `{"type":"object","title":"X"}` placeholder.
+//!
+//! This derive mirrors the schema `#[model]` already generates
+//! (`crate::model::emit_schema_fn_body`): each field becomes a JSON-schema
+//! property and every non-`Option` field is `required`. It additionally submits
+//! the schema into the compile-time `DerivedSchemaDescriptor` inventory that the
+//! spec/MCP back-fill loops consult, so a referenced struct resolves to its real
+//! schema with no manual registration.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields, parse_macro_input};
+
+pub fn derive_openapi_schema(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+
+    // The emitted impl uses the bare type name for both `schema_name()` and the
+    // inventory descriptor, and the descriptor's `schema` field is a plain
+    // `fn() -> Value` — none of which can carry generic parameters. Reject
+    // generics with a clear message rather than emitting an impl that fails to
+    // compile downstream.
+    if !input.generics.params.is_empty() {
+        return syn::Error::new_spanned(
+            &input.generics,
+            "#[derive(OpenApiSchema)] does not support generic types",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    let fields = match &input.data {
+        Data::Struct(data) => match &data.fields {
+            Fields::Named(named) => &named.named,
+            _ => {
+                return syn::Error::new_spanned(
+                    &input,
+                    "#[derive(OpenApiSchema)] is only supported on structs with named fields",
+                )
+                .to_compile_error()
+                .into();
+            }
+        },
+        _ => {
+            return syn::Error::new_spanned(
+                &input,
+                "#[derive(OpenApiSchema)] is only supported on structs",
+            )
+            .to_compile_error()
+            .into();
+        }
+    };
+
+    // `emit_schema_fn_body` expects `&[&&Field]` (it was written against the
+    // `Vec<&&Field>` the model macro collects); build that shape here.
+    let field_refs: Vec<&syn::Field> = fields.iter().collect();
+    let field_ref_refs: Vec<&&syn::Field> = field_refs.iter().collect();
+    let schema_body = crate::model::emit_schema_fn_body(&field_ref_refs, false);
+
+    quote! {
+        impl ::autumn_web::openapi::OpenApiSchema for #name {
+            fn schema_name() -> &'static str {
+                ::core::stringify!(#name)
+            }
+            fn schema() -> ::autumn_web::reexports::serde_json::Value {
+                #schema_body
+            }
+        }
+
+        // Advertise the derived schema by name so the OpenAPI/MCP schema
+        // back-fill resolves it instead of the generic object placeholder.
+        ::autumn_web::reexports::inventory::submit! {
+            ::autumn_web::openapi::DerivedSchemaDescriptor {
+                name: ::core::stringify!(#name),
+                schema: <#name as ::autumn_web::openapi::OpenApiSchema>::schema,
+            }
+        }
+    }
+    .into()
+}

--- a/autumn/src/openapi.rs
+++ b/autumn/src/openapi.rs
@@ -293,6 +293,22 @@ pub trait OpenApiSchema {
     fn schema() -> serde_json::Value;
 }
 
+/// Derive a field-accurate [`OpenApiSchema`] impl for a plain struct with named
+/// fields (issue #1972), so a handler-arg struct used in `Query<T>` / `Json<T>`
+/// advertises its real fields in the OpenAPI spec and the MCP tool `inputSchema`
+/// instead of collapsing to a generic `{"type":"object"}` placeholder — with no
+/// hand-written impl or `OpenApiConfig::register_schema` call.
+///
+/// Each field becomes a JSON-schema property (nullable `Option<T>` via
+/// `oneOf [T, null]`, `Vec<T>` as an array, primitives inline, other named types
+/// as `$ref`s), and every non-`Option` field is listed as `required` — mirroring
+/// the schema `#[model]` already generates. The derive also registers the schema
+/// in the compile-time inventory the spec/MCP back-fill consults, so a
+/// `Query<MyArgs>` / `Json<MyArgs>` handler picks it up automatically.
+///
+/// Bring it into scope alongside the trait: `use autumn_web::openapi::OpenApiSchema;`.
+pub use autumn_macros::OpenApiSchema;
+
 macro_rules! impl_primitive_schema {
     ($ty:ty, $name:literal, $json:literal) => {
         impl OpenApiSchema for $ty {
@@ -320,6 +336,50 @@ impl_primitive_schema!(u64, "integer", "integer");
 impl_primitive_schema!(f32, "number", "number");
 impl_primitive_schema!(f64, "number", "number");
 impl_primitive_schema!(serde_json::Value, "object", "object");
+
+// ──────────────────────────────────────────────────────────────────
+// Compile-time inventory of `#[derive(OpenApiSchema)]` component schemas.
+// ──────────────────────────────────────────────────────────────────
+
+/// Compile-time registration of a plain struct's derived `OpenApiSchema`,
+/// emitted by `#[derive(OpenApiSchema)]` (issue #1972).
+///
+/// The spec generator and the MCP tool-catalog builder both back-fill component
+/// schemas for referenced type names they did not otherwise register. Without a
+/// hand-written `OpenApiSchema` impl + `OpenApiConfig::register_schema`, a plain
+/// handler-arg struct (a `Query<T>` param struct or a non-`#[model]` `Json<T>`
+/// body) used to resolve to a generic `{"type":"object","title":"X"}`
+/// placeholder — so the argument's real fields lived only in prose. This
+/// descriptor lets a `#[derive(OpenApiSchema)]` struct advertise its
+/// field-accurate schema by name, which the back-fill loops pick up
+/// automatically (no manual registration).
+///
+/// This is deliberately not feature-gated: `#[derive(OpenApiSchema)]` submits an
+/// entry unconditionally, and the `openapi`-gated spec builder consults it only
+/// when that feature is compiled in.
+pub struct DerivedSchemaDescriptor {
+    /// Component schema name. Matches `OpenApiSchema::schema_name()` and the
+    /// `$ref` component name emitted for `Query<T>` / `Json<T>` handler args
+    /// (the type's last path segment).
+    pub name: &'static str,
+    /// Produces the JSON schema for the type (the type's `OpenApiSchema::schema`).
+    pub schema: fn() -> serde_json::Value,
+}
+
+inventory::collect!(DerivedSchemaDescriptor);
+
+/// Look up the derived component schema for `name`.
+///
+/// Returns the schema when a `#[derive(OpenApiSchema)]` type with that schema
+/// name was linked into the binary, or `None` when no such derive exists (so
+/// callers fall back to the generic placeholder).
+#[must_use]
+pub fn registered_derived_schema(name: &str) -> Option<serde_json::Value> {
+    inventory::iter::<DerivedSchemaDescriptor>
+        .into_iter()
+        .find(|descriptor| descriptor.name == name)
+        .map(|descriptor| (descriptor.schema)())
+}
 
 // ──────────────────────────────────────────────────────────────────
 // Runtime registry of component schemas populated while building the spec.
@@ -619,19 +679,21 @@ pub fn generate_spec_at(
         }
     }
 
-    // Back-fill a minimal `{"type": "object", "title": "X"}` schema for
-    // every referenced name the user didn't already register. Types that
-    // implement OpenApiSchema can be registered explicitly via
-    // OpenApiConfig::register_schema to replace the placeholder.
+    // Back-fill a schema for every referenced name the user didn't already
+    // register. A `#[derive(OpenApiSchema)]` type advertises a real
+    // field-accurate schema through the compile-time inventory (issue #1972),
+    // which we consult first; only a name with no derived schema (and no
+    // explicit `OpenApiConfig::register_schema`) falls back to the minimal
+    // `{"type": "object", "title": "X"}` placeholder.
     for name in referenced_names {
         if !registry.schemas().contains_key(name) {
-            registry.insert(
-                name,
+            let schema = registered_derived_schema(name).unwrap_or_else(|| {
                 serde_json::json!({
                     "type": "object",
                     "title": name,
-                }),
-            );
+                })
+            });
+            registry.insert(name, schema);
         }
     }
 

--- a/autumn/tests/integration/mcp_schema_derive.rs
+++ b/autumn/tests/integration/mcp_schema_derive.rs
@@ -1,0 +1,154 @@
+//! `#[derive(OpenApiSchema)]` gives a plain handler-arg struct a real
+//! MCP tool `inputSchema` instead of the generic object placeholder (issue #1972).
+//!
+//! DB-free: like `mcp_repository`, these tests collect the generated routes'
+//! `ApiDoc` metadata and run it through the same production entry point the
+//! router uses to assemble `/mcp` (`autumn_web::mcp::derive_tools`).
+//!
+//! Covers the FIRST-SLICE contract:
+//! * A `#[derive(OpenApiSchema)]` struct used as a `Json<T>` body advertises a
+//!   field-accurate `body` schema (properties + required), not
+//!   `{"type":"object","title":"X"}`.
+//! * The same for a `Query<T>` param struct under the `query` property.
+//! * A struct WITHOUT the derive still degrades to the placeholder — proving the
+//!   derive (not some unrelated change) is what produces the real schema.
+
+#![cfg(feature = "mcp")]
+
+use autumn_web::mcp::derive_tools;
+use autumn_web::openapi::OpenApiSchema;
+use autumn_web::prelude::*;
+use serde::{Deserialize, Serialize};
+
+// A plain (non-`#[model]`) struct with the new derive: one required string and
+// one nullable integer — the canonical `struct { a: String, b: Option<i32> }`.
+#[derive(Serialize, Deserialize, OpenApiSchema)]
+struct DerivedArgs {
+    a: String,
+    b: Option<i32>,
+}
+
+// A plain struct WITHOUT the derive — the pre-#1972 behaviour (placeholder).
+#[derive(Serialize, Deserialize)]
+struct PlainArgs {
+    a: String,
+}
+
+#[post("/api/derived-body")]
+#[api_doc(mcp, summary = "Body arg with a derived schema")]
+async fn derived_body(Json(_body): Json<DerivedArgs>) -> AutumnResult<Json<DerivedArgs>> {
+    Ok(Json(DerivedArgs {
+        a: "ok".into(),
+        b: None,
+    }))
+}
+
+#[get("/api/derived-query")]
+#[api_doc(mcp, summary = "Query arg with a derived schema")]
+async fn derived_query(Query(_q): Query<DerivedArgs>) -> AutumnResult<Json<DerivedArgs>> {
+    Ok(Json(DerivedArgs {
+        a: "ok".into(),
+        b: None,
+    }))
+}
+
+#[post("/api/plain-body")]
+#[api_doc(mcp, summary = "Body arg without a derived schema")]
+async fn plain_body(Json(_body): Json<PlainArgs>) -> AutumnResult<Json<PlainArgs>> {
+    Ok(Json(PlainArgs { a: "ok".into() }))
+}
+
+#[test]
+fn derived_schema_impl_is_field_accurate() {
+    // The derive itself yields the mirrored `#[model]` schema shape.
+    let schema = <DerivedArgs as OpenApiSchema>::schema();
+    assert_eq!(DerivedArgs::schema_name(), "DerivedArgs");
+    assert_eq!(schema["type"], "object");
+    assert_eq!(schema["properties"]["a"]["type"], "string");
+    // Nullable field → `oneOf [ {integer}, {null} ]`.
+    let one_of = schema["properties"]["b"]["oneOf"]
+        .as_array()
+        .expect("Option<i32> renders as oneOf");
+    assert!(one_of.iter().any(|v| v["type"] == "integer"));
+    assert!(one_of.iter().any(|v| v["type"] == "null"));
+    // Only the non-`Option` field is required.
+    let required = schema["required"].as_array().expect("has required list");
+    assert!(required.iter().any(|v| v == "a"));
+    assert!(!required.iter().any(|v| v == "b"));
+}
+
+#[test]
+fn mcp_body_input_schema_reflects_derived_struct() {
+    let docs = vec![__autumn_route_info_derived_body().api_doc];
+    let tools = derive_tools(&docs, false, None);
+    let tool = tools.iter().find(|t| t.name() == "derived_body").unwrap();
+    let body = &tool.input_schema()["properties"]["body"];
+
+    // A `$ref` into `$defs` OR the inlined object — either way it must resolve to
+    // the real fields, never the `{type:object,title}` placeholder.
+    let resolved = resolve_ref(tool.input_schema(), body);
+    assert_eq!(
+        resolved["type"], "object",
+        "derived body schema: {resolved}"
+    );
+    assert_eq!(
+        resolved["properties"]["a"]["type"], "string",
+        "derived body must expose field `a`: {resolved}"
+    );
+    assert!(
+        resolved["properties"].get("b").is_some(),
+        "derived body must expose field `b`: {resolved}"
+    );
+    assert!(
+        resolved.get("title").is_none() || resolved["properties"].is_object(),
+        "must not be the bare placeholder: {resolved}"
+    );
+}
+
+#[test]
+fn mcp_query_input_schema_reflects_derived_struct() {
+    let docs = vec![__autumn_route_info_derived_query().api_doc];
+    let tools = derive_tools(&docs, false, None);
+    let tool = tools.iter().find(|t| t.name() == "derived_query").unwrap();
+    let query = &tool.input_schema()["properties"]["query"];
+
+    let resolved = resolve_ref(tool.input_schema(), query);
+    assert_eq!(
+        resolved["type"], "object",
+        "derived query schema: {resolved}"
+    );
+    assert_eq!(
+        resolved["properties"]["a"]["type"], "string",
+        "derived query must expose field `a`: {resolved}"
+    );
+}
+
+#[test]
+fn mcp_body_without_derive_stays_placeholder() {
+    let docs = vec![__autumn_route_info_plain_body().api_doc];
+    let tools = derive_tools(&docs, false, None);
+    let tool = tools.iter().find(|t| t.name() == "plain_body").unwrap();
+    let body = &tool.input_schema()["properties"]["body"];
+
+    let resolved = resolve_ref(tool.input_schema(), body);
+    // Pre-#1972 behaviour: no properties, just the object+title placeholder.
+    assert_eq!(resolved["type"], "object");
+    assert!(
+        resolved["properties"].is_null()
+            || resolved["properties"]
+                .as_object()
+                .is_none_or(serde_json::Map::is_empty),
+        "a struct without the derive must stay a bare placeholder: {resolved}"
+    );
+}
+
+/// If `value` is a `{ "$ref": "#/$defs/X" }` pointer, resolve it against the
+/// schema's `$defs`; otherwise return the value unchanged.
+fn resolve_ref(root: &serde_json::Value, value: &serde_json::Value) -> serde_json::Value {
+    if let Some(reference) = value.get("$ref").and_then(serde_json::Value::as_str)
+        && let Some(name) = reference.strip_prefix("#/$defs/")
+    {
+        return root["$defs"][name].clone();
+    }
+    value.clone()
+}

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -112,6 +112,8 @@ mod mcp_plugin;
 #[cfg(all(feature = "db", feature = "mcp"))]
 mod mcp_repository;
 #[cfg(feature = "mcp")]
+mod mcp_schema_derive;
+#[cfg(feature = "mcp")]
 mod mcp_streaming;
 mod middleware_introspection;
 mod middleware_pipeline;


### PR DESCRIPTION
## Before / After

**Before:** an MCP tool's `inputSchema` degraded to the generic `{"type":"object"}` placeholder unless the arg struct hand-implemented `OpenApiSchema`.

**After:** `#[derive(OpenApiSchema)]` on a plain arg struct yields a real field-level JSON schema, back-filled into `openapi::generate_spec_at` via an inventory registry so the MCP catalog surfaces real fields.

## How

The derive reuses `#[model]`'s `emit_schema_fn_body` to generate the field-level schema body, so the derived and model-emitted schemas share one code path. Each derived struct registers a `DerivedSchemaDescriptor` via `inventory::collect!`, and `openapi::generate_spec_at` walks that registry to back-fill real inputSchemas. The trait is re-exported at `autumn_web::openapi::OpenApiSchema`.

**Part 2 — the `Query<T>` / `serde_urlencoded` nested-args problem — is intentionally out of scope for this slice and stays open on the issue.**

Part of #1972

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1kjhJB6QjfaNMMjKhtDfb)_