### PR TITLE
ci: add Windows (x86_64-pc-windows-msvc) CLI release binary

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,7 +1,7 @@
 name: CLI Release Binaries
 
 # Builds prebuilt `autumn` CLI binaries for Linux + macOS (x86_64 + aarch64)
-# and attaches them — with sha256 checksums — to a GitHub Release.
+# and Windows (x86_64) and attaches them — with sha256 checksums — to a GitHub Release.
 #
 # Binaries correspond to DELIBERATE, TAGGED CRATE RELEASES, not trunk. This is a
 # reusable workflow invoked by `release.yml` (its `binaries` job) right after the
@@ -21,11 +21,12 @@ name: CLI Release Binaries
 # current ref for validation (uploads workflow artifacts, no release upload).
 #
 # Distribution contract (see scripts/install.sh and the README "Install" section):
-#   - Version-pinned: .../releases/download/<tag>/autumn-<target>.tar.gz
-#   - Stable latest:  .../releases/latest/download/autumn-<target>.tar.gz
+#   - Version-pinned: .../releases/download/<tag>/autumn-<target>.tar.gz  (Windows: .zip)
+#   - Stable latest:  .../releases/latest/download/autumn-<target>.tar.gz (Windows: .zip)
 # Asset names are intentionally version-less so the latest/download URL is stable.
-# Linux targets build via `cross` (musl, no glibc dependency); macOS targets build
-# natively on macOS runners. Windows is a documented follow-up (see #2005).
+# Linux targets build via `cross` (musl, no glibc dependency); macOS and Windows
+# targets build natively on their runners. The Windows binary (autumn.exe) ships as
+# a .zip packaged with PowerShell (Git-bash on windows-latest lacks `zip`); see #2005.
 
 on:
   workflow_call:
@@ -68,6 +69,11 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
             cross: false
+          # Native windows-latest build (aws-lc crypto stack builds there — see ci.yml).
+          # NOT cross: `cross` is Linux-container only. Packaged as a .zip, not a tarball.
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            cross: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -93,7 +99,9 @@ jobs:
         if: ${{ ! matrix.cross }}
         run: cargo build --locked -p autumn-cli --release --bin autumn --target ${{ matrix.target }}
 
+      # Linux/macOS: tarball the `autumn` binary + licenses, checksum with coreutils.
       - name: Package tarball + checksum
+        if: ${{ runner.os != 'Windows' }}
         run: |
           set -euo pipefail
           asset="autumn-${{ matrix.target }}.tar.gz"
@@ -109,23 +117,41 @@ jobs:
           echo "--- checksum ---"
           cat "$asset.sha256"
 
+      # Windows: zip the `autumn.exe` binary + licenses (Git-bash has no `zip`),
+      # and emit a sha256sum-format checksum ("<hash>  <file>") via Get-FileHash.
+      - name: Package zip + checksum (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          $asset = "autumn-${{ matrix.target }}.zip"
+          $staging = Join-Path $env:RUNNER_TEMP "autumn-stage"
+          New-Item -ItemType Directory -Path $staging -Force | Out-Null
+          Copy-Item "target/${{ matrix.target }}/release/autumn.exe" (Join-Path $staging "autumn.exe")
+          Copy-Item LICENSE-MIT, LICENSE-APACHE $staging -ErrorAction SilentlyContinue
+          Compress-Archive -Path (Join-Path $staging '*') -DestinationPath $asset -Force
+          $hash = (Get-FileHash -Algorithm SHA256 $asset).Hash.ToLower()
+          # Match `sha256sum` output format so downstream verification is uniform.
+          Set-Content -Path "$asset.sha256" -Value "$hash  $asset" -Encoding ascii
+          Write-Host "--- checksum ---"
+          Get-Content "$asset.sha256"
+
+      # Glob covers both the Linux/macOS `.tar.gz(.sha256)` and Windows `.zip(.sha256)` assets.
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4
         with:
           name: autumn-${{ matrix.target }}
-          path: |
-            autumn-${{ matrix.target }}.tar.gz
-            autumn-${{ matrix.target }}.tar.gz.sha256
+          path: autumn-${{ matrix.target }}.*
           if-no-files-found: error
 
       - name: Attach to release
         if: ${{ inputs.tag != '' }}
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
+          # Glob expands to the archive + its .sha256 (.tar.gz on Linux/macOS, .zip on Windows).
           gh release upload "$TAG" \
-            "autumn-${{ matrix.target }}.tar.gz" \
-            "autumn-${{ matrix.target }}.tar.gz.sha256" \
+            autumn-${{ matrix.target }}.* \
             --clobber --repo "$GITHUB_REPOSITORY"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,24 @@ Prefer a manual download? Grab the tarball plus its `.sha256`:
 - Latest: `https://github.com/madmax983/autumn/releases/latest/download/autumn-<target>.tar.gz`
 - Pinned: `https://github.com/madmax983/autumn/releases/download/<tag>/autumn-<target>.tar.gz`
 
-where `<target>` is one of `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`, `x86_64-apple-darwin`, or `aarch64-apple-darwin` (Linux binaries are static musl — no glibc version dependency). Binaries track tagged crate releases (e.g. `v0.6.0`); `latest` is the most recent released version — there are no rolling trunk-dev builds. Windows is a documented follow-up (see #2005); build from source there for now.
+where `<target>` is one of `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`, `x86_64-apple-darwin`, or `aarch64-apple-darwin` (Linux binaries are static musl — no glibc version dependency). Binaries track tagged crate releases (e.g. `v0.6.0`); `latest` is the most recent released version — there are no rolling trunk-dev builds.
+
+### Install a prebuilt binary (Windows)
+
+Windows ships a native `x86_64-pc-windows-msvc` build as a `.zip` (not a tarball). The POSIX `install.sh` above does not run on Windows; use the PowerShell installer instead:
+
+```powershell
+irm https://raw.githubusercontent.com/madmax983/autumn/trunk-dev/scripts/install.ps1 | iex
+```
+
+It downloads `autumn-x86_64-pc-windows-msvc.zip`, verifies its sha256 (`Get-FileHash`), extracts `autumn.exe` to `%LOCALAPPDATA%\autumn\bin`, and prints the line to add if that directory isn't on your `PATH`. Override the install dir with `-Dir`, or pin a version with `-Version vX.Y.Z`.
+
+Prefer a manual download? Grab the zip plus its `.sha256`:
+
+- Latest: `https://github.com/madmax983/autumn/releases/latest/download/autumn-x86_64-pc-windows-msvc.zip`
+- Pinned: `https://github.com/madmax983/autumn/releases/download/<tag>/autumn-x86_64-pc-windows-msvc.zip`
+
+Verify with `Get-FileHash autumn-x86_64-pc-windows-msvc.zip -Algorithm SHA256` and compare against the `.sha256` file, then extract `autumn.exe` and put it on your `PATH`.
 
 Prefer building from source? `cargo install --path autumn-cli` still works.
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,6 +34,10 @@ param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+# Windows PowerShell 5.1 doesn't enable TLS 1.2 by default, which breaks GitHub
+# downloads. Opt in explicitly before any network call.
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
 $target = 'x86_64-pc-windows-msvc'
 $asset  = "autumn-$target.zip"
 
@@ -71,11 +75,13 @@ try {
     Copy-Item -Path $exe -Destination $dest -Force
     Write-Host "autumn-install: installed autumn -> $dest"
 
-    $pathEntries = ($env:PATH -split ';')
-    if ($pathEntries -notcontains $Dir) {
+    $pathEntries = ($env:PATH -split ';') | ForEach-Object { $_.TrimEnd('\') }
+    $normalizedDir = $Dir.TrimEnd('\')
+    if ($pathEntries -notcontains $normalizedDir) {
         Write-Host "autumn-install: note: $Dir is not on your PATH."
         Write-Host "  Add it for the current session:  `$env:PATH = `"$Dir;`$env:PATH`""
-        Write-Host "  Or persist it for your user:      setx PATH `"$Dir;`$env:PATH`""
+        Write-Host "  Or persist it for your user:"
+        Write-Host "    [Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';$Dir', 'User')"
     }
 
     & $dest --version

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,84 @@
+<#
+.SYNOPSIS
+    Autumn CLI installer for Windows (x86_64-pc-windows-msvc).
+
+.DESCRIPTION
+    Downloads a prebuilt `autumn.exe` from GitHub Releases, verifies its sha256
+    checksum, and installs it. This is the Windows counterpart to the POSIX
+    scripts/install.sh (which covers Linux and macOS). Binaries correspond to
+    tagged crate releases; "latest" is the most recent release.
+
+    Run it directly:
+        irm https://raw.githubusercontent.com/madmax983/autumn/trunk-dev/scripts/install.ps1 | iex
+
+    Or with options after downloading:
+        .\install.ps1 -Version v0.6.0 -Dir C:\tools\autumn
+
+.PARAMETER Version
+    Version tag to install, or "latest" (default: latest). Env override: AUTUMN_VERSION.
+
+.PARAMETER Dir
+    Install directory (default: %LOCALAPPDATA%\autumn\bin). Env override: AUTUMN_INSTALL_DIR.
+
+.PARAMETER BaseUrl
+    Release base URL (default: https://github.com/madmax983/autumn/releases).
+    Env override: AUTUMN_BASE_URL.
+#>
+[CmdletBinding()]
+param(
+    [string]$Version = $(if ($env:AUTUMN_VERSION) { $env:AUTUMN_VERSION } else { 'latest' }),
+    [string]$Dir     = $(if ($env:AUTUMN_INSTALL_DIR) { $env:AUTUMN_INSTALL_DIR } else { Join-Path $env:LOCALAPPDATA 'autumn\bin' }),
+    [string]$BaseUrl = $(if ($env:AUTUMN_BASE_URL) { $env:AUTUMN_BASE_URL } else { 'https://github.com/madmax983/autumn/releases' })
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$target = 'x86_64-pc-windows-msvc'
+$asset  = "autumn-$target.zip"
+
+if ($Version -eq 'latest') {
+    $url = "$BaseUrl/latest/download/$asset"
+} else {
+    $url = "$BaseUrl/download/$Version/$asset"
+}
+
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("autumn-install-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+try {
+    $zipPath = Join-Path $tmp $asset
+    $shaPath = "$zipPath.sha256"
+
+    Write-Host "autumn-install: downloading $asset ($Version)"
+    Invoke-WebRequest -Uri $url -OutFile $zipPath -UseBasicParsing
+    Invoke-WebRequest -Uri "$url.sha256" -OutFile $shaPath -UseBasicParsing
+
+    # The .sha256 file is "<hash>  <filename>" (sha256sum format); take the first field.
+    $expected = ((Get-Content -Path $shaPath -Raw).Trim() -split '\s+')[0].ToLower()
+    if (-not $expected) { throw "empty checksum from $url.sha256" }
+    $actual = (Get-FileHash -Path $zipPath -Algorithm SHA256).Hash.ToLower()
+    if ($expected -ne $actual) {
+        throw "checksum mismatch: expected $expected, got $actual"
+    }
+    Write-Host "autumn-install: checksum ok ($actual)"
+
+    Expand-Archive -Path $zipPath -DestinationPath $tmp -Force
+    $exe = Join-Path $tmp 'autumn.exe'
+    if (-not (Test-Path $exe)) { throw "archive did not contain autumn.exe" }
+
+    New-Item -ItemType Directory -Path $Dir -Force | Out-Null
+    $dest = Join-Path $Dir 'autumn.exe'
+    Copy-Item -Path $exe -Destination $dest -Force
+    Write-Host "autumn-install: installed autumn -> $dest"
+
+    $pathEntries = ($env:PATH -split ';')
+    if ($pathEntries -notcontains $Dir) {
+        Write-Host "autumn-install: note: $Dir is not on your PATH."
+        Write-Host "  Add it for the current session:  `$env:PATH = `"$Dir;`$env:PATH`""
+        Write-Host "  Or persist it for your user:      setx PATH `"$Dir;`$env:PATH`""
+    }
+
+    & $dest --version
+} finally {
+    Remove-Item -Path $tmp -Recurse -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Before / After

**Before:** the CLI release workflow ships only Linux-musl (x86_64 + aarch64) and macOS (x86_64 + aarch64) binaries. Windows users have **no download** — they must build from source.

**After:** a native `windows-latest` matrix leg publishes `autumn-x86_64-pc-windows-msvc.zip` + its `.sha256` checksum on each tagged release, plus a `scripts/install.ps1` PowerShell installer (the Windows counterpart to `scripts/install.sh`).

## How

- **Native `windows-latest` matrix leg** (`cross: false`) for `x86_64-pc-windows-msvc` — proven buildable since `autumn-cli` already passes `cargo test --workspace` on `windows-latest` in `ci.yml`; `cross` is Linux-container-only, so Windows builds natively.
- **`.zip` packaging** via PowerShell (`Compress-Archive` — Git-bash on `windows-latest` has no `zip`) with a `sha256sum`-format checksum from `Get-FileHash`. The existing tarball step is gated `if: runner.os != 'Windows'`, and the artifact/release-upload steps use a `autumn-<target>.*` glob so both `.tar.gz` and `.zip` assets are covered. `fail-fast: false` and the `workflow_call`/`workflow_dispatch` + `release.yml` coupling are unchanged.
- **`scripts/install.ps1`** downloads the zip from Releases, verifies the sha256, extracts `autumn.exe` to `%LOCALAPPDATA%\autumn\bin`, and prints PATH guidance (`-Version` / `-Dir` overrides). README gains a Windows install subsection.

Part of #2005.

**Validation pending**: needs a `windows-latest` run of `cli-release.yml` via `workflow_dispatch` (artifact-only) to prove packaging — runners are starved today; keep draft until green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPw736F7Hs65HQ6nZTD4Pa)_