### PR TITLE
ci: refresh deploy-real-vps server-type preference list to current Hetzner plans

### DIFF
--- a/.github/workflows/deploy-real-vps.yml
+++ b/.github/workflows/deploy-real-vps.yml
@@ -126,11 +126,20 @@ jobs:
           set -euo pipefail
           hcloud ssh-key create --name "${HCLOUD_SSH_KEY_NAME}" --public-key-from-file "${SSH_KEY}.pub"
 
-          # Cheapest-first preference list. The workflow_dispatch `server_type`
-          # input is kept for backward-compat but is now only a HINT: it is tried
-          # first when set (empty on scheduled runs), then the live selection is
-          # authoritative — a retired/sold-out hint simply falls through.
-          PREF_TYPES="${{ inputs.server_type }} cpx22 cx32 cpx31 cpx41 cx42 cpx51"
+          # Cheapest-first preference list of CURRENT Hetzner shared-vCPU plans
+          # (verified 2026-07 against docs.hetzner.cloud/changelog): cost-optimized
+          # Intel `cx*3` (cx23/cx33/cx43/cx53) interleaved small->large with AMD
+          # `cpx*` (cpx22/cpx32/cpx42/cpx52/cpx62). The prior cx22/cx32/cx42/cx52
+          # and cpx11/cpx21/cpx31/cpx41/cpx51 generations were retired for new
+          # orders on 2026-01-01, so those names are dropped (a stale name is
+          # harmless — it just never matches — but omitting a current one is the
+          # bug this list guards against). Refresh when Hetzner retires a
+          # generation (watch the changelog for the next server-type deprecation).
+          # The workflow_dispatch `server_type` input is kept for backward-compat
+          # but is now only a HINT: it is tried first when set (empty on scheduled
+          # runs), then the live selection is authoritative — a retired/sold-out
+          # hint simply falls through.
+          PREF_TYPES="${{ inputs.server_type }} cx23 cpx22 cx33 cpx32 cx43 cpx42 cx53 cpx52 cpx62"
           # Configured location first, then EU fallbacks (deduped, order kept).
           LOCATIONS="${{ inputs.location || 'nbg1' }} fsn1 hel1 nbg1"
 


### PR DESCRIPTION
## Before / After

**Before:** the runtime live-selection preference list still named Hetzner plans that were **retired for new orders on 2026-01-01** — `cx32`, `cpx31`, `cpx41`, `cx42`, `cpx51` (only `cpx22` in the list is still current). If `cpx22` is ever sold out in all three fallback locations at once, no other name in the list is orderable, so the step would hard-fail even though larger current-generation plans (`cpx32`/`cpx42`/`cpx52`, the `cx*3` cost-optimized line) are freely orderable — reintroducing the exact "guessed-wrong-static-type" failure class #2048 removed.

**After:** `PREF_TYPES` lists only **current, cheapest-first** shared-vCPU plans, so the runtime selector (first orderable name across the fallback locations) practically always finds an orderable plan and the fail-with-table branch stays a pure diagnostic.

```
- PREF_TYPES="${{ inputs.server_type }} cpx22 cx32 cpx31 cpx41 cx42 cpx51"
+ PREF_TYPES="${{ inputs.server_type }} cx23 cpx22 cx33 cpx32 cx43 cpx42 cx53 cpx52 cpx62"
```

### Verified plan lineup (docs.hetzner.cloud/changelog, 2026-07)

- **Retired for new orders 2026-01-01** — Intel `cx22/cx32/cx42/cx52` and AMD `cpx11/cpx21/cpx31/cpx41/cpx51`. (Codex flagged `cx32/cx42/cpx31/cpx41/cpx51`; the changelog additionally retires the whole `cx2*` Intel generation, including `cx22` — which earlier runs already saw fail to order.)
- **Current AMD** — `cpx12`, `cpx22`, `cpx32`, `cpx42`, `cpx52`, `cpx62` (introduced Oct 2025).
- **Current cost-optimized Intel** — `cx23`, `cx33`, `cx43`, `cx53` (introduced Oct 2025).

New list interleaves the cost-optimized `cx*3` line with the AMD `cpx*` line small→large. The tiny 2 GB `cpx12` is deliberately omitted (too small to build/deploy on, matching the original list's choice to start at the 4 GB tier). A stale name in the list is harmless (it never matches); omitting a current one was the bug — so the list errs toward including every current-generation name.

## How

`PREF_TYPES` contents only, plus the adjacent comment (now naming the current plans + a note to refresh when Hetzner retires a generation). The jq/loop/`$GITHUB_ENV`/fail-table logic is unchanged — the selection mechanism from #2048 is untouched.

- `python3 -c "import yaml; yaml.safe_load(...)"` → yaml ok
- `bash -n` on the provision step body → rc 0

---

Addresses the Codex review on #2048; Part of #2019.

_Note: the trunk-tip Quickstart Gate red is a pre-existing, unrelated failure in another lane._

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPw736F7Hs65HQ6nZTD4Pa)_