### PR TITLE
autumn-media: arroyo env migration shim (slice 5)

### DIFF
--- a/autumn-media-plugin/src/lib.rs
+++ b/autumn-media-plugin/src/lib.rs
@@ -102,6 +102,7 @@ pub mod prelude {
 }
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -169,6 +170,49 @@ impl MediaPlugin {
             recordings_root: None,
             retention_defer: None,
         }
+    }
+
+    /// Build a fully-wired broadcast [`MediaPlugin`] from an Arroyo operator's
+    /// existing `ARROYO_*` environment — the ratified migration shim (issue
+    /// #1974, slice 5). One call maps the operator's env onto a plugin ready to
+    /// install, so adopting `autumn-media-plugin` changes no ops config:
+    ///
+    /// - the `[media]` config surface — `MediaMTX` origins, `FFmpeg` bin, the
+    ///   local/S3 storage selection (including Arroyo's Tigris `auto` region /
+    ///   `t3.storage.dev` endpoint / `highlights` key-prefix defaults), and the
+    ///   retention window — via
+    ///   [`MediaConfig::from_arroyo_env`](config::MediaConfig::from_arroyo_env);
+    /// - the **broadcast** primitive enabled (Arroyo is one-to-many and uses no
+    ///   rooms), so the plugin is watch-path-ready without a further builder
+    ///   call;
+    /// - the retention sweep's recordings root from `ARROYO_RECORDINGS_ROOT`
+    ///   (default `recordings`, matching Arroyo's own
+    ///   `configured_recordings_root()` fallback), so the hourly retention loop
+    ///   is wired exactly as before.
+    ///
+    /// The returned value is a normal builder: chain
+    /// [`artifact_sink`](Self::artifact_sink) (the app writes its own tables on
+    /// completion), [`workflow_delegate`](Self::workflow_delegate),
+    /// [`retention_defer`](Self::retention_defer), etc. This reads the process
+    /// environment; the pure mapping lives in
+    /// [`from_arroyo_env_pairs`](Self::from_arroyo_env_pairs) for testability.
+    #[must_use]
+    pub fn from_arroyo_env() -> Self {
+        let env: HashMap<String, String> = std::env::vars().collect();
+        Self::from_arroyo_env_pairs(&env)
+    }
+
+    /// Pure core of [`from_arroyo_env`](Self::from_arroyo_env): map the supplied
+    /// `ARROYO_*` environment map onto a wired [`MediaPlugin`] without touching
+    /// process-global environment (mirroring
+    /// [`MediaConfig::from_arroyo_env_pairs`](config::MediaConfig::from_arroyo_env_pairs)).
+    #[must_use]
+    pub fn from_arroyo_env_pairs(env: &HashMap<String, String>) -> Self {
+        let config = MediaConfig::from_arroyo_env_pairs(env);
+        Self::new()
+            .config(config)
+            .with_broadcast()
+            .recordings_root(arroyo_recordings_root(env))
     }
 
     /// Supply the resolved `[media]` configuration.
@@ -386,6 +430,25 @@ impl Plugin for MediaPlugin {
     }
 }
 
+/// Recordings root an Arroyo deployment uses when `ARROYO_RECORDINGS_ROOT` is
+/// unset — mirrors Arroyo's own `configured_recordings_root()` fallback, so the
+/// migration shim wires the retention sweep the same way with no ops change.
+const DEFAULT_ARROYO_RECORDINGS_ROOT: &str = "recordings";
+
+/// Resolve the Arroyo recordings root from an env map: a non-blank
+/// `ARROYO_RECORDINGS_ROOT`, else [`DEFAULT_ARROYO_RECORDINGS_ROOT`]. Blank /
+/// whitespace-only values are treated as unset (parity with
+/// [`MediaConfig::from_arroyo_env_pairs`](config::MediaConfig::from_arroyo_env_pairs)).
+fn arroyo_recordings_root(env: &HashMap<String, String>) -> PathBuf {
+    env.get("ARROYO_RECORDINGS_ROOT")
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map_or_else(
+            || PathBuf::from(DEFAULT_ARROYO_RECORDINGS_ROOT),
+            PathBuf::from,
+        )
+}
+
 /// The route metadata `MediaPlugin` declares for `autumn routes` listing.
 ///
 /// **Slice 0: empty.** Later slices will fill this in with the broadcast and
@@ -393,6 +456,110 @@ impl Plugin for MediaPlugin {
 /// nests. Extracted so the empty slice-0 declaration is directly testable.
 const fn media_route_infos(_api_prefix: &str) -> Vec<autumn_web::route_listing::RouteInfo> {
     Vec::new()
+}
+
+// ── Arroyo migration shim (slice 5) ─────────────────────────────────────────
+
+#[cfg(test)]
+mod arroyo_shim_tests {
+    use super::{DEFAULT_ARROYO_RECORDINGS_ROOT, MediaPlugin, arroyo_recordings_root};
+    use crate::config::MediaStorageBackend;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    fn env(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(key, value)| ((*key).to_owned(), (*value).to_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn empty_env_is_wired_broadcast_local_plugin() {
+        let plugin = MediaPlugin::from_arroyo_env_pairs(&HashMap::new());
+        // Broadcast is enabled (Arroyo is one-to-many); rooms are not.
+        assert!(plugin.enable_broadcast, "broadcast must be enabled");
+        assert!(!plugin.enable_rooms, "rooms must stay disabled");
+        // Config maps through with neutral defaults for an empty env.
+        assert_eq!(plugin.config.storage.backend, MediaStorageBackend::Local);
+        assert_eq!(plugin.config.mediamtx.api_base, "http://127.0.0.1:9997");
+        assert_eq!(plugin.config.ffmpeg.bin, "/usr/bin/ffmpeg");
+        // Retention sweep is wired to Arroyo's default recordings root, so the
+        // hourly loop runs exactly as it did pre-migration.
+        assert_eq!(
+            plugin.recordings_root.as_deref(),
+            Some(std::path::Path::new(DEFAULT_ARROYO_RECORDINGS_ROOT))
+        );
+        // The produced config is valid to hand to MediaStorage::from_config.
+        assert!(plugin.config.validate().is_ok());
+    }
+
+    #[test]
+    fn maps_full_s3_environment_and_validates() {
+        let vars = env(&[
+            ("ARROYO_VIDEO_STORAGE_BACKEND", "s3"),
+            ("BUCKET_NAME", "arroyo-bucket"),
+            ("AWS_ACCESS_KEY_ID", "AKIA"),
+            ("AWS_SECRET_ACCESS_KEY", "secret"),
+            ("ARROYO_MEDIAMTX_API_BASE", "http://mtx:9997"),
+            ("ARROYO_FFMPEG_BIN", "/opt/ffmpeg"),
+            ("ARROYO_RECORDING_RETENTION_DAYS", "21"),
+            ("ARROYO_RECORDINGS_ROOT", "/data/recordings"),
+        ]);
+        let plugin = MediaPlugin::from_arroyo_env_pairs(&vars);
+        assert!(plugin.enable_broadcast);
+        assert_eq!(plugin.config.storage.backend, MediaStorageBackend::S3);
+        assert_eq!(
+            plugin.config.storage.bucket.as_deref(),
+            Some("arroyo-bucket")
+        );
+        // Arroyo's Tigris S3 defaults flow through the config-level shim.
+        assert_eq!(plugin.config.storage.region.as_deref(), Some("auto"));
+        assert_eq!(
+            plugin.config.storage.endpoint_url.as_deref(),
+            Some("https://t3.storage.dev")
+        );
+        assert_eq!(plugin.config.storage.key_prefix, "highlights");
+        assert_eq!(plugin.config.mediamtx.api_base, "http://mtx:9997");
+        assert_eq!(plugin.config.ffmpeg.bin, "/opt/ffmpeg");
+        // Retention window flows from ARROYO_RECORDING_RETENTION_DAYS into the
+        // config (the plugin resolves the effective days from it at build time).
+        assert_eq!(plugin.config.recording.retention_days, 21);
+        assert_eq!(
+            plugin.recordings_root.as_deref(),
+            Some(std::path::Path::new("/data/recordings"))
+        );
+        assert!(plugin.config.validate().is_ok());
+    }
+
+    #[test]
+    fn recordings_root_honors_env_and_defaults() {
+        assert_eq!(
+            arroyo_recordings_root(&env(&[("ARROYO_RECORDINGS_ROOT", "/mnt/rec")])),
+            PathBuf::from("/mnt/rec")
+        );
+        // Blank / whitespace-only is treated as unset → Arroyo's default.
+        assert_eq!(
+            arroyo_recordings_root(&env(&[("ARROYO_RECORDINGS_ROOT", "   ")])),
+            PathBuf::from(DEFAULT_ARROYO_RECORDINGS_ROOT)
+        );
+        assert_eq!(
+            arroyo_recordings_root(&HashMap::new()),
+            PathBuf::from(DEFAULT_ARROYO_RECORDINGS_ROOT)
+        );
+    }
+
+    #[test]
+    fn returned_plugin_stays_chainable() {
+        // The shim returns a normal builder, so an app can layer its own
+        // overrides (queue name, retention window) on top of the mapped env.
+        let plugin = MediaPlugin::from_arroyo_env_pairs(&HashMap::new())
+            .queue("arroyo-media")
+            .retention_days(30);
+        assert!(plugin.enable_broadcast);
+        assert_eq!(plugin.queue, "arroyo-media");
+        assert_eq!(plugin.retention_days, Some(30));
+    }
 }
 
 // ── Conformance reference tests ─────────────────────────────────────────────


### PR DESCRIPTION
## Before

An arroyo-style app could already map its existing `ARROYO_*` environment onto a `MediaConfig` — the config-level `MediaConfig::from_arroyo_env()` / `from_arroyo_env_pairs()` shim landed with slice 4. But adopting the plugin still meant hand-wiring the plugin itself afterward: enabling the broadcast primitive and pointing the retention sweep at `ARROYO_RECORDINGS_ROOT` before installing it.

```rust
let config = MediaConfig::from_arroyo_env();
MediaPlugin::new()
    .config(config)
    .with_broadcast()
    .recordings_root(std::env::var("ARROYO_RECORDINGS_ROOT").unwrap_or_else(|_| "recordings".into()))
    // ...
```

## After

One call returns a **fully-wired broadcast plugin** an arroyo-style app can install as-is — adopting `autumn-media-plugin` changes **no operator env**:

```rust
app.plugin(
    MediaPlugin::from_arroyo_env()
        .artifact_sink(Arc::new(ArroyoMediaSink)) // app writes its own tables
)
```

`MediaPlugin::from_arroyo_env()` composes the three pieces of the migration into one ergonomic entry point:

- the `[media]` config surface (MediaMTX origins, FFmpeg bin, local/S3 storage — including arroyo's Tigris `auto` region / `t3.storage.dev` endpoint / `highlights` key-prefix defaults — and the retention window) via the existing `MediaConfig::from_arroyo_env`;
- the **broadcast** primitive enabled (arroyo is one-to-many and uses no rooms), so the plugin is watch-path-ready without a further builder call;
- the retention sweep's recordings root from `ARROYO_RECORDINGS_ROOT` (default `recordings`, matching arroyo's own `configured_recordings_root()` fallback), so the hourly retention loop is wired exactly as before.

The result is a normal builder, so the app still layers its own `artifact_sink` / `workflow_delegate` / `retention_defer` / `queue` on top.

## How

Additive, plugin-crate-only (`autumn-media-plugin/src/lib.rs`), built on the existing `MediaConfig::from_arroyo_env_pairs` seed:

- `MediaPlugin::from_arroyo_env()` reads the process env; the pure mapping lives in `MediaPlugin::from_arroyo_env_pairs(&HashMap)` for testability (mirrors the config-level pair fn exactly).
- A small `arroyo_recordings_root(env)` helper resolves a non-blank `ARROYO_RECORDINGS_ROOT`, else the `DEFAULT_ARROYO_RECORDINGS_ROOT` (`recordings`) constant — blank/whitespace treated as unset, parity with the config shim.
- Rustdoc documents the arroyo-var → generic-field mapping on the constructor.

**Harvest-free and backend-agnostic**: no arroyo dependency, no new crate dependency, no workspace version bump, no CHANGELOG/skills edits. This is the `from_arroyo_env()`-era shim slice of the ratified extraction plan; the broader arroyo-repo integration (deleting `media.rs` internals, re-expressing `publish_highlight`/`publish_clip`, implementing `ArroyoMediaSink`) is out of scope here — it lives in the arroyo repo, not this workspace.

## Test evidence

New `arroyo_shim_tests` module (4 tests): empty env → broadcast + local backend + default recordings root + valid config; full S3 arroyo env → S3 backend + Tigris defaults + retention window flows through + config validates; recordings-root env/default/blank handling; returned-plugin builder chainability.

```
cargo fmt --all -- --check            # clean
cargo clippy -p autumn-media-plugin --all-targets -- -D warnings   # exit 0, clean
cargo test -p autumn-media-plugin     # test result: ok. 154 passed; 0 failed
cargo build -p autumn-media-plugin    # Finished
```

Part of #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015b2JHGzyvPj86FcyMnTRdV

---
_Generated by [Claude Code](https://claude.ai/code/session_015b2JHGzyvPj86FcyMnTRdV)_