### PR TITLE
Extend a11y gate to examples + admin-plugin, skip test modules (#1934)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,16 +40,15 @@ jobs:
         run: cargo clippy -p autumn-web --features "ws,mail,offline-sync,redis" --all-targets -- -D warnings
       - name: Panic-free request-path gate
         run: ./scripts/check-panic-gate.sh
-      - name: Accessibility gate (raw html! escape hatches in framework source)
+      - name: Accessibility gate (raw html! escape hatches across the repo)
         # `autumn a11y verify` statically audits raw `html!` markup for fields
         # that bypass the typed a11y primitives and lack an accessible name.
-        # Scoped to the framework's own source (autumn/src + autumn-cli/src);
-        # examples/ and the admin plugin are tracked separately. The verifier
-        # takes a single path, so scan each dir in its own invocation; either
-        # non-zero exit fails the job.
-        run: |
-          cargo run -p autumn-cli --bin autumn -- a11y verify autumn/src
-          cargo run -p autumn-cli --bin autumn -- a11y verify autumn-cli/src
+        # Scoped to the whole repo root now that the framework source, the admin
+        # plugin, and every example are clean (issue #1934). The scanner skips
+        # `target/`, dot-dirs, and `tests/` directories (test scaffolding and the
+        # committed red/green fixtures), so a single invocation over `.` fails the
+        # job on any real product finding.
+        run: cargo run -p autumn-cli --bin autumn -- a11y verify .
 
   test:
     name: Test (${{ matrix.os }})

--- a/autumn-admin-plugin/src/templates.rs
+++ b/autumn-admin-plugin/src/templates.rs
@@ -984,6 +984,7 @@ pub fn model_list_page(
                 // every input in the form, including the filter hiddens).
                 form class="search-bar" method="get" {
                     input type="search" name="q" placeholder="Search…"
+                        aria-label="Search records"
                         value=(search_query)
                         hx-get={ (prefix) "/" (model_slug) }
                         hx-trigger="input changed delay:300ms"
@@ -1008,7 +1009,7 @@ pub fn model_list_page(
                             tr {
                                 th class="checkbox-cell" {
                                     // Wired up by admin.js via event delegation on #select-all.
-                                    input type="checkbox" id="select-all";
+                                    input type="checkbox" id="select-all" aria-label="Select all rows";
                                 }
                                 @for field in &list_fields {
                                     @let is_sorted = sort_by == Some(field.name);
@@ -1053,6 +1054,7 @@ pub fn model_list_page(
                                         // the wrong record.
                                         @if let Some(id) = row_id {
                                             input type="checkbox" class="row-check"
+                                                aria-label="Select row"
                                                 name="ids" value=(id);
                                         }
                                     }
@@ -1632,6 +1634,7 @@ pub fn config_page(
                                             style="display: flex; gap: 0.25rem; align-items: center;" {
                                             (csrf_hidden_input(csrf_token, csrf_form_field))
                                             input type="text" name="value"
+                                                aria-label=(format!("Value for {}", entry.name))
                                                 value=(entry.current.to_raw())
                                                 style="width: 11rem; font-size: 0.8125rem; padding: 0.25rem 0.5rem; border: 1px solid var(--border); border-radius: 0.25rem;" {}
                                             button type="submit" class="btn btn-sm btn-primary" { "Save" }

--- a/autumn-cli/src/a11y.rs
+++ b/autumn-cli/src/a11y.rs
@@ -314,7 +314,14 @@ fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
         let name = entry.file_name();
         let name = name.to_string_lossy();
         if file_type.is_dir() {
-            if name == "target" || name.starts_with('.') {
+            // Skip build output, dot-dirs, and any `tests` directory. Test code
+            // (integration tests, system-test scaffolding, committed fixtures)
+            // is not shipped product markup, so a raw-`html!` defect there is not
+            // a product accessibility bug (issue #1934). The skip is scan-root
+            // RELATIVE: the a11y-verify integration test passes a fixture dir as
+            // the scan root itself, so no `tests` path component exists below
+            // that root and the fixture is still scanned/flagged there.
+            if name == "target" || name == "tests" || name.starts_with('.') {
                 continue;
             }
             collect_rs_files(&path, out);
@@ -339,6 +346,15 @@ fn find_html_blocks(stream: &TokenStream, file: &str, scan: &mut Scan) {
     let trees: Vec<TokenTree> = stream.clone().into_iter().collect();
     let mut i = 0;
     while i < trees.len() {
+        // A `#[cfg(test)]`-annotated item (`mod tests { … }`, a test `fn`) is
+        // test-only scaffolding, not shipped product markup — an inline
+        // `html!` defect inside it is intentional test data, not a product
+        // accessibility bug (issue #1934, the #1930 `form.rs` case). Skip the
+        // whole item without descending into its body.
+        if is_cfg_test_attr(&trees, i) {
+            i = skip_cfg_test_item(&trees, i + 2);
+            continue;
+        }
         if let TokenTree::Ident(ident) = &trees[i]
             && *ident == "html"
             && matches!(trees.get(i + 1), Some(TokenTree::Punct(p)) if p.as_char() == '!')
@@ -368,6 +384,61 @@ fn find_html_blocks(stream: &TokenStream, file: &str, scan: &mut Scan) {
         }
         i += 1;
     }
+}
+
+/// Whether `trees[i]` begins a `#[cfg(test)]` outer attribute — a `#` punct
+/// immediately followed by a `[cfg(test)]` bracket group. Such an attribute
+/// precedes a test-only item whose body is scaffolding the scanner must not
+/// descend into (issue #1934). Matching is deliberately precise (`cfg` then a
+/// parenthesized single `test` ident): it never fires on `#[cfg(not(test))]`
+/// (production code) or `#[cfg(feature = "…")]`, so it can only ever exclude a
+/// genuine test item.
+fn is_cfg_test_attr(trees: &[TokenTree], i: usize) -> bool {
+    let Some(TokenTree::Punct(p)) = trees.get(i) else {
+        return false;
+    };
+    if p.as_char() != '#' {
+        return false;
+    }
+    let Some(TokenTree::Group(g)) = trees.get(i + 1) else {
+        return false;
+    };
+    if g.delimiter() != Delimiter::Bracket {
+        return false;
+    }
+    let inner: Vec<TokenTree> = g.stream().into_iter().collect();
+    matches!(inner.first(), Some(TokenTree::Ident(id)) if *id == "cfg")
+        && matches!(
+            inner.get(1),
+            Some(TokenTree::Group(paren))
+                if paren.delimiter() == Delimiter::Parenthesis
+                    && is_single_test_ident(&paren.stream())
+        )
+}
+
+/// Whether a token stream is exactly the single ident `test` (the body of a
+/// `cfg(test)` predicate).
+fn is_single_test_ident(stream: &TokenStream) -> bool {
+    let trees: Vec<TokenTree> = stream.clone().into_iter().collect();
+    trees.len() == 1 && matches!(&trees[0], TokenTree::Ident(id) if *id == "test")
+}
+
+/// Advance past a `#[cfg(test)]`-annotated item without descending into its
+/// body, starting at `start` (the token just past the attribute's bracket
+/// group). The item body is the first top-level brace group (`mod tests { … }`,
+/// `fn … { … }`); a body-less item (`#[cfg(test)] use …;`) ends at its `;`.
+/// Not descending into that brace is the whole point — any `html!` markup
+/// inside is intentionally excluded from the scan.
+fn skip_cfg_test_item(trees: &[TokenTree], start: usize) -> usize {
+    let mut i = start;
+    while i < trees.len() {
+        match &trees[i] {
+            TokenTree::Group(g) if g.delimiter() == Delimiter::Brace => return i + 1,
+            TokenTree::Punct(p) if p.as_char() == ';' => return i + 1,
+            _ => i += 1,
+        }
+    }
+    i
 }
 
 /// Whether an `html!` body is JSX/Yew-style angle-bracket markup rather than
@@ -2879,5 +2950,80 @@ mod tests {
             strict: false,
         };
         assert_eq!(run_in(dir.path(), opts), 0);
+    }
+
+    // ── Test-scaffolding skips (issue #1934) ───────────────────────────────
+
+    #[test]
+    fn defect_in_inline_cfg_test_module_is_not_flagged() {
+        // A raw-`html!` defect inside a `#[cfg(test)] mod tests { … }` is test
+        // scaffolding, not shipped product markup, so it must not be flagged —
+        // while a real product defect in the same file still is (issue #1934,
+        // the #1930 `form.rs` case).
+        let src = r#"
+            fn view() { let _ = html! { img src="product.png"; }; }
+            #[cfg(test)]
+            mod tests {
+                fn t() { let _ = html! { img src="scaffold.png"; }; }
+            }
+        "#;
+        let f = findings_for(src);
+        assert_eq!(f.len(), 1, "only the product defect should flag: {f:?}");
+        assert_eq!(f[0].rule_id, "image-alt");
+    }
+
+    #[test]
+    fn defect_in_inline_cfg_test_fn_is_not_flagged() {
+        // The `#[cfg(test)]` skip also covers a bare test `fn`, not just `mod`.
+        let src = r"
+            #[cfg(test)]
+            fn helper() { let _ = html! { button { } }; }
+        ";
+        assert!(findings_for(src).is_empty(), "{:?}", findings_for(src));
+    }
+
+    #[test]
+    fn cfg_not_test_module_is_still_scanned() {
+        // The skip is precise: `#[cfg(not(test))]` is production code and its
+        // defects must still be flagged (only a literal `cfg(test)` is skipped).
+        let src = r#"
+            #[cfg(not(test))]
+            mod prod {
+                fn v() { let _ = html! { img src="x.png"; }; }
+            }
+        "#;
+        let f = findings_for(src);
+        assert_eq!(f.len(), 1, "{f:?}");
+        assert_eq!(f[0].rule_id, "image-alt");
+    }
+
+    #[test]
+    fn defect_under_tests_subdir_is_skipped_but_flagged_at_root() {
+        // The `tests/`-directory skip is scan-root RELATIVE: the SAME defect is
+        // ignored under a `tests/` subdir of the scan root but flagged when it
+        // sits at the root — proving the skip never neuters the fixture-dir
+        // integration test, which passes a fixture dir AS the scan root
+        // (issue #1934).
+        let dir = tempfile::tempdir().unwrap();
+        let opts = A11yVerifyOptions {
+            format: OutputFormat::Text,
+            strict: false,
+        };
+
+        let tests_dir = dir.path().join("tests");
+        std::fs::create_dir(&tests_dir).unwrap();
+        std::fs::write(tests_dir.join("view.rs"), wrap(r#"img src="x.png";"#)).unwrap();
+        assert_eq!(
+            run_in(dir.path(), opts),
+            0,
+            "a defect under a tests/ subdir must not be flagged",
+        );
+
+        std::fs::write(dir.path().join("view.rs"), wrap(r#"img src="x.png";"#)).unwrap();
+        assert_eq!(
+            run_in(dir.path(), opts),
+            1,
+            "the same defect at the scan root must be flagged",
+        );
     }
 }

--- a/examples/bookmarks/src/routes/bookmarks.rs
+++ b/examples/bookmarks/src/routes/bookmarks.rs
@@ -204,6 +204,7 @@ pub async fn show(id: Path<i64>, mut db: Db) -> AutumnResult<Markup> {
                     "Edit"
                 }
                 button
+                    aria-label="Delete bookmark"
                     hx-delete=(format!("/api/bookmarks/{}", row.id))
                     hx-confirm="Delete this bookmark?"
                     hx-on--after-request="if(event.detail.successful) window.location='/bookmarks'"

--- a/examples/reddit-clone/src/routes/avatars.rs
+++ b/examples/reddit-clone/src/routes/avatars.rs
@@ -97,6 +97,7 @@ pub async fn avatar_form(
                      class="space-y-3" {
                     input type="hidden" name="_csrf" value=(csrf.token());
                     input type="file" name="avatar" accept="image/png,image/jpeg,image/webp"
+                          aria-label="Choose avatar image"
                           required class="block w-full text-sm";
                     button type="submit"
                            class="bg-orange-500 text-white py-2 px-4 rounded font-medium \

--- a/examples/reddit-clone/src/routes/posts.rs
+++ b/examples/reddit-clone/src/routes/posts.rs
@@ -763,6 +763,7 @@ pub async fn show(
                                  class="flex items-center gap-2 mt-3 text-sm" {
                                 input type="hidden" name="_csrf" value=(csrf.token());
                                 input type="text" name="tags"
+                                      aria-label="Post tags"
                                       value=(post_tags.iter().map(|t| t.slug.clone()).collect::<Vec<_>>().join(", "))
                                       placeholder="tags, comma separated"
                                       class="flex-1 border border-gray-300 rounded px-2 py-1 text-xs \
@@ -798,6 +799,7 @@ pub async fn show(
                      class="bg-white rounded-lg shadow-sm border border-gray-200 p-4 mb-6" {
                     input type="hidden" name="_csrf" value=(csrf.token());
                     textarea name="body" rows="4" required
+                             aria-label="Comment body"
                              placeholder="What are your thoughts?"
                              class="w-full border border-gray-300 rounded px-3 py-2 text-sm mb-3 \
                                     focus:outline-none focus:ring-2 focus:ring-orange-400" {}

--- a/examples/todo-app/src/routes/todos.rs
+++ b/examples/todo-app/src/routes/todos.rs
@@ -176,6 +176,7 @@ fn title_field_partial(form: &ChangesetForm<TodoForm>) -> Markup {
     html! {
         div id="title-field" data-autumn-field-wrapper="title" class="flex-1 flex flex-col gap-1" {
             input type="text" name="title"
+                  aria-label="Todo title"
                   value=(value)
                   placeholder="What needs to be done?"
                   autocomplete="off"

--- a/examples/wiki/src/routes/pages.rs
+++ b/examples/wiki/src/routes/pages.rs
@@ -93,6 +93,7 @@ pub async fn list(repo: PgPageRepository) -> AutumnResult<Markup> {
             }
             div class="mb-6 bg-white p-4 rounded shadow flex items-center" {
                 input type="search" name="q" placeholder="Search pages..."
+                      aria-label="Search pages"
                       hx-get="/search" hx-trigger="keyup changed delay:300ms, search"
                       hx-target="#search-results" hx-swap="outerHTML" hx-indicator="#search-indicator"
                       class="flex-grow border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-emerald-500";


### PR DESCRIPTION
## Before / After
**Before:** `autumn a11y verify` ran only over `autumn/src` + `autumn-cli/src` in CI; raw `html!` a11y findings remained across `autumn-admin-plugin` and the example apps, and the scanner flagged intentional test fixtures.
**After:** the gate runs over the whole repo (`a11y verify .`) and passes clean (exit 0); the scanner skips `tests/` dirs and inline `#[cfg(test)]` modules so intentional fixtures aren't flagged.

## How
- 10 descriptive `aria-label`s added across `autumn-admin-plugin/src/templates.rs` and `examples/{bookmarks,reddit-clone,todo-app,wiki}/…`.
- `autumn-cli/src/a11y.rs`: `collect_rs_files` skips `tests/` dirs (scan-root-relative — the red fixture is still flagged when its own dir is the scan root); `find_html_blocks` skips inline `#[cfg(test)]` items (precise: `#[cfg(not(test))]` / `#[cfg(feature=…)]` untouched). 4 regression tests added.
- `.github/workflows/ci.yml`: a11y gate widened to `a11y verify .`.

## Verification (local)
- `autumn a11y verify .` → exit 0 (scanned 434 `html!` blocks across 466 files, no violations).
- `cargo test -p autumn-cli --bins a11y` → 162 passed; the RED→flagged / GREEN→clean fixture integration tests still pass.
- `cargo fmt --all --check` clean; `cargo clippy -p autumn-cli --all-targets -- -D warnings` clean; edited example crates `cargo check` clean; `ci.yml` YAML parses.

**Note:** this and #1945 both touch `.github/workflows/ci.yml` (different steps); whichever merges second needs a trivial rebase, which the author will handle.

Closes #1934

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyHpN8kZw9ZNeVa5a8Qqzc)_