### PR TITLE
schema migrate + doctor (declarative schema slice 6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,6 +417,7 @@ dependencies = [
  "crossterm",
  "ctrlc",
  "diesel",
+ "diesel_migrations",
  "directories",
  "getrandom 0.4.3",
  "hex",

--- a/autumn-cli/Cargo.toml
+++ b/autumn-cli/Cargo.toml
@@ -24,22 +24,56 @@ path = "src/main.rs"
 # explaining the feature is disabled). Enabling it turns on `autumn-web`'s
 # `tls` feature, whose `autumn_web::tls::inspect_leaf` does the offline
 # certificate parsing.
-default = ["tls"]
+# Default = the Postgres CLI: `tls` (below) plus the `postgres` bundle, which
+# carries the pg-only `autumn-web` features that predate — and do not compile
+# under — the sqlite backend-flip. The DEFAULT build enables exactly the same
+# `autumn-web` feature set as before (nothing dropped); only the feature GRAPH
+# is refactored so the mutually-exclusive `sqlite` build can select a
+# sqlite-compatible set.
+default = ["tls", "postgres"]
 tls = ["autumn-web/tls"]
+# The pg-only `autumn-web` features the CLI enables that assume the Postgres
+# runtime and fail to compile under the `sqlite` backend-flip. Only `mail`
+# (its `DbSuppressionStore` is hard-typed to `Pool<AsyncPgConnection>`) is a
+# genuine breaker today; it is grouped here (rather than left unconditionally on)
+# so the `sqlite` build — which excludes the `postgres` bundle — resolves a
+# mail-free `autumn-web` set that mirrors what autumn-web's OWN sqlite CI builds.
+# The CLI's own source references NO `autumn_web::mail` symbol (only generated
+# string literals), so no source `#[cfg]` gating is needed. Kept in `default`,
+# so a normal `cargo build -p autumn-cli` is byte-for-byte identical to before.
+postgres = ["autumn-web/mail"]
 # Mirrors autumn-web's `acme` feature (issue #1608). The `autumn doctor` ACME
 # preflight checks compile in every build (they only need `std`), but enabling
 # this keeps CLI/library feature parity and turns on `autumn-web/acme` for any
 # future ACME-aware CLI tooling. Implies `tls` (ACME builds on it).
 acme = ["tls", "autumn-web/acme"]
+# SQLite backend-flip for the CLI's `autumn schema migrate` (issue #1975 slice 6,
+# on top of autumn-web's #1614 sqlite runtime lane). Non-default and MUTUALLY
+# EXCLUSIVE with the default Postgres backend: it turns on `autumn-web/sqlite`,
+# which flips autumn-web's `RuntimeConnection` type alias from Postgres to SQLite
+# for the WHOLE build graph, and pulls diesel's sqlite migration backend. Because
+# cargo feature unification is global AND the `postgres` bundle (a default
+# feature) pulls the pg-only `mail` path that does not compile under the flip,
+# the sqlite CLI MUST be built with default features OFF:
+#   `cargo build -p autumn-cli --no-default-features --features sqlite`
+# NEVER `--all-features` (co-enables the Postgres path and fails to compile), and
+# never co-built with the `postgres` bundle. Default builds target Postgres and
+# reference no SQLite symbol. (See autumn-web's `sqlite` feature for parity.)
+sqlite = ["autumn-web/sqlite", "diesel_migrations/sqlite"]
 
 [dependencies]
 autumn-web = { version = "0.6.0", path = "../autumn", default-features = false, features = [
-    "db", "htmx", "maud", "mail", "storage", "i18n", "telemetry-otlp", "redis", "cache-moka", "http-client", "reporting"
+    "db", "htmx", "maud", "storage", "i18n", "telemetry-otlp", "redis", "cache-moka", "http-client", "reporting"
 ] }
 autumn-schema-core = { path = "../autumn-schema-core" }
 base64 = "0.22"
 clap = { version = "4", features = ["derive", "env"] }
 diesel = { workspace = true }
+# File-based migration source (`FileBasedMigrations`) for `autumn schema migrate`.
+# Backend-agnostic: the pg/sqlite `MigrationSource` impls come from the `diesel`
+# backend features (both on via the workspace pin). The `sqlite` CLI feature
+# additionally enables `diesel_migrations/sqlite` for parity with the flip.
+diesel_migrations = { workspace = true }
 crossterm = "0.29"
 ctrlc = "3.5.2"
 getrandom = "0.4"

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -1790,12 +1790,37 @@ fn is_valid_mailto_address_doctor(value: &str) -> bool {
 /// value fails EVERY delivery with `MailError::InvalidAddress`.
 ///
 /// lettre is reachable from the CLI via `autumn_web`'s `mail`-gated re-export
-/// (`autumn_web::reexports::lettre`); `autumn-cli` enables that feature, so no
-/// direct `lettre` dependency is required.
+/// (`autumn_web::reexports::lettre`); the default (Postgres) CLI enables that
+/// feature via the `postgres` bundle, so no direct `lettre` dependency is
+/// required.
+#[cfg(feature = "postgres")]
 fn is_valid_alert_mailbox_doctor(value: &str) -> bool {
     value
         .parse::<autumn_web::reexports::lettre::message::Mailbox>()
         .is_ok()
+}
+
+/// SQLite backend-flip build fallback: the `mail` feature (and its `lettre`
+/// re-export) is not compiled under `--features sqlite`, so this conservative
+/// syntactic check stands in for the lettre `Mailbox` parser. The alert-email
+/// doctor check is a Postgres-runtime concern; the fallback keeps the sqlite CLI
+/// compiling without pulling the pg-only `mail` path, accepting a bare
+/// `local@domain` mailbox and rejecting scheme-prefixed / whitespaced / empty
+/// values. Exact lettre parity (including RFC 5322 display-name forms) applies to
+/// the default build only.
+#[cfg(not(feature = "postgres"))]
+fn is_valid_alert_mailbox_doctor(value: &str) -> bool {
+    let value = value.trim();
+    if value.is_empty() || value.contains(':') || value.contains(char::is_whitespace) {
+        return false;
+    }
+    let mut parts = value.split('@');
+    match (parts.next(), parts.next(), parts.next()) {
+        (Some(local), Some(domain), None) => {
+            !local.is_empty() && !domain.is_empty() && domain.contains('.')
+        }
+        _ => false,
+    }
 }
 
 // ─── Pure helper functions (fully unit-testable) ──────────────────────────────
@@ -8553,6 +8578,11 @@ pub struct Vault {
         assert!(!is_absolute_http_url_doctor("http://"));
     }
 
+    // Exercises the lettre-backed parser + its runtime parity, so it is gated to
+    // the default (Postgres) build where the `mail` re-export is compiled. The
+    // sqlite-build fallback (a coarse syntactic check) is deliberately not held to
+    // lettre parity.
+    #[cfg(feature = "postgres")]
     #[test]
     fn is_valid_alert_mailbox_matches_lettre_and_accepts_display_name() {
         // Bare recipient mailboxes are accepted (this is what lettre parses at

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -1800,21 +1800,28 @@ fn is_valid_alert_mailbox_doctor(value: &str) -> bool {
         .is_ok()
 }
 
-/// SQLite backend-flip build fallback: the `mail` feature (and its `lettre`
-/// re-export) is not compiled under `--features sqlite`, so this conservative
-/// syntactic check stands in for the lettre `Mailbox` parser. The alert-email
-/// doctor check is a Postgres-runtime concern; the fallback keeps the sqlite CLI
-/// compiling without pulling the pg-only `mail` path, accepting a bare
-/// `local@domain` mailbox and rejecting scheme-prefixed / whitespaced / empty
-/// values. Exact lettre parity (including RFC 5322 display-name forms) applies to
-/// the default build only.
+/// `SQLite` backend-flip build fallback: the `mail` feature (and its `lettre`
+/// re-export) is not compiled under `--features sqlite`, so this syntactic check
+/// stands in for the lettre `Mailbox` parser. The alert-email doctor check is a
+/// Postgres-runtime concern; the fallback keeps the sqlite CLI compiling without
+/// pulling the pg-only `mail` path while agreeing with lettre for the cases
+/// doctor validates: it accepts a bare `local@domain` mailbox and the RFC 5322
+/// display-name form `Name <local@domain>` (validating the bracketed address),
+/// and rejects scheme-prefixed / whitespaced / `@`-malformed / empty values. Full
+/// lettre parity applies to the default (Postgres) build.
 #[cfg(not(feature = "postgres"))]
 fn is_valid_alert_mailbox_doctor(value: &str) -> bool {
     let value = value.trim();
-    if value.is_empty() || value.contains(':') || value.contains(char::is_whitespace) {
+    // Accept `Name <local@domain>` by validating the bracketed address; the
+    // display-name text before `<` is free-form and not checked.
+    let addr = match (value.rfind('<'), value.rfind('>')) {
+        (Some(lt), Some(gt)) if gt > lt => value[lt + 1..gt].trim(),
+        _ => value,
+    };
+    if addr.is_empty() || addr.contains(':') || addr.contains(char::is_whitespace) {
         return false;
     }
-    let mut parts = value.split('@');
+    let mut parts = addr.split('@');
     match (parts.next(), parts.next(), parts.next()) {
         (Some(local), Some(domain), None) => {
             !local.is_empty() && !domain.is_empty() && domain.contains('.')
@@ -12353,6 +12360,11 @@ foo = "bar"
         assert_eq!(r.status, CheckStatus::Pass);
     }
 
+    // `KNOWN_TOML_SECTIONS` lists `mail`, but autumn-web's config schema
+    // (`get_schema_keys`) drops the `[mail]` section under the sqlite backend-flip
+    // build (mail feature off), so this static-list-vs-runtime-schema parity check
+    // is gated to the default (Postgres) build where `[mail]` is compiled in.
+    #[cfg(feature = "postgres")]
     #[test]
     fn check_toml_content_all_known_sections_pass() {
         let content: String = KNOWN_TOML_SECTIONS

--- a/autumn-cli/src/generate/mod.rs
+++ b/autumn-cli/src/generate/mod.rs
@@ -319,7 +319,26 @@ pub fn read_or_empty(path: &Path) -> String {
 /// `SQLite` (AC #4).
 #[must_use]
 pub fn detect_backend(project_root: &Path) -> autumn_web::config::DatabaseBackend {
-    let effective = crate::migrate::effective_profile(None);
+    detect_backend_for_profile(project_root, None)
+}
+
+/// Profile-aware variant of [`detect_backend`]: resolves the project's database
+/// backend for an explicit `--profile` (else the ambient profile resolution when
+/// `profile` is `None`).
+///
+/// Schema commands that honor an explicit `--profile` (`schema migrate`,
+/// `schema doctor`) must detect the backend of the SAME profile whose database
+/// URL they act against — otherwise a project whose default backend differs from
+/// the selected profile's would pick the wrong apply path / provider-lock. This
+/// resolves the effective profile through [`crate::migrate::effective_profile`]
+/// (so `profile == None` reproduces [`detect_backend`] byte-for-byte) and reuses
+/// the same profile-aware config/`.env` resolution as [`detect_backend_with`].
+#[must_use]
+pub fn detect_backend_for_profile(
+    project_root: &Path,
+    profile: Option<&str>,
+) -> autumn_web::config::DatabaseBackend {
+    let effective = crate::migrate::effective_profile(profile);
     detect_backend_with(project_root, Some(&effective), |k| std::env::var(k))
 }
 

--- a/autumn-cli/src/schema/doctor.rs
+++ b/autumn-cli/src/schema/doctor.rs
@@ -136,13 +136,20 @@ pub fn run_doctor(profile: Option<&str>, json: bool) -> Result<(), String> {
 fn gather_local_facts(project_root: &Path, profile: Option<&str>) -> LocalFacts {
     let cargo_toml_present = project_root.join("Cargo.toml").is_file();
     let autumn_dir_present = project_root.join(".autumn").is_dir();
-    let detected_backend =
-        super::map_detected_backend(crate::generate::detect_backend(project_root));
-    let snapshot = probe_snapshot(project_root, detected_backend);
-    let url_backend = crate::migrate::resolve_primary_url(profile)
+
+    // Resolve the URL once for the requested `--profile`; both the URL-implied
+    // backend (dialect-vs-DB check) and the project/selected backend (provider-
+    // lock + pending-path selection) derive from this SAME profile-resolved
+    // context, so `schema doctor --profile <name>` diagnoses the profile it
+    // claims to (rather than mixing the requested profile's URL with the ambient
+    // profile's detected backend).
+    let url = crate::migrate::resolve_primary_url(profile);
+    let url_backend = url
         .as_deref()
         .and_then(autumn_web::config::DatabaseBackend::detect)
         .map(super::map_detected_backend);
+    let detected_backend = super::backend_for_url(project_root, profile, url.as_deref());
+    let snapshot = probe_snapshot(project_root, detected_backend);
 
     LocalFacts {
         cargo_toml_present,
@@ -584,6 +591,32 @@ mod tests {
         assert!(drift.detail.contains("pending model change"), "{drift:?}");
         // A WARN alone does not fail the command.
         assert!(finish(&checks).is_ok());
+    }
+
+    /// Finding 3 (#2036): the SELECTED profile's backend must flow into the
+    /// checks. When `gather_local_facts` resolves the requested profile's backend
+    /// to Sqlite (from its database URL), a Sqlite-tagged snapshot must NOT trip a
+    /// false `provider-lock` ERROR — even though the ambient project default is
+    /// Postgres (see the contrasting `snapshot_backend_mismatch_is_provider_lock_error`).
+    /// Synthesizes the post-resolution facts directly so the pure check layer is
+    /// exercised without a database.
+    #[test]
+    fn selected_profile_backend_flows_into_provider_lock() {
+        let local = LocalFacts {
+            cargo_toml_present: true,
+            autumn_dir_present: true,
+            snapshot: SnapshotState::Loaded {
+                backend: Backend::Sqlite,
+                drift: DriftState::Clean,
+            },
+            detected_backend: Backend::Sqlite,
+            url_backend: Some(Backend::Sqlite),
+        };
+        let checks = compute_checks(&local, &PendingState::NotConfigured);
+        let lock = checks.iter().find(|c| c.name == "provider-lock").unwrap();
+        assert_eq!(lock.status, Status::Ok, "{lock:?}");
+        // No ERROR overall: the selected Sqlite backend agrees with the snapshot.
+        assert!(finish(&checks).is_ok(), "checks: {checks:?}");
     }
 
     #[test]

--- a/autumn-cli/src/schema/doctor.rs
+++ b/autumn-cli/src/schema/doctor.rs
@@ -1,0 +1,671 @@
+//! `autumn schema doctor` — read-only diagnosis of the declarative-schema state
+//! (slice 6 of tracking issue #1975).
+//!
+//! Doctor answers "is my declarative-schema setup healthy?" without mutating
+//! anything: it reports a table of named checks — filesystem, snapshot, model
+//! drift, backend provider-lock, and pending migrations — each with an
+//! `OK`/`WARN`/`ERROR` status and a one-line detail. It exits non-zero when any
+//! check is `ERROR` (an actionable misconfiguration); a `WARN` alone (e.g.
+//! uncommitted model changes, or an unreachable database) never fails the
+//! command, so doctor stays runnable offline.
+//!
+//! # Testability
+//!
+//! The check computation is a pure function ([`compute_checks`]) over gathered
+//! facts ([`LocalFacts`] + a [`PendingState`]); all filesystem/DB/env I/O lives
+//! in the thin shell ([`run_doctor`] / [`gather_local_facts`]). Unit tests
+//! exercise the pure layer directly with no database.
+//!
+//! # Backend note
+//!
+//! The pending-migrations check is Postgres-specific (it consumes the pg
+//! `pending_migrations` status API). A non-Postgres backend is reported as a
+//! skipped WARN rather than failing — doctor references no `SQLite` symbol and so
+//! compiles identically with or without the `sqlite` feature.
+
+use std::path::{Path, PathBuf};
+
+use autumn_schema_core::{Backend, Table};
+use diesel_migrations::FileBasedMigrations;
+use serde::Serialize;
+
+use super::diff::{DiffOptions, diff_schema};
+use super::parse::parse_models_path;
+use super::snapshot::{SNAPSHOT_DEFAULT_PATH, SnapshotError, load_snapshot};
+
+/// A single diagnostic check outcome.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Check {
+    /// Stable check identifier (e.g. `project-root`, `snapshot-drift`).
+    pub name: String,
+    /// The severity of the outcome.
+    pub status: Status,
+    /// A one-line, human-readable detail (remediation when actionable).
+    pub detail: String,
+}
+
+/// Check severity. Serializes as the upper-case token used in the report and the
+/// `--json` output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum Status {
+    /// The check passed.
+    Ok,
+    /// A heads-up that does not fail the command (drift, unreachable DB, skips).
+    Warn,
+    /// An actionable problem — the command exits non-zero.
+    Error,
+}
+
+impl Status {
+    /// The bracketed label used in the plain-text report.
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Ok => "[OK]   ",
+            Self::Warn => "[WARN] ",
+            Self::Error => "[ERROR]",
+        }
+    }
+}
+
+/// Snapshot load outcome plus, when loaded, its dialect tag and the model-drift
+/// result computed against it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SnapshotState {
+    /// Loaded and parsed; carries its backend tag and the drift verdict.
+    Loaded { backend: Backend, drift: DriftState },
+    /// No snapshot file at the default path.
+    Missing,
+    /// The file exists but could not be read/parsed (IO, JSON, or bad version).
+    Unreadable(String),
+}
+
+/// Model-vs-snapshot drift verdict (only meaningful when the snapshot loaded).
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DriftState {
+    /// The declared models match the snapshot baseline.
+    Clean,
+    /// The models diverge from the baseline by this many changes.
+    Changed(usize),
+    /// The declared models could not be parsed to compute drift.
+    ModelsError(String),
+}
+
+/// Pending-migrations probe outcome.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PendingState {
+    /// No database URL is configured — the check is skipped.
+    NotConfigured,
+    /// The backend/build cannot run this check (e.g. non-Postgres backend).
+    Skipped(String),
+    /// The database was reached; carries the pending migration names.
+    Reachable(Vec<String>),
+    /// The database could not be reached (secret-free reason).
+    Unreachable(String),
+}
+
+/// Filesystem/snapshot/backend facts gathered without touching the database.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LocalFacts {
+    cargo_toml_present: bool,
+    autumn_dir_present: bool,
+    snapshot: SnapshotState,
+    detected_backend: Backend,
+    /// Backend implied by the resolved DB URL scheme (`None` if no URL / unknown).
+    url_backend: Option<Backend>,
+}
+
+/// Run the doctor: gather facts, compute checks, print the report (table or
+/// JSON), and return `Err(summary)` when any check is `ERROR` so the dispatch
+/// tail exits non-zero.
+///
+/// # Errors
+///
+/// Returns a one-line summary when one or more checks are `ERROR`.
+pub fn run_doctor(profile: Option<&str>, json: bool) -> Result<(), String> {
+    let project_root = std::env::current_dir()
+        .map_err(|e| format!("failed to resolve the current directory: {e}"))?;
+    let local = gather_local_facts(&project_root, profile);
+    let pending = gather_pending(&project_root, profile, &local);
+    let checks = compute_checks(&local, &pending);
+    render(&checks, json)?;
+    finish(&checks)
+}
+
+/// Gather the non-DB facts (filesystem, snapshot, drift, backends).
+fn gather_local_facts(project_root: &Path, profile: Option<&str>) -> LocalFacts {
+    let cargo_toml_present = project_root.join("Cargo.toml").is_file();
+    let autumn_dir_present = project_root.join(".autumn").is_dir();
+    let detected_backend =
+        super::map_detected_backend(crate::generate::detect_backend(project_root));
+    let snapshot = probe_snapshot(project_root, detected_backend);
+    let url_backend = crate::migrate::resolve_primary_url(profile)
+        .as_deref()
+        .and_then(autumn_web::config::DatabaseBackend::detect)
+        .map(super::map_detected_backend);
+
+    LocalFacts {
+        cargo_toml_present,
+        autumn_dir_present,
+        snapshot,
+        detected_backend,
+        url_backend,
+    }
+}
+
+/// Load the snapshot and, if it loads, compute model drift against it using the
+/// snapshot's own dialect tag.
+fn probe_snapshot(project_root: &Path, _detected: Backend) -> SnapshotState {
+    let snapshot_path = project_root.join(SNAPSHOT_DEFAULT_PATH);
+    match load_snapshot(&snapshot_path) {
+        Ok(snapshot) => {
+            let drift = compute_drift(project_root, snapshot.backend, &snapshot.tables);
+            SnapshotState::Loaded {
+                backend: snapshot.backend,
+                drift,
+            }
+        }
+        Err(SnapshotError::Io { source, .. }) if source.kind() == std::io::ErrorKind::NotFound => {
+            SnapshotState::Missing
+        }
+        Err(other) => SnapshotState::Unreadable(other.to_string()),
+    }
+}
+
+/// Diff the declared models (parsed with the snapshot's backend) against the
+/// baseline tables to decide the drift verdict.
+fn compute_drift(project_root: &Path, backend: Backend, baseline: &[Table]) -> DriftState {
+    let Some(models_path) = existing_models_path(project_root) else {
+        return DriftState::ModelsError(
+            "no declarative models found under src/ to compare against the snapshot".to_string(),
+        );
+    };
+    match parse_models_path(&models_path, backend) {
+        Ok(desired) => {
+            let plan = diff_schema(baseline, &desired, DiffOptions::default());
+            if plan.is_empty() {
+                DriftState::Clean
+            } else {
+                DriftState::Changed(plan.changes.len())
+            }
+        }
+        Err(e) => DriftState::ModelsError(e.to_string()),
+    }
+}
+
+/// Probe pending migrations for the detected backend. Postgres consults the live
+/// `pending_migrations` status API; any other backend (and a build without the
+/// database URL) is skipped with a note. Never references a `SQLite` symbol.
+fn gather_pending(project_root: &Path, profile: Option<&str>, local: &LocalFacts) -> PendingState {
+    let Some(url) = crate::migrate::resolve_primary_url(profile) else {
+        return PendingState::NotConfigured;
+    };
+    if local.detected_backend != Backend::Postgres {
+        return PendingState::Skipped(format!(
+            "pending-migration check is Postgres-only; detected {:?} backend",
+            local.detected_backend
+        ));
+    }
+    let migrations_dir = project_root.join("migrations");
+    // No/unreadable migrations dir: nothing to be pending, treat as reachable-empty.
+    let Ok(migrations) = FileBasedMigrations::from_path(&migrations_dir) else {
+        return PendingState::Reachable(Vec::new());
+    };
+    match autumn_web::migrate::pending_migrations(&url, migrations) {
+        Ok(names) => PendingState::Reachable(names),
+        // MigrationError Display is secret-free.
+        Err(e) => PendingState::Unreachable(e.to_string()),
+    }
+}
+
+/// Pure check computation over gathered facts. Ordered filesystem → snapshot →
+/// drift → backend (provider-lock, then dialect-vs-DB) → database.
+fn compute_checks(local: &LocalFacts, pending: &PendingState) -> Vec<Check> {
+    let mut checks = Vec::new();
+
+    // 1. project-root
+    checks.push(if !local.cargo_toml_present {
+        Check {
+            name: "project-root".to_string(),
+            status: Status::Error,
+            detail: "not in an Autumn project (no Cargo.toml) — run from your project root"
+                .to_string(),
+        }
+    } else if !local.autumn_dir_present {
+        Check {
+            name: "project-root".to_string(),
+            status: Status::Error,
+            detail: "missing .autumn/ state directory — run `autumn schema snapshot` first"
+                .to_string(),
+        }
+    } else {
+        Check {
+            name: "project-root".to_string(),
+            status: Status::Ok,
+            detail: "Cargo.toml and .autumn/ present".to_string(),
+        }
+    });
+
+    // 2. snapshot-present
+    checks.push(match &local.snapshot {
+        SnapshotState::Loaded { backend, .. } => Check {
+            name: "snapshot-present".to_string(),
+            status: Status::Ok,
+            detail: format!("snapshot loaded (backend {backend:?})"),
+        },
+        SnapshotState::Missing => Check {
+            name: "snapshot-present".to_string(),
+            status: Status::Error,
+            detail: format!(
+                "no snapshot at {SNAPSHOT_DEFAULT_PATH} — run `autumn schema snapshot`"
+            ),
+        },
+        SnapshotState::Unreadable(reason) => Check {
+            name: "snapshot-present".to_string(),
+            status: Status::Error,
+            detail: format!("snapshot is unreadable: {reason}"),
+        },
+    });
+
+    // 3. snapshot-drift
+    checks.push(drift_check(&local.snapshot));
+
+    // 4. provider-lock (snapshot backend vs detected backend)
+    checks.push(provider_lock_check(&local.snapshot, local.detected_backend));
+
+    // 5. snapshot-dialect vs DB (snapshot backend vs resolved-URL backend)
+    checks.push(dialect_vs_db_check(&local.snapshot, local.url_backend));
+
+    // 6. pending-migrations
+    checks.push(pending_check(pending));
+
+    checks
+}
+
+/// The `snapshot-drift` row.
+fn drift_check(snapshot: &SnapshotState) -> Check {
+    let name = "snapshot-drift".to_string();
+    match snapshot {
+        SnapshotState::Loaded {
+            drift: DriftState::Clean,
+            ..
+        } => Check {
+            name,
+            status: Status::Ok,
+            detail: "models match the snapshot baseline".to_string(),
+        },
+        SnapshotState::Loaded {
+            drift: DriftState::Changed(n),
+            ..
+        } => Check {
+            name,
+            status: Status::Warn,
+            detail: format!(
+                "{n} pending model change(s) — run `autumn schema diff --write-migration`"
+            ),
+        },
+        SnapshotState::Loaded {
+            drift: DriftState::ModelsError(reason),
+            ..
+        } => Check {
+            name,
+            status: Status::Warn,
+            detail: format!("could not evaluate drift: {reason}"),
+        },
+        SnapshotState::Missing | SnapshotState::Unreadable(_) => Check {
+            name,
+            status: Status::Warn,
+            detail: "skipped — no readable snapshot baseline".to_string(),
+        },
+    }
+}
+
+/// The `provider-lock` row (snapshot dialect vs the detected backend).
+fn provider_lock_check(snapshot: &SnapshotState, detected: Backend) -> Check {
+    let name = "provider-lock".to_string();
+    match snapshot {
+        SnapshotState::Loaded { backend, .. } if *backend == detected => Check {
+            name,
+            status: Status::Ok,
+            detail: format!("snapshot and detected backend agree ({detected:?})"),
+        },
+        SnapshotState::Loaded { backend, .. } => Check {
+            name,
+            status: Status::Error,
+            detail: format!(
+                "snapshot backend {backend:?} does not match the detected backend {detected:?}"
+            ),
+        },
+        SnapshotState::Missing | SnapshotState::Unreadable(_) => Check {
+            name,
+            status: Status::Warn,
+            detail: "skipped — no readable snapshot".to_string(),
+        },
+    }
+}
+
+/// The `snapshot-dialect-vs-db` row (snapshot dialect vs the resolved DB URL's
+/// backend). Distinct from provider-lock: the configured backend and the URL
+/// scheme can diverge.
+fn dialect_vs_db_check(snapshot: &SnapshotState, url_backend: Option<Backend>) -> Check {
+    let name = "snapshot-dialect-vs-db".to_string();
+    match (snapshot, url_backend) {
+        (SnapshotState::Missing | SnapshotState::Unreadable(_), _) => Check {
+            name,
+            status: Status::Warn,
+            detail: "skipped — no readable snapshot".to_string(),
+        },
+        (SnapshotState::Loaded { .. }, None) => Check {
+            name,
+            status: Status::Warn,
+            detail: "no database URL configured — skipped".to_string(),
+        },
+        (SnapshotState::Loaded { backend, .. }, Some(url_backend)) if *backend == url_backend => {
+            Check {
+                name,
+                status: Status::Ok,
+                detail: format!("snapshot dialect matches the database URL ({url_backend:?})"),
+            }
+        }
+        (SnapshotState::Loaded { backend, .. }, Some(url_backend)) => Check {
+            name,
+            status: Status::Error,
+            detail: format!(
+                "snapshot backend {backend:?} does not match the database URL backend {url_backend:?}"
+            ),
+        },
+    }
+}
+
+/// The `pending-migrations` row.
+fn pending_check(pending: &PendingState) -> Check {
+    let name = "pending-migrations".to_string();
+    match pending {
+        PendingState::NotConfigured => Check {
+            name,
+            status: Status::Warn,
+            detail: "no database configured — skipped".to_string(),
+        },
+        PendingState::Skipped(reason) => Check {
+            name,
+            status: Status::Warn,
+            detail: reason.clone(),
+        },
+        PendingState::Unreachable(reason) => Check {
+            name,
+            status: Status::Warn,
+            detail: format!("could not reach database: {reason}"),
+        },
+        PendingState::Reachable(names) if names.is_empty() => Check {
+            name,
+            status: Status::Ok,
+            detail: "database is up to date".to_string(),
+        },
+        PendingState::Reachable(names) => Check {
+            name,
+            status: Status::Warn,
+            detail: format!(
+                "{} pending migration(s): {} — run `autumn schema migrate`",
+                names.len(),
+                names.join(", ")
+            ),
+        },
+    }
+}
+
+/// Print the report as an aligned table, or as JSON when `json` is set.
+fn render(checks: &[Check], json: bool) -> Result<(), String> {
+    if json {
+        let out = serde_json::to_string_pretty(checks)
+            .map_err(|e| format!("failed to serialize doctor report: {e}"))?;
+        println!("{out}");
+        return Ok(());
+    }
+    let width = checks.iter().map(|c| c.name.len()).max().unwrap_or(0);
+    println!("Schema doctor:");
+    for check in checks {
+        println!(
+            "  {} {:<width$}  {}",
+            check.status.label(),
+            check.name,
+            check.detail,
+            width = width
+        );
+    }
+    Ok(())
+}
+
+/// Turn an `ERROR`-containing report into a non-zero exit via `Err`, else `Ok`.
+fn finish(checks: &[Check]) -> Result<(), String> {
+    let errors: Vec<&str> = checks
+        .iter()
+        .filter(|c| c.status == Status::Error)
+        .map(|c| c.name.as_str())
+        .collect();
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "schema doctor found {} error check(s): {}",
+            errors.len(),
+            errors.join(", ")
+        ))
+    }
+}
+
+/// Resolve the declarative models source when it exists (dir precedence, then
+/// single file), else `None`. Mirrors the parent module's resolver but non-fatal
+/// on absence (doctor reports the absence, it does not error out on it).
+fn existing_models_path(project_root: &Path) -> Option<PathBuf> {
+    let dir = project_root.join("src").join("models");
+    if dir.is_dir() {
+        return Some(dir);
+    }
+    let file = project_root.join("src").join("models.rs");
+    if file.is_file() {
+        return Some(file);
+    }
+    None
+}
+
+#[cfg(test)]
+#[allow(clippy::needless_raw_string_hashes)]
+mod tests {
+    use super::*;
+
+    const POST_MODEL: &str = r#"
+        #[autumn_web::model(managed)]
+        pub struct Post {
+            #[id]
+            pub id: i64,
+            pub title: String,
+        }
+    "#;
+
+    /// A version-1 snapshot for a `posts(id, title, created_at)` table, matching
+    /// `POST_MODEL` (the parser adds the implicit `created_at`).
+    fn posts_snapshot(backend: &str) -> String {
+        format!(
+            r#"{{
+  "snapshot_version": 1,
+  "backend": "{backend}",
+  "tables": [
+    {{
+      "name": "posts",
+      "columns": [
+        {{ "name": "id", "ty": "Int64", "nullable": false, "primary_key": true, "unique": false, "default": null, "references": null }},
+        {{ "name": "title", "ty": "Text", "nullable": false, "primary_key": false, "unique": false, "default": null, "references": null }},
+        {{ "name": "created_at", "ty": "Timestamp", "nullable": false, "primary_key": false, "unique": false, "default": "Now", "references": null }}
+      ],
+      "primary_key": ["id"],
+      "indexes": [],
+      "checks": [],
+      "backend": "{backend}",
+      "managed": true
+    }}
+  ]
+}}
+"#
+        )
+    }
+
+    /// Write a project scaffold: `Cargo.toml`, `src/models.rs`, and a snapshot at
+    /// the default path. Returns the tempdir (kept alive by the caller).
+    fn scaffold(models: &str, snapshot_json: Option<&str>) -> tempfile::TempDir {
+        let root = tempfile::tempdir().expect("tempdir");
+        std::fs::write(root.path().join("Cargo.toml"), "[package]\nname=\"x\"\n")
+            .expect("Cargo.toml");
+        let src = root.path().join("src");
+        std::fs::create_dir_all(&src).expect("mkdir src");
+        std::fs::write(src.join("models.rs"), models).expect("models.rs");
+        let autumn = root.path().join(".autumn");
+        std::fs::create_dir_all(&autumn).expect("mkdir .autumn");
+        if let Some(json) = snapshot_json {
+            std::fs::write(autumn.join("schema-snapshot.json"), json).expect("snapshot");
+        }
+        root
+    }
+
+    #[test]
+    fn missing_project_root_is_error() {
+        let root = tempfile::tempdir().expect("tempdir"); // no Cargo.toml
+        let local = gather_local_facts(root.path(), None);
+        let checks = compute_checks(&local, &PendingState::NotConfigured);
+        let pr = checks.iter().find(|c| c.name == "project-root").unwrap();
+        assert_eq!(pr.status, Status::Error, "{pr:?}");
+        // finish() turns it into a non-zero exit.
+        assert!(finish(&checks).is_err());
+    }
+
+    #[test]
+    fn matching_models_report_drift_ok() {
+        let root = scaffold(POST_MODEL, Some(&posts_snapshot("Postgres")));
+        let local = gather_local_facts(root.path(), None);
+        let checks = compute_checks(&local, &PendingState::NotConfigured);
+        let drift = checks.iter().find(|c| c.name == "snapshot-drift").unwrap();
+        assert_eq!(drift.status, Status::Ok, "{drift:?}");
+        // No ERROR checks (detected Postgres matches the Postgres snapshot).
+        assert!(finish(&checks).is_ok(), "checks: {checks:?}");
+    }
+
+    #[test]
+    fn diverging_models_report_drift_warn() {
+        // Model adds a `body` column the snapshot lacks → drift WARN.
+        let models = r#"
+            #[autumn_web::model(managed)]
+            pub struct Post {
+                #[id]
+                pub id: i64,
+                pub title: String,
+                pub body: Option<String>,
+            }
+        "#;
+        let root = scaffold(models, Some(&posts_snapshot("Postgres")));
+        let local = gather_local_facts(root.path(), None);
+        let checks = compute_checks(&local, &PendingState::NotConfigured);
+        let drift = checks.iter().find(|c| c.name == "snapshot-drift").unwrap();
+        assert_eq!(drift.status, Status::Warn, "{drift:?}");
+        assert!(drift.detail.contains("pending model change"), "{drift:?}");
+        // A WARN alone does not fail the command.
+        assert!(finish(&checks).is_ok());
+    }
+
+    #[test]
+    fn snapshot_backend_mismatch_is_provider_lock_error() {
+        // Sqlite-tagged snapshot but the tempdir project detects Postgres.
+        let root = scaffold(POST_MODEL, Some(&posts_snapshot("Sqlite")));
+        let local = gather_local_facts(root.path(), None);
+        assert_eq!(local.detected_backend, Backend::Postgres);
+        let checks = compute_checks(&local, &PendingState::NotConfigured);
+        let lock = checks.iter().find(|c| c.name == "provider-lock").unwrap();
+        assert_eq!(lock.status, Status::Error, "{lock:?}");
+        assert!(finish(&checks).is_err());
+    }
+
+    #[test]
+    fn missing_snapshot_is_snapshot_present_error() {
+        let root = scaffold(POST_MODEL, None); // .autumn present, no snapshot file
+        let local = gather_local_facts(root.path(), None);
+        let checks = compute_checks(&local, &PendingState::NotConfigured);
+        let snap = checks
+            .iter()
+            .find(|c| c.name == "snapshot-present")
+            .unwrap();
+        assert_eq!(snap.status, Status::Error, "{snap:?}");
+        // Drift/provider-lock degrade to WARN skips when there's no snapshot.
+        let drift = checks.iter().find(|c| c.name == "snapshot-drift").unwrap();
+        assert_eq!(drift.status, Status::Warn);
+        assert!(finish(&checks).is_err());
+    }
+
+    #[test]
+    fn unreadable_snapshot_is_snapshot_present_error() {
+        let root = scaffold(POST_MODEL, Some("{ not valid json"));
+        let local = gather_local_facts(root.path(), None);
+        let checks = compute_checks(&local, &PendingState::NotConfigured);
+        let snap = checks
+            .iter()
+            .find(|c| c.name == "snapshot-present")
+            .unwrap();
+        assert_eq!(snap.status, Status::Error, "{snap:?}");
+    }
+
+    #[test]
+    fn pending_reachable_empty_is_ok_and_nonempty_is_warn() {
+        let clean = pending_check(&PendingState::Reachable(Vec::new()));
+        assert_eq!(clean.status, Status::Ok);
+        let dirty = pending_check(&PendingState::Reachable(vec!["20260101_init".to_string()]));
+        assert_eq!(dirty.status, Status::Warn);
+        assert!(dirty.detail.contains("autumn schema migrate"));
+        // Unreachable is a WARN, never a hard fail (doctor runs offline).
+        let down = pending_check(&PendingState::Unreachable("connection refused".to_string()));
+        assert_eq!(down.status, Status::Warn);
+    }
+
+    #[test]
+    fn dialect_vs_db_mismatch_is_error() {
+        let snapshot = SnapshotState::Loaded {
+            backend: Backend::Postgres,
+            drift: DriftState::Clean,
+        };
+        let check = dialect_vs_db_check(&snapshot, Some(Backend::Sqlite));
+        assert_eq!(check.status, Status::Error, "{check:?}");
+        // Matching URL backend is OK.
+        let ok = dialect_vs_db_check(&snapshot, Some(Backend::Postgres));
+        assert_eq!(ok.status, Status::Ok);
+        // No URL → skipped WARN.
+        let skip = dialect_vs_db_check(&snapshot, None);
+        assert_eq!(skip.status, Status::Warn);
+    }
+
+    #[test]
+    fn status_serializes_uppercase_in_json() {
+        let checks = vec![Check {
+            name: "x".to_string(),
+            status: Status::Warn,
+            detail: "y".to_string(),
+        }];
+        let json = serde_json::to_string(&checks).unwrap();
+        assert!(json.contains("\"status\":\"WARN\""), "{json}");
+        assert!(json.contains("\"name\":\"x\""));
+    }
+
+    #[test]
+    fn report_ordering_is_filesystem_then_snapshot_then_db() {
+        let root = scaffold(POST_MODEL, Some(&posts_snapshot("Postgres")));
+        let local = gather_local_facts(root.path(), None);
+        let checks = compute_checks(&local, &PendingState::NotConfigured);
+        let names: Vec<&str> = checks.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "project-root",
+                "snapshot-present",
+                "snapshot-drift",
+                "provider-lock",
+                "snapshot-dialect-vs-db",
+                "pending-migrations",
+            ]
+        );
+    }
+}

--- a/autumn-cli/src/schema/doctor.rs
+++ b/autumn-cli/src/schema/doctor.rs
@@ -23,7 +23,7 @@
 //! skipped WARN rather than failing — doctor references no `SQLite` symbol and so
 //! compiles identically with or without the `sqlite` feature.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use autumn_schema_core::{Backend, Table};
 use diesel_migrations::FileBasedMigrations;
@@ -175,7 +175,7 @@ fn probe_snapshot(project_root: &Path, _detected: Backend) -> SnapshotState {
 /// Diff the declared models (parsed with the snapshot's backend) against the
 /// baseline tables to decide the drift verdict.
 fn compute_drift(project_root: &Path, backend: Backend, baseline: &[Table]) -> DriftState {
-    let Some(models_path) = existing_models_path(project_root) else {
+    let Some(models_path) = super::existing_models_path(project_root) else {
         return DriftState::ModelsError(
             "no declarative models found under src/ to compare against the snapshot".to_string(),
         );
@@ -206,12 +206,43 @@ fn gather_pending(project_root: &Path, profile: Option<&str>, local: &LocalFacts
             local.detected_backend
         ));
     }
-    let migrations_dir = project_root.join("migrations");
-    // No/unreadable migrations dir: nothing to be pending, treat as reachable-empty.
-    let Ok(migrations) = FileBasedMigrations::from_path(&migrations_dir) else {
-        return PendingState::Reachable(Vec::new());
+    probe_pending(&url, &project_root.join("migrations"))
+}
+
+/// Probe pending migrations against `url` using the project's `migrations_dir`.
+///
+/// A present, readable dir is the migration source. When it is missing/unreadable
+/// we must NOT short-circuit to "up to date" — that would let a missing migrations
+/// directory mask an offline or misconfigured database (a false OK). Instead we
+/// probe connectivity with a freshly-created, guaranteed-empty temp directory:
+/// with zero available migrations `pending_migrations` still connects, returning
+/// an empty set on a reachable DB (correctly "up to date") and an error on an
+/// unreachable one (surfaced as [`PendingState::Unreachable`], i.e. a WARN).
+fn probe_pending(url: &str, migrations_dir: &Path) -> PendingState {
+    // Deferred-init tempdir guard: bound in this scope so, when used, it outlives
+    // the `pending_migrations` call below.
+    let fallback_dir;
+    let migrations = if let Ok(source) = FileBasedMigrations::from_path(migrations_dir) {
+        source
+    } else {
+        fallback_dir = match tempfile::tempdir() {
+            Ok(dir) => dir,
+            Err(e) => {
+                return PendingState::Unreachable(format!(
+                    "could not create a temp directory to probe the database: {e}"
+                ));
+            }
+        };
+        match FileBasedMigrations::from_path(fallback_dir.path()) {
+            Ok(source) => source,
+            Err(e) => {
+                return PendingState::Unreachable(format!(
+                    "could not build an empty migration source to probe the database: {e}"
+                ));
+            }
+        }
     };
-    match autumn_web::migrate::pending_migrations(&url, migrations) {
+    match autumn_web::migrate::pending_migrations(url, migrations) {
         Ok(names) => PendingState::Reachable(names),
         // MigrationError Display is secret-free.
         Err(e) => PendingState::Unreachable(e.to_string()),
@@ -453,21 +484,6 @@ fn finish(checks: &[Check]) -> Result<(), String> {
     }
 }
 
-/// Resolve the declarative models source when it exists (dir precedence, then
-/// single file), else `None`. Mirrors the parent module's resolver but non-fatal
-/// on absence (doctor reports the absence, it does not error out on it).
-fn existing_models_path(project_root: &Path) -> Option<PathBuf> {
-    let dir = project_root.join("src").join("models");
-    if dir.is_dir() {
-        return Some(dir);
-    }
-    let file = project_root.join("src").join("models.rs");
-    if file.is_file() {
-        return Some(file);
-    }
-    None
-}
-
 #[cfg(test)]
 #[allow(clippy::needless_raw_string_hashes)]
 mod tests {
@@ -608,6 +624,27 @@ mod tests {
             .find(|c| c.name == "snapshot-present")
             .unwrap();
         assert_eq!(snap.status, Status::Error, "{snap:?}");
+    }
+
+    /// Finding 1 (connectivity false-positive): a MISSING migrations dir must not
+    /// short-circuit `probe_pending` to `Reachable(empty)` — with a configured URL
+    /// the probe must still attempt a connection, so an offline/misconfigured
+    /// database surfaces as `Unreachable` (a WARN) rather than a false "database is
+    /// up to date". Uses a loopback port with nothing listening (immediate
+    /// connection-refused — fast and deterministic, no network egress). Gated to
+    /// the default Postgres lane since the pending probe is Postgres-only.
+    #[cfg(not(feature = "sqlite"))]
+    #[test]
+    fn missing_migrations_dir_still_probes_the_database() {
+        let root = tempfile::tempdir().expect("tempdir"); // no migrations/ dir
+        let state = probe_pending(
+            "postgres://user:pw@127.0.0.1:1/db",
+            &root.path().join("migrations"),
+        );
+        assert!(
+            matches!(state, PendingState::Unreachable(_)),
+            "missing dir + unreachable DB must be Unreachable, got {state:?}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/schema/migrate.rs
+++ b/autumn-cli/src/schema/migrate.rs
@@ -96,11 +96,24 @@ fn migrate_at(project_root: &Path, profile: Option<&str>) -> Result<(), String> 
             .to_string()
     })?;
 
-    // No migrations directory (or an empty one) is a clean success, not an error.
+    // The `migrations/` path is handled in three distinct cases: an absent path
+    // or a readable-but-empty directory is a clean success (no DB call); an
+    // unreadable path or a regular file is an ERROR — never silently skipped, so
+    // a deployment can never boot against an outdated schema by treating an
+    // unreadable directory as "nothing to apply".
     let migrations_dir = project_root.join("migrations");
-    if migrations_dir_is_empty(&migrations_dir) {
-        println!("No migrations to apply.");
-        return Ok(());
+    match classify_migrations_dir(&migrations_dir) {
+        MigrationsDir::Absent | MigrationsDir::Empty => {
+            println!("No migrations to apply.");
+            return Ok(());
+        }
+        MigrationsDir::Unreadable(e) => {
+            return Err(format!(
+                "failed to read migrations directory {}: {e}",
+                migrations_dir.display()
+            ));
+        }
+        MigrationsDir::HasMigrations => {}
     }
 
     // Apply. The destructive-change guards already ran at diff time; migration
@@ -215,12 +228,54 @@ fn file_based_migrations(migrations_dir: &Path) -> Result<FileBasedMigrations, S
     })
 }
 
-/// True when there is nothing to apply: the `migrations/` directory is absent or
-/// contains no migration subdirectories.
-fn migrations_dir_is_empty(migrations_dir: &Path) -> bool {
-    std::fs::read_dir(migrations_dir).map_or(true, |entries| {
-        !entries.filter_map(Result::ok).any(|e| e.path().is_dir())
-    })
+/// Classification of the `migrations/` path for the apply decision.
+///
+/// Distinguishes the three cases the apply path must treat differently: an
+/// absent path and a readable-but-empty directory are both clean no-ops, but an
+/// unreadable path (an I/O error, or a regular file where a directory was
+/// expected) must be surfaced as an error so a deployment can never silently
+/// skip required migrations and boot against an outdated schema.
+#[derive(Debug)]
+enum MigrationsDir {
+    /// The path does not exist — nothing to apply, clean no-op.
+    Absent,
+    /// A readable directory with no migration subdirectories — clean no-op.
+    Empty,
+    /// A readable directory containing at least one migration subdirectory.
+    HasMigrations,
+    /// The path exists but could not be read as a directory (an I/O error, or it
+    /// is a regular file, not a directory) — the caller must error.
+    Unreadable(std::io::Error),
+}
+
+/// Classify the `migrations/` path into [`MigrationsDir`].
+///
+/// An absent path is [`MigrationsDir::Absent`]. Otherwise the path must be a
+/// readable directory: a `read_dir` failure — including the "path is a regular
+/// file" case, on which `read_dir` errors — is [`MigrationsDir::Unreadable`],
+/// never silently treated as empty. A readable directory is
+/// [`MigrationsDir::HasMigrations`] when it contains at least one migration
+/// subdirectory (the diesel layout) and [`MigrationsDir::Empty`] otherwise. Pure
+/// over the filesystem so the decision is testable without a database.
+fn classify_migrations_dir(migrations_dir: &Path) -> MigrationsDir {
+    match migrations_dir.try_exists() {
+        Ok(false) => return MigrationsDir::Absent,
+        Ok(true) => {}
+        // The path's very existence is unknowable (e.g. a permission error on a
+        // parent) — treat as unreadable, NOT as an absent/empty no-op.
+        Err(e) => return MigrationsDir::Unreadable(e),
+    }
+
+    match std::fs::read_dir(migrations_dir) {
+        Ok(entries) => {
+            if entries.filter_map(Result::ok).any(|e| e.path().is_dir()) {
+                MigrationsDir::HasMigrations
+            } else {
+                MigrationsDir::Empty
+            }
+        }
+        Err(e) => MigrationsDir::Unreadable(e),
+    }
 }
 
 /// Print the applied-migration summary (mirrors `autumn migrate` reporting).
@@ -277,20 +332,83 @@ mod tests {
     use super::*;
 
     #[test]
-    fn migrations_dir_is_empty_true_when_missing_or_no_subdirs() {
+    fn classify_absent_path_is_a_no_op() {
         let root = tempfile::tempdir().expect("tempdir");
-        // Missing entirely.
-        assert!(migrations_dir_is_empty(&root.path().join("migrations")));
-        // Present but empty.
+        // Missing entirely → Absent (clean no-op, no DB call).
+        assert!(matches!(
+            classify_migrations_dir(&root.path().join("migrations")),
+            MigrationsDir::Absent
+        ));
+    }
+
+    #[test]
+    fn classify_readable_empty_dir_is_a_no_op() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let migrations = root.path().join("migrations");
+        // Present but empty → Empty (clean no-op).
+        std::fs::create_dir_all(&migrations).expect("mkdir");
+        assert!(matches!(
+            classify_migrations_dir(&migrations),
+            MigrationsDir::Empty
+        ));
+        // A stray file (not a migration dir) still classifies as Empty.
+        std::fs::write(migrations.join("README.md"), "x").expect("write");
+        assert!(matches!(
+            classify_migrations_dir(&migrations),
+            MigrationsDir::Empty
+        ));
+    }
+
+    #[test]
+    fn classify_dir_with_migration_subdir_proceeds() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let migrations = root.path().join("migrations");
+        std::fs::create_dir_all(migrations.join("20260101000000_init")).expect("mkdir");
+        // A real migration subdir → HasMigrations (proceed to apply).
+        assert!(matches!(
+            classify_migrations_dir(&migrations),
+            MigrationsDir::HasMigrations
+        ));
+    }
+
+    #[test]
+    fn classify_regular_file_is_unreadable_error() {
+        let root = tempfile::tempdir().expect("tempdir");
+        // `migrations` is a regular FILE, not a directory: `read_dir` errors, so
+        // it must classify as Unreadable (an error) — never as an empty no-op.
+        let migrations = root.path().join("migrations");
+        std::fs::write(&migrations, "not a directory").expect("write");
+        assert!(matches!(
+            classify_migrations_dir(&migrations),
+            MigrationsDir::Unreadable(_)
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn classify_unreadable_dir_is_an_error() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // A directory with no read permission cannot be listed. Skipped when the
+        // process can bypass the permission bits (e.g. running as root, where
+        // chmod 000 is ignored), which would otherwise make this non-deterministic.
+        let root = tempfile::tempdir().expect("tempdir");
         let migrations = root.path().join("migrations");
         std::fs::create_dir_all(&migrations).expect("mkdir");
-        assert!(migrations_dir_is_empty(&migrations));
-        // A stray file (not a migration dir) still counts as empty.
-        std::fs::write(migrations.join("README.md"), "x").expect("write");
-        assert!(migrations_dir_is_empty(&migrations));
-        // A real migration subdir flips it to non-empty.
-        std::fs::create_dir_all(migrations.join("20260101000000_init")).expect("mkdir");
-        assert!(!migrations_dir_is_empty(&migrations));
+        std::fs::set_permissions(&migrations, std::fs::Permissions::from_mode(0o000))
+            .expect("chmod");
+
+        let can_still_read = std::fs::read_dir(&migrations).is_ok();
+        let classified = classify_migrations_dir(&migrations);
+        // Restore permissions so the tempdir can be cleaned up.
+        std::fs::set_permissions(&migrations, std::fs::Permissions::from_mode(0o755))
+            .expect("restore chmod");
+
+        if can_still_read {
+            // Permission bits were bypassed (root) — the guard cannot be exercised.
+            return;
+        }
+        assert!(matches!(classified, MigrationsDir::Unreadable(_)));
     }
 
     #[test]

--- a/autumn-cli/src/schema/migrate.rs
+++ b/autumn-cli/src/schema/migrate.rs
@@ -25,7 +25,7 @@
 //! `SQLite` backend yields a clear "rebuild with `--features sqlite`" error; no
 //! `SQLite` symbol is referenced unless the feature is on.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use autumn_schema_core::Backend;
 use diesel_migrations::FileBasedMigrations;
@@ -72,7 +72,7 @@ fn migrate_at(project_root: &Path, profile: Option<&str>) -> Result<(), String> 
     // snapshot is not fatal here (the DB may be pre-snapshot), but we note it.
     let snapshot_path = project_root.join(SNAPSHOT_DEFAULT_PATH);
     if !enforce_provider_lock(&snapshot_path, backend)? {
-        println!(
+        eprintln!(
             "note: no schema snapshot at {} — applying migrations without a provider-lock check; \
              run `autumn schema snapshot` to establish the baseline.",
             snapshot_path.display()
@@ -214,8 +214,8 @@ fn report_applied(result: &MigrationResult) {
 /// warning (never surfaced as an apply failure), and a missing models source is
 /// a benign note.
 fn refresh_snapshot_after_apply(project_root: &Path, backend: Backend) {
-    let Some(models_path) = existing_models_path(project_root) else {
-        println!(
+    let Some(models_path) = super::existing_models_path(project_root) else {
+        eprintln!(
             "note: no declarative models found under src/ — migrations applied, but the schema \
              snapshot was not refreshed (nothing to snapshot)."
         );
@@ -225,7 +225,7 @@ fn refresh_snapshot_after_apply(project_root: &Path, backend: Backend) {
     let desired = match parse_models_path(&models_path, backend) {
         Ok(parsed) => parsed,
         Err(e) => {
-            println!(
+            eprintln!(
                 "warning: migrations applied, but re-parsing models to refresh the snapshot \
                  failed: {e}"
             );
@@ -237,28 +237,11 @@ fn refresh_snapshot_after_apply(project_root: &Path, backend: Backend) {
     let out = project_root.join(SNAPSHOT_DEFAULT_PATH);
     match write_snapshot(&out, &snapshot) {
         Ok(()) => println!("refreshed schema snapshot at {}", out.display()),
-        Err(e) => println!(
+        Err(e) => eprintln!(
             "warning: migrations applied, but refreshing the schema snapshot at {} failed: {e}",
             out.display()
         ),
     }
-}
-
-/// Resolve the declarative models source only when it actually exists, so the
-/// snapshot refresh can skip cleanly when the project has no models. Mirrors the
-/// `src/models` dir → `src/models.rs` file precedence the parent module's
-/// `resolve_default_models_path` uses, but returns `None` (not an error) when
-/// neither is present.
-fn existing_models_path(project_root: &Path) -> Option<PathBuf> {
-    let dir = project_root.join("src").join("models");
-    if dir.is_dir() {
-        return Some(dir);
-    }
-    let file = project_root.join("src").join("models.rs");
-    if file.is_file() {
-        return Some(file);
-    }
-    None
 }
 
 #[cfg(test)]
@@ -337,21 +320,5 @@ mod tests {
             err.contains("--features sqlite") && err.contains("SQLite"),
             "seam error names the feature: {err}"
         );
-    }
-
-    #[test]
-    fn existing_models_path_prefers_dir_then_file_then_none() {
-        let root = tempfile::tempdir().expect("tempdir");
-        assert!(existing_models_path(root.path()).is_none());
-
-        let src = root.path().join("src");
-        std::fs::create_dir_all(&src).expect("mkdir src");
-        let file = src.join("models.rs");
-        std::fs::write(&file, "").expect("write file");
-        assert_eq!(existing_models_path(root.path()), Some(file));
-
-        let dir = src.join("models");
-        std::fs::create_dir_all(&dir).expect("mkdir models");
-        assert_eq!(existing_models_path(root.path()), Some(dir));
     }
 }

--- a/autumn-cli/src/schema/migrate.rs
+++ b/autumn-cli/src/schema/migrate.rs
@@ -1,0 +1,357 @@
+//! `autumn schema migrate` — apply the generated migrations, then advance the
+//! snapshot baseline (slice 6 of tracking issue #1975).
+//!
+//! This is the *apply* half of the declarative-schema loop. `autumn schema diff
+//! --write-migration` (slice 4) authored `migrations/<ts>_<name>/{up,down}.sql`
+//! after running the destructive-change guards; this command applies whatever is
+//! pending against the configured database and then re-snapshots the declared
+//! models so the checked-in baseline advances to the state the database is now
+//! in.
+//!
+//! # What this command deliberately does NOT do
+//!
+//! It does not re-run the diff guards. The `-- autumn-safety:` advisories a
+//! generated migration may carry are inert SQL comments; the destructive-change
+//! refusal happened at diff time, not here. Migration files apply verbatim,
+//! exactly as `autumn migrate` applies them — this command adds only the
+//! provider-lock check and the post-apply snapshot refresh.
+//!
+//! # Backend handling (Postgres default; `SQLite` behind a feature)
+//!
+//! The CLI is a Postgres-first, single-backend build. The Postgres apply path is
+//! always compiled. The `SQLite` apply path is gated behind the non-default
+//! `sqlite` cargo feature (a backend-flip that must never be co-built with the
+//! default Postgres backend — see `Cargo.toml`). In a default build a detected
+//! `SQLite` backend yields a clear "rebuild with `--features sqlite`" error; no
+//! `SQLite` symbol is referenced unless the feature is on.
+
+use std::path::{Path, PathBuf};
+
+use autumn_schema_core::Backend;
+use diesel_migrations::FileBasedMigrations;
+
+use autumn_web::migrate::{DEFAULT_LOCK_WAIT_TIMEOUT, MigrationResult};
+
+use super::parse::parse_models_path;
+use super::snapshot::{
+    SNAPSHOT_DEFAULT_PATH, SchemaSnapshot, SnapshotError, load_snapshot, write_snapshot,
+};
+
+/// Apply pending migrations against the configured database, then refresh the
+/// checked-in schema snapshot.
+///
+/// Resolves the project root from the current directory; `profile` is the
+/// explicit `--profile` flag (else the ambient profile resolution the rest of
+/// the CLI uses). Returns a human-readable message on failure — never the
+/// database URL or any credential.
+///
+/// # Errors
+///
+/// Returns a message when the command is run outside a project, the database URL
+/// cannot be resolved, the snapshot's dialect does not match the detected
+/// backend (provider-lock), or a migration fails to apply.
+pub fn run_migrate(profile: Option<&str>) -> Result<(), String> {
+    let project_root = std::env::current_dir()
+        .map_err(|e| format!("failed to resolve the current directory: {e}"))?;
+    migrate_at(&project_root, profile)
+}
+
+/// The body of [`run_migrate`] taking an explicit `project_root` so the wiring is
+/// testable without mutating the process CWD (mirrors `diff_at` in the parent
+/// module).
+fn migrate_at(project_root: &Path, profile: Option<&str>) -> Result<(), String> {
+    crate::generate::ensure_project_root(project_root)
+        .map_err(|_| crate::generate::GenerateError::NotInProject.to_string())?;
+
+    // Detected backend drives both the provider-lock check and which apply path
+    // runs. Reuses the same detection the generator and `autumn schema diff` use.
+    let backend = super::map_detected_backend(crate::generate::detect_backend(project_root));
+
+    // PROVIDER-LOCK: if a snapshot exists, its dialect tag must match the
+    // detected backend before we apply anything cross-dialect. A missing
+    // snapshot is not fatal here (the DB may be pre-snapshot), but we note it.
+    let snapshot_path = project_root.join(SNAPSHOT_DEFAULT_PATH);
+    if !enforce_provider_lock(&snapshot_path, backend)? {
+        println!(
+            "note: no schema snapshot at {} — applying migrations without a provider-lock check; \
+             run `autumn schema snapshot` to establish the baseline.",
+            snapshot_path.display()
+        );
+    }
+
+    // Resolve the write/primary database URL exactly as `autumn migrate` does.
+    let url = crate::migrate::resolve_primary_url(profile).ok_or_else(|| {
+        "no database URL configured — set AUTUMN_DATABASE__URL or DATABASE_URL, or add a \
+         [database] primary_url to autumn.toml"
+            .to_string()
+    })?;
+
+    // No migrations directory (or an empty one) is a clean success, not an error.
+    let migrations_dir = project_root.join("migrations");
+    if migrations_dir_is_empty(&migrations_dir) {
+        println!("No migrations to apply.");
+        return Ok(());
+    }
+
+    // Apply. The destructive-change guards already ran at diff time; migration
+    // files apply verbatim (`-- autumn-safety:` lines are inert SQL comments).
+    let result = apply_pending(backend, &url, &migrations_dir)?;
+    report_applied(&result);
+
+    // SNAPSHOT REFRESH: the declarative snapshot is the diff baseline. After a
+    // successful apply the database matches the desired models, so the snapshot
+    // advances to that state — we re-parse the models and rewrite the snapshot
+    // (atomically). Only done when a declarative models source exists; if none
+    // is present the migrations still applied, there is just nothing to snapshot.
+    // A snapshot-write failure AFTER a successful DB apply is a warning, not an
+    // apply failure — the migration really did apply.
+    refresh_snapshot_after_apply(project_root, backend);
+
+    Ok(())
+}
+
+/// Enforce the provider-lock guard against an on-disk snapshot.
+///
+/// Returns `Ok(true)` when a snapshot was present and its backend matches,
+/// `Ok(false)` when no snapshot file exists (caller decides how to note it), and
+/// `Err` when the snapshot exists but is dialect-mismatched or unreadable.
+fn enforce_provider_lock(snapshot_path: &Path, backend: Backend) -> Result<bool, String> {
+    match load_snapshot(snapshot_path) {
+        Ok(snapshot) => {
+            snapshot
+                .ensure_backend_matches(backend)
+                .map_err(|e| e.to_string())?;
+            Ok(true)
+        }
+        Err(SnapshotError::Io { source, .. }) if source.kind() == std::io::ErrorKind::NotFound => {
+            Ok(false)
+        }
+        Err(other) => Err(other.to_string()),
+    }
+}
+
+/// Apply pending migrations for `backend`. The Postgres path is always compiled;
+/// the `SQLite` path is real only under the `sqlite` feature (see
+/// [`apply_pending_sqlite`]).
+fn apply_pending(
+    backend: Backend,
+    url: &str,
+    migrations_dir: &Path,
+) -> Result<MigrationResult, String> {
+    match backend {
+        Backend::Postgres => apply_pending_pg(url, migrations_dir),
+        Backend::Sqlite => apply_pending_sqlite(url, migrations_dir),
+    }
+}
+
+/// Postgres apply path: advisory-locked (`run_pending_locked`) so concurrent
+/// migrators serialize cleanly.
+fn apply_pending_pg(url: &str, migrations_dir: &Path) -> Result<MigrationResult, String> {
+    let migrations = file_based_migrations(migrations_dir)?;
+    autumn_web::migrate::run_pending_locked(url, migrations, Some(DEFAULT_LOCK_WAIT_TIMEOUT))
+        .map_err(|e| e.to_string())
+}
+
+/// `SQLite` apply path (feature-gated). `SQLite` is a single-writer local database,
+/// so — unlike Postgres — there is **no advisory lock** (issue #1999):
+/// `run_pending_sqlite` applies directly.
+#[cfg(feature = "sqlite")]
+fn apply_pending_sqlite(url: &str, migrations_dir: &Path) -> Result<MigrationResult, String> {
+    let migrations = file_based_migrations(migrations_dir)?;
+    autumn_web::migrate::run_pending_sqlite(url, migrations).map_err(|e| e.to_string())
+}
+
+/// `SQLite` apply seam in the default (Postgres-only) build. The `sqlite`
+/// backend-flip is a separate, non-default cargo feature that must never be
+/// co-built with the default Postgres backend; without it a detected `SQLite`
+/// backend cannot be applied here. This arm references **no** `SQLite` symbol.
+#[cfg(not(feature = "sqlite"))]
+fn apply_pending_sqlite(_url: &str, _migrations_dir: &Path) -> Result<MigrationResult, String> {
+    Err(
+        "`autumn schema migrate` detected a SQLite backend, but this CLI build targets Postgres \
+         only. Rebuild with `--features sqlite` to apply SQLite migrations (the sqlite \
+         backend-flip must never be co-built with the default Postgres backend)."
+            .to_string(),
+    )
+}
+
+/// Build a diesel [`FileBasedMigrations`] source rooted at `migrations_dir`,
+/// mapping the read failure to a clear message. Left generic over the backend by
+/// inference — the Postgres and `SQLite` callers each pin their own `MigrationSource`
+/// bound.
+fn file_based_migrations(migrations_dir: &Path) -> Result<FileBasedMigrations, String> {
+    FileBasedMigrations::from_path(migrations_dir).map_err(|e| {
+        format!(
+            "failed to read migrations directory {}: {e}",
+            migrations_dir.display()
+        )
+    })
+}
+
+/// True when there is nothing to apply: the `migrations/` directory is absent or
+/// contains no migration subdirectories.
+fn migrations_dir_is_empty(migrations_dir: &Path) -> bool {
+    std::fs::read_dir(migrations_dir).map_or(true, |entries| {
+        !entries.filter_map(Result::ok).any(|e| e.path().is_dir())
+    })
+}
+
+/// Print the applied-migration summary (mirrors `autumn migrate` reporting).
+fn report_applied(result: &MigrationResult) {
+    if result.applied.is_empty() {
+        println!("Database already up to date.");
+        return;
+    }
+    for name in &result.applied {
+        println!("  applied {name}");
+    }
+    println!("Applied {} migration(s).", result.applied.len());
+}
+
+/// Re-parse the declared models and rewrite the snapshot at
+/// [`SNAPSHOT_DEFAULT_PATH`], tagged with `backend`. Best-effort: after a
+/// successful DB apply, a failure to refresh the snapshot is reported as a
+/// warning (never surfaced as an apply failure), and a missing models source is
+/// a benign note.
+fn refresh_snapshot_after_apply(project_root: &Path, backend: Backend) {
+    let Some(models_path) = existing_models_path(project_root) else {
+        println!(
+            "note: no declarative models found under src/ — migrations applied, but the schema \
+             snapshot was not refreshed (nothing to snapshot)."
+        );
+        return;
+    };
+
+    let desired = match parse_models_path(&models_path, backend) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            println!(
+                "warning: migrations applied, but re-parsing models to refresh the snapshot \
+                 failed: {e}"
+            );
+            return;
+        }
+    };
+
+    let snapshot = SchemaSnapshot::new(backend, desired.tables);
+    let out = project_root.join(SNAPSHOT_DEFAULT_PATH);
+    match write_snapshot(&out, &snapshot) {
+        Ok(()) => println!("refreshed schema snapshot at {}", out.display()),
+        Err(e) => println!(
+            "warning: migrations applied, but refreshing the schema snapshot at {} failed: {e}",
+            out.display()
+        ),
+    }
+}
+
+/// Resolve the declarative models source only when it actually exists, so the
+/// snapshot refresh can skip cleanly when the project has no models. Mirrors the
+/// `src/models` dir → `src/models.rs` file precedence the parent module's
+/// `resolve_default_models_path` uses, but returns `None` (not an error) when
+/// neither is present.
+fn existing_models_path(project_root: &Path) -> Option<PathBuf> {
+    let dir = project_root.join("src").join("models");
+    if dir.is_dir() {
+        return Some(dir);
+    }
+    let file = project_root.join("src").join("models.rs");
+    if file.is_file() {
+        return Some(file);
+    }
+    None
+}
+
+#[cfg(test)]
+#[allow(clippy::needless_raw_string_hashes)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migrations_dir_is_empty_true_when_missing_or_no_subdirs() {
+        let root = tempfile::tempdir().expect("tempdir");
+        // Missing entirely.
+        assert!(migrations_dir_is_empty(&root.path().join("migrations")));
+        // Present but empty.
+        let migrations = root.path().join("migrations");
+        std::fs::create_dir_all(&migrations).expect("mkdir");
+        assert!(migrations_dir_is_empty(&migrations));
+        // A stray file (not a migration dir) still counts as empty.
+        std::fs::write(migrations.join("README.md"), "x").expect("write");
+        assert!(migrations_dir_is_empty(&migrations));
+        // A real migration subdir flips it to non-empty.
+        std::fs::create_dir_all(migrations.join("20260101000000_init")).expect("mkdir");
+        assert!(!migrations_dir_is_empty(&migrations));
+    }
+
+    #[test]
+    fn provider_lock_missing_snapshot_is_not_an_error() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let path = root.path().join(SNAPSHOT_DEFAULT_PATH);
+        // No snapshot → Ok(false): caller notes it, does not fail.
+        assert_eq!(enforce_provider_lock(&path, Backend::Postgres), Ok(false));
+    }
+
+    #[test]
+    fn provider_lock_mismatch_is_refused() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let path = root.path().join(SNAPSHOT_DEFAULT_PATH);
+        let snap = SchemaSnapshot::new(Backend::Sqlite, Vec::new());
+        write_snapshot(&path, &snap).expect("write snapshot");
+        // Detected Postgres vs a Sqlite-tagged snapshot → refused.
+        let err = enforce_provider_lock(&path, Backend::Postgres).unwrap_err();
+        assert!(
+            err.to_lowercase().contains("backend") && err.contains("does not match"),
+            "provider-lock refusal: {err}"
+        );
+    }
+
+    #[test]
+    fn provider_lock_match_is_ok() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let path = root.path().join(SNAPSHOT_DEFAULT_PATH);
+        let snap = SchemaSnapshot::new(Backend::Postgres, Vec::new());
+        write_snapshot(&path, &snap).expect("write snapshot");
+        assert_eq!(enforce_provider_lock(&path, Backend::Postgres), Ok(true));
+    }
+
+    #[test]
+    fn migrate_outside_project_is_friendly_error() {
+        let root = tempfile::tempdir().expect("tempdir");
+        // No Cargo.toml → not a project.
+        let err = migrate_at(root.path(), None).unwrap_err();
+        assert!(
+            err.contains("Autumn project"),
+            "friendly not-in-project error: {err}"
+        );
+    }
+
+    #[cfg(not(feature = "sqlite"))]
+    #[test]
+    fn sqlite_apply_seam_names_the_feature_in_default_build() {
+        // In the default (Postgres-only) build the SQLite apply path is the seam:
+        // it must point the user at `--features sqlite` and never touch the DB.
+        let root = tempfile::tempdir().expect("tempdir");
+        let err = apply_pending_sqlite("sqlite:///tmp/x.db", &root.path().join("migrations"))
+            .unwrap_err();
+        assert!(
+            err.contains("--features sqlite") && err.contains("SQLite"),
+            "seam error names the feature: {err}"
+        );
+    }
+
+    #[test]
+    fn existing_models_path_prefers_dir_then_file_then_none() {
+        let root = tempfile::tempdir().expect("tempdir");
+        assert!(existing_models_path(root.path()).is_none());
+
+        let src = root.path().join("src");
+        std::fs::create_dir_all(&src).expect("mkdir src");
+        let file = src.join("models.rs");
+        std::fs::write(&file, "").expect("write file");
+        assert_eq!(existing_models_path(root.path()), Some(file));
+
+        let dir = src.join("models");
+        std::fs::create_dir_all(&dir).expect("mkdir models");
+        assert_eq!(existing_models_path(root.path()), Some(dir));
+    }
+}

--- a/autumn-cli/src/schema/migrate.rs
+++ b/autumn-cli/src/schema/migrate.rs
@@ -63,12 +63,22 @@ fn migrate_at(project_root: &Path, profile: Option<&str>) -> Result<(), String> 
     crate::generate::ensure_project_root(project_root)
         .map_err(|_| crate::generate::GenerateError::NotInProject.to_string())?;
 
-    // Detected backend drives both the provider-lock check and which apply path
-    // runs. Reuses the same detection the generator and `autumn schema diff` use.
-    let backend = super::map_detected_backend(crate::generate::detect_backend(project_root));
+    // Resolve the write/primary database URL exactly as `autumn migrate` does,
+    // honoring an explicit `--profile`.
+    let url = crate::migrate::resolve_primary_url(profile);
+
+    // The migration backend is derived from the SAME profile-resolved context as
+    // the URL: when a URL is configured its scheme is authoritative, so
+    // `--profile <name>` selects the correct apply path / provider-lock even when
+    // the project's ambient/default backend differs from the selected profile's
+    // (using the ambient `detect_backend` here would pick the wrong apply impl).
+    // With no URL configured we fall back to the profile-aware project default.
+    // This backend also tags the refreshed snapshot below. With `profile == None`
+    // the resolution is byte-identical to the previous ambient detection.
+    let backend = super::backend_for_url(project_root, profile, url.as_deref());
 
     // PROVIDER-LOCK: if a snapshot exists, its dialect tag must match the
-    // detected backend before we apply anything cross-dialect. A missing
+    // resolved backend before we apply anything cross-dialect. A missing
     // snapshot is not fatal here (the DB may be pre-snapshot), but we note it.
     let snapshot_path = project_root.join(SNAPSHOT_DEFAULT_PATH);
     if !enforce_provider_lock(&snapshot_path, backend)? {
@@ -79,8 +89,8 @@ fn migrate_at(project_root: &Path, profile: Option<&str>) -> Result<(), String> 
         );
     }
 
-    // Resolve the write/primary database URL exactly as `autumn migrate` does.
-    let url = crate::migrate::resolve_primary_url(profile).ok_or_else(|| {
+    // Require the URL now that the provider-lock has been checked.
+    let url = url.ok_or_else(|| {
         "no database URL configured — set AUTUMN_DATABASE__URL or DATABASE_URL, or add a \
          [database] primary_url to autumn.toml"
             .to_string()
@@ -98,16 +108,33 @@ fn migrate_at(project_root: &Path, profile: Option<&str>) -> Result<(), String> 
     let result = apply_pending(backend, &url, &migrations_dir)?;
     report_applied(&result);
 
-    // SNAPSHOT REFRESH: the declarative snapshot is the diff baseline. After a
-    // successful apply the database matches the desired models, so the snapshot
-    // advances to that state — we re-parse the models and rewrite the snapshot
-    // (atomically). Only done when a declarative models source exists; if none
-    // is present the migrations still applied, there is just nothing to snapshot.
-    // A snapshot-write failure AFTER a successful DB apply is a warning, not an
-    // apply failure — the migration really did apply.
-    refresh_snapshot_after_apply(project_root, backend);
+    // SNAPSHOT REFRESH: the declarative snapshot is the diff baseline. It advances
+    // ONLY when migrations were actually applied (`should_refresh_snapshot`) — a
+    // real apply means the database moved to a new state, so the baseline follows
+    // it to that state (re-parse the models, rewrite the snapshot atomically,
+    // dialect-tagged). When nothing was applied (the DB was already up to date)
+    // there is no new state to advance to, so the snapshot is left UNTOUCHED —
+    // rewriting it from the (possibly newly-edited, still-ungenerated) models
+    // would falsely bake those edits into the baseline and hide the drift from
+    // the next `schema diff` / `doctor`. A snapshot-write failure AFTER a
+    // successful apply is a warning, not an apply failure — the migration really
+    // did apply.
+    if should_refresh_snapshot(&result) {
+        refresh_snapshot_after_apply(project_root, backend);
+    }
 
     Ok(())
+}
+
+/// Whether a completed apply should advance the checked-in snapshot baseline.
+///
+/// The invariant: the snapshot tracks the APPLIED database state, so it advances
+/// **iff** migrations were actually applied. An empty `applied` list means the DB
+/// was already up to date — there is no new applied state to snapshot, so the
+/// baseline must stay put (otherwise ungenerated model edits would be silently
+/// baked into it and never surface as drift). Pure so the decision is testable.
+const fn should_refresh_snapshot(result: &MigrationResult) -> bool {
+    !result.applied.is_empty()
 }
 
 /// Enforce the provider-lock guard against an on-disk snapshot.
@@ -264,6 +291,21 @@ mod tests {
         // A real migration subdir flips it to non-empty.
         std::fs::create_dir_all(migrations.join("20260101000000_init")).expect("mkdir");
         assert!(!migrations_dir_is_empty(&migrations));
+    }
+
+    #[test]
+    fn should_refresh_snapshot_only_when_something_was_applied() {
+        // A real apply (non-empty `applied`) advances the baseline.
+        let applied = MigrationResult {
+            applied: vec!["20260101000000_init".to_string()],
+        };
+        assert!(should_refresh_snapshot(&applied));
+        // A no-op apply (DB already up to date) must NOT advance it — otherwise
+        // ungenerated model edits would be silently baked into the baseline.
+        let noop = MigrationResult {
+            applied: Vec::new(),
+        };
+        assert!(!should_refresh_snapshot(&noop));
     }
 
     #[test]

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -13,6 +13,8 @@
 //! `autumn schema` group.
 
 pub mod diff;
+pub mod doctor;
+pub mod migrate;
 pub mod parse;
 pub mod snapshot;
 
@@ -101,6 +103,28 @@ pub enum SchemaAction {
         #[arg(long)]
         allow_destructive: bool,
     },
+    /// Apply pending migrations against the configured database, then advance the
+    /// checked-in snapshot baseline to the freshly-applied state. Provider-locked
+    /// against the snapshot's dialect; the destructive-change guards ran at diff
+    /// time, so migration files apply verbatim here.
+    Migrate {
+        /// Config profile whose database URL to apply against (defaults to the
+        /// ambient profile resolution the other CLI commands use).
+        #[arg(long, value_name = "PROFILE")]
+        profile: Option<String>,
+    },
+    /// Read-only diagnosis of the declarative-schema state: filesystem, snapshot,
+    /// model drift, backend provider-lock, and pending migrations. Exits
+    /// non-zero when any check is an actionable error.
+    Doctor {
+        /// Config profile whose database URL to probe (defaults to the ambient
+        /// profile resolution the other CLI commands use).
+        #[arg(long, value_name = "PROFILE")]
+        profile: Option<String>,
+        /// Emit the checks as JSON instead of the aligned text report.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 /// Run an `autumn schema` action. Prints to stdout on success; on error, writes
@@ -130,6 +154,8 @@ pub fn run(action: SchemaAction) {
             name.as_deref(),
             allow_destructive,
         ),
+        SchemaAction::Migrate { profile } => migrate::run_migrate(profile.as_deref()),
+        SchemaAction::Doctor { profile, json } => doctor::run_doctor(profile.as_deref(), json),
     };
     if let Err(message) = result {
         eprintln!("error: {message}");

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -172,6 +172,31 @@ const fn map_detected_backend(detected: autumn_web::config::DatabaseBackend) -> 
     }
 }
 
+/// Resolve the schema-command backend for an explicit `--profile`, from the
+/// already profile-resolved primary database `url`.
+///
+/// When a URL is configured its scheme is authoritative
+/// ([`DatabaseBackend::detect`](autumn_web::config::DatabaseBackend::detect)),
+/// so `--profile <name>` selects the apply path / provider-lock of the database
+/// it actually acts against; only when no URL is configured does it fall back to
+/// the profile-aware project default
+/// ([`crate::generate::detect_backend_for_profile`]). Shared by `schema migrate`
+/// and `schema doctor` so the two commands can never derive the backend
+/// inconsistently for the same profile. With `profile == None` the resolution is
+/// unchanged from the ambient behavior.
+fn backend_for_url(project_root: &Path, profile: Option<&str>, url: Option<&str>) -> Backend {
+    url.and_then(autumn_web::config::DatabaseBackend::detect)
+        .map_or_else(
+            || {
+                map_detected_backend(crate::generate::detect_backend_for_profile(
+                    project_root,
+                    profile,
+                ))
+            },
+            map_detected_backend,
+        )
+}
+
 /// Resolve the default models source when `--from` is omitted: the app's
 /// `src/models` directory if it exists, else the single-file `src/models.rs`
 /// layout, else a clear error telling the user to pass `--from`. Autumn supports
@@ -1000,6 +1025,29 @@ mod tests {
             ])
             .is_ok()
         );
+    }
+
+    /// Findings 2 & 3 (#2036): the schema-command backend derives from the
+    /// profile-resolved URL when one is configured (its scheme is authoritative),
+    /// and only falls back to the project default when no URL is present — so
+    /// `--profile <name>` picks the apply path / provider-lock of the database it
+    /// acts against, not the ambient project default.
+    #[test]
+    fn backend_for_url_prefers_url_scheme_over_project_default() {
+        // A tempdir with no config → the project default is Postgres.
+        let root = tempfile::tempdir().expect("tempdir");
+        // A configured SQLite URL is authoritative regardless of that default.
+        assert_eq!(
+            backend_for_url(root.path(), None, Some("sqlite://app.db")),
+            Backend::Sqlite
+        );
+        // A configured Postgres URL likewise.
+        assert_eq!(
+            backend_for_url(root.path(), None, Some("postgres://u@h/db")),
+            Backend::Postgres
+        );
+        // No URL → falls back to the profile-aware project default (Postgres here).
+        assert_eq!(backend_for_url(root.path(), None, None), Backend::Postgres);
     }
 
     #[test]

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -195,6 +195,24 @@ fn resolve_default_models_path(project_root: &Path) -> Result<PathBuf, String> {
     ))
 }
 
+/// Resolve the declarative models source only when it actually exists.
+///
+/// Mirrors [`resolve_default_models_path`]'s `src/models` dir → `src/models.rs`
+/// file precedence, but returns `None` (not an error) when neither is present —
+/// so callers that must degrade gracefully on absence (the `migrate` snapshot
+/// refresh, `doctor`'s drift check) share one resolver instead of duplicating it.
+fn existing_models_path(project_root: &Path) -> Option<PathBuf> {
+    let dir = project_root.join("src").join("models");
+    if dir.is_dir() {
+        return Some(dir);
+    }
+    let file = project_root.join("src").join("models.rs");
+    if file.is_file() {
+        return Some(file);
+    }
+    None
+}
+
 /// Whether the `snapshot` command requires the current directory to be the
 /// project root. It does whenever any input falls back to a project-relative
 /// default: the source (`--from` omitted → `src/models`), the default output
@@ -982,6 +1000,22 @@ mod tests {
             ])
             .is_ok()
         );
+    }
+
+    #[test]
+    fn existing_models_path_prefers_dir_then_file_then_none() {
+        let root = tempfile::tempdir().expect("tempdir");
+        assert!(existing_models_path(root.path()).is_none());
+
+        let src = root.path().join("src");
+        std::fs::create_dir_all(&src).expect("mkdir src");
+        let file = src.join("models.rs");
+        std::fs::write(&file, "").expect("write file");
+        assert_eq!(existing_models_path(root.path()), Some(file));
+
+        let dir = src.join("models");
+        std::fs::create_dir_all(&dir).expect("mkdir models");
+        assert_eq!(existing_models_path(root.path()), Some(dir));
     }
 
     #[test]

--- a/autumn-cli/tests/integration/mod.rs
+++ b/autumn-cli/tests/integration/mod.rs
@@ -14,13 +14,13 @@ mod migrate_down;
 mod offsite_backup;
 mod repo_hygiene;
 mod scaffold_belongs_to;
-mod schema_migrate;
-#[cfg(feature = "sqlite")]
-mod schema_migrate_sqlite;
 mod scaffold_form_for;
 mod scaffold_search;
 mod scaffold_sort_filter;
 mod scaffold_validation;
+mod schema_migrate;
+#[cfg(feature = "sqlite")]
+mod schema_migrate_sqlite;
 mod seed_model_linking;
 #[cfg(unix)]
 mod serve;

--- a/autumn-cli/tests/integration/mod.rs
+++ b/autumn-cli/tests/integration/mod.rs
@@ -14,6 +14,9 @@ mod migrate_down;
 mod offsite_backup;
 mod repo_hygiene;
 mod scaffold_belongs_to;
+mod schema_migrate;
+#[cfg(feature = "sqlite")]
+mod schema_migrate_sqlite;
 mod scaffold_form_for;
 mod scaffold_search;
 mod scaffold_sort_filter;

--- a/autumn-cli/tests/integration/schema_migrate.rs
+++ b/autumn-cli/tests/integration/schema_migrate.rs
@@ -148,10 +148,14 @@ async fn schema_migrate_applies_generated_migration_and_refreshes_snapshot() {
     );
     assert_no_secret_leak(&mig_out, &mig_err);
 
-    // 4. The snapshot advanced to the applied state (now contains `posts`).
-    let snap =
-        std::fs::read_to_string(project.join(".autumn/schema-snapshot.json")).expect("snapshot");
-    assert!(snap.contains("\"name\": \"posts\""), "snapshot: {snap}");
+    // 4. The snapshot advanced to the applied state (now contains `posts`). This
+    //    is the FIRST, real apply — the snapshot refresh is anchored to it.
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+    let snap_after_apply = std::fs::read_to_string(&snapshot_path).expect("snapshot");
+    assert!(
+        snap_after_apply.contains("\"name\": \"posts\""),
+        "snapshot: {snap_after_apply}"
+    );
 
     // 5. A second migrate is a clean no-op ("already up to date").
     let (rerun_out, rerun_err) = run_autumn_ok(&project, &["schema", "migrate"], &envs);
@@ -172,4 +176,43 @@ async fn schema_migrate_applies_generated_migration_and_refreshes_snapshot() {
         "doctor pending check clean:\n{doc_out}"
     );
     assert_no_secret_leak(&doc_out, &doc_err);
+
+    // 7. Finding 1 (#2036): introduce a NEW, ungenerated model change (add `body`)
+    //    WITHOUT generating/applying a migration for it, then run `schema migrate`
+    //    again. With nothing pending to apply it is a no-op, and MUST leave the
+    //    snapshot untouched — re-snapshotting from the edited models here would
+    //    silently bake the new column into the baseline and hide the drift.
+    std::fs::write(
+        project.join("src/models.rs"),
+        "#[autumn_web::model(managed)]\npub struct Post {\n    #[id]\n    pub id: i64,\n    pub title: String,\n    pub body: Option<String>,\n}\n",
+    )
+    .expect("edit models.rs with ungenerated drift");
+    let (noop_out, noop_err) = run_autumn_ok(&project, &["schema", "migrate"], &envs);
+    assert!(
+        noop_out.contains("Database already up to date."),
+        "no-op migrate after model edit: {noop_out}"
+    );
+    assert!(
+        !noop_out.contains("refreshed schema snapshot"),
+        "a no-op migrate must NOT refresh the snapshot: {noop_out}"
+    );
+    let snap_after_noop = std::fs::read_to_string(&snapshot_path).expect("snapshot");
+    assert_eq!(
+        snap_after_apply, snap_after_noop,
+        "a no-op migrate must leave the snapshot byte-for-byte unchanged"
+    );
+    assert!(
+        !snap_after_noop.contains("body"),
+        "the ungenerated `body` edit must NOT be baked into the baseline: {snap_after_noop}"
+    );
+    assert_no_secret_leak(&noop_out, &noop_err);
+
+    // 8. Because the snapshot never advanced, the ungenerated edit is still
+    //    visible as drift: `schema diff` still generates the pending column add.
+    let (diff_after, diff_after_err) = run_autumn_ok(&project, &["schema", "diff"], &envs);
+    assert!(
+        !diff_after.contains("No schema changes") && diff_after.contains("body"),
+        "drift must still be detected after the no-op migrate: {diff_after}"
+    );
+    assert_no_secret_leak(&diff_after, &diff_after_err);
 }

--- a/autumn-cli/tests/integration/schema_migrate.rs
+++ b/autumn-cli/tests/integration/schema_migrate.rs
@@ -1,0 +1,169 @@
+//! Integration tests for `autumn schema migrate` / `autumn schema doctor`
+//! (issue #1975 slice 6), Postgres path.
+//!
+//! These require Docker (via testcontainers) and are marked `#[ignore]`, so they
+//! only run when explicitly requested:
+//!
+//!   `cargo test -p autumn-cli --test cli_tests -- --ignored schema_migrate`
+//!
+//! The happy path proves the headline behaviour: a generated migration is
+//! applied against a live Postgres, a second run reports up-to-date, the schema
+//! snapshot is refreshed to the applied state, and no credential ever leaks into
+//! the CLI output.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const SECRET_PW: &str = "s3cr3t_pw_do_not_leak";
+
+const fn autumn_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_autumn")
+}
+
+fn run_autumn(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String, Option<i32>) {
+    let output = Command::new(autumn_bin())
+        .args(args)
+        .current_dir(dir)
+        .envs(envs.iter().copied())
+        .output()
+        .expect("failed to run autumn");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code(),
+    )
+}
+
+fn run_autumn_ok(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String) {
+    let (stdout, stderr, code) = run_autumn(dir, args, envs);
+    assert_eq!(
+        code,
+        Some(0),
+        "autumn {args:?} failed (exit={code:?})\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    (stdout, stderr)
+}
+
+/// `autumn new <name>` in a fresh tempdir, returning that tempdir + project root.
+fn fresh_project(name: &str) -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", name], &[]);
+    let project = tmp.path().join(name);
+    (tmp, project)
+}
+
+async fn start_postgres() -> (
+    testcontainers::ContainerAsync<testcontainers_modules::postgres::Postgres>,
+    String,
+    u16,
+) {
+    use testcontainers::runners::AsyncRunner as _;
+    use testcontainers_modules::postgres::Postgres;
+
+    let container = Postgres::default()
+        .with_password(SECRET_PW)
+        .start()
+        .await
+        .expect("failed to start Postgres testcontainer — is Docker running?");
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    (container, host, port)
+}
+
+/// Overwrite the project's single-file models with a `Post` model and remove any
+/// scaffolded `src/models/` directory so the single-file layout resolves.
+fn write_post_model(project: &Path) {
+    let src = project.join("src");
+    let _ = std::fs::remove_dir_all(src.join("models"));
+    std::fs::write(
+        src.join("models.rs"),
+        "#[autumn_web::model(managed)]\npub struct Post {\n    #[id]\n    pub id: i64,\n    pub title: String,\n}\n",
+    )
+    .expect("write models.rs");
+}
+
+fn assert_no_secret_leak(stdout: &str, stderr: &str) {
+    assert!(
+        !stdout.contains(SECRET_PW) && !stderr.contains(SECRET_PW),
+        "credentials leaked!\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_migrate_applies_generated_migration_and_refreshes_snapshot() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("migrate_app");
+
+    // 1. A `Post` model plus an EMPTY baseline snapshot, so the diff produces a
+    //    CREATE TABLE migration. The empty baseline comes from snapshotting an
+    //    empty models file (portable, no `/dev/null` dependency).
+    write_post_model(&project);
+    std::fs::write(project.join("empty_models.rs"), "").expect("empty models");
+    run_autumn_ok(
+        &project,
+        &[
+            "schema",
+            "snapshot",
+            "--from",
+            "empty_models.rs",
+            "--backend",
+            "pg",
+        ],
+        &envs,
+    );
+    // Sanity: doctor sees drift now (models diverge from the empty snapshot).
+    let (doc_json, _) = run_autumn_ok(&project, &["schema", "doctor", "--json"], &envs);
+    assert!(
+        doc_json.contains("\"name\": \"snapshot-drift\"") && doc_json.contains("\"WARN\""),
+        "doctor should report drift before migrating:\n{doc_json}"
+    );
+
+    // 2. Generate the migration from the diff.
+    let (diff_out, _) = run_autumn_ok(
+        &project,
+        &["schema", "diff", "--write-migration", "--name", "create_posts"],
+        &envs,
+    );
+    assert!(diff_out.contains("wrote migration"), "diff: {diff_out}");
+
+    // 3. Apply it. Reports the applied migration, refreshes the snapshot, exit 0.
+    let (mig_out, mig_err) = run_autumn_ok(&project, &["schema", "migrate"], &envs);
+    assert!(
+        mig_out.contains("Applied 1 migration(s)."),
+        "migrate stdout: {mig_out}"
+    );
+    assert!(
+        mig_out.contains("refreshed schema snapshot"),
+        "snapshot refresh reported: {mig_out}"
+    );
+    assert_no_secret_leak(&mig_out, &mig_err);
+
+    // 4. The snapshot advanced to the applied state (now contains `posts`).
+    let snap =
+        std::fs::read_to_string(project.join(".autumn/schema-snapshot.json")).expect("snapshot");
+    assert!(snap.contains("\"name\": \"posts\""), "snapshot: {snap}");
+
+    // 5. A second migrate is a clean no-op ("already up to date").
+    let (rerun_out, rerun_err) = run_autumn_ok(&project, &["schema", "migrate"], &envs);
+    assert!(
+        rerun_out.contains("Database already up to date."),
+        "second migrate: {rerun_out}"
+    );
+    assert_no_secret_leak(&rerun_out, &rerun_err);
+
+    // 6. Doctor is now clean: drift OK, pending-migrations OK, exit 0.
+    let (doc_out, doc_err) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("[OK]") && doc_out.contains("models match the snapshot baseline"),
+        "doctor after migrate:\n{doc_out}"
+    );
+    assert!(
+        doc_out.contains("database is up to date"),
+        "doctor pending check clean:\n{doc_out}"
+    );
+    assert_no_secret_leak(&doc_out, &doc_err);
+}

--- a/autumn-cli/tests/integration/schema_migrate.rs
+++ b/autumn-cli/tests/integration/schema_migrate.rs
@@ -125,7 +125,13 @@ async fn schema_migrate_applies_generated_migration_and_refreshes_snapshot() {
     // 2. Generate the migration from the diff.
     let (diff_out, _) = run_autumn_ok(
         &project,
-        &["schema", "diff", "--write-migration", "--name", "create_posts"],
+        &[
+            "schema",
+            "diff",
+            "--write-migration",
+            "--name",
+            "create_posts",
+        ],
         &envs,
     );
     assert!(diff_out.contains("wrote migration"), "diff: {diff_out}");

--- a/autumn-cli/tests/integration/schema_migrate_sqlite.rs
+++ b/autumn-cli/tests/integration/schema_migrate_sqlite.rs
@@ -92,7 +92,13 @@ fn schema_migrate_applies_to_a_sqlite_file_and_refreshes_snapshot() {
     // 2. Generate the SQLite migration from the diff.
     let (diff_out, _) = run_autumn_ok(
         &project,
-        &["schema", "diff", "--write-migration", "--name", "create_posts"],
+        &[
+            "schema",
+            "diff",
+            "--write-migration",
+            "--name",
+            "create_posts",
+        ],
         &envs,
     );
     assert!(diff_out.contains("wrote migration"), "diff: {diff_out}");

--- a/autumn-cli/tests/integration/schema_migrate_sqlite.rs
+++ b/autumn-cli/tests/integration/schema_migrate_sqlite.rs
@@ -1,0 +1,126 @@
+//! SQLite integration test for `autumn schema migrate` (issue #1975 slice 6).
+//!
+//! Compiles and runs **only** under the non-default `sqlite` cargo feature (the
+//! backend-flip). A default `cargo test -p autumn-cli` neither compiles nor
+//! requires this file — it is `#[cfg(feature = "sqlite")]`-gated in
+//! `tests/integration/mod.rs` and additionally guarded here.
+//!
+//! Unlike the Postgres path this needs **no Docker**: it applies against a
+//! temp-FILE SQLite database (not `:memory:`, which the runtime rejects for
+//! migrations), so it is a real, runnable end-to-end check:
+//!
+//!   `cargo test -p autumn-cli --features sqlite --test cli_tests schema_migrate_sqlite`
+#![cfg(feature = "sqlite")]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const fn autumn_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_autumn")
+}
+
+fn run_autumn(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String, Option<i32>) {
+    let output = Command::new(autumn_bin())
+        .args(args)
+        .current_dir(dir)
+        .envs(envs.iter().copied())
+        .output()
+        .expect("failed to run autumn");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code(),
+    )
+}
+
+fn run_autumn_ok(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String) {
+    let (stdout, stderr, code) = run_autumn(dir, args, envs);
+    assert_eq!(
+        code,
+        Some(0),
+        "autumn {args:?} failed (exit={code:?})\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    (stdout, stderr)
+}
+
+fn fresh_project(name: &str) -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", name], &[]);
+    let project = tmp.path().join(name);
+    (tmp, project)
+}
+
+/// Overwrite the project's single-file models with a `Post` model and drop any
+/// scaffolded `src/models/` directory so the single-file layout resolves.
+fn write_post_model(project: &Path) {
+    let src = project.join("src");
+    let _ = std::fs::remove_dir_all(src.join("models"));
+    std::fs::write(
+        src.join("models.rs"),
+        "#[autumn_web::model(managed)]\npub struct Post {\n    #[id]\n    pub id: i64,\n    pub title: String,\n}\n",
+    )
+    .expect("write models.rs");
+}
+
+#[test]
+fn schema_migrate_applies_to_a_sqlite_file_and_refreshes_snapshot() {
+    let (_tmp, project) = fresh_project("sqlite_migrate_app");
+
+    // A file-backed SQLite database inside the project (NOT `:memory:` — the
+    // runtime rejects in-memory targets for registered migrations).
+    let db_path = project.join("app.db");
+    let url = format!("sqlite://{}", db_path.display());
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    // 1. Post model + empty baseline snapshot (Sqlite-tagged), so the diff
+    //    produces a CREATE TABLE migration for SQLite.
+    write_post_model(&project);
+    std::fs::write(project.join("empty_models.rs"), "").expect("empty models");
+    run_autumn_ok(
+        &project,
+        &[
+            "schema",
+            "snapshot",
+            "--from",
+            "empty_models.rs",
+            "--backend",
+            "sqlite",
+        ],
+        &envs,
+    );
+
+    // 2. Generate the SQLite migration from the diff.
+    let (diff_out, _) = run_autumn_ok(
+        &project,
+        &["schema", "diff", "--write-migration", "--name", "create_posts"],
+        &envs,
+    );
+    assert!(diff_out.contains("wrote migration"), "diff: {diff_out}");
+
+    // 3. Apply against the SQLite file: reports applied, refreshes snapshot,
+    //    exit 0. (No advisory lock — SQLite is single-writer, issue #1999.)
+    let (mig_out, _) = run_autumn_ok(&project, &["schema", "migrate"], &envs);
+    assert!(
+        mig_out.contains("Applied 1 migration(s)."),
+        "migrate stdout: {mig_out}"
+    );
+    assert!(
+        mig_out.contains("refreshed schema snapshot"),
+        "snapshot refresh reported: {mig_out}"
+    );
+
+    // The SQLite database file exists and the snapshot advanced to Sqlite-tagged
+    // `posts`.
+    assert!(db_path.is_file(), "sqlite db file created");
+    let snap =
+        std::fs::read_to_string(project.join(".autumn/schema-snapshot.json")).expect("snapshot");
+    assert!(snap.contains("\"backend\": \"Sqlite\""), "snapshot: {snap}");
+    assert!(snap.contains("\"name\": \"posts\""), "snapshot: {snap}");
+
+    // 4. A second migrate is a clean no-op.
+    let (rerun_out, _) = run_autumn_ok(&project, &["schema", "migrate"], &envs);
+    assert!(
+        rerun_out.contains("Database already up to date."),
+        "second migrate: {rerun_out}"
+    );
+}

--- a/autumn-cli/tests/integration/schema_migrate_sqlite.rs
+++ b/autumn-cli/tests/integration/schema_migrate_sqlite.rs
@@ -1,4 +1,4 @@
-//! SQLite integration test for `autumn schema migrate` (issue #1975 slice 6).
+//! `SQLite` integration test for `autumn schema migrate` (issue #1975 slice 6).
 //!
 //! Compiles and runs **only** under the non-default `sqlite` cargo feature (the
 //! backend-flip). A default `cargo test -p autumn-cli` neither compiles nor
@@ -6,7 +6,7 @@
 //! `tests/integration/mod.rs` and additionally guarded here.
 //!
 //! Unlike the Postgres path this needs **no Docker**: it applies against a
-//! temp-FILE SQLite database (not `:memory:`, which the runtime rejects for
+//! temp-FILE `SQLite` database (not `:memory:`, which the runtime rejects for
 //! migrations), so it is a real, runnable end-to-end check:
 //!
 //!   `cargo test -p autumn-cli --features sqlite --test cli_tests schema_migrate_sqlite`

--- a/autumn-cli/tests/integration/schema_migrate_sqlite.rs
+++ b/autumn-cli/tests/integration/schema_migrate_sqlite.rs
@@ -116,17 +116,60 @@ fn schema_migrate_applies_to_a_sqlite_file_and_refreshes_snapshot() {
     );
 
     // The SQLite database file exists and the snapshot advanced to Sqlite-tagged
-    // `posts`.
+    // `posts` (this is the FIRST, real apply — the refresh is anchored here).
     assert!(db_path.is_file(), "sqlite db file created");
-    let snap =
-        std::fs::read_to_string(project.join(".autumn/schema-snapshot.json")).expect("snapshot");
-    assert!(snap.contains("\"backend\": \"Sqlite\""), "snapshot: {snap}");
-    assert!(snap.contains("\"name\": \"posts\""), "snapshot: {snap}");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+    let snap_after_apply = std::fs::read_to_string(&snapshot_path).expect("snapshot");
+    assert!(
+        snap_after_apply.contains("\"backend\": \"Sqlite\""),
+        "snapshot: {snap_after_apply}"
+    );
+    assert!(
+        snap_after_apply.contains("\"name\": \"posts\""),
+        "snapshot: {snap_after_apply}"
+    );
 
-    // 4. A second migrate is a clean no-op.
+    // Finding 1 (#2036): introduce a NEW, ungenerated model change (add `body`)
+    // WITHOUT generating/applying a migration for it. The next `schema migrate`
+    // has nothing pending to apply, so it is a no-op — and MUST leave the
+    // snapshot untouched. If it re-snapshotted from the edited models, the new
+    // column would be silently baked into the baseline and never diff as drift.
+    std::fs::write(
+        project.join("src/models.rs"),
+        "#[autumn_web::model(managed)]\npub struct Post {\n    #[id]\n    pub id: i64,\n    pub title: String,\n    pub body: Option<String>,\n}\n",
+    )
+    .expect("edit models.rs with ungenerated drift");
+
+    // 4. A second migrate is a clean no-op — it does NOT report a snapshot
+    //    refresh and does NOT advance the on-disk snapshot.
     let (rerun_out, _) = run_autumn_ok(&project, &["schema", "migrate"], &envs);
     assert!(
         rerun_out.contains("Database already up to date."),
         "second migrate: {rerun_out}"
+    );
+    assert!(
+        !rerun_out.contains("refreshed schema snapshot"),
+        "a no-op migrate must NOT refresh the snapshot: {rerun_out}"
+    );
+    let snap_after_noop = std::fs::read_to_string(&snapshot_path).expect("snapshot");
+    assert_eq!(
+        snap_after_apply, snap_after_noop,
+        "a no-op migrate must leave the snapshot byte-for-byte unchanged"
+    );
+    assert!(
+        !snap_after_noop.contains("body"),
+        "the ungenerated `body` edit must NOT be baked into the baseline: {snap_after_noop}"
+    );
+
+    // 5. Because the snapshot never advanced, the ungenerated edit is still
+    //    visible as drift: `schema diff` still generates the pending column add.
+    let (diff_after, _) = run_autumn_ok(&project, &["schema", "diff"], &envs);
+    assert!(
+        !diff_after.contains("No schema changes"),
+        "drift must still be detected after the no-op migrate: {diff_after}"
+    );
+    assert!(
+        diff_after.contains("body"),
+        "the pending `body` column add still diffs: {diff_after}"
     );
 }


### PR DESCRIPTION
Part of #1975

## Before / After

Before, the declarative-schema loop stopped at authoring: `autumn schema diff --write-migration` (slice 4) could generate `migrations/<ts>_<name>/{up,down}.sql`, but there was no CLI way to *apply* those generated migrations end-to-end, and no way to diagnose whether a project's declarative-schema state was healthy.

After:
- **`autumn schema migrate`** applies whatever is pending against the configured database and then refreshes the checked-in snapshot to the freshly-applied state. Postgres is advisory-locked (concurrent migrators serialize cleanly); SQLite applies unlocked under the backend-flip feature (single-writer, no advisory-lock primitive). It provider-locks against the snapshot's dialect *before* applying anything, prints an applied-migration summary, and re-snapshots the declared models so the baseline advances.
- **`autumn schema doctor`** is a read-only health report over six checks — project scaffolding, snapshot presence, model-vs-snapshot drift, backend provider-lock, snapshot-dialect-vs-DB, and pending migrations — each `OK`/`WARN`/`ERROR` with a one-line remediation. It exits non-zero only on an actionable `ERROR`; a `WARN` alone (uncommitted drift, unreachable DB, non-Postgres skips) never fails, so doctor stays runnable offline. `--json` emits the same checks as a machine-readable array.

## How

- Consumes the existing diff/snapshot/parse public surface (`diff_schema` / `DiffOptions`, `SchemaSnapshot` / `write_snapshot` / `load_snapshot` / `ensure_backend_matches`, `parse_models_path`) and the runtime `autumn_web::migrate` harness (`run_pending_locked` / `run_pending_sqlite` / `pending_migrations`) via diesel's `FileBasedMigrations`.
- Provider-lock refuses cross-dialect *before* applying: `migrate` loads the snapshot and calls `ensure_backend_matches(detected_backend)`, returning an error with no apply on a mismatch.
- `-- autumn-safety:` advisories are inert SQL comments here — the destructive-change guards ran at diff time (slice 4), so migration files apply verbatim, exactly as `autumn migrate` applies them.
- A snapshot-write failure *after* a successful DB apply is surfaced as a warning (the migration did apply), never reported as an apply failure; the refresh is skipped with a note when the project has no declarative models.
- `doctor`'s check computation is a pure function over gathered facts (no I/O), unit-tested directly; all filesystem/DB/env I/O lives in a thin shell. Secrets are scrubbed on every path — the resolved DB URL is only ever passed as an argument, never interpolated into output.
- `schema/diff.rs` is untouched (a parallel lane owns it).

## SQLite backend-flip note

autumn-cli now carries the same mutually-exclusive SQLite flip as autumn-web. The **default build targets Postgres**; the SQLite lane builds with default features off. `mail` was moved out of the direct `autumn-web` feature list into a **default-on `postgres` feature bundle** (`postgres = ["autumn-web/mail"]`), because autumn-web's `mail` `DbSuppressionStore` is hard-typed to `Pool<AsyncPgConnection>` and cannot compile under the backend-flip. The default build's `autumn-web` feature set is therefore **byte-for-byte identical to before** — only the feature *graph* changed so the `sqlite` build can resolve a mail-free set. Three localized `#[cfg]` gates in the pre-existing `autumn-cli/src/doctor.rs` keep its single `lettre` reference (the alert-email mailbox check) out of the sqlite build, with a conservative syntactic fallback; `schema/doctor.rs` references no `mail`/SQLite symbol.

Exact both-lane commands (never `--all-features`, never pg+sqlite in one invocation):

```
# Default (Postgres) lane
cargo fmt --all -- --check
cargo clippy -p autumn-cli --all-targets -- -D warnings
cargo test -p autumn-cli

# SQLite backend-flip lane
cargo clippy -p autumn-cli --no-default-features --features sqlite --all-targets -- -D warnings
cargo test -p autumn-cli --no-default-features --features sqlite
```

## Tests

- **Postgres e2e** (`schema_migrate.rs`, `#[ignore]`, Docker/testcontainers): snapshot → diff → migrate → refreshed snapshot → second migrate no-op → doctor clean, asserting no credential leak throughout.
- **SQLite e2e** (`schema_migrate_sqlite.rs`, feature-gated, **no Docker**): applies against a temp-file SQLite database end-to-end; runs in the sqlite lane.
- **Doctor/migrate unit tests**: `compute_checks` over synthesized states (drift OK/WARN, provider-lock error, missing/unreadable snapshot, dialect-vs-db mismatch, pending reachable/unreachable, ordering, JSON serialization, ERROR→non-zero exit), provider-lock refusal, the default-build SQLite apply seam naming the feature, and models-path resolution.

## Verification

Both lanes verified locally on this branch (rebased on current `trunk-dev`):

- **Default (pg):** `cargo fmt --all -- --check` clean; `cargo clippy -p autumn-cli --all-targets -- -D warnings` clean; `cargo test -p autumn-cli` — lib 4115 passed, integration 222 passed (schema migrate/doctor unit tests all green), Docker e2e `#[ignore]`d.
- **SQLite flip:** `cargo clippy -p autumn-cli --no-default-features --features sqlite --all-targets -- -D warnings` clean; `cargo test -p autumn-cli --no-default-features --features sqlite` — the SQLite file-DB e2e test compiles and runs green (223 integration passed).

Note: an unrelated pre-existing hygiene test (`repo_hygiene::first_run_docs_match_current_release_line`) fails identically on `trunk-dev` — `docs/guide/getting-started.md` pins the CLI install at `0.5.0` while the README and workspace are `0.6.0`. It is independent of this slice (this branch touches none of those files) and is intentionally left for the docs/release lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFWREUn6jHMrrsM6ovU2Hv)_