### PR TITLE
Accept declarative-schema markers in #[model] (managed, #[unique], #[references]) — slice 3.5

### DIFF
--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -17,30 +17,102 @@ use quote::{format_ident, quote};
 use syn::parse::Parser as _;
 use syn::{DeriveInput, Field, LitStr};
 
-/// Process `#[model]` or `#[model(table = "...")]` attribute arguments.
-fn parse_attr_args(attr: TokenStream) -> syn::Result<Option<String>> {
+/// Parsed `#[model(...)]` attribute arguments.
+///
+/// `managed` is a declarative-schema opt-in marker (#1975, Decision 4). It is
+/// accepted and validated here, but has **zero effect on generated code** —
+/// the marker is schema-authoritative for the CLI toolchain only; the codegen
+/// side is wired in a later slice.
+#[derive(Default, Debug)]
+struct ModelArgs {
+    /// Explicit `table = "..."` override, if any.
+    table: Option<String>,
+    /// Whether the model opted into declarative-schema management via
+    /// `#[model(managed)]`. Captured but intentionally unused by codegen.
+    #[allow(dead_code)]
+    managed: bool,
+}
+
+/// Process `#[model]`, `#[model(table = "...")]`, and `#[model(managed)]`
+/// attribute arguments.
+fn parse_attr_args(attr: TokenStream) -> syn::Result<ModelArgs> {
+    let mut args = ModelArgs::default();
     if attr.is_empty() {
-        return Ok(None);
+        return Ok(args);
     }
 
-    let mut table = None;
     syn::meta::parser(|meta| {
         if meta.path.is_ident("table") {
             let value: LitStr = meta.value()?.parse()?;
-            table = Some(value.value());
+            args.table = Some(value.value());
+            Ok(())
+        } else if meta.path.is_ident("managed") {
+            // The required form is a bare `managed` path. `managed = <expr>` is
+            // rejected with a clear message rather than silently accepted.
+            if meta.input.peek(syn::Token![=]) {
+                return Err(
+                    meta.error("`managed` takes no value; write a bare `#[model(managed)]`")
+                );
+            }
+            args.managed = true;
             Ok(())
         } else {
-            Err(meta.error("unsupported model attribute"))
+            Err(meta.error(
+                "unsupported `#[model(...)]` argument; expected `table = \"...\"` or `managed`",
+            ))
         }
     })
     .parse2(attr)?;
 
-    Ok(table)
+    Ok(args)
 }
 
 /// Check if a field has the `#[id]` attribute.
 fn has_attr(field: &Field, name: &str) -> bool {
     field.attrs.iter().any(|a| a.path().is_ident(name))
+}
+
+/// Validate the declarative-schema field markers `#[unique]` and
+/// `#[references(...)]` (#1975).
+///
+/// These markers are schema-authoritative for the CLI toolchain (the slice-2
+/// syn parser reads them from source text); the `#[model]` macro only needs to
+/// **accept** them and reject malformed shapes with a clear, actionable error.
+/// No FK/index codegen is produced here — the markers are validated then
+/// stripped by [`user_attrs`], leaving generated code byte-for-byte unchanged.
+///
+/// Accepted shapes (mirroring `autumn-cli`'s `schema::parse`):
+/// - `#[unique]` — a bare marker; any argument (`#[unique(...)]` / `#[unique =
+///   ...]`) is an error.
+/// - `#[references]` — bare; the target table is inferred from the field name.
+/// - `#[references(table = "other_table")]` — an explicit target table.
+fn validate_field_schema_markers(field: &Field) -> syn::Result<()> {
+    for attr in &field.attrs {
+        if attr.path().is_ident("unique") {
+            if !matches!(attr.meta, syn::Meta::Path(_)) {
+                return Err(syn::Error::new_spanned(
+                    attr,
+                    "`#[unique]` takes no arguments; write a bare `#[unique]`",
+                ));
+            }
+        } else if attr.path().is_ident("references") {
+            // Bare `#[references]` is valid (target inferred from field name).
+            if matches!(attr.meta, syn::Meta::Path(_)) {
+                continue;
+            }
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("table") {
+                    let _value: LitStr = meta.value()?.parse()?;
+                    Ok(())
+                } else {
+                    Err(meta.error(
+                        "unsupported `#[references(...)]` argument; expected `table = \"...\"`",
+                    ))
+                }
+            })?;
+        }
+    }
+    Ok(())
 }
 
 /// The three declarative association kinds supported on `#[model]`.
@@ -1362,6 +1434,11 @@ fn user_attrs(field: &Field) -> Vec<&syn::Attribute> {
                 && !a.path().is_ident("private")
                 && !a.path().is_ident("normalize")
                 && !a.path().is_ident("state_machine")
+                // Declarative-schema field markers (#1975). Accepted and
+                // validated, but stripped from the generated query struct so
+                // they never leak onto the Diesel derives; codegen is unchanged.
+                && !a.path().is_ident("unique")
+                && !a.path().is_ident("references")
         })
         .collect()
 }
@@ -3171,7 +3248,9 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let table_name = match parse_attr_args(attr) {
-        Ok(explicit) => explicit.unwrap_or_else(|| infer_table_name(&input.ident)),
+        Ok(model_args) => model_args
+            .table
+            .unwrap_or_else(|| infer_table_name(&input.ident)),
         Err(err) => return err.to_compile_error(),
     };
 
@@ -3214,6 +3293,15 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     // Classify fields
     let all_fields: Vec<&Field> = fields.named.iter().collect();
+
+    // Validate the declarative-schema field markers (#1975) before any codegen,
+    // so a malformed `#[unique]` / `#[references(...)]` yields a single clean
+    // compile error rather than a cascade of downstream failures.
+    for field in &all_fields {
+        if let Err(err) = validate_field_schema_markers(field) {
+            return err.to_compile_error();
+        }
+    }
 
     // Validate that the declared shard_key names an existing field (or "id").
     if let Some(ref key) = shard_key_field {
@@ -7153,6 +7241,156 @@ mod tests {
         // The lock_version attribute must not leak onto the generated Diesel
         // struct — Diesel doesn't know about it and would emit a warning/error.
         assert!(attrs.is_empty());
+    }
+
+    // --- Declarative-schema markers (#1975, slice 3.5) -------------------
+    // Acceptance-only: the `#[model]` macro must ACCEPT `#[model(managed)]`
+    // and the `#[unique]` / `#[references(...)]` field markers, validate their
+    // shapes, strip them from generated code, and change NO codegen behavior.
+
+    #[test]
+    fn model_managed_arg_accepted_by_parse_attr_args() {
+        let args = parse_attr_args(quote! { managed }).expect("`managed` must parse");
+        assert!(
+            args.managed,
+            "`#[model(managed)]` must set the managed flag"
+        );
+        assert!(args.table.is_none());
+    }
+
+    #[test]
+    fn model_managed_and_table_accepted_together() {
+        let args =
+            parse_attr_args(quote! { table = "accounts", managed }).expect("both args must parse");
+        assert!(args.managed);
+        assert_eq!(args.table.as_deref(), Some("accounts"));
+    }
+
+    #[test]
+    fn model_managed_with_value_rejected() {
+        let err = parse_attr_args(quote! { managed = true })
+            .expect_err("`managed = ...` must be rejected");
+        assert!(
+            err.to_string().contains("`managed` takes no value"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn model_unknown_arg_still_rejected() {
+        let err =
+            parse_attr_args(quote! { bogus }).expect_err("an unknown `#[model]` arg must error");
+        assert!(
+            err.to_string()
+                .contains("unsupported `#[model(...)]` argument"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn empty_model_args_default() {
+        let args = parse_attr_args(TokenStream::new()).expect("empty args must parse");
+        assert!(!args.managed);
+        assert!(args.table.is_none());
+    }
+
+    #[test]
+    fn unique_and_references_filtered_from_user_attrs() {
+        let field: syn::Field = syn::parse_quote! {
+            #[unique]
+            #[references(table = "accounts")]
+            pub account_id: i64
+        };
+        let attrs = user_attrs(&field);
+        // Neither marker may leak onto the generated Diesel query struct.
+        assert!(
+            attrs.is_empty(),
+            "`#[unique]` / `#[references]` must be stripped: {attrs:?}",
+            attrs = attrs
+                .iter()
+                .map(|a| quote!(#a).to_string())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn bare_unique_and_references_pass_validation() {
+        let field: syn::Field = syn::parse_quote! {
+            #[unique]
+            #[references]
+            pub account_id: i64
+        };
+        validate_field_schema_markers(&field).expect("bare markers must validate");
+
+        let explicit: syn::Field = syn::parse_quote! {
+            #[references(table = "accounts")]
+            pub account_id: i64
+        };
+        validate_field_schema_markers(&explicit).expect("explicit references must validate");
+    }
+
+    #[test]
+    fn unique_with_args_rejected() {
+        let field: syn::Field = syn::parse_quote! {
+            #[unique(x)]
+            pub account_id: i64
+        };
+        let err =
+            validate_field_schema_markers(&field).expect_err("`#[unique(...)]` must be rejected");
+        assert!(
+            err.to_string().contains("`#[unique]` takes no arguments"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn references_with_bad_key_rejected() {
+        let field: syn::Field = syn::parse_quote! {
+            #[references(bogus = "x")]
+            pub account_id: i64
+        };
+        let err = validate_field_schema_markers(&field)
+            .expect_err("`#[references(bogus = ...)]` must be rejected");
+        assert!(
+            err.to_string()
+                .contains("unsupported `#[references(...)]` argument"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn schema_markers_do_not_change_codegen() {
+        // The generated output for a model that USES the markers must be
+        // identical (modulo the stripped marker attrs) to the same model
+        // WITHOUT them — i.e. the markers contribute nothing to codegen.
+        let with_markers = model_macro(
+            quote! { managed },
+            quote! {
+                pub struct Membership {
+                    #[id]
+                    pub id: i64,
+                    #[unique]
+                    #[references(table = "accounts")]
+                    pub account_id: i64,
+                }
+            },
+        )
+        .to_string();
+        let without_markers = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Membership {
+                    #[id]
+                    pub id: i64,
+                    pub account_id: i64,
+                }
+            },
+        )
+        .to_string();
+        assert_eq!(
+            with_markers, without_markers,
+            "schema markers must not alter generated code"
+        );
     }
 
     #[test]

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -47,9 +47,10 @@ fn parse_attr_args(attr: TokenStream) -> syn::Result<ModelArgs> {
             args.table = Some(value.value());
             Ok(())
         } else if meta.path.is_ident("managed") {
-            // The required form is a bare `managed` path. `managed = <expr>` is
-            // rejected with a clear message rather than silently accepted.
-            if meta.input.peek(syn::Token![=]) {
+            // The required form is a bare `managed` path. Both `managed = <expr>`
+            // and `managed(...)` are rejected with a clear message rather than
+            // falling through to a generic `syn` parser error.
+            if meta.input.peek(syn::Token![=]) || meta.input.peek(syn::token::Paren) {
                 return Err(
                     meta.error("`managed` takes no value; write a bare `#[model(managed)]`")
                 );
@@ -99,6 +100,16 @@ fn validate_field_schema_markers(field: &Field) -> syn::Result<()> {
             // Bare `#[references]` is valid (target inferred from field name).
             if matches!(attr.meta, syn::Meta::Path(_)) {
                 continue;
+            }
+            // Only the list form `#[references(...)]` carries arguments. A
+            // name-value shape like `#[references = "accounts"]` would make
+            // `parse_nested_meta` fail with a generic "expected attribute list"
+            // error, so reject it here with an actionable message.
+            if !matches!(attr.meta, syn::Meta::List(_)) {
+                return Err(syn::Error::new_spanned(
+                    attr,
+                    "`#[references]` must be a bare attribute or have the form `#[references(table = \"...\")]`",
+                ));
             }
             attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("table") {
@@ -7354,6 +7365,53 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("unsupported `#[references(...)]` argument"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn model_managed_with_paren_args_rejected() {
+        // `#[model(managed(foo))]` (parenthesized) must produce our clear
+        // message, not a generic `syn` "expected identifier" parser error.
+        let err =
+            parse_attr_args(quote! { managed(foo) }).expect_err("`managed(...)` must be rejected");
+        assert!(
+            err.to_string().contains("`managed` takes no value"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn references_namevalue_rejected() {
+        // `#[references = "accounts"]` (name-value) must produce our clear
+        // message, not a generic `parse_nested_meta` "expected attribute list"
+        // error.
+        let field: syn::Field = syn::parse_quote! {
+            #[references = "accounts"]
+            pub account_id: i64
+        };
+        let err = validate_field_schema_markers(&field)
+            .expect_err("`#[references = \"...\"]` must be rejected");
+        assert!(
+            err.to_string()
+                .contains("`#[references]` must be a bare attribute"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn unique_namevalue_rejected() {
+        // `#[unique = "x"]` (name-value) is already covered by the existing
+        // Path-only check; assert it yields the clear message rather than a
+        // generic parser error.
+        let field: syn::Field = syn::parse_quote! {
+            #[unique = "x"]
+            pub account_id: i64
+        };
+        let err = validate_field_schema_markers(&field)
+            .expect_err("`#[unique = \"x\"]` must be rejected");
+        assert!(
+            err.to_string().contains("`#[unique]` takes no arguments"),
             "unexpected message: {err}"
         );
     }

--- a/autumn/tests/compile-fail/model_bogus_arg.rs
+++ b/autumn/tests/compile-fail/model_bogus_arg.rs
@@ -1,0 +1,12 @@
+// Compile-fail: an unknown `#[model(...)]` argument is rejected with a clear
+// message (#1975, slice 3.5).
+use autumn_web::model;
+
+#[model(bogus)]
+pub struct Widget {
+    #[id]
+    pub id: i64,
+    pub name: String,
+}
+
+fn main() {}

--- a/autumn/tests/compile-fail/model_bogus_arg.stderr
+++ b/autumn/tests/compile-fail/model_bogus_arg.stderr
@@ -1,0 +1,5 @@
+error: unsupported `#[model(...)]` argument; expected `table = "..."` or `managed`
+ --> tests/compile-fail/model_bogus_arg.rs:5:9
+  |
+5 | #[model(bogus)]
+  |         ^^^^^

--- a/autumn/tests/compile-fail/model_managed_with_args.rs
+++ b/autumn/tests/compile-fail/model_managed_with_args.rs
@@ -1,0 +1,13 @@
+// Compile-fail: `#[model(managed)]` is a bare marker; a parenthesized
+// `managed(...)` shape is rejected with a clear message rather than a generic
+// parser error (#1975, slice 3.5).
+use autumn_web::model;
+
+#[model(managed(foo))]
+pub struct Widget {
+    #[id]
+    pub id: i64,
+    pub name: String,
+}
+
+fn main() {}

--- a/autumn/tests/compile-fail/model_managed_with_args.stderr
+++ b/autumn/tests/compile-fail/model_managed_with_args.stderr
@@ -1,0 +1,5 @@
+error: `managed` takes no value; write a bare `#[model(managed)]`
+ --> tests/compile-fail/model_managed_with_args.rs:6:9
+  |
+6 | #[model(managed(foo))]
+  |         ^^^^^^^

--- a/autumn/tests/compile-fail/model_references_bad_key.rs
+++ b/autumn/tests/compile-fail/model_references_bad_key.rs
@@ -1,0 +1,12 @@
+// Compile-fail: `#[references(...)]` accepts only `table = "..."` (#1975).
+use autumn_web::model;
+
+#[model]
+pub struct Widget {
+    #[id]
+    pub id: i64,
+    #[references(bogus = "x")]
+    pub account_id: i64,
+}
+
+fn main() {}

--- a/autumn/tests/compile-fail/model_references_bad_key.stderr
+++ b/autumn/tests/compile-fail/model_references_bad_key.stderr
@@ -1,0 +1,5 @@
+error: unsupported `#[references(...)]` argument; expected `table = "..."`
+ --> tests/compile-fail/model_references_bad_key.rs:8:18
+  |
+8 |     #[references(bogus = "x")]
+  |                  ^^^^^

--- a/autumn/tests/compile-fail/model_references_namevalue.rs
+++ b/autumn/tests/compile-fail/model_references_namevalue.rs
@@ -1,0 +1,15 @@
+// Compile-fail: `#[references]` is either a bare marker or the list form
+// `#[references(table = "...")]`; a name-value `#[references = "..."]` shape is
+// rejected with a clear message rather than a generic parser error (#1975,
+// slice 3.5).
+use autumn_web::model;
+
+#[model]
+pub struct Widget {
+    #[id]
+    pub id: i64,
+    #[references = "accounts"]
+    pub account_id: i64,
+}
+
+fn main() {}

--- a/autumn/tests/compile-fail/model_references_namevalue.stderr
+++ b/autumn/tests/compile-fail/model_references_namevalue.stderr
@@ -1,0 +1,5 @@
+error: `#[references]` must be a bare attribute or have the form `#[references(table = "...")]`
+  --> tests/compile-fail/model_references_namevalue.rs:11:5
+   |
+11 |     #[references = "accounts"]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/autumn/tests/compile-fail/model_unique_with_args.rs
+++ b/autumn/tests/compile-fail/model_unique_with_args.rs
@@ -1,0 +1,12 @@
+// Compile-fail: `#[unique]` is a bare marker and takes no arguments (#1975).
+use autumn_web::model;
+
+#[model]
+pub struct Widget {
+    #[id]
+    pub id: i64,
+    #[unique(x)]
+    pub slug: String,
+}
+
+fn main() {}

--- a/autumn/tests/compile-fail/model_unique_with_args.stderr
+++ b/autumn/tests/compile-fail/model_unique_with_args.stderr
@@ -1,0 +1,5 @@
+error: `#[unique]` takes no arguments; write a bare `#[unique]`
+ --> tests/compile-fail/model_unique_with_args.rs:8:5
+  |
+8 |     #[unique(x)]
+  |     ^^^^^^^^^^^^

--- a/autumn/tests/compile-pass/model_schema_markers.rs
+++ b/autumn/tests/compile-pass/model_schema_markers.rs
@@ -1,0 +1,59 @@
+// Compile-pass: declarative-schema markers on a model (#1975, slice 3.5).
+//
+// Acceptance-only: `#[model(managed)]`, `#[unique]`, and `#[references(...)]`
+// (both the explicit `table = "..."` form and the bare, inferred form) must be
+// ACCEPTED and validated by the `#[model]` macro, stripped from the generated
+// query struct, and change NO codegen — the model still generates its normal
+// New*/Update* types over the Diesel table below.
+
+mod schema {
+    autumn_web::reexports::diesel::table! {
+        memberships (id) {
+            id -> Int8,
+            slug -> Text,
+            account_id -> Int8,
+            team_id -> Int8,
+        }
+    }
+}
+
+use schema::memberships;
+
+#[autumn_web::model(managed)]
+pub struct Membership {
+    #[id]
+    pub id: i64,
+    #[unique]
+    pub slug: String,
+    #[references(table = "accounts")]
+    pub account_id: i64,
+    // Bare `#[references]` — the target table is inferred from the field name
+    // by the CLI toolchain; the macro simply accepts and strips it.
+    #[references]
+    pub team_id: i64,
+}
+
+fn build() {
+    // The markers must not touch the generated write types: NewMembership still
+    // carries the plain user columns.
+    let _new = NewMembership {
+        slug: "acme".to_string(),
+        account_id: 1,
+        team_id: 2,
+    };
+    let _update = UpdateMembership {
+        slug: autumn_web::hooks::Patch::Set("beta".to_string()),
+        account_id: autumn_web::hooks::Patch::Unchanged,
+        team_id: autumn_web::hooks::Patch::Unchanged,
+    };
+    let _row = Membership {
+        id: 1,
+        slug: "acme".to_string(),
+        account_id: 1,
+        team_id: 2,
+    };
+}
+
+fn main() {
+    build();
+}

--- a/autumn/tests/integration/compile_fail.rs
+++ b/autumn/tests/integration/compile_fail.rs
@@ -39,6 +39,16 @@ fn compile_fail_tests() {
     #[cfg(feature = "db")]
     t.compile_fail("tests/compile-fail/model_m2m_helper_collision.rs");
 
+    // Declarative-schema markers (#1975, slice 3.5): the `#[model]` macro
+    // ACCEPTS `#[model(managed)]` / `#[unique]` / `#[references(...)]` but
+    // rejects malformed shapes with a clear, actionable `compile_error!`.
+    #[cfg(feature = "db")]
+    t.compile_fail("tests/compile-fail/model_bogus_arg.rs");
+    #[cfg(feature = "db")]
+    t.compile_fail("tests/compile-fail/model_unique_with_args.rs");
+    #[cfg(feature = "db")]
+    t.compile_fail("tests/compile-fail/model_references_bad_key.rs");
+
     // #1911: `#[state_machine(lifecycle = T)]` where `T` is not a `#[lifecycle]`
     // enum fails with an unsatisfied `T: Lifecycle` trait bound.
     #[cfg(feature = "db")]
@@ -124,6 +134,12 @@ fn compile_pass_tests() {
     // Model derive (requires db feature)
     #[cfg(feature = "db")]
     t.pass("tests/compile-pass/model_derive.rs");
+
+    // Declarative-schema markers (#1975, slice 3.5): `#[model(managed)]`,
+    // `#[unique]`, and `#[references(...)]` are accepted, validated, and
+    // stripped — the model still generates its normal write types.
+    #[cfg(feature = "db")]
+    t.pass("tests/compile-pass/model_schema_markers.rs");
 
     // Model field enum (requires db feature)
     #[cfg(feature = "db")]

--- a/autumn/tests/integration/compile_fail.rs
+++ b/autumn/tests/integration/compile_fail.rs
@@ -45,9 +45,13 @@ fn compile_fail_tests() {
     #[cfg(feature = "db")]
     t.compile_fail("tests/compile-fail/model_bogus_arg.rs");
     #[cfg(feature = "db")]
+    t.compile_fail("tests/compile-fail/model_managed_with_args.rs");
+    #[cfg(feature = "db")]
     t.compile_fail("tests/compile-fail/model_unique_with_args.rs");
     #[cfg(feature = "db")]
     t.compile_fail("tests/compile-fail/model_references_bad_key.rs");
+    #[cfg(feature = "db")]
+    t.compile_fail("tests/compile-fail/model_references_namevalue.rs");
 
     // #1911: `#[state_machine(lifecycle = T)]` where `T` is not a `#[lifecycle]`
     // enum fails with an unsatisfied `T: Lifecycle` trait bound.


### PR DESCRIPTION
## What

An **acceptance-only** change to the `#[model]` proc-macro: it now accepts the new declarative-schema markers, validates their shapes with clear compile errors, and changes **no codegen behavior**. The markers are schema-authoritative for the CLI toolchain only (the slice-2 syn parser already reads them from source text); the macro simply stops rejecting them.

## Before / After (plain language)

**Before:** a model annotated with `#[model(managed)]`, or with `#[unique]` / `#[references(...)]` fields, fails to compile — `#[model(managed)]` hits `unsupported model attribute`, and `#[unique]` / `#[references]` leak onto the generated Diesel query struct and break its derives.

**After:** such a model compiles. The markers are validated (with a clear, actionable `compile_error!` on a malformed shape) and then dropped — they contribute nothing to the generated model struct, query struct, Diesel derives, or migrations. For any model that does *not* use the markers, generated output is byte-for-byte identical.

## How

Two macro sites plus validation:

1. **Model arg** — `parse_attr_args` now returns `ModelArgs { table, managed }` and accepts a bare `#[model(managed)]` path in addition to `table = "..."`. `managed = ...` and any other unknown argument are rejected with `unsupported #[model(...)] argument; expected table = "..." or managed`. The `managed` flag is captured but wired to nothing (codegen opt-in lands in a later slice).
2. **Field markers** — a new `validate_field_schema_markers` runs before any codegen and validates `#[unique]` (bare marker; arguments rejected) and `#[references]` (bare, or `#[references(table = "...")]`; unknown keys rejected), mirroring the accepted forms in `autumn-cli`'s `schema::parse`. Because it early-returns only the `compile_error!`, a bad marker yields a single clean error, not a cascade. Both `unique` and `references` are added to the `user_attrs` strip list so they never reach the Diesel derives.

**Tests:** inline `autumn-macros` unit tests cover the parse/validate accept + reject paths and assert codegen equality with/without the markers; trybuild fixtures in `autumn-web` cover an end-to-end accept case (`model_schema_markers.rs`) and the three clear-error cases (`model_bogus_arg`, `model_unique_with_args`, `model_references_bad_key`). The three error goldens contain only our own `compile_error!` text (single error block each), so they are stable across rustc toolchains.

Part of #1975.