### PR TITLE
SQLite runtime lane PR3: run real SQLite startup migrations (MigrationHarness, no advisory lock)

### DIFF
--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -366,6 +366,14 @@ path = "tests/integration_tests.rs"
 name = "sqlite_boot_serve"
 path = "tests/sqlite_boot_serve.rs"
 
+# SQLite startup-migration proof (issue #1614, PR3). Only meaningful under
+# `--features sqlite`; the file is `#![cfg(feature = "sqlite")]` so a default
+# `cargo test` compiles it to an empty (passing) binary. Run explicitly:
+# `cargo test -p autumn-web --features sqlite --test sqlite_migrations`.
+[[test]]
+name = "sqlite_migrations"
+path = "tests/sqlite_migrations.rs"
+
 # SQLite pooled-connection foreign-key enforcement proof (issue #1614, Codex P1).
 # Only meaningful under `--features sqlite`; the file is
 # `#![cfg(feature = "sqlite")]` so a default `cargo test` compiles it to an empty

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -4914,27 +4914,22 @@ impl AppBuilder {
             std::process::exit(0);
         }
 
-        // SQLite migrate-only guard (issue #1614 follow-up): the per-target applier
-        // below routes every target through the same Postgres-only `run_pending_locked`
-        // harness the normal-boot path uses, so a `sqlite:` control or shard target
-        // with registered migrations would attempt a `PgConnection::establish`
-        // against a SQLite URL and exit with a generic connection failure instead of
-        // the explicit, actionable "SQLite startup migrations not supported" error.
-        // Apply the SAME `sqlite_startup_migration_guard` here as normal boot, BEFORE
-        // the migration loop, so the boot and migrate-only paths cannot drift. The
-        // migration set is non-empty at this point (checked above), so both the
-        // control and shard "has migrations" flags mirror the boot call's
-        // `!migrations.is_empty()`. An all-Postgres / empty-shard configuration is
-        // never gated, leaving the Postgres path byte-identical.
+        // SQLite migrate-only guard (issue #1614, PR3): sharding is Postgres-only,
+        // so a `sqlite:` control target with shards configured, or any `sqlite:`
+        // shard target, fails fast here with the actionable sharding error — the
+        // SAME `sqlite_sharding_unsupported_guard` normal boot applies, so the two
+        // paths cannot drift. A plain `sqlite:` control target (no shards) is NOT
+        // gated: its migrations are applied by the SQLite apply path in the loop
+        // below. An all-Postgres / empty-shard configuration is never gated,
+        // leaving the Postgres path byte-identical.
         #[cfg(feature = "sqlite")]
         {
             let sqlite_guard_shard_urls: Vec<&str> =
                 shard_targets.iter().map(|(_, url)| url.as_str()).collect();
-            if let Err(e) = sqlite_startup_migration_guard(
+            if let Err(e) = sqlite_sharding_unsupported_guard(
                 control_url.as_deref(),
-                !migrations.is_empty(),
+                !shard_targets.is_empty(),
                 &sqlite_guard_shard_urls,
-                !migrations.is_empty(),
             ) {
                 eprintln!("autumn migrate: {e}");
                 // `process::exit` skips `on_shutdown`/`Drop`; stop any managed
@@ -4950,12 +4945,31 @@ impl AppBuilder {
         let applied_total = tokio::task::spawn_blocking(move || {
             let mut total = 0_usize;
             if let Some(url) = &control_url {
-                for mig in &migrations {
-                    total += apply_pending_or_exit(url, mig, "control");
+                // SQLite single-writer control target (issue #1614, PR3): apply with
+                // NO advisory lock via the SQLite harness. Sharding is rejected above,
+                // so a SQLite control target here is always unsharded (shard_targets
+                // is empty). Every non-SQLite target keeps the byte-identical locked
+                // Postgres applier.
+                #[cfg(feature = "sqlite")]
+                let is_sqlite_control = crate::config::DatabaseBackend::detect(url)
+                    == Some(crate::config::DatabaseBackend::Sqlite);
+                #[cfg(not(feature = "sqlite"))]
+                let is_sqlite_control = false;
+                if is_sqlite_control {
+                    #[cfg(feature = "sqlite")]
+                    for mig in &migrations {
+                        total += apply_pending_sqlite_or_exit(url, mig, "control");
+                    }
+                } else {
+                    for mig in &migrations {
+                        total += apply_pending_or_exit(url, mig, "control");
+                    }
                 }
             }
             // Shards hold tenant data, not the control-plane schema; skip the
             // control framework set for shard targets (mirrors `run_startup_migrations`).
+            // A `sqlite:` shard is rejected by the guard above, so every shard here
+            // is Postgres.
             for (label, url) in &shard_targets {
                 for mig in migrations
                     .iter()
@@ -7259,16 +7273,17 @@ async fn setup_database(
         .and_then(|t| t.migration_url())
         .map(str::to_owned);
 
-    // SQLite startup-migration guard (issue #1614 follow-up): the startup
-    // migration path is Postgres-only, so a `sqlite://` control URL with
-    // registered migrations must fail fast here rather than crash inside
-    // `PgConnection::establish` before serving. See `sqlite_startup_migration_guard`.
-    // The shard loop in `run_startup_migrations` migrates each `shard.primary_url`
-    // through the same Postgres-only harness, gated by `shards.is_some()` and the
-    // presence of registered migrations — independently of the control topology.
-    // Collect the shard targets so the guard can reject a SQLite shard the same
-    // way it rejects a SQLite control target (Codex P1). Empty when unsharded or
-    // when the shard loop won't run, so the Postgres path is unaffected.
+    // SQLite sharding guard (issue #1614, PR3): the SQLite startup-migration
+    // path now applies registered migrations to a `sqlite://` control target
+    // (`run_startup_migrations` routes them through
+    // `crate::migrate::auto_migrate_sqlite`), so registered migrations no longer
+    // fail fast here. What remains unsupported on SQLite is **sharding** — the
+    // directory/shard-map control migrations and per-shard fan-out are
+    // Postgres/sharding-specific — so a sqlite control target with sharding
+    // enabled fails fast here, as does any `sqlite:` shard `primary_url` (the
+    // shard loop routes each shard through the Postgres-only harness). Empty when
+    // unsharded or when the shard loop won't run, so the Postgres path is
+    // unaffected. See `sqlite_sharding_unsupported_guard`.
     #[cfg(feature = "sqlite")]
     let sqlite_guard_shard_urls: Vec<&str> = if shards.is_some() {
         config
@@ -7282,7 +7297,7 @@ async fn setup_database(
     };
     #[cfg(feature = "sqlite")]
     #[allow(clippy::question_mark)] // managed-pg child must be stopped before returning
-    if let Err(e) = sqlite_startup_migration_guard(
+    if let Err(e) = sqlite_sharding_unsupported_guard(
         if topology.is_some() {
             provider_migration_url
                 .as_deref()
@@ -7290,9 +7305,10 @@ async fn setup_database(
         } else {
             None
         },
-        !migrations.is_empty() || directory_migration_required || shard_map_migration_required,
+        directory_migration_required
+            || shard_map_migration_required
+            || config.database.has_shards(),
         &sqlite_guard_shard_urls,
-        !migrations.is_empty(),
     ) {
         #[cfg(feature = "managed-pg")]
         crate::managed_pg::emergency_stop_async().await;
@@ -7412,58 +7428,95 @@ fn apply_pending_or_exit(
     }
 }
 
-/// Guard the startup-migration path against a `SQLite` control target.
+/// Apply pending migrations for one `SQLite` target in the `AUTUMN_MIGRATE=1`
+/// one-shot, returning the number applied — or exiting non-zero on failure
+/// (issue #1614, PR3).
 ///
-/// The Rust startup-migration harness is Postgres-only — it applies
-/// `MigrationSource<Pg>` through [`crate::db::establish_migration_connection`],
-/// which calls `PgConnection::establish`. A `sqlite://` URL routed there would
-/// try to open a Postgres connection against a `SQLite` target and crash before
-/// the app ever serves (issue #1614 review, Codex P1). Full `SQLite` migration
-/// support (a `MigrationHarness<Sqlite>` path) is a deliberate follow-up; until
-/// then, registering migrations with a `SQLite` target fails fast here with an
-/// actionable message rather than deep inside the Postgres engine.
-///
-/// Returns `Ok(())` unless the control target is `SQLite` **and** at least one
-/// migration would be applied to it. With no registered migrations the
-/// manual-schema path is fully supported, so boot proceeds. Uses the same
-/// [`crate::config::DatabaseBackend::detect`] predicate as `db::build_pool`, so
-/// the gate and the pool routing agree on what "is a `SQLite` URL" means.
-///
-/// The same crash lurks on the **shard** targets: the shard loop in
-/// [`run_startup_migrations`] migrates every `shard.primary_url` through the same
-/// Postgres-only harness, independently of the control topology. A shards-only
-/// app (control `topology` is `None`, so the control check above permits boot)
-/// with `sqlite:` shard `primary_url`s and registered migrations would hit the
-/// exact pre-serve crash this guard exists to prevent, so any `SQLite` shard
-/// target with migrations pending is rejected here too (issue #1614 review,
-/// Codex P1). `shard_urls` is empty when the app is unsharded or the shard loop
-/// won't run, so the Postgres path is unaffected.
+/// The `SQLite` counterpart to [`apply_pending_or_exit`]: it uses the unlocked
+/// [`run_pending_sqlite`](crate::migrate::run_pending_sqlite) harness (`SQLite`
+/// is single-writer, so there is no advisory lock and no cross-process race to
+/// serialize) and REDACTS failure messages to a value-free reason plus the
+/// target label, exactly like the Postgres path, so a driver string embedding
+/// the database path is never printed.
 #[cfg(feature = "sqlite")]
-fn sqlite_startup_migration_guard(
+fn apply_pending_sqlite_or_exit(
+    database_url: &str,
+    migrations: &crate::migrate::EmbeddedMigrations,
+    target: &str,
+) -> usize {
+    match crate::migrate::run_pending_sqlite(
+        database_url,
+        crate::migrate::EmbeddedMigrationsRef(migrations),
+    ) {
+        Ok(result) => result.applied.len(),
+        Err(error) => {
+            let reason = match error {
+                crate::migrate::MigrationError::Connection(_) => {
+                    "could not connect to the database"
+                }
+                crate::migrate::MigrationError::Migration(_) => "a migration failed to apply",
+                _ => "migration error",
+            };
+            eprintln!("autumn migrate: {reason} (target {target})");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Guard the startup-migration path against a **sharded** `SQLite` deployment.
+///
+/// PR3 (#1614) wired a working `SQLite` startup-migration path: registered
+/// migrations now apply to a `sqlite://` control target through diesel's
+/// `MigrationHarness` on a `SqliteConnection`, with no advisory lock (see
+/// [`crate::migrate::run_pending_sqlite`] / [`crate::migrate::auto_migrate_sqlite`],
+/// routed from [`run_startup_migrations`]). So registered migrations are no
+/// longer rejected here — a `sqlite://` control target with `.migrations(...)`
+/// boots and applies its schema.
+///
+/// What remains unsupported is **sharding on `SQLite`**: the shard-directory and
+/// shard-map control tables and the per-shard fan-out are Postgres/sharding
+/// primitives (advisory locks, Postgres DDL), and a single-node `SQLite`
+/// deployment has no shards. Two situations are therefore rejected here with an
+/// actionable message rather than attempting to create Postgres-shaped sharding
+/// tables on `SQLite`:
+///
+///   * a `SQLite` **control** target for which the sharding control migrations
+///     are required or shards are configured (`control_sharding_required` —
+///     `directory_migration_required || shard_map_migration_required ||
+///     config.database.has_shards()`); and
+///   * any `SQLite` **shard** `primary_url`: the shard loop in
+///     [`run_startup_migrations`] migrates every shard through the Postgres-only
+///     harness, so a `sqlite:` shard is sharding-on-`SQLite` regardless of the
+///     control backend. `shard_urls` is empty when the app is unsharded or the
+///     shard loop won't run, so the Postgres path is unaffected.
+///
+/// Uses the same [`crate::config::DatabaseBackend::detect`] predicate as
+/// `db::build_pool`, so the gate and the pool routing agree on what "is a
+/// `SQLite` URL" means.
+#[cfg(feature = "sqlite")]
+fn sqlite_sharding_unsupported_guard(
     control_url: Option<&str>,
-    control_has_migrations: bool,
+    control_sharding_required: bool,
     shard_urls: &[&str],
-    shard_has_migrations: bool,
 ) -> Result<(), String> {
     fn is_sqlite(url: &str) -> bool {
         crate::config::DatabaseBackend::detect(url) == Some(crate::config::DatabaseBackend::Sqlite)
     }
-    if control_url.is_some_and(is_sqlite) && control_has_migrations {
+    if control_url.is_some_and(is_sqlite) && control_sharding_required {
         return Err(
-            "SQLite startup migrations are not yet supported in this build of autumn-web. \
-             Registered migrations cannot be applied to a SQLite target here \u{2014} apply \
-             your schema out-of-band, or boot without registered migrations. Tracking: SQLite \
-             migration support is a follow-up to #1614."
+            "SQLite deployments do not support sharding. The configured sqlite:// control target \
+             has sharding enabled (shards and/or the directory/shard-map control migrations), \
+             which is a Postgres-only capability \u{2014} remove the shard configuration to run \
+             on SQLite, or use a Postgres control database. Tracking: #1614."
                 .to_owned(),
         );
     }
-    if shard_has_migrations && shard_urls.iter().copied().any(is_sqlite) {
+    if shard_urls.iter().copied().any(is_sqlite) {
         return Err(
-            "SQLite startup migrations are not yet supported in this build of autumn-web. \
-             A configured shard targets a SQLite database, and registered migrations cannot be \
-             applied to a SQLite target here \u{2014} apply your shard schema out-of-band, or \
-             boot without registered migrations. Tracking: SQLite migration support is a \
-             follow-up to #1614."
+            "SQLite deployments do not support sharding. A configured shard targets a SQLite \
+             database, and per-shard migration/fan-out is a Postgres-only capability \u{2014} \
+             remove the SQLite shard configuration to run on SQLite, or use Postgres shard \
+             targets. Tracking: #1614."
                 .to_owned(),
         );
     }
@@ -7471,57 +7524,61 @@ fn sqlite_startup_migration_guard(
 }
 
 #[cfg(all(test, feature = "sqlite"))]
-mod sqlite_startup_migration_guard_tests {
-    use super::sqlite_startup_migration_guard;
+mod sqlite_sharding_unsupported_guard_tests {
+    use super::sqlite_sharding_unsupported_guard;
 
     #[test]
-    fn sqlite_target_with_registered_migrations_fails_fast() {
-        // The exact bug the Codex P1 flags: a sqlite:// control URL with
-        // registered migrations must NOT reach `PgConnection::establish`; it
-        // must return the actionable, SQLite-named boot error instead.
+    fn sqlite_control_target_with_sharding_fails_fast() {
+        // PR3: a sqlite:// control URL with sharding enabled must fail fast with
+        // an actionable, sharding-named boot error — sharding is Postgres-only.
         for url in [
             "sqlite:///var/lib/app.db",
             "sqlite://./relative.db",
             "sqlite::memory:",
         ] {
-            let err = sqlite_startup_migration_guard(Some(url), true, &[], false)
-                .expect_err("sqlite target + registered migrations must be rejected");
+            let err = sqlite_sharding_unsupported_guard(Some(url), true, &[])
+                .expect_err("sqlite control target + sharding must be rejected");
             assert!(
-                err.contains("SQLite startup migrations are not yet supported"),
-                "message must name the SQLite situation clearly: {err}"
+                err.contains("do not support sharding"),
+                "message must name the sharding situation clearly: {err}"
             );
             assert!(
                 err.contains("#1614"),
-                "message must point at the tracking follow-up: {err}"
+                "message must point at the tracking issue: {err}"
             );
         }
     }
 
     #[test]
-    fn sqlite_target_without_migrations_boots() {
-        // The manual-schema path (the `sqlite_boot_serve` scenario): a sqlite
-        // target with no registered migrations must boot normally.
-        assert!(
-            sqlite_startup_migration_guard(Some("sqlite:///var/lib/app.db"), false, &[], false)
-                .is_ok(),
-            "sqlite target + no migrations must boot"
-        );
+    fn sqlite_control_target_without_sharding_boots() {
+        // PR3 behavior: a sqlite target with registered (non-sharding)
+        // migrations now boots — they are applied by `auto_migrate_sqlite`.
+        for url in [
+            "sqlite:///var/lib/app.db",
+            "sqlite://./relative.db",
+            "sqlite::memory:",
+        ] {
+            assert!(
+                sqlite_sharding_unsupported_guard(Some(url), false, &[]).is_ok(),
+                "sqlite target without sharding must boot (migrations now applied): {url}"
+            );
+        }
     }
 
     #[test]
     fn postgres_target_is_unchanged() {
-        // The default Postgres path is untouched, migrations registered or not.
+        // The default Postgres path is untouched, sharding required or not.
         for url in [
             "postgres://u@h/db",
             "postgresql://user:pass@db:5432/app",
             "host=db user=app sslmode=require",
         ] {
             assert!(
-                sqlite_startup_migration_guard(Some(url), true, &[], false).is_ok(),
+                sqlite_sharding_unsupported_guard(Some(url), true, &[]).is_ok(),
                 "postgres target must never be gated: {url}"
             );
             assert!(
-                sqlite_startup_migration_guard(Some(url), false, &[], false).is_ok(),
+                sqlite_sharding_unsupported_guard(Some(url), false, &[]).is_ok(),
                 "postgres target must never be gated: {url}"
             );
         }
@@ -7530,54 +7587,41 @@ mod sqlite_startup_migration_guard_tests {
     #[test]
     fn absent_control_url_boots() {
         // No control URL (no-DB / opt-out provider): nothing to gate.
-        assert!(sqlite_startup_migration_guard(None, true, &[], false).is_ok());
-        assert!(sqlite_startup_migration_guard(None, false, &[], false).is_ok());
+        assert!(sqlite_sharding_unsupported_guard(None, true, &[]).is_ok());
+        assert!(sqlite_sharding_unsupported_guard(None, false, &[]).is_ok());
     }
 
     #[test]
-    fn sqlite_shard_target_with_registered_migrations_fails_fast() {
-        // The Codex P1: a shards-only app (no control topology, so the control
-        // arg is None) with a `sqlite:` shard primary_url and registered
-        // migrations must NOT reach the Postgres shard-migration harness; it
-        // must return the actionable, SQLite-named boot error instead.
-        let err = sqlite_startup_migration_guard(
-            None,
-            false,
-            &["sqlite:///var/lib/shard0.db", "postgres://u@h/shard1"],
-            true,
-        )
-        .expect_err("a sqlite shard target + registered migrations must be rejected");
-        assert!(
-            err.contains("SQLite startup migrations are not yet supported")
-                && err.contains("shard"),
-            "message must name the SQLite shard situation clearly: {err}"
-        );
-        assert!(
-            err.contains("#1614"),
-            "message must point at the tracking follow-up: {err}"
-        );
-    }
-
-    #[test]
-    fn sqlite_shard_target_without_migrations_boots() {
-        // A sqlite shard with no registered migrations (manual-schema shards)
-        // must boot normally.
-        assert!(
-            sqlite_startup_migration_guard(None, false, &["sqlite:///var/lib/shard0.db"], false)
-                .is_ok(),
-            "sqlite shard + no migrations must boot"
-        );
+    fn sqlite_shard_target_fails_fast() {
+        // A `sqlite:` shard `primary_url` is sharding-on-SQLite regardless of the
+        // control backend and regardless of migrations — the shard loop routes it
+        // through the Postgres-only harness. It must be rejected with the
+        // actionable sharding error.
+        for shards in [
+            &["sqlite:///var/lib/shard0.db"][..],
+            &["sqlite:///var/lib/shard0.db", "postgres://u@h/shard1"][..],
+        ] {
+            let err = sqlite_sharding_unsupported_guard(None, false, shards)
+                .expect_err("a sqlite shard target must be rejected");
+            assert!(
+                err.contains("do not support sharding") && err.contains("shard"),
+                "message must name the SQLite shard situation clearly: {err}"
+            );
+            assert!(
+                err.contains("#1614"),
+                "message must point at the tracking issue: {err}"
+            );
+        }
     }
 
     #[test]
     fn postgres_shard_targets_are_unchanged() {
-        // All-Postgres shards are never gated, migrations registered or not.
+        // All-Postgres shards are never gated, sharding required or not.
         assert!(
-            sqlite_startup_migration_guard(
+            sqlite_sharding_unsupported_guard(
                 Some("postgres://u@h/control"),
                 true,
                 &["postgres://u@h/shard0", "postgres://u@h/shard1"],
-                true,
             )
             .is_ok(),
             "all-postgres shard targets must never be gated"
@@ -7586,55 +7630,48 @@ mod sqlite_startup_migration_guard_tests {
 
     #[test]
     fn migrate_only_mode_reuses_the_boot_guard_for_sqlite_targets() {
-        // `run_migrate_only_mode` (the `AUTUMN_MIGRATE=1` one-shot) now applies the
-        // SAME guard as normal boot BEFORE its migration loop, so a SQLite migrate
-        // target with registered migrations exits with the actionable error rather
-        // than attempting a `PgConnection` through the Postgres-only harness. The
-        // migrate-only path always has a non-empty migration set at the guard point,
-        // so it passes `control_has_migrations = shard_has_migrations = true`.
+        // `run_migrate_only_mode` (the `AUTUMN_MIGRATE=1` one-shot) applies the
+        // SAME guard as normal boot BEFORE its migration loop, so the boot and
+        // migrate-only paths cannot drift. A sqlite control/shard target with
+        // sharding still fails fast; a plain sqlite control target now proceeds
+        // (its migrations are applied by the sqlite apply path).
 
-        // A sqlite CONTROL migrate target + registered migrations → actionable error.
-        let err = sqlite_startup_migration_guard(Some("sqlite:///var/lib/app.db"), true, &[], true)
-            .expect_err("sqlite migrate control target must be rejected, not sent to PgConnection");
+        // A sqlite CONTROL migrate target with sharding → actionable error.
+        let err = sqlite_sharding_unsupported_guard(Some("sqlite:///var/lib/app.db"), true, &[])
+            .expect_err("sqlite migrate control target with sharding must be rejected");
         assert!(
-            err.contains("SQLite startup migrations are not yet supported")
-                && err.contains("#1614"),
-            "migrate-only sqlite control error must be the actionable boot message: {err}"
+            err.contains("do not support sharding") && err.contains("#1614"),
+            "migrate-only sqlite control error must be the actionable sharding message: {err}"
         );
 
-        // A sqlite SHARD migrate target + registered migrations → actionable error.
-        let shard_err = sqlite_startup_migration_guard(
+        // A sqlite SHARD migrate target → actionable error.
+        let shard_err = sqlite_sharding_unsupported_guard(
             Some("postgres://u@h/control"),
             true,
             &["sqlite:///var/lib/shard0.db"],
-            true,
         )
-        .expect_err("sqlite migrate shard target must be rejected, not sent to PgConnection");
+        .expect_err("sqlite migrate shard target must be rejected");
         assert!(
-            shard_err.contains("SQLite startup migrations are not yet supported")
-                && shard_err.contains("shard"),
-            "migrate-only sqlite shard error must be the actionable boot message: {shard_err}"
+            shard_err.contains("do not support sharding") && shard_err.contains("shard"),
+            "migrate-only sqlite shard error must be the actionable sharding message: {shard_err}"
         );
 
         // An all-Postgres migrate configuration (control + shards) is never gated.
         assert!(
-            sqlite_startup_migration_guard(
+            sqlite_sharding_unsupported_guard(
                 Some("postgres://u@h/control"),
                 true,
                 &["postgres://u@h/shard0"],
-                true,
             )
             .is_ok(),
             "an all-postgres migrate configuration must proceed unchanged"
         );
 
-        // A sqlite migrate target with NO registered migrations (manual-schema) is
-        // impossible in migrate-only (it early-exits before the guard), but the
-        // helper still returns Ok, confirming the guard only fires on real applies.
+        // A plain sqlite migrate control target (no sharding) proceeds — its
+        // migrations are applied by the sqlite apply path.
         assert!(
-            sqlite_startup_migration_guard(Some("sqlite:///var/lib/app.db"), false, &[], false)
-                .is_ok(),
-            "sqlite target with no migrations must never be gated"
+            sqlite_sharding_unsupported_guard(Some("sqlite:///var/lib/app.db"), false, &[]).is_ok(),
+            "sqlite control target without sharding must never be gated"
         );
     }
 }
@@ -7674,6 +7711,31 @@ async fn run_startup_migrations(
     let profile = config.profile.clone();
     let auto_in_prod = config.database.auto_migrate_in_production;
     let migration_result = tokio::task::spawn_blocking(move || {
+        // SQLite single-writer startup-migration path (issue #1614, PR3): apply
+        // the registered migrations to a `sqlite://` control target with NO
+        // advisory lock. Sharding (directory / shard-map / per-shard fan-out) is
+        // Postgres-only and is rejected upstream in `setup_database`
+        // (`sqlite_sharding_unsupported_guard`), so there is nothing shard- or
+        // directory-related to do on this path — the directory/shard-map framework
+        // migrations below are skipped for a SQLite control target. The Postgres
+        // path is left byte-identical for every non-SQLite target.
+        #[cfg(feature = "sqlite")]
+        if let Some(url) = control_url.as_deref()
+            && crate::config::DatabaseBackend::detect(url)
+                == Some(crate::config::DatabaseBackend::Sqlite)
+        {
+            for mig in &migrations {
+                crate::migrate::auto_migrate_sqlite(
+                    url,
+                    profile.as_deref(),
+                    auto_in_prod,
+                    mig,
+                    "control",
+                );
+            }
+            return;
+        }
+
         if let Some(url) = control_url {
             for mig in &migrations {
                 crate::migrate::auto_migrate(
@@ -9836,14 +9898,14 @@ mod tests {
             "the migrate handler exits after applying"
         );
 
-        // Issue #1614 follow-up: the migrate one-shot must apply the SAME SQLite
-        // guard as normal boot BEFORE its migration loop, so a `sqlite:` target with
-        // registered migrations exits with the actionable unsupported-migrations
-        // error instead of a generic `PgConnection` failure — and the two paths
-        // cannot drift because both call `sqlite_startup_migration_guard`.
+        // Issue #1614, PR3: the migrate one-shot must apply the SAME SQLite
+        // sharding guard as normal boot BEFORE its migration loop, so a sharded
+        // `sqlite:` target exits with the actionable sharding error instead of a
+        // generic `PgConnection` failure — and the two paths cannot drift because
+        // both call `sqlite_sharding_unsupported_guard`.
         let guard_call = handler
-            .find("sqlite_startup_migration_guard(")
-            .expect("migrate handler applies the SQLite migrate guard");
+            .find("sqlite_sharding_unsupported_guard(")
+            .expect("migrate handler applies the SQLite sharding guard");
         let first_apply = handler
             .find("apply_pending_or_exit")
             .expect("migrate handler applies per target");

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -7444,12 +7444,13 @@ fn apply_pending_sqlite_or_exit(
     migrations: &crate::migrate::EmbeddedMigrations,
     target: &str,
 ) -> usize {
-    // Reject a private in-memory target with registered migrations up front,
-    // BEFORE `run_pending_sqlite` (whose `Migration` error would be redacted to
-    // a value-free reason below, hiding the guidance). Each `:memory:`
-    // connection is its own empty database, so migrations here never reach the
-    // runtime pool (issue #1614 follow-up).
-    if let Some(err) = crate::migrate::reject_private_in_memory_migrations(
+    // Reject ANY in-memory target (private OR shared-cache) with registered
+    // migrations up front, BEFORE `run_pending_sqlite` (whose `Migration` error
+    // would be redacted to a value-free reason below, hiding the guidance). The
+    // migrated schema never survives to the runtime pool — a private `:memory:`
+    // connection is its own empty database, and a shared in-memory database is
+    // destroyed when its last connection closes (issue #1614 follow-up).
+    if let Some(err) = crate::migrate::reject_in_memory_migrations(
         database_url,
         &crate::migrate::EmbeddedMigrationsRef(migrations),
     ) {

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -7444,6 +7444,18 @@ fn apply_pending_sqlite_or_exit(
     migrations: &crate::migrate::EmbeddedMigrations,
     target: &str,
 ) -> usize {
+    // Reject a private in-memory target with registered migrations up front,
+    // BEFORE `run_pending_sqlite` (whose `Migration` error would be redacted to
+    // a value-free reason below, hiding the guidance). Each `:memory:`
+    // connection is its own empty database, so migrations here never reach the
+    // runtime pool (issue #1614 follow-up).
+    if let Some(err) = crate::migrate::reject_private_in_memory_migrations(
+        database_url,
+        &crate::migrate::EmbeddedMigrationsRef(migrations),
+    ) {
+        eprintln!("autumn migrate: {err} (target {target})");
+        std::process::exit(1);
+    }
     match crate::migrate::run_pending_sqlite(
         database_url,
         crate::migrate::EmbeddedMigrationsRef(migrations),

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -1186,26 +1186,35 @@ fn sqlite_target_is_memory(target: &str) -> bool {
         || target.contains("mode=memory")
 }
 
-/// Whether a `SQLite` database URL (any accepted spelling) resolves to a
-/// **private** in-memory target — `sqlite::memory:` / `:memory:` /
-/// `file::memory:` *without* `cache=shared`.
+/// Whether a `SQLite` database URL (any accepted spelling) resolves to **any**
+/// in-memory target — the private spellings (`sqlite::memory:` / `:memory:` /
+/// `file::memory:`) AND the shared-cache in-memory form
+/// (`file::memory:?cache=shared`, `file:app?mode=memory&cache=shared`).
 ///
-/// Each connection to a private in-memory database gets its own, isolated,
-/// empty database (see [`normalize_sqlite_target`]). That is why the runtime
-/// pool forces such targets single-slot, and why a throwaway synchronous
-/// migration connection can never make its schema visible to the async runtime
-/// pool: the two connections are different databases. Callers registering
-/// startup migrations use this to reject the doomed configuration up front.
+/// This is deliberately broader than [`sqlite_target_is_memory`] (the pool
+/// *sizing* predicate): it does NOT exempt `cache=shared`. It is the predicate
+/// the startup-migration reject uses, because **no** in-memory target — private
+/// or shared-cache — can retain a registered migration for the runtime pool. The
+/// migration runs on a transient synchronous connection; `SQLite` destroys a
+/// shared in-memory database the moment its *last* connection closes, and the
+/// runtime deadpool is created lazily (it may not have checked out a connection
+/// yet), so the pool's first checkout opens a fresh, empty in-memory database and
+/// every DB-backed request then 500s with "no such table". Only a **file-backed**
+/// database survives the migration connection closing, so that is the sole
+/// supported remedy.
 ///
-/// A **file-backed** target (persists on disk, shared by every connection) and
-/// a **shared-cache** in-memory target (`file::memory:?cache=shared`, shared
-/// across connections within one process) both return `false` — they retain
-/// migrations for the pool and must not be rejected. This is exactly
-/// [`sqlite_target_is_memory`] applied to the normalized URL, so pool sizing and
-/// this guard agree on what "private in-memory" means.
+/// Pool *sizing* deliberately keeps using [`sqlite_target_is_memory`] instead:
+/// a shared-cache in-memory database IS shareable across the pool's connections
+/// within one live process, so it must NOT be forced single-slot. The two
+/// predicates answer different questions ("share across the pool?" vs. "survive
+/// the migration connection closing?") and must not be conflated.
 #[cfg(feature = "sqlite")]
-pub(crate) fn sqlite_target_is_private_in_memory(url: &str) -> bool {
-    sqlite_target_is_memory(&normalize_sqlite_target(url))
+pub(crate) fn sqlite_target_is_any_in_memory(url: &str) -> bool {
+    let target = normalize_sqlite_target(url);
+    target == ":memory:"
+        || target == "file::memory:"
+        || target.starts_with("file::memory:?")
+        || target.contains("mode=memory")
 }
 
 /// Whether a normalized `SQLite` target names a **read-only** database via its
@@ -3846,35 +3855,77 @@ mod tests {
         assert!(!sqlite_target_is_memory("/var/lib/app.db"));
     }
 
-    // `sqlite_target_is_private_in_memory` classifies raw URLs (every accepted
-    // spelling) so the startup-migration path can reject a private in-memory
-    // target that would apply migrations to a throwaway connection the runtime
-    // pool never sees (issue #1614 follow-up). It is exactly
-    // `sqlite_target_is_memory` over the normalized URL: private in-memory →
-    // true; file-backed and shared-cache in-memory → false.
+    // `sqlite_target_is_any_in_memory` is the broader predicate the
+    // startup-migration reject uses: it classifies EVERY in-memory spelling —
+    // private AND shared-cache — as in-memory, because none of them survive the
+    // transient migration connection closing to reach the runtime pool (issue
+    // #1614 follow-up). It must diverge from `sqlite_target_is_memory` (pool
+    // sizing) precisely on `cache=shared`, which sizing keeps NOT-in-memory so a
+    // shared-cache DB is never forced single-slot.
     #[cfg(feature = "sqlite")]
     #[test]
-    fn sqlite_target_is_private_in_memory_classifies_targets() {
-        // Private in-memory spellings the runtime pool accepts.
-        assert!(sqlite_target_is_private_in_memory(":memory:"));
-        assert!(sqlite_target_is_private_in_memory("sqlite::memory:"));
-        assert!(sqlite_target_is_private_in_memory("sqlite://:memory:"));
-        assert!(sqlite_target_is_private_in_memory("sqlite://"));
-        assert!(sqlite_target_is_private_in_memory("file::memory:"));
-        assert!(sqlite_target_is_private_in_memory("file::memory:?foo=bar"));
-        // Shared-cache in-memory is shareable across connections — NOT private.
-        assert!(!sqlite_target_is_private_in_memory(
-            "file::memory:?cache=shared"
-        ));
-        assert!(!sqlite_target_is_private_in_memory(
+    fn sqlite_target_is_any_in_memory_covers_shared_cache() {
+        // Private in-memory spellings — in-memory for BOTH predicates.
+        assert!(sqlite_target_is_any_in_memory(":memory:"));
+        assert!(sqlite_target_is_any_in_memory("sqlite::memory:"));
+        assert!(sqlite_target_is_any_in_memory("sqlite://:memory:"));
+        assert!(sqlite_target_is_any_in_memory("sqlite://"));
+        assert!(sqlite_target_is_any_in_memory("file::memory:"));
+        assert!(sqlite_target_is_any_in_memory("file::memory:?foo=bar"));
+        // Shared-cache in-memory: `any_in_memory` → true (rejected for
+        // migrations), but pool sizing's `sqlite_target_is_memory` → false (NOT
+        // forced single-slot). This divergence is the whole point.
+        assert!(sqlite_target_is_any_in_memory("file::memory:?cache=shared"));
+        assert!(sqlite_target_is_any_in_memory(
             "file:app?mode=memory&cache=shared"
         ));
-        // File-backed targets persist and are shared — NOT private in-memory.
-        assert!(!sqlite_target_is_private_in_memory(
-            "sqlite:///var/lib/app.db"
+        assert!(!sqlite_target_is_memory("file::memory:?cache=shared"));
+        assert!(!sqlite_target_is_memory(
+            "file:app?mode=memory&cache=shared"
         ));
-        assert!(!sqlite_target_is_private_in_memory("/var/lib/app.db"));
-        assert!(!sqlite_target_is_private_in_memory("file:/var/lib/app.db"));
+        // File-backed targets are never in-memory under either predicate.
+        assert!(!sqlite_target_is_any_in_memory("sqlite:///var/lib/app.db"));
+        assert!(!sqlite_target_is_any_in_memory("/var/lib/app.db"));
+        assert!(!sqlite_target_is_any_in_memory("file:/var/lib/app.db"));
+    }
+
+    // The transient SQLite migration connection must carry `PRAGMA busy_timeout`
+    // (mirroring the runtime pool's per-connection setup) so a concurrent
+    // migrator or a briefly-held write lock WAITS instead of failing immediately
+    // with SQLITE_BUSY and aborting `auto_migrate_sqlite` (Codex P1). Proof: a
+    // fresh migration connection reports the configured non-zero timeout.
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_migration_connection_sets_busy_timeout() {
+        use diesel::RunQueryDsl as _;
+
+        #[derive(diesel::QueryableByName)]
+        struct BusyTimeout {
+            #[diesel(sql_type = diesel::sql_types::Integer)]
+            timeout: i32,
+        }
+
+        // A tempfile-backed target (not `:memory:`) so the connection maps to a
+        // real database the pragma read reflects.
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let db_path = tmp.path().join("migration.db");
+        let url = format!("sqlite://{}", db_path.display());
+
+        let mut conn = super::establish_sqlite_migration_connection(&url)
+            .expect("establish sqlite migration connection");
+        let rows: Vec<BusyTimeout> = diesel::sql_query("PRAGMA busy_timeout")
+            .load(&mut conn)
+            .expect("read busy_timeout pragma");
+        let timeout = rows
+            .into_iter()
+            .next()
+            .expect("busy_timeout pragma returns a row")
+            .timeout;
+        assert_eq!(
+            timeout, 5000,
+            "the migration connection must carry the configured busy_timeout (ms) \
+             so concurrent/locked migrators wait rather than hitting SQLITE_BUSY"
+        );
     }
 
     // A read-only URI target (`mode=ro` / `immutable`) must be detected so the
@@ -5340,16 +5391,32 @@ pub(crate) fn establish_migration_connection(
 /// normalized through the same [`normalize_sqlite_target`] the runtime pool
 /// uses, so the migration connection and the pool open the same database file.
 ///
+/// The connection sets `PRAGMA busy_timeout = 5000` right after opening,
+/// mirroring the runtime pool's per-connection `custom_setup` (see
+/// [`build_sqlite_pool`]): without it, a second concurrent migrator — or a write
+/// lock briefly held by the runtime pool — makes this connection fail
+/// *immediately* with `SQLITE_BUSY`, and `auto_migrate_sqlite` exits the process.
+/// With the timeout, migration statements WAIT up to 5s for the lock to clear
+/// instead of aborting; diesel migrations are idempotent, so a migrator that
+/// waits and then finds migrations already applied is fine. Only `busy_timeout`
+/// is set here — NOT `foreign_keys`/`journal_mode`, because `foreign_keys = ON`
+/// can break table-recreating migrations.
+///
 /// # Errors
 ///
 /// Returns the underlying [`diesel::ConnectionError`] when the database cannot
-/// be opened.
+/// be opened, or [`diesel::ConnectionError::CouldntSetupConfiguration`] if the
+/// `busy_timeout` pragma cannot be applied.
 #[cfg(feature = "sqlite")]
 pub(crate) fn establish_sqlite_migration_connection(
     database_url: &str,
 ) -> Result<diesel::SqliteConnection, diesel::ConnectionError> {
     use diesel::Connection as _;
-    diesel::SqliteConnection::establish(&normalize_sqlite_target(database_url))
+    use diesel::connection::SimpleConnection as _;
+    let mut conn = diesel::SqliteConnection::establish(&normalize_sqlite_target(database_url))?;
+    conn.batch_execute("PRAGMA busy_timeout = 5000;")
+        .map_err(diesel::ConnectionError::CouldntSetupConfiguration)?;
+    Ok(conn)
 }
 
 #[cfg(test)]

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -5277,6 +5277,28 @@ pub(crate) fn establish_migration_connection(
     })
 }
 
+/// Establish a synchronous diesel [`diesel::SqliteConnection`] for the `SQLite`
+/// startup-migration path (issue #1614, PR3).
+///
+/// The `SQLite` counterpart to [`establish_migration_connection`], and much
+/// thinner: `SQLite` is a single-writer local database, so there is no TLS
+/// negotiation and no advisory-lock connection wrapper — diesel's
+/// `MigrationHarness` runs directly on a plain `SqliteConnection`. The URL is
+/// normalized through the same [`normalize_sqlite_target`] the runtime pool
+/// uses, so the migration connection and the pool open the same database file.
+///
+/// # Errors
+///
+/// Returns the underlying [`diesel::ConnectionError`] when the database cannot
+/// be opened.
+#[cfg(feature = "sqlite")]
+pub(crate) fn establish_sqlite_migration_connection(
+    database_url: &str,
+) -> Result<diesel::SqliteConnection, diesel::ConnectionError> {
+    use diesel::Connection as _;
+    diesel::SqliteConnection::establish(&normalize_sqlite_target(database_url))
+}
+
 #[cfg(test)]
 mod migration_connection_tests {
     use super::migration_connection_needs_rustls;

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -1186,6 +1186,28 @@ fn sqlite_target_is_memory(target: &str) -> bool {
         || target.contains("mode=memory")
 }
 
+/// Whether a `SQLite` database URL (any accepted spelling) resolves to a
+/// **private** in-memory target — `sqlite::memory:` / `:memory:` /
+/// `file::memory:` *without* `cache=shared`.
+///
+/// Each connection to a private in-memory database gets its own, isolated,
+/// empty database (see [`normalize_sqlite_target`]). That is why the runtime
+/// pool forces such targets single-slot, and why a throwaway synchronous
+/// migration connection can never make its schema visible to the async runtime
+/// pool: the two connections are different databases. Callers registering
+/// startup migrations use this to reject the doomed configuration up front.
+///
+/// A **file-backed** target (persists on disk, shared by every connection) and
+/// a **shared-cache** in-memory target (`file::memory:?cache=shared`, shared
+/// across connections within one process) both return `false` — they retain
+/// migrations for the pool and must not be rejected. This is exactly
+/// [`sqlite_target_is_memory`] applied to the normalized URL, so pool sizing and
+/// this guard agree on what "private in-memory" means.
+#[cfg(feature = "sqlite")]
+pub(crate) fn sqlite_target_is_private_in_memory(url: &str) -> bool {
+    sqlite_target_is_memory(&normalize_sqlite_target(url))
+}
+
 /// Whether a normalized `SQLite` target names a **read-only** database via its
 /// URI query string (`mode=ro`, or `immutable=1`/`immutable=true`).
 ///
@@ -3822,6 +3844,37 @@ mod tests {
         ));
         // Plain file targets are not in-memory.
         assert!(!sqlite_target_is_memory("/var/lib/app.db"));
+    }
+
+    // `sqlite_target_is_private_in_memory` classifies raw URLs (every accepted
+    // spelling) so the startup-migration path can reject a private in-memory
+    // target that would apply migrations to a throwaway connection the runtime
+    // pool never sees (issue #1614 follow-up). It is exactly
+    // `sqlite_target_is_memory` over the normalized URL: private in-memory →
+    // true; file-backed and shared-cache in-memory → false.
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_target_is_private_in_memory_classifies_targets() {
+        // Private in-memory spellings the runtime pool accepts.
+        assert!(sqlite_target_is_private_in_memory(":memory:"));
+        assert!(sqlite_target_is_private_in_memory("sqlite::memory:"));
+        assert!(sqlite_target_is_private_in_memory("sqlite://:memory:"));
+        assert!(sqlite_target_is_private_in_memory("sqlite://"));
+        assert!(sqlite_target_is_private_in_memory("file::memory:"));
+        assert!(sqlite_target_is_private_in_memory("file::memory:?foo=bar"));
+        // Shared-cache in-memory is shareable across connections — NOT private.
+        assert!(!sqlite_target_is_private_in_memory(
+            "file::memory:?cache=shared"
+        ));
+        assert!(!sqlite_target_is_private_in_memory(
+            "file:app?mode=memory&cache=shared"
+        ));
+        // File-backed targets persist and are shared — NOT private in-memory.
+        assert!(!sqlite_target_is_private_in_memory(
+            "sqlite:///var/lib/app.db"
+        ));
+        assert!(!sqlite_target_is_private_in_memory("/var/lib/app.db"));
+        assert!(!sqlite_target_is_private_in_memory("file:/var/lib/app.db"));
     }
 
     // A read-only URI target (`mode=ro` / `immutable`) must be detected so the

--- a/autumn/src/migrate.rs
+++ b/autumn/src/migrate.rs
@@ -264,6 +264,61 @@ pub fn pending_migrations(
     })
 }
 
+/// Actionable error surfaced when a **private** in-memory `SQLite` target is
+/// configured together with registered startup migrations (issue #1614
+/// follow-up).
+///
+/// A private in-memory database (`sqlite::memory:` / `:memory:` /
+/// `file::memory:` without `cache=shared`) gives every connection its own
+/// isolated, empty database, so migrations applied on the throwaway migration
+/// connection can never become visible to the runtime pool. The remedy is a
+/// file-backed database or a shared-cache in-memory URL, both of which retain
+/// the migrated schema for the pool.
+#[cfg(feature = "sqlite")]
+pub(crate) const PRIVATE_IN_MEMORY_MIGRATION_MSG: &str = "Private in-memory SQLite (`sqlite::memory:` / `:memory:`) cannot retain startup \
+     migrations for the runtime pool \u{2014} each connection gets its own empty database. \
+     Use a file-backed SQLite database, or a shared-cache in-memory URL \
+     (`file::memory:?cache=shared`), when registering migrations.";
+
+/// Return the [`PRIVATE_IN_MEMORY_MIGRATION_MSG`] reject error when
+/// `database_url` is a **private** in-memory `SQLite` target AND `migrations`
+/// carries at least one registered migration to apply; otherwise `None`.
+///
+/// This is the single decision point the `SQLite` migration-application paths
+/// share (the boot [`auto_migrate_sqlite`], the pub [`run_pending_sqlite`], and
+/// the `AUTUMN_MIGRATE=1` `apply_pending_sqlite_or_exit`), so they cannot drift.
+/// It performs no I/O — the target is classified from the URL string
+/// ([`crate::db::sqlite_target_is_private_in_memory`], which reuses the same
+/// helpers pool sizing uses) and the registered set is enumerated in-memory —
+/// so it runs **before** any throwaway migration connection is opened.
+///
+/// An empty migration set returns `None`: a private in-memory target with no
+/// registered migrations is a legitimate configuration (it is the default test
+/// harness), so it is never rejected. A file-backed or shared-cache in-memory
+/// target likewise returns `None` — those retain migrations for the pool.
+#[cfg(feature = "sqlite")]
+pub(crate) fn reject_private_in_memory_migrations<S>(
+    database_url: &str,
+    migrations: &S,
+) -> Option<MigrationError>
+where
+    S: diesel::migration::MigrationSource<diesel::sqlite::Sqlite>,
+{
+    if !crate::db::sqlite_target_is_private_in_memory(database_url) {
+        return None;
+    }
+    // Only reject when there is actually a migration to apply. If the set can't
+    // be enumerated, treat it as non-empty (the apply would fail anyway) so the
+    // doomed configuration is still surfaced rather than silently proceeding.
+    let has_registered = migrations.migrations().map_or(true, |m| !m.is_empty());
+    if !has_registered {
+        return None;
+    }
+    Some(MigrationError::Migration(
+        PRIVATE_IN_MEMORY_MIGRATION_MSG.to_owned(),
+    ))
+}
+
 /// Run all pending migrations against a `SQLite` database URL (issue #1614, PR3).
 ///
 /// The `SQLite` counterpart to [`run_pending`]. `SQLite` is a single-writer local
@@ -288,6 +343,14 @@ pub fn run_pending_sqlite(
     database_url: &str,
     migrations: impl diesel::migration::MigrationSource<diesel::sqlite::Sqlite>,
 ) -> Result<MigrationResult, MigrationError> {
+    // Reject a PRIVATE in-memory target with registered migrations before
+    // opening the (throwaway) migration connection: each such connection is its
+    // own empty database, so migrations applied here can never reach the runtime
+    // pool (issue #1614 follow-up). A file-backed or shared-cache in-memory
+    // target is unaffected.
+    if let Some(err) = reject_private_in_memory_migrations(database_url, &migrations) {
+        return Err(err);
+    }
     let mut conn = crate::db::establish_sqlite_migration_connection(database_url)
         .map_err(|e| MigrationError::Connection(e.to_string()))?;
     let mut harness = HarnessWithOutput::write_to_stdout(&mut conn);
@@ -2339,6 +2402,22 @@ pub(crate) fn auto_migrate_sqlite(
     migrations: &EmbeddedMigrations,
     target: &str,
 ) {
+    // A private in-memory target with registered migrations cannot work: each
+    // connection is its own empty database, so migrations applied on the
+    // throwaway migration connection never reach the runtime pool. Fail startup
+    // fast with an actionable message — in both the auto-apply and
+    // report-pending profiles — rather than booting into a schema-less pool
+    // whose every DB-backed request 500s (issue #1614 follow-up).
+    if let Some(err) =
+        reject_private_in_memory_migrations(database_url, &EmbeddedMigrationsRef(migrations))
+    {
+        tracing::error!(
+            target = %target,
+            error = %err,
+            "Refusing to run SQLite migrations against a private in-memory target",
+        );
+        std::process::exit(1);
+    }
     if should_auto_apply(profile, allow_auto_migrate_in_production) {
         tracing::info!(target = %target, "Running pending SQLite database migrations...");
         match run_pending_sqlite(database_url, EmbeddedMigrationsRef(migrations)) {

--- a/autumn/src/migrate.rs
+++ b/autumn/src/migrate.rs
@@ -264,6 +264,66 @@ pub fn pending_migrations(
     })
 }
 
+/// Run all pending migrations against a `SQLite` database URL (issue #1614, PR3).
+///
+/// The `SQLite` counterpart to [`run_pending`]. `SQLite` is a single-writer local
+/// database, so — unlike the Postgres path — there is **no advisory lock**: no
+/// cross-process serialization is needed and `SQLite` has no `pg_advisory_lock`
+/// primitive. Establishes a synchronous `SqliteConnection` (via
+/// [`crate::db::establish_sqlite_migration_connection`]) and applies pending
+/// migrations through diesel's `MigrationHarness`.
+///
+/// The migration set is taken as a [`MigrationSource<Sqlite>`](diesel::migration::MigrationSource);
+/// the framework's [`EmbeddedMigrations`] (and [`EmbeddedMigrationsRef`]) satisfy
+/// this for the `SQLite` backend exactly as they do for Postgres, so a set
+/// registered via [`AppBuilder::migrations`](crate::app::AppBuilder::migrations)
+/// runs here unchanged.
+///
+/// # Errors
+///
+/// Returns [`MigrationError::Connection`] if the database cannot be opened, or
+/// [`MigrationError::Migration`] if a migration fails.
+#[cfg(feature = "sqlite")]
+pub fn run_pending_sqlite(
+    database_url: &str,
+    migrations: impl diesel::migration::MigrationSource<diesel::sqlite::Sqlite>,
+) -> Result<MigrationResult, MigrationError> {
+    let mut conn = crate::db::establish_sqlite_migration_connection(database_url)
+        .map_err(|e| MigrationError::Connection(e.to_string()))?;
+    let mut harness = HarnessWithOutput::write_to_stdout(&mut conn);
+    let applied = harness
+        .run_pending_migrations(migrations)
+        .map_err(|e| MigrationError::Migration(e.to_string()))?;
+    Ok(MigrationResult {
+        applied: applied.iter().map(|m| format!("{m}")).collect(),
+    })
+}
+
+/// Return names of pending (not yet applied) migrations on a `SQLite` target.
+///
+/// The `SQLite` status counterpart to [`pending_migrations`], used by
+/// [`auto_migrate_sqlite`] to report pending work without applying it.
+///
+/// # Errors
+///
+/// Returns [`MigrationError::Connection`] if the database cannot be opened, or
+/// [`MigrationError::Migration`] if status cannot be determined.
+#[cfg(feature = "sqlite")]
+fn pending_migrations_sqlite(
+    database_url: &str,
+    migrations: impl diesel::migration::MigrationSource<diesel::sqlite::Sqlite>,
+) -> Result<Vec<String>, MigrationError> {
+    let mut conn = crate::db::establish_sqlite_migration_connection(database_url)
+        .map_err(|e| MigrationError::Connection(e.to_string()))?;
+    let pending = conn
+        .pending_migrations(migrations)
+        .map_err(|e| MigrationError::Migration(e.to_string()))?;
+    Ok(pending
+        .iter()
+        .map(|m| m.name().version().to_string())
+        .collect())
+}
+
 pub(crate) fn compare_replica_migration_versions(
     primary: &[String],
     replica: &[String],
@@ -2233,6 +2293,79 @@ pub(crate) fn auto_migrate(
                          rolling deploy (expand/contract pattern)."
                     );
                 }
+                tracing::warn!(
+                    count = pending.len(),
+                    target = %target,
+                    "Pending migrations detected. Run `autumn migrate` to apply them."
+                );
+                for name in &pending {
+                    tracing::warn!(migration = %name, target = %target, "Pending migration");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, target = %target, "Could not check migration status");
+            }
+        }
+    }
+}
+
+/// Run migrations against a `SQLite` control target at startup (issue #1614, PR3).
+///
+/// The `SQLite` counterpart to [`auto_migrate`]: it honors the same profile
+/// policy via [`should_auto_apply`] (dev / development auto-applies; prod /
+/// production applies only when `allow_auto_migrate_in_production` is set;
+/// otherwise it reports pending work), and fails fast (`process::exit(1)`) on an
+/// apply error exactly like the Postgres path.
+///
+/// It deliberately omits the two Postgres-specific mechanisms
+/// [`auto_migrate`] relies on:
+///
+///   * **the advisory lock** — `SQLite` is single-writer; there is no
+///     `pg_advisory_lock` and no cross-process migration race to serialize
+///     (`run_pending_sqlite` applies directly, unlocked).
+///   * **the content-checksum drift guard** — its `autumn_migration_checksums`
+///     bookkeeping is Postgres DDL (`TIMESTAMPTZ`, `now()`, `to_regclass`) and
+///     is not ported to `SQLite` in this PR.
+///
+/// Sharding (directory / shard-map control tables, per-shard fan-out) is
+/// Postgres-only and is rejected upstream at boot
+/// (`sqlite_sharding_unsupported_guard`), so this only ever applies the
+/// registered control migration set.
+#[cfg(feature = "sqlite")]
+pub(crate) fn auto_migrate_sqlite(
+    database_url: &str,
+    profile: Option<&str>,
+    allow_auto_migrate_in_production: bool,
+    migrations: &EmbeddedMigrations,
+    target: &str,
+) {
+    if should_auto_apply(profile, allow_auto_migrate_in_production) {
+        tracing::info!(target = %target, "Running pending SQLite database migrations...");
+        match run_pending_sqlite(database_url, EmbeddedMigrationsRef(migrations)) {
+            Ok(result) if result.applied.is_empty() => {
+                tracing::info!(target = %target, "No pending migrations");
+            }
+            Ok(result) => {
+                for name in &result.applied {
+                    tracing::info!(migration = %name, target = %target, "Applied migration");
+                }
+                tracing::info!(
+                    count = result.applied.len(),
+                    target = %target,
+                    "All pending migrations applied"
+                );
+            }
+            Err(e) => {
+                tracing::error!(error = %e, target = %target, "Failed to run migrations");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        match pending_migrations_sqlite(database_url, EmbeddedMigrationsRef(migrations)) {
+            Ok(pending) if pending.is_empty() => {
+                tracing::info!(target = %target, "Database migrations are up to date");
+            }
+            Ok(pending) => {
                 tracing::warn!(
                     count = pending.len(),
                     target = %target,

--- a/autumn/src/migrate.rs
+++ b/autumn/src/migrate.rs
@@ -264,47 +264,51 @@ pub fn pending_migrations(
     })
 }
 
-/// Actionable error surfaced when a **private** in-memory `SQLite` target is
+/// Actionable error surfaced when **any** in-memory `SQLite` target is
 /// configured together with registered startup migrations (issue #1614
 /// follow-up).
 ///
-/// A private in-memory database (`sqlite::memory:` / `:memory:` /
-/// `file::memory:` without `cache=shared`) gives every connection its own
-/// isolated, empty database, so migrations applied on the throwaway migration
-/// connection can never become visible to the runtime pool. The remedy is a
-/// file-backed database or a shared-cache in-memory URL, both of which retain
-/// the migrated schema for the pool.
+/// No in-memory database — private (`sqlite::memory:` / `:memory:` /
+/// `file::memory:`) OR shared-cache (`file::memory:?cache=shared`) — can retain
+/// a registered migration for the runtime pool. The migration runs on a
+/// transient synchronous connection; a *private* in-memory database gives every
+/// connection its own empty database, and a *shared* in-memory database is
+/// destroyed the moment its last connection closes — and because the runtime
+/// deadpool is created lazily (it may not have checked out a connection yet), the
+/// pool's first checkout opens a fresh, empty database. Either way the migrated
+/// schema is gone before the pool anchors it. The only remedy is a **file-backed**
+/// database, which persists on disk across the migration connection closing.
 #[cfg(feature = "sqlite")]
-pub(crate) const PRIVATE_IN_MEMORY_MIGRATION_MSG: &str = "Private in-memory SQLite (`sqlite::memory:` / `:memory:`) cannot retain startup \
-     migrations for the runtime pool \u{2014} each connection gets its own empty database. \
-     Use a file-backed SQLite database, or a shared-cache in-memory URL \
-     (`file::memory:?cache=shared`), when registering migrations.";
+pub(crate) const IN_MEMORY_MIGRATION_MSG: &str = "In-memory SQLite (`:memory:` / `sqlite::memory:` / `file::memory:`, including \
+     `cache=shared`) cannot be used with registered startup migrations \u{2014} the \
+     schema is applied on a transient connection and is lost before the runtime \
+     pool anchors it. Use a file-backed SQLite database.";
 
-/// Return the [`PRIVATE_IN_MEMORY_MIGRATION_MSG`] reject error when
-/// `database_url` is a **private** in-memory `SQLite` target AND `migrations`
+/// Return the [`IN_MEMORY_MIGRATION_MSG`] reject error when `database_url` is
+/// **any** in-memory `SQLite` target (private OR shared-cache) AND `migrations`
 /// carries at least one registered migration to apply; otherwise `None`.
 ///
 /// This is the single decision point the `SQLite` migration-application paths
 /// share (the boot [`auto_migrate_sqlite`], the pub [`run_pending_sqlite`], and
 /// the `AUTUMN_MIGRATE=1` `apply_pending_sqlite_or_exit`), so they cannot drift.
 /// It performs no I/O — the target is classified from the URL string
-/// ([`crate::db::sqlite_target_is_private_in_memory`], which reuses the same
-/// helpers pool sizing uses) and the registered set is enumerated in-memory —
-/// so it runs **before** any throwaway migration connection is opened.
+/// ([`crate::db::sqlite_target_is_any_in_memory`]) and the registered set is
+/// enumerated in-memory — so it runs **before** any transient migration
+/// connection is opened.
 ///
-/// An empty migration set returns `None`: a private in-memory target with no
-/// registered migrations is a legitimate configuration (it is the default test
-/// harness), so it is never rejected. A file-backed or shared-cache in-memory
-/// target likewise returns `None` — those retain migrations for the pool.
+/// An empty migration set returns `None`: an in-memory target with no registered
+/// migrations is a legitimate configuration (it is the default test harness), so
+/// it is never rejected. A file-backed target likewise returns `None` — only it
+/// retains the migrated schema for the pool.
 #[cfg(feature = "sqlite")]
-pub(crate) fn reject_private_in_memory_migrations<S>(
+pub(crate) fn reject_in_memory_migrations<S>(
     database_url: &str,
     migrations: &S,
 ) -> Option<MigrationError>
 where
     S: diesel::migration::MigrationSource<diesel::sqlite::Sqlite>,
 {
-    if !crate::db::sqlite_target_is_private_in_memory(database_url) {
+    if !crate::db::sqlite_target_is_any_in_memory(database_url) {
         return None;
     }
     // Only reject when there is actually a migration to apply. If the set can't
@@ -315,7 +319,7 @@ where
         return None;
     }
     Some(MigrationError::Migration(
-        PRIVATE_IN_MEMORY_MIGRATION_MSG.to_owned(),
+        IN_MEMORY_MIGRATION_MSG.to_owned(),
     ))
 }
 
@@ -343,12 +347,13 @@ pub fn run_pending_sqlite(
     database_url: &str,
     migrations: impl diesel::migration::MigrationSource<diesel::sqlite::Sqlite>,
 ) -> Result<MigrationResult, MigrationError> {
-    // Reject a PRIVATE in-memory target with registered migrations before
-    // opening the (throwaway) migration connection: each such connection is its
-    // own empty database, so migrations applied here can never reach the runtime
-    // pool (issue #1614 follow-up). A file-backed or shared-cache in-memory
-    // target is unaffected.
-    if let Some(err) = reject_private_in_memory_migrations(database_url, &migrations) {
+    // Reject ANY in-memory target (private OR shared-cache) with registered
+    // migrations before opening the (transient) migration connection: the
+    // migrated schema is lost before the runtime pool anchors it — a private
+    // in-memory connection is its own empty database, and a shared in-memory
+    // database is destroyed when its last connection closes (issue #1614
+    // follow-up). Only a file-backed target is unaffected.
+    if let Some(err) = reject_in_memory_migrations(database_url, &migrations) {
         return Err(err);
     }
     let mut conn = crate::db::establish_sqlite_migration_connection(database_url)
@@ -2402,19 +2407,19 @@ pub(crate) fn auto_migrate_sqlite(
     migrations: &EmbeddedMigrations,
     target: &str,
 ) {
-    // A private in-memory target with registered migrations cannot work: each
-    // connection is its own empty database, so migrations applied on the
-    // throwaway migration connection never reach the runtime pool. Fail startup
-    // fast with an actionable message — in both the auto-apply and
-    // report-pending profiles — rather than booting into a schema-less pool
-    // whose every DB-backed request 500s (issue #1614 follow-up).
-    if let Some(err) =
-        reject_private_in_memory_migrations(database_url, &EmbeddedMigrationsRef(migrations))
+    // An in-memory target (private OR shared-cache) with registered migrations
+    // cannot work: the migrated schema is lost before the runtime pool anchors
+    // it — a private connection is its own empty database, and a shared in-memory
+    // database is destroyed when its last connection closes. Fail startup fast
+    // with an actionable message — in both the auto-apply and report-pending
+    // profiles — rather than booting into a schema-less pool whose every
+    // DB-backed request 500s (issue #1614 follow-up).
+    if let Some(err) = reject_in_memory_migrations(database_url, &EmbeddedMigrationsRef(migrations))
     {
         tracing::error!(
             target = %target,
             error = %err,
-            "Refusing to run SQLite migrations against a private in-memory target",
+            "Refusing to run SQLite migrations against an in-memory target",
         );
         std::process::exit(1);
     }

--- a/autumn/tests/fixtures/sqlite_migrations/00000000000001_create_widgets/down.sql
+++ b/autumn/tests/fixtures/sqlite_migrations/00000000000001_create_widgets/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE widgets;

--- a/autumn/tests/fixtures/sqlite_migrations/00000000000001_create_widgets/up.sql
+++ b/autumn/tests/fixtures/sqlite_migrations/00000000000001_create_widgets/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE widgets (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL
+);

--- a/autumn/tests/sqlite_migrations.rs
+++ b/autumn/tests/sqlite_migrations.rs
@@ -161,3 +161,47 @@ async fn registered_migrations_apply_to_sqlite_and_serve() {
         "response body is the row written to and read from the migrated `widgets` table"
     );
 }
+
+/// A **private** in-memory target with registered migrations is rejected up
+/// front with an actionable error (issue #1614 follow-up). Each `:memory:`
+/// connection is its own empty database, so migrations applied on the throwaway
+/// migration connection could never reach the runtime pool — surfacing the
+/// error beats silently applying to a database the pool never sees.
+#[test]
+fn private_in_memory_target_with_registered_migrations_is_rejected() {
+    for url in [
+        "sqlite::memory:",
+        ":memory:",
+        "sqlite://:memory:",
+        "file::memory:",
+    ] {
+        let err = run_pending_sqlite(url, MIGRATIONS)
+            .expect_err("private in-memory + registered migrations must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("in-memory"),
+            "error names the in-memory problem (got {msg:?})"
+        );
+        assert!(
+            msg.contains("file-backed") && msg.contains("cache=shared"),
+            "error gives the file-backed / shared-cache remedy (got {msg:?})"
+        );
+    }
+}
+
+/// A **shared-cache** in-memory target (`file::memory:?cache=shared`) is shared
+/// across connections within one process, so it retains migrations for the
+/// runtime pool and is NOT rejected — the migration applies exactly like a
+/// file-backed target. (The private-vs-shared classification itself is unit
+/// tested in `db::sqlite_target_is_private_in_memory_classifies_targets`.)
+#[test]
+fn shared_cache_in_memory_target_is_not_rejected() {
+    let result = run_pending_sqlite("file::memory:?cache=shared", MIGRATIONS)
+        .expect("shared-cache in-memory retains migrations for the pool and is not rejected");
+    assert_eq!(
+        result.applied.len(),
+        1,
+        "the one registered migration applies on a shared-cache in-memory target (got {:?})",
+        result.applied
+    );
+}

--- a/autumn/tests/sqlite_migrations.rs
+++ b/autumn/tests/sqlite_migrations.rs
@@ -164,9 +164,10 @@ async fn registered_migrations_apply_to_sqlite_and_serve() {
 
 /// A **private** in-memory target with registered migrations is rejected up
 /// front with an actionable error (issue #1614 follow-up). Each `:memory:`
-/// connection is its own empty database, so migrations applied on the throwaway
+/// connection is its own empty database, so migrations applied on the transient
 /// migration connection could never reach the runtime pool — surfacing the
-/// error beats silently applying to a database the pool never sees.
+/// error beats silently applying to a database the pool never sees. The remedy
+/// is a **file-backed** database only.
 #[test]
 fn private_in_memory_target_with_registered_migrations_is_rejected() {
     for url in [
@@ -179,29 +180,45 @@ fn private_in_memory_target_with_registered_migrations_is_rejected() {
             .expect_err("private in-memory + registered migrations must be rejected");
         let msg = err.to_string();
         assert!(
-            msg.contains("in-memory"),
+            msg.to_lowercase().contains("in-memory"),
             "error names the in-memory problem (got {msg:?})"
         );
         assert!(
-            msg.contains("file-backed") && msg.contains("cache=shared"),
-            "error gives the file-backed / shared-cache remedy (got {msg:?})"
+            msg.contains("file-backed"),
+            "error gives the file-backed remedy (got {msg:?})"
         );
     }
 }
 
-/// A **shared-cache** in-memory target (`file::memory:?cache=shared`) is shared
-/// across connections within one process, so it retains migrations for the
-/// runtime pool and is NOT rejected — the migration applies exactly like a
-/// file-backed target. (The private-vs-shared classification itself is unit
-/// tested in `db::sqlite_target_is_private_in_memory_classifies_targets`.)
+/// A **shared-cache** in-memory target (`file::memory:?cache=shared`) with
+/// registered migrations is ALSO rejected up front (issue #1614 follow-up).
+/// Although a shared-cache database is shareable across the runtime pool's live
+/// connections, the migration runs on a *transient* synchronous connection and
+/// SQLite destroys a shared in-memory database the moment its last connection
+/// closes; the runtime deadpool is created lazily and may not have anchored a
+/// connection yet, so the pool's first checkout opens a fresh, empty database
+/// and every DB-backed request then 500s. The remedy is a **file-backed**
+/// database — the corrected recommendation no longer suggests `cache=shared`.
+/// (The private-vs-shared sizing classification stays unchanged and is unit
+/// tested in `db::sqlite_target_is_any_in_memory_covers_shared_cache`.)
 #[test]
-fn shared_cache_in_memory_target_is_not_rejected() {
-    let result = run_pending_sqlite("file::memory:?cache=shared", MIGRATIONS)
-        .expect("shared-cache in-memory retains migrations for the pool and is not rejected");
-    assert_eq!(
-        result.applied.len(),
-        1,
-        "the one registered migration applies on a shared-cache in-memory target (got {:?})",
-        result.applied
+fn shared_cache_in_memory_target_with_registered_migrations_is_rejected() {
+    let err = run_pending_sqlite("file::memory:?cache=shared", MIGRATIONS).expect_err(
+        "shared-cache in-memory + registered migrations must be rejected: the schema is \
+         lost before the runtime pool anchors it",
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.to_lowercase().contains("in-memory"),
+        "error names the in-memory problem (got {msg:?})"
+    );
+    assert!(
+        msg.contains("file-backed"),
+        "error gives the file-backed remedy (got {msg:?})"
+    );
+    assert!(
+        !msg.contains("`file::memory:?cache=shared`"),
+        "the corrected message no longer recommends a shared-cache in-memory URL as a remedy \
+         (got {msg:?})"
     );
 }

--- a/autumn/tests/sqlite_migrations.rs
+++ b/autumn/tests/sqlite_migrations.rs
@@ -1,0 +1,163 @@
+//! Startup-migration proof for the `SQLite` runtime lane (issue #1614, PR3).
+//!
+//! PR2 built the `SQLite` deadpool pool + boot/serve but *gated* registered
+//! startup migrations (a `sqlite://` target with `.migrations(...)` failed
+//! fast). PR3 replaces that gate with a working `SQLite` migration path. This
+//! test exercises the whole chain the way an app does:
+//!
+//! 1. **Registered migrations apply** — an [`EmbeddedMigrations`] set (exactly
+//!    the type [`AppBuilder::migrations`](autumn_web) stores) is applied to a
+//!    `sqlite://` file target through the new
+//!    [`autumn_web::migrate::run_pending_sqlite`] path — diesel's
+//!    `MigrationHarness` on a `SqliteConnection`, with **no** Postgres advisory
+//!    lock.
+//! 2. **The migrated schema is visible to the runtime pool** — the public
+//!    [`autumn_web::db::create_pool`] entry builds the real `SQLite` runtime
+//!    pool over the *same* database file, and a checked-out connection reads and
+//!    writes the migration-created `widgets` table.
+//! 3. **A DB-backed request serves** — a minimal Axum router holds the pool in
+//!    state and answers an HTTP request by `INSERT`ing then `SELECT`ing from
+//!    `widgets`, driving one real request/response through the migrated schema.
+//!
+//! A **file** target (tempfile) is deliberate: an in-memory `SQLite` database is
+//! private per connection, so migrations applied on the (separate) migration
+//! connection would be invisible to the pool. File targets share the database.
+//!
+//! Run it explicitly (never via a members-enable edge — that would trip the
+//! feature-unification hazard):
+//!
+//! ```sh
+//! cargo test -p autumn-web --features sqlite --test sqlite_migrations
+//! ```
+#![cfg(feature = "sqlite")]
+
+use autumn_web::config::DatabaseConfig;
+use autumn_web::db::{RuntimeConnection, create_pool};
+use autumn_web::migrate::{EmbeddedMigrations, embed_migrations, run_pending_sqlite};
+use autumn_web::reexports::{axum, diesel, diesel_async};
+
+use axum::Router;
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{Request, StatusCode};
+use axum::routing::post;
+use diesel_async::RunQueryDsl as _;
+use diesel_async::pooled_connection::deadpool::Pool;
+use tower::ServiceExt as _; // for `oneshot`
+
+/// The app-registered migration set — the identical `EmbeddedMigrations` type
+/// `.migrations(MIGRATIONS)` stores. It creates the `widgets` table.
+const MIGRATIONS: EmbeddedMigrations = embed_migrations!("tests/fixtures/sqlite_migrations");
+
+/// The runtime pool type. Under `--features sqlite` `RuntimeConnection` resolves
+/// to `SyncConnectionWrapper<SqliteConnection>`.
+type SqlitePool = Pool<RuntimeConnection>;
+
+#[derive(diesel::QueryableByName)]
+struct Widget {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    name: String,
+}
+
+/// Answers `POST /widgets` by writing a row into the migration-created table and
+/// reading it back — proving the migrated schema is live through the pool.
+async fn create_and_read_widget(State(pool): State<SqlitePool>) -> Result<String, StatusCode> {
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
+    diesel::sql_query("INSERT INTO widgets (id, name) VALUES (1, 'sprocket')")
+        .execute(&mut *conn)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let rows: Vec<Widget> = diesel::sql_query("SELECT name FROM widgets WHERE id = 1")
+        .load(&mut *conn)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    rows.into_iter()
+        .next()
+        .map(|w| w.name)
+        .ok_or(StatusCode::NOT_FOUND)
+}
+
+#[tokio::test]
+async fn registered_migrations_apply_to_sqlite_and_serve() {
+    // A tempfile-backed database so the migration connection and every pooled
+    // connection observe the same `widgets` table.
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let db_path = tmp.path().join("migrate.db");
+    let url = format!("sqlite://{}", db_path.display());
+
+    // (1) Apply the registered migrations through the new SQLite path (no
+    //     advisory lock). This is the behavior PR2 rejected with a fail-fast
+    //     gate; PR3 makes it work.
+    let result =
+        run_pending_sqlite(&url, MIGRATIONS).expect("registered migrations apply on sqlite");
+    assert_eq!(
+        result.applied.len(),
+        1,
+        "exactly the one registered migration is applied (got {:?})",
+        result.applied
+    );
+
+    // Re-running is a no-op: the migration is already recorded.
+    let again =
+        run_pending_sqlite(&url, MIGRATIONS).expect("re-running pending migrations is a no-op");
+    assert!(
+        again.applied.is_empty(),
+        "second run applies nothing (got {:?})",
+        again.applied
+    );
+
+    // (2) Build the real SQLite runtime pool over the same file via the public
+    //     `create_pool` entry, and confirm the migrated `widgets` table exists
+    //     on a checked-out pooled connection.
+    let config = DatabaseConfig {
+        url: Some(url),
+        ..Default::default()
+    };
+    let pool: SqlitePool = create_pool(&config)
+        .expect("sqlite pool builds")
+        .expect("a url is configured");
+    {
+        let mut conn = pool.get().await.expect("checkout a sqlite connection");
+        // If the migration had not applied, this SELECT would error ("no such
+        // table: widgets").
+        let rows: Vec<Widget> = diesel::sql_query("SELECT name FROM widgets WHERE 1 = 0")
+            .load(&mut *conn)
+            .await
+            .expect("the migrated `widgets` table is visible to the runtime pool");
+        assert!(rows.is_empty(), "no rows seeded yet");
+    }
+
+    // (3) A minimal router backed by the SQLite pool serves a DB-backed request
+    //     against the migrated schema.
+    let app: Router = Router::new()
+        .route("/widgets", post(create_and_read_widget))
+        .with_state(pool);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/widgets")
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("router serves the request");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "DB-backed route against the migrated schema is 200"
+    );
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    assert_eq!(
+        &body[..],
+        b"sprocket",
+        "response body is the row written to and read from the migrated `widgets` table"
+    );
+}


### PR DESCRIPTION
## Before / After

**Before** (PR2 / #1987): registering `.migrations(...)` on an app whose control target is a `sqlite://` URL **failed fast** at boot with an actionable "SQLite startup migrations are not yet supported" error — the Rust startup-migration harness was Postgres-only (`PgConnection::establish`), so a `sqlite:` URL routed there would have crashed before serving. Registered migrations could not be applied to a SQLite target; you had to apply your schema out-of-band.

**After**: registered migrations **actually apply** to a `sqlite://` target through diesel's `MigrationHarness` on a plain `SqliteConnection`, with **no advisory lock** (SQLite is single-writer; there's no `pg_advisory_lock` and no cross-process race to serialize). The standard `AppBuilder` flow — register `.migrations(...)` and boot with a `sqlite://` URL — now applies the schema and serves DB-backed requests. This works on both the normal boot path and the `AUTUMN_MIGRATE=1` one-shot.

**Still unsupported**: **sharding on SQLite**. The shard-directory / shard-map control tables and per-shard fan-out are Postgres-only primitives, so a `sqlite://` control target with sharding required (directory/shard-map control migrations or configured shards) — and any `sqlite:` shard `primary_url` — is still rejected with an actionable, sharding-named boot error. Postgres (the default, `not(feature = "sqlite")`) is byte-identical.

## How

- **`db::establish_sqlite_migration_connection`** — a thin `SqliteConnection` establisher normalized through the existing `normalize_sqlite_target`, so the migration connection and the runtime pool open the same database file. (`#[cfg(feature = "sqlite")]`.)
- **`migrate::run_pending_sqlite`** (pub), **`pending_migrations_sqlite`**, **`auto_migrate_sqlite`** — the SQLite counterparts of the Postgres `run_pending` / `pending_migrations` / `auto_migrate`, honoring the same auto-apply profile policy (`should_auto_apply`) but **without** the advisory lock and **without** the Postgres-only content-checksum drift guard (its `autumn_migration_checksums` bookkeeping is Postgres DDL).
- **Boot + migrate-only integration.** The former `sqlite_startup_migration_guard` is renamed/repurposed to **`sqlite_sharding_unsupported_guard`** and now rejects only the sharding case (a SQLite control target with `directory_migration_required || shard_map_migration_required || has_shards()`, or any SQLite shard target). `run_startup_migrations` routes a SQLite control target through `auto_migrate_sqlite` (skipping the Postgres-only directory/shard-map framework migrations — single-node, no shards), and the `AUTUMN_MIGRATE=1` handler applies a SQLite control target through the new unlocked `apply_pending_sqlite_or_exit`. Both paths call the same guard, so boot and migrate-only can't drift (enforced by the existing source-drift test).
- **Retained sharding rejection.** Directory/shard-map internal migrations under SQLite are omitted by design; the two sharding-under-SQLite situations fail fast with an actionable "SQLite deployments do not support sharding … Tracking: #1614" message.
- **No public API change.** The stored `EmbeddedMigrations` already impls `MigrationSource<DB: Backend>` generically (via `EmbeddedMigrationsRef`), so a set registered via `AppBuilder::migrations` runs against the SQLite backend unchanged. All new logic is `#[cfg(feature = "sqlite")]`, so the Postgres path is byte-identical.
- **Boot/serve test** (`tests/sqlite_migrations.rs`, an isolated `#[cfg(feature = "sqlite")]` `[[test]]`): applies a registered `CREATE TABLE widgets` migration to a `sqlite://` tempfile via `run_pending_sqlite` (asserts one applied, then idempotent), builds the real runtime pool via the public `create_pool`, and serves an `INSERT`+`SELECT` HTTP request against the migrated table — proving migrations apply *and then* serve. The retained sharding rejection is covered by the `sqlite_sharding_unsupported_guard` unit tests.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo check --workspace -j 2` GREEN
- `cargo build -p autumn-web --features sqlite -j 2` GREEN
- `cargo clippy -p autumn-web --all-targets -- -D warnings` (default Lint gate) GREEN, zero warnings
- `cargo clippy -p autumn-web --features sqlite --lib -- -D warnings` GREEN
- New `sqlite_migrations` test + all existing sqlite tests + the 7 guard unit tests PASS
- `cargo test -p autumn-web --lib -- db:: app:: migrate::` (default) — 281 passed (includes the boot/migrate-only source-drift test)

## Out of scope

Full `#[repository]` CRUD on SQLite still can't compile under the `sqlite` feature — tracked as **#1996** — and is out of scope here. This PR is the migration-mechanism lane only.

Part of #1614

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuoMnnmkhC2hsTmqm1inA6)_