### PR TITLE
Port legacy `autumn migrate` up/down to the SQLite backend-flip

### DIFF
--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -352,6 +352,17 @@ fn resolve_targets(
         resolve_primary_database_url_from_sources(|key| env.var(key), config_table.as_ref());
     let shards =
         resolve_shard_database_urls_from_sources(|key| env.var(key), config_table.as_ref());
+    // Fail closed BEFORE building targets or applying anything: a SQLite
+    // primary/control target with `[[database.shards]]` entries is a topology the
+    // runtime validator (`autumn_web::config::database_backend_consistency`)
+    // rejects at boot — horizontal sharding is Postgres-only. Without this guard
+    // the new per-target SQLite apply/revert path would migrate the control file
+    // AND every shard file and report success for an app that cannot boot (issue
+    // #2058). Mirror the validator's wording.
+    if let Err(message) = reject_sqlite_primary_with_shards(control.as_deref(), &shards) {
+        eprintln!("{message}");
+        std::process::exit(1);
+    }
     match build_targets(control, shards, target) {
         Ok(targets) => (targets, config_table),
         Err(message) => {
@@ -363,6 +374,31 @@ fn resolve_targets(
             std::process::exit(1);
         }
     }
+}
+
+/// Reject a `SQLite` primary/control target when `[[database.shards]]` entries are
+/// configured — horizontal sharding is Postgres-only.
+///
+/// Mirrors the runtime validator `autumn_web::config::database_backend_consistency`
+/// (which rejects this topology at boot with the same wording), so
+/// `autumn migrate` fails closed BEFORE touching any database rather than
+/// applying migrations to the control file and every shard file for an app that
+/// cannot boot. Pure so the decision is unit-testable; `resolve_targets` prints
+/// the message and exits on `Err`. A `None` control (no primary role) or a
+/// non-SQLite control is `Ok` — matching the validator, which only guards a
+/// detected `SQLite` primary.
+fn reject_sqlite_primary_with_shards(
+    control: Option<&str>,
+    shards: &[(String, String)],
+) -> Result<(), String> {
+    if !shards.is_empty() && control.is_some_and(is_sqlite_target) {
+        return Err(
+            "\u{2717} database.shards are configured but the primary target is SQLite; \
+             database shards require the postgres backend."
+                .to_owned(),
+        );
+    }
+    Ok(())
 }
 
 /// Pure target-selection logic behind [`resolve_targets`], separated so
@@ -3100,6 +3136,46 @@ replica_url = "postgres://replica:5432/app"
     fn build_targets_all_errors_with_no_databases_at_all() {
         let error = build_targets(None, Vec::new(), &MigrateTarget::All).unwrap_err();
         assert!(error.contains("No database URL"));
+    }
+
+    #[test]
+    fn reject_sqlite_primary_with_shards_rejects_sqlite_control_and_shards() {
+        // SQLite primary + shard entries is a boot-invalid topology (sharding is
+        // Postgres-only); the guard must reject with the runtime validator's wording.
+        let err = reject_sqlite_primary_with_shards(Some("sqlite:///tmp/app.db"), &two_shards())
+            .unwrap_err();
+        assert!(
+            err.contains("database shards require the postgres backend"),
+            "guard mirrors the runtime validator wording: {err}"
+        );
+    }
+
+    #[test]
+    fn reject_sqlite_primary_with_shards_allows_sqlite_without_shards() {
+        // A plain SQLite deployment (no shards) is the normal, supported case.
+        assert_eq!(
+            reject_sqlite_primary_with_shards(Some("sqlite:///tmp/app.db"), &[]),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn reject_sqlite_primary_with_shards_allows_postgres_with_shards() {
+        // Postgres primary + shards is the intended sharded topology — never rejected.
+        assert_eq!(
+            reject_sqlite_primary_with_shards(Some("postgres://control/app"), &two_shards()),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn reject_sqlite_primary_with_shards_allows_no_control() {
+        // No primary role resolved: the runtime validator returns Ok when the
+        // primary backend is undetected, so the guard must too.
+        assert_eq!(
+            reject_sqlite_primary_with_shards(None, &two_shards()),
+            Ok(())
+        );
     }
 
     #[test]

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -270,14 +270,36 @@ pub fn run(
             run_all_targets(&targets, &migrations_dir, with_maintenance, wait);
         }
         MigrateAction::Status => {
+            // `show_status` shells out to `diesel migration list`, and the
+            // rollback/framework status readers use the Postgres migration
+            // connection — none of which is wired for the SQLite backend (the
+            // #2058 port covers `migrate` up/down only). A `sqlite://` target
+            // therefore gets a clear provider-appropriate message here instead of
+            // reaching the `diesel` subprocess and dying with a raw OS error (the
+            // `diesel` CLI preflight was deliberately skipped for all-SQLite runs).
+            let mut sqlite_unsupported = false;
             for (label, url) in &targets {
                 eprintln!("\u{2500}\u{2500} {label} \u{2500}\u{2500}");
+                if is_sqlite_target(url) {
+                    eprintln!(
+                        "  \u{2717} `autumn migrate status` is not supported under the SQLite \
+                         backend. The #2058 port covers `autumn migrate` (up) and \
+                         `autumn migrate down` only \u{2014} run those to apply or roll back a \
+                         `sqlite://` database."
+                    );
+                    eprintln!();
+                    sqlite_unsupported = true;
+                    continue;
+                }
                 show_status(url, &migrations_dir);
                 show_rollback_availability(url, &migrations_dir);
                 // Shard targets only require the shard framework migrations, so
                 // report against that set instead of the full control-plane one.
                 show_framework_status(url, label.starts_with("shard:"));
                 eprintln!();
+            }
+            if sqlite_unsupported {
+                std::process::exit(1);
             }
         }
         MigrateAction::Check | MigrateAction::Down(_) | MigrateAction::Baseline(_) => {

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -40,6 +40,101 @@ use autumn_web::migrate::{
 /// Default directory containing Diesel migration files.
 const DEFAULT_MIGRATIONS_DIR: &str = "migrations";
 
+/// Seam message shown when a `sqlite://` database URL is resolved but this CLI
+/// build targets Postgres only. The `sqlite` backend-flip is a separate,
+/// non-default cargo feature that must never be co-built with the default
+/// Postgres backend (see `autumn-cli/Cargo.toml`).
+///
+/// Only referenced by the `#[cfg(not(feature = "sqlite"))]` seams, so it is gated
+/// off the `sqlite` build to avoid a dead-code warning there.
+#[cfg(not(feature = "sqlite"))]
+const SQLITE_FEATURE_MSG: &str = "`autumn migrate` detected a SQLite database URL, but this CLI build targets Postgres only. \
+     Rebuild with `--no-default-features --features sqlite` to run migrations against a \
+     `sqlite://` database (the sqlite backend-flip must never be co-built with the default \
+     Postgres backend).";
+
+/// Whether `database_url` names a `SQLite` target (`sqlite:` / `file:` scheme).
+///
+/// A Postgres URL, a libpq keyword/value string, or any unrecognized target is
+/// treated as Postgres — i.e. it keeps the historical advisory-locked apply/
+/// rollback path — so only an explicit `sqlite://` (or `sqlite:` / `file:`) URL
+/// routes to the unlocked `SQLite` harness path (issue #2058). This is
+/// backend-detection, independent of the compiled feature: under the default
+/// build a detected `SQLite` URL still routes here and then hits the
+/// [`SQLITE_FEATURE_MSG`] seam.
+fn is_sqlite_target(database_url: &str) -> bool {
+    matches!(
+        autumn_web::config::DatabaseBackend::detect(database_url),
+        Some(autumn_web::config::DatabaseBackend::Sqlite)
+    )
+}
+
+/// Whether every resolved target is a `SQLite` URL, used to skip the Postgres-only
+/// `diesel` CLI preflight (`check_diesel_cli`) — the `SQLite` apply path uses the
+/// in-process harness, never the `diesel` subprocess.
+fn all_targets_sqlite(targets: &[(String, String)]) -> bool {
+    !targets.is_empty() && targets.iter().all(|(_, url)| is_sqlite_target(url))
+}
+
+/// Apply pending user migrations against a `SQLite` database through the unlocked
+/// diesel harness (no advisory lock, no `diesel` subprocess — issue #1999/#2036
+/// precedent). Real only under the `sqlite` feature; the default build returns
+/// the [`SQLITE_FEATURE_MSG`] seam.
+#[cfg(feature = "sqlite")]
+fn apply_pending_sqlite_cli(
+    database_url: &str,
+    migrations_dir: &Path,
+) -> Result<MigrationResult, MigrationError> {
+    let migrations =
+        diesel_migrations::FileBasedMigrations::from_path(migrations_dir).map_err(|e| {
+            MigrationError::Migration(format!(
+                "failed to read migrations directory {}: {e}",
+                migrations_dir.display()
+            ))
+        })?;
+    autumn_web::migrate::run_pending_sqlite(database_url, migrations)
+}
+
+/// `SQLite` apply seam in the default (Postgres-only) build — references no
+/// `SQLite` symbol and points the operator at the backend-flip feature.
+#[cfg(not(feature = "sqlite"))]
+fn apply_pending_sqlite_cli(
+    _database_url: &str,
+    _migrations_dir: &Path,
+) -> Result<MigrationResult, MigrationError> {
+    Err(MigrationError::Migration(SQLITE_FEATURE_MSG.to_owned()))
+}
+
+/// Return the applied user migrations for a target, routing an explicit
+/// `sqlite://` URL to the unlocked `SQLite` harness path and everything else to
+/// the historical Postgres path.
+fn applied_user_migrations_for_target(
+    database_url: &str,
+    migrations_dir: &Path,
+) -> Result<Vec<AppliedUserMigration>, MigrationError> {
+    if is_sqlite_target(database_url) {
+        applied_user_migrations_sqlite_cli(database_url, migrations_dir)
+    } else {
+        autumn_web::migrate::applied_user_migrations(database_url, migrations_dir)
+    }
+}
+
+#[cfg(feature = "sqlite")]
+fn applied_user_migrations_sqlite_cli(
+    database_url: &str,
+    migrations_dir: &Path,
+) -> Result<Vec<AppliedUserMigration>, MigrationError> {
+    autumn_web::migrate::applied_user_migrations_sqlite(database_url, migrations_dir)
+}
+
+#[cfg(not(feature = "sqlite"))]
+fn applied_user_migrations_sqlite_cli(
+    _database_url: &str,
+    _migrations_dir: &Path,
+) -> Result<Vec<AppliedUserMigration>, MigrationError> {
+    Err(MigrationError::Migration(SQLITE_FEATURE_MSG.to_owned()))
+}
+
 /// Arguments for `autumn migrate down`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DownArgs {
@@ -154,8 +249,13 @@ pub fn run(
     // 2. Resolve migrations directory
     let migrations_dir = resolve_migrations_dir();
 
-    // 3. Check that diesel CLI is available
-    check_diesel_cli();
+    // 3. Check that diesel CLI is available — but only when a target actually
+    //    needs the `diesel` subprocess. The SQLite apply path uses the in-process
+    //    harness (issue #2058), so an all-SQLite run must not demand a
+    //    Postgres-oriented `diesel` CLI on PATH.
+    if !all_targets_sqlite(&targets) {
+        check_diesel_cli();
+    }
 
     // 4. Enable maintenance mode if requested
     if with_maintenance && *action == MigrateAction::Run {
@@ -401,6 +501,15 @@ fn run_single_target(
 ) -> bool {
     use autumn_web::migrate::{DEFAULT_LOCK_WAIT_TIMEOUT, hold_migration_lock, wait_for_database};
 
+    // SQLite (issue #2058): a single-writer local database has no advisory lock,
+    // no `diesel` subprocess, no Postgres content-checksum table, and no
+    // control-plane framework migrations — the unlocked harness applies the user
+    // migrations directly (mirrors `autumn schema migrate`, #1999/#2036). The
+    // Postgres path below is unchanged.
+    if is_sqlite_target(database_url) {
+        return run_single_target_sqlite(database_url, migrations_dir);
+    }
+
     // Startup wait — only when enabled (startup_wait_secs > 0 or --wait N).
     // When wait == Duration::ZERO we skip entirely so the existing fail-fast
     // path is preserved byte-for-byte (AC #6).
@@ -509,6 +618,36 @@ fn run_single_target(
     }
 
     true
+}
+
+/// Apply pending user migrations to a single `SQLite` target through the unlocked
+/// harness (issue #2058). Returns whether it succeeded.
+///
+/// Deliberately mirrors `autumn schema migrate`'s `SQLite` path: no advisory lock
+/// (`SQLite` is single-writer, #1999), no `diesel` subprocess, no Postgres
+/// content-checksum bookkeeping, and no control-plane / shard framework
+/// migrations (their DDL is Postgres-specific and is never applied to a `SQLite`
+/// database). Only the project's `migrations/` user set is applied.
+fn run_single_target_sqlite(database_url: &str, migrations_dir: &str) -> bool {
+    let dir = std::path::Path::new(migrations_dir);
+    eprintln!("  Running pending migrations (SQLite, unlocked harness)...\n");
+    match apply_pending_sqlite_cli(database_url, dir) {
+        Ok(result) if result.applied.is_empty() => {
+            eprintln!("\u{2713} Migrations are already up to date.");
+            true
+        }
+        Ok(result) => {
+            for migration in &result.applied {
+                eprintln!("  Applied {migration}");
+            }
+            eprintln!("\n\u{2713} Migrations applied successfully.");
+            true
+        }
+        Err(e) => {
+            eprintln!("\u{2717} {e}");
+            false
+        }
+    }
 }
 
 /// Fail-fast validation of every applied migration's checksum against its
@@ -1604,9 +1743,7 @@ fn preflight_rollback_target(
     dir: &Path,
     label: &str,
 ) -> Vec<String> {
-    use autumn_web::migrate::applied_user_migrations;
-
-    let applied = applied_user_migrations(database_url, dir).unwrap_or_else(|e| {
+    let applied = applied_user_migrations_for_target(database_url, dir).unwrap_or_else(|e| {
         eprintln!("\u{2717} Could not preflight rollback for {label}: {e}");
         std::process::exit(1);
     });
@@ -1660,12 +1797,15 @@ fn reject_divergent_rollback_plans(plans: &[(String, Vec<String>)]) {
     std::process::exit(1);
 }
 
-/// Roll back the planned user migrations on a single target database, under the
-/// migration advisory lock. Returns the number of migrations reverted.
+/// Roll back the planned user migrations on a single target database. Returns the
+/// number of migrations reverted.
 ///
-/// Listing applied migrations, building the plan, and preflighting `down.sql`
-/// all happen inside the `plan` closure (under the lock) so the plan cannot go
-/// stale between read and execute (e.g. two concurrent `down` runs).
+/// Postgres runs under the migration advisory lock; a `sqlite://` target uses the
+/// unlocked harness (`SQLite` is single-writer — no cross-process serialization is
+/// needed, issue #2058). Listing applied migrations, building the plan, and
+/// preflighting `down.sql` all happen inside the `plan` closure (on the same
+/// connection) so the plan cannot go stale between read and execute (e.g. two
+/// concurrent Postgres `down` runs).
 /// `maintenance_enabled` is shared across targets so maintenance mode is
 /// enabled at most once, the first time any target has work to do.
 ///
@@ -1684,59 +1824,108 @@ fn run_down_target(
     maintenance_enabled: &mut bool,
     preflighted_plan: &[String],
 ) -> Result<usize, autumn_web::migrate::MigrationError> {
-    use autumn_web::migrate::{MigrationError, revert_user_migrations_locked};
+    use autumn_web::migrate::MigrationError;
 
-    revert_user_migrations_locked(
-        database_url,
-        dir,
-        None,
-        |applied| {
-            let plan = build_rollback_plan(args, applied);
+    // The plan/execute closures are backend-agnostic; only the revert engine
+    // differs — Postgres runs under the advisory lock, SQLite through the
+    // unlocked harness (issue #2058, single-writer #1999). The plan is still
+    // rebuilt and re-validated under the same connection in both.
+    let plan = |applied: &[AppliedUserMigration]| -> Result<Vec<String>, MigrationError> {
+        let plan = build_rollback_plan(args, applied);
 
-            // Recheck under the lock that this target's plan still matches what
-            // preflight saw (and verified uniform across targets). A concurrent
-            // migrate/down may have changed the applied history in the window
-            // between preflight and acquiring this lock; rolling back a now-
-            // different version list would diverge this target from the ones
-            // already reverted.
-            if plan != preflighted_plan {
-                return Err(MigrationError::Migration(format!(
-                    "rollback plan for this target changed under the lock since preflight \
+        // Recheck under the lock that this target's plan still matches what
+        // preflight saw (and verified uniform across targets). A concurrent
+        // migrate/down may have changed the applied history in the window
+        // between preflight and acquiring this lock; rolling back a now-
+        // different version list would diverge this target from the ones
+        // already reverted.
+        if plan != preflighted_plan {
+            return Err(MigrationError::Migration(format!(
+                "rollback plan for this target changed under the lock since preflight \
                      (a concurrent migrate/down likely altered its applied history). \
                      Preflighted [{}] but now [{}]. Aborting before mutating this target; \
                      re-run `autumn migrate down` once migrations are quiesced.",
-                    preflighted_plan.join(", "),
-                    plan.join(", "),
-                )));
-            }
+                preflighted_plan.join(", "),
+                plan.join(", "),
+            )));
+        }
 
-            if plan.is_empty() {
-                eprintln!("  \u{2713} Nothing to roll back.");
-                return Ok(plan);
-            }
+        if plan.is_empty() {
+            eprintln!("  \u{2713} Nothing to roll back.");
+            return Ok(plan);
+        }
 
-            // Re-validate under the lock (defense-in-depth against the plan
-            // going stale between the up-front preflight and here).
-            check_rollback_plan_revertable(applied, &plan);
+        // Re-validate under the lock (defense-in-depth against the plan
+        // going stale between the up-front preflight and here).
+        check_rollback_plan_revertable(applied, &plan);
 
-            // Preflight passed: enable maintenance mode (if requested and not
-            // already enabled for an earlier target) before we mutate schema,
-            // then stream the rollback.
-            if with_maintenance && !*maintenance_enabled {
-                enable_maintenance_for_migrate();
-                *maintenance_enabled = true;
-            }
-            eprintln!("  Rolling back {} migration(s)...\n", plan.len());
-            Ok(plan)
-        },
-        |r| {
-            eprintln!(
-                "  \u{2713} Rolled back {}  ({}ms)",
-                r.name,
-                r.duration.as_millis()
-            );
-        },
+        // Preflight passed: enable maintenance mode (if requested and not
+        // already enabled for an earlier target) before we mutate schema,
+        // then stream the rollback.
+        if with_maintenance && !*maintenance_enabled {
+            enable_maintenance_for_migrate();
+            *maintenance_enabled = true;
+        }
+        eprintln!("  Rolling back {} migration(s)...\n", plan.len());
+        Ok(plan)
+    };
+    let on_reverted = |r: &autumn_web::migrate::RevertedMigration| {
+        eprintln!(
+            "  \u{2713} Rolled back {}  ({}ms)",
+            r.name,
+            r.duration.as_millis()
+        );
+    };
+
+    if is_sqlite_target(database_url) {
+        revert_user_migrations_sqlite_cli(database_url, dir, plan, on_reverted)
+    } else {
+        autumn_web::migrate::revert_user_migrations_locked(
+            database_url,
+            dir,
+            None,
+            plan,
+            on_reverted,
+        )
+    }
+}
+
+/// Revert user migrations on a `SQLite` target through the unlocked harness
+/// (issue #2058). Real only under the `sqlite` feature; the default build returns
+/// the [`SQLITE_FEATURE_MSG`] seam.
+#[cfg(feature = "sqlite")]
+fn revert_user_migrations_sqlite_cli<P, F>(
+    database_url: &str,
+    migrations_dir: &Path,
+    plan: P,
+    on_reverted: F,
+) -> Result<usize, autumn_web::migrate::MigrationError>
+where
+    P: FnOnce(&[AppliedUserMigration]) -> Result<Vec<String>, autumn_web::migrate::MigrationError>,
+    F: FnMut(&autumn_web::migrate::RevertedMigration),
+{
+    autumn_web::migrate::revert_user_migrations_sqlite(
+        database_url,
+        migrations_dir,
+        plan,
+        on_reverted,
     )
+}
+
+#[cfg(not(feature = "sqlite"))]
+fn revert_user_migrations_sqlite_cli<P, F>(
+    _database_url: &str,
+    _migrations_dir: &Path,
+    _plan: P,
+    _on_reverted: F,
+) -> Result<usize, autumn_web::migrate::MigrationError>
+where
+    P: FnOnce(&[AppliedUserMigration]) -> Result<Vec<String>, autumn_web::migrate::MigrationError>,
+    F: FnMut(&autumn_web::migrate::RevertedMigration),
+{
+    Err(autumn_web::migrate::MigrationError::Migration(
+        SQLITE_FEATURE_MSG.to_owned(),
+    ))
 }
 
 /// Show rollback availability for all applied user migrations.

--- a/autumn-cli/src/migrate.rs
+++ b/autumn-cli/src/migrate.rs
@@ -352,14 +352,15 @@ fn resolve_targets(
         resolve_primary_database_url_from_sources(|key| env.var(key), config_table.as_ref());
     let shards =
         resolve_shard_database_urls_from_sources(|key| env.var(key), config_table.as_ref());
-    // Fail closed BEFORE building targets or applying anything: a SQLite
-    // primary/control target with `[[database.shards]]` entries is a topology the
-    // runtime validator (`autumn_web::config::database_backend_consistency`)
-    // rejects at boot — horizontal sharding is Postgres-only. Without this guard
-    // the new per-target SQLite apply/revert path would migrate the control file
-    // AND every shard file and report success for an app that cannot boot (issue
-    // #2058). Mirror the validator's wording.
-    if let Err(message) = reject_sqlite_primary_with_shards(control.as_deref(), &shards) {
+    // Fail closed BEFORE building targets or applying anything: SQLite anywhere
+    // in a sharded topology is rejected at boot by the runtime guards
+    // (`autumn/src/config.rs` `database_backend_consistency` + shard-URL
+    // Postgres-only validation, and `autumn/src/app.rs`
+    // `sqlite_sharding_unsupported_guard`). Without this the new per-target
+    // SQLite apply/revert path would create + migrate the control file and/or a
+    // SQLite shard file and report success for an app that cannot boot (issue
+    // #2058). Mirror the runtime guard's wording.
+    if let Err(message) = reject_sqlite_sharding_topology(control.as_deref(), &shards) {
         eprintln!("{message}");
         std::process::exit(1);
     }
@@ -376,25 +377,43 @@ fn resolve_targets(
     }
 }
 
-/// Reject a `SQLite` primary/control target when `[[database.shards]]` entries are
-/// configured — horizontal sharding is Postgres-only.
+/// Reject any `SQLite` target within a sharded topology — horizontal sharding is
+/// Postgres-only.
 ///
-/// Mirrors the runtime validator `autumn_web::config::database_backend_consistency`
-/// (which rejects this topology at boot with the same wording), so
-/// `autumn migrate` fails closed BEFORE touching any database rather than
-/// applying migrations to the control file and every shard file for an app that
-/// cannot boot. Pure so the decision is unit-testable; `resolve_targets` prints
-/// the message and exits on `Err`. A `None` control (no primary role) or a
-/// non-SQLite control is `Ok` — matching the validator, which only guards a
-/// detected `SQLite` primary.
-fn reject_sqlite_primary_with_shards(
+/// Mirrors the runtime guard `autumn_web`'s `sqlite_sharding_unsupported_guard`
+/// (and the `database_backend_consistency` / shard-URL Postgres-only validators)
+/// so `autumn migrate` fails closed BEFORE touching any database, rather than
+/// creating + migrating a `SQLite` control or shard file for an app that cannot
+/// boot. Two branches, matching the runtime guard:
+///
+/// * a detected-`SQLite` **control** with shard entries present, and
+/// * **any shard** whose resolved `primary_url` is a detected `SQLite` backend
+///   (regardless of the control backend — the shard loop would otherwise route it
+///   through the Postgres-only harness).
+///
+/// A non-`SQLite` control with all-Postgres shards (the intended sharded
+/// topology), and a control-less non-sharded deployment, both pass. Pure so the
+/// decision is unit-testable; `resolve_targets` prints the message and exits on
+/// `Err`.
+fn reject_sqlite_sharding_topology(
     control: Option<&str>,
     shards: &[(String, String)],
 ) -> Result<(), String> {
     if !shards.is_empty() && control.is_some_and(is_sqlite_target) {
         return Err(
-            "\u{2717} database.shards are configured but the primary target is SQLite; \
-             database shards require the postgres backend."
+            "\u{2717} SQLite deployments do not support sharding. The configured sqlite:// \
+             control target has shard entries configured, which is a Postgres-only capability \
+             \u{2014} remove the shard configuration to run on SQLite, or use a Postgres control \
+             database. Tracking: #1614."
+                .to_owned(),
+        );
+    }
+    if shards.iter().any(|(_, url)| is_sqlite_target(url)) {
+        return Err(
+            "\u{2717} SQLite deployments do not support sharding. A configured shard targets a \
+             SQLite database, and per-shard migration is a Postgres-only capability \u{2014} \
+             remove the SQLite shard configuration to run on SQLite, or use Postgres shard \
+             targets. Tracking: #1614."
                 .to_owned(),
         );
     }
@@ -3138,44 +3157,71 @@ replica_url = "postgres://replica:5432/app"
         assert!(error.contains("No database URL"));
     }
 
+    fn sqlite_shard() -> Vec<(String, String)> {
+        vec![("shard0".to_owned(), "sqlite:///tmp/shard0.db".to_owned())]
+    }
+
     #[test]
-    fn reject_sqlite_primary_with_shards_rejects_sqlite_control_and_shards() {
-        // SQLite primary + shard entries is a boot-invalid topology (sharding is
-        // Postgres-only); the guard must reject with the runtime validator's wording.
-        let err = reject_sqlite_primary_with_shards(Some("sqlite:///tmp/app.db"), &two_shards())
+    fn reject_sqlite_sharding_rejects_sqlite_control_and_shards() {
+        // SQLite control + shard entries is a boot-invalid topology (sharding is
+        // Postgres-only); the guard mirrors the runtime guard's wording (#1614).
+        let err = reject_sqlite_sharding_topology(Some("sqlite:///tmp/app.db"), &two_shards())
             .unwrap_err();
         assert!(
-            err.contains("database shards require the postgres backend"),
-            "guard mirrors the runtime validator wording: {err}"
+            err.contains("do not support sharding") && err.contains("#1614"),
+            "guard names the SQLite sharding situation clearly: {err}"
         );
     }
 
     #[test]
-    fn reject_sqlite_primary_with_shards_allows_sqlite_without_shards() {
+    fn reject_sqlite_sharding_rejects_postgres_control_with_sqlite_shard() {
+        // The sibling case: a Postgres (or any non-sqlite) control with a shard
+        // whose primary_url is sqlite:// — the shard loop would migrate that
+        // sqlite file. Must be rejected regardless of the control backend.
+        let err = reject_sqlite_sharding_topology(Some("postgres://control/app"), &sqlite_shard())
+            .unwrap_err();
+        assert!(
+            err.contains("do not support sharding")
+                && err.contains("shard")
+                && err.contains("#1614"),
+            "guard rejects a sqlite shard target: {err}"
+        );
+    }
+
+    #[test]
+    fn reject_sqlite_sharding_rejects_no_control_with_sqlite_shard() {
+        // No control role, but a sqlite shard target: still rejected (the shard
+        // loop would route it through the Postgres-only harness).
+        let err = reject_sqlite_sharding_topology(None, &sqlite_shard()).unwrap_err();
+        assert!(
+            err.contains("do not support sharding") && err.contains("#1614"),
+            "guard rejects a sqlite shard even without a control: {err}"
+        );
+    }
+
+    #[test]
+    fn reject_sqlite_sharding_allows_sqlite_without_shards() {
         // A plain SQLite deployment (no shards) is the normal, supported case.
         assert_eq!(
-            reject_sqlite_primary_with_shards(Some("sqlite:///tmp/app.db"), &[]),
+            reject_sqlite_sharding_topology(Some("sqlite:///tmp/app.db"), &[]),
             Ok(())
         );
     }
 
     #[test]
-    fn reject_sqlite_primary_with_shards_allows_postgres_with_shards() {
-        // Postgres primary + shards is the intended sharded topology — never rejected.
+    fn reject_sqlite_sharding_allows_postgres_with_postgres_shards() {
+        // Postgres control + all-Postgres shards is the intended sharded topology
+        // — never rejected.
         assert_eq!(
-            reject_sqlite_primary_with_shards(Some("postgres://control/app"), &two_shards()),
+            reject_sqlite_sharding_topology(Some("postgres://control/app"), &two_shards()),
             Ok(())
         );
     }
 
     #[test]
-    fn reject_sqlite_primary_with_shards_allows_no_control() {
-        // No primary role resolved: the runtime validator returns Ok when the
-        // primary backend is undetected, so the guard must too.
-        assert_eq!(
-            reject_sqlite_primary_with_shards(None, &two_shards()),
-            Ok(())
-        );
+    fn reject_sqlite_sharding_allows_no_control_no_shards() {
+        // No primary role and no shards: nothing to reject.
+        assert_eq!(reject_sqlite_sharding_topology(None, &[]), Ok(()));
     }
 
     #[test]

--- a/autumn-cli/tests/integration/migrate_sqlite.rs
+++ b/autumn-cli/tests/integration/migrate_sqlite.rs
@@ -1,0 +1,132 @@
+//! `SQLite` integration test for the legacy `autumn migrate` verb (issue #2058).
+//!
+//! Compiles and runs **only** under the non-default `sqlite` cargo feature (the
+//! backend-flip). A default `cargo test -p autumn-cli` neither compiles nor
+//! requires this file — it is `#[cfg(feature = "sqlite")]`-gated in
+//! `tests/integration/mod.rs` and additionally guarded here.
+//!
+//! Unlike the Postgres path this needs **no Docker** and **no `diesel` CLI**: it
+//! drives `autumn migrate` (up) and `autumn migrate down` against a temp-FILE
+//! `SQLite` database (not `:memory:`, which the runtime rejects for migrations)
+//! through the unlocked in-process harness, so it is a real, runnable end-to-end
+//! check:
+//!
+//!   `cargo test -p autumn-cli --no-default-features --features sqlite --test cli_tests migrate_sqlite`
+#![cfg(feature = "sqlite")]
+
+use std::path::Path;
+use std::process::Command;
+
+use diesel::prelude::*;
+use diesel::sql_query;
+
+const fn autumn_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_autumn")
+}
+
+fn run_autumn(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String, Option<i32>) {
+    let output = Command::new(autumn_bin())
+        .args(args)
+        .current_dir(dir)
+        .envs(envs.iter().copied())
+        .output()
+        .expect("failed to run autumn");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code(),
+    )
+}
+
+#[derive(QueryableByName)]
+struct TableName {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    #[allow(dead_code)]
+    name: String,
+}
+
+/// Open the file-backed `SQLite` database directly (not through the CLI) and report
+/// whether a `posts` table exists — the authoritative schema assertion.
+fn posts_table_exists(db_path: &Path) -> bool {
+    let mut conn = SqliteConnection::establish(db_path.to_str().expect("utf-8 path"))
+        .expect("open sqlite file");
+    let rows: Vec<TableName> =
+        sql_query("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'posts'")
+            .load(&mut conn)
+            .expect("query sqlite_master");
+    !rows.is_empty()
+}
+
+#[test]
+fn migrate_up_then_down_against_a_sqlite_file() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+
+    // A real user migration on disk: create/drop a `posts` table.
+    let migration = root.join("migrations/20990101000000_create_posts");
+    std::fs::create_dir_all(&migration).expect("mkdir migrations");
+    std::fs::write(
+        migration.join("up.sql"),
+        "CREATE TABLE posts (id INTEGER PRIMARY KEY, title TEXT NOT NULL);\n",
+    )
+    .expect("write up.sql");
+    std::fs::write(migration.join("down.sql"), "DROP TABLE posts;\n").expect("write down.sql");
+
+    // A file-backed SQLite database inside the temp dir (NOT `:memory:` — the
+    // runtime rejects in-memory targets for registered migrations).
+    let db_path = root.join("app.db");
+    let url = format!("sqlite://{}", db_path.display());
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    // 1. `autumn migrate` (up): applies the user migration through the unlocked
+    //    SQLite harness — no advisory lock, no `diesel` CLI subprocess.
+    let (_out, err, code) = run_autumn(root, &["migrate"], &envs);
+    assert_eq!(code, Some(0), "migrate up failed (exit={code:?})\n{err}");
+    assert!(
+        err.contains("Migrations applied successfully"),
+        "up reports success: {err}"
+    );
+    assert!(db_path.is_file(), "sqlite db file created");
+    assert!(
+        posts_table_exists(&db_path),
+        "posts table exists after migrate up"
+    );
+
+    // 2. A second `autumn migrate` is a clean, idempotent no-op.
+    let (_out2, err2, code2) = run_autumn(root, &["migrate"], &envs);
+    assert_eq!(code2, Some(0), "second migrate up failed: {err2}");
+    assert!(
+        err2.contains("already up to date"),
+        "second up is a no-op: {err2}"
+    );
+
+    // 3. `autumn migrate down`: reverts the user migration through the unlocked
+    //    SQLite harness, dropping the table and clearing the applied row.
+    let (_out3, err3, code3) = run_autumn(root, &["migrate", "down"], &envs);
+    assert_eq!(
+        code3,
+        Some(0),
+        "migrate down failed (exit={code3:?})\n{err3}"
+    );
+    assert!(
+        err3.contains("rolled back"),
+        "down reports rollback: {err3}"
+    );
+    assert!(
+        !posts_table_exists(&db_path),
+        "posts table is gone after migrate down"
+    );
+
+    // 4. After the rollback the migration is pending again — `autumn migrate`
+    //    re-applies it, proving the down genuinely removed the applied record.
+    let (_out4, err4, code4) = run_autumn(root, &["migrate"], &envs);
+    assert_eq!(code4, Some(0), "re-apply after down failed: {err4}");
+    assert!(
+        err4.contains("Migrations applied successfully"),
+        "re-apply after down: {err4}"
+    );
+    assert!(
+        posts_table_exists(&db_path),
+        "posts table exists again after re-apply"
+    );
+}

--- a/autumn-cli/tests/integration/migrate_sqlite.rs
+++ b/autumn-cli/tests/integration/migrate_sqlite.rs
@@ -130,3 +130,40 @@ fn migrate_up_then_down_against_a_sqlite_file() {
         "posts table exists again after re-apply"
     );
 }
+
+/// `autumn migrate status` is Postgres-only (it shells out to `diesel migration
+/// list` and reads the Postgres migration connection). Under the `SQLite` backend
+/// it must fail with a CLEAR provider-appropriate message rather than reaching
+/// the `diesel` subprocess and dying with a raw "No such file or directory" OS
+/// error — the `diesel` CLI preflight is deliberately skipped for all-SQLite runs
+/// (issue #2058, codex P2).
+#[test]
+fn migrate_status_under_sqlite_is_a_clear_provider_error() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+
+    let migration = root.join("migrations/20990101000000_create_posts");
+    std::fs::create_dir_all(&migration).expect("mkdir migrations");
+    std::fs::write(
+        migration.join("up.sql"),
+        "CREATE TABLE posts (id INTEGER PRIMARY KEY, title TEXT NOT NULL);\n",
+    )
+    .expect("write up.sql");
+    std::fs::write(migration.join("down.sql"), "DROP TABLE posts;\n").expect("write down.sql");
+
+    let db_path = root.join("app.db");
+    let url = format!("sqlite://{}", db_path.display());
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_out, err, code) = run_autumn(root, &["migrate", "status"], &envs);
+    assert_eq!(code, Some(1), "status under sqlite exits non-zero: {err}");
+    assert!(
+        err.contains("not supported under the SQLite backend"),
+        "status under sqlite gives a provider-appropriate message: {err}"
+    );
+    // It must NOT reach the `diesel` subprocess (the bug it replaces).
+    assert!(
+        !err.contains("diesel migration list") && !err.contains("os error 2"),
+        "status under sqlite must not invoke the diesel subprocess: {err}"
+    );
+}

--- a/autumn-cli/tests/integration/migrate_sqlite.rs
+++ b/autumn-cli/tests/integration/migrate_sqlite.rs
@@ -167,3 +167,57 @@ fn migrate_status_under_sqlite_is_a_clear_provider_error() {
         "status under sqlite must not invoke the diesel subprocess: {err}"
     );
 }
+
+/// A `SQLite` control/primary URL together with `[[database.shards]]` entries is a
+/// topology the runtime validator (`database_backend_consistency`) rejects at
+/// boot — horizontal sharding is Postgres-only. `autumn migrate` must fail closed
+/// with that provider-appropriate message BEFORE applying anything, rather than
+/// migrating the control file and every shard file for an app that cannot boot
+/// (issue #2058, codex).
+#[test]
+fn migrate_sqlite_control_with_shards_is_rejected_before_applying() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+
+    let migration = root.join("migrations/20990101000000_create_posts");
+    std::fs::create_dir_all(&migration).expect("mkdir migrations");
+    std::fs::write(
+        migration.join("up.sql"),
+        "CREATE TABLE posts (id INTEGER PRIMARY KEY, title TEXT NOT NULL);\n",
+    )
+    .expect("write up.sql");
+    std::fs::write(migration.join("down.sql"), "DROP TABLE posts;\n").expect("write down.sql");
+
+    let control_db = root.join("app.db");
+    let shard_db = root.join("shard0.db");
+    let control_url = format!("sqlite://{}", control_db.display());
+    let shard_url = format!("sqlite://{}", shard_db.display());
+    let envs = [
+        ("AUTUMN_DATABASE__URL", control_url.as_str()),
+        ("AUTUMN_DATABASE__SHARDS__0__NAME", "shard0"),
+        (
+            "AUTUMN_DATABASE__SHARDS__0__PRIMARY_URL",
+            shard_url.as_str(),
+        ),
+    ];
+
+    let (_out, err, code) = run_autumn(root, &["migrate"], &envs);
+    assert_eq!(
+        code,
+        Some(1),
+        "sqlite control + shards exits non-zero: {err}"
+    );
+    assert!(
+        err.contains("database shards require the postgres backend"),
+        "clear provider-appropriate rejection: {err}"
+    );
+    // Fail-closed: NOTHING was applied to any file — neither db exists.
+    assert!(
+        !control_db.exists(),
+        "control sqlite file must not be created/migrated"
+    );
+    assert!(
+        !shard_db.exists(),
+        "shard sqlite file must not be created/migrated"
+    );
+}

--- a/autumn-cli/tests/integration/migrate_sqlite.rs
+++ b/autumn-cli/tests/integration/migrate_sqlite.rs
@@ -168,17 +168,9 @@ fn migrate_status_under_sqlite_is_a_clear_provider_error() {
     );
 }
 
-/// A `SQLite` control/primary URL together with `[[database.shards]]` entries is a
-/// topology the runtime validator (`database_backend_consistency`) rejects at
-/// boot — horizontal sharding is Postgres-only. `autumn migrate` must fail closed
-/// with that provider-appropriate message BEFORE applying anything, rather than
-/// migrating the control file and every shard file for an app that cannot boot
-/// (issue #2058, codex).
-#[test]
-fn migrate_sqlite_control_with_shards_is_rejected_before_applying() {
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let root = tmp.path();
-
+/// Write a throwaway `migrations/` dir so the guard is proven to fire BEFORE the
+/// apply path (if it didn't, a real migration would create + mutate db files).
+fn write_posts_migration(root: &Path) {
     let migration = root.join("migrations/20990101000000_create_posts");
     std::fs::create_dir_all(&migration).expect("mkdir migrations");
     std::fs::write(
@@ -187,6 +179,20 @@ fn migrate_sqlite_control_with_shards_is_rejected_before_applying() {
     )
     .expect("write up.sql");
     std::fs::write(migration.join("down.sql"), "DROP TABLE posts;\n").expect("write down.sql");
+}
+
+/// `SQLite` anywhere in a sharded topology is boot-invalid (horizontal sharding is
+/// Postgres-only; the runtime `sqlite_sharding_unsupported_guard` rejects it).
+/// `autumn migrate` must fail closed with that provider-appropriate `#1614`
+/// message BEFORE applying anything, rather than creating + migrating the control
+/// and/or shard file for an app that cannot boot (issue #2058, codex). Covers
+/// both branches: a `SQLite` control with shards, and a Postgres control with a
+/// `SQLite` shard.
+#[test]
+fn migrate_sqlite_control_with_shards_is_rejected_before_applying() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    write_posts_migration(root);
 
     let control_db = root.join("app.db");
     let shard_db = root.join("shard0.db");
@@ -208,7 +214,7 @@ fn migrate_sqlite_control_with_shards_is_rejected_before_applying() {
         "sqlite control + shards exits non-zero: {err}"
     );
     assert!(
-        err.contains("database shards require the postgres backend"),
+        err.contains("do not support sharding") && err.contains("#1614"),
         "clear provider-appropriate rejection: {err}"
     );
     // Fail-closed: NOTHING was applied to any file — neither db exists.
@@ -219,5 +225,47 @@ fn migrate_sqlite_control_with_shards_is_rejected_before_applying() {
     assert!(
         !shard_db.exists(),
         "shard sqlite file must not be created/migrated"
+    );
+}
+
+/// Sibling case: a Postgres control with a `SQLite` shard target. The shard loop
+/// would route the `sqlite://` shard through the harness and create + migrate the
+/// shard file; the guard must reject it before any apply (and never touch the
+/// Postgres control either).
+#[test]
+fn migrate_postgres_control_with_sqlite_shard_is_rejected_before_applying() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    write_posts_migration(root);
+
+    let shard_db = root.join("shard0.db");
+    let shard_url = format!("sqlite://{}", shard_db.display());
+    let envs = [
+        // A Postgres control URL (never connected to — the guard fires first).
+        (
+            "AUTUMN_DATABASE__URL",
+            "postgres://user@127.0.0.1:1/does_not_exist",
+        ),
+        ("AUTUMN_DATABASE__SHARDS__0__NAME", "shard0"),
+        (
+            "AUTUMN_DATABASE__SHARDS__0__PRIMARY_URL",
+            shard_url.as_str(),
+        ),
+    ];
+
+    let (_out, err, code) = run_autumn(root, &["migrate"], &envs);
+    assert_eq!(
+        code,
+        Some(1),
+        "postgres control + sqlite shard exits non-zero: {err}"
+    );
+    assert!(
+        err.contains("do not support sharding") && err.contains("shard") && err.contains("#1614"),
+        "clear provider-appropriate rejection naming the sqlite shard: {err}"
+    );
+    // Fail-closed: the sqlite shard file must never be created.
+    assert!(
+        !shard_db.exists(),
+        "sqlite shard file must not be created/migrated"
     );
 }

--- a/autumn-cli/tests/integration/mod.rs
+++ b/autumn-cli/tests/integration/mod.rs
@@ -11,6 +11,8 @@ mod i18n_check;
 mod lifecycle_check;
 mod manifest_posture;
 mod migrate_down;
+#[cfg(feature = "sqlite")]
+mod migrate_sqlite;
 mod offsite_backup;
 mod repo_hygiene;
 mod scaffold_belongs_to;

--- a/autumn/src/migrate.rs
+++ b/autumn/src/migrate.rs
@@ -638,11 +638,25 @@ pub struct AppliedUserMigration {
 /// `down.sql`, so without this exclusion `autumn migrate down --shard` would
 /// plan one of them as a user migration and fail.
 fn framework_migration_versions() -> Result<std::collections::BTreeSet<String>, MigrationError> {
+    framework_migration_versions_for::<Pg>()
+}
+
+/// Backend-generic core of [`framework_migration_versions`]. The version strings
+/// are identical across backends (they come from the same embedded directory
+/// names), so the `SQLite` rollback path (issue #2058) can enumerate the same
+/// framework-owned set through the `Sqlite` `MigrationSource` impl without
+/// duplicating the list.
+fn framework_migration_versions_for<DB>()
+-> Result<std::collections::BTreeSet<String>, MigrationError>
+where
+    DB: diesel::backend::Backend,
+    EmbeddedMigrations: diesel::migration::MigrationSource<DB>,
+{
     let mut versions = std::collections::BTreeSet::new();
     for migrations in [
-        MigrationSource::<Pg>::migrations(&FRAMEWORK_MIGRATIONS),
-        MigrationSource::<Pg>::migrations(&crate::version_history::VERSION_HISTORY_MIGRATIONS),
-        MigrationSource::<Pg>::migrations(
+        MigrationSource::<DB>::migrations(&FRAMEWORK_MIGRATIONS),
+        MigrationSource::<DB>::migrations(&crate::version_history::VERSION_HISTORY_MIGRATIONS),
+        MigrationSource::<DB>::migrations(
             &crate::repository_commit_hooks::REPOSITORY_COMMIT_HOOK_MIGRATIONS,
         ),
     ] {
@@ -1684,6 +1698,151 @@ where
 
         result
     })
+}
+
+// ── SQLite migrate up/down (issue #2058) ─────────────────────────────────────
+
+/// Backend-generic core of [`resolve_applied_user_migrations`], parameterized
+/// over the diesel backend so the Postgres and `SQLite` `MigrationHarness`
+/// connections share one classification path.
+///
+/// The version normalisation, framework-exclusion, and local-directory
+/// resolution are backend-independent; only the connection's `applied_migrations`
+/// call and the migration boxes' backend differ. The pure
+/// [`classify_applied_user_migrations`] does the rest.
+#[cfg(feature = "sqlite")]
+fn resolve_applied_user_migrations_sqlite<C>(
+    conn: &mut C,
+    all_migrations: &[Box<dyn Migration<diesel::sqlite::Sqlite>>],
+    migrations_dir: &Path,
+) -> Result<Vec<AppliedUserMigration>, MigrationError>
+where
+    C: MigrationHarness<diesel::sqlite::Sqlite>,
+{
+    let by_version: std::collections::BTreeMap<String, String> = all_migrations
+        .iter()
+        .map(|m| (m.name().version().to_string(), m.name().to_string()))
+        .collect();
+
+    // The framework version strings are backend-independent; enumerate them via
+    // the `Sqlite` source so a framework version that somehow landed in
+    // `__diesel_schema_migrations` is still excluded from user rollback planning.
+    let framework = framework_migration_versions_for::<diesel::sqlite::Sqlite>()?;
+
+    let applied: Vec<String> = conn
+        .applied_migrations()
+        .map_err(|e| MigrationError::Migration(e.to_string()))?
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+
+    Ok(classify_applied_user_migrations(
+        &applied,
+        &by_version,
+        &framework,
+        migrations_dir,
+    ))
+}
+
+/// `SQLite` counterpart to [`applied_user_migrations`]: return the applied
+/// **user** migrations (ascending by version), each resolved to its local
+/// directory, from a `SQLite` database.
+///
+/// `SQLite` is a single-writer local database, so — unlike the Postgres path —
+/// there is **no advisory lock** (issue #1999 / #2036 precedent); the read runs
+/// directly on a synchronous `SqliteConnection`. Read-only status listing used by
+/// the `autumn migrate down` preflight on a `sqlite://` target.
+///
+/// # Errors
+///
+/// - [`MigrationError::Connection`] if the database cannot be opened.
+/// - [`MigrationError::Migration`] if `migrations_dir` cannot be read or querying
+///   applied versions fails.
+#[cfg(feature = "sqlite")]
+pub fn applied_user_migrations_sqlite(
+    database_url: &str,
+    migrations_dir: &Path,
+) -> Result<Vec<AppliedUserMigration>, MigrationError> {
+    let mut conn = crate::db::establish_sqlite_migration_connection(database_url)
+        .map_err(|e| MigrationError::Connection(e.to_string()))?;
+    let source = FileBasedMigrations::from_path(migrations_dir)
+        .map_err(|e| MigrationError::Migration(format!("failed to read migrations dir: {e}")))?;
+    let all_migrations: Vec<Box<dyn Migration<diesel::sqlite::Sqlite>>> = source
+        .migrations()
+        .map_err(|e| MigrationError::Migration(e.to_string()))?;
+    resolve_applied_user_migrations_sqlite(&mut conn, &all_migrations, migrations_dir)
+}
+
+/// `SQLite` counterpart to [`revert_user_migrations_locked`]: plan and execute a
+/// user-migration rollback against a `SQLite` database.
+///
+/// `SQLite` is a single-writer local database, so there is **no advisory lock**
+/// (issue #1999 / #2036 precedent): the applied set is listed, `plan` chooses the
+/// newest-first versions to revert, and each is reverted through diesel's
+/// `MigrationHarness`. There is likewise **no content-checksum bookkeeping** — the
+/// `SQLite` `autumn migrate up` path applies through the unlocked harness and
+/// records no `autumn_migration_checksums` rows (that table's DDL is
+/// Postgres-specific), so there is nothing to delete on revert.
+///
+/// `plan` may inspect each [`AppliedUserMigration`] and return an error (or
+/// terminate the process) to refuse the rollback; `on_reverted` streams
+/// per-migration UX. Returns the number reverted.
+///
+/// # Errors
+///
+/// - [`MigrationError::Connection`] if the database cannot be opened.
+/// - [`MigrationError::Migration`] if `plan` returns an error, a revert fails, or
+///   a planned version is not present in `migrations_dir`.
+#[cfg(feature = "sqlite")]
+pub fn revert_user_migrations_sqlite<P, F>(
+    database_url: &str,
+    migrations_dir: &Path,
+    plan: P,
+    mut on_reverted: F,
+) -> Result<usize, MigrationError>
+where
+    P: FnOnce(&[AppliedUserMigration]) -> Result<Vec<String>, MigrationError>,
+    F: FnMut(&RevertedMigration),
+{
+    let mut conn = crate::db::establish_sqlite_migration_connection(database_url)
+        .map_err(|e| MigrationError::Connection(e.to_string()))?;
+    let source = FileBasedMigrations::from_path(migrations_dir)
+        .map_err(|e| MigrationError::Migration(format!("failed to read migrations dir: {e}")))?;
+    let all_migrations: Vec<Box<dyn Migration<diesel::sqlite::Sqlite>>> = source
+        .migrations()
+        .map_err(|e| MigrationError::Migration(e.to_string()))?;
+
+    let applied_user =
+        resolve_applied_user_migrations_sqlite(&mut conn, &all_migrations, migrations_dir)?;
+    let versions = plan(&applied_user)?;
+
+    let mut count = 0;
+    for version in &versions {
+        let target = diesel::migration::MigrationVersion::from(version.as_str());
+        let migration = all_migrations
+            .iter()
+            .find(|m| m.name().version() == target)
+            .ok_or_else(|| {
+                MigrationError::Migration(format!(
+                    "migration version {version} is applied but not present in {} — \
+                     cannot revert (its down.sql is unavailable)",
+                    migrations_dir.display()
+                ))
+            })?;
+
+        let started = std::time::Instant::now();
+        conn.revert_migration(migration.as_ref())
+            .map_err(|e| MigrationError::Migration(e.to_string()))?;
+        let duration = started.elapsed();
+
+        on_reverted(&RevertedMigration {
+            version: version.clone(),
+            name: migration.name().to_string(),
+            duration,
+        });
+        count += 1;
+    }
+    Ok(count)
 }
 
 // ── Startup wait-for-database ─────────────────────────────────────────────────


### PR DESCRIPTION
## Before / After

**Before:** the legacy `autumn migrate` verb was Postgres-only. Both its up path (`hold_migration_lock` → advisory lock → `diesel` CLI subprocess → framework migrations) and its down path (`revert_user_migrations_locked`) routed through `establish_migration_connection`, which only returns a Postgres connection. A `sqlite://` URL could not be migrated with the CLI — only startup auto-migrate and the newer `autumn schema migrate` (#2036) understood SQLite.

**After:** under `--no-default-features --features sqlite`, `autumn migrate` (up) and `autumn migrate down` run against a `sqlite://` database. `autumn migrate check` is unchanged.

## How

- **Backend seam.** Routing keys off `DatabaseBackend::detect(url)`: only an explicit `sqlite:` / `file:` URL takes the SQLite path; a Postgres URL, a libpq keyword/value string, or an unrecognized target keeps the historical advisory-locked path byte-for-byte. This mirrors `autumn schema migrate`'s SQLite path (#1999/#2036) — no new pattern.
- **Unlocked harness, no advisory lock.** SQLite is a single-writer local database, so the SQLite path takes **no** advisory lock, spawns **no** `diesel` CLI subprocess, writes **no** Postgres content-checksum rows, and applies **no** control-plane/shard framework migrations (their DDL is Postgres-specific). Up applies the project's `migrations/` user set via the in-process `run_pending_sqlite` harness; down reverts via the new unlocked harness path. The `diesel` CLI preflight (`check_diesel_cli`) is skipped when every target is SQLite.
- **New autumn-web primitives (feature-gated):** `applied_user_migrations_sqlite` and `revert_user_migrations_sqlite` (unlocked, no checksum bookkeeping), plus a backend-generic `framework_migration_versions` core so the SQLite rollback reuses the same framework-exclusion set.
- **Provider-appropriate errors.** In the default (Postgres-only) build a detected SQLite URL hits a clear "rebuild with `--no-default-features --features sqlite`" seam that references no SQLite symbol; the SQLite build keeps the Postgres apply/revert path compiled for a Postgres URL.

## `migrate check`

The offline SQL-safety linter reads no DB URL and connects to no database, so it is untouched by this change. Its documented behavior (runs offline; rules are Postgres-oriented) remains accurate — no adjustment needed.

## Tests

Adds a real file-DB end-to-end test (`autumn-cli/tests/integration/migrate_sqlite.rs`, `#[cfg(feature = "sqlite")]`, **no Docker, no `diesel` CLI**): temp SQLite file → `autumn migrate` up → assert the `posts` table exists → `autumn migrate down` → assert the table is gone → re-apply. Both build lanes verified separately (never co-built): DEFAULT (Postgres) and `--no-default-features --features sqlite` — `cargo fmt`, `cargo clippy` (autumn-web `--features sqlite --lib`; autumn-cli `--all-targets` per lane), and the migrate unit/integration tests all green.

## Docs (not edited here — parallel docs batch owns `docs/guide/sqlite-in-production.md`)

The support-matrix row **"Embedded migrations + `autumn migrate` up/down"** can flip from **⚠️ Partial** — its "`autumn migrate` CLI up/down is Postgres-only (planned)" caveat is what this PR removes (the CLI now migrates a `sqlite://` URL through the unlocked harness). The `autumn migrate check` row stays as-is (offline linter, Postgres-oriented rules — unchanged).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Tco7XxCX5nsX5ULXgLCvxU)_