### PR TITLE
ci: fix kamal-proxy version probe in deploy-real-vps bootstrap

### DIFF
--- a/.github/workflows/deploy-real-vps.yml
+++ b/.github/workflows/deploy-real-vps.yml
@@ -36,9 +36,9 @@ on:
         type: string
         default: "nbg1"
       kamal_proxy_version:
-        description: "kamal-proxy image tag to install during host bootstrap"
+        description: "kamal-proxy image tag to install during host bootstrap (pin a released tag, not latest)"
         type: string
-        default: "latest"
+        default: "v0.9.2"
   schedule:
     # 04:17 UTC nightly — off-peak, jittered minute to avoid the top-of-hour herd.
     - cron: "17 4 * * *"
@@ -206,7 +206,7 @@ jobs:
         env:
           AUTUMN_BIN: ${{ github.workspace }}/target/release/autumn
           SSH_PORT: "22"
-          KAMAL_PROXY_VERSION: ${{ inputs.kamal_proxy_version || 'latest' }}
+          KAMAL_PROXY_VERSION: ${{ inputs.kamal_proxy_version || 'v0.9.2' }}
         run: |
           chmod +x scripts/deploy-real-vps-validate.sh
           ./scripts/deploy-real-vps-validate.sh

--- a/scripts/deploy-real-vps-validate.sh
+++ b/scripts/deploy-real-vps-validate.sh
@@ -44,7 +44,12 @@ SSH_PORT="${SSH_PORT:-22}"
 PUBLIC_PORT="${PUBLIC_PORT:-80}"
 APP_NAME="${APP_NAME:-rvpsapp}"
 : "${SIGNING_SECRET:?SIGNING_SECRET is required}"
-KAMAL_PROXY_VERSION="${KAMAL_PROXY_VERSION:-latest}"
+# Pin to a specific released tag, not `latest`: the CLI surface drifts across
+# releases (e.g. v0.9.2 dropped the `version` subcommand), so a mutable `latest`
+# makes this a non-deterministic test. Production does NOT pin kamal-proxy (it
+# defers binary provisioning to host bootstrap), so this pin is the test's own
+# reproducibility choice — bump it deliberately when validating a newer proxy.
+KAMAL_PROXY_VERSION="${KAMAL_PROXY_VERSION:-v0.9.2}"
 ONBOARD_BUDGET_SECS="${ONBOARD_BUDGET_SECS:-900}"
 
 BASE_URL="http://${TARGET_HOST}:${PUBLIC_PORT}"
@@ -127,7 +132,13 @@ stop_prober() { touch "${WORK}/prober.stop"; wait "$1" 2>/dev/null || true; rm -
 # no-op exit 0. Compiled fully static so it runs on the stock VM regardless of
 # its glibc.
 compile_app() { # <version> <out>
-  local version="$1" out="$2" src="${WORK}/app_${version}.rs"
+  # NOTE: keep these as separate `local` statements. A single
+  # `local version="$1" ... src="...${version}..."` expands ${version} (a later
+  # word) BEFORE `local` binds it (an earlier word in the same statement), so
+  # under `set -u` it aborts with `version: unbound variable`.
+  local version="$1"
+  local out="$2"
+  local src="${WORK}/app_${version}.rs"
   cat > "${src}" <<RUST
 use std::io::{Read, Write};
 use std::net::TcpListener;
@@ -205,7 +216,9 @@ rssh 'set -e; export DEBIAN_FRONTEND=noninteractive; apt-get update -qq;
       docker cp "$cid:/usr/local/bin/kamal-proxy" /usr/local/bin/kamal-proxy;
       docker rm -f "$cid" >/dev/null;
       chmod 755 /usr/local/bin/kamal-proxy;
-      /usr/local/bin/kamal-proxy version || true' \
+      /usr/local/bin/kamal-proxy --help >/dev/null 2>&1 \
+        && echo "kamal-proxy binary present and runnable" \
+        || echo "kamal-proxy --help probe failed (non-fatal informational check)"' \
   || fail "host bootstrap failed"
 # pam_systemd is deliberately LEFT ENABLED (unlike the container fixture) so the
 # ssh sessions the deploy opens get XDG_RUNTIME_DIR=/run/user/0 — the real-host


### PR DESCRIPTION
## Before / After

**Before:** the real-VPS validation script pinned `basecamp/kamal-proxy:latest` and its host-bootstrap smoke-check probed `kamal-proxy version`. Newer `latest` (now **v0.9.2**) **dropped the `version` subcommand** (`Error: unknown command &#34;version&#34; for &#34;kamal-proxy&#34;`). That probe is `|| true`-guarded so it was only misleading stderr noise — but the run then reached the `compile_app` helper, whose line

```sh
local version=&#34;$1&#34; out=&#34;$2&#34; src=&#34;${WORK}/app_${version}.rs&#34;
```

aborts under `set -euo pipefail`: bash expands `${version}` (a later word in the statement) **before** `local` binds `version` (an earlier word), so `set -u` fires `line 130: version: unbound variable` → exit 1, before any deploy assertion. Round-4 was the first run to get past provisioning + bootstrap into `compile_app`, so this latent bug surfaced then. (Provisioning succeeded — `cpx22`@`nbg1`, VM up — and cleanup deleted the VM + ssh-key with no leak.)

**After:**
- Pins kamal-proxy to **`v0.9.2`** (script default + workflow input default + `||` fallback) so the CLI surface is deterministic instead of tracking a mutable `latest`.
- Replaces the removed `version` probe with a **`kamal-proxy --help`** smoke check (cobra built-in, present on v0.9.2 which exposes only `run/deploy/remove/pause/stop/resume/list/rollout` — no `version`, no `--version`), kept non-fatal/informational.
- Fixes `compile_app` by splitting the single `local` into separate statements so `${version}` is bound before it is used — no longer crashes under `set -u`.

## How

Three edits to `scripts/deploy-real-vps-validate.sh` (tag default, `--help` probe, `compile_app` local split) + two matching edits to `.github/workflows/deploy-real-vps.yml` (input default `latest`→`v0.9.2` and the `inputs.kamal_proxy_version || &#39;…&#39;` fallback, so the workflow no longer forces `latest` back over the script&#39;s pin). `bash -n` clean; `compile_app` pattern and the non-fatal probe verified under `set -euo pipefail`.

## Production note

`autumn-cli` production deploy code **does not pin** kamal-proxy and **never calls `kamal-proxy version`**. `autumn-cli/src/deploy/proxy.rs:37-38` explicitly defers &#34;the exact `kamal-proxy` binary provisioning (**download/version pin**) … to host bootstrap&#34;, assuming the binary on `/usr/local/bin`; the only CLI verbs production uses are `run`, `deploy`, and `list` (`proxy.rs` / `exec.rs`). So the exact `version`-subcommand drift that broke this test does **not** break real deploys. It is, however, the same class of risk worth flagging on the deploy epic: production consumes an **unpinned** kamal-proxy binary, so a future `latest` that changes `run`/`deploy`/`list` flags could break real cutovers with no guardrail. This PR pins only the **test** for reproducibility; pinning/recommending a kamal-proxy version for production bootstrap is a separate call for the epic owner.

Part of #2019.