### PR TITLE
SQLite runtime lane PR5: CI job gating --features sqlite build + tests (AC#11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,49 @@ jobs:
       - name: Check MSRV compiles
         run: cargo check --workspace
 
+  # SQLite runtime lane gate (issue #1614, AC#11). This is the ONLY place in CI
+  # that enables autumn-web's `sqlite` feature, and it does so via an EXPLICIT
+  # `--features sqlite` on each dedicated invocation below — NEVER via
+  # `--all-features` and never via a workspace dependency edge. `sqlite` is a
+  # backend-flip feature: it flips `db::RuntimeConnection` from `AsyncPgConnection`
+  # to a SQLite connection, so unifying it with the Postgres-assuming features
+  # breaks compilation (the earlier trunk-red). Keep it isolated to this job.
+  #
+  # No Postgres `services:` / Docker: the sqlite tests use tempfile/in-memory
+  # SQLite with no external DB. The job builds + lints autumn-web under the
+  # sqlite backend and runs the sqlite integration suite by NAMED `[[test]]`
+  # target — a bare `cargo test --features sqlite` is unsafe (it would compile
+  # the Postgres `integration_tests` binary and the pg-URL lib unit tests under
+  # the flipped backend and fail).
+  sqlite-runtime:
+    name: SQLite runtime (feature=sqlite)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2.7.8
+      - name: Build autumn-web under the sqlite backend
+        run: cargo build -p autumn-web --features sqlite
+      - name: Clippy (autumn-web lib, sqlite backend)
+        run: cargo clippy -p autumn-web --features sqlite --lib -- -D warnings
+      - name: Run the sqlite integration suite
+        # Named sqlite `[[test]]` targets only. `test-support` is required by the
+        # TestApp/Db-extractor-based tests (sqlite_db_extractor, sqlite_read_only_tx,
+        # sqlite_transactional_url_pool) and is additive/harmless for the rest.
+        run: |
+          cargo test -p autumn-web --features "sqlite,test-support" \
+            --test sqlite_boot_serve \
+            --test sqlite_migrations \
+            --test sqlite_foreign_keys \
+            --test sqlite_db_extractor \
+            --test sqlite_pool_pragmas \
+            --test sqlite_read_only_pool \
+            --test sqlite_scoped_repository \
+            --test sqlite_read_only_tx \
+            --test sqlite_transactional_url_pool
+
   # Genuine loom model checks: the loom_models test binary uses loom::sync::*
   # unconditionally, so loom::model() exhaustively explores thread interleavings
   # here. We gate the binary with a NEUTRAL custom cfg (loom_models) rather than


### PR DESCRIPTION
## Before / After

**Before:** nothing in CI exercised the `sqlite` backend. PR1/#1987/#1999 landed the `sqlite` cargo feature, the SQLite pool + boot/serve, real SQLite migrations, and a suite of `#[cfg(feature = "sqlite")]` integration tests — but no CI job compiled or ran any of it, so a regression to the SQLite runtime could merge unnoticed.

**After:** a dedicated `sqlite-runtime` CI job builds `autumn-web --features sqlite` and runs the full SQLite integration test suite on every push/PR, so a break in the SQLite runtime fails CI.

## How

The new `sqlite-runtime` job (plain Linux, **no Postgres `services:` / Docker** — the sqlite tests use tempfile/in-memory SQLite) runs three steps:

1. `cargo build -p autumn-web --features sqlite` — compile the lib+bins under the SQLite backend.
2. `cargo clippy -p autumn-web --features sqlite --lib -- -D warnings` — lint the feature-on lib.
3. `cargo test -p autumn-web --features "sqlite,test-support"` over the named `[[test]]` targets:
   `sqlite_boot_serve`, `sqlite_migrations`, `sqlite_foreign_keys`, `sqlite_db_extractor`, `sqlite_pool_pragmas`, `sqlite_read_only_pool`, `sqlite_scoped_repository`, `sqlite_read_only_tx`, `sqlite_transactional_url_pool`.

The suite runs by **named `[[test]]` target** rather than a bare `cargo test --features sqlite`, which is unsafe: it would compile the Postgres `integration_tests` binary and the pg-URL lib unit tests under the flipped backend and fail. `test-support` is required by the TestApp/Db-extractor-based tests and is additive/harmless for the rest.

## Invariant reinforced

`sqlite` is a **backend-flip** feature — it flips `db::RuntimeConnection` from `AsyncPgConnection` to a SQLite connection, so unifying it with the Postgres-assuming features breaks compilation (the earlier trunk-red, caused by `--all-features` enabling sqlite). This job is the **ONLY** place in CI that enables `sqlite`, and it does so via an **explicit `--features sqlite`** on each invocation — never `--all-features` and never a workspace dependency edge. A YAML comment above the job documents this. No other job is modified.

## Scope

This gates the SQLite **runtime** (pool, boot/serve, migrations) plus the tests that pass under sqlite. Full `#[repository]` CRUD on SQLite remains out of scope, tracked separately in #1996.

## Verification (local)

- YAML parses; `jobs` = lint, test, coverage, msrv, **sqlite-runtime**, loom.
- `cargo build -p autumn-web --features sqlite` — GREEN.
- `cargo clippy -p autumn-web --features sqlite --lib -- -D warnings` — GREEN.
- All 9 sqlite `[[test]]` targets — `test result: ok` under `--features "sqlite,test-support"`.
- Default lane untouched: `cargo check --workspace` GREEN; `cargo clippy -p autumn-web --all-targets -- -D warnings` GREEN.

Closes #1614

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuoMnnmkhC2hsTmqm1inA6)_