### PR TITLE
fix(lint): split long first doc paragraphs (clippy 1.97 too_long_first_doc_paragraph)

### DIFF
--- a/autumn/src/repository.rs
+++ b/autumn/src/repository.rs
@@ -65,7 +65,9 @@ macro_rules! maybe_for_update {
     };
 }
 
-/// `SQLite` arm of [`maybe_for_update!`] — the identity. See the Postgres
+/// `SQLite` arm of [`maybe_for_update!`] — the identity.
+///
+/// See the Postgres
 /// definition for the full contract; `SQLite` has no `SELECT … FOR UPDATE`, so a
 /// pessimistic-lock read degrades to a plain read.
 #[cfg(all(feature = "db", feature = "sqlite"))]
@@ -77,6 +79,7 @@ macro_rules! maybe_for_update {
 }
 
 /// Compile-time backend block selector for generated `#[repository]`/`#[model]`
+///
 /// CRUD where the two backends need *structurally different* code (not just a
 /// swapped receiver), e.g. Postgres multi-row batch insert vs. the `SQLite`
 /// per-row loop, or the batched `ON CONFLICT` upsert vs. `SQLite`'s per-row
@@ -133,7 +136,9 @@ pub enum ReadRoute {
     ReadPool(diesel_async::pooled_connection::deadpool::Pool<crate::db::RuntimeConnection>),
     /// A replica is configured but currently unready, and the
     /// [`ReplicaFallback::FailReadiness`](crate::config::ReplicaFallback)
-    /// policy forbids falling back to the primary. Generated reads fail
+    /// policy forbids falling back to the primary.
+    ///
+    /// Generated reads fail
     /// fast with `503 Service Unavailable` instead of silently serving
     /// from the wrong role.
     Unavailable,
@@ -349,6 +354,7 @@ pub trait AutumnDependents {
 impl<T: ?Sized> AutumnDependents for T {}
 
 /// Publish a batch of deferred dependent-cascade OOB *delete* broadcasts,
+///
 /// accumulated during a `dependent = destroy` cascade over `broadcasts = true`
 /// children and published **after** the parent transaction commits (#1369).
 ///
@@ -387,7 +393,9 @@ pub fn publish_deferred_dependent_broadcasts(broadcasts: Vec<(String, String)>) 
     }
 }
 
-/// No-op fallback when live broadcasting is not compiled in. The accumulation
+/// No-op fallback when live broadcasting is not compiled in.
+///
+/// The accumulation
 /// side only runs for `broadcasts = true` children (which require these
 /// features), so the buffer is always empty in this configuration.
 #[cfg(not(all(feature = "ws", feature = "maud", feature = "htmx")))]
@@ -495,7 +503,9 @@ pub trait ModelPrimaryKey {
 
 /// Framework plumbing bridging a `#[repository]`-generated struct to the
 /// many-to-many (`#[has_many(Target, through = join_table)]`) mutation
-/// helpers `#[model]` generates. `#[repository(Model, ...)]` implements this
+/// helpers `#[model]` generates.
+///
+/// `#[repository(Model, ...)]` implements this
 /// once, unconditionally, alongside the model's other generated impls; the
 /// `Model` associated type is what keeps `add_*`/`remove_*`/`set_*` method
 /// resolution unambiguous when more than one m2m trait is in scope (e.g. two
@@ -512,7 +522,9 @@ pub trait M2mConnSource: Send + Sync {
     type Model;
 
     /// Acquire a primary-pool connection for an `add_*`/`remove_*`/`set_*`
-    /// many-to-many mutation. Mirrors the write-connection acquisition every
+    /// many-to-many mutation.
+    ///
+    /// Mirrors the write-connection acquisition every
     /// other mutating generated method uses (marks the read-your-writes pin
     /// on success).
     fn __autumn_m2m_write_conn(

--- a/autumn/tests/sqlite_upsert_isolation.rs
+++ b/autumn/tests/sqlite_upsert_isolation.rs
@@ -1,28 +1,28 @@
 //! `#[repository]` upsert isolation + optimistic-lock proof on the `SQLite`
 //! runtime backend (issue #1996, PR #2021).
 //!
-//! Pins the two P1 fixes on the cfg-dual `__autumn_execute_upsert` SQLite arm and
+//! Pins the two P1 fixes on the cfg-dual `__autumn_execute_upsert` `SQLite` arm and
 //! the versioned `upsert_many` path:
 //!
 //! * **Bug 2 — tenant isolation (SECURITY):** the Postgres upsert's
 //!   `ON CONFLICT (id) DO UPDATE … WHERE tenant_id = $current` predicate keeps an
-//!   id owned by another tenant from being hijacked. The SQLite arm conflicts on
+//!   id owned by another tenant from being hijacked. The `SQLite` arm conflicts on
 //!   `id` only and its DO UPDATE set-clause writes `tenant_id`, so without the
 //!   SAME `WHERE tenant_id = <current>` predicate, upserting another tenant's id
 //!   would MOVE that row into the caller's tenant. This test proves the fix:
 //!   `upsert_many` under tenant B with tenant A's id leaves tenant A's row
 //!   completely untouched (no cross-tenant leak) and creates nothing under B.
-//! * **Bug 2 — optimistic lock guard:** the SQLite DO UPDATE preserves
+//! * **Bug 2 — optimistic lock guard:** the `SQLite` DO UPDATE preserves
 //!   `WHERE lock_version = excluded.lock_version`, so a stale-version upsert is
 //!   left untouched, dropped from `RETURNING`, and surfaces as a 409 Conflict —
 //!   matching Postgres exactly.
 //!
 //! Bug 1 (the versioned advisory lock `SELECT pg_advisory_xact_lock($1)` being
-//! cfg-gated to Postgres-only, so it is skipped on SQLite's single-writer engine)
+//! cfg-gated to Postgres-only, so it is skipped on `SQLite`'s single-writer engine)
 //! is pinned by the macro-expansion test
 //! `repository_macro_versioned_upsert_many_gates_advisory_lock_to_postgres_only`
 //! in `autumn-macros`. A full `versioned = true` (version-history) repository
-//! cannot run end-to-end on SQLite yet because the version-history writer emits a
+//! cannot run end-to-end on `SQLite` yet because the version-history writer emits a
 //! Postgres-only `$7::jsonb` cast — a separate unported construct outside these
 //! two P1s — so the runtime lock-conflict behaviour is proven here with the
 //! optimistic-lock (`#[lock_version]`) shape, which does not require version


### PR DESCRIPTION
## What changed

**Before:** CI's Lint job (clippy 1.97.0, `cargo clippy --workspace --all-targets -- -D warnings`) was red trunk-wide — the container's local clippy is 1.94 and doesn't emit `clippy::too_long_first_doc_paragraph`, so the violations passed local checks but failed CI.

**After:** the workspace Lint gate is green under clippy 1.97 (verified `cargo +1.97.0 clippy --workspace --all-targets -- -D warnings` → exit 0).

## How

- **`autumn/src/repository.rs`** — split 7 doc comments whose first paragraph exceeded the `too_long_first_doc_paragraph` threshold. Each split is mechanical: a short first line, a blank doc line, then the original content unchanged (no wording changes). Covers both `#[cfg]` arms of the `maybe_for_update!` / `backend_select!` macros, the `ReadRoute::Unavailable` variant, both arms of `publish_deferred_dependent_broadcasts`, and the `M2mConnSource` trait + method.
- **`autumn/tests/sqlite_upsert_isolation.rs`** — wrapped 5 bare `SQLite` tokens in the always-compiled `//!` header in backticks to clear `clippy::doc_markdown`. These errors were previously *masked* by the paragraph lint aborting the run first; fixing the paragraphs unmasked them, so they're folded in here to actually leave the `--all-targets` Lint gate green rather than red on the next lint.

## Notes
- Un-reds the trunk-wide Lint gate.
- The schema-diff-engine branch (#2020) carries a duplicate of the 5 `repository.rs` doc splits (this PR is a superset — 7, including 2 macro arms newer on trunk); #2020 will drop its duplicate on rebase once this merges.
- No CHANGELOG entry, no version bump, no skills changes — pure lint hotfix.

---
_Generated by [Claude Code](https://claude.ai/code/session_012fPpT6z2mAGMCLBwTnX8ko)_