### PR TITLE
Fix broken mark_startup_complete doctest (crate::db path in doctest crate)

### DIFF
--- a/autumn/src/probe.rs
+++ b/autumn/src/probe.rs
@@ -77,7 +77,7 @@ pub trait ProvideProbeState {
     ///     fn profile(&self) -> &str { "dev" }
     ///     fn uptime_display(&self) -> String { String::new() }
     ///     #[cfg(feature = "db")]
-    ///     fn pool(&self) -> Option<&diesel_async::pooled_connection::deadpool::Pool<crate::db::RuntimeConnection>> { None }
+    ///     fn pool(&self) -> Option<&diesel_async::pooled_connection::deadpool::Pool<autumn_web::db::RuntimeConnection>> { None }
     /// }
     ///
     /// let state = MyState { probes: ProbeState::pending_startup() };


### PR DESCRIPTION
## Before / After

The `ProvideProbeState::mark_startup_complete` doctest in `autumn/src/probe.rs` fails to compile, reddening `cargo test --workspace` (the Test job) on ubuntu/windows/macos and every open PR.

```
error[E0433]: cannot find `db` in `crate`
  --> autumn/src/probe.rs:81:86
   |
81 |     fn pool(&self) -> Option<&diesel_async::pooled_connection::deadpool::Pool<crate::db::RuntimeConnection>> { None }
   |                                                                                      ^^ could not find `db` in the crate root
```

The one-line change in the doctest's example `impl`:

```diff
-    ///     fn pool(&self) -> Option<&diesel_async::pooled_connection::deadpool::Pool<crate::db::RuntimeConnection>> { None }
+    ///     fn pool(&self) -> Option<&diesel_async::pooled_connection::deadpool::Pool<autumn_web::db::RuntimeConnection>> { None }
```

## Root cause

Inside a rustdoc doctest, `crate` resolves to the **synthetic doctest crate**, which has no `db` module — not to `autumn_web`. Because `db` is a **default feature** of `autumn-web`, the `#[cfg(feature = "db")]`-gated `pool` line inside the example `impl` is actually compiled, and `crate::db::RuntimeConnection` cannot resolve → `E0433`.

The `crate::db::RuntimeConnection` typing of `ProvideProbeState::pool` / `replica_pool` entered `trunk-dev` via the trunk merge `9da2b79` ("Merge branch 'trunk' into trunk-dev"), which carried the sqlite `RuntimeConnection`-threading series (issue #1996 / PRs #2016, #2021, #2038). That series retyped the trait methods on `crate::db::RuntimeConnection` and mirrored the same path verbatim into the doctest — valid in source (`crate` = `autumn_web`) but invalid in a doctest. (The FTS5 change #2047 does not touch `probe.rs`.)

## Fix

Use the real public path `autumn_web::db::RuntimeConnection` — exactly what a downstream implementor of `ProvideProbeState` in their own crate would write. `pub mod db` and `pub type RuntimeConnection` are both `#[cfg(feature = "db")]`, matching the `#[cfg(feature = "db")]` on the example's `pool` fn, so the example is a compiling, honest example under default features (no `ignore`).

## Sweep (fix the class, not the instance)

- `cargo test -p autumn-web --doc`: **235 passed / 1 failed** before → **236 passed / 0 failed** after. The only executable doctest broken by this root cause is the `probe.rs` one; the full-crate doctest run is the authoritative sweep.
- Other `crate::db::…` occurrences in `autumn/src` are intra-doc links `[text](crate::db::…)` in prose — they resolve against the documented crate, not doctest code, so they are unaffected.
- `cargo test -p autumn --doc` → `package ID specification 'autumn' did not match any packages` (`autumn` is only a bin-target name, not a package).
- `cargo test -p autumn-cli --doc` → `no library targets found in package 'autumn-cli'` (binary-only crate, no doctests).

## Verification

- **Doctest (autumn-web), after fix:** `test result: ok. 236 passed; 0 failed; 155 ignored; 0 measured; 0 filtered out`.
- **`cargo fmt --all -- --check`:** clean (exit 0, no diff).
- **`cargo clippy -p autumn-web --all-targets -- -D warnings`:** exit 0, `Finished` with no lint warnings/errors. (Only note is an unrelated third-party future-incompat on `proc-macro-error2`.)

Doc-comment-only change; no feature-gated code changed, so the `db`-default lane CI runs (`cargo test --workspace`) already exercises the fixed doctest.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WdWWejaUXDLkGV62CrpBHT)_