### PR TITLE
Part of #1910: SQLite FTS5 full-text search (replace ASCII LIKE fallback)

### DIFF
--- a/autumn-cli/src/generate/migration.rs
+++ b/autumn-cli/src/generate/migration.rs
@@ -11,8 +11,8 @@ use super::dsl::parse_fields;
 use super::emit::Plan;
 use super::naming::pascal_to_snake;
 use super::schema_edit::{
-    MigrationShape, add_columns_down_sql_for, add_columns_up_sql_for, add_search_down_sql,
-    add_search_up_sql, detect_migration_shape, encrypt_columns_down_sql, encrypt_columns_up_sql,
+    MigrationShape, add_columns_down_sql_for, add_columns_up_sql_for, add_search_down_sql_for,
+    add_search_up_sql_for, detect_migration_shape, encrypt_columns_down_sql, encrypt_columns_up_sql,
     parse_model_search_config_for_table, remove_columns_down_sql_for, remove_columns_up_sql_for,
     singularize,
 };
@@ -147,12 +147,11 @@ pub fn plan_migration_with_options(
             encrypt_columns_down_sql(table, columns),
         ),
         MigrationShape::AddSearch { ref table } => {
-            // Postgres FTS (`tsvector` + GIN) has no SQLite equivalent in this
-            // slice; reject at generate time citing #1910 (issue #1614 AC #4)
-            // rather than emit Postgres-only DDL that breaks on SQLite.
-            if backend == autumn_web::config::DatabaseBackend::Sqlite {
-                return Err(super::sqlite_search_unsupported_error());
-            }
+            // Full-text search is backend-aware (issue #1910): Postgres emits a
+            // `tsvector` generated column + GIN index; SQLite emits an
+            // external-content FTS5 virtual table + maintenance triggers (see
+            // `add_search_up_sql_for`). Neither leaks DDL that breaks the other
+            // backend, so `--search` now works on both.
             let singular = singularize(table);
 
             // Collect all potential model file candidates in order of preference
@@ -213,8 +212,8 @@ pub fn plan_migration_with_options(
             };
 
             (
-                add_search_up_sql(table, &language, &fts_fields),
-                add_search_down_sql(table),
+                add_search_up_sql_for(backend, table, &language, &fts_fields),
+                add_search_down_sql_for(backend, table),
             )
         }
         _ => (String::new(), String::new()),
@@ -627,24 +626,66 @@ pub struct Post {
         tmp
     }
 
-    /// `AddSearchTo…` on a `SQLite` app is rejected at generate time citing #1910
-    /// (Postgres `tsvector` FTS has no `SQLite` equivalent in this slice, AC #4).
+    /// `AddSearchTo…` on a `SQLite` app now emits an FTS5 external-content virtual
+    /// table + maintenance triggers (issue #1910) instead of being rejected, and
+    /// no Postgres-only `tsvector`/GIN DDL leaks into the SQLite migration.
     #[test]
-    fn add_search_migration_on_sqlite_is_rejected_citing_1910() {
+    fn add_search_migration_on_sqlite_emits_fts5() {
         with_no_db_env(|| {
             let tmp = sqlite_project();
-            let err =
-                plan_migration(tmp.path(), "AddSearchToPosts", &[], "20260427000000").unwrap_err();
-            let msg = err.to_string();
+            // The AddSearch shape reads the model's #[searchable] config from a
+            // model file to know which columns to index.
+            fs::create_dir_all(tmp.path().join("src/models")).unwrap();
+            fs::write(
+                tmp.path().join("src/models/post.rs"),
+                "#[autumn_web::model(table = \"posts\")]\n\
+                 #[searchable(language = \"english\")]\n\
+                 pub struct Post {\n\
+                 \x20   #[id]\n\
+                 \x20   pub id: i64,\n\
+                 \x20   #[searchable(weight = \"A\")]\n\
+                 \x20   pub title: String,\n\
+                 \x20   #[searchable(weight = \"B\")]\n\
+                 \x20   pub body: String,\n\
+                 }\n",
+            )
+            .unwrap();
+
+            let plan =
+                plan_migration(tmp.path(), "AddSearchToPosts", &[], "20260427000000").unwrap();
+            plan.execute(Flags::default()).unwrap();
+
+            let dir = tmp
+                .path()
+                .join("migrations/20260427000000_add_search_to_posts");
+            let up = fs::read_to_string(dir.join("up.sql")).unwrap();
+            let down = fs::read_to_string(dir.join("down.sql")).unwrap();
+
             assert!(
-                matches!(err, GenerateError::Config(_)),
-                "expected Config error, got: {err:?}"
+                up.contains(
+                    "CREATE VIRTUAL TABLE \"posts__fts\" USING fts5(\"title\", \"body\", \
+                     content='posts', content_rowid='id', tokenize='unicode61');"
+                ),
+                "up.sql must create the FTS5 vtable: {up}"
             );
-            assert!(msg.contains("1910"), "must cite issue #1910: {msg}");
             assert!(
-                msg.contains("SQLite") && msg.contains("full-text search"),
-                "message must be actionable: {msg}"
+                up.contains("INSERT INTO \"posts__fts\"(\"posts__fts\") VALUES('rebuild');"),
+                "up.sql must backfill via 'rebuild': {up}"
             );
+            for trig in ["posts__fts_ai", "posts__fts_ad", "posts__fts_au"] {
+                assert!(up.contains(trig), "up.sql must create trigger {trig}: {up}");
+                assert!(
+                    down.contains(&format!("DROP TRIGGER IF EXISTS \"{trig}\";")),
+                    "down.sql must drop trigger {trig}: {down}"
+                );
+            }
+            assert!(
+                down.contains("DROP TABLE IF EXISTS \"posts__fts\";"),
+                "down.sql must drop the FTS table: {down}"
+            );
+            for leak in ["tsvector", "to_tsvector", "USING gin", "search_vector"] {
+                assert!(!up.contains(leak), "SQLite up.sql leaked `{leak}`: {up}");
+            }
         });
     }
 

--- a/autumn-cli/src/generate/migration.rs
+++ b/autumn-cli/src/generate/migration.rs
@@ -212,7 +212,7 @@ pub fn plan_migration_with_options(
             };
 
             (
-                add_search_up_sql_for(backend, table, &language, &fts_fields),
+                add_search_up_sql_for(backend, table, &language, &fts_fields)?,
                 add_search_down_sql_for(backend, table),
             )
         }

--- a/autumn-cli/src/generate/migration.rs
+++ b/autumn-cli/src/generate/migration.rs
@@ -12,9 +12,9 @@ use super::emit::Plan;
 use super::naming::pascal_to_snake;
 use super::schema_edit::{
     MigrationShape, add_columns_down_sql_for, add_columns_up_sql_for, add_search_down_sql_for,
-    add_search_up_sql_for, detect_migration_shape, encrypt_columns_down_sql, encrypt_columns_up_sql,
-    parse_model_search_config_for_table, remove_columns_down_sql_for, remove_columns_up_sql_for,
-    singularize,
+    add_search_up_sql_for, detect_migration_shape, encrypt_columns_down_sql,
+    encrypt_columns_up_sql, parse_model_search_config_for_table, remove_columns_down_sql_for,
+    remove_columns_up_sql_for, singularize,
 };
 use super::{GenerateError, detect_backend, ensure_project_root};
 
@@ -628,7 +628,7 @@ pub struct Post {
 
     /// `AddSearchTo…` on a `SQLite` app now emits an FTS5 external-content virtual
     /// table + maintenance triggers (issue #1910) instead of being rejected, and
-    /// no Postgres-only `tsvector`/GIN DDL leaks into the SQLite migration.
+    /// no Postgres-only `tsvector`/GIN DDL leaks into the `SQLite` migration.
     #[test]
     fn add_search_migration_on_sqlite_emits_fts5() {
         with_no_db_env(|| {

--- a/autumn-cli/src/generate/mod.rs
+++ b/autumn-cli/src/generate/mod.rs
@@ -130,7 +130,7 @@ pub fn sqlite_uuid_pk_unsupported_error() -> GenerateError {
 /// rejects *any* `database.shards` against a `SQLite` primary, so no valid
 /// `SQLite` config can ever use a generated sharded resource. Unlike UUID ids
 /// (#1905) or the unsupported field kinds (#1924) — and unlike FTS, now
-/// supported on SQLite via FTS5 (#1910) — this is **not** a deferred slice:
+/// supported on `SQLite` via FTS5 (#1910) — this is **not** a deferred slice:
 /// `SQLite` is single-host / single-writer, so
 /// horizontal sharding is Postgres-only and permanently out of scope for
 /// `SQLite` (see `docs/guide/sqlite-in-production.md`). Rather than emit a

--- a/autumn-cli/src/generate/mod.rs
+++ b/autumn-cli/src/generate/mod.rs
@@ -94,25 +94,6 @@ fn format_collisions(paths: &[PathBuf]) -> String {
     out
 }
 
-/// The generate-time rejection for Postgres full-text search (`--search` /
-/// `#[searchable]`) on a `SQLite`-backed app (`SQLite` foundation, issue #1614).
-///
-/// Postgres FTS is emitted as a `tsvector` generated column plus a GIN index,
-/// neither of which `SQLite` has. `SQLite`'s own full-text search (FTS5) is a
-/// later slice tracked in issue #1910, so rather than emit Postgres-only DDL
-/// that would break on `SQLite`, generation fails here with an actionable
-/// message (AC #4).
-#[must_use]
-pub fn sqlite_search_unsupported_error() -> GenerateError {
-    GenerateError::Config(
-        "full-text search (--search / #[searchable]) is not yet supported on SQLite apps; \
-         Postgres FTS uses a tsvector generated column and a GIN index, which SQLite lacks. \
-         SQLite FTS5 support is tracked in https://github.com/madmax983/autumn/issues/1910 — \
-         re-run without the search flag, or target a Postgres database."
-            .to_owned(),
-    )
-}
-
 /// The generate-time rejection for a UUID primary key (`--id uuid`) on a
 /// `SQLite`-backed app (`SQLite` foundation, issue #1614 AC #4).
 ///
@@ -147,9 +128,10 @@ pub fn sqlite_uuid_pk_unsupported_error() -> GenerateError {
 /// `ShardedDb` routes and shard-aware migrations, all of which require a
 /// `[[database.shards]]` topology. But `DatabaseConfig::validate_backend_consistency`
 /// rejects *any* `database.shards` against a `SQLite` primary, so no valid
-/// `SQLite` config can ever use a generated sharded resource. Unlike FTS
-/// (#1910), UUID ids (#1905), or the unsupported field kinds (#1924), this is
-/// **not** a deferred slice: `SQLite` is single-host / single-writer, so
+/// `SQLite` config can ever use a generated sharded resource. Unlike UUID ids
+/// (#1905) or the unsupported field kinds (#1924) — and unlike FTS, now
+/// supported on SQLite via FTS5 (#1910) — this is **not** a deferred slice:
+/// `SQLite` is single-host / single-writer, so
 /// horizontal sharding is Postgres-only and permanently out of scope for
 /// `SQLite` (see `docs/guide/sqlite-in-production.md`). Rather than emit a
 /// resource that no `SQLite` app can boot, generation fails here with an

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -8,7 +8,8 @@ use super::dsl::{Field, FieldConstraints, FieldKind, IdType, parse_fields};
 use super::emit::Plan;
 use super::naming::{pascal, pluralize, snake};
 use super::schema_edit::{
-    add_mod_declaration, add_search_down_sql, add_search_up_sql, append_schema_table_with_id_for,
+    add_mod_declaration, add_search_down_sql_for, add_search_up_sql_for,
+    append_schema_table_with_id_for,
     create_table_sql_with_metadata_and_id_for, drop_table_sql, link_models_into_seed_bin,
 };
 use super::{GenerateError, detect_backend, ensure_project_root, read_or_empty};
@@ -146,13 +147,11 @@ pub fn plan_model_with_options(
     let metadata = parse_model_metadata(&fields, options)?;
 
     // Determine the target app's database backend so the emitted DDL / diesel
-    // schema is backend-aware (SQLite foundation, issue #1614). Postgres FTS
-    // (`--searchable`) has no SQLite equivalent in this slice, so reject it at
-    // generate time rather than emit `tsvector` DDL that breaks on SQLite.
+    // schema is backend-aware (SQLite foundation, issue #1614). Full-text search
+    // (`--searchable`) is now supported on both backends — Postgres emits a
+    // `tsvector` column + GIN index, SQLite emits an FTS5 virtual table +
+    // triggers (issue #1910) — so it is no longer rejected here.
     let backend = detect_backend(project_root);
-    if backend == autumn_web::config::DatabaseBackend::Sqlite && !metadata.searchable().is_empty() {
-        return Err(super::sqlite_search_unsupported_error());
-    }
     // A UUID primary key needs app-side id generation on SQLite (no
     // `gen_random_uuid()`), which is part of the deferred runtime slice #1905;
     // reject `--id uuid` on a SQLite app at generate time rather than emit a
@@ -249,18 +248,20 @@ pub fn plan_model_with_options(
     } else {
         table_sql
     };
-    // Full-text search (issue #1319): the `search_vector` generated column + GIN
-    // index are what `#[repository(..., searchable)]`'s `search_page` queries.
-    // Emitted in the same create-table migration so `autumn migrate` yields a
-    // working search with zero manual SQL. The column is a stored generated
-    // column, so it is intentionally NOT added to the model struct or schema.rs
-    // (the macro loads matched rows by id via raw SQL).
+    // Full-text search (issues #1319, #1910): backend-aware FTS scaffold emitted
+    // in the same create-table migration so `autumn migrate` yields a working
+    // search with zero manual SQL. On Postgres this is the `search_vector`
+    // generated column + GIN index; on SQLite it is an external-content FTS5
+    // virtual table + maintenance triggers (`add_search_up_sql_for`). Neither is
+    // added to the model struct or schema.rs (the macro loads matched rows by id
+    // via raw SQL), so the FTS objects stay outside the model surface on both
+    // backends.
     let (up_sql, down_sql) = if metadata.searchable().is_empty() {
         (up_sql, drop_table_sql(&table))
     } else {
         let language = metadata.search_language().unwrap_or("english");
-        let search_up = add_search_up_sql(&table, language, metadata.searchable());
-        let search_down = add_search_down_sql(&table);
+        let search_up = add_search_up_sql_for(backend, &table, language, metadata.searchable());
+        let search_down = add_search_down_sql_for(backend, &table);
         (
             format!("{up_sql}\n{search_up}"),
             format!("{search_down}{}", drop_table_sql(&table)),
@@ -3131,13 +3132,14 @@ mod tests {
         });
     }
 
-    /// Postgres FTS on a `SQLite` app is rejected at generate time citing #1910
-    /// rather than emitting `tsvector` DDL that `SQLite` cannot run (AC #4).
+    /// FTS on a `SQLite` app now emits an FTS5 external-content virtual table +
+    /// maintenance triggers (issue #1910) instead of being rejected — and no
+    /// Postgres-only `tsvector`/GIN DDL leaks into the SQLite migration.
     #[test]
-    fn searchable_on_sqlite_app_is_rejected_citing_1910() {
+    fn searchable_on_sqlite_app_emits_fts5() {
         with_no_db_env(|| {
             let tmp = project_with_db_url("sqlite://app.db");
-            let err = plan_model_with_options(
+            let plan = plan_model_with_options(
                 tmp.path(),
                 "Post",
                 &["title:String".into(), "body:Text".into()],
@@ -3147,17 +3149,51 @@ mod tests {
                     ..Default::default()
                 },
             )
-            .unwrap_err();
-            let msg = err.to_string();
+            .expect("searchable SQLite model plans without rejection");
+            plan.execute(Flags::default()).unwrap();
+
+            let up = fs::read_to_string(
+                tmp.path()
+                    .join("migrations/20260427000000_create_posts/up.sql"),
+            )
+            .unwrap();
+            let down = fs::read_to_string(
+                tmp.path()
+                    .join("migrations/20260427000000_create_posts/down.sql"),
+            )
+            .unwrap();
+
+            // External-content FTS5 virtual table over the searchable columns.
             assert!(
-                matches!(err, GenerateError::Config(_)),
-                "expected Config error, got: {err:?}"
+                up.contains(
+                    "CREATE VIRTUAL TABLE \"posts__fts\" USING fts5(\"title\", \"body\", \
+                     content='posts', content_rowid='id', tokenize='unicode61');"
+                ),
+                "up.sql must create the FTS5 vtable: {up}"
             );
-            assert!(msg.contains("1910"), "must cite issue #1910: {msg}");
+            // Maintenance triggers keep the index in sync.
+            for trig in ["posts__fts_ai", "posts__fts_ad", "posts__fts_au"] {
+                assert!(up.contains(trig), "up.sql must create trigger {trig}: {up}");
+            }
             assert!(
-                msg.contains("SQLite") && msg.contains("full-text search"),
-                "message must be actionable: {msg}"
+                up.contains("INSERT INTO \"posts__fts\"(\"posts__fts\") VALUES('rebuild');"),
+                "up.sql must backfill via 'rebuild': {up}"
             );
+            // down.sql drops the triggers and the FTS table.
+            assert!(
+                down.contains("DROP TABLE IF EXISTS \"posts__fts\";"),
+                "down.sql must drop the FTS table: {down}"
+            );
+            for trig in ["posts__fts_ai", "posts__fts_ad", "posts__fts_au"] {
+                assert!(
+                    down.contains(&format!("DROP TRIGGER IF EXISTS \"{trig}\";")),
+                    "down.sql must drop trigger {trig}: {down}"
+                );
+            }
+            // No Postgres-only FTS DDL may leak into the SQLite migration.
+            for leak in ["tsvector", "to_tsvector", "USING gin", "search_vector"] {
+                assert!(!up.contains(leak), "SQLite up.sql leaked `{leak}`: {up}");
+            }
         });
     }
 

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -9,8 +9,8 @@ use super::emit::Plan;
 use super::naming::{pascal, pluralize, snake};
 use super::schema_edit::{
     add_mod_declaration, add_search_down_sql_for, add_search_up_sql_for,
-    append_schema_table_with_id_for,
-    create_table_sql_with_metadata_and_id_for, drop_table_sql, link_models_into_seed_bin,
+    append_schema_table_with_id_for, create_table_sql_with_metadata_and_id_for, drop_table_sql,
+    link_models_into_seed_bin,
 };
 use super::{GenerateError, detect_backend, ensure_project_root, read_or_empty};
 
@@ -3134,7 +3134,7 @@ mod tests {
 
     /// FTS on a `SQLite` app now emits an FTS5 external-content virtual table +
     /// maintenance triggers (issue #1910) instead of being rejected — and no
-    /// Postgres-only `tsvector`/GIN DDL leaks into the SQLite migration.
+    /// Postgres-only `tsvector`/GIN DDL leaks into the `SQLite` migration.
     #[test]
     fn searchable_on_sqlite_app_emits_fts5() {
         with_no_db_env(|| {

--- a/autumn-cli/src/generate/model.rs
+++ b/autumn-cli/src/generate/model.rs
@@ -260,7 +260,7 @@ pub fn plan_model_with_options(
         (up_sql, drop_table_sql(&table))
     } else {
         let language = metadata.search_language().unwrap_or("english");
-        let search_up = add_search_up_sql_for(backend, &table, language, metadata.searchable());
+        let search_up = add_search_up_sql_for(backend, &table, language, metadata.searchable())?;
         let search_down = add_search_down_sql_for(backend, &table);
         (
             format!("{up_sql}\n{search_up}"),

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -3760,15 +3760,26 @@ fn is_section_boundary(trimmed: &str, section: &str) -> bool {
 ///   `language` is unused on that arm (it selects the tokenizer, not a Postgres
 ///   text-search dictionary). The generated repository (`#[repository(...,
 ///   searchable)]`) queries this table with `MATCH` + `bm25()` ranking.
-#[must_use]
+///
+/// # Errors
+/// On the `SQLite` arm, returns [`GenerateError::Config`] when a `#[searchable]`
+/// field uses an FTS5-reserved column name (`rowid`/`rank`, or one colliding
+/// with the generated `<table>__fts` table) — `SQLite` would otherwise reject
+/// the generated `CREATE VIRTUAL TABLE … fts5(…)` only at `autumn migrate` time.
+/// The Postgres arm never errors.
 pub fn add_search_up_sql_for(
     backend: DatabaseBackend,
     table: &str,
     language: &str,
     fields: &[(String, char)],
-) -> String {
+) -> Result<String, GenerateError> {
     match backend {
-        DatabaseBackend::Sqlite => sqlite_add_search_up_sql(table, fields),
+        DatabaseBackend::Sqlite => {
+            // FTS5 rejects reserved indexed-column names at migrate time; catch
+            // them at generate time instead (issue #1910, epic #1614 AC #4).
+            reject_reserved_sqlite_search_columns(table, fields)?;
+            Ok(sqlite_add_search_up_sql(table, fields))
+        }
         DatabaseBackend::Postgres => {
             let mut out = String::new();
             let _ = writeln!(
@@ -3806,9 +3817,64 @@ pub fn add_search_up_sql_for(
                 out,
                 "CREATE INDEX idx_{table}_search_vector ON {table} USING gin(search_vector);"
             );
-            out
+            Ok(out)
         }
     }
+}
+
+/// True iff `column` is a name FTS5 forbids for an indexed column of the
+/// generated `<table>__fts` external-content table (issue #1910).
+///
+/// FTS5 reserves the column names `rowid` and `rank` (the auto rowid alias and
+/// the ranking pseudo-column) and forbids a column named the same as the FTS
+/// table itself (that identifier is the table's special "command" column). All
+/// three are matched **case-insensitively** — `SQLite` rejects `RANK`/`RowId`
+/// exactly as `rank`/`rowid`. Quoting the identifier does **not** help: these
+/// are special FTS5 names, not merely SQL keywords, so `SQLite` returns a
+/// `reserved fts5 column name` error (or a `vtable constructor failed` error
+/// for the self-collision) at `CREATE VIRTUAL TABLE` time.
+#[must_use]
+fn is_fts5_reserved_search_column(column: &str, fts_table: &str) -> bool {
+    column.eq_ignore_ascii_case("rowid")
+        || column.eq_ignore_ascii_case("rank")
+        || column.eq_ignore_ascii_case(fts_table)
+}
+
+/// Reject, at generate time, a `#[searchable]` field whose column name FTS5
+/// reserves as an indexed column on the `SQLite` backend (issue #1910; epic
+/// #1614 AC #4 "map or reject-at-generate").
+///
+/// Now that the `SQLite` search arm emits real `CREATE VIRTUAL TABLE
+/// "<table>__fts" USING fts5(<cols>, …)` DDL, a model that marks a text field
+/// named `rank`/`rowid` (or one colliding with the `<table>__fts` name) as
+/// `#[searchable]` would generate DDL that only fails at `autumn migrate` time
+/// with a `reserved fts5 column name` error. Catch it here with an actionable
+/// message naming the offending field instead. The Postgres path is unaffected
+/// (its `search_vector` generated column indexes the same fields with no such
+/// reservation), so this guard is `SQLite`-only by construction — it is called
+/// solely from the `SQLite` arm of [`add_search_up_sql_for`].
+///
+/// # Errors
+/// Returns [`GenerateError::Config`] on the first offending field.
+fn reject_reserved_sqlite_search_columns(
+    table: &str,
+    fields: &[(String, char)],
+) -> Result<(), GenerateError> {
+    let fts_table = format!("{table}__fts");
+    for (field, _) in fields {
+        if is_fts5_reserved_search_column(field, &fts_table) {
+            return Err(GenerateError::Config(format!(
+                "the #[searchable] field '{field}' on table '{table}' uses an FTS5-reserved \
+                 column name: SQLite would reject the generated `CREATE VIRTUAL TABLE \
+                 \"{fts_table}\" USING fts5(...)` search index because FTS5 reserves the column \
+                 names `rowid` and `rank` and forbids a column named the same as the FTS table \
+                 (`{fts_table}`) — matched case-insensitively, and quoting the identifier does \
+                 not help. Rename the field, or drop #[searchable] from it, to generate SQLite \
+                 FTS5 search. (Postgres full-text search is unaffected.)"
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Backend-aware `down.sql` companion to [`add_search_up_sql_for`].
@@ -7360,7 +7426,8 @@ pub struct Post {
             "posts",
             "english",
             &[("title".to_string(), 'A'), ("body".to_string(), 'B')],
-        );
+        )
+        .expect("postgres search DDL never errors");
         assert!(sql.contains("coalesce(\"title\"::text, '')"));
         assert!(sql.contains("coalesce(\"body\"::text, '')"));
     }
@@ -7375,7 +7442,8 @@ pub struct Post {
             "posts",
             "english",
             &[("title".to_string(), 'A'), ("body".to_string(), 'B')],
-        );
+        )
+        .expect("valid searchable columns generate FTS5 DDL");
         assert!(
             up.contains(
                 "CREATE VIRTUAL TABLE \"posts__fts\" USING fts5(\"title\", \"body\", \
@@ -7425,6 +7493,57 @@ pub struct Post {
     }
 
     #[test]
+    fn test_add_search_up_sql_sqlite_rejects_fts5_reserved_column_names() {
+        // #1910 / #1614 AC #4: FTS5 reserves `rowid`/`rank` (and forbids a column
+        // named the same as the `<table>__fts` table). A #[searchable] field with
+        // such a name must be rejected at GENERATE time with an actionable message
+        // — not silently emitted to fail only at `autumn migrate` time. Reserved
+        // names are matched case-insensitively, and quoting does not save them.
+        for reserved in ["rowid", "rank", "RANK", "RowId", "posts__fts"] {
+            let err = add_search_up_sql_for(
+                DatabaseBackend::Sqlite,
+                "posts",
+                "english",
+                &[("title".to_string(), 'A'), (reserved.to_string(), 'B')],
+            )
+            .expect_err(&format!("reserved column `{reserved}` must be rejected"));
+            let msg = err.to_string();
+            assert!(
+                msg.contains(reserved) && msg.contains("FTS5-reserved"),
+                "message must name the offending field `{reserved}` and the reason: {msg}"
+            );
+            assert!(
+                msg.contains("Rename the field") && msg.contains("#[searchable]"),
+                "message must be actionable (rename / drop #[searchable]): {msg}"
+            );
+        }
+
+        // A normal searchable field still generates the FTS5 DDL (guard is not a
+        // blanket rejection), and Postgres never sees this reservation.
+        let up = add_search_up_sql_for(
+            DatabaseBackend::Sqlite,
+            "posts",
+            "english",
+            &[("rank_note".to_string(), 'A'), ("body".to_string(), 'B')],
+        )
+        .expect("non-reserved columns (even `rank_note`) still generate FTS5 DDL");
+        assert!(
+            up.contains("CREATE VIRTUAL TABLE \"posts__fts\" USING fts5(\"rank_note\", \"body\", "),
+            "up: {up}"
+        );
+        // The Postgres arm indexes a field literally named `rank` with no error —
+        // the reservation is FTS5-only and must not weaken the pg path.
+        let pg = add_search_up_sql_for(
+            DatabaseBackend::Postgres,
+            "posts",
+            "english",
+            &[("rank".to_string(), 'A')],
+        )
+        .expect("postgres search DDL never errors on a `rank` column");
+        assert!(pg.contains("coalesce(\"rank\"::text, '')"), "pg: {pg}");
+    }
+
+    #[test]
     fn test_singularize_ves_plurals() {
         assert_eq!(singularize("wolves"), "wolf");
         assert_eq!(singularize("leaves"), "leaf");
@@ -7442,7 +7561,8 @@ pub struct Post {
             "posts",
             "english'; DROP TABLE posts;--",
             &[("title".to_string(), 'A')],
-        );
+        )
+        .expect("postgres search DDL never errors");
         assert!(sql.contains("to_tsvector('englishDROPTABLEposts'::regconfig"));
 
         let sql_qualified = add_search_up_sql_for(
@@ -7450,7 +7570,8 @@ pub struct Post {
             "posts",
             "pg_catalog.english",
             &[("title".to_string(), 'A')],
-        );
+        )
+        .expect("postgres search DDL never errors");
         assert!(sql_qualified.contains("to_tsvector('pg_catalog.english'::regconfig"));
     }
 

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -3748,57 +3748,148 @@ fn is_section_boundary(trimmed: &str, section: &str) -> bool {
     trimmed.starts_with('[') && !trimmed.starts_with(&format!("[{section}."))
 }
 
-/// SQL for adding a stored generated `search_vector` column and GIN index.
+/// Backend-aware `up.sql` for the full-text-search scaffold (issue #1910).
+///
+/// * **Postgres**: a stored generated `search_vector` `tsvector` column
+///   (`setweight`/`to_tsvector` per `SEARCH_FIELDS` weight) plus a GIN index.
+/// * **`SQLite`**: an **external-content FTS5 virtual table** `"<table>__fts"`
+///   over the same `SEARCH_FIELDS` columns (tokenized `unicode61`, so case
+///   folding covers the full Unicode range), kept in sync with `AFTER
+///   INSERT`/`DELETE`/`UPDATE` triggers on the base table, and backfilled with
+///   the FTS5 `'rebuild'` command. `SQLite` FTS5 has no per-language stemmer, so
+///   `language` is unused on that arm (it selects the tokenizer, not a Postgres
+///   text-search dictionary). The generated repository (`#[repository(...,
+///   searchable)]`) queries this table with `MATCH` + `bm25()` ranking.
 #[must_use]
-pub fn add_search_up_sql(table: &str, language: &str, fields: &[(String, char)]) -> String {
+pub fn add_search_up_sql_for(
+    backend: DatabaseBackend,
+    table: &str,
+    language: &str,
+    fields: &[(String, char)],
+) -> String {
+    match backend {
+        DatabaseBackend::Sqlite => sqlite_add_search_up_sql(table, fields),
+        DatabaseBackend::Postgres => {
+            let mut out = String::new();
+            let _ = writeln!(
+                out,
+                "-- autumn-safety: potentially-blocking \n\
+                 -- adding stored generated column will backfill existing rows"
+            );
+
+            let safe_lang: String = language
+                .chars()
+                .filter(|c| c.is_alphanumeric() || *c == '_' || *c == '.')
+                .collect();
+            let safe_lang = if safe_lang.is_empty() {
+                "simple".to_string()
+            } else {
+                safe_lang
+            };
+
+            let mut expr = String::new();
+            for (i, (field, weight)) in fields.iter().enumerate() {
+                if i > 0 {
+                    expr.push_str(" || ");
+                }
+                let _ = write!(
+                    expr,
+                    "setweight(to_tsvector('{safe_lang}'::regconfig, coalesce(\"{field}\"::text, '')), '{weight}')"
+                );
+            }
+
+            let _ = writeln!(
+                out,
+                "ALTER TABLE {table} ADD COLUMN search_vector tsvector GENERATED ALWAYS AS ({expr}) STORED;"
+            );
+            let _ = writeln!(
+                out,
+                "CREATE INDEX idx_{table}_search_vector ON {table} USING gin(search_vector);"
+            );
+            out
+        }
+    }
+}
+
+/// Backend-aware `down.sql` companion to [`add_search_up_sql_for`].
+#[must_use]
+pub fn add_search_down_sql_for(backend: DatabaseBackend, table: &str) -> String {
+    match backend {
+        DatabaseBackend::Sqlite => sqlite_add_search_down_sql(table),
+        DatabaseBackend::Postgres => {
+            let mut out = String::new();
+            let _ = writeln!(out, "DROP INDEX IF EXISTS idx_{table}_search_vector;");
+            let _ = writeln!(
+                out,
+                "ALTER TABLE {table} DROP COLUMN IF EXISTS search_vector;"
+            );
+            out
+        }
+    }
+}
+
+/// `SQLite` FTS5 `up.sql`: external-content virtual table + maintenance triggers
+/// + backfill rebuild (issue #1910). The FTS table is `"<table>__fts"`, indexes
+/// the `SEARCH_FIELDS` columns in priority order, and mirrors the base table via
+/// `content='<table>', content_rowid='id'` so the base table stays the single
+/// source of truth (the generated `bm25()`-ranked `MATCH` query joins the two).
+fn sqlite_add_search_up_sql(table: &str, fields: &[(String, char)]) -> String {
+    let fts = format!("{table}__fts");
+    // Quoted, comma-separated indexed column list, shared across the DDL.
+    let cols: Vec<String> = fields.iter().map(|(f, _)| format!("\"{f}\"")).collect();
+    let cols_csv = cols.join(", ");
+    // `new."col"` / `old."col"` lists for the trigger bodies.
+    let new_vals: Vec<String> = fields.iter().map(|(f, _)| format!("new.\"{f}\"")).collect();
+    let new_vals_csv = new_vals.join(", ");
+    let old_vals: Vec<String> = fields.iter().map(|(f, _)| format!("old.\"{f}\"")).collect();
+    let old_vals_csv = old_vals.join(", ");
+
     let mut out = String::new();
     let _ = writeln!(
         out,
         "-- autumn-safety: potentially-blocking \n\
-         -- adding stored generated column will backfill existing rows"
+         -- rebuilding the FTS5 index backfills every existing row"
     );
-
-    let safe_lang: String = language
-        .chars()
-        .filter(|c| c.is_alphanumeric() || *c == '_' || *c == '.')
-        .collect();
-    let safe_lang = if safe_lang.is_empty() {
-        "simple".to_string()
-    } else {
-        safe_lang
-    };
-
-    let mut expr = String::new();
-    for (i, (field, weight)) in fields.iter().enumerate() {
-        if i > 0 {
-            expr.push_str(" || ");
-        }
-        let _ = write!(
-            expr,
-            "setweight(to_tsvector('{safe_lang}'::regconfig, coalesce(\"{field}\"::text, '')), '{weight}')"
-        );
-    }
-
+    // External-content FTS5 virtual table over the SEARCH_FIELDS columns.
     let _ = writeln!(
         out,
-        "ALTER TABLE {table} ADD COLUMN search_vector tsvector GENERATED ALWAYS AS ({expr}) STORED;"
+        "CREATE VIRTUAL TABLE \"{fts}\" USING fts5({cols_csv}, content='{table}', content_rowid='id', tokenize='unicode61');"
+    );
+    // Keep the index in sync with the base table (standard external-content
+    // pattern): insert the new row, tombstone the old row on delete, and do both
+    // on update.
+    let _ = writeln!(
+        out,
+        "CREATE TRIGGER \"{fts}_ai\" AFTER INSERT ON \"{table}\" BEGIN\n  \
+         INSERT INTO \"{fts}\"(rowid, {cols_csv}) VALUES (new.id, {new_vals_csv});\n\
+         END;"
     );
     let _ = writeln!(
         out,
-        "CREATE INDEX idx_{table}_search_vector ON {table} USING gin(search_vector);"
+        "CREATE TRIGGER \"{fts}_ad\" AFTER DELETE ON \"{table}\" BEGIN\n  \
+         INSERT INTO \"{fts}\"(\"{fts}\", rowid, {cols_csv}) VALUES('delete', old.id, {old_vals_csv});\n\
+         END;"
     );
+    let _ = writeln!(
+        out,
+        "CREATE TRIGGER \"{fts}_au\" AFTER UPDATE ON \"{table}\" BEGIN\n  \
+         INSERT INTO \"{fts}\"(\"{fts}\", rowid, {cols_csv}) VALUES('delete', old.id, {old_vals_csv});\n  \
+         INSERT INTO \"{fts}\"(rowid, {cols_csv}) VALUES (new.id, {new_vals_csv});\n\
+         END;"
+    );
+    // Backfill the index for rows that already exist.
+    let _ = writeln!(out, "INSERT INTO \"{fts}\"(\"{fts}\") VALUES('rebuild');");
     out
 }
 
-/// `down.sql` companion to [`add_search_up_sql`].
-#[must_use]
-pub fn add_search_down_sql(table: &str) -> String {
+/// `SQLite` FTS5 `down.sql`: drop the maintenance triggers, then the FTS table.
+fn sqlite_add_search_down_sql(table: &str) -> String {
+    let fts = format!("{table}__fts");
     let mut out = String::new();
-    let _ = writeln!(out, "DROP INDEX IF EXISTS idx_{table}_search_vector;");
-    let _ = writeln!(
-        out,
-        "ALTER TABLE {table} DROP COLUMN IF EXISTS search_vector;"
-    );
+    let _ = writeln!(out, "DROP TRIGGER IF EXISTS \"{fts}_au\";");
+    let _ = writeln!(out, "DROP TRIGGER IF EXISTS \"{fts}_ad\";");
+    let _ = writeln!(out, "DROP TRIGGER IF EXISTS \"{fts}_ai\";");
+    let _ = writeln!(out, "DROP TABLE IF EXISTS \"{fts}\";");
     out
 }
 
@@ -7263,13 +7354,70 @@ pub struct Post {
 
     #[test]
     fn test_add_search_up_sql_quotes_columns() {
-        let sql = add_search_up_sql(
+        let sql = add_search_up_sql_for(
+            DatabaseBackend::Postgres,
             "posts",
             "english",
             &[("title".to_string(), 'A'), ("body".to_string(), 'B')],
         );
         assert!(sql.contains("coalesce(\"title\"::text, '')"));
         assert!(sql.contains("coalesce(\"body\"::text, '')"));
+    }
+
+    #[test]
+    fn test_add_search_up_sql_sqlite_emits_fts5_external_content_and_triggers() {
+        // #1910: the SQLite arm emits an external-content FTS5 vtable over the
+        // SEARCH_FIELDS columns, maintenance triggers, and a backfill rebuild —
+        // and NO Postgres tsvector/GIN DDL.
+        let up = add_search_up_sql_for(
+            DatabaseBackend::Sqlite,
+            "posts",
+            "english",
+            &[("title".to_string(), 'A'), ("body".to_string(), 'B')],
+        );
+        assert!(
+            up.contains(
+                "CREATE VIRTUAL TABLE \"posts__fts\" USING fts5(\"title\", \"body\", \
+                 content='posts', content_rowid='id', tokenize='unicode61');"
+            ),
+            "up: {up}"
+        );
+        // Insert trigger writes the new row into the index.
+        assert!(
+            up.contains(
+                "INSERT INTO \"posts__fts\"(rowid, \"title\", \"body\") \
+                 VALUES (new.id, new.\"title\", new.\"body\");"
+            ),
+            "up: {up}"
+        );
+        // Delete trigger tombstones the old row via the external-content 'delete'
+        // command.
+        assert!(
+            up.contains(
+                "INSERT INTO \"posts__fts\"(\"posts__fts\", rowid, \"title\", \"body\") \
+                 VALUES('delete', old.id, old.\"title\", old.\"body\");"
+            ),
+            "up: {up}"
+        );
+        // Update trigger does both (delete-then-insert).
+        assert!(up.contains("CREATE TRIGGER \"posts__fts_au\""), "up: {up}");
+        assert!(
+            up.contains("INSERT INTO \"posts__fts\"(\"posts__fts\") VALUES('rebuild');"),
+            "up: {up}"
+        );
+        for leak in ["tsvector", "to_tsvector", "USING gin", "search_vector"] {
+            assert!(!up.contains(leak), "SQLite up leaked `{leak}`: {up}");
+        }
+
+        // down.sql drops the three triggers then the FTS table.
+        let down = add_search_down_sql_for(DatabaseBackend::Sqlite, "posts");
+        for trig in ["posts__fts_au", "posts__fts_ad", "posts__fts_ai"] {
+            assert!(
+                down.contains(&format!("DROP TRIGGER IF EXISTS \"{trig}\";")),
+                "down: {down}"
+            );
+        }
+        assert!(down.contains("DROP TABLE IF EXISTS \"posts__fts\";"), "down: {down}");
     }
 
     #[test]
@@ -7285,15 +7433,20 @@ pub struct Post {
 
     #[test]
     fn test_add_search_up_sql_sanitizes_language() {
-        let sql = add_search_up_sql(
+        let sql = add_search_up_sql_for(
+            DatabaseBackend::Postgres,
             "posts",
             "english'; DROP TABLE posts;--",
             &[("title".to_string(), 'A')],
         );
         assert!(sql.contains("to_tsvector('englishDROPTABLEposts'::regconfig"));
 
-        let sql_qualified =
-            add_search_up_sql("posts", "pg_catalog.english", &[("title".to_string(), 'A')]);
+        let sql_qualified = add_search_up_sql_for(
+            DatabaseBackend::Postgres,
+            "posts",
+            "pg_catalog.english",
+            &[("title".to_string(), 'A')],
+        );
         assert!(sql_qualified.contains("to_tsvector('pg_catalog.english'::regconfig"));
     }
 

--- a/autumn-cli/src/generate/schema_edit.rs
+++ b/autumn-cli/src/generate/schema_edit.rs
@@ -3828,11 +3828,12 @@ pub fn add_search_down_sql_for(backend: DatabaseBackend, table: &str) -> String 
     }
 }
 
-/// `SQLite` FTS5 `up.sql`: external-content virtual table + maintenance triggers
-/// + backfill rebuild (issue #1910). The FTS table is `"<table>__fts"`, indexes
-/// the `SEARCH_FIELDS` columns in priority order, and mirrors the base table via
-/// `content='<table>', content_rowid='id'` so the base table stays the single
-/// source of truth (the generated `bm25()`-ranked `MATCH` query joins the two).
+/// `SQLite` FTS5 `up.sql`: an external-content virtual table, its maintenance
+/// triggers, and a backfill rebuild (issue #1910). The FTS table is
+/// `"<table>__fts"`, indexes the `SEARCH_FIELDS` columns in priority order, and
+/// mirrors the base table via `content='<table>', content_rowid='id'` so the
+/// base table stays the single source of truth (the generated `bm25()`-ranked
+/// `MATCH` query joins the two).
 fn sqlite_add_search_up_sql(table: &str, fields: &[(String, char)]) -> String {
     let fts = format!("{table}__fts");
     // Quoted, comma-separated indexed column list, shared across the DDL.
@@ -7417,7 +7418,10 @@ pub struct Post {
                 "down: {down}"
             );
         }
-        assert!(down.contains("DROP TABLE IF EXISTS \"posts__fts\";"), "down: {down}");
+        assert!(
+            down.contains("DROP TABLE IF EXISTS \"posts__fts\";"),
+            "down: {down}"
+        );
     }
 
     #[test]

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -13737,37 +13737,41 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         };
 
-        // #1996 SQLite full-text-search fallback. Postgres uses tsvector ranked
+        // #1910 SQLite FTS5 full-text search. Postgres uses tsvector ranked
         // search (`websearch_to_tsquery`/`ts_rank_cd`); SQLite has no tsvector, so
-        // the `backend_select!` sqlite arm below matches each `SEARCH_FIELDS`
-        // column with a case-insensitive `lower(col) LIKE '%term%'` substring test,
-        // ORed together, ordered `id DESC` (unranked — FTS5 ranking is deferred to
-        // #1910). Case-insensitivity here is ASCII-only: SQLite's built-in `lower()`
-        // folds only ASCII A–Z, so the query side is folded with the matching
-        // `to_ascii_lowercase()` (NOT Rust's full-Unicode `to_lowercase()`) to keep
-        // both sides consistent — a non-ASCII term (e.g. `Äpfel`) matches only with
-        // matching case. Full-Unicode/ICU case folding is deferred to #1910 (with
-        // FTS5 ranking). This fragment builds the shared `__autumn_like_where`
-        // OR-clause (positional `$1` pattern, reused across every column — SQLite
-        // collapses a repeated `$1` to one bind) and the `__autumn_pattern` search
-        // term with LIKE metacharacters (`\`, `%`, `_`) escaped so they match
-        // literally and a query can never become a match-everything wildcard. It is
-        // spliced into each sqlite arm (never the pg arm), so the pattern/where are
-        // only built where they are used.
-        let sqlite_like_setup = quote! {
-            let mut __autumn_like_clauses: ::std::vec::Vec<::std::string::String> = ::std::vec::Vec::new();
-            for (__autumn_field, _) in <#model_name as ::autumn_web::repository::AutumnSearchableModel>::SEARCH_FIELDS {
-                __autumn_like_clauses.push(::std::format!("lower(\"{__autumn_field}\") LIKE $1 ESCAPE '\\'"));
+        // the `backend_select!` sqlite arm below queries an external-content FTS5
+        // virtual table (`"<table>__fts"`, tokenized with `unicode61`) that the
+        // `AddSearch` migration creates and keeps in sync with triggers. The id
+        // SELECT joins that FTS table to the base table (so the tenant /
+        // soft-delete / owner predicates still filter the BASE table exactly as
+        // the pg arm does), matches with `WHERE "<table>__fts" MATCH ?`, and ranks
+        // with `ORDER BY bm25("<table>__fts", <weights>)` — per-column weights
+        // derived from the `#[searchable(weight=...)]` priorities (A→10, B→5, C→2,
+        // else 1), so a higher-priority field sorts first (bm25 returns lower =
+        // better, so a larger weight yields a more-negative score). `unicode61`
+        // folds case for the full Unicode range (fixing the old ASCII-only `lower`
+        // limitation — e.g. `äpfel` now matches `Äpfel`). This fragment builds the
+        // trusted `__autumn_bm25_weights` literal list and the fail-closed
+        // `__autumn_fts_match_opt` (see `sqlite_fts5_match_query`); it is spliced
+        // into each sqlite arm (never the pg arm), so it is only built where used.
+        let sqlite_fts_setup = quote! {
+            // Trusted per-column bm25 weights from the developer-declared
+            // SEARCH_FIELDS priorities — never request input, so spliced as SQL
+            // literals rather than bound.
+            let mut __autumn_bm25_weights: ::std::vec::Vec<&'static str> = ::std::vec::Vec::new();
+            for (_, __autumn_weight) in <#model_name as ::autumn_web::repository::AutumnSearchableModel>::SEARCH_FIELDS {
+                __autumn_bm25_weights.push(match *__autumn_weight {
+                    'A' => "10.0",
+                    'B' => "5.0",
+                    'C' => "2.0",
+                    _ => "1.0",
+                });
             }
-            let __autumn_like_where = __autumn_like_clauses.join(" OR ");
-            let mut __autumn_escaped = ::std::string::String::new();
-            for __autumn_ch in query.to_ascii_lowercase().chars() {
-                if ::core::matches!(__autumn_ch, '\\' | '%' | '_') {
-                    __autumn_escaped.push('\\');
-                }
-                __autumn_escaped.push(__autumn_ch);
-            }
-            let __autumn_pattern = ::std::format!("%{__autumn_escaped}%");
+            let __autumn_bm25_weights = __autumn_bm25_weights.join(", ");
+            // Fail-closed FTS5 MATCH sanitization: `None` ⇒ no usable tokens ⇒ the
+            // arm yields an empty result and runs NO query (never a full scan).
+            let __autumn_fts_match_opt =
+                ::autumn_web::repository::sqlite_fts5_match_query(query);
         };
 
         // §1d: under across_tenants on a sharded repo the `Vec`-returning
@@ -13867,38 +13871,47 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         }
                     }},
                     sqlite => {{
-                        #sqlite_like_setup
+                        #sqlite_fts_setup
 
-                        let mut sql = ::std::format!(
-                            "SELECT id FROM \"{}\" WHERE ({})",
-                            #table_name, __autumn_like_where
-                        );
-                        if #config_soft_delete {
-                            sql.push_str(" AND deleted_at IS NULL");
-                        }
-                        if let ::core::option::Option::Some(ref _t) = tenant_id {
-                            sql.push_str(" AND tenant_id = $2");
-                        }
-                        sql.push_str(" ORDER BY id DESC");
+                        match __autumn_fts_match_opt {
+                            // Fail-closed: no usable tokens ⇒ empty result, no query.
+                            ::core::option::Option::None => ::std::vec::Vec::<SearchId>::new(),
+                            ::core::option::Option::Some(__autumn_match) => {
+                                let mut sql = ::std::format!(
+                                    "SELECT id FROM \"{tbl}\" JOIN \"{tbl}__fts\" ON \"{tbl}__fts\".rowid = \"{tbl}\".id WHERE \"{tbl}__fts\" MATCH $1",
+                                    tbl = #table_name
+                                );
+                                if #config_soft_delete {
+                                    sql.push_str(" AND deleted_at IS NULL");
+                                }
+                                if let ::core::option::Option::Some(ref _t) = tenant_id {
+                                    sql.push_str(" AND tenant_id = $2");
+                                }
+                                sql.push_str(&::std::format!(
+                                    " ORDER BY bm25(\"{tbl}__fts\", {weights}), id DESC",
+                                    tbl = #table_name, weights = __autumn_bm25_weights
+                                ));
 
-                        if #config_tenant_scoped {
-                            if let ::core::option::Option::Some(ref t) = tenant_id {
-                                ::autumn_web::reexports::diesel::sql_query(sql)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_pattern)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(t)
-                                    .load::<SearchId>(&mut conn)
-                                    .await?
-                            } else {
-                                ::autumn_web::reexports::diesel::sql_query(sql)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_pattern)
-                                    .load::<SearchId>(&mut conn)
-                                    .await?
+                                if #config_tenant_scoped {
+                                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        ::autumn_web::reexports::diesel::sql_query(sql)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_match)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(t)
+                                            .load::<SearchId>(&mut conn)
+                                            .await?
+                                    } else {
+                                        ::autumn_web::reexports::diesel::sql_query(sql)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_match)
+                                            .load::<SearchId>(&mut conn)
+                                            .await?
+                                    }
+                                } else {
+                                    ::autumn_web::reexports::diesel::sql_query(sql)
+                                        .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_match)
+                                        .load::<SearchId>(&mut conn)
+                                        .await?
+                                }
                             }
-                        } else {
-                            ::autumn_web::reexports::diesel::sql_query(sql)
-                                .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_pattern)
-                                .load::<SearchId>(&mut conn)
-                                .await?
                         }
                     }},
                 };
@@ -14026,39 +14039,45 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         }
                     }},
                     sqlite => {{
-                        #sqlite_like_setup
-                        let mut count_sql = ::std::format!(
-                            "SELECT COUNT(*) AS count FROM \"{}\" WHERE ({})",
-                            #table_name, __autumn_like_where
-                        );
-                        if #config_soft_delete {
-                            count_sql.push_str(" AND deleted_at IS NULL");
-                        }
-                        if let ::core::option::Option::Some(ref _t) = tenant_id {
-                            count_sql.push_str(" AND tenant_id = $2");
-                        }
+                        #sqlite_fts_setup
+                        match __autumn_fts_match_opt {
+                            // Fail-closed: no usable tokens ⇒ zero total, no query.
+                            ::core::option::Option::None => 0_i64,
+                            ::core::option::Option::Some(__autumn_match) => {
+                                let mut count_sql = ::std::format!(
+                                    "SELECT COUNT(*) AS count FROM \"{tbl}\" JOIN \"{tbl}__fts\" ON \"{tbl}__fts\".rowid = \"{tbl}\".id WHERE \"{tbl}__fts\" MATCH $1",
+                                    tbl = #table_name
+                                );
+                                if #config_soft_delete {
+                                    count_sql.push_str(" AND deleted_at IS NULL");
+                                }
+                                if let ::core::option::Option::Some(ref _t) = tenant_id {
+                                    count_sql.push_str(" AND tenant_id = $2");
+                                }
 
-                        if #config_tenant_scoped {
-                            if let ::core::option::Option::Some(ref t) = tenant_id {
-                                ::autumn_web::reexports::diesel::sql_query(count_sql)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_pattern)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(t)
-                                    .get_result::<SearchCount>(&mut conn)
-                                    .await?
-                                    .count
-                            } else {
-                                ::autumn_web::reexports::diesel::sql_query(count_sql)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_pattern)
-                                    .get_result::<SearchCount>(&mut conn)
-                                    .await?
-                                    .count
+                                if #config_tenant_scoped {
+                                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        ::autumn_web::reexports::diesel::sql_query(count_sql)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_match)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(t)
+                                            .get_result::<SearchCount>(&mut conn)
+                                            .await?
+                                            .count
+                                    } else {
+                                        ::autumn_web::reexports::diesel::sql_query(count_sql)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_match)
+                                            .get_result::<SearchCount>(&mut conn)
+                                            .await?
+                                            .count
+                                    }
+                                } else {
+                                    ::autumn_web::reexports::diesel::sql_query(count_sql)
+                                        .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_match)
+                                        .get_result::<SearchCount>(&mut conn)
+                                        .await?
+                                        .count
+                                }
                             }
-                        } else {
-                            ::autumn_web::reexports::diesel::sql_query(count_sql)
-                                .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_pattern)
-                                .get_result::<SearchCount>(&mut conn)
-                                .await?
-                                .count
                         }
                     }},
                 };
@@ -14112,47 +14131,57 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         }
                     }},
                     sqlite => {{
-                        #sqlite_like_setup
-                        let mut select_sql = ::std::format!(
-                            "SELECT id FROM \"{}\" WHERE ({})",
-                            #table_name, __autumn_like_where
-                        );
-                        if #config_soft_delete {
-                            select_sql.push_str(" AND deleted_at IS NULL");
-                        }
-                        if let ::core::option::Option::Some(ref _t) = tenant_id {
-                            select_sql.push_str(" AND tenant_id = $2");
-                            select_sql.push_str(" ORDER BY id DESC");
-                            select_sql.push_str(" LIMIT $3 OFFSET $4");
-                        } else {
-                            select_sql.push_str(" ORDER BY id DESC");
-                            select_sql.push_str(" LIMIT $2 OFFSET $3");
-                        }
+                        #sqlite_fts_setup
+                        match __autumn_fts_match_opt {
+                            // Fail-closed: no usable tokens ⇒ empty page, no query.
+                            ::core::option::Option::None => ::std::vec::Vec::<SearchId>::new(),
+                            ::core::option::Option::Some(__autumn_match) => {
+                                let mut select_sql = ::std::format!(
+                                    "SELECT id FROM \"{tbl}\" JOIN \"{tbl}__fts\" ON \"{tbl}__fts\".rowid = \"{tbl}\".id WHERE \"{tbl}__fts\" MATCH $1",
+                                    tbl = #table_name
+                                );
+                                if #config_soft_delete {
+                                    select_sql.push_str(" AND deleted_at IS NULL");
+                                }
+                                let __autumn_order = ::std::format!(
+                                    " ORDER BY bm25(\"{tbl}__fts\", {weights}), id DESC",
+                                    tbl = #table_name, weights = __autumn_bm25_weights
+                                );
+                                if let ::core::option::Option::Some(ref _t) = tenant_id {
+                                    select_sql.push_str(" AND tenant_id = $2");
+                                    select_sql.push_str(&__autumn_order);
+                                    select_sql.push_str(" LIMIT $3 OFFSET $4");
+                                } else {
+                                    select_sql.push_str(&__autumn_order);
+                                    select_sql.push_str(" LIMIT $2 OFFSET $3");
+                                }
 
-                        if #config_tenant_scoped {
-                            if let ::core::option::Option::Some(ref t) = tenant_id {
-                                ::autumn_web::reexports::diesel::sql_query(select_sql)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_pattern)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(t)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(limit)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(offset)
-                                    .load::<SearchId>(&mut conn)
-                                    .await?
-                            } else {
-                                ::autumn_web::reexports::diesel::sql_query(select_sql)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_pattern)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(limit)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(offset)
-                                    .load::<SearchId>(&mut conn)
-                                    .await?
+                                if #config_tenant_scoped {
+                                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        ::autumn_web::reexports::diesel::sql_query(select_sql)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_match)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(t)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(limit)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(offset)
+                                            .load::<SearchId>(&mut conn)
+                                            .await?
+                                    } else {
+                                        ::autumn_web::reexports::diesel::sql_query(select_sql)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_match)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(limit)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(offset)
+                                            .load::<SearchId>(&mut conn)
+                                            .await?
+                                    }
+                                } else {
+                                    ::autumn_web::reexports::diesel::sql_query(select_sql)
+                                        .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_match)
+                                        .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(limit)
+                                        .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(offset)
+                                        .load::<SearchId>(&mut conn)
+                                        .await?
+                                }
                             }
-                        } else {
-                            ::autumn_web::reexports::diesel::sql_query(select_sql)
-                                .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_pattern)
-                                .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(limit)
-                                .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(offset)
-                                .load::<SearchId>(&mut conn)
-                                .await?
                         }
                     }},
                 };
@@ -14216,8 +14245,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         let owner_and_p3 = format!(" AND {owner_col_name} = $3");
         let owner_and_p4 = format!(" AND {owner_col_name} = $4");
 
-        // #1996 SQLite owner clause literals. The sqlite arm renumbers positional
-        // slots from `$1` (the LIKE pattern replaces Postgres's `$1`/`$2`
+        // #1910 SQLite owner clause literals. The sqlite arm renumbers positional
+        // slots from `$1` (the FTS5 MATCH string replaces Postgres's `$1`/`$2`
         // language+query pair), so the owner filter lands on `$2` (no tenant) or
         // `$3` (tenant occupies `$2`). Same trusted developer-declared identifier
         // as the pg literals — never request input.
@@ -14239,26 +14268,25 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 let tenant_id = ::core::option::Option::None::<::std::string::String>;
             }
         };
-        // #1996 SQLite LIKE-substring fallback for the owner-scoped search (see the
-        // sibling `sqlite_like_setup` in the unscoped searchable block for the full
-        // rationale, including the ASCII-only case-folding note — the query side is
-        // `to_ascii_lowercase()` to match SQLite's ASCII-only `lower()`). Recomputed
-        // locally here because the scoped block is a separate `if let` and cannot
-        // see the unscoped block's binding.
-        let sqlite_like_setup = quote! {
-            let mut __autumn_like_clauses: ::std::vec::Vec<::std::string::String> = ::std::vec::Vec::new();
-            for (__autumn_field, _) in <#model_name as ::autumn_web::repository::AutumnSearchableModel>::SEARCH_FIELDS {
-                __autumn_like_clauses.push(::std::format!("lower(\"{__autumn_field}\") LIKE $1 ESCAPE '\\'"));
+        // #1910 SQLite FTS5 setup for the owner-scoped search (see the sibling
+        // `sqlite_fts_setup` in the unscoped searchable block for the full
+        // rationale — external-content FTS5 vtable, unicode61 tokenizer, bm25
+        // ranking, and the fail-closed `sqlite_fts5_match_query` sanitizer).
+        // Recomputed locally here because the scoped block is a separate `if let`
+        // and cannot see the unscoped block's binding.
+        let sqlite_fts_setup = quote! {
+            let mut __autumn_bm25_weights: ::std::vec::Vec<&'static str> = ::std::vec::Vec::new();
+            for (_, __autumn_weight) in <#model_name as ::autumn_web::repository::AutumnSearchableModel>::SEARCH_FIELDS {
+                __autumn_bm25_weights.push(match *__autumn_weight {
+                    'A' => "10.0",
+                    'B' => "5.0",
+                    'C' => "2.0",
+                    _ => "1.0",
+                });
             }
-            let __autumn_like_where = __autumn_like_clauses.join(" OR ");
-            let mut __autumn_escaped = ::std::string::String::new();
-            for __autumn_ch in query.to_ascii_lowercase().chars() {
-                if ::core::matches!(__autumn_ch, '\\' | '%' | '_') {
-                    __autumn_escaped.push('\\');
-                }
-                __autumn_escaped.push(__autumn_ch);
-            }
-            let __autumn_pattern = ::std::format!("%{__autumn_escaped}%");
+            let __autumn_bm25_weights = __autumn_bm25_weights.join(", ");
+            let __autumn_fts_match_opt =
+                ::autumn_web::repository::sqlite_fts5_match_query(query);
         };
         let search_page_cross_shard_guard = if config.sharded && config.tenant_scoped {
             quote! {
@@ -14378,49 +14406,55 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         }
                     }},
                     sqlite => {{
-                        #sqlite_like_setup
-                        let mut count_sql = ::std::format!(
-                            "SELECT COUNT(*) AS count FROM \"{}\" WHERE ({})",
-                            #table_name, __autumn_like_where
-                        );
-                        if #config_soft_delete {
-                            count_sql.push_str(" AND deleted_at IS NULL");
-                        }
-                        if #config_tenant_scoped {
-                            if let ::core::option::Option::Some(ref _t) = tenant_id {
-                                count_sql.push_str(" AND tenant_id = $2");
-                                count_sql.push_str(#owner_sqlite_p3);
-                            } else {
-                                count_sql.push_str(#owner_sqlite_p2);
-                            }
-                        } else {
-                            count_sql.push_str(#owner_sqlite_p2);
-                        }
+                        #sqlite_fts_setup
+                        match __autumn_fts_match_opt {
+                            // Fail-closed: no usable tokens ⇒ zero total, no query.
+                            ::core::option::Option::None => 0_i64,
+                            ::core::option::Option::Some(__autumn_match) => {
+                                let mut count_sql = ::std::format!(
+                                    "SELECT COUNT(*) AS count FROM \"{tbl}\" JOIN \"{tbl}__fts\" ON \"{tbl}__fts\".rowid = \"{tbl}\".id WHERE \"{tbl}__fts\" MATCH $1",
+                                    tbl = #table_name
+                                );
+                                if #config_soft_delete {
+                                    count_sql.push_str(" AND deleted_at IS NULL");
+                                }
+                                if #config_tenant_scoped {
+                                    if let ::core::option::Option::Some(ref _t) = tenant_id {
+                                        count_sql.push_str(" AND tenant_id = $2");
+                                        count_sql.push_str(#owner_sqlite_p3);
+                                    } else {
+                                        count_sql.push_str(#owner_sqlite_p2);
+                                    }
+                                } else {
+                                    count_sql.push_str(#owner_sqlite_p2);
+                                }
 
-                        if #config_tenant_scoped {
-                            if let ::core::option::Option::Some(ref t) = tenant_id {
-                                ::autumn_web::reexports::diesel::sql_query(count_sql)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_pattern)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(t)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(owner_id)
-                                    .get_result::<SearchCount>(&mut conn)
-                                    .await?
-                                    .count
-                            } else {
-                                ::autumn_web::reexports::diesel::sql_query(count_sql)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_pattern)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(owner_id)
-                                    .get_result::<SearchCount>(&mut conn)
-                                    .await?
-                                    .count
+                                if #config_tenant_scoped {
+                                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        ::autumn_web::reexports::diesel::sql_query(count_sql)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_match)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(t)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(owner_id)
+                                            .get_result::<SearchCount>(&mut conn)
+                                            .await?
+                                            .count
+                                    } else {
+                                        ::autumn_web::reexports::diesel::sql_query(count_sql)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_match)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(owner_id)
+                                            .get_result::<SearchCount>(&mut conn)
+                                            .await?
+                                            .count
+                                    }
+                                } else {
+                                    ::autumn_web::reexports::diesel::sql_query(count_sql)
+                                        .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_match)
+                                        .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(owner_id)
+                                        .get_result::<SearchCount>(&mut conn)
+                                        .await?
+                                        .count
+                                }
                             }
-                        } else {
-                            ::autumn_web::reexports::diesel::sql_query(count_sql)
-                                .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_pattern)
-                                .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(owner_id)
-                                .get_result::<SearchCount>(&mut conn)
-                                .await?
-                                .count
                         }
                     }},
                 };
@@ -14486,58 +14520,68 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         }
                     }},
                     sqlite => {{
-                        #sqlite_like_setup
-                        let mut select_sql = ::std::format!(
-                            "SELECT id FROM \"{}\" WHERE ({})",
-                            #table_name, __autumn_like_where
-                        );
-                        if #config_soft_delete {
-                            select_sql.push_str(" AND deleted_at IS NULL");
-                        }
-                        if #config_tenant_scoped {
-                            if let ::core::option::Option::Some(ref _t) = tenant_id {
-                                select_sql.push_str(" AND tenant_id = $2");
-                                select_sql.push_str(#owner_sqlite_p3);
-                                select_sql.push_str(" ORDER BY id DESC");
-                                select_sql.push_str(" LIMIT $4 OFFSET $5");
-                            } else {
-                                select_sql.push_str(#owner_sqlite_p2);
-                                select_sql.push_str(" ORDER BY id DESC");
-                                select_sql.push_str(" LIMIT $3 OFFSET $4");
-                            }
-                        } else {
-                            select_sql.push_str(#owner_sqlite_p2);
-                            select_sql.push_str(" ORDER BY id DESC");
-                            select_sql.push_str(" LIMIT $3 OFFSET $4");
-                        }
+                        #sqlite_fts_setup
+                        match __autumn_fts_match_opt {
+                            // Fail-closed: no usable tokens ⇒ empty page, no query.
+                            ::core::option::Option::None => ::std::vec::Vec::<SearchId>::new(),
+                            ::core::option::Option::Some(__autumn_match) => {
+                                let mut select_sql = ::std::format!(
+                                    "SELECT id FROM \"{tbl}\" JOIN \"{tbl}__fts\" ON \"{tbl}__fts\".rowid = \"{tbl}\".id WHERE \"{tbl}__fts\" MATCH $1",
+                                    tbl = #table_name
+                                );
+                                if #config_soft_delete {
+                                    select_sql.push_str(" AND deleted_at IS NULL");
+                                }
+                                let __autumn_order = ::std::format!(
+                                    " ORDER BY bm25(\"{tbl}__fts\", {weights}), id DESC",
+                                    tbl = #table_name, weights = __autumn_bm25_weights
+                                );
+                                if #config_tenant_scoped {
+                                    if let ::core::option::Option::Some(ref _t) = tenant_id {
+                                        select_sql.push_str(" AND tenant_id = $2");
+                                        select_sql.push_str(#owner_sqlite_p3);
+                                        select_sql.push_str(&__autumn_order);
+                                        select_sql.push_str(" LIMIT $4 OFFSET $5");
+                                    } else {
+                                        select_sql.push_str(#owner_sqlite_p2);
+                                        select_sql.push_str(&__autumn_order);
+                                        select_sql.push_str(" LIMIT $3 OFFSET $4");
+                                    }
+                                } else {
+                                    select_sql.push_str(#owner_sqlite_p2);
+                                    select_sql.push_str(&__autumn_order);
+                                    select_sql.push_str(" LIMIT $3 OFFSET $4");
+                                }
 
-                        if #config_tenant_scoped {
-                            if let ::core::option::Option::Some(ref t) = tenant_id {
-                                ::autumn_web::reexports::diesel::sql_query(select_sql)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_pattern)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(t)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(owner_id)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(limit)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(offset)
-                                    .load::<SearchId>(&mut conn)
-                                    .await?
-                            } else {
-                                ::autumn_web::reexports::diesel::sql_query(select_sql)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_pattern)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(owner_id)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(limit)
-                                    .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(offset)
-                                    .load::<SearchId>(&mut conn)
-                                    .await?
+                                if #config_tenant_scoped {
+                                    if let ::core::option::Option::Some(ref t) = tenant_id {
+                                        ::autumn_web::reexports::diesel::sql_query(select_sql)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_match)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(t)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(owner_id)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(limit)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(offset)
+                                            .load::<SearchId>(&mut conn)
+                                            .await?
+                                    } else {
+                                        ::autumn_web::reexports::diesel::sql_query(select_sql)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_match)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(owner_id)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(limit)
+                                            .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(offset)
+                                            .load::<SearchId>(&mut conn)
+                                            .await?
+                                    }
+                                } else {
+                                    ::autumn_web::reexports::diesel::sql_query(select_sql)
+                                        .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_match)
+                                        .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(owner_id)
+                                        .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(limit)
+                                        .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(offset)
+                                        .load::<SearchId>(&mut conn)
+                                        .await?
+                                }
                             }
-                        } else {
-                            ::autumn_web::reexports::diesel::sql_query(select_sql)
-                                .bind::<::autumn_web::reexports::diesel::sql_types::Text, _>(__autumn_pattern)
-                                .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(owner_id)
-                                .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(limit)
-                                .bind::<::autumn_web::reexports::diesel::sql_types::BigInt, _>(offset)
-                                .load::<SearchId>(&mut conn)
-                                .await?
                         }
                     }},
                 };
@@ -19423,11 +19467,11 @@ mod tests {
     }
 
     #[test]
-    fn repository_macro_searchable_forks_sqlite_like_fallback() {
-        // #1996: the full-text search codegen must fork into pg/sqlite
+    fn repository_macro_searchable_forks_sqlite_fts5() {
+        // #1910: the full-text search codegen must fork into pg/sqlite
         // `backend_select!` arms. Postgres keeps tsvector ranked search; SQLite
-        // falls back to case-insensitive `lower(col) LIKE '%term%'` substring
-        // matching over SEARCH_FIELDS, ordered `id DESC` (no rank function).
+        // queries an external-content FTS5 virtual table (`"<table>__fts"`),
+        // MATCH-filtered and bm25-ranked over SEARCH_FIELDS.
         let generated = repository_macro(
             quote! { Post, searchable },
             quote! { pub trait PostRepository {} },
@@ -19440,22 +19484,26 @@ mod tests {
             "a searchable repository must emit a backend_select! fork: {generated}"
         );
 
-        // ── SQLite arm: LIKE substring fallback, no tsvector functions ──
+        // ── SQLite arm: FTS5 MATCH + bm25, no LIKE / tsvector functions ──
         assert!(
-            generated.contains("LIKE $1 ESCAPE"),
-            "the SQLite search arm must emit a LIKE substring predicate: {generated}"
+            generated.contains("{tbl}__fts") && generated.contains("MATCH $1"),
+            "the SQLite search arm must MATCH against the FTS5 virtual table: {generated}"
         );
         assert!(
-            generated.contains("lower(\\\"{__autumn_field}\\\")"),
-            "the SQLite search arm must lower() each SEARCH_FIELD column: {generated}"
+            generated.contains("bm25(\\\"{tbl}__fts\\\""),
+            "the SQLite search arm must rank with bm25 over the FTS5 table: {generated}"
         );
         assert!(
             generated.contains("SEARCH_FIELDS"),
-            "the SQLite search arm must build its predicate from SEARCH_FIELDS: {generated}"
+            "the SQLite search arm must derive its bm25 weights from SEARCH_FIELDS: {generated}"
         );
         assert!(
-            generated.contains("ORDER BY id DESC"),
-            "the SQLite search arm must order by id DESC (unranked): {generated}"
+            generated.contains("sqlite_fts5_match_query"),
+            "the SQLite search arm must sanitize the MATCH query (fail-closed): {generated}"
+        );
+        assert!(
+            !generated.contains("LIKE $1 ESCAPE"),
+            "the SQLite search arm must NOT keep the old LIKE fallback: {generated}"
         );
 
         // ── Postgres arm: tsvector ranked search preserved (no regression) ──
@@ -19471,10 +19519,10 @@ mod tests {
 
     #[test]
     fn repository_macro_tenant_scoped_searchable_filters_tenant_in_both_arms() {
-        // #1996: tenant isolation is load-bearing — BOTH the pg (tsvector) and
-        // sqlite (LIKE) arms must carry the `tenant_id = $n` predicate so a search
+        // #1910: tenant isolation is load-bearing — BOTH the pg (tsvector) and
+        // sqlite (FTS5) arms must carry the `tenant_id = $n` predicate so a search
         // never crosses tenants on either backend. The pg arm binds tenant at $3;
-        // the sqlite arm renumbers to $2 (the LIKE pattern is $1).
+        // the sqlite arm renumbers to $2 (the FTS5 MATCH string is $1).
         let generated = repository_macro(
             quote! { Post, tenant_scoped, searchable },
             quote! { pub trait PostRepository {} },
@@ -19489,19 +19537,19 @@ mod tests {
             generated.contains("AND tenant_id = $2"),
             "the SQLite search arm must filter tenant_id = $2: {generated}"
         );
-        // The pg arm still ranks; the sqlite arm still substring-matches.
+        // The pg arm still ranks with tsvector; the sqlite arm still MATCHes FTS5.
         assert!(
-            generated.contains("websearch_to_tsquery") && generated.contains("LIKE $1 ESCAPE"),
+            generated.contains("websearch_to_tsquery") && generated.contains("MATCH $1"),
             "both search arms must survive tenant scoping: {generated}"
         );
     }
 
     #[test]
-    fn repository_macro_owner_scoped_searchable_forks_sqlite_like_fallback() {
-        // #1996: the owner-scoped search_page_scoped (#1841) path must fork too,
+    fn repository_macro_owner_scoped_searchable_forks_sqlite_fts5() {
+        // #1910: the owner-scoped search_page_scoped (#1841) path must fork too,
         // and the owner filter must survive in BOTH arms so an owner-scoped search
         // never leaks another user's rows. pg binds owner at $3; sqlite renumbers
-        // the owner filter to $2 (LIKE pattern is $1).
+        // the owner filter to $2 (FTS5 MATCH string is $1).
         let generated = repository_macro(
             quote! { Post, owner = user_id, searchable },
             quote! { pub trait PostRepository {} },
@@ -19512,7 +19560,7 @@ mod tests {
             generated.contains("search_page_scoped"),
             "an owner-scoped searchable repository must emit search_page_scoped: {generated}"
         );
-        // Postgres owner filter (ranked) and SQLite owner filter (LIKE).
+        // Postgres owner filter (ranked) and SQLite owner filter (FTS5 MATCH).
         assert!(
             generated.contains("AND user_id = $3"),
             "the Postgres owner-scoped arm must filter user_id = $3: {generated}"
@@ -19522,7 +19570,7 @@ mod tests {
             "the SQLite owner-scoped arm must filter \"user_id\" = $2: {generated}"
         );
         assert!(
-            generated.contains("websearch_to_tsquery") && generated.contains("LIKE $1 ESCAPE"),
+            generated.contains("websearch_to_tsquery") && generated.contains("MATCH $1"),
             "both owner-scoped search arms must be present: {generated}"
         );
     }

--- a/autumn-macros/src/repository.rs
+++ b/autumn-macros/src/repository.rs
@@ -13878,17 +13878,17 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             ::core::option::Option::None => ::std::vec::Vec::<SearchId>::new(),
                             ::core::option::Option::Some(__autumn_match) => {
                                 let mut sql = ::std::format!(
-                                    "SELECT id FROM \"{tbl}\" JOIN \"{tbl}__fts\" ON \"{tbl}__fts\".rowid = \"{tbl}\".id WHERE \"{tbl}__fts\" MATCH $1",
+                                    "SELECT \"{tbl}\".id FROM \"{tbl}\" JOIN \"{tbl}__fts\" ON \"{tbl}__fts\".rowid = \"{tbl}\".id WHERE \"{tbl}__fts\" MATCH $1",
                                     tbl = #table_name
                                 );
                                 if #config_soft_delete {
-                                    sql.push_str(" AND deleted_at IS NULL");
+                                    sql.push_str(&::std::format!(" AND \"{tbl}\".deleted_at IS NULL", tbl = #table_name));
                                 }
                                 if let ::core::option::Option::Some(ref _t) = tenant_id {
-                                    sql.push_str(" AND tenant_id = $2");
+                                    sql.push_str(&::std::format!(" AND \"{tbl}\".tenant_id = $2", tbl = #table_name));
                                 }
                                 sql.push_str(&::std::format!(
-                                    " ORDER BY bm25(\"{tbl}__fts\", {weights}), id DESC",
+                                    " ORDER BY bm25(\"{tbl}__fts\", {weights}), \"{tbl}\".id DESC",
                                     tbl = #table_name, weights = __autumn_bm25_weights
                                 ));
 
@@ -14049,10 +14049,10 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     tbl = #table_name
                                 );
                                 if #config_soft_delete {
-                                    count_sql.push_str(" AND deleted_at IS NULL");
+                                    count_sql.push_str(&::std::format!(" AND \"{tbl}\".deleted_at IS NULL", tbl = #table_name));
                                 }
                                 if let ::core::option::Option::Some(ref _t) = tenant_id {
-                                    count_sql.push_str(" AND tenant_id = $2");
+                                    count_sql.push_str(&::std::format!(" AND \"{tbl}\".tenant_id = $2", tbl = #table_name));
                                 }
 
                                 if #config_tenant_scoped {
@@ -14137,18 +14137,18 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             ::core::option::Option::None => ::std::vec::Vec::<SearchId>::new(),
                             ::core::option::Option::Some(__autumn_match) => {
                                 let mut select_sql = ::std::format!(
-                                    "SELECT id FROM \"{tbl}\" JOIN \"{tbl}__fts\" ON \"{tbl}__fts\".rowid = \"{tbl}\".id WHERE \"{tbl}__fts\" MATCH $1",
+                                    "SELECT \"{tbl}\".id FROM \"{tbl}\" JOIN \"{tbl}__fts\" ON \"{tbl}__fts\".rowid = \"{tbl}\".id WHERE \"{tbl}__fts\" MATCH $1",
                                     tbl = #table_name
                                 );
                                 if #config_soft_delete {
-                                    select_sql.push_str(" AND deleted_at IS NULL");
+                                    select_sql.push_str(&::std::format!(" AND \"{tbl}\".deleted_at IS NULL", tbl = #table_name));
                                 }
                                 let __autumn_order = ::std::format!(
-                                    " ORDER BY bm25(\"{tbl}__fts\", {weights}), id DESC",
+                                    " ORDER BY bm25(\"{tbl}__fts\", {weights}), \"{tbl}\".id DESC",
                                     tbl = #table_name, weights = __autumn_bm25_weights
                                 );
                                 if let ::core::option::Option::Some(ref _t) = tenant_id {
-                                    select_sql.push_str(" AND tenant_id = $2");
+                                    select_sql.push_str(&::std::format!(" AND \"{tbl}\".tenant_id = $2", tbl = #table_name));
                                     select_sql.push_str(&__autumn_order);
                                     select_sql.push_str(" LIMIT $3 OFFSET $4");
                                 } else {
@@ -14250,8 +14250,8 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         // language+query pair), so the owner filter lands on `$2` (no tenant) or
         // `$3` (tenant occupies `$2`). Same trusted developer-declared identifier
         // as the pg literals — never request input.
-        let owner_sqlite_p2 = format!(" AND \"{owner_col_name}\" = $2");
-        let owner_sqlite_p3 = format!(" AND \"{owner_col_name}\" = $3");
+        let owner_sqlite_p2 = format!(" AND \"{table_name}\".\"{owner_col_name}\" = $2");
+        let owner_sqlite_p3 = format!(" AND \"{table_name}\".\"{owner_col_name}\" = $3");
 
         let tenant_id_setup = if config.tenant_scoped {
             quote! {
@@ -14416,11 +14416,11 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     tbl = #table_name
                                 );
                                 if #config_soft_delete {
-                                    count_sql.push_str(" AND deleted_at IS NULL");
+                                    count_sql.push_str(&::std::format!(" AND \"{tbl}\".deleted_at IS NULL", tbl = #table_name));
                                 }
                                 if #config_tenant_scoped {
                                     if let ::core::option::Option::Some(ref _t) = tenant_id {
-                                        count_sql.push_str(" AND tenant_id = $2");
+                                        count_sql.push_str(&::std::format!(" AND \"{tbl}\".tenant_id = $2", tbl = #table_name));
                                         count_sql.push_str(#owner_sqlite_p3);
                                     } else {
                                         count_sql.push_str(#owner_sqlite_p2);
@@ -14526,19 +14526,19 @@ pub fn repository_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             ::core::option::Option::None => ::std::vec::Vec::<SearchId>::new(),
                             ::core::option::Option::Some(__autumn_match) => {
                                 let mut select_sql = ::std::format!(
-                                    "SELECT id FROM \"{tbl}\" JOIN \"{tbl}__fts\" ON \"{tbl}__fts\".rowid = \"{tbl}\".id WHERE \"{tbl}__fts\" MATCH $1",
+                                    "SELECT \"{tbl}\".id FROM \"{tbl}\" JOIN \"{tbl}__fts\" ON \"{tbl}__fts\".rowid = \"{tbl}\".id WHERE \"{tbl}__fts\" MATCH $1",
                                     tbl = #table_name
                                 );
                                 if #config_soft_delete {
-                                    select_sql.push_str(" AND deleted_at IS NULL");
+                                    select_sql.push_str(&::std::format!(" AND \"{tbl}\".deleted_at IS NULL", tbl = #table_name));
                                 }
                                 let __autumn_order = ::std::format!(
-                                    " ORDER BY bm25(\"{tbl}__fts\", {weights}), id DESC",
+                                    " ORDER BY bm25(\"{tbl}__fts\", {weights}), \"{tbl}\".id DESC",
                                     tbl = #table_name, weights = __autumn_bm25_weights
                                 );
                                 if #config_tenant_scoped {
                                     if let ::core::option::Option::Some(ref _t) = tenant_id {
-                                        select_sql.push_str(" AND tenant_id = $2");
+                                        select_sql.push_str(&::std::format!(" AND \"{tbl}\".tenant_id = $2", tbl = #table_name));
                                         select_sql.push_str(#owner_sqlite_p3);
                                         select_sql.push_str(&__autumn_order);
                                         select_sql.push_str(" LIMIT $4 OFFSET $5");
@@ -19493,6 +19493,19 @@ mod tests {
             generated.contains("bm25(\\\"{tbl}__fts\\\""),
             "the SQLite search arm must rank with bm25 over the FTS5 table: {generated}"
         );
+        // Codex P2 (#1910): every base-table column referenced across the FTS
+        // JOIN must be qualified with the base table (`"{tbl}".<col>`), or a
+        // model that marks a base column (e.g. `tenant_id`) `#[searchable]`
+        // would make SQLite raise `ambiguous column name`. The selected id and
+        // the bm25 tiebreak id are both base-table-qualified.
+        assert!(
+            generated.contains("SELECT \\\"{tbl}\\\".id FROM \\\"{tbl}\\\""),
+            "the SQLite search select must qualify id against the base table: {generated}"
+        );
+        assert!(
+            generated.contains("\\\"{tbl}\\\".id DESC"),
+            "the SQLite bm25 tiebreak must qualify id against the base table: {generated}"
+        );
         assert!(
             generated.contains("SEARCH_FIELDS"),
             "the SQLite search arm must derive its bm25 weights from SEARCH_FIELDS: {generated}"
@@ -19533,9 +19546,13 @@ mod tests {
             generated.contains("AND tenant_id = $3"),
             "the Postgres search arm must filter tenant_id = $3: {generated}"
         );
+        // Codex P2 (#1910): the SQLite tenant predicate must be base-table-
+        // qualified (`"{tbl}".tenant_id`) so a searchable `tenant_id` column
+        // (which also lands on `<table>__fts`) doesn't make it ambiguous under
+        // the FTS JOIN. The predicate survives — only the qualification changes.
         assert!(
-            generated.contains("AND tenant_id = $2"),
-            "the SQLite search arm must filter tenant_id = $2: {generated}"
+            generated.contains("AND \\\"{tbl}\\\".tenant_id = $2"),
+            "the SQLite search arm must filter \"{{tbl}}\".tenant_id = $2: {generated}"
         );
         // The pg arm still ranks with tsvector; the sqlite arm still MATCHes FTS5.
         assert!(
@@ -19565,9 +19582,13 @@ mod tests {
             generated.contains("AND user_id = $3"),
             "the Postgres owner-scoped arm must filter user_id = $3: {generated}"
         );
+        // Codex P2 (#1910): the SQLite owner predicate must be base-table-
+        // qualified (`"posts"."user_id"`) so a searchable owner column doesn't
+        // collide with the `<table>__fts` side of the JOIN. The owner filter
+        // survives — only the qualification changes.
         assert!(
-            generated.contains("AND \\\"user_id\\\" = $2"),
-            "the SQLite owner-scoped arm must filter \"user_id\" = $2: {generated}"
+            generated.contains("AND \\\"posts\\\".\\\"user_id\\\" = $2"),
+            "the SQLite owner-scoped arm must filter \"posts\".\"user_id\" = $2: {generated}"
         );
         assert!(
             generated.contains("websearch_to_tsquery") && generated.contains("MATCH $1"),

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -87,7 +87,15 @@ offline-sync = ["db", "http-client"]
 # (`PoolError::UnsupportedBackend`); a working pool is PR2. Needs no extra deps
 # — diesel's sqlite backend and diesel-async's sync-connection-wrapper are
 # already in the graph.
-sqlite = ["diesel/sqlite", "diesel/returning_clauses_for_sqlite_3_35", "diesel-async/sync-connection-wrapper"]
+# `dep:libsqlite3-sys` is listed so the `sqlite` feature is self-sufficient: it
+# guarantees the BUNDLED SQLite amalgamation (workspace dep pins
+# `features = ["bundled"]`), which compiles with `SQLITE_ENABLE_FTS5` defined —
+# so FTS5 full-text search (issue #1910: searchable repositories emit FTS5
+# virtual tables + bm25 ranking) is always available, even under
+# `--no-default-features --features sqlite`. The default `db` feature already
+# pulls it in, so this adds nothing to the Postgres/default lane (which never
+# enables `sqlite`).
+sqlite = ["dep:libsqlite3-sys", "diesel/sqlite", "diesel/returning_clauses_for_sqlite_3_35", "diesel-async/sync-connection-wrapper"]
 test-support = ["dep:testcontainers", "dep:testcontainers-modules"]
 telemetry-otlp = [
     "dep:opentelemetry",

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -87,15 +87,24 @@ offline-sync = ["db", "http-client"]
 # (`PoolError::UnsupportedBackend`); a working pool is PR2. Needs no extra deps
 # — diesel's sqlite backend and diesel-async's sync-connection-wrapper are
 # already in the graph.
-# `dep:libsqlite3-sys` is listed so the `sqlite` feature is self-sufficient: it
-# guarantees the BUNDLED SQLite amalgamation (workspace dep pins
-# `features = ["bundled"]`), which compiles with `SQLITE_ENABLE_FTS5` defined —
-# so FTS5 full-text search (issue #1910: searchable repositories emit FTS5
-# virtual tables + bm25 ranking) is always available, even under
-# `--no-default-features --features sqlite`. The default `db` feature already
-# pulls it in, so this adds nothing to the Postgres/default lane (which never
-# enables `sqlite`).
-sqlite = ["dep:libsqlite3-sys", "diesel/sqlite", "diesel/returning_clauses_for_sqlite_3_35", "diesel-async/sync-connection-wrapper"]
+# `sqlite` pulls in `db` so it is genuinely self-sufficient: `db` owns the
+# shared, backend-neutral migration/pool plumbing this feature builds on — the
+# `crate::migrate` module (itself `#[cfg(feature = "db")]`), `deadpool`, and
+# `diesel_migrations` — which the SQLite migration path (`app.rs`
+# `apply_pending_sqlite_or_exit`, gated on `#[cfg(feature = "sqlite")]`) calls
+# directly. Without this edge, `--no-default-features --features sqlite` fails to
+# compile (`crate::migrate` configured out). This is NOT a second backend: the
+# `RuntimeConnection` alias (see `src/db.rs`) flips to SQLite purely on
+# `#[cfg(feature = "sqlite")]` regardless of `db`, so enabling `db` alongside
+# does not resurrect the Postgres runtime — it only supplies the plumbing. This
+# mirrors the ratified verification lane `--features "db test-support sqlite"`.
+# The bundled SQLite amalgamation (`libsqlite3-sys` workspace dep pins
+# `features = ["bundled"]`, which `db` already pulls in) compiles with
+# `SQLITE_ENABLE_FTS5` defined, so FTS5 full-text search (issue #1910:
+# searchable repositories emit FTS5 virtual tables + bm25 ranking) is always
+# available. Adding `db` here changes nothing for the Postgres/default lane,
+# which never enables `sqlite`.
+sqlite = ["db", "diesel/sqlite", "diesel/returning_clauses_for_sqlite_3_35", "diesel-async/sync-connection-wrapper"]
 test-support = ["dep:testcontainers", "dep:testcontainers-modules"]
 telemetry-otlp = [
     "dep:opentelemetry",

--- a/autumn/src/db.rs
+++ b/autumn/src/db.rs
@@ -1354,6 +1354,36 @@ fn build_sqlite_pool(
             conn.batch_execute(pragmas)
                 .await
                 .map_err(diesel::ConnectionError::CouldntSetupConfiguration)?;
+            // #1910 FTS5 capability probe. Searchable repositories emit FTS5
+            // virtual tables + `bm25()` ranking, and the `AddSearch` migration's
+            // `CREATE VIRTUAL TABLE ... USING fts5(...)` is the hard stop that
+            // fails loudly at boot if the linked SQLite lacks FTS5. Probe it here
+            // (create + drop a throwaway FTS5 table in the always-writable `temp`
+            // database — harmless on read-only main targets) so the failure is a
+            // clear, actionable diagnostic naming FTS5 and the fix, instead of a
+            // bare "no such module: fts5" surfacing from a migration. There is NO
+            // silent fallback to LIKE — full-text search requires FTS5.
+            if let Err(e) = conn
+                .batch_execute(
+                    "CREATE VIRTUAL TABLE temp.__autumn_fts5_probe USING fts5(x); \
+                     DROP TABLE temp.__autumn_fts5_probe;",
+                )
+                .await
+            {
+                return Err(diesel::ConnectionError::CouldntSetupConfiguration(
+                    diesel::result::Error::QueryBuilderError(
+                        format!(
+                            "SQLite FTS5 is not available in the linked SQLite library, but \
+                             autumn-web full-text search (searchable repositories / the \
+                             `--search` scaffold, issue #1910) requires it. Build with the \
+                             bundled, FTS5-enabled SQLite by enabling autumn-web's `sqlite` \
+                             feature (it turns on `libsqlite3-sys/bundled`, whose amalgamation \
+                             defines SQLITE_ENABLE_FTS5). Underlying probe error: {e}"
+                        )
+                        .into(),
+                    ),
+                ));
+            }
             Ok(conn)
         }
         .boxed()

--- a/autumn/src/repository.rs
+++ b/autumn/src/repository.rs
@@ -543,6 +543,50 @@ pub trait AutumnSearchableModel {
     const SEARCH_FIELDS: &'static [(&'static str, char)];
 }
 
+/// Build a fail-closed SQLite FTS5 `MATCH` query string from raw user input
+/// (issue #1910).
+///
+/// SQLite FTS5's `MATCH` right-hand operand is a query *language*, not a plain
+/// string: bare words are terms, but `AND` / `OR` / `NOT` / `NEAR`, a `col:`
+/// prefix, `*` (prefix), `^` (initial-token), `(`/`)` grouping, `"` phrases and
+/// a leading `-` are all operators. Passing raw user input straight to `MATCH`
+/// would let a caller inject FTS5 query syntax — or, more commonly, trigger a
+/// hard syntax error on innocuous punctuation. This helper neutralizes all of
+/// it: the input is split on Unicode whitespace and each token is emitted as a
+/// quoted FTS5 string literal (a `"..."` phrase), with any embedded `"` doubled
+/// (`""`) per FTS5's own string escaping. The quoted tokens are joined with a
+/// single space, which FTS5 reads as an implicit AND of literal phrases. Every
+/// operator character therefore becomes part of a literal term and can never
+/// change the query's structure (the analogue of the Postgres path's
+/// `websearch_to_tsquery` and the old LIKE path's metacharacter escaping).
+///
+/// Returns `None` when the input yields no tokens (empty or whitespace-only).
+/// The caller MUST treat `None` as an empty result set and run **no** query —
+/// never an unfiltered scan.
+#[must_use]
+pub fn sqlite_fts5_match_query(input: &str) -> Option<String> {
+    let mut out = String::new();
+    for token in input.split_whitespace() {
+        if token.is_empty() {
+            continue;
+        }
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push('"');
+        for ch in token.chars() {
+            if ch == '"' {
+                // FTS5 escapes a literal double-quote inside a "..." string by
+                // doubling it.
+                out.push('"');
+            }
+            out.push(ch);
+        }
+        out.push('"');
+    }
+    if out.is_empty() { None } else { Some(out) }
+}
+
 /// Derive a stable signed 64-bit advisory lock key for repository upserts.
 ///
 /// Generated versioned repositories use this before pre-reading rows for
@@ -652,6 +696,63 @@ impl<T: DisplayTopicField> DisplayTopicField for Option<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fts5_match_quotes_plain_terms_and_ands_them() {
+        // A plain multi-word query becomes an implicit-AND of quoted phrases.
+        assert_eq!(
+            sqlite_fts5_match_query("rust web").as_deref(),
+            Some("\"rust\" \"web\"")
+        );
+        assert_eq!(
+            sqlite_fts5_match_query("hello").as_deref(),
+            Some("\"hello\"")
+        );
+    }
+
+    #[test]
+    fn fts5_match_neutralizes_operators_as_literals() {
+        // FTS5 operators are quoted into literal terms — never parsed as syntax.
+        assert_eq!(
+            sqlite_fts5_match_query("foo OR bar").as_deref(),
+            Some("\"foo\" \"OR\" \"bar\"")
+        );
+        assert_eq!(
+            sqlite_fts5_match_query("title:secret").as_deref(),
+            Some("\"title:secret\"")
+        );
+        assert_eq!(
+            sqlite_fts5_match_query("pre*").as_deref(),
+            Some("\"pre*\"")
+        );
+        assert_eq!(
+            sqlite_fts5_match_query("NEAR(a b)").as_deref(),
+            Some("\"NEAR(a\" \"b)\"")
+        );
+    }
+
+    #[test]
+    fn fts5_match_doubles_embedded_quotes() {
+        // An embedded double-quote is escaped by doubling, so it can never close
+        // the phrase early and inject trailing syntax.
+        assert_eq!(
+            sqlite_fts5_match_query("a\"b").as_deref(),
+            Some("\"a\"\"b\"")
+        );
+        assert_eq!(
+            sqlite_fts5_match_query("\" OR x").as_deref(),
+            Some("\"\"\"\" \"OR\" \"x\"")
+        );
+    }
+
+    #[test]
+    fn fts5_match_empty_input_is_none() {
+        // Empty / whitespace-only / no-token input yields None so the caller
+        // returns an empty page WITHOUT running any query (fail-closed).
+        assert_eq!(sqlite_fts5_match_query(""), None);
+        assert_eq!(sqlite_fts5_match_query("   "), None);
+        assert_eq!(sqlite_fts5_match_query("\t\n  \r"), None);
+    }
 
     #[test]
     fn conflict_variant_stores_all_fields() {

--- a/autumn/src/repository.rs
+++ b/autumn/src/repository.rs
@@ -543,10 +543,10 @@ pub trait AutumnSearchableModel {
     const SEARCH_FIELDS: &'static [(&'static str, char)];
 }
 
-/// Build a fail-closed SQLite FTS5 `MATCH` query string from raw user input
+/// Build a fail-closed `SQLite` FTS5 `MATCH` query string from raw user input
 /// (issue #1910).
 ///
-/// SQLite FTS5's `MATCH` right-hand operand is a query *language*, not a plain
+/// `SQLite` FTS5's `MATCH` right-hand operand is a query *language*, not a plain
 /// string: bare words are terms, but `AND` / `OR` / `NOT` / `NEAR`, a `col:`
 /// prefix, `*` (prefix), `^` (initial-token), `(`/`)` grouping, `"` phrases and
 /// a leading `-` are all operators. Passing raw user input straight to `MATCH`
@@ -721,10 +721,7 @@ mod tests {
             sqlite_fts5_match_query("title:secret").as_deref(),
             Some("\"title:secret\"")
         );
-        assert_eq!(
-            sqlite_fts5_match_query("pre*").as_deref(),
-            Some("\"pre*\"")
-        );
+        assert_eq!(sqlite_fts5_match_query("pre*").as_deref(), Some("\"pre*\""));
         assert_eq!(
             sqlite_fts5_match_query("NEAR(a b)").as_deref(),
             Some("\"NEAR(a\" \"b)\"")

--- a/autumn/src/repository.rs
+++ b/autumn/src/repository.rs
@@ -565,11 +565,10 @@ pub trait AutumnSearchableModel {
 /// never an unfiltered scan.
 #[must_use]
 pub fn sqlite_fts5_match_query(input: &str) -> Option<String> {
-    let mut out = String::new();
+    // Worst case (no embedded quotes to double): every byte kept plus the two
+    // surrounding quotes of a single token — pre-size to avoid reallocation.
+    let mut out = String::with_capacity(input.len() + 2);
     for token in input.split_whitespace() {
-        if token.is_empty() {
-            continue;
-        }
         if !out.is_empty() {
             out.push(' ');
         }

--- a/autumn/tests/sqlite_searchable_repository.rs
+++ b/autumn/tests/sqlite_searchable_repository.rs
@@ -2,7 +2,7 @@
 //! via **FTS5** (issue #1910).
 //!
 //! Postgres searchable repositories rank rows with a `tsvector` +
-//! `websearch_to_tsquery`/`ts_rank_cd` query. SQLite has no `tsvector`, so the
+//! `websearch_to_tsquery`/`ts_rank_cd` query. `SQLite` has no `tsvector`, so the
 //! generated codegen forks (via `backend_select!`): the `SQLite` arm queries an
 //! **external-content FTS5 virtual table** (`"<table>__fts"`, tokenized with
 //! `unicode61`) joined back to the base table (so the tenant / soft-delete /
@@ -351,7 +351,10 @@ async fn search_sanitizes_fts5_operators_on_sqlite() {
     // `OR` is a literal term, not the FTS5 OR operator. Raw FTS5 `alpha OR beta`
     // would match BOTH rows; sanitized it is the implicit-AND of three literal
     // phrases "alpha" AND "or" AND "beta", which no single row contains → empty.
-    let ored = repo.search("alpha OR beta").await.expect("search alpha OR beta");
+    let ored = repo
+        .search("alpha OR beta")
+        .await
+        .expect("search alpha OR beta");
     assert!(
         ored.is_empty(),
         "`OR` must be a literal, not an operator (no row has all of alpha/or/beta): {ored:?}"
@@ -360,13 +363,20 @@ async fn search_sanitizes_fts5_operators_on_sqlite() {
     // A bare `alpha` still matches its one row (the operator neutralization does
     // not break ordinary search).
     let alpha = repo.search("alpha").await.expect("search alpha");
-    assert_eq!(alpha.len(), 1, "plain term still matches its row: {alpha:?}");
+    assert_eq!(
+        alpha.len(),
+        1,
+        "plain term still matches its row: {alpha:?}"
+    );
     assert_eq!(alpha[0].title, "Alpha");
 
     // A `col:` column-filter operator is neutralized: "title:alpha" becomes the
     // literal phrase, whose tokens ("title","alpha") are AND-ed — no row contains
     // the token "title", so it matches nothing (never a targeted column search).
-    let colon = repo.search("title:alpha").await.expect("search title:alpha");
+    let colon = repo
+        .search("title:alpha")
+        .await
+        .expect("search title:alpha");
     assert!(
         colon.is_empty(),
         "`col:` must be neutralized to a literal, matching nothing here: {colon:?}"
@@ -382,7 +392,10 @@ async fn search_sanitizes_fts5_operators_on_sqlite() {
     );
 
     // FAIL-CLOSED: an all-operator query returns an empty page, never everything.
-    let all_ops = repo.search("OR NEAR *").await.expect("search all-operators");
+    let all_ops = repo
+        .search("OR NEAR *")
+        .await
+        .expect("search all-operators");
     assert!(
         all_ops.is_empty(),
         "an all-operator query must return empty, not every row: {all_ops:?}"
@@ -391,10 +404,13 @@ async fn search_sanitizes_fts5_operators_on_sqlite() {
     // FAIL-CLOSED: a whitespace-only query yields no tokens → empty result with
     // NO FTS query run (the sanitizer returns None).
     let blank = repo.search("   ").await.expect("blank search");
-    assert!(blank.is_empty(), "whitespace-only query returns nothing: {blank:?}");
+    assert!(
+        blank.is_empty(),
+        "whitespace-only query returns nothing: {blank:?}"
+    );
 }
 
-/// `search_page` returns the right page slice and total on SQLite.
+/// `search_page` returns the right page slice and total on `SQLite`.
 #[tokio::test]
 async fn search_page_paginates_on_sqlite() {
     let pool = boot_pool("search_page").await;
@@ -486,7 +502,7 @@ async fn search_ranks_title_above_body_on_sqlite() {
 
 /// ADVERSARIAL: fail-closed tenant isolation. A search run under tenant B must
 /// never return tenant A's rows even when the term matches. Without the
-/// `tenant_id = $n` predicate in the SQLite arm this would leak A's data.
+/// `tenant_id = $n` predicate in the `SQLite` arm this would leak A's data.
 #[tokio::test]
 async fn search_never_crosses_tenants_on_sqlite() {
     let pool = boot_pool("search_tenant").await;
@@ -559,7 +575,9 @@ async fn search_never_crosses_tenants_on_sqlite() {
     // operators, so neither layer can leak A's data.
     for probe in ["secret", "secret OR alpha", "tenant_id:tenant-a"] {
         let leaked = with_tenant("tenant-b".to_string(), async {
-            repo.search(probe).await.expect("adversarial search under tenant-b")
+            repo.search(probe)
+                .await
+                .expect("adversarial search under tenant-b")
         })
         .await;
         assert!(

--- a/autumn/tests/sqlite_searchable_repository.rs
+++ b/autumn/tests/sqlite_searchable_repository.rs
@@ -1,26 +1,31 @@
-//! `#[repository(searchable)]` full-text-search fallback on the `SQLite` runtime
-//! backend (issue #1996).
+//! `#[repository(searchable)]` full-text search on the `SQLite` runtime backend
+//! via **FTS5** (issue #1910).
 //!
 //! Postgres searchable repositories rank rows with a `tsvector` +
-//! `websearch_to_tsquery`/`ts_rank_cd` query, which has no `SQLite` equivalent.
-//! The generated codegen therefore forks (via `backend_select!`): the `SQLite`
-//! arm matches each `SEARCH_FIELDS` column with a case-insensitive
-//! `lower(col) LIKE '%term%' ESCAPE '\'` substring test, OR-ed across the fields,
-//! ordered `id DESC` (unranked — FTS5 ranking is a separate slice, #1910). This
-//! suite drives that fallback end-to-end on an in-memory `SQLite` database (no
+//! `websearch_to_tsquery`/`ts_rank_cd` query. SQLite has no `tsvector`, so the
+//! generated codegen forks (via `backend_select!`): the `SQLite` arm queries an
+//! **external-content FTS5 virtual table** (`"<table>__fts"`, tokenized with
+//! `unicode61`) joined back to the base table (so the tenant / soft-delete /
+//! owner predicates still filter the base table), `MATCH`-filtered and ranked
+//! with `bm25()` (per-column weights from the `#[searchable(weight=...)]`
+//! priorities). The user's query is run through the fail-closed
+//! `sqlite_fts5_match_query` sanitizer so no FTS5 operator survives as syntax.
+//! This suite drives that path end-to-end on an in-memory `SQLite` database (no
 //! Docker):
 //!
-//! * substring matches are found case-insensitively and non-matches excluded;
-//! * case-insensitivity is **ASCII-only** (the query is folded with
-//!   `to_ascii_lowercase()` to match `SQLite`'s ASCII-only `lower()`): ASCII
-//!   terms fold both ways, but a non-ASCII letter matches only with matching
-//!   case — full-Unicode/ICU folding is deferred to #1910;
-//! * `LIKE` metacharacters (`%`, `_`) in the query match **literally** and can
-//!   never become a match-everything wildcard;
+//! * token matches are found case-insensitively and non-matches excluded;
+//! * case-folding is **full-Unicode** now (via `unicode61`): `äpfel` matches
+//!   `Äpfel` (the old ASCII-only `lower()` limitation is gone) — the pinned
+//!   behavioral flip of #1910;
+//! * FTS5 query operators (`OR`, `col:`, `*`, …) are neutralized into literal
+//!   terms by the sanitizer, and an all-operator query returns an empty page
+//!   rather than everything (fail-closed);
+//! * `bm25()` ranking sorts a higher-priority-field (title) hit above a
+//!   lower-priority-field (body) hit;
 //! * `search_page` returns the right page + total;
 //! * **ADVERSARIAL cross-tenant isolation:** a search run under tenant B never
-//!   returns tenant A's rows even when the term matches (fail-closed tenant
-//!   isolation is inviolable);
+//!   returns tenant A's rows even when the term matches — including via an FTS5
+//!   injection attempt (fail-closed tenant isolation is inviolable);
 //! * the owner-scoped `search_page_scoped` path (#1841) never returns another
 //!   owner's rows.
 //!
@@ -37,9 +42,38 @@ use autumn_web::reexports::{diesel, diesel_async};
 use autumn_web::tenancy::with_tenant;
 
 use diesel_async::RunQueryDsl as _;
+use diesel_async::SimpleAsyncConnection as _;
 use diesel_async::pooled_connection::deadpool::Pool;
 
 type SqlitePool = Pool<RuntimeConnection>;
+
+/// The FTS5 DDL the `AddSearch` migration emits for a `(title, body)` searchable
+/// model: an external-content virtual table + the three maintenance triggers the
+/// generated `MATCH`/`bm25()` query relies on. Hand-authored here (the runtime
+/// suite hand-creates its tables rather than running the CLI migration) so it
+/// mirrors `autumn-cli`'s `add_search_up_sql_for(Sqlite, ...)` exactly. No
+/// `'rebuild'` backfill is needed — every table is created empty, then populated
+/// through `repo.save`, which fires the `AFTER INSERT` trigger.
+fn fts5_ddl(table: &str) -> String {
+    format!(
+        "CREATE VIRTUAL TABLE \"{table}__fts\" USING fts5(\"title\", \"body\", \
+             content='{table}', content_rowid='id', tokenize='unicode61'); \
+         CREATE TRIGGER \"{table}__fts_ai\" AFTER INSERT ON \"{table}\" BEGIN \
+             INSERT INTO \"{table}__fts\"(rowid, \"title\", \"body\") \
+                 VALUES (new.id, new.\"title\", new.\"body\"); \
+         END; \
+         CREATE TRIGGER \"{table}__fts_ad\" AFTER DELETE ON \"{table}\" BEGIN \
+             INSERT INTO \"{table}__fts\"(\"{table}__fts\", rowid, \"title\", \"body\") \
+                 VALUES('delete', old.id, old.\"title\", old.\"body\"); \
+         END; \
+         CREATE TRIGGER \"{table}__fts_au\" AFTER UPDATE ON \"{table}\" BEGIN \
+             INSERT INTO \"{table}__fts\"(\"{table}__fts\", rowid, \"title\", \"body\") \
+                 VALUES('delete', old.id, old.\"title\", old.\"body\"); \
+             INSERT INTO \"{table}__fts\"(rowid, \"title\", \"body\") \
+                 VALUES (new.id, new.\"title\", new.\"body\"); \
+         END;"
+    )
+}
 
 mod schema {
     autumn_web::reexports::diesel::table! {
@@ -138,8 +172,9 @@ async fn boot_pool(db_name: &str) -> SqlitePool {
 
     {
         let mut conn = pool.get().await.expect("checkout a sqlite connection");
-        // No `search_vector` column: the SQLite fallback matches the plain
-        // SEARCH_FIELDS columns directly.
+        // Base tables, plus the external-content FTS5 virtual table + triggers the
+        // generated `MATCH`/`bm25()` query joins against (the FTS objects live
+        // outside the model/schema surface, mirroring Postgres's `search_vector`).
         diesel::sql_query(
             "CREATE TABLE search_notes (\
                  id INTEGER PRIMARY KEY AUTOINCREMENT, \
@@ -150,6 +185,9 @@ async fn boot_pool(db_name: &str) -> SqlitePool {
         .execute(&mut *conn)
         .await
         .expect("create search_notes table");
+        conn.batch_execute(&fts5_ddl("search_notes"))
+            .await
+            .expect("create search_notes FTS5 objects");
         diesel::sql_query(
             "CREATE TABLE tenant_search_notes (\
                  id INTEGER PRIMARY KEY AUTOINCREMENT, \
@@ -161,6 +199,9 @@ async fn boot_pool(db_name: &str) -> SqlitePool {
         .execute(&mut *conn)
         .await
         .expect("create tenant_search_notes table");
+        conn.batch_execute(&fts5_ddl("tenant_search_notes"))
+            .await
+            .expect("create tenant_search_notes FTS5 objects");
         diesel::sql_query(
             "CREATE TABLE owner_search_notes (\
                  id INTEGER PRIMARY KEY AUTOINCREMENT, \
@@ -172,6 +213,9 @@ async fn boot_pool(db_name: &str) -> SqlitePool {
         .execute(&mut *conn)
         .await
         .expect("create owner_search_notes table");
+        conn.batch_execute(&fts5_ddl("owner_search_notes"))
+            .await
+            .expect("create owner_search_notes FTS5 objects");
     }
 
     pool
@@ -235,16 +279,15 @@ async fn search_matches_substrings_case_insensitively_on_sqlite() {
     assert!(blank.is_empty(), "blank query returns nothing: {blank:?}");
 }
 
-/// The `SQLite` search case-insensitivity is **ASCII-only** (issue #1996): the
-/// query side is folded with `to_ascii_lowercase()` to match `SQLite`'s built-in
-/// `lower()`, which folds only ASCII A–Z. So an ASCII term matches
-/// case-insensitively, and even an accented term's ASCII characters fold — but a
-/// non-ASCII letter matches only with matching case (full-Unicode/ICU folding is
-/// deferred to #1910 with FTS5 ranking). This test pins both halves so the code
-/// and the documented divergence agree.
+/// FTS5 case-folding is **full-Unicode** now (issue #1910): the `unicode61`
+/// tokenizer folds case (and diacritics) across the whole Unicode range, so the
+/// lowercase query `äpfel` matches the stored `Äpfel` — the exact case the old
+/// ASCII-only `lower()` fallback could NOT match (the pinned regression, now
+/// flipped). This test pins the flip so the code and the documented behavior
+/// agree.
 #[tokio::test]
-async fn search_case_insensitivity_is_ascii_only_on_sqlite() {
-    let pool = boot_pool("search_ascii_fold").await;
+async fn search_case_folding_is_full_unicode_on_sqlite() {
+    let pool = boot_pool("search_unicode_fold").await;
     let repo = PgSearchNoteRepository::with_pool_untracked(pool);
 
     repo.save(&NewSearchNote {
@@ -254,9 +297,7 @@ async fn search_case_insensitivity_is_ascii_only_on_sqlite() {
     .await
     .expect("save accented row");
 
-    // ── ASCII case-folding works ──
-    // A pure-ASCII term matches case-insensitively (uppercase query vs lowercase
-    // stored "apple").
+    // ── ASCII case-folding still works ──
     let ascii = repo.search("APPLE").await.expect("search APPLE");
     assert_eq!(
         ascii.len(),
@@ -264,91 +305,93 @@ async fn search_case_insensitivity_is_ascii_only_on_sqlite() {
         "ASCII term matches case-insensitively: {ascii:?}"
     );
 
-    // Even alongside a non-ASCII letter, the ASCII characters fold: query "ÄP"
-    // lowercases (ASCII-only) to "Äp", whose pattern `%Äp%` still matches the
-    // stored "Äpfel Tart" because SQLite's `lower()` leaves the non-ASCII "Ä"
-    // untouched on BOTH sides. (The old full-Unicode `to_lowercase()` folded the
-    // query's "Ä"→"ä", producing `%äp%` that never matched — the F4 bug.)
-    let mixed = repo.search("ÄP").await.expect("search ÄP");
+    // ── The #1910 flip: full-Unicode case-folding ──
+    // The lowercase non-ASCII query "äpfel" (U+00E4) now MATCHES the stored
+    // "Äpfel" (U+00C4) — `unicode61` folds the non-ASCII letter's case, so the
+    // whole-token match succeeds where the old ASCII-only `lower()` fallback
+    // produced two distinct codepoints and never matched (the old F4 limitation).
+    let folded = repo.search("äpfel").await.expect("search äpfel");
     assert_eq!(
-        mixed.len(),
+        folded.len(),
         1,
-        "ASCII 'P' folds even next to a non-ASCII letter, so 'ÄP' matches 'Äpfel': {mixed:?}"
+        "full-Unicode folding: lowercase 'äpfel' matches stored 'Äpfel' (#1910 flip): {folded:?}"
     );
 
-    // ── The ASCII-only limitation, documented ──
-    // A differently-cased non-ASCII query letter does NOT match: query "äpfel"
-    // (lowercase ä, U+00E4) folds to itself (ASCII-only), but the stored "Äpfel"
-    // keeps its uppercase "Ä" (U+00C4) through SQLite's ASCII-only `lower()`, so
-    // the two non-ASCII codepoints differ and no row matches. Full-Unicode case
-    // folding would match here; it is intentionally deferred (#1910).
-    let non_ascii = repo.search("äpfel").await.expect("search äpfel");
-    assert!(
-        non_ascii.is_empty(),
-        "non-ASCII case is NOT folded (ASCII-only limitation): 'äpfel' must not match 'Äpfel': {non_ascii:?}"
+    // And the reverse direction folds too (uppercase query vs stored title).
+    let folded_upper = repo.search("ÄPFEL").await.expect("search ÄPFEL");
+    assert_eq!(
+        folded_upper.len(),
+        1,
+        "full-Unicode folding is symmetric: 'ÄPFEL' matches stored 'Äpfel': {folded_upper:?}"
     );
 }
 
-/// LIKE metacharacters (`%`, `_`) in the query match literally — a query
-/// containing `%` can never become a match-everything wildcard.
+/// FTS5 query operators in the user's input are neutralized into literal terms
+/// by the fail-closed `sqlite_fts5_match_query` sanitizer (issue #1910), so a
+/// query can never inject FTS5 syntax, trigger a syntax error, or become a
+/// match-everything wildcard.
 #[tokio::test]
-async fn search_treats_like_metacharacters_literally_on_sqlite() {
-    let pool = boot_pool("search_metachars").await;
+async fn search_sanitizes_fts5_operators_on_sqlite() {
+    let pool = boot_pool("search_fts_ops").await;
     let repo = PgSearchNoteRepository::with_pool_untracked(pool);
 
     repo.save(&NewSearchNote {
-        title: "Sale".to_string(),
-        body: "50% off everything".to_string(),
+        title: "Alpha".to_string(),
+        body: "first note".to_string(),
     })
     .await
-    .expect("save percent row");
+    .expect("save alpha row");
     repo.save(&NewSearchNote {
-        title: "Sale".to_string(),
-        body: "50X off select items".to_string(),
+        title: "Beta".to_string(),
+        body: "second note".to_string(),
     })
     .await
-    .expect("save non-percent row");
-    repo.save(&NewSearchNote {
-        title: "Codes".to_string(),
-        body: "use a_b as the coupon".to_string(),
-    })
-    .await
-    .expect("save underscore row");
-    repo.save(&NewSearchNote {
-        title: "Codes".to_string(),
-        body: "use axb as the coupon".to_string(),
-    })
-    .await
-    .expect("save non-underscore row");
+    .expect("save beta row");
 
-    // `%` is escaped: "50%" matches only the literal-percent row, NOT "50X".
-    let pct = repo.search("50%").await.expect("search 50%");
-    assert_eq!(pct.len(), 1, "only the literal 50% row matches: {pct:?}");
+    // `OR` is a literal term, not the FTS5 OR operator. Raw FTS5 `alpha OR beta`
+    // would match BOTH rows; sanitized it is the implicit-AND of three literal
+    // phrases "alpha" AND "or" AND "beta", which no single row contains → empty.
+    let ored = repo.search("alpha OR beta").await.expect("search alpha OR beta");
     assert!(
-        pct[0].body.contains("50% off"),
-        "matched the wrong row: {pct:?}"
+        ored.is_empty(),
+        "`OR` must be a literal, not an operator (no row has all of alpha/or/beta): {ored:?}"
     );
 
-    // `_` is escaped: "a_b" matches only the literal-underscore row, NOT "axb"
-    // (an unescaped `_` would match any single char and catch "axb" too).
-    let underscore = repo.search("a_b").await.expect("search a_b");
-    assert_eq!(
-        underscore.len(),
-        1,
-        "only the literal a_b row matches, not axb: {underscore:?}"
-    );
+    // A bare `alpha` still matches its one row (the operator neutralization does
+    // not break ordinary search).
+    let alpha = repo.search("alpha").await.expect("search alpha");
+    assert_eq!(alpha.len(), 1, "plain term still matches its row: {alpha:?}");
+    assert_eq!(alpha[0].title, "Alpha");
+
+    // A `col:` column-filter operator is neutralized: "title:alpha" becomes the
+    // literal phrase, whose tokens ("title","alpha") are AND-ed — no row contains
+    // the token "title", so it matches nothing (never a targeted column search).
+    let colon = repo.search("title:alpha").await.expect("search title:alpha");
     assert!(
-        underscore[0].body.contains("a_b"),
-        "matched the wrong row: {underscore:?}"
+        colon.is_empty(),
+        "`col:` must be neutralized to a literal, matching nothing here: {colon:?}"
     );
 
-    // A bare `%` must NOT return everything (it would with an unescaped LIKE).
-    let bare_pct = repo.search("%").await.expect("search bare %");
-    assert_eq!(
-        bare_pct.len(),
-        1,
-        "a literal '%' matches only the row containing '%', never all rows: {bare_pct:?}"
+    // A `*` prefix operator is neutralized: "alph*" is a literal token "alph"
+    // (star stripped by the tokenizer), which is NOT the full token "alpha", so
+    // no prefix expansion happens and it matches nothing.
+    let prefix = repo.search("alph*").await.expect("search alph*");
+    assert!(
+        prefix.is_empty(),
+        "`*` prefix must be neutralized (no prefix expansion): {prefix:?}"
     );
+
+    // FAIL-CLOSED: an all-operator query returns an empty page, never everything.
+    let all_ops = repo.search("OR NEAR *").await.expect("search all-operators");
+    assert!(
+        all_ops.is_empty(),
+        "an all-operator query must return empty, not every row: {all_ops:?}"
+    );
+
+    // FAIL-CLOSED: a whitespace-only query yields no tokens → empty result with
+    // NO FTS query run (the sanitizer returns None).
+    let blank = repo.search("   ").await.expect("blank search");
+    assert!(blank.is_empty(), "whitespace-only query returns nothing: {blank:?}");
 }
 
 /// `search_page` returns the right page slice and total on SQLite.
@@ -401,6 +444,44 @@ async fn search_page_paginates_on_sqlite() {
         "second page holds the remaining row"
     );
     assert_eq!(page2.total_elements, 3);
+}
+
+/// bm25 ranking sanity (issue #1910): a hit in a higher-priority field (title,
+/// `#[searchable(weight = "A")]`) must rank above a hit in a lower-priority field
+/// (body, `weight = "B"`). The per-column bm25 weights are derived from those
+/// priorities, so the title match gets a more-negative (better) score and sorts
+/// first — parity with the Postgres `setweight('A' > 'B')` / `ts_rank_cd` intent.
+#[tokio::test]
+async fn search_ranks_title_above_body_on_sqlite() {
+    let pool = boot_pool("search_bm25_rank").await;
+    let repo = PgSearchNoteRepository::with_pool_untracked(pool);
+
+    // A body-only match, saved FIRST (higher id would otherwise win the id-DESC
+    // tiebreak — proving the ordering is genuinely by rank, not insertion order).
+    repo.save(&NewSearchNote {
+        title: "Gardening basics".to_string(),
+        body: "a quantum leap in tomatoes".to_string(),
+    })
+    .await
+    .expect("save body-match row");
+    // A title match, saved SECOND.
+    repo.save(&NewSearchNote {
+        title: "Quantum computing".to_string(),
+        body: "an introduction".to_string(),
+    })
+    .await
+    .expect("save title-match row");
+
+    let hits = repo.search("quantum").await.expect("search quantum");
+    assert_eq!(hits.len(), 2, "both rows match 'quantum': {hits:?}");
+    assert_eq!(
+        hits[0].title, "Quantum computing",
+        "the title (weight A) match must rank above the body (weight B) match: {hits:?}"
+    );
+    assert_eq!(
+        hits[1].title, "Gardening basics",
+        "the body-only match ranks second despite its lower id: {hits:?}"
+    );
 }
 
 /// ADVERSARIAL: fail-closed tenant isolation. A search run under tenant B must
@@ -469,6 +550,27 @@ async fn search_never_crosses_tenants_on_sqlite() {
     .await;
     assert_eq!(a_hits.len(), 1, "tenant-a sees its own row: {a_hits:?}");
     assert_eq!(a_hits[0].tenant_id, "tenant-a");
+
+    // ADVERSARIAL FTS injection: tenant B searches for a token that exists ONLY
+    // in tenant A's row ("secret", in A's body) — including an FTS5-operator
+    // injection attempt. The FTS `MATCH` genuinely matches A's row, but the
+    // `tenant_id = ?` predicate on the JOINed base table filters it out, so
+    // tenant B still sees nothing. The sanitizer additionally neutralizes the
+    // operators, so neither layer can leak A's data.
+    for probe in ["secret", "secret OR alpha", "tenant_id:tenant-a"] {
+        let leaked = with_tenant("tenant-b".to_string(), async {
+            repo.search(probe).await.expect("adversarial search under tenant-b")
+        })
+        .await;
+        assert!(
+            leaked.iter().all(|n| n.tenant_id == "tenant-b"),
+            "tenant-b must never see tenant-a rows via `{probe}`: {leaked:?}"
+        );
+        assert!(
+            leaked.is_empty(),
+            "`{probe}` matches only tenant-a data, so tenant-b sees nothing: {leaked:?}"
+        );
+    }
 }
 
 /// Owner-scoped `search_page_scoped` (#1841) never returns another owner's rows.

--- a/autumn/tests/sqlite_searchable_repository.rs
+++ b/autumn/tests/sqlite_searchable_repository.rs
@@ -101,9 +101,22 @@ mod schema {
             user_id -> Int8,
         }
     }
+
+    // Tenant-scoped model whose `tenant_id` is ALSO `#[searchable]`, so the
+    // generated FTS5 table carries a `tenant_id` column too — the exact column
+    // collision that makes an *unqualified* `AND tenant_id = ?` ambiguous once
+    // the base table is JOINed to `<table>__fts` (Codex P2 / #1910).
+    autumn_web::reexports::diesel::table! {
+        tenant_collision_notes (id) {
+            id -> Int8,
+            title -> Text,
+            body -> Text,
+            tenant_id -> Text,
+        }
+    }
 }
 
-use schema::{owner_search_notes, search_notes, tenant_search_notes};
+use schema::{owner_search_notes, search_notes, tenant_collision_notes, tenant_search_notes};
 
 // Plain searchable repository (no tenant, no owner).
 #[autumn_web::model(table = "search_notes")]
@@ -157,6 +170,34 @@ pub struct OwnerSearchNote {
 
 #[autumn_web::repository(OwnerSearchNote, table = "owner_search_notes", owner = user_id, searchable)]
 pub trait OwnerSearchNoteRepository {}
+
+// Tenant-scoped searchable repository whose `tenant_id` is itself `#[searchable]`.
+// Marking the tenant column searchable puts a `tenant_id` column on the generated
+// `tenant_collision_notes__fts` table, so the base↔FTS JOIN exposes two
+// `tenant_id` columns. The macro must qualify the tenant predicate as
+// `"tenant_collision_notes"."tenant_id"` or SQLite raises
+// `ambiguous column name: tenant_id` (Codex P2 / #1910).
+#[autumn_web::model(table = "tenant_collision_notes")]
+#[searchable(language = "english")]
+pub struct TenantCollisionNote {
+    #[id]
+    pub id: i64,
+    #[searchable(weight = "A")]
+    pub title: String,
+    #[searchable(weight = "B")]
+    pub body: String,
+    #[default]
+    #[searchable(weight = "C")]
+    pub tenant_id: String,
+}
+
+#[autumn_web::repository(
+    TenantCollisionNote,
+    table = "tenant_collision_notes",
+    tenant_scoped,
+    searchable
+)]
+pub trait TenantCollisionNoteRepository {}
 
 async fn boot_pool(db_name: &str) -> SqlitePool {
     // A shared-cache in-memory database so every pooled checkout observes the
@@ -216,6 +257,44 @@ async fn boot_pool(db_name: &str) -> SqlitePool {
         conn.batch_execute(&fts5_ddl("owner_search_notes"))
             .await
             .expect("create owner_search_notes FTS5 objects");
+        diesel::sql_query(
+            "CREATE TABLE tenant_collision_notes (\
+                 id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                 title TEXT NOT NULL, \
+                 body TEXT NOT NULL, \
+                 tenant_id TEXT NOT NULL\
+             )",
+        )
+        .execute(&mut *conn)
+        .await
+        .expect("create tenant_collision_notes table");
+        // FTS5 objects for the collision model: the indexed columns are
+        // (title, body, tenant_id) in SEARCH_FIELDS order — `tenant_id` is
+        // indexed here precisely to reproduce the base↔FTS `tenant_id` collision.
+        conn.batch_execute(
+            "CREATE VIRTUAL TABLE \"tenant_collision_notes__fts\" USING fts5(\
+                 \"title\", \"body\", \"tenant_id\", \
+                 content='tenant_collision_notes', content_rowid='id', tokenize='unicode61'); \
+             CREATE TRIGGER \"tenant_collision_notes__fts_ai\" \
+                 AFTER INSERT ON \"tenant_collision_notes\" BEGIN \
+                 INSERT INTO \"tenant_collision_notes__fts\"(rowid, \"title\", \"body\", \"tenant_id\") \
+                     VALUES (new.id, new.\"title\", new.\"body\", new.\"tenant_id\"); \
+             END; \
+             CREATE TRIGGER \"tenant_collision_notes__fts_ad\" \
+                 AFTER DELETE ON \"tenant_collision_notes\" BEGIN \
+                 INSERT INTO \"tenant_collision_notes__fts\"(\"tenant_collision_notes__fts\", rowid, \"title\", \"body\", \"tenant_id\") \
+                     VALUES('delete', old.id, old.\"title\", old.\"body\", old.\"tenant_id\"); \
+             END; \
+             CREATE TRIGGER \"tenant_collision_notes__fts_au\" \
+                 AFTER UPDATE ON \"tenant_collision_notes\" BEGIN \
+                 INSERT INTO \"tenant_collision_notes__fts\"(\"tenant_collision_notes__fts\", rowid, \"title\", \"body\", \"tenant_id\") \
+                     VALUES('delete', old.id, old.\"title\", old.\"body\", old.\"tenant_id\"); \
+                 INSERT INTO \"tenant_collision_notes__fts\"(rowid, \"title\", \"body\", \"tenant_id\") \
+                     VALUES (new.id, new.\"title\", new.\"body\", new.\"tenant_id\"); \
+             END;",
+        )
+        .await
+        .expect("create tenant_collision_notes FTS5 objects");
     }
 
     pool
@@ -589,6 +668,98 @@ async fn search_never_crosses_tenants_on_sqlite() {
             "`{probe}` matches only tenant-a data, so tenant-b sees nothing: {leaked:?}"
         );
     }
+}
+
+/// Codex P2 (#1910): when the tenant column is itself `#[searchable]`, the
+/// generated FTS5 table also carries a `tenant_id` column, so the base↔FTS JOIN
+/// exposes two `tenant_id` columns. Before the fix the unqualified
+/// `AND tenant_id = ?` made SQLite raise `ambiguous column name: tenant_id`
+/// (`.expect` below would panic). The macro now qualifies every base-table
+/// predicate as `"tenant_collision_notes"."tenant_id"` (and `.deleted_at`,
+/// the owner col, the selected/ordered `.id`), so search resolves cleanly AND
+/// tenant isolation still holds under the FTS join.
+#[tokio::test]
+async fn search_tenant_predicate_is_base_table_qualified_on_sqlite() {
+    let pool = boot_pool("search_tenant_collision").await;
+    let repo = PgTenantCollisionNoteRepository::with_pool_untracked(pool);
+
+    // Tenant A and tenant B both own a row whose title matches "report".
+    with_tenant("tenant-a".to_string(), async {
+        repo.save(&NewTenantCollisionNote {
+            title: "Alpha Report".to_string(),
+            body: "tenant a private note".to_string(),
+        })
+        .await
+        .expect("save under tenant-a");
+    })
+    .await;
+    with_tenant("tenant-b".to_string(), async {
+        repo.save(&NewTenantCollisionNote {
+            title: "Bravo Report".to_string(),
+            body: "tenant b private note".to_string(),
+        })
+        .await
+        .expect("save under tenant-b");
+    })
+    .await;
+
+    // The `.expect` here is the load-bearing assertion: with an unqualified
+    // tenant predicate SQLite would raise `ambiguous column name: tenant_id`
+    // and this would panic. It resolves — the predicate is base-table-qualified.
+    let b_hits = with_tenant("tenant-b".to_string(), async {
+        repo.search("report")
+            .await
+            .expect("search must not raise `ambiguous column name: tenant_id`")
+    })
+    .await;
+    assert_eq!(
+        b_hits.len(),
+        1,
+        "tenant-b sees exactly its own matching row (no ambiguity, no leak): {b_hits:?}"
+    );
+    assert_eq!(b_hits[0].tenant_id, "tenant-b", "no cross-tenant leak");
+    assert_eq!(b_hits[0].title, "Bravo Report");
+
+    // The paginated path (count + select, both JOIN the FTS table) is qualified too.
+    let req = PageRequest::new(1, 10);
+    let b_page = with_tenant("tenant-b".to_string(), async {
+        repo.search_page("report", &req)
+            .await
+            .expect("search_page must not raise `ambiguous column name: tenant_id`")
+    })
+    .await;
+    assert_eq!(
+        b_page.total_elements, 1,
+        "tenant-b's paged total counts only its own rows: {:?}",
+        b_page.content
+    );
+    assert!(
+        b_page.content.iter().all(|n| n.tenant_id == "tenant-b"),
+        "no cross-tenant row in the page: {:?}",
+        b_page.content
+    );
+
+    // Tenant A still finds its own row (search genuinely works per tenant).
+    let a_hits = with_tenant("tenant-a".to_string(), async {
+        repo.search("report").await.expect("search under tenant-a")
+    })
+    .await;
+    assert_eq!(a_hits.len(), 1, "tenant-a sees its own row: {a_hits:?}");
+    assert_eq!(a_hits[0].tenant_id, "tenant-a");
+
+    // ADVERSARIAL: a token present only in tenant A's row must never surface for
+    // tenant B — the FTS MATCH hits A's row, the qualified tenant predicate on
+    // the JOINed base table filters it out.
+    let leaked = with_tenant("tenant-b".to_string(), async {
+        repo.search("private note")
+            .await
+            .expect("adversarial search under tenant-b")
+    })
+    .await;
+    assert!(
+        leaked.iter().all(|n| n.tenant_id == "tenant-b"),
+        "tenant-b must never see tenant-a rows: {leaked:?}"
+    );
 }
 
 /// Owner-scoped `search_page_scoped` (#1841) never returns another owner's rows.


### PR DESCRIPTION
## Before / After (what a searchable-repo caller experiences on SQLite)

**Before:** On the SQLite backend, `#[repository(..., searchable)]` fell back to an ASCII-only `lower(col) LIKE '%term%'` substring match over `SEARCH_FIELDS`, ordered `id DESC` (unranked). Non-ASCII case-folding did not work (`äpfel` never matched `Äpfel`). The `--search` / `#[searchable]` generator scaffold was **rejected at generate time** on SQLite, citing this issue.

**After:** SQLite searchable repositories run real **FTS5** full-text search — `unicode61` tokenization (full-Unicode case/diacritic folding, so `äpfel` matches `Äpfel`), **bm25** ranking with per-column weights derived from the `#[searchable(weight=...)]` priorities, and a **fail-closed, injection-safe** MATCH query builder. `--search` now scaffolds on both backends. Tenant / soft-delete / owner isolation is preserved exactly.

## How

- **FTS5 table = external-content virtual table.** The `AddSearch` migration's new SQLite arm emits `CREATE VIRTUAL TABLE "<t>__fts" USING fts5(<searchcols>, content='<t>', content_rowid='id', tokenize='unicode61')`, kept in sync with `AFTER INSERT/DELETE/UPDATE` triggers, backfilled via the FTS5 `'rebuild'` command; `down.sql` drops the triggers + table. The base table stays the source of truth (mirrors Postgres's `search_vector` generated column — the FTS objects live outside the model/schema surface).
- **Macro query swap.** The generated `search` / `search_page` / `search_page_scoped` SQLite `backend_select!` arms now join `"<t>__fts"` to the base table, match with `WHERE "<t>__fts" MATCH ?`, and rank with `ORDER BY bm25("<t>__fts", <weights>), id DESC`. The **tenant / soft-delete / owner predicates and the two-phase (SELECT ids → hydrate) shape are unchanged** — only the id-selection SQL + ORDER BY changed. bm25 weights: A=10, B=5, C=2, else 1 (higher priority → more-negative bm25 → sorts first).
- **Fail-closed sanitization.** New pure helper `repository::sqlite_fts5_match_query(&str) -> Option<String>`: tokenizes on Unicode whitespace, wraps each token in a quoted `"..."` phrase (embedded quotes doubled), joins with implicit-AND spaces. Every FTS5 operator (`AND`/`OR`/`NOT`/`NEAR`/`col:`/`*`/parens/quotes/`-`) becomes a literal term. Empty/whitespace/no-token input returns `None`, and the caller then yields an **empty page with no query run** — never an unfiltered scan.
- **Capability probe.** `libsqlite3-sys` is built bundled (amalgamation defines `SQLITE_ENABLE_FTS5`), and the `sqlite` cargo feature now pulls it in explicitly so FTS5 is available even under `--no-default-features --features sqlite`. `build_sqlite_pool`'s per-connection setup probes FTS5 (create + drop a throwaway `temp` fts5 table) and fails loudly with an actionable message if it's missing — **no silent LIKE downgrade**. The AddSearch migration's `CREATE VIRTUAL TABLE` is the hard stop at boot.

## Tenant-isolation guarantee

FTS5 indexes only the search columns, so the tenant/soft-delete/owner predicates filter the **base table** via the join, exactly as the LIKE path did. An adversarial test drives an FTS injection attempt (`secret`, `secret OR alpha`, `tenant_id:tenant-a`) from tenant B against tokens that exist only in tenant A's rows — the MATCH genuinely hits A's row, but the `tenant_id = ?` predicate filters it out, so B sees nothing.

## Tests

- **Macro golden** (`autumn-macros`): the three searchable-fork tests updated to assert the FTS5 MATCH + bm25 SQL, keeping the tenant / soft-delete / owner predicate assertions in the new golden output. Unit tests for `sqlite_fts5_match_query` (operator neutralization, quote-doubling, empty→None).
- **CLI** (`autumn-cli`): the two reject tests flipped to assert FTS5 DDL (vtable + triggers + rebuild, down.sql drops, no tsvector/GIN leak); a schema_edit unit test for the SQLite DDL builder.
- **SQLite runtime** (`autumn/tests/sqlite_searchable_repository.rs`): flipped the pinned case-folding test (`äpfel` now matches `Äpfel`); replaced the LIKE-metachar test with an FTS5 operator-sanitization + fail-closed test (`OR NEAR *` → empty, not everything); added a bm25 ranking-sanity test (title-field hit ranks above body-field hit); strengthened cross-tenant + owner-scoped isolation with injection probes.

## Verification run (locally, both lanes)

- `cargo fmt --all -- --check` — PASS
- `cargo test -p autumn-macros` — PASS (572)
- `cargo clippy --workspace --all-targets -- -D warnings` (pg lane) — PASS
- `cargo build -p autumn-web` / `cargo build -p autumn-cli` — PASS
- `cargo build -p autumn-web --features sqlite` — PASS
- `cargo clippy -p autumn-web --features sqlite --lib -- -D warnings` — PASS
- `cargo test -p autumn-web --features "sqlite,test-support" --test sqlite_searchable_repository` — PASS (7)

(clippy run with system stable clippy 0.1.94; CI targets 1.97 — the lints exercised, `doc_markdown` / `doc_lazy_continuation`, exist in both.)

## Docs follow-up (out of scope for this PR)

`docs/guide/sqlite-in-production.md` still asserts the old "FTS rejected at generate time / deferred (#1910)" claim (around L150 / L186 / L314) and `docs/guide/full-text-search.md` has no SQLite section. These should be corrected in the docs batch — this PR corrects only the source rustdoc.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hmi69LxECaxbHAuALnVB9T)_