### PR TITLE
sqlite: repository CRUD foundation — RETURNING flag + RuntimeConnection threading (#1996)

### DIFF
--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -87,7 +87,7 @@ offline-sync = ["db", "http-client"]
 # (`PoolError::UnsupportedBackend`); a working pool is PR2. Needs no extra deps
 # — diesel's sqlite backend and diesel-async's sync-connection-wrapper are
 # already in the graph.
-sqlite = ["diesel/sqlite", "diesel-async/sync-connection-wrapper"]
+sqlite = ["diesel/sqlite", "diesel/returning_clauses_for_sqlite_3_35", "diesel-async/sync-connection-wrapper"]
 test-support = ["dep:testcontainers", "dep:testcontainers-modules"]
 telemetry-otlp = [
     "dep:opentelemetry",

--- a/autumn/src/repository.rs
+++ b/autumn/src/repository.rs
@@ -180,8 +180,8 @@ pub type RuntimeDependentCascadeFuture<'a> = ::std::pin::Pin<
 /// All references share one lifetime so the returned future can borrow the
 /// connection and all three guard sets for exactly as long as it is awaited.
 pub type RuntimeDependentCascadeFn = for<'a> fn(
-    &'a ::diesel_async::pooled_connection::deadpool::Pool<::diesel_async::AsyncPgConnection>,
-    &'a mut ::diesel_async::AsyncPgConnection,
+    &'a ::diesel_async::pooled_connection::deadpool::Pool<crate::db::RuntimeConnection>,
+    &'a mut crate::db::RuntimeConnection,
     i64,
     bool,
     &'a mut ::std::collections::HashSet<(&'static str, i64)>,
@@ -360,7 +360,7 @@ pub trait AutumnUpsertExecutionExt {
     fn __autumn_execute_upsert<'a>(
         chunk: &'a [Self::Model],
         tenant_id: ::core::option::Option<&'a str>,
-        conn: &'a mut ::diesel_async::AsyncPgConnection,
+        conn: &'a mut crate::db::RuntimeConnection,
     ) -> impl ::std::future::Future<
         Output = ::core::result::Result<::std::vec::Vec<Self::Model>, ::diesel::result::Error>,
     > + Send
@@ -420,7 +420,7 @@ pub trait M2mConnSource: Send + Sync {
         &self,
     ) -> impl ::std::future::Future<
         Output = crate::AutumnResult<
-            diesel_async::pooled_connection::deadpool::Object<diesel_async::AsyncPgConnection>,
+            diesel_async::pooled_connection::deadpool::Object<crate::db::RuntimeConnection>,
         >,
     > + Send;
 }


### PR DESCRIPTION
## What

Foundation groundwork toward SQLite-backed `#[repository]` CRUD (issue #1996, Wave A).

**Before** — under `--features sqlite`, the generic CRUD support code in `autumn/src/repository.rs` hardcodes the Postgres connection type (`AsyncPgConnection`), and diesel's SQLite `RETURNING` support is left disabled, so the connection types in these definitions don't match the backend-agnostic types the `#[repository]` macro generates.

**After** — the `sqlite` cargo feature enables diesel's `returning_clauses_for_sqlite_3_35` (the runtime requirement is already satisfied by the bundled SQLite 3.51.3), and three backend-agnostic CRUD definitions use `crate::db::RuntimeConnection` instead of `AsyncPgConnection`, matching the macro-generated impls. Both the sqlite-feature library build and the default Postgres build compile clean.

## How

- **Cargo feature line** (`autumn/Cargo.toml`): `sqlite = ["diesel/sqlite", "diesel/returning_clauses_for_sqlite_3_35", "diesel-async/sync-connection-wrapper"]` — adds the `returning_clauses_for_sqlite_3_35` flag so diesel emits `RETURNING` clauses for SQLite.
- **Three threaded signatures** (`autumn/src/repository.rs`), each moved from `AsyncPgConnection` to `crate::db::RuntimeConnection`:
  - `RuntimeDependentCascadeFn` — both the `Pool<…>` and the `&mut` connection parameters.
  - `AutumnUpsertExecutionExt::__autumn_execute_upsert` — the `conn` parameter.
  - `M2mConnSource::__autumn_m2m_write_conn` — the returned `Object<…>`.

## Scope / not yet

This PR is **foundation only** and intentionally ships **no functional CRUD change and no test**. A full `#[repository]`'s generated CRUD still cannot compile under `--features sqlite`, because it emits:

- `.for_update()` (no SQLite equivalent — needs removal under the sqlite dialect),
- an always-present `on_conflict` upsert (needs the SQLite upsert dialect),
- Postgres batch-insert fragments (need the SQLite batch-insert dialect),

and two more files — `autumn/src/repository_commit_hooks.rs` and `autumn/src/preload.rs` — still hardcode the Pg connection type. Those are the follow-up waves for #1996. This PR is the necessary groundwork that unblocks them.

Relates to #1996.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxTssPbKEhZ99r8NDTdvUq)_