### PR TITLE
ci: fix hcloud CLI install in deploy-real-vps validation workflow

### DIFF
--- a/.github/workflows/deploy-real-vps.yml
+++ b/.github/workflows/deploy-real-vps.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Install hcloud CLI
         run: |
-          ver="1.49.1"
+          ver="1.66.0"
           curl -fsSL "https://github.com/hetznercloud/cli/releases/download/v${ver}/hcloud-linux-amd64.tar.gz" \
             | sudo tar -xz -C /usr/local/bin hcloud
           hcloud version


### PR DESCRIPTION
## Before / After

**Before:** The "Deploy real-VPS validation" workflow failed instantly (<1s) at the **Install hcloud CLI** step. The step pinned a nonexistent hcloud release (`ver="1.49.1"`), so the download 404'd:

```
curl: (22) The requested URL returned error: 404
gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now
##[error]Process completed with exit code 2.
```

Because the CLI never installed, every downstream step (SSH keygen, VM provision, deploy-lifecycle assertions) was skipped, so **no real-VPS deploy validation ran** at all. (The VM-destroy cleanup ran fine — no leaked VM.)

**After:** The version pin is bumped to a valid current hcloud release, so the step downloads `https://github.com/hetznercloud/cli/releases/download/v1.66.0/hcloud-linux-amd64.tar.gz`, extracts `hcloud` onto PATH cleanly, and the pipeline can proceed to actual deploy validation.

## How

One-line change in `.github/workflows/deploy-real-vps.yml`, "Install hcloud CLI" step: `ver="1.49.1"` → `ver="1.66.0"`. `1.49.1` was never a published release tag (latest is `1.66.0`); the release asset filename scheme (`hcloud-linux-amd64.tar.gz`) is unchanged, so the download URL, the `curl -fsSL | sudo tar -xz -C /usr/local/bin hcloud` install, `set -e`, and surrounding structure are all preserved. No checksum is used by this step, so nothing else needs to change.

## Verification notes

This CI step can't be integration-tested outside GitHub Actions. The corrected release was verified out-of-band: `github.com/hetznercloud/cli/releases/latest` resolves to `v1.66.0`; that release lists `hcloud-linux-amd64.tar.gz` (checksum `8b1a8598…03e29a86`); and the pinned download URL `…/download/v1.66.0/hcloud-linux-amd64.tar.gz` returns a `302` redirect to a signed `release-assets.githubusercontent.com` asset URL (a nonexistent version/asset would 404), confirming it resolves.

Part of #2019 (real-VPS validation).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPw736F7Hs65HQ6nZTD4Pa)_