### PR TITLE
test: un-gate pam_systemd deploy e2e test

### DIFF
--- a/autumn-cli/Cargo.toml
+++ b/autumn-cli/Cargo.toml
@@ -31,12 +31,6 @@ tls = ["autumn-web/tls"]
 # this keeps CLI/library feature parity and turns on `autumn-web/acme` for any
 # future ACME-aware CLI tooling. Implies `tls` (ACME builds on it).
 acme = ["tls", "autumn-web/acme"]
-# Opt-in gate for the pam_systemd kamal-proxy control-socket regression in
-# `tests/deploy_e2e.rs` (issue #1948 item 4). It is NOT part of the default
-# Docker CI `--ignored` sweep because the socket behaviour under a live
-# pam_systemd session can only be observed against Docker; enable it to run that
-# one extra `#[ignore]`d test. No production code depends on this feature.
-deploy-e2e-pam = []
 
 [dependencies]
 autumn-web = { version = "0.6.0", path = "../autumn", default-features = false, features = [

--- a/autumn-cli/tests/deploy_e2e.rs
+++ b/autumn-cli/tests/deploy_e2e.rs
@@ -711,18 +711,17 @@ fn deploy_e2e_full_lifecycle() {
 /// invocation in `KamalProxyController`) holds without the fixture papering over
 /// the mismatch.
 ///
-/// Feature-gated behind `deploy-e2e-pam` (NOT part of the default Docker CI
-/// `--ignored` sweep): the socket behaviour under a live `pam_systemd` session can
-/// only be observed against Docker, which this environment cannot run, so it is
-/// opt-in to avoid destabilizing CI on an unverified path. Run it with:
+/// Runs as part of the default Docker CI `--ignored` sweep (same as the sibling
+/// `deploy_e2e_full_lifecycle`): the "Run Docker-dependent tests" job executes
+/// `cargo test -p autumn-cli --test deploy_e2e -- --ignored`, which picks this up
+/// automatically. Run it locally the same way:
 /// ```text
-/// cargo test -p autumn-cli --features deploy-e2e-pam --test deploy_e2e -- --ignored --nocapture
+/// cargo test -p autumn-cli --test deploy_e2e -- --ignored --nocapture
 /// ```
 /// The real-VPS GitHub Actions job (`.github/workflows/deploy-real-vps.yml`)
 /// covers the same fidelity end-to-end on an actual VM.
-#[cfg(feature = "deploy-e2e-pam")]
 #[test]
-#[ignore = "requires Docker + ssh client; run with --features deploy-e2e-pam --ignored"]
+#[ignore = "requires Docker + ssh client; run with --ignored"]
 fn deploy_e2e_pam_systemd_control_socket() {
     let ws = Workspace::build();
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -427,8 +427,9 @@ systemd + kamal-proxy — nothing is mocked:
   harness's curl/ssh assertions while driving the real `autumn` binary; the
   Hetzner-specific provisioning is isolated in the workflow so another provider
   can be swapped in without touching the script. The in-container half of the
-  pam_systemd socket check is also available on demand via
-  `cargo test -p autumn-cli --features deploy-e2e-pam --test deploy_e2e -- --ignored`.
+  pam_systemd socket check runs as part of the standard
+  `cargo test -p autumn-cli --test deploy_e2e -- --ignored` Docker sweep (no
+  separate feature needed).
 
 ---
 


### PR DESCRIPTION
## Before / After

**Before:** the `pam_systemd` kamal-proxy control-socket regression test (`deploy_e2e_pam_systemd_control_socket` in `autumn-cli/tests/deploy_e2e.rs`) only compiled behind an opt-in `deploy-e2e-pam` cargo feature. No CI job passed that feature, so the test **never ran in CI** — the regression it guards was effectively unprotected.

**After:** the test compiles by default and runs in the existing "Run Docker-dependent tests" ubuntu sweep alongside `deploy_e2e_full_lifecycle`, via the bare `cargo test -p autumn-cli --test deploy_e2e -- --ignored` invocation. **No workflow change** is needed — the sweep already picks up every `#[ignore]`d test in the default binary.

## How

- Removed the `#[cfg(feature = "deploy-e2e-pam")]` gate on the test.
- Removed the empty `deploy-e2e-pam = []` feature (and its explanatory comment) from `autumn-cli/Cargo.toml`; `default`/`tls`/`acme` are untouched.
- Reworded the stale doc comment and the `docs/guide/deployment.md` run-command reference from the `--features deploy-e2e-pam` form to the standard `--ignored` Docker sweep. The real-VPS `deploy-real-vps.yml` narrative is preserved, as is what the test proves.

Verified: run under Docker and passed (privileged systemd-in-Docker fixture; asserts `XDG_RUNTIME_DIR=/run/user/0`, deploy-up success, traffic served through kamal-proxy).

References #2019 (which introduced the gate).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPw736F7Hs65HQ6nZTD4Pa)_