### PR TITLE
ci: fix retired Hetzner server type (cx22) in deploy-real-vps validation

### DIFF
--- a/.github/workflows/deploy-real-vps.yml
+++ b/.github/workflows/deploy-real-vps.yml
@@ -23,9 +23,13 @@ on:
         type: string
         default: "ubuntu-24.04"
       server_type:
+        # Single source of truth for the provisioned server type. The
+        # provisioning step below falls back to this same value for scheduled
+        # runs (which supply no inputs). Update BOTH when Hetzner retires the
+        # type: cx22 was retired, hence cpx11 (current AMD shared-vCPU, nbg1).
         description: "Hetzner server type"
         type: string
-        default: "cx22"
+        default: "cpx11"
       location:
         description: "Hetzner location"
         type: string
@@ -110,7 +114,7 @@ jobs:
           hcloud ssh-key create --name "${HCLOUD_SSH_KEY_NAME}" --public-key-from-file "${SSH_KEY}.pub"
           hcloud server create \
             --name "${HCLOUD_SERVER_NAME}" \
-            --type "${{ inputs.server_type || 'cx22' }}" \
+            --type "${{ inputs.server_type || 'cpx11' }}" \
             --image "${{ inputs.ubuntu_image || 'ubuntu-24.04' }}" \
             --location "${{ inputs.location || 'nbg1' }}" \
             --ssh-key "${HCLOUD_SSH_KEY_NAME}"


### PR DESCRIPTION
## Before / After

**Before:** The real-VPS validation workflow reached VM provisioning and failed at the **Provision throwaway VM (Hetzner Cloud)** step. The `hcloud server create --type "cx22" ... --location "nbg1"` invocation errored with:

```
hcloud: Server Type not found: cx22
```

Hetzner no longer resolves `cx22` for this project/location, so provisioning could never start (all downstream lifecycle-assertion steps were skipped).

**After:** The workflow provisions a **current** server type — `cpx11` — verified available in `nbg1`. `cpx11` is Hetzner's entry-level AMD shared-vCPU plan: **2 shared AMD EPYC vCPUs, 2 GB RAM, 40 GB SSD, ~€4.99/mo**, which is plenty for the throwaway VM (kamal-proxy + a tiny test app). Verified current and nbg1-available against Hetzner's live type list (Spare Cores lists `cpx11` in 6 availability zones including Nuremberg / NBG1).

## How

Replaced `cx22` in both places it appears, keeping them consistent:

- `workflow_dispatch` input default: `default: "cx22"` → `default: "cpx11"`
- provisioning shell fallback (used by scheduled runs, which supply no inputs): `--type "${{ inputs.server_type || 'cx22' }}"` → `--type "${{ inputs.server_type || 'cpx11' }}"`

**Single source of truth / future-proofing:** the shell already reads `${{ inputs.server_type }}` and only falls back to the literal for schedule-triggered runs. Added a comment on the input noting both spots must be updated (with the `|| 'cpx11'` fallback) whenever Hetzner retires the type, so the next retirement is an obvious one-line change. Diff is minimal — no other workflow logic touched.

```diff
       server_type:
+        # Single source of truth for the provisioned server type. The
+        # provisioning step below falls back to this same value for scheduled
+        # runs (which supply no inputs). Update BOTH when Hetzner retires the
+        # type: cx22 was retired, hence cpx11 (current AMD shared-vCPU, nbg1).
         description: "Hetzner server type"
         type: string
-        default: "cx22"
+        default: "cpx11"
...
-            --type "${{ inputs.server_type || 'cx22' }}" \
+            --type "${{ inputs.server_type || 'cpx11' }}" \
```

## Notes

- Part of #2019 (real-VPS validation).
- The hcloud CLI install fix from #2039 is confirmed working — the failed run got past hcloud install (`hcloud 1.66.0`), the release CLI build, and SSH keypair creation; the server type was the only remaining failure. This is the next step in the chain.
- The fix is verified against Hetzner's live server-type list; provisioning itself can't be integration-tested outside GitHub Actions without an `HCLOUD_TOKEN`. `yaml.safe_load` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPw736F7Hs65HQ6nZTD4Pa)_