### PR TITLE
feat(cli): run autumn a11y verify in generated-app CI via the install script

### DIFF
--- a/autumn-cli/src/templates/.github/workflows/ci.yml.tmpl
+++ b/autumn-cli/src/templates/.github/workflows/ci.yml.tmpl
@@ -68,6 +68,18 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings
 
+      # Accessibility gate: install the prebuilt `autumn` CLI matching this app's
+      # autumn-web version and scan raw html! markup for a11y violations. Non-blocking
+      # (continue-on-error) until the pinned autumn release publishes its prebuilt
+      # binaries; remove `continue-on-error` to make this an enforcing gate.
+      - name: Accessibility (a11y) verify
+        continue-on-error: true
+        run: |
+          curl -fsSL "https://raw.githubusercontent.com/madmax983/autumn/v{{autumn_version}}/scripts/install.sh" \
+            | sh -s -- --version "v{{autumn_version}}"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/autumn" a11y verify .
+
       - name: Build
         run: cargo build
 

--- a/autumn-cli/tests/integration/cloud_native_scaffold.rs
+++ b/autumn-cli/tests/integration/cloud_native_scaffold.rs
@@ -382,6 +382,26 @@ fn ci_workflow_contains_expected_jobs() {
 }
 
 #[test]
+fn ci_workflow_runs_a11y_verify() {
+    let temp_dir = scaffold("ci-a11y-app");
+    let project_dir = temp_dir.path().join("ci-a11y-app");
+    let ci = fs::read_to_string(project_dir.join(".github/workflows/ci.yml")).unwrap();
+
+    assert!(
+        ci.contains("a11y verify"),
+        "ci.yml must run `autumn a11y verify`"
+    );
+    assert!(
+        ci.contains("scripts/install.sh"),
+        "ci.yml must install the autumn CLI via the install script"
+    );
+    assert!(
+        ci.contains(&format!("v{}", env!("CARGO_PKG_VERSION"))),
+        "ci.yml must pin the installed CLI to this app's autumn version"
+    );
+}
+
+#[test]
 fn ci_workflow_pins_msrv_toolchain() {
     let temp_dir = scaffold("ci-msrv-app");
     let project_dir = temp_dir.path().join("ci-msrv-app");


### PR DESCRIPTION
## What changed

**Before:** apps scaffolded by `autumn new` shipped a CI workflow that runs fmt / clippy / build / test — but nothing checked accessibility, even though autumn has an `autumn a11y verify` scanner.

**After:** the generated `.github/workflows/ci.yml` gains an **Accessibility (a11y) verify** step that installs the prebuilt `autumn` CLI (matching the app's `autumn-web` version) via the curl install script from #2005/#2011 and runs `autumn a11y verify .` over the app's `html!` markup.

Closes #1931.

## How

- **`autumn-cli/src/templates/.github/workflows/ci.yml.tmpl`** gains one step (after Clippy): it fetches `scripts/install.sh` pinned to the app's autumn version and installs the matching binary (`--version v{{autumn_version}}`), adds `~/.local/bin` to `$GITHUB_PATH`, and runs `autumn a11y verify .`. It reuses the existing `{{autumn_version}}` template var (already `env!("CARGO_PKG_VERSION")` = the autumn-web version the app pins), so the scanner version always matches the app's dependency — no new template variable.
- **Non-blocking for now (`continue-on-error: true`).** The prebuilt binaries only exist on releases cut *after* #2011 merged (the current latest release, v0.5.0, predates it), so `install.sh` would 404 until the first ≥ v0.6.0 release publishes the assets — and a freshly-scaffolded app already pins the not-yet-published `autumn-web = "{{autumn_version}}"`, so its CI is inherently release-gated. Shipping the step non-blocking guarantees no fresh scaffold ever goes red because of it (the issue's "fresh scaffold must stay green" requirement). A one-line follow-up drops `continue-on-error` to make it enforcing once a binary-carrying release exists; the template comment documents this.
- **`autumn-cli/tests/integration/cloud_native_scaffold.rs`** gains an assertion that the rendered ci.yml runs the a11y-verify step (installs via `scripts/install.sh`, pins `v{{autumn_version}}`, invokes `a11y verify`); the existing no-unsubstituted-`{{` guard still holds because `{{autumn_version}}` substitutes. No snapshots exist for this template (content-assertion tests only). `generate/scaffold.rs` is untouched, per the issue scope.

## Verification (local)

- Built `autumn` (`autumn 0.6.0`); `autumn new`, `autumn new --api`, `autumn new --daemon`, and `generate scaffold Post …` all **pass `autumn a11y verify` with exit 0** (text, JSON, `--strict`) — generated CRUD markup routes through the typed `autumn_web::a11y` primitives, so the scanner finds nothing.
- A freshly-generated `ci.yml` contains the a11y step with the version substituted (`v0.6.0`) and **no leftover `{{` placeholders**.
- `cargo test -p autumn-cli` scaffold CI tests green; `cargo fmt --all -- --check` + `cargo clippy -p autumn-cli --all-targets -- -D warnings` clean.

## Follow-up

Flip the step to enforcing (drop `continue-on-error`) once the first ≥ v0.6.0 release publishes the prebuilt binaries via `cli-release.yml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0111zrQFHhi2j1bWj3de6iSQ)_