### PR TITLE
autumn-cli: schema pull (Postgres introspection) + doctor drift-vs-database

### DIFF
--- a/autumn-cli/src/schema/diff.rs
+++ b/autumn-cli/src/schema/diff.rs
@@ -3321,6 +3321,41 @@ mod tests {
         );
     }
 
+    /// Model diff: a baseline constraint-owned index (a brownfield `UNIQUE`
+    /// constraint's auto-created index, retained by `schema pull` via its
+    /// `definition`) absent from the desired (model) side is **retained** — no
+    /// `DropIndex`. This is the load-bearing case: Postgres rejects dropping an
+    /// index that backs a constraint, so emitting a `DROP INDEX` would produce a
+    /// failing migration. Retention is purely `definition`-based, so the same code
+    /// path that preserves expression/partial indexes preserves this one.
+    #[test]
+    fn model_diff_retains_constraint_owned_unique_index() {
+        let constraint_idx = Index {
+            name: "users_email_key".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: Some(
+                "CREATE UNIQUE INDEX users_email_key ON public.users USING btree (email)"
+                    .to_owned(),
+            ),
+        };
+        let mut base_table = posts_with(vec![col("email", ColumnType::Text)]);
+        base_table.indexes.push(constraint_idx);
+        let want = parsed(
+            vec![posts_with(vec![col("email", ColumnType::Text)])],
+            vec![],
+        );
+        let plan = diff_schema(&[base_table], &want, DEFAULT_OPTS);
+        assert!(
+            !plan
+                .changes
+                .iter()
+                .any(|c| matches!(c, SchemaChange::DropIndex { .. })),
+            "model diff must retain (not drop) a constraint-owned index; got {:?}",
+            plan.changes
+        );
+    }
+
     /// Retention holds even under `--allow-destructive`: the declarative tool
     /// never drops a construct it cannot express.
     #[test]

--- a/autumn-cli/src/schema/diff.rs
+++ b/autumn-cli/src/schema/diff.rs
@@ -1243,28 +1243,49 @@ pub fn index_depends_on_column(index: &Index, col: &str) -> bool {
 /// model-diff path to recognize that a desired `#[unique]` index is already
 /// enforced by a differently-named brownfield constraint/unique index.
 ///
-/// ## Why exact-set-equality (not subset)
+/// ## Why exact **key**-set-equality on a FULL, NON-PARTIAL index
 ///
-/// For a `definition`-carrying baseline index, [`Index::columns`] is the exact
-/// `pg_depend` dependent-column set (key + expression + predicate columns). That
-/// set does **not** cheaply distinguish an index's *key* columns from a covering
-/// index's non-key `INCLUDE` columns: a `UNIQUE(a) INCLUDE(b)` index has unique
-/// scope `{a}` but `columns == {a, b}`. Treating such an index as unique over
-/// `{a, b}` (or letting it satisfy a desired unique on the superset) would be
-/// wrong. Since the IR does not carry the key/include split, we are conservative:
-/// only an EXACT set match suppresses the `AddIndex`. A covering index with extra
-/// `INCLUDE` columns simply does not match here and falls back to today's behavior
-/// for that rarer case — not a regression, just no new suppression.
+/// Only a baseline unique index that actually enforces table-wide uniqueness of the
+/// desired columns may suppress the `AddIndex`. Two catalog shapes look like they
+/// cover the set but do **not**, and are deliberately rejected:
+///
+/// - A **partial** unique index (`… ON t(email) WHERE …`) enforces uniqueness only
+///   for rows matching its predicate — duplicates can exist outside it — so it does
+///   NOT guarantee the model's table-wide `#[unique] email`. Rejected via
+///   [`Index::is_partial`].
+/// - An **expression** unique index (`UNIQUE (lower(email))`) enforces uniqueness of
+///   the *expression*, not the column, so it does NOT guarantee `#[unique] email`
+///   either. Introspection records an expression index with an EMPTY
+///   [`Index::key_columns`], which is rejected.
+///
+/// The comparison is therefore against the index's real **key** columns
+/// ([`Index::key_columns`]), which excludes a covering index's non-key `INCLUDE`
+/// columns — so `UNIQUE(a) INCLUDE(b)` (key `{a}`) satisfies `#[unique] a` but not
+/// `#[unique] {a, b}`. For a plain simple index introspection leaves `key_columns`
+/// empty (its key columns are exactly [`Index::columns`]); such a `definition`-less
+/// index falls back to comparing `columns`. A `definition`-carrying index with an
+/// empty `key_columns` is an expression index (or an older snapshot we cannot vouch
+/// for) and never satisfies — the conservative direction (emit the `AddIndex`), not
+/// a wrongful suppression.
 fn baseline_unique_index_covers(base: &Table, want_columns: &[String]) -> bool {
     let want_set: BTreeSet<&str> = want_columns.iter().map(String::as_str).collect();
     base.indexes.iter().any(|idx| {
-        idx.unique
-            && idx
-                .columns
-                .iter()
-                .map(String::as_str)
-                .collect::<BTreeSet<_>>()
-                == want_set
+        if !idx.unique || idx.is_partial {
+            return false;
+        }
+        // Effective KEY columns: an explicit `key_columns` (recorded for every
+        // `definition`-carrying index; empty ⇒ expression key ⇒ reject) wins;
+        // otherwise, for a plain `definition`-less index, its `columns` ARE its key
+        // columns. A `definition`-carrying index with no recorded key columns cannot
+        // be vouched for and is rejected.
+        let key: BTreeSet<&str> = if !idx.key_columns.is_empty() {
+            idx.key_columns.iter().map(String::as_str).collect()
+        } else if idx.definition.is_none() {
+            idx.columns.iter().map(String::as_str).collect()
+        } else {
+            return false;
+        };
+        key == want_set
     })
 }
 
@@ -3117,14 +3138,34 @@ fn single_pk_column(table: &Table) -> Option<(&Column, IdKind)> {
 
 /// Derive the id-generation strategy for a single-column PK:
 ///   `Int64` PK, no default            → `BigSerial`
+///   `Int32` PK, `nextval(...)` default → `Serial` (a brownfield `SERIAL` id)
 ///   `Uuid`  PK                        → `Uuid`
 /// Any other PK column → `None` (rendered normally with a table-level clause).
-const fn pk_kind_for(column: &Column) -> Option<IdKind> {
+///
+/// The `Int32`/`Serial` case only ever arises for a **brownfield-introspected**
+/// table: the model DSL never produces an int4 PK, so this cannot conflict with a
+/// model diff. Introspection deliberately preserves the `nextval(...)` default on an
+/// int4 PK (see `introspect::normalize_serial_pk_default`) precisely so it is
+/// recognized here and recreated as `SERIAL PRIMARY KEY` (auto-increment) rather
+/// than a plain `INTEGER PRIMARY KEY`. An int4 PK with NO default falls through to
+/// `None` → a plain integer PK (no auto-increment), which is correct.
+fn pk_kind_for(column: &Column) -> Option<IdKind> {
     match &column.ty {
         ColumnType::Int64 if column.default.is_none() => Some(IdKind::BigSerial),
+        ColumnType::Int32 if is_nextval_default(column) => Some(IdKind::Serial),
         ColumnType::Uuid => Some(IdKind::Uuid),
         _ => None,
     }
+}
+
+/// Whether a column's default is a `nextval(...)` sequence default (a `SERIAL`
+/// auto-increment default), which the DDL emitter reconstructs by suppressing the
+/// explicit default and rendering the `SERIAL`/`BIGSERIAL` keyword instead.
+fn is_nextval_default(column: &Column) -> bool {
+    matches!(
+        &column.default,
+        Some(ColumnDefault::Sql(sql)) if sql.trim_start().to_ascii_lowercase().starts_with("nextval(")
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -3410,6 +3451,8 @@ mod tests {
             columns: vec!["body".to_owned()],
             unique: false,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         };
         // desired gains the index.
         let base = vec![posts_with(vec![col("body", ColumnType::Text)])];
@@ -3449,6 +3492,8 @@ mod tests {
             columns: vec!["body".to_owned()],
             unique: false,
             definition: Some("CREATE INDEX idx_posts_lower_body ON posts (lower(body))".to_owned()),
+            is_partial: false,
+            key_columns: Vec::new(),
         }
     }
 
@@ -3492,6 +3537,8 @@ mod tests {
                 "CREATE UNIQUE INDEX users_email_key ON public.users USING btree (email)"
                     .to_owned(),
             ),
+            is_partial: false,
+            key_columns: vec!["email".to_owned()],
         };
         let mut base_table = posts_with(vec![col("email", ColumnType::Text)]);
         base_table.indexes.push(constraint_idx);
@@ -3529,6 +3576,8 @@ mod tests {
                 "CREATE UNIQUE INDEX accounts_email_key ON public.accounts USING btree (email)"
                     .to_owned(),
             ),
+            is_partial: false,
+            key_columns: vec!["email".to_owned()],
         };
         let mut base_table = posts_with(vec![col("email", ColumnType::Text)]);
         base_table.indexes.push(constraint_idx);
@@ -3540,6 +3589,8 @@ mod tests {
             columns: vec!["email".to_owned()],
             unique: true,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         });
         let plan = diff_schema(
             &[base_table],
@@ -3569,6 +3620,8 @@ mod tests {
             columns: vec!["email".to_owned()],
             unique: false,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         };
         let mut base_table = posts_with(vec![col("email", ColumnType::Text)]);
         base_table.indexes.push(nonunique);
@@ -3579,6 +3632,8 @@ mod tests {
             columns: vec!["email".to_owned()],
             unique: true,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         });
         let plan = diff_schema(
             &[base_table],
@@ -3611,6 +3666,8 @@ mod tests {
                 "CREATE UNIQUE INDEX accounts_email_key ON public.accounts USING btree (email)"
                     .to_owned(),
             ),
+            is_partial: false,
+            key_columns: vec!["email".to_owned()],
         };
         let mut base_table = posts_with(vec![col("email", ColumnType::Text)]);
         base_table.indexes.push(constraint_idx);
@@ -3621,6 +3678,8 @@ mod tests {
             columns: vec!["email".to_owned()],
             unique: true,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         });
         let plan = diff_schema(
             &[base_table],
@@ -3635,6 +3694,139 @@ mod tests {
             "authoritative diff must still emit AddIndex for a differently-named unique \
              index (column-set suppression is model-diff-only); got {:?}",
             plan.changes
+        );
+    }
+
+    /// A **partial** unique index (`… ON t(email) WHERE …`) enforces uniqueness only
+    /// for rows matching its predicate, so it does NOT satisfy a model `#[unique]
+    /// email` (table-wide) — even though its key columns equal `{email}`. The
+    /// `AddIndex` must still be emitted.
+    #[test]
+    fn baseline_partial_unique_index_does_not_satisfy_model_unique() {
+        let partial = Index {
+            name: "accounts_email_active_key".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: Some(
+                "CREATE UNIQUE INDEX accounts_email_active_key ON accounts (email) WHERE active"
+                    .to_owned(),
+            ),
+            is_partial: true,
+            key_columns: vec!["email".to_owned()],
+        };
+        let mut base = posts_with(vec![col("email", ColumnType::Text)]);
+        base.indexes.push(partial);
+        assert!(
+            !baseline_unique_index_covers(&base, &["email".to_owned()]),
+            "a partial unique index must NOT satisfy a table-wide #[unique]"
+        );
+
+        // End-to-end: the model #[unique] still emits an AddIndex (not suppressed).
+        let mut want_table = posts_with(vec![col("email", ColumnType::Text)]);
+        want_table.indexes.push(Index {
+            name: "idx_posts_email_unique".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
+        });
+        let plan = diff_schema(&[base], &parsed(vec![want_table], vec![]), DEFAULT_OPTS);
+        assert!(
+            plan.changes.iter().any(|c| matches!(
+                c,
+                SchemaChange::AddIndex { index, .. } if index.name == "idx_posts_email_unique"
+            )),
+            "partial baseline unique index must not suppress the model AddIndex; got {:?}",
+            plan.changes
+        );
+    }
+
+    /// An **expression** unique index (`UNIQUE (lower(email))`) enforces uniqueness of
+    /// the expression, not the column, so it does NOT satisfy `#[unique] email`.
+    /// Introspection records it with an EMPTY `key_columns` (its dependency `columns`
+    /// still names `email`), which must be rejected — the `AddIndex` is emitted.
+    #[test]
+    fn baseline_expression_unique_index_does_not_satisfy_model_unique() {
+        let expr = Index {
+            name: "accounts_lower_email_key".to_owned(),
+            // `columns` is the pg_depend dependency set (references `email`)...
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: Some(
+                "CREATE UNIQUE INDEX accounts_lower_email_key ON accounts (lower(email))"
+                    .to_owned(),
+            ),
+            is_partial: false,
+            // ...but its KEY is an expression, so no plain key columns are recorded.
+            key_columns: Vec::new(),
+        };
+        let mut base = posts_with(vec![col("email", ColumnType::Text)]);
+        base.indexes.push(expr);
+        assert!(
+            !baseline_unique_index_covers(&base, &["email".to_owned()]),
+            "an expression unique index (empty key_columns) must NOT satisfy #[unique]"
+        );
+
+        let mut want_table = posts_with(vec![col("email", ColumnType::Text)]);
+        want_table.indexes.push(Index {
+            name: "idx_posts_email_unique".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
+        });
+        let plan = diff_schema(&[base], &parsed(vec![want_table], vec![]), DEFAULT_OPTS);
+        assert!(
+            plan.changes.iter().any(|c| matches!(
+                c,
+                SchemaChange::AddIndex { index, .. } if index.name == "idx_posts_email_unique"
+            )),
+            "expression baseline unique index must not suppress the model AddIndex; got {:?}",
+            plan.changes
+        );
+    }
+
+    /// Regression guard for the last commit's fix: a plain, FULL, non-partial unique
+    /// constraint index whose key columns exactly equal the target STILL satisfies the
+    /// model `#[unique]` (no `AddIndex`). Covers both a `definition`-carrying
+    /// constraint index (key columns recorded) and a plain `definition`-less unique
+    /// index (key columns derived from `columns`).
+    #[test]
+    fn baseline_full_unique_constraint_index_still_satisfies_model_unique() {
+        // (c1) constraint-owned (definition-carrying) unique index, key == [email].
+        let constraint = Index {
+            name: "accounts_email_key".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: Some(
+                "CREATE UNIQUE INDEX accounts_email_key ON accounts (email)".to_owned(),
+            ),
+            is_partial: false,
+            key_columns: vec!["email".to_owned()],
+        };
+        let mut base = posts_with(vec![col("email", ColumnType::Text)]);
+        base.indexes.push(constraint);
+        assert!(
+            baseline_unique_index_covers(&base, &["email".to_owned()]),
+            "a full non-partial unique constraint index over the exact key set must satisfy #[unique]"
+        );
+
+        // (c2) plain definition-less unique index: key columns derived from `columns`.
+        let plain = Index {
+            name: "idx_accounts_email_unique".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
+        };
+        let mut base2 = posts_with(vec![col("email", ColumnType::Text)]);
+        base2.indexes.push(plain);
+        assert!(
+            baseline_unique_index_covers(&base2, &["email".to_owned()]),
+            "a plain full unique index must satisfy #[unique] via its columns"
         );
     }
 
@@ -3671,6 +3863,8 @@ mod tests {
             columns: vec!["body".to_owned()],
             unique: false,
             definition: Some("CREATE INDEX idx_posts_body ON posts (lower(body))".to_owned()),
+            is_partial: false,
+            key_columns: Vec::new(),
         };
         let mut base_table = posts_with(vec![col("body", ColumnType::Text)]);
         base_table.indexes.push(base_expr);
@@ -3682,6 +3876,8 @@ mod tests {
             columns: vec!["body".to_owned()],
             unique: false,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         });
         let plan = diff_schema(
             &[base_table],
@@ -3939,6 +4135,8 @@ mod tests {
             columns: vec!["status".to_owned()],
             unique: true,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         });
         let want = parsed(
             vec![posts_with(vec![])],
@@ -3967,6 +4165,8 @@ mod tests {
             columns: vec!["body".to_owned()],
             unique: false,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         };
         let mut base_table = posts_with(vec![col("body", ColumnType::Text)]);
         base_table.indexes.push(idx.clone());
@@ -4004,6 +4204,8 @@ mod tests {
             columns: vec!["author_id".to_owned(), "status".to_owned()],
             unique: true,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         });
         // desired retains `author_id` but the enum `status` is skipped (diagnostic),
         // so the parser never sees the composite index either.
@@ -4296,6 +4498,8 @@ mod tests {
                     columns: vec!["body".to_owned()],
                     unique: false,
                     definition: None,
+                    is_partial: false,
+                    key_columns: Vec::new(),
                 },
             }],
         };
@@ -4320,6 +4524,8 @@ mod tests {
                     columns: vec!["body".to_owned()],
                     unique: false,
                     definition: None,
+                    is_partial: false,
+                    key_columns: Vec::new(),
                 },
             }],
         };
@@ -4347,6 +4553,8 @@ mod tests {
                         columns: vec!["foo".to_owned()],
                         unique: true,
                         definition: None,
+                        is_partial: false,
+                        key_columns: Vec::new(),
                     },
                 },
                 SchemaChange::AddIndex {
@@ -4356,6 +4564,8 @@ mod tests {
                         columns: vec!["foo_unique".to_owned()],
                         unique: false,
                         definition: None,
+                        is_partial: false,
+                        key_columns: Vec::new(),
                     },
                 },
             ],
@@ -4391,12 +4601,16 @@ mod tests {
                 columns: vec!["foo".to_owned()],
                 unique: true,
                 definition: None,
+                is_partial: false,
+                key_columns: Vec::new(),
             },
             Index {
                 name: dup.clone(),
                 columns: vec!["foo_unique".to_owned()],
                 unique: false,
                 definition: None,
+                is_partial: false,
+                key_columns: Vec::new(),
             },
         ];
         let plan = MigrationPlan {
@@ -4425,6 +4639,8 @@ mod tests {
                         columns: vec!["foo".to_owned()],
                         unique: false,
                         definition: None,
+                        is_partial: false,
+                        key_columns: Vec::new(),
                     },
                 },
                 SchemaChange::AddIndex {
@@ -4434,6 +4650,8 @@ mod tests {
                         columns: vec!["bar".to_owned()],
                         unique: false,
                         definition: None,
+                        is_partial: false,
+                        key_columns: Vec::new(),
                     },
                 },
             ],
@@ -4460,6 +4678,8 @@ mod tests {
                     columns: vec!["email".to_owned()],
                     unique: true,
                     definition: None,
+                    is_partial: false,
+                    key_columns: Vec::new(),
                 },
             }],
         };
@@ -4507,6 +4727,8 @@ mod tests {
                         columns: vec!["email".to_owned()],
                         unique: true,
                         definition: None,
+                        is_partial: false,
+                        key_columns: Vec::new(),
                     },
                 },
             ],
@@ -4528,6 +4750,8 @@ mod tests {
             columns: vec!["email".to_owned()],
             unique: true,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         }];
         let plan = MigrationPlan {
             backend: Backend::Postgres,
@@ -4552,6 +4776,8 @@ mod tests {
                     columns: vec!["email".to_owned()],
                     unique: false,
                     definition: None,
+                    is_partial: false,
+                    key_columns: Vec::new(),
                 },
             }],
         };
@@ -4762,6 +4988,64 @@ mod tests {
         assert!(
             up.contains("id UUID PRIMARY KEY DEFAULT gen_random_uuid()"),
             "uuid PK: {up}"
+        );
+    }
+
+    /// A brownfield single-column `Int32` PK whose default is a `nextval(...)`
+    /// sequence (a `SERIAL PRIMARY KEY`) recreates as `SERIAL PRIMARY KEY` — the
+    /// explicit default is suppressed and auto-increment is preserved, mirroring the
+    /// `Int64` → `BIGSERIAL` path. It must NOT render `INTEGER … DEFAULT nextval`.
+    #[test]
+    fn create_table_int4_serial_pk_renders_serial() {
+        let mut t = Table::new("counters", Backend::Postgres);
+        let mut id = col("id", ColumnType::Int32);
+        id.primary_key = true;
+        id.default = Some(ColumnDefault::Sql(
+            "nextval('counters_id_seq'::regclass)".to_owned(),
+        ));
+        t.primary_key.push("id".to_owned());
+        t.columns.push(id);
+        t.columns.push(col("label", ColumnType::Text));
+        let body = render_create_table_body("counters", &t, Backend::Postgres);
+        assert!(
+            body.contains("id SERIAL PRIMARY KEY"),
+            "int4 SERIAL PK renders SERIAL: {body}"
+        );
+        assert!(
+            !body.contains("nextval") && !body.contains("id INTEGER"),
+            "the explicit nextval default is suppressed (no INTEGER … DEFAULT nextval): {body}"
+        );
+    }
+
+    /// A single-column `Int32` PK with NO default is a plain integer PK (no
+    /// auto-increment): it renders `INTEGER` with a table-level `PRIMARY KEY` clause,
+    /// never `SERIAL`.
+    #[test]
+    fn create_table_int4_pk_without_default_renders_plain_integer() {
+        let mut t = Table::new("counters", Backend::Postgres);
+        let mut id = col("id", ColumnType::Int32);
+        id.primary_key = true;
+        t.primary_key.push("id".to_owned());
+        t.columns.push(id);
+        let body = render_create_table_body("counters", &t, Backend::Postgres);
+        assert!(
+            !body.contains("SERIAL"),
+            "a plain int4 PK must not become SERIAL: {body}"
+        );
+        assert!(
+            body.contains("id INTEGER NOT NULL") && body.contains("PRIMARY KEY (id)"),
+            "a plain int4 PK renders a plain INTEGER column with a table-level PRIMARY KEY: {body}"
+        );
+    }
+
+    /// The existing `Int64` PK path is unchanged: `BIGSERIAL PRIMARY KEY`.
+    #[test]
+    fn create_table_int8_pk_still_renders_bigserial() {
+        let t = posts_with(vec![col("body", ColumnType::Text)]);
+        let body = render_create_table_body("posts", &t, Backend::Postgres);
+        assert!(
+            body.contains("id BIGSERIAL PRIMARY KEY"),
+            "int8 PK renders BIGSERIAL: {body}"
         );
     }
 
@@ -5023,6 +5307,8 @@ mod tests {
             columns: vec!["author_id".to_owned()],
             unique: false,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         });
         let plan = diff_schema(&base, &parsed(vec![want_table], vec![]), DEFAULT_OPTS);
         let up = emit_up_sql(&plan).expect("emit");
@@ -5075,6 +5361,8 @@ mod tests {
                 columns: vec!["slug".to_owned()],
                 unique: true,
                 definition: None,
+                is_partial: false,
+                key_columns: Vec::new(),
             },
         );
         assert_eq!(
@@ -5091,6 +5379,8 @@ mod tests {
                     columns: vec!["slug".to_owned()],
                     unique: false,
                     definition: None,
+                    is_partial: false,
+                    key_columns: Vec::new(),
                 },
             }],
         };
@@ -5117,6 +5407,8 @@ mod tests {
                         columns: vec!["new".to_owned()],
                         unique: false,
                         definition: None,
+                        is_partial: false,
+                        key_columns: Vec::new(),
                     },
                 },
                 SchemaChange::AddColumn {
@@ -5153,12 +5445,16 @@ mod tests {
             columns: vec!["slug".to_owned()],
             unique: false,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         };
         let new = Index {
             name: "idx_posts_slug".to_owned(),
             columns: vec!["slug".to_owned()],
             unique: true,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         };
         let mut base_table = posts_with(vec![col("slug", ColumnType::Text)]);
         base_table.indexes.push(old);
@@ -5212,6 +5508,8 @@ mod tests {
                         columns: vec!["old".to_owned()],
                         unique: false,
                         definition: None,
+                        is_partial: false,
+                        key_columns: Vec::new(),
                     },
                 },
                 SchemaChange::AddIndex {
@@ -5221,6 +5519,8 @@ mod tests {
                         columns: vec!["new".to_owned()],
                         unique: false,
                         definition: None,
+                        is_partial: false,
+                        key_columns: Vec::new(),
                     },
                 },
             ],
@@ -5334,6 +5634,8 @@ mod tests {
             columns: vec!["body".to_owned()],
             unique: false,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         });
         let plan = MigrationPlan {
             backend: Backend::Postgres,
@@ -5435,6 +5737,8 @@ mod tests {
                         columns: vec!["bio".to_owned()],
                         unique: false,
                         definition: None,
+                        is_partial: false,
+                        key_columns: Vec::new(),
                     },
                 },
             ],
@@ -5523,6 +5827,8 @@ mod tests {
             columns: vec!["body".to_owned()],
             unique: false,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         };
         let baseline = sqlite_table(
             "posts",
@@ -6951,6 +7257,8 @@ PRAGMA foreign_keys=ON;
             definition: Some(
                 "CREATE INDEX t_id_email_kind ON t (id) WHERE kind = 'email'".to_owned(),
             ),
+            is_partial: false,
+            key_columns: Vec::new(),
         };
         assert!(
             !index_depends_on_column(&partial, "email"),
@@ -6967,6 +7275,8 @@ PRAGMA foreign_keys=ON;
             columns: vec!["email".to_owned()],
             unique: false,
             definition: Some("CREATE INDEX u_lower_email ON users (lower(email))".to_owned()),
+            is_partial: false,
+            key_columns: Vec::new(),
         };
         assert!(
             index_depends_on_column(&expr, "email"),
@@ -6982,6 +7292,8 @@ PRAGMA foreign_keys=ON;
             columns: vec!["email".to_owned()],
             unique: true,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         };
         assert!(
             index_depends_on_column(&plain, "email"),
@@ -7002,6 +7314,8 @@ PRAGMA foreign_keys=ON;
             columns: vec!["email".to_owned()],
             unique: true,
             definition: Some("CREATE UNIQUE INDEX users_email_key ON users (email)".to_owned()),
+            is_partial: false,
+            key_columns: Vec::new(),
         });
         // Desired side: `email` removed. `diff_indexes` retains the definition
         // index (no DropIndex), so the plan is a lone DropColumn.
@@ -7100,6 +7414,8 @@ PRAGMA foreign_keys=ON;
                 "CREATE INDEX users_active ON users (lower(email)) WHERE tenant_id IS NOT NULL"
                     .to_owned(),
             ),
+            is_partial: false,
+            key_columns: Vec::new(),
         });
 
         // Desired side: BOTH `email` and `tenant_id` removed. The model diff

--- a/autumn-cli/src/schema/diff.rs
+++ b/autumn-cli/src/schema/diff.rs
@@ -1183,6 +1183,49 @@ fn indexes_equivalent(a: &Index, b: &Index) -> bool {
     }
 }
 
+/// Whether `index` depends on column `col` — i.e. Postgres would automatically
+/// drop the index (and any constraint it backs) when `col` is dropped via
+/// `ALTER TABLE … DROP COLUMN`. True when the index lists `col` among its indexed
+/// `columns`, or when its raw `definition` references `col` as a word-bounded SQL
+/// identifier (so `email` matches `lower(email)` / `(email)` but not `emailer`).
+///
+/// The token match on the `definition` text is a best-effort mirror of Postgres's
+/// cascade (see the introspect.rs "Deferred blind spots"): it detects the common
+/// expression/partial-index shapes without fully parsing the index expression.
+/// Both `project_plan_target` (snapshot projection) and [`emit_down_sql_pg`]
+/// (rollback restore) use this single test so they cannot drift.
+pub fn index_depends_on_column(index: &Index, col: &str) -> bool {
+    index.columns.iter().any(|c| c == col)
+        || index
+            .definition
+            .as_deref()
+            .is_some_and(|def| sql_token_references(def, col))
+}
+
+/// Whether `haystack` contains `needle` as a word-bounded token, where a "word"
+/// character is `[A-Za-z0-9_]`. Hand-rolled (no `regex` dependency) so a column
+/// name matches `lower(email)` / `(email)` / `email DESC` but never a longer
+/// identifier such as `emailer` or `user_email`.
+fn sql_token_references(haystack: &str, needle: &str) -> bool {
+    if needle.is_empty() {
+        return false;
+    }
+    let bytes = haystack.as_bytes();
+    let is_word = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+    let mut from = 0;
+    while let Some(rel) = haystack[from..].find(needle) {
+        let start = from + rel;
+        let end = start + needle.len();
+        let before_ok = start == 0 || !is_word(bytes[start - 1]);
+        let after_ok = end >= bytes.len() || !is_word(bytes[end]);
+        if before_ok && after_ok {
+            return true;
+        }
+        from = start + 1;
+    }
+    false
+}
+
 ///
 /// ## Unmodellable (expression/partial) indexes
 ///
@@ -1880,7 +1923,7 @@ pub fn emit_down_sql_with_context(
     ctx: &SchemaContext,
 ) -> Result<String, EmitError> {
     match plan.backend {
-        Backend::Postgres => emit_down_sql_pg(plan),
+        Backend::Postgres => emit_down_sql_pg(plan, ctx),
         Backend::Sqlite => emit_down_sql_sqlite(plan, ctx),
     }
 }
@@ -1902,7 +1945,17 @@ fn emit_up_sql_pg(plan: &MigrationPlan) -> Result<String, EmitError> {
 
 /// The Postgres reverse path: changes reversed and individually inverted, with
 /// `-- irreversible:` markers where data cannot round-trip.
-fn emit_down_sql_pg(plan: &MigrationPlan) -> Result<String, EmitError> {
+///
+/// A `DropColumn` on a column covered by a RETAINED (`definition`-carrying)
+/// baseline index — the expression/partial/constraint-owned indexes `schema pull`
+/// preserves and the model diff never `DropIndex`'s — cascade-drops that index in
+/// Postgres along with the column (the up path is a bare `ALTER TABLE … DROP
+/// COLUMN`, never a failing `DROP INDEX` on a constraint-backed index). So after
+/// re-adding the column the down path must recreate each such index from its
+/// verbatim `definition`, else rollback silently loses the uniqueness/index. This
+/// needs the baseline shapes carried in `ctx`; ordinary model-managed indexes are
+/// restored via their own `DropIndex → AddIndex` inversion and are skipped here.
+fn emit_down_sql_pg(plan: &MigrationPlan, ctx: &SchemaContext) -> Result<String, EmitError> {
     let mut ordered = up_ordered(&plan.changes)?;
     ordered.reverse();
     let mut groups = Vec::new();
@@ -1912,8 +1965,33 @@ fn emit_down_sql_pg(plan: &MigrationPlan) -> Result<String, EmitError> {
         if !sql.is_empty() {
             groups.push(sql.to_owned());
         }
+        // The column is re-added above; recreate its cascade-dropped retained
+        // indexes immediately after (column-before-index ordering).
+        if let SchemaChange::DropColumn { table, column } = change {
+            for idx in retained_indexes_depending_on(ctx, table, &column.name) {
+                groups.push(index_sql(table, idx).trim_end().to_owned());
+            }
+        }
     }
     Ok(join_groups(&groups))
+}
+
+/// The RETAINED (`definition`-carrying) baseline indexes of `table` that depend on
+/// `column` — the expression/partial/constraint-owned indexes Postgres
+/// cascade-drops with the column and that carry no `DropIndex` in the plan, so the
+/// down migration must recreate them verbatim. Returns empty when the table is
+/// absent from `ctx.baseline` (e.g. context-free emit).
+fn retained_indexes_depending_on<'a>(
+    ctx: &'a SchemaContext,
+    table: &str,
+    column: &str,
+) -> Vec<&'a Index> {
+    ctx.baseline.get(table).map_or_else(Vec::new, |t| {
+        t.indexes
+            .iter()
+            .filter(|i| i.definition.is_some() && index_depends_on_column(i, column))
+            .collect()
+    })
 }
 
 /// The change kinds whose `SQLite` realisation is a full table recreate: the
@@ -6647,6 +6725,126 @@ PRAGMA foreign_keys=ON;
             *tables,
             vec!["a".to_owned(), "b".to_owned()],
             "names the cycle"
+        );
+    }
+
+    // -- Part B: rollback restores a cascade-dropped retained index ----------
+
+    /// The `index_depends_on_column` word-boundary contract: a column name matches
+    /// `columns` membership and its word-bounded appearance in an expression
+    /// `definition`, but never a longer identifier that merely contains it.
+    #[test]
+    fn index_dependency_detection_is_word_bounded() {
+        let expr = Index {
+            name: "u_lower_email".to_owned(),
+            columns: vec![],
+            unique: false,
+            definition: Some("CREATE INDEX u_lower_email ON users (lower(email))".to_owned()),
+        };
+        assert!(
+            index_depends_on_column(&expr, "email"),
+            "matches lower(email)"
+        );
+        assert!(
+            !index_depends_on_column(&expr, "mail"),
+            "must not match a substring inside the token"
+        );
+
+        let emailer = Index {
+            name: "u_emailer".to_owned(),
+            columns: vec![],
+            unique: false,
+            definition: Some("CREATE INDEX u_emailer ON users (emailer)".to_owned()),
+        };
+        assert!(
+            !index_depends_on_column(&emailer, "email"),
+            "`email` must not match the longer identifier `emailer`"
+        );
+
+        let plain = Index {
+            name: "u_email".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: None,
+        };
+        assert!(
+            index_depends_on_column(&plain, "email"),
+            "columns membership counts as a dependency"
+        );
+    }
+
+    #[test]
+    fn drop_column_up_drops_column_and_down_restores_retained_index() {
+        // Baseline `users(id, email)` with a RETAINED constraint-owned unique
+        // index on `email` (definition-carrying, no paired DropIndex). The model
+        // removes `email`, so the plan carries only a DropColumn.
+        let mut email_col = col("email", ColumnType::Text);
+        email_col.nullable = false;
+        let mut baseline = posts_ref_table("users", email_col);
+        baseline.indexes.push(Index {
+            name: "users_email_key".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: Some("CREATE UNIQUE INDEX users_email_key ON users (email)".to_owned()),
+        });
+        // Desired side: `email` removed. `diff_indexes` retains the definition
+        // index (no DropIndex), so the plan is a lone DropColumn.
+        let desired = posts_ref_table("users", col("keep", ColumnType::Text));
+        let plan = diff_schema(
+            std::slice::from_ref(&baseline),
+            &parsed(vec![desired.clone()], vec![]),
+            ALLOW,
+        );
+        assert!(
+            plan.changes.iter().any(
+                |c| matches!(c, SchemaChange::DropColumn { column, .. } if column.name == "email")
+            ),
+            "plan must drop `email`: {:?}",
+            plan.changes
+        );
+        assert!(
+            !plan
+                .changes
+                .iter()
+                .any(|c| matches!(c, SchemaChange::DropIndex { index, .. } if index.name == "users_email_key")),
+            "the retained definition index must NOT get a DropIndex: {:?}",
+            plan.changes
+        );
+
+        let ctx = SchemaContext::from_tables(
+            std::slice::from_ref(&desired),
+            std::slice::from_ref(&baseline),
+        );
+        let up = emit_up_sql_with_context(&plan, &ctx).expect("emit up");
+        let down = emit_down_sql_with_context(&plan, &ctx).expect("emit down");
+
+        // UP: a bare DROP COLUMN (Postgres cascade-drops the index), never a
+        // failing DROP INDEX on the constraint-backed index.
+        assert!(
+            up.contains("ALTER TABLE users DROP COLUMN email"),
+            "up must drop the column: {up}"
+        );
+        assert!(
+            !up.contains("DROP INDEX users_email_key"),
+            "up must NOT emit DROP INDEX for the cascade-dropped retained index: {up}"
+        );
+
+        // DOWN: re-add the column, THEN recreate the retained index verbatim.
+        assert!(
+            down.contains("ADD COLUMN email"),
+            "down must re-add the column: {down}"
+        );
+        assert!(
+            down.contains("CREATE UNIQUE INDEX users_email_key ON users (email)"),
+            "down must restore the cascade-dropped retained index: {down}"
+        );
+        let readd_at = down.find("ADD COLUMN email").expect("re-add present");
+        let index_at = down
+            .find("CREATE UNIQUE INDEX users_email_key")
+            .expect("index restore present");
+        assert!(
+            readd_at < index_at,
+            "column must be re-added before its dependent index is recreated: {down}"
         );
     }
 }

--- a/autumn-cli/src/schema/diff.rs
+++ b/autumn-cli/src/schema/diff.rs
@@ -1929,41 +1929,72 @@ fn emit_up_sql_pg(plan: &MigrationPlan) -> Result<String, EmitError> {
 /// verbatim `definition`, else rollback silently loses the uniqueness/index. This
 /// needs the baseline shapes carried in `ctx`; ordinary model-managed indexes are
 /// restored via their own `DropIndex → AddIndex` inversion and are skipped here.
+///
+/// Recreation is **delayed and deduped**: a retained index can depend on more than
+/// one dropped column (e.g. a partial index
+/// `... ON t (lower(email)) WHERE tenant_id IS NOT NULL` when the model drops BOTH
+/// `email` and `tenant_id`). Recreating it inline after re-adding only the *first*
+/// dependent column would (a) fail — the other dependent column is still absent, so
+/// Postgres rejects the `CREATE INDEX` — and (b) re-emit the same `CREATE INDEX`
+/// again for the second column. So the down path first emits ALL the column
+/// re-adds (and every other reversed change), then recreates each cascade-dropped
+/// retained index EXACTLY ONCE, keyed by `(table, index name)`, after all of its
+/// dropped columns have been restored.
 fn emit_down_sql_pg(plan: &MigrationPlan, ctx: &SchemaContext) -> Result<String, EmitError> {
     let mut ordered = up_ordered(&plan.changes)?;
     ordered.reverse();
     let mut groups = Vec::new();
+    // Per-table set of columns this migration drops (and the down path re-adds),
+    // gathered so a multi-column retained index is recreated only after ALL its
+    // dependent dropped columns are back.
+    let mut dropped_by_table: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
     for change in ordered {
         let sql = emit_change_down(change, plan.backend)?;
         let sql = sql.trim_end();
         if !sql.is_empty() {
             groups.push(sql.to_owned());
         }
-        // The column is re-added above; recreate its cascade-dropped retained
-        // indexes immediately after (column-before-index ordering).
         if let SchemaChange::DropColumn { table, column } = change {
-            for idx in retained_indexes_depending_on(ctx, table, &column.name) {
-                groups.push(index_sql(table, idx).trim_end().to_owned());
-            }
+            dropped_by_table
+                .entry(table.clone())
+                .or_default()
+                .insert(column.name.clone());
+        }
+    }
+    // Every column re-add is now emitted. Recreate each retained index whose
+    // dependent-column set intersects this table's dropped columns — once per
+    // (table, index name) — so a multi-column index is created exactly once, after
+    // all of its dropped columns are restored.
+    for (table, dropped) in &dropped_by_table {
+        for idx in retained_indexes_depending_on_any(ctx, table, dropped) {
+            groups.push(index_sql(table, idx).trim_end().to_owned());
         }
     }
     Ok(join_groups(&groups))
 }
 
-/// The RETAINED (`definition`-carrying) baseline indexes of `table` that depend on
-/// `column` — the expression/partial/constraint-owned indexes Postgres
-/// cascade-drops with the column and that carry no `DropIndex` in the plan, so the
-/// down migration must recreate them verbatim. Returns empty when the table is
-/// absent from `ctx.baseline` (e.g. context-free emit).
-fn retained_indexes_depending_on<'a>(
+/// The RETAINED (`definition`-carrying) baseline indexes of `table` whose
+/// dependent-column set intersects `dropped_columns` — the
+/// expression/partial/constraint-owned indexes Postgres cascade-drops when ANY of
+/// those columns is dropped and that carry no `DropIndex` in the plan, so the down
+/// migration must recreate them verbatim. Each qualifying index appears once (the
+/// baseline lists each index once), so a retained index depending on two dropped
+/// columns is returned — and thus recreated — exactly once. Returns empty when the
+/// table is absent from `ctx.baseline` (e.g. context-free emit).
+fn retained_indexes_depending_on_any<'a>(
     ctx: &'a SchemaContext,
     table: &str,
-    column: &str,
+    dropped_columns: &BTreeSet<String>,
 ) -> Vec<&'a Index> {
     ctx.baseline.get(table).map_or_else(Vec::new, |t| {
         t.indexes
             .iter()
-            .filter(|i| i.definition.is_some() && index_depends_on_column(i, column))
+            .filter(|i| {
+                i.definition.is_some()
+                    && dropped_columns
+                        .iter()
+                        .any(|c| index_depends_on_column(i, c))
+            })
             .collect()
     })
 }
@@ -6831,6 +6862,102 @@ PRAGMA foreign_keys=ON;
         assert!(
             readd_at < index_at,
             "column must be re-added before its dependent index is recreated: {down}"
+        );
+        // No regression: a single-column retained index is restored EXACTLY ONCE.
+        assert_eq!(
+            down.matches("CREATE UNIQUE INDEX users_email_key").count(),
+            1,
+            "the single-column retained index must be recreated exactly once: {down}"
+        );
+    }
+
+    /// A retained index depending on TWO columns, both dropped, must have its
+    /// recreation DELAYED until BOTH columns are restored and emitted EXACTLY ONCE
+    /// (never once per dependent dropped column). Recreating it inline after the
+    /// first re-add would fail (the second dependent column is still absent) and
+    /// duplicate the `CREATE INDEX`.
+    #[test]
+    fn drop_two_columns_down_restores_multicol_retained_index_once_after_both() {
+        // Baseline `users(id, keep, email, tenant_id)` with a RETAINED partial +
+        // expression index depending on BOTH `email` and `tenant_id`
+        // (definition-carrying, no paired DropIndex).
+        let mut baseline = Table::new("users", Backend::Postgres);
+        let mut id = col("id", ColumnType::Int64);
+        id.primary_key = true;
+        baseline.primary_key.push("id".to_owned());
+        baseline.columns.push(id);
+        baseline.columns.push(col("keep", ColumnType::Text));
+        let mut email = col("email", ColumnType::Text);
+        email.nullable = false;
+        baseline.columns.push(email);
+        baseline.columns.push(col("tenant_id", ColumnType::Int64));
+        baseline.indexes.push(Index {
+            name: "users_active".to_owned(),
+            // The exact `pg_depend` dependent set: expression column + predicate
+            // column (sorted by name, as introspection records it).
+            columns: vec!["email".to_owned(), "tenant_id".to_owned()],
+            unique: false,
+            definition: Some(
+                "CREATE INDEX users_active ON users (lower(email)) WHERE tenant_id IS NOT NULL"
+                    .to_owned(),
+            ),
+        });
+
+        // Desired side: BOTH `email` and `tenant_id` removed. The model diff
+        // retains the definition index (no DropIndex), so the plan is two
+        // DropColumns.
+        let mut desired = Table::new("users", Backend::Postgres);
+        let mut did = col("id", ColumnType::Int64);
+        did.primary_key = true;
+        desired.primary_key.push("id".to_owned());
+        desired.columns.push(did);
+        desired.columns.push(col("keep", ColumnType::Text));
+
+        let plan = diff_schema(
+            std::slice::from_ref(&baseline),
+            &parsed(vec![desired.clone()], vec![]),
+            ALLOW,
+        );
+        assert_eq!(
+            plan.changes
+                .iter()
+                .filter(|c| matches!(c, SchemaChange::DropColumn { .. }))
+                .count(),
+            2,
+            "plan must drop both columns: {:?}",
+            plan.changes
+        );
+        assert!(
+            !plan
+                .changes
+                .iter()
+                .any(|c| matches!(c, SchemaChange::DropIndex { index, .. } if index.name == "users_active")),
+            "the retained definition index must NOT get a DropIndex: {:?}",
+            plan.changes
+        );
+
+        let ctx = SchemaContext::from_tables(
+            std::slice::from_ref(&desired),
+            std::slice::from_ref(&baseline),
+        );
+        let down = emit_down_sql_with_context(&plan, &ctx).expect("emit down");
+
+        // DOWN re-adds BOTH columns and recreates the index EXACTLY ONCE.
+        let email_at = down.find("ADD COLUMN email").expect("email re-add present");
+        let tenant_at = down
+            .find("ADD COLUMN tenant_id")
+            .expect("tenant_id re-add present");
+        assert_eq!(
+            down.matches("CREATE INDEX users_active").count(),
+            1,
+            "the multi-column retained index must be recreated exactly once (deduped): {down}"
+        );
+        let index_at = down
+            .find("CREATE INDEX users_active")
+            .expect("index restore present");
+        assert!(
+            email_at < index_at && tenant_at < index_at,
+            "both dependent columns must be re-added BEFORE the index is recreated: {down}"
         );
     }
 }

--- a/autumn-cli/src/schema/diff.rs
+++ b/autumn-cli/src/schema/diff.rs
@@ -3137,9 +3137,9 @@ fn single_pk_column(table: &Table) -> Option<(&Column, IdKind)> {
 }
 
 /// Derive the id-generation strategy for a single-column PK:
-///   `Int64` PK, no default            → `BigSerial`
-///   `Int32` PK, `nextval(...)` default → `Serial` (a brownfield `SERIAL` id)
-///   `Uuid`  PK                        → `Uuid`
+///   `Int64` PK, no default                      → `BigSerial`
+///   `Int32` PK, `nextval(...)` default           → `Serial` (a brownfield `SERIAL` id)
+///   `Uuid`  PK, `gen_random_uuid()` default      → `Uuid`
 /// Any other PK column → `None` (rendered normally with a table-level clause).
 ///
 /// The `Int32`/`Serial` case only ever arises for a **brownfield-introspected**
@@ -3149,13 +3149,39 @@ fn single_pk_column(table: &Table) -> Option<(&Column, IdKind)> {
 /// recognized here and recreated as `SERIAL PRIMARY KEY` (auto-increment) rather
 /// than a plain `INTEGER PRIMARY KEY`. An int4 PK with NO default falls through to
 /// `None` → a plain integer PK (no auto-increment), which is correct.
+///
+/// The `Uuid` convention is likewise **default-gated**: the `IdKind::Uuid` shape
+/// renders `UUID PRIMARY KEY DEFAULT gen_random_uuid()`, so it is only applied when
+/// the pulled column's stored default is *exactly* that convention (the value the
+/// model parser records — see `parse::convention_default` — so the round-trip stays
+/// clean). A brownfield UUID PK whose default is a different expression (e.g.
+/// `uuid_generate_v4()`) or is absent entirely falls through to `None`: it renders
+/// as an ordinary `UUID` column preserving its real default (or lack of one), with
+/// its primary key expressed via the trailing table-level `PRIMARY KEY (col)` clause
+/// — so recreation (e.g. the down migration for a dropped table) never silently
+/// swaps its UUID-generation behavior for `gen_random_uuid()` or adds a default
+/// where none existed.
 fn pk_kind_for(column: &Column) -> Option<IdKind> {
     match &column.ty {
         ColumnType::Int64 if column.default.is_none() => Some(IdKind::BigSerial),
         ColumnType::Int32 if is_nextval_default(column) => Some(IdKind::Serial),
-        ColumnType::Uuid => Some(IdKind::Uuid),
+        ColumnType::Uuid if is_convention_uuid_default(column) => Some(IdKind::Uuid),
         _ => None,
     }
+}
+
+/// Whether a UUID primary-key column's stored default is *exactly* the Autumn model
+/// convention `gen_random_uuid()` — the value `parse::convention_default` records for
+/// a Postgres UUID `#[id]` and the string introspection preserves verbatim
+/// (`normalize_default` keeps it as-is). Only then may the DDL emitter collapse the
+/// column into the `IdKind::Uuid` shape (`UUID PRIMARY KEY DEFAULT
+/// gen_random_uuid()`); a UUID PK with any other default — or none — is rendered as an
+/// ordinary column so its true generation behavior is never silently rewritten.
+fn is_convention_uuid_default(column: &Column) -> bool {
+    matches!(
+        &column.default,
+        Some(ColumnDefault::Sql(sql)) if sql.trim() == "gen_random_uuid()"
+    )
 }
 
 /// Whether a column's default is a `nextval(...)` sequence default (a `SERIAL`
@@ -4978,6 +5004,10 @@ mod tests {
         let mut t = Table::new("posts", Backend::Postgres);
         let mut id = col("id", ColumnType::Uuid);
         id.primary_key = true;
+        // The model convention default — the exact string `parse::convention_default`
+        // records and introspection preserves — is required for the `IdKind::Uuid`
+        // shape to render.
+        id.default = Some(ColumnDefault::Sql("gen_random_uuid()".to_owned()));
         t.primary_key.push("id".to_owned());
         t.columns.push(id);
         let plan = MigrationPlan {
@@ -4988,6 +5018,108 @@ mod tests {
         assert!(
             up.contains("id UUID PRIMARY KEY DEFAULT gen_random_uuid()"),
             "uuid PK: {up}"
+        );
+    }
+
+    #[test]
+    fn pk_kind_for_uuid_is_gated_on_the_convention_default() {
+        // Convention `gen_random_uuid()` default → the `IdKind::Uuid` shape.
+        let mut conv = col("id", ColumnType::Uuid);
+        conv.primary_key = true;
+        conv.default = Some(ColumnDefault::Sql("gen_random_uuid()".to_owned()));
+        assert_eq!(pk_kind_for(&conv), Some(IdKind::Uuid));
+        // A leading/trailing whitespace variant still resolves (trim-tolerant).
+        let mut conv_ws = col("id", ColumnType::Uuid);
+        conv_ws.primary_key = true;
+        conv_ws.default = Some(ColumnDefault::Sql("  gen_random_uuid()  ".to_owned()));
+        assert_eq!(pk_kind_for(&conv_ws), Some(IdKind::Uuid));
+
+        // A non-convention default (`uuid_generate_v4()`) → None (ordinary column).
+        let mut v4 = col("id", ColumnType::Uuid);
+        v4.primary_key = true;
+        v4.default = Some(ColumnDefault::Sql("uuid_generate_v4()".to_owned()));
+        assert_eq!(pk_kind_for(&v4), None);
+
+        // No default → None (ordinary column; the PK is expressed table-level).
+        let mut none = col("id", ColumnType::Uuid);
+        none.primary_key = true;
+        assert_eq!(pk_kind_for(&none), None);
+    }
+
+    /// A convention UUID PK (`DEFAULT gen_random_uuid()`) renders the `IdKind::Uuid`
+    /// shape verbatim — the `gen_random_uuid()` default is not double-emitted.
+    #[test]
+    fn create_table_convention_uuid_pk_renders_id_kind_shape() {
+        let mut t = Table::new("sessions", Backend::Postgres);
+        let mut id = col("id", ColumnType::Uuid);
+        id.primary_key = true;
+        id.default = Some(ColumnDefault::Sql("gen_random_uuid()".to_owned()));
+        t.primary_key.push("id".to_owned());
+        t.columns.push(id);
+        let body = render_create_table_body("sessions", &t, Backend::Postgres);
+        assert!(
+            body.contains("id UUID PRIMARY KEY DEFAULT gen_random_uuid()"),
+            "convention UUID PK renders the IdKind::Uuid shape: {body}"
+        );
+        // Exactly one `gen_random_uuid()` — the explicit column default is not also
+        // appended alongside the `IdKind::Uuid` shape's own default.
+        assert_eq!(
+            body.matches("gen_random_uuid()").count(),
+            1,
+            "the convention default is emitted exactly once: {body}"
+        );
+    }
+
+    /// A UUID PK with NO default must NOT gain a `gen_random_uuid()` default on
+    /// recreation: it renders as an ordinary `UUID` column plus a table-level
+    /// `PRIMARY KEY (id)` clause, preserving "no default".
+    #[test]
+    fn create_table_uuid_pk_without_default_renders_ordinary_column_with_pk() {
+        let mut t = Table::new("tokens", Backend::Postgres);
+        let mut id = col("id", ColumnType::Uuid);
+        id.primary_key = true;
+        t.primary_key.push("id".to_owned());
+        t.columns.push(id);
+        t.columns.push(col("label", ColumnType::Text));
+        let body = render_create_table_body("tokens", &t, Backend::Postgres);
+        assert!(
+            body.contains("id UUID NOT NULL"),
+            "no-default UUID PK renders as an ordinary UUID column: {body}"
+        );
+        assert!(
+            !body.contains("gen_random_uuid()"),
+            "no default must be invented on recreation: {body}"
+        );
+        assert!(
+            body.contains("PRIMARY KEY (id)"),
+            "the PK is still expressed via the table-level clause: {body}"
+        );
+    }
+
+    /// A brownfield UUID PK whose default is a NON-convention expression
+    /// (`uuid_generate_v4()`) renders that default verbatim — recreation preserves the
+    /// real UUID-generation behavior rather than silently swapping it for
+    /// `gen_random_uuid()`.
+    #[test]
+    fn create_table_uuid_pk_with_non_convention_default_renders_it_verbatim() {
+        let mut t = Table::new("tokens", Backend::Postgres);
+        let mut id = col("id", ColumnType::Uuid);
+        id.primary_key = true;
+        id.default = Some(ColumnDefault::Sql("uuid_generate_v4()".to_owned()));
+        t.primary_key.push("id".to_owned());
+        t.columns.push(id);
+        let body = render_create_table_body("tokens", &t, Backend::Postgres);
+        assert!(
+            body.contains("id UUID NOT NULL DEFAULT uuid_generate_v4()"),
+            "the real non-convention default renders verbatim: {body}"
+        );
+        assert!(
+            !body.contains("gen_random_uuid()"),
+            "the convention default is never substituted: {body}"
+        );
+        assert!(
+            body.contains("PRIMARY KEY (id)"),
+            "the PK is still expressed via the table-level clause: {body}"
         );
     }
 
@@ -6344,9 +6476,13 @@ PRAGMA foreign_keys=ON;
         };
         let baseline = uuid_table("posts");
         let desired = uuid_table("posts");
+        // A default-less UUID PK is no longer the `IdKind::Uuid` convention shape
+        // (that is gated on the `gen_random_uuid()` default): it resolves to `None`
+        // and is rendered as an ordinary column with a table-level PK. Either way it
+        // is not an autoincrement PK, so no sequence preservation is emitted.
         assert!(
-            matches!(single_pk_column(&desired), Some((_, IdKind::Uuid))),
-            "the fixture PK resolves to Uuid"
+            single_pk_column(&desired).is_none(),
+            "a default-less UUID PK is not the IdKind::Uuid convention shape"
         );
         for leg in [RebuildLeg::Up, RebuildLeg::Down] {
             let sql = render_sqlite_rebuild("posts", &desired, &baseline, leg, &[]);

--- a/autumn-cli/src/schema/diff.rs
+++ b/autumn-cli/src/schema/diff.rs
@@ -415,6 +415,26 @@ pub struct DiffOptions {
     /// by [`guard_plan`]. When `true`, both are permitted (the rename is treated
     /// as an independent drop+add).
     pub allow_destructive: bool,
+
+    /// Whether the DESIRED side can authoritatively express expression/partial
+    /// indexes (an [`Index`] carrying a raw `definition`).
+    ///
+    /// `false` (the **default**) is the *model diff* case (`schema diff` /
+    /// `--write-migration`, and doctor's model-vs-snapshot `compute_drift`): the
+    /// desired side is parsed from the model DSL, which can only ever produce a
+    /// plain `Index { definition: None, .. }` — it *cannot* express an
+    /// expression/partial index. A baseline index carrying a `definition` is
+    /// therefore an unmodellable/adopted construct, and [`diff_indexes`] **retains**
+    /// it (never `DropIndex`/replace) — exactly like an unmanaged/adopted table.
+    /// This retention is independent of `allow_destructive`: the declarative tool
+    /// never drops what it cannot express.
+    ///
+    /// `true` is the *introspection diff* case (doctor's
+    /// `database-schema-drift` `compute_db_schema_drift`, and `pull --dry-run`),
+    /// where BOTH sides are complete introspections, so a `definition` index IS
+    /// authoritative — a dropped/changed expression index is real drift and is
+    /// still reported (via [`indexes_equivalent`]).
+    pub definitions_authoritative: bool,
 }
 
 /// Why a computed plan is refused for emission (policy, not structure).
@@ -742,7 +762,6 @@ pub enum EmitError {
 /// pure diff does not consult it.
 #[must_use]
 pub fn diff_schema(baseline: &[Table], desired: &ParsedSchema, opts: DiffOptions) -> MigrationPlan {
-    let _ = opts;
     let backend = plan_backend(baseline, desired);
     let mut changes = Vec::new();
 
@@ -768,7 +787,7 @@ pub fn diff_schema(baseline: &[Table], desired: &ParsedSchema, opts: DiffOptions
             // Present on both sides — diff only Autumn-managed tables.
             (Some(base), Some(want)) => {
                 if want.managed {
-                    diff_table(base, want, desired, &mut changes);
+                    diff_table(base, want, desired, opts, &mut changes);
                 }
             }
             // Desired only — create it if Autumn owns it. But if the parser
@@ -1014,7 +1033,13 @@ fn column_participates_in_fk(
 
 /// Diff a table present on both sides (already known Autumn-managed on the
 /// desired side), pushing column / index / check changes.
-fn diff_table(base: &Table, want: &Table, desired: &ParsedSchema, changes: &mut Vec<SchemaChange>) {
+fn diff_table(
+    base: &Table,
+    want: &Table,
+    desired: &ParsedSchema,
+    opts: DiffOptions,
+    changes: &mut Vec<SchemaChange>,
+) {
     // A primary-key change is refused wholesale (guarded); emit only the marker
     // and skip the rest of this table's diff.
     if base.primary_key != want.primary_key {
@@ -1056,7 +1081,7 @@ fn diff_table(base: &Table, want: &Table, desired: &ParsedSchema, changes: &mut 
         }
     }
 
-    diff_indexes(&want.name, base, want, &skipped, changes);
+    diff_indexes(&want.name, base, want, &skipped, opts, changes);
     diff_checks(&want.name, base, want, changes);
 }
 
@@ -1158,11 +1183,30 @@ fn indexes_equivalent(a: &Index, b: &Index) -> bool {
     }
 }
 
+///
+/// ## Unmodellable (expression/partial) indexes
+///
+/// An [`Index`] carrying a raw `definition` (an expression or partial index,
+/// preserved verbatim by `schema pull` introspection) **cannot be produced by the
+/// model parser** — `#[indexed]`/`#[unique]` only ever yield
+/// `Index { definition: None, .. }`. So in a *model diff*
+/// (`opts.definitions_authoritative == false`) a baseline `definition` index is an
+/// adopted construct the desired side is simply unable to describe, and it is
+/// **retained** — never `DropIndex`'d or replaced — exactly like an
+/// unmanaged/adopted table. This retention is independent of `allow_destructive`:
+/// the declarative tool never drops what it cannot express. In an *introspection
+/// diff* (`opts.definitions_authoritative == true`, from
+/// [`compute_db_schema_drift`](super::doctor::compute_db_schema_drift) and
+/// `pull --dry-run`) BOTH sides are complete introspections, so a `definition`
+/// index IS authoritative and a dropped/changed one is reported as real drift via
+/// [`indexes_equivalent`]. Plain (`definition: None`) indexes are diffed
+/// identically in both modes — a model may always ADD a brand-new plain index.
 fn diff_indexes(
     table: &str,
     base: &Table,
     want: &Table,
     skipped: &BTreeSet<String>,
+    opts: DiffOptions,
     changes: &mut Vec<SchemaChange>,
 ) {
     let base_by_name: BTreeMap<&str, &Index> =
@@ -1176,29 +1220,49 @@ fn diff_indexes(
                 table: table.to_owned(),
                 index: want_idx.clone(),
             }),
-            Some(base_idx) if !indexes_equivalent(base_idx, want_idx) => {
-                changes.push(SchemaChange::DropIndex {
-                    table: table.to_owned(),
-                    index: (*base_idx).clone(),
-                });
-                changes.push(SchemaChange::AddIndex {
-                    table: table.to_owned(),
-                    index: want_idx.clone(),
-                });
+            Some(base_idx) => {
+                // A same-named pair where EITHER carries a `definition`: in a model
+                // diff the desired side cannot express the definition, so retain
+                // the baseline index (emit nothing) rather than emit a destructive
+                // DropIndex + plain replacement. In an introspection diff both
+                // sides are authoritative, so fall through to the equivalence check.
+                let involves_definition =
+                    base_idx.definition.is_some() || want_idx.definition.is_some();
+                if involves_definition && !opts.definitions_authoritative {
+                    continue;
+                }
+                if !indexes_equivalent(base_idx, want_idx) {
+                    changes.push(SchemaChange::DropIndex {
+                        table: table.to_owned(),
+                        index: (*base_idx).clone(),
+                    });
+                    changes.push(SchemaChange::AddIndex {
+                        table: table.to_owned(),
+                        index: want_idx.clone(),
+                    });
+                }
             }
-            Some(_) => {}
         }
     }
 
     for base_idx in &base.indexes {
-        if !want_by_name.contains_key(base_idx.name.as_str())
-            && !base_idx.columns.iter().any(|c| skipped.contains(c))
+        if want_by_name.contains_key(base_idx.name.as_str())
+            || base_idx.columns.iter().any(|c| skipped.contains(c))
         {
-            changes.push(SchemaChange::DropIndex {
-                table: table.to_owned(),
-                index: base_idx.clone(),
-            });
+            continue;
         }
+        // A baseline-only `definition` index has no same-named desired index, and
+        // in a model diff the desired side could not have expressed it anyway —
+        // retain it (never DropIndex), independent of `allow_destructive`. In an
+        // introspection diff it is authoritative, so a genuinely-dropped
+        // expression/partial index still drops.
+        if base_idx.definition.is_some() && !opts.definitions_authoritative {
+            continue;
+        }
+        changes.push(SchemaChange::DropIndex {
+            table: table.to_owned(),
+            index: base_idx.clone(),
+        });
     }
 }
 
@@ -3059,9 +3123,15 @@ mod tests {
 
     const DEFAULT_OPTS: DiffOptions = DiffOptions {
         allow_destructive: false,
+        definitions_authoritative: false,
     };
     const ALLOW: DiffOptions = DiffOptions {
         allow_destructive: true,
+        definitions_authoritative: false,
+    };
+    const AUTHORITATIVE: DiffOptions = DiffOptions {
+        allow_destructive: false,
+        definitions_authoritative: true,
     };
 
     // -- 13.1 structural diff ------------------------------------------------
@@ -3214,6 +3284,120 @@ mod tests {
                 table: "posts".to_owned(),
                 index: idx,
             }]
+        );
+    }
+
+    /// A `definition`-carrying (expression/partial) index that the model DSL can
+    /// never express: an expression index on `lower(email)`.
+    fn expr_index() -> Index {
+        Index {
+            name: "idx_posts_lower_body".to_owned(),
+            columns: vec!["body".to_owned()],
+            unique: false,
+            definition: Some("CREATE INDEX idx_posts_lower_body ON posts (lower(body))".to_owned()),
+        }
+    }
+
+    /// Model diff (`DEFAULT_OPTS`, `definitions_authoritative: false`): a
+    /// baseline-only `definition` index absent from the desired (model) side is
+    /// **retained** — the model DSL cannot express it, so its absence is a parser
+    /// gap, not a removal. NO `DropIndex` is emitted.
+    #[test]
+    fn model_diff_retains_baseline_only_definition_index() {
+        let mut base_table = posts_with(vec![col("body", ColumnType::Text)]);
+        base_table.indexes.push(expr_index());
+        let want = parsed(
+            vec![posts_with(vec![col("body", ColumnType::Text)])],
+            vec![],
+        );
+        let plan = diff_schema(&[base_table], &want, DEFAULT_OPTS);
+        assert!(
+            !plan
+                .changes
+                .iter()
+                .any(|c| matches!(c, SchemaChange::DropIndex { .. })),
+            "model diff must retain (not drop) an unmodellable definition index; got {:?}",
+            plan.changes
+        );
+    }
+
+    /// Retention holds even under `--allow-destructive`: the declarative tool
+    /// never drops a construct it cannot express.
+    #[test]
+    fn model_diff_retains_definition_index_even_with_allow_destructive() {
+        let mut base_table = posts_with(vec![col("body", ColumnType::Text)]);
+        base_table.indexes.push(expr_index());
+        let want = parsed(
+            vec![posts_with(vec![col("body", ColumnType::Text)])],
+            vec![],
+        );
+        let plan = diff_schema(&[base_table], &want, ALLOW);
+        assert!(
+            !plan
+                .changes
+                .iter()
+                .any(|c| matches!(c, SchemaChange::DropIndex { .. })),
+            "--allow-destructive must still retain an unmodellable definition index; got {:?}",
+            plan.changes
+        );
+    }
+
+    /// Model diff: a baseline `definition` index sharing a NAME with a desired
+    /// (model-parsed, `definition: None`) index is **retained** — no
+    /// `DropIndex`/replacement that would clobber the expression/partial index with
+    /// a plain column index.
+    #[test]
+    fn model_diff_retains_definition_index_sharing_name_with_plain_desired() {
+        // Baseline: an expression index named `idx_posts_body`.
+        let base_expr = Index {
+            name: "idx_posts_body".to_owned(),
+            columns: vec!["body".to_owned()],
+            unique: false,
+            definition: Some("CREATE INDEX idx_posts_body ON posts (lower(body))".to_owned()),
+        };
+        let mut base_table = posts_with(vec![col("body", ColumnType::Text)]);
+        base_table.indexes.push(base_expr);
+
+        // Desired (model): a plain column index of the SAME name (definition: None).
+        let mut want_table = posts_with(vec![col("body", ColumnType::Text)]);
+        want_table.indexes.push(Index {
+            name: "idx_posts_body".to_owned(),
+            columns: vec!["body".to_owned()],
+            unique: false,
+            definition: None,
+        });
+        let plan = diff_schema(
+            &[base_table],
+            &parsed(vec![want_table], vec![]),
+            DEFAULT_OPTS,
+        );
+        assert!(
+            plan.changes.is_empty(),
+            "model diff must retain the definition index and emit no drop/replace; got {:?}",
+            plan.changes
+        );
+    }
+
+    /// Introspection diff (`AUTHORITATIVE`, `definitions_authoritative: true`): a
+    /// baseline-only `definition` index absent from the desired side IS a genuine
+    /// drop and MUST emit `DropIndex` — this proves doctor's `database-schema-drift`
+    /// / `pull --dry-run` still catches a dropped expression/partial index.
+    #[test]
+    fn authoritative_diff_drops_baseline_only_definition_index() {
+        let mut base_table = posts_with(vec![col("body", ColumnType::Text)]);
+        base_table.indexes.push(expr_index());
+        let want = parsed(
+            vec![posts_with(vec![col("body", ColumnType::Text)])],
+            vec![],
+        );
+        let plan = diff_schema(&[base_table], &want, AUTHORITATIVE);
+        assert_eq!(
+            plan.changes,
+            vec![SchemaChange::DropIndex {
+                table: "posts".to_owned(),
+                index: expr_index(),
+            }],
+            "authoritative introspection diff must report a dropped definition index as drift"
         );
     }
 

--- a/autumn-cli/src/schema/diff.rs
+++ b/autumn-cli/src/schema/diff.rs
@@ -1289,6 +1289,19 @@ fn baseline_unique_index_covers(base: &Table, want_columns: &[String]) -> bool {
     })
 }
 
+/// The single suppression predicate shared by **both** [`diff_indexes`] branches
+/// (the same-name match and the desired-only `AddIndex`), so they can never
+/// drift: a desired UNIQUE index is already satisfied — and may be suppressed —
+/// only when SOME baseline index provides **full** coverage, i.e. a non-partial,
+/// non-expression unique index over exactly its key columns (see
+/// [`baseline_unique_index_covers`]). A non-unique desired index is never
+/// suppressed by this rule, and a merely same-named baseline index that is
+/// partial, an expression index (empty key columns), or keyed on a different
+/// column set does **not** count as coverage.
+fn baseline_satisfies_desired_unique(base: &Table, want_idx: &Index) -> bool {
+    want_idx.unique && baseline_unique_index_covers(base, &want_idx.columns)
+}
+
 fn diff_indexes(
     table: &str,
     base: &Table,
@@ -1319,8 +1332,7 @@ fn diff_indexes(
                 // untouched: a brownfield constraint index has the same name on both
                 // sides there and already matches by name, so real drift stays detected.
                 if !opts.definitions_authoritative
-                    && want_idx.unique
-                    && baseline_unique_index_covers(base, &want_idx.columns)
+                    && baseline_satisfies_desired_unique(base, want_idx)
                 {
                     continue;
                 }
@@ -1338,6 +1350,23 @@ fn diff_indexes(
                 let involves_definition =
                     base_idx.definition.is_some() || want_idx.definition.is_some();
                 if involves_definition && !opts.definitions_authoritative {
+                    // Model diff: the desired side cannot express B's
+                    // definition, so the same-named definition-carrying baseline
+                    // index B is retained (the drop loop below skips a name still
+                    // present in `want`). But a unique D whose uniqueness B does
+                    // NOT fully cover — B is partial, an expression index (empty
+                    // key columns), or keyed on a different column set — leaves
+                    // the model's table-wide `#[unique]` UNENFORCED even though a
+                    // conventionally-named index exists. Emit `AddIndex(D)` so the
+                    // full unique index is created ALONGSIDE the retained B;
+                    // suppress D only when SOME baseline index fully covers it
+                    // (or D is non-unique).
+                    if want_idx.unique && !baseline_satisfies_desired_unique(base, want_idx) {
+                        changes.push(SchemaChange::AddIndex {
+                            table: table.to_owned(),
+                            index: want_idx.clone(),
+                        });
+                    }
                     continue;
                 }
                 if !indexes_equivalent(base_idx, want_idx) {
@@ -3913,6 +3942,166 @@ mod tests {
         assert!(
             plan.changes.is_empty(),
             "model diff must retain the definition index and emit no drop/replace; got {:?}",
+            plan.changes
+        );
+    }
+
+    /// A model-parsed unique index over `[email]` on the `posts` table, carrying
+    /// the parser's conventional name `idx_posts_email_unique` (`definition: None`).
+    fn desired_posts_email_unique() -> Index {
+        Index {
+            name: "idx_posts_email_unique".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
+        }
+    }
+
+    /// Fix 1 (a): a baseline **partial** unique index that happens to carry the
+    /// model's conventional name (`idx_posts_email_unique`) hits the same-NAME
+    /// match branch but does NOT provide table-wide coverage. It must NOT suppress
+    /// the model's `#[unique]` — the full unique `AddIndex` is emitted — while the
+    /// partial index (definition-carrying) is itself RETAINED (no `DropIndex`).
+    #[test]
+    fn model_diff_same_named_partial_unique_does_not_suppress_and_retains_partial() {
+        let partial = Index {
+            name: "idx_posts_email_unique".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: Some(
+                "CREATE UNIQUE INDEX idx_posts_email_unique ON posts (email) \
+                 WHERE email IS NOT NULL"
+                    .to_owned(),
+            ),
+            is_partial: true,
+            key_columns: vec!["email".to_owned()],
+        };
+        let mut base = posts_with(vec![col("email", ColumnType::Text)]);
+        base.indexes.push(partial);
+
+        let mut want_table = posts_with(vec![col("email", ColumnType::Text)]);
+        want_table.indexes.push(desired_posts_email_unique());
+        let plan = diff_schema(&[base], &parsed(vec![want_table], vec![]), DEFAULT_OPTS);
+        assert!(
+            plan.changes.iter().any(|c| matches!(
+                c,
+                SchemaChange::AddIndex { index, .. }
+                    if index.name == "idx_posts_email_unique" && index.definition.is_none()
+            )),
+            "a same-named PARTIAL unique index must not suppress the model's full \
+             #[unique]; got {:?}",
+            plan.changes
+        );
+        assert!(
+            !plan
+                .changes
+                .iter()
+                .any(|c| matches!(c, SchemaChange::DropIndex { .. })),
+            "the retained partial index must not be dropped; got {:?}",
+            plan.changes
+        );
+    }
+
+    /// Fix 1 (b): a baseline **expression** unique index (empty `key_columns`)
+    /// carrying the model's conventional name must NOT suppress the model's
+    /// `#[unique]` — the full unique `AddIndex` is emitted, and the expression
+    /// index is retained (no `DropIndex`).
+    #[test]
+    fn model_diff_same_named_expression_unique_does_not_suppress() {
+        let expr = Index {
+            name: "idx_posts_email_unique".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: Some(
+                "CREATE UNIQUE INDEX idx_posts_email_unique ON posts (lower(email))".to_owned(),
+            ),
+            is_partial: false,
+            key_columns: Vec::new(),
+        };
+        let mut base = posts_with(vec![col("email", ColumnType::Text)]);
+        base.indexes.push(expr);
+
+        let mut want_table = posts_with(vec![col("email", ColumnType::Text)]);
+        want_table.indexes.push(desired_posts_email_unique());
+        let plan = diff_schema(&[base], &parsed(vec![want_table], vec![]), DEFAULT_OPTS);
+        assert!(
+            plan.changes.iter().any(|c| matches!(
+                c,
+                SchemaChange::AddIndex { index, .. }
+                    if index.name == "idx_posts_email_unique" && index.definition.is_none()
+            )),
+            "a same-named EXPRESSION unique index must not suppress the model's \
+             #[unique]; got {:?}",
+            plan.changes
+        );
+        assert!(
+            !plan
+                .changes
+                .iter()
+                .any(|c| matches!(c, SchemaChange::DropIndex { .. })),
+            "the retained expression index must not be dropped; got {:?}",
+            plan.changes
+        );
+    }
+
+    /// Fix 1 (c) regression guard: a baseline **full plain** unique index
+    /// (`definition: None`) over exactly the model's key, sharing its name, STILL
+    /// suppresses the model `#[unique]` — a clean, empty plan (no `AddIndex`, no
+    /// `DropIndex`).
+    #[test]
+    fn model_diff_same_named_full_plain_unique_still_suppresses() {
+        let plain_index = Index {
+            name: "idx_posts_email_unique".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
+        };
+        let mut base = posts_with(vec![col("email", ColumnType::Text)]);
+        base.indexes.push(plain_index);
+
+        let mut want_table = posts_with(vec![col("email", ColumnType::Text)]);
+        want_table.indexes.push(desired_posts_email_unique());
+        let plan = diff_schema(&[base], &parsed(vec![want_table], vec![]), DEFAULT_OPTS);
+        assert!(
+            plan.changes.is_empty(),
+            "a same-named FULL plain unique index over the same key must still \
+             suppress the model #[unique]; got {:?}",
+            plan.changes
+        );
+    }
+
+    /// Fix 1 (d): a baseline **full constraint** (definition-carrying) unique index
+    /// over exactly the model's key, sharing its name, fully covers the model
+    /// `#[unique]` — so it is retained and the model index is suppressed (empty
+    /// plan). This exercises the same-NAME branch's "B fully covers → suppress D"
+    /// path.
+    #[test]
+    fn model_diff_same_named_full_constraint_unique_suppresses() {
+        let constraint = Index {
+            name: "idx_posts_email_unique".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: Some(
+                "CREATE UNIQUE INDEX idx_posts_email_unique ON posts USING btree (email)"
+                    .to_owned(),
+            ),
+            is_partial: false,
+            key_columns: vec!["email".to_owned()],
+        };
+        let mut base = posts_with(vec![col("email", ColumnType::Text)]);
+        base.indexes.push(constraint);
+
+        let mut want_table = posts_with(vec![col("email", ColumnType::Text)]);
+        want_table.indexes.push(desired_posts_email_unique());
+        let plan = diff_schema(&[base], &parsed(vec![want_table], vec![]), DEFAULT_OPTS);
+        assert!(
+            plan.changes.is_empty(),
+            "a same-named FULL constraint unique index that fully covers the key \
+             must suppress the model #[unique] (retained, no add); got {:?}",
             plan.changes
         );
     }

--- a/autumn-cli/src/schema/diff.rs
+++ b/autumn-cli/src/schema/diff.rs
@@ -1185,45 +1185,19 @@ fn indexes_equivalent(a: &Index, b: &Index) -> bool {
 
 /// Whether `index` depends on column `col` — i.e. Postgres would automatically
 /// drop the index (and any constraint it backs) when `col` is dropped via
-/// `ALTER TABLE … DROP COLUMN`. True when the index lists `col` among its indexed
-/// `columns`, or when its raw `definition` references `col` as a word-bounded SQL
-/// identifier (so `email` matches `lower(email)` / `(email)` but not `emailer`).
+/// `ALTER TABLE … DROP COLUMN`. True iff `col` is in the index's `columns`.
 ///
-/// The token match on the `definition` text is a best-effort mirror of Postgres's
-/// cascade (see the introspect.rs "Deferred blind spots"): it detects the common
-/// expression/partial-index shapes without fully parsing the index expression.
-/// Both `project_plan_target` (snapshot projection) and [`emit_down_sql_pg`]
-/// (rollback restore) use this single test so they cannot drift.
+/// For a retained (`definition`-carrying) expression/partial/constraint-owned index
+/// `columns` is the **exact `pg_depend` dependent-column set** captured by
+/// introspection (key, expression-referenced, AND predicate columns — the same set
+/// Postgres cascades on a `DROP COLUMN`), so membership is an exact match rather
+/// than a `definition`-text scan (which could false-positive on a column name that
+/// merely appears in a string literal, e.g. a partial index `WHERE kind = 'email'`
+/// while dropping an unrelated `email` column). Both `project_plan_target` (snapshot
+/// projection) and [`emit_down_sql_pg`] (rollback restore) use this single test so
+/// they cannot drift.
 pub fn index_depends_on_column(index: &Index, col: &str) -> bool {
     index.columns.iter().any(|c| c == col)
-        || index
-            .definition
-            .as_deref()
-            .is_some_and(|def| sql_token_references(def, col))
-}
-
-/// Whether `haystack` contains `needle` as a word-bounded token, where a "word"
-/// character is `[A-Za-z0-9_]`. Hand-rolled (no `regex` dependency) so a column
-/// name matches `lower(email)` / `(email)` / `email DESC` but never a longer
-/// identifier such as `emailer` or `user_email`.
-fn sql_token_references(haystack: &str, needle: &str) -> bool {
-    if needle.is_empty() {
-        return false;
-    }
-    let bytes = haystack.as_bytes();
-    let is_word = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
-    let mut from = 0;
-    while let Some(rel) = haystack[from..].find(needle) {
-        let start = from + rel;
-        let end = start + needle.len();
-        let before_ok = start == 0 || !is_word(bytes[start - 1]);
-        let after_ok = end >= bytes.len() || !is_word(bytes[end]);
-        if before_ok && after_ok {
-            return true;
-        }
-        from = start + 1;
-    }
-    false
 }
 
 ///
@@ -6730,35 +6704,47 @@ PRAGMA foreign_keys=ON;
 
     // -- Part B: rollback restores a cascade-dropped retained index ----------
 
-    /// The `index_depends_on_column` word-boundary contract: a column name matches
-    /// `columns` membership and its word-bounded appearance in an expression
-    /// `definition`, but never a longer identifier that merely contains it.
+    /// The `index_depends_on_column` contract: dependency is EXACT `columns`
+    /// membership (the introspected `pg_depend` set), never a `definition`-text
+    /// scan. A column name that merely appears in the `definition` string — e.g.
+    /// as a string literal in a partial-index predicate — is NOT a dependency, so
+    /// the projection can't wrongly prune an index Postgres actually keeps.
     #[test]
-    fn index_dependency_detection_is_word_bounded() {
+    fn index_dependency_detection_is_exact_column_membership() {
+        // A partial index on `id` whose predicate string literal mentions `email`,
+        // but which does NOT depend on the `email` column (its `pg_depend` set is
+        // just `id`). Dropping `email` must NOT be read as a dependency.
+        let partial = Index {
+            name: "t_id_email_kind".to_owned(),
+            columns: vec!["id".to_owned()],
+            unique: false,
+            definition: Some(
+                "CREATE INDEX t_id_email_kind ON t (id) WHERE kind = 'email'".to_owned(),
+            ),
+        };
+        assert!(
+            !index_depends_on_column(&partial, "email"),
+            "a column name in a definition string literal is NOT a dependency (no false positive)"
+        );
+        assert!(
+            index_depends_on_column(&partial, "id"),
+            "the true dependent column (in `columns`) IS a dependency"
+        );
+
+        // An expression index carrying its exact `pg_depend` dependent set.
         let expr = Index {
             name: "u_lower_email".to_owned(),
-            columns: vec![],
+            columns: vec!["email".to_owned()],
             unique: false,
             definition: Some("CREATE INDEX u_lower_email ON users (lower(email))".to_owned()),
         };
         assert!(
             index_depends_on_column(&expr, "email"),
-            "matches lower(email)"
+            "the expression-referenced `email` is captured in `columns`"
         );
         assert!(
             !index_depends_on_column(&expr, "mail"),
-            "must not match a substring inside the token"
-        );
-
-        let emailer = Index {
-            name: "u_emailer".to_owned(),
-            columns: vec![],
-            unique: false,
-            definition: Some("CREATE INDEX u_emailer ON users (emailer)".to_owned()),
-        };
-        assert!(
-            !index_depends_on_column(&emailer, "email"),
-            "`email` must not match the longer identifier `emailer`"
+            "a column absent from `columns` is not a dependency"
         );
 
         let plain = Index {

--- a/autumn-cli/src/schema/diff.rs
+++ b/autumn-cli/src/schema/diff.rs
@@ -1144,6 +1144,20 @@ fn diff_column(table: &str, base: &Column, want: &Column, changes: &mut Vec<Sche
 /// column. This mirrors the `DropColumn` suppression in [`diff_table`]. A composite
 /// index touching even one skipped column is suppressed whole, since the parser
 /// cannot authoritatively say it was removed.
+/// Whether two same-named indexes are equivalent for drift purposes. When either
+/// carries a raw `definition` (an expression/partial index preserved verbatim by
+/// introspection), they are compared by that canonical `pg_get_indexdef` text and
+/// `unique` — the `columns` list is only a partial, display-oriented view of such
+/// an index. Otherwise (ordinary column indexes) they compare by `columns` +
+/// `unique`, identical to the pre-`definition` behavior.
+fn indexes_equivalent(a: &Index, b: &Index) -> bool {
+    if a.definition.is_some() || b.definition.is_some() {
+        a.definition == b.definition && a.unique == b.unique
+    } else {
+        a.columns == b.columns && a.unique == b.unique
+    }
+}
+
 fn diff_indexes(
     table: &str,
     base: &Table,
@@ -1162,7 +1176,7 @@ fn diff_indexes(
                 table: table.to_owned(),
                 index: want_idx.clone(),
             }),
-            Some(base_idx) if *base_idx != want_idx => {
+            Some(base_idx) if !indexes_equivalent(base_idx, want_idx) => {
                 changes.push(SchemaChange::DropIndex {
                     table: table.to_owned(),
                     index: (*base_idx).clone(),
@@ -2829,7 +2843,17 @@ fn render_column_def(column: &Column, backend: Backend) -> String {
 }
 
 /// `CREATE [UNIQUE] INDEX {name} ON {table} ({cols});`.
+///
+/// When the index carries a raw `definition` (an expression/partial index
+/// preserved verbatim by introspection), that full `pg_get_indexdef` statement is
+/// emitted verbatim — with exactly one trailing `;` appended, since
+/// `pg_get_indexdef` output has none — instead of reconstructing a
+/// `CREATE INDEX … (columns)` form that cannot express the expression/predicate.
 fn index_sql(table: &str, index: &Index) -> String {
+    if let Some(def) = &index.definition {
+        let def = def.trim_end().trim_end_matches(';');
+        return format!("{def};");
+    }
     let unique = if index.unique { "UNIQUE " } else { "" };
     format!(
         "CREATE {unique}INDEX {} ON {table} ({});",
@@ -3161,6 +3185,7 @@ mod tests {
             name: "idx_posts_body".to_owned(),
             columns: vec!["body".to_owned()],
             unique: false,
+            definition: None,
         };
         // desired gains the index.
         let base = vec![posts_with(vec![col("body", ColumnType::Text)])];
@@ -3412,6 +3437,7 @@ mod tests {
             name: "idx_posts_status".to_owned(),
             columns: vec!["status".to_owned()],
             unique: true,
+            definition: None,
         });
         let want = parsed(
             vec![posts_with(vec![])],
@@ -3439,6 +3465,7 @@ mod tests {
             name: "idx_posts_body".to_owned(),
             columns: vec!["body".to_owned()],
             unique: false,
+            definition: None,
         };
         let mut base_table = posts_with(vec![col("body", ColumnType::Text)]);
         base_table.indexes.push(idx.clone());
@@ -3475,6 +3502,7 @@ mod tests {
             name: "idx_posts_author_status".to_owned(),
             columns: vec!["author_id".to_owned(), "status".to_owned()],
             unique: true,
+            definition: None,
         });
         // desired retains `author_id` but the enum `status` is skipped (diagnostic),
         // so the parser never sees the composite index either.
@@ -3766,6 +3794,7 @@ mod tests {
                     name: format!("idx_{}", "x".repeat(70)),
                     columns: vec!["body".to_owned()],
                     unique: false,
+                    definition: None,
                 },
             }],
         };
@@ -3789,6 +3818,7 @@ mod tests {
                     name: format!("idx_{}", "x".repeat(70)),
                     columns: vec!["body".to_owned()],
                     unique: false,
+                    definition: None,
                 },
             }],
         };
@@ -3815,6 +3845,7 @@ mod tests {
                         name: dup.clone(),
                         columns: vec!["foo".to_owned()],
                         unique: true,
+                        definition: None,
                     },
                 },
                 SchemaChange::AddIndex {
@@ -3823,6 +3854,7 @@ mod tests {
                         name: dup.clone(),
                         columns: vec!["foo_unique".to_owned()],
                         unique: false,
+                        definition: None,
                     },
                 },
             ],
@@ -3857,11 +3889,13 @@ mod tests {
                 name: dup.clone(),
                 columns: vec!["foo".to_owned()],
                 unique: true,
+                definition: None,
             },
             Index {
                 name: dup.clone(),
                 columns: vec!["foo_unique".to_owned()],
                 unique: false,
+                definition: None,
             },
         ];
         let plan = MigrationPlan {
@@ -3889,6 +3923,7 @@ mod tests {
                         name: "idx_posts_foo".to_owned(),
                         columns: vec!["foo".to_owned()],
                         unique: false,
+                        definition: None,
                     },
                 },
                 SchemaChange::AddIndex {
@@ -3897,6 +3932,7 @@ mod tests {
                         name: "idx_posts_bar".to_owned(),
                         columns: vec!["bar".to_owned()],
                         unique: false,
+                        definition: None,
                     },
                 },
             ],
@@ -3922,6 +3958,7 @@ mod tests {
                     name: "idx_posts_email_unique".to_owned(),
                     columns: vec!["email".to_owned()],
                     unique: true,
+                    definition: None,
                 },
             }],
         };
@@ -3968,6 +4005,7 @@ mod tests {
                         name: "idx_posts_email_unique".to_owned(),
                         columns: vec!["email".to_owned()],
                         unique: true,
+                        definition: None,
                     },
                 },
             ],
@@ -3988,6 +4026,7 @@ mod tests {
             name: "idx_posts_email_unique".to_owned(),
             columns: vec!["email".to_owned()],
             unique: true,
+            definition: None,
         }];
         let plan = MigrationPlan {
             backend: Backend::Postgres,
@@ -4011,6 +4050,7 @@ mod tests {
                     name: "idx_posts_email".to_owned(),
                     columns: vec!["email".to_owned()],
                     unique: false,
+                    definition: None,
                 },
             }],
         };
@@ -4481,6 +4521,7 @@ mod tests {
             name: "idx_posts_author_id".to_owned(),
             columns: vec!["author_id".to_owned()],
             unique: false,
+            definition: None,
         });
         let plan = diff_schema(&base, &parsed(vec![want_table], vec![]), DEFAULT_OPTS);
         let up = emit_up_sql(&plan).expect("emit");
@@ -4532,6 +4573,7 @@ mod tests {
                 name: "idx_posts_slug_unique".to_owned(),
                 columns: vec!["slug".to_owned()],
                 unique: true,
+                definition: None,
             },
         );
         assert_eq!(
@@ -4547,6 +4589,7 @@ mod tests {
                     name: "idx_posts_slug".to_owned(),
                     columns: vec!["slug".to_owned()],
                     unique: false,
+                    definition: None,
                 },
             }],
         };
@@ -4572,6 +4615,7 @@ mod tests {
                         name: "idx_posts_new".to_owned(),
                         columns: vec!["new".to_owned()],
                         unique: false,
+                        definition: None,
                     },
                 },
                 SchemaChange::AddColumn {
@@ -4607,11 +4651,13 @@ mod tests {
             name: "idx_posts_slug".to_owned(),
             columns: vec!["slug".to_owned()],
             unique: false,
+            definition: None,
         };
         let new = Index {
             name: "idx_posts_slug".to_owned(),
             columns: vec!["slug".to_owned()],
             unique: true,
+            definition: None,
         };
         let mut base_table = posts_with(vec![col("slug", ColumnType::Text)]);
         base_table.indexes.push(old);
@@ -4664,6 +4710,7 @@ mod tests {
                         name: "idx_posts_old".to_owned(),
                         columns: vec!["old".to_owned()],
                         unique: false,
+                        definition: None,
                     },
                 },
                 SchemaChange::AddIndex {
@@ -4672,6 +4719,7 @@ mod tests {
                         name: "idx_posts_new".to_owned(),
                         columns: vec!["new".to_owned()],
                         unique: false,
+                        definition: None,
                     },
                 },
             ],
@@ -4784,6 +4832,7 @@ mod tests {
             name: "idx_posts_body".to_owned(),
             columns: vec!["body".to_owned()],
             unique: false,
+            definition: None,
         });
         let plan = MigrationPlan {
             backend: Backend::Postgres,
@@ -4884,6 +4933,7 @@ mod tests {
                         name: "idx_posts_bio".to_owned(),
                         columns: vec!["bio".to_owned()],
                         unique: false,
+                        definition: None,
                     },
                 },
             ],
@@ -4971,6 +5021,7 @@ mod tests {
             name: "idx_posts_body".to_owned(),
             columns: vec!["body".to_owned()],
             unique: false,
+            definition: None,
         };
         let baseline = sqlite_table(
             "posts",

--- a/autumn-cli/src/schema/diff.rs
+++ b/autumn-cli/src/schema/diff.rs
@@ -1218,6 +1218,56 @@ pub fn index_depends_on_column(index: &Index, col: &str) -> bool {
 /// index IS authoritative and a dropped/changed one is reported as real drift via
 /// [`indexes_equivalent`]. Plain (`definition: None`) indexes are diffed
 /// identically in both modes — a model may always ADD a brand-new plain index.
+///
+/// ## Model `#[unique]` satisfied by an existing unique index (brownfield adoption)
+///
+/// In a *model diff* only, a desired UNIQUE index whose name is absent from the
+/// baseline is nonetheless treated as **already satisfied** when the baseline
+/// carries some `unique` index (under ANY name — including a `definition`-carrying
+/// constraint index a brownfield `UNIQUE` produced, e.g. `accounts_email_key`)
+/// over the **exact same column set** ([`baseline_unique_index_covers`]). This is
+/// the brownfield-adoption case: the user pulls `email TEXT UNIQUE`, then writes
+/// the natural model `Account { id, email }` with `#[unique]` on `email`. The
+/// parser emits `idx_accounts_email_unique` (a differently-named unique index over
+/// `{email}`); without this recognition `diff_indexes` would emit a redundant
+/// `AddIndex`, which `guard_plan`'s dedup refusal would then reject on a populated
+/// table — leaving the user unable to keep the annotation. Instead the desired
+/// unique index is suppressed (no `AddIndex`, and no `DropIndex` for the retained
+/// baseline index), so the model resolves to a clean, empty diff. Uniqueness must
+/// match: a desired unique index over `{email}` is NOT satisfied by a baseline
+/// *non-unique* index over `{email}` (it still emits `AddIndex`). Authoritative
+/// diffs are unaffected — a brownfield constraint index shares its name on both
+/// introspected sides and already matches by name, so real drift stays intact.
+/// Whether the baseline table already carries a `unique` index whose covered
+/// column set is **exactly** `want_columns` (order-insensitive) — used only in the
+/// model-diff path to recognize that a desired `#[unique]` index is already
+/// enforced by a differently-named brownfield constraint/unique index.
+///
+/// ## Why exact-set-equality (not subset)
+///
+/// For a `definition`-carrying baseline index, [`Index::columns`] is the exact
+/// `pg_depend` dependent-column set (key + expression + predicate columns). That
+/// set does **not** cheaply distinguish an index's *key* columns from a covering
+/// index's non-key `INCLUDE` columns: a `UNIQUE(a) INCLUDE(b)` index has unique
+/// scope `{a}` but `columns == {a, b}`. Treating such an index as unique over
+/// `{a, b}` (or letting it satisfy a desired unique on the superset) would be
+/// wrong. Since the IR does not carry the key/include split, we are conservative:
+/// only an EXACT set match suppresses the `AddIndex`. A covering index with extra
+/// `INCLUDE` columns simply does not match here and falls back to today's behavior
+/// for that rarer case — not a regression, just no new suppression.
+fn baseline_unique_index_covers(base: &Table, want_columns: &[String]) -> bool {
+    let want_set: BTreeSet<&str> = want_columns.iter().map(String::as_str).collect();
+    base.indexes.iter().any(|idx| {
+        idx.unique
+            && idx
+                .columns
+                .iter()
+                .map(String::as_str)
+                .collect::<BTreeSet<_>>()
+                == want_set
+    })
+}
+
 fn diff_indexes(
     table: &str,
     base: &Table,
@@ -1233,10 +1283,31 @@ fn diff_indexes(
 
     for want_idx in &want.indexes {
         match base_by_name.get(want_idx.name.as_str()) {
-            None => changes.push(SchemaChange::AddIndex {
-                table: table.to_owned(),
-                index: want_idx.clone(),
-            }),
+            None => {
+                // In a MODEL diff (`!definitions_authoritative`), a desired UNIQUE
+                // index whose column SET is already enforced by an existing baseline
+                // unique index — under ANY name, including a `definition`-carrying
+                // constraint index a brownfield `UNIQUE` produced (`accounts_email_key`)
+                // — is already satisfied. The differently-named baseline index enforces
+                // the exact uniqueness the model's `#[unique]` asks for, so emitting an
+                // `AddIndex` here would be redundant AND would trip `guard_plan`'s
+                // unique-index-on-populated-table dedup refusal, blocking the user from
+                // ever keeping the annotation. Suppress it (and leave the retained
+                // baseline index in place — no `DropIndex`). Matching is by EXACT column
+                // set (see [`baseline_unique_index_covers`]). Authoritative diffs are
+                // untouched: a brownfield constraint index has the same name on both
+                // sides there and already matches by name, so real drift stays detected.
+                if !opts.definitions_authoritative
+                    && want_idx.unique
+                    && baseline_unique_index_covers(base, &want_idx.columns)
+                {
+                    continue;
+                }
+                changes.push(SchemaChange::AddIndex {
+                    table: table.to_owned(),
+                    index: want_idx.clone(),
+                });
+            }
             Some(base_idx) => {
                 // A same-named pair where EITHER carries a `definition`: in a model
                 // diff the desired side cannot express the definition, so retain
@@ -3435,6 +3506,134 @@ mod tests {
                 .iter()
                 .any(|c| matches!(c, SchemaChange::DropIndex { .. })),
             "model diff must retain (not drop) a constraint-owned index; got {:?}",
+            plan.changes
+        );
+    }
+
+    /// Brownfield adoption (the P2 fix): a table pulled with `email TEXT UNIQUE`
+    /// retains the constraint-owned unique index Postgres named `accounts_email_key`
+    /// (`definition: Some(..)`, `unique`, columns `[email]`). The user then writes
+    /// the natural model `Account { id, email }` with `#[unique]` on `email`, whose
+    /// parser emits a differently-named unique index `idx_accounts_email_unique`
+    /// over `[email]` (`definition: None`). A model diff must recognize the existing
+    /// unique index as already satisfying the desired `#[unique]` — emitting NEITHER
+    /// an `AddIndex` (which `guard_plan` would reject on a populated table) NOR a
+    /// `DropIndex` for the retained constraint index. The plan must be clean.
+    #[test]
+    fn model_diff_existing_unique_index_satisfies_model_unique_by_columns() {
+        let constraint_idx = Index {
+            name: "accounts_email_key".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: Some(
+                "CREATE UNIQUE INDEX accounts_email_key ON public.accounts USING btree (email)"
+                    .to_owned(),
+            ),
+        };
+        let mut base_table = posts_with(vec![col("email", ColumnType::Text)]);
+        base_table.indexes.push(constraint_idx);
+
+        // Desired (model): the parser-emitted, differently-named unique index.
+        let mut want_table = posts_with(vec![col("email", ColumnType::Text)]);
+        want_table.indexes.push(Index {
+            name: "idx_posts_email_unique".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: None,
+        });
+        let plan = diff_schema(
+            &[base_table],
+            &parsed(vec![want_table], vec![]),
+            DEFAULT_OPTS,
+        );
+        assert!(
+            plan.changes.is_empty(),
+            "existing unique index over the same column set must satisfy the model \
+             #[unique]; expected a clean plan, got {:?}",
+            plan.changes
+        );
+        // And the whole plan must pass the policy guard (no dedup refusal).
+        assert!(
+            guard_plan(&plan, DEFAULT_OPTS).is_ok(),
+            "clean plan must not trip guard_plan"
+        );
+    }
+
+    /// The satisfaction is uniqueness-aware: a desired UNIQUE index over `[email]`
+    /// is NOT satisfied by a baseline **non-unique** index over `[email]`, so the
+    /// `AddIndex` is still emitted (the uniqueness is genuinely new).
+    #[test]
+    fn model_diff_nonunique_baseline_does_not_satisfy_unique_model_index() {
+        let nonunique = Index {
+            name: "idx_posts_email".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: false,
+            definition: None,
+        };
+        let mut base_table = posts_with(vec![col("email", ColumnType::Text)]);
+        base_table.indexes.push(nonunique);
+
+        let mut want_table = posts_with(vec![col("email", ColumnType::Text)]);
+        want_table.indexes.push(Index {
+            name: "idx_posts_email_unique".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: None,
+        });
+        let plan = diff_schema(
+            &[base_table],
+            &parsed(vec![want_table], vec![]),
+            DEFAULT_OPTS,
+        );
+        assert!(
+            plan.changes.iter().any(|c| matches!(
+                c,
+                SchemaChange::AddIndex { index, .. } if index.name == "idx_posts_email_unique"
+            )),
+            "a unique model index over a column with only a non-unique baseline index \
+             must still emit AddIndex; got {:?}",
+            plan.changes
+        );
+    }
+
+    /// Authoritative mode (doctor drift / `pull --dry-run`, both sides introspected)
+    /// is unaffected: a differently-named desired unique index is NOT suppressed by a
+    /// column-set match, so real drift (a renamed/added unique index) is still
+    /// detected. There the brownfield constraint index has the same name on both
+    /// sides and would match by name; a genuinely new name is genuine drift.
+    #[test]
+    fn authoritative_diff_still_emits_add_for_differently_named_unique_index() {
+        let constraint_idx = Index {
+            name: "accounts_email_key".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: Some(
+                "CREATE UNIQUE INDEX accounts_email_key ON public.accounts USING btree (email)"
+                    .to_owned(),
+            ),
+        };
+        let mut base_table = posts_with(vec![col("email", ColumnType::Text)]);
+        base_table.indexes.push(constraint_idx);
+
+        let mut want_table = posts_with(vec![col("email", ColumnType::Text)]);
+        want_table.indexes.push(Index {
+            name: "idx_posts_email_unique".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: None,
+        });
+        let plan = diff_schema(
+            &[base_table],
+            &parsed(vec![want_table], vec![]),
+            AUTHORITATIVE,
+        );
+        assert!(
+            plan.changes.iter().any(|c| matches!(
+                c,
+                SchemaChange::AddIndex { index, .. } if index.name == "idx_posts_email_unique"
+            )),
+            "authoritative diff must still emit AddIndex for a differently-named unique \
+             index (column-set suppression is model-diff-only); got {:?}",
             plan.changes
         );
     }

--- a/autumn-cli/src/schema/doctor.rs
+++ b/autumn-cli/src/schema/doctor.rs
@@ -29,7 +29,7 @@ use autumn_schema_core::{Backend, Table};
 use diesel_migrations::FileBasedMigrations;
 use serde::Serialize;
 
-use super::diff::{DiffOptions, diff_schema};
+use super::diff::{DiffOptions, MigrationPlan, diff_schema};
 use super::introspect::introspect_postgres;
 use super::parse::{ParsedSchema, parse_models_path};
 use super::snapshot::{SNAPSHOT_DEFAULT_PATH, SnapshotError, load_snapshot};
@@ -309,17 +309,72 @@ fn gather_db_schema_drift(
     };
     match introspect_postgres(&url) {
         Ok(tables) => {
-            let desired = ParsedSchema::from_tables(tables);
-            let plan = diff_schema(&snapshot.tables, &desired, DiffOptions::default());
-            if plan.is_empty() {
+            let drift = compute_db_schema_drift(&snapshot.tables, &tables);
+            if drift.is_clean() {
                 DbSchemaState::Clean
             } else {
-                DbSchemaState::Drifted(plan.changes.len())
+                DbSchemaState::Drifted(drift.reported_count())
             }
         }
         // IntrospectError Display is credential-safe.
         Err(e) => DbSchemaState::Unreachable(e.to_string()),
     }
+}
+
+/// Bidirectional database-vs-snapshot drift, computed purely from two table sets
+/// (no I/O) so both `schema doctor` and `schema pull --dry-run` share one engine.
+///
+/// The **forward** diff (`snapshot` baseline → introspected `db` desired) is what a
+/// `schema pull` would change in the snapshot: it catches column/index/table
+/// adds+drops and type changes. But because [`diff_column`](super::diff) /
+/// `diff_checks` treat a desired-side `None` as "unknown, retained" (never a
+/// `DropDefault` / `DropForeignKey` / `DropCheck`), the forward pass MISSES a
+/// manually-dropped default, foreign key, or CHECK in the live DB. Running the diff
+/// in the **reverse** direction (`db` baseline → `snapshot` desired) surfaces
+/// exactly those dropped-facet cases, so drift is the union of the two passes.
+pub struct DbSchemaDrift {
+    /// What a `schema pull` would change in the snapshot baseline.
+    pub forward: MigrationPlan,
+    /// The reverse diff — catches the dropped default/FK/CHECK cases the forward
+    /// pass misses.
+    pub reverse: MigrationPlan,
+}
+
+impl DbSchemaDrift {
+    /// True when neither direction reports any change.
+    pub const fn is_clean(&self) -> bool {
+        self.forward.is_empty() && self.reverse.is_empty()
+    }
+
+    /// The advisory change count to report. Prefers the forward plan's length when
+    /// it is non-empty (the common single-direction case), else the reverse plan's
+    /// — avoiding the worst double-counting without over-engineering dedup.
+    pub const fn reported_count(&self) -> usize {
+        if self.forward.is_empty() {
+            self.reverse.changes.len()
+        } else {
+            self.forward.changes.len()
+        }
+    }
+}
+
+/// Compute [`DbSchemaDrift`] between the checked-in `snapshot_tables` baseline and
+/// the live `db_tables` introspected from the database. Pure and unit-testable —
+/// runs [`diff_schema`] in both directions (see [`DbSchemaDrift`]).
+pub fn compute_db_schema_drift(snapshot_tables: &[Table], db_tables: &[Table]) -> DbSchemaDrift {
+    // Forward: what pulling the DB would change in the snapshot baseline.
+    let forward = diff_schema(
+        snapshot_tables,
+        &ParsedSchema::from_tables(db_tables.to_vec()),
+        DiffOptions::default(),
+    );
+    // Reverse: catches the dropped-default/FK/CHECK cases the forward pass misses.
+    let reverse = diff_schema(
+        db_tables,
+        &ParsedSchema::from_tables(snapshot_tables.to_vec()),
+        DiffOptions::default(),
+    );
+    DbSchemaDrift { forward, reverse }
 }
 
 /// Pure check computation over gathered facts. Ordered filesystem → snapshot →
@@ -541,8 +596,8 @@ fn db_schema_drift_check(state: &DbSchemaState) -> Check {
             name,
             status: Status::Warn,
             detail: format!(
-                "database schema differs from the snapshot in {n} place(s) — run \
-                 `autumn schema pull` to update the baseline or generate a migration"
+                "database schema differs from the snapshot baseline ({n} difference(s)); \
+                 run `autumn schema pull` to update the baseline or generate a migration"
             ),
         },
         DbSchemaState::Unreachable(reason) => Check {
@@ -899,7 +954,7 @@ mod tests {
         // Drifted → WARN, names the remediation.
         let drifted = db_schema_drift_check(&DbSchemaState::Drifted(3));
         assert_eq!(drifted.status, Status::Warn);
-        assert!(drifted.detail.contains("3 place(s)"), "{drifted:?}");
+        assert!(drifted.detail.contains("3 difference(s)"), "{drifted:?}");
         assert!(drifted.detail.contains("autumn schema pull"), "{drifted:?}");
         // Unreachable → WARN (never an error; doctor stays offline-runnable).
         let down = db_schema_drift_check(&DbSchemaState::Unreachable("refused".to_string()));
@@ -939,5 +994,122 @@ mod tests {
             assert_ne!(db.status, Status::Error, "{db:?}");
             assert!(finish(&checks).is_ok(), "checks: {checks:?}");
         }
+    }
+
+    // --- Bidirectional drift (`compute_db_schema_drift`) --------------------
+    //
+    // The forward pass alone (`diff_column` treats a desired `None` as "unknown,
+    // retained") silently MISSES a manually-dropped default / FK / CHECK in the
+    // live DB. These pure tests pin that the union of the two directions catches
+    // those cases, while the forward-caught cases (adds/type changes) still count.
+
+    /// A Postgres `posts(id BIGINT PK, created_at TIMESTAMP DEFAULT now())`-shaped
+    /// table, built with the schema-core constructors, so drift tests can vary a
+    /// single facet (a default, an FK, an extra column) against a clone.
+    fn drift_posts_table(created_at_default: Option<autumn_schema_core::ColumnDefault>) -> Table {
+        use autumn_schema_core::{Column, ColumnType};
+        let mut id = Column::new("id".to_string(), ColumnType::Int64);
+        id.primary_key = true;
+        let mut created_at = Column::new("created_at".to_string(), ColumnType::Timestamp);
+        created_at.default = created_at_default;
+        let mut table = Table::new("posts", Backend::Postgres);
+        table.managed = true;
+        table.primary_key = vec!["id".to_string()];
+        table.columns = vec![id, created_at];
+        table
+    }
+
+    #[test]
+    fn compute_db_schema_drift_identical_is_clean() {
+        let snapshot = vec![drift_posts_table(Some(
+            autumn_schema_core::ColumnDefault::Now,
+        ))];
+        let db = snapshot.clone();
+        let drift = compute_db_schema_drift(&snapshot, &db);
+        assert!(drift.is_clean(), "identical table sets must be clean");
+        assert_eq!(drift.reported_count(), 0);
+    }
+
+    #[test]
+    fn compute_db_schema_drift_catches_dropped_default() {
+        // Snapshot keeps `created_at DEFAULT now()`; the live DB dropped the
+        // default (default: None). The FORWARD pass misses this (a desired `None`
+        // is "retained"); the reverse pass catches it, so the union is drift.
+        let snapshot = vec![drift_posts_table(Some(
+            autumn_schema_core::ColumnDefault::Now,
+        ))];
+        let db = vec![drift_posts_table(None)];
+        let drift = compute_db_schema_drift(&snapshot, &db);
+        assert!(
+            drift.forward.is_empty(),
+            "forward pass alone must miss the dropped default: {:?}",
+            drift.forward.changes
+        );
+        assert!(
+            !drift.reverse.is_empty(),
+            "reverse pass must catch the dropped default"
+        );
+        assert!(!drift.is_clean(), "dropped default is drift");
+        assert!(drift.reported_count() >= 1);
+    }
+
+    #[test]
+    fn compute_db_schema_drift_catches_dropped_foreign_key() {
+        use autumn_schema_core::{Column, ColumnType, ForeignKey};
+        // Both tables share the same columns; the snapshot's `author_id` carries an
+        // FK the live DB dropped. Forward misses it (desired `None` retained);
+        // reverse catches it.
+        let build = |with_fk: bool| {
+            let mut id = Column::new("id".to_string(), ColumnType::Int64);
+            id.primary_key = true;
+            let mut author_id = Column::new("author_id".to_string(), ColumnType::Int64);
+            if with_fk {
+                author_id.references = Some(ForeignKey::new("authors", "id"));
+            }
+            let mut table = Table::new("posts", Backend::Postgres);
+            table.managed = true;
+            table.primary_key = vec!["id".to_string()];
+            table.columns = vec![id, author_id];
+            table
+        };
+        let snapshot = vec![build(true)];
+        let db = vec![build(false)];
+        let drift = compute_db_schema_drift(&snapshot, &db);
+        assert!(
+            drift.forward.is_empty(),
+            "forward pass alone must miss the dropped FK: {:?}",
+            drift.forward.changes
+        );
+        assert!(
+            !drift.reverse.is_empty(),
+            "reverse pass must catch the dropped FK"
+        );
+        assert!(!drift.is_clean(), "dropped FK is drift");
+    }
+
+    #[test]
+    fn compute_db_schema_drift_catches_added_column() {
+        use autumn_schema_core::{Column, ColumnType};
+        // The live DB gained a column the snapshot lacks — the FORWARD pass catches
+        // this as an AddColumn, so the reported count comes from the forward plan.
+        let snapshot = vec![drift_posts_table(Some(
+            autumn_schema_core::ColumnDefault::Now,
+        ))];
+        let mut db_table = drift_posts_table(Some(autumn_schema_core::ColumnDefault::Now));
+        db_table
+            .columns
+            .push(Column::new("extra".to_string(), ColumnType::Text));
+        let db = vec![db_table];
+        let drift = compute_db_schema_drift(&snapshot, &db);
+        assert!(
+            !drift.forward.is_empty(),
+            "forward pass must catch the added column"
+        );
+        assert!(!drift.is_clean(), "added column is drift");
+        assert_eq!(
+            drift.reported_count(),
+            drift.forward.changes.len(),
+            "reported count prefers the non-empty forward plan"
+        );
     }
 }

--- a/autumn-cli/src/schema/doctor.rs
+++ b/autumn-cli/src/schema/doctor.rs
@@ -362,17 +362,26 @@ impl DbSchemaDrift {
 /// the live `db_tables` introspected from the database. Pure and unit-testable —
 /// runs [`diff_schema`] in both directions (see [`DbSchemaDrift`]).
 pub fn compute_db_schema_drift(snapshot_tables: &[Table], db_tables: &[Table]) -> DbSchemaDrift {
+    // Both sides are complete introspections, so expression/partial-index
+    // definitions ARE authoritative here — a dropped/changed one is real drift and
+    // must still be reported (unlike a model diff, which retains what the DSL
+    // cannot express). This flag governs BOTH directions and also serves
+    // `pull --dry-run`, which computes drift through this function.
+    let opts = DiffOptions {
+        definitions_authoritative: true,
+        ..DiffOptions::default()
+    };
     // Forward: what pulling the DB would change in the snapshot baseline.
     let forward = diff_schema(
         snapshot_tables,
         &ParsedSchema::from_tables(db_tables.to_vec()),
-        DiffOptions::default(),
+        opts,
     );
     // Reverse: catches the dropped-default/FK/CHECK cases the forward pass misses.
     let reverse = diff_schema(
         db_tables,
         &ParsedSchema::from_tables(snapshot_tables.to_vec()),
-        DiffOptions::default(),
+        opts,
     );
     DbSchemaDrift { forward, reverse }
 }
@@ -1110,6 +1119,43 @@ mod tests {
             drift.reported_count(),
             drift.forward.changes.len(),
             "reported count prefers the non-empty forward plan"
+        );
+    }
+
+    /// A dropped expression/partial index IS real drift for the introspection
+    /// diff: `compute_db_schema_drift` runs with `definitions_authoritative: true`,
+    /// so a snapshot table carrying a `definition` index the live DB is missing
+    /// reports Drifted (proving the authoritative, bidirectional path still catches
+    /// a dropped expression index — the model-diff retention does NOT leak here).
+    #[test]
+    fn compute_db_schema_drift_catches_dropped_expression_index() {
+        use autumn_schema_core::Index;
+        let mut snapshot_table = drift_posts_table(None);
+        snapshot_table.indexes.push(Index {
+            name: "idx_posts_lower_created".to_owned(),
+            columns: vec!["created_at".to_owned()],
+            unique: false,
+            definition: Some(
+                "CREATE INDEX idx_posts_lower_created ON posts (lower(created_at::text))"
+                    .to_owned(),
+            ),
+        });
+        let snapshot = vec![snapshot_table];
+        // Live DB lacks the expression index entirely.
+        let db = vec![drift_posts_table(None)];
+        let drift = compute_db_schema_drift(&snapshot, &db);
+        assert!(
+            !drift.is_clean(),
+            "a dropped expression index must be reported as drift by the authoritative path"
+        );
+        assert!(
+            drift
+                .forward
+                .changes
+                .iter()
+                .any(|c| matches!(c, crate::schema::diff::SchemaChange::DropIndex { .. })),
+            "forward introspection pass must emit a DropIndex for the missing expression index: {:?}",
+            drift.forward.changes
         );
     }
 }

--- a/autumn-cli/src/schema/doctor.rs
+++ b/autumn-cli/src/schema/doctor.rs
@@ -1139,6 +1139,8 @@ mod tests {
                 "CREATE INDEX idx_posts_lower_created ON posts (lower(created_at::text))"
                     .to_owned(),
             ),
+            is_partial: false,
+            key_columns: Vec::new(),
         });
         let snapshot = vec![snapshot_table];
         // Live DB lacks the expression index entirely.

--- a/autumn-cli/src/schema/doctor.rs
+++ b/autumn-cli/src/schema/doctor.rs
@@ -30,7 +30,8 @@ use diesel_migrations::FileBasedMigrations;
 use serde::Serialize;
 
 use super::diff::{DiffOptions, diff_schema};
-use super::parse::parse_models_path;
+use super::introspect::introspect_postgres;
+use super::parse::{ParsedSchema, parse_models_path};
 use super::snapshot::{SNAPSHOT_DEFAULT_PATH, SnapshotError, load_snapshot};
 
 /// A single diagnostic check outcome.
@@ -104,6 +105,25 @@ enum PendingState {
     Unreachable(String),
 }
 
+/// Database-vs-snapshot drift probe outcome (the live database introspected and
+/// diffed against the checked-in snapshot baseline). Offline-safe: an
+/// unreachable database is a distinct, non-failing state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DbSchemaState {
+    /// No database URL is configured — the check is skipped.
+    NotConfigured,
+    /// The backend/build cannot run this check (e.g. non-Postgres backend).
+    Skipped(String),
+    /// No readable snapshot baseline to diff the database against.
+    SnapshotMissing,
+    /// The database could not be reached/introspected (secret-free reason).
+    Unreachable(String),
+    /// The live database matches the snapshot baseline.
+    Clean,
+    /// The database diverges from the snapshot baseline by this many changes.
+    Drifted(usize),
+}
+
 /// Filesystem/snapshot/backend facts gathered without touching the database.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct LocalFacts {
@@ -127,7 +147,8 @@ pub fn run_doctor(profile: Option<&str>, json: bool) -> Result<(), String> {
         .map_err(|e| format!("failed to resolve the current directory: {e}"))?;
     let local = gather_local_facts(&project_root, profile);
     let pending = gather_pending(&project_root, profile, &local);
-    let checks = compute_checks(&local, &pending);
+    let db_schema = gather_db_schema_drift(&project_root, profile, &local);
+    let checks = compute_checks(&local, &pending, &db_schema);
     render(&checks, json)?;
     finish(&checks)
 }
@@ -256,9 +277,59 @@ fn probe_pending(url: &str, migrations_dir: &Path) -> PendingState {
     }
 }
 
+/// Probe the live database schema and diff it against the checked-in snapshot.
+///
+/// Offline-safe by construction (mirrors [`gather_pending`]): no URL →
+/// [`DbSchemaState::NotConfigured`]; a non-Postgres backend →
+/// [`DbSchemaState::Skipped`] (introspection is Postgres-only in this slice); a
+/// missing/unreadable snapshot → [`DbSchemaState::SnapshotMissing`]; a
+/// connect/query failure → [`DbSchemaState::Unreachable`] (a WARN, never an
+/// error — doctor must stay runnable offline). Only when all of those pass does
+/// it diff the introspected tables (desired) against the snapshot tables
+/// (baseline) into [`DbSchemaState::Clean`] / [`DbSchemaState::Drifted`].
+fn gather_db_schema_drift(
+    project_root: &Path,
+    profile: Option<&str>,
+    local: &LocalFacts,
+) -> DbSchemaState {
+    let Some(url) = crate::migrate::resolve_primary_url(profile) else {
+        return DbSchemaState::NotConfigured;
+    };
+    if local.detected_backend != Backend::Postgres {
+        return DbSchemaState::Skipped(format!(
+            "database-schema drift check is Postgres-only; detected {:?} backend",
+            local.detected_backend
+        ));
+    }
+    // Reload the snapshot baseline from disk (offline, cheap). A missing or
+    // unreadable snapshot means there is nothing to diff the database against.
+    let snapshot_path = project_root.join(SNAPSHOT_DEFAULT_PATH);
+    let Ok(snapshot) = load_snapshot(&snapshot_path) else {
+        return DbSchemaState::SnapshotMissing;
+    };
+    match introspect_postgres(&url) {
+        Ok(tables) => {
+            let desired = ParsedSchema::from_tables(tables);
+            let plan = diff_schema(&snapshot.tables, &desired, DiffOptions::default());
+            if plan.is_empty() {
+                DbSchemaState::Clean
+            } else {
+                DbSchemaState::Drifted(plan.changes.len())
+            }
+        }
+        // IntrospectError Display is credential-safe.
+        Err(e) => DbSchemaState::Unreachable(e.to_string()),
+    }
+}
+
 /// Pure check computation over gathered facts. Ordered filesystem → snapshot →
-/// drift → backend (provider-lock, then dialect-vs-DB) → database.
-fn compute_checks(local: &LocalFacts, pending: &PendingState) -> Vec<Check> {
+/// drift → backend (provider-lock, then dialect-vs-DB) → database
+/// (pending-migrations, then database-schema drift).
+fn compute_checks(
+    local: &LocalFacts,
+    pending: &PendingState,
+    db_schema: &DbSchemaState,
+) -> Vec<Check> {
     let mut checks = Vec::new();
 
     // 1. project-root
@@ -316,6 +387,9 @@ fn compute_checks(local: &LocalFacts, pending: &PendingState) -> Vec<Check> {
 
     // 6. pending-migrations
     checks.push(pending_check(pending));
+
+    // 7. database-schema-drift (live DB introspected vs the snapshot baseline)
+    checks.push(db_schema_drift_check(db_schema));
 
     checks
 }
@@ -451,6 +525,49 @@ fn pending_check(pending: &PendingState) -> Check {
     }
 }
 
+/// The `database-schema-drift` row (live database introspected vs the snapshot
+/// baseline). Never an `Error`: an unreachable/misconfigured/non-Postgres
+/// database is a WARN so doctor stays runnable offline (mirroring
+/// `pending-migrations` / `snapshot-dialect-vs-db`).
+fn db_schema_drift_check(state: &DbSchemaState) -> Check {
+    let name = "database-schema-drift".to_string();
+    match state {
+        DbSchemaState::Clean => Check {
+            name,
+            status: Status::Ok,
+            detail: "database schema matches the snapshot baseline".to_string(),
+        },
+        DbSchemaState::Drifted(n) => Check {
+            name,
+            status: Status::Warn,
+            detail: format!(
+                "database schema differs from the snapshot in {n} place(s) — run \
+                 `autumn schema pull` to update the baseline or generate a migration"
+            ),
+        },
+        DbSchemaState::Unreachable(reason) => Check {
+            name,
+            status: Status::Warn,
+            detail: format!("could not reach the database: {reason}"),
+        },
+        DbSchemaState::NotConfigured => Check {
+            name,
+            status: Status::Warn,
+            detail: "no database configured — skipped".to_string(),
+        },
+        DbSchemaState::Skipped(reason) => Check {
+            name,
+            status: Status::Warn,
+            detail: reason.clone(),
+        },
+        DbSchemaState::SnapshotMissing => Check {
+            name,
+            status: Status::Warn,
+            detail: "skipped — no readable snapshot baseline".to_string(),
+        },
+    }
+}
+
 /// Print the report as an aligned table, or as JSON when `json` is set.
 fn render(checks: &[Check], json: bool) -> Result<(), String> {
     if json {
@@ -553,7 +670,11 @@ mod tests {
     fn missing_project_root_is_error() {
         let root = tempfile::tempdir().expect("tempdir"); // no Cargo.toml
         let local = gather_local_facts(root.path(), None);
-        let checks = compute_checks(&local, &PendingState::NotConfigured);
+        let checks = compute_checks(
+            &local,
+            &PendingState::NotConfigured,
+            &DbSchemaState::NotConfigured,
+        );
         let pr = checks.iter().find(|c| c.name == "project-root").unwrap();
         assert_eq!(pr.status, Status::Error, "{pr:?}");
         // finish() turns it into a non-zero exit.
@@ -564,7 +685,11 @@ mod tests {
     fn matching_models_report_drift_ok() {
         let root = scaffold(POST_MODEL, Some(&posts_snapshot("Postgres")));
         let local = gather_local_facts(root.path(), None);
-        let checks = compute_checks(&local, &PendingState::NotConfigured);
+        let checks = compute_checks(
+            &local,
+            &PendingState::NotConfigured,
+            &DbSchemaState::NotConfigured,
+        );
         let drift = checks.iter().find(|c| c.name == "snapshot-drift").unwrap();
         assert_eq!(drift.status, Status::Ok, "{drift:?}");
         // No ERROR checks (detected Postgres matches the Postgres snapshot).
@@ -585,7 +710,11 @@ mod tests {
         "#;
         let root = scaffold(models, Some(&posts_snapshot("Postgres")));
         let local = gather_local_facts(root.path(), None);
-        let checks = compute_checks(&local, &PendingState::NotConfigured);
+        let checks = compute_checks(
+            &local,
+            &PendingState::NotConfigured,
+            &DbSchemaState::NotConfigured,
+        );
         let drift = checks.iter().find(|c| c.name == "snapshot-drift").unwrap();
         assert_eq!(drift.status, Status::Warn, "{drift:?}");
         assert!(drift.detail.contains("pending model change"), "{drift:?}");
@@ -612,7 +741,11 @@ mod tests {
             detected_backend: Backend::Sqlite,
             url_backend: Some(Backend::Sqlite),
         };
-        let checks = compute_checks(&local, &PendingState::NotConfigured);
+        let checks = compute_checks(
+            &local,
+            &PendingState::NotConfigured,
+            &DbSchemaState::NotConfigured,
+        );
         let lock = checks.iter().find(|c| c.name == "provider-lock").unwrap();
         assert_eq!(lock.status, Status::Ok, "{lock:?}");
         // No ERROR overall: the selected Sqlite backend agrees with the snapshot.
@@ -625,7 +758,11 @@ mod tests {
         let root = scaffold(POST_MODEL, Some(&posts_snapshot("Sqlite")));
         let local = gather_local_facts(root.path(), None);
         assert_eq!(local.detected_backend, Backend::Postgres);
-        let checks = compute_checks(&local, &PendingState::NotConfigured);
+        let checks = compute_checks(
+            &local,
+            &PendingState::NotConfigured,
+            &DbSchemaState::NotConfigured,
+        );
         let lock = checks.iter().find(|c| c.name == "provider-lock").unwrap();
         assert_eq!(lock.status, Status::Error, "{lock:?}");
         assert!(finish(&checks).is_err());
@@ -635,7 +772,11 @@ mod tests {
     fn missing_snapshot_is_snapshot_present_error() {
         let root = scaffold(POST_MODEL, None); // .autumn present, no snapshot file
         let local = gather_local_facts(root.path(), None);
-        let checks = compute_checks(&local, &PendingState::NotConfigured);
+        let checks = compute_checks(
+            &local,
+            &PendingState::NotConfigured,
+            &DbSchemaState::NotConfigured,
+        );
         let snap = checks
             .iter()
             .find(|c| c.name == "snapshot-present")
@@ -651,7 +792,11 @@ mod tests {
     fn unreadable_snapshot_is_snapshot_present_error() {
         let root = scaffold(POST_MODEL, Some("{ not valid json"));
         let local = gather_local_facts(root.path(), None);
-        let checks = compute_checks(&local, &PendingState::NotConfigured);
+        let checks = compute_checks(
+            &local,
+            &PendingState::NotConfigured,
+            &DbSchemaState::NotConfigured,
+        );
         let snap = checks
             .iter()
             .find(|c| c.name == "snapshot-present")
@@ -724,7 +869,11 @@ mod tests {
     fn report_ordering_is_filesystem_then_snapshot_then_db() {
         let root = scaffold(POST_MODEL, Some(&posts_snapshot("Postgres")));
         let local = gather_local_facts(root.path(), None);
-        let checks = compute_checks(&local, &PendingState::NotConfigured);
+        let checks = compute_checks(
+            &local,
+            &PendingState::NotConfigured,
+            &DbSchemaState::NotConfigured,
+        );
         let names: Vec<&str> = checks.iter().map(|c| c.name.as_str()).collect();
         assert_eq!(
             names,
@@ -735,7 +884,60 @@ mod tests {
                 "provider-lock",
                 "snapshot-dialect-vs-db",
                 "pending-migrations",
+                "database-schema-drift",
             ]
         );
+    }
+
+    #[test]
+    fn db_schema_drift_states_map_to_expected_status() {
+        // Clean → OK.
+        assert_eq!(
+            db_schema_drift_check(&DbSchemaState::Clean).status,
+            Status::Ok
+        );
+        // Drifted → WARN, names the remediation.
+        let drifted = db_schema_drift_check(&DbSchemaState::Drifted(3));
+        assert_eq!(drifted.status, Status::Warn);
+        assert!(drifted.detail.contains("3 place(s)"), "{drifted:?}");
+        assert!(drifted.detail.contains("autumn schema pull"), "{drifted:?}");
+        // Unreachable → WARN (never an error; doctor stays offline-runnable).
+        let down = db_schema_drift_check(&DbSchemaState::Unreachable("refused".to_string()));
+        assert_eq!(down.status, Status::Warn);
+        assert!(down.detail.contains("could not reach the database"));
+        // Non-Postgres skip / not-configured / no-snapshot → WARN, never error.
+        assert_eq!(
+            db_schema_drift_check(&DbSchemaState::Skipped("sqlite".to_string())).status,
+            Status::Warn
+        );
+        assert_eq!(
+            db_schema_drift_check(&DbSchemaState::NotConfigured).status,
+            Status::Warn
+        );
+        assert_eq!(
+            db_schema_drift_check(&DbSchemaState::SnapshotMissing).status,
+            Status::Warn
+        );
+    }
+
+    #[test]
+    fn db_schema_drift_never_fails_the_command() {
+        // Even a drifted/unreachable database keeps the whole report non-failing
+        // (a WARN alone never trips `finish`) — doctor must run clean offline.
+        let root = scaffold(POST_MODEL, Some(&posts_snapshot("Postgres")));
+        let local = gather_local_facts(root.path(), None);
+        for state in [
+            DbSchemaState::Drifted(5),
+            DbSchemaState::Unreachable("connection refused".to_string()),
+            DbSchemaState::Clean,
+        ] {
+            let checks = compute_checks(&local, &PendingState::NotConfigured, &state);
+            let db = checks
+                .iter()
+                .find(|c| c.name == "database-schema-drift")
+                .unwrap();
+            assert_ne!(db.status, Status::Error, "{db:?}");
+            assert!(finish(&checks).is_ok(), "checks: {checks:?}");
+        }
     }
 }

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -81,15 +81,17 @@
 //!   the `ALTER TABLE … DROP COLUMN` (the up path emits no `DROP INDEX`). The
 //!   snapshot projection prunes it to match (so `doctor` / `pull --dry-run` do not
 //!   false-drift) and the down migration recreates it from its verbatim
-//!   `definition`. Two nuances are deferred: **(i)** a cascade-removed brownfield
-//!   `UNIQUE`/`EXCLUDE` *constraint* is restored on rollback as a unique *index*
-//!   (via its `pg_get_indexdef` definition), not as the original named
-//!   `CONSTRAINT` — functional uniqueness is preserved, exact constraint-object
-//!   reconstruction is deferred; **(ii)** whether a column is *depended on* by an
-//!   expression index is detected best-effort — `columns` membership plus a
-//!   word-bounded token match of the column name in the `definition` text (so
-//!   `email` matches `lower(email)` but not `emailer`), not a full parse of the
-//!   index expression.
+//!   `definition`. Whether a column is *depended on* is now detected **exactly**:
+//!   a retained index carries in its [`Index::columns`] the precise `pg_depend`
+//!   dependent-column set (key, expression-referenced, AND predicate columns) —
+//!   the authoritative cascade set Postgres itself uses — so the diff engine tests
+//!   dependency by exact set membership, never a `definition`-text scan (which
+//!   could false-positive on a column name appearing in a string literal). One
+//!   nuance remains deferred: a cascade-removed brownfield `UNIQUE`/`EXCLUDE`
+//!   *constraint* is restored on rollback as a unique *index* (via its
+//!   `pg_get_indexdef` definition), not as the original named `CONSTRAINT` —
+//!   functional uniqueness is preserved, exact constraint-object reconstruction is
+//!   deferred.
 //!
 //! Errors are **credential-safe** by construction: no variant ever embeds the
 //! resolved database URL (only a parsed host/port on the connection-error path,
@@ -246,9 +248,22 @@ struct IndexRow {
     /// model DSL cannot express it, so it is retained verbatim.
     #[diesel(sql_type = diesel::sql_types::Bool)]
     is_constraint: bool,
-    /// Comma-joined resolvable ordinary column names, in key order (may be empty).
+    /// Comma-joined resolvable ordinary *key* column names, in key order (may be
+    /// empty for an all-expression index). Used to populate a *simple* index's
+    /// `Index.columns` for round-trip parity.
     #[diesel(sql_type = diesel::sql_types::Text)]
     columns: String,
+    /// Comma-joined set of every column this index *depends on* — key columns,
+    /// expression-referenced columns, AND predicate (`WHERE`) columns per
+    /// `pg_depend`, combined via `UNION` with the backing constraint's `conkey`
+    /// columns for a constraint-owned index (whose column dependency routes through
+    /// `pg_constraint`, not a direct index→column `pg_depend` row). Together this
+    /// is exactly what Postgres cascade-drops with an `ALTER TABLE … DROP COLUMN`.
+    /// Sorted by name (deterministic). Used to populate a *definition*-carrying
+    /// index's `Index.columns` so the diff engine's column-dependency detection is
+    /// exact (no string scan).
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    dep_columns: String,
 }
 
 #[derive(QueryableByName)]
@@ -389,7 +404,13 @@ fn fetch_primary_keys(
 /// ORDINALITY` subquery; `has_expression` flags any `0` key, `is_partial`
 /// flags an `indpred`, and `is_constraint` flags an index backing a
 /// `pg_constraint` (UNIQUE/EXCLUDE), so the builder can classify each index as
-/// simple-representable vs. preserved-verbatim.
+/// simple-representable vs. preserved-verbatim. A second correlated subquery
+/// aggregates `dep_columns` — the exact set of columns the index depends on (key,
+/// expression-referenced, AND predicate columns via **`pg_depend`**, combined via
+/// `UNION` with the backing constraint's `conkey` columns for a constraint-owned
+/// index), the
+/// authoritative cascade set Postgres itself uses for `DROP COLUMN` — so a retained
+/// index's column-dependency detection is exact, not a string scan.
 fn fetch_indexes(
     conn: &mut PgConnection,
     tables: &[String],
@@ -410,7 +431,26 @@ fn fetch_indexes(
                 WITH ORDINALITY AS k(attnum, ord) \
            JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = k.attnum \
            WHERE k.attnum > 0 \
-         ), '') AS columns \
+         ), '') AS columns, \
+         COALESCE(( \
+           SELECT string_agg(DISTINCT attname, ',' ORDER BY attname) FROM ( \
+             SELECT a.attname \
+             FROM pg_depend d \
+             JOIN pg_attribute a \
+               ON a.attrelid = d.refobjid AND a.attnum = d.refobjsubid \
+             WHERE d.classid = 'pg_class'::regclass \
+               AND d.objid = i.indexrelid \
+               AND d.refclassid = 'pg_class'::regclass \
+               AND d.refobjid = i.indrelid \
+               AND d.refobjsubid > 0 \
+             UNION \
+             SELECT a.attname \
+             FROM pg_constraint c \
+             JOIN unnest(c.conkey) AS ck(attnum) ON TRUE \
+             JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ck.attnum \
+             WHERE c.conindid = i.indexrelid AND ck.attnum > 0 \
+           ) deps \
+         ), '') AS dep_columns \
          FROM pg_index i \
          JOIN pg_class t ON t.oid = i.indrelid \
          JOIN pg_class ic ON ic.oid = i.indexrelid \
@@ -540,7 +580,7 @@ fn collapse_indexes(rows: &[IndexRow]) -> (Vec<Index>, std::collections::BTreeSe
     let mut indexes = Vec::with_capacity(rows.len());
     let mut unique_columns = std::collections::BTreeSet::new();
     for row in rows {
-        let columns: Vec<String> = row
+        let key_columns: Vec<String> = row
             .columns
             .split(',')
             .filter(|c| !c.is_empty())
@@ -551,18 +591,31 @@ fn collapse_indexes(rows: &[IndexRow]) -> (Vec<Index>, std::collections::BTreeSe
         // column's `unique` flag whether or not it backs a constraint (the flag
         // is accurate either way and is never diffed).
         let simple = !row.is_partial && !row.has_expression;
-        if simple && row.is_unique && columns.len() == 1 {
-            unique_columns.insert(columns[0].clone());
+        if simple && row.is_unique && key_columns.len() == 1 {
+            unique_columns.insert(key_columns[0].clone());
         }
         // Retain (preserve verbatim, never drop) any index the model DSL cannot
         // express: an expression or partial index, OR a constraint-owned index
         // (UNIQUE/EXCLUDE) whose backing constraint Postgres won't let us drop.
         // A plain, non-constraint index keeps `definition: None` so its JSON is
         // unchanged and the model round-trip stays clean.
-        let definition = if simple && !row.is_constraint {
-            None
+        //
+        // For a SIMPLE index `Index.columns` stays the ordered key columns (exact
+        // round-trip parity; the `pg_depend` set equals the key columns anyway).
+        // For a DEFINITION-carrying index (expression / partial / constraint-owned),
+        // `Index.columns` is the exact `pg_depend` dependent-column set — key,
+        // expression-referenced, AND predicate columns — the set the diff engine
+        // uses for exact cascade/dependency detection (no string scan).
+        let (columns, definition) = if simple && !row.is_constraint {
+            (key_columns, None)
         } else {
-            Some(row.definition.clone())
+            let dep_columns: Vec<String> = row
+                .dep_columns
+                .split(',')
+                .filter(|c| !c.is_empty())
+                .map(str::to_owned)
+                .collect();
+            (dep_columns, Some(row.definition.clone()))
         };
         indexes.push(Index {
             name: row.index_name.clone(),
@@ -722,13 +775,18 @@ mod tests {
     }
 
     /// Build a one-per-index [`IndexRow`] for tests. `columns` is the comma-joined
-    /// resolvable-column string the SQL aggregation produces. `is_constraint` is
-    /// left `false` (an ordinary/model-style or expression/partial index); use
-    /// [`constraint_index_row`] for a constraint-owned index.
+    /// resolvable *key*-column string the SQL aggregation produces; `dep_columns`
+    /// is the comma-joined `pg_depend` dependent-column set (key + expression +
+    /// predicate columns). For a simple index the two are equal; for an
+    /// expression/partial index they differ (empty/partial key columns, full
+    /// dependent set). `is_constraint` is left `false` (an ordinary/model-style or
+    /// expression/partial index); use [`constraint_index_row`] for a
+    /// constraint-owned index.
     fn index_row(
         index_name: &str,
         is_unique: bool,
         columns: &str,
+        dep_columns: &str,
         is_partial: bool,
         has_expression: bool,
         definition: &str,
@@ -742,12 +800,14 @@ mod tests {
             has_expression,
             is_constraint: false,
             columns: columns.to_owned(),
+            dep_columns: dep_columns.to_owned(),
         }
     }
 
     /// Build a constraint-owned (non-primary, non-partial, non-expression)
     /// [`IndexRow`] — the auto-created index behind a brownfield column/table-level
-    /// `UNIQUE`/`EXCLUDE` constraint (`is_constraint == true`).
+    /// `UNIQUE`/`EXCLUDE` constraint (`is_constraint == true`). The `pg_depend`
+    /// dependent set of such an index equals its key columns.
     fn constraint_index_row(
         index_name: &str,
         is_unique: bool,
@@ -756,7 +816,9 @@ mod tests {
     ) -> IndexRow {
         IndexRow {
             is_constraint: true,
-            ..index_row(index_name, is_unique, columns, false, false, definition)
+            ..index_row(
+                index_name, is_unique, columns, columns, false, false, definition,
+            )
         }
     }
 
@@ -765,6 +827,7 @@ mod tests {
         let rows = vec![index_row(
             "idx_accounts_email_unique",
             true,
+            "email",
             "email",
             false,
             false,
@@ -786,6 +849,7 @@ mod tests {
             "idx_comments_post_id",
             false,
             "post_id",
+            "post_id",
             false,
             false,
             "CREATE INDEX idx_comments_post_id ON public.comments USING btree (post_id)",
@@ -804,6 +868,7 @@ mod tests {
         let rows = vec![index_row(
             "idx_memberships_org_user",
             true,
+            "org_id,user_id",
             "org_id,user_id",
             false,
             false,
@@ -832,7 +897,8 @@ mod tests {
         let rows = vec![index_row(
             "users_lower_email_idx",
             false,
-            "", // no resolvable ordinary columns
+            "",      // no resolvable ordinary KEY columns (all-expression)
+            "email", // but `pg_depend` records the expression-referenced column
             false,
             true,
             def,
@@ -840,7 +906,10 @@ mod tests {
         let (indexes, unique_cols) = collapse_indexes(&rows);
         assert_eq!(indexes.len(), 1, "expression index preserved, not dropped");
         assert_eq!(indexes[0].name, "users_lower_email_idx");
-        assert!(indexes[0].columns.is_empty());
+        // A definition-carrying index carries its exact `pg_depend` dependent set,
+        // so the expression-referenced `email` column is captured for exact
+        // cascade/dependency detection.
+        assert_eq!(indexes[0].columns, vec!["email".to_owned()]);
         assert_eq!(indexes[0].definition.as_deref(), Some(def));
         assert!(unique_cols.is_empty());
     }
@@ -854,14 +923,20 @@ mod tests {
         let rows = vec![index_row(
             "users_active_idx",
             false,
-            "email",
+            "email",            // key column
+            "deleted_at,email", // `pg_depend` set: predicate + key column (sorted)
             true,
             false,
             def,
         )];
         let (indexes, unique_cols) = collapse_indexes(&rows);
         assert_eq!(indexes.len(), 1);
-        assert_eq!(indexes[0].columns, vec!["email".to_owned()]);
+        // A partial index depends on BOTH its key column and its predicate column;
+        // the exact `pg_depend` set (which cascades on `DROP COLUMN`) is captured.
+        assert_eq!(
+            indexes[0].columns,
+            vec!["deleted_at".to_owned(), "email".to_owned()]
+        );
         assert_eq!(indexes[0].definition.as_deref(), Some(def));
         assert!(
             unique_cols.is_empty(),
@@ -906,6 +981,7 @@ mod tests {
             "idx_users_email_unique",
             true,
             "email",
+            "email",
             false,
             false,
             def,
@@ -947,6 +1023,7 @@ mod tests {
         let indexes = vec![index_row(
             "idx_comments_post_id",
             false,
+            "post_id",
             "post_id",
             false,
             false,

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -131,7 +131,9 @@
 
 use std::collections::BTreeMap;
 
-use autumn_schema_core::{Backend, Column, ColumnDefault, ColumnType, ForeignKey, Index, Table};
+use autumn_schema_core::{
+    Backend, CheckConstraint, Column, ColumnDefault, ColumnType, ForeignKey, Index, Table,
+};
 use diesel::{Connection as _, PgConnection, QueryableByName, RunQueryDsl as _, sql_query};
 
 /// Failure modes for Postgres introspection. `Display` is credential-safe: the
@@ -187,6 +189,7 @@ pub fn introspect_postgres(url: &str) -> Result<Vec<Table>, IntrospectError> {
     let pks_by_table = fetch_primary_keys(&mut conn, &table_names)?;
     let indexes_by_table = fetch_indexes(&mut conn, &table_names)?;
     let fks_by_table = fetch_foreign_keys(&mut conn, &table_names)?;
+    let checks_by_table = fetch_checks(&mut conn, &table_names)?;
 
     let mut tables = Vec::with_capacity(table_names.len());
     for name in &table_names {
@@ -196,6 +199,7 @@ pub fn introspect_postgres(url: &str) -> Result<Vec<Table>, IntrospectError> {
             pks_by_table.get(name).map_or(&[][..], Vec::as_slice),
             indexes_by_table.get(name).map_or(&[][..], Vec::as_slice),
             fks_by_table.get(name).map_or(&[][..], Vec::as_slice),
+            checks_by_table.get(name).map_or(&[][..], Vec::as_slice),
         ));
     }
     Ok(tables)
@@ -235,6 +239,16 @@ struct ColumnRow {
     numeric_precision: Option<i32>,
     #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Integer>)]
     numeric_scale: Option<i32>,
+    /// The Postgres DOMAIN name backing this column, or `NULL` when the column's
+    /// type is not a domain. When set, the column's type is preserved verbatim as
+    /// [`ColumnType::Opaque`] (schema-qualified via `domain_schema`) so the
+    /// domain's identity/validation is never flattened to its base `udt_name`.
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+    domain_name: Option<String>,
+    /// The schema owning the column's domain (`NULL` for a non-domain column).
+    /// Only qualifies the emitted type when it is not `public`.
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+    domain_schema: Option<String>,
 }
 
 #[derive(QueryableByName)]
@@ -343,8 +357,26 @@ struct ForeignKeyRow {
     column_name: String,
     #[diesel(sql_type = diesel::sql_types::Text)]
     foreign_table: String,
+    /// The schema owning the referenced table. A cross-schema FK target (not
+    /// `public`) is stored schema-qualified in [`ForeignKey::table`] so it never
+    /// silently retargets a same-named table in `public` on recreation.
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    foreign_schema: String,
     #[diesel(sql_type = diesel::sql_types::Text)]
     foreign_column: String,
+}
+
+#[derive(QueryableByName)]
+struct CheckRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    table_name: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    constraint_name: String,
+    /// The full `pg_get_constraintdef` text (`CHECK ((price >= 0))`), stripped to
+    /// the inner predicate (`price >= 0`) at build time to match the emitter's
+    /// `CHECK ({expression})` wrapping.
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    definition: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -406,7 +438,8 @@ fn fetch_columns(
     let query = format!(
         "SELECT table_name, column_name, udt_name, is_nullable, column_default, \
          numeric_precision::integer AS numeric_precision, \
-         numeric_scale::integer AS numeric_scale FROM information_schema.columns \
+         numeric_scale::integer AS numeric_scale, \
+         domain_name, domain_schema FROM information_schema.columns \
          WHERE table_schema = 'public' AND table_name IN ({}) \
          ORDER BY table_name, ordinal_position",
         quoted_in_list(tables)
@@ -571,11 +604,13 @@ fn fetch_foreign_keys(
 ) -> Result<BTreeMap<String, Vec<ForeignKeyRow>>, IntrospectError> {
     let query = format!(
         "SELECT t.relname AS table_name, att.attname AS column_name, \
-         ft.relname AS foreign_table, fatt.attname AS foreign_column \
+         ft.relname AS foreign_table, fn.nspname AS foreign_schema, \
+         fatt.attname AS foreign_column \
          FROM pg_constraint con \
          JOIN pg_class t ON t.oid = con.conrelid \
          JOIN pg_namespace n ON n.oid = t.relnamespace \
          JOIN pg_class ft ON ft.oid = con.confrelid \
+         JOIN pg_namespace fn ON fn.oid = ft.relnamespace \
          JOIN pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = con.conkey[1] \
          JOIN pg_attribute fatt ON fatt.attrelid = con.confrelid AND fatt.attnum = con.confkey[1] \
          WHERE con.contype = 'f' AND n.nspname = 'public' AND t.relname IN ({})",
@@ -594,6 +629,58 @@ fn fetch_foreign_keys(
     Ok(by_table)
 }
 
+/// Fetch every table-level `CHECK` constraint for all `tables`, grouped by table.
+///
+/// `contype = 'c'` selects **real** CHECK constraints only — a column's `NOT NULL`
+/// is `pg_attribute.attnotnull` (not a check), and a DOMAIN's check has
+/// `conrelid = 0`, so scoping the join to the table's own `conrelid` naturally
+/// excludes domain checks. `pg_get_constraintdef` renders the constraint's full
+/// `CHECK (...)` definition, which `build_table` strips to the inner predicate to
+/// match the emitter's `CHECK ({expression})` wrapping.
+fn fetch_checks(
+    conn: &mut PgConnection,
+    tables: &[String],
+) -> Result<BTreeMap<String, Vec<CheckRow>>, IntrospectError> {
+    let query = format!(
+        "SELECT t.relname AS table_name, con.conname AS constraint_name, \
+         pg_get_constraintdef(con.oid) AS definition \
+         FROM pg_constraint con \
+         JOIN pg_class t ON t.oid = con.conrelid \
+         JOIN pg_namespace n ON n.oid = t.relnamespace \
+         WHERE con.contype = 'c' AND n.nspname = 'public' AND t.relname IN ({}) \
+         ORDER BY t.relname, con.conname",
+        quoted_in_list(tables)
+    );
+    let rows: Vec<CheckRow> = sql_query(query)
+        .load(conn)
+        .map_err(|e| IntrospectError::Query(e.to_string()))?;
+    let mut by_table: BTreeMap<String, Vec<CheckRow>> = BTreeMap::new();
+    for row in rows {
+        by_table
+            .entry(row.table_name.clone())
+            .or_default()
+            .push(row);
+    }
+    Ok(by_table)
+}
+
+/// Strip a `pg_get_constraintdef` CHECK definition (`CHECK ((price >= 0))`) to the
+/// inner predicate (`price >= 0`) the emitter re-wraps in `CHECK (...)`. Removes
+/// the leading `CHECK ` keyword and exactly one balanced outer paren pair; a
+/// definition that does not match the expected shape is returned trimmed verbatim
+/// (never silently dropped).
+fn strip_check_wrapper(definition: &str) -> String {
+    let trimmed = definition.trim();
+    let inner = trimmed
+        .strip_prefix("CHECK ")
+        .or_else(|| trimmed.strip_prefix("CHECK"))
+        .map_or(trimmed, str::trim);
+    inner
+        .strip_prefix('(')
+        .and_then(|s| s.strip_suffix(')'))
+        .map_or_else(|| inner.to_owned(), |unwrapped| unwrapped.trim().to_owned())
+}
+
 // ---------------------------------------------------------------------------
 // IR assembly (pure over the fetched rows)
 // ---------------------------------------------------------------------------
@@ -605,6 +692,7 @@ fn build_table(
     primary_key: &[String],
     indexes: &[IndexRow],
     foreign_keys: &[ForeignKeyRow],
+    checks: &[CheckRow],
 ) -> Table {
     let mut table = Table::new(name, Backend::Postgres);
     table.managed = true;
@@ -622,10 +710,30 @@ fn build_table(
         .collect();
 
     for row in columns {
-        let ty = ColumnType::from_pg_introspection(
-            &row.udt_name,
-            row.numeric_precision,
-            row.numeric_scale,
+        // Fail-closed floor for Postgres DOMAIN columns: when the column is typed
+        // on a domain (`CREATE DOMAIN email_dom AS text CHECK (…)`),
+        // `information_schema` reports the base type in `udt_name` (`text`) while
+        // naming the domain in `domain_name`. Flattening to the base type would
+        // silently drop the domain's identity and validation on recreation, so
+        // preserve the domain verbatim as `Opaque` (schema-qualified when not in
+        // `public`). `Opaque`'s `sql_type` emits `pg_type` unchanged, so the down
+        // migration re-references the still-existing domain type. A non-domain
+        // column (`domain_name` NULL) maps exactly as before.
+        let ty = row.domain_name.as_ref().map_or_else(
+            || {
+                ColumnType::from_pg_introspection(
+                    &row.udt_name,
+                    row.numeric_precision,
+                    row.numeric_scale,
+                )
+            },
+            |domain| {
+                let pg_type = match row.domain_schema.as_deref() {
+                    Some(schema) if schema != "public" => format!("{schema}.{domain}"),
+                    _ => domain.clone(),
+                };
+                ColumnType::Opaque { pg_type }
+            },
         );
         let is_pk = primary_key.iter().any(|c| c == &row.column_name);
         let mut column = Column::new(row.column_name.clone(), ty.clone());
@@ -634,15 +742,37 @@ fn build_table(
         column.unique = unique_columns.contains(row.column_name.as_str());
         column.default = normalize_default(row.column_default.as_deref(), &ty, is_pk, primary_key);
         if let Some(fk) = fk_by_column.get(row.column_name.as_str()) {
-            column.references = Some(ForeignKey::new(
-                fk.foreign_table.clone(),
-                fk.foreign_column.clone(),
-            ));
+            // Fail-closed floor for cross-schema FK targets: a FK to a table
+            // outside `public` (`REFERENCES auth.users(id)`) must be stored
+            // schema-qualified, else `render_column_def` would emit
+            // `REFERENCES users(id)` and point at the wrong (or a nonexistent)
+            // `public.users`. A `public` target stays bare (the common case,
+            // unchanged).
+            let foreign_table = if fk.foreign_schema == "public" {
+                fk.foreign_table.clone()
+            } else {
+                format!("{}.{}", fk.foreign_schema, fk.foreign_table)
+            };
+            column.references = Some(ForeignKey::new(foreign_table, fk.foreign_column.clone()));
         }
         table.columns.push(column);
     }
 
     table.indexes = ir_indexes;
+
+    // Preserve real `CHECK` constraints (Fix 4): recording them faithfully so a
+    // pull never silently drops a `CHECK (price >= 0)`. The definition is stripped
+    // to the inner predicate the emitter re-wraps in `CHECK (...)`. Snapshot
+    // canonicalization sorts checks by name, so no explicit ordering is needed
+    // here (the query already orders by `conname`).
+    table.checks = checks
+        .iter()
+        .map(|c| CheckConstraint {
+            name: Some(c.constraint_name.clone()),
+            expression: strip_check_wrapper(&c.definition),
+        })
+        .collect();
+
     table
 }
 
@@ -1328,6 +1458,8 @@ mod tests {
                 column_default: Some("nextval('comments_id_seq'::regclass)".to_owned()),
                 numeric_precision: None,
                 numeric_scale: None,
+                domain_name: None,
+                domain_schema: None,
             },
             ColumnRow {
                 table_name: "comments".to_owned(),
@@ -1337,6 +1469,8 @@ mod tests {
                 column_default: None,
                 numeric_precision: None,
                 numeric_scale: None,
+                domain_name: None,
+                domain_schema: None,
             },
         ];
         let pk = vec!["id".to_owned()];
@@ -1353,9 +1487,10 @@ mod tests {
             table_name: "comments".to_owned(),
             column_name: "post_id".to_owned(),
             foreign_table: "posts".to_owned(),
+            foreign_schema: "public".to_owned(),
             foreign_column: "id".to_owned(),
         }];
-        let table = build_table("comments", &columns, &pk, &indexes, &fks);
+        let table = build_table("comments", &columns, &pk, &indexes, &fks, &[]);
         assert_eq!(table.name, "comments");
         assert!(table.managed);
         assert_eq!(table.primary_key, vec!["id".to_owned()]);
@@ -1383,8 +1518,10 @@ mod tests {
             column_default: None,
             numeric_precision: None,
             numeric_scale: None,
+            domain_name: None,
+            domain_schema: None,
         }];
-        let table = build_table("widgets", &columns, &[], &[], &[]);
+        let table = build_table("widgets", &columns, &[], &[], &[], &[]);
         let addr = table.columns.iter().find(|c| c.name == "addr").unwrap();
         assert_eq!(
             addr.ty,
@@ -1393,5 +1530,203 @@ mod tests {
             }
         );
         assert!(addr.nullable);
+    }
+
+    #[test]
+    fn build_table_preserves_domain_column_as_opaque() {
+        // A column typed on a Postgres DOMAIN reports its base type in `udt_name`
+        // (`text`) but names the domain in `domain_name`. The fail-closed floor
+        // must preserve the domain verbatim as `Opaque`, NOT flatten to `Text`.
+        let columns = vec![
+            ColumnRow {
+                table_name: "contacts".to_owned(),
+                column_name: "email".to_owned(),
+                udt_name: "text".to_owned(),
+                is_nullable: "NO".to_owned(),
+                column_default: None,
+                numeric_precision: None,
+                numeric_scale: None,
+                domain_name: Some("email_dom".to_owned()),
+                domain_schema: Some("public".to_owned()),
+            },
+            // A non-domain column (`domain_name` NULL) maps exactly as before.
+            ColumnRow {
+                table_name: "contacts".to_owned(),
+                column_name: "note".to_owned(),
+                udt_name: "text".to_owned(),
+                is_nullable: "YES".to_owned(),
+                column_default: None,
+                numeric_precision: None,
+                numeric_scale: None,
+                domain_name: None,
+                domain_schema: None,
+            },
+        ];
+        let table = build_table("contacts", &columns, &[], &[], &[], &[]);
+        let email = table.columns.iter().find(|c| c.name == "email").unwrap();
+        assert_eq!(
+            email.ty,
+            ColumnType::Opaque {
+                pg_type: "email_dom".to_owned()
+            },
+            "a public-schema domain column preserves the bare domain name as Opaque"
+        );
+        let note = table.columns.iter().find(|c| c.name == "note").unwrap();
+        assert_eq!(
+            note.ty,
+            ColumnType::Text,
+            "a non-domain text column maps to Text unchanged"
+        );
+    }
+
+    #[test]
+    fn build_table_qualifies_non_public_domain_column() {
+        // A domain in a non-`public` schema is schema-qualified so recreation
+        // references the correct domain type.
+        let columns = vec![ColumnRow {
+            table_name: "contacts".to_owned(),
+            column_name: "email".to_owned(),
+            udt_name: "text".to_owned(),
+            is_nullable: "NO".to_owned(),
+            column_default: None,
+            numeric_precision: None,
+            numeric_scale: None,
+            domain_name: Some("email_dom".to_owned()),
+            domain_schema: Some("otherschema".to_owned()),
+        }];
+        let table = build_table("contacts", &columns, &[], &[], &[], &[]);
+        let email = table.columns.iter().find(|c| c.name == "email").unwrap();
+        assert_eq!(
+            email.ty,
+            ColumnType::Opaque {
+                pg_type: "otherschema.email_dom".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn build_table_qualifies_non_public_fk_target() {
+        // A FK referencing a table outside `public` is stored schema-qualified in
+        // `ForeignKey.table` so recreation emits `REFERENCES auth.users(id)`, not
+        // a wrong bare `REFERENCES users(id)`.
+        let columns = vec![ColumnRow {
+            table_name: "sessions".to_owned(),
+            column_name: "account_id".to_owned(),
+            udt_name: "int8".to_owned(),
+            is_nullable: "YES".to_owned(),
+            column_default: None,
+            numeric_precision: None,
+            numeric_scale: None,
+            domain_name: None,
+            domain_schema: None,
+        }];
+        let fks = vec![ForeignKeyRow {
+            table_name: "sessions".to_owned(),
+            column_name: "account_id".to_owned(),
+            foreign_table: "accounts".to_owned(),
+            foreign_schema: "auth".to_owned(),
+            foreign_column: "id".to_owned(),
+        }];
+        let table = build_table("sessions", &columns, &[], &[], &fks, &[]);
+        let account_id = table
+            .columns
+            .iter()
+            .find(|c| c.name == "account_id")
+            .unwrap();
+        assert_eq!(
+            account_id.references,
+            Some(ForeignKey::new("auth.accounts", "id")),
+            "a cross-schema FK target is stored schema-qualified"
+        );
+    }
+
+    #[test]
+    fn build_table_keeps_public_fk_target_bare() {
+        // The common case — a FK to a `public` table — stays a bare relname.
+        let columns = vec![ColumnRow {
+            table_name: "comments".to_owned(),
+            column_name: "post_id".to_owned(),
+            udt_name: "int8".to_owned(),
+            is_nullable: "YES".to_owned(),
+            column_default: None,
+            numeric_precision: None,
+            numeric_scale: None,
+            domain_name: None,
+            domain_schema: None,
+        }];
+        let fks = vec![ForeignKeyRow {
+            table_name: "comments".to_owned(),
+            column_name: "post_id".to_owned(),
+            foreign_table: "posts".to_owned(),
+            foreign_schema: "public".to_owned(),
+            foreign_column: "id".to_owned(),
+        }];
+        let table = build_table("comments", &columns, &[], &[], &fks, &[]);
+        let post_id = table.columns.iter().find(|c| c.name == "post_id").unwrap();
+        assert_eq!(
+            post_id.references,
+            Some(ForeignKey::new("posts", "id")),
+            "a public FK target stays bare, unchanged"
+        );
+    }
+
+    #[test]
+    fn build_table_populates_check_constraints() {
+        // A fetched CHECK row is preserved as a named CheckConstraint whose
+        // expression is stripped to the inner predicate the emitter re-wraps.
+        let columns = vec![ColumnRow {
+            table_name: "products".to_owned(),
+            column_name: "price".to_owned(),
+            udt_name: "int4".to_owned(),
+            is_nullable: "NO".to_owned(),
+            column_default: None,
+            numeric_precision: None,
+            numeric_scale: None,
+            domain_name: None,
+            domain_schema: None,
+        }];
+        let checks = vec![CheckRow {
+            table_name: "products".to_owned(),
+            constraint_name: "products_price_check".to_owned(),
+            definition: "CHECK ((price >= 0))".to_owned(),
+        }];
+        let table = build_table("products", &columns, &[], &[], &[], &checks);
+        assert_eq!(table.checks.len(), 1);
+        assert_eq!(
+            table.checks[0].name.as_deref(),
+            Some("products_price_check")
+        );
+        assert_eq!(table.checks[0].expression, "(price >= 0)");
+    }
+
+    #[test]
+    fn build_table_without_checks_is_empty() {
+        let columns = vec![ColumnRow {
+            table_name: "products".to_owned(),
+            column_name: "price".to_owned(),
+            udt_name: "int4".to_owned(),
+            is_nullable: "NO".to_owned(),
+            column_default: None,
+            numeric_precision: None,
+            numeric_scale: None,
+            domain_name: None,
+            domain_schema: None,
+        }];
+        let table = build_table("products", &columns, &[], &[], &[], &[]);
+        assert!(
+            table.checks.is_empty(),
+            "a table with no CHECK rows has empty checks (unchanged)"
+        );
+    }
+
+    #[test]
+    fn strip_check_wrapper_unwraps_pg_constraintdef() {
+        assert_eq!(strip_check_wrapper("CHECK ((price >= 0))"), "(price >= 0)");
+        assert_eq!(
+            strip_check_wrapper("CHECK (status IN ('a','b'))"),
+            "status IN ('a','b')"
+        );
+        // A shape that doesn't match is returned trimmed verbatim (never dropped).
+        assert_eq!(strip_check_wrapper("price >= 0"), "price >= 0");
     }
 }

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -75,6 +75,21 @@
 //!   index, never a failure. Full constraint↔index reconciliation is deferred;
 //!   the load-bearing property this slice guarantees is only that the generated
 //!   migration no longer *fails* with a rejected `DROP INDEX`.
+//! - **Cascade-dropped retained indexes on a dropped column**: when a model
+//!   removes a column that a retained (`definition`-carrying) expression / partial
+//!   / constraint-owned index depends on, Postgres cascade-drops that index with
+//!   the `ALTER TABLE … DROP COLUMN` (the up path emits no `DROP INDEX`). The
+//!   snapshot projection prunes it to match (so `doctor` / `pull --dry-run` do not
+//!   false-drift) and the down migration recreates it from its verbatim
+//!   `definition`. Two nuances are deferred: **(i)** a cascade-removed brownfield
+//!   `UNIQUE`/`EXCLUDE` *constraint* is restored on rollback as a unique *index*
+//!   (via its `pg_get_indexdef` definition), not as the original named
+//!   `CONSTRAINT` — functional uniqueness is preserved, exact constraint-object
+//!   reconstruction is deferred; **(ii)** whether a column is *depended on* by an
+//!   expression index is detected best-effort — `columns` membership plus a
+//!   word-bounded token match of the column name in the `definition` text (so
+//!   `email` matches `lower(email)` but not `emailer`), not a full parse of the
+//!   index expression.
 //!
 //! Errors are **credential-safe** by construction: no variant ever embeds the
 //! resolved database URL (only a parsed host/port on the connection-error path,

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -40,6 +40,14 @@
 //!   single-column indexes (exact here), so this affects only hand-authored
 //!   multi-column indexes; recording them faithfully but with attnum ordering is
 //!   preferred over dropping them.
+//! - **Operator classes / collations / ordering on *simple* indexes**: a plain
+//!   column index with a non-default operator class, collation, or `ASC`/`DESC`
+//!   ordering is still recorded by its columns (matching what the model parser
+//!   emits), so those attributes are not separately normalized. Expression and
+//!   partial indexes do not share this gap — they round-trip verbatim through
+//!   [`pg_get_indexdef`](https://www.postgresql.org/docs/current/functions-info.html)
+//!   (see [`Index::definition`]), so their operator classes/collations/ordering
+//!   are preserved exactly.
 //! - **Composite / multi-column foreign keys**: only the first
 //!   referencing/referenced column pair is recorded (the IR [`ForeignKey`] is
 //!   single-column). The model parser never emits a composite FK.
@@ -172,6 +180,12 @@ struct TablePkRow {
     ord: i32,
 }
 
+/// One row per non-primary index (never one-per-column, so an expression index —
+/// whose `indkey` carries a `0` with no matching `pg_attribute` row — is never
+/// dropped). `columns` is a comma-joined list of the *resolvable* ordinary
+/// columns (the `indkey` entries `> 0`) in true key order; it is empty for an
+/// index whose keys are all expressions. `definition` is the verbatim
+/// `pg_get_indexdef` statement, preserved for expression/partial indexes.
 #[derive(QueryableByName)]
 struct IndexRow {
     #[diesel(sql_type = diesel::sql_types::Text)]
@@ -180,10 +194,18 @@ struct IndexRow {
     index_name: String,
     #[diesel(sql_type = diesel::sql_types::Bool)]
     is_unique: bool,
+    /// The full `CREATE [UNIQUE] INDEX …` statement (no trailing `;`).
     #[diesel(sql_type = diesel::sql_types::Text)]
-    column_name: String,
-    #[diesel(sql_type = diesel::sql_types::SmallInt)]
-    attnum: i16,
+    definition: String,
+    /// Whether the index has a `WHERE` predicate (`indpred IS NOT NULL`).
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    is_partial: bool,
+    /// Whether any key column is an expression (an `indkey` entry equal to `0`).
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    has_expression: bool,
+    /// Comma-joined resolvable ordinary column names, in key order (may be empty).
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    columns: String,
 }
 
 #[derive(QueryableByName)]
@@ -316,23 +338,40 @@ fn fetch_primary_keys(
 }
 
 /// Fetch every non-primary index (unique and plain) for all `tables`, grouped by
-/// table. One row per (index, column); the builder collapses them into
-/// [`Index`]es. Composite index columns are ordered by `attnum` (see the module
-/// blind-spot note).
+/// table. **One row per index** (never one-per-column), so an **expression
+/// index** — whose `indkey` contains a `0` for the expression column with no
+/// matching `pg_attribute` row — is preserved rather than dropped by an inner
+/// join that returns nothing for it. The resolvable ordinary columns are
+/// aggregated in true key order via a correlated `unnest(indkey) WITH
+/// ORDINALITY` subquery; `has_expression` flags any `0` key and `is_partial`
+/// flags an `indpred`, so the builder can classify each index as
+/// simple-representable vs. preserved-verbatim.
 fn fetch_indexes(
     conn: &mut PgConnection,
     tables: &[String],
 ) -> Result<BTreeMap<String, Vec<IndexRow>>, IntrospectError> {
+    // The `int2vector -> text -> int[]` cast chain (mirroring `fetch_primary_keys`)
+    // turns `indkey` into a subscriptable/unnestable array. The correlated
+    // subquery keeps only `> 0` (ordinary-column) keys and preserves key order
+    // via `WITH ORDINALITY`; an all-expression index yields an empty string.
     let query = format!(
         "SELECT t.relname AS table_name, ic.relname AS index_name, \
-         i.indisunique AS is_unique, a.attname AS column_name, a.attnum AS attnum \
+         i.indisunique AS is_unique, pg_get_indexdef(i.indexrelid) AS definition, \
+         (i.indpred IS NOT NULL) AS is_partial, \
+         (0 = ANY(string_to_array(i.indkey::text, ' ')::int[])) AS has_expression, \
+         COALESCE(( \
+           SELECT string_agg(a.attname, ',' ORDER BY k.ord) \
+           FROM unnest(string_to_array(i.indkey::text, ' ')::int[]) \
+                WITH ORDINALITY AS k(attnum, ord) \
+           JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = k.attnum \
+           WHERE k.attnum > 0 \
+         ), '') AS columns \
          FROM pg_index i \
          JOIN pg_class t ON t.oid = i.indrelid \
          JOIN pg_class ic ON ic.oid = i.indexrelid \
          JOIN pg_namespace n ON n.oid = t.relnamespace \
-         JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) \
          WHERE n.nspname = 'public' AND NOT i.indisprimary AND t.relname IN ({}) \
-         ORDER BY t.relname, ic.relname, a.attnum",
+         ORDER BY t.relname, ic.relname",
         quoted_in_list(tables)
     );
     let rows: Vec<IndexRow> = sql_query(query)
@@ -432,36 +471,51 @@ fn build_table(
     table
 }
 
-/// Collapse per-(index, column) rows into IR [`Index`]es plus the set of columns
-/// that are covered by a **single-column unique** index (used to set the column
-/// `unique` flag, matching how the model parser represents `#[unique]`).
+/// Map one-per-index rows into IR [`Index`]es plus the set of columns covered by
+/// a **single-column simple unique** index (used to set the column `unique` flag,
+/// matching how the model parser represents `#[unique]`).
+///
+/// Each index is classified:
+/// - **simple/representable** — NOT partial AND has no expression key — is built
+///   as `Index { columns, unique, definition: None }` exactly as before, so a
+///   simple index's serialized JSON is byte-identical to prior snapshots and a
+///   single-column simple unique index still sets the owning column's `unique`
+///   flag for model-parser round-trip parity.
+/// - **expression or partial** — preserved verbatim via `definition:
+///   Some(pg_get_indexdef(...))`, never dropped. Its resolvable columns (if any)
+///   are still recorded for display, but it never sets a column `unique` flag
+///   (there is no single representable column).
 fn collapse_indexes(rows: &[IndexRow]) -> (Vec<Index>, std::collections::BTreeSet<String>) {
-    // Preserve first-seen index order while grouping columns.
-    let mut order: Vec<String> = Vec::new();
-    let mut grouped: BTreeMap<String, (bool, Vec<(i16, String)>)> = BTreeMap::new();
-    for row in rows {
-        let entry = grouped.entry(row.index_name.clone()).or_insert_with(|| {
-            order.push(row.index_name.clone());
-            (row.is_unique, Vec::new())
-        });
-        entry.0 = row.is_unique;
-        entry.1.push((row.attnum, row.column_name.clone()));
-    }
-
-    let mut indexes = Vec::with_capacity(order.len());
+    let mut indexes = Vec::with_capacity(rows.len());
     let mut unique_columns = std::collections::BTreeSet::new();
-    for name in order {
-        let (unique, mut cols) = grouped.remove(&name).expect("grouped index present");
-        cols.sort_by_key(|(attnum, _)| *attnum);
-        let columns: Vec<String> = cols.into_iter().map(|(_, c)| c).collect();
-        if unique && columns.len() == 1 {
-            unique_columns.insert(columns[0].clone());
+    for row in rows {
+        let columns: Vec<String> = row
+            .columns
+            .split(',')
+            .filter(|c| !c.is_empty())
+            .map(str::to_owned)
+            .collect();
+        let simple = !row.is_partial && !row.has_expression;
+        if simple {
+            if row.is_unique && columns.len() == 1 {
+                unique_columns.insert(columns[0].clone());
+            }
+            indexes.push(Index {
+                name: row.index_name.clone(),
+                columns,
+                unique: row.is_unique,
+                definition: None,
+            });
+        } else {
+            // Expression/partial index: preserve its canonical statement so it is
+            // never dropped and diffs by its verbatim text.
+            indexes.push(Index {
+                name: row.index_name.clone(),
+                columns,
+                unique: row.is_unique,
+                definition: Some(row.definition.clone()),
+            });
         }
-        indexes.push(Index {
-            name,
-            columns,
-            unique,
-        });
     }
     (indexes, unique_columns)
 }
@@ -613,35 +667,61 @@ mod tests {
         assert_eq!(d, Some(ColumnDefault::Sql("gen_random_uuid()".to_owned())));
     }
 
+    /// Build a one-per-index [`IndexRow`] for tests. `columns` is the comma-joined
+    /// resolvable-column string the SQL aggregation produces.
+    fn index_row(
+        index_name: &str,
+        is_unique: bool,
+        columns: &str,
+        is_partial: bool,
+        has_expression: bool,
+        definition: &str,
+    ) -> IndexRow {
+        IndexRow {
+            table_name: "t".to_owned(),
+            index_name: index_name.to_owned(),
+            is_unique,
+            definition: definition.to_owned(),
+            is_partial,
+            has_expression,
+            columns: columns.to_owned(),
+        }
+    }
+
     #[test]
     fn collapse_indexes_single_column_unique_sets_flag_and_index() {
-        let rows = vec![IndexRow {
-            table_name: "accounts".to_owned(),
-            index_name: "idx_accounts_email_unique".to_owned(),
-            is_unique: true,
-            column_name: "email".to_owned(),
-            attnum: 2,
-        }];
+        let rows = vec![index_row(
+            "idx_accounts_email_unique",
+            true,
+            "email",
+            false,
+            false,
+            "CREATE UNIQUE INDEX idx_accounts_email_unique ON public.accounts USING btree (email)",
+        )];
         let (indexes, unique_cols) = collapse_indexes(&rows);
         assert_eq!(indexes.len(), 1);
         assert_eq!(indexes[0].name, "idx_accounts_email_unique");
         assert_eq!(indexes[0].columns, vec!["email".to_owned()]);
         assert!(indexes[0].unique);
+        // A simple index keeps `definition` None so its JSON is unchanged.
+        assert_eq!(indexes[0].definition, None);
         assert!(unique_cols.contains("email"));
     }
 
     #[test]
     fn collapse_indexes_plain_index_no_unique_flag() {
-        let rows = vec![IndexRow {
-            table_name: "comments".to_owned(),
-            index_name: "idx_comments_post_id".to_owned(),
-            is_unique: false,
-            column_name: "post_id".to_owned(),
-            attnum: 2,
-        }];
+        let rows = vec![index_row(
+            "idx_comments_post_id",
+            false,
+            "post_id",
+            false,
+            false,
+            "CREATE INDEX idx_comments_post_id ON public.comments USING btree (post_id)",
+        )];
         let (indexes, unique_cols) = collapse_indexes(&rows);
         assert_eq!(indexes.len(), 1);
         assert!(!indexes[0].unique);
+        assert_eq!(indexes[0].definition, None);
         assert!(unique_cols.is_empty());
     }
 
@@ -649,22 +729,14 @@ mod tests {
     fn collapse_indexes_multi_column_unique_only_index_not_column_flag() {
         // A composite unique index records an Index but does NOT set a per-column
         // unique flag (the model IR's `unique` flag is single-column only).
-        let rows = vec![
-            IndexRow {
-                table_name: "memberships".to_owned(),
-                index_name: "idx_memberships_org_user".to_owned(),
-                is_unique: true,
-                column_name: "org_id".to_owned(),
-                attnum: 2,
-            },
-            IndexRow {
-                table_name: "memberships".to_owned(),
-                index_name: "idx_memberships_org_user".to_owned(),
-                is_unique: true,
-                column_name: "user_id".to_owned(),
-                attnum: 3,
-            },
-        ];
+        let rows = vec![index_row(
+            "idx_memberships_org_user",
+            true,
+            "org_id,user_id",
+            false,
+            false,
+            "CREATE UNIQUE INDEX idx_memberships_org_user ON public.memberships USING btree (org_id, user_id)",
+        )];
         let (indexes, unique_cols) = collapse_indexes(&rows);
         assert_eq!(indexes.len(), 1);
         assert_eq!(
@@ -672,9 +744,56 @@ mod tests {
             vec!["org_id".to_owned(), "user_id".to_owned()]
         );
         assert!(indexes[0].unique);
+        assert_eq!(indexes[0].definition, None);
         assert!(
             unique_cols.is_empty(),
             "composite unique sets no column flag"
+        );
+    }
+
+    #[test]
+    fn collapse_indexes_expression_index_preserved_not_dropped() {
+        // An expression index (indkey contains 0 → has_expression) must be
+        // preserved verbatim via `definition`, never dropped, and must not set a
+        // column `unique` flag.
+        let def = "CREATE INDEX users_lower_email_idx ON public.users USING btree (lower(email))";
+        let rows = vec![index_row(
+            "users_lower_email_idx",
+            false,
+            "", // no resolvable ordinary columns
+            false,
+            true,
+            def,
+        )];
+        let (indexes, unique_cols) = collapse_indexes(&rows);
+        assert_eq!(indexes.len(), 1, "expression index preserved, not dropped");
+        assert_eq!(indexes[0].name, "users_lower_email_idx");
+        assert!(indexes[0].columns.is_empty());
+        assert_eq!(indexes[0].definition.as_deref(), Some(def));
+        assert!(unique_cols.is_empty());
+    }
+
+    #[test]
+    fn collapse_indexes_partial_index_preserves_predicate() {
+        // A partial index over a real column keeps its `WHERE` predicate via the
+        // verbatim definition rather than degrading to a plain column index.
+        let def = "CREATE INDEX users_active_idx ON public.users USING btree (email) \
+                   WHERE (deleted_at IS NULL)";
+        let rows = vec![index_row(
+            "users_active_idx",
+            false,
+            "email",
+            true,
+            false,
+            def,
+        )];
+        let (indexes, unique_cols) = collapse_indexes(&rows);
+        assert_eq!(indexes.len(), 1);
+        assert_eq!(indexes[0].columns, vec!["email".to_owned()]);
+        assert_eq!(indexes[0].definition.as_deref(), Some(def));
+        assert!(
+            unique_cols.is_empty(),
+            "partial index sets no column unique flag"
         );
     }
 
@@ -701,13 +820,14 @@ mod tests {
             },
         ];
         let pk = vec!["id".to_owned()];
-        let indexes = vec![IndexRow {
-            table_name: "comments".to_owned(),
-            index_name: "idx_comments_post_id".to_owned(),
-            is_unique: false,
-            column_name: "post_id".to_owned(),
-            attnum: 2,
-        }];
+        let indexes = vec![index_row(
+            "idx_comments_post_id",
+            false,
+            "post_id",
+            false,
+            false,
+            "CREATE INDEX idx_comments_post_id ON public.comments USING btree (post_id)",
+        )];
         let fks = vec![ForeignKeyRow {
             table_name: "comments".to_owned(),
             column_name: "post_id".to_owned(),

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -77,13 +77,18 @@
 //!   definition (`pg_get_indexdef`, a valid `CREATE UNIQUE INDEX …`), not by the
 //!   originating `ALTER TABLE … ADD CONSTRAINT`. So if the authoritative path
 //!   (`pull --dry-run`) ever rendered a recreation it would emit the
-//!   `CREATE UNIQUE INDEX` form rather than re-adding the constraint; and a model
-//!   that *also* declares `#[unique]` on a column already covered by a brownfield
-//!   `UNIQUE` constraint additively creates the model's own
-//!   `idx_<table>_<col>_unique` index — a redundant-but-valid second unique
-//!   index, never a failure. Full constraint↔index reconciliation is deferred;
-//!   the load-bearing property this slice guarantees is only that the generated
-//!   migration no longer *fails* with a rejected `DROP INDEX`.
+//!   `CREATE UNIQUE INDEX` form rather than re-adding the constraint. A model that
+//!   *also* declares `#[unique]` on a column already covered by a brownfield
+//!   `UNIQUE` constraint is now **recognized as satisfied** by the existing unique
+//!   index: `diff_indexes` (model-diff path) treats a desired unique index whose
+//!   exact column set is already enforced by any baseline `unique` index — including
+//!   the retained constraint index — as fulfilled, so it emits **no** redundant
+//!   `AddIndex` (and no `DropIndex`), and the plan is clean rather than tripping
+//!   `guard_plan`'s unique-index dedup refusal. (This resolves the earlier
+//!   "additively creates a redundant `idx_<table>_<col>_unique` index" caveat.)
+//!   Full constraint↔index reconciliation is otherwise deferred; the load-bearing
+//!   property this slice guarantees is only that the generated migration no longer
+//!   *fails* with a rejected `DROP INDEX`.
 //! - **Cascade-dropped retained indexes on a dropped column**: when a model
 //!   removes a column that a retained (`definition`-carrying) expression / partial
 //!   / constraint-owned index depends on, Postgres cascade-drops that index with

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -54,6 +54,15 @@
 //!   [`pg_get_indexdef`](https://www.postgresql.org/docs/current/functions-info.html)
 //!   (see [`Index::definition`]), so their operator classes/collations/ordering
 //!   are preserved exactly.
+//! - **Covering (`INCLUDE`) indexes are retained by definition**: a covering
+//!   index (`CREATE UNIQUE INDEX idx ON t (a) INCLUDE (b)`, detected via
+//!   `pg_index.indnkeyatts < indnatts`) is *not* a simple droppable index — its
+//!   uniqueness scope is only the KEY column(s) `(a)`, but the `indkey`-derived
+//!   column list mixes key and `INCLUDE` columns indistinguishably, and the model
+//!   DSL cannot express the split. It is retained verbatim via
+//!   [`Index::definition`] (like an expression/partial/constraint index) rather
+//!   than rebuilt as a scope-widening `(a, b)` unique index, and never sets a
+//!   single-column `unique` flag. See [`collapse_indexes`].
 //! - **Composite / multi-column foreign keys**: only the first
 //!   referencing/referenced column pair is recorded (the IR [`ForeignKey`] is
 //!   single-column). The model parser never emits a composite FK.
@@ -242,6 +251,14 @@ struct IndexRow {
     /// Whether any key column is an expression (an `indkey` entry equal to `0`).
     #[diesel(sql_type = diesel::sql_types::Bool)]
     has_expression: bool,
+    /// Whether the index is a *covering* index — i.e. it carries non-key
+    /// `INCLUDE` columns (`pg_index.indnkeyatts < indnatts`). Such an index's
+    /// uniqueness scope is only its KEY columns, but its `indkey`-derived
+    /// `columns` list mixes key and INCLUDE columns indistinguishably, so it is
+    /// not expressible by the model DSL and must be retained verbatim via its
+    /// `definition` (never rebuilt as a plain `(key, include)` unique index).
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    has_include: bool,
     /// Whether the index backs a constraint (`pg_constraint.conindid` points at
     /// it) — true for UNIQUE/EXCLUDE (and PK, but PKs are already filtered out).
     /// Such an index cannot be dropped independently of its constraint, and the
@@ -424,6 +441,7 @@ fn fetch_indexes(
          i.indisunique AS is_unique, pg_get_indexdef(i.indexrelid) AS definition, \
          (i.indpred IS NOT NULL) AS is_partial, \
          (0 = ANY(string_to_array(i.indkey::text, ' ')::int[])) AS has_expression, \
+         (i.indnkeyatts < i.indnatts) AS has_include, \
          EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conindid = i.indexrelid) AS is_constraint, \
          COALESCE(( \
            SELECT string_agg(a.attname, ',' ORDER BY k.ord) \
@@ -567,8 +585,15 @@ fn build_table(
 ///   prior snapshots and a single-column plain unique index (the model-DSL
 ///   `#[unique]` shape, a bare `CREATE UNIQUE INDEX` with no backing constraint)
 ///   still sets the owning column's `unique` flag for round-trip parity.
-/// - **expression, partial, or constraint-owned** — preserved verbatim via
-///   `definition: Some(pg_get_indexdef(...))`, never dropped. A constraint-owned
+/// - **expression, partial, covering (`INCLUDE`), or constraint-owned** —
+///   preserved verbatim via
+///   `definition: Some(pg_get_indexdef(...))`, never dropped. A covering
+///   `INCLUDE` index (`indnkeyatts < indnatts`) is retained because its
+///   uniqueness scope is only its KEY columns while the model DSL cannot
+///   distinguish key from `INCLUDE` columns — rebuilding it as a plain
+///   `(key, include)` unique index would silently widen the uniqueness scope and
+///   drop the covering behavior, so it never sets a single-column `unique` flag.
+///   A constraint-owned
 ///   index (a brownfield column/table-level `UNIQUE`/`EXCLUDE`, which auto-creates
 ///   a `pg_constraint`-backed index Postgres refuses to drop independently, and
 ///   which the declarative model DSL cannot express) is retained just like an
@@ -587,18 +612,23 @@ fn collapse_indexes(rows: &[IndexRow]) -> (Vec<Index>, std::collections::BTreeSe
             .map(str::to_owned)
             .collect();
         // "Simple" == a single representable column set (not partial, not an
-        // expression). A single-column simple unique index sets the owning
-        // column's `unique` flag whether or not it backs a constraint (the flag
-        // is accurate either way and is never diffed).
-        let simple = !row.is_partial && !row.has_expression;
+        // expression, and NOT a covering `INCLUDE` index — whose key/INCLUDE
+        // columns are indistinguishable in the `indkey`-derived list). A
+        // single-column simple unique index sets the owning column's `unique`
+        // flag whether or not it backs a constraint (the flag is accurate either
+        // way and is never diffed). A covering `INCLUDE` unique index is NOT
+        // simple, so it never sets that flag (its uniqueness scope is only its
+        // key columns) and is retained verbatim via its `definition`.
+        let simple = !row.is_partial && !row.has_expression && !row.has_include;
         if simple && row.is_unique && key_columns.len() == 1 {
             unique_columns.insert(key_columns[0].clone());
         }
         // Retain (preserve verbatim, never drop) any index the model DSL cannot
-        // express: an expression or partial index, OR a constraint-owned index
-        // (UNIQUE/EXCLUDE) whose backing constraint Postgres won't let us drop.
-        // A plain, non-constraint index keeps `definition: None` so its JSON is
-        // unchanged and the model round-trip stays clean.
+        // express: an expression, partial, or covering `INCLUDE` index, OR a
+        // constraint-owned index (UNIQUE/EXCLUDE) whose backing constraint
+        // Postgres won't let us drop. A plain, non-constraint index keeps
+        // `definition: None` so its JSON is unchanged and the model round-trip
+        // stays clean.
         //
         // For a SIMPLE index `Index.columns` stays the ordered key columns (exact
         // round-trip parity; the `pg_depend` set equals the key columns anyway).
@@ -798,6 +828,7 @@ mod tests {
             definition: definition.to_owned(),
             is_partial,
             has_expression,
+            has_include: false,
             is_constraint: false,
             columns: columns.to_owned(),
             dep_columns: dep_columns.to_owned(),
@@ -995,6 +1026,40 @@ mod tests {
             "a non-constraint (model-style) unique index stays ordinary/droppable"
         );
         assert!(unique_cols.contains("email"));
+    }
+
+    #[test]
+    fn collapse_indexes_covering_include_index_retained_via_definition() {
+        // A covering index `CREATE UNIQUE INDEX ... ON t (a) INCLUDE (b)`
+        // (`has_include == true`) must be RETAINED verbatim via `definition`,
+        // never rebuilt as a plain `(a, b)` unique index (which would widen the
+        // uniqueness scope from (a) to (a, b) and drop the covering behavior). It
+        // must NOT set a single-column `unique` column flag, and `columns` carries
+        // the exact `pg_depend` dependent set (key + INCLUDE columns).
+        let def = "CREATE UNIQUE INDEX idx_cover ON public.t USING btree (a) INCLUDE (b)";
+        let rows = vec![IndexRow {
+            has_include: true,
+            ..index_row("idx_cover", true, "a,b", "a,b", false, false, def)
+        }];
+        let (indexes, unique_cols) = collapse_indexes(&rows);
+        assert_eq!(indexes.len(), 1);
+        assert_eq!(indexes[0].name, "idx_cover");
+        assert!(indexes[0].unique);
+        assert_eq!(
+            indexes[0].definition.as_deref(),
+            Some(def),
+            "an INCLUDE covering index must be retained via its definition, not left droppable"
+        );
+        assert_eq!(
+            indexes[0].columns,
+            vec!["a".to_owned(), "b".to_owned()],
+            "columns carries the exact pg_depend dependent set (key + INCLUDE)"
+        );
+        assert!(
+            unique_cols.is_empty(),
+            "an INCLUDE unique index must not set a single-column unique flag \
+             (its uniqueness scope is only the key column)"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -124,6 +124,12 @@
 //!   deferred. (An **EXCLUDE** constraint is not subject to this deferral: it is
 //!   restored as the real `ADD CONSTRAINT … EXCLUDE USING …`, per the reconciliation
 //!   note above.)
+//! - **CHECK constraint `NO INHERIT` / `NOT VALID` suffixes**: dropped on
+//!   recreation (the predicate is preserved; the suffix is not modeled).
+//! - **`GENERATED ... AS IDENTITY` columns**: pulled as ordinary integer columns
+//!   (their identity metadata from `information_schema.columns.is_identity` is not
+//!   modeled); recreation emits a plain column / loses the identity — identity
+//!   modeling is deferred alongside owned sequences.
 //!
 //! Errors are **credential-safe** by construction: no variant ever embeds the
 //! resolved database URL (only a parsed host/port on the connection-error path,
@@ -239,6 +245,13 @@ struct ColumnRow {
     numeric_precision: Option<i32>,
     #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Integer>)]
     numeric_scale: Option<i32>,
+    /// The declared length limit for a `varchar(n)` / `char(n)` column (`NULL` for
+    /// an unbounded `varchar`, `text`, or any non-character type). When set on a
+    /// non-domain `varchar`/`bpchar` column it is preserved verbatim as
+    /// [`ColumnType::Opaque`] so the DB-enforced length survives recreation rather
+    /// than being flattened to an unconstrained `TEXT`.
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Integer>)]
+    character_maximum_length: Option<i32>,
     /// The Postgres DOMAIN name backing this column, or `NULL` when the column's
     /// type is not a domain. When set, the column's type is preserved verbatim as
     /// [`ColumnType::Opaque`] (schema-qualified via `domain_schema`) so the
@@ -428,17 +441,18 @@ fn fetch_columns(
     conn: &mut PgConnection,
     tables: &[String],
 ) -> Result<BTreeMap<String, Vec<ColumnRow>>, IntrospectError> {
-    // `numeric_precision` / `numeric_scale` are the `information_schema`
-    // `cardinal_number` domain, not a plain `int4`. Decoding that domain as diesel
-    // `Nullable<Integer>` on the wire is unproven (no sibling query reads them), and
-    // if it does not present as `int4` the whole column query would error and every
-    // pull would fail. Cast both to a plain `integer` in SQL so the output type is
-    // guaranteed `int4` regardless of the domain. The `AS <name>` aliases keep the
-    // result column names aligned with the `ColumnRow` field bindings.
+    // `numeric_precision` / `numeric_scale` / `character_maximum_length` are the
+    // `information_schema` `cardinal_number` domain, not a plain `int4`. Decoding
+    // that domain as diesel `Nullable<Integer>` on the wire is unproven (no sibling
+    // query reads them), and if it does not present as `int4` the whole column query
+    // would error and every pull would fail. Cast each to a plain `integer` in SQL so
+    // the output type is guaranteed `int4` regardless of the domain. The `AS <name>`
+    // aliases keep the result column names aligned with the `ColumnRow` field bindings.
     let query = format!(
         "SELECT table_name, column_name, udt_name, is_nullable, column_default, \
          numeric_precision::integer AS numeric_precision, \
          numeric_scale::integer AS numeric_scale, \
+         character_maximum_length::integer AS character_maximum_length, \
          domain_name, domain_schema FROM information_schema.columns \
          WHERE table_schema = 'public' AND table_name IN ({}) \
          ORDER BY table_name, ordinal_position",
@@ -665,20 +679,66 @@ fn fetch_checks(
 }
 
 /// Strip a `pg_get_constraintdef` CHECK definition (`CHECK ((price >= 0))`) to the
-/// inner predicate (`price >= 0`) the emitter re-wraps in `CHECK (...)`. Removes
-/// the leading `CHECK ` keyword and exactly one balanced outer paren pair; a
-/// definition that does not match the expected shape is returned trimmed verbatim
-/// (never silently dropped).
+/// inner predicate (`price >= 0`) the emitter re-wraps in `CHECK (...)`. Removes the
+/// leading `CHECK ` keyword, then extracts **only** the span inside the FIRST
+/// balanced outer paren pair — so a trailing suffix such as `NOT VALID` or
+/// `NO INHERIT` (which `pg_get_constraintdef` appends after the predicate) is
+/// dropped rather than left inside the re-wrapped `CHECK (...)`, where it would
+/// produce syntactically invalid / semantically altered DDL on recreation. The
+/// dropped suffix is a documented deferral (see the "Deferred blind spots" note):
+/// on a recreated (dropped, empty) table a `NOT VALID` check is trivially satisfied
+/// and `NO INHERIT` only affects table inheritance, so the re-wrap stays valid and
+/// behavior-equivalent. A definition that does not match the expected `CHECK (...)`
+/// shape is returned trimmed verbatim (never silently dropped).
 fn strip_check_wrapper(definition: &str) -> String {
     let trimmed = definition.trim();
-    let inner = trimmed
+    let Some(rest) = trimmed
         .strip_prefix("CHECK ")
         .or_else(|| trimmed.strip_prefix("CHECK"))
-        .map_or(trimmed, str::trim);
-    inner
-        .strip_prefix('(')
-        .and_then(|s| s.strip_suffix(')'))
-        .map_or_else(|| inner.to_owned(), |unwrapped| unwrapped.trim().to_owned())
+        .map(str::trim_start)
+    else {
+        return trimmed.to_owned();
+    };
+    let bytes = rest.as_bytes();
+    if bytes.first() != Some(&b'(') {
+        return trimmed.to_owned();
+    }
+    // Scan the first balanced `(...)` span, tracking paren depth (ignoring parens
+    // inside single-quoted string literals, where Postgres escapes an embedded
+    // quote by doubling it). The inner predicate is everything between the outer
+    // parens; any trailing suffix after the matching close paren is discarded.
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if in_string {
+            if b == b'\'' {
+                if bytes.get(i + 1) == Some(&b'\'') {
+                    i += 2;
+                    continue;
+                }
+                in_string = false;
+            }
+        } else {
+            match b {
+                b'\'' => in_string = true,
+                b'(' => depth += 1,
+                b')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        // `rest[0]` is `(` and `rest[i]` is `)` — both ASCII, so the
+                        // slice boundaries fall on char boundaries.
+                        return rest[1..i].trim().to_owned();
+                    }
+                }
+                _ => {}
+            }
+        }
+        i += 1;
+    }
+    // Unbalanced parens — the input never matched the expected shape.
+    trimmed.to_owned()
 }
 
 // ---------------------------------------------------------------------------
@@ -725,6 +785,7 @@ fn build_table(
                     &row.udt_name,
                     row.numeric_precision,
                     row.numeric_scale,
+                    row.character_maximum_length,
                 )
             },
             |domain| {
@@ -1458,6 +1519,7 @@ mod tests {
                 column_default: Some("nextval('comments_id_seq'::regclass)".to_owned()),
                 numeric_precision: None,
                 numeric_scale: None,
+                character_maximum_length: None,
                 domain_name: None,
                 domain_schema: None,
             },
@@ -1469,6 +1531,7 @@ mod tests {
                 column_default: None,
                 numeric_precision: None,
                 numeric_scale: None,
+                character_maximum_length: None,
                 domain_name: None,
                 domain_schema: None,
             },
@@ -1518,6 +1581,7 @@ mod tests {
             column_default: None,
             numeric_precision: None,
             numeric_scale: None,
+            character_maximum_length: None,
             domain_name: None,
             domain_schema: None,
         }];
@@ -1546,6 +1610,7 @@ mod tests {
                 column_default: None,
                 numeric_precision: None,
                 numeric_scale: None,
+                character_maximum_length: None,
                 domain_name: Some("email_dom".to_owned()),
                 domain_schema: Some("public".to_owned()),
             },
@@ -1558,6 +1623,7 @@ mod tests {
                 column_default: None,
                 numeric_precision: None,
                 numeric_scale: None,
+                character_maximum_length: None,
                 domain_name: None,
                 domain_schema: None,
             },
@@ -1580,6 +1646,103 @@ mod tests {
     }
 
     #[test]
+    fn build_table_preserves_length_limited_char_columns_as_opaque() {
+        // `VARCHAR(32)` / `CHAR(2)` report `udt_name` `varchar` / `bpchar` with a
+        // `character_maximum_length`. The fail-closed floor must preserve the length
+        // verbatim as `Opaque` (`varchar(32)` / `char(2)`), NOT flatten to `Text`
+        // and drop the DB-enforced limit. Unbounded `varchar` / `text` stay `Text`.
+        let columns = vec![
+            ColumnRow {
+                table_name: "labels".to_owned(),
+                column_name: "code".to_owned(),
+                udt_name: "varchar".to_owned(),
+                is_nullable: "NO".to_owned(),
+                column_default: None,
+                numeric_precision: None,
+                numeric_scale: None,
+                character_maximum_length: Some(32),
+                domain_name: None,
+                domain_schema: None,
+            },
+            ColumnRow {
+                table_name: "labels".to_owned(),
+                column_name: "kind".to_owned(),
+                udt_name: "bpchar".to_owned(),
+                is_nullable: "NO".to_owned(),
+                column_default: None,
+                numeric_precision: None,
+                numeric_scale: None,
+                character_maximum_length: Some(2),
+                domain_name: None,
+                domain_schema: None,
+            },
+            ColumnRow {
+                table_name: "labels".to_owned(),
+                column_name: "note".to_owned(),
+                udt_name: "text".to_owned(),
+                is_nullable: "YES".to_owned(),
+                column_default: None,
+                numeric_precision: None,
+                numeric_scale: None,
+                character_maximum_length: None,
+                domain_name: None,
+                domain_schema: None,
+            },
+        ];
+        let table = build_table("labels", &columns, &[], &[], &[], &[]);
+        let code = table.columns.iter().find(|c| c.name == "code").unwrap();
+        assert_eq!(
+            code.ty,
+            ColumnType::Opaque {
+                pg_type: "varchar(32)".to_owned()
+            },
+            "VARCHAR(32) is preserved as Opaque, not flattened to Text"
+        );
+        let kind = table.columns.iter().find(|c| c.name == "kind").unwrap();
+        assert_eq!(
+            kind.ty,
+            ColumnType::Opaque {
+                pg_type: "char(2)".to_owned()
+            },
+            "CHAR(2) is preserved as Opaque, not flattened to Text"
+        );
+        let note = table.columns.iter().find(|c| c.name == "note").unwrap();
+        assert_eq!(
+            note.ty,
+            ColumnType::Text,
+            "an unbounded text column stays Text"
+        );
+    }
+
+    #[test]
+    fn build_table_domain_precedence_over_length_floor() {
+        // A domain column reports its base type (e.g. `varchar`) in `udt_name` and
+        // can carry a `character_maximum_length`, but the domain floor must win:
+        // the column is preserved as the domain type, not `varchar(n)`.
+        let columns = vec![ColumnRow {
+            table_name: "labels".to_owned(),
+            column_name: "code".to_owned(),
+            udt_name: "varchar".to_owned(),
+            is_nullable: "NO".to_owned(),
+            column_default: None,
+            numeric_precision: None,
+            numeric_scale: None,
+            character_maximum_length: Some(32),
+            domain_name: Some("code_dom".to_owned()),
+            domain_schema: Some("public".to_owned()),
+        }];
+        let table = build_table("labels", &columns, &[], &[], &[], &[]);
+        let code = table.columns.iter().find(|c| c.name == "code").unwrap();
+        assert_eq!(
+            code.ty,
+            ColumnType::Opaque {
+                pg_type: "code_dom".to_owned()
+            },
+            "the domain floor takes precedence over the length floor"
+        );
+    }
+
+    #[test]
     fn build_table_qualifies_non_public_domain_column() {
         // A domain in a non-`public` schema is schema-qualified so recreation
         // references the correct domain type.
@@ -1591,6 +1754,7 @@ mod tests {
             column_default: None,
             numeric_precision: None,
             numeric_scale: None,
+            character_maximum_length: None,
             domain_name: Some("email_dom".to_owned()),
             domain_schema: Some("otherschema".to_owned()),
         }];
@@ -1617,6 +1781,7 @@ mod tests {
             column_default: None,
             numeric_precision: None,
             numeric_scale: None,
+            character_maximum_length: None,
             domain_name: None,
             domain_schema: None,
         }];
@@ -1651,6 +1816,7 @@ mod tests {
             column_default: None,
             numeric_precision: None,
             numeric_scale: None,
+            character_maximum_length: None,
             domain_name: None,
             domain_schema: None,
         }];
@@ -1682,6 +1848,7 @@ mod tests {
             column_default: None,
             numeric_precision: None,
             numeric_scale: None,
+            character_maximum_length: None,
             domain_name: None,
             domain_schema: None,
         }];
@@ -1709,6 +1876,7 @@ mod tests {
             column_default: None,
             numeric_precision: None,
             numeric_scale: None,
+            character_maximum_length: None,
             domain_name: None,
             domain_schema: None,
         }];
@@ -1728,5 +1896,24 @@ mod tests {
         );
         // A shape that doesn't match is returned trimmed verbatim (never dropped).
         assert_eq!(strip_check_wrapper("price >= 0"), "price >= 0");
+    }
+
+    #[test]
+    fn strip_check_wrapper_drops_trailing_suffixes() {
+        // `pg_get_constraintdef` can append `NOT VALID` / `NO INHERIT` after the
+        // predicate; the suffix must be dropped so the emitter's `CHECK ({expr})`
+        // re-wrap stays valid — never left inside the parens.
+        assert_eq!(
+            strip_check_wrapper("CHECK ((price >= 0)) NOT VALID"),
+            "(price >= 0)"
+        );
+        assert_eq!(strip_check_wrapper("CHECK (x > 0) NO INHERIT"), "x > 0");
+        // No suffix → unchanged.
+        assert_eq!(strip_check_wrapper("CHECK (a = 1)"), "a = 1");
+        // A paren inside a string literal never miscounts the balanced span.
+        assert_eq!(
+            strip_check_wrapper("CHECK (label <> ')') NOT VALID"),
+            "label <> ')'"
+        );
     }
 }

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -16,9 +16,13 @@
 //!   Postgres type as [`ColumnType::Opaque`] rather than dropping the column —
 //!   introspection never silently loses a column.
 //! - **Serial/UUID PK round-trip**: a single-column integer PK whose default is a
-//!   `nextval(...)` sequence is a `BIGSERIAL`-shaped id, which the model IR
-//!   represents as an [`Int64`](ColumnType::Int64) PK with **no** default — so the
-//!   `nextval` default is stripped to `None`. A single-column UUID PK keeps its
+//!   `nextval(...)` sequence **that the column owns** is a `BIGSERIAL`-shaped id,
+//!   which the model IR represents as an [`Int64`](ColumnType::Int64) PK with **no**
+//!   default — so the `nextval` default is stripped to `None`. Ownership is required:
+//!   a brownfield int8 PK backed by a *shared/custom* sequence it does not own
+//!   (`id BIGINT PRIMARY KEY DEFAULT nextval('global_ids')`) keeps its raw default
+//!   verbatim, so recreation continues allocating from that sequence rather than
+//!   minting a fresh owned `BIGSERIAL`. A single-column UUID PK keeps its
 //!   `gen_random_uuid()` default (the model parser records the same), so the two
 //!   agree. See [`normalize_default`] / [`normalize_serial_pk_default`].
 //! - **Uniqueness**: a single-column unique index sets the owning column's
@@ -130,6 +134,15 @@
 //!   (their identity metadata from `information_schema.columns.is_identity` is not
 //!   modeled); recreation emits a plain column / loses the identity — identity
 //!   modeling is deferred alongside owned sequences.
+//! - **PG15+ `NULLS NOT DISTINCT` unique indexes**: pulled as ordinary unique
+//!   indexes; the `NULLS NOT DISTINCT` clause is not preserved (detecting it needs
+//!   the PG15+ `pg_index.indnullsnotdistinct` catalog column, which would break
+//!   introspection on PG13/14). Deferred.
+//! - **Stored/virtual `GENERATED ALWAYS AS (...) STORED` generated columns**: pulled
+//!   as ordinary columns; the generation expression
+//!   (`information_schema.columns.generation_expression`) is not modeled, so
+//!   recreation drops the computed-value behavior. Deferred alongside
+//!   identity/owned-sequence modeling.
 //!
 //! Errors are **credential-safe** by construction: no variant ever embeds the
 //! resolved database URL (only a parsed host/port on the connection-error path,
@@ -262,6 +275,18 @@ struct ColumnRow {
     /// Only qualifies the emitted type when it is not `public`.
     #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
     domain_schema: Option<String>,
+    /// Whether this column **owns** the sequence backing its `nextval(...)`
+    /// default — the conventional `SERIAL`/`BIGSERIAL` shape, where Postgres links
+    /// the sequence to the column with an `OWNED BY` auto-dependency (`pg_depend`
+    /// `deptype = 'a'`). A `nextval(...)` default over a *shared*/custom sequence
+    /// that is **not** owned by the column reports `false`, so its raw default is
+    /// preserved verbatim rather than collapsed to a fresh owned `BIGSERIAL` on
+    /// recreation (which would silently change ID-allocation behavior — see
+    /// [`normalize_serial_pk_default`]). Detected via long-standing catalogs only
+    /// (`pg_depend` / `pg_class` / `pg_attribute`), so it is version-safe on every
+    /// supported Postgres (no PG15+ catalog columns).
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    owns_sequence: bool,
 }
 
 #[derive(QueryableByName)]
@@ -448,14 +473,41 @@ fn fetch_columns(
     // would error and every pull would fail. Cast each to a plain `integer` in SQL so
     // the output type is guaranteed `int4` regardless of the domain. The `AS <name>`
     // aliases keep the result column names aligned with the `ColumnRow` field bindings.
+    //
+    // `owns_sequence` is an `EXISTS` over `pg_depend`: a serial column OWNS its
+    // sequence through an `OWNED BY` auto-dependency — a `pg_depend` row whose
+    // `deptype = 'a'` links a sequence (`pg_class.relkind = 'S'`, as `objid`) to
+    // this exact column (`refobjid = <table oid>`, `refobjsubid = <column
+    // attnum>`, `refclassid = classid = 'pg_class'::regclass`). This is the
+    // conventional `SERIAL`/`BIGSERIAL` shape. A `nextval(...)` default over a
+    // shared/custom sequence NOT owned by the column has no such row, so
+    // `owns_sequence` is `false` and the raw default is preserved. `pg_depend`
+    // exists in every supported Postgres, so this never breaks older servers.
     let query = format!(
-        "SELECT table_name, column_name, udt_name, is_nullable, column_default, \
-         numeric_precision::integer AS numeric_precision, \
-         numeric_scale::integer AS numeric_scale, \
-         character_maximum_length::integer AS character_maximum_length, \
-         domain_name, domain_schema FROM information_schema.columns \
-         WHERE table_schema = 'public' AND table_name IN ({}) \
-         ORDER BY table_name, ordinal_position",
+        "SELECT c.table_name, c.column_name, c.udt_name, c.is_nullable, c.column_default, \
+         c.numeric_precision::integer AS numeric_precision, \
+         c.numeric_scale::integer AS numeric_scale, \
+         c.character_maximum_length::integer AS character_maximum_length, \
+         c.domain_name, c.domain_schema, \
+         EXISTS ( \
+           SELECT 1 \
+           FROM pg_depend dep \
+           JOIN pg_class seq ON seq.oid = dep.objid AND seq.relkind = 'S' \
+           JOIN pg_class tbl ON tbl.oid = dep.refobjid \
+           JOIN pg_namespace tn ON tn.oid = tbl.relnamespace \
+           JOIN pg_attribute att \
+             ON att.attrelid = dep.refobjid AND att.attnum = dep.refobjsubid \
+           WHERE dep.classid = 'pg_class'::regclass \
+             AND dep.refclassid = 'pg_class'::regclass \
+             AND dep.deptype = 'a' \
+             AND dep.refobjsubid > 0 \
+             AND tn.nspname = 'public' \
+             AND tbl.relname = c.table_name \
+             AND att.attname = c.column_name \
+         ) AS owns_sequence \
+         FROM information_schema.columns c \
+         WHERE c.table_schema = 'public' AND c.table_name IN ({}) \
+         ORDER BY c.table_name, c.ordinal_position",
         quoted_in_list(tables)
     );
     let rows: Vec<ColumnRow> = sql_query(query)
@@ -801,7 +853,13 @@ fn build_table(
         column.nullable = row.is_nullable.eq_ignore_ascii_case("YES");
         column.primary_key = is_pk;
         column.unique = unique_columns.contains(row.column_name.as_str());
-        column.default = normalize_default(row.column_default.as_deref(), &ty, is_pk, primary_key);
+        column.default = normalize_default(
+            row.column_default.as_deref(),
+            &ty,
+            is_pk,
+            primary_key,
+            row.owns_sequence,
+        );
         if let Some(fk) = fk_by_column.get(row.column_name.as_str()) {
             // Fail-closed floor for cross-schema FK targets: a FK to a table
             // outside `public` (`REFERENCES auth.users(id)`) must be stored
@@ -973,10 +1031,15 @@ fn collapse_indexes(rows: &[IndexRow]) -> (Vec<Index>, std::collections::BTreeSe
 ///
 /// - `NULL` (no default) → `None`.
 /// - `now()` / `CURRENT_TIMESTAMP` → [`ColumnDefault::Now`].
-/// - a `nextval(...)` serial default on a single-column **int8** primary key →
-///   `None` (a `BIGSERIAL`-shaped id has no explicit default in the model IR;
-///   see [`normalize_serial_pk_default`]). An **int4** `SERIAL` PK keeps its
-///   `nextval(...)` default so the emitter can reconstruct it as `SERIAL`.
+/// - a `nextval(...)` serial default on a single-column **int8** primary key whose
+///   sequence is **owned** by the column → `None` (a `BIGSERIAL`-shaped id has no
+///   explicit default in the model IR; see [`normalize_serial_pk_default`]). An
+///   **int4** `SERIAL` PK keeps its `nextval(...)` default so the emitter can
+///   reconstruct it as `SERIAL`.
+/// - a `nextval(...)` default over a **shared/custom** sequence NOT owned by the
+///   column (`owns_sequence == false`) → preserved verbatim as
+///   [`ColumnDefault::Sql`], so recreation continues to allocate from that
+///   sequence instead of minting a fresh owned `BIGSERIAL`.
 /// - anything else → [`ColumnDefault::Sql`] verbatim (e.g. a UUID PK's
 ///   `gen_random_uuid()`, which the model parser records identically).
 fn normalize_default(
@@ -984,6 +1047,7 @@ fn normalize_default(
     ty: &ColumnType,
     is_primary_key: bool,
     primary_key: &[String],
+    owns_sequence: bool,
 ) -> Option<ColumnDefault> {
     let raw = raw?.trim();
     if raw.is_empty() {
@@ -994,36 +1058,51 @@ fn normalize_default(
         return Some(ColumnDefault::Now);
     }
     // A serial (`nextval(...)`) default on a single-column integer PK is the
-    // BIGSERIAL id shape — the model IR carries no explicit default for it.
-    if normalize_serial_pk_default(&lowered, ty, is_primary_key, primary_key) {
+    // BIGSERIAL id shape ONLY when the column owns its sequence — the model IR
+    // carries no explicit default for it. A shared/custom (non-owned) sequence
+    // default falls through and is preserved verbatim below.
+    if normalize_serial_pk_default(&lowered, ty, is_primary_key, primary_key, owns_sequence) {
         return None;
     }
     Some(ColumnDefault::Sql(raw.to_owned()))
 }
 
 /// Whether a raw (lower-cased) default is the auto-increment sequence default of
-/// a single-column **`BIGSERIAL`** (int8) primary key — i.e. the shape the model IR
-/// represents as an [`Int64`](ColumnType::Int64) PK with **no** default. Such a
-/// default is stripped to `None` so an introspected `BIGSERIAL` id round-trips
-/// against the model parser (whose `pk_kind_for` requires `default.is_none()` for a
-/// `BigSerial` PK).
+/// a single-column **`BIGSERIAL`** (int8) primary key **that owns its sequence** —
+/// i.e. the shape the model IR represents as an [`Int64`](ColumnType::Int64) PK with
+/// **no** default. Such a default is stripped to `None` so an introspected
+/// `BIGSERIAL` id round-trips against the model parser (whose `pk_kind_for` requires
+/// `default.is_none()` for a `BigSerial` PK).
 ///
-/// A single-column **`SERIAL`** (int4) PK is deliberately **not** stripped: the
-/// model IR has no default-less int4-PK shape, so keeping the `nextval(...)` default
-/// is what lets the DDL emitter recognize it (via `pk_kind_for`) and reconstruct it
-/// as `SERIAL PRIMARY KEY` — recreating it as a plain `INTEGER PRIMARY KEY` would
-/// silently drop the sequence. A plain int PK with no default stays default-less and
-/// so recreates as a plain integer PK (no auto-increment).
+/// **Ownership is load-bearing**: only a *conventional* serial — where Postgres
+/// links the sequence to the column via an `OWNED BY` auto-dependency
+/// (`owns_sequence == true`, sourced from `pg_depend` `deptype = 'a'`) — is the
+/// default-less `BIGSERIAL` shape. A brownfield int8 PK backed by a **shared/custom**
+/// sequence it does NOT own (`id BIGINT PRIMARY KEY DEFAULT nextval('global_ids')`)
+/// is deliberately **not** stripped: stripping it would make recreation/rollback
+/// emit a fresh owned `BIGSERIAL` (a NEW sequence) instead of continuing to allocate
+/// from `global_ids` — a silent, wrong ID-allocation change. Its raw
+/// `nextval(...)` default is preserved verbatim instead.
+///
+/// A single-column **`SERIAL`** (int4) PK is deliberately **not** stripped (this
+/// function only ever matches [`Int64`](ColumnType::Int64)): the model IR has no
+/// default-less int4-PK shape, so keeping the `nextval(...)` default is what lets the
+/// DDL emitter recognize it (via `pk_kind_for`) and reconstruct it as `SERIAL PRIMARY
+/// KEY` — recreating it as a plain `INTEGER PRIMARY KEY` would silently drop the
+/// sequence. A plain int PK with no default stays default-less and so recreates as a
+/// plain integer PK (no auto-increment).
 fn normalize_serial_pk_default(
     lowered_default: &str,
     ty: &ColumnType,
     is_primary_key: bool,
     primary_key: &[String],
+    owns_sequence: bool,
 ) -> bool {
     is_primary_key
         && primary_key.len() == 1
         && matches!(ty, ColumnType::Int64)
         && lowered_default.starts_with("nextval(")
+        && owns_sequence
 }
 
 #[cfg(test)]
@@ -1069,50 +1148,86 @@ mod tests {
 
     #[test]
     fn normalize_default_now_variants() {
-        let now = normalize_default(Some("now()"), &ColumnType::Timestamp, false, &[]);
+        let now = normalize_default(Some("now()"), &ColumnType::Timestamp, false, &[], false);
         assert_eq!(now, Some(ColumnDefault::Now));
         let ct = normalize_default(
             Some("CURRENT_TIMESTAMP"),
             &ColumnType::TimestampTz,
             false,
             &[],
+            false,
         );
         assert_eq!(ct, Some(ColumnDefault::Now));
     }
 
     #[test]
     fn normalize_default_null_is_none() {
-        assert_eq!(normalize_default(None, &ColumnType::Text, false, &[]), None);
         assert_eq!(
-            normalize_default(Some("  "), &ColumnType::Text, false, &[]),
+            normalize_default(None, &ColumnType::Text, false, &[], false),
+            None
+        );
+        assert_eq!(
+            normalize_default(Some("  "), &ColumnType::Text, false, &[], false),
             None
         );
     }
 
     #[test]
     fn normalize_serial_pk_default_stripped_to_none() {
-        // A `nextval(...)` default on a single-column int8 PK → None (BIGSERIAL id).
+        // (a) A `nextval(...)` default on a single-column int8 PK that OWNS its
+        // sequence (the conventional `BIGSERIAL` shape) → None (BIGSERIAL id).
         let pk = vec!["id".to_owned()];
         let d = normalize_default(
             Some("nextval('posts_id_seq'::regclass)"),
             &ColumnType::Int64,
             true,
             &pk,
+            true, // owns its sequence — conventional BIGSERIAL
         );
-        assert_eq!(d, None, "int8 serial PK default must be stripped to None");
+        assert_eq!(
+            d, None,
+            "int8 serial PK default (owned sequence) must be stripped to None"
+        );
+    }
+
+    #[test]
+    fn normalize_int8_serial_pk_shared_sequence_default_is_preserved() {
+        // (b) A `nextval(...)` default on a single-column int8 PK backed by a
+        // SHARED/custom sequence the column does NOT own
+        // (`id BIGINT PRIMARY KEY DEFAULT nextval('global_ids')`) must be PRESERVED
+        // verbatim — stripping it would make recreation mint a fresh owned
+        // `BIGSERIAL` (a new sequence) instead of continuing to allocate from
+        // `global_ids`, silently changing ID-allocation behavior.
+        let pk = vec!["id".to_owned()];
+        let d = normalize_default(
+            Some("nextval('global_ids'::regclass)"),
+            &ColumnType::Int64,
+            true,
+            &pk,
+            false, // does NOT own the sequence — shared/custom
+        );
+        assert_eq!(
+            d,
+            Some(ColumnDefault::Sql(
+                "nextval('global_ids'::regclass)".to_owned()
+            )),
+            "int8 PK default over a non-owned (shared) sequence must be preserved verbatim"
+        );
     }
 
     #[test]
     fn normalize_int4_serial_pk_default_is_kept() {
-        // A `nextval(...)` default on a single-column int4 PK is a brownfield
+        // (c) A `nextval(...)` default on a single-column int4 PK is a brownfield
         // `SERIAL PRIMARY KEY` — its default is PRESERVED (not stripped) so the DDL
-        // emitter can reconstruct it as `SERIAL` rather than a plain `INTEGER`.
+        // emitter can reconstruct it as `SERIAL` rather than a plain `INTEGER`. This
+        // holds regardless of ownership (only int8 owned serials are stripped).
         let pk = vec!["id".to_owned()];
         let d = normalize_default(
             Some("nextval('counters_id_seq'::regclass)"),
             &ColumnType::Int32,
             true,
             &pk,
+            true, // even an owned int4 serial keeps its default (int4 is never stripped)
         );
         assert_eq!(
             d,
@@ -1128,28 +1243,37 @@ mod tests {
         // A plain int4 PK with NO default stays default-less → a plain integer PK
         // (no auto-increment), never mistaken for a SERIAL.
         let pk = vec!["id".to_owned()];
-        let d = normalize_default(None, &ColumnType::Int32, true, &pk);
+        let d = normalize_default(None, &ColumnType::Int32, true, &pk, false);
         assert_eq!(d, None, "a plain int4 PK carries no default");
     }
 
     #[test]
     fn normalize_serial_default_on_non_pk_is_kept_as_sql() {
-        // A sequence default on a NON-pk column is not the id shape — keep it.
+        // A sequence default on a NON-pk column is not the id shape — keep it (even
+        // when the column owns the sequence, i.e. a non-PK `SERIAL` column).
         let d = normalize_default(
             Some("nextval('counter_seq'::regclass)"),
             &ColumnType::Int64,
             false,
             &[],
+            true,
         );
         assert!(matches!(d, Some(ColumnDefault::Sql(_))));
     }
 
     #[test]
     fn normalize_uuid_pk_default_is_kept_as_sql() {
-        // A UUID PK keeps its gen_random_uuid() default (the model parser records
-        // the same), so the two agree on a round-trip.
+        // (d) A UUID PK keeps its gen_random_uuid() default (the model parser records
+        // the same), so the two agree on a round-trip — unaffected by the ownership
+        // signal (UUID PKs have no sequence).
         let pk = vec!["id".to_owned()];
-        let d = normalize_default(Some("gen_random_uuid()"), &ColumnType::Uuid, true, &pk);
+        let d = normalize_default(
+            Some("gen_random_uuid()"),
+            &ColumnType::Uuid,
+            true,
+            &pk,
+            false,
+        );
         assert_eq!(d, Some(ColumnDefault::Sql("gen_random_uuid()".to_owned())));
     }
 
@@ -1522,6 +1646,9 @@ mod tests {
                 character_maximum_length: None,
                 domain_name: None,
                 domain_schema: None,
+                // The conventional BIGSERIAL id owns its sequence, so the nextval
+                // default is stripped to None below.
+                owns_sequence: true,
             },
             ColumnRow {
                 table_name: "comments".to_owned(),
@@ -1534,6 +1661,7 @@ mod tests {
                 character_maximum_length: None,
                 domain_name: None,
                 domain_schema: None,
+                owns_sequence: false,
             },
         ];
         let pk = vec!["id".to_owned()];
@@ -1584,6 +1712,7 @@ mod tests {
             character_maximum_length: None,
             domain_name: None,
             domain_schema: None,
+            owns_sequence: false,
         }];
         let table = build_table("widgets", &columns, &[], &[], &[], &[]);
         let addr = table.columns.iter().find(|c| c.name == "addr").unwrap();
@@ -1613,6 +1742,7 @@ mod tests {
                 character_maximum_length: None,
                 domain_name: Some("email_dom".to_owned()),
                 domain_schema: Some("public".to_owned()),
+                owns_sequence: false,
             },
             // A non-domain column (`domain_name` NULL) maps exactly as before.
             ColumnRow {
@@ -1626,6 +1756,7 @@ mod tests {
                 character_maximum_length: None,
                 domain_name: None,
                 domain_schema: None,
+                owns_sequence: false,
             },
         ];
         let table = build_table("contacts", &columns, &[], &[], &[], &[]);
@@ -1663,6 +1794,7 @@ mod tests {
                 character_maximum_length: Some(32),
                 domain_name: None,
                 domain_schema: None,
+                owns_sequence: false,
             },
             ColumnRow {
                 table_name: "labels".to_owned(),
@@ -1675,6 +1807,7 @@ mod tests {
                 character_maximum_length: Some(2),
                 domain_name: None,
                 domain_schema: None,
+                owns_sequence: false,
             },
             ColumnRow {
                 table_name: "labels".to_owned(),
@@ -1687,6 +1820,7 @@ mod tests {
                 character_maximum_length: None,
                 domain_name: None,
                 domain_schema: None,
+                owns_sequence: false,
             },
         ];
         let table = build_table("labels", &columns, &[], &[], &[], &[]);
@@ -1730,6 +1864,7 @@ mod tests {
             character_maximum_length: Some(32),
             domain_name: Some("code_dom".to_owned()),
             domain_schema: Some("public".to_owned()),
+            owns_sequence: false,
         }];
         let table = build_table("labels", &columns, &[], &[], &[], &[]);
         let code = table.columns.iter().find(|c| c.name == "code").unwrap();
@@ -1757,6 +1892,7 @@ mod tests {
             character_maximum_length: None,
             domain_name: Some("email_dom".to_owned()),
             domain_schema: Some("otherschema".to_owned()),
+            owns_sequence: false,
         }];
         let table = build_table("contacts", &columns, &[], &[], &[], &[]);
         let email = table.columns.iter().find(|c| c.name == "email").unwrap();
@@ -1784,6 +1920,7 @@ mod tests {
             character_maximum_length: None,
             domain_name: None,
             domain_schema: None,
+            owns_sequence: false,
         }];
         let fks = vec![ForeignKeyRow {
             table_name: "sessions".to_owned(),
@@ -1819,6 +1956,7 @@ mod tests {
             character_maximum_length: None,
             domain_name: None,
             domain_schema: None,
+            owns_sequence: false,
         }];
         let fks = vec![ForeignKeyRow {
             table_name: "comments".to_owned(),
@@ -1851,6 +1989,7 @@ mod tests {
             character_maximum_length: None,
             domain_name: None,
             domain_schema: None,
+            owns_sequence: false,
         }];
         let checks = vec![CheckRow {
             table_name: "products".to_owned(),
@@ -1879,6 +2018,7 @@ mod tests {
             character_maximum_length: None,
             domain_name: None,
             domain_schema: None,
+            owns_sequence: false,
         }];
         let table = build_table("products", &columns, &[], &[], &[], &[]);
         assert!(

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -275,6 +275,17 @@ struct IndexRow {
     /// `Index.columns` for round-trip parity.
     #[diesel(sql_type = diesel::sql_types::Text)]
     columns: String,
+    /// Comma-joined **key** column names in key order — the first `indnkeyatts`
+    /// index attributes, EXCLUDING any non-key `INCLUDE` columns, and **empty when
+    /// any key position is an expression** (an `indkey` `0` inside the key range).
+    /// This is the exact set the index's uniqueness is enforced over: distinct from
+    /// `columns` (which folds in `INCLUDE` columns for a covering index) and from
+    /// `dep_columns` (the full cascade dependency set). Used to populate
+    /// `Index.key_columns` so the diff can decide — offline, with no DB — whether a
+    /// baseline unique index actually enforces a model `#[unique]`'s exact column set
+    /// (a partial or expression index does not).
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    key_columns: String,
     /// Comma-joined set of every column this index *depends on* — key columns,
     /// expression-referenced columns, AND predicate (`WHERE`) columns per
     /// `pg_depend`, combined via `UNION` with the backing constraint's `conkey`
@@ -426,7 +437,11 @@ fn fetch_primary_keys(
 /// ORDINALITY` subquery; `has_expression` flags any `0` key, `is_partial`
 /// flags an `indpred`, and `is_constraint` flags an index backing a
 /// `pg_constraint` (UNIQUE/EXCLUDE), so the builder can classify each index as
-/// simple-representable vs. preserved-verbatim. A second correlated subquery
+/// simple-representable vs. preserved-verbatim. A separate `key_columns` projection
+/// aggregates only the first `indnkeyatts` (true KEY) attributes — excluding
+/// `INCLUDE` columns and yielding empty for an expression key — which is the exact
+/// set an index's uniqueness is enforced over (used to decide, offline, whether a
+/// baseline unique index satisfies a model `#[unique]`). A second correlated subquery
 /// aggregates `dep_columns` — the exact set of columns the index depends on (key,
 /// expression-referenced, AND predicate columns via **`pg_depend`**, combined via
 /// `UNION` with the backing constraint's `conkey` columns for a constraint-owned
@@ -455,6 +470,16 @@ fn fetch_indexes(
            JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = k.attnum \
            WHERE k.attnum > 0 \
          ), '') AS columns, \
+         CASE \
+           WHEN 0 = ANY((string_to_array(i.indkey::text, ' ')::int[])[1:i.indnkeyatts]) \
+             THEN '' \
+           ELSE COALESCE(( \
+             SELECT string_agg(a.attname, ',' ORDER BY k.ord) \
+             FROM unnest((string_to_array(i.indkey::text, ' ')::int[])[1:i.indnkeyatts]) \
+                  WITH ORDINALITY AS k(attnum, ord) \
+             JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = k.attnum \
+           ), '') \
+         END AS key_columns, \
          COALESCE(( \
            SELECT string_agg(DISTINCT attname, ',' ORDER BY attname) FROM ( \
              SELECT a.attname \
@@ -641,8 +666,11 @@ fn collapse_indexes(rows: &[IndexRow]) -> (Vec<Index>, std::collections::BTreeSe
         // `Index.columns` is the exact `pg_depend` dependent-column set — key,
         // expression-referenced, AND predicate columns — the set the diff engine
         // uses for exact cascade/dependency detection (no string scan).
-        let (columns, definition) = if simple && !row.is_constraint {
-            (key_columns, None)
+        let (columns, definition, key_cols) = if simple && !row.is_constraint {
+            // A plain simple index's key columns ARE its `columns`, so recording
+            // `key_columns` separately would be redundant JSON noise — leave it empty
+            // and let the diff derive the key set from `columns` for such indexes.
+            (key_columns, None, Vec::new())
         } else {
             let dep_columns: Vec<String> = row
                 .dep_columns
@@ -650,13 +678,26 @@ fn collapse_indexes(rows: &[IndexRow]) -> (Vec<Index>, std::collections::BTreeSe
                 .filter(|c| !c.is_empty())
                 .map(str::to_owned)
                 .collect();
-            (dep_columns, Some(row.definition.clone()))
+            // For a `definition`-carrying index (expression / partial / covering /
+            // constraint-owned) the KEY columns are recorded explicitly: they differ
+            // from `columns` (which is the full cascade dependency set here) and are
+            // EMPTY for an expression key, which is exactly the signal the diff uses to
+            // refuse to treat such an index as satisfying a model `#[unique]`.
+            let key_cols: Vec<String> = row
+                .key_columns
+                .split(',')
+                .filter(|c| !c.is_empty())
+                .map(str::to_owned)
+                .collect();
+            (dep_columns, Some(row.definition.clone()), key_cols)
         };
         indexes.push(Index {
             name: row.index_name.clone(),
             columns,
             unique: row.is_unique,
             definition,
+            is_partial: row.is_partial,
+            key_columns: key_cols,
         });
     }
     (indexes, unique_columns)
@@ -667,9 +708,10 @@ fn collapse_indexes(rows: &[IndexRow]) -> (Vec<Index>, std::collections::BTreeSe
 ///
 /// - `NULL` (no default) → `None`.
 /// - `now()` / `CURRENT_TIMESTAMP` → [`ColumnDefault::Now`].
-/// - a `nextval(...)` serial default on a single-column integer primary key →
+/// - a `nextval(...)` serial default on a single-column **int8** primary key →
 ///   `None` (a `BIGSERIAL`-shaped id has no explicit default in the model IR;
-///   see [`normalize_serial_pk_default`]).
+///   see [`normalize_serial_pk_default`]). An **int4** `SERIAL` PK keeps its
+///   `nextval(...)` default so the emitter can reconstruct it as `SERIAL`.
 /// - anything else → [`ColumnDefault::Sql`] verbatim (e.g. a UUID PK's
 ///   `gen_random_uuid()`, which the model parser records identically).
 fn normalize_default(
@@ -695,11 +737,18 @@ fn normalize_default(
 }
 
 /// Whether a raw (lower-cased) default is the auto-increment sequence default of
-/// a single-column integer primary key — i.e. the shape the model IR represents
-/// as an [`Int64`](ColumnType::Int64) PK with **no** default. Such a default is
-/// stripped to `None` so an introspected `BIGSERIAL` id round-trips against the
-/// model parser (whose `pk_kind_for` requires `default.is_none()` for a
+/// a single-column **`BIGSERIAL`** (int8) primary key — i.e. the shape the model IR
+/// represents as an [`Int64`](ColumnType::Int64) PK with **no** default. Such a
+/// default is stripped to `None` so an introspected `BIGSERIAL` id round-trips
+/// against the model parser (whose `pk_kind_for` requires `default.is_none()` for a
 /// `BigSerial` PK).
+///
+/// A single-column **`SERIAL`** (int4) PK is deliberately **not** stripped: the
+/// model IR has no default-less int4-PK shape, so keeping the `nextval(...)` default
+/// is what lets the DDL emitter recognize it (via `pk_kind_for`) and reconstruct it
+/// as `SERIAL PRIMARY KEY` — recreating it as a plain `INTEGER PRIMARY KEY` would
+/// silently drop the sequence. A plain int PK with no default stays default-less and
+/// so recreates as a plain integer PK (no auto-increment).
 fn normalize_serial_pk_default(
     lowered_default: &str,
     ty: &ColumnType,
@@ -708,7 +757,7 @@ fn normalize_serial_pk_default(
 ) -> bool {
     is_primary_key
         && primary_key.len() == 1
-        && matches!(ty, ColumnType::Int32 | ColumnType::Int64)
+        && matches!(ty, ColumnType::Int64)
         && lowered_default.starts_with("nextval(")
 }
 
@@ -777,7 +826,7 @@ mod tests {
 
     #[test]
     fn normalize_serial_pk_default_stripped_to_none() {
-        // A `nextval(...)` default on a single-column int PK → None (BIGSERIAL id).
+        // A `nextval(...)` default on a single-column int8 PK → None (BIGSERIAL id).
         let pk = vec!["id".to_owned()];
         let d = normalize_default(
             Some("nextval('posts_id_seq'::regclass)"),
@@ -785,7 +834,37 @@ mod tests {
             true,
             &pk,
         );
-        assert_eq!(d, None, "serial PK default must be stripped to None");
+        assert_eq!(d, None, "int8 serial PK default must be stripped to None");
+    }
+
+    #[test]
+    fn normalize_int4_serial_pk_default_is_kept() {
+        // A `nextval(...)` default on a single-column int4 PK is a brownfield
+        // `SERIAL PRIMARY KEY` — its default is PRESERVED (not stripped) so the DDL
+        // emitter can reconstruct it as `SERIAL` rather than a plain `INTEGER`.
+        let pk = vec!["id".to_owned()];
+        let d = normalize_default(
+            Some("nextval('counters_id_seq'::regclass)"),
+            &ColumnType::Int32,
+            true,
+            &pk,
+        );
+        assert_eq!(
+            d,
+            Some(ColumnDefault::Sql(
+                "nextval('counters_id_seq'::regclass)".to_owned()
+            )),
+            "int4 SERIAL PK default must be preserved, not stripped"
+        );
+    }
+
+    #[test]
+    fn normalize_int4_pk_without_default_stays_none() {
+        // A plain int4 PK with NO default stays default-less → a plain integer PK
+        // (no auto-increment), never mistaken for a SERIAL.
+        let pk = vec!["id".to_owned()];
+        let d = normalize_default(None, &ColumnType::Int32, true, &pk);
+        assert_eq!(d, None, "a plain int4 PK carries no default");
     }
 
     #[test]
@@ -836,6 +915,14 @@ mod tests {
             has_include: false,
             is_constraint: false,
             columns: columns.to_owned(),
+            // Mirror the SQL `key_columns`: empty when any key position is an
+            // expression, otherwise the (non-INCLUDE) key columns — which, for these
+            // `has_include: false` fixtures, are exactly `columns`.
+            key_columns: if has_expression {
+                String::new()
+            } else {
+                columns.to_owned()
+            },
             dep_columns: dep_columns.to_owned(),
         }
     }

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -72,23 +72,30 @@
 //! - **Enum `CHECK` constraints**: enum recovery from `CHECK` expressions is a
 //!   later slice; a `TEXT`-with-`CHECK` column pulls back as plain
 //!   [`Text`](ColumnType::Text).
-//! - **Constraint-vs-index reconciliation for constraint-owned indexes**: a
-//!   brownfield `UNIQUE`/`EXCLUDE` constraint is retained by its *index*
-//!   definition (`pg_get_indexdef`, a valid `CREATE UNIQUE INDEX …`), not by the
-//!   originating `ALTER TABLE … ADD CONSTRAINT`. So if the authoritative path
-//!   (`pull --dry-run`) ever rendered a recreation it would emit the
-//!   `CREATE UNIQUE INDEX` form rather than re-adding the constraint. A model that
+//! - **Constraint-vs-index reconciliation for constraint-owned indexes**: an
+//!   **EXCLUDE** constraint (`pg_constraint.contype = 'x'`) IS preserved as the real
+//!   constraint: its retained `definition` is the
+//!   `ALTER TABLE … ADD CONSTRAINT <name> <pg_get_constraintdef>` form
+//!   (`EXCLUDE USING <method> (…)`), so a recreation
+//!   re-establishes the actual exclusion rather than a plain index that would fail
+//!   to enforce it (which would let overlapping rows through — a data-integrity
+//!   loss). A brownfield `UNIQUE` (or PK) constraint-owned index, by contrast, is
+//!   still retained by its *index* definition (`pg_get_indexdef`, a valid
+//!   `CREATE UNIQUE INDEX …`), not by the originating
+//!   `ALTER TABLE … ADD CONSTRAINT` — a recreation emits the `CREATE UNIQUE INDEX` form, which enforces
+//!   the same uniqueness, so exact constraint-*object* reconstruction for
+//!   unique/PK constraints remains the documented deferral. A model that
 //!   *also* declares `#[unique]` on a column already covered by a brownfield
-//!   `UNIQUE` constraint is now **recognized as satisfied** by the existing unique
+//!   `UNIQUE` constraint is **recognized as satisfied** by the existing unique
 //!   index: `diff_indexes` (model-diff path) treats a desired unique index whose
 //!   exact column set is already enforced by any baseline `unique` index — including
 //!   the retained constraint index — as fulfilled, so it emits **no** redundant
 //!   `AddIndex` (and no `DropIndex`), and the plan is clean rather than tripping
 //!   `guard_plan`'s unique-index dedup refusal. (This resolves the earlier
 //!   "additively creates a redundant `idx_<table>_<col>_unique` index" caveat.)
-//!   Full constraint↔index reconciliation is otherwise deferred; the load-bearing
-//!   property this slice guarantees is only that the generated migration no longer
-//!   *fails* with a rejected `DROP INDEX`.
+//!   Full unique/PK constraint↔index reconciliation is otherwise deferred; the
+//!   load-bearing property this slice guarantees is only that the generated
+//!   migration no longer *fails* with a rejected `DROP INDEX`.
 //! - **Cascade-dropped retained indexes on a dropped column**: when a model
 //!   removes a column that a retained (`definition`-carrying) expression / partial
 //!   / constraint-owned index depends on, Postgres cascade-drops that index with
@@ -101,11 +108,13 @@
 //!   the authoritative cascade set Postgres itself uses — so the diff engine tests
 //!   dependency by exact set membership, never a `definition`-text scan (which
 //!   could false-positive on a column name appearing in a string literal). One
-//!   nuance remains deferred: a cascade-removed brownfield `UNIQUE`/`EXCLUDE`
+//!   nuance remains deferred: a cascade-removed brownfield `UNIQUE` (or PK)
 //!   *constraint* is restored on rollback as a unique *index* (via its
 //!   `pg_get_indexdef` definition), not as the original named `CONSTRAINT` —
 //!   functional uniqueness is preserved, exact constraint-object reconstruction is
-//!   deferred.
+//!   deferred. (An **EXCLUDE** constraint is not subject to this deferral: it is
+//!   restored as the real `ADD CONSTRAINT … EXCLUDE USING …`, per the reconciliation
+//!   note above.)
 //!
 //! Errors are **credential-safe** by construction: no variant ever embeds the
 //! resolved database URL (only a parsed host/port on the connection-error path,
@@ -270,6 +279,24 @@ struct IndexRow {
     /// model DSL cannot express it, so it is retained verbatim.
     #[diesel(sql_type = diesel::sql_types::Bool)]
     is_constraint: bool,
+    /// The backing constraint's `pg_constraint.contype` (`'u'` unique, `'x'`
+    /// EXCLUDE), or `''` when the index backs no constraint. An `'x'` EXCLUDE index
+    /// must be retained as its real `ADD CONSTRAINT` (not just the backing
+    /// `CREATE INDEX`), because a plain index does not enforce the exclusion — see
+    /// [`collapse_indexes`].
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    constraint_type: String,
+    /// The backing constraint's name (`pg_constraint.conname`), or `''` when the
+    /// index backs no constraint. Used to build the `ALTER TABLE … ADD CONSTRAINT
+    /// <name> …` recreation for an EXCLUDE constraint.
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    constraint_name: String,
+    /// The backing constraint's canonical definition (`pg_get_constraintdef`), or
+    /// `''` when the index backs no constraint. For an EXCLUDE constraint this is
+    /// `EXCLUDE USING <method> (…)`, which the `ALTER TABLE … ADD CONSTRAINT` form
+    /// wraps into a valid, exclusion-enforcing recreation statement.
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    constraint_def: String,
     /// Comma-joined resolvable ordinary *key* column names, in key order (may be
     /// empty for an all-expression index). Used to populate a *simple* index's
     /// `Index.columns` for round-trip parity.
@@ -436,7 +463,10 @@ fn fetch_primary_keys(
 /// aggregated in true key order via a correlated `unnest(indkey) WITH
 /// ORDINALITY` subquery; `has_expression` flags any `0` key, `is_partial`
 /// flags an `indpred`, and `is_constraint` flags an index backing a
-/// `pg_constraint` (UNIQUE/EXCLUDE), so the builder can classify each index as
+/// `pg_constraint` (UNIQUE/EXCLUDE) — with `constraint_type` (`pg_constraint.contype`),
+/// `constraint_name` (`conname`), and `constraint_def` (`pg_get_constraintdef`) so an
+/// EXCLUDE constraint can be recreated as the real constraint rather than a bare
+/// backing index — so the builder can classify each index as
 /// simple-representable vs. preserved-verbatim. A separate `key_columns` projection
 /// aggregates only the first `indnkeyatts` (true KEY) attributes — excluding
 /// `INCLUDE` columns and yielding empty for an expression key — which is the exact
@@ -463,6 +493,9 @@ fn fetch_indexes(
          (0 = ANY(string_to_array(i.indkey::text, ' ')::int[])) AS has_expression, \
          (i.indnkeyatts < i.indnatts) AS has_include, \
          EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conindid = i.indexrelid) AS is_constraint, \
+         COALESCE((SELECT c.contype::text FROM pg_constraint c WHERE c.conindid = i.indexrelid LIMIT 1), '') AS constraint_type, \
+         COALESCE((SELECT c.conname FROM pg_constraint c WHERE c.conindid = i.indexrelid LIMIT 1), '') AS constraint_name, \
+         COALESCE((SELECT pg_get_constraintdef(c.oid) FROM pg_constraint c WHERE c.conindid = i.indexrelid LIMIT 1), '') AS constraint_def, \
          COALESCE(( \
            SELECT string_agg(a.attname, ',' ORDER BY k.ord) \
            FROM unnest(string_to_array(i.indkey::text, ' ')::int[]) \
@@ -631,6 +664,17 @@ fn build_table(
 ///   that Postgres would reject. A single-column constraint-owned unique index
 ///   still sets the owning column's `unique` flag (accurate, and the flag is not
 ///   diffed) — that classification is independent of constraint ownership.
+///
+///   An **EXCLUDE** constraint (`pg_constraint.contype = 'x'`) is a special case:
+///   its backing `CREATE INDEX` (`pg_get_indexdef`) does NOT enforce the exclusion,
+///   so retaining only the plain index would let overlapping rows through on a
+///   rollback/recreation (a data-integrity loss). For an EXCLUDE index the retained
+///   `definition` is therefore the REAL constraint recreation —
+///   `ALTER TABLE <table> ADD CONSTRAINT <conname> <pg_get_constraintdef>` (whose
+///   `pg_get_constraintdef` is `EXCLUDE USING <method> (…)`) — so `index_sql`'s
+///   verbatim emission restores the actual exclusion constraint. A UNIQUE/PK
+///   constraint-owned index keeps its `pg_get_indexdef` (`CREATE UNIQUE INDEX`)
+///   recreation, which enforces the same uniqueness (the documented deferral).
 fn collapse_indexes(rows: &[IndexRow]) -> (Vec<Index>, std::collections::BTreeSet<String>) {
     let mut indexes = Vec::with_capacity(rows.len());
     let mut unique_columns = std::collections::BTreeSet::new();
@@ -678,18 +722,39 @@ fn collapse_indexes(rows: &[IndexRow]) -> (Vec<Index>, std::collections::BTreeSe
                 .filter(|c| !c.is_empty())
                 .map(str::to_owned)
                 .collect();
-            // For a `definition`-carrying index (expression / partial / covering /
-            // constraint-owned) the KEY columns are recorded explicitly: they differ
-            // from `columns` (which is the full cascade dependency set here) and are
-            // EMPTY for an expression key, which is exactly the signal the diff uses to
-            // refuse to treat such an index as satisfying a model `#[unique]`.
-            let key_cols: Vec<String> = row
-                .key_columns
-                .split(',')
-                .filter(|c| !c.is_empty())
-                .map(str::to_owned)
-                .collect();
-            (dep_columns, Some(row.definition.clone()), key_cols)
+            if row.is_constraint && row.constraint_type == "x" {
+                // An EXCLUDE constraint (`pg_constraint.contype = 'x'`) is backed by
+                // an index, but the backing `CREATE INDEX` (pg_get_indexdef) alone
+                // does NOT enforce the exclusion — recreating only the plain index on
+                // rollback would silently allow overlapping rows (a data-integrity
+                // loss). Retain the REAL constraint instead: `pg_get_constraintdef`
+                // yields `EXCLUDE USING <method> (…)`, which the `ALTER TABLE … ADD
+                // CONSTRAINT <name> …` form wraps into a valid, exclusion-enforcing
+                // statement (`index_sql` emits `definition` verbatim). The table is
+                // referenced by its bare name, matching the rest of the emitter
+                // (`index_sql`'s plain branch / `CREATE TABLE`). `key_columns` is left
+                // empty: an EXCLUDE index is not `unique`, so it never participates in
+                // the model `#[unique]` coverage check.
+                let definition = format!(
+                    "ALTER TABLE {} ADD CONSTRAINT {} {}",
+                    row.table_name, row.constraint_name, row.constraint_def
+                );
+                (dep_columns, Some(definition), Vec::new())
+            } else {
+                // For a `definition`-carrying index (expression / partial / covering /
+                // unique-constraint-owned) the KEY columns are recorded explicitly:
+                // they differ from `columns` (which is the full cascade dependency set
+                // here) and are EMPTY for an expression key, which is exactly the
+                // signal the diff uses to refuse to treat such an index as satisfying a
+                // model `#[unique]`.
+                let key_cols: Vec<String> = row
+                    .key_columns
+                    .split(',')
+                    .filter(|c| !c.is_empty())
+                    .map(str::to_owned)
+                    .collect();
+                (dep_columns, Some(row.definition.clone()), key_cols)
+            }
         };
         indexes.push(Index {
             name: row.index_name.clone(),
@@ -914,6 +979,9 @@ mod tests {
             has_expression,
             has_include: false,
             is_constraint: false,
+            constraint_type: String::new(),
+            constraint_name: String::new(),
+            constraint_def: String::new(),
             columns: columns.to_owned(),
             // Mirror the SQL `key_columns`: empty when any key position is an
             // expression, otherwise the (non-INCLUDE) key columns — which, for these
@@ -939,8 +1007,40 @@ mod tests {
     ) -> IndexRow {
         IndexRow {
             is_constraint: true,
+            // A UNIQUE constraint (`contype = 'u'`) — the EXCLUDE (`'x'`) path is
+            // exercised by [`exclude_constraint_index_row`].
+            constraint_type: "u".to_owned(),
             ..index_row(
                 index_name, is_unique, columns, columns, false, false, definition,
+            )
+        }
+    }
+
+    /// Build an EXCLUDE-constraint-owned (`contype = 'x'`) [`IndexRow`]. The
+    /// `constraint_def` is the `pg_get_constraintdef` text (`EXCLUDE USING <method>
+    /// (…)`); the backing index `definition` is a plain `CREATE INDEX` Postgres
+    /// auto-created, which alone would NOT enforce the exclusion.
+    fn exclude_constraint_index_row(
+        index_name: &str,
+        constraint_name: &str,
+        dep_columns: &str,
+        index_definition: &str,
+        constraint_def: &str,
+    ) -> IndexRow {
+        IndexRow {
+            is_constraint: true,
+            constraint_type: "x".to_owned(),
+            constraint_name: constraint_name.to_owned(),
+            constraint_def: constraint_def.to_owned(),
+            // An EXCLUDE index is never `unique`.
+            ..index_row(
+                index_name,
+                false,
+                dep_columns,
+                dep_columns,
+                false,
+                false,
+                index_definition,
             )
         }
     }
@@ -1089,6 +1189,60 @@ mod tests {
         assert!(
             unique_cols.contains("email"),
             "single-column constraint-owned unique still sets the column unique flag"
+        );
+    }
+
+    #[test]
+    fn collapse_indexes_exclude_constraint_retained_as_real_constraint() {
+        // A range EXCLUDE constraint (`EXCLUDE USING gist (during WITH &&)`) is
+        // backed by a gist index Postgres auto-creates. Retaining ONLY that backing
+        // `CREATE INDEX` would NOT enforce the exclusion on a rollback/recreation
+        // (overlapping rows become possible — a data-integrity loss), so the retained
+        // `definition` must be the REAL constraint recreation: `ALTER TABLE … ADD
+        // CONSTRAINT … EXCLUDE USING …`, not a `CREATE INDEX`.
+        let index_def =
+            "CREATE INDEX reservations_during_excl ON public.reservations USING gist (during)";
+        let constraint_def = "EXCLUDE USING gist (during WITH &&)";
+        let rows = vec![exclude_constraint_index_row(
+            "reservations_during_excl",
+            "reservations_during_excl",
+            "during",
+            index_def,
+            constraint_def,
+        )];
+        let (indexes, unique_cols) = collapse_indexes(&rows);
+        assert_eq!(indexes.len(), 1);
+        let idx = &indexes[0];
+        let def = idx
+            .definition
+            .as_deref()
+            .expect("EXCLUDE constraint must be retained via a definition");
+        assert!(
+            def.contains("ADD CONSTRAINT reservations_during_excl")
+                && def.contains("EXCLUDE USING gist"),
+            "EXCLUDE index must be recreated as the real ADD CONSTRAINT … EXCLUDE form, got: {def}"
+        );
+        assert!(
+            !def.starts_with("CREATE INDEX") && !def.contains("CREATE INDEX"),
+            "the retained definition must NOT be the bare backing CREATE INDEX, got: {def}"
+        );
+        assert_eq!(
+            def,
+            // The fixture's table_name is "t"; the ALTER uses the bare table name
+            // form the emitter uses elsewhere (`index_sql` plain branch / CREATE TABLE).
+            "ALTER TABLE t ADD CONSTRAINT reservations_during_excl EXCLUDE USING gist (during WITH &&)",
+            "the ALTER TABLE must use the bare table name form the emitter uses elsewhere"
+        );
+        // Dependency (cascade) set is still populated; not unique; key_columns empty.
+        assert_eq!(idx.columns, vec!["during".to_owned()]);
+        assert!(!idx.unique, "an EXCLUDE index is not unique");
+        assert!(
+            idx.key_columns.is_empty(),
+            "EXCLUDE index leaves key_columns empty (not a #[unique] candidate)"
+        );
+        assert!(
+            unique_cols.is_empty(),
+            "an EXCLUDE constraint sets no column unique flag"
         );
     }
 

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -72,6 +72,15 @@
 //! - **Enum `CHECK` constraints**: enum recovery from `CHECK` expressions is a
 //!   later slice; a `TEXT`-with-`CHECK` column pulls back as plain
 //!   [`Text`](ColumnType::Text).
+//! - **Non-PK `SERIAL`/`BIGSERIAL` owned sequences**: a non-primary-key
+//!   `SERIAL`/`BIGSERIAL` column is preserved with its raw
+//!   `nextval('..._seq'::regclass)` default so the pulled snapshot and `doctor`
+//!   drift are faithful, but its owned sequence is not modeled; on rollback of a
+//!   dropped table/column the down migration would fail with a missing-relation
+//!   error rather than recreate the sequence. Owned-sequence / serial-identity
+//!   modeling is deferred to a later slice (alongside views/triggers). The forward
+//!   pull/doctor path is unaffected — it already round-trips the raw default
+//!   verbatim; only the down-migration recreation of the sequence is out of scope.
 //! - **Constraint-vs-index reconciliation for constraint-owned indexes**: an
 //!   **EXCLUDE** constraint (`pg_constraint.contype = 'x'`) IS preserved as the real
 //!   constraint: its retained `definition` is the

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -28,6 +28,13 @@
 //!
 //! # Deferred blind spots (documented, not silently dropped)
 //!
+//! - **Long-identifier unique index names**: Postgres truncates (or hashes) an
+//!   index/constraint identifier to `NAMEDATALEN` (63 bytes), but the model parser
+//!   emits the un-truncated derived name. So a `#[unique]` field with a long name
+//!   pulls back under the truncated DB identifier while the model side keeps the
+//!   full one — a pre-existing parser gap that makes a round-trip diff non-empty
+//!   for long field names. Introspection records the DB's identifier faithfully;
+//!   reconciling the two names is a later slice.
 //! - **Composite index key order**: multi-column index columns are ordered by
 //!   `attnum`, not the true index key order. The model parser only ever emits
 //!   single-column indexes (exact here), so this affects only hand-authored
@@ -240,9 +247,17 @@ fn fetch_columns(
     conn: &mut PgConnection,
     tables: &[String],
 ) -> Result<BTreeMap<String, Vec<ColumnRow>>, IntrospectError> {
+    // `numeric_precision` / `numeric_scale` are the `information_schema`
+    // `cardinal_number` domain, not a plain `int4`. Decoding that domain as diesel
+    // `Nullable<Integer>` on the wire is unproven (no sibling query reads them), and
+    // if it does not present as `int4` the whole column query would error and every
+    // pull would fail. Cast both to a plain `integer` in SQL so the output type is
+    // guaranteed `int4` regardless of the domain. The `AS <name>` aliases keep the
+    // result column names aligned with the `ColumnRow` field bindings.
     let query = format!(
         "SELECT table_name, column_name, udt_name, is_nullable, column_default, \
-         numeric_precision, numeric_scale FROM information_schema.columns \
+         numeric_precision::integer AS numeric_precision, \
+         numeric_scale::integer AS numeric_scale FROM information_schema.columns \
          WHERE table_schema = 'public' AND table_name IN ({}) \
          ORDER BY table_name, ordinal_position",
         quoted_in_list(tables)

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -24,7 +24,13 @@
 //! - **Uniqueness**: a single-column unique index sets the owning column's
 //!   `unique` flag *and* is recorded as an [`Index`] (`unique = true`), mirroring
 //!   how the model parser represents a `#[unique]` field, so a round-trip diff is
-//!   empty.
+//!   empty. A *constraint-owned* unique index — the auto-created index behind a
+//!   brownfield column/table-level `UNIQUE`/`EXCLUDE` constraint, which the
+//!   declarative model DSL cannot express (it models uniqueness as unique
+//!   *indexes*, not constraints) and which Postgres refuses to `DROP INDEX`
+//!   independently of its constraint — is instead **retained verbatim** via its
+//!   [`Index::definition`] (exactly like an expression/partial index), so a
+//!   model-side diff never emits a rejected `DROP INDEX`. See [`collapse_indexes`].
 //!
 //! # Deferred blind spots (documented, not silently dropped)
 //!
@@ -57,6 +63,18 @@
 //! - **Enum `CHECK` constraints**: enum recovery from `CHECK` expressions is a
 //!   later slice; a `TEXT`-with-`CHECK` column pulls back as plain
 //!   [`Text`](ColumnType::Text).
+//! - **Constraint-vs-index reconciliation for constraint-owned indexes**: a
+//!   brownfield `UNIQUE`/`EXCLUDE` constraint is retained by its *index*
+//!   definition (`pg_get_indexdef`, a valid `CREATE UNIQUE INDEX …`), not by the
+//!   originating `ALTER TABLE … ADD CONSTRAINT`. So if the authoritative path
+//!   (`pull --dry-run`) ever rendered a recreation it would emit the
+//!   `CREATE UNIQUE INDEX` form rather than re-adding the constraint; and a model
+//!   that *also* declares `#[unique]` on a column already covered by a brownfield
+//!   `UNIQUE` constraint additively creates the model's own
+//!   `idx_<table>_<col>_unique` index — a redundant-but-valid second unique
+//!   index, never a failure. Full constraint↔index reconciliation is deferred;
+//!   the load-bearing property this slice guarantees is only that the generated
+//!   migration no longer *fails* with a rejected `DROP INDEX`.
 //!
 //! Errors are **credential-safe** by construction: no variant ever embeds the
 //! resolved database URL (only a parsed host/port on the connection-error path,
@@ -186,6 +204,10 @@ struct TablePkRow {
 /// columns (the `indkey` entries `> 0`) in true key order; it is empty for an
 /// index whose keys are all expressions. `definition` is the verbatim
 /// `pg_get_indexdef` statement, preserved for expression/partial indexes.
+// A flat `QueryableByName` catalog-row DTO: each bool maps to one `pg_index`
+// classification column (`indisunique`, `indpred IS NOT NULL`, expression-key,
+// constraint-owned), so they are independent flags, not a state machine.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(QueryableByName)]
 struct IndexRow {
     #[diesel(sql_type = diesel::sql_types::Text)]
@@ -203,6 +225,12 @@ struct IndexRow {
     /// Whether any key column is an expression (an `indkey` entry equal to `0`).
     #[diesel(sql_type = diesel::sql_types::Bool)]
     has_expression: bool,
+    /// Whether the index backs a constraint (`pg_constraint.conindid` points at
+    /// it) — true for UNIQUE/EXCLUDE (and PK, but PKs are already filtered out).
+    /// Such an index cannot be dropped independently of its constraint, and the
+    /// model DSL cannot express it, so it is retained verbatim.
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    is_constraint: bool,
     /// Comma-joined resolvable ordinary column names, in key order (may be empty).
     #[diesel(sql_type = diesel::sql_types::Text)]
     columns: String,
@@ -343,8 +371,9 @@ fn fetch_primary_keys(
 /// matching `pg_attribute` row — is preserved rather than dropped by an inner
 /// join that returns nothing for it. The resolvable ordinary columns are
 /// aggregated in true key order via a correlated `unnest(indkey) WITH
-/// ORDINALITY` subquery; `has_expression` flags any `0` key and `is_partial`
-/// flags an `indpred`, so the builder can classify each index as
+/// ORDINALITY` subquery; `has_expression` flags any `0` key, `is_partial`
+/// flags an `indpred`, and `is_constraint` flags an index backing a
+/// `pg_constraint` (UNIQUE/EXCLUDE), so the builder can classify each index as
 /// simple-representable vs. preserved-verbatim.
 fn fetch_indexes(
     conn: &mut PgConnection,
@@ -359,6 +388,7 @@ fn fetch_indexes(
          i.indisunique AS is_unique, pg_get_indexdef(i.indexrelid) AS definition, \
          (i.indpred IS NOT NULL) AS is_partial, \
          (0 = ANY(string_to_array(i.indkey::text, ' ')::int[])) AS has_expression, \
+         EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conindid = i.indexrelid) AS is_constraint, \
          COALESCE(( \
            SELECT string_agg(a.attname, ',' ORDER BY k.ord) \
            FROM unnest(string_to_array(i.indkey::text, ' ')::int[]) \
@@ -476,15 +506,21 @@ fn build_table(
 /// matching how the model parser represents `#[unique]`).
 ///
 /// Each index is classified:
-/// - **simple/representable** — NOT partial AND has no expression key — is built
-///   as `Index { columns, unique, definition: None }` exactly as before, so a
-///   simple index's serialized JSON is byte-identical to prior snapshots and a
-///   single-column simple unique index still sets the owning column's `unique`
-///   flag for model-parser round-trip parity.
-/// - **expression or partial** — preserved verbatim via `definition:
-///   Some(pg_get_indexdef(...))`, never dropped. Its resolvable columns (if any)
-///   are still recorded for display, but it never sets a column `unique` flag
-///   (there is no single representable column).
+/// - **plain/representable** — NOT partial, NO expression key, AND NOT
+///   constraint-owned — is built as `Index { columns, unique, definition: None }`
+///   exactly as before, so a plain index's serialized JSON is byte-identical to
+///   prior snapshots and a single-column plain unique index (the model-DSL
+///   `#[unique]` shape, a bare `CREATE UNIQUE INDEX` with no backing constraint)
+///   still sets the owning column's `unique` flag for round-trip parity.
+/// - **expression, partial, or constraint-owned** — preserved verbatim via
+///   `definition: Some(pg_get_indexdef(...))`, never dropped. A constraint-owned
+///   index (a brownfield column/table-level `UNIQUE`/`EXCLUDE`, which auto-creates
+///   a `pg_constraint`-backed index Postgres refuses to drop independently, and
+///   which the declarative model DSL cannot express) is retained just like an
+///   expression/partial index, so a model-side diff never emits a `DROP INDEX`
+///   that Postgres would reject. A single-column constraint-owned unique index
+///   still sets the owning column's `unique` flag (accurate, and the flag is not
+///   diffed) — that classification is independent of constraint ownership.
 fn collapse_indexes(rows: &[IndexRow]) -> (Vec<Index>, std::collections::BTreeSet<String>) {
     let mut indexes = Vec::with_capacity(rows.len());
     let mut unique_columns = std::collections::BTreeSet::new();
@@ -495,27 +531,30 @@ fn collapse_indexes(rows: &[IndexRow]) -> (Vec<Index>, std::collections::BTreeSe
             .filter(|c| !c.is_empty())
             .map(str::to_owned)
             .collect();
+        // "Simple" == a single representable column set (not partial, not an
+        // expression). A single-column simple unique index sets the owning
+        // column's `unique` flag whether or not it backs a constraint (the flag
+        // is accurate either way and is never diffed).
         let simple = !row.is_partial && !row.has_expression;
-        if simple {
-            if row.is_unique && columns.len() == 1 {
-                unique_columns.insert(columns[0].clone());
-            }
-            indexes.push(Index {
-                name: row.index_name.clone(),
-                columns,
-                unique: row.is_unique,
-                definition: None,
-            });
-        } else {
-            // Expression/partial index: preserve its canonical statement so it is
-            // never dropped and diffs by its verbatim text.
-            indexes.push(Index {
-                name: row.index_name.clone(),
-                columns,
-                unique: row.is_unique,
-                definition: Some(row.definition.clone()),
-            });
+        if simple && row.is_unique && columns.len() == 1 {
+            unique_columns.insert(columns[0].clone());
         }
+        // Retain (preserve verbatim, never drop) any index the model DSL cannot
+        // express: an expression or partial index, OR a constraint-owned index
+        // (UNIQUE/EXCLUDE) whose backing constraint Postgres won't let us drop.
+        // A plain, non-constraint index keeps `definition: None` so its JSON is
+        // unchanged and the model round-trip stays clean.
+        let definition = if simple && !row.is_constraint {
+            None
+        } else {
+            Some(row.definition.clone())
+        };
+        indexes.push(Index {
+            name: row.index_name.clone(),
+            columns,
+            unique: row.is_unique,
+            definition,
+        });
     }
     (indexes, unique_columns)
 }
@@ -668,7 +707,9 @@ mod tests {
     }
 
     /// Build a one-per-index [`IndexRow`] for tests. `columns` is the comma-joined
-    /// resolvable-column string the SQL aggregation produces.
+    /// resolvable-column string the SQL aggregation produces. `is_constraint` is
+    /// left `false` (an ordinary/model-style or expression/partial index); use
+    /// [`constraint_index_row`] for a constraint-owned index.
     fn index_row(
         index_name: &str,
         is_unique: bool,
@@ -684,7 +725,23 @@ mod tests {
             definition: definition.to_owned(),
             is_partial,
             has_expression,
+            is_constraint: false,
             columns: columns.to_owned(),
+        }
+    }
+
+    /// Build a constraint-owned (non-primary, non-partial, non-expression)
+    /// [`IndexRow`] — the auto-created index behind a brownfield column/table-level
+    /// `UNIQUE`/`EXCLUDE` constraint (`is_constraint == true`).
+    fn constraint_index_row(
+        index_name: &str,
+        is_unique: bool,
+        columns: &str,
+        definition: &str,
+    ) -> IndexRow {
+        IndexRow {
+            is_constraint: true,
+            ..index_row(index_name, is_unique, columns, false, false, definition)
         }
     }
 
@@ -795,6 +852,58 @@ mod tests {
             unique_cols.is_empty(),
             "partial index sets no column unique flag"
         );
+    }
+
+    #[test]
+    fn collapse_indexes_constraint_owned_index_retained_via_definition() {
+        // A brownfield column-level `UNIQUE` (e.g. `email TEXT UNIQUE`) auto-creates
+        // a constraint-backed index Postgres names (e.g. `users_email_key`). It must
+        // be RETAINED verbatim via `definition` (never an ordinary droppable index),
+        // so a later model-side diff can't emit a `DROP INDEX` Postgres rejects. Its
+        // single-column `unique` flag is still set (accurate, and not diffed).
+        let def = "CREATE UNIQUE INDEX users_email_key ON public.users USING btree (email)";
+        let rows = vec![constraint_index_row("users_email_key", true, "email", def)];
+        let (indexes, unique_cols) = collapse_indexes(&rows);
+        assert_eq!(indexes.len(), 1);
+        assert_eq!(indexes[0].name, "users_email_key");
+        assert_eq!(indexes[0].columns, vec!["email".to_owned()]);
+        assert!(indexes[0].unique);
+        assert_eq!(
+            indexes[0].definition.as_deref(),
+            Some(def),
+            "constraint-owned index must be retained via its definition, not left droppable"
+        );
+        assert!(
+            unique_cols.contains("email"),
+            "single-column constraint-owned unique still sets the column unique flag"
+        );
+    }
+
+    #[test]
+    fn collapse_indexes_model_style_unique_index_stays_ordinary_droppable() {
+        // The MODEL style: `CREATE UNIQUE INDEX idx_users_email_unique` with NO
+        // backing constraint (`is_constraint == false`) must stay an ORDINARY
+        // `Index { definition: None }` so the migrate-from-models round-trip is
+        // clean — a `#[unique]` field produces a plain unique index, not a
+        // constraint, so it is diffable/droppable as before.
+        let def = "CREATE UNIQUE INDEX idx_users_email_unique ON public.users USING btree (email)";
+        let rows = vec![index_row(
+            "idx_users_email_unique",
+            true,
+            "email",
+            false,
+            false,
+            def,
+        )];
+        let (indexes, unique_cols) = collapse_indexes(&rows);
+        assert_eq!(indexes.len(), 1);
+        assert_eq!(indexes[0].name, "idx_users_email_unique");
+        assert!(indexes[0].unique);
+        assert_eq!(
+            indexes[0].definition, None,
+            "a non-constraint (model-style) unique index stays ordinary/droppable"
+        );
+        assert!(unique_cols.contains("email"));
     }
 
     #[test]

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -1,0 +1,741 @@
+//! Postgres database introspection into the [`autumn_schema_core`] schema IR —
+//! the read-side of `autumn schema pull` (the first DB-introspection slice of
+//! tracking issue #1975).
+//!
+//! Where [`crate::schema::parse`] lifts the **declared** `#[model]` structs into
+//! the IR (the desired state), this module lifts the **live database** into the
+//! same IR — a [`Table`] per public base table, with columns, primary keys,
+//! unique/plain indexes, and single-column foreign keys — so a pulled snapshot
+//! and the model-derived snapshot are directly diffable by the same
+//! [`crate::schema::diff`] engine.
+//!
+//! # Design notes / fidelity
+//!
+//! - **Centralized type mapping**: every column type flows through
+//!   [`ColumnType::from_pg_introspection`], which preserves an unmappable
+//!   Postgres type as [`ColumnType::Opaque`] rather than dropping the column —
+//!   introspection never silently loses a column.
+//! - **Serial/UUID PK round-trip**: a single-column integer PK whose default is a
+//!   `nextval(...)` sequence is a `BIGSERIAL`-shaped id, which the model IR
+//!   represents as an [`Int64`](ColumnType::Int64) PK with **no** default — so the
+//!   `nextval` default is stripped to `None`. A single-column UUID PK keeps its
+//!   `gen_random_uuid()` default (the model parser records the same), so the two
+//!   agree. See [`normalize_default`] / [`normalize_serial_pk_default`].
+//! - **Uniqueness**: a single-column unique index sets the owning column's
+//!   `unique` flag *and* is recorded as an [`Index`] (`unique = true`), mirroring
+//!   how the model parser represents a `#[unique]` field, so a round-trip diff is
+//!   empty.
+//!
+//! # Deferred blind spots (documented, not silently dropped)
+//!
+//! - **Composite index key order**: multi-column index columns are ordered by
+//!   `attnum`, not the true index key order. The model parser only ever emits
+//!   single-column indexes (exact here), so this affects only hand-authored
+//!   multi-column indexes; recording them faithfully but with attnum ordering is
+//!   preferred over dropping them.
+//! - **Composite / multi-column foreign keys**: only the first
+//!   referencing/referenced column pair is recorded (the IR [`ForeignKey`] is
+//!   single-column). The model parser never emits a composite FK.
+//! - **Foreign-key / constraint names**: the IR [`ForeignKey`] carries only
+//!   `table`/`column`, so the Postgres constraint name is not represented (and so
+//!   never diffed).
+//! - **Enum `CHECK` constraints**: enum recovery from `CHECK` expressions is a
+//!   later slice; a `TEXT`-with-`CHECK` column pulls back as plain
+//!   [`Text`](ColumnType::Text).
+//!
+//! Errors are **credential-safe** by construction: no variant ever embeds the
+//! resolved database URL (only a parsed host/port on the connection-error path,
+//! mirroring [`crate::db_pull`]).
+
+use std::collections::BTreeMap;
+
+use autumn_schema_core::{Backend, Column, ColumnDefault, ColumnType, ForeignKey, Index, Table};
+use diesel::{Connection as _, PgConnection, QueryableByName, RunQueryDsl as _, sql_query};
+
+/// Failure modes for Postgres introspection. `Display` is credential-safe: the
+/// resolved URL is never embedded — only a parsed host/port on the connection
+/// path, and server-sourced messages on the query path.
+#[derive(Debug, thiserror::Error)]
+pub enum IntrospectError {
+    /// The database could not be connected to. Carries only a parsed host/port,
+    /// never credentials.
+    #[error(
+        "could not connect to Postgres at {host}:{port} — is the server running and reachable?"
+    )]
+    Connection {
+        /// The parsed host (defaulting to `localhost` when unparseable).
+        host: String,
+        /// The parsed port (defaulting to `5432` when unparseable).
+        port: u16,
+    },
+    /// A catalog query failed. The message comes from the server, not the URL.
+    #[error("database introspection query failed: {0}")]
+    Query(String),
+}
+
+/// Introspect the `public` schema of the Postgres database at `url` into a set of
+/// [`Table`]s tagged [`Backend::Postgres`] and marked `managed`.
+///
+/// Framework-owned tables (the `autumn_*` / `_autumn*` prefixes plus Diesel's
+/// bookkeeping table) are excluded, mirroring [`crate::db_pull`]'s unscoped-pull
+/// rule, so a pulled snapshot describes only the app's own tables.
+///
+/// # Errors
+///
+/// Returns [`IntrospectError::Connection`] if the database is unreachable, or
+/// [`IntrospectError::Query`] if a catalog query fails. Neither ever leaks the
+/// database URL.
+pub fn introspect_postgres(url: &str) -> Result<Vec<Table>, IntrospectError> {
+    // `PgConnection::establish` accepts both URL and libpq key-value DSNs; defer
+    // URL parsing to the error path so a valid key-value string still connects
+    // (host/port are only needed for a credential-safe message). Mirrors db_pull.
+    let mut conn = PgConnection::establish(url).map_err(|_| {
+        let (host, port) = parse_host_port(url).unwrap_or_else(|| ("localhost".to_owned(), 5432));
+        IntrospectError::Connection { host, port }
+    })?;
+
+    let table_names = list_tables(&mut conn)?;
+    if table_names.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Batched catalog reads — a constant number of queries regardless of table
+    // count (never one query per table).
+    let columns_by_table = fetch_columns(&mut conn, &table_names)?;
+    let pks_by_table = fetch_primary_keys(&mut conn, &table_names)?;
+    let indexes_by_table = fetch_indexes(&mut conn, &table_names)?;
+    let fks_by_table = fetch_foreign_keys(&mut conn, &table_names)?;
+
+    let mut tables = Vec::with_capacity(table_names.len());
+    for name in &table_names {
+        tables.push(build_table(
+            name,
+            columns_by_table.get(name).map_or(&[][..], Vec::as_slice),
+            pks_by_table.get(name).map_or(&[][..], Vec::as_slice),
+            indexes_by_table.get(name).map_or(&[][..], Vec::as_slice),
+            fks_by_table.get(name).map_or(&[][..], Vec::as_slice),
+        ));
+    }
+    Ok(tables)
+}
+
+/// Parse host/port from a connection URL for credential-safe error messages.
+fn parse_host_port(url: &str) -> Option<(String, u16)> {
+    let parsed = url::Url::parse(url).ok()?;
+    let host = parsed.host_str().unwrap_or("localhost").to_owned();
+    let port = parsed.port().unwrap_or(5432);
+    Some((host, port))
+}
+
+// ---------------------------------------------------------------------------
+// Catalog row shapes
+// ---------------------------------------------------------------------------
+
+#[derive(QueryableByName)]
+struct NameRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    name: String,
+}
+
+#[derive(QueryableByName)]
+struct ColumnRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    table_name: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    column_name: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    udt_name: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    is_nullable: String,
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+    column_default: Option<String>,
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Integer>)]
+    numeric_precision: Option<i32>,
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Integer>)]
+    numeric_scale: Option<i32>,
+}
+
+#[derive(QueryableByName)]
+struct TablePkRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    table_name: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    column_name: String,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    ord: i32,
+}
+
+#[derive(QueryableByName)]
+struct IndexRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    table_name: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    index_name: String,
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    is_unique: bool,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    column_name: String,
+    #[diesel(sql_type = diesel::sql_types::SmallInt)]
+    attnum: i16,
+}
+
+#[derive(QueryableByName)]
+struct ForeignKeyRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    table_name: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    column_name: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    foreign_table: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    foreign_column: String,
+}
+
+// ---------------------------------------------------------------------------
+// Catalog probes
+// ---------------------------------------------------------------------------
+
+/// List the `public` base tables, excluding Diesel's bookkeeping table and
+/// Autumn/Diesel framework-owned tables (mirrors [`crate::db_pull`]'s unscoped
+/// rule).
+fn list_tables(conn: &mut PgConnection) -> Result<Vec<String>, IntrospectError> {
+    let query = "SELECT table_name AS name FROM information_schema.tables \
+         WHERE table_schema = 'public' AND table_type = 'BASE TABLE' \
+         AND table_name <> '__diesel_schema_migrations' \
+         ORDER BY table_name";
+    let rows: Vec<NameRow> = sql_query(query)
+        .load(conn)
+        .map_err(|e| IntrospectError::Query(e.to_string()))?;
+    Ok(rows
+        .into_iter()
+        .map(|r| r.name)
+        .filter(|t| !is_framework_table(t))
+        .collect())
+}
+
+/// Whether `table` is an Autumn/Diesel framework-owned table an introspection
+/// should skip. Kept in lock-step with [`crate::db_pull`]'s `is_framework_table`.
+fn is_framework_table(table: &str) -> bool {
+    table.starts_with("autumn_")
+        || table.starts_with("_autumn")
+        || matches!(
+            table,
+            "api_tokens" | "feature_flag_changes" | "__diesel_schema_migrations"
+        )
+}
+
+/// Build a comma-separated SQL string-literal list (`'a', 'b'`) for an `IN (..)`
+/// clause from catalog-sourced names. `tables` is always non-empty here.
+fn quoted_in_list(tables: &[String]) -> String {
+    tables
+        .iter()
+        .map(|t| crate::db::quote_literal(t))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Fetch every column (ordinal order) for all `tables` in one query, grouped by
+/// table.
+fn fetch_columns(
+    conn: &mut PgConnection,
+    tables: &[String],
+) -> Result<BTreeMap<String, Vec<ColumnRow>>, IntrospectError> {
+    let query = format!(
+        "SELECT table_name, column_name, udt_name, is_nullable, column_default, \
+         numeric_precision, numeric_scale FROM information_schema.columns \
+         WHERE table_schema = 'public' AND table_name IN ({}) \
+         ORDER BY table_name, ordinal_position",
+        quoted_in_list(tables)
+    );
+    let rows: Vec<ColumnRow> = sql_query(query)
+        .load(conn)
+        .map_err(|e| IntrospectError::Query(e.to_string()))?;
+    let mut by_table: BTreeMap<String, Vec<ColumnRow>> = BTreeMap::new();
+    for row in rows {
+        by_table
+            .entry(row.table_name.clone())
+            .or_default()
+            .push(row);
+    }
+    Ok(by_table)
+}
+
+/// Fetch the primary-key columns (in key order) for all `tables`, grouped by
+/// table.
+fn fetch_primary_keys(
+    conn: &mut PgConnection,
+    tables: &[String],
+) -> Result<BTreeMap<String, Vec<String>>, IntrospectError> {
+    // `array_position(i.indkey::int2[]::int[], a.attnum::int)` recovers the true
+    // key position. The `int2vector -> text -> int[]` cast chain is the portable
+    // way to turn `indkey` into a subscriptable array for `array_position`.
+    let query = format!(
+        "SELECT c.relname AS table_name, a.attname AS column_name, \
+         array_position(string_to_array(i.indkey::text, ' ')::int[], a.attnum::int) AS ord \
+         FROM pg_index i \
+         JOIN pg_class c ON c.oid = i.indrelid \
+         JOIN pg_namespace n ON n.oid = c.relnamespace \
+         JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) \
+         WHERE n.nspname = 'public' AND i.indisprimary AND c.relname IN ({}) \
+         ORDER BY c.relname, ord",
+        quoted_in_list(tables)
+    );
+    let rows: Vec<TablePkRow> = sql_query(query)
+        .load(conn)
+        .map_err(|e| IntrospectError::Query(e.to_string()))?;
+    // Rows arrive ordered by (table, key position), so push preserves key order.
+    let mut by_table: BTreeMap<String, Vec<(i32, String)>> = BTreeMap::new();
+    for row in rows {
+        by_table
+            .entry(row.table_name)
+            .or_default()
+            .push((row.ord, row.column_name));
+    }
+    Ok(by_table
+        .into_iter()
+        .map(|(table, mut cols)| {
+            cols.sort_by_key(|(ord, _)| *ord);
+            (table, cols.into_iter().map(|(_, name)| name).collect())
+        })
+        .collect())
+}
+
+/// Fetch every non-primary index (unique and plain) for all `tables`, grouped by
+/// table. One row per (index, column); the builder collapses them into
+/// [`Index`]es. Composite index columns are ordered by `attnum` (see the module
+/// blind-spot note).
+fn fetch_indexes(
+    conn: &mut PgConnection,
+    tables: &[String],
+) -> Result<BTreeMap<String, Vec<IndexRow>>, IntrospectError> {
+    let query = format!(
+        "SELECT t.relname AS table_name, ic.relname AS index_name, \
+         i.indisunique AS is_unique, a.attname AS column_name, a.attnum AS attnum \
+         FROM pg_index i \
+         JOIN pg_class t ON t.oid = i.indrelid \
+         JOIN pg_class ic ON ic.oid = i.indexrelid \
+         JOIN pg_namespace n ON n.oid = t.relnamespace \
+         JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) \
+         WHERE n.nspname = 'public' AND NOT i.indisprimary AND t.relname IN ({}) \
+         ORDER BY t.relname, ic.relname, a.attnum",
+        quoted_in_list(tables)
+    );
+    let rows: Vec<IndexRow> = sql_query(query)
+        .load(conn)
+        .map_err(|e| IntrospectError::Query(e.to_string()))?;
+    let mut by_table: BTreeMap<String, Vec<IndexRow>> = BTreeMap::new();
+    for row in rows {
+        by_table
+            .entry(row.table_name.clone())
+            .or_default()
+            .push(row);
+    }
+    Ok(by_table)
+}
+
+/// Fetch single-column foreign keys for all `tables`, grouped by table. Only the
+/// first referencing/referenced column pair is read (see the module blind-spot
+/// note); the model parser never emits a composite FK.
+fn fetch_foreign_keys(
+    conn: &mut PgConnection,
+    tables: &[String],
+) -> Result<BTreeMap<String, Vec<ForeignKeyRow>>, IntrospectError> {
+    let query = format!(
+        "SELECT t.relname AS table_name, att.attname AS column_name, \
+         ft.relname AS foreign_table, fatt.attname AS foreign_column \
+         FROM pg_constraint con \
+         JOIN pg_class t ON t.oid = con.conrelid \
+         JOIN pg_namespace n ON n.oid = t.relnamespace \
+         JOIN pg_class ft ON ft.oid = con.confrelid \
+         JOIN pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = con.conkey[1] \
+         JOIN pg_attribute fatt ON fatt.attrelid = con.confrelid AND fatt.attnum = con.confkey[1] \
+         WHERE con.contype = 'f' AND n.nspname = 'public' AND t.relname IN ({})",
+        quoted_in_list(tables)
+    );
+    let rows: Vec<ForeignKeyRow> = sql_query(query)
+        .load(conn)
+        .map_err(|e| IntrospectError::Query(e.to_string()))?;
+    let mut by_table: BTreeMap<String, Vec<ForeignKeyRow>> = BTreeMap::new();
+    for row in rows {
+        by_table
+            .entry(row.table_name.clone())
+            .or_default()
+            .push(row);
+    }
+    Ok(by_table)
+}
+
+// ---------------------------------------------------------------------------
+// IR assembly (pure over the fetched rows)
+// ---------------------------------------------------------------------------
+
+/// Assemble one [`Table`] from its pre-fetched catalog rows. Pure — no I/O.
+fn build_table(
+    name: &str,
+    columns: &[ColumnRow],
+    primary_key: &[String],
+    indexes: &[IndexRow],
+    foreign_keys: &[ForeignKeyRow],
+) -> Table {
+    let mut table = Table::new(name, Backend::Postgres);
+    table.managed = true;
+    table.primary_key = primary_key.to_vec();
+
+    // Collapse index rows into IR indexes, keyed by index name (input already
+    // sorted by table, index name, attnum). Also derive the per-column `unique`
+    // flag from single-column unique indexes (mirroring the model IR).
+    let (ir_indexes, unique_columns) = collapse_indexes(indexes);
+
+    // Foreign keys by referencing column name (first pair only).
+    let fk_by_column: BTreeMap<&str, &ForeignKeyRow> = foreign_keys
+        .iter()
+        .map(|fk| (fk.column_name.as_str(), fk))
+        .collect();
+
+    for row in columns {
+        let ty = ColumnType::from_pg_introspection(
+            &row.udt_name,
+            row.numeric_precision,
+            row.numeric_scale,
+        );
+        let is_pk = primary_key.iter().any(|c| c == &row.column_name);
+        let mut column = Column::new(row.column_name.clone(), ty.clone());
+        column.nullable = row.is_nullable.eq_ignore_ascii_case("YES");
+        column.primary_key = is_pk;
+        column.unique = unique_columns.contains(row.column_name.as_str());
+        column.default = normalize_default(row.column_default.as_deref(), &ty, is_pk, primary_key);
+        if let Some(fk) = fk_by_column.get(row.column_name.as_str()) {
+            column.references = Some(ForeignKey::new(
+                fk.foreign_table.clone(),
+                fk.foreign_column.clone(),
+            ));
+        }
+        table.columns.push(column);
+    }
+
+    table.indexes = ir_indexes;
+    table
+}
+
+/// Collapse per-(index, column) rows into IR [`Index`]es plus the set of columns
+/// that are covered by a **single-column unique** index (used to set the column
+/// `unique` flag, matching how the model parser represents `#[unique]`).
+fn collapse_indexes(rows: &[IndexRow]) -> (Vec<Index>, std::collections::BTreeSet<String>) {
+    // Preserve first-seen index order while grouping columns.
+    let mut order: Vec<String> = Vec::new();
+    let mut grouped: BTreeMap<String, (bool, Vec<(i16, String)>)> = BTreeMap::new();
+    for row in rows {
+        let entry = grouped.entry(row.index_name.clone()).or_insert_with(|| {
+            order.push(row.index_name.clone());
+            (row.is_unique, Vec::new())
+        });
+        entry.0 = row.is_unique;
+        entry.1.push((row.attnum, row.column_name.clone()));
+    }
+
+    let mut indexes = Vec::with_capacity(order.len());
+    let mut unique_columns = std::collections::BTreeSet::new();
+    for name in order {
+        let (unique, mut cols) = grouped.remove(&name).expect("grouped index present");
+        cols.sort_by_key(|(attnum, _)| *attnum);
+        let columns: Vec<String> = cols.into_iter().map(|(_, c)| c).collect();
+        if unique && columns.len() == 1 {
+            unique_columns.insert(columns[0].clone());
+        }
+        indexes.push(Index {
+            name,
+            columns,
+            unique,
+        });
+    }
+    (indexes, unique_columns)
+}
+
+/// Normalize a raw Postgres `column_default` string into a [`ColumnDefault`],
+/// matching what the model IR records so a round-trip diff is empty.
+///
+/// - `NULL` (no default) → `None`.
+/// - `now()` / `CURRENT_TIMESTAMP` → [`ColumnDefault::Now`].
+/// - a `nextval(...)` serial default on a single-column integer primary key →
+///   `None` (a `BIGSERIAL`-shaped id has no explicit default in the model IR;
+///   see [`normalize_serial_pk_default`]).
+/// - anything else → [`ColumnDefault::Sql`] verbatim (e.g. a UUID PK's
+///   `gen_random_uuid()`, which the model parser records identically).
+fn normalize_default(
+    raw: Option<&str>,
+    ty: &ColumnType,
+    is_primary_key: bool,
+    primary_key: &[String],
+) -> Option<ColumnDefault> {
+    let raw = raw?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let lowered = raw.to_ascii_lowercase();
+    if lowered == "now()" || lowered == "current_timestamp" {
+        return Some(ColumnDefault::Now);
+    }
+    // A serial (`nextval(...)`) default on a single-column integer PK is the
+    // BIGSERIAL id shape — the model IR carries no explicit default for it.
+    if normalize_serial_pk_default(&lowered, ty, is_primary_key, primary_key) {
+        return None;
+    }
+    Some(ColumnDefault::Sql(raw.to_owned()))
+}
+
+/// Whether a raw (lower-cased) default is the auto-increment sequence default of
+/// a single-column integer primary key — i.e. the shape the model IR represents
+/// as an [`Int64`](ColumnType::Int64) PK with **no** default. Such a default is
+/// stripped to `None` so an introspected `BIGSERIAL` id round-trips against the
+/// model parser (whose `pk_kind_for` requires `default.is_none()` for a
+/// `BigSerial` PK).
+fn normalize_serial_pk_default(
+    lowered_default: &str,
+    ty: &ColumnType,
+    is_primary_key: bool,
+    primary_key: &[String],
+) -> bool {
+    is_primary_key
+        && primary_key.len() == 1
+        && matches!(ty, ColumnType::Int32 | ColumnType::Int64)
+        && lowered_default.starts_with("nextval(")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_host_port_extracts_and_defaults() {
+        let (host, port) = parse_host_port("postgres://u:pw@db.example.com:6543/app").unwrap();
+        assert_eq!(host, "db.example.com");
+        assert_eq!(port, 6543);
+        let (host, port) = parse_host_port("postgres://localhost/app").unwrap();
+        assert_eq!(host, "localhost");
+        assert_eq!(port, 5432);
+    }
+
+    #[test]
+    fn connection_error_is_credential_safe() {
+        let err = IntrospectError::Connection {
+            host: "db.example.com".to_owned(),
+            port: 5432,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("db.example.com"));
+        assert!(!msg.contains("hunter2") && !msg.contains("postgres://"));
+    }
+
+    #[test]
+    fn framework_tables_are_excluded_user_tables_kept() {
+        for fw in [
+            "autumn_jobs",
+            "_autumn_version_history",
+            "api_tokens",
+            "feature_flag_changes",
+            "__diesel_schema_migrations",
+        ] {
+            assert!(is_framework_table(fw), "{fw} is a framework table");
+        }
+        for user in ["posts", "comments", "accounts"] {
+            assert!(!is_framework_table(user), "{user} must be kept");
+        }
+    }
+
+    #[test]
+    fn normalize_default_now_variants() {
+        let now = normalize_default(Some("now()"), &ColumnType::Timestamp, false, &[]);
+        assert_eq!(now, Some(ColumnDefault::Now));
+        let ct = normalize_default(
+            Some("CURRENT_TIMESTAMP"),
+            &ColumnType::TimestampTz,
+            false,
+            &[],
+        );
+        assert_eq!(ct, Some(ColumnDefault::Now));
+    }
+
+    #[test]
+    fn normalize_default_null_is_none() {
+        assert_eq!(normalize_default(None, &ColumnType::Text, false, &[]), None);
+        assert_eq!(
+            normalize_default(Some("  "), &ColumnType::Text, false, &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn normalize_serial_pk_default_stripped_to_none() {
+        // A `nextval(...)` default on a single-column int PK → None (BIGSERIAL id).
+        let pk = vec!["id".to_owned()];
+        let d = normalize_default(
+            Some("nextval('posts_id_seq'::regclass)"),
+            &ColumnType::Int64,
+            true,
+            &pk,
+        );
+        assert_eq!(d, None, "serial PK default must be stripped to None");
+    }
+
+    #[test]
+    fn normalize_serial_default_on_non_pk_is_kept_as_sql() {
+        // A sequence default on a NON-pk column is not the id shape — keep it.
+        let d = normalize_default(
+            Some("nextval('counter_seq'::regclass)"),
+            &ColumnType::Int64,
+            false,
+            &[],
+        );
+        assert!(matches!(d, Some(ColumnDefault::Sql(_))));
+    }
+
+    #[test]
+    fn normalize_uuid_pk_default_is_kept_as_sql() {
+        // A UUID PK keeps its gen_random_uuid() default (the model parser records
+        // the same), so the two agree on a round-trip.
+        let pk = vec!["id".to_owned()];
+        let d = normalize_default(Some("gen_random_uuid()"), &ColumnType::Uuid, true, &pk);
+        assert_eq!(d, Some(ColumnDefault::Sql("gen_random_uuid()".to_owned())));
+    }
+
+    #[test]
+    fn collapse_indexes_single_column_unique_sets_flag_and_index() {
+        let rows = vec![IndexRow {
+            table_name: "accounts".to_owned(),
+            index_name: "idx_accounts_email_unique".to_owned(),
+            is_unique: true,
+            column_name: "email".to_owned(),
+            attnum: 2,
+        }];
+        let (indexes, unique_cols) = collapse_indexes(&rows);
+        assert_eq!(indexes.len(), 1);
+        assert_eq!(indexes[0].name, "idx_accounts_email_unique");
+        assert_eq!(indexes[0].columns, vec!["email".to_owned()]);
+        assert!(indexes[0].unique);
+        assert!(unique_cols.contains("email"));
+    }
+
+    #[test]
+    fn collapse_indexes_plain_index_no_unique_flag() {
+        let rows = vec![IndexRow {
+            table_name: "comments".to_owned(),
+            index_name: "idx_comments_post_id".to_owned(),
+            is_unique: false,
+            column_name: "post_id".to_owned(),
+            attnum: 2,
+        }];
+        let (indexes, unique_cols) = collapse_indexes(&rows);
+        assert_eq!(indexes.len(), 1);
+        assert!(!indexes[0].unique);
+        assert!(unique_cols.is_empty());
+    }
+
+    #[test]
+    fn collapse_indexes_multi_column_unique_only_index_not_column_flag() {
+        // A composite unique index records an Index but does NOT set a per-column
+        // unique flag (the model IR's `unique` flag is single-column only).
+        let rows = vec![
+            IndexRow {
+                table_name: "memberships".to_owned(),
+                index_name: "idx_memberships_org_user".to_owned(),
+                is_unique: true,
+                column_name: "org_id".to_owned(),
+                attnum: 2,
+            },
+            IndexRow {
+                table_name: "memberships".to_owned(),
+                index_name: "idx_memberships_org_user".to_owned(),
+                is_unique: true,
+                column_name: "user_id".to_owned(),
+                attnum: 3,
+            },
+        ];
+        let (indexes, unique_cols) = collapse_indexes(&rows);
+        assert_eq!(indexes.len(), 1);
+        assert_eq!(
+            indexes[0].columns,
+            vec!["org_id".to_owned(), "user_id".to_owned()]
+        );
+        assert!(indexes[0].unique);
+        assert!(
+            unique_cols.is_empty(),
+            "composite unique sets no column flag"
+        );
+    }
+
+    #[test]
+    fn build_table_assembles_columns_pk_fk_and_indexes() {
+        let columns = vec![
+            ColumnRow {
+                table_name: "comments".to_owned(),
+                column_name: "id".to_owned(),
+                udt_name: "int8".to_owned(),
+                is_nullable: "NO".to_owned(),
+                column_default: Some("nextval('comments_id_seq'::regclass)".to_owned()),
+                numeric_precision: None,
+                numeric_scale: None,
+            },
+            ColumnRow {
+                table_name: "comments".to_owned(),
+                column_name: "post_id".to_owned(),
+                udt_name: "int8".to_owned(),
+                is_nullable: "NO".to_owned(),
+                column_default: None,
+                numeric_precision: None,
+                numeric_scale: None,
+            },
+        ];
+        let pk = vec!["id".to_owned()];
+        let indexes = vec![IndexRow {
+            table_name: "comments".to_owned(),
+            index_name: "idx_comments_post_id".to_owned(),
+            is_unique: false,
+            column_name: "post_id".to_owned(),
+            attnum: 2,
+        }];
+        let fks = vec![ForeignKeyRow {
+            table_name: "comments".to_owned(),
+            column_name: "post_id".to_owned(),
+            foreign_table: "posts".to_owned(),
+            foreign_column: "id".to_owned(),
+        }];
+        let table = build_table("comments", &columns, &pk, &indexes, &fks);
+        assert_eq!(table.name, "comments");
+        assert!(table.managed);
+        assert_eq!(table.primary_key, vec!["id".to_owned()]);
+
+        let id = table.columns.iter().find(|c| c.name == "id").unwrap();
+        assert_eq!(id.ty, ColumnType::Int64);
+        assert!(id.primary_key);
+        // The serial default is stripped → BigSerial id shape.
+        assert_eq!(id.default, None);
+
+        let post_id = table.columns.iter().find(|c| c.name == "post_id").unwrap();
+        assert_eq!(post_id.references, Some(ForeignKey::new("posts", "id")));
+
+        assert_eq!(table.indexes.len(), 1);
+        assert_eq!(table.indexes[0].name, "idx_comments_post_id");
+    }
+
+    #[test]
+    fn build_table_preserves_opaque_type() {
+        let columns = vec![ColumnRow {
+            table_name: "widgets".to_owned(),
+            column_name: "addr".to_owned(),
+            udt_name: "inet".to_owned(),
+            is_nullable: "YES".to_owned(),
+            column_default: None,
+            numeric_precision: None,
+            numeric_scale: None,
+        }];
+        let table = build_table("widgets", &columns, &[], &[], &[]);
+        let addr = table.columns.iter().find(|c| c.name == "addr").unwrap();
+        assert_eq!(
+            addr.ty,
+            ColumnType::Opaque {
+                pg_type: "inet".to_owned()
+            }
+        );
+        assert!(addr.nullable);
+    }
+}

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -504,9 +504,16 @@ fn load_existing_snapshot(path: &Path) -> Option<SchemaSnapshot> {
     snapshot::load_snapshot(path).ok()
 }
 
-/// Print what a `--dry-run` pull would change: the pending migration plan between
-/// the existing snapshot (baseline) and the freshly-pulled tables (desired),
-/// without writing anything.
+/// Print what a `--dry-run` pull would change between the existing snapshot
+/// (baseline) and the freshly-pulled tables, without writing anything.
+///
+/// Drift is computed BIDIRECTIONALLY (via [`doctor::compute_db_schema_drift`]) so
+/// the dry-run never under-reports: the forward plan is what pulling would change
+/// in the snapshot, but a manually-dropped default / FK / CHECK in the live DB is
+/// invisible to the forward pass (a desired `None` is "retained") and only surfaces
+/// in the reverse plan. When the forward plan has changes it is printed via
+/// [`diff::describe_plan`]; when only the reverse plan does, a short note names the
+/// dropped-facet differences so they are not silently omitted.
 fn report_pull_dry_run(
     pulled: &SchemaSnapshot,
     existing: Option<&SchemaSnapshot>,
@@ -522,21 +529,31 @@ fn report_pull_dry_run(
             );
         }
         Some(existing) => {
-            let desired = parse::ParsedSchema::from_tables(pulled.tables.clone());
-            let plan = diff::diff_schema(&existing.tables, &desired, diff::DiffOptions::default());
-            if plan.is_empty() {
-                println!(
-                    "--dry-run: the snapshot at {} is up to date — the database matches it.",
-                    out_path.display()
-                );
-            } else {
+            let drift = doctor::compute_db_schema_drift(&existing.tables, &pulled.tables);
+            if !drift.forward.is_empty() {
                 println!(
                     "--dry-run: the database differs from the snapshot at {} — {} change(s) would \
                      be captured (nothing written):",
                     out_path.display(),
-                    plan.changes.len()
+                    drift.forward.changes.len()
                 );
-                print!("{}", diff::describe_plan(&plan));
+                print!("{}", diff::describe_plan(&drift.forward));
+            } else if !drift.reverse.is_empty() {
+                // The forward pass found nothing to pull, but the reverse pass did:
+                // the live DB dropped a default / foreign key / CHECK the snapshot
+                // still carries. Name it rather than falsely report "up to date".
+                println!(
+                    "--dry-run: the database at {} has {} dropped-default/foreign-key/CHECK \
+                     difference(s) the snapshot still carries — run `autumn schema diff \
+                     --write-migration` to generate a migration (nothing written).",
+                    out_path.display(),
+                    drift.reverse.changes.len()
+                );
+            } else {
+                println!(
+                    "--dry-run: the snapshot at {} is up to date — the database matches it.",
+                    out_path.display()
+                );
             }
         }
     }

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod diff;
 pub mod doctor;
+pub mod introspect;
 pub mod migrate;
 pub mod parse;
 pub mod snapshot;
@@ -105,6 +106,30 @@ pub enum SchemaAction {
         #[arg(long)]
         allow_destructive: bool,
     },
+    /// Introspect the configured Postgres database and write a canonical,
+    /// dialect-tagged snapshot of its live shape — the DB-derived diff baseline.
+    ///
+    /// Read-only w.r.t. the database (only catalog reads). Unlike `snapshot`
+    /// (which derives the baseline from the declared `#[model]` structs), `pull`
+    /// derives it from the live database, so a brownfield schema — or a schema
+    /// that drifted from the models — is captured exactly as it exists. Postgres
+    /// only in this slice; a `SQLite` URL is refused with a clear message.
+    Pull {
+        /// Config profile whose database URL to introspect (defaults to the
+        /// ambient profile resolution the other CLI commands use).
+        #[arg(long, value_name = "PROFILE")]
+        profile: Option<String>,
+        /// Where to write the snapshot. Defaults to `.autumn/schema-snapshot.json`.
+        #[arg(long, value_name = "PATH")]
+        out: Option<PathBuf>,
+        /// Override the dialect tag / apply-path selection. Defaults to the
+        /// backend implied by the resolved database URL.
+        #[arg(long, value_enum)]
+        backend: Option<BackendArg>,
+        /// Print what would change without writing the snapshot file.
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Apply pending migration files against the configured database.
     ///
     /// Does NOT modify the checked-in schema snapshot: the baseline advances at
@@ -159,6 +184,12 @@ pub fn run(action: SchemaAction) {
             name.as_deref(),
             allow_destructive,
         ),
+        SchemaAction::Pull {
+            profile,
+            out,
+            backend,
+            dry_run,
+        } => run_pull(profile.as_deref(), out.as_deref(), backend, dry_run),
         SchemaAction::Migrate { profile } => migrate::run_migrate(profile.as_deref()),
         SchemaAction::Doctor { profile, json } => doctor::run_doctor(profile.as_deref(), json),
     };
@@ -347,6 +378,155 @@ fn run_snapshot(
         out_path.display()
     );
     Ok(())
+}
+
+/// Introspect the configured Postgres database and write (or, with `--dry-run`,
+/// describe) a canonical, dialect-tagged snapshot of its live shape.
+///
+/// This is the DB-introspection counterpart to `snapshot` (which derives the
+/// baseline from the declared models). The resolution order — project root, then
+/// the profile-resolved database URL, then the URL-implied backend (honoring a
+/// `--backend` override) — mirrors `schema migrate` / `schema doctor`, so the
+/// three commands can never derive the backend inconsistently for one profile.
+///
+/// Postgres only in this slice: a resolved `SQLite` backend is refused loudly (no
+/// partial support, no partial write). Before writing, a **provider-lock** guard
+/// refuses to clobber an existing snapshot tagged for another backend.
+fn run_pull(
+    profile: Option<&str>,
+    out: Option<&Path>,
+    backend: Option<BackendArg>,
+    dry_run: bool,
+) -> Result<(), String> {
+    let project_root = std::env::current_dir()
+        .map_err(|e| format!("failed to resolve the current directory: {e}"))?;
+    pull_at(&project_root, profile, out, backend, dry_run)
+}
+
+/// The body of [`run_pull`], taking an explicit `project_root` so the wiring is
+/// testable without mutating the process CWD (mirrors `diff_at` / `migrate_at`).
+fn pull_at(
+    project_root: &Path,
+    profile: Option<&str>,
+    out: Option<&Path>,
+    backend: Option<BackendArg>,
+    dry_run: bool,
+) -> Result<(), String> {
+    crate::generate::ensure_project_root(project_root)
+        .map_err(|_| crate::generate::GenerateError::NotInProject.to_string())?;
+
+    // Resolve the write/primary database URL exactly as the other schema commands
+    // do, honoring an explicit `--profile`.
+    let url = crate::migrate::resolve_primary_url(profile).ok_or_else(|| {
+        "no database URL configured — set AUTUMN_DATABASE__URL or DATABASE_URL, or add a \
+         [database] primary_url to autumn.toml"
+            .to_string()
+    })?;
+
+    // Backend from the SAME profile-resolved context as the URL (its scheme is
+    // authoritative), honoring an explicit `--backend` override.
+    let backend: Backend = backend.map_or_else(
+        || backend_for_url(project_root, profile, Some(url.as_str())),
+        Backend::from,
+    );
+
+    // SQLite introspection is a future slice of #1975 — fail loud, never partial.
+    if backend == Backend::Sqlite {
+        return Err(
+            "`autumn schema pull` currently supports Postgres only — SQLite database \
+             introspection is a future slice of the declarative-schema work (#1975). No \
+             snapshot was written."
+                .to_string(),
+        );
+    }
+
+    let out_path = out.map_or_else(
+        || project_root.join(SNAPSHOT_DEFAULT_PATH),
+        Path::to_path_buf,
+    );
+
+    // PROVIDER-LOCK: refuse to overwrite an existing snapshot tagged for another
+    // backend (mirrors `ensure_backend_matches` / the doctor provider-lock check).
+    // A missing or unreadable-as-absent snapshot is fine — this is the first
+    // baseline. The existing tables also serve as the `--dry-run` diff baseline.
+    let existing = load_existing_snapshot(&out_path);
+    if let Some(existing) = &existing
+        && existing.backend != backend
+    {
+        return Err(format!(
+            "refusing to overwrite the existing snapshot at {} (backend {:?}) with a {:?} pull \
+             — the snapshot is provider-locked to {:?}. Point --out elsewhere or remove the \
+             mismatched snapshot first.",
+            out_path.display(),
+            existing.backend,
+            backend,
+            existing.backend
+        ));
+    }
+
+    // Introspect the live database into the IR.
+    let tables = introspect::introspect_postgres(&url).map_err(|e| e.to_string())?;
+    let snapshot = SchemaSnapshot::new(backend, tables);
+
+    if dry_run {
+        report_pull_dry_run(&snapshot, existing.as_ref(), &out_path);
+        return Ok(());
+    }
+
+    snapshot::write_snapshot(&out_path, &snapshot).map_err(|e| e.to_string())?;
+    println!(
+        "pulled schema snapshot for {} table(s) from the database to {}",
+        snapshot.tables.len(),
+        out_path.display()
+    );
+    Ok(())
+}
+
+/// Load the snapshot at `path` for the pull's provider-lock / dry-run baseline.
+/// A missing OR unreadable file is treated as **absent** (`Ok(None)`) — a pull
+/// establishes a fresh baseline, so a corrupt prior file is not fatal — but a
+/// backend-mismatched *readable* snapshot still surfaces to the provider-lock
+/// caller (it loaded fine; only its backend disagrees).
+fn load_existing_snapshot(path: &Path) -> Option<SchemaSnapshot> {
+    snapshot::load_snapshot(path).ok()
+}
+
+/// Print what a `--dry-run` pull would change: the pending migration plan between
+/// the existing snapshot (baseline) and the freshly-pulled tables (desired),
+/// without writing anything.
+fn report_pull_dry_run(
+    pulled: &SchemaSnapshot,
+    existing: Option<&SchemaSnapshot>,
+    out_path: &Path,
+) {
+    match existing {
+        None => {
+            println!(
+                "--dry-run: no existing snapshot at {} — would create a new baseline with {} \
+                 table(s) from the database.",
+                out_path.display(),
+                pulled.tables.len()
+            );
+        }
+        Some(existing) => {
+            let desired = parse::ParsedSchema::from_tables(pulled.tables.clone());
+            let plan = diff::diff_schema(&existing.tables, &desired, diff::DiffOptions::default());
+            if plan.is_empty() {
+                println!(
+                    "--dry-run: the snapshot at {} is up to date — the database matches it.",
+                    out_path.display()
+                );
+            } else {
+                println!(
+                    "--dry-run: the database differs from the snapshot at {} — {} change(s) would \
+                     be captured (nothing written):",
+                    out_path.display(),
+                    plan.changes.len()
+                );
+                print!("{}", diff::describe_plan(&plan));
+            }
+        }
+    }
 }
 
 /// Diff the declared models against the checked-in snapshot baseline and either
@@ -1442,6 +1622,22 @@ mod tests {
         let dir = src.join("models");
         std::fs::create_dir_all(&dir).expect("mkdir models");
         assert_eq!(existing_models_path(root.path()), Some(dir));
+    }
+
+    #[test]
+    fn load_existing_snapshot_absent_and_corrupt_are_none_valid_is_some() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let path = root.path().join("snap.json");
+        // Missing file → treated as absent (fresh baseline).
+        assert!(load_existing_snapshot(&path).is_none());
+        // Corrupt/unreadable-as-absent → also None (a pull re-establishes it).
+        std::fs::write(&path, "{ not json").expect("write corrupt");
+        assert!(load_existing_snapshot(&path).is_none());
+        // A valid snapshot loads and surfaces its backend to the provider-lock.
+        let snap = SchemaSnapshot::new(Backend::Sqlite, Vec::new());
+        snapshot::write_snapshot(&path, &snap).expect("write valid");
+        let loaded = load_existing_snapshot(&path).expect("some");
+        assert_eq!(loaded.backend, Backend::Sqlite);
     }
 
     #[test]

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -1718,6 +1718,8 @@ mod tests {
             unique: true,
             // A constraint-owned unique index, retained verbatim by `schema pull`.
             definition: Some("CREATE UNIQUE INDEX users_email_key ON users (email)".to_string()),
+            is_partial: false,
+            key_columns: Vec::new(),
         }];
         table
     }
@@ -1778,6 +1780,8 @@ mod tests {
             definition: Some(
                 "CREATE INDEX users_lower_handle_idx ON users (lower(handle))".to_string(),
             ),
+            is_partial: false,
+            key_columns: Vec::new(),
         }];
         let projected = project_plan_target(&[table], &drop_email_plan());
         let users = projected

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -511,9 +511,8 @@ fn load_existing_snapshot(path: &Path) -> Option<SchemaSnapshot> {
 /// the dry-run never under-reports: the forward plan is what pulling would change
 /// in the snapshot, but a manually-dropped default / FK / CHECK in the live DB is
 /// invisible to the forward pass (a desired `None` is "retained") and only surfaces
-/// in the reverse plan. When the forward plan has changes it is printed via
-/// [`diff::describe_plan`]; when only the reverse plan does, a short note names the
-/// dropped-facet differences so they are not silently omitted.
+/// in the reverse plan. The report is built by the pure [`format_pull_dry_run_report`]
+/// so it can be unit-tested without any I/O.
 fn report_pull_dry_run(
     pulled: &SchemaSnapshot,
     existing: Option<&SchemaSnapshot>,
@@ -530,33 +529,112 @@ fn report_pull_dry_run(
         }
         Some(existing) => {
             let drift = doctor::compute_db_schema_drift(&existing.tables, &pulled.tables);
-            if !drift.forward.is_empty() {
-                println!(
-                    "--dry-run: the database differs from the snapshot at {} — {} change(s) would \
-                     be captured (nothing written):",
-                    out_path.display(),
-                    drift.forward.changes.len()
-                );
-                print!("{}", diff::describe_plan(&drift.forward));
-            } else if !drift.reverse.is_empty() {
-                // The forward pass found nothing to pull, but the reverse pass did:
-                // the live DB dropped a default / foreign key / CHECK the snapshot
-                // still carries. Name it rather than falsely report "up to date".
-                println!(
-                    "--dry-run: the database at {} has {} dropped-default/foreign-key/CHECK \
-                     difference(s) the snapshot still carries — run `autumn schema diff \
-                     --write-migration` to generate a migration (nothing written).",
-                    out_path.display(),
-                    drift.reverse.changes.len()
-                );
-            } else {
-                println!(
-                    "--dry-run: the snapshot at {} is up to date — the database matches it.",
-                    out_path.display()
-                );
-            }
+            print!(
+                "{}",
+                format_pull_dry_run_report(&drift.forward, &drift.reverse, out_path)
+            );
         }
     }
+}
+
+/// Format the `--dry-run` report body for a snapshot that already exists, from the
+/// pre-computed bidirectional plans. Pure (no I/O) so it is unit-testable.
+///
+/// The report ALWAYS surfaces both directions independently:
+///
+/// * The **forward** plan — the structural changes a real pull would apply to the
+///   snapshot (added/dropped columns, type changes, index adds/drops, …) — is
+///   printed via [`diff::describe_plan`] whenever it is non-empty.
+/// * The **reverse-only** removals — a default / foreign key / CHECK the snapshot
+///   still carries but the live DB has dropped, which the forward pass structurally
+///   cannot express (a desired `None` is "retained", never a drop) — are ALWAYS
+///   named, phrased as removals, INDEPENDENT of whether the forward plan had
+///   changes. Without this a pull that both adds a column AND drops a default would
+///   report only the added column and silently omit that pulling also removes the
+///   default from the snapshot.
+///
+/// Structural adds/drops already in the forward plan are never re-listed here — only
+/// the asymmetric [`reverse_only_removals`] facets are surfaced from the reverse
+/// plan, so nothing is double-counted. When BOTH directions are empty the snapshot
+/// is up to date.
+fn format_pull_dry_run_report(
+    forward: &MigrationPlan,
+    reverse: &MigrationPlan,
+    out_path: &Path,
+) -> String {
+    use std::fmt::Write as _;
+
+    let removals = reverse_only_removals(reverse);
+    if forward.is_empty() && removals.is_empty() {
+        return format!(
+            "--dry-run: the snapshot at {} is up to date — the database matches it.\n",
+            out_path.display()
+        );
+    }
+
+    let mut out = String::new();
+    if !forward.is_empty() {
+        let _ = writeln!(
+            out,
+            "--dry-run: the database differs from the snapshot at {} — {} change(s) would be \
+             captured (nothing written):",
+            out_path.display(),
+            forward.changes.len()
+        );
+        out.push_str(&diff::describe_plan(forward));
+    }
+    if !removals.is_empty() {
+        let _ = writeln!(
+            out,
+            "--dry-run: pulling would also remove from the snapshot at {}: {} (nothing written).",
+            out_path.display(),
+            removals.join(", ")
+        );
+    }
+    out
+}
+
+/// The reverse-plan changes that represent a facet present in the snapshot but
+/// **dropped from the live DB** — the asymmetric removals the forward pass cannot
+/// emit (`diff_column` treats a desired `None` as "unknown, retained", never a
+/// drop). Rendered as human-readable removal phrases for the dry-run report.
+///
+/// Only genuine removals are surfaced, so a facet that merely *changed* value (and
+/// is therefore already captured by the forward plan) is never double-counted:
+///
+/// * [`SchemaChange::SetDefault`] with `from: None` — the reverse baseline (the DB)
+///   had no default at all, so the snapshot's default was dropped. A reverse
+///   `SetDefault` whose `from` is `Some` is a value *change* the forward plan
+///   already reports and is skipped here.
+/// * [`SchemaChange::AddForeignKey`] / [`SchemaChange::AddForeignKeyToExistingColumn`]
+///   — a foreign key the snapshot carries that the DB dropped (the reverse pass
+///   only ever emits these when the DB-side column had no FK; a *retarget* surfaces
+///   as `ForeignKeyChange` in BOTH directions and is not listed here).
+/// * [`SchemaChange::AddCheck`] — a CHECK constraint the snapshot carries that the
+///   DB dropped (checks are name-keyed add-only, so a reverse `AddCheck` is always a
+///   removal).
+fn reverse_only_removals(reverse: &MigrationPlan) -> Vec<String> {
+    reverse
+        .changes
+        .iter()
+        .filter_map(|change| match change {
+            SchemaChange::SetDefault {
+                table,
+                column,
+                from: None,
+                ..
+            } => Some(format!("default on `{table}.{column}`")),
+            SchemaChange::AddForeignKey { table, column, .. }
+            | SchemaChange::AddForeignKeyToExistingColumn { table, column } => {
+                Some(format!("foreign key on `{table}.{column}`"))
+            }
+            SchemaChange::AddCheck { table, check } => Some(format!(
+                "CHECK `{}` on `{table}`",
+                check.name.as_deref().unwrap_or("(unnamed)")
+            )),
+            _ => None,
+        })
+        .collect()
 }
 
 /// Diff the declared models against the checked-in snapshot baseline and either
@@ -1820,6 +1898,116 @@ mod tests {
              forward={:?} reverse={:?}",
             drift.forward.changes,
             drift.reverse.changes
+        );
+    }
+
+    // -- `pull --dry-run` report formatting (pure) ---------------------------
+
+    /// A `posts(id BIGINT PK, created_at TIMESTAMP [default])` table. `default`
+    /// controls the `created_at` default; `extra` adds a trailing `TEXT` column.
+    fn dry_run_posts(default: Option<autumn_schema_core::ColumnDefault>, extra: bool) -> Table {
+        use autumn_schema_core::{Column, ColumnType};
+        let mut id = Column::new("id".to_string(), ColumnType::Int64);
+        id.primary_key = true;
+        let mut created_at = Column::new("created_at".to_string(), ColumnType::Timestamp);
+        created_at.default = default;
+        let mut table = Table::new("posts", Backend::Postgres);
+        table.managed = true;
+        table.primary_key = vec!["id".to_string()];
+        table.columns = vec![id, created_at];
+        if extra {
+            table
+                .columns
+                .push(Column::new("extra".to_string(), ColumnType::Text));
+        }
+        table
+    }
+
+    #[test]
+    fn dry_run_report_surfaces_reverse_only_removal_alongside_forward_change() {
+        // Snapshot: posts(id, created_at DEFAULT now()). Live DB: added an `extra`
+        // column AND dropped the `created_at` default. The forward plan catches the
+        // added column; the reverse-only pass must still surface the dropped
+        // default — the two must both appear, not just the forward change.
+        let snapshot = vec![dry_run_posts(
+            Some(autumn_schema_core::ColumnDefault::Now),
+            false,
+        )];
+        let db = vec![dry_run_posts(None, true)];
+        let drift = doctor::compute_db_schema_drift(&snapshot, &db);
+
+        // Precondition: the forward plan is non-empty (the added column) so we are
+        // exercising the "both directions non-empty" path, not the old fallback.
+        assert!(
+            !drift.forward.is_empty(),
+            "forward plan should carry the added column: {:?}",
+            drift.forward.changes
+        );
+
+        let report = format_pull_dry_run_report(
+            &drift.forward,
+            &drift.reverse,
+            Path::new(".autumn/schema-snapshot.json"),
+        );
+
+        assert!(
+            report.contains("ADD COLUMN posts.extra"),
+            "dry-run report must include the forward added-column change:\n{report}"
+        );
+        assert!(
+            report.contains("pulling would also remove from the snapshot")
+                && report.contains("default on `posts.created_at`"),
+            "dry-run report must ALSO surface the reverse-only dropped default even though a \
+             forward change exists:\n{report}"
+        );
+    }
+
+    #[test]
+    fn dry_run_report_reverse_only_removal_with_empty_forward() {
+        // Only a dropped default (no forward change) — the reverse-only removal must
+        // still be surfaced (never a false "up to date").
+        let snapshot = vec![dry_run_posts(
+            Some(autumn_schema_core::ColumnDefault::Now),
+            false,
+        )];
+        let db = vec![dry_run_posts(None, false)];
+        let drift = doctor::compute_db_schema_drift(&snapshot, &db);
+        assert!(
+            drift.forward.is_empty(),
+            "forward pass must miss the dropped default"
+        );
+
+        let report = format_pull_dry_run_report(
+            &drift.forward,
+            &drift.reverse,
+            Path::new(".autumn/schema-snapshot.json"),
+        );
+        assert!(
+            report.contains("default on `posts.created_at`"),
+            "dry-run report must surface the reverse-only dropped default:\n{report}"
+        );
+        assert!(
+            !report.contains("is up to date"),
+            "a dropped default is drift, never 'up to date':\n{report}"
+        );
+    }
+
+    #[test]
+    fn dry_run_report_clean_when_both_directions_empty() {
+        let snapshot = vec![dry_run_posts(
+            Some(autumn_schema_core::ColumnDefault::Now),
+            false,
+        )];
+        let db = snapshot.clone();
+        let drift = doctor::compute_db_schema_drift(&snapshot, &db);
+        let report = format_pull_dry_run_report(
+            &drift.forward,
+            &drift.reverse,
+            Path::new(".autumn/schema-snapshot.json"),
+        );
+        assert!(
+            report.contains("is up to date"),
+            "identical snapshot/DB must report up to date:\n{report}"
         );
     }
 }

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -652,7 +652,10 @@ fn diff_at(
     }
 
     // (e) Diff (pure) then guard (policy).
-    let opts = diff::DiffOptions { allow_destructive };
+    let opts = diff::DiffOptions {
+        allow_destructive,
+        ..Default::default()
+    };
     let plan = diff::diff_schema(&baseline.tables, &desired, opts);
     if plan.is_empty() {
         println!("No schema changes — models match the snapshot baseline.");

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -749,6 +749,19 @@ fn project_plan_target(baseline: &[Table], plan: &MigrationPlan) -> Vec<Table> {
             SchemaChange::DropColumn { table, column } => {
                 if let Some(t) = tables.get_mut(table) {
                     t.columns.retain(|c| c.name != column.name);
+                    // Postgres `ALTER TABLE … DROP COLUMN` automatically drops any
+                    // index (and the constraint it backs) that depends on the
+                    // column. Ordinary model-managed indexes on the column already
+                    // carry an explicit `DropIndex` in this plan; this ALSO prunes
+                    // the RETAINED (`definition`-carrying) expression / partial /
+                    // constraint-owned indexes that have NO `DropIndex` — otherwise
+                    // the projected snapshot would claim an index the database just
+                    // cascade-dropped and every subsequent `schema doctor` /
+                    // `pull --dry-run` would report false, perpetual drift. Uses
+                    // the same dependency test the down emitter uses to restore
+                    // these indexes on rollback, so projection and rollback agree.
+                    t.indexes
+                        .retain(|i| !diff::index_depends_on_column(i, &column.name));
                 }
             }
             SchemaChange::AlterColumnType {
@@ -1682,6 +1695,127 @@ mod tests {
         assert!(
             err.contains("--from"),
             "error tells the user to pass --from"
+        );
+    }
+
+    // -- Part A: `project_plan_target` prunes column-dependent retained indexes --
+
+    /// A `posts(id, email)` table carrying a RETAINED expression/constraint index
+    /// on `email` (a `definition`-carrying index with NO paired `DropIndex`, the
+    /// shape `schema pull` preserves for a brownfield `UNIQUE`/expression index).
+    fn users_table_with_email_unique_index() -> Table {
+        use autumn_schema_core::{ColumnType, Index};
+        let mut id = Column::new("id".to_string(), ColumnType::Int64);
+        id.primary_key = true;
+        let email = Column::new("email".to_string(), ColumnType::Text);
+        let mut table = Table::new("users", Backend::Postgres);
+        table.managed = true;
+        table.primary_key = vec!["id".to_string()];
+        table.columns = vec![id, email];
+        table.indexes = vec![Index {
+            name: "users_email_key".to_string(),
+            columns: vec!["email".to_string()],
+            unique: true,
+            // A constraint-owned unique index, retained verbatim by `schema pull`.
+            definition: Some("CREATE UNIQUE INDEX users_email_key ON users (email)".to_string()),
+        }];
+        table
+    }
+
+    fn drop_email_plan() -> MigrationPlan {
+        use autumn_schema_core::{Column, ColumnType};
+        MigrationPlan {
+            backend: Backend::Postgres,
+            changes: vec![SchemaChange::DropColumn {
+                table: "users".to_string(),
+                column: Column::new("email".to_string(), ColumnType::Text),
+            }],
+        }
+    }
+
+    #[test]
+    fn project_plan_target_prunes_retained_index_depending_on_dropped_column() {
+        // Dropping `email` cascade-drops the retained unique index in Postgres, so
+        // the projected snapshot must contain NEITHER the column NOR the index —
+        // otherwise `doctor` / `pull --dry-run` would report false perpetual drift.
+        let baseline = vec![users_table_with_email_unique_index()];
+        let projected = project_plan_target(&baseline, &drop_email_plan());
+        let users = projected
+            .iter()
+            .find(|t| t.name == "users")
+            .expect("users table retained");
+        assert!(
+            users.columns.iter().all(|c| c.name != "email"),
+            "dropped column must be gone: {:?}",
+            users.columns
+        );
+        assert!(
+            users.indexes.is_empty(),
+            "retained index depending on the dropped column must be pruned: {:?}",
+            users.indexes
+        );
+    }
+
+    #[test]
+    fn project_plan_target_keeps_retained_index_on_unrelated_column() {
+        use autumn_schema_core::{Column, ColumnType, Index};
+        // A retained expression index on `handle`; a DropColumn of the UNRELATED
+        // `email` must leave it intact (no over-pruning).
+        let mut table = Table::new("users", Backend::Postgres);
+        table.managed = true;
+        let mut id = Column::new("id".to_string(), ColumnType::Int64);
+        id.primary_key = true;
+        table.primary_key = vec!["id".to_string()];
+        table.columns = vec![
+            id,
+            Column::new("email".to_string(), ColumnType::Text),
+            Column::new("handle".to_string(), ColumnType::Text),
+        ];
+        table.indexes = vec![Index {
+            name: "users_lower_handle_idx".to_string(),
+            columns: vec!["handle".to_string()],
+            unique: false,
+            definition: Some(
+                "CREATE INDEX users_lower_handle_idx ON users (lower(handle))".to_string(),
+            ),
+        }];
+        let projected = project_plan_target(&[table], &drop_email_plan());
+        let users = projected
+            .iter()
+            .find(|t| t.name == "users")
+            .expect("users table");
+        assert_eq!(
+            users.indexes.len(),
+            1,
+            "an index on an unrelated column must survive: {:?}",
+            users.indexes
+        );
+        assert_eq!(users.indexes[0].name, "users_lower_handle_idx");
+    }
+
+    #[test]
+    fn project_plan_target_false_drift_regression_is_clean() {
+        // Snapshot = the projected target (post-Part-A). The live DB (like
+        // Postgres) also lacks the cascade-dropped column AND index. The
+        // authoritative drift check must then report Clean — proving the false
+        // perpetual drift is gone.
+        let baseline = vec![users_table_with_email_unique_index()];
+        let snapshot = project_plan_target(&baseline, &drop_email_plan());
+
+        // The database after `ALTER TABLE users DROP COLUMN email` cascades:
+        // no `email` column, no dependent index.
+        let mut db_users = users_table_with_email_unique_index();
+        db_users.columns.retain(|c| c.name != "email");
+        db_users.indexes.clear();
+        let db = vec![db_users];
+
+        let drift = doctor::compute_db_schema_drift(&snapshot, &db);
+        assert!(
+            drift.is_clean(),
+            "projected snapshot must match the cascade-dropped DB (no false drift); \
+             forward={:?} reverse={:?}",
+            drift.forward.changes,
+            drift.reverse.changes
         );
     }
 }

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -473,6 +473,19 @@ fn pull_at(
         return Ok(());
     }
 
+    // A file that is present on disk but did not load (`existing` is `None` while
+    // the path exists) is corrupt/unreadable-as-absent — a non-dry-run pull is
+    // about to replace it. Tell the user rather than silently clobber it. An
+    // absent snapshot stays silent (it exists nowhere to overwrite); a readable
+    // but backend-mismatched snapshot never reaches here (provider-lock refused
+    // above).
+    if existing.is_none() && out_path.exists() {
+        eprintln!(
+            "note: existing snapshot at {} was unreadable; replacing it.",
+            out_path.display()
+        );
+    }
+
     snapshot::write_snapshot(&out_path, &snapshot).map_err(|e| e.to_string())?;
     println!(
         "pulled schema snapshot for {} table(s) from the database to {}",

--- a/autumn-cli/src/schema/parse.rs
+++ b/autumn-cli/src/schema/parse.rs
@@ -162,6 +162,29 @@ pub struct ParsedSchema {
     pub diagnostics: Vec<SchemaDiagnostic>,
 }
 
+impl ParsedSchema {
+    /// Wrap an already-materialized set of [`Table`]s as a desired-state
+    /// [`ParsedSchema`] with no diagnostics.
+    ///
+    /// The `#[model]` parser is not the only producer of a desired state: the
+    /// [`crate::schema::introspect`] database-introspection path builds
+    /// [`Table`]s directly from a live Postgres catalog. Both feed the same
+    /// [`crate::schema::diff::diff_schema`] engine (which takes a `&ParsedSchema`
+    /// as its desired side), so this adapter lets an introspected table set be
+    /// diffed against a snapshot baseline without inventing a fake model source.
+    /// There are no parser diagnostics for an introspected schema (every column
+    /// is resolved — an unmappable type becomes
+    /// [`ColumnType::Opaque`](autumn_schema_core::ColumnType::Opaque) rather than
+    /// being skipped), so the `diagnostics` vec is empty.
+    #[must_use]
+    pub const fn from_tables(tables: Vec<Table>) -> Self {
+        Self {
+            tables,
+            diagnostics: Vec::new(),
+        }
+    }
+}
+
 /// Parse a single Rust source string, returning one [`Table`] per `#[model]`
 /// struct plus any per-field diagnostics.
 ///

--- a/autumn-cli/src/schema/parse.rs
+++ b/autumn-cli/src/schema/parse.rs
@@ -584,6 +584,8 @@ fn build_table(
             columns: vec![field_name.clone()],
             unique: false,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         });
     }
     for field_name in &unique_index_fields {
@@ -593,6 +595,8 @@ fn build_table(
             columns: vec![field_name.clone()],
             unique: true,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         });
     }
 

--- a/autumn-cli/src/schema/parse.rs
+++ b/autumn-cli/src/schema/parse.rs
@@ -583,6 +583,7 @@ fn build_table(
             name: format!("idx_{table_name}_{field_name}"),
             columns: vec![field_name.clone()],
             unique: false,
+            definition: None,
         });
     }
     for field_name in &unique_index_fields {
@@ -591,6 +592,7 @@ fn build_table(
             name: format!("idx_{table_name}_{field_name}_unique"),
             columns: vec![field_name.clone()],
             unique: true,
+            definition: None,
         });
     }
 

--- a/autumn-cli/src/schema/snapshot.rs
+++ b/autumn-cli/src/schema/snapshot.rs
@@ -332,11 +332,13 @@ mod tests {
             name: "idx_posts_created_at".to_owned(),
             columns: vec!["created_at".to_owned()],
             unique: false,
+            definition: None,
         });
         posts.indexes.push(Index {
             name: "idx_posts_author_id".to_owned(),
             columns: vec!["author_id".to_owned()],
             unique: false,
+            definition: None,
         });
         posts.checks.push(CheckConstraint {
             name: Some("posts_body_len".to_owned()),

--- a/autumn-cli/src/schema/snapshot.rs
+++ b/autumn-cli/src/schema/snapshot.rs
@@ -333,12 +333,16 @@ mod tests {
             columns: vec!["created_at".to_owned()],
             unique: false,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         });
         posts.indexes.push(Index {
             name: "idx_posts_author_id".to_owned(),
             columns: vec!["author_id".to_owned()],
             unique: false,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         });
         posts.checks.push(CheckConstraint {
             name: Some("posts_body_len".to_owned()),

--- a/autumn-cli/tests/integration/mod.rs
+++ b/autumn-cli/tests/integration/mod.rs
@@ -21,6 +21,7 @@ mod scaffold_validation;
 mod schema_migrate;
 #[cfg(feature = "sqlite")]
 mod schema_migrate_sqlite;
+mod schema_pull;
 mod seed_model_linking;
 #[cfg(unix)]
 mod serve;

--- a/autumn-cli/tests/integration/schema_pull.rs
+++ b/autumn-cli/tests/integration/schema_pull.rs
@@ -1088,6 +1088,137 @@ pub struct Member {
     assert_no_secret_leak(&doc_out, &doc_err);
 }
 
+/// A brownfield `SERIAL PRIMARY KEY` (int4) column must be introspected faithfully:
+/// its `nextval(...)` sequence default is PRESERVED (not stripped like the int8
+/// `BIGSERIAL` id shape), so a recreation of the table reconstructs it as `SERIAL`
+/// (auto-increment) rather than a plain `INTEGER PRIMARY KEY` that silently loses the
+/// sequence. The faithful-representation acceptance is a byte-stable re-pull plus a
+/// clean `doctor`, and the preserved `nextval` default visible in the snapshot.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_pull_preserves_int4_serial_primary_key() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_int4_serial_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    // A brownfield table whose primary key is an int4 `SERIAL` (not `BIGSERIAL`),
+    // authored via a raw migration so Postgres records the `nextval(...)` default.
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_create_counters",
+        "CREATE TABLE counters (id SERIAL PRIMARY KEY, label TEXT NOT NULL, created_at TIMESTAMP NOT NULL DEFAULT NOW());",
+        "DROP TABLE counters;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // Pull: the int4 SERIAL id's sequence default must survive (NOT be stripped like
+    // the int8 BIGSERIAL id shape), so the emitter can reconstruct it as `SERIAL`.
+    let (out, err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&out, &err);
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    assert!(
+        snap.contains("counters"),
+        "the brownfield table is captured: {snap}"
+    );
+    assert!(
+        snap.contains("nextval"),
+        "the int4 SERIAL PK's nextval default is PRESERVED (not stripped): {snap}"
+    );
+
+    // A re-pull of the same database is byte-for-byte stable (no int4-serial drift).
+    let snap_before = snap;
+    let (pull2_out, pull2_err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&pull2_out, &pull2_err);
+    let snap_after = std::fs::read_to_string(&snapshot_path).expect("snapshot after second pull");
+    assert_eq!(
+        snap_before, snap_after,
+        "a re-pull of the same database must be byte-for-byte stable (int4 serial faithful)"
+    );
+
+    // doctor agrees the database still matches the pulled baseline (no drift from the
+    // preserved int4 SERIAL primary key).
+    let (doc_out, doc_err) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor reports the DB matches the snapshot with the int4 SERIAL PK:\n{doc_out}"
+    );
+    assert_no_secret_leak(&doc_out, &doc_err);
+}
+
+/// A **partial** unique index (`… ON accounts(email) WHERE …`) enforces uniqueness
+/// only for rows matching its predicate, so it must NOT be treated as satisfying a
+/// model `#[unique] email` (which demands table-wide uniqueness). Unlike a full
+/// brownfield `UNIQUE` constraint (which DOES satisfy `#[unique]` — see
+/// `schema_diff_model_unique_matches_pulled_constraint_index`), the model diff here
+/// must emit the unique `AddIndex`, which the policy guard then refuses on the
+/// pre-existing `email` column with `UniqueIndexRequiresDedup` — the decisive signal
+/// that the partial index did NOT suppress the model `#[unique]`.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_diff_partial_unique_index_does_not_satisfy_model_unique() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_partial_unique_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    // Brownfield `accounts(id, email, created_at)` with a PARTIAL unique index on
+    // `email` (only enforces uniqueness where `email <> ''`). `created_at TIMESTAMP
+    // NOT NULL DEFAULT NOW()` matches the column the managed-model parser synthesizes
+    // for `Account` below, so the diff isolates the unique-index behavior.
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_create_accounts",
+        "CREATE TABLE accounts (id BIGSERIAL PRIMARY KEY, email TEXT NOT NULL, created_at TIMESTAMP NOT NULL DEFAULT NOW());\n\
+         CREATE UNIQUE INDEX accounts_email_active_key ON accounts (email) WHERE email <> '';",
+        "DROP TABLE accounts;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // Pull: the partial unique index is retained verbatim and flagged partial.
+    let (out, err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&out, &err);
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    assert!(
+        snap.contains("accounts_email_active_key"),
+        "the partial unique index is retained by name: {snap}"
+    );
+    assert!(
+        snap.contains("\"is_partial\"") && snap.contains("WHERE"),
+        "the pulled index is flagged partial and keeps its predicate: {snap}"
+    );
+
+    // The natural model declares `#[unique]` on email. A PARTIAL unique index does
+    // NOT enforce table-wide uniqueness, so the diff must NOT be suppressed — it emits
+    // the unique AddIndex, which the guard refuses on the pre-existing column.
+    write_models(
+        &project,
+        "
+#[autumn_web::model(managed)]
+pub struct Account {
+    #[id]
+    pub id: i64,
+    #[unique]
+    pub email: String,
+}
+",
+    );
+    let (mdiff_out, mdiff_err) = run_autumn_fail(&project, &["schema", "diff"], &envs);
+    let combined = format!("{mdiff_out}{mdiff_err}");
+    assert!(
+        combined.contains("cannot add unique index") && combined.contains("accounts"),
+        "a partial unique index must NOT satisfy the model #[unique]; the diff must emit \
+         the unique AddIndex (guard-refused on the pre-existing column):\n{combined}"
+    );
+    assert_no_secret_leak(&mdiff_out, &mdiff_err);
+}
+
 /// `SQLite` introspection is a future slice: `schema pull` against a `SQLite` URL
 /// is refused loudly (no Docker needed — the refusal happens before any
 /// connection), names `SQLite`, and writes no snapshot.

--- a/autumn-cli/tests/integration/schema_pull.rs
+++ b/autumn-cli/tests/integration/schema_pull.rs
@@ -627,6 +627,75 @@ pub struct Account {
     assert_no_secret_leak(&mdiff_out, &mdiff_err);
 }
 
+/// A range-based `EXCLUDE` constraint (`EXCLUDE USING gist (during WITH &&)`) is
+/// backed by a gist index Postgres auto-creates. Retaining ONLY the backing
+/// `CREATE INDEX` (`pg_get_indexdef`) would NOT enforce the exclusion on a
+/// rollback/recreation — overlapping rows would become possible, a data-integrity
+/// loss. `schema pull` must therefore retain the REAL constraint recreation via the
+/// index `definition` — `ALTER TABLE … ADD CONSTRAINT … EXCLUDE USING …`
+/// (`pg_get_constraintdef`) — so the snapshot round-trips the actual exclusion. A
+/// re-pull is byte-stable and `schema doctor` reports no drift.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_pull_retains_exclude_constraint_as_real_constraint() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_exclude_constraint_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    // A table with a range EXCLUDE constraint. `tstzrange WITH &&` needs no
+    // extension (gist supports range types out of the box), so no `CREATE EXTENSION`
+    // is required. `created_at TIMESTAMP NOT NULL DEFAULT NOW()` matches the column
+    // the managed-model parser would synthesize; the EXCLUDE itself is unmodellable.
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_create_reservations",
+        "CREATE TABLE reservations (id BIGSERIAL PRIMARY KEY, during tstzrange NOT NULL, created_at TIMESTAMP NOT NULL DEFAULT NOW(), EXCLUDE USING gist (during WITH &&));",
+        "DROP TABLE reservations;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // Pull: the EXCLUDE constraint must be retained as the real ADD CONSTRAINT form,
+    // NOT the bare backing CREATE INDEX.
+    let (out, err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&out, &err);
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+
+    assert!(
+        snap.contains("EXCLUDE USING gist"),
+        "the EXCLUDE constraint is retained via its ADD CONSTRAINT … EXCLUDE USING … definition: {snap}"
+    );
+    assert!(
+        snap.contains("ADD CONSTRAINT"),
+        "the retained definition is the real constraint recreation (ALTER TABLE … ADD CONSTRAINT): {snap}"
+    );
+    assert!(
+        snap.contains("\"definition\""),
+        "the raw definition field is serialized for the EXCLUDE constraint index: {snap}"
+    );
+
+    // A second pull round-trips clean against the just-pulled baseline (byte-stable).
+    let snap_before = snap;
+    let (pull2_out, pull2_err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&pull2_out, &pull2_err);
+    let snap_after = std::fs::read_to_string(&snapshot_path).expect("snapshot after second pull");
+    assert_eq!(
+        snap_before, snap_after,
+        "a re-pull of the same database must be byte-for-byte stable (no EXCLUDE-constraint drift)"
+    );
+
+    // doctor agrees the DB matches the pulled baseline (retained EXCLUDE is stable).
+    let (doc_out, doc_err) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor reports the DB matches the snapshot with the EXCLUDE constraint:\n{doc_out}"
+    );
+    assert_no_secret_leak(&doc_out, &doc_err);
+}
+
 /// Brownfield adoption with the natural `#[unique]` annotation (the P2 fix): after
 /// `schema pull` retains the constraint-owned `accounts_email_key` index, the user
 /// writes the natural model `Account { id, email }` and DOES declare `#[unique]` on

--- a/autumn-cli/tests/integration/schema_pull.rs
+++ b/autumn-cli/tests/integration/schema_pull.rs
@@ -502,6 +502,36 @@ async fn schema_pull_preserves_expression_and_partial_indexes() {
         "doctor reports the DB matches the snapshot with expression/partial indexes:\n{doc_out}"
     );
     assert_no_secret_leak(&doc_out, &doc_err);
+
+    // A MODEL-side `schema diff` against the pulled snapshot must RETAIN the
+    // expression/partial indexes — the model DSL cannot express them, so their
+    // absence from the desired side is not a removal. The diff is clean (no
+    // destructive DropIndex that would clobber `lower(email)` with a plain index
+    // or strip the partial predicate).
+    write_models(
+        &project,
+        "
+#[autumn_web::model(managed)]
+pub struct Member {
+    #[id]
+    pub id: i64,
+    pub email: String,
+    pub deleted_at: Option<chrono::NaiveDateTime>,
+}
+",
+    );
+    let (mdiff_out, mdiff_err) = run_autumn_ok(&project, &["schema", "diff"], &envs);
+    assert!(
+        !mdiff_out.contains("DROP INDEX")
+            && !mdiff_out.contains("members_lower_email_idx")
+            && !mdiff_out.contains("members_active_email_idx"),
+        "a model-side `schema diff` must NOT drop the unmodellable expression/partial indexes:\n{mdiff_out}"
+    );
+    assert!(
+        mdiff_out.contains("No schema changes"),
+        "model diff against the pulled snapshot is clean (definition indexes retained):\n{mdiff_out}"
+    );
+    assert_no_secret_leak(&mdiff_out, &mdiff_err);
 }
 
 /// `SQLite` introspection is a future slice: `schema pull` against a `SQLite` URL

--- a/autumn-cli/tests/integration/schema_pull.rs
+++ b/autumn-cli/tests/integration/schema_pull.rs
@@ -1,0 +1,418 @@
+//! Integration tests for `autumn schema pull` (Postgres database → snapshot IR)
+//! and the `schema doctor` database-schema-drift check (the first
+//! DB-introspection slice of issue #1975).
+//!
+//! The Docker-dependent tests require testcontainers and are marked `#[ignore]`,
+//! so they only run when explicitly requested (and are swept automatically in
+//! CI):
+//!
+//!   `cargo test -p autumn-cli --test cli_tests -- --ignored schema_pull`
+//!
+//! The headline test proves the round-trip fidelity acceptance: a schema built
+//! from `#[model]` structs, migrated into a live Postgres, then `schema pull`ed
+//! back, produces a snapshot that a subsequent `schema diff` reports as
+//! unchanged. Credentials never leak into any command output.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const SECRET_PW: &str = "s3cr3t_pw_do_not_leak";
+
+const fn autumn_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_autumn")
+}
+
+fn run_autumn(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String, Option<i32>) {
+    let output = Command::new(autumn_bin())
+        .args(args)
+        .current_dir(dir)
+        .envs(envs.iter().copied())
+        .output()
+        .expect("failed to run autumn");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code(),
+    )
+}
+
+fn run_autumn_ok(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String) {
+    let (stdout, stderr, code) = run_autumn(dir, args, envs);
+    assert_eq!(
+        code,
+        Some(0),
+        "autumn {args:?} failed (exit={code:?})\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    (stdout, stderr)
+}
+
+fn run_autumn_fail(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String) {
+    let (stdout, stderr, code) = run_autumn(dir, args, envs);
+    assert_ne!(
+        code,
+        Some(0),
+        "autumn {args:?} should have failed but exited 0\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    (stdout, stderr)
+}
+
+/// `autumn new <name>` in a fresh tempdir, returning that tempdir + project root.
+fn fresh_project(name: &str) -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", name], &[]);
+    let project = tmp.path().join(name);
+    (tmp, project)
+}
+
+/// Overwrite the project's models with `content` in the single-file
+/// `src/models.rs` layout (removing any scaffolded `src/models/` directory so the
+/// single-file layout resolves).
+fn write_models(project: &Path, content: &str) {
+    let src = project.join("src");
+    let _ = std::fs::remove_dir_all(src.join("models"));
+    std::fs::write(src.join("models.rs"), content).expect("write models.rs");
+}
+
+/// Write a raw diesel migration under `migrations/<name>/`.
+fn write_raw_migration(project: &Path, name: &str, up_sql: &str, down_sql: &str) {
+    let dir = project.join("migrations").join(name);
+    std::fs::create_dir_all(&dir).expect("mkdir migration");
+    std::fs::write(dir.join("up.sql"), up_sql).expect("up.sql");
+    std::fs::write(dir.join("down.sql"), down_sql).expect("down.sql");
+}
+
+async fn start_postgres() -> (
+    testcontainers::ContainerAsync<testcontainers_modules::postgres::Postgres>,
+    String,
+    u16,
+) {
+    use testcontainers::runners::AsyncRunner as _;
+    use testcontainers_modules::postgres::Postgres;
+
+    let container = Postgres::default()
+        .with_password(SECRET_PW)
+        .start()
+        .await
+        .expect("failed to start Postgres testcontainer — is Docker running?");
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    (container, host, port)
+}
+
+fn assert_no_secret_leak(stdout: &str, stderr: &str) {
+    assert!(
+        !stdout.contains(SECRET_PW) && !stderr.contains(SECRET_PW),
+        "credentials leaked!\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+/// Two well-behaved models covering the full mapped type surface plus a foreign
+/// key (`Post.author_id → authors`), a unique column, a `NUMERIC` decimal, a
+/// `JSONB` attachment, and a `TIMESTAMPTZ`.
+const ROUND_TRIP_MODELS: &str = r"
+#[autumn_web::model(managed)]
+pub struct Author {
+    #[id]
+    pub id: i64,
+    #[unique]
+    pub email: String,
+    pub name: String,
+    #[default]
+    pub created_at: chrono::NaiveDateTime,
+}
+
+#[autumn_web::model(managed)]
+pub struct Post {
+    #[id]
+    pub id: i64,
+    #[references]
+    pub author_id: i64,
+    pub title: String,
+    pub views: i32,
+    pub published: bool,
+    pub rating: rust_decimal::Decimal,
+    pub metadata: autumn_web::storage::Blob,
+    pub launched_at: chrono::DateTime<chrono::Utc>,
+    #[default]
+    pub created_at: chrono::NaiveDateTime,
+}
+";
+
+/// Build the schema from the models: an empty baseline snapshot, then
+/// `schema diff --write-migration`, then `schema migrate` so the tables exist in
+/// the live database.
+fn build_schema_into_db(project: &Path, envs: &[(&str, &str)]) {
+    std::fs::write(project.join("empty_models.rs"), "").expect("empty models");
+    run_autumn_ok(
+        project,
+        &[
+            "schema",
+            "snapshot",
+            "--from",
+            "empty_models.rs",
+            "--backend",
+            "pg",
+        ],
+        envs,
+    );
+    run_autumn_ok(
+        project,
+        &[
+            "schema",
+            "diff",
+            "--write-migration",
+            "--name",
+            "create_schema",
+        ],
+        envs,
+    );
+    run_autumn_ok(project, &["schema", "migrate"], envs);
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+#[allow(clippy::too_many_lines)] // linear end-to-end round-trip reads clearest whole
+async fn schema_pull_round_trips_models_through_the_database() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_roundtrip_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    // 1. Declare the models and materialize them in the live database.
+    write_models(&project, ROUND_TRIP_MODELS);
+    build_schema_into_db(&project, &envs);
+
+    // 2. Pull the live database back into the snapshot, OVERWRITING the
+    //    model-derived baseline with the DB-introspected one.
+    let (pull_out, pull_err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert!(
+        pull_out.contains("pulled schema snapshot") && pull_out.contains("2 table(s)"),
+        "pull reports the table count: {pull_out}"
+    );
+    assert_no_secret_leak(&pull_out, &pull_err);
+
+    // 3. The pulled snapshot faithfully carries both tables and the full type
+    //    spread (the FK target, the unique index, the decimal, the attachment).
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    assert!(
+        snap.contains("\"name\": \"authors\""),
+        "authors table: {snap}"
+    );
+    assert!(snap.contains("\"name\": \"posts\""), "posts table: {snap}");
+    assert!(
+        snap.contains("\"name\": \"author_id\""),
+        "fk column present"
+    );
+    assert!(
+        snap.contains("\"table\": \"authors\""),
+        "the FK references authors: {snap}"
+    );
+    assert!(
+        snap.contains("idx_authors_email_unique"),
+        "unique index: {snap}"
+    );
+    assert!(
+        snap.contains("idx_posts_author_id"),
+        "fk auto-index: {snap}"
+    );
+    assert!(
+        snap.contains("\"Decimal\""),
+        "decimal type preserved: {snap}"
+    );
+    assert!(snap.contains("\"Attachment\""), "jsonb→Attachment: {snap}");
+    assert!(
+        snap.contains("\"TimestampTz\""),
+        "timestamptz preserved: {snap}"
+    );
+    // No framework/bookkeeping tables leaked into the pulled snapshot.
+    assert!(
+        !snap.contains("__diesel_schema_migrations"),
+        "no diesel table"
+    );
+
+    // 4. THE ACCEPTANCE: a subsequent `schema diff` (models vs the pulled
+    //    snapshot) reports no changes — the DB-derived snapshot is byte-faithful
+    //    to what the models produce, so the round-trip is clean.
+    let (diff_out, diff_err) = run_autumn_ok(&project, &["schema", "diff"], &envs);
+    assert!(
+        diff_out.contains("No schema changes"),
+        "round-trip must yield an empty diff:\n{diff_out}"
+    );
+    assert_no_secret_leak(&diff_out, &diff_err);
+
+    // 5. doctor agrees the database matches the (pulled) snapshot baseline.
+    let (doc_out, doc_err) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database-schema-drift")
+            && doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor reports the DB matches the snapshot:\n{doc_out}"
+    );
+    assert_no_secret_leak(&doc_out, &doc_err);
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_pull_preserves_unmappable_types_as_opaque() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_opaque_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    // A table with an `inet` column — outside Autumn's mapped surface. Created via
+    // a raw migration so the unmappable type reaches the live catalog.
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_create_gadgets",
+        "CREATE TABLE gadgets (id BIGSERIAL PRIMARY KEY, addr inet NOT NULL);",
+        "DROP TABLE gadgets;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // Pull: the unmappable column must be preserved as an Opaque type carrying
+    // the raw Postgres type name, never dropped.
+    let (out, err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&out, &err);
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    assert!(
+        snap.contains("\"name\": \"gadgets\""),
+        "gadgets pulled: {snap}"
+    );
+    assert!(
+        snap.contains("\"name\": \"addr\""),
+        "opaque column present: {snap}"
+    );
+    assert!(
+        snap.contains("\"Opaque\""),
+        "opaque variant emitted: {snap}"
+    );
+    assert!(
+        snap.contains("\"pg_type\": \"inet\""),
+        "raw pg type preserved verbatim: {snap}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_doctor_reports_database_schema_drift() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_doctor_drift_app");
+
+    // 1. A simple model, built into the database. The snapshot (advanced at diff
+    //    time) now matches the DB, so doctor sees no DB drift.
+    write_models(
+        &project,
+        "#[autumn_web::model(managed)]\npub struct Post {\n    #[id]\n    pub id: i64,\n    pub title: String,\n}\n",
+    );
+    build_schema_into_db(&project, &envs);
+
+    let (clean_out, _) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        clean_out.contains("database schema matches the snapshot baseline"),
+        "doctor is clean before the out-of-band change:\n{clean_out}"
+    );
+
+    // 2. Mutate the live database OUT OF BAND (a raw migration the snapshot does
+    //    not know about) — `schema migrate` applies it but never advances the
+    //    snapshot, so the DB now drifts from the baseline.
+    write_raw_migration(
+        &project,
+        "20990101000000_add_extra",
+        "ALTER TABLE posts ADD COLUMN extra TEXT;",
+        "ALTER TABLE posts DROP COLUMN extra;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // 3. doctor now reports the database-schema-drift check as a WARN. A WARN
+    //    never fails the command (doctor stays runnable), so it still exits 0.
+    let (drift_stdout, drift_stderr) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        drift_stdout.contains("database-schema-drift") && drift_stdout.contains("[WARN]"),
+        "doctor reports DB drift as a WARN:\n{drift_stdout}"
+    );
+    assert!(
+        drift_stdout.contains("differs from the snapshot")
+            && drift_stdout.contains("autumn schema pull"),
+        "the drift detail names the remediation:\n{drift_stdout}"
+    );
+    assert_no_secret_leak(&drift_stdout, &drift_stderr);
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_pull_dry_run_reports_diff_without_writing() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_dry_run_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    // 1. Build a schema and pull it, so the snapshot reflects the DB.
+    write_models(
+        &project,
+        "#[autumn_web::model(managed)]\npub struct Post {\n    #[id]\n    pub id: i64,\n    pub title: String,\n}\n",
+    );
+    build_schema_into_db(&project, &envs);
+    run_autumn_ok(&project, &["schema", "pull"], &envs);
+    let snap_before = std::fs::read_to_string(&snapshot_path).expect("snapshot before dry-run");
+
+    // 2. Mutate the DB out of band so a fresh pull would differ from the snapshot.
+    write_raw_migration(
+        &project,
+        "20990202000000_add_note",
+        "ALTER TABLE posts ADD COLUMN note TEXT;",
+        "ALTER TABLE posts DROP COLUMN note;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // 3. A dry-run pull reports the pending change but writes NOTHING.
+    let (dry_out, dry_err) = run_autumn_ok(&project, &["schema", "pull", "--dry-run"], &envs);
+    assert!(
+        dry_out.contains("--dry-run") && dry_out.contains("differs from the snapshot"),
+        "dry-run reports the diff:\n{dry_out}"
+    );
+    assert_no_secret_leak(&dry_out, &dry_err);
+
+    let snap_after = std::fs::read_to_string(&snapshot_path).expect("snapshot after dry-run");
+    assert_eq!(
+        snap_before, snap_after,
+        "a --dry-run pull must leave the snapshot byte-for-byte unchanged"
+    );
+    assert!(
+        !snap_after.contains("note"),
+        "the out-of-band `note` column must NOT be written by a dry-run: {snap_after}"
+    );
+}
+
+/// `SQLite` introspection is a future slice: `schema pull` against a `SQLite` URL
+/// is refused loudly (no Docker needed — the refusal happens before any
+/// connection), names `SQLite`, and writes no snapshot.
+#[test]
+fn schema_pull_refuses_sqlite_backend() {
+    let (_tmp, project) = fresh_project("pull_sqlite_refusal_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+    let existed_before = snapshot_path.exists();
+
+    let envs = [("AUTUMN_DATABASE__URL", "sqlite://./pull_test.db")];
+    let (stdout, stderr) = run_autumn_fail(&project, &["schema", "pull"], &envs);
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("SQLite") && combined.to_lowercase().contains("postgres only"),
+        "refusal names SQLite as a future slice:\n{combined}"
+    );
+
+    // No snapshot was written by the refused pull.
+    assert_eq!(
+        existed_before,
+        snapshot_path.exists(),
+        "a refused SQLite pull must not create a snapshot file"
+    );
+}

--- a/autumn-cli/tests/integration/schema_pull.rs
+++ b/autumn-cli/tests/integration/schema_pull.rs
@@ -106,9 +106,13 @@ fn assert_no_secret_leak(stdout: &str, stderr: &str) {
     );
 }
 
-/// Two well-behaved models covering the full mapped type surface plus a foreign
+/// Three well-behaved models covering the full mapped type surface plus a foreign
 /// key (`Post.author_id → authors`), a unique column, a `NUMERIC` decimal, a
-/// `JSONB` attachment, and a `TIMESTAMPTZ`.
+/// `JSONB` attachment, and a `TIMESTAMPTZ`. `Session` additionally exercises the
+/// key judgment call end-to-end: a **UUID primary key** (`id UUID PRIMARY KEY
+/// DEFAULT gen_random_uuid()`), whose `gen_random_uuid()` default must survive the
+/// round-trip (the model parser recovers it, so pulling it back is not read as
+/// drift), plus a `DOUBLE PRECISION` float and a nullable column.
 const ROUND_TRIP_MODELS: &str = r"
 #[autumn_web::model(managed)]
 pub struct Author {
@@ -133,6 +137,17 @@ pub struct Post {
     pub rating: rust_decimal::Decimal,
     pub metadata: autumn_web::storage::Blob,
     pub launched_at: chrono::DateTime<chrono::Utc>,
+    #[default]
+    pub created_at: chrono::NaiveDateTime,
+}
+
+#[autumn_web::model(managed)]
+pub struct Session {
+    #[id]
+    pub id: uuid::Uuid,
+    pub label: String,
+    pub weight: f64,
+    pub note: Option<String>,
     #[default]
     pub created_at: chrono::NaiveDateTime,
 }
@@ -188,7 +203,7 @@ async fn schema_pull_round_trips_models_through_the_database() {
     //    model-derived baseline with the DB-introspected one.
     let (pull_out, pull_err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
     assert!(
-        pull_out.contains("pulled schema snapshot") && pull_out.contains("2 table(s)"),
+        pull_out.contains("pulled schema snapshot") && pull_out.contains("3 table(s)"),
         "pull reports the table count: {pull_out}"
     );
     assert_no_secret_leak(&pull_out, &pull_err);
@@ -225,6 +240,23 @@ async fn schema_pull_round_trips_models_through_the_database() {
     assert!(
         snap.contains("\"TimestampTz\""),
         "timestamptz preserved: {snap}"
+    );
+    // The UUID-PK judgment call: the sessions table pulls back with a UUID id
+    // whose `gen_random_uuid()` default is preserved (so the round-trip below is
+    // clean rather than flagging the default as drift), plus a float and a
+    // nullable column.
+    assert!(
+        snap.contains("\"name\": \"sessions\""),
+        "sessions table: {snap}"
+    );
+    assert!(snap.contains("\"Uuid\""), "uuid PK type preserved: {snap}");
+    assert!(
+        snap.contains("gen_random_uuid()"),
+        "uuid PK default preserved: {snap}"
+    );
+    assert!(
+        snap.contains("\"Float64\""),
+        "float column preserved: {snap}"
     );
     // No framework/bookkeeping tables leaked into the pulled snapshot.
     assert!(

--- a/autumn-cli/tests/integration/schema_pull.rs
+++ b/autumn-cli/tests/integration/schema_pull.rs
@@ -1355,6 +1355,249 @@ pub struct Account {
     assert_no_secret_leak(&mdiff_out, &mdiff_err);
 }
 
+/// Fix 1 (same-name coverage): a brownfield PARTIAL unique index deliberately
+/// NAMED with the model's conventional index name (`idx_members_email_unique`)
+/// hits the same-NAME match branch in `diff_indexes`. Because it is
+/// definition-carrying it is RETAINED, but a partial index does NOT enforce
+/// table-wide uniqueness — so it must NOT suppress the model's `#[unique] email`.
+/// The model diff must still emit the full unique `AddIndex`, which the policy
+/// guard then refuses on the pre-existing `email` column — the decisive signal
+/// that the same-named partial index did NOT silently satisfy the annotation.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_diff_same_named_partial_unique_index_does_not_satisfy_model_unique() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_same_named_partial_unique_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    // Brownfield `members(id, email, created_at)` with a PARTIAL unique index on
+    // `email` that carries the MODEL'S CONVENTIONAL NAME `idx_members_email_unique`
+    // (the parser emits exactly this name for `#[unique] email` on `Member`).
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_create_members",
+        "CREATE TABLE members (id BIGSERIAL PRIMARY KEY, email TEXT NOT NULL, created_at TIMESTAMP NOT NULL DEFAULT NOW());\n\
+         CREATE UNIQUE INDEX idx_members_email_unique ON members (email) WHERE email IS NOT NULL;",
+        "DROP TABLE members;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // Pull: the partial unique index is retained verbatim and flagged partial.
+    let (out, err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&out, &err);
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    assert!(
+        snap.contains("idx_members_email_unique"),
+        "the conventionally-named partial unique index is retained by name: {snap}"
+    );
+    assert!(
+        snap.contains("\"is_partial\"") && snap.contains("WHERE"),
+        "the pulled index is flagged partial and keeps its predicate: {snap}"
+    );
+
+    // The natural model declares `#[unique]` on email, whose parser emits an index
+    // named `idx_members_email_unique` — the SAME name as the retained partial
+    // index. The same-NAME branch must NOT suppress it (a partial index cannot
+    // enforce table-wide uniqueness): the diff emits the unique AddIndex, which the
+    // guard refuses on the pre-existing column.
+    write_models(
+        &project,
+        "
+#[autumn_web::model(managed)]
+pub struct Member {
+    #[id]
+    pub id: i64,
+    #[unique]
+    pub email: String,
+}
+",
+    );
+    let (mdiff_out, mdiff_err) = run_autumn_fail(&project, &["schema", "diff"], &envs);
+    let combined = format!("{mdiff_out}{mdiff_err}");
+    assert!(
+        combined.contains("cannot add unique index") && combined.contains("members"),
+        "a same-named partial unique index must NOT satisfy the model #[unique]; the diff \
+         must emit the unique AddIndex (guard-refused on the pre-existing column):\n{combined}"
+    );
+    assert_no_secret_leak(&mdiff_out, &mdiff_err);
+}
+
+/// Fix 2 (fail-closed floor for Postgres DOMAIN columns): a column typed on a
+/// domain (`CREATE DOMAIN email_dom AS text CHECK (…)`) reports its base type in
+/// `udt_name` (`text`) but names the domain in `information_schema.columns`. Pull
+/// must preserve the domain verbatim as an `Opaque` type carrying the domain name
+/// — NOT flatten it to `Text`, which would silently drop the domain's identity and
+/// validation on recreation. Re-pull is byte-stable and doctor is clean.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_pull_preserves_domain_column_as_opaque() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_domain_opaque_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_create_contacts",
+        "CREATE DOMAIN email_dom AS text CHECK (VALUE LIKE '%@%');\n\
+         CREATE TABLE contacts (id BIGSERIAL PRIMARY KEY, email email_dom NOT NULL, created_at TIMESTAMP NOT NULL DEFAULT NOW());",
+        "DROP TABLE contacts; DROP DOMAIN email_dom;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // Pull: the domain column is preserved as Opaque{pg_type: "email_dom"}, not Text.
+    let (out, err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&out, &err);
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    assert!(
+        snap.contains("\"name\": \"email\""),
+        "the domain column is present: {snap}"
+    );
+    assert!(
+        snap.contains("\"Opaque\"") && snap.contains("\"pg_type\": \"email_dom\""),
+        "the domain column is preserved as Opaque carrying the domain name (NOT Text): {snap}"
+    );
+
+    // Re-pull is byte-for-byte stable.
+    let snap_before = snap;
+    let (pull2_out, pull2_err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&pull2_out, &pull2_err);
+    let snap_after = std::fs::read_to_string(&snapshot_path).expect("snapshot after second pull");
+    assert_eq!(
+        snap_before, snap_after,
+        "a re-pull of the same database must be byte-for-byte stable (no domain drift)"
+    );
+
+    // doctor agrees the DB matches the pulled baseline.
+    let (doc_out, doc_err) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor reports the DB matches the snapshot with the domain column:\n{doc_out}"
+    );
+    assert_no_secret_leak(&doc_out, &doc_err);
+}
+
+/// Fix 3 (fail-closed floor for cross-schema FK targets): a FK referencing a table
+/// outside `public` (`REFERENCES auth.accounts(id)`) must be recorded
+/// schema-qualified (`auth.accounts`) so recreation emits `REFERENCES
+/// auth.accounts(id)` — never a wrong bare `REFERENCES accounts(id)` pointing at a
+/// (nonexistent) `public.accounts`. Re-pull is byte-stable and doctor is clean.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_pull_qualifies_cross_schema_foreign_key_target() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_cross_schema_fk_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_create_sessions",
+        "CREATE SCHEMA auth;\n\
+         CREATE TABLE auth.accounts (id BIGSERIAL PRIMARY KEY);\n\
+         CREATE TABLE public.sessions (id BIGSERIAL PRIMARY KEY, account_id BIGINT REFERENCES auth.accounts(id), created_at TIMESTAMP NOT NULL DEFAULT NOW());",
+        "DROP TABLE public.sessions; DROP TABLE auth.accounts; DROP SCHEMA auth;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // Pull: the FK target is recorded schema-qualified as `auth.accounts`.
+    let (out, err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&out, &err);
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    assert!(
+        snap.contains("\"table\": \"auth.accounts\""),
+        "the cross-schema FK target is recorded schema-qualified: {snap}"
+    );
+    assert!(
+        !snap.contains("\"table\": \"accounts\""),
+        "the FK target must NOT be recorded as a bare (wrong) `accounts`: {snap}"
+    );
+
+    // Re-pull is byte-for-byte stable.
+    let snap_before = snap;
+    let (pull2_out, pull2_err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&pull2_out, &pull2_err);
+    let snap_after = std::fs::read_to_string(&snapshot_path).expect("snapshot after second pull");
+    assert_eq!(
+        snap_before, snap_after,
+        "a re-pull of the same database must be byte-for-byte stable (no cross-schema FK drift)"
+    );
+
+    // doctor agrees the DB matches the pulled baseline.
+    let (doc_out, doc_err) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor reports the DB matches the snapshot with the cross-schema FK:\n{doc_out}"
+    );
+    assert_no_secret_leak(&doc_out, &doc_err);
+}
+
+/// Fix 4 (preserve CHECK constraints): a real table-level `CHECK (price >= 0)`
+/// must be pulled into the snapshot's `Table.checks` — previously `checks` was
+/// always left empty, silently dropping the constraint on recreation. The column
+/// `NOT NULL` is not a check (it is `attnotnull`), so it never appears here.
+/// Re-pull is byte-stable and doctor is clean.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_pull_preserves_check_constraints() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_check_constraint_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_create_products",
+        "CREATE TABLE products (id BIGSERIAL PRIMARY KEY, price INTEGER NOT NULL CHECK (price >= 0), created_at TIMESTAMP NOT NULL DEFAULT NOW());",
+        "DROP TABLE products;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // Pull: the CHECK constraint is preserved in the products table's checks.
+    let (out, err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&out, &err);
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    assert!(
+        snap.contains("\"name\": \"products\""),
+        "products pulled: {snap}"
+    );
+    assert!(
+        snap.contains("\"checks\"") && snap.contains("price >= 0"),
+        "the CHECK constraint predicate is preserved on pull (not dropped): {snap}"
+    );
+
+    // Re-pull is byte-for-byte stable.
+    let snap_before = snap;
+    let (pull2_out, pull2_err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&pull2_out, &pull2_err);
+    let snap_after = std::fs::read_to_string(&snapshot_path).expect("snapshot after second pull");
+    assert_eq!(
+        snap_before, snap_after,
+        "a re-pull of the same database must be byte-for-byte stable (no check drift)"
+    );
+
+    // doctor agrees the DB matches the pulled baseline.
+    let (doc_out, doc_err) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor reports the DB matches the snapshot with the CHECK constraint:\n{doc_out}"
+    );
+    assert_no_secret_leak(&doc_out, &doc_err);
+}
+
 /// `SQLite` introspection is a future slice: `schema pull` against a `SQLite` URL
 /// is refused loudly (no Docker needed — the refusal happens before any
 /// connection), names `SQLite`, and writes no snapshot.

--- a/autumn-cli/tests/integration/schema_pull.rs
+++ b/autumn-cli/tests/integration/schema_pull.rs
@@ -1484,6 +1484,75 @@ async fn schema_pull_preserves_domain_column_as_opaque() {
     assert_no_secret_leak(&doc_out, &doc_err);
 }
 
+/// Fail-closed floor for length-limited character types: a `VARCHAR(32)` /
+/// `CHAR(2)` column reports `udt_name` `varchar` / `bpchar`, which the shared
+/// mapped surface would otherwise flatten to `Text`, silently dropping the
+/// DB-enforced length limit (recreation would emit an unconstrained `TEXT`). Pull
+/// must preserve the length verbatim as `Opaque` carrying `varchar(32)` /
+/// `char(2)`, while an unbounded `TEXT` column stays `Text`. Re-pull is byte-stable
+/// and doctor is clean.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_pull_preserves_length_limited_char_columns_as_opaque() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_varchar_opaque_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_create_labels",
+        "CREATE TABLE labels (id BIGSERIAL PRIMARY KEY, code VARCHAR(32) NOT NULL, \
+         kind CHAR(2) NOT NULL, note TEXT, created_at TIMESTAMP NOT NULL DEFAULT NOW());",
+        "DROP TABLE labels;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // Pull: the length-limited columns are preserved as Opaque{varchar(32)} /
+    // Opaque{char(2)}, never flattened to Text; the unbounded `note` stays Text.
+    let (out, err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&out, &err);
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    assert!(
+        snap.contains("\"name\": \"code\"") && snap.contains("\"pg_type\": \"varchar(32)\""),
+        "VARCHAR(32) is preserved as Opaque varchar(32) (NOT Text): {snap}"
+    );
+    assert!(
+        snap.contains("\"name\": \"kind\"") && snap.contains("\"pg_type\": \"char(2)\""),
+        "CHAR(2) is preserved as Opaque char(2) (NOT Text): {snap}"
+    );
+    // `note` (unbounded TEXT) must map to Text, not Opaque.
+    let note_idx = snap
+        .find("\"name\": \"note\"")
+        .expect("note column present");
+    let note_slice = &snap[note_idx..];
+    assert!(
+        note_slice.contains("\"Text\""),
+        "the unbounded TEXT column stays Text: {snap}"
+    );
+
+    // Re-pull is byte-for-byte stable.
+    let snap_before = snap;
+    let (pull2_out, pull2_err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&pull2_out, &pull2_err);
+    let snap_after = std::fs::read_to_string(&snapshot_path).expect("snapshot after second pull");
+    assert_eq!(
+        snap_before, snap_after,
+        "a re-pull of the same database must be byte-for-byte stable (no varchar-length drift)"
+    );
+
+    // doctor agrees the DB matches the pulled baseline.
+    let (doc_out, doc_err) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor reports the DB matches the snapshot with the length-limited columns:\n{doc_out}"
+    );
+    assert_no_secret_leak(&doc_out, &doc_err);
+}
+
 /// Fix 3 (fail-closed floor for cross-schema FK targets): a FK referencing a table
 /// outside `public` (`REFERENCES auth.accounts(id)`) must be recorded
 /// schema-qualified (`auth.accounts`) so recreation emits `REFERENCES

--- a/autumn-cli/tests/integration/schema_pull.rs
+++ b/autumn-cli/tests/integration/schema_pull.rs
@@ -86,11 +86,17 @@ async fn start_postgres() -> (
     String,
     u16,
 ) {
+    use testcontainers::ImageExt as _;
     use testcontainers::runners::AsyncRunner as _;
     use testcontainers_modules::postgres::Postgres;
 
+    // Pin a modern Postgres image (the module default is `postgres:11-alpine`).
+    // The round-trip fixture's UUID PK generates `DEFAULT gen_random_uuid()`, a
+    // built-in only from PostgreSQL 13+, so PG11 would fail `schema migrate` with
+    // `function gen_random_uuid() does not exist`.
     let container = Postgres::default()
         .with_password(SECRET_PW)
+        .with_tag("16-alpine")
         .start()
         .await
         .expect("failed to start Postgres testcontainer — is Docker running?");
@@ -449,7 +455,11 @@ async fn schema_pull_preserves_expression_and_partial_indexes() {
     write_raw_migration(
         &project,
         "20260101000000_create_members",
-        "CREATE TABLE members (id BIGSERIAL PRIMARY KEY, email TEXT NOT NULL, deleted_at TIMESTAMP);\n\
+        // `created_at TIMESTAMP NOT NULL DEFAULT NOW()` matches the column the
+        // managed-model parser synthesizes for `Member` below, so the later
+        // model-side `schema diff` is genuinely empty (no spurious ADD COLUMN)
+        // and validates only the index-retention behavior.
+        "CREATE TABLE members (id BIGSERIAL PRIMARY KEY, email TEXT NOT NULL, deleted_at TIMESTAMP, created_at TIMESTAMP NOT NULL DEFAULT NOW());\n\
          CREATE INDEX members_lower_email_idx ON members (lower(email));\n\
          CREATE INDEX members_active_email_idx ON members (email) WHERE deleted_at IS NULL;",
         "DROP TABLE members;",
@@ -560,7 +570,11 @@ async fn schema_pull_retains_constraint_owned_unique_index() {
     write_raw_migration(
         &project,
         "20260101000000_create_accounts",
-        "CREATE TABLE accounts (id BIGSERIAL PRIMARY KEY, email TEXT NOT NULL UNIQUE);",
+        // `created_at TIMESTAMP NOT NULL DEFAULT NOW()` matches the column the
+        // managed-model parser synthesizes for `Account` below, so the later
+        // model-side `schema diff` is genuinely empty (no spurious ADD COLUMN)
+        // and validates only the constraint-owned-index retention.
+        "CREATE TABLE accounts (id BIGSERIAL PRIMARY KEY, email TEXT NOT NULL UNIQUE, created_at TIMESTAMP NOT NULL DEFAULT NOW());",
         "DROP TABLE accounts;",
     );
     run_autumn_ok(&project, &["schema", "migrate"], &envs);
@@ -706,6 +720,102 @@ pub struct Account {
     assert!(
         doc_out.contains("database schema matches the snapshot baseline"),
         "doctor reports no drift after dropping the uniquely-indexed column:\n{doc_out}"
+    );
+    assert_no_secret_leak(&doc_out, &doc_err);
+}
+
+/// Dropping a column whose name merely appears as a STRING LITERAL in an unrelated
+/// partial index's predicate (`WHERE kind = 'email'`) must NOT prune that index —
+/// Postgres keeps it (the index depends on `id`/`kind`, never `email`). This guards
+/// the exact-`pg_depend` dependency detection (Codex P1): the prior string scan of
+/// the `definition` text false-matched the `'email'` literal, wrongly pruned the
+/// retained index from the projected snapshot, and left `doctor` perpetually
+/// drifting (or the down migration recreating an index Postgres never dropped).
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_diff_dropping_column_named_in_index_predicate_literal_stays_clean() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_predicate_literal_app");
+
+    // Brownfield `events(id, kind, email)` with a PARTIAL index on `id` whose
+    // predicate is a string literal `kind = 'email'` — it depends on `id` and
+    // `kind`, NOT on the `email` column. `created_at` matches the synthesized model
+    // column so the only real change below is the DROP COLUMN.
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_create_events",
+        "CREATE TABLE events (id BIGSERIAL PRIMARY KEY, kind TEXT, email TEXT, created_at TIMESTAMP NOT NULL DEFAULT NOW());\n\
+         CREATE INDEX events_id_when_email_idx ON events (id) WHERE kind = 'email';",
+        "DROP TABLE events;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+    run_autumn_ok(&project, &["schema", "pull"], &envs);
+
+    // Model DROPS `email` (keeps id + kind). The partial index does not depend on
+    // `email`, so it must survive both the projection and the actual DROP COLUMN.
+    write_models(
+        &project,
+        "
+#[autumn_web::model(managed)]
+pub struct Event {
+    #[id]
+    pub id: i64,
+    pub kind: Option<String>,
+}
+",
+    );
+    let (diff_out, diff_err) = run_autumn_ok(
+        &project,
+        &[
+            "schema",
+            "diff",
+            "--write-migration",
+            "--name",
+            "drop_email",
+            "--allow-destructive",
+        ],
+        &envs,
+    );
+    assert_no_secret_leak(&diff_out, &diff_err);
+
+    let mig_root = project.join("migrations");
+    let mut up_sql = String::new();
+    let mut down_sql = String::new();
+    for entry in std::fs::read_dir(&mig_root).expect("migrations dir") {
+        let dir = entry.expect("entry").path();
+        if dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.contains("drop_email"))
+        {
+            up_sql = std::fs::read_to_string(dir.join("up.sql")).unwrap_or_default();
+            down_sql = std::fs::read_to_string(dir.join("down.sql")).unwrap_or_default();
+        }
+    }
+    assert!(
+        up_sql.contains("DROP COLUMN email"),
+        "up migration drops the column: {up_sql}"
+    );
+    // The unrelated partial index is NOT cascade-dropped, so the down migration
+    // must NOT try to recreate it (Postgres never removed it).
+    assert!(
+        !down_sql.contains("events_id_when_email_idx"),
+        "down migration must NOT recreate an index Postgres never dropped: {down_sql}"
+    );
+
+    // Apply: Postgres drops only the column and KEEPS the partial index.
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // doctor must be clean: the projected snapshot retained the partial index
+    // (exact dependency detection), matching the live DB that still has it.
+    let (doc_out, doc_err) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor reports no drift — the partial index was not falsely pruned:\n{doc_out}"
     );
     assert_no_secret_leak(&doc_out, &doc_err);
 }

--- a/autumn-cli/tests/integration/schema_pull.rs
+++ b/autumn-cli/tests/integration/schema_pull.rs
@@ -1218,6 +1218,73 @@ async fn schema_pull_preserves_int4_serial_primary_key() {
     assert_no_secret_leak(&doc_out, &doc_err);
 }
 
+/// A brownfield single-column **UUID** primary key whose default is NOT the Autumn
+/// convention `gen_random_uuid()` — here a UUID PK with **no** default at all — must
+/// pull back preserving "no default", NOT the convention `gen_random_uuid()`. The
+/// no-default case is used deliberately so the test needs no `uuid-ossp` extension:
+/// `schema pull` records the id column with no default, a re-pull is byte-stable, and
+/// `schema doctor` reports no drift. This guards the emitter fix that gates the
+/// `IdKind::Uuid` shape on the stored default (see `diff::pk_kind_for`) so recreation
+/// never silently invents a `gen_random_uuid()` default the database never had.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_pull_preserves_uuid_pk_without_convention_default() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_uuid_no_default_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    // A brownfield table whose primary key is a bare `uuid` with NO default — the
+    // application supplies the id, so Postgres records no column default. Authored via
+    // a raw migration (needs no `uuid-ossp` / `pgcrypto` extension).
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_create_tokens",
+        "CREATE TABLE tokens (id uuid PRIMARY KEY, label TEXT NOT NULL, created_at TIMESTAMP NOT NULL DEFAULT NOW());",
+        "DROP TABLE tokens;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // Pull: the UUID id is captured, but with NO `gen_random_uuid()` default invented.
+    let (out, err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&out, &err);
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    assert!(
+        snap.contains("tokens"),
+        "the brownfield table is captured: {snap}"
+    );
+    assert!(
+        snap.contains("\"Uuid\""),
+        "the UUID PK type is preserved: {snap}"
+    );
+    assert!(
+        !snap.contains("gen_random_uuid()"),
+        "a non-convention UUID PK must NOT gain a gen_random_uuid() default on pull: {snap}"
+    );
+
+    // A re-pull of the same database is byte-for-byte stable (no UUID-default drift).
+    let snap_before = snap;
+    let (pull2_out, pull2_err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&pull2_out, &pull2_err);
+    let snap_after = std::fs::read_to_string(&snapshot_path).expect("snapshot after second pull");
+    assert_eq!(
+        snap_before, snap_after,
+        "a re-pull of the same database must be byte-for-byte stable (UUID-no-default faithful)"
+    );
+
+    // doctor agrees the database still matches the pulled baseline (no drift from the
+    // preserved default-less UUID primary key).
+    let (doc_out, doc_err) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor reports the DB matches the snapshot with the default-less UUID PK:\n{doc_out}"
+    );
+    assert_no_secret_leak(&doc_out, &doc_err);
+}
+
 /// A **partial** unique index (`… ON accounts(email) WHERE …`) enforces uniqueness
 /// only for rows matching its predicate, so it must NOT be treated as satisfying a
 /// model `#[unique] email` (which demands table-wide uniqueness). Unlike a full

--- a/autumn-cli/tests/integration/schema_pull.rs
+++ b/autumn-cli/tests/integration/schema_pull.rs
@@ -1218,6 +1218,73 @@ async fn schema_pull_preserves_int4_serial_primary_key() {
     assert_no_secret_leak(&doc_out, &doc_err);
 }
 
+/// A brownfield int8 primary key backed by a **shared/custom** sequence the column
+/// does NOT own (`id BIGINT PRIMARY KEY DEFAULT nextval('global_ids')`) must have its
+/// `nextval(...)` default PRESERVED verbatim — NOT stripped like a conventional owned
+/// `BIGSERIAL` id, and NOT re-emitted as a fresh `BIGSERIAL` (which would mint a new
+/// owned sequence and silently change ID allocation, abandoning `global_ids`). Only a
+/// sequence the column *owns* (an `OWNED BY` `pg_depend` `deptype = 'a'` row) is the
+/// default-less `BIGSERIAL` shape. The faithful-representation acceptance is the
+/// preserved `nextval('global_ids'...)` default visible in the snapshot, a byte-stable
+/// re-pull, and a clean `doctor`.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_pull_preserves_shared_sequence_int8_primary_key() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_shared_seq_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    // A brownfield table whose int8 PK draws from a STANDALONE sequence it does not
+    // own (a shared/global id allocator), authored via a raw migration so Postgres
+    // records the `nextval('global_ids'...)` default WITHOUT an `OWNED BY` dependency.
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_create_events",
+        "CREATE SEQUENCE global_ids;\n\
+         CREATE TABLE events (id BIGINT PRIMARY KEY DEFAULT nextval('global_ids'), label TEXT NOT NULL, created_at TIMESTAMP NOT NULL DEFAULT NOW());",
+        "DROP TABLE events;\nDROP SEQUENCE global_ids;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // Pull: the shared-sequence id's default must survive verbatim — NOT stripped to
+    // None (which would recreate it as a fresh owned BIGSERIAL) and NOT rewritten.
+    let (out, err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&out, &err);
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    assert!(
+        snap.contains("events"),
+        "the brownfield table is captured: {snap}"
+    );
+    assert!(
+        snap.contains("global_ids"),
+        "the shared-sequence int8 PK's nextval('global_ids') default is PRESERVED \
+         (not stripped, not re-emitted as BIGSERIAL): {snap}"
+    );
+
+    // A re-pull of the same database is byte-for-byte stable (no shared-sequence drift).
+    let snap_before = snap;
+    let (pull2_out, pull2_err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&pull2_out, &pull2_err);
+    let snap_after = std::fs::read_to_string(&snapshot_path).expect("snapshot after second pull");
+    assert_eq!(
+        snap_before, snap_after,
+        "a re-pull of the same database must be byte-for-byte stable (shared-sequence faithful)"
+    );
+
+    // doctor agrees the database still matches the pulled baseline (no drift from the
+    // preserved shared-sequence primary key).
+    let (doc_out, doc_err) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor reports the DB matches the snapshot with the shared-sequence int8 PK:\n{doc_out}"
+    );
+    assert_no_secret_leak(&doc_out, &doc_err);
+}
+
 /// A brownfield single-column **UUID** primary key whose default is NOT the Autumn
 /// convention `gen_random_uuid()` — here a UUID PK with **no** default at all — must
 /// pull back preserving "no default", NOT the convention `gen_random_uuid()`. The

--- a/autumn-cli/tests/integration/schema_pull.rs
+++ b/autumn-cli/tests/integration/schema_pull.rs
@@ -627,6 +627,79 @@ pub struct Account {
     assert_no_secret_leak(&mdiff_out, &mdiff_err);
 }
 
+/// Brownfield adoption with the natural `#[unique]` annotation (the P2 fix): after
+/// `schema pull` retains the constraint-owned `accounts_email_key` index, the user
+/// writes the natural model `Account { id, email }` and DOES declare `#[unique]` on
+/// `email`. The parser emits its own differently-named `idx_accounts_email_unique`
+/// unique index over `[email]`. Before the fix, the model-side `schema diff` saw
+/// that name as absent from the baseline and emitted a unique `AddIndex`, which the
+/// policy guard then REJECTED (a unique index on a populated table needs dedup
+/// verification) — so the user could not keep the `#[unique]` annotation even
+/// though the database already enforces that exact uniqueness. After the fix the
+/// existing unique index (same column set) satisfies the desired `#[unique]`, so
+/// the diff is CLEAN: no `AddIndex`, no `DROP INDEX`, no guard rejection.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_diff_model_unique_matches_pulled_constraint_index() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_model_unique_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    // Brownfield `accounts(id, email UNIQUE, created_at)` — Postgres auto-creates
+    // the constraint-backed `accounts_email_key` index. `created_at TIMESTAMP NOT
+    // NULL DEFAULT NOW()` matches the column the managed-model parser synthesizes
+    // for `Account` below, so the diff isolates the unique-index behavior.
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_create_accounts",
+        "CREATE TABLE accounts (id BIGSERIAL PRIMARY KEY, email TEXT NOT NULL UNIQUE, created_at TIMESTAMP NOT NULL DEFAULT NOW());",
+        "DROP TABLE accounts;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // Pull the brownfield shape (retains the constraint-owned index).
+    let (out, err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&out, &err);
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    assert!(
+        snap.contains("accounts_email_key"),
+        "constraint-backed index retained by its Postgres-assigned name: {snap}"
+    );
+
+    // The natural model DOES declare `#[unique]` on email. The existing unique
+    // index must satisfy it — the diff must be clean, with no guard rejection.
+    write_models(
+        &project,
+        "
+#[autumn_web::model(managed)]
+pub struct Account {
+    #[id]
+    pub id: i64,
+    #[unique]
+    pub email: String,
+}
+",
+    );
+    let (mdiff_out, mdiff_err) = run_autumn_ok(&project, &["schema", "diff"], &envs);
+    assert!(
+        !mdiff_out.contains("AddIndex") && !mdiff_out.contains("CREATE UNIQUE INDEX"),
+        "a model #[unique] over a brownfield-UNIQUE column must NOT emit AddIndex:\n{mdiff_out}"
+    );
+    assert!(
+        !mdiff_out.contains("DROP INDEX") && !mdiff_out.contains("accounts_email_key"),
+        "the retained constraint-owned index must NOT be dropped:\n{mdiff_out}"
+    );
+    assert!(
+        mdiff_out.contains("No schema changes"),
+        "model diff with #[unique] against the pulled unique constraint is clean:\n{mdiff_out}"
+    );
+    assert_no_secret_leak(&mdiff_out, &mdiff_err);
+}
+
 /// A covering `INCLUDE` index (`CREATE UNIQUE INDEX … ON t (a) INCLUDE (b)`) must
 /// be RETAINED verbatim via its `definition`, not recorded as a plain `(a, b)`
 /// unique index. Recording it as an ordinary index would widen the uniqueness

--- a/autumn-cli/tests/integration/schema_pull.rs
+++ b/autumn-cli/tests/integration/schema_pull.rs
@@ -613,6 +613,103 @@ pub struct Account {
     assert_no_secret_leak(&mdiff_out, &mdiff_err);
 }
 
+/// Dropping a model column covered by a RETAINED constraint-owned unique index
+/// must not leave the snapshot stale. Postgres cascade-drops the index with the
+/// column (`ALTER TABLE … DROP COLUMN`), so the generated up-migration is a bare
+/// `DROP COLUMN` (never a rejected `DROP INDEX`), the advanced snapshot prunes the
+/// index (so `doctor` reports NO drift after apply), and the down-migration
+/// restores the index verbatim.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_diff_dropping_uniquely_indexed_column_stays_clean() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_drop_unique_col_app");
+
+    // Brownfield `accounts(id, email UNIQUE, note)` — Postgres auto-creates the
+    // constraint-backed `accounts_email_key` index.
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_create_accounts",
+        "CREATE TABLE accounts (id BIGSERIAL PRIMARY KEY, email TEXT NOT NULL UNIQUE, note TEXT);",
+        "DROP TABLE accounts;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // Pull the brownfield shape (retains the constraint-owned index).
+    run_autumn_ok(&project, &["schema", "pull"], &envs);
+
+    // Model DROPS `email` (keeps id + note). Generate the migration; the snapshot
+    // advances at generation time.
+    write_models(
+        &project,
+        "
+#[autumn_web::model(managed)]
+pub struct Account {
+    #[id]
+    pub id: i64,
+    pub note: Option<String>,
+}
+",
+    );
+    let (diff_out, diff_err) = run_autumn_ok(
+        &project,
+        &[
+            "schema",
+            "diff",
+            "--write-migration",
+            "--name",
+            "drop_email",
+            "--allow-destructive",
+        ],
+        &envs,
+    );
+    assert_no_secret_leak(&diff_out, &diff_err);
+
+    // Read the generated up/down SQL.
+    let mig_root = project.join("migrations");
+    let mut up_sql = String::new();
+    let mut down_sql = String::new();
+    for entry in std::fs::read_dir(&mig_root).expect("migrations dir") {
+        let dir = entry.expect("entry").path();
+        if dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.contains("drop_email"))
+        {
+            up_sql = std::fs::read_to_string(dir.join("up.sql")).unwrap_or_default();
+            down_sql = std::fs::read_to_string(dir.join("down.sql")).unwrap_or_default();
+        }
+    }
+    assert!(
+        up_sql.contains("DROP COLUMN email"),
+        "up migration drops the column: {up_sql}"
+    );
+    assert!(
+        !up_sql.contains("DROP INDEX"),
+        "up migration must NOT emit a DROP INDEX for the cascade-dropped constraint index: {up_sql}"
+    );
+    assert!(
+        down_sql.contains("CREATE UNIQUE INDEX") && down_sql.contains("accounts_email_key"),
+        "down migration restores the cascade-dropped retained index: {down_sql}"
+    );
+
+    // Apply the migration (Postgres cascades the index away with the column).
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // doctor must report NO database-schema drift: the advanced snapshot pruned
+    // the retained index to match the cascade-dropped DB (no false perpetual drift).
+    let (doc_out, doc_err) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor reports no drift after dropping the uniquely-indexed column:\n{doc_out}"
+    );
+    assert_no_secret_leak(&doc_out, &doc_err);
+}
+
 /// `SQLite` introspection is a future slice: `schema pull` against a `SQLite` URL
 /// is refused loudly (no Docker needed — the refusal happens before any
 /// connection), names `SQLite`, and writes no snapshot.

--- a/autumn-cli/tests/integration/schema_pull.rs
+++ b/autumn-cli/tests/integration/schema_pull.rs
@@ -424,6 +424,86 @@ async fn schema_pull_dry_run_reports_diff_without_writing() {
     );
 }
 
+/// Expression and partial indexes must be **preserved verbatim** by `schema pull`
+/// (via each index's `pg_get_indexdef` `definition`), never silently dropped or
+/// degraded to a plain column index (the P1 fixed here). An expression index over
+/// `lower(email)` has an `indkey` of `0` for the expression column (no matching
+/// `pg_attribute` row), and a partial index carries a `WHERE` predicate — both
+/// were lost by the prior inner-join fetch. After pulling, both index names and
+/// their definition text (`lower(email)` / the `WHERE` predicate) appear in the
+/// snapshot, and a second pull reports no drift against the just-pulled baseline.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_pull_preserves_expression_and_partial_indexes() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_expr_index_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    // A table with an EXPRESSION index (`lower(email)`) and a PARTIAL index
+    // (`WHERE deleted_at IS NULL`), created via a raw migration so they reach the
+    // live catalog exactly as authored.
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_create_members",
+        "CREATE TABLE members (id BIGSERIAL PRIMARY KEY, email TEXT NOT NULL, deleted_at TIMESTAMP);\n\
+         CREATE INDEX members_lower_email_idx ON members (lower(email));\n\
+         CREATE INDEX members_active_email_idx ON members (email) WHERE deleted_at IS NULL;",
+        "DROP TABLE members;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // Pull: both non-representable indexes must be preserved, not dropped.
+    let (out, err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&out, &err);
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+
+    assert!(
+        snap.contains("members_lower_email_idx"),
+        "expression index preserved by name: {snap}"
+    );
+    assert!(
+        snap.contains("lower(email)"),
+        "expression index definition preserved verbatim: {snap}"
+    );
+    assert!(
+        snap.contains("members_active_email_idx"),
+        "partial index preserved by name: {snap}"
+    );
+    assert!(
+        // pg_get_indexdef renders the predicate; assert the WHERE clause survived.
+        snap.contains("WHERE") && snap.contains("deleted_at IS NULL"),
+        "partial index predicate preserved verbatim: {snap}"
+    );
+    assert!(
+        snap.contains("\"definition\""),
+        "the raw definition field is serialized for non-representable indexes: {snap}"
+    );
+
+    // A second pull round-trips clean against the just-pulled baseline: two
+    // introspected snapshots of the same DB agree, so no drift is reported.
+    let snap_before = snap;
+    let (pull2_out, pull2_err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&pull2_out, &pull2_err);
+    let snap_after = std::fs::read_to_string(&snapshot_path).expect("snapshot after second pull");
+    assert_eq!(
+        snap_before, snap_after,
+        "a re-pull of the same database must be byte-for-byte stable (no expression/partial drift)"
+    );
+
+    // doctor agrees the database still matches the pulled baseline (no drift from
+    // the preserved expression/partial indexes).
+    let (doc_out, doc_err) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor reports the DB matches the snapshot with expression/partial indexes:\n{doc_out}"
+    );
+    assert_no_secret_leak(&doc_out, &doc_err);
+}
+
 /// `SQLite` introspection is a future slice: `schema pull` against a `SQLite` URL
 /// is refused loudly (no Docker needed — the refusal happens before any
 /// connection), names `SQLite`, and writes no snapshot.

--- a/autumn-cli/tests/integration/schema_pull.rs
+++ b/autumn-cli/tests/integration/schema_pull.rs
@@ -534,6 +534,85 @@ pub struct Member {
     assert_no_secret_leak(&mdiff_out, &mdiff_err);
 }
 
+/// A brownfield column-level `UNIQUE` constraint (`email TEXT UNIQUE`) auto-creates
+/// a `pg_constraint`-backed index Postgres names (`<table>_email_key`). `schema
+/// pull` must RETAIN that constraint-owned index verbatim via its `definition`
+/// (the P1 fixed here) — recording it as an ordinary droppable index would make a
+/// later model-side `schema diff` emit a `DROP INDEX` that Postgres REJECTS
+/// (`cannot drop index ... because constraint ... requires it`), producing a
+/// FAILING migration. The model DSL cannot express a UNIQUE constraint (it models
+/// uniqueness as unique *indexes*), so a model diff that does not redeclare the
+/// unique must be clean: no `DROP INDEX` for the constraint index.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_pull_retains_constraint_owned_unique_index() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_constraint_index_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    // A table with a column-level `UNIQUE` constraint, authored via a raw
+    // migration so Postgres auto-creates the constraint-backed `accounts_email_key`
+    // index exactly as a brownfield database would have it.
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_create_accounts",
+        "CREATE TABLE accounts (id BIGSERIAL PRIMARY KEY, email TEXT NOT NULL UNIQUE);",
+        "DROP TABLE accounts;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // Pull: the constraint-backed index must be preserved via its definition.
+    let (out, err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&out, &err);
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+
+    assert!(
+        snap.contains("accounts_email_key"),
+        "constraint-backed index preserved by its Postgres-assigned name: {snap}"
+    );
+    assert!(
+        snap.contains("\"definition\"") && snap.contains("CREATE UNIQUE INDEX"),
+        "the constraint-owned index is retained via its verbatim CREATE UNIQUE INDEX definition: {snap}"
+    );
+
+    // doctor agrees the DB matches the pulled baseline (retained index is stable).
+    let (doc_out, doc_err) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor reports the DB matches the snapshot with the constraint-owned index:\n{doc_out}"
+    );
+    assert_no_secret_leak(&doc_out, &doc_err);
+
+    // A MODEL-side `schema diff` whose model does NOT redeclare the unique must
+    // RETAIN the constraint-owned index — no `DROP INDEX` (which Postgres would
+    // reject). The diff is clean.
+    write_models(
+        &project,
+        "
+#[autumn_web::model(managed)]
+pub struct Account {
+    #[id]
+    pub id: i64,
+    pub email: String,
+}
+",
+    );
+    let (mdiff_out, mdiff_err) = run_autumn_ok(&project, &["schema", "diff"], &envs);
+    assert!(
+        !mdiff_out.contains("DROP INDEX") && !mdiff_out.contains("accounts_email_key"),
+        "a model-side `schema diff` must NOT drop the constraint-owned index:\n{mdiff_out}"
+    );
+    assert!(
+        mdiff_out.contains("No schema changes"),
+        "model diff against the pulled snapshot is clean (constraint-owned index retained):\n{mdiff_out}"
+    );
+    assert_no_secret_leak(&mdiff_out, &mdiff_err);
+}
+
 /// `SQLite` introspection is a future slice: `schema pull` against a `SQLite` URL
 /// is refused loudly (no Docker needed — the refusal happens before any
 /// connection), names `SQLite`, and writes no snapshot.

--- a/autumn-cli/tests/integration/schema_pull.rs
+++ b/autumn-cli/tests/integration/schema_pull.rs
@@ -627,6 +627,86 @@ pub struct Account {
     assert_no_secret_leak(&mdiff_out, &mdiff_err);
 }
 
+/// A covering `INCLUDE` index (`CREATE UNIQUE INDEX … ON t (a) INCLUDE (b)`) must
+/// be RETAINED verbatim via its `definition`, not recorded as a plain `(a, b)`
+/// unique index. Recording it as an ordinary index would widen the uniqueness
+/// scope from `(a)` to `(a, b)` and drop the covering behavior on recreation — and
+/// the model DSL cannot express the key/INCLUDE split. So the snapshot keeps the
+/// verbatim `CREATE UNIQUE INDEX … INCLUDE …` definition and a later model-side
+/// `schema diff` is clean (the definition index is retained, never recreated).
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_pull_retains_covering_include_index() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_include_index_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    // A table with a covering unique index, authored via a raw migration so
+    // Postgres records the `INCLUDE` clause. `created_at TIMESTAMP NOT NULL DEFAULT
+    // NOW()` matches the column the managed-model parser synthesizes for `Cover`
+    // below, so the later model-side `schema diff` is genuinely empty and validates
+    // only the INCLUDE-index retention.
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_create_covers",
+        "CREATE TABLE covers (id BIGSERIAL PRIMARY KEY, a TEXT NOT NULL, b TEXT, created_at TIMESTAMP NOT NULL DEFAULT NOW());\n\
+         CREATE UNIQUE INDEX covers_a_inc_b ON covers (a) INCLUDE (b);",
+        "DROP TABLE covers;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // Pull: the covering index must be preserved via its verbatim definition.
+    let (out, err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&out, &err);
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+
+    assert!(
+        snap.contains("covers_a_inc_b"),
+        "the covering index is preserved by name: {snap}"
+    );
+    assert!(
+        snap.contains("\"definition\"") && snap.contains("INCLUDE"),
+        "the covering index is retained via its verbatim CREATE UNIQUE INDEX … INCLUDE … definition: {snap}"
+    );
+
+    // doctor agrees the DB matches the pulled baseline (retained index is stable).
+    let (doc_out, doc_err) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor reports the DB matches the snapshot with the covering index:\n{doc_out}"
+    );
+    assert_no_secret_leak(&doc_out, &doc_err);
+
+    // A MODEL-side `schema diff` whose model does NOT redeclare the index must
+    // RETAIN it — no recreation, clean diff.
+    write_models(
+        &project,
+        "
+#[autumn_web::model(managed)]
+pub struct Cover {
+    #[id]
+    pub id: i64,
+    pub a: String,
+    pub b: Option<String>,
+}
+",
+    );
+    let (mdiff_out, mdiff_err) = run_autumn_ok(&project, &["schema", "diff"], &envs);
+    assert!(
+        !mdiff_out.contains("covers_a_inc_b"),
+        "a model-side `schema diff` must NOT recreate or drop the covering index:\n{mdiff_out}"
+    );
+    assert!(
+        mdiff_out.contains("No schema changes"),
+        "model diff against the pulled snapshot is clean (covering index retained):\n{mdiff_out}"
+    );
+    assert_no_secret_leak(&mdiff_out, &mdiff_err);
+}
+
 /// Dropping a model column covered by a RETAINED constraint-owned unique index
 /// must not leave the snapshot stale. Postgres cascade-drops the index with the
 /// column (`ALTER TABLE … DROP COLUMN`), so the generated up-migration is a bare
@@ -816,6 +896,121 @@ pub struct Event {
     assert!(
         doc_out.contains("database schema matches the snapshot baseline"),
         "doctor reports no drift — the partial index was not falsely pruned:\n{doc_out}"
+    );
+    assert_no_secret_leak(&doc_out, &doc_err);
+}
+
+/// Dropping TWO columns that a single RETAINED index depends on (an expression +
+/// partial index `… ON t (lower(email)) WHERE tenant_id IS NOT NULL`, cascade-
+/// dropped once BOTH `email` and `tenant_id` are removed) must produce a down
+/// migration that re-adds BOTH columns and recreates the index EXACTLY ONCE, after
+/// both re-adds. Recreating it inline after only the first re-add would (a) fail —
+/// the other dependent column is still absent — and (b) duplicate the
+/// `CREATE INDEX`.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_diff_dropping_two_indexed_columns_recreates_index_once() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_drop_two_indexed_cols_app");
+
+    // Brownfield `members(id, email, tenant_id, created_at)` with an expression +
+    // partial index depending on BOTH `email` (via `lower(email)`) and `tenant_id`
+    // (via the `WHERE` predicate). `created_at` matches the synthesized model column
+    // so the only real changes are the two DROP COLUMNs.
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_create_members",
+        "CREATE TABLE members (id BIGSERIAL PRIMARY KEY, email TEXT NOT NULL, tenant_id BIGINT, created_at TIMESTAMP NOT NULL DEFAULT NOW());\n\
+         CREATE INDEX members_active_idx ON members (lower(email)) WHERE tenant_id IS NOT NULL;",
+        "DROP TABLE members;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+    run_autumn_ok(&project, &["schema", "pull"], &envs);
+
+    // Model DROPS both `email` and `tenant_id` (keeps only id + synthesized
+    // created_at). The index depends on both, so it is cascade-dropped by the
+    // DROP COLUMNs; the down migration must restore both columns then the index.
+    write_models(
+        &project,
+        "
+#[autumn_web::model(managed)]
+pub struct Member {
+    #[id]
+    pub id: i64,
+}
+",
+    );
+    let (diff_out, diff_err) = run_autumn_ok(
+        &project,
+        &[
+            "schema",
+            "diff",
+            "--write-migration",
+            "--name",
+            "drop_both",
+            "--allow-destructive",
+        ],
+        &envs,
+    );
+    assert_no_secret_leak(&diff_out, &diff_err);
+
+    let mig_root = project.join("migrations");
+    let mut up_sql = String::new();
+    let mut down_sql = String::new();
+    for entry in std::fs::read_dir(&mig_root).expect("migrations dir") {
+        let dir = entry.expect("entry").path();
+        if dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.contains("drop_both"))
+        {
+            up_sql = std::fs::read_to_string(dir.join("up.sql")).unwrap_or_default();
+            down_sql = std::fs::read_to_string(dir.join("down.sql")).unwrap_or_default();
+        }
+    }
+    assert!(
+        up_sql.contains("DROP COLUMN email") && up_sql.contains("DROP COLUMN tenant_id"),
+        "up migration drops both columns: {up_sql}"
+    );
+    assert!(
+        !up_sql.contains("DROP INDEX"),
+        "up migration must NOT emit a DROP INDEX for the cascade-dropped index: {up_sql}"
+    );
+
+    // DOWN: re-adds BOTH columns and recreates the index EXACTLY ONCE, after both.
+    assert!(
+        down_sql.contains("ADD COLUMN email") && down_sql.contains("ADD COLUMN tenant_id"),
+        "down migration re-adds both dependent columns: {down_sql}"
+    );
+    assert_eq!(
+        down_sql.matches("members_active_idx").count(),
+        1,
+        "the multi-column retained index must be recreated exactly once (deduped): {down_sql}"
+    );
+    let email_at = down_sql.find("ADD COLUMN email").expect("email re-add");
+    let tenant_at = down_sql
+        .find("ADD COLUMN tenant_id")
+        .expect("tenant_id re-add");
+    let index_at = down_sql
+        .find("members_active_idx")
+        .expect("index recreation");
+    assert!(
+        email_at < index_at && tenant_at < index_at,
+        "both dependent columns must be re-added BEFORE the index recreation: {down_sql}"
+    );
+
+    // Apply the up migration (Postgres cascades the index away with the columns).
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    // doctor must report NO drift: the advanced snapshot pruned the index to match.
+    let (doc_out, doc_err) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor reports no drift after dropping both indexed columns:\n{doc_out}"
     );
     assert_no_secret_leak(&doc_out, &doc_err);
 }

--- a/autumn-schema-core/src/lib.rs
+++ b/autumn-schema-core/src/lib.rs
@@ -101,6 +101,23 @@ pub enum ColumnType {
         /// The allowed variant labels, in declaration order.
         variants: Vec<String>,
     },
+    /// A Postgres type outside Autumn's mapped surface, **preserved verbatim** by
+    /// database introspection (`autumn schema pull`) so an unmappable column is
+    /// never silently dropped from the snapshot IR.
+    ///
+    /// This variant is **introspection/snapshot-only**: it records the raw
+    /// Postgres type name (e.g. `inet`, `citext`, `macaddr`) exactly as read from
+    /// the catalog. [`sql_type`](Self::sql_type) emits `pg_type` verbatim (on both
+    /// backends), so a pulled snapshot round-trips the raw type. It is deliberately
+    /// **not** intended for Rust codegen in this slice — [`rust_type`](Self::rust_type)
+    /// and [`diesel_type`](Self::diesel_type) return a safe `String`/`Text`
+    /// sentinel rather than a faithful mapping (an opaque type has no known Rust
+    /// representation), and there is no forward DSL / `#[model]` source that
+    /// produces it.
+    Opaque {
+        /// The raw Postgres type name (`udt_name`), preserved exactly.
+        pg_type: String,
+    },
 }
 
 impl ColumnType {
@@ -114,7 +131,10 @@ impl ColumnType {
     #[must_use]
     pub fn rust_type(&self) -> String {
         match self {
-            Self::Text | Self::Enum { .. } => "String",
+            // `Opaque` is introspection-only and has no known Rust representation,
+            // so it shares the `String` storage-fallback sentinel (it is not
+            // intended for Rust codegen in this slice — never panics).
+            Self::Text | Self::Enum { .. } | Self::Opaque { .. } => "String",
             Self::Int32 => "i32",
             Self::Int64 => "i64",
             Self::Bool => "bool",
@@ -141,7 +161,9 @@ impl ColumnType {
     pub const fn diesel_type(&self, backend: Backend) -> &'static str {
         match backend {
             Backend::Postgres => match self {
-                Self::Text | Self::Enum { .. } => "Text",
+                // `Opaque` shares the `Text` diesel sentinel (introspection-only,
+                // not intended for diesel codegen).
+                Self::Text | Self::Enum { .. } | Self::Opaque { .. } => "Text",
                 Self::Int32 => "Int4",
                 Self::Int64 => "Int8",
                 Self::Bool => "Bool",
@@ -155,11 +177,13 @@ impl ColumnType {
                 Self::Decimal { .. } => "Numeric",
             },
             Backend::Sqlite => match self {
+                // `Opaque` shares the `Text` diesel sentinel (introspection-only).
                 Self::Text
                 | Self::Uuid
                 | Self::Attachment
                 | Self::Decimal { .. }
-                | Self::Enum { .. } => "Text",
+                | Self::Enum { .. }
+                | Self::Opaque { .. } => "Text",
                 Self::Int32 => "Int4",
                 Self::Int64 => "Int8",
                 Self::Bool => "Bool",
@@ -197,6 +221,8 @@ impl ColumnType {
                 Self::Bytes => "BYTEA".to_owned(),
                 Self::Attachment => "JSONB".to_owned(),
                 Self::Decimal { precision, scale } => format!("NUMERIC({precision},{scale})"),
+                // Preserved verbatim: the raw Postgres type name round-trips.
+                Self::Opaque { pg_type } => pg_type.clone(),
             },
             Backend::Sqlite => match self {
                 Self::Text
@@ -209,6 +235,10 @@ impl ColumnType {
                 Self::Int32 | Self::Int64 | Self::Bool => "INTEGER".to_owned(),
                 Self::Float32 | Self::Float64 => "REAL".to_owned(),
                 Self::Bytes => "BLOB".to_owned(),
+                // Preserved verbatim (an `Opaque` is only ever produced by
+                // Postgres introspection, but the arm is emitted on both backends
+                // for exhaustiveness and never loses the raw type name).
+                Self::Opaque { pg_type } => pg_type.clone(),
             },
         }
     }
@@ -232,6 +262,8 @@ impl ColumnType {
                 | Self::Decimal { .. }
                 | Self::TimestampTz
                 | Self::Enum { .. }
+                // Introspection-only: an opaque type has no known diesel conversion.
+                | Self::Opaque { .. }
         )
     }
 
@@ -268,6 +300,58 @@ impl ColumnType {
             // `jsonb` (ambiguous Blob-vs-JSON) and `numeric` (missing
             // precision/scale) are intentionally unsupported — see the doc above.
             _ => None,
+        }
+    }
+
+    /// The centralized database-introspection inverse used by `autumn schema
+    /// pull`: resolve a Postgres `udt_name` plus its catalog `numeric_precision`
+    /// / `numeric_scale` (only meaningful for `numeric`/`decimal`) to a
+    /// [`ColumnType`] that is **always** produced — an unmappable type is
+    /// preserved as [`Opaque`](Self::Opaque) rather than dropped.
+    ///
+    /// Resolution order:
+    ///
+    /// 1. [`from_pg_udt`](Self::from_pg_udt) — the shared mapped surface
+    ///    (`text`/`int4`/`int8`/`bool`/`float4`/`float8`/`uuid`/`timestamp`/
+    ///    `timestamptz`/`bytea`).
+    /// 2. `numeric` / `decimal` **with** a precision (and scale) available →
+    ///    [`Decimal`](Self::Decimal). A bare `numeric` with no precision carries
+    ///    no `(p, s)` to reconstruct, so it falls through to `Opaque` rather than
+    ///    guessing.
+    /// 3. `jsonb` → [`Attachment`](Self::Attachment). Autumn only ever emits
+    ///    `jsonb` for an [`Attachment`](Self::Attachment) column, so a pulled
+    ///    `jsonb` column is round-tripped as an attachment. (This is the
+    ///    deliberate introspection counterpart to
+    ///    [`from_pg_udt`](Self::from_pg_udt) returning `None` for `jsonb` — that
+    ///    inverse is used by the model-scaffolding `db pull`, which must not
+    ///    guess `Blob` for arbitrary brownfield JSON; the declarative-schema
+    ///    `schema pull` instead prioritises a clean round-trip of Autumn-owned
+    ///    tables.)
+    /// 4. Anything else → [`Opaque`](Self::Opaque) carrying the raw `udt`, so the
+    ///    column is never silently lost.
+    #[must_use]
+    pub fn from_pg_introspection(
+        udt: &str,
+        numeric_precision: Option<i32>,
+        numeric_scale: Option<i32>,
+    ) -> Self {
+        if let Some(mapped) = Self::from_pg_udt(udt) {
+            return mapped;
+        }
+        if matches!(udt, "numeric" | "decimal")
+            && let Some(precision) = numeric_precision
+        {
+            let precision = u8::try_from(precision).unwrap_or(u8::MAX);
+            let scale = numeric_scale
+                .and_then(|s| u8::try_from(s).ok())
+                .unwrap_or(0);
+            return Self::Decimal { precision, scale };
+        }
+        if udt == "jsonb" {
+            return Self::Attachment;
+        }
+        Self::Opaque {
+            pg_type: udt.to_owned(),
         }
     }
 
@@ -552,7 +636,9 @@ mod tests {
     fn rust_type_mapping_is_exhaustive_and_exact() {
         for ct in all_column_types() {
             let expected = match &ct {
-                ColumnType::Text | ColumnType::Enum { .. } => "String",
+                // `Opaque` shares the `String` sentinel; `all_column_types()`
+                // never yields it, but the match must stay exhaustive.
+                ColumnType::Text | ColumnType::Enum { .. } | ColumnType::Opaque { .. } => "String",
                 ColumnType::Int32 => "i32",
                 ColumnType::Int64 => "i64",
                 ColumnType::Bool => "bool",
@@ -765,6 +851,91 @@ mod tests {
         assert_eq!(ColumnType::from_pg_udt("jsonb"), None);
         assert_eq!(ColumnType::from_pg_udt("numeric"), None);
         assert_eq!(ColumnType::from_pg_udt("wat"), None);
+    }
+
+    #[test]
+    fn from_pg_introspection_maps_the_shared_surface() {
+        // Every type the shared `from_pg_udt` maps resolves identically here.
+        for (udt, expected) in [
+            ("text", ColumnType::Text),
+            ("varchar", ColumnType::Text),
+            ("bpchar", ColumnType::Text),
+            ("int4", ColumnType::Int32),
+            ("int8", ColumnType::Int64),
+            ("bool", ColumnType::Bool),
+            ("float4", ColumnType::Float32),
+            ("float8", ColumnType::Float64),
+            ("uuid", ColumnType::Uuid),
+            ("timestamp", ColumnType::Timestamp),
+            ("timestamptz", ColumnType::TimestampTz),
+            ("bytea", ColumnType::Bytes),
+        ] {
+            assert_eq!(
+                ColumnType::from_pg_introspection(udt, None, None),
+                expected,
+                "from_pg_introspection for {udt}"
+            );
+        }
+    }
+
+    #[test]
+    fn from_pg_introspection_numeric_with_precision_is_decimal() {
+        assert_eq!(
+            ColumnType::from_pg_introspection("numeric", Some(12), Some(2)),
+            ColumnType::Decimal {
+                precision: 12,
+                scale: 2
+            }
+        );
+        // `decimal` alias, and a scale that defaults to 0 when NULL.
+        assert_eq!(
+            ColumnType::from_pg_introspection("decimal", Some(8), None),
+            ColumnType::Decimal {
+                precision: 8,
+                scale: 0
+            }
+        );
+        // A bare `numeric` with no precision cannot be reconstructed → Opaque.
+        assert_eq!(
+            ColumnType::from_pg_introspection("numeric", None, None),
+            ColumnType::Opaque {
+                pg_type: "numeric".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn from_pg_introspection_jsonb_is_attachment() {
+        assert_eq!(
+            ColumnType::from_pg_introspection("jsonb", None, None),
+            ColumnType::Attachment
+        );
+    }
+
+    #[test]
+    fn from_pg_introspection_unknown_types_are_preserved_opaque() {
+        for udt in ["inet", "citext", "macaddr", "tsvector", "point"] {
+            assert_eq!(
+                ColumnType::from_pg_introspection(udt, None, None),
+                ColumnType::Opaque {
+                    pg_type: udt.to_owned()
+                },
+                "unmapped {udt} must be preserved as Opaque"
+            );
+        }
+    }
+
+    #[test]
+    fn opaque_sql_type_round_trips_the_raw_name_verbatim() {
+        let ct = ColumnType::from_pg_introspection("inet", None, None);
+        // The raw Postgres type name is emitted verbatim on both backends, so a
+        // pulled snapshot never loses the type.
+        assert_eq!(ct.sql_type(Backend::Postgres), "inet");
+        assert_eq!(ct.sql_type(Backend::Sqlite), "inet");
+        // The codegen sentinels are safe (introspection-only, never panics).
+        assert_eq!(ct.rust_type(), "String");
+        assert_eq!(ct.diesel_type(Backend::Postgres), "Text");
+        assert!(!ct.sqlite_has_diesel_conversion());
     }
 
     #[test]

--- a/autumn-schema-core/src/lib.rs
+++ b/autumn-schema-core/src/lib.rs
@@ -531,6 +531,30 @@ pub struct Index {
     pub columns: Vec<String>,
     /// Whether the index enforces uniqueness.
     pub unique: bool,
+    /// The verbatim `CREATE [UNIQUE] INDEX …` statement for an index that
+    /// cannot be represented by plain columns alone — an expression index
+    /// (e.g. `lower(email)`) or a partial index (`WHERE …`). When `Some`, the
+    /// emitter renders this definition verbatim instead of building
+    /// `CREATE INDEX … (columns)`, and the diff compares indexes by this text
+    /// rather than by `columns`. `None` for ordinary column indexes, which keeps
+    /// their serialized JSON byte-identical to snapshots written before this
+    /// field existed (see the `#[serde(default, skip_serializing_if)]`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub definition: Option<String>,
+}
+
+impl Index {
+    /// Construct an ordinary column index (no raw `definition`), the common case
+    /// for both the model parser and simple introspected indexes.
+    #[must_use]
+    pub fn new(name: impl Into<String>, columns: Vec<String>, unique: bool) -> Self {
+        Self {
+            name: name.into(),
+            columns,
+            unique,
+            definition: None,
+        }
+    }
 }
 
 /// A `CHECK` constraint on a [`Table`] (e.g. the closed-set constraint an
@@ -1043,6 +1067,7 @@ mod tests {
             name: "posts_author_idx".to_owned(),
             columns: vec!["author_id".to_owned()],
             unique: false,
+            definition: None,
         });
         table.checks.push(CheckConstraint {
             name: Some("posts_status_check".to_owned()),

--- a/autumn-schema-core/src/lib.rs
+++ b/autumn-schema-core/src/lib.rs
@@ -430,8 +430,15 @@ impl ColumnType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum IdKind {
     /// `BIGSERIAL PRIMARY KEY` (PG) / `INTEGER PRIMARY KEY AUTOINCREMENT`
-    /// (`SQLite`) — a sequential auto-increment integer.
+    /// (`SQLite`) — a sequential auto-increment 64-bit integer.
     BigSerial,
+    /// `SERIAL PRIMARY KEY` (PG) / `INTEGER PRIMARY KEY AUTOINCREMENT`
+    /// (`SQLite`) — a sequential auto-increment 32-bit integer. The model DSL
+    /// never produces this (its `#[id]` is always `BigSerial` or `Uuid`); it
+    /// exists so a **brownfield** `SERIAL PRIMARY KEY` (int4) column introspected
+    /// by `schema pull` recreates as `SERIAL` (auto-increment) rather than a plain
+    /// `INTEGER PRIMARY KEY` that silently loses the sequence.
+    Serial,
     /// `UUID PRIMARY KEY DEFAULT gen_random_uuid()` (PG) / `TEXT PRIMARY KEY`
     /// (`SQLite`) — a non-enumerable UUID.
     Uuid,
@@ -443,6 +450,7 @@ impl IdKind {
     pub const fn rust_type(self) -> &'static str {
         match self {
             Self::BigSerial => "i64",
+            Self::Serial => "i32",
             Self::Uuid => "uuid::Uuid",
         }
     }
@@ -453,6 +461,7 @@ impl IdKind {
     pub const fn diesel_type(self, backend: Backend) -> &'static str {
         match (self, backend) {
             (Self::BigSerial, _) => "Int8",
+            (Self::Serial, _) => "Int4",
             (Self::Uuid, Backend::Postgres) => "Uuid",
             (Self::Uuid, Backend::Sqlite) => "Text",
         }
@@ -464,7 +473,10 @@ impl IdKind {
     pub const fn pk_sql(self, backend: Backend) -> &'static str {
         match (self, backend) {
             (Self::BigSerial, Backend::Postgres) => "BIGSERIAL PRIMARY KEY",
-            (Self::BigSerial, Backend::Sqlite) => "INTEGER PRIMARY KEY AUTOINCREMENT",
+            (Self::Serial, Backend::Postgres) => "SERIAL PRIMARY KEY",
+            (Self::BigSerial | Self::Serial, Backend::Sqlite) => {
+                "INTEGER PRIMARY KEY AUTOINCREMENT"
+            }
             (Self::Uuid, Backend::Postgres) => "UUID PRIMARY KEY DEFAULT gen_random_uuid()",
             (Self::Uuid, Backend::Sqlite) => "TEXT PRIMARY KEY",
         }
@@ -557,6 +569,37 @@ pub struct Index {
     /// field existed (see the `#[serde(default, skip_serializing_if)]`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub definition: Option<String>,
+    /// Whether the index carries a `WHERE` predicate (a **partial** index). A
+    /// partial unique index only enforces uniqueness for the rows matching its
+    /// predicate, so it must NOT be treated as satisfying a model `#[unique]`
+    /// (which demands table-wide uniqueness). Introspection sets this from
+    /// `pg_index.indpred IS NOT NULL`; the model parser never emits a partial
+    /// index. Defaults to `false` and is skipped when serializing so ordinary
+    /// indexes stay byte-identical to pre-existing snapshots.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub is_partial: bool,
+    /// The index's real **key** columns, in key order — the columns whose values
+    /// uniqueness is enforced over — EXCLUDING any non-key `INCLUDE` columns, and
+    /// **empty** when any key position is an expression (e.g. `lower(email)`). It
+    /// is distinct from [`columns`](Self::columns): for a `definition`-carrying
+    /// index `columns` is the full dependency set (key + `INCLUDE` + expression- +
+    /// predicate-referenced columns, used for cascade detection), whereas
+    /// `key_columns` is only what the index's uniqueness is keyed on. Populated by
+    /// introspection for `definition`-carrying indexes; for a plain simple index it
+    /// is left empty (its key columns are exactly `columns`, so recording them again
+    /// would be redundant JSON noise). An empty `key_columns` on an
+    /// expression/`definition` index deliberately signals "no plain key column set"
+    /// so such an index cannot satisfy a model `#[unique]`. Defaults to empty and is
+    /// skipped when serializing.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub key_columns: Vec<String>,
+}
+
+/// `serde` `skip_serializing_if` helper: whether a bool is `false` (so a
+/// default-`false` flag is omitted from the serialized form).
+#[allow(clippy::trivially_copy_pass_by_ref)]
+const fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 impl Index {
@@ -569,6 +612,8 @@ impl Index {
             columns,
             unique,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         }
     }
 }
@@ -1066,6 +1111,7 @@ mod tests {
     #[test]
     fn id_kind_rust_type() {
         assert_eq!(IdKind::BigSerial.rust_type(), "i64");
+        assert_eq!(IdKind::Serial.rust_type(), "i32");
         assert_eq!(IdKind::Uuid.rust_type(), "uuid::Uuid");
     }
 
@@ -1080,6 +1126,14 @@ mod tests {
             "INTEGER PRIMARY KEY AUTOINCREMENT"
         );
         assert_eq!(
+            IdKind::Serial.pk_sql(Backend::Postgres),
+            "SERIAL PRIMARY KEY"
+        );
+        assert_eq!(
+            IdKind::Serial.pk_sql(Backend::Sqlite),
+            "INTEGER PRIMARY KEY AUTOINCREMENT"
+        );
+        assert_eq!(
             IdKind::Uuid.pk_sql(Backend::Postgres),
             "UUID PRIMARY KEY DEFAULT gen_random_uuid()"
         );
@@ -1090,6 +1144,8 @@ mod tests {
     fn id_kind_diesel_type_both_backends() {
         assert_eq!(IdKind::BigSerial.diesel_type(Backend::Postgres), "Int8");
         assert_eq!(IdKind::BigSerial.diesel_type(Backend::Sqlite), "Int8");
+        assert_eq!(IdKind::Serial.diesel_type(Backend::Postgres), "Int4");
+        assert_eq!(IdKind::Serial.diesel_type(Backend::Sqlite), "Int4");
         assert_eq!(IdKind::Uuid.diesel_type(Backend::Postgres), "Uuid");
         assert_eq!(IdKind::Uuid.diesel_type(Backend::Sqlite), "Text");
     }
@@ -1119,6 +1175,8 @@ mod tests {
             columns: vec!["author_id".to_owned()],
             unique: false,
             definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
         });
         table.checks.push(CheckConstraint {
             name: Some("posts_status_check".to_owned()),

--- a/autumn-schema-core/src/lib.rs
+++ b/autumn-schema-core/src/lib.rs
@@ -314,10 +314,14 @@ impl ColumnType {
     /// 1. [`from_pg_udt`](Self::from_pg_udt) — the shared mapped surface
     ///    (`text`/`int4`/`int8`/`bool`/`float4`/`float8`/`uuid`/`timestamp`/
     ///    `timestamptz`/`bytea`).
-    /// 2. `numeric` / `decimal` **with** a precision (and scale) available →
-    ///    [`Decimal`](Self::Decimal). A bare `numeric` with no precision carries
-    ///    no `(p, s)` to reconstruct, so it falls through to `Opaque` rather than
-    ///    guessing.
+    /// 2. `numeric` / `decimal` **with** an in-`u8`-range precision (and scale)
+    ///    available → [`Decimal`](Self::Decimal). A bare `numeric` with no
+    ///    precision carries no `(p, s)` to reconstruct, so it falls through to
+    ///    `Opaque` rather than guessing; and an out-of-range precision/scale (a
+    ///    valid Postgres `NUMERIC(1000, 0)` or a negative scale that does not fit
+    ///    the `u8` fields) is likewise preserved as [`Opaque`](Self::Opaque) with a
+    ///    faithfully-reconstructed `numeric(...)` type string rather than silently
+    ///    clamped to `NUMERIC(255, 0)`.
     /// 3. `jsonb` → [`Attachment`](Self::Attachment). Autumn only ever emits
     ///    `jsonb` for an [`Attachment`](Self::Attachment) column, so a pulled
     ///    `jsonb` column is round-tripped as an attachment. (This is the
@@ -341,11 +345,23 @@ impl ColumnType {
         if matches!(udt, "numeric" | "decimal")
             && let Some(precision) = numeric_precision
         {
-            let precision = u8::try_from(precision).unwrap_or(u8::MAX);
-            let scale = numeric_scale
-                .and_then(|s| u8::try_from(s).ok())
-                .unwrap_or(0);
-            return Self::Decimal { precision, scale };
+            // Map to `Decimal` ONLY when both precision and scale fit the `u8`
+            // fields — never silently clamp an out-of-range `NUMERIC(1000, 0)` (or
+            // a negative/oversized scale) down to `NUMERIC(255, 0)`. An out-of-
+            // range value is instead preserved as `Opaque` with a faithfully-
+            // reconstructed type string, so the down migration re-adds the true
+            // type verbatim (`Opaque`'s `sql_type` emits `pg_type` unchanged).
+            let precision_u8 = u8::try_from(precision).ok().filter(|&p| p >= 1);
+            let scale_u8 = numeric_scale.map_or(Some(0), |scale| u8::try_from(scale).ok());
+            if let (Some(precision), Some(scale)) = (precision_u8, scale_u8) {
+                return Self::Decimal { precision, scale };
+            }
+            return Self::Opaque {
+                pg_type: match numeric_scale {
+                    None | Some(0) => format!("numeric({precision})"),
+                    Some(scale) => format!("numeric({precision},{scale})"),
+                },
+            };
         }
         if udt == "jsonb" {
             return Self::Attachment;
@@ -924,6 +940,41 @@ mod tests {
             ColumnType::from_pg_introspection("numeric", None, None),
             ColumnType::Opaque {
                 pg_type: "numeric".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn from_pg_introspection_out_of_range_numeric_is_opaque_not_clamped() {
+        // A valid Postgres `NUMERIC(1000, 0)` does not fit the `u8` Decimal fields;
+        // it must be preserved as `Opaque` carrying the true type string, NOT
+        // silently clamped to `NUMERIC(255, 0)`.
+        assert_eq!(
+            ColumnType::from_pg_introspection("numeric", Some(1000), Some(0)),
+            ColumnType::Opaque {
+                pg_type: "numeric(1000)".to_owned()
+            }
+        );
+        // An out-of-range precision with a non-zero scale keeps both.
+        assert_eq!(
+            ColumnType::from_pg_introspection("numeric", Some(1000), Some(500)),
+            ColumnType::Opaque {
+                pg_type: "numeric(1000,500)".to_owned()
+            }
+        );
+        // A negative scale does not fit `u8` → preserved verbatim, not clamped.
+        assert_eq!(
+            ColumnType::from_pg_introspection("numeric", Some(10), Some(-2)),
+            ColumnType::Opaque {
+                pg_type: "numeric(10,-2)".to_owned()
+            }
+        );
+        // In-range values are unaffected (round-trip parity).
+        assert_eq!(
+            ColumnType::from_pg_introspection("numeric", Some(12), Some(2)),
+            ColumnType::Decimal {
+                precision: 12,
+                scale: 2
             }
         );
     }

--- a/autumn-schema-core/src/lib.rs
+++ b/autumn-schema-core/src/lib.rs
@@ -311,6 +311,12 @@ impl ColumnType {
     ///
     /// Resolution order:
     ///
+    /// 0. A **length-limited character type** — `varchar` (`character varying`) or
+    ///    `bpchar` (`character`/`char`) **with** a `character_maximum_length` — is
+    ///    preserved as [`Opaque`](Self::Opaque) carrying `varchar(n)` / `char(n)`
+    ///    so the DB-enforced length limit survives recreation rather than being
+    ///    flattened to an unconstrained `TEXT`. An unbounded `varchar` (length
+    ///    `None`, or `text`, which never carries a length) falls through to `Text`.
     /// 1. [`from_pg_udt`](Self::from_pg_udt) — the shared mapped surface
     ///    (`text`/`int4`/`int8`/`bool`/`float4`/`float8`/`uuid`/`timestamp`/
     ///    `timestamptz`/`bytea`).
@@ -338,7 +344,32 @@ impl ColumnType {
         udt: &str,
         numeric_precision: Option<i32>,
         numeric_scale: Option<i32>,
+        character_maximum_length: Option<i32>,
     ) -> Self {
+        // Fail-closed floor for length-limited character types. `VARCHAR(32)` and
+        // `CHAR(2)` report `udt_name` `varchar` / `bpchar`, which `from_pg_udt`
+        // otherwise collapses to `Text`, silently dropping the DB-enforced length
+        // limit (recreation would emit an unconstrained `TEXT`). When a length
+        // modifier is present, preserve the column verbatim as `Opaque` carrying a
+        // valid Postgres type string (`Opaque`'s `sql_type` emits `pg_type`
+        // unchanged), checked BEFORE the `from_pg_udt` mapped return. An unbounded
+        // `varchar` (or `text`, which never carries a length) has `None` here and
+        // maps to `Text` exactly as before.
+        if let Some(length) = character_maximum_length {
+            match udt {
+                "varchar" => {
+                    return Self::Opaque {
+                        pg_type: format!("varchar({length})"),
+                    };
+                }
+                "bpchar" => {
+                    return Self::Opaque {
+                        pg_type: format!("char({length})"),
+                    };
+                }
+                _ => {}
+            }
+        }
         if let Some(mapped) = Self::from_pg_udt(udt) {
             return mapped;
         }
@@ -956,7 +987,7 @@ mod tests {
             ("bytea", ColumnType::Bytes),
         ] {
             assert_eq!(
-                ColumnType::from_pg_introspection(udt, None, None),
+                ColumnType::from_pg_introspection(udt, None, None, None),
                 expected,
                 "from_pg_introspection for {udt}"
             );
@@ -966,7 +997,7 @@ mod tests {
     #[test]
     fn from_pg_introspection_numeric_with_precision_is_decimal() {
         assert_eq!(
-            ColumnType::from_pg_introspection("numeric", Some(12), Some(2)),
+            ColumnType::from_pg_introspection("numeric", Some(12), Some(2), None),
             ColumnType::Decimal {
                 precision: 12,
                 scale: 2
@@ -974,7 +1005,7 @@ mod tests {
         );
         // `decimal` alias, and a scale that defaults to 0 when NULL.
         assert_eq!(
-            ColumnType::from_pg_introspection("decimal", Some(8), None),
+            ColumnType::from_pg_introspection("decimal", Some(8), None, None),
             ColumnType::Decimal {
                 precision: 8,
                 scale: 0
@@ -982,7 +1013,7 @@ mod tests {
         );
         // A bare `numeric` with no precision cannot be reconstructed → Opaque.
         assert_eq!(
-            ColumnType::from_pg_introspection("numeric", None, None),
+            ColumnType::from_pg_introspection("numeric", None, None, None),
             ColumnType::Opaque {
                 pg_type: "numeric".to_owned()
             }
@@ -995,28 +1026,28 @@ mod tests {
         // it must be preserved as `Opaque` carrying the true type string, NOT
         // silently clamped to `NUMERIC(255, 0)`.
         assert_eq!(
-            ColumnType::from_pg_introspection("numeric", Some(1000), Some(0)),
+            ColumnType::from_pg_introspection("numeric", Some(1000), Some(0), None),
             ColumnType::Opaque {
                 pg_type: "numeric(1000)".to_owned()
             }
         );
         // An out-of-range precision with a non-zero scale keeps both.
         assert_eq!(
-            ColumnType::from_pg_introspection("numeric", Some(1000), Some(500)),
+            ColumnType::from_pg_introspection("numeric", Some(1000), Some(500), None),
             ColumnType::Opaque {
                 pg_type: "numeric(1000,500)".to_owned()
             }
         );
         // A negative scale does not fit `u8` → preserved verbatim, not clamped.
         assert_eq!(
-            ColumnType::from_pg_introspection("numeric", Some(10), Some(-2)),
+            ColumnType::from_pg_introspection("numeric", Some(10), Some(-2), None),
             ColumnType::Opaque {
                 pg_type: "numeric(10,-2)".to_owned()
             }
         );
         // In-range values are unaffected (round-trip parity).
         assert_eq!(
-            ColumnType::from_pg_introspection("numeric", Some(12), Some(2)),
+            ColumnType::from_pg_introspection("numeric", Some(12), Some(2), None),
             ColumnType::Decimal {
                 precision: 12,
                 scale: 2
@@ -1025,9 +1056,39 @@ mod tests {
     }
 
     #[test]
+    fn from_pg_introspection_length_limited_char_types_are_opaque() {
+        // `VARCHAR(32)` / `CHAR(2)` report `udt_name` `varchar` / `bpchar`, which
+        // `from_pg_udt` would otherwise flatten to `Text`, dropping the length
+        // limit. With a length modifier present they are preserved verbatim as
+        // `Opaque` carrying valid Postgres DDL, checked before the mapped return.
+        assert_eq!(
+            ColumnType::from_pg_introspection("varchar", None, None, Some(32)),
+            ColumnType::Opaque {
+                pg_type: "varchar(32)".to_owned()
+            }
+        );
+        assert_eq!(
+            ColumnType::from_pg_introspection("bpchar", None, None, Some(2)),
+            ColumnType::Opaque {
+                pg_type: "char(2)".to_owned()
+            }
+        );
+        // An unbounded `varchar` (length `None`) and `text` (never length-carrying)
+        // behave exactly as before → `Text`.
+        assert_eq!(
+            ColumnType::from_pg_introspection("varchar", None, None, None),
+            ColumnType::Text
+        );
+        assert_eq!(
+            ColumnType::from_pg_introspection("text", None, None, None),
+            ColumnType::Text
+        );
+    }
+
+    #[test]
     fn from_pg_introspection_jsonb_is_attachment() {
         assert_eq!(
-            ColumnType::from_pg_introspection("jsonb", None, None),
+            ColumnType::from_pg_introspection("jsonb", None, None, None),
             ColumnType::Attachment
         );
     }
@@ -1036,7 +1097,7 @@ mod tests {
     fn from_pg_introspection_unknown_types_are_preserved_opaque() {
         for udt in ["inet", "citext", "macaddr", "tsvector", "point"] {
             assert_eq!(
-                ColumnType::from_pg_introspection(udt, None, None),
+                ColumnType::from_pg_introspection(udt, None, None, None),
                 ColumnType::Opaque {
                     pg_type: udt.to_owned()
                 },
@@ -1047,7 +1108,7 @@ mod tests {
 
     #[test]
     fn opaque_sql_type_round_trips_the_raw_name_verbatim() {
-        let ct = ColumnType::from_pg_introspection("inet", None, None);
+        let ct = ColumnType::from_pg_introspection("inet", None, None, None);
         // The raw Postgres type name is emitted verbatim on both backends, so a
         // pulled snapshot never loses the type.
         assert_eq!(ct.sql_type(Backend::Postgres), "inet");


### PR DESCRIPTION
Part of #1975.

## What changes

**Before:** the declarative-schema snapshot could only be produced from `#[model]` source (`schema snapshot`). There was no way to baseline the snapshot from an existing Postgres database, and `schema doctor` couldn't tell you whether the live database had drifted from the snapshot — its drift check only compared models vs snapshot.

**After:**
- `autumn schema pull` connects to the profile-resolved Postgres database, introspects `information_schema`/`pg_catalog` into the **same snapshot IR the parser produces** (tables, columns + types + nullability + defaults, primary keys, foreign keys, unique constraints, indexes), and writes it as the dialect-tagged snapshot baseline (atomic write, provider-lock). `--dry-run` prints the would-be snapshot diff and writes nothing. A SQLite URL is refused with a specific error naming SQLite introspection as a future slice — no partial support.
- `schema doctor` gains a `database-schema-drift` check: when a Postgres database is reachable it introspects and compares against the snapshot, reporting drift as actionable **WARN** items; when no database is reachable it stays a WARN, never a failure (doctor's offline behavior is unchanged).

## How

- **Type mapping** is centralized in `autumn-schema-core`: a new `ColumnType::from_pg_introspection(udt, numeric_precision, numeric_scale)` reuses the existing `from_pg_udt` inverse, maps `numeric` → `Decimal{precision,scale}` and `jsonb` → `Attachment`, and falls back to a new `ColumnType::Opaque { pg_type }` variant that preserves any unmappable Postgres type **verbatim** (never silently dropped; `sql_type` emits it back unchanged). Opaque is introspection/snapshot-only and never reaches Rust codegen.
- **Introspection** (`autumn-cli/src/schema/introspect.rs`) uses the same synchronous diesel `PgConnection` + `sql_query`/`QueryableByName` pattern as `db pull`, with credential-safe errors (the URL is never interpolated into any error or log — only host/port derived on the connection-error path). BigSerial `nextval(...)` PK defaults are normalized to `None` to match the model-parsed IR; `numeric_precision`/`numeric_scale` are cast to `::integer` in SQL for a stable wire type.
- **Drift detection** runs the diff in both directions, so a manually-dropped default / FK / CHECK in the live database is caught, not just column/index/table adds-drops and type changes.
- **Provider-lock / dry-run**: the SQLite refusal and a mismatched-backend provider-lock both fire before any write or connection; `--dry-run` is strictly read-only.

## Tests
- Postgres testcontainer e2e: round-trip (migrate from models → `schema pull` → `schema diff` is empty, including a UUID-PK `gen_random_uuid()` model), opaque `inet` preservation, doctor drift after an out-of-band `ALTER`, and `--dry-run` writes nothing — plus a non-Docker SQLite-refusal test and pure unit tests for the type mapping and bidirectional drift.
- Local verification green: `cargo fmt --check`, `clippy -D warnings` on both the default (pg) and `--no-default-features --features sqlite` lanes, `cargo test -p autumn-cli` / `-p autumn-schema-core`, and both build lanes.

## Deferred (recorded on #1975; documented in the `introspect.rs` module rustdoc, not silent)
SQLite introspection; long-identifier unique-index name truncation vs. the un-truncated parser name; composite multi-column indexes/FKs (first pair only); FK/constraint names (not represented by the IR); enum CHECK recovery (TEXT-with-CHECK pulls back as Text).

> The Docker-dependent integration tests were not executed in the authoring environment (no Docker available); they run in CI's Docker sweep.

---
_Generated by [Claude Code](https://claude.ai/code/session_0185Ta3yHyKBgzNBngksHCzs)_