### PR TITLE
Converge transition effects onto the lifecycle = Enum path (#1973)

### DIFF
--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -2747,14 +2747,17 @@ struct StateMachineTransition {
     /// Optional guard: name of a `&self` bool method that must return `true`.
     guard: Option<String>,
     /// Optional after-commit effect (issue #1973): the path of a `#[job]`
-    /// struct to enqueue transactionally when this specific edge fires. Only
-    /// meaningful for inline `transitions(...)` machines — lifecycle-derived
-    /// tables carry no effects.
+    /// struct to enqueue transactionally when this specific edge fires.
+    /// Declarable on both the inline `transitions(...)` path and the
+    /// `lifecycle = <Enum>` path's `effects(...)` clause (issue #1973); both
+    /// route through the same effect codegen.
     on_commit: Option<syn::Path>,
     /// Optional sync in-transaction effect (issue #1973): the name of an
     /// `async fn(&self, conn) -> AutumnResult<()>` method run inside the
     /// transition's transaction when this edge fires. `Err` rolls the
-    /// transition back (mirrors `before_*` mutation hooks). Inline-only.
+    /// transition back (mirrors `before_*` mutation hooks). Declarable on both
+    /// the inline `transitions(...)` path and the `lifecycle = <Enum>` path's
+    /// `effects(...)` clause.
     on: Option<String>,
 }
 
@@ -2766,7 +2769,13 @@ enum StateMachineSource {
     Inline(Vec<StateMachineTransition>),
     /// `#[state_machine(lifecycle = SomeEnum)]` — transitions derived from the
     /// referenced `#[lifecycle]` enum's `Lifecycle::STATE_MACHINE_TRANSITIONS`.
-    Lifecycle(syn::Path),
+    Lifecycle {
+        path: syn::Path,
+        /// Per-edge effects declared at the binding site via `effects(...)`.
+        /// Empty when no clause is present (byte-identical to pre-#1973). Guards
+        /// are rejected here — lifecycle transitions are unguarded.
+        effects: Vec<StateMachineTransition>,
+    },
 }
 
 /// Parsed `#[state_machine(...)]` spec for one field.
@@ -2900,7 +2909,42 @@ fn parse_state_machine_source(
     } else if key == "lifecycle" {
         input.parse::<syn::Token![=]>()?;
         let path: syn::Path = input.parse()?;
-        Ok(StateMachineSource::Lifecycle(path))
+        // Optionally consume a trailing `, effects(...)` clause declaring
+        // per-edge effects at the binding site (issue #1973). Absent → no
+        // effects (byte-identical to a plain `lifecycle = <Enum>`).
+        let effects: Vec<StateMachineTransition> = if input.peek(syn::Token![,]) {
+            input.parse::<syn::Token![,]>()?;
+            let effects_kw: syn::Ident = input.parse()?;
+            if effects_kw != "effects" {
+                return Err(syn::Error::new(
+                    effects_kw.span(),
+                    "expected `effects(...)` after `lifecycle = <Enum>`",
+                ));
+            }
+            let content;
+            syn::parenthesized!(content in input);
+            let parsed = parse_transition_list(&content)?;
+            // Reject guards + require at least one effect per edge.
+            for t in &parsed {
+                if t.guard.is_some() {
+                    return Err(syn::Error::new(
+                        effects_kw.span(),
+                        "guards are not supported on `lifecycle = <Enum>` effects; \
+                         lifecycle transitions are unguarded (declare effects only)",
+                    ));
+                }
+                if t.on.is_none() && t.on_commit.is_none() {
+                    return Err(syn::Error::new(
+                        effects_kw.span(),
+                        "each `effects(...)` edge must declare `on = \"...\"` and/or `on_commit = <Job>`",
+                    ));
+                }
+            }
+            parsed
+        } else {
+            Vec::new()
+        };
+        Ok(StateMachineSource::Lifecycle { path, effects })
     } else {
         Err(syn::Error::new(
             key.span(),
@@ -2990,8 +3034,8 @@ fn emit_state_machine_impl(
         StateMachineSource::Inline(transitions) => {
             emit_state_machine_inline(model_name, &spec.field_ident, transitions, pk_ident)
         }
-        StateMachineSource::Lifecycle(path) => {
-            emit_state_machine_lifecycle(model_name, &spec.field_ident, path)
+        StateMachineSource::Lifecycle { path, effects } => {
+            emit_state_machine_lifecycle(model_name, &spec.field_ident, path, effects, pk_ident)
         }
     }
 }
@@ -3227,10 +3271,19 @@ fn emit_state_machine_on_conn(
 /// predicate requires the guard slot to be absent — guards remain an
 /// inline-only shorthand feature (see the `Lifecycle` trait docs for the
 /// rationale).
+///
+/// Per-edge effects (a sync `on = "handler"` and/or an `on_commit = <Job>`)
+/// declared at the binding site via `effects(...)` (issue #1973) route through
+/// the shared [`emit_state_machine_on_conn`], so the lifecycle path emits the
+/// identical `transition_{field}_to_on_conn` method as the inline path. When
+/// `effects` is empty the helper returns an empty token stream, keeping the
+/// lifecycle codegen byte-for-byte identical to before.
 fn emit_state_machine_lifecycle(
     model_name: &syn::Ident,
     field: &syn::Ident,
     path: &syn::Path,
+    effects: &[StateMachineTransition],
+    pk_ident: Option<&syn::Ident>,
 ) -> TokenStream {
     let StateMachineNames {
         const_name,
@@ -3238,6 +3291,18 @@ fn emit_state_machine_lifecycle(
         transition_fn,
         field_str,
     } = state_machine_names(field);
+
+    // Per-edge effect method (issue #1973): only emitted when the binding site
+    // declares one or more `effects(...)` edges. Empty `effects` returns an
+    // empty token stream, so a plain `lifecycle = <Enum>` is unchanged.
+    let on_conn_impl = emit_state_machine_on_conn(
+        model_name,
+        field,
+        &field_str,
+        &transition_fn,
+        effects,
+        pk_ident,
+    );
 
     quote! {
         impl #model_name {
@@ -3275,6 +3340,8 @@ fn emit_state_machine_lifecycle(
                 }
             }
         }
+
+        #on_conn_impl
     }
 }
 
@@ -8614,6 +8681,200 @@ mod tests {
         assert!(
             generated.contains("only supported on `String` fields"),
             "lifecycle SM on a non-String field must be rejected: {generated}"
+        );
+    }
+
+    // ── lifecycle `effects(...)` per-edge effects (#1973) ─────────────────────
+
+    #[test]
+    fn state_machine_lifecycle_with_effects_emits_on_conn_method() {
+        // An `effects(...)` clause routes the lifecycle path through the shared
+        // `_on_conn` emitter: the connection-taking method is emitted, keyed on
+        // the fired edge, and enqueues the named job.
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(lifecycle = OrderState, effects(
+                        processing -> shipped: on_commit = SendShippedEmailJob,
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("transition_status_to_on_conn"),
+            "a lifecycle `effects` edge must emit the connection-taking method: {generated}"
+        );
+        // The const still aliases the enum's trait table (transitions come from
+        // the enum, effects come from the binding site).
+        assert!(
+            generated.contains(
+                "< OrderState as :: autumn_web :: Lifecycle > :: STATE_MACHINE_TRANSITIONS"
+            ),
+            "lifecycle `effects` must not replace the enum-derived transition table: {generated}"
+        );
+        assert!(
+            generated.contains("enqueue_on_conn")
+                && generated.contains("< SendShippedEmailJob > :: NAME"),
+            "the effect must enqueue the named job on the connection: {generated}"
+        );
+        assert!(
+            generated.contains("(\"processing\" , \"shipped\")"),
+            "the effect arm must match the fired edge: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_lifecycle_without_effects_emits_no_on_conn_method() {
+        // A plain `lifecycle = <Enum>` (no `effects(...)`) is byte-for-byte
+        // unchanged: no `_on_conn` method and no after-commit effect codegen.
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(lifecycle = OrderState)]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            !generated.contains("transition_status_to_on_conn"),
+            "a lifecycle SM with no `effects` must not emit the `_on_conn` method: {generated}"
+        );
+        assert!(
+            !generated.contains("enqueue_on_conn"),
+            "a lifecycle SM with no `effects` must not emit after-commit effect codegen: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_lifecycle_effects_sync_on_emits_handler_call() {
+        // An `on = "handler"` effect edge emits the in-transaction handler call
+        // and, being `on`-only, no after-commit enqueue.
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(lifecycle = OrderState, effects(
+                        shipped -> archived: on = "audit",
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("transition_status_to_on_conn"),
+            "a lifecycle `on` effect edge must emit the connection-taking method: {generated}"
+        );
+        assert!(
+            generated.contains("self . audit (conn) . await ?"),
+            "the `on` effect must call its handler in-transaction: {generated}"
+        );
+        assert!(
+            !generated.contains("enqueue_on_conn"),
+            "an `on`-only lifecycle effect must not emit after-commit codegen: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_lifecycle_effects_guard_is_rejected() {
+        // Guards are meaningless on lifecycle edges (the runtime table validator
+        // ignores them), so declaring one on an `effects(...)` edge is an error.
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(lifecycle = OrderState, effects(
+                        processing -> shipped: guard = "can_ship",
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("compile_error"),
+            "a guard on a lifecycle `effects` edge must be rejected: {generated}"
+        );
+        assert!(
+            generated.contains("guards are not supported"),
+            "the rejection must mention guards not being supported: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_lifecycle_effects_empty_edge_is_rejected() {
+        // An `effects(...)` edge with neither `on` nor `on_commit` is pointless
+        // and rejected — declare it in the enum's transition table instead.
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(lifecycle = OrderState, effects(
+                        processing -> shipped,
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("compile_error"),
+            "an effect-less `effects` edge must be rejected: {generated}"
+        );
+        assert!(
+            generated.contains("must declare `on"),
+            "the rejection must require an `on`/`on_commit` effect: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_lifecycle_effects_derive_idempotency_key() {
+        // The lifecycle path reuses the identical idempotency-key derivation as
+        // the inline path: model:field:record_id:from:to.
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(lifecycle = OrderState, effects(
+                        processing -> shipped: on_commit = SendShippedEmailJob,
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("idempotency_key"),
+            "the effect must carry a derived idempotency key: {generated}"
+        );
+        assert!(
+            generated.contains("\"{}:{}:{}:{}:{}\""),
+            "the idempotency key must combine model/field/record_id/from/to: {generated}"
+        );
+        assert!(
+            generated.contains("\"Order\"") && generated.contains("\"status\""),
+            "the key must embed the model and field names: {generated}"
+        );
+        assert!(
+            generated.contains("self . id"),
+            "the record id must come from the primary key: {generated}"
         );
     }
 

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -502,6 +502,14 @@ path = "tests/state_machine_on_commit.rs"
 name = "state_machine_on"
 path = "tests/state_machine_on.rs"
 
+# Issue #1973: `lifecycle = <Enum>` + binding-site `effects(...)` per-edge
+# effects converged onto the shared connection-taking method — pure validation +
+# compile-time type-check of the generated method. No DB connection, runs
+# without Docker. Isolated so it is cheap to compile/run alone.
+[[test]]
+name = "state_machine_lifecycle_effects"
+path = "tests/state_machine_lifecycle_effects.rs"
+
 [[test]]
 name = "repository_shard_replica_routing"
 path = "tests/repository_shard_replica_routing.rs"

--- a/autumn/tests/compile-pass/model_state_machine_lifecycle_effects.rs
+++ b/autumn/tests/compile-pass/model_state_machine_lifecycle_effects.rs
@@ -1,0 +1,90 @@
+//! Issue #1973: a `#[state_machine(lifecycle = <Enum>)]` binding can declare
+//! per-edge effects at the binding site via an `effects(...)` clause — a sync
+//! `on = "handler"` in-transaction effect and/or an `on_commit = <Job>`
+//! after-commit enqueue — while the transition TABLE still comes from the
+//! `#[lifecycle]` enum. Declaring `effects(...)` makes the model gain the
+//! connection-taking `transition_{field}_to_on_conn` method, identical to the
+//! inline path. This is the lifecycle companion to `model_state_machine_on.rs`.
+
+use autumn_web::model;
+use autumn_web::prelude::*;
+use autumn_web::reexports::diesel_async::AsyncPgConnection;
+use autumn_web::lifecycle;
+use serde::{Deserialize, Serialize};
+
+// The typed source of truth for the transition table.
+#[lifecycle(
+    initial = Draft,
+    terminal(Archived),
+    transitions(
+        Draft -> Published,
+        Published -> Archived,
+    )
+)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrderState {
+    Draft,
+    Published,
+    Archived,
+}
+
+// A `#[job]` whose args are the framework-provided transition context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EffectArgs {
+    idempotency_key: String,
+}
+
+#[job(name = "announce_publish")]
+async fn announce_publish(_state: AppState, _args: EffectArgs) -> AutumnResult<()> {
+    Ok(())
+}
+
+diesel::table! {
+    articles (id) {
+        id -> BigInt,
+        status -> Text,
+    }
+}
+
+#[model(table = "articles")]
+pub struct Article {
+    #[id]
+    pub id: i64,
+    // Transition table from `OrderState`; effects declared at the binding site.
+    #[state_machine(lifecycle = OrderState, effects(
+        Draft -> Published: on_commit = AnnouncePublishJob,
+        Published -> Archived: on = "record_archive",
+    ))]
+    pub status: String,
+}
+
+impl Article {
+    // The sync in-transaction effect runs inside the transition's transaction;
+    // a returned `Err` rolls the transition back.
+    async fn record_archive(&self, _conn: &mut AsyncPgConnection) -> AutumnResult<()> {
+        Ok(())
+    }
+}
+
+// The pure validator is unchanged and still generated (table from the enum).
+fn _assert_pure_validator_compiles(article: &Article) {
+    let _ = article.can_transition_status_to("Published");
+    let _ = article.transition_status_to("Published");
+}
+
+// The additive connection-taking method is generated because the binding
+// declares one or more `effects(...)` edges. It takes an explicit connection so
+// the sync `on` handler and the `on_commit` enqueue both run inside the caller's
+// transaction.
+async fn _assert_on_conn_compiles(
+    article: &Article,
+    conn: &mut AsyncPgConnection,
+) -> AutumnResult<String> {
+    article.transition_status_to_on_conn(conn, "Published").await
+}
+
+fn main() {
+    let _ = _assert_pure_validator_compiles;
+    let _ = _assert_on_conn_compiles;
+    let _ = announce_publish;
+}

--- a/autumn/tests/integration/compile_fail.rs
+++ b/autumn/tests/integration/compile_fail.rs
@@ -245,6 +245,12 @@ fn compile_pass_tests() {
     #[cfg(feature = "db")]
     t.pass("tests/compile-pass/model_state_machine_on.rs");
 
+    // Issue #1973: `lifecycle = <Enum>` + binding-site `effects(...)` per-edge
+    // effects converge onto the shared connection-taking method; the transition
+    // table still comes from the enum.
+    #[cfg(feature = "db")]
+    t.pass("tests/compile-pass/model_state_machine_lifecycle_effects.rs");
+
     // Soft delete (requires db feature)
     #[cfg(feature = "db")]
     t.pass("tests/compile-pass/repository_soft_delete.rs");

--- a/autumn/tests/state_machine_lifecycle_effects.rs
+++ b/autumn/tests/state_machine_lifecycle_effects.rs
@@ -1,0 +1,137 @@
+//! Issue #1973: a `#[state_machine(lifecycle = <Enum>)]` binding can declare
+//! per-edge effects at the binding site via an `effects(...)` clause that reuses
+//! the EXACT per-edge grammar of the inline `transitions(...)` path (`on = "..."`
+//! sync in-transaction effect and/or `on_commit = <Job>` after-commit enqueue),
+//! EXCEPT guards are rejected (lifecycle transitions are unguarded). The
+//! transition TABLE still comes from the `#[lifecycle]` enum; only the effects
+//! are declared at the binding site. Both the inline and lifecycle paths route
+//! their effects through the SAME `transition_{field}_to_on_conn` codegen, so a
+//! lifecycle binding with `effects(...)` gains the identical connection-taking
+//! method.
+//!
+//! This is a lightweight compilation + pure-validation contract test that runs
+//! WITHOUT Docker (it never opens a connection): it constructs models by hand
+//! and calls the generated pure validators, and references the connection-taking
+//! method behind a never-called async fn so the generated effect codegen is
+//! type-checked. Run it standalone with:
+//!
+//! ```text
+//! cargo test -p autumn-web --test state_machine_lifecycle_effects
+//! ```
+
+#![cfg(feature = "db")]
+
+use autumn_web::model;
+use autumn_web::prelude::*;
+use autumn_web::reexports::diesel_async::AsyncPgConnection;
+use autumn_web::{Lifecycle, lifecycle};
+use serde::{Deserialize, Serialize};
+
+// ── The typed source of truth for the transition table ────────────────────────
+
+#[lifecycle(
+    initial = Draft,
+    terminal(Archived),
+    transitions(
+        Draft -> Published,
+        Published -> Archived,
+    )
+)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrderState {
+    Draft,
+    Published,
+    Archived,
+}
+
+// The after-commit effect job. The derived idempotency key rides on the payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EffectArgs {
+    idempotency_key: String,
+}
+
+#[job(name = "lifecycle_effects_announce_publish")]
+#[allow(clippy::unused_async)] // stub handler: no real work in this codegen test
+async fn announce_publish(_state: AppState, _args: EffectArgs) -> AutumnResult<()> {
+    Ok(())
+}
+
+diesel::table! {
+    lifecycle_effects_articles (id) {
+        id -> BigInt,
+        status -> Text,
+    }
+}
+
+/// The transition table comes from `OrderState`; the per-edge effects are
+/// declared at the binding site via `effects(...)`. The state strings in the
+/// effect edges match the `PascalCase` the enum's variant names render to.
+#[model(table = "lifecycle_effects_articles")]
+pub struct Article {
+    #[id]
+    pub id: i64,
+    #[state_machine(lifecycle = OrderState, effects(
+        // After-commit enqueue on this edge.
+        Draft -> Published: on_commit = AnnouncePublishJob,
+        // Sync in-transaction handler on this edge.
+        Published -> Archived: on = "record_archive",
+    ))]
+    pub status: String,
+}
+
+impl Article {
+    // The sync in-transaction effect: runs inside the transition's transaction,
+    // and `Err` rolls the transition back. A no-op stub here.
+    #[allow(clippy::unused_async)] // stub handler: no real work in this codegen test
+    async fn record_archive(&self, _conn: &mut AsyncPgConnection) -> AutumnResult<()> {
+        Ok(())
+    }
+}
+
+fn article(status: &str) -> Article {
+    Article {
+        id: 7,
+        status: status.to_string(),
+    }
+}
+
+// The pure validators are byte-for-byte unchanged by the `effects(...)` clause —
+// the allowed/denied set still comes from the enum's transition table.
+#[test]
+fn pure_validator_still_governs_lifecycle_edges() {
+    // Declared edges are allowed.
+    assert!(article("Draft").can_transition_status_to("Published"));
+    assert!(article("Published").can_transition_status_to("Archived"));
+    // Undeclared edges remain denied.
+    assert!(!article("Draft").can_transition_status_to("Archived"));
+    assert!(!article("Archived").can_transition_status_to("Draft"));
+
+    // `transition_*_to` mirrors the predicate.
+    assert_eq!(
+        article("Draft")
+            .transition_status_to("Published")
+            .expect("declared edge"),
+        "Published"
+    );
+    assert!(article("Draft").transition_status_to("Archived").is_err());
+
+    // The table is a direct alias of the enum's typed table.
+    assert_eq!(
+        Article::__AUTUMN_SM_STATUS_TRANSITIONS,
+        <OrderState as Lifecycle>::STATE_MACHINE_TRANSITIONS
+    );
+}
+
+// Compilation contract: the additive connection-taking method exists, takes a
+// connection, and returns the new state. Never called (no runtime/DB here) — its
+// mere existence type-checks the lifecycle-path `on_commit` + `on` effect codegen
+// end to end, proving the shared emitter converged both paths.
+#[allow(dead_code)]
+async fn _assert_on_conn_signature(
+    article: &Article,
+    conn: &mut AsyncPgConnection,
+) -> AutumnResult<String> {
+    article
+        .transition_status_to_on_conn(conn, "Published")
+        .await
+}


### PR DESCRIPTION
Part of #1973.

## Before / After

**Before.** Per-edge transition effects — a synchronous in-transaction `on = "handler"` and an after-commit `on_commit = <Job>` — were only expressible on the inline `#[state_machine(transitions(...))]` path. The `#[state_machine(lifecycle = <Enum>)]` path could reuse a `#[lifecycle]` enum's typed transition table, but it could declare **no** effects at all: it emitted no `transition_{field}_to_on_conn` method and received no primary-key ident. A creator who wanted the enum-typed table *and* an after-commit job on one edge had to abandon the lifecycle binding and re-hand-write every edge inline.

**After.** A lifecycle binding can declare per-edge effects at the binding site via an optional `effects(...)` clause, while the transition **table** still comes from the enum:

```rust
#[model]
struct Article {
    #[state_machine(lifecycle = ArticleState, effects(
        Draft     -> Published: on_commit = AnnouncePublishJob,
        Published -> Archived:  on = "write_archive_audit",
    ))]
    status: String,
}
```

`effects(...)` reuses the **exact** per-edge grammar of `transitions(...)`, except **guards are rejected** (lifecycle transitions are unguarded — a guard there would be silently ignored by the runtime-table validator, so it is now a compile error) and each edge must declare at least one effect. When no `effects(...)` clause is present the lifecycle codegen is **byte-for-byte identical** to before.

## How

The `StateMachineSource::Lifecycle` variant now carries an `effects: Vec<StateMachineTransition>` alongside its `path`. `parse_state_machine_source` optionally consumes a trailing `, effects(...)` after `lifecycle = <Enum>`, parsing it with the existing `parse_transition_list` and then rejecting any edge that carries a guard or declares no effect. `emit_state_machine_lifecycle` gained `effects` + `pk_ident` params and splices the shared `emit_state_machine_on_conn(...)` helper after its `impl` block — the identical emitter the inline path already uses. When `effects` is empty that helper returns an empty token stream, so a plain `lifecycle = <Enum>` is unchanged. No runtime-crate changes (`TransitionEffect` + `enqueue_on_conn` already exist); no `autumn/src/lib.rs` change.

**Tests:** 6 macro unit tests (on_conn emitted with effects / absent without / sync-`on` handler call / guard rejected / empty-edge rejected / idempotency-key derivation), an isolated no-Docker contract test (`autumn/tests/state_machine_lifecycle_effects.rs`) that type-checks the generated `transition_status_to_on_conn` behind a never-called async fn and asserts the pure validators still behave, and a trybuild compile-pass fixture (`model_state_machine_lifecycle_effects.rs`). No compile-**fail** golden is added (the guard/empty-edge rejections are covered by the macro unit tests, avoiding fragile `.stderr` blessing).

## Design note: no runtime registry

The ratified spec proposed a *runtime edge-keyed registry* to converge the two paths. That is not needed here. The merged wave-1 mechanism (PR1, #2017) is an explicit `transition_{field}_to_on_conn` method with **compile-time edge match arms**, not a runtime table. Because effects are declared at the binding site with **compile-time-literal** edges (and literal handler names / job paths), the same helper generalizes to the lifecycle path with **no runtime registry**. The registry was only ever necessary to converge *named guards* — a runtime string table can't call `self.<name>()` — and effects sidestep that entirely (a guard on a lifecycle edge is a compile error). Result: zero runtime overhead, and both the inline and lifecycle paths generate the **identical** `_on_conn` method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017b2TS7EVMkMvcvjSyy1MrQ

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2TS7EVMkMvcvjSyy1MrQ)_