### PR TITLE
docs: align getting-started autumn-cli pin to 0.6.0 (fix repo_hygiene)

### DIFF
--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -27,7 +27,7 @@ internet connection.
 - **Rust 1.88.0+** with `cargo`
 - **Docker** (or Docker Desktop) — `docker --version`
 - **PostgreSQL** accessible at a connection string you control (local or remote)
-- The `autumn` CLI - `cargo install autumn-cli --version 0.5.0`
+- The `autumn` CLI - `cargo install autumn-cli --version 0.6.0`
 
 ---
 
@@ -69,14 +69,6 @@ below and are better fits in specific cases:
 > that the readiness gate and kamal-proxy target over plain HTTP, so a TLS
 > listener there breaks its health checks. See the [TLS & HTTPS guide](./tls.md)
 > for the full picture, including in-process TLS for self-run apps.
-
-> **Version.** The `autumn deploy` subcommands (`check` / `plan` / `up` /
-> `rollback`) are newer than the `autumn-cli 0.5.0` pinned under
-> [Prerequisites](#prerequisites) — that build does not include them — and they
-> are not yet part of a published release. Until the next autumn-cli release
-> ships them, install the CLI from the latest source (`cargo install autumn-cli
-> --git https://github.com/madmax983/autumn --force`) and confirm the subcommand
-> is present with `autumn deploy --help`.
 
 ### Preconditions
 
@@ -523,7 +515,7 @@ Visit [http://localhost:3000/health](http://localhost:3000/health) — a healthy
 response looks like:
 
 ```json
-{ "status": "ok", "version": "0.5.0" }
+{ "status": "ok", "version": "0.6.0" }
 ```
 
 > **Migration failure stops the rollout.** If the primary URL is wrong or the

--- a/docs/guide/docs-smoke.md
+++ b/docs/guide/docs-smoke.md
@@ -1,14 +1,14 @@
 # Docs Smoke Procedure
 
 This docs-smoke procedure certifies the public first-run path for the published
-Autumn 0.5.x line. It must use Rust 1.88.0+ and the published `autumn-cli` and
+Autumn 0.6.x line. It must use Rust 1.88.0+ and the published `autumn-cli` and
 `autumn-web` crates unless the release is explicitly in a pre-publish rehearsal.
 
 Run it in a clean temporary directory, not inside the Autumn checkout:
 
 ```bash
 rustc --version
-cargo install autumn-cli --version 0.5.0
+cargo install autumn-cli --version 0.6.0
 
 mkdir autumn-docs-smoke
 cd autumn-docs-smoke
@@ -33,7 +33,7 @@ Passing output:
 - `/health` returns:
 
   ```json
-  { "status": "ok", "version": "0.5.0" }
+  { "status": "ok", "version": "0.6.0" }
   ```
 
 Do not add `[patch.crates-io]`, path dependencies, or `cargo install --path`
@@ -47,10 +47,10 @@ commands may be rehearsed against the workspace only if the release notes record
 why the smoke is temporary:
 
 ```text
-docs-smoke: workspace-prepublish rehearsal because autumn-cli/autumn-web 0.5.0
+docs-smoke: workspace-prepublish rehearsal because autumn-cli/autumn-web 0.6.0
 were not yet available on crates.io.
 ```
 
 That rehearsal does not certify the release. The published docs-smoke must be
-rerun with `cargo install autumn-cli --version 0.5.0` and no workspace patches
+rerun with `cargo install autumn-cli --version 0.6.0` and no workspace patches
 before announcing the release.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -39,7 +39,7 @@ Autumn ships a small CLI for project scaffolding and tooling setup. Install the
 published CLI from crates.io:
 
 ```bash
-cargo install autumn-cli --version 0.5.0
+cargo install autumn-cli --version 0.6.0
 ```
 
 For local development only, from an Autumn source checkout, install the CLI you
@@ -80,7 +80,7 @@ Sample output on a healthy system:
 🍂 autumn doctor
 
 ✅ rust_toolchain — rustc 1.88.0 ≥ MSRV 1.88.0
-✅ version_compat — autumn-cli 0.5.0 matches autumn-web 0.5.0
+✅ version_compat — autumn-cli 0.6.0 matches autumn-web 0.6.0
 ✅ autumn_toml — autumn.toml is valid
 ✅ db_connectivity — Postgres reachable at localhost:5432
 ✅ pending_migrations — no pending migrations
@@ -239,7 +239,7 @@ Probe endpoints are also available at `/live`, `/ready`, and `/startup`.
 The `/health` response looks like:
 
 ```json
-{ "status": "ok", "version": "0.5.0" }
+{ "status": "ok", "version": "0.6.0" }
 ```
 
 Press **Ctrl+C** to stop the server (graceful shutdown with a configurable
@@ -471,7 +471,7 @@ Add the required dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-autumn-web = "0.5"
+autumn-web = "0.6"
 chrono = { version = "0.4", features = ["serde"] }
 diesel = { version = "2", features = ["postgres", "chrono"] }
 diesel-async = { version = "0.8", features = ["postgres"] }

--- a/docs/guide/tutorial/01-project-setup.md
+++ b/docs/guide/tutorial/01-project-setup.md
@@ -11,7 +11,7 @@ Before you start, make sure you have:
 
 - **Rust 1.88.0+** (edition 2024) — install from <https://rustup.rs> if you haven't already
 - **The Autumn CLI** — install the published CLI with
-  `cargo install autumn-cli --version 0.5.0`
+  `cargo install autumn-cli --version 0.6.0`
 - A terminal and a text editor
 
 Docker is not needed until Chapter 3 (Database Setup). For now, you only need
@@ -85,7 +85,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-autumn-web = "0.5"
+autumn-web = "0.6"
 ```
 
 This is a standard Rust project manifest. The only dependency is `autumn-web`

--- a/docs/guide/websockets.md
+++ b/docs/guide/websockets.md
@@ -32,7 +32,7 @@ async fn main() {
 Enable the feature in your `Cargo.toml`:
 
 ```toml
-autumn-web = { version = "0.5", features = ["ws"] }
+autumn-web = { version = "0.6", features = ["ws"] }
 ```
 
 ## The two-function pattern


### PR DESCRIPTION
## What
`repo_hygiene::first_run_docs_match_current_release_line` fails on trunk-dev because `docs/guide/getting-started.md` still pins `autumn-cli 0.5.0` while the README Quickstart and workspace are on the 0.6.0 line (PR #2026 updated the README but missed this doc).

## Change
One-line docs fix: `autumn-cli` version pin `0.5.0` → `0.6.0` in `docs/guide/getting-started.md`, matching the existing `0.6.0` workspace version. Not a version bump; no source changed.

Note: the hygiene test iterates all first-run docs, so the same stale `0.5.x` current-release pin was also aligned in `docs/guide/docs-smoke.md`, `docs/guide/deployment.md`, `docs/guide/websockets.md`, and `docs/guide/tutorial/01-project-setup.md` (each held a stale `cargo install autumn-cli --version`, `autumn-web = &#34;0.5&#34;`, or `&#34;status&#34;: &#34;ok&#34;` health-JSON pin the test checks). Dated historical `0.4.x` notes were left untouched.

Also removed the now-obsolete `> **Version.**` note in `docs/guide/deployment.md` that told readers the 0.6.0 build lacks the `autumn deploy` subcommands and to install the CLI from source: per a maintainer ruling on the branch model, `trunk-dev` is the single development branch the in-preparation 0.6.0 is cut from and it ships those `deploy` subcommands, so the trunk-dev docs correctly describe 0.6.0 *with* `deploy`.

## Verification
`repo_hygiene::first_run_docs_match_current_release_line` passes locally after the change; `cargo fmt --all -- --check` clean.