### PR TITLE
Part of #1996: durable commit-hook worker on the SQLite backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,7 +308,8 @@ jobs:
             --test sqlite_statement_timeout_fail_closed \
             --test sqlite_crud_basic \
             --test sqlite_upsert_isolation \
-            --test sqlite_dependent_destroy
+            --test sqlite_dependent_destroy \
+            --test sqlite_commit_hook_worker
 
   # Genuine loom model checks: the loom_models test binary uses loom::sync::*
   # unconditionally, so loom::model() exhaustively explores thread interleavings

--- a/autumn/Cargo.toml
+++ b/autumn/Cargo.toml
@@ -493,6 +493,22 @@ path = "tests/sqlite_upsert_isolation.rs"
 name = "sqlite_version_history"
 path = "tests/sqlite_version_history.rs"
 
+# SQLite durable commit-hook worker end-to-end proof (issue #1996 item 5). Drives
+# the ported worker (BEGIN IMMEDIATE claim + in-process Notify kick + retry/backoff
+# + dead-letter + graceful drain) and the real enqueue surface against an in-memory
+# SQLite pool: a queued hook survives a simulated restart and is delivered exactly
+# once (idempotency dedup), transient failures retry then succeed, a permanent
+# failure is dead-lettered after max_attempts, a graceful shutdown settles the
+# in-flight leased entry, and — the adversarial assertion — a hook enqueued under
+# tenant A executes with tenant A's scope and never touches tenant B's data while
+# tenant B has its own queued hook, and a hook with no tenant fails closed. Only
+# meaningful under `--features sqlite`; the file is `#![cfg(feature = "sqlite")]`
+# so a default `cargo test` compiles it to an empty (passing) binary. Run:
+# `cargo test -p autumn-web --features "sqlite,test-support" --test sqlite_commit_hook_worker`.
+[[test]]
+name = "sqlite_commit_hook_worker"
+path = "tests/sqlite_commit_hook_worker.rs"
+
 # SQLite searchable-repository fallback proof (issue #1996). Drives
 # `#[repository(searchable)]` against an in-memory SQLite pool: substring matches
 # are found case-insensitively, non-matches excluded, LIKE metacharacters (`%`,

--- a/autumn/repository_commit_hook_migrations_sqlite/20260515000000_create_repository_commit_hook_queue/down.sql
+++ b/autumn/repository_commit_hook_migrations_sqlite/20260515000000_create_repository_commit_hook_queue/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS autumn_repository_commit_hooks;

--- a/autumn/repository_commit_hook_migrations_sqlite/20260515000000_create_repository_commit_hook_queue/up.sql
+++ b/autumn/repository_commit_hook_migrations_sqlite/20260515000000_create_repository_commit_hook_queue/up.sql
@@ -1,0 +1,58 @@
+-- Durable repository commit-hook queue table, SQLite variant (#1996 item 5).
+--
+-- Backend-forked from the Postgres migration in
+-- `repository_commit_hook_migrations/`. The version dir name is kept identical
+-- so `__diesel_schema_migrations` bookkeeping and the framework migration set
+-- do not diverge across backends. Differences from the Postgres DDL:
+--   * `context`/`record` are `TEXT` — SQLite has no `JSONB` type; the durable
+--     worker round-trips the same JSON string it does on Postgres (only the
+--     storage type differs), so tenant/scope/actor context is byte-identical;
+--   * every `TIMESTAMPTZ` becomes `TEXT` — SQLite has no timestamp type. The
+--     worker binds explicit UTC `YYYY-MM-DD HH:MM:SS[.fff]` strings for
+--     comparable, lexicographically-orderable timestamps, so `CURRENT_TIMESTAMP`
+--     (a UTC `YYYY-MM-DD HH:MM:SS` string) is only a fallback default;
+--   * `NOW()` is not a SQLite function, so defaults use `CURRENT_TIMESTAMP`.
+-- The partial indexes are preserved verbatim — SQLite supports partial indexes
+-- (>= 3.8.0), and they gate the same claim / stale-recovery access paths.
+
+CREATE TABLE IF NOT EXISTS autumn_repository_commit_hooks (
+    id                  TEXT    PRIMARY KEY,
+    handler_key         TEXT    NOT NULL,
+    hook_name           TEXT    NOT NULL,
+    context             TEXT    NOT NULL DEFAULT '{}',
+    record              TEXT    NOT NULL DEFAULT '{}',
+    status              TEXT    NOT NULL DEFAULT 'enqueued',
+    attempt             INTEGER NOT NULL DEFAULT 1,
+    max_attempts        INTEGER NOT NULL DEFAULT 5,
+    initial_backoff_ms  BIGINT  NOT NULL DEFAULT 1000,
+    enqueued_at         TEXT    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    started_at          TEXT,
+    finished_at         TEXT,
+    claimed_by          TEXT,
+    claimed_at          TEXT,
+    last_error          TEXT,
+    run_at              TEXT    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Workers claim ready rows under a BEGIN IMMEDIATE write lock (SQLite is
+-- single-writer, so there is no FOR UPDATE SKIP LOCKED).
+CREATE INDEX IF NOT EXISTS idx_autumn_repository_commit_hooks_ready
+    ON autumn_repository_commit_hooks (run_at ASC, enqueued_at ASC)
+    WHERE status = 'enqueued';
+
+-- Dispatchers only claim hooks whose generated runner is registered locally.
+CREATE INDEX IF NOT EXISTS idx_autumn_repository_commit_hooks_handler_ready
+    ON autumn_repository_commit_hooks (handler_key, run_at ASC)
+    WHERE status = 'enqueued';
+
+-- Stale-claim recovery lets the worker retry work abandoned by a dead process.
+CREATE INDEX IF NOT EXISTS idx_autumn_repository_commit_hooks_stale_recovery
+    ON autumn_repository_commit_hooks (claimed_at)
+    WHERE status = 'running';
+
+-- Staged create/update hooks are leased by the request until regular after hooks finish.
+-- `after_hook_succeeded` rows have durably persisted finalized after-hook payloads and may be
+-- recovered to `enqueued`; ambiguous `pending_after_hook` rows must fail closed instead.
+CREATE INDEX IF NOT EXISTS idx_autumn_repository_commit_hooks_pending_recovery
+    ON autumn_repository_commit_hooks (claimed_at)
+    WHERE status IN ('pending_after_hook', 'after_hook_succeeded');

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -3711,6 +3711,30 @@ impl AppBuilder {
                 );
             }
         }
+        // SQLite durable commit-hook worker (#1996 item 5): the runtime pool is a
+        // single-node SQLite pool the Postgres queue worker cannot drive, so the
+        // SQLite worker (BEGIN IMMEDIATE claim + in-process Notify kick + poll
+        // fallback) is spawned instead — same `role.runs_workers()` gate and same
+        // `server_shutdown.child_token()` graceful-drain wiring as the Postgres tier.
+        #[cfg(all(feature = "db", feature = "sqlite"))]
+        if role.runs_workers()
+            && let Some(pool) = state.pool().cloned()
+        {
+            #[cfg(feature = "ws")]
+            {
+                let channels = state.channels().clone();
+                crate::repository_commit_hooks::start_repository_commit_hook_worker(
+                    pool,
+                    Some(channels),
+                    server_shutdown.child_token(),
+                );
+            }
+            #[cfg(not(feature = "ws"))]
+            crate::repository_commit_hooks::start_repository_commit_hook_worker(
+                pool,
+                server_shutdown.child_token(),
+            );
+        }
 
         #[cfg(feature = "presence")]
         {
@@ -5290,6 +5314,25 @@ impl AppBuilder {
                     task_shutdown.child_token(),
                 );
             }
+        }
+        // SQLite durable commit-hook worker on the one-off task-runner path
+        // (#1996 item 5); see the server-path spawn above for the rationale.
+        #[cfg(all(feature = "db", feature = "sqlite"))]
+        if let Some(pool) = state.pool().cloned() {
+            #[cfg(feature = "ws")]
+            {
+                let channels = state.channels().clone();
+                crate::repository_commit_hooks::start_repository_commit_hook_worker(
+                    pool,
+                    Some(channels),
+                    task_shutdown.child_token(),
+                );
+            }
+            #[cfg(not(feature = "ws"))]
+            crate::repository_commit_hooks::start_repository_commit_hook_worker(
+                pool,
+                task_shutdown.child_token(),
+            );
         }
 
         if let Err(error) = run_startup_hooks(&startup_hooks, state.clone()).await {

--- a/autumn/src/repository_commit_hooks.rs
+++ b/autumn/src/repository_commit_hooks.rs
@@ -19,44 +19,116 @@ use diesel::OptionalExtension as _;
 use diesel_async::RunQueryDsl as _;
 use diesel_async::pooled_connection::deadpool::Pool;
 use futures::FutureExt as _;
+// `scope_boxed` boxes the `SQLite` claim's transaction closure future for
+// `scoped_immediate_transaction`.
+#[cfg(feature = "sqlite")]
+use scoped_futures::ScopedFutureExt as _;
 use serde::Serialize;
 use serde_json::Value;
 use sha2::Digest as _;
-// `Notify` backs the Postgres kick-worker, `cfg`-gated off under `sqlite`.
-#[cfg(not(feature = "sqlite"))]
+// `Notify` backs the Postgres kick-worker's coalesced pending flag, and (under
+// `sqlite`) the single-node poll-loop wake used in place of Postgres LISTEN/NOTIFY.
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
 use crate::{AutumnError, AutumnResult};
 
+// The Postgres worker is typed on `PgPool`; the shared enqueue/finalize surface
+// and the `SQLite` worker are typed on the runtime pool alias `RtPool` (on
+// Postgres the two are the SAME type, since `RuntimeConnection = AsyncPgConnection`).
+#[cfg(not(feature = "sqlite"))]
 type PgPool = Pool<diesel_async::AsyncPgConnection>;
+type RtPool = Pool<crate::db::RuntimeConnection>;
 type HookFuture = Pin<Box<dyn Future<Output = AutumnResult<()>> + Send + 'static>>;
 type HookRunner = Arc<dyn Fn(Value, Value) -> HookFuture + Send + Sync + 'static>;
 
+/// Reserved key under which the `SQLite` durable worker embeds the originating
+/// tenant into the persisted `context` JSON, so a claimed hook re-establishes
+/// the SAME tenant scope it was enqueued under before executing. `MutationContext`
+/// does not carry a tenant field, so tenant isolation for durable hooks would
+/// otherwise be lost across the process boundary. The key is stripped before the
+/// context is handed to the generated runner (which deserializes `MutationContext`).
+#[cfg(feature = "sqlite")]
+const TENANT_CONTEXT_KEY: &str = "__autumn_tenant";
+
+/// Framework migration set for the durable commit-hook queue table.
+///
+/// Backend-forked (#1996 item 5): the Postgres DDL (`JSONB`/`TIMESTAMPTZ`/
+/// `DEFAULT NOW()`) is not valid `SQLite`, so the `SQLite` build embeds a parallel
+/// set (`TEXT` JSON / `TEXT` timestamps / `DEFAULT CURRENT_TIMESTAMP`) under the
+/// same `20260515000000_create_repository_commit_hook_queue` version dir name,
+/// keeping `__diesel_schema_migrations` bookkeeping identical across backends.
+#[cfg(not(feature = "sqlite"))]
 pub const REPOSITORY_COMMIT_HOOK_MIGRATIONS: diesel_migrations::EmbeddedMigrations =
     diesel_migrations::embed_migrations!("repository_commit_hook_migrations");
 
-const HOOK_SELECT_COLS: &str = "id, handler_key, hook_name, context::TEXT AS context, \
-    record::TEXT AS record, status, attempt, max_attempts, initial_backoff_ms";
+/// `SQLite` variant of [`REPOSITORY_COMMIT_HOOK_MIGRATIONS`]. See that item for
+/// the backend-fork rationale.
+#[cfg(feature = "sqlite")]
+pub const REPOSITORY_COMMIT_HOOK_MIGRATIONS: diesel_migrations::EmbeddedMigrations =
+    diesel_migrations::embed_migrations!("repository_commit_hook_migrations_sqlite");
+
 const HOOK_WORKER_IDLE_SLEEP: Duration = Duration::from_millis(250);
 const HOOK_STALE_CLAIM_AFTER: Duration = Duration::from_secs(60);
 const HOOK_CLAIM_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
 const HOOK_PENDING_FINALIZER_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
 const HOOK_AFTER_HOOK_FAILURE_MARK_RETRY_SLEEP: Duration = Duration::from_millis(100);
 const HOOK_AFTER_HOOK_FAILURE_MARK_MAX_ATTEMPTS: usize = 3;
+
+// ── Backend-forked SQL (#1996 item 5) ────────────────────────────────────────
+//
+// Only one backend's arm is ever compiled. The Postgres SQL is byte-identical to
+// the original (numbered `$n` placeholders, `NOW()`, `::JSONB` casts). The `SQLite`
+// SQL uses `?` positional placeholders (bound in the SAME order as the Postgres
+// binds so a single shared function body serves both), `CURRENT_TIMESTAMP` in
+// place of `NOW()`, no `::JSONB` casts (the columns are already `TEXT`), and
+// lowercase `excluded` in the upsert. Structurally-divergent statements (claim,
+// nack retry/dead-letter, stale recovery, and bulk enqueue) are forked at the
+// function level instead — see `*_claim_next` / `*_nack_*` / `*_recover_stale*`.
+
+#[cfg(not(feature = "sqlite"))]
+const HOOK_SELECT_COLS: &str = "id, handler_key, hook_name, context::TEXT AS context, \
+    record::TEXT AS record, status, attempt, max_attempts, initial_backoff_ms";
+#[cfg(feature = "sqlite")]
+const HOOK_SELECT_COLS: &str = "id, handler_key, hook_name, context, \
+    record, status, attempt, max_attempts, initial_backoff_ms";
+
+#[cfg(not(feature = "sqlite"))]
 const HOOK_ACK_SUCCESS_SQL: &str = "UPDATE autumn_repository_commit_hooks \
      SET status = 'completed', finished_at = NOW(), \
          context = '{}'::JSONB, record = '{}'::JSONB, \
          claimed_by = NULL, claimed_at = NULL, last_error = NULL \
      WHERE id = $1 AND claimed_by = $2 AND status = 'running'";
+#[cfg(feature = "sqlite")]
+const HOOK_ACK_SUCCESS_SQL: &str = "UPDATE autumn_repository_commit_hooks \
+     SET status = 'completed', finished_at = CURRENT_TIMESTAMP, \
+         context = '{}', record = '{}', \
+         claimed_by = NULL, claimed_at = NULL, last_error = NULL \
+     WHERE id = ? AND claimed_by = ? AND status = 'running'";
+
+#[cfg(not(feature = "sqlite"))]
 const HOOK_EXTEND_CLAIM_SQL: &str = "UPDATE autumn_repository_commit_hooks \
      SET claimed_at = NOW() \
      WHERE id = $1 AND claimed_by = $2 AND status = 'running'";
+#[cfg(feature = "sqlite")]
+const HOOK_EXTEND_CLAIM_SQL: &str = "UPDATE autumn_repository_commit_hooks \
+     SET claimed_at = CURRENT_TIMESTAMP \
+     WHERE id = ? AND claimed_by = ? AND status = 'running'";
+
+#[cfg(not(feature = "sqlite"))]
 const HOOK_ENQUEUE_INSERT_SQL: &str = "INSERT INTO autumn_repository_commit_hooks \
      (id, handler_key, hook_name, context, record, status, attempt, \
       max_attempts, initial_backoff_ms, enqueued_at, run_at) \
      VALUES ($1, $2, $3, $4::JSONB, $5::JSONB, 'enqueued', 1, 5, 1000, NOW(), NOW()) \
      ON CONFLICT (id) DO NOTHING";
+#[cfg(feature = "sqlite")]
+const HOOK_ENQUEUE_INSERT_SQL: &str = "INSERT INTO autumn_repository_commit_hooks \
+     (id, handler_key, hook_name, context, record, status, attempt, \
+      max_attempts, initial_backoff_ms, enqueued_at, run_at) \
+     VALUES (?, ?, ?, ?, ?, 'enqueued', 1, 5, 1000, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP) \
+     ON CONFLICT (id) DO NOTHING";
+
+#[cfg(not(feature = "sqlite"))]
 const HOOK_PENDING_INSERT_SQL: &str = "INSERT INTO autumn_repository_commit_hooks \
      (id, handler_key, hook_name, context, record, status, attempt, \
        max_attempts, initial_backoff_ms, enqueued_at, run_at, claimed_by, claimed_at) \
@@ -71,26 +143,78 @@ const HOOK_PENDING_INSERT_SQL: &str = "INSERT INTO autumn_repository_commit_hook
           claimed_by = EXCLUDED.claimed_by, claimed_at = EXCLUDED.claimed_at, \
           started_at = NULL, finished_at = NULL, last_error = NULL \
       WHERE autumn_repository_commit_hooks.status IN ('pending_after_hook', 'after_hook_failed')";
+#[cfg(feature = "sqlite")]
+const HOOK_PENDING_INSERT_SQL: &str = "INSERT INTO autumn_repository_commit_hooks \
+     (id, handler_key, hook_name, context, record, status, attempt, \
+       max_attempts, initial_backoff_ms, enqueued_at, run_at, claimed_by, claimed_at) \
+     VALUES (?, ?, ?, ?, ?, 'pending_after_hook', 1, 5, 1000, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, ?, CURRENT_TIMESTAMP) \
+     ON CONFLICT (id) DO UPDATE \
+      SET handler_key = excluded.handler_key, hook_name = excluded.hook_name, \
+          context = excluded.context, record = excluded.record, \
+          status = 'pending_after_hook', attempt = 1, \
+          max_attempts = excluded.max_attempts, \
+          initial_backoff_ms = excluded.initial_backoff_ms, \
+          enqueued_at = excluded.enqueued_at, run_at = excluded.run_at, \
+          claimed_by = excluded.claimed_by, claimed_at = excluded.claimed_at, \
+          started_at = NULL, finished_at = NULL, last_error = NULL \
+      WHERE autumn_repository_commit_hooks.status IN ('pending_after_hook', 'after_hook_failed')";
+
+#[cfg(not(feature = "sqlite"))]
 const HOOK_MARK_AFTER_HOOK_SUCCEEDED_SQL: &str = "UPDATE autumn_repository_commit_hooks \
      SET context = $1::JSONB, record = $2::JSONB, status = 'after_hook_succeeded', \
           claimed_at = NOW(), last_error = NULL \
      WHERE id = $3 AND claimed_by = $4 AND status = 'pending_after_hook'";
+#[cfg(feature = "sqlite")]
+const HOOK_MARK_AFTER_HOOK_SUCCEEDED_SQL: &str = "UPDATE autumn_repository_commit_hooks \
+     SET context = ?, record = ?, status = 'after_hook_succeeded', \
+          claimed_at = CURRENT_TIMESTAMP, last_error = NULL \
+     WHERE id = ? AND claimed_by = ? AND status = 'pending_after_hook'";
+
+#[cfg(not(feature = "sqlite"))]
 const HOOK_FINALIZE_AFTER_HOOK_SQL: &str = "UPDATE autumn_repository_commit_hooks \
      SET status = 'enqueued', run_at = NOW(), \
           enqueued_at = COALESCE(enqueued_at, NOW()), \
           claimed_by = NULL, claimed_at = NULL, last_error = NULL \
       WHERE id = $1 AND claimed_by = $2 AND status = 'after_hook_succeeded'";
+#[cfg(feature = "sqlite")]
+const HOOK_FINALIZE_AFTER_HOOK_SQL: &str = "UPDATE autumn_repository_commit_hooks \
+     SET status = 'enqueued', run_at = CURRENT_TIMESTAMP, \
+          enqueued_at = COALESCE(enqueued_at, CURRENT_TIMESTAMP), \
+          claimed_by = NULL, claimed_at = NULL, last_error = NULL \
+      WHERE id = ? AND claimed_by = ? AND status = 'after_hook_succeeded'";
+
+#[cfg(not(feature = "sqlite"))]
 const HOOK_DISCARD_PENDING_SQL: &str = "DELETE FROM autumn_repository_commit_hooks \
      WHERE id = $1 AND claimed_by = $2 AND status = 'pending_after_hook'";
+#[cfg(feature = "sqlite")]
+const HOOK_DISCARD_PENDING_SQL: &str = "DELETE FROM autumn_repository_commit_hooks \
+     WHERE id = ? AND claimed_by = ? AND status = 'pending_after_hook'";
+
+#[cfg(not(feature = "sqlite"))]
 const HOOK_AFTER_HOOK_FAILED_SQL: &str = "UPDATE autumn_repository_commit_hooks \
      SET status = 'after_hook_failed', \
          finished_at = NOW(), \
          context = '{}'::JSONB, record = '{}'::JSONB, \
          claimed_by = NULL, claimed_at = NULL, last_error = $1 \
       WHERE id = $2 AND claimed_by = $3 AND status = 'pending_after_hook'";
+#[cfg(feature = "sqlite")]
+const HOOK_AFTER_HOOK_FAILED_SQL: &str = "UPDATE autumn_repository_commit_hooks \
+     SET status = 'after_hook_failed', \
+         finished_at = CURRENT_TIMESTAMP, \
+         context = '{}', record = '{}', \
+         claimed_by = NULL, claimed_at = NULL, last_error = ? \
+      WHERE id = ? AND claimed_by = ? AND status = 'pending_after_hook'";
+
+#[cfg(not(feature = "sqlite"))]
 const HOOK_EXTEND_PENDING_FINALIZER_SQL: &str = "UPDATE autumn_repository_commit_hooks \
      SET claimed_at = NOW() \
      WHERE id = $1 AND claimed_by = $2 AND status = 'pending_after_hook'";
+#[cfg(feature = "sqlite")]
+const HOOK_EXTEND_PENDING_FINALIZER_SQL: &str = "UPDATE autumn_repository_commit_hooks \
+     SET claimed_at = CURRENT_TIMESTAMP \
+     WHERE id = ? AND claimed_by = ? AND status = 'pending_after_hook'";
+
+#[cfg(not(feature = "sqlite"))]
 const HOOK_RECOVER_STALE_RUNNING_SQL: &str = "UPDATE autumn_repository_commit_hooks \
      SET status = CASE \
            WHEN attempt < max_attempts THEN 'enqueued' \
@@ -114,6 +238,7 @@ const HOOK_RECOVER_STALE_RUNNING_SQL: &str = "UPDATE autumn_repository_commit_ho
          last_error = $1 \
      WHERE status = 'running' \
        AND claimed_at < NOW() - ($2::BIGINT * INTERVAL '1 millisecond')";
+#[cfg(not(feature = "sqlite"))]
 const HOOK_RECOVER_STALE_PENDING_SQL: &str = "UPDATE autumn_repository_commit_hooks \
      SET status = CASE \
             WHEN status = 'after_hook_succeeded' THEN 'enqueued' \
@@ -145,6 +270,67 @@ const HOOK_RECOVER_STALE_PENDING_SQL: &str = "UPDATE autumn_repository_commit_ho
           last_error = COALESCE(last_error, $1) \
       WHERE status IN ('pending_after_hook', 'after_hook_succeeded') \
         AND claimed_at < NOW() - ($2::BIGINT * INTERVAL '1 millisecond')";
+
+// `SQLite` stale recovery: identical branch semantics, but the `NOW() - INTERVAL`
+// arithmetic is replaced by a Rust-computed cutoff bound (bound SECOND, matching
+// its textual position after the `last_error` message) — `WHERE claimed_at < ?`
+// compares against a UTC `YYYY-MM-DD HH:MM:SS.fff` string. Binds: (last_error, cutoff).
+#[cfg(feature = "sqlite")]
+const HOOK_RECOVER_STALE_RUNNING_SQL: &str = "UPDATE autumn_repository_commit_hooks \
+     SET status = CASE \
+           WHEN attempt < max_attempts THEN 'enqueued' \
+           ELSE 'failed' \
+         END, \
+         attempt = CASE \
+           WHEN attempt < max_attempts THEN attempt + 1 \
+           ELSE attempt \
+         END, \
+         run_at = CASE \
+           WHEN attempt < max_attempts THEN CURRENT_TIMESTAMP \
+           ELSE run_at \
+         END, \
+         started_at = NULL, \
+         finished_at = CASE \
+           WHEN attempt >= max_attempts THEN CURRENT_TIMESTAMP \
+           ELSE NULL \
+         END, \
+         claimed_by = NULL, \
+         claimed_at = NULL, \
+         last_error = ? \
+     WHERE status = 'running' \
+       AND claimed_at < ?";
+#[cfg(feature = "sqlite")]
+const HOOK_RECOVER_STALE_PENDING_SQL: &str = "UPDATE autumn_repository_commit_hooks \
+     SET status = CASE \
+            WHEN status = 'after_hook_succeeded' THEN 'enqueued' \
+            ELSE 'after_hook_failed' \
+          END, \
+          run_at = CASE \
+            WHEN status = 'after_hook_succeeded' THEN CURRENT_TIMESTAMP \
+            ELSE run_at \
+          END, \
+          enqueued_at = CASE \
+            WHEN status = 'after_hook_succeeded' THEN COALESCE(enqueued_at, CURRENT_TIMESTAMP) \
+            ELSE enqueued_at \
+          END, \
+          context = CASE \
+            WHEN status = 'pending_after_hook' THEN '{}' \
+            ELSE context \
+          END, \
+          record = CASE \
+            WHEN status = 'pending_after_hook' THEN '{}' \
+            ELSE record \
+          END, \
+          finished_at = CASE \
+            WHEN status = 'pending_after_hook' THEN CURRENT_TIMESTAMP \
+            ELSE finished_at \
+          END, \
+          started_at = NULL, \
+          claimed_by = NULL, \
+          claimed_at = NULL, \
+          last_error = COALESCE(last_error, ?) \
+      WHERE status IN ('pending_after_hook', 'after_hook_succeeded') \
+        AND claimed_at < ?";
 
 static REPOSITORY_COMMIT_HOOK_RUNNERS: OnceLock<
     RwLock<HashMap<String, RepositoryCommitHookRegistration>>,
@@ -183,6 +369,34 @@ impl RepositoryCommitHookKickState {
     fn take_pending_kick(&self) -> bool {
         self.pending.swap(false, Ordering::AcqRel)
     }
+}
+
+// `SQLite` is single-node and single-writer, so it needs no LISTEN/NOTIFY: an
+// in-process `Notify` per pool wakes that pool's poll loop the moment a mutation
+// commits. A missed kick is harmless — the loop also wakes on its idle sleep and
+// drains, so durability never depends on the kick landing.
+#[cfg(feature = "sqlite")]
+static SQLITE_HOOK_KICKERS: OnceLock<RwLock<HashMap<usize, Arc<Notify>>>> = OnceLock::new();
+
+#[cfg(feature = "sqlite")]
+fn sqlite_repository_commit_hook_kick(pool: &RtPool) -> Arc<Notify> {
+    let key = std::ptr::from_ref(pool.manager()).addr();
+    let registry = SQLITE_HOOK_KICKERS.get_or_init(|| RwLock::new(HashMap::new()));
+    {
+        let registry = registry
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(notify) = registry.get(&key) {
+            return notify.clone();
+        }
+    }
+    let mut registry = registry
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    registry
+        .entry(key)
+        .or_insert_with(|| Arc::new(Notify::new()))
+        .clone()
 }
 
 #[doc(hidden)]
@@ -240,7 +454,7 @@ impl RepositoryCommitHookRegistration {
 
 #[derive(diesel::QueryableByName, Debug, Clone)]
 #[allow(dead_code)]
-struct PgRepositoryCommitHookRow {
+struct RepositoryCommitHookRow {
     #[diesel(sql_type = diesel::sql_types::Text)]
     id: String,
     #[diesel(sql_type = diesel::sql_types::Text)]
@@ -319,7 +533,7 @@ pub fn has_repository_commit_hook_descriptors() -> bool {
 /// Returns an error when the context or record cannot be serialized, or when
 /// Postgres rejects the enqueue insert.
 pub async fn enqueue_repository_commit_hook_on_conn<C, R>(
-    conn: &mut diesel_async::AsyncPgConnection,
+    conn: &mut crate::db::RuntimeConnection,
     handler_key: &str,
     hook_name: &str,
     idempotency_key: Option<&str>,
@@ -367,7 +581,7 @@ where
 /// Returns an error when the context or record cannot be serialized, or when
 /// Postgres rejects the staged insert.
 pub async fn enqueue_repository_commit_hook_pending_on_conn<C, R>(
-    conn: &mut diesel_async::AsyncPgConnection,
+    conn: &mut crate::db::RuntimeConnection,
     handler_key: &str,
     hook_name: &str,
     idempotency_key: Option<&str>,
@@ -413,7 +627,7 @@ where
 /// Returns an error when any context or record cannot be serialized, or when
 /// Postgres rejects the staged insert.
 pub async fn enqueue_repository_commit_hooks_pending_bulk_on_conn<C, R>(
-    conn: &mut diesel_async::AsyncPgConnection,
+    conn: &mut crate::db::RuntimeConnection,
     handler_key: &str,
     hook_name: &str,
     inputs: &[(Option<String>, Option<String>, &C, &R)],
@@ -422,6 +636,12 @@ where
     C: Serialize + Sync + ?Sized,
     R: Serialize + Sync + ?Sized,
 {
+    // Postgres stages every row in one `UNNEST`-driven statement. `SQLite` has no
+    // array binds, so its arm loops the single-row staged insert on the SAME
+    // caller connection (already inside the mutation transaction, so the rows
+    // still commit atomically with the domain write). Both dedupe/restage
+    // identically via `ON CONFLICT (id) DO UPDATE`.
+    #[cfg(not(feature = "sqlite"))]
     const SQL: &str = "INSERT INTO autumn_repository_commit_hooks \
          (id, handler_key, hook_name, context, record, status, attempt, \
           max_attempts, initial_backoff_ms, enqueued_at, run_at, claimed_by, claimed_at) \
@@ -474,21 +694,44 @@ where
         results.push((id, owner.clone()));
     }
 
-    diesel::sql_query(SQL)
-        .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(ids)
-        .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(handler_keys)
-        .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(hook_names)
-        .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(contexts)
-        .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(records)
-        .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(owners)
-        .execute(conn)
-        .await
-        .map(|_| results)
-        .map_err(|error| {
-            AutumnError::internal_server_error_msg(format!(
-                "repository commit hook bulk staging failed: {error}"
-            ))
-        })
+    crate::backend_select! {
+        pg => {{
+            diesel::sql_query(SQL)
+                .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(ids)
+                .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(handler_keys)
+                .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(hook_names)
+                .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(contexts)
+                .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(records)
+                .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(owners)
+                .execute(conn)
+                .await
+                .map(|_| results)
+                .map_err(|error| {
+                    AutumnError::internal_server_error_msg(format!(
+                        "repository commit hook bulk staging failed: {error}"
+                    ))
+                })
+        }},
+        sqlite => {{
+            for index in 0..ids.len() {
+                diesel::sql_query(HOOK_PENDING_INSERT_SQL)
+                    .bind::<diesel::sql_types::Text, _>(ids[index].clone())
+                    .bind::<diesel::sql_types::Text, _>(handler_keys[index].clone())
+                    .bind::<diesel::sql_types::Text, _>(hook_names[index].clone())
+                    .bind::<diesel::sql_types::Text, _>(contexts[index].clone())
+                    .bind::<diesel::sql_types::Text, _>(records[index].clone())
+                    .bind::<diesel::sql_types::Text, _>(owners[index].clone())
+                    .execute(&mut *conn)
+                    .await
+                    .map_err(|error| {
+                        AutumnError::internal_server_error_msg(format!(
+                            "repository commit hook bulk staging failed: {error}"
+                        ))
+                    })?;
+            }
+            Ok(results)
+        }},
+    }
 }
 
 /// Insert multiple generated repository commit hook rows directly in an enqueued state in a single query.
@@ -498,7 +741,7 @@ where
 /// Returns an error when any context or record cannot be serialized, or when
 /// Postgres rejects the staged insert.
 pub async fn enqueue_repository_commit_hooks_bulk_on_conn<C, R>(
-    conn: &mut diesel_async::AsyncPgConnection,
+    conn: &mut crate::db::RuntimeConnection,
     handler_key: &str,
     hook_name: &str,
     inputs: &[(Option<String>, Option<String>, &C, &R)],
@@ -507,6 +750,9 @@ where
     C: Serialize + Sync + ?Sized,
     R: Serialize + Sync + ?Sized,
 {
+    // See `enqueue_repository_commit_hooks_pending_bulk_on_conn` for the pg/sqlite
+    // fork rationale (UNNEST batch vs. per-row loop on the same txn connection).
+    #[cfg(not(feature = "sqlite"))]
     const SQL: &str = "INSERT INTO autumn_repository_commit_hooks \
          (id, handler_key, hook_name, context, record, status, attempt, \
           max_attempts, initial_backoff_ms, enqueued_at, run_at) \
@@ -544,20 +790,42 @@ where
         records.push(record_str);
     }
 
-    diesel::sql_query(SQL)
-        .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(ids)
-        .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(handler_keys)
-        .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(hook_names)
-        .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(contexts)
-        .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(records)
-        .execute(conn)
-        .await
-        .map(|_| ())
-        .map_err(|error| {
-            AutumnError::internal_server_error_msg(format!(
-                "repository commit hook bulk enqueue failed: {error}"
-            ))
-        })
+    crate::backend_select! {
+        pg => {{
+            diesel::sql_query(SQL)
+                .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(ids)
+                .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(handler_keys)
+                .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(hook_names)
+                .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(contexts)
+                .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(records)
+                .execute(conn)
+                .await
+                .map(|_| ())
+                .map_err(|error| {
+                    AutumnError::internal_server_error_msg(format!(
+                        "repository commit hook bulk enqueue failed: {error}"
+                    ))
+                })
+        }},
+        sqlite => {{
+            for index in 0..ids.len() {
+                diesel::sql_query(HOOK_ENQUEUE_INSERT_SQL)
+                    .bind::<diesel::sql_types::Text, _>(ids[index].clone())
+                    .bind::<diesel::sql_types::Text, _>(handler_keys[index].clone())
+                    .bind::<diesel::sql_types::Text, _>(hook_names[index].clone())
+                    .bind::<diesel::sql_types::Text, _>(contexts[index].clone())
+                    .bind::<diesel::sql_types::Text, _>(records[index].clone())
+                    .execute(&mut *conn)
+                    .await
+                    .map_err(|error| {
+                        AutumnError::internal_server_error_msg(format!(
+                            "repository commit hook bulk enqueue failed: {error}"
+                        ))
+                    })?;
+            }
+            Ok(())
+        }},
+    }
 }
 
 /// Promote a staged create/update commit hook after the regular after hook
@@ -568,7 +836,7 @@ where
 /// Returns an error when serialization fails, the database cannot be reached,
 /// or the staged row is no longer present.
 pub async fn finalize_repository_commit_hook_after_hook<C, R>(
-    pool: &PgPool,
+    pool: &RtPool,
     hook_id: &str,
     owner: &str,
     context: &C,
@@ -634,7 +902,7 @@ fn missing_repository_commit_hook_finalization_result(hook_id: &str) -> AutumnRe
 ///
 /// Returns an error when the database cannot be reached or rejects the delete.
 pub async fn discard_repository_commit_hook_pending(
-    pool: &PgPool,
+    pool: &RtPool,
     hook_id: &str,
     owner: &str,
 ) -> AutumnResult<()> {
@@ -661,14 +929,15 @@ pub async fn discard_repository_commit_hook_pending(
 /// This retries transient pool or database failures a bounded number of times
 /// so callers can return the original hook error without hanging forever.
 pub async fn mark_repository_commit_hook_after_hook_failed(
-    pool: &PgPool,
+    pool: &RtPool,
     hook_id: &str,
     owner: &str,
     failure: impl Into<String>,
 ) {
     let failure = failure.into();
     for attempt in 1..=HOOK_AFTER_HOOK_FAILURE_MARK_MAX_ATTEMPTS {
-        match pg_mark_repository_commit_hook_after_hook_failed(pool, hook_id, owner, &failure).await
+        match mark_repository_commit_hook_after_hook_failed_once(pool, hook_id, owner, &failure)
+            .await
         {
             Ok(true) => return,
             Ok(false) => {
@@ -701,8 +970,8 @@ pub async fn mark_repository_commit_hook_after_hook_failed(
     }
 }
 
-async fn pg_mark_repository_commit_hook_after_hook_failed(
-    pool: &PgPool,
+async fn mark_repository_commit_hook_after_hook_failed_once(
+    pool: &RtPool,
     hook_id: &str,
     owner: &str,
     failure: &str,
@@ -743,7 +1012,7 @@ where
 
 #[doc(hidden)]
 pub fn start_repository_commit_hook_pending_finalizer_heartbeat(
-    pool: PgPool,
+    pool: RtPool,
     hook_id: String,
     owner: String,
 ) -> RepositoryCommitHookPendingHeartbeat {
@@ -776,11 +1045,99 @@ where
             "serialize repository commit hook record: {error}"
         ))
     })?;
+    let context = embed_originating_tenant_in_context(context)?;
 
     Ok((context, record))
 }
 
-#[cfg(feature = "ws")]
+/// Postgres identity: the persisted `context` is byte-identical to the serialized
+/// `MutationContext`, so the Postgres worker's behaviour is unchanged. The
+/// fallible signature (and lint allowances) mirror the `SQLite` arm, which can
+/// genuinely fail while re-serializing the tenant-embedded context.
+#[cfg(not(feature = "sqlite"))]
+#[inline]
+#[allow(clippy::unnecessary_wraps, clippy::missing_const_for_fn)]
+fn embed_originating_tenant_in_context(context: String) -> AutumnResult<String> {
+    Ok(context)
+}
+
+/// `SQLite`: capture the ambient `CURRENT_TENANT` at enqueue/finalize time (both run
+/// inside the request's tenant scope) and embed it into the persisted `context`
+/// JSON under [`TENANT_CONTEXT_KEY`], so the durable worker can re-establish the
+/// SAME tenant before executing the hook. `MutationContext` carries no tenant
+/// field, so without this a `tenant_scoped` repository touched by a durable hook
+/// would lose its scope across the process boundary. A hook enqueued with no
+/// ambient tenant embeds nothing (the worker then runs it with the tenant UNSET,
+/// so a `tenant_scoped` repo fails closed rather than touching a default scope).
+#[cfg(feature = "sqlite")]
+fn embed_originating_tenant_in_context(context: String) -> AutumnResult<String> {
+    let tenant = crate::tenancy::CURRENT_TENANT
+        .try_with(std::clone::Clone::clone)
+        .ok()
+        .flatten();
+    // Fail closed: only embed a genuinely non-blank tenant. A blank or
+    // whitespace-only ambient tenant is never persisted, so the worker runs the
+    // hook with `CURRENT_TENANT` UNSET and a `tenant_scoped` repo fails closed
+    // rather than resolving to `tenant_id = ''` (or whitespace).
+    let tenant = tenant.filter(|value| !value.trim().is_empty());
+    let Some(tenant) = tenant else {
+        return Ok(context);
+    };
+
+    let mut value: Value = serde_json::from_str(&context).map_err(|error| {
+        AutumnError::internal_server_error_msg(format!(
+            "embed tenant into repository commit hook context: {error}"
+        ))
+    })?;
+    if let Value::Object(map) = &mut value {
+        map.insert(TENANT_CONTEXT_KEY.to_owned(), Value::String(tenant));
+    }
+    serde_json::to_string(&value).map_err(|error| {
+        AutumnError::internal_server_error_msg(format!(
+            "reserialize repository commit hook context with tenant: {error}"
+        ))
+    })
+}
+
+/// `SQLite`: pull the originating tenant back out of the persisted `context` JSON
+/// (and strip the reserved key so the generated runner still deserializes a clean
+/// `MutationContext`). Returns the parsed context [`Value`] and the tenant to
+/// re-establish (`None` when the hook was enqueued outside any tenant scope).
+#[cfg(feature = "sqlite")]
+fn extract_originating_tenant_from_context(context: &str) -> (Value, Option<String>) {
+    // A context that does not parse is handled downstream when the runner
+    // re-parses it; surface it untouched with no tenant so the hook still runs
+    // (and fails closed if it touches a tenant_scoped repo).
+    serde_json::from_str::<Value>(context).map_or((Value::Null, None), |mut value| {
+        let tenant = match &mut value {
+            Value::Object(map) => map
+                .remove(TENANT_CONTEXT_KEY)
+                .and_then(|value| match value {
+                    // Fail closed: a blank or whitespace-only persisted tenant is
+                    // NOT an established tenant. Normalize it to `None` so the drain
+                    // loop leaves `CURRENT_TENANT` UNSET rather than scoping a
+                    // `tenant_scoped` repo to `tenant_id = ''` (or whitespace).
+                    // A non-blank tenant is preserved verbatim (never trimmed).
+                    Value::String(tenant) if tenant.trim().is_empty() => None,
+                    Value::String(tenant) => Some(tenant),
+                    _ => None,
+                }),
+            _ => None,
+        };
+        (value, tenant)
+    })
+}
+
+/// `SQLite`: a UTC `YYYY-MM-DD HH:MM:SS.fff` timestamp string. Ordered
+/// lexicographically it compares correctly against `CURRENT_TIMESTAMP` defaults
+/// (which share the leading second-precision prefix), and the fractional part
+/// gives the worker sub-second retry/lease resolution.
+#[cfg(feature = "sqlite")]
+fn sqlite_timestamp(instant: chrono::DateTime<chrono::Utc>) -> String {
+    instant.format("%Y-%m-%d %H:%M:%S%.3f").to_string()
+}
+
+#[cfg(all(feature = "ws", not(feature = "sqlite")))]
 pub fn start_repository_commit_hook_worker(
     pool: PgPool,
     channels: Option<crate::channels::Channels>,
@@ -826,7 +1183,7 @@ pub fn start_repository_commit_hook_worker(
     });
 }
 
-#[cfg(not(feature = "ws"))]
+#[cfg(all(not(feature = "ws"), not(feature = "sqlite")))]
 pub fn start_repository_commit_hook_worker(pool: PgPool, shutdown: CancellationToken) {
     register_inventory_repository_commit_hook_runners();
     if !should_start_repository_commit_hook_worker(&registered_handler_keys()) {
@@ -847,6 +1204,80 @@ pub fn start_repository_commit_hook_worker(pool: PgPool, shutdown: CancellationT
     });
 }
 
+// ── `SQLite` durable worker (#1996 item 5) ─────────────────────────────────────
+//
+// Single-node, single-writer: no `LISTEN/NOTIFY`, no `FOR UPDATE SKIP LOCKED`.
+// The worker polls on the idle sleep AND wakes immediately on an in-process
+// `Notify` kick, then claims one ready row at a time under a `BEGIN IMMEDIATE`
+// write lock (`sqlite_claim_next_repository_commit_hook`). Graceful shutdown is
+// the same `tokio::select!` on the child `CancellationToken` the Postgres worker
+// uses: the loop finishes the in-flight `drain` iteration (claim → run →
+// ack/nack) it is on and settles it before observing `cancelled()` on the next
+// pass, so no leased row is abandoned mid-flight.
+#[cfg(all(feature = "ws", feature = "sqlite"))]
+pub fn start_repository_commit_hook_worker(
+    pool: RtPool,
+    channels: Option<crate::channels::Channels>,
+    shutdown: CancellationToken,
+) {
+    register_inventory_repository_commit_hook_runners();
+    if !should_start_repository_commit_hook_worker(&registered_handler_keys()) {
+        return;
+    }
+
+    let worker_id = repository_commit_hook_worker_id();
+    let kick = sqlite_repository_commit_hook_kick(&pool);
+    tokio::spawn(async move {
+        if let Some(ch) = channels {
+            CURRENT_CHANNELS
+                .scope(
+                    ch,
+                    sqlite_repository_commit_hook_worker_loop(pool, worker_id, kick, shutdown),
+                )
+                .await;
+        } else {
+            sqlite_repository_commit_hook_worker_loop(pool, worker_id, kick, shutdown).await;
+        }
+    });
+}
+
+#[cfg(all(not(feature = "ws"), feature = "sqlite"))]
+pub fn start_repository_commit_hook_worker(pool: RtPool, shutdown: CancellationToken) {
+    register_inventory_repository_commit_hook_runners();
+    if !should_start_repository_commit_hook_worker(&registered_handler_keys()) {
+        return;
+    }
+
+    let worker_id = repository_commit_hook_worker_id();
+    let kick = sqlite_repository_commit_hook_kick(&pool);
+    tokio::spawn(sqlite_repository_commit_hook_worker_loop(
+        pool, worker_id, kick, shutdown,
+    ));
+}
+
+#[cfg(feature = "sqlite")]
+async fn sqlite_repository_commit_hook_worker_loop(
+    pool: RtPool,
+    worker_id: String,
+    kick: Arc<Notify>,
+    shutdown: CancellationToken,
+) {
+    loop {
+        tokio::select! {
+            biased;
+            () = shutdown.cancelled() => break,
+            () = kick.notified() => {
+                recover_stale_repository_commit_hooks(&pool, &worker_id).await;
+                sqlite_drain_ready_repository_commit_hooks(&pool, &worker_id, 32).await;
+            }
+            () = tokio::time::sleep(HOOK_WORKER_IDLE_SLEEP) => {
+                recover_stale_repository_commit_hooks(&pool, &worker_id).await;
+                sqlite_drain_ready_repository_commit_hooks(&pool, &worker_id, 32).await;
+            }
+        }
+    }
+}
+
 /// Nudge dispatch after a mutation commits, without relying on this replica for
 /// durability. Polling workers on all replicas can still claim the row later.
 #[cfg(not(feature = "sqlite"))]
@@ -862,17 +1293,21 @@ pub fn kick_repository_commit_hook_dispatcher(pool: &PgPool) {
     }
 }
 
-/// `SQLite` no-op variant of the commit-hook dispatcher kick.
+/// `SQLite` variant of the commit-hook dispatcher kick (#1996 item 5).
 ///
-/// The durable dispatcher is a Postgres queue worker (`LISTEN/NOTIFY` +
-/// `FOR UPDATE SKIP LOCKED` row claiming + `unnest`/`Array` bulk binds) that is
-/// never spawned under the `sqlite` feature (see the cfg-gated worker start in
-/// `app.rs`). Generated `#[repository]` CRUD still emits the kick call — over the
-/// runtime pool, which is a `SQLite` pool here — so this signature accepts a
-/// `Pool<RuntimeConnection>` and does nothing. Threading the real Postgres worker
-/// onto `SQLite` is a later wave (issue #1996).
+/// `SQLite` has no `LISTEN/NOTIFY`, but it is single-node, so an in-process
+/// `Notify` wakes this pool's poll loop the instant a mutation commits. A missed
+/// kick is harmless: the loop also wakes on its idle sleep and drains, so
+/// durability never depends on the kick landing.
 #[cfg(feature = "sqlite")]
-pub const fn kick_repository_commit_hook_dispatcher(_pool: &Pool<crate::db::RuntimeConnection>) {}
+pub fn kick_repository_commit_hook_dispatcher(pool: &RtPool) {
+    register_inventory_repository_commit_hook_runners();
+    if !should_start_repository_commit_hook_worker(&registered_handler_keys()) {
+        return;
+    }
+
+    sqlite_repository_commit_hook_kick(pool).notify_one();
+}
 
 #[cfg(not(feature = "sqlite"))]
 fn repository_commit_hook_kick_state(pool: &PgPool) -> Arc<RepositoryCommitHookKickState> {
@@ -941,6 +1376,7 @@ fn spawn_repository_commit_hook_kick_worker(
     });
 }
 
+#[cfg(not(feature = "sqlite"))]
 async fn drain_ready_repository_commit_hooks(pool: &PgPool, worker_id: &str, max_rows: usize) {
     for _ in 0..max_rows {
         let Some(row) = pg_claim_next_repository_commit_hook(pool, worker_id).await else {
@@ -959,7 +1395,7 @@ async fn drain_ready_repository_commit_hooks(pool: &PgPool, worker_id: &str, max
         match result {
             Ok(()) => {
                 if let Err(error) =
-                    pg_ack_repository_commit_hook_success(pool, &row.id, worker_id).await
+                    ack_repository_commit_hook_success(pool, &row.id, worker_id).await
                 {
                     tracing::warn!(
                         hook_id = %row.id,
@@ -1001,9 +1437,20 @@ async fn drain_ready_repository_commit_hooks(pool: &PgPool, worker_id: &str, max
     }
 }
 
-async fn run_repository_commit_hook_row(row: &PgRepositoryCommitHookRow) -> Result<(), String> {
+#[cfg(not(feature = "sqlite"))]
+async fn run_repository_commit_hook_row(row: &RepositoryCommitHookRow) -> Result<(), String> {
     let context = serde_json::from_str::<Value>(&row.context)
         .map_err(|error| format!("decode repository hook context: {error}"))?;
+    run_repository_commit_hook_row_value(row, context).await
+}
+
+/// Run a claimed hook with an already-parsed `context` [`Value`]. The `SQLite`
+/// worker parses (and strips the tenant key from) the context before calling this;
+/// the Postgres worker parses it in `run_repository_commit_hook_row`.
+async fn run_repository_commit_hook_row_value(
+    row: &RepositoryCommitHookRow,
+    context: Value,
+) -> Result<(), String> {
     let record = serde_json::from_str::<Value>(&row.record)
         .map_err(|error| format!("decode repository hook record: {error}"))?;
     let result = std::panic::AssertUnwindSafe(run_registered_repository_commit_hook(
@@ -1048,7 +1495,7 @@ async fn run_registered_repository_commit_hook(
 }
 
 async fn heartbeat_repository_commit_hook_claim(
-    pool: PgPool,
+    pool: RtPool,
     hook_id: String,
     worker_id: String,
     shutdown: CancellationToken,
@@ -1057,7 +1504,7 @@ async fn heartbeat_repository_commit_hook_claim(
         tokio::select! {
             () = shutdown.cancelled() => break,
             () = tokio::time::sleep(HOOK_CLAIM_HEARTBEAT_INTERVAL) => {
-                match pg_extend_repository_commit_hook_claim(&pool, &hook_id, &worker_id).await {
+                match extend_repository_commit_hook_claim(&pool, &hook_id, &worker_id).await {
                     Ok(true) => {}
                     Ok(false) => break,
                     Err(error) => {
@@ -1074,7 +1521,7 @@ async fn heartbeat_repository_commit_hook_claim(
 }
 
 async fn heartbeat_repository_commit_hook_pending_finalizer(
-    pool: PgPool,
+    pool: RtPool,
     hook_id: String,
     owner: String,
     shutdown: CancellationToken,
@@ -1083,7 +1530,7 @@ async fn heartbeat_repository_commit_hook_pending_finalizer(
         tokio::select! {
             () = shutdown.cancelled() => break,
             () = tokio::time::sleep(HOOK_PENDING_FINALIZER_HEARTBEAT_INTERVAL) => {
-                match pg_extend_repository_commit_hook_pending_finalizer(&pool, &hook_id, &owner).await {
+                match extend_repository_commit_hook_pending_finalizer(&pool, &hook_id, &owner).await {
                     Ok(true) => {}
                     Ok(false) => break,
                     Err(error) => {
@@ -1113,10 +1560,11 @@ const fn should_start_repository_commit_hook_worker(handler_keys: &[String]) -> 
     !handler_keys.is_empty()
 }
 
+#[cfg(not(feature = "sqlite"))]
 async fn pg_claim_next_repository_commit_hook(
     pool: &PgPool,
     worker_id: &str,
-) -> Option<PgRepositoryCommitHookRow> {
+) -> Option<RepositoryCommitHookRow> {
     let handler_keys = registered_handler_keys();
     if handler_keys.is_empty() {
         return None;
@@ -1141,7 +1589,7 @@ async fn pg_claim_next_repository_commit_hook(
     diesel::sql_query(sql)
         .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(handler_keys)
         .bind::<diesel::sql_types::Text, _>(worker_id)
-        .get_result::<PgRepositoryCommitHookRow>(&mut *conn)
+        .get_result::<RepositoryCommitHookRow>(&mut *conn)
         .await
         .optional()
         .unwrap_or_else(|error| {
@@ -1157,13 +1605,13 @@ async fn pg_claim_next_repository_commit_hook(
         })
 }
 
-async fn pg_ack_repository_commit_hook_success(
-    pool: &PgPool,
+async fn ack_repository_commit_hook_success(
+    pool: &RtPool,
     hook_id: &str,
     worker_id: &str,
 ) -> AutumnResult<bool> {
     let mut conn = pool.get().await.map_err(|error| {
-        AutumnError::internal_server_error_msg(format!("pg pool error: {error}"))
+        AutumnError::internal_server_error_msg(format!("commit hook pool error: {error}"))
     })?;
 
     diesel::sql_query(HOOK_ACK_SUCCESS_SQL)
@@ -1179,13 +1627,13 @@ async fn pg_ack_repository_commit_hook_success(
         })
 }
 
-async fn pg_extend_repository_commit_hook_claim(
-    pool: &PgPool,
+async fn extend_repository_commit_hook_claim(
+    pool: &RtPool,
     hook_id: &str,
     worker_id: &str,
 ) -> AutumnResult<bool> {
     let mut conn = pool.get().await.map_err(|error| {
-        AutumnError::internal_server_error_msg(format!("pg pool error: {error}"))
+        AutumnError::internal_server_error_msg(format!("commit hook pool error: {error}"))
     })?;
 
     diesel::sql_query(HOOK_EXTEND_CLAIM_SQL)
@@ -1201,13 +1649,13 @@ async fn pg_extend_repository_commit_hook_claim(
         })
 }
 
-async fn pg_extend_repository_commit_hook_pending_finalizer(
-    pool: &PgPool,
+async fn extend_repository_commit_hook_pending_finalizer(
+    pool: &RtPool,
     hook_id: &str,
     owner: &str,
 ) -> AutumnResult<bool> {
     let mut conn = pool.get().await.map_err(|error| {
-        AutumnError::internal_server_error_msg(format!("pg pool error: {error}"))
+        AutumnError::internal_server_error_msg(format!("commit hook pool error: {error}"))
     })?;
 
     diesel::sql_query(HOOK_EXTEND_PENDING_FINALIZER_SQL)
@@ -1223,12 +1671,13 @@ async fn pg_extend_repository_commit_hook_pending_finalizer(
         })
 }
 
+#[cfg(not(feature = "sqlite"))]
 async fn pg_nack_repository_commit_hook_failure(
     pool: &PgPool,
     hook_id: &str,
     worker_id: &str,
     error: &str,
-    row: &PgRepositoryCommitHookRow,
+    row: &RepositoryCommitHookRow,
 ) -> AutumnResult<bool> {
     let mut conn = pool.get().await.map_err(|error| {
         AutumnError::internal_server_error_msg(format!("pg pool error: {error}"))
@@ -1284,18 +1733,34 @@ async fn pg_nack_repository_commit_hook_failure(
     }
 }
 
-async fn recover_stale_repository_commit_hooks(pool: &PgPool, worker_id: &str) {
-    let stale_after_ms = i64::try_from(HOOK_STALE_CLAIM_AFTER.as_millis()).unwrap_or(i64::MAX);
+async fn recover_stale_repository_commit_hooks(pool: &RtPool, worker_id: &str) {
     let Ok(mut conn) = pool.get().await else {
         return;
     };
 
-    if let Err(error) = diesel::sql_query(HOOK_RECOVER_STALE_RUNNING_SQL)
-        .bind::<diesel::sql_types::Text, _>(format!("stale claim recovered by {worker_id}"))
-        .bind::<diesel::sql_types::BigInt, _>(stale_after_ms)
-        .execute(&mut *conn)
-        .await
-    {
+    // Postgres computes the stale cutoff inline (`NOW() - INTERVAL`); `SQLite` has
+    // no interval arithmetic, so the cutoff is computed here and bound as a
+    // comparable UTC timestamp string. Same recovery semantics on both.
+    let running_result = crate::backend_select! {
+        pg => {{
+            let stale_after_ms =
+                i64::try_from(HOOK_STALE_CLAIM_AFTER.as_millis()).unwrap_or(i64::MAX);
+            diesel::sql_query(HOOK_RECOVER_STALE_RUNNING_SQL)
+                .bind::<diesel::sql_types::Text, _>(format!("stale claim recovered by {worker_id}"))
+                .bind::<diesel::sql_types::BigInt, _>(stale_after_ms)
+                .execute(&mut *conn)
+                .await
+        }},
+        sqlite => {{
+            let cutoff = sqlite_timestamp(sqlite_stale_claim_cutoff());
+            diesel::sql_query(HOOK_RECOVER_STALE_RUNNING_SQL)
+                .bind::<diesel::sql_types::Text, _>(format!("stale claim recovered by {worker_id}"))
+                .bind::<diesel::sql_types::Text, _>(cutoff)
+                .execute(&mut *conn)
+                .await
+        }},
+    };
+    if let Err(error) = running_result {
         if is_missing_hook_table_error(&error) {
             tracing::debug!(
                 error = %error,
@@ -1306,14 +1771,30 @@ async fn recover_stale_repository_commit_hooks(pool: &PgPool, worker_id: &str) {
         }
     }
 
-    if let Err(error) = diesel::sql_query(HOOK_RECOVER_STALE_PENDING_SQL)
-        .bind::<diesel::sql_types::Text, _>(format!(
-            "stale pending after hook recovered by {worker_id}"
-        ))
-        .bind::<diesel::sql_types::BigInt, _>(stale_after_ms)
-        .execute(&mut *conn)
-        .await
-    {
+    let pending_result = crate::backend_select! {
+        pg => {{
+            let stale_after_ms =
+                i64::try_from(HOOK_STALE_CLAIM_AFTER.as_millis()).unwrap_or(i64::MAX);
+            diesel::sql_query(HOOK_RECOVER_STALE_PENDING_SQL)
+                .bind::<diesel::sql_types::Text, _>(format!(
+                    "stale pending after hook recovered by {worker_id}"
+                ))
+                .bind::<diesel::sql_types::BigInt, _>(stale_after_ms)
+                .execute(&mut *conn)
+                .await
+        }},
+        sqlite => {{
+            let cutoff = sqlite_timestamp(sqlite_stale_claim_cutoff());
+            diesel::sql_query(HOOK_RECOVER_STALE_PENDING_SQL)
+                .bind::<diesel::sql_types::Text, _>(format!(
+                    "stale pending after hook recovered by {worker_id}"
+                ))
+                .bind::<diesel::sql_types::Text, _>(cutoff)
+                .execute(&mut *conn)
+                .await
+        }},
+    };
+    if let Err(error) = pending_result {
         if is_missing_hook_table_error(&error) {
             tracing::debug!(
                 error = %error,
@@ -1328,10 +1809,266 @@ async fn recover_stale_repository_commit_hooks(pool: &PgPool, worker_id: &str) {
     }
 }
 
+/// `SQLite`: the UTC instant before which a still-`running` (or leased-pending)
+/// claim is considered abandoned by a dead worker.
+#[cfg(feature = "sqlite")]
+fn sqlite_stale_claim_cutoff() -> chrono::DateTime<chrono::Utc> {
+    let stale_after = chrono::Duration::from_std(HOOK_STALE_CLAIM_AFTER)
+        .unwrap_or_else(|_| chrono::Duration::seconds(60));
+    chrono::Utc::now() - stale_after
+}
+
+// ── `SQLite` claim / drain / nack (#1996 item 5) ───────────────────────────────
+
+/// Claim the next ready hook row under a `BEGIN IMMEDIATE` write lock. `SQLite` is
+/// single-writer, so instead of `FOR UPDATE SKIP LOCKED` the worker takes the
+/// write lock up front, `SELECT`s the oldest ready+registered row, flips it to
+/// `running`, and returns it — no other writer can interleave between the select
+/// and the update.
+#[cfg(feature = "sqlite")]
+async fn sqlite_claim_next_repository_commit_hook(
+    pool: &RtPool,
+    worker_id: &str,
+) -> Option<RepositoryCommitHookRow> {
+    let handler_keys = registered_handler_keys();
+    if handler_keys.is_empty() {
+        return None;
+    }
+
+    let mut conn = pool.get().await.ok()?;
+    let now = sqlite_timestamp(chrono::Utc::now());
+    // The registered handler keys are internal Rust type-path strings (no
+    // user input); inline them as an escaped `IN (...)` literal list so the raw
+    // `sql_query` needs a fixed bind arity (`run_at <= ?` only). Single quotes
+    // are still doubled defensively.
+    let handler_in_list = handler_keys
+        .iter()
+        .map(|key| format!("'{}'", key.replace('\'', "''")))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let select_sql = format!(
+        "SELECT {HOOK_SELECT_COLS} FROM autumn_repository_commit_hooks \
+         WHERE status = 'enqueued' \
+           AND run_at <= ? \
+           AND handler_key IN ({handler_in_list}) \
+         ORDER BY run_at ASC, enqueued_at ASC \
+         LIMIT 1"
+    );
+    let worker_id = worker_id.to_owned();
+
+    let claim = crate::db::scoped_immediate_transaction::<
+        Option<RepositoryCommitHookRow>,
+        diesel::result::Error,
+        _,
+    >(&mut conn, move |conn| {
+        async move {
+            let Some(row) = diesel::sql_query(select_sql)
+                .bind::<diesel::sql_types::Text, _>(now.clone())
+                .get_result::<RepositoryCommitHookRow>(&mut *conn)
+                .await
+                .optional()?
+            else {
+                return Ok(None);
+            };
+
+            diesel::sql_query(
+                "UPDATE autumn_repository_commit_hooks \
+                 SET status = 'running', started_at = ?, claimed_by = ?, claimed_at = ? \
+                 WHERE id = ? AND status = 'enqueued'",
+            )
+            .bind::<diesel::sql_types::Text, _>(now.clone())
+            .bind::<diesel::sql_types::Text, _>(worker_id)
+            .bind::<diesel::sql_types::Text, _>(now)
+            .bind::<diesel::sql_types::Text, _>(row.id.clone())
+            .execute(&mut *conn)
+            .await?;
+
+            Ok(Some(row))
+        }
+        .scope_boxed()
+    })
+    .await;
+
+    match claim {
+        Ok(row) => row,
+        Err(error) => {
+            if is_missing_hook_table_error(&error) {
+                tracing::debug!(
+                    error = %error,
+                    "repository commit hook queue table is not available yet"
+                );
+            } else {
+                tracing::warn!(error = %error, "repository commit hook claim query failed");
+            }
+            None
+        }
+    }
+}
+
+/// `SQLite` drain loop: claim → lease heartbeat → run (under the originating tenant
+/// scope) → ack/nack, one row at a time. Mirrors the Postgres
+/// `drain_ready_repository_commit_hooks` shape.
+#[cfg(feature = "sqlite")]
+async fn sqlite_drain_ready_repository_commit_hooks(
+    pool: &RtPool,
+    worker_id: &str,
+    max_rows: usize,
+) {
+    for _ in 0..max_rows {
+        let Some(row) = sqlite_claim_next_repository_commit_hook(pool, worker_id).await else {
+            break;
+        };
+
+        let heartbeat_shutdown = CancellationToken::new();
+        let heartbeat_task = tokio::spawn(heartbeat_repository_commit_hook_claim(
+            pool.clone(),
+            row.id.clone(),
+            worker_id.to_owned(),
+            heartbeat_shutdown.child_token(),
+        ));
+
+        // Tenant isolation (INVIOLABLE): re-establish the SAME tenant the hook was
+        // enqueued under before running it, so a `tenant_scoped` repository the
+        // hook touches resolves to the originating tenant — never another tenant,
+        // and never a default/global scope. A hook enqueued with no tenant runs
+        // with `CURRENT_TENANT` UNSET, so such a repo fails closed.
+        let (context_value, tenant) = extract_originating_tenant_from_context(&row.context);
+        let result = match tenant {
+            Some(tenant) => {
+                crate::tenancy::CURRENT_TENANT
+                    .scope(
+                        Some(tenant),
+                        run_repository_commit_hook_row_value(&row, context_value),
+                    )
+                    .await
+            }
+            None => run_repository_commit_hook_row_value(&row, context_value).await,
+        };
+
+        match result {
+            Ok(()) => {
+                if let Err(error) =
+                    ack_repository_commit_hook_success(pool, &row.id, worker_id).await
+                {
+                    tracing::warn!(
+                        hook_id = %row.id,
+                        error = %error,
+                        "failed to ack repository commit hook success"
+                    );
+                }
+            }
+            Err(error) => {
+                let failures_total = crate::db::record_after_commit_failure();
+                tracing::error!(
+                    hook_id = %row.id,
+                    handler_key = %row.handler_key,
+                    hook_name = %row.hook_name,
+                    autumn.after_commit.failures_total = failures_total,
+                    "repository after_commit hook failed: {error}"
+                );
+                if let Err(nack_error) = sqlite_nack_repository_commit_hook_failure(
+                    pool, &row.id, worker_id, &error, &row,
+                )
+                .await
+                {
+                    tracing::warn!(
+                        hook_id = %row.id,
+                        error = %nack_error,
+                        "failed to record repository commit hook failure"
+                    );
+                }
+            }
+        }
+
+        heartbeat_shutdown.cancel();
+        if let Err(error) = heartbeat_task.await {
+            tracing::warn!(
+                hook_id = %row.id,
+                error = %error,
+                "repository commit hook heartbeat task failed"
+            );
+        }
+    }
+}
+
+/// `SQLite` retry / dead-letter. Same attempt-count and exponential-backoff
+/// semantics as the Postgres `pg_nack_*`, but the `run_at` retry target is
+/// computed in Rust (`SQLite` has no `NOW() + INTERVAL`) and bound as a UTC string.
+#[cfg(feature = "sqlite")]
+async fn sqlite_nack_repository_commit_hook_failure(
+    pool: &RtPool,
+    hook_id: &str,
+    worker_id: &str,
+    error: &str,
+    row: &RepositoryCommitHookRow,
+) -> AutumnResult<bool> {
+    let mut conn = pool.get().await.map_err(|error| {
+        AutumnError::internal_server_error_msg(format!("commit hook pool error: {error}"))
+    })?;
+
+    if row.attempt < row.max_attempts {
+        let delay_ms = retry_delay_ms(row.initial_backoff_ms, row.attempt);
+        let run_at = sqlite_timestamp(
+            chrono::Utc::now()
+                + chrono::Duration::try_milliseconds(delay_ms)
+                    .unwrap_or_else(chrono::Duration::zero),
+        );
+        diesel::sql_query(
+            "UPDATE autumn_repository_commit_hooks \
+             SET status = 'enqueued', \
+                 attempt = attempt + 1, \
+                 run_at = ?, \
+                 started_at = NULL, \
+                 finished_at = NULL, \
+                 claimed_by = NULL, \
+                 claimed_at = NULL, \
+                 last_error = ? \
+             WHERE id = ? AND claimed_by = ? AND status = 'running'",
+        )
+        .bind::<diesel::sql_types::Text, _>(run_at)
+        .bind::<diesel::sql_types::Text, _>(error)
+        .bind::<diesel::sql_types::Text, _>(hook_id)
+        .bind::<diesel::sql_types::Text, _>(worker_id)
+        .execute(&mut *conn)
+        .await
+        .map(|rows| rows > 0)
+        .map_err(|error| {
+            AutumnError::internal_server_error_msg(format!(
+                "repository commit hook retry failed: {error}"
+            ))
+        })
+    } else {
+        diesel::sql_query(
+            "UPDATE autumn_repository_commit_hooks \
+             SET status = 'failed', \
+                 finished_at = CURRENT_TIMESTAMP, \
+                 claimed_by = NULL, \
+                 claimed_at = NULL, \
+                 last_error = ? \
+             WHERE id = ? AND claimed_by = ? AND status = 'running'",
+        )
+        .bind::<diesel::sql_types::Text, _>(error)
+        .bind::<diesel::sql_types::Text, _>(hook_id)
+        .bind::<diesel::sql_types::Text, _>(worker_id)
+        .execute(&mut *conn)
+        .await
+        .map(|rows| rows > 0)
+        .map_err(|error| {
+            AutumnError::internal_server_error_msg(format!(
+                "repository commit hook dead-letter failed: {error}"
+            ))
+        })
+    }
+}
+
 fn is_missing_hook_table_error(error: &diesel::result::Error) -> bool {
     let message = error.to_string().to_ascii_lowercase();
     message.contains("autumn_repository_commit_hooks")
-        && (message.contains("does not exist") || message.contains("undefinedtable"))
+        // Postgres reports the missing table as "does not exist" / "UndefinedTable";
+        // SQLite reports it as "no such table: autumn_repository_commit_hooks".
+        && (message.contains("does not exist")
+            || message.contains("undefinedtable")
+            || message.contains("no such table"))
 }
 
 fn retry_delay_ms(initial_backoff_ms: i64, attempt: i32) -> i64 {
@@ -1531,6 +2268,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(feature = "sqlite"))]
     #[tokio::test]
     async fn after_hook_failure_marking_returns_when_pool_is_unavailable() {
         use diesel_async::AsyncPgConnection;
@@ -1734,6 +2472,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(feature = "sqlite"))]
     #[test]
     fn pending_insert_reclaims_only_unfinalized_or_failed_rows() {
         assert!(
@@ -1742,6 +2481,26 @@ mod tests {
                 && HOOK_PENDING_INSERT_SQL.contains("context = EXCLUDED.context")
                 && HOOK_PENDING_INSERT_SQL.contains("record = EXCLUDED.record")
                 && HOOK_PENDING_INSERT_SQL.contains("claimed_by = EXCLUDED.claimed_by")
+                && HOOK_PENDING_INSERT_SQL.contains("last_error = NULL"),
+            "a retried idempotent mutation must be able to restage durable hooks after an earlier unfinalized or failed regular after-hook"
+        );
+        assert!(
+            HOOK_PENDING_INSERT_SQL.contains(
+                "WHERE autumn_repository_commit_hooks.status IN ('pending_after_hook', 'after_hook_failed')"
+            ),
+            "restaging must reclaim unfinalized pending rows but not replace already finalized, enqueued, running, completed, or worker-failed rows"
+        );
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn pending_insert_reclaims_only_unfinalized_or_failed_rows_sqlite() {
+        assert!(
+            HOOK_PENDING_INSERT_SQL.contains("ON CONFLICT (id) DO UPDATE")
+                && HOOK_PENDING_INSERT_SQL.contains("status = 'pending_after_hook'")
+                && HOOK_PENDING_INSERT_SQL.contains("context = excluded.context")
+                && HOOK_PENDING_INSERT_SQL.contains("record = excluded.record")
+                && HOOK_PENDING_INSERT_SQL.contains("claimed_by = excluded.claimed_by")
                 && HOOK_PENDING_INSERT_SQL.contains("last_error = NULL"),
             "a retried idempotent mutation must be able to restage durable hooks after an earlier unfinalized or failed regular after-hook"
         );
@@ -1777,6 +2536,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(feature = "sqlite"))]
     #[test]
     fn success_ack_clears_retained_payloads() {
         assert!(
@@ -1786,6 +2546,23 @@ mod tests {
         assert!(
             HOOK_ACK_SUCCESS_SQL.contains("record = '{}'::JSONB"),
             "success ack must clear serialized record payload"
+        );
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn success_ack_clears_retained_payloads_sqlite() {
+        assert!(
+            HOOK_ACK_SUCCESS_SQL.contains("context = '{}'"),
+            "success ack must clear serialized context payload"
+        );
+        assert!(
+            HOOK_ACK_SUCCESS_SQL.contains("record = '{}'"),
+            "success ack must clear serialized record payload"
+        );
+        assert!(
+            !HOOK_ACK_SUCCESS_SQL.contains("::JSONB") && !HOOK_ACK_SUCCESS_SQL.contains("NOW()"),
+            "the SQLite ack must not carry Postgres-only JSONB casts or NOW()"
         );
     }
 
@@ -1813,6 +2590,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(feature = "sqlite"))]
     #[test]
     fn staged_hooks_are_not_dispatchable_until_finalized_after_regular_hooks() {
         assert!(
@@ -1881,6 +2659,58 @@ mod tests {
         );
     }
 
+    // `SQLite` fork of the staged-lifecycle invariants: identical status-machine
+    // wording, but `CURRENT_TIMESTAMP`/`excluded`/bare-`'{}'` in place of the
+    // Postgres `NOW()`/`EXCLUDED`/`::JSONB`.
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn staged_hooks_are_not_dispatchable_until_finalized_after_regular_hooks_sqlite() {
+        assert!(
+            HOOK_PENDING_INSERT_SQL.contains("'pending_after_hook'")
+                && HOOK_PENDING_INSERT_SQL.contains("claimed_by, claimed_at"),
+            "create/update hooks must first be staged in a non-dispatchable leased state"
+        );
+        assert!(
+            HOOK_MARK_AFTER_HOOK_SUCCEEDED_SQL.contains("status = 'after_hook_succeeded'")
+                && HOOK_MARK_AFTER_HOOK_SUCCEEDED_SQL.contains("context = ?")
+                && HOOK_MARK_AFTER_HOOK_SUCCEEDED_SQL.contains("record = ?")
+                && HOOK_MARK_AFTER_HOOK_SUCCEEDED_SQL
+                    .contains("WHERE id = ? AND claimed_by = ? AND status = 'pending_after_hook'"),
+            "regular after-hook success must durably persist finalized hook payload before enqueue"
+        );
+        assert!(
+            HOOK_FINALIZE_AFTER_HOOK_SQL.contains("status = 'enqueued'")
+                && HOOK_FINALIZE_AFTER_HOOK_SQL.contains(
+                    "WHERE id = ? AND claimed_by = ? AND status = 'after_hook_succeeded'"
+                ),
+            "after-hook finalization must only enqueue rows with a durable regular-hook success marker"
+        );
+        assert!(
+            HOOK_AFTER_HOOK_FAILED_SQL.contains("status = 'after_hook_failed'")
+                && HOOK_AFTER_HOOK_FAILED_SQL.contains("context = '{}'")
+                && HOOK_AFTER_HOOK_FAILED_SQL.contains("record = '{}'")
+                && HOOK_AFTER_HOOK_FAILED_SQL
+                    .contains("WHERE id = ? AND claimed_by = ? AND status = 'pending_after_hook'"),
+            "failed regular after hooks must mark only the owner-scoped staged row terminal and non-dispatchable"
+        );
+        assert!(
+            HOOK_RECOVER_STALE_PENDING_SQL
+                .contains("status IN ('pending_after_hook', 'after_hook_succeeded')")
+                && HOOK_RECOVER_STALE_PENDING_SQL
+                    .contains("WHEN status = 'after_hook_succeeded' THEN 'enqueued'")
+                && HOOK_RECOVER_STALE_PENDING_SQL.contains("ELSE 'after_hook_failed'")
+                && HOOK_RECOVER_STALE_PENDING_SQL
+                    .contains("WHEN status = 'pending_after_hook' THEN '{}'"),
+            "stale recovery must enqueue only durably-succeeded rows and fail ambiguous ones closed"
+        );
+        assert!(
+            !HOOK_PENDING_INSERT_SQL.contains("::JSONB")
+                && !HOOK_AFTER_HOOK_FAILED_SQL.contains("::JSONB")
+                && !HOOK_MARK_AFTER_HOOK_SUCCEEDED_SQL.contains("::JSONB"),
+            "the SQLite staged-lifecycle SQL must carry no Postgres-only JSONB casts"
+        );
+    }
+
     #[test]
     fn pending_heartbeat_guard_cancels_on_drop() {
         let guard = RepositoryCommitHookPendingHeartbeat::new(CancellationToken::new());
@@ -1894,6 +2724,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(feature = "sqlite"))]
     #[test]
     fn claim_heartbeat_is_owner_scoped() {
         assert!(
@@ -1910,6 +2741,23 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn claim_heartbeat_is_owner_scoped_sqlite() {
+        assert!(
+            HOOK_EXTEND_CLAIM_SQL.contains("claimed_at = CURRENT_TIMESTAMP"),
+            "heartbeat must extend the stale-recovery lease"
+        );
+        assert!(
+            HOOK_EXTEND_CLAIM_SQL.contains("claimed_by = ?"),
+            "heartbeat must only extend this worker's claim"
+        );
+        assert!(
+            HOOK_EXTEND_CLAIM_SQL.contains("status = 'running'"),
+            "heartbeat must only touch running rows"
+        );
+    }
+
     #[test]
     fn missing_hook_table_error_is_detected_for_quiet_polling() {
         let error = diesel::result::Error::QueryBuilderError(
@@ -1918,5 +2766,19 @@ mod tests {
         );
 
         assert!(is_missing_hook_table_error(&error));
+
+        // SQLite reports the missing queue table differently.
+        let sqlite_error = diesel::result::Error::QueryBuilderError(
+            std::io::Error::other("no such table: autumn_repository_commit_hooks").into(),
+        );
+
+        assert!(is_missing_hook_table_error(&sqlite_error));
+
+        // An unrelated error must not be misclassified as a missing table.
+        let unrelated = diesel::result::Error::QueryBuilderError(
+            std::io::Error::other("connection reset by peer").into(),
+        );
+
+        assert!(!is_missing_hook_table_error(&unrelated));
     }
 }

--- a/autumn/tests/sqlite_commit_hook_worker.rs
+++ b/autumn/tests/sqlite_commit_hook_worker.rs
@@ -1,0 +1,875 @@
+//! Durable repository commit-hook worker on the `SQLite` runtime backend
+//! (issue #1996 item 5).
+//!
+//! Ports the Postgres durable dispatcher (`FOR UPDATE SKIP LOCKED` claim + NOTIFY
+//! kick + retry/backoff + dead-letter + stale recovery + graceful drain) to the
+//! `SQLite` backend flip, where the claim is a `BEGIN IMMEDIATE` single-writer
+//! transaction and the kick is an in-process `Notify`. These tests drive the real
+//! worker (`start_repository_commit_hook_worker`) and the real enqueue surface
+//! (`enqueue_repository_commit_hook_on_conn`) against an in-memory `SQLite`
+//! database — no Docker — and prove:
+//!
+//!  * (a) a queued hook survives a "restart" (enqueued before any worker exists)
+//!    and is delivered exactly once, with request-level idempotency dedup holding;
+//!  * (b) transient failures retry on the recorded backoff and then succeed;
+//!  * (c) a permanently-failing hook is dead-lettered (`status = 'failed'`) after
+//!    `max_attempts`;
+//!  * (d) a graceful shutdown settles the in-flight leased entry before exiting;
+//!  * (e) tenant isolation is INVIOLABLE and fail-closed: a hook enqueued under
+//!    tenant A executes with tenant A's scope and writes ONLY tenant A's data even
+//!    while tenant B has its own queued hook, and a hook enqueued with NO tenant
+//!    fails closed (it never runs against a default/global scope).
+//!
+//! Only meaningful under `--features sqlite`; the file is `#![cfg(feature = "sqlite")]`
+//! so a default `cargo test` compiles it to an empty (passing) binary. Run:
+//! `cargo test -p autumn-web --features "sqlite,test-support" --test sqlite_commit_hook_worker`.
+#![cfg(feature = "sqlite")]
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use autumn_web::config::DatabaseConfig;
+use autumn_web::db::{RuntimeConnection, create_pool};
+use autumn_web::reexports::{diesel, diesel_async, serde_json, tokio, tokio_util};
+use autumn_web::tenancy::{CURRENT_TENANT, with_tenant};
+
+use diesel_async::RunQueryDsl as _;
+use diesel_async::pooled_connection::deadpool::Pool;
+use serde_json::json;
+use tokio_util::sync::CancellationToken;
+
+type SqlitePool = Pool<RuntimeConnection>;
+
+static HANDLER_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Read an atomic counter. Fully qualified because `diesel_async::RunQueryDsl`'s
+/// blanket `load(self, conn)` is in scope and otherwise shadows `AtomicU64::load`.
+fn load(counter: &std::sync::atomic::AtomicU64) -> u64 {
+    std::sync::atomic::AtomicU64::load(counter, Ordering::SeqCst)
+}
+
+/// A leaked, process-unique handler key so each test registers an isolated runner
+/// (the runner registry is global; a shared key would let one test's worker run a
+/// different test's closure over the wrong pool).
+fn unique_handler_key() -> &'static str {
+    let n = HANDLER_SEQ.fetch_add(1, Ordering::Relaxed);
+    Box::leak(format!("test::sqlite_commit_hook_worker::handler::{n}").into_boxed_str())
+}
+
+mod schema {
+    autumn_web::reexports::diesel::table! {
+        hook_notes (id) {
+            id -> Int8,
+            body -> Text,
+            tenant_id -> Text,
+        }
+    }
+}
+
+use schema::hook_notes;
+
+// A tenant-scoped target the durable hook writes into. Proving a hook's write
+// lands under the ORIGINATING tenant (and never another tenant) is the strongest
+// adversarial tenant-isolation assertion.
+#[autumn_web::model(table = "hook_notes")]
+pub struct HookNote {
+    #[id]
+    pub id: i64,
+    pub body: String,
+    #[default]
+    pub tenant_id: String,
+}
+
+#[autumn_web::repository(HookNote, table = "hook_notes", tenant_scoped)]
+pub trait HookNoteRepository {}
+
+async fn boot(db_name: &str) -> SqlitePool {
+    let config = DatabaseConfig {
+        url: Some(format!("sqlite://file:{db_name}?mode=memory&cache=shared")),
+        primary_pool_size: Some(4),
+        ..Default::default()
+    };
+    let pool: SqlitePool = create_pool(&config)
+        .expect("sqlite pool builds")
+        .expect("a url is configured");
+
+    let mut conn = pool.get().await.expect("checkout sqlite connection");
+    diesel::sql_query(
+        "CREATE TABLE hook_notes (\
+             id INTEGER PRIMARY KEY AUTOINCREMENT, \
+             body TEXT NOT NULL, \
+             tenant_id TEXT NOT NULL\
+         )",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("create hook_notes table");
+    // The SQLite durable commit-hook queue (same DDL the #1996 item-5 migration
+    // installs; indexes omitted — they are a pure perf concern for these tests).
+    diesel::sql_query(
+        "CREATE TABLE autumn_repository_commit_hooks (\
+             id                  TEXT    PRIMARY KEY, \
+             handler_key         TEXT    NOT NULL, \
+             hook_name           TEXT    NOT NULL, \
+             context             TEXT    NOT NULL DEFAULT '{}', \
+             record              TEXT    NOT NULL DEFAULT '{}', \
+             status              TEXT    NOT NULL DEFAULT 'enqueued', \
+             attempt             INTEGER NOT NULL DEFAULT 1, \
+             max_attempts        INTEGER NOT NULL DEFAULT 5, \
+             initial_backoff_ms  BIGINT  NOT NULL DEFAULT 1000, \
+             enqueued_at         TEXT    NOT NULL DEFAULT CURRENT_TIMESTAMP, \
+             started_at          TEXT, \
+             finished_at         TEXT, \
+             claimed_by          TEXT, \
+             claimed_at          TEXT, \
+             last_error          TEXT, \
+             run_at              TEXT    NOT NULL DEFAULT CURRENT_TIMESTAMP\
+         )",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("create commit hook queue table");
+    pool
+}
+
+#[derive(diesel::QueryableByName)]
+struct StatusRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    status: String,
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+    last_error: Option<String>,
+}
+
+async fn hook_row_status(pool: &SqlitePool, id: &str) -> Option<(String, Option<String>)> {
+    let mut conn = pool.get().await.expect("checkout");
+    diesel::sql_query("SELECT status, last_error FROM autumn_repository_commit_hooks WHERE id = ?")
+        .bind::<diesel::sql_types::Text, _>(id)
+        .get_result::<StatusRow>(&mut conn)
+        .await
+        .ok()
+        .map(|row| (row.status, row.last_error))
+}
+
+async fn count_notes(pool: &SqlitePool, tenant: &str) -> i64 {
+    #[derive(diesel::QueryableByName)]
+    struct CountRow {
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        n: i64,
+    }
+    let mut conn = pool.get().await.expect("checkout");
+    diesel::sql_query("SELECT COUNT(*) AS n FROM hook_notes WHERE tenant_id = ?")
+        .bind::<diesel::sql_types::Text, _>(tenant)
+        .get_result::<CountRow>(&mut conn)
+        .await
+        .expect("count notes")
+        .n
+}
+
+async fn total_notes(pool: &SqlitePool) -> i64 {
+    #[derive(diesel::QueryableByName)]
+    struct CountRow {
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        n: i64,
+    }
+    let mut conn = pool.get().await.expect("checkout");
+    diesel::sql_query("SELECT COUNT(*) AS n FROM hook_notes")
+        .get_result::<CountRow>(&mut conn)
+        .await
+        .expect("count notes")
+        .n
+}
+
+/// Enqueue a durable hook through the REAL enqueue surface, inside the ambient
+/// tenant scope (so the SQLite worker's tenant round-trip is exercised).
+async fn enqueue(
+    pool: &SqlitePool,
+    handler_key: &str,
+    idempotency_key: Option<&str>,
+    record: &serde_json::Value,
+) {
+    let mut conn = pool.get().await.expect("checkout");
+    autumn_web::__private::enqueue_repository_commit_hook_on_conn(
+        &mut conn,
+        handler_key,
+        "create",
+        idempotency_key,
+        None,
+        &json!({ "op": "create" }),
+        record,
+    )
+    .await
+    .expect("enqueue durable hook");
+}
+
+/// Insert a queue row directly so tests can control `initial_backoff_ms` /
+/// `max_attempts` (the public enqueue hardcodes 1000ms / 5, too slow for
+/// retry/dead-letter timing).
+async fn insert_raw_row(
+    pool: &SqlitePool,
+    id: &str,
+    handler_key: &str,
+    max_attempts: i32,
+    initial_backoff_ms: i64,
+) {
+    let mut conn = pool.get().await.expect("checkout");
+    diesel::sql_query(
+        "INSERT INTO autumn_repository_commit_hooks \
+         (id, handler_key, hook_name, context, record, status, attempt, max_attempts, \
+          initial_backoff_ms, enqueued_at, run_at) \
+         VALUES (?, ?, 'create', '{}', '{}', 'enqueued', 1, ?, ?, \
+                 '2000-01-01 00:00:00.000', '2000-01-01 00:00:00.000')",
+    )
+    .bind::<diesel::sql_types::Text, _>(id)
+    .bind::<diesel::sql_types::Text, _>(handler_key)
+    .bind::<diesel::sql_types::Integer, _>(max_attempts)
+    .bind::<diesel::sql_types::BigInt, _>(initial_backoff_ms)
+    .execute(&mut conn)
+    .await
+    .expect("insert raw hook row");
+}
+
+/// Insert a queue row with a caller-supplied `context` JSON so a test can simulate
+/// a persisted row whose embedded `__autumn_tenant` is blank / whitespace (as an
+/// older, pre-fix producer — or a tampered row — could have written). Exercises the
+/// EXTRACT path's fail-closed normalization independent of the enqueue surface.
+async fn insert_raw_row_with_context(
+    pool: &SqlitePool,
+    id: &str,
+    handler_key: &str,
+    context: &str,
+) {
+    let mut conn = pool.get().await.expect("checkout");
+    diesel::sql_query(
+        "INSERT INTO autumn_repository_commit_hooks \
+         (id, handler_key, hook_name, context, record, status, attempt, max_attempts, \
+          initial_backoff_ms, enqueued_at, run_at) \
+         VALUES (?, ?, 'create', ?, '{}', 'enqueued', 1, 5, 1000, \
+                 '2000-01-01 00:00:00.000', '2000-01-01 00:00:00.000')",
+    )
+    .bind::<diesel::sql_types::Text, _>(id)
+    .bind::<diesel::sql_types::Text, _>(handler_key)
+    .bind::<diesel::sql_types::Text, _>(context)
+    .execute(&mut conn)
+    .await
+    .expect("insert raw hook row with context");
+}
+
+/// Count notes whose `tenant_id` is empty or whitespace-only — the exact rows a
+/// fail-closed worker must NEVER create from a blank/whitespace tenant scope.
+async fn count_blank_tenant_notes(pool: &SqlitePool) -> i64 {
+    #[derive(diesel::QueryableByName)]
+    struct CountRow {
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        n: i64,
+    }
+    let mut conn = pool.get().await.expect("checkout");
+    diesel::sql_query("SELECT COUNT(*) AS n FROM hook_notes WHERE trim(tenant_id) = ''")
+        .get_result::<CountRow>(&mut conn)
+        .await
+        .expect("count blank-tenant notes")
+        .n
+}
+
+/// Read the persisted `context` JSON of the single queue row (embed-path assertion).
+async fn single_row_context(pool: &SqlitePool) -> Option<String> {
+    #[derive(diesel::QueryableByName)]
+    struct ContextRow {
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        context: String,
+    }
+    let mut conn = pool.get().await.expect("checkout");
+    diesel::sql_query("SELECT context FROM autumn_repository_commit_hooks LIMIT 1")
+        .get_result::<ContextRow>(&mut conn)
+        .await
+        .ok()
+        .map(|row| row.context)
+}
+
+async fn wait_until<F, Fut>(label: &str, mut predicate: F)
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    for _ in 0..200 {
+        if predicate().await {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("timed out waiting for: {label}");
+}
+
+// ── (a) delivered-once after simulated restart + idempotency dedup ────────────
+
+#[tokio::test]
+async fn queued_hook_survives_restart_and_is_delivered_exactly_once_on_sqlite() {
+    let pool = boot("hook_deliver_once").await;
+    let handler_key = unique_handler_key();
+
+    let observed = Arc::new(Mutex::new(Vec::<Option<String>>::new()));
+    let runner_pool = pool.clone();
+    let runner_observed = observed.clone();
+    autumn_web::__private::register_repository_commit_hook_runner(
+        handler_key,
+        move |_ctx, _record| {
+            let pool = runner_pool.clone();
+            let observed = runner_observed.clone();
+            async move {
+                let tenant = CURRENT_TENANT.try_with(Clone::clone).ok().flatten();
+                observed.lock().unwrap().push(tenant);
+                let repo = PgHookNoteRepository::with_pool_untracked(pool);
+                repo.save(&NewHookNote {
+                    body: "delivered".to_string(),
+                })
+                .await?;
+                Ok(())
+            }
+        },
+        |_ctx, _record| async { Ok(()) },
+        |_ctx, _record| async { Ok(()) },
+    );
+
+    // Enqueue TWICE with the same idempotency key BEFORE any worker exists — the
+    // second call collapses onto the first (ON CONFLICT DO NOTHING). The row is
+    // durable in the queue table; the worker starts "after a restart".
+    with_tenant("tenant-a".to_string(), async {
+        enqueue(&pool, handler_key, Some("idem-1"), &json!({ "id": 1 })).await;
+        enqueue(&pool, handler_key, Some("idem-1"), &json!({ "id": 1 })).await;
+    })
+    .await;
+
+    let shutdown = CancellationToken::new();
+    autumn_web::__private::start_repository_commit_hook_worker(pool.clone(), shutdown.clone());
+
+    wait_until("hook delivered", || {
+        let observed = observed.clone();
+        async move { observed.lock().unwrap().len() >= 1 }
+    })
+    .await;
+    // Give any (erroneous) duplicate delivery a chance to also land before asserting once.
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    shutdown.cancel();
+
+    let runs = observed.lock().unwrap().clone();
+    assert_eq!(
+        runs.len(),
+        1,
+        "the durable hook must be delivered exactly once (idempotency dedup), got: {runs:?}"
+    );
+    assert_eq!(
+        runs[0].as_deref(),
+        Some("tenant-a"),
+        "the worker must re-establish the originating tenant before running the hook"
+    );
+    assert_eq!(
+        count_notes(&pool, "tenant-a").await,
+        1,
+        "the hook's tenant-scoped write must land under tenant-a exactly once"
+    );
+    assert_eq!(
+        count_notes(&pool, "tenant-b").await,
+        0,
+        "the hook must never write another tenant's data"
+    );
+}
+
+// ── (e) adversarial cross-tenant isolation ────────────────────────────────────
+
+#[tokio::test]
+async fn cross_tenant_hooks_never_leak_across_tenants_on_sqlite() {
+    let pool = boot("hook_cross_tenant").await;
+    let handler_key = unique_handler_key();
+
+    let runner_pool = pool.clone();
+    autumn_web::__private::register_repository_commit_hook_runner(
+        handler_key,
+        move |_ctx, record| {
+            let pool = runner_pool.clone();
+            async move {
+                let body = record
+                    .get("body")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("?")
+                    .to_string();
+                let repo = PgHookNoteRepository::with_pool_untracked(pool);
+                repo.save(&NewHookNote { body }).await?;
+                Ok(())
+            }
+        },
+        |_ctx, _record| async { Ok(()) },
+        |_ctx, _record| async { Ok(()) },
+    );
+
+    with_tenant("tenant-a".to_string(), async {
+        enqueue(
+            &pool,
+            handler_key,
+            Some("a-1"),
+            &json!({ "id": 1, "body": "from-a" }),
+        )
+        .await;
+    })
+    .await;
+    with_tenant("tenant-b".to_string(), async {
+        enqueue(
+            &pool,
+            handler_key,
+            Some("b-1"),
+            &json!({ "id": 2, "body": "from-b" }),
+        )
+        .await;
+    })
+    .await;
+
+    let shutdown = CancellationToken::new();
+    autumn_web::__private::start_repository_commit_hook_worker(pool.clone(), shutdown.clone());
+
+    wait_until("both hooks delivered", {
+        let pool = pool.clone();
+        move || {
+            let pool = pool.clone();
+            async move { total_notes(&pool).await >= 2 }
+        }
+    })
+    .await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    shutdown.cancel();
+
+    // Each tenant sees ONLY its own hook's write; neither leaked into the other.
+    assert_eq!(
+        count_notes(&pool, "tenant-a").await,
+        1,
+        "tenant-a note count"
+    );
+    assert_eq!(
+        count_notes(&pool, "tenant-b").await,
+        1,
+        "tenant-b note count"
+    );
+
+    let repo = PgHookNoteRepository::with_pool_untracked(pool.clone());
+    let a_notes = with_tenant("tenant-a".to_string(), async {
+        repo.find_all().await.expect("list tenant-a")
+    })
+    .await;
+    let b_notes = with_tenant("tenant-b".to_string(), async {
+        repo.find_all().await.expect("list tenant-b")
+    })
+    .await;
+    assert_eq!(
+        a_notes.iter().map(|n| n.body.as_str()).collect::<Vec<_>>(),
+        vec!["from-a"],
+        "tenant-a must only contain its own hook's write"
+    );
+    assert_eq!(
+        b_notes.iter().map(|n| n.body.as_str()).collect::<Vec<_>>(),
+        vec!["from-b"],
+        "tenant-b must only contain its own hook's write"
+    );
+}
+
+// ── (e) missing tenant fails closed ───────────────────────────────────────────
+
+#[tokio::test]
+async fn hook_with_no_tenant_fails_closed_and_writes_nothing_on_sqlite() {
+    let pool = boot("hook_fail_closed").await;
+    let handler_key = unique_handler_key();
+
+    let attempts = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let runner_pool = pool.clone();
+    let runner_attempts = attempts.clone();
+    autumn_web::__private::register_repository_commit_hook_runner(
+        handler_key,
+        move |_ctx, _record| {
+            let pool = runner_pool.clone();
+            let attempts = runner_attempts.clone();
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                // A tenant_scoped write with NO ambient tenant must error — the
+                // worker must NOT have established a default/global scope.
+                let repo = PgHookNoteRepository::with_pool_untracked(pool);
+                repo.save(&NewHookNote {
+                    body: "should-never-persist".to_string(),
+                })
+                .await?;
+                Ok(())
+            }
+        },
+        |_ctx, _record| async { Ok(()) },
+        |_ctx, _record| async { Ok(()) },
+    );
+
+    // Enqueue OUTSIDE any tenant scope → no tenant embedded in context.
+    enqueue(&pool, handler_key, Some("no-tenant"), &json!({ "id": 9 })).await;
+
+    let shutdown = CancellationToken::new();
+    autumn_web::__private::start_repository_commit_hook_worker(pool.clone(), shutdown.clone());
+
+    // Wait until the hook has been attempted at least once, then confirm nothing persisted.
+    wait_until("hook attempted", {
+        let attempts = attempts.clone();
+        move || {
+            let attempts = attempts.clone();
+            async move { load(&attempts) >= 1 }
+        }
+    })
+    .await;
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    shutdown.cancel();
+
+    assert_eq!(
+        total_notes(&pool).await,
+        0,
+        "a hook with no tenant context must fail closed — never writing to any (default/global) scope"
+    );
+}
+
+// ── (e) blank / whitespace persisted tenant fails closed (EXTRACT path) ───────
+
+// Regression for the P1 tenant-isolation finding: a persisted `__autumn_tenant`
+// that is `""` or whitespace-only must be treated as UNSET, not as an established
+// tenant. Without the extract-side normalization the drain loop scopes
+// `CURRENT_TENANT` to the blank string and a `tenant_scoped` repo happily
+// reads/writes `tenant_id = ''` — a fail-closed breach. Both blank and whitespace
+// rows must run with the tenant UNSET and therefore write NOTHING.
+#[tokio::test]
+async fn hook_with_blank_or_whitespace_persisted_tenant_fails_closed_on_sqlite() {
+    let pool = boot("hook_blank_tenant").await;
+    let handler_key = unique_handler_key();
+
+    let attempts = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let runner_pool = pool.clone();
+    let runner_attempts = attempts.clone();
+    autumn_web::__private::register_repository_commit_hook_runner(
+        handler_key,
+        move |_ctx, _record| {
+            let pool = runner_pool.clone();
+            let attempts = runner_attempts.clone();
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                // The persisted tenant was blank/whitespace: the worker must have
+                // left CURRENT_TENANT UNSET, so this tenant_scoped write fails
+                // closed rather than persisting a tenant_id = '' (or whitespace) row.
+                let repo = PgHookNoteRepository::with_pool_untracked(pool);
+                repo.save(&NewHookNote {
+                    body: "should-never-persist".to_string(),
+                })
+                .await?;
+                Ok(())
+            }
+        },
+        |_ctx, _record| async { Ok(()) },
+        |_ctx, _record| async { Ok(()) },
+    );
+
+    // Two already-persisted rows whose embedded __autumn_tenant is blank / whitespace.
+    insert_raw_row_with_context(
+        &pool,
+        "blank-tenant",
+        handler_key,
+        r#"{"op":"create","__autumn_tenant":""}"#,
+    )
+    .await;
+    insert_raw_row_with_context(
+        &pool,
+        "whitespace-tenant",
+        handler_key,
+        r#"{"op":"create","__autumn_tenant":"   "}"#,
+    )
+    .await;
+
+    let shutdown = CancellationToken::new();
+    autumn_web::__private::start_repository_commit_hook_worker(pool.clone(), shutdown.clone());
+
+    // Both rows must be attempted at least once (the fail-closed write errors).
+    wait_until("both blank/whitespace hooks attempted", {
+        let attempts = attempts.clone();
+        move || {
+            let attempts = attempts.clone();
+            async move { load(&attempts) >= 2 }
+        }
+    })
+    .await;
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    shutdown.cancel();
+
+    // Critical negative: NO row was written under a blank/whitespace tenant.
+    assert_eq!(
+        count_blank_tenant_notes(&pool).await,
+        0,
+        "a blank/whitespace persisted tenant must fail closed — never writing a tenant_id = '' (or whitespace) row"
+    );
+    assert_eq!(
+        total_notes(&pool).await,
+        0,
+        "a hook whose persisted tenant is blank/whitespace must write NOTHING (fail closed)"
+    );
+}
+
+// ── (e) blank / whitespace ambient tenant is never embedded (EMBED path) ──────
+
+// Defense-in-depth for the same finding at the producer side: a blank/whitespace
+// ambient tenant must never be persisted into the context in the first place, so a
+// blank tenant is neither stored nor trusted. The enqueued hook then runs with the
+// tenant UNSET and its tenant_scoped write fails closed.
+#[tokio::test]
+async fn blank_ambient_tenant_is_never_embedded_on_sqlite() {
+    let pool = boot("hook_blank_embed").await;
+    let handler_key = unique_handler_key();
+
+    let attempts = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let runner_pool = pool.clone();
+    let runner_attempts = attempts.clone();
+    autumn_web::__private::register_repository_commit_hook_runner(
+        handler_key,
+        move |_ctx, _record| {
+            let pool = runner_pool.clone();
+            let attempts = runner_attempts.clone();
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                let repo = PgHookNoteRepository::with_pool_untracked(pool);
+                repo.save(&NewHookNote {
+                    body: "should-never-persist".to_string(),
+                })
+                .await?;
+                Ok(())
+            }
+        },
+        |_ctx, _record| async { Ok(()) },
+        |_ctx, _record| async { Ok(()) },
+    );
+
+    // Enqueue inside a whitespace-only ambient tenant scope → the embed site must
+    // persist NO __autumn_tenant key (blank is never written).
+    with_tenant("   ".to_string(), async {
+        enqueue(&pool, handler_key, Some("blank-embed"), &json!({ "id": 7 })).await;
+    })
+    .await;
+
+    let context = single_row_context(&pool).await.expect("one queue row");
+    assert!(
+        !context.contains("__autumn_tenant"),
+        "a blank/whitespace ambient tenant must never be embedded into the context, got: {context}"
+    );
+
+    let shutdown = CancellationToken::new();
+    autumn_web::__private::start_repository_commit_hook_worker(pool.clone(), shutdown.clone());
+
+    wait_until("blank-embed hook attempted", {
+        let attempts = attempts.clone();
+        move || {
+            let attempts = attempts.clone();
+            async move { load(&attempts) >= 1 }
+        }
+    })
+    .await;
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    shutdown.cancel();
+
+    assert_eq!(
+        count_blank_tenant_notes(&pool).await,
+        0,
+        "a hook enqueued under a blank/whitespace tenant must fail closed — no tenant_id = '' row"
+    );
+    assert_eq!(
+        total_notes(&pool).await,
+        0,
+        "a hook enqueued under a blank/whitespace tenant must write NOTHING (fail closed)"
+    );
+}
+
+// ── (b) retry / backoff on transient failure ──────────────────────────────────
+
+#[tokio::test]
+async fn transient_hook_failure_retries_then_succeeds_on_sqlite() {
+    let pool = boot("hook_retry").await;
+    let handler_key = unique_handler_key();
+
+    let calls = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let runner_calls = calls.clone();
+    autumn_web::__private::register_repository_commit_hook_runner(
+        handler_key,
+        move |_ctx, _record| {
+            let calls = runner_calls.clone();
+            async move {
+                let n = calls.fetch_add(1, Ordering::SeqCst);
+                if n == 0 {
+                    Err(autumn_web::AutumnError::internal_server_error_msg(
+                        "transient failure on first attempt",
+                    ))
+                } else {
+                    Ok(())
+                }
+            }
+        },
+        |_ctx, _record| async { Ok(()) },
+        |_ctx, _record| async { Ok(()) },
+    );
+
+    // Small backoff so the retry lands quickly.
+    insert_raw_row(&pool, "retry-1", handler_key, 5, 10).await;
+
+    let shutdown = CancellationToken::new();
+    autumn_web::__private::start_repository_commit_hook_worker(pool.clone(), shutdown.clone());
+
+    wait_until("hook completed after retry", {
+        let pool = pool.clone();
+        move || {
+            let pool = pool.clone();
+            async move {
+                matches!(hook_row_status(&pool, "retry-1").await, Some((s, _)) if s == "completed")
+            }
+        }
+    })
+    .await;
+    shutdown.cancel();
+
+    assert_eq!(
+        load(&calls),
+        2,
+        "the hook must be attempted twice: one transient failure, then a successful retry"
+    );
+}
+
+// ── (c) dead-letter after max attempts ────────────────────────────────────────
+
+#[tokio::test]
+async fn permanently_failing_hook_is_dead_lettered_on_sqlite() {
+    let pool = boot("hook_dead_letter").await;
+    let handler_key = unique_handler_key();
+
+    let calls = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let runner_calls = calls.clone();
+    autumn_web::__private::register_repository_commit_hook_runner(
+        handler_key,
+        move |_ctx, _record| {
+            let calls = runner_calls.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Err(autumn_web::AutumnError::internal_server_error_msg(
+                    "permanent failure",
+                ))
+            }
+        },
+        |_ctx, _record| async { Ok(()) },
+        |_ctx, _record| async { Ok(()) },
+    );
+
+    // max_attempts = 2, tiny backoff → dead-letter fast.
+    insert_raw_row(&pool, "dead-1", handler_key, 2, 5).await;
+
+    let shutdown = CancellationToken::new();
+    autumn_web::__private::start_repository_commit_hook_worker(pool.clone(), shutdown.clone());
+
+    wait_until("hook dead-lettered", {
+        let pool = pool.clone();
+        move || {
+            let pool = pool.clone();
+            async move {
+                matches!(hook_row_status(&pool, "dead-1").await, Some((s, _)) if s == "failed")
+            }
+        }
+    })
+    .await;
+    shutdown.cancel();
+
+    let (status, last_error) = hook_row_status(&pool, "dead-1").await.expect("row exists");
+    assert_eq!(status, "failed", "exhausted hooks must be dead-lettered");
+    assert!(
+        last_error.is_some_and(|e| e.contains("permanent failure")),
+        "the dead-lettered row must retain the last failure detail"
+    );
+    assert_eq!(
+        load(&calls),
+        2,
+        "the hook must be attempted exactly max_attempts (2) times before dead-lettering"
+    );
+}
+
+// ── (d) graceful shutdown settles in-flight work ──────────────────────────────
+
+#[tokio::test]
+async fn graceful_shutdown_settles_in_flight_hook_on_sqlite() {
+    let pool = boot("hook_drain").await;
+    let handler_key = unique_handler_key();
+
+    let done = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let runner_done = done.clone();
+    autumn_web::__private::register_repository_commit_hook_runner(
+        handler_key,
+        move |_ctx, _record| {
+            let done = runner_done.clone();
+            async move {
+                // A slow hook so the shutdown signal arrives while it is in-flight.
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                done.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        },
+        |_ctx, _record| async { Ok(()) },
+        |_ctx, _record| async { Ok(()) },
+    );
+
+    enqueue(&pool, handler_key, Some("drain-1"), &json!({ "id": 1 })).await;
+
+    let shutdown = CancellationToken::new();
+    autumn_web::__private::start_repository_commit_hook_worker(pool.clone(), shutdown.clone());
+    // Wake the worker immediately (exercises the SQLite Notify kick), then cancel
+    // while the hook is still sleeping mid-flight.
+    kick(&pool);
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    shutdown.cancel();
+
+    // Despite the shutdown arriving mid-flight, the claimed hook must settle.
+    wait_until("in-flight hook settles after shutdown", {
+        let done = done.clone();
+        move || {
+            let done = done.clone();
+            async move { load(&done) >= 1 }
+        }
+    })
+    .await;
+    assert_eq!(
+        load(&done),
+        1,
+        "the in-flight leased hook must finish exactly once before the worker exits"
+    );
+
+    // And it must have been acknowledged (not left leased/abandoned): the single
+    // queue row reaches the terminal `completed` state.
+    let row_id = single_row_id(&pool).await.expect("one queue row");
+    wait_until("in-flight hook acknowledged", {
+        let pool = pool.clone();
+        let row_id = row_id.clone();
+        move || {
+            let pool = pool.clone();
+            let row_id = row_id.clone();
+            async move {
+                matches!(hook_row_status(&pool, &row_id).await, Some((s, _)) if s == "completed")
+            }
+        }
+    })
+    .await;
+}
+
+fn kick(pool: &SqlitePool) {
+    autumn_web::__private::kick_repository_commit_hook_dispatcher(pool);
+}
+
+/// The drain test enqueues through the real surface (an idempotent, derived row
+/// id); recover it so the settle assertion can read the row's terminal status.
+async fn single_row_id(pool: &SqlitePool) -> Option<String> {
+    #[derive(diesel::QueryableByName)]
+    struct IdRow {
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        id: String,
+    }
+    let mut conn = pool.get().await.expect("checkout");
+    diesel::sql_query("SELECT id FROM autumn_repository_commit_hooks LIMIT 1")
+        .get_result::<IdRow>(&mut conn)
+        .await
+        .ok()
+        .map(|row| row.id)
+}


### PR DESCRIPTION
**Before:** The durable repository commit-hook dispatcher ran only on Postgres. Under the `sqlite` backend flip the worker was compiled out (`#[cfg(not(feature="sqlite"))]`), the dispatcher wake (`kick_repository_commit_hook_dispatcher`) was a no-op, and the queue-table DDL used JSONB/TIMESTAMPTZ/NOW() — so a `#[repository(commit_hooks = true)]` couldn't even build under `--features sqlite`, and queued hooks had no durable delivery on SQLite.

**After:** The durable worker runs on the SQLite backend too. Queued commit-hooks survive process crashes/restarts on SQLite, are delivered exactly once (reusing the existing #1995 auto-derived idempotency-key dedup), retry with backoff, dead-letter after max attempts with a loud error log, and drain gracefully on shutdown. This completes the **fifth and final deferred item** from PR #2034's "Out of scope" list (the durable commit-hook worker). Part of #1996 (the issue is closed with no AC checklist, so this references the #2034 out-of-scope list for traceability).

**How:**
- **Queue DDL fork:** a SQLite dialect variant of the queue table (TEXT for the context/payload JSON, TEXT timestamps + `CURRENT_TIMESTAMP`, partial indexes preserved), under the same migration version dir as the Postgres one — mirroring the item-2 `_autumn_version_history` per-backend fork. Postgres DDL/SQL and persisted bytes are unchanged.
- **Claim path:** SQLite has no `FOR UPDATE SKIP LOCKED`; the worker claims a due entry with a `BEGIN IMMEDIATE` single-writer transaction via the existing `scoped_immediate_transaction` precedent. Backend selection is routed through the `backend_select!` macro so only the chosen arm type-checks; the bulk-enqueue `UNNEST` batch forks to a per-row loop on the caller's mutation connection (still atomic in the same txn).
- **Wake + poll:** a real in-process `Notify` kick per pool replaces the SQLite no-op, with an idle-poll fallback so a missed kick still drains (SQLite is single-node).
- **Retry / dead-letter / recovery:** same attempt-count + exponential-backoff semantics as the Postgres worker (retry/dead-letter/stale-lease-recovery timestamps computed in Rust and bound as comparable UTC strings).
- **Graceful drain:** on the shutdown token the worker settles the in-flight leased entry before exiting (biased `select!` on a child `CancellationToken`), wired into the same startup/shutdown machinery as the Postgres worker and gated by `role.runs_workers()`.
- **Fail-closed tenant isolation:** `MutationContext` carries no tenant, so the SQLite enqueue embeds the ambient `CURRENT_TENANT` into the persisted `context` JSON (`__autumn_tenant`); the worker re-establishes exactly that tenant before executing each hook. A hook with no/blank tenant runs with `CURRENT_TENANT` unset, so any `tenant_scoped` repo fails closed rather than touching a default/global scope. Postgres persisted bytes stay byte-identical.

**Tests:** new `autumn/tests/sqlite_commit_hook_worker.rs` (6 tests: delivered-exactly-once after simulated restart + idempotency dedup; retry-then-succeed; dead-letter at max_attempts; graceful-drain of an in-flight entry; adversarial cross-tenant isolation; missing-tenant-fails-closed) plus the `[[test]]` target and a `sqlite-runtime` CI entry. Forked the `#[cfg(test)]` SQL-string invariants per backend where the SQL diverges.

**Local verification (CI queue is backlogged; local is the gate):**
- `cargo fmt --all -- --check` — clean
- SQLite lib+lint: `cargo +1.97.0 clippy -p autumn-web --features sqlite --lib -- -D warnings` — clean
- PG lib+lint: `cargo +1.97.0 clippy -p autumn-web --all-targets -- -D warnings` — clean
- SQLite runtime: `sqlite_commit_hook_worker` — 6 passed
- Macro golden: `cargo +1.97.0 test -p autumn-macros` — 572 passed (no generated-output change)
- PG unit: `repository_commit_hook*` — 24 passed
- SQLite regression: `sqlite_migrations` / `sqlite_version_history` / `sqlite_crud_basic` / `sqlite_upsert_isolation` — pass
- `db_hooks_lifecycle` (pg Docker) requires a live Postgres — not runnable in this environment; the PG path is exercised by the compiled `--all-targets` build + the pg unit/SQL-invariant tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvSBWpNEN2RFPrXZUcUTYX)_