### PR TITLE
🗺️ Atlas: [fix SQLite compilation issues with generic pools]

### DIFF
--- a/autumn/src/lib.rs
+++ b/autumn/src/lib.rs
@@ -518,6 +518,8 @@ pub mod __private {
     pub use crate::db::scoped_transaction;
     #[cfg(all(feature = "db", feature = "ws"))]
     pub use crate::repository_commit_hooks::CURRENT_CHANNELS;
+    #[cfg(all(feature = "db", not(feature = "sqlite")))]
+    pub use crate::repository_commit_hooks::start_repository_commit_hook_worker;
     #[cfg(feature = "db")]
     pub use crate::repository_commit_hooks::{
         RepositoryCommitHookDescriptor, catch_repository_after_hook_unwind,
@@ -528,7 +530,6 @@ pub mod __private {
         finalize_repository_commit_hook_after_hook, kick_repository_commit_hook_dispatcher,
         mark_repository_commit_hook_after_hook_failed, register_repository_commit_hook_runner,
         start_repository_commit_hook_pending_finalizer_heartbeat,
-        start_repository_commit_hook_worker,
     };
     #[cfg(feature = "db")]
     pub use crate::repository_commit_hooks::{

--- a/autumn/src/mail.rs
+++ b/autumn/src/mail.rs
@@ -4081,13 +4081,13 @@ pub mod suppression {
         /// ```
         #[derive(Clone)]
         pub struct PgSuppressionStore {
-            pool: Pool<AsyncPgConnection>,
+            pool: Pool<crate::db::RuntimeConnection>,
         }
 
         impl PgSuppressionStore {
             /// Create a store backed by `pool`.
             #[must_use]
-            pub const fn new(pool: Pool<AsyncPgConnection>) -> Self {
+            pub const fn new(pool: Pool<crate::db::RuntimeConnection>) -> Self {
                 Self { pool }
             }
         }
@@ -4207,13 +4207,13 @@ pub mod db_suppression {
     /// `autumn generate mailer --list-unsubscribe` writes into the app.
     #[derive(Clone)]
     pub struct DbSuppressionStore {
-        pool: Pool<AsyncPgConnection>,
+        pool: Pool<crate::db::RuntimeConnection>,
     }
 
     impl DbSuppressionStore {
         /// Create a store backed by `pool`.
         #[must_use]
-        pub const fn new(pool: Pool<AsyncPgConnection>) -> Self {
+        pub const fn new(pool: Pool<crate::db::RuntimeConnection>) -> Self {
             Self { pool }
         }
     }

--- a/autumn/src/managed_pg.rs
+++ b/autumn/src/managed_pg.rs
@@ -514,7 +514,7 @@ impl DatabasePoolProvider for ManagedPostgresPoolProvider {
     async fn create_pool(
         &self,
         config: &DatabaseConfig,
-    ) -> Result<Option<Pool<AsyncPgConnection>>, PoolError> {
+    ) -> Result<Option<Pool<crate::db::RuntimeConnection>>, PoolError> {
         // Reject a sharded config before starting anything. When the provider is
         // installed only as the *pool* provider (`.with_pool_provider`),
         // `resolve_shard_set` builds the shards directly from config and never

--- a/autumn/src/repository_commit_hooks.rs
+++ b/autumn/src/repository_commit_hooks.rs
@@ -780,7 +780,7 @@ where
     Ok((context, record))
 }
 
-#[cfg(feature = "ws")]
+#[cfg(all(feature = "ws", not(feature = "sqlite")))]
 pub fn start_repository_commit_hook_worker(
     pool: PgPool,
     channels: Option<crate::channels::Channels>,
@@ -826,7 +826,7 @@ pub fn start_repository_commit_hook_worker(
     });
 }
 
-#[cfg(not(feature = "ws"))]
+#[cfg(all(not(feature = "ws"), not(feature = "sqlite")))]
 pub fn start_repository_commit_hook_worker(pool: PgPool, shutdown: CancellationToken) {
     register_inventory_repository_commit_hook_runners();
     if !should_start_repository_commit_hook_worker(&registered_handler_keys()) {
@@ -1571,6 +1571,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(feature = "sqlite"))]
     #[test]
     fn dispatcher_kick_state_coalesces_pending_notifications() {
         let state = RepositoryCommitHookKickState::default();


### PR DESCRIPTION
🕸️ Tangle: The codebase had hardcoded `Pool<AsyncPgConnection>` types in trait implementations (e.g., `ManagedPostgresPoolProvider`, `PgSuppressionStore`, and `DbSuppressionStore`). This broke the `--all-features` build (which enables the `sqlite` feature), as `RuntimeConnection` resolves to a SQLite connection in that scenario, causing type mismatches against the `DatabasePoolProvider` trait requirement.
📐 Blueprint: Replaced explicit `AsyncPgConnection` usages with `crate::db::RuntimeConnection` where generic pools are constructed. Properly gated Postgres-specific repository commit hook workers and exports behind `#[cfg(not(feature = "sqlite"))]` guards.
🧱 Stability: Unified the connection alias usage, restoring compilation under `--all-features` while preserving SQLite backend abstraction boundaries. 
🔬 Verification: Ran `cargo check --workspace --all-features` and `cargo test -p autumn-web --lib --all-features` successfully.

---
*PR created automatically by Jules for task [8238770887905100542](https://jules.google.com/task/8238770887905100542) started by @madmax983*