### PR TITLE
Plugin config-section registration seam for strict_config

### DIFF
--- a/autumn-media-plugin/src/lib.rs
+++ b/autumn-media-plugin/src/lib.rs
@@ -363,6 +363,13 @@ impl Plugin for MediaPlugin {
         Cow::Borrowed("autumn-media-plugin")
     }
 
+    /// Applies the plugin to the [`AppBuilder`].
+    ///
+    /// Declares the plugin-owned `[media]` top-level config section (via
+    /// [`AppBuilder::config_section`]) so a host app with
+    /// `server.strict_config = true` boots without core rejecting `[media]` as
+    /// an unknown key, then mounts the room/broadcast routers, installs the
+    /// service extensions, and spawns the retention/background loops.
     fn build(self, app: AppBuilder) -> AppBuilder {
         let Self {
             config,
@@ -377,6 +384,15 @@ impl Plugin for MediaPlugin {
             recordings_root,
             retention_defer,
         } = self;
+
+        // Declare the plugin-owned `[media]` top-level config table so a host app
+        // running `server.strict_config = true` boots cleanly instead of failing
+        // with `unknown key "media"`. `MediaConfig` is still read from raw TOML
+        // (see `MediaConfig::from_autumn_toml`); this only tells core's strict
+        // unknown-key check that `[media]` is a known, opaque section the plugin
+        // owns and validates itself. Applied first so every return path below
+        // (including the early room-misconfig abort) carries the declaration.
+        let app = app.config_section("media");
 
         let retention_days = retention_days.unwrap_or(config.recording.retention_days);
 
@@ -923,6 +939,25 @@ mod conformance_tests {
             result.status,
             CheckStatus::Fail,
             "expected collision to be detected"
+        );
+    }
+}
+
+#[cfg(test)]
+mod config_section_tests {
+    use super::MediaPlugin;
+
+    // #1974 item 7: `MediaPlugin::build` must declare its `[media]` top-level
+    // config section on the builder so a host app with
+    // `server.strict_config = true` boots without core rejecting `[media]` as an
+    // unknown key. Registering the real plugin and asserting the section is
+    // declared proves the wiring end-to-end (not just a stand-in).
+    #[test]
+    fn build_declares_media_config_section() {
+        let builder = autumn_web::app().plugin(MediaPlugin::new());
+        assert!(
+            builder.has_config_section("media"),
+            "MediaPlugin::build must declare the [media] config section for strict_config"
         );
     }
 }

--- a/autumn/src/app.rs
+++ b/autumn/src/app.rs
@@ -25,7 +25,7 @@
 //! ```
 
 use std::any::{Any, TypeId};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -87,6 +87,7 @@ pub fn app() -> AppBuilder {
         shutdown_hooks: Vec::new(),
         extensions: HashMap::new(),
         registered_plugins: HashSet::new(),
+        plugin_config_roots: BTreeSet::new(),
         #[cfg(feature = "maud")]
         error_page_renderer: None,
         #[cfg(feature = "db")]
@@ -336,6 +337,11 @@ pub struct AppBuilder {
     pub(crate) extensions: HashMap<TypeId, Box<dyn Any + Send>>,
     /// Plugin names that have already been applied, for duplicate detection.
     pub(crate) registered_plugins: HashSet<String>,
+    /// Top-level config roots plugins have declared as their own opaque config
+    /// sections via [`config_section`](AppBuilder::config_section). Threaded into
+    /// the default config loader so `server.strict_config` treats them as
+    /// known-and-opaque instead of unknown-key hard errors.
+    pub(crate) plugin_config_roots: BTreeSet<String>,
     /// Custom error page renderer (overrides built-in pages).
     #[cfg(feature = "maud")]
     error_page_renderer: Option<SharedRenderer>,
@@ -2429,6 +2435,63 @@ impl AppBuilder {
         self.registered_plugins.contains(name)
     }
 
+    /// Declare a plugin-owned top-level config section so it coexists with
+    /// `server.strict_config = true`.
+    ///
+    /// Core's [`AutumnConfig`](crate::config::AutumnConfig) schema is closed: any
+    /// top-level `[root]` table it does not know about is an unknown key. Under
+    /// `strict_config`, an unknown root is a **hard** boot error. A plugin that
+    /// reads its own top-level table — for example `autumn-media-plugin` reading
+    /// `[media]` via raw TOML — would therefore make a `strict_config` app fail
+    /// at boot with `unknown key "media"`.
+    ///
+    /// Calling `config_section("media")` registers `[media]` as a **known,
+    /// opaque** section: the strict unknown-key check accepts the root and does
+    /// **not** validate its contents (the plugin owns that — core has no schema
+    /// for it). The seam is **fail-closed**: only the roots a plugin explicitly
+    /// declares are exempt; every other unknown top-level root still hard-fails,
+    /// so a typo like `[medai]` is still caught.
+    ///
+    /// Call this from your [`Plugin::build`](crate::plugin::Plugin::build)
+    /// implementation, where the plugin is applied to the builder:
+    ///
+    /// ```ignore
+    /// impl Plugin for MediaPlugin {
+    ///     fn build(self, app: AppBuilder) -> AppBuilder {
+    ///         app.config_section("media") // `[media]` is now strict-config-safe
+    ///         // … register routes, jobs, startup hooks, …
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// The declared roots are threaded into the default config loader
+    /// ([`TomlEnvConfigLoader`](crate::config::TomlEnvConfigLoader)); a fully
+    /// custom loader installed via
+    /// [`with_config_loader`](AppBuilder::with_config_loader) owns its own
+    /// strict-config handling and is unaffected.
+    ///
+    /// Future: an optional eager per-section validation hook (handing each
+    /// plugin its raw `[root]` table at boot to validate uniformly) could be
+    /// layered on top of this registry later. It is deliberately deferred — the
+    /// media plugin already fail-fast-validates its own `[media]` config in its
+    /// startup hook, and an eager hook adds callback-storage and error-surface
+    /// plumbing this declarative seam does not need.
+    #[must_use]
+    pub fn config_section(mut self, root: impl Into<String>) -> Self {
+        self.plugin_config_roots.insert(root.into());
+        self
+    }
+
+    /// Return `true` if the given top-level config root has been declared as a
+    /// plugin config section via [`config_section`](AppBuilder::config_section).
+    ///
+    /// Mirrors [`has_plugin`](AppBuilder::has_plugin); useful for tests and
+    /// builder introspection.
+    #[must_use]
+    pub fn has_config_section(&self, root: &str) -> bool {
+        self.plugin_config_roots.contains(root)
+    }
+
     /// Register a named [`MetricsSource`](crate::actuator::MetricsSource) that contributes
     /// metric families to `/actuator/prometheus` and `/actuator/metrics`.
     ///
@@ -2716,6 +2779,7 @@ impl AppBuilder {
             shutdown_hooks,
             extensions: _,
             registered_plugins: _,
+            plugin_config_roots,
             #[cfg(feature = "maud")]
             error_page_renderer,
             #[cfg(feature = "db")]
@@ -2786,8 +2850,12 @@ impl AppBuilder {
         let all_routes = routes;
 
         // 1 & 2. Load configuration and initialize logging/telemetry
-        let (mut config, telemetry_guard) =
-            load_config_and_telemetry(config_loader_factory, telemetry_provider).await;
+        let (mut config, telemetry_guard) = load_config_and_telemetry(
+            config_loader_factory,
+            telemetry_provider,
+            plugin_config_roots,
+        )
+        .await;
 
         // Process role selects which slice of the runtime this replica runs. A
         // split role (web/worker) requires a durable jobs backend the separate
@@ -4242,6 +4310,7 @@ impl AppBuilder {
             shutdown_hooks: _,
             extensions: _,
             registered_plugins: _,
+            plugin_config_roots,
             #[cfg(feature = "maud")]
                 error_page_renderer: _,
             #[cfg(feature = "db")]
@@ -4315,8 +4384,12 @@ impl AppBuilder {
         let all_routes = routes;
 
         // Load config (same as normal startup)
-        let (mut config, telemetry_guard) =
-            load_config_and_telemetry(config_loader_factory, telemetry_provider).await;
+        let (mut config, telemetry_guard) = load_config_and_telemetry(
+            config_loader_factory,
+            telemetry_provider,
+            plugin_config_roots,
+        )
+        .await;
 
         #[cfg(feature = "mail")]
         if mount_unsubscribe_endpoint {
@@ -4710,6 +4783,7 @@ impl AppBuilder {
     /// Triggered when `AUTUMN_DUMP_ROUTES=1` is set (by `autumn routes`).
     /// Exits with code 0 on success, code 1 on JSON serialization failure.
     /// Does not connect to a database or bind a TCP port.
+    #[allow(clippy::too_many_lines)]
     async fn run_dump_routes_mode(self) {
         let Self {
             routes,
@@ -4723,6 +4797,7 @@ impl AppBuilder {
             telemetry_provider,
             #[cfg(feature = "openapi")]
             openapi,
+            plugin_config_roots,
             ..
         } = self;
 
@@ -4785,8 +4860,12 @@ impl AppBuilder {
             );
         }
 
-        let (config, _telemetry_guard) =
-            load_config_and_telemetry(config_loader_factory, telemetry_provider).await;
+        let (config, _telemetry_guard) = load_config_and_telemetry(
+            config_loader_factory,
+            telemetry_provider,
+            plugin_config_roots,
+        )
+        .await;
 
         // Emit the resolved security configuration for the manifest's `declared`
         // dimensions (CSRF, security headers). Gated on `AUTUMN_DUMP_SECURITY`
@@ -4846,11 +4925,16 @@ impl AppBuilder {
             listeners,
             config_loader_factory,
             telemetry_provider,
+            plugin_config_roots,
             ..
         } = self;
 
-        let (config, _telemetry_guard) =
-            load_config_and_telemetry(config_loader_factory, telemetry_provider).await;
+        let (config, _telemetry_guard) = load_config_and_telemetry(
+            config_loader_factory,
+            telemetry_provider,
+            plugin_config_roots,
+        )
+        .await;
 
         // Fold in the synthesized durable-listener jobs exactly as the boot path
         // does, so the manifest reflects the same effective drained-queue set the
@@ -4904,14 +4988,19 @@ impl AppBuilder {
             migrations,
             config_loader_factory,
             telemetry_provider,
+            plugin_config_roots,
             ..
         } = self;
 
         // The telemetry guard is dropped at end of scope; a migrate-only run does
         // not need tracing wired, but loading config the same way keeps env/profile
         // resolution identical to a normal boot.
-        let (config, _telemetry_guard) =
-            load_config_and_telemetry(config_loader_factory, telemetry_provider).await;
+        let (config, _telemetry_guard) = load_config_and_telemetry(
+            config_loader_factory,
+            telemetry_provider,
+            plugin_config_roots,
+        )
+        .await;
 
         // Fold in the framework migration sets a normal boot would apply, using the
         // SAME helper as `setup_database`, so the applied set is identical.
@@ -5088,6 +5177,7 @@ impl AppBuilder {
             channels_interceptor,
             #[cfg(feature = "oauth2")]
             http_interceptor,
+            plugin_config_roots,
             ..
         } = self;
 
@@ -5111,8 +5201,12 @@ impl AppBuilder {
             std::process::exit(1);
         });
 
-        let (config, telemetry_guard) =
-            load_config_and_telemetry(config_loader_factory, telemetry_provider).await;
+        let (config, telemetry_guard) = load_config_and_telemetry(
+            config_loader_factory,
+            telemetry_provider,
+            plugin_config_roots,
+        )
+        .await;
 
         // Register the embedded `static/` tree (if any) before the router is
         // built so `/static/*` serves from the binary and `asset_url()` resolves
@@ -6972,12 +7066,25 @@ fn bootstrap_local_storage(
 async fn load_config_and_telemetry(
     config_loader: Option<ConfigLoaderFactory>,
     telemetry_provider: Option<Box<dyn crate::telemetry::TelemetryProvider>>,
+    plugin_config_roots: BTreeSet<String>,
 ) -> (AutumnConfig, crate::telemetry::TelemetryGuard) {
     // 1. Load configuration via the installed loader, falling back to the
     //    five-layer TOML + env default.
+    //
+    // A custom `config_loader` factory owns its entire load + strict-config
+    // handling (it bypasses the default TOML path), so it does not receive the
+    // declared plugin config roots — such a loader is responsible for accepting
+    // its own plugin-owned sections. The default `TomlEnvConfigLoader` is handed
+    // the roots so `server.strict_config` treats each plugin-declared `[root]`
+    // (e.g. `[media]`) as known-and-opaque instead of an unknown-key hard error.
     let mut config = match config_loader {
         Some(factory) => factory().await,
-        None => crate::config::TomlEnvConfigLoader::new().load().await,
+        None => {
+            crate::config::TomlEnvConfigLoader::new()
+                .with_plugin_config_roots(plugin_config_roots)
+                .load()
+                .await
+        }
     }
     .unwrap_or_else(|e| {
         eprintln!("Failed to load configuration: {e}");
@@ -9217,6 +9324,30 @@ mod tests {
 
     // ── omitted-router accounting for `autumn routes audit` ──────────────────
 
+    // #1974 item 7: a plugin declares a top-level config section from its
+    // `build()` via `config_section`, so `server.strict_config` treats that root
+    // as known-and-opaque. Prove the declaration lands on the builder and that
+    // the registry is fail-closed (an undeclared root is not registered).
+    #[test]
+    fn plugin_declares_config_section_via_build() {
+        struct DummyMediaPlugin;
+        impl crate::plugin::Plugin for DummyMediaPlugin {
+            fn build(self, app: AppBuilder) -> AppBuilder {
+                app.config_section("media")
+            }
+        }
+
+        let builder = app().plugin(DummyMediaPlugin);
+        assert!(
+            builder.has_config_section("media"),
+            "a plugin's build() must declare its [media] config section"
+        );
+        assert!(
+            !builder.has_config_section("definitely_not_a_root"),
+            "only explicitly-declared roots are registered — the seam is fail-closed"
+        );
+    }
+
     /// Compute the omitted-router count for a builder using the same inputs
     /// `run_dump_routes_mode` feeds `omitted_router_count`: the merge count, the
     /// nest prefixes, and the declared routes that prove nest coverage.
@@ -10594,11 +10725,16 @@ mod tests {
             telemetry_provider,
             i18n_bundle,
             i18n_auto_load,
+            plugin_config_roots,
             ..
         } = builder;
 
-        let (loaded_config, _guard) =
-            load_config_and_telemetry(config_loader_factory, telemetry_provider).await;
+        let (loaded_config, _guard) = load_config_and_telemetry(
+            config_loader_factory,
+            telemetry_provider,
+            plugin_config_roots,
+        )
+        .await;
         let env = crate::config::MockEnv::new().with(
             "AUTUMN_MANIFEST_DIR",
             project.path().to_str().expect("utf-8 path"),

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -2892,20 +2892,26 @@ impl AutumnConfig {
                         _ => {}
                     }
                     path.pop();
-                } else if schema_path.is_empty() && plugin_config_roots.contains(k) {
-                    // A plugin has declared this root as its own config section
-                    // (via `AppBuilder::config_section`). It is known AND opaque:
-                    // accept it and do NOT descend — the plugin, not core, owns
-                    // validation of its subtree. The `schema_path.is_empty()` guard
-                    // fires whenever `valid_keys` is the ROOT schema set
-                    // (`schema.get("")`) — that is, both at the true top-level root
-                    // (`[media]`, path `[]`) AND under a profile prefix
-                    // (`[profile.prod.media]`, path `["profile","prod"]`), since
-                    // Autumn validates `[profile.<name>.<key>]` overrides against
-                    // the root schema. It stays strictly root-level: a key that
-                    // merely shares a plugin-root name while nested inside a known
-                    // section (e.g. `[database.media]`, `schema_path == "database"`)
-                    // is still validated normally (fail-closed). Deliberately NOT
+                } else if path.is_empty() && plugin_config_roots.contains(k) {
+                    // A plugin has declared this TOP-LEVEL root as its own config
+                    // section (via `AppBuilder::config_section`). It is known AND
+                    // opaque: accept it and do NOT descend — the plugin, not core,
+                    // owns validation of its subtree. The `path.is_empty()` guard
+                    // keeps this strictly the TRUE top-level root (`[media]`,
+                    // path `[]`), so a key that merely shares a plugin-root name
+                    // while nested inside a known section is still validated
+                    // normally (fail-closed).
+                    //
+                    // A profile-prefixed plugin root (`[profile.<env>.media]`,
+                    // path `["profile","<env>"]`) is deliberately NOT exempted and
+                    // falls through to the normal unknown-root strict rejection:
+                    // the plugin consumes ONLY the top-level `[media]` table (its
+                    // reader deserializes `root.media` directly and does not apply
+                    // Autumn's profile merge), so exempting a profile layer the
+                    // plugin cannot read would let a strict app with media settings
+                    // only under `[profile.<env>.media]` boot SILENTLY on default
+                    // plugin config instead of failing loudly. Profile-aware plugin
+                    // config is a separate, larger enhancement. Deliberately NOT
                     // added to `valid_keys`, which would make the walk recurse and
                     // flag every one of the plugin's children as unknown.
                 } else {
@@ -8199,15 +8205,17 @@ mod tests {
         );
     }
 
-    // A registered plugin root set through the inline PROFILE layer
-    // (`[profile.prod.media]`) is opaque too. Autumn validates
-    // `[profile.<name>.<key>]` overrides against the ROOT schema (that's why
-    // `[profile.prod.database]` is accepted), so a registered root must be opaque
-    // under a profile prefix exactly as it is at the true root — otherwise a
-    // strict-profiled media app still can't boot. Even with `enforce_all` the
-    // arbitrary nested children are never descended into.
+    // A registered plugin root under a PROFILE prefix (`[profile.prod.media]`)
+    // stays STRICT and must be rejected — the exemption only ever covers the
+    // TRUE top-level `[media]` table. Soundness rationale: the media plugin's
+    // reader deserializes only the top-level `root.media` and does NOT apply
+    // Autumn's profile merge, so a profile layer the plugin cannot consume must
+    // not be exempted — otherwise a strict app with media settings only under
+    // `[profile.prod.media]` would boot silently on default plugin config
+    // instead of failing loudly. (Profile-aware plugin config is a separate,
+    // larger enhancement.)
     #[test]
-    fn profile_prefixed_registered_plugin_root_is_opaque_under_enforce_all() {
+    fn strict_config_still_rejects_profile_prefixed_plugin_root() {
         let temp = tempfile::tempdir().unwrap();
         std::fs::write(
             temp.path().join("autumn.toml"),
@@ -8219,9 +8227,15 @@ mod tests {
         let env = strict_prod_env(temp.path(), true);
         let res = AutumnConfig::load_with_env_and_plugin_roots(&env, &plugin_roots(&["media"]));
         assert!(
-            res.is_ok(),
-            "a registered [media] root must be opaque under a profile prefix \
-             ([profile.prod.media]) even with enforce_all: {res:?}"
+            res.is_err(),
+            "a profile-prefixed plugin root ([profile.prod.media]) must stay strict \
+             and be rejected — the plugin reads only the top-level [media] table, so \
+             exempting the profile layer would boot silently on default config: {res:?}"
+        );
+        let err_str = format!("{:?}", res.err().unwrap());
+        assert!(
+            err_str.contains("media"),
+            "error should name the media/profile root: {err_str}"
         );
     }
 

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -2795,7 +2795,7 @@ impl AutumnConfig {
         content: &str,
         schema: &HashMap<String, HashSet<String>>,
     ) -> Vec<(String, Option<String>)> {
-        Self::validate_toml_detailed(content, schema)
+        Self::validate_toml_detailed(content, schema, &BTreeSet::new())
             .into_iter()
             .map(|(path, sug, _parent)| (path, sug))
             .collect()
@@ -2806,10 +2806,16 @@ impl AutumnConfig {
     /// correct even for quoted dotted profile names like
     /// `[profile."prod.eu".server]`). Used by strict-config classification;
     /// `validate_toml` maps this down to `(path, suggestion)`.
+    ///
+    /// `plugin_config_roots` lists top-level roots a plugin has declared via
+    /// [`config_section`](crate::app::AppBuilder::config_section): each is
+    /// treated as a known, opaque table — accepted at the root and never
+    /// descended into. An empty set restores the pre-seam behavior.
     #[must_use]
     pub(crate) fn validate_toml_detailed(
         content: &str,
         schema: &HashMap<String, HashSet<String>>,
+        plugin_config_roots: &BTreeSet<String>,
     ) -> Vec<(String, Option<String>, String)> {
         let Ok(table) = toml::from_str::<toml::Table>(content) else {
             return Vec::new();
@@ -2817,7 +2823,7 @@ impl AutumnConfig {
 
         let mut errors = Vec::new();
         let mut path = Vec::new();
-        Self::validate_toml_table(&table, &mut path, schema, &mut errors);
+        Self::validate_toml_table(&table, &mut path, schema, plugin_config_roots, &mut errors);
         errors
     }
 
@@ -2826,6 +2832,7 @@ impl AutumnConfig {
         table: &toml::Table,
         path: &mut Vec<String>,
         schema: &HashMap<String, HashSet<String>>,
+        plugin_config_roots: &BTreeSet<String>,
         errors: &mut Vec<(String, Option<String>, String)>,
     ) {
         let mut schema_path_parts = Vec::new();
@@ -2842,12 +2849,18 @@ impl AutumnConfig {
                     path.push(k.clone());
                     match val {
                         toml::Value::Table(t) => {
-                            Self::validate_toml_table(t, path, schema, errors);
+                            Self::validate_toml_table(t, path, schema, plugin_config_roots, errors);
                         }
                         toml::Value::Array(arr) => {
                             for item in arr {
                                 if let toml::Value::Table(t) = item {
-                                    Self::validate_toml_table(t, path, schema, errors);
+                                    Self::validate_toml_table(
+                                        t,
+                                        path,
+                                        schema,
+                                        plugin_config_roots,
+                                        errors,
+                                    );
                                 }
                             }
                         }
@@ -2861,18 +2874,34 @@ impl AutumnConfig {
                     path.push(k.clone());
                     match val {
                         toml::Value::Table(t) => {
-                            Self::validate_toml_table(t, path, schema, errors);
+                            Self::validate_toml_table(t, path, schema, plugin_config_roots, errors);
                         }
                         toml::Value::Array(arr) => {
                             for item in arr {
                                 if let toml::Value::Table(t) = item {
-                                    Self::validate_toml_table(t, path, schema, errors);
+                                    Self::validate_toml_table(
+                                        t,
+                                        path,
+                                        schema,
+                                        plugin_config_roots,
+                                        errors,
+                                    );
                                 }
                             }
                         }
                         _ => {}
                     }
                     path.pop();
+                } else if path.is_empty() && plugin_config_roots.contains(k) {
+                    // A plugin has declared this TOP-LEVEL root as its own config
+                    // section (via `AppBuilder::config_section`). It is known AND
+                    // opaque: accept it and do NOT descend — the plugin, not core,
+                    // owns validation of its subtree. The `path.is_empty()` guard
+                    // keeps this strictly root-level, so a key that merely shares
+                    // a plugin-root name while nested inside a known section is
+                    // still validated normally (fail-closed). Deliberately NOT
+                    // added to `valid_keys`, which would make the walk recurse and
+                    // flag every one of the plugin's children as unknown.
                 } else {
                     let mut full_path_parts = path.clone();
                     full_path_parts.push(k.clone());
@@ -2901,7 +2930,7 @@ impl AutumnConfig {
             for (k, val) in table {
                 if let toml::Value::Table(t) = val {
                     path.push(k.clone());
-                    Self::validate_toml_table(t, path, schema, errors);
+                    Self::validate_toml_table(t, path, schema, plugin_config_roots, errors);
                     path.pop();
                 } else {
                     let mut full_path_parts = path.clone();
@@ -2912,7 +2941,36 @@ impl AutumnConfig {
         } else if path.is_empty() {
             let root_keys = schema.get("").cloned().unwrap_or_default();
             for (k, val) in table {
-                if k != "profile" && !root_keys.contains(k) {
+                if k == "profile" || root_keys.contains(k) {
+                    path.push(k.clone());
+                    match val {
+                        toml::Value::Table(t) => {
+                            Self::validate_toml_table(t, path, schema, plugin_config_roots, errors);
+                        }
+                        toml::Value::Array(arr) => {
+                            for item in arr {
+                                if let toml::Value::Table(t) = item {
+                                    Self::validate_toml_table(
+                                        t,
+                                        path,
+                                        schema,
+                                        plugin_config_roots,
+                                        errors,
+                                    );
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                    path.pop();
+                } else if plugin_config_roots.contains(k) {
+                    // A plugin has declared this top-level root as its own config
+                    // section (via `AppBuilder::config_section`). It is known AND
+                    // opaque: accept it and do NOT descend — the plugin, not core,
+                    // owns validation of its subtree. Deliberately NOT injected
+                    // into `root_keys`, which would make the walk recurse and flag
+                    // every one of the plugin's children as unknown.
+                } else {
                     let mut closest: Option<&str> = None;
                     let mut min_dist = usize::MAX;
                     for valid_key in &root_keys {
@@ -2923,22 +2981,6 @@ impl AutumnConfig {
                         }
                     }
                     errors.push((k.clone(), closest.map(String::from), schema_path.clone()));
-                } else {
-                    path.push(k.clone());
-                    match val {
-                        toml::Value::Table(t) => {
-                            Self::validate_toml_table(t, path, schema, errors);
-                        }
-                        toml::Value::Array(arr) => {
-                            for item in arr {
-                                if let toml::Value::Table(t) = item {
-                                    Self::validate_toml_table(t, path, schema, errors);
-                                }
-                            }
-                        }
-                        _ => {}
-                    }
-                    path.pop();
                 }
             }
         }
@@ -3004,6 +3046,39 @@ impl AutumnConfig {
     /// # Panics
     /// Panics if the internally-built TOML table fails to re-serialize.
     pub fn load_with_env(env: &dyn Env) -> Result<Self, ConfigError> {
+        Self::load_with_env_and_plugin_roots(env, &BTreeSet::new())
+    }
+
+    /// Like [`load_with_env`](Self::load_with_env), but treats each top-level
+    /// root in `plugin_config_roots` as a **known, opaque** config table under
+    /// `server.strict_config`.
+    ///
+    /// A plugin owns a top-level `[root]` table (e.g. `[media]`) that core's
+    /// closed [`AutumnConfig`] schema knows nothing about. Without a
+    /// registration seam, the strict unknown-key check hard-rejects that root as
+    /// an unknown key and a plugin-enabled app cannot boot under
+    /// `strict_config = true`. Passing the plugin's declared roots here exempts
+    /// exactly those roots from the check: each listed root is accepted and its
+    /// subtree is **not** descended into (the plugin, not core, validates its own
+    /// section). Every other unknown root still hard-fails — the seam is
+    /// fail-closed, never a blanket "allow unknown roots" escape hatch.
+    ///
+    /// This is the roots-aware path the [`AppBuilder`](crate::app::AppBuilder)
+    /// wires up from [`config_section`](crate::app::AppBuilder::config_section)
+    /// declarations; the plain [`load_with_env`](Self::load_with_env) delegates
+    /// here with an empty set, so all existing callers are unaffected.
+    ///
+    /// # Errors
+    /// Returns [`ConfigError::Io`] if a config file cannot be read,
+    /// [`ConfigError::Parse`] if a file contains invalid TOML, or
+    /// [`ConfigError::Validation`] if a value is invalid.
+    ///
+    /// # Panics
+    /// Panics if the internally-built TOML table fails to re-serialize.
+    pub fn load_with_env_and_plugin_roots(
+        env: &dyn Env,
+        plugin_config_roots: &BTreeSet<String>,
+    ) -> Result<Self, ConfigError> {
         let selected_profile_input = resolve_profile_input(env);
         let profile =
             normalize_profile_name(&selected_profile_input).unwrap_or_else(|| "dev".to_owned());
@@ -3059,7 +3134,7 @@ impl AutumnConfig {
                 || env
                     .var("AUTUMN_SERVER__STRICT_CONFIG_ENFORCE_ALL")
                     .is_ok_and(|v| v == "true" || v == "1");
-            Self::run_strict_unknown_key_check(&toml_str, enforce_all)?;
+            Self::run_strict_unknown_key_check(&toml_str, enforce_all, plugin_config_roots)?;
         }
 
         // ── Deprecation channel (purely additive; never mutates `config`). ──────
@@ -3126,9 +3201,13 @@ impl AutumnConfig {
     /// schema-walk fix (or all keys when `enforce_all` is set) hard-fail; keys
     /// in sections that only became covered by the fix are warned about but
     /// tolerated for one release (warn-first rollout).
-    fn run_strict_unknown_key_check(toml_str: &str, enforce_all: bool) -> Result<(), ConfigError> {
+    fn run_strict_unknown_key_check(
+        toml_str: &str,
+        enforce_all: bool,
+        plugin_config_roots: &BTreeSet<String>,
+    ) -> Result<(), ConfigError> {
         let schema = Self::get_schema_keys();
-        let errors = Self::validate_toml_detailed(toml_str, &schema);
+        let errors = Self::validate_toml_detailed(toml_str, &schema, plugin_config_roots);
 
         let mut hard_errors = Vec::new();
         let mut warn_only = Vec::new();
@@ -6985,14 +7064,36 @@ pub trait ConfigLoader: Send + Sync + 'static {
 /// Delegates to [`AutumnConfig::load_with_env`] using [`OsEnv`] for environment
 /// variable reads. This is the loader used when no override is installed via
 /// [`with_config_loader`](crate::app::AppBuilder::with_config_loader).
-#[derive(Debug, Default, Clone, Copy)]
-pub struct TomlEnvConfigLoader;
+#[derive(Debug, Default, Clone)]
+pub struct TomlEnvConfigLoader {
+    /// Top-level config roots declared by plugins via
+    /// [`AppBuilder::config_section`](crate::app::AppBuilder::config_section).
+    /// Each is treated as known-and-opaque under `server.strict_config`. Empty
+    /// by default, so a bare `TomlEnvConfigLoader::new()` behaves exactly as
+    /// before the plugin config-section seam.
+    allowed_plugin_roots: BTreeSet<String>,
+}
 
 impl TomlEnvConfigLoader {
-    /// Construct a new default loader.
+    /// Construct a new default loader with no declared plugin config roots.
     #[must_use]
-    pub const fn new() -> Self {
-        Self
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Declare the plugin-owned top-level config roots this loader should treat
+    /// as known-and-opaque under `server.strict_config`.
+    ///
+    /// Wired by [`AppBuilder::run`](crate::app::AppBuilder::run) from the roots
+    /// registered through
+    /// [`config_section`](crate::app::AppBuilder::config_section), so a
+    /// plugin-enabled app boots under strict config while genuinely-unknown
+    /// roots still hard-fail. See
+    /// [`load_with_env_and_plugin_roots`](AutumnConfig::load_with_env_and_plugin_roots).
+    #[must_use]
+    pub fn with_plugin_config_roots(mut self, roots: BTreeSet<String>) -> Self {
+        self.allowed_plugin_roots = roots;
+        self
     }
 }
 
@@ -7015,7 +7116,7 @@ impl ConfigLoader for TomlEnvConfigLoader {
         let vars = crate::dotenv::resolve_dotenv_vars(&dir, &profile, &base)
             .map_err(|e| ConfigError::Dotenv(e.to_string()))?;
         let env = crate::dotenv::DotenvEnv::new(&base, vars);
-        AutumnConfig::load_with_env(&env)
+        AutumnConfig::load_with_env_and_plugin_roots(&env, &self.allowed_plugin_roots)
     }
 }
 
@@ -7319,7 +7420,7 @@ impl AutumnConfig {
 }
 
 use serde::de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -7973,6 +8074,148 @@ mod tests {
         assert!(
             err_str.contains("bogus_zzz"),
             "error should name the key: {err_str}"
+        );
+    }
+
+    // ── Plugin config-section seam (#1974 item 7) ─────────────────────────────
+    //
+    // A plugin owns a top-level `[media]` table core's closed schema knows
+    // nothing about. `load_with_env_and_plugin_roots` exempts declared roots
+    // from the strict unknown-key check as known-and-opaque, while every other
+    // unknown root still hard-fails. All tests pin `AUTUMN_ENV=prod` so the dev
+    // smart-defaults' feature-gated `[storage]` root isn't injected (storage
+    // feature off), which would otherwise be flagged independently of `[media]`.
+
+    fn plugin_roots(names: &[&str]) -> BTreeSet<String> {
+        names.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    fn strict_prod_env(dir: &std::path::Path, enforce_all: bool) -> FakeEnv {
+        let mut vars = vec![
+            ("AUTUMN_SERVER__STRICT_CONFIG".to_owned(), "true".to_owned()),
+            ("AUTUMN_ENV".to_owned(), "prod".to_owned()),
+            (
+                "AUTUMN_MANIFEST_DIR".to_owned(),
+                dir.to_str().unwrap().to_owned(),
+            ),
+        ];
+        if enforce_all {
+            vars.push((
+                "AUTUMN_SERVER__STRICT_CONFIG_ENFORCE_ALL".to_owned(),
+                "true".to_owned(),
+            ));
+        }
+        FakeEnv(vars.into_iter().collect())
+    }
+
+    // A registered `[media]` root boots green under strict_config: a
+    // media-enabled app no longer fails at boot with `unknown key "media"`.
+    #[test]
+    fn strict_config_accepts_registered_plugin_root() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("autumn.toml"),
+            "[media]\nqueue = \"media\"\n[media.mediamtx]\napi_base = \"http://localhost:9997\"\n",
+        )
+        .unwrap();
+
+        let env = strict_prod_env(temp.path(), false);
+        let res = AutumnConfig::load_with_env_and_plugin_roots(&env, &plugin_roots(&["media"]));
+        assert!(
+            res.is_ok(),
+            "a registered [media] root must boot under strict_config: {res:?}"
+        );
+    }
+
+    // Without registration the same `[media]` root is still an unknown top-level
+    // key and hard-fails — the seam is fail-closed, not a blanket allow.
+    #[test]
+    fn strict_config_rejects_unregistered_plugin_root() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("autumn.toml"),
+            "[media]\nqueue = \"media\"\n",
+        )
+        .unwrap();
+
+        let env = strict_prod_env(temp.path(), false);
+        let res = AutumnConfig::load_with_env_and_plugin_roots(&env, &BTreeSet::new());
+        assert!(
+            res.is_err(),
+            "an unregistered [media] root must still hard-fail under strict_config"
+        );
+        assert!(format!("{:?}", res.err().unwrap()).contains("media"));
+    }
+
+    // Registering `[media]` does not weaken the check for OTHER unknown roots: a
+    // genuinely-unknown top-level table still hard-fails.
+    #[test]
+    fn strict_config_still_rejects_other_unknown_root_when_plugin_registered() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("autumn.toml"),
+            "[media]\nqueue = \"media\"\n\n[definitely_not_a_root]\nx = 1\n",
+        )
+        .unwrap();
+
+        let env = strict_prod_env(temp.path(), false);
+        let res = AutumnConfig::load_with_env_and_plugin_roots(&env, &plugin_roots(&["media"]));
+        assert!(
+            res.is_err(),
+            "an unrelated unknown root must still hard-fail even with [media] registered"
+        );
+        let err_str = format!("{:?}", res.err().unwrap());
+        assert!(
+            err_str.contains("definitely_not_a_root"),
+            "error should name the unknown root: {err_str}"
+        );
+    }
+
+    // A registered root is OPAQUE: even with `strict_config_enforce_all` set,
+    // arbitrary nested children of `[media]` are never descended into and so are
+    // never flagged — the plugin owns validation of its own subtree.
+    #[test]
+    fn registered_plugin_root_is_opaque_under_enforce_all() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("autumn.toml"),
+            "[media]\nwholly_made_up = true\n[media.deeply.nested]\nalso_bogus = 42\n",
+        )
+        .unwrap();
+
+        let env = strict_prod_env(temp.path(), true);
+        let res = AutumnConfig::load_with_env_and_plugin_roots(&env, &plugin_roots(&["media"]));
+        assert!(
+            res.is_ok(),
+            "enforce_all must NOT flag children of a registered opaque root: {res:?}"
+        );
+    }
+
+    // When strict_config is OFF, behavior is unchanged: `[media]` is tolerated
+    // even with no roots registered (non-strict never ran the check).
+    #[test]
+    fn non_strict_config_tolerates_media_root_without_registration() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("autumn.toml"),
+            "[media]\nqueue = \"media\"\n",
+        )
+        .unwrap();
+
+        let env = FakeEnv(
+            [
+                ("AUTUMN_ENV".to_owned(), "prod".to_owned()),
+                (
+                    "AUTUMN_MANIFEST_DIR".to_owned(),
+                    temp.path().to_str().unwrap().to_owned(),
+                ),
+            ]
+            .into(),
+        );
+        let res = AutumnConfig::load_with_env_and_plugin_roots(&env, &BTreeSet::new());
+        assert!(
+            res.is_ok(),
+            "non-strict config must tolerate an unregistered [media] root: {res:?}"
         );
     }
 

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -2892,14 +2892,20 @@ impl AutumnConfig {
                         _ => {}
                     }
                     path.pop();
-                } else if path.is_empty() && plugin_config_roots.contains(k) {
-                    // A plugin has declared this TOP-LEVEL root as its own config
-                    // section (via `AppBuilder::config_section`). It is known AND
-                    // opaque: accept it and do NOT descend — the plugin, not core,
-                    // owns validation of its subtree. The `path.is_empty()` guard
-                    // keeps this strictly root-level, so a key that merely shares
-                    // a plugin-root name while nested inside a known section is
-                    // still validated normally (fail-closed). Deliberately NOT
+                } else if schema_path.is_empty() && plugin_config_roots.contains(k) {
+                    // A plugin has declared this root as its own config section
+                    // (via `AppBuilder::config_section`). It is known AND opaque:
+                    // accept it and do NOT descend — the plugin, not core, owns
+                    // validation of its subtree. The `schema_path.is_empty()` guard
+                    // fires whenever `valid_keys` is the ROOT schema set
+                    // (`schema.get("")`) — that is, both at the true top-level root
+                    // (`[media]`, path `[]`) AND under a profile prefix
+                    // (`[profile.prod.media]`, path `["profile","prod"]`), since
+                    // Autumn validates `[profile.<name>.<key>]` overrides against
+                    // the root schema. It stays strictly root-level: a key that
+                    // merely shares a plugin-root name while nested inside a known
+                    // section (e.g. `[database.media]`, `schema_path == "database"`)
+                    // is still validated normally (fail-closed). Deliberately NOT
                     // added to `valid_keys`, which would make the walk recurse and
                     // flag every one of the plugin's children as unknown.
                 } else {
@@ -8190,6 +8196,59 @@ mod tests {
         assert!(
             res.is_ok(),
             "enforce_all must NOT flag children of a registered opaque root: {res:?}"
+        );
+    }
+
+    // A registered plugin root set through the inline PROFILE layer
+    // (`[profile.prod.media]`) is opaque too. Autumn validates
+    // `[profile.<name>.<key>]` overrides against the ROOT schema (that's why
+    // `[profile.prod.database]` is accepted), so a registered root must be opaque
+    // under a profile prefix exactly as it is at the true root — otherwise a
+    // strict-profiled media app still can't boot. Even with `enforce_all` the
+    // arbitrary nested children are never descended into.
+    #[test]
+    fn profile_prefixed_registered_plugin_root_is_opaque_under_enforce_all() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("autumn.toml"),
+            "[profile.prod.media]\nwholly_made_up = true\n\
+             [profile.prod.media.deeply.nested]\nalso_bogus = 42\n",
+        )
+        .unwrap();
+
+        let env = strict_prod_env(temp.path(), true);
+        let res = AutumnConfig::load_with_env_and_plugin_roots(&env, &plugin_roots(&["media"]));
+        assert!(
+            res.is_ok(),
+            "a registered [media] root must be opaque under a profile prefix \
+             ([profile.prod.media]) even with enforce_all: {res:?}"
+        );
+    }
+
+    // The profile-prefix opacity is NOT a blanket allow of profile subtrees: a
+    // genuinely-unknown root under a profile prefix
+    // (`[profile.prod.definitely_not_a_root]`) still hard-fails, because it is
+    // validated against the root schema and is not a registered plugin root.
+    #[test]
+    fn strict_config_rejects_profile_prefixed_unknown_root() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("autumn.toml"),
+            "[profile.prod.definitely_not_a_root]\nx = 1\n",
+        )
+        .unwrap();
+
+        let env = strict_prod_env(temp.path(), false);
+        let res = AutumnConfig::load_with_env_and_plugin_roots(&env, &plugin_roots(&["media"]));
+        assert!(
+            res.is_err(),
+            "a profile-prefixed genuinely-unknown root must still hard-fail even \
+             with [media] registered (the fix must not blanket-allow profile subtrees)"
+        );
+        let err_str = format!("{:?}", res.err().unwrap());
+        assert!(
+            err_str.contains("definitely_not_a_root"),
+            "error should name the unknown root: {err_str}"
         );
     }
 

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -2892,7 +2892,7 @@ impl AutumnConfig {
                         _ => {}
                     }
                     path.pop();
-                } else if path.is_empty() && plugin_config_roots.contains(k) {
+                } else if path.is_empty() && plugin_config_roots.contains(k) && val.is_table() {
                     // A plugin has declared this TOP-LEVEL root as its own config
                     // section (via `AppBuilder::config_section`). It is known AND
                     // opaque: accept it and do NOT descend — the plugin, not core,
@@ -2901,6 +2901,15 @@ impl AutumnConfig {
                     // path `[]`), so a key that merely shares a plugin-root name
                     // while nested inside a known section is still validated
                     // normally (fail-closed).
+                    //
+                    // The `val.is_table()` guard keeps the exemption TABLE-only:
+                    // `config_section` declares a top-level config TABLE (`[media]`),
+                    // so a registered root written as a scalar or array
+                    // (`media = "enabled"`, `media = ["a", "b"]`) is a malformed
+                    // section — nothing would deserialize it and the app would boot
+                    // on default plugin config. A non-table value therefore does NOT
+                    // match here and falls through to the normal unknown-root strict
+                    // rejection below, failing loudly instead of booting on defaults.
                     //
                     // A profile-prefixed plugin root (`[profile.<env>.media]`,
                     // path `["profile","<env>"]`) is deliberately NOT exempted and
@@ -2975,13 +2984,19 @@ impl AutumnConfig {
                         _ => {}
                     }
                     path.pop();
-                } else if plugin_config_roots.contains(k) {
+                } else if plugin_config_roots.contains(k) && val.is_table() {
                     // A plugin has declared this top-level root as its own config
                     // section (via `AppBuilder::config_section`). It is known AND
                     // opaque: accept it and do NOT descend — the plugin, not core,
                     // owns validation of its subtree. Deliberately NOT injected
                     // into `root_keys`, which would make the walk recurse and flag
                     // every one of the plugin's children as unknown.
+                    //
+                    // The `val.is_table()` guard keeps the exemption TABLE-only
+                    // (`config_section` declares a top-level `[media]` TABLE): a
+                    // registered root written as a scalar/array is malformed and
+                    // falls through to the unknown-root strict rejection below
+                    // instead of being silently exempted and booting on defaults.
                 } else {
                     let mut closest: Option<&str> = None;
                     let mut min_dist = usize::MAX;
@@ -8138,6 +8153,53 @@ mod tests {
         assert!(
             res.is_ok(),
             "a registered [media] root must boot under strict_config: {res:?}"
+        );
+    }
+
+    // A registered plugin root written as a NON-TABLE (scalar or array) is a
+    // malformed section, not the opaque `[media]` TABLE `config_section`
+    // declares. It must NOT be exempted: nothing would deserialize it and the
+    // app would boot silently on default plugin config, so it stays a strict
+    // unknown-root HARD failure instead. Only a table-shaped `[media]` is opaque.
+    #[test]
+    fn strict_config_rejects_non_table_registered_plugin_root() {
+        // Scalar misspelling of a registered root (`media = "enabled"` instead of
+        // the `[media]` table) must hard-fail under strict_config.
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("autumn.toml"), "media = \"enabled\"\n").unwrap();
+
+        let env = strict_prod_env(temp.path(), false);
+        let res = AutumnConfig::load_with_env_and_plugin_roots(&env, &plugin_roots(&["media"]));
+        assert!(
+            res.is_err(),
+            "a scalar-valued registered root (media = \"enabled\") must hard-fail \
+             under strict_config, not be exempted as an opaque table: {res:?}"
+        );
+        assert!(
+            format!("{:?}", res.err().unwrap()).contains("media"),
+            "error should name the malformed media root"
+        );
+
+        // Array-valued registered root (`media = ["a", "b"]`) is likewise
+        // malformed and must hard-fail.
+        let temp_arr = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp_arr.path().join("autumn.toml"),
+            "media = [\"a\", \"b\"]\n",
+        )
+        .unwrap();
+
+        let env_arr = strict_prod_env(temp_arr.path(), false);
+        let res_arr =
+            AutumnConfig::load_with_env_and_plugin_roots(&env_arr, &plugin_roots(&["media"]));
+        assert!(
+            res_arr.is_err(),
+            "an array-valued registered root (media = [\"a\", \"b\"]) must hard-fail \
+             under strict_config, not be exempted as an opaque table: {res_arr:?}"
+        );
+        assert!(
+            format!("{:?}", res_arr.err().unwrap()).contains("media"),
+            "error should name the malformed media array root"
         );
     }
 

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -7077,8 +7077,10 @@ pub struct TomlEnvConfigLoader {
 impl TomlEnvConfigLoader {
     /// Construct a new default loader with no declared plugin config roots.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self {
+            allowed_plugin_roots: BTreeSet::new(),
+        }
     }
 
     /// Declare the plugin-owned top-level config roots this loader should treat


### PR DESCRIPTION
Part of #1974 (item 7).

## Before / After

**Before:** A plugin that owns a top-level config table — like `autumn-media-plugin` reading `[media]` via raw TOML — has no way to tell core about that root. Core's `AutumnConfig` schema is closed, so under `server.strict_config = true` the strict unknown-key check hard-rejects `[media]` as an unknown top-level root. A media-enabled app (and the deploy CLI that loads the same config) fails at boot with `Strict config check failed. Unknown keys in configuration: unknown key "media"`. The only workaround was to not set `strict_config`.

**After:** A plugin declares its root once, from `Plugin::build`:

```rust
impl Plugin for MediaPlugin {
    fn build(self, app: AppBuilder) -> AppBuilder {
        app.config_section("media") // [media] is now strict-config-safe
        // … routes, jobs, startup hooks …
    }
}
```

The declared root is treated as **known and opaque**: the strict check accepts `[media]` and does not descend into it (the plugin owns validation of its own subtree). Boot succeeds. The seam is **fail-closed** — only roots a plugin explicitly declares are exempt; every other unknown top-level root still hard-fails, so a typo like `[medai]` is still caught, and even with `strict_config_enforce_all` set the registered root's children are never flagged.

## How

The seam is `AppBuilder::config_section("media")`, threaded through the config loader into the strict check as an opaque-subtree allow-set:

- **`autumn/src/app.rs`**
  - New `plugin_config_roots: BTreeSet<String>` field on `AppBuilder` (initialized in `app()`, bound in every `run_*` mode's `Self` destructure).
  - `#[must_use] pub fn config_section(root: impl Into<String>) -> Self` — the declarative registration a plugin calls in `build()` — and `pub fn has_config_section(&str) -> bool` (mirrors `has_plugin`).
  - `load_config_and_telemetry` takes the declared roots and builds the default loader via `TomlEnvConfigLoader::new().with_plugin_config_roots(roots)`. A fully-custom `with_config_loader` factory owns its own strict handling and does not receive the roots (documented).
- **`autumn/src/config.rs`**
  - `TomlEnvConfigLoader` gains an `allowed_plugin_roots` field + `with_plugin_config_roots(..)`.
  - New `AutumnConfig::load_with_env_and_plugin_roots(env, roots)`; the existing `load_with_env(env)` delegates with an empty set, so all current callers/tests are untouched. Roots thread → `run_strict_unknown_key_check` → `validate_toml_detailed` → `validate_toml_table`.
  - In `validate_toml_table`, a **top-level** key (`path.is_empty()`) that is a declared plugin root is accepted without recursing into its subtree. It is deliberately not injected into the schema's root key set (that would make the walk descend and flag every child as unknown). The `path.is_empty()` guard keeps this strictly root-level, so a nested key that merely shares a plugin-root name is still validated normally. `validate_toml`'s public 2-arg signature is unchanged (passes an empty set).
- **`autumn-media-plugin/src/lib.rs`**: `MediaPlugin::build` now calls `.config_section("media")` (applied first, so every return path — including the early room-misconfig abort — carries the declaration). Raw-TOML `[media]` reading via `MediaConfig::from_autumn_toml` is unchanged.

## #1974 item 7 alignment

The recorded slice-7 suggested fix offered two options: a narrow `load_*_allowing_unknown_roots(&["media"])` seam, **or** "a general plugin config-section registry so plugin-owned roots are accepted under strict_config for both the deploy CLI and the app runtime." This implements the second, cleaner option — a declarative registry rather than an ad-hoc allowlist call. No material conflict with the suggested fix.

## Deferred: eager per-section validation

The coordinator floated optionally handing each plugin its raw `[root]` table at boot to validate uniformly. Deferred: it needs a callback stored on the builder, threaded into the loader, plus ordering/error-surface plumbing this declarative seam doesn't need — and the media plugin already fail-fast-validates its own `[media]` config in its startup hook. A `// Future:` note on `config_section` records that an eager hook can be layered on later.

## For docs batch 6

Guide-worthy bit (not edited here): **how plugin authors declare a config section** — call `app.config_section("<root>")` from `Plugin::build` so a plugin-owned top-level `[root]` table coexists with `server.strict_config = true` (known-and-opaque, fail-closed). Belongs in the extensibility guide.

## Verification

- `cargo +stable fmt --all -- --check` — clean (1.97.0 toolchain lacks the rustfmt component locally; stable used).
- `cargo +stable clippy -p autumn-web -p autumn-media-plugin --all-targets -- -D warnings` — clean (1.97.0 lacks the clippy component locally; stable used).
- `cargo +1.97 test -p autumn-web --lib config::` → **493 passed** (incl. 5 new: registered root boots green, unregistered root still rejected, unrelated unknown root still rejected under registration, registered root opaque under `enforce_all`, non-strict unchanged).
- `cargo +1.97 test -p autumn-web --lib app::` → **124 passed** (incl. `plugin_declares_config_section_via_build`).
- `cargo +1.97 test -p autumn-media-plugin` → **207 passed** (incl. `build_declares_media_config_section`, which registers the real `MediaPlugin` and asserts `has_config_section("media")`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019M6jVUM5hHR8AKzLgmxBxr)_