### PR TITLE
MCP schema quality Part 2: serde rename fidelity, collision-proof identity, flat-query guard (Part 2 of #1972)

### DIFF
--- a/autumn-macros/src/api_doc.rs
+++ b/autumn-macros/src/api_doc.rs
@@ -505,6 +505,7 @@ fn schema_entry_for_type(ty: &syn::Type) -> TokenStream {
             ::autumn_web::openapi::SchemaEntry {
                 name: "array",
                 kind: ::autumn_web::openapi::SchemaKind::Array(&#inner_tokens),
+                identity: ::core::option::Option::None,
             }
         };
     }
@@ -515,6 +516,7 @@ fn schema_entry_for_type(ty: &syn::Type) -> TokenStream {
             ::autumn_web::openapi::SchemaEntry {
                 name: "nullable",
                 kind: ::autumn_web::openapi::SchemaKind::Nullable(&#inner_tokens),
+                identity: ::core::option::Option::None,
             }
         };
     }
@@ -527,13 +529,20 @@ fn schema_entry_for_type(ty: &syn::Type) -> TokenStream {
             ::autumn_web::openapi::SchemaEntry {
                 name: #name_lit,
                 kind: ::autumn_web::openapi::SchemaKind::Primitive(#json_lit),
+                identity: ::core::option::Option::None,
             }
         }
     } else {
+        // A named object ref carries its globally-unique `type_name` identity so
+        // the spec/MCP back-fill can disambiguate two distinct types that share
+        // this last path segment (issue #1972).
         quote! {
             ::autumn_web::openapi::SchemaEntry {
                 name: #name_lit,
                 kind: ::autumn_web::openapi::SchemaKind::Ref,
+                identity: ::core::option::Option::Some(
+                    ::autumn_web::openapi::type_name_of::<#ty>
+                ),
             }
         }
     }

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -1758,7 +1758,7 @@ fn field_has_serde_rename(field: &syn::Field) -> bool {
 /// Same parsing convention as `field_has_serde_rename`: a `#[serde(...)]`
 /// list this parser can't fully walk simply yields no rule (the real serde
 /// derive still validates the attribute itself).
-fn serde_rename_all_serialize_rule(attrs: &[syn::Attribute]) -> Option<String> {
+pub fn serde_rename_all_serialize_rule(attrs: &[syn::Attribute]) -> Option<String> {
     let mut rule = None;
     for attr in attrs.iter().filter(|a| a.path().is_ident("serde")) {
         let _ = attr.parse_nested_meta(|meta| {
@@ -1860,6 +1860,34 @@ fn apply_serde_rename_all_rule(rule: &str, field: &str) -> Option<String> {
         "SCREAMING-KEBAB-CASE" => Some(field.to_ascii_uppercase().replace('_', "-")),
         _ => None,
     }
+}
+
+/// The JSON-schema property name a field serializes to, honoring serde attrs.
+///
+/// Precedence mirrors serde: a field-level `#[serde(rename = "...")]` wins over
+/// a container `#[serde(rename_all = "...")]`, which in turn overrides the raw
+/// identifier. The raw-ident prefix (`r#`) is stripped first, so a field
+/// `r#type` advertises the property name `"type"` (what the handler actually
+/// deserializes), never the literal `"r#type"`.
+///
+/// KNOWN LIMITATION: this uses the *serialize* side of a split
+/// `#[serde(rename(serialize = ..., deserialize = ...))]` /
+/// `#[serde(rename_all(serialize = ..., deserialize = ...))]`. For the common
+/// symmetric `rename` / `rename_all` (which apply to both sides) this is exact;
+/// only the rare split-form input struct could differ between the advertised
+/// schema and the deserialized wire name. This is deliberate: it keeps the
+/// `#[derive(OpenApiSchema)]`, `#[model]`, and `FormModel` code paths in
+/// lockstep on the same serde helpers rather than duplicating a
+/// deserialize-side variant.
+fn schema_property_name(field: &syn::Field, rename_all_rule: Option<&str>) -> Option<String> {
+    let ident = field.ident.as_ref()?;
+    let raw = ident.to_string();
+    let raw = raw.strip_prefix("r#").unwrap_or(&raw).to_owned();
+    Some(
+        field_serde_serialize_rename(field)
+            .or_else(|| rename_all_rule.and_then(|rule| apply_serde_rename_all_rule(rule, &raw)))
+            .unwrap_or(raw),
+    )
 }
 
 /// Parse the struct-level language dictionary configuration from `#[searchable(language = "...")]`
@@ -2534,21 +2562,31 @@ fn emit_json_schema_tokens(ty: &syn::Type) -> TokenStream {
 ///
 /// `all_optional` is `true` for `UpdateX` structs where every field is
 /// conceptually optional (backed by `Patch<T>`).
-pub fn emit_schema_fn_body(fields: &[&&Field], all_optional: bool) -> TokenStream {
-    emit_schema_fn_body_ext(fields, all_optional, &[])
+pub fn emit_schema_fn_body(
+    fields: &[&&Field],
+    all_optional: bool,
+    rename_all_rule: Option<&str>,
+) -> TokenStream {
+    emit_schema_fn_body_ext(fields, all_optional, &[], rename_all_rule)
 }
 
 fn emit_schema_fn_body_ext(
     fields: &[&&Field],
     all_optional: bool,
     extra_required: &[&&Field],
+    rename_all_rule: Option<&str>,
 ) -> TokenStream {
+    // Resolve each field's advertised property name once — through the shared
+    // serde helpers so the schema honors `#[serde(rename)]` /
+    // `#[serde(rename_all)]` and strips raw-ident `r#` prefixes — and reuse the
+    // same resolved name for BOTH the property key and the `required` entry, so
+    // the two can never drift.
     let insertions: Vec<TokenStream> = fields
         .iter()
         .chain(extra_required.iter())
         .map(|f| {
-            let ident = f.ident.as_ref().unwrap();
-            let field_name = ident.to_string();
+            let field_name = schema_property_name(f, rename_all_rule)
+                .unwrap_or_else(|| f.ident.as_ref().unwrap().to_string());
             let schema_expr = emit_json_schema_tokens(&f.ty);
             quote! {
                 __props.insert(#field_name.to_owned(), #schema_expr);
@@ -2562,12 +2600,12 @@ fn emit_schema_fn_body_ext(
         fields
             .iter()
             .filter(|f| !is_option_type(&f.ty))
-            .filter_map(|f| f.ident.as_ref().map(ToString::to_string))
+            .filter_map(|f| schema_property_name(f, rename_all_rule))
             .collect()
     };
     for f in extra_required {
-        if let Some(id) = f.ident.as_ref() {
-            required_names.push(id.to_string());
+        if let Some(name) = schema_property_name(f, rename_all_rule) {
+            required_names.push(name);
         }
     }
 
@@ -4263,12 +4301,18 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     // Compute schema bodies for OpenApiSchema impls.
     // all_fields is Vec<&Field>; emit_schema_fn_body expects &[&&Field].
+    // Thread the container `#[serde(rename_all)]` rule so the advertised schema
+    // property names match the wire names the (de)serialized struct uses.
+    let schema_rename_all_rule = serde_rename_all_serialize_rule(outer_attrs);
+    let schema_rename_all_rule = schema_rename_all_rule.as_deref();
     let all_field_refs: Vec<&&Field> = all_fields.iter().collect();
-    let query_struct_schema_body = emit_schema_fn_body(&all_field_refs, false);
-    let new_struct_schema_body = emit_schema_fn_body(&fields_for_new, false);
+    let query_struct_schema_body =
+        emit_schema_fn_body(&all_field_refs, false, schema_rename_all_rule);
+    let new_struct_schema_body =
+        emit_schema_fn_body(&fields_for_new, false, schema_rename_all_rule);
     let update_struct_schema_body = {
         let extra: &[&&Field] = lock_version_field.as_slice();
-        emit_schema_fn_body_ext(&fields_for_new, true, extra)
+        emit_schema_fn_body_ext(&fields_for_new, true, extra, schema_rename_all_rule)
     };
     let commit_hook_serialize_fields: Vec<TokenStream> = all_fields
         .iter()
@@ -5335,6 +5379,39 @@ mod tests {
             .parse2(quote! { #[serde(default)] pub title: String })
             .unwrap();
         assert_eq!(field_serde_serialize_rename(&field), None);
+    }
+
+    #[test]
+    fn schema_property_name_resolves_renames_and_strips_raw_idents() {
+        // field rename wins over rename_all.
+        let field: syn::Field = syn::Field::parse_named
+            .parse2(quote! { #[serde(rename = "kind")] pub category: String })
+            .unwrap();
+        assert_eq!(
+            schema_property_name(&field, Some("camelCase")).as_deref(),
+            Some("kind")
+        );
+
+        // container rename_all applies when there is no field rename.
+        let field: syn::Field = syn::Field::parse_named
+            .parse2(quote! { pub word_count: i64 })
+            .unwrap();
+        assert_eq!(
+            schema_property_name(&field, Some("camelCase")).as_deref(),
+            Some("wordCount")
+        );
+
+        // raw-ident prefix is stripped (advertise the wire name).
+        let field: syn::Field = syn::Field::parse_named
+            .parse2(quote! { pub r#type: String })
+            .unwrap();
+        assert_eq!(schema_property_name(&field, None).as_deref(), Some("type"));
+
+        // no rule, plain field → the identifier verbatim.
+        let field: syn::Field = syn::Field::parse_named
+            .parse2(quote! { pub title: String })
+            .unwrap();
+        assert_eq!(schema_property_name(&field, None).as_deref(), Some("title"));
     }
 
     #[test]

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -2549,8 +2549,18 @@ fn emit_json_schema_tokens(ty: &syn::Type) -> TokenStream {
     let name = type_name_str(ty);
     crate::api_doc::primitive_json_type(&name).map_or_else(
         || {
-            let ref_path = format!("#/components/schemas/{name}");
-            quote! { ::autumn_web::reexports::serde_json::json!({ "$ref": #ref_path }) }
+            // Emit the `$ref` against the field type's FULL `type_name` identity
+            // (built at runtime), NOT its short last segment, so the finalize
+            // collision index can match this nested ref to the exact producing
+            // type and rewrite it to the same display key the top-level route
+            // refs use — even when two types share a last segment (issue #1972).
+            quote! {{
+                let __ref_path = ::std::format!(
+                    "#/components/schemas/{}",
+                    ::core::any::type_name::<#ty>()
+                );
+                ::autumn_web::reexports::serde_json::json!({ "$ref": __ref_path })
+            }}
         },
         |json_type| {
             quote! { ::autumn_web::reexports::serde_json::json!({ "type": #json_type }) }

--- a/autumn-macros/src/openapi_schema.rs
+++ b/autumn-macros/src/openapi_schema.rs
@@ -63,7 +63,12 @@ pub fn derive_openapi_schema(input: TokenStream) -> TokenStream {
     // `Vec<&&Field>` the model macro collects); build that shape here.
     let field_refs: Vec<&syn::Field> = fields.iter().collect();
     let field_ref_refs: Vec<&&syn::Field> = field_refs.iter().collect();
-    let schema_body = crate::model::emit_schema_fn_body(&field_ref_refs, false);
+    // Honor a container `#[serde(rename_all = "...")]` on the derived struct so
+    // the advertised property names + `required` entries match the serialized
+    // wire names — same helper/precedence `#[model]` and `FormModel` use.
+    let rename_all_rule = crate::model::serde_rename_all_serialize_rule(&input.attrs);
+    let schema_body =
+        crate::model::emit_schema_fn_body(&field_ref_refs, false, rename_all_rule.as_deref());
 
     quote! {
         impl ::autumn_web::openapi::OpenApiSchema for #name {
@@ -80,6 +85,7 @@ pub fn derive_openapi_schema(input: TokenStream) -> TokenStream {
         ::autumn_web::reexports::inventory::submit! {
             ::autumn_web::openapi::DerivedSchemaDescriptor {
                 name: ::core::stringify!(#name),
+                identity: ::autumn_web::openapi::type_name_of::<#name>,
                 schema: <#name as ::autumn_web::openapi::OpenApiSchema>::schema,
             }
         }

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -12245,6 +12245,11 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         path: #api_path,
                         operation_id: ::core::stringify!(#list_fn),
                         success_status: 200,
+                        // The pagination query/response envelopes are synthetic,
+                        // runtime-inserted component schemas (`PageRequest` /
+                        // `CursorRequest` / `<Model>Page` / `<Model>CursorPage`)
+                        // with no addressable Rust type, so they carry no
+                        // `type_name` identity and key off their short name.
                         query_schema: ::core::option::Option::Some(
                             ::autumn_web::openapi::SchemaEntry {
                                 name: #list_query_schema_name,
@@ -12311,7 +12316,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             ::autumn_web::openapi::SchemaEntry {
                                 name: ::core::stringify!(#model_name),
                                 kind: ::autumn_web::openapi::SchemaKind::Ref,
-                                identity: ::core::option::Option::None,
+                                identity: ::core::option::Option::Some(
+                                    ::autumn_web::openapi::type_name_of::<#model_name>
+                                ),
                             }
                         ),
                         mcp_tool: #mcp_get_op,
@@ -12356,14 +12363,18 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             ::autumn_web::openapi::SchemaEntry {
                                 name: ::core::stringify!(#new_name),
                                 kind: ::autumn_web::openapi::SchemaKind::Ref,
-                                identity: ::core::option::Option::None,
+                                identity: ::core::option::Option::Some(
+                                    ::autumn_web::openapi::type_name_of::<#new_name>
+                                ),
                             }
                         ),
                         response: ::core::option::Option::Some(
                             ::autumn_web::openapi::SchemaEntry {
                                 name: ::core::stringify!(#model_name),
                                 kind: ::autumn_web::openapi::SchemaKind::Ref,
-                                identity: ::core::option::Option::None,
+                                identity: ::core::option::Option::Some(
+                                    ::autumn_web::openapi::type_name_of::<#model_name>
+                                ),
                             }
                         ),
                         mcp_tool: #mcp_create_op,
@@ -12410,14 +12421,18 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             ::autumn_web::openapi::SchemaEntry {
                                 name: ::core::stringify!(#update_name),
                                 kind: ::autumn_web::openapi::SchemaKind::Ref,
-                                identity: ::core::option::Option::None,
+                                identity: ::core::option::Option::Some(
+                                    ::autumn_web::openapi::type_name_of::<#update_name>
+                                ),
                             }
                         ),
                         response: ::core::option::Option::Some(
                             ::autumn_web::openapi::SchemaEntry {
                                 name: ::core::stringify!(#model_name),
                                 kind: ::autumn_web::openapi::SchemaKind::Ref,
-                                identity: ::core::option::Option::None,
+                                identity: ::core::option::Option::Some(
+                                    ::autumn_web::openapi::type_name_of::<#model_name>
+                                ),
                             }
                         ),
                         mcp_tool: #mcp_update_op,

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -12249,12 +12249,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             ::autumn_web::openapi::SchemaEntry {
                                 name: #list_query_schema_name,
                                 kind: ::autumn_web::openapi::SchemaKind::Ref,
+                                identity: ::core::option::Option::None,
                             }
                         ),
                         response: ::core::option::Option::Some(
                             ::autumn_web::openapi::SchemaEntry {
                                 name: #list_response_schema_name,
                                 kind: ::autumn_web::openapi::SchemaKind::Ref,
+                                identity: ::core::option::Option::None,
                             }
                         ),
                         register_schemas: ::core::option::Option::Some(#list_schema_fn),
@@ -12309,6 +12311,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             ::autumn_web::openapi::SchemaEntry {
                                 name: ::core::stringify!(#model_name),
                                 kind: ::autumn_web::openapi::SchemaKind::Ref,
+                                identity: ::core::option::Option::None,
                             }
                         ),
                         mcp_tool: #mcp_get_op,
@@ -12353,12 +12356,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             ::autumn_web::openapi::SchemaEntry {
                                 name: ::core::stringify!(#new_name),
                                 kind: ::autumn_web::openapi::SchemaKind::Ref,
+                                identity: ::core::option::Option::None,
                             }
                         ),
                         response: ::core::option::Option::Some(
                             ::autumn_web::openapi::SchemaEntry {
                                 name: ::core::stringify!(#model_name),
                                 kind: ::autumn_web::openapi::SchemaKind::Ref,
+                                identity: ::core::option::Option::None,
                             }
                         ),
                         mcp_tool: #mcp_create_op,
@@ -12405,12 +12410,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             ::autumn_web::openapi::SchemaEntry {
                                 name: ::core::stringify!(#update_name),
                                 kind: ::autumn_web::openapi::SchemaKind::Ref,
+                                identity: ::core::option::Option::None,
                             }
                         ),
                         response: ::core::option::Option::Some(
                             ::autumn_web::openapi::SchemaEntry {
                                 name: ::core::stringify!(#model_name),
                                 kind: ::autumn_web::openapi::SchemaKind::Ref,
+                                identity: ::core::option::Option::None,
                             }
                         ),
                         mcp_tool: #mcp_update_op,

--- a/autumn/src/extract.rs
+++ b/autumn/src/extract.rs
@@ -144,6 +144,25 @@ where
 ///
 /// Wraps [`axum::extract::Query`] so query parse failures use Autumn's
 /// Problem Details error contract.
+///
+/// # Query strings are flat
+///
+/// Deserialization goes through
+/// [`serde_urlencoded`](https://docs.rs/serde_urlencoded), which is **strictly
+/// flat**. It decodes scalar fields (`?q=foo&page=2`) and a sequence field from
+/// repeated keys (`?tags=a&tags=b`), but it **cannot** deserialize a nested
+/// struct by any encoding — neither bracketed (`key[sub]=`) nor
+/// JSON-in-a-string. If a request needs structured/nested input, take it as a
+/// JSON body ([`Json<T>`](crate::extract::Json)) instead of a query struct.
+///
+/// This also shapes MCP tool exposure (issue #1972): a `Query<T>` becomes the
+/// tool's `query` object property, and dispatch renders it as flat `key=value`
+/// pairs. A `Query<T>` whose schema has a nested object / array-of-object field
+/// therefore cannot round-trip, and Autumn emits a build-time `tracing::warn`
+/// steering that input to a JSON body. See the [MCP guide]'s "Query is flat"
+/// note.
+///
+/// [MCP guide]: https://docs.rs/autumn-web (guide/mcp.md)
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Query<T>(pub T);
 

--- a/autumn/src/mcp.rs
+++ b/autumn/src/mcp.rs
@@ -434,7 +434,11 @@ fn annotations_for(method: &str, title: &str) -> Value {
 /// becomes a `query` object property, and the JSON request body becomes a
 /// `body` property. Named component refs are inlined into `$defs` so the
 /// schema is self-contained.
-fn build_input_schema(doc: &ApiDoc, components: &serde_json::Map<String, Value>) -> Value {
+fn build_input_schema(
+    doc: &ApiDoc,
+    components: &serde_json::Map<String, Value>,
+    index: &crate::openapi::SchemaComponentIndex,
+) -> Value {
     let mut properties = serde_json::Map::new();
     let mut required: Vec<Value> = Vec::new();
     let mut defs = serde_json::Map::new();
@@ -459,12 +463,12 @@ fn build_input_schema(doc: &ApiDoc, components: &serde_json::Map<String, Value>)
     }
 
     if let Some(query) = &doc.query_schema {
-        let schema = rewrite_refs(schema_entry_to_value(query), components, &mut defs);
+        let schema = rewrite_refs(schema_entry_to_value(query, index), components, &mut defs);
         properties.insert("query".to_owned(), schema);
     }
 
     if let Some(body) = &doc.request_body {
-        let schema = rewrite_refs(schema_entry_to_value(body), components, &mut defs);
+        let schema = rewrite_refs(schema_entry_to_value(body, index), components, &mut defs);
         properties.insert("body".to_owned(), schema);
         required.push(json!("body"));
     }
@@ -525,6 +529,144 @@ fn rewrite_refs(
     }
 }
 
+/// A build-time quality problem detected in a tool's derived `inputSchema`.
+///
+/// Surfaced as `tracing::warn` from [`derive_tools`] (mirroring the existing
+/// ineligible-route warning) so an author sees it when assembling `/mcp`,
+/// rather than a runtime surprise when an LLM client calls the tool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SchemaDegradation {
+    /// The `query` property resolved to a bare `{"type":"object"}` placeholder
+    /// (the arg type has no `OpenApiSchema`), so the tool advertises no query
+    /// fields.
+    OpaqueQuery,
+    /// The `body` property resolved to a bare `{"type":"object"}` placeholder,
+    /// so the tool advertises no body fields.
+    OpaqueBody,
+    /// A `query` field is itself a nested object (or an array of objects) — a
+    /// shape `serde_urlencoded` (which `Query<T>` delegates to) cannot parse,
+    /// so dispatch of such an argument could never round-trip to the handler.
+    NestedQuery,
+}
+
+/// Resolve a schema node through a single `#/$defs/X` indirection (the form
+/// [`rewrite_refs`] inlines), returning the node itself when it is not a ref.
+fn resolve_local_ref<'a>(root: &'a Value, node: &'a Value) -> &'a Value {
+    if let Some(name) = node
+        .get("$ref")
+        .and_then(Value::as_str)
+        .and_then(|r| r.strip_prefix("#/$defs/"))
+        && let Some(def) = root.get("$defs").and_then(|defs| defs.get(name))
+    {
+        return def;
+    }
+    node
+}
+
+/// True when `schema` is the opaque object placeholder the spec generator emits
+/// for a type with no real `OpenApiSchema` (`{"type":"object","title":…}` with
+/// no `properties`). A derived/registered object always carries a `properties`
+/// key (even if empty), so a legitimately field-less struct is not flagged.
+fn is_opaque_object(schema: &Value) -> bool {
+    schema.get("type").and_then(Value::as_str) == Some("object")
+        && schema
+            .as_object()
+            .is_none_or(|map| !map.contains_key("properties"))
+}
+
+/// True when `schema` (already ref-resolved) is a nested object or an array of
+/// objects — the shapes flat `serde_urlencoded` query decoding cannot handle.
+fn is_nested_query_shape(root: &Value, schema: &Value) -> bool {
+    match schema.get("type").and_then(Value::as_str) {
+        // A non-placeholder object nested under a query field.
+        Some("object") => schema
+            .as_object()
+            .is_some_and(|map| map.contains_key("properties")),
+        Some("array") => schema
+            .get("items")
+            .map(|items| resolve_local_ref(root, items))
+            .is_some_and(|items| is_nested_query_shape(root, items)),
+        _ => false,
+    }
+}
+
+/// Inspect a built `inputSchema` for the degradations in [`SchemaDegradation`].
+///
+/// Pure and self-contained (no logging) so it is unit-testable; [`derive_tools`]
+/// turns the results into `tracing::warn` lines with route context.
+fn detect_schema_degradations(
+    input_schema: &Value,
+    has_query: bool,
+    has_body: bool,
+) -> Vec<SchemaDegradation> {
+    let mut out = Vec::new();
+    let props = input_schema.get("properties");
+
+    if has_body
+        && let Some(body) = props.and_then(|p| p.get("body"))
+        && is_opaque_object(resolve_local_ref(input_schema, body))
+    {
+        out.push(SchemaDegradation::OpaqueBody);
+    }
+
+    if has_query && let Some(query) = props.and_then(|p| p.get("query")) {
+        let resolved = resolve_local_ref(input_schema, query);
+        if is_opaque_object(resolved) {
+            out.push(SchemaDegradation::OpaqueQuery);
+        } else if let Some(fields) = resolved.get("properties").and_then(Value::as_object) {
+            // A `Query<T>` whose schema is real but has a nested/object-of-array
+            // field can't round-trip through `serde_urlencoded`.
+            let nested = fields
+                .values()
+                .map(|field| resolve_local_ref(input_schema, field))
+                .any(|field| is_nested_query_shape(input_schema, field));
+            if nested {
+                out.push(SchemaDegradation::NestedQuery);
+            }
+        }
+    }
+
+    out
+}
+
+/// Emit a `tracing::warn` for each degradation in a tool's derived
+/// `inputSchema`, naming the tool and the recommended fix (issue #1972).
+fn warn_on_degraded_input_schema(doc: &ApiDoc, input_schema: &Value) {
+    for degradation in detect_schema_degradations(
+        input_schema,
+        doc.query_schema.is_some(),
+        doc.request_body.is_some(),
+    ) {
+        match degradation {
+            SchemaDegradation::OpaqueBody => tracing::warn!(
+                operation_id = doc.operation_id,
+                method = doc.method,
+                path = doc.path,
+                "MCP tool body has no field-level schema (opaque object); derive or \
+                 impl `OpenApiSchema` on the `Json<T>` body type so the tool advertises \
+                 its real fields instead of a bare `{{\"type\":\"object\"}}` placeholder"
+            ),
+            SchemaDegradation::OpaqueQuery => tracing::warn!(
+                operation_id = doc.operation_id,
+                method = doc.method,
+                path = doc.path,
+                "MCP tool query has no field-level schema (opaque object); derive or \
+                 impl `OpenApiSchema` on the `Query<T>` type so the tool advertises \
+                 its real query parameters instead of a bare `{{\"type\":\"object\"}}` placeholder"
+            ),
+            SchemaDegradation::NestedQuery => tracing::warn!(
+                operation_id = doc.operation_id,
+                method = doc.method,
+                path = doc.path,
+                "MCP tool query advertises a nested object/array-of-object field; \
+                 `Query<T>` decodes with `serde_urlencoded`, which is strictly flat and \
+                 cannot parse nested query parameters — move the structured input to a \
+                 JSON request body (`Json<T>`) so it round-trips losslessly"
+            ),
+        }
+    }
+}
+
 /// Derive the tool catalog from collected route docs.
 ///
 /// Emits a build-time `tracing::warn` for any endpoint that opts into MCP but
@@ -552,6 +694,11 @@ pub fn derive_tools(
         .map(|c| serde_json::to_value(&c.schemas).unwrap_or(Value::Null))
         .and_then(|v| v.as_object().cloned())
         .unwrap_or_default();
+    // Resolve `$ref` component keys through the exact same identity→display-key
+    // mapping the OpenAPI generator used, so a tool's inlined `$defs` refs match
+    // the served component names even when two types share a last segment
+    // (issue #1972).
+    let index = crate::openapi::build_schema_component_index(&refs);
 
     let mut tools = Vec::new();
     let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
@@ -596,10 +743,12 @@ pub fn derive_tools(
             continue;
         }
         let title = doc.summary.unwrap_or(doc.operation_id);
+        let input_schema = build_input_schema(doc, &components, &index);
+        warn_on_degraded_input_schema(doc, &input_schema);
         tools.push(McpToolInfo {
             name: doc.operation_id.to_owned(),
             description: doc.description.or(doc.summary).map(str::to_owned),
-            input_schema: build_input_schema(doc, &components),
+            input_schema,
             annotations: annotations_for(doc.method, title),
             method: doc.method.to_owned(),
             path_template: doc.path.to_owned(),
@@ -2023,6 +2172,7 @@ mod tests {
             response: Some(SchemaEntry {
                 name: "Todo",
                 kind: SchemaKind::Ref,
+                identity: None,
             }),
             ..Default::default()
         }
@@ -2291,14 +2441,92 @@ mod tests {
         d.request_body = Some(SchemaEntry {
             name: "NewUser",
             kind: SchemaKind::Ref,
+            identity: None,
         });
-        let schema = build_input_schema(&d, &serde_json::Map::new());
+        let schema = build_input_schema(
+            &d,
+            &serde_json::Map::new(),
+            &crate::openapi::SchemaComponentIndex::default(),
+        );
         assert_eq!(schema["type"], "object");
         assert!(schema["properties"]["id"].is_object());
         assert!(schema["properties"]["body"].is_object());
         let required = schema["required"].as_array().unwrap();
         assert!(required.contains(&json!("id")));
         assert!(required.contains(&json!("body")));
+    }
+
+    #[test]
+    fn detect_degradation_flags_opaque_body_and_query() {
+        // Both `query` and `body` resolve to the bare object placeholder.
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "object", "title": "Q" },
+                "body": { "type": "object", "title": "B" },
+            },
+        });
+        let degradations = detect_schema_degradations(&schema, true, true);
+        assert!(degradations.contains(&SchemaDegradation::OpaqueQuery));
+        assert!(degradations.contains(&SchemaDegradation::OpaqueBody));
+        assert!(!degradations.contains(&SchemaDegradation::NestedQuery));
+    }
+
+    #[test]
+    fn detect_degradation_ignores_field_accurate_schemas() {
+        // A real query object (with `properties`) and a real body: no warning.
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "object",
+                    "properties": { "page": { "type": "integer" }, "tags": { "type": "array", "items": { "type": "string" } } },
+                },
+                "body": { "$ref": "#/$defs/Real" },
+            },
+            "$defs": { "Real": { "type": "object", "properties": { "a": { "type": "string" } } } },
+        });
+        assert!(detect_schema_degradations(&schema, true, true).is_empty());
+    }
+
+    #[test]
+    fn detect_degradation_flags_nested_query_object_and_array() {
+        // A query field that is itself an object → nested (flat-encoding cannot
+        // round-trip). Also cover an array-of-objects field.
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "object",
+                    "properties": {
+                        "filter": { "type": "object", "properties": { "min": { "type": "integer" } } },
+                        "rows": { "type": "array", "items": { "type": "object", "properties": { "k": { "type": "string" } } } },
+                    },
+                },
+            },
+        });
+        let degradations = detect_schema_degradations(&schema, true, false);
+        assert!(degradations.contains(&SchemaDegradation::NestedQuery));
+        assert!(!degradations.contains(&SchemaDegradation::OpaqueQuery));
+    }
+
+    #[test]
+    fn detect_degradation_flags_nested_query_via_ref() {
+        // A query field that is a `$ref` to an object def is still nested.
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "object",
+                    "properties": { "filter": { "$ref": "#/$defs/Filter" } },
+                },
+            },
+            "$defs": { "Filter": { "type": "object", "properties": { "min": { "type": "integer" } } } },
+        });
+        assert!(
+            detect_schema_degradations(&schema, true, false)
+                .contains(&SchemaDegradation::NestedQuery)
+        );
     }
 
     #[test]

--- a/autumn/src/mcp.rs
+++ b/autumn/src/mcp.rs
@@ -574,9 +574,33 @@ fn is_opaque_object(schema: &Value) -> bool {
             .is_none_or(|map| !map.contains_key("properties"))
 }
 
+/// True when a `oneOf`/`anyOf` branch is the `{"type":"null"}` arm the
+/// `OpenApiSchema` derive emits for the `None` case of an `Option<T>` field.
+fn is_null_branch(branch: &Value) -> bool {
+    branch.get("type").and_then(Value::as_str) == Some("null")
+}
+
 /// True when `schema` (already ref-resolved) is a nested object or an array of
 /// objects — the shapes flat `serde_urlencoded` query decoding cannot handle.
+///
+/// A nullable query field (`Option<Struct>`, `Option<Vec<Struct>>`) derives to a
+/// `oneOf`/`anyOf` with the nested-shape branch plus a `{"type":"null"}` branch
+/// and therefore carries no top-level `type`; unwrap those wrappers and treat the
+/// field as nested when ANY non-null branch is itself nested, so a nullable
+/// structured query field warns exactly like its non-nullable form (issue #1972).
 fn is_nested_query_shape(root: &Value, schema: &Value) -> bool {
+    if let Some(branches) = schema
+        .get("oneOf")
+        .or_else(|| schema.get("anyOf"))
+        .and_then(Value::as_array)
+    {
+        return branches
+            .iter()
+            .filter(|branch| !is_null_branch(branch))
+            .map(|branch| resolve_local_ref(root, branch))
+            .any(|branch| is_nested_query_shape(root, branch));
+    }
+
     match schema.get("type").and_then(Value::as_str) {
         // A non-placeholder object nested under a query field.
         Some("object") => schema
@@ -2526,6 +2550,83 @@ mod tests {
         assert!(
             detect_schema_degradations(&schema, true, false)
                 .contains(&SchemaDegradation::NestedQuery)
+        );
+    }
+
+    #[test]
+    fn detect_degradation_flags_nullable_nested_query_field() {
+        // `filter: Option<Filter>` derives to a nullable `oneOf` (the nested
+        // object branch + a `{"type":"null"}` branch) with no top-level `type`.
+        // The detector must still flag it — `serde_urlencoded` cannot decode the
+        // structured value whether or not the field is optional (issue #1972).
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "object",
+                    "properties": {
+                        "filter": { "oneOf": [ { "$ref": "#/$defs/Filter" }, { "type": "null" } ] },
+                    },
+                },
+            },
+            "$defs": { "Filter": { "type": "object", "properties": { "min": { "type": "integer" } } } },
+        });
+        let degradations = detect_schema_degradations(&schema, true, false);
+        assert!(
+            degradations.contains(&SchemaDegradation::NestedQuery),
+            "nullable nested query field must warn: {degradations:?}"
+        );
+    }
+
+    #[test]
+    fn detect_degradation_flags_nullable_array_of_objects_query_field() {
+        // `filter: Option<Vec<Filter>>` → `oneOf[{array of $ref}, {null}]`.
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "object",
+                    "properties": {
+                        "filters": { "oneOf": [
+                            { "type": "array", "items": { "$ref": "#/$defs/Filter" } },
+                            { "type": "null" },
+                        ] },
+                    },
+                },
+            },
+            "$defs": { "Filter": { "type": "object", "properties": { "min": { "type": "integer" } } } },
+        });
+        assert!(
+            detect_schema_degradations(&schema, true, false)
+                .contains(&SchemaDegradation::NestedQuery),
+            "nullable array-of-objects query field must warn"
+        );
+    }
+
+    #[test]
+    fn detect_degradation_ignores_nullable_scalar_query_field() {
+        // `q: Option<String>` → `oneOf[{type:string}, {type:null}]` and
+        // `tags: Option<Vec<String>>` → `oneOf[{array of scalar}, {null}]`: both
+        // are flat-encodable, so neither may produce a false positive.
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "object",
+                    "properties": {
+                        "q": { "oneOf": [ { "type": "string" }, { "type": "null" } ] },
+                        "tags": { "oneOf": [
+                            { "type": "array", "items": { "type": "string" } },
+                            { "type": "null" },
+                        ] },
+                    },
+                },
+            },
+        });
+        assert!(
+            !detect_schema_degradations(&schema, true, false)
+                .contains(&SchemaDegradation::NestedQuery),
+            "nullable scalar / scalar-array query fields must NOT warn"
         );
     }
 

--- a/autumn/src/openapi.rs
+++ b/autumn/src/openapi.rs
@@ -719,6 +719,15 @@ impl SchemaComponentIndex {
             .unwrap_or_else(|| component_key(entry.name))
     }
 
+    /// Resolve a raw schema *identity* string (`type_name`) to its display key,
+    /// or `None` when the identity is not part of this index. Used by the
+    /// finalize body-ref rewrite to map a nested derived-schema `$ref` (emitted
+    /// as the field type's full `type_name`) to its collision-resolved component
+    /// key (issue #1972).
+    fn display_key_for_identity(&self, identity: &str) -> Option<&str> {
+        self.by_identity.get(identity).map(String::as_str)
+    }
+
     /// Iterate `(identity, display_key)` pairs — used by the back-fill to
     /// register a component under its display key keyed by identity.
     fn iter(&self) -> impl Iterator<Item = (&String, &String)> {
@@ -742,32 +751,60 @@ fn qualified_suffix_key(identity: &str, depth: usize) -> String {
 #[cfg(feature = "openapi")]
 #[must_use]
 pub fn build_schema_component_index(routes: &[&ApiDoc]) -> SchemaComponentIndex {
-    // Collect (identity, base-display) for every referenced Ref entry.
-    let mut refs: Vec<(&'static str, String)> = Vec::new();
-    let mut collect = |entry: &SchemaEntry| {
-        for e in flatten_ref_entries(entry) {
-            refs.push((e.identity_key(), component_key(e.name)));
-        }
-    };
+    // Collect (identity, base-display) for every referenced Ref entry, deduped
+    // by identity. `seen` gives the identity-graph closure below an O(1) "already
+    // queued?" check.
+    let mut refs: Vec<(String, String)> = Vec::new();
+    let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     for api_doc in routes {
         if api_doc.hidden {
             continue;
         }
-        if let Some(e) = &api_doc.request_body {
-            collect(e);
+        for entry in [
+            api_doc.request_body.as_ref(),
+            api_doc.response.as_ref(),
+            api_doc.query_schema.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            for e in flatten_ref_entries(entry) {
+                let identity = e.identity_key().to_owned();
+                if seen.insert(identity.clone()) {
+                    refs.push((identity, component_key(e.name)));
+                }
+            }
         }
-        if let Some(e) = &api_doc.response {
-            collect(e);
-        }
-        if let Some(e) = &api_doc.query_schema {
-            collect(e);
+    }
+
+    // Close the identity graph: a `$ref` emitted *inside* a derived schema body
+    // (a nested named-struct field) can reference an identity that no route
+    // mentions directly. Fetch each derived body and recursively collect the
+    // identities it refers to, to a fixpoint, so nested-only types participate
+    // in collision detection and each earns its own component (issue #1972).
+    let mut queue: Vec<String> = refs.iter().map(|(id, _)| id.clone()).collect();
+    while let Some(identity) = queue.pop() {
+        let Some(body) = registered_derived_schema(&identity) else {
+            continue;
+        };
+        let mut nested: Vec<String> = Vec::new();
+        collect_body_ref_identities(&body, &mut nested);
+        for n in nested {
+            if seen.insert(n.clone()) {
+                let base = base_display_for_identity(&n);
+                refs.push((n.clone(), base));
+                queue.push(n);
+            }
         }
     }
 
     // Which base display keys are shared by more than one distinct identity?
-    let mut by_base: BTreeMap<String, std::collections::BTreeSet<&'static str>> = BTreeMap::new();
+    let mut by_base: BTreeMap<String, std::collections::BTreeSet<&str>> = BTreeMap::new();
     for (identity, base) in &refs {
-        by_base.entry(base.clone()).or_default().insert(identity);
+        by_base
+            .entry(base.clone())
+            .or_default()
+            .insert(identity.as_str());
     }
 
     let mut by_identity: BTreeMap<String, String> = BTreeMap::new();
@@ -779,19 +816,17 @@ pub fn build_schema_component_index(routes: &[&ApiDoc]) -> SchemaComponentIndex 
     for (identity, base) in &refs {
         let collides = by_base[base].len() > 1 && identity.contains("::");
         if !collides {
-            by_identity
-                .entry((*identity).to_owned())
-                .or_insert_with(|| {
-                    used.insert(base.clone());
-                    base.clone()
-                });
+            by_identity.entry(identity.clone()).or_insert_with(|| {
+                used.insert(base.clone());
+                base.clone()
+            });
         }
     }
 
     // Second pass: qualify each genuinely-colliding real type path with the
     // fewest trailing module segments that make its key unique.
     for (identity, _base) in &refs {
-        if by_identity.contains_key(*identity) {
+        if by_identity.contains_key(identity) {
             continue;
         }
         let depth_max = identity.split("::").count();
@@ -805,10 +840,96 @@ pub fn build_schema_component_index(routes: &[&ApiDoc]) -> SchemaComponentIndex 
         }
         let display = display.unwrap_or_else(|| component_key(identity));
         used.insert(display.clone());
-        by_identity.insert((*identity).to_owned(), display);
+        by_identity.insert(identity.clone(), display);
     }
 
     SchemaComponentIndex { by_identity }
+}
+
+/// The base (short) display key for a raw schema *identity* string: its last
+/// `::`-segment (ignoring any generic argument list), sanitized into a component
+/// key. Mirrors what the macros derive from `last_segment_name` for a top-level
+/// route ref, so a nested-only identity groups under the same base as a route
+/// ref of the same short name (issue #1972).
+#[cfg(feature = "openapi")]
+fn base_display_for_identity(identity: &str) -> String {
+    let without_generics = identity.split('<').next().unwrap_or(identity);
+    let last = without_generics
+        .rsplit("::")
+        .next()
+        .unwrap_or(without_generics);
+    component_key(last)
+}
+
+/// Recursively collect every `#/components/schemas/<identity>` ref target found
+/// inside a (derived) schema body, pushing each raw identity string into `out`.
+///
+/// The macro emits a nested named-struct field's `$ref` as the field type's full
+/// `type_name` identity, so the strings gathered here are exactly the identity
+/// keys the collision index resolves.
+#[cfg(feature = "openapi")]
+fn collect_body_ref_identities(value: &serde_json::Value, out: &mut Vec<String>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(serde_json::Value::String(reference)) = map.get("$ref")
+                && let Some(id) = reference.strip_prefix("#/components/schemas/")
+            {
+                out.push(id.to_owned());
+            }
+            for v in map.values() {
+                collect_body_ref_identities(v, out);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for v in items {
+                collect_body_ref_identities(v, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Rewrite every body-internal `#/components/schemas/<identity>` ref in each
+/// registered component to its collision-resolved display key.
+///
+/// A ref whose target is not a known identity (e.g. the pagination envelope's
+/// short `#/components/schemas/<Model>` ref, which is already a display key) is
+/// left untouched, so the common non-colliding case produces exactly the short
+/// key it did before (no churn — issue #1972).
+#[cfg(feature = "openapi")]
+fn rewrite_component_body_refs(
+    components: &mut BTreeMap<String, serde_json::Value>,
+    index: &SchemaComponentIndex,
+) {
+    for schema in components.values_mut() {
+        rewrite_identity_refs(schema, index);
+    }
+}
+
+#[cfg(feature = "openapi")]
+fn rewrite_identity_refs(value: &mut serde_json::Value, index: &SchemaComponentIndex) {
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(serde_json::Value::String(reference)) = map.get_mut("$ref") {
+                let replacement = reference
+                    .strip_prefix("#/components/schemas/")
+                    .and_then(|identity| index.display_key_for_identity(identity))
+                    .map(|display| format!("#/components/schemas/{display}"));
+                if let Some(new_ref) = replacement {
+                    *reference = new_ref;
+                }
+            }
+            for v in map.values_mut() {
+                rewrite_identity_refs(v, index);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for v in items {
+                rewrite_identity_refs(v, index);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Flatten an entry, yielding each leaf `Ref` entry reached through
@@ -926,7 +1047,14 @@ pub fn generate_spec_at(
         );
     }
 
-    let components_map = registry.into_map();
+    let mut components_map = registry.into_map();
+    // Rewrite every `$ref` that appears *inside* a component body from its raw
+    // schema identity (`type_name`) to its collision-resolved display key, so a
+    // nested derived-schema ref resolves to the same component the top-level
+    // route refs use (issue #1972). Top-level operation refs are already emitted
+    // as display keys by `operation_for`/`schema_value_for`; this closes the
+    // body-internal half of the `$ref` graph.
+    rewrite_component_body_refs(&mut components_map, &index);
     let components = if !components_map.is_empty() || !security_schemes.is_empty() {
         Some(Components {
             schemas: components_map,

--- a/autumn/src/openapi.rs
+++ b/autumn/src/openapi.rs
@@ -157,13 +157,89 @@ pub struct ApiDoc {
 }
 
 /// Reference to a schema definition, produced by the route macros.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug)]
 pub struct SchemaEntry {
-    /// Short human-readable type name (used as `#/components/schemas/Name`).
+    /// Short human-readable type name, used as the *default* component
+    /// display key (`#/components/schemas/Name`) when it does not collide.
     pub name: &'static str,
     /// Whether this is a primitive JSON type (string/number/bool/array) as
     /// opposed to a named object ref.
     pub kind: SchemaKind,
+    /// Globally-unique schema *identity* for a `Ref` entry, as a fn pointer to
+    /// [`type_name_of`] (i.e. `::core::any::type_name::<T>()`). This is what
+    /// matches a route reference to its producer (`#[derive(OpenApiSchema)]`
+    /// descriptor / registered schema) and disambiguates two distinct types
+    /// that share a last path segment (e.g. `create::Args` vs `update::Args`)
+    /// so neither silently shadows the other (issue #1972).
+    ///
+    /// A fn pointer (rather than the `&'static str` directly) keeps a nested
+    /// `SchemaEntry` const-promotable to `&'static` in `Array` / `Nullable`
+    /// wrappers, since `type_name` is not yet a stably-const fn.
+    ///
+    /// `None` for primitives and for the `Array` / `Nullable` wrapper entries
+    /// (whose `name` is the sentinel `"array"` / `"nullable"`), and for legacy
+    /// short-name refs (e.g. the repository macro's model refs) which keep their
+    /// last-segment display key.
+    pub identity: Option<fn() -> &'static str>,
+}
+
+impl SchemaEntry {
+    /// The globally-unique identity key for this entry: its `type_name` when an
+    /// `identity` fn is present, otherwise the short `name` (legacy behavior).
+    #[must_use]
+    pub fn identity_key(&self) -> &'static str {
+        self.identity.map_or(self.name, |f| f())
+    }
+}
+
+// `PartialEq`/`Eq` are implemented by hand rather than derived: deriving them
+// would compare the `identity` field's fn *pointers*, which the
+// `unpredictable_function_pointer_comparisons` lint (rightly) flags as
+// meaningless. Comparing the *resolved* identity strings is both meaningful and
+// what callers actually want (two entries are equal iff they describe the same
+// type the same way).
+impl PartialEq for SchemaEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.kind == other.kind
+            && self.identity_key() == other.identity_key()
+    }
+}
+
+impl Eq for SchemaEntry {}
+
+/// Monomorphized `::core::any::type_name::<T>()` behind a fn pointer.
+///
+/// The route macros emit `Some(type_name_of::<T>)` as a [`SchemaEntry::identity`]
+/// so producer and consumer agree on a globally-unique schema identity by
+/// construction (both are the `type_name` of the same `T`). Using a fn pointer
+/// keeps nested entries const-promotable to `&'static` (see
+/// [`SchemaEntry::identity`]).
+#[must_use]
+pub fn type_name_of<T: ?Sized>() -> &'static str {
+    core::any::type_name::<T>()
+}
+
+/// Sanitize a schema identity into a valid OpenAPI component key.
+///
+/// OpenAPI restricts component keys to `^[A-Za-z0-9._-]+$`, so a Rust
+/// `type_name` (`crate::module::Args`, `Vec<T>`) cannot be used verbatim. `::`
+/// collapses to `.` (utoipa-style) and any other out-of-range character maps to
+/// `_`. Centralizing this here means the registration side and the `$ref` side
+/// always derive the exact same key from the same identity.
+#[must_use]
+pub fn component_key(raw: &str) -> String {
+    let dotted = raw.replace("::", ".");
+    dotted
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }
 
 /// Classifier for how a type should appear in the spec.
@@ -358,26 +434,32 @@ impl_primitive_schema!(serde_json::Value, "object", "object");
 /// entry unconditionally, and the `openapi`-gated spec builder consults it only
 /// when that feature is compiled in.
 pub struct DerivedSchemaDescriptor {
-    /// Component schema name. Matches `OpenApiSchema::schema_name()` and the
-    /// `$ref` component name emitted for `Query<T>` / `Json<T>` handler args
-    /// (the type's last path segment).
+    /// Short display hint (the type's last path segment / `schema_name()`).
     pub name: &'static str,
+    /// The type's globally-unique *identity* (`type_name`), behind a fn pointer.
+    /// The spec/MCP back-fill matches a route reference to this descriptor by
+    /// identity, so two distinct types sharing a last segment resolve to their
+    /// own schema instead of whichever inventory entry link-order hit first
+    /// (issue #1972).
+    pub identity: fn() -> &'static str,
     /// Produces the JSON schema for the type (the type's `OpenApiSchema::schema`).
     pub schema: fn() -> serde_json::Value,
 }
 
 inventory::collect!(DerivedSchemaDescriptor);
 
-/// Look up the derived component schema for `name`.
+/// Look up the derived component schema for a schema *identity* (`type_name`).
 ///
-/// Returns the schema when a `#[derive(OpenApiSchema)]` type with that schema
-/// name was linked into the binary, or `None` when no such derive exists (so
-/// callers fall back to the generic placeholder).
+/// Returns the schema when a `#[derive(OpenApiSchema)]` type with that identity
+/// was linked into the binary, or `None` when no such derive exists (so callers
+/// fall back to the generic placeholder). Matching by identity — not the short
+/// last-segment name — is what keeps two distinct `Args` types from shadowing
+/// each other in the back-fill.
 #[must_use]
-pub fn registered_derived_schema(name: &str) -> Option<serde_json::Value> {
+pub fn registered_derived_schema(identity: &str) -> Option<serde_json::Value> {
     inventory::iter::<DerivedSchemaDescriptor>
         .into_iter()
-        .find(|descriptor| descriptor.name == name)
+        .find(|descriptor| (descriptor.identity)() == identity)
         .map(|descriptor| (descriptor.schema)())
 }
 
@@ -605,6 +687,141 @@ pub fn write_openapi_spec_to_dist(
     Ok(())
 }
 
+/// Resolves each referenced schema *identity* (`type_name`) to a readable,
+/// collision-free OpenAPI component *display key* (issue #1972).
+///
+/// Built once at spec-finalize (and re-derivable purely from the routes so the
+/// MCP tool builder computes the identical mapping). A short last-segment key
+/// (`Args`) is used whenever it is unambiguous; only when two *distinct*
+/// identities would collide on the same last segment is each qualified with
+/// enough trailing module segments to disambiguate (`create.Args` /
+/// `update.Args`). Both the component registration and every `$ref` go through
+/// this map, so a route reference can never resolve to the wrong schema.
+#[cfg(feature = "openapi")]
+#[derive(Default, Debug, Clone)]
+pub struct SchemaComponentIndex {
+    /// identity key (`type_name` or legacy short name) → display component key.
+    by_identity: BTreeMap<String, String>,
+}
+
+#[cfg(feature = "openapi")]
+impl SchemaComponentIndex {
+    /// The component display key for a `Ref` entry — the value emitted in its
+    /// `#/components/schemas/{key}` `$ref`. Falls back to the sanitized short
+    /// name for an identity that was not part of the indexed route set (e.g. a
+    /// hand-built entry in a unit test).
+    #[must_use]
+    pub fn display_key(&self, entry: &SchemaEntry) -> String {
+        let identity = entry.identity_key();
+        self.by_identity
+            .get(identity)
+            .cloned()
+            .unwrap_or_else(|| component_key(entry.name))
+    }
+
+    /// Iterate `(identity, display_key)` pairs — used by the back-fill to
+    /// register a component under its display key keyed by identity.
+    fn iter(&self) -> impl Iterator<Item = (&String, &String)> {
+        self.by_identity.iter()
+    }
+}
+
+/// The trailing `n` `::`-segments of a `type_name`, joined with `.` and
+/// sanitized into a component key (`a::b::Args`, n=2 → `b.Args`).
+#[cfg(feature = "openapi")]
+fn qualified_suffix_key(identity: &str, depth: usize) -> String {
+    let segments: Vec<&str> = identity.split("::").collect();
+    let start = segments.len().saturating_sub(depth);
+    component_key(&segments[start..].join("::"))
+}
+
+/// Build the identity→display-key map for every schema referenced by `routes`.
+///
+/// Pure over the route set, so [`generate_spec_at`] and the MCP tool builder
+/// derive the exact same keys.
+#[cfg(feature = "openapi")]
+#[must_use]
+pub fn build_schema_component_index(routes: &[&ApiDoc]) -> SchemaComponentIndex {
+    // Collect (identity, base-display) for every referenced Ref entry.
+    let mut refs: Vec<(&'static str, String)> = Vec::new();
+    let mut collect = |entry: &SchemaEntry| {
+        for e in flatten_ref_entries(entry) {
+            refs.push((e.identity_key(), component_key(e.name)));
+        }
+    };
+    for api_doc in routes {
+        if api_doc.hidden {
+            continue;
+        }
+        if let Some(e) = &api_doc.request_body {
+            collect(e);
+        }
+        if let Some(e) = &api_doc.response {
+            collect(e);
+        }
+        if let Some(e) = &api_doc.query_schema {
+            collect(e);
+        }
+    }
+
+    // Which base display keys are shared by more than one distinct identity?
+    let mut by_base: BTreeMap<String, std::collections::BTreeSet<&'static str>> = BTreeMap::new();
+    for (identity, base) in &refs {
+        by_base.entry(base.clone()).or_default().insert(identity);
+    }
+
+    let mut by_identity: BTreeMap<String, String> = BTreeMap::new();
+    let mut used: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+
+    // First pass: assign the plain last-segment key to every identity whose base
+    // is unambiguous, and to legacy short-name identities (no `::` path — the
+    // repository macro's model refs) which cannot be qualified anyway.
+    for (identity, base) in &refs {
+        let collides = by_base[base].len() > 1 && identity.contains("::");
+        if !collides {
+            by_identity
+                .entry((*identity).to_owned())
+                .or_insert_with(|| {
+                    used.insert(base.clone());
+                    base.clone()
+                });
+        }
+    }
+
+    // Second pass: qualify each genuinely-colliding real type path with the
+    // fewest trailing module segments that make its key unique.
+    for (identity, _base) in &refs {
+        if by_identity.contains_key(*identity) {
+            continue;
+        }
+        let depth_max = identity.split("::").count();
+        let mut display = None;
+        for depth in 2..=depth_max {
+            let candidate = qualified_suffix_key(identity, depth);
+            if !used.contains(&candidate) {
+                display = Some(candidate);
+                break;
+            }
+        }
+        let display = display.unwrap_or_else(|| component_key(identity));
+        used.insert(display.clone());
+        by_identity.insert((*identity).to_owned(), display);
+    }
+
+    SchemaComponentIndex { by_identity }
+}
+
+/// Flatten an entry, yielding each leaf `Ref` entry reached through
+/// `Array` / `Nullable` wrappers (so a `Json<Vec<User>>` contributes `User`).
+#[cfg(feature = "openapi")]
+fn flatten_ref_entries(entry: &SchemaEntry) -> Vec<&SchemaEntry> {
+    match entry.kind {
+        SchemaKind::Ref => vec![entry],
+        SchemaKind::Array(inner) | SchemaKind::Nullable(inner) => flatten_ref_entries(inner),
+        SchemaKind::Primitive(_) => Vec::new(),
+    }
+}
+
 /// Build an [`OpenApiSpec`] from a collection of routes and user config.
 ///
 /// This is the core of the auto-generation: every route's [`ApiDoc`] is
@@ -630,13 +847,10 @@ pub fn generate_spec_at(
     }
     registry.insert("ProblemDetails", problem_details_schema());
 
-    // Collect every named schema reference produced by any operation so
-    // we can back-fill component entries for types the user didn't
-    // explicitly register. Without this, auto-inferred `Json<MyDto>`
-    // payloads would emit `$ref`s pointing at nonexistent component
-    // schemas — an invalid OpenAPI document.
-    let mut referenced_names: std::collections::BTreeSet<&'static str> =
-        std::collections::BTreeSet::new();
+    // Resolve every referenced schema identity to a collision-free component
+    // display key up front, so both the `$ref` sites (via `operation_for`) and
+    // the back-fill below register/reference the exact same key (issue #1972).
+    let index = build_schema_component_index(routes);
 
     let mut any_secured = false;
     let mut any_scoped = false;
@@ -655,17 +869,7 @@ pub fn generate_spec_at(
             (register)(&mut registry);
         }
 
-        if let Some(entry) = &api_doc.request_body {
-            collect_ref_names(entry, &mut referenced_names);
-        }
-        if let Some(entry) = &api_doc.response {
-            collect_ref_names(entry, &mut referenced_names);
-        }
-        if let Some(entry) = &api_doc.query_schema {
-            collect_ref_names(entry, &mut referenced_names);
-        }
-
-        let operation = operation_for(api_doc, &config.api_versions, now);
+        let operation = operation_for(api_doc, &config.api_versions, now, &index);
         let entry = paths.entry(api_doc.path.to_owned()).or_default();
         match api_doc.method {
             "GET" => entry.get = Some(operation),
@@ -679,21 +883,22 @@ pub fn generate_spec_at(
         }
     }
 
-    // Back-fill a schema for every referenced name the user didn't already
-    // register. A `#[derive(OpenApiSchema)]` type advertises a real
-    // field-accurate schema through the compile-time inventory (issue #1972),
-    // which we consult first; only a name with no derived schema (and no
+    // Back-fill a schema for every referenced identity the user didn't already
+    // register, under its resolved display key. A `#[derive(OpenApiSchema)]`
+    // type advertises a real field-accurate schema through the compile-time
+    // inventory (matched by identity, so two same-named types never shadow each
+    // other — issue #1972); only an identity with no derived schema (and no
     // explicit `OpenApiConfig::register_schema`) falls back to the minimal
     // `{"type": "object", "title": "X"}` placeholder.
-    for name in referenced_names {
-        if !registry.schemas().contains_key(name) {
-            let schema = registered_derived_schema(name).unwrap_or_else(|| {
+    for (identity, display_key) in index.iter() {
+        if !registry.schemas().contains_key(display_key) {
+            let schema = registered_derived_schema(identity).unwrap_or_else(|| {
                 serde_json::json!({
                     "type": "object",
-                    "title": name,
+                    "title": display_key,
                 })
             });
-            registry.insert(name, schema);
+            registry.insert(display_key.clone(), schema);
         }
     }
 
@@ -749,6 +954,7 @@ fn operation_for(
     api_doc: &ApiDoc,
     api_versions: &[crate::app::ApiVersion],
     now: chrono::DateTime<chrono::Utc>,
+    index: &SchemaComponentIndex,
 ) -> Operation {
     let mut tags = if api_doc.tags.is_empty() {
         default_tag(api_doc.path)
@@ -797,7 +1003,7 @@ fn operation_for(
             name: query_entry.name.to_owned(),
             location: "query".to_owned(),
             required: false,
-            schema: schema_value_for(query_entry),
+            schema: schema_value_for(query_entry, index),
             style: Some("form".to_owned()),
             explode: Some(true),
         });
@@ -808,7 +1014,7 @@ fn operation_for(
         content: std::iter::once((
             "application/json".to_owned(),
             MediaType {
-                schema: schema_value_for(entry),
+                schema: schema_value_for(entry, index),
             },
         ))
         .collect(),
@@ -828,7 +1034,7 @@ fn operation_for(
             content.insert(
                 "application/json".to_owned(),
                 MediaType {
-                    schema: schema_value_for(entry),
+                    schema: schema_value_for(entry, index),
                 },
             );
             content
@@ -912,22 +1118,29 @@ fn operation_for(
 /// Produces the same shape the OpenAPI generator emits. Exposed so the MCP
 /// projection can derive a tool's `inputSchema` from the exact same typed
 /// contract — guaranteeing the tool schema cannot drift from the handler.
+///
+/// `index` resolves each `Ref` to its collision-free component display key
+/// (issue #1972); build it once with [`build_schema_component_index`] over the
+/// same route set so tool `$ref`s match the served OpenAPI components exactly.
 #[cfg(feature = "openapi")]
 #[must_use]
-pub fn schema_entry_to_value(entry: &SchemaEntry) -> serde_json::Value {
-    schema_value_for(entry)
+pub fn schema_entry_to_value(
+    entry: &SchemaEntry,
+    index: &SchemaComponentIndex,
+) -> serde_json::Value {
+    schema_value_for(entry, index)
 }
 
 #[cfg(feature = "openapi")]
-fn schema_value_for(entry: &SchemaEntry) -> serde_json::Value {
+fn schema_value_for(entry: &SchemaEntry, index: &SchemaComponentIndex) -> serde_json::Value {
     match entry.kind {
         SchemaKind::Primitive(json_type) => serde_json::json!({ "type": json_type }),
         SchemaKind::Ref => {
-            serde_json::json!({ "$ref": format!("#/components/schemas/{}", entry.name) })
+            serde_json::json!({ "$ref": format!("#/components/schemas/{}", index.display_key(entry)) })
         }
         SchemaKind::Array(items) => serde_json::json!({
             "type": "array",
-            "items": schema_value_for(items),
+            "items": schema_value_for(items, index),
         }),
         SchemaKind::Nullable(inner) => {
             // OpenAPI 3.1 aligns with JSON Schema 2020-12, which supports
@@ -941,7 +1154,7 @@ fn schema_value_for(entry: &SchemaEntry) -> serde_json::Value {
                 SchemaKind::Ref | SchemaKind::Array(_) | SchemaKind::Nullable(_) => {
                     serde_json::json!({
                         "oneOf": [
-                            schema_value_for(inner),
+                            schema_value_for(inner, index),
                             { "type": "null" },
                         ],
                     })
@@ -951,20 +1164,6 @@ fn schema_value_for(entry: &SchemaEntry) -> serde_json::Value {
                 }
             }
         }
-    }
-}
-
-/// Walk into a `SchemaEntry` and yield every named ref reached through
-/// `Array` / `Nullable` wrappers. Back-fill logic uses this so a
-/// `Json<Vec<User>>` response registers a `User` component schema.
-#[cfg(feature = "openapi")]
-fn collect_ref_names(entry: &SchemaEntry, out: &mut std::collections::BTreeSet<&'static str>) {
-    match entry.kind {
-        SchemaKind::Ref => {
-            out.insert(entry.name);
-        }
-        SchemaKind::Array(inner) | SchemaKind::Nullable(inner) => collect_ref_names(inner, out),
-        SchemaKind::Primitive(_) => {}
     }
 }
 
@@ -1293,6 +1492,7 @@ mod tests {
         doc.request_body = Some(SchemaEntry {
             name: "CreateUser",
             kind: SchemaKind::Ref,
+            identity: None,
         });
         doc.success_status = 201;
 
@@ -1315,6 +1515,7 @@ mod tests {
         doc.response = Some(SchemaEntry {
             name: "string",
             kind: SchemaKind::Primitive("string"),
+            identity: None,
         });
         let config = OpenApiConfig::new("Demo", "1.0.0");
         let spec = generate_spec(&config, &[&doc]);
@@ -1367,10 +1568,12 @@ mod tests {
         doc.request_body = Some(SchemaEntry {
             name: "CreateUser",
             kind: SchemaKind::Ref,
+            identity: None,
         });
         doc.response = Some(SchemaEntry {
             name: "User",
             kind: SchemaKind::Ref,
+            identity: None,
         });
 
         let config = OpenApiConfig::new("Demo", "1.0.0");
@@ -1396,6 +1599,7 @@ mod tests {
         doc.response = Some(SchemaEntry {
             name: "User",
             kind: SchemaKind::Ref,
+            identity: None,
         });
 
         let user_schema = serde_json::json!({
@@ -1460,12 +1664,14 @@ mod tests {
         static INNER: SchemaEntry = SchemaEntry {
             name: "User",
             kind: SchemaKind::Ref,
+            identity: None,
         };
         let entry = SchemaEntry {
             name: "nullable",
             kind: SchemaKind::Nullable(&INNER),
+            identity: None,
         };
-        let value = schema_value_for(&entry);
+        let value = schema_value_for(&entry, &SchemaComponentIndex::default());
         assert!(
             value.get("nullable").is_none(),
             "3.1 must not emit `nullable: true` (that is 3.0 only)"
@@ -1495,12 +1701,14 @@ mod tests {
         static INNER: SchemaEntry = SchemaEntry {
             name: "integer",
             kind: SchemaKind::Primitive("integer"),
+            identity: None,
         };
         let entry = SchemaEntry {
             name: "nullable",
             kind: SchemaKind::Nullable(&INNER),
+            identity: None,
         };
-        let value = schema_value_for(&entry);
+        let value = schema_value_for(&entry, &SchemaComponentIndex::default());
         assert!(
             value.get("nullable").is_none(),
             "3.1 must not emit `nullable: true`"

--- a/autumn/src/openapi.rs
+++ b/autumn/src/openapi.rs
@@ -798,9 +798,32 @@ pub fn build_schema_component_index(routes: &[&ApiDoc]) -> SchemaComponentIndex 
         }
     }
 
+    SchemaComponentIndex {
+        by_identity: assign_display_keys(&refs),
+    }
+}
+
+/// Assign a **unique, deterministic** display component key to every referenced
+/// schema identity. `refs` is `(identity, base_display)` pairs; identities are
+/// assumed already deduped. Pure over its input and independent of the order the
+/// pairs are supplied (identities are qualified in a stable sorted order), so the
+/// same route set always yields the same keys across runs and link orders.
+///
+/// Every distinct identity is guaranteed a distinct display key: the collision
+/// ladder (fewest trailing `::`-segments that make the key unique → full
+/// sanitized fallback) can be exhausted, and a colliding identity's fallback key
+/// can equal a key another colliding identity already claimed (e.g. crate `app`
+/// with `app::app::Args` claiming `app.Args` at depth 2 while `app::Args`
+/// exhausts its ladder and falls back to the same `app.Args`). When the best
+/// candidate is still taken, a deterministic `-N` disambiguator is appended until
+/// the key is free. `-` never appears in a `component_key` output derived from a
+/// real Rust `type_name` (Rust paths contain no `-`), so the disambiguator can
+/// never collide with a naturally-produced key (issue #1972).
+#[cfg(feature = "openapi")]
+fn assign_display_keys(refs: &[(String, String)]) -> BTreeMap<String, String> {
     // Which base display keys are shared by more than one distinct identity?
     let mut by_base: BTreeMap<String, std::collections::BTreeSet<&str>> = BTreeMap::new();
-    for (identity, base) in &refs {
+    for (identity, base) in refs {
         by_base
             .entry(base.clone())
             .or_default()
@@ -813,7 +836,7 @@ pub fn build_schema_component_index(routes: &[&ApiDoc]) -> SchemaComponentIndex 
     // First pass: assign the plain last-segment key to every identity whose base
     // is unambiguous, and to legacy short-name identities (no `::` path — the
     // repository macro's model refs) which cannot be qualified anyway.
-    for (identity, base) in &refs {
+    for (identity, base) in refs {
         let collides = by_base[base].len() > 1 && identity.contains("::");
         if !collides {
             by_identity.entry(identity.clone()).or_insert_with(|| {
@@ -824,26 +847,39 @@ pub fn build_schema_component_index(routes: &[&ApiDoc]) -> SchemaComponentIndex 
     }
 
     // Second pass: qualify each genuinely-colliding real type path with the
-    // fewest trailing module segments that make its key unique.
-    for (identity, _base) in &refs {
-        if by_identity.contains_key(identity) {
-            continue;
-        }
+    // fewest trailing module segments that make its key unique. Iterate in a
+    // stable sorted order so the assignment is deterministic regardless of the
+    // order pairs were collected, and guarantee the final key is free even when
+    // the suffix ladder and the full-sanitized fallback are both exhausted.
+    let mut pending: Vec<&String> = refs
+        .iter()
+        .map(|(identity, _)| identity)
+        .filter(|identity| !by_identity.contains_key(*identity))
+        .collect();
+    pending.sort_unstable();
+    for identity in pending {
         let depth_max = identity.split("::").count();
-        let mut display = None;
-        for depth in 2..=depth_max {
-            let candidate = qualified_suffix_key(identity, depth);
-            if !used.contains(&candidate) {
-                display = Some(candidate);
-                break;
+        let mut display = (2..=depth_max)
+            .map(|depth| qualified_suffix_key(identity, depth))
+            .find(|candidate| !used.contains(candidate))
+            .unwrap_or_else(|| component_key(identity));
+        if used.contains(&display) {
+            let base = display.clone();
+            let mut n = 2u32;
+            loop {
+                let candidate = format!("{base}-{n}");
+                if !used.contains(&candidate) {
+                    display = candidate;
+                    break;
+                }
+                n += 1;
             }
         }
-        let display = display.unwrap_or_else(|| component_key(identity));
         used.insert(display.clone());
         by_identity.insert(identity.clone(), display);
     }
 
-    SchemaComponentIndex { by_identity }
+    by_identity
 }
 
 /// The base (short) display key for a raw schema *identity* string: its last
@@ -2049,5 +2085,61 @@ mod tests {
         let spec = generate_spec(&config, &[&unscoped]);
         let schemes = &spec.components.as_ref().unwrap().security_schemes;
         assert!(!schemes.contains_key("BearerAuth"));
+    }
+
+    // Regression (issue #1972): the fallback display-key assignment must be
+    // collision-proof. This generalizes the reviewer's `app::app::Args` /
+    // `app::Args` example to a pair that still clashes under the deterministic
+    // sorted assignment order: `a::x::Args` sorts first and claims the 2-segment
+    // suffix `x.Args`, then `x::Args` exhausts its suffix ladder (its only
+    // qualified candidate IS `x.Args`) and falls back to
+    // `component_key("x::Args")` == `x.Args` — the exact key `a::x::Args` already
+    // took. Without the disambiguator both identities would map to `x.Args`, so
+    // the second schema would silently overwrite the first.
+    #[test]
+    fn colliding_fallback_keys_are_disambiguated() {
+        let refs = vec![
+            ("a::x::Args".to_owned(), "Args".to_owned()),
+            ("x::Args".to_owned(), "Args".to_owned()),
+        ];
+        let by_identity = assign_display_keys(&refs);
+
+        let a = by_identity.get("a::x::Args").expect("a::x::Args assigned");
+        let b = by_identity.get("x::Args").expect("x::Args assigned");
+        assert_ne!(
+            a, b,
+            "distinct identities must map to distinct display keys, got {a} == {b}"
+        );
+        // `a::x::Args` claims the suffix key; `x::Args` must be pushed onto the
+        // deterministic `-N` disambiguator rather than overwriting it — pinning
+        // this proves the disambiguator branch actually ran.
+        assert_eq!(a, "x.Args");
+        assert_eq!(b, "x.Args-2");
+        // Both keys are valid OpenAPI component keys.
+        for key in [a, b] {
+            assert!(
+                key.chars()
+                    .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_')),
+                "display key {key} is not a valid component key"
+            );
+        }
+    }
+
+    // Determinism: the same identity set must yield the same keys regardless of
+    // the order the `(identity, base)` pairs are supplied.
+    #[test]
+    fn assign_display_keys_is_order_independent() {
+        let forward = vec![
+            ("app::app::Args".to_owned(), "Args".to_owned()),
+            ("app::Args".to_owned(), "Args".to_owned()),
+            ("other::mod::Args".to_owned(), "Args".to_owned()),
+        ];
+        let mut reversed = forward.clone();
+        reversed.reverse();
+        assert_eq!(
+            assign_display_keys(&forward),
+            assign_display_keys(&reversed),
+            "display-key assignment must not depend on input order"
+        );
     }
 }

--- a/autumn/tests/integration/mcp_schema_derive.rs
+++ b/autumn/tests/integration/mcp_schema_derive.rs
@@ -34,6 +34,71 @@ struct PlainArgs {
     a: String,
 }
 
+// Serde-rename fidelity (issue #1972, Part 2 / Item 1): a container
+// `rename_all`, a field-level `rename`, and a raw-ident field must all be
+// reflected in the advertised property names + `required` entries.
+#[derive(Serialize, Deserialize, OpenApiSchema)]
+#[serde(rename_all = "camelCase")]
+struct RenamedArgs {
+    word_count: i64,
+    #[serde(rename = "kind")]
+    category: String,
+    r#type: String,
+    maybe_flag: Option<bool>,
+}
+
+#[test]
+fn derived_schema_honors_serde_renames_and_raw_idents() {
+    let schema = <RenamedArgs as OpenApiSchema>::schema();
+    let props = schema["properties"].as_object().expect("properties object");
+
+    // container rename_all = camelCase → snake_case field advertised camelCased.
+    assert!(props.contains_key("wordCount"), "camelCased key: {schema}");
+    assert!(!props.contains_key("word_count"), "raw key gone: {schema}");
+    // field-level rename wins over rename_all.
+    assert!(props.contains_key("kind"), "field rename wins: {schema}");
+    assert!(!props.contains_key("category"), "raw field gone: {schema}");
+    // raw ident `r#type` advertises the bare `type`, never `r#type`.
+    assert!(props.contains_key("type"), "raw-ident stripped: {schema}");
+    assert!(
+        !props.contains_key("r#type"),
+        "no r# prefix leaks: {schema}"
+    );
+    // optional field is still camelCased.
+    assert!(
+        props.contains_key("maybeFlag"),
+        "optional camelCased: {schema}"
+    );
+
+    // `required` uses the same resolved names (and excludes the Option).
+    let required: Vec<&str> = schema["required"]
+        .as_array()
+        .expect("required list")
+        .iter()
+        .filter_map(serde_json::Value::as_str)
+        .collect();
+    assert!(
+        required.contains(&"wordCount"),
+        "required camelCased: {required:?}"
+    );
+    assert!(
+        required.contains(&"kind"),
+        "required field-rename: {required:?}"
+    );
+    assert!(
+        required.contains(&"type"),
+        "required raw-ident: {required:?}"
+    );
+    assert!(
+        !required.contains(&"maybeFlag"),
+        "optional not required: {required:?}"
+    );
+    // no stale raw names leak into required.
+    assert!(!required.contains(&"word_count"));
+    assert!(!required.contains(&"category"));
+    assert!(!required.contains(&"r#type"));
+}
+
 #[post("/api/derived-body")]
 #[api_doc(mcp, summary = "Body arg with a derived schema")]
 async fn derived_body(Json(_body): Json<DerivedArgs>) -> AutumnResult<Json<DerivedArgs>> {
@@ -139,6 +204,92 @@ fn mcp_body_without_derive_stays_placeholder() {
                 .as_object()
                 .is_none_or(serde_json::Map::is_empty),
         "a struct without the derive must stay a bare placeholder: {resolved}"
+    );
+}
+
+// Collision-proof schema identity (issue #1972, Part 2 / Item 2): two derived
+// structs sharing a final identifier (`create::Args` / `update::Args`) used as
+// route args must resolve to DISTINCT, correctly-referenced component schemas —
+// neither may shadow the other in the back-fill.
+mod create {
+    use super::{Deserialize, OpenApiSchema, Serialize};
+    #[derive(Serialize, Deserialize, OpenApiSchema)]
+    pub struct Args {
+        pub create_only_field: String,
+    }
+}
+
+mod update {
+    use super::{Deserialize, OpenApiSchema, Serialize};
+    #[derive(Serialize, Deserialize, OpenApiSchema)]
+    pub struct Args {
+        pub update_only_field: i64,
+    }
+}
+
+#[get("/api/collide-create")]
+#[api_doc(mcp, summary = "Query arg named Args (create module)")]
+async fn collide_create(Query(_q): Query<create::Args>) -> AutumnResult<Json<serde_json::Value>> {
+    Ok(Json(serde_json::json!({})))
+}
+
+#[post("/api/collide-update")]
+#[api_doc(mcp, summary = "Body arg named Args (update module)")]
+async fn collide_update(Json(_b): Json<update::Args>) -> AutumnResult<Json<serde_json::Value>> {
+    Ok(Json(serde_json::json!({})))
+}
+
+#[test]
+fn colliding_derive_names_resolve_to_distinct_schemas() {
+    let docs = vec![
+        __autumn_route_info_collide_create().api_doc,
+        __autumn_route_info_collide_update().api_doc,
+    ];
+    let tools = derive_tools(&docs, false, None);
+
+    let create_tool = tools.iter().find(|t| t.name() == "collide_create").unwrap();
+    let update_tool = tools.iter().find(|t| t.name() == "collide_update").unwrap();
+
+    let create_query = &create_tool.input_schema()["properties"]["query"];
+    let update_body = &update_tool.input_schema()["properties"]["body"];
+
+    // The two refs must be DISTINCT component keys — otherwise one shadows the
+    // other and both would resolve to the same schema.
+    let create_ref = create_query["$ref"]
+        .as_str()
+        .expect("create query is a $ref");
+    let update_ref = update_body["$ref"].as_str().expect("update body is a $ref");
+    assert_ne!(
+        create_ref, update_ref,
+        "distinct types must not share a component key: {create_ref} == {update_ref}"
+    );
+
+    // Each ref must resolve to its OWN field, never the other's.
+    let create_schema = resolve_ref(create_tool.input_schema(), create_query);
+    let update_schema = resolve_ref(update_tool.input_schema(), update_body);
+    assert!(
+        create_schema["properties"]
+            .get("create_only_field")
+            .is_some(),
+        "create Args must expose its own field: {create_schema}"
+    );
+    assert!(
+        create_schema["properties"]
+            .get("update_only_field")
+            .is_none(),
+        "create Args must NOT be shadowed by update Args: {create_schema}"
+    );
+    assert!(
+        update_schema["properties"]
+            .get("update_only_field")
+            .is_some(),
+        "update Args must expose its own field: {update_schema}"
+    );
+    assert!(
+        update_schema["properties"]
+            .get("create_only_field")
+            .is_none(),
+        "update Args must NOT be shadowed by create Args: {update_schema}"
     );
 }
 

--- a/autumn/tests/integration/mcp_schema_derive.rs
+++ b/autumn/tests/integration/mcp_schema_derive.rs
@@ -293,6 +293,105 @@ fn colliding_derive_names_resolve_to_distinct_schemas() {
     );
 }
 
+// A `$ref` emitted *inside* a derived schema body must resolve through the same
+// collision index in the MCP `$defs` projection (issue #1972 P1 follow-up): a
+// wrapper tool whose field is a `create::Args` must inline the CREATE Args under
+// its own `$defs` key, distinct from a sibling tool's `update::Args`.
+mod wrap_create_mcp {
+    use super::{Deserialize, OpenApiSchema, Serialize};
+    #[derive(Serialize, Deserialize, OpenApiSchema)]
+    pub struct Args {
+        pub create_only_field: String,
+    }
+}
+
+mod wrap_update_mcp {
+    use super::{Deserialize, OpenApiSchema, Serialize};
+    #[derive(Serialize, Deserialize, OpenApiSchema)]
+    pub struct Args {
+        pub update_only_field: i64,
+    }
+}
+
+#[derive(Serialize, Deserialize, OpenApiSchema)]
+struct WrapEnvelope {
+    payload: wrap_create_mcp::Args,
+    note: String,
+}
+
+#[post("/api/mcp-wrap-envelope")]
+#[api_doc(mcp, summary = "Envelope whose field is a nested create Args")]
+async fn wrap_envelope_tool(Json(_e): Json<WrapEnvelope>) -> AutumnResult<Json<serde_json::Value>> {
+    Ok(Json(serde_json::json!({})))
+}
+
+#[post("/api/mcp-wrap-update")]
+#[api_doc(mcp, summary = "Body arg named Args (update module)")]
+async fn wrap_update_tool(
+    Json(_b): Json<wrap_update_mcp::Args>,
+) -> AutumnResult<Json<serde_json::Value>> {
+    Ok(Json(serde_json::json!({})))
+}
+
+#[test]
+fn nested_derived_ref_resolves_in_mcp_defs() {
+    let docs = vec![
+        __autumn_route_info_wrap_envelope_tool().api_doc,
+        __autumn_route_info_wrap_update_tool().api_doc,
+    ];
+    let tools = derive_tools(&docs, false, None);
+    let envelope_tool = tools
+        .iter()
+        .find(|t| t.name() == "wrap_envelope_tool")
+        .unwrap();
+    let update_tool = tools
+        .iter()
+        .find(|t| t.name() == "wrap_update_tool")
+        .unwrap();
+
+    // Resolve the envelope body → its nested `payload` ref, both through `$defs`.
+    let schema = envelope_tool.input_schema();
+    let envelope_schema = resolve_ref(schema, &schema["properties"]["body"]);
+    let payload_ref = &envelope_schema["properties"]["payload"];
+    let payload_schema = resolve_ref(schema, payload_ref);
+    assert!(
+        payload_schema["properties"]
+            .get("create_only_field")
+            .is_some(),
+        "nested MCP ref must resolve to CREATE Args (not a placeholder, not update): {payload_schema}"
+    );
+    assert!(
+        payload_schema["properties"]
+            .get("update_only_field")
+            .is_none(),
+        "nested MCP ref must NOT resolve to UPDATE Args: {payload_schema}"
+    );
+
+    // The nested payload inlines under a DISTINCT `$defs` key from the sibling
+    // update tool's body — neither shadows the other.
+    let payload_key = payload_ref["$ref"]
+        .as_str()
+        .expect("payload is a $ref")
+        .trim_start_matches("#/$defs/");
+    let update_body = &update_tool.input_schema()["properties"]["body"];
+    let update_key = update_body["$ref"]
+        .as_str()
+        .expect("update body is a $ref")
+        .trim_start_matches("#/$defs/");
+    assert_ne!(
+        payload_key, update_key,
+        "create and update Args must inline under distinct $defs keys: {payload_key} == {update_key}"
+    );
+    // And the update tool's body resolves to its OWN field.
+    let update_schema = resolve_ref(update_tool.input_schema(), update_body);
+    assert!(
+        update_schema["properties"]
+            .get("update_only_field")
+            .is_some(),
+        "update tool body must expose its own field: {update_schema}"
+    );
+}
+
 /// If `value` is a `{ "$ref": "#/$defs/X" }` pointer, resolve it against the
 /// schema's `$defs`; otherwise return the value unchanged.
 fn resolve_ref(root: &serde_json::Value, value: &serde_json::Value) -> serde_json::Value {

--- a/autumn/tests/integration/openapi.rs
+++ b/autumn/tests/integration/openapi.rs
@@ -705,3 +705,98 @@ fn generated_spec_reuses_problem_details_schema_for_errors() {
         );
     }
 }
+
+// ── Collision-proof schema component identity (issue #1972, Part 2 / Item 2) ──
+
+mod spec_create {
+    use autumn_web::openapi::OpenApiSchema;
+    #[derive(serde::Serialize, serde::Deserialize, OpenApiSchema)]
+    pub struct Payload {
+        pub create_only: String,
+    }
+}
+
+mod spec_update {
+    use autumn_web::openapi::OpenApiSchema;
+    #[derive(serde::Serialize, serde::Deserialize, OpenApiSchema)]
+    pub struct Payload {
+        pub update_only: i64,
+    }
+}
+
+#[post("/api/spec-create")]
+async fn spec_create_route(Json(_p): Json<spec_create::Payload>) -> axum::Json<serde_json::Value> {
+    axum::Json(serde_json::json!({}))
+}
+
+#[post("/api/spec-update")]
+async fn spec_update_route(Json(_p): Json<spec_update::Payload>) -> axum::Json<serde_json::Value> {
+    axum::Json(serde_json::json!({}))
+}
+
+#[test]
+fn openapi_spec_disambiguates_same_named_component_schemas() {
+    let create = __autumn_route_info_spec_create_route().api_doc;
+    let update = __autumn_route_info_spec_update_route().api_doc;
+    let config = OpenApiConfig::new("Demo", "1.0.0");
+    let spec = autumn_web::openapi::generate_spec(&config, &[&create, &update]);
+
+    // The two request-body `$ref`s must be distinct component keys.
+    let create_ref = spec.paths["/api/spec-create"]
+        .post
+        .as_ref()
+        .unwrap()
+        .request_body
+        .as_ref()
+        .unwrap()
+        .content["application/json"]
+        .schema["$ref"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    let update_ref = spec.paths["/api/spec-update"]
+        .post
+        .as_ref()
+        .unwrap()
+        .request_body
+        .as_ref()
+        .unwrap()
+        .content["application/json"]
+        .schema["$ref"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    assert_ne!(
+        create_ref, update_ref,
+        "distinct types must not share a $ref"
+    );
+
+    // Both refs must resolve to their own field-accurate component schema.
+    let components = spec.components.expect("components");
+    let create_key = create_ref.trim_start_matches("#/components/schemas/");
+    let update_key = update_ref.trim_start_matches("#/components/schemas/");
+    let create_schema = components
+        .schemas
+        .get(create_key)
+        .expect("create component present");
+    let update_schema = components
+        .schemas
+        .get(update_key)
+        .expect("update component present");
+    assert!(
+        create_schema["properties"].get("create_only").is_some(),
+        "{create_schema}"
+    );
+    assert!(
+        create_schema["properties"].get("update_only").is_none(),
+        "no shadow: {create_schema}"
+    );
+    assert!(
+        update_schema["properties"].get("update_only").is_some(),
+        "{update_schema}"
+    );
+    assert!(
+        update_schema["properties"].get("create_only").is_none(),
+        "no shadow: {update_schema}"
+    );
+}

--- a/autumn/tests/integration/openapi.rs
+++ b/autumn/tests/integration/openapi.rs
@@ -800,3 +800,179 @@ fn openapi_spec_disambiguates_same_named_component_schemas() {
         "no shadow: {update_schema}"
     );
 }
+
+// ── Nested derived-schema refs resolve through the collision index (issue #1972,
+//    Part 2 / P1 follow-up) ──
+//
+// A `$ref` emitted *inside* a derived schema body (a nested named-struct field)
+// must carry the field type's `type_name` identity and be rewritten to the same
+// collision-resolved display key the top-level route refs use — so a wrapper
+// whose field is a `create::Args` resolves correctly even when a sibling route
+// references a same-last-segment `update::Args`.
+
+mod wrap_create {
+    use autumn_web::openapi::OpenApiSchema;
+    #[derive(serde::Serialize, serde::Deserialize, OpenApiSchema)]
+    pub struct Args {
+        pub create_only: String,
+    }
+}
+
+mod wrap_update {
+    use autumn_web::openapi::OpenApiSchema;
+    #[derive(serde::Serialize, serde::Deserialize, OpenApiSchema)]
+    pub struct Args {
+        pub update_only: i64,
+    }
+}
+
+// A wrapper whose `payload` field is the CREATE Args — the nested-only type that
+// no route references directly (Mode 1 back-fill + collision closure).
+#[derive(serde::Serialize, serde::Deserialize, autumn_web::openapi::OpenApiSchema)]
+struct WrapEnvelope {
+    pub payload: wrap_create::Args,
+    pub note: String,
+}
+
+#[post("/api/wrap-envelope")]
+async fn wrap_envelope_route(Json(_e): Json<WrapEnvelope>) -> axum::Json<serde_json::Value> {
+    axum::Json(serde_json::json!({}))
+}
+
+#[post("/api/wrap-update")]
+async fn wrap_update_route(Json(_u): Json<wrap_update::Args>) -> axum::Json<serde_json::Value> {
+    axum::Json(serde_json::json!({}))
+}
+
+fn request_body_ref(spec: &autumn_web::openapi::OpenApiSpec, path: &str) -> String {
+    spec.paths[path]
+        .post
+        .as_ref()
+        .unwrap()
+        .request_body
+        .as_ref()
+        .unwrap()
+        .content["application/json"]
+        .schema["$ref"]
+        .as_str()
+        .unwrap()
+        .to_owned()
+}
+
+#[test]
+fn nested_derived_ref_resolves_through_collision_index() {
+    let envelope = __autumn_route_info_wrap_envelope_route().api_doc;
+    let update = __autumn_route_info_wrap_update_route().api_doc;
+    let config = OpenApiConfig::new("Demo", "1.0.0");
+    let spec = autumn_web::openapi::generate_spec(&config, &[&envelope, &update]);
+
+    let envelope_ref = request_body_ref(&spec, "/api/wrap-envelope");
+    let update_ref = request_body_ref(&spec, "/api/wrap-update");
+    let components = spec.components.expect("components");
+
+    // The two `Args` collide (create is nested in the envelope, update is a route
+    // ref), so both must qualify away from the bare `Args` key.
+    assert_ne!(
+        update_ref, "#/components/schemas/Args",
+        "colliding update Args must qualify: {update_ref}"
+    );
+
+    // The envelope's nested `payload` ref must resolve to the CREATE Args — not
+    // dangle, not carry a raw `type_name` identity, and not point at update.
+    let envelope_key = envelope_ref.trim_start_matches("#/components/schemas/");
+    let envelope_schema = components
+        .schemas
+        .get(envelope_key)
+        .expect("envelope component present");
+    let payload_ref = envelope_schema["properties"]["payload"]["$ref"]
+        .as_str()
+        .expect("envelope payload is a $ref");
+    let payload_key = payload_ref.trim_start_matches("#/components/schemas/");
+    assert!(
+        !payload_key.contains("::"),
+        "nested ref must be a display key, not a raw identity: {payload_ref}"
+    );
+    let payload_schema = components
+        .schemas
+        .get(payload_key)
+        .expect("nested CREATE Args component present (not dangling)");
+    assert!(
+        payload_schema["properties"].get("create_only").is_some(),
+        "nested ref must resolve to CREATE Args: {payload_schema}"
+    );
+    assert!(
+        payload_schema["properties"].get("update_only").is_none(),
+        "nested ref must NOT resolve to UPDATE Args: {payload_schema}"
+    );
+
+    // The update route's own component is the OTHER, distinct Args.
+    let update_key = update_ref.trim_start_matches("#/components/schemas/");
+    assert_ne!(
+        update_key, payload_key,
+        "create and update Args must be distinct components: {update_key} == {payload_key}"
+    );
+    let update_schema = components
+        .schemas
+        .get(update_key)
+        .expect("update Args component present");
+    assert!(
+        update_schema["properties"].get("update_only").is_some(),
+        "update component must expose its own field: {update_schema}"
+    );
+}
+
+// ── No-collision nested ref: no churn + nested-only back-fill (Mode 1) ──
+
+mod ncnest {
+    use autumn_web::openapi::OpenApiSchema;
+    #[derive(serde::Serialize, serde::Deserialize, OpenApiSchema)]
+    pub struct NestedFoo {
+        pub value: String,
+    }
+    #[derive(serde::Serialize, serde::Deserialize, OpenApiSchema)]
+    pub struct OuterBar {
+        pub foo: NestedFoo,
+        pub label: String,
+    }
+}
+
+#[post("/api/nc-outer")]
+async fn nc_outer_route(Json(_o): Json<ncnest::OuterBar>) -> axum::Json<serde_json::Value> {
+    axum::Json(serde_json::json!({}))
+}
+
+#[test]
+fn non_colliding_nested_ref_stays_short_with_no_churn() {
+    let outer = __autumn_route_info_nc_outer_route().api_doc;
+    let config = OpenApiConfig::new("Demo", "1.0.0");
+    let spec = autumn_web::openapi::generate_spec(&config, &[&outer]);
+
+    let outer_ref = request_body_ref(&spec, "/api/nc-outer");
+    assert_eq!(
+        outer_ref, "#/components/schemas/OuterBar",
+        "top-level ref stays short"
+    );
+    let components = spec.components.expect("components");
+    let outer_schema = components
+        .schemas
+        .get("OuterBar")
+        .expect("outer component present");
+    let nested_ref = outer_schema["properties"]["foo"]["$ref"]
+        .as_str()
+        .expect("nested foo is a $ref");
+    // No churn: a non-colliding nested ref stays the short last-segment key.
+    assert_eq!(
+        nested_ref, "#/components/schemas/NestedFoo",
+        "non-colliding nested ref must stay the short key (no churn): {nested_ref}"
+    );
+    // Mode 1: the nested-only type (no direct route ref) is back-filled with its
+    // real field-accurate schema.
+    let nested_schema = components
+        .schemas
+        .get("NestedFoo")
+        .expect("nested-only component back-filled");
+    assert!(
+        nested_schema["properties"].get("value").is_some(),
+        "nested-only component carries its real fields: {nested_schema}"
+    );
+}

--- a/autumn/tests/integration/repository_openapi.rs
+++ b/autumn/tests/integration/repository_openapi.rs
@@ -409,3 +409,84 @@ fn new_model_schema_honors_serde_renames() {
     assert!(props.contains_key("kind"), "field rename on New: {schema}");
     assert!(!props.contains_key("id"), "New excludes id: {schema}");
 }
+
+// ── Model referenced by BOTH a `#[repository]` and a hand-written
+//    `#[api_doc]` handler stays ONE short component (issue #1972, Part 2 / Item 2)
+//
+// The repository's model-typed refs (get/create/update responses, new/update
+// bodies) now carry the same `type_name` identity as a hand-written handler's
+// `Json<T>` ref, so `build_schema_component_index` sees a single identity under
+// base `Gadget` — no false collision, no module-path-qualified duplicate. Before
+// the fix the repository refs keyed on the short name while the handler ref keyed
+// on `type_name`, splitting `Gadget` into `Gadget` + `<module>.Gadget`.
+
+#[autumn_web::post("/api/gadgets/echo")]
+async fn echo_gadget(
+    autumn_web::prelude::Json(g): autumn_web::prelude::Json<Gadget>,
+) -> autumn_web::prelude::Json<Gadget> {
+    autumn_web::prelude::Json(g)
+}
+
+#[test]
+fn model_shared_by_repository_and_handwritten_route_is_one_short_component() {
+    use autumn_web::openapi::{OpenApiConfig, generate_spec};
+
+    // `Gadget` is referenced by its repository (create response, `/api/gadgets`)
+    // and by the hand-written `echo_gadget` handler (`Json<Gadget>` body, at
+    // `/api/gadgets/echo`).
+    let create = __autumn_route_info_gadget_api_create().api_doc;
+    let echo = __autumn_route_info_echo_gadget().api_doc;
+    let config = OpenApiConfig::new("Demo", "1.0.0");
+    let spec = generate_spec(&config, &[&create, &echo]);
+
+    // Repository create route's 201 response references the model.
+    let repo_ref = spec.paths["/api/gadgets"].post.as_ref().unwrap().responses["201"]
+        .content["application/json"]
+        .schema["$ref"]
+        .as_str()
+        .expect("repository create response $ref")
+        .to_owned();
+    // Hand-written route's request body references the same model.
+    let handwritten_ref = spec.paths["/api/gadgets/echo"]
+        .post
+        .as_ref()
+        .unwrap()
+        .request_body
+        .as_ref()
+        .unwrap()
+        .content["application/json"]
+        .schema["$ref"]
+        .as_str()
+        .expect("hand-written request-body $ref")
+        .to_owned();
+
+    // Both resolve to the SAME single short component key — no module-path leak,
+    // no duplicate opaque component.
+    assert_eq!(
+        repo_ref, "#/components/schemas/Gadget",
+        "repository ref must stay the short `Gadget` key"
+    );
+    assert_eq!(
+        handwritten_ref, "#/components/schemas/Gadget",
+        "hand-written ref must share the short `Gadget` key, not `<module>.Gadget`"
+    );
+
+    // Exactly one component key for `Gadget` — nothing module-qualified alongside it.
+    let components = spec.components.expect("components");
+    assert!(
+        components.schemas.contains_key("Gadget"),
+        "single `Gadget` component present"
+    );
+    let gadget_like: Vec<&String> = components
+        .schemas
+        .keys()
+        .filter(|k| {
+            k.ends_with("Gadget") && k.as_str() != "NewGadget" && k.as_str() != "UpdateGadget"
+        })
+        .collect();
+    assert_eq!(
+        gadget_like,
+        vec![&"Gadget".to_owned()],
+        "the model must not split into a second module-qualified component: {gadget_like:?}"
+    );
+}

--- a/autumn/tests/integration/repository_openapi.rs
+++ b/autumn/tests/integration/repository_openapi.rs
@@ -332,3 +332,80 @@ fn option_field_emits_nullable_schema() {
         "oneOf should include string type"
     );
 }
+
+// ── Serde-rename fidelity on `#[model]` (issue #1972, Part 2 / Item 1) ──
+
+mod schema_rename {
+    autumn_web::reexports::diesel::table! {
+        renamed_rows (id) {
+            id -> Int8,
+            word_count -> Int8,
+            category -> Text,
+            active -> Nullable<Bool>,
+        }
+    }
+}
+
+use schema_rename::renamed_rows;
+
+#[autumn_web::model(table = "renamed_rows")]
+#[serde(rename_all = "camelCase")]
+pub struct RenamedRow {
+    #[id]
+    pub id: i64,
+    pub word_count: i64,
+    #[serde(rename = "kind")]
+    pub category: String,
+    pub active: Option<bool>,
+}
+
+#[test]
+fn model_schema_honors_serde_rename_all_and_field_rename() {
+    use autumn_web::openapi::OpenApiSchema;
+    let schema = RenamedRow::schema();
+    let props = schema["properties"].as_object().expect("properties");
+
+    // container rename_all = camelCase.
+    assert!(props.contains_key("wordCount"), "camelCased: {schema}");
+    assert!(!props.contains_key("word_count"), "no raw key: {schema}");
+    // field-level rename wins over rename_all.
+    assert!(props.contains_key("kind"), "field rename wins: {schema}");
+    assert!(!props.contains_key("category"), "raw field gone: {schema}");
+    // optional field still camelCased (id is not renamed — already flat).
+    assert!(props.contains_key("active"), "optional present: {schema}");
+
+    let required: Vec<&str> = schema["required"]
+        .as_array()
+        .expect("required")
+        .iter()
+        .filter_map(serde_json::Value::as_str)
+        .collect();
+    assert!(
+        required.contains(&"wordCount"),
+        "required camelCased: {required:?}"
+    );
+    assert!(
+        required.contains(&"kind"),
+        "required field rename: {required:?}"
+    );
+    assert!(
+        !required.contains(&"active"),
+        "optional not required: {required:?}"
+    );
+    assert!(!required.contains(&"word_count"));
+    assert!(!required.contains(&"category"));
+}
+
+#[test]
+fn new_model_schema_honors_serde_renames() {
+    use autumn_web::openapi::OpenApiSchema;
+    // NewRenamedRow drops the id; the rename rules still apply to the rest.
+    let schema = NewRenamedRow::schema();
+    let props = schema["properties"].as_object().expect("properties");
+    assert!(
+        props.contains_key("wordCount"),
+        "camelCased on New: {schema}"
+    );
+    assert!(props.contains_key("kind"), "field rename on New: {schema}");
+    assert!(!props.contains_key("id"), "New excludes id: {schema}");
+}

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -120,6 +120,32 @@ Because every piece comes from the same `SchemaEntry` data the OpenAPI
 generator uses, **there is no second schema to maintain** and no way for the
 tool catalog to drift from the handler.
 
+### Query is flat — put structured input in the body
+
+`Query<T>` deserializes with
+[`serde_urlencoded`](https://docs.rs/serde_urlencoded), which is **strictly
+flat**: it can decode scalars (`?q=foo&page=2`) and repeated keys for a
+sequence field (`?tags=a&tags=b`), but it **cannot** deserialize a nested
+struct by any encoding — not `key[sub]=`, not JSON-in-a-string. MCP `tools/call`
+dispatch honors this: query values are rendered as flat `key=value` pairs
+(arrays expand to repeated keys), so a query field that is itself an object or
+an array of objects could never round-trip back to the handler.
+
+So keep query parameters flat and **steer structured/nested input to a JSON
+body** (`Json<T>`), which round-trips losslessly through the tool's `body`
+property. When assembling `/mcp`, Autumn emits a build-time `tracing::warn` for
+a tool whose:
+
+- `query` or `body` resolves to a bare `{"type":"object"}` placeholder — the
+  arg type has no `OpenApiSchema`, so its fields aren't advertised. Fix it by
+  deriving (`#[derive(OpenApiSchema)]`) or implementing `OpenApiSchema` on the
+  arg type.
+- `query` advertises a nested object / array-of-object field — move that input
+  to a `Json<T>` body.
+
+These are warnings, not errors: the app still builds and the tool is still
+exposed.
+
 ### Safety annotations
 
 The HTTP method maps to MCP safety hints so agents and UIs can reason about


### PR DESCRIPTION
Part of #1972.

Part 2 of the MCP schema-quality work (Part 1 was #1983, the `#[derive(OpenApiSchema)]` derive). Three fixes to the typed schema pipeline that feeds **both** the OpenAPI document and MCP tool `inputSchema`s.

## Item 1 — serde rename fidelity

**Before:** the shared schema-body emitter (`emit_schema_fn_body`) advertised JSON-schema property names (and the `required` array) straight from the raw Rust identifier — it ignored `#[serde(rename)]` / `#[serde(rename_all)]` and a field `r#type` advertised the literal `"r#type"`. So the schema disagreed with what the handler actually (de)serializes.

**After:** the emitter resolves each field's advertised name through the existing serde helpers (`field_serde_serialize_rename` → `apply_serde_rename_all_rule`, raw-ident `r#` stripped first) and uses that **one resolved name for both the property key and the `required` entry**, so they can never drift. Fixed once in the shared helper, so `#[model]`, `#[derive(OpenApiSchema)]`, and `FormModel` stay in lockstep.

_Known limitation (documented in a code comment):_ this uses the **serialize** side of a split `#[serde(rename(serialize=…, deserialize=…))]`. For the common symmetric `rename` / `rename_all` (which apply to both sides) this is exact; only a rare split-form input struct could differ. Deliberate — it keeps all three code paths on the same helpers rather than duplicating a deserialize-side variant.

## Item 2 — collision-proof schema identity

**Before:** component names were the type's **last path segment** only, on both the producer side (`schema_name()`, `DerivedSchemaDescriptor.name`) and the consumer side (`last_segment_name` → `$ref`). Two derived types `create::Args` and `update::Args` both keyed on `"Args"`, both `$ref`'d `.../Args`, and the back-fill (first-match-wins over the inventory) let whichever linked first **silently shadow** the other.

**After:** a `Ref` `SchemaEntry` and the inventory descriptor now carry a globally-unique **`type_name` identity** (behind a `fn() -> &'static str` pointer so nested `Array`/`Nullable` entries stay const-promotable to `&'static` — `type_name` is not yet a stably-const fn). A central pass at spec-finalize (`build_schema_component_index`) resolves each identity to a readable component **display key** — the short last segment when unambiguous, a module-qualified key (`create.Args` / `update.Args`, sanitized to `[A-Za-z0-9._-]`) **only** when two distinct identities would collide. Both the component registration and every `$ref` (OpenAPI operations **and** the MCP `$defs` inlining) resolve through that same map, so a route reference can never resolve to the wrong schema. The producer↔consumer match is by identity (`type_name`), so it is correct by construction.

**Design chosen: the primary "central resolution", scoped.** Identity is carried only on route-macro `Ref` entries + the derive descriptor; `#[model]` / repository / `register_schema` short-name refs are unchanged, so existing specs keep their short component names (no output churn) and only genuine collisions get qualified. I did **not** take the "sanitized full-`type_name` everywhere" fallback — it would have renamed every component (`User` → `crate.models.User`) and churned every existing spec/test, which is exactly what the short-name-when-unambiguous design avoids. Threading the resolver into the MCP builder (via the same `build_schema_component_index` over the same routes) keeps MCP `$defs` refs correct in the collision case too.

## Item 3 — `Query<T>` nested-args story

**Before:** `Query<T>` delegates to `axum::extract::Query` → `serde_urlencoded`, which is **strictly flat** — it cannot deserialize a nested struct by any encoding (not `key[sub]=`, not JSON-in-a-string). MCP dispatch stringifies a nested-object query value to JSON-in-a-string, which the extractor then can't parse, so advertising a nested query schema would promise a contract the handler literally cannot honor.

**After:** flat query encoding is unchanged (scalars → `key=v`, arrays-of-scalars → repeated keys). The MCP tool builder now emits a build-time `tracing::warn` (mirroring the existing ineligible-route warning) when a tool's `query`/`body` resolves to an opaque `{"type":"object"}` placeholder (advising to derive/impl `OpenApiSchema`), **or** when a `Query<T>` advertises a nested object / array-of-object field (advising to move it to a `Json<T>` body). The flatness limit + JSON-body recommendation are documented on `Query`'s rustdoc and in the MCP guide.

**Decision & justification:** keep query flat and steer nested/structured input to a JSON body, which round-trips losslessly through the tool's `body` property. Advertising a nested query schema + inventing a bracket/JSON encoding would create a contract `serde_urlencoded` cannot honor, so a warn-and-steer is the honest behavior. Matches issue #1972 Proposal item 3.

## How

- `emit_schema_fn_body` gains a `rename_all_rule` param; a new `schema_property_name` helper resolves names; both `#[model]` and the derive thread the container rule in.
- `SchemaEntry` gains `identity: Option<fn() -> &'static str>` (+ manual `PartialEq`/`Eq` comparing the *resolved* identity string, not fn pointers); `type_name_of` / `component_key` / `SchemaComponentIndex` / `build_schema_component_index` centralize identity→display-key resolution; `schema_value_for` / `schema_entry_to_value` / `operation_for` / MCP `build_input_schema` all resolve through it.
- `detect_schema_degradations` (pure, unit-tested) drives the build-time warns in `derive_tools`.

## Tests

- Item 1: `mcp_schema_derive::derived_schema_honors_serde_renames_and_raw_idents`, `repository_openapi::model_schema_honors_serde_rename_all_and_field_rename` / `new_model_schema_honors_serde_renames`, `model::tests::schema_property_name_resolves_renames_and_strips_raw_idents`.
- Item 2: `mcp_schema_derive::colliding_derive_names_resolve_to_distinct_schemas`, `openapi::openapi_spec_disambiguates_same_named_component_schemas`.
- Item 3: `mcp::tests::detect_degradation_*` (opaque body/query, field-accurate no-op, nested object/array, nested via `$ref`).

`cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, and the openapi/mcp/schema test suites are all green.

_Uses "Part of #1972" (not "Closes") — Part 1's remaining Proposal items and full ACs aren't all in this PR's scope._

---
_Generated by [Claude Code](https://claude.ai/code/session_0192CdFighDY1zF1CQPPyMaG)_