### PR TITLE
autumn-cli: advance schema snapshot at generation time (#2041)

### DIFF
--- a/autumn-cli/src/schema/migrate.rs
+++ b/autumn-cli/src/schema/migrate.rs
@@ -1,12 +1,14 @@
-//! `autumn schema migrate` — apply the generated migrations, then advance the
-//! snapshot baseline (slice 6 of tracking issue #1975).
+//! `autumn schema migrate` — apply the generated migrations (slice 6 of tracking
+//! issue #1975).
 //!
 //! This is the *apply* half of the declarative-schema loop. `autumn schema diff
 //! --write-migration` (slice 4) authored `migrations/<ts>_<name>/{up,down}.sql`
-//! after running the destructive-change guards; this command applies whatever is
-//! pending against the configured database and then re-snapshots the declared
-//! models so the checked-in baseline advances to the state the database is now
-//! in.
+//! after running the destructive-change guards AND advanced the checked-in
+//! snapshot baseline to the generated plan's target state; this command applies
+//! whatever is pending against the configured database. It does NOT touch the
+//! snapshot — the baseline already moved at generation time, so re-snapshotting
+//! here (from possibly-newer, still-ungenerated models) could only bake un-drift
+//! into the baseline and hide it from the next `schema diff` / `doctor`.
 //!
 //! # What this command deliberately does NOT do
 //!
@@ -14,7 +16,7 @@
 //! generated migration may carry are inert SQL comments; the destructive-change
 //! refusal happened at diff time, not here. Migration files apply verbatim,
 //! exactly as `autumn migrate` applies them — this command adds only the
-//! provider-lock check and the post-apply snapshot refresh.
+//! provider-lock check. It also does not advance the snapshot (see above).
 //!
 //! # Backend handling (Postgres default; `SQLite` behind a feature)
 //!
@@ -32,13 +34,12 @@ use diesel_migrations::FileBasedMigrations;
 
 use autumn_web::migrate::{DEFAULT_LOCK_WAIT_TIMEOUT, MigrationResult};
 
-use super::parse::parse_models_path;
-use super::snapshot::{
-    SNAPSHOT_DEFAULT_PATH, SchemaSnapshot, SnapshotError, load_snapshot, write_snapshot,
-};
+use super::snapshot::{SNAPSHOT_DEFAULT_PATH, SnapshotError, load_snapshot};
 
-/// Apply pending migrations against the configured database, then refresh the
-/// checked-in schema snapshot.
+/// Apply pending migrations against the configured database.
+///
+/// The checked-in schema snapshot is NOT touched here — it already advanced at
+/// `schema diff --write-migration` (generation) time.
 ///
 /// Resolves the project root from the current directory; `profile` is the
 /// explicit `--profile` flag (else the ambient profile resolution the rest of
@@ -117,37 +118,13 @@ fn migrate_at(project_root: &Path, profile: Option<&str>) -> Result<(), String> 
     }
 
     // Apply. The destructive-change guards already ran at diff time; migration
-    // files apply verbatim (`-- autumn-safety:` lines are inert SQL comments).
+    // files apply verbatim (`-- autumn-safety:` lines are inert SQL comments). The
+    // snapshot baseline already advanced at `schema diff --write-migration` time,
+    // so nothing is re-snapshotted here.
     let result = apply_pending(backend, &url, &migrations_dir)?;
     report_applied(&result);
 
-    // SNAPSHOT REFRESH: the declarative snapshot is the diff baseline. It advances
-    // ONLY when migrations were actually applied (`should_refresh_snapshot`) — a
-    // real apply means the database moved to a new state, so the baseline follows
-    // it to that state (re-parse the models, rewrite the snapshot atomically,
-    // dialect-tagged). When nothing was applied (the DB was already up to date)
-    // there is no new state to advance to, so the snapshot is left UNTOUCHED —
-    // rewriting it from the (possibly newly-edited, still-ungenerated) models
-    // would falsely bake those edits into the baseline and hide the drift from
-    // the next `schema diff` / `doctor`. A snapshot-write failure AFTER a
-    // successful apply is a warning, not an apply failure — the migration really
-    // did apply.
-    if should_refresh_snapshot(&result) {
-        refresh_snapshot_after_apply(project_root, backend);
-    }
-
     Ok(())
-}
-
-/// Whether a completed apply should advance the checked-in snapshot baseline.
-///
-/// The invariant: the snapshot tracks the APPLIED database state, so it advances
-/// **iff** migrations were actually applied. An empty `applied` list means the DB
-/// was already up to date — there is no new applied state to snapshot, so the
-/// baseline must stay put (otherwise ungenerated model edits would be silently
-/// baked into it and never surface as drift). Pure so the decision is testable.
-const fn should_refresh_snapshot(result: &MigrationResult) -> bool {
-    !result.applied.is_empty()
 }
 
 /// Enforce the provider-lock guard against an on-disk snapshot.
@@ -257,6 +234,12 @@ enum MigrationsDir {
 /// [`MigrationsDir::HasMigrations`] when it contains at least one migration
 /// subdirectory (the diesel layout) and [`MigrationsDir::Empty`] otherwise. Pure
 /// over the filesystem so the decision is testable without a database.
+///
+/// Per-entry iteration errors are propagated, NOT swallowed: a `read_dir`
+/// iterator can yield `Err` mid-scan (an I/O failure after the directory opened
+/// cleanly). The whole iterator is consumed and ANY per-entry `Err` yields
+/// [`MigrationsDir::Unreadable`] — otherwise a mid-scan failure could be
+/// misclassified `Empty` and silently skip a required deploy.
 fn classify_migrations_dir(migrations_dir: &Path) -> MigrationsDir {
     match migrations_dir.try_exists() {
         Ok(false) => return MigrationsDir::Absent,
@@ -266,9 +249,15 @@ fn classify_migrations_dir(migrations_dir: &Path) -> MigrationsDir {
         Err(e) => return MigrationsDir::Unreadable(e),
     }
 
-    match std::fs::read_dir(migrations_dir) {
+    let entries = match std::fs::read_dir(migrations_dir) {
+        Ok(entries) => entries,
+        Err(e) => return MigrationsDir::Unreadable(e),
+    };
+    // Fully consume the iterator, surfacing any per-entry read error rather than
+    // filtering it out (which would misclassify a mid-scan failure as `Empty`).
+    match entries.collect::<Result<Vec<_>, _>>() {
         Ok(entries) => {
-            if entries.filter_map(Result::ok).any(|e| e.path().is_dir()) {
+            if entries.iter().any(|e| e.path().is_dir()) {
                 MigrationsDir::HasMigrations
             } else {
                 MigrationsDir::Empty
@@ -290,46 +279,13 @@ fn report_applied(result: &MigrationResult) {
     println!("Applied {} migration(s).", result.applied.len());
 }
 
-/// Re-parse the declared models and rewrite the snapshot at
-/// [`SNAPSHOT_DEFAULT_PATH`], tagged with `backend`. Best-effort: after a
-/// successful DB apply, a failure to refresh the snapshot is reported as a
-/// warning (never surfaced as an apply failure), and a missing models source is
-/// a benign note.
-fn refresh_snapshot_after_apply(project_root: &Path, backend: Backend) {
-    let Some(models_path) = super::existing_models_path(project_root) else {
-        eprintln!(
-            "note: no declarative models found under src/ — migrations applied, but the schema \
-             snapshot was not refreshed (nothing to snapshot)."
-        );
-        return;
-    };
-
-    let desired = match parse_models_path(&models_path, backend) {
-        Ok(parsed) => parsed,
-        Err(e) => {
-            eprintln!(
-                "warning: migrations applied, but re-parsing models to refresh the snapshot \
-                 failed: {e}"
-            );
-            return;
-        }
-    };
-
-    let snapshot = SchemaSnapshot::new(backend, desired.tables);
-    let out = project_root.join(SNAPSHOT_DEFAULT_PATH);
-    match write_snapshot(&out, &snapshot) {
-        Ok(()) => println!("refreshed schema snapshot at {}", out.display()),
-        Err(e) => eprintln!(
-            "warning: migrations applied, but refreshing the schema snapshot at {} failed: {e}",
-            out.display()
-        ),
-    }
-}
-
 #[cfg(test)]
 #[allow(clippy::needless_raw_string_hashes)]
 mod tests {
     use super::*;
+    // The provider-lock tests write a snapshot; the production apply path no
+    // longer touches the snapshot writer, so import it in the test scope only.
+    use super::super::snapshot::{SchemaSnapshot, write_snapshot};
 
     #[test]
     fn classify_absent_path_is_a_no_op() {
@@ -384,6 +340,13 @@ mod tests {
         ));
     }
 
+    // NOTE: `classify_migrations_dir` also propagates a per-entry iteration `Err`
+    // (a `read_dir` iterator yielding `Err` mid-scan) as `Unreadable`, not `Empty`.
+    // Forcing a per-entry iteration error deterministically and portably is not
+    // feasible (it needs an I/O failure to occur *after* the directory opened
+    // cleanly, which no portable filesystem primitive can inject), so it is not
+    // unit-tested here; the `collect::<Result<Vec<_>, _>>()` in the implementation
+    // is the guard, and the open-error path below covers `read_dir` failing.
     #[cfg(unix)]
     #[test]
     fn classify_unreadable_dir_is_an_error() {
@@ -409,21 +372,6 @@ mod tests {
             return;
         }
         assert!(matches!(classified, MigrationsDir::Unreadable(_)));
-    }
-
-    #[test]
-    fn should_refresh_snapshot_only_when_something_was_applied() {
-        // A real apply (non-empty `applied`) advances the baseline.
-        let applied = MigrationResult {
-            applied: vec!["20260101000000_init".to_string()],
-        };
-        assert!(should_refresh_snapshot(&applied));
-        // A no-op apply (DB already up to date) must NOT advance it — otherwise
-        // ungenerated model edits would be silently baked into the baseline.
-        let noop = MigrationResult {
-            applied: Vec::new(),
-        };
-        assert!(!should_refresh_snapshot(&noop));
     }
 
     #[test]

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -105,10 +105,13 @@ pub enum SchemaAction {
         #[arg(long)]
         allow_destructive: bool,
     },
-    /// Apply pending migrations against the configured database, then advance the
-    /// checked-in snapshot baseline to the freshly-applied state. Provider-locked
-    /// against the snapshot's dialect; the destructive-change guards ran at diff
-    /// time, so migration files apply verbatim here.
+    /// Apply pending migration files against the configured database.
+    ///
+    /// Does NOT modify the checked-in schema snapshot: the baseline advances at
+    /// generation time via `schema diff --write-migration`, so this command only
+    /// applies pending migrations. Provider-locked against the snapshot's dialect;
+    /// the destructive-change guards ran at diff time, so migration files apply
+    /// verbatim here.
     Migrate {
         /// Config profile whose database URL to apply against (defaults to the
         /// ambient profile resolution the other CLI commands use).

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -464,11 +464,6 @@ fn diff_at(
     let ts = crate::generate::timestamp_now();
     let suffix = crate::generate::naming::snake(name.unwrap_or("schema_update"));
     let dir = write_migration_dir(project_root, &ts, &suffix, &up, &down)?;
-    println!(
-        "wrote migration {} ({} change(s))",
-        dir.display(),
-        plan.changes.len()
-    );
 
     // (g) Advance the checked-in snapshot to the state this migration converges
     // the database on. The snapshot now moves at GENERATION time (here), not at
@@ -478,9 +473,26 @@ fn diff_at(
     // snapshot tracks exactly what the emitted SQL produces. A plain `schema diff`
     // (no `--write-migration`) returned above (step e), so it never reaches here
     // and never touches the snapshot.
+    //
+    // The migration files and the checked-in snapshot must advance together: if
+    // the snapshot write fails (read-only dir, full disk, ...) after the
+    // migration is on disk, retrying `schema diff --write-migration` would
+    // regenerate the same SQL as a second migration (baseline never advanced)
+    // and applying both would fail on duplicate DDL. Roll the migration dir back
+    // on a snapshot-write failure so the pre-command state is left intact.
     let target_tables = project_plan_target(&baseline.tables, &plan);
-    snapshot::write_snapshot(&snapshot_path, &SchemaSnapshot::new(backend, target_tables))
-        .map_err(|e| e.to_string())?;
+    if let Err(e) =
+        snapshot::write_snapshot(&snapshot_path, &SchemaSnapshot::new(backend, target_tables))
+    {
+        let _ = std::fs::remove_dir_all(&dir);
+        return Err(e.to_string());
+    }
+
+    println!(
+        "wrote migration {} ({} change(s))",
+        dir.display(),
+        plan.changes.len()
+    );
     println!("advanced schema snapshot at {}", snapshot_path.display());
     Ok(())
 }
@@ -894,6 +906,85 @@ mod tests {
             posts.columns.iter().any(|c| c.name == "body"),
             "advanced snapshot must contain the new `body` column: {:?}",
             posts.columns.iter().map(|c| &c.name).collect::<Vec<_>>()
+        );
+    }
+
+    // The migration files and the checked-in snapshot must advance together
+    // (Codex P1): if the snapshot write fails after `write_migration_dir` has
+    // already left a complete migration on disk, the baseline never advances, so
+    // retrying `schema diff --write-migration` regenerates the same SQL as a
+    // SECOND migration and applying both fails on duplicate DDL. `diff_at` rolls
+    // the migration dir back on a snapshot-write failure. Reproduce that failure
+    // portably by making the snapshot's parent dir (`.autumn`) read-only so the
+    // earlier snapshot LOAD still succeeds but `write_snapshot`'s tempfile
+    // create+rename cannot, then assert the command errors and left no migration.
+    #[cfg(unix)]
+    #[test]
+    fn write_migration_rolls_back_on_snapshot_write_failure() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Add a `body` column the snapshot lacks → a non-empty plan that would
+        // write a migration and then advance the snapshot.
+        let models = r#"
+            #[autumn_web::model(managed)]
+            pub struct Post {
+                #[id]
+                pub id: i64,
+                pub title: String,
+                pub body: Option<String>,
+            }
+        "#;
+        let root = scaffold_project(models, &posts_snapshot("Postgres"));
+        let autumn_dir = root.path().join(".autumn");
+
+        // Make the snapshot's parent directory read-only so a new tempfile cannot
+        // be created in it (the earlier read of the existing snapshot still works).
+        std::fs::set_permissions(&autumn_dir, std::fs::Permissions::from_mode(0o555))
+            .expect("chmod .autumn read-only");
+
+        // Skipped when the process can bypass the permission bits (e.g. running as
+        // root, where a read-only dir is still writable), which would otherwise
+        // make this non-deterministic — mirrors `classify_unreadable_dir_is_an_error`.
+        let can_still_write = tempfile::NamedTempFile::new_in(&autumn_dir).is_ok();
+        if can_still_write {
+            std::fs::set_permissions(&autumn_dir, std::fs::Permissions::from_mode(0o755))
+                .expect("restore chmod");
+            return;
+        }
+
+        let result = diff_at(
+            root.path(),
+            None,
+            None,
+            Some(BackendArg::Pg),
+            true,
+            Some("add_body"),
+            false,
+        );
+
+        // Restore permissions so the tempdir can be cleaned up (and the migrations
+        // assertion below can read the dir regardless of outcome).
+        std::fs::set_permissions(&autumn_dir, std::fs::Permissions::from_mode(0o755))
+            .expect("restore chmod");
+
+        // (a) The command surfaced the snapshot-write failure as an error.
+        assert!(
+            result.is_err(),
+            "a snapshot-write failure must surface as an error, got: {result:?}"
+        );
+
+        // (b) The just-created migration was rolled back: no migration directory
+        // is left behind, so a retry regenerates a single migration (not a second).
+        let migrations = root.path().join("migrations");
+        let leftover: Vec<_> = std::fs::read_dir(&migrations)
+            .map(|rd| {
+                rd.map(|e| e.expect("entry").file_name().to_string_lossy().into_owned())
+                    .collect()
+            })
+            .unwrap_or_default();
+        assert!(
+            leftover.is_empty(),
+            "the migration dir must be rolled back on a snapshot-write failure, found: {leftover:?}"
         );
     }
 

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -18,10 +18,12 @@ pub mod migrate;
 pub mod parse;
 pub mod snapshot;
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use autumn_schema_core::Backend;
+use autumn_schema_core::{Backend, Column, Table};
 
+use diff::{MigrationPlan, SchemaChange};
 use parse::parse_models_path;
 use snapshot::{SNAPSHOT_DEFAULT_PATH, SchemaSnapshot};
 
@@ -467,7 +469,135 @@ fn diff_at(
         dir.display(),
         plan.changes.len()
     );
+
+    // (g) Advance the checked-in snapshot to the state this migration converges
+    // the database on. The snapshot now moves at GENERATION time (here), not at
+    // apply time — `schema migrate` only applies files. The target is the guarded
+    // `plan` PROJECTED onto the baseline (not `desired.tables` wholesale), so a
+    // change the guard reduced or refused is never baked into the baseline: the
+    // snapshot tracks exactly what the emitted SQL produces. A plain `schema diff`
+    // (no `--write-migration`) returned above (step e), so it never reaches here
+    // and never touches the snapshot.
+    let target_tables = project_plan_target(&baseline.tables, &plan);
+    snapshot::write_snapshot(&snapshot_path, &SchemaSnapshot::new(backend, target_tables))
+        .map_err(|e| e.to_string())?;
+    println!("advanced schema snapshot at {}", snapshot_path.display());
     Ok(())
+}
+
+/// Project the guarded migration `plan` onto the `baseline` tables to compute the
+/// state the database will be in once the migration applies — the new snapshot
+/// baseline `schema diff --write-migration` advances to.
+///
+/// Each [`SchemaChange`] carries the full desired objects/values (they come from
+/// the desired state), so applying them onto a clone of the baseline is verbatim
+/// and convergent: the result equals what the emitted `up.sql` produces. This is
+/// deliberately NOT a snapshot of `desired.tables` wholesale — the guard may have
+/// reduced or refused parts of the delta, and the snapshot must track only what
+/// the migration actually does. Table order is irrelevant here: `write_snapshot`
+/// re-sorts tables by name canonically.
+fn project_plan_target(baseline: &[Table], plan: &MigrationPlan) -> Vec<Table> {
+    // Name-keyed working set cloned from the baseline.
+    let mut tables: BTreeMap<String, Table> = baseline
+        .iter()
+        .map(|t| (t.name.clone(), t.clone()))
+        .collect();
+
+    // Exhaustive match with NO wildcard arm: a future `SchemaChange` variant
+    // forces a compile error here rather than silently mis-projecting the target.
+    for change in &plan.changes {
+        match change {
+            SchemaChange::CreateTable(table) => {
+                tables.insert(table.name.clone(), table.clone());
+            }
+            SchemaChange::DropTable(table) => {
+                tables.remove(&table.name);
+            }
+            SchemaChange::AddColumn { table, column } => {
+                if let Some(t) = tables.get_mut(table) {
+                    t.columns.push(column.clone());
+                }
+            }
+            SchemaChange::DropColumn { table, column } => {
+                if let Some(t) = tables.get_mut(table) {
+                    t.columns.retain(|c| c.name != column.name);
+                }
+            }
+            SchemaChange::AlterColumnType {
+                table, column, to, ..
+            } => {
+                if let Some(c) = column_mut(&mut tables, table, column) {
+                    c.ty = to.clone();
+                }
+            }
+            SchemaChange::SetNotNull { table, column } => {
+                if let Some(c) = column_mut(&mut tables, table, column) {
+                    c.nullable = false;
+                }
+            }
+            SchemaChange::DropNotNull { table, column } => {
+                if let Some(c) = column_mut(&mut tables, table, column) {
+                    c.nullable = true;
+                }
+            }
+            SchemaChange::SetDefault {
+                table, column, to, ..
+            } => {
+                if let Some(c) = column_mut(&mut tables, table, column) {
+                    c.default = Some(to.clone());
+                }
+            }
+            SchemaChange::AddForeignKey {
+                table,
+                column,
+                foreign_key,
+            } => {
+                if let Some(c) = column_mut(&mut tables, table, column) {
+                    c.references = Some(foreign_key.clone());
+                }
+            }
+            SchemaChange::AddIndex { table, index } => {
+                if let Some(t) = tables.get_mut(table) {
+                    t.indexes.push(index.clone());
+                }
+            }
+            SchemaChange::DropIndex { table, index } => {
+                if let Some(t) = tables.get_mut(table) {
+                    t.indexes.retain(|i| i.name != index.name);
+                }
+            }
+            SchemaChange::AddCheck { table, check } => {
+                if let Some(t) = tables.get_mut(table) {
+                    t.checks.push(check.clone());
+                }
+            }
+            // The non-emittable marker variants: `guard_plan` refuses these before
+            // we get here (a guarded plan never carries one), so projecting them is
+            // a no-op — never a panic.
+            SchemaChange::PrimaryKeyChange { .. }
+            | SchemaChange::ForeignKeyChange { .. }
+            | SchemaChange::DropTableBlockedByInboundFk { .. }
+            | SchemaChange::AlterColumnTypeBlockedByFk { .. }
+            | SchemaChange::AddForeignKeyToExistingColumn { .. }
+            | SchemaChange::CreateTableBlockedBySkippedField { .. } => {}
+        }
+    }
+
+    tables.into_values().collect()
+}
+
+/// Find a mutable column by name within a named table in the working set — the
+/// column-facet helper [`project_plan_target`] uses to apply the `Alter*` /
+/// `Set*` / `Drop*Null` column changes. Returns `None` when the table or column
+/// is absent (a guarded plan never carries such a change, so a miss is a no-op).
+fn column_mut<'a>(
+    tables: &'a mut BTreeMap<String, Table>,
+    table: &str,
+    column: &str,
+) -> Option<&'a mut Column> {
+    tables
+        .get_mut(table)
+        .and_then(|t| t.columns.iter_mut().find(|c| c.name == column))
 }
 
 /// Write a `migrations/<ts>_<suffix>/{up,down}.sql` pair, creating the leaf
@@ -677,8 +807,12 @@ mod tests {
 
     #[test]
     fn diff_no_op_writes_nothing() {
-        // Models match the snapshot → no-op → no migration directory.
+        // Models match the snapshot → no-op → no migration directory AND the
+        // checked-in snapshot is left byte-for-byte unchanged (a no-op diff must
+        // not advance the baseline).
         let root = scaffold_project(POST_MODEL, &posts_snapshot("Postgres"));
+        let snapshot_path = root.path().join(".autumn/schema-snapshot.json");
+        let before = std::fs::read_to_string(&snapshot_path).expect("snapshot before");
         diff_at(
             root.path(),
             None,
@@ -692,6 +826,11 @@ mod tests {
         assert!(
             !root.path().join("migrations").exists(),
             "a no-op must not create a migrations directory"
+        );
+        let after = std::fs::read_to_string(&snapshot_path).expect("snapshot after");
+        assert_eq!(
+            before, after,
+            "a no-op diff must leave the snapshot byte-for-byte unchanged"
         );
     }
 
@@ -740,6 +879,147 @@ mod tests {
         assert!(
             down.contains("ALTER TABLE posts DROP COLUMN body;"),
             "down: {down}"
+        );
+
+        // The checked-in snapshot ADVANCED to the plan's target state: it now
+        // carries the `body` column the migration adds. Load it back and check.
+        let snapshot_path = root.path().join(".autumn/schema-snapshot.json");
+        let advanced = snapshot::load_snapshot(&snapshot_path).expect("load advanced snapshot");
+        let posts = advanced
+            .tables
+            .iter()
+            .find(|t| t.name == "posts")
+            .expect("posts table in advanced snapshot");
+        assert!(
+            posts.columns.iter().any(|c| c.name == "body"),
+            "advanced snapshot must contain the new `body` column: {:?}",
+            posts.columns.iter().map(|c| &c.name).collect::<Vec<_>>()
+        );
+    }
+
+    /// The core drift scenario from #2041: `schema diff --write-migration`
+    /// advances the snapshot to the GENERATED plan's target, so a later,
+    /// still-ungenerated model edit diffs on top of it (only the *new* delta),
+    /// never re-generating the already-generated change.
+    #[test]
+    #[allow(clippy::too_many_lines)] // linear scenario reads clearest end-to-end
+    fn write_migration_advances_snapshot_so_later_edits_diff_on_top() {
+        // Change A: add `body`. Baseline is the posts(id,title,created_at) snapshot.
+        let models_a = r#"
+            #[autumn_web::model(managed)]
+            pub struct Post {
+                #[id]
+                pub id: i64,
+                pub title: String,
+                pub body: Option<String>,
+            }
+        "#;
+        let root = scaffold_project(models_a, &posts_snapshot("Postgres"));
+        let snapshot_path = root.path().join(".autumn/schema-snapshot.json");
+
+        // Generate change A. The snapshot advances to include `body`.
+        diff_at(
+            root.path(),
+            None,
+            None,
+            Some(BackendArg::Pg),
+            true,
+            Some("add_body"),
+            false,
+        )
+        .expect("write migration A ok");
+
+        let after_a = snapshot::load_snapshot(&snapshot_path).expect("load snapshot after A");
+        let posts_a = after_a
+            .tables
+            .iter()
+            .find(|t| t.name == "posts")
+            .expect("posts after A");
+        assert!(
+            posts_a.columns.iter().any(|c| c.name == "body"),
+            "snapshot advanced to include `body`"
+        );
+        // The not-yet-added `draft` column is NOT in the snapshot yet.
+        assert!(
+            !posts_a.columns.iter().any(|c| c.name == "draft"),
+            "snapshot must not contain the not-yet-added `draft` column"
+        );
+
+        // Convergence: re-running with the SAME models is now a no-op — no second
+        // migration directory is written (the snapshot already matches).
+        diff_at(
+            root.path(),
+            None,
+            None,
+            Some(BackendArg::Pg),
+            true,
+            Some("add_body_again"),
+            false,
+        )
+        .expect("second (converged) diff ok");
+        let dir_count = std::fs::read_dir(root.path().join("migrations"))
+            .expect("read migrations")
+            .count();
+        assert_eq!(
+            dir_count, 1,
+            "a converged re-run must not write a second migration"
+        );
+
+        // Now edit the models to add `draft` on top of the already-generated
+        // `body`. Because the snapshot advanced to change A, the next diff
+        // generates ONLY `draft` — proving the baseline moved to the plan target,
+        // not that it stayed at the original baseline.
+        std::fs::write(
+            root.path().join("src").join("models.rs"),
+            r#"
+                #[autumn_web::model(managed)]
+                pub struct Post {
+                    #[id]
+                    pub id: i64,
+                    pub title: String,
+                    pub body: Option<String>,
+                    pub draft: Option<String>,
+                }
+            "#,
+        )
+        .expect("edit models to add draft");
+
+        diff_at(
+            root.path(),
+            None,
+            None,
+            Some(BackendArg::Pg),
+            true,
+            Some("add_draft"),
+            false,
+        )
+        .expect("write migration B (draft) ok");
+
+        // Exactly two migration dirs; the newest carries `draft` but NOT `body`.
+        let mut names: Vec<String> = std::fs::read_dir(root.path().join("migrations"))
+            .expect("read migrations")
+            .map(|e| e.expect("entry").file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        assert_eq!(names.len(), 2, "two migration dirs now: {names:?}");
+        let draft_dir = names
+            .iter()
+            .find(|n| n.ends_with("_add_draft"))
+            .expect("add_draft dir");
+        let up = std::fs::read_to_string(
+            root.path()
+                .join("migrations")
+                .join(draft_dir)
+                .join("up.sql"),
+        )
+        .expect("draft up.sql");
+        assert!(
+            up.contains("draft"),
+            "the second migration still generates `draft`: {up}"
+        );
+        assert!(
+            !up.contains("body"),
+            "the second migration must NOT re-generate the already-added `body`: {up}"
         );
     }
 

--- a/autumn-cli/tests/integration/schema_migrate.rs
+++ b/autumn-cli/tests/integration/schema_migrate.rs
@@ -6,10 +6,12 @@
 //!
 //!   `cargo test -p autumn-cli --test cli_tests -- --ignored schema_migrate`
 //!
-//! The happy path proves the headline behaviour: a generated migration is
-//! applied against a live Postgres, a second run reports up-to-date, the schema
-//! snapshot is refreshed to the applied state, and no credential ever leaks into
-//! the CLI output.
+//! The happy path proves the headline behaviour (#2041): `schema diff
+//! --write-migration` advances the checked-in snapshot to the generated plan's
+//! target state at generation time; `schema migrate` then applies the migration
+//! against a live Postgres, a second run reports up-to-date, the snapshot file is
+//! left BYTE-IDENTICAL by the apply, and no credential ever leaks into the CLI
+//! output.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -91,12 +93,14 @@ fn assert_no_secret_leak(stdout: &str, stderr: &str) {
 
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers); run with -- --ignored"]
-async fn schema_migrate_applies_generated_migration_and_refreshes_snapshot() {
+#[allow(clippy::too_many_lines)] // linear end-to-end scenario reads clearest whole
+async fn schema_migrate_applies_generated_migration_and_leaves_snapshot_untouched() {
     let (_container, host, port) = start_postgres().await;
     let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
     let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
 
     let (_tmp, project) = fresh_project("migrate_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
 
     // 1. A `Post` model plus an EMPTY baseline snapshot, so the diff produces a
     //    CREATE TABLE migration. The empty baseline comes from snapshotting an
@@ -119,10 +123,12 @@ async fn schema_migrate_applies_generated_migration_and_refreshes_snapshot() {
     let (doc_json, _) = run_autumn_ok(&project, &["schema", "doctor", "--json"], &envs);
     assert!(
         doc_json.contains("\"name\": \"snapshot-drift\"") && doc_json.contains("\"WARN\""),
-        "doctor should report drift before migrating:\n{doc_json}"
+        "doctor should report drift before generating:\n{doc_json}"
     );
 
-    // 2. Generate the migration from the diff.
+    // 2. Generate the migration from the diff. THIS is where the snapshot now
+    //    advances (#2041): `--write-migration` moves the checked-in baseline to
+    //    the generated plan's target state at generation time.
     let (diff_out, _) = run_autumn_ok(
         &project,
         &[
@@ -135,29 +141,46 @@ async fn schema_migrate_applies_generated_migration_and_refreshes_snapshot() {
         &envs,
     );
     assert!(diff_out.contains("wrote migration"), "diff: {diff_out}");
+    assert!(
+        diff_out.contains("advanced schema snapshot"),
+        "diff --write-migration reports advancing the snapshot: {diff_out}"
+    );
 
-    // 3. Apply it. Reports the applied migration, refreshes the snapshot, exit 0.
+    // The snapshot advanced to the plan target (now contains `posts`). Capture the
+    // exact bytes: the apply below must NOT change them.
+    let snap_after_generation = std::fs::read_to_string(&snapshot_path).expect("snapshot");
+    assert!(
+        snap_after_generation.contains("\"name\": \"posts\""),
+        "snapshot advanced at generation: {snap_after_generation}"
+    );
+
+    // Drift is already resolved right after generation: models match the advanced
+    // snapshot (there is still a pending, unapplied migration though).
+    let (doc_gen, _) = run_autumn_ok(&project, &["schema", "doctor", "--json"], &envs);
+    assert!(
+        doc_gen.contains("\"name\": \"snapshot-drift\"") && doc_gen.contains("\"OK\""),
+        "doctor drift is clean right after generation:\n{doc_gen}"
+    );
+
+    // 3. Apply it. Reports the applied migration; must NOT report or perform a
+    //    snapshot refresh, and must leave the snapshot file byte-identical.
     let (mig_out, mig_err) = run_autumn_ok(&project, &["schema", "migrate"], &envs);
     assert!(
         mig_out.contains("Applied 1 migration(s)."),
         "migrate stdout: {mig_out}"
     );
     assert!(
-        mig_out.contains("refreshed schema snapshot"),
-        "snapshot refresh reported: {mig_out}"
+        !mig_out.contains("refreshed schema snapshot"),
+        "migrate must NOT refresh the snapshot anymore: {mig_out}"
     );
     assert_no_secret_leak(&mig_out, &mig_err);
-
-    // 4. The snapshot advanced to the applied state (now contains `posts`). This
-    //    is the FIRST, real apply — the snapshot refresh is anchored to it.
-    let snapshot_path = project.join(".autumn/schema-snapshot.json");
     let snap_after_apply = std::fs::read_to_string(&snapshot_path).expect("snapshot");
-    assert!(
-        snap_after_apply.contains("\"name\": \"posts\""),
-        "snapshot: {snap_after_apply}"
+    assert_eq!(
+        snap_after_generation, snap_after_apply,
+        "migrate must leave the snapshot byte-for-byte unchanged"
     );
 
-    // 5. A second migrate is a clean no-op ("already up to date").
+    // 4. A second migrate is a clean no-op ("already up to date").
     let (rerun_out, rerun_err) = run_autumn_ok(&project, &["schema", "migrate"], &envs);
     assert!(
         rerun_out.contains("Database already up to date."),
@@ -165,7 +188,7 @@ async fn schema_migrate_applies_generated_migration_and_refreshes_snapshot() {
     );
     assert_no_secret_leak(&rerun_out, &rerun_err);
 
-    // 6. Doctor is now clean: drift OK, pending-migrations OK, exit 0.
+    // 5. Doctor is now fully clean: drift OK, pending-migrations OK, exit 0.
     let (doc_out, doc_err) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
     assert!(
         doc_out.contains("[OK]") && doc_out.contains("models match the snapshot baseline"),
@@ -177,11 +200,10 @@ async fn schema_migrate_applies_generated_migration_and_refreshes_snapshot() {
     );
     assert_no_secret_leak(&doc_out, &doc_err);
 
-    // 7. Finding 1 (#2036): introduce a NEW, ungenerated model change (add `body`)
+    // 6. Finding 1 (#2036): introduce a NEW, ungenerated model change (add `body`)
     //    WITHOUT generating/applying a migration for it, then run `schema migrate`
     //    again. With nothing pending to apply it is a no-op, and MUST leave the
-    //    snapshot untouched — re-snapshotting from the edited models here would
-    //    silently bake the new column into the baseline and hide the drift.
+    //    snapshot untouched — migrate no longer touches the snapshot at all.
     std::fs::write(
         project.join("src/models.rs"),
         "#[autumn_web::model(managed)]\npub struct Post {\n    #[id]\n    pub id: i64,\n    pub title: String,\n    pub body: Option<String>,\n}\n",
@@ -207,7 +229,7 @@ async fn schema_migrate_applies_generated_migration_and_refreshes_snapshot() {
     );
     assert_no_secret_leak(&noop_out, &noop_err);
 
-    // 8. Because the snapshot never advanced, the ungenerated edit is still
+    // 7. Because the snapshot never advanced for the ungenerated edit, it is still
     //    visible as drift: `schema diff` still generates the pending column add.
     let (diff_after, diff_after_err) = run_autumn_ok(&project, &["schema", "diff"], &envs);
     assert!(

--- a/autumn-cli/tests/integration/schema_migrate_sqlite.rs
+++ b/autumn-cli/tests/integration/schema_migrate_sqlite.rs
@@ -63,7 +63,7 @@ fn write_post_model(project: &Path) {
 }
 
 #[test]
-fn schema_migrate_applies_to_a_sqlite_file_and_refreshes_snapshot() {
+fn schema_migrate_applies_to_a_sqlite_file_and_advances_snapshot_at_generation() {
     let (_tmp, project) = fresh_project("sqlite_migrate_app");
 
     // A file-backed SQLite database inside the project (NOT `:memory:` — the
@@ -71,6 +71,7 @@ fn schema_migrate_applies_to_a_sqlite_file_and_refreshes_snapshot() {
     let db_path = project.join("app.db");
     let url = format!("sqlite://{}", db_path.display());
     let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
 
     // 1. Post model + empty baseline snapshot (Sqlite-tagged), so the diff
     //    produces a CREATE TABLE migration for SQLite.
@@ -89,7 +90,8 @@ fn schema_migrate_applies_to_a_sqlite_file_and_refreshes_snapshot() {
         &envs,
     );
 
-    // 2. Generate the SQLite migration from the diff.
+    // 2. Generate the SQLite migration from the diff. The snapshot advances HERE
+    //    (#2041), to the generated plan's target — Sqlite-tagged `posts`.
     let (diff_out, _) = run_autumn_ok(
         &project,
         &[
@@ -102,38 +104,42 @@ fn schema_migrate_applies_to_a_sqlite_file_and_refreshes_snapshot() {
         &envs,
     );
     assert!(diff_out.contains("wrote migration"), "diff: {diff_out}");
+    assert!(
+        diff_out.contains("advanced schema snapshot"),
+        "diff --write-migration reports advancing the snapshot: {diff_out}"
+    );
+    let snap_after_generation = std::fs::read_to_string(&snapshot_path).expect("snapshot");
+    assert!(
+        snap_after_generation.contains("\"backend\": \"Sqlite\""),
+        "snapshot: {snap_after_generation}"
+    );
+    assert!(
+        snap_after_generation.contains("\"name\": \"posts\""),
+        "snapshot advanced at generation: {snap_after_generation}"
+    );
 
-    // 3. Apply against the SQLite file: reports applied, refreshes snapshot,
-    //    exit 0. (No advisory lock — SQLite is single-writer, issue #1999.)
+    // 3. Apply against the SQLite file: reports applied, exit 0, and does NOT
+    //    touch the snapshot. (No advisory lock — SQLite is single-writer, #1999.)
     let (mig_out, _) = run_autumn_ok(&project, &["schema", "migrate"], &envs);
     assert!(
         mig_out.contains("Applied 1 migration(s)."),
         "migrate stdout: {mig_out}"
     );
     assert!(
-        mig_out.contains("refreshed schema snapshot"),
-        "snapshot refresh reported: {mig_out}"
+        !mig_out.contains("refreshed schema snapshot"),
+        "migrate must NOT refresh the snapshot anymore: {mig_out}"
     );
-
-    // The SQLite database file exists and the snapshot advanced to Sqlite-tagged
-    // `posts` (this is the FIRST, real apply — the refresh is anchored here).
     assert!(db_path.is_file(), "sqlite db file created");
-    let snapshot_path = project.join(".autumn/schema-snapshot.json");
     let snap_after_apply = std::fs::read_to_string(&snapshot_path).expect("snapshot");
-    assert!(
-        snap_after_apply.contains("\"backend\": \"Sqlite\""),
-        "snapshot: {snap_after_apply}"
-    );
-    assert!(
-        snap_after_apply.contains("\"name\": \"posts\""),
-        "snapshot: {snap_after_apply}"
+    assert_eq!(
+        snap_after_generation, snap_after_apply,
+        "migrate must leave the snapshot byte-for-byte unchanged"
     );
 
     // Finding 1 (#2036): introduce a NEW, ungenerated model change (add `body`)
     // WITHOUT generating/applying a migration for it. The next `schema migrate`
     // has nothing pending to apply, so it is a no-op — and MUST leave the
-    // snapshot untouched. If it re-snapshotted from the edited models, the new
-    // column would be silently baked into the baseline and never diff as drift.
+    // snapshot untouched (migrate no longer touches the snapshot at all).
     std::fs::write(
         project.join("src/models.rs"),
         "#[autumn_web::model(managed)]\npub struct Post {\n    #[id]\n    pub id: i64,\n    pub title: String,\n    pub body: Option<String>,\n}\n",
@@ -161,7 +167,7 @@ fn schema_migrate_applies_to_a_sqlite_file_and_refreshes_snapshot() {
         "the ungenerated `body` edit must NOT be baked into the baseline: {snap_after_noop}"
     );
 
-    // 5. Because the snapshot never advanced, the ungenerated edit is still
+    // 5. Because the snapshot never advanced for the ungenerated edit, it is still
     //    visible as drift: `schema diff` still generates the pending column add.
     let (diff_after, _) = run_autumn_ok(&project, &["schema", "diff"], &envs);
     assert!(


### PR DESCRIPTION
## Before / After

**Before:** `autumn schema migrate` refreshed the checked-in snapshot to the *current models* after applying migrations (gated on "something was actually applied"). Because the refresh re-parsed whatever the models looked like at apply time, a model edit made after generation but not yet turned into a migration could get silently baked into the baseline — hiding real drift from the next `schema diff` / `doctor`. The snapshot only moved when the database moved.

**After:** `autumn schema diff --write-migration` advances the snapshot to the **generated plan's target state** at generation time — the moment the migration is authored — and `autumn schema migrate` only applies pending migration files (it never touches the snapshot). The baseline now tracks exactly what the emitted SQL produces, so the snapshot and the migration are always in lock-step, and un-generated model drift stays visible as drift until it too is generated.

## How

- **`project_plan_target(baseline, plan)` (in `schema/mod.rs`)** — the new projection. It clones the baseline tables into a name-keyed working set and applies each guarded `SchemaChange` in order using the full objects/values the change carries (they come from the desired state, so the deltas are verbatim and convergent): `CreateTable`/`DropTable`, `AddColumn`/`DropColumn`, `AlterColumnType`/`SetNotNull`/`DropNotNull`/`SetDefault`, `AddIndex`/`DropIndex`, `AddCheck`. It is deliberately **not** a snapshot of `desired.tables` wholesale — the guard may have reduced or refused parts of the delta. The match is exhaustive with **no wildcard arm** (a future variant forces a compile error); the non-emittable marker variants that `guard_plan` refuses before generation are an explicit no-op arm. `diff_at`'s `--write-migration` branch calls it after the migration dir is written, then `write_snapshot`s the dialect-tagged envelope and prints `advanced schema snapshot at <path>`. Plain `schema diff` returns before this point, so it never touches the snapshot.
- **Removed the migrate-time refresh** (in `schema/migrate.rs`): `refresh_snapshot_after_apply`, `should_refresh_snapshot`, their call site, the now-moot "refreshed schema snapshot" text, and the now-unused imports/test. The provider-lock check (which still needs `load_snapshot` / `SnapshotError` / `SNAPSHOT_DEFAULT_PATH`) is unchanged.
- **`classify_migrations_dir` per-entry error fix**: the old `entries.filter_map(Result::ok).any(...)` swallowed per-entry iteration `Err`s, so a mid-scan I/O failure was misclassified `Empty` (a silent no-op deploy-skip). It now fully consumes the iterator via `collect::<Result<Vec<_>, _>>()` and returns `Unreadable` on any per-entry `Err`, only returning `HasMigrations`/`Empty` when every entry reads cleanly.

## Tests

- `schema/mod.rs`: `write_migration_creates_up_and_down` now asserts the snapshot advanced to include the new column; `diff_no_op_writes_nothing` asserts a no-op leaves the snapshot byte-identical; new `write_migration_advances_snapshot_so_later_edits_diff_on_top` covers the core drift scenario (generate `body` → snapshot has `body` not `draft`; converged re-run writes no second migration; later `draft` edit still diffs `draft` and not `body`).
- `schema/migrate.rs`: removed the `should_refresh_snapshot` unit test; the classify tests are retained.
- Integration tests rewired: the "snapshot advanced" assertion moved to right after `diff --write-migration`, and `migrate` is asserted to leave the snapshot **byte-identical** and to not print "refreshed schema snapshot". Renamed to `..._leaves_snapshot_untouched` (Postgres) and `..._advances_snapshot_at_generation` (SQLite).

`diff.rs` is untouched.

Part of #1975 / Closes #2041

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLCovVRZh6po4x1MHo44gE)_