### PR TITLE
⚡ Bolt: [performance improvement] Eliminate heap allocations in paths.rs

### DIFF
--- a/autumn/src/paths.rs
+++ b/autumn/src/paths.rs
@@ -32,11 +32,16 @@ pub trait PathExt {
 }
 
 impl PathExt for String {
-    fn with_query(self, key: impl std::fmt::Display, value: impl std::fmt::Display) -> String {
-        let encoded_key = percent_encode(&key.to_string());
-        let encoded_value = percent_encode(&value.to_string());
+    /// Appends a percent-encoded `key=value` query parameter directly to `self`.
+    /// This optimization eliminates allocating separate Strings for `key`, `value`,
+    /// and `format!`, reducing heap allocations per query parameter.
+    fn with_query(mut self, key: impl std::fmt::Display, value: impl std::fmt::Display) -> String {
         let sep = if self.contains('?') { '&' } else { '?' };
-        format!("{self}{sep}{encoded_key}={encoded_value}")
+        self.push(sep);
+        percent_encode_to(&key.to_string(), &mut self);
+        self.push('=');
+        percent_encode_to(&value.to_string(), &mut self);
+        self
     }
 }
 
@@ -58,18 +63,20 @@ pub fn encode_path_segment(value: impl std::fmt::Display) -> String {
 #[must_use]
 pub fn encode_catch_all_param(value: impl std::fmt::Display) -> String {
     let s = value.to_string();
-    s.split('/')
-        .map(|segment| {
-            if segment == "." {
-                "%2E".to_string()
-            } else if segment == ".." {
-                "%2E%2E".to_string()
-            } else {
-                percent_encode(segment)
-            }
-        })
-        .collect::<Vec<String>>()
-        .join("/")
+    let mut out = String::with_capacity(s.len() + 16);
+    for (i, segment) in s.split('/').enumerate() {
+        if i > 0 {
+            out.push('/');
+        }
+        if segment == "." {
+            out.push_str("%2E");
+        } else if segment == ".." {
+            out.push_str("%2E%2E");
+        } else {
+            percent_encode_to(segment, &mut out);
+        }
+    }
+    out
 }
 
 /// Percent-encode a query component per RFC 3986.
@@ -78,6 +85,13 @@ pub fn encode_catch_all_param(value: impl std::fmt::Display) -> String {
 /// unchanged; everything else is `%XX`-encoded.
 fn percent_encode(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
+    percent_encode_to(s, &mut out);
+    out
+}
+
+/// Appends a percent-encoded query component per RFC 3986 directly into the provided buffer.
+/// This prevents allocating intermediate Strings and copying bytes into the final string.
+fn percent_encode_to(s: &str, out: &mut String) {
     for byte in s.bytes() {
         match byte {
             b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
@@ -100,7 +114,6 @@ fn percent_encode(s: &str) -> String {
             }
         }
     }
-    out
 }
 
 #[cfg(test)]


### PR DESCRIPTION
💡 What: Refactored `paths.rs` to use a `percent_encode_to` function that writes directly to an existing `&mut String` buffer, avoiding intermediate `String` allocations. `PathExt::with_query` was updated to take `mut self` and append directly, and `encode_catch_all_param` was updated to use a single `String::with_capacity` buffer.
🎯 Why: `percent_encode` and `with_query` were creating multiple intermediate `String` allocations and using `format!` internally. Since `with_query` is used on hot paths in route generation and query manipulation, avoiding these allocations reduces heap pressure and improves speed.
📊 Impact: Removes 3 heap allocations per query parameter added via `with_query` and eliminates a `Vec<String>` and multiple intermediate string allocations in `encode_catch_all_param`.
🔬 Measurement: Run tests via `cargo test -p autumn-web --lib -- paths` and full suite with `cargo test`. Verified with `cargo clippy` that code complies with standards.

---
*PR created automatically by Jules for task [3288767907645946534](https://jules.google.com/task/3288767907645946534) started by @madmax983*