### PR TITLE
fix(cli): resolve autumn doctor deploy secret/DB values under the [deploy] profile

### DIFF
--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -172,7 +172,14 @@ pub(crate) fn canonicalize_deploy_profile(raw: &str) -> String {
 /// `autumn_web::config::default_deploy_profile`); otherwise returns the trimmed
 /// string verbatim (no alias folding, no case change). Grading normalizes
 /// separately via [`canonicalize_deploy_profile`] at the grade site.
-fn trimmed_deploy_profile(raw: &str) -> String {
+// `pub(crate)` (not `pub`): reachable from `doctor` so its deploy secret/DB
+// value graders derive the RAW deploy-profile spelling exactly like
+// [`ResolvedDeployConfig::resolve`] stores it (trimmed, empty → `prod`), rather
+// than re-deriving (and drifting from) that rule. Kept crate-internal. In this
+// bin-only crate `deploy` is a private module, so clippy flags the `pub(crate)`
+// as redundant; we keep it to document the intended visibility.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn trimmed_deploy_profile(raw: &str) -> String {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return "prod".to_owned();
@@ -924,12 +931,43 @@ impl<E: Env> Env for ForcedProfileEnv<E> {
 /// strips `AUTUMN_ENV`/`AUTUMN_PROFILE`/`AUTUMN_IS_DEBUG` from any `.env` file,
 /// matching `AutumnConfig::load()`.
 fn load_runtime_config(resolved: &ResolvedDeployConfig) -> Result<AutumnConfig, DeployError> {
+    let forced = deploy_profile_env_overlay(&resolved.profile)?;
+    AutumnConfig::load_with_env(&forced).map_err(|e| DeployError::Config(e.to_string()))
+}
+
+/// Build the profile-aware env overlay that [`load_runtime_config`] resolves the
+/// deploy config under — the `.env.<profile>` overlay plus a forced
+/// `AUTUMN_ENV` — WITHOUT loading [`AutumnConfig`].
+///
+/// `profile_raw` is the operator's trimmed RAW `[deploy] profile` spelling (as
+/// stored on [`ResolvedDeployConfig::profile`] by [`trimmed_deploy_profile`]).
+/// The `.env.<profile>` overlay is selected by the CANONICAL profile
+/// ([`canonicalize_deploy_profile`]) so a `[deploy] profile` alias like
+/// `production`/`PROD` still reads `.env.prod` (matching `AutumnConfig::load()`),
+/// while the returned [`ForcedProfileEnv`] forces `AUTUMN_ENV` to the RAW
+/// spelling so the loader layers `[profile.<profile>]` / `autumn-<profile>.toml`
+/// under the operator's exact profile name, and reports `AUTUMN_DOTENV=1` so a
+/// non-dev deploy profile still loads `.env.<profile>`.
+///
+/// `doctor` reuses this so its deploy secret/DB value graders resolve under the
+/// `[deploy] profile` EXACTLY like `autumn deploy check` — same overlay
+/// selection and same forced profile — rather than replicating (and risking
+/// drift from) the layering.
+///
+/// # Errors
+/// Returns [`DeployError::Config`] when a project-root `.env` file exists but
+/// cannot be read or parsed.
+// `pub(crate)`: reachable from `doctor`, kept crate-internal. In this bin-only
+// crate `deploy` is a private module, so clippy flags the `pub(crate)` as
+// redundant; we keep it to document the intended visibility.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn deploy_profile_env_overlay(profile_raw: &str) -> Result<impl Env, DeployError> {
     use autumn_web::config::OsEnv;
     // Gating base: the real OS env, but reports `AUTUMN_DOTENV=1` so
     // `should_load` loads `.env.<profile>` for a non-dev deploy profile —
     // without mutating the global process environment.
     let gating = ForcedProfileEnv {
-        profile: resolved.profile.clone(),
+        profile: profile_raw.to_owned(),
         inner: OsEnv,
     };
     // Select the `.env.<profile>` overlay by the CANONICAL profile, so a
@@ -938,14 +976,13 @@ fn load_runtime_config(resolved: &ResolvedDeployConfig) -> Result<AutumnConfig, 
     // normalization — not `.env.production`/`.env.PROD`. Only the dotenv-overlay
     // SELECTION is canonicalized; `AUTUMN_ENV` and the TOML override-file
     // precedence (handled by `load_with_env`) still see the RAW spelling below.
-    let dotenv_profile = canonicalize_deploy_profile(&resolved.profile);
+    let dotenv_profile = canonicalize_deploy_profile(profile_raw);
     let inner = autumn_web::dotenv::os_env_with_dotenv_for_profile_using(&gating, &dotenv_profile)
         .map_err(|e| DeployError::Config(e.to_string()))?;
-    let forced = ForcedProfileEnv {
-        profile: resolved.profile.clone(),
+    Ok(ForcedProfileEnv {
+        profile: profile_raw.to_owned(),
         inner,
-    };
-    AutumnConfig::load_with_env(&forced).map_err(|e| DeployError::Config(e.to_string()))
+    })
 }
 
 /// Resolve the project's package name (for the `app_name` default), falling back

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -5913,6 +5913,47 @@ fn resolve_deploy_doctor_config(
     (deploy_cfg, None)
 }
 
+/// Strict-load guard mirroring what `autumn deploy check` does
+/// (`deploy.rs::load_runtime_config`): attempt to load the full runtime
+/// [`autumn_web::config::AutumnConfig`] under the DEPLOY profile via the SAME
+/// `AutumnConfig::load_with_env` call, using the profile-forced env overlay
+/// (`deploy::deploy_profile_env_overlay`) the caller already built.
+///
+/// `run()`'s deploy value graders build the merged TOML table with
+/// [`get_merged_toml_table_runtime`], whose profile-override read swallows a
+/// parse/IO error with `.ok()` — so a MALFORMED or unreadable
+/// `autumn-<profile>.toml` override is silently DROPPED and doctor grades only
+/// the base values, PASSING `--strict`. `autumn deploy check`, by contrast,
+/// loads `AutumnConfig::load_with_env` under the deploy profile and FAILS on the
+/// same override. This guard closes that gap: when the deploy-profile load
+/// errors it returns a FAILING `deploy_config` check reporting the load error;
+/// when it succeeds it returns `None` and the existing value grading proceeds.
+///
+/// Additive: on a well-formed, deployable config the load succeeds — that is
+/// exactly what lets `autumn deploy check` pass — so this never newly fails a
+/// valid override.
+fn deploy_profile_config_load_check(
+    deploy_profile_raw: &str,
+    env: &dyn autumn_web::config::Env,
+) -> Option<CheckResult> {
+    match autumn_web::config::AutumnConfig::load_with_env(env) {
+        Ok(_) => None,
+        Err(err) => Some(CheckResult {
+            name: "deploy_config",
+            status: CheckStatus::Fail,
+            detail: Some(format!(
+                "deploy profile config failed to load under `[deploy] profile = \
+                 {deploy_profile_raw}`: {err} — `autumn deploy check` would reject this"
+            )),
+            hint: Some(
+                "Fix the deploy-profile config (e.g. a malformed or unreadable \
+                 autumn-<profile>.toml override) so it loads under the deploy profile \
+                 (see `autumn deploy check`)",
+            ),
+        }),
+    }
+}
+
 // ─── Main entry point ─────────────────────────────────────────────────────────
 
 /// Run all doctor checks and report results.
@@ -6303,6 +6344,23 @@ pub fn run(opts: DoctorOptions) {
                 Ok(e) => Box::new(e),
                 Err(_) => Box::new(autumn_web::config::OsEnv),
             };
+        // STRICT-LOAD GUARD (Codex review): the value graders below build
+        // `merged_deploy_toml` via `get_merged_toml_table_runtime`, whose
+        // profile-override read swallows a parse/IO error with `.ok()` — so a
+        // MALFORMED or unreadable `autumn-<profile>.toml` override is silently
+        // DROPPED and doctor would grade only the base values and PASS `--strict`,
+        // while `autumn deploy check` (which loads `AutumnConfig::load_with_env`
+        // under the deploy profile) FAILS on the same file. Mirror `deploy check`'s
+        // exact load here — through the SAME profile-forced `deploy_denv` overlay
+        // `load_runtime_config` uses — and surface any error as a failing
+        // `deploy_config` check so the two agree. On a well-formed (deployable)
+        // config the load succeeds, so this never newly fails a valid override;
+        // the existing value grading below proceeds unchanged.
+        if let Some(check) =
+            deploy_profile_config_load_check(&deploy_profile_raw, deploy_denv.as_ref())
+        {
+            tasks.push(Box::new(move || check));
+        }
         // Resolve the deploy signing secret from the SAME merged active-profile
         // table used for `deploy_cfg` and the DB URL (env first, then
         // `merged_deploy_toml`'s `security.signing_secret.secret`) — NOT the raw
@@ -15293,6 +15351,73 @@ redirect_uri = "http://localhost/callback"
             resolve_deploy_signing_secret(&deploy_merged, &MockEnv::new()),
             None,
             "a dev-only secret is not keyed by the deploy grade under the prod profile"
+        );
+    }
+
+    /// Codex review (P2): doctor's deploy value graders build the merged TOML via
+    /// `get_merged_toml_table_runtime`, whose profile-override read uses `.ok()`,
+    /// so a MALFORMED `autumn-<profile>.toml` is silently dropped — doctor would
+    /// then grade only the base values and PASS `--strict`, while `autumn deploy
+    /// check` (which loads `AutumnConfig::load_with_env` under the deploy profile)
+    /// FAILS on the same file. `deploy_profile_config_load_check` closes that gap:
+    /// a malformed deploy-profile override FAILS the `deploy_config` check; a
+    /// well-formed one does NOT newly fail. Uses an `AUTUMN_MANIFEST_DIR`-scoped
+    /// `MockEnv` (the same mechanism the runtime's own config tests use) so
+    /// `load_with_env` reads the temp-dir files with no process-env mutation.
+    #[test]
+    fn malformed_deploy_profile_override_fails_deploy_config_load_check() {
+        use autumn_web::config::MockEnv;
+        let dir = tempfile::tempdir().unwrap();
+        // `[deploy] profile = "prod"`, ambient = dev. The prod override file is
+        // present but MALFORMED (invalid TOML) — exactly the case
+        // `get_merged_toml_table_runtime`'s `.ok()` merge silently drops.
+        std::fs::write(
+            dir.path().join("autumn.toml"),
+            "[deploy]\nhost = \"deploy.example.com\"\nprofile = \"prod\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("autumn-prod.toml"),
+            "this line has no equals sign and is not valid toml\n",
+        )
+        .unwrap();
+
+        // Resolve config files from the temp dir under the prod (deploy) profile
+        // without mutating the process env — the same mechanism the runtime's
+        // config tests use (`AUTUMN_MANIFEST_DIR` selects the dir, `AUTUMN_ENV`
+        // selects the profile that pulls in `autumn-prod.toml`).
+        let env = MockEnv::new()
+            .with("AUTUMN_MANIFEST_DIR", dir.path().to_str().unwrap())
+            .with("AUTUMN_ENV", "prod");
+
+        let check = deploy_profile_config_load_check("prod", &env)
+            .expect("a malformed autumn-prod.toml must fail the deploy_config load check");
+        assert_eq!(check.name, "deploy_config");
+        assert!(
+            matches!(check.status, CheckStatus::Fail),
+            "the malformed override must FAIL, not pass"
+        );
+        let detail = check.detail.unwrap_or_default();
+        assert!(
+            detail.contains("prod"),
+            "the failure names the deploy profile: {detail}"
+        );
+        assert!(
+            detail.contains("failed to load"),
+            "the failure surfaces the load error: {detail}"
+        );
+
+        // Companion: a WELL-FORMED prod override under the same layout does NOT
+        // trigger this new failure — the normal case still passes (mirroring how
+        // `autumn deploy check` loads it without error).
+        std::fs::write(
+            dir.path().join("autumn-prod.toml"),
+            "[server]\nport = 8443\n",
+        )
+        .unwrap();
+        assert!(
+            deploy_profile_config_load_check("prod", &env).is_none(),
+            "a well-formed autumn-prod.toml must not newly fail the deploy_config check"
         );
     }
 

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -6263,6 +6263,46 @@ pub fn run(opts: DoctorOptions) {
         tasks.push(Box::new(move || check));
     }
     if let Some(deploy_cfg) = deploy_cfg {
+        // PHASE 2 (issue found via #1966 review): re-derive the value-resolution
+        // inputs — the merged TOML table and the `.env` overlay — under the
+        // `[deploy] profile`, NOT the AMBIENT CLI runtime profile.
+        //
+        // Phase 1 above resolved `deploy_cfg` (and its `.profile`) from the
+        // `[deploy]` table under the ambient profile — reading the `[deploy]`
+        // table itself under the ambient profile is fine (it decides the target
+        // profile). But the deploy SECRET / DB VALUES (signing secret, database
+        // URL, shard URLs, db-backed-runtime DB requirement) must be resolved
+        // under the DEPLOY profile the uploaded unit boots under: a value
+        // supplied only under the deploy profile (`[profile.prod]` / `.env.prod`)
+        // is invisible to the ambient (default `dev`) resolution, so grading it
+        // there would falsely report it MISSING/insecure even though `autumn
+        // deploy check` (fixed for the deploy command in #1966) resolves it
+        // correctly. Strictness grading below already keys on the deploy profile.
+        //
+        // This mirrors `deploy.rs` `load_runtime_config`'s own two-phase reload
+        // (the same chicken-and-egg: learn the profile, then resolve under it).
+        // Reuse `deploy::deploy_profile_env_overlay` — the EXACT overlay
+        // `load_runtime_config` uses (`.env.<canonical>` selection + forced RAW
+        // `AUTUMN_ENV`) — rather than replicating the layering, so doctor and
+        // `deploy check` cannot drift. `trimmed_deploy_profile` yields the raw
+        // spelling exactly as `ResolvedDeployConfig::resolve` stores it.
+        let deploy_profile_raw = crate::deploy::trimmed_deploy_profile(&deploy_cfg.profile);
+        let deploy_profile_canonical =
+            crate::deploy::canonicalize_deploy_profile(&deploy_profile_raw);
+        // Rebuild the merged TOML under the deploy profile (canonical + raw
+        // selected), matching how `resolve_active_profiles`' (canonical, selected)
+        // tuple feeds `get_merged_toml_table_runtime` above.
+        let merged_deploy_toml =
+            get_merged_toml_table_runtime(&deploy_profile_canonical, &deploy_profile_raw);
+        // Rebuild the `.env` overlay under the deploy profile via the SAME path as
+        // `load_runtime_config`, so `.env.<deploy>` loads and `AUTUMN_ENV` reads
+        // as the deploy profile. Fall back to bare OS env on a malformed `.env`,
+        // matching the phase-1 fallback above.
+        let deploy_denv: Box<dyn autumn_web::config::Env> =
+            match crate::deploy::deploy_profile_env_overlay(&deploy_profile_raw) {
+                Ok(e) => Box::new(e),
+                Err(_) => Box::new(autumn_web::config::OsEnv),
+            };
         // Resolve the deploy signing secret from the SAME merged active-profile
         // table used for `deploy_cfg` and the DB URL (env first, then
         // `merged_deploy_toml`'s `security.signing_secret.secret`) — NOT the raw
@@ -15106,6 +15146,153 @@ redirect_uri = "http://localhost/callback"
         assert!(
             check.detail.unwrap().contains("present but invalid"),
             "detail must explain the [deploy] table is present but invalid"
+        );
+    }
+
+    /// Issue found via #1966 review: doctor must resolve the deploy SIGNING
+    /// SECRET under the `[deploy] profile`, NOT the ambient CLI runtime profile
+    /// (default `dev`). A secret supplied only under `[profile.prod]` is invisible
+    /// to the ambient (dev) resolution, so grading it there falsely reports it
+    /// MISSING even though `autumn deploy check` (fixed in #1966) resolves it.
+    /// This mirrors `run()`'s two-phase deploy resolution the way the F21 DB tests
+    /// mirror `run()`'s DB resolution — via the injectable
+    /// `get_merged_toml_table_runtime_with`, no process-env mutation.
+    #[test]
+    fn deploy_signing_secret_in_deploy_profile_is_resolved_under_that_profile() {
+        use autumn_web::config::MockEnv;
+        let dir = tempfile::tempdir().unwrap();
+        // Base declares `[deploy] profile = "prod"`; the signing secret lives ONLY
+        // under `[profile.prod]` — exactly the value the ambient (dev) lookup misses.
+        std::fs::write(
+            dir.path().join("autumn.toml"),
+            "[deploy]\nhost = \"deploy.example.com\"\nprofile = \"prod\"\n\
+             [profile.prod.security.signing_secret]\n\
+             secret = \"prod-only-32-char-strong-secret-value-xyz\"\n",
+        )
+        .unwrap();
+        let base = dir.path().to_path_buf();
+
+        // PHASE 1 (unchanged): learn the deploy target profile from the `[deploy]`
+        // table resolved under the AMBIENT (dev) merged table, as `run()` does.
+        let base_dev = base.clone();
+        let ambient_merged =
+            get_merged_toml_table_runtime_with("dev", "dev", move |f| base_dev.join(f));
+        let (deploy_cfg, config_check) =
+            resolve_deploy_doctor_config(&ambient_merged, &MockEnv::new());
+        assert!(
+            config_check.is_none(),
+            "the [deploy] table parses under the ambient profile"
+        );
+        let deploy_cfg = deploy_cfg.expect("[deploy] present");
+        assert_eq!(
+            crate::deploy::trimmed_deploy_profile(&deploy_cfg.profile),
+            "prod",
+            "deploy target profile is learned from the ambient [deploy] table"
+        );
+
+        // Regression guard (the BUG): resolving the secret under the ambient (dev)
+        // merged table does NOT see the prod-only secret — this is what falsely
+        // reported it missing before the fix.
+        assert_eq!(
+            resolve_deploy_signing_secret(&ambient_merged, &MockEnv::new()),
+            None,
+            "prod-only secret is invisible under the ambient dev profile (the bug)"
+        );
+
+        // PHASE 2 (the FIX): re-derive the merged table under the `[deploy] profile`
+        // and resolve the secret there — the exact re-derivation `run()` now does.
+        let deploy_profile_raw = crate::deploy::trimmed_deploy_profile(&deploy_cfg.profile);
+        let deploy_profile_canonical =
+            crate::deploy::canonicalize_deploy_profile(&deploy_profile_raw);
+        let deploy_merged = get_merged_toml_table_runtime_with(
+            &deploy_profile_canonical,
+            &deploy_profile_raw,
+            move |f| base.join(f),
+        );
+        assert_eq!(
+            resolve_deploy_signing_secret(&deploy_merged, &MockEnv::new()).as_deref(),
+            Some("prod-only-32-char-strong-secret-value-xyz"),
+            "the fix: doctor resolves the deploy signing secret under the [deploy] profile"
+        );
+    }
+
+    /// Companion to the signing-secret case for the deploy DATABASE URL: a
+    /// `primary_url` supplied only under `[profile.prod.database]` must be resolved
+    /// under the `[deploy] profile`, not the ambient (dev) profile — otherwise
+    /// `deploy_database_url` falsely fails under `--strict` even though `autumn
+    /// deploy check` (fixed in #1966) resolves it.
+    #[test]
+    fn deploy_database_url_in_deploy_profile_is_resolved_under_that_profile() {
+        use autumn_web::config::MockEnv;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("autumn.toml"),
+            "[deploy]\nhost = \"deploy.example.com\"\nprofile = \"prod\"\n\
+             [profile.prod.database]\n\
+             primary_url = \"postgres://prod-host/appdb\"\n",
+        )
+        .unwrap();
+        let base = dir.path().to_path_buf();
+
+        // PHASE 1: learn the deploy profile from the ambient `[deploy]` table.
+        let base_dev = base.clone();
+        let ambient_merged =
+            get_merged_toml_table_runtime_with("dev", "dev", move |f| base_dev.join(f));
+        let (deploy_cfg, _) = resolve_deploy_doctor_config(&ambient_merged, &MockEnv::new());
+        let deploy_cfg = deploy_cfg.expect("[deploy] present");
+
+        // Bug parity: the prod-only DB URL is invisible under the ambient dev merge.
+        let ambient_topology =
+            resolve_database_topology_from_sources(|_| None, Some(&ambient_merged));
+        assert_eq!(
+            ambient_topology.primary_url, None,
+            "prod-only DB URL is invisible under the ambient dev profile (the bug)"
+        );
+
+        // PHASE 2 (the FIX): resolve the DB topology under the `[deploy] profile`.
+        let deploy_profile_raw = crate::deploy::trimmed_deploy_profile(&deploy_cfg.profile);
+        let deploy_profile_canonical =
+            crate::deploy::canonicalize_deploy_profile(&deploy_profile_raw);
+        let deploy_merged = get_merged_toml_table_runtime_with(
+            &deploy_profile_canonical,
+            &deploy_profile_raw,
+            move |f| base.join(f),
+        );
+        let deploy_topology =
+            resolve_database_topology_from_sources(|_| None, Some(&deploy_merged));
+        assert_eq!(
+            deploy_topology.primary_url.as_deref(),
+            Some("postgres://prod-host/appdb"),
+            "the fix: doctor resolves the deploy DB URL under the [deploy] profile"
+        );
+    }
+
+    /// Negative/parity: a signing secret present ONLY under the AMBIENT (dev)
+    /// profile — while `[deploy] profile = "prod"` — must NOT be what the deploy
+    /// grade keys on. The deploy grade reflects the `[deploy] profile`'s config, so
+    /// resolving under prod does not see the dev-only value. This proves the fix
+    /// keys strictly on the deploy profile, not a leaky ambient value.
+    #[test]
+    fn deploy_signing_secret_only_under_ambient_profile_is_not_keyed_by_deploy_grade() {
+        use autumn_web::config::MockEnv;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("autumn.toml"),
+            "[deploy]\nhost = \"deploy.example.com\"\nprofile = \"prod\"\n\
+             [profile.dev.security.signing_secret]\n\
+             secret = \"dev-only-secret-not-for-prod-grade-xyz\"\n",
+        )
+        .unwrap();
+        let base = dir.path().to_path_buf();
+
+        // The deploy grade resolves under the `[deploy] profile` (prod), so the
+        // dev-only secret is NOT seen — the deploy grade reflects prod config only.
+        let deploy_merged =
+            get_merged_toml_table_runtime_with("prod", "prod", move |f| base.join(f));
+        assert_eq!(
+            resolve_deploy_signing_secret(&deploy_merged, &MockEnv::new()),
+            None,
+            "a dev-only secret is not keyed by the deploy grade under the prod profile"
         );
     }
 


### PR DESCRIPTION
**Before:** `autumn doctor`'s deploy section resolved the deploy signing-secret and database-URL *values* under the **ambient** profile (`AUTUMN_ENV` / `AUTUMN_PROFILE`, default `dev`), even though it grades strictness against the `[deploy] profile`. So a secret or `DATABASE_URL` supplied only under the deploy profile's layer (`[profile.<deploy>]`, `autumn-<deploy>.toml`, or `.env.<deploy>`) was falsely reported missing whenever the deploy profile differed from the ambient one — the same class of gap #1966 fixed for the deploy *command*, deliberately left out of scope for doctor there.

**After:** doctor re-derives the value-resolution inputs (the merged TOML table + the `.env` overlay) under the `[deploy] profile` before the secret/DB graders — a two-phase resolution mirroring the deploy command's `load_runtime_config`. Phase 1 reads the `[deploy]` table (ambient) only to learn the profile; phase 2 rebuilds the merged TOML (canonical profile for the merge, raw spelling as the selected profile) and the `.env` overlay (`.env.<profile>` loaded, `AUTUMN_ENV` forced to the raw deploy profile) and feeds them to the unchanged graders. Strictness grading is unchanged.

**How:** extracted the deploy command's env-overlay construction into a shared `pub(crate) deploy_profile_env_overlay(profile)` so `autumn doctor` and `autumn deploy check` use one code path and can't drift; doctor's phase 2 shadows `merged_deploy_toml` / `deploy_denv` under the deploy profile. Three new doctor tests prove a prod-only signing secret and a prod-only `DATABASE_URL` resolve under `[deploy] profile = "prod"` while the ambient profile is `dev`, plus a guard that an ambient-only value isn't leaked into the deploy grade.

Found via #1966 review. Part of #1607.

---
_Generated by [Claude Code](https://claude.ai/code/session_014XPpqH7hPPF3B29HZxGbAd)_