### PR TITLE
Fix webauthn schema-keys snapshot drift under --all-features (#1959)

### DIFF
--- a/autumn/tests/fixtures/schema_keys.snapshot
+++ b/autumn/tests/fixtures/schema_keys.snapshot
@@ -46,6 +46,10 @@ auth.sessions.last_seen_update_secs
 auth.sessions.revoke_on_credential_change
 auth.step_up
 auth.step_up.default_max_age_secs
+auth.webauthn
+auth.webauthn.rp_id
+auth.webauthn.rp_name
+auth.webauthn.rp_origin
 backup
 backup.offsite
 backup.offsite.allow_shared_bucket

--- a/autumn/tests/integration/schema_drift_guard.rs
+++ b/autumn/tests/integration/schema_drift_guard.rs
@@ -70,6 +70,17 @@ const fn feature_gated_roots() -> [(bool, &'static str); 6] {
     ]
 }
 
+/// Feature-gated NESTED keys (not whole root sections). `auth` is always
+/// present, but its `webauthn` subtree only compiles under the `webauthn`
+/// feature, so when that feature is off these snapshot leaves are legitimately
+/// absent from `schema_leaf_paths()` — exclude by prefix rather than failing.
+/// Keep in sync with `config.rs`'s `#[cfg(feature = "...")]` nested fields —
+/// [`feature_gated_leaf_prefixes_match_config_when_enabled`] below self-checks
+/// this list whenever a listed feature happens to be enabled.
+const fn feature_gated_leaf_prefixes() -> [(bool, &'static str); 1] {
+    [(cfg!(feature = "webauthn"), "auth.webauthn")]
+}
+
 const SNAPSHOT_PATH: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/tests/fixtures/schema_keys.snapshot",
@@ -121,15 +132,27 @@ fn schema_keys_snapshot_guard() {
         .filter(|(enabled, _)| !enabled)
         .map(|(_, root)| root)
         .collect();
+    let disabled_leaf_prefixes: Vec<&str> = feature_gated_leaf_prefixes()
+        .into_iter()
+        .filter(|(enabled, _)| !enabled)
+        .map(|(_, prefix)| prefix)
+        .collect();
 
     // Keys in snapshot but absent from current schema without a registry
     // entry, excluding root sections whose gating feature isn't compiled
-    // into this test binary (see module docs).
+    // into this test binary, and nested subtrees whose gating feature is off
+    // (e.g. `auth.webauthn.*` under the always-present `auth` root — see module
+    // docs and `feature_gated_leaf_prefixes`).
     let removed_without_deprecation: Vec<&str> = snapshot
         .iter()
         .filter(|k| !current.contains(k.as_str()))
         .filter(|k| !registry.contains(k.as_str()))
         .filter(|k| !disabled_roots.contains(k.split('.').next().unwrap_or(k.as_str())))
+        .filter(|k| {
+            !disabled_leaf_prefixes
+                .iter()
+                .any(|p| k.as_str() == *p || k.strip_prefix(p).is_some_and(|r| r.starts_with('.')))
+        })
         .map(String::as_str)
         .collect();
 
@@ -202,6 +225,35 @@ fn feature_gated_roots_mapping_matches_config_when_enabled() {
         "feature_gated_roots() in this file is stale: these features are enabled in this \
          build but their mapped root section is missing from the compiled schema: {stale:?}\n\
          Update the mapping to match config.rs's current #[cfg(feature = \"...\")] fields.",
+    );
+}
+
+/// Self-check for [`feature_gated_leaf_prefixes`]: whenever a listed feature
+/// happens to be enabled in this build (e.g. via `--all-features`, or workspace
+/// feature unification with `cargo test --workspace`), its mapped nested prefix
+/// must actually appear in the compiled schema. Catches the prefix list going
+/// stale (a feature renamed, or the nested field renamed/removed) instead of
+/// silently letting a real removal slip past the guard above as "expected".
+#[test]
+fn feature_gated_leaf_prefixes_match_config_when_enabled() {
+    let current = AutumnConfig::schema_leaf_paths();
+    let stale: Vec<&str> = feature_gated_leaf_prefixes()
+        .into_iter()
+        .filter(|(enabled, _)| *enabled)
+        .map(|(_, prefix)| prefix)
+        .filter(|prefix| {
+            !current.iter().any(|k| {
+                k.as_str() == *prefix || k.strip_prefix(*prefix).is_some_and(|r| r.starts_with('.'))
+            })
+        })
+        .collect();
+
+    assert!(
+        stale.is_empty(),
+        "feature_gated_leaf_prefixes() in this file is stale: these features are enabled in \
+         this build but their mapped nested prefix is missing from the compiled schema: \
+         {stale:?}\nUpdate the mapping to match config.rs's current \
+         #[cfg(feature = \"...\")] nested fields.",
     );
 }
 


### PR DESCRIPTION
## Before / After
**Before:** the Coverage CI job (`--all-features`, which enables the non-default `webauthn` feature) failed `schema_keys_snapshot_guard` — the checked-in snapshot was missing four `auth.webauthn.*` config keys.
**After:** the guard handles the feature-gated `auth.webauthn` subtree in both directions — the snapshot includes the four keys, and when `webauthn` is OFF (the default `cargo test --workspace` job) those keys are excluded from the "removed without deprecation" check instead of failing.

## How
- `autumn/tests/integration/schema_drift_guard.rs`: added `feature_gated_leaf_prefixes()` (a nested-prefix analogue of the existing `feature_gated_roots()`) mapping `(cfg!(feature="webauthn"), "auth.webauthn")`, wired into the removed-key computation; plus a self-check test so the prefix can't silently go stale.
- Re-blessed `autumn/tests/fixtures/schema_keys.snapshot` (+4 sorted lines: `auth.webauthn`, `.rp_id`, `.rp_name`, `.rp_origin`).
- Re-blessing alone would have flipped the failure onto the default-features job; the leaf-prefix tolerance is what keeps both green.

## Verification (local)
- webauthn OFF: `cargo test --workspace schema_drift` → PASS (12/12).
- webauthn ON: `cargo test -p autumn-web --features <all-but-bundled> schema_drift` → PASS (12/12).
- `cargo clippy --workspace --all-targets -- -D warnings` → clean; `cargo fmt --all --check` → clean.

**Environment caveat:** `--all-features` cannot build in this environment — it enables `managed-pg-bundled`, whose build script downloads Postgres binaries and gets a 403 from the outbound proxy. Local verification used **all-features-minus-`managed-pg-bundled`** (`bundled` is a build-time binary-embedding flag that adds no config schema keys); the resulting snapshot diff vs a true `--all-features` regen is exactly the 4 webauthn lines. CI (which can fetch) exercises the real `--all-features` path.

Closes #1959

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyHpN8kZw9ZNeVa5a8Qqzc)_