### PR TITLE
Fold feature-gated Docker tests into the CI ignored-sweep (#1945)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           ssh -V
       - name: Run Docker-dependent tests
         if: runner.os == 'Linux'
-        timeout-minutes: 30
+        timeout-minutes: 45
         run: |
           cargo test -p autumn-web --test db_hooks_lifecycle -- --ignored
           cargo test -p autumn-web --test repository_shard_replica_routing -- --ignored
@@ -143,8 +143,17 @@ jobs:
           # `#[cfg(feature = "offline-sync")]` (not a default feature), so the
           # workspace test run above compiles them out; run them here. Same
           # feature set as the sweep below so the binary is compiled once.
-          cargo test -p autumn-web --features "test-support,offline-sync" --test integration_tests offline_sync
-          cargo test -p autumn-web --features "test-support,offline-sync" --test integration_tests -- \
+          #
+          # The feature set also enables `ws`, `mail`, and `redis` (#1945): those
+          # gate previously-unreachable testcontainer-managed Docker `#[ignore]`d
+          # tests (the `ws` live_broadcast OOB-fragment suite, the `redis` worker-
+          # gating/dedicated-capacity/rate-limit suites, and the `mail` newsletter
+          # unsubscribe test) which never compiled into this binary and so were
+          # never swept. All are Postgres/Redis testcontainer-managed, so no CI
+          # `services:` block is needed. Chromium/browser tests stay OUT — they
+          # live behind `system-tests` and require a browser this runner lacks.
+          cargo test -p autumn-web --features "test-support,offline-sync,ws,mail,redis" --test integration_tests offline_sync
+          cargo test -p autumn-web --features "test-support,offline-sync,ws,mail,redis" --test integration_tests -- \
             --ignored \
             --test-threads=1 \
             --skip per_request_overhead_is_under_50_microseconds_p99 \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,20 +54,24 @@ test that compiles into the `autumn` consolidated `integration_tests` binary wit
 house-pattern testcontainer DB test — `#[ignore = "requires Docker (testcontainers)"]` in a `db`-gated (or ungated) module — executes in CI with
 **no workflow edit**. Do not add a per-test allowlist line.
 
-This sweep only covers ignored tests that compile under the `default +
-test-support + offline-sync` feature set — the real win is that a new
-Postgres/DB testcontainer test in that set runs automatically. Ignored Docker
-tests gated behind **other** non-default cargo features are **not** built into
-this binary and so are **not** run by it: the Redis suites
-(`process_role_worker_gating`, `queue_dedicated_capacity`,
-`rate_limit_redis_integration`, all `#[cfg(feature = "redis")]`) and any
-`ws`/`mail`/`system-tests`-gated Docker tests are out of scope here (tracked in
-#1945). Consequently, a new `#[ignore]`d test that must not be swept in (a
-browser/Chromium test, a container this sweep doesn't provision, or a
-release-mode timing microbenchmark) must sit behind such a non-default feature
-so it never compiles into this run — browser tests already live behind the
-`system-tests` feature. The one unconditionally-compiled exception (the
-access_log p99 timing bench) is named in the step's `--skip` list.
+This sweep compiles the consolidated binary with `--features
+"test-support,offline-sync,ws,mail,redis"` (db + maud are already defaults), so
+a new Postgres/DB testcontainer test — and now also the previously-unreachable
+`ws`/`mail`/`redis` testcontainer Docker tests — runs automatically. As of
+#1945 the feature set folds in the `ws` `live_broadcast` OOB-fragment suite, the
+`redis` suites (`process_role_worker_gating`, `queue_dedicated_capacity`,
+`rate_limit_redis_integration`), and the `mail` newsletter-unsubscribe test:
+each is testcontainer-managed (Postgres/Redis in-process), so no CI `services:`
+block is required.
+
+Only **`system-tests`-gated** (browser/Chromium) Docker tests remain excluded —
+they need a Chromium binary this runner does not provide. Consequently, a new
+`#[ignore]`d test that must not be swept in (a browser/Chromium test, a
+container this sweep doesn't provision, or a release-mode timing microbenchmark)
+must either sit behind a non-default feature **not** in this set (browser tests
+already live behind `system-tests`) so it never compiles into this run, or be
+added to the step's `--skip` list. The one unconditionally-compiled exception
+(the access_log p99 timing bench) is named in the step's `--skip` list.
 
 #### 2. Isolated Integration Tests (Separate Binaries)
 


### PR DESCRIPTION
## Before / After
**Before:** the #1941 CI "Run Docker-dependent tests" sweep built the consolidated `integration_tests` binary with `--features "test-support,offline-sync"`, so 10 `#[ignore]`d Docker tests behind other non-default features never compiled in and were never run.
**After:** the sweep also runs those 10 — 5 `ws` (`live_broadcast`), 4 `redis` (`process_role_worker_gating`, `queue_dedicated_capacity`, `rate_limit_redis_integration`), and 1 `mail` (`mail_unsubscribe` DB-backed).

## How
- `.github/workflows/ci.yml`: both sweep invocations `--features "test-support,offline-sync"` → `"test-support,offline-sync,ws,mail,redis"` (identical, so the binary compiles once). Testcontainers self-manage Postgres/Redis, so no new `services:` block. `system-tests` (8 Chromium tests) left OFF; the `--skip` list is unchanged. Step timeout 30 → 45 min (10 more container-spinning tests under `--test-threads=1`).
- `autumn/CLAUDE.md`: updated the sweep scope note.

## Verification (local; Docker unavailable, so tests not run — only compile + discovery)
- Widened binary compiles: `cargo test -p autumn-web --features "test-support,offline-sync,ws,mail,redis" --test integration_tests --no-run` → PASS.
- `--ignored --list` shows all 10 target tests, no Chromium leakage; the only non-Docker ignored tests present are the two already `--skip`ped.
- `cargo fmt --all --check` clean; `ci.yml` YAML parses.

**Note:** this and #1934 both touch `.github/workflows/ci.yml` (different steps — the Docker-sweep here vs the a11y gate there); whichever merges second needs a trivial rebase, which the author will handle.

**Remaining follow-up (out of scope per the issue):** the `autumn-cli` `cli_tests` heterogeneous ignored set needs per-test triage, and `system_test_api` (Chromium) stays excluded.

Part of #1945

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyHpN8kZw9ZNeVa5a8Qqzc)_