### PR TITLE
Parse #[model] structs into the schema IR (declarative schema, slice 2)

### DIFF
--- a/autumn-cli/src/main.rs
+++ b/autumn-cli/src/main.rs
@@ -38,6 +38,7 @@ mod release;
 mod routes;
 mod routes_audit;
 mod scaling_driver;
+mod schema;
 mod seed;
 mod serve;
 mod setup;
@@ -347,6 +348,14 @@ enum Commands {
         /// When omitted, the config value is used (default `0` = fail fast).
         #[arg(long, value_name = "SECS")]
         wait: Option<u64>,
+    },
+    /// Declarative schema tooling (experimental; wave-15).
+    ///
+    /// Reads `#[model]` structs into the shared schema IR. Slice 2 ships only
+    /// the read-only `parse` action; `diff`/`snapshot`/… arrive in later slices.
+    Schema {
+        #[command(subcommand)]
+        action: schema::SchemaAction,
     },
     /// Create, drop, or reset the database itself.
     ///
@@ -2642,6 +2651,7 @@ fn run_command(command: Commands) {
                 },
             );
         }
+        Commands::Schema { action } => schema::run(action),
         Commands::Migrate {
             action,
             with_maintenance,

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -1,0 +1,70 @@
+//! Declarative-schema tooling (wave-15, tracking issue #1975).
+//!
+//! Slice 2 lives here: [`parse`], a `syn`-backed reader that lifts an app's
+//! `#[model]` structs into the shared [`autumn_schema_core`] IR — the
+//! **desired state** later slices (a checked-in snapshot, then the diff engine
+//! and the full `autumn schema` command group) build on. It is read-only:
+//! nothing here writes a migration, `schema.rs`, or any other codegen output.
+//!
+//! The experimental [`run`] entrypoint backs `autumn schema parse <path>`, which
+//! prints the parsed IR as JSON. It is the first (deliberately minimal) stub of
+//! the eventual `autumn schema` group and gives the parser a real caller.
+
+pub mod parse;
+
+use std::path::Path;
+
+use autumn_schema_core::Backend;
+
+use parse::{parse_model_source, parse_models_dir};
+
+/// The `autumn schema` subcommand actions (experimental; slice 2 ships only
+/// `parse`). Kept here so the slice-6 command group can grow additional actions
+/// (`diff`, `snapshot`, …) alongside it in later slices.
+#[derive(clap::Subcommand, Debug)]
+pub enum SchemaAction {
+    /// Parse `#[model]` structs at PATH (a `.rs` file or a directory of them)
+    /// and print the resulting schema IR as JSON. Experimental / read-only.
+    Parse {
+        /// A `.rs` file or a directory containing `*.rs` model files.
+        path: std::path::PathBuf,
+    },
+}
+
+/// Run an `autumn schema` action. Prints to stdout on success; on error, writes
+/// a message to stderr and exits non-zero (matching the other CLI handlers,
+/// which own their own error reporting).
+pub fn run(action: SchemaAction) {
+    match action {
+        SchemaAction::Parse { path } => match run_parse(&path) {
+            Ok(json) => println!("{json}"),
+            Err(message) => {
+                eprintln!("error: {message}");
+                std::process::exit(1);
+            }
+        },
+    }
+}
+
+/// Parse a file or directory and render the tables as pretty JSON, surfacing any
+/// per-field diagnostics on stderr. Split out (returning `Result`) so it is
+/// testable without a process exit.
+fn run_parse(path: &Path) -> Result<String, String> {
+    // The parser IR is backend-tagged; `parse` defaults to Postgres (the fully
+    // wired runtime backend). A backend flag is a later-slice concern.
+    let backend = Backend::Postgres;
+    let parsed = if path.is_dir() {
+        parse_models_dir(path, backend)
+    } else {
+        let src = std::fs::read_to_string(path)
+            .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+        parse_model_source(&src, backend)
+    }
+    .map_err(|e| e.to_string())?;
+
+    for diag in &parsed.diagnostics {
+        eprintln!("warning: {}", diag.message);
+    }
+
+    serde_json::to_string_pretty(&parsed.tables).map_err(|e| e.to_string())
+}

--- a/autumn-cli/src/schema/parse.rs
+++ b/autumn-cli/src/schema/parse.rs
@@ -26,10 +26,12 @@
 //! - `#[id]` — primary-key column (macro PK resolution is mirrored: explicit
 //!   `#[id]` fields win, else the first `i32`/`i64` field, else a reserved `id`).
 //! - `#[indexed]` — a non-unique secondary index on the column.
-//! - `#[default]` — a column default. The `NOW()` default is recovered only for
-//!   the reserved `created_at` column (→ [`ColumnDefault::Now`]); other
-//!   `#[default]` fields carry no inferred DB default (their default, if any,
-//!   lives in the migration). See the slice-3+ limitation below.
+//! - `#[default]` — a column default. Convention defaults the generator emits are
+//!   recovered by [`convention_default`]: the reserved `created_at` column gets a
+//!   `NOW()` default (→ [`ColumnDefault::Now`]) and a UUID primary key on Postgres
+//!   gets `gen_random_uuid()` (→ [`ColumnDefault::Sql`]). Every other `#[default]`
+//!   field carries no inferred DB default (their default, if any, lives in the
+//!   migration). See the slice-3+ limitation below.
 //! - `#[references]` / `#[references(table = "...")]` — a foreign-key column
 //!   (forces [`ColumnType::Int64`], infers the target table from the column name
 //!   via the generator's `<name>`-minus-`_id`-then-pluralize convention, and adds
@@ -62,9 +64,11 @@
 //!   foreign key from that convention (or from the association attribute) requires
 //!   cross-model resolution and is deferred; today only an explicit
 //!   `#[references]` field attribute yields a [`ForeignKey`].
-//! - **Non-`created_at` `#[default]` fields**: the `NOW()` default is recovered
-//!   only for the reserved `created_at` column; other `#[default]` fields carry
-//!   no inferred DB default (their default, if any, lives in the migration). A
+//! - **Non-convention `#[default]` fields**: only the two conventions
+//!   [`convention_default`] knows about are recovered from the struct alone — the
+//!   reserved `created_at` `NOW()` default and a Postgres UUID primary key's
+//!   `gen_random_uuid()` default. Every other `#[default]` field carries no
+//!   inferred DB default (their default, if any, lives in the migration). A
 //!   soft-delete `deleted_at` carries `#[default]` solely to exclude it from the
 //!   generated `New*`/`Update*` structs — the migration leaves its column default
 //!   UNSET (new rows stay NULL), so the parser must not infer `Now` for it. A
@@ -291,12 +295,10 @@ enum ReferenceSpec {
 }
 
 /// A field's parsed schema-relevant attributes.
-#[allow(clippy::struct_excessive_bools)] // independent field markers, not a state machine
 struct FieldAttrs {
     is_id: bool,
     is_indexed: bool,
     is_unique: bool,
-    is_default: bool,
     reference: ReferenceSpec,
 }
 
@@ -305,7 +307,6 @@ fn parse_field_attrs(field: &syn::Field) -> FieldAttrs {
         is_id: false,
         is_indexed: false,
         is_unique: false,
-        is_default: false,
         reference: ReferenceSpec::None,
     };
     for attr in &field.attrs {
@@ -316,7 +317,9 @@ fn parse_field_attrs(field: &syn::Field) -> FieldAttrs {
             "id" => out.is_id = true,
             "indexed" => out.is_indexed = true,
             "unique" => out.is_unique = true,
-            "default" => out.is_default = true,
+            // `#[default]` no longer changes a column's parsed shape: DB column
+            // defaults the generator emits are recovered by `convention_default`
+            // from the column name/type/PK, not the attribute's presence.
             "references" => {
                 let mut target = None;
                 if !matches!(attr.meta, syn::Meta::Path(_)) {
@@ -444,24 +447,16 @@ fn build_table(
         column.primary_key = is_pk;
         column.unique = raw.attrs.is_unique;
 
-        // Default (slice-3+): the NOW() default is recovered only for the
-        // reserved `created_at` column; other `#[default]` fields carry no
-        // inferred DB default (their default, if any, lives in the migration).
-        // The generator gives a DB `DEFAULT NOW()` (Postgres) / `CURRENT_TIMESTAMP`
-        // (sqlite) *only* to `created_at`. A soft-delete `deleted_at` also carries
-        // `#[default]`, but purely to exclude it from the generated `New*`/`Update*`
-        // insert structs — the migration leaves its column default UNSET so new
-        // rows stay NULL. Inferring `Now` for it (or for any user `#[default]`
-        // timestamp) would fabricate a wrong desired-state IR, so restrict the
-        // inference to the `created_at` convention. The `#[default]`→exclude-from-
-        // insert semantics are orthogonal to the IR `default`, which represents the
-        // DB column default only.
-        if raw.name == "created_at"
-            && raw.attrs.is_default
-            && matches!(ty, ColumnType::Timestamp | ColumnType::TimestampTz)
-        {
-            column.default = Some(ColumnDefault::Now);
-        }
+        // Default (slice-3+): recover only the DB column defaults the generator
+        // emits *by convention* (see `convention_default`) — the `created_at`
+        // NOW() default and a Postgres UUID primary key's `gen_random_uuid()`.
+        // The convention is a fallback: it never overwrites an already-parsed
+        // explicit default. Non-convention `#[default]` fields (a soft-delete
+        // `deleted_at`, an enum/numeric literal) carry no inferred DB default —
+        // their value lives in the migration, not the struct.
+        column.default = column
+            .default
+            .or_else(|| convention_default(&raw.name, &ty, is_pk, backend));
 
         // Foreign key: infer the target table from the generator's convention
         // (`<name>` minus a trailing `_id`, pluralized) unless overridden.
@@ -525,6 +520,36 @@ fn build_table(
     }
 
     table
+}
+
+/// Recover the DB column default the generator emits *by convention*, so the
+/// desired-state IR matches what `autumn generate` actually produced.
+///
+/// Known conventions:
+/// - the reserved `created_at` (timestamp) column -> `NOW()` / `CURRENT_TIMESTAMP`
+///   (the generator gives a DB default only to `created_at`, not to any other
+///   `#[default]` timestamp such as a soft-delete `deleted_at`);
+/// - a UUID `PRIMARY KEY` on Postgres -> `gen_random_uuid()` (the only primary
+///   key that carries an explicit column `DEFAULT`; a `BIGSERIAL`/serial PK is
+///   type-encoded with no `DEFAULT` clause, and on sqlite a UUID PK is `TEXT
+///   PRIMARY KEY` with no default — indeed `uuid::Uuid` is a rejected type there).
+///
+/// Everything else is `None` — a non-convention default lives in the migration
+/// and is recovered in a later slice. This is a *fallback*: the caller applies it
+/// only when a column has no already-parsed explicit default.
+fn convention_default(
+    name: &str,
+    ty: &ColumnType,
+    is_primary_key: bool,
+    backend: Backend,
+) -> Option<ColumnDefault> {
+    if name == "created_at" && matches!(ty, ColumnType::Timestamp | ColumnType::TimestampTz) {
+        return Some(ColumnDefault::Now);
+    }
+    if is_primary_key && *ty == ColumnType::Uuid && backend == Backend::Postgres {
+        return Some(ColumnDefault::Sql("gen_random_uuid()".to_owned()));
+    }
+    None
 }
 
 /// Resolve the primary-key column name(s) from the lifted fields, mirroring the
@@ -812,6 +837,77 @@ mod tests {
         assert!(deleted_at.nullable);
         // `created_at` still recovers its NOW() default.
         assert_eq!(col(&table, "created_at").default, Some(ColumnDefault::Now));
+    }
+
+    #[test]
+    fn uuid_primary_key_recovers_gen_random_uuid_default_on_postgres() {
+        // `autumn generate model --id uuid` emits `#[id] pub id: uuid::Uuid`, and
+        // its Postgres migration declares the PK as
+        // `id UUID PRIMARY KEY DEFAULT gen_random_uuid()`. The parser must recover
+        // that convention default, or a later snapshot/diff would read the live
+        // DB's `gen_random_uuid()` default as drift and try to REMOVE it.
+        let src = r#"
+            #[autumn_web::model]
+            pub struct Session {
+                #[id]
+                pub id: uuid::Uuid,
+                pub token: String,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let table = parse_one(src);
+        let id = col(&table, "id");
+        assert_eq!(id.ty, ColumnType::Uuid);
+        assert!(id.primary_key);
+        assert_eq!(
+            id.default,
+            Some(ColumnDefault::Sql("gen_random_uuid()".to_owned()))
+        );
+    }
+
+    #[test]
+    fn non_pk_uuid_field_has_no_inferred_default() {
+        // The `gen_random_uuid()` convention is PRIMARY-KEY-only: a plain
+        // `uuid::Uuid` column carries no DB default (its value, if any, lives in
+        // the migration), so the parser must report `default == None` for it.
+        let src = r#"
+            #[autumn_web::model]
+            pub struct ApiKey {
+                #[id]
+                pub id: i64,
+                pub external_ref: uuid::Uuid,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let table = parse_one(src);
+        let external = col(&table, "external_ref");
+        assert_eq!(external.ty, ColumnType::Uuid);
+        assert!(!external.primary_key);
+        assert_eq!(external.default, None);
+    }
+
+    #[test]
+    fn bigserial_primary_key_has_no_inferred_default() {
+        // A `BIGSERIAL PRIMARY KEY` is type-encoded — the serial type IS the
+        // default, there is no separate `DEFAULT` clause — so an `i64` `#[id]` PK
+        // must NOT pick up `gen_random_uuid()` (which is UUID-PK-only).
+        let src = r#"
+            #[autumn_web::model]
+            pub struct Post {
+                #[id]
+                pub id: i64,
+                pub title: String,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let table = parse_one(src);
+        let id = col(&table, "id");
+        assert_eq!(id.ty, ColumnType::Int64);
+        assert!(id.primary_key);
+        assert_eq!(id.default, None);
     }
 
     #[test]

--- a/autumn-cli/src/schema/parse.rs
+++ b/autumn-cli/src/schema/parse.rs
@@ -1,0 +1,981 @@
+//! `syn`-backed reader that turns an app's `#[model]` structs into the shared
+//! [`autumn_schema_core`] schema IR — the **desired state** input a later slice
+//! diffs against a checked-in snapshot and the live database.
+//!
+//! This is slice 2 of the declarative-schema wave (tracking issue #1975): it is
+//! deliberately **read-only**. It parses Rust source with [`syn`], walks each
+//! `#[model]` struct, and reconstructs the [`Table`] the generator would have
+//! produced — reusing [`ColumnType::from_rust_type`] for the field-type mapping
+//! and the CLI's own [`naming::pluralize`] / [`naming::pascal_to_snake`] for
+//! table-name inference so the parser and the generator can never drift on those
+//! two axes. It emits **no** migration, `schema.rs`, or codegen output; those are
+//! later slices.
+//!
+//! # Recognized `#[model]` vocabulary
+//!
+//! Struct-level, on the `#[model(...)]` / `#[autumn_web::model(...)]` attribute:
+//! - `table = "..."` — explicit table-name override (mirrors the macro's one
+//!   real argument; see `autumn_macros`'s `parse_attr_args`).
+//! - `managed` (also accepted as `schema = "managed"`) — the Decision-4 adoption
+//!   marker recorded on [`Table::managed`]. NOTE: this is a **parser-recognized**
+//!   marker for the declarative-schema wave; the runtime `#[model]` macro does
+//!   not yet accept it as an argument. Any other nested argument is ignored
+//!   (forward-compatible).
+//!
+//! Field-level:
+//! - `#[id]` — primary-key column (macro PK resolution is mirrored: explicit
+//!   `#[id]` fields win, else the first `i32`/`i64` field, else a reserved `id`).
+//! - `#[indexed]` — a non-unique secondary index on the column.
+//! - `#[default]` — a column default. Recoverable from the struct only for a
+//!   `created_at`-style timestamp field (→ [`ColumnDefault::Now`]); see the
+//!   slice-3+ limitation below.
+//! - `#[references]` / `#[references(table = "...")]` — a foreign-key column
+//!   (forces [`ColumnType::Int64`], infers the target table from the column name
+//!   via the generator's `<name>`-minus-`_id`-then-pluralize convention, and adds
+//!   the same auto-index the generator emits for a reference column). This is a
+//!   **parser-recognized** marker: real generator output today represents a
+//!   foreign key as a plain `<name>_id: i64` field plus a struct-level
+//!   `#[belongs_to(...)]` association, not a `#[references]` field attribute (see
+//!   the slice-3+ limitation below).
+//! - `#[unique]` — a `UNIQUE` column + unique index. Also **parser-recognized**:
+//!   generator output records uniqueness only in the migration (a `CREATE UNIQUE
+//!   INDEX`), not on the struct field (see the slice-3+ limitation below).
+//!
+//! Every other field attribute the `#[model]` macro accepts (`#[searchable]`,
+//! `#[validate]`, `#[encrypted]`, `#[private]`, `#[normalize]`, `#[lock_version]`,
+//! `#[state_machine]`, `#[factory_assoc]`) does not change a column's *shape* and
+//! is ignored here — the column is still parsed from its Rust type.
+//!
+//! # Deliberate slice-3+ limitations (documented, not bugs)
+//!
+//! - **Enum variants + `CHECK` constraints**: a field whose type is a generated
+//!   enum (`pub status: PostStatus`) cannot be resolved from the struct alone —
+//!   [`ColumnType::from_rust_type`] returns `None` because the concrete enum type
+//!   is not a known scalar and its variant set is not visible from the field.
+//!   The parser records a [`SchemaDiagnostic`] and skips the column rather than
+//!   guessing; it never fabricates a `CHECK` for an enum. Reading the enum
+//!   `#[derive]` definitions (to recover the variant set and the closed-set
+//!   `CHECK`) is a later slice.
+//! - **Association-based foreign keys**: real generator output models a foreign
+//!   key as `<name>_id: i64` + a struct-level `#[belongs_to(...)]`. Resolving a
+//!   foreign key from that convention (or from the association attribute) requires
+//!   cross-model resolution and is deferred; today only an explicit
+//!   `#[references]` field attribute yields a [`ForeignKey`].
+//! - **Non-timestamp default literals**: a `#[default]` on a non-timestamp field
+//!   (an enum default `'draft'`, a numeric default) does not carry its literal in
+//!   the struct — the value lives in the migration/DSL. Only the `created_at`
+//!   `NOW()` default is recoverable here; recovering the rest is a later slice.
+//! - **Unique-index name disambiguation**: the generator disambiguates a unique
+//!   index name past Postgres's 63-byte identifier limit (see
+//!   `schema_edit::unique_index_name`). The parser uses the plain
+//!   `idx_<table>_<field>_unique` form; exact parity for pathological long names
+//!   is a later refinement.
+
+use std::path::Path;
+
+use autumn_schema_core::{Backend, Column, ColumnDefault, ColumnType, ForeignKey, Index, Table};
+
+use crate::generate::naming;
+
+/// An error that aborts a whole parse (a syntactically invalid source file or an
+/// unreadable path). A single unsupported *field* does **not** abort — it is
+/// recorded as a [`SchemaDiagnostic`] on the successful [`ParsedSchema`].
+#[derive(Debug, thiserror::Error)]
+pub enum SchemaParseError {
+    /// The Rust source did not parse. Carries the `syn` message plus the 1-based
+    /// line/column of the offending span (available because `autumn-cli` builds
+    /// `proc-macro2` with `span-locations`).
+    #[error("failed to parse Rust source at line {line}, column {column}: {message}")]
+    Syntax {
+        /// The underlying `syn` error message.
+        message: String,
+        /// 1-based line of the error span.
+        line: usize,
+        /// 1-based column of the error span.
+        column: usize,
+    },
+    /// A models file or directory could not be read.
+    #[error("failed to read {path}: {source}")]
+    Io {
+        /// The path that could not be read.
+        path: String,
+        /// The underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+impl SchemaParseError {
+    fn from_syn(err: &syn::Error) -> Self {
+        let start = err.span().start();
+        Self::Syntax {
+            message: err.to_string(),
+            line: start.line,
+            column: start.column + 1,
+        }
+    }
+}
+
+/// A non-fatal parse diagnostic: a field the parser could not map to a
+/// [`ColumnType`] (typically a generated-enum or association type). The column is
+/// skipped — never silently mapped to a wrong type — and this record explains why.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaDiagnostic {
+    /// The `#[model]` struct the field belongs to.
+    pub model: String,
+    /// The field name whose type could not be resolved.
+    pub field: String,
+    /// The unresolved Rust type token (as written in the struct).
+    pub rust_type: String,
+    /// A human-readable explanation.
+    pub message: String,
+}
+
+/// The result of a successful parse: the reconstructed tables plus any
+/// non-fatal per-field diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedSchema {
+    /// One [`Table`] per `#[model]` struct, in source order.
+    pub tables: Vec<Table>,
+    /// Fields that could not be resolved (see [`SchemaDiagnostic`]).
+    pub diagnostics: Vec<SchemaDiagnostic>,
+}
+
+/// Parse a single Rust source string, returning one [`Table`] per `#[model]`
+/// struct plus any per-field diagnostics.
+///
+/// # Errors
+///
+/// Returns [`SchemaParseError::Syntax`] if `src` is not valid Rust.
+pub fn parse_model_source(src: &str, backend: Backend) -> Result<ParsedSchema, SchemaParseError> {
+    let file = syn::parse_file(src).map_err(|e| SchemaParseError::from_syn(&e))?;
+    let mut out = ParsedSchema {
+        tables: Vec::new(),
+        diagnostics: Vec::new(),
+    };
+    for item in &file.items {
+        if let syn::Item::Struct(item_struct) = item
+            && let Some(model_attr) = find_model_attr(&item_struct.attrs)
+        {
+            let table = build_table(item_struct, model_attr, backend, &mut out.diagnostics);
+            out.tables.push(table);
+        }
+    }
+    Ok(out)
+}
+
+/// Parse every `*.rs` file directly under `dir` (non-recursive) and aggregate
+/// the results in a stable, filename-sorted order.
+///
+/// # Errors
+///
+/// Returns [`SchemaParseError::Io`] if `dir` (or a file within it) cannot be
+/// read, or [`SchemaParseError::Syntax`] if any file is not valid Rust.
+pub fn parse_models_dir(dir: &Path, backend: Backend) -> Result<ParsedSchema, SchemaParseError> {
+    let read = std::fs::read_dir(dir).map_err(|source| SchemaParseError::Io {
+        path: dir.display().to_string(),
+        source,
+    })?;
+    let mut paths: Vec<std::path::PathBuf> = Vec::new();
+    for entry in read {
+        let entry = entry.map_err(|source| SchemaParseError::Io {
+            path: dir.display().to_string(),
+            source,
+        })?;
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "rs") {
+            paths.push(path);
+        }
+    }
+    // Deterministic aggregation regardless of directory iteration order.
+    paths.sort();
+
+    let mut out = ParsedSchema {
+        tables: Vec::new(),
+        diagnostics: Vec::new(),
+    };
+    for path in paths {
+        let src = std::fs::read_to_string(&path).map_err(|source| SchemaParseError::Io {
+            path: path.display().to_string(),
+            source,
+        })?;
+        let mut parsed = parse_model_source(&src, backend)?;
+        out.tables.append(&mut parsed.tables);
+        out.diagnostics.append(&mut parsed.diagnostics);
+    }
+    Ok(out)
+}
+
+/// Find the `#[model]` / `#[autumn_web::model]` attribute on a struct, if any.
+/// The last path segment must be `model`, so both the bare and fully-qualified
+/// spellings match.
+fn find_model_attr(attrs: &[syn::Attribute]) -> Option<&syn::Attribute> {
+    attrs.iter().find(|attr| {
+        attr.path()
+            .segments
+            .last()
+            .is_some_and(|seg| seg.ident == "model")
+    })
+}
+
+/// Struct-level `#[model(...)]` arguments the parser recognizes.
+#[derive(Default)]
+struct ModelArgs {
+    table: Option<String>,
+    managed: bool,
+}
+
+/// Parse the recognized `#[model(...)]` arguments (`table = "..."`, `managed`,
+/// `schema = "managed"`), leniently ignoring any other nested argument so a
+/// future macro argument does not break the parser.
+fn parse_model_args(attr: &syn::Attribute) -> ModelArgs {
+    let mut args = ModelArgs::default();
+    // A bare `#[model]` (path, no parens) carries no arguments.
+    if matches!(attr.meta, syn::Meta::Path(_)) {
+        return args;
+    }
+    // `parse_nested_meta` errors on the first argument whose value we do not
+    // consume; to stay forward-compatible we consume-and-ignore unknown ones.
+    let _ = attr.parse_nested_meta(|meta| {
+        if meta.path.is_ident("table") {
+            if let Ok(value) = meta.value()
+                && let Ok(lit) = value.parse::<syn::LitStr>()
+            {
+                args.table = Some(lit.value());
+            }
+        } else if meta.path.is_ident("managed") {
+            args.managed = true;
+        } else if meta.path.is_ident("schema") {
+            if let Ok(value) = meta.value()
+                && let Ok(lit) = value.parse::<syn::LitStr>()
+                && lit.value() == "managed"
+            {
+                args.managed = true;
+            }
+        } else if let Ok(value) = meta.value() {
+            // Unknown `key = value` — consume the value token so parsing can
+            // continue to the next comma-separated argument.
+            let _ = value.parse::<syn::Lit>();
+        }
+        Ok(())
+    });
+    args
+}
+
+/// How a field participates in a foreign-key relationship.
+#[derive(Default, PartialEq, Eq)]
+enum ReferenceSpec {
+    /// Not a `#[references]` field.
+    #[default]
+    None,
+    /// Bare `#[references]` — infer the target table from the column name.
+    Inferred,
+    /// `#[references(table = "...")]` — explicit target-table override.
+    Explicit(String),
+}
+
+/// A field's parsed schema-relevant attributes.
+#[allow(clippy::struct_excessive_bools)] // independent field markers, not a state machine
+struct FieldAttrs {
+    is_id: bool,
+    is_indexed: bool,
+    is_unique: bool,
+    is_default: bool,
+    reference: ReferenceSpec,
+}
+
+fn parse_field_attrs(field: &syn::Field) -> FieldAttrs {
+    let mut out = FieldAttrs {
+        is_id: false,
+        is_indexed: false,
+        is_unique: false,
+        is_default: false,
+        reference: ReferenceSpec::None,
+    };
+    for attr in &field.attrs {
+        let Some(ident) = attr.path().get_ident() else {
+            continue;
+        };
+        match ident.to_string().as_str() {
+            "id" => out.is_id = true,
+            "indexed" => out.is_indexed = true,
+            "unique" => out.is_unique = true,
+            "default" => out.is_default = true,
+            "references" => {
+                let mut target = None;
+                if !matches!(attr.meta, syn::Meta::Path(_)) {
+                    let _ = attr.parse_nested_meta(|meta| {
+                        if meta.path.is_ident("table")
+                            && let Ok(value) = meta.value()
+                            && let Ok(lit) = value.parse::<syn::LitStr>()
+                        {
+                            target = Some(lit.value());
+                        }
+                        Ok(())
+                    });
+                }
+                out.reference = target.map_or(ReferenceSpec::Inferred, ReferenceSpec::Explicit);
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// A field lifted out of the struct with its name, parsed attributes, and Rust
+/// type (already split on `Option<…>`).
+struct RawField {
+    name: String,
+    attrs: FieldAttrs,
+    nullable: bool,
+    rust_type: String,
+}
+
+/// Build a [`Table`] from one `#[model]` struct.
+#[allow(clippy::too_many_lines)]
+fn build_table(
+    item: &syn::ItemStruct,
+    model_attr: &syn::Attribute,
+    backend: Backend,
+    diagnostics: &mut Vec<SchemaDiagnostic>,
+) -> Table {
+    let model_name = item.ident.to_string();
+    let args = parse_model_args(model_attr);
+    let table_name = args
+        .table
+        .clone()
+        .unwrap_or_else(|| naming::pluralize(&naming::pascal_to_snake(&model_name)));
+
+    // Lift the named fields (a tuple/unit struct carries no columns).
+    let mut raw_fields: Vec<RawField> = Vec::new();
+    if let syn::Fields::Named(named) = &item.fields {
+        for field in &named.named {
+            let Some(ident) = &field.ident else { continue };
+            let (nullable, inner_ty) = strip_option(&field.ty);
+            raw_fields.push(RawField {
+                name: ident.to_string(),
+                attrs: parse_field_attrs(field),
+                nullable,
+                rust_type: type_to_string(inner_ty),
+            });
+        }
+    }
+
+    // Primary-key resolution, mirroring the `#[model]` macro:
+    //   1. explicit `#[id]` fields win;
+    //   2. else the first `i32`/`i64` field;
+    //   3. else a synthesized reserved `id`.
+    let pk_field_names = resolve_pk_field_names(&raw_fields);
+    let needs_synthetic_id = pk_field_names.is_empty();
+
+    let mut table = Table::new(table_name.clone(), backend);
+    table.managed = args.managed;
+
+    // (1) A synthesized reserved `id` PK leads the column list (BigSerial
+    // convention: an `Int64` PK with no explicit default).
+    if needs_synthetic_id {
+        let mut id = Column::new("id", ColumnType::Int64);
+        id.primary_key = true;
+        table.columns.push(id);
+        table.primary_key.push("id".to_owned());
+    }
+
+    // Collected index sources, mirroring the generator's emission order.
+    let mut plain_index_fields: Vec<String> = Vec::new();
+    let mut unique_index_fields: Vec<String> = Vec::new();
+    let mut has_created_at = false;
+
+    for raw in &raw_fields {
+        if raw.name == "created_at" {
+            has_created_at = true;
+        }
+        let is_pk = pk_field_names.contains(&raw.name);
+
+        // Resolve the column type. A `#[references]` field is always an `Int64`
+        // FK column regardless of the written Rust type (which is `i64` anyway).
+        let is_reference = raw.attrs.reference != ReferenceSpec::None;
+        let column_ty = if is_reference {
+            Some(ColumnType::Int64)
+        } else {
+            ColumnType::from_rust_type(&raw.rust_type)
+        };
+        let Some(ty) = column_ty else {
+            // Unknown/unsupported type (a generated enum, an association type):
+            // record a diagnostic and skip — never fabricate a wrong mapping.
+            diagnostics.push(SchemaDiagnostic {
+                model: model_name.clone(),
+                field: raw.name.clone(),
+                rust_type: raw.rust_type.clone(),
+                message: format!(
+                    "unsupported field type `{}` on `{model_name}.{}`; column skipped \
+                     (enum/CHECK + association resolution is a later slice)",
+                    raw.rust_type, raw.name
+                ),
+            });
+            continue;
+        };
+
+        let mut column = Column::new(raw.name.clone(), ty.clone());
+        column.nullable = raw.nullable;
+        column.primary_key = is_pk;
+        column.unique = raw.attrs.is_unique;
+
+        // Default: recoverable from the struct only for a `created_at`-style
+        // timestamp `#[default]` (→ NOW()); non-timestamp default literals live
+        // in the migration and are a later slice.
+        if raw.attrs.is_default && matches!(ty, ColumnType::Timestamp | ColumnType::TimestampTz) {
+            column.default = Some(ColumnDefault::Now);
+        }
+
+        // Foreign key: infer the target table from the generator's convention
+        // (`<name>` minus a trailing `_id`, pluralized) unless overridden.
+        match &raw.attrs.reference {
+            ReferenceSpec::None => {}
+            ReferenceSpec::Inferred => {
+                let base = raw.name.strip_suffix("_id").unwrap_or(&raw.name);
+                column.references = Some(ForeignKey::new(naming::pluralize(base), "id"));
+            }
+            ReferenceSpec::Explicit(target) => {
+                column.references = Some(ForeignKey::new(target.clone(), "id"));
+            }
+        }
+
+        // Index bookkeeping (deduped/retained below, mirroring the generator).
+        if raw.attrs.is_unique {
+            unique_index_fields.push(raw.name.clone());
+        }
+        if raw.attrs.is_indexed || is_reference {
+            plain_index_fields.push(raw.name.clone());
+        }
+
+        // Record a struct-declared PK column name (a synthesized `id` was already
+        // pushed above; an explicit PK is pushed here in declaration order).
+        if is_pk {
+            table.primary_key.push(raw.name.clone());
+        }
+
+        table.columns.push(column);
+    }
+
+    // (2) Synthesize `created_at TIMESTAMP DEFAULT NOW()` when the struct did not
+    // declare it, matching what the generator always appends.
+    if !has_created_at {
+        let mut created = Column::new("created_at", ColumnType::Timestamp);
+        created.default = Some(ColumnDefault::Now);
+        table.columns.push(created);
+    }
+
+    // Index emission, mirroring `schema_edit::create_table_sql_*`:
+    //  - every `references` column gets an auto-index (already folded into
+    //    `plain_index_fields`);
+    //  - a `unique` field's own unique index covers lookups, so it must not
+    //    also get a redundant plain index (issue #1032).
+    plain_index_fields.retain(|name| !unique_index_fields.contains(name));
+    plain_index_fields.dedup();
+    for field_name in &plain_index_fields {
+        table.indexes.push(Index {
+            name: format!("idx_{table_name}_{field_name}"),
+            columns: vec![field_name.clone()],
+            unique: false,
+        });
+    }
+    for field_name in &unique_index_fields {
+        table.indexes.push(Index {
+            // Plain (un-disambiguated) form; 63-byte disambiguation is a later slice.
+            name: format!("idx_{table_name}_{field_name}_unique"),
+            columns: vec![field_name.clone()],
+            unique: true,
+        });
+    }
+
+    table
+}
+
+/// Resolve the primary-key column name(s) from the lifted fields, mirroring the
+/// `#[model]` macro: explicit `#[id]` fields win; else the first `i32`/`i64`
+/// field; else empty (the caller synthesizes a reserved `id`).
+fn resolve_pk_field_names(fields: &[RawField]) -> Vec<String> {
+    let explicit: Vec<String> = fields
+        .iter()
+        .filter(|f| f.attrs.is_id)
+        .map(|f| f.name.clone())
+        .collect();
+    if !explicit.is_empty() {
+        return explicit;
+    }
+    fields
+        .iter()
+        .find(|f| !f.nullable && matches!(f.rust_type.as_str(), "i32" | "i64"))
+        .map_or_else(Vec::new, |f| vec![f.name.clone()])
+}
+
+/// Split a `Option<T>` type into `(true, T)`; any other type is `(false, ty)`.
+/// Tolerates `std::option::Option<T>` / `core::option::Option<T>` spellings.
+fn strip_option(ty: &syn::Type) -> (bool, &syn::Type) {
+    if let syn::Type::Path(type_path) = ty
+        && type_path.qself.is_none()
+        && let Some(seg) = type_path.path.segments.last()
+        && seg.ident == "Option"
+        && let syn::PathArguments::AngleBracketed(args) = &seg.arguments
+        && let Some(syn::GenericArgument::Type(inner)) = args.args.first()
+    {
+        return (true, inner);
+    }
+    (false, ty)
+}
+
+/// Render a `syn::Type` to a string [`ColumnType::from_rust_type`] accepts. That
+/// function normalizes whitespace and is path-tolerant, so the spacing `quote`
+/// introduces (`Vec < u8 >`, `chrono :: NaiveDateTime`) is handled there.
+fn type_to_string(ty: &syn::Type) -> String {
+    quote::quote!(#ty).to_string()
+}
+
+#[cfg(test)]
+// Fixtures use a uniform `r#"…"#` raw-string style (several embed `"`); keeping
+// the rest bare would be inconsistent noise.
+#[allow(clippy::needless_raw_string_hashes)]
+mod tests {
+    use super::*;
+
+    fn parse_one(src: &str) -> Table {
+        let parsed = parse_model_source(src, Backend::Postgres).expect("parse");
+        assert_eq!(parsed.tables.len(), 1, "expected exactly one table");
+        parsed.tables.into_iter().next().unwrap()
+    }
+
+    fn col<'a>(table: &'a Table, name: &str) -> &'a Column {
+        table
+            .columns
+            .iter()
+            .find(|c| c.name == name)
+            .unwrap_or_else(|| panic!("column `{name}` not found in {:?}", table.name))
+    }
+
+    #[test]
+    fn basic_model_id_string_option_bool_created_at() {
+        let src = r#"
+            #[autumn_web::model]
+            pub struct Post {
+                #[id]
+                pub id: i64,
+                pub title: String,
+                pub views: Option<i32>,
+                pub published: bool,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let table = parse_one(src);
+        assert_eq!(table.name, "posts");
+        assert!(!table.managed, "unmarked model is not managed");
+        assert_eq!(table.backend, Backend::Postgres);
+        assert_eq!(table.primary_key, vec!["id".to_owned()]);
+
+        let id = col(&table, "id");
+        assert_eq!(id.ty, ColumnType::Int64);
+        assert!(id.primary_key);
+
+        let title = col(&table, "title");
+        assert_eq!(title.ty, ColumnType::Text);
+        assert!(!title.nullable);
+
+        let views = col(&table, "views");
+        assert_eq!(views.ty, ColumnType::Int32);
+        assert!(views.nullable, "Option<i32> is nullable");
+
+        let published = col(&table, "published");
+        assert_eq!(published.ty, ColumnType::Bool);
+
+        let created = col(&table, "created_at");
+        assert_eq!(created.ty, ColumnType::Timestamp);
+        assert_eq!(created.default, Some(ColumnDefault::Now));
+    }
+
+    #[test]
+    fn full_basic_table_equals_hand_built() {
+        let src = r#"
+            #[autumn_web::model]
+            pub struct Widget {
+                #[id]
+                pub id: i64,
+                pub name: String,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let table = parse_one(src);
+
+        let mut expected = Table::new("widgets", Backend::Postgres);
+        // An unmarked `#[model]` is not managed (Table::new defaults to true).
+        expected.managed = false;
+        let mut id = Column::new("id", ColumnType::Int64);
+        id.primary_key = true;
+        expected.columns.push(id);
+        expected.columns.push(Column::new("name", ColumnType::Text));
+        let mut created = Column::new("created_at", ColumnType::Timestamp);
+        created.default = Some(ColumnDefault::Now);
+        expected.columns.push(created);
+        expected.primary_key.push("id".to_owned());
+
+        assert_eq!(table, expected);
+    }
+
+    #[test]
+    fn table_override_is_honored() {
+        let src = r#"
+            #[autumn_web::model(table = "people")]
+            pub struct Person {
+                #[id]
+                pub id: i64,
+                pub name: String,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let table = parse_one(src);
+        assert_eq!(table.name, "people");
+    }
+
+    #[test]
+    fn managed_marker_sets_managed_true() {
+        let marked = parse_one(
+            r#"
+            #[model(managed)]
+            pub struct Account {
+                #[id]
+                pub id: i64,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#,
+        );
+        assert!(marked.managed, "#[model(managed)] opts in");
+
+        let via_schema = parse_one(
+            r#"
+            #[model(schema = "managed")]
+            pub struct Account {
+                #[id]
+                pub id: i64,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#,
+        );
+        assert!(via_schema.managed, "#[model(schema = \"managed\")] opts in");
+
+        let unmarked = parse_one(
+            r#"
+            #[model]
+            pub struct Account {
+                #[id]
+                pub id: i64,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#,
+        );
+        assert!(!unmarked.managed, "unmarked model defaults to unmanaged");
+    }
+
+    #[test]
+    fn references_field_yields_fk_int64_and_auto_index() {
+        let src = r#"
+            #[model]
+            pub struct Comment {
+                #[id]
+                pub id: i64,
+                #[references]
+                pub post_id: i64,
+                pub body: String,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let table = parse_one(src);
+        let post = col(&table, "post_id");
+        assert_eq!(post.ty, ColumnType::Int64);
+        assert_eq!(post.references, Some(ForeignKey::new("posts", "id")));
+
+        // The reference column gets an auto-index, mirroring the generator.
+        let idx = table
+            .indexes
+            .iter()
+            .find(|i| i.columns == vec!["post_id".to_owned()])
+            .expect("auto-index on the reference column");
+        assert_eq!(idx.name, "idx_comments_post_id");
+        assert!(!idx.unique);
+    }
+
+    #[test]
+    fn references_table_override() {
+        let src = r#"
+            #[model]
+            pub struct Comment {
+                #[id]
+                pub id: i64,
+                #[references(table = "blog_posts")]
+                pub post_id: i64,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let table = parse_one(src);
+        assert_eq!(
+            col(&table, "post_id").references,
+            Some(ForeignKey::new("blog_posts", "id"))
+        );
+    }
+
+    #[test]
+    fn default_on_timestamp_is_now() {
+        let src = r#"
+            #[model]
+            pub struct Event {
+                #[id]
+                pub id: i64,
+                #[default]
+                pub occurred_at: chrono::NaiveDateTime,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let table = parse_one(src);
+        assert_eq!(col(&table, "occurred_at").default, Some(ColumnDefault::Now));
+    }
+
+    #[test]
+    fn indexed_field_produces_index() {
+        let src = r#"
+            #[model]
+            pub struct User {
+                #[id]
+                pub id: i64,
+                #[indexed]
+                pub slug: String,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let table = parse_one(src);
+        let idx = table
+            .indexes
+            .iter()
+            .find(|i| i.columns == vec!["slug".to_owned()])
+            .expect("index on the #[indexed] column");
+        assert_eq!(idx.name, "idx_users_slug");
+        assert!(!idx.unique);
+    }
+
+    #[test]
+    fn unique_field_produces_unique_index_and_no_plain_index() {
+        let src = r#"
+            #[model]
+            pub struct Account {
+                #[id]
+                pub id: i64,
+                #[unique]
+                #[indexed]
+                pub email: String,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let table = parse_one(src);
+        assert!(col(&table, "email").unique);
+
+        let email_indexes: Vec<&Index> = table
+            .indexes
+            .iter()
+            .filter(|i| i.columns == vec!["email".to_owned()])
+            .collect();
+        assert_eq!(
+            email_indexes.len(),
+            1,
+            "a unique field must not also get a redundant plain index"
+        );
+        assert!(email_indexes[0].unique);
+        assert_eq!(email_indexes[0].name, "idx_accounts_email_unique");
+    }
+
+    #[test]
+    fn each_scalar_type_maps_correctly() {
+        let src = r#"
+            #[model]
+            pub struct Kitchen {
+                #[id]
+                pub id: i64,
+                pub a: String,
+                pub b: i32,
+                pub c: i64,
+                pub d: bool,
+                pub e: f32,
+                pub f: f64,
+                pub g: uuid::Uuid,
+                pub h: chrono::NaiveDateTime,
+                pub i: chrono::DateTime<chrono::Utc>,
+                pub j: Vec<u8>,
+                pub k: autumn_web::storage::Blob,
+                pub l: rust_decimal::Decimal,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let table = parse_one(src);
+        assert_eq!(col(&table, "a").ty, ColumnType::Text);
+        assert_eq!(col(&table, "b").ty, ColumnType::Int32);
+        assert_eq!(col(&table, "c").ty, ColumnType::Int64);
+        assert_eq!(col(&table, "d").ty, ColumnType::Bool);
+        assert_eq!(col(&table, "e").ty, ColumnType::Float32);
+        assert_eq!(col(&table, "f").ty, ColumnType::Float64);
+        assert_eq!(col(&table, "g").ty, ColumnType::Uuid);
+        assert_eq!(col(&table, "h").ty, ColumnType::Timestamp);
+        assert_eq!(col(&table, "i").ty, ColumnType::TimestampTz);
+        assert_eq!(col(&table, "j").ty, ColumnType::Bytes);
+        assert_eq!(col(&table, "k").ty, ColumnType::Attachment);
+        assert_eq!(
+            col(&table, "l").ty,
+            ColumnType::Decimal {
+                precision: 12,
+                scale: 2
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_field_type_produces_diagnostic_not_wrong_mapping() {
+        let src = r#"
+            #[model]
+            pub struct Post {
+                #[id]
+                pub id: i64,
+                pub title: String,
+                pub status: PostStatus,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let parsed = parse_model_source(src, Backend::Postgres).expect("parse");
+        let table = &parsed.tables[0];
+        // The unresolved column is skipped, not fabricated.
+        assert!(table.columns.iter().all(|c| c.name != "status"));
+        assert_eq!(parsed.diagnostics.len(), 1);
+        let diag = &parsed.diagnostics[0];
+        assert_eq!(diag.model, "Post");
+        assert_eq!(diag.field, "status");
+        assert!(diag.rust_type.contains("PostStatus"));
+    }
+
+    #[test]
+    fn synthesizes_reserved_id_and_created_at_when_absent() {
+        // No `#[id]`, no i32/i64 field, no `created_at`.
+        let src = r#"
+            #[model]
+            pub struct Note {
+                pub body: String,
+            }
+        "#;
+        let table = parse_one(src);
+        assert_eq!(table.primary_key, vec!["id".to_owned()]);
+        let id = col(&table, "id");
+        assert_eq!(id.ty, ColumnType::Int64);
+        assert!(id.primary_key);
+        // Synthesized id leads, created_at trails.
+        assert_eq!(table.columns.first().unwrap().name, "id");
+        let created = col(&table, "created_at");
+        assert_eq!(created.ty, ColumnType::Timestamp);
+        assert_eq!(created.default, Some(ColumnDefault::Now));
+    }
+
+    #[test]
+    fn pk_falls_back_to_first_integer_field_without_id_attr() {
+        let src = r#"
+            #[model]
+            pub struct Legacy {
+                pub legacy_key: i64,
+                pub name: String,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let table = parse_one(src);
+        assert_eq!(table.primary_key, vec!["legacy_key".to_owned()]);
+        assert!(col(&table, "legacy_key").primary_key);
+        // No synthesized `id` when a fallback PK field exists.
+        assert!(table.columns.iter().all(|c| c.name != "id"));
+    }
+
+    #[test]
+    fn non_model_structs_are_ignored() {
+        let src = r#"
+            pub struct NotAModel {
+                pub x: i64,
+            }
+            #[model]
+            pub struct Real {
+                #[id]
+                pub id: i64,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let parsed = parse_model_source(src, Backend::Postgres).expect("parse");
+        assert_eq!(parsed.tables.len(), 1);
+        assert_eq!(parsed.tables[0].name, "reals");
+    }
+
+    #[test]
+    fn syntax_error_is_reported_with_location() {
+        let err = parse_model_source("pub struct { ", Backend::Postgres).unwrap_err();
+        assert!(matches!(err, SchemaParseError::Syntax { .. }));
+    }
+
+    #[test]
+    fn parses_a_real_repo_model_file() {
+        // A real generated model in the checked-in `bookmarks` example. If the
+        // example is ever moved, skip rather than fail this crate's tests.
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../examples/bookmarks/src/models/bookmark.rs");
+        let Ok(src) = std::fs::read_to_string(&path) else {
+            eprintln!("skipping: {} not found", path.display());
+            return;
+        };
+        let parsed = parse_model_source(&src, Backend::Postgres).expect("real model parses");
+        assert_eq!(parsed.tables.len(), 1);
+        let table = &parsed.tables[0];
+        assert_eq!(table.name, "bookmarks");
+        assert_eq!(table.primary_key, vec!["id".to_owned()]);
+        assert_eq!(col(table, "url").ty, ColumnType::Text);
+        assert_eq!(col(table, "alive").ty, ColumnType::Bool);
+        assert_eq!(col(table, "created_at").default, Some(ColumnDefault::Now));
+        // `#[indexed]` on `url` and `tag` produces two plain indexes.
+        assert!(
+            table
+                .indexes
+                .iter()
+                .any(|i| i.name == "idx_bookmarks_url" && !i.unique)
+        );
+        assert!(
+            table
+                .indexes
+                .iter()
+                .any(|i| i.name == "idx_bookmarks_tag" && !i.unique)
+        );
+    }
+
+    #[test]
+    fn sqlite_backend_is_carried_through() {
+        let src = r#"
+            #[model]
+            pub struct Thing {
+                #[id]
+                pub id: i64,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let parsed = parse_model_source(src, Backend::Sqlite).expect("parse");
+        assert_eq!(parsed.tables[0].backend, Backend::Sqlite);
+    }
+}

--- a/autumn-cli/src/schema/parse.rs
+++ b/autumn-cli/src/schema/parse.rs
@@ -27,11 +27,13 @@
 //!   `#[id]` fields win, else the first `i32`/`i64` field, else a reserved `id`).
 //! - `#[indexed]` — a non-unique secondary index on the column.
 //! - `#[default]` — a column default. Convention defaults the generator emits are
-//!   recovered by [`convention_default`]: the reserved `created_at` column gets a
-//!   `NOW()` default (→ [`ColumnDefault::Now`]) and a UUID primary key on Postgres
-//!   gets `gen_random_uuid()` (→ [`ColumnDefault::Sql`]). Every other `#[default]`
-//!   field carries no inferred DB default (their default, if any, lives in the
-//!   migration). See the slice-3+ limitation below.
+//!   recovered by [`convention_default`]: the reserved `created_at` column *marked
+//!   `#[default]`* gets a `NOW()` default (→ [`ColumnDefault::Now`]) and a UUID
+//!   primary key on Postgres gets `gen_random_uuid()` (→ [`ColumnDefault::Sql`]).
+//!   The `created_at` `NOW()` convention requires the generator's `#[default]`
+//!   marker — a hand-written `created_at` without `#[default]` gets no inferred
+//!   default. Every other `#[default]` field carries no inferred DB default (their
+//!   default, if any, lives in the migration). See the slice-3+ limitation below.
 //! - `#[references]` / `#[references(table = "...")]` — a foreign-key column
 //!   (forces [`ColumnType::Int64`], infers the target table from the column name
 //!   via the generator's `<name>`-minus-`_id`-then-pluralize convention, and adds
@@ -66,15 +68,17 @@
 //!   `#[references]` field attribute yields a [`ForeignKey`].
 //! - **Non-convention `#[default]` fields**: only the two conventions
 //!   [`convention_default`] knows about are recovered from the struct alone — the
-//!   reserved `created_at` `NOW()` default and a Postgres UUID primary key's
-//!   `gen_random_uuid()` default. Every other `#[default]` field carries no
-//!   inferred DB default (their default, if any, lives in the migration). A
-//!   soft-delete `deleted_at` carries `#[default]` solely to exclude it from the
-//!   generated `New*`/`Update*` structs — the migration leaves its column default
-//!   UNSET (new rows stay NULL), so the parser must not infer `Now` for it. A
-//!   `#[default]` on any other field (an enum default `'draft'`, a numeric
-//!   default) likewise does not carry its literal in the struct — the value lives
-//!   in the migration/DSL. Recovering those from the migration is a later slice.
+//!   reserved `created_at` `NOW()` default (which requires the generator's
+//!   `#[default]` marker — a hand-written `created_at` without `#[default]` gets no
+//!   inferred default) and a Postgres UUID primary key's `gen_random_uuid()`
+//!   default. Every other `#[default]` field carries no inferred DB default (their
+//!   default, if any, lives in the migration). A soft-delete `deleted_at` carries
+//!   `#[default]` solely to exclude it from the generated `New*`/`Update*`
+//!   structs — the migration leaves its column default UNSET (new rows stay NULL),
+//!   so the parser must not infer `Now` for it. A `#[default]` on any other field
+//!   (an enum default `'draft'`, a numeric default) likewise does not carry its
+//!   literal in the struct — the value lives in the migration/DSL. Recovering those
+//!   from the migration is a later slice.
 //! - **Unique-index name disambiguation**: the generator disambiguates a unique
 //!   index name past Postgres's 63-byte identifier limit (see
 //!   `schema_edit::unique_index_name`). The parser uses the plain
@@ -295,10 +299,12 @@ enum ReferenceSpec {
 }
 
 /// A field's parsed schema-relevant attributes.
+#[allow(clippy::struct_excessive_bools)] // independent field markers, not a state machine
 struct FieldAttrs {
     is_id: bool,
     is_indexed: bool,
     is_unique: bool,
+    is_default: bool,
     reference: ReferenceSpec,
 }
 
@@ -307,6 +313,7 @@ fn parse_field_attrs(field: &syn::Field) -> FieldAttrs {
         is_id: false,
         is_indexed: false,
         is_unique: false,
+        is_default: false,
         reference: ReferenceSpec::None,
     };
     for attr in &field.attrs {
@@ -317,9 +324,11 @@ fn parse_field_attrs(field: &syn::Field) -> FieldAttrs {
             "id" => out.is_id = true,
             "indexed" => out.is_indexed = true,
             "unique" => out.is_unique = true,
-            // `#[default]` no longer changes a column's parsed shape: DB column
-            // defaults the generator emits are recovered by `convention_default`
-            // from the column name/type/PK, not the attribute's presence.
+            // `#[default]` gates the `created_at` NOW() convention default (see
+            // `convention_default`): the generator always marks its `created_at`
+            // with `#[default]`, so a hand-written `created_at` WITHOUT the marker
+            // gets no inferred NOW() default.
+            "default" => out.is_default = true,
             "references" => {
                 let mut target = None;
                 if !matches!(attr.meta, syn::Meta::Path(_)) {
@@ -448,15 +457,16 @@ fn build_table(
         column.unique = raw.attrs.is_unique;
 
         // Default (slice-3+): recover only the DB column defaults the generator
-        // emits *by convention* (see `convention_default`) — the `created_at`
-        // NOW() default and a Postgres UUID primary key's `gen_random_uuid()`.
-        // The convention is a fallback: it never overwrites an already-parsed
-        // explicit default. Non-convention `#[default]` fields (a soft-delete
-        // `deleted_at`, an enum/numeric literal) carry no inferred DB default —
+        // emits *by convention* (see `convention_default`) — the `#[default]`-marked
+        // `created_at` NOW() default and a Postgres UUID primary key's
+        // `gen_random_uuid()`. The convention is a fallback: it never overwrites an
+        // already-parsed explicit default. A hand-written `created_at` without
+        // `#[default]`, and other non-convention `#[default]` fields (a soft-delete
+        // `deleted_at`, an enum/numeric literal), carry no inferred DB default —
         // their value lives in the migration, not the struct.
         column.default = column
             .default
-            .or_else(|| convention_default(&raw.name, &ty, is_pk, backend));
+            .or_else(|| convention_default(&raw.name, &ty, is_pk, raw.attrs.is_default, backend));
 
         // Foreign key: infer the target table from the generator's convention
         // (`<name>` minus a trailing `_id`, pluralized) unless overridden.
@@ -526,13 +536,20 @@ fn build_table(
 /// desired-state IR matches what `autumn generate` actually produced.
 ///
 /// Known conventions:
-/// - the reserved `created_at` (timestamp) column -> `NOW()` / `CURRENT_TIMESTAMP`
-///   (the generator gives a DB default only to `created_at`, not to any other
-///   `#[default]` timestamp such as a soft-delete `deleted_at`);
+/// - the reserved `created_at` (timestamp) column marked `#[default]` -> `NOW()`
+///   / `CURRENT_TIMESTAMP`. The convention requires the generator's `#[default]`
+///   marker: the generator ALWAYS marks its `created_at` with `#[default]`, so
+///   gating on it matches generated output exactly. A hand-written `created_at`
+///   timestamp WITHOUT `#[default]` gets no inferred default (its DDL is
+///   `created_at TIMESTAMP NOT NULL` with no default clause). The default is
+///   likewise not inferred for any other `#[default]` timestamp such as a
+///   soft-delete `deleted_at`.
 /// - a UUID `PRIMARY KEY` on Postgres -> `gen_random_uuid()` (the only primary
 ///   key that carries an explicit column `DEFAULT`; a `BIGSERIAL`/serial PK is
 ///   type-encoded with no `DEFAULT` clause, and on sqlite a UUID PK is `TEXT
 ///   PRIMARY KEY` with no default — indeed `uuid::Uuid` is a rejected type there).
+///   A `#[id]` PK is not `#[default]`-marked, so this arm is NOT gated on
+///   `is_default`.
 ///
 /// Everything else is `None` — a non-convention default lives in the migration
 /// and is recovered in a later slice. This is a *fallback*: the caller applies it
@@ -541,9 +558,13 @@ fn convention_default(
     name: &str,
     ty: &ColumnType,
     is_primary_key: bool,
+    is_default: bool,
     backend: Backend,
 ) -> Option<ColumnDefault> {
-    if name == "created_at" && matches!(ty, ColumnType::Timestamp | ColumnType::TimestampTz) {
+    if name == "created_at"
+        && is_default
+        && matches!(ty, ColumnType::Timestamp | ColumnType::TimestampTz)
+    {
         return Some(ColumnDefault::Now);
     }
     if is_primary_key && *ty == ColumnType::Uuid && backend == Backend::Postgres {
@@ -809,6 +830,49 @@ mod tests {
         let table = parse_one(src);
         assert_eq!(col(&table, "occurred_at").default, None);
         assert_eq!(col(&table, "created_at").default, Some(ColumnDefault::Now));
+    }
+
+    #[test]
+    fn hand_written_created_at_without_default_marker_has_no_inferred_default() {
+        // The `created_at` NOW() convention is gated on the generator's
+        // `#[default]` marker. A hand-written model that declares a `created_at`
+        // timestamp WITHOUT `#[default]` has DDL `created_at TIMESTAMP NOT NULL`
+        // with NO default — so the parser must report `default == None`, or a
+        // later snapshot/diff would spuriously try to ADD a NOW() default.
+        let src = r#"
+            #[autumn_web::model]
+            pub struct Event {
+                #[id]
+                pub id: i64,
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let table = parse_one(src);
+        let created = col(&table, "created_at");
+        assert_eq!(created.ty, ColumnType::Timestamp);
+        assert_eq!(created.default, None);
+    }
+
+    #[test]
+    fn hand_written_agg_event_created_at_has_no_inferred_default() {
+        // An inline copy of `AggEvent` from
+        // `autumn/tests/integration/repository_grouped_aggregates.rs`, a real
+        // hand-written model whose `created_at` carries no `#[default]` and whose
+        // DDL is `created_at TIMESTAMP NOT NULL` (no default). The parser must not
+        // over-infer a NOW() default for it.
+        let src = r#"
+            #[autumn_web::model(table = "test_agg_events")]
+            pub struct AggEvent {
+                #[id]
+                pub id: i64,
+                pub post_id: i64,
+                pub score: i32,
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let table = parse_one(src);
+        assert_eq!(table.name, "test_agg_events");
+        assert_eq!(col(&table, "created_at").default, None);
     }
 
     #[test]

--- a/autumn-cli/src/schema/parse.rs
+++ b/autumn-cli/src/schema/parse.rs
@@ -26,9 +26,10 @@
 //! - `#[id]` — primary-key column (macro PK resolution is mirrored: explicit
 //!   `#[id]` fields win, else the first `i32`/`i64` field, else a reserved `id`).
 //! - `#[indexed]` — a non-unique secondary index on the column.
-//! - `#[default]` — a column default. Recoverable from the struct only for a
-//!   `created_at`-style timestamp field (→ [`ColumnDefault::Now`]); see the
-//!   slice-3+ limitation below.
+//! - `#[default]` — a column default. The `NOW()` default is recovered only for
+//!   the reserved `created_at` column (→ [`ColumnDefault::Now`]); other
+//!   `#[default]` fields carry no inferred DB default (their default, if any,
+//!   lives in the migration). See the slice-3+ limitation below.
 //! - `#[references]` / `#[references(table = "...")]` — a foreign-key column
 //!   (forces [`ColumnType::Int64`], infers the target table from the column name
 //!   via the generator's `<name>`-minus-`_id`-then-pluralize convention, and adds
@@ -61,10 +62,15 @@
 //!   foreign key from that convention (or from the association attribute) requires
 //!   cross-model resolution and is deferred; today only an explicit
 //!   `#[references]` field attribute yields a [`ForeignKey`].
-//! - **Non-timestamp default literals**: a `#[default]` on a non-timestamp field
-//!   (an enum default `'draft'`, a numeric default) does not carry its literal in
-//!   the struct — the value lives in the migration/DSL. Only the `created_at`
-//!   `NOW()` default is recoverable here; recovering the rest is a later slice.
+//! - **Non-`created_at` `#[default]` fields**: the `NOW()` default is recovered
+//!   only for the reserved `created_at` column; other `#[default]` fields carry
+//!   no inferred DB default (their default, if any, lives in the migration). A
+//!   soft-delete `deleted_at` carries `#[default]` solely to exclude it from the
+//!   generated `New*`/`Update*` structs — the migration leaves its column default
+//!   UNSET (new rows stay NULL), so the parser must not infer `Now` for it. A
+//!   `#[default]` on any other field (an enum default `'draft'`, a numeric
+//!   default) likewise does not carry its literal in the struct — the value lives
+//!   in the migration/DSL. Recovering those from the migration is a later slice.
 //! - **Unique-index name disambiguation**: the generator disambiguates a unique
 //!   index name past Postgres's 63-byte identifier limit (see
 //!   `schema_edit::unique_index_name`). The parser uses the plain
@@ -438,10 +444,22 @@ fn build_table(
         column.primary_key = is_pk;
         column.unique = raw.attrs.is_unique;
 
-        // Default: recoverable from the struct only for a `created_at`-style
-        // timestamp `#[default]` (→ NOW()); non-timestamp default literals live
-        // in the migration and are a later slice.
-        if raw.attrs.is_default && matches!(ty, ColumnType::Timestamp | ColumnType::TimestampTz) {
+        // Default (slice-3+): the NOW() default is recovered only for the
+        // reserved `created_at` column; other `#[default]` fields carry no
+        // inferred DB default (their default, if any, lives in the migration).
+        // The generator gives a DB `DEFAULT NOW()` (Postgres) / `CURRENT_TIMESTAMP`
+        // (sqlite) *only* to `created_at`. A soft-delete `deleted_at` also carries
+        // `#[default]`, but purely to exclude it from the generated `New*`/`Update*`
+        // insert structs — the migration leaves its column default UNSET so new
+        // rows stay NULL. Inferring `Now` for it (or for any user `#[default]`
+        // timestamp) would fabricate a wrong desired-state IR, so restrict the
+        // inference to the `created_at` convention. The `#[default]`→exclude-from-
+        // insert semantics are orthogonal to the IR `default`, which represents the
+        // DB column default only.
+        if raw.name == "created_at"
+            && raw.attrs.is_default
+            && matches!(ty, ColumnType::Timestamp | ColumnType::TimestampTz)
+        {
             column.default = Some(ColumnDefault::Now);
         }
 
@@ -747,7 +765,11 @@ mod tests {
     }
 
     #[test]
-    fn default_on_timestamp_is_now() {
+    fn now_default_only_for_created_at_not_other_timestamps() {
+        // A `#[default]` on a non-`created_at` timestamp field must NOT infer a
+        // NOW() default: the generator gives a DB `DEFAULT NOW()` only to the
+        // reserved `created_at` column. A non-`created_at` `#[default]`'s DB
+        // default (if any) lives in the migration, not the struct.
         let src = r#"
             #[model]
             pub struct Event {
@@ -760,7 +782,36 @@ mod tests {
             }
         "#;
         let table = parse_one(src);
-        assert_eq!(col(&table, "occurred_at").default, Some(ColumnDefault::Now));
+        assert_eq!(col(&table, "occurred_at").default, None);
+        assert_eq!(col(&table, "created_at").default, Some(ColumnDefault::Now));
+    }
+
+    #[test]
+    fn soft_delete_deleted_at_has_no_inferred_default() {
+        // The generator emits a nullable `deleted_at` with `#[default]` ONLY to
+        // exclude it from the `New*`/`Update*` insert structs — the migration
+        // leaves its column default UNSET, so new rows stay NULL. The parser must
+        // report `default == None` (never `Some(Now)`), or a later snapshot/diff
+        // would read a spurious "add DEFAULT NOW()" change that, if applied, would
+        // make newly inserted rows appear soft-deleted.
+        let src = r#"
+            #[model]
+            pub struct Post {
+                #[id]
+                pub id: i64,
+                pub title: String,
+                #[default]
+                pub deleted_at: Option<chrono::NaiveDateTime>,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let table = parse_one(src);
+        let deleted_at = col(&table, "deleted_at");
+        assert_eq!(deleted_at.default, None);
+        assert!(deleted_at.nullable);
+        // `created_at` still recovers its NOW() default.
+        assert_eq!(col(&table, "created_at").default, Some(ColumnDefault::Now));
     }
 
     #[test]

--- a/autumn-cli/src/schema/parse.rs
+++ b/autumn-cli/src/schema/parse.rs
@@ -183,7 +183,14 @@ pub fn parse_models_dir(dir: &Path, backend: Backend) -> Result<ParsedSchema, Sc
             source,
         })?;
         let path = entry.path();
-        if path.extension().is_some_and(|ext| ext == "rs") {
+        // Query the entry's type directly (one syscall, from the DirEntry) rather
+        // than an extra `Path::is_file` metadata stat, and skip anything that is
+        // not a regular file — e.g. a subdirectory named `something.rs`.
+        let file_type = entry.file_type().map_err(|source| SchemaParseError::Io {
+            path: path.display().to_string(),
+            source,
+        })?;
+        if file_type.is_file() && path.extension().is_some_and(|ext| ext == "rs") {
             paths.push(path);
         }
     }
@@ -235,23 +242,26 @@ fn parse_model_args(attr: &syn::Attribute) -> ModelArgs {
         return args;
     }
     // `parse_nested_meta` errors on the first argument whose value we do not
-    // consume; to stay forward-compatible we consume-and-ignore unknown ones.
+    // consume; to stay forward-compatible we consume-and-ignore unknown ones so
+    // a future `#[model(...)]` argument never breaks parsing of the known ones.
     let _ = attr.parse_nested_meta(|meta| {
-        if meta.path.is_ident("table") {
-            if let Ok(value) = meta.value()
-                && let Ok(lit) = value.parse::<syn::LitStr>()
-            {
-                args.table = Some(lit.value());
-            }
+        if meta.path.is_ident("table")
+            && let Ok(value) = meta.value()
+            && let Ok(lit) = value.parse::<syn::LitStr>()
+        {
+            args.table = Some(lit.value());
         } else if meta.path.is_ident("managed") {
             args.managed = true;
-        } else if meta.path.is_ident("schema") {
-            if let Ok(value) = meta.value()
-                && let Ok(lit) = value.parse::<syn::LitStr>()
-                && lit.value() == "managed"
-            {
-                args.managed = true;
-            }
+        } else if meta.path.is_ident("schema")
+            && let Ok(value) = meta.value()
+            && let Ok(lit) = value.parse::<syn::LitStr>()
+            && lit.value() == "managed"
+        {
+            args.managed = true;
+        } else if meta.input.peek(syn::token::Paren) {
+            // Unknown nested list `key(...)` — consume it so parsing can
+            // continue to the next comma-separated argument.
+            let _ = meta.parse_nested_meta(|_| Ok(()));
         } else if let Ok(value) = meta.value() {
             // Unknown `key = value` — consume the value token so parsing can
             // continue to the next comma-separated argument.
@@ -304,12 +314,20 @@ fn parse_field_attrs(field: &syn::Field) -> FieldAttrs {
             "references" => {
                 let mut target = None;
                 if !matches!(attr.meta, syn::Meta::Path(_)) {
+                    // Extract the known `table = "..."` override, but consume any
+                    // other nested list / `key = value` pair so a future arg
+                    // (e.g. `on_delete = "cascade"`) never aborts target
+                    // extraction.
                     let _ = attr.parse_nested_meta(|meta| {
                         if meta.path.is_ident("table")
                             && let Ok(value) = meta.value()
                             && let Ok(lit) = value.parse::<syn::LitStr>()
                         {
                             target = Some(lit.value());
+                        } else if meta.input.peek(syn::token::Paren) {
+                            let _ = meta.parse_nested_meta(|_| Ok(()));
+                        } else if let Ok(value) = meta.value() {
+                            let _ = value.parse::<syn::Lit>();
                         }
                         Ok(())
                     });
@@ -977,5 +995,60 @@ mod tests {
         "#;
         let parsed = parse_model_source(src, Backend::Sqlite).expect("parse");
         assert_eq!(parsed.tables[0].backend, Backend::Sqlite);
+    }
+
+    #[test]
+    fn model_unknown_kv_arg_is_ignored_and_known_args_survive() {
+        // A future `key = value` arg must not abort parsing of `table`.
+        let src = r#"
+            #[model(table = "widgets", future_unknown = "x")]
+            pub struct Widget {
+                #[id]
+                pub id: i64,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let table = parse_one(src);
+        assert_eq!(table.name, "widgets");
+    }
+
+    #[test]
+    fn model_unknown_nested_list_arg_is_consumed_and_managed_survives() {
+        // A future nested-list arg `key(...)` must be consumed, not abort the
+        // `managed` marker that precedes it.
+        let src = r#"
+            #[model(managed, future_list(a = 1, b = 2))]
+            pub struct Account {
+                #[id]
+                pub id: i64,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let table = parse_one(src);
+        assert!(table.managed, "unknown nested list must not drop `managed`");
+    }
+
+    #[test]
+    fn references_unknown_kv_arg_is_ignored_and_target_survives() {
+        // A future `#[references(table = "...", on_delete = "...")]` arg must
+        // not abort extraction of the `table` target.
+        let src = r#"
+            #[model]
+            pub struct Comment {
+                #[id]
+                pub id: i64,
+                #[references(table = "users", on_delete = "cascade")]
+                pub author_id: i64,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let table = parse_one(src);
+        assert_eq!(
+            col(&table, "author_id").references,
+            Some(ForeignKey::new("users", "id"))
+        );
     }
 }


### PR DESCRIPTION
## Before / After

**Before:** the desired shape of a table lives only implicitly inside the `#[model]` struct and is re-derived transiently by the `autumn generate` DSL — there is no inspectable, shared representation of "what the model *says* the table should be."

**After:** `autumn-cli` gains a new read-only `schema::parse` module that reads `#[model]` structs via `syn` into the shared `autumn_schema_core` IR (slice 1). This is the **desired-state** input that slice 3's checked-in snapshot and the later diff engine consume. It emits no migration / `schema.rs` / codegen output. An experimental, read-only `autumn schema parse <path>` dev command prints the parsed IR as JSON — the first (deliberately minimal) stub of the eventual `autumn schema` command group.

## How

- **Module location** (per the ratified scoping decision): a new `autumn-cli/src/schema/` module (`mod.rs` + `parse.rs`), *not* a new workspace crate — all future consumers (diff engine, `autumn schema` commands) live in autumn-cli, which already depends on `autumn-schema-core`. `syn`/`quote`/`proc-macro2`/`serde_json`/`thiserror` were already autumn-cli deps.
- **Public API:** `parse_model_source(&str, Backend) -> Result<ParsedSchema, SchemaParseError>` and `parse_models_dir(&Path, Backend) -> …`. `ParsedSchema { tables, diagnostics }` — one `Table` per `#[model]` struct plus non-fatal per-field diagnostics. `SchemaParseError` carries `syn` span line/column for syntax errors and I/O errors for unreadable paths.
- **Reuse (no drift):** `ColumnType::from_rust_type` for the field-type mapping; the CLI's own `naming::pluralize` / `naming::pascal_to_snake` for table-name inference (byte-identical to the macro's `infer_table_name`); the generator's `<name>`-minus-`_id`-then-pluralize convention for reference-target inference; and the generator's index-emission rules (references auto-index; a `unique` field's own unique index suppresses a redundant plain one).
- **PK resolution mirrors the `#[model]` macro:** explicit `#[id]` fields win, else the first `i32`/`i64` field, else a synthesized reserved `id`. `created_at TIMESTAMP DEFAULT NOW()` is synthesized only when the struct does not already declare it.
- **Honest, never-guessing:** an unresolvable field type (a generated enum, an association type) is **skipped with a structured diagnostic** rather than mapped to a wrong `ColumnType`. Verified end-to-end against real example models (`bookmarks`, `reddit-clone`).
- **Experimental command:** `autumn schema parse <path>` (a `.rs` file or a directory of them) prints `Vec<Table>` as pretty JSON and surfaces diagnostics on stderr. Read-only; no diff/migrate/snapshot here.
- **Tests:** 17 `#[cfg(test)]` fixture tests in `parse.rs` (basic model, `table = "..."` override, `#[model(managed)]` vs unmarked, `#[references]` FK + inferred target + auto-index + table override, `#[default]` timestamp → `Now`, `#[indexed]` index, `#[unique]` unique-index-only, every recognized scalar type, unknown-type diagnostic, PK fallback + synthesis, non-model structs ignored, syntax-error location, backend carry-through, plus a smoke test that parses a real checked-in model file). Two full fixtures assert equality against a hand-built `Table`.

## Documented slice-3+ limitations (by design, not bugs)

- **Enum variants + `CHECK` constraints** — not resolvable from the struct alone; the parser records a diagnostic and never fabricates a `CHECK`. Reading the enum `#[derive]` definitions is a later slice.
- **Association-based foreign keys** — real generator output models a FK as `<name>_id: i64` + a struct-level `#[belongs_to(...)]`; resolving that (cross-model) is deferred. Today only an explicit `#[references]` field attribute yields a `ForeignKey`.
- **Non-timestamp default literals** — a `#[default]` on a non-timestamp field does not carry its literal in the struct (it lives in the migration/DSL); only the `created_at` `NOW()` default is recovered here.
- **Unique-index name disambiguation** — the parser uses the plain `idx_<table>_<field>_unique` form; exact parity with the generator's 63-byte-limit disambiguation is a later refinement.

## Verification

Scoped-only per workspace policy (a full `--workspace`/`--all-features` run ENOSPCs the shared target on trybuild):

- `cargo fmt --all -- --check` — clean
- `cargo build -p autumn-cli` — clean
- `cargo test -p autumn-cli --bin autumn schema::parse` — **17 passed; 0 failed**
- `cargo clippy -p autumn-cli --all-targets -- -D warnings` — clean (workspace `pedantic` + `nursery` are `warn`, so effectively denied)

Part of #1975.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDTbyteT8p6bBRPL7DVJHo

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDTbyteT8p6bBRPL7DVJHo)_