### PR TITLE
ci: add cargo-deny supply-chain gating (advisories/licenses/sources)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,20 @@ jobs:
         # job on any real product finding.
         run: cargo run -p autumn-cli --bin autumn -- a11y verify .
 
+  supply-chain:
+    name: Supply chain (cargo-deny)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny@0.20.2
+      - name: cargo-deny check
+        run: cargo deny check advisories licenses sources
+      - name: cargo-deny check (sqlite backend graph)
+        run: cargo deny --config deny-sqlite.toml check advisories licenses sources
+
   test:
     name: Test (${{ matrix.os }})
     needs: [lint, meta]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,3 +241,28 @@ Reviewers should treat a new request-path parser with neither as incomplete.
 
 [cargo-fuzz]: https://github.com/rust-fuzz/cargo-fuzz
 [issue-1611]: https://github.com/madmax983/autumn/issues/1611
+
+## Supply chain (cargo-deny)
+
+The `supply-chain` CI job (`.github/workflows/ci.yml`) runs `cargo deny check
+advisories licenses sources` **twice** against a pinned cargo-deny (0.20.2):
+once on the checked-in `deny.toml` (the default + Postgres + additive CI feature
+graph) and once on `deny-sqlite.toml` (the mutually-exclusive sqlite backend
+graph). The two configs share the same advisories/licenses/sources policy — keep
+them in sync — and differ only in their `[graph]` features. All three checks —
+advisories (RustSec), licenses (allow-list, including dev- and build-dependency
+licenses), and sources (crate registries) — are **blocking** in both passes, so
+a PR that introduces a new advisory, an un-allowed license, or an unknown source
+registry will fail CI. The step-by-step for triaging a failing advisory (prefer
+a minimal fix; document an ignore with a reason and a review-by date only when
+no fix exists) lives in the header comment of `deny.toml`.
+
+**Scope.** The gate covers the shipped root workspace — the default plus
+additive Postgres feature graph (`deny.toml`) and the mutually-exclusive sqlite
+backend graph (`deny-sqlite.toml`), including dev- and build-dependency
+licenses. The repository's separate *excluded* sub-workspaces — `fuzz/` and
+`examples/island-flock`, which each declare their own `[workspace]` and are
+excluded from the root `Cargo.toml` — are non-shipped harnesses/examples and are
+not gated here. Adding a per-sub-workspace cargo-deny pass (each needs its own
+config, and `fuzz/Cargo.lock` is currently out of sync with its manifest) is a
+possible follow-up.

--- a/deny-sqlite.toml
+++ b/deny-sqlite.toml
@@ -1,0 +1,108 @@
+# Companion cargo-deny config for the SQLite backend graph (issue #2040 / #1600).
+#
+# The main deny.toml scans the default + Postgres + additive-feature graph; the
+# sqlite and postgres backends are mutually exclusive, so this second config
+# scans the `autumn-web/sqlite` graph. CI runs BOTH:
+#   cargo deny check advisories licenses sources
+#   cargo deny --config deny-sqlite.toml check advisories licenses sources
+#
+# KEEP [advisories].ignore, [licenses].allow, and [sources] IN SYNC with
+# deny.toml — only the [graph] features and the unused-ignored-advisory knob
+# below intentionally differ. See CONTRIBUTING.md and deny.toml's header for how
+# to triage a failing check.
+
+[graph]
+# The SQLite backend graph: default features + autumn-web/sqlite. NOT the
+# additive Postgres set (sqlite flips the backend and is mutually exclusive with
+# managed-pg/pq-sys), and NOT --all-features. Purpose: catch any dependency
+# reachable only from the sqlite backend (the `SQLite runtime` CI job builds it).
+all-features = false
+no-default-features = false
+features = ["autumn-web/sqlite"]
+
+[advisories]
+# RustSec advisory database. Cover the ENTIRE resolved dependency graph
+# (transitive included), not just direct/workspace crates: vulnerabilities are
+# always denied, and unmaintained + unsound are set explicitly to "all" rather
+# than relying on cargo-deny's version-dependent default scope, so no advisory
+# anywhere in the tree can slip past this gate. Yanked crates stay at the
+# default `warn` (currently spin 0.9.8 / 0.10.0, transitive) — tracked but
+# non-blocking.
+# The RUSTSEC-2024-0384 (instant) ignore enters only via managed-pg-bundled,
+# which is not in the sqlite graph, so it is legitimately unused here — don't
+# warn on it (the shared ignore list is kept identical to deny.toml on purpose).
+unused-ignored-advisory = "allow"
+unmaintained = "all"
+unsound = "all"
+yanked = "warn"
+ignore = [
+    # RUSTSEC-2023-0071 — rsa 0.9.x "Marvin Attack" timing sidechannel.
+    # No patched rsa release exists (advisory: "no safe upgrade available").
+    # Ingress: rsa 0.9.10 -> jsonwebtoken -> autumn-web, i.e. only the RSA-family
+    # JWT sign/verify path. Autumn exposes no network-reachable attacker-timed
+    # RSA private-key decryption oracle, so real exposure is limited. Tracked by
+    # issue #1600. Review-by: 2026-10-01 (or when a fixed rsa ships).
+    { id = "RUSTSEC-2023-0071", reason = "no fixed rsa release; RSA-JWT path only via jsonwebtoken; tracked in #1600; review-by 2026-10-01" },
+    # RUSTSEC-2026-0173 — proc-macro-error2 unmaintained. Build-time proc-macro
+    # only, pulled transitively by validator_derive -> validator 0.20. Not a
+    # runtime vulnerability and no safe upgrade. Review-by: 2026-10-01 (drop when
+    # validator ships a release that migrates off proc-macro-error2).
+    { id = "RUSTSEC-2026-0173", reason = "unmaintained build-time proc-macro via validator 0.20; no safe upgrade; review-by 2026-10-01" },
+    # RUSTSEC-2024-0384 — instant unmaintained. Build-time, transitive, and only
+    # pulled in by the managed-pg-bundled feature scanned above:
+    # instant -> parking_lot -> reqwest-retry -> postgresql_archive ->
+    # (build) postgresql_embedded -> autumn-web. Not a runtime vulnerability and no
+    # safe upgrade (author recommends web-time). Review-by: 2026-10-01.
+    { id = "RUSTSEC-2024-0384", reason = "instant unmaintained; build-time transitive via postgresql_embedded (managed-pg-bundled feature); no safe upgrade; review-by 2026-10-01" },
+]
+
+[licenses]
+# The initial tree is entirely permissive (plus weak, file-level MPL-2.0). This
+# allow-list is BLOCKING: a dependency introducing an unlisted license fails CI.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-1-Clause",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "0BSD",
+    "ISC",
+    "Zlib",
+    "BSL-1.0",
+    "CC0-1.0",
+    "Unicode-3.0",
+    "MIT-0",
+    "Unlicense",
+    "CDLA-Permissive-2.0",
+    "PostgreSQL",
+    # MPL-2.0 is weak, file-level copyleft (the cssparser/selectors stack). It
+    # imposes obligations only on modifications to those upstream files, none on
+    # Autumn's own source, so it is deliberately allowed.
+    "MPL-2.0",
+]
+confidence-threshold = 0.8
+# Gate dev- and build-dependency licenses too (both default false for the
+# licenses check; advisories/sources already include dev+build deps). CI's
+# `cargo test --workspace` compiles dev-dependencies, so their licenses are in
+# scope for this gate.
+include-dev = true
+include-build = true
+
+[licenses.private]
+# The workspace's own example/benchmark crates carry no `license` field; do not
+# fail the gate on first-party unpublished crates.
+ignore = true
+
+[bans]
+# NOT run in CI. Duplicate versions are pervasive and cosmetic in this tree
+# (RustCrypto old/new, windows-sys target shims), so keep them at `warn` for
+# local `cargo deny check bans` runs rather than fighting the tree.
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+# All dependencies come from crates.io; there are no git sources. BLOCKING.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,121 @@
+# cargo-deny configuration — supply-chain gating for the Autumn workspace.
+#
+# CI runs `cargo deny check advisories licenses sources` in the `supply-chain`
+# job (.github/workflows/ci.yml). All three checks are BLOCKING: the initial
+# inventory was clean, so a new advisory, an un-allowed license, or an unknown
+# source registry will fail CI. `bans` (duplicate versions) is intentionally not
+# run in CI — see the [bans] note below.
+#
+# ── Handling a supply-chain check that fails CI ────────────────────────────
+# When the `supply-chain` job fails on a PR:
+#   1. Read the RUSTSEC id / license / source and the dependency path cargo-deny
+#      prints.
+#   2. Prefer a FIX: `cargo update -p <crate>` to a patched version, or bump the
+#      direct dependency that pulls it in. Keep the bump minimal and in its own
+#      commit, justified in the PR body.
+#   3. If NO fix exists (advisory says "no safe upgrade available"), add an entry
+#      to `[advisories] ignore` below with: the RUSTSEC id, a `reason` citing why
+#      the exposure is acceptable for Autumn, and a review-by date. Ignores are
+#      debt — revisit them when a fix ships.
+#   4. A genuinely-new license or source is handled the same way: drop/replace
+#      the dependency, or deliberately add it to `[licenses] allow` / the
+#      `[sources]` allow-lists.
+# ───────────────────────────────────────────────────────────────────────────
+
+[graph]
+# Scan the default feature set PLUS every additive feature CI actually compiles,
+# so an advisory/license/source introduced through any CI-built feature dependency
+# can't slip past this gate. This list mirrors ci.yml's Postgres-backend feature
+# build (the feature-flags + coverage jobs' PG_FEATURES set) — i.e. all autumn-web
+# features EXCEPT `sqlite`. NOT --all-features, and `sqlite` is excluded, because
+# the sqlite and postgres backends are mutually exclusive (a single graph enabling
+# both is invalid); the sqlite-only deps (e.g. libsqlite3-sys) are already pulled
+# unconditionally by the `db` feature so they are in this graph regardless, and a
+# companion `deny-sqlite.toml` scans the sqlite backend graph in a second CI
+# pass (see below).
+all-features = false
+no-default-features = false
+features = ["autumn-web/ws", "autumn-web/presence", "autumn-web/flash", "autumn-web/cache-moka", "autumn-web/maud", "autumn-web/htmx", "autumn-web/multipart", "autumn-web/tailwind", "autumn-web/http-client", "autumn-web/oauth2", "autumn-web/webauthn", "autumn-web/openapi", "autumn-web/mcp", "autumn-web/markdown", "autumn-web/db", "autumn-web/offline-sync", "autumn-web/test-support", "autumn-web/telemetry-otlp", "autumn-web/redis", "autumn-web/i18n", "autumn-web/embed-assets", "autumn-web/storage", "autumn-web/variants", "autumn-web/reporting", "autumn-web/mail", "autumn-web/inbound-mail", "autumn-web/inbound-mailgun", "autumn-web/inbound-ses", "autumn-web/seed", "autumn-web/system-info", "autumn-web/csv", "autumn-web/system-tests", "autumn-web/managed-pg", "autumn-web/managed-pg-bundled", "autumn-web/tls", "autumn-web/acme"]
+
+[advisories]
+# RustSec advisory database. Cover the ENTIRE resolved dependency graph
+# (transitive included), not just direct/workspace crates: vulnerabilities are
+# always denied, and unmaintained + unsound are set explicitly to "all" rather
+# than relying on cargo-deny's version-dependent default scope, so no advisory
+# anywhere in the tree can slip past this gate. Yanked crates stay at the
+# default `warn` (currently spin 0.9.8 / 0.10.0, transitive) — tracked but
+# non-blocking.
+unmaintained = "all"
+unsound = "all"
+yanked = "warn"
+ignore = [
+    # RUSTSEC-2023-0071 — rsa 0.9.x "Marvin Attack" timing sidechannel.
+    # No patched rsa release exists (advisory: "no safe upgrade available").
+    # Ingress: rsa 0.9.10 -> jsonwebtoken -> autumn-web, i.e. only the RSA-family
+    # JWT sign/verify path. Autumn exposes no network-reachable attacker-timed
+    # RSA private-key decryption oracle, so real exposure is limited. Tracked by
+    # issue #1600. Review-by: 2026-10-01 (or when a fixed rsa ships).
+    { id = "RUSTSEC-2023-0071", reason = "no fixed rsa release; RSA-JWT path only via jsonwebtoken; tracked in #1600; review-by 2026-10-01" },
+    # RUSTSEC-2026-0173 — proc-macro-error2 unmaintained. Build-time proc-macro
+    # only, pulled transitively by validator_derive -> validator 0.20. Not a
+    # runtime vulnerability and no safe upgrade. Review-by: 2026-10-01 (drop when
+    # validator ships a release that migrates off proc-macro-error2).
+    { id = "RUSTSEC-2026-0173", reason = "unmaintained build-time proc-macro via validator 0.20; no safe upgrade; review-by 2026-10-01" },
+    # RUSTSEC-2024-0384 — instant unmaintained. Build-time, transitive, and only
+    # pulled in by the managed-pg-bundled feature scanned above:
+    # instant -> parking_lot -> reqwest-retry -> postgresql_archive ->
+    # (build) postgresql_embedded -> autumn-web. Not a runtime vulnerability and no
+    # safe upgrade (author recommends web-time). Review-by: 2026-10-01.
+    { id = "RUSTSEC-2024-0384", reason = "instant unmaintained; build-time transitive via postgresql_embedded (managed-pg-bundled feature); no safe upgrade; review-by 2026-10-01" },
+]
+
+[licenses]
+# The initial tree is entirely permissive (plus weak, file-level MPL-2.0). This
+# allow-list is BLOCKING: a dependency introducing an unlisted license fails CI.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-1-Clause",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "0BSD",
+    "ISC",
+    "Zlib",
+    "BSL-1.0",
+    "CC0-1.0",
+    "Unicode-3.0",
+    "MIT-0",
+    "Unlicense",
+    "CDLA-Permissive-2.0",
+    "PostgreSQL",
+    # MPL-2.0 is weak, file-level copyleft (the cssparser/selectors stack). It
+    # imposes obligations only on modifications to those upstream files, none on
+    # Autumn's own source, so it is deliberately allowed.
+    "MPL-2.0",
+]
+confidence-threshold = 0.8
+# Gate dev- and build-dependency licenses too (both default false for the
+# licenses check; advisories/sources already include dev+build deps). CI's
+# `cargo test --workspace` compiles dev-dependencies, so their licenses are in
+# scope for this gate.
+include-dev = true
+include-build = true
+
+[licenses.private]
+# The workspace's own example/benchmark crates carry no `license` field; do not
+# fail the gate on first-party unpublished crates.
+ignore = true
+
+[bans]
+# NOT run in CI. Duplicate versions are pervasive and cosmetic in this tree
+# (RustCrypto old/new, windows-sys target shims), so keep them at `warn` for
+# local `cargo deny check bans` runs rather than fighting the tree.
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+# All dependencies come from crates.io; there are no git sources. BLOCKING.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Before / After

**Before:** the workspace had no advisory gating — no `deny.toml`, no cargo-audit/cargo-deny in CI — so a known advisory (`rsa` 0.9.x, RUSTSEC-2023-0071 / #1600) rode along untracked. There was no policy for dependency licenses or crate sources.

**After:** a checked-in `deny.toml` plus a lightweight standalone `supply-chain` CI job (`cargo deny check advisories licenses sources`, pinned cargo-deny 0.20.2, ubuntu-latest) that BLOCKS on new advisories, un-allowed licenses, and unknown sources. Every advisory the first run surfaced is triaged and either accepted with a documented, review-by'd ignore or left as a non-blocking warning.

Closes the supply-chain gating gap flagged on the 0.6.0 readiness audit (#2040). References #1600.

## How

- **`deny.toml`** (repo root): advisories / licenses / sources configured. `[graph] all-features = false` (CI never uses `--all-features`). The graph now also scans the additive features CI actually compiles (`autumn-web/managed-pg-bundled` + `acme`) via `[graph] features`, not just the default feature set, so an advisory/license/source reachable only through a CI-built feature dependency (e.g. the `postgresql_embedded` / `instant-acme` subtrees) can't slip past the gate. The header comment documents how to handle a check that fails CI.
- **`.github/workflows/ci.yml`**: new standalone `supply-chain` job mirroring the `lint` job shape (checkout@v7 + dtolnay/rust-toolchain@stable + taiki-e/install-action@v2 `tool: cargo-deny@0.20.2`). Not nested inside the heavy `test`/`coverage` jobs, no `needs:`. `bans` is deliberately NOT run in CI (duplicate versions are cosmetic in this tree — 62 warnings, all RustCrypto/windows-sys skew).
- **Docs**: `CONTRIBUTING.md` — triaging a new advisory failure.

## Triage (first-run advisories)

| Advisory | Crate (ver) | Ingress path | Patched release? | Disposition |
|---|---|---|---|---|
| RUSTSEC-2023-0071 (Marvin timing sidechannel) | `rsa` 0.9.10 | `jsonwebtoken` → `autumn-web` | No | `ignore`, review-by 2026-10-01; tracked by #1600 |
| RUSTSEC-2026-0173 (unmaintained) | `proc-macro-error2` 2.0.1 | `validator_derive` → `validator` 0.20 | No | `ignore`, review-by 2026-10-01 (build-time proc-macro only) |
| RUSTSEC-2024-0384 (unmaintained) | `instant` 0.1.13 | `postgresql_embedded` (managed-pg-bundled feat) → autumn-web | No | `ignore`, review-by 2026-10-01 (build-time transitive) |
| yanked | `spin` 0.9.8 / 0.10.0 | transitive | n/a | left at default `warn` (non-blocking) |

## Policy decisions

- **advisories / licenses / sources are all BLOCKING** because the initial inventory was clean: licenses are all-permissive once the allow-list + `[licenses.private] ignore` (for first-party example crates) is set — the only deliberate call is weak, file-level **MPL-2.0** (cssparser/selectors stack, no obligation on Autumn source); sources are 100% crates.io with **no git dependencies**.
- **No dependency bumps.** Neither deny-level advisory has a patched release ("no safe upgrade available"), so both are documented ignores rather than churny, ineffective bumps.
- **cargo-deny pinned to 0.20.2.** Note ≤0.16.x cannot parse the current advisory DB (CVSS 4.0), so the pin must stay recent.

## Verification

`cargo deny check advisories licenses sources` passes locally; the new CI job runs the same command.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AusgRkHMXH3R5uVZ8T7Kuh)_