### PR TITLE
Reject lifecycle effects declared on non-transition edges at compile time (#1973)

### DIFF
--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -3304,7 +3304,39 @@ fn emit_state_machine_lifecycle(
         pk_ident,
     );
 
+    // Compile-time guard (issue #1973): the referenced enum's transition table
+    // is not resolvable at macro-expansion time, so validate each declared
+    // effect edge against `<Enum>::STATE_MACHINE_TRANSITIONS` with a const
+    // assertion instead. An effect declared on an edge the lifecycle does not
+    // permit would otherwise compile with a silently-unreachable match arm and
+    // drop the effect; this turns that into a compile error. Empty `effects`
+    // emits no assertions, keeping a plain `lifecycle = <Enum>` unchanged.
+    let effect_edge_assertions: Vec<TokenStream> = effects
+        .iter()
+        .map(|t| {
+            let from = &t.from;
+            let to = &t.to;
+            let msg = format!(
+                "state-machine effect declared on edge `{from} -> {to}`, which is not a \
+                 transition of the referenced lifecycle enum; declare the effect on a real \
+                 transition edge (or add the edge to the lifecycle)"
+            );
+            quote! {
+                const _: () = ::core::assert!(
+                    ::autumn_web::__transition_edge_declared(
+                        <#path as ::autumn_web::Lifecycle>::STATE_MACHINE_TRANSITIONS,
+                        #from,
+                        #to,
+                    ),
+                    #msg,
+                );
+            }
+        })
+        .collect();
+
     quote! {
+        #(#effect_edge_assertions)*
+
         impl #model_name {
             #[doc(hidden)]
             pub const #const_name: &'static [(&'static str, &'static str, ::core::option::Option<&'static str>)] =
@@ -8995,6 +9027,63 @@ mod tests {
         assert!(
             generated.contains("self . id"),
             "the record id must come from the primary key: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_lifecycle_effects_emit_edge_validation_asserts() {
+        // Issue #1973: on the lifecycle path an `effects(...)` edge that is not a
+        // real transition of the referenced enum would otherwise compile with a
+        // silently-unreachable match arm and drop the effect. The codegen emits a
+        // per-edge compile-time const assertion against the enum's
+        // `STATE_MACHINE_TRANSITIONS` table to reject that at compile time.
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(lifecycle = OrderState, effects(
+                        processing -> shipped: on_commit = SendShippedEmailJob,
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            generated.contains("__transition_edge_declared"),
+            "each effect edge must be validated against the lifecycle table: {generated}"
+        );
+        assert!(
+            generated.contains("const _ : () ="),
+            "the edge validation must be a compile-time const assertion: {generated}"
+        );
+        assert!(
+            generated.contains("STATE_MACHINE_TRANSITIONS"),
+            "the assertion must check the referenced enum's transition table: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_lifecycle_without_effects_emits_no_edge_validation() {
+        // A plain `lifecycle = <Enum>` (no `effects(...)`) must be byte-identical
+        // to before: no per-edge validation assertions are emitted.
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(lifecycle = OrderState)]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        assert!(
+            !generated.contains("__transition_edge_declared"),
+            "a no-effects lifecycle model must emit no edge validation: {generated}"
         );
     }
 

--- a/autumn-macros/src/model.rs
+++ b/autumn-macros/src/model.rs
@@ -3254,6 +3254,13 @@ fn emit_state_machine_on_conn(
     }
 }
 
+/// Strip a leading raw-identifier (`r#`) prefix from a state name, mirroring
+/// `lifecycle::variant_name_str` so effect-edge state strings align with the
+/// enum's already-stripped `STATE_MACHINE_TRANSITIONS` entries.
+fn strip_raw(s: &str) -> &str {
+    s.strip_prefix("r#").unwrap_or(s)
+}
+
 /// Emit the state-machine items for a `lifecycle = <Enum>` reference (#1911).
 ///
 /// The transitions constant is an alias of the referenced enum's
@@ -3291,6 +3298,27 @@ fn emit_state_machine_lifecycle(
         transition_fn,
         field_str,
     } = state_machine_names(field);
+
+    // Normalize each effect edge's `from`/`to` by stripping a leading raw-
+    // identifier prefix (issue #1973 / Codex P2 on #2027). The `#[lifecycle]`
+    // macro stores variant names in `STATE_MACHINE_TRANSITIONS` with `r#`
+    // already stripped (see `lifecycle::variant_name_str`), but the effect
+    // edges parsed at the binding site preserve it (e.g. `Draft -> r#type`).
+    // Without this alignment the const assertion below would check `"r#type"`
+    // against a table containing `"type"` (falsely rejecting a real edge) and
+    // the generated match arm would never fire (silently dropping the effect).
+    // Guard/on_commit/on are carried through unchanged.
+    let normalized_effects: Vec<StateMachineTransition> = effects
+        .iter()
+        .map(|t| StateMachineTransition {
+            from: strip_raw(&t.from).to_owned(),
+            to: strip_raw(&t.to).to_owned(),
+            guard: t.guard.clone(),
+            on_commit: t.on_commit.clone(),
+            on: t.on.clone(),
+        })
+        .collect();
+    let effects = &normalized_effects;
 
     // Per-edge effect method (issue #1973): only emitted when the binding site
     // declares one or more `effects(...)` edges. Empty `effects` returns an
@@ -9084,6 +9112,49 @@ mod tests {
         assert!(
             !generated.contains("__transition_edge_declared"),
             "a no-effects lifecycle model must emit no edge validation: {generated}"
+        );
+    }
+
+    #[test]
+    fn state_machine_lifecycle_effects_normalize_raw_identifier_edges() {
+        // Codex P2 on #2027: a lifecycle effect edge naming a raw-identifier
+        // variant (e.g. `ready -> r#type`) must be normalized to the enum's
+        // already-stripped `STATE_MACHINE_TRANSITIONS` entry (`"type"`) — the
+        // `#[lifecycle]` macro strips `r#` when building that table, but the
+        // effect edge parsed here preserves it. Both the compile-time edge
+        // assertion and the runtime effect match arm must use the stripped name
+        // so a real edge is not falsely rejected and the effect is not silently
+        // dropped.
+        let output = model_macro(
+            TokenStream::new(),
+            quote! {
+                pub struct Order {
+                    #[id]
+                    pub id: i64,
+                    #[state_machine(lifecycle = OrderState, effects(
+                        ready -> r#type: on_commit = SendTypedJob,
+                    ))]
+                    pub status: String,
+                }
+            },
+        );
+        let generated = output.to_string();
+        // The stripped name is what the enum table stores and what the codegen
+        // (const assertion, match arm, idempotency key) must emit.
+        assert!(
+            generated.contains("\"type\""),
+            "normalized effect edge must use the stripped `type` state: {generated}"
+        );
+        // The raw-identifier form must never survive into an assertion / match
+        // literal — that is exactly the mismatch the bug produced.
+        assert!(
+            !generated.contains("\"r#type\""),
+            "the raw `r#type` form must be stripped before codegen: {generated}"
+        );
+        // The per-edge validation is still emitted (now against the aligned name).
+        assert!(
+            generated.contains("__transition_edge_declared"),
+            "the normalized edge must still be validated at compile time: {generated}"
         );
     }
 

--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -1356,6 +1356,53 @@ pub struct TransitionEffect {
     pub idempotency_key: String,
 }
 
+/// Internal: returns `true` if `(from, to)` appears as an edge in a
+/// `#[lifecycle]` enum's `STATE_MACHINE_TRANSITIONS` table. Used by
+/// `#[state_machine(lifecycle = ..., effects(...))]` codegen to reject at
+/// compile time an effect declared on an edge the lifecycle does not permit
+/// (which would otherwise silently drop the effect). Not part of the public API.
+#[doc(hidden)]
+#[must_use]
+pub const fn __transition_edge_declared(
+    table: &[(&str, &str, ::core::option::Option<&str>)],
+    from: &str,
+    to: &str,
+) -> bool {
+    // Iterators/`for` are not permitted in a const fn, so index with `while`.
+    #[allow(clippy::needless_range_loop)]
+    let mut i = 0;
+    while i < table.len() {
+        let (f, t, _) = table[i];
+        if __const_str_eq(f, from) && __const_str_eq(t, to) {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+/// Internal: byte-wise `&str` equality usable in a const context (where the
+/// `PartialEq` `==` operator on `str` is not available). Not part of the
+/// public API.
+#[doc(hidden)]
+#[must_use]
+pub const fn __const_str_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    // Iterators/`for` are not permitted in a const fn, so index with `while`.
+    #[allow(clippy::needless_range_loop)]
+    let mut i = 0;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
 // ── Maud re-exports ────────────────────────────────────────────────
 
 /// Rendered HTML fragment produced by the [`html!`] macro.


### PR DESCRIPTION
Part of #1973.

## Before / After

**Before:** on the `#[state_machine(lifecycle = <Enum>, effects(...))]` path, an `effects(...)` edge that is *not* a real transition of the referenced lifecycle enum (a typo, or an edge left stale after the enum changed) compiled cleanly. Its generated effect match arm was simply unreachable — the valid transition completed and the declared `on` / `on_commit` effect was **silently dropped**. (Only the lifecycle path had this gap; inline `transitions(...)` effects are declared on the edge itself, so a bogus edge there is already a non-edge.)

**After:** each declared effect edge is validated at compile time against the enum's `STATE_MACHINE_TRANSITIONS` table. An effect declared on a non-transition edge now **fails to compile** with a clear message instead of silently dropping the effect.

## How

The referenced enum's transition table is not resolvable at macro-expansion time (it comes from another module/crate), so parser-level validation — as the review suggested — is impossible in a proc-macro. Instead, `emit_state_machine_lifecycle` now emits one const-eval assertion per effect edge:

```rust
const _: () = ::core::assert!(
    ::autumn_web::__transition_edge_declared(
        <Enum as ::autumn_web::Lifecycle>::STATE_MACHINE_TRANSITIONS,
        "From", "To",
    ),
    "…not a transition of the referenced lifecycle enum…",
);
```

`__transition_edge_declared` / `__const_str_eq` are `#[doc(hidden)]` `const fn` helpers in `autumn-web` (byte-wise `&str` comparison, since `str == str` isn't available in const context; `while`-indexed since iterators aren't allowed in const fn). Const-eval resolves the enum's table cross-crate, so the assertion works regardless of where the lifecycle enum lives. When `effects` is empty, no assertions are emitted — a plain `lifecycle = <Enum>` is byte-identical to before.

## Review note

This addresses the Codex P2 on #2024. The review proposed validating in the parser, but a proc-macro cannot resolve an external enum's transition table at expansion time — the table is only known once the referenced type is fully compiled. A const-eval assertion is the correct mechanism: it defers the check to const evaluation (which *can* see the table) while still failing the build, and it works across crate boundaries.

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2TS7EVMkMvcvjSyy1MrQ)_