### PR TITLE
sqlite: repository CRUD — FOR UPDATE removal + on_conflict/batch dialect (#1996)

### DIFF
--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -4198,6 +4198,99 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         )
     };
 
+    // SQLite counterpart of `#execute_upsert_body`: the per-row loop body that
+    // builds one `INSERT … ON CONFLICT(id) DO UPDATE …` statement, applies the
+    // SAME tenant/lock-version `DO UPDATE … WHERE` refinements Postgres uses
+    // (SQLite's `ON CONFLICT DO UPDATE` supports a `WHERE` clause), runs it, and
+    // pushes any RETURNING row (issue #1996, PR #2021). Matching Postgres' WHERE
+    // is load-bearing for two reasons:
+    //   * tenant isolation (SECURITY): the conflict target is `id` only and the
+    //     shared set-clause (`__autumn_upsert_set`) writes `tenant_id`, so
+    //     without `WHERE tenant_id = <current>` an id owned by another tenant
+    //     would be MOVED into the caller's tenant. With the predicate the DO
+    //     UPDATE simply does not fire for a cross-tenant id → the row is left
+    //     untouched and drops out of RETURNING (silent, no leak).
+    //   * optimistic locking: `WHERE lock_version = excluded.lock_version` leaves
+    //     a stale-version row untouched, dropping it from RETURNING.
+    // A dropped row yields no RETURNING output, so per-row `get_result` returns
+    // `Error::NotFound`; `.optional()?` maps that to `None` so the row is simply
+    // absent from the returned Vec — exactly like Postgres' `get_results` omits
+    // filtered rows. The caller's fail-closed reconciliation (re-select dropped
+    // ids under tenant scope → 409 only if still present for this tenant) then
+    // behaves identically on both backends.
+    let execute_upsert_body_sqlite = {
+        let build_stmt = quote! {
+            let stmt = ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                .values(__autumn_row)
+                .on_conflict(#table_ident::id)
+                .do_update()
+                .set(Self::__autumn_upsert_set());
+        };
+        if has_tenant_id {
+            lock_version_field.map_or_else(
+                || quote! {
+                    #build_stmt
+                    let __autumn_r = if let ::core::option::Option::Some(t) = tenant_id {
+                        ::autumn_web::reexports::diesel::query_dsl::methods::FilterDsl::filter(stmt, #table_ident::tenant_id.eq(t.to_string()))
+                            .get_result::<Self>(conn)
+                            .await
+                            .optional()?
+                    } else {
+                        stmt.get_result::<Self>(conn).await.optional()?
+                    };
+                    if let ::core::option::Option::Some(__autumn_r) = __autumn_r {
+                        __autumn_upserted.push(__autumn_r);
+                    }
+                },
+                |lv_field| {
+                    let lv_ident = lv_field.ident.as_ref().unwrap();
+                    quote! {
+                        #build_stmt
+                        let lv_cond = #table_ident::#lv_ident.eq(::autumn_web::reexports::diesel::upsert::excluded(#table_ident::#lv_ident));
+                        let __autumn_r = if let ::core::option::Option::Some(t) = tenant_id {
+                            ::autumn_web::reexports::diesel::query_dsl::methods::FilterDsl::filter(stmt, lv_cond.and(#table_ident::tenant_id.eq(t.to_string())))
+                                .get_result::<Self>(conn)
+                                .await
+                                .optional()?
+                        } else {
+                            ::autumn_web::reexports::diesel::query_dsl::methods::FilterDsl::filter(stmt, lv_cond)
+                                .get_result::<Self>(conn)
+                                .await
+                                .optional()?
+                        };
+                        if let ::core::option::Option::Some(__autumn_r) = __autumn_r {
+                            __autumn_upserted.push(__autumn_r);
+                        }
+                    }
+                },
+            )
+        } else {
+            lock_version_field.map_or_else(
+                || quote! {
+                    #build_stmt
+                    let __autumn_r = stmt.get_result::<Self>(conn).await.optional()?;
+                    if let ::core::option::Option::Some(__autumn_r) = __autumn_r {
+                        __autumn_upserted.push(__autumn_r);
+                    }
+                },
+                |lv_field| {
+                    let lv_ident = lv_field.ident.as_ref().unwrap();
+                    quote! {
+                        #build_stmt
+                        let lv_cond = #table_ident::#lv_ident.eq(::autumn_web::reexports::diesel::upsert::excluded(#table_ident::#lv_ident));
+                        let __autumn_r = ::autumn_web::reexports::diesel::query_dsl::methods::FilterDsl::filter(stmt, lv_cond)
+                            .get_result::<Self>(conn)
+                            .await
+                            .optional()?;
+                        if let ::core::option::Option::Some(__autumn_r) = __autumn_r {
+                            __autumn_upserted.push(__autumn_r);
+                        }
+                    }
+                },
+            )
+        }
+    };
+
     let compare_fields = fields_for_new.iter().map(|f| {
         let ident = &f.ident;
         quote! { input.#ident == record.#ident }
@@ -5186,14 +5279,18 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 // RETURNING` over the whole chunk; SQLite cannot express a
                 // multi-row `VALUES` with the `DEFAULT` keyword (`BatchInsert<…,
                 // false>` has no `QueryFragment<Sqlite>`), so it upserts row by
-                // row, each `INSERT … ON CONFLICT(id) DO UPDATE … RETURNING`
+                // row, each `INSERT … ON CONFLICT(id) DO UPDATE … WHERE … RETURNING`
                 // (valid single-row on SQLite with the `returning_clauses`
                 // flag). The caller (`save_many`/`upsert_many`) already runs this
                 // inside a transaction, so the per-row loop stays atomic. The
-                // tenant/lock-version RETURNING refinements in `#execute_upsert_body`
-                // are Postgres-only (`pg::upsert::excluded`) and belong to the
-                // scoped/versioned/upsert-trait waves; the SQLite arm upserts the
-                // plain row set (issue #1996).
+                // per-row body (`#execute_upsert_body_sqlite`) applies the SAME
+                // tenant/lock-version `DO UPDATE … WHERE` refinements as the
+                // Postgres arm — `diesel::upsert::excluded` is the backend-agnostic
+                // form (vs. `pg::upsert::excluded`) and SQLite's `ON CONFLICT DO
+                // UPDATE` supports a `WHERE` clause — so cross-tenant ids are left
+                // untouched (SECURITY: no cross-tenant row movement) and stale
+                // lock-version rows drop out of RETURNING, matching Postgres
+                // exactly (issue #1996, PR #2021).
                 ::autumn_web::backend_select! {
                     pg => {
                         let stmt = ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
@@ -5210,14 +5307,7 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     sqlite => {
                         let mut __autumn_upserted = ::std::vec::Vec::new();
                         for __autumn_row in chunk.to_vec() {
-                            let __autumn_r = ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
-                                .values(__autumn_row)
-                                .on_conflict(#table_ident::id)
-                                .do_update()
-                                .set(Self::__autumn_upsert_set())
-                                .get_result::<Self>(conn)
-                                .await?;
-                            __autumn_upserted.push(__autumn_r);
+                            #execute_upsert_body_sqlite
                         }
                         ::core::result::Result::Ok(__autumn_upserted)
                     },

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -4932,7 +4932,7 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         ::autumn_web::reexports::diesel::helper_types::IntoBoxed<
             '__lq,
             #table_ident::table,
-            ::autumn_web::reexports::diesel::pg::Pg,
+            ::autumn_web::RuntimeBackend,
         >
     };
     // Single primary key used for the default order + tie-break. Absent for
@@ -5167,7 +5167,7 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             #[doc(hidden)]
             pub fn __autumn_upsert_set() -> impl ::autumn_web::reexports::diesel::query_builder::AsChangeset<
                 Target = #table_ident::table,
-                Changeset = impl ::autumn_web::reexports::diesel::query_builder::QueryFragment<::autumn_web::reexports::diesel::pg::Pg> + ::core::marker::Send + ::core::marker::Sync + 'static
+                Changeset = impl ::autumn_web::reexports::diesel::query_builder::QueryFragment<::autumn_web::RuntimeBackend> + ::core::marker::Send + ::core::marker::Sync + 'static
             > + ::core::marker::Send + ::core::marker::Sync + 'static {
                 use ::autumn_web::reexports::diesel::ExpressionMethods as _;
                 (#(#upsert_columns,)*)
@@ -5182,16 +5182,46 @@ pub fn model_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 use ::autumn_web::reexports::diesel::prelude::*;
                 use ::autumn_web::reexports::diesel_async::RunQueryDsl;
 
-                let stmt = ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
-                    // Owned `Vec` (not `&[Self]`): encrypted columns use diesel
-                    // `serialize_as`, which only implements `Insertable` for owned
-                    // values. `to_vec()` also works for plain models.
-                    .values(chunk.to_vec())
-                    .on_conflict(#table_ident::id)
-                    .do_update()
-                    .set(Self::__autumn_upsert_set());
+                // Postgres builds one batched `INSERT … ON CONFLICT … DO UPDATE …
+                // RETURNING` over the whole chunk; SQLite cannot express a
+                // multi-row `VALUES` with the `DEFAULT` keyword (`BatchInsert<…,
+                // false>` has no `QueryFragment<Sqlite>`), so it upserts row by
+                // row, each `INSERT … ON CONFLICT(id) DO UPDATE … RETURNING`
+                // (valid single-row on SQLite with the `returning_clauses`
+                // flag). The caller (`save_many`/`upsert_many`) already runs this
+                // inside a transaction, so the per-row loop stays atomic. The
+                // tenant/lock-version RETURNING refinements in `#execute_upsert_body`
+                // are Postgres-only (`pg::upsert::excluded`) and belong to the
+                // scoped/versioned/upsert-trait waves; the SQLite arm upserts the
+                // plain row set (issue #1996).
+                ::autumn_web::backend_select! {
+                    pg => {
+                        let stmt = ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                            // Owned `Vec` (not `&[Self]`): encrypted columns use diesel
+                            // `serialize_as`, which only implements `Insertable` for owned
+                            // values. `to_vec()` also works for plain models.
+                            .values(chunk.to_vec())
+                            .on_conflict(#table_ident::id)
+                            .do_update()
+                            .set(Self::__autumn_upsert_set());
 
-                #execute_upsert_body
+                        #execute_upsert_body
+                    },
+                    sqlite => {
+                        let mut __autumn_upserted = ::std::vec::Vec::new();
+                        for __autumn_row in chunk.to_vec() {
+                            let __autumn_r = ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                .values(__autumn_row)
+                                .on_conflict(#table_ident::id)
+                                .do_update()
+                                .set(Self::__autumn_upsert_set())
+                                .get_result::<Self>(conn)
+                                .await?;
+                            __autumn_upserted.push(__autumn_r);
+                        }
+                        ::core::result::Result::Ok(__autumn_upserted)
+                    },
+                }
             }
 
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -8844,24 +8844,36 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             };
             let vh_upsert_lock_keys = if config.versioned {
                 let table_name = table_name.clone();
+                // `pg_advisory_xact_lock` is a Postgres-only function; SQLite has
+                // no equivalent and would fail at runtime. Cfg-gate the advisory
+                // lock to Postgres via `backend_select!` and skip it on SQLite:
+                // SQLite is single-writer (a write transaction locks the whole
+                // database), so the cross-connection serialization the advisory
+                // lock provides on Postgres is already guaranteed there — nothing
+                // to acquire (issue #1996, PR #2021).
                 quote! {
-                    let mut __autumn_upsert_lock_ids: Vec<_> =
-                        records.iter().map(|r| r.id).collect();
-                    __autumn_upsert_lock_ids.sort_unstable();
-                    __autumn_upsert_lock_ids.dedup();
-                    for __autumn_upsert_lock_id in __autumn_upsert_lock_ids {
-                        let __autumn_upsert_lock_key =
-                            ::autumn_web::repository::repository_upsert_advisory_lock_key(
-                                #table_name,
-                                __autumn_upsert_lock_id,
-                            );
-                        ::autumn_web::reexports::diesel::sql_query("SELECT pg_advisory_xact_lock($1)")
-                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(
-                                __autumn_upsert_lock_key,
-                            )
-                            .execute(conn)
-                            .await
-                            .map_err(::autumn_web::AutumnError::from)?;
+                    ::autumn_web::backend_select! {
+                        pg => {
+                            let mut __autumn_upsert_lock_ids: Vec<_> =
+                                records.iter().map(|r| r.id).collect();
+                            __autumn_upsert_lock_ids.sort_unstable();
+                            __autumn_upsert_lock_ids.dedup();
+                            for __autumn_upsert_lock_id in __autumn_upsert_lock_ids {
+                                let __autumn_upsert_lock_key =
+                                    ::autumn_web::repository::repository_upsert_advisory_lock_key(
+                                        #table_name,
+                                        __autumn_upsert_lock_id,
+                                    );
+                                ::autumn_web::reexports::diesel::sql_query("SELECT pg_advisory_xact_lock($1)")
+                                    .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(
+                                        __autumn_upsert_lock_key,
+                                    )
+                                    .execute(conn)
+                                    .await
+                                    .map_err(::autumn_web::AutumnError::from)?;
+                            }
+                        },
+                        sqlite => {},
                     }
                 }
             } else {
@@ -18822,6 +18834,42 @@ mod tests {
         assert!(
             generated.contains("records . iter () . map (| r | r . id)"),
             "versioned upsert_many lock set must be collected from all input records, not the current chunk: {generated}"
+        );
+    }
+
+    #[test]
+    fn repository_macro_versioned_upsert_many_gates_advisory_lock_to_postgres_only() {
+        // Bug 1 (#1996, PR #2021): `pg_advisory_xact_lock` is a Postgres-only
+        // function; emitting it unconditionally made versioned `upsert_many` fail
+        // at runtime on SQLite. The advisory-lock acquisition must now sit inside
+        // a `backend_select!` whose `pg` arm holds it and whose `sqlite` arm is
+        // empty — SQLite is single-writer, so the serialization is already
+        // guaranteed and nothing must be acquired.
+        let generated = repository_macro(
+            quote! { Post, versioned = true },
+            quote! { pub trait PostRepository {} },
+        )
+        .to_string();
+
+        let select_pos = generated
+            .find("backend_select")
+            .expect("versioned upsert_many must wrap the advisory lock in a backend_select!");
+        let lock_pos = generated
+            .find("pg_advisory_xact_lock")
+            .expect("versioned upsert_many must still acquire the advisory lock on Postgres");
+        assert!(
+            select_pos < lock_pos,
+            "the advisory lock must be emitted inside the backend_select! (pg arm), not before it: {generated}"
+        );
+        // The `pg =>` selector must precede the advisory lock, proving it lives in
+        // the Postgres arm (skipped on SQLite where the arm is empty).
+        let pg_arm_pos = generated[select_pos..]
+            .find("pg =>")
+            .map(|p| select_pos + p)
+            .expect("backend_select! must have a pg arm");
+        assert!(
+            pg_arm_pos < lock_pos,
+            "pg_advisory_xact_lock must be inside the `pg =>` arm of the backend_select!: {generated}"
         );
     }
 

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1905,8 +1905,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             // skip the hard delete, and leave the row to FK-fail
                             // the parent DELETE. The id set is authoritative for
                             // the parent kind; the row is locked with `for_update`.
-                            let __record = #table_ident::table.find(__cid)
-                                .for_update()
+                            let __record = ::autumn_web::maybe_for_update!(#table_ident::table.find(__cid))
+
                                 .first::<#model_name>(conn)
                                 .await
                                 .optional()
@@ -2020,20 +2020,20 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 #delete_many_live_filter;
             let __autumn_dep_rows: ::std::vec::Vec<#model_name> =
                 if let ::core::option::Option::Some(t) = tenant_id {
-                    __autumn_dep_q.filter(#table_ident::tenant_id.eq(t)).for_update()
+                    ::autumn_web::maybe_for_update!(__autumn_dep_q.filter(#table_ident::tenant_id.eq(t)))
                         .load::<#model_name>(conn).await
                 } else {
-                    __autumn_dep_q.for_update().load::<#model_name>(conn).await
+                    ::autumn_web::maybe_for_update!(__autumn_dep_q).load::<#model_name>(conn).await
                 }
                 .map_err(::autumn_web::AutumnError::from)?;
         }
     } else {
         quote! {
             let __autumn_dep_rows: ::std::vec::Vec<#model_name> =
-                #table_ident::table
+                ::autumn_web::maybe_for_update!(#table_ident::table
                     .filter(#table_ident::id.eq_any(chunk))
-                    #delete_many_live_filter
-                    .for_update()
+                    #delete_many_live_filter)
+
                     .load::<#model_name>(conn).await
                     .map_err(::autumn_web::AutumnError::from)?;
         }
@@ -4110,9 +4110,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 {
                                     let load_query = #table_ident::table.find(id);
                                     let current = if let ::core::option::Option::Some(ref t) = tenant_id {
-                                        load_query.filter(#table_ident::tenant_id.eq(t)).for_update().first::<#model_name>(conn).await
+                                        ::autumn_web::maybe_for_update!(load_query.filter(#table_ident::tenant_id.eq(t))).first::<#model_name>(conn).await
                                     } else {
-                                        load_query.for_update().first::<#model_name>(conn).await
+                                        ::autumn_web::maybe_for_update!(load_query).first::<#model_name>(conn).await
                                     }
                                     .optional()
                                     .map_err(::autumn_web::AutumnError::from)?
@@ -4162,9 +4162,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 } else {
                                     let load_query = #table_ident::table.find(id);
                                     let current = if let ::core::option::Option::Some(ref t) = tenant_id {
-                                        load_query.filter(#table_ident::tenant_id.eq(t)).for_update().first::<#model_name>(conn).await
+                                        ::autumn_web::maybe_for_update!(load_query.filter(#table_ident::tenant_id.eq(t))).first::<#model_name>(conn).await
                                     } else {
-                                        load_query.for_update().first::<#model_name>(conn).await
+                                        ::autumn_web::maybe_for_update!(load_query).first::<#model_name>(conn).await
                                     }
                                     .optional()
                                     .map_err(::autumn_web::AutumnError::from)?
@@ -4321,9 +4321,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 {
                                     let load_query = #table_ident::table.find(id);
                                     let current = if let ::core::option::Option::Some(ref t) = tenant_id {
-                                        load_query.filter(#table_ident::tenant_id.eq(t)).for_update().first::<#model_name>(conn).await
+                                        ::autumn_web::maybe_for_update!(load_query.filter(#table_ident::tenant_id.eq(t))).first::<#model_name>(conn).await
                                     } else {
-                                        load_query.for_update().first::<#model_name>(conn).await
+                                        ::autumn_web::maybe_for_update!(load_query).first::<#model_name>(conn).await
                                     }
                                     .optional()
                                     .map_err(::autumn_web::AutumnError::from)?
@@ -4373,9 +4373,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 } else {
                                     let load_query = #table_ident::table.find(id);
                                     let current = if let ::core::option::Option::Some(ref t) = tenant_id {
-                                        load_query.filter(#table_ident::tenant_id.eq(t)).for_update().first::<#model_name>(conn).await
+                                        ::autumn_web::maybe_for_update!(load_query.filter(#table_ident::tenant_id.eq(t))).first::<#model_name>(conn).await
                                     } else {
-                                        load_query.for_update().first::<#model_name>(conn).await
+                                        ::autumn_web::maybe_for_update!(load_query).first::<#model_name>(conn).await
                                     }
                                     .optional()
                                     .map_err(::autumn_web::AutumnError::from)?
@@ -4453,9 +4453,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     // SELECT FOR UPDATE grabs an exclusive row lock so
                                     // no concurrent writer can commit between our
                                     // version check and the UPDATE below.
-                                    let current = #table_ident::table
-                                        .find(id)
-                                        .for_update()
+                                    let current = ::autumn_web::maybe_for_update!(#table_ident::table
+                                        .find(id))
+
                                         .first::<#model_name>(conn)
                                         .await
                                         .optional()
@@ -4491,9 +4491,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     (updated, ::core::option::Option::Some(__vh_before_inner))
                                 } else {
                                     // Load current record
-                                    let current = #table_ident::table
-                                        .find(id)
-                                        .for_update()
+                                    let current = ::autumn_web::maybe_for_update!(#table_ident::table
+                                        .find(id))
+
                                         .first::<#model_name>(conn)
                                         .await
                                         .optional()
@@ -4636,9 +4636,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 let (record, __vh_before): (#model_name, #model_name) = if let ::core::option::Option::Some(expected_version) =
                                     changes.__autumn_lock_version_expected()
                                 {
-                                    let current = #table_ident::table
-                                        .find(id)
-                                        .for_update()
+                                    let current = ::autumn_web::maybe_for_update!(#table_ident::table
+                                        .find(id))
+
                                         .first::<#model_name>(conn)
                                         .await
                                         .optional()
@@ -4724,9 +4724,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 let record: #model_name = if let ::core::option::Option::Some(expected_version) =
                                     changes.__autumn_lock_version_expected()
                                 {
-                                    let current = #table_ident::table
-                                        .find(id)
-                                        .for_update()
+                                    let current = ::autumn_web::maybe_for_update!(#table_ident::table
+                                        .find(id))
+
                                         .first::<#model_name>(conn)
                                         .await
                                         .optional()
@@ -4882,9 +4882,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 // hooks only run when the row is actually deletable.
                                 let load_query = #table_ident::table.find(id) #sd_filter;
                                 let record = if let ::core::option::Option::Some(ref t) = tenant_id {
-                                    load_query.filter(#table_ident::tenant_id.eq(t)).for_update().first::<#model_name>(conn).await
+                                    ::autumn_web::maybe_for_update!(load_query.filter(#table_ident::tenant_id.eq(t))).first::<#model_name>(conn).await
                                 } else {
-                                    load_query.for_update().first::<#model_name>(conn).await
+                                    ::autumn_web::maybe_for_update!(load_query).first::<#model_name>(conn).await
                                 }
                                 .optional()
                                 .map_err(::autumn_web::AutumnError::from)?
@@ -4936,9 +4936,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
                                 let load_query = #table_ident::table.find(id);
                                 let record = if let ::core::option::Option::Some(ref t) = tenant_id {
-                                    load_query.filter(#table_ident::tenant_id.eq(t)).for_update().first::<#model_name>(conn).await
+                                    ::autumn_web::maybe_for_update!(load_query.filter(#table_ident::tenant_id.eq(t))).first::<#model_name>(conn).await
                                 } else {
-                                    load_query.for_update().first::<#model_name>(conn).await
+                                    ::autumn_web::maybe_for_update!(load_query).first::<#model_name>(conn).await
                                 }
                                 .optional()
                                 .map_err(::autumn_web::AutumnError::from)?
@@ -4985,7 +4985,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
                             // Load current record for before_delete context.
                             let load_query = #table_ident::table.find(id) #sd_filter;
-                            let record = load_query.for_update().first::<#model_name>(conn).await
+                            let record = ::autumn_web::maybe_for_update!(load_query).first::<#model_name>(conn).await
                             .optional()
                             .map_err(::autumn_web::AutumnError::from)?
                             .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
@@ -5043,7 +5043,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             let mut ctx = MutationContext::new(MutationOp::Delete);
 
                             let load_query = #table_ident::table.find(id);
-                            let record = load_query.for_update().first::<#model_name>(conn).await
+                            let record = ::autumn_web::maybe_for_update!(load_query).first::<#model_name>(conn).await
                             .optional()
                             .map_err(::autumn_web::AutumnError::from)?
                             .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
@@ -5079,7 +5079,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             let mut ctx = MutationContext::new(MutationOp::Delete);
 
                             let load_query = #table_ident::table.find(id);
-                            let record = load_query.for_update().first::<#model_name>(conn).await
+                            let record = ::autumn_web::maybe_for_update!(load_query).first::<#model_name>(conn).await
                             .optional()
                             .map_err(::autumn_web::AutumnError::from)?
                             .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
@@ -5122,25 +5122,85 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     {
                         if let ::core::option::Option::Some(t) = tenant_id {
                             let values: Vec<_> = chunk.iter().cloned().map(|item| ::autumn_web::tenancy::TenantInsertable::tenant_values(item, t)).collect();
+                            ::autumn_web::backend_select! {
+                        pg => {
                             ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
                                 .values(values)
                                 .get_results::<#model_name>(conn)
                                 .await
+                        },
+                        sqlite => {
+                            let mut __autumn_inserted = ::std::vec::Vec::new();
+                            let mut __autumn_res: ::core::result::Result<(), ::autumn_web::reexports::diesel::result::Error> =
+                                ::core::result::Result::Ok(());
+                            for __autumn_row in values {
+                                match ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                    .values(__autumn_row)
+                                    .get_result::<#model_name>(conn)
+                                    .await
+                                {
+                                    ::core::result::Result::Ok(__r) => __autumn_inserted.push(__r),
+                                    ::core::result::Result::Err(__e) => { __autumn_res = ::core::result::Result::Err(__e); break; }
+                                }
+                            }
+                            __autumn_res.map(|()| __autumn_inserted)
+                        },
+                    }
                         } else {
+                            ::autumn_web::backend_select! {
+                        pg => {
                             ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
                                 .values(chunk.to_vec())
                                 .get_results::<#model_name>(conn)
                                 .await
+                        },
+                        sqlite => {
+                            let mut __autumn_inserted = ::std::vec::Vec::new();
+                            let mut __autumn_res: ::core::result::Result<(), ::autumn_web::reexports::diesel::result::Error> =
+                                ::core::result::Result::Ok(());
+                            for __autumn_row in chunk.to_vec() {
+                                match ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                    .values(__autumn_row)
+                                    .get_result::<#model_name>(conn)
+                                    .await
+                                {
+                                    ::core::result::Result::Ok(__r) => __autumn_inserted.push(__r),
+                                    ::core::result::Result::Err(__e) => { __autumn_res = ::core::result::Result::Err(__e); break; }
+                                }
+                            }
+                            __autumn_res.map(|()| __autumn_inserted)
+                        },
+                    }
                         }
                     }
                 }
             } else {
                 quote! {
                     {
-                        ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
-                            .values(chunk.to_vec())
-                            .get_results::<#model_name>(conn)
-                            .await
+                        ::autumn_web::backend_select! {
+                        pg => {
+                            ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                .values(chunk.to_vec())
+                                .get_results::<#model_name>(conn)
+                                .await
+                        },
+                        sqlite => {
+                            let mut __autumn_inserted = ::std::vec::Vec::new();
+                            let mut __autumn_res: ::core::result::Result<(), ::autumn_web::reexports::diesel::result::Error> =
+                                ::core::result::Result::Ok(());
+                            for __autumn_row in chunk.to_vec() {
+                                match ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                    .values(__autumn_row)
+                                    .get_result::<#model_name>(conn)
+                                    .await
+                                {
+                                    ::core::result::Result::Ok(__r) => __autumn_inserted.push(__r),
+                                    ::core::result::Result::Err(__e) => { __autumn_res = ::core::result::Result::Err(__e); break; }
+                                }
+                            }
+                            __autumn_res.map(|()| __autumn_inserted)
+                        },
+                    }
                     }
                 }
             };
@@ -5206,7 +5266,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             let mut global_indices = Vec::new();
                             let mut offset = 0;
                             let cols = (&new[0]).__autumn_column_count() + #tenant_extra;
-                            let chunk_size = if cols == 0 { 1000 } else { (65535usize / cols).min(1000).max(1) };
+                            let chunk_size = if cols == 0 { 1000 } else { (::autumn_web::repository::MAX_BIND_PARAMS / cols).min(1000).max(1) };
                             for chunk in inputs.chunks(chunk_size) {
                                 let chunk_inserted = (#insert_expr)
                                     .map_err(::autumn_web::AutumnError::from)?;
@@ -5389,7 +5449,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             let mut inserted = Vec::new();
                             let mut offset = 0;
                             let cols = (&new[0]).__autumn_column_count() + #tenant_extra;
-                            let chunk_size = if cols == 0 { 1000 } else { (65535usize / cols).min(1000).max(1) };
+                            let chunk_size = if cols == 0 { 1000 } else { (::autumn_web::repository::MAX_BIND_PARAMS / cols).min(1000).max(1) };
                             for chunk in inputs_ref.chunks(chunk_size) {
                                 let chunk_inserted = (#insert_expr)
                                     .map_err(::autumn_web::AutumnError::from)?;
@@ -5448,16 +5508,56 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     {
                         if let ::core::option::Option::Some(t) = tenant_id {
                             let values: Vec<_> = chunk.iter().map(|item| ::autumn_web::tenancy::TenantInsertable::tenant_values(item.0.clone(), t)).collect();
+                            ::autumn_web::backend_select! {
+                        pg => {
                             ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
                                 .values(values)
                                 .get_results::<#model_name>(conn)
                                 .await
+                        },
+                        sqlite => {
+                            let mut __autumn_inserted = ::std::vec::Vec::new();
+                            let mut __autumn_res: ::core::result::Result<(), ::autumn_web::reexports::diesel::result::Error> =
+                                ::core::result::Result::Ok(());
+                            for __autumn_row in values {
+                                match ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                    .values(__autumn_row)
+                                    .get_result::<#model_name>(conn)
+                                    .await
+                                {
+                                    ::core::result::Result::Ok(__r) => __autumn_inserted.push(__r),
+                                    ::core::result::Result::Err(__e) => { __autumn_res = ::core::result::Result::Err(__e); break; }
+                                }
+                            }
+                            __autumn_res.map(|()| __autumn_inserted)
+                        },
+                    }
                         } else {
                             let values: Vec<_> = chunk.iter().map(|item| item.0.clone()).collect();
+                            ::autumn_web::backend_select! {
+                        pg => {
                             ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
                                 .values(values)
                                 .get_results::<#model_name>(conn)
                                 .await
+                        },
+                        sqlite => {
+                            let mut __autumn_inserted = ::std::vec::Vec::new();
+                            let mut __autumn_res: ::core::result::Result<(), ::autumn_web::reexports::diesel::result::Error> =
+                                ::core::result::Result::Ok(());
+                            for __autumn_row in values {
+                                match ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                    .values(__autumn_row)
+                                    .get_result::<#model_name>(conn)
+                                    .await
+                                {
+                                    ::core::result::Result::Ok(__r) => __autumn_inserted.push(__r),
+                                    ::core::result::Result::Err(__e) => { __autumn_res = ::core::result::Result::Err(__e); break; }
+                                }
+                            }
+                            __autumn_res.map(|()| __autumn_inserted)
+                        },
+                    }
                         }
                     }
                 }
@@ -5465,10 +5565,30 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 quote! {
                     {
                         let values: Vec<_> = chunk.iter().map(|item| item.0.clone()).collect();
-                        ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
-                            .values(values)
-                            .get_results::<#model_name>(conn)
-                            .await
+                        ::autumn_web::backend_select! {
+                        pg => {
+                            ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                .values(values)
+                                .get_results::<#model_name>(conn)
+                                .await
+                        },
+                        sqlite => {
+                            let mut __autumn_inserted = ::std::vec::Vec::new();
+                            let mut __autumn_res: ::core::result::Result<(), ::autumn_web::reexports::diesel::result::Error> =
+                                ::core::result::Result::Ok(());
+                            for __autumn_row in values {
+                                match ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                    .values(__autumn_row)
+                                    .get_result::<#model_name>(conn)
+                                    .await
+                                {
+                                    ::core::result::Result::Ok(__r) => __autumn_inserted.push(__r),
+                                    ::core::result::Result::Err(__e) => { __autumn_res = ::core::result::Result::Err(__e); break; }
+                                }
+                            }
+                            __autumn_res.map(|()| __autumn_inserted)
+                        },
+                    }
                     }
                 }
             };
@@ -5519,7 +5639,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         return Ok((successes, failures));
                     }
                     let cols = (&valid_items[0].0).__autumn_column_count() + #tenant_extra;
-                    let chunk_size = if cols == 0 { 1000 } else { (65535usize / cols).min(1000).max(1) };
+                    let chunk_size = if cols == 0 { 1000 } else { (::autumn_web::repository::MAX_BIND_PARAMS / cols).min(1000).max(1) };
                     let mut offset = 0;
                     for chunk in valid_items.chunks(chunk_size) {
                         let batch_res = ::autumn_web::__private::scoped_transaction::<_, ::autumn_web::AutumnError, _, _>(&mut *conn, |conn| {
@@ -5788,7 +5908,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         return Ok((successes, failures));
                     }
                     let cols = (&valid_items[0].0).__autumn_column_count() + #tenant_extra;
-                    let chunk_size = if cols == 0 { 1000 } else { (65535usize / cols).min(1000).max(1) };
+                    let chunk_size = if cols == 0 { 1000 } else { (::autumn_web::repository::MAX_BIND_PARAMS / cols).min(1000).max(1) };
                     for chunk in valid_items.chunks(chunk_size) {
                         let batch_res = ::autumn_web::__private::scoped_transaction::<_, ::autumn_web::AutumnError, _, _>(&mut *conn, |conn| {
                             async move {
@@ -5963,14 +6083,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             let load_expr = if config.tenant_scoped {
                 quote! {
                     if let ::core::option::Option::Some(t) = tenant_id {
-                        load_query.filter(#table_ident::tenant_id.eq(t)).for_update().load::<#model_name>(conn).await
+                        ::autumn_web::maybe_for_update!(load_query.filter(#table_ident::tenant_id.eq(t))).load::<#model_name>(conn).await
                     } else {
-                        load_query.for_update().load::<#model_name>(conn).await
+                        ::autumn_web::maybe_for_update!(load_query).load::<#model_name>(conn).await
                     }
                 }
             } else {
                 quote! {
-                    load_query.for_update().load::<#model_name>(conn).await
+                    ::autumn_web::maybe_for_update!(load_query).load::<#model_name>(conn).await
                 }
             };
 
@@ -6431,28 +6551,28 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 if config.soft_delete {
                     quote! {
                         if let ::core::option::Option::Some(t) = tenant_id {
-                            load_query.filter(#table_ident::tenant_id.eq(t)).filter(#table_ident::deleted_at.is_null()).for_update().load::<#model_name>(conn).await
+                            ::autumn_web::maybe_for_update!(load_query.filter(#table_ident::tenant_id.eq(t)).filter(#table_ident::deleted_at.is_null())).load::<#model_name>(conn).await
                         } else {
-                            load_query.filter(#table_ident::deleted_at.is_null()).for_update().load::<#model_name>(conn).await
+                            ::autumn_web::maybe_for_update!(load_query.filter(#table_ident::deleted_at.is_null())).load::<#model_name>(conn).await
                         }
                     }
                 } else {
                     quote! {
                         if let ::core::option::Option::Some(t) = tenant_id {
-                            load_query.filter(#table_ident::tenant_id.eq(t)).for_update().load::<#model_name>(conn).await
+                            ::autumn_web::maybe_for_update!(load_query.filter(#table_ident::tenant_id.eq(t))).load::<#model_name>(conn).await
                         } else {
-                            load_query.for_update().load::<#model_name>(conn).await
+                            ::autumn_web::maybe_for_update!(load_query).load::<#model_name>(conn).await
                         }
                     }
                 }
             } else {
                 if config.soft_delete {
                     quote! {
-                        load_query.filter(#table_ident::deleted_at.is_null()).for_update().load::<#model_name>(conn).await
+                        ::autumn_web::maybe_for_update!(load_query.filter(#table_ident::deleted_at.is_null())).load::<#model_name>(conn).await
                     }
                 } else {
                     quote! {
-                        load_query.for_update().load::<#model_name>(conn).await
+                        ::autumn_web::maybe_for_update!(load_query).load::<#model_name>(conn).await
                     }
                 }
             };
@@ -7078,9 +7198,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             changes.__autumn_lock_version_expected()
                         {
                             let c = if let ::core::option::Option::Some(ref t) = tenant_id {
-                                load_query.filter(#table_ident::tenant_id.eq(t)).for_update().first::<#model_name>(conn).await
+                                ::autumn_web::maybe_for_update!(load_query.filter(#table_ident::tenant_id.eq(t))).first::<#model_name>(conn).await
                             } else {
-                                load_query.for_update().first::<#model_name>(conn).await
+                                ::autumn_web::maybe_for_update!(load_query).first::<#model_name>(conn).await
                             }
                             .optional()
                             .map_err(::autumn_web::AutumnError::from)?
@@ -7101,9 +7221,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             c
                         } else {
                             if let ::core::option::Option::Some(ref t) = tenant_id {
-                                load_query.filter(#table_ident::tenant_id.eq(t)).for_update().first::<#model_name>(conn).await
+                                ::autumn_web::maybe_for_update!(load_query.filter(#table_ident::tenant_id.eq(t))).first::<#model_name>(conn).await
                             } else {
-                                load_query.for_update().first::<#model_name>(conn).await
+                                ::autumn_web::maybe_for_update!(load_query).first::<#model_name>(conn).await
                             }
                             .optional()
                             .map_err(::autumn_web::AutumnError::from)?
@@ -7163,9 +7283,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             // version check and the UPDATE below.
                             let load_query = #table_ident::table.find(id);
                             let current = if let ::core::option::Option::Some(ref t) = tenant_id {
-                                load_query.filter(#table_ident::tenant_id.eq(t)).for_update().first::<#model_name>(conn).await
+                                ::autumn_web::maybe_for_update!(load_query.filter(#table_ident::tenant_id.eq(t))).first::<#model_name>(conn).await
                             } else {
-                                load_query.for_update().first::<#model_name>(conn).await
+                                ::autumn_web::maybe_for_update!(load_query).first::<#model_name>(conn).await
                             }
                             .optional()
                             .map_err(::autumn_web::AutumnError::from)?
@@ -7256,7 +7376,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         let current = if let ::core::option::Option::Some(expected_version) =
                             changes.__autumn_lock_version_expected()
                         {
-                            let c = load_query.for_update().first::<#model_name>(conn).await
+                            let c = ::autumn_web::maybe_for_update!(load_query).first::<#model_name>(conn).await
                                 .optional()
                                 .map_err(::autumn_web::AutumnError::from)?
                                 .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
@@ -7277,7 +7397,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             }
                             c
                         } else {
-                            load_query.for_update().first::<#model_name>(conn).await
+                            ::autumn_web::maybe_for_update!(load_query).first::<#model_name>(conn).await
                                 .optional()
                                 .map_err(::autumn_web::AutumnError::from)?
                                 .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
@@ -7315,7 +7435,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     ::autumn_web::__private::scoped_transaction::<_, ::autumn_web::AutumnError, _, _>(&mut *conn, |conn| {
                         async move {
                             let load_query = #table_ident::table.find(id);
-                            let current = load_query.for_update().first::<#model_name>(conn).await
+                            let current = ::autumn_web::maybe_for_update!(load_query).first::<#model_name>(conn).await
                             .optional()
                             .map_err(::autumn_web::AutumnError::from)?
                             .ok_or_else(|| ::autumn_web::AutumnError::not_found_msg(
@@ -7392,9 +7512,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     ::autumn_web::__private::scoped_transaction::<_, ::autumn_web::AutumnError, _, _>(&mut *conn, |conn| async move {
                         let load_query = #table_ident::table.find(id).filter(#table_ident::deleted_at.is_null());
                         let record = if let ::core::option::Option::Some(ref t) = tenant_id {
-                            load_query.filter(#table_ident::tenant_id.eq(t)).for_update().first::<#model_name>(conn).await
+                            ::autumn_web::maybe_for_update!(load_query.filter(#table_ident::tenant_id.eq(t))).first::<#model_name>(conn).await
                         } else {
-                            load_query.for_update().first::<#model_name>(conn).await
+                            ::autumn_web::maybe_for_update!(load_query).first::<#model_name>(conn).await
                         }
                         .optional()
                         .map_err(::autumn_web::AutumnError::from)?
@@ -7471,9 +7591,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     ::autumn_web::__private::scoped_transaction::<_, ::autumn_web::AutumnError, _, _>(&mut *conn, |conn| async move {
                         let load_query = #table_ident::table.find(id);
                         let record = if let ::core::option::Option::Some(ref t) = tenant_id {
-                            load_query.filter(#table_ident::tenant_id.eq(t)).for_update().first::<#model_name>(conn).await
+                            ::autumn_web::maybe_for_update!(load_query.filter(#table_ident::tenant_id.eq(t))).first::<#model_name>(conn).await
                         } else {
-                            load_query.for_update().first::<#model_name>(conn).await
+                            ::autumn_web::maybe_for_update!(load_query).first::<#model_name>(conn).await
                         }
                         .optional()
                         .map_err(::autumn_web::AutumnError::from)?
@@ -7545,9 +7665,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     let __now = ::autumn_web::reexports::chrono::Utc::now().naive_utc();
                     let mut conn = self.__autumn_acquire_conn().await?;
                     ::autumn_web::__private::scoped_transaction::<_, ::autumn_web::AutumnError, _, _>(&mut *conn, |conn| async move {
-                        let record = #table_ident::table.find(id)
-                            .filter(#table_ident::deleted_at.is_null())
-                            .for_update()
+                        let record = ::autumn_web::maybe_for_update!(#table_ident::table.find(id)
+                            .filter(#table_ident::deleted_at.is_null()))
+
                             .first::<#model_name>(conn)
                             .await
                             .optional()
@@ -7609,8 +7729,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 use ::autumn_web::reexports::scoped_futures::ScopedFutureExt as _;
                 let mut conn = self.__autumn_acquire_conn().await?;
                 ::autumn_web::__private::scoped_transaction::<_, ::autumn_web::AutumnError, _, _>(&mut *conn, |conn| async move {
-                    let record = #table_ident::table.find(id)
-                        .for_update()
+                    let record = ::autumn_web::maybe_for_update!(#table_ident::table.find(id))
+
                         .first::<#model_name>(conn)
                         .await
                         .optional()
@@ -7685,19 +7805,59 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     async move {
                         let mut inserted = Vec::new();
                         let cols = (&new[0]).__autumn_column_count() + #tenant_extra;
-                        let chunk_size = if cols == 0 { 1000 } else { (65535usize / cols).min(1000).max(1) };
+                        let chunk_size = if cols == 0 { 1000 } else { (::autumn_web::repository::MAX_BIND_PARAMS / cols).min(1000).max(1) };
                         for chunk in new.chunks(chunk_size) {
                             let chunk_inserted = if let ::core::option::Option::Some(t) = tenant_id {
                                 let values: Vec<_> = chunk.iter().cloned().map(|item| ::autumn_web::tenancy::TenantInsertable::tenant_values(item, t)).collect();
-                                ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
-                                    .values(values)
-                                    .get_results::<#model_name>(conn)
+                                ::autumn_web::backend_select! {
+                        pg => {
+                            ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                .values(values)
+                                .get_results::<#model_name>(conn)
+                                .await
+                        },
+                        sqlite => {
+                            let mut __autumn_inserted = ::std::vec::Vec::new();
+                            let mut __autumn_res: ::core::result::Result<(), ::autumn_web::reexports::diesel::result::Error> =
+                                ::core::result::Result::Ok(());
+                            for __autumn_row in values {
+                                match ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                    .values(__autumn_row)
+                                    .get_result::<#model_name>(conn)
                                     .await
+                                {
+                                    ::core::result::Result::Ok(__r) => __autumn_inserted.push(__r),
+                                    ::core::result::Result::Err(__e) => { __autumn_res = ::core::result::Result::Err(__e); break; }
+                                }
+                            }
+                            __autumn_res.map(|()| __autumn_inserted)
+                        },
+                    }
                             } else {
-                                ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
-                                    .values(chunk.to_vec())
-                                    .get_results::<#model_name>(conn)
+                                ::autumn_web::backend_select! {
+                        pg => {
+                            ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                .values(chunk.to_vec())
+                                .get_results::<#model_name>(conn)
+                                .await
+                        },
+                        sqlite => {
+                            let mut __autumn_inserted = ::std::vec::Vec::new();
+                            let mut __autumn_res: ::core::result::Result<(), ::autumn_web::reexports::diesel::result::Error> =
+                                ::core::result::Result::Ok(());
+                            for __autumn_row in chunk.to_vec() {
+                                match ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                    .values(__autumn_row)
+                                    .get_result::<#model_name>(conn)
                                     .await
+                                {
+                                    ::core::result::Result::Ok(__r) => __autumn_inserted.push(__r),
+                                    ::core::result::Result::Err(__e) => { __autumn_res = ::core::result::Result::Err(__e); break; }
+                                }
+                            }
+                            __autumn_res.map(|()| __autumn_inserted)
+                        },
+                    }
                             }
                             .map_err(::autumn_web::AutumnError::from)?;
                             for r in &chunk_inserted {
@@ -7736,19 +7896,59 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     async move {
                         let mut inserted = Vec::new();
                         let cols = (&new[0]).__autumn_column_count() + #tenant_extra;
-                        let chunk_size = if cols == 0 { 1000 } else { (65535usize / cols).min(1000).max(1) };
+                        let chunk_size = if cols == 0 { 1000 } else { (::autumn_web::repository::MAX_BIND_PARAMS / cols).min(1000).max(1) };
                         for chunk in new.chunks(chunk_size) {
                             let chunk_inserted = if let ::core::option::Option::Some(t) = tenant_id {
                                 let values: Vec<_> = chunk.iter().cloned().map(|item| ::autumn_web::tenancy::TenantInsertable::tenant_values(item, t)).collect();
-                                ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
-                                    .values(values)
-                                    .get_results::<#model_name>(conn)
+                                ::autumn_web::backend_select! {
+                        pg => {
+                            ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                .values(values)
+                                .get_results::<#model_name>(conn)
+                                .await
+                        },
+                        sqlite => {
+                            let mut __autumn_inserted = ::std::vec::Vec::new();
+                            let mut __autumn_res: ::core::result::Result<(), ::autumn_web::reexports::diesel::result::Error> =
+                                ::core::result::Result::Ok(());
+                            for __autumn_row in values {
+                                match ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                    .values(__autumn_row)
+                                    .get_result::<#model_name>(conn)
                                     .await
+                                {
+                                    ::core::result::Result::Ok(__r) => __autumn_inserted.push(__r),
+                                    ::core::result::Result::Err(__e) => { __autumn_res = ::core::result::Result::Err(__e); break; }
+                                }
+                            }
+                            __autumn_res.map(|()| __autumn_inserted)
+                        },
+                    }
                             } else {
-                                ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
-                                    .values(chunk.to_vec())
-                                    .get_results::<#model_name>(conn)
+                                ::autumn_web::backend_select! {
+                        pg => {
+                            ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                .values(chunk.to_vec())
+                                .get_results::<#model_name>(conn)
+                                .await
+                        },
+                        sqlite => {
+                            let mut __autumn_inserted = ::std::vec::Vec::new();
+                            let mut __autumn_res: ::core::result::Result<(), ::autumn_web::reexports::diesel::result::Error> =
+                                ::core::result::Result::Ok(());
+                            for __autumn_row in chunk.to_vec() {
+                                match ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                    .values(__autumn_row)
+                                    .get_result::<#model_name>(conn)
                                     .await
+                                {
+                                    ::core::result::Result::Ok(__r) => __autumn_inserted.push(__r),
+                                    ::core::result::Result::Err(__e) => { __autumn_res = ::core::result::Result::Err(__e); break; }
+                                }
+                            }
+                            __autumn_res.map(|()| __autumn_inserted)
+                        },
+                    }
                             }
                             .map_err(::autumn_web::AutumnError::from)?;
                             inserted.extend(chunk_inserted);
@@ -7785,12 +7985,32 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     async move {
                         let mut inserted = Vec::new();
                         let cols = (&new[0]).__autumn_column_count() + #tenant_extra;
-                        let chunk_size = if cols == 0 { 1000 } else { (65535usize / cols).min(1000).max(1) };
+                        let chunk_size = if cols == 0 { 1000 } else { (::autumn_web::repository::MAX_BIND_PARAMS / cols).min(1000).max(1) };
                         for chunk in new.chunks(chunk_size) {
-                            let chunk_inserted = ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                            let chunk_inserted = ::autumn_web::backend_select! {
+                        pg => {
+                            ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
                                 .values(chunk.to_vec())
                                 .get_results::<#model_name>(conn)
                                 .await
+                        },
+                        sqlite => {
+                            let mut __autumn_inserted = ::std::vec::Vec::new();
+                            let mut __autumn_res: ::core::result::Result<(), ::autumn_web::reexports::diesel::result::Error> =
+                                ::core::result::Result::Ok(());
+                            for __autumn_row in chunk.to_vec() {
+                                match ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                    .values(__autumn_row)
+                                    .get_result::<#model_name>(conn)
+                                    .await
+                                {
+                                    ::core::result::Result::Ok(__r) => __autumn_inserted.push(__r),
+                                    ::core::result::Result::Err(__e) => { __autumn_res = ::core::result::Result::Err(__e); break; }
+                                }
+                            }
+                            __autumn_res.map(|()| __autumn_inserted)
+                        },
+                    }
                                 .map_err(::autumn_web::AutumnError::from)?;
                             for r in &chunk_inserted {
                                 #vh_r
@@ -7820,12 +8040,32 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     async move {
                         let mut inserted = Vec::new();
                         let cols = (&new[0]).__autumn_column_count() + #tenant_extra;
-                        let chunk_size = if cols == 0 { 1000 } else { (65535usize / cols).min(1000).max(1) };
+                        let chunk_size = if cols == 0 { 1000 } else { (::autumn_web::repository::MAX_BIND_PARAMS / cols).min(1000).max(1) };
                         for chunk in new.chunks(chunk_size) {
-                            let chunk_inserted = ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                            let chunk_inserted = ::autumn_web::backend_select! {
+                        pg => {
+                            ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
                                 .values(chunk.to_vec())
                                 .get_results::<#model_name>(conn)
                                 .await
+                        },
+                        sqlite => {
+                            let mut __autumn_inserted = ::std::vec::Vec::new();
+                            let mut __autumn_res: ::core::result::Result<(), ::autumn_web::reexports::diesel::result::Error> =
+                                ::core::result::Result::Ok(());
+                            for __autumn_row in chunk.to_vec() {
+                                match ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                    .values(__autumn_row)
+                                    .get_result::<#model_name>(conn)
+                                    .await
+                                {
+                                    ::core::result::Result::Ok(__r) => __autumn_inserted.push(__r),
+                                    ::core::result::Result::Err(__e) => { __autumn_res = ::core::result::Result::Err(__e); break; }
+                                }
+                            }
+                            __autumn_res.map(|()| __autumn_inserted)
+                        },
+                    }
                                 .map_err(::autumn_web::AutumnError::from)?;
                             inserted.extend(chunk_inserted);
                         }
@@ -7886,23 +8126,83 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 quote! {
                     if let ::core::option::Option::Some(t) = tenant_id {
                         let values: Vec<_> = chunk.iter().cloned().map(|item| ::autumn_web::tenancy::TenantInsertable::tenant_values(item, t)).collect();
-                        ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
-                            .values(values)
-                            .get_results::<#model_name>(conn)
-                            .await
+                        ::autumn_web::backend_select! {
+                        pg => {
+                            ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                .values(values)
+                                .get_results::<#model_name>(conn)
+                                .await
+                        },
+                        sqlite => {
+                            let mut __autumn_inserted = ::std::vec::Vec::new();
+                            let mut __autumn_res: ::core::result::Result<(), ::autumn_web::reexports::diesel::result::Error> =
+                                ::core::result::Result::Ok(());
+                            for __autumn_row in values {
+                                match ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                    .values(__autumn_row)
+                                    .get_result::<#model_name>(conn)
+                                    .await
+                                {
+                                    ::core::result::Result::Ok(__r) => __autumn_inserted.push(__r),
+                                    ::core::result::Result::Err(__e) => { __autumn_res = ::core::result::Result::Err(__e); break; }
+                                }
+                            }
+                            __autumn_res.map(|()| __autumn_inserted)
+                        },
+                    }
                     } else {
-                        ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
-                            .values(chunk.to_vec())
-                            .get_results::<#model_name>(conn)
-                            .await
+                        ::autumn_web::backend_select! {
+                        pg => {
+                            ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                .values(chunk.to_vec())
+                                .get_results::<#model_name>(conn)
+                                .await
+                        },
+                        sqlite => {
+                            let mut __autumn_inserted = ::std::vec::Vec::new();
+                            let mut __autumn_res: ::core::result::Result<(), ::autumn_web::reexports::diesel::result::Error> =
+                                ::core::result::Result::Ok(());
+                            for __autumn_row in chunk.to_vec() {
+                                match ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                    .values(__autumn_row)
+                                    .get_result::<#model_name>(conn)
+                                    .await
+                                {
+                                    ::core::result::Result::Ok(__r) => __autumn_inserted.push(__r),
+                                    ::core::result::Result::Err(__e) => { __autumn_res = ::core::result::Result::Err(__e); break; }
+                                }
+                            }
+                            __autumn_res.map(|()| __autumn_inserted)
+                        },
+                    }
                     }
                 }
             } else {
                 quote! {
-                    ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
-                        .values(chunk.to_vec())
-                        .get_results::<#model_name>(conn)
-                        .await
+                    ::autumn_web::backend_select! {
+                        pg => {
+                            ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                .values(chunk.to_vec())
+                                .get_results::<#model_name>(conn)
+                                .await
+                        },
+                        sqlite => {
+                            let mut __autumn_inserted = ::std::vec::Vec::new();
+                            let mut __autumn_res: ::core::result::Result<(), ::autumn_web::reexports::diesel::result::Error> =
+                                ::core::result::Result::Ok(());
+                            for __autumn_row in chunk.to_vec() {
+                                match ::autumn_web::reexports::diesel::insert_into(#table_ident::table)
+                                    .values(__autumn_row)
+                                    .get_result::<#model_name>(conn)
+                                    .await
+                                {
+                                    ::core::result::Result::Ok(__r) => __autumn_inserted.push(__r),
+                                    ::core::result::Result::Err(__e) => { __autumn_res = ::core::result::Result::Err(__e); break; }
+                                }
+                            }
+                            __autumn_res.map(|()| __autumn_inserted)
+                        },
+                    }
                 }
             };
 
@@ -7949,7 +8249,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
                 let mut offset = 0;
                 let cols = (&new[0]).__autumn_column_count() + #tenant_extra;
-                let chunk_size = if cols == 0 { 1000 } else { (65535usize / cols).min(1000).max(1) };
+                let chunk_size = if cols == 0 { 1000 } else { (::autumn_web::repository::MAX_BIND_PARAMS / cols).min(1000).max(1) };
                 for chunk in new.chunks(chunk_size) {
                     let batch_res = ::autumn_web::__private::scoped_transaction::<_, ::autumn_web::AutumnError, _, _>(&mut *conn, |conn| {
                         async move {
@@ -8046,14 +8346,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             let vh_load_before_map_no_lock_expr = if config.tenant_scoped {
                 quote! {
                     if let ::core::option::Option::Some(t) = tenant_id {
-                        load_query.filter(#table_ident::tenant_id.eq(t)).for_update().load::<#model_name>(conn).await
+                        ::autumn_web::maybe_for_update!(load_query.filter(#table_ident::tenant_id.eq(t))).load::<#model_name>(conn).await
                     } else {
-                        load_query.for_update().load::<#model_name>(conn).await
+                        ::autumn_web::maybe_for_update!(load_query).load::<#model_name>(conn).await
                     }
                 }
             } else {
                 quote! {
-                    load_query.for_update().load::<#model_name>(conn).await
+                    ::autumn_web::maybe_for_update!(load_query).load::<#model_name>(conn).await
                 }
             };
             let vh_load_before_map_no_lock = if config.versioned {
@@ -8098,14 +8398,14 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             let load_expr = if config.tenant_scoped {
                 quote! {
                     if let ::core::option::Option::Some(t) = tenant_id {
-                        load_query.filter(#table_ident::tenant_id.eq(t)).for_update().load::<#model_name>(conn).await
+                        ::autumn_web::maybe_for_update!(load_query.filter(#table_ident::tenant_id.eq(t))).load::<#model_name>(conn).await
                     } else {
-                        load_query.for_update().load::<#model_name>(conn).await
+                        ::autumn_web::maybe_for_update!(load_query).load::<#model_name>(conn).await
                     }
                 }
             } else {
                 quote! {
-                    load_query.for_update().load::<#model_name>(conn).await
+                    ::autumn_web::maybe_for_update!(load_query).load::<#model_name>(conn).await
                 }
             };
 
@@ -8237,9 +8537,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             .filter(#table_ident::id.eq_any(chunk))
                             #soft_delete_filter;
                         let chunk_rows = if let ::core::option::Option::Some(t) = tenant_id {
-                            load_query.filter(#table_ident::tenant_id.eq(t)).for_update().load::<#model_name>(conn).await
+                            ::autumn_web::maybe_for_update!(load_query.filter(#table_ident::tenant_id.eq(t))).load::<#model_name>(conn).await
                         } else {
-                            load_query.for_update().load::<#model_name>(conn).await
+                            ::autumn_web::maybe_for_update!(load_query).load::<#model_name>(conn).await
                         }
                         .map_err(::autumn_web::AutumnError::from)?;
                     }
@@ -8248,7 +8548,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         let load_query = #table_ident::table
                             .filter(#table_ident::id.eq_any(chunk))
                             #soft_delete_filter;
-                        let chunk_rows = load_query.for_update().load::<#model_name>(conn).await
+                        let chunk_rows = ::autumn_web::maybe_for_update!(load_query).load::<#model_name>(conn).await
                             .map_err(::autumn_web::AutumnError::from)?;
                     }
                 };
@@ -8596,25 +8896,25 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             let load_expr = if config.tenant_scoped {
                 quote! {
                     if let ::core::option::Option::Some(ref t) = tenant_id {
-                        #table_ident::table
+                        ::autumn_web::maybe_for_update!(#table_ident::table
                             .filter(#table_ident::id.eq_any(&chunk_ids))
-                            .filter(#table_ident::tenant_id.eq(t.clone()))
-                            .for_update()
+                            .filter(#table_ident::tenant_id.eq(t.clone())))
+
                             .load::<#model_name>(conn)
                             .await
                     } else {
-                        #table_ident::table
-                            .filter(#table_ident::id.eq_any(&chunk_ids))
-                            .for_update()
+                        ::autumn_web::maybe_for_update!(#table_ident::table
+                            .filter(#table_ident::id.eq_any(&chunk_ids)))
+
                             .load::<#model_name>(conn)
                             .await
                     }
                 }
             } else {
                 quote! {
-                    #table_ident::table
-                        .filter(#table_ident::id.eq_any(&chunk_ids))
-                        .for_update()
+                    ::autumn_web::maybe_for_update!(#table_ident::table
+                        .filter(#table_ident::id.eq_any(&chunk_ids)))
+
                         .load::<#model_name>(conn)
                         .await
                 }
@@ -8681,17 +8981,17 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             .collect();
                         let __autumn_still_present: Vec<#model_name> =
                             if let ::core::option::Option::Some(ref t) = tenant_id {
-                                #table_ident::table
+                                ::autumn_web::maybe_for_update!(#table_ident::table
                                     .filter(#table_ident::id.eq_any(&__autumn_dropped_ids))
-                                    .filter(#table_ident::tenant_id.eq(t.clone()))
-                                    .for_update()
+                                    .filter(#table_ident::tenant_id.eq(t.clone())))
+
                                     .load::<#model_name>(conn)
                                     .await
                                     .map_err(::autumn_web::AutumnError::from)?
                             } else {
-                                #table_ident::table
-                                    .filter(#table_ident::id.eq_any(&__autumn_dropped_ids))
-                                    .for_update()
+                                ::autumn_web::maybe_for_update!(#table_ident::table
+                                    .filter(#table_ident::id.eq_any(&__autumn_dropped_ids)))
+
                                     .load::<#model_name>(conn)
                                     .await
                                     .map_err(::autumn_web::AutumnError::from)?
@@ -8771,7 +9071,7 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     async move {
                         let mut upserted = Vec::new();
                         let cols = (&records[0]).__autumn_column_count() + #tenant_extra;
-                        let chunk_size = if cols == 0 { 1000 } else { (65535usize / cols).min(1000).max(1) };
+                        let chunk_size = if cols == 0 { 1000 } else { (::autumn_web::repository::MAX_BIND_PARAMS / cols).min(1000).max(1) };
                         #vh_upsert_lock_keys
                         for chunk in records.chunks(chunk_size) {
                             let chunk_ids: Vec<_> = chunk.iter().map(|r| r.id).collect();
@@ -8920,9 +9220,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             quote! {
                 let __load_query = #table_ident::table.find(id) #sd_filter;
                 let #parent_record_bind = if let ::core::option::Option::Some(ref t) = tenant_id {
-                    __load_query.filter(#table_ident::tenant_id.eq(t)).for_update().first::<#model_name>(conn).await
+                    ::autumn_web::maybe_for_update!(__load_query.filter(#table_ident::tenant_id.eq(t))).first::<#model_name>(conn).await
                 } else {
-                    __load_query.for_update().first::<#model_name>(conn).await
+                    ::autumn_web::maybe_for_update!(__load_query).first::<#model_name>(conn).await
                 }
                 .optional()
                 .map_err(::autumn_web::AutumnError::from)?
@@ -8932,8 +9232,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         } else {
             quote! {
-                let #parent_record_bind = #table_ident::table.find(id) #sd_filter
-                    .for_update()
+                let #parent_record_bind = ::autumn_web::maybe_for_update!(#table_ident::table.find(id) #sd_filter)
+
                     .first::<#model_name>(conn)
                     .await
                     .optional()
@@ -14750,19 +15050,31 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 // Postgres statement_timeout is a signed 32-bit integer; cap to be safe.
                 let timeout_ms = timeout_ms.min(i32::MAX as u64);
 
-                ::autumn_web::reexports::diesel::sql_query(
-                    ::std::format!("SET statement_timeout = {timeout_ms}")
-                )
-                .execute(&mut conn)
-                .await
-                .map_err(|e| {
-                    ::autumn_web::reexports::tracing::error!(
-                        "repository: failed to set statement_timeout to {timeout_ms}ms: {e}"
-                    );
-                    ::autumn_web::AutumnError::service_unavailable_msg(
-                        ::std::format!("Database initialization error: {e}")
-                    )
-                })?;
+                // `SET statement_timeout` is Postgres session syntax; SQLite
+                // rejects it ("near \"SET\": syntax error"). SQLite has no
+                // per-statement timeout SQL — the pool already installs
+                // `busy_timeout` at connection setup — so the SQLite arm skips
+                // it. A true SQLite statement timeout is a later wave (#1996).
+                ::autumn_web::backend_select! {
+                    pg => {{
+                        ::autumn_web::reexports::diesel::sql_query(
+                            ::std::format!("SET statement_timeout = {timeout_ms}")
+                        )
+                        .execute(&mut conn)
+                        .await
+                        .map_err(|e| {
+                            ::autumn_web::reexports::tracing::error!(
+                                "repository: failed to set statement_timeout to {timeout_ms}ms: {e}"
+                            );
+                            ::autumn_web::AutumnError::service_unavailable_msg(
+                                ::std::format!("Database initialization error: {e}")
+                            )
+                        })?;
+                    }},
+                    sqlite => {{
+                        let _ = timeout_ms;
+                    }},
+                }
                 ::core::result::Result::Ok(conn)
             }
 
@@ -14802,9 +15114,9 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 let mut conn = self.__autumn_acquire_conn().await?;
                 ::autumn_web::__private::scoped_transaction::<T, ::autumn_web::AutumnError, _, _>(&mut *conn, |conn| {
                     async move {
-                        let row = #table_ident::table
-                            .find(id)
-                            .for_update()
+                        let row = ::autumn_web::maybe_for_update!(#table_ident::table
+                            .find(id))
+
                             .first::<#model_name>(conn)
                             .await
                             .optional()

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -1817,9 +1817,22 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         // hard child deletes (the `#destroy_live_filter` gate is applied
                         // BEFORE `FOR UPDATE`, so the locked row set matches the rows
                         // the pre-scan + mutating pass operate on).
+                        // The `FOR UPDATE` locking clause is emitted only on
+                        // Postgres. `SQLite` rejects `SELECT … FOR UPDATE`
+                        // outright, and it needs no such clause: its single-writer
+                        // database-level lock already serializes concurrent
+                        // cascades (the same rationale that degrades the DSL
+                        // `maybe_for_update!` seam to a plain read on `SQLite`).
+                        // The suffix is selected in autumn-web's compilation via
+                        // `backend_select!`, so the Postgres SQL is byte-identical
+                        // to before and the `SQLite` form simply drops the clause.
+                        let __for_update: &str = ::autumn_web::backend_select! {
+                            pg => { " FOR UPDATE" },
+                            sqlite => { "" },
+                        };
                         let __q = format!(
-                            "SELECT id FROM \"{}\" WHERE \"{}\" = $1{} ORDER BY id FOR UPDATE",
-                            __table, __fk_column, #destroy_live_filter
+                            "SELECT id FROM \"{}\" WHERE \"{}\" = $1{} ORDER BY id{}",
+                            __table, __fk_column, #destroy_live_filter, __for_update
                         );
                         let __ids: ::std::vec::Vec<__AutumnDepId> =
                             ::autumn_web::reexports::diesel::sql_query(__q)
@@ -16678,9 +16691,15 @@ mod tests {
             .find("MutationOp :: Delete")
             .expect("delete path should still be generated");
         let delete_generated = &generated[delete_start..];
+        // The delete path now locks the row through the `maybe_for_update!`
+        // backend seam (`FOR UPDATE` on Postgres, a plain read on `SQLite`)
+        // instead of a bare `.for_update()` chain. The lock must still be
+        // applied to the load that precedes `before_delete`.
         let delete_lock = delete_generated
-            .find(". for_update ()")
-            .expect("delete path should lock the row before before_delete");
+            .find("maybe_for_update ! (load_query)")
+            .expect(
+                "delete path should lock the row (maybe_for_update! seam) before before_delete",
+            );
         let before_delete = delete_generated
             .find("before_delete")
             .expect("before_delete hook should still be generated");
@@ -17414,8 +17433,10 @@ mod tests {
         // is already parent-soft-gated, so on a HARD parent delete it returns
         // already-soft-deleted children too; a live-only reload would return
         // `None`, skip the hard delete, and leave the FK to fail the parent
-        // DELETE. Assert the reload goes straight `find(__cid).for_update()` with
-        // no intervening `deleted_at` filter, even for a soft_delete child.
+        // DELETE. Assert the reload loads the selected id straight into the
+        // `maybe_for_update!` lock seam (`FOR UPDATE` on Postgres, a plain read
+        // on `SQLite`) with no intervening `deleted_at` filter, even for a
+        // soft_delete child.
         let generated = repository_macro(
             quote! { Comment, soft_delete, dependent(PgReplyRepository, fk = "comment_id", on_delete = destroy) },
             quote! { pub trait CommentRepository {} },
@@ -17423,9 +17444,10 @@ mod tests {
         .to_string();
         let destroy_arm = dependent_destroy_arm(&generated);
         assert!(
-            destroy_arm.contains("find (__cid) . for_update"),
-            "the per-ID reload must load the selected id straight to for_update, \
-             with no deleted_at filter that could drop a pre-soft-deleted child: {destroy_arm}"
+            destroy_arm.contains("maybe_for_update ! (comments :: table . find (__cid))"),
+            "the per-ID reload must load the selected id straight into the \
+             maybe_for_update! lock wrapper, with no deleted_at filter that could \
+             drop a pre-soft-deleted child: {destroy_arm}"
         );
     }
 
@@ -17601,8 +17623,15 @@ mod tests {
         // through to a raw FK error (or a soft delete proceeds despite a live
         // restrict dependent). Holding `FOR UPDATE` on the child row blocks the
         // concurrent grandchild insert's `FOR KEY SHARE` on that referenced row,
-        // closing the TOCTOU window between probe and hook/delete. Structurally:
-        // the `SELECT id ... ORDER BY id FOR UPDATE` id query must precede the
+        // closing the TOCTOU window between probe and hook/delete.
+        //
+        // The child-id SELECT now appends a backend-gated lock suffix rather than
+        // a hard-coded `FOR UPDATE`: `... ORDER BY id{}` where the `{}` binding
+        // (`__for_update`) is `" FOR UPDATE"` on Postgres and `""` on `SQLite`
+        // (which rejects `SELECT … FOR UPDATE`), selected in autumn-web's
+        // compilation via `backend_select!`. The Postgres SQL is byte-identical to
+        // before. Structurally: the backend-gated `FOR UPDATE` lock must still be
+        // applied to the `SELECT id ... ORDER BY id` query, which must precede the
         // `for __row in & __ids` pre-scan loop.
         let generated = repository_macro(
             quote! {
@@ -17615,10 +17644,17 @@ mod tests {
         )
         .to_string();
         let destroy_arm = dependent_destroy_arm(&generated);
-        // The child-id selection SQL literal must acquire the row lock.
-        let id_lock_pos = destroy_arm.find("ORDER BY id FOR UPDATE").expect(
-            "Codex P2: the child-id selection feeding the restrict pre-scan must \
-             acquire FOR UPDATE (SELECT id ... ORDER BY id FOR UPDATE)",
+        // The Postgres arm of the backend-gated lock suffix must still emit
+        // `FOR UPDATE`, bound into the child-id SELECT's `ORDER BY id{}` clause.
+        let pg_lock_pos = destroy_arm
+            .find("backend_select ! { pg => { \" FOR UPDATE\" } , sqlite => { \"\" } , }")
+            .expect(
+                "Codex P2: the child-id selection feeding the restrict pre-scan must \
+                 acquire FOR UPDATE on Postgres via the backend_select! lock seam",
+            );
+        let ordered_lock_pos = destroy_arm.find("ORDER BY id{}").expect(
+            "Codex P2: the child-id SELECT must append the backend-gated lock \
+             suffix to its ORDER BY id clause (SELECT id ... ORDER BY id{})",
         );
         let id_select_pos = destroy_arm
             .find("SELECT id FROM")
@@ -17626,12 +17662,16 @@ mod tests {
         let prescan_pos = destroy_arm
             .find("for __row in & __ids")
             .expect("the restrict pre-scan loop must be emitted");
+        // The backend-gated FOR UPDATE lock belongs to the child-id SELECT: the
+        // `__for_update` suffix binding is emitted just before the `format!`, and
+        // the `ORDER BY id{}` clause consumes it in the same query.
         assert!(
-            id_select_pos <= id_lock_pos,
-            "Codex P2: FOR UPDATE must belong to the child-id SELECT: {destroy_arm}"
+            pg_lock_pos < id_select_pos && id_select_pos < ordered_lock_pos,
+            "Codex P2: the backend-gated FOR UPDATE lock must belong to the child-id \
+             SELECT (ORDER BY id{{}} suffix): {destroy_arm}"
         );
         assert!(
-            id_lock_pos < prescan_pos,
+            id_select_pos < prescan_pos && ordered_lock_pos < prescan_pos,
             "Codex P2: the locked child-id SELECT must run BEFORE the restrict \
              pre-scan EXISTS pass so no FK insert can slip between probe and hook: \
              {destroy_arm}"
@@ -18760,13 +18800,19 @@ mod tests {
         )
         .to_string();
 
+        // The versioned-update load was reshaped: a single `load_query` is now
+        // declared once, and the no-expected-version arm is the `else` branch that
+        // loads the before image through the `maybe_for_update!` lock seam
+        // (`FOR UPDATE` on Postgres, a plain read on `SQLite`) instead of a bare
+        // `.for_update()` chain. That branch must still lock the row before the
+        // history diff (`INSERT INTO _autumn_version_history`) is computed.
         let no_expected_branch = generated
-            .find("} else { load_query")
+            .find("} else { :: autumn_web :: maybe_for_update ! (load_query)")
             .expect("versioned update should have a no-expected-version load branch");
         let section = &generated[no_expected_branch..];
         let lock_pos = section
-            .find(". for_update ()")
-            .expect("versioned update must lock the row before computing history diff");
+            .find("maybe_for_update ! (load_query)")
+            .expect("versioned update must lock the row (maybe_for_update! seam) before computing history diff");
         let first_pos = section
             .find(". first :: < Post >")
             .expect("versioned update should load the row before applying the update");
@@ -18776,7 +18822,7 @@ mod tests {
 
         assert!(
             lock_pos < first_pos && first_pos < history_pos,
-            "versioned update must SELECT FOR UPDATE before loading the before image and writing history: {section}"
+            "versioned update must lock (maybe_for_update! → FOR UPDATE on Postgres) before loading the before image and writing history: {section}"
         );
     }
 

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -435,6 +435,18 @@ path = "tests/sqlite_read_only_pool.rs"
 name = "sqlite_scoped_repository"
 path = "tests/sqlite_scoped_repository.rs"
 
+# Basic `#[repository]` CRUD proof on the SQLite backend (issue #1996, wave B+C):
+# instantiates a simple model + repository and exercises the always-emitted CRUD
+# (save/find_by_id/update/count/save_many/delete_by_id) on an in-memory SQLite
+# pool, proving the FOR UPDATE removal + on_conflict/batch dialect port compile
+# AND run with no Docker. Only meaningful under `--features sqlite`; the file is
+# `#![cfg(feature = "sqlite")]` so a default `cargo test` compiles it to an empty
+# (passing) binary. Run explicitly:
+# `cargo test -p autumn-web --features sqlite --test sqlite_crud_basic`.
+[[test]]
+name = "sqlite_crud_basic"
+path = "tests/sqlite_crud_basic.rs"
+
 # SQLite read-only-transaction safety proof (issue #1614, Codex P2). The SQLite
 # arm of `Db::tx_with` cannot enforce `READ ONLY`, so a `TxOptions::read_only()`
 # request is rejected before the closure runs rather than silently running a

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -461,6 +461,20 @@ path = "tests/sqlite_crud_basic.rs"
 name = "sqlite_upsert_isolation"
 path = "tests/sqlite_upsert_isolation.rs"
 
+# SQLite `dependent(..., on_delete = destroy)` cascade proof (issue #1996, PR
+# #2021). The Destroy arm selects child ids with a hand-built SQL string that
+# used to emit a trailing `FOR UPDATE` (rejected by SQLite) — outside the
+# `maybe_for_update!` DSL seam. This test proves the `backend_select!`-gated fix:
+# `delete_by_id` on a parent with a `destroy` child succeeds on an in-memory
+# SQLite pool and actually deletes the dependent child rows, with no Docker. Only
+# meaningful under `--features sqlite`; the file is `#![cfg(feature = "sqlite")]`
+# so a default `cargo test` compiles it to an empty (passing) binary. Run
+# explicitly:
+# `cargo test -p autumn-web --features sqlite --test sqlite_dependent_destroy`.
+[[test]]
+name = "sqlite_dependent_destroy"
+path = "tests/sqlite_dependent_destroy.rs"
+
 # SQLite read-only-transaction safety proof (issue #1614, Codex P2). The SQLite
 # arm of `Db::tx_with` cannot enforce `READ ONLY`, so a `TxOptions::read_only()`
 # request is rejected before the closure runs rather than silently running a

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -447,6 +447,20 @@ path = "tests/sqlite_scoped_repository.rs"
 name = "sqlite_crud_basic"
 path = "tests/sqlite_crud_basic.rs"
 
+# SQLite upsert isolation + optimistic-lock proof (issue #1996, PR #2021): the two
+# P1 fixes on the cfg-dual `__autumn_execute_upsert` SQLite arm. Proves (Bug 2,
+# SECURITY) a tenant-scoped `upsert_many` under tenant B with tenant A's id leaves
+# tenant A's row untouched (no cross-tenant leak) and (Bug 2, lock) a stale
+# `lock_version` upsert surfaces a 409 — matching Postgres. Runs on an in-memory
+# SQLite pool with no Docker. Bug 1 (advisory-lock cfg-gate) is pinned by the
+# autumn-macros expansion test. Only meaningful under `--features sqlite`; the
+# file is `#![cfg(feature = "sqlite")]` so a default `cargo test` compiles it to
+# an empty (passing) binary. Run explicitly:
+# `cargo test -p autumn-web --features sqlite --test sqlite_upsert_isolation`.
+[[test]]
+name = "sqlite_upsert_isolation"
+path = "tests/sqlite_upsert_isolation.rs"
+
 # SQLite read-only-transaction safety proof (issue #1614, Codex P2). The SQLite
 # arm of `Db::tx_with` cannot enforce `READ ONLY`, so a `TxOptions::read_only()`
 # request is rejected before the closure runs rather than silently running a

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -69,6 +69,25 @@ pub type RuntimeConnection = diesel_async::AsyncPgConnection;
 pub type RuntimeConnection =
     diesel_async::sync_connection_wrapper::SyncConnectionWrapper<diesel::SqliteConnection>;
 
+/// The diesel query backend the runtime is built against — the companion of
+/// [`RuntimeConnection`].
+///
+/// Defaults to Postgres (`diesel::pg::Pg`); the `sqlite` feature flips it to
+/// `diesel::sqlite::Sqlite`. Generated `#[repository]`/`#[model]` CRUD names
+/// this alias (as `::autumn_web::RuntimeBackend`) wherever a diesel
+/// `QueryFragment<_>` / `SelectableHelper<_>` bound must resolve to the *active*
+/// backend rather than a hard-coded `Pg`. Threading it (instead of `Pg`) through
+/// the always-emitted upsert set-clause and boxed-query types is what lets the
+/// same generated code type-check on either backend. Genuinely Postgres-only
+/// query fragments (advisory-lock upserts, FTS `searchable`) keep an explicit
+/// `Pg` bound — they are not portable and are cfg-gated off under `sqlite`.
+#[cfg(not(feature = "sqlite"))]
+pub type RuntimeBackend = diesel::pg::Pg;
+/// See [`RuntimeBackend`] (Postgres variant). Under the `sqlite` feature the
+/// runtime query backend is `diesel::sqlite::Sqlite`.
+#[cfg(feature = "sqlite")]
+pub type RuntimeBackend = diesel::sqlite::Sqlite;
+
 // ── After-commit callback infrastructure ─────────────────────────────────────
 
 /// A boxed async callback registered for post-transaction execution.

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -592,6 +592,13 @@ pub use db::{IsolationLevel, TxOptions, savepoint};
 #[cfg(feature = "db")]
 pub use db::RuntimeConnection;
 
+/// The runtime diesel query backend (`diesel::pg::Pg` by default;
+/// `diesel::sqlite::Sqlite` under the `sqlite` feature). Named by generated
+/// `#[repository]`/`#[model]` code as `::autumn_web::RuntimeBackend`. See
+/// [`db::RuntimeBackend`].
+#[cfg(feature = "db")]
+pub use db::RuntimeBackend;
+
 /// Framework error type and result alias.
 ///
 /// [`AutumnError`] wraps any `Error + Send + Sync` with an HTTP status code.

--- a/autumn/src/preload.rs
+++ b/autumn/src/preload.rs
@@ -350,7 +350,7 @@ macro_rules! impl_preloadable_leaf {
             fn load_associations<'__a>(
                 _records: &'__a mut [$crate::preload::Preloaded<Self>],
                 _spec: &'__a Self::Spec,
-                _conn: &'__a mut $crate::reexports::diesel_async::AsyncPgConnection,
+                _conn: &'__a mut $crate::RuntimeConnection,
             ) -> $crate::preload::PreloadFuture<'__a> {
                 ::std::boxed::Box::pin(async move { ::core::result::Result::Ok(()) })
             }
@@ -392,7 +392,7 @@ mod db_support {
         fn load_associations<'a>(
             records: &'a mut [Preloaded<Self>],
             spec: &'a Self::Spec,
-            conn: &'a mut crate::reexports::diesel_async::AsyncPgConnection,
+            conn: &'a mut crate::db::RuntimeConnection,
         ) -> PreloadFuture<'a>;
     }
 }

--- a/autumn/src/repository.rs
+++ b/autumn/src/repository.rs
@@ -27,6 +27,88 @@
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
+/// Backend-portable `FOR UPDATE` seam for generated `#[repository]` CRUD.
+///
+/// Postgres pessimistic-lock reads chain `.for_update()` onto a select query to
+/// take a row lock, but diesel's `LockingClause` only implements
+/// `QueryFragment<Pg>` — the same query is not constructible against the
+/// `SQLite` backend at all, so even a *simple* repository's always-emitted lock
+/// reads would fail to compile under `--features sqlite`. Worse, diesel's
+/// `FOR UPDATE` lock marker is `pub(crate)`, so no generic extension trait in a
+/// downstream crate can name the bound `for_update()` needs — a portable seam
+/// cannot be a plain trait.
+///
+/// This macro is that seam: the `#[repository]` macro emits
+/// `::autumn_web::maybe_for_update!(<query>)` where it used to chain
+/// `<query>.for_update()`, and the returned query is still loadable
+/// (`.first(...)`/`.load(...)`), so the generated call chains compose
+/// identically on either backend. Because the `#[cfg]` that selects the
+/// expansion lives on the macro **definition**, it is evaluated in
+/// **autumn-web's** compilation (where the `sqlite` feature actually lives) —
+/// not the consumer crate's — so a downstream app needs no `sqlite` feature of
+/// its own for the right arm to be chosen.
+///
+/// - **Postgres** (default): expands to `QueryDsl::for_update(<query>)` — the
+///   `FOR UPDATE` locking clause, unchanged. Marker resolution happens at the
+///   concrete call site, so no unnameable bound is ever written.
+/// - **`SQLite`**: expands to `<query>` verbatim — `SQLite` has no
+///   `SELECT … FOR UPDATE` (it serializes writers with a database-level lock),
+///   so the row-lock read degrades to a plain read. Write-write correctness
+///   still rests on the optimistic `lock_version` check plus the pool's
+///   `busy_timeout`; see [`crate::db::RuntimeConnection`] and issue #1996 for
+///   the residual single-writer concurrency caveat.
+#[cfg(all(feature = "db", not(feature = "sqlite")))]
+#[macro_export]
+macro_rules! maybe_for_update {
+    ($query:expr $(,)?) => {
+        $crate::reexports::diesel::query_dsl::QueryDsl::for_update($query)
+    };
+}
+
+/// `SQLite` arm of [`maybe_for_update!`] — the identity. See the Postgres
+/// definition for the full contract; `SQLite` has no `SELECT … FOR UPDATE`, so a
+/// pessimistic-lock read degrades to a plain read.
+#[cfg(all(feature = "db", feature = "sqlite"))]
+#[macro_export]
+macro_rules! maybe_for_update {
+    ($query:expr $(,)?) => {
+        $query
+    };
+}
+
+/// Compile-time backend block selector for generated `#[repository]`/`#[model]`
+/// CRUD where the two backends need *structurally different* code (not just a
+/// swapped receiver), e.g. Postgres multi-row batch insert vs. the `SQLite`
+/// per-row loop, or the batched `ON CONFLICT` upsert vs. `SQLite`'s per-row
+/// upsert.
+///
+/// The `#[cfg]` selecting the arm lives on the macro **definition**, so it is
+/// evaluated in **autumn-web's** compilation (where the `sqlite` feature lives)
+/// — the un-selected arm's tokens are never even type-checked, which is what
+/// lets each arm use backend-specific diesel fragments (Postgres `DEFAULT`-keyword
+/// batch inserts, `SQLite` per-row `RETURNING`) that would not compile against
+/// the other backend.
+///
+/// Expands to the chosen block as an expression:
+/// `::autumn_web::backend_select! { pg => { … }, sqlite => { … } }`.
+#[cfg(all(feature = "db", not(feature = "sqlite")))]
+#[macro_export]
+macro_rules! backend_select {
+    (pg => $pg:block, sqlite => $sqlite:block $(,)?) => {
+        $pg
+    };
+}
+
+/// `SQLite` arm of [`backend_select!`]. See the Postgres definition for the
+/// contract.
+#[cfg(all(feature = "db", feature = "sqlite"))]
+#[macro_export]
+macro_rules! backend_select {
+    (pg => $pg:block, sqlite => $sqlite:block $(,)?) => {
+        $sqlite
+    };
+}
+
 /// Where a generated repository routes its read-only methods (`find_by_id`,
 /// `find_all`, `count`, `paginate`, `cursor_page`, derived `find_by_*`,
 /// full-text-search reads, …).
@@ -85,6 +167,23 @@ impl std::fmt::Debug for ReadRoute {
         }
     }
 }
+
+/// Upper bound on bound parameters in one prepared statement, per backend —
+/// used by generated bulk-write CRUD to size insert/update chunks so a batch
+/// never exceeds the driver's placeholder limit.
+///
+/// Postgres caps a statement at 65535 (`u16`) parameters; `SQLite`'s default
+/// `SQLITE_MAX_VARIABLE_NUMBER` is 32766 (since 3.32.0). The generated code
+/// divides this by the per-row column count to pick a chunk size, so the
+/// value tracks the active backend via the same `sqlite` feature that flips
+/// [`crate::db::RuntimeConnection`]. (The `SQLite` write path also inserts
+/// row-by-row, so this bound is a conservative belt-and-suspenders there.)
+#[cfg(not(feature = "sqlite"))]
+pub const MAX_BIND_PARAMS: usize = 65535;
+/// See [`MAX_BIND_PARAMS`] (Postgres). `SQLite`'s default
+/// `SQLITE_MAX_VARIABLE_NUMBER` is 32766.
+#[cfg(feature = "sqlite")]
+pub const MAX_BIND_PARAMS: usize = 32766;
 
 /// Typed errors returned by generated repository methods.
 ///

--- a/autumn/src/repository_commit_hooks.rs
+++ b/autumn/src/repository_commit_hooks.rs
@@ -8,10 +8,11 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::{
-    Arc, OnceLock, RwLock,
-    atomic::{AtomicBool, Ordering},
-};
+use std::sync::{Arc, OnceLock, RwLock};
+// `AtomicBool`/`Ordering` back the Postgres kick-worker's pending flag, which is
+// `cfg`-gated off under `sqlite` (the durable hook worker is Postgres-only).
+#[cfg(not(feature = "sqlite"))]
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use diesel::OptionalExtension as _;
@@ -21,6 +22,8 @@ use futures::FutureExt as _;
 use serde::Serialize;
 use serde_json::Value;
 use sha2::Digest as _;
+// `Notify` backs the Postgres kick-worker, `cfg`-gated off under `sqlite`.
+#[cfg(not(feature = "sqlite"))]
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
@@ -146,10 +149,12 @@ const HOOK_RECOVER_STALE_PENDING_SQL: &str = "UPDATE autumn_repository_commit_ho
 static REPOSITORY_COMMIT_HOOK_RUNNERS: OnceLock<
     RwLock<HashMap<String, RepositoryCommitHookRegistration>>,
 > = OnceLock::new();
+#[cfg(not(feature = "sqlite"))]
 static REPOSITORY_COMMIT_HOOK_KICKERS: OnceLock<
     RwLock<HashMap<usize, Arc<RepositoryCommitHookKickState>>>,
 > = OnceLock::new();
 
+#[cfg(not(feature = "sqlite"))]
 struct RepositoryCommitHookKickState {
     notify: Notify,
     pending: AtomicBool,
@@ -157,6 +162,7 @@ struct RepositoryCommitHookKickState {
     channels: OnceLock<crate::channels::Channels>,
 }
 
+#[cfg(not(feature = "sqlite"))]
 impl Default for RepositoryCommitHookKickState {
     fn default() -> Self {
         Self {
@@ -168,6 +174,7 @@ impl Default for RepositoryCommitHookKickState {
     }
 }
 
+#[cfg(not(feature = "sqlite"))]
 impl RepositoryCommitHookKickState {
     fn request_kick(&self) -> bool {
         !self.pending.swap(true, Ordering::AcqRel)
@@ -842,6 +849,7 @@ pub fn start_repository_commit_hook_worker(pool: PgPool, shutdown: CancellationT
 
 /// Nudge dispatch after a mutation commits, without relying on this replica for
 /// durability. Polling workers on all replicas can still claim the row later.
+#[cfg(not(feature = "sqlite"))]
 pub fn kick_repository_commit_hook_dispatcher(pool: &PgPool) {
     register_inventory_repository_commit_hook_runners();
     if !should_start_repository_commit_hook_worker(&registered_handler_keys()) {
@@ -854,6 +862,19 @@ pub fn kick_repository_commit_hook_dispatcher(pool: &PgPool) {
     }
 }
 
+/// `SQLite` no-op variant of the commit-hook dispatcher kick.
+///
+/// The durable dispatcher is a Postgres queue worker (`LISTEN/NOTIFY` +
+/// `FOR UPDATE SKIP LOCKED` row claiming + `unnest`/`Array` bulk binds) that is
+/// never spawned under the `sqlite` feature (see the cfg-gated worker start in
+/// `app.rs`). Generated `#[repository]` CRUD still emits the kick call — over the
+/// runtime pool, which is a `SQLite` pool here — so this signature accepts a
+/// `Pool<RuntimeConnection>` and does nothing. Threading the real Postgres worker
+/// onto `SQLite` is a later wave (issue #1996).
+#[cfg(feature = "sqlite")]
+pub const fn kick_repository_commit_hook_dispatcher(_pool: &Pool<crate::db::RuntimeConnection>) {}
+
+#[cfg(not(feature = "sqlite"))]
 fn repository_commit_hook_kick_state(pool: &PgPool) -> Arc<RepositoryCommitHookKickState> {
     let key = repository_commit_hook_pool_key(pool);
     let registry = REPOSITORY_COMMIT_HOOK_KICKERS.get_or_init(|| RwLock::new(HashMap::new()));
@@ -880,10 +901,12 @@ fn repository_commit_hook_kick_state(pool: &PgPool) -> Arc<RepositoryCommitHookK
     state
 }
 
+#[cfg(not(feature = "sqlite"))]
 fn repository_commit_hook_pool_key(pool: &PgPool) -> usize {
     std::ptr::from_ref(pool.manager()).addr()
 }
 
+#[cfg(not(feature = "sqlite"))]
 fn spawn_repository_commit_hook_kick_worker(
     pool: PgPool,
     state: Arc<RepositoryCommitHookKickState>,

--- a/autumn/tests/sqlite_crud_basic.rs
+++ b/autumn/tests/sqlite_crud_basic.rs
@@ -1,0 +1,164 @@
+//! Basic `#[repository]` CRUD proof on the `SQLite` runtime backend (issue
+//! #1996, wave B+C).
+//!
+//! The scope-threading proof (`sqlite_scoped_repository.rs`) deliberately does
+//! **not** instantiate a full `#[repository]`, because the default CRUD the
+//! macro generates — pessimistic `FOR UPDATE` locking, an `ON CONFLICT … DO
+//! UPDATE` upsert set-clause bounded to `QueryFragment<Pg>`, and a Postgres
+//! multi-row batch insert (`BatchInsert<…, false>` / the `DEFAULT` keyword) —
+//! used Postgres-only diesel query fragments that could not compile against the
+//! `SQLite` backend at all.
+//!
+//! This test pins that those always-emitted constructs are now backend-portable:
+//! it declares a **simple** model + repository (unscoped, unversioned, not
+//! searchable, no hooks), boots an in-memory `SQLite` pool through the real
+//! [`autumn_web::db::create_pool`] path, and exercises the generated CRUD end to
+//! end — `save` (single-row insert + `RETURNING`), `find_by_id`, `update`
+//! (read-modify-write, i.e. the `FOR UPDATE` → `maybe_for_update!` seam),
+//! `count`, `save_many` (the cfg-dual batch-insert path), and `delete_by_id`.
+//! Running to green means the whole generated CRUD surface type-checked **and**
+//! executed on `SQLite` with no Docker.
+//!
+//! Only meaningful under `--features sqlite`; the file is
+//! `#![cfg(feature = "sqlite")]` so a default `cargo test` compiles it to an
+//! empty (passing) binary. Run explicitly:
+//! `cargo test -p autumn-web --features sqlite --test sqlite_crud_basic`.
+#![cfg(feature = "sqlite")]
+
+use autumn_web::config::DatabaseConfig;
+use autumn_web::db::{RuntimeConnection, create_pool};
+use autumn_web::reexports::{diesel, diesel_async};
+
+use diesel_async::RunQueryDsl as _;
+use diesel_async::pooled_connection::deadpool::Pool;
+
+type SqlitePool = Pool<RuntimeConnection>;
+
+mod schema {
+    autumn_web::reexports::diesel::table! {
+        crud_notes (id) {
+            id -> Int8,
+            content -> Text,
+            views -> Int8,
+        }
+    }
+}
+
+use schema::crud_notes;
+
+#[autumn_web::model]
+pub struct CrudNote {
+    #[id]
+    pub id: i64,
+    pub content: String,
+    pub views: i64,
+}
+
+#[autumn_web::repository(CrudNote)]
+pub trait CrudNoteRepository {}
+
+async fn boot_pool() -> SqlitePool {
+    // A shared-cache in-memory database so every pooled checkout observes the
+    // same schema (a bare `:memory:` target is private per connection). The
+    // pool's per-connection setup already turns on `foreign_keys`/`busy_timeout`.
+    let config = DatabaseConfig {
+        url: Some("sqlite://file:crud_basic?mode=memory&cache=shared".to_string()),
+        primary_pool_size: Some(1),
+        ..Default::default()
+    };
+    let pool: SqlitePool = create_pool(&config)
+        .expect("sqlite pool builds via build_sqlite_pool")
+        .expect("a url is configured");
+
+    {
+        let mut conn = pool.get().await.expect("checkout a sqlite connection");
+        diesel::sql_query(
+            "CREATE TABLE crud_notes (\
+                 id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                 content TEXT NOT NULL, \
+                 views BIGINT NOT NULL DEFAULT 0\
+             )",
+        )
+        .execute(&mut *conn)
+        .await
+        .expect("create crud_notes table");
+    }
+
+    pool
+}
+
+#[tokio::test]
+async fn generated_crud_compiles_and_runs_on_sqlite() {
+    let pool = boot_pool().await;
+    let repo = PgCrudNoteRepository::with_pool_untracked(pool);
+
+    // insert (single-row) + RETURNING
+    let created = repo
+        .save(&NewCrudNote {
+            content: "first".to_string(),
+            views: 0,
+        })
+        .await
+        .expect("save inserts a row and returns it");
+    assert_eq!(created.content, "first");
+    assert!(created.id > 0, "autoincrement id assigned");
+
+    // find_by_id round-trips the inserted row
+    let found = repo
+        .find_by_id(created.id)
+        .await
+        .expect("find_by_id query")
+        .expect("row exists");
+    assert_eq!(found.content, "first");
+    assert_eq!(found.views, 0);
+
+    // update — the read-modify-write path (the FOR UPDATE → maybe_for_update! seam)
+    let updated = repo
+        .update(
+            created.id,
+            &UpdateCrudNote {
+                content: autumn_web::hooks::Patch::Set("first-edited".to_string()),
+                views: autumn_web::hooks::Patch::Set(7),
+            },
+        )
+        .await
+        .expect("update mutates and returns the row");
+    assert_eq!(updated.content, "first-edited");
+    assert_eq!(updated.views, 7);
+
+    // save_many — the cfg-dual batch-insert path (2 rows)
+    let many = repo
+        .save_many(&[
+            NewCrudNote {
+                content: "second".to_string(),
+                views: 1,
+            },
+            NewCrudNote {
+                content: "third".to_string(),
+                views: 2,
+            },
+        ])
+        .await
+        .expect("save_many inserts a batch and returns the rows");
+    assert_eq!(many.len(), 2);
+    let mut contents: Vec<&str> = many.iter().map(|m| m.content.as_str()).collect();
+    contents.sort_unstable();
+    assert_eq!(contents, ["second", "third"]);
+
+    // count — 3 rows total (1 from save + 2 from save_many)
+    let total = repo.count().await.expect("count query");
+    assert_eq!(total, 3);
+
+    // delete_by_id removes one row
+    repo.delete_by_id(created.id)
+        .await
+        .expect("delete_by_id removes the row");
+    assert!(
+        repo.find_by_id(created.id)
+            .await
+            .expect("find_by_id after delete")
+            .is_none(),
+        "deleted row is gone"
+    );
+    assert_eq!(repo.count().await.expect("count after delete"), 2);
+}

--- a/autumn/tests/sqlite_dependent_destroy.rs
+++ b/autumn/tests/sqlite_dependent_destroy.rs
@@ -1,0 +1,198 @@
+//! `dependent(..., on_delete = destroy)` cascade proof on the `SQLite` runtime
+//! backend (issue #1996 / PR #2021).
+//!
+//! The Destroy arm of the generated `__autumn_apply_dependent_on_conn` helper
+//! selects the child ids to cascade with a **hand-built SQL string** (not the
+//! diesel DSL the `maybe_for_update!` seam covers). That string used to emit a
+//! trailing `FOR UPDATE`, which `SQLite` rejects outright — so `delete_by_id`
+//! (and `delete_many`) on a parent that has a `destroy`-cascade dependent failed
+//! at run time on `SQLite`. The fix gates the lock clause with `backend_select!`
+//! (`" FOR UPDATE"` on Postgres, `""` on `SQLite`, whose single-writer database
+//! lock already serializes the cascade).
+//!
+//! This test proves the runtime behaviour on `SQLite`: a parent repository with
+//! a `destroy` child, seeded with a parent that has children, whose
+//! `delete_by_id` (a) succeeds (no `FOR UPDATE` syntax error) and (b) actually
+//! deletes the dependent child rows in the same transaction, leaving no orphans.
+//!
+//! Only meaningful under `--features sqlite`; the file is
+//! `#![cfg(feature = "sqlite")]` so a default `cargo test` compiles it to an
+//! empty (passing) binary. Run explicitly:
+//! `cargo test -p autumn-web --features sqlite --test sqlite_dependent_destroy`.
+#![cfg(feature = "sqlite")]
+
+use autumn_web::config::DatabaseConfig;
+use autumn_web::db::{RuntimeConnection, create_pool};
+use autumn_web::reexports::{diesel, diesel_async};
+
+use diesel::QueryableByName;
+use diesel_async::RunQueryDsl as _;
+use diesel_async::pooled_connection::deadpool::Pool;
+
+type SqlitePool = Pool<RuntimeConnection>;
+
+mod schema {
+    autumn_web::reexports::diesel::table! {
+        casc_posts (id) {
+            id -> Int8,
+            title -> Text,
+        }
+    }
+
+    autumn_web::reexports::diesel::table! {
+        casc_comments (id) {
+            id -> Int8,
+            post_id -> Int8,
+            body -> Text,
+        }
+    }
+}
+
+use schema::{casc_comments, casc_posts};
+
+#[autumn_web::model(table = "casc_posts")]
+pub struct CascPost {
+    #[id]
+    pub id: i64,
+    pub title: String,
+}
+
+#[autumn_web::model(table = "casc_comments")]
+pub struct CascComment {
+    #[id]
+    pub id: i64,
+    pub post_id: i64,
+    pub body: String,
+}
+
+// Child repository — the `destroy` cascade instantiates `PgCascCommentRepository`
+// internally and hard-deletes its rows.
+#[autumn_web::repository(CascComment, table = "casc_comments")]
+pub trait CascCommentRepository {}
+
+// Parent repository with a `destroy`-cascade dependent on the child. Deleting a
+// parent must destroy its comments in the same transaction.
+#[autumn_web::repository(
+    CascPost,
+    table = "casc_posts",
+    dependent(PgCascCommentRepository, fk = "post_id", on_delete = destroy)
+)]
+pub trait CascPostRepository {}
+
+#[derive(QueryableByName)]
+struct CountRow {
+    #[diesel(sql_type = autumn_web::reexports::diesel::sql_types::BigInt)]
+    n: i64,
+}
+
+async fn count(pool: &SqlitePool, sql: &str) -> i64 {
+    let mut conn = pool.get().await.expect("checkout a sqlite connection");
+    diesel::sql_query(sql)
+        .get_result::<CountRow>(&mut *conn)
+        .await
+        .expect("count query")
+        .n
+}
+
+async fn boot_pool() -> SqlitePool {
+    let config = DatabaseConfig {
+        url: Some("sqlite://file:casc_destroy?mode=memory&cache=shared".to_string()),
+        primary_pool_size: Some(1),
+        ..Default::default()
+    };
+    let pool: SqlitePool = create_pool(&config)
+        .expect("sqlite pool builds via build_sqlite_pool")
+        .expect("a url is configured");
+
+    {
+        let mut conn = pool.get().await.expect("checkout a sqlite connection");
+        diesel::sql_query(
+            "CREATE TABLE casc_posts (\
+                 id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                 title TEXT NOT NULL\
+             )",
+        )
+        .execute(&mut *conn)
+        .await
+        .expect("create casc_posts table");
+        diesel::sql_query(
+            "CREATE TABLE casc_comments (\
+                 id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                 post_id BIGINT NOT NULL REFERENCES casc_posts(id), \
+                 body TEXT NOT NULL\
+             )",
+        )
+        .execute(&mut *conn)
+        .await
+        .expect("create casc_comments table");
+    }
+
+    pool
+}
+
+#[tokio::test]
+async fn deleting_parent_destroys_dependent_children_on_sqlite() {
+    let pool = boot_pool().await;
+
+    // Seed one post with three comments plus a second, unrelated post + comment
+    // so the cascade is proven to scope to the deleted parent only.
+    {
+        let mut conn = pool.get().await.expect("checkout a sqlite connection");
+        diesel::sql_query("INSERT INTO casc_posts (id, title) VALUES (1, 'hello'), (2, 'other')")
+            .execute(&mut *conn)
+            .await
+            .expect("seed posts");
+        diesel::sql_query(
+            "INSERT INTO casc_comments (id, post_id, body) VALUES \
+                 (1, 1, 'a'), (2, 1, 'b'), (3, 1, 'c'), (4, 2, 'keep')",
+        )
+        .execute(&mut *conn)
+        .await
+        .expect("seed comments");
+    }
+
+    assert_eq!(
+        count(
+            &pool,
+            "SELECT COUNT(*) AS n FROM casc_comments WHERE post_id = 1"
+        )
+        .await,
+        3
+    );
+
+    let repo = PgCascPostRepository::with_pool_untracked(pool.clone());
+
+    // The load-bearing assertion: this succeeds on SQLite (the child-id SELECT no
+    // longer emits `FOR UPDATE`, which SQLite would reject) instead of erroring.
+    repo.delete_by_id(1)
+        .await
+        .expect("destroy cascade must succeed on SQLite (no FOR UPDATE syntax error)");
+
+    // Parent gone.
+    assert_eq!(
+        count(&pool, "SELECT COUNT(*) AS n FROM casc_posts WHERE id = 1").await,
+        0
+    );
+    // Its dependent children were destroyed in the same transaction — no orphans.
+    assert_eq!(
+        count(
+            &pool,
+            "SELECT COUNT(*) AS n FROM casc_comments WHERE post_id = 1"
+        )
+        .await,
+        0
+    );
+    // The unrelated post and its comment are untouched.
+    assert_eq!(
+        count(&pool, "SELECT COUNT(*) AS n FROM casc_posts WHERE id = 2").await,
+        1
+    );
+    assert_eq!(
+        count(
+            &pool,
+            "SELECT COUNT(*) AS n FROM casc_comments WHERE post_id = 2"
+        )
+        .await,
+        1
+    );
+}

--- a/autumn/tests/sqlite_upsert_isolation.rs
+++ b/autumn/tests/sqlite_upsert_isolation.rs
@@ -1,0 +1,371 @@
+//! `#[repository]` upsert isolation + optimistic-lock proof on the `SQLite`
+//! runtime backend (issue #1996, PR #2021).
+//!
+//! Pins the two P1 fixes on the cfg-dual `__autumn_execute_upsert` SQLite arm and
+//! the versioned `upsert_many` path:
+//!
+//! * **Bug 2 — tenant isolation (SECURITY):** the Postgres upsert's
+//!   `ON CONFLICT (id) DO UPDATE … WHERE tenant_id = $current` predicate keeps an
+//!   id owned by another tenant from being hijacked. The SQLite arm conflicts on
+//!   `id` only and its DO UPDATE set-clause writes `tenant_id`, so without the
+//!   SAME `WHERE tenant_id = <current>` predicate, upserting another tenant's id
+//!   would MOVE that row into the caller's tenant. This test proves the fix:
+//!   `upsert_many` under tenant B with tenant A's id leaves tenant A's row
+//!   completely untouched (no cross-tenant leak) and creates nothing under B.
+//! * **Bug 2 — optimistic lock guard:** the SQLite DO UPDATE preserves
+//!   `WHERE lock_version = excluded.lock_version`, so a stale-version upsert is
+//!   left untouched, dropped from `RETURNING`, and surfaces as a 409 Conflict —
+//!   matching Postgres exactly.
+//!
+//! Bug 1 (the versioned advisory lock `SELECT pg_advisory_xact_lock($1)` being
+//! cfg-gated to Postgres-only, so it is skipped on SQLite's single-writer engine)
+//! is pinned by the macro-expansion test
+//! `repository_macro_versioned_upsert_many_gates_advisory_lock_to_postgres_only`
+//! in `autumn-macros`. A full `versioned = true` (version-history) repository
+//! cannot run end-to-end on SQLite yet because the version-history writer emits a
+//! Postgres-only `$7::jsonb` cast — a separate unported construct outside these
+//! two P1s — so the runtime lock-conflict behaviour is proven here with the
+//! optimistic-lock (`#[lock_version]`) shape, which does not require version
+//! history or the advisory lock.
+//!
+//! Uses an in-memory shared-cache `SQLite` database — no Docker.
+//!
+//! Only meaningful under `--features sqlite`; the file is
+//! `#![cfg(feature = "sqlite")]` so a default `cargo test` compiles it to an
+//! empty (passing) binary. Run explicitly:
+//! `cargo test -p autumn-web --features sqlite --test sqlite_upsert_isolation`.
+#![cfg(feature = "sqlite")]
+
+use autumn_web::config::DatabaseConfig;
+use autumn_web::db::{RuntimeConnection, create_pool};
+use autumn_web::reexports::{diesel, diesel_async};
+use autumn_web::tenancy::with_tenant;
+
+use diesel_async::RunQueryDsl as _;
+use diesel_async::pooled_connection::deadpool::Pool;
+
+type SqlitePool = Pool<RuntimeConnection>;
+
+mod schema {
+    autumn_web::reexports::diesel::table! {
+        iso_notes (id) {
+            id -> Int8,
+            content -> Text,
+            tenant_id -> Text,
+        }
+    }
+
+    autumn_web::reexports::diesel::table! {
+        iso_lock_notes (id) {
+            id -> Int8,
+            content -> Text,
+            tenant_id -> Text,
+            lock_version -> Int8,
+        }
+    }
+
+    autumn_web::reexports::diesel::table! {
+        plain_lock_notes (id) {
+            id -> Int8,
+            content -> Text,
+            lock_version -> Int8,
+        }
+    }
+}
+
+use schema::{iso_lock_notes, iso_notes, plain_lock_notes};
+
+// Tenant-scoped, no optimistic lock.
+#[autumn_web::model(table = "iso_notes")]
+pub struct IsoNote {
+    #[id]
+    pub id: i64,
+    pub content: String,
+    #[default]
+    pub tenant_id: String,
+}
+
+#[autumn_web::repository(IsoNote, table = "iso_notes", tenant_scoped)]
+pub trait IsoNoteRepository {}
+
+// Tenant-scoped + optimistic lock (`has_lock`), NOT `versioned = true` (no
+// version history / advisory lock), so it compiles and runs on SQLite.
+#[autumn_web::model(table = "iso_lock_notes")]
+pub struct IsoLockNote {
+    #[id]
+    pub id: i64,
+    pub content: String,
+    #[default]
+    pub tenant_id: String,
+    #[lock_version]
+    pub lock_version: i64,
+}
+
+#[autumn_web::repository(IsoLockNote, table = "iso_lock_notes", tenant_scoped)]
+pub trait IsoLockNoteRepository {}
+
+// Plain optimistic lock, no tenant.
+#[autumn_web::model(table = "plain_lock_notes")]
+pub struct PlainLockNote {
+    #[id]
+    pub id: i64,
+    pub content: String,
+    #[lock_version]
+    pub lock_version: i64,
+}
+
+#[autumn_web::repository(PlainLockNote, table = "plain_lock_notes")]
+pub trait PlainLockNoteRepository {}
+
+async fn boot_pool(db_name: &str) -> SqlitePool {
+    // A shared-cache in-memory database so every pooled checkout observes the
+    // same schema (a bare `:memory:` target is private per connection).
+    let config = DatabaseConfig {
+        url: Some(format!("sqlite://file:{db_name}?mode=memory&cache=shared")),
+        primary_pool_size: Some(1),
+        ..Default::default()
+    };
+    let pool: SqlitePool = create_pool(&config)
+        .expect("sqlite pool builds via build_sqlite_pool")
+        .expect("a url is configured");
+
+    {
+        let mut conn = pool.get().await.expect("checkout a sqlite connection");
+        diesel::sql_query(
+            "CREATE TABLE iso_notes (\
+                 id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                 content TEXT NOT NULL, \
+                 tenant_id TEXT NOT NULL\
+             )",
+        )
+        .execute(&mut *conn)
+        .await
+        .expect("create iso_notes table");
+        diesel::sql_query(
+            "CREATE TABLE iso_lock_notes (\
+                 id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                 content TEXT NOT NULL, \
+                 tenant_id TEXT NOT NULL, \
+                 lock_version BIGINT NOT NULL DEFAULT 1\
+             )",
+        )
+        .execute(&mut *conn)
+        .await
+        .expect("create iso_lock_notes table");
+        diesel::sql_query(
+            "CREATE TABLE plain_lock_notes (\
+                 id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                 content TEXT NOT NULL, \
+                 lock_version BIGINT NOT NULL DEFAULT 1\
+             )",
+        )
+        .execute(&mut *conn)
+        .await
+        .expect("create plain_lock_notes table");
+    }
+
+    pool
+}
+
+/// SECURITY (Bug 2): a tenant-scoped `upsert_many` called under tenant B with an
+/// id that belongs to tenant A must leave tenant A's row completely untouched —
+/// the DO UPDATE `WHERE tenant_id = <current>` predicate never matches, so the
+/// row is neither returned nor moved into tenant B. This is the no-cross-tenant-
+/// leak assertion; without the SQLite tenant predicate the row's `tenant_id`
+/// would be rewritten to "tenant-b".
+#[tokio::test]
+async fn tenant_scoped_upsert_many_never_leaks_cross_tenant_row_on_sqlite() {
+    let pool = boot_pool("iso_upsert_tenant").await;
+    let repo = PgIsoNoteRepository::with_pool_untracked(pool);
+
+    // 1. Create a row owned by tenant-a.
+    let record_a = with_tenant("tenant-a".to_string(), async {
+        repo.save(&NewIsoNote {
+            content: "owned-by-a".to_string(),
+        })
+        .await
+        .expect("save under tenant-a")
+    })
+    .await;
+    assert_eq!(record_a.tenant_id, "tenant-a");
+
+    // 2. Under tenant-b, attempt to upsert tenant-a's id with new content.
+    let upserted = with_tenant("tenant-b".to_string(), async {
+        let mut hijack = record_a.clone();
+        hijack.content = "hijacked-by-b".to_string();
+        repo.upsert_many(&[hijack]).await
+    })
+    .await
+    .expect("cross-tenant upsert must silently filter (Ok, not Err)");
+
+    // The cross-tenant row is NOT in the result and nothing new was created.
+    assert!(
+        upserted.is_empty(),
+        "no in-scope rows existed for tenant-b, so nothing should be upserted, got: {upserted:?}"
+    );
+
+    // 3. SECURITY: tenant-a's row is byte-for-byte untouched — content unchanged
+    //    AND still owned by tenant-a (never moved into tenant-b).
+    let a_after = repo
+        .across_tenants()
+        .find_by_id(record_a.id)
+        .await
+        .expect("query tenant-a row")
+        .expect("tenant-a row still exists");
+    assert_eq!(
+        a_after.content, "owned-by-a",
+        "tenant-a row content must be unchanged (no cross-tenant hijack)"
+    );
+    assert_eq!(
+        a_after.tenant_id, "tenant-a",
+        "tenant-a row must NOT be moved into tenant-b (no cross-tenant leak)"
+    );
+
+    // And tenant-b genuinely has nothing.
+    let b_rows = with_tenant("tenant-b".to_string(), async {
+        repo.find_all().await.expect("list tenant-b rows")
+    })
+    .await;
+    assert!(
+        b_rows.is_empty(),
+        "tenant-b must own no rows after the filtered upsert, got: {b_rows:?}"
+    );
+}
+
+/// Tenant-scoped + optimistic lock: proves the SQLite DO UPDATE carries BOTH the
+/// tenant predicate (cross-tenant silent, no leak) AND the
+/// `lock_version = excluded.lock_version` guard (same-tenant stale → 409),
+/// matching Postgres exactly.
+#[tokio::test]
+async fn tenant_scoped_versioned_upsert_many_isolates_and_conflicts_on_sqlite() {
+    let pool = boot_pool("iso_upsert_tenant_lock").await;
+    let repo = PgIsoLockNoteRepository::with_pool_untracked(pool);
+
+    // 1. Create a versioned row for tenant-a (lock_version defaults to 1).
+    let record_a = with_tenant("tenant-a".to_string(), async {
+        repo.save(&NewIsoLockNote {
+            content: "a-v1".to_string(),
+        })
+        .await
+        .expect("save under tenant-a")
+    })
+    .await;
+    assert_eq!(record_a.lock_version, 1);
+    assert_eq!(record_a.tenant_id, "tenant-a");
+
+    // 2. Cross-tenant upsert under tenant-b is silently filtered, row untouched.
+    let upserted = with_tenant("tenant-b".to_string(), async {
+        let mut hijack = record_a.clone();
+        hijack.content = "hijacked-by-b".to_string();
+        repo.upsert_many(&[hijack]).await
+    })
+    .await
+    .expect("cross-tenant versioned upsert must silently filter (Ok, not Err)");
+    assert!(
+        upserted.is_empty(),
+        "cross-tenant versioned upsert must return nothing, got: {upserted:?}"
+    );
+
+    let a_after = repo
+        .across_tenants()
+        .find_by_id(record_a.id)
+        .await
+        .expect("query tenant-a row")
+        .expect("tenant-a row still exists");
+    assert_eq!(
+        a_after.content, "a-v1",
+        "content untouched by cross-tenant upsert"
+    );
+    assert_eq!(a_after.tenant_id, "tenant-a", "row not moved into tenant-b");
+    assert_eq!(
+        a_after.lock_version, 1,
+        "lock version untouched by cross-tenant upsert"
+    );
+
+    // 3. A valid same-tenant upsert bumps the version.
+    let bumped = with_tenant("tenant-a".to_string(), async {
+        let mut valid = record_a.clone();
+        valid.content = "a-v2".to_string();
+        repo.upsert_many(&[valid])
+            .await
+            .expect("valid same-tenant upsert")
+    })
+    .await;
+    assert_eq!(bumped.len(), 1);
+    assert_eq!(bumped[0].content, "a-v2");
+    assert_eq!(bumped[0].lock_version, 2, "DB increments the lock version");
+
+    // 4. A STALE same-tenant upsert (still lock_version = 1) must fail loudly 409.
+    let stale_res = with_tenant("tenant-a".to_string(), async {
+        let mut stale = record_a.clone(); // lock_version = 1, DB now at 2
+        stale.content = "a-stale".to_string();
+        repo.upsert_many(&[stale]).await
+    })
+    .await;
+    assert!(
+        stale_res.is_err(),
+        "stale same-tenant optimistic-lock upsert must fail loudly, but it succeeded"
+    );
+    let err_str = stale_res.unwrap_err().to_string();
+    assert!(
+        err_str.contains("onflict"),
+        "expected a conflict error for a stale lock version, got: {err_str}"
+    );
+
+    // The stale write did not land: DB is still at v2 with content "a-v2".
+    let final_a = repo
+        .across_tenants()
+        .find_by_id(record_a.id)
+        .await
+        .expect("query tenant-a row")
+        .expect("tenant-a row still exists");
+    assert_eq!(final_a.content, "a-v2");
+    assert_eq!(final_a.lock_version, 2);
+}
+
+/// Plain (non-tenant) optimistic-lock `upsert_many` runs on SQLite: a valid
+/// upsert bumps the version, and a stale one yields the 409 conflict — matching
+/// Postgres.
+#[tokio::test]
+async fn plain_versioned_upsert_many_succeeds_and_conflicts_on_sqlite() {
+    let pool = boot_pool("iso_upsert_plain_lock").await;
+    let repo = PgPlainLockNoteRepository::with_pool_untracked(pool);
+
+    let inserted = repo
+        .save_many(&[NewPlainLockNote {
+            content: "lock-a".to_string(),
+        }])
+        .await
+        .expect("save_many inserts a versioned row");
+    assert_eq!(inserted.len(), 1);
+    let original = inserted[0].clone();
+    assert_eq!(original.lock_version, 1);
+
+    // Valid upsert with the current version succeeds and bumps the version.
+    let mut to_upsert = original.clone();
+    to_upsert.content = "lock-a-updated".to_string();
+    let upserted = repo
+        .upsert_many(&[to_upsert])
+        .await
+        .expect("valid versioned upsert_many must succeed on sqlite");
+    assert_eq!(upserted.len(), 1);
+    assert_eq!(upserted[0].content, "lock-a-updated");
+    assert_eq!(
+        upserted[0].lock_version, 2,
+        "DB increments the lock version"
+    );
+
+    // Stale upsert (lock_version = 1, DB now at 2) must fail loudly with 409.
+    let mut stale = original.clone();
+    stale.content = "lock-a-stale".to_string();
+    let stale_res = repo.upsert_many(&[stale]).await;
+    assert!(
+        stale_res.is_err(),
+        "stale optimistic-lock upsert must fail loudly on sqlite, but it succeeded"
+    );
+    let err_str = stale_res.unwrap_err().to_string();
+    assert!(
+        err_str.contains("onflict"),
+        "expected a conflict error for a stale lock version, got: {err_str}"
+    );
+}


### PR DESCRIPTION
## Before / After

**Before** — a full `#[repository]` cannot compile under `--features sqlite`: the generated CRUD emits `.for_update()`, an always-present Postgres `on_conflict` upsert, and the Postgres batch-insert form, none of which the SQLite backend accepts.

**After** — a simple repository's `save` / `find_by_id` / `update` / `save_many` / `count` / `delete_by_id` compiles and passes on in-memory SQLite, proven by `tests/sqlite_crud_basic.rs`. The default Postgres build stays clean.

## How

- A `RuntimeBackend` type alias (`Pg` / `Sqlite`) as a companion to `RuntimeConnection`.
- A `maybe_for_update!` cfg-seam replacing 65 `.for_update()` emissions — a no-op on SQLite, where single-writer serialization plus optimistic `lock_version` provide the guarantee.
- A `backend_select!` cfg-dual batch insert (Postgres multi-row / SQLite per-row inside a transaction) plus a SQLite-aware bind-param chunk limit.
- A cfg-dual `__autumn_execute_upsert`.
- `RuntimeConnection` threading in `preload.rs` and a SQLite no-op stub in `repository_commit_hooks.rs`.

## Scope / deferred to later waves

- Scoped / versioned / upsert-trait / searchable repositories on SQLite.
- The raw-SQL aggregate `$n` / `::jsonb` paths.
- A real SQLite statement-timeout.
- The durable commit-hook worker.
- `BEGIN IMMEDIATE` immediate-transaction RMW (documented `TODO(#1996)`) — the optimistic `lock_version` + `busy_timeout` cover single-writer correctness; immediate-txn is a production-concurrency hardening.

Closes part of #1996. Builds on the now-merged #2016.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxTssPbKEhZ99r8NDTdvUq)_