### PR TITLE
Annotate transition effects in `autumn lifecycle diagram` (#1973)

### DIFF
--- a/autumn-cli/src/lifecycle.rs
+++ b/autumn-cli/src/lifecycle.rs
@@ -215,13 +215,17 @@ pub struct LifecycleDef {
 
 /// An effect declared on a `#[state_machine(lifecycle = Enum, effects(...))]`
 /// binding (issue #1973), correlated to a `#[lifecycle]` enum's diagram by that
-/// enum's module-qualified [`LifecycleDef::id`] (the `lifecycle = <Path>`
-/// resolved relative to the binding's module — see [`resolve_lifecycle_id`]).
-/// Keying by the qualified id, not the bare enum name, keeps two same-named
-/// lifecycle enums in different modules from cross-contaminating each other's
-/// effect labels. This rides in a separate structure consulted only by the
-/// diagram renderers, so the `check` command, the JSON artifact, and
-/// [`LifecycleDef::transitions`] stay byte-identical.
+/// enum's module-qualified [`LifecycleDef::id`] in a post-scan pass (see
+/// [`resolve_effect_bindings`]): the binding's `lifecycle = <Path>` is first
+/// resolved relative to the binding's module ([`resolve_lifecycle_id`]) and, if
+/// that qualified id is a scanned lifecycle, keyed by it; otherwise it falls back
+/// to a scanned lifecycle whose bare enum name is *globally unique*. Qualified
+/// matching keeps two same-named lifecycle enums in different modules from
+/// cross-contaminating each other's effect labels (their bare name is ambiguous,
+/// so the fallback never fires), while the unique-bare-name fallback rescues a
+/// model that imports its lifecycle from another module. This rides in a separate
+/// structure consulted only by the diagram renderers, so the `check` command, the
+/// JSON artifact, and [`LifecycleDef::transitions`] stay byte-identical.
 #[derive(Debug)]
 struct EffectEdge {
     from: String,
@@ -231,6 +235,42 @@ struct EffectEdge {
     /// The `on_commit = <Job>` after-commit effect (its `syn::Path`'s last
     /// segment rendered as the job name), if declared.
     on_commit: Option<String>,
+}
+
+/// A raw `#[state_machine(lifecycle = <Path>, effects(...))]` binding collected
+/// during the scan. Its `lifecycle = <Path>` is resolved to a scanned lifecycle
+/// id only in a post-pass ([`resolve_effect_bindings`]), once the *complete* set
+/// of scanned lifecycle ids is known — a single-pass resolution could not see a
+/// lifecycle declared later in the scan (nor decide whether a bare enum name is
+/// globally unique), so the correlation is deferred.
+struct RawBinding {
+    /// The inline-module context the binding is declared in (same context
+    /// [`collect_lifecycle_enum`] uses to build a [`LifecycleDef::id`]).
+    module_path: Vec<String>,
+    /// The binding's `lifecycle = <Path>`, resolved in the post-pass.
+    lifecycle_path: syn::Path,
+    /// The binding's declared `effects(...)` edges.
+    edges: Vec<EffectEdge>,
+}
+
+// `syn::Path` does not implement `Debug` without the `extra-traits` feature, so
+// `Debug` is hand-written (rendering the path as its `::`-joined segment idents)
+// to keep the `Debug`-derived [`Scan`] compiling without pulling in that feature.
+impl std::fmt::Debug for RawBinding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let path = self
+            .lifecycle_path
+            .segments
+            .iter()
+            .map(|s| s.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("::");
+        f.debug_struct("RawBinding")
+            .field("module_path", &self.module_path)
+            .field("lifecycle_path", &path)
+            .field("edges", &self.edges)
+            .finish()
+    }
 }
 
 // ── Analysis ─────────────────────────────────────────────────────────────────
@@ -478,13 +518,17 @@ struct Scan {
     lifecycles: Vec<LifecycleDef>,
     errors: Vec<String>,
     files_scanned: usize,
-    /// Transition effects collected from
-    /// `#[state_machine(lifecycle = Enum, effects(...))]` bindings (issue #1973),
-    /// keyed by the bound lifecycle enum's module-qualified [`LifecycleDef::id`]
-    /// (the `lifecycle = <Path>` resolved relative to the binding's module). A
-    /// binding whose path cannot be resolved to that id scheme is left
-    /// uncorrelated (dropped) rather than matched by bare name. Consulted only by
-    /// the diagram renderers.
+    /// Raw `#[state_machine(lifecycle = Enum, effects(...))]` bindings collected
+    /// during the scan (issue #1973), resolved into [`Self::effect_edges`] only
+    /// in a post-pass once every lifecycle id is known (see
+    /// [`resolve_effect_bindings`]).
+    raw_bindings: Vec<RawBinding>,
+    /// Transition effects keyed by the bound lifecycle enum's module-qualified
+    /// [`LifecycleDef::id`], produced by the post-scan [`resolve_effect_bindings`]
+    /// pass. A binding is keyed by its qualified id when that id is a scanned
+    /// lifecycle, else by a scanned lifecycle whose bare enum name is globally
+    /// unique, else dropped (a safe failure — missing labels, never a mismatch).
+    /// Consulted only by the diagram renderers.
     effect_edges: HashMap<String, Vec<EffectEdge>>,
 }
 
@@ -509,6 +553,14 @@ fn scan_project(root: &Path) -> std::io::Result<Scan> {
         scan_source(&src, &rel, &mut scan);
         scan.files_scanned += 1;
     }
+    // Post-pass: now that the complete set of scanned lifecycle ids is known,
+    // correlate every collected effect binding (qualified-match first, then a
+    // unique-bare-name fallback for imported lifecycles). Deferring this until
+    // the whole scan finishes lets a binding correlate to a lifecycle declared
+    // later in scan order, and lets the bare-name fallback see whether a name is
+    // globally unique.
+    scan.effect_edges =
+        resolve_effect_bindings(std::mem::take(&mut scan.raw_bindings), &scan.lifecycles);
     Ok(scan)
 }
 
@@ -699,11 +751,9 @@ fn collect_lifecycle_enum(
 ///
 /// `module_path` is the inline-module context the binding is declared in (the
 /// same context [`collect_lifecycle_enum`] uses to build a [`LifecycleDef::id`]).
-/// The binding's `lifecycle = <Path>` is resolved to that qualified-id scheme via
-/// [`resolve_lifecycle_id`], so effects are keyed by the *same* id the renderers
-/// look the lifecycle up by. A path that cannot be resolved is left uncorrelated
-/// (dropped) — a safe failure (missing labels) strictly better than the previous
-/// bare-name matching, which could label an unrelated same-named lifecycle.
+/// The binding is stashed *raw* (path + module + edges) and correlated to a
+/// scanned lifecycle only in the post-scan [`resolve_effect_bindings`] pass, when
+/// the complete set of scanned lifecycle ids is known.
 fn collect_state_machine_effects(
     item_struct: &syn::ItemStruct,
     scan: &mut Scan,
@@ -719,12 +769,71 @@ fn collect_state_machine_effects(
             if let Ok(Some((lifecycle_path, edges))) =
                 attr.parse_args_with(parse_state_machine_effects)
                 && !edges.is_empty()
-                && let Some(id) = resolve_lifecycle_id(module_path, &lifecycle_path)
             {
-                scan.effect_edges.entry(id).or_default().extend(edges);
+                scan.raw_bindings.push(RawBinding {
+                    module_path: module_path.to_vec(),
+                    lifecycle_path,
+                    edges,
+                });
             }
         }
     }
+}
+
+/// Correlate the raw effect bindings collected during the scan to scanned
+/// lifecycle ids, producing the `id -> effects` map the diagram renderers consult
+/// (issue #1973; Codex P2 on #2029). Runs as a post-pass so it can see the
+/// *complete* set of scanned lifecycles. Each binding is resolved by, in order:
+///
+/// 1. **Qualified match**: resolve the binding's `lifecycle = <Path>` relative to
+///    its own module ([`resolve_lifecycle_id`]); if that id names a scanned
+///    lifecycle, key the effects by it. This handles co-located and
+///    explicitly-pathed lifecycles and disambiguates two same-named enums in
+///    different modules (each binding pins to its co-located enum).
+/// 2. **Unique-bare-name fallback**: otherwise take the path's bare last segment;
+///    if *exactly one* scanned lifecycle has that bare enum name, key the effects
+///    by that lifecycle's id. This rescues a model that imports its lifecycle from
+///    another module (`use crate::states::OrderState; lifecycle = OrderState`),
+///    where Rust resolves the bare name to another module but the binding's own
+///    module prefix would mis-qualify it.
+/// 3. **Drop**: otherwise (qualified miss *and* the bare name is absent or
+///    ambiguous among scanned lifecycles) the binding is left uncorrelated — a
+///    safe failure (missing labels), never a guess. Crucially, two same-named
+///    enums make the bare name ambiguous, so step 2 never fires for them and the
+///    same-module isolation from step 1 is preserved.
+fn resolve_effect_bindings(
+    bindings: Vec<RawBinding>,
+    lifecycles: &[LifecycleDef],
+) -> HashMap<String, Vec<EffectEdge>> {
+    let id_set: BTreeSet<&str> = lifecycles.iter().map(|l| l.id.as_str()).collect();
+    // Bare enum name -> the ids of every scanned lifecycle with that name. A name
+    // mapping to a single id is globally unique (the fallback's precondition).
+    let mut by_bare_name: HashMap<&str, Vec<&str>> = HashMap::new();
+    for l in lifecycles {
+        by_bare_name
+            .entry(l.name.as_str())
+            .or_default()
+            .push(l.id.as_str());
+    }
+    let mut effect_edges: HashMap<String, Vec<EffectEdge>> = HashMap::new();
+    for binding in bindings {
+        // Step 1: qualified match against the complete scanned-id set.
+        let qualified = resolve_lifecycle_id(&binding.module_path, &binding.lifecycle_path)
+            .filter(|id| id_set.contains(id.as_str()));
+        let key = qualified.or_else(|| {
+            // Step 2: unique-bare-name fallback (last path segment).
+            let bare = binding.lifecycle_path.segments.last()?.ident.to_string();
+            match by_bare_name.get(bare.as_str()) {
+                Some(ids) if ids.len() == 1 => Some(ids[0].to_string()),
+                _ => None,
+            }
+        });
+        // Step 3: an unresolved binding is dropped (no labels).
+        if let Some(key) = key {
+            effect_edges.entry(key).or_default().extend(binding.edges);
+        }
+    }
+    effect_edges
 }
 
 /// Resolve a `#[state_machine(lifecycle = <Path>)]` binding's enum path to the

--- a/autumn-cli/src/lifecycle.rs
+++ b/autumn-cli/src/lifecycle.rs
@@ -711,15 +711,10 @@ fn collect_state_machine_effects(item_struct: &syn::ItemStruct, scan: &mut Scan)
 /// Recognize a `#[state_machine(...)]` attribute under a bare `state_machine`
 /// path or any qualified path whose last segment is `state_machine`.
 fn is_state_machine_attr(attr: &syn::Attribute) -> bool {
-    let path = attr.path();
-    path.get_ident().map_or_else(
-        || {
-            path.segments
-                .last()
-                .is_some_and(|s| s.ident == "state_machine")
-        },
-        |ident| ident == "state_machine",
-    )
+    attr.path()
+        .segments
+        .last()
+        .is_some_and(|s| s.ident == "state_machine")
 }
 
 /// Parse the inside of a `#[state_machine(...)]` attribute, returning the bound

--- a/autumn-cli/src/lifecycle.rs
+++ b/autumn-cli/src/lifecycle.rs
@@ -214,10 +214,14 @@ pub struct LifecycleDef {
 }
 
 /// An effect declared on a `#[state_machine(lifecycle = Enum, effects(...))]`
-/// binding (issue #1973), correlated to a `#[lifecycle]` enum's diagram by enum
-/// name (the last segment of the `lifecycle = <Path>`). This rides in a separate
-/// structure consulted only by the diagram renderers, so the `check` command,
-/// the JSON artifact, and [`LifecycleDef::transitions`] stay byte-identical.
+/// binding (issue #1973), correlated to a `#[lifecycle]` enum's diagram by that
+/// enum's module-qualified [`LifecycleDef::id`] (the `lifecycle = <Path>`
+/// resolved relative to the binding's module — see [`resolve_lifecycle_id`]).
+/// Keying by the qualified id, not the bare enum name, keeps two same-named
+/// lifecycle enums in different modules from cross-contaminating each other's
+/// effect labels. This rides in a separate structure consulted only by the
+/// diagram renderers, so the `check` command, the JSON artifact, and
+/// [`LifecycleDef::transitions`] stay byte-identical.
 #[derive(Debug)]
 struct EffectEdge {
     from: String,
@@ -474,9 +478,13 @@ struct Scan {
     lifecycles: Vec<LifecycleDef>,
     errors: Vec<String>,
     files_scanned: usize,
-    /// Per-enum-name transition effects collected from
+    /// Transition effects collected from
     /// `#[state_machine(lifecycle = Enum, effects(...))]` bindings (issue #1973),
-    /// keyed by the bound enum name. Consulted only by the diagram renderers.
+    /// keyed by the bound lifecycle enum's module-qualified [`LifecycleDef::id`]
+    /// (the `lifecycle = <Path>` resolved relative to the binding's module). A
+    /// binding whose path cannot be resolved to that id scheme is left
+    /// uncorrelated (dropped) rather than matched by bare name. Consulted only by
+    /// the diagram renderers.
     effect_edges: HashMap<String, Vec<EffectEdge>>,
 }
 
@@ -603,7 +611,7 @@ fn scan_items(
                 );
             }
             syn::Item::Struct(item_struct) => {
-                collect_state_machine_effects(item_struct, scan);
+                collect_state_machine_effects(item_struct, scan, module_path.as_slice());
             }
             syn::Item::Mod(item_mod) => {
                 if let Some((_, inner)) = &item_mod.content {
@@ -688,7 +696,19 @@ fn collect_lifecycle_enum(
 /// an inline `#[state_machine(transitions(...))]` machine has no `#[lifecycle]`
 /// enum (and thus no diagram surface today) and is skipped. Parsing is tolerant:
 /// a miss on one attribute is skipped and never aborts the scan.
-fn collect_state_machine_effects(item_struct: &syn::ItemStruct, scan: &mut Scan) {
+///
+/// `module_path` is the inline-module context the binding is declared in (the
+/// same context [`collect_lifecycle_enum`] uses to build a [`LifecycleDef::id`]).
+/// The binding's `lifecycle = <Path>` is resolved to that qualified-id scheme via
+/// [`resolve_lifecycle_id`], so effects are keyed by the *same* id the renderers
+/// look the lifecycle up by. A path that cannot be resolved is left uncorrelated
+/// (dropped) — a safe failure (missing labels) strictly better than the previous
+/// bare-name matching, which could label an unrelated same-named lifecycle.
+fn collect_state_machine_effects(
+    item_struct: &syn::ItemStruct,
+    scan: &mut Scan,
+    module_path: &[String],
+) {
     for field in &item_struct.fields {
         for attr in &field.attrs {
             if !is_state_machine_attr(attr) {
@@ -696,16 +716,60 @@ fn collect_state_machine_effects(item_struct: &syn::ItemStruct, scan: &mut Scan)
             }
             // Tolerant: an unrelated `transitions(...)` form → `Ok(None)`, and a
             // parse miss → `Err`; both simply skip this attribute.
-            if let Ok(Some((enum_name, edges))) = attr.parse_args_with(parse_state_machine_effects)
+            if let Ok(Some((lifecycle_path, edges))) =
+                attr.parse_args_with(parse_state_machine_effects)
                 && !edges.is_empty()
+                && let Some(id) = resolve_lifecycle_id(module_path, &lifecycle_path)
             {
-                scan.effect_edges
-                    .entry(enum_name)
-                    .or_default()
-                    .extend(edges);
+                scan.effect_edges.entry(id).or_default().extend(edges);
             }
         }
     }
+}
+
+/// Resolve a `#[state_machine(lifecycle = <Path>)]` binding's enum path to the
+/// module-qualified [`LifecycleDef::id`] scheme (`a::b::State`), relative to the
+/// binding's inline-module `module_path`, mirroring how [`collect_lifecycle_enum`]
+/// roots enum ids (at the crate root, without a crate-name prefix). Returns
+/// `None` when the path cannot be confidently resolved (empty, or more `super::`
+/// hops than there are enclosing modules), so the binding stays uncorrelated
+/// rather than being force-matched.
+///
+/// - Bare single-segment (`State`) → `<module_path>::State` (same module — the
+///   common case).
+/// - Leading `crate::` → rooted at the crate root (empty prefix), matching a
+///   top-level enum's bare id.
+/// - Leading `self::` → the binding's own module.
+/// - Leading `super::` (one per hop) → pops one enclosing module per `super`.
+/// - Otherwise relative (`a::State`) → nested under the binding's module.
+fn resolve_lifecycle_id(module_path: &[String], path: &syn::Path) -> Option<String> {
+    let segs: Vec<String> = path.segments.iter().map(|s| s.ident.to_string()).collect();
+    if segs.is_empty() {
+        return None;
+    }
+    let (mut prefix, rest): (Vec<String>, &[String]) = match segs[0].as_str() {
+        // `crate::…` is rooted at the crate root; the scanner ids are also rooted
+        // there with no crate-name segment, so the prefix is empty.
+        "crate" => (Vec::new(), &segs[1..]),
+        "self" => (module_path.to_vec(), &segs[1..]),
+        "super" => {
+            let mut prefix = module_path.to_vec();
+            let mut i = 0;
+            while i < segs.len() && segs[i] == "super" {
+                // More `super` hops than enclosing modules → cannot resolve.
+                prefix.pop()?;
+                i += 1;
+            }
+            (prefix, &segs[i..])
+        }
+        // A plain relative path resolves under the binding's own module.
+        _ => (module_path.to_vec(), &segs[..]),
+    };
+    if rest.is_empty() {
+        return None;
+    }
+    prefix.extend(rest.iter().cloned());
+    Some(prefix.join("::"))
 }
 
 /// Recognize a `#[state_machine(...)]` attribute under a bare `state_machine`
@@ -718,13 +782,14 @@ fn is_state_machine_attr(attr: &syn::Attribute) -> bool {
 }
 
 /// Parse the inside of a `#[state_machine(...)]` attribute, returning the bound
-/// enum name (last path segment of `lifecycle = <Path>`) and its declared
-/// `effects(...)` edges. Returns `Ok(None)` for the inline `transitions(...)`
-/// form (out of scope — no `#[lifecycle]` enum, no diagram surface). Mirrors the
-/// macro grammar in `autumn-macros/src/model.rs` (`parse_state_machine_source`).
+/// enum's full `lifecycle = <Path>` (resolved to a module-qualified id by the
+/// caller via [`resolve_lifecycle_id`]) and its declared `effects(...)` edges.
+/// Returns `Ok(None)` for the inline `transitions(...)` form (out of scope — no
+/// `#[lifecycle]` enum, no diagram surface). Mirrors the macro grammar in
+/// `autumn-macros/src/model.rs` (`parse_state_machine_source`).
 fn parse_state_machine_effects(
     input: ParseStream,
-) -> syn::Result<Option<(String, Vec<EffectEdge>)>> {
+) -> syn::Result<Option<(syn::Path, Vec<EffectEdge>)>> {
     let key: Ident = input.parse()?;
     if key == "transitions" {
         return Ok(None);
@@ -737,15 +802,12 @@ fn parse_state_machine_effects(
     }
     input.parse::<Token![=]>()?;
     let path: syn::Path = input.parse()?;
-    let enum_name = path.segments.last().map_or_else(
-        || {
-            Err(syn::Error::new_spanned(
-                &path,
-                "`lifecycle = <Enum>` requires a non-empty path",
-            ))
-        },
-        |seg| Ok(seg.ident.to_string()),
-    )?;
+    if path.segments.is_empty() {
+        return Err(syn::Error::new_spanned(
+            &path,
+            "`lifecycle = <Enum>` requires a non-empty path",
+        ));
+    }
     let edges = if input.peek(Token![,]) {
         input.parse::<Token![,]>()?;
         let effects_kw: Ident = input.parse()?;
@@ -761,7 +823,7 @@ fn parse_state_machine_effects(
     } else {
         Vec::new()
     };
-    Ok(Some((enum_name, edges)))
+    Ok(Some((path, edges)))
 }
 
 /// Parse the inner edge list of an `effects(...)` group (surrounding parens
@@ -1028,12 +1090,12 @@ fn render_mermaid_document(
     effects: &HashMap<String, Vec<EffectEdge>>,
 ) -> String {
     if let [single] = lifecycles {
-        return render_mermaid(single, &build_edge_labels(effects.get(&single.name)));
+        return render_mermaid(single, &build_edge_labels(effects.get(&single.id)));
     }
     let mut out = String::new();
     out.push_str("stateDiagram-v2\n");
     for wf in lifecycles {
-        let labels = build_edge_labels(effects.get(&wf.name));
+        let labels = build_edge_labels(effects.get(&wf.id));
         let ns = sanitize_ident(&wf.id);
         let sid = |state: &str| format!("{ns}_{}", sanitize_ident(state));
         let _ = writeln!(out, "    state \"{}\" as {ns} {{", wf.name);
@@ -1090,14 +1152,14 @@ fn render_dot_document(
     effects: &HashMap<String, Vec<EffectEdge>>,
 ) -> String {
     if let [single] = lifecycles {
-        return render_dot(single, &build_edge_labels(effects.get(&single.name)));
+        return render_dot(single, &build_edge_labels(effects.get(&single.id)));
     }
     let mut out = String::new();
     out.push_str("digraph {\n");
     out.push_str("    rankdir=LR;\n");
     out.push_str("    node [shape=box, style=rounded];\n");
     for wf in lifecycles {
-        write_dot_cluster(&mut out, wf, &build_edge_labels(effects.get(&wf.name)));
+        write_dot_cluster(&mut out, wf, &build_edge_labels(effects.get(&wf.id)));
     }
     out.push_str("}\n");
     out

--- a/autumn-cli/src/lifecycle.rs
+++ b/autumn-cli/src/lifecycle.rs
@@ -50,7 +50,7 @@
 //! emits a lifecycle diagram per lifecycle in Graphviz DOT or Mermaid
 //! `stateDiagram-v2` form, highlighting the initial and terminal states.
 
-use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
@@ -211,6 +211,22 @@ pub struct LifecycleDef {
     pub terminals: Vec<String>,
     /// Declared `(from, to)` edges.
     pub transitions: Vec<(String, String)>,
+}
+
+/// An effect declared on a `#[state_machine(lifecycle = Enum, effects(...))]`
+/// binding (issue #1973), correlated to a `#[lifecycle]` enum's diagram by enum
+/// name (the last segment of the `lifecycle = <Path>`). This rides in a separate
+/// structure consulted only by the diagram renderers, so the `check` command,
+/// the JSON artifact, and [`LifecycleDef::transitions`] stay byte-identical.
+#[derive(Debug)]
+struct EffectEdge {
+    from: String,
+    to: String,
+    /// The `on = "<handler>"` sync in-transaction effect, if declared.
+    on: Option<String>,
+    /// The `on_commit = <Job>` after-commit effect (its `syn::Path`'s last
+    /// segment rendered as the job name), if declared.
+    on_commit: Option<String>,
 }
 
 // ── Analysis ─────────────────────────────────────────────────────────────────
@@ -458,6 +474,10 @@ struct Scan {
     lifecycles: Vec<LifecycleDef>,
     errors: Vec<String>,
     files_scanned: usize,
+    /// Per-enum-name transition effects collected from
+    /// `#[state_machine(lifecycle = Enum, effects(...))]` bindings (issue #1973),
+    /// keyed by the bound enum name. Consulted only by the diagram renderers.
+    effect_edges: HashMap<String, Vec<EffectEdge>>,
 }
 
 /// Walk `root` recursively and collect every `#[lifecycle]` enum in its `.rs`
@@ -582,6 +602,9 @@ fn scan_items(
                     module_path.as_slice(),
                 );
             }
+            syn::Item::Struct(item_struct) => {
+                collect_state_machine_effects(item_struct, scan);
+            }
             syn::Item::Mod(item_mod) => {
                 if let Some((_, inner)) = &item_mod.content {
                     module_path.push(item_mod.ident.to_string());
@@ -656,6 +679,202 @@ fn collect_lifecycle_enum(
             ));
         }
     }
+}
+
+/// Collect per-edge transition effects from any `#[state_machine(...)]` field
+/// attribute on `item_struct` (issue #1973). Only the
+/// `#[state_machine(lifecycle = <Enum>, effects(...))]` form — the one whose
+/// edges correlate to an existing `#[lifecycle]` enum diagram — is collected;
+/// an inline `#[state_machine(transitions(...))]` machine has no `#[lifecycle]`
+/// enum (and thus no diagram surface today) and is skipped. Parsing is tolerant:
+/// a miss on one attribute is skipped and never aborts the scan.
+fn collect_state_machine_effects(item_struct: &syn::ItemStruct, scan: &mut Scan) {
+    for field in &item_struct.fields {
+        for attr in &field.attrs {
+            if !is_state_machine_attr(attr) {
+                continue;
+            }
+            // Tolerant: an unrelated `transitions(...)` form → `Ok(None)`, and a
+            // parse miss → `Err`; both simply skip this attribute.
+            if let Ok(Some((enum_name, edges))) = attr.parse_args_with(parse_state_machine_effects)
+                && !edges.is_empty()
+            {
+                scan.effect_edges
+                    .entry(enum_name)
+                    .or_default()
+                    .extend(edges);
+            }
+        }
+    }
+}
+
+/// Recognize a `#[state_machine(...)]` attribute under a bare `state_machine`
+/// path or any qualified path whose last segment is `state_machine`.
+fn is_state_machine_attr(attr: &syn::Attribute) -> bool {
+    let path = attr.path();
+    path.get_ident().map_or_else(
+        || {
+            path.segments
+                .last()
+                .is_some_and(|s| s.ident == "state_machine")
+        },
+        |ident| ident == "state_machine",
+    )
+}
+
+/// Parse the inside of a `#[state_machine(...)]` attribute, returning the bound
+/// enum name (last path segment of `lifecycle = <Path>`) and its declared
+/// `effects(...)` edges. Returns `Ok(None)` for the inline `transitions(...)`
+/// form (out of scope — no `#[lifecycle]` enum, no diagram surface). Mirrors the
+/// macro grammar in `autumn-macros/src/model.rs` (`parse_state_machine_source`).
+fn parse_state_machine_effects(
+    input: ParseStream,
+) -> syn::Result<Option<(String, Vec<EffectEdge>)>> {
+    let key: Ident = input.parse()?;
+    if key == "transitions" {
+        return Ok(None);
+    }
+    if key != "lifecycle" {
+        return Err(syn::Error::new_spanned(
+            &key,
+            "expected `transitions(...)` or `lifecycle = <Enum>`",
+        ));
+    }
+    input.parse::<Token![=]>()?;
+    let path: syn::Path = input.parse()?;
+    let enum_name = path.segments.last().map_or_else(
+        || {
+            Err(syn::Error::new_spanned(
+                &path,
+                "`lifecycle = <Enum>` requires a non-empty path",
+            ))
+        },
+        |seg| Ok(seg.ident.to_string()),
+    )?;
+    let edges = if input.peek(Token![,]) {
+        input.parse::<Token![,]>()?;
+        let effects_kw: Ident = input.parse()?;
+        if effects_kw != "effects" {
+            return Err(syn::Error::new_spanned(
+                &effects_kw,
+                "expected `effects(...)` after `lifecycle = <Enum>`",
+            ));
+        }
+        let content;
+        syn::parenthesized!(content in input);
+        parse_effect_edges(&content)?
+    } else {
+        Vec::new()
+    };
+    Ok(Some((enum_name, edges)))
+}
+
+/// Parse the inner edge list of an `effects(...)` group (surrounding parens
+/// already consumed), extracting each edge's `on = "..."` and/or
+/// `on_commit = <Job>` effect. Mirrors `parse_transition_list` in the macro
+/// (including the `, <ident> =` vs `, <State> ->` comma disambiguation); any
+/// `guard = "..."` present is parsed and ignored (effects-only).
+fn parse_effect_edges(content: ParseStream) -> syn::Result<Vec<EffectEdge>> {
+    let mut edges = Vec::new();
+    while !content.is_empty() {
+        let from: Ident = content.parse()?;
+        content.parse::<Token![->]>()?;
+        let to: Ident = content.parse()?;
+        let mut on: Option<String> = None;
+        let mut on_commit: Option<String> = None;
+        if content.peek(Token![:]) {
+            content.parse::<Token![:]>()?;
+            if content.peek(syn::LitStr) {
+                // Legacy bare-string guard shorthand `: "guard"` — ignored.
+                let _: syn::LitStr = content.parse()?;
+            } else {
+                loop {
+                    let mkey: Ident = content.parse()?;
+                    content.parse::<Token![=]>()?;
+                    if mkey == "guard" {
+                        let _: syn::LitStr = content.parse()?;
+                    } else if mkey == "on_commit" {
+                        let job: syn::Path = content.parse()?;
+                        on_commit = job.segments.last().map(|seg| seg.ident.to_string());
+                    } else if mkey == "on" {
+                        let lit: syn::LitStr = content.parse()?;
+                        on = Some(lit.value());
+                    } else {
+                        return Err(syn::Error::new_spanned(
+                            &mkey,
+                            "expected `guard = \"...\"`, `on = \"...\"`, or `on_commit = <Job>`",
+                        ));
+                    }
+                    // Continue the meta list only on a following `, <ident> =`
+                    // (another key for this edge); a `, <State> ->` (or the end)
+                    // begins the next edge and its comma is left for the
+                    // separator below.
+                    if !content.peek(Token![,]) {
+                        break;
+                    }
+                    let ahead = content.fork();
+                    ahead.parse::<Token![,]>()?;
+                    if ahead.peek(Ident) && ahead.peek2(Token![=]) {
+                        content.parse::<Token![,]>()?;
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+        edges.push(EffectEdge {
+            from: from.to_string(),
+            to: to.to_string(),
+            on,
+            on_commit,
+        });
+        if content.peek(Token![,]) {
+            content.parse::<Token![,]>()?;
+        }
+    }
+    Ok(edges)
+}
+
+/// Build the diagram edge-label lookup for one lifecycle from its collected
+/// effect edges: `(from, to) -> "on: <h>[, on_commit: <J>]"`. Multiple bindings
+/// touching the same edge are merged — the `on` / `on_commit` values are unioned
+/// and rendered in a stable (sorted) order so the output is deterministic. Edges
+/// with no effect are absent from the map (and so render without a label).
+fn build_edge_labels(effects: Option<&Vec<EffectEdge>>) -> BTreeMap<(String, String), String> {
+    let mut acc: BTreeMap<(String, String), (BTreeSet<String>, BTreeSet<String>)> = BTreeMap::new();
+    if let Some(effects) = effects {
+        for edge in effects {
+            let entry = acc.entry((edge.from.clone(), edge.to.clone())).or_default();
+            if let Some(on) = &edge.on {
+                entry.0.insert(on.clone());
+            }
+            if let Some(on_commit) = &edge.on_commit {
+                entry.1.insert(on_commit.clone());
+            }
+        }
+    }
+    acc.into_iter()
+        .filter_map(|(edge, (ons, commits))| {
+            let mut parts = Vec::new();
+            parts.extend(ons.iter().map(|on| format!("on: {on}")));
+            parts.extend(
+                commits
+                    .iter()
+                    .map(|on_commit| format!("on_commit: {on_commit}")),
+            );
+            if parts.is_empty() {
+                None
+            } else {
+                Some((edge, parts.join(", ")))
+            }
+        })
+        .collect()
+}
+
+/// Escape a DOT label's `"`/`\` so an effect handler/job name can never break
+/// out of the quoted `label="..."` attribute (defensive — names are idents).
+fn dot_label_escape(label: &str) -> String {
+    label.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 /// Build a [`Report`] from a scan, analyzing each discovered lifecycle.
@@ -777,8 +996,8 @@ pub fn run_diagram(root: &Path, opts: &DiagramOptions) -> i32 {
     }
 
     let output = match opts.format {
-        DiagramFormat::Dot => render_dot_document(&scan.lifecycles),
-        DiagramFormat::Mermaid => render_mermaid_document(&scan.lifecycles),
+        DiagramFormat::Dot => render_dot_document(&scan.lifecycles, &scan.effect_edges),
+        DiagramFormat::Mermaid => render_mermaid_document(&scan.lifecycles, &scan.effect_edges),
     };
 
     match &opts.out {
@@ -809,13 +1028,17 @@ pub fn run_diagram(root: &Path, opts: &DiagramOptions) -> i32 {
 /// a state name shared across lifecycles stays a distinct node, each carrying a
 /// label of its bare state name.
 #[must_use]
-fn render_mermaid_document(lifecycles: &[LifecycleDef]) -> String {
+fn render_mermaid_document(
+    lifecycles: &[LifecycleDef],
+    effects: &HashMap<String, Vec<EffectEdge>>,
+) -> String {
     if let [single] = lifecycles {
-        return render_mermaid(single);
+        return render_mermaid(single, &build_edge_labels(effects.get(&single.name)));
     }
     let mut out = String::new();
     out.push_str("stateDiagram-v2\n");
     for wf in lifecycles {
+        let labels = build_edge_labels(effects.get(&wf.name));
         let ns = sanitize_ident(&wf.id);
         let sid = |state: &str| format!("{ns}_{}", sanitize_ident(state));
         let _ = writeln!(out, "    state \"{}\" as {ns} {{", wf.name);
@@ -824,7 +1047,11 @@ fn render_mermaid_document(lifecycles: &[LifecycleDef]) -> String {
         }
         let _ = writeln!(out, "        [*] --> {}", sid(&wf.initial));
         for (from, to) in &wf.transitions {
-            let _ = writeln!(out, "        {} --> {}", sid(from), sid(to));
+            if let Some(label) = labels.get(&(from.clone(), to.clone())) {
+                let _ = writeln!(out, "        {} --> {} : {label}", sid(from), sid(to));
+            } else {
+                let _ = writeln!(out, "        {} --> {}", sid(from), sid(to));
+            }
         }
         for t in &wf.terminals {
             let _ = writeln!(out, "        {} --> [*]", sid(t));
@@ -838,13 +1065,17 @@ fn render_mermaid_document(lifecycles: &[LifecycleDef]) -> String {
 /// entered from `[*]`; each terminal state exits to `[*]`, which is how Mermaid
 /// renders start/end markers.
 #[must_use]
-pub fn render_mermaid(wf: &LifecycleDef) -> String {
+pub fn render_mermaid(wf: &LifecycleDef, labels: &BTreeMap<(String, String), String>) -> String {
     let mut out = String::new();
     let _ = writeln!(out, "%% lifecycle: {}", wf.name);
     out.push_str("stateDiagram-v2\n");
     let _ = writeln!(out, "    [*] --> {}", wf.initial);
     for (from, to) in &wf.transitions {
-        let _ = writeln!(out, "    {from} --> {to}");
+        if let Some(label) = labels.get(&(from.clone(), to.clone())) {
+            let _ = writeln!(out, "    {from} --> {to} : {label}");
+        } else {
+            let _ = writeln!(out, "    {from} --> {to}");
+        }
     }
     for t in &wf.terminals {
         let _ = writeln!(out, "    {t} --> [*]");
@@ -859,16 +1090,19 @@ pub fn render_mermaid(wf: &LifecycleDef) -> String {
 /// single valid DOT document (consumers expect one graph per document), so the
 /// multi-lifecycle case must be one graph with clusters.
 #[must_use]
-fn render_dot_document(lifecycles: &[LifecycleDef]) -> String {
+fn render_dot_document(
+    lifecycles: &[LifecycleDef],
+    effects: &HashMap<String, Vec<EffectEdge>>,
+) -> String {
     if let [single] = lifecycles {
-        return render_dot(single);
+        return render_dot(single, &build_edge_labels(effects.get(&single.name)));
     }
     let mut out = String::new();
     out.push_str("digraph {\n");
     out.push_str("    rankdir=LR;\n");
     out.push_str("    node [shape=box, style=rounded];\n");
     for wf in lifecycles {
-        write_dot_cluster(&mut out, wf);
+        write_dot_cluster(&mut out, wf, &build_edge_labels(effects.get(&wf.name)));
     }
     out.push_str("}\n");
     out
@@ -878,7 +1112,11 @@ fn render_dot_document(lifecycles: &[LifecycleDef]) -> String {
 /// namespaced by the lifecycle name (DOT node ids live in the digraph's single
 /// global namespace, so an un-namespaced state shared across lifecycles would
 /// collapse into one node), and each carries a `label` of its bare state name.
-fn write_dot_cluster(out: &mut String, wf: &LifecycleDef) {
+fn write_dot_cluster(
+    out: &mut String,
+    wf: &LifecycleDef,
+    labels: &BTreeMap<(String, String), String>,
+) {
     let ns = sanitize_ident(&wf.id);
     let nid = |state: &str| dot_id(&format!("{ns}.{state}"));
     let start = dot_id(&format!("{ns}.__start"));
@@ -897,7 +1135,17 @@ fn write_dot_cluster(out: &mut String, wf: &LifecycleDef) {
     }
     let _ = writeln!(out, "        {start} -> {};", nid(&wf.initial));
     for (from, to) in &wf.transitions {
-        let _ = writeln!(out, "        {} -> {};", nid(from), nid(to));
+        if let Some(label) = labels.get(&(from.clone(), to.clone())) {
+            let _ = writeln!(
+                out,
+                "        {} -> {} [label=\"{}\"];",
+                nid(from),
+                nid(to),
+                dot_label_escape(label)
+            );
+        } else {
+            let _ = writeln!(out, "        {} -> {};", nid(from), nid(to));
+        }
     }
     out.push_str("    }\n");
 }
@@ -921,7 +1169,7 @@ fn sanitize_ident(name: &str) -> String {
 /// Render a lifecycle as a Graphviz DOT `digraph`. The initial state is filled
 /// and reached from a start point; terminal states are drawn as double circles.
 #[must_use]
-pub fn render_dot(wf: &LifecycleDef) -> String {
+pub fn render_dot(wf: &LifecycleDef, labels: &BTreeMap<(String, String), String>) -> String {
     let mut out = String::new();
     // The graph name is the enum ident — already a valid bare DOT id.
     let _ = writeln!(out, "digraph {} {{", wf.name);
@@ -939,7 +1187,17 @@ pub fn render_dot(wf: &LifecycleDef) -> String {
     }
     let _ = writeln!(out, "    __start -> {};", dot_id(&wf.initial));
     for (from, to) in &wf.transitions {
-        let _ = writeln!(out, "    {} -> {};", dot_id(from), dot_id(to));
+        if let Some(label) = labels.get(&(from.clone(), to.clone())) {
+            let _ = writeln!(
+                out,
+                "    {} -> {} [label=\"{}\"];",
+                dot_id(from),
+                dot_id(to),
+                dot_label_escape(label)
+            );
+        } else {
+            let _ = writeln!(out, "    {} -> {};", dot_id(from), dot_id(to));
+        }
     }
     out.push_str("}\n");
     out

--- a/autumn-cli/tests/integration/lifecycle_check.rs
+++ b/autumn-cli/tests/integration/lifecycle_check.rs
@@ -720,3 +720,137 @@ mod invoices {
         "state nodes must be namespaced by module-qualified id\n{stdout}"
     );
 }
+
+/// A `#[lifecycle]` enum whose diagram edges carry transition effects declared
+/// on a `#[state_machine(lifecycle = OrderState, effects(...))]` binding on a
+/// separate `#[model]` struct field (issue #1973). The fixture only needs to
+/// parse — it is scanned, not compiled.
+const EFFECTS_FIXTURE: &str = r#"
+use autumn_web::lifecycle;
+
+#[lifecycle(
+    initial = Draft,
+    terminal(Archived),
+    transitions(
+        Draft -> Published,
+        Published -> Archived,
+    )
+)]
+pub enum OrderState {
+    Draft,
+    Published,
+    Archived,
+}
+
+#[model]
+pub struct Article {
+    #[state_machine(
+        lifecycle = OrderState,
+        effects(
+            Draft -> Published: on_commit = AnnouncePublishJob,
+            Published -> Archived: on = "write_archive_audit",
+        )
+    )]
+    pub status: String,
+}
+"#;
+
+#[test]
+fn diagram_mermaid_shows_effect_labels() {
+    // The Mermaid diagram annotates each edge that has a correlated
+    // `#[state_machine(... effects(...))]` binding with its effect label
+    // (`on: ...` / `on_commit: ...`), leaving effect-free edges unchanged.
+    let dir = tempfile::tempdir().unwrap();
+    write(dir.path(), "src/article.rs", EFFECTS_FIXTURE);
+    let output = run_lifecycle(dir.path(), &["diagram", "--format", "mermaid"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "diagram render should exit 0\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        stdout.contains("Draft --> Published"),
+        "the effect edge should still render its transition\n{stdout}"
+    );
+    assert!(
+        stdout.contains("on_commit: AnnouncePublishJob"),
+        "the on_commit effect should be annotated on its edge\n{stdout}"
+    );
+    assert!(
+        stdout.contains("on: write_archive_audit"),
+        "the on effect should be annotated on its edge\n{stdout}"
+    );
+}
+
+#[test]
+fn diagram_dot_shows_effect_labels() {
+    // The DOT diagram annotates effect edges with a `[label="..."]` carrying the
+    // same effect text.
+    let dir = tempfile::tempdir().unwrap();
+    write(dir.path(), "src/article.rs", EFFECTS_FIXTURE);
+    let output = run_lifecycle(dir.path(), &["diagram", "--format", "dot"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "dot render should exit 0\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        stdout.contains("[label=\"on_commit: AnnouncePublishJob\"]"),
+        "the on_commit effect should be a DOT edge label\n{stdout}"
+    );
+    assert!(
+        stdout.contains("[label=\"on: write_archive_audit\"]"),
+        "the on effect should be a DOT edge label\n{stdout}"
+    );
+}
+
+/// A plain `#[lifecycle]` enum with no `#[state_machine]` effects binding — its
+/// diagram edges must be byte-identical to the pre-#1973 output (no labels).
+const PLAIN_LIFECYCLE: &str = r"
+#[lifecycle(
+    initial = Draft,
+    terminal(Archived),
+    transitions(
+        Draft -> Published,
+        Published -> Archived,
+    )
+)]
+pub enum OrderState {
+    Draft,
+    Published,
+    Archived,
+}
+";
+
+#[test]
+fn diagram_without_effects_has_no_edge_labels() {
+    // With no effects binding, an edge renders with no ` : ` label (Mermaid) and
+    // no `[label=` (DOT) — the byte-identical guarantee.
+    let dir = tempfile::tempdir().unwrap();
+    write(dir.path(), "src/order.rs", PLAIN_LIFECYCLE);
+
+    let mermaid = run_lifecycle(dir.path(), &["diagram", "--format", "mermaid"]);
+    let mstdout = String::from_utf8_lossy(&mermaid.stdout);
+    assert!(
+        mermaid.status.success(),
+        "mermaid render should exit 0\n{mstdout}"
+    );
+    assert!(
+        mstdout.contains("Draft --> Published"),
+        "the transition edge should render\n{mstdout}"
+    );
+    assert!(
+        !mstdout.contains(" : "),
+        "an effect-free lifecycle must render no edge labels\n{mstdout}"
+    );
+
+    let dot = run_lifecycle(dir.path(), &["diagram", "--format", "dot"]);
+    let dstdout = String::from_utf8_lossy(&dot.stdout);
+    assert!(dot.status.success(), "dot render should exit 0\n{dstdout}");
+    assert!(
+        !dstdout.contains("[label="),
+        "an effect-free single-lifecycle DOT diagram must render no edge labels\n{dstdout}"
+    );
+}

--- a/autumn-cli/tests/integration/lifecycle_check.rs
+++ b/autumn-cli/tests/integration/lifecycle_check.rs
@@ -806,6 +806,101 @@ fn diagram_dot_shows_effect_labels() {
     );
 }
 
+/// Two `#[lifecycle]` enums with the SAME identifier (`State`) and identical
+/// edges declared in two separate modules, where ONLY the `orders` module also
+/// carries a `#[state_machine(lifecycle = State, effects(...))]` binding. The
+/// effect label must be correlated by the module-qualified `LifecycleDef::id`
+/// (`orders::State`), so it annotates the `orders` diagram only and never bleeds
+/// onto the unrelated same-named `invoices::State` (issue #2029 Codex P2).
+const SAME_NAMED_EFFECTS_FIXTURE: &str = r"
+mod orders {
+    #[lifecycle(
+        initial = Draft,
+        terminal(Published),
+        transitions(
+            Draft -> Published,
+        )
+    )]
+    pub enum State {
+        Draft,
+        Published,
+    }
+
+    #[model]
+    pub struct Order {
+        #[state_machine(
+            lifecycle = State,
+            effects(
+                Draft -> Published: on_commit = SomeJob,
+            )
+        )]
+        pub status: String,
+    }
+}
+
+mod invoices {
+    #[lifecycle(
+        initial = Draft,
+        terminal(Published),
+        transitions(
+            Draft -> Published,
+        )
+    )]
+    pub enum State {
+        Draft,
+        Published,
+    }
+}
+";
+
+#[test]
+fn effect_labels_do_not_bleed_across_same_named_enums_in_separate_modules() {
+    // The `orders` binding must label only the `orders::State` diagram; the
+    // same-named `invoices::State` (no binding) must render its `Draft ->
+    // Published` edge with no effect label.
+    let dir = tempfile::tempdir().unwrap();
+    write(dir.path(), "src/domain.rs", SAME_NAMED_EFFECTS_FIXTURE);
+
+    // DOT: node ids are namespaced by module-qualified id, so the two clusters'
+    // edges are distinguishable and the label is pinned to exactly one edge.
+    let dot = run_lifecycle(dir.path(), &["diagram", "--format", "dot"]);
+    let dstdout = String::from_utf8_lossy(&dot.stdout);
+    assert!(
+        dot.status.success(),
+        "dot render should exit 0\nstdout:\n{dstdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&dot.stderr)
+    );
+    assert_eq!(
+        dstdout.matches("on_commit: SomeJob").count(),
+        1,
+        "the effect label must appear exactly once (only on the enum with the binding)\n{dstdout}"
+    );
+    assert!(
+        dstdout.contains(
+            "\"orders__State.Draft\" -> \"orders__State.Published\" [label=\"on_commit: SomeJob\"];"
+        ),
+        "the effect label must annotate the orders::State edge that has the binding\n{dstdout}"
+    );
+    assert!(
+        dstdout.contains("\"invoices__State.Draft\" -> \"invoices__State.Published\";"),
+        "the unrelated invoices::State edge must render with no effect label\n{dstdout}"
+    );
+
+    // Mermaid: the composite document must carry the label exactly once, too.
+    let mermaid = run_lifecycle(dir.path(), &["diagram", "--format", "mermaid"]);
+    let mstdout = String::from_utf8_lossy(&mermaid.stdout);
+    assert!(
+        mermaid.status.success(),
+        "mermaid render should exit 0\nstdout:\n{mstdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&mermaid.stderr)
+    );
+    assert_eq!(
+        mstdout.matches("on_commit: SomeJob").count(),
+        1,
+        "the effect label must appear exactly once in the mermaid document\n{mstdout}"
+    );
+}
+
 /// A plain `#[lifecycle]` enum with no `#[state_machine]` effects binding — its
 /// diagram edges must be byte-identical to the pre-#1973 output (no labels).
 const PLAIN_LIFECYCLE: &str = r"

--- a/autumn-cli/tests/integration/lifecycle_check.rs
+++ b/autumn-cli/tests/integration/lifecycle_check.rs
@@ -857,7 +857,10 @@ mod invoices {
 fn effect_labels_do_not_bleed_across_same_named_enums_in_separate_modules() {
     // The `orders` binding must label only the `orders::State` diagram; the
     // same-named `invoices::State` (no binding) must render its `Draft ->
-    // Published` edge with no effect label.
+    // Published` edge with no effect label. Step 1 (qualified match) pins the
+    // binding to its co-located `orders::State`; the bare name `State` is
+    // ambiguous (two same-named enums), so the step-2 fallback never fires and
+    // cannot bleed the label onto `invoices::State`.
     let dir = tempfile::tempdir().unwrap();
     write(dir.path(), "src/domain.rs", SAME_NAMED_EFFECTS_FIXTURE);
 
@@ -899,6 +902,154 @@ fn effect_labels_do_not_bleed_across_same_named_enums_in_separate_modules() {
         1,
         "the effect label must appear exactly once in the mermaid document\n{mstdout}"
     );
+}
+
+/// A `#[lifecycle]` enum declared in one module (`states`) and *imported* into
+/// another (`models`) that binds it with a bare `#[state_machine(lifecycle =
+/// OrderState, effects(...))]`. Rust resolves the bare `OrderState` to
+/// `states::OrderState` via the `use`, but the binding's own module prefix would
+/// mis-qualify it to `models::OrderState` (no such lifecycle). The unique-bare-name
+/// fallback must correlate the effect to the single scanned `OrderState` diagram
+/// (issue #2029 Codex P2 — the imported-lifecycle case).
+const IMPORTED_LIFECYCLE_EFFECTS_FIXTURE: &str = r"
+mod states {
+    #[lifecycle(
+        initial = Draft,
+        terminal(Published),
+        transitions(
+            Draft -> Published,
+        )
+    )]
+    pub enum OrderState {
+        Draft,
+        Published,
+    }
+}
+
+mod models {
+    use crate::states::OrderState;
+
+    #[model]
+    pub struct Order {
+        #[state_machine(
+            lifecycle = OrderState,
+            effects(
+                Draft -> Published: on_commit = SomeJob,
+            )
+        )]
+        pub status: String,
+    }
+}
+";
+
+#[test]
+fn effect_labels_apply_to_imported_lifecycle_via_unique_bare_name() {
+    // The binding's qualified id (`models::OrderState`) is not a scanned
+    // lifecycle, so correlation falls back to the globally-unique bare enum name
+    // `OrderState` and labels the `states::OrderState` diagram.
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "src/domain.rs",
+        IMPORTED_LIFECYCLE_EFFECTS_FIXTURE,
+    );
+
+    let mermaid = run_lifecycle(dir.path(), &["diagram", "--format", "mermaid"]);
+    let mstdout = String::from_utf8_lossy(&mermaid.stdout);
+    assert!(
+        mermaid.status.success(),
+        "mermaid render should exit 0\nstdout:\n{mstdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&mermaid.stderr)
+    );
+    assert_eq!(
+        mstdout.matches("on_commit: SomeJob").count(),
+        1,
+        "the imported-lifecycle effect must be correlated exactly once\n{mstdout}"
+    );
+
+    let dot = run_lifecycle(dir.path(), &["diagram", "--format", "dot"]);
+    let dstdout = String::from_utf8_lossy(&dot.stdout);
+    assert!(
+        dot.status.success(),
+        "dot render should exit 0\nstdout:\n{dstdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&dot.stderr)
+    );
+    assert!(
+        dstdout.contains("[label=\"on_commit: SomeJob\"]"),
+        "the imported-lifecycle effect should be a DOT edge label\n{dstdout}"
+    );
+}
+
+/// Two `#[lifecycle]` enums that SHARE the bare name `OrderState` in different
+/// modules, plus an imported-style bare `#[state_machine(lifecycle = OrderState,
+/// effects(...))]` binding in a third module. The binding's qualified id does not
+/// name a scanned lifecycle *and* the bare name is ambiguous (two candidates), so
+/// the unique-bare-name fallback must NOT fire — the effect is dropped rather than
+/// guessed onto an arbitrary same-named enum (issue #2029 Codex P2 — safe failure).
+const AMBIGUOUS_IMPORTED_FIXTURE: &str = r"
+mod states {
+    #[lifecycle(
+        initial = Draft,
+        terminal(Published),
+        transitions(
+            Draft -> Published,
+        )
+    )]
+    pub enum OrderState {
+        Draft,
+        Published,
+    }
+}
+
+mod other {
+    #[lifecycle(
+        initial = Draft,
+        terminal(Published),
+        transitions(
+            Draft -> Published,
+        )
+    )]
+    pub enum OrderState {
+        Draft,
+        Published,
+    }
+}
+
+mod models {
+    #[model]
+    pub struct Order {
+        #[state_machine(
+            lifecycle = OrderState,
+            effects(
+                Draft -> Published: on_commit = SomeJob,
+            )
+        )]
+        pub status: String,
+    }
+}
+";
+
+#[test]
+fn effect_labels_dropped_when_bare_name_is_ambiguous_across_modules() {
+    // An ambiguous bare name (two same-named enums) means the fallback cannot
+    // pick a lifecycle, so the effect must be dropped — no diagram gets the label.
+    let dir = tempfile::tempdir().unwrap();
+    write(dir.path(), "src/domain.rs", AMBIGUOUS_IMPORTED_FIXTURE);
+
+    for format in ["mermaid", "dot"] {
+        let output = run_lifecycle(dir.path(), &["diagram", "--format", format]);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            output.status.success(),
+            "{format} render should exit 0\nstdout:\n{stdout}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            stdout.matches("on_commit: SomeJob").count(),
+            0,
+            "an ambiguous bare-name binding must never label a same-named enum ({format})\n{stdout}"
+        );
+    }
 }
 
 /// A plain `#[lifecycle]` enum with no `#[state_machine]` effects binding — its


### PR DESCRIPTION
Part of #1973.

## Before / After
`autumn lifecycle diagram` scans only `#[lifecycle]` enums, which carry no effect data — so its edges were unlabelled. Transition effects (`on = "..."`, `on_commit = <Job>`) are declared on the separate `#[state_machine(lifecycle = Enum, effects(...))]` binding, and never surfaced in the diagram.

**After:** diagram edges that have a correlated effect now carry a label:

- **Mermaid:** `Draft --> Published : on_commit: AnnouncePublishJob`
- **DOT:** `"Draft" -> "Published" [label="on_commit: AnnouncePublishJob"];`

Labels join present effects as `on: <handler>` and/or `on_commit: <JobName>` (comma-separated). Effect-free edges render exactly as before — the byte-identical guarantee.

## How
- An additive second scan pass reads `#[state_machine(...)]` field attributes, extracting effect edges **only** from the `lifecycle = <Enum>, effects(...)` form (the one whose edges correlate to a `#[lifecycle]` enum's diagram). The edge-list parser mirrors the macro's grammar in `autumn-macros/src/model.rs` (`parse_transition_list` / `parse_state_machine_source`), including the `, <ident> =` vs `, <State> ->` comma disambiguation; `guard` is parsed and ignored (effects-only).
- Effects are collected into a `HashMap<enum name, Vec<EffectEdge>>` and correlated to a `LifecycleDef` by the enum path's **last segment** (enum name). Multiple bindings touching the same edge merge (unioned, sorted) deterministically.
- The effects ride in a **separate structure** consulted only by the four diagram renderers (Mermaid single/composite, DOT single/cluster). The `check` command, the JSON artifact, and `LifecycleDef.transitions: Vec<(String, String)>` are untouched and byte-identical, confining the blast radius to `diagram`.
- Parsing is tolerant: a miss on one `#[state_machine]` attribute is skipped and never aborts the scan.

## Scope
Inline `#[state_machine(transitions(...))]` machines have no `#[lifecycle]` enum and thus no diagram surface today, so their effects are **out of scope** for this stretch — the scan skips that form.

## Tests
`autumn-cli/tests/integration/lifecycle_check.rs`:
- `diagram_mermaid_shows_effect_labels` — Mermaid edges carry `on: ...` / `on_commit: ...`.
- `diagram_dot_shows_effect_labels` — DOT edges carry `[label="..."]`.
- `diagram_without_effects_has_no_edge_labels` — a plain `#[lifecycle]` renders no edge labels (byte-identical guarantee).

Existing `diagram_*` / `json_format_*` / `check` tests remain green (no regression).

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2TS7EVMkMvcvjSyy1MrQ)_