### PR TITLE
autumn-media: Rooms (slice 6) + deferred hardening

### DIFF
--- a/autumn-media-plugin/README.md
+++ b/autumn-media-plugin/README.md
@@ -23,7 +23,9 @@ The plugin is configured by a `[media]` section in your Autumn profile:
 
 ```toml
 [media]
-room_max_participants = 6            # hard cap, mesh, no SFU
+room_max_participants  = 6           # hard cap, mesh, no SFU (1..=6)
+room_token_ttl_seconds = 300         # room session-token lifetime
+# room_namespace       = "tenant-a"  # optional MediaMTX path namespace
 
 [media.mediamtx]
 api_base            = "http://127.0.0.1:9997"

--- a/autumn-media-plugin/src/config.rs
+++ b/autumn-media-plugin/src/config.rs
@@ -956,16 +956,24 @@ mod tests {
         assert_eq!(config.rooms.namespace.as_deref(), Some("tenant-b"));
         assert!(config.validate().is_ok());
 
-        // Above the hard cap → rejected by validate().
+        // Above the hard cap → rejected by validate() with a specific message
+        // naming the offending value and the ceiling (fail-fast, never clamp).
         let mut over = MediaConfig::default();
         over.rooms.max_participants = 7;
+        let err = over.validate().expect_err("7 > 6 must be rejected");
         assert!(matches!(
-            over.validate(),
-            Err(MediaConfigError::InvalidRoomMaxParticipants {
+            err,
+            MediaConfigError::InvalidRoomMaxParticipants {
                 requested: 7,
                 cap: DEFAULT_ROOM_MAX_PARTICIPANTS
-            })
+            }
         ));
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains('7'),
+            "names the offending value: {rendered}"
+        );
+        assert!(rendered.contains('6'), "names the ceiling: {rendered}");
 
         // Zero participants → rejected.
         let mut zero = MediaConfig::default();

--- a/autumn-media-plugin/src/config.rs
+++ b/autumn-media-plugin/src/config.rs
@@ -11,8 +11,9 @@
 //! [`Plugin::build`]: autumn_web::plugin::Plugin::build
 //!
 //! ```toml
-//! [media]
-//! room_max_participants = 6
+//! [media.rooms]
+//! max_participants = 6
+//! token_ttl_seconds = 300
 //!
 //! [media.mediamtx]
 //! api_base = "http://127.0.0.1:9997"
@@ -79,6 +80,11 @@ const fn default_room_max_participants() -> usize {
     DEFAULT_ROOM_MAX_PARTICIPANTS
 }
 
+/// Default lifetime, in seconds, of a minted room session token.
+const fn default_room_token_ttl_seconds() -> u32 {
+    300
+}
+
 // ── Errors ──────────────────────────────────────────────────────────────────
 
 /// Errors returned while loading or validating a [`MediaConfig`].
@@ -95,6 +101,17 @@ pub enum MediaConfigError {
          media.storage.secret_access_key must both be set, or neither"
     )]
     MissingS3Credential,
+    /// `[media.rooms].max_participants` was `0` or exceeded the hard cap of
+    /// [`DEFAULT_ROOM_MAX_PARTICIPANTS`] (mesh rooms have no SFU).
+    #[error(
+        "media.rooms.max_participants must be between 1 and {cap} (mesh rooms have no SFU), got {requested}"
+    )]
+    InvalidRoomMaxParticipants {
+        /// The rejected value.
+        requested: usize,
+        /// The hard cap ([`DEFAULT_ROOM_MAX_PARTICIPANTS`]).
+        cap: usize,
+    },
     /// The TOML file could not be parsed.
     #[error("failed to parse media config TOML: {0}")]
     Toml(#[from] toml::de::Error),
@@ -303,8 +320,37 @@ impl Default for RecordingConfig {
     }
 }
 
-/// The full `[media]` configuration surface.
+/// Mesh-room (`[media.rooms]`) settings.
+///
+/// Rooms are small mesh calls with **no SFU**, so `max_participants` is capped
+/// at [`DEFAULT_ROOM_MAX_PARTICIPANTS`]; a joining participant is issued a
+/// session token that stays valid for `token_ttl_seconds`, and `namespace`
+/// optionally isolates one deployment's room paths from another's.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct RoomConfig {
+    /// Hard cap on participants in one mesh room (must be `1..=`
+    /// [`DEFAULT_ROOM_MAX_PARTICIPANTS`]).
+    pub max_participants: usize,
+    /// Seconds a minted room session token stays valid after a join.
+    pub token_ttl_seconds: u32,
+    /// Optional `MediaMTX` path namespace isolating this deployment's rooms
+    /// (empty / `None` inserts no namespace segment).
+    pub namespace: Option<String>,
+}
+
+impl Default for RoomConfig {
+    fn default() -> Self {
+        Self {
+            max_participants: default_room_max_participants(),
+            token_ttl_seconds: default_room_token_ttl_seconds(),
+            namespace: None,
+        }
+    }
+}
+
+/// The full `[media]` configuration surface.
+#[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 pub struct MediaConfig {
     /// `MediaMTX` origin URLs.
@@ -315,20 +361,8 @@ pub struct MediaConfig {
     pub storage: MediaStorageConfig,
     /// Recording retention policy.
     pub recording: RecordingConfig,
-    /// Hard cap on mesh-room participants (no SFU).
-    pub room_max_participants: usize,
-}
-
-impl Default for MediaConfig {
-    fn default() -> Self {
-        Self {
-            mediamtx: MediaMtxConfig::default(),
-            ffmpeg: FfmpegConfig::default(),
-            storage: MediaStorageConfig::default(),
-            recording: RecordingConfig::default(),
-            room_max_participants: default_room_max_participants(),
-        }
-    }
+    /// Mesh-room settings.
+    pub rooms: RoomConfig,
 }
 
 /// The `[media]` table wrapper used to deserialize a full `autumn.toml`.
@@ -343,10 +377,19 @@ impl MediaConfig {
     ///
     /// # Errors
     ///
-    /// Returns [`MediaConfigError::MissingBucket`] when the S3 backend is
-    /// selected without a bucket, and [`MediaConfigError::MissingS3Credential`]
-    /// when exactly one of the access-key / secret-key pair is set.
+    /// Returns [`MediaConfigError::InvalidRoomMaxParticipants`] when the mesh
+    /// room cap is `0` or above [`DEFAULT_ROOM_MAX_PARTICIPANTS`],
+    /// [`MediaConfigError::MissingBucket`] when the S3 backend is selected
+    /// without a bucket, and [`MediaConfigError::MissingS3Credential`] when
+    /// exactly one of the access-key / secret-key pair is set.
     pub fn validate(&self) -> Result<(), MediaConfigError> {
+        let max = self.rooms.max_participants;
+        if max == 0 || max > DEFAULT_ROOM_MAX_PARTICIPANTS {
+            return Err(MediaConfigError::InvalidRoomMaxParticipants {
+                requested: max,
+                cap: DEFAULT_ROOM_MAX_PARTICIPANTS,
+            });
+        }
         if self.storage.backend != MediaStorageBackend::S3 {
             return Ok(());
         }
@@ -421,16 +464,32 @@ impl MediaConfig {
         interpolate_opt(&mut self.storage.session_token, env);
         interpolate_opt(&mut self.storage.public_base_url, env);
         interpolate(&mut self.storage.key_prefix, env);
+        interpolate_opt(&mut self.rooms.namespace, env);
+    }
+
+    /// Apply the `AUTUMN_MEDIA__ROOMS__*` scalar leaf overrides.
+    fn apply_room_env_overrides(&mut self, env: &HashMap<String, String>) {
+        if let Some(value) = env.get("AUTUMN_MEDIA__ROOMS__MAX_PARTICIPANTS")
+            && let Ok(parsed) = value.parse::<usize>()
+        {
+            self.rooms.max_participants = parsed;
+        }
+        if let Some(value) = env.get("AUTUMN_MEDIA__ROOMS__TOKEN_TTL_SECONDS")
+            && let Ok(parsed) = value.parse::<u32>()
+        {
+            self.rooms.token_ttl_seconds = parsed;
+        }
+        override_opt(
+            &mut self.rooms.namespace,
+            env,
+            "AUTUMN_MEDIA__ROOMS__NAMESPACE",
+        );
     }
 
     /// Apply `AUTUMN_MEDIA__<TABLE>__<FIELD>` scalar leaf overrides
     /// (double-underscore = table nesting).
     fn apply_env_overrides(&mut self, env: &HashMap<String, String>) {
-        if let Some(value) = env.get("AUTUMN_MEDIA__ROOM_MAX_PARTICIPANTS")
-            && let Ok(parsed) = value.parse::<usize>()
-        {
-            self.room_max_participants = parsed;
-        }
+        self.apply_room_env_overrides(env);
 
         override_string(
             &mut self.mediamtx.api_base,
@@ -754,7 +813,9 @@ mod tests {
         assert_eq!(config.storage.key_prefix, "media");
         assert!(!config.storage.force_path_style);
         assert_eq!(config.recording.retention_days, 14);
-        assert_eq!(config.room_max_participants, DEFAULT_ROOM_MAX_PARTICIPANTS);
+        assert_eq!(config.rooms.max_participants, DEFAULT_ROOM_MAX_PARTICIPANTS);
+        assert_eq!(config.rooms.token_ttl_seconds, 300);
+        assert_eq!(config.rooms.namespace, None);
     }
 
     #[test]
@@ -823,8 +884,10 @@ mod tests {
     #[test]
     fn from_toml_parses_media_table() {
         let toml_str = r#"
-            [media]
-            room_max_participants = 4
+            [media.rooms]
+            max_participants = 4
+            token_ttl_seconds = 120
+            namespace = "tenant-a"
 
             [media.mediamtx]
             api_base = "http://mtx:9997"
@@ -839,7 +902,9 @@ mod tests {
             retention_days = 30
         "#;
         let config = MediaConfig::from_toml_str_with_env(toml_str, &HashMap::new()).unwrap();
-        assert_eq!(config.room_max_participants, 4);
+        assert_eq!(config.rooms.max_participants, 4);
+        assert_eq!(config.rooms.token_ttl_seconds, 120);
+        assert_eq!(config.rooms.namespace.as_deref(), Some("tenant-a"));
         assert_eq!(config.mediamtx.api_base, "http://mtx:9997");
         assert_eq!(config.mediamtx.hls_probe_base(), "http://mediamtx:8888");
         assert_eq!(config.storage.backend, MediaStorageBackend::S3);
@@ -862,14 +927,53 @@ mod tests {
             ("AUTUMN_MEDIA__STORAGE__BACKEND", "s3"),
             ("AUTUMN_MEDIA__STORAGE__BUCKET", "env-bucket"),
             ("AUTUMN_MEDIA__RECORDING__RETENTION_DAYS", "7"),
-            ("AUTUMN_MEDIA__ROOM_MAX_PARTICIPANTS", "3"),
+            ("AUTUMN_MEDIA__ROOMS__MAX_PARTICIPANTS", "3"),
         ]);
         let config = MediaConfig::from_toml_str_with_env("[media]\n", &overrides).unwrap();
         assert_eq!(config.mediamtx.api_base, "http://override:9997");
         assert_eq!(config.storage.backend, MediaStorageBackend::S3);
         assert_eq!(config.storage.bucket.as_deref(), Some("env-bucket"));
         assert_eq!(config.recording.retention_days, 7);
-        assert_eq!(config.room_max_participants, 3);
+        assert_eq!(config.rooms.max_participants, 3);
+    }
+
+    #[test]
+    fn room_config_parses_table_and_env_override_and_validates_cap() {
+        // `[media.rooms]` parses, then `AUTUMN_MEDIA__ROOMS__*` overrides win.
+        let toml_str = r"
+            [media.rooms]
+            max_participants = 4
+            token_ttl_seconds = 90
+        ";
+        let overrides = env(&[
+            ("AUTUMN_MEDIA__ROOMS__MAX_PARTICIPANTS", "5"),
+            ("AUTUMN_MEDIA__ROOMS__TOKEN_TTL_SECONDS", "600"),
+            ("AUTUMN_MEDIA__ROOMS__NAMESPACE", "tenant-b"),
+        ]);
+        let config = MediaConfig::from_toml_str_with_env(toml_str, &overrides).unwrap();
+        assert_eq!(config.rooms.max_participants, 5);
+        assert_eq!(config.rooms.token_ttl_seconds, 600);
+        assert_eq!(config.rooms.namespace.as_deref(), Some("tenant-b"));
+        assert!(config.validate().is_ok());
+
+        // Above the hard cap → rejected by validate().
+        let mut over = MediaConfig::default();
+        over.rooms.max_participants = 7;
+        assert!(matches!(
+            over.validate(),
+            Err(MediaConfigError::InvalidRoomMaxParticipants {
+                requested: 7,
+                cap: DEFAULT_ROOM_MAX_PARTICIPANTS
+            })
+        ));
+
+        // Zero participants → rejected.
+        let mut zero = MediaConfig::default();
+        zero.rooms.max_participants = 0;
+        assert!(matches!(
+            zero.validate(),
+            Err(MediaConfigError::InvalidRoomMaxParticipants { requested: 0, .. })
+        ));
     }
 
     #[test]

--- a/autumn-media-plugin/src/config.rs
+++ b/autumn-media-plugin/src/config.rs
@@ -11,9 +11,10 @@
 //! [`Plugin::build`]: autumn_web::plugin::Plugin::build
 //!
 //! ```toml
-//! [media.rooms]
-//! max_participants = 6
-//! token_ttl_seconds = 300
+//! [media]
+//! room_max_participants = 6
+//! room_token_ttl_seconds = 300
+//! # room_namespace = "tenant-a"   # optional MediaMTX path namespace
 //!
 //! [media.mediamtx]
 //! api_base = "http://127.0.0.1:9997"
@@ -101,10 +102,10 @@ pub enum MediaConfigError {
          media.storage.secret_access_key must both be set, or neither"
     )]
     MissingS3Credential,
-    /// `[media.rooms].max_participants` was `0` or exceeded the hard cap of
+    /// `[media].room_max_participants` was `0` or exceeded the hard cap of
     /// [`DEFAULT_ROOM_MAX_PARTICIPANTS`] (mesh rooms have no SFU).
     #[error(
-        "media.rooms.max_participants must be between 1 and {cap} (mesh rooms have no SFU), got {requested}"
+        "media.room_max_participants must be between 1 and {cap} (mesh rooms have no SFU), got {requested}"
     )]
     InvalidRoomMaxParticipants {
         /// The rejected value.
@@ -320,37 +321,15 @@ impl Default for RecordingConfig {
     }
 }
 
-/// Mesh-room (`[media.rooms]`) settings.
+/// The full `[media]` configuration surface.
 ///
-/// Rooms are small mesh calls with **no SFU**, so `max_participants` is capped
-/// at [`DEFAULT_ROOM_MAX_PARTICIPANTS`]; a joining participant is issued a
-/// session token that stays valid for `token_ttl_seconds`, and `namespace`
+/// The mesh-room knobs are flat `[media]` keys (`room_max_participants`,
+/// `room_token_ttl_seconds`, `room_namespace`): rooms are small mesh calls with
+/// **no SFU**, so `room_max_participants` is capped at
+/// [`DEFAULT_ROOM_MAX_PARTICIPANTS`]; a joining participant is issued a session
+/// token that stays valid for `room_token_ttl_seconds`, and `room_namespace`
 /// optionally isolates one deployment's room paths from another's.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(default)]
-pub struct RoomConfig {
-    /// Hard cap on participants in one mesh room (must be `1..=`
-    /// [`DEFAULT_ROOM_MAX_PARTICIPANTS`]).
-    pub max_participants: usize,
-    /// Seconds a minted room session token stays valid after a join.
-    pub token_ttl_seconds: u32,
-    /// Optional `MediaMTX` path namespace isolating this deployment's rooms
-    /// (empty / `None` inserts no namespace segment).
-    pub namespace: Option<String>,
-}
-
-impl Default for RoomConfig {
-    fn default() -> Self {
-        Self {
-            max_participants: default_room_max_participants(),
-            token_ttl_seconds: default_room_token_ttl_seconds(),
-            namespace: None,
-        }
-    }
-}
-
-/// The full `[media]` configuration surface.
-#[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 pub struct MediaConfig {
     /// `MediaMTX` origin URLs.
@@ -361,8 +340,31 @@ pub struct MediaConfig {
     pub storage: MediaStorageConfig,
     /// Recording retention policy.
     pub recording: RecordingConfig,
-    /// Mesh-room settings.
-    pub rooms: RoomConfig,
+    /// Hard cap on participants in one mesh room (must be `1..=`
+    /// [`DEFAULT_ROOM_MAX_PARTICIPANTS`]; mesh, no SFU).
+    #[serde(default = "default_room_max_participants")]
+    pub room_max_participants: usize,
+    /// Seconds a minted room session token stays valid after a join.
+    #[serde(default = "default_room_token_ttl_seconds")]
+    pub room_token_ttl_seconds: u32,
+    /// Optional `MediaMTX` path namespace isolating this deployment's rooms
+    /// (empty / `None` inserts no namespace segment).
+    #[serde(default)]
+    pub room_namespace: Option<String>,
+}
+
+impl Default for MediaConfig {
+    fn default() -> Self {
+        Self {
+            mediamtx: MediaMtxConfig::default(),
+            ffmpeg: FfmpegConfig::default(),
+            storage: MediaStorageConfig::default(),
+            recording: RecordingConfig::default(),
+            room_max_participants: default_room_max_participants(),
+            room_token_ttl_seconds: default_room_token_ttl_seconds(),
+            room_namespace: None,
+        }
+    }
 }
 
 /// The `[media]` table wrapper used to deserialize a full `autumn.toml`.
@@ -383,7 +385,7 @@ impl MediaConfig {
     /// without a bucket, and [`MediaConfigError::MissingS3Credential`] when
     /// exactly one of the access-key / secret-key pair is set.
     pub fn validate(&self) -> Result<(), MediaConfigError> {
-        let max = self.rooms.max_participants;
+        let max = self.room_max_participants;
         if max == 0 || max > DEFAULT_ROOM_MAX_PARTICIPANTS {
             return Err(MediaConfigError::InvalidRoomMaxParticipants {
                 requested: max,
@@ -464,30 +466,31 @@ impl MediaConfig {
         interpolate_opt(&mut self.storage.session_token, env);
         interpolate_opt(&mut self.storage.public_base_url, env);
         interpolate(&mut self.storage.key_prefix, env);
-        interpolate_opt(&mut self.rooms.namespace, env);
+        interpolate_opt(&mut self.room_namespace, env);
     }
 
-    /// Apply the `AUTUMN_MEDIA__ROOMS__*` scalar leaf overrides.
+    /// Apply the flat `AUTUMN_MEDIA__ROOM_*` scalar leaf overrides.
     fn apply_room_env_overrides(&mut self, env: &HashMap<String, String>) {
-        if let Some(value) = env.get("AUTUMN_MEDIA__ROOMS__MAX_PARTICIPANTS")
+        if let Some(value) = env.get("AUTUMN_MEDIA__ROOM_MAX_PARTICIPANTS")
             && let Ok(parsed) = value.parse::<usize>()
         {
-            self.rooms.max_participants = parsed;
+            self.room_max_participants = parsed;
         }
-        if let Some(value) = env.get("AUTUMN_MEDIA__ROOMS__TOKEN_TTL_SECONDS")
+        if let Some(value) = env.get("AUTUMN_MEDIA__ROOM_TOKEN_TTL_SECONDS")
             && let Ok(parsed) = value.parse::<u32>()
         {
-            self.rooms.token_ttl_seconds = parsed;
+            self.room_token_ttl_seconds = parsed;
         }
         override_opt(
-            &mut self.rooms.namespace,
+            &mut self.room_namespace,
             env,
-            "AUTUMN_MEDIA__ROOMS__NAMESPACE",
+            "AUTUMN_MEDIA__ROOM_NAMESPACE",
         );
     }
 
     /// Apply `AUTUMN_MEDIA__<TABLE>__<FIELD>` scalar leaf overrides
-    /// (double-underscore = table nesting).
+    /// (double-underscore = table nesting; flat `[media]` leaves use a single
+    /// segment, e.g. `AUTUMN_MEDIA__ROOM_MAX_PARTICIPANTS`).
     fn apply_env_overrides(&mut self, env: &HashMap<String, String>) {
         self.apply_room_env_overrides(env);
 
@@ -813,9 +816,9 @@ mod tests {
         assert_eq!(config.storage.key_prefix, "media");
         assert!(!config.storage.force_path_style);
         assert_eq!(config.recording.retention_days, 14);
-        assert_eq!(config.rooms.max_participants, DEFAULT_ROOM_MAX_PARTICIPANTS);
-        assert_eq!(config.rooms.token_ttl_seconds, 300);
-        assert_eq!(config.rooms.namespace, None);
+        assert_eq!(config.room_max_participants, DEFAULT_ROOM_MAX_PARTICIPANTS);
+        assert_eq!(config.room_token_ttl_seconds, 300);
+        assert_eq!(config.room_namespace, None);
     }
 
     #[test]
@@ -884,10 +887,10 @@ mod tests {
     #[test]
     fn from_toml_parses_media_table() {
         let toml_str = r#"
-            [media.rooms]
-            max_participants = 4
-            token_ttl_seconds = 120
-            namespace = "tenant-a"
+            [media]
+            room_max_participants = 4
+            room_token_ttl_seconds = 120
+            room_namespace = "tenant-a"
 
             [media.mediamtx]
             api_base = "http://mtx:9997"
@@ -902,9 +905,9 @@ mod tests {
             retention_days = 30
         "#;
         let config = MediaConfig::from_toml_str_with_env(toml_str, &HashMap::new()).unwrap();
-        assert_eq!(config.rooms.max_participants, 4);
-        assert_eq!(config.rooms.token_ttl_seconds, 120);
-        assert_eq!(config.rooms.namespace.as_deref(), Some("tenant-a"));
+        assert_eq!(config.room_max_participants, 4);
+        assert_eq!(config.room_token_ttl_seconds, 120);
+        assert_eq!(config.room_namespace.as_deref(), Some("tenant-a"));
         assert_eq!(config.mediamtx.api_base, "http://mtx:9997");
         assert_eq!(config.mediamtx.hls_probe_base(), "http://mediamtx:8888");
         assert_eq!(config.storage.backend, MediaStorageBackend::S3);
@@ -927,39 +930,41 @@ mod tests {
             ("AUTUMN_MEDIA__STORAGE__BACKEND", "s3"),
             ("AUTUMN_MEDIA__STORAGE__BUCKET", "env-bucket"),
             ("AUTUMN_MEDIA__RECORDING__RETENTION_DAYS", "7"),
-            ("AUTUMN_MEDIA__ROOMS__MAX_PARTICIPANTS", "3"),
+            ("AUTUMN_MEDIA__ROOM_MAX_PARTICIPANTS", "3"),
         ]);
         let config = MediaConfig::from_toml_str_with_env("[media]\n", &overrides).unwrap();
         assert_eq!(config.mediamtx.api_base, "http://override:9997");
         assert_eq!(config.storage.backend, MediaStorageBackend::S3);
         assert_eq!(config.storage.bucket.as_deref(), Some("env-bucket"));
         assert_eq!(config.recording.retention_days, 7);
-        assert_eq!(config.rooms.max_participants, 3);
+        assert_eq!(config.room_max_participants, 3);
     }
 
     #[test]
-    fn room_config_parses_table_and_env_override_and_validates_cap() {
-        // `[media.rooms]` parses, then `AUTUMN_MEDIA__ROOMS__*` overrides win.
+    fn room_flat_config_parses_env_override_and_validates_cap() {
+        // Flat `[media]` room keys parse, then `AUTUMN_MEDIA__ROOM_*` overrides win.
         let toml_str = r"
-            [media.rooms]
-            max_participants = 4
-            token_ttl_seconds = 90
+            [media]
+            room_max_participants = 4
+            room_token_ttl_seconds = 90
         ";
         let overrides = env(&[
-            ("AUTUMN_MEDIA__ROOMS__MAX_PARTICIPANTS", "5"),
-            ("AUTUMN_MEDIA__ROOMS__TOKEN_TTL_SECONDS", "600"),
-            ("AUTUMN_MEDIA__ROOMS__NAMESPACE", "tenant-b"),
+            ("AUTUMN_MEDIA__ROOM_MAX_PARTICIPANTS", "5"),
+            ("AUTUMN_MEDIA__ROOM_TOKEN_TTL_SECONDS", "600"),
+            ("AUTUMN_MEDIA__ROOM_NAMESPACE", "tenant-b"),
         ]);
         let config = MediaConfig::from_toml_str_with_env(toml_str, &overrides).unwrap();
-        assert_eq!(config.rooms.max_participants, 5);
-        assert_eq!(config.rooms.token_ttl_seconds, 600);
-        assert_eq!(config.rooms.namespace.as_deref(), Some("tenant-b"));
+        assert_eq!(config.room_max_participants, 5);
+        assert_eq!(config.room_token_ttl_seconds, 600);
+        assert_eq!(config.room_namespace.as_deref(), Some("tenant-b"));
         assert!(config.validate().is_ok());
 
         // Above the hard cap → rejected by validate() with a specific message
         // naming the offending value and the ceiling (fail-fast, never clamp).
-        let mut over = MediaConfig::default();
-        over.rooms.max_participants = 7;
+        let over = MediaConfig {
+            room_max_participants: 7,
+            ..MediaConfig::default()
+        };
         let err = over.validate().expect_err("7 > 6 must be rejected");
         assert!(matches!(
             err,
@@ -976,8 +981,10 @@ mod tests {
         assert!(rendered.contains('6'), "names the ceiling: {rendered}");
 
         // Zero participants → rejected.
-        let mut zero = MediaConfig::default();
-        zero.rooms.max_participants = 0;
+        let zero = MediaConfig {
+            room_max_participants: 0,
+            ..MediaConfig::default()
+        };
         assert!(matches!(
             zero.validate(),
             Err(MediaConfigError::InvalidRoomMaxParticipants { requested: 0, .. })

--- a/autumn-media-plugin/src/encode.rs
+++ b/autumn-media-plugin/src/encode.rs
@@ -736,6 +736,17 @@ const ROOM_COMPOSITE_MAX_INPUTS: usize = 6;
 /// encoders. The composite needs `2..=6` participant recordings (the mesh-room
 /// cap); one input per participant, so — unlike the clip/poster encoders — it
 /// never concatenates.
+///
+/// # Audio-stream assumption
+///
+/// This composite assumes **each participant recording carries an audio
+/// stream**: the `-filter_complex` graph references every input's audio and
+/// mixes them with `amix`, so a **video-only participant recording (no audio
+/// stream) is not supported for composition this slice** — `FFmpeg` would fail
+/// on the missing stream. The **per-participant recordings themselves are
+/// unaffected**; this limitation is only about the composited grid output.
+/// Robust handling (per-input audio detection / silence synthesis) is recorded
+/// future work on the epic.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FfmpegRoomCompositeCommand {
     ffmpeg_bin: String,

--- a/autumn-media-plugin/src/encode.rs
+++ b/autumn-media-plugin/src/encode.rs
@@ -717,6 +717,14 @@ pub const ROOM_COMPOSITE_CELL_WIDTH: u32 = 640;
 /// Height, in pixels, of one participant cell in a room-composite grid (16:9).
 pub const ROOM_COMPOSITE_CELL_HEIGHT: u32 = 360;
 
+/// Maximum participant recordings a room composite accepts.
+///
+/// Tied to the mesh-room seat cap
+/// ([`crate::config::DEFAULT_ROOM_MAX_PARTICIPANTS`], 6): a mesh call never
+/// exceeds 6 participants, so a composite never tiles more. Kept as a local
+/// const so this dependency-free encode module needs no `config` import.
+const ROOM_COMPOSITE_MAX_INPUTS: usize = 6;
+
 /// Grid-composite encoder for a finished mesh-room recording.
 ///
 /// Tiles each participant's recording into a grid — `2x1` for two participants,
@@ -783,14 +791,20 @@ impl FfmpegRoomCompositeCommand {
     ///
     /// # Errors
     ///
-    /// Returns an error when there are fewer than two source recordings, a
-    /// source is missing, the output directory cannot be created, `FFmpeg`
-    /// fails, or the output cannot be inspected after a successful run.
+    /// Returns an error when there are fewer than two or more than six source
+    /// recordings (the `2..=6` mesh-room band), a source is missing, the output
+    /// directory cannot be created, `FFmpeg` fails, or the output cannot be
+    /// inspected after a successful run.
     pub fn run(&self) -> Result<u64, MediaError> {
         require_sources(&self.input_paths)?;
         if self.input_paths.len() < 2 {
             return Err(MediaError::FfmpegSourceMissing {
                 path: "<room composite needs at least two participant recordings>".to_owned(),
+            });
+        }
+        if self.input_paths.len() > ROOM_COMPOSITE_MAX_INPUTS {
+            return Err(MediaError::FfmpegSourceMissing {
+                path: "<room composite accepts at most six participant recordings>".to_owned(),
             });
         }
         create_output_parent(&self.output_path)?;
@@ -1299,6 +1313,25 @@ mod tests {
             FfmpegRoomCompositeCommand::new("ffmpeg", vec![only], dir.path().join("room.mp4"));
         // A one-participant composite is meaningless; run() must reject it
         // before spawning FFmpeg.
+        assert!(matches!(
+            cmd.run(),
+            Err(super::MediaError::FfmpegSourceMissing { .. })
+        ));
+    }
+
+    #[test]
+    fn room_composite_run_rejects_more_than_six_participants() {
+        let dir = tempfile::tempdir().unwrap();
+        // Seven present sources: `require_sources` passes, then the `2..=6`
+        // upper bound rejects before spawning FFmpeg (mesh rooms cap at six).
+        let sources: Vec<PathBuf> = (0..7)
+            .map(|i| {
+                let path = dir.path().join(format!("p{i}.mp4"));
+                File::create(&path).unwrap();
+                path
+            })
+            .collect();
+        let cmd = FfmpegRoomCompositeCommand::new("ffmpeg", sources, dir.path().join("room.mp4"));
         assert!(matches!(
             cmd.run(),
             Err(super::MediaError::FfmpegSourceMissing { .. })

--- a/autumn-media-plugin/src/encode.rs
+++ b/autumn-media-plugin/src/encode.rs
@@ -711,6 +711,164 @@ impl FfmpegLiveThumbnailCommand {
     }
 }
 
+/// Width, in pixels, of one participant cell in a room-composite grid (16:9).
+pub const ROOM_COMPOSITE_CELL_WIDTH: u32 = 640;
+
+/// Height, in pixels, of one participant cell in a room-composite grid (16:9).
+pub const ROOM_COMPOSITE_CELL_HEIGHT: u32 = 360;
+
+/// Grid-composite encoder for a finished mesh-room recording.
+///
+/// Tiles each participant's recording into a grid — `2x1` for two participants,
+/// `2x2` for three–four, `3x2` for five–six — via `FFmpeg`'s `xstack` filter
+/// (each cell letterboxed to
+/// [`ROOM_COMPOSITE_CELL_WIDTH`]×[`ROOM_COMPOSITE_CELL_HEIGHT`]) and mixes every
+/// participant's audio into one track with `amix`, producing a single
+/// composited MP4. Best-effort by convention, like the other recording
+/// encoders. The composite needs `2..=6` participant recordings (the mesh-room
+/// cap); one input per participant, so — unlike the clip/poster encoders — it
+/// never concatenates.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FfmpegRoomCompositeCommand {
+    ffmpeg_bin: String,
+    input_paths: Vec<PathBuf>,
+    output_path: PathBuf,
+}
+
+impl FfmpegRoomCompositeCommand {
+    /// Build a room-composite command. One `input_path` per participant.
+    #[must_use]
+    pub fn new(
+        ffmpeg_bin: impl Into<String>,
+        input_paths: Vec<PathBuf>,
+        output_path: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            ffmpeg_bin: ffmpeg_bin.into(),
+            input_paths,
+            output_path: output_path.into(),
+        }
+    }
+
+    /// The exact `FFmpeg` argument vector this command runs.
+    #[must_use]
+    pub fn args(&self) -> Vec<String> {
+        let n = self.input_paths.len();
+        let mut args = vec!["-y".to_owned()];
+        for path in &self.input_paths {
+            args.push("-i".to_owned());
+            args.push(path.display().to_string());
+        }
+        args.push("-filter_complex".to_owned());
+        args.push(room_composite_filtergraph(n));
+        args.extend([
+            "-map".to_owned(),
+            "[vout]".to_owned(),
+            "-map".to_owned(),
+            "[aout]".to_owned(),
+            "-c:v".to_owned(),
+            "libx264".to_owned(),
+            "-preset".to_owned(),
+            "veryfast".to_owned(),
+            "-c:a".to_owned(),
+            "aac".to_owned(),
+            "-movflags".to_owned(),
+            "+faststart".to_owned(),
+            self.output_path.display().to_string(),
+        ]);
+        args
+    }
+
+    /// Render the composited MP4 and return its size in bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when there are fewer than two source recordings, a
+    /// source is missing, the output directory cannot be created, `FFmpeg`
+    /// fails, or the output cannot be inspected after a successful run.
+    pub fn run(&self) -> Result<u64, MediaError> {
+        require_sources(&self.input_paths)?;
+        if self.input_paths.len() < 2 {
+            return Err(MediaError::FfmpegSourceMissing {
+                path: "<room composite needs at least two participant recordings>".to_owned(),
+            });
+        }
+        create_output_parent(&self.output_path)?;
+
+        let output = Command::new(&self.ffmpeg_bin)
+            .args(self.args())
+            .output()
+            .map_err(|source| MediaError::FfmpegSpawn {
+                bin: self.ffmpeg_bin.clone(),
+                source,
+            })?;
+
+        check_exit(&output)?;
+        output_size(&self.output_path)
+    }
+}
+
+/// Grid dimensions `(cols, rows)` for an `n`-participant composite: `2x1` for
+/// two, `2x2` for three–four, `3x2` for five–six.
+const fn room_composite_grid_dims(n: usize) -> (usize, usize) {
+    if n <= 2 {
+        (2, 1)
+    } else if n <= 4 {
+        (2, 2)
+    } else {
+        (3, 2)
+    }
+}
+
+/// Build the `-filter_complex` graph: one letterboxed `scale`/`pad` per input,
+/// an `xstack` grid of them, and an `amix` of every audio track.
+fn room_composite_filtergraph(n: usize) -> String {
+    use std::fmt::Write as _;
+
+    let (cols, _rows) = room_composite_grid_dims(n);
+    let (w, h) = (ROOM_COMPOSITE_CELL_WIDTH, ROOM_COMPOSITE_CELL_HEIGHT);
+    let mut parts = Vec::new();
+    let mut video_labels = String::new();
+    let mut audio_labels = String::new();
+    for i in 0..n {
+        parts.push(format!(
+            "[{i}:v]scale={w}:{h}:force_original_aspect_ratio=decrease,pad={w}:{h}:(ow-iw)/2:(oh-ih)/2,setsar=1[v{i}]"
+        ));
+        let _ = write!(video_labels, "[v{i}]");
+        let _ = write!(audio_labels, "[{i}:a]");
+    }
+    let layout = room_composite_layout(cols, n);
+    parts.push(format!(
+        "{video_labels}xstack=inputs={n}:layout={layout}[vout]"
+    ));
+    parts.push(format!("{audio_labels}amix=inputs={n}:normalize=1[aout]"));
+    parts.join(";")
+}
+
+/// The `xstack` `layout` string. Every cell is the same size, so each input at
+/// `(row, col)` is placed at `X_Y` where the column offset is a sum of the
+/// first cell's width (`w0`) and the row offset a sum of its height (`h0`).
+fn room_composite_layout(cols: usize, n: usize) -> String {
+    (0..n)
+        .map(|i| {
+            let col = i % cols;
+            let row = i / cols;
+            let x = if col == 0 {
+                "0".to_owned()
+            } else {
+                vec!["w0"; col].join("+")
+            };
+            let y = if row == 0 {
+                "0".to_owned()
+            } else {
+                vec!["h0"; row].join("+")
+            };
+            format!("{x}_{y}")
+        })
+        .collect::<Vec<_>>()
+        .join("|")
+}
+
 // ── Shared run() helpers ────────────────────────────────────────────────────
 
 /// Reject an empty or missing set of source recordings before spawning.
@@ -920,10 +1078,10 @@ mod tests {
 
     use super::{
         FfmpegClipTailCommand, FfmpegHighlightCommand, FfmpegLiveThumbnailCommand,
-        FfmpegPosterCommand, FfmpegPreviewSpriteCommand, PREVIEW_CELL_HEIGHT, PREVIEW_CELL_WIDTH,
-        PREVIEW_FRAME_INTERVAL_SECONDS, PREVIEW_SPRITE_COLUMNS, build_preview_webvtt,
-        newest_recording_files, newest_recording_files_since, recording_segments_covering_window,
-        slugify,
+        FfmpegPosterCommand, FfmpegPreviewSpriteCommand, FfmpegRoomCompositeCommand,
+        PREVIEW_CELL_HEIGHT, PREVIEW_CELL_WIDTH, PREVIEW_FRAME_INTERVAL_SECONDS,
+        PREVIEW_SPRITE_COLUMNS, build_preview_webvtt, newest_recording_files,
+        newest_recording_files_since, recording_segments_covering_window, slugify,
     };
 
     // ── Arg-vector contracts (no FFmpeg binary required) ────────────────────
@@ -1067,6 +1225,84 @@ mod tests {
         let i = args.iter().position(|a| a == "-i").unwrap();
         assert_eq!(args[i + 1], "http://mediamtx/live/key/index.m3u8");
         assert_eq!(args.last().map(String::as_str), Some("/out/thumb.jpg"));
+    }
+
+    #[test]
+    fn room_composite_two_participants_side_by_side() {
+        let cmd = FfmpegRoomCompositeCommand::new(
+            "ffmpeg",
+            vec![PathBuf::from("/rec/a.mp4"), PathBuf::from("/rec/b.mp4")],
+            "/out/room.mp4",
+        );
+        let args = cmd.args();
+        assert_eq!(args.first().map(String::as_str), Some("-y"));
+        // One -i per participant.
+        assert_eq!(args.iter().filter(|a| *a == "-i").count(), 2);
+        // Exact filter graph: two letterboxed cells, a 2x1 xstack, an amix.
+        let fc = args.iter().position(|a| a == "-filter_complex").unwrap();
+        assert_eq!(
+            args[fc + 1],
+            "[0:v]scale=640:360:force_original_aspect_ratio=decrease,pad=640:360:(ow-iw)/2:(oh-ih)/2,setsar=1[v0];\
+             [1:v]scale=640:360:force_original_aspect_ratio=decrease,pad=640:360:(ow-iw)/2:(oh-ih)/2,setsar=1[v1];\
+             [v0][v1]xstack=inputs=2:layout=0_0|w0_0[vout];\
+             [0:a][1:a]amix=inputs=2:normalize=1[aout]"
+        );
+        assert_windowed(&args, "-map", "[vout]");
+        assert_windowed(&args, "-c:v", "libx264");
+        assert_windowed(&args, "-c:a", "aac");
+        assert_windowed(&args, "-movflags", "+faststart");
+        assert_eq!(args.last().map(String::as_str), Some("/out/room.mp4"));
+    }
+
+    #[test]
+    fn room_composite_four_participants_two_by_two_grid() {
+        let cmd = FfmpegRoomCompositeCommand::new(
+            "ffmpeg",
+            vec![
+                PathBuf::from("/rec/a.mp4"),
+                PathBuf::from("/rec/b.mp4"),
+                PathBuf::from("/rec/c.mp4"),
+                PathBuf::from("/rec/d.mp4"),
+            ],
+            "/out/room.mp4",
+        );
+        let args = cmd.args();
+        assert_eq!(args.iter().filter(|a| *a == "-i").count(), 4);
+        let fc = args.iter().position(|a| a == "-filter_complex").unwrap();
+        assert_eq!(
+            args[fc + 1],
+            "[0:v]scale=640:360:force_original_aspect_ratio=decrease,pad=640:360:(ow-iw)/2:(oh-ih)/2,setsar=1[v0];\
+             [1:v]scale=640:360:force_original_aspect_ratio=decrease,pad=640:360:(ow-iw)/2:(oh-ih)/2,setsar=1[v1];\
+             [2:v]scale=640:360:force_original_aspect_ratio=decrease,pad=640:360:(ow-iw)/2:(oh-ih)/2,setsar=1[v2];\
+             [3:v]scale=640:360:force_original_aspect_ratio=decrease,pad=640:360:(ow-iw)/2:(oh-ih)/2,setsar=1[v3];\
+             [v0][v1][v2][v3]xstack=inputs=4:layout=0_0|w0_0|0_h0|w0_h0[vout];\
+             [0:a][1:a][2:a][3:a]amix=inputs=4:normalize=1[aout]"
+        );
+    }
+
+    #[test]
+    fn room_composite_grid_dims_match_participant_bands() {
+        use super::room_composite_grid_dims;
+        assert_eq!(room_composite_grid_dims(2), (2, 1));
+        assert_eq!(room_composite_grid_dims(3), (2, 2));
+        assert_eq!(room_composite_grid_dims(4), (2, 2));
+        assert_eq!(room_composite_grid_dims(5), (3, 2));
+        assert_eq!(room_composite_grid_dims(6), (3, 2));
+    }
+
+    #[test]
+    fn room_composite_run_rejects_single_participant() {
+        let dir = tempfile::tempdir().unwrap();
+        let only = dir.path().join("solo.mp4");
+        File::create(&only).unwrap();
+        let cmd =
+            FfmpegRoomCompositeCommand::new("ffmpeg", vec![only], dir.path().join("room.mp4"));
+        // A one-participant composite is meaningless; run() must reject it
+        // before spawning FFmpeg.
+        assert!(matches!(
+            cmd.run(),
+            Err(super::MediaError::FfmpegSourceMissing { .. })
+        ));
     }
 
     /// Assert `flag` appears immediately followed by `value`.

--- a/autumn-media-plugin/src/error.rs
+++ b/autumn-media-plugin/src/error.rs
@@ -26,6 +26,21 @@ pub enum MediaError {
     )]
     PartialS3Credentials,
 
+    /// A caller-supplied storage key contained a dot-only (`.`/`..`) or empty
+    /// path segment.
+    ///
+    /// Percent-encoding such a segment is not enough: WHATWG URL parsers
+    /// normalize `%2E` back to `.`, so the advertised public URL could
+    /// path-normalize down to a *different* object than the one stored. The key
+    /// is refused at the storage boundary instead. `key` is a caller object key
+    /// (not a secret — it already appears in public URLs and the S3 error
+    /// variants).
+    #[error("invalid storage key `{key}`: path segments must not be `.`, `..`, or empty")]
+    InvalidKeySegment {
+        /// The offending caller-relative key.
+        key: String,
+    },
+
     /// A local file staged for persistence could not be read.
     #[error("failed to read local file `{path}`: {source}")]
     LocalRead {

--- a/autumn-media-plugin/src/lib.rs
+++ b/autumn-media-plugin/src/lib.rs
@@ -49,7 +49,7 @@ pub mod workflows;
 
 pub use config::{
     MediaConfig, MediaConfigError, MediaMtxConfig, MediaStorageBackend, MediaStorageConfig,
-    RecordingConfig, RoomConfig,
+    RecordingConfig,
 };
 pub use encode::{
     FfmpegClipTailCommand, FfmpegHighlightCommand, FfmpegLiveThumbnailCommand, FfmpegPosterCommand,
@@ -104,9 +104,9 @@ pub mod prelude {
         newest_recording_files_since, recording_segments_covering_window, slugify,
     };
     pub use crate::{
-        InMemoryRoomStore, JoinRecord, JoinResponse, ParticipantView, RoomConfig, RoomError,
-        RoomService, RoomSnapshot, RoomStore, SessionToken, room_participant_path,
-        room_route_infos, room_router, validate_room_segment,
+        InMemoryRoomStore, JoinRecord, JoinResponse, ParticipantView, RoomError, RoomService,
+        RoomSnapshot, RoomStore, SessionToken, room_participant_path, room_route_infos,
+        room_router, validate_room_segment,
     };
     pub use crate::{
         IngestStatus, MediaMtxClient, MediaUrls, StreamQualityStats, StreamStatus, ViewerCount,
@@ -238,10 +238,10 @@ impl MediaPlugin {
     /// after [`Plugin::build`] runs; resolve it up front with
     /// [`MediaConfig::from_autumn_toml`](config::MediaConfig::from_autumn_toml)
     /// or [`MediaConfig::from_arroyo_env`](config::MediaConfig::from_arroyo_env)
-    /// and pass it here. Adopts the config's `rooms.max_participants`.
+    /// and pass it here. Adopts the config's `room_max_participants`.
     #[must_use]
     pub fn config(mut self, config: MediaConfig) -> Self {
-        self.room_max_participants = config.rooms.max_participants;
+        self.room_max_participants = config.room_max_participants;
         self.config = config;
         self
     }
@@ -268,18 +268,18 @@ impl MediaPlugin {
     }
 
     /// Override the mesh-room session-token lifetime, in seconds (shortcut for
-    /// `config.rooms.token_ttl_seconds`).
+    /// `config.room_token_ttl_seconds`).
     #[must_use]
     pub const fn room_token_ttl_seconds(mut self, seconds: u32) -> Self {
-        self.config.rooms.token_ttl_seconds = seconds;
+        self.config.room_token_ttl_seconds = seconds;
         self
     }
 
     /// Override the mesh-room `MediaMTX` path namespace (shortcut for
-    /// `config.rooms.namespace`).
+    /// `config.room_namespace`).
     #[must_use]
     pub fn room_namespace(mut self, namespace: impl Into<String>) -> Self {
-        self.config.rooms.namespace = Some(namespace.into());
+        self.config.room_namespace = Some(namespace.into());
         self
     }
 
@@ -381,7 +381,7 @@ impl Plugin for MediaPlugin {
         let retention_days = retention_days.unwrap_or(config.recording.retention_days);
 
         // The mesh is O(N²), so `DEFAULT_ROOM_MAX_PARTICIPANTS` (6) is an
-        // ABSOLUTE ceiling with no SFU: the `[media.rooms]` config and the
+        // ABSOLUTE ceiling with no SFU: the `[media]` room config and the
         // `room_max_participants` builder may set a per-room seat count only
         // within `1..=6`. An out-of-range value (0 or >6) is a fatal
         // misconfiguration — fail fast and LOUD at boot, never a silent clamp.
@@ -390,7 +390,7 @@ impl Plugin for MediaPlugin {
         // boot with `process::exit(1)` exactly as a failed init would (see
         // autumn-web's `run_startup_hooks`). `room_max_participants` is the
         // effective seat count sourced from either `config(..)` (which copies
-        // `rooms.max_participants` into it) or the `room_max_participants(..)`
+        // `room_max_participants` into it) or the `room_max_participants(..)`
         // builder, so this single check covers both the TOML and builder paths;
         // `InMemoryRoomStore::create_room` re-checks the fixed 6 ceiling as a
         // defense-in-depth backstop, and `MediaConfig::validate` stays the
@@ -432,8 +432,8 @@ impl Plugin for MediaPlugin {
             let room_service = rooms::RoomService::new(
                 Arc::new(rooms::InMemoryRoomStore::new(room_max_participants)),
                 transport::MediaUrls::from_config(&config.mediamtx),
-                config.rooms.namespace.clone().unwrap_or_default(),
-                chrono::Duration::seconds(i64::from(config.rooms.token_ttl_seconds)),
+                config.room_namespace.clone().unwrap_or_default(),
+                chrono::Duration::seconds(i64::from(config.room_token_ttl_seconds)),
                 room_max_participants,
             );
             app = app
@@ -692,10 +692,12 @@ mod room_cap_tests {
         assert_eq!(ok.room_max_participants, 4);
         assert!(room_max_participants_error(ok.room_max_participants).is_none());
 
-        // The `[media.rooms] max_participants = 50` config path flows into the
+        // The `[media] room_max_participants = 50` config path flows into the
         // same effective field via `config(..)`, so it is rejected identically.
-        let mut config = MediaConfig::default();
-        config.rooms.max_participants = 50;
+        let config = MediaConfig {
+            room_max_participants: 50,
+            ..MediaConfig::default()
+        };
         let from_config = MediaPlugin::new().config(config);
         assert_eq!(from_config.room_max_participants, 50);
         assert!(room_max_participants_error(from_config.room_max_participants).is_some());

--- a/autumn-media-plugin/src/lib.rs
+++ b/autumn-media-plugin/src/lib.rs
@@ -53,8 +53,9 @@ pub use config::{
 };
 pub use encode::{
     FfmpegClipTailCommand, FfmpegHighlightCommand, FfmpegLiveThumbnailCommand, FfmpegPosterCommand,
-    FfmpegPreviewSpriteCommand, PREVIEW_CELL_HEIGHT, PREVIEW_CELL_WIDTH,
-    PREVIEW_FRAME_INTERVAL_SECONDS, PREVIEW_SPRITE_COLUMNS, build_preview_webvtt,
+    FfmpegPreviewSpriteCommand, FfmpegRoomCompositeCommand, PREVIEW_CELL_HEIGHT,
+    PREVIEW_CELL_WIDTH, PREVIEW_FRAME_INTERVAL_SECONDS, PREVIEW_SPRITE_COLUMNS,
+    ROOM_COMPOSITE_CELL_HEIGHT, ROOM_COMPOSITE_CELL_WIDTH, build_preview_webvtt,
     newest_recording_file, newest_recording_files, newest_recording_files_since,
     recording_segments_covering_window, slugify,
 };
@@ -82,22 +83,24 @@ pub use transport::{
 };
 pub use workflows::{
     FinalizeRecordingJobArgs, MediaWorkflowDelegate, MediaWorkflowDelegateExt,
-    MediaWorkflowRequest, MediaWorkflows, PreviewJobArgs, ThumbnailJobArgs, TranscodeJobArgs,
-    media_job_infos,
+    MediaWorkflowRequest, MediaWorkflows, PreviewJobArgs, RoomCompositeJobArgs, ThumbnailJobArgs,
+    TranscodeJobArgs, media_job_infos,
 };
 
 /// Common downstream imports for configuring and mounting the media plugin.
 pub mod prelude {
     pub use crate::{
         FfmpegClipTailCommand, FfmpegHighlightCommand, FfmpegLiveThumbnailCommand,
-        FfmpegPosterCommand, FfmpegPreviewSpriteCommand, FinalizeRecordingJobArgs, MediaArtifact,
-        MediaArtifactFile, MediaArtifactKind, MediaArtifactSink, MediaArtifactSinkExt, MediaConfig,
-        MediaConfigError, MediaError, MediaMtxConfig, MediaPlugin, MediaStorage,
-        MediaStorageBackend, MediaStorageConfig, MediaWorkflowDelegate, MediaWorkflowDelegateExt,
-        MediaWorkflowRequest, MediaWorkflows, PREVIEW_CELL_HEIGHT, PREVIEW_CELL_WIDTH,
-        PREVIEW_FRAME_INTERVAL_SECONDS, PREVIEW_SPRITE_COLUMNS, PreviewJobArgs, RecordingConfig,
-        RetentionDefer, S3MediaStorage, StoredObject, ThumbnailJobArgs, TranscodeJobArgs,
-        build_preview_webvtt, media_job_infos, newest_recording_file, newest_recording_files,
+        FfmpegPosterCommand, FfmpegPreviewSpriteCommand, FfmpegRoomCompositeCommand,
+        FinalizeRecordingJobArgs, MediaArtifact, MediaArtifactFile, MediaArtifactKind,
+        MediaArtifactSink, MediaArtifactSinkExt, MediaConfig, MediaConfigError, MediaError,
+        MediaMtxConfig, MediaPlugin, MediaStorage, MediaStorageBackend, MediaStorageConfig,
+        MediaWorkflowDelegate, MediaWorkflowDelegateExt, MediaWorkflowRequest, MediaWorkflows,
+        PREVIEW_CELL_HEIGHT, PREVIEW_CELL_WIDTH, PREVIEW_FRAME_INTERVAL_SECONDS,
+        PREVIEW_SPRITE_COLUMNS, PreviewJobArgs, ROOM_COMPOSITE_CELL_HEIGHT,
+        ROOM_COMPOSITE_CELL_WIDTH, RecordingConfig, RetentionDefer, RoomCompositeJobArgs,
+        S3MediaStorage, StoredObject, ThumbnailJobArgs, TranscodeJobArgs, build_preview_webvtt,
+        media_job_infos, newest_recording_file, newest_recording_files,
         newest_recording_files_since, recording_segments_covering_window, slugify,
     };
     pub use crate::{

--- a/autumn-media-plugin/src/lib.rs
+++ b/autumn-media-plugin/src/lib.rs
@@ -380,6 +380,35 @@ impl Plugin for MediaPlugin {
 
         let retention_days = retention_days.unwrap_or(config.recording.retention_days);
 
+        // The mesh is O(N²), so `DEFAULT_ROOM_MAX_PARTICIPANTS` (6) is an
+        // ABSOLUTE ceiling with no SFU: the `[media.rooms]` config and the
+        // `room_max_participants` builder may set a per-room seat count only
+        // within `1..=6`. An out-of-range value (0 or >6) is a fatal
+        // misconfiguration — fail fast and LOUD at boot, never a silent clamp.
+        // `Plugin::build` returns an `AppBuilder` (not a `Result`), so the
+        // specific error is surfaced from an `on_startup` hook, which aborts
+        // boot with `process::exit(1)` exactly as a failed init would (see
+        // autumn-web's `run_startup_hooks`). `room_max_participants` is the
+        // effective seat count sourced from either `config(..)` (which copies
+        // `rooms.max_participants` into it) or the `room_max_participants(..)`
+        // builder, so this single check covers both the TOML and builder paths;
+        // `InMemoryRoomStore::create_room` re-checks the fixed 6 ceiling as a
+        // defense-in-depth backstop, and `MediaConfig::validate` stays the
+        // opt-in strict check for consumers who validate config up front. The
+        // storage backend keeps its own degrade path below (unchanged), so this
+        // only fails fast on the room cap.
+        if let Some(message) = room_max_participants_error(room_max_participants) {
+            tracing::error!(
+                room_max_participants,
+                ceiling = DEFAULT_ROOM_MAX_PARTICIPANTS,
+                "🍂 Autumn Media: {message}"
+            );
+            return app.on_startup(move |_state| {
+                let message = message.clone();
+                async move { Err(autumn_web::AutumnError::internal_server_error_msg(message)) }
+            });
+        }
+
         tracing::info!(
             broadcast = %enable_broadcast,
             rooms = %enable_rooms,
@@ -475,6 +504,26 @@ impl Plugin for MediaPlugin {
             }
             app
         }
+    }
+}
+
+/// Validate an effective mesh-room seat count against the ABSOLUTE ceiling.
+///
+/// Mesh WebRTC is O(N²), so [`DEFAULT_ROOM_MAX_PARTICIPANTS`] (6) is a hard cap
+/// with no SFU, and a room must seat at least one participant. Returns the
+/// specific, fail-fast error message — naming the offending value and the cap —
+/// when `configured` is outside `1..=6`, or `None` when it is in range.
+fn room_max_participants_error(configured: usize) -> Option<String> {
+    if configured == 0 {
+        Some(format!(
+            "a room must allow at least 1 participant; got {configured}"
+        ))
+    } else if configured > DEFAULT_ROOM_MAX_PARTICIPANTS {
+        Some(format!(
+            "mesh rooms are capped at {DEFAULT_ROOM_MAX_PARTICIPANTS} participants (no SFU); got {configured}"
+        ))
+    } else {
+        None
     }
 }
 
@@ -598,6 +647,58 @@ mod arroyo_shim_tests {
         assert!(plugin.enable_broadcast);
         assert_eq!(plugin.queue, "arroyo-media");
         assert_eq!(plugin.retention_days, Some(30));
+    }
+}
+
+// ── Absolute room-cap enforcement (Fix 1) ───────────────────────────────────
+
+#[cfg(test)]
+mod room_cap_tests {
+    use super::{DEFAULT_ROOM_MAX_PARTICIPANTS, MediaPlugin, room_max_participants_error};
+    use crate::config::MediaConfig;
+
+    #[test]
+    fn out_of_range_room_cap_is_a_specific_fail_fast_error() {
+        // >6 fails loud, naming the offending value and the ceiling — never a
+        // clamp.
+        let over = room_max_participants_error(50).expect("50 > 6 must be rejected");
+        assert!(over.contains("50"), "names the offending value: {over}");
+        assert!(over.contains('6'), "names the ceiling: {over}");
+        assert!(over.contains("no SFU"), "explains why: {over}");
+        // 0 fails loud with its own message.
+        let zero = room_max_participants_error(0).expect("0 must be rejected");
+        assert!(zero.contains("at least 1 participant"), "0 message: {zero}");
+        assert!(zero.contains('0'), "names the value: {zero}");
+    }
+
+    #[test]
+    fn in_range_room_cap_is_accepted() {
+        assert!(room_max_participants_error(1).is_none());
+        assert!(room_max_participants_error(4).is_none());
+        assert!(room_max_participants_error(DEFAULT_ROOM_MAX_PARTICIPANTS).is_none());
+    }
+
+    #[test]
+    fn builder_and_config_paths_feed_the_same_effective_cap_that_boot_rejects() {
+        // The `room_max_participants(50)` builder stores what it was given;
+        // `build()` is what rejects it fail-fast (no clamp), so an out-of-range
+        // builder value produces the specific error at boot.
+        let over = MediaPlugin::new().with_rooms().room_max_participants(50);
+        assert_eq!(over.room_max_participants, 50);
+        assert!(room_max_participants_error(over.room_max_participants).is_some());
+
+        // `room_max_participants(4)` stays in range → a real 4-seat room.
+        let ok = MediaPlugin::new().with_rooms().room_max_participants(4);
+        assert_eq!(ok.room_max_participants, 4);
+        assert!(room_max_participants_error(ok.room_max_participants).is_none());
+
+        // The `[media.rooms] max_participants = 50` config path flows into the
+        // same effective field via `config(..)`, so it is rejected identically.
+        let mut config = MediaConfig::default();
+        config.rooms.max_participants = 50;
+        let from_config = MediaPlugin::new().config(config);
+        assert_eq!(from_config.room_max_participants, 50);
+        assert!(room_max_participants_error(from_config.room_max_participants).is_some());
     }
 }
 

--- a/autumn-media-plugin/src/lib.rs
+++ b/autumn-media-plugin/src/lib.rs
@@ -41,6 +41,7 @@ pub mod config;
 pub mod encode;
 pub mod error;
 pub mod retention;
+pub mod rooms;
 pub mod sink;
 pub mod storage;
 pub mod transport;
@@ -48,7 +49,7 @@ pub mod workflows;
 
 pub use config::{
     MediaConfig, MediaConfigError, MediaMtxConfig, MediaStorageBackend, MediaStorageConfig,
-    RecordingConfig,
+    RecordingConfig, RoomConfig,
 };
 pub use encode::{
     FfmpegClipTailCommand, FfmpegHighlightCommand, FfmpegLiveThumbnailCommand, FfmpegPosterCommand,
@@ -61,6 +62,12 @@ pub use error::MediaError;
 pub use retention::{
     RetentionDefer, RetentionReport, is_expired, recording_expires_at, spawn_retention_sweep_loop,
     sweep_recordings_root, within_root,
+};
+pub use rooms::{
+    InMemoryRoomStore, JoinRecord, JoinRequest, JoinResponse, LeaveRequest, ParticipantView,
+    PublishTarget, RoomError, RoomLeaveResponse, RoomService, RoomSnapshot, RoomStore,
+    SessionToken, SubscribeTarget, room_participant_path, room_route_infos, room_router,
+    validate_room_segment,
 };
 pub use sink::{
     MediaArtifact, MediaArtifactFile, MediaArtifactKind, MediaArtifactSink, MediaArtifactSinkExt,
@@ -94,6 +101,11 @@ pub mod prelude {
         newest_recording_files_since, recording_segments_covering_window, slugify,
     };
     pub use crate::{
+        InMemoryRoomStore, JoinRecord, JoinResponse, ParticipantView, RoomConfig, RoomError,
+        RoomService, RoomSnapshot, RoomStore, SessionToken, room_participant_path,
+        room_route_infos, room_router, validate_room_segment,
+    };
+    pub use crate::{
         IngestStatus, MediaMtxClient, MediaUrls, StreamQualityStats, StreamStatus, ViewerCount,
         duration_seconds_param, ingest_statuses_from_paths_json, quality_stats_from_path_json,
         recording_available, recording_mediamtx_path, stream_status_from_path_json,
@@ -121,8 +133,10 @@ use crate::workflows::MediaWorkflowDelegate as MediaWorkflowDelegateHook;
 /// [`MediaConfig`](config::MediaConfig) with [`config`](Self::config), then
 /// install with `app.plugin(...)`.
 ///
-/// This is the slice-0 skeleton: [`build`](Plugin::build) currently declares no
-/// routes and installs no extensions.
+/// When [`with_rooms`](Self::with_rooms) is enabled, [`build`](Plugin::build)
+/// nests the [`rooms::room_router`] under the API prefix and installs a
+/// [`rooms::RoomService`] extension; the broadcast surface installs the storage
+/// / encode wiring.
 pub struct MediaPlugin {
     /// Resolved `[media]` configuration.
     config: MediaConfig,
@@ -221,10 +235,10 @@ impl MediaPlugin {
     /// after [`Plugin::build`] runs; resolve it up front with
     /// [`MediaConfig::from_autumn_toml`](config::MediaConfig::from_autumn_toml)
     /// or [`MediaConfig::from_arroyo_env`](config::MediaConfig::from_arroyo_env)
-    /// and pass it here. Adopts the config's `room_max_participants`.
+    /// and pass it here. Adopts the config's `rooms.max_participants`.
     #[must_use]
     pub fn config(mut self, config: MediaConfig) -> Self {
-        self.room_max_participants = config.room_max_participants;
+        self.room_max_participants = config.rooms.max_participants;
         self.config = config;
         self
     }
@@ -247,6 +261,22 @@ impl MediaPlugin {
     #[must_use]
     pub const fn room_max_participants(mut self, max: usize) -> Self {
         self.room_max_participants = max;
+        self
+    }
+
+    /// Override the mesh-room session-token lifetime, in seconds (shortcut for
+    /// `config.rooms.token_ttl_seconds`).
+    #[must_use]
+    pub const fn room_token_ttl_seconds(mut self, seconds: u32) -> Self {
+        self.config.rooms.token_ttl_seconds = seconds;
+        self
+    }
+
+    /// Override the mesh-room `MediaMTX` path namespace (shortcut for
+    /// `config.rooms.namespace`).
+    #[must_use]
+    pub fn room_namespace(mut self, namespace: impl Into<String>) -> Self {
+        self.config.rooms.namespace = Some(namespace.into());
         self
     }
 
@@ -360,9 +390,31 @@ impl Plugin for MediaPlugin {
             "🍂 Autumn Media configured"
         );
 
+        // Rooms are storage-independent, so mount the room signaling router and
+        // install the `RoomService` extension up front — they must stay
+        // available even if the storage backend below fails to resolve. The
+        // `nest` + `declare_plugin_routes` pair keeps the room routes both
+        // served and audit-visible under `api_prefix`.
+        let mut app = app;
+        if enable_rooms {
+            let room_service = rooms::RoomService::new(
+                Arc::new(rooms::InMemoryRoomStore::new(room_max_participants)),
+                transport::MediaUrls::from_config(&config.mediamtx),
+                config.rooms.namespace.clone().unwrap_or_default(),
+                chrono::Duration::seconds(i64::from(config.rooms.token_ttl_seconds)),
+                room_max_participants,
+            );
+            app = app
+                .nest(&api_prefix, rooms::room_router())
+                .declare_plugin_routes(rooms::room_route_infos(&api_prefix))
+                .state_initializer(move |state| {
+                    state.insert_extension(room_service);
+                });
+        }
+
         // Resolve the storage backend up front so a misconfiguration surfaces
-        // as one error line here rather than inside a job. On failure we still
-        // register the (empty) route surface, but install no encode wiring.
+        // as one error line here rather than inside a job. On failure the plugin
+        // still serves any mounted room routes, but installs no encode wiring.
         let storage = match storage::MediaStorage::from_config(&config.storage) {
             Ok(storage) => storage,
             Err(error) => {
@@ -370,25 +422,18 @@ impl Plugin for MediaPlugin {
                     %error,
                     "🍂 Autumn Media: storage config invalid; encode workflows disabled"
                 );
-                return app.declare_plugin_routes(media_route_infos(&api_prefix));
+                return app;
             }
         };
 
         let ffmpeg_bin = config.ffmpeg.bin;
         let workflows = workflows::MediaWorkflows::new(ffmpeg_bin, queue.clone());
 
-        // slice 3 (transport/rooms): the `transport` module (MediaMtxClient +
-        //   MediaUrls + status parsers) now exists and is re-exported; its
-        //   AppState extension wiring lands with the consumer slice — insert the
-        //   MediaMtxClient / MediaUrls extensions and
-        //   nest the broadcast + room routers under `api_prefix`.
-        //
         // Extensions are installed via `state_initializer` (not `on_startup`)
         // so they exist BEFORE job workers start — mirroring autumn-web's
         // outbound-webhook plugin, whose manager must be present before the
         // first job runs.
         let app = app
-            .declare_plugin_routes(media_route_infos(&api_prefix))
             .state_initializer(move |state| {
                 state.insert_extension(storage.clone());
                 state.insert_extension(workflows.clone());
@@ -447,15 +492,6 @@ fn arroyo_recordings_root(env: &HashMap<String, String>) -> PathBuf {
             || PathBuf::from(DEFAULT_ARROYO_RECORDINGS_ROOT),
             PathBuf::from,
         )
-}
-
-/// The route metadata `MediaPlugin` declares for `autumn routes` listing.
-///
-/// **Slice 0: empty.** Later slices will fill this in with the broadcast and
-/// room routers' routes under `api_prefix`, kept in sync with what `build`
-/// nests. Extracted so the empty slice-0 declaration is directly testable.
-const fn media_route_infos(_api_prefix: &str) -> Vec<autumn_web::route_listing::RouteInfo> {
-    Vec::new()
 }
 
 // ── Arroyo migration shim (slice 5) ─────────────────────────────────────────
@@ -564,14 +600,12 @@ mod arroyo_shim_tests {
 
 // ── Conformance reference tests ─────────────────────────────────────────────
 //
-// Slice 0's `build()` declares **zero** routes (asserted directly). The
-// conformance harness, however, treats a plugin that declares no routes as a
-// FAIL — it expects every plugin to eventually declare at least one route. So,
-// mirroring `autumn-admin-plugin`'s `conformance_tests`, the harness checks run
-// against a small **representative** future route set attributed to the plugin
-// under `/api/media`: this proves the plugin's naming/prefix conventions are
-// conformance-clean the moment routes land in a later slice, so a later slice
-// that adds routes must consciously keep them conformant.
+// The room signaling routes `MediaPlugin::build` declares under `/api/media`
+// (via `rooms::room_route_infos`) are run through autumn-web's plugin
+// conformance harness — the same checks `autumn-admin-plugin`'s
+// `conformance_tests` uses — so the plugin's naming / prefix / attribution
+// conventions stay clean and a future slice that touches the room routes must
+// consciously keep them conformant.
 
 #[cfg(test)]
 mod conformance_tests {
@@ -582,35 +616,35 @@ mod conformance_tests {
     use autumn_web::route_listing::{RouteInfo, RouteSource};
 
     const PLUGIN_NAME: &str = "autumn-media-plugin";
+    const API_PREFIX: &str = "/api/media";
 
-    /// Slice-0 `MediaPlugin` declares **no** routes.
-    #[test]
-    fn media_plugin_declares_no_routes_in_slice_0() {
-        assert!(
-            super::media_route_infos("/api/media").is_empty(),
-            "slice 0 must declare no routes"
-        );
-    }
-
-    /// A representative route set attributed to the plugin, all under the
-    /// plugin's `/api/media` prefix. Stands in for the routes later slices will
-    /// declare, so the conformance conventions are pinned now.
-    fn representative_routes() -> Vec<RouteInfo> {
-        ["/api/media/broadcasts", "/api/media/rooms"]
+    /// The real room routes `build` declares, attributed to the plugin exactly
+    /// as `declare_plugin_routes` attributes them at runtime.
+    fn declared_room_routes() -> Vec<RouteInfo> {
+        super::rooms::room_route_infos(API_PREFIX)
             .into_iter()
-            .map(|path| RouteInfo {
-                method: "GET".to_owned(),
-                path: path.to_owned(),
-                handler: format!("media::{}", path.rsplit('/').next().unwrap_or("handler")),
-                source: RouteSource::Plugin(PLUGIN_NAME.to_owned()),
-                ..Default::default()
+            .map(|mut route| {
+                route.source = RouteSource::Plugin(PLUGIN_NAME.to_owned());
+                route
             })
             .collect()
     }
 
     #[test]
-    fn representative_routes_are_attributed_to_plugin_name() {
-        let result = check_route_attribution(PLUGIN_NAME, &representative_routes());
+    fn build_declares_the_four_room_routes_when_rooms_enabled() {
+        let routes = super::rooms::room_route_infos(API_PREFIX);
+        assert_eq!(routes.len(), 4, "rooms declare exactly four routes");
+        assert!(
+            routes
+                .iter()
+                .all(|route| route.path.starts_with(API_PREFIX)),
+            "every declared room route lives under the API prefix"
+        );
+    }
+
+    #[test]
+    fn room_routes_are_attributed_to_plugin_name() {
+        let result = check_route_attribution(PLUGIN_NAME, &declared_room_routes());
         assert_eq!(
             result.status,
             CheckStatus::Pass,
@@ -620,8 +654,8 @@ mod conformance_tests {
     }
 
     #[test]
-    fn representative_routes_live_under_api_prefix() {
-        let result = check_route_prefix(PLUGIN_NAME, "/api/media", &[], &representative_routes());
+    fn room_routes_live_under_api_prefix() {
+        let result = check_route_prefix(PLUGIN_NAME, API_PREFIX, &[], &declared_room_routes());
         assert_eq!(
             result.status,
             CheckStatus::Pass,
@@ -631,8 +665,8 @@ mod conformance_tests {
     }
 
     #[test]
-    fn representative_routes_have_no_collisions_in_isolation() {
-        let (result, _) = check_collisions(&representative_routes());
+    fn room_routes_have_no_collisions_in_isolation() {
+        let (result, _) = check_collisions(&declared_room_routes());
         assert_eq!(
             result.status,
             CheckStatus::Pass,
@@ -642,8 +676,8 @@ mod conformance_tests {
     }
 
     #[test]
-    fn representative_routes_have_no_undeclared_sensitive_surfaces() {
-        let result = check_sensitive_surfaces(PLUGIN_NAME, &representative_routes(), &[]);
+    fn room_routes_have_no_undeclared_sensitive_surfaces() {
+        let result = check_sensitive_surfaces(PLUGIN_NAME, &declared_room_routes(), &[]);
         assert_eq!(
             result.status,
             CheckStatus::Pass,
@@ -653,8 +687,8 @@ mod conformance_tests {
     }
 
     #[test]
-    fn representative_single_registration_passes_duplicate_check() {
-        let result = check_duplicate_registration(PLUGIN_NAME, &representative_routes());
+    fn room_single_registration_passes_duplicate_check() {
+        let result = check_duplicate_registration(PLUGIN_NAME, &declared_room_routes());
         assert_eq!(
             result.status,
             CheckStatus::Pass,
@@ -664,9 +698,9 @@ mod conformance_tests {
     }
 
     #[test]
-    fn representative_routes_pass_full_conformance() {
-        let config = ConformanceConfig::new(PLUGIN_NAME).prefix("/api/media");
-        let report = run_conformance(&config, &representative_routes());
+    fn room_routes_pass_full_conformance() {
+        let config = ConformanceConfig::new(PLUGIN_NAME).prefix(API_PREFIX);
+        let report = run_conformance(&config, &declared_room_routes());
         assert!(
             report.passed(),
             "MediaPlugin conformance failed:\n{}",
@@ -677,8 +711,8 @@ mod conformance_tests {
     #[test]
     fn duplicate_registration_detected() {
         // Installing the plugin twice would double its routes → FAIL.
-        let mut routes = representative_routes();
-        routes.extend(representative_routes());
+        let mut routes = declared_room_routes();
+        routes.extend(declared_room_routes());
         let result = check_duplicate_registration(PLUGIN_NAME, &routes);
         assert_eq!(
             result.status,
@@ -691,11 +725,11 @@ mod conformance_tests {
     fn collision_with_host_route_detected() {
         // Sanity check the harness is wired: a host route colliding with a
         // plugin route is flagged.
-        let mut routes = representative_routes();
+        let mut routes = declared_room_routes();
         routes.push(RouteInfo {
             method: "GET".to_owned(),
-            path: "/api/media/broadcasts".to_owned(),
-            handler: "host::list".to_owned(),
+            path: format!("{API_PREFIX}/rooms/{{room_id}}"),
+            handler: "host::roster".to_owned(),
             source: RouteSource::User,
             ..Default::default()
         });

--- a/autumn-media-plugin/src/lib.rs
+++ b/autumn-media-plugin/src/lib.rs
@@ -394,10 +394,18 @@ impl Plugin for MediaPlugin {
         // builder, so this single check covers both the TOML and builder paths;
         // `InMemoryRoomStore::create_room` re-checks the fixed 6 ceiling as a
         // defense-in-depth backstop, and `MediaConfig::validate` stays the
-        // opt-in strict check for consumers who validate config up front. The
-        // storage backend keeps its own degrade path below (unchanged), so this
-        // only fails fast on the room cap.
-        if let Some(message) = room_max_participants_error(room_max_participants) {
+        // opt-in strict check for consumers who validate config up front.
+        //
+        // A configured `room_namespace` is prepended to every room path, so an
+        // invalid one (a slash, a dot segment, whitespace) would likewise mount
+        // the router fine yet make every `POST /rooms` fail `InvalidSegment` —
+        // another config that can never serve a request. It fails fast here too,
+        // via the same `on_startup` abort but its own specific message.
+        // The storage backend keeps its own degrade path below (unchanged), so
+        // this only fails fast on the room cap and room namespace.
+        if let Some(message) = room_max_participants_error(room_max_participants)
+            .or_else(|| room_namespace_error(config.room_namespace.as_deref()))
+        {
             tracing::error!(
                 room_max_participants,
                 ceiling = DEFAULT_ROOM_MAX_PARTICIPANTS,
@@ -525,6 +533,26 @@ fn room_max_participants_error(configured: usize) -> Option<String> {
     } else {
         None
     }
+}
+
+/// Validate a configured mesh-room `MediaMTX` path namespace at boot.
+///
+/// The namespace is prepended to every room / participant `MediaMTX` path, so a
+/// value [`rooms::validate_room_segment`] would reject (a slash, a `.` / `..`
+/// dot segment, whitespace, or other non-`[A-Za-z0-9_-]` label) mounts the
+/// router fine but makes every `POST /rooms` fail with `InvalidSegment` — a
+/// config that can never serve a request must instead refuse to boot. Returns
+/// the specific, fail-fast error message — naming the offending value and the
+/// allowed charset — when the namespace is present-and-invalid, or `None` when
+/// it is absent, empty, or a valid segment.
+fn room_namespace_error(namespace: Option<&str>) -> Option<String> {
+    let ns = namespace?;
+    if ns.is_empty() || rooms::validate_room_segment(ns).is_ok() {
+        return None;
+    }
+    Some(format!(
+        "media.room_namespace {ns:?} is not a valid room path segment: use only ASCII letters, digits, '_' or '-' (no '/', '.', or empty)"
+    ))
 }
 
 /// Recordings root an Arroyo deployment uses when `ARROYO_RECORDINGS_ROOT` is
@@ -701,6 +729,57 @@ mod room_cap_tests {
         let from_config = MediaPlugin::new().config(config);
         assert_eq!(from_config.room_max_participants, 50);
         assert!(room_max_participants_error(from_config.room_max_participants).is_some());
+    }
+}
+
+// ── Room-namespace fail-fast (Fix P2-a) ─────────────────────────────────────
+
+#[cfg(test)]
+mod room_namespace_tests {
+    use super::{MediaPlugin, room_namespace_error};
+
+    #[test]
+    fn absent_empty_and_valid_namespaces_are_accepted() {
+        // Absent and empty mean "no namespace" → no boot error; a valid segment
+        // passes through untouched.
+        assert!(room_namespace_error(None).is_none());
+        assert!(room_namespace_error(Some("")).is_none());
+        assert!(room_namespace_error(Some("tenant-a")).is_none());
+        assert!(room_namespace_error(Some("room_1")).is_none());
+    }
+
+    #[test]
+    fn invalid_namespace_is_a_specific_fail_fast_error() {
+        // A slash, either dot segment, or embedded whitespace fails loud, naming
+        // the offending value and the allowed charset — never a silent mount
+        // that 500s every request.
+        for bad in ["tenant/a", ".", "..", "a b"] {
+            let message = room_namespace_error(Some(bad))
+                .unwrap_or_else(|| panic!("{bad:?} must be rejected"));
+            assert!(
+                message.contains(bad),
+                "names the offending value: {message}"
+            );
+            assert!(
+                message.contains("letters") && message.contains('-'),
+                "mentions the allowed charset: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn room_namespace_builder_feeds_the_effective_value_that_boot_rejects() {
+        // The `room_namespace("tenant/a")` builder stores what it was given;
+        // `build()` is what rejects it fail-fast, so an invalid builder value
+        // produces the specific error at boot.
+        let bad = MediaPlugin::new().with_rooms().room_namespace("tenant/a");
+        assert_eq!(bad.config.room_namespace.as_deref(), Some("tenant/a"));
+        assert!(room_namespace_error(bad.config.room_namespace.as_deref()).is_some());
+
+        // A valid namespace flows through untouched → a real namespaced room.
+        let ok = MediaPlugin::new().with_rooms().room_namespace("tenant-a");
+        assert_eq!(ok.config.room_namespace.as_deref(), Some("tenant-a"));
+        assert!(room_namespace_error(ok.config.room_namespace.as_deref()).is_none());
     }
 }
 

--- a/autumn-media-plugin/src/rooms.rs
+++ b/autumn-media-plugin/src/rooms.rs
@@ -1,0 +1,1206 @@
+//! Small mesh (no-`SFU`) multi-participant call rooms and their `MediaMTX`
+//! `WHIP`/`WHEP` signaling surface.
+//!
+//! A **room** is an ephemeral, in-memory rendezvous: participants join, each
+//! publishes their own `WebRTC` track to a `MediaMTX` path and subscribes to
+//! every *other* participant's path, forming a full mesh. Because the topology
+//! is a mesh, each of `N` participants holds `N - 1` subscriptions —
+//! `O(N * (N - 1))` connections room-wide — so the room is hard-capped at
+//! [`config::DEFAULT_ROOM_MAX_PARTICIPANTS`](crate::config::DEFAULT_ROOM_MAX_PARTICIPANTS)
+//! (6) participants. A selective-forwarding unit (`SFU`) that would lift that
+//! cap is explicitly **out of scope** for this slice.
+//!
+//! # Isolation & `MediaMTX` paths
+//!
+//! Every participant maps to one `MediaMTX` path. The path carries an optional
+//! `namespace` segment so two deployments (or tenants) sharing a `MediaMTX`
+//! never collide:
+//!
+//! - namespace empty → `room/{room_id}/{participant_id}`
+//! - namespace set → `room/{namespace}/{room_id}/{participant_id}`
+//!
+//! `room_id` and `participant_id` are server-minted v4 UUIDs (slug-safe), while
+//! `namespace` is caller/operator-supplied and is the real guard target:
+//! [`validate_room_segment`] rejects empty, `.`, `..`, and any character
+//! outside `[A-Za-z0-9_-]` before a path is composed, so a crafted namespace
+//! can never traverse the `MediaMTX` path space. Room lookups key on the
+//! `(namespace, room_id)` pair and **fail closed**: a request under the wrong
+//! namespace resolves to [`RoomError::RoomNotFound`], never another namespace's
+//! room.
+//!
+//! # Operator requirements
+//!
+//! - **`MediaMTX` path matcher**: this crate ships no `mediamtx.yml` (the
+//!   template lives in the consumer app), so an operator enabling rooms must add
+//!   a `path: "~^room/.+$"` matcher alongside the live `~^live/.+$` one, so
+//!   `MediaMTX` accepts the `room/…` publish/read paths.
+//! - **`CSP`**: an embedding page's `connect-src` must allow the `MediaMTX`
+//!   `WebRTC` origin (`:8889` by default), exactly as the broadcast player does.
+//!
+//! # Single-process limitation
+//!
+//! [`InMemoryRoomStore`] keeps all room state in process memory, so it is
+//! **single-process only** — a multi-process / multi-replica deployment needs a
+//! shared backing store. [`RoomStore`] is the swap seam for that: a networked
+//! (and necessarily async) store would revisit these synchronous signatures.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Serialize, Serializer};
+use thiserror::Error;
+use uuid::Uuid;
+
+use autumn_web::reexports::axum::{
+    Json, Router,
+    extract::{Path, State},
+    routing::{get, post},
+};
+use autumn_web::route_listing::RouteInfo;
+use autumn_web::{AppState, AutumnError, AutumnResult};
+
+use crate::config::DEFAULT_ROOM_MAX_PARTICIPANTS;
+use crate::transport::MediaUrls;
+
+// ── Path segment validation ──────────────────────────────────────────────────
+
+/// Validate one `MediaMTX` room-path segment (namespace / room / participant).
+///
+/// Rejects an empty segment, the dot segments `.` / `..`, and any segment
+/// containing a character outside `[A-Za-z0-9_-]` — the join-within-root
+/// equivalent guard for the transport path surface, so a crafted namespace can
+/// never traverse the `MediaMTX` path space.
+///
+/// # Errors
+///
+/// Returns [`RoomError::InvalidSegment`] for any rejected segment.
+pub fn validate_room_segment(segment: &str) -> Result<(), RoomError> {
+    let ok = !segment.is_empty()
+        && segment != "."
+        && segment != ".."
+        && segment
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-');
+    if ok {
+        Ok(())
+    } else {
+        Err(RoomError::InvalidSegment {
+            value: segment.to_owned(),
+        })
+    }
+}
+
+/// Compose the `MediaMTX` path for a room participant, validating every
+/// caller-influenced segment first.
+///
+/// The namespace is validated only when non-empty (an empty namespace inserts
+/// no segment); `room_id` and `participant_id` are always validated.
+///
+/// # Errors
+///
+/// Returns [`RoomError::InvalidSegment`] when any segment fails
+/// [`validate_room_segment`].
+pub fn room_participant_path(
+    namespace: &str,
+    room_id: &str,
+    participant_id: &str,
+) -> Result<String, RoomError> {
+    validate_room_segment(room_id)?;
+    validate_room_segment(participant_id)?;
+    if namespace.is_empty() {
+        Ok(format!("room/{room_id}/{participant_id}"))
+    } else {
+        validate_room_segment(namespace)?;
+        Ok(format!("room/{namespace}/{room_id}/{participant_id}"))
+    }
+}
+
+// ── Session token ─────────────────────────────────────────────────────────────
+
+/// An opaque, single-use-per-session room token minted for a joining
+/// participant and presented on leave.
+///
+/// The inner value is **never** rendered by [`std::fmt::Debug`] (it prints
+/// `SessionToken("<redacted>")`, mirroring the storage-layer redaction
+/// discipline) so it cannot leak into logs, but it **is** serialized verbatim,
+/// because the join response returns it to the participant that owns it.
+/// Verification is always by value **and** expiry against the stored
+/// participant record, using a constant-time compare.
+#[derive(Clone)]
+pub struct SessionToken(String);
+
+impl SessionToken {
+    /// Mint a fresh random token (a hyphen-free v4 UUID, ~122 bits of entropy).
+    #[must_use]
+    pub fn generate() -> Self {
+        Self(Uuid::new_v4().simple().to_string())
+    }
+
+    /// Borrow the raw token value (for a constant-time verify or to return it
+    /// to the owning participant).
+    #[must_use]
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for SessionToken {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_tuple("SessionToken")
+            .field(&"<redacted>")
+            .finish()
+    }
+}
+
+impl Serialize for SessionToken {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+// ── Errors ────────────────────────────────────────────────────────────────────
+
+/// Errors returned by the room primitive and its [`RoomStore`].
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum RoomError {
+    /// No room exists for the requested `(namespace, room_id)` pair. Also
+    /// returned for a namespace mismatch (rooms never leak across namespaces).
+    #[error("room not found")]
+    RoomNotFound,
+
+    /// The room is already at its participant cap.
+    #[error("room is full (max {max} participants)")]
+    RoomFull {
+        /// The room's participant cap.
+        max: usize,
+    },
+
+    /// No participant with the given id exists in the room.
+    #[error("participant not found")]
+    ParticipantNotFound,
+
+    /// The presented session token was wrong or expired. The message is
+    /// deliberately token-free so it can never echo a secret.
+    #[error("invalid or expired session token")]
+    Unauthorized,
+
+    /// A caller-supplied path segment (namespace / room / participant) was
+    /// invalid (see [`validate_room_segment`]).
+    #[error("invalid room path segment `{value}`")]
+    InvalidSegment {
+        /// The rejected segment (a path label, never a token).
+        value: String,
+    },
+
+    /// A room was requested with a participant cap outside `1..=cap`.
+    #[error("max_participants {requested} is out of range (1..={cap})")]
+    InvalidMaxParticipants {
+        /// The rejected value.
+        requested: usize,
+        /// The hard cap.
+        cap: usize,
+    },
+}
+
+impl RoomError {
+    /// Map this error to an [`AutumnError`] carrying the appropriate HTTP
+    /// status, keeping every message token-free.
+    ///
+    /// This is an inherent method (not a `From` impl) because autumn-web already
+    /// carries a blanket `From<E: std::error::Error>` for [`AutumnError`] that
+    /// would otherwise flatten every `RoomError` to a `500`; mapping explicitly
+    /// preserves the `404`/`409`/`401`/`400` distinctions. Handlers call it via
+    /// `.map_err(RoomError::into_autumn)`.
+    #[must_use]
+    pub fn into_autumn(self) -> AutumnError {
+        match self {
+            Self::RoomNotFound | Self::ParticipantNotFound => {
+                AutumnError::not_found_msg(self.to_string())
+            }
+            // A full room is a genuine conflict (409), distinct from a bad request.
+            Self::RoomFull { .. } => AutumnError::conflict_msg(self.to_string()),
+            Self::Unauthorized => AutumnError::unauthorized_msg(self.to_string()),
+            Self::InvalidSegment { .. } | Self::InvalidMaxParticipants { .. } => {
+                AutumnError::bad_request_msg(self.to_string())
+            }
+        }
+    }
+}
+
+// ── Participant / room state ──────────────────────────────────────────────────
+
+/// One participant in a room (internal state — carries the secret token).
+#[derive(Debug)]
+struct RoomParticipant {
+    id: String,
+    display_name: Option<String>,
+    joined_at: DateTime<Utc>,
+    token: SessionToken,
+    token_expires_at: DateTime<Utc>,
+}
+
+impl RoomParticipant {
+    /// Constant-time-verify a presented token against this participant, treating
+    /// an expired token as a failure. `now` is passed in so verification is
+    /// deterministic under test.
+    fn verify(&self, candidate: &str, now: DateTime<Utc>) -> bool {
+        now < self.token_expires_at
+            && autumn_web::auth::constant_time_eq(
+                candidate.as_bytes(),
+                self.token.expose().as_bytes(),
+            )
+    }
+}
+
+/// A public, token-free view of a participant, safe to serialize into a roster.
+#[derive(Clone, Debug, Serialize)]
+pub struct ParticipantView {
+    /// The participant's id.
+    pub id: String,
+    /// The participant's optional display name.
+    pub display_name: Option<String>,
+    /// When the participant joined.
+    pub joined_at: DateTime<Utc>,
+}
+
+/// A room's public snapshot (never carries a token).
+#[derive(Clone, Debug, Serialize)]
+pub struct RoomSnapshot {
+    /// The room id.
+    pub id: String,
+    /// The room's namespace (omitted from JSON when empty).
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub namespace: String,
+    /// The room's participant cap.
+    pub max_participants: usize,
+    /// When the room was created.
+    pub created_at: DateTime<Utc>,
+    /// The current roster (token-free), ordered by join time then id.
+    pub participants: Vec<ParticipantView>,
+}
+
+/// A room and its live roster (internal state).
+struct Room {
+    id: String,
+    namespace: String,
+    max_participants: usize,
+    created_at: DateTime<Utc>,
+    participants: HashMap<String, RoomParticipant>,
+}
+
+impl Room {
+    fn is_full(&self) -> bool {
+        self.participants.len() >= self.max_participants
+    }
+
+    /// Build a token-free snapshot with a deterministic roster order.
+    fn snapshot(&self) -> RoomSnapshot {
+        let mut participants: Vec<ParticipantView> = self
+            .participants
+            .values()
+            .map(|participant| ParticipantView {
+                id: participant.id.clone(),
+                display_name: participant.display_name.clone(),
+                joined_at: participant.joined_at,
+            })
+            .collect();
+        participants.sort_by(|a, b| a.joined_at.cmp(&b.joined_at).then_with(|| a.id.cmp(&b.id)));
+        RoomSnapshot {
+            id: self.id.clone(),
+            namespace: self.namespace.clone(),
+            max_participants: self.max_participants,
+            created_at: self.created_at,
+            participants,
+        }
+    }
+}
+
+// ── Store seam ────────────────────────────────────────────────────────────────
+
+/// The outcome of a successful join: the minted participant identity plus a
+/// token-free snapshot of the room (transport-agnostic — URL composition lives
+/// in [`RoomService`], never in the store).
+#[derive(Debug)]
+pub struct JoinRecord {
+    /// The minted participant id.
+    pub participant_id: String,
+    /// The minted session token (returned to the joining participant).
+    pub token: SessionToken,
+    /// When the token expires.
+    pub token_expires_at: DateTime<Utc>,
+    /// A snapshot of the room *after* the join (includes the new participant).
+    pub room: RoomSnapshot,
+}
+
+/// The pluggable room-state store — the swap seam for a shared/durable backend.
+///
+/// Every method keys on the `(namespace, room_id)` pair and **fails closed**: a
+/// namespace mismatch resolves to [`RoomError::RoomNotFound`], never another
+/// namespace's room. The signatures are synchronous because the shipped
+/// [`InMemoryRoomStore`] is in-memory; a networked backing store would revisit
+/// them (returning futures).
+pub trait RoomStore: Send + Sync {
+    /// Create a room in `namespace` capped at `max_participants`, returning its
+    /// snapshot.
+    ///
+    /// # Errors
+    ///
+    /// [`RoomError::InvalidSegment`] for an invalid non-empty namespace, and
+    /// [`RoomError::InvalidMaxParticipants`] when the cap exceeds the store's
+    /// hard cap.
+    fn create_room(
+        &self,
+        namespace: &str,
+        max_participants: usize,
+    ) -> Result<RoomSnapshot, RoomError>;
+
+    /// Join the room `(namespace, room_id)`, minting a participant + token that
+    /// stays valid for `token_ttl`.
+    ///
+    /// # Errors
+    ///
+    /// [`RoomError::RoomNotFound`] (including a namespace mismatch) or
+    /// [`RoomError::RoomFull`] when the room is at capacity.
+    fn join_room(
+        &self,
+        namespace: &str,
+        room_id: &str,
+        display_name: Option<String>,
+        token_ttl: Duration,
+    ) -> Result<JoinRecord, RoomError>;
+
+    /// Remove a participant from the room after verifying its token.
+    ///
+    /// # Errors
+    ///
+    /// [`RoomError::RoomNotFound`], [`RoomError::ParticipantNotFound`], or
+    /// [`RoomError::Unauthorized`] on a wrong/expired token.
+    fn leave_room(
+        &self,
+        namespace: &str,
+        room_id: &str,
+        participant_id: &str,
+        token: &str,
+    ) -> Result<(), RoomError>;
+
+    /// Return the current roster snapshot for `(namespace, room_id)`.
+    ///
+    /// # Errors
+    ///
+    /// [`RoomError::RoomNotFound`] (including a namespace mismatch).
+    fn roster(&self, namespace: &str, room_id: &str) -> Result<RoomSnapshot, RoomError>;
+}
+
+/// A single-process, in-memory [`RoomStore`].
+///
+/// Keyed on `(namespace, room_id)` under one `RwLock`. When the last
+/// participant leaves a room, the room is dropped so an idle room never lingers.
+pub struct InMemoryRoomStore {
+    rooms: RwLock<HashMap<(String, String), Room>>,
+    hard_cap: usize,
+}
+
+impl InMemoryRoomStore {
+    /// Create an empty store whose rooms may hold up to `hard_cap` participants.
+    #[must_use]
+    pub fn new(hard_cap: usize) -> Self {
+        Self {
+            rooms: RwLock::new(HashMap::new()),
+            hard_cap,
+        }
+    }
+}
+
+impl Default for InMemoryRoomStore {
+    fn default() -> Self {
+        Self::new(DEFAULT_ROOM_MAX_PARTICIPANTS)
+    }
+}
+
+impl RoomStore for InMemoryRoomStore {
+    fn create_room(
+        &self,
+        namespace: &str,
+        max_participants: usize,
+    ) -> Result<RoomSnapshot, RoomError> {
+        if !namespace.is_empty() {
+            validate_room_segment(namespace)?;
+        }
+        if max_participants > self.hard_cap {
+            return Err(RoomError::InvalidMaxParticipants {
+                requested: max_participants,
+                cap: self.hard_cap,
+            });
+        }
+        // Clamp the lower bound: a 0 cap is meaningless, so a room always seats
+        // at least one participant.
+        let max_participants = max_participants.max(1);
+        let id = Uuid::new_v4().to_string();
+        let room = Room {
+            id: id.clone(),
+            namespace: namespace.to_owned(),
+            max_participants,
+            created_at: Utc::now(),
+            participants: HashMap::new(),
+        };
+        let snapshot = room.snapshot();
+        self.rooms
+            .write()
+            .expect("room store lock poisoned")
+            .insert((namespace.to_owned(), id), room);
+        Ok(snapshot)
+    }
+
+    fn join_room(
+        &self,
+        namespace: &str,
+        room_id: &str,
+        display_name: Option<String>,
+        token_ttl: Duration,
+    ) -> Result<JoinRecord, RoomError> {
+        let mut rooms = self.rooms.write().expect("room store lock poisoned");
+        let room = rooms
+            .get_mut(&(namespace.to_owned(), room_id.to_owned()))
+            .ok_or(RoomError::RoomNotFound)?;
+        if room.is_full() {
+            return Err(RoomError::RoomFull {
+                max: room.max_participants,
+            });
+        }
+        let now = Utc::now();
+        let participant_id = Uuid::new_v4().to_string();
+        let token = SessionToken::generate();
+        let token_expires_at = now + token_ttl;
+        room.participants.insert(
+            participant_id.clone(),
+            RoomParticipant {
+                id: participant_id.clone(),
+                display_name,
+                joined_at: now,
+                token: token.clone(),
+                token_expires_at,
+            },
+        );
+        let snapshot = room.snapshot();
+        drop(rooms);
+        Ok(JoinRecord {
+            participant_id,
+            token,
+            token_expires_at,
+            room: snapshot,
+        })
+    }
+
+    fn leave_room(
+        &self,
+        namespace: &str,
+        room_id: &str,
+        participant_id: &str,
+        token: &str,
+    ) -> Result<(), RoomError> {
+        let mut rooms = self.rooms.write().expect("room store lock poisoned");
+        let key = (namespace.to_owned(), room_id.to_owned());
+        let room = rooms.get_mut(&key).ok_or(RoomError::RoomNotFound)?;
+        let participant = room
+            .participants
+            .get(participant_id)
+            .ok_or(RoomError::ParticipantNotFound)?;
+        if !participant.verify(token, Utc::now()) {
+            return Err(RoomError::Unauthorized);
+        }
+        room.participants.remove(participant_id);
+        // Drop an emptied room so idle rooms never accumulate.
+        let now_empty = room.participants.is_empty();
+        if now_empty {
+            rooms.remove(&key);
+        }
+        drop(rooms);
+        Ok(())
+    }
+
+    fn roster(&self, namespace: &str, room_id: &str) -> Result<RoomSnapshot, RoomError> {
+        self.rooms
+            .read()
+            .expect("room store lock poisoned")
+            .get(&(namespace.to_owned(), room_id.to_owned()))
+            .map(Room::snapshot)
+            .ok_or(RoomError::RoomNotFound)
+    }
+}
+
+// ── Service (URL composition + AppState extension) ────────────────────────────
+
+/// A participant's own publish target.
+#[derive(Clone, Debug, Serialize)]
+pub struct PublishTarget {
+    /// The `MediaMTX` path the participant publishes to.
+    pub path: String,
+    /// The `WHIP` publish URL for that path.
+    pub whip_url: String,
+}
+
+/// A subscribe target for one *other* participant in the mesh.
+#[derive(Clone, Debug, Serialize)]
+pub struct SubscribeTarget {
+    /// The peer participant's id.
+    pub participant_id: String,
+    /// The peer's `MediaMTX` path.
+    pub path: String,
+    /// The `WHEP` read (subscribe) URL for that path.
+    pub whep_url: String,
+}
+
+/// The full result of a join: identity, token, and the mesh transport targets.
+#[derive(Debug, Serialize)]
+pub struct JoinResponse {
+    /// The minted participant id.
+    pub participant_id: String,
+    /// The minted session token (returned only to the joining participant).
+    pub session_token: SessionToken,
+    /// When the token expires.
+    pub token_expires_at: DateTime<Utc>,
+    /// The participant's own publish target.
+    pub publish: PublishTarget,
+    /// One subscribe target per *other* participant (the mesh).
+    pub subscribe: Vec<SubscribeTarget>,
+    /// A token-free snapshot of the room after the join.
+    pub room: RoomSnapshot,
+}
+
+/// The programmatic room API installed on `AppState`.
+///
+/// Owns the [`RoomStore`] plus the [`MediaUrls`] used to compose each
+/// participant's `WHIP`/`WHEP` URLs, and carries the deployment's namespace,
+/// token TTL, and participant cap. `Clone` is cheap (the store is an `Arc`),
+/// mirroring how [`MediaWorkflows`](crate::workflows::MediaWorkflows) is
+/// installed and read.
+#[derive(Clone)]
+pub struct RoomService {
+    store: Arc<dyn RoomStore>,
+    urls: MediaUrls,
+    namespace: String,
+    token_ttl: Duration,
+    max_participants: usize,
+}
+
+impl RoomService {
+    /// Build a room service.
+    #[must_use]
+    pub fn new(
+        store: Arc<dyn RoomStore>,
+        urls: MediaUrls,
+        namespace: impl Into<String>,
+        token_ttl: Duration,
+        max_participants: usize,
+    ) -> Self {
+        Self {
+            store,
+            urls,
+            namespace: namespace.into(),
+            token_ttl,
+            max_participants,
+        }
+    }
+
+    /// The configured namespace (empty string = none).
+    #[must_use]
+    pub fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    /// Create a new room under the service's namespace and participant cap.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any [`RoomError`] from the store.
+    pub fn create(&self) -> Result<RoomSnapshot, RoomError> {
+        self.store
+            .create_room(&self.namespace, self.max_participants)
+    }
+
+    /// Join `room_id`, composing the joiner's publish target and one subscribe
+    /// target per existing participant (the mesh).
+    ///
+    /// # Errors
+    ///
+    /// Propagates any [`RoomError`] from the store, or
+    /// [`RoomError::InvalidSegment`] if a path cannot be composed.
+    pub fn join(
+        &self,
+        room_id: &str,
+        display_name: Option<String>,
+    ) -> Result<JoinResponse, RoomError> {
+        let record =
+            self.store
+                .join_room(&self.namespace, room_id, display_name, self.token_ttl)?;
+
+        let publish_path = room_participant_path(&self.namespace, room_id, &record.participant_id)?;
+        let publish = PublishTarget {
+            whip_url: self.urls.whip_publish_url_for_path(&publish_path),
+            path: publish_path,
+        };
+
+        let mut subscribe = Vec::new();
+        for peer in &record.room.participants {
+            if peer.id == record.participant_id {
+                continue;
+            }
+            let peer_path = room_participant_path(&self.namespace, room_id, &peer.id)?;
+            subscribe.push(SubscribeTarget {
+                participant_id: peer.id.clone(),
+                whep_url: self.urls.whep_read_url(&peer_path),
+                path: peer_path,
+            });
+        }
+
+        Ok(JoinResponse {
+            participant_id: record.participant_id,
+            session_token: record.token,
+            token_expires_at: record.token_expires_at,
+            publish,
+            subscribe,
+            room: record.room,
+        })
+    }
+
+    /// Leave `room_id` as `participant_id`, verifying `token`.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any [`RoomError`] from the store.
+    pub fn leave(&self, room_id: &str, participant_id: &str, token: &str) -> Result<(), RoomError> {
+        self.store
+            .leave_room(&self.namespace, room_id, participant_id, token)
+    }
+
+    /// Return the roster for `room_id`.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any [`RoomError`] from the store.
+    pub fn roster(&self, room_id: &str) -> Result<RoomSnapshot, RoomError> {
+        self.store.roster(&self.namespace, room_id)
+    }
+}
+
+// ── HTTP surface ──────────────────────────────────────────────────────────────
+
+/// Body of a room-join request.
+#[derive(Debug, serde::Deserialize)]
+pub struct JoinRequest {
+    /// Optional display name for the joining participant.
+    #[serde(default)]
+    pub display_name: Option<String>,
+}
+
+/// Body of a room-leave request.
+#[derive(Debug, serde::Deserialize)]
+pub struct LeaveRequest {
+    /// The participant id being removed.
+    pub participant_id: String,
+    /// The session token minted at join time.
+    pub session_token: String,
+}
+
+/// Resolve the installed [`RoomService`] or fail with a `500`.
+fn room_service(state: &AppState) -> AutumnResult<Arc<RoomService>> {
+    state.extension::<RoomService>().ok_or_else(|| {
+        AutumnError::internal_server_error_msg("RoomService extension is not installed")
+    })
+}
+
+/// `POST {prefix}/rooms` — create a room.
+async fn rooms_create(State(state): State<AppState>) -> AutumnResult<Json<RoomSnapshot>> {
+    let snapshot = room_service(&state)?
+        .create()
+        .map_err(RoomError::into_autumn)?;
+    Ok(Json(snapshot))
+}
+
+/// `POST {prefix}/rooms/{room_id}/join` — join a room.
+async fn rooms_join(
+    State(state): State<AppState>,
+    Path(room_id): Path<String>,
+    Json(body): Json<JoinRequest>,
+) -> AutumnResult<Json<JoinResponse>> {
+    let response = room_service(&state)?
+        .join(&room_id, body.display_name)
+        .map_err(RoomError::into_autumn)?;
+    Ok(Json(response))
+}
+
+/// `POST {prefix}/rooms/{room_id}/leave` — leave a room.
+async fn rooms_leave(
+    State(state): State<AppState>,
+    Path(room_id): Path<String>,
+    Json(body): Json<LeaveRequest>,
+) -> AutumnResult<Json<RoomLeaveResponse>> {
+    room_service(&state)?
+        .leave(&room_id, &body.participant_id, &body.session_token)
+        .map_err(RoomError::into_autumn)?;
+    Ok(Json(RoomLeaveResponse { left: true }))
+}
+
+/// `GET {prefix}/rooms/{room_id}` — the room roster.
+async fn rooms_roster(
+    State(state): State<AppState>,
+    Path(room_id): Path<String>,
+) -> AutumnResult<Json<RoomSnapshot>> {
+    let snapshot = room_service(&state)?
+        .roster(&room_id)
+        .map_err(RoomError::into_autumn)?;
+    Ok(Json(snapshot))
+}
+
+/// Acknowledgement returned by a successful leave.
+#[derive(Debug, Serialize)]
+pub struct RoomLeaveResponse {
+    /// Always `true` — the participant was removed.
+    pub left: bool,
+}
+
+/// The room signaling router (nested under the plugin's API prefix in
+/// [`MediaPlugin::build`](crate::MediaPlugin)).
+pub fn room_router() -> Router<AppState> {
+    Router::new()
+        .route("/rooms", post(rooms_create))
+        .route("/rooms/{room_id}/join", post(rooms_join))
+        .route("/rooms/{room_id}/leave", post(rooms_leave))
+        .route("/rooms/{room_id}", get(rooms_roster))
+}
+
+/// The [`RouteInfo`] set the room router serves under `api_prefix`, for
+/// `autumn routes` listing / conformance.
+#[must_use]
+pub fn room_route_infos(api_prefix: &str) -> Vec<RouteInfo> {
+    let prefix = api_prefix.trim_end_matches('/');
+    vec![
+        room_route("POST", format!("{prefix}/rooms"), "rooms::rooms_create"),
+        room_route(
+            "POST",
+            format!("{prefix}/rooms/{{room_id}}/join"),
+            "rooms::rooms_join",
+        ),
+        room_route(
+            "POST",
+            format!("{prefix}/rooms/{{room_id}}/leave"),
+            "rooms::rooms_leave",
+        ),
+        room_route(
+            "GET",
+            format!("{prefix}/rooms/{{room_id}}"),
+            "rooms::rooms_roster",
+        ),
+    ]
+}
+
+/// Build one plugin [`RouteInfo`] (source is overwritten by
+/// `declare_plugin_routes` with the plugin attribution).
+fn room_route(method: &str, path: String, handler: &str) -> RouteInfo {
+    RouteInfo {
+        method: method.to_owned(),
+        path,
+        handler: handler.to_owned(),
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        InMemoryRoomStore, JoinRequest, RoomError, RoomService, RoomStore, SessionToken,
+        room_participant_path, room_route_infos, rooms_create, rooms_join, rooms_roster,
+        validate_room_segment,
+    };
+    use crate::config::MediaMtxConfig;
+    use crate::transport::MediaUrls;
+    use autumn_web::AppState;
+    use autumn_web::reexports::axum::extract::{Path, State};
+    use chrono::{Duration, Utc};
+    use std::sync::Arc;
+
+    // ── Fixtures ─────────────────────────────────────────────────────────────
+
+    fn urls() -> MediaUrls {
+        MediaUrls::from_config(&MediaMtxConfig::default())
+    }
+
+    fn service(namespace: &str) -> RoomService {
+        RoomService::new(
+            Arc::new(InMemoryRoomStore::new(6)),
+            urls(),
+            namespace,
+            Duration::seconds(300),
+            6,
+        )
+    }
+
+    // ── Segment guard ────────────────────────────────────────────────────────
+
+    #[test]
+    fn segment_guard_accepts_uuid_and_normal_labels_rejects_traversal() {
+        assert!(validate_room_segment("tenant-a").is_ok());
+        assert!(validate_room_segment("a1b2_c3-d4").is_ok());
+        assert!(validate_room_segment(&uuid::Uuid::new_v4().to_string()).is_ok());
+        for bad in ["", ".", "..", "a/b", "a b", "a.b", "a%2e", "café"] {
+            assert!(
+                matches!(
+                    validate_room_segment(bad),
+                    Err(RoomError::InvalidSegment { .. })
+                ),
+                "segment {bad:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn participant_path_scheme_with_and_without_namespace() {
+        assert_eq!(
+            room_participant_path("", "room1", "part1").unwrap(),
+            "room/room1/part1"
+        );
+        assert_eq!(
+            room_participant_path("tenant-a", "room1", "part1").unwrap(),
+            "room/tenant-a/room1/part1"
+        );
+        // A traversal namespace never composes a path.
+        assert!(matches!(
+            room_participant_path("..", "room1", "part1"),
+            Err(RoomError::InvalidSegment { .. })
+        ));
+    }
+
+    #[test]
+    fn room_error_maps_to_expected_http_status() {
+        use autumn_web::reexports::http::StatusCode;
+        assert_eq!(
+            RoomError::RoomNotFound.into_autumn().status(),
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(
+            RoomError::ParticipantNotFound.into_autumn().status(),
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(
+            RoomError::RoomFull { max: 6 }.into_autumn().status(),
+            StatusCode::CONFLICT
+        );
+        assert_eq!(
+            RoomError::Unauthorized.into_autumn().status(),
+            StatusCode::UNAUTHORIZED
+        );
+        assert_eq!(
+            RoomError::InvalidSegment {
+                value: "..".to_owned()
+            }
+            .into_autumn()
+            .status(),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            RoomError::InvalidMaxParticipants {
+                requested: 9,
+                cap: 6
+            }
+            .into_autumn()
+            .status(),
+            StatusCode::BAD_REQUEST
+        );
+    }
+
+    // ── Session token ────────────────────────────────────────────────────────
+
+    #[test]
+    fn session_token_debug_is_redacted() {
+        let token = SessionToken::generate();
+        let raw = token.expose().to_owned();
+        assert!(!raw.is_empty());
+        let rendered = format!("{token:?}");
+        assert!(
+            !rendered.contains(&raw),
+            "raw token must not appear in Debug: {rendered}"
+        );
+        assert!(rendered.contains("<redacted>"), "Debug: {rendered}");
+    }
+
+    #[test]
+    fn session_token_serializes_the_real_value() {
+        let token = SessionToken::generate();
+        let json = serde_json::to_string(&token).unwrap();
+        assert_eq!(json, format!("\"{}\"", token.expose()));
+    }
+
+    // ── Create / cap ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn create_room_mints_uuid_id_and_clamps_and_rejects_cap() {
+        let store = InMemoryRoomStore::new(6);
+        let snapshot = store.create_room("", 4).unwrap();
+        assert_eq!(uuid::Uuid::parse_str(&snapshot.id).map(|_| ()), Ok(()));
+        assert_eq!(snapshot.max_participants, 4);
+        assert!(snapshot.participants.is_empty());
+
+        // A 0 cap clamps up to 1 (a room always seats at least one).
+        assert_eq!(store.create_room("", 0).unwrap().max_participants, 1);
+
+        // Above the hard cap → rejected.
+        assert!(matches!(
+            store.create_room("", 7),
+            Err(RoomError::InvalidMaxParticipants {
+                requested: 7,
+                cap: 6
+            })
+        ));
+    }
+
+    // ── Join / mesh URLs / cap enforcement ───────────────────────────────────
+
+    #[test]
+    fn join_mints_token_and_composes_publish_and_subscribe_urls() {
+        let service = service("tenant-a");
+        let room = service.create().unwrap();
+
+        let first = service.join(&room.id, Some("Ada".to_owned())).unwrap();
+        assert!(first.subscribe.is_empty(), "first joiner sees no peers");
+        // Publish path + exact WHIP URL for the joiner's own path.
+        let publish_path = format!("room/tenant-a/{}/{}", room.id, first.participant_id);
+        assert_eq!(first.publish.path, publish_path);
+        assert_eq!(
+            first.publish.whip_url,
+            format!("http://127.0.0.1:8889/{publish_path}/whip")
+        );
+        assert!(!first.session_token.expose().is_empty());
+
+        // A second joiner now subscribes to the first (mesh).
+        let second = service.join(&room.id, Some("Grace".to_owned())).unwrap();
+        assert_eq!(second.subscribe.len(), 1);
+        let peer = &second.subscribe[0];
+        assert_eq!(peer.participant_id, first.participant_id);
+        let peer_path = format!("room/tenant-a/{}/{}", room.id, first.participant_id);
+        assert_eq!(peer.path, peer_path);
+        assert_eq!(
+            peer.whep_url,
+            format!("http://127.0.0.1:8889/{peer_path}/whep")
+        );
+        assert_eq!(second.room.participants.len(), 2);
+    }
+
+    #[test]
+    fn join_enforces_participant_cap() {
+        let service = RoomService::new(
+            Arc::new(InMemoryRoomStore::new(6)),
+            urls(),
+            "",
+            Duration::seconds(300),
+            6,
+        );
+        let room = service.create().unwrap();
+        for _ in 0..6 {
+            service.join(&room.id, None).unwrap();
+        }
+        // The 7th join exceeds the cap.
+        assert!(matches!(
+            service.join(&room.id, None),
+            Err(RoomError::RoomFull { max: 6 })
+        ));
+    }
+
+    // ── Fail-closed namespace isolation ──────────────────────────────────────
+
+    #[test]
+    fn rooms_never_leak_across_namespaces() {
+        let store = Arc::new(InMemoryRoomStore::new(6));
+        let ns_a = RoomService::new(store.clone(), urls(), "a", Duration::seconds(300), 6);
+        let ns_b = RoomService::new(store, urls(), "b", Duration::seconds(300), 6);
+
+        let room = ns_a.create().unwrap();
+        // The same store, but namespace "b" cannot see namespace "a"'s room.
+        assert!(matches!(
+            ns_b.roster(&room.id),
+            Err(RoomError::RoomNotFound)
+        ));
+        assert!(matches!(
+            ns_b.join(&room.id, None),
+            Err(RoomError::RoomNotFound)
+        ));
+        // The owning namespace still resolves it.
+        assert!(ns_a.roster(&room.id).is_ok());
+    }
+
+    // ── Token verification (correct / wrong / expired) ───────────────────────
+
+    #[test]
+    fn participant_verify_matches_only_unexpired_correct_token() {
+        use super::RoomParticipant;
+        let now = Utc::now();
+        let participant = RoomParticipant {
+            id: "p1".to_owned(),
+            display_name: None,
+            joined_at: now,
+            token: SessionToken("secret-token-value".to_owned()),
+            token_expires_at: now + Duration::seconds(300),
+        };
+        assert!(participant.verify("secret-token-value", now));
+        assert!(!participant.verify("wrong-token", now), "wrong token fails");
+        // Past the expiry, even the correct token fails.
+        assert!(
+            !participant.verify("secret-token-value", now + Duration::seconds(301)),
+            "expired token fails"
+        );
+    }
+
+    #[test]
+    fn leave_rejects_wrong_and_expired_tokens_then_accepts_correct() {
+        // Expired: join with a negative TTL so the token is already expired.
+        let expired = RoomService::new(
+            Arc::new(InMemoryRoomStore::new(6)),
+            urls(),
+            "",
+            Duration::seconds(-10),
+            6,
+        );
+        let room = expired.create().unwrap();
+        let joined = expired.join(&room.id, None).unwrap();
+        assert!(matches!(
+            expired.leave(
+                &room.id,
+                &joined.participant_id,
+                joined.session_token.expose()
+            ),
+            Err(RoomError::Unauthorized)
+        ));
+
+        // Valid TTL: wrong token rejected, correct token accepted.
+        let service = service("");
+        let room = service.create().unwrap();
+        let joined = service.join(&room.id, None).unwrap();
+        assert!(matches!(
+            service.leave(&room.id, &joined.participant_id, "not-the-token"),
+            Err(RoomError::Unauthorized)
+        ));
+        assert!(
+            service
+                .leave(
+                    &room.id,
+                    &joined.participant_id,
+                    joined.session_token.expose()
+                )
+                .is_ok()
+        );
+        // Emptying the room drops it.
+        assert!(matches!(
+            service.roster(&room.id),
+            Err(RoomError::RoomNotFound)
+        ));
+    }
+
+    // ── Roster serialization excludes tokens ─────────────────────────────────
+
+    #[test]
+    fn roster_snapshot_json_never_carries_tokens() {
+        let service = service("tenant-a");
+        let room = service.create().unwrap();
+        let joined = service.join(&room.id, Some("Ada".to_owned())).unwrap();
+        let snapshot = service.roster(&room.id).unwrap();
+        let json = serde_json::to_string(&snapshot).unwrap();
+        assert!(
+            !json.contains(joined.session_token.expose()),
+            "roster json leaked a token: {json}"
+        );
+        assert!(
+            !json.contains("token"),
+            "roster json has a token field: {json}"
+        );
+        assert!(json.contains("\"namespace\":\"tenant-a\""));
+        assert!(json.contains("Ada"));
+    }
+
+    #[test]
+    fn empty_namespace_is_omitted_from_snapshot_json() {
+        let service = service("");
+        let room = service.create().unwrap();
+        let json = serde_json::to_string(&service.roster(&room.id).unwrap()).unwrap();
+        assert!(
+            !json.contains("namespace"),
+            "empty namespace must be omitted: {json}"
+        );
+    }
+
+    // ── Route metadata ───────────────────────────────────────────────────────
+
+    #[test]
+    fn room_route_infos_cover_the_four_routes_under_prefix() {
+        let infos = room_route_infos("/api/media");
+        let pairs: Vec<(&str, &str)> = infos
+            .iter()
+            .map(|info| (info.method.as_str(), info.path.as_str()))
+            .collect();
+        assert_eq!(
+            pairs,
+            vec![
+                ("POST", "/api/media/rooms"),
+                ("POST", "/api/media/rooms/{room_id}/join"),
+                ("POST", "/api/media/rooms/{room_id}/leave"),
+                ("GET", "/api/media/rooms/{room_id}"),
+            ]
+        );
+        // A trailing slash on the prefix does not double up.
+        assert_eq!(room_route_infos("/api/media/")[0].path, "/api/media/rooms");
+    }
+
+    // ── Handler round-trip (create → join → roster through RoomService ext) ──
+
+    #[tokio::test]
+    async fn handlers_round_trip_create_join_roster() {
+        let state = AppState::for_test();
+        state.insert_extension(service("tenant-a"));
+
+        // Create.
+        let created = rooms_create(State(state.clone())).await.expect("create").0;
+        assert!(created.participants.is_empty());
+        let room_id = created.id.clone();
+
+        // Join.
+        let joined = rooms_join(
+            State(state.clone()),
+            Path(room_id.clone()),
+            axum_json(JoinRequest {
+                display_name: Some("Ada".to_owned()),
+            }),
+        )
+        .await
+        .expect("join")
+        .0;
+        assert!(!joined.session_token.expose().is_empty());
+        assert!(!joined.participant_id.is_empty());
+
+        // Roster reflects the join.
+        let roster = rooms_roster(State(state.clone()), Path(room_id))
+            .await
+            .expect("roster")
+            .0;
+        assert_eq!(roster.participants.len(), 1);
+        assert_eq!(roster.participants[0].id, joined.participant_id);
+    }
+
+    #[tokio::test]
+    async fn handler_missing_service_extension_is_500() {
+        let state = AppState::for_test();
+        let err = rooms_create(State(state)).await.expect_err("no ext → 500");
+        assert_eq!(
+            err.status(),
+            autumn_web::reexports::http::StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
+    /// Wrap a value in an axum `Json` extractor for direct handler calls.
+    fn axum_json<T>(value: T) -> autumn_web::reexports::axum::Json<T> {
+        autumn_web::reexports::axum::Json(value)
+    }
+}

--- a/autumn-media-plugin/src/rooms.rs
+++ b/autumn-media-plugin/src/rooms.rs
@@ -349,11 +349,16 @@ pub trait RoomStore: Send + Sync {
     /// Create a room in `namespace` capped at `max_participants`, returning its
     /// snapshot.
     ///
+    /// `max_participants` must be within `1..=`
+    /// [`DEFAULT_ROOM_MAX_PARTICIPANTS`](crate::config::DEFAULT_ROOM_MAX_PARTICIPANTS)
+    /// — 6 is the absolute mesh ceiling (no SFU), a per-room seat count is
+    /// configurable only within that range, and `0` is nonsense.
+    ///
     /// # Errors
     ///
     /// [`RoomError::InvalidSegment`] for an invalid non-empty namespace, and
-    /// [`RoomError::InvalidMaxParticipants`] when the cap exceeds the store's
-    /// hard cap.
+    /// [`RoomError::InvalidMaxParticipants`] when `max_participants` is `0` or
+    /// exceeds the absolute ceiling.
     fn create_room(
         &self,
         namespace: &str,
@@ -408,6 +413,13 @@ pub struct InMemoryRoomStore {
 
 impl InMemoryRoomStore {
     /// Create an empty store whose rooms may hold up to `hard_cap` participants.
+    ///
+    /// `hard_cap` is further bounded by the absolute mesh ceiling: a room can
+    /// never seat more than
+    /// [`DEFAULT_ROOM_MAX_PARTICIPANTS`](crate::config::DEFAULT_ROOM_MAX_PARTICIPANTS)
+    /// (6, no SFU) regardless of `hard_cap`, so with a larger `hard_cap`
+    /// [`create_room`](RoomStore::create_room) still rejects any request above 6
+    /// as a backstop.
     #[must_use]
     pub fn new(hard_cap: usize) -> Self {
         Self {
@@ -432,15 +444,18 @@ impl RoomStore for InMemoryRoomStore {
         if !namespace.is_empty() {
             validate_room_segment(namespace)?;
         }
-        if max_participants > self.hard_cap {
+        // The mesh is O(N²), so the absolute ceiling is a fixed
+        // `DEFAULT_ROOM_MAX_PARTICIPANTS` (6) — enforced here structurally, so
+        // this backstop stays non-vacuous even if a larger `hard_cap` slipped
+        // past the builder/config clamp. A 0-seat room is nonsense. Both are
+        // rejected outright (no lower clamp).
+        let ceiling = self.hard_cap.min(DEFAULT_ROOM_MAX_PARTICIPANTS);
+        if max_participants == 0 || max_participants > ceiling {
             return Err(RoomError::InvalidMaxParticipants {
                 requested: max_participants,
-                cap: self.hard_cap,
+                cap: ceiling,
             });
         }
-        // Clamp the lower bound: a 0 cap is meaningless, so a room always seats
-        // at least one participant.
-        let max_participants = max_participants.max(1);
         let id = Uuid::new_v4().to_string();
         let room = Room {
             id: id.clone(),
@@ -700,12 +715,27 @@ pub struct JoinRequest {
 }
 
 /// Body of a room-leave request.
-#[derive(Debug, serde::Deserialize)]
+///
+/// [`std::fmt::Debug`] renders `participant_id` verbatim but redacts
+/// `session_token` (it prints `<redacted>`, mirroring [`SessionToken`] and the
+/// storage-layer redaction discipline) so a request body cannot leak the secret
+/// into logs.
+#[derive(serde::Deserialize)]
 pub struct LeaveRequest {
     /// The participant id being removed.
     pub participant_id: String,
     /// The session token minted at join time.
     pub session_token: String,
+}
+
+impl std::fmt::Debug for LeaveRequest {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("LeaveRequest")
+            .field("participant_id", &self.participant_id)
+            .field("session_token", &"<redacted>")
+            .finish()
+    }
 }
 
 /// Resolve the installed [`RoomService`] or fail with a `500`.
@@ -814,9 +844,9 @@ fn room_route(method: &str, path: String, handler: &str) -> RouteInfo {
 #[cfg(test)]
 mod tests {
     use super::{
-        InMemoryRoomStore, JoinRequest, RoomError, RoomService, RoomStore, SessionToken,
-        room_participant_path, room_route_infos, rooms_create, rooms_join, rooms_roster,
-        validate_room_segment,
+        InMemoryRoomStore, JoinRequest, LeaveRequest, RoomError, RoomService, RoomStore,
+        SessionToken, room_participant_path, room_route_infos, rooms_create, rooms_join,
+        rooms_roster, validate_room_segment,
     };
     use crate::config::MediaMtxConfig;
     use crate::transport::MediaUrls;
@@ -930,6 +960,24 @@ mod tests {
     }
 
     #[test]
+    fn leave_request_debug_redacts_session_token() {
+        let req = LeaveRequest {
+            participant_id: "part-123".to_owned(),
+            session_token: "super-secret-token-value".to_owned(),
+        };
+        let rendered = format!("{req:?}");
+        assert!(
+            !rendered.contains("super-secret-token-value"),
+            "raw token must not appear in Debug: {rendered}"
+        );
+        assert!(
+            rendered.contains("part-123"),
+            "participant id must appear: {rendered}"
+        );
+        assert!(rendered.contains("<redacted>"), "Debug: {rendered}");
+    }
+
+    #[test]
     fn session_token_serializes_the_real_value() {
         let token = SessionToken::generate();
         let json = serde_json::to_string(&token).unwrap();
@@ -939,17 +987,23 @@ mod tests {
     // ── Create / cap ─────────────────────────────────────────────────────────
 
     #[test]
-    fn create_room_mints_uuid_id_and_clamps_and_rejects_cap() {
+    fn create_room_mints_uuid_id_and_rejects_out_of_range_cap() {
         let store = InMemoryRoomStore::new(6);
         let snapshot = store.create_room("", 4).unwrap();
         assert_eq!(uuid::Uuid::parse_str(&snapshot.id).map(|_| ()), Ok(()));
         assert_eq!(snapshot.max_participants, 4);
         assert!(snapshot.participants.is_empty());
 
-        // A 0 cap clamps up to 1 (a room always seats at least one).
-        assert_eq!(store.create_room("", 0).unwrap().max_participants, 1);
+        // A 0-seat room is nonsense → rejected (never clamped up to 1).
+        assert!(matches!(
+            store.create_room("", 0),
+            Err(RoomError::InvalidMaxParticipants {
+                requested: 0,
+                cap: 6
+            })
+        ));
 
-        // Above the hard cap → rejected.
+        // Above the absolute ceiling → rejected.
         assert!(matches!(
             store.create_room("", 7),
             Err(RoomError::InvalidMaxParticipants {
@@ -957,6 +1011,23 @@ mod tests {
                 cap: 6
             })
         ));
+    }
+
+    #[test]
+    fn create_room_backstops_the_absolute_ceiling_even_with_a_larger_hard_cap() {
+        // Defense-in-depth: even if a larger `hard_cap` slipped past the
+        // builder/config fail-fast, the store enforces the fixed 6 ceiling — a
+        // 50-seat request is rejected, reporting the effective ceiling (6).
+        let store = InMemoryRoomStore::new(50);
+        assert!(matches!(
+            store.create_room("", 50),
+            Err(RoomError::InvalidMaxParticipants {
+                requested: 50,
+                cap: 6
+            })
+        ));
+        // A within-ceiling value still works, capped at the absolute 6.
+        assert_eq!(store.create_room("", 6).unwrap().max_participants, 6);
     }
 
     // ── Join / mesh URLs / cap enforcement ───────────────────────────────────

--- a/autumn-media-plugin/src/rooms.rs
+++ b/autumn-media-plugin/src/rooms.rs
@@ -28,6 +28,21 @@
 //! namespace resolves to [`RoomError::RoomNotFound`], never another namespace's
 //! room.
 //!
+//! # Security & host responsibilities
+//!
+//! The room signaling router ([`room_router`]) ships **no built-in
+//! authentication or rate limiting** on create/join in this slice — `POST
+//! {prefix}/rooms` and `POST {prefix}/rooms/{room_id}/join` are open. It
+//! therefore **MUST be mounted behind the host application's auth / rate-limit
+//! middleware**; the plugin does not gate who may create or join a room. As a
+//! defense-in-depth backstop against unbounded memory growth from a create loop
+//! (a created-but-never-joined room is only reaped when its last participant
+//! leaves), [`InMemoryRoomStore`] caps the registry at [`MAX_ROOMS`] rooms and
+//! rejects further creation with [`RoomError::RegistryFull`] (mapped to a
+//! transient `503`). Empty/idle-room reaping remains recorded future work (see
+//! *Known limitations*) — the cap is a backstop, not a substitute for the host
+//! auth/rate-limit layer.
+//!
 //! # Operator requirements
 //!
 //! - **`MediaMTX` path matcher**: this crate ships no `mediamtx.yml` (the
@@ -231,6 +246,16 @@ pub enum RoomError {
         /// The hard cap.
         cap: usize,
     },
+
+    /// The in-memory room registry is at its capacity backstop of [`MAX_ROOMS`]
+    /// rooms, so no new room can be created right now. A transient overload
+    /// condition, not a client error — mapped to a `503`. The message names no
+    /// internals beyond the cap.
+    #[error("room registry is at capacity ({max} rooms); try again later")]
+    RegistryFull {
+        /// The registry capacity that was reached.
+        max: usize,
+    },
 }
 
 impl RoomError {
@@ -250,6 +275,9 @@ impl RoomError {
             }
             // A full room is a genuine conflict (409), distinct from a bad request.
             Self::RoomFull { .. } => AutumnError::conflict_msg(self.to_string()),
+            // A full registry is a transient overload condition (503), not a
+            // client error — the caller can retry once rooms drain.
+            Self::RegistryFull { .. } => AutumnError::service_unavailable_msg(self.to_string()),
             Self::Unauthorized => AutumnError::unauthorized_msg(self.to_string()),
             Self::InvalidSegment { .. } | Self::InvalidMaxParticipants { .. } => {
                 AutumnError::bad_request_msg(self.to_string())
@@ -449,13 +477,27 @@ pub trait RoomStore: Send + Sync {
     ) -> Result<RoomSnapshot, RoomError>;
 }
 
+/// Capacity backstop on the number of rooms an [`InMemoryRoomStore`] holds.
+///
+/// `rooms_create` is unauthenticated in this slice and a created-but-never-joined
+/// room is only reaped when its last participant leaves, so an unbounded create
+/// loop would grow process memory for the lifetime of the process. This cap is a
+/// defense-in-depth backstop against that (mirroring the workspace's
+/// `MAX_BUCKETS` capacity-cap idiom for in-memory registries), **not** a
+/// substitute for the host app's auth / rate-limit middleware — see the
+/// module-level *Security & host responsibilities* note.
+pub const MAX_ROOMS: usize = 10_000;
+
 /// A single-process, in-memory [`RoomStore`].
 ///
 /// Keyed on `(namespace, room_id)` under one `RwLock`. When the last
 /// participant leaves a room, the room is dropped so an idle room never lingers.
+/// The registry is capped at `max_rooms` (default [`MAX_ROOMS`]) as a
+/// memory-growth backstop.
 pub struct InMemoryRoomStore {
     rooms: RwLock<HashMap<(String, String), Room>>,
     hard_cap: usize,
+    max_rooms: usize,
 }
 
 impl InMemoryRoomStore {
@@ -466,13 +508,25 @@ impl InMemoryRoomStore {
     /// [`DEFAULT_ROOM_MAX_PARTICIPANTS`](crate::config::DEFAULT_ROOM_MAX_PARTICIPANTS)
     /// (6, no SFU) regardless of `hard_cap`, so with a larger `hard_cap`
     /// [`create_room`](RoomStore::create_room) still rejects any request above 6
-    /// as a backstop.
+    /// as a backstop. The registry-size cap defaults to [`MAX_ROOMS`]; override
+    /// it with [`with_max_rooms`](Self::with_max_rooms).
     #[must_use]
     pub fn new(hard_cap: usize) -> Self {
         Self {
             rooms: RwLock::new(HashMap::new()),
             hard_cap,
+            max_rooms: MAX_ROOMS,
         }
+    }
+
+    /// Override the registry-size backstop (the maximum number of rooms the
+    /// store holds before [`create_room`](RoomStore::create_room) rejects with
+    /// [`RoomError::RegistryFull`]). Chiefly for tests that need a tiny cap
+    /// without allocating [`MAX_ROOMS`] rooms.
+    #[must_use]
+    pub const fn with_max_rooms(mut self, max_rooms: usize) -> Self {
+        self.max_rooms = max_rooms;
+        self
     }
 }
 
@@ -512,10 +566,19 @@ impl RoomStore for InMemoryRoomStore {
             participants: HashMap::new(),
         };
         let snapshot = room.snapshot();
-        self.rooms
-            .write()
-            .expect("room store lock poisoned")
-            .insert((namespace.to_owned(), id), room);
+        let mut rooms = self.rooms.write().expect("room store lock poisoned");
+        // Registry capacity backstop: reject once the store is at `max_rooms`
+        // rooms (checked under the write lock, so no create can race past it).
+        // The signaling router is unauthenticated in this slice, so this guards
+        // against unbounded memory growth from a create loop — a transient 503,
+        // not a client error.
+        if rooms.len() >= self.max_rooms {
+            return Err(RoomError::RegistryFull {
+                max: self.max_rooms,
+            });
+        }
+        rooms.insert((namespace.to_owned(), id), room);
+        drop(rooms);
         Ok(snapshot)
     }
 
@@ -1094,6 +1157,13 @@ mod tests {
             .status(),
             StatusCode::BAD_REQUEST
         );
+        // A full registry is a transient overload → 503, not a client error.
+        assert_eq!(
+            RoomError::RegistryFull { max: 10_000 }
+                .into_autumn()
+                .status(),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
     }
 
     // ── Session token ────────────────────────────────────────────────────────
@@ -1180,6 +1250,23 @@ mod tests {
         ));
         // A within-ceiling value still works, capped at the absolute 6.
         assert_eq!(store.create_room("", 6).unwrap().max_participants, 6);
+    }
+
+    #[test]
+    fn create_room_rejects_once_registry_is_at_capacity() {
+        // Inject a tiny registry cap so we can trip it without allocating
+        // MAX_ROOMS rooms: two creates succeed, the third is RegistryFull.
+        let store = InMemoryRoomStore::new(6).with_max_rooms(2);
+        assert!(store.create_room("", 4).is_ok());
+        assert!(store.create_room("", 4).is_ok());
+        assert!(matches!(
+            store.create_room("", 4),
+            Err(RoomError::RegistryFull { max: 2 })
+        ));
+
+        // The default cap is the MAX_ROOMS backstop — an ordinary store never
+        // trips it under a normal number of rooms.
+        assert_eq!(super::MAX_ROOMS, 10_000);
     }
 
     // ── Join / mesh URLs / cap enforcement ───────────────────────────────────

--- a/autumn-media-plugin/src/rooms.rs
+++ b/autumn-media-plugin/src/rooms.rs
@@ -37,6 +37,28 @@
 //! - **`CSP`**: an embedding page's `connect-src` must allow the `MediaMTX`
 //!   `WebRTC` origin (`:8889` by default), exactly as the broadcast player does.
 //!
+//! # Peer discovery
+//!
+//! Peer discovery is by client polling of the member-gated roster
+//! (`GET {prefix}/rooms/{room_id}`), not server push — there is no `WebSocket`
+//! or `SSE` signaling channel in this slice. The join response seeds a client
+//! with the peers present at join time; to pick up later joiners a client
+//! re-polls the roster, which returns a subscribe target (`WHEP` URL) for every
+//! current member. The roster is **member-gated and fail-closed**: only a caller
+//! presenting a valid participant token for that room may read it (see
+//! [`RoomStore::roster`]), because it hands out per-peer media endpoints.
+//!
+//! # Known limitations
+//!
+//! - **No participant reaping**: a client that never sends leave holds its seat
+//!   until the process restarts — there is no automatic reaping of abandoned
+//!   participants or idle rooms. A stale-participant / idle-room reaper is
+//!   recorded future work.
+//! - **Advisory token expiry**: `token_expires_at` is returned to the joiner but
+//!   is **not** enforced anywhere yet (`MediaMTX` does not verify these tokens),
+//!   so it never gates a lifecycle operation — a participant can always leave
+//!   with a value-correct token regardless of its age.
+//!
 //! # Single-process limitation
 //!
 //! [`InMemoryRoomStore`] keeps all room state in process memory, so it is
@@ -57,6 +79,7 @@ use autumn_web::reexports::axum::{
     extract::{Path, State},
     routing::{get, post},
 };
+use autumn_web::reexports::http::HeaderMap;
 use autumn_web::route_listing::RouteInfo;
 use autumn_web::{AppState, AutumnError, AutumnResult};
 
@@ -125,8 +148,9 @@ pub fn room_participant_path(
 /// `SessionToken("<redacted>")`, mirroring the storage-layer redaction
 /// discipline) so it cannot leak into logs, but it **is** serialized verbatim,
 /// because the join response returns it to the participant that owns it.
-/// Verification is always by value **and** expiry against the stored
-/// participant record, using a constant-time compare.
+/// Verification for lifecycle/auth operations is **value-only**, using a
+/// constant-time compare against the stored participant record — token expiry
+/// is advisory and never enforced.
 #[derive(Clone)]
 pub struct SessionToken(String);
 
@@ -185,9 +209,10 @@ pub enum RoomError {
     #[error("participant not found")]
     ParticipantNotFound,
 
-    /// The presented session token was wrong or expired. The message is
-    /// deliberately token-free so it can never echo a secret.
-    #[error("invalid or expired session token")]
+    /// The presented session token did not match (value-only compare; expiry is
+    /// advisory and never checked). The message is deliberately token-free so it
+    /// can never echo a secret.
+    #[error("invalid session token")]
     Unauthorized,
 
     /// A caller-supplied path segment (namespace / room / participant) was
@@ -242,19 +267,24 @@ struct RoomParticipant {
     display_name: Option<String>,
     joined_at: DateTime<Utc>,
     token: SessionToken,
+    /// Advisory metadata only, for a future media-auth / renewal slice.
+    ///
+    /// Returned to the joiner and surfaced in the join response, but **not**
+    /// enforced anywhere — `MediaMTX` does not verify these tokens yet — so it
+    /// must never gate a lifecycle operation (leave, roster auth). Verification
+    /// is value-only (see [`verify_token`](Self::verify_token)).
     token_expires_at: DateTime<Utc>,
 }
 
 impl RoomParticipant {
-    /// Constant-time-verify a presented token against this participant, treating
-    /// an expired token as a failure. `now` is passed in so verification is
-    /// deterministic under test.
-    fn verify(&self, candidate: &str, now: DateTime<Utc>) -> bool {
-        now < self.token_expires_at
-            && autumn_web::auth::constant_time_eq(
-                candidate.as_bytes(),
-                self.token.expose().as_bytes(),
-            )
+    /// Constant-time-verify a presented token against this participant by
+    /// **value only**.
+    ///
+    /// The token's expiry is deliberately ignored, so a lifecycle/auth operation
+    /// (leave, member-gated roster read) always succeeds for the value-correct
+    /// token regardless of its age.
+    fn verify_token(&self, candidate: &str) -> bool {
+        autumn_web::auth::constant_time_eq(candidate.as_bytes(), self.token.expose().as_bytes())
     }
 }
 
@@ -380,12 +410,15 @@ pub trait RoomStore: Send + Sync {
         token_ttl: Duration,
     ) -> Result<JoinRecord, RoomError>;
 
-    /// Remove a participant from the room after verifying its token.
+    /// Remove a participant from the room after verifying its token by value.
+    ///
+    /// Verification is value-only (token expiry is advisory and never checked),
+    /// so a participant can always leave with a value-correct token.
     ///
     /// # Errors
     ///
     /// [`RoomError::RoomNotFound`], [`RoomError::ParticipantNotFound`], or
-    /// [`RoomError::Unauthorized`] on a wrong/expired token.
+    /// [`RoomError::Unauthorized`] on a wrong token.
     fn leave_room(
         &self,
         namespace: &str,
@@ -394,12 +427,26 @@ pub trait RoomStore: Send + Sync {
         token: &str,
     ) -> Result<(), RoomError>;
 
-    /// Return the current roster snapshot for `(namespace, room_id)`.
+    /// Return the current roster snapshot for `(namespace, room_id)`, gated on
+    /// the caller presenting a valid member token.
+    ///
+    /// The roster hands out per-peer media endpoints, so the read is
+    /// **member-gated and fail-closed**: `auth_token` is verified value-only
+    /// against every current member and, unless one matches, this returns
+    /// [`RoomError::RoomNotFound`] — the *same* error as a nonexistent room, so a
+    /// non-member with a guessable `room_id` cannot distinguish "room exists but
+    /// I'm not a member" from "no such room" (no existence/membership oracle).
     ///
     /// # Errors
     ///
-    /// [`RoomError::RoomNotFound`] (including a namespace mismatch).
-    fn roster(&self, namespace: &str, room_id: &str) -> Result<RoomSnapshot, RoomError>;
+    /// [`RoomError::RoomNotFound`] for an unknown room, a namespace mismatch, or
+    /// an `auth_token` matching no current member.
+    fn roster(
+        &self,
+        namespace: &str,
+        room_id: &str,
+        auth_token: &str,
+    ) -> Result<RoomSnapshot, RoomError>;
 }
 
 /// A single-process, in-memory [`RoomStore`].
@@ -491,17 +538,18 @@ impl RoomStore for InMemoryRoomStore {
         let now = Utc::now();
         let participant_id = Uuid::new_v4().to_string();
         let token = SessionToken::generate();
-        let token_expires_at = now + token_ttl;
-        room.participants.insert(
-            participant_id.clone(),
-            RoomParticipant {
-                id: participant_id.clone(),
-                display_name,
-                joined_at: now,
-                token: token.clone(),
-                token_expires_at,
-            },
-        );
+        let participant = RoomParticipant {
+            id: participant_id.clone(),
+            display_name,
+            joined_at: now,
+            token: token.clone(),
+            token_expires_at: now + token_ttl,
+        };
+        // The stored record is the single source of truth for the advisory
+        // expiry surfaced in the join response.
+        let token_expires_at = participant.token_expires_at;
+        room.participants
+            .insert(participant_id.clone(), participant);
         let snapshot = room.snapshot();
         drop(rooms);
         Ok(JoinRecord {
@@ -526,7 +574,7 @@ impl RoomStore for InMemoryRoomStore {
             .participants
             .get(participant_id)
             .ok_or(RoomError::ParticipantNotFound)?;
-        if !participant.verify(token, Utc::now()) {
+        if !participant.verify_token(token) {
             return Err(RoomError::Unauthorized);
         }
         room.participants.remove(participant_id);
@@ -539,13 +587,29 @@ impl RoomStore for InMemoryRoomStore {
         Ok(())
     }
 
-    fn roster(&self, namespace: &str, room_id: &str) -> Result<RoomSnapshot, RoomError> {
-        self.rooms
-            .read()
-            .expect("room store lock poisoned")
+    fn roster(
+        &self,
+        namespace: &str,
+        room_id: &str,
+        auth_token: &str,
+    ) -> Result<RoomSnapshot, RoomError> {
+        let rooms = self.rooms.read().expect("room store lock poisoned");
+        let room = rooms
             .get(&(namespace.to_owned(), room_id.to_owned()))
-            .map(Room::snapshot)
-            .ok_or(RoomError::RoomNotFound)
+            .ok_or(RoomError::RoomNotFound)?;
+        // Member-gate, fail-closed: a caller whose token matches no current
+        // member gets the same `RoomNotFound` as a nonexistent room, so a
+        // non-member cannot probe room existence or their own membership.
+        if !room
+            .participants
+            .values()
+            .any(|participant| participant.verify_token(auth_token))
+        {
+            return Err(RoomError::RoomNotFound);
+        }
+        let snapshot = room.snapshot();
+        drop(rooms);
+        Ok(snapshot)
     }
 }
 
@@ -586,6 +650,43 @@ pub struct JoinResponse {
     pub subscribe: Vec<SubscribeTarget>,
     /// A token-free snapshot of the room after the join.
     pub room: RoomSnapshot,
+}
+
+/// One entry in a member-gated roster: a participant's identity plus its
+/// subscribe target, so a polling member can subscribe to every peer.
+///
+/// Carries the peer's `WHEP` subscribe URL — never a token — so a member that
+/// polls the roster picks up later joiners the join response could not have
+/// seen. Clients exclude their own `participant_id`.
+#[derive(Clone, Debug, Serialize)]
+pub struct RosterEntry {
+    /// The participant's id.
+    pub participant_id: String,
+    /// The participant's optional display name.
+    pub display_name: Option<String>,
+    /// When the participant joined.
+    pub joined_at: DateTime<Utc>,
+    /// The participant's `MediaMTX` path.
+    pub path: String,
+    /// The `WHEP` read (subscribe) URL for that path.
+    pub whep_url: String,
+}
+
+/// The member-gated roster view: a token-free room snapshot whose participants
+/// each carry a per-peer subscribe target.
+#[derive(Clone, Debug, Serialize)]
+pub struct RoomRoster {
+    /// The room id.
+    pub id: String,
+    /// The room's namespace (omitted from JSON when empty).
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub namespace: String,
+    /// The room's participant cap.
+    pub max_participants: usize,
+    /// When the room was created.
+    pub created_at: DateTime<Utc>,
+    /// The current roster, each entry carrying a subscribe target.
+    pub participants: Vec<RosterEntry>,
 }
 
 /// The programmatic room API installed on `AppState`.
@@ -694,13 +795,38 @@ impl RoomService {
             .leave_room(&self.namespace, room_id, participant_id, token)
     }
 
-    /// Return the roster for `room_id`.
+    /// Return the member-gated roster for `room_id`, composing a subscribe
+    /// target for every participant.
+    ///
+    /// `auth_token` must be a current member's session token: the store gates
+    /// the read fail-closed, returning [`RoomError::RoomNotFound`] (the same
+    /// error as a nonexistent room) to any non-member, so the roster's per-peer
+    /// media endpoints are never handed to an outsider.
     ///
     /// # Errors
     ///
-    /// Propagates any [`RoomError`] from the store.
-    pub fn roster(&self, room_id: &str) -> Result<RoomSnapshot, RoomError> {
-        self.store.roster(&self.namespace, room_id)
+    /// Propagates any [`RoomError`] from the store, or
+    /// [`RoomError::InvalidSegment`] if a path cannot be composed.
+    pub fn roster(&self, room_id: &str, auth_token: &str) -> Result<RoomRoster, RoomError> {
+        let snapshot = self.store.roster(&self.namespace, room_id, auth_token)?;
+        let mut participants = Vec::with_capacity(snapshot.participants.len());
+        for participant in snapshot.participants {
+            let path = room_participant_path(&self.namespace, room_id, &participant.id)?;
+            participants.push(RosterEntry {
+                participant_id: participant.id,
+                display_name: participant.display_name,
+                joined_at: participant.joined_at,
+                whep_url: self.urls.whep_read_url(&path),
+                path,
+            });
+        }
+        Ok(RoomRoster {
+            id: snapshot.id,
+            namespace: snapshot.namespace,
+            max_participants: snapshot.max_participants,
+            created_at: snapshot.created_at,
+            participants,
+        })
     }
 }
 
@@ -777,15 +903,40 @@ async fn rooms_leave(
     Ok(Json(RoomLeaveResponse { left: true }))
 }
 
-/// `GET {prefix}/rooms/{room_id}` — the room roster.
+/// Extract a bearer token from the `Authorization` header (case-insensitive
+/// `Bearer` scheme).
+///
+/// Returns `None` when the header is absent, non-`ASCII`, or not a `Bearer`
+/// scheme — callers treat that as "no token", which the member-gated roster
+/// then fails closed on.
+fn bearer_token(headers: &HeaderMap) -> Option<&str> {
+    let value = headers
+        .get(autumn_web::reexports::http::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?;
+    let (scheme, token) = value.split_once(' ')?;
+    scheme
+        .eq_ignore_ascii_case("bearer")
+        .then_some(token.trim())
+}
+
+/// `GET {prefix}/rooms/{room_id}` — the member-gated room roster.
+///
+/// Requires an `Authorization: Bearer <token>` header carrying a current
+/// member's session token. A missing/malformed header or a non-member token
+/// yields the same `404` [`RoomError::RoomNotFound`] as a nonexistent room
+/// (fail-closed, no membership oracle), because the roster hands out per-peer
+/// media endpoints.
 async fn rooms_roster(
     State(state): State<AppState>,
     Path(room_id): Path<String>,
-) -> AutumnResult<Json<RoomSnapshot>> {
-    let snapshot = room_service(&state)?
-        .roster(&room_id)
+    headers: HeaderMap,
+) -> AutumnResult<Json<RoomRoster>> {
+    let auth_token = bearer_token(&headers).unwrap_or_default();
+    let roster = room_service(&state)?
+        .roster(&room_id, auth_token)
         .map_err(RoomError::into_autumn)?;
-    Ok(Json(snapshot))
+    Ok(Json(roster))
 }
 
 /// Acknowledgement returned by a successful leave.
@@ -845,13 +996,14 @@ fn room_route(method: &str, path: String, handler: &str) -> RouteInfo {
 mod tests {
     use super::{
         InMemoryRoomStore, JoinRequest, LeaveRequest, RoomError, RoomService, RoomStore,
-        SessionToken, room_participant_path, room_route_infos, rooms_create, rooms_join,
-        rooms_roster, validate_room_segment,
+        SessionToken, bearer_token, room_participant_path, room_route_infos, rooms_create,
+        rooms_join, rooms_roster, validate_room_segment,
     };
     use crate::config::MediaMtxConfig;
     use crate::transport::MediaUrls;
     use autumn_web::AppState;
     use autumn_web::reexports::axum::extract::{Path, State};
+    use autumn_web::reexports::http::HeaderMap;
     use chrono::{Duration, Utc};
     use std::sync::Arc;
 
@@ -1091,70 +1243,69 @@ mod tests {
         let ns_b = RoomService::new(store, urls(), "b", Duration::seconds(300), 6);
 
         let room = ns_a.create().unwrap();
-        // The same store, but namespace "b" cannot see namespace "a"'s room.
+        let member = ns_a.join(&room.id, None).unwrap();
+        // The same store, but namespace "b" cannot see namespace "a"'s room —
+        // even presenting namespace "a"'s valid member token.
         assert!(matches!(
-            ns_b.roster(&room.id),
+            ns_b.roster(&room.id, member.session_token.expose()),
             Err(RoomError::RoomNotFound)
         ));
         assert!(matches!(
             ns_b.join(&room.id, None),
             Err(RoomError::RoomNotFound)
         ));
-        // The owning namespace still resolves it.
-        assert!(ns_a.roster(&room.id).is_ok());
+        // The owning namespace still resolves it for its member.
+        assert!(ns_a.roster(&room.id, member.session_token.expose()).is_ok());
     }
 
     // ── Token verification (correct / wrong / expired) ───────────────────────
 
     #[test]
-    fn participant_verify_matches_only_unexpired_correct_token() {
+    fn participant_verify_token_matches_by_value_only_ignoring_expiry() {
         use super::RoomParticipant;
         let now = Utc::now();
+        // An already-expired token: `verify_token` ignores expiry entirely, so
+        // the value-correct token still verifies and a wrong value still fails.
         let participant = RoomParticipant {
             id: "p1".to_owned(),
             display_name: None,
             joined_at: now,
             token: SessionToken("secret-token-value".to_owned()),
-            token_expires_at: now + Duration::seconds(300),
+            token_expires_at: now - Duration::seconds(1),
         };
-        assert!(participant.verify("secret-token-value", now));
-        assert!(!participant.verify("wrong-token", now), "wrong token fails");
-        // Past the expiry, even the correct token fails.
         assert!(
-            !participant.verify("secret-token-value", now + Duration::seconds(301)),
-            "expired token fails"
+            participant.verify_token("secret-token-value"),
+            "value-correct token verifies even though it is past its expiry"
+        );
+        assert!(
+            !participant.verify_token("wrong-token"),
+            "a wrong token value still fails"
         );
     }
 
     #[test]
-    fn leave_rejects_wrong_and_expired_tokens_then_accepts_correct() {
-        // Expired: join with a negative TTL so the token is already expired.
-        let expired = RoomService::new(
+    fn leave_succeeds_with_expired_token_and_rejects_wrong_value() {
+        // Join with a negative TTL so `token_expires_at` is already in the past;
+        // the participant must still be able to leave with the correct value.
+        let service = RoomService::new(
             Arc::new(InMemoryRoomStore::new(6)),
             urls(),
             "",
             Duration::seconds(-10),
             6,
         );
-        let room = expired.create().unwrap();
-        let joined = expired.join(&room.id, None).unwrap();
-        assert!(matches!(
-            expired.leave(
-                &room.id,
-                &joined.participant_id,
-                joined.session_token.expose()
-            ),
-            Err(RoomError::Unauthorized)
-        ));
-
-        // Valid TTL: wrong token rejected, correct token accepted.
-        let service = service("");
         let room = service.create().unwrap();
         let joined = service.join(&room.id, None).unwrap();
+        assert!(
+            joined.token_expires_at < Utc::now(),
+            "token is already expired (advisory only)"
+        );
+        // A wrong token value is still rejected.
         assert!(matches!(
             service.leave(&room.id, &joined.participant_id, "not-the-token"),
             Err(RoomError::Unauthorized)
         ));
+        // The value-correct (but expired) token still leaves successfully.
         assert!(
             service
                 .leave(
@@ -1162,24 +1313,102 @@ mod tests {
                     &joined.participant_id,
                     joined.session_token.expose()
                 )
-                .is_ok()
+                .is_ok(),
+            "a participant can always leave with a value-correct token"
         );
-        // Emptying the room drops it.
-        assert!(matches!(
-            service.roster(&room.id),
-            Err(RoomError::RoomNotFound)
-        ));
     }
 
     // ── Roster serialization excludes tokens ─────────────────────────────────
 
     #[test]
-    fn roster_snapshot_json_never_carries_tokens() {
+    fn roster_returns_per_peer_subscribe_targets_for_a_member() {
+        let service = service("tenant-a");
+        let room = service.create().unwrap();
+        let first = service.join(&room.id, Some("Ada".to_owned())).unwrap();
+        let second = service.join(&room.id, Some("Grace".to_owned())).unwrap();
+
+        // A member polling the roster sees a subscribe target for every peer,
+        // with the exact same WHEP URL construction the join response uses.
+        let roster = service
+            .roster(&room.id, first.session_token.expose())
+            .unwrap();
+        assert_eq!(roster.participants.len(), 2);
+        let grace = roster
+            .participants
+            .iter()
+            .find(|entry| entry.participant_id == second.participant_id)
+            .expect("second joiner is in the first member's roster");
+        let grace_path = format!("room/tenant-a/{}/{}", room.id, second.participant_id);
+        assert_eq!(grace.path, grace_path);
+        assert_eq!(
+            grace.whep_url,
+            format!("http://127.0.0.1:8889/{grace_path}/whep")
+        );
+        assert_eq!(grace.display_name.as_deref(), Some("Grace"));
+    }
+
+    #[test]
+    fn roster_is_member_gated_fail_closed_no_oracle() {
+        let service = service("tenant-a");
+        let room = service.create().unwrap();
+        service.join(&room.id, Some("Ada".to_owned())).unwrap();
+
+        // No token and a wrong token both resolve to the SAME error a
+        // nonexistent room returns — a non-member cannot tell them apart.
+        assert!(matches!(
+            service.roster(&room.id, ""),
+            Err(RoomError::RoomNotFound)
+        ));
+        assert!(matches!(
+            service.roster(&room.id, "not-a-member-token"),
+            Err(RoomError::RoomNotFound)
+        ));
+        assert!(matches!(
+            service.roster("00000000-0000-0000-0000-000000000000", ""),
+            Err(RoomError::RoomNotFound)
+        ));
+    }
+
+    #[test]
+    fn roster_poll_surfaces_a_late_joiner_to_an_earlier_member() {
+        let service = service("tenant-a");
+        let room = service.create().unwrap();
+
+        // A joins first; at that point A's join response saw no peers.
+        let a = service.join(&room.id, Some("Ada".to_owned())).unwrap();
+        assert!(
+            service
+                .roster(&room.id, a.session_token.expose())
+                .unwrap()
+                .participants
+                .iter()
+                .all(|entry| entry.participant_id == a.participant_id)
+        );
+
+        // B joins later; A's next roster poll now lists B with B's WHEP target.
+        let b = service.join(&room.id, Some("Grace".to_owned())).unwrap();
+        let roster = service.roster(&room.id, a.session_token.expose()).unwrap();
+        let b_entry = roster
+            .participants
+            .iter()
+            .find(|entry| entry.participant_id == b.participant_id)
+            .expect("A's later poll surfaces the late joiner B");
+        let b_path = format!("room/tenant-a/{}/{}", room.id, b.participant_id);
+        assert_eq!(
+            b_entry.whep_url,
+            format!("http://127.0.0.1:8889/{b_path}/whep")
+        );
+    }
+
+    #[test]
+    fn roster_json_never_carries_tokens() {
         let service = service("tenant-a");
         let room = service.create().unwrap();
         let joined = service.join(&room.id, Some("Ada".to_owned())).unwrap();
-        let snapshot = service.roster(&room.id).unwrap();
-        let json = serde_json::to_string(&snapshot).unwrap();
+        let roster = service
+            .roster(&room.id, joined.session_token.expose())
+            .unwrap();
+        let json = serde_json::to_string(&roster).unwrap();
         assert!(
             !json.contains(joined.session_token.expose()),
             "roster json leaked a token: {json}"
@@ -1189,14 +1418,19 @@ mod tests {
             "roster json has a token field: {json}"
         );
         assert!(json.contains("\"namespace\":\"tenant-a\""));
+        assert!(json.contains("whep_url"));
         assert!(json.contains("Ada"));
     }
 
     #[test]
-    fn empty_namespace_is_omitted_from_snapshot_json() {
+    fn empty_namespace_is_omitted_from_roster_json() {
         let service = service("");
         let room = service.create().unwrap();
-        let json = serde_json::to_string(&service.roster(&room.id).unwrap()).unwrap();
+        let joined = service.join(&room.id, None).unwrap();
+        let roster = service
+            .roster(&room.id, joined.session_token.expose())
+            .unwrap();
+        let json = serde_json::to_string(&roster).unwrap();
         assert!(
             !json.contains("namespace"),
             "empty namespace must be omitted: {json}"
@@ -1225,6 +1459,29 @@ mod tests {
         assert_eq!(room_route_infos("/api/media/")[0].path, "/api/media/rooms");
     }
 
+    // ── Bearer token parsing ─────────────────────────────────────────────────
+
+    #[test]
+    fn bearer_token_parses_case_insensitive_scheme_and_rejects_malformed() {
+        let with = |value: &str| {
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                autumn_web::reexports::http::header::AUTHORIZATION,
+                value.parse().unwrap(),
+            );
+            headers
+        };
+        assert_eq!(bearer_token(&with("Bearer abc123")), Some("abc123"));
+        // Scheme match is case-insensitive; the token is trimmed.
+        assert_eq!(bearer_token(&with("bearer   abc123  ")), Some("abc123"));
+        assert_eq!(bearer_token(&with("BEARER abc123")), Some("abc123"));
+        // A different scheme or a bare value is not a bearer token.
+        assert_eq!(bearer_token(&with("Basic abc123")), None);
+        assert_eq!(bearer_token(&with("abc123")), None);
+        // An absent header yields no token.
+        assert_eq!(bearer_token(&HeaderMap::new()), None);
+    }
+
     // ── Handler round-trip (create → join → roster through RoomService ext) ──
 
     #[tokio::test]
@@ -1251,13 +1508,30 @@ mod tests {
         assert!(!joined.session_token.expose().is_empty());
         assert!(!joined.participant_id.is_empty());
 
-        // Roster reflects the join.
-        let roster = rooms_roster(State(state.clone()), Path(room_id))
+        // Roster reflects the join — read with the member's Bearer token.
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            autumn_web::reexports::http::header::AUTHORIZATION,
+            format!("Bearer {}", joined.session_token.expose())
+                .parse()
+                .unwrap(),
+        );
+        let roster = rooms_roster(State(state.clone()), Path(room_id.clone()), headers)
             .await
             .expect("roster")
             .0;
         assert_eq!(roster.participants.len(), 1);
-        assert_eq!(roster.participants[0].id, joined.participant_id);
+        assert_eq!(roster.participants[0].participant_id, joined.participant_id);
+        assert!(!roster.participants[0].whep_url.is_empty());
+
+        // A roster read with no Authorization header is fail-closed → 404.
+        let unauth = rooms_roster(State(state), Path(room_id), HeaderMap::new())
+            .await
+            .expect_err("no bearer → not found");
+        assert_eq!(
+            unauth.status(),
+            autumn_web::reexports::http::StatusCode::NOT_FOUND
+        );
     }
 
     #[tokio::test]

--- a/autumn-media-plugin/src/storage.rs
+++ b/autumn-media-plugin/src/storage.rs
@@ -363,14 +363,19 @@ impl MediaStorage {
     ///
     /// # Errors
     ///
-    /// Returns [`MediaError::LocalRead`] when the staged file cannot be read
-    /// for upload, and [`MediaError::S3Upload`] when the remote upload fails.
+    /// Returns [`MediaError::InvalidKeySegment`] when the caller key contains a
+    /// dot-only (`.`/`..`) or empty path segment (rejected at this write
+    /// boundary so such an object is never stored or advertised — see
+    /// [`reject_dot_only_segments`]), [`MediaError::LocalRead`] when the staged
+    /// file cannot be read for upload, and [`MediaError::S3Upload`] when the
+    /// remote upload fails.
     pub async fn persist_file_with_content_type(
         &self,
         key: &str,
         local_path: &Path,
         content_type: &str,
     ) -> Result<StoredObject, MediaError> {
+        reject_dot_only_segments(key)?;
         match self {
             Self::Local { .. } => Ok(StoredObject {
                 backend: self.backend_name().to_owned(),
@@ -567,6 +572,33 @@ pub fn join_key_prefix(prefix: &str, key: &str) -> String {
     } else {
         format!("{prefix}/{key}")
     }
+}
+
+/// Reject a caller key whose path carries a dot-only or empty segment.
+///
+/// After trimming outer slashes (the same normalization [`join_key_prefix`] /
+/// [`MediaStorage::resolved_key`] apply), every `/`-split segment must be
+/// non-empty and neither `.` nor `..` once trimmed. This is the boundary check
+/// behind [`MediaStorage::persist_file`]: percent-encoding a dot-only segment
+/// (as [`encode_key_for_url`] does defensively) is insufficient on its own
+/// because WHATWG URL parsers normalize `%2E` back to `.` before the request,
+/// so `clips/../other.mp4` could address a different object than the one stored.
+/// Refusing the key here means such an object is never created or advertised.
+///
+/// # Errors
+///
+/// Returns [`MediaError::InvalidKeySegment`] naming the offending key (a
+/// caller object key, not a secret).
+pub(crate) fn reject_dot_only_segments(key: &str) -> Result<(), MediaError> {
+    for segment in key.trim_matches('/').split('/') {
+        let segment = segment.trim();
+        if segment.is_empty() || segment == "." || segment == ".." {
+            return Err(MediaError::InvalidKeySegment {
+                key: key.to_owned(),
+            });
+        }
+    }
+    Ok(())
 }
 
 /// The inverse of [`join_key_prefix`]: strip a leading `{prefix}/` from a stored
@@ -1053,6 +1085,73 @@ mod tests {
     #[test]
     fn strip_key_prefix_key_equal_to_prefix_is_empty() {
         assert_eq!(strip_key_prefix("media", "media"), "");
+    }
+
+    // ── reject_dot_only_segments ─────────────────────────────────────────────
+
+    #[test]
+    fn reject_dot_only_segments_rejects_dotdot() {
+        assert!(matches!(
+            reject_dot_only_segments("clips/../other.mp4"),
+            Err(MediaError::InvalidKeySegment { .. })
+        ));
+    }
+
+    #[test]
+    fn reject_dot_only_segments_rejects_single_dot() {
+        assert!(matches!(
+            reject_dot_only_segments("clips/./a.mp4"),
+            Err(MediaError::InvalidKeySegment { .. })
+        ));
+    }
+
+    #[test]
+    fn reject_dot_only_segments_accepts_filename_with_dots() {
+        // Dots *inside* a segment (an ordinary filename) are fine.
+        assert!(reject_dot_only_segments("clips/my.file.mp4").is_ok());
+        // A normal nested key round-trips fine.
+        assert!(reject_dot_only_segments("highlights/chan/a-b_c.mp4").is_ok());
+    }
+
+    #[test]
+    fn reject_dot_only_segments_trims_outer_slashes_but_rejects_inner_empties() {
+        // Leading/trailing slashes are trimmed (as resolved_key would), so a
+        // key with only outer slashes is accepted.
+        assert!(reject_dot_only_segments("/clips/a.mp4/").is_ok());
+        // An internal empty segment (`//`) is rejected.
+        assert!(reject_dot_only_segments("clips//a.mp4").is_err());
+        // A whitespace-padded dot-only segment is rejected.
+        assert!(reject_dot_only_segments("clips/ .. /a.mp4").is_err());
+        // An empty key has no legitimate object to name.
+        assert!(reject_dot_only_segments("").is_err());
+    }
+
+    #[tokio::test]
+    async fn persist_file_rejects_dot_only_segment_key() {
+        let storage = MediaStorage::Local {
+            root: PathBuf::from("media"),
+            public_base_url: "/media".to_owned(),
+        };
+        let err = storage
+            .persist_file("clips/../secret.mp4", Path::new("/tmp/staged/x.mp4"))
+            .await
+            .expect_err("dot-only-segment key must be rejected at the boundary");
+        assert!(matches!(err, MediaError::InvalidKeySegment { .. }));
+    }
+
+    #[tokio::test]
+    async fn persist_file_accepts_ordinary_dotted_filename() {
+        // The local backend records the path without I/O, so this exercises the
+        // validation boundary while accepting an ordinary dotted filename.
+        let storage = MediaStorage::Local {
+            root: PathBuf::from("media"),
+            public_base_url: "/media".to_owned(),
+        };
+        let stored = storage
+            .persist_file("clips/my.file.mp4", Path::new("/tmp/staged/my.file.mp4"))
+            .await
+            .expect("ordinary dotted filename must be accepted");
+        assert_eq!(stored.key, "clips/my.file.mp4");
     }
 
     // ── from_config ──────────────────────────────────────────────────────────

--- a/autumn-media-plugin/src/transport.rs
+++ b/autumn-media-plugin/src/transport.rs
@@ -529,6 +529,28 @@ impl MediaUrls {
         format!("{}/live/{stream_key}/whip", self.webrtc_base)
     }
 
+    /// `WHIP` publish URL for an arbitrary `MediaMTX` `path`.
+    ///
+    /// Unlike [`whip_publish_url`](Self::whip_publish_url) — the broadcast
+    /// helper that inserts the `live/` segment — this takes the full
+    /// `MediaMTX` path verbatim, so the rooms surface (whose participant paths
+    /// are `room/…`, not `live/…`) composes publish URLs through it.
+    #[must_use]
+    pub fn whip_publish_url_for_path(&self, path: &str) -> String {
+        format!("{}/{path}/whip", self.webrtc_base)
+    }
+
+    /// `WHEP` read (subscribe) URL for an arbitrary `MediaMTX` `path`.
+    ///
+    /// Mirrors [`whip_publish_url_for_path`](Self::whip_publish_url_for_path)
+    /// for the subscribe side: the rooms surface builds each peer's subscribe
+    /// URL with it (the broadcast [`webrtc_playback_url`](Self::webrtc_playback_url)
+    /// only serves `live/…` paths).
+    #[must_use]
+    pub fn whep_read_url(&self, path: &str) -> String {
+        format!("{}/{path}/whep", self.webrtc_base)
+    }
+
     /// Browser-facing recorded-`VOD` playback URL for a finished recording.
     ///
     /// Returns `None` when the recording path does not resolve to a
@@ -868,6 +890,20 @@ mod tests {
             "http://127.0.0.1:8889/live/sk/whip"
         );
         assert_eq!(urls.api_base(), "http://127.0.0.1:9997");
+    }
+
+    #[test]
+    fn raw_path_whip_whep_urls_take_the_path_verbatim() {
+        let urls = MediaUrls::from_config(&MediaMtxConfig::default());
+        // No `live/` insertion — the room path is used exactly as given.
+        assert_eq!(
+            urls.whip_publish_url_for_path("room/tenant-a/room1/part1"),
+            "http://127.0.0.1:8889/room/tenant-a/room1/part1/whip"
+        );
+        assert_eq!(
+            urls.whep_read_url("room/tenant-a/room1/part1"),
+            "http://127.0.0.1:8889/room/tenant-a/room1/part1/whep"
+        );
     }
 
     #[test]

--- a/autumn-media-plugin/src/transport.rs
+++ b/autumn-media-plugin/src/transport.rs
@@ -31,6 +31,13 @@ use crate::config::MediaMtxConfig;
 const DEFAULT_TIMEOUT_SECS: u64 = 3;
 /// Timeout used for the best-effort publisher-kick calls.
 const KICK_TIMEOUT_SECS: u64 = 5;
+/// Page size for the paginated `MediaMTX` v3 paths-list fetch.
+const PATHS_ITEMS_PER_PAGE: u32 = 1000;
+/// Hard cap on paths-list pages walked per fetch.
+///
+/// Guards against a malformed or absent `pageCount` ever driving an unbounded
+/// loop; at 1000 items per page this still covers a million live paths.
+const MAX_PATHS_PAGES: u64 = 1000;
 
 // ── Status enums ────────────────────────────────────────────────────────────
 
@@ -136,6 +143,25 @@ pub fn viewer_counts_from_paths_json(json: &serde_json::Value) -> Option<HashMap
         counts.insert(stream_key.to_owned(), count);
     }
     Some(counts)
+}
+
+/// Resolve the total page count from a `MediaMTX` paths-list response.
+///
+/// Clamped to at least 1: an absent or malformed `pageCount` is treated as a
+/// single page so the paginated fetchers can never infinite-loop.
+fn page_count_from_paths_json(json: &serde_json::Value) -> u64 {
+    json.get("pageCount")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(1)
+        .max(1)
+}
+
+/// Whether a `MediaMTX` paths-list response carries no `items` (a well-formed
+/// empty page), used as a defensive pagination stop.
+fn paths_page_is_empty(json: &serde_json::Value) -> bool {
+    json.get("items")
+        .and_then(serde_json::Value::as_array)
+        .is_none_or(Vec::is_empty)
 }
 
 /// Extract per-stream-key ingest statuses from the `MediaMTX` paths list
@@ -256,30 +282,57 @@ impl MediaMtxClient {
         &self.api_base
     }
 
-    /// Read ingest statuses for every path from the `MediaMTX` v3 paths API.
+    /// Fetch one page of the `MediaMTX` v3 paths list.
     ///
-    /// Returns `None` when the API is unreachable or returns an unexpected body
-    /// so callers (a stream reaper) can distinguish "`MediaMTX` is down" from
-    /// "no publisher" — a transport failure must never be treated as feed loss.
-    pub async fn fetch_ingest_statuses(&self) -> Option<HashMap<String, IngestStatus>> {
-        let url = format!("{}/v3/paths/list?itemsPerPage=1000", self.api_base);
+    /// Returns `None` on any transport, non-success, or parse failure so the
+    /// paginated fetchers preserve their "`MediaMTX` is down" sentinel.
+    async fn fetch_paths_page(&self, page: u64) -> Option<serde_json::Value> {
+        let url = format!(
+            "{}/v3/paths/list?itemsPerPage={PATHS_ITEMS_PER_PAGE}&page={page}",
+            self.api_base
+        );
         let response = self.http.get(&url).send().await.ok()?;
         if !response.status().is_success() {
             return None;
         }
-        let json = response.json::<serde_json::Value>().await.ok()?;
-        ingest_statuses_from_paths_json(&json)
+        response.json::<serde_json::Value>().await.ok()
+    }
+
+    /// Read ingest statuses for every path from the `MediaMTX` v3 paths API.
+    ///
+    /// Walks every page of the paginated list so paths beyond the first
+    /// `itemsPerPage` are visible. Returns `None` when the API is unreachable or
+    /// returns an unexpected body so callers (a stream reaper) can distinguish
+    /// "`MediaMTX` is down" from "no publisher" — a transport failure must never
+    /// be treated as feed loss.
+    pub async fn fetch_ingest_statuses(&self) -> Option<HashMap<String, IngestStatus>> {
+        let mut merged = HashMap::new();
+        for page in 0..MAX_PATHS_PAGES {
+            let json = self.fetch_paths_page(page).await?;
+            let statuses = ingest_statuses_from_paths_json(&json)?;
+            merged.extend(statuses);
+            if paths_page_is_empty(&json) || page + 1 >= page_count_from_paths_json(&json) {
+                break;
+            }
+        }
+        Some(merged)
     }
 
     /// Read all active path viewer counts from the `MediaMTX` v3 paths API.
+    ///
+    /// Walks every page of the paginated list so paths beyond the first
+    /// `itemsPerPage` are counted.
     pub async fn fetch_viewer_counts(&self) -> Option<HashMap<String, u64>> {
-        let url = format!("{}/v3/paths/list?itemsPerPage=1000", self.api_base);
-        let response = self.http.get(&url).send().await.ok()?;
-        if !response.status().is_success() {
-            return None;
+        let mut merged = HashMap::new();
+        for page in 0..MAX_PATHS_PAGES {
+            let json = self.fetch_paths_page(page).await?;
+            let counts = viewer_counts_from_paths_json(&json)?;
+            merged.extend(counts);
+            if paths_page_is_empty(&json) || page + 1 >= page_count_from_paths_json(&json) {
+                break;
+            }
         }
-        let json = response.json::<serde_json::Value>().await.ok()?;
-        viewer_counts_from_paths_json(&json)
+        Some(merged)
     }
 
     /// Read ingest and viewer state for one channel from the `MediaMTX` v3 paths
@@ -1038,5 +1091,184 @@ mod tests {
     async fn client_constructs_and_reports_api_base() {
         let client = MediaMtxClient::new(&MediaMtxConfig::default());
         assert_eq!(client.api_base(), "http://127.0.0.1:9997");
+    }
+
+    // ── Paths-list pagination (local TcpListener stub) ───────────────────────
+
+    /// Spawn a stub that serves the supplied paths-list pages, dispatching each
+    /// request by its `page=` query parameter and serving a well-formed empty
+    /// page for any out-of-range page.
+    async fn spawn_paths_list_server(pages: Vec<serde_json::Value>) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test paths server should bind");
+        let addr = listener
+            .local_addr()
+            .expect("test paths server should have address");
+        let page_total = pages.len();
+        tokio::spawn(async move {
+            while let Ok((mut socket, _)) = listener.accept().await {
+                let mut buffer = [0_u8; 2048];
+                let read = socket.read(&mut buffer).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&buffer[..read]).into_owned();
+                let page = parse_page_param(&request);
+                let body = pages.get(page).cloned().unwrap_or_else(|| {
+                    serde_json::json!({
+                        "itemCount": 0,
+                        "pageCount": page_total,
+                        "items": []
+                    })
+                });
+                let body = body.to_string();
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    /// Extract the `page=` value from a raw HTTP request line (defaults to 0).
+    fn parse_page_param(request: &str) -> usize {
+        request
+            .split("page=")
+            .nth(1)
+            .and_then(|rest| rest.split(|c: char| !c.is_ascii_digit()).next())
+            .and_then(|digits| digits.parse().ok())
+            .unwrap_or(0)
+    }
+
+    fn client_for(base: &str) -> MediaMtxClient {
+        MediaMtxClient::new(&MediaMtxConfig {
+            api_base: base.to_owned(),
+            ..MediaMtxConfig::default()
+        })
+    }
+
+    #[tokio::test]
+    async fn fetch_viewer_counts_walks_all_pages() {
+        let page0 = serde_json::json!({
+            "itemCount": 3,
+            "pageCount": 2,
+            "items": [
+                { "name": "live/room_a", "readers": [ {}, {} ] },
+                { "name": "live/room_b", "readers": [ {} ] }
+            ]
+        });
+        let page1 = serde_json::json!({
+            "itemCount": 3,
+            "pageCount": 2,
+            "items": [
+                { "name": "live/room_c", "readers": [ {}, {}, {} ] }
+            ]
+        });
+        let base = spawn_paths_list_server(vec![page0, page1]).await;
+        let counts = client_for(&base)
+            .fetch_viewer_counts()
+            .await
+            .expect("reachable API must yield counts");
+        assert_eq!(counts.get("room_a"), Some(&2));
+        assert_eq!(counts.get("room_b"), Some(&1));
+        assert_eq!(counts.get("room_c"), Some(&3), "second page must be walked");
+        assert_eq!(counts.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn fetch_ingest_statuses_walks_all_pages() {
+        let page0 = serde_json::json!({
+            "itemCount": 2,
+            "pageCount": 2,
+            "items": [
+                { "name": "live/first", "source": { "type": "rtmpConn", "id": "a" }, "readers": [] }
+            ]
+        });
+        let page1 = serde_json::json!({
+            "itemCount": 2,
+            "pageCount": 2,
+            "items": [
+                { "name": "live/second", "source": null, "readers": [] }
+            ]
+        });
+        let base = spawn_paths_list_server(vec![page0, page1]).await;
+        let statuses = client_for(&base)
+            .fetch_ingest_statuses()
+            .await
+            .expect("reachable API must yield statuses");
+        assert!(matches!(
+            statuses.get("first"),
+            Some(IngestStatus::Receiving { .. })
+        ));
+        assert!(
+            matches!(statuses.get("second"), Some(IngestStatus::NotReceiving)),
+            "second page must be walked"
+        );
+        assert_eq!(statuses.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn fetch_ingest_statuses_single_page() {
+        let page0 = serde_json::json!({
+            "itemCount": 1,
+            "pageCount": 1,
+            "items": [
+                { "name": "live/only", "source": { "type": "whipSession", "id": "z" }, "readers": [] }
+            ]
+        });
+        let base = spawn_paths_list_server(vec![page0]).await;
+        let statuses = client_for(&base)
+            .fetch_ingest_statuses()
+            .await
+            .expect("reachable API must yield statuses");
+        assert!(matches!(
+            statuses.get("only"),
+            Some(IngestStatus::Receiving { .. })
+        ));
+        assert_eq!(statuses.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn fetch_viewer_counts_absent_page_count_is_single_page() {
+        // No `pageCount` field: must be treated as one page (never infinite-loop).
+        let page0 = serde_json::json!({
+            "items": [ { "name": "live/solo", "readers": [ {} ] } ]
+        });
+        let base = spawn_paths_list_server(vec![page0]).await;
+        let counts = client_for(&base)
+            .fetch_viewer_counts()
+            .await
+            .expect("reachable API must yield counts");
+        assert_eq!(counts.get("solo"), Some(&1));
+        assert_eq!(counts.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn fetch_viewer_counts_unreachable_api_is_none() {
+        // Bind then drop to obtain a port with nothing listening (connection
+        // refused is immediate) — the transport sentinel must stay `None`.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("should bind");
+        let addr = listener.local_addr().expect("should have address");
+        drop(listener);
+        let client = client_for(&format!("http://{addr}"));
+        assert!(client.fetch_viewer_counts().await.is_none());
+        assert!(client.fetch_ingest_statuses().await.is_none());
+    }
+
+    #[test]
+    fn page_count_clamps_and_defaults() {
+        assert_eq!(
+            page_count_from_paths_json(&serde_json::json!({ "pageCount": 4 })),
+            4
+        );
+        // Absent → single page.
+        assert_eq!(page_count_from_paths_json(&serde_json::json!({})), 1);
+        // Malformed (zero) → clamped to at least one page.
+        assert_eq!(
+            page_count_from_paths_json(&serde_json::json!({ "pageCount": 0 })),
+            1
+        );
     }
 }

--- a/autumn-media-plugin/src/transport.rs
+++ b/autumn-media-plugin/src/transport.rs
@@ -533,7 +533,7 @@ fn recording_url(
         return None;
     }
     let start = DateTime::<Utc>::from_naive_utc_and_offset(started_at, Utc)
-        .to_rfc3339_opts(SecondsFormat::Secs, true);
+        .to_rfc3339_opts(SecondsFormat::AutoSi, true);
     let duration = duration_seconds_param(duration_millis);
     let mut url =
         reqwest::Url::parse(&format!("{}/get", playback_base.trim_end_matches('/'))).ok()?;
@@ -861,6 +861,49 @@ mod tests {
             Some(
                 "http://public-playback.example/get?path=live%2Fsk_test&start=2026-05-14T10%3A00%3A00Z&duration=3600&format=fmp4"
             )
+        );
+    }
+
+    #[test]
+    fn recording_playback_url_preserves_subsecond_start_anchor() {
+        let config = MediaMtxConfig {
+            playback_base: "http://public-playback.example".to_owned(),
+            ..MediaMtxConfig::default()
+        };
+        let urls = MediaUrls::from_config(&config);
+        // A start anchor 250ms into the second must not be truncated away.
+        let start = chrono::NaiveDate::from_ymd_opt(2026, 5, 14)
+            .unwrap()
+            .and_hms_milli_opt(10, 0, 0, 250)
+            .unwrap();
+        let end = start + chrono::Duration::hours(1);
+        let url = urls
+            .recording_playback_url(
+                &PathBuf::from("recordings/live/sk_test"),
+                &PathBuf::from("recordings"),
+                start,
+                end,
+            )
+            .expect("playback url should build");
+        // AutoSi renders the millisecond component (percent-encoded `.` stays raw).
+        assert!(
+            url.contains("start=2026-05-14T10%3A00%3A00.250Z"),
+            "sub-second start must be preserved, got {url}"
+        );
+
+        // A whole-second start still renders cleanly with no fractional digits.
+        let whole = started_at();
+        let whole_url = urls
+            .recording_playback_url(
+                &PathBuf::from("recordings/live/sk_test"),
+                &PathBuf::from("recordings"),
+                whole,
+                whole + chrono::Duration::hours(1),
+            )
+            .expect("playback url should build");
+        assert!(
+            whole_url.contains("start=2026-05-14T10%3A00%3A00Z"),
+            "whole-second start must render without a decimal, got {whole_url}"
         );
     }
 

--- a/autumn-media-plugin/src/workflows.rs
+++ b/autumn-media-plugin/src/workflows.rs
@@ -596,23 +596,29 @@ async fn run_room_composite(
     storage: &MediaStorage,
     args: RoomCompositeJobArgs,
 ) -> Result<MediaArtifact, MediaError> {
-    let (output_path, ephemeral) = staged_output(storage, &args.output_key, "mp4")?;
-    let command =
-        FfmpegRoomCompositeCommand::new(ffmpeg_bin, args.source_paths.clone(), output_path.clone());
+    let RoomCompositeJobArgs {
+        source_paths,
+        output_key,
+        content_type,
+        workflow_id,
+        source_id,
+    } = args;
+    let (output_path, ephemeral) = staged_output(storage, &output_key, "mp4")?;
+    let command = FfmpegRoomCompositeCommand::new(ffmpeg_bin, source_paths, output_path.clone());
     let bytes = run_blocking(move || command.run()).await?;
     let file = persist_and_cleanup(
         storage,
-        &args.output_key,
+        &output_key,
         &output_path,
-        &args.content_type,
+        &content_type,
         bytes,
         ephemeral,
     )
     .await?;
     Ok(MediaArtifact {
         kind: MediaArtifactKind::Transcode,
-        workflow_id: args.workflow_id,
-        source_id: args.source_id,
+        workflow_id,
+        source_id,
         primary: file,
         secondary: None,
         metadata: BTreeMap::new(),

--- a/autumn-media-plugin/src/workflows.rs
+++ b/autumn-media-plugin/src/workflows.rs
@@ -33,9 +33,9 @@ use autumn_web::{AppState, AutumnError, AutumnResult, job};
 use serde::{Deserialize, Serialize};
 
 use crate::encode::{
-    FfmpegHighlightCommand, FfmpegPosterCommand, FfmpegPreviewSpriteCommand, PREVIEW_CELL_HEIGHT,
-    PREVIEW_CELL_WIDTH, PREVIEW_FRAME_INTERVAL_SECONDS, PREVIEW_SPRITE_COLUMNS,
-    build_preview_webvtt,
+    FfmpegHighlightCommand, FfmpegPosterCommand, FfmpegPreviewSpriteCommand,
+    FfmpegRoomCompositeCommand, PREVIEW_CELL_HEIGHT, PREVIEW_CELL_WIDTH,
+    PREVIEW_FRAME_INTERVAL_SECONDS, PREVIEW_SPRITE_COLUMNS, build_preview_webvtt,
 };
 use crate::error::MediaError;
 use crate::sink::{MediaArtifact, MediaArtifactFile, MediaArtifactKind, MediaArtifactSinkExt};
@@ -94,6 +94,23 @@ pub struct TranscodeJobArgs {
     /// Caller-supplied workflow id echoed back to the sink.
     pub workflow_id: String,
     /// Caller-supplied source identifier echoed back.
+    #[serde(default)]
+    pub source_id: Option<String>,
+}
+
+/// Arguments for the room-composite job, which tiles every participant's
+/// recording into one composited MP4 (see [`FfmpegRoomCompositeCommand`]).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoomCompositeJobArgs {
+    /// One recording per room participant (`2..=6`), tiled into the grid.
+    pub source_paths: Vec<PathBuf>,
+    /// Caller-relative storage key for the composited MP4.
+    pub output_key: String,
+    /// MIME content type to persist the output with.
+    pub content_type: String,
+    /// Caller-supplied workflow id echoed back to the sink.
+    pub workflow_id: String,
+    /// Caller-supplied source identifier (e.g. a room id) echoed back.
     #[serde(default)]
     pub source_id: Option<String>,
 }
@@ -168,6 +185,19 @@ async fn transcode_window(state: AppState, args: TranscodeJobArgs) -> AutumnResu
 }
 
 #[job(
+    name = "autumn_media_compose_room_recording",
+    max_attempts = 3,
+    backoff_ms = 1000,
+    queue = "media"
+)]
+async fn compose_room_recording(state: AppState, args: RoomCompositeJobArgs) -> AutumnResult<()> {
+    let (storage, ffmpeg) = resolve_engine(&state)?;
+    let workflow_id = args.workflow_id.clone();
+    let result = run_room_composite(&ffmpeg, &storage, args).await;
+    deliver_result(&state, MediaArtifactKind::Transcode, workflow_id, result).await
+}
+
+#[job(
     name = "autumn_media_finalize_recording",
     max_attempts = 3,
     backoff_ms = 1000,
@@ -209,6 +239,7 @@ pub fn media_job_infos(queue: &str) -> Vec<JobInfo> {
         __autumn_job_info_extract_thumbnail(),
         __autumn_job_info_extract_preview(),
         __autumn_job_info_transcode_window(),
+        __autumn_job_info_compose_room_recording(),
         __autumn_job_info_finalize_recording(),
     ]
     .into_iter()
@@ -252,6 +283,8 @@ pub enum MediaWorkflowRequest {
     Preview(Box<PreviewJobArgs>),
     /// A transcode-window request.
     Transcode(Box<TranscodeJobArgs>),
+    /// A room-composite request.
+    RoomComposite(Box<RoomCompositeJobArgs>),
     /// A recording-finalize orchestration request.
     Finalize(Box<FinalizeRecordingJobArgs>),
 }
@@ -327,6 +360,21 @@ impl MediaWorkflows {
             .await
     }
 
+    /// Queue a room-composite encode (tile every participant recording into one
+    /// composited MP4).
+    ///
+    /// # Errors
+    ///
+    /// Returns any error from the runtime delegate or the fallback enqueue.
+    pub async fn queue_room_composite(
+        &self,
+        state: &AppState,
+        args: RoomCompositeJobArgs,
+    ) -> AutumnResult<()> {
+        self.dispatch(state, MediaWorkflowRequest::RoomComposite(Box::new(args)))
+            .await
+    }
+
     /// Queue a recording-finalize orchestration (poster + seek-preview).
     ///
     /// # Errors
@@ -353,6 +401,9 @@ impl MediaWorkflows {
             MediaWorkflowRequest::Thumbnail(args) => ExtractThumbnailJob::enqueue(*args).await,
             MediaWorkflowRequest::Preview(args) => ExtractPreviewJob::enqueue(*args).await,
             MediaWorkflowRequest::Transcode(args) => TranscodeWindowJob::enqueue(*args).await,
+            MediaWorkflowRequest::RoomComposite(args) => {
+                ComposeRoomRecordingJob::enqueue(*args).await
+            }
             MediaWorkflowRequest::Finalize(args) => FinalizeRecordingJob::enqueue(*args).await,
         }
     }
@@ -540,6 +591,34 @@ async fn run_transcode(
     })
 }
 
+async fn run_room_composite(
+    ffmpeg_bin: &str,
+    storage: &MediaStorage,
+    args: RoomCompositeJobArgs,
+) -> Result<MediaArtifact, MediaError> {
+    let (output_path, ephemeral) = staged_output(storage, &args.output_key, "mp4")?;
+    let command =
+        FfmpegRoomCompositeCommand::new(ffmpeg_bin, args.source_paths.clone(), output_path.clone());
+    let bytes = run_blocking(move || command.run()).await?;
+    let file = persist_and_cleanup(
+        storage,
+        &args.output_key,
+        &output_path,
+        &args.content_type,
+        bytes,
+        ephemeral,
+    )
+    .await?;
+    Ok(MediaArtifact {
+        kind: MediaArtifactKind::Transcode,
+        workflow_id: args.workflow_id,
+        source_id: args.source_id,
+        primary: file,
+        secondary: None,
+        metadata: BTreeMap::new(),
+    })
+}
+
 /// Run a blocking encode closure off the async runtime.
 async fn run_blocking<F>(f: F) -> Result<u64, MediaError>
 where
@@ -678,8 +757,9 @@ async fn write_text_file(path: &Path, contents: &str) -> Result<(), MediaError> 
 mod tests {
     use super::{
         FinalizeRecordingJobArgs, MediaWorkflowDelegate, MediaWorkflowDelegateExt,
-        MediaWorkflowRequest, MediaWorkflows, PreviewJobArgs, ThumbnailJobArgs, TranscodeJobArgs,
-        extract_thumbnail, media_job_infos, persist_and_cleanup, staged_output,
+        MediaWorkflowRequest, MediaWorkflows, PreviewJobArgs, RoomCompositeJobArgs,
+        ThumbnailJobArgs, TranscodeJobArgs, compose_room_recording, extract_thumbnail,
+        media_job_infos, persist_and_cleanup, staged_output,
     };
     use crate::sink::MediaArtifactSinkExt;
     use crate::sink::tests::CountingSink;
@@ -709,12 +789,13 @@ mod tests {
     #[test]
     fn media_job_infos_override_declared_queue() {
         let infos = media_job_infos("custom-queue");
-        assert_eq!(infos.len(), 4);
+        assert_eq!(infos.len(), 5);
         assert!(infos.iter().all(|info| info.queue == "custom-queue"));
         let names: Vec<&str> = infos.iter().map(|info| info.name.as_str()).collect();
         assert!(names.contains(&"autumn_media_extract_thumbnail"));
         assert!(names.contains(&"autumn_media_extract_preview"));
         assert!(names.contains(&"autumn_media_transcode_window"));
+        assert!(names.contains(&"autumn_media_compose_room_recording"));
         assert!(names.contains(&"autumn_media_finalize_recording"));
     }
 
@@ -916,6 +997,77 @@ mod tests {
             std::path::Path::new(&file.storage_uri).exists(),
             "local backend keeps the served file in place"
         );
+    }
+
+    fn room_composite_args(sources: Vec<PathBuf>) -> RoomCompositeJobArgs {
+        RoomCompositeJobArgs {
+            source_paths: sources,
+            output_key: "rooms/room-7.mp4".to_owned(),
+            content_type: "video/mp4".to_owned(),
+            workflow_id: "wf-room".to_owned(),
+            source_id: Some("room-7".to_owned()),
+        }
+    }
+
+    #[test]
+    fn room_composite_args_round_trip_through_json() {
+        let args = room_composite_args(vec![
+            PathBuf::from("/rec/a.mp4"),
+            PathBuf::from("/rec/b.mp4"),
+        ]);
+        let back: RoomCompositeJobArgs =
+            serde_json::from_str(&serde_json::to_string(&args).expect("ser")).expect("de");
+        assert_eq!(args, back);
+    }
+
+    #[tokio::test]
+    async fn dispatch_routes_room_composite_to_delegate() {
+        let state = AppState::for_test();
+        let seen = Arc::new(std::sync::Mutex::new(None::<MediaWorkflowRequest>));
+        let seen_c = seen.clone();
+        let delegate: MediaWorkflowDelegate = Arc::new(move |_state, request| {
+            *seen_c.lock().expect("lock") = Some(request);
+            Box::pin(async { Ok(()) })
+        });
+        state.insert_extension(MediaWorkflowDelegateExt(delegate));
+
+        let workflows = MediaWorkflows::new("ffmpeg", "media");
+        workflows
+            .queue_room_composite(
+                &state,
+                room_composite_args(vec![
+                    PathBuf::from("/rec/a.mp4"),
+                    PathBuf::from("/rec/b.mp4"),
+                ]),
+            )
+            .await
+            .expect("delegate path returns Ok");
+        assert!(matches!(
+            seen.lock().expect("lock").as_ref(),
+            Some(MediaWorkflowRequest::RoomComposite(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn room_composite_job_reports_failure_to_sink_when_source_missing() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let state = AppState::for_test();
+        state.insert_extension(local_storage(temp.path()));
+        state.insert_extension(MediaWorkflows::new("ffmpeg", "media"));
+        let sink = Arc::new(CountingSink::new());
+        state.insert_extension(MediaArtifactSinkExt(sink.clone()));
+
+        // Two source paths that do not exist → require_sources fails before
+        // FFmpeg is ever spawned, so this test needs no binary.
+        let args = room_composite_args(vec![
+            temp.path().join("missing-a.mp4"),
+            temp.path().join("missing-b.mp4"),
+        ]);
+        let result = compose_room_recording(state, args).await;
+
+        assert!(result.is_err(), "missing sources must fail the job");
+        assert_eq!(sink.failed.load(Ordering::SeqCst), 1);
+        assert_eq!(sink.completed.load(Ordering::SeqCst), 0);
     }
 
     #[test]


### PR DESCRIPTION
Part of #1974.

## Before / After
Before: `autumn-media-plugin` had the broadcast-oriented transport / storage / encode / workflow layers (slices 0–5) but no room primitive and an empty HTTP route set — `/api/media/rooms` existed only as a conformance-test placeholder.

After: an app that enables rooms on the plugin (`with_rooms()`) gets a working `/api/media/rooms` signaling API — create a room, join it (receiving a short-lived per-participant session token plus a WHIP publish URL and per-peer WHEP subscribe URLs), read the roster, and leave — a `RoomService` extension to drive rooms programmatically, and a `compose_room_recording` grid workflow. Also folds in the three cheapest deferred hardening items from the epic.

## Rooms (slice 6)
- New `rooms` module: `Room` / `RoomParticipant`, a namespace-scoped `RoomStore` trait with an `InMemoryRoomStore` default, a `RoomService` AppState extension (create / join / leave / roster), and an axum `room_router()` nested under the configured `api(prefix)` (default `/api/media`).
- **Fail-closed isolation**: rooms are keyed by `(namespace, room_id)`; a lookup/join/leave/roster under a mismatched namespace returns `RoomNotFound` (never leaks existence, no room-by-id-alone path). Namespace is caller-supplied (default none), producing the MediaMTX path `room/{namespace?}/{room_id}/{participant_id}`; every segment passes a slug-safe guard (`validate_room_segment`) before any URL is composed.
- **Tokens**: opaque random `SessionToken` (uuid v4), redacted in `Debug`, verified with `autumn_web::auth::constant_time_eq` plus a short TTL (default 300 s). Tokens are never serialized into roster/`RoomSnapshot` views — only into the join response for the joining participant. No JWT, no new dependency.
- **Mesh**: each participant WHIP-publishes its own path and WHEP-subscribes to the ≤5 peers — O(N²) subscriptions, hard cap 6, SFU explicitly out of scope.
- **Config**: flat `[media]` keys `room_max_participants` (≤ 6), `room_token_ttl_seconds`, `room_namespace` with `AUTUMN_MEDIA__ROOM_*` env overrides; `room_max_participants` / `room_token_ttl_seconds` / `room_namespace` builders. `validate()` rejects a 0 or &gt; 6 cap.
- **`compose_room_recording`**: a composited-grid MP4 (`FfmpegRoomCompositeCommand`, xstack/hstack video + amix audio) delivered as a `#[job]` on the `media` queue and dispatched through the existing `MediaWorkflowDelegate` seam — no workflow-engine dependency in this repo.

## Deferred hardening — 3 of the epic&#39;s 6 items folded in
- Taken: (1) sub-second VOD start anchor (`SecondsFormat::AutoSi`); (2) MediaMTX paths-list pagination (walks all pages, not just the first 1000); (3) reject dot-only storage-key segments at the `persist_file` boundary.
- Remaining on the epic (unchanged, still recorded there): encode output buffering (streaming pipes), encode non-UTF-8 (`OsString`) paths, storage generic-S3 Tigris-fallback.

## Limitations (recorded in `rooms.rs` module docs)
- `InMemoryRoomStore` is single-process; `RoomStore` is the swap seam for a shared/backed registry (multi-process deployments).
- Operators must add a `~^room/.+$` MediaMTX path matcher; embedding pages must allow the MediaMTX WebRTC origin (`:8889`) in their `connect-src` CSP.
- Autumn&#39;s `#[job]` macro exposes no timeout/heartbeat attributes, so the spec&#39;s &#34;120 s timeout / 30 s heartbeat&#34; is not expressible; retry is `max_attempts = 3, backoff_ms = 1000`.

## Testing
`cargo fmt -p autumn-media-plugin -- --check`, `cargo clippy -p autumn-media-plugin --all-targets -- -D warnings`, and `cargo test -p autumn-media-plugin` all clean — 192 tests pass. All new tests are inline, matching the crate&#39;s convention.

## Do not
- Do not push to any other branch, do not force-push, do not open a non-draft PR, do not edit any file (this is a push+PR task only).

---
_Generated by [Claude Code](https://claude.ai/code/session_017GV4VbxUCqHXxxLc8Lbrcj)_

---

## Review updates

Two follow-up commits address automated-review findings (draft was flipped ready between them):

**`222879b` — fail-fast room cap + token-Debug redaction (adversarial review + Gemini):**
- The room seat cap of 6 is now an absolute ceiling: an out-of-range value (0 or &gt;6) from config or the `room_max_participants` builder fails the app&#39;s startup with a specific error naming the value and the ceiling (no silent clamp); the store keeps a fixed-6 backstop. The builder tunes the seat count only within 1..=6.
- `LeaveRequest.session_token` now has a manual redacted `Debug` (was a plain `String`) — closes a cleartext-token log path.
- `FfmpegRoomCompositeCommand::run()` rejects &gt;6 inputs to match its doc; `run_room_composite` destructures its args to drop needless clones.

**`29cbc63` — leave liveness + roster access control (Codex P1s):**
- **Leave always works.** Participant leave now authorizes by a constant-time token *value* match only, never expiry — a call outlasting the token TTL can still remove participants, so seats no longer leak. `token_expires_at` remains advisory metadata (returned at join for a future media-auth/renewal slice) and currently gates nothing, since MediaMTX does not verify these tokens yet.
- **Full mesh is discoverable, and the roster is member-only.** `GET /api/media/rooms/{room_id}` now returns a per-participant subscribe target (`whep_url` + `path`) so existing members poll the roster and subscribe to later joiners (client-poll discovery; no server push this slice). Because the roster hands out per-peer WHEP media endpoints, it is gated on a valid member session token presented as `Authorization: Bearer `; a missing/wrong token returns the same `404` as a nonexistent room (fail-closed, no existence/membership oracle). Tokens are never serialized into the roster.

**`3fb4162` — room-registry cap + flat config keys (Codex P1/P2):**
- **Bounded room registry.** `InMemoryRoomStore` now caps the number of live rooms at `MAX_ROOMS` (10,000); `POST /rooms` returns `503` (`RegistryFull`) at capacity instead of growing memory unbounded. The room router ships no built-in auth/rate-limiting this slice and must be mounted behind the host app&#39;s auth/rate-limit middleware (documented in the module docs); empty/idle-room reaping remains recorded future work on #1974.
- **Flat room config restored.** Reverted the `[media.rooms]` sub-table back to the flat `[media]` keys the spec names — `room_max_participants`, `room_token_ttl_seconds`, `room_namespace` (env `AUTUMN_MEDIA__ROOM_*`) — so the pre-existing `room_max_participants` key and its README docs keep working (no silent config regression).

**`61d38ab` — namespace boot fail-fast + composite audio assumption (Codex P2s):**
- **Invalid `room_namespace` now fails fast.** A configured `room_namespace` that isn&#39;t a valid slug-safe path segment (e.g. `tenant/a`, `.`) now aborts startup with a specific error, instead of mounting a rooms API where every `POST /rooms` would fail — mirroring the participant-cap fail-fast.
- **Composite audio assumption documented.** `compose_room_recording` requires each participant recording to carry an audio track (the `amix` filtergraph references every input&#39;s audio); video-only participants are unsupported for composition this slice (per-participant recordings are unaffected). Robust per-input audio detection is recorded as future work on #1974.

### Known limitation (recorded on #1974&#39;s deferred list)
There is no automatic reaping of abandoned participants — a client that never sends leave holds its seat until the room is emptied. A stale-participant / idle-room reaper is future work.