### PR TITLE
feat(media): MediaStorage service — Local + S3 backends (slice 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,8 +465,17 @@ name = "autumn-media-plugin"
 version = "0.6.0"
 dependencies = [
  "autumn-web",
+ "aws-config",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-s3",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
  "serde",
  "thiserror 2.0.18",
+ "time",
+ "tokio",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
+ "percent-encoding",
  "serde",
  "thiserror 2.0.18",
  "time",

--- a/autumn-media-plugin/Cargo.toml
+++ b/autumn-media-plugin/Cargo.toml
@@ -15,8 +15,61 @@ categories = ["web-programming", "multimedia"]
 autumn-web = { version = "0.6.0", path = "../autumn" }
 serde = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
+
+# ── AWS SDK (S3 media storage) ────────────────────────────────────────────────
+# These pins are copied VERBATIM from autumn-storage-s3/Cargo.toml. They are
+# MSRV-1.88 + rustls-advisory-constrained; a looser pin breaks workspace
+# resolution. (Follow-up for the orchestrator: these are duplicated across
+# autumn-storage-s3 and this crate — a future slice may hoist them into
+# [workspace.dependencies]; deliberately NOT done here to keep the slice small.)
+aws-config = { version = "1", features = ["behavior-version-latest"] }
+aws-credential-types = { version = "1", features = ["hardcoded-credentials"] }
+aws-runtime = ">=1, <1.7"
+# aws-smithy-types 1.5 moved DeferredSignerSender behind a generic send(),
+# which breaks type inference in every published aws-runtime release
+# (E0282 in its sigv4 signer). Without this constraint any fresh
+# resolution of this crate fails to compile — `cargo add autumn-media-plugin`
+# included, not just cargo-semver-checks' isolated CI builds. Constrain to
+# the known-good series until upstream ships an aws-runtime compatible
+# with smithy-types 1.5.
+aws-smithy-types = ">=1.4, <1.5"
+# time 0.3.48 breaks trait coherence (E0119) in aws-smithy-types 1.4.x's
+# blanket From impl; time is already in this crate's graph via the aws
+# crates, so this only bounds resolution. Lift once upstream releases
+# are compatible.
+time = { version = ">=0.3.36, <0.3.48", default-features = false }
+# aws-smithy-async 1.3.0 bumped its rust-version to 1.94.1, above this
+# workspace's pinned toolchains (MSRV 1.88.0; CI's semver-check runner is
+# 1.92.0). This is a transitive dep pulled in via aws-config/aws-sdk-s3, not
+# used directly by this crate — it only bounds resolution, same as the
+# aws-smithy-types/time constraints above. Lift once CI's toolchain is bumped
+# past 1.94.1 or upstream ships an older-rustc-compatible release.
+aws-smithy-async = ">=1.2, <1.3"
+# aws-smithy-runtime-api is NOT tightly bound by the aws-smithy-async
+# constraint above -- some other crate in this graph (aws-config/aws-runtime/
+# aws-sdk-s3) has a looser requirement on it, so it can independently float up
+# to 1.12.0+, which depends on aws-smithy-runtime-api-macros (MSRV 1.94.1;
+# its only earlier release is an unusable 0.0.1 placeholder). Confirmed by
+# reproducing cargo-semver-checks' own isolated-crate resolution (`cargo new
+# --lib example && echo '[workspace]' >> Cargo.toml && cargo add --path
+# autumn-storage-s3`), which floats aws-smithy-runtime-api to 1.12.3 even with
+# the aws-smithy-async pin above in place. 1.11.4+ also bumps its own
+# rust-version to 1.91, above this workspace's 1.88.0 MSRV, so pin the ceiling
+# at the last 1.88.0-compatible patch. Lift alongside aws-smithy-async once
+# CI's toolchain allows it.
+aws-smithy-runtime-api = ">=1.11, <1.11.4"
+# Default features minus "rustls": the legacy `rustls` feature pulls the
+# deprecated hyper 0.14 / rustls 0.21 connector stack, whose rustls-webpki
+# 0.101 line has unfixed advisories (RUSTSEC-2026-0098/0099/0104 — fixes only
+# exist on the 0.103 line). The SDK's actual runtime client is the modern
+# `default-https-client` stack (hyper 1.x / rustls 0.23), which stays enabled.
+# Floor at 1.122 so the resolved `lru` is >=0.16.3 (RUSTSEC-2026-0002); 1.122
+# is also the last aws-sdk-s3 release compatible with this workspace's 1.88.0
+# MSRV and the aws-smithy-* ceilings above.
+aws-sdk-s3 = { version = ">=1.122, <1.123", default-features = false, features = ["sigv4a", "default-https-client", "rt-tokio"] }
 
 [lints]
 workspace = true

--- a/autumn-media-plugin/Cargo.toml
+++ b/autumn-media-plugin/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["web-programming", "multimedia"]
 
 [dependencies]
 autumn-web = { version = "0.6.0", path = "../autumn" }
+percent-encoding = "2"
 serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/autumn-media-plugin/src/config.rs
+++ b/autumn-media-plugin/src/config.rs
@@ -622,10 +622,11 @@ impl MediaConfig {
         // `highlights`, and an unset public base → the Tigris bucket URL derived
         // from the (resolved) bucket + key prefix. These are applied ONLY for
         // the S3 backend and ONLY in this compatibility shim — the generic
-        // `[media]` path keeps the neutral `MediaConfig` defaults (blank region
-        // → `auto` and the Tigris public-base fallback are re-derived at
-        // `MediaStorage::from_config` time; the endpoint and key-prefix defaults
-        // are Arroyo-specific and live here).
+        // `[media]` path keeps the neutral `MediaConfig` defaults (an unset
+        // region stays `None`/ambient-resolved and the Tigris public-base
+        // fallback is re-derived at `MediaStorage::from_config` time; the `auto`
+        // region, endpoint, and key-prefix defaults are Arroyo-specific and are
+        // set here, so the Tigris path always carries region `Some("auto")`).
         if config.storage.backend == MediaStorageBackend::S3 {
             if config.storage.region.is_none() {
                 config.storage.region = Some("auto".to_owned());

--- a/autumn-media-plugin/src/config.rs
+++ b/autumn-media-plugin/src/config.rs
@@ -562,6 +562,36 @@ impl MediaConfig {
             config.storage.force_path_style = matches_bool(&value);
         }
 
+        // Reproduce Arroyo's `VideoStorageConfig::from_env_pairs` S3 defaults so
+        // a migrating operator changes NO env: an unset region → `auto`, an
+        // unset endpoint → `https://t3.storage.dev`, an unset key prefix →
+        // `highlights`, and an unset public base → the Tigris bucket URL derived
+        // from the (resolved) bucket + key prefix. These are applied ONLY for
+        // the S3 backend and ONLY in this compatibility shim — the generic
+        // `[media]` path keeps the neutral `MediaConfig` defaults (blank region
+        // → `auto` and the Tigris public-base fallback are re-derived at
+        // `MediaStorage::from_config` time; the endpoint and key-prefix defaults
+        // are Arroyo-specific and live here).
+        if config.storage.backend == MediaStorageBackend::S3 {
+            if config.storage.region.is_none() {
+                config.storage.region = Some("auto".to_owned());
+            }
+            if config.storage.endpoint_url.is_none() {
+                config.storage.endpoint_url = Some("https://t3.storage.dev".to_owned());
+            }
+            if arroyo_value(env, "ARROYO_S3_KEY_PREFIX").is_none() {
+                "highlights".clone_into(&mut config.storage.key_prefix);
+            }
+            if config.storage.public_base_url.is_none()
+                && let Some(bucket) = config.storage.bucket.as_deref()
+            {
+                config.storage.public_base_url = Some(crate::storage::default_tigris_public_base(
+                    bucket,
+                    &config.storage.key_prefix,
+                ));
+            }
+        }
+
         // Recording retention.
         if let Some(value) = arroyo_value(env, "ARROYO_RECORDING_RETENTION_DAYS")
             && let Ok(parsed) = value.parse::<u32>()
@@ -869,6 +899,66 @@ mod tests {
             Some("https://cdn.example.com/media")
         );
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn arroyo_env_s3_defaults_match_arroyo() {
+        // No endpoint / region / key-prefix / public-base vars set: the shim
+        // must reproduce Arroyo's `from_env_pairs` S3 defaults verbatim.
+        let vars = env(&[
+            ("ARROYO_VIDEO_STORAGE_BACKEND", "s3"),
+            ("BUCKET_NAME", "arroyo-bucket"),
+            ("AWS_ACCESS_KEY_ID", "AKIA"),
+            ("AWS_SECRET_ACCESS_KEY", "secret"),
+        ]);
+        let config = MediaConfig::from_arroyo_env_pairs(&vars);
+        assert_eq!(config.storage.backend, MediaStorageBackend::S3);
+        assert_eq!(config.storage.region.as_deref(), Some("auto"));
+        assert_eq!(
+            config.storage.endpoint_url.as_deref(),
+            Some("https://t3.storage.dev")
+        );
+        assert_eq!(config.storage.key_prefix, "highlights");
+        assert_eq!(
+            config.storage.public_base_url.as_deref(),
+            Some("https://arroyo-bucket.t3.tigrisfiles.io/highlights")
+        );
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn arroyo_env_s3_defaults_do_not_override_explicit_vars() {
+        let vars = env(&[
+            ("ARROYO_VIDEO_STORAGE_BACKEND", "s3"),
+            ("BUCKET_NAME", "b"),
+            ("AWS_ACCESS_KEY_ID", "AKIA"),
+            ("AWS_SECRET_ACCESS_KEY", "secret"),
+            ("ARROYO_S3_REGION", "us-east-1"),
+            ("ARROYO_S3_ENDPOINT_URL", "https://example.r2.dev"),
+            ("ARROYO_S3_KEY_PREFIX", "vids"),
+            ("ARROYO_S3_PUBLIC_BASE_URL", "https://cdn.example.com/vids"),
+        ]);
+        let config = MediaConfig::from_arroyo_env_pairs(&vars);
+        assert_eq!(config.storage.region.as_deref(), Some("us-east-1"));
+        assert_eq!(
+            config.storage.endpoint_url.as_deref(),
+            Some("https://example.r2.dev")
+        );
+        assert_eq!(config.storage.key_prefix, "vids");
+        assert_eq!(
+            config.storage.public_base_url.as_deref(),
+            Some("https://cdn.example.com/vids")
+        );
+    }
+
+    #[test]
+    fn arroyo_env_local_keeps_neutral_defaults() {
+        // The S3-default block must not touch the local backend.
+        let config = MediaConfig::from_arroyo_env_pairs(&HashMap::new());
+        assert_eq!(config.storage.backend, MediaStorageBackend::Local);
+        assert_eq!(config.storage.endpoint_url, None);
+        assert_eq!(config.storage.region, None);
+        assert_eq!(config.storage.key_prefix, "media");
     }
 
     #[test]

--- a/autumn-media-plugin/src/config.rs
+++ b/autumn-media-plugin/src/config.rs
@@ -216,6 +216,9 @@ pub struct MediaStorageConfig {
     pub access_key_id: Option<String>,
     /// S3 secret access key (paired with `access_key_id`).
     pub secret_access_key: Option<String>,
+    /// S3 session token for temporary/rotating credentials (Lambda/ECS). `None`
+    /// selects permanent static keys or the ambient chain.
+    pub session_token: Option<String>,
     /// Public base URL served objects resolve under.
     pub public_base_url: Option<String>,
     /// Object key prefix (namespace) for stored media.
@@ -234,6 +237,7 @@ impl Default for MediaStorageConfig {
             region: None,
             access_key_id: None,
             secret_access_key: None,
+            session_token: None,
             public_base_url: None,
             key_prefix: default_s3_key_prefix(),
             force_path_style: false,
@@ -373,6 +377,7 @@ impl MediaConfig {
         interpolate_opt(&mut self.storage.region, env);
         interpolate_opt(&mut self.storage.access_key_id, env);
         interpolate_opt(&mut self.storage.secret_access_key, env);
+        interpolate_opt(&mut self.storage.session_token, env);
         interpolate_opt(&mut self.storage.public_base_url, env);
         interpolate(&mut self.storage.key_prefix, env);
     }
@@ -455,6 +460,11 @@ impl MediaConfig {
             &mut self.storage.secret_access_key,
             env,
             "AUTUMN_MEDIA__STORAGE__SECRET_ACCESS_KEY",
+        );
+        override_opt(
+            &mut self.storage.session_token,
+            env,
+            "AUTUMN_MEDIA__STORAGE__SESSION_TOKEN",
         );
         override_opt(
             &mut self.storage.public_base_url,
@@ -549,6 +559,9 @@ impl MediaConfig {
         config.storage.bucket = bucket;
         config.storage.access_key_id = access_key_id;
         config.storage.secret_access_key = secret_access_key;
+        // Standard AWS env var for temporary/rotating credentials; Arroyo has no
+        // ARROYO_-prefixed equivalent, so only the AWS_ name is read.
+        config.storage.session_token = arroyo_value(env, "AWS_SESSION_TOKEN");
         config.storage.endpoint_url = arroyo_value(env, "ARROYO_S3_ENDPOINT_URL")
             .or_else(|| arroyo_value(env, "AWS_ENDPOINT_URL_S3"));
         config.storage.region =
@@ -898,7 +911,35 @@ mod tests {
             config.storage.public_base_url.as_deref(),
             Some("https://cdn.example.com/media")
         );
+        // No AWS_SESSION_TOKEN set → session token stays None (permanent keys).
+        assert_eq!(config.storage.session_token, None);
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn arroyo_env_maps_session_token_from_aws_var() {
+        let vars = env(&[
+            ("ARROYO_VIDEO_STORAGE_BACKEND", "s3"),
+            ("BUCKET_NAME", "arroyo-bucket"),
+            ("AWS_ACCESS_KEY_ID", "AKIA"),
+            ("AWS_SECRET_ACCESS_KEY", "secret"),
+            ("AWS_SESSION_TOKEN", "temporary-session-token"),
+        ]);
+        let config = MediaConfig::from_arroyo_env_pairs(&vars);
+        assert_eq!(
+            config.storage.session_token.as_deref(),
+            Some("temporary-session-token")
+        );
+    }
+
+    #[test]
+    fn env_override_applies_session_token() {
+        let overrides = env(&[("AUTUMN_MEDIA__STORAGE__SESSION_TOKEN", "override-token")]);
+        let config = MediaConfig::from_toml_str_with_env("[media]\n", &overrides).unwrap();
+        assert_eq!(
+            config.storage.session_token.as_deref(),
+            Some("override-token")
+        );
     }
 
     #[test]

--- a/autumn-media-plugin/src/config.rs
+++ b/autumn-media-plugin/src/config.rs
@@ -199,7 +199,12 @@ impl MediaStorageBackend {
 }
 
 /// Media object storage settings (local filesystem or S3-compatible).
-#[derive(Debug, Clone, Deserialize)]
+///
+/// `secret_access_key` and `session_token` are redacted by the hand-written
+/// [`std::fmt::Debug`] impl (mirroring [`crate::storage::S3MediaStorage`]), so a
+/// `MediaStorageConfig` — or the enclosing [`MediaConfig`], whose derived
+/// `Debug` delegates here — can be logged without leaking bearer credentials.
+#[derive(Clone, Deserialize)]
 #[serde(default)]
 pub struct MediaStorageConfig {
     /// Selected backend. Defaults to [`MediaStorageBackend::Local`].
@@ -216,8 +221,14 @@ pub struct MediaStorageConfig {
     pub access_key_id: Option<String>,
     /// S3 secret access key (paired with `access_key_id`).
     pub secret_access_key: Option<String>,
-    /// S3 session token for temporary/rotating credentials (Lambda/ECS). `None`
-    /// selects permanent static keys or the ambient chain.
+    /// S3 session token for a fixed short-lived credential (paired with the
+    /// explicit `access_key_id` / `secret_access_key`). Config-supplied
+    /// credentials are **static** — loaded once at construction and never
+    /// hot-reloaded — so this is for a token that stays valid for the task's
+    /// lifetime; it does not self-refresh. For rotating/temporary credentials in
+    /// a long-running service, leave the explicit credential fields unset so the
+    /// ambient AWS provider chain (env / IMDS / ECS / STS) resolves and refreshes
+    /// them. `None` selects permanent static keys or the ambient chain.
     pub session_token: Option<String>,
     /// Public base URL served objects resolve under.
     pub public_base_url: Option<String>,
@@ -225,6 +236,36 @@ pub struct MediaStorageConfig {
     pub key_prefix: String,
     /// Whether to force S3 path-style addressing.
     pub force_path_style: bool,
+}
+
+impl std::fmt::Debug for MediaStorageConfig {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Render every non-secret field verbatim so the Debug stays useful, but
+        // redact the two bearer credentials (`secret_access_key`,
+        // `session_token`) — matching `S3MediaStorage`'s redaction so the two
+        // never drift. `access_key_id`, region, bucket, endpoint, etc. are not
+        // secret and are shown as-is.
+        formatter
+            .debug_struct("MediaStorageConfig")
+            .field("backend", &self.backend)
+            .field("root", &self.root)
+            .field("bucket", &self.bucket)
+            .field("endpoint_url", &self.endpoint_url)
+            .field("region", &self.region)
+            .field("access_key_id", &self.access_key_id)
+            .field(
+                "secret_access_key",
+                &self.secret_access_key.as_ref().map(|_| "** redacted **"),
+            )
+            .field(
+                "session_token",
+                &self.session_token.as_ref().map(|_| "** redacted **"),
+            )
+            .field("public_base_url", &self.public_base_url)
+            .field("key_prefix", &self.key_prefix)
+            .field("force_path_style", &self.force_path_style)
+            .finish()
+    }
 }
 
 impl Default for MediaStorageConfig {
@@ -1011,6 +1052,78 @@ mod tests {
         ]);
         let config = MediaConfig::from_arroyo_env_pairs(&vars);
         assert_eq!(config.storage.backend, MediaStorageBackend::S3);
+    }
+
+    #[test]
+    fn storage_config_debug_redacts_secret_and_session_token() {
+        let config = MediaStorageConfig {
+            backend: MediaStorageBackend::S3,
+            bucket: Some("b".to_owned()),
+            access_key_id: Some("AKIA-visible".to_owned()),
+            secret_access_key: Some("s3kr3t-value-xyz".to_owned()),
+            session_token: Some("session-token-value-abc".to_owned()),
+            ..MediaStorageConfig::default()
+        };
+        let rendered = format!("{config:?}");
+        // The bearer credentials must never appear in cleartext.
+        assert!(
+            !rendered.contains("s3kr3t-value-xyz"),
+            "secret value must not appear: {rendered}"
+        );
+        assert!(
+            !rendered.contains("session-token-value-abc"),
+            "session token value must not appear: {rendered}"
+        );
+        // Both present secrets render redacted.
+        assert!(
+            rendered.contains("secret_access_key: Some(\"** redacted **\")"),
+            "secret must render redacted when present: {rendered}"
+        );
+        assert!(
+            rendered.contains("session_token: Some(\"** redacted **\")"),
+            "session token must render redacted when present: {rendered}"
+        );
+        // Non-secret fields stay visible so the Debug is still useful.
+        assert!(
+            rendered.contains("AKIA-visible"),
+            "access_key_id is not secret and must stay visible: {rendered}"
+        );
+    }
+
+    #[test]
+    fn storage_config_debug_renders_absent_secrets_as_none() {
+        // Absent credentials render as `None`, never a redaction marker.
+        let rendered = format!("{:?}", MediaStorageConfig::default());
+        assert!(
+            rendered.contains("secret_access_key: None"),
+            "absent secret must render None: {rendered}"
+        );
+        assert!(
+            rendered.contains("session_token: None"),
+            "absent session token must render None: {rendered}"
+        );
+    }
+
+    #[test]
+    fn media_config_debug_propagates_storage_redaction() {
+        // The enclosing MediaConfig's derived Debug delegates to the storage
+        // field's hand-written impl, so secrets stay redacted there too.
+        let mut config = MediaConfig::default();
+        config.storage.secret_access_key = Some("s3kr3t-value-xyz".to_owned());
+        config.storage.session_token = Some("session-token-value-abc".to_owned());
+        let rendered = format!("{config:?}");
+        assert!(
+            !rendered.contains("s3kr3t-value-xyz"),
+            "secret value must not appear via MediaConfig: {rendered}"
+        );
+        assert!(
+            !rendered.contains("session-token-value-abc"),
+            "session token value must not appear via MediaConfig: {rendered}"
+        );
+        assert!(
+            rendered.contains("** redacted **"),
+            "redaction marker must propagate through MediaConfig: {rendered}"
+        );
     }
 
     #[test]

--- a/autumn-media-plugin/src/error.rs
+++ b/autumn-media-plugin/src/error.rs
@@ -1,0 +1,60 @@
+//! Shared error type for the media plugin's storage (and, in later slices,
+//! encode/transport) surfaces.
+//!
+//! AWS SDK error types are deliberately **stringified** into the `message`
+//! fields here rather than surfaced directly, so the public API never leaks an
+//! `aws-sdk-s3` type — and, by construction, never a credential (the SDK's
+//! `Display` for these errors carries only request/response metadata, and the
+//! signing key never appears in it).
+
+use thiserror::Error;
+
+/// Errors returned by the media plugin's storage operations.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum MediaError {
+    /// The S3 backend was selected without a bucket name.
+    #[error("media.storage.bucket is required when backend = \"s3\"")]
+    MissingBucket,
+
+    /// Exactly one of `access_key_id` / `secret_access_key` was configured for
+    /// the S3 backend. Both must be provided together, or neither (to use the
+    /// ambient AWS credential chain).
+    #[error(
+        "partial S3 credentials: media.storage.access_key_id and \
+         media.storage.secret_access_key must both be set, or neither"
+    )]
+    PartialS3Credentials,
+
+    /// A local file staged for persistence could not be read.
+    #[error("failed to read local file `{path}`: {source}")]
+    LocalRead {
+        /// The local filesystem path that could not be read.
+        path: String,
+        /// The underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// An S3 object upload failed. `message` is the stringified SDK error.
+    #[error("failed to upload s3://{bucket}/{key}: {message}")]
+    S3Upload {
+        /// Target bucket.
+        bucket: String,
+        /// Target object key.
+        key: String,
+        /// Stringified SDK error (no AWS type, no credentials).
+        message: String,
+    },
+
+    /// An S3 object delete failed. `message` is the stringified SDK error.
+    #[error("failed to delete s3://{bucket}/{key}: {message}")]
+    S3Delete {
+        /// Target bucket.
+        bucket: String,
+        /// Target object key.
+        key: String,
+        /// Stringified SDK error (no AWS type, no credentials).
+        message: String,
+    },
+}

--- a/autumn-media-plugin/src/lib.rs
+++ b/autumn-media-plugin/src/lib.rs
@@ -38,17 +38,21 @@
 //! First-party plugin: `autumn-<name>-plugin`.
 
 pub mod config;
+pub mod error;
+pub mod storage;
 
 pub use config::{
     MediaConfig, MediaConfigError, MediaMtxConfig, MediaStorageBackend, MediaStorageConfig,
     RecordingConfig,
 };
+pub use error::MediaError;
+pub use storage::{MediaStorage, S3MediaStorage, StoredObject};
 
 /// Common downstream imports for configuring and mounting the media plugin.
 pub mod prelude {
     pub use crate::{
-        MediaConfig, MediaConfigError, MediaMtxConfig, MediaPlugin, MediaStorageBackend,
-        MediaStorageConfig, RecordingConfig,
+        MediaConfig, MediaConfigError, MediaError, MediaMtxConfig, MediaPlugin, MediaStorage,
+        MediaStorageBackend, MediaStorageConfig, RecordingConfig, S3MediaStorage, StoredObject,
     };
 }
 

--- a/autumn-media-plugin/src/storage.rs
+++ b/autumn-media-plugin/src/storage.rs
@@ -80,6 +80,10 @@ pub struct S3MediaStorage {
     pub access_key_id: String,
     /// Secret access key (redacted in `Debug`).
     pub secret_access_key: String,
+    /// Session token for temporary/rotating credentials (Lambda/ECS), if any.
+    /// `None` selects permanent static keys (e.g. Tigris) or the ambient chain.
+    /// Sensitive — redacted in `Debug`.
+    pub session_token: Option<String>,
     /// Public base URL that stored objects resolve under.
     pub public_base_url: String,
     /// Object key prefix (namespace) prepended to caller keys.
@@ -105,6 +109,10 @@ impl std::fmt::Debug for S3MediaStorage {
             .field("region", &self.region)
             .field("access_key_id", &self.access_key_id)
             .field("secret_access_key", &"** redacted **")
+            .field(
+                "session_token",
+                &self.session_token.as_ref().map(|_| "** redacted **"),
+            )
             .field("public_base_url", &self.public_base_url)
             .field("key_prefix", &self.key_prefix)
             .field("force_path_style", &self.force_path_style)
@@ -181,6 +189,7 @@ impl MediaStorage {
                     region,
                     access_key_id: access_key_id.unwrap_or_default().to_owned(),
                     secret_access_key: secret_access_key.unwrap_or_default().to_owned(),
+                    session_token: non_empty(cfg.session_token.as_deref()).map(ToOwned::to_owned),
                     public_base_url,
                     key_prefix,
                     force_path_style: cfg.force_path_style,
@@ -381,7 +390,7 @@ impl MediaStorage {
                     let credentials = Credentials::new(
                         config.access_key_id.clone(),
                         config.secret_access_key.clone(),
-                        None,
+                        config.session_token.clone(),
                         None,
                         "autumn-media-plugin",
                     );
@@ -740,6 +749,7 @@ mod tests {
     fn secret_access_key_is_redacted_in_debug() {
         let mut cfg = s3_config(Some("b"));
         cfg.secret_access_key = Some("s3kr3t-value-xyz".to_owned());
+        cfg.session_token = Some("session-token-value-abc".to_owned());
         let storage = MediaStorage::from_config(&cfg).unwrap();
         let rendered = format!("{storage:?}");
         assert!(rendered.contains("** redacted **"));
@@ -749,6 +759,58 @@ mod tests {
             !rendered.contains("s3kr3t-value-xyz"),
             "secret value must not appear: {rendered}"
         );
+        // The session token is equally sensitive: its value must never appear,
+        // and its `Some(_)` presence must render as `** redacted **`.
+        assert!(
+            !rendered.contains("session-token-value-abc"),
+            "session token value must not appear: {rendered}"
+        );
+        assert!(
+            rendered.contains("session_token: Some(\"** redacted **\")"),
+            "session token must render redacted when present: {rendered}"
+        );
+    }
+
+    #[test]
+    fn session_token_is_none_in_debug_when_absent() {
+        // An absent session token renders as `None`, never a redaction marker.
+        let storage = MediaStorage::from_config(&s3_config(Some("b"))).unwrap();
+        let rendered = format!("{storage:?}");
+        assert!(
+            rendered.contains("session_token: None"),
+            "absent session token must render None: {rendered}"
+        );
+    }
+
+    #[test]
+    fn from_config_threads_session_token() {
+        let mut cfg = s3_config(Some("b"));
+        cfg.session_token = Some("temp-creds-token".to_owned());
+        let MediaStorage::S3(config) = MediaStorage::from_config(&cfg).unwrap() else {
+            panic!("expected s3 backend");
+        };
+        assert_eq!(config.session_token.as_deref(), Some("temp-creds-token"));
+    }
+
+    #[test]
+    fn from_config_blank_session_token_is_none() {
+        // A blank token is normalized to `None`, matching the access-key /
+        // secret-key non-empty handling.
+        let mut cfg = s3_config(Some("b"));
+        cfg.session_token = Some("   ".to_owned());
+        let MediaStorage::S3(config) = MediaStorage::from_config(&cfg).unwrap() else {
+            panic!("expected s3 backend");
+        };
+        assert_eq!(config.session_token, None);
+    }
+
+    #[test]
+    fn from_config_absent_session_token_is_none() {
+        let MediaStorage::S3(config) = MediaStorage::from_config(&s3_config(Some("b"))).unwrap()
+        else {
+            panic!("expected s3 backend");
+        };
+        assert_eq!(config.session_token, None);
     }
 
     // ── client-builder smoke test (no network) ───────────────────────────────

--- a/autumn-media-plugin/src/storage.rs
+++ b/autumn-media-plugin/src/storage.rs
@@ -223,13 +223,19 @@ impl MediaStorage {
 
     /// The public URL a browser fetches the object at — the backend's public
     /// base joined with the caller key.
+    ///
+    /// The key's path segments are percent-encoded (preserving `/`
+    /// separators) so a caller key containing URL-reserved characters (e.g.
+    /// `#`, `?`, space) addresses exactly the stored object rather than being
+    /// reinterpreted as a fragment/query by the browser.
     #[must_use]
     pub fn public_url(&self, key: &str) -> String {
+        let encoded = encode_key_for_url(key);
         match self {
             Self::Local {
                 public_base_url, ..
-            } => join_url(public_base_url, key),
-            Self::S3(config) => join_url(&config.public_base_url, key),
+            } => join_url(public_base_url, &encoded),
+            Self::S3(config) => join_url(&config.public_base_url, &encoded),
         }
     }
 
@@ -451,6 +457,25 @@ pub fn join_key_prefix(prefix: &str, key: &str) -> String {
     }
 }
 
+/// Percent-encode each path segment of a storage key for safe inclusion in a
+/// browser-facing URL, preserving `/` separators. Unreserved RFC 3986 chars
+/// (`A-Z a-z 0-9 - . _ ~`) pass through; everything else (e.g. `#`, `?`, `%`,
+/// space) is percent-encoded so the URL addresses exactly the stored object.
+fn encode_key_for_url(key: &str) -> String {
+    use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
+    // NON_ALPHANUMERIC encodes everything except ASCII alphanumerics; add back
+    // the RFC 3986 unreserved marks so `.mp4`, `-`, `_`, `~` stay readable.
+    const SEGMENT: &AsciiSet = &NON_ALPHANUMERIC
+        .remove(b'-')
+        .remove(b'.')
+        .remove(b'_')
+        .remove(b'~');
+    key.split('/')
+        .map(|seg| utf8_percent_encode(seg, SEGMENT).to_string())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
 /// Join a base URL and a path with exactly one separating slash. An empty path
 /// yields the trailing-slash-trimmed base alone.
 #[must_use]
@@ -588,6 +613,47 @@ mod tests {
         assert_eq!(
             storage.public_url("/clips/1.mp4"),
             "https://cdn.example.com/media/clips/1.mp4"
+        );
+    }
+
+    #[test]
+    fn public_url_percent_encodes_reserved_char() {
+        let storage = MediaStorage::Local {
+            root: PathBuf::from("media"),
+            public_base_url: "/media".to_owned(),
+        };
+        let url = storage.public_url("clips/a#b.mp4");
+        // The `#` is encoded so the browser fetches the object, not a fragment.
+        assert_eq!(url, "/media/clips/a%23b.mp4");
+        assert!(!url.contains("a#b"), "reserved `#` must be encoded: {url}");
+        // `/` separators are preserved.
+        assert!(url.contains("/clips/"), "path separators preserved: {url}");
+    }
+
+    #[test]
+    fn public_url_passes_through_unreserved_chars() {
+        let storage = MediaStorage::Local {
+            root: PathBuf::from("media"),
+            public_base_url: "/media".to_owned(),
+        };
+        let url = storage.public_url("highlights/my-clip_1.mp4");
+        // Unreserved RFC 3986 chars (`.`, `-`, `_`) are untouched — no encoding.
+        assert_eq!(url, "/media/highlights/my-clip_1.mp4");
+        assert!(
+            !url.contains('%'),
+            "no percent-encoding for slug key: {url}"
+        );
+    }
+
+    #[test]
+    fn public_url_encodes_space_question_and_percent() {
+        let storage = MediaStorage::Local {
+            root: PathBuf::from("media"),
+            public_base_url: "/media".to_owned(),
+        };
+        assert_eq!(
+            storage.public_url("clips/a b?c%d.mp4"),
+            "/media/clips/a%20b%3Fc%25d.mp4"
         );
     }
 

--- a/autumn-media-plugin/src/storage.rs
+++ b/autumn-media-plugin/src/storage.rs
@@ -93,10 +93,15 @@ pub struct S3MediaStorage {
     /// Lazily-built, cached aws-sdk-s3 client shared across operations.
     ///
     /// Private (unlike the config fields): an internal cache, not part of the
-    /// resolved configuration. The AWS SDK recommends one long-lived client
-    /// whose credential provider self-refreshes, so it is built once via
-    /// [`tokio::sync::OnceCell`] and reused. Wrapped in [`std::sync::Arc`] so a
-    /// `#[derive(Clone)]` of `S3MediaStorage` shares the same cache.
+    /// resolved configuration. The AWS SDK recommends one long-lived client, so
+    /// it is built once via [`tokio::sync::OnceCell`] and reused. Wrapped in
+    /// [`std::sync::Arc`] so a `#[derive(Clone)]` of `S3MediaStorage` shares the
+    /// same cache. Whether the cached client's credentials can *refresh* depends
+    /// on how it was built (see [`MediaStorage::build_client`]): a client built
+    /// from the explicit `access_key_id` / `secret_access_key` (with or without a
+    /// `session_token`) carries those static values verbatim and cannot refresh
+    /// them; only the ambient-provider-chain path (used when the explicit keys
+    /// are unset) refreshes credentials on its own.
     client: std::sync::Arc<tokio::sync::OnceCell<Client>>,
 }
 
@@ -372,13 +377,22 @@ impl MediaStorage {
     ///
     /// The client is built lazily on first use and cached in the backend's
     /// [`tokio::sync::OnceCell`], so every operation reuses one long-lived
-    /// client (the AWS SDK recommendation — its credential provider
-    /// self-refreshes) instead of rebuilding per operation. The endpoint is set
-    /// **only when configured** (an improvement over Arroyo's always-set
-    /// endpoint, borrowed from `autumn-storage-s3`): an unset endpoint leaves
-    /// the SDK default in place. When both credentials are present they are used
-    /// as hard-coded `SigV4` credentials; otherwise the ambient AWS credential
-    /// chain is loaded.
+    /// client (the AWS SDK recommendation) instead of rebuilding per operation.
+    /// The endpoint is set **only when configured** (an improvement over
+    /// Arroyo's always-set endpoint, borrowed from `autumn-storage-s3`): an
+    /// unset endpoint leaves the SDK default in place.
+    ///
+    /// **Credential source and refresh semantics.** When both explicit
+    /// credentials are present they are used as **static** `SigV4` credentials
+    /// (with the optional `session_token`): the config is loaded once at
+    /// construction and is not hot-reloaded, so a client built this way cannot
+    /// refresh its credentials — it is the right choice for permanent static
+    /// keys (e.g. Tigris) or a fixed, short-lived token for a short-lived task.
+    /// When the explicit `access_key_id` / `secret_access_key` are unset, the
+    /// **ambient AWS credential chain** is loaded instead (env / IMDS / ECS /
+    /// STS), and that provider refreshes rotating/temporary credentials
+    /// automatically — so a long-running service with rotating creds should
+    /// leave the explicit credential fields empty and rely on the ambient chain.
     ///
     /// # Panics
     ///
@@ -461,6 +475,13 @@ pub fn join_key_prefix(prefix: &str, key: &str) -> String {
 /// browser-facing URL, preserving `/` separators. Unreserved RFC 3986 chars
 /// (`A-Z a-z 0-9 - . _ ~`) pass through; everything else (e.g. `#`, `?`, `%`,
 /// space) is percent-encoded so the URL addresses exactly the stored object.
+///
+/// A whole-segment `.` or `..` is special-cased: while an ordinary filename dot
+/// (`my-clip_1.mp4`) stays readable, leaving a bare `.`/`..` segment literal
+/// would let a browser/proxy path-normalize `clips/../other.mp4` down to
+/// `other.mp4` *before* the request — addressing a different object than the
+/// stored key. Those dot-only segments therefore have their dots percent-encoded
+/// (`.` → `%2E`, `..` → `%2E%2E`) so the URL survives normalization intact.
 fn encode_key_for_url(key: &str) -> String {
     use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
     // NON_ALPHANUMERIC encodes everything except ASCII alphanumerics; add back
@@ -471,7 +492,15 @@ fn encode_key_for_url(key: &str) -> String {
         .remove(b'_')
         .remove(b'~');
     key.split('/')
-        .map(|seg| utf8_percent_encode(seg, SEGMENT).to_string())
+        .map(|seg| {
+            if seg == "." || seg == ".." {
+                // Encode the dot(s) of a dot-only segment so path normalization
+                // can't collapse the URL to a different object.
+                seg.replace('.', "%2E")
+            } else {
+                utf8_percent_encode(seg, SEGMENT).to_string()
+            }
+        })
         .collect::<Vec<_>>()
         .join("/")
 }
@@ -654,6 +683,54 @@ mod tests {
         assert_eq!(
             storage.public_url("clips/a b?c%d.mp4"),
             "/media/clips/a%20b%3Fc%25d.mp4"
+        );
+    }
+
+    #[test]
+    fn public_url_encodes_dotdot_segment() {
+        let storage = MediaStorage::Local {
+            root: PathBuf::from("media"),
+            public_base_url: "/media".to_owned(),
+        };
+        let url = storage.public_url("clips/../other.mp4");
+        // The `..` segment is encoded so a browser/proxy can't normalize the URL
+        // down to `/media/other.mp4` and address a different object.
+        assert_eq!(url, "/media/clips/%2E%2E/other.mp4");
+        assert!(
+            !url.contains("/../"),
+            "literal `..` traversal must not survive: {url}"
+        );
+    }
+
+    #[test]
+    fn public_url_encodes_single_dot_segment() {
+        let storage = MediaStorage::Local {
+            root: PathBuf::from("media"),
+            public_base_url: "/media".to_owned(),
+        };
+        let url = storage.public_url("clips/./a.mp4");
+        // The whole-segment `.` is encoded; the filename dot in `a.mp4` is not.
+        assert_eq!(url, "/media/clips/%2E/a.mp4");
+        assert!(
+            !url.contains("/./"),
+            "literal `.` current-dir segment must not survive: {url}"
+        );
+    }
+
+    #[test]
+    fn encode_key_for_url_preserves_ordinary_filename_dot() {
+        // A normal filename dot is untouched — only whole-segment `.`/`..` are
+        // encoded.
+        assert_eq!(encode_key_for_url("clips/a.mp4"), "clips/a.mp4");
+        assert!(!encode_key_for_url("clips/a.mp4").contains("%2E"));
+        // And the dot-only segments still encode.
+        assert_eq!(
+            encode_key_for_url("clips/../other.mp4"),
+            "clips/%2E%2E/other.mp4"
+        );
+        assert_eq!(
+            encode_key_for_url("clips/./other.mp4"),
+            "clips/%2E/other.mp4"
         );
     }
 

--- a/autumn-media-plugin/src/storage.rs
+++ b/autumn-media-plugin/src/storage.rs
@@ -67,7 +67,7 @@ pub struct StoredObject {
 ///
 /// `secret_access_key` is redacted by the hand-written [`std::fmt::Debug`]
 /// impl, so a `MediaStorage` can be safely logged.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct S3MediaStorage {
     /// Bucket name.
     pub bucket: String,
@@ -86,6 +86,14 @@ pub struct S3MediaStorage {
     pub key_prefix: String,
     /// Whether to force S3 path-style addressing.
     pub force_path_style: bool,
+    /// Lazily-built, cached aws-sdk-s3 client shared across operations.
+    ///
+    /// Private (unlike the config fields): an internal cache, not part of the
+    /// resolved configuration. The AWS SDK recommends one long-lived client
+    /// whose credential provider self-refreshes, so it is built once via
+    /// [`tokio::sync::OnceCell`] and reused. Wrapped in [`std::sync::Arc`] so a
+    /// `#[derive(Clone)]` of `S3MediaStorage` shares the same cache.
+    client: std::sync::Arc<tokio::sync::OnceCell<Client>>,
 }
 
 impl std::fmt::Debug for S3MediaStorage {
@@ -100,7 +108,8 @@ impl std::fmt::Debug for S3MediaStorage {
             .field("public_base_url", &self.public_base_url)
             .field("key_prefix", &self.key_prefix)
             .field("force_path_style", &self.force_path_style)
-            .finish()
+            // `client` (the cached aws-sdk-s3 client) is intentionally omitted.
+            .finish_non_exhaustive()
     }
 }
 
@@ -175,6 +184,7 @@ impl MediaStorage {
                     public_base_url,
                     key_prefix,
                     force_path_style: cfg.force_path_style,
+                    client: std::sync::Arc::new(tokio::sync::OnceCell::new()),
                 }))
             }
         }
@@ -285,7 +295,7 @@ impl MediaStorage {
                 let body = ByteStream::from_path(local_path).await.map_err(|error| {
                     MediaError::LocalRead {
                         path: local_path.display().to_string(),
-                        source: std::io::Error::other(error.to_string()),
+                        source: std::io::Error::other(error),
                     }
                 })?;
                 let client = self.build_client().await;
@@ -343,14 +353,17 @@ impl MediaStorage {
         }
     }
 
-    /// Build a fresh aws-sdk-s3 client for the S3 backend.
+    /// Return the S3 backend's cached aws-sdk-s3 client, building it once.
     ///
-    /// A new client is built per operation (matching Arroyo), so it does not
-    /// need to be cached on the enum. The endpoint is set **only when
-    /// configured** (an improvement over Arroyo's always-set endpoint, borrowed
-    /// from `autumn-storage-s3`): an unset endpoint leaves the SDK default in
-    /// place. When both credentials are present they are used as hard-coded
-    /// `SigV4` credentials; otherwise the ambient AWS credential chain is loaded.
+    /// The client is built lazily on first use and cached in the backend's
+    /// [`tokio::sync::OnceCell`], so every operation reuses one long-lived
+    /// client (the AWS SDK recommendation — its credential provider
+    /// self-refreshes) instead of rebuilding per operation. The endpoint is set
+    /// **only when configured** (an improvement over Arroyo's always-set
+    /// endpoint, borrowed from `autumn-storage-s3`): an unset endpoint leaves
+    /// the SDK default in place. When both credentials are present they are used
+    /// as hard-coded `SigV4` credentials; otherwise the ambient AWS credential
+    /// chain is loaded.
     ///
     /// # Panics
     ///
@@ -361,35 +374,41 @@ impl MediaStorage {
             unreachable!("build_client is only called for the S3 backend");
         };
 
-        if !config.access_key_id.is_empty() && !config.secret_access_key.is_empty() {
-            let credentials = Credentials::new(
-                config.access_key_id.clone(),
-                config.secret_access_key.clone(),
-                None,
-                None,
-                "autumn-media-plugin",
-            );
-            let mut builder = aws_sdk_s3::Config::builder()
-                .behavior_version(BehaviorVersion::latest())
-                .region(Region::new(config.region.clone()))
-                .credentials_provider(credentials)
-                .force_path_style(config.force_path_style);
-            if let Some(endpoint) = &config.endpoint_url {
-                builder = builder.endpoint_url(endpoint);
-            }
-            Client::from_conf(builder.build())
-        } else {
-            let shared = aws_config::defaults(BehaviorVersion::latest())
-                .region(Region::new(config.region.clone()))
-                .load()
-                .await;
-            let mut builder = aws_sdk_s3::config::Builder::from(&shared)
-                .force_path_style(config.force_path_style);
-            if let Some(endpoint) = &config.endpoint_url {
-                builder = builder.endpoint_url(endpoint);
-            }
-            Client::from_conf(builder.build())
-        }
+        config
+            .client
+            .get_or_init(|| async {
+                if !config.access_key_id.is_empty() && !config.secret_access_key.is_empty() {
+                    let credentials = Credentials::new(
+                        config.access_key_id.clone(),
+                        config.secret_access_key.clone(),
+                        None,
+                        None,
+                        "autumn-media-plugin",
+                    );
+                    let mut builder = aws_sdk_s3::Config::builder()
+                        .behavior_version(BehaviorVersion::latest())
+                        .region(Region::new(config.region.clone()))
+                        .credentials_provider(credentials)
+                        .force_path_style(config.force_path_style);
+                    if let Some(endpoint) = &config.endpoint_url {
+                        builder = builder.endpoint_url(endpoint);
+                    }
+                    Client::from_conf(builder.build())
+                } else {
+                    let shared = aws_config::defaults(BehaviorVersion::latest())
+                        .region(Region::new(config.region.clone()))
+                        .load()
+                        .await;
+                    let mut builder = aws_sdk_s3::config::Builder::from(&shared)
+                        .force_path_style(config.force_path_style);
+                    if let Some(endpoint) = &config.endpoint_url {
+                        builder = builder.endpoint_url(endpoint);
+                    }
+                    Client::from_conf(builder.build())
+                }
+            })
+            .await
+            .clone()
     }
 }
 

--- a/autumn-media-plugin/src/storage.rs
+++ b/autumn-media-plugin/src/storage.rs
@@ -213,29 +213,54 @@ impl MediaStorage {
         }
     }
 
-    /// Resolve the caller key into the backend's stored object key.
+    /// Resolve a caller-relative key into the backend's fully-resolved stored
+    /// object key — the **single authority** for key-prefix + slash
+    /// normalization.
     ///
-    /// The local backend passes the key through unchanged; the S3 backend
-    /// prepends the configured key prefix (slash-trimmed) via
-    /// [`join_key_prefix`].
-    #[must_use]
-    pub fn object_key(&self, key: &str) -> String {
+    /// The local backend slash-trims the key; the S3 backend prepends the
+    /// configured key prefix (both ends slash-trimmed) via [`join_key_prefix`].
+    /// Every method that needs the stored key ([`Self::object_key`],
+    /// [`Self::storage_uri`], [`Self::persist_file_with_content_type`], and
+    /// [`Self::remove_object_if_present`]) routes through this one helper, so
+    /// they can never diverge on prefix or slash handling.
+    fn resolved_key(&self, key: &str) -> String {
         match self {
-            Self::Local { .. } => key.to_owned(),
+            Self::Local { .. } => key.trim_matches('/').to_owned(),
             Self::S3(config) => join_key_prefix(&config.key_prefix, key),
         }
+    }
+
+    /// Resolve the caller-relative key into the backend's stored object key.
+    ///
+    /// The local backend slash-trims the key; the S3 backend prepends the
+    /// configured key prefix (slash-trimmed). This is the same resolution used
+    /// by [`Self::persist_file`], [`Self::storage_uri`], and
+    /// [`Self::remove_object_if_present`], so the key advertised here is exactly
+    /// the key those methods store, address, and delete.
+    #[must_use]
+    pub fn object_key(&self, key: &str) -> String {
+        self.resolved_key(key)
     }
 
     /// The public URL a browser fetches the object at — the backend's public
     /// base joined with the caller key.
     ///
-    /// The key's path segments are percent-encoded (preserving `/`
-    /// separators) so a caller key containing URL-reserved characters (e.g.
-    /// `#`, `?`, space) addresses exactly the stored object rather than being
-    /// reinterpreted as a fragment/query by the browser.
+    /// The caller key is slash-trimmed first (identically to the stored key —
+    /// see [`Self::resolved_key`] / [`join_key_prefix`]) so a trailing slash can
+    /// never advertise a URL (`…/clips/a.mp4/`) that differs from the object
+    /// actually stored (`…/clips/a.mp4`). The key's path segments are then
+    /// percent-encoded (preserving `/` separators) so a caller key containing
+    /// URL-reserved characters (e.g. `#`, `?`, space) addresses exactly the
+    /// stored object rather than being reinterpreted as a fragment/query by the
+    /// browser.
+    ///
+    /// The S3 public base already embeds the key prefix (see
+    /// [`default_tigris_public_base`]), so this joins the base with the
+    /// caller-relative key and — unlike the stored key — does **not** re-apply
+    /// the prefix here.
     #[must_use]
     pub fn public_url(&self, key: &str) -> String {
-        let encoded = encode_key_for_url(key);
+        let encoded = encode_key_for_url(key.trim_matches('/'));
         match self {
             Self::Local {
                 public_base_url, ..
@@ -245,31 +270,53 @@ impl MediaStorage {
     }
 
     /// The stored object URI: the on-disk path for the local backend, or an
-    /// `s3://{bucket}/{key}` URI for the S3 backend.
+    /// `s3://{bucket}/{stored_key}` URI for the S3 backend.
     ///
-    /// The S3 form uses the *stored* object key ([`Self::object_key`]).
+    /// The S3 form embeds the fully-resolved stored key ([`Self::resolved_key`],
+    /// prefix-inclusive) — the same key [`Self::persist_file`] uploads to and
+    /// [`Self::parse_s3_uri_key`] round-trips back into a caller-relative key.
     #[must_use]
     pub fn storage_uri(&self, key: &str, local_path: &Path) -> String {
         match self {
             Self::Local { .. } => local_path.display().to_string(),
-            Self::S3(config) => format!("s3://{}/{}", config.bucket, self.object_key(key)),
+            Self::S3(config) => format!("s3://{}/{}", config.bucket, self.resolved_key(key)),
         }
     }
 
-    /// Extract the object key from an `s3://{bucket}/{key}` URI.
+    /// Extract the **caller-relative** object key from an `s3://{bucket}/{key}`
+    /// URI (e.g. one produced by [`Self::storage_uri`]).
     ///
-    /// The generalized form of Arroyo's `highlight_storage_object_key`: returns
-    /// `Some(key)` only for a well-formed S3 URI with a non-empty key; a local
-    /// path, a non-`s3://` URI, or a degenerate URI returns `None`, so callers
+    /// The generalized form of Arroyo's `highlight_storage_object_key`, but with
+    /// a load-bearing difference: the stored key embedded in the URI is
+    /// prefix-**inclusive** (`{key_prefix}/{caller_key}`), whereas this crate's
+    /// public methods ([`Self::persist_file`], [`Self::remove_object_if_present`],
+    /// [`Self::public_url`]) take a caller-**relative** key and apply the prefix
+    /// internally. This method therefore strips the configured `key_prefix` back
+    /// off, so a key round-tripped through the URI can be handed straight to
+    /// [`Self::remove_object_if_present`] and delete the **same** object
+    /// [`Self::persist_file`] created — never a double-prefixed
+    /// `{key_prefix}/{key_prefix}/…` that would target the wrong object and leak
+    /// the real one.
+    ///
+    /// Returns `Some(key)` only for a well-formed S3 URI whose key is non-empty
+    /// after prefix stripping; a local path, a non-`s3://` URI, a degenerate
+    /// URI, or a key that is nothing but the prefix returns `None`, so callers
     /// never issue a delete against an empty key.
     #[must_use]
-    pub fn parse_s3_uri_key(uri: &str) -> Option<String> {
+    pub fn parse_s3_uri_key(&self, uri: &str) -> Option<String> {
         let rest = uri.strip_prefix("s3://")?;
-        let (_bucket, key) = rest.split_once('/')?;
-        if key.is_empty() {
+        let (_bucket, stored_key) = rest.split_once('/')?;
+        if stored_key.is_empty() {
             return None;
         }
-        Some(key.to_owned())
+        let relative = match self {
+            Self::Local { .. } => stored_key.trim_matches('/').to_owned(),
+            Self::S3(config) => strip_key_prefix(&config.key_prefix, stored_key),
+        };
+        if relative.is_empty() {
+            return None;
+        }
+        Some(relative)
     }
 
     /// Persist a completed local file under `key`, defaulting the content type
@@ -311,7 +358,7 @@ impl MediaStorage {
                 uri: self.storage_uri(key, local_path),
             }),
             Self::S3(config) => {
-                let stored_key = join_key_prefix(&config.key_prefix, key);
+                let stored_key = self.resolved_key(key);
                 let body = ByteStream::from_path(local_path).await.map_err(|error| {
                     MediaError::LocalRead {
                         path: local_path.display().to_string(),
@@ -341,7 +388,13 @@ impl MediaStorage {
         }
     }
 
-    /// Best-effort delete of a stored object by caller key.
+    /// Best-effort delete of a stored object by **caller-relative** key.
+    ///
+    /// The key is resolved the same way [`Self::persist_file`] resolves it (via
+    /// [`Self::resolved_key`] — prefix applied exactly once), so passing the
+    /// same caller key you persisted deletes exactly that object. A key obtained
+    /// from [`Self::parse_s3_uri_key`] is already caller-relative, so it too can
+    /// be passed here directly without double-prefixing.
     ///
     /// The local backend is a no-op (the caller manages the staged file). The
     /// S3 backend issues a `DeleteObject`; S3 returns success for both existing
@@ -355,7 +408,7 @@ impl MediaStorage {
         match self {
             Self::Local { .. } => Ok(()),
             Self::S3(config) => {
-                let stored_key = join_key_prefix(&config.key_prefix, key);
+                let stored_key = self.resolved_key(key);
                 let client = self.build_client().await;
                 client
                     .delete_object()
@@ -469,6 +522,33 @@ pub fn join_key_prefix(prefix: &str, key: &str) -> String {
     } else {
         format!("{prefix}/{key}")
     }
+}
+
+/// The inverse of [`join_key_prefix`]: strip a leading `{prefix}/` from a stored
+/// object key, yielding the caller-relative key. Both ends are slash-trimmed.
+///
+/// The prefix is only stripped on a path-segment boundary — a stored key of
+/// `media-extra/x` is **not** stripped by the prefix `media` — so a coincidental
+/// textual prefix can never corrupt the returned key. An empty prefix, or a key
+/// that does not carry the prefix, returns the slash-trimmed key unchanged.
+#[must_use]
+pub fn strip_key_prefix(prefix: &str, stored_key: &str) -> String {
+    let prefix = prefix.trim_matches('/');
+    let stored_key = stored_key.trim_matches('/');
+    if prefix.is_empty() {
+        return stored_key.to_owned();
+    }
+    if let Some(rest) = stored_key.strip_prefix(prefix) {
+        // Only a boundary match counts: `rest` is empty (key == prefix) or the
+        // next char is the `/` separator.
+        if rest.is_empty() {
+            return String::new();
+        }
+        if let Some(after) = rest.strip_prefix('/') {
+            return after.trim_matches('/').to_owned();
+        }
+    }
+    stored_key.to_owned()
 }
 
 /// Percent-encode each path segment of a storage key for safe inclusion in a
@@ -760,30 +840,157 @@ mod tests {
     // ── parse_s3_uri_key ─────────────────────────────────────────────────────
 
     #[test]
-    fn parse_s3_uri_key_valid() {
+    fn parse_s3_uri_key_strips_prefix_to_caller_relative() {
+        // The stored key embedded in the URI is prefix-inclusive; parse strips
+        // the configured `key_prefix` ("media") back off so the returned key is
+        // caller-relative and safe to re-feed to remove_object_if_present.
+        let storage = MediaStorage::from_config(&s3_config(Some("bucket"))).unwrap();
         assert_eq!(
-            MediaStorage::parse_s3_uri_key("s3://bucket/media/clips/1.mp4"),
-            Some("media/clips/1.mp4".to_owned())
+            storage.parse_s3_uri_key("s3://bucket/media/clips/1.mp4"),
+            Some("clips/1.mp4".to_owned())
         );
     }
 
     #[test]
-    fn parse_s3_uri_key_nested() {
+    fn parse_s3_uri_key_empty_prefix_returns_full_key() {
+        let mut cfg = s3_config(Some("bucket"));
+        cfg.key_prefix = String::new();
+        let storage = MediaStorage::from_config(&cfg).unwrap();
         assert_eq!(
-            MediaStorage::parse_s3_uri_key("s3://bucket/a/b/c.jpg"),
+            storage.parse_s3_uri_key("s3://bucket/a/b/c.jpg"),
             Some("a/b/c.jpg".to_owned())
         );
     }
 
     #[test]
+    fn parse_s3_uri_key_foreign_prefix_left_intact() {
+        // A stored key that does not carry the configured prefix (nor a
+        // coincidental textual match) is returned unchanged.
+        let storage = MediaStorage::from_config(&s3_config(Some("bucket"))).unwrap();
+        assert_eq!(
+            storage.parse_s3_uri_key("s3://bucket/media-extra/x.jpg"),
+            Some("media-extra/x.jpg".to_owned())
+        );
+    }
+
+    #[test]
+    fn parse_s3_uri_key_prefix_only_is_none() {
+        // A URI whose whole key is exactly the prefix has no caller-relative
+        // key, so it is None (callers never delete an empty key).
+        let storage = MediaStorage::from_config(&s3_config(Some("bucket"))).unwrap();
+        assert_eq!(storage.parse_s3_uri_key("s3://bucket/media"), None);
+    }
+
+    #[test]
     fn parse_s3_uri_key_empty_key_is_none() {
-        assert_eq!(MediaStorage::parse_s3_uri_key("s3://bucket/"), None);
+        let storage = MediaStorage::from_config(&s3_config(Some("bucket"))).unwrap();
+        assert_eq!(storage.parse_s3_uri_key("s3://bucket/"), None);
     }
 
     #[test]
     fn parse_s3_uri_key_non_s3_is_none() {
-        assert_eq!(MediaStorage::parse_s3_uri_key("/local/path/1.mp4"), None);
-        assert_eq!(MediaStorage::parse_s3_uri_key("https://x/y"), None);
+        let storage = MediaStorage::from_config(&s3_config(Some("bucket"))).unwrap();
+        assert_eq!(storage.parse_s3_uri_key("/local/path/1.mp4"), None);
+        assert_eq!(storage.parse_s3_uri_key("https://x/y"), None);
+    }
+
+    // ── contract round-trip: persist ⇄ storage_uri ⇄ parse ⇄ remove ──────────
+
+    #[test]
+    fn key_resolution_is_consistent_across_object_key_storage_uri_and_parse() {
+        // With key_prefix = "media", a caller key `clips/a.mp4` must resolve to
+        // `media/clips/a.mp4` EVERYWHERE, and the parse→remove path must target
+        // that same key — never a double-prefixed `media/media/clips/a.mp4`.
+        let storage = MediaStorage::from_config(&s3_config(Some("bucket"))).unwrap();
+        let caller_key = "clips/a.mp4";
+
+        // object_key and the s3:// URI embed the same resolved key.
+        assert_eq!(storage.object_key(caller_key), "media/clips/a.mp4");
+        let uri = storage.storage_uri(caller_key, Path::new("/tmp/staged/a.mp4"));
+        assert_eq!(uri, "s3://bucket/media/clips/a.mp4");
+
+        // Parsing the URI yields the ORIGINAL caller-relative key back.
+        let parsed = storage.parse_s3_uri_key(&uri).unwrap();
+        assert_eq!(parsed, caller_key);
+
+        // Re-resolving the parsed key targets the SAME object (no double prefix).
+        assert_eq!(storage.object_key(&parsed), "media/clips/a.mp4");
+        assert_ne!(storage.object_key(&parsed), "media/media/clips/a.mp4");
+    }
+
+    #[test]
+    fn key_resolution_round_trips_with_empty_prefix() {
+        let mut cfg = s3_config(Some("bucket"));
+        cfg.key_prefix = String::new();
+        let storage = MediaStorage::from_config(&cfg).unwrap();
+        let caller_key = "clips/a.mp4";
+        let uri = storage.storage_uri(caller_key, Path::new("/tmp/a.mp4"));
+        assert_eq!(uri, "s3://bucket/clips/a.mp4");
+        assert_eq!(storage.parse_s3_uri_key(&uri).as_deref(), Some(caller_key));
+    }
+
+    #[test]
+    fn public_url_and_stored_key_agree_on_trailing_slash() {
+        // A caller key with a trailing slash must be advertised at the SAME URL
+        // the stored key resolves to — never `…/clips/a.mp4/` (a 404) while the
+        // object is stored at `…/clips/a.mp4`.
+        let mut cfg = s3_config(Some("bucket"));
+        cfg.public_base_url = Some("https://cdn.example.com/media/".to_owned());
+        let storage = MediaStorage::from_config(&cfg).unwrap();
+        // Stored key trims the trailing slash.
+        assert_eq!(storage.object_key("clips/a.mp4/"), "media/clips/a.mp4");
+        // Public URL trims it identically — no advertised trailing slash.
+        assert_eq!(
+            storage.public_url("clips/a.mp4/"),
+            "https://cdn.example.com/media/clips/a.mp4"
+        );
+        // And a leading slash is handled the same way.
+        assert_eq!(
+            storage.public_url("/clips/a.mp4/"),
+            "https://cdn.example.com/media/clips/a.mp4"
+        );
+    }
+
+    #[test]
+    fn public_url_local_trailing_slash_matches_object_key() {
+        let storage = MediaStorage::Local {
+            root: PathBuf::from("media"),
+            public_base_url: "/media".to_owned(),
+        };
+        assert_eq!(storage.object_key("clips/a.mp4/"), "clips/a.mp4");
+        assert_eq!(storage.public_url("clips/a.mp4/"), "/media/clips/a.mp4");
+    }
+
+    // ── strip_key_prefix ─────────────────────────────────────────────────────
+
+    #[test]
+    fn strip_key_prefix_removes_boundary_prefix() {
+        assert_eq!(
+            strip_key_prefix("media", "media/clips/1.mp4"),
+            "clips/1.mp4"
+        );
+        assert_eq!(
+            strip_key_prefix("/media/", "media/clips/1.mp4"),
+            "clips/1.mp4"
+        );
+    }
+
+    #[test]
+    fn strip_key_prefix_leaves_non_boundary_and_foreign_keys() {
+        // Coincidental textual prefix is not a path boundary.
+        assert_eq!(strip_key_prefix("media", "media-extra/x"), "media-extra/x");
+        // Foreign key without the prefix is unchanged.
+        assert_eq!(strip_key_prefix("media", "other/x"), "other/x");
+    }
+
+    #[test]
+    fn strip_key_prefix_empty_prefix_trims_only() {
+        assert_eq!(strip_key_prefix("", "/clips/1.mp4/"), "clips/1.mp4");
+    }
+
+    #[test]
+    fn strip_key_prefix_key_equal_to_prefix_is_empty() {
+        assert_eq!(strip_key_prefix("media", "media"), "");
     }
 
     // ── from_config ──────────────────────────────────────────────────────────

--- a/autumn-media-plugin/src/storage.rs
+++ b/autumn-media-plugin/src/storage.rs
@@ -44,10 +44,6 @@ pub const DEFAULT_CONTENT_TYPE: &str = "video/mp4";
 /// specify one.
 const DEFAULT_LOCAL_PUBLIC_BASE: &str = "/media";
 
-/// Region used when the S3 config leaves the region blank (matches the Arroyo /
-/// Tigris `auto` default).
-const DEFAULT_S3_REGION: &str = "auto";
-
 /// The location a completed media object was persisted to.
 ///
 /// The generalized form of Arroyo's `StoredVideo`: `backend` is `"local"` or
@@ -73,8 +69,12 @@ pub struct S3MediaStorage {
     pub bucket: String,
     /// Endpoint URL. `None` uses the AWS SDK default endpoint.
     pub endpoint_url: Option<String>,
-    /// Region (e.g. `auto` for Tigris).
-    pub region: String,
+    /// Region, when explicitly configured (e.g. `auto` for Tigris). `None`
+    /// leaves region resolution to the ambient AWS chain (`AWS_REGION`, the
+    /// shared config/profile, IMDS) — the correct behaviour for a generic AWS
+    /// S3 deployment on the SDK default endpoint, where forcing `auto` would
+    /// break signing/resolution.
+    pub region: Option<String>,
     /// Access key id. Empty together with `secret_access_key` selects the
     /// ambient AWS credential chain.
     pub access_key_id: String,
@@ -143,12 +143,14 @@ pub enum MediaStorage {
 impl MediaStorage {
     /// Build a [`MediaStorage`] from a resolved [`MediaStorageConfig`].
     ///
-    /// Defaults applied here: a blank S3 region becomes `auto`; an unset S3
-    /// public base is derived from the bucket + key prefix via the Tigris
-    /// convention ([`default_tigris_public_base`]); an unset local public base
-    /// becomes `/media`. An unset S3 endpoint stays `None` (the SDK default) —
-    /// no Tigris endpoint is hard-coded generically here (the
-    /// `from_arroyo_env` shim is where the Tigris endpoint default lives).
+    /// Defaults applied here: a blank S3 region stays `None` (ambient AWS
+    /// resolution — no generic `auto` default; the Tigris `auto` region is set
+    /// by the `from_arroyo_env` shim); an unset S3 public base is derived from
+    /// the bucket + key prefix via the Tigris convention
+    /// ([`default_tigris_public_base`]); an unset local public base becomes
+    /// `/media`. An unset S3 endpoint stays `None` (the SDK default) — no Tigris
+    /// endpoint is hard-coded generically here (the `from_arroyo_env` shim is
+    /// where the Tigris endpoint default lives).
     ///
     /// # Errors
     ///
@@ -179,9 +181,12 @@ impl MediaStorage {
                     return Err(MediaError::PartialS3Credentials);
                 }
 
-                let region = non_empty(cfg.region.as_deref())
-                    .unwrap_or(DEFAULT_S3_REGION)
-                    .to_owned();
+                // Region is threaded through only when explicitly configured;
+                // an unset region stays `None` so the ambient AWS chain resolves
+                // it. No generic `auto` default here — that value is
+                // Tigris/arroyo-specific and is applied by the `from_arroyo_env`
+                // shim, not this generic path.
+                let region = non_empty(cfg.region.as_deref()).map(ToOwned::to_owned);
                 let key_prefix = cfg.key_prefix.trim_matches('/').to_owned();
                 let public_base_url = non_empty(cfg.public_base_url.as_deref()).map_or_else(
                     || default_tigris_public_base(&bucket, &key_prefix),
@@ -298,20 +303,35 @@ impl MediaStorage {
     /// `{key_prefix}/{key_prefix}/…` that would target the wrong object and leak
     /// the real one.
     ///
-    /// Returns `Some(key)` only for a well-formed S3 URI whose key is non-empty
-    /// after prefix stripping; a local path, a non-`s3://` URI, a degenerate
-    /// URI, or a key that is nothing but the prefix returns `None`, so callers
-    /// never issue a delete against an empty key.
+    /// For the S3 backend the URI's bucket must match the currently-configured
+    /// bucket: a URI from a **different** bucket (a legacy record, or one written
+    /// before `media.storage.bucket` was changed) returns `None`. Otherwise the
+    /// caller-relative key handed back would target the wrong bucket and, fed to
+    /// [`Self::remove_object_if_present`], delete an unrelated object out of the
+    /// currently-configured bucket.
+    ///
+    /// Returns `Some(key)` only for a well-formed S3 URI in this backend's bucket
+    /// whose key is non-empty after prefix stripping; a local path, a non-`s3://`
+    /// URI, a degenerate URI, a foreign-bucket URI, or a key that is nothing but
+    /// the prefix returns `None`, so callers never issue a delete against an empty
+    /// key or the wrong bucket.
     #[must_use]
     pub fn parse_s3_uri_key(&self, uri: &str) -> Option<String> {
         let rest = uri.strip_prefix("s3://")?;
-        let (_bucket, stored_key) = rest.split_once('/')?;
+        let (bucket, stored_key) = rest.split_once('/')?;
         if stored_key.is_empty() {
             return None;
         }
         let relative = match self {
             Self::Local { .. } => stored_key.trim_matches('/').to_owned(),
-            Self::S3(config) => strip_key_prefix(&config.key_prefix, stored_key),
+            Self::S3(config) => {
+                // Refuse a key from a different bucket — deleting it against the
+                // configured bucket would hit an unrelated object.
+                if bucket != config.bucket {
+                    return None;
+                }
+                strip_key_prefix(&config.key_prefix, stored_key)
+            }
         };
         if relative.is_empty() {
             return None;
@@ -459,6 +479,12 @@ impl MediaStorage {
         config
             .client
             .get_or_init(|| async {
+                // Only an explicitly-configured region is threaded in; when
+                // unset, region is resolved from the ambient AWS chain instead
+                // of being forced to a Tigris-specific `auto` that would break a
+                // generic AWS S3 deployment.
+                let explicit_region = non_empty(config.region.as_deref())
+                    .map(|region| Region::new(region.to_owned()));
                 if !config.access_key_id.is_empty() && !config.secret_access_key.is_empty() {
                     let credentials = Credentials::new(
                         config.access_key_id.clone(),
@@ -467,20 +493,39 @@ impl MediaStorage {
                         None,
                         "autumn-media-plugin",
                     );
+                    // Static-credential path builds the S3 config directly, so
+                    // there is no ambient loader to supply a region. Use the
+                    // explicit region when set (e.g. Tigris `auto`), otherwise
+                    // resolve it from the ambient default chain so a generic AWS
+                    // deployment with static keys + `AWS_REGION`/profile works.
+                    let region = match explicit_region {
+                        Some(region) => Some(region),
+                        None => aws_config::defaults(BehaviorVersion::latest())
+                            .load()
+                            .await
+                            .region()
+                            .cloned(),
+                    };
                     let mut builder = aws_sdk_s3::Config::builder()
                         .behavior_version(BehaviorVersion::latest())
-                        .region(Region::new(config.region.clone()))
                         .credentials_provider(credentials)
                         .force_path_style(config.force_path_style);
+                    if let Some(region) = region {
+                        builder = builder.region(region);
+                    }
                     if let Some(endpoint) = &config.endpoint_url {
                         builder = builder.endpoint_url(endpoint);
                     }
                     Client::from_conf(builder.build())
                 } else {
-                    let shared = aws_config::defaults(BehaviorVersion::latest())
-                        .region(Region::new(config.region.clone()))
-                        .load()
-                        .await;
+                    // Ambient-credential path: the default loader already carries
+                    // the ambient region chain, so only override it when a region
+                    // is explicitly configured.
+                    let mut loader = aws_config::defaults(BehaviorVersion::latest());
+                    if let Some(region) = explicit_region {
+                        loader = loader.region(region);
+                    }
+                    let shared = loader.load().await;
                     let mut builder = aws_sdk_s3::config::Builder::from(&shared)
                         .force_path_style(config.force_path_style);
                     if let Some(endpoint) = &config.endpoint_url {
@@ -874,6 +919,23 @@ mod tests {
     }
 
     #[test]
+    fn parse_s3_uri_key_foreign_bucket_is_none() {
+        // A URI naming a DIFFERENT bucket must not yield a key: handing it to
+        // remove_object_if_present would delete an unrelated object out of the
+        // currently-configured bucket.
+        let storage = MediaStorage::from_config(&s3_config(Some("bucket"))).unwrap();
+        assert_eq!(
+            storage.parse_s3_uri_key("s3://other-bucket/media/clips/1.mp4"),
+            None
+        );
+        // The matching-bucket URI still round-trips to the caller-relative key.
+        assert_eq!(
+            storage.parse_s3_uri_key("s3://bucket/media/clips/1.mp4"),
+            Some("clips/1.mp4".to_owned())
+        );
+    }
+
+    #[test]
     fn parse_s3_uri_key_prefix_only_is_none() {
         // A URI whose whole key is exactly the prefix has no caller-relative
         // key, so it is None (callers never delete an empty key).
@@ -1017,13 +1079,14 @@ mod tests {
     }
 
     #[test]
-    fn from_config_s3_with_bucket_defaults_region_and_tigris_base() {
+    fn from_config_s3_with_bucket_no_region_and_tigris_base() {
         let storage = MediaStorage::from_config(&s3_config(Some("my-bucket"))).unwrap();
         match storage {
             MediaStorage::S3(config) => {
                 assert_eq!(config.bucket, "my-bucket");
-                // blank region → "auto"
-                assert_eq!(config.region, DEFAULT_S3_REGION);
+                // blank region stays None on the generic path (ambient-resolved);
+                // no `auto` default here — that is Tigris/arroyo-only.
+                assert_eq!(config.region, None);
                 // unset endpoint stays None (SDK default)
                 assert_eq!(config.endpoint_url, None);
                 // unset public base → tigris fallback using the "media" prefix
@@ -1045,12 +1108,37 @@ mod tests {
         let MediaStorage::S3(config) = MediaStorage::from_config(&cfg).unwrap() else {
             panic!("expected s3 backend");
         };
-        assert_eq!(config.region, "us-east-1");
+        assert_eq!(config.region.as_deref(), Some("us-east-1"));
         assert_eq!(
             config.endpoint_url.as_deref(),
             Some("https://example.r2.cloudflarestorage.com")
         );
         assert_eq!(config.public_base_url, "https://cdn.example.com");
+    }
+
+    #[test]
+    fn from_config_s3_no_region_yields_none() {
+        // The generic S3 path leaves region unset (`None`) so the ambient AWS
+        // chain (AWS_REGION / profile / IMDS) resolves it — a generic AWS
+        // deployment on the SDK default endpoint is not signed for `auto`.
+        let MediaStorage::S3(config) = MediaStorage::from_config(&s3_config(Some("b"))).unwrap()
+        else {
+            panic!("expected s3 backend");
+        };
+        assert_eq!(config.region, None);
+    }
+
+    #[test]
+    fn from_config_s3_threads_explicit_auto_region() {
+        // The arroyo/Tigris shim resolves region to `auto` in the config; a
+        // `Some("auto")` region must be threaded through verbatim (only the
+        // no-region generic path yields `None`).
+        let mut cfg = s3_config(Some("b"));
+        cfg.region = Some("auto".to_owned());
+        let MediaStorage::S3(config) = MediaStorage::from_config(&cfg).unwrap() else {
+            panic!("expected s3 backend");
+        };
+        assert_eq!(config.region.as_deref(), Some("auto"));
     }
 
     #[test]
@@ -1177,5 +1265,21 @@ mod tests {
         let storage = MediaStorage::from_config(&cfg).unwrap();
         // Should return a constructed client; nothing here reaches the network.
         let _client = storage.build_client().await;
+    }
+
+    #[tokio::test]
+    async fn build_client_threads_explicit_region_into_client() {
+        // An explicitly-configured region must be threaded into the built S3
+        // client's config (e.g. Tigris `auto`, or a real AWS region).
+        let mut cfg = s3_config(Some("test-bucket"));
+        cfg.region = Some("eu-west-2".to_owned());
+        cfg.endpoint_url = Some("http://127.0.0.1:9".to_owned());
+        cfg.force_path_style = true;
+        let storage = MediaStorage::from_config(&cfg).unwrap();
+        let client = storage.build_client().await;
+        assert_eq!(
+            client.config().region().map(Region::as_ref),
+            Some("eu-west-2")
+        );
     }
 }

--- a/autumn-media-plugin/src/storage.rs
+++ b/autumn-media-plugin/src/storage.rs
@@ -1,0 +1,750 @@
+//! [`MediaStorage`] — a completed-media object store with **caller-supplied**
+//! keys.
+//!
+//! This is a generalization of Arroyo's `VideoStorageConfig` (`src/media.rs`):
+//! Arroyo hard-coded a fixed set of key namespaces (`highlights/`, `clips/`,
+//! `thumbnails/`, `previews/`, `channel-avatars/`, `channel-emotes/`,
+//! `avatars/`) into the storage type itself. Here the namespace lives with the
+//! *caller* — every method takes the already-finished object key — so a
+//! downstream app (or a later encode slice) decides its own layout while this
+//! type only owns backend selection, key-prefix/URL joining, and the S3
+//! upload/delete plumbing.
+//!
+//! It deliberately does **not** reuse `autumn-storage-s3`'s `BlobStore`: that
+//! trait produces presigned/expiring URLs, validates/rejects arbitrary keys,
+//! and models credentials as env-var *names*. Media objects need permanent,
+//! public URLs under app-chosen keys. The aws-sdk client-builder idiom (and the
+//! exact aws-* dependency pins) are copied from `autumn-storage-s3`, but the
+//! surface is bespoke.
+//!
+//! The two backends:
+//! - [`MediaStorage::Local`] keeps objects on the local filesystem and records
+//!   the on-disk path as the object URI. Persist is a no-op record and delete
+//!   is a no-op (the caller manages the staged file lifecycle).
+//! - [`MediaStorage::S3`] uploads to any S3-compatible store (AWS S3, Fly
+//!   Tigris, Cloudflare R2, `MinIO`, …) and records the `s3://{bucket}/{key}`
+//!   URI.
+
+use std::path::{Path, PathBuf};
+
+use aws_credential_types::Credentials;
+use aws_sdk_s3::Client;
+use aws_sdk_s3::config::{BehaviorVersion, Region};
+use aws_sdk_s3::primitives::ByteStream;
+use serde::{Deserialize, Serialize};
+
+use crate::config::MediaStorageConfig;
+use crate::error::MediaError;
+
+/// Default content type used by [`MediaStorage::persist_file`] when the caller
+/// does not specify one.
+pub const DEFAULT_CONTENT_TYPE: &str = "video/mp4";
+
+/// Neutral public base used by the local backend when the config does not
+/// specify one.
+const DEFAULT_LOCAL_PUBLIC_BASE: &str = "/media";
+
+/// Region used when the S3 config leaves the region blank (matches the Arroyo /
+/// Tigris `auto` default).
+const DEFAULT_S3_REGION: &str = "auto";
+
+/// The location a completed media object was persisted to.
+///
+/// The generalized form of Arroyo's `StoredVideo`: `backend` is `"local"` or
+/// `"s3"`, `key` is the finished object key, and `uri` is the on-disk path
+/// (local) or an `s3://{bucket}/{key}` URI (S3).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StoredObject {
+    /// Backend label — `"local"` or `"s3"`.
+    pub backend: String,
+    /// The finished object key.
+    pub key: String,
+    /// The object URI (local path, or `s3://{bucket}/{key}`).
+    pub uri: String,
+}
+
+/// Resolved S3 storage settings (concrete values, not env-var names).
+///
+/// `secret_access_key` is redacted by the hand-written [`std::fmt::Debug`]
+/// impl, so a `MediaStorage` can be safely logged.
+#[derive(Clone, PartialEq, Eq)]
+pub struct S3MediaStorage {
+    /// Bucket name.
+    pub bucket: String,
+    /// Endpoint URL. `None` uses the AWS SDK default endpoint.
+    pub endpoint_url: Option<String>,
+    /// Region (e.g. `auto` for Tigris).
+    pub region: String,
+    /// Access key id. Empty together with `secret_access_key` selects the
+    /// ambient AWS credential chain.
+    pub access_key_id: String,
+    /// Secret access key (redacted in `Debug`).
+    pub secret_access_key: String,
+    /// Public base URL that stored objects resolve under.
+    pub public_base_url: String,
+    /// Object key prefix (namespace) prepended to caller keys.
+    pub key_prefix: String,
+    /// Whether to force S3 path-style addressing.
+    pub force_path_style: bool,
+}
+
+impl std::fmt::Debug for S3MediaStorage {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("S3MediaStorage")
+            .field("bucket", &self.bucket)
+            .field("endpoint_url", &self.endpoint_url)
+            .field("region", &self.region)
+            .field("access_key_id", &self.access_key_id)
+            .field("secret_access_key", &"** redacted **")
+            .field("public_base_url", &self.public_base_url)
+            .field("key_prefix", &self.key_prefix)
+            .field("force_path_style", &self.force_path_style)
+            .finish()
+    }
+}
+
+/// A completed-media object store with caller-supplied keys.
+#[derive(Clone, Debug)]
+pub enum MediaStorage {
+    /// Keep objects on the local filesystem.
+    Local {
+        /// Filesystem root the backend serves objects from.
+        root: PathBuf,
+        /// Public base URL objects resolve under.
+        public_base_url: String,
+    },
+    /// Upload objects to an S3-compatible object store.
+    S3(S3MediaStorage),
+}
+
+impl MediaStorage {
+    /// Build a [`MediaStorage`] from a resolved [`MediaStorageConfig`].
+    ///
+    /// Defaults applied here: a blank S3 region becomes `auto`; an unset S3
+    /// public base is derived from the bucket + key prefix via the Tigris
+    /// convention ([`default_tigris_public_base`]); an unset local public base
+    /// becomes `/media`. An unset S3 endpoint stays `None` (the SDK default) —
+    /// no Tigris endpoint is hard-coded generically here (the
+    /// `from_arroyo_env` shim is where the Tigris endpoint default lives).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MediaError::MissingBucket`] when the S3 backend is selected
+    /// without a bucket, and [`MediaError::PartialS3Credentials`] when exactly
+    /// one of the access-key / secret-key pair is set.
+    pub fn from_config(cfg: &MediaStorageConfig) -> Result<Self, MediaError> {
+        use crate::config::MediaStorageBackend;
+
+        match cfg.backend {
+            MediaStorageBackend::Local => {
+                let public_base_url = non_empty(cfg.public_base_url.as_deref())
+                    .unwrap_or(DEFAULT_LOCAL_PUBLIC_BASE)
+                    .to_owned();
+                Ok(Self::Local {
+                    root: PathBuf::from(&cfg.root),
+                    public_base_url,
+                })
+            }
+            MediaStorageBackend::S3 => {
+                let bucket = non_empty(cfg.bucket.as_deref())
+                    .ok_or(MediaError::MissingBucket)?
+                    .to_owned();
+
+                let access_key_id = non_empty(cfg.access_key_id.as_deref());
+                let secret_access_key = non_empty(cfg.secret_access_key.as_deref());
+                if access_key_id.is_some() != secret_access_key.is_some() {
+                    return Err(MediaError::PartialS3Credentials);
+                }
+
+                let region = non_empty(cfg.region.as_deref())
+                    .unwrap_or(DEFAULT_S3_REGION)
+                    .to_owned();
+                let key_prefix = cfg.key_prefix.trim_matches('/').to_owned();
+                let public_base_url = non_empty(cfg.public_base_url.as_deref()).map_or_else(
+                    || default_tigris_public_base(&bucket, &key_prefix),
+                    ToOwned::to_owned,
+                );
+
+                Ok(Self::S3(S3MediaStorage {
+                    bucket,
+                    endpoint_url: non_empty(cfg.endpoint_url.as_deref()).map(ToOwned::to_owned),
+                    region,
+                    access_key_id: access_key_id.unwrap_or_default().to_owned(),
+                    secret_access_key: secret_access_key.unwrap_or_default().to_owned(),
+                    public_base_url,
+                    key_prefix,
+                    force_path_style: cfg.force_path_style,
+                }))
+            }
+        }
+    }
+
+    /// Stable backend label — `"local"` or `"s3"`.
+    #[must_use]
+    pub const fn backend_name(&self) -> &'static str {
+        match self {
+            Self::Local { .. } => "local",
+            Self::S3(_) => "s3",
+        }
+    }
+
+    /// Resolve the caller key into the backend's stored object key.
+    ///
+    /// The local backend passes the key through unchanged; the S3 backend
+    /// prepends the configured key prefix (slash-trimmed) via
+    /// [`join_key_prefix`].
+    #[must_use]
+    pub fn object_key(&self, key: &str) -> String {
+        match self {
+            Self::Local { .. } => key.to_owned(),
+            Self::S3(config) => join_key_prefix(&config.key_prefix, key),
+        }
+    }
+
+    /// The public URL a browser fetches the object at — the backend's public
+    /// base joined with the caller key.
+    #[must_use]
+    pub fn public_url(&self, key: &str) -> String {
+        match self {
+            Self::Local {
+                public_base_url, ..
+            } => join_url(public_base_url, key),
+            Self::S3(config) => join_url(&config.public_base_url, key),
+        }
+    }
+
+    /// The stored object URI: the on-disk path for the local backend, or an
+    /// `s3://{bucket}/{key}` URI for the S3 backend.
+    ///
+    /// The S3 form uses the *stored* object key ([`Self::object_key`]).
+    #[must_use]
+    pub fn storage_uri(&self, key: &str, local_path: &Path) -> String {
+        match self {
+            Self::Local { .. } => local_path.display().to_string(),
+            Self::S3(config) => format!("s3://{}/{}", config.bucket, self.object_key(key)),
+        }
+    }
+
+    /// Extract the object key from an `s3://{bucket}/{key}` URI.
+    ///
+    /// The generalized form of Arroyo's `highlight_storage_object_key`: returns
+    /// `Some(key)` only for a well-formed S3 URI with a non-empty key; a local
+    /// path, a non-`s3://` URI, or a degenerate URI returns `None`, so callers
+    /// never issue a delete against an empty key.
+    #[must_use]
+    pub fn parse_s3_uri_key(uri: &str) -> Option<String> {
+        let rest = uri.strip_prefix("s3://")?;
+        let (_bucket, key) = rest.split_once('/')?;
+        if key.is_empty() {
+            return None;
+        }
+        Some(key.to_owned())
+    }
+
+    /// Persist a completed local file under `key`, defaulting the content type
+    /// to [`DEFAULT_CONTENT_TYPE`] (`video/mp4`).
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::persist_file_with_content_type`].
+    pub async fn persist_file(
+        &self,
+        key: &str,
+        local_path: &Path,
+    ) -> Result<StoredObject, MediaError> {
+        self.persist_file_with_content_type(key, local_path, DEFAULT_CONTENT_TYPE)
+            .await
+    }
+
+    /// Persist a completed local file under `key` with an explicit content
+    /// type.
+    ///
+    /// The local backend records the on-disk path without copying (the caller
+    /// owns the staged file); the S3 backend streams the file to
+    /// `s3://{bucket}/{stored_key}`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MediaError::LocalRead`] when the staged file cannot be read
+    /// for upload, and [`MediaError::S3Upload`] when the remote upload fails.
+    pub async fn persist_file_with_content_type(
+        &self,
+        key: &str,
+        local_path: &Path,
+        content_type: &str,
+    ) -> Result<StoredObject, MediaError> {
+        match self {
+            Self::Local { .. } => Ok(StoredObject {
+                backend: self.backend_name().to_owned(),
+                key: key.to_owned(),
+                uri: self.storage_uri(key, local_path),
+            }),
+            Self::S3(config) => {
+                let stored_key = join_key_prefix(&config.key_prefix, key);
+                let body = ByteStream::from_path(local_path).await.map_err(|error| {
+                    MediaError::LocalRead {
+                        path: local_path.display().to_string(),
+                        source: std::io::Error::other(error.to_string()),
+                    }
+                })?;
+                let client = self.build_client().await;
+                client
+                    .put_object()
+                    .bucket(&config.bucket)
+                    .key(&stored_key)
+                    .content_type(content_type)
+                    .body(body)
+                    .send()
+                    .await
+                    .map_err(|error| MediaError::S3Upload {
+                        bucket: config.bucket.clone(),
+                        key: stored_key.clone(),
+                        message: error.to_string(),
+                    })?;
+                Ok(StoredObject {
+                    backend: self.backend_name().to_owned(),
+                    key: key.to_owned(),
+                    uri: self.storage_uri(key, local_path),
+                })
+            }
+        }
+    }
+
+    /// Best-effort delete of a stored object by caller key.
+    ///
+    /// The local backend is a no-op (the caller manages the staged file). The
+    /// S3 backend issues a `DeleteObject`; S3 returns success for both existing
+    /// and missing keys, so this is idempotent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MediaError::S3Delete`] when the S3 `DeleteObject` request
+    /// fails.
+    pub async fn remove_object_if_present(&self, key: &str) -> Result<(), MediaError> {
+        match self {
+            Self::Local { .. } => Ok(()),
+            Self::S3(config) => {
+                let stored_key = join_key_prefix(&config.key_prefix, key);
+                let client = self.build_client().await;
+                client
+                    .delete_object()
+                    .bucket(&config.bucket)
+                    .key(&stored_key)
+                    .send()
+                    .await
+                    .map_err(|error| MediaError::S3Delete {
+                        bucket: config.bucket.clone(),
+                        key: stored_key.clone(),
+                        message: error.to_string(),
+                    })?;
+                Ok(())
+            }
+        }
+    }
+
+    /// Build a fresh aws-sdk-s3 client for the S3 backend.
+    ///
+    /// A new client is built per operation (matching Arroyo), so it does not
+    /// need to be cached on the enum. The endpoint is set **only when
+    /// configured** (an improvement over Arroyo's always-set endpoint, borrowed
+    /// from `autumn-storage-s3`): an unset endpoint leaves the SDK default in
+    /// place. When both credentials are present they are used as hard-coded
+    /// `SigV4` credentials; otherwise the ambient AWS credential chain is loaded.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called on the local backend (callers only reach this from the
+    /// S3 arms of the persist/delete methods).
+    async fn build_client(&self) -> Client {
+        let Self::S3(config) = self else {
+            unreachable!("build_client is only called for the S3 backend");
+        };
+
+        if !config.access_key_id.is_empty() && !config.secret_access_key.is_empty() {
+            let credentials = Credentials::new(
+                config.access_key_id.clone(),
+                config.secret_access_key.clone(),
+                None,
+                None,
+                "autumn-media-plugin",
+            );
+            let mut builder = aws_sdk_s3::Config::builder()
+                .behavior_version(BehaviorVersion::latest())
+                .region(Region::new(config.region.clone()))
+                .credentials_provider(credentials)
+                .force_path_style(config.force_path_style);
+            if let Some(endpoint) = &config.endpoint_url {
+                builder = builder.endpoint_url(endpoint);
+            }
+            Client::from_conf(builder.build())
+        } else {
+            let shared = aws_config::defaults(BehaviorVersion::latest())
+                .region(Region::new(config.region.clone()))
+                .load()
+                .await;
+            let mut builder = aws_sdk_s3::config::Builder::from(&shared)
+                .force_path_style(config.force_path_style);
+            if let Some(endpoint) = &config.endpoint_url {
+                builder = builder.endpoint_url(endpoint);
+            }
+            Client::from_conf(builder.build())
+        }
+    }
+}
+
+// ── Pure helpers ─────────────────────────────────────────────────────────────
+
+/// Return a trimmed, non-empty view of an optional string.
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+/// The default public base URL for a Tigris-hosted bucket + key prefix
+/// (`https://{bucket}.t3.tigrisfiles.io/{prefix}`).
+#[must_use]
+pub fn default_tigris_public_base(bucket: &str, key_prefix: &str) -> String {
+    join_url(
+        &format!("https://{bucket}.t3.tigrisfiles.io"),
+        key_prefix.trim_matches('/'),
+    )
+}
+
+/// Join an object-key prefix and a key, slash-trimming both. An empty prefix
+/// yields the slash-trimmed key alone.
+#[must_use]
+pub fn join_key_prefix(prefix: &str, key: &str) -> String {
+    let prefix = prefix.trim_matches('/');
+    let key = key.trim_matches('/');
+    if prefix.is_empty() {
+        key.to_owned()
+    } else {
+        format!("{prefix}/{key}")
+    }
+}
+
+/// Join a base URL and a path with exactly one separating slash. An empty path
+/// yields the trailing-slash-trimmed base alone.
+#[must_use]
+pub fn join_url(base: &str, path: &str) -> String {
+    let base = base.trim_end_matches('/');
+    let path = path.trim_start_matches('/');
+    if path.is_empty() {
+        base.to_owned()
+    } else {
+        format!("{base}/{path}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{MediaStorageBackend, MediaStorageConfig};
+
+    fn s3_config(bucket: Option<&str>) -> MediaStorageConfig {
+        MediaStorageConfig {
+            backend: MediaStorageBackend::S3,
+            bucket: bucket.map(ToOwned::to_owned),
+            access_key_id: Some("AKIA".to_owned()),
+            secret_access_key: Some("secret".to_owned()),
+            ..MediaStorageConfig::default()
+        }
+    }
+
+    // ── join_url ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn join_url_joins_base_and_path() {
+        assert_eq!(
+            join_url("https://cdn.example.com", "a/b.mp4"),
+            "https://cdn.example.com/a/b.mp4"
+        );
+    }
+
+    #[test]
+    fn join_url_collapses_extra_slashes() {
+        assert_eq!(
+            join_url("https://cdn.example.com/", "/a/b.mp4"),
+            "https://cdn.example.com/a/b.mp4"
+        );
+    }
+
+    #[test]
+    fn join_url_empty_path_returns_trimmed_base() {
+        assert_eq!(
+            join_url("https://cdn.example.com/", ""),
+            "https://cdn.example.com"
+        );
+    }
+
+    // ── join_key_prefix ──────────────────────────────────────────────────────
+
+    #[test]
+    fn join_key_prefix_prepends_prefix() {
+        assert_eq!(join_key_prefix("media", "clips/1.mp4"), "media/clips/1.mp4");
+    }
+
+    #[test]
+    fn join_key_prefix_empty_prefix_trims_key() {
+        assert_eq!(join_key_prefix("", "/clips/1.mp4/"), "clips/1.mp4");
+    }
+
+    #[test]
+    fn join_key_prefix_trims_surrounding_slashes() {
+        assert_eq!(
+            join_key_prefix("/media/", "/clips/1.mp4"),
+            "media/clips/1.mp4"
+        );
+    }
+
+    // ── default_tigris_public_base ───────────────────────────────────────────
+
+    #[test]
+    fn tigris_public_base_uses_bucket_and_prefix() {
+        assert_eq!(
+            default_tigris_public_base("my-bucket", "highlights"),
+            "https://my-bucket.t3.tigrisfiles.io/highlights"
+        );
+    }
+
+    #[test]
+    fn tigris_public_base_empty_prefix_omits_trailing_slash() {
+        assert_eq!(
+            default_tigris_public_base("my-bucket", ""),
+            "https://my-bucket.t3.tigrisfiles.io"
+        );
+    }
+
+    // ── object_key ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn object_key_local_passthrough() {
+        let storage = MediaStorage::Local {
+            root: PathBuf::from("media"),
+            public_base_url: "/media".to_owned(),
+        };
+        assert_eq!(storage.object_key("clips/1.mp4"), "clips/1.mp4");
+    }
+
+    #[test]
+    fn object_key_s3_prefix_join() {
+        let storage = MediaStorage::from_config(&s3_config(Some("b"))).unwrap();
+        // default key_prefix is "media".
+        assert_eq!(storage.object_key("clips/1.mp4"), "media/clips/1.mp4");
+    }
+
+    #[test]
+    fn object_key_s3_empty_prefix() {
+        let mut cfg = s3_config(Some("b"));
+        cfg.key_prefix = String::new();
+        let storage = MediaStorage::from_config(&cfg).unwrap();
+        assert_eq!(storage.object_key("/clips/1.mp4/"), "clips/1.mp4");
+    }
+
+    // ── public_url ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn public_url_local_joins_base() {
+        let storage = MediaStorage::Local {
+            root: PathBuf::from("media"),
+            public_base_url: "/media".to_owned(),
+        };
+        assert_eq!(storage.public_url("clips/1.mp4"), "/media/clips/1.mp4");
+    }
+
+    #[test]
+    fn public_url_s3_joins_public_base() {
+        let mut cfg = s3_config(Some("b"));
+        cfg.public_base_url = Some("https://cdn.example.com/media/".to_owned());
+        let storage = MediaStorage::from_config(&cfg).unwrap();
+        assert_eq!(
+            storage.public_url("/clips/1.mp4"),
+            "https://cdn.example.com/media/clips/1.mp4"
+        );
+    }
+
+    // ── storage_uri ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn storage_uri_local_is_path() {
+        let storage = MediaStorage::Local {
+            root: PathBuf::from("media"),
+            public_base_url: "/media".to_owned(),
+        };
+        assert_eq!(
+            storage.storage_uri("clips/1.mp4", Path::new("/tmp/staged/1.mp4")),
+            "/tmp/staged/1.mp4"
+        );
+    }
+
+    #[test]
+    fn storage_uri_s3_is_s3_uri_with_prefix() {
+        let storage = MediaStorage::from_config(&s3_config(Some("my-bucket"))).unwrap();
+        assert_eq!(
+            storage.storage_uri("clips/1.mp4", Path::new("/tmp/staged/1.mp4")),
+            "s3://my-bucket/media/clips/1.mp4"
+        );
+    }
+
+    // ── parse_s3_uri_key ─────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_s3_uri_key_valid() {
+        assert_eq!(
+            MediaStorage::parse_s3_uri_key("s3://bucket/media/clips/1.mp4"),
+            Some("media/clips/1.mp4".to_owned())
+        );
+    }
+
+    #[test]
+    fn parse_s3_uri_key_nested() {
+        assert_eq!(
+            MediaStorage::parse_s3_uri_key("s3://bucket/a/b/c.jpg"),
+            Some("a/b/c.jpg".to_owned())
+        );
+    }
+
+    #[test]
+    fn parse_s3_uri_key_empty_key_is_none() {
+        assert_eq!(MediaStorage::parse_s3_uri_key("s3://bucket/"), None);
+    }
+
+    #[test]
+    fn parse_s3_uri_key_non_s3_is_none() {
+        assert_eq!(MediaStorage::parse_s3_uri_key("/local/path/1.mp4"), None);
+        assert_eq!(MediaStorage::parse_s3_uri_key("https://x/y"), None);
+    }
+
+    // ── from_config ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn from_config_local_default() {
+        let storage = MediaStorage::from_config(&MediaStorageConfig::default()).unwrap();
+        match storage {
+            MediaStorage::Local {
+                root,
+                public_base_url,
+            } => {
+                assert_eq!(root, PathBuf::from("media"));
+                assert_eq!(public_base_url, "/media");
+            }
+            MediaStorage::S3(_) => panic!("expected local backend"),
+        }
+        assert_eq!(
+            MediaStorage::from_config(&MediaStorageConfig::default())
+                .unwrap()
+                .backend_name(),
+            "local"
+        );
+    }
+
+    #[test]
+    fn from_config_s3_with_bucket_defaults_region_and_tigris_base() {
+        let storage = MediaStorage::from_config(&s3_config(Some("my-bucket"))).unwrap();
+        match storage {
+            MediaStorage::S3(config) => {
+                assert_eq!(config.bucket, "my-bucket");
+                // blank region → "auto"
+                assert_eq!(config.region, DEFAULT_S3_REGION);
+                // unset endpoint stays None (SDK default)
+                assert_eq!(config.endpoint_url, None);
+                // unset public base → tigris fallback using the "media" prefix
+                assert_eq!(
+                    config.public_base_url,
+                    "https://my-bucket.t3.tigrisfiles.io/media"
+                );
+            }
+            MediaStorage::Local { .. } => panic!("expected s3 backend"),
+        }
+    }
+
+    #[test]
+    fn from_config_s3_respects_explicit_region_endpoint_public_base() {
+        let mut cfg = s3_config(Some("b"));
+        cfg.region = Some("us-east-1".to_owned());
+        cfg.endpoint_url = Some("https://example.r2.cloudflarestorage.com".to_owned());
+        cfg.public_base_url = Some("https://cdn.example.com".to_owned());
+        let MediaStorage::S3(config) = MediaStorage::from_config(&cfg).unwrap() else {
+            panic!("expected s3 backend");
+        };
+        assert_eq!(config.region, "us-east-1");
+        assert_eq!(
+            config.endpoint_url.as_deref(),
+            Some("https://example.r2.cloudflarestorage.com")
+        );
+        assert_eq!(config.public_base_url, "https://cdn.example.com");
+    }
+
+    #[test]
+    fn from_config_s3_missing_bucket_errors() {
+        assert!(matches!(
+            MediaStorage::from_config(&s3_config(None)),
+            Err(MediaError::MissingBucket)
+        ));
+        // blank bucket is also missing.
+        assert!(matches!(
+            MediaStorage::from_config(&s3_config(Some("   "))),
+            Err(MediaError::MissingBucket)
+        ));
+    }
+
+    #[test]
+    fn from_config_s3_partial_credentials_errors() {
+        let mut cfg = s3_config(Some("b"));
+        cfg.secret_access_key = None;
+        assert!(matches!(
+            MediaStorage::from_config(&cfg),
+            Err(MediaError::PartialS3Credentials)
+        ));
+
+        let mut cfg = s3_config(Some("b"));
+        cfg.access_key_id = None;
+        assert!(matches!(
+            MediaStorage::from_config(&cfg),
+            Err(MediaError::PartialS3Credentials)
+        ));
+    }
+
+    #[test]
+    fn from_config_s3_without_credentials_is_ok() {
+        let mut cfg = s3_config(Some("b"));
+        cfg.access_key_id = None;
+        cfg.secret_access_key = None;
+        let MediaStorage::S3(config) = MediaStorage::from_config(&cfg).unwrap() else {
+            panic!("expected s3 backend");
+        };
+        assert!(config.access_key_id.is_empty());
+        assert!(config.secret_access_key.is_empty());
+    }
+
+    #[test]
+    fn secret_access_key_is_redacted_in_debug() {
+        let mut cfg = s3_config(Some("b"));
+        cfg.secret_access_key = Some("s3kr3t-value-xyz".to_owned());
+        let storage = MediaStorage::from_config(&cfg).unwrap();
+        let rendered = format!("{storage:?}");
+        assert!(rendered.contains("** redacted **"));
+        // The literal secret value must never appear (the field *name*
+        // `secret_access_key` legitimately contains the word "secret").
+        assert!(
+            !rendered.contains("s3kr3t-value-xyz"),
+            "secret value must not appear: {rendered}"
+        );
+    }
+
+    // ── client-builder smoke test (no network) ───────────────────────────────
+
+    #[tokio::test]
+    async fn build_client_constructs_against_fake_endpoint_without_network() {
+        // Mirrors autumn-storage-s3's smoke test: constructing an S3 client
+        // against an unreachable fake endpoint must succeed with no network
+        // round-trip (no request is sent until an operation runs).
+        let mut cfg = s3_config(Some("test-bucket"));
+        cfg.region = Some("us-east-1".to_owned());
+        cfg.endpoint_url = Some("http://127.0.0.1:9".to_owned());
+        cfg.force_path_style = true;
+        let storage = MediaStorage::from_config(&cfg).unwrap();
+        // Should return a constructed client; nothing here reaches the network.
+        let _client = storage.build_client().await;
+    }
+}


### PR DESCRIPTION
Part of #1974.

Second slice of the ratified **autumn-media** extraction (builds on the slice-0 crate skeleton merged in #1976). Adds the storage subsystem — still a library surface; the plugin wires it as an AppState extension in the transport slice.

### Before / After
- **Before:** `autumn-media-plugin` had config + a no-op `MediaPlugin`; no object storage.
- **After:** a `MediaStorage` service with Local and S3 backends, ported from arroyo's `VideoStorageConfig` and generalized so callers supply their own object keys (the hard-coded `highlights/` / `clips/` / `thumbnails/` / `previews/` namespaces are gone).

### What's included
- `MediaStorage { Local, S3(S3MediaStorage) }` + `StoredObject`, built from the existing `MediaStorageConfig` via `from_config` (resolves Local/Tigris public-base + endpoint/region defaults).
- Caller-supplied-key API: `object_key` / `public_url` / `storage_uri` / `parse_s3_uri_key` / `persist_file` / `persist_file_with_content_type` (default `video/mp4`) / `remove_object_if_present`. Hand-written `Debug` redacts the S3 secret.
- `MediaError` (`thiserror`, `#[non_exhaustive]`): `MissingBucket`, `PartialS3Credentials`, `LocalRead`, `S3Upload`, `S3Delete` — AWS SDK errors are stringified, no aws-* types leak into the public API, no credentials in any `Display`.
- aws-* dependency pins (`aws-config`/`aws-credential-types`/`aws-runtime`/`aws-smithy-*`/`aws-sdk-s3` + the `time` coherence pin) **copied verbatim** from `autumn-storage-s3` (MSRV/rustls-advisory constrained; `aws-sdk-s3` default-features-off — a security improvement over arroyo's default-features build). Not hoisted to `[workspace.dependencies]` — a possible follow-up.
- The `from_arroyo_env` compatibility shim extended so the S3 path reproduces arroyo's `from_env_pairs` defaults (region→`auto`, endpoint→`https://t3.storage.dev`, key_prefix→`highlights`, Tigris public base), preserving zero-change migration for arroyo operators.

### Why not reuse `autumn-storage-s3`'s `BlobStore`
`BlobStore` exposes only **presigned (expiring)** URLs and validates/rejects arbitrary keys; media needs **permanent public URLs** baked into DB rows and caller-supplied keys. The two are genuinely different contracts, so this slice ports arroyo's own `aws-sdk-s3` usage (reusing `autumn-storage-s3`'s dependency pins and conditional-endpoint client-builder idiom).

### Deferred
Transport / MediaMTX client + URL builders (slice 3), generic workflows + `MediaArtifactSink` (slice 4). Extension wiring into `build()` lands with the transport slice (there are no handlers to read it yet).

### Tests
Pure unit tests for the key/URL/`s3://` join logic, `from_config` default resolution, the invariant errors, and a no-network client-builder smoke test. A Docker-gated MinIO round-trip is a documented fast-follow (would be the workspace's first minio test); the pure tests already cover the real regression risk.

### Verification (local, post-rebase onto current trunk-dev)
- `cargo fmt --all -- --check` → clean
- `cargo clippy -p autumn-media-plugin --all-targets -- -D warnings` → clean
- `cargo test -p autumn-media-plugin` → `55 passed; 0 failed`