### PR TITLE
autumn-media: MediaMTX host provisioning (deploy slice 7)

### DIFF
--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -858,7 +858,7 @@ pub fn run(action: DeployAction) -> Result<(), DeployError> {
         // `plan` is a pure dry-run over `resolved` alone — it never grades or
         // uploads runtime VALUES, so it needs no reload under the target profile.
         DeployAction::Plan => {
-            let (media_cfg, _ffmpeg_bin) = load_media_host_config()?;
+            let (media_cfg, _ffmpeg_bin) = load_media_host_config(&resolved)?;
             print_plan(&resolved, &media_cfg);
             Ok(())
         }
@@ -869,7 +869,7 @@ pub fn run(action: DeployAction) -> Result<(), DeployError> {
         DeployAction::Check => run_check(&load_runtime_config(&resolved)?, &resolved),
         DeployAction::Rollback => run_rollback(&load_runtime_config(&resolved)?, &resolved),
         DeployAction::Up => {
-            let (media_cfg, ffmpeg_bin) = load_media_host_config()?;
+            let (media_cfg, ffmpeg_bin) = load_media_host_config(&resolved)?;
             run_up(
                 &load_runtime_config(&resolved)?,
                 &resolved,
@@ -881,49 +881,172 @@ pub fn run(action: DeployAction) -> Result<(), DeployError> {
 }
 
 /// Load the `[media.mediamtx]` host-provisioning config and the `[media.ffmpeg]
-/// bin` path from the project `autumn.toml` (issue #1974, Slice 7).
+/// bin` path from the project config, resolved **under the target deploy profile**
+/// (issue #1974, Slice 7; issue #2051, Finding O).
 ///
-/// Reads the raw `autumn.toml` string and deserializes only the `[media]`
-/// subtree (mirroring how `autumn-media-plugin` reads its own config), so it
-/// bypasses `autumn-web`'s strict `AutumnConfig` schema and adds no dependency on
-/// the plugin. A missing file (or one that cannot be read) yields the disabled
-/// default plus the default `FFmpeg` path, so a project that does not use
-/// autumn-media is unaffected.
+/// Reads the raw project TOML and deserializes only the `[media]` subtree
+/// (mirroring how `autumn-media-plugin` reads its own config), so it bypasses
+/// `autumn-web`'s strict `AutumnConfig` schema and adds no dependency on the
+/// plugin. Crucially it applies the **same base+profile TOML layering
+/// `AutumnConfig::load()` applies to the app config** — base `autumn.toml`, then
+/// the inline `[profile.<name>]` sections, then `autumn-<profile>.toml` — so a
+/// profiled deploy (`prod`/`staging`) provisions `MediaMTX` from the profile's
+/// `[media.mediamtx]` / `[media.ffmpeg]` (`[profile.<name>.media.*]` or
+/// `autumn-<profile>.toml`) instead of the base default. Without this a
+/// prod-enabled `[profile.prod.media.mediamtx]` (or `autumn-prod.toml`) would be
+/// ignored and `plan`/`up` would see the disabled base config, so the release
+/// boots under the target profile with no media daemon provisioned. The env-var
+/// override layer (`AUTUMN_MEDIA__*`) is deliberately NOT applied here — an
+/// env/interpolation-indirected value is resolved from the SERVICE'S OWN
+/// environment at runtime (see [`media::ffmpeg_preflight`]'s fail-closed-honest
+/// deferral), which the CLI neither has nor may guess.
+///
+/// A missing file (or one that cannot be read) yields the disabled default plus
+/// the default `FFmpeg` path, so a project that does not use autumn-media is
+/// unaffected.
 ///
 /// **Fails closed on invalid media config.** A `[media.mediamtx]` /
 /// `[media.ffmpeg]` table that is *present but does not deserialize* (a
-/// wrong-typed value) is an error, not a silent fallback: it returns
-/// [`DeployError::Config`] so `deploy plan`/`deploy up` abort with a clear
-/// message instead of proceeding WITHOUT provisioning a media-enabled app's
-/// `MediaMTX` daemon. The disabled default is reserved for the genuinely *absent*
-/// case — `from_toml_str` / `ffmpeg_bin_from_toml_str` map a missing table to
-/// `Ok(default)` and a present-but-invalid table to `Err`, so a non-media
-/// project stays unaffected while a broken media config can never be swallowed.
-fn load_media_host_config() -> Result<(media::MediaMtxHostConfig, String), DeployError> {
+/// wrong-typed value) **in any contributing layer** is an error, not a silent
+/// fallback: the merged value carries the bad type and
+/// [`media::media_host_config_from_value`] returns [`DeployError::Config`] so
+/// `deploy plan`/`deploy up` abort with a clear message instead of proceeding
+/// WITHOUT provisioning a media-enabled app's `MediaMTX` daemon. The disabled
+/// default is reserved for the genuinely *absent* case.
+fn load_media_host_config(
+    resolved: &ResolvedDeployConfig,
+) -> Result<(media::MediaMtxHostConfig, String), DeployError> {
+    load_media_host_config_in(&manifest_project_dirs(), &resolved.profile)
+}
+
+/// Pure core of [`load_media_host_config`] over an explicit ordered search path
+/// and RAW deploy-profile spelling, so the base+profile media layering is
+/// unit-testable against temp dirs (mirrors [`manifest_uploads_in`]).
+///
+/// Builds a merged `[media]` subtree exactly as `AutumnConfig::load_with_env`
+/// builds the app config (minus the env-override layer, see the caller docs):
+/// base `autumn.toml` ← inline `[profile.<name>]` sections ←
+/// `autumn-<profile>.toml`. A base file that is absent/unreadable yields the
+/// disabled default; a base or profile file that does not parse, or a merged
+/// `[media]` subtree with a wrong-typed value, is a fail-closed
+/// [`DeployError::Config`].
+fn load_media_host_config_in(
+    dirs: &[PathBuf],
+    profile_raw: &str,
+) -> Result<(media::MediaMtxHostConfig, String), DeployError> {
     let disabled = || {
         (
             media::MediaMtxHostConfig::default(),
             media::DEFAULT_FFMPEG_BIN.to_owned(),
         )
     };
-    let Some(path) = first_dir_with_file(&manifest_project_dirs(), "autumn.toml") else {
+    let Some(base_path) = first_dir_with_file(dirs, "autumn.toml") else {
         return Ok(disabled());
     };
-    let Ok(contents) = std::fs::read_to_string(&path) else {
+    let Ok(base_str) = std::fs::read_to_string(&base_path) else {
         return Ok(disabled());
     };
-    // `from_toml_str` parses the whole `[media]` subtree (both `mediamtx` and the
-    // sibling `ffmpeg` table), so a type error in *either* surfaces here — the
-    // second `ffmpeg_bin_from_toml_str` parse is a defensive companion. Propagate
-    // rather than `.unwrap_or_default()` so a malformed media config aborts the
-    // deploy instead of silently disabling MediaMTX provisioning.
-    let cfg = media::MediaMtxHostConfig::from_toml_str(&contents).map_err(|e| {
-        DeployError::Config(format!("invalid [media] config in {}: {e}", path.display()))
+    // Layer 3: base autumn.toml (a malformed base is fail-closed).
+    let base: toml::Value = toml::from_str(&base_str).map_err(|e| {
+        DeployError::Config(format!("invalid config in {}: {e}", base_path.display()))
     })?;
-    let bin = media::ffmpeg_bin_from_toml_str(&contents).map_err(|e| {
-        DeployError::Config(format!("invalid [media] config in {}: {e}", path.display()))
-    })?;
-    Ok((cfg, bin))
+    let mut merged = base.clone();
+
+    // Layer 4: inline `[profile.<name>]` sections in the base autumn.toml, in the
+    // runtime's alias-then-canonical merge order (`production` then `prod`), so a
+    // `[profile.prod.media.mediamtx]` wins over the base — matching
+    // `AutumnConfig::load_with_env`.
+    let canonical = canonicalize_deploy_profile(profile_raw);
+    for name in profile_inline_lookup_names(&canonical) {
+        if let Some(section) = profile_section_from_base_toml(&base, name) {
+            deep_merge_toml(&mut merged, section);
+        }
+    }
+
+    // Layer 5: `autumn-<profile>.toml` (first existing in the ordered lookup wins,
+    // reusing the runtime's own pure override-file name resolver so the deploy
+    // reads the SAME profile file the host runtime loads).
+    for name in autumn_web::config::profile_override_file_lookup_names(&canonical, profile_raw) {
+        let basename = format!("autumn-{name}.toml");
+        if let Some(path) = first_dir_with_file(dirs, &basename) {
+            let overlay_str = std::fs::read_to_string(&path).map_err(|e| {
+                DeployError::Config(format!("could not read {}: {e}", path.display()))
+            })?;
+            let overlay: toml::Value = toml::from_str(&overlay_str).map_err(|e| {
+                DeployError::Config(format!("invalid config in {}: {e}", path.display()))
+            })?;
+            deep_merge_toml(&mut merged, overlay);
+            break;
+        }
+    }
+
+    // Deserialize the merged `[media]` subtree — fail-closed on an ill-typed value
+    // in any contributing layer.
+    media::media_host_config_from_value(merged).map_err(|e| {
+        DeployError::Config(format!(
+            "invalid [media] config for deploy profile `{profile_raw}`: {e}"
+        ))
+    })
+}
+
+/// Inline `[profile.<name>]` lookup names for the canonical profile, mirroring
+/// `autumn-web`'s private `profile_lookup_names`: canonical profiles also pull
+/// their legacy alias (`prod`→`production`,`prod`; `dev`→`development`,`dev`) so
+/// a `[profile.production.media.mediamtx]` is honored for a `prod` deploy, while a
+/// custom profile is looked up verbatim. Merged in list order (alias first) so the
+/// canonical spelling wins — identical to the runtime. Kept a local mirror (like
+/// [`canonicalize_deploy_profile`] mirrors `normalize_profile_name`) because the
+/// runtime helper is private.
+fn profile_inline_lookup_names(canonical: &str) -> Vec<&str> {
+    match canonical {
+        "prod" => vec!["production", "prod"],
+        "dev" => vec!["development", "dev"],
+        other => vec![other],
+    }
+}
+
+/// Extract a `[profile.<name>]` table from a parsed `autumn.toml` value as a
+/// standalone TOML value (mirrors `autumn-web`'s private
+/// `profile_section_from_base_toml`). `None` when the section is absent.
+fn profile_section_from_base_toml(base: &toml::Value, profile: &str) -> Option<toml::Value> {
+    base.get("profile")
+        .and_then(toml::Value::as_table)
+        .and_then(|profiles| profiles.get(profile))
+        .and_then(toml::Value::as_table)
+        .map(|table| toml::Value::Table(table.clone()))
+}
+
+/// Deep-merge two TOML values — tables merged recursively, non-table `overlay`
+/// values replace `base` (a faithful copy of `autumn-web`'s private `deep_merge`,
+/// so the deploy-side media layering matches the runtime's app-config layering
+/// exactly). Bounded recursion mirrors the runtime's `MAX_MERGE_DEPTH`.
+fn deep_merge_toml(base: &mut toml::Value, overlay: toml::Value) {
+    deep_merge_toml_depth(base, overlay, 0);
+}
+
+fn deep_merge_toml_depth(base: &mut toml::Value, overlay: toml::Value, depth: usize) {
+    /// Matches `autumn-web`'s `MAX_MERGE_DEPTH`.
+    const MAX_MERGE_DEPTH: usize = 16;
+    if depth > MAX_MERGE_DEPTH {
+        return;
+    }
+    let toml::Value::Table(overlay_table) = overlay else {
+        return;
+    };
+    let Some(base_table) = base.as_table_mut() else {
+        return;
+    };
+    for (key, overlay_val) in overlay_table {
+        let is_recursive_merge =
+            overlay_val.is_table() && base_table.get(&key).is_some_and(toml::Value::is_table);
+        if is_recursive_merge {
+            if let Some(base_val) = base_table.get_mut(&key) {
+                deep_merge_toml_depth(base_val, overlay_val, depth + 1);
+            }
+        } else {
+            base_table.insert(key, overlay_val);
+        }
+    }
 }
 
 /// An [`Env`] that forces `AUTUMN_ENV` to a specific deploy profile while
@@ -1227,8 +1350,10 @@ fn print_media_plan(media_cfg: &media::MediaMtxHostConfig) {
         println!("  {}. [{}]", i + 1, op.label());
     }
     println!(
-        "\nMediaMTX doctor checks at `deploy up`: {}, {}, {}",
+        "\nMediaMTX doctor checks at `deploy up`: {}, {}, {}, {}, {}",
+        media::CHECK_MEDIAMTX_PORTS_DISTINCT,
         media::CHECK_FFMPEG_PREFLIGHT,
+        media::CHECK_MEDIAMTX_BINARY,
         media::CHECK_RECORDINGS_DIR_WRITABLE,
         media::CHECK_MEDIAMTX_PORTS_AVAILABLE,
     );
@@ -2474,6 +2599,130 @@ mod tests {
         assert!(uploads.is_empty(), "no autumn.toml → nothing to upload");
     }
 
+    // ── Media config resolves under the deploy profile (Finding O) ───────────
+
+    #[test]
+    fn media_config_no_manifest_is_disabled_default() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dirs = vec![dir.path().to_path_buf()];
+        let (cfg, bin) = load_media_host_config_in(&dirs, "prod").expect("loads");
+        assert!(!cfg.enabled, "no autumn.toml → controller disabled");
+        assert_eq!(bin, media::DEFAULT_FFMPEG_BIN);
+    }
+
+    #[test]
+    fn media_config_honors_inline_profile_section() {
+        // `[profile.prod.media.mediamtx]` enables media over a base that omits it —
+        // a profiled deploy must see the profile's config, not the base default.
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("autumn.toml"),
+            "[media.ffmpeg]\nbin = \"/usr/bin/ffmpeg\"\n\
+             [profile.prod.media.mediamtx]\nenabled = true\napi_port = 19997\n",
+        )
+        .expect("write base");
+        let dirs = vec![dir.path().to_path_buf()];
+
+        // prod: the inline profile section is layered on.
+        let (prod, _) = load_media_host_config_in(&dirs, "prod").expect("loads prod");
+        assert!(prod.enabled, "prod profile enables media");
+        assert_eq!(prod.api_port, 19997);
+
+        // dev: no matching profile section → base default (media disabled).
+        let (dev, _) = load_media_host_config_in(&dirs, "dev").expect("loads dev");
+        assert!(
+            !dev.enabled,
+            "dev has no profile media section → base default"
+        );
+    }
+
+    #[test]
+    fn media_config_honors_profile_override_file() {
+        // The `autumn-prod.toml` override file enables media over a base that omits
+        // it, matching the runtime's Layer-5 override.
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("autumn.toml"), "[server]\nport = 3000\n")
+            .expect("write base");
+        std::fs::write(
+            dir.path().join("autumn-prod.toml"),
+            "[media.mediamtx]\nenabled = true\nrtmp_port = 11935\n",
+        )
+        .expect("write prod override");
+        let dirs = vec![dir.path().to_path_buf()];
+
+        let (prod, _) = load_media_host_config_in(&dirs, "prod").expect("loads prod");
+        assert!(prod.enabled, "autumn-prod.toml enables media");
+        assert_eq!(prod.rtmp_port, 11935);
+    }
+
+    #[test]
+    fn media_config_profile_layer_overrides_base_value() {
+        // Base enables media on one api_port; the profile override wins.
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("autumn.toml"),
+            "[media.mediamtx]\nenabled = true\napi_port = 9997\n",
+        )
+        .expect("write base");
+        std::fs::write(
+            dir.path().join("autumn-prod.toml"),
+            "[media.mediamtx]\napi_port = 29997\n",
+        )
+        .expect("write prod override");
+        let dirs = vec![dir.path().to_path_buf()];
+
+        let (prod, _) = load_media_host_config_in(&dirs, "prod").expect("loads prod");
+        assert!(
+            prod.enabled,
+            "base enablement is preserved under deep merge"
+        );
+        assert_eq!(
+            prod.api_port, 29997,
+            "profile override wins over the base value"
+        );
+    }
+
+    #[test]
+    fn media_config_base_only_when_profile_has_no_media_layer() {
+        // No inline `[profile.prod]` and no autumn-prod.toml → the base config is
+        // read verbatim under the profile.
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("autumn.toml"),
+            "[media.mediamtx]\nenabled = true\napi_port = 9001\n",
+        )
+        .expect("write base");
+        let dirs = vec![dir.path().to_path_buf()];
+
+        let (prod, _) = load_media_host_config_in(&dirs, "prod").expect("loads prod");
+        assert!(prod.enabled);
+        assert_eq!(prod.api_port, 9001);
+    }
+
+    #[test]
+    fn media_config_fails_closed_on_invalid_value_in_active_profile_layer() {
+        // A present-but-ill-typed value in the ACTIVE profile layer aborts, even
+        // though the base is valid — the fail-closed rule spans every layer.
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("autumn.toml"),
+            "[media.mediamtx]\nenabled = true\n",
+        )
+        .expect("write base");
+        std::fs::write(
+            dir.path().join("autumn-prod.toml"),
+            "[media.mediamtx]\napi_port = \"nope\"\n",
+        )
+        .expect("write bad prod override");
+        let dirs = vec![dir.path().to_path_buf()];
+
+        let err = load_media_host_config_in(&dirs, "prod").expect_err("must fail closed");
+        assert!(
+            matches!(err, DeployError::Config(_)),
+            "invalid profile-layer media config aborts the deploy: {err:?}"
+        );
+    }
+
     #[test]
     fn manifest_notice_warns_loudly_when_no_manifest() {
         let notice = manifest_preflight_notice(&[]);
@@ -3015,8 +3264,9 @@ mod tests {
         // Plan and Up match arms, never in Check/Rollback.
         let src = include_str!("deploy.rs");
         // Build the needle at runtime so this test's own source text (which mentions
-        // the fn name) can never be miscounted as a call site.
-        let needle = ["load_media_host_config", "()?"].concat();
+        // the fn name) can never be miscounted as a call site. The loader now takes
+        // the resolved deploy config (Finding O), so match the call shape, not `()`.
+        let needle = ["load_media_host_config", "(&resolved)?"].concat();
         let call_sites = src.matches(needle.as_str()).count();
         assert_eq!(
             call_sites, 2,

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -295,6 +295,13 @@ pub struct PreflightCheck {
     pub name: &'static str,
     /// Whether the check passed.
     pub passed: bool,
+    /// Whether the check could not be verified here and is deliberately
+    /// **deferred to the service's own runtime** (e.g. an env/interpolation
+    /// indirected `[media.ffmpeg] bin` the deploy side must not guess). A
+    /// deferred check is non-passing but **non-blocking** — it is surfaced as a
+    /// warning and never aborts a deploy, distinct from an honest failure. See
+    /// [`PreflightCheck::blocking`].
+    pub deferred: bool,
     /// Human-readable detail (what was found).
     pub detail: String,
     /// One-line remediation hint shown on failure.
@@ -306,6 +313,7 @@ impl PreflightCheck {
         Self {
             name,
             passed: true,
+            deferred: false,
             detail: detail.into(),
             hint: None,
         }
@@ -315,9 +323,20 @@ impl PreflightCheck {
         Self {
             name,
             passed: false,
+            deferred: false,
             detail: detail.into(),
             hint: Some(hint),
         }
+    }
+
+    /// Whether this check must abort the deploy. A check blocks only when it
+    /// genuinely failed — a **deferred** check (non-passing, but resolved in the
+    /// service's own runtime environment) is surfaced as a warning and never
+    /// blocks. This is the single predicate every preflight gate keys on so a
+    /// deferred outcome can never silently pass *or* hard-fail a deploy.
+    #[must_use]
+    pub const fn blocking(&self) -> bool {
+        !self.passed && !self.deferred
     }
 }
 
@@ -1304,6 +1323,13 @@ fn report_preflight(checks: &[PreflightCheck]) -> usize {
     for check in checks {
         if check.passed {
             eprintln!("\u{2705} {}: {}", check.name, check.detail);
+        } else if check.deferred {
+            // Non-blocking: verified in the service's own runtime, not here.
+            // Surfaced as a warning so it is visible but never aborts the deploy.
+            eprintln!("\u{26A0}\u{FE0F}  {}: {}", check.name, check.detail);
+            if let Some(hint) = check.hint {
+                eprintln!("   \u{2192} {hint}");
+            }
         } else {
             failed += 1;
             eprintln!("\u{274C} {}: {}", check.name, check.detail);
@@ -1381,13 +1407,19 @@ fn print_media_plan(media_cfg: &media::MediaMtxHostConfig) {
     );
 }
 
-/// Grade the media host with the three fail-closed, **non-mutating** doctor
-/// checks (`FFmpeg` preflight, recordings dir writable, ports available) and abort
-/// the deploy on any failure — so a host that cannot serve media fails fast BEFORE
-/// the app deploy touches anything. A no-op when `[media.mediamtx]` is not
-/// enabled. This writes and restarts nothing; the mutating provisioning is
-/// deferred to [`provision_media_host`], which runs only after the app cutover
-/// succeeds.
+/// Grade the media host with the fail-closed, **non-mutating** doctor checks
+/// (`FFmpeg` preflight, `MediaMTX` binary, recordings dir writable, ports
+/// distinct/available) and abort the deploy on any **blocking** failure — so a
+/// host that cannot serve media fails fast BEFORE the app deploy touches
+/// anything. A **deferred** check (an env/interpolation-indirected
+/// `[media.ffmpeg] bin` the deployed service resolves from its own runtime
+/// environment) is surfaced as a warning and does **not** abort — the service
+/// resolves `FFmpeg` at runtime, so blocking the deploy here would be wrong,
+/// while a concrete literal `FFmpeg` path that is missing/not-executable still
+/// fails closed (see [`media::ffmpeg_preflight`] and
+/// [`PreflightCheck::blocking`]). A no-op when `[media.mediamtx]` is not enabled.
+/// This writes and restarts nothing; the mutating provisioning is deferred to
+/// [`provision_media_host`], which runs only after the app cutover succeeds.
 fn check_media_host_preflight(
     media_cfg: &media::MediaMtxHostConfig,
     ffmpeg_bin: &str,

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -23,6 +23,7 @@
 //! shared with `autumn doctor`.
 
 pub mod exec;
+pub mod media;
 pub mod proxy;
 
 use std::net::{TcpStream, ToSocketAddrs};
@@ -846,11 +847,17 @@ pub fn run(action: DeployAction) -> Result<(), DeployError> {
     let resolved = ResolvedDeployConfig::resolve(&deploy_cfg, &resolve_project_name())
         .map_err(DeployError::Config)?;
 
+    // MediaMTX host-provisioning config (issue #1974, Slice 7). Read straight
+    // from the project `autumn.toml` string (like the media plugin reads
+    // `[media]`), so it needs no `AutumnConfig`/plugin coupling and defaults to
+    // disabled — a non-media project is byte-for-byte unaffected.
+    let (media_cfg, ffmpeg_bin) = load_media_host_config();
+
     match action {
         // `plan` is a pure dry-run over `resolved` alone — it never grades or
         // uploads runtime VALUES, so it needs no reload under the target profile.
         DeployAction::Plan => {
-            print_plan(&resolved);
+            print_plan(&resolved, &media_cfg);
             Ok(())
         }
         // `check`/`rollback`/`up` grade and (for `up`) upload the signing secret
@@ -858,8 +865,41 @@ pub fn run(action: DeployAction) -> Result<(), DeployError> {
         // deploy profile — not the operator's ambient/dev config. Reload here.
         DeployAction::Check => run_check(&load_runtime_config(&resolved)?, &resolved),
         DeployAction::Rollback => run_rollback(&load_runtime_config(&resolved)?, &resolved),
-        DeployAction::Up => run_up(&load_runtime_config(&resolved)?, &resolved),
+        DeployAction::Up => run_up(
+            &load_runtime_config(&resolved)?,
+            &resolved,
+            &media_cfg,
+            &ffmpeg_bin,
+        ),
     }
+}
+
+/// Load the `[media.mediamtx]` host-provisioning config and the `[media.ffmpeg]
+/// bin` path from the project `autumn.toml` (issue #1974, Slice 7).
+///
+/// Reads the raw `autumn.toml` string and deserializes only the `[media]`
+/// subtree (mirroring how `autumn-media-plugin` reads its own config), so it
+/// bypasses `autumn-web`'s strict `AutumnConfig` schema and adds no dependency on
+/// the plugin. A missing or unparseable file yields the disabled default plus
+/// the default `FFmpeg` path, so a project that does not use autumn-media is
+/// unaffected.
+fn load_media_host_config() -> (media::MediaMtxHostConfig, String) {
+    let disabled = || {
+        (
+            media::MediaMtxHostConfig::default(),
+            media::DEFAULT_FFMPEG_BIN.to_owned(),
+        )
+    };
+    let Some(path) = first_dir_with_file(&manifest_project_dirs(), "autumn.toml") else {
+        return disabled();
+    };
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return disabled();
+    };
+    let cfg = media::MediaMtxHostConfig::from_toml_str(&contents).unwrap_or_default();
+    let bin = media::ffmpeg_bin_from_toml_str(&contents)
+        .unwrap_or_else(|_| media::DEFAULT_FFMPEG_BIN.to_owned());
+    (cfg, bin)
 }
 
 /// An [`Env`] that forces `AUTUMN_ENV` to a specific deploy profile while
@@ -1130,7 +1170,7 @@ fn run_check(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(
     }
 }
 
-fn print_plan(resolved: &ResolvedDeployConfig) {
+fn print_plan(resolved: &ResolvedDeployConfig, media_cfg: &media::MediaMtxHostConfig) {
     println!("\u{1F342} autumn deploy plan (dry-run)\n");
     println!("systemd unit ({}.service):\n", resolved.service_name);
     println!("{}", render_systemd_unit(resolved));
@@ -1139,6 +1179,74 @@ fn print_plan(resolved: &ResolvedDeployConfig) {
     for (i, step) in build_deploy_plan(resolved).iter().enumerate() {
         println!("  {}. [{}] {}", i + 1, step.label, step.description);
     }
+
+    // MediaMTX host provisioning (issue #1974, Slice 7): only when the
+    // `[media.mediamtx]` section is enabled — a non-media deploy prints nothing
+    // new here.
+    if media_cfg.enabled {
+        print_media_plan(media_cfg);
+    }
+}
+
+/// Print the `MediaMTX` host-provisioning section of `deploy plan` — the rendered
+/// systemd unit, the ordered provisioning ops, and the CSP origins the app must
+/// allow. Pure output; runs nothing.
+fn print_media_plan(media_cfg: &media::MediaMtxHostConfig) {
+    let controller = media::MediaMtxController::new(media_cfg.clone());
+    println!(
+        "\nMediaMTX host provisioning (media unit {}.service):\n",
+        media_cfg.unit_name
+    );
+    println!("{}", media::render_mediamtx_unit(media_cfg));
+    println!("MediaMTX provisioning steps:");
+    for (i, op) in controller.ensure_installed_ops().iter().enumerate() {
+        println!("  {}. [{}]", i + 1, op.label());
+    }
+    println!(
+        "\nMediaMTX doctor checks at `deploy up`: {}, {}, {}",
+        media::CHECK_FFMPEG_PREFLIGHT,
+        media::CHECK_RECORDINGS_DIR_WRITABLE,
+        media::CHECK_MEDIAMTX_PORTS_AVAILABLE,
+    );
+    println!(
+        "CSP: the app must allow these MediaMTX origins in connect-src/media-src \
+         (frame-src for WebRTC): {}",
+        media_cfg.required_csp_origins().join(", "),
+    );
+}
+
+/// Grade the media host and provision `MediaMTX` as a systemd unit over the live
+/// executor (issue #1974, Slice 7). A no-op when `[media.mediamtx]` is not
+/// enabled.
+///
+/// Runs the three fail-closed doctor checks first (`FFmpeg` preflight, recordings
+/// dir writable, ports available) and aborts the deploy on any failure — so a
+/// host that cannot serve media never gets a half-provisioned unit — then drives
+/// the controller's write-config / write-unit / enable+restart ops.
+fn provision_media_host(
+    media_cfg: &media::MediaMtxHostConfig,
+    ffmpeg_bin: &str,
+    executor: &impl exec::DeployExecutor,
+) -> Result<(), DeployError> {
+    if !media_cfg.enabled {
+        return Ok(());
+    }
+    eprintln!("\u{1F3A5} provisioning MediaMTX host (autumn-media)\n");
+
+    let checks = media::collect_media_doctor_checks(executor, media_cfg, ffmpeg_bin);
+    let failed = report_preflight(&checks);
+    if failed > 0 {
+        return Err(DeployError::PreflightFailed(failed));
+    }
+
+    let controller = media::MediaMtxController::new(media_cfg.clone());
+    exec::run_ops(&controller.ensure_installed_ops(), executor)
+        .map_err(|e| DeployError::Exec(e.to_string()))?;
+    eprintln!(
+        "\u{2705} MediaMTX provisioned ({}.service)",
+        media_cfg.unit_name
+    );
+    Ok(())
 }
 
 /// Build the secret env-file body sourced by the systemd unit's
@@ -1368,7 +1476,15 @@ fn validate_public_port(public_port: u16) -> Result<(), String> {
     Ok(())
 }
 
-fn run_up(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(), DeployError> {
+// Linear deploy orchestrator; the added MediaMTX host-prep step (#1974 Slice 7)
+// tips it one line over the threshold, and it reads clearest as one sequence.
+#[allow(clippy::too_many_lines)]
+fn run_up(
+    config: &AutumnConfig,
+    resolved: &ResolvedDeployConfig,
+    media_cfg: &media::MediaMtxHostConfig,
+    ffmpeg_bin: &str,
+) -> Result<(), DeployError> {
     eprintln!("\u{1F342} autumn deploy up\n");
 
     // Fail fast: run the full preflight and abort BEFORE any remote call.
@@ -1401,6 +1517,9 @@ fn run_up(config: &AutumnConfig, resolved: &ResolvedDeployConfig) -> Result<(), 
     let proxy = proxy::KamalProxyController::new(resolved.readiness_timeout_secs)
         .with_tls_host(resolved.tls_host.clone());
     let executor = exec::SshExecutor::new(target);
+    // MediaMTX host provisioning (#1974 Slice 7) — no-op unless enabled (see fn).
+    provision_media_host(media_cfg, ffmpeg_bin, &executor)?;
+
     let release_dir = format!("{}/{release_id}", resolved.releases_dir());
 
     // Probe the target to choose first-deploy vs zero-downtime redeploy. The same

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -926,40 +926,57 @@ fn load_media_host_config(
 /// Builds a merged `[media]` subtree exactly as `AutumnConfig::load_with_env`
 /// builds the app config (minus the env-override layer, see the caller docs):
 /// base `autumn.toml` ← inline `[profile.<name>]` sections ←
-/// `autumn-<profile>.toml`. A base file that is absent/unreadable yields the
-/// disabled default; a base or profile file that does not parse, or a merged
-/// `[media]` subtree with a wrong-typed value, is a fail-closed
-/// [`DeployError::Config`].
+/// `autumn-<profile>.toml`. The base `autumn.toml` is **optional** — an
+/// absent/unreadable base skips only that layer, exactly like `load_with_env`,
+/// so a deploy that keeps `[media.mediamtx] enabled = true` ONLY in
+/// `autumn-<profile>.toml` (with `[deploy] host` supplied via env and no base
+/// file) still resolves the profile override and provisions `MediaMTX` (Finding
+/// R). When no layer contributes a `[media]` subtree the `#[serde(default)]`
+/// `MediaTomlRoot` deserializes to the disabled default; a base or profile file
+/// that does not parse, or a merged `[media]` subtree with a wrong-typed value,
+/// is a fail-closed [`DeployError::Config`].
 fn load_media_host_config_in(
     dirs: &[PathBuf],
     profile_raw: &str,
 ) -> Result<(media::MediaMtxHostConfig, String), DeployError> {
-    let disabled = || {
-        (
-            media::MediaMtxHostConfig::default(),
-            media::DEFAULT_FFMPEG_BIN.to_owned(),
-        )
-    };
-    let Some(base_path) = first_dir_with_file(dirs, "autumn.toml") else {
-        return Ok(disabled());
-    };
-    let Ok(base_str) = std::fs::read_to_string(&base_path) else {
-        return Ok(disabled());
-    };
-    // Layer 3: base autumn.toml (a malformed base is fail-closed).
-    let base: toml::Value = toml::from_str(&base_str).map_err(|e| {
-        DeployError::Config(format!("invalid config in {}: {e}", base_path.display()))
-    })?;
-    let mut merged = base.clone();
+    // Start from an empty root and deep-merge each contributing layer in the same
+    // order `AutumnConfig::load_with_env` does, so the deploy-side `[media]`
+    // resolution matches the app/runtime resolution for every base/profile
+    // combination. The runtime seeds `merged` with `profile_defaults_as_toml`, but
+    // those smart defaults carry NO `[media]` keys, so an empty root is faithful
+    // for the media subtree — an absent `[media]` deserializes to the disabled
+    // default via the `#[serde(default)]` `MediaTomlRoot`. The env-override layer
+    // is deliberately excluded (see the caller docs).
+    let mut merged = toml::Value::Table(toml::map::Map::new());
 
-    // Layer 4: inline `[profile.<name>]` sections in the base autumn.toml, in the
-    // runtime's alias-then-canonical merge order (`production` then `prod`), so a
-    // `[profile.prod.media.mediamtx]` wins over the base — matching
-    // `AutumnConfig::load_with_env`.
+    // Layer 3: base `autumn.toml` — OPTIONAL, exactly like `load_with_env`. A
+    // missing or unreadable base skips only this layer (a project without
+    // autumn-media is unaffected) but does NOT skip the profile override file
+    // below; a base present-but-malformed is fail-closed.
+    let base_toml: Option<toml::Value> = match first_dir_with_file(dirs, "autumn.toml") {
+        Some(base_path) => match std::fs::read_to_string(&base_path) {
+            Ok(base_str) => {
+                let base: toml::Value = toml::from_str(&base_str).map_err(|e| {
+                    DeployError::Config(format!("invalid config in {}: {e}", base_path.display()))
+                })?;
+                deep_merge_toml(&mut merged, base.clone());
+                Some(base)
+            }
+            Err(_) => None,
+        },
+        None => None,
+    };
+
+    // Layer 4: inline `[profile.<name>]` sections in the base autumn.toml (only
+    // present when the base parsed), in the runtime's alias-then-canonical merge
+    // order (`production` then `prod`), so a `[profile.prod.media.mediamtx]` wins
+    // over the base — matching `AutumnConfig::load_with_env`.
     let canonical = canonicalize_deploy_profile(profile_raw);
-    for name in profile_inline_lookup_names(&canonical) {
-        if let Some(section) = profile_section_from_base_toml(&base, name) {
-            deep_merge_toml(&mut merged, section);
+    if let Some(base) = &base_toml {
+        for name in profile_inline_lookup_names(&canonical) {
+            if let Some(section) = profile_section_from_base_toml(base, name) {
+                deep_merge_toml(&mut merged, section);
+            }
         }
     }
 
@@ -2653,6 +2670,35 @@ mod tests {
         let (prod, _) = load_media_host_config_in(&dirs, "prod").expect("loads prod");
         assert!(prod.enabled, "autumn-prod.toml enables media");
         assert_eq!(prod.rtmp_port, 11935);
+    }
+
+    #[test]
+    fn media_config_honors_profile_override_file_without_base_autumn_toml() {
+        // Finding R: the base `autumn.toml` is OPTIONAL, exactly like
+        // `AutumnConfig::load_with_env`. A deploy that supplies `[deploy] host` via
+        // env and keeps `[media.mediamtx] enabled = true` ONLY in `autumn-prod.toml`
+        // (with NO base autumn.toml) must still resolve the profile override and
+        // provision MediaMTX — previously the loader early-returned the disabled
+        // default the moment no base file existed, silently skipping the override.
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("autumn-prod.toml"),
+            "[media.mediamtx]\nenabled = true\nrtmp_port = 11935\n",
+        )
+        .expect("write prod override");
+        let dirs = vec![dir.path().to_path_buf()];
+
+        let (prod, _) = load_media_host_config_in(&dirs, "prod").expect("loads prod");
+        assert!(
+            prod.enabled,
+            "profile-only media config is provisioned with no base autumn.toml"
+        );
+        assert_eq!(prod.rtmp_port, 11935);
+
+        // dev: no `autumn-dev.toml` and no base → disabled default (the override
+        // file is profile-scoped, so a different profile is unaffected).
+        let (dev, _) = load_media_host_config_in(&dirs, "dev").expect("loads dev");
+        assert!(!dev.enabled, "dev has no override file → disabled default");
     }
 
     #[test]

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -847,30 +847,36 @@ pub fn run(action: DeployAction) -> Result<(), DeployError> {
     let resolved = ResolvedDeployConfig::resolve(&deploy_cfg, &resolve_project_name())
         .map_err(DeployError::Config)?;
 
-    // MediaMTX host-provisioning config (issue #1974, Slice 7). Read straight
-    // from the project `autumn.toml` string (like the media plugin reads
-    // `[media]`), so it needs no `AutumnConfig`/plugin coupling and defaults to
-    // disabled — a non-media project is byte-for-byte unaffected.
-    let (media_cfg, ffmpeg_bin) = load_media_host_config()?;
-
+    // MediaMTX host-provisioning config (issue #1974, Slice 7) is loaded ONLY in
+    // the actions that plan/provision media (`plan` and `up`). `check`/`rollback`
+    // neither read nor provision `MediaMTX`, so parsing `[media]` there would let a
+    // typo in `[media.mediamtx]`/`[media.ffmpeg]` fail-close a rollback that does
+    // not touch media at all — a regression the round-2 fail-closed fix must not
+    // introduce. The load stays fail-closed where it IS relevant (`plan`/`up`): a
+    // present-but-invalid `[media]` table still aborts those two.
     match action {
         // `plan` is a pure dry-run over `resolved` alone — it never grades or
         // uploads runtime VALUES, so it needs no reload under the target profile.
         DeployAction::Plan => {
+            let (media_cfg, _ffmpeg_bin) = load_media_host_config()?;
             print_plan(&resolved, &media_cfg);
             Ok(())
         }
         // `check`/`rollback`/`up` grade and (for `up`) upload the signing secret
         // and DB URL, so they must see those VALUES resolved under the TARGET
         // deploy profile — not the operator's ambient/dev config. Reload here.
+        // `check`/`rollback` deliberately do NOT load the media config.
         DeployAction::Check => run_check(&load_runtime_config(&resolved)?, &resolved),
         DeployAction::Rollback => run_rollback(&load_runtime_config(&resolved)?, &resolved),
-        DeployAction::Up => run_up(
-            &load_runtime_config(&resolved)?,
-            &resolved,
-            &media_cfg,
-            &ffmpeg_bin,
-        ),
+        DeployAction::Up => {
+            let (media_cfg, ffmpeg_bin) = load_media_host_config()?;
+            run_up(
+                &load_runtime_config(&resolved)?,
+                &resolved,
+                &media_cfg,
+                &ffmpeg_bin,
+            )
+        }
     }
 }
 
@@ -2962,5 +2968,53 @@ mod tests {
         let mut config = AutumnConfig::default();
         config.jobs.backend = "redis".to_owned();
         assert!(!requires_database_pool(&config));
+    }
+
+    #[test]
+    fn rollback_dispatch_does_not_load_media_config() {
+        // Finding F: the media host config is loaded ONLY in the plan/up action
+        // paths. `check`/`rollback` neither read nor provision MediaMTX, so a typo
+        // in `[media.mediamtx]`/`[media.ffmpeg]` must not fail-close a rollback (a
+        // regression the round-2 fail-closed load would otherwise reintroduce). The
+        // load is filesystem-coupled (`manifest_project_dirs()`), so we assert the
+        // dispatch source itself: the fallible load call appears only inside the
+        // Plan and Up match arms, never in Check/Rollback.
+        let src = include_str!("deploy.rs");
+        // Build the needle at runtime so this test's own source text (which mentions
+        // the fn name) can never be miscounted as a call site.
+        let needle = ["load_media_host_config", "()?"].concat();
+        let call_sites = src.matches(needle.as_str()).count();
+        assert_eq!(
+            call_sites, 2,
+            "expected exactly two fallible load-media call sites (Plan + Up), found {call_sites}",
+        );
+
+        // Isolate `run()`'s match arms and prove Rollback/Check don't load media.
+        let run_body = src
+            .split("pub fn run(action: DeployAction)")
+            .nth(1)
+            .expect("run() present");
+        let rollback_arm = run_body
+            .split("DeployAction::Rollback =>")
+            .nth(1)
+            .expect("Rollback arm present");
+        // Rollback dispatch line runs to the next arm.
+        let rollback_line = rollback_arm
+            .split("DeployAction::Up")
+            .next()
+            .expect("Up arm follows Rollback");
+        assert!(
+            !rollback_line.contains("load_media_host_config"),
+            "the Rollback arm must not load the media config",
+        );
+        let check_arm = run_body
+            .split("DeployAction::Check =>")
+            .nth(1)
+            .and_then(|s| s.split("DeployAction::Rollback").next())
+            .expect("Check arm present");
+        assert!(
+            !check_arm.contains("load_media_host_config"),
+            "the Check arm must not load the media config",
+        );
     }
 }

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -1239,15 +1239,14 @@ fn print_media_plan(media_cfg: &media::MediaMtxHostConfig) {
     );
 }
 
-/// Grade the media host and provision `MediaMTX` as a systemd unit over the live
-/// executor (issue #1974, Slice 7). A no-op when `[media.mediamtx]` is not
-/// enabled.
-///
-/// Runs the three fail-closed doctor checks first (`FFmpeg` preflight, recordings
-/// dir writable, ports available) and aborts the deploy on any failure — so a
-/// host that cannot serve media never gets a half-provisioned unit — then drives
-/// the controller's write-config / write-unit / enable+restart ops.
-fn provision_media_host(
+/// Grade the media host with the three fail-closed, **non-mutating** doctor
+/// checks (`FFmpeg` preflight, recordings dir writable, ports available) and abort
+/// the deploy on any failure — so a host that cannot serve media fails fast BEFORE
+/// the app deploy touches anything. A no-op when `[media.mediamtx]` is not
+/// enabled. This writes and restarts nothing; the mutating provisioning is
+/// deferred to [`provision_media_host`], which runs only after the app cutover
+/// succeeds.
+fn check_media_host_preflight(
     media_cfg: &media::MediaMtxHostConfig,
     ffmpeg_bin: &str,
     executor: &impl exec::DeployExecutor,
@@ -1255,13 +1254,37 @@ fn provision_media_host(
     if !media_cfg.enabled {
         return Ok(());
     }
-    eprintln!("\u{1F3A5} provisioning MediaMTX host (autumn-media)\n");
+    eprintln!("\u{1F3A5} media host preflight (autumn-media)\n");
 
     let checks = media::collect_media_doctor_checks(executor, media_cfg, ffmpeg_bin);
     let failed = report_preflight(&checks);
     if failed > 0 {
         return Err(DeployError::PreflightFailed(failed));
     }
+    Ok(())
+}
+
+/// Provision `MediaMTX` as a systemd unit over the live executor — write the
+/// rendered `mediamtx.yml` + unit and enable/restart the service (issue #1974,
+/// Slice 7). A no-op when `[media.mediamtx]` is not enabled.
+///
+/// **Runs only AFTER the app deploy/cutover has fully succeeded.** The app deploy
+/// rolls back on failure (readiness-gate miss, migration failure) and leaves the
+/// OLD release serving; there is deliberately no media teardown restoring the
+/// previous `mediamtx.yml`, so mutating (and possibly restarting) the host
+/// `MediaMTX` unit BEFORE the app is committed would strand a rolled-back release
+/// against a media daemon whose ports/recording-paths/matchers just moved.
+/// Deferring the mutation until the deploy is committed means a failed/rolled-back
+/// app deploy never writes or restarts `MediaMTX`. The non-mutating doctor checks
+/// already ran up front in [`check_media_host_preflight`].
+fn provision_media_host(
+    media_cfg: &media::MediaMtxHostConfig,
+    executor: &impl exec::DeployExecutor,
+) -> Result<(), DeployError> {
+    if !media_cfg.enabled {
+        return Ok(());
+    }
+    eprintln!("\u{1F3A5} provisioning MediaMTX host (autumn-media)\n");
 
     let controller = media::MediaMtxController::new(media_cfg.clone());
     exec::run_ops(&controller.ensure_installed_ops(), executor)
@@ -1541,8 +1564,12 @@ fn run_up(
     let proxy = proxy::KamalProxyController::new(resolved.readiness_timeout_secs)
         .with_tls_host(resolved.tls_host.clone());
     let executor = exec::SshExecutor::new(target);
-    // MediaMTX host provisioning (#1974 Slice 7) — no-op unless enabled (see fn).
-    provision_media_host(media_cfg, ffmpeg_bin, &executor)?;
+    // MediaMTX host preflight (#1974 Slice 7) — non-mutating doctor checks run
+    // BEFORE the app deploy so a bad media host fails fast without anything being
+    // written. The MUTATING provisioning (write config/unit + restart) is deferred
+    // until after the app cutover succeeds (below) so a rolled-back app deploy
+    // never touches the host MediaMTX unit. No-op unless enabled (see fn).
+    check_media_host_preflight(media_cfg, ffmpeg_bin, &executor)?;
 
     let release_dir = format!("{}/{release_id}", resolved.releases_dir());
 
@@ -1646,6 +1673,13 @@ fn run_up(
         exec::execute_redeploy(&checks, &ops, &teardown, &executor)
     };
     result.map_err(|e| DeployError::Exec(e.to_string()))?;
+
+    // App deploy is committed here: the cutover succeeded and there is no longer a
+    // rollback path. Only NOW provision the host MediaMTX unit (write config/unit +
+    // restart) — deferring the mutation past this point means a failed/rolled-back
+    // app deploy above never wrote or restarted MediaMTX (#1974 Slice 7). No-op
+    // unless enabled (see fn).
+    provision_media_host(media_cfg, &executor)?;
 
     eprintln!("\n\u{2705} Deploy complete. Roll back with `autumn deploy rollback`.");
     Ok(())
@@ -3015,6 +3049,71 @@ mod tests {
         assert!(
             !check_arm.contains("load_media_host_config"),
             "the Check arm must not load the media config",
+        );
+    }
+
+    #[test]
+    fn media_provisioning_is_deferred_past_app_cutover_in_up() {
+        // Finding K: the MUTATING MediaMTX provisioning must run only AFTER the app
+        // deploy/cutover commits. The app deploy rolls back on failure (readiness
+        // gate, migrations) and leaves the OLD release serving, and there is
+        // deliberately no media teardown — so writing/restarting the host MediaMTX
+        // unit BEFORE the app is committed would strand a rolled-back release
+        // against a moved media daemon. We assert the `run_up` source order: the
+        // non-mutating preflight precedes the app deploy, and `provision_media_host`
+        // is invoked only after the committing `result.map_err(...)?` line.
+        let src = include_str!("deploy.rs");
+        let up_body = src
+            .split("fn run_up(")
+            .nth(1)
+            .and_then(|s| s.split("\nfn run_rollback(").next())
+            .expect("run_up body present");
+
+        let preflight_at = up_body
+            .find("check_media_host_preflight(media_cfg")
+            .expect("preflight call present in run_up");
+        // The app deploy is executed via execute_first_deploy/execute_redeploy and
+        // committed by this `result.map_err(...)?` line; a failed deploy returns
+        // here (after the teardown-on-failure) before anything below runs.
+        let commit_at = up_body
+            .find("result.map_err(|e| DeployError::Exec(e.to_string()))?;")
+            .expect("app deploy commit line present in run_up");
+        let provision_at = up_body
+            .find("provision_media_host(media_cfg, &executor)?;")
+            .expect("deferred provisioning call present in run_up");
+
+        assert!(
+            preflight_at < commit_at,
+            "media preflight must precede the app deploy commit",
+        );
+        assert!(
+            commit_at < provision_at,
+            "MediaMTX provisioning must run only AFTER the app deploy commits — so a \
+             rolled-back app deploy (which returns at the commit line) never reaches it",
+        );
+
+        // The preflight itself is non-mutating: it runs the doctor checks but must
+        // NOT drive the controller ops (those live only in provision_media_host).
+        let preflight_fn = src
+            .split("fn check_media_host_preflight(")
+            .nth(1)
+            .and_then(|s| s.split("\nfn provision_media_host(").next())
+            .expect("check_media_host_preflight present");
+        assert!(
+            preflight_fn.contains("collect_media_doctor_checks"),
+            "preflight must run the doctor checks",
+        );
+        assert!(
+            !preflight_fn.contains("ensure_installed_ops"),
+            "preflight must NOT drive the mutating controller ops (write/restart)",
+        );
+
+        // And the mutating provisioning is reachable only on the post-commit path.
+        let after_commit = &up_body[commit_at..];
+        assert!(
+            after_commit.contains("provision_media_host(media_cfg, &executor)?;"),
+            "provisioning must sit on the post-commit path (unreachable when the app \
+             deploy errors out at the commit line)",
         );
     }
 }

--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -851,7 +851,7 @@ pub fn run(action: DeployAction) -> Result<(), DeployError> {
     // from the project `autumn.toml` string (like the media plugin reads
     // `[media]`), so it needs no `AutumnConfig`/plugin coupling and defaults to
     // disabled — a non-media project is byte-for-byte unaffected.
-    let (media_cfg, ffmpeg_bin) = load_media_host_config();
+    let (media_cfg, ffmpeg_bin) = load_media_host_config()?;
 
     match action {
         // `plan` is a pure dry-run over `resolved` alone — it never grades or
@@ -880,10 +880,20 @@ pub fn run(action: DeployAction) -> Result<(), DeployError> {
 /// Reads the raw `autumn.toml` string and deserializes only the `[media]`
 /// subtree (mirroring how `autumn-media-plugin` reads its own config), so it
 /// bypasses `autumn-web`'s strict `AutumnConfig` schema and adds no dependency on
-/// the plugin. A missing or unparseable file yields the disabled default plus
-/// the default `FFmpeg` path, so a project that does not use autumn-media is
-/// unaffected.
-fn load_media_host_config() -> (media::MediaMtxHostConfig, String) {
+/// the plugin. A missing file (or one that cannot be read) yields the disabled
+/// default plus the default `FFmpeg` path, so a project that does not use
+/// autumn-media is unaffected.
+///
+/// **Fails closed on invalid media config.** A `[media.mediamtx]` /
+/// `[media.ffmpeg]` table that is *present but does not deserialize* (a
+/// wrong-typed value) is an error, not a silent fallback: it returns
+/// [`DeployError::Config`] so `deploy plan`/`deploy up` abort with a clear
+/// message instead of proceeding WITHOUT provisioning a media-enabled app's
+/// `MediaMTX` daemon. The disabled default is reserved for the genuinely *absent*
+/// case — `from_toml_str` / `ffmpeg_bin_from_toml_str` map a missing table to
+/// `Ok(default)` and a present-but-invalid table to `Err`, so a non-media
+/// project stays unaffected while a broken media config can never be swallowed.
+fn load_media_host_config() -> Result<(media::MediaMtxHostConfig, String), DeployError> {
     let disabled = || {
         (
             media::MediaMtxHostConfig::default(),
@@ -891,15 +901,23 @@ fn load_media_host_config() -> (media::MediaMtxHostConfig, String) {
         )
     };
     let Some(path) = first_dir_with_file(&manifest_project_dirs(), "autumn.toml") else {
-        return disabled();
+        return Ok(disabled());
     };
     let Ok(contents) = std::fs::read_to_string(&path) else {
-        return disabled();
+        return Ok(disabled());
     };
-    let cfg = media::MediaMtxHostConfig::from_toml_str(&contents).unwrap_or_default();
-    let bin = media::ffmpeg_bin_from_toml_str(&contents)
-        .unwrap_or_else(|_| media::DEFAULT_FFMPEG_BIN.to_owned());
-    (cfg, bin)
+    // `from_toml_str` parses the whole `[media]` subtree (both `mediamtx` and the
+    // sibling `ffmpeg` table), so a type error in *either* surfaces here — the
+    // second `ffmpeg_bin_from_toml_str` parse is a defensive companion. Propagate
+    // rather than `.unwrap_or_default()` so a malformed media config aborts the
+    // deploy instead of silently disabling MediaMTX provisioning.
+    let cfg = media::MediaMtxHostConfig::from_toml_str(&contents).map_err(|e| {
+        DeployError::Config(format!("invalid [media] config in {}: {e}", path.display()))
+    })?;
+    let bin = media::ffmpeg_bin_from_toml_str(&contents).map_err(|e| {
+        DeployError::Config(format!("invalid [media] config in {}: {e}", path.display()))
+    })?;
+    Ok((cfg, bin))
 }
 
 /// An [`Env`] that forces `AUTUMN_ENV` to a specific deploy profile while

--- a/autumn-cli/src/deploy/exec.rs
+++ b/autumn-cli/src/deploy/exec.rs
@@ -1721,7 +1721,9 @@ fn execute_with_teardown(
     kind: TeardownKind,
     exec: &impl DeployExecutor,
 ) -> Result<(), DeployExecError> {
-    let failed = checks.iter().filter(|c| !c.passed).count();
+    // Only genuinely blocking failures abort — a deferred check (resolved in the
+    // service's own runtime) is non-blocking and never aborts the deploy.
+    let failed = checks.iter().filter(|c| c.blocking()).count();
     if failed > 0 {
         return Err(DeployExecError::PreflightAborted { failed });
     }

--- a/autumn-cli/src/deploy/media.rs
+++ b/autumn-cli/src/deploy/media.rs
@@ -33,6 +33,30 @@
 //!   unverifiable result (transport error, unparseable output) reports a clear
 //!   failure — never a silent pass.
 //!
+//! ## `FFmpeg` path resolution (decoupled from the plugin)
+//!
+//! `[media.ffmpeg] bin` may be written as a `${VAR}` placeholder or overridden by
+//! the `AUTUMN_MEDIA__FFMPEG__BIN` environment variable — the plugin resolves both
+//! before it ever shells out to `FFmpeg`. So the deploy-side preflight must probe
+//! the binary the app will *actually* run, not the raw TOML literal.
+//! [`resolve_ffmpeg_bin`] mirrors the plugin's resolution: the
+//! `AUTUMN_MEDIA__FFMPEG__BIN` process-env override wins over the configured
+//! value, and a whole-string `${VAR}` value is interpolated from the process env
+//! (unset ⇒ empty). It is a deliberately decoupled re-implementation — this crate
+//! takes **no** `autumn-media-plugin` dependency — so it matches only the plugin's
+//! *whole-string* `${VAR}` rule; an *embedded* placeholder (`/opt/${VER}/ffmpeg`)
+//! is left literal and therefore still contains `${`.
+//!
+//! **Fail-closed-honest.** When resolution leaves the path empty or still
+//! containing an unresolved `${`, [`ffmpeg_preflight`] does **not** probe a literal
+//! placeholder or a wrong default — it returns a clear non-passing outcome
+//! ("ffmpeg path unresolved (env/interpolation indirection); deferring
+//! verification to runtime") so the operator sees the indirection rather than a
+//! false pass/fail against the wrong binary. Known limitation of the decoupled
+//! resolver: an embedded `${...}` the plugin *could* resolve is reported as
+//! deferred here (the plugin only interpolates whole-string placeholders, so full
+//! parity holds for the whole-string form).
+//!
 //! ## `MediaMTX` = a SEPARATE host daemon
 //!
 //! Compose/Fly deployments can still run `MediaMTX` as a separate service/app
@@ -332,6 +356,20 @@ pub fn render_mediamtx_yml(cfg: &MediaMtxHostConfig) -> String {
     format!(
         "logLevel: info\n\
          \n\
+         # Only the protocols autumn-media manages are enabled below (RTMP ingest,\n\
+         # HLS, WebRTC/WHEP playback, the control API, and the recording-playback\n\
+         # server). Every other protocol MediaMTX turns on by default is disabled\n\
+         # explicitly, so the systemd unit only ever opens the ports this deploy\n\
+         # plan declares — an occupied default RTSP (:8554) or SRT (:8890) port\n\
+         # cannot make `systemctl restart mediamtx` fail after preflight passed.\n\
+         # (`rtsp: no` also disables RTSPS; `metrics`/`pprof` default off but are\n\
+         # pinned off for the same 'declared ports only' contract. This MediaMTX\n\
+         # release line ships no MoQ server, so there is no MoQ listener to close.)\n\
+         rtsp: no\n\
+         srt: no\n\
+         metrics: no\n\
+         pprof: no\n\
+         \n\
          api: true\n\
          apiAddress: :{api}\n\
          \n\
@@ -543,31 +581,98 @@ const RECORDINGS_HINT: &str =
 const PORTS_HINT: &str =
     "Free the conflicting MediaMTX ports on the host (or stop the service already bound to them)";
 
+/// The plugin's `FFmpeg` bin env override (`[media.ffmpeg] bin`). Set in the
+/// deploy/runtime environment, it wins over the configured TOML value — exactly
+/// as `autumn-media-plugin` resolves it before running any workflow.
+pub const FFMPEG_BIN_ENV_OVERRIDE: &str = "AUTUMN_MEDIA__FFMPEG__BIN";
+
+/// Remediation hint shown when the resolved `FFmpeg` path is still an unresolved
+/// `${VAR}` / env indirection the deploy-side resolver cannot expand.
+const FFMPEG_UNRESOLVED_HINT: &str = "Set AUTUMN_MEDIA__FFMPEG__BIN (or export the ${VAR} it references) in the deploy \
+     environment so the FFmpeg path resolves to a concrete binary";
+
+/// Resolve `[media.ffmpeg] bin` to the path the app will actually run, from the
+/// process environment — mirroring `autumn-media-plugin`'s own resolution without
+/// depending on the plugin. Delegates to [`resolve_ffmpeg_bin_with`] with a
+/// `std::env`-backed lookup.
+#[must_use]
+pub fn resolve_ffmpeg_bin(configured: &str) -> String {
+    resolve_ffmpeg_bin_with(configured, |key| std::env::var(key).ok())
+}
+
+/// Pure resolver core (testable with an injected `lookup`, so no process-env
+/// mutation is needed): the `AUTUMN_MEDIA__FFMPEG__BIN` override wins over
+/// `configured`, and a **whole-string** `${VAR}` value is interpolated from
+/// `lookup` (unset ⇒ empty string, matching the plugin's `resolve_placeholder`).
+/// An *embedded* placeholder is deliberately left literal — the plugin only
+/// interpolates whole-string placeholders — so it survives as an unresolved
+/// `${...}` the caller's guard treats as deferred.
+#[must_use]
+fn resolve_ffmpeg_bin_with(configured: &str, lookup: impl Fn(&str) -> Option<String>) -> String {
+    // Whole-string `${VAR}` interpolation of the configured value (plugin parity:
+    // only an exact `${VAR}` is expanded; unset resolves to empty).
+    let interpolated = configured
+        .strip_prefix("${")
+        .and_then(|rest| rest.strip_suffix('}'))
+        .map_or_else(
+            || configured.to_owned(),
+            |var| lookup(var).unwrap_or_default(),
+        );
+    // The env override wins (verbatim), like the plugin's `override_string` applied
+    // after interpolation. A blank/whitespace override is treated as unset so an
+    // empty export never silently becomes the path.
+    match lookup(FFMPEG_BIN_ENV_OVERRIDE) {
+        Some(v) if !v.trim().is_empty() => v,
+        _ => interpolated,
+    }
+}
+
 /// Grade that `FFmpeg` resolves on the host and reports a version banner
 /// (generalized from arroyo's boot preflight).
 ///
-/// Runs `<ffmpeg_bin> -version` over the executor and requires the standard
+/// First resolves `ffmpeg_bin` via [`resolve_ffmpeg_bin`] (env override +
+/// whole-string `${VAR}` interpolation) so the probe targets the binary the app
+/// will actually run — not a raw `${VAR}` literal. **Fail-closed-honest:** if the
+/// resolved path is empty or still contains an unresolved `${`, it does NOT probe
+/// (a literal placeholder / wrong default would be a false pass/fail); it reports
+/// a clear non-passing "deferred to runtime" outcome instead. Otherwise it runs
+/// `<resolved> -version` over the executor and requires the standard
 /// `ffmpeg version` banner in stdout — a binary that is missing, not executable,
 /// or is not actually `FFmpeg` (no banner) is a clear failure. Fail-closed: a
 /// transport error is a failure, not a pass.
 #[must_use]
 pub fn ffmpeg_preflight(exec: &impl DeployExecutor, ffmpeg_bin: &str) -> PreflightCheck {
+    let resolved = resolve_ffmpeg_bin(ffmpeg_bin);
+    // Unverifiable path: empty (an unset whole-string `${VAR}`) or an embedded
+    // placeholder we cannot expand. Defer to runtime rather than probe the wrong
+    // binary — the plugin resolves these itself before it runs FFmpeg.
+    if resolved.trim().is_empty() || resolved.contains("${") {
+        return PreflightCheck {
+            name: CHECK_FFMPEG_PREFLIGHT,
+            passed: false,
+            detail: format!(
+                "FFmpeg path unresolved (env/interpolation indirection): `{ffmpeg_bin}` \
+                 resolves to `{resolved}`; deferring verification to runtime"
+            ),
+            hint: Some(FFMPEG_UNRESOLVED_HINT),
+        };
+    }
     let cmd = RemoteCommand::new(
         "media-ffmpeg-preflight",
-        format!("{} -version", super::exec::shell_quote(ffmpeg_bin)),
+        format!("{} -version", super::exec::shell_quote(&resolved)),
     );
     match exec.run(&cmd) {
         Ok(out) if out.stdout.contains("ffmpeg version") => PreflightCheck {
             name: CHECK_FFMPEG_PREFLIGHT,
             passed: true,
-            detail: format!("FFmpeg resolves at `{ffmpeg_bin}` and reports a version banner"),
+            detail: format!("FFmpeg resolves at `{resolved}` and reports a version banner"),
             hint: None,
         },
         Ok(_) => PreflightCheck {
             name: CHECK_FFMPEG_PREFLIGHT,
             passed: false,
             detail: format!(
-                "`{ffmpeg_bin} -version` ran but did not report an `ffmpeg version` banner — \
+                "`{resolved} -version` ran but did not report an `ffmpeg version` banner — \
                  the binary is not FFmpeg"
             ),
             hint: Some(FFMPEG_HINT),
@@ -575,7 +680,7 @@ pub fn ffmpeg_preflight(exec: &impl DeployExecutor, ffmpeg_bin: &str) -> Preflig
         Err(err) => PreflightCheck {
             name: CHECK_FFMPEG_PREFLIGHT,
             passed: false,
-            detail: format!("could not run `{ffmpeg_bin} -version` on the host: {err}"),
+            detail: format!("could not run `{resolved} -version` on the host: {err}"),
             hint: Some(FFMPEG_HINT),
         },
     }
@@ -1024,6 +1129,27 @@ unit_name = \"mediamtx-prod\"
     }
 
     #[test]
+    fn rendered_yml_disables_unmanaged_protocols_but_keeps_managed_ones() {
+        // Finding E: MediaMTX fills omitted protocol flags from its own defaults, so
+        // RTSP (:8554) and SRT (:8890) would otherwise listen even though the deploy
+        // plan never declares/checks those ports — an occupied default port could
+        // then fail `systemctl restart mediamtx` after preflight passed. The template
+        // pins every unmanaged default-on protocol OFF so the unit only opens the
+        // declared ports.
+        let yml = render_mediamtx_yml(&MediaMtxHostConfig::default());
+        assert!(yml.contains("rtsp: no"), "RTSP must be disabled: {yml}");
+        assert!(yml.contains("srt: no"), "SRT must be disabled: {yml}");
+        assert!(yml.contains("metrics: no"), "metrics must be off: {yml}");
+        assert!(yml.contains("pprof: no"), "pprof must be off: {yml}");
+        // The managed protocols stay enabled (RTMP/HLS/WebRTC/API/playback).
+        assert!(yml.contains("rtmp: true"), "rtmp managed: {yml}");
+        assert!(yml.contains("hls: true"), "hls managed: {yml}");
+        assert!(yml.contains("webrtc: true"), "webrtc managed: {yml}");
+        assert!(yml.contains("api: true"), "api managed: {yml}");
+        assert!(yml.contains("playback: true"), "playback managed: {yml}");
+    }
+
+    #[test]
     fn rendered_yml_has_both_live_and_room_path_matchers() {
         let yml = render_mediamtx_yml(&MediaMtxHostConfig::default());
         assert!(yml.contains("~^live/.+$:"), "broadcast matcher: {yml}");
@@ -1236,6 +1362,75 @@ unit_name = \"mediamtx-prod\"
         let check = ffmpeg_preflight(&exec, "/usr/bin/ffmpeg");
         assert!(!check.passed);
         assert!(check.detail.contains("could not run"));
+    }
+
+    // ── Finding G: FFmpeg path resolution (env override + `${VAR}`) ───────────
+    //
+    // The resolver core is exercised through the injected-`lookup` variant so no
+    // process-env mutation (unsafe under edition 2024, and racy across parallel
+    // tests) is needed. `ffmpeg_preflight`'s public wrapper reads `std::env`, but
+    // its unverifiable-path guard is exercised via `resolve_ffmpeg_bin_with` +
+    // the fake executor below.
+
+    #[test]
+    fn resolve_honors_env_override_over_toml_value() {
+        // Finding G (1): AUTUMN_MEDIA__FFMPEG__BIN wins over the configured value.
+        let resolved = resolve_ffmpeg_bin_with("/usr/bin/ffmpeg", |k| {
+            (k == FFMPEG_BIN_ENV_OVERRIDE).then(|| "/opt/custom/ffmpeg".to_owned())
+        });
+        assert_eq!(resolved, "/opt/custom/ffmpeg");
+        // A blank override is treated as unset — the TOML value stands.
+        let resolved_blank = resolve_ffmpeg_bin_with("/usr/bin/ffmpeg", |k| {
+            (k == FFMPEG_BIN_ENV_OVERRIDE).then(|| "   ".to_owned())
+        });
+        assert_eq!(resolved_blank, "/usr/bin/ffmpeg");
+    }
+
+    #[test]
+    fn resolve_interpolates_whole_string_placeholder_from_env() {
+        // Finding G (2): a whole-string `${VAR}` value is expanded from the env.
+        let resolved = resolve_ffmpeg_bin_with("${FF_BIN}", |k| {
+            (k == "FF_BIN").then(|| "/usr/local/bin/ffmpeg".to_owned())
+        });
+        assert_eq!(resolved, "/usr/local/bin/ffmpeg");
+        // An unset whole-string placeholder resolves to empty (plugin parity).
+        let unset = resolve_ffmpeg_bin_with("${FF_BIN}", |_| None);
+        assert_eq!(unset, "");
+    }
+
+    #[test]
+    fn ffmpeg_preflight_defers_on_unresolved_path_without_probing() {
+        // Finding G (3): an empty resolution (unset whole-string `${VAR}`) and an
+        // embedded placeholder we can't expand both DEFER — a clear non-passing
+        // outcome, and crucially NO probe of a literal placeholder runs.
+        for configured in ["${FF_BIN_UNSET_XYZ}", "/opt/${VER}/ffmpeg"] {
+            let exec = RecordingExecutor::new();
+            let check = ffmpeg_preflight(&exec, configured);
+            assert!(!check.passed, "must be non-passing for `{configured}`");
+            assert!(
+                check.detail.contains("unresolved") && check.detail.contains("deferring"),
+                "detail must name the deferral for `{configured}`: {}",
+                check.detail
+            );
+            assert!(check.hint.is_some());
+            // Fail-closed-honest: never probed the wrong/placeholder binary.
+            assert!(
+                exec.labels().is_empty(),
+                "no probe must run for `{configured}`, ran {:?}",
+                exec.labels()
+            );
+        }
+    }
+
+    #[test]
+    fn ffmpeg_preflight_probes_a_concrete_resolved_path() {
+        // A concrete (non-placeholder, no override) path resolves to itself and IS
+        // probed — the healthy path is unchanged by the resolver.
+        let exec = RecordingExecutor::new()
+            .with_stdout("media-ffmpeg-preflight", "ffmpeg version 6.1.1 Copyright");
+        let check = ffmpeg_preflight(&exec, "/usr/bin/ffmpeg");
+        assert!(check.passed, "detail: {}", check.detail);
+        assert_eq!(exec.labels(), vec!["media-ffmpeg-preflight"]);
     }
 
     // ── Doctor: recordings dir writable ──────────────────────────────────────

--- a/autumn-cli/src/deploy/media.rs
+++ b/autumn-cli/src/deploy/media.rs
@@ -26,12 +26,15 @@
 //!   [`DeployExecutor`](super::exec::DeployExecutor), so the remote command
 //!   sequence is assertable against a recording fake with no live host. It
 //!   no-ops (empty op vector) when the section is not `enabled`.
-//! - Three fail-closed doctor checks — [`ffmpeg_preflight`],
-//!   [`recordings_dir_writable`], and [`mediamtx_ports_available`] — run over the
-//!   same executor and return the shared [`PreflightCheck`] type, so a media host
-//!   can be graded the same way `autumn deploy check` grades the app host. An
-//!   unverifiable result (transport error, unparseable output) reports a clear
-//!   failure — never a silent pass.
+//! - Four fail-closed doctor checks — [`ffmpeg_preflight`],
+//!   [`mediamtx_binary_preflight`], [`recordings_dir_writable`], and
+//!   [`mediamtx_ports_available`] — run over the same executor and return the
+//!   shared [`PreflightCheck`] type, so a media host can be graded the same way
+//!   `autumn deploy check` grades the app host. The binary preflight runs before
+//!   cutover so a host missing the (deferred-provisioned) `MediaMTX` binary fails
+//!   fast instead of committing the app and then failing the post-cutover
+//!   restart. An unverifiable result (transport error, unparseable output)
+//!   reports a clear failure — never a silent pass.
 //!
 //! ## `FFmpeg` path verification (concrete literals only)
 //!
@@ -370,8 +373,14 @@ pub fn render_mediamtx_yml(cfg: &MediaMtxHostConfig) -> String {
          metrics: no\n\
          pprof: no\n\
          \n\
+         # The control API is the server-side control plane: the co-located app\n\
+         # reaches it at 127.0.0.1:{api} and it is intentionally excluded from the\n\
+         # browser-facing CSP origins, so bind it to loopback only rather than\n\
+         # every interface. The viewer/ingest listeners below (RTMP, HLS,\n\
+         # WebRTC/WHEP, playback) stay bound on all interfaces so encoders and\n\
+         # browsers can reach them.\n\
          api: true\n\
-         apiAddress: :{api}\n\
+         apiAddress: 127.0.0.1:{api}\n\
          \n\
          playback: true\n\
          playbackAddress: :{playback}\n\
@@ -609,6 +618,8 @@ pub const CHECK_FFMPEG_PREFLIGHT: &str = "media_ffmpeg_preflight";
 pub const CHECK_RECORDINGS_DIR_WRITABLE: &str = "media_recordings_dir_writable";
 /// The check name for the `MediaMTX` port-availability probe.
 pub const CHECK_MEDIAMTX_PORTS_AVAILABLE: &str = "media_mediamtx_ports_available";
+/// The check name for the `MediaMTX` binary-executable preflight.
+pub const CHECK_MEDIAMTX_BINARY: &str = "media_mediamtx_binary";
 
 /// Remediation hint shown when `FFmpeg` does not resolve.
 const FFMPEG_HINT: &str =
@@ -619,6 +630,9 @@ const RECORDINGS_HINT: &str =
 /// Remediation hint shown when a `MediaMTX` port is occupied or unverifiable.
 const PORTS_HINT: &str =
     "Free the conflicting MediaMTX ports on the host (or stop the service already bound to them)";
+/// Remediation hint shown when the `MediaMTX` binary is missing / not executable.
+const MEDIAMTX_BINARY_HINT: &str = "Install the MediaMTX binary at `[media.mediamtx] binary_path` on the host — a host-bootstrap \
+     prerequisite (download/version-pin the Go binary, exactly as autumn does for kamal-proxy)";
 
 /// Remediation hint shown when `[media.ffmpeg] bin` is env/interpolation
 /// indirected and therefore deferred to the service's own runtime resolution.
@@ -999,13 +1013,64 @@ fn join_ports(ports: &[u16]) -> String {
         .join(", ")
 }
 
-/// Collect the three `MediaMTX` host doctor checks against a live executor.
+/// Grade that the configured `MediaMTX` binary exists and is executable on the
+/// host.
 ///
-/// Runs the `FFmpeg` preflight (against `ffmpeg_bin`), the recordings-dir probe,
-/// and the port-availability probe — returning the shared [`PreflightCheck`]
-/// results so a caller that already holds a [`DeployExecutor`] can grade a media
-/// host the same way `autumn deploy check` grades the app host. `ffmpeg_bin` is
-/// the resolved `[media.ffmpeg] bin` (the plugin's default is `/usr/bin/ffmpeg`).
+/// The binary is a **host-bootstrap prerequisite** — the Go binary is
+/// downloaded / version-pinned by host bootstrap (see the module rustdoc), never
+/// provisioned by this module, exactly as autumn treats kamal-proxy. This check
+/// verifies it is present before cutover.
+///
+/// **Why this must run in the pre-cutover preflight:** [`provision_media_host`]
+/// (which writes the unit and runs `systemctl … restart`) is deliberately
+/// deferred until AFTER the app deploy commits. Without this check a host missing
+/// the binary passes the other three checks, the app cuts over, and only THEN
+/// does the deferred `systemctl restart` fail on the missing `ExecStart` —
+/// leaving the new release live without its media daemon. Verifying `binary_path`
+/// up front turns that into a clean, fail-closed preflight failure before any
+/// cutover, symmetric with [`ffmpeg_preflight`].
+///
+/// Runs `test -x <binary_path>` over the executor — non-mutating. Fail-closed: a
+/// missing/not-executable binary (non-zero exit → transport error) and any other
+/// transport failure both report a clear failure naming `binary_path`.
+#[must_use]
+pub fn mediamtx_binary_preflight(
+    exec: &impl DeployExecutor,
+    cfg: &MediaMtxHostConfig,
+) -> PreflightCheck {
+    let bin = &cfg.binary_path;
+    let cmd = RemoteCommand::new(
+        "media-mediamtx-binary",
+        format!("test -x {}", super::exec::shell_quote(bin)),
+    );
+    match exec.run(&cmd) {
+        Ok(_) => PreflightCheck {
+            name: CHECK_MEDIAMTX_BINARY,
+            passed: true,
+            detail: format!("MediaMTX binary `{bin}` exists and is executable"),
+            hint: None,
+        },
+        Err(err) => PreflightCheck {
+            name: CHECK_MEDIAMTX_BINARY,
+            passed: false,
+            detail: format!(
+                "MediaMTX binary `{bin}` is missing or not executable: {err} — MediaMTX cannot \
+                 start, so the post-cutover `systemctl restart` would fail; the binary is a \
+                 host-bootstrap prerequisite (download/version-pin it, like kamal-proxy)"
+            ),
+            hint: Some(MEDIAMTX_BINARY_HINT),
+        },
+    }
+}
+
+/// Collect the four `MediaMTX` host doctor checks against a live executor.
+///
+/// Runs the `FFmpeg` preflight (against `ffmpeg_bin`), the `MediaMTX`
+/// binary-executable preflight, the recordings-dir probe, and the
+/// port-availability probe — returning the shared [`PreflightCheck`] results so a
+/// caller that already holds a [`DeployExecutor`] can grade a media host the same
+/// way `autumn deploy check` grades the app host. `ffmpeg_bin` is the resolved
+/// `[media.ffmpeg] bin` (the plugin's default is `/usr/bin/ffmpeg`).
 #[must_use]
 pub fn collect_media_doctor_checks(
     exec: &impl DeployExecutor,
@@ -1014,6 +1079,7 @@ pub fn collect_media_doctor_checks(
 ) -> Vec<PreflightCheck> {
     vec![
         ffmpeg_preflight(exec, ffmpeg_bin),
+        mediamtx_binary_preflight(exec, cfg),
         recordings_dir_writable(exec, cfg),
         mediamtx_ports_available(exec, cfg),
     ]
@@ -1196,12 +1262,50 @@ unit_name = \"mediamtx-prod\"
     #[test]
     fn rendered_yml_contains_every_port() {
         let yml = render_mediamtx_yml(&MediaMtxHostConfig::default());
-        assert!(yml.contains("apiAddress: :9997"), "api port: {yml}");
+        // The control API binds loopback-only (Finding M) — server-side control
+        // plane for the co-located app, excluded from browser-facing CSP origins.
+        assert!(
+            yml.contains("apiAddress: 127.0.0.1:9997"),
+            "api port: {yml}"
+        );
         assert!(yml.contains("playbackAddress: :9996"), "playback: {yml}");
         assert!(yml.contains("rtmpAddress: :1935"), "rtmp: {yml}");
         assert!(yml.contains("hlsAddress: :8888"), "hls: {yml}");
         assert!(yml.contains("webrtcAddress: :8889"), "webrtc: {yml}");
         assert!(yml.contains("webrtcLocalUDPAddress: :8189"), "udp: {yml}");
+    }
+
+    #[test]
+    fn rendered_yml_binds_api_to_loopback_but_leaves_public_listeners_open() {
+        // Finding M: the control API is the server-side control plane (the
+        // co-located app reaches it at 127.0.0.1) and is excluded from the
+        // browser-facing CSP origins, so it must NOT listen on every interface.
+        let yml = render_mediamtx_yml(&MediaMtxHostConfig::default());
+        assert!(
+            yml.contains("apiAddress: 127.0.0.1:9997"),
+            "control API must bind loopback only: {yml}"
+        );
+        assert!(
+            !yml.contains("apiAddress: :9997"),
+            "control API must NOT bind all interfaces: {yml}"
+        );
+        // The viewer/ingest-facing listeners MUST stay bound on all interfaces so
+        // encoders and browsers can reach them — none is loopback-bound.
+        for public in [
+            "rtmpAddress: :1935",
+            "hlsAddress: :8888",
+            "webrtcAddress: :8889",
+            "playbackAddress: :9996",
+        ] {
+            assert!(yml.contains(public), "public listener {public}: {yml}");
+        }
+        assert!(
+            !yml.contains("rtmpAddress: 127.0.0.1")
+                && !yml.contains("hlsAddress: 127.0.0.1")
+                && !yml.contains("webrtcAddress: 127.0.0.1")
+                && !yml.contains("playbackAddress: 127.0.0.1"),
+            "no public listener may be loopback-bound: {yml}"
+        );
     }
 
     #[test]
@@ -1262,7 +1366,7 @@ unit_name = \"mediamtx-prod\"
             ..MediaMtxHostConfig::default()
         };
         let yml = render_mediamtx_yml(&cfg);
-        assert!(yml.contains("apiAddress: :19997"));
+        assert!(yml.contains("apiAddress: 127.0.0.1:19997"));
         assert!(yml.contains("hlsAddress: :18888"));
         assert!(yml.contains("recordPath: /data/rec/%path/"));
         assert!(yml.contains("recordDeleteAfter: 24h"));
@@ -1588,6 +1692,88 @@ unit_name = \"mediamtx-prod\"
         assert_eq!(exec.labels(), vec!["media-ffmpeg-preflight"]);
     }
 
+    // ── Doctor: MediaMTX binary preflight (Finding N) ────────────────────────
+    //
+    // Provisioning (`systemctl … restart`) is deferred until AFTER the app
+    // cutover commits, so a host missing the MediaMTX binary must be caught by a
+    // non-mutating `test -x <binary_path>` check BEFORE cutover — otherwise the
+    // app commits and the deferred restart then fails on the missing `ExecStart`.
+
+    #[test]
+    fn mediamtx_binary_preflight_passes_when_executable() {
+        // `test -x` exits zero → Ok → pass.
+        let exec = RecordingExecutor::new();
+        let check = mediamtx_binary_preflight(&exec, &MediaMtxHostConfig::default());
+        assert!(check.passed, "detail: {}", check.detail);
+        assert_eq!(check.name, CHECK_MEDIAMTX_BINARY);
+        assert_eq!(exec.labels(), vec!["media-mediamtx-binary"]);
+        // Non-mutating: it only runs `test -x`, never a mutating command.
+        assert!(check.hint.is_none());
+    }
+
+    #[test]
+    fn mediamtx_binary_preflight_fails_when_missing_or_not_executable() {
+        // A missing / non-executable binary makes `test -x` exit non-zero → the
+        // fake surfaces a transport error → fail-closed, naming binary_path and
+        // the deferred-restart consequence.
+        let exec = RecordingExecutor::failing_on("media-mediamtx-binary");
+        let cfg = MediaMtxHostConfig::default();
+        let check = mediamtx_binary_preflight(&exec, &cfg);
+        assert!(!check.passed);
+        assert_eq!(check.name, CHECK_MEDIAMTX_BINARY);
+        assert!(
+            check.detail.contains(&cfg.binary_path),
+            "detail must name binary_path: {}",
+            check.detail
+        );
+        assert!(
+            check.detail.contains("systemctl restart"),
+            "detail must state the post-cutover restart would fail: {}",
+            check.detail
+        );
+        assert!(check.hint.is_some());
+    }
+
+    #[test]
+    fn mediamtx_binary_preflight_uses_test_x_and_shell_quotes_the_path() {
+        // Verify the exact non-mutating command shape (shell-quoted binary_path).
+        struct CaptureExec {
+            cmd: RefCell<Option<String>>,
+        }
+        impl DeployExecutor for CaptureExec {
+            fn run(&self, cmd: &RemoteCommand) -> Result<CommandOutput, DeployExecError> {
+                *self.cmd.borrow_mut() = Some(cmd.shell.clone());
+                Ok(CommandOutput {
+                    stdout: String::new(),
+                    stderr: String::new(),
+                })
+            }
+            fn upload(
+                &self,
+                _local: &Path,
+                _remote_path: &str,
+                _mode: Option<u32>,
+            ) -> Result<(), DeployExecError> {
+                Ok(())
+            }
+        }
+        let exec = CaptureExec {
+            cmd: RefCell::new(None),
+        };
+        let cfg = MediaMtxHostConfig {
+            binary_path: "/opt/media mtx/mediamtx".to_owned(),
+            ..MediaMtxHostConfig::default()
+        };
+        let _ = mediamtx_binary_preflight(&exec, &cfg);
+        let cmd = exec.cmd.borrow().clone().expect("command ran");
+        assert!(cmd.starts_with("test -x "), "must be `test -x`: {cmd}");
+        // Path with a space must be shell-quoted so it stays one argument.
+        assert!(
+            cmd.contains("'/opt/media mtx/mediamtx'"),
+            "binary_path must be shell-quoted: {cmd}"
+        );
+    }
+
     // ── Doctor: recordings dir writable ──────────────────────────────────────
 
     #[test]
@@ -1839,7 +2025,7 @@ sctp  LISTEN 0 128  0.0.0.0:9999  0.0.0.0:*
     }
 
     #[test]
-    fn collect_runs_all_three_checks_in_order() {
+    fn collect_runs_all_four_checks_in_order() {
         let exec = RecordingExecutor::new()
             .with_stdout("media-ffmpeg-preflight", "ffmpeg version 6.1")
             .with_stdout(
@@ -1848,12 +2034,16 @@ sctp  LISTEN 0 128  0.0.0.0:9999  0.0.0.0:*
             );
         let checks =
             collect_media_doctor_checks(&exec, &MediaMtxHostConfig::default(), "/usr/bin/ffmpeg");
-        assert_eq!(checks.len(), 3);
+        assert_eq!(checks.len(), 4);
         assert!(checks.iter().all(|c| c.passed), "all should pass");
         assert_eq!(
             exec.labels(),
             vec![
                 "media-ffmpeg-preflight",
+                // The MediaMTX binary preflight (Finding N) runs before cutover,
+                // symmetric with the FFmpeg preflight, so a host missing the
+                // deferred-provisioned binary fails fast.
+                "media-mediamtx-binary",
                 "media-recordings-dir",
                 // The ports check is a single process-aware `ss -tulnp` scan; the
                 // old `systemctl is-active` gate was removed (Finding D).

--- a/autumn-cli/src/deploy/media.rs
+++ b/autumn-cli/src/deploy/media.rs
@@ -1,0 +1,1152 @@
+//! `MediaMTX` host provisioning for autumn-media (issue #1974, Slice 7).
+//!
+//! [autumn-media](../../../../autumn-media-plugin/index.html) turns `MediaMTX` +
+//! `FFmpeg` into the streaming substrate for an Autumn app: RTMP/WHIP ingest,
+//! HLS/WebRTC/WHEP playback, recording, and a control API — served by a Go
+//! binary that is a **host prerequisite, not a cargo dependency**. This module
+//! provisions that binary on a bare host from `autumn deploy`, mirroring exactly
+//! how [`super::proxy::KamalProxyController`] provisions kamal-proxy: a
+//! non-Rust host daemon is a systemd unit written and enabled by ordered
+//! [`DeployOp`]s over ssh; the binary itself (download / version pin) is left to
+//! host bootstrap.
+//!
+//! ## What is real here
+//!
+//! - [`MediaMtxHostConfig`] deserializes the `[media.mediamtx]` deploy section
+//!   (defaults everywhere, so a project that never runs the media controller is
+//!   unaffected). The `MediaMTX` ports are real [`u16`] constants with defaults
+//!   ([`MEDIAMTX_API_PORT`] etc.), NOT parsed out of URL strings.
+//! - [`render_mediamtx_yml`] renders the ingest/playback/recording config
+//!   (generalized from arroyo's `mediamtx.yml`), and [`render_mediamtx_unit`]
+//!   renders the `/etc/systemd/system/<unit>.service` unit — both pure, so the
+//!   exact rendered text is unit-testable.
+//! - [`MediaMtxController::ensure_installed_ops`] emits the ordered
+//!   [`DeployOp`]s (write the yml, write the unit, `daemon-reload && enable
+//!   --now && restart`) driven over the injectable
+//!   [`DeployExecutor`](super::exec::DeployExecutor), so the remote command
+//!   sequence is assertable against a recording fake with no live host. It
+//!   no-ops (empty op vector) when the section is not `enabled`.
+//! - Three fail-closed doctor checks — [`ffmpeg_preflight`],
+//!   [`recordings_dir_writable`], and [`mediamtx_ports_available`] — run over the
+//!   same executor and return the shared [`PreflightCheck`] type, so a media host
+//!   can be graded the same way `autumn deploy check` grades the app host. An
+//!   unverifiable result (transport error, unparseable output) reports a clear
+//!   failure — never a silent pass.
+//!
+//! ## `MediaMTX` = a SEPARATE host daemon
+//!
+//! Compose/Fly deployments can still run `MediaMTX` as a separate service/app
+//! (arroyo does exactly this). This controller is for the `autumn deploy`
+//! (bare-host) path: it stands `MediaMTX` up as a host systemd unit alongside the
+//! reverse-proxied app. The two share nothing but the host.
+//!
+//! ## CSP requirement (the app owns its CSP profile)
+//!
+//! Apps embedding the players must allow the `MediaMTX` origins in their
+//! `content_security_policy`: `connect-src`/`media-src` for the WebRTC (`:8889`),
+//! HLS (`:8888`), and playback (`:9996`) origins, plus `frame-src` for WebRTC,
+//! and the object-store origin in `media-src` for recorded playback. This module
+//! documents the required origins ([`MediaMtxHostConfig::required_csp_origins`]);
+//! the app owns the actual directive. See arroyo's `autumn.toml` /
+//! `autumn-fly.toml` for the concrete `connect-src`/`media-src`/`frame-src`
+//! strings (local origins collapse to `https://*.fly.dev` + the object store in
+//! production).
+//!
+//! ## What is deferred
+//!
+//! - The `MediaMTX` binary provisioning (download / version pin) is a host
+//!   bootstrap step, exactly as autumn does for kamal-proxy — this controller
+//!   assumes the binary is at [`MediaMtxHostConfig::binary_path`].
+//! - Wiring these executor-driven doctor checks into the offline `autumn doctor`
+//!   CLI (which has no ssh executor) is left to a follow-up; the checks
+//!   themselves are complete, fail-closed, and unit-tested via the recording
+//!   fake, and are collected by [`collect_media_doctor_checks`] for a caller that
+//!   already holds a live [`DeployExecutor`].
+
+use std::collections::BTreeSet;
+
+use serde::Deserialize;
+
+use super::PreflightCheck;
+use super::exec::{DeployExecutor, DeployOp, FileContents, RemoteCommand};
+
+// ── MediaMTX ports (real u16 constants, NOT parsed from URLs) ────────────────
+
+/// `MediaMTX` RTMP/WHIP ingest port.
+pub const MEDIAMTX_RTMP_PORT: u16 = 1935;
+/// `MediaMTX` HLS playback port.
+pub const MEDIAMTX_HLS_PORT: u16 = 8888;
+/// `MediaMTX` WebRTC/WHEP playback port.
+pub const MEDIAMTX_WEBRTC_PORT: u16 = 8889;
+/// `MediaMTX` recording-playback port.
+pub const MEDIAMTX_PLAYBACK_PORT: u16 = 9996;
+/// `MediaMTX` control-API port.
+pub const MEDIAMTX_API_PORT: u16 = 9997;
+/// `MediaMTX` WebRTC local UDP port (ICE host candidates).
+pub const MEDIAMTX_WEBRTC_LOCAL_UDP_PORT: u16 = 8189;
+
+// ── LL-HLS window (copied verbatim from arroyo's mediamtx.yml) ───────────────
+//
+// The DVR-on-live window = `HLS_SEGMENT_COUNT * HLS_SEGMENT_DURATION` = 60 * 2s
+// = 120s. Kept as constants (not config) so the low-latency segmenting contract
+// matches the players' assumptions; changing them means updating the app's
+// advertised DVR window to match.
+
+/// LL-HLS variant selector.
+const HLS_VARIANT: &str = "lowLatency";
+/// LL-HLS partial-segment duration.
+const HLS_PART_DURATION: &str = "200ms";
+/// LL-HLS full-segment duration.
+const HLS_SEGMENT_DURATION: &str = "2s";
+/// LL-HLS retained-segment count (× segment duration = the DVR window).
+const HLS_SEGMENT_COUNT: u32 = 60;
+
+// ── Config-section defaults (free fns so serde + `Default` share one source) ──
+
+fn default_recordings_dir() -> String {
+    "/recordings".to_owned()
+}
+
+fn default_record_delete_after() -> String {
+    "72h".to_owned()
+}
+
+fn default_config_path() -> String {
+    "/etc/mediamtx/mediamtx.yml".to_owned()
+}
+
+fn default_binary_path() -> String {
+    "/usr/local/bin/mediamtx".to_owned()
+}
+
+fn default_unit_name() -> String {
+    "mediamtx".to_owned()
+}
+
+const fn default_api_port() -> u16 {
+    MEDIAMTX_API_PORT
+}
+
+const fn default_rtmp_port() -> u16 {
+    MEDIAMTX_RTMP_PORT
+}
+
+const fn default_hls_port() -> u16 {
+    MEDIAMTX_HLS_PORT
+}
+
+const fn default_webrtc_port() -> u16 {
+    MEDIAMTX_WEBRTC_PORT
+}
+
+const fn default_playback_port() -> u16 {
+    MEDIAMTX_PLAYBACK_PORT
+}
+
+const fn default_webrtc_local_udp() -> u16 {
+    MEDIAMTX_WEBRTC_LOCAL_UDP_PORT
+}
+
+/// Default `FFmpeg` binary path — the plugin's `[media.ffmpeg] bin` default.
+/// Shared so the deploy-side `FFmpeg` preflight and the plugin agree on the
+/// fallback path.
+pub const DEFAULT_FFMPEG_BIN: &str = "/usr/bin/ffmpeg";
+
+fn default_ffmpeg_bin() -> String {
+    DEFAULT_FFMPEG_BIN.to_owned()
+}
+
+/// Host-provisioning settings for `MediaMTX`, read from the `[media.mediamtx]`
+/// deploy section.
+///
+/// Every field has a serde default (via the struct-level `#[serde(default)]` +
+/// the [`Default`] impl), so a bare `[media.mediamtx]` table — or none at all —
+/// yields the localhost dev shape with the controller disabled. Deserialized
+/// out of the raw `autumn.toml` string via [`MediaMtxHostConfig::from_toml_str`]
+/// (mirroring how the plugin reads `[media]`), so it never touches
+/// `autumn-web`'s strict `AutumnConfig` schema — no `autumn-media-plugin`
+/// dependency and no change to the app config type.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct MediaMtxHostConfig {
+    /// When `false` (the default) the controller is a no-op — it emits no
+    /// [`DeployOp`]s, so an app that never provisions `MediaMTX` is unaffected.
+    pub enabled: bool,
+    /// Control-API listen port.
+    pub api_port: u16,
+    /// RTMP/WHIP ingest listen port.
+    pub rtmp_port: u16,
+    /// HLS playback listen port.
+    pub hls_port: u16,
+    /// WebRTC/WHEP playback listen port.
+    pub webrtc_port: u16,
+    /// Recording-playback listen port.
+    pub playback_port: u16,
+    /// WebRTC local UDP port for ICE host candidates.
+    pub webrtc_local_udp: u16,
+    /// Root directory recordings are written under (`recordPath` prefix).
+    pub recordings_dir: String,
+    /// `MediaMTX` `recordDeleteAfter` retention window (e.g. `72h`).
+    pub record_delete_after: String,
+    /// Remote path the rendered `mediamtx.yml` is written to.
+    pub config_path: String,
+    /// Remote path the `MediaMTX` binary is expected at (host bootstrap installs
+    /// it; the controller does not download it).
+    pub binary_path: String,
+    /// systemd unit name (without the `.service` suffix).
+    pub unit_name: String,
+    /// Extra hostnames/IPs announced as WebRTC ICE candidates
+    /// (`webrtcAdditionalHosts`) — e.g. a public address in production.
+    pub webrtc_additional_hosts: Vec<String>,
+}
+
+impl Default for MediaMtxHostConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            api_port: default_api_port(),
+            rtmp_port: default_rtmp_port(),
+            hls_port: default_hls_port(),
+            webrtc_port: default_webrtc_port(),
+            playback_port: default_playback_port(),
+            webrtc_local_udp: default_webrtc_local_udp(),
+            recordings_dir: default_recordings_dir(),
+            record_delete_after: default_record_delete_after(),
+            config_path: default_config_path(),
+            binary_path: default_binary_path(),
+            unit_name: default_unit_name(),
+            webrtc_additional_hosts: Vec::new(),
+        }
+    }
+}
+
+/// The `[media]` table wrapper used to deserialize a full `autumn.toml` string
+/// down to the `MediaMTX` host section, sidestepping `autumn-web`'s strict
+/// `AutumnConfig` schema (mirrors the plugin's own `AutumnTomlRoot`).
+#[derive(Debug, Default, Deserialize)]
+struct MediaTomlRoot {
+    #[serde(default)]
+    media: MediaSection,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct MediaSection {
+    mediamtx: MediaMtxHostConfig,
+    ffmpeg: FfmpegSection,
+}
+
+/// The `[media.ffmpeg]` sub-table — only the `bin` path is relevant to the
+/// deploy-side `FFmpeg` preflight.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+struct FfmpegSection {
+    bin: String,
+}
+
+impl Default for FfmpegSection {
+    fn default() -> Self {
+        Self {
+            bin: default_ffmpeg_bin(),
+        }
+    }
+}
+
+/// Read the `[media.ffmpeg] bin` path out of a raw `autumn.toml` string,
+/// defaulting to [`DEFAULT_FFMPEG_BIN`] when the section (or the whole file) is
+/// absent. Companion to [`MediaMtxHostConfig::from_toml_str`] so the deploy
+/// `FFmpeg` preflight checks the same binary the app resolves.
+///
+/// # Errors
+///
+/// Returns the [`toml::de::Error`] when the string does not parse.
+pub fn ffmpeg_bin_from_toml_str(toml_str: &str) -> Result<String, toml::de::Error> {
+    let root: MediaTomlRoot = toml::from_str(toml_str)?;
+    Ok(root.media.ffmpeg.bin)
+}
+
+impl MediaMtxHostConfig {
+    /// Deserialize the `[media.mediamtx]` section out of a raw `autumn.toml`
+    /// string. A file with no `[media.mediamtx]` table yields
+    /// [`MediaMtxHostConfig::default`] (disabled).
+    ///
+    /// # Errors
+    ///
+    /// Returns the [`toml::de::Error`] when the string does not parse.
+    pub fn from_toml_str(toml_str: &str) -> Result<Self, toml::de::Error> {
+        let root: MediaTomlRoot = toml::from_str(toml_str)?;
+        Ok(root.media.mediamtx)
+    }
+
+    /// The `MediaMTX` origins an embedding app must allow in its
+    /// `connect-src`/`media-src` (and `frame-src` for WebRTC) CSP directives, in
+    /// the local `http://127.0.0.1:<port>` shape.
+    ///
+    /// Returns the WebRTC (`webrtc_port`), HLS (`hls_port`), and playback
+    /// (`playback_port`) origins — the three browser-facing `MediaMTX` ports. The
+    /// control API (`api_port`) is server-side only (browsers never hit it) and
+    /// so is deliberately excluded. In production these origins collapse to the
+    /// public `MediaMTX` origin (e.g. `https://<app>-mediamtx.fly.dev`), and the
+    /// object-store origin must additionally be allowed in `media-src` for
+    /// recorded playback — see the module docs.
+    #[must_use]
+    pub fn required_csp_origins(&self) -> Vec<String> {
+        vec![
+            format!("http://127.0.0.1:{}", self.webrtc_port),
+            format!("http://127.0.0.1:{}", self.hls_port),
+            format!("http://127.0.0.1:{}", self.playback_port),
+        ]
+    }
+}
+
+/// Render the `MediaMTX` `mediamtx.yml`, parameterized by [`MediaMtxHostConfig`].
+///
+/// Generalized from arroyo's broadcast-only `mediamtx.yml`: same LL-HLS window
+/// (`hlsVariant: lowLatency`, `hlsPartDuration: 200ms`, `hlsSegmentDuration: 2s`,
+/// `hlsSegmentCount: 60`), same fmp4 recording defaults under `recordings_dir`,
+/// and the same WebRTC config — plus a **`~^room/.+$` path matcher** for
+/// autumn-media's Rooms primitive (Slice 6), which arroyo lacks (it is
+/// broadcast-only). Pure — exposed for unit assertions.
+#[must_use]
+pub fn render_mediamtx_yml(cfg: &MediaMtxHostConfig) -> String {
+    // `webrtcAdditionalHosts` renders as an inline YAML list. Each host is
+    // single-quoted so an IPv6 literal or a host with special chars stays a
+    // single scalar; empty -> `[]`.
+    let webrtc_hosts = if cfg.webrtc_additional_hosts.is_empty() {
+        "[]".to_owned()
+    } else {
+        let joined = cfg
+            .webrtc_additional_hosts
+            .iter()
+            .map(|h| format!("'{}'", h.replace('\'', "''")))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{joined}]")
+    };
+
+    format!(
+        "logLevel: info\n\
+         \n\
+         api: true\n\
+         apiAddress: :{api}\n\
+         \n\
+         playback: true\n\
+         playbackAddress: :{playback}\n\
+         \n\
+         rtmp: true\n\
+         rtmpAddress: :{rtmp}\n\
+         \n\
+         hls: true\n\
+         hlsAddress: :{hls}\n\
+         hlsAllowOrigin: \"*\"\n\
+         hlsVariant: {hls_variant}\n\
+         hlsPartDuration: {hls_part}\n\
+         # DVR-on-live window: retained window = hlsSegmentCount x hlsSegmentDuration\n\
+         # = {seg_count} x {seg_dur}. Surfaced to the player so the UI never promises\n\
+         # more rewind than MediaMTX actually keeps.\n\
+         hlsSegmentCount: {seg_count}\n\
+         hlsSegmentDuration: {seg_dur}\n\
+         \n\
+         webrtc: true\n\
+         webrtcAddress: :{webrtc}\n\
+         webrtcAllowOrigins: ['*']\n\
+         webrtcLocalUDPAddress: :{webrtc_udp}\n\
+         webrtcAdditionalHosts: {webrtc_hosts}\n\
+         \n\
+         pathDefaults:\n\
+         \x20\x20source: publisher\n\
+         \x20\x20record: true\n\
+         \x20\x20recordPath: {rec_dir}/%path/%Y-%m-%d_%H-%M-%S-%f\n\
+         \x20\x20recordFormat: fmp4\n\
+         \x20\x20recordPartDuration: 1s\n\
+         \x20\x20recordSegmentDuration: 5m\n\
+         \x20\x20recordDeleteAfter: {rec_delete}\n\
+         \n\
+         paths:\n\
+         # Broadcast ingest (single-publisher channels), as in arroyo.\n\
+         \x20\x20~^live/.+$:\n\
+         \x20\x20\x20\x20source: publisher\n\
+         # autumn-media Rooms (Slice 6): room/{{namespace?}}/{{room_id}}/{{participant}}.\n\
+         # arroyo is broadcast-only and has no room matcher; this is the addition.\n\
+         \x20\x20~^room/.+$:\n\
+         \x20\x20\x20\x20source: publisher\n",
+        api = cfg.api_port,
+        playback = cfg.playback_port,
+        rtmp = cfg.rtmp_port,
+        hls = cfg.hls_port,
+        webrtc = cfg.webrtc_port,
+        webrtc_udp = cfg.webrtc_local_udp,
+        hls_variant = HLS_VARIANT,
+        hls_part = HLS_PART_DURATION,
+        seg_count = HLS_SEGMENT_COUNT,
+        seg_dur = HLS_SEGMENT_DURATION,
+        webrtc_hosts = webrtc_hosts,
+        rec_dir = cfg.recordings_dir,
+        rec_delete = cfg.record_delete_after,
+    )
+}
+
+/// Render the systemd unit that supervises `MediaMTX`, styled like
+/// [`super::render_app_unit`] / [`super::proxy::KamalProxyController::render_proxy_unit`].
+///
+/// `ExecStart` is `<binary_path> <config_path>`; `Restart=always` (a media
+/// daemon that dies must come straight back so ingest/playback recover without
+/// operator intervention). Pure — exposed for unit assertions.
+#[must_use]
+pub fn render_mediamtx_unit(cfg: &MediaMtxHostConfig) -> String {
+    format!(
+        "[Unit]\n\
+         Description=MediaMTX (autumn-media host daemon)\n\
+         After=network-online.target\n\
+         Wants=network-online.target\n\
+         \n\
+         [Service]\n\
+         Type=simple\n\
+         ExecStart={bin} {config}\n\
+         Restart=always\n\
+         RestartSec=2\n\
+         \n\
+         [Install]\n\
+         WantedBy=multi-user.target\n",
+        bin = cfg.binary_path,
+        config = cfg.config_path,
+    )
+}
+
+/// Provisions `MediaMTX` as a host systemd unit, modeled on
+/// [`super::proxy::KamalProxyController`].
+///
+/// The single [`Self::ensure_installed_ops`] method returns the ordered
+/// [`DeployOp`]s (rather than driving the executor directly) so the media steps
+/// slot into the same recorded op sequence as the rest of the deploy and are
+/// assertable in-order against the recording fake.
+#[derive(Debug, Clone)]
+pub struct MediaMtxController {
+    cfg: MediaMtxHostConfig,
+}
+
+impl MediaMtxController {
+    /// Build a controller for the given host config.
+    #[must_use]
+    pub const fn new(cfg: MediaMtxHostConfig) -> Self {
+        Self { cfg }
+    }
+
+    /// Remote path of the systemd unit (`/etc/systemd/system/<unit>.service`).
+    #[must_use]
+    pub fn unit_path(&self) -> String {
+        format!("/etc/systemd/system/{}.service", self.cfg.unit_name)
+    }
+
+    /// Ordered ops that render `mediamtx.yml` + the systemd unit to the host and
+    /// make `MediaMTX` enabled, running, and reloaded with the freshest config.
+    ///
+    /// Returns an **empty vector when the section is not `enabled`** — the
+    /// controller is a no-op for an app that does not provision `MediaMTX`. When
+    /// enabled it emits, in order:
+    /// 1. `WriteFile` the rendered `mediamtx.yml` to `config_path` (mode `0644`).
+    /// 2. `WriteFile` the rendered unit to `/etc/systemd/system/<unit>.service`
+    ///    (mode `0644`).
+    /// 3. `Run` `systemctl daemon-reload && systemctl enable --now <unit>.service
+    ///    && systemctl restart <unit>.service` — idempotent, and the trailing
+    ///    `restart` reloads the freshly-written config on a redeploy.
+    #[must_use]
+    pub fn ensure_installed_ops(&self) -> Vec<DeployOp> {
+        if !self.cfg.enabled {
+            return Vec::new();
+        }
+        let unit = self.cfg.unit_name.clone();
+        vec![
+            DeployOp::WriteFile {
+                label: "media-write-config",
+                contents: FileContents::Plain(render_mediamtx_yml(&self.cfg)),
+                remote_path: self.cfg.config_path.clone(),
+                mode: Some(0o644),
+            },
+            DeployOp::WriteFile {
+                label: "media-write-unit",
+                contents: FileContents::Plain(render_mediamtx_unit(&self.cfg)),
+                remote_path: self.unit_path(),
+                mode: Some(0o644),
+            },
+            DeployOp::Run(RemoteCommand::new(
+                "media-install",
+                format!(
+                    "systemctl daemon-reload && systemctl enable --now {unit}.service && \
+                     systemctl restart {unit}.service",
+                ),
+            )),
+        ]
+    }
+}
+
+// ── Doctor checks (fail-closed, executor-driven) ─────────────────────────────
+//
+// Each check runs a bounded remote command over the injectable `DeployExecutor`
+// and returns the shared `PreflightCheck` type. An unverifiable result (the
+// command could not run, or its output does not prove the healthy case) reports
+// a clear failure — never a silent pass — so a broken media host is caught
+// before ingest/playback/encode silently fail at runtime.
+
+/// The check name for the `FFmpeg` preflight.
+pub const CHECK_FFMPEG_PREFLIGHT: &str = "media_ffmpeg_preflight";
+/// The check name for the recordings-directory-writable probe.
+pub const CHECK_RECORDINGS_DIR_WRITABLE: &str = "media_recordings_dir_writable";
+/// The check name for the `MediaMTX` port-availability probe.
+pub const CHECK_MEDIAMTX_PORTS_AVAILABLE: &str = "media_mediamtx_ports_available";
+
+/// Remediation hint shown when `FFmpeg` does not resolve.
+const FFMPEG_HINT: &str =
+    "Install FFmpeg on the host (apt package) and set `[media.ffmpeg] bin` to its path";
+/// Remediation hint shown when the recordings dir is not writable.
+const RECORDINGS_HINT: &str =
+    "Create `[media.mediamtx] recordings_dir` on the host and make it writable by the media user";
+/// Remediation hint shown when a `MediaMTX` port is occupied or unverifiable.
+const PORTS_HINT: &str =
+    "Free the conflicting MediaMTX ports on the host (or stop the service already bound to them)";
+
+/// Grade that `FFmpeg` resolves on the host and reports a version banner
+/// (generalized from arroyo's boot preflight).
+///
+/// Runs `<ffmpeg_bin> -version` over the executor and requires the standard
+/// `ffmpeg version` banner in stdout — a binary that is missing, not executable,
+/// or is not actually `FFmpeg` (no banner) is a clear failure. Fail-closed: a
+/// transport error is a failure, not a pass.
+#[must_use]
+pub fn ffmpeg_preflight(exec: &impl DeployExecutor, ffmpeg_bin: &str) -> PreflightCheck {
+    let cmd = RemoteCommand::new(
+        "media-ffmpeg-preflight",
+        format!("{} -version", super::exec::shell_quote(ffmpeg_bin)),
+    );
+    match exec.run(&cmd) {
+        Ok(out) if out.stdout.contains("ffmpeg version") => PreflightCheck {
+            name: CHECK_FFMPEG_PREFLIGHT,
+            passed: true,
+            detail: format!("FFmpeg resolves at `{ffmpeg_bin}` and reports a version banner"),
+            hint: None,
+        },
+        Ok(_) => PreflightCheck {
+            name: CHECK_FFMPEG_PREFLIGHT,
+            passed: false,
+            detail: format!(
+                "`{ffmpeg_bin} -version` ran but did not report an `ffmpeg version` banner — \
+                 the binary is not FFmpeg"
+            ),
+            hint: Some(FFMPEG_HINT),
+        },
+        Err(err) => PreflightCheck {
+            name: CHECK_FFMPEG_PREFLIGHT,
+            passed: false,
+            detail: format!("could not run `{ffmpeg_bin} -version` on the host: {err}"),
+            hint: Some(FFMPEG_HINT),
+        },
+    }
+}
+
+/// Grade that the `MediaMTX` recordings directory exists and is writable on the
+/// host.
+///
+/// Runs `test -d <dir> && test -w <dir>` over the executor. Fail-closed: a
+/// missing/unwritable directory (non-zero exit → transport error) and any other
+/// transport failure both report a clear failure.
+#[must_use]
+pub fn recordings_dir_writable(
+    exec: &impl DeployExecutor,
+    cfg: &MediaMtxHostConfig,
+) -> PreflightCheck {
+    let dir = &cfg.recordings_dir;
+    let quoted = super::exec::shell_quote(dir);
+    let cmd = RemoteCommand::new(
+        "media-recordings-dir",
+        format!("test -d {quoted} && test -w {quoted}"),
+    );
+    match exec.run(&cmd) {
+        Ok(_) => PreflightCheck {
+            name: CHECK_RECORDINGS_DIR_WRITABLE,
+            passed: true,
+            detail: format!("recordings directory `{dir}` exists and is writable"),
+            hint: None,
+        },
+        Err(err) => PreflightCheck {
+            name: CHECK_RECORDINGS_DIR_WRITABLE,
+            passed: false,
+            detail: format!("recordings directory `{dir}` is missing or not writable: {err}"),
+            hint: Some(RECORDINGS_HINT),
+        },
+    }
+}
+
+/// The `MediaMTX` ports a bare host must have free before provisioning: the five
+/// TCP listeners plus the WebRTC local UDP port. A port already bound by another
+/// service is a conflict `MediaMTX` cannot resolve.
+#[must_use]
+fn mediamtx_required_ports(cfg: &MediaMtxHostConfig) -> Vec<u16> {
+    vec![
+        cfg.api_port,
+        cfg.rtmp_port,
+        cfg.hls_port,
+        cfg.webrtc_port,
+        cfg.playback_port,
+        cfg.webrtc_local_udp,
+    ]
+}
+
+/// Parse the set of listening local ports out of `ss -H -tuln` output.
+///
+/// Each line's 5th column (index 4: `Netid State Recv-Q Send-Q Local Peer`) is
+/// the `Local Address:Port` — the port is the tail after the last `:` (covers
+/// IPv4 `0.0.0.0:8888`, IPv6 `[::]:8888`, and `*:8888`). Lines that do not
+/// parse are skipped. Pure — unit-tested against captured `ss` output.
+#[must_use]
+fn parse_listening_ports(ss_output: &str) -> BTreeSet<u16> {
+    ss_output
+        .lines()
+        .filter_map(|line| {
+            let local = line.split_whitespace().nth(4)?;
+            let port_str = local.rsplit(':').next()?;
+            port_str.parse::<u16>().ok()
+        })
+        .collect()
+}
+
+/// Grade that the `MediaMTX` ports are free on the host (no conflicting service is
+/// already bound to them).
+///
+/// Runs `ss -H -tuln` over the executor and parses the listening TCP/UDP ports.
+/// Reports a clear failure listing any required port already in use. Fail-closed:
+/// if `ss` cannot run, or its output does not parse into any recognizable ports,
+/// the check fails with a "could not verify" message rather than passing blind.
+///
+/// Note: if `MediaMTX` is already running under this unit, its own ports show as
+/// occupied and this reports them as conflicts — run this check before enabling
+/// the unit (or expect a self-conflict once it is live).
+#[must_use]
+pub fn mediamtx_ports_available(
+    exec: &impl DeployExecutor,
+    cfg: &MediaMtxHostConfig,
+) -> PreflightCheck {
+    let cmd = RemoteCommand::new("media-ports", "ss -H -tuln".to_owned());
+    let output = match exec.run(&cmd) {
+        Ok(out) => out.stdout,
+        Err(err) => {
+            return PreflightCheck {
+                name: CHECK_MEDIAMTX_PORTS_AVAILABLE,
+                passed: false,
+                detail: format!("could not verify MediaMTX port availability (`ss` failed): {err}"),
+                hint: Some(PORTS_HINT),
+            };
+        }
+    };
+
+    let listening = parse_listening_ports(&output);
+    // Fail-closed: a non-empty `ss` run that yields zero parseable ports means we
+    // could not actually read the host's listener state — treat it as
+    // unverifiable rather than a pass.
+    if listening.is_empty() && !output.trim().is_empty() {
+        return PreflightCheck {
+            name: CHECK_MEDIAMTX_PORTS_AVAILABLE,
+            passed: false,
+            detail: "could not verify MediaMTX port availability: `ss` output did not parse into \
+                     any listening ports"
+                .to_owned(),
+            hint: Some(PORTS_HINT),
+        };
+    }
+
+    let occupied: Vec<u16> = mediamtx_required_ports(cfg)
+        .into_iter()
+        .filter(|p| listening.contains(p))
+        .collect();
+
+    if occupied.is_empty() {
+        PreflightCheck {
+            name: CHECK_MEDIAMTX_PORTS_AVAILABLE,
+            passed: true,
+            detail: "all MediaMTX ports are free on the host".to_owned(),
+            hint: None,
+        }
+    } else {
+        let list = occupied
+            .iter()
+            .map(u16::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        PreflightCheck {
+            name: CHECK_MEDIAMTX_PORTS_AVAILABLE,
+            passed: false,
+            detail: format!("MediaMTX port(s) already in use on the host: {list}"),
+            hint: Some(PORTS_HINT),
+        }
+    }
+}
+
+/// Collect the three `MediaMTX` host doctor checks against a live executor.
+///
+/// Runs the `FFmpeg` preflight (against `ffmpeg_bin`), the recordings-dir probe,
+/// and the port-availability probe — returning the shared [`PreflightCheck`]
+/// results so a caller that already holds a [`DeployExecutor`] can grade a media
+/// host the same way `autumn deploy check` grades the app host. `ffmpeg_bin` is
+/// the resolved `[media.ffmpeg] bin` (the plugin's default is `/usr/bin/ffmpeg`).
+#[must_use]
+pub fn collect_media_doctor_checks(
+    exec: &impl DeployExecutor,
+    cfg: &MediaMtxHostConfig,
+    ffmpeg_bin: &str,
+) -> Vec<PreflightCheck> {
+    vec![
+        ffmpeg_preflight(exec, ffmpeg_bin),
+        recordings_dir_writable(exec, cfg),
+        mediamtx_ports_available(exec, cfg),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::path::Path;
+
+    use super::super::exec::{CommandOutput, DeployExecError};
+
+    /// A recording fake executor mirroring `exec.rs`'s test fake (which is
+    /// private to that module): records `run` calls in order and returns
+    /// scripted stdout / scripted failures per command label, so the controller
+    /// ops and the doctor checks are assertable with no live host.
+    #[derive(Default)]
+    struct RecordingExecutor {
+        run_labels: RefCell<Vec<&'static str>>,
+        fail_labels: Vec<&'static str>,
+        stdout_by_label: Vec<(&'static str, String)>,
+    }
+
+    impl RecordingExecutor {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        fn failing_on(label: &'static str) -> Self {
+            Self {
+                fail_labels: vec![label],
+                ..Self::default()
+            }
+        }
+
+        fn with_stdout(mut self, label: &'static str, stdout: impl Into<String>) -> Self {
+            self.stdout_by_label.push((label, stdout.into()));
+            self
+        }
+
+        fn labels(&self) -> Vec<&'static str> {
+            self.run_labels.borrow().clone()
+        }
+    }
+
+    impl DeployExecutor for RecordingExecutor {
+        fn run(&self, cmd: &RemoteCommand) -> Result<CommandOutput, DeployExecError> {
+            self.run_labels.borrow_mut().push(cmd.label);
+            if self.fail_labels.contains(&cmd.label) {
+                return Err(DeployExecError::CommandFailed {
+                    label: cmd.label,
+                    message: "scripted failure".to_owned(),
+                });
+            }
+            let stdout = self
+                .stdout_by_label
+                .iter()
+                .find(|(l, _)| *l == cmd.label)
+                .map(|(_, out)| out.clone())
+                .unwrap_or_default();
+            Ok(CommandOutput {
+                stdout,
+                stderr: String::new(),
+            })
+        }
+
+        fn upload(
+            &self,
+            _local: &Path,
+            _remote_path: &str,
+            _mode: Option<u32>,
+        ) -> Result<(), DeployExecError> {
+            Ok(())
+        }
+    }
+
+    // ── Config defaults / deserialization ────────────────────────────────────
+
+    #[test]
+    fn config_defaults_are_the_localhost_disabled_shape() {
+        let cfg = MediaMtxHostConfig::default();
+        assert!(!cfg.enabled, "controller is disabled by default");
+        assert_eq!(cfg.api_port, MEDIAMTX_API_PORT);
+        assert_eq!(cfg.rtmp_port, MEDIAMTX_RTMP_PORT);
+        assert_eq!(cfg.hls_port, MEDIAMTX_HLS_PORT);
+        assert_eq!(cfg.webrtc_port, MEDIAMTX_WEBRTC_PORT);
+        assert_eq!(cfg.playback_port, MEDIAMTX_PLAYBACK_PORT);
+        assert_eq!(cfg.webrtc_local_udp, MEDIAMTX_WEBRTC_LOCAL_UDP_PORT);
+        assert_eq!(cfg.recordings_dir, "/recordings");
+        assert_eq!(cfg.record_delete_after, "72h");
+        assert_eq!(cfg.config_path, "/etc/mediamtx/mediamtx.yml");
+        assert_eq!(cfg.binary_path, "/usr/local/bin/mediamtx");
+        assert_eq!(cfg.unit_name, "mediamtx");
+        assert!(cfg.webrtc_additional_hosts.is_empty());
+    }
+
+    #[test]
+    fn empty_toml_yields_disabled_defaults() {
+        let cfg = MediaMtxHostConfig::from_toml_str("").expect("empty toml parses");
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.api_port, MEDIAMTX_API_PORT);
+    }
+
+    #[test]
+    fn toml_reads_the_media_mediamtx_section() {
+        let toml = "\
+[media.mediamtx]
+enabled = true
+recordings_dir = \"/srv/recordings\"
+record_delete_after = \"48h\"
+webrtc_additional_hosts = [\"stream.example.com\", \"203.0.113.7\"]
+unit_name = \"mediamtx-prod\"
+";
+        let cfg = MediaMtxHostConfig::from_toml_str(toml).expect("parses");
+        assert!(cfg.enabled);
+        assert_eq!(cfg.recordings_dir, "/srv/recordings");
+        assert_eq!(cfg.record_delete_after, "48h");
+        assert_eq!(
+            cfg.webrtc_additional_hosts,
+            vec!["stream.example.com".to_owned(), "203.0.113.7".to_owned()]
+        );
+        assert_eq!(cfg.unit_name, "mediamtx-prod");
+        // Unspecified fields keep their defaults.
+        assert_eq!(cfg.hls_port, MEDIAMTX_HLS_PORT);
+    }
+
+    #[test]
+    fn toml_without_media_table_is_default() {
+        let cfg = MediaMtxHostConfig::from_toml_str("[deploy]\nhost = \"h\"\n").expect("parses");
+        assert!(!cfg.enabled);
+    }
+
+    #[test]
+    fn ffmpeg_bin_defaults_and_reads_from_media_ffmpeg() {
+        assert_eq!(
+            ffmpeg_bin_from_toml_str("").expect("empty parses"),
+            DEFAULT_FFMPEG_BIN
+        );
+        let bin =
+            ffmpeg_bin_from_toml_str("[media.ffmpeg]\nbin = \"/opt/ffmpeg\"\n").expect("parses");
+        assert_eq!(bin, "/opt/ffmpeg");
+    }
+
+    // ── mediamtx.yml rendering ───────────────────────────────────────────────
+
+    #[test]
+    fn rendered_yml_contains_every_port() {
+        let yml = render_mediamtx_yml(&MediaMtxHostConfig::default());
+        assert!(yml.contains("apiAddress: :9997"), "api port: {yml}");
+        assert!(yml.contains("playbackAddress: :9996"), "playback: {yml}");
+        assert!(yml.contains("rtmpAddress: :1935"), "rtmp: {yml}");
+        assert!(yml.contains("hlsAddress: :8888"), "hls: {yml}");
+        assert!(yml.contains("webrtcAddress: :8889"), "webrtc: {yml}");
+        assert!(yml.contains("webrtcLocalUDPAddress: :8189"), "udp: {yml}");
+    }
+
+    #[test]
+    fn rendered_yml_has_ll_hls_recording_and_webrtc_config() {
+        let yml = render_mediamtx_yml(&MediaMtxHostConfig::default());
+        // LL-HLS window copied from arroyo.
+        assert!(yml.contains("hlsVariant: lowLatency"));
+        assert!(yml.contains("hlsPartDuration: 200ms"));
+        assert!(yml.contains("hlsSegmentDuration: 2s"));
+        assert!(yml.contains("hlsSegmentCount: 60"));
+        // Recording config under the configured recordings dir.
+        assert!(yml.contains("record: true"));
+        assert!(yml.contains("recordPath: /recordings/%path/%Y-%m-%d_%H-%M-%S-%f"));
+        assert!(yml.contains("recordFormat: fmp4"));
+        assert!(yml.contains("recordDeleteAfter: 72h"));
+        // WebRTC config.
+        assert!(yml.contains("webrtc: true"));
+        assert!(yml.contains("webrtcAdditionalHosts: []"));
+    }
+
+    #[test]
+    fn rendered_yml_has_both_live_and_room_path_matchers() {
+        let yml = render_mediamtx_yml(&MediaMtxHostConfig::default());
+        assert!(yml.contains("~^live/.+$:"), "broadcast matcher: {yml}");
+        // The autumn-media addition arroyo lacks.
+        assert!(yml.contains("~^room/.+$:"), "room matcher: {yml}");
+    }
+
+    #[test]
+    fn rendered_yml_honors_custom_ports_dirs_and_hosts() {
+        let cfg = MediaMtxHostConfig {
+            api_port: 19997,
+            hls_port: 18888,
+            recordings_dir: "/data/rec".to_owned(),
+            record_delete_after: "24h".to_owned(),
+            webrtc_additional_hosts: vec!["a.example.com".to_owned(), "b.example.com".to_owned()],
+            ..MediaMtxHostConfig::default()
+        };
+        let yml = render_mediamtx_yml(&cfg);
+        assert!(yml.contains("apiAddress: :19997"));
+        assert!(yml.contains("hlsAddress: :18888"));
+        assert!(yml.contains("recordPath: /data/rec/%path/"));
+        assert!(yml.contains("recordDeleteAfter: 24h"));
+        assert!(yml.contains("webrtcAdditionalHosts: ['a.example.com', 'b.example.com']"));
+    }
+
+    // ── systemd unit rendering ───────────────────────────────────────────────
+
+    #[test]
+    fn rendered_unit_uses_binary_and_config_paths_and_restarts_always() {
+        let unit = render_mediamtx_unit(&MediaMtxHostConfig::default());
+        assert!(
+            unit.contains("ExecStart=/usr/local/bin/mediamtx /etc/mediamtx/mediamtx.yml\n"),
+            "ExecStart: {unit}"
+        );
+        assert!(unit.contains("Restart=always\n"), "restart: {unit}");
+        assert!(unit.contains("After=network-online.target\n"));
+        assert!(unit.contains("WantedBy=multi-user.target\n"));
+    }
+
+    // ── Controller op sequence ───────────────────────────────────────────────
+
+    #[test]
+    fn controller_noops_when_disabled() {
+        let controller = MediaMtxController::new(MediaMtxHostConfig::default());
+        assert!(
+            controller.ensure_installed_ops().is_empty(),
+            "a disabled controller emits no ops"
+        );
+    }
+
+    #[test]
+    fn controller_emits_write_write_install_when_enabled() {
+        let cfg = MediaMtxHostConfig {
+            enabled: true,
+            ..MediaMtxHostConfig::default()
+        };
+        let controller = MediaMtxController::new(cfg);
+        let ops = controller.ensure_installed_ops();
+        assert_eq!(ops.len(), 3);
+
+        // op 0: write mediamtx.yml to config_path (0644), with rendered config.
+        match &ops[0] {
+            DeployOp::WriteFile {
+                label,
+                contents,
+                remote_path,
+                mode,
+            } => {
+                assert_eq!(*label, "media-write-config");
+                assert_eq!(remote_path, "/etc/mediamtx/mediamtx.yml");
+                assert_eq!(*mode, Some(0o644));
+                let FileContents::Plain(yml) = contents else {
+                    panic!("config must be plain text");
+                };
+                assert!(yml.contains("~^room/.+$:"));
+            }
+            other => panic!("op 0 must write the config, got {other:?}"),
+        }
+
+        // op 1: write the unit to /etc/systemd/system/mediamtx.service (0644).
+        match &ops[1] {
+            DeployOp::WriteFile {
+                label,
+                contents,
+                remote_path,
+                mode,
+            } => {
+                assert_eq!(*label, "media-write-unit");
+                assert_eq!(remote_path, "/etc/systemd/system/mediamtx.service");
+                assert_eq!(*mode, Some(0o644));
+                let FileContents::Plain(unit) = contents else {
+                    panic!("unit must be plain text");
+                };
+                assert!(unit.contains("ExecStart=/usr/local/bin/mediamtx"));
+            }
+            other => panic!("op 1 must write the unit, got {other:?}"),
+        }
+
+        // op 2: daemon-reload + enable --now + restart.
+        let DeployOp::Run(cmd) = &ops[2] else {
+            panic!("op 2 must be the install Run op");
+        };
+        assert_eq!(cmd.label, "media-install");
+        assert_eq!(
+            cmd.shell,
+            "systemctl daemon-reload && systemctl enable --now mediamtx.service && \
+             systemctl restart mediamtx.service",
+        );
+    }
+
+    #[test]
+    fn controller_honors_custom_unit_name_in_paths_and_command() {
+        let cfg = MediaMtxHostConfig {
+            enabled: true,
+            unit_name: "mediamtx-prod".to_owned(),
+            ..MediaMtxHostConfig::default()
+        };
+        let controller = MediaMtxController::new(cfg);
+        assert_eq!(
+            controller.unit_path(),
+            "/etc/systemd/system/mediamtx-prod.service"
+        );
+        let ops = controller.ensure_installed_ops();
+        let DeployOp::Run(cmd) = &ops[2] else {
+            panic!("op 2 must be the install Run op");
+        };
+        assert!(cmd.shell.contains("enable --now mediamtx-prod.service"));
+        assert!(cmd.shell.contains("restart mediamtx-prod.service"));
+    }
+
+    // ── Doctor: ffmpeg preflight ─────────────────────────────────────────────
+
+    #[test]
+    fn ffmpeg_preflight_passes_on_version_banner() {
+        let exec = RecordingExecutor::new().with_stdout(
+            "media-ffmpeg-preflight",
+            "ffmpeg version 6.1.1 Copyright (c)",
+        );
+        let check = ffmpeg_preflight(&exec, "/usr/bin/ffmpeg");
+        assert!(check.passed, "detail: {}", check.detail);
+        assert_eq!(check.name, CHECK_FFMPEG_PREFLIGHT);
+        assert_eq!(exec.labels(), vec!["media-ffmpeg-preflight"]);
+    }
+
+    #[test]
+    fn ffmpeg_preflight_fails_without_banner() {
+        // A binary that runs but is not FFmpeg (no banner) fails — fail-closed.
+        let exec =
+            RecordingExecutor::new().with_stdout("media-ffmpeg-preflight", "not-ffmpeg output");
+        let check = ffmpeg_preflight(&exec, "/usr/bin/ffmpeg");
+        assert!(!check.passed);
+        assert!(check.hint.is_some());
+    }
+
+    #[test]
+    fn ffmpeg_preflight_fails_when_binary_missing() {
+        // A non-zero exit (missing / not executable) surfaces as a transport
+        // error — fail-closed, not a pass.
+        let exec = RecordingExecutor::failing_on("media-ffmpeg-preflight");
+        let check = ffmpeg_preflight(&exec, "/usr/bin/ffmpeg");
+        assert!(!check.passed);
+        assert!(check.detail.contains("could not run"));
+    }
+
+    // ── Doctor: recordings dir writable ──────────────────────────────────────
+
+    #[test]
+    fn recordings_dir_passes_when_writable() {
+        let exec = RecordingExecutor::new();
+        let check = recordings_dir_writable(&exec, &MediaMtxHostConfig::default());
+        assert!(check.passed, "detail: {}", check.detail);
+        assert_eq!(check.name, CHECK_RECORDINGS_DIR_WRITABLE);
+        assert_eq!(exec.labels(), vec!["media-recordings-dir"]);
+    }
+
+    #[test]
+    fn recordings_dir_fails_when_not_writable() {
+        // `test -d && test -w` exits non-zero → transport error → fail-closed.
+        let exec = RecordingExecutor::failing_on("media-recordings-dir");
+        let check = recordings_dir_writable(&exec, &MediaMtxHostConfig::default());
+        assert!(!check.passed);
+        assert!(check.detail.contains("/recordings"));
+        assert!(check.hint.is_some());
+    }
+
+    // ── Doctor: mediamtx ports available ─────────────────────────────────────
+
+    #[test]
+    fn parse_listening_ports_extracts_ipv4_ipv6_and_star() {
+        let ss = "\
+tcp   LISTEN 0 128  0.0.0.0:22    0.0.0.0:*
+tcp   LISTEN 0 128  [::]:8888     [::]:*
+udp   UNCONN 0 0    *:8189        *:*
+";
+        let ports = parse_listening_ports(ss);
+        assert!(ports.contains(&22));
+        assert!(ports.contains(&8888));
+        assert!(ports.contains(&8189));
+        assert_eq!(ports.len(), 3);
+    }
+
+    #[test]
+    fn ports_available_passes_when_ports_free() {
+        // ss shows only sshd — none of MediaMTX's ports are taken.
+        let exec = RecordingExecutor::new()
+            .with_stdout("media-ports", "tcp LISTEN 0 128 0.0.0.0:22 0.0.0.0:*\n");
+        let check = mediamtx_ports_available(&exec, &MediaMtxHostConfig::default());
+        assert!(check.passed, "detail: {}", check.detail);
+        assert_eq!(check.name, CHECK_MEDIAMTX_PORTS_AVAILABLE);
+    }
+
+    #[test]
+    fn ports_available_fails_when_port_occupied() {
+        // Something is already bound to the HLS port (8888).
+        let exec = RecordingExecutor::new().with_stdout(
+            "media-ports",
+            "tcp LISTEN 0 128 0.0.0.0:22 0.0.0.0:*\ntcp LISTEN 0 128 0.0.0.0:8888 0.0.0.0:*\n",
+        );
+        let check = mediamtx_ports_available(&exec, &MediaMtxHostConfig::default());
+        assert!(!check.passed);
+        assert!(check.detail.contains("8888"), "detail: {}", check.detail);
+        assert!(check.hint.is_some());
+    }
+
+    #[test]
+    fn ports_available_fails_closed_when_ss_errors() {
+        let exec = RecordingExecutor::failing_on("media-ports");
+        let check = mediamtx_ports_available(&exec, &MediaMtxHostConfig::default());
+        assert!(!check.passed);
+        assert!(check.detail.contains("could not verify"));
+    }
+
+    #[test]
+    fn ports_available_fails_closed_on_unparseable_output() {
+        // A non-empty ss body that yields zero ports is unverifiable, not a pass.
+        let exec =
+            RecordingExecutor::new().with_stdout("media-ports", "garbage that has no ports\n");
+        let check = mediamtx_ports_available(&exec, &MediaMtxHostConfig::default());
+        assert!(!check.passed);
+        assert!(check.detail.contains("could not verify"));
+    }
+
+    #[test]
+    fn collect_runs_all_three_checks_in_order() {
+        let exec = RecordingExecutor::new()
+            .with_stdout("media-ffmpeg-preflight", "ffmpeg version 6.1")
+            .with_stdout("media-ports", "tcp LISTEN 0 128 0.0.0.0:22 0.0.0.0:*\n");
+        let checks =
+            collect_media_doctor_checks(&exec, &MediaMtxHostConfig::default(), "/usr/bin/ffmpeg");
+        assert_eq!(checks.len(), 3);
+        assert!(checks.iter().all(|c| c.passed), "all should pass");
+        assert_eq!(
+            exec.labels(),
+            vec![
+                "media-ffmpeg-preflight",
+                "media-recordings-dir",
+                "media-ports"
+            ]
+        );
+    }
+
+    // ── CSP origins ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn required_csp_origins_lists_browser_facing_ports() {
+        let origins = MediaMtxHostConfig::default().required_csp_origins();
+        assert!(
+            origins.contains(&"http://127.0.0.1:8889".to_owned()),
+            "webrtc"
+        );
+        assert!(origins.contains(&"http://127.0.0.1:8888".to_owned()), "hls");
+        assert!(
+            origins.contains(&"http://127.0.0.1:9996".to_owned()),
+            "playback"
+        );
+        // The control API (9997) is server-side only and must NOT be advertised.
+        assert!(!origins.iter().any(|o| o.contains("9997")));
+    }
+}

--- a/autumn-cli/src/deploy/media.rs
+++ b/autumn-cli/src/deploy/media.rs
@@ -366,13 +366,15 @@ pub fn render_mediamtx_yml(cfg: &MediaMtxHostConfig) -> String {
          # HLS, WebRTC/WHEP playback, the control API, and the recording-playback\n\
          # server). Every other protocol MediaMTX turns on by default is disabled\n\
          # explicitly, so the systemd unit only ever opens the ports this deploy\n\
-         # plan declares — an occupied default RTSP (:8554) or SRT (:8890) port\n\
-         # cannot make `systemctl restart mediamtx` fail after preflight passed.\n\
-         # (`rtsp: no` also disables RTSPS; `metrics`/`pprof` default off but are\n\
-         # pinned off for the same 'declared ports only' contract. This MediaMTX\n\
-         # release line ships no MoQ server, so there is no MoQ listener to close.)\n\
+         # plan declares — an occupied default RTSP (:8554), SRT (:8890), or MoQ\n\
+         # (:8892) port cannot make `systemctl restart mediamtx` fail after\n\
+         # preflight passed. (`rtsp: no` also disables RTSPS; `moq: no` closes the\n\
+         # default-on MoQ HTTP/2+HTTP/3 listeners — autumn-media does not use MoQ;\n\
+         # `metrics`/`pprof` default off but are pinned off for the same 'declared\n\
+         # ports only' contract.)\n\
          rtsp: no\n\
          srt: no\n\
+         moq: no\n\
          metrics: no\n\
          pprof: no\n\
          \n\
@@ -1406,15 +1408,16 @@ unit_name = \"mediamtx-prod\"
 
     #[test]
     fn rendered_yml_disables_unmanaged_protocols_but_keeps_managed_ones() {
-        // Finding E: MediaMTX fills omitted protocol flags from its own defaults, so
-        // RTSP (:8554) and SRT (:8890) would otherwise listen even though the deploy
-        // plan never declares/checks those ports — an occupied default port could
-        // then fail `systemctl restart mediamtx` after preflight passed. The template
-        // pins every unmanaged default-on protocol OFF so the unit only opens the
-        // declared ports.
+        // Finding E/Q: MediaMTX fills omitted protocol flags from its own defaults, so
+        // RTSP (:8554), SRT (:8890), and MoQ (:8892) would otherwise listen even though
+        // the deploy plan never declares/checks those ports — an occupied default port
+        // could then fail `systemctl restart mediamtx` after preflight passed. The
+        // template pins every unmanaged default-on protocol OFF so the unit only opens
+        // the declared ports.
         let yml = render_mediamtx_yml(&MediaMtxHostConfig::default());
         assert!(yml.contains("rtsp: no"), "RTSP must be disabled: {yml}");
         assert!(yml.contains("srt: no"), "SRT must be disabled: {yml}");
+        assert!(yml.contains("moq: no"), "MoQ must be disabled: {yml}");
         assert!(yml.contains("metrics: no"), "metrics must be off: {yml}");
         assert!(yml.contains("pprof: no"), "pprof must be off: {yml}");
         // The managed protocols stay enabled (RTMP/HLS/WebRTC/API/playback).

--- a/autumn-cli/src/deploy/media.rs
+++ b/autumn-cli/src/deploy/media.rs
@@ -21,8 +21,8 @@
 //!   renders the `/etc/systemd/system/<unit>.service` unit — both pure, so the
 //!   exact rendered text is unit-testable.
 //! - [`MediaMtxController::ensure_installed_ops`] emits the ordered
-//!   [`DeployOp`]s (write the yml, write the unit, `daemon-reload && enable
-//!   --now && restart`) driven over the injectable
+//!   [`DeployOp`]s (mkdir the config dir, write the yml, write the unit,
+//!   `daemon-reload && enable --now && restart`) driven over the injectable
 //!   [`DeployExecutor`](super::exec::DeployExecutor), so the remote command
 //!   sequence is assertable against a recording fake with no live host. It
 //!   no-ops (empty op vector) when the section is not `enabled`.
@@ -413,6 +413,24 @@ pub fn render_mediamtx_unit(cfg: &MediaMtxHostConfig) -> String {
     )
 }
 
+/// The parent directory of a remote unix path — everything before the last `/`,
+/// or `None` when the path has no parent segment (a bare filename, or a
+/// root-level path whose parent `/` always exists).
+///
+/// Used to `mkdir -p` a config file's directory before `scp` writes into it:
+/// [`super::exec::SshExecutor::upload`] shells out to `scp`, which does **not**
+/// create missing parent directories, so the default
+/// `config_path = /etc/mediamtx/mediamtx.yml` would otherwise fail at
+/// `media-write-config` on the first deploy (the `/etc/mediamtx` dir does not
+/// exist on a fresh host). Pure — unit-tested.
+#[must_use]
+fn parent_dir(path: &str) -> Option<&str> {
+    match path.rsplit_once('/') {
+        Some((parent, _)) if !parent.is_empty() => Some(parent),
+        _ => None,
+    }
+}
+
 /// Provisions `MediaMTX` as a host systemd unit, modeled on
 /// [`super::proxy::KamalProxyController`].
 ///
@@ -444,10 +462,15 @@ impl MediaMtxController {
     /// Returns an **empty vector when the section is not `enabled`** — the
     /// controller is a no-op for an app that does not provision `MediaMTX`. When
     /// enabled it emits, in order:
-    /// 1. `WriteFile` the rendered `mediamtx.yml` to `config_path` (mode `0644`).
-    /// 2. `WriteFile` the rendered unit to `/etc/systemd/system/<unit>.service`
+    /// 1. `Run` `mkdir -p <config parent dir>` — `scp` (the upload transport)
+    ///    does not create parents, so the config dir must exist before op 2
+    ///    writes into it (omitted only for a parent-less `config_path`). The
+    ///    unit's parent (`/etc/systemd/system`) is a standard existing dir and
+    ///    needs no `mkdir`.
+    /// 2. `WriteFile` the rendered `mediamtx.yml` to `config_path` (mode `0644`).
+    /// 3. `WriteFile` the rendered unit to `/etc/systemd/system/<unit>.service`
     ///    (mode `0644`).
-    /// 3. `Run` `systemctl daemon-reload && systemctl enable --now <unit>.service
+    /// 4. `Run` `systemctl daemon-reload && systemctl enable --now <unit>.service
     ///    && systemctl restart <unit>.service` — idempotent, and the trailing
     ///    `restart` reloads the freshly-written config on a redeploy.
     #[must_use]
@@ -456,27 +479,37 @@ impl MediaMtxController {
             return Vec::new();
         }
         let unit = self.cfg.unit_name.clone();
-        vec![
-            DeployOp::WriteFile {
-                label: "media-write-config",
-                contents: FileContents::Plain(render_mediamtx_yml(&self.cfg)),
-                remote_path: self.cfg.config_path.clone(),
-                mode: Some(0o644),
-            },
-            DeployOp::WriteFile {
-                label: "media-write-unit",
-                contents: FileContents::Plain(render_mediamtx_unit(&self.cfg)),
-                remote_path: self.unit_path(),
-                mode: Some(0o644),
-            },
-            DeployOp::Run(RemoteCommand::new(
-                "media-install",
-                format!(
-                    "systemctl daemon-reload && systemctl enable --now {unit}.service && \
-                     systemctl restart {unit}.service",
-                ),
-            )),
-        ]
+        let mut ops = Vec::new();
+        // Create the config's parent dir before scp writes the file into it —
+        // `scp` never creates missing parents, so the default
+        // `/etc/mediamtx/mediamtx.yml` would fail at `media-write-config` on a
+        // fresh host without this. Skipped for a parent-less path (root/bare).
+        if let Some(parent) = parent_dir(&self.cfg.config_path) {
+            ops.push(DeployOp::Run(RemoteCommand::new(
+                "media-prepare-dirs",
+                format!("mkdir -p {}", super::exec::shell_quote(parent)),
+            )));
+        }
+        ops.push(DeployOp::WriteFile {
+            label: "media-write-config",
+            contents: FileContents::Plain(render_mediamtx_yml(&self.cfg)),
+            remote_path: self.cfg.config_path.clone(),
+            mode: Some(0o644),
+        });
+        ops.push(DeployOp::WriteFile {
+            label: "media-write-unit",
+            contents: FileContents::Plain(render_mediamtx_unit(&self.cfg)),
+            remote_path: self.unit_path(),
+            mode: Some(0o644),
+        });
+        ops.push(DeployOp::Run(RemoteCommand::new(
+            "media-install",
+            format!(
+                "systemctl daemon-reload && systemctl enable --now {unit}.service && \
+                 systemctl restart {unit}.service",
+            ),
+        )));
+        ops
     }
 }
 
@@ -612,19 +645,47 @@ fn parse_listening_ports(ss_output: &str) -> BTreeSet<u16> {
 /// Grade that the `MediaMTX` ports are free on the host (no conflicting service is
 /// already bound to them).
 ///
-/// Runs `ss -H -tuln` over the executor and parses the listening TCP/UDP ports.
-/// Reports a clear failure listing any required port already in use. Fail-closed:
-/// if `ss` cannot run, or its output does not parse into any recognizable ports,
-/// the check fails with a "could not verify" message rather than passing blind.
+/// **Redeploy-safe:** first consults `systemctl is-active <unit>.service`. When the
+/// managed `MediaMTX` unit is already `active`, the required ports are legitimately
+/// held by *our own* service, so the check passes with an informational note and
+/// skips the scan — otherwise the 2nd+ `deploy up` would abort on a self-conflict
+/// even though the service is healthy. Only a literal `active` counts; any other
+/// state (inactive / failed / activating, or an absent unit → non-zero exit →
+/// transport error) falls through to the strict scan below.
 ///
-/// Note: if `MediaMTX` is already running under this unit, its own ports show as
-/// occupied and this reports them as conflicts — run this check before enabling
-/// the unit (or expect a self-conflict once it is live).
+/// On a fresh host (unit inactive/absent) it runs `ss -H -tuln` over the executor
+/// and parses the listening TCP/UDP ports, reporting a clear failure listing any
+/// required port already in use by a **foreign** service. Fail-closed: if `ss`
+/// cannot run, or its output does not parse into any recognizable ports, the check
+/// fails with a "could not verify" message rather than passing blind.
 #[must_use]
 pub fn mediamtx_ports_available(
     exec: &impl DeployExecutor,
     cfg: &MediaMtxHostConfig,
 ) -> PreflightCheck {
+    // Redeploy-safe gate: a managed unit that is already `active` holds these
+    // ports itself, so treat that as a pass and skip the strict scan. Self-
+    // contained (one extra command over the same executor) so it stays correct on
+    // both the `deploy up` and any doctor path.
+    let unit = format!("{}.service", cfg.unit_name);
+    let is_active = RemoteCommand::new(
+        "media-ports-isactive",
+        format!("systemctl is-active {}", super::exec::shell_quote(&unit)),
+    );
+    if let Ok(out) = exec.run(&is_active)
+        && out.stdout.trim() == "active"
+    {
+        return PreflightCheck {
+            name: CHECK_MEDIAMTX_PORTS_AVAILABLE,
+            passed: true,
+            detail: format!(
+                "managed MediaMTX unit `{unit}` is already running; its ports are held by \
+                 our own service — skipping port-conflict scan"
+            ),
+            hint: None,
+        };
+    }
+
     let cmd = RemoteCommand::new("media-ports", "ss -H -tuln".to_owned());
     let output = match exec.run(&cmd) {
         Ok(out) => out.stdout,
@@ -929,10 +990,17 @@ unit_name = \"mediamtx-prod\"
         };
         let controller = MediaMtxController::new(cfg);
         let ops = controller.ensure_installed_ops();
-        assert_eq!(ops.len(), 3);
+        assert_eq!(ops.len(), 4);
 
-        // op 0: write mediamtx.yml to config_path (0644), with rendered config.
-        match &ops[0] {
+        // op 0: mkdir -p the config's parent dir BEFORE scp writes into it.
+        let DeployOp::Run(mkdir) = &ops[0] else {
+            panic!("op 0 must be the mkdir Run op, got {:?}", ops[0]);
+        };
+        assert_eq!(mkdir.label, "media-prepare-dirs");
+        assert_eq!(mkdir.shell, "mkdir -p '/etc/mediamtx'");
+
+        // op 1: write mediamtx.yml to config_path (0644), with rendered config.
+        match &ops[1] {
             DeployOp::WriteFile {
                 label,
                 contents,
@@ -947,11 +1015,11 @@ unit_name = \"mediamtx-prod\"
                 };
                 assert!(yml.contains("~^room/.+$:"));
             }
-            other => panic!("op 0 must write the config, got {other:?}"),
+            other => panic!("op 1 must write the config, got {other:?}"),
         }
 
-        // op 1: write the unit to /etc/systemd/system/mediamtx.service (0644).
-        match &ops[1] {
+        // op 2: write the unit to /etc/systemd/system/mediamtx.service (0644).
+        match &ops[2] {
             DeployOp::WriteFile {
                 label,
                 contents,
@@ -966,12 +1034,12 @@ unit_name = \"mediamtx-prod\"
                 };
                 assert!(unit.contains("ExecStart=/usr/local/bin/mediamtx"));
             }
-            other => panic!("op 1 must write the unit, got {other:?}"),
+            other => panic!("op 2 must write the unit, got {other:?}"),
         }
 
-        // op 2: daemon-reload + enable --now + restart.
-        let DeployOp::Run(cmd) = &ops[2] else {
-            panic!("op 2 must be the install Run op");
+        // op 3: daemon-reload + enable --now + restart.
+        let DeployOp::Run(cmd) = &ops[3] else {
+            panic!("op 3 must be the install Run op");
         };
         assert_eq!(cmd.label, "media-install");
         assert_eq!(
@@ -994,11 +1062,54 @@ unit_name = \"mediamtx-prod\"
             "/etc/systemd/system/mediamtx-prod.service"
         );
         let ops = controller.ensure_installed_ops();
-        let DeployOp::Run(cmd) = &ops[2] else {
-            panic!("op 2 must be the install Run op");
+        let DeployOp::Run(cmd) = &ops[3] else {
+            panic!("op 3 must be the install Run op");
         };
         assert!(cmd.shell.contains("enable --now mediamtx-prod.service"));
         assert!(cmd.shell.contains("restart mediamtx-prod.service"));
+    }
+
+    #[test]
+    fn controller_mkdirs_config_parent_before_writing_config() {
+        // Finding B: `scp` never creates parent dirs, so a `mkdir -p` of the
+        // config's parent must precede the `media-write-config` upload.
+        let cfg = MediaMtxHostConfig {
+            enabled: true,
+            config_path: "/opt/media/etc/mediamtx.yml".to_owned(),
+            ..MediaMtxHostConfig::default()
+        };
+        let ops = MediaMtxController::new(cfg).ensure_installed_ops();
+
+        let mkdir_idx = ops
+            .iter()
+            .position(|op| op.label() == "media-prepare-dirs")
+            .expect("a media-prepare-dirs op must be emitted");
+        let write_idx = ops
+            .iter()
+            .position(|op| op.label() == "media-write-config")
+            .expect("a media-write-config op must be emitted");
+        assert!(
+            mkdir_idx < write_idx,
+            "mkdir must precede the config write (mkdir at {mkdir_idx}, write at {write_idx})"
+        );
+
+        let DeployOp::Run(mkdir) = &ops[mkdir_idx] else {
+            panic!("media-prepare-dirs must be a Run op");
+        };
+        // The parent is derived from `config_path`, not hardcoded (shell-quoted).
+        assert_eq!(mkdir.shell, "mkdir -p '/opt/media/etc'");
+    }
+
+    #[test]
+    fn parent_dir_extracts_parent_or_none() {
+        assert_eq!(
+            parent_dir("/etc/mediamtx/mediamtx.yml"),
+            Some("/etc/mediamtx")
+        );
+        assert_eq!(parent_dir("/opt/a/b/c.yml"), Some("/opt/a/b"));
+        // Root-level and bare-filename paths have no parent to create.
+        assert_eq!(parent_dir("/mediamtx.yml"), None);
+        assert_eq!(parent_dir("mediamtx.yml"), None);
     }
 
     // ── Doctor: ffmpeg preflight ─────────────────────────────────────────────
@@ -1096,6 +1207,59 @@ udp   UNCONN 0 0    *:8189        *:*
     }
 
     #[test]
+    fn ports_available_passes_when_managed_unit_already_active() {
+        // Finding A (redeploy-safe): the managed unit is already running, so its
+        // ports show as occupied — but the is-active gate treats that as a pass
+        // and never scans, so a 2nd+ `deploy up` is not aborted by a self-conflict.
+        let exec = RecordingExecutor::new()
+            .with_stdout("media-ports-isactive", "active\n")
+            // Even with every MediaMTX port "busy", the scan is skipped.
+            .with_stdout(
+                "media-ports",
+                "tcp LISTEN 0 128 0.0.0.0:8888 0.0.0.0:*\ntcp LISTEN 0 128 0.0.0.0:1935 0.0.0.0:*\n",
+            );
+        let check = mediamtx_ports_available(&exec, &MediaMtxHostConfig::default());
+        assert!(check.passed, "detail: {}", check.detail);
+        assert!(
+            check.detail.contains("already running"),
+            "detail: {}",
+            check.detail
+        );
+        // The strict `ss` scan must NOT have run — the is-active gate short-circuits.
+        assert_eq!(exec.labels(), vec!["media-ports-isactive"]);
+    }
+
+    #[test]
+    fn ports_available_still_fails_closed_on_foreign_listener_when_unit_inactive() {
+        // Finding A: with the managed unit INACTIVE, a foreign listener on a
+        // required port must still fail — the redeploy gate never weakens the
+        // genuine fresh-host conflict path.
+        let exec = RecordingExecutor::new()
+            .with_stdout("media-ports-isactive", "inactive\n")
+            .with_stdout(
+                "media-ports",
+                "tcp LISTEN 0 128 0.0.0.0:22 0.0.0.0:*\ntcp LISTEN 0 128 0.0.0.0:8888 0.0.0.0:*\n",
+            );
+        let check = mediamtx_ports_available(&exec, &MediaMtxHostConfig::default());
+        assert!(!check.passed, "detail: {}", check.detail);
+        assert!(check.detail.contains("8888"), "detail: {}", check.detail);
+        assert!(check.hint.is_some());
+        // The scan ran after the is-active check reported a non-active state.
+        assert_eq!(exec.labels(), vec!["media-ports-isactive", "media-ports"]);
+    }
+
+    #[test]
+    fn ports_available_scans_when_is_active_errors_absent_unit() {
+        // An absent unit → `systemctl is-active` exits non-zero → transport error
+        // → the gate falls through to the strict scan (fail-closed preserved).
+        let exec = RecordingExecutor::failing_on("media-ports-isactive")
+            .with_stdout("media-ports", "tcp LISTEN 0 128 0.0.0.0:22 0.0.0.0:*\n");
+        let check = mediamtx_ports_available(&exec, &MediaMtxHostConfig::default());
+        assert!(check.passed, "detail: {}", check.detail);
+        assert_eq!(exec.labels(), vec!["media-ports-isactive", "media-ports"]);
+    }
+
+    #[test]
     fn ports_available_fails_closed_when_ss_errors() {
         let exec = RecordingExecutor::failing_on("media-ports");
         let check = mediamtx_ports_available(&exec, &MediaMtxHostConfig::default());
@@ -1127,6 +1291,9 @@ udp   UNCONN 0 0    *:8189        *:*
             vec![
                 "media-ffmpeg-preflight",
                 "media-recordings-dir",
+                // The ports check first consults `systemctl is-active` (the
+                // redeploy-safe gate) before the strict `ss` scan.
+                "media-ports-isactive",
                 "media-ports"
             ]
         );

--- a/autumn-cli/src/deploy/media.rs
+++ b/autumn-cli/src/deploy/media.rs
@@ -63,8 +63,6 @@
 //!   fake, and are collected by [`collect_media_doctor_checks`] for a caller that
 //!   already holds a live [`DeployExecutor`].
 
-use std::collections::BTreeSet;
-
 use serde::Deserialize;
 
 use super::PreflightCheck;
@@ -268,11 +266,18 @@ pub fn ffmpeg_bin_from_toml_str(toml_str: &str) -> Result<String, toml::de::Erro
 impl MediaMtxHostConfig {
     /// Deserialize the `[media.mediamtx]` section out of a raw `autumn.toml`
     /// string. A file with no `[media.mediamtx]` table yields
-    /// [`MediaMtxHostConfig::default`] (disabled).
+    /// [`MediaMtxHostConfig::default`] (disabled), so a non-media project reads
+    /// as "controller off".
+    ///
+    /// Fail-closed contract: an *absent* table maps to `Ok(default)`, but a table
+    /// that is *present with an ill-typed value* is a hard `Err` — the caller
+    /// must abort rather than fall back to the disabled default, otherwise a
+    /// media-enabled app would deploy WITHOUT provisioning `MediaMTX`.
     ///
     /// # Errors
     ///
-    /// Returns the [`toml::de::Error`] when the string does not parse.
+    /// Returns the [`toml::de::Error`] when the string does not parse or a
+    /// present `[media.mediamtx]` / `[media.ffmpeg]` value has the wrong type.
     pub fn from_toml_str(toml_str: &str) -> Result<Self, toml::de::Error> {
         let root: MediaTomlRoot = toml::from_str(toml_str)?;
         Ok(root.media.mediamtx)
@@ -624,69 +629,93 @@ fn mediamtx_required_ports(cfg: &MediaMtxHostConfig) -> Vec<u16> {
     ]
 }
 
-/// Parse the set of listening local ports out of `ss -H -tuln` output.
+/// A listening socket parsed from `ss -H -tulnp`: the local port plus the owning
+/// process name (`None` when `ss` could not attribute the socket — e.g. the
+/// `users:(("name",…))` column is absent because the caller lacked privilege).
+type ListeningSocket = (u16, Option<String>);
+
+/// Parse the listening sockets out of `ss -H -tulnp` output as
+/// `(port, owner_process)` pairs.
 ///
-/// Each line's 5th column (index 4: `Netid State Recv-Q Send-Q Local Peer`) is
+/// Each line's 5th column (index 4: `Netid State Recv-Q Send-Q Local Peer …`) is
 /// the `Local Address:Port` — the port is the tail after the last `:` (covers
-/// IPv4 `0.0.0.0:8888`, IPv6 `[::]:8888`, and `*:8888`). Lines that do not
-/// parse are skipped. Pure — unit-tested against captured `ss` output.
+/// IPv4 `0.0.0.0:8888`, IPv6 `[::]:8888`, and `*:8888`). The owning process is
+/// read from the trailing `users:(("<name>",pid=…,fd=…))` column (added by `-p`),
+/// or `None` when that column is absent. Lines whose port does not parse are
+/// skipped. Pure — unit-tested against captured `ss` output.
 #[must_use]
-fn parse_listening_ports(ss_output: &str) -> BTreeSet<u16> {
+fn parse_listening_sockets(ss_output: &str) -> Vec<ListeningSocket> {
     ss_output
         .lines()
         .filter_map(|line| {
             let local = line.split_whitespace().nth(4)?;
-            let port_str = local.rsplit(':').next()?;
-            port_str.parse::<u16>().ok()
+            let port = local.rsplit(':').next()?.parse::<u16>().ok()?;
+            Some((port, process_name_from_ss_line(line)))
         })
         .collect()
 }
 
-/// Grade that the `MediaMTX` ports are free on the host (no conflicting service is
+/// Extract the owning process name from an `ss -p` line's
+/// `users:(("<name>",pid=…,fd=…))` column, if present. Returns the first process
+/// name (a socket shared by several PIDs of the same binary lists them all, but
+/// the first name is the owning binary). `None` when the column is absent.
+#[must_use]
+fn process_name_from_ss_line(line: &str) -> Option<String> {
+    // `…users:(("mediamtx",pid=10,fd=7))` → the text after the opening `"`.
+    let after_quote = line.split_once("users:((\"")?.1;
+    let name = after_quote.split_once('"')?.0;
+    (!name.is_empty()).then(|| name.to_owned())
+}
+
+/// The managed `MediaMTX` process name, derived from the configured binary path's
+/// basename (`/usr/local/bin/mediamtx` → `mediamtx`). This is the `comm` `ss`
+/// reports for our own daemon; the kernel truncates `comm` to 15 chars, which the
+/// short `mediamtx` name never hits.
+#[must_use]
+fn managed_process_name(cfg: &MediaMtxHostConfig) -> &str {
+    cfg.binary_path
+        .rsplit('/')
+        .next()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(cfg.binary_path.as_str())
+}
+
+/// Grade that the `MediaMTX` ports are free on the host (no *foreign* service is
 /// already bound to them).
 ///
-/// **Redeploy-safe:** first consults `systemctl is-active <unit>.service`. When the
-/// managed `MediaMTX` unit is already `active`, the required ports are legitimately
-/// held by *our own* service, so the check passes with an informational note and
-/// skips the scan — otherwise the 2nd+ `deploy up` would abort on a self-conflict
-/// even though the service is healthy. Only a literal `active` counts; any other
-/// state (inactive / failed / activating, or an absent unit → non-zero exit →
-/// transport error) falls through to the strict scan below.
+/// **Process-aware, redeploy-safe on changed ports.** It always runs the port
+/// scan — `ss -H -tulnp` (the `-p` adds the owning-process column) over the
+/// executor — and classifies each configured target port by *who* holds it, not
+/// merely whether it is occupied:
 ///
-/// On a fresh host (unit inactive/absent) it runs `ss -H -tuln` over the executor
-/// and parses the listening TCP/UDP ports, reporting a clear failure listing any
-/// required port already in use by a **foreign** service. Fail-closed: if `ss`
-/// cannot run, or its output does not parse into any recognizable ports, the check
-/// fails with a "could not verify" message rather than passing blind.
+/// - No listener → the port is free → pass.
+/// - Every listener owned by *our own* managed `MediaMTX` (process basename of
+///   [`MediaMtxHostConfig::binary_path`]) → a same-port redeploy, not a conflict
+///   → pass (informational note).
+/// - A listener owned by any *other* process, **or** a listener whose owner
+///   cannot be attributed (empty process column — e.g. insufficient privilege) →
+///   conflict → fail-closed. `autumn deploy` runs as root managing systemd, so
+///   `-p` attribution is normally available; an unattributable listener on a
+///   target port is deliberately treated as a conflict rather than assumed benign.
+///
+/// This replaces an earlier blanket `systemctl is-active` skip, which passed a
+/// running unit without scanning at all — so a redeploy that *changed* a `MediaMTX`
+/// port could not detect a foreign service already bound to the new port (the old
+/// unit only holds the old ports). The per-port ownership check keeps the
+/// same-port redeploy self-conflict passing while still catching that case.
+///
+/// Fail-closed: if `ss` cannot run, or its output does not parse into any
+/// recognizable listener, the check fails with a "could not verify" message
+/// rather than passing blind.
 #[must_use]
 pub fn mediamtx_ports_available(
     exec: &impl DeployExecutor,
     cfg: &MediaMtxHostConfig,
 ) -> PreflightCheck {
-    // Redeploy-safe gate: a managed unit that is already `active` holds these
-    // ports itself, so treat that as a pass and skip the strict scan. Self-
-    // contained (one extra command over the same executor) so it stays correct on
-    // both the `deploy up` and any doctor path.
-    let unit = format!("{}.service", cfg.unit_name);
-    let is_active = RemoteCommand::new(
-        "media-ports-isactive",
-        format!("systemctl is-active {}", super::exec::shell_quote(&unit)),
-    );
-    if let Ok(out) = exec.run(&is_active)
-        && out.stdout.trim() == "active"
-    {
-        return PreflightCheck {
-            name: CHECK_MEDIAMTX_PORTS_AVAILABLE,
-            passed: true,
-            detail: format!(
-                "managed MediaMTX unit `{unit}` is already running; its ports are held by \
-                 our own service — skipping port-conflict scan"
-            ),
-            hint: None,
-        };
-    }
-
-    let cmd = RemoteCommand::new("media-ports", "ss -H -tuln".to_owned());
+    // `-p` attaches the owning-process column so a target port held by our own
+    // managed MediaMTX (a same-port redeploy) is distinguished from a foreign
+    // conflict. Deploy runs as root, so `-p` attribution is available.
+    let cmd = RemoteCommand::new("media-ports", "ss -H -tulnp".to_owned());
     let output = match exec.run(&cmd) {
         Ok(out) => out.stdout,
         Err(err) => {
@@ -699,11 +728,11 @@ pub fn mediamtx_ports_available(
         }
     };
 
-    let listening = parse_listening_ports(&output);
-    // Fail-closed: a non-empty `ss` run that yields zero parseable ports means we
+    let sockets = parse_listening_sockets(&output);
+    // Fail-closed: a non-empty `ss` run that yields zero parseable sockets means we
     // could not actually read the host's listener state — treat it as
     // unverifiable rather than a pass.
-    if listening.is_empty() && !output.trim().is_empty() {
+    if sockets.is_empty() && !output.trim().is_empty() {
         return PreflightCheck {
             name: CHECK_MEDIAMTX_PORTS_AVAILABLE,
             passed: false,
@@ -714,30 +743,69 @@ pub fn mediamtx_ports_available(
         };
     }
 
-    let occupied: Vec<u16> = mediamtx_required_ports(cfg)
-        .into_iter()
-        .filter(|p| listening.contains(p))
-        .collect();
-
-    if occupied.is_empty() {
-        PreflightCheck {
-            name: CHECK_MEDIAMTX_PORTS_AVAILABLE,
-            passed: true,
-            detail: "all MediaMTX ports are free on the host".to_owned(),
-            hint: None,
+    let ours = managed_process_name(cfg);
+    let mut conflicts: Vec<u16> = Vec::new();
+    let mut held_by_us: Vec<u16> = Vec::new();
+    for port in mediamtx_required_ports(cfg) {
+        let mut has_listener = false;
+        let mut all_ours = true;
+        for (socket_port, owner) in &sockets {
+            if *socket_port != port {
+                continue;
+            }
+            has_listener = true;
+            // A listener owned by our own mediamtx is fine; a foreign process OR
+            // an unattributable listener (owner `None`) is a conflict → fail-closed.
+            if owner.as_deref() != Some(ours) {
+                all_ours = false;
+            }
         }
-    } else {
-        let list = occupied
+        if !has_listener {
+            continue; // free
+        }
+        if all_ours {
+            held_by_us.push(port);
+        } else {
+            conflicts.push(port);
+        }
+    }
+    conflicts.sort_unstable();
+    conflicts.dedup();
+
+    if !conflicts.is_empty() {
+        let list = conflicts
             .iter()
             .map(u16::to_string)
             .collect::<Vec<_>>()
             .join(", ");
-        PreflightCheck {
+        return PreflightCheck {
             name: CHECK_MEDIAMTX_PORTS_AVAILABLE,
             passed: false,
-            detail: format!("MediaMTX port(s) already in use on the host: {list}"),
+            detail: format!(
+                "MediaMTX port(s) already in use by another service on the host: {list}"
+            ),
             hint: Some(PORTS_HINT),
-        }
+        };
+    }
+
+    let detail = if held_by_us.is_empty() {
+        "all MediaMTX ports are free on the host".to_owned()
+    } else {
+        let list = held_by_us
+            .iter()
+            .map(u16::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "MediaMTX ports are available; port(s) {list} are already held by our own managed \
+             MediaMTX (same-port redeploy)"
+        )
+    };
+    PreflightCheck {
+        name: CHECK_MEDIAMTX_PORTS_AVAILABLE,
+        passed: true,
+        detail,
+        hint: None,
     }
 }
 
@@ -898,6 +966,30 @@ unit_name = \"mediamtx-prod\"
         let bin =
             ffmpeg_bin_from_toml_str("[media.ffmpeg]\nbin = \"/opt/ffmpeg\"\n").expect("parses");
         assert_eq!(bin, "/opt/ffmpeg");
+    }
+
+    #[test]
+    fn from_toml_str_fails_closed_on_malformed_mediamtx_section() {
+        // Finding C: a PRESENT `[media.mediamtx]` with an ill-typed value is a hard
+        // error, so the caller must abort rather than silently disable provisioning.
+        // `enabled` as a string, not a bool:
+        assert!(
+            MediaMtxHostConfig::from_toml_str("[media.mediamtx]\nenabled = \"yes\"\n").is_err()
+        );
+        // A port field as a non-number:
+        assert!(
+            MediaMtxHostConfig::from_toml_str("[media.mediamtx]\napi_port = \"nope\"\n").is_err()
+        );
+    }
+
+    #[test]
+    fn media_config_fails_closed_on_malformed_ffmpeg_section() {
+        // Finding C: a malformed `[media.ffmpeg]` is also a hard error — both
+        // deploy-side parsers deserialize the whole `[media]` subtree, so neither
+        // can be tricked into the disabled default by a broken ffmpeg table.
+        let toml = "[media.ffmpeg]\nbin = 123\n";
+        assert!(ffmpeg_bin_from_toml_str(toml).is_err());
+        assert!(MediaMtxHostConfig::from_toml_str(toml).is_err());
     }
 
     // ── mediamtx.yml rendering ───────────────────────────────────────────────
@@ -1170,93 +1262,110 @@ unit_name = \"mediamtx-prod\"
     // ── Doctor: mediamtx ports available ─────────────────────────────────────
 
     #[test]
-    fn parse_listening_ports_extracts_ipv4_ipv6_and_star() {
+    fn parse_listening_sockets_extracts_port_and_owner() {
         let ss = "\
-tcp   LISTEN 0 128  0.0.0.0:22    0.0.0.0:*
-tcp   LISTEN 0 128  [::]:8888     [::]:*
+tcp   LISTEN 0 128  0.0.0.0:8888  0.0.0.0:*  users:((\"mediamtx\",pid=10,fd=5))
+tcp   LISTEN 0 128  [::]:22       [::]:*     users:((\"sshd\",pid=5,fd=3))
 udp   UNCONN 0 0    *:8189        *:*
 ";
-        let ports = parse_listening_ports(ss);
-        assert!(ports.contains(&22));
-        assert!(ports.contains(&8888));
-        assert!(ports.contains(&8189));
-        assert_eq!(ports.len(), 3);
+        let sockets = parse_listening_sockets(ss);
+        assert!(sockets.contains(&(8888, Some("mediamtx".to_owned()))));
+        assert!(sockets.contains(&(22, Some("sshd".to_owned()))));
+        // The UDP row has no `users:` column → unattributable owner.
+        assert!(sockets.contains(&(8189, None)));
+        assert_eq!(sockets.len(), 3);
     }
 
     #[test]
     fn ports_available_passes_when_ports_free() {
         // ss shows only sshd — none of MediaMTX's ports are taken.
-        let exec = RecordingExecutor::new()
-            .with_stdout("media-ports", "tcp LISTEN 0 128 0.0.0.0:22 0.0.0.0:*\n");
+        let exec = RecordingExecutor::new().with_stdout(
+            "media-ports",
+            "tcp LISTEN 0 128 0.0.0.0:22 0.0.0.0:* users:((\"sshd\",pid=5,fd=3))\n",
+        );
         let check = mediamtx_ports_available(&exec, &MediaMtxHostConfig::default());
         assert!(check.passed, "detail: {}", check.detail);
         assert_eq!(check.name, CHECK_MEDIAMTX_PORTS_AVAILABLE);
+        assert!(check.detail.contains("free"), "detail: {}", check.detail);
     }
 
     #[test]
-    fn ports_available_fails_when_port_occupied() {
-        // Something is already bound to the HLS port (8888).
+    fn ports_available_fails_when_foreign_process_holds_port() {
+        // Finding D (b): a foreign process (nginx) is bound to the HLS port (8888).
         let exec = RecordingExecutor::new().with_stdout(
             "media-ports",
-            "tcp LISTEN 0 128 0.0.0.0:22 0.0.0.0:*\ntcp LISTEN 0 128 0.0.0.0:8888 0.0.0.0:*\n",
+            "tcp LISTEN 0 128 0.0.0.0:22 0.0.0.0:* users:((\"sshd\",pid=5,fd=3))\n\
+             tcp LISTEN 0 128 0.0.0.0:8888 0.0.0.0:* users:((\"nginx\",pid=99,fd=6))\n",
         );
-        let check = mediamtx_ports_available(&exec, &MediaMtxHostConfig::default());
-        assert!(!check.passed);
-        assert!(check.detail.contains("8888"), "detail: {}", check.detail);
-        assert!(check.hint.is_some());
-    }
-
-    #[test]
-    fn ports_available_passes_when_managed_unit_already_active() {
-        // Finding A (redeploy-safe): the managed unit is already running, so its
-        // ports show as occupied — but the is-active gate treats that as a pass
-        // and never scans, so a 2nd+ `deploy up` is not aborted by a self-conflict.
-        let exec = RecordingExecutor::new()
-            .with_stdout("media-ports-isactive", "active\n")
-            // Even with every MediaMTX port "busy", the scan is skipped.
-            .with_stdout(
-                "media-ports",
-                "tcp LISTEN 0 128 0.0.0.0:8888 0.0.0.0:*\ntcp LISTEN 0 128 0.0.0.0:1935 0.0.0.0:*\n",
-            );
-        let check = mediamtx_ports_available(&exec, &MediaMtxHostConfig::default());
-        assert!(check.passed, "detail: {}", check.detail);
-        assert!(
-            check.detail.contains("already running"),
-            "detail: {}",
-            check.detail
-        );
-        // The strict `ss` scan must NOT have run — the is-active gate short-circuits.
-        assert_eq!(exec.labels(), vec!["media-ports-isactive"]);
-    }
-
-    #[test]
-    fn ports_available_still_fails_closed_on_foreign_listener_when_unit_inactive() {
-        // Finding A: with the managed unit INACTIVE, a foreign listener on a
-        // required port must still fail — the redeploy gate never weakens the
-        // genuine fresh-host conflict path.
-        let exec = RecordingExecutor::new()
-            .with_stdout("media-ports-isactive", "inactive\n")
-            .with_stdout(
-                "media-ports",
-                "tcp LISTEN 0 128 0.0.0.0:22 0.0.0.0:*\ntcp LISTEN 0 128 0.0.0.0:8888 0.0.0.0:*\n",
-            );
         let check = mediamtx_ports_available(&exec, &MediaMtxHostConfig::default());
         assert!(!check.passed, "detail: {}", check.detail);
         assert!(check.detail.contains("8888"), "detail: {}", check.detail);
+        assert!(check.detail.contains("another service"));
         assert!(check.hint.is_some());
-        // The scan ran after the is-active check reported a non-active state.
-        assert_eq!(exec.labels(), vec!["media-ports-isactive", "media-ports"]);
     }
 
     #[test]
-    fn ports_available_scans_when_is_active_errors_absent_unit() {
-        // An absent unit → `systemctl is-active` exits non-zero → transport error
-        // → the gate falls through to the strict scan (fail-closed preserved).
-        let exec = RecordingExecutor::failing_on("media-ports-isactive")
-            .with_stdout("media-ports", "tcp LISTEN 0 128 0.0.0.0:22 0.0.0.0:*\n");
+    fn ports_available_passes_when_our_mediamtx_owns_all_ports() {
+        // Finding D (a): every required port is held by OUR managed mediamtx (a
+        // same-port redeploy) — not a conflict, so the check passes and never
+        // aborts the 2nd+ `deploy up`.
+        let exec = RecordingExecutor::new().with_stdout(
+            "media-ports",
+            "tcp LISTEN 0 128 0.0.0.0:9997 0.0.0.0:* users:((\"mediamtx\",pid=10,fd=3))\n\
+             tcp LISTEN 0 128 0.0.0.0:1935 0.0.0.0:* users:((\"mediamtx\",pid=10,fd=4))\n\
+             tcp LISTEN 0 128 0.0.0.0:8888 0.0.0.0:* users:((\"mediamtx\",pid=10,fd=5))\n\
+             tcp LISTEN 0 128 0.0.0.0:8889 0.0.0.0:* users:((\"mediamtx\",pid=10,fd=6))\n\
+             tcp LISTEN 0 128 0.0.0.0:9996 0.0.0.0:* users:((\"mediamtx\",pid=10,fd=7))\n\
+             udp UNCONN 0 0 0.0.0.0:8189 0.0.0.0:* users:((\"mediamtx\",pid=10,fd=8))\n",
+        );
         let check = mediamtx_ports_available(&exec, &MediaMtxHostConfig::default());
         assert!(check.passed, "detail: {}", check.detail);
-        assert_eq!(exec.labels(), vec!["media-ports-isactive", "media-ports"]);
+        assert!(
+            check.detail.contains("our own managed"),
+            "detail: {}",
+            check.detail
+        );
+        // No is-active gate anymore: only the single `ss` scan runs.
+        assert_eq!(exec.labels(), vec!["media-ports"]);
+    }
+
+    #[test]
+    fn ports_available_fails_when_changed_port_held_by_foreign_service() {
+        // Finding D core: a redeploy that MOVED the HLS port to 8080, where a
+        // foreign service is already bound. The old managed unit only held the old
+        // ports, so a process-aware scan of the NEW target port must still fail —
+        // exactly the case the removed is-active skip missed.
+        let cfg = MediaMtxHostConfig {
+            hls_port: 8080,
+            ..MediaMtxHostConfig::default()
+        };
+        let exec = RecordingExecutor::new().with_stdout(
+            "media-ports",
+            // Our mediamtx still holds its OTHER (unchanged) ports, but the
+            // newly-configured HLS port 8080 is held by a foreign nginx.
+            "tcp LISTEN 0 128 0.0.0.0:9997 0.0.0.0:* users:((\"mediamtx\",pid=10,fd=3))\n\
+             tcp LISTEN 0 128 0.0.0.0:1935 0.0.0.0:* users:((\"mediamtx\",pid=10,fd=4))\n\
+             tcp LISTEN 0 128 0.0.0.0:8080 0.0.0.0:* users:((\"nginx\",pid=99,fd=6))\n",
+        );
+        let check = mediamtx_ports_available(&exec, &cfg);
+        assert!(!check.passed, "detail: {}", check.detail);
+        assert!(check.detail.contains("8080"), "detail: {}", check.detail);
+    }
+
+    #[test]
+    fn ports_available_fails_closed_on_unattributable_listener() {
+        // Finding D (e): a listener on a required port whose owner cannot be
+        // attributed (no `users:` column — e.g. insufficient privilege) is treated
+        // as a conflict, not assumed benign. Deploy runs as root so this is rare,
+        // but fail-closed is the safe default.
+        let exec = RecordingExecutor::new().with_stdout(
+            "media-ports",
+            "tcp LISTEN 0 128 0.0.0.0:22 0.0.0.0:* users:((\"sshd\",pid=5,fd=3))\n\
+             tcp LISTEN 0 128 0.0.0.0:8888 0.0.0.0:*\n",
+        );
+        let check = mediamtx_ports_available(&exec, &MediaMtxHostConfig::default());
+        assert!(!check.passed, "detail: {}", check.detail);
+        assert!(check.detail.contains("8888"), "detail: {}", check.detail);
     }
 
     #[test]
@@ -1281,7 +1390,10 @@ udp   UNCONN 0 0    *:8189        *:*
     fn collect_runs_all_three_checks_in_order() {
         let exec = RecordingExecutor::new()
             .with_stdout("media-ffmpeg-preflight", "ffmpeg version 6.1")
-            .with_stdout("media-ports", "tcp LISTEN 0 128 0.0.0.0:22 0.0.0.0:*\n");
+            .with_stdout(
+                "media-ports",
+                "tcp LISTEN 0 128 0.0.0.0:22 0.0.0.0:* users:((\"sshd\",pid=5,fd=3))\n",
+            );
         let checks =
             collect_media_doctor_checks(&exec, &MediaMtxHostConfig::default(), "/usr/bin/ffmpeg");
         assert_eq!(checks.len(), 3);
@@ -1291,9 +1403,8 @@ udp   UNCONN 0 0    *:8189        *:*
             vec![
                 "media-ffmpeg-preflight",
                 "media-recordings-dir",
-                // The ports check first consults `systemctl is-active` (the
-                // redeploy-safe gate) before the strict `ss` scan.
-                "media-ports-isactive",
+                // The ports check is a single process-aware `ss -tulnp` scan; the
+                // old `systemctl is-active` gate was removed (Finding D).
                 "media-ports"
             ]
         );

--- a/autumn-cli/src/deploy/media.rs
+++ b/autumn-cli/src/deploy/media.rs
@@ -33,29 +33,29 @@
 //!   unverifiable result (transport error, unparseable output) reports a clear
 //!   failure — never a silent pass.
 //!
-//! ## `FFmpeg` path resolution (decoupled from the plugin)
+//! ## `FFmpeg` path verification (concrete literals only)
 //!
-//! `[media.ffmpeg] bin` may be written as a `${VAR}` placeholder or overridden by
-//! the `AUTUMN_MEDIA__FFMPEG__BIN` environment variable — the plugin resolves both
-//! before it ever shells out to `FFmpeg`. So the deploy-side preflight must probe
-//! the binary the app will *actually* run, not the raw TOML literal.
-//! [`resolve_ffmpeg_bin`] mirrors the plugin's resolution: the
-//! `AUTUMN_MEDIA__FFMPEG__BIN` process-env override wins over the configured
-//! value, and a whole-string `${VAR}` value is interpolated from the process env
-//! (unset ⇒ empty). It is a deliberately decoupled re-implementation — this crate
-//! takes **no** `autumn-media-plugin` dependency — so it matches only the plugin's
-//! *whole-string* `${VAR}` rule; an *embedded* placeholder (`/opt/${VER}/ffmpeg`)
-//! is left literal and therefore still contains `${`.
+//! `[media.ffmpeg] bin` may be a concrete path (the default `/usr/bin/ffmpeg` or
+//! any explicit path), a `${VAR}` placeholder, or overridden at runtime by the
+//! `AUTUMN_MEDIA__FFMPEG__BIN` environment variable — the plugin resolves the
+//! latter two from the **service's own environment** before it ever shells out to
+//! `FFmpeg`. The deploy side does not have and must not guess that service
+//! environment: the generated service env-file (`build_env_file`)
+//! propagates only `AUTUMN_ENV`, the signing secret, and the database URL — never
+//! the operator's local shell. Resolving `[media.ffmpeg] bin` against the CLI's
+//! local process env (as an earlier revision did) therefore probes the *wrong*
+//! environment, so [`ffmpeg_preflight`] verifies **only a concrete literal** `bin`
+//! — an environment-independent value it can probe correctly.
 //!
-//! **Fail-closed-honest.** When resolution leaves the path empty or still
-//! containing an unresolved `${`, [`ffmpeg_preflight`] does **not** probe a literal
-//! placeholder or a wrong default — it returns a clear non-passing outcome
-//! ("ffmpeg path unresolved (env/interpolation indirection); deferring
-//! verification to runtime") so the operator sees the indirection rather than a
-//! false pass/fail against the wrong binary. Known limitation of the decoupled
-//! resolver: an embedded `${...}` the plugin *could* resolve is reported as
-//! deferred here (the plugin only interpolates whole-string placeholders, so full
-//! parity holds for the whole-string form).
+//! **Fail-closed-honest.** An env/interpolation-indirected path — an empty value,
+//! or one carrying a `${...}` placeholder (including
+//! `${AUTUMN_MEDIA__FFMPEG__BIN}`) — is **deferred to runtime** with a clear
+//! non-passing outcome ("`FFmpeg` path uses env/interpolation indirection resolved
+//! in the service environment; deferring verification to runtime") rather than
+//! resolved against the CLI's local env and probed. Deferring is honest: the
+//! deployed service resolves and runs whatever *its* environment names, and the
+//! deploy side would otherwise report a false pass/fail against a binary the
+//! service will never run.
 //!
 //! ## `MediaMTX` = a SEPARATE host daemon
 //!
@@ -620,98 +620,62 @@ const RECORDINGS_HINT: &str =
 const PORTS_HINT: &str =
     "Free the conflicting MediaMTX ports on the host (or stop the service already bound to them)";
 
-/// The plugin's `FFmpeg` bin env override (`[media.ffmpeg] bin`). Set in the
-/// deploy/runtime environment, it wins over the configured TOML value — exactly
-/// as `autumn-media-plugin` resolves it before running any workflow.
-pub const FFMPEG_BIN_ENV_OVERRIDE: &str = "AUTUMN_MEDIA__FFMPEG__BIN";
-
-/// Remediation hint shown when the resolved `FFmpeg` path is still an unresolved
-/// `${VAR}` / env indirection the deploy-side resolver cannot expand.
-const FFMPEG_UNRESOLVED_HINT: &str = "Set AUTUMN_MEDIA__FFMPEG__BIN (or export the ${VAR} it references) in the deploy \
-     environment so the FFmpeg path resolves to a concrete binary";
-
-/// Resolve `[media.ffmpeg] bin` to the path the app will actually run, from the
-/// process environment — mirroring `autumn-media-plugin`'s own resolution without
-/// depending on the plugin. Delegates to [`resolve_ffmpeg_bin_with`] with a
-/// `std::env`-backed lookup.
-#[must_use]
-pub fn resolve_ffmpeg_bin(configured: &str) -> String {
-    resolve_ffmpeg_bin_with(configured, |key| std::env::var(key).ok())
-}
-
-/// Pure resolver core (testable with an injected `lookup`, so no process-env
-/// mutation is needed): the `AUTUMN_MEDIA__FFMPEG__BIN` override wins over
-/// `configured`, and a **whole-string** `${VAR}` value is interpolated from
-/// `lookup` (unset ⇒ empty string, matching the plugin's `resolve_placeholder`).
-/// An *embedded* placeholder is deliberately left literal — the plugin only
-/// interpolates whole-string placeholders — so it survives as an unresolved
-/// `${...}` the caller's guard treats as deferred.
-#[must_use]
-fn resolve_ffmpeg_bin_with(configured: &str, lookup: impl Fn(&str) -> Option<String>) -> String {
-    // Whole-string `${VAR}` interpolation of the configured value (plugin parity:
-    // only an exact `${VAR}` is expanded; unset resolves to empty).
-    let interpolated = configured
-        .strip_prefix("${")
-        .and_then(|rest| rest.strip_suffix('}'))
-        .map_or_else(
-            || configured.to_owned(),
-            |var| lookup(var).unwrap_or_default(),
-        );
-    // The env override wins (verbatim), like the plugin's `override_string` applied
-    // after interpolation. A blank/whitespace override is treated as unset so an
-    // empty export never silently becomes the path.
-    match lookup(FFMPEG_BIN_ENV_OVERRIDE) {
-        Some(v) if !v.trim().is_empty() => v,
-        _ => interpolated,
-    }
-}
+/// Remediation hint shown when `[media.ffmpeg] bin` is env/interpolation
+/// indirected and therefore deferred to the service's own runtime resolution.
+const FFMPEG_UNRESOLVED_HINT: &str = "Set `[media.ffmpeg] bin` to a concrete path to verify it here, or ensure \
+     AUTUMN_MEDIA__FFMPEG__BIN / the referenced ${VAR} is set in the SERVICE \
+     environment (the deploy side defers env-indirected paths to runtime)";
 
 /// Grade that `FFmpeg` resolves on the host and reports a version banner
 /// (generalized from arroyo's boot preflight).
 ///
-/// First resolves `ffmpeg_bin` via [`resolve_ffmpeg_bin`] (env override +
-/// whole-string `${VAR}` interpolation) so the probe targets the binary the app
-/// will actually run — not a raw `${VAR}` literal. **Fail-closed-honest:** if the
-/// resolved path is empty or still contains an unresolved `${`, it does NOT probe
-/// (a literal placeholder / wrong default would be a false pass/fail); it reports
-/// a clear non-passing "deferred to runtime" outcome instead. Otherwise it runs
-/// `<resolved> -version` over the executor and requires the standard
-/// `ffmpeg version` banner in stdout — a binary that is missing, not executable,
-/// or is not actually `FFmpeg` (no banner) is a clear failure. Fail-closed: a
-/// transport error is a failure, not a pass.
+/// The deploy side verifies **only a concrete literal** `[media.ffmpeg] bin` (the
+/// default `/usr/bin/ffmpeg` or any explicit path): that value is
+/// environment-independent, so probing it here matches the binary the service
+/// will run. Any **env/interpolation-indirected** path — an empty value, or one
+/// carrying a `${...}` placeholder (including `${AUTUMN_MEDIA__FFMPEG__BIN}`) — is
+/// resolved by the deployed service from ITS OWN environment, which the deploy
+/// side neither has nor may guess (`build_env_file` does not propagate the
+/// operator's local shell). Probing a value resolved against the CLI's local env
+/// would be a false pass/fail against a binary the service will not use, so such a
+/// path is **deferred to runtime** with a clear non-passing outcome instead of
+/// probed. Otherwise it runs `<bin> -version` over the executor and requires the
+/// standard `ffmpeg version` banner in stdout — a binary that is missing, not
+/// executable, or is not actually `FFmpeg` (no banner) is a clear failure.
+/// Fail-closed: a transport error is a failure, not a pass.
 #[must_use]
 pub fn ffmpeg_preflight(exec: &impl DeployExecutor, ffmpeg_bin: &str) -> PreflightCheck {
-    let resolved = resolve_ffmpeg_bin(ffmpeg_bin);
-    // Unverifiable path: empty (an unset whole-string `${VAR}`) or an embedded
-    // placeholder we cannot expand. Defer to runtime rather than probe the wrong
-    // binary — the plugin resolves these itself before it runs FFmpeg.
-    if resolved.trim().is_empty() || resolved.contains("${") {
+    // Env/interpolation indirection the deployed service resolves from its OWN
+    // environment (empty value, or a `${...}` placeholder such as
+    // `${AUTUMN_MEDIA__FFMPEG__BIN}`): defer rather than resolve/probe against the
+    // CLI's local env, which the service does not share.
+    if ffmpeg_bin.trim().is_empty() || ffmpeg_bin.contains("${") {
         return PreflightCheck {
             name: CHECK_FFMPEG_PREFLIGHT,
             passed: false,
             detail: format!(
-                "FFmpeg path unresolved (env/interpolation indirection): `{ffmpeg_bin}` \
-                 resolves to `{resolved}`; deferring verification to runtime"
+                "FFmpeg path uses env/interpolation indirection (`{ffmpeg_bin}`) resolved in \
+                 the service environment; deferring verification to runtime"
             ),
             hint: Some(FFMPEG_UNRESOLVED_HINT),
         };
     }
     let cmd = RemoteCommand::new(
         "media-ffmpeg-preflight",
-        format!("{} -version", super::exec::shell_quote(&resolved)),
+        format!("{} -version", super::exec::shell_quote(ffmpeg_bin)),
     );
     match exec.run(&cmd) {
         Ok(out) if out.stdout.contains("ffmpeg version") => PreflightCheck {
             name: CHECK_FFMPEG_PREFLIGHT,
             passed: true,
-            detail: format!("FFmpeg resolves at `{resolved}` and reports a version banner"),
+            detail: format!("FFmpeg resolves at `{ffmpeg_bin}` and reports a version banner"),
             hint: None,
         },
         Ok(_) => PreflightCheck {
             name: CHECK_FFMPEG_PREFLIGHT,
             passed: false,
             detail: format!(
-                "`{resolved} -version` ran but did not report an `ffmpeg version` banner — \
+                "`{ffmpeg_bin} -version` ran but did not report an `ffmpeg version` banner — \
                  the binary is not FFmpeg"
             ),
             hint: Some(FFMPEG_HINT),
@@ -719,7 +683,7 @@ pub fn ffmpeg_preflight(exec: &impl DeployExecutor, ffmpeg_bin: &str) -> Preflig
         Err(err) => PreflightCheck {
             name: CHECK_FFMPEG_PREFLIGHT,
             passed: false,
-            detail: format!("could not run `{resolved} -version` on the host: {err}"),
+            detail: format!("could not run `{ffmpeg_bin} -version` on the host: {err}"),
             hint: Some(FFMPEG_HINT),
         },
     }
@@ -1573,56 +1537,38 @@ unit_name = \"mediamtx-prod\"
         assert!(check.detail.contains("could not run"));
     }
 
-    // ── Finding G: FFmpeg path resolution (env override + `${VAR}`) ───────────
+    // ── Finding L: verify only a concrete literal; defer env-indirected paths ──
     //
-    // The resolver core is exercised through the injected-`lookup` variant so no
-    // process-env mutation (unsafe under edition 2024, and racy across parallel
-    // tests) is needed. `ffmpeg_preflight`'s public wrapper reads `std::env`, but
-    // its unverifiable-path guard is exercised via `resolve_ffmpeg_bin_with` +
-    // the fake executor below.
+    // The deploy side must NOT resolve `[media.ffmpeg] bin` against the operator's
+    // LOCAL shell — the generated service env-file does not propagate it, so the
+    // service would resolve a different path. Only an environment-independent
+    // concrete literal is probed; anything env/interpolation-indirected (a
+    // `${...}` placeholder — including `${AUTUMN_MEDIA__FFMPEG__BIN}` — or an empty
+    // value) is deferred to runtime with NO probe, regardless of any local env.
 
     #[test]
-    fn resolve_honors_env_override_over_toml_value() {
-        // Finding G (1): AUTUMN_MEDIA__FFMPEG__BIN wins over the configured value.
-        let resolved = resolve_ffmpeg_bin_with("/usr/bin/ffmpeg", |k| {
-            (k == FFMPEG_BIN_ENV_OVERRIDE).then(|| "/opt/custom/ffmpeg".to_owned())
-        });
-        assert_eq!(resolved, "/opt/custom/ffmpeg");
-        // A blank override is treated as unset — the TOML value stands.
-        let resolved_blank = resolve_ffmpeg_bin_with("/usr/bin/ffmpeg", |k| {
-            (k == FFMPEG_BIN_ENV_OVERRIDE).then(|| "   ".to_owned())
-        });
-        assert_eq!(resolved_blank, "/usr/bin/ffmpeg");
-    }
-
-    #[test]
-    fn resolve_interpolates_whole_string_placeholder_from_env() {
-        // Finding G (2): a whole-string `${VAR}` value is expanded from the env.
-        let resolved = resolve_ffmpeg_bin_with("${FF_BIN}", |k| {
-            (k == "FF_BIN").then(|| "/usr/local/bin/ffmpeg".to_owned())
-        });
-        assert_eq!(resolved, "/usr/local/bin/ffmpeg");
-        // An unset whole-string placeholder resolves to empty (plugin parity).
-        let unset = resolve_ffmpeg_bin_with("${FF_BIN}", |_| None);
-        assert_eq!(unset, "");
-    }
-
-    #[test]
-    fn ffmpeg_preflight_defers_on_unresolved_path_without_probing() {
-        // Finding G (3): an empty resolution (unset whole-string `${VAR}`) and an
-        // embedded placeholder we can't expand both DEFER — a clear non-passing
-        // outcome, and crucially NO probe of a literal placeholder runs.
-        for configured in ["${FF_BIN_UNSET_XYZ}", "/opt/${VER}/ffmpeg"] {
+    fn ffmpeg_preflight_defers_env_indirected_paths_without_probing() {
+        // A whole-string `${VAR}`, an embedded placeholder, a value that relies on
+        // the AUTUMN_MEDIA__FFMPEG__BIN override, and an empty value all DEFER — a
+        // clear non-passing outcome, and crucially NO probe runs.
+        for configured in [
+            "${FF_BIN_UNSET_XYZ}",
+            "/opt/${VER}/ffmpeg",
+            // A value that relies on the AUTUMN_MEDIA__FFMPEG__BIN override — the
+            // service resolves it from ITS own env; the deploy side must defer.
+            "${AUTUMN_MEDIA__FFMPEG__BIN}",
+            "",
+        ] {
             let exec = RecordingExecutor::new();
             let check = ffmpeg_preflight(&exec, configured);
             assert!(!check.passed, "must be non-passing for `{configured}`");
             assert!(
-                check.detail.contains("unresolved") && check.detail.contains("deferring"),
+                check.detail.contains("indirection") && check.detail.contains("deferring"),
                 "detail must name the deferral for `{configured}`: {}",
                 check.detail
             );
             assert!(check.hint.is_some());
-            // Fail-closed-honest: never probed the wrong/placeholder binary.
+            // Fail-closed-honest: never probed a locally-resolved / placeholder path.
             assert!(
                 exec.labels().is_empty(),
                 "no probe must run for `{configured}`, ran {:?}",
@@ -1632,9 +1578,9 @@ unit_name = \"mediamtx-prod\"
     }
 
     #[test]
-    fn ffmpeg_preflight_probes_a_concrete_resolved_path() {
-        // A concrete (non-placeholder, no override) path resolves to itself and IS
-        // probed — the healthy path is unchanged by the resolver.
+    fn ffmpeg_preflight_probes_a_concrete_literal_path() {
+        // A concrete (non-placeholder) literal path IS probed verbatim — the
+        // healthy, environment-independent path.
         let exec = RecordingExecutor::new()
             .with_stdout("media-ffmpeg-preflight", "ffmpeg version 6.1.1 Copyright");
         let check = ffmpeg_preflight(&exec, "/usr/bin/ffmpeg");

--- a/autumn-cli/src/deploy/media.rs
+++ b/autumn-cli/src/deploy/media.rs
@@ -375,11 +375,25 @@ pub fn render_mediamtx_yml(cfg: &MediaMtxHostConfig) -> String {
         let joined = cfg
             .webrtc_additional_hosts
             .iter()
-            .map(|h| format!("'{}'", h.replace('\'', "''")))
+            .map(|h| yaml_single_quote(h))
             .collect::<Vec<_>>()
             .join(", ");
         format!("[{joined}]")
     };
+
+    // The two config-derived string values in this template (the `recordPath`
+    // prefix built from `recordings_dir`, and the `recordDeleteAfter` retention
+    // window) are rendered as single-quoted YAML scalars (issue #2051, Finding T
+    // sweep). A plain scalar carrying a leading/trailing space or a YAML
+    // structural char (`:`/`#`/`{`/`[`/…) would otherwise break parsing — and a
+    // `mediamtx.yml` that fails to parse strands the daemon on the deferred
+    // post-cutover `systemctl restart`, the worst time. Quoting a path/duration
+    // is loss-free for MediaMTX (both parse the same string either way).
+    let record_path = yaml_single_quote(&format!(
+        "{}/%path/%Y-%m-%d_%H-%M-%S-%f",
+        cfg.recordings_dir
+    ));
+    let record_delete = yaml_single_quote(&cfg.record_delete_after);
 
     format!(
         "logLevel: info\n\
@@ -435,7 +449,7 @@ pub fn render_mediamtx_yml(cfg: &MediaMtxHostConfig) -> String {
          pathDefaults:\n\
          \x20\x20source: publisher\n\
          \x20\x20record: true\n\
-         \x20\x20recordPath: {rec_dir}/%path/%Y-%m-%d_%H-%M-%S-%f\n\
+         \x20\x20recordPath: {rec_path}\n\
          \x20\x20recordFormat: fmp4\n\
          \x20\x20recordPartDuration: 1s\n\
          \x20\x20recordSegmentDuration: 5m\n\
@@ -460,17 +474,42 @@ pub fn render_mediamtx_yml(cfg: &MediaMtxHostConfig) -> String {
         seg_count = HLS_SEGMENT_COUNT,
         seg_dur = HLS_SEGMENT_DURATION,
         webrtc_hosts = webrtc_hosts,
-        rec_dir = cfg.recordings_dir,
-        rec_delete = cfg.record_delete_after,
+        rec_path = record_path,
+        rec_delete = record_delete,
     )
+}
+
+/// Render `value` as a single-quoted YAML scalar (the only escape inside a YAML
+/// single-quoted scalar is a doubled `''` for a literal quote). Used for the
+/// config-derived string values in [`render_mediamtx_yml`] (record path, retention
+/// window, WebRTC additional hosts) so a value carrying whitespace or a YAML
+/// structural char stays a single scalar and never breaks `mediamtx.yml` parsing.
+#[must_use]
+fn yaml_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+/// Render `value` as a systemd double-quoted `ExecStart` argument (issue #2051,
+/// Finding T). systemd is **not** a shell: it splits `ExecStart` on whitespace but
+/// honors its own C-style quoting, where a double-quoted token is one argument and
+/// `\\` / `\"` are the escapes for a literal backslash / quote. So a
+/// `binary_path`/`config_path` containing a space (e.g. `/opt/media mtx/mediamtx`)
+/// must be wrapped in double quotes or the deferred post-cutover
+/// `systemctl restart` parses the command as the truncated path `/opt/media`.
+/// Backslash is escaped first, then the quote, so the result round-trips exactly.
+#[must_use]
+fn systemd_quote(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
 }
 
 /// Render the systemd unit that supervises `MediaMTX`, styled like
 /// [`super::render_app_unit`] / [`super::proxy::KamalProxyController::render_proxy_unit`].
 ///
-/// `ExecStart` is `<binary_path> <config_path>`; `Restart=always` (a media
-/// daemon that dies must come straight back so ingest/playback recover without
-/// operator intervention). Pure — exposed for unit assertions.
+/// `ExecStart` is `"<binary_path>" "<config_path>"` — both paths are
+/// [`systemd_quote`]d (issue #2051, Finding T) so a path containing whitespace
+/// stays a single argument instead of splitting the command; `Restart=always` (a
+/// media daemon that dies must come straight back so ingest/playback recover
+/// without operator intervention). Pure — exposed for unit assertions.
 #[must_use]
 pub fn render_mediamtx_unit(cfg: &MediaMtxHostConfig) -> String {
     format!(
@@ -487,8 +526,8 @@ pub fn render_mediamtx_unit(cfg: &MediaMtxHostConfig) -> String {
          \n\
          [Install]\n\
          WantedBy=multi-user.target\n",
-        bin = cfg.binary_path,
-        config = cfg.config_path,
+        bin = systemd_quote(&cfg.binary_path),
+        config = systemd_quote(&cfg.config_path),
     )
 }
 
@@ -608,6 +647,11 @@ impl MediaMtxController {
         let cfg_new = super::exec::shell_quote(&config_tmp);
         let unit_live = super::exec::shell_quote(&unit_path);
         let unit_new = super::exec::shell_quote(&unit_tmp);
+        // The systemd unit id passed to `systemctl` is a config-derived string
+        // (`unit_name`), so shell-quote `<unit_name>.service` (issue #2051, Finding
+        // T sweep) — an unquoted unit name containing whitespace/special chars
+        // would otherwise split the `systemctl enable/is-active/restart` arguments.
+        let unit_service = super::exec::shell_quote(&format!("{unit}.service"));
         // POSIX-sh, fail-fast (`set -e`): compare each staged file to its live
         // counterpart; a missing live file (`cmp` non-zero) or a real diff copies
         // it over and flags `changed`. daemon-reload + enable are idempotent. The
@@ -621,9 +665,9 @@ impl MediaMtxController {
              if ! cmp -s {unit_new} {unit_live}; then cp {unit_new} {unit_live}; chmod 0644 {unit_live}; changed=1; fi; \
              rm -f {cfg_new} {unit_new}; \
              systemctl daemon-reload; \
-             systemctl enable {unit}.service; \
-             if [ \"$changed\" -ne 0 ] || ! systemctl is-active --quiet {unit}.service; then \
-             systemctl restart {unit}.service; \
+             systemctl enable {unit_service}; \
+             if [ \"$changed\" -ne 0 ] || ! systemctl is-active --quiet {unit_service}; then \
+             systemctl restart {unit_service}; \
              fi",
         );
         ops.push(DeployOp::Run(RemoteCommand::new("media-install", install)));
@@ -873,9 +917,12 @@ fn managed_process_name(cfg: &MediaMtxHostConfig) -> &str {
 /// at most once per check and the result reused.
 #[must_use]
 fn unit_is_active(exec: &impl DeployExecutor, unit_name: &str) -> bool {
+    // `unit_name` is a config-derived string, so shell-quote `<unit>.service`
+    // (issue #2051, Finding T sweep) rather than interpolating it bare.
+    let unit_service = super::exec::shell_quote(&format!("{unit_name}.service"));
     let cmd = RemoteCommand::new(
         "media-unit-active",
-        format!("systemctl is-active --quiet {unit_name}.service"),
+        format!("systemctl is-active --quiet {unit_service}"),
     );
     exec.run(&cmd).is_ok()
 }
@@ -1420,9 +1467,12 @@ unit_name = \"mediamtx-prod\"
         assert!(yml.contains("hlsSegmentCount: 60"));
         // Recording config under the configured recordings dir.
         assert!(yml.contains("record: true"));
-        assert!(yml.contains("recordPath: /recordings/%path/%Y-%m-%d_%H-%M-%S-%f"));
+        // Config-derived path/duration values are single-quoted YAML scalars
+        // (Finding T sweep) so a value with whitespace/special chars can't break
+        // parsing.
+        assert!(yml.contains("recordPath: '/recordings/%path/%Y-%m-%d_%H-%M-%S-%f'"));
         assert!(yml.contains("recordFormat: fmp4"));
-        assert!(yml.contains("recordDeleteAfter: 72h"));
+        assert!(yml.contains("recordDeleteAfter: '72h'"));
         // WebRTC config.
         assert!(yml.contains("webrtc: true"));
         assert!(yml.contains("webrtcAdditionalHosts: []"));
@@ -1494,8 +1544,8 @@ unit_name = \"mediamtx-prod\"
         let yml = render_mediamtx_yml(&cfg);
         assert!(yml.contains("apiAddress: 127.0.0.1:19997"));
         assert!(yml.contains("hlsAddress: :18888"));
-        assert!(yml.contains("recordPath: /data/rec/%path/"));
-        assert!(yml.contains("recordDeleteAfter: 24h"));
+        assert!(yml.contains("recordPath: '/data/rec/%path/%Y-%m-%d_%H-%M-%S-%f'"));
+        assert!(yml.contains("recordDeleteAfter: '24h'"));
         assert!(yml.contains("webrtcAdditionalHosts: ['a.example.com', 'b.example.com']"));
     }
 
@@ -1504,13 +1554,110 @@ unit_name = \"mediamtx-prod\"
     #[test]
     fn rendered_unit_uses_binary_and_config_paths_and_restarts_always() {
         let unit = render_mediamtx_unit(&MediaMtxHostConfig::default());
+        // Finding T: the binary/config paths are systemd double-quoted so a path
+        // with whitespace stays one argument.
         assert!(
-            unit.contains("ExecStart=/usr/local/bin/mediamtx /etc/mediamtx/mediamtx.yml\n"),
+            unit.contains("ExecStart=\"/usr/local/bin/mediamtx\" \"/etc/mediamtx/mediamtx.yml\"\n"),
             "ExecStart: {unit}"
         );
         assert!(unit.contains("Restart=always\n"), "restart: {unit}");
         assert!(unit.contains("After=network-online.target\n"));
         assert!(unit.contains("WantedBy=multi-user.target\n"));
+    }
+
+    #[test]
+    fn rendered_unit_quotes_whitespace_paths_in_execstart() {
+        // Finding T (issue #2051): a `binary_path`/`config_path` containing
+        // whitespace must be systemd double-quoted in `ExecStart`, or systemd
+        // parses `ExecStart=/opt/media mtx/mediamtx ...` as the truncated command
+        // `/opt/media` and the deferred post-cutover `systemctl restart` fails.
+        let cfg = MediaMtxHostConfig {
+            binary_path: "/opt/media mtx/mediamtx".to_owned(),
+            config_path: "/etc/media mtx/mediamtx.yml".to_owned(),
+            ..MediaMtxHostConfig::default()
+        };
+        let unit = render_mediamtx_unit(&cfg);
+        // Each path is wrapped in systemd double quotes → one argument each.
+        assert!(
+            unit.contains(
+                "ExecStart=\"/opt/media mtx/mediamtx\" \"/etc/media mtx/mediamtx.yml\"\n"
+            ),
+            "ExecStart must double-quote whitespace paths: {unit}"
+        );
+        // And NOT the bare, space-splitting form.
+        assert!(
+            !unit.contains("ExecStart=/opt/media mtx/mediamtx"),
+            "ExecStart must not interpolate the path unquoted: {unit}"
+        );
+    }
+
+    #[test]
+    fn systemd_quote_escapes_backslash_and_double_quote() {
+        // systemd C-style quoting: `\\` and `\"` are the escapes inside a
+        // double-quoted token, escaped in that order so the value round-trips.
+        assert_eq!(systemd_quote("/usr/bin/mediamtx"), "\"/usr/bin/mediamtx\"");
+        assert_eq!(systemd_quote("/opt/a b/mtx"), "\"/opt/a b/mtx\"");
+        assert_eq!(systemd_quote(r#"/a"b"#), "\"/a\\\"b\"");
+        assert_eq!(systemd_quote(r"/a\b"), "\"/a\\\\b\"");
+    }
+
+    #[test]
+    fn rendered_yml_quotes_whitespace_and_special_config_values() {
+        // Finding T sweep: config-derived path/duration values are single-quoted
+        // YAML scalars, so a recordings dir with a space or a YAML structural char
+        // stays a single scalar instead of breaking `mediamtx.yml` parsing.
+        let cfg = MediaMtxHostConfig {
+            recordings_dir: "/mnt/rec ords".to_owned(),
+            record_delete_after: "72h".to_owned(),
+            ..MediaMtxHostConfig::default()
+        };
+        let yml = render_mediamtx_yml(&cfg);
+        assert!(
+            yml.contains("recordPath: '/mnt/rec ords/%path/%Y-%m-%d_%H-%M-%S-%f'"),
+            "recordPath must be single-quoted: {yml}"
+        );
+        // A `#` in the recordings dir would otherwise start a YAML comment.
+        let hashy = MediaMtxHostConfig {
+            recordings_dir: "/mnt/rec#1".to_owned(),
+            ..MediaMtxHostConfig::default()
+        };
+        let yml = render_mediamtx_yml(&hashy);
+        assert!(
+            yml.contains("recordPath: '/mnt/rec#1/%path/%Y-%m-%d_%H-%M-%S-%f'"),
+            "a `#` path must be quoted, not truncated by a YAML comment: {yml}"
+        );
+    }
+
+    #[test]
+    fn install_op_quotes_whitespace_unit_name() {
+        // Finding T sweep: the config-derived unit name is shell-quoted in every
+        // systemctl invocation, so a unit name with whitespace does not split the
+        // arguments.
+        let cfg = MediaMtxHostConfig {
+            enabled: true,
+            unit_name: "media mtx".to_owned(),
+            ..MediaMtxHostConfig::default()
+        };
+        let ops = MediaMtxController::new(cfg).ensure_installed_ops();
+        let DeployOp::Run(cmd) = &ops[3] else {
+            panic!("op 3 must be the install Run op");
+        };
+        assert!(
+            cmd.shell.contains("systemctl enable 'media mtx.service'"),
+            "unit name must be shell-quoted: {}",
+            cmd.shell
+        );
+        assert!(
+            cmd.shell
+                .contains("systemctl is-active --quiet 'media mtx.service'"),
+            "{}",
+            cmd.shell
+        );
+        assert!(
+            cmd.shell.contains("systemctl restart 'media mtx.service'"),
+            "{}",
+            cmd.shell
+        );
     }
 
     // ── Controller op sequence ───────────────────────────────────────────────
@@ -1578,7 +1725,7 @@ unit_name = \"mediamtx-prod\"
                 let FileContents::Plain(unit) = contents else {
                     panic!("unit must be plain text");
                 };
-                assert!(unit.contains("ExecStart=/usr/local/bin/mediamtx"));
+                assert!(unit.contains("ExecStart=\"/usr/local/bin/mediamtx\""));
             }
             other => panic!("op 2 must write the unit, got {other:?}"),
         }
@@ -1640,8 +1787,10 @@ unit_name = \"mediamtx-prod\"
         // Idempotent daemon-reload + enable (NOT `enable --now` — start is handled
         // by the conditional restart).
         assert!(shell.contains("systemctl daemon-reload"), "{shell}");
+        // The unit id is shell-quoted (`'mediamtx.service'`, Finding T sweep) in
+        // every systemctl invocation.
         assert!(
-            shell.contains("systemctl enable mediamtx.service"),
+            shell.contains("systemctl enable 'mediamtx.service'"),
             "{shell}"
         );
         assert!(
@@ -1651,12 +1800,12 @@ unit_name = \"mediamtx-prod\"
         // Restart gated on change-OR-inactive, never unconditional.
         assert!(
             shell.contains(
-                "if [ \"$changed\" -ne 0 ] || ! systemctl is-active --quiet mediamtx.service; then"
+                "if [ \"$changed\" -ne 0 ] || ! systemctl is-active --quiet 'mediamtx.service'; then"
             ),
             "restart must be gated on change or an inactive unit: {shell}"
         );
         assert!(
-            shell.contains("systemctl restart mediamtx.service"),
+            shell.contains("systemctl restart 'mediamtx.service'"),
             "{shell}"
         );
     }
@@ -1677,12 +1826,15 @@ unit_name = \"mediamtx-prod\"
         let DeployOp::Run(cmd) = &ops[3] else {
             panic!("op 3 must be the install Run op");
         };
-        assert!(cmd.shell.contains("systemctl enable mediamtx-prod.service"));
         assert!(
             cmd.shell
-                .contains("is-active --quiet mediamtx-prod.service")
+                .contains("systemctl enable 'mediamtx-prod.service'")
         );
-        assert!(cmd.shell.contains("restart mediamtx-prod.service"));
+        assert!(
+            cmd.shell
+                .contains("is-active --quiet 'mediamtx-prod.service'")
+        );
+        assert!(cmd.shell.contains("restart 'mediamtx-prod.service'"));
         // The staged temp unit tracks the custom unit name too.
         assert!(
             cmd.shell

--- a/autumn-cli/src/deploy/media.rs
+++ b/autumn-cli/src/deploy/media.rs
@@ -342,6 +342,28 @@ pub fn media_host_config_from_value(
 /// and the same WebRTC config — plus a **`~^room/.+$` path matcher** for
 /// autumn-media's Rooms primitive (Slice 6), which arroyo lacks (it is
 /// broadcast-only). Pure — exposed for unit assertions.
+///
+/// # `MediaMTX` schema currency (validated against v1.19.x / `bluenviron/mediamtx:1`)
+///
+/// `MediaMTX` rejects an **unknown** config field at startup (`json: unknown
+/// field ...`), and this config is installed by a post-cutover `systemctl
+/// restart` — so a single stale key would commit the app release then leave the
+/// daemon dead and playback stranded. Every key rendered here is therefore
+/// cross-checked against the current `MediaMTX` reference config
+/// (<https://github.com/bluenviron/mediamtx/blob/main/mediamtx.yml> and
+/// `internal/conf/conf.go`), the schema targeted by arroyo's pinned
+/// `bluenviron/mediamtx:1` image. Notably the HLS CORS key is the plural array
+/// `hlsAllowOrigins: ['*']` — the singular scalar `hlsAllowOrigin` is a
+/// deprecated alias, so the current plural form is emitted (issue #2051,
+/// Finding S). The globals (`api`/`apiAddress`, `playback`/`playbackAddress`,
+/// `rtmp`/`rtmpAddress`, `hls`/`hlsAddress`/`hlsVariant`/`hlsPartDuration`/
+/// `hlsSegmentCount`/`hlsSegmentDuration`, `webrtc`/`webrtcAddress`/
+/// `webrtcAllowOrigins`/`webrtcLocalUDPAddress`/`webrtcAdditionalHosts`, the
+/// `rtsp`/`srt`/`moq`/`metrics`/`pprof` disable toggles), the `pathDefaults`
+/// recording keys (`record`/`recordPath`/`recordFormat`/`recordPartDuration`/
+/// `recordSegmentDuration`/`recordDeleteAfter`), and the `paths` matchers all
+/// match that reference in name and value shape. Future edits: re-validate any
+/// added key against that reference before shipping it.
 #[must_use]
 pub fn render_mediamtx_yml(cfg: &MediaMtxHostConfig) -> String {
     // `webrtcAdditionalHosts` renders as an inline YAML list. Each host is
@@ -395,7 +417,7 @@ pub fn render_mediamtx_yml(cfg: &MediaMtxHostConfig) -> String {
          \n\
          hls: true\n\
          hlsAddress: :{hls}\n\
-         hlsAllowOrigin: \"*\"\n\
+         hlsAllowOrigins: ['*']\n\
          hlsVariant: {hls_variant}\n\
          hlsPartDuration: {hls_part}\n\
          # DVR-on-live window: retained window = hlsSegmentCount x hlsSegmentDuration\n\
@@ -1404,6 +1426,29 @@ unit_name = \"mediamtx-prod\"
         // WebRTC config.
         assert!(yml.contains("webrtc: true"));
         assert!(yml.contains("webrtcAdditionalHosts: []"));
+    }
+
+    #[test]
+    fn rendered_yml_uses_current_mediamtx_cors_schema() {
+        // Finding S (issue #2051): MediaMTX rejects unknown config fields at
+        // startup, and this config is installed by a post-cutover `systemctl
+        // restart`. The HLS CORS key is the plural array `hlsAllowOrigins` in the
+        // current schema (v1.19.x / `bluenviron/mediamtx:1`); the singular scalar
+        // `hlsAllowOrigin` is a deprecated alias, so the template must emit the
+        // current plural form, matching the already-plural `webrtcAllowOrigins`.
+        let yml = render_mediamtx_yml(&MediaMtxHostConfig::default());
+        assert!(
+            yml.contains("hlsAllowOrigins: ['*']"),
+            "HLS CORS must use the current plural array key: {yml}"
+        );
+        assert!(
+            !yml.contains("hlsAllowOrigin:"),
+            "the deprecated singular hlsAllowOrigin key must not be rendered: {yml}"
+        );
+        assert!(
+            yml.contains("webrtcAllowOrigins: ['*']"),
+            "WebRTC CORS must use the plural array key: {yml}"
+        );
     }
 
     #[test]

--- a/autumn-cli/src/deploy/media.rs
+++ b/autumn-cli/src/deploy/media.rs
@@ -54,15 +54,19 @@
 //! environment, so [`ffmpeg_preflight`] verifies **only a concrete literal** `bin`
 //! — an environment-independent value it can probe correctly.
 //!
-//! **Fail-closed-honest.** An env/interpolation-indirected path — an empty value,
-//! or one carrying a `${...}` placeholder (including
+//! **Deferred, not failed.** An env/interpolation-indirected path — an empty
+//! value, or one carrying a `${...}` placeholder (including
 //! `${AUTUMN_MEDIA__FFMPEG__BIN}`) — is **deferred to runtime** with a clear
-//! non-passing outcome ("`FFmpeg` path uses env/interpolation indirection resolved
-//! in the service environment; deferring verification to runtime") rather than
-//! resolved against the CLI's local env and probed. Deferring is honest: the
-//! deployed service resolves and runs whatever *its* environment names, and the
-//! deploy side would otherwise report a false pass/fail against a binary the
-//! service will never run.
+//! non-passing, **non-blocking** outcome ("`FFmpeg` path uses env/interpolation
+//! indirection resolved in the service environment; deferring verification to
+//! runtime") rather than resolved against the CLI's local env and probed. It sets
+//! [`PreflightCheck::deferred`], so [`PreflightCheck::blocking`] is `false` and
+//! the deferred result is surfaced as a **warning that does not abort `deploy
+//! up`** — the deployed service resolves and runs whatever *its* environment
+//! names, so blocking the deploy on a path the deploy side cannot (and must not)
+//! verify would be wrong, while reporting it as a plain pass would falsely claim
+//! success. A **concrete literal** `FFmpeg` path that is missing / not executable
+//! / not actually `FFmpeg` still fails closed (blocking) as before.
 //!
 //! ## `MediaMTX` = a SEPARATE host daemon
 //!
@@ -195,6 +199,23 @@ fn default_ffmpeg_bin() -> String {
 /// (mirroring how the plugin reads `[media]`), so it never touches
 /// `autumn-web`'s strict `AutumnConfig` schema — no `autumn-media-plugin`
 /// dependency and no change to the app config type.
+///
+/// ## Deploy-side ports ↔ app runtime base URLs must stay consistent
+///
+/// The `*_port` fields here (`api_port` / `rtmp_port` / `hls_port` /
+/// `webrtc_port` / `playback_port`) only **provision the daemon's listeners** in
+/// the rendered `mediamtx.yml` (see [`render_mediamtx_yml`]). They are a separate
+/// config surface from the *app's* runtime `MediaMtxConfig` `*_base` URLs
+/// (`api_base` / `hls_base` / `webrtc_base` / playback base), which the deployed
+/// app/clients build request URLs from and which default to the standard ports
+/// (`9997`/`8888`/`8889`/`9996`). This module deliberately does **not** read or
+/// unify with the plugin's `MediaMtxConfig` — that autumn-cli→autumn-media-plugin
+/// coupling is out of slice-7 scope (a plugin-owned config-model change; issue
+/// #1974, codex PR #2051 finding). Consequence: **if you customize a
+/// `[media.mediamtx] *_port` here you MUST update the matching app-side `*_base`
+/// URL to the same port**, or the app/clients will keep calling the standard-port
+/// origin the daemon no longer binds. The two surfaces are default-aligned, so
+/// the common case needs no action.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct MediaMtxHostConfig {
@@ -729,11 +750,14 @@ const FFMPEG_UNRESOLVED_HINT: &str = "Set `[media.ffmpeg] bin` to a concrete pat
 /// side neither has nor may guess (`build_env_file` does not propagate the
 /// operator's local shell). Probing a value resolved against the CLI's local env
 /// would be a false pass/fail against a binary the service will not use, so such a
-/// path is **deferred to runtime** with a clear non-passing outcome instead of
-/// probed. Otherwise it runs `<bin> -version` over the executor and requires the
-/// standard `ffmpeg version` banner in stdout — a binary that is missing, not
-/// executable, or is not actually `FFmpeg` (no banner) is a clear failure.
-/// Fail-closed: a transport error is a failure, not a pass.
+/// path is **deferred to runtime**: a non-passing but **non-blocking** result
+/// (`deferred: true`, so [`PreflightCheck::blocking`] is `false`) that surfaces as
+/// a warning and does **not** abort `deploy up` — the deployed service resolves
+/// `FFmpeg` from its own environment at runtime. Otherwise it runs `<bin>
+/// -version` over the executor and requires the standard `ffmpeg version` banner
+/// in stdout — a **concrete literal** binary that is missing, not executable, or
+/// is not actually `FFmpeg` (no banner) is a clear, **blocking** failure.
+/// Fail-closed: a transport error is a blocking failure, not a pass.
 #[must_use]
 pub fn ffmpeg_preflight(exec: &impl DeployExecutor, ffmpeg_bin: &str) -> PreflightCheck {
     // Env/interpolation indirection the deployed service resolves from its OWN
@@ -744,6 +768,7 @@ pub fn ffmpeg_preflight(exec: &impl DeployExecutor, ffmpeg_bin: &str) -> Preflig
         return PreflightCheck {
             name: CHECK_FFMPEG_PREFLIGHT,
             passed: false,
+            deferred: true,
             detail: format!(
                 "FFmpeg path uses env/interpolation indirection (`{ffmpeg_bin}`) resolved in \
                  the service environment; deferring verification to runtime"
@@ -759,12 +784,14 @@ pub fn ffmpeg_preflight(exec: &impl DeployExecutor, ffmpeg_bin: &str) -> Preflig
         Ok(out) if out.stdout.contains("ffmpeg version") => PreflightCheck {
             name: CHECK_FFMPEG_PREFLIGHT,
             passed: true,
+            deferred: false,
             detail: format!("FFmpeg resolves at `{ffmpeg_bin}` and reports a version banner"),
             hint: None,
         },
         Ok(_) => PreflightCheck {
             name: CHECK_FFMPEG_PREFLIGHT,
             passed: false,
+            deferred: false,
             detail: format!(
                 "`{ffmpeg_bin} -version` ran but did not report an `ffmpeg version` banner — \
                  the binary is not FFmpeg"
@@ -774,6 +801,7 @@ pub fn ffmpeg_preflight(exec: &impl DeployExecutor, ffmpeg_bin: &str) -> Preflig
         Err(err) => PreflightCheck {
             name: CHECK_FFMPEG_PREFLIGHT,
             passed: false,
+            deferred: false,
             detail: format!("could not run `{ffmpeg_bin} -version` on the host: {err}"),
             hint: Some(FFMPEG_HINT),
         },
@@ -801,12 +829,14 @@ pub fn recordings_dir_writable(
         Ok(_) => PreflightCheck {
             name: CHECK_RECORDINGS_DIR_WRITABLE,
             passed: true,
+            deferred: false,
             detail: format!("recordings directory `{dir}` exists and is writable"),
             hint: None,
         },
         Err(err) => PreflightCheck {
             name: CHECK_RECORDINGS_DIR_WRITABLE,
             passed: false,
+            deferred: false,
             detail: format!("recordings directory `{dir}` is missing or not writable: {err}"),
             hint: Some(RECORDINGS_HINT),
         },
@@ -975,6 +1005,7 @@ pub fn mediamtx_ports_available(
             return PreflightCheck {
                 name: CHECK_MEDIAMTX_PORTS_AVAILABLE,
                 passed: false,
+                deferred: false,
                 detail: format!("could not verify MediaMTX port availability (`ss` failed): {err}"),
                 hint: Some(PORTS_HINT),
             };
@@ -989,6 +1020,7 @@ pub fn mediamtx_ports_available(
         return PreflightCheck {
             name: CHECK_MEDIAMTX_PORTS_AVAILABLE,
             passed: false,
+            deferred: false,
             detail: "could not verify MediaMTX port availability: `ss` output did not parse into \
                      any listening ports"
                 .to_owned(),
@@ -1061,6 +1093,7 @@ pub fn mediamtx_ports_available(
         return PreflightCheck {
             name: CHECK_MEDIAMTX_PORTS_AVAILABLE,
             passed: false,
+            deferred: false,
             detail: conflict_msgs.join("; "),
             hint: Some(PORTS_HINT),
         };
@@ -1078,6 +1111,7 @@ pub fn mediamtx_ports_available(
     PreflightCheck {
         name: CHECK_MEDIAMTX_PORTS_AVAILABLE,
         passed: true,
+        deferred: false,
         detail,
         hint: None,
     }
@@ -1127,12 +1161,14 @@ pub fn mediamtx_binary_preflight(
         Ok(_) => PreflightCheck {
             name: CHECK_MEDIAMTX_BINARY,
             passed: true,
+            deferred: false,
             detail: format!("MediaMTX binary `{bin}` exists and is executable"),
             hint: None,
         },
         Err(err) => PreflightCheck {
             name: CHECK_MEDIAMTX_BINARY,
             passed: false,
+            deferred: false,
             detail: format!(
                 "MediaMTX binary `{bin}` is missing or not executable: {err} — MediaMTX cannot \
                  start, so the post-cutover `systemctl restart` would fail; the binary is a \
@@ -1187,6 +1223,7 @@ pub fn mediamtx_ports_distinct(cfg: &MediaMtxHostConfig) -> PreflightCheck {
         PreflightCheck {
             name: CHECK_MEDIAMTX_PORTS_DISTINCT,
             passed: true,
+            deferred: false,
             detail: "all MediaMTX TCP listener ports are distinct".to_owned(),
             hint: None,
         }
@@ -1194,6 +1231,7 @@ pub fn mediamtx_ports_distinct(cfg: &MediaMtxHostConfig) -> PreflightCheck {
         PreflightCheck {
             name: CHECK_MEDIAMTX_PORTS_DISTINCT,
             passed: false,
+            deferred: false,
             detail: format!(
                 "MediaMTX listener ports must be unique per protocol, but {} — two servers \
                  cannot bind the same TCP port, so `systemctl restart mediamtx` would fail after \
@@ -1906,6 +1944,10 @@ unit_name = \"mediamtx-prod\"
             RecordingExecutor::new().with_stdout("media-ffmpeg-preflight", "not-ffmpeg output");
         let check = ffmpeg_preflight(&exec, "/usr/bin/ffmpeg");
         assert!(!check.passed);
+        // A concrete literal that is not FFmpeg is a BLOCKING failure (not
+        // deferred) — it must still abort the deploy (Finding U, #2051).
+        assert!(!check.deferred);
+        assert!(check.blocking());
         assert!(check.hint.is_some());
     }
 
@@ -1916,6 +1958,9 @@ unit_name = \"mediamtx-prod\"
         let exec = RecordingExecutor::failing_on("media-ffmpeg-preflight");
         let check = ffmpeg_preflight(&exec, "/usr/bin/ffmpeg");
         assert!(!check.passed);
+        // A missing concrete literal is a BLOCKING failure, not deferred.
+        assert!(!check.deferred);
+        assert!(check.blocking());
         assert!(check.detail.contains("could not run"));
     }
 
@@ -1944,6 +1989,13 @@ unit_name = \"mediamtx-prod\"
             let exec = RecordingExecutor::new();
             let check = ffmpeg_preflight(&exec, configured);
             assert!(!check.passed, "must be non-passing for `{configured}`");
+            // Deferred, not failed: the service resolves FFmpeg from its own
+            // runtime env, so this must NOT abort the deploy (Finding U, #2051).
+            assert!(check.deferred, "must be deferred for `{configured}`");
+            assert!(
+                !check.blocking(),
+                "deferred check must be non-blocking for `{configured}`"
+            );
             assert!(
                 check.detail.contains("indirection") && check.detail.contains("deferring"),
                 "detail must name the deferral for `{configured}`: {}",
@@ -2331,6 +2383,39 @@ sctp  LISTEN 0 128  0.0.0.0:9999  0.0.0.0:*
                 // old `systemctl is-active` gate was removed (Finding D).
                 "media-ports"
             ]
+        );
+    }
+
+    #[test]
+    fn collect_with_env_indirected_ffmpeg_has_no_blocking_failures() {
+        // Finding U (#2051): an env/interpolation-indirected `[media.ffmpeg] bin`
+        // is DEFERRED to the service runtime — non-passing but non-blocking — so
+        // the aggregate has zero blocking checks and `deploy up` proceeds (the
+        // deploy gate counts `blocking()`, not `!passed`). A concrete missing
+        // FFmpeg would instead block.
+        let exec = RecordingExecutor::new().with_stdout(
+            "media-ports",
+            "tcp LISTEN 0 128 0.0.0.0:22 0.0.0.0:* users:((\"sshd\",pid=5,fd=3))\n",
+        );
+        let checks = collect_media_doctor_checks(
+            &exec,
+            &MediaMtxHostConfig::default(),
+            "${AUTUMN_MEDIA__FFMPEG__BIN}",
+        );
+        // The ffmpeg check is present, deferred, and non-passing …
+        let ffmpeg = checks
+            .iter()
+            .find(|c| c.name == CHECK_FFMPEG_PREFLIGHT)
+            .expect("ffmpeg check present");
+        assert!(ffmpeg.deferred && !ffmpeg.passed);
+        // … and no probe ran for it (no ffmpeg-preflight label recorded).
+        assert!(!exec.labels().contains(&"media-ffmpeg-preflight"));
+        // The deploy gate keys on `blocking()`: the deferred ffmpeg does NOT
+        // count, so the aggregate is non-blocking and the deploy is not aborted.
+        assert_eq!(
+            checks.iter().filter(|c| c.blocking()).count(),
+            0,
+            "deferred ffmpeg must not block the deploy"
         );
     }
 

--- a/autumn-cli/src/deploy/media.rs
+++ b/autumn-cli/src/deploy/media.rs
@@ -26,15 +26,19 @@
 //!   [`DeployExecutor`](super::exec::DeployExecutor), so the remote command
 //!   sequence is assertable against a recording fake with no live host. It
 //!   no-ops (empty op vector) when the section is not `enabled`.
-//! - Four fail-closed doctor checks — [`ffmpeg_preflight`],
-//!   [`mediamtx_binary_preflight`], [`recordings_dir_writable`], and
-//!   [`mediamtx_ports_available`] — run over the same executor and return the
-//!   shared [`PreflightCheck`] type, so a media host can be graded the same way
-//!   `autumn deploy check` grades the app host. The binary preflight runs before
-//!   cutover so a host missing the (deferred-provisioned) `MediaMTX` binary fails
-//!   fast instead of committing the app and then failing the post-cutover
-//!   restart. An unverifiable result (transport error, unparseable output)
-//!   reports a clear failure — never a silent pass.
+//! - Five fail-closed doctor checks — [`mediamtx_ports_distinct`],
+//!   [`ffmpeg_preflight`], [`mediamtx_binary_preflight`],
+//!   [`recordings_dir_writable`], and [`mediamtx_ports_available`] — most run over
+//!   the same executor and all return the shared [`PreflightCheck`] type, so a
+//!   media host can be graded the same way `autumn deploy check` grades the app
+//!   host. [`mediamtx_ports_distinct`] is a **pure config** check (issue #2051,
+//!   Finding P): it rejects a config that binds two same-protocol listeners to one
+//!   port before provisioning, so `systemctl restart` cannot fail after cutover on
+//!   a config that a fresh-host `ss` scan would pass. The binary preflight runs
+//!   before cutover so a host missing the (deferred-provisioned) `MediaMTX` binary
+//!   fails fast instead of committing the app and then failing the post-cutover
+//!   restart. An unverifiable result (transport error, unparseable output) reports
+//!   a clear failure — never a silent pass.
 //!
 //! ## `FFmpeg` path verification (concrete literals only)
 //!
@@ -187,7 +191,7 @@ fn default_ffmpeg_bin() -> String {
 /// Every field has a serde default (via the struct-level `#[serde(default)]` +
 /// the [`Default`] impl), so a bare `[media.mediamtx]` table — or none at all —
 /// yields the localhost dev shape with the controller disabled. Deserialized
-/// out of the raw `autumn.toml` string via [`MediaMtxHostConfig::from_toml_str`]
+/// out of the merged `autumn.toml` value via [`media_host_config_from_value`]
 /// (mirroring how the plugin reads `[media]`), so it never touches
 /// `autumn-web`'s strict `AutumnConfig` schema — no `autumn-media-plugin`
 /// dependency and no change to the app config type.
@@ -277,39 +281,7 @@ impl Default for FfmpegSection {
     }
 }
 
-/// Read the `[media.ffmpeg] bin` path out of a raw `autumn.toml` string,
-/// defaulting to [`DEFAULT_FFMPEG_BIN`] when the section (or the whole file) is
-/// absent. Companion to [`MediaMtxHostConfig::from_toml_str`] so the deploy
-/// `FFmpeg` preflight checks the same binary the app resolves.
-///
-/// # Errors
-///
-/// Returns the [`toml::de::Error`] when the string does not parse.
-pub fn ffmpeg_bin_from_toml_str(toml_str: &str) -> Result<String, toml::de::Error> {
-    let root: MediaTomlRoot = toml::from_str(toml_str)?;
-    Ok(root.media.ffmpeg.bin)
-}
-
 impl MediaMtxHostConfig {
-    /// Deserialize the `[media.mediamtx]` section out of a raw `autumn.toml`
-    /// string. A file with no `[media.mediamtx]` table yields
-    /// [`MediaMtxHostConfig::default`] (disabled), so a non-media project reads
-    /// as "controller off".
-    ///
-    /// Fail-closed contract: an *absent* table maps to `Ok(default)`, but a table
-    /// that is *present with an ill-typed value* is a hard `Err` — the caller
-    /// must abort rather than fall back to the disabled default, otherwise a
-    /// media-enabled app would deploy WITHOUT provisioning `MediaMTX`.
-    ///
-    /// # Errors
-    ///
-    /// Returns the [`toml::de::Error`] when the string does not parse or a
-    /// present `[media.mediamtx]` / `[media.ffmpeg]` value has the wrong type.
-    pub fn from_toml_str(toml_str: &str) -> Result<Self, toml::de::Error> {
-        let root: MediaTomlRoot = toml::from_str(toml_str)?;
-        Ok(root.media.mediamtx)
-    }
-
     /// The `MediaMTX` origins an embedding app must allow in its
     /// `connect-src`/`media-src` (and `frame-src` for WebRTC) CSP directives, in
     /// the local `http://127.0.0.1:<port>` shape.
@@ -329,6 +301,37 @@ impl MediaMtxHostConfig {
             format!("http://127.0.0.1:{}", self.playback_port),
         ]
     }
+}
+
+/// Deserialize the `[media]` host config out of an **already-merged**
+/// `autumn.toml` root [`toml::Value`] — base ← inline `[profile.<name>]` ←
+/// `autumn-<profile>.toml` — returning both the [`MediaMtxHostConfig`] and the
+/// `[media.ffmpeg] bin` path (issue #2051, Finding O).
+///
+/// The deploy-side loader resolves the media config under the **target deploy
+/// profile** using the SAME base+profile TOML layering `AutumnConfig::load()`
+/// applies to the app config, so a profiled deploy (`prod`/`staging`) sees the
+/// profile's `[media.mediamtx]` / `[media.ffmpeg]` (from
+/// `[profile.<name>.media.*]` or `autumn-<profile>.toml`) instead of the base
+/// default. Rather than round-tripping the merged value back through a string
+/// (which can panic on `toml::to_string` table-ordering), the caller merges raw
+/// `toml::Value`s and deserializes the `[media]` subtree here.
+///
+/// Fail-closed: an *absent*
+/// `[media]` subtree maps to the disabled default, but a subtree present with an
+/// **ill-typed value in any contributing layer** is a hard [`Err`] (the merged
+/// value carries the bad type), so the caller aborts `deploy plan`/`up` rather
+/// than deploying a media-enabled app WITHOUT provisioning `MediaMTX`.
+///
+/// # Errors
+///
+/// Returns the [`toml::de::Error`] when the merged `[media.mediamtx]` /
+/// `[media.ffmpeg]` subtree has a wrong-typed value.
+pub fn media_host_config_from_value(
+    root: toml::Value,
+) -> Result<(MediaMtxHostConfig, String), toml::de::Error> {
+    let parsed: MediaTomlRoot = root.try_into()?;
+    Ok((parsed.media.mediamtx, parsed.media.ffmpeg.bin))
 }
 
 /// Render the `MediaMTX` `mediamtx.yml`, parameterized by [`MediaMtxHostConfig`].
@@ -620,6 +623,8 @@ pub const CHECK_RECORDINGS_DIR_WRITABLE: &str = "media_recordings_dir_writable";
 pub const CHECK_MEDIAMTX_PORTS_AVAILABLE: &str = "media_mediamtx_ports_available";
 /// The check name for the `MediaMTX` binary-executable preflight.
 pub const CHECK_MEDIAMTX_BINARY: &str = "media_mediamtx_binary";
+/// The check name for the `MediaMTX` distinct-listener-port config preflight.
+pub const CHECK_MEDIAMTX_PORTS_DISTINCT: &str = "media_mediamtx_ports_distinct";
 
 /// Remediation hint shown when `FFmpeg` does not resolve.
 const FFMPEG_HINT: &str =
@@ -630,6 +635,10 @@ const RECORDINGS_HINT: &str =
 /// Remediation hint shown when a `MediaMTX` port is occupied or unverifiable.
 const PORTS_HINT: &str =
     "Free the conflicting MediaMTX ports on the host (or stop the service already bound to them)";
+/// Remediation hint shown when two same-protocol `MediaMTX` listeners are
+/// configured onto one port.
+const PORTS_DISTINCT_HINT: &str = "Give each MediaMTX TCP listener (`rtmp_port`/`hls_port`/`webrtc_port`/`playback_port`/`api_port`) \
+     a distinct port in `[media.mediamtx]`";
 /// Remediation hint shown when the `MediaMTX` binary is missing / not executable.
 const MEDIAMTX_BINARY_HINT: &str = "Install the MediaMTX binary at `[media.mediamtx] binary_path` on the host — a host-bootstrap \
      prerequisite (download/version-pin the Go binary, exactly as autumn does for kamal-proxy)";
@@ -1063,14 +1072,78 @@ pub fn mediamtx_binary_preflight(
     }
 }
 
-/// Collect the four `MediaMTX` host doctor checks against a live executor.
+/// Grade that the configured `MediaMTX` **TCP listener ports are all distinct**
+/// (issue #2051, Finding P) — a **pure config** check, no executor, no host I/O.
 ///
-/// Runs the `FFmpeg` preflight (against `ffmpeg_bin`), the `MediaMTX`
-/// binary-executable preflight, the recordings-dir probe, and the
-/// port-availability probe — returning the shared [`PreflightCheck`] results so a
-/// caller that already holds a [`DeployExecutor`] can grade a media host the same
-/// way `autumn deploy check` grades the app host. `ffmpeg_bin` is the resolved
-/// `[media.ffmpeg] bin` (the plugin's default is `/usr/bin/ffmpeg`).
+/// `MediaMTX` runs a separate server per protocol, each binding its own TCP
+/// socket: RTMP (`rtmp_port`), HLS (`hls_port`), WebRTC/WHEP (`webrtc_port`),
+/// recording-playback (`playback_port`), and the control API (`api_port`). If two
+/// of those are configured to the same value, the rendered `mediamtx.yml` asks two
+/// servers to bind one port. [`mediamtx_ports_available`]'s `ss` scan can still
+/// pass on a fresh host (nothing is listening yet), so the conflict would only
+/// surface as a failed **deferred** `systemctl restart` AFTER app cutover — the
+/// worst time. This check catches it up front and fails closed.
+///
+/// The WebRTC local **UDP** port (`webrtc_local_udp`) is a *separate protocol
+/// namespace*, so it may legitimately equal a TCP port and is deliberately not
+/// compared against the TCP set (mirroring [`mediamtx_required_ports`]'s
+/// protocol-aware conflict rule). Fail-closed message names the duplicated value
+/// and every field bound to it.
+#[must_use]
+pub fn mediamtx_ports_distinct(cfg: &MediaMtxHostConfig) -> PreflightCheck {
+    // The five TCP listeners MediaMTX binds — each its own server, so all must be
+    // distinct. `webrtc_local_udp` is UDP and intentionally excluded.
+    let tcp: [(u16, &str); 5] = [
+        (cfg.rtmp_port, "rtmp_port"),
+        (cfg.hls_port, "hls_port"),
+        (cfg.webrtc_port, "webrtc_port"),
+        (cfg.playback_port, "playback_port"),
+        (cfg.api_port, "api_port"),
+    ];
+    // Group fields by port (BTreeMap → deterministic ascending-port ordering) and
+    // report every port claimed by more than one field.
+    let mut by_port: std::collections::BTreeMap<u16, Vec<&str>> = std::collections::BTreeMap::new();
+    for (port, field) in tcp {
+        by_port.entry(port).or_default().push(field);
+    }
+    let conflicts: Vec<String> = by_port
+        .iter()
+        .filter(|(_, fields)| fields.len() > 1)
+        .map(|(port, fields)| format!("TCP port {port} is bound by {}", fields.join(", ")))
+        .collect();
+
+    if conflicts.is_empty() {
+        PreflightCheck {
+            name: CHECK_MEDIAMTX_PORTS_DISTINCT,
+            passed: true,
+            detail: "all MediaMTX TCP listener ports are distinct".to_owned(),
+            hint: None,
+        }
+    } else {
+        PreflightCheck {
+            name: CHECK_MEDIAMTX_PORTS_DISTINCT,
+            passed: false,
+            detail: format!(
+                "MediaMTX listener ports must be unique per protocol, but {} — two servers \
+                 cannot bind the same TCP port, so `systemctl restart mediamtx` would fail after \
+                 cutover",
+                conflicts.join("; ")
+            ),
+            hint: Some(PORTS_DISTINCT_HINT),
+        }
+    }
+}
+
+/// Collect the five `MediaMTX` host doctor checks against a live executor.
+///
+/// Runs the distinct-listener-port **config** check first (pure — no host I/O, so
+/// a duplicated-port config aborts before any probe), then the `FFmpeg` preflight
+/// (against `ffmpeg_bin`), the `MediaMTX` binary-executable preflight, the
+/// recordings-dir probe, and the port-availability probe — returning the shared
+/// [`PreflightCheck`] results so a caller that already holds a [`DeployExecutor`]
+/// can grade a media host the same way `autumn deploy check` grades the app host.
+/// `ffmpeg_bin` is the resolved `[media.ffmpeg] bin` (the plugin's default is
+/// `/usr/bin/ffmpeg`).
 #[must_use]
 pub fn collect_media_doctor_checks(
     exec: &impl DeployExecutor,
@@ -1078,6 +1151,7 @@ pub fn collect_media_doctor_checks(
     ffmpeg_bin: &str,
 ) -> Vec<PreflightCheck> {
     vec![
+        mediamtx_ports_distinct(cfg),
         ffmpeg_preflight(exec, ffmpeg_bin),
         mediamtx_binary_preflight(exec, cfg),
         recordings_dir_writable(exec, cfg),
@@ -1186,11 +1260,20 @@ mod tests {
         assert!(cfg.webrtc_additional_hosts.is_empty());
     }
 
+    /// Parse a raw `autumn.toml` string and deserialize its `[media]` subtree via
+    /// the production [`media_host_config_from_value`] path — the deploy loader
+    /// merges raw `toml::Value`s and calls that fn, so tests exercise the same
+    /// deserializer over a single (unmerged) document.
+    fn host_cfg_from_toml_str(s: &str) -> Result<(MediaMtxHostConfig, String), toml::de::Error> {
+        media_host_config_from_value(toml::from_str(s)?)
+    }
+
     #[test]
     fn empty_toml_yields_disabled_defaults() {
-        let cfg = MediaMtxHostConfig::from_toml_str("").expect("empty toml parses");
+        let (cfg, bin) = host_cfg_from_toml_str("").expect("empty toml parses");
         assert!(!cfg.enabled);
         assert_eq!(cfg.api_port, MEDIAMTX_API_PORT);
+        assert_eq!(bin, DEFAULT_FFMPEG_BIN);
     }
 
     #[test]
@@ -1203,7 +1286,7 @@ record_delete_after = \"48h\"
 webrtc_additional_hosts = [\"stream.example.com\", \"203.0.113.7\"]
 unit_name = \"mediamtx-prod\"
 ";
-        let cfg = MediaMtxHostConfig::from_toml_str(toml).expect("parses");
+        let (cfg, _) = host_cfg_from_toml_str(toml).expect("parses");
         assert!(cfg.enabled);
         assert_eq!(cfg.recordings_dir, "/srv/recordings");
         assert_eq!(cfg.record_delete_after, "48h");
@@ -1218,43 +1301,38 @@ unit_name = \"mediamtx-prod\"
 
     #[test]
     fn toml_without_media_table_is_default() {
-        let cfg = MediaMtxHostConfig::from_toml_str("[deploy]\nhost = \"h\"\n").expect("parses");
+        let (cfg, _) = host_cfg_from_toml_str("[deploy]\nhost = \"h\"\n").expect("parses");
         assert!(!cfg.enabled);
     }
 
     #[test]
     fn ffmpeg_bin_defaults_and_reads_from_media_ffmpeg() {
         assert_eq!(
-            ffmpeg_bin_from_toml_str("").expect("empty parses"),
+            host_cfg_from_toml_str("").expect("empty parses").1,
             DEFAULT_FFMPEG_BIN
         );
-        let bin =
-            ffmpeg_bin_from_toml_str("[media.ffmpeg]\nbin = \"/opt/ffmpeg\"\n").expect("parses");
+        let (_, bin) =
+            host_cfg_from_toml_str("[media.ffmpeg]\nbin = \"/opt/ffmpeg\"\n").expect("parses");
         assert_eq!(bin, "/opt/ffmpeg");
     }
 
     #[test]
-    fn from_toml_str_fails_closed_on_malformed_mediamtx_section() {
+    fn media_config_fails_closed_on_malformed_mediamtx_section() {
         // Finding C: a PRESENT `[media.mediamtx]` with an ill-typed value is a hard
         // error, so the caller must abort rather than silently disable provisioning.
         // `enabled` as a string, not a bool:
-        assert!(
-            MediaMtxHostConfig::from_toml_str("[media.mediamtx]\nenabled = \"yes\"\n").is_err()
-        );
+        assert!(host_cfg_from_toml_str("[media.mediamtx]\nenabled = \"yes\"\n").is_err());
         // A port field as a non-number:
-        assert!(
-            MediaMtxHostConfig::from_toml_str("[media.mediamtx]\napi_port = \"nope\"\n").is_err()
-        );
+        assert!(host_cfg_from_toml_str("[media.mediamtx]\napi_port = \"nope\"\n").is_err());
     }
 
     #[test]
     fn media_config_fails_closed_on_malformed_ffmpeg_section() {
-        // Finding C: a malformed `[media.ffmpeg]` is also a hard error — both
-        // deploy-side parsers deserialize the whole `[media]` subtree, so neither
-        // can be tricked into the disabled default by a broken ffmpeg table.
+        // Finding C: a malformed `[media.ffmpeg]` is also a hard error — the deploy
+        // deserializer reads the whole `[media]` subtree, so a broken ffmpeg table
+        // cannot be tricked into the disabled default.
         let toml = "[media.ffmpeg]\nbin = 123\n";
-        assert!(ffmpeg_bin_from_toml_str(toml).is_err());
-        assert!(MediaMtxHostConfig::from_toml_str(toml).is_err());
+        assert!(host_cfg_from_toml_str(toml).is_err());
     }
 
     // ── mediamtx.yml rendering ───────────────────────────────────────────────
@@ -2025,7 +2103,7 @@ sctp  LISTEN 0 128  0.0.0.0:9999  0.0.0.0:*
     }
 
     #[test]
-    fn collect_runs_all_four_checks_in_order() {
+    fn collect_runs_all_five_checks_in_order() {
         let exec = RecordingExecutor::new()
             .with_stdout("media-ffmpeg-preflight", "ffmpeg version 6.1")
             .with_stdout(
@@ -2034,8 +2112,12 @@ sctp  LISTEN 0 128  0.0.0.0:9999  0.0.0.0:*
             );
         let checks =
             collect_media_doctor_checks(&exec, &MediaMtxHostConfig::default(), "/usr/bin/ffmpeg");
-        assert_eq!(checks.len(), 4);
+        assert_eq!(checks.len(), 5);
         assert!(checks.iter().all(|c| c.passed), "all should pass");
+        // The pure ports-distinct config check (Finding P) leads and runs NO
+        // command, so the recorded command order is unchanged from the four
+        // executor-driven checks.
+        assert_eq!(checks[0].name, CHECK_MEDIAMTX_PORTS_DISTINCT);
         assert_eq!(
             exec.labels(),
             vec![
@@ -2050,6 +2132,91 @@ sctp  LISTEN 0 128  0.0.0.0:9999  0.0.0.0:*
                 "media-ports"
             ]
         );
+    }
+
+    // ── Distinct listener ports (Finding P) ──────────────────────────────────
+
+    #[test]
+    fn ports_distinct_passes_for_default_config() {
+        let check = mediamtx_ports_distinct(&MediaMtxHostConfig::default());
+        assert!(
+            check.passed,
+            "default ports are all distinct: {}",
+            check.detail
+        );
+        assert_eq!(check.name, CHECK_MEDIAMTX_PORTS_DISTINCT);
+    }
+
+    #[test]
+    fn ports_distinct_fails_when_two_tcp_listeners_share_a_port() {
+        // hls_port == playback_port: two MediaMTX servers asked to bind one TCP
+        // port. `ss` passes on a fresh host, but the deferred restart fails.
+        let cfg = MediaMtxHostConfig {
+            hls_port: 8888,
+            playback_port: 8888,
+            ..MediaMtxHostConfig::default()
+        };
+        let check = mediamtx_ports_distinct(&cfg);
+        assert!(!check.passed);
+        // Names the duplicated value and BOTH conflicting fields.
+        assert!(check.detail.contains("8888"), "detail: {}", check.detail);
+        assert!(
+            check.detail.contains("hls_port"),
+            "detail: {}",
+            check.detail
+        );
+        assert!(
+            check.detail.contains("playback_port"),
+            "detail: {}",
+            check.detail
+        );
+        assert!(check.hint.is_some());
+    }
+
+    #[test]
+    fn ports_distinct_allows_tcp_port_equal_to_udp_port() {
+        // The WebRTC local UDP port (8189) is a separate protocol namespace, so a
+        // TCP listener numerically equal to it is NOT a conflict.
+        let cfg = MediaMtxHostConfig {
+            rtmp_port: MEDIAMTX_WEBRTC_LOCAL_UDP_PORT,
+            ..MediaMtxHostConfig::default()
+        };
+        assert_eq!(cfg.rtmp_port, cfg.webrtc_local_udp);
+        let check = mediamtx_ports_distinct(&cfg);
+        assert!(
+            check.passed,
+            "a TCP port equal to the UDP port is not a same-protocol conflict: {}",
+            check.detail
+        );
+    }
+
+    // ── media_host_config_from_value (Finding O merge target) ────────────────
+
+    #[test]
+    fn media_host_config_from_value_reads_merged_media_subtree() {
+        let root: toml::Value = toml::from_str(
+            "[media.mediamtx]\nenabled = true\napi_port = 19997\n[media.ffmpeg]\nbin = \"/opt/ff\"\n",
+        )
+        .expect("parses");
+        let (cfg, bin) = media_host_config_from_value(root).expect("deserializes");
+        assert!(cfg.enabled);
+        assert_eq!(cfg.api_port, 19997);
+        assert_eq!(bin, "/opt/ff");
+    }
+
+    #[test]
+    fn media_host_config_from_value_absent_media_is_disabled_default() {
+        let root: toml::Value = toml::from_str("[deploy]\nhost = \"h\"\n").expect("parses");
+        let (cfg, bin) = media_host_config_from_value(root).expect("deserializes");
+        assert!(!cfg.enabled);
+        assert_eq!(bin, DEFAULT_FFMPEG_BIN);
+    }
+
+    #[test]
+    fn media_host_config_from_value_fails_closed_on_ill_typed_value() {
+        let root: toml::Value =
+            toml::from_str("[media.mediamtx]\nenabled = \"yes\"\n").expect("parses");
+        assert!(media_host_config_from_value(root).is_err());
     }
 
     // ── CSP origins ──────────────────────────────────────────────────────────

--- a/autumn-cli/src/deploy/media.rs
+++ b/autumn-cli/src/deploy/media.rs
@@ -500,58 +500,97 @@ impl MediaMtxController {
     }
 
     /// Ordered ops that render `mediamtx.yml` + the systemd unit to the host and
-    /// make `MediaMTX` enabled, running, and reloaded with the freshest config.
+    /// make `MediaMTX` enabled, running, and reloaded — **restarting the daemon
+    /// only when the rendered config/unit actually changed, or when the unit is
+    /// not already running.**
     ///
     /// Returns an **empty vector when the section is not `enabled`** — the
     /// controller is a no-op for an app that does not provision `MediaMTX`. When
     /// enabled it emits, in order:
     /// 1. `Run` `mkdir -p <config parent dir>` — `scp` (the upload transport)
     ///    does not create parents, so the config dir must exist before op 2
-    ///    writes into it (omitted only for a parent-less `config_path`). The
-    ///    unit's parent (`/etc/systemd/system`) is a standard existing dir and
-    ///    needs no `mkdir`.
-    /// 2. `WriteFile` the rendered `mediamtx.yml` to `config_path` (mode `0644`).
-    /// 3. `WriteFile` the rendered unit to `/etc/systemd/system/<unit>.service`
-    ///    (mode `0644`).
-    /// 4. `Run` `systemctl daemon-reload && systemctl enable --now <unit>.service
-    ///    && systemctl restart <unit>.service` — idempotent, and the trailing
-    ///    `restart` reloads the freshly-written config on a redeploy.
+    ///    writes the staged config into it (omitted only for a parent-less
+    ///    `config_path`). The unit's parent (`/etc/systemd/system`) is a standard
+    ///    existing dir and needs no `mkdir`.
+    /// 2. `WriteFile` the rendered `mediamtx.yml` to a **temp path**
+    ///    (`<config_path>.autumn-new`, mode `0644`) — a sibling of the live file,
+    ///    never over it, so the live config is untouched until op 4 proves a real
+    ///    change.
+    /// 3. `WriteFile` the rendered unit to a **temp path**
+    ///    (`/etc/systemd/system/<unit>.service.autumn-new`, mode `0644`).
+    /// 4. `Run` a single idempotent shell command that `cmp -s`-compares each
+    ///    staged temp file to its live counterpart (a missing live file counts as
+    ///    changed), copies over only the changed ones (tracking a `changed`
+    ///    flag), removes the temp files, runs `systemctl daemon-reload` +
+    ///    `systemctl enable <unit>.service` (both idempotent), and restarts the
+    ///    unit **only if** `changed` is set **or** the unit is not currently
+    ///    active (`systemctl is-active --quiet <unit>.service` fails).
+    ///
+    /// The load-bearing behaviour (issue #2051, Finding H): a pure app redeploy
+    /// or a no-op media-config redeploy leaves the config and unit byte-identical
+    /// and the unit already active, so **no restart runs** — active
+    /// RTMP/WebRTC/HLS sessions are never killed before cutover. A genuine config
+    /// or unit change (or a dead/never-started unit) still restarts, so the
+    /// freshest config always takes effect.
     #[must_use]
     pub fn ensure_installed_ops(&self) -> Vec<DeployOp> {
         if !self.cfg.enabled {
             return Vec::new();
         }
         let unit = self.cfg.unit_name.clone();
+        let config_tmp = format!("{}.autumn-new", self.cfg.config_path);
+        let unit_path = self.unit_path();
+        let unit_tmp = format!("{unit_path}.autumn-new");
         let mut ops = Vec::new();
-        // Create the config's parent dir before scp writes the file into it —
-        // `scp` never creates missing parents, so the default
+        // Create the config's parent dir before scp writes the staged file into
+        // it — `scp` never creates missing parents, so the default
         // `/etc/mediamtx/mediamtx.yml` would fail at `media-write-config` on a
-        // fresh host without this. Skipped for a parent-less path (root/bare).
+        // fresh host without this. The temp file is a sibling of the live config,
+        // so this one `mkdir` covers both. Skipped for a parent-less path.
         if let Some(parent) = parent_dir(&self.cfg.config_path) {
             ops.push(DeployOp::Run(RemoteCommand::new(
                 "media-prepare-dirs",
                 format!("mkdir -p {}", super::exec::shell_quote(parent)),
             )));
         }
+        // Stage config + unit to TEMP paths (never directly over the live files),
+        // so op 4 can diff them and restart only on a real change.
         ops.push(DeployOp::WriteFile {
             label: "media-write-config",
             contents: FileContents::Plain(render_mediamtx_yml(&self.cfg)),
-            remote_path: self.cfg.config_path.clone(),
+            remote_path: config_tmp.clone(),
             mode: Some(0o644),
         });
         ops.push(DeployOp::WriteFile {
             label: "media-write-unit",
             contents: FileContents::Plain(render_mediamtx_unit(&self.cfg)),
-            remote_path: self.unit_path(),
+            remote_path: unit_tmp.clone(),
             mode: Some(0o644),
         });
-        ops.push(DeployOp::Run(RemoteCommand::new(
-            "media-install",
-            format!(
-                "systemctl daemon-reload && systemctl enable --now {unit}.service && \
-                 systemctl restart {unit}.service",
-            ),
-        )));
+
+        let cfg_live = super::exec::shell_quote(&self.cfg.config_path);
+        let cfg_new = super::exec::shell_quote(&config_tmp);
+        let unit_live = super::exec::shell_quote(&unit_path);
+        let unit_new = super::exec::shell_quote(&unit_tmp);
+        // POSIX-sh, fail-fast (`set -e`): compare each staged file to its live
+        // counterpart; a missing live file (`cmp` non-zero) or a real diff copies
+        // it over and flags `changed`. daemon-reload + enable are idempotent. The
+        // unit is restarted ONLY when the config/unit changed OR it is not
+        // already active — an app-only redeploy over unchanged, already-running
+        // media never interrupts live sessions.
+        let install = format!(
+            "set -e; \
+             changed=0; \
+             if ! cmp -s {cfg_new} {cfg_live}; then cp {cfg_new} {cfg_live}; chmod 0644 {cfg_live}; changed=1; fi; \
+             if ! cmp -s {unit_new} {unit_live}; then cp {unit_new} {unit_live}; chmod 0644 {unit_live}; changed=1; fi; \
+             rm -f {cfg_new} {unit_new}; \
+             systemctl daemon-reload; \
+             systemctl enable {unit}.service; \
+             if [ \"$changed\" -ne 0 ] || ! systemctl is-active --quiet {unit}.service; then \
+             systemctl restart {unit}.service; \
+             fi",
+        );
+        ops.push(DeployOp::Run(RemoteCommand::new("media-install", install)));
         ops
     }
 }
@@ -719,43 +758,74 @@ pub fn recordings_dir_writable(
     }
 }
 
-/// The `MediaMTX` ports a bare host must have free before provisioning: the five
-/// TCP listeners plus the WebRTC local UDP port. A port already bound by another
-/// service is a conflict `MediaMTX` cannot resolve.
+/// The transport protocol of a listening socket (the `ss` Netid column). Only
+/// `tcp` / `udp` are relevant to `MediaMTX`; any other Netid is ignored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Protocol {
+    Tcp,
+    Udp,
+}
+
+/// The `MediaMTX` ports a bare host must have free before provisioning, **each
+/// tagged with the protocol `MediaMTX` actually binds** (issue #2051, Finding I):
+/// the five TCP listeners (RTMP, HLS, WebRTC/WHEP, playback, control API) plus the
+/// WebRTC local **UDP** port (`webrtcLocalUDPAddress`, ICE host candidates). A
+/// listener conflicts only when it matches BOTH the port AND the protocol — a
+/// same-port/different-protocol listener (e.g. a TCP service on the UDP-only
+/// `:8189`) is not a conflict.
 #[must_use]
-fn mediamtx_required_ports(cfg: &MediaMtxHostConfig) -> Vec<u16> {
+fn mediamtx_required_ports(cfg: &MediaMtxHostConfig) -> Vec<(u16, Protocol)> {
     vec![
-        cfg.api_port,
-        cfg.rtmp_port,
-        cfg.hls_port,
-        cfg.webrtc_port,
-        cfg.playback_port,
-        cfg.webrtc_local_udp,
+        (cfg.api_port, Protocol::Tcp),
+        (cfg.rtmp_port, Protocol::Tcp),
+        (cfg.hls_port, Protocol::Tcp),
+        (cfg.webrtc_port, Protocol::Tcp),
+        (cfg.playback_port, Protocol::Tcp),
+        (cfg.webrtc_local_udp, Protocol::Udp),
     ]
 }
 
-/// A listening socket parsed from `ss -H -tulnp`: the local port plus the owning
-/// process name (`None` when `ss` could not attribute the socket — e.g. the
+/// A listening socket parsed from `ss -H -tulnp`: the local port, its transport
+/// protocol (the Netid column — issue #2051, Finding I), and the owning process
+/// name (`None` when `ss` could not attribute the socket — e.g. the
 /// `users:(("name",…))` column is absent because the caller lacked privilege).
-type ListeningSocket = (u16, Option<String>);
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ListeningSocket {
+    port: u16,
+    protocol: Protocol,
+    owner: Option<String>,
+}
 
-/// Parse the listening sockets out of `ss -H -tulnp` output as
-/// `(port, owner_process)` pairs.
+/// Parse the listening sockets out of `ss -H -tulnp` output.
 ///
-/// Each line's 5th column (index 4: `Netid State Recv-Q Send-Q Local Peer …`) is
-/// the `Local Address:Port` — the port is the tail after the last `:` (covers
-/// IPv4 `0.0.0.0:8888`, IPv6 `[::]:8888`, and `*:8888`). The owning process is
-/// read from the trailing `users:(("<name>",pid=…,fd=…))` column (added by `-p`),
-/// or `None` when that column is absent. Lines whose port does not parse are
-/// skipped. Pure — unit-tested against captured `ss` output.
+/// Each row's 1st column (index 0) is the `Netid` (`tcp` / `udp`) and its 5th
+/// column (index 4: `Netid State Recv-Q Send-Q Local Peer …`) is the
+/// `Local Address:Port` — the port is the tail after the last `:` (covers IPv4
+/// `0.0.0.0:8888`, IPv6 `[::]:8888`, and `*:8888`). The owning process is read
+/// from the trailing `users:(("<name>",pid=…,fd=…))` column (added by `-p`), or
+/// `None` when that column is absent. Rows whose Netid is not `tcp`/`udp`, or
+/// whose port does not parse, are skipped. Pure — unit-tested against captured
+/// `ss` output.
 #[must_use]
 fn parse_listening_sockets(ss_output: &str) -> Vec<ListeningSocket> {
     ss_output
         .lines()
         .filter_map(|line| {
-            let local = line.split_whitespace().nth(4)?;
+            let mut cols = line.split_whitespace();
+            let protocol = match cols.next()? {
+                "tcp" => Protocol::Tcp,
+                "udp" => Protocol::Udp,
+                _ => return None,
+            };
+            // We already consumed index 0 (Netid); the Local column is index 4,
+            // i.e. the 4th remaining column (skip State/Recv-Q/Send-Q).
+            let local = cols.nth(3)?;
             let port = local.rsplit(':').next()?.parse::<u16>().ok()?;
-            Some((port, process_name_from_ss_line(line)))
+            Some(ListeningSocket {
+                port,
+                protocol,
+                owner: process_name_from_ss_line(line),
+            })
         })
         .collect()
 }
@@ -785,29 +855,48 @@ fn managed_process_name(cfg: &MediaMtxHostConfig) -> &str {
         .unwrap_or(cfg.binary_path.as_str())
 }
 
+/// Whether our configured `MediaMTX` systemd unit is currently active, via
+/// `systemctl is-active --quiet <unit>.service` (exit `0` ⇒ active). Any failure
+/// (inactive, unknown unit, or transport error) is read as **not active** — the
+/// fail-closed direction for [`mediamtx_ports_available`]'s Finding-J gate. Run
+/// at most once per check and the result reused.
+#[must_use]
+fn unit_is_active(exec: &impl DeployExecutor, unit_name: &str) -> bool {
+    let cmd = RemoteCommand::new(
+        "media-unit-active",
+        format!("systemctl is-active --quiet {unit_name}.service"),
+    );
+    exec.run(&cmd).is_ok()
+}
+
 /// Grade that the `MediaMTX` ports are free on the host (no *foreign* service is
 /// already bound to them).
 ///
-/// **Process-aware, redeploy-safe on changed ports.** It always runs the port
-/// scan — `ss -H -tulnp` (the `-p` adds the owning-process column) over the
-/// executor — and classifies each configured target port by *who* holds it, not
-/// merely whether it is occupied:
+/// **Protocol-aware and unit-verified** (issue #2051, Findings I + J). It runs a
+/// single port scan — `ss -H -tulnp` (the `-p` adds the owning-process column,
+/// the leading Netid gives the protocol) over the executor — and classifies each
+/// configured target `(port, protocol)`:
 ///
-/// - No listener → the port is free → pass.
-/// - Every listener owned by *our own* managed `MediaMTX` (process basename of
-///   [`MediaMtxHostConfig::binary_path`]) → a same-port redeploy, not a conflict
-///   → pass (informational note).
-/// - A listener owned by any *other* process, **or** a listener whose owner
+/// - No **same-protocol** listener on the port → free → pass. A same-port but
+///   *different-protocol* listener is NOT a conflict: the WebRTC local port
+///   `:8189` is UDP-only, so a TCP service on `8189` (or a UDP service on a TCP
+///   `MediaMTX` port) never cross-conflicts (Finding I).
+/// - Every same-protocol listener owned by *our own* managed `MediaMTX` (process
+///   basename of [`MediaMtxHostConfig::binary_path`]) **and** our configured unit
+///   reports active (`systemctl is-active --quiet <unit>.service`) → a same-port
+///   redeploy of our own daemon, not a conflict → pass (informational note).
+/// - A same-protocol listener owned by a `MediaMTX` process while our configured
+///   unit is **not** active (manual run, a differently-named service, or a
+///   crashed unit) → conflict → fail-closed (Finding J): `enable --now` would
+///   start a *second* instance over ports the old process still owns.
+/// - A same-protocol listener owned by any *other* process, **or** whose owner
 ///   cannot be attributed (empty process column — e.g. insufficient privilege) →
 ///   conflict → fail-closed. `autumn deploy` runs as root managing systemd, so
 ///   `-p` attribution is normally available; an unattributable listener on a
 ///   target port is deliberately treated as a conflict rather than assumed benign.
 ///
-/// This replaces an earlier blanket `systemctl is-active` skip, which passed a
-/// running unit without scanning at all — so a redeploy that *changed* a `MediaMTX`
-/// port could not detect a foreign service already bound to the new port (the old
-/// unit only holds the old ports). The per-port ownership check keeps the
-/// same-port redeploy self-conflict passing while still catching that case.
+/// The unit `is-active` query runs at most **once** (only when a MediaMTX-owned
+/// port is actually found) and the result is reused across the held ports.
 ///
 /// Fail-closed: if `ss` cannot run, or its output does not parse into any
 /// recognizable listener, the check fails with a "could not verify" message
@@ -819,7 +908,8 @@ pub fn mediamtx_ports_available(
 ) -> PreflightCheck {
     // `-p` attaches the owning-process column so a target port held by our own
     // managed MediaMTX (a same-port redeploy) is distinguished from a foreign
-    // conflict. Deploy runs as root, so `-p` attribution is available.
+    // conflict; the Netid column gives the protocol. Deploy runs as root, so `-p`
+    // attribution is available.
     let cmd = RemoteCommand::new("media-ports", "ss -H -tulnp".to_owned());
     let output = match exec.run(&cmd) {
         Ok(out) => out.stdout,
@@ -849,46 +939,71 @@ pub fn mediamtx_ports_available(
     }
 
     let ours = managed_process_name(cfg);
-    let mut conflicts: Vec<u16> = Vec::new();
-    let mut held_by_us: Vec<u16> = Vec::new();
-    for port in mediamtx_required_ports(cfg) {
-        let mut has_listener = false;
-        let mut all_ours = true;
-        for (socket_port, owner) in &sockets {
-            if *socket_port != port {
-                continue;
-            }
-            has_listener = true;
-            // A listener owned by our own mediamtx is fine; a foreign process OR
-            // an unattributable listener (owner `None`) is a conflict → fail-closed.
-            if owner.as_deref() != Some(ours) {
-                all_ours = false;
-            }
+    // Ports held by a foreign / unattributable same-protocol listener.
+    let mut foreign: Vec<u16> = Vec::new();
+    // Ports held only by our own MediaMTX process (pending the Finding-J
+    // is-active gate below).
+    let mut ours_ports: Vec<u16> = Vec::new();
+    for (port, protocol) in mediamtx_required_ports(cfg) {
+        // A listener conflicts only when it matches BOTH the port AND the
+        // protocol (Finding I) — a same-port/different-protocol listener is not
+        // a conflict.
+        let mut matching = sockets
+            .iter()
+            .filter(|s| s.port == port && s.protocol == protocol)
+            .peekable();
+        if matching.peek().is_none() {
+            continue; // no same-protocol listener → free
         }
-        if !has_listener {
-            continue; // free
-        }
-        if all_ours {
-            held_by_us.push(port);
+        // A listener owned by our own mediamtx is (provisionally) ours; a foreign
+        // process OR an unattributable listener (owner `None`) is a conflict.
+        if matching.all(|s| s.owner.as_deref() == Some(ours)) {
+            ours_ports.push(port);
         } else {
-            conflicts.push(port);
+            foreign.push(port);
         }
     }
-    conflicts.sort_unstable();
-    conflicts.dedup();
 
-    if !conflicts.is_empty() {
-        let list = conflicts
-            .iter()
-            .map(u16::to_string)
-            .collect::<Vec<_>>()
-            .join(", ");
+    // Finding J: a MediaMTX-owned port counts as "ours" only when our configured
+    // unit is actually active. If the ports are held by a `mediamtx` process that
+    // is NOT our managed unit (manual run / differently-named service / crashed),
+    // treat them as conflicts (fail-closed) — `enable --now` must not start a
+    // second instance over them. The is-active query runs at most once.
+    let mut held_by_us: Vec<u16> = Vec::new();
+    let mut unmanaged: Vec<u16> = Vec::new();
+    if !ours_ports.is_empty() {
+        if unit_is_active(exec, &cfg.unit_name) {
+            held_by_us = ours_ports;
+        } else {
+            unmanaged = ours_ports;
+        }
+    }
+
+    let mut conflict_msgs: Vec<String> = Vec::new();
+    foreign.sort_unstable();
+    foreign.dedup();
+    if !foreign.is_empty() {
+        conflict_msgs.push(format!(
+            "MediaMTX port(s) already in use by another service on the host: {}",
+            join_ports(&foreign)
+        ));
+    }
+    unmanaged.sort_unstable();
+    unmanaged.dedup();
+    if !unmanaged.is_empty() {
+        conflict_msgs.push(format!(
+            "MediaMTX port(s) {} are held by a `{ours}` process, but the configured \
+             `{}` unit is not active — an unmanaged/manual MediaMTX (or a crashed unit) still \
+             owns them, so starting our unit would launch a second instance over them",
+            join_ports(&unmanaged),
+            cfg.unit_name,
+        ));
+    }
+    if !conflict_msgs.is_empty() {
         return PreflightCheck {
             name: CHECK_MEDIAMTX_PORTS_AVAILABLE,
             passed: false,
-            detail: format!(
-                "MediaMTX port(s) already in use by another service on the host: {list}"
-            ),
+            detail: conflict_msgs.join("; "),
             hint: Some(PORTS_HINT),
         };
     }
@@ -896,14 +1011,10 @@ pub fn mediamtx_ports_available(
     let detail = if held_by_us.is_empty() {
         "all MediaMTX ports are free on the host".to_owned()
     } else {
-        let list = held_by_us
-            .iter()
-            .map(u16::to_string)
-            .collect::<Vec<_>>()
-            .join(", ");
         format!(
-            "MediaMTX ports are available; port(s) {list} are already held by our own managed \
-             MediaMTX (same-port redeploy)"
+            "MediaMTX ports are available; port(s) {} are already held by our own managed \
+             MediaMTX (same-port redeploy)",
+            join_ports(&held_by_us),
         )
     };
     PreflightCheck {
@@ -912,6 +1023,16 @@ pub fn mediamtx_ports_available(
         detail,
         hint: None,
     }
+}
+
+/// Join a sorted list of ports as a `"1935, 8888"` string for messages.
+#[must_use]
+fn join_ports(ports: &[u16]) -> String {
+    ports
+        .iter()
+        .map(u16::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Collect the three `MediaMTX` host doctor checks against a live executor.
@@ -967,6 +1088,15 @@ mod tests {
 
         fn with_stdout(mut self, label: &'static str, stdout: impl Into<String>) -> Self {
             self.stdout_by_label.push((label, stdout.into()));
+            self
+        }
+
+        /// Chainable variant of [`Self::failing_on`]: mark an additional command
+        /// label as failing (so a check can succeed on one command and fail on
+        /// another — e.g. `ss` succeeds but `systemctl is-active` reports the unit
+        /// inactive).
+        fn failing(mut self, label: &'static str) -> Self {
+            self.fail_labels.push(label);
             self
         }
 
@@ -1217,7 +1347,8 @@ unit_name = \"mediamtx-prod\"
         assert_eq!(mkdir.label, "media-prepare-dirs");
         assert_eq!(mkdir.shell, "mkdir -p '/etc/mediamtx'");
 
-        // op 1: write mediamtx.yml to config_path (0644), with rendered config.
+        // Finding H: op 1 writes mediamtx.yml to a TEMP path (never over the live
+        // file), so op 3 can diff it and restart only on a real change.
         match &ops[1] {
             DeployOp::WriteFile {
                 label,
@@ -1226,7 +1357,7 @@ unit_name = \"mediamtx-prod\"
                 mode,
             } => {
                 assert_eq!(*label, "media-write-config");
-                assert_eq!(remote_path, "/etc/mediamtx/mediamtx.yml");
+                assert_eq!(remote_path, "/etc/mediamtx/mediamtx.yml.autumn-new");
                 assert_eq!(*mode, Some(0o644));
                 let FileContents::Plain(yml) = contents else {
                     panic!("config must be plain text");
@@ -1236,7 +1367,7 @@ unit_name = \"mediamtx-prod\"
             other => panic!("op 1 must write the config, got {other:?}"),
         }
 
-        // op 2: write the unit to /etc/systemd/system/mediamtx.service (0644).
+        // op 2: write the unit to a TEMP path next to the live unit (0644).
         match &ops[2] {
             DeployOp::WriteFile {
                 label,
@@ -1245,7 +1376,10 @@ unit_name = \"mediamtx-prod\"
                 mode,
             } => {
                 assert_eq!(*label, "media-write-unit");
-                assert_eq!(remote_path, "/etc/systemd/system/mediamtx.service");
+                assert_eq!(
+                    remote_path,
+                    "/etc/systemd/system/mediamtx.service.autumn-new"
+                );
                 assert_eq!(*mode, Some(0o644));
                 let FileContents::Plain(unit) = contents else {
                     panic!("unit must be plain text");
@@ -1255,15 +1389,81 @@ unit_name = \"mediamtx-prod\"
             other => panic!("op 2 must write the unit, got {other:?}"),
         }
 
-        // op 3: daemon-reload + enable --now + restart.
+        // op 3 (the conditional-restart install) is asserted in
+        // `controller_install_op_is_conditional_restart` below.
+        assert!(matches!(&ops[3], DeployOp::Run(c) if c.label == "media-install"));
+    }
+
+    #[test]
+    fn controller_install_op_is_conditional_restart() {
+        // Finding H: op 3 must `cmp` the staged temp files against the live ones,
+        // copy only the changed, and restart the unit ONLY on a real change or an
+        // inactive unit — never unconditionally (which would kill live sessions on
+        // a pure app redeploy).
+        let cfg = MediaMtxHostConfig {
+            enabled: true,
+            ..MediaMtxHostConfig::default()
+        };
+        let ops = MediaMtxController::new(cfg).ensure_installed_ops();
         let DeployOp::Run(cmd) = &ops[3] else {
             panic!("op 3 must be the install Run op");
         };
         assert_eq!(cmd.label, "media-install");
-        assert_eq!(
-            cmd.shell,
-            "systemctl daemon-reload && systemctl enable --now mediamtx.service && \
-             systemctl restart mediamtx.service",
+        let shell = &cmd.shell;
+        // Diffs the staged temp files against the live counterparts.
+        assert!(
+            shell.contains(
+                "cmp -s '/etc/mediamtx/mediamtx.yml.autumn-new' '/etc/mediamtx/mediamtx.yml'"
+            ),
+            "must cmp the staged config against the live config: {shell}"
+        );
+        assert!(
+            shell.contains(
+                "cmp -s '/etc/systemd/system/mediamtx.service.autumn-new' \
+                 '/etc/systemd/system/mediamtx.service'"
+            ),
+            "must cmp the staged unit against the live unit: {shell}"
+        );
+        // Copies over only the changed files and tracks a `changed` flag.
+        assert!(
+            shell.contains("changed=1"),
+            "must track a changed flag: {shell}"
+        );
+        assert!(
+            shell.contains(
+                "cp '/etc/mediamtx/mediamtx.yml.autumn-new' '/etc/mediamtx/mediamtx.yml'"
+            ),
+            "must copy the staged config into place on change: {shell}"
+        );
+        // Cleans up the temp files.
+        assert!(
+            shell.contains(
+                "rm -f '/etc/mediamtx/mediamtx.yml.autumn-new' \
+                 '/etc/systemd/system/mediamtx.service.autumn-new'"
+            ),
+            "must clean up the staged temp files: {shell}"
+        );
+        // Idempotent daemon-reload + enable (NOT `enable --now` — start is handled
+        // by the conditional restart).
+        assert!(shell.contains("systemctl daemon-reload"), "{shell}");
+        assert!(
+            shell.contains("systemctl enable mediamtx.service"),
+            "{shell}"
+        );
+        assert!(
+            !shell.contains("enable --now"),
+            "must not `enable --now` (that would start unconditionally): {shell}"
+        );
+        // Restart gated on change-OR-inactive, never unconditional.
+        assert!(
+            shell.contains(
+                "if [ \"$changed\" -ne 0 ] || ! systemctl is-active --quiet mediamtx.service; then"
+            ),
+            "restart must be gated on change or an inactive unit: {shell}"
+        );
+        assert!(
+            shell.contains("systemctl restart mediamtx.service"),
+            "{shell}"
         );
     }
 
@@ -1283,8 +1483,17 @@ unit_name = \"mediamtx-prod\"
         let DeployOp::Run(cmd) = &ops[3] else {
             panic!("op 3 must be the install Run op");
         };
-        assert!(cmd.shell.contains("enable --now mediamtx-prod.service"));
+        assert!(cmd.shell.contains("systemctl enable mediamtx-prod.service"));
+        assert!(
+            cmd.shell
+                .contains("is-active --quiet mediamtx-prod.service")
+        );
         assert!(cmd.shell.contains("restart mediamtx-prod.service"));
+        // The staged temp unit tracks the custom unit name too.
+        assert!(
+            cmd.shell
+                .contains("/etc/systemd/system/mediamtx-prod.service.autumn-new")
+        );
     }
 
     #[test]
@@ -1457,17 +1666,28 @@ unit_name = \"mediamtx-prod\"
     // ── Doctor: mediamtx ports available ─────────────────────────────────────
 
     #[test]
-    fn parse_listening_sockets_extracts_port_and_owner() {
+    fn parse_listening_sockets_extracts_port_protocol_and_owner() {
+        // Finding I: the Netid (tcp/udp) column is parsed onto each socket.
         let ss = "\
 tcp   LISTEN 0 128  0.0.0.0:8888  0.0.0.0:*  users:((\"mediamtx\",pid=10,fd=5))
 tcp   LISTEN 0 128  [::]:22       [::]:*     users:((\"sshd\",pid=5,fd=3))
 udp   UNCONN 0 0    *:8189        *:*
+sctp  LISTEN 0 128  0.0.0.0:9999  0.0.0.0:*
 ";
         let sockets = parse_listening_sockets(ss);
-        assert!(sockets.contains(&(8888, Some("mediamtx".to_owned()))));
-        assert!(sockets.contains(&(22, Some("sshd".to_owned()))));
-        // The UDP row has no `users:` column → unattributable owner.
-        assert!(sockets.contains(&(8189, None)));
+        assert!(sockets.iter().any(|s| s.port == 8888
+            && s.protocol == Protocol::Tcp
+            && s.owner.as_deref() == Some("mediamtx")));
+        assert!(sockets.iter().any(|s| s.port == 22
+            && s.protocol == Protocol::Tcp
+            && s.owner.as_deref() == Some("sshd")));
+        // The UDP row has no `users:` column → unattributable owner, protocol UDP.
+        assert!(
+            sockets
+                .iter()
+                .any(|s| s.port == 8189 && s.protocol == Protocol::Udp && s.owner.is_none())
+        );
+        // A non-tcp/udp Netid (e.g. `sctp`) is skipped entirely.
         assert_eq!(sockets.len(), 3);
     }
 
@@ -1520,8 +1740,10 @@ udp   UNCONN 0 0    *:8189        *:*
             "detail: {}",
             check.detail
         );
-        // No is-active gate anymore: only the single `ss` scan runs.
-        assert_eq!(exec.labels(), vec!["media-ports"]);
+        // Finding J: because MediaMTX-owned ports were found, the is-active gate
+        // runs exactly once after the `ss` scan (the fake reports the unit active
+        // by default), so the same-port redeploy passes.
+        assert_eq!(exec.labels(), vec!["media-ports", "media-unit-active"]);
     }
 
     #[test]
@@ -1545,6 +1767,95 @@ udp   UNCONN 0 0    *:8189        *:*
         let check = mediamtx_ports_available(&exec, &cfg);
         assert!(!check.passed, "detail: {}", check.detail);
         assert!(check.detail.contains("8080"), "detail: {}", check.detail);
+    }
+
+    #[test]
+    fn ports_available_ignores_same_port_different_protocol_listener() {
+        // Finding I: the WebRTC local port 8189 is UDP-only. A TCP service on 8189
+        // is a DIFFERENT protocol, so it must NOT be flagged as a conflict.
+        let exec = RecordingExecutor::new().with_stdout(
+            "media-ports",
+            "tcp LISTEN 0 128 0.0.0.0:22 0.0.0.0:* users:((\"sshd\",pid=5,fd=3))\n\
+             tcp LISTEN 0 128 0.0.0.0:8189 0.0.0.0:* users:((\"someapp\",pid=77,fd=9))\n",
+        );
+        let check = mediamtx_ports_available(&exec, &MediaMtxHostConfig::default());
+        assert!(check.passed, "detail: {}", check.detail);
+        assert!(check.detail.contains("free"), "detail: {}", check.detail);
+
+        // The mirror case: a UDP service on a TCP MediaMTX port (8888 is TCP) is
+        // also a different protocol and not a conflict.
+        let exec = RecordingExecutor::new().with_stdout(
+            "media-ports",
+            "udp UNCONN 0 0 0.0.0.0:8888 0.0.0.0:* users:((\"someapp\",pid=88,fd=4))\n",
+        );
+        let check = mediamtx_ports_available(&exec, &MediaMtxHostConfig::default());
+        assert!(check.passed, "detail: {}", check.detail);
+    }
+
+    #[test]
+    fn ports_available_fails_on_same_protocol_foreign_listener() {
+        // Finding I: a TCP listener on the TCP HLS port (8888), owned by a foreign
+        // process, IS a same-protocol conflict.
+        let exec = RecordingExecutor::new().with_stdout(
+            "media-ports",
+            "tcp LISTEN 0 128 0.0.0.0:8888 0.0.0.0:* users:((\"nginx\",pid=99,fd=6))\n",
+        );
+        let check = mediamtx_ports_available(&exec, &MediaMtxHostConfig::default());
+        assert!(!check.passed, "detail: {}", check.detail);
+        assert!(check.detail.contains("8888"), "detail: {}", check.detail);
+        assert!(check.detail.contains("another service"));
+    }
+
+    #[test]
+    fn ports_available_fails_on_udp_foreign_listener_on_udp_target() {
+        // Finding I: a UDP foreign listener on the UDP-target 8189 IS a conflict.
+        let exec = RecordingExecutor::new().with_stdout(
+            "media-ports",
+            "udp UNCONN 0 0 0.0.0.0:8189 0.0.0.0:* users:((\"coturn\",pid=42,fd=8))\n",
+        );
+        let check = mediamtx_ports_available(&exec, &MediaMtxHostConfig::default());
+        assert!(!check.passed, "detail: {}", check.detail);
+        assert!(check.detail.contains("8189"), "detail: {}", check.detail);
+    }
+
+    #[test]
+    fn ports_available_fails_closed_when_mediamtx_owns_ports_but_unit_inactive() {
+        // Finding J: the ports are held by a `mediamtx` process, but OUR configured
+        // unit is NOT active (manual run / differently-named service / crashed).
+        // Starting our unit would launch a second instance over them → fail-closed.
+        let exec = RecordingExecutor::new()
+            .with_stdout(
+                "media-ports",
+                "tcp LISTEN 0 128 0.0.0.0:9997 0.0.0.0:* users:((\"mediamtx\",pid=10,fd=3))\n\
+                 tcp LISTEN 0 128 0.0.0.0:8888 0.0.0.0:* users:((\"mediamtx\",pid=10,fd=5))\n",
+            )
+            // `systemctl is-active --quiet` exits non-zero → transport error →
+            // read as NOT active.
+            .failing("media-unit-active");
+        let check = mediamtx_ports_available(&exec, &MediaMtxHostConfig::default());
+        assert!(!check.passed, "detail: {}", check.detail);
+        assert!(check.detail.contains("8888"), "detail: {}", check.detail);
+        assert!(
+            check.detail.contains("not active"),
+            "detail: {}",
+            check.detail
+        );
+        // The is-active gate ran exactly once, after the single ss scan.
+        assert_eq!(exec.labels(), vec!["media-ports", "media-unit-active"]);
+    }
+
+    #[test]
+    fn ports_available_does_not_query_is_active_when_no_mediamtx_port_held() {
+        // Finding J: the is-active gate runs at most once, and only when a
+        // MediaMTX-owned port is actually found. A foreign-only conflict (or a
+        // free host) never queries it.
+        let exec = RecordingExecutor::new().with_stdout(
+            "media-ports",
+            "tcp LISTEN 0 128 0.0.0.0:8888 0.0.0.0:* users:((\"nginx\",pid=99,fd=6))\n",
+        );
+        let check = mediamtx_ports_available(&exec, &MediaMtxHostConfig::default());
+        assert!(!check.passed);
+        assert_eq!(exec.labels(), vec!["media-ports"]);
     }
 
     #[test]


### PR DESCRIPTION
Part of #1974 (autumn-media plugin extraction — slice 7, deploy controller / host provisioning).

## Before / After (plain language)

**Before:** `autumn deploy` could stand up the app and its reverse proxy (kamal-proxy) on a bare host, but the streaming substrate autumn-media needs — the MediaMTX daemon (RTMP/WHIP ingest, HLS/WebRTC/WHEP playback, recording, control API) — had to be installed and configured by hand. There was no `mediamtx.yml` template, no systemd unit, and no host preflight, so a misconfigured media host only surfaced later as failed ingest/playback.

**After:** when a project opts in with `[media.mediamtx] enabled = true`, `autumn deploy` provisions MediaMTX as a host systemd unit — writing a generalized `mediamtx.yml` and the unit, then `daemon-reload && enable --now && restart` — exactly the way it already provisions kamal-proxy. Before touching the host it runs three fail-closed host checks (FFmpeg resolves, recordings dir writable, MediaMTX ports free) and aborts the deploy if the host can't serve media. `autumn deploy plan` shows the media unit, the provisioning steps, and the CSP origins the app must allow. A project that doesn't use autumn-media is byte-for-byte unaffected (disabled by default).

## How

- New module `autumn-cli/src/deploy/media.rs`, patterned exactly on `KamalProxyController` (same `DeployOp` emission, `DeployExecutor` usage, pure systemd-unit rendering).
  - `MediaMtxHostConfig` (serde, all-defaults, disabled by default) deserialized from a new `[media.mediamtx]` section read straight from the raw `autumn.toml` string — mirroring how `autumn-media-plugin` reads `[media]`, so there is **no dependency on autumn-media-plugin** and **no change to autumn-web's `AutumnConfig`**.
  - MediaMTX ports are real `u16` constants (RTMP 1935, HLS 8888, WebRTC/WHEP 8889, playback 9996, control API 9997, WebRTC local UDP 8189), not parsed from URLs.
  - `render_mediamtx_yml` generalizes arroyo's `mediamtx.yml` (LL-HLS window `lowLatency`/`200ms`/`2s`/`60`, fmp4 recording under `recordings_dir`, `recordDeleteAfter`, WebRTC + `webrtcAdditionalHosts`) and adds a `~^room/.+$` path matcher for autumn-media Rooms alongside the arroyo-style `~^live/.+$`.
  - `render_mediamtx_unit` renders the systemd unit (`ExecStart = <binary> <config>`, `Restart=always`).
  - `MediaMtxController::ensure_installed_ops` emits the ordered write-config / write-unit / install ops (no-op when disabled).
  - Three fail-closed doctor checks over the injectable executor: `media_ffmpeg_preflight`, `media_recordings_dir_writable`, `media_mediamtx_ports_available`.
  - `required_csp_origins` + module rustdoc document the host-provisioning story and the `connect-src`/`media-src`/`frame-src` requirement.
- Wired into `autumn-cli/src/deploy.rs`: `deploy up` runs the doctor checks (fail-closed host-prep, aborting before the app cutover) then provisions the unit; `deploy plan` surfaces the media section. Gated on `enabled` (default false).

## Tests

Inline `#[cfg(test)]` in `media.rs` (25 tests, recording-executor fake): config defaults/`[media.mediamtx]` parsing, `mediamtx.yml` rendering (every port, `~^room/.+$` matcher, LL-HLS/recording/webrtc config, custom ports/dirs/hosts), unit rendering, controller op sequence + disabled no-op, and each doctor check pass/fail (ffmpeg banner present/absent/missing, dir writable/not, ports free/occupied/unverifiable), plus CSP origins.

## Deliberate deferrals

- The MediaMTX binary download/version-pin stays a host-bootstrap prerequisite (identical to how autumn handles the kamal-proxy binary).
- The `[media.mediamtx]` config template lives in **autumn-cli** (the deploy controller), **not** in `autumn-media-plugin` — deliberately, to avoid adding an autumn-cli → plugin dependency (and the sqlite backend-flip that would pull in).
- The three doctor checks run in the executor-holding `deploy up`/`plan` paths. Wiring them into the offline `autumn doctor` CLI (which has no ssh executor) is left to a follow-up; the checks are complete, fail-closed, and unit-tested.

## Verification (local)

`cargo fmt --all -- --check`, `cargo clippy -p autumn-cli --all-targets -- -D warnings`, `cargo test -p autumn-cli` (4241 + consolidated suites, incl. 25 new media tests), and `cargo test -p autumn-media-plugin` (206) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECvwdPayxkoyJtprW8LkYJ)_