### PR TITLE
feat(dist): prebuilt curl-able autumn CLI binaries + install script

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -3,14 +3,20 @@ name: CLI Release Binaries
 # Builds prebuilt `autumn` CLI binaries for Linux + macOS (x86_64 + aarch64)
 # and attaches them — with sha256 checksums — to a GitHub Release.
 #
-# Binaries correspond to DELIBERATE, TAGGED CRATE RELEASES, not trunk. The canonical
-# trigger is `release: published`, which fires only when a release is cut from a
-# version tag (release.yml runs on `v[0-9]+.*` tags) — cutting a release is always an
-# explicit maintainer action. The binary is built from that tag's source, so
-# `releases/latest/download/...` always means "the latest RELEASED version"; there
-# are no rolling/nightly trunk-dev builds.
+# Binaries correspond to DELIBERATE, TAGGED CRATE RELEASES, not trunk. This is a
+# reusable workflow invoked by `release.yml` (its `binaries` job) right after the
+# GitHub Release for a `v[0-9]+.*` tag is created — so it runs only once the Publish
+# Gate has passed and the release exists, and it uploads to that release. Cutting a
+# release is always an explicit maintainer action; there are no rolling/nightly
+# trunk-dev builds, and `releases/latest/download/...` always means "the latest
+# RELEASED version".
 #
-# `workflow_dispatch` is a manual escape hatch only: supply a `tag` to (re)build a
+# It is deliberately NOT triggered by `on: release`: release.yml creates the release
+# with the default GITHUB_TOKEN, and events raised by GITHUB_TOKEN do not start new
+# workflow runs, so an `on: release` trigger would silently never fire. Invoking it
+# as a reusable job from release.yml side-steps that entirely and is deterministic.
+#
+# `workflow_dispatch` is a manual escape hatch: supply a `tag` to (re)build a
 # specific released tag and attach to its release, or leave it blank to build the
 # current ref for validation (uploads workflow artifacts, no release upload).
 #
@@ -22,8 +28,12 @@ name: CLI Release Binaries
 # natively on macOS runners. Windows is a documented follow-up (see #2005).
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag to build from and attach binaries to (e.g. v0.6.0)."
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       tag:
@@ -35,7 +45,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: cli-release-${{ github.event.release.tag_name || inputs.tag || github.run_id }}
+  group: cli-release-${{ inputs.tag || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -62,7 +72,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name || inputs.tag || github.ref }}
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -109,10 +119,10 @@ jobs:
           if-no-files-found: error
 
       - name: Attach to release
-        if: github.event_name == 'release' || inputs.tag != ''
+        if: ${{ inputs.tag != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
           gh release upload "$TAG" \

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,10 +1,18 @@
 name: CLI Release Binaries
 
 # Builds prebuilt `autumn` CLI binaries for Linux (x86_64 + aarch64, static musl)
-# and attaches them — with sha256 checksums — to the GitHub Release that triggered
-# the run. Also workflow_dispatch-able for validation before any tag exists: a manual
-# run builds and uploads the binaries as workflow artifacts (and, when an existing
-# release `tag` input is supplied, also attaches them to that release).
+# and attaches them — with sha256 checksums — to a GitHub Release.
+#
+# Binaries correspond to DELIBERATE, TAGGED CRATE RELEASES, not trunk. The canonical
+# trigger is `release: published`, which fires only when a release is cut from a
+# version tag (release.yml runs on `v[0-9]+.*` tags) — cutting a release is always an
+# explicit maintainer action. The binary is built from that tag's source, so
+# `releases/latest/download/...` always means "the latest RELEASED version"; there
+# are no rolling/nightly trunk-dev builds.
+#
+# `workflow_dispatch` is a manual escape hatch only: supply a `tag` to (re)build a
+# specific released tag and attach to its release, or leave it blank to build the
+# current ref for validation (uploads workflow artifacts, no release upload).
 #
 # Distribution contract (see scripts/install.sh and the README "Install" section):
 #   - Version-pinned: .../releases/download/<tag>/autumn-<target>.tar.gz
@@ -17,7 +25,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing release tag to attach binaries to (blank = build-only validation, artifacts only)."
+        description: "Released tag to build from and attach to (e.g. v0.6.0). Blank = build the current ref for validation only (artifacts, no release upload)."
         required: false
         type: string
 
@@ -41,6 +49,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag || github.ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,6 +1,6 @@
 name: CLI Release Binaries
 
-# Builds prebuilt `autumn` CLI binaries for Linux (x86_64 + aarch64, static musl)
+# Builds prebuilt `autumn` CLI binaries for Linux + macOS (x86_64 + aarch64)
 # and attaches them — with sha256 checksums — to a GitHub Release.
 #
 # Binaries correspond to DELIBERATE, TAGGED CRATE RELEASES, not trunk. The canonical
@@ -18,6 +18,8 @@ name: CLI Release Binaries
 #   - Version-pinned: .../releases/download/<tag>/autumn-<target>.tar.gz
 #   - Stable latest:  .../releases/latest/download/autumn-<target>.tar.gz
 # Asset names are intentionally version-less so the latest/download URL is stable.
+# Linux targets build via `cross` (musl, no glibc dependency); macOS targets build
+# natively on macOS runners. Windows is a documented follow-up (see #2005).
 
 on:
   release:
@@ -39,13 +41,23 @@ concurrency:
 jobs:
   build:
     name: build (${{ matrix.target }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            cross: true
           - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            cross: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            cross: false
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            cross: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -58,12 +70,18 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Install cross
+        if: ${{ matrix.cross }}
         uses: taiki-e/install-action@v2
         with:
           tool: cross
 
-      - name: Build autumn (${{ matrix.target }})
+      - name: Build autumn via cross (${{ matrix.target }})
+        if: ${{ matrix.cross }}
         run: cross build --locked -p autumn-cli --release --bin autumn --target ${{ matrix.target }}
+
+      - name: Build autumn via cargo (${{ matrix.target }})
+        if: ${{ ! matrix.cross }}
+        run: cargo build --locked -p autumn-cli --release --bin autumn --target ${{ matrix.target }}
 
       - name: Package tarball + checksum
         run: |
@@ -73,7 +91,11 @@ jobs:
           cp "target/${{ matrix.target }}/release/autumn" "$staging/autumn"
           cp LICENSE-MIT LICENSE-APACHE "$staging/" 2>/dev/null || true
           tar -C "$staging" -czf "$asset" .
-          sha256sum "$asset" > "$asset.sha256"
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$asset" > "$asset.sha256"
+          else
+            shasum -a 256 "$asset" > "$asset.sha256"
+          fi
           echo "--- checksum ---"
           cat "$asset.sha256"
 

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,0 +1,89 @@
+name: CLI Release Binaries
+
+# Builds prebuilt `autumn` CLI binaries for Linux (x86_64 + aarch64, static musl)
+# and attaches them — with sha256 checksums — to the GitHub Release that triggered
+# the run. Also workflow_dispatch-able for validation before any tag exists: a manual
+# run builds and uploads the binaries as workflow artifacts (and, when an existing
+# release `tag` input is supplied, also attaches them to that release).
+#
+# Distribution contract (see scripts/install.sh and the README "Install" section):
+#   - Version-pinned: .../releases/download/<tag>/autumn-<target>.tar.gz
+#   - Stable latest:  .../releases/latest/download/autumn-<target>.tar.gz
+# Asset names are intentionally version-less so the latest/download URL is stable.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to attach binaries to (blank = build-only validation, artifacts only)."
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: cli-release-${{ github.event.release.tag_name || inputs.tag || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: build (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+          - target: aarch64-unknown-linux-musl
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
+      - name: Build autumn (${{ matrix.target }})
+        run: cross build --locked -p autumn-cli --release --bin autumn --target ${{ matrix.target }}
+
+      - name: Package tarball + checksum
+        run: |
+          set -euo pipefail
+          asset="autumn-${{ matrix.target }}.tar.gz"
+          staging="$(mktemp -d)"
+          cp "target/${{ matrix.target }}/release/autumn" "$staging/autumn"
+          cp LICENSE-MIT LICENSE-APACHE "$staging/" 2>/dev/null || true
+          tar -C "$staging" -czf "$asset" .
+          sha256sum "$asset" > "$asset.sha256"
+          echo "--- checksum ---"
+          cat "$asset.sha256"
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: autumn-${{ matrix.target }}
+          path: |
+            autumn-${{ matrix.target }}.tar.gz
+            autumn-${{ matrix.target }}.tar.gz.sha256
+          if-no-files-found: error
+
+      - name: Attach to release
+        if: github.event_name == 'release' || inputs.tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" \
+            "autumn-${{ matrix.target }}.tar.gz" \
+            "autumn-${{ matrix.target }}.tar.gz.sha256" \
+            --clobber --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
     if: |
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push'
+    outputs:
+      tag: ${{ steps.tag.outputs.name }}
     steps:
       - name: Download release artifacts
         uses: actions/download-artifact@v8
@@ -60,3 +62,12 @@ jobs:
           body_path: RELEASE_NOTES.md
           draft: false
           prerelease: ${{ steps.tag.outputs.prerelease == 'true' }}
+
+  binaries:
+    name: Build & attach CLI binaries
+    needs: release
+    permissions:
+      contents: write
+    uses: ./.github/workflows/cli-release.yml
+    with:
+      tag: ${{ needs.release.outputs.tag }}

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Direct download URLs (static musl binaries — no glibc version dependency):
 - Latest: `https://github.com/madmax983/autumn/releases/latest/download/autumn-x86_64-unknown-linux-musl.tar.gz`
 - Pinned: `https://github.com/madmax983/autumn/releases/download/<tag>/autumn-x86_64-unknown-linux-musl.tar.gz`
 
+Binaries track tagged crate releases (e.g. `v0.6.0`); `latest` is the most recent released version — there are no rolling trunk-dev builds.
+
 Each tarball ships a companion `.sha256`. Prefer source? `cargo install --path autumn-cli` still works.
 
 ### Watching custom directories

--- a/README.md
+++ b/README.md
@@ -58,24 +58,24 @@ autumn dev
 Visit <http://localhost:3000>. Autumn also auto-mounts `/health`,
 `/actuator/health`, `/actuator/info`, and `/static/js/htmx.min.js`.
 
-### Install a prebuilt binary (Linux)
+### Install a prebuilt binary (macOS & Linux)
 
-Grab the `autumn` CLI without compiling from source:
+Get the `autumn` CLI without compiling from source — no Rust toolchain required:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/madmax983/autumn/trunk-dev/scripts/install.sh | sh
 ```
 
-This downloads the prebuilt binary for your architecture (x86_64 or aarch64), verifies its sha256 checksum, and installs it to `~/.local/bin/autumn`. Override the target dir with `AUTUMN_INSTALL_DIR`, or pin a version with `AUTUMN_VERSION=vX.Y.Z` (or `--version vX.Y.Z`).
+The installer detects your OS and architecture (macOS or Linux, x86_64 or aarch64), downloads the matching prebuilt binary, verifies its sha256 checksum, and installs it to `~/.local/bin/autumn` — printing the line to add if that directory isn't on your `PATH`. Override the target dir with `AUTUMN_INSTALL_DIR`, or pin a version with `AUTUMN_VERSION=vX.Y.Z` (or `--version vX.Y.Z`).
 
-Direct download URLs (static musl binaries — no glibc version dependency):
+Prefer a manual download? Grab the tarball plus its `.sha256`:
 
-- Latest: `https://github.com/madmax983/autumn/releases/latest/download/autumn-x86_64-unknown-linux-musl.tar.gz`
-- Pinned: `https://github.com/madmax983/autumn/releases/download/<tag>/autumn-x86_64-unknown-linux-musl.tar.gz`
+- Latest: `https://github.com/madmax983/autumn/releases/latest/download/autumn-<target>.tar.gz`
+- Pinned: `https://github.com/madmax983/autumn/releases/download/<tag>/autumn-<target>.tar.gz`
 
-Binaries track tagged crate releases (e.g. `v0.6.0`); `latest` is the most recent released version — there are no rolling trunk-dev builds.
+where `<target>` is one of `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`, `x86_64-apple-darwin`, or `aarch64-apple-darwin` (Linux binaries are static musl — no glibc version dependency). Binaries track tagged crate releases (e.g. `v0.6.0`); `latest` is the most recent released version — there are no rolling trunk-dev builds. Windows is a documented follow-up (see #2005); build from source there for now.
 
-Each tarball ships a companion `.sha256`. Prefer source? `cargo install --path autumn-cli` still works.
+Prefer building from source? `cargo install --path autumn-cli` still works.
 
 ### Watching custom directories
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,23 @@ autumn dev
 Visit <http://localhost:3000>. Autumn also auto-mounts `/health`,
 `/actuator/health`, `/actuator/info`, and `/static/js/htmx.min.js`.
 
+### Install a prebuilt binary (Linux)
+
+Grab the `autumn` CLI without compiling from source:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/madmax983/autumn/trunk-dev/scripts/install.sh | sh
+```
+
+This downloads the prebuilt binary for your architecture (x86_64 or aarch64), verifies its sha256 checksum, and installs it to `~/.local/bin/autumn`. Override the target dir with `AUTUMN_INSTALL_DIR`, or pin a version with `AUTUMN_VERSION=vX.Y.Z` (or `--version vX.Y.Z`).
+
+Direct download URLs (static musl binaries — no glibc version dependency):
+
+- Latest: `https://github.com/madmax983/autumn/releases/latest/download/autumn-x86_64-unknown-linux-musl.tar.gz`
+- Pinned: `https://github.com/madmax983/autumn/releases/download/<tag>/autumn-x86_64-unknown-linux-musl.tar.gz`
+
+Each tarball ships a companion `.sha256`. Prefer source? `cargo install --path autumn-cli` still works.
+
 ### Watching custom directories
 
 `autumn dev` always watches `src/`, `static/`, `templates/`, and `migrations/`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,6 +5,7 @@
 #
 # Downloads a prebuilt `autumn` binary from GitHub Releases, verifies its sha256
 # checksum, and installs it. Linux x86_64 and aarch64 are supported.
+# Binaries correspond to tagged crate releases; "latest" is the most recent release.
 #
 # Environment overrides (flags --version/--dir/--target mirror them):
 #   AUTUMN_VERSION      version tag to install, or "latest" (default: latest)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,13 +26,32 @@ info() { printf 'autumn-install: %s\n' "$1" >&2; }
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --version) VERSION="${2:?--version requires a value}"; shift 2 ;;
+    --version)
+      [ $# -ge 2 ] || err "--version requires a value"
+      VERSION="$2"; shift 2 ;;
     --version=*) VERSION="${1#*=}"; shift ;;
-    --dir) INSTALL_DIR="${2:?--dir requires a value}"; shift 2 ;;
+    --dir)
+      [ $# -ge 2 ] || err "--dir requires a value"
+      INSTALL_DIR="$2"; shift 2 ;;
     --dir=*) INSTALL_DIR="${1#*=}"; shift ;;
-    --target) TARGET="${2:?--target requires a value}"; shift 2 ;;
+    --target)
+      [ $# -ge 2 ] || err "--target requires a value"
+      TARGET="$2"; shift 2 ;;
     --target=*) TARGET="${1#*=}"; shift ;;
-    -h|--help) sed -n '2,15p' "$0" 2>/dev/null || true; exit 0 ;;
+    -h|--help)
+      cat <<'EOF'
+Autumn CLI installer.
+
+Downloads a prebuilt autumn binary from GitHub Releases, verifies its sha256
+checksum, and installs it. Linux x86_64 and aarch64 are supported.
+
+Environment overrides (flags --version/--dir/--target mirror them):
+  AUTUMN_VERSION      version tag to install, or "latest" (default: latest)
+  AUTUMN_INSTALL_DIR  install directory (default: $HOME/.local/bin)
+  AUTUMN_TARGET       force target triple (default: autodetected)
+  AUTUMN_BASE_URL     release base URL (default: https://github.com/madmax983/autumn/releases)
+EOF
+      exit 0 ;;
     *) err "unknown argument: $1 (try --help)" ;;
   esac
 done
@@ -70,12 +89,13 @@ info "downloading ${asset} (${VERSION})"
 download "$url" "$tmp/$asset" || err "download failed: $url"
 download "${url}.sha256" "$tmp/$asset.sha256" || err "checksum download failed: ${url}.sha256"
 
-expected="$(awk '{print $1}' "$tmp/$asset.sha256")"
+expected=""
+read -r expected _ < "$tmp/$asset.sha256" 2>/dev/null || true
 [ -n "$expected" ] || err "empty checksum from ${url}.sha256"
 if command -v sha256sum >/dev/null 2>&1; then
-  actual="$(sha256sum "$tmp/$asset" | awk '{print $1}')"
+  actual="$(sha256sum "$tmp/$asset")"; actual="${actual%% *}"
 elif command -v shasum >/dev/null 2>&1; then
-  actual="$(shasum -a 256 "$tmp/$asset" | awk '{print $1}')"
+  actual="$(shasum -a 256 "$tmp/$asset")"; actual="${actual%% *}"
 else
   err "need sha256sum or shasum to verify the download"
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# Autumn CLI installer.
+#
+#   curl -fsSL https://raw.githubusercontent.com/madmax983/autumn/trunk-dev/scripts/install.sh | sh
+#
+# Downloads a prebuilt `autumn` binary from GitHub Releases, verifies its sha256
+# checksum, and installs it. Linux x86_64 and aarch64 are supported.
+#
+# Environment overrides (flags --version/--dir/--target mirror them):
+#   AUTUMN_VERSION      version tag to install, or "latest" (default: latest)
+#   AUTUMN_INSTALL_DIR  install directory (default: $HOME/.local/bin)
+#   AUTUMN_TARGET       force target triple (default: autodetected)
+#   AUTUMN_BASE_URL     release base URL (default: https://github.com/madmax983/autumn/releases)
+set -eu
+
+REPO_SLUG="madmax983/autumn"
+DEFAULT_BASE_URL="https://github.com/${REPO_SLUG}/releases"
+
+VERSION="${AUTUMN_VERSION:-latest}"
+INSTALL_DIR="${AUTUMN_INSTALL_DIR:-${HOME}/.local/bin}"
+TARGET="${AUTUMN_TARGET:-}"
+BASE_URL="${AUTUMN_BASE_URL:-$DEFAULT_BASE_URL}"
+
+err() { printf 'autumn-install: error: %s\n' "$1" >&2; exit 1; }
+info() { printf 'autumn-install: %s\n' "$1" >&2; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version) VERSION="${2:?--version requires a value}"; shift 2 ;;
+    --version=*) VERSION="${1#*=}"; shift ;;
+    --dir) INSTALL_DIR="${2:?--dir requires a value}"; shift 2 ;;
+    --dir=*) INSTALL_DIR="${1#*=}"; shift ;;
+    --target) TARGET="${2:?--target requires a value}"; shift 2 ;;
+    --target=*) TARGET="${1#*=}"; shift ;;
+    -h|--help) sed -n '2,15p' "$0" 2>/dev/null || true; exit 0 ;;
+    *) err "unknown argument: $1 (try --help)" ;;
+  esac
+done
+
+if command -v curl >/dev/null 2>&1; then
+  download() { curl -fsSL "$1" -o "$2"; }
+elif command -v wget >/dev/null 2>&1; then
+  download() { wget -qO "$2" "$1"; }
+else
+  err "need curl or wget to download"
+fi
+
+if [ -z "$TARGET" ]; then
+  os="$(uname -s)"
+  arch="$(uname -m)"
+  [ "$os" = "Linux" ] || err "unsupported OS: $os (prebuilt binaries are Linux-only for now; build from source with 'cargo install --path autumn-cli')"
+  case "$arch" in
+    x86_64|amd64) TARGET="x86_64-unknown-linux-musl" ;;
+    aarch64|arm64) TARGET="aarch64-unknown-linux-musl" ;;
+    *) err "unsupported architecture: $arch (build from source with 'cargo install --path autumn-cli')" ;;
+  esac
+fi
+
+asset="autumn-${TARGET}.tar.gz"
+if [ "$VERSION" = "latest" ]; then
+  url="${BASE_URL}/latest/download/${asset}"
+else
+  url="${BASE_URL}/download/${VERSION}/${asset}"
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+info "downloading ${asset} (${VERSION})"
+download "$url" "$tmp/$asset" || err "download failed: $url"
+download "${url}.sha256" "$tmp/$asset.sha256" || err "checksum download failed: ${url}.sha256"
+
+expected="$(awk '{print $1}' "$tmp/$asset.sha256")"
+[ -n "$expected" ] || err "empty checksum from ${url}.sha256"
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "$tmp/$asset" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  actual="$(shasum -a 256 "$tmp/$asset" | awk '{print $1}')"
+else
+  err "need sha256sum or shasum to verify the download"
+fi
+[ "$expected" = "$actual" ] || err "checksum mismatch: expected $expected, got $actual"
+info "checksum ok ($actual)"
+
+tar -xzf "$tmp/$asset" -C "$tmp"
+[ -f "$tmp/autumn" ] || err "archive did not contain an 'autumn' binary"
+
+mkdir -p "$INSTALL_DIR"
+if command -v install >/dev/null 2>&1; then
+  install -m 0755 "$tmp/autumn" "$INSTALL_DIR/autumn"
+else
+  cp "$tmp/autumn" "$INSTALL_DIR/autumn"
+  chmod 0755 "$INSTALL_DIR/autumn"
+fi
+info "installed autumn -> ${INSTALL_DIR}/autumn"
+
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) : ;;
+  *) info "note: ${INSTALL_DIR} is not on your PATH; add it, e.g. export PATH=\"${INSTALL_DIR}:\$PATH\"" ;;
+esac
+
+"$INSTALL_DIR/autumn" --version 2>/dev/null || true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,7 +4,7 @@
 #   curl -fsSL https://raw.githubusercontent.com/madmax983/autumn/trunk-dev/scripts/install.sh | sh
 #
 # Downloads a prebuilt `autumn` binary from GitHub Releases, verifies its sha256
-# checksum, and installs it. Linux x86_64 and aarch64 are supported.
+# checksum, and installs it. Linux and macOS (x86_64 and aarch64) are supported.
 # Binaries correspond to tagged crate releases; "latest" is the most recent release.
 #
 # Environment overrides (flags --version/--dir/--target mirror them):
@@ -68,12 +68,17 @@ fi
 if [ -z "$TARGET" ]; then
   os="$(uname -s)"
   arch="$(uname -m)"
-  [ "$os" = "Linux" ] || err "unsupported OS: $os (prebuilt binaries are Linux-only for now; build from source with 'cargo install --path autumn-cli')"
+  case "$os" in
+    Linux) os_part="unknown-linux-musl" ;;
+    Darwin) os_part="apple-darwin" ;;
+    *) err "unsupported OS: $os (prebuilt binaries cover Linux and macOS; build from source with 'cargo install --path autumn-cli')" ;;
+  esac
   case "$arch" in
-    x86_64|amd64) TARGET="x86_64-unknown-linux-musl" ;;
-    aarch64|arm64) TARGET="aarch64-unknown-linux-musl" ;;
+    x86_64|amd64) arch_part="x86_64" ;;
+    aarch64|arm64) arch_part="aarch64" ;;
     *) err "unsupported architecture: $arch (build from source with 'cargo install --path autumn-cli')" ;;
   esac
+  TARGET="${arch_part}-${os_part}"
 fi
 
 asset="autumn-${TARGET}.tar.gz"


### PR DESCRIPTION
## What changed

**Before:** the only way to get the `autumn` CLI was `cargo install` — a from-source compile. Poor onboarding DX ("you have to cargo install just to start an autumn project") and unworkable as the distribution mechanism for downstream CI (issue #1931's generated-app runners have no `autumn` on PATH).

**After:** `autumn` ships as a prebuilt, curl-able binary for macOS and Linux, built from tagged crate releases. Onboarding leads with:

```sh
curl -fsSL https://raw.githubusercontent.com/madmax983/autumn/trunk-dev/scripts/install.sh | sh
```

— a checksum-verified binary in `~/.local/bin/autumn`, no Rust toolchain, no compile. `cargo install` remains the fallback.

Closes #2005.

## How

- **New reusable workflow `.github/workflows/cli-release.yml`** builds the `autumn` binary for four targets — **`x86_64-unknown-linux-musl`**, **`aarch64-unknown-linux-musl`** (via `cross` on `ubuntu-latest`, static musl) and **`x86_64-apple-darwin`**, **`aarch64-apple-darwin`** (native `cargo` on `macos-latest`) — packages each as a **version-less** tarball `autumn-<target>.tar.gz` + companion `.sha256` (sha256sum on Linux, shasum on macOS), uploads them as workflow artifacts, and attaches them to the GitHub Release with `gh release upload --clobber`.
  - **Wired into the release pipeline (deterministic, tagged-releases-only).** `cli-release.yml` is a `workflow_call` reusable workflow invoked by a small additive **`binaries` job in `release.yml`**, which runs right after the GitHub Release for a `v[0-9]+.*` tag is created — i.e. only once the Publish Gate has passed and the release exists. It builds from that tag and uploads to that release. An `on: release` trigger would **never fire**: `release.yml` creates the release with the default `GITHUB_TOKEN`, and GitHub suppresses new workflow runs from `GITHUB_TOKEN`-raised events — so invoking it as a reusable job is the correct deterministic fix (thanks @chatgpt-codex-connector for catching this). `releases/latest/download/…` therefore always means *the latest released version* — no rolling trunk builds. `ci.yml` is untouched.
  - **`workflow_dispatch` remains a manual escape hatch:** supply a `tag` to (re)build a specific released tag and attach to its release, or leave it blank to build the current ref for validation (artifacts only, no release upload).
  - **Static musl** (Linux) so a single binary runs across distros with no glibc-version dependency; **version-less asset names** make the stable `releases/latest/download/<asset>` URL work alongside version-pinned URLs.
- **New `scripts/install.sh`** (`curl | sh`, POSIX `sh`): detects OS + arch via `uname` (Darwin/Linux × x86_64/aarch64 → the right target triple), resolves the download URL for `latest` or a pinned `AUTUMN_VERSION`/`--version`, downloads the tarball + `.sha256`, **verifies the checksum** (POSIX `read` + parameter expansion; sha256sum/shasum, no `awk`), extracts, and installs to `AUTUMN_INSTALL_DIR` (default `~/.local/bin`), printing a PATH hint if needed. `--help` prints from a heredoc; missing flag values fail cleanly via `err()`. Overridable base URL/target make it testable + mirror-friendly.
- **README** `Install a prebuilt binary (macOS & Linux)` subsection now leads with the curl one-liner, documents the direct latest/pinned URLs + the four target triples, and keeps `cargo install` as the fallback.

**Checksum/signature story:** every asset ships a sha256 the installer verifies. Cryptographic signing (cosign/minisign) is intentionally deferred — sha256 covers integrity now; signing layers on later without changing the URL contract.

**Windows:** deferred to a follow-up (tracked on #2005) — the shell installer doesn't serve Windows, and adding an `x86_64-pc-windows-msvc` artifact + a manual-download/PowerShell path is separable from the macOS/Linux curl story. Windows users build from source for now.

## Verification (local — no release tag exists yet, so CI-side builds are unexercised)

- Both workflow files parse (`yaml.safe_load`); `release.yml` exposes `release.outputs.tag` and its `binaries` job `uses: ./.github/workflows/cli-release.yml` with `tag: ${{ needs.release.outputs.tag }}`.
- `sh -n scripts/install.sh` clean; `cargo build -p autumn-cli --release --bin autumn` → `autumn 0.6.0` (confirms crate/bin name).
- **Install-script E2E** against a locally-built artifact served over `file://`, OS/arch **auto-detected** (no `AUTUMN_TARGET`): `latest` path → `checksum ok`, installs, exit 0; pinned `--version` path → exit 0; corrupted tarball → `checksum mismatch`, **exit 1** (verify fails closed). Darwin triple assembly confirmed via a forced `AUTUMN_TARGET=aarch64-apple-darwin` dry run.
- macOS/musl compiles run only on CI runners (no tag yet); the Linux host can't produce them locally (`cross` supplies the musl toolchain; macOS builds use the `macos-latest` runners CI already exercises).

## Follow-up

#1931 (wire `autumn a11y verify` into generated-app CI via this install script) is the first consumer and lands as a separate PR after this merges. Windows binaries are a separate follow-up (see #2005).