### PR TITLE
Add the checked-in schema snapshot + autumn schema snapshot command (declarative schema, slice 3)

### DIFF
--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -6,21 +6,44 @@
 //! and the full `autumn schema` command group) build on. It is read-only:
 //! nothing here writes a migration, `schema.rs`, or any other codegen output.
 //!
-//! The experimental [`run`] entrypoint backs `autumn schema parse <path>`, which
-//! prints the parsed IR as JSON. It is the first (deliberately minimal) stub of
-//! the eventual `autumn schema` group and gives the parser a real caller.
+//! The experimental [`run`] entrypoint backs `autumn schema parse <path>` (slice
+//! 2) and `autumn schema snapshot` (slice 3). `parse` prints the parsed IR as
+//! JSON; `snapshot` writes the canonical, checked-in [`snapshot`] baseline the
+//! later diff engine consumes. These are the first actions of the eventual full
+//! `autumn schema` group.
 
 pub mod parse;
+pub mod snapshot;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use autumn_schema_core::Backend;
 
 use parse::{parse_model_source, parse_models_dir};
+use snapshot::{SNAPSHOT_DEFAULT_PATH, SchemaSnapshot};
 
-/// The `autumn schema` subcommand actions (experimental; slice 2 ships only
-/// `parse`). Kept here so the slice-6 command group can grow additional actions
-/// (`diff`, `snapshot`, …) alongside it in later slices.
+/// A `--backend pg|sqlite` override for the `snapshot` action, mapping onto the
+/// schema-core [`Backend`] dialect tag.
+#[derive(clap::ValueEnum, Debug, Clone, Copy)]
+pub enum BackendArg {
+    /// `PostgreSQL` (accepted as `pg` or `postgres`).
+    #[value(alias = "postgres")]
+    Pg,
+    /// `SQLite`.
+    Sqlite,
+}
+
+impl From<BackendArg> for Backend {
+    fn from(arg: BackendArg) -> Self {
+        match arg {
+            BackendArg::Pg => Self::Postgres,
+            BackendArg::Sqlite => Self::Sqlite,
+        }
+    }
+}
+
+/// The `autumn schema` subcommand actions (experimental). Slices 2–3 ship
+/// `parse` and `snapshot`; `diff`/… arrive in later slices.
 #[derive(clap::Subcommand, Debug)]
 pub enum SchemaAction {
     /// Parse `#[model]` structs at PATH (a `.rs` file or a directory of them)
@@ -29,21 +52,104 @@ pub enum SchemaAction {
         /// A `.rs` file or a directory containing `*.rs` model files.
         path: std::path::PathBuf,
     },
+    /// Write a canonical, versioned, dialect-tagged snapshot of the declared
+    /// `#[model]` structs — the checked-in diff baseline a later slice's diff
+    /// engine compares the desired state against. Read-only w.r.t. the models.
+    Snapshot {
+        /// The models directory to snapshot. Defaults to the app's `src/models`.
+        #[arg(long, value_name = "DIR")]
+        from: Option<PathBuf>,
+        /// Where to write the snapshot. Defaults to `.autumn/schema-snapshot.json`.
+        #[arg(long, value_name = "PATH")]
+        out: Option<PathBuf>,
+        /// The dialect to tag the snapshot with. Defaults to the project's
+        /// configured database backend (`detect_backend`).
+        #[arg(long, value_enum)]
+        backend: Option<BackendArg>,
+        /// Print the canonical JSON to stdout instead of writing a file (useful
+        /// for diffing / tests).
+        #[arg(long)]
+        stdout: bool,
+    },
 }
 
 /// Run an `autumn schema` action. Prints to stdout on success; on error, writes
 /// a message to stderr and exits non-zero (matching the other CLI handlers,
 /// which own their own error reporting).
 pub fn run(action: SchemaAction) {
-    match action {
-        SchemaAction::Parse { path } => match run_parse(&path) {
-            Ok(json) => println!("{json}"),
-            Err(message) => {
-                eprintln!("error: {message}");
-                std::process::exit(1);
-            }
-        },
+    let result = match action {
+        SchemaAction::Parse { path } => run_parse(&path).map(|json| println!("{json}")),
+        SchemaAction::Snapshot {
+            from,
+            out,
+            backend,
+            stdout,
+        } => run_snapshot(from.as_deref(), out.as_deref(), backend, stdout),
+    };
+    if let Err(message) = result {
+        eprintln!("error: {message}");
+        std::process::exit(1);
     }
+}
+
+/// Map the CLI's runtime [`autumn_web::config::DatabaseBackend`] onto the
+/// schema-core [`Backend`] dialect tag.
+const fn map_detected_backend(detected: autumn_web::config::DatabaseBackend) -> Backend {
+    match detected {
+        autumn_web::config::DatabaseBackend::Postgres => Backend::Postgres,
+        autumn_web::config::DatabaseBackend::Sqlite => Backend::Sqlite,
+    }
+}
+
+/// Assemble a snapshot from the declared models and either write it to `out`
+/// (default [`SNAPSHOT_DEFAULT_PATH`]) or print it to stdout.
+///
+/// The backend is `--backend` when given, else the project's configured backend
+/// (`generate::detect_backend`, the same pg-vs-sqlite resolution the generator
+/// uses). The source is `--from`, else the project's `src/models` directory.
+/// Parser diagnostics are surfaced on stderr (non-fatal), mirroring `parse`.
+///
+/// Building the baseline from the declared models (not a live DB) is deliberate:
+/// at adoption time the models and the database agree, so this establishes the
+/// initial baseline with no database connection. A `--from-db` oracle that reads
+/// a live Postgres schema is deferred to a later slice (see the module docs).
+fn run_snapshot(
+    from: Option<&Path>,
+    out: Option<&Path>,
+    backend: Option<BackendArg>,
+    stdout: bool,
+) -> Result<(), String> {
+    let project_root = std::env::current_dir()
+        .map_err(|e| format!("failed to resolve the current directory: {e}"))?;
+    let models_dir = from.map_or_else(
+        || project_root.join("src").join("models"),
+        Path::to_path_buf,
+    );
+
+    let backend = backend.map_or_else(
+        || map_detected_backend(crate::generate::detect_backend(&project_root)),
+        Backend::from,
+    );
+
+    let parsed = parse_models_dir(&models_dir, backend).map_err(|e| e.to_string())?;
+    for diag in &parsed.diagnostics {
+        eprintln!("warning: {}", diag.message);
+    }
+
+    let snapshot = SchemaSnapshot::new(backend, parsed.tables);
+    if stdout {
+        print!("{}", snapshot::to_canonical_json(&snapshot));
+        return Ok(());
+    }
+
+    let out_path = out.map_or_else(|| PathBuf::from(SNAPSHOT_DEFAULT_PATH), Path::to_path_buf);
+    snapshot::write_snapshot(&out_path, &snapshot).map_err(|e| e.to_string())?;
+    println!(
+        "wrote schema snapshot for {} table(s) to {}",
+        snapshot.tables.len(),
+        out_path.display()
+    );
+    Ok(())
 }
 
 /// Parse a file or directory and render the tables as pretty JSON, surfacing any

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -121,6 +121,18 @@ fn run_snapshot(
 ) -> Result<(), String> {
     let project_root = std::env::current_dir()
         .map_err(|e| format!("failed to resolve the current directory: {e}"))?;
+
+    // When either default is in play — `src/models` for the source (no `--from`)
+    // or `.autumn/…` for the output (no `--out`, writing a file) — the command
+    // assumes the current directory is the project root. Fail fast with a clear
+    // message instead of a confusing IO error (`src/models` / `.autumn/` not
+    // found) when it is run from a subdirectory. A fully explicit invocation
+    // (`--from` plus either `--out` or `--stdout`) needs no project root and
+    // skips the check.
+    if from.is_none() || (out.is_none() && !stdout) {
+        crate::generate::ensure_project_root(&project_root).map_err(|e| e.to_string())?;
+    }
+
     let models_dir = from.map_or_else(
         || project_root.join("src").join("models"),
         Path::to_path_buf,

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -61,7 +61,10 @@ pub enum SchemaAction {
         #[arg(long, value_name = "PATH")]
         from: Option<PathBuf>,
         /// Where to write the snapshot. Defaults to `.autumn/schema-snapshot.json`.
-        #[arg(long, value_name = "PATH")]
+        /// Mutually exclusive with `--stdout` (writing a file and printing to
+        /// stdout are two different output modes). The default is applied in
+        /// code when omitted, so `conflicts_with` never misfires on the default.
+        #[arg(long, value_name = "PATH", conflicts_with = "stdout")]
         out: Option<PathBuf>,
         /// The dialect to tag the snapshot with. Defaults to the project's
         /// configured database backend (`detect_backend`).
@@ -350,6 +353,50 @@ mod tests {
         assert!(
             msg.contains("Autumn project"),
             "the generic project-root message: {msg}"
+        );
+    }
+
+    /// A minimal `clap::Parser` wrapper so the `SchemaAction` subcommand args
+    /// (a `Subcommand`, not a `Parser`) can be exercised at parse time.
+    #[derive(clap::Parser, Debug)]
+    struct TestCli {
+        #[command(subcommand)]
+        action: SchemaAction,
+    }
+
+    #[test]
+    fn out_and_stdout_are_mutually_exclusive() {
+        use clap::Parser;
+        // clap rejects `--out` together with `--stdout` before `run_snapshot`
+        // ever runs, so the misleading "printed but `--out` file unwritten" case
+        // is impossible.
+        let err = TestCli::try_parse_from([
+            "autumn",
+            "snapshot",
+            "--from",
+            "models.rs",
+            "--out",
+            "snap.json",
+            "--stdout",
+        ])
+        .unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+
+        // Each mode alone still parses.
+        assert!(
+            TestCli::try_parse_from(["autumn", "snapshot", "--from", "models.rs", "--stdout"])
+                .is_ok()
+        );
+        assert!(
+            TestCli::try_parse_from([
+                "autumn",
+                "snapshot",
+                "--from",
+                "models.rs",
+                "--out",
+                "snap.json"
+            ])
+            .is_ok()
         );
     }
 

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -125,6 +125,41 @@ fn resolve_default_models_path(project_root: &Path) -> Result<PathBuf, String> {
     ))
 }
 
+/// Whether the `snapshot` command requires the current directory to be the
+/// project root. It does whenever any input falls back to a project-relative
+/// default: the source (`--from` omitted → `src/models`), the default output
+/// file (`--out` omitted while not writing to stdout → `.autumn/…`), or the
+/// auto-detected backend (`--backend` omitted — detection reads the root's
+/// `autumn.toml` / `.env`, so anywhere else it would silently mis-detect
+/// Postgres).
+///
+/// A fully explicit invocation — `--from` plus `--out`/`--stdout` plus
+/// `--backend` — needs no project root and can run from anywhere. Kept pure so
+/// the decision matrix is unit-testable without touching the process CWD.
+const fn needs_project_root(
+    from: Option<&Path>,
+    out: Option<&Path>,
+    stdout: bool,
+    backend: Option<BackendArg>,
+) -> bool {
+    from.is_none() || (out.is_none() && !stdout) || backend.is_none()
+}
+
+/// The error surfaced when the `snapshot` command needs the project root but the
+/// current directory is not one. When auto-detecting the backend is one of the
+/// reasons, the message names `--backend` so the user can either run from the
+/// root or opt out of detection; otherwise it is the generic project-root
+/// message (a default path, not the backend, forced the requirement).
+fn project_root_required_error(backend_is_a_reason: bool) -> String {
+    if backend_is_a_reason {
+        "cannot auto-detect the database backend outside the project root — \
+         run from the project root or pass --backend pg|sqlite"
+            .to_string()
+    } else {
+        crate::generate::GenerateError::NotInProject.to_string()
+    }
+}
+
 /// Assemble a snapshot from the declared models and either write it to `out`
 /// (default [`SNAPSHOT_DEFAULT_PATH`]) or print it to stdout.
 ///
@@ -148,15 +183,21 @@ fn run_snapshot(
     let project_root = std::env::current_dir()
         .map_err(|e| format!("failed to resolve the current directory: {e}"))?;
 
-    // When either default is in play — `src/models` for the source (no `--from`)
-    // or `.autumn/…` for the output (no `--out`, writing a file) — the command
-    // assumes the current directory is the project root. Fail fast with a clear
-    // message instead of a confusing IO error (`src/models` / `.autumn/` not
-    // found) when it is run from a subdirectory. A fully explicit invocation
-    // (`--from` plus either `--out` or `--stdout`) needs no project root and
-    // skips the check.
-    if from.is_none() || (out.is_none() && !stdout) {
-        crate::generate::ensure_project_root(&project_root).map_err(|e| e.to_string())?;
+    // When any input falls back to a project-relative default the command needs
+    // the current directory to be the project root (see `needs_project_root`):
+    // the source (`--from` omitted → `src/models`), the default output file
+    // (`--out` omitted while writing a file), or — critically — the auto-detected
+    // backend (`--backend` omitted → detection reads the root's `autumn.toml` /
+    // `.env`). Run from a subdirectory without `--backend`, `detect_backend`
+    // would find no config and silently tag the snapshot Postgres, producing a
+    // wrong baseline for a SQLite app. Fail fast with a clear message instead of
+    // a confusing IO error or a mis-tagged snapshot. A fully explicit invocation
+    // (`--from` plus `--out`/`--stdout` plus `--backend`) needs no project root.
+    let backend_given = backend.is_some();
+    if needs_project_root(from, out, stdout, backend)
+        && crate::generate::ensure_project_root(&project_root).is_err()
+    {
+        return Err(project_root_required_error(!backend_given));
     }
 
     let models_path = match from {
@@ -232,6 +273,84 @@ mod tests {
 
         let resolved = resolve_default_models_path(root.path()).expect("resolve");
         assert_eq!(resolved, file);
+    }
+
+    #[test]
+    fn fully_explicit_invocation_needs_no_project_root() {
+        let from = Path::new("models.rs");
+        let out = Path::new("snap.json");
+        // `--from` + `--out` + `--backend`: nothing is defaulted, so the command
+        // can run from any directory.
+        assert!(!needs_project_root(
+            Some(from),
+            Some(out),
+            false,
+            Some(BackendArg::Sqlite)
+        ));
+        // `--from` + `--stdout` + `--backend` likewise.
+        assert!(!needs_project_root(
+            Some(from),
+            None,
+            true,
+            Some(BackendArg::Sqlite)
+        ));
+    }
+
+    #[test]
+    fn missing_backend_requires_project_root_even_with_explicit_paths() {
+        let from = Path::new("models.rs");
+        let out = Path::new("snap.json");
+        // Explicit `--from` and `--out`/`--stdout`, but no `--backend`: detection
+        // needs the root's config, so the root is still required.
+        assert!(needs_project_root(Some(from), Some(out), false, None));
+        assert!(needs_project_root(Some(from), None, true, None));
+    }
+
+    #[test]
+    fn default_paths_require_project_root() {
+        let from = Path::new("models.rs");
+        let out = Path::new("snap.json");
+        // Missing `--from` defaults the source to `src/models`.
+        assert!(needs_project_root(
+            None,
+            Some(out),
+            false,
+            Some(BackendArg::Sqlite)
+        ));
+        // Missing `--out` while not writing to stdout defaults the output file.
+        assert!(needs_project_root(
+            Some(from),
+            None,
+            false,
+            Some(BackendArg::Sqlite)
+        ));
+        // Bare `snapshot` (everything defaulted) certainly needs the root.
+        assert!(needs_project_root(None, None, false, None));
+    }
+
+    #[test]
+    fn root_required_error_names_backend_when_detection_is_a_reason() {
+        let msg = project_root_required_error(true);
+        assert!(
+            msg.contains("--backend"),
+            "guides the user to --backend: {msg}"
+        );
+        assert!(
+            msg.contains("auto-detect"),
+            "explains the auto-detection failure: {msg}"
+        );
+    }
+
+    #[test]
+    fn root_required_error_is_generic_when_backend_is_explicit() {
+        // Backend was given, so only a default path forced the requirement — the
+        // generic project-root message is used (no misleading --backend hint).
+        let msg = project_root_required_error(false);
+        assert!(!msg.contains("--backend"), "no --backend hint: {msg}");
+        assert!(
+            msg.contains("Autumn project"),
+            "the generic project-root message: {msg}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 
 use autumn_schema_core::Backend;
 
-use parse::{parse_model_source, parse_models_dir};
+use parse::parse_models_path;
 use snapshot::{SNAPSHOT_DEFAULT_PATH, SchemaSnapshot};
 
 /// A `--backend pg|sqlite` override for the `snapshot` action, mapping onto the
@@ -56,8 +56,9 @@ pub enum SchemaAction {
     /// `#[model]` structs — the checked-in diff baseline a later slice's diff
     /// engine compares the desired state against. Read-only w.r.t. the models.
     Snapshot {
-        /// The models directory to snapshot. Defaults to the app's `src/models`.
-        #[arg(long, value_name = "DIR")]
+        /// A `.rs` model file or a directory of them to snapshot. Defaults to
+        /// the app's `src/models` directory, else `src/models.rs`.
+        #[arg(long, value_name = "PATH")]
         from: Option<PathBuf>,
         /// Where to write the snapshot. Defaults to `.autumn/schema-snapshot.json`.
         #[arg(long, value_name = "PATH")]
@@ -101,13 +102,38 @@ const fn map_detected_backend(detected: autumn_web::config::DatabaseBackend) -> 
     }
 }
 
+/// Resolve the default models source when `--from` is omitted: the app's
+/// `src/models` directory if it exists, else the single-file `src/models.rs`
+/// layout, else a clear error telling the user to pass `--from`. Autumn supports
+/// both layouts, so the snapshot default must accept either.
+///
+/// Takes an explicit `project_root` (rather than reading the process CWD) so it
+/// is testable without mutating the current directory.
+fn resolve_default_models_path(project_root: &Path) -> Result<PathBuf, String> {
+    let dir = project_root.join("src").join("models");
+    if dir.is_dir() {
+        return Ok(dir);
+    }
+    let file = project_root.join("src").join("models.rs");
+    if file.is_file() {
+        return Ok(file);
+    }
+    Err(format!(
+        "no models found at {} or {} — pass --from to point at your models file or directory",
+        dir.display(),
+        file.display()
+    ))
+}
+
 /// Assemble a snapshot from the declared models and either write it to `out`
 /// (default [`SNAPSHOT_DEFAULT_PATH`]) or print it to stdout.
 ///
 /// The backend is `--backend` when given, else the project's configured backend
 /// (`generate::detect_backend`, the same pg-vs-sqlite resolution the generator
-/// uses). The source is `--from`, else the project's `src/models` directory.
-/// Parser diagnostics are surfaced on stderr (non-fatal), mirroring `parse`.
+/// uses). The source is `--from` (a `.rs` file or a directory), else the
+/// project's default models path (`src/models` directory, else `src/models.rs`;
+/// see [`resolve_default_models_path`]). Parser diagnostics are surfaced on
+/// stderr (non-fatal), mirroring `parse`.
 ///
 /// Building the baseline from the declared models (not a live DB) is deliberate:
 /// at adoption time the models and the database agree, so this establishes the
@@ -133,17 +159,17 @@ fn run_snapshot(
         crate::generate::ensure_project_root(&project_root).map_err(|e| e.to_string())?;
     }
 
-    let models_dir = from.map_or_else(
-        || project_root.join("src").join("models"),
-        Path::to_path_buf,
-    );
+    let models_path = match from {
+        Some(path) => path.to_path_buf(),
+        None => resolve_default_models_path(&project_root)?,
+    };
 
     let backend = backend.map_or_else(
         || map_detected_backend(crate::generate::detect_backend(&project_root)),
         Backend::from,
     );
 
-    let parsed = parse_models_dir(&models_dir, backend).map_err(|e| e.to_string())?;
+    let parsed = parse_models_path(&models_path, backend).map_err(|e| e.to_string())?;
     for diag in &parsed.diagnostics {
         eprintln!("warning: {}", diag.message);
     }
@@ -171,18 +197,52 @@ fn run_parse(path: &Path) -> Result<String, String> {
     // The parser IR is backend-tagged; `parse` defaults to Postgres (the fully
     // wired runtime backend). A backend flag is a later-slice concern.
     let backend = Backend::Postgres;
-    let parsed = if path.is_dir() {
-        parse_models_dir(path, backend)
-    } else {
-        let src = std::fs::read_to_string(path)
-            .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
-        parse_model_source(&src, backend)
-    }
-    .map_err(|e| e.to_string())?;
+    let parsed = parse_models_path(path, backend).map_err(|e| e.to_string())?;
 
     for diag in &parsed.diagnostics {
         eprintln!("warning: {}", diag.message);
     }
 
     serde_json::to_string_pretty(&parsed.tables).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_resolver_prefers_src_models_dir() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let dir = root.path().join("src").join("models");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        // A `src/models.rs` file also present must not win over the directory.
+        std::fs::write(root.path().join("src").join("models.rs"), "").expect("write file");
+
+        let resolved = resolve_default_models_path(root.path()).expect("resolve");
+        assert_eq!(resolved, dir);
+    }
+
+    #[test]
+    fn default_resolver_falls_back_to_single_file() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let src = root.path().join("src");
+        std::fs::create_dir_all(&src).expect("mkdir");
+        let file = src.join("models.rs");
+        std::fs::write(&file, "").expect("write file");
+
+        let resolved = resolve_default_models_path(root.path()).expect("resolve");
+        assert_eq!(resolved, file);
+    }
+
+    #[test]
+    fn default_resolver_errors_when_neither_exists() {
+        let root = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(root.path().join("src")).expect("mkdir");
+
+        let err = resolve_default_models_path(root.path()).unwrap_err();
+        assert!(
+            err.contains("--from"),
+            "error tells the user to pass --from"
+        );
+    }
 }

--- a/autumn-cli/src/schema/parse.rs
+++ b/autumn-cli/src/schema/parse.rs
@@ -227,6 +227,40 @@ pub fn parse_models_dir(dir: &Path, backend: Backend) -> Result<ParsedSchema, Sc
     Ok(out)
 }
 
+/// Parse the `#[model]` structs at `path`, dispatching on what the path is:
+/// a DIRECTORY is walked via [`parse_models_dir`]; a `.rs` FILE is read and
+/// parsed via [`parse_model_source`] (the single-file `src/models.rs` layout);
+/// a path that is neither (does not exist) yields a clear error naming it.
+///
+/// This is the one file-vs-directory dispatch both `autumn schema parse` and
+/// `autumn schema snapshot` route through, so the two commands accept the same
+/// `src/models/` (directory) and single-file `src/models.rs` layouts and can
+/// never drift.
+///
+/// # Errors
+///
+/// Returns [`SchemaParseError::Io`] if `path` does not exist or cannot be read,
+/// or [`SchemaParseError::Syntax`] if a file is not valid Rust.
+pub fn parse_models_path(path: &Path, backend: Backend) -> Result<ParsedSchema, SchemaParseError> {
+    if path.is_dir() {
+        parse_models_dir(path, backend)
+    } else if path.is_file() {
+        let src = std::fs::read_to_string(path).map_err(|source| SchemaParseError::Io {
+            path: path.display().to_string(),
+            source,
+        })?;
+        parse_model_source(&src, backend)
+    } else {
+        Err(SchemaParseError::Io {
+            path: path.display().to_string(),
+            source: std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "expected a `.rs` model file or a directory of model files",
+            ),
+        })
+    }
+}
+
 /// Find the `#[model]` / `#[autumn_web::model]` attribute on a struct, if any.
 /// The last path segment must be `model`, so both the bare and fully-qualified
 /// spellings match.
@@ -1261,5 +1295,54 @@ mod tests {
             col(&table, "author_id").references,
             Some(ForeignKey::new("users", "id"))
         );
+    }
+
+    const SINGLE_FILE_MODEL: &str = r#"
+        #[model]
+        pub struct Post {
+            #[id]
+            pub id: i64,
+            pub body: String,
+        }
+    "#;
+
+    #[test]
+    fn parse_models_path_reads_a_single_rs_file() {
+        // The single-file `src/models.rs` layout: `--from` points at a `.rs`
+        // file, not a directory.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("models.rs");
+        std::fs::write(&file, SINGLE_FILE_MODEL).expect("write model file");
+
+        let parsed = parse_models_path(&file, Backend::Postgres).expect("parse single file");
+        assert_eq!(parsed.tables.len(), 1);
+        assert_eq!(parsed.tables[0].name, "posts");
+    }
+
+    #[test]
+    fn parse_models_path_reads_a_directory() {
+        // The `src/models/` directory layout with one `*.rs` file.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let models_dir = dir.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir");
+        std::fs::write(models_dir.join("post.rs"), SINGLE_FILE_MODEL).expect("write model file");
+
+        let parsed = parse_models_path(&models_dir, Backend::Postgres).expect("parse dir");
+        assert_eq!(parsed.tables.len(), 1);
+        assert_eq!(parsed.tables[0].name, "posts");
+    }
+
+    #[test]
+    fn parse_models_path_missing_path_is_a_clear_io_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("does_not_exist.rs");
+
+        let err = parse_models_path(&missing, Backend::Postgres).unwrap_err();
+        match err {
+            SchemaParseError::Io { path, .. } => {
+                assert!(path.contains("does_not_exist.rs"), "path names the input");
+            }
+            other @ SchemaParseError::Syntax { .. } => panic!("expected Io error, got {other:?}"),
+        }
     }
 }

--- a/autumn-cli/src/schema/snapshot.rs
+++ b/autumn-cli/src/schema/snapshot.rs
@@ -1,0 +1,552 @@
+//! The checked-in schema **snapshot** artifact and its canonical save/load — the
+//! offline, VCS-reviewable *diff baseline* the declarative-schema wave builds on
+//! (slice 3 of tracking issue #1975).
+//!
+//! Slice 2 gave us a reader of the **desired state** ([`crate::schema::parse`],
+//! which lifts `#[model]` structs into the [`autumn_schema_core`] IR). This slice
+//! adds the other half of a diff: a durable, versioned, dialect-tagged file that
+//! records the schema's *last-known agreed shape*. At adoption time the declared
+//! models and the live database agree, so writing a snapshot of the models
+//! establishes the initial baseline; a later slice's diff engine compares the
+//! freshly-parsed desired state against this committed file to compute the
+//! pending migration.
+//!
+//! # Why a bespoke envelope (not just `Vec<Table>`)
+//!
+//! A raw `Vec<Table>` round-trips through serde, but a checked-in artifact needs
+//! two extra guarantees the bare IR does not carry at the top level:
+//!
+//! - **A `snapshot_version`** ([`SNAPSHOT_VERSION`]) so a future format change is
+//!   detected loudly ([`SnapshotError::UnsupportedVersion`]) instead of being
+//!   silently mis-parsed by an older CLI.
+//! - **A top-level `backend`** dialect tag (Decision 5 provider-lock): the same
+//!   logical schema renders different DDL per backend, so a snapshot is locked to
+//!   the provider it was generated against. [`SchemaSnapshot::ensure_backend_matches`]
+//!   is the guard a later slice's diff engine calls before diffing.
+//!
+//! # Canonical serialization
+//!
+//! [`to_canonical_json`] is deterministic: tables are sorted by name and, within
+//! a table, indexes and checks are sorted by name, so the same logical schema
+//! always serializes to byte-identical JSON regardless of source-file order or
+//! map iteration. Columns keep their declared struct order — that order is
+//! meaningful (it is the `CREATE TABLE` column order) and readable in review.
+//! Deterministic output is what makes the file a clean `git diff` target.
+
+use std::path::Path;
+
+use autumn_schema_core::{Backend, Schema, Table};
+use serde::{Deserialize, Serialize};
+
+/// The current on-disk snapshot format version. Bumped only by a
+/// backwards-incompatible change to the envelope; [`load_snapshot`] rejects any
+/// other value so an older CLI never silently mis-reads a newer file.
+pub const SNAPSHOT_VERSION: u32 = 1;
+
+/// The conventional, checked-in location of the schema snapshot, relative to the
+/// project root. Lives under the `.autumn/` state directory (the same
+/// dot-namespace the CLI already uses for generated state such as
+/// `static/.autumn-assets.json` / `.autumn-manifest.json`) so the diff baseline
+/// sits beside the project's other Autumn-owned artifacts and is easy to review
+/// in a pull request. The `snapshot` command's `--out` flag overrides it.
+pub const SNAPSHOT_DEFAULT_PATH: &str = ".autumn/schema-snapshot.json";
+
+/// A durable, versioned, dialect-tagged snapshot of a schema's shape — the
+/// checked-in diff baseline.
+///
+/// The field order (`snapshot_version`, `backend`, `tables`) is also the
+/// serialized key order, chosen so the two most operationally important facts
+/// (which format, which provider) lead the file.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SchemaSnapshot {
+    /// The on-disk format version (see [`SNAPSHOT_VERSION`]).
+    pub snapshot_version: u32,
+    /// The dialect this snapshot is locked to (its provider-lock; see [`Backend`]).
+    pub backend: Backend,
+    /// The tables, canonicalized on write (see [`to_canonical_json`]).
+    pub tables: Vec<Table>,
+}
+
+impl SchemaSnapshot {
+    /// Build a snapshot at the current [`SNAPSHOT_VERSION`] from `backend` and
+    /// `tables`. The tables are stored as given; canonical ordering is applied at
+    /// serialization time by [`to_canonical_json`], not here, so a caller's live
+    /// in-memory ordering (e.g. declaration order) is preserved for any other use.
+    #[must_use]
+    pub const fn new(backend: Backend, tables: Vec<Table>) -> Self {
+        Self {
+            snapshot_version: SNAPSHOT_VERSION,
+            backend,
+            tables,
+        }
+    }
+
+    /// Build a snapshot from an [`autumn_schema_core::Schema`], taking its
+    /// backend tag and tables.
+    // Part of the snapshot API surface; the model-derived `snapshot` command
+    // builds from `Vec<Table>` directly, so this `Schema`-taking constructor is
+    // exercised by tests / later slices rather than the current command path.
+    #[allow(dead_code)]
+    #[must_use]
+    pub fn from_schema(schema: Schema) -> Self {
+        Self::new(schema.backend, schema.tables)
+    }
+
+    /// Confirm this snapshot targets `expected` — the provider-lock guard a later
+    /// slice's diff engine calls before diffing a desired state against the
+    /// baseline (a snapshot generated for one dialect must not be diffed against
+    /// another). Never enforced by the writer.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SnapshotError::BackendMismatch`] when the tags differ.
+    // The provider-lock guard is consumed by the slice-4 diff engine (which
+    // reads a baseline and diffs it against a desired state); the writer never
+    // calls it, so it is not yet reachable from the command path.
+    #[allow(dead_code)]
+    pub fn ensure_backend_matches(&self, expected: Backend) -> Result<(), SnapshotError> {
+        if self.backend == expected {
+            Ok(())
+        } else {
+            Err(SnapshotError::BackendMismatch {
+                expected,
+                found: self.backend,
+            })
+        }
+    }
+}
+
+/// Failure modes for reading, writing, or validating a snapshot file. `Display`
+/// carries no secrets — a snapshot describes schema shape only.
+// The read-side variants (`Json` / `UnsupportedVersion` / `BackendMismatch`) are
+// produced by `load_snapshot` / `ensure_backend_matches`, which the slice-4 diff
+// engine consumes; the current `snapshot` command only writes (using `Io`).
+#[allow(dead_code)]
+#[derive(Debug, thiserror::Error)]
+pub enum SnapshotError {
+    /// The snapshot file could not be read or written.
+    #[error("failed to access snapshot at {path}: {source}")]
+    Io {
+        /// The path that could not be read or written.
+        path: String,
+        /// The underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// The snapshot file was not valid JSON (or did not match the envelope shape).
+    #[error("failed to parse snapshot at {path}: {source}")]
+    Json {
+        /// The path whose contents failed to parse.
+        path: String,
+        /// The underlying serde error.
+        #[source]
+        source: serde_json::Error,
+    },
+    /// The file declares a `snapshot_version` this CLI does not understand.
+    #[error(
+        "unsupported snapshot_version {found} (this build understands version {SNAPSHOT_VERSION}); \
+         upgrade the Autumn CLI to read this snapshot"
+    )]
+    UnsupportedVersion {
+        /// The version found in the file.
+        found: u32,
+    },
+    /// The snapshot's dialect tag does not match the expected backend (the
+    /// provider-lock guard; see [`SchemaSnapshot::ensure_backend_matches`]).
+    #[error("snapshot backend {found:?} does not match the expected backend {expected:?}")]
+    BackendMismatch {
+        /// The backend the caller expected.
+        expected: Backend,
+        /// The backend recorded in the snapshot.
+        found: Backend,
+    },
+}
+
+/// Render `snapshot` to canonical, pretty-printed (2-space) JSON with a trailing
+/// newline.
+///
+/// Canonical means deterministic: tables are sorted by name and, within each
+/// table, indexes and checks are sorted (by name, then by a stable tiebreak), so
+/// the same logical schema always yields byte-identical output. Columns keep
+/// their declared order (the `CREATE TABLE` column order). Serializing the same
+/// input twice is guaranteed to produce identical bytes.
+#[must_use]
+pub fn to_canonical_json(snapshot: &SchemaSnapshot) -> String {
+    let canonical = SchemaSnapshot {
+        snapshot_version: snapshot.snapshot_version,
+        backend: snapshot.backend,
+        tables: canonical_tables(&snapshot.tables),
+    };
+    // `serde_json::to_string_pretty` on a struct emits fields in declaration
+    // order (not a sorted map), so ordering nondeterminism can only come from the
+    // `Vec`s we sort above — the output is stable.
+    let mut json = serde_json::to_string_pretty(&canonical)
+        .expect("SchemaSnapshot is always serializable to JSON");
+    json.push('\n');
+    json
+}
+
+/// Return a name-sorted clone of `tables` with each table's indexes and checks
+/// sorted too. Columns are intentionally left in declared order.
+fn canonical_tables(tables: &[Table]) -> Vec<Table> {
+    let mut tables = tables.to_vec();
+    tables.sort_by(|a, b| a.name.cmp(&b.name));
+    for table in &mut tables {
+        table.indexes.sort_by(|a, b| a.name.cmp(&b.name));
+        // Checks carry an `Option<String>` name; fall back to the expression as a
+        // stable tiebreak so unnamed checks still order deterministically.
+        table.checks.sort_by(|a, b| {
+            a.name
+                .cmp(&b.name)
+                .then_with(|| a.expression.cmp(&b.expression))
+        });
+    }
+    tables
+}
+
+/// Write `snapshot` canonically to `path`, creating any missing parent
+/// directories (e.g. the conventional `.autumn/` dir).
+///
+/// # Errors
+///
+/// Returns [`SnapshotError::Io`] if a parent directory cannot be created or the
+/// file cannot be written.
+pub fn write_snapshot(path: &Path, snapshot: &SchemaSnapshot) -> Result<(), SnapshotError> {
+    if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        std::fs::create_dir_all(parent).map_err(|source| SnapshotError::Io {
+            path: parent.display().to_string(),
+            source,
+        })?;
+    }
+    std::fs::write(path, to_canonical_json(snapshot)).map_err(|source| SnapshotError::Io {
+        path: path.display().to_string(),
+        source,
+    })
+}
+
+/// Read and validate a snapshot from `path`.
+///
+/// The `snapshot_version` is checked *before* the full envelope is deserialized,
+/// so a future format the current CLI cannot read fails with a clear
+/// [`SnapshotError::UnsupportedVersion`] rather than an opaque field-shape error.
+///
+/// # Errors
+///
+/// Returns [`SnapshotError::Io`] if the file cannot be read,
+/// [`SnapshotError::UnsupportedVersion`] if it declares an unknown version, or
+/// [`SnapshotError::Json`] if it is not a valid snapshot document.
+// The baseline reader is consumed by the slice-4 diff engine; the current
+// command only writes, so it is not yet reachable from the command path.
+#[allow(dead_code)]
+pub fn load_snapshot(path: &Path) -> Result<SchemaSnapshot, SnapshotError> {
+    let text = std::fs::read_to_string(path).map_err(|source| SnapshotError::Io {
+        path: path.display().to_string(),
+        source,
+    })?;
+    parse_snapshot_str(&text, &path.display().to_string())
+}
+
+/// Parse a snapshot from an in-memory string, applying the same version guard as
+/// [`load_snapshot`]. Split out so it is testable without touching the
+/// filesystem; `label` names the source in any error.
+// Reachable only through `load_snapshot` (slice-4 diff engine) and the tests.
+#[allow(dead_code)]
+fn parse_snapshot_str(text: &str, label: &str) -> Result<SchemaSnapshot, SnapshotError> {
+    // Read the version from a loose `Value` first so an unknown *future* format
+    // (whose table shape this build may not understand) still fails with the
+    // precise version error instead of a confusing deserialize error.
+    let value: serde_json::Value =
+        serde_json::from_str(text).map_err(|source| SnapshotError::Json {
+            path: label.to_owned(),
+            source,
+        })?;
+    if let Some(version) = value
+        .get("snapshot_version")
+        .and_then(serde_json::Value::as_u64)
+        && version != u64::from(SNAPSHOT_VERSION)
+    {
+        return Err(SnapshotError::UnsupportedVersion {
+            found: u32::try_from(version).unwrap_or(u32::MAX),
+        });
+    }
+    serde_json::from_value(value).map_err(|source| SnapshotError::Json {
+        path: label.to_owned(),
+        source,
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::needless_raw_string_hashes)]
+mod tests {
+    use super::*;
+    use autumn_schema_core::{
+        CheckConstraint, Column, ColumnDefault, ColumnType, ForeignKey, Index,
+    };
+
+    use crate::schema::parse::parse_model_source;
+
+    /// A small, deterministic two-table fixture exercising columns, a foreign
+    /// key, a default, indexes (deliberately out of name order), and a check.
+    fn fixture_tables() -> Vec<Table> {
+        // Declared second alphabetically but pushed first, to prove sorting.
+        let mut posts = Table::new("posts", Backend::Postgres);
+        let mut id = Column::new("id", ColumnType::Int64);
+        id.primary_key = true;
+        posts.primary_key.push("id".to_owned());
+        let mut author = Column::new("author_id", ColumnType::Int64);
+        author.references = Some(ForeignKey::new("users", "id"));
+        let mut created = Column::new("created_at", ColumnType::Timestamp);
+        created.default = Some(ColumnDefault::Now);
+        posts.columns.push(id);
+        posts.columns.push(author);
+        posts.columns.push(Column::new("body", ColumnType::Text));
+        posts.columns.push(created);
+        // Two indexes pushed out of name order to prove index sorting.
+        posts.indexes.push(Index {
+            name: "idx_posts_created_at".to_owned(),
+            columns: vec!["created_at".to_owned()],
+            unique: false,
+        });
+        posts.indexes.push(Index {
+            name: "idx_posts_author_id".to_owned(),
+            columns: vec!["author_id".to_owned()],
+            unique: false,
+        });
+        posts.checks.push(CheckConstraint {
+            name: Some("posts_body_len".to_owned()),
+            expression: "length(body) > 0".to_owned(),
+        });
+
+        let mut accounts = Table::new("accounts", Backend::Postgres);
+        let mut aid = Column::new("id", ColumnType::Int64);
+        aid.primary_key = true;
+        accounts.primary_key.push("id".to_owned());
+        let mut email = Column::new("email", ColumnType::Text);
+        email.unique = true;
+        accounts.columns.push(aid);
+        accounts.columns.push(email);
+
+        // `posts` pushed before `accounts` on purpose — canonical output sorts them.
+        vec![posts, accounts]
+    }
+
+    #[test]
+    fn round_trips_through_canonical_json() {
+        let snapshot = SchemaSnapshot::new(Backend::Postgres, fixture_tables());
+        let json = to_canonical_json(&snapshot);
+        let back = parse_snapshot_str(&json, "<test>").expect("parse back");
+        // Equality is order-insensitive at the table/index level only if both
+        // sides are canonical; canonicalize the original for the comparison.
+        let expected = SchemaSnapshot {
+            snapshot_version: SNAPSHOT_VERSION,
+            backend: Backend::Postgres,
+            tables: canonical_tables(&snapshot.tables),
+        };
+        assert_eq!(back, expected);
+    }
+
+    #[test]
+    fn write_then_load_round_trips_on_disk() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // A nested path proves parent-dir creation.
+        let path = dir.path().join(".autumn").join("schema-snapshot.json");
+        let snapshot = SchemaSnapshot::new(Backend::Sqlite, fixture_tables());
+        write_snapshot(&path, &snapshot).expect("write");
+        let loaded = load_snapshot(&path).expect("load");
+        assert_eq!(loaded.backend, Backend::Sqlite);
+        assert_eq!(loaded.snapshot_version, SNAPSHOT_VERSION);
+        // Loaded tables are the canonical form.
+        assert_eq!(loaded.tables, canonical_tables(&snapshot.tables));
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)] // the pinned golden JSON fixture is inline
+    fn canonical_json_matches_golden_and_is_byte_stable() {
+        let snapshot = SchemaSnapshot::new(Backend::Postgres, fixture_tables());
+        let json = to_canonical_json(&snapshot);
+
+        // Golden fixture: tables sorted (accounts before posts), indexes sorted
+        // (author_id before created_at), columns in declared order, envelope
+        // fields leading. Re-generate deliberately if the IR shape changes.
+        let expected = r#"{
+  "snapshot_version": 1,
+  "backend": "Postgres",
+  "tables": [
+    {
+      "name": "accounts",
+      "columns": [
+        {
+          "name": "id",
+          "ty": "Int64",
+          "nullable": false,
+          "primary_key": true,
+          "unique": false,
+          "default": null,
+          "references": null
+        },
+        {
+          "name": "email",
+          "ty": "Text",
+          "nullable": false,
+          "primary_key": false,
+          "unique": true,
+          "default": null,
+          "references": null
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "indexes": [],
+      "checks": [],
+      "backend": "Postgres",
+      "managed": true
+    },
+    {
+      "name": "posts",
+      "columns": [
+        {
+          "name": "id",
+          "ty": "Int64",
+          "nullable": false,
+          "primary_key": true,
+          "unique": false,
+          "default": null,
+          "references": null
+        },
+        {
+          "name": "author_id",
+          "ty": "Int64",
+          "nullable": false,
+          "primary_key": false,
+          "unique": false,
+          "default": null,
+          "references": {
+            "table": "users",
+            "column": "id"
+          }
+        },
+        {
+          "name": "body",
+          "ty": "Text",
+          "nullable": false,
+          "primary_key": false,
+          "unique": false,
+          "default": null,
+          "references": null
+        },
+        {
+          "name": "created_at",
+          "ty": "Timestamp",
+          "nullable": false,
+          "primary_key": false,
+          "unique": false,
+          "default": "Now",
+          "references": null
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "indexes": [
+        {
+          "name": "idx_posts_author_id",
+          "columns": [
+            "author_id"
+          ],
+          "unique": false
+        },
+        {
+          "name": "idx_posts_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "unique": false
+        }
+      ],
+      "checks": [
+        {
+          "name": "posts_body_len",
+          "expression": "length(body) > 0"
+        }
+      ],
+      "backend": "Postgres",
+      "managed": true
+    }
+  ]
+}
+"#;
+        assert_eq!(
+            json, expected,
+            "canonical JSON drifted from the golden fixture"
+        );
+        // Byte-stability: re-serializing yields identical bytes.
+        assert_eq!(to_canonical_json(&snapshot), json);
+        // And canonicalization is idempotent: feeding the canonical form back in
+        // produces the same output (input order does not matter).
+        let reparsed = parse_snapshot_str(&json, "<test>").expect("parse");
+        assert_eq!(to_canonical_json(&reparsed), json);
+    }
+
+    #[test]
+    fn unknown_future_version_is_rejected() {
+        let doc = r#"{ "snapshot_version": 999, "backend": "Postgres", "tables": [] }"#;
+        let err = parse_snapshot_str(doc, "<test>").unwrap_err();
+        match err {
+            SnapshotError::UnsupportedVersion { found } => assert_eq!(found, 999),
+            other => panic!("expected UnsupportedVersion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn backend_tag_serializes_and_ensure_matches() {
+        let pg = SchemaSnapshot::new(Backend::Postgres, Vec::new());
+        assert!(to_canonical_json(&pg).contains("\"backend\": \"Postgres\""));
+        assert!(pg.ensure_backend_matches(Backend::Postgres).is_ok());
+        let mismatch = pg.ensure_backend_matches(Backend::Sqlite).unwrap_err();
+        assert!(matches!(
+            mismatch,
+            SnapshotError::BackendMismatch {
+                expected: Backend::Sqlite,
+                found: Backend::Postgres
+            }
+        ));
+
+        let sqlite = SchemaSnapshot::new(Backend::Sqlite, Vec::new());
+        assert!(to_canonical_json(&sqlite).contains("\"backend\": \"Sqlite\""));
+        assert!(sqlite.ensure_backend_matches(Backend::Sqlite).is_ok());
+    }
+
+    #[test]
+    fn malformed_json_is_a_json_error() {
+        let err = parse_snapshot_str("{ not json", "<test>").unwrap_err();
+        assert!(matches!(err, SnapshotError::Json { .. }));
+    }
+
+    #[test]
+    fn end_to_end_from_parsed_model_source() {
+        // Slice-2 parser -> snapshot -> canonical JSON contains the expected shape.
+        let src = r#"
+            #[autumn_web::model]
+            pub struct Post {
+                #[id]
+                pub id: i64,
+                pub title: String,
+                #[default]
+                pub created_at: chrono::NaiveDateTime,
+            }
+        "#;
+        let parsed = parse_model_source(src, Backend::Postgres).expect("parse");
+        let snapshot = SchemaSnapshot::new(Backend::Postgres, parsed.tables);
+        let json = to_canonical_json(&snapshot);
+        assert!(json.contains("\"name\": \"posts\""));
+        assert!(json.contains("\"name\": \"title\""));
+        assert!(json.contains("\"snapshot_version\": 1"));
+        assert!(json.contains("\"default\": \"Now\""));
+        // Re-loading the produced JSON yields a valid, version-1 snapshot.
+        let loaded = parse_snapshot_str(&json, "<test>").expect("reload");
+        assert_eq!(loaded.snapshot_version, SNAPSHOT_VERSION);
+        assert_eq!(loaded.tables.len(), 1);
+        assert_eq!(loaded.tables[0].name, "posts");
+    }
+}

--- a/autumn-cli/src/schema/snapshot.rs
+++ b/autumn-cli/src/schema/snapshot.rs
@@ -207,21 +207,47 @@ fn canonical_tables(tables: &[Table]) -> Vec<Table> {
 /// Write `snapshot` canonically to `path`, creating any missing parent
 /// directories (e.g. the conventional `.autumn/` dir).
 ///
+/// The replacement is **atomic**: the canonical JSON is written to a
+/// same-directory temporary file, flushed and `fsync`ed, then `rename`d over the
+/// destination (an atomic swap on the same filesystem). A disk-full or
+/// interrupted write therefore leaves the previously-committed baseline intact
+/// instead of truncating or corrupting it, and readers never observe a
+/// half-written file. On any failure the temp file is cleaned up (best-effort)
+/// and the error is returned.
+///
 /// # Errors
 ///
 /// Returns [`SnapshotError::Io`] if a parent directory cannot be created or the
-/// file cannot be written.
+/// snapshot cannot be written and swapped into place.
 pub fn write_snapshot(path: &Path, snapshot: &SchemaSnapshot) -> Result<(), SnapshotError> {
+    use std::io::Write;
+
+    let io_error = |source: std::io::Error| SnapshotError::Io {
+        path: path.display().to_string(),
+        source,
+    };
+
     if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
         std::fs::create_dir_all(parent).map_err(|source| SnapshotError::Io {
             path: parent.display().to_string(),
             source,
         })?;
     }
-    std::fs::write(path, to_canonical_json(snapshot)).map_err(|source| SnapshotError::Io {
-        path: path.display().to_string(),
-        source,
-    })
+
+    // Stage into a temp file in the *same directory* as the destination so the
+    // final `rename` is an atomic same-filesystem swap. `NamedTempFile` picks a
+    // collision-resistant name and removes the temp file on drop, so any early
+    // return below (or a failed `persist`) cleans it up automatically.
+    let dir = match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent,
+        _ => Path::new("."),
+    };
+    let mut temp = tempfile::NamedTempFile::new_in(dir).map_err(io_error)?;
+    temp.write_all(to_canonical_json(snapshot).as_bytes())
+        .and_then(|()| temp.as_file().sync_all())
+        .map_err(io_error)?;
+    temp.persist(path).map_err(|e| io_error(e.error))?;
+    Ok(())
 }
 
 /// Read and validate a snapshot from `path`.
@@ -486,6 +512,35 @@ mod tests {
         // produces the same output (input order does not matter).
         let reparsed = parse_snapshot_str(&json, "<test>").expect("parse");
         assert_eq!(to_canonical_json(&reparsed), json);
+    }
+
+    #[test]
+    fn write_snapshot_atomically_replaces_existing_file_without_leftover_temp() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("schema-snapshot.json");
+
+        // Seed a pre-existing (stale) baseline at the destination.
+        std::fs::write(&path, "OLD STALE CONTENT").expect("seed old baseline");
+
+        let snapshot = SchemaSnapshot::new(Backend::Postgres, fixture_tables());
+        write_snapshot(&path, &snapshot).expect("write");
+
+        // The destination now holds the fresh canonical JSON (replacement worked).
+        let written = std::fs::read_to_string(&path).expect("read back");
+        assert_eq!(written, to_canonical_json(&snapshot));
+        assert!(!written.contains("OLD STALE CONTENT"));
+
+        // No temp file leaked into the directory on success: the destination is
+        // the only entry.
+        let entries: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("read_dir")
+            .map(|e| e.expect("entry").file_name())
+            .collect();
+        assert_eq!(
+            entries,
+            vec![std::ffi::OsString::from("schema-snapshot.json")],
+            "the atomic write must leave no leftover temp file: {entries:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Before / After

**Before:** slice 2 gave us a reader of the *desired state* — `autumn schema parse` lifts an app's `#[model]` structs into the shared `autumn_schema_core` IR — but there was no *baseline* to diff that desired state against.

**After:** `autumn schema snapshot` writes a canonical, dialect-tagged, versioned snapshot of the declared models to a checked-in file. That file is the offline, VCS-reviewable **diff baseline** the slice-4 diff engine will consume: at adoption time the models and the database agree, so snapshotting the models establishes the initial baseline, and a later slice diffs `desired(models)` against this committed snapshot to compute the pending migration.

## How

- **`SchemaSnapshot { snapshot_version, backend, tables }`** — a serde envelope over the slice-1 IR. `snapshot_version` (`= 1`) is a forward-compat guard; the top-level `backend` is the Decision-5 provider-lock dialect tag. Built from a `Vec<Table>` (`SchemaSnapshot::new`) or an `autumn_schema_core::Schema` (`from_schema`).
- **Canonical serialization** (`to_canonical_json`) — deterministic, pretty-printed (2-space) JSON with a trailing newline: **tables sorted by name**, and within a table **indexes and checks sorted by name** (columns keep their declared `CREATE TABLE` order, which is meaningful and readable). The same input always yields byte-identical output, so the file is a clean `git diff` target.
- **Save / load** — `write_snapshot` (creates the parent `.autumn/` dir), `load_snapshot` (parses + validates), and `ensure_backend_matches` (the provider-lock guard later slices call before diffing — *not* enforced by the writer). `SnapshotError` (thiserror) covers IO, JSON, unsupported-version, and backend-mismatch; the version is checked from a loose `Value` *before* full deserialization, so an unknown future format fails with a precise version error rather than an opaque field-shape error.
- **Default path** — `.autumn/schema-snapshot.json` (centralized constant; `--out` overrides). Chosen to sit under the same `.autumn`-namespace the CLI already uses for generated state (`static/.autumn-assets.json`, `.autumn-manifest.json`).
- **The command** — `autumn schema snapshot [--from <DIR>] [--out <PATH>] [--backend pg|sqlite] [--stdout]`, a new `Snapshot` variant on the slice-2 `SchemaAction` group. Source is the declared models (`--from`, default `src/models`), parsed via the slice-2 `parse_models_dir`; backend is `--backend` else the project's configured backend (`generate::detect_backend`, mapped to the schema-core `Backend`). Writes canonically to `--out` (default the constant) or prints with `--stdout`. Parser diagnostics surface on stderr (non-fatal), mirroring `schema parse`.
- **`--from-db` deferred to slice 11** — a live-Postgres oracle would require mapping the existing introspection module's own `Column`/`TableSchema` types (plus FK/index/check reconstruction) into the IR; that's non-trivial plumbing and scope creep, so slice 3 ships the model-derived `--from` source only. Documented as a follow-up in the module docs.
- **Tests** (no-DB, deterministic, in-module): round-trip through canonical JSON; a pinned **golden** fixture asserting the exact canonical bytes + byte-stability + idempotence; on-disk write→load round-trip (proving parent-dir creation); forward-compat rejection of `snapshot_version: 999`; backend-tag serialization + `ensure_backend_matches` ok/err; malformed-JSON error; and an end-to-end `parse_model_source` → snapshot → canonical-JSON check.

## Verification

Scoped-verification only (a `cargo test --workspace` trybuild run ENOSPCs this environment):

- `cargo build -p autumn-cli` — clean
- `cargo clippy -p autumn-cli --all-targets -- -D warnings` — clean
- `cargo test -p autumn-cli --bin autumn schema::snapshot` — **7 passed**
- `cargo test -p autumn-cli --bin autumn schema::parse` — **26 passed** (slice-2 parser unaffected)
- Manual smoke: `autumn schema snapshot --from examples/bookmarks/src/models --backend pg --stdout` and `--out …/.autumn/schema-snapshot.json` both produce the canonical file (trailing newline, parent dir created).

Part of #1975.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDTbyteT8p6bBRPL7DVJHo)_