### PR TITLE
HOTFIX: trunk red — exclude sqlite from `--all-features` CI steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Free disk space (Linux)
         if: runner.os == 'Linux'
         run: |
-          # The full workspace build (especially the --all-features +
+          # The full workspace build (especially the wide-feature +
           # Postgres-container step below) sits near the runner's disk
           # ceiling; a cold-cache PR build tips it over ("No space left on
           # device"). Reclaim the preinstalled toolchains a Rust build never
@@ -106,7 +106,14 @@ jobs:
         run: |
           cargo test -p autumn-web --test db_hooks_lifecycle -- --ignored
           cargo test -p autumn-web --test repository_shard_replica_routing -- --ignored
-          cargo test -p autumn-web --all-features --test feature_flags_pg_integration -- --ignored
+          # NOTE: explicit feature list (NOT `--all-features`). `--all-features`
+          # would enable the backend-flip `sqlite` feature, which flips
+          # `db::RuntimeConnection` from `AsyncPgConnection` to a SQLite
+          # connection and fails to compile the Postgres-assuming modules
+          # (db.rs/managed_pg.rs/state.rs/job.rs/repository.rs/sharding.rs). This
+          # list is every autumn-web feature EXCEPT `sqlite` (i.e. the Postgres
+          # backend, which this pg-integration test requires). See #1614.
+          cargo test -p autumn-web --features "ws,presence,flash,cache-moka,maud,htmx,multipart,tailwind,http-client,oauth2,webauthn,openapi,mcp,markdown,db,offline-sync,test-support,telemetry-otlp,redis,i18n,embed-assets,storage,variants,reporting,mail,inbound-mail,inbound-mailgun,inbound-ses,seed,system-info,csv,system-tests,managed-pg,managed-pg-bundled,tls,acme" --test feature_flags_pg_integration -- --ignored
           cargo test -p autumn-web --test scoped_tokens_db -- --ignored
           cargo test -p autumn-admin-plugin --test token_admin_db -- --ignored
           cargo test -p autumn-cache-redis -- --ignored
@@ -205,14 +212,24 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cargo llvm-cov clean --workspace
-          cargo llvm-cov --workspace --all-features --no-report
-          cargo llvm-cov --no-report -p autumn-web --all-features \
+          # `--all-features` is unsafe here: it would enable autumn-web's
+          # backend-flip `sqlite` feature alongside the Postgres-assuming
+          # features, flipping `db::RuntimeConnection` to SQLite and failing
+          # autumn-web's lib to compile (#1614). Cargo has no "all-features
+          # except one crate feature" flag, so cover the rest of the workspace
+          # with `--all-features --exclude autumn-web`, then cover autumn-web
+          # separately with an explicit Postgres feature list (every autumn-web
+          # feature EXCEPT `sqlite`). Both accumulate into the same profile set.
+          PG_FEATURES="ws,presence,flash,cache-moka,maud,htmx,multipart,tailwind,http-client,oauth2,webauthn,openapi,mcp,markdown,db,offline-sync,test-support,telemetry-otlp,redis,i18n,embed-assets,storage,variants,reporting,mail,inbound-mail,inbound-mailgun,inbound-ses,seed,system-info,csv,system-tests,managed-pg,managed-pg-bundled,tls,acme"
+          cargo llvm-cov --workspace --exclude autumn-web --all-features --no-report
+          cargo llvm-cov --no-report -p autumn-web --features "$PG_FEATURES"
+          cargo llvm-cov --no-report -p autumn-web --features "$PG_FEATURES" \
             --test db_hooks_lifecycle -- --ignored
-          cargo llvm-cov --no-report -p autumn-web --all-features \
+          cargo llvm-cov --no-report -p autumn-web --features "$PG_FEATURES" \
             --test repository_shard_replica_routing -- --ignored
-          cargo llvm-cov --no-report -p autumn-web --all-features \
+          cargo llvm-cov --no-report -p autumn-web --features "$PG_FEATURES" \
             --test feature_flags_pg_integration -- --ignored
-          cargo llvm-cov --no-report -p autumn-web --all-features \
+          cargo llvm-cov --no-report -p autumn-web --features "$PG_FEATURES" \
             --test scoped_tokens_db -- --ignored
           cargo llvm-cov --no-report -p autumn-admin-plugin \
             --test token_admin_db -- --ignored

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -76,6 +76,12 @@ offline-sync = ["db", "http-client"]
 # breaks the Postgres default build. Feature-on testing is done via explicit
 # `cargo build -p autumn-web --features sqlite` invocations only.
 #
+# Do NOT enable via `--all-features` — this is a backend-flip feature, so
+# `--all-features` turns it on ALONGSIDE the Postgres-assuming features and
+# fails autumn-web's lib to compile. CI/scripts that want the Postgres backend
+# must use an explicit `--features` list that EXCLUDES `sqlite` (see
+# `.github/workflows/ci.yml`).
+#
 # PR1 is a no-op refactor: enabling it switches the connection *type alias* but
 # the SQLite pool CONSTRUCTION stays refused at runtime
 # (`PoolError::UnsupportedBackend`); a working pool is PR2. Needs no extra deps


### PR DESCRIPTION
**URGENT — trunk-dev is red on every open PR.** Draft per policy, but this should merge fast: it unblocks the ubuntu Test leg (and the Coverage job) for all PRs.

## Before / After
**Before:** The Postgres-context CI steps run autumn-web (and the workspace) with `--all-features`. Because the merged `sqlite` feature (#1614) is a **backend-flip, non-additive** feature — it flips `db::RuntimeConnection` from `AsyncPgConnection` to `SyncConnectionWrapper<SqliteConnection>` for the whole build graph — `--all-features` enables `sqlite` **alongside** every Postgres-assuming feature. autumn-web's lib then fails to compile (~28 `mismatched types` / `AsyncPgConnection` vs `SyncConnectionWrapper` errors in `db.rs`/`managed_pg.rs`/`state.rs`/`job.rs`/`repository.rs`/`sharding.rs`/`app.rs`/`test.rs`) on every PR's ubuntu leg. Even if it compiled, running the Postgres integration tests with the alias flipped to SQLite is semantically wrong.

**After:** Those steps use an explicit `--features` list = **every autumn-web feature EXCEPT `sqlite`** (its absence *is* the Postgres backend, which these steps require), so autumn-web compiles against Postgres exactly as it did before `sqlite` merged. `--all-features` is fundamentally unsafe with a mutually-exclusive backend feature.

## How
Changes are confined to `.github/workflows/ci.yml` and one doc comment in `autumn/Cargo.toml` (no source changes, no version bump).

**`<PGLIST>`** (every autumn-web `[features]` key except `default` and `sqlite`):
```
ws,presence,flash,cache-moka,maud,htmx,multipart,tailwind,http-client,oauth2,webauthn,openapi,mcp,markdown,db,offline-sync,test-support,telemetry-otlp,redis,i18n,embed-assets,storage,variants,reporting,mail,inbound-mail,inbound-mailgun,inbound-ses,seed,system-info,csv,system-tests,managed-pg,managed-pg-bundled,tls,acme
```
(Switching from `--all-features` to `--features` leaves default features on, so no `--no-default-features` is added.)

Steps changed:
| Job / step | Before | After |
|---|---|---|
| **Test** → "Run Docker-dependent tests" | `cargo test -p autumn-web --all-features --test feature_flags_pg_integration -- --ignored` | `cargo test -p autumn-web --features "<PGLIST>" --test feature_flags_pg_integration -- --ignored` |
| **Coverage** → "Generate coverage" (workspace base run) | `cargo llvm-cov --workspace --all-features --no-report` | `cargo llvm-cov --workspace --exclude autumn-web --all-features --no-report` **+** a new `cargo llvm-cov --no-report -p autumn-web --features "<PGLIST>"` |
| **Coverage** → 4× `-p autumn-web --all-features --test {db_hooks_lifecycle,repository_shard_replica_routing,feature_flags_pg_integration,scoped_tokens_db} -- --ignored` | `--all-features` | `--features "<PGLIST>"` (via a `PG_FEATURES` shell var) |

**Why the split on the workspace-wide coverage line:** cargo has no "all-features-except-one-crate-feature" flag, and simply scoping that line to autumn-web would silently drop the all-features coverage of every *other* workspace crate. So the base run keeps `--all-features` but `--exclude autumn-web` (full coverage of all other crates), and autumn-web is covered separately with `<PGLIST>`. Both accumulate into the same `--no-report` profile set that `cargo llvm-cov report` combines — no coverage dropped.

Also reinforced the hazard doc comment above the `sqlite` feature in `autumn/Cargo.toml`: *"Do NOT enable via `--all-features` … CI/scripts must use an explicit feature list that excludes `sqlite`."* (No `compile_error!` guard — there's no clean Postgres-feature predicate to conflict against, and it would just move the failure.)

The comments in ci.yml at lines 36 (clippy) and the disk-space step already/now describe why `--all-features` is unusable; the disk-step comment wording was updated to "wide-feature" since that step no longer literally passes `--all-features`.

## Local verification
- **Repro (break):** `cargo build -p autumn-web --features "db,managed-pg,ws,mail,offline-sync,redis,storage,seed,sqlite"` → **28 errors**, e.g. `expected AsyncPgConnection, found SyncConnectionWrapper<..>` in `db.rs`/`app.rs`/`sharding.rs`/`test.rs` — confirms the backend-flip diagnosis.
- **Fixed build (sqlite off):** the same feature set minus `sqlite` → **green** (compiles all backend-flip modules).
- **Test binary:** `cargo test -p autumn-web --features "db,ws,mail,offline-sync,redis" --test feature_flags_pg_integration --no-run` → **green** (executable produced; `--ignored` body needs Docker/pg, not run here).
- **Default build:** `cargo build -p autumn-web` → **green**.
- The full `<PGLIST>` build was not run end-to-end locally (the runner's ~4 GB free disk can't hold `system-tests`/chromiumoxide + `managed-pg-bundled`'s bundled Postgres + `variants`/image); those features are additive and don't touch `RuntimeConnection`, and `<PGLIST>` is exactly the pre-`sqlite` `--all-features` state, which was green before `sqlite` merged.

Part of #1614

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuoMnnmkhC2hsTmqm1inA6)_