### PR TITLE
autumn-media: generic media workflows + artifact sink (slice 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,7 @@ dependencies = [
  "tokio",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/autumn-media-plugin/Cargo.toml
+++ b/autumn-media-plugin/Cargo.toml
@@ -21,6 +21,9 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
+# Fresh workflow ids for staged (S3) encode outputs. Matches the pin autumn
+# itself uses (`uuid = { version = "1", features = ["v4"] }`).
+uuid = { version = "1", features = ["v4"] }
 
 # ── HTTP client (MediaMTX control API + recorded-VOD availability probe) ──────
 # Production MediaMTX origins can be https (Fly), so TLS is required. This pin
@@ -89,6 +92,8 @@ aws-sdk-s3 = { version = ">=1.122, <1.123", default-features = false, features =
 # dir; `std::fs::File::set_modified` (stable, MSRV 1.88) sets mtimes, so no
 # `filetime` dep is needed.
 tempfile = "3"
+# Job-arg / artifact (de)serialization round-trip tests.
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/autumn-media-plugin/src/error.rs
+++ b/autumn-media-plugin/src/error.rs
@@ -113,6 +113,28 @@ pub enum MediaError {
         #[source]
         source: std::io::Error,
     },
+
+    /// A derived media artifact (e.g. a seek-preview `WebVTT` track) could not
+    /// be written to its staging path before persistence.
+    #[error("failed to write media artifact `{path}`: {source}")]
+    ArtifactWrite {
+        /// The artifact (or parent directory) path involved.
+        path: String,
+        /// The underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The blocking encode task panicked or was cancelled before completing.
+    ///
+    /// The encode primitives run synchronously on a blocking thread
+    /// ([`tokio::task::spawn_blocking`]); a panic there surfaces here rather
+    /// than unwinding the async worker.
+    #[error("media encode task did not complete: {message}")]
+    EncodeTaskJoin {
+        /// The stringified join error.
+        message: String,
+    },
 }
 
 /// Maximum number of stderr bytes carried in [`MediaError::FfmpegNonZeroExit`].

--- a/autumn-media-plugin/src/lib.rs
+++ b/autumn-media-plugin/src/lib.rs
@@ -40,8 +40,11 @@
 pub mod config;
 pub mod encode;
 pub mod error;
+pub mod retention;
+pub mod sink;
 pub mod storage;
 pub mod transport;
+pub mod workflows;
 
 pub use config::{
     MediaConfig, MediaConfigError, MediaMtxConfig, MediaStorageBackend, MediaStorageConfig,
@@ -55,6 +58,14 @@ pub use encode::{
     recording_segments_covering_window, slugify,
 };
 pub use error::MediaError;
+pub use retention::{
+    RetentionDefer, RetentionReport, is_expired, recording_expires_at, spawn_retention_sweep_loop,
+    sweep_recordings_root, within_root,
+};
+pub use sink::{
+    MediaArtifact, MediaArtifactFile, MediaArtifactKind, MediaArtifactSink, MediaArtifactSinkExt,
+    MediaSinkFuture,
+};
 pub use storage::{MediaStorage, S3MediaStorage, StoredObject};
 pub use transport::{
     IngestStatus, MediaMtxClient, MediaUrls, StreamQualityStats, StreamStatus, ViewerCount,
@@ -62,16 +73,24 @@ pub use transport::{
     recording_available, recording_mediamtx_path, stream_status_from_path_json,
     viewer_count_from_path_json, viewer_counts_from_paths_json,
 };
+pub use workflows::{
+    FinalizeRecordingJobArgs, MediaWorkflowDelegate, MediaWorkflowDelegateExt,
+    MediaWorkflowRequest, MediaWorkflows, PreviewJobArgs, ThumbnailJobArgs, TranscodeJobArgs,
+    media_job_infos,
+};
 
 /// Common downstream imports for configuring and mounting the media plugin.
 pub mod prelude {
     pub use crate::{
         FfmpegClipTailCommand, FfmpegHighlightCommand, FfmpegLiveThumbnailCommand,
-        FfmpegPosterCommand, FfmpegPreviewSpriteCommand, MediaConfig, MediaConfigError, MediaError,
-        MediaMtxConfig, MediaPlugin, MediaStorage, MediaStorageBackend, MediaStorageConfig,
-        PREVIEW_CELL_HEIGHT, PREVIEW_CELL_WIDTH, PREVIEW_FRAME_INTERVAL_SECONDS,
-        PREVIEW_SPRITE_COLUMNS, RecordingConfig, S3MediaStorage, StoredObject,
-        build_preview_webvtt, newest_recording_file, newest_recording_files,
+        FfmpegPosterCommand, FfmpegPreviewSpriteCommand, FinalizeRecordingJobArgs, MediaArtifact,
+        MediaArtifactFile, MediaArtifactKind, MediaArtifactSink, MediaArtifactSinkExt, MediaConfig,
+        MediaConfigError, MediaError, MediaMtxConfig, MediaPlugin, MediaStorage,
+        MediaStorageBackend, MediaStorageConfig, MediaWorkflowDelegate, MediaWorkflowDelegateExt,
+        MediaWorkflowRequest, MediaWorkflows, PREVIEW_CELL_HEIGHT, PREVIEW_CELL_WIDTH,
+        PREVIEW_FRAME_INTERVAL_SECONDS, PREVIEW_SPRITE_COLUMNS, PreviewJobArgs, RecordingConfig,
+        RetentionDefer, S3MediaStorage, StoredObject, ThumbnailJobArgs, TranscodeJobArgs,
+        build_preview_webvtt, media_job_infos, newest_recording_file, newest_recording_files,
         newest_recording_files_since, recording_segments_covering_window, slugify,
     };
     pub use crate::{
@@ -83,11 +102,16 @@ pub mod prelude {
 }
 
 use std::borrow::Cow;
+use std::path::PathBuf;
+use std::sync::Arc;
 
 use autumn_web::app::AppBuilder;
 use autumn_web::plugin::Plugin;
 
 use crate::config::DEFAULT_ROOM_MAX_PARTICIPANTS;
+use crate::retention::RetentionDefer as RetentionDeferHook;
+use crate::sink::MediaArtifactSink as MediaArtifactSinkTrait;
+use crate::workflows::MediaWorkflowDelegate as MediaWorkflowDelegateHook;
 
 /// The live-streaming media plugin.
 ///
@@ -107,12 +131,23 @@ pub struct MediaPlugin {
     enable_rooms: bool,
     /// Hard cap on mesh-room participants.
     room_max_participants: usize,
-    /// Harvest/job queue name used by media encode work (later slices).
+    /// Job queue name the built-in media encode jobs are registered on.
     queue: String,
     /// URL prefix for the plugin's API routes (later slices).
     api_prefix: String,
-    // slice N: no encode-sink / retention-defer wiring yet — those depend on
-    // types introduced in later slices and are intentionally omitted here.
+    /// App-supplied artifact completion callback (parallels the
+    /// `OutboundWebhookHandler` store).
+    artifact_sink: Option<Arc<dyn MediaArtifactSinkTrait>>,
+    /// Optional runtime delegate that overrides the built-in `#[job]` engine
+    /// (e.g. an external Harvest adapter).
+    workflow_delegate: Option<MediaWorkflowDelegateHook>,
+    /// Retention window override (days). `None` uses `config.recording.retention_days`.
+    retention_days: Option<u32>,
+    /// Filesystem root the retention sweep operates on. `None` disables the
+    /// sweep (there is nothing to sweep without a recordings root).
+    recordings_root: Option<PathBuf>,
+    /// App-overridable retention-defer predicate.
+    retention_defer: Option<RetentionDeferHook>,
 }
 
 impl MediaPlugin {
@@ -128,6 +163,11 @@ impl MediaPlugin {
             room_max_participants: DEFAULT_ROOM_MAX_PARTICIPANTS,
             queue: "media".to_owned(),
             api_prefix: "/api/media".to_owned(),
+            artifact_sink: None,
+            workflow_delegate: None,
+            retention_days: None,
+            recordings_root: None,
+            retention_defer: None,
         }
     }
 
@@ -187,6 +227,52 @@ impl MediaPlugin {
         self.config.ffmpeg.bin = bin.into();
         self
     }
+
+    /// Install the app-supplied [`MediaArtifactSink`](sink::MediaArtifactSink)
+    /// the built-in workflow jobs invoke on completion.
+    ///
+    /// Without a sink, a completed workflow persists its output but logs that
+    /// no sink recorded it (parallels leaving `OutboundWebhookHandler` unset).
+    #[must_use]
+    pub fn artifact_sink(mut self, sink: Arc<dyn MediaArtifactSinkTrait>) -> Self {
+        self.artifact_sink = Some(sink);
+        self
+    }
+
+    /// Install a runtime workflow delegate that overrides the built-in `#[job]`
+    /// engine (e.g. an external Harvest adapter maintained outside this
+    /// workspace). When set, every [`MediaWorkflows`] `queue_*` call routes
+    /// through the delegate instead of enqueuing the built-in job.
+    #[must_use]
+    pub fn workflow_delegate(mut self, delegate: MediaWorkflowDelegateHook) -> Self {
+        self.workflow_delegate = Some(delegate);
+        self
+    }
+
+    /// Override the recording-retention window, in days (`0` disables the
+    /// sweep). Defaults to `config.recording.retention_days`.
+    #[must_use]
+    pub const fn retention_days(mut self, days: u32) -> Self {
+        self.retention_days = Some(days);
+        self
+    }
+
+    /// Set the filesystem root the retention sweep deletes expired recordings
+    /// from. Required to spawn the sweep — without it, no retention loop runs.
+    #[must_use]
+    pub fn recordings_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.recordings_root = Some(root.into());
+        self
+    }
+
+    /// Install the app-overridable retention-defer predicate: return `true` for
+    /// a path to hold it back this sweep (e.g. a still-encoding workflow
+    /// references it).
+    #[must_use]
+    pub fn retention_defer(mut self, defer: RetentionDeferHook) -> Self {
+        self.retention_defer = Some(defer);
+        self
+    }
 }
 
 impl Default for MediaPlugin {
@@ -208,7 +294,14 @@ impl Plugin for MediaPlugin {
             room_max_participants,
             queue,
             api_prefix,
+            artifact_sink,
+            workflow_delegate,
+            retention_days,
+            recordings_root,
+            retention_defer,
         } = self;
+
+        let retention_days = retention_days.unwrap_or(config.recording.retention_days);
 
         tracing::info!(
             broadcast = %enable_broadcast,
@@ -217,22 +310,79 @@ impl Plugin for MediaPlugin {
             storage_backend = config.storage.backend.as_str(),
             queue = %queue,
             api_prefix = %api_prefix,
+            has_artifact_sink = artifact_sink.is_some(),
+            has_workflow_delegate = workflow_delegate.is_some(),
+            retention_days,
             "🍂 Autumn Media configured"
         );
 
-        // slice 1 (storage): insert the resolved MediaProfile / MediaStorage
-        //   extensions and register the recording-retention sweep.
-        // slice 2 (encode): register the FFmpeg encode jobs on `queue`.
-        // slice 3 (transport): the `transport` module (MediaMtxClient + MediaUrls
-        //   + status parsers) now exists and is re-exported, but its AppState
-        //   extension wiring lands with the consumer slice (the broadcast/room
-        //   router) — no consumers yet, so nothing is inserted here.
-        // slice 3+ (rooms): insert the MediaMtxClient / MediaUrls extensions and
+        // Resolve the storage backend up front so a misconfiguration surfaces
+        // as one error line here rather than inside a job. On failure we still
+        // register the (empty) route surface, but install no encode wiring.
+        let storage = match storage::MediaStorage::from_config(&config.storage) {
+            Ok(storage) => storage,
+            Err(error) => {
+                tracing::error!(
+                    %error,
+                    "🍂 Autumn Media: storage config invalid; encode workflows disabled"
+                );
+                return app.declare_plugin_routes(media_route_infos(&api_prefix));
+            }
+        };
+
+        let ffmpeg_bin = config.ffmpeg.bin;
+        let workflows = workflows::MediaWorkflows::new(ffmpeg_bin, queue.clone());
+
+        // slice 3 (transport/rooms): the `transport` module (MediaMtxClient +
+        //   MediaUrls + status parsers) now exists and is re-exported; its
+        //   AppState extension wiring lands with the consumer slice — insert the
+        //   MediaMtxClient / MediaUrls extensions and
         //   nest the broadcast + room routers under `api_prefix`.
         //
-        // Slice 0 declares no routes and installs no extensions; the empty
-        // declaration keeps `autumn routes audit` clean and explicit.
-        app.declare_plugin_routes(media_route_infos(&api_prefix))
+        // Extensions are installed via `state_initializer` (not `on_startup`)
+        // so they exist BEFORE job workers start — mirroring autumn-web's
+        // outbound-webhook plugin, whose manager must be present before the
+        // first job runs.
+        let app = app
+            .declare_plugin_routes(media_route_infos(&api_prefix))
+            .state_initializer(move |state| {
+                state.insert_extension(storage.clone());
+                state.insert_extension(workflows.clone());
+                if let Some(sink) = &artifact_sink {
+                    state.insert_extension(sink::MediaArtifactSinkExt(sink.clone()));
+                }
+                if let Some(delegate) = &workflow_delegate {
+                    state.insert_extension(workflows::MediaWorkflowDelegateExt(delegate.clone()));
+                }
+            })
+            // Register the built-in encode jobs with the queue overridden to
+            // `queue` (the JobInfo's `queue` field, not the `#[job]` literal, is
+            // what the enqueue chokepoint routes on). autumn-web's worker
+            // auto-registers any declared-but-unconfigured queue at lowest
+            // priority, so the media queue drains without extra config.
+            .jobs(workflows::media_job_infos(&queue));
+
+        // Recording-retention sweep: spawn only when a recordings root is
+        // configured and retention is enabled. Spawned from `on_startup` so it
+        // shares the running app's runtime, matching how the thumbnail/retention
+        // loops are spawned in an Autumn app.
+        if let Some(root) = recordings_root {
+            app.on_startup(move |_state| {
+                let root = root.clone();
+                let defer = retention_defer.clone();
+                async move {
+                    retention::spawn_retention_sweep_loop(root, retention_days, defer);
+                    Ok(())
+                }
+            })
+        } else {
+            if retention_days > 0 {
+                tracing::debug!(
+                    "🍂 Autumn Media: retention window set but no recordings_root; sweep not spawned"
+                );
+            }
+            app
+        }
     }
 }
 

--- a/autumn-media-plugin/src/retention.rs
+++ b/autumn-media-plugin/src/retention.rs
@@ -1,0 +1,303 @@
+//! Generic, harvest-free recording-retention sweep.
+//!
+//! The generalization of Arroyo's recording-retention service
+//! (`src/services/recordings.rs`): an hourly loop
+//! that deletes recording files older than a configured retention window and
+//! leaves everything else alone. Arroyo keyed expiry on a broadcast row's
+//! `ended_at` and, after deleting, cleared `recording_path`; the generic form
+//! here has no application schema, so it keys expiry on each file's **mtime**
+//! and only owns the filesystem side — deleting individual expired files inside
+//! a configured recordings root.
+//!
+//! The one application-specific decision Arroyo made — *defer* a file that is
+//! still referenced by an in-progress encode workflow — is exposed as an
+//! app-overridable [`RetentionDefer`] predicate: when it returns `true` for a
+//! path, the sweep skips that file this tick and retries on the next.
+//!
+//! Safety mirrors Arroyo's sweep: only regular **files** are removed
+//! (directories are left to the ingest layer / `MediaMTX`'s own
+//! `recordDeleteAfter`), a missing file is treated as success (idempotent), and
+//! every candidate is checked to be [`within_root`] before deletion.
+
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+/// Seconds between retention sweeps (hourly, matching Arroyo).
+const SWEEP_INTERVAL_SECONDS: u64 = 3600;
+
+/// Seconds in a day.
+const SECONDS_PER_DAY: u64 = 86_400;
+
+/// An app-overridable predicate: given a candidate recording path, return
+/// `true` to **defer** its deletion (e.g. a still-encoding workflow references
+/// it). Deferred files are retried on the next sweep.
+pub type RetentionDefer =
+    Arc<dyn Fn(PathBuf) -> Pin<Box<dyn Future<Output = bool> + Send>> + Send + Sync>;
+
+/// The outcome tallies of one sweep.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RetentionReport {
+    /// Expired files deleted this sweep.
+    pub deleted: usize,
+    /// Expired files skipped because the defer predicate held them.
+    pub deferred: usize,
+    /// Files kept because they are not yet expired (or their mtime is
+    /// unreadable).
+    pub kept: usize,
+    /// Files that could not be inspected or deleted.
+    pub errors: usize,
+}
+
+/// The retention window as a [`Duration`].
+fn retention_window(retention_days: u32) -> Duration {
+    Duration::from_secs(u64::from(retention_days) * SECONDS_PER_DAY)
+}
+
+/// Compute when a recording expires given its `modified` time and the window.
+#[must_use]
+pub fn recording_expires_at(modified: SystemTime, retention_days: u32) -> SystemTime {
+    modified
+        .checked_add(retention_window(retention_days))
+        .unwrap_or(modified)
+}
+
+/// Whether a recording modified at `modified` is expired as of `now`.
+#[must_use]
+pub fn is_expired(modified: SystemTime, now: SystemTime, retention_days: u32) -> bool {
+    recording_expires_at(modified, retention_days) <= now
+}
+
+/// Whether `path` resolves inside `root`.
+///
+/// Prevents a symlink or a caller-supplied path from escaping the recordings
+/// root. Resolution order: lexical prefix (fast path), then canonicalize both,
+/// then canonicalize the parent and reconstruct (covers an already-deleted
+/// file whose parent still exists).
+#[must_use]
+pub fn within_root(root: &Path, path: &Path) -> bool {
+    if path.starts_with(root) {
+        return true;
+    }
+    let Ok(canonical_root) = std::fs::canonicalize(root) else {
+        return false;
+    };
+    if let Ok(canonical_path) = std::fs::canonicalize(path) {
+        return canonical_path.starts_with(&canonical_root);
+    }
+    if let Some(parent) = path.parent()
+        && let Ok(canonical_parent) = std::fs::canonicalize(parent)
+    {
+        let reconstructed = canonical_parent.join(path.file_name().unwrap_or_default());
+        return reconstructed.starts_with(&canonical_root);
+    }
+    false
+}
+
+/// Delete a single recording **file**.
+///
+/// Directories are left alone (the ingest layer owns segment-directory
+/// cleanup), and a missing file is treated as success so the sweep is
+/// idempotent against concurrent cleanup.
+fn delete_recording_file(path: &Path) -> std::io::Result<()> {
+    if path.is_dir() {
+        return Ok(());
+    }
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+/// Recursively collect regular files under `root`.
+fn collect_files(root: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        match entry.file_type() {
+            Ok(file_type) if file_type.is_dir() => collect_files(&path, out),
+            Ok(file_type) if file_type.is_file() => out.push(path),
+            _ => {}
+        }
+    }
+}
+
+/// Sweep `root` once, deleting recording files older than the retention window.
+///
+/// `now` is taken as a parameter (never the wall clock) so the decision is
+/// deterministic for tests. A `retention_days` of `0` disables the sweep and
+/// returns an empty report. `defer`, when provided, can hold back an
+/// otherwise-expired file for the next tick.
+pub async fn sweep_recordings_root(
+    root: &Path,
+    retention_days: u32,
+    now: SystemTime,
+    defer: Option<&RetentionDefer>,
+) -> RetentionReport {
+    let mut report = RetentionReport::default();
+    if retention_days == 0 {
+        return report;
+    }
+
+    let mut files = Vec::new();
+    collect_files(root, &mut files);
+
+    for path in files {
+        let Ok(metadata) = std::fs::metadata(&path) else {
+            report.errors += 1;
+            continue;
+        };
+        let Ok(modified) = metadata.modified() else {
+            report.kept += 1;
+            continue;
+        };
+        if !is_expired(modified, now, retention_days) {
+            report.kept += 1;
+            continue;
+        }
+        if let Some(defer) = defer
+            && defer(path.clone()).await
+        {
+            report.deferred += 1;
+            continue;
+        }
+        if !within_root(root, &path) {
+            // Should not happen for a path collected from within root, but the
+            // guard keeps a symlinked entry from escaping.
+            report.errors += 1;
+            continue;
+        }
+        match delete_recording_file(&path) {
+            Ok(()) => report.deleted += 1,
+            Err(error) => {
+                tracing::warn!(path = %path.display(), %error, "media retention: failed to delete recording file");
+                report.errors += 1;
+            }
+        }
+    }
+
+    report
+}
+
+/// Spawn the hourly retention sweep loop over `root`.
+///
+/// A `retention_days` of `0` disables retention: no loop is spawned. The loop
+/// tolerates transient failures (each tick is independent) and never panics.
+pub fn spawn_retention_sweep_loop(
+    root: PathBuf,
+    retention_days: u32,
+    defer: Option<RetentionDefer>,
+) {
+    if retention_days == 0 {
+        tracing::info!("media retention: disabled (retention_days = 0); sweep not spawned");
+        return;
+    }
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(SWEEP_INTERVAL_SECONDS));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            let report =
+                sweep_recordings_root(&root, retention_days, SystemTime::now(), defer.as_ref())
+                    .await;
+            if report.deleted > 0 || report.errors > 0 || report.deferred > 0 {
+                tracing::info!(
+                    deleted = report.deleted,
+                    deferred = report.deferred,
+                    errors = report.errors,
+                    "media retention sweep completed"
+                );
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        RetentionDefer, is_expired, recording_expires_at, sweep_recordings_root, within_root,
+    };
+    use std::sync::Arc;
+    use std::time::{Duration, SystemTime};
+
+    const DAY: u64 = 86_400;
+
+    fn write_with_mtime(path: &std::path::Path, contents: &[u8], age_secs: u64) {
+        std::fs::write(path, contents).expect("write");
+        let modified = SystemTime::now() - Duration::from_secs(age_secs);
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .expect("open for mtime");
+        file.set_modified(modified).expect("set_modified");
+    }
+
+    #[test]
+    fn expiry_boundary_is_days_after_modified() {
+        let modified = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        let expires = recording_expires_at(modified, 14);
+        assert_eq!(expires, modified + Duration::from_secs(14 * DAY));
+
+        let now = SystemTime::now();
+        let old = now - Duration::from_secs(100 * DAY);
+        assert!(is_expired(old, now, 14));
+        assert!(!is_expired(old, now, 200));
+    }
+
+    #[tokio::test]
+    async fn sweep_deletes_expired_and_keeps_fresh() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let old = temp.path().join("old.mp4");
+        let fresh = temp.path().join("fresh.mp4");
+        write_with_mtime(&old, b"old", 100 * DAY);
+        write_with_mtime(&fresh, b"fresh", 60);
+
+        let report = sweep_recordings_root(temp.path(), 14, SystemTime::now(), None).await;
+
+        assert_eq!(report.deleted, 1);
+        assert_eq!(report.kept, 1);
+        assert!(!old.exists(), "expired file should be deleted");
+        assert!(fresh.exists(), "fresh file should be kept");
+    }
+
+    #[tokio::test]
+    async fn sweep_honors_defer_hook() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let old = temp.path().join("held.mp4");
+        write_with_mtime(&old, b"held", 100 * DAY);
+
+        let defer: RetentionDefer = Arc::new(|_path| Box::pin(async { true }));
+        let report = sweep_recordings_root(temp.path(), 14, SystemTime::now(), Some(&defer)).await;
+
+        assert_eq!(report.deferred, 1);
+        assert_eq!(report.deleted, 0);
+        assert!(old.exists(), "deferred file must survive the sweep");
+    }
+
+    #[tokio::test]
+    async fn sweep_disabled_when_retention_zero() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let old = temp.path().join("old.mp4");
+        write_with_mtime(&old, b"old", 100 * DAY);
+
+        let report = sweep_recordings_root(temp.path(), 0, SystemTime::now(), None).await;
+
+        assert_eq!(report, super::RetentionReport::default());
+        assert!(old.exists(), "disabled retention deletes nothing");
+    }
+
+    #[test]
+    fn within_root_rejects_outside_paths() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        assert!(within_root(temp.path(), &temp.path().join("live/seg.mp4")));
+        assert!(!within_root(
+            temp.path(),
+            std::path::Path::new("/etc/hostname")
+        ));
+    }
+}

--- a/autumn-media-plugin/src/retention.rs
+++ b/autumn-media-plugin/src/retention.rs
@@ -127,12 +127,83 @@ fn collect_files(root: &Path, out: &mut Vec<PathBuf>) {
     }
 }
 
+/// The result of the synchronous scan phase: expired candidates plus the tallies
+/// for files decided without needing the (async) defer hook.
+#[derive(Default)]
+struct RecordingScan {
+    /// Expired files awaiting the async defer decision + deletion.
+    expired: Vec<PathBuf>,
+    /// Files kept because not yet expired or with an unreadable mtime.
+    kept: usize,
+    /// Files whose metadata could not be read.
+    errors: usize,
+}
+
+/// Traverse `root` and classify each regular file as expired / kept / error.
+///
+/// Pure synchronous filesystem work (`read_dir` + `metadata`), intended to run
+/// under [`tokio::task::spawn_blocking`] so it never blocks the async executor.
+/// The async defer decision and deletion are handled by the caller.
+fn scan_recordings_root(root: &Path, retention_days: u32, now: SystemTime) -> RecordingScan {
+    let mut scan = RecordingScan::default();
+    let mut files = Vec::new();
+    collect_files(root, &mut files);
+    for path in files {
+        let Ok(metadata) = std::fs::metadata(&path) else {
+            scan.errors += 1;
+            continue;
+        };
+        let Ok(modified) = metadata.modified() else {
+            scan.kept += 1;
+            continue;
+        };
+        if is_expired(modified, now, retention_days) {
+            scan.expired.push(path);
+        } else {
+            scan.kept += 1;
+        }
+    }
+    scan
+}
+
+/// Delete the given (already expired, non-deferred) files, re-checking
+/// [`within_root`] for each. Returns `(deleted, errors)`.
+///
+/// Pure synchronous filesystem work (`canonicalize` + `remove_file`), intended
+/// to run under [`tokio::task::spawn_blocking`].
+fn delete_expired_files(root: &Path, paths: &[PathBuf]) -> (usize, usize) {
+    let mut deleted = 0;
+    let mut errors = 0;
+    for path in paths {
+        if !within_root(root, path) {
+            // Should not happen for a path collected from within root, but the
+            // guard keeps a symlinked entry from escaping.
+            errors += 1;
+            continue;
+        }
+        match delete_recording_file(path) {
+            Ok(()) => deleted += 1,
+            Err(error) => {
+                tracing::warn!(path = %path.display(), %error, "media retention: failed to delete recording file");
+                errors += 1;
+            }
+        }
+    }
+    (deleted, errors)
+}
+
 /// Sweep `root` once, deleting recording files older than the retention window.
 ///
 /// `now` is taken as a parameter (never the wall clock) so the decision is
 /// deterministic for tests. A `retention_days` of `0` disables the sweep and
 /// returns an empty report. `defer`, when provided, can hold back an
 /// otherwise-expired file for the next tick.
+///
+/// The blocking filesystem work (directory traversal + `metadata`, then
+/// `canonicalize` + `remove_file`) runs on [`tokio::task::spawn_blocking`]
+/// threads so it never stalls the async executor; the app-overridable async
+/// [`RetentionDefer`] hook is consulted between the two phases, preserving its
+/// per-file semantics.
 pub async fn sweep_recordings_root(
     root: &Path,
     retention_days: u32,
@@ -144,42 +215,37 @@ pub async fn sweep_recordings_root(
         return report;
     }
 
-    let mut files = Vec::new();
-    collect_files(root, &mut files);
+    // Phase 1 — scan off the executor.
+    let scan = {
+        let root = root.to_path_buf();
+        tokio::task::spawn_blocking(move || scan_recordings_root(&root, retention_days, now))
+            .await
+            .unwrap_or_default()
+    };
+    report.kept = scan.kept;
+    report.errors = scan.errors;
 
-    for path in files {
-        let Ok(metadata) = std::fs::metadata(&path) else {
-            report.errors += 1;
-            continue;
-        };
-        let Ok(modified) = metadata.modified() else {
-            report.kept += 1;
-            continue;
-        };
-        if !is_expired(modified, now, retention_days) {
-            report.kept += 1;
-            continue;
-        }
+    // Between phases — consult the async defer hook per expired file.
+    let mut to_delete = Vec::with_capacity(scan.expired.len());
+    for path in scan.expired {
         if let Some(defer) = defer
             && defer(path.clone()).await
         {
             report.deferred += 1;
             continue;
         }
-        if !within_root(root, &path) {
-            // Should not happen for a path collected from within root, but the
-            // guard keeps a symlinked entry from escaping.
-            report.errors += 1;
-            continue;
-        }
-        match delete_recording_file(&path) {
-            Ok(()) => report.deleted += 1,
-            Err(error) => {
-                tracing::warn!(path = %path.display(), %error, "media retention: failed to delete recording file");
-                report.errors += 1;
-            }
-        }
+        to_delete.push(path);
     }
+
+    // Phase 2 — delete off the executor.
+    let (deleted, delete_errors) = {
+        let root = root.to_path_buf();
+        tokio::task::spawn_blocking(move || delete_expired_files(&root, &to_delete))
+            .await
+            .unwrap_or((0, 0))
+    };
+    report.deleted = deleted;
+    report.errors += delete_errors;
 
     report
 }

--- a/autumn-media-plugin/src/retention.rs
+++ b/autumn-media-plugin/src/retention.rs
@@ -84,14 +84,25 @@ pub fn within_root(root: &Path, path: &Path) -> bool {
     let Ok(canonical_root) = std::fs::canonicalize(root) else {
         return false;
     };
+    within_canonical_root(&canonical_root, path)
+}
+
+/// Strict containment check with **no lexical fast path**, used on the delete
+/// path (see [`delete_expired_files`]): fully resolve `path` — following
+/// symlinks in every component, including a parent directory that may have been
+/// swapped for a symlink after the scan — and confirm it is still inside the
+/// already-canonicalized `canonical_root`. A file whose parent is gone is
+/// reconstructed from its canonical parent so an in-flight concurrent delete is
+/// still judged correctly.
+fn within_canonical_root(canonical_root: &Path, path: &Path) -> bool {
     if let Ok(canonical_path) = std::fs::canonicalize(path) {
-        return canonical_path.starts_with(&canonical_root);
+        return canonical_path.starts_with(canonical_root);
     }
     if let Some(parent) = path.parent()
         && let Ok(canonical_parent) = std::fs::canonicalize(parent)
     {
         let reconstructed = canonical_parent.join(path.file_name().unwrap_or_default());
-        return reconstructed.starts_with(&canonical_root);
+        return reconstructed.starts_with(canonical_root);
     }
     false
 }
@@ -166,20 +177,59 @@ fn scan_recordings_root(root: &Path, retention_days: u32, now: SystemTime) -> Re
     scan
 }
 
-/// Delete the given (already expired, non-deferred) files, re-checking
-/// [`within_root`] for each. Returns `(deleted, errors)`.
+/// Delete the given (already expired, non-deferred) files. Returns
+/// `(deleted, kept, errors)`.
 ///
-/// Pure synchronous filesystem work (`canonicalize` + `remove_file`), intended
-/// to run under [`tokio::task::spawn_blocking`].
-fn delete_expired_files(root: &Path, paths: &[PathBuf]) -> (usize, usize) {
+/// Pure synchronous filesystem work (`canonicalize` + `metadata` + `remove_file`),
+/// intended to run under [`tokio::task::spawn_blocking`]. Because the async
+/// defer hook awaits between the scan and this phase, each candidate is
+/// re-validated immediately before unlinking:
+///
+/// * **Containment (TOCTOU on the parent):** a strict, non-lexical canonical
+///   check ([`within_canonical_root`]) — a parent directory swapped for a
+///   symlink after the scan would still satisfy the lexical [`within_root`] fast
+///   path, so re-resolve here and skip anything that now escapes `root`.
+/// * **Freshness (TOCTOU on the file):** re-`stat` and re-check expiry against
+///   the same `now`/`retention_days` used by the scan — a file touched or
+///   replaced during the await may no longer be expired and must not be deleted
+///   on the stale decision. A vanished/again-fresh file is a normal race
+///   outcome, not an error.
+fn delete_expired_files(
+    root: &Path,
+    paths: &[PathBuf],
+    retention_days: u32,
+    now: SystemTime,
+) -> (usize, usize, usize) {
     let mut deleted = 0;
+    let mut kept = 0;
     let mut errors = 0;
+    let canonical_root = std::fs::canonicalize(root).ok();
     for path in paths {
-        if !within_root(root, path) {
-            // Should not happen for a path collected from within root, but the
-            // guard keeps a symlinked entry from escaping.
+        // Strict canonical containment when root canonicalizes; otherwise fall
+        // back to the lexical guard rather than mass-deleting on an
+        // unverifiable root.
+        let contained = canonical_root.as_ref().map_or_else(
+            || within_root(root, path),
+            |canonical_root| within_canonical_root(canonical_root, path),
+        );
+        if !contained {
+            // A parent was swapped for a symlink escaping root (or the entry is
+            // otherwise no longer within it): refuse to follow it out.
             errors += 1;
             continue;
+        }
+        match std::fs::metadata(path) {
+            Ok(metadata) => match metadata.modified() {
+                Ok(modified) if is_expired(modified, now, retention_days) => {}
+                // Freshened between scan and delete, or its mtime is no longer
+                // readable — do not delete on an unconfirmed decision.
+                Ok(_) | Err(_) => {
+                    kept += 1;
+                    continue;
+                }
+            },
+            // Vanished (or now unreadable) since the scan — a benign race, skip.
+            Err(_) => continue,
         }
         match delete_recording_file(path) {
             Ok(()) => deleted += 1,
@@ -189,7 +239,7 @@ fn delete_expired_files(root: &Path, paths: &[PathBuf]) -> (usize, usize) {
             }
         }
     }
-    (deleted, errors)
+    (deleted, kept, errors)
 }
 
 /// Sweep `root` once, deleting recording files older than the retention window.
@@ -237,14 +287,18 @@ pub async fn sweep_recordings_root(
         to_delete.push(path);
     }
 
-    // Phase 2 — delete off the executor.
-    let (deleted, delete_errors) = {
+    // Phase 2 — delete off the executor, re-validating each candidate against
+    // the scan→delete race window (containment + freshness).
+    let (deleted, kept, delete_errors) = {
         let root = root.to_path_buf();
-        tokio::task::spawn_blocking(move || delete_expired_files(&root, &to_delete))
-            .await
-            .unwrap_or((0, 0))
+        tokio::task::spawn_blocking(move || {
+            delete_expired_files(&root, &to_delete, retention_days, now)
+        })
+        .await
+        .unwrap_or((0, 0, 0))
     };
     report.deleted = deleted;
+    report.kept += kept;
     report.errors += delete_errors;
 
     report
@@ -343,6 +397,94 @@ mod tests {
         assert_eq!(report.deferred, 1);
         assert_eq!(report.deleted, 0);
         assert!(old.exists(), "deferred file must survive the sweep");
+    }
+
+    #[tokio::test]
+    async fn sweep_skips_file_freshened_between_scan_and_delete() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let racy = temp.path().join("racy.mp4");
+        let normal = temp.path().join("normal.mp4");
+        write_with_mtime(&racy, b"racy", 100 * DAY);
+        write_with_mtime(&normal, b"normal", 100 * DAY);
+
+        // The defer hook runs between the scan (phase 1) and the delete
+        // (phase 2). Use it to freshen `racy`'s mtime mid-sweep — standing in
+        // for a concurrent touch/replace during the async await — while never
+        // actually deferring.
+        let racy_for_defer = racy.clone();
+        let defer: RetentionDefer = Arc::new(move |path| {
+            let racy = racy_for_defer.clone();
+            Box::pin(async move {
+                if path == racy {
+                    std::fs::OpenOptions::new()
+                        .write(true)
+                        .open(&racy)
+                        .expect("open for mtime")
+                        .set_modified(SystemTime::now())
+                        .expect("set_modified");
+                }
+                false
+            })
+        });
+
+        let report = sweep_recordings_root(temp.path(), 14, SystemTime::now(), Some(&defer)).await;
+
+        assert!(
+            racy.exists(),
+            "a file freshened between scan and delete must not be deleted"
+        );
+        assert!(!normal.exists(), "a still-expired file is still deleted");
+        assert_eq!(report.deleted, 1);
+        assert_eq!(
+            report.kept, 1,
+            "the freshened file counts as kept, not deleted"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn sweep_rejects_parent_symlink_swap_on_delete() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("root");
+        let outside = temp.path().join("outside");
+        std::fs::create_dir_all(root.join("subdir")).expect("mkdir subdir");
+        std::fs::create_dir_all(&outside).expect("mkdir outside");
+
+        // A fresh file outside root, sharing the candidate's file name. If the
+        // delete path followed the swapped parent symlink it would be unlinked.
+        let victim = outside.join("seg.mp4");
+        write_with_mtime(&victim, b"victim", 60);
+
+        let expired = root.join("subdir").join("seg.mp4");
+        write_with_mtime(&expired, b"seg", 100 * DAY);
+
+        // Between scan and delete, swap root/subdir (a real dir at scan time)
+        // for a symlink to `outside`. root/subdir/seg.mp4 still satisfies the
+        // lexical within_root fast path but now resolves outside root.
+        let root_subdir = root.join("subdir");
+        let outside_for_defer = outside.clone();
+        let defer: RetentionDefer = Arc::new(move |_path| {
+            let root_subdir = root_subdir.clone();
+            let outside = outside_for_defer.clone();
+            Box::pin(async move {
+                std::fs::remove_dir_all(&root_subdir).expect("rm subdir");
+                symlink(&outside, &root_subdir).expect("symlink");
+                false
+            })
+        });
+
+        let report = sweep_recordings_root(&root, 14, SystemTime::now(), Some(&defer)).await;
+
+        assert!(
+            victim.exists(),
+            "a file outside root must never be unlinked via a swapped parent symlink"
+        );
+        assert_eq!(
+            report.deleted, 0,
+            "nothing inside root was actually deleted"
+        );
     }
 
     #[tokio::test]

--- a/autumn-media-plugin/src/sink.rs
+++ b/autumn-media-plugin/src/sink.rs
@@ -1,0 +1,221 @@
+//! [`MediaArtifactSink`] — the app-supplied completion callback the generic
+//! media workflows invoke once a derived artifact is encoded and persisted.
+//!
+//! This is the media-workflow analogue of autumn-web's `OutboundWebhookHandler`
+//! (the pluggable store an app implements): the built-in `#[job]` handlers in
+//! [`crate::workflows`] run the `FFmpeg` encode, upload the output through
+//! [`crate::storage::MediaStorage`], then hand a fully-described
+//! [`MediaArtifact`] back to the app through this trait so the app can record
+//! the public URL against its own schema — exactly the `record_*_completed`
+//! activity Arroyo's Harvest workflows used to perform, but harvest-free.
+//!
+//! The trait is written with hand-rolled boxed futures (rather than
+//! `#[async_trait]`) to mirror autumn-web's own webhook seam and avoid pulling a
+//! new dependency into this crate.
+
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::MediaError;
+
+/// The boxed future the sink callbacks return.
+pub type MediaSinkFuture<'a> = Pin<Box<dyn Future<Output = Result<(), MediaError>> + Send + 'a>>;
+
+/// The class of derived media artifact a workflow produced.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MediaArtifactKind {
+    /// A single poster/thumbnail frame extracted from a recording.
+    Thumbnail,
+    /// A seek-preview sprite mosaic (plus its companion `WebVTT` track carried
+    /// as the artifact's secondary file).
+    Preview,
+    /// A transcoded window of a recording (a clip/highlight MP4).
+    Transcode,
+}
+
+impl MediaArtifactKind {
+    /// Stable lowercase label for logs and app-side matching.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Thumbnail => "thumbnail",
+            Self::Preview => "preview",
+            Self::Transcode => "transcode",
+        }
+    }
+}
+
+/// One persisted file belonging to a [`MediaArtifact`].
+///
+/// `key` is the caller-relative storage key, `storage_uri` is the backend URI
+/// (`s3://…` or a local path) exactly as [`crate::storage::StoredObject`]
+/// records it, and `public_url` is the browser-facing URL.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MediaArtifactFile {
+    /// Caller-relative object key the file was persisted under.
+    pub key: String,
+    /// Backend URI (`s3://{bucket}/{key}` or a local path).
+    pub storage_uri: String,
+    /// Public URL a browser fetches the object at.
+    pub public_url: String,
+    /// MIME content type the file was stored with.
+    pub content_type: String,
+    /// Size of the encoded output in bytes.
+    pub bytes: u64,
+}
+
+/// A fully-described artifact a media workflow produced and persisted.
+///
+/// The generalized, harvest-free form of the payload Arroyo's
+/// `record_thumbnail_completed` / `record_preview_completed` /
+/// `record_highlight_completed` activities consumed: it names the workflow that
+/// produced it, the kind of artifact, the caller-supplied `source_id` the app
+/// keys its own row on, the primary output file, an optional `secondary` file
+/// (the seek-preview `WebVTT` track), and free-form `metadata`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MediaArtifact {
+    /// The kind of artifact produced.
+    pub kind: MediaArtifactKind,
+    /// The workflow id that produced this artifact (caller-supplied in the job
+    /// args), so the app can correlate the callback with the request.
+    pub workflow_id: String,
+    /// The caller-supplied identifier for the source the artifact derives from
+    /// (e.g. a broadcast/stream id), threaded straight through from the job
+    /// args so the app can key its own row on it.
+    pub source_id: Option<String>,
+    /// The primary persisted output (the sprite JPEG for a preview, the poster
+    /// JPEG for a thumbnail, the MP4 for a transcode).
+    pub primary: MediaArtifactFile,
+    /// An optional companion file — the seek-preview `WebVTT` track for a
+    /// preview artifact; `None` for thumbnail/transcode.
+    pub secondary: Option<MediaArtifactFile>,
+    /// Free-form workflow metadata (deterministically ordered for stable
+    /// logging/serialization).
+    pub metadata: BTreeMap<String, String>,
+}
+
+/// App-supplied completion callback for the generic media workflows.
+///
+/// Implement this on the application side (Arroyo/Nexus) to record a produced
+/// artifact against your own schema. It parallels autumn-web's
+/// `OutboundWebhookHandler`: the plugin never touches app tables — it hands the
+/// finished artifact (or a failure) to this trait.
+pub trait MediaArtifactSink: Send + Sync + 'static {
+    /// Record a successfully encoded and persisted artifact.
+    fn on_completed(&self, artifact: MediaArtifact) -> MediaSinkFuture<'_>;
+
+    /// Record that a workflow failed before producing an artifact.
+    ///
+    /// `error` is the stringified [`MediaError`]. This is best-effort: the
+    /// workflow already logs and returns the underlying error to the durable
+    /// job engine for retry, so an implementation should not itself fail the
+    /// job — return `Ok(())` unless it genuinely could not record the failure.
+    fn on_failed(
+        &self,
+        kind: MediaArtifactKind,
+        workflow_id: String,
+        error: String,
+    ) -> MediaSinkFuture<'_>;
+}
+
+/// `AppState` extension wrapping the app-supplied [`MediaArtifactSink`].
+///
+/// The workflow `#[job]` handlers resolve this from `AppState`; when it is
+/// absent they persist the artifact but log that no sink recorded it.
+#[derive(Clone)]
+pub struct MediaArtifactSinkExt(pub Arc<dyn MediaArtifactSink>);
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::{
+        MediaArtifact, MediaArtifactFile, MediaArtifactKind, MediaArtifactSink, MediaSinkFuture,
+    };
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// A fake sink that counts completed/failed callbacks, used across the
+    /// workflow tests too.
+    pub struct CountingSink {
+        pub completed: AtomicUsize,
+        pub failed: AtomicUsize,
+        pub last_key: std::sync::Mutex<Option<String>>,
+    }
+
+    impl CountingSink {
+        pub fn new() -> Self {
+            Self {
+                completed: AtomicUsize::new(0),
+                failed: AtomicUsize::new(0),
+                last_key: std::sync::Mutex::new(None),
+            }
+        }
+    }
+
+    impl MediaArtifactSink for CountingSink {
+        fn on_completed(&self, artifact: MediaArtifact) -> MediaSinkFuture<'_> {
+            self.completed.fetch_add(1, Ordering::SeqCst);
+            *self.last_key.lock().expect("lock") = Some(artifact.primary.key);
+            Box::pin(async { Ok(()) })
+        }
+
+        fn on_failed(
+            &self,
+            _kind: MediaArtifactKind,
+            _workflow_id: String,
+            _error: String,
+        ) -> MediaSinkFuture<'_> {
+            self.failed.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    fn sample_artifact() -> MediaArtifact {
+        MediaArtifact {
+            kind: MediaArtifactKind::Thumbnail,
+            workflow_id: "wf-1".to_owned(),
+            source_id: Some("stream-7".to_owned()),
+            primary: MediaArtifactFile {
+                key: "thumbnails/7.jpg".to_owned(),
+                storage_uri: "/media/thumbnails/7.jpg".to_owned(),
+                public_url: "/media/thumbnails/7.jpg".to_owned(),
+                content_type: "image/jpeg".to_owned(),
+                bytes: 2048,
+            },
+            secondary: None,
+            metadata: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn artifact_kind_labels_are_stable() {
+        assert_eq!(MediaArtifactKind::Thumbnail.as_str(), "thumbnail");
+        assert_eq!(MediaArtifactKind::Preview.as_str(), "preview");
+        assert_eq!(MediaArtifactKind::Transcode.as_str(), "transcode");
+    }
+
+    #[test]
+    fn artifact_round_trips_through_json() {
+        let artifact = sample_artifact();
+        let json = serde_json::to_string(&artifact).expect("serialize");
+        let back: MediaArtifact = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(artifact, back);
+    }
+
+    #[tokio::test]
+    async fn sink_on_completed_receives_the_artifact() {
+        let sink = Arc::new(CountingSink::new());
+        sink.on_completed(sample_artifact()).await.expect("ok");
+        assert_eq!(sink.completed.load(Ordering::SeqCst), 1);
+        assert_eq!(sink.failed.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            sink.last_key.lock().expect("lock").as_deref(),
+            Some("thumbnails/7.jpg")
+        );
+    }
+}

--- a/autumn-media-plugin/src/workflows.rs
+++ b/autumn-media-plugin/src/workflows.rs
@@ -1,0 +1,787 @@
+//! Generic, harvest-free media workflows built on autumn-web's `#[job]` system.
+//!
+//! Each pipeline Arroyo drove through Autumn Harvest activities — poster
+//! extraction, seek-preview sprite + `WebVTT`, and clip/highlight transcode —
+//! is generalized here into a durable background job that:
+//!
+//! 1. resolves [`MediaStorage`](crate::storage::MediaStorage) and the `FFmpeg`
+//!    binary from `AppState`,
+//! 2. runs the matching [`crate::encode`] command **off** the async runtime via
+//!    [`tokio::task::spawn_blocking`],
+//! 3. persists the output through `MediaStorage`, and
+//! 4. hands a [`MediaArtifact`] to the app-supplied
+//!    [`MediaArtifactSink`](crate::sink::MediaArtifactSink).
+//!
+//! # The extension seam
+//!
+//! Dispatch flows through [`MediaWorkflows`], whose `queue_*` methods mirror
+//! autumn-web's outbound-webhook seam exactly: if a
+//! [`MediaWorkflowDelegateExt`] is installed on `AppState`, the request is
+//! handed to that runtime delegate (an external Harvest adapter, maintained
+//! outside this workspace); otherwise the **built-in** `#[job]` default is
+//! enqueued. There is **no** `autumn-harvest` dependency here — the `#[job]`
+//! path is the default and the delegate is the override.
+
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+
+use autumn_web::job::JobInfo;
+use autumn_web::{AppState, AutumnError, AutumnResult, job};
+use serde::{Deserialize, Serialize};
+
+use crate::encode::{
+    FfmpegHighlightCommand, FfmpegPosterCommand, FfmpegPreviewSpriteCommand, PREVIEW_CELL_HEIGHT,
+    PREVIEW_CELL_WIDTH, PREVIEW_FRAME_INTERVAL_SECONDS, PREVIEW_SPRITE_COLUMNS,
+    build_preview_webvtt,
+};
+use crate::error::MediaError;
+use crate::sink::{MediaArtifact, MediaArtifactFile, MediaArtifactKind, MediaArtifactSinkExt};
+use crate::storage::MediaStorage;
+
+// ── Job argument structs ─────────────────────────────────────────────────────
+
+/// Arguments for the poster/thumbnail extraction job.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ThumbnailJobArgs {
+    /// Recording segment(s) to sample the poster frame from. Multiple segments
+    /// are concatenated first (see [`FfmpegPosterCommand`]).
+    pub source_paths: Vec<PathBuf>,
+    /// Caller-relative storage key for the poster JPEG.
+    pub output_key: String,
+    /// Seconds back from end-of-file to sample the poster frame.
+    pub tail_offset_seconds: u32,
+    /// Caller-supplied workflow id echoed back to the sink.
+    pub workflow_id: String,
+    /// Caller-supplied source identifier (e.g. a broadcast id) echoed back.
+    #[serde(default)]
+    pub source_id: Option<String>,
+}
+
+/// Arguments for the seek-preview sprite + `WebVTT` job.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PreviewJobArgs {
+    /// Recording segment(s) to sample preview frames from.
+    pub source_paths: Vec<PathBuf>,
+    /// Caller-relative storage key for the sprite-mosaic JPEG.
+    pub sprite_key: String,
+    /// Caller-relative storage key for the companion `WebVTT` track.
+    pub vtt_key: String,
+    /// Total number of preview frames to sample and tile.
+    pub frame_count: u32,
+    /// Caller-supplied workflow id echoed back to the sink.
+    pub workflow_id: String,
+    /// Caller-supplied source identifier echoed back.
+    #[serde(default)]
+    pub source_id: Option<String>,
+}
+
+/// Arguments for the transcode-window (clip/highlight) job.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TranscodeJobArgs {
+    /// Recording to transcode a window of.
+    pub source_path: PathBuf,
+    /// Caller-relative storage key for the encoded MP4.
+    pub output_key: String,
+    /// Start offset (seconds) into the source.
+    pub start_seconds: u32,
+    /// Length (seconds) of the window to encode.
+    pub duration_seconds: u32,
+    /// MIME content type to persist the output with.
+    pub content_type: String,
+    /// Caller-supplied workflow id echoed back to the sink.
+    pub workflow_id: String,
+    /// Caller-supplied source identifier echoed back.
+    #[serde(default)]
+    pub source_id: Option<String>,
+}
+
+/// Arguments for the recording-finalize orchestration job, which fans a
+/// finished recording out into a poster and a seek-preview.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FinalizeRecordingJobArgs {
+    /// The poster job to enqueue for the finished recording.
+    pub thumbnail: ThumbnailJobArgs,
+    /// The seek-preview job to enqueue for the finished recording.
+    pub preview: PreviewJobArgs,
+}
+
+// ── Built-in `#[job]` handlers (the default engine) ──────────────────────────
+
+#[job(
+    name = "autumn_media_extract_thumbnail",
+    max_attempts = 3,
+    backoff_ms = 1000,
+    queue = "media"
+)]
+async fn extract_thumbnail(state: AppState, args: ThumbnailJobArgs) -> AutumnResult<()> {
+    let (storage, ffmpeg) = resolve_engine(&state)?;
+    let workflow_id = args.workflow_id.clone();
+    let result = run_thumbnail(&ffmpeg, &storage, args).await;
+    deliver_result(&state, MediaArtifactKind::Thumbnail, workflow_id, result).await
+}
+
+#[job(
+    name = "autumn_media_extract_preview",
+    max_attempts = 3,
+    backoff_ms = 1000,
+    queue = "media"
+)]
+async fn extract_preview(state: AppState, args: PreviewJobArgs) -> AutumnResult<()> {
+    let (storage, ffmpeg) = resolve_engine(&state)?;
+    let workflow_id = args.workflow_id.clone();
+    let result = run_preview(&ffmpeg, &storage, args).await;
+    deliver_result(&state, MediaArtifactKind::Preview, workflow_id, result).await
+}
+
+#[job(
+    name = "autumn_media_transcode_window",
+    max_attempts = 3,
+    backoff_ms = 1000,
+    queue = "media"
+)]
+async fn transcode_window(state: AppState, args: TranscodeJobArgs) -> AutumnResult<()> {
+    let (storage, ffmpeg) = resolve_engine(&state)?;
+    let workflow_id = args.workflow_id.clone();
+    let result = run_transcode(&ffmpeg, &storage, args).await;
+    deliver_result(&state, MediaArtifactKind::Transcode, workflow_id, result).await
+}
+
+#[job(
+    name = "autumn_media_finalize_recording",
+    max_attempts = 3,
+    backoff_ms = 1000,
+    queue = "media"
+)]
+async fn finalize_recording(state: AppState, args: FinalizeRecordingJobArgs) -> AutumnResult<()> {
+    // Orchestration: dispatch the two derived-artifact jobs through the same
+    // seam, so an installed delegate governs the sub-work too and each gets its
+    // own durable retry envelope.
+    let workflows = state.extension::<MediaWorkflows>().ok_or_else(|| {
+        AutumnError::internal_server_error_msg("MediaWorkflows extension is not installed")
+    })?;
+    workflows.queue_thumbnail(&state, args.thumbnail).await?;
+    workflows.queue_preview(&state, args.preview).await?;
+    Ok(())
+}
+
+/// The [`JobInfo`] set for the built-in media jobs, with each job's queue
+/// overridden to `queue`.
+///
+/// The `#[job(queue = "media")]` literal is a compile-time default; the plugin
+/// lets an application override [`crate::MediaPlugin::queue`], so registration
+/// rewrites `JobInfo.queue` here — the enqueue chokepoint routes by the
+/// registered `JobInfo`, so this is what makes the override take effect (the
+/// same technique autumn-web's outbound-webhook plugin uses).
+#[must_use]
+pub fn media_job_infos(queue: &str) -> Vec<JobInfo> {
+    [
+        __autumn_job_info_extract_thumbnail(),
+        __autumn_job_info_extract_preview(),
+        __autumn_job_info_transcode_window(),
+        __autumn_job_info_finalize_recording(),
+    ]
+    .into_iter()
+    .map(|mut info| {
+        queue.clone_into(&mut info.queue);
+        info
+    })
+    .collect()
+}
+
+// ── The dispatch seam ────────────────────────────────────────────────────────
+
+/// A runtime delegation callback bridging the generic media workflow layer to
+/// an external durable engine (e.g. an Autumn Harvest adapter).
+///
+/// When a [`MediaWorkflowDelegateExt`] is present on `AppState`, every
+/// [`MediaWorkflows`] `queue_*` call routes through it instead of enqueuing the
+/// built-in `#[job]`. Mirrors autumn-web's `WebhookDelegate`.
+pub type MediaWorkflowDelegate = Arc<
+    dyn Fn(
+            &AppState,
+            MediaWorkflowRequest,
+        ) -> Pin<Box<dyn Future<Output = AutumnResult<()>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// `AppState` extension carrying the runtime delegation hook. Present → the
+/// delegate overrides the built-in `#[job]`; absent → the `#[job]` default runs.
+#[derive(Clone)]
+pub struct MediaWorkflowDelegateExt(pub MediaWorkflowDelegate);
+
+/// A media-workflow request, as handed to a [`MediaWorkflowDelegate`].
+///
+/// Variants are boxed so the enum stays small regardless of the payload sizes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MediaWorkflowRequest {
+    /// A poster/thumbnail extraction request.
+    Thumbnail(Box<ThumbnailJobArgs>),
+    /// A seek-preview sprite + `WebVTT` request.
+    Preview(Box<PreviewJobArgs>),
+    /// A transcode-window request.
+    Transcode(Box<TranscodeJobArgs>),
+    /// A recording-finalize orchestration request.
+    Finalize(Box<FinalizeRecordingJobArgs>),
+}
+
+/// The service applications call to queue media work.
+///
+/// Installed on `AppState` by [`crate::MediaPlugin`]. Each `queue_*` method
+/// runs the extension-seam branch: delegate if present, else enqueue the
+/// built-in `#[job]`.
+#[derive(Clone, Debug)]
+pub struct MediaWorkflows {
+    ffmpeg_bin: String,
+    queue: String,
+}
+
+impl MediaWorkflows {
+    /// Create a workflow service bound to an `FFmpeg` binary and job queue.
+    #[must_use]
+    pub fn new(ffmpeg_bin: impl Into<String>, queue: impl Into<String>) -> Self {
+        Self {
+            ffmpeg_bin: ffmpeg_bin.into(),
+            queue: queue.into(),
+        }
+    }
+
+    /// The configured `FFmpeg` binary path the built-in jobs shell out to.
+    #[must_use]
+    pub fn ffmpeg_bin(&self) -> &str {
+        &self.ffmpeg_bin
+    }
+
+    /// The job queue the built-in media jobs are registered on.
+    #[must_use]
+    pub fn queue(&self) -> &str {
+        &self.queue
+    }
+
+    /// Queue a poster/thumbnail extraction.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error from the runtime delegate or the fallback enqueue.
+    pub async fn queue_thumbnail(
+        &self,
+        state: &AppState,
+        args: ThumbnailJobArgs,
+    ) -> AutumnResult<()> {
+        self.dispatch(state, MediaWorkflowRequest::Thumbnail(Box::new(args)))
+            .await
+    }
+
+    /// Queue a seek-preview sprite + `WebVTT` build.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error from the runtime delegate or the fallback enqueue.
+    pub async fn queue_preview(&self, state: &AppState, args: PreviewJobArgs) -> AutumnResult<()> {
+        self.dispatch(state, MediaWorkflowRequest::Preview(Box::new(args)))
+            .await
+    }
+
+    /// Queue a transcode-window (clip/highlight) encode.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error from the runtime delegate or the fallback enqueue.
+    pub async fn queue_transcode(
+        &self,
+        state: &AppState,
+        args: TranscodeJobArgs,
+    ) -> AutumnResult<()> {
+        self.dispatch(state, MediaWorkflowRequest::Transcode(Box::new(args)))
+            .await
+    }
+
+    /// Queue a recording-finalize orchestration (poster + seek-preview).
+    ///
+    /// # Errors
+    ///
+    /// Returns any error from the runtime delegate or the fallback enqueue.
+    pub async fn queue_recording_finalize(
+        &self,
+        state: &AppState,
+        args: FinalizeRecordingJobArgs,
+    ) -> AutumnResult<()> {
+        self.dispatch(state, MediaWorkflowRequest::Finalize(Box::new(args)))
+            .await
+    }
+
+    /// The extension-seam branch, identical in shape to autumn-web's outbound
+    /// webhook `dispatch`.
+    async fn dispatch(&self, state: &AppState, request: MediaWorkflowRequest) -> AutumnResult<()> {
+        if let Some(delegate) = state.extension::<MediaWorkflowDelegateExt>() {
+            tracing::debug!("MediaWorkflows::dispatch: delegating media work via runtime hook");
+            return (delegate.0)(state, request).await;
+        }
+        tracing::debug!("MediaWorkflows::dispatch: enqueuing built-in media job");
+        match request {
+            MediaWorkflowRequest::Thumbnail(args) => ExtractThumbnailJob::enqueue(*args).await,
+            MediaWorkflowRequest::Preview(args) => ExtractPreviewJob::enqueue(*args).await,
+            MediaWorkflowRequest::Transcode(args) => TranscodeWindowJob::enqueue(*args).await,
+            MediaWorkflowRequest::Finalize(args) => FinalizeRecordingJob::enqueue(*args).await,
+        }
+    }
+}
+
+// ── Internal run helpers (shared by the jobs) ────────────────────────────────
+
+/// Resolve the storage backend and `FFmpeg` binary the jobs need from state.
+fn resolve_engine(state: &AppState) -> AutumnResult<(Arc<MediaStorage>, String)> {
+    let storage = state.extension::<MediaStorage>().ok_or_else(|| {
+        AutumnError::internal_server_error_msg("MediaStorage extension is not installed")
+    })?;
+    let workflows = state.extension::<MediaWorkflows>().ok_or_else(|| {
+        AutumnError::internal_server_error_msg("MediaWorkflows extension is not installed")
+    })?;
+    let ffmpeg = workflows.ffmpeg_bin.clone();
+    Ok((storage, ffmpeg))
+}
+
+/// Deliver a workflow result to the app-supplied sink, mapping errors for the
+/// durable job engine.
+async fn deliver_result(
+    state: &AppState,
+    kind: MediaArtifactKind,
+    workflow_id: String,
+    result: Result<MediaArtifact, MediaError>,
+) -> AutumnResult<()> {
+    match result {
+        Ok(artifact) => {
+            if let Some(sink) = state.extension::<MediaArtifactSinkExt>() {
+                sink.0
+                    .on_completed(artifact)
+                    .await
+                    .map_err(|error| media_to_autumn(&error))?;
+            } else {
+                tracing::warn!(
+                    workflow_id = %workflow_id,
+                    kind = kind.as_str(),
+                    "media workflow completed but no MediaArtifactSink is installed; artifact not recorded"
+                );
+            }
+            Ok(())
+        }
+        Err(error) => {
+            let message = error.to_string();
+            if let Some(sink) = state.extension::<MediaArtifactSinkExt>()
+                && let Err(sink_error) = sink.0.on_failed(kind, workflow_id.clone(), message).await
+            {
+                tracing::warn!(%sink_error, workflow_id = %workflow_id, "MediaArtifactSink::on_failed itself failed");
+            }
+            // Return the error so the durable job engine retries per the job's
+            // max_attempts/backoff.
+            Err(media_to_autumn(&error))
+        }
+    }
+}
+
+fn media_to_autumn(error: &MediaError) -> AutumnError {
+    AutumnError::internal_server_error_msg(error.to_string())
+}
+
+async fn run_thumbnail(
+    ffmpeg_bin: &str,
+    storage: &MediaStorage,
+    args: ThumbnailJobArgs,
+) -> Result<MediaArtifact, MediaError> {
+    let (output_path, ephemeral) = staged_output(storage, &args.output_key, "jpg");
+    let command = FfmpegPosterCommand::new(
+        ffmpeg_bin,
+        args.source_paths.clone(),
+        output_path.clone(),
+        args.tail_offset_seconds,
+    );
+    let bytes = run_blocking(move || command.run()).await?;
+    let file = persist_and_cleanup(
+        storage,
+        &args.output_key,
+        &output_path,
+        "image/jpeg",
+        bytes,
+        ephemeral,
+    )
+    .await?;
+    Ok(MediaArtifact {
+        kind: MediaArtifactKind::Thumbnail,
+        workflow_id: args.workflow_id,
+        source_id: args.source_id,
+        primary: file,
+        secondary: None,
+        metadata: BTreeMap::new(),
+    })
+}
+
+async fn run_preview(
+    ffmpeg_bin: &str,
+    storage: &MediaStorage,
+    args: PreviewJobArgs,
+) -> Result<MediaArtifact, MediaError> {
+    let cols = PREVIEW_SPRITE_COLUMNS;
+    let rows = args.frame_count.div_ceil(cols).max(1);
+    let (sprite_path, sprite_ephemeral) = staged_output(storage, &args.sprite_key, "jpg");
+    let command = FfmpegPreviewSpriteCommand::new(
+        ffmpeg_bin,
+        args.source_paths.clone(),
+        sprite_path.clone(),
+        cols,
+        rows,
+    );
+    let sprite_bytes = run_blocking(move || command.run()).await?;
+    let sprite_file = persist_and_cleanup(
+        storage,
+        &args.sprite_key,
+        &sprite_path,
+        "image/jpeg",
+        sprite_bytes,
+        sprite_ephemeral,
+    )
+    .await?;
+
+    // The WebVTT cues point at the sprite's *public* URL, so build it only once
+    // the sprite has been persisted and its URL is known.
+    let vtt = build_preview_webvtt(
+        args.frame_count,
+        PREVIEW_FRAME_INTERVAL_SECONDS,
+        cols,
+        PREVIEW_CELL_WIDTH,
+        PREVIEW_CELL_HEIGHT,
+        &sprite_file.public_url,
+    );
+    let (vtt_path, vtt_ephemeral) = staged_output(storage, &args.vtt_key, "vtt");
+    write_text_file(&vtt_path, &vtt).await?;
+    let vtt_bytes = u64::try_from(vtt.len()).unwrap_or(u64::MAX);
+    let vtt_file = persist_and_cleanup(
+        storage,
+        &args.vtt_key,
+        &vtt_path,
+        "text/vtt",
+        vtt_bytes,
+        vtt_ephemeral,
+    )
+    .await?;
+
+    let mut metadata = BTreeMap::new();
+    metadata.insert("frame_count".to_owned(), args.frame_count.to_string());
+    Ok(MediaArtifact {
+        kind: MediaArtifactKind::Preview,
+        workflow_id: args.workflow_id,
+        source_id: args.source_id,
+        primary: sprite_file,
+        secondary: Some(vtt_file),
+        metadata,
+    })
+}
+
+async fn run_transcode(
+    ffmpeg_bin: &str,
+    storage: &MediaStorage,
+    args: TranscodeJobArgs,
+) -> Result<MediaArtifact, MediaError> {
+    let (output_path, ephemeral) = staged_output(storage, &args.output_key, "mp4");
+    let command = FfmpegHighlightCommand::new(
+        ffmpeg_bin,
+        args.source_path.clone(),
+        output_path.clone(),
+        args.start_seconds,
+        args.duration_seconds,
+    );
+    let bytes = run_blocking(move || command.run()).await?;
+    let file = persist_and_cleanup(
+        storage,
+        &args.output_key,
+        &output_path,
+        &args.content_type,
+        bytes,
+        ephemeral,
+    )
+    .await?;
+    Ok(MediaArtifact {
+        kind: MediaArtifactKind::Transcode,
+        workflow_id: args.workflow_id,
+        source_id: args.source_id,
+        primary: file,
+        secondary: None,
+        metadata: BTreeMap::new(),
+    })
+}
+
+/// Run a blocking encode closure off the async runtime.
+async fn run_blocking<F>(f: F) -> Result<u64, MediaError>
+where
+    F: FnOnce() -> Result<u64, MediaError> + Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|error| MediaError::EncodeTaskJoin {
+            message: error.to_string(),
+        })?
+}
+
+/// Resolve the on-disk path an encode command should write its output to.
+///
+/// The **local** backend serves objects straight from its root, so the output
+/// is written to its final served location (`root/{object_key}`) and never
+/// cleaned up. The **S3** backend stages to a unique temp file that is uploaded
+/// and then removed — so the returned `bool` reports whether the path is
+/// ephemeral.
+fn staged_output(storage: &MediaStorage, key: &str, ext: &str) -> (PathBuf, bool) {
+    match storage {
+        MediaStorage::Local { root, .. } => (root.join(storage.object_key(key)), false),
+        MediaStorage::S3(_) => (
+            std::env::temp_dir().join(format!("autumn-media-{}.{ext}", uuid::Uuid::new_v4())),
+            true,
+        ),
+    }
+}
+
+/// Persist a staged output under `key`, cleaning up an ephemeral (S3) staging
+/// file afterwards, and describe the stored file.
+async fn persist_and_cleanup(
+    storage: &MediaStorage,
+    key: &str,
+    local_path: &Path,
+    content_type: &str,
+    bytes: u64,
+    ephemeral: bool,
+) -> Result<MediaArtifactFile, MediaError> {
+    let stored = storage
+        .persist_file_with_content_type(key, local_path, content_type)
+        .await;
+    if ephemeral {
+        // Best-effort: the upload already succeeded or failed; the temp file is
+        // never the source of truth.
+        let _ = tokio::fs::remove_file(local_path).await;
+    }
+    let stored = stored?;
+    Ok(MediaArtifactFile {
+        key: stored.key,
+        storage_uri: stored.uri,
+        public_url: storage.public_url(key),
+        content_type: content_type.to_owned(),
+        bytes,
+    })
+}
+
+/// Write text (the `WebVTT` track) to a staging path, creating parent dirs.
+async fn write_text_file(path: &Path, contents: &str) -> Result<(), MediaError> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|source| MediaError::ArtifactWrite {
+                path: parent.display().to_string(),
+                source,
+            })?;
+    }
+    tokio::fs::write(path, contents)
+        .await
+        .map_err(|source| MediaError::ArtifactWrite {
+            path: path.display().to_string(),
+            source,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        FinalizeRecordingJobArgs, MediaWorkflowDelegate, MediaWorkflowDelegateExt,
+        MediaWorkflowRequest, MediaWorkflows, PreviewJobArgs, ThumbnailJobArgs, TranscodeJobArgs,
+        extract_thumbnail, media_job_infos, persist_and_cleanup, staged_output,
+    };
+    use crate::sink::MediaArtifactSinkExt;
+    use crate::sink::tests::CountingSink;
+    use crate::storage::MediaStorage;
+    use autumn_web::AppState;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn local_storage(root: &std::path::Path) -> MediaStorage {
+        MediaStorage::Local {
+            root: root.to_path_buf(),
+            public_base_url: "/media".to_owned(),
+        }
+    }
+
+    fn thumbnail_args(source: PathBuf) -> ThumbnailJobArgs {
+        ThumbnailJobArgs {
+            source_paths: vec![source],
+            output_key: "thumbnails/7.jpg".to_owned(),
+            tail_offset_seconds: 5,
+            workflow_id: "wf-thumb".to_owned(),
+            source_id: Some("stream-7".to_owned()),
+        }
+    }
+
+    #[test]
+    fn media_job_infos_override_declared_queue() {
+        let infos = media_job_infos("custom-queue");
+        assert_eq!(infos.len(), 4);
+        assert!(infos.iter().all(|info| info.queue == "custom-queue"));
+        let names: Vec<&str> = infos.iter().map(|info| info.name.as_str()).collect();
+        assert!(names.contains(&"autumn_media_extract_thumbnail"));
+        assert!(names.contains(&"autumn_media_extract_preview"));
+        assert!(names.contains(&"autumn_media_transcode_window"));
+        assert!(names.contains(&"autumn_media_finalize_recording"));
+    }
+
+    #[test]
+    fn job_args_round_trip_through_json() {
+        let args = thumbnail_args(PathBuf::from("/rec/seg.mp4"));
+        let json = serde_json::to_string(&args).expect("serialize");
+        let back: ThumbnailJobArgs = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(args, back);
+
+        let preview = PreviewJobArgs {
+            source_paths: vec![PathBuf::from("/rec/a.mp4")],
+            sprite_key: "previews/7.jpg".to_owned(),
+            vtt_key: "previews/7.vtt".to_owned(),
+            frame_count: 24,
+            workflow_id: "wf-prev".to_owned(),
+            source_id: None,
+        };
+        let back: PreviewJobArgs =
+            serde_json::from_str(&serde_json::to_string(&preview).expect("ser")).expect("de");
+        assert_eq!(preview, back);
+
+        let transcode = TranscodeJobArgs {
+            source_path: PathBuf::from("/rec/a.mp4"),
+            output_key: "clips/7.mp4".to_owned(),
+            start_seconds: 10,
+            duration_seconds: 30,
+            content_type: "video/mp4".to_owned(),
+            workflow_id: "wf-clip".to_owned(),
+            source_id: Some("clip-7".to_owned()),
+        };
+        let back: TranscodeJobArgs =
+            serde_json::from_str(&serde_json::to_string(&transcode).expect("ser")).expect("de");
+        assert_eq!(transcode, back);
+    }
+
+    #[test]
+    fn staged_output_is_final_for_local_and_ephemeral_for_temp() {
+        let storage = local_storage(std::path::Path::new("/srv/media"));
+        let (path, ephemeral) = staged_output(&storage, "/thumbnails/7.jpg", "jpg");
+        assert!(!ephemeral, "local backend writes to its served location");
+        assert_eq!(path, PathBuf::from("/srv/media/thumbnails/7.jpg"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_uses_delegate_when_present() {
+        let state = AppState::for_test();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let seen = Arc::new(std::sync::Mutex::new(None::<MediaWorkflowRequest>));
+        let calls_c = calls.clone();
+        let seen_c = seen.clone();
+        let delegate: MediaWorkflowDelegate = Arc::new(move |_state, request| {
+            calls_c.fetch_add(1, Ordering::SeqCst);
+            *seen_c.lock().expect("lock") = Some(request);
+            Box::pin(async { Ok(()) })
+        });
+        state.insert_extension(MediaWorkflowDelegateExt(delegate));
+
+        let workflows = MediaWorkflows::new("ffmpeg", "media");
+        workflows
+            .queue_thumbnail(&state, thumbnail_args(PathBuf::from("/rec/seg.mp4")))
+            .await
+            .expect("delegate path returns Ok");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(matches!(
+            seen.lock().expect("lock").as_ref(),
+            Some(MediaWorkflowRequest::Thumbnail(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn dispatch_enqueues_builtin_job_when_no_delegate() {
+        let _guard = autumn_web::job::global_job_runtime_test_lock().lock().await;
+        autumn_web::job::clear_global_job_client();
+
+        let state = AppState::for_test();
+        let workflows = MediaWorkflows::new("ffmpeg", "media");
+        // No delegate installed → dispatch takes the built-in enqueue branch,
+        // which errors because no job runtime is initialized in this unit test.
+        let err = workflows
+            .queue_thumbnail(&state, thumbnail_args(PathBuf::from("/rec/seg.mp4")))
+            .await
+            .expect_err("enqueue branch should be taken without a delegate");
+        assert!(
+            err.to_string().contains("job runtime is not initialized"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn job_reports_failure_to_sink_when_source_missing() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let state = AppState::for_test();
+        state.insert_extension(local_storage(temp.path()));
+        state.insert_extension(MediaWorkflows::new("ffmpeg", "media"));
+        let sink = Arc::new(CountingSink::new());
+        state.insert_extension(MediaArtifactSinkExt(sink.clone()));
+
+        // A source path that does not exist → the poster command fails before it
+        // ever spawns FFmpeg (require_sources), so this test needs no binary.
+        let args = thumbnail_args(temp.path().join("does-not-exist.mp4"));
+        let result = extract_thumbnail(state, args).await;
+
+        assert!(result.is_err(), "missing source must fail the job");
+        assert_eq!(sink.failed.load(Ordering::SeqCst), 1);
+        assert_eq!(sink.completed.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn persist_and_cleanup_describes_the_stored_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let storage = local_storage(temp.path());
+        // Stage a real "encoded" file at the served location.
+        let (output_path, ephemeral) = staged_output(&storage, "clips/7.mp4", "mp4");
+        std::fs::create_dir_all(output_path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&output_path, b"encoded-bytes").expect("write");
+
+        let file = persist_and_cleanup(
+            &storage,
+            "clips/7.mp4",
+            &output_path,
+            "video/mp4",
+            13,
+            ephemeral,
+        )
+        .await
+        .expect("persist");
+
+        assert_eq!(file.key, "clips/7.mp4");
+        assert_eq!(file.content_type, "video/mp4");
+        assert_eq!(file.bytes, 13);
+        assert_eq!(file.public_url, "/media/clips/7.mp4");
+        assert!(
+            std::path::Path::new(&file.storage_uri).exists(),
+            "local backend keeps the served file in place"
+        );
+    }
+
+    #[test]
+    fn finalize_args_carry_both_sub_requests() {
+        let args = FinalizeRecordingJobArgs {
+            thumbnail: thumbnail_args(PathBuf::from("/rec/seg.mp4")),
+            preview: PreviewJobArgs {
+                source_paths: vec![PathBuf::from("/rec/seg.mp4")],
+                sprite_key: "previews/7.jpg".to_owned(),
+                vtt_key: "previews/7.vtt".to_owned(),
+                frame_count: 12,
+                workflow_id: "wf-final".to_owned(),
+                source_id: Some("stream-7".to_owned()),
+            },
+        };
+        let back: FinalizeRecordingJobArgs =
+            serde_json::from_str(&serde_json::to_string(&args).expect("ser")).expect("de");
+        assert_eq!(args, back);
+    }
+}

--- a/autumn-media-plugin/src/workflows.rs
+++ b/autumn-media-plugin/src/workflows.rs
@@ -110,11 +110,24 @@ pub struct FinalizeRecordingJobArgs {
 
 // ── Built-in `#[job]` handlers (the default engine) ──────────────────────────
 
+// `unique_by = "workflow_id"` + a TTL window make a re-enqueue of the same
+// workflow_id a coalesced no-op (returns `Ok(())`, spawns no second job). This
+// is what keeps `finalize_recording`'s partial-failure retry idempotent: if the
+// thumbnail enqueue succeeds but the preview enqueue then fails, the retried
+// orchestration re-enqueues the thumbnail as a dedup no-op (only the missing
+// preview is filled), so the app-supplied `MediaArtifactSink::on_completed` is
+// not invoked twice for the same artifact via that path. The TTL (5 min) simply
+// has to outlast the finalize retry envelope (3 attempts, 1s exponential
+// backoff); it is keyed on the caller's own `workflow_id`, so it only ever
+// coalesces work the caller already labelled as one logical workflow.
 #[job(
     name = "autumn_media_extract_thumbnail",
     max_attempts = 3,
     backoff_ms = 1000,
-    queue = "media"
+    queue = "media",
+    unique,
+    unique_by = "workflow_id",
+    unique_for_ms = 300_000
 )]
 async fn extract_thumbnail(state: AppState, args: ThumbnailJobArgs) -> AutumnResult<()> {
     let (storage, ffmpeg) = resolve_engine(&state)?;
@@ -123,11 +136,16 @@ async fn extract_thumbnail(state: AppState, args: ThumbnailJobArgs) -> AutumnRes
     deliver_result(&state, MediaArtifactKind::Thumbnail, workflow_id, result).await
 }
 
+// See `extract_thumbnail`: the same workflow_id-keyed TTL dedup makes the
+// finalize retry re-enqueue of the preview a coalesced no-op.
 #[job(
     name = "autumn_media_extract_preview",
     max_attempts = 3,
     backoff_ms = 1000,
-    queue = "media"
+    queue = "media",
+    unique,
+    unique_by = "workflow_id",
+    unique_for_ms = 300_000
 )]
 async fn extract_preview(state: AppState, args: PreviewJobArgs) -> AutumnResult<()> {
     let (storage, ffmpeg) = resolve_engine(&state)?;
@@ -159,6 +177,16 @@ async fn finalize_recording(state: AppState, args: FinalizeRecordingJobArgs) -> 
     // Orchestration: dispatch the two derived-artifact jobs through the same
     // seam, so an installed delegate governs the sub-work too and each gets its
     // own durable retry envelope.
+    //
+    // Partial-failure retry safety: if `queue_thumbnail` succeeds but
+    // `queue_preview` then fails, this job returns `Err` and is retried. The two
+    // sub-jobs are `unique`-keyed on their `workflow_id` (see `extract_thumbnail`
+    // / `extract_preview`), so the retry re-enqueues the already-queued thumbnail
+    // as a coalesced no-op and only fills the missing preview — no duplicate
+    // sub-job, and therefore no duplicate `on_completed` for the same artifact
+    // via this orchestration path. (The durable engine is still at-least-once, so
+    // the app-side sink must remain idempotent by `workflow_id` + `kind` for the
+    // general worker-crash-after-persist case, which no enqueue key can remove.)
     let workflows = state.extension::<MediaWorkflows>().ok_or_else(|| {
         AutumnError::internal_server_error_msg("MediaWorkflows extension is not installed")
     })?;
@@ -391,7 +419,7 @@ async fn run_thumbnail(
     storage: &MediaStorage,
     args: ThumbnailJobArgs,
 ) -> Result<MediaArtifact, MediaError> {
-    let (output_path, ephemeral) = staged_output(storage, &args.output_key, "jpg");
+    let (output_path, ephemeral) = staged_output(storage, &args.output_key, "jpg")?;
     let command = FfmpegPosterCommand::new(
         ffmpeg_bin,
         args.source_paths.clone(),
@@ -425,7 +453,7 @@ async fn run_preview(
 ) -> Result<MediaArtifact, MediaError> {
     let cols = PREVIEW_SPRITE_COLUMNS;
     let rows = args.frame_count.div_ceil(cols).max(1);
-    let (sprite_path, sprite_ephemeral) = staged_output(storage, &args.sprite_key, "jpg");
+    let (sprite_path, sprite_ephemeral) = staged_output(storage, &args.sprite_key, "jpg")?;
     let command = FfmpegPreviewSpriteCommand::new(
         ffmpeg_bin,
         args.source_paths.clone(),
@@ -454,7 +482,7 @@ async fn run_preview(
         PREVIEW_CELL_HEIGHT,
         &sprite_file.public_url,
     );
-    let (vtt_path, vtt_ephemeral) = staged_output(storage, &args.vtt_key, "vtt");
+    let (vtt_path, vtt_ephemeral) = staged_output(storage, &args.vtt_key, "vtt")?;
     write_text_file(&vtt_path, &vtt).await?;
     let vtt_bytes = u64::try_from(vtt.len()).unwrap_or(u64::MAX);
     let vtt_file = persist_and_cleanup(
@@ -484,7 +512,7 @@ async fn run_transcode(
     storage: &MediaStorage,
     args: TranscodeJobArgs,
 ) -> Result<MediaArtifact, MediaError> {
-    let (output_path, ephemeral) = staged_output(storage, &args.output_key, "mp4");
+    let (output_path, ephemeral) = staged_output(storage, &args.output_key, "mp4")?;
     let command = FfmpegHighlightCommand::new(
         ffmpeg_bin,
         args.source_path.clone(),
@@ -531,12 +559,71 @@ where
 /// cleaned up. The **S3** backend stages to a unique temp file that is uploaded
 /// and then removed — so the returned `bool` reports whether the path is
 /// ephemeral.
-fn staged_output(storage: &MediaStorage, key: &str, ext: &str) -> (PathBuf, bool) {
+///
+/// # Errors
+///
+/// Returns [`MediaError::ArtifactWrite`] when a local output key would escape
+/// the storage root (see [`join_within_root`]). The S3 arm cannot fail (it
+/// stages under [`std::env::temp_dir`]).
+fn staged_output(
+    storage: &MediaStorage,
+    key: &str,
+    ext: &str,
+) -> Result<(PathBuf, bool), MediaError> {
     match storage {
-        MediaStorage::Local { root, .. } => (root.join(storage.object_key(key)), false),
-        MediaStorage::S3(_) => (
+        MediaStorage::Local { root, .. } => {
+            // `object_key` only slash-trims a local key — it does not reject a
+            // `..`/absolute segment — so guard the join against traversal before
+            // an encode writes to `root/{object_key}`.
+            let path = join_within_root(root, &storage.object_key(key))?;
+            Ok((path, false))
+        }
+        MediaStorage::S3(_) => Ok((
             std::env::temp_dir().join(format!("autumn-media-{}.{ext}", uuid::Uuid::new_v4())),
             true,
+        )),
+    }
+}
+
+/// Join an already-slash-trimmed caller key onto the local backend `root`,
+/// rejecting any key that could escape it.
+///
+/// Slice-1's key resolution ([`MediaStorage::object_key`]) only slash-trims a
+/// local key; its dot-segment handling is URL-only (`encode_key_for_url`), so
+/// nothing upstream stops a `..`/absolute/drive-prefix segment from reaching the
+/// on-disk join here — and the local encode output is written straight to
+/// `root/{object_key}`. This guard rejects such keys before the join (defense in
+/// depth), keeping every staged local output inside `root`. Only
+/// [`std::path::Component::Normal`] segments are allowed; a `ParentDir` (`..`),
+/// a `RootDir`/`Prefix` (absolute), a leading `CurDir` (`.`), or an
+/// empty/dot-only key is rejected.
+fn join_within_root(root: &Path, key: &str) -> Result<PathBuf, MediaError> {
+    use std::path::Component;
+    let relative = Path::new(key);
+    let mut has_normal = false;
+    for component in relative.components() {
+        match component {
+            Component::Normal(_) => has_normal = true,
+            _ => return Err(rejected_output_key(key)),
+        }
+    }
+    if !has_normal {
+        // Empty or dot-only key: nothing legitimate to write under `root`.
+        return Err(rejected_output_key(key));
+    }
+    Ok(root.join(relative))
+}
+
+/// Build the traversal-rejection error for an unsafe local output key, reusing
+/// [`MediaError::ArtifactWrite`] (the crate's "could not write this artifact
+/// path" error) rather than introducing a new variant.
+fn rejected_output_key(key: &str) -> MediaError {
+    MediaError::ArtifactWrite {
+        path: key.to_owned(),
+        source: std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "media output key must stay within the storage root \
+             (no `..`, absolute, or dot-only path segments)",
         ),
     }
 }
@@ -632,6 +719,42 @@ mod tests {
     }
 
     #[test]
+    fn derived_sub_jobs_dedup_on_workflow_id() {
+        use autumn_web::job::JobUniquenessWindow;
+        // The thumbnail and preview jobs are `unique` on `workflow_id` with a TTL
+        // window, so a `finalize_recording` partial-failure retry coalesces the
+        // already-enqueued sub-job instead of spawning a duplicate. The transcode
+        // and orchestration jobs carry no dedup.
+        let infos = media_job_infos("media");
+        let uniqueness = |name: &str| {
+            infos
+                .iter()
+                .find(|info| info.name == name)
+                .expect("job registered")
+                .uniqueness
+                .clone()
+        };
+        for name in [
+            "autumn_media_extract_thumbnail",
+            "autumn_media_extract_preview",
+        ] {
+            let u = uniqueness(name).unwrap_or_else(|| panic!("{name} must be unique"));
+            assert_eq!(
+                u.by,
+                vec!["workflow_id".to_owned()],
+                "{name} keys on workflow_id"
+            );
+            assert!(
+                matches!(u.window, JobUniquenessWindow::TtlMs(ms) if ms > 0),
+                "{name} must use a TTL dedup window, got {:?}",
+                u.window
+            );
+        }
+        assert!(uniqueness("autumn_media_transcode_window").is_none());
+        assert!(uniqueness("autumn_media_finalize_recording").is_none());
+    }
+
+    #[test]
     fn job_args_round_trip_through_json() {
         let args = thumbnail_args(PathBuf::from("/rec/seg.mp4"));
         let json = serde_json::to_string(&args).expect("serialize");
@@ -667,9 +790,36 @@ mod tests {
     #[test]
     fn staged_output_is_final_for_local_and_ephemeral_for_temp() {
         let storage = local_storage(std::path::Path::new("/srv/media"));
-        let (path, ephemeral) = staged_output(&storage, "/thumbnails/7.jpg", "jpg");
+        let (path, ephemeral) =
+            staged_output(&storage, "/thumbnails/7.jpg", "jpg").expect("normal key");
         assert!(!ephemeral, "local backend writes to its served location");
         assert_eq!(path, PathBuf::from("/srv/media/thumbnails/7.jpg"));
+    }
+
+    #[test]
+    fn staged_output_rejects_local_traversal_keys() {
+        let storage = local_storage(std::path::Path::new("/srv/media"));
+        // A `..` segment would escape the media root — must be rejected, not
+        // joined into `/srv/media/../../etc/...`. (A plain absolute key like
+        // `/etc/passwd` is *not* traversal here: `object_key` slash-trims it to
+        // the benign in-root relative key `etc/passwd`, so it is not in this set.)
+        for key in [
+            "../../etc/passwd",
+            "clips/../../../etc/passwd",
+            "..",
+            ".",
+            "",
+        ] {
+            let err = staged_output(&storage, key, "jpg")
+                .expect_err("traversal/degenerate key must be rejected");
+            assert!(
+                matches!(err, super::MediaError::ArtifactWrite { .. }),
+                "expected ArtifactWrite rejection for {key:?}, got {err:?}"
+            );
+        }
+        // A normal nested key still resolves inside the root.
+        let (path, _) = staged_output(&storage, "previews/7.vtt", "vtt").expect("normal key");
+        assert_eq!(path, PathBuf::from("/srv/media/previews/7.vtt"));
     }
 
     #[tokio::test]
@@ -742,7 +892,8 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let storage = local_storage(temp.path());
         // Stage a real "encoded" file at the served location.
-        let (output_path, ephemeral) = staged_output(&storage, "clips/7.mp4", "mp4");
+        let (output_path, ephemeral) =
+            staged_output(&storage, "clips/7.mp4", "mp4").expect("normal key");
         std::fs::create_dir_all(output_path.parent().expect("parent")).expect("mkdir");
         std::fs::write(&output_path, b"encoded-bytes").expect("write");
 


### PR DESCRIPTION
## Before / After

**Before:** `autumn-media-plugin` shipped storage (slice 1) and the FFmpeg encode primitives (slice 2), but nothing tied them together — there was no durable pipeline that ran an encode, persisted its output, and reported the result back to an application, and no extension point for an external durable engine.

**After:** slice 4 adds the **harvest-free** media-workflow layer, built on autumn-web's own `#[job]` system and modelled directly on the outbound-webhook extension seam. An application queues media work through a `MediaWorkflows` service; the built-in `#[job]` handlers run the encode, persist the output, and hand the result to an app-supplied sink — and an external Harvest adapter (maintained outside this workspace) can slot in by registering a runtime delegate.

## How

- **Extension seam (mirrors `webhook_outbound.rs`).** `MediaWorkflows::queue_*` runs the exact webhooks branch: `if let Some(delegate) = state.extension::<MediaWorkflowDelegateExt>() { delegate(request) } else { <BuiltinJob>::enqueue(args) }`. The `#[job]` implementation is the **built-in default**; the delegate is the override. There is **no `autumn-harvest` dependency anywhere** (not even feature-gated).
- **`#[job]` default engine (`workflows.rs`).** Four handlers — `extract_thumbnail`, `extract_preview` (sprite + WebVTT), `transcode_window`, and `finalize_recording` (orchestration). Each resolves `MediaStorage` + the FFmpeg binary from `AppState`, runs the matching `crate::encode` command **off** the runtime via `spawn_blocking`, persists the output through `MediaStorage`, then invokes the sink. `media_job_infos(queue)` rebuilds the generated `JobInfo`s with the plugin's `queue` override so the enqueue chokepoint routes to the right queue (the same technique the outbound-webhook plugin uses); the worker auto-registers the declared queue.
- **Sink (`sink.rs`).** The app-supplied `MediaArtifactSink` trait — the completion callback that records a produced artifact against the app's own schema, parallel to `OutboundWebhookHandler`. Plus the `MediaArtifact` / `MediaArtifactFile` / `MediaArtifactKind` value types and the `MediaArtifactSinkExt` AppState extension. Hand-rolled boxed futures (no `async_trait`) to match the webhook seam and add no dependency.
- **Retention (`retention.rs`).** The harvest-free generalization of Arroyo's recording-retention sweep: mtime-based expiry, a within-root guard, file-only idempotent delete, an app-overridable `RetentionDefer` predicate (Arroyo's "defer a file still referenced by an in-progress workflow"), and an hourly spawn loop (`0` days disables).
- **Wiring (`lib.rs`).** `MediaPlugin` gains `artifact_sink`, `workflow_delegate`, `retention_days`, `recordings_root`, and `retention_defer` builders. `build()` resolves `MediaStorage` up front (one clear error line on misconfig), installs `MediaStorage` + `MediaWorkflows` + the sink/delegate extensions via `state_initializer` **before workers start** (mirroring the webhook plugin), registers the built-in jobs with the overridden queue, and spawns the retention sweep from `on_startup` when a recordings root is configured. Existing builder methods are unchanged.

## Test evidence

`cargo test -p autumn-media-plugin` → **128 passed** (no Docker, no FFmpeg binary required). New coverage:
- `dispatch_uses_delegate_when_present` — a registered delegate overrides and is invoked; no enqueue attempted.
- `dispatch_enqueues_builtin_job_when_no_delegate` — with no delegate the enqueue branch is taken (errors cleanly when no job runtime is initialized).
- `job_reports_failure_to_sink_when_source_missing` — a job with a missing source fails before FFmpeg spawns, calls `sink.on_failed`, and returns `Err`.
- `persist_and_cleanup_describes_the_stored_file`, `sink_on_completed_receives_the_artifact` — sink callback + persist/public-URL shape.
- `sweep_deletes_expired_and_keeps_fresh`, `sweep_honors_defer_hook`, `sweep_disabled_when_retention_zero`, `within_root_rejects_outside_paths`, `expiry_boundary_is_days_after_modified` — retention decision + guard.
- `media_job_infos_override_declared_queue`, `staged_output_is_final_for_local_and_ephemeral_for_temp`, job-arg / artifact JSON round-trips.

Gate — all green:

```
cargo fmt --all -- --check          # clean
cargo clippy -p autumn-media-plugin --all-targets -- -D warnings   # exit 0
cargo test -p autumn-media-plugin   # 128 passed
cargo build -p autumn-media-plugin  # exit 0
```

## Notes / deviations from the research plan

- **`queue_*` returns `AutumnResult<()>`, not a uuid.** The workflow id is caller-supplied in the job args (and echoed back on the `MediaArtifact`), which is cleaner for app-side correlation than minting one inside the service; this matches the webhook `dispatch` shape.
- **Retention is a self-contained filesystem sweep** over a configured `recordings_root` (mtime-based), rather than an app-DB-driven candidate source. The plugin has no recordings schema, so this keeps retention honest and dependency-free while still exposing the app-overridable defer hook the plan called for.
- **Reachable deferred-hardening item fixed:** the S3 backend now stages encode output to a unique temp file and cleans it up after upload, while the Local backend writes straight to its served location — so the persist path is correct for both real callers this slice adds. The other deferred items (S3 public-base fallback, dot-only key rejection, ffmpeg child-output buffering, non-UTF-8 path threading) remain deferred — this slice's callers don't newly reach them (dot-only encoding and the buffering cap live in slice 1/2 code paths unchanged here).

Part of #1974

---
_Generated by [Claude Code](https://claude.ai/code/session_015b2JHGzyvPj86FcyMnTRdV)_