### PR TITLE
Add sync on transition effects to #[state_machine] (#1973)

### DIFF
--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -2663,6 +2663,11 @@ struct StateMachineTransition {
     /// meaningful for inline `transitions(...)` machines — lifecycle-derived
     /// tables carry no effects.
     on_commit: Option<syn::Path>,
+    /// Optional sync in-transaction effect (issue #1973): the name of an
+    /// `async fn(&self, conn) -> AutumnResult<()>` method run inside the
+    /// transition's transaction when this edge fires. `Err` rolls the
+    /// transition back (mirrors `before_*` mutation hooks). Inline-only.
+    on: Option<String>,
 }
 
 /// The declared source of a field's transition table: either an inline
@@ -2703,10 +2708,12 @@ fn validate_guard_ident(lit: &syn::LitStr) -> syn::Result<String> {
 ///
 /// Each edge is `From -> To` with an optional per-edge suffix after `:`:
 /// - the legacy bare-string guard shorthand `From -> To: "guard"`, or
-/// - a `key = value` meta list `From -> To: guard = "guard", on_commit = Job`
-///   (issue #1973), where `guard` names a `&self -> bool` method and
+/// - a `key = value` meta list `From -> To: guard = "guard", on = "handler",
+///   on_commit = Job` (issue #1973), where `guard` names a `&self -> bool`
+///   method, `on` names an `async fn(&self, conn) -> AutumnResult<()>` method
+///   run in the transition's transaction (`Err` rolls it back), and
 ///   `on_commit` names a `#[job]` struct to enqueue transactionally when the
-///   edge fires. Keys may appear in either order and are each optional.
+///   edge fires. Keys may appear in any order and are each optional.
 fn parse_transition_list(
     content: syn::parse::ParseStream<'_>,
 ) -> syn::Result<Vec<StateMachineTransition>> {
@@ -2717,6 +2724,7 @@ fn parse_transition_list(
         let to: syn::Ident = content.parse()?;
         let mut guard: Option<String> = None;
         let mut on_commit: Option<syn::Path> = None;
+        let mut on: Option<String> = None;
         if content.peek(syn::Token![:]) {
             content.parse::<syn::Token![:]>()?;
             if content.peek(syn::LitStr) {
@@ -2745,10 +2753,19 @@ fn parse_transition_list(
                             ));
                         }
                         on_commit = Some(content.parse::<syn::Path>()?);
+                    } else if key == "on" {
+                        if on.is_some() {
+                            return Err(syn::Error::new_spanned(
+                                &key,
+                                "duplicate `on` on a single transition",
+                            ));
+                        }
+                        let lit: syn::LitStr = content.parse()?;
+                        on = Some(validate_guard_ident(&lit)?);
                     } else {
                         return Err(syn::Error::new_spanned(
                             &key,
-                            "expected `guard = \"...\"` or `on_commit = <Job>`",
+                            "expected `guard = \"...\"`, `on = \"...\"`, or `on_commit = <Job>`",
                         ));
                     }
                     // Continue the meta list only when a `, <ident> =` follows
@@ -2773,6 +2790,7 @@ fn parse_transition_list(
             to: to.to_string(),
             guard,
             on_commit,
+            on,
         });
         if content.peek(syn::Token![,]) {
             content.parse::<syn::Token![,]>()?;
@@ -2991,18 +3009,21 @@ fn emit_state_machine_inline(
 }
 
 /// Emit the connection-taking `transition_{field}_to_on_conn` method for an
-/// inline state machine that declares one or more `on_commit` effects (issue
-/// #1973). Returns an empty token stream when no edge names a job, so machines
-/// without effects generate exactly the pre-existing items.
+/// inline state machine that declares one or more per-edge effects — a sync
+/// `on = "handler"` and/or an `on_commit = <Job>` (issue #1973). Returns an
+/// empty token stream when no edge declares an effect, so machines without
+/// effects generate exactly the pre-existing items.
 ///
 /// The generated method: (1) validates the transition via the pure
 /// `transition_{field}_to` (returning its `Err` unchanged when the edge is
 /// disallowed or a guard rejects it), (2) for the specific fired `(from, to)`
-/// edge that carries an `on_commit` job, enqueues that job **transactionally**
-/// on `conn` (so a rollback drops it) with a [`TransitionEffect`] payload whose
-/// `idempotency_key` is derived from `(model, field, record_id, from, to)`, and
-/// (3) returns the new state string for the caller to persist — mirroring the
-/// explicit-call contract of `transition_{field}_to`.
+/// edge, first runs its declared sync `on` handler on `conn` inside the
+/// transaction (an `Err` propagates out, rolling the transition back), then
+/// enqueues its `on_commit` job **transactionally** on `conn` (so a rollback
+/// drops it) with a [`TransitionEffect`] payload whose `idempotency_key` is
+/// derived from `(model, field, record_id, from, to)`, and (3) returns the new
+/// state string for the caller to persist — mirroring the explicit-call
+/// contract of `transition_{field}_to`.
 fn emit_state_machine_on_conn(
     model_name: &syn::Ident,
     field: &syn::Ident,
@@ -3011,7 +3032,9 @@ fn emit_state_machine_on_conn(
     transitions: &[StateMachineTransition],
     pk_ident: Option<&syn::Ident>,
 ) -> TokenStream {
-    let has_effects = transitions.iter().any(|t| t.on_commit.is_some());
+    let has_effects = transitions
+        .iter()
+        .any(|t| t.on_commit.is_some() || t.on.is_some());
     if !has_effects {
         return TokenStream::new();
     }
@@ -3031,11 +3054,20 @@ fn emit_state_machine_on_conn(
     let effect_arms: Vec<TokenStream> = transitions
         .iter()
         .filter_map(|t| {
-            let job = t.on_commit.as_ref()?;
+            if t.on.is_none() && t.on_commit.is_none() {
+                return None;
+            }
             let from = &t.from;
             let to = &t.to;
-            Some(quote! {
-                (#from, #to) => {
+            // Sync in-transaction effect: runs first; `?` rolls the transition
+            // back (mirrors a failing `before_*` mutation hook).
+            let sync_effect = t.on.as_ref().map(|name| {
+                let handler = format_ident!("{name}");
+                quote! { self.#handler(conn).await?; }
+            });
+            // After-commit effect: enqueued transactionally, dispatched post-commit.
+            let commit_effect = t.on_commit.as_ref().map(|job| {
+                quote! {
                     let __record_id: ::std::string::String = #record_id_expr;
                     let __idempotency_key = ::std::format!(
                         "{}:{}:{}:{}:{}",
@@ -3055,17 +3087,25 @@ fn emit_state_machine_on_conn(
                         conn,
                     ).await?;
                 }
+            });
+            Some(quote! {
+                (#from, #to) => {
+                    #sync_effect
+                    #commit_effect
+                }
             })
         })
         .collect();
 
     quote! {
         impl #model_name {
-            /// Validates a `{field}` transition and, for an edge declaring
-            /// `on_commit = <Job>`, enqueues that job transactionally on `conn`
-            /// so it runs after the surrounding transaction commits
-            /// (issue #1973). Returns the new state value for the caller to
-            /// persist; the enqueue rolls back with the caller's transaction.
+            /// Validates a `{field}` transition and, for the fired edge, runs
+            /// its declared effects on `conn` (issue #1973): first a sync
+            /// `on = "handler"` method inside the transaction (an `Err` rolls
+            /// the transition back), then an `on_commit = <Job>` enqueue that
+            /// runs after the surrounding transaction commits. Returns the new
+            /// state value for the caller to persist; both effects roll back
+            /// with the caller's transaction.
             pub async fn #on_conn_fn(
                 &self,
                 conn: &mut ::autumn_web::reexports::diesel_async::AsyncPgConnection,
@@ -8001,6 +8041,170 @@ mod tests {
         assert!(
             generated.contains("compile_error") && generated.contains("on_commit = <Job>"),
             "an unknown per-edge meta key must emit a compile error: {generated}"
+        );
+        // The refreshed unknown-key message now also advertises `on = "..."`.
+        assert!(
+            generated.contains("`on = "),
+            "the unknown per-edge meta key error must mention `on = \"...\"`: {generated}"
+        );
+    }
+
+    // ── sync `on = "handler"` transition effects (#1973) ──────────────────────
+
+    #[test]
+    fn state_machine_on_sync_effect_emits_on_conn_method() {
+        // An edge with a sync `on = "handler"` emits the connection-taking
+        // method whose fired-edge arm calls `self.<handler>(conn).await?`.
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(transitions(
+                        pending -> processing,
+                        processing -> shipped: on = "record_audit",
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("transition_status_to_on_conn"),
+            "an `on` edge must emit the connection-taking method: {generated}"
+        );
+        assert!(
+            generated.contains("AsyncPgConnection"),
+            "the `_on_conn` method must take a connection: {generated}"
+        );
+        // The sync effect calls the named `&self` handler with the connection.
+        assert!(
+            generated.contains("self . record_audit (conn) . await ?"),
+            "the `on` edge must call its handler in-transaction: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_on_sync_effect_only_does_not_enqueue() {
+        // An `on`-only machine (no `on_commit` anywhere) emits the method but no
+        // after-commit enqueue/`TransitionEffect` codegen.
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(transitions(
+                        processing -> shipped: on = "record_audit",
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("transition_status_to_on_conn"),
+            "an `on` edge must still emit the connection-taking method: {generated}"
+        );
+        assert!(
+            !generated.contains("enqueue_on_conn") && !generated.contains("TransitionEffect"),
+            "an `on`-only machine must not emit after-commit effect codegen: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_on_and_on_commit_compose_on_one_edge() {
+        // A single edge with both `on` and `on_commit` emits both effects, with
+        // the sync handler call ordered BEFORE the after-commit enqueue.
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(transitions(
+                        processing -> shipped: on = "record_audit", on_commit = SendShippedEmailJob,
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        let sync_at = generated
+            .find("self . record_audit (conn) . await ?")
+            .expect("sync handler call must be emitted");
+        let commit_at = generated
+            .find("enqueue_on_conn")
+            .expect("on_commit enqueue must be emitted");
+        assert!(
+            sync_at < commit_at,
+            "the sync `on` handler must run before the `on_commit` enqueue: {generated}"
+        );
+        assert!(
+            generated.contains("< SendShippedEmailJob > :: NAME"),
+            "the composed edge must enqueue its on_commit job: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_guard_and_on_and_on_commit_compose() {
+        // Guard + sync `on` + `on_commit` on one edge: the guard stays in the
+        // const table and `can_*` dispatch; both effects emit.
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Article {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(transitions(
+                        draft -> published,
+                        published -> archived: guard = "can_archive", on = "audit", on_commit = AnnounceArchiveJob,
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        // Guard remains in the transition table and `can_*` dispatch.
+        assert!(
+            generated.contains("Some (\"can_archive\")"),
+            "guard must remain in the transition table when composed: {generated}"
+        );
+        assert!(
+            generated.contains("self . can_archive ()"),
+            "guarded edge must still call the guard in `can_transition_*`: {generated}"
+        );
+        // Both effects emit on the composed edge.
+        assert!(
+            generated.contains("self . audit (conn) . await ?"),
+            "the composed edge must run its sync `on` handler: {generated}"
+        );
+        assert!(
+            generated.contains("< AnnounceArchiveJob > :: NAME"),
+            "the composed edge must enqueue its on_commit job: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_duplicate_on_is_rejected() {
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(transitions(
+                        processing -> shipped: on = "a", on = "b",
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("compile_error") && generated.contains("duplicate `on`"),
+            "a duplicate `on` on one edge must emit a compile error: {generated}"
         );
     }
 

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -493,6 +493,14 @@ path = "tests/state_machine_lifecycle.rs"
 name = "state_machine_on_commit"
 path = "tests/state_machine_on_commit.rs"
 
+# Issue #1973: sync `on = "handler"` in-transaction transition effect — pure
+# validation + compile-time type-check of the generated connection-taking
+# method. No DB connection, runs without Docker. Isolated so it is cheap to
+# compile/run alone.
+[[test]]
+name = "state_machine_on"
+path = "tests/state_machine_on.rs"
+
 [[test]]
 name = "repository_shard_replica_routing"
 path = "tests/repository_shard_replica_routing.rs"

--- a/autumn/tests/compile-pass/model_state_machine_on.rs
+++ b/autumn/tests/compile-pass/model_state_machine_on.rs
@@ -1,0 +1,80 @@
+//! Issue #1973: a `#[state_machine(transitions(...))]` edge can declare a sync
+//! `on = "handler"` in-transaction effect — an inherent
+//! `async fn(&self, conn) -> AutumnResult<()>` method run inside the
+//! transition's transaction when that edge fires (`Err` rolls it back).
+//! Declaring `on` (like `on_commit`) makes the model gain the connection-taking
+//! `transition_{field}_to_on_conn` method. `on` composes with `guard` and
+//! `on_commit` on one edge. This is the compile-pass companion to the pure
+//! `model_state_machine.rs` case.
+
+use autumn_web::model;
+use autumn_web::prelude::*;
+use autumn_web::reexports::diesel_async::AsyncPgConnection;
+use serde::{Deserialize, Serialize};
+
+// A `#[job]` whose args are the framework-provided transition context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EffectArgs {
+    idempotency_key: String,
+}
+
+#[job(name = "announce_archive")]
+async fn announce_archive(_state: AppState, _args: EffectArgs) -> AutumnResult<()> {
+    Ok(())
+}
+
+diesel::table! {
+    orders (id) {
+        id -> BigInt,
+        status -> Text,
+    }
+}
+
+#[model(table = "orders")]
+pub struct Order {
+    #[id]
+    pub id: i64,
+    #[state_machine(transitions(
+        pending -> processing,
+        // A pure sync in-transaction effect.
+        processing -> shipped: on = "record_audit",
+        // Guard + sync `on` + after-commit `on_commit` compose on one edge.
+        shipped -> archived: guard = "can_archive", on = "record_audit", on_commit = AnnounceArchiveJob,
+    ))]
+    pub status: String,
+}
+
+impl Order {
+    fn can_archive(&self) -> bool {
+        true
+    }
+
+    // The sync in-transaction effect runs inside the transition's transaction;
+    // a returned `Err` rolls the transition back.
+    async fn record_audit(&self, _conn: &mut AsyncPgConnection) -> AutumnResult<()> {
+        Ok(())
+    }
+}
+
+// The pure validator is unchanged and still generated.
+fn _assert_pure_validator_compiles(order: &Order) {
+    let _ = order.can_transition_status_to("processing");
+    let _ = order.transition_status_to("processing");
+}
+
+// The additive connection-taking method is generated because at least one edge
+// declares an effect (`on` and/or `on_commit`). It takes an explicit connection
+// so the sync `on` handler and the `on_commit` enqueue both run inside the
+// caller's transaction.
+async fn _assert_on_conn_compiles(
+    order: &Order,
+    conn: &mut AsyncPgConnection,
+) -> AutumnResult<String> {
+    order.transition_status_to_on_conn(conn, "shipped").await
+}
+
+fn main() {
+    let _ = _assert_pure_validator_compiles;
+    let _ = _assert_on_conn_compiles;
+    let _ = announce_archive;
+}

--- a/autumn/tests/integration/compile_fail.rs
+++ b/autumn/tests/integration/compile_fail.rs
@@ -220,6 +220,11 @@ fn compile_pass_tests() {
     #[cfg(feature = "db")]
     t.pass("tests/compile-pass/model_state_machine_on_commit.rs");
 
+    // #1973: a sync `on = "handler"` edge also emits the connection-taking
+    // method; `on` composes with `guard` and `on_commit` on one edge.
+    #[cfg(feature = "db")]
+    t.pass("tests/compile-pass/model_state_machine_on.rs");
+
     // Soft delete (requires db feature)
     #[cfg(feature = "db")]
     t.pass("tests/compile-pass/repository_soft_delete.rs");

--- a/autumn/tests/state_machine_on.rs
+++ b/autumn/tests/state_machine_on.rs
@@ -1,0 +1,111 @@
+//! Issue #1973: a `#[state_machine(transitions(...))]` edge can declare a sync
+//! `on = "handler"` in-transaction effect. `handler` is an inherent
+//! `async fn(&self, conn) -> AutumnResult<()>` method run inside the
+//! transition's transaction when that edge fires; a returned `Err` rolls the
+//! transition back. Declaring `on` (like `on_commit`) makes the model generate
+//! the connection-taking `transition_{field}_to_on_conn` method. `on` composes
+//! with `guard` and `on_commit` on a single edge.
+//!
+//! This is a lightweight compilation + pure-validation contract test that runs
+//! WITHOUT Docker (it never opens a connection): it constructs models by hand
+//! and calls the generated pure validators, and references the connection-taking
+//! method behind a never-called async fn so the generated effect codegen is
+//! type-checked. Run it standalone with:
+//!
+//! ```text
+//! cargo test -p autumn-web --test state_machine_on
+//! ```
+
+#![cfg(feature = "db")]
+
+use autumn_web::model;
+use autumn_web::prelude::*;
+use autumn_web::reexports::diesel_async::AsyncPgConnection;
+use serde::{Deserialize, Serialize};
+
+// The framework-provided transition context is this job's args. The derived
+// idempotency key rides on the payload, so declaring the job
+// `unique, by = ["idempotency_key"]` coalesces a retried transition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EffectArgs {
+    idempotency_key: String,
+}
+
+#[job(name = "on_sync_announce_archive")]
+#[allow(clippy::unused_async)] // stub handler: no real work in this codegen test
+async fn announce_archive(_state: AppState, _args: EffectArgs) -> AutumnResult<()> {
+    Ok(())
+}
+
+diesel::table! {
+    on_sync_orders (id) {
+        id -> BigInt,
+        status -> Text,
+    }
+}
+
+#[model(table = "on_sync_orders")]
+pub struct Order {
+    #[id]
+    pub id: i64,
+    #[state_machine(transitions(
+        pending -> processing,
+        // A pure sync in-transaction effect.
+        processing -> shipped: on = "record_audit",
+        // Guard + sync `on` + after-commit `on_commit` compose on one edge.
+        shipped -> archived: guard = "can_archive", on = "record_audit", on_commit = AnnounceArchiveJob,
+    ))]
+    pub status: String,
+}
+
+impl Order {
+    // A stub guard for the codegen test; real guards do non-trivial work.
+    #[allow(clippy::missing_const_for_fn)]
+    fn can_archive(&self) -> bool {
+        !self.status.is_empty()
+    }
+
+    // The sync in-transaction effect: runs inside the transition's transaction,
+    // and `Err` rolls the transition back. A no-op stub here.
+    #[allow(clippy::unused_async)] // stub handler: no real work in this codegen test
+    async fn record_audit(&self, _conn: &mut AsyncPgConnection) -> AutumnResult<()> {
+        Ok(())
+    }
+}
+
+fn order(status: &str) -> Order {
+    Order {
+        id: 7,
+        status: status.to_string(),
+    }
+}
+
+// The pure validator is byte-for-byte unchanged by adding `on`.
+#[test]
+fn pure_validator_still_governs_allowed_edges() {
+    assert!(order("pending").can_transition_status_to("processing"));
+    assert!(order("processing").can_transition_status_to("shipped"));
+    // The guard on the composed edge is still honoured.
+    assert!(order("shipped").can_transition_status_to("archived"));
+    // Undeclared edges remain denied.
+    assert!(!order("pending").can_transition_status_to("shipped"));
+    assert!(order("pending").transition_status_to("shipped").is_err());
+    assert_eq!(
+        order("processing")
+            .transition_status_to("shipped")
+            .expect("declared edge"),
+        "shipped"
+    );
+}
+
+// Compilation contract: the additive connection-taking method exists, takes a
+// connection, and returns the new state. Never called (no runtime/DB here) — its
+// mere existence type-checks the composed sync `on` + `on_commit` effect codegen
+// end to end.
+#[allow(dead_code)]
+async fn _assert_on_conn_signature(
+    order: &Order,
+    conn: &mut AsyncPgConnection,
+) -> AutumnResult<String> {
+    order.transition_status_to_on_conn(conn, "shipped").await
+}


### PR DESCRIPTION
Part of #1973 (wave 2, slice PR1).

## Before / After
Before: a `#[state_machine]` edge could reject a transition (`guard = "..."`) and enqueue an after-commit job (`on_commit = <Job>`, wave-1 #1995), but had no way to run work *in the same transaction* as the state change — write an outbox row, bump a counter, append an audit record — such that a failure rolls the transition back.

After: an edge may declare `on = "handler"`:

    #[state_machine(transitions(
        Processing -> Shipped: on = "record_shipment",
        Shipped -> Archived: guard = "can_archive", on = "audit", on_commit = <AnnounceArchiveJob>,
    ))]

`handler` is an inherent async method `async fn handler(&self, conn: &mut AsyncPgConnection) -> AutumnResult<()>` that runs inside the transition's transaction. Returning `Err` propagates out of `transition_{field}_to_on_conn` and rolls the whole transition back — mirroring how a failing `before_update` aborts a write. `on` composes with `guard` and `on_commit` on one edge.

## Handler-signature decision (the open question the spec left)
Chosen: a string-named `&self` async method taking the connection. Rationale:
- Mirrors the existing per-edge `guard = "..."` surface (both name `&self` methods on the model), so guards and sync effects read consistently. `on_commit` takes a `<Job>` path because a job is a distinct type; a sync effect is model logic like a guard, so a method name is the natural fit.
- Async + `&mut AsyncPgConnection` generalizes the guard's `&self -> bool` for effects that must *do* in-transaction work. Guards *decide*; effects *act*.
- Runs in-transaction, rollback-on-`Err`: the `on : before_* :: on_commit : after_*_commit` correspondence.
- Single `on` per edge (mirrors wave-1's single `on_commit`); duplicate `on` is a compile error. Widening to multiple effects is deferred.
- The edge is statically known per handler; a richer edge-context param is documented future work.

## How
- `autumn-macros/src/model.rs`: `StateMachineTransition` gains `on: Option<String>`; `parse_transition_list` accepts the `on = "..."` meta key (duplicate + unknown-key are compile errors); `emit_state_machine_on_conn` emits the sync `self.handler(conn).await?` call before any `on_commit` enqueue in the same match arm, and `has_effects` now triggers on `on` too. The pure validator, const table, `can_`/`transition_` methods, and `TransitionEffect` are unchanged; runtime crate untouched.

## Tests
- Macro unit tests (string-assertion) for `on` emission, on-only-no-enqueue, on+on_commit ordering, guard+on+on_commit composition, duplicate-`on` rejection, unknown-key message.
- Isolated no-Docker contract test `tests/state_machine_on.rs` (type-checks the generated method via a never-called async fn; asserts pure validators unchanged).
- trybuild compile-pass fixture `tests/compile-pass/model_state_machine_on.rs`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2TS7EVMkMvcvjSyy1MrQ)_