### PR TITLE
schema pull: SQLite database introspection + IR fidelity (serial/identity/NULLS NOT DISTINCT)

### DIFF
--- a/autumn-cli/src/schema/diff.rs
+++ b/autumn-cli/src/schema/diff.rs
@@ -156,7 +156,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 
 use autumn_schema_core::{
-    Backend, CheckConstraint, Column, ColumnDefault, ColumnType, IdKind, Index, SerialKind, Table,
+    Backend, CheckConstraint, Column, ColumnDefault, ColumnType, IdKind, Index, SerialKind,
+    SqliteAffinity, Table,
 };
 
 use crate::schema::parse::ParsedSchema;
@@ -824,7 +825,7 @@ pub fn diff_schema(baseline: &[Table], desired: &ParsedSchema, opts: DiffOptions
             // Present on both sides — diff only Autumn-managed tables.
             (Some(base), Some(want)) => {
                 if want.managed {
-                    diff_table(base, want, desired, opts, &mut changes);
+                    diff_table(base, want, desired, opts, backend, &mut changes);
                 }
             }
             // Desired only — create it if Autumn owns it. But if the parser
@@ -1075,6 +1076,7 @@ fn diff_table(
     want: &Table,
     desired: &ParsedSchema,
     opts: DiffOptions,
+    backend: Backend,
     changes: &mut Vec<SchemaChange>,
 ) {
     // A primary-key change is refused wholesale (guarded); emit only the marker
@@ -1107,7 +1109,7 @@ fn diff_table(
                 table: want.name.clone(),
                 column: want_col.clone(),
             }),
-            Some(base_col) => diff_column(&want.name, base_col, want_col, opts, changes),
+            Some(base_col) => diff_column(&want.name, base_col, want_col, opts, backend, changes),
         }
     }
 
@@ -1128,14 +1130,50 @@ fn diff_table(
 }
 
 /// Diff a single same-named column (keyed on name, never position).
+/// Whether two column types are equivalent for drift purposes on `backend`.
+///
+/// On **Postgres** this is exact [`ColumnType`] equality — `INTEGER` vs `BIGINT`
+/// (int4 vs int8) is a genuine, distinct type change that must still diff.
+///
+/// On **`SQLite`** the emitter renders several distinct IR types to the same
+/// declared type (`Int32`/`Int64`/`Bool` → `INTEGER`, `Float32`/`Float64` →
+/// `REAL`, `Text`/`Uuid`/`Timestamp`/`TimestampTz`/`Decimal`/`Attachment`/`Enum` →
+/// `TEXT`, `Bytes` → `BLOB`), and a pull cannot recover the original variant — so
+/// comparing by exact `ColumnType` would report a spurious type change (and a
+/// table-recreate) for every `bool`/`i32`/`f32`/plain-`Timestamp` column on every
+/// pull. Instead they are compared by [`SqliteAffinity`] class, so a matching
+/// model↔pull round-trips CLEAN while a genuine class change (e.g. `INTEGER`→`TEXT`)
+/// still drifts. An [`Opaque`](ColumnType::Opaque) type (a verbatim, pull-only type
+/// with no clean class) or the ambiguous [`Numeric`](SqliteAffinity::Numeric)
+/// catch-all falls back to exact equality so distinct verbatim types are never
+/// conflated. This rule is strictly `SQLite`-gated and never affects the pg lane.
+fn column_types_equivalent(base: &ColumnType, want: &ColumnType, backend: Backend) -> bool {
+    if base == want {
+        return true;
+    }
+    if backend != Backend::Sqlite {
+        return false;
+    }
+    // An Opaque (verbatim, pull-only) type must match exactly — never conflate two
+    // distinct raw types by affinity.
+    if matches!(base, ColumnType::Opaque { .. }) || matches!(want, ColumnType::Opaque { .. }) {
+        return false;
+    }
+    let base_class = base.sqlite_affinity();
+    // Only the four unambiguous storage classes collapse; the NUMERIC catch-all
+    // requires exact equality (already failed the `base == want` check above).
+    base_class == want.sqlite_affinity() && base_class != SqliteAffinity::Numeric
+}
+
 fn diff_column(
     table: &str,
     base: &Column,
     want: &Column,
     opts: DiffOptions,
+    backend: Backend,
     changes: &mut Vec<SchemaChange>,
 ) {
-    if base.ty != want.ty {
+    if !column_types_equivalent(&base.ty, &want.ty, backend) {
         changes.push(SchemaChange::AlterColumnType {
             table: table.to_owned(),
             column: want.name.clone(),
@@ -1334,6 +1372,22 @@ pub fn index_depends_on_column(index: &Index, col: &str) -> bool {
 /// a wrongful suppression.
 fn baseline_unique_index_covers(base: &Table, want_columns: &[String]) -> bool {
     let want_set: BTreeSet<&str> = want_columns.iter().map(String::as_str).collect();
+    // A single-column baseline `column.unique = true` fully enforces uniqueness of
+    // that column. This covers the SQLite brownfield inline-`col TEXT UNIQUE` case:
+    // its constraint auto-index (`sqlite_autoindex_*`) is deliberately NOT recorded
+    // as an `Index` (its name is un-creatable/un-droppable — see
+    // `introspect::sqlite::collapse_indexes`), so the column flag is the ONLY signal
+    // that the model's `#[unique]` is already satisfied. (On Postgres the constraint
+    // ALSO produces a retained unique index, so this clause is redundant-but-correct
+    // there.)
+    if want_columns.len() == 1
+        && base
+            .columns
+            .iter()
+            .any(|c| c.unique && c.name == want_columns[0])
+    {
+        return true;
+    }
     base.indexes.iter().any(|idx| {
         if !idx.unique || idx.is_partial {
             return false;
@@ -3313,6 +3367,19 @@ fn serial_kinds_conflict(base: &Table, want: &Table) -> bool {
 /// swaps its UUID-generation behavior for `gen_random_uuid()` or adds a default
 /// where none existed.
 fn pk_kind_for(column: &Column) -> Option<IdKind> {
+    // An EXPLICIT `Plain` serial marker (a brownfield plain `BIGINT`/`INTEGER
+    // PRIMARY KEY` with no owned sequence — populated by both introspectors, never
+    // by the model parser) must NOT reconstruct as `BIGSERIAL`/`AUTOINCREMENT`: that
+    // would fabricate auto-increment (and a `sqlite_sequence` row) on a table
+    // rebuild or `DropTable` rollback, silently changing id-generation behavior. The
+    // `None` path renders it as an ordinary integer column plus a table-level
+    // `PRIMARY KEY (col)` clause — a plain PK with no sequence/AUTOINCREMENT. A
+    // legacy/unknown `None` marker keeps the historical `BigSerial` behavior for
+    // back-compat (`serial_kinds_conflict` treats a legacy `None` as compatible, so
+    // this only ever fires for an explicitly-`Plain`-marked pull).
+    if column.serial == Some(SerialKind::Plain) {
+        return None;
+    }
     match &column.ty {
         ColumnType::Int64 if column.default.is_none() => Some(IdKind::BigSerial),
         ColumnType::Int32 if is_nextval_default(column) => Some(IdKind::Serial),
@@ -5458,6 +5525,132 @@ mod tests {
         assert_eq!(pk_kind_for(&none), None);
     }
 
+    #[test]
+    fn pk_kind_for_honors_plain_serial_marker() {
+        // An explicit `Some(Plain)` Int64 PK must NOT reconstruct as BigSerial (that
+        // would fabricate auto-increment on a rebuild/rollback).
+        let mut plain = col("id", ColumnType::Int64);
+        plain.primary_key = true;
+        plain.serial = Some(SerialKind::Plain);
+        assert_eq!(pk_kind_for(&plain), None, "a Plain PK is a plain column");
+
+        // A `BigSerial`-marked (or legacy `None`) Int64 PK keeps the BigSerial shape.
+        let mut big = col("id", ColumnType::Int64);
+        big.primary_key = true;
+        big.serial = Some(SerialKind::BigSerial);
+        assert_eq!(pk_kind_for(&big), Some(IdKind::BigSerial));
+        let mut legacy = col("id", ColumnType::Int64);
+        legacy.primary_key = true; // serial: None (legacy/unknown)
+        assert_eq!(pk_kind_for(&legacy), Some(IdKind::BigSerial));
+    }
+
+    #[test]
+    fn plain_pk_reconstructs_without_bigserial_or_autoincrement() {
+        for (backend, forbidden) in [
+            (Backend::Postgres, "BIGSERIAL"),
+            (Backend::Sqlite, "AUTOINCREMENT"),
+        ] {
+            let mut t = Table::new("ledger", backend);
+            let mut id = col("id", ColumnType::Int64);
+            id.primary_key = true;
+            id.serial = Some(SerialKind::Plain);
+            t.primary_key.push("id".to_owned());
+            t.columns.push(id);
+            let body = render_create_table_body("ledger", &t, backend);
+            assert!(
+                !body.contains(forbidden),
+                "a Plain PK must not render {forbidden} on {backend:?}: {body}"
+            );
+            assert!(
+                body.contains("PRIMARY KEY (id)"),
+                "a Plain PK renders a table-level primary key on {backend:?}: {body}"
+            );
+        }
+    }
+
+    // -- SQLite affinity-aware type comparison -------------------------------
+
+    #[test]
+    fn sqlite_type_comparison_is_affinity_aware_but_pg_stays_exact() {
+        // On SQLite, types that collapse to the same declared type are equivalent.
+        for (a, b) in [
+            (ColumnType::Int32, ColumnType::Int64),
+            (ColumnType::Int64, ColumnType::Bool),
+            (ColumnType::Float32, ColumnType::Float64),
+            (ColumnType::Text, ColumnType::Timestamp),
+            (ColumnType::Timestamp, ColumnType::TimestampTz),
+        ] {
+            assert!(
+                column_types_equivalent(&a, &b, Backend::Sqlite),
+                "{a:?} and {b:?} share a SQLite affinity class"
+            );
+            // Postgres keeps exact equality — these are genuinely distinct there.
+            assert!(
+                !column_types_equivalent(&a, &b, Backend::Postgres),
+                "{a:?} vs {b:?} must still differ on Postgres"
+            );
+        }
+        // A genuine class change still drifts on SQLite.
+        assert!(!column_types_equivalent(
+            &ColumnType::Int64,
+            &ColumnType::Text,
+            Backend::Sqlite
+        ));
+        assert!(!column_types_equivalent(
+            &ColumnType::Bytes,
+            &ColumnType::Text,
+            Backend::Sqlite
+        ));
+        // Opaque (verbatim) types require exact equality even on SQLite.
+        let a = ColumnType::Opaque {
+            pg_type: "citext".to_owned(),
+        };
+        let b = ColumnType::Opaque {
+            pg_type: "hstore".to_owned(),
+        };
+        assert!(!column_types_equivalent(&a, &b, Backend::Sqlite));
+        assert!(column_types_equivalent(&a, &a.clone(), Backend::Sqlite));
+    }
+
+    #[test]
+    fn sqlite_diff_no_alter_within_affinity_class_but_drifts_across() {
+        // Baseline `views: Int64` (pulled), model `views: Int32` — same INTEGER class
+        // on SQLite → NO AlterColumnType.
+        let mut base = Table::new("posts", Backend::Sqlite);
+        base.managed = true;
+        base.columns.push(col("views", ColumnType::Int64));
+        let mut want = Table::new("posts", Backend::Sqlite);
+        want.managed = true;
+        want.columns.push(col("views", ColumnType::Int32));
+        let plan = diff_schema(
+            std::slice::from_ref(&base),
+            &parsed(vec![want], vec![]),
+            AUTHORITATIVE,
+        );
+        assert!(
+            !plan
+                .changes
+                .iter()
+                .any(|c| matches!(c, SchemaChange::AlterColumnType { .. })),
+            "same-class INTEGER change must not drift on SQLite: {:?}",
+            plan.changes
+        );
+
+        // A cross-class change (Int64 → Text) still drifts.
+        let mut want2 = Table::new("posts", Backend::Sqlite);
+        want2.managed = true;
+        want2.columns.push(col("views", ColumnType::Text));
+        let plan2 = diff_schema(&[base], &parsed(vec![want2], vec![]), AUTHORITATIVE);
+        assert!(
+            plan2
+                .changes
+                .iter()
+                .any(|c| matches!(c, SchemaChange::AlterColumnType { .. })),
+            "a cross-class change must still drift on SQLite: {:?}",
+            plan2.changes
+        );
+    }
+
     /// A convention UUID PK (`DEFAULT gen_random_uuid()`) renders the `IdKind::Uuid`
     /// shape verbatim — the `gen_random_uuid()` default is not double-emitted.
     #[test]
@@ -7507,34 +7700,37 @@ PRAGMA foreign_keys=ON;
 
     /// The `SQLite` counterpart to `type_change_on_referencing_fk_column_is_refused`:
     /// the FK-bound-type-change guard is `Postgres`-only, so on `SQLite` an FK
-    /// column's type change (`posts.author_id` `Int32` → `Int64`, still
+    /// column's type change (`posts.author_id` `Int64` → `Text`, still
     /// `REFERENCES users(id)`) is NOT refused — it flows to the table-recreate,
     /// which applies the new type, preserves the inline `REFERENCES`, and emits the
-    /// FK type-consistency advisory naming the column. The `Postgres` plan with the
-    /// same change still refuses with `TypeChangeOnForeignKeyColumn` (the backend
+    /// FK type-consistency advisory naming the column. (A GENUINE cross-affinity-class
+    /// change is used because on `SQLite` a same-class change like `Int32` → `Int64`
+    /// is now a no-op — both are `INTEGER` affinity — see the affinity-aware
+    /// comparison in [`column_types_equivalent`].) The `Postgres` plan with an int4→
+    /// int8 change still refuses with `TypeChangeOnForeignKeyColumn` (the backend
     /// contrast).
     #[test]
     fn sqlite_fk_column_type_change_recreates_with_advisory() {
         let baseline = vec![
             sqlite_users_table(),
-            sqlite_posts_with_author(ColumnType::Int32),
+            sqlite_posts_with_author(ColumnType::Int64),
         ];
         let desired = vec![
             sqlite_users_table(),
-            sqlite_posts_with_author(ColumnType::Int64),
+            sqlite_posts_with_author(ColumnType::Text),
         ];
         let plan = diff_schema(&baseline, &parsed(desired.clone(), vec![]), ALLOW);
 
-        // The plan is a SQLite plan carrying the real type change AND the blocked
-        // marker appended alongside it.
+        // The plan is a SQLite plan carrying the real (cross-class) type change AND
+        // the blocked marker appended alongside it.
         assert_eq!(plan.backend, Backend::Sqlite);
         assert!(
             plan.changes.iter().any(|c| matches!(
                 c,
                 SchemaChange::AlterColumnType { table, column, to, .. }
-                    if table == "posts" && column == "author_id" && *to == ColumnType::Int64
+                    if table == "posts" && column == "author_id" && *to == ColumnType::Text
             )),
-            "the real AlterColumnType (→ Int64) rides in the plan: {:?}",
+            "the real AlterColumnType (→ Text) rides in the plan: {:?}",
             plan.changes
         );
         assert!(
@@ -7556,8 +7752,8 @@ PRAGMA foreign_keys=ON;
         let ctx = SchemaContext::from_tables(&desired, &baseline);
         let up = emit_up_sql_with_context(&plan, &ctx).expect("emit sqlite rebuild");
         assert!(
-            up.contains("author_id INTEGER NULL REFERENCES users(id)"),
-            "the recreate expresses author_id with its (widened) type and keeps the \
+            up.contains("author_id TEXT NULL REFERENCES users(id)"),
+            "the recreate expresses author_id with its (changed) type and keeps the \
              inline REFERENCES: {up}"
         );
         assert!(

--- a/autumn-cli/src/schema/diff.rs
+++ b/autumn-cli/src/schema/diff.rs
@@ -350,6 +350,27 @@ pub enum SchemaChange {
         column: String,
     },
 
+    /// A same-named column whose single-column `UNIQUE` (the `Column.unique` flag)
+    /// changed between two authoritative introspections — e.g. the live database
+    /// dropped a `col TEXT UNIQUE` to a plain `col TEXT`. A non-emittable marker:
+    /// [`guard_plan`] refuses any plan containing it (with **no override**).
+    ///
+    /// It exists so a change to an inline single-column `UNIQUE` — which the `SQLite`
+    /// introspector folds into `Column.unique` (its constraint auto-index is
+    /// deliberately NOT recorded as an [`Index`], so the flag is the ONLY signal) —
+    /// surfaces as real drift in the introspection diff (doctor's
+    /// `database-schema-drift` and `pull --dry-run`) instead of being silently
+    /// ignored. It is produced **only** in an authoritative diff
+    /// (`definitions_authoritative`): in a model diff a `#[unique]` is expressed as an
+    /// [`Index`] (diffed by [`diff_indexes`]), not the column flag, so comparing the
+    /// flag there would double-count.
+    UniqueChange {
+        /// The owning table name.
+        table: String,
+        /// The column whose `UNIQUE` flag changed.
+        column: String,
+    },
+
     /// A managed table is dropped while a **retained** table still holds a
     /// baseline foreign key pointing at it (e.g. drop `users` while
     /// `posts.user_id REFERENCES users(id)` survives). A non-emittable marker:
@@ -529,6 +550,20 @@ pub enum DiffError {
         /// The owning table name.
         table: String,
         /// The column whose identity clause changed.
+        column: String,
+    },
+
+    /// A column's inline single-column `UNIQUE` (`Column.unique`) changed between two
+    /// authoritative introspections (unsupported this slice, **no override** — see
+    /// [`SchemaChange::UniqueChange`]).
+    #[error(
+        "unique-constraint change on `{table}.{column}` is not supported in this slice: \
+         adding or dropping an inline column `UNIQUE` requires a manual migration."
+    )]
+    UniqueChange {
+        /// The owning table name.
+        table: String,
+        /// The column whose `UNIQUE` flag changed.
         column: String,
     },
 
@@ -1258,6 +1293,20 @@ fn diff_column(
             column: want.name.clone(),
         });
     }
+
+    // Inline single-column `UNIQUE` (`Column.unique`): compared ONLY in an
+    // authoritative diff (both sides introspected). The SQLite introspector folds an
+    // inline `col TEXT UNIQUE` into this flag (its constraint auto-index is not
+    // recorded as an `Index`), so the flag is the ONLY drift signal there — without
+    // this, a live DB dropping the `UNIQUE` diffs clean in doctor / `pull --dry-run`.
+    // In a MODEL diff a `#[unique]` is expressed as an `Index` (handled by
+    // `diff_indexes`), not this flag, so comparing it there would double-count.
+    if opts.definitions_authoritative && base.unique != want.unique {
+        changes.push(SchemaChange::UniqueChange {
+            table: table.to_owned(),
+            column: want.name.clone(),
+        });
+    }
 }
 
 /// Diff a table's indexes by name. A same-named index whose shape changed is a
@@ -1466,6 +1515,43 @@ fn baseline_satisfies_desired_unique(base: &Table, want_idx: &Index) -> bool {
     want_idx.unique && baseline_unique_index_covers(base, &want_idx.columns)
 }
 
+/// The full (non-partial) unique KEY column set of `idx`, or `None` when `idx` is not
+/// a vouchable full-unique index (non-unique, partial, or an expression key with no
+/// recorded key columns). Mirrors the key resolution in
+/// [`baseline_unique_index_covers`].
+fn full_unique_key_columns(idx: &Index) -> Option<BTreeSet<&str>> {
+    if !idx.unique || idx.is_partial {
+        return None;
+    }
+    if !idx.key_columns.is_empty() {
+        Some(idx.key_columns.iter().map(String::as_str).collect())
+    } else if idx.definition.is_none() {
+        Some(idx.columns.iter().map(String::as_str).collect())
+    } else {
+        None
+    }
+}
+
+/// Whether a baseline-only index `base_idx` (in a MODEL diff) is the covering index
+/// for a desired `#[unique]` requirement whose own `AddIndex` was suppressed as
+/// already-satisfied — i.e. the SAME uniqueness enforced under a DIFFERENT name (a
+/// pulled `accounts_email_uq` vs the model's `idx_accounts_email_unique`). Such an
+/// index must be RETAINED: dropping it would remove the only enforcement while the
+/// model's matching `AddIndex` stays suppressed. The symmetric counterpart to
+/// [`baseline_satisfies_desired_unique`] (which suppresses the add side).
+fn base_index_covers_suppressed_model_unique(base: &Table, base_idx: &Index, want: &Table) -> bool {
+    let Some(base_key) = full_unique_key_columns(base_idx) else {
+        return false;
+    };
+    want.indexes.iter().any(|w| {
+        // A same-named desired index is matched by name (not suppressed by coverage),
+        // so only a DIFFERENTLY-named desired unique over the same key set counts.
+        w.unique
+            && !base.indexes.iter().any(|b| b.name == w.name)
+            && full_unique_key_columns(w).is_some_and(|wk| wk == base_key)
+    })
+}
+
 fn diff_indexes(
     table: &str,
     base: &Table,
@@ -1579,15 +1665,24 @@ fn diff_indexes(
             && dropped_columns
                 .iter()
                 .any(|c| index_depends_on_column(base_idx, c, backend));
-        // A baseline-only `definition` index has no same-named desired index, and
-        // in a model diff the desired side could not have expressed it anyway —
-        // retain it (never DropIndex), independent of `allow_destructive`. In an
-        // introspection diff it is authoritative, so a genuinely-dropped
-        // expression/partial index still drops.
-        if base_idx.definition.is_some()
-            && !opts.definitions_authoritative
+        // Retain (never DropIndex) — in a MODEL diff, and only when the index is not
+        // being orphaned by a SQLite column drop — when EITHER:
+        //   (a) it carries a `definition` the model DSL cannot express (an
+        //       expression/partial/constraint-owned index), OR
+        //   (b) it is a plain unique index that COVERS a model `#[unique]` whose own
+        //       `AddIndex` was suppressed as already-satisfied (the SAME uniqueness
+        //       under a different name — e.g. a pulled `accounts_email_uq` vs the
+        //       model's `idx_accounts_email_unique`). Dropping it would remove the
+        //       ONLY uniqueness enforcement with no replacement — a silent
+        //       data-integrity loss. This is the symmetric counterpart to the add
+        //       branch's `baseline_satisfies_desired_unique` suppression.
+        // In an introspection diff both sides are authoritative (indexes match by
+        // name), so neither retention applies and a genuinely-dropped index drops.
+        let retain = !opts.definitions_authoritative
             && !orphaned_by_column_drop
-        {
+            && (base_idx.definition.is_some()
+                || base_index_covers_suppressed_model_unique(base, base_idx, want));
+        if retain {
             continue;
         }
         changes.push(SchemaChange::DropIndex {
@@ -1674,9 +1769,9 @@ pub fn guard_plan(plan: &MigrationPlan, opts: DiffOptions) -> Result<(), DiffErr
         return Err(DiffError::ForeignKeyChange { table, column });
     }
 
-    // 2a. Identity-generation change — no override (needs ADD/DROP/SET GENERATED,
-    //     out of scope this slice). Only produced by an authoritative diff.
-    if let Some(err) = find_identity_change_block(plan) {
+    // 2a / 2a'. Identity-generation and inline-UNIQUE changes — no override; both
+    //           are produced ONLY by an authoritative diff (drift detection).
+    if let Some(err) = find_identity_change_block(plan).or_else(|| find_unique_change_block(plan)) {
         return Err(err);
     }
 
@@ -1845,6 +1940,18 @@ pub fn guard_plan(plan: &MigrationPlan, opts: DiffOptions) -> Result<(), DiffErr
 fn find_identity_change_block(plan: &MigrationPlan) -> Option<DiffError> {
     plan.changes.iter().find_map(|c| match c {
         SchemaChange::IdentityChange { table, column } => Some(DiffError::IdentityChange {
+            table: table.clone(),
+            column: column.clone(),
+        }),
+        _ => None,
+    })
+}
+
+/// The [`DiffError::UniqueChange`] refusal for the first
+/// [`SchemaChange::UniqueChange`] marker in `plan`, if any.
+fn find_unique_change_block(plan: &MigrationPlan) -> Option<DiffError> {
+    plan.changes.iter().find_map(|c| match c {
+        SchemaChange::UniqueChange { table, column } => Some(DiffError::UniqueChange {
             table: table.clone(),
             column: column.clone(),
         }),
@@ -2385,6 +2492,7 @@ const fn change_table_name(change: &SchemaChange) -> &str {
         | SchemaChange::PrimaryKeyChange { table }
         | SchemaChange::ForeignKeyChange { table, .. }
         | SchemaChange::IdentityChange { table, .. }
+        | SchemaChange::UniqueChange { table, .. }
         | SchemaChange::DropTableBlockedByInboundFk { table, .. }
         | SchemaChange::AlterColumnTypeBlockedByFk { table, .. }
         | SchemaChange::AddForeignKeyToExistingColumn { table, .. }
@@ -3028,6 +3136,7 @@ const fn up_bucket(change: &SchemaChange) -> u8 {
         SchemaChange::PrimaryKeyChange { .. }
         | SchemaChange::ForeignKeyChange { .. }
         | SchemaChange::IdentityChange { .. }
+        | SchemaChange::UniqueChange { .. }
         | SchemaChange::DropTableBlockedByInboundFk { .. }
         | SchemaChange::AlterColumnTypeBlockedByFk { .. }
         | SchemaChange::AddForeignKeyToExistingColumn { .. }
@@ -3115,6 +3224,7 @@ fn emit_change_up(change: &SchemaChange, backend: Backend) -> Result<String, Emi
         SchemaChange::PrimaryKeyChange { .. }
         | SchemaChange::ForeignKeyChange { .. }
         | SchemaChange::IdentityChange { .. }
+        | SchemaChange::UniqueChange { .. }
         | SchemaChange::DropTableBlockedByInboundFk { .. }
         | SchemaChange::AlterColumnTypeBlockedByFk { .. }
         | SchemaChange::AddForeignKeyToExistingColumn { .. }
@@ -3203,6 +3313,7 @@ fn emit_change_down(change: &SchemaChange, backend: Backend) -> Result<String, E
         SchemaChange::PrimaryKeyChange { .. }
         | SchemaChange::ForeignKeyChange { .. }
         | SchemaChange::IdentityChange { .. }
+        | SchemaChange::UniqueChange { .. }
         | SchemaChange::DropTableBlockedByInboundFk { .. }
         | SchemaChange::AlterColumnTypeBlockedByFk { .. }
         | SchemaChange::AddForeignKeyToExistingColumn { .. }
@@ -3569,6 +3680,9 @@ fn describe_change(change: &SchemaChange) -> String {
         SchemaChange::IdentityChange { table, column } => {
             format!("! IDENTITY CHANGE on {table}.{column} (refused)")
         }
+        SchemaChange::UniqueChange { table, column } => {
+            format!("! UNIQUE CHANGE on {table}.{column} (refused)")
+        }
         SchemaChange::DropTableBlockedByInboundFk {
             table,
             referencing_table,
@@ -3754,6 +3868,43 @@ mod tests {
                 .iter()
                 .any(|c| matches!(c, SchemaChange::IdentityChange { .. })),
             "model diff never flags an identity change: {:?}",
+            model.changes
+        );
+    }
+
+    /// P2 (authoritative Column.unique): a live DB dropping a single-column inline
+    /// `UNIQUE` (folded into `Column.unique`, with NO recorded Index) surfaces as
+    /// `UniqueChange` drift in the authoritative diff (doctor / pull --dry-run), but
+    /// is NOT flagged in a model diff (where `#[unique]` is an Index, not the flag).
+    #[test]
+    fn unique_flag_change_flagged_only_in_authoritative_diff() {
+        let mut base_email = col("email", ColumnType::Text);
+        base_email.unique = true; // snapshot: email is UNIQUE
+        let base = vec![posts_with(vec![base_email])];
+        let want_col = col("email", ColumnType::Text); // live: unique dropped
+        let want = posts_with(vec![want_col]);
+
+        let auth = diff_schema(&base, &parsed(vec![want.clone()], vec![]), AUTHORITATIVE);
+        assert!(
+            auth.changes.iter().any(|c| matches!(
+                c,
+                SchemaChange::UniqueChange { table, column } if table == "posts" && column == "email"
+            )),
+            "authoritative diff flags the dropped inline UNIQUE: {:?}",
+            auth.changes
+        );
+        assert!(matches!(
+            guard_plan(&auth, AUTHORITATIVE).unwrap_err(),
+            DiffError::UniqueChange { .. }
+        ));
+
+        let model = diff_schema(&base, &parsed(vec![want], vec![]), DEFAULT_OPTS);
+        assert!(
+            !model
+                .changes
+                .iter()
+                .any(|c| matches!(c, SchemaChange::UniqueChange { .. })),
+            "model diff never flags a Column.unique change: {:?}",
             model.changes
         );
     }
@@ -4036,6 +4187,77 @@ mod tests {
         assert!(
             guard_plan(&plan, DEFAULT_OPTS).is_ok(),
             "clean plan must not trip guard_plan"
+        );
+    }
+
+    /// P1 (retain covering unique): a baseline **definition-less** unique index under
+    /// a NON-model name (`accounts_email_uq`) that covers the model's `#[unique]`
+    /// (whose own `AddIndex` is suppressed as already-satisfied) must be RETAINED — a
+    /// `DropIndex` would remove the only uniqueness enforcement with no replacement.
+    /// The plan must be clean (no `DropIndex`, no `AddIndex`).
+    #[test]
+    fn model_diff_retains_differently_named_covering_unique_index() {
+        let covering = Index {
+            name: "accounts_email_uq".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: None, // a plain CREATE UNIQUE INDEX, not a constraint index
+            is_partial: false,
+            key_columns: Vec::new(),
+        };
+        let mut base_table = posts_with(vec![col("email", ColumnType::Text)]);
+        base_table.indexes.push(covering);
+        // Model `#[unique] email` → a differently-named unique index.
+        let mut want_table = posts_with(vec![col("email", ColumnType::Text)]);
+        want_table.indexes.push(Index {
+            name: "idx_posts_email_unique".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: true,
+            definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
+        });
+        let plan = diff_schema(
+            &[base_table],
+            &parsed(vec![want_table], vec![]),
+            DEFAULT_OPTS,
+        );
+        assert!(
+            plan.changes.is_empty(),
+            "a differently-named covering unique index is RETAINED and the model's \
+             matching AddIndex suppressed (same uniqueness, different name): {:?}",
+            plan.changes
+        );
+    }
+
+    /// The retention is coverage-scoped: a baseline unique index the model does NOT
+    /// cover (no matching `#[unique]`) still DROPS — the user removed the annotation.
+    #[test]
+    fn model_diff_unmatched_baseline_unique_index_still_drops() {
+        let orphan = Index {
+            name: "posts_nickname_uq".to_owned(),
+            columns: vec!["nickname".to_owned()],
+            unique: true,
+            definition: None,
+            is_partial: false,
+            key_columns: Vec::new(),
+        };
+        let mut base_table = posts_with(vec![col("nickname", ColumnType::Text)]);
+        base_table.indexes.push(orphan);
+        // Model keeps the column but declares NO `#[unique]` on it.
+        let want_table = posts_with(vec![col("nickname", ColumnType::Text)]);
+        let plan = diff_schema(
+            &[base_table],
+            &parsed(vec![want_table], vec![]),
+            DEFAULT_OPTS,
+        );
+        assert!(
+            plan.changes.iter().any(|c| matches!(
+                c,
+                SchemaChange::DropIndex { index, .. } if index.name == "posts_nickname_uq"
+            )),
+            "an unmatched baseline unique index must still drop: {:?}",
+            plan.changes
         );
     }
 

--- a/autumn-cli/src/schema/diff.rs
+++ b/autumn-cli/src/schema/diff.rs
@@ -350,27 +350,6 @@ pub enum SchemaChange {
         column: String,
     },
 
-    /// A same-named column whose single-column `UNIQUE` (the `Column.unique` flag)
-    /// changed between two authoritative introspections — e.g. the live database
-    /// dropped a `col TEXT UNIQUE` to a plain `col TEXT`. A non-emittable marker:
-    /// [`guard_plan`] refuses any plan containing it (with **no override**).
-    ///
-    /// It exists so a change to an inline single-column `UNIQUE` — which the `SQLite`
-    /// introspector folds into `Column.unique` (its constraint auto-index is
-    /// deliberately NOT recorded as an [`Index`], so the flag is the ONLY signal) —
-    /// surfaces as real drift in the introspection diff (doctor's
-    /// `database-schema-drift` and `pull --dry-run`) instead of being silently
-    /// ignored. It is produced **only** in an authoritative diff
-    /// (`definitions_authoritative`): in a model diff a `#[unique]` is expressed as an
-    /// [`Index`] (diffed by [`diff_indexes`]), not the column flag, so comparing the
-    /// flag there would double-count.
-    UniqueChange {
-        /// The owning table name.
-        table: String,
-        /// The column whose `UNIQUE` flag changed.
-        column: String,
-    },
-
     /// A managed table is dropped while a **retained** table still holds a
     /// baseline foreign key pointing at it (e.g. drop `users` while
     /// `posts.user_id REFERENCES users(id)` survives). A non-emittable marker:
@@ -550,20 +529,6 @@ pub enum DiffError {
         /// The owning table name.
         table: String,
         /// The column whose identity clause changed.
-        column: String,
-    },
-
-    /// A column's inline single-column `UNIQUE` (`Column.unique`) changed between two
-    /// authoritative introspections (unsupported this slice, **no override** — see
-    /// [`SchemaChange::UniqueChange`]).
-    #[error(
-        "unique-constraint change on `{table}.{column}` is not supported in this slice: \
-         adding or dropping an inline column `UNIQUE` requires a manual migration."
-    )]
-    UniqueChange {
-        /// The owning table name.
-        table: String,
-        /// The column whose `UNIQUE` flag changed.
         column: String,
     },
 
@@ -1293,20 +1258,11 @@ fn diff_column(
             column: want.name.clone(),
         });
     }
-
-    // Inline single-column `UNIQUE` (`Column.unique`): compared ONLY in an
-    // authoritative diff (both sides introspected). The SQLite introspector folds an
-    // inline `col TEXT UNIQUE` into this flag (its constraint auto-index is not
-    // recorded as an `Index`), so the flag is the ONLY drift signal there — without
-    // this, a live DB dropping the `UNIQUE` diffs clean in doctor / `pull --dry-run`.
-    // In a MODEL diff a `#[unique]` is expressed as an `Index` (handled by
-    // `diff_indexes`), not this flag, so comparing it there would double-count.
-    if opts.definitions_authoritative && base.unique != want.unique {
-        changes.push(SchemaChange::UniqueChange {
-            table: table.to_owned(),
-            column: want.name.clone(),
-        });
-    }
+    // NOTE: `Column.unique` is deliberately NOT diffed. On Postgres a single-column
+    // unique is ALSO recorded as an `Index`, so a uniqueness change surfaces through
+    // `diff_indexes` (comparing the flag too would double-report). On SQLite a
+    // brownfield inline `col TEXT UNIQUE` is not modeled at all (#1975 deferral — see
+    // `introspect::sqlite::collapse_indexes`), so there is no flag to diff.
 }
 
 /// Diff a table's indexes by name. A same-named index whose shape changed is a
@@ -1468,12 +1424,12 @@ fn baseline_unique_index_covers(base: &Table, want_columns: &[String]) -> bool {
     let want_set: BTreeSet<&str> = want_columns.iter().map(String::as_str).collect();
     // A single-column baseline `column.unique = true` fully enforces uniqueness of
     // that column. This covers the SQLite brownfield inline-`col TEXT UNIQUE` case:
-    // its constraint auto-index (`sqlite_autoindex_*`) is deliberately NOT recorded
-    // as an `Index` (its name is un-creatable/un-droppable — see
-    // `introspect::sqlite::collapse_indexes`), so the column flag is the ONLY signal
-    // that the model's `#[unique]` is already satisfied. (On Postgres the constraint
-    // ALSO produces a retained unique index, so this clause is redundant-but-correct
-    // there.)
+    // its constraint auto-index (`sqlite_autoindex_*`) is deliberately folded into the
+    // column flag (not recorded as an `Index` — its name is un-creatable/un-droppable,
+    // see `introspect::sqlite::collapse_indexes`), so the flag is the signal that the
+    // model's `#[unique]` is already satisfied (no redundant `AddIndex` that
+    // `guard_plan` would refuse on a populated table). On Postgres the constraint ALSO
+    // produces a retained unique index, so this clause is redundant-but-correct there.
     if want_columns.len() == 1
         && base
             .columns
@@ -1769,9 +1725,9 @@ pub fn guard_plan(plan: &MigrationPlan, opts: DiffOptions) -> Result<(), DiffErr
         return Err(DiffError::ForeignKeyChange { table, column });
     }
 
-    // 2a / 2a'. Identity-generation and inline-UNIQUE changes — no override; both
-    //           are produced ONLY by an authoritative diff (drift detection).
-    if let Some(err) = find_identity_change_block(plan).or_else(|| find_unique_change_block(plan)) {
+    // 2a. Identity-generation change — no override (needs ADD/DROP/SET GENERATED,
+    //     out of scope this slice). Only produced by an authoritative diff.
+    if let Some(err) = find_identity_change_block(plan) {
         return Err(err);
     }
 
@@ -1940,18 +1896,6 @@ pub fn guard_plan(plan: &MigrationPlan, opts: DiffOptions) -> Result<(), DiffErr
 fn find_identity_change_block(plan: &MigrationPlan) -> Option<DiffError> {
     plan.changes.iter().find_map(|c| match c {
         SchemaChange::IdentityChange { table, column } => Some(DiffError::IdentityChange {
-            table: table.clone(),
-            column: column.clone(),
-        }),
-        _ => None,
-    })
-}
-
-/// The [`DiffError::UniqueChange`] refusal for the first
-/// [`SchemaChange::UniqueChange`] marker in `plan`, if any.
-fn find_unique_change_block(plan: &MigrationPlan) -> Option<DiffError> {
-    plan.changes.iter().find_map(|c| match c {
-        SchemaChange::UniqueChange { table, column } => Some(DiffError::UniqueChange {
             table: table.clone(),
             column: column.clone(),
         }),
@@ -2492,7 +2436,6 @@ const fn change_table_name(change: &SchemaChange) -> &str {
         | SchemaChange::PrimaryKeyChange { table }
         | SchemaChange::ForeignKeyChange { table, .. }
         | SchemaChange::IdentityChange { table, .. }
-        | SchemaChange::UniqueChange { table, .. }
         | SchemaChange::DropTableBlockedByInboundFk { table, .. }
         | SchemaChange::AlterColumnTypeBlockedByFk { table, .. }
         | SchemaChange::AddForeignKeyToExistingColumn { table, .. }
@@ -3136,7 +3079,6 @@ const fn up_bucket(change: &SchemaChange) -> u8 {
         SchemaChange::PrimaryKeyChange { .. }
         | SchemaChange::ForeignKeyChange { .. }
         | SchemaChange::IdentityChange { .. }
-        | SchemaChange::UniqueChange { .. }
         | SchemaChange::DropTableBlockedByInboundFk { .. }
         | SchemaChange::AlterColumnTypeBlockedByFk { .. }
         | SchemaChange::AddForeignKeyToExistingColumn { .. }
@@ -3224,7 +3166,6 @@ fn emit_change_up(change: &SchemaChange, backend: Backend) -> Result<String, Emi
         SchemaChange::PrimaryKeyChange { .. }
         | SchemaChange::ForeignKeyChange { .. }
         | SchemaChange::IdentityChange { .. }
-        | SchemaChange::UniqueChange { .. }
         | SchemaChange::DropTableBlockedByInboundFk { .. }
         | SchemaChange::AlterColumnTypeBlockedByFk { .. }
         | SchemaChange::AddForeignKeyToExistingColumn { .. }
@@ -3313,7 +3254,6 @@ fn emit_change_down(change: &SchemaChange, backend: Backend) -> Result<String, E
         SchemaChange::PrimaryKeyChange { .. }
         | SchemaChange::ForeignKeyChange { .. }
         | SchemaChange::IdentityChange { .. }
-        | SchemaChange::UniqueChange { .. }
         | SchemaChange::DropTableBlockedByInboundFk { .. }
         | SchemaChange::AlterColumnTypeBlockedByFk { .. }
         | SchemaChange::AddForeignKeyToExistingColumn { .. }
@@ -3365,7 +3305,15 @@ fn render_create_table_body(name: &str, table: &Table, backend: Backend) -> Stri
         {
             lines.push(format!("    {} {}", col.name, kind.pk_sql(backend)));
         } else {
-            lines.push(format!("    {}", render_column_def(col, backend)));
+            // Render inline `UNIQUE` for a `Column.unique` column whose uniqueness is
+            // NOT already owned by a separate index (the SQLite inline-`UNIQUE` fold),
+            // so a rebuild/rollback preserves it without double-emitting for a model
+            // `#[unique]` field (which has a covering named index).
+            let render_unique = col.unique && !column_covered_by_unique_index(table, &col.name);
+            lines.push(format!(
+                "    {}",
+                render_column_def(col, backend, render_unique)
+            ));
         }
     }
 
@@ -3422,7 +3370,10 @@ fn emit_add_column(table: &str, column: &Column, backend: Backend) -> Result<Str
     let _ = writeln!(
         out,
         "ALTER TABLE {table} ADD COLUMN {};",
-        render_column_def(column, backend)
+        // ADD COLUMN never renders inline UNIQUE: a model `#[unique]` column arrives
+        // with a separate `AddIndex` that owns the uniqueness (SQLite column changes
+        // go through the table-rebuild path, not ADD COLUMN).
+        render_column_def(column, backend, false)
     );
     Ok(out)
 }
@@ -3430,13 +3381,23 @@ fn emit_add_column(table: &str, column: &Column, backend: Backend) -> Result<Str
 /// Render a column definition body: `{name} {type} {NOT NULL|NULL} [REFERENCES
 /// t(c)] [DEFAULT d]`. Shared by `CREATE TABLE` (non-PK columns) and `ADD
 /// COLUMN`.
-fn render_column_def(column: &Column, backend: Backend) -> String {
+fn render_column_def(column: &Column, backend: Backend, render_unique: bool) -> String {
     let mut def = format!(
         "{} {} {}",
         column.name,
         column.ty.sql_type(backend),
         nullability(column.nullable)
     );
+    // Inline single-column `UNIQUE` — rendered ONLY when the caller says so. It is
+    // emitted for a `Column.unique` column that is NOT already covered by a separate
+    // unique `Index` in the table (the SQLite brownfield inline-`UNIQUE` fold, whose
+    // constraint auto-index is deliberately not an `Index`). For a model `#[unique]`
+    // field — which carries BOTH `Column.unique` AND a covering named `Index` — the
+    // caller passes `false`, so the index owns the uniqueness and it is never
+    // double-emitted (zero golden churn).
+    if render_unique {
+        def.push_str(" UNIQUE");
+    }
     if let Some(fk) = &column.references {
         let _ = write!(def, " REFERENCES {}({})", fk.table, fk.column);
     }
@@ -3444,6 +3405,16 @@ fn render_column_def(column: &Column, backend: Backend) -> String {
         let _ = write!(def, " DEFAULT {}", default_sql(default, backend));
     }
     def
+}
+
+/// Whether some unique, non-partial `Index` in `table` keys on **exactly** the single
+/// column `col` — i.e. the column's uniqueness is already owned by a separate index,
+/// so it must NOT also be rendered as an inline `UNIQUE` (double-emit).
+fn column_covered_by_unique_index(table: &Table, col: &str) -> bool {
+    table
+        .indexes
+        .iter()
+        .any(|idx| full_unique_key_columns(idx).is_some_and(|k| k.len() == 1 && k.contains(col)))
 }
 
 /// `CREATE [UNIQUE] INDEX {name} ON {table} ({cols});`.
@@ -3680,9 +3651,6 @@ fn describe_change(change: &SchemaChange) -> String {
         SchemaChange::IdentityChange { table, column } => {
             format!("! IDENTITY CHANGE on {table}.{column} (refused)")
         }
-        SchemaChange::UniqueChange { table, column } => {
-            format!("! UNIQUE CHANGE on {table}.{column} (refused)")
-        }
         SchemaChange::DropTableBlockedByInboundFk {
             table,
             referencing_table,
@@ -3868,43 +3836,6 @@ mod tests {
                 .iter()
                 .any(|c| matches!(c, SchemaChange::IdentityChange { .. })),
             "model diff never flags an identity change: {:?}",
-            model.changes
-        );
-    }
-
-    /// P2 (authoritative Column.unique): a live DB dropping a single-column inline
-    /// `UNIQUE` (folded into `Column.unique`, with NO recorded Index) surfaces as
-    /// `UniqueChange` drift in the authoritative diff (doctor / pull --dry-run), but
-    /// is NOT flagged in a model diff (where `#[unique]` is an Index, not the flag).
-    #[test]
-    fn unique_flag_change_flagged_only_in_authoritative_diff() {
-        let mut base_email = col("email", ColumnType::Text);
-        base_email.unique = true; // snapshot: email is UNIQUE
-        let base = vec![posts_with(vec![base_email])];
-        let want_col = col("email", ColumnType::Text); // live: unique dropped
-        let want = posts_with(vec![want_col]);
-
-        let auth = diff_schema(&base, &parsed(vec![want.clone()], vec![]), AUTHORITATIVE);
-        assert!(
-            auth.changes.iter().any(|c| matches!(
-                c,
-                SchemaChange::UniqueChange { table, column } if table == "posts" && column == "email"
-            )),
-            "authoritative diff flags the dropped inline UNIQUE: {:?}",
-            auth.changes
-        );
-        assert!(matches!(
-            guard_plan(&auth, AUTHORITATIVE).unwrap_err(),
-            DiffError::UniqueChange { .. }
-        ));
-
-        let model = diff_schema(&base, &parsed(vec![want], vec![]), DEFAULT_OPTS);
-        assert!(
-            !model
-                .changes
-                .iter()
-                .any(|c| matches!(c, SchemaChange::UniqueChange { .. })),
-            "model diff never flags a Column.unique change: {:?}",
             model.changes
         );
     }

--- a/autumn-cli/src/schema/diff.rs
+++ b/autumn-cli/src/schema/diff.rs
@@ -1125,7 +1125,7 @@ fn diff_table(
         }
     }
 
-    diff_indexes(&want.name, base, want, &skipped, opts, changes);
+    diff_indexes(&want.name, base, want, &skipped, opts, backend, changes);
     diff_checks(&want.name, base, want, changes);
 }
 
@@ -1286,21 +1286,66 @@ fn indexes_equivalent(a: &Index, b: &Index) -> bool {
     }
 }
 
-/// Whether `index` depends on column `col` — i.e. Postgres would automatically
-/// drop the index (and any constraint it backs) when `col` is dropped via
-/// `ALTER TABLE … DROP COLUMN`. True iff `col` is in the index's `columns`.
+/// Whether `index` depends on column `col` — i.e. dropping `col` via
+/// `ALTER TABLE … DROP COLUMN` would leave the index referencing a missing column
+/// (so the index must be dropped/pruned first).
 ///
-/// For a retained (`definition`-carrying) expression/partial/constraint-owned index
-/// `columns` is the **exact `pg_depend` dependent-column set** captured by
-/// introspection (key, expression-referenced, AND predicate columns — the same set
-/// Postgres cascades on a `DROP COLUMN`), so membership is an exact match rather
-/// than a `definition`-text scan (which could false-positive on a column name that
-/// merely appears in a string literal, e.g. a partial index `WHERE kind = 'email'`
-/// while dropping an unrelated `email` column). Both `project_plan_target` (snapshot
-/// projection) and [`emit_down_sql_pg`] (rollback restore) use this single test so
-/// they cannot drift.
-pub fn index_depends_on_column(index: &Index, col: &str) -> bool {
-    index.columns.iter().any(|c| c == col)
+/// **Postgres**: dependency is EXACT `columns` membership. For a retained
+/// (`definition`-carrying) expression/partial/constraint-owned index `columns` is
+/// the **exact `pg_depend` dependent-column set** captured by introspection (key,
+/// expression-referenced, AND predicate columns — the same set Postgres cascades on
+/// a `DROP COLUMN`), so a text scan is unnecessary and deliberately avoided (it would
+/// false-positive on a column name that merely appears in a string literal, e.g. a
+/// partial index `WHERE kind = 'email'` while dropping an unrelated `email` column).
+///
+/// **`SQLite`**: a retained partial/expression index records only its KEY columns in
+/// `columns` (its WHERE-predicate / key-expression columns are NOT captured there —
+/// `SQLite`'s catalog exposes no `pg_depend` equivalent), so exact `columns`
+/// membership misses a predicate/expression column. To avoid emitting an
+/// invalid `DROP COLUMN` that orphans such an index, the verbatim `definition` is
+/// **word-bounded token-scanned** for `col`: any occurrence counts as a dependency,
+/// so the index is pruned before the column drop. This is the conservative
+/// over-include-is-safe direction (a false positive from a string literal at worst
+/// prunes an index that a rebuild would recreate anyway — never invalid SQL).
+///
+/// Both `project_plan_target` (snapshot projection) and [`emit_down_sql_pg`] use this
+/// single test so they cannot drift.
+pub fn index_depends_on_column(index: &Index, col: &str, backend: Backend) -> bool {
+    if index.columns.iter().any(|c| c == col) {
+        return true;
+    }
+    if backend == Backend::Sqlite
+        && let Some(def) = &index.definition
+    {
+        return definition_references_column(def, col);
+    }
+    false
+}
+
+/// Whether the verbatim index `definition` references the identifier `col` as a
+/// **word-bounded** token (case-insensitive; word chars are `[A-Za-z0-9_]`), so a
+/// quoted `"col"`, a bare `col`, or `col` inside an expression/predicate matches, but
+/// a longer identifier that merely contains it (`col_backup`, `old_col`) does not.
+fn definition_references_column(definition: &str, col: &str) -> bool {
+    if col.is_empty() {
+        return false;
+    }
+    let hay = definition.to_ascii_lowercase();
+    let needle = col.to_ascii_lowercase();
+    let hb = hay.as_bytes();
+    let is_word = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+    let mut from = 0;
+    while let Some(rel) = hay[from..].find(&needle) {
+        let start = from + rel;
+        let end = start + needle.len();
+        let before_ok = start == 0 || !is_word(hb[start - 1]);
+        let after_ok = end == hb.len() || !is_word(hb[end]);
+        if before_ok && after_ok {
+            return true;
+        }
+        from = start + 1;
+    }
+    false
 }
 
 ///
@@ -1427,12 +1472,25 @@ fn diff_indexes(
     want: &Table,
     skipped: &BTreeSet<String>,
     opts: DiffOptions,
+    backend: Backend,
     changes: &mut Vec<SchemaChange>,
 ) {
     let base_by_name: BTreeMap<&str, &Index> =
         base.indexes.iter().map(|i| (i.name.as_str(), i)).collect();
     let want_by_name: BTreeMap<&str, &Index> =
         want.indexes.iter().map(|i| (i.name.as_str(), i)).collect();
+    // Columns that this diff DROPS (present in the baseline, absent from the desired
+    // side, and not a parser-skipped column). An index — even a retained one — that
+    // depends on such a column CANNOT survive the drop (SQLite rejects DROP COLUMN on
+    // a referenced column), so it must be dropped BEFORE the column (`DropIndex` is
+    // ordered ahead of `DropColumn`).
+    let want_col_names: BTreeSet<&str> = want.columns.iter().map(|c| c.name.as_str()).collect();
+    let dropped_columns: Vec<&str> = base
+        .columns
+        .iter()
+        .map(|c| c.name.as_str())
+        .filter(|n| !want_col_names.contains(n) && !skipped.contains(*n))
+        .collect();
 
     for want_idx in &want.indexes {
         match base_by_name.get(want_idx.name.as_str()) {
@@ -1508,12 +1566,28 @@ fn diff_indexes(
         {
             continue;
         }
+        // SQLite ONLY: an index that depends on a column being DROPPED must be
+        // dropped first — even a retained (`definition`) one the model cannot express
+        // — else it would reference a missing column (SQLite rejects the
+        // `DROP COLUMN`). This OVERRIDES the retention rule below; its down leg
+        // recreates the index verbatim (after the column is re-added), so the
+        // rollback is faithful. Postgres is EXCLUDED: it cascade-drops the dependent
+        // index automatically on `DROP COLUMN` and restores it on rollback via
+        // `retained_indexes_depending_on_any`, so an explicit `DropIndex` there would
+        // double-drop and break that mechanism.
+        let orphaned_by_column_drop = backend == Backend::Sqlite
+            && dropped_columns
+                .iter()
+                .any(|c| index_depends_on_column(base_idx, c, backend));
         // A baseline-only `definition` index has no same-named desired index, and
         // in a model diff the desired side could not have expressed it anyway —
         // retain it (never DropIndex), independent of `allow_destructive`. In an
         // introspection diff it is authoritative, so a genuinely-dropped
         // expression/partial index still drops.
-        if base_idx.definition.is_some() && !opts.definitions_authoritative {
+        if base_idx.definition.is_some()
+            && !opts.definitions_authoritative
+            && !orphaned_by_column_drop
+        {
             continue;
         }
         changes.push(SchemaChange::DropIndex {
@@ -2251,7 +2325,9 @@ fn retained_indexes_depending_on_any<'a>(
                 i.definition.is_some()
                     && dropped_columns
                         .iter()
-                        .any(|c| index_depends_on_column(i, c))
+                        // pg-only rollback path (`emit_down_sql_pg`) — exact `columns`
+                        // membership; the SQLite definition-scan branch never runs here.
+                        .any(|c| index_depends_on_column(i, c, Backend::Postgres))
             })
             .collect()
     })
@@ -2501,6 +2577,14 @@ fn baseline_with_changes_applied(
             SchemaChange::DropColumn { column, .. } => {
                 shape.columns.retain(|c| c.name != column.name);
                 shape.primary_key.retain(|n| n != &column.name);
+                // Prune any index depending on the dropped column — including a
+                // retained partial/expression index that references the column only
+                // in its `definition` predicate/expression (SQLite rejects DROP
+                // COLUMN on a referenced column, and this rebuild must NOT recreate an
+                // orphaned index on the new table). This is the SQLite rebuild path.
+                shape
+                    .indexes
+                    .retain(|i| !index_depends_on_column(i, &column.name, Backend::Sqlite));
             }
             SchemaChange::AlterColumnType { column, to, .. } => {
                 if let Some(c) = shape.columns.iter_mut().find(|c| &c.name == column) {
@@ -8005,11 +8089,11 @@ PRAGMA foreign_keys=ON;
             key_columns: Vec::new(),
         };
         assert!(
-            !index_depends_on_column(&partial, "email"),
+            !index_depends_on_column(&partial, "email", Backend::Postgres),
             "a column name in a definition string literal is NOT a dependency (no false positive)"
         );
         assert!(
-            index_depends_on_column(&partial, "id"),
+            index_depends_on_column(&partial, "id", Backend::Postgres),
             "the true dependent column (in `columns`) IS a dependency"
         );
 
@@ -8023,11 +8107,11 @@ PRAGMA foreign_keys=ON;
             key_columns: Vec::new(),
         };
         assert!(
-            index_depends_on_column(&expr, "email"),
+            index_depends_on_column(&expr, "email", Backend::Postgres),
             "the expression-referenced `email` is captured in `columns`"
         );
         assert!(
-            !index_depends_on_column(&expr, "mail"),
+            !index_depends_on_column(&expr, "mail", Backend::Postgres),
             "a column absent from `columns` is not a dependency"
         );
 
@@ -8040,9 +8124,72 @@ PRAGMA foreign_keys=ON;
             key_columns: Vec::new(),
         };
         assert!(
-            index_depends_on_column(&plain, "email"),
+            index_depends_on_column(&plain, "email", Backend::Postgres),
             "columns membership counts as a dependency"
         );
+    }
+
+    /// On `SQLite` a retained partial/expression index records only its KEY columns in
+    /// `columns`, so a WHERE-predicate / key-expression column is detected via a
+    /// word-bounded `definition` scan — otherwise dropping it would orphan the index
+    /// and `SQLite` rejects the `DROP COLUMN`.
+    #[test]
+    fn sqlite_index_dependency_includes_predicate_and_expression_columns() {
+        // A partial index whose KEY is `email` but whose predicate references
+        // `deleted_at` (only in the definition text, NOT in `columns`).
+        let partial = Index {
+            name: "t_email_active".to_owned(),
+            columns: vec!["email".to_owned()],
+            unique: false,
+            definition: Some(
+                "CREATE INDEX t_email_active ON t (email) WHERE deleted_at IS NULL".to_owned(),
+            ),
+            is_partial: true,
+            key_columns: Vec::new(),
+        };
+        assert!(
+            index_depends_on_column(&partial, "deleted_at", Backend::Sqlite),
+            "the WHERE-predicate column is a dependency on SQLite (definition scan)"
+        );
+        assert!(
+            index_depends_on_column(&partial, "email", Backend::Sqlite),
+            "the key column is still a dependency"
+        );
+        // Word-bounded: a longer identifier that merely contains the name is NOT a hit.
+        assert!(!index_depends_on_column(
+            &partial,
+            "deleted",
+            Backend::Sqlite
+        ));
+        assert!(!index_depends_on_column(&partial, "at", Backend::Sqlite));
+        // The SAME index on Postgres keeps exact `columns` semantics (its real deps
+        // would be in `columns`), so the definition text is never scanned.
+        assert!(!index_depends_on_column(
+            &partial,
+            "deleted_at",
+            Backend::Postgres
+        ));
+    }
+
+    #[test]
+    fn definition_references_column_is_word_bounded_and_case_insensitive() {
+        let def = "CREATE INDEX i ON t (email) WHERE Deleted_At IS NULL AND kind = 'deleted_at_x'";
+        assert!(definition_references_column(def, "email"));
+        assert!(
+            definition_references_column(def, "deleted_at"),
+            "case-insensitive match against `Deleted_At`"
+        );
+        // A quoted identifier still matches (quotes are non-word boundaries).
+        assert!(definition_references_column(
+            "CREATE INDEX i ON t (\"email\")",
+            "email"
+        ));
+        // Substring of a longer token does NOT match.
+        assert!(!definition_references_column(
+            "CREATE INDEX i ON t (email_verified)",
+            "email"
+        ));
+        assert!(!definition_references_column(def, ""));
     }
 
     #[test]

--- a/autumn-cli/src/schema/diff.rs
+++ b/autumn-cli/src/schema/diff.rs
@@ -327,6 +327,28 @@ pub enum SchemaChange {
         column: String,
     },
 
+    /// A same-named column whose `GENERATED … AS IDENTITY` clause changed between
+    /// two authoritative introspections — e.g. the live database dropped the
+    /// identity (`GENERATED ALWAYS AS IDENTITY` → a plain column) or flipped its
+    /// generation (`ALWAYS` ↔ `BY DEFAULT`). A non-emittable marker: [`guard_plan`]
+    /// refuses any plan containing it (with **no override**).
+    ///
+    /// It exists so an identity-generation change surfaces as real drift in the
+    /// introspection diff (doctor's `database-schema-drift` and `pull --dry-run`)
+    /// instead of being silently ignored — changing an identity clause requires
+    /// `ADD`/`DROP`/`SET GENERATED …`, an exotic, out-of-scope operation this slice
+    /// does not auto-emit (mirroring the serial-PK id-generation refusal). It is
+    /// produced **only** in an authoritative diff (`definitions_authoritative`):
+    /// the model parser cannot express an identity clause, so in a model diff a
+    /// desired `identity: None` is "unknown, retained" (never drift), exactly like a
+    /// baseline `definition` index the DSL cannot describe.
+    IdentityChange {
+        /// The owning table name.
+        table: String,
+        /// The column whose identity clause changed.
+        column: String,
+    },
+
     /// A managed table is dropped while a **retained** table still holds a
     /// baseline foreign key pointing at it (e.g. drop `users` while
     /// `posts.user_id REFERENCES users(id)` survives). A non-emittable marker:
@@ -491,6 +513,21 @@ pub enum DiffError {
         /// The owning table name.
         table: String,
         /// The column whose FK target changed.
+        column: String,
+    },
+
+    /// A column's `GENERATED … AS IDENTITY` clause changed between two authoritative
+    /// introspections (unsupported this slice, **no override** — see
+    /// [`SchemaChange::IdentityChange`]).
+    #[error(
+        "identity-generation change on `{table}.{column}` is not supported in this slice: \
+         changing or dropping a `GENERATED … AS IDENTITY` clause requires an \
+         `ADD`/`DROP`/`SET GENERATED` migration this engine does not auto-emit."
+    )]
+    IdentityChange {
+        /// The owning table name.
+        table: String,
+        /// The column whose identity clause changed.
         column: String,
     },
 
@@ -1047,7 +1084,7 @@ fn diff_table(
     // likewise a primary-key change: converting one into the other requires
     // creating/dropping an owned sequence, which is deliberately out of scope for
     // an auto-generated migration, so it is refused through the same marker.
-    if base.primary_key != want.primary_key || single_pk_serial(base) != single_pk_serial(want) {
+    if base.primary_key != want.primary_key || serial_kinds_conflict(base, want) {
         changes.push(SchemaChange::PrimaryKeyChange {
             table: want.name.clone(),
         });
@@ -1070,7 +1107,7 @@ fn diff_table(
                 table: want.name.clone(),
                 column: want_col.clone(),
             }),
-            Some(base_col) => diff_column(&want.name, base_col, want_col, changes),
+            Some(base_col) => diff_column(&want.name, base_col, want_col, opts, changes),
         }
     }
 
@@ -1091,7 +1128,13 @@ fn diff_table(
 }
 
 /// Diff a single same-named column (keyed on name, never position).
-fn diff_column(table: &str, base: &Column, want: &Column, changes: &mut Vec<SchemaChange>) {
+fn diff_column(
+    table: &str,
+    base: &Column,
+    want: &Column,
+    opts: DiffOptions,
+    changes: &mut Vec<SchemaChange>,
+) {
     if base.ty != want.ty {
         changes.push(SchemaChange::AlterColumnType {
             table: table.to_owned(),
@@ -1159,6 +1202,23 @@ fn diff_column(table: &str, base: &Column, want: &Column, changes: &mut Vec<Sche
                 column: want.name.clone(),
             }),
         }
+    }
+
+    // Identity clause: an id-generation change (`GENERATED ALWAYS AS IDENTITY` →
+    // plain, or `ALWAYS` ↔ `BY DEFAULT`) is compared ONLY in an authoritative diff
+    // (both sides introspected — doctor's `database-schema-drift` and
+    // `pull --dry-run`). The model parser cannot express an identity clause, so in a
+    // model diff a desired `identity: None` is "unknown, retained" (never drift),
+    // exactly like a baseline `definition` index the DSL cannot describe — comparing
+    // it there would spuriously refuse every model against an identity-column DB.
+    // In an authoritative diff both sides carry the clause faithfully, so a genuine
+    // change surfaces as the refused `IdentityChange` marker instead of being
+    // silently dropped.
+    if opts.definitions_authoritative && base.identity != want.identity {
+        changes.push(SchemaChange::IdentityChange {
+            table: table.to_owned(),
+            column: want.name.clone(),
+        });
     }
 }
 
@@ -1486,6 +1546,12 @@ pub fn guard_plan(plan: &MigrationPlan, opts: DiffOptions) -> Result<(), DiffErr
         return Err(DiffError::ForeignKeyChange { table, column });
     }
 
+    // 2a. Identity-generation change — no override (needs ADD/DROP/SET GENERATED,
+    //     out of scope this slice). Only produced by an authoritative diff.
+    if let Some(err) = find_identity_change_block(plan) {
+        return Err(err);
+    }
+
     // 2b. Foreign key added to a pre-existing column — no override. A baseline
     //     `references: None` is *unknown* (the parser cannot see an association
     //     FK), so the DB may already carry the `<table>_<column>_fkey` constraint;
@@ -1644,6 +1710,18 @@ pub fn guard_plan(plan: &MigrationPlan, opts: DiffOptions) -> Result<(), DiffErr
     }
 
     Ok(())
+}
+
+/// The [`DiffError::IdentityChange`] refusal for the first
+/// [`SchemaChange::IdentityChange`] marker in `plan`, if any.
+fn find_identity_change_block(plan: &MigrationPlan) -> Option<DiffError> {
+    plan.changes.iter().find_map(|c| match c {
+        SchemaChange::IdentityChange { table, column } => Some(DiffError::IdentityChange {
+            table: table.clone(),
+            column: column.clone(),
+        }),
+        _ => None,
+    })
 }
 
 /// The [`DiffError::DropTableInboundReference`] refusal for the first
@@ -2176,6 +2254,7 @@ const fn change_table_name(change: &SchemaChange) -> &str {
         | SchemaChange::AddCheck { table, .. }
         | SchemaChange::PrimaryKeyChange { table }
         | SchemaChange::ForeignKeyChange { table, .. }
+        | SchemaChange::IdentityChange { table, .. }
         | SchemaChange::DropTableBlockedByInboundFk { table, .. }
         | SchemaChange::AlterColumnTypeBlockedByFk { table, .. }
         | SchemaChange::AddForeignKeyToExistingColumn { table, .. }
@@ -2810,6 +2889,7 @@ const fn up_bucket(change: &SchemaChange) -> u8 {
         // Non-emittable markers; the guard refuses them before emission is reached.
         SchemaChange::PrimaryKeyChange { .. }
         | SchemaChange::ForeignKeyChange { .. }
+        | SchemaChange::IdentityChange { .. }
         | SchemaChange::DropTableBlockedByInboundFk { .. }
         | SchemaChange::AlterColumnTypeBlockedByFk { .. }
         | SchemaChange::AddForeignKeyToExistingColumn { .. }
@@ -2896,6 +2976,7 @@ fn emit_change_up(change: &SchemaChange, backend: Backend) -> Result<String, Emi
         // in the command flow. Render nothing defensively rather than panicking.
         SchemaChange::PrimaryKeyChange { .. }
         | SchemaChange::ForeignKeyChange { .. }
+        | SchemaChange::IdentityChange { .. }
         | SchemaChange::DropTableBlockedByInboundFk { .. }
         | SchemaChange::AlterColumnTypeBlockedByFk { .. }
         | SchemaChange::AddForeignKeyToExistingColumn { .. }
@@ -2983,6 +3064,7 @@ fn emit_change_down(change: &SchemaChange, backend: Backend) -> Result<String, E
         }
         SchemaChange::PrimaryKeyChange { .. }
         | SchemaChange::ForeignKeyChange { .. }
+        | SchemaChange::IdentityChange { .. }
         | SchemaChange::DropTableBlockedByInboundFk { .. }
         | SchemaChange::AlterColumnTypeBlockedByFk { .. }
         | SchemaChange::AddForeignKeyToExistingColumn { .. }
@@ -3171,16 +3253,38 @@ fn single_pk_column(table: &Table) -> Option<(&Column, IdKind)> {
 }
 
 /// The [`SerialKind`] marker of a table's single-column primary key, or `None` for
-/// a composite PK, no PK, or a non-serial (plain / UUID) single PK. Used by
+/// a composite PK, no PK, a UUID single PK, or a legacy/unknown snapshot (the marker
+/// predates the field). A plain integer PK carries `Some(Plain)`; an owned-sequence
+/// id carries `Some(Serial)`/`Some(BigSerial)`. Used by [`serial_kinds_conflict`] /
 /// [`diff_table`] to detect a plain-int-PK ↔ serial-PK id-generation change (which
-/// is refused like any other primary-key change). Two matching serial ids compare
-/// equal, so a model↔database round-trip of a `BIGSERIAL` id stays clean.
+/// is refused like any other primary-key change) while a legacy `None` never drifts.
 fn single_pk_serial(table: &Table) -> Option<SerialKind> {
     if table.primary_key.len() != 1 {
         return None;
     }
     let name = &table.primary_key[0];
     table.columns.iter().find(|c| &c.name == name)?.serial
+}
+
+/// Whether the two tables' single-column-PK [`SerialKind`] markers CONFLICT — i.e.
+/// both sides carry an **explicit** marker and they differ.
+///
+/// The marker is three-state: `None` is *unknown* (a snapshot written before the
+/// field existed — serde default — or a non-integer/composite PK), while
+/// `Some(_)` is an explicit introspected/parsed id-generation strategy. A conflict
+/// is flagged ONLY when both sides are `Some(_)` and differ, so:
+///   * a legacy snapshot (`None`) vs the parser's `Some(BigSerial)` → NO drift
+///     (backward-compatibility: an existing project's pre-marker snapshot keeps
+///     round-tripping clean instead of a spurious refused primary-key change);
+///   * a fresh `BIGSERIAL` pull (`Some(BigSerial)`) vs model `Some(BigSerial)` →
+///     no drift;
+///   * a genuine plain-`BIGINT`-PK pull (`Some(Plain)`) vs model `Some(BigSerial)`
+///     → drift (fidelity preserved).
+fn serial_kinds_conflict(base: &Table, want: &Table) -> bool {
+    matches!(
+        (single_pk_serial(base), single_pk_serial(want)),
+        (Some(a), Some(b)) if a != b
+    )
 }
 
 /// Derive the id-generation strategy for a single-column PK:
@@ -3311,6 +3415,9 @@ fn describe_change(change: &SchemaChange) -> String {
         SchemaChange::ForeignKeyChange { table, column } => {
             format!("! FOREIGN KEY RETARGET on {table}.{column} (refused)")
         }
+        SchemaChange::IdentityChange { table, column } => {
+            format!("! IDENTITY CHANGE on {table}.{column} (refused)")
+        }
         SchemaChange::DropTableBlockedByInboundFk {
             table,
             referencing_table,
@@ -3401,6 +3508,104 @@ mod tests {
         allow_destructive: false,
         definitions_authoritative: true,
     };
+
+    /// `posts` with an explicit `serial` marker on its `id` PK (index 0).
+    fn posts_with_id_serial(kind: Option<SerialKind>) -> Table {
+        let mut t = posts_with(vec![]);
+        t.columns[0].serial = kind;
+        t
+    }
+
+    // -- serial-marker three-state compatibility -----------------------------
+
+    #[test]
+    fn serial_marker_legacy_none_is_compatible_with_parser_bigserial() {
+        // A pre-marker (legacy) snapshot deserializes `id.serial = None`; the parser
+        // marks the model `#[id]` as `Some(BigSerial)`. This must NOT flag a
+        // primary-key change — otherwise every existing project breaks until it
+        // rewrites its snapshot. Verified in BOTH diff modes.
+        let legacy = vec![posts_with_id_serial(None)];
+        let model = posts_with_id_serial(Some(SerialKind::BigSerial));
+        for opts in [DEFAULT_OPTS, AUTHORITATIVE] {
+            let plan = diff_schema(&legacy, &parsed(vec![model.clone()], vec![]), opts);
+            assert!(
+                !plan
+                    .changes
+                    .iter()
+                    .any(|c| matches!(c, SchemaChange::PrimaryKeyChange { .. })),
+                "legacy None vs Some(BigSerial) must be compatible ({opts:?}): {:?}",
+                plan.changes
+            );
+        }
+    }
+
+    #[test]
+    fn serial_marker_matching_bigserial_is_clean() {
+        let base = vec![posts_with_id_serial(Some(SerialKind::BigSerial))];
+        let want = posts_with_id_serial(Some(SerialKind::BigSerial));
+        let plan = diff_schema(&base, &parsed(vec![want], vec![]), DEFAULT_OPTS);
+        assert!(
+            plan.changes.is_empty(),
+            "matching markers: {:?}",
+            plan.changes
+        );
+    }
+
+    #[test]
+    fn serial_marker_plain_conflicts_with_bigserial() {
+        // A genuine plain-BIGINT-PK pull (`Some(Plain)`) vs a `BigSerial` model —
+        // BOTH explicit — is a real id-generation change → refused primary-key change
+        // (fidelity preserved).
+        let base = vec![posts_with_id_serial(Some(SerialKind::Plain))];
+        let want = posts_with_id_serial(Some(SerialKind::BigSerial));
+        let plan = diff_schema(&base, &parsed(vec![want], vec![]), DEFAULT_OPTS);
+        assert_eq!(
+            plan.changes,
+            vec![SchemaChange::PrimaryKeyChange {
+                table: "posts".to_owned(),
+            }]
+        );
+    }
+
+    // -- identity-clause drift -----------------------------------------------
+
+    #[test]
+    fn identity_change_flagged_only_in_authoritative_diff() {
+        // Two both-present introspections whose `id` identity clause differs
+        // (`ALWAYS` dropped to a plain column). In an authoritative diff (doctor /
+        // pull --dry-run) this is real drift → the refused `IdentityChange` marker;
+        // in a model diff the parser cannot express identity, so a desired `None` is
+        // "unknown, retained" (never drift).
+        let mut base_id = posts_with_id_serial(Some(SerialKind::BigSerial));
+        base_id.columns[0].identity = Some("ALWAYS".to_owned());
+        let base = vec![base_id];
+        let want = posts_with_id_serial(Some(SerialKind::BigSerial)); // identity: None
+
+        let auth = diff_schema(&base, &parsed(vec![want.clone()], vec![]), AUTHORITATIVE);
+        assert!(
+            auth.changes.iter().any(|c| matches!(
+                c,
+                SchemaChange::IdentityChange { table, column } if table == "posts" && column == "id"
+            )),
+            "authoritative diff flags the identity change: {:?}",
+            auth.changes
+        );
+        // The refused marker is rejected by the guard (no override).
+        assert!(matches!(
+            guard_plan(&auth, AUTHORITATIVE).unwrap_err(),
+            DiffError::IdentityChange { .. }
+        ));
+
+        let model = diff_schema(&base, &parsed(vec![want], vec![]), DEFAULT_OPTS);
+        assert!(
+            !model
+                .changes
+                .iter()
+                .any(|c| matches!(c, SchemaChange::IdentityChange { .. })),
+            "model diff never flags an identity change: {:?}",
+            model.changes
+        );
+    }
 
     // -- 13.1 structural diff ------------------------------------------------
 

--- a/autumn-cli/src/schema/diff.rs
+++ b/autumn-cli/src/schema/diff.rs
@@ -156,7 +156,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 
 use autumn_schema_core::{
-    Backend, CheckConstraint, Column, ColumnDefault, ColumnType, IdKind, Index, Table,
+    Backend, CheckConstraint, Column, ColumnDefault, ColumnType, IdKind, Index, SerialKind, Table,
 };
 
 use crate::schema::parse::ParsedSchema;
@@ -1041,8 +1041,13 @@ fn diff_table(
     changes: &mut Vec<SchemaChange>,
 ) {
     // A primary-key change is refused wholesale (guarded); emit only the marker
-    // and skip the rest of this table's diff.
-    if base.primary_key != want.primary_key {
+    // and skip the rest of this table's diff. A change to the id-generation
+    // strategy of the single-column PK (a plain `BIGINT PRIMARY KEY` becoming a
+    // `BIGSERIAL`, or vice versa — surfaced by the [`SerialKind`] marker) is
+    // likewise a primary-key change: converting one into the other requires
+    // creating/dropping an owned sequence, which is deliberately out of scope for
+    // an auto-generated migration, so it is refused through the same marker.
+    if base.primary_key != want.primary_key || single_pk_serial(base) != single_pk_serial(want) {
         changes.push(SchemaChange::PrimaryKeyChange {
             table: want.name.clone(),
         });
@@ -3163,6 +3168,19 @@ fn single_pk_column(table: &Table) -> Option<(&Column, IdKind)> {
     let name = &table.primary_key[0];
     let column = table.columns.iter().find(|c| &c.name == name)?;
     pk_kind_for(column).map(|kind| (column, kind))
+}
+
+/// The [`SerialKind`] marker of a table's single-column primary key, or `None` for
+/// a composite PK, no PK, or a non-serial (plain / UUID) single PK. Used by
+/// [`diff_table`] to detect a plain-int-PK ↔ serial-PK id-generation change (which
+/// is refused like any other primary-key change). Two matching serial ids compare
+/// equal, so a model↔database round-trip of a `BIGSERIAL` id stays clean.
+fn single_pk_serial(table: &Table) -> Option<SerialKind> {
+    if table.primary_key.len() != 1 {
+        return None;
+    }
+    let name = &table.primary_key[0];
+    table.columns.iter().find(|c| &c.name == name)?.serial
 }
 
 /// Derive the id-generation strategy for a single-column PK:

--- a/autumn-cli/src/schema/doctor.rs
+++ b/autumn-cli/src/schema/doctor.rs
@@ -20,8 +20,11 @@
 //!
 //! The pending-migrations check is Postgres-specific (it consumes the pg
 //! `pending_migrations` status API). A non-Postgres backend is reported as a
-//! skipped WARN rather than failing — doctor references no `SQLite` symbol and so
-//! compiles identically with or without the `sqlite` feature.
+//! skipped WARN rather than failing. The database-schema-drift check introspects
+//! the live database: on a default (Postgres-only) build a `SQLite` backend is
+//! skipped, while a `--features sqlite` build additionally references
+//! [`introspect_sqlite`](super::introspect::introspect_sqlite) so it can diff a live
+//! `SQLite` database too.
 
 use std::path::Path;
 
@@ -31,6 +34,8 @@ use serde::Serialize;
 
 use super::diff::{DiffOptions, MigrationPlan, diff_schema};
 use super::introspect::introspect_postgres;
+#[cfg(feature = "sqlite")]
+use super::introspect::introspect_sqlite;
 use super::parse::{ParsedSchema, parse_models_path};
 use super::snapshot::{SNAPSHOT_DEFAULT_PATH, SnapshotError, load_snapshot};
 
@@ -112,7 +117,12 @@ enum PendingState {
 enum DbSchemaState {
     /// No database URL is configured — the check is skipped.
     NotConfigured,
-    /// The backend/build cannot run this check (e.g. non-Postgres backend).
+    /// The backend/build cannot run this check (a `SQLite` backend on a default
+    /// Postgres-only build). Constructed only off the `sqlite` lane — on a `sqlite`
+    /// build both backends introspect, so this state is unreachable there (the
+    /// variant stays part of the type's vocabulary and is still matched in the check
+    /// renderer).
+    #[cfg_attr(feature = "sqlite", allow(dead_code))]
     Skipped(String),
     /// No readable snapshot baseline to diff the database against.
     SnapshotMissing,
@@ -280,9 +290,10 @@ fn probe_pending(url: &str, migrations_dir: &Path) -> PendingState {
 /// Probe the live database schema and diff it against the checked-in snapshot.
 ///
 /// Offline-safe by construction (mirrors [`gather_pending`]): no URL →
-/// [`DbSchemaState::NotConfigured`]; a non-Postgres backend →
-/// [`DbSchemaState::Skipped`] (introspection is Postgres-only in this slice); a
-/// missing/unreadable snapshot → [`DbSchemaState::SnapshotMissing`]; a
+/// [`DbSchemaState::NotConfigured`]; a `SQLite` backend on a default (Postgres-only)
+/// build → [`DbSchemaState::Skipped`] (the `SQLite` introspector is compiled only under
+/// the `sqlite` feature); a missing/unreadable snapshot →
+/// [`DbSchemaState::SnapshotMissing`]; a
 /// connect/query failure → [`DbSchemaState::Unreachable`] (a WARN, never an
 /// error — doctor must stay runnable offline). Only when all of those pass does
 /// it diff the introspected tables (desired) against the snapshot tables
@@ -295,19 +306,39 @@ fn gather_db_schema_drift(
     let Some(url) = crate::migrate::resolve_primary_url(profile) else {
         return DbSchemaState::NotConfigured;
     };
-    if local.detected_backend != Backend::Postgres {
-        return DbSchemaState::Skipped(format!(
-            "database-schema drift check is Postgres-only; detected {:?} backend",
+    match local.detected_backend {
+        Backend::Postgres => gather_db_schema_drift_with(project_root, &url, introspect_postgres),
+        #[cfg(feature = "sqlite")]
+        Backend::Sqlite => gather_db_schema_drift_with(project_root, &url, introspect_sqlite),
+        // On a default (Postgres-only) build the SQLite arm is not compiled, so a
+        // SQLite backend is skipped rather than failing doctor — introspection is
+        // Postgres-only on this build.
+        #[cfg(not(feature = "sqlite"))]
+        Backend::Sqlite => DbSchemaState::Skipped(format!(
+            "database-schema drift check is Postgres-only on this build; detected {:?} backend \
+             (rebuild with `--features sqlite` to check SQLite drift)",
             local.detected_backend
-        ));
+        )),
     }
+}
+
+/// Reload the snapshot baseline and diff it against the live database via
+/// `introspect` (a backend-specific introspector). Shared by the Postgres and `SQLite`
+/// arms of [`gather_db_schema_drift`] so both keep the identical offline-safe posture:
+/// a missing snapshot → [`DbSchemaState::SnapshotMissing`]; a connect/query failure →
+/// [`DbSchemaState::Unreachable`] (a WARN, never a hard failure).
+fn gather_db_schema_drift_with(
+    project_root: &Path,
+    url: &str,
+    introspect: impl Fn(&str) -> Result<Vec<Table>, super::introspect::IntrospectError>,
+) -> DbSchemaState {
     // Reload the snapshot baseline from disk (offline, cheap). A missing or
     // unreadable snapshot means there is nothing to diff the database against.
     let snapshot_path = project_root.join(SNAPSHOT_DEFAULT_PATH);
     let Ok(snapshot) = load_snapshot(&snapshot_path) else {
         return DbSchemaState::SnapshotMissing;
     };
-    match introspect_postgres(&url) {
+    match introspect(url) {
         Ok(tables) => {
             let drift = compute_db_schema_drift(&snapshot.tables, &tables);
             if drift.is_clean() {
@@ -697,7 +728,7 @@ mod tests {
     {{
       "name": "posts",
       "columns": [
-        {{ "name": "id", "ty": "Int64", "nullable": false, "primary_key": true, "unique": false, "default": null, "references": null }},
+        {{ "name": "id", "ty": "Int64", "nullable": false, "primary_key": true, "unique": false, "default": null, "references": null, "serial": "BigSerial" }},
         {{ "name": "title", "ty": "Text", "nullable": false, "primary_key": false, "unique": false, "default": null, "references": null }},
         {{ "name": "created_at", "ty": "Timestamp", "nullable": false, "primary_key": false, "unique": false, "default": "Now", "references": null }}
       ],

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -1280,12 +1280,16 @@ fn serial_kind_for(
 //   AUTOINCREMENT id is always recorded as `BigSerial` (there is no int4 serial).
 // - **FK on-update/on-delete actions, composite FKs, expression/collation index
 //   attributes**: same deferrals as the Postgres arm.
-// - **Composite inline `UNIQUE(a, b)` constraints**: a table-level UNIQUE-constraint
-//   auto-index (`sqlite_autoindex_*`) cannot be recorded — its name is un-creatable
-//   (`SQLite` refuses `CREATE … "sqlite_…"`) and the IR has no table-level
-//   unique-constraint node — so a composite inline `UNIQUE` is skipped (a
-//   single-column inline `UNIQUE` IS captured, as the column's `unique` flag). Rare
-//   brownfield shape; not tracked in the snapshot.
+// - **Composite inline `UNIQUE(a, b)` constraints (#1975)**: a table-level
+//   `UNIQUE(a, b)` produces a `sqlite_autoindex_*` auto-index whose name is
+//   un-creatable (`SQLite` refuses `CREATE … "sqlite_…"`) and un-droppable, and the
+//   IR has no table-level unique-constraint node — so it is skipped entirely (a rare
+//   brownfield shape; the live constraint is untouched). A SINGLE-column inline
+//   `col TEXT UNIQUE` IS modeled (folded into `Column.unique`, rendered inline on
+//   rebuild/rollback so uniqueness is preserved). Deferred narrow edge: an
+//   authoritative diff does not surface a MANUALLY-dropped single-column inline
+//   `UNIQUE` (the fold's `Column.unique` change is not diffed — on Postgres the
+//   equivalent drift is caught via the index diff).
 // - **Generated columns' expressions**: generated columns are PRESERVED (read via
 //   `pragma_table_xinfo`, never dropped), but their `GENERATED ALWAYS AS (...)`
 //   expression is not captured — a generated column round-trips as an ordinary column
@@ -1537,7 +1541,9 @@ mod sqlite {
         #[diesel(sql_type = Text)]
         column_name: String,
         /// The referenced column; `NULL` when the FK targets the referenced table's
-        /// PK implicitly (recovered as `id`, the Autumn convention).
+        /// PK implicitly (`REFERENCES parent` with no column) — then resolved to the
+        /// parent's actual single-column PK, or the FK is omitted if the parent has a
+        /// composite / no single-column PK.
         #[diesel(sql_type = Nullable<Text>)]
         foreign_column: Option<String>,
     }
@@ -1559,6 +1565,9 @@ mod sqlite {
         let indexes_by_table = fetch_indexes(conn)?;
         let index_columns = fetch_index_columns(conn)?;
         let fks_by_table = fetch_foreign_keys(conn)?;
+        // Each table's single-column primary key (absent for composite / PK-less
+        // tables), used to resolve an implicit `REFERENCES parent` FK target.
+        let single_col_pks = single_column_pks(&columns_by_table);
 
         let mut out = Vec::with_capacity(tables.len());
         for (name, table_sql) in &tables {
@@ -1569,9 +1578,27 @@ mod sqlite {
                 indexes_by_table.get(name).map_or(&[][..], Vec::as_slice),
                 &index_columns,
                 fks_by_table.get(name).map_or(&[][..], Vec::as_slice),
+                &single_col_pks,
             ));
         }
         Ok(out)
+    }
+
+    /// Map each table to its SINGLE-column primary-key column name, if it has exactly
+    /// one. Composite-PK (or PK-less) tables are deliberately ABSENT — an implicit
+    /// `REFERENCES parent` FK (`SQLite` reports `.to = NULL`) to such a parent has no
+    /// unambiguous target column and is omitted rather than guessed.
+    fn single_column_pks(
+        columns_by_table: &BTreeMap<String, Vec<ColumnRow>>,
+    ) -> BTreeMap<String, String> {
+        let mut out = BTreeMap::new();
+        for (table, cols) in columns_by_table {
+            let mut pk_cols = cols.iter().filter(|c| c.pk > 0);
+            if let (Some(first), None) = (pk_cols.next(), pk_cols.next()) {
+                out.insert(table.clone(), first.column_name.clone());
+            }
+        }
+        out
     }
 
     /// List app tables (name + `CREATE TABLE` SQL), excluding `SQLite` internal
@@ -1915,6 +1942,7 @@ mod sqlite {
         indexes: &[IndexRow],
         index_columns: &BTreeMap<IndexKey, Vec<IndexColumnRow>>,
         foreign_keys: &[ForeignKeyRow],
+        single_col_pks: &BTreeMap<String, String>,
     ) -> Table {
         let mut table = Table::new(name, Backend::Sqlite);
         table.managed = true;
@@ -1980,8 +2008,20 @@ mod sqlite {
                 });
             }
             if let Some(fk) = fk_by_column.get(row.column_name.as_str()) {
-                let foreign_column = fk.foreign_column.clone().unwrap_or_else(|| "id".to_owned());
-                column.references = Some(ForeignKey::new(fk.foreign_table.clone(), foreign_column));
+                // An implicit `REFERENCES parent` (SQLite reports `to = NULL`) targets
+                // the parent's PRIMARY KEY — resolve the parent's actual single-column
+                // PK rather than guessing `id`. A parent with a composite (or no)
+                // single-column PK is unresolvable, so the FK is OMITTED (fail-closed)
+                // rather than recorded with a wrong target that would re-emit wrong on
+                // rebuild/rollback and never drift.
+                let foreign_column = fk.foreign_column.clone().or_else(|| {
+                    // Implicit target → the parent's actual single-column PK.
+                    single_col_pks.get(&fk.foreign_table).cloned()
+                });
+                if let Some(foreign_column) = foreign_column {
+                    column.references =
+                        Some(ForeignKey::new(fk.foreign_table.clone(), foreign_column));
+                }
             }
             table.columns.push(column);
         }
@@ -1999,21 +2039,18 @@ mod sqlite {
     /// key auto-index (`origin = 'pk'`) is skipped (the PK is modeled separately).
     ///
     /// A `UNIQUE`-constraint auto-index (`origin = 'u'`, named
-    /// `sqlite_autoindex_<table>_<n>`) has **no** standalone `CREATE INDEX` statement
-    /// and is owned by the constraint — it cannot be `DROP INDEX`ed, and `SQLite`
-    /// refuses to `CREATE` any object named `sqlite_*`, so it must **never** appear as
-    /// an [`Index`] in the IR (the emitter would try to re-`CREATE` it by name on a
-    /// table rebuild / `DropTable` rollback and produce illegal `CREATE … "sqlite_…"`
-    /// DDL). Instead:
-    /// * a **single-column** inline `col TEXT UNIQUE` is represented purely as the
-    ///   column's `unique = true` flag (no [`Index`] object) — a matching `#[unique]`
-    ///   model is recognized as already satisfied (clean diff, no `DropIndex`, no
-    ///   `sqlite_`-named `CREATE`);
-    /// * a **composite** table-level `UNIQUE(a, b)` cannot be represented (the IR has
-    ///   no table-level unique-constraint node, and the model DSL cannot express it),
-    ///   so it is **skipped entirely** rather than synthesized as a `sqlite_`-named
-    ///   index (DEFERRED: composite inline-`UNIQUE` fidelity — a rare brownfield shape
-    ///   — is not tracked in the snapshot; see the module note).
+    /// `sqlite_autoindex_<table>_<n>`) is **never** recorded as an [`Index`] — its
+    /// `sqlite_*` name is un-creatable (`SQLite` refuses to `CREATE` a
+    /// `sqlite_`-prefixed object) and un-droppable, so re-emitting it by name on a
+    /// rebuild / `DropTable` rollback would produce illegal DDL. Instead a
+    /// **single-column** inline `col TEXT UNIQUE` is folded into the column's
+    /// `unique = true` flag: a matching `#[unique]` model is recognized as already
+    /// satisfied ([`baseline_unique_index_covers`], no `AddIndex` / no guard refusal),
+    /// and the emitter renders it as inline `UNIQUE` on a rebuild/rollback
+    /// ([`render_create_table_body`]) so uniqueness is preserved. A **composite**
+    /// table-level `UNIQUE(a, b)` has no single-column flag and no recreatable IR form,
+    /// so it is skipped entirely (DEFERRED, #1975 — a rare brownfield shape; the live
+    /// constraint is untouched).
     fn collapse_indexes(
         table_name: &str,
         rows: &[IndexRow],
@@ -2025,6 +2062,20 @@ mod sqlite {
             if row.origin == "pk" {
                 continue;
             }
+            // A UNIQUE-constraint auto-index (`origin = 'u'`) is NEVER an Index; a
+            // single-column one folds into the column's `unique` flag, a composite one
+            // is skipped (see the fn note).
+            if row.origin == "u" {
+                let cols = index_columns
+                    .get(&(table_name.to_owned(), row.index_name.clone()))
+                    .map_or(&[][..], Vec::as_slice);
+                let key_columns: Vec<String> =
+                    cols.iter().filter_map(|c| c.column_name.clone()).collect();
+                if row.is_unique != 0 && key_columns.len() == 1 {
+                    unique_columns.insert(key_columns[0].clone());
+                }
+                continue;
+            }
             let cols = index_columns
                 .get(&(table_name.to_owned(), row.index_name.clone()))
                 .map_or(&[][..], Vec::as_slice);
@@ -2033,16 +2084,6 @@ mod sqlite {
                 cols.iter().filter_map(|c| c.column_name.clone()).collect();
             let is_unique = row.is_unique != 0;
             let is_partial = row.partial != 0;
-
-            // A UNIQUE-constraint auto-index (`origin = 'u'`) is NEVER emitted as an
-            // Index (its `sqlite_*` name is un-creatable and un-droppable). A single
-            // column becomes the column's `unique` flag; a composite one is skipped.
-            if row.origin == "u" {
-                if is_unique && !has_expression && key_columns.len() == 1 {
-                    unique_columns.insert(key_columns[0].clone());
-                }
-                continue;
-            }
 
             let simple = !is_partial && !has_expression;
             if simple && is_unique && key_columns.len() == 1 {
@@ -2170,7 +2211,15 @@ mod sqlite {
             let table_sql = "CREATE TABLE posts (id INTEGER PRIMARY KEY AUTOINCREMENT, \
                              title TEXT NOT NULL, body TEXT NULL, \
                              created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)";
-            let table = build_table("posts", table_sql, &columns, &[], &BTreeMap::new(), &[]);
+            let table = build_table(
+                "posts",
+                table_sql,
+                &columns,
+                &[],
+                &BTreeMap::new(),
+                &[],
+                &BTreeMap::new(),
+            );
             assert_eq!(table.primary_key, vec!["id".to_owned()]);
 
             let id = table.columns.iter().find(|c| c.name == "id").unwrap();
@@ -2201,7 +2250,15 @@ mod sqlite {
             // compatible.
             let columns = vec![col_row("id", "INTEGER", 0, None, 1)];
             let table_sql = "CREATE TABLE posts (id INTEGER PRIMARY KEY)";
-            let table = build_table("posts", table_sql, &columns, &[], &BTreeMap::new(), &[]);
+            let table = build_table(
+                "posts",
+                table_sql,
+                &columns,
+                &[],
+                &BTreeMap::new(),
+                &[],
+                &BTreeMap::new(),
+            );
             let id = table.columns.iter().find(|c| c.name == "id").unwrap();
             assert_eq!(id.serial, Some(SerialKind::Plain));
         }
@@ -2260,6 +2317,7 @@ mod sqlite {
                 &[],
                 &BTreeMap::new(),
                 &[],
+                &BTreeMap::new(),
             );
             let id = table.columns.iter().find(|c| c.name == "id").unwrap();
             assert_eq!(id.serial, Some(SerialKind::Plain));
@@ -2280,7 +2338,15 @@ mod sqlite {
             let table_sql = "CREATE TABLE posts (id INTEGER PRIMARY KEY, first TEXT NOT NULL, \
                              full_stored TEXT GENERATED ALWAYS AS (first) STORED, \
                              full_virtual TEXT GENERATED ALWAYS AS (first) VIRTUAL)";
-            let table = build_table("posts", table_sql, &columns, &[], &BTreeMap::new(), &[]);
+            let table = build_table(
+                "posts",
+                table_sql,
+                &columns,
+                &[],
+                &BTreeMap::new(),
+                &[],
+                &BTreeMap::new(),
+            );
             let names: Vec<&str> = table.columns.iter().map(|c| c.name.as_str()).collect();
             assert!(
                 names.contains(&"full_stored") && names.contains(&"full_virtual"),
@@ -2290,6 +2356,85 @@ mod sqlite {
                 !names.contains(&"internal"),
                 "an internal hidden column (hidden = 1) is skipped: {names:?}"
             );
+        }
+
+        #[test]
+        fn build_table_resolves_implicit_fk_target_from_parent_pk() {
+            let columns = vec![
+                col_row("id", "INTEGER", 0, None, 1),
+                col_row("parent_code", "TEXT", 1, None, 0),
+                col_row("orphan_ref", "TEXT", 1, None, 0),
+            ];
+            // Two implicit FKs (`foreign_column = None`): one to a parent with a real
+            // single-column non-`id` PK (`code`), one to a composite-PK parent.
+            let fks = vec![
+                ForeignKeyRow {
+                    table_name: "children".to_owned(),
+                    foreign_table: "parents".to_owned(),
+                    column_name: "parent_code".to_owned(),
+                    foreign_column: None,
+                },
+                ForeignKeyRow {
+                    table_name: "children".to_owned(),
+                    foreign_table: "composite_parent".to_owned(),
+                    column_name: "orphan_ref".to_owned(),
+                    foreign_column: None,
+                },
+            ];
+            // `parents` has a single-column PK `code`; `composite_parent` is absent
+            // (composite/unresolvable).
+            let mut single_col_pks = BTreeMap::new();
+            single_col_pks.insert("parents".to_owned(), "code".to_owned());
+            let table = build_table(
+                "children",
+                "CREATE TABLE children (id INTEGER PRIMARY KEY, parent_code TEXT NOT NULL \
+                 REFERENCES parents, orphan_ref TEXT NOT NULL REFERENCES composite_parent)",
+                &columns,
+                &[],
+                &BTreeMap::new(),
+                &fks,
+                &single_col_pks,
+            );
+            // The implicit FK resolves to the parent's REAL single-column PK, not `id`.
+            let parent_code = table
+                .columns
+                .iter()
+                .find(|c| c.name == "parent_code")
+                .unwrap();
+            let fk = parent_code.references.as_ref().expect("FK resolved");
+            assert_eq!(fk.table, "parents");
+            assert_eq!(fk.column, "code", "resolved to the real PK, not `id`");
+            // The FK to a composite/unresolvable parent is OMITTED (not guessed `id`).
+            let orphan = table
+                .columns
+                .iter()
+                .find(|c| c.name == "orphan_ref")
+                .unwrap();
+            assert!(
+                orphan.references.is_none(),
+                "an implicit FK to a composite/unresolvable-PK parent is omitted"
+            );
+        }
+
+        #[test]
+        fn single_column_pks_excludes_composite_and_pkless() {
+            let mut columns_by_table = BTreeMap::new();
+            columns_by_table.insert(
+                "parents".to_owned(),
+                vec![col_row("code", "TEXT", 1, None, 1)],
+            );
+            columns_by_table.insert(
+                "composite".to_owned(),
+                vec![
+                    col_row("a", "INTEGER", 1, None, 1),
+                    col_row("b", "INTEGER", 1, None, 2),
+                ],
+            );
+            columns_by_table.insert("pkless".to_owned(), vec![col_row("x", "TEXT", 0, None, 0)]);
+            let pks = single_column_pks(&columns_by_table);
+            assert_eq!(pks.get("parents").map(String::as_str), Some("code"));
+            assert!(!pks.contains_key("composite"), "composite PK excluded");
+            assert!(!pks.contains_key("pkless"), "PK-less table excluded");
         }
 
         #[test]
@@ -2369,88 +2514,48 @@ mod sqlite {
         }
 
         #[test]
-        fn collapse_indexes_single_col_unique_autoindex_becomes_column_flag_not_index() {
-            // A single-column `col TEXT UNIQUE` inline constraint produces a
-            // `sqlite_autoindex_*` (origin = 'u') with NO standalone CREATE INDEX SQL.
-            // Its `sqlite_*` name is un-creatable AND un-droppable, so it must produce
-            // NO Index object (only the column's `unique` flag) — otherwise the
-            // emitter would try to re-CREATE / DROP `sqlite_autoindex_*` on a rebuild.
-            let rows = vec![IndexRow {
-                table_name: "accounts".to_owned(),
-                index_name: "sqlite_autoindex_accounts_1".to_owned(),
-                is_unique: 1,
-                origin: "u".to_owned(),
-                partial: 0,
-                index_sql: None,
-            }];
-            let mut index_columns = BTreeMap::new();
-            index_columns.insert(
-                (
-                    "accounts".to_owned(),
-                    "sqlite_autoindex_accounts_1".to_owned(),
-                ),
-                vec![IndexColumnRow {
-                    table_name: "accounts".to_owned(),
-                    index_name: "sqlite_autoindex_accounts_1".to_owned(),
-                    seqno: 0,
-                    column_name: Some("email".to_owned()),
-                }],
-            );
-            let (indexes, unique_cols) = collapse_indexes("accounts", &rows, &index_columns);
-            assert!(
-                indexes.is_empty(),
-                "a UNIQUE-constraint autoindex is NEVER an Index (its sqlite_* name is \
-                 un-creatable/un-droppable): {indexes:?}"
-            );
-            assert!(
-                unique_cols.contains("email"),
-                "it is represented purely as the column's unique flag"
-            );
-        }
-
-        #[test]
-        fn collapse_indexes_composite_unique_autoindex_is_skipped() {
-            // A composite table-level `UNIQUE(a, b)` autoindex (origin = 'u') cannot be
-            // represented (no table-level unique node in the IR, un-creatable name), so
-            // it is skipped entirely — never synthesized as a `sqlite_`-named index.
-            let rows = vec![IndexRow {
-                table_name: "memberships".to_owned(),
-                index_name: "sqlite_autoindex_memberships_1".to_owned(),
-                is_unique: 1,
-                origin: "u".to_owned(),
-                partial: 0,
-                index_sql: None,
-            }];
-            let mut index_columns = BTreeMap::new();
-            index_columns.insert(
-                (
-                    "memberships".to_owned(),
-                    "sqlite_autoindex_memberships_1".to_owned(),
-                ),
-                vec![
-                    IndexColumnRow {
-                        table_name: "memberships".to_owned(),
-                        index_name: "sqlite_autoindex_memberships_1".to_owned(),
-                        seqno: 0,
-                        column_name: Some("org_id".to_owned()),
-                    },
-                    IndexColumnRow {
-                        table_name: "memberships".to_owned(),
-                        index_name: "sqlite_autoindex_memberships_1".to_owned(),
-                        seqno: 1,
-                        column_name: Some("user_id".to_owned()),
-                    },
-                ],
-            );
-            let (indexes, unique_cols) = collapse_indexes("memberships", &rows, &index_columns);
-            assert!(
-                indexes.is_empty(),
-                "composite UNIQUE autoindex is skipped: {indexes:?}"
-            );
-            assert!(
-                unique_cols.is_empty(),
-                "a composite UNIQUE marks no single column unique"
-            );
+        fn collapse_indexes_unique_constraint_autoindex_folds_or_skips() {
+            // A `sqlite_autoindex_*` (origin = 'u') is NEVER an Index (un-creatable /
+            // un-droppable name). A SINGLE-column one folds into the column's `unique`
+            // flag; a COMPOSITE one is skipped entirely (no flag either).
+            for (cols, expect_flag) in [(vec!["email"], Some("email")), (vec!["a", "b"], None)] {
+                let rows = vec![IndexRow {
+                    table_name: "t".to_owned(),
+                    index_name: "sqlite_autoindex_t_1".to_owned(),
+                    is_unique: 1,
+                    origin: "u".to_owned(),
+                    partial: 0,
+                    index_sql: None,
+                }];
+                let mut index_columns = BTreeMap::new();
+                index_columns.insert(
+                    ("t".to_owned(), "sqlite_autoindex_t_1".to_owned()),
+                    cols.iter()
+                        .enumerate()
+                        .map(|(i, c)| IndexColumnRow {
+                            table_name: "t".to_owned(),
+                            index_name: "sqlite_autoindex_t_1".to_owned(),
+                            seqno: i32::try_from(i).unwrap(),
+                            column_name: Some((*c).to_owned()),
+                        })
+                        .collect(),
+                );
+                let (indexes, unique_cols) = collapse_indexes("t", &rows, &index_columns);
+                assert!(
+                    indexes.is_empty(),
+                    "a UNIQUE-constraint autoindex is never an Index: {indexes:?}"
+                );
+                match expect_flag {
+                    Some(c) => assert!(
+                        unique_cols.contains(c),
+                        "single-column inline UNIQUE folds into the column flag"
+                    ),
+                    None => assert!(
+                        unique_cols.is_empty(),
+                        "a composite UNIQUE marks no single column unique: {unique_cols:?}"
+                    ),
+                }
+            }
         }
 
         #[test]

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -130,14 +130,16 @@
 //!   note above.)
 //! - **CHECK constraint `NO INHERIT` / `NOT VALID` suffixes**: dropped on
 //!   recreation (the predicate is preserved; the suffix is not modeled).
-//! - **`GENERATED ... AS IDENTITY` columns**: pulled as ordinary integer columns
-//!   (their identity metadata from `information_schema.columns.is_identity` is not
-//!   modeled); recreation emits a plain column / loses the identity — identity
-//!   modeling is deferred alongside owned sequences.
-//! - **PG15+ `NULLS NOT DISTINCT` unique indexes**: pulled as ordinary unique
-//!   indexes; the `NULLS NOT DISTINCT` clause is not preserved (detecting it needs
-//!   the PG15+ `pg_index.indnullsnotdistinct` catalog column, which would break
-//!   introspection on PG13/14). Deferred.
+//! - **`GENERATED ... AS IDENTITY` columns**: the identity generation clause
+//!   (`information_schema.columns.is_identity` / `identity_generation`) is now
+//!   **preserved verbatim** on [`Column::identity`] so the column round-trips a
+//!   pull rather than flattening to a plain integer column. (Emitting the identity
+//!   clause back out into recreated DDL is a later slice — the IR preserves it, the
+//!   DDL emitter does not yet re-render it.)
+//! - **PG15+ `NULLS NOT DISTINCT` unique indexes**: now **retained verbatim** via
+//!   [`Index::definition`] — detected in the `pg_get_indexdef` text (version-safe on
+//!   PG13/14, which never emit the clause) rather than via the PG15-only
+//!   `pg_index.indnullsnotdistinct` catalog column — so the clause round-trips.
 //! - **Stored/virtual `GENERATED ALWAYS AS (...) STORED` generated columns**: pulled
 //!   as ordinary columns; the generation expression
 //!   (`information_schema.columns.generation_expression`) is not modeled, so
@@ -151,7 +153,8 @@
 use std::collections::BTreeMap;
 
 use autumn_schema_core::{
-    Backend, CheckConstraint, Column, ColumnDefault, ColumnType, ForeignKey, Index, Table,
+    Backend, CheckConstraint, Column, ColumnDefault, ColumnType, ForeignKey, Index, SerialKind,
+    Table,
 };
 use diesel::{Connection as _, PgConnection, QueryableByName, RunQueryDsl as _, sql_query};
 
@@ -174,6 +177,14 @@ pub enum IntrospectError {
     /// A catalog query failed. The message comes from the server, not the URL.
     #[error("database introspection query failed: {0}")]
     Query(String),
+    /// The `SQLite` database file could not be opened. Carries only the parsed
+    /// file path (a `SQLite` DSN carries no credentials), never the raw URL.
+    #[cfg(feature = "sqlite")]
+    #[error("could not open the SQLite database at {path} — is the file present and readable?")]
+    ConnectionSqlite {
+        /// The resolved `SQLite` file path (`:memory:` for an in-memory target).
+        path: String,
+    },
 }
 
 /// Introspect the `public` schema of the Postgres database at `url` into a set of
@@ -287,6 +298,19 @@ struct ColumnRow {
     /// supported Postgres (no PG15+ catalog columns).
     #[diesel(sql_type = diesel::sql_types::Bool)]
     owns_sequence: bool,
+    /// `information_schema.columns.is_identity` (`'YES'`/`'NO'`) — whether the
+    /// column is declared `GENERATED { ALWAYS | BY DEFAULT } AS IDENTITY`. An
+    /// identity column has no `column_default` (its value is minted by an internal
+    /// sequence Postgres owns), so without this flag it would pull back as an
+    /// ordinary integer column and silently lose its identity behavior. Version-safe:
+    /// `is_identity` has existed since PG10 (identity columns were introduced there).
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    is_identity: String,
+    /// `information_schema.columns.identity_generation` (`'ALWAYS'` / `'BY DEFAULT'`,
+    /// or `NULL` for a non-identity column) — preserved verbatim on
+    /// [`Column::identity`] so the identity clause round-trips through a pull.
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+    identity_generation: Option<String>,
 }
 
 #[derive(QueryableByName)]
@@ -489,6 +513,7 @@ fn fetch_columns(
          c.numeric_scale::integer AS numeric_scale, \
          c.character_maximum_length::integer AS character_maximum_length, \
          c.domain_name, c.domain_schema, \
+         c.is_identity, c.identity_generation, \
          EXISTS ( \
            SELECT 1 \
            FROM pg_depend dep \
@@ -860,6 +885,30 @@ fn build_table(
             primary_key,
             row.owns_sequence,
         );
+        // Serial-vs-plain marker: a single-column integer PK whose `nextval(...)`
+        // default the column OWNS is a `SERIAL`/`BIGSERIAL` id (distinguished by
+        // int4 vs int8). A plain manually-assigned `INTEGER`/`BIGINT` PK (no owned
+        // sequence) leaves this `None`, so the two are no longer indistinguishable
+        // in the IR. Computed from the RAW default (before `normalize_default`
+        // strips an int8 owned-serial default to `None`).
+        column.serial = serial_kind_for(
+            row.column_default.as_deref(),
+            &ty,
+            is_pk,
+            primary_key,
+            row.owns_sequence,
+        );
+        // Identity marker: preserve a `GENERATED { ALWAYS | BY DEFAULT } AS
+        // IDENTITY` column's generation clause verbatim so it round-trips a pull
+        // instead of flattening to a plain integer column. An identity column has
+        // no `column_default`, so it never collides with the serial marker.
+        if row.is_identity.eq_ignore_ascii_case("YES") {
+            column.identity = Some(
+                row.identity_generation
+                    .clone()
+                    .unwrap_or_else(|| "ALWAYS".to_owned()),
+            );
+        }
         if let Some(fk) = fk_by_column.get(row.column_name.as_str()) {
             // Fail-closed floor for cross-schema FK targets: a FK to a table
             // outside `public` (`REFERENCES auth.users(id)`) must be stored
@@ -951,7 +1000,21 @@ fn collapse_indexes(rows: &[IndexRow]) -> (Vec<Index>, std::collections::BTreeSe
         // way and is never diffed). A covering `INCLUDE` unique index is NOT
         // simple, so it never sets that flag (its uniqueness scope is only its
         // key columns) and is retained verbatim via its `definition`.
-        let simple = !row.is_partial && !row.has_expression && !row.has_include;
+        // A PG15+ `NULLS NOT DISTINCT` unique index enforces STRICTER uniqueness
+        // than a plain (nulls-distinct) unique index, and the model DSL cannot
+        // express it. `pg_get_indexdef` (version-safe on every supported Postgres —
+        // it never emits the clause on PG13/14) renders the `NULLS NOT DISTINCT`
+        // clause into the `definition` text; detecting it there (rather than via the
+        // PG15-only `pg_index.indnullsnotdistinct` catalog column, which would break
+        // introspection on PG13/14) forces the index to be retained VERBATIM via its
+        // `definition` so the clause round-trips, instead of collapsing to an
+        // ordinary unique index that would silently drop it.
+        let nulls_not_distinct = row
+            .definition
+            .to_ascii_uppercase()
+            .contains("NULLS NOT DISTINCT");
+        let simple =
+            !row.is_partial && !row.has_expression && !row.has_include && !nulls_not_distinct;
         if simple && row.is_unique && key_columns.len() == 1 {
             unique_columns.insert(key_columns[0].clone());
         }
@@ -1103,6 +1166,719 @@ fn normalize_serial_pk_default(
         && matches!(ty, ColumnType::Int64)
         && lowered_default.starts_with("nextval(")
         && owns_sequence
+}
+
+/// The [`SerialKind`] marker for a column: `Some` only for a single-column integer
+/// primary key whose `nextval(...)` default the column **owns** — a conventional
+/// `SERIAL` (int4) / `BIGSERIAL` (int8). A plain manually-assigned `INTEGER` /
+/// `BIGINT` PK (no owned sequence), a non-PK serial, a composite PK, or a shared
+/// (non-owned) sequence default all return `None`, so the marker cleanly separates
+/// an owned-sequence auto-increment id from a plain integer PK of the same width.
+///
+/// This mirrors [`normalize_serial_pk_default`]'s ownership rule but distinguishes
+/// int4 vs int8 (so a brownfield `SERIAL` PK is marked `Serial` and a `BIGSERIAL`
+/// PK `BigSerial`), and is independent of the default-stripping: an int8 owned
+/// serial's `nextval(...)` default is stripped to `None` while an int4 serial keeps
+/// its default, but BOTH carry the marker.
+fn serial_kind_for(
+    raw_default: Option<&str>,
+    ty: &ColumnType,
+    is_primary_key: bool,
+    primary_key: &[String],
+    owns_sequence: bool,
+) -> Option<SerialKind> {
+    if !is_primary_key || primary_key.len() != 1 || !owns_sequence {
+        return None;
+    }
+    let lowered = raw_default?.trim().to_ascii_lowercase();
+    if !lowered.starts_with("nextval(") {
+        return None;
+    }
+    match ty {
+        ColumnType::Int64 => Some(SerialKind::BigSerial),
+        ColumnType::Int32 => Some(SerialKind::Serial),
+        _ => None,
+    }
+}
+
+// ===========================================================================
+// SQLite introspection (`autumn schema pull` on the sqlite backend-flip)
+// ===========================================================================
+//
+// Compiled only under the `sqlite` cargo feature (the backend-flip that must never
+// be co-built with the default Postgres backend — see `autumn-cli/Cargo.toml`), so
+// the default (Postgres) build references no `SqliteConnection` here. It lifts a
+// live SQLite database into the SAME `autumn_schema_core` snapshot IR as
+// [`introspect_postgres`], reading the SQLite catalog through `sqlite_master` and
+// the table-valued `pragma_*` functions in a constant number of batched queries
+// (one per catalog, joined against `sqlite_master` — never one query per table
+// beyond what a PRAGMA inherently requires).
+//
+// # Fidelity / fail-closed posture (mirrors the Postgres arm)
+//
+// - **Type mapping is conservative**: SQLite type affinity maps to the IR
+//   [`ColumnType`] only where unambiguous — INTEGER affinity → [`Int64`], TEXT →
+//   [`Text`], REAL → [`Float64`], BLOB → [`Bytes`]. A NUMERIC-affinity (or otherwise
+//   unmapped) declared type is preserved verbatim as [`Opaque`](ColumnType::Opaque),
+//   never dropped, exactly like the Postgres arm's `Opaque` floor.
+// - **Convention recovery** keeps a model↔database round-trip clean: a single-column
+//   `INTEGER PRIMARY KEY AUTOINCREMENT` id maps to an [`Int64`] PK carrying
+//   `serial: Some(BigSerial)` (Autumn's `#[id]` convention; AUTOINCREMENT is detected
+//   from the table's `CREATE TABLE` SQL because `sqlite_sequence` is empty until the
+//   first insert), and a column defaulting to `CURRENT_TIMESTAMP` — the exact DDL
+//   Autumn emits for a `Timestamp` `#[default]` column — is recovered as a
+//   [`Timestamp`](ColumnType::Timestamp) with a [`ColumnDefault::Now`] default.
+// - **Errors are credential-safe**: a connection failure carries only the parsed
+//   file path; a query/PRAGMA failure is an [`IntrospectError::Query`] carrying only
+//   the SQLite message — never the URL, and never a partial result.
+//
+// # Deferred (recorded, not silently dropped)
+//
+// - **Table-level `CHECK` constraints**: parsing a `CHECK (...)` predicate out of the
+//   raw `CREATE TABLE` SQL text is deferred (SQLite exposes no catalog view for it,
+//   unlike Postgres `pg_get_constraintdef`); `checks` is left empty for SQLite.
+// - **`SERIAL` vs `BIGSERIAL` distinction**: SQLite has a single 64-bit rowid, so an
+//   AUTOINCREMENT id is always recorded as `BigSerial` (there is no int4 serial).
+// - **FK on-update/on-delete actions, composite FKs, expression/collation index
+//   attributes**: same deferrals as the Postgres arm.
+
+/// Resolve a `sqlite:`/`sqlite://`/`file:` URL (or a bare path) to the concrete
+/// target [`diesel::SqliteConnection::establish`] expects, mirroring autumn-web's
+/// own `normalize_sqlite_target` (kept in lock-step so the pull connects to the same
+/// file `schema migrate` does). An empty or `:memory:` target stays `:memory:`.
+#[cfg(feature = "sqlite")]
+fn sqlite_target(url: &str) -> String {
+    if url.starts_with("file:") {
+        return url.to_owned();
+    }
+    let rest = url
+        .strip_prefix("sqlite://")
+        .or_else(|| url.strip_prefix("sqlite:"))
+        .unwrap_or(url);
+    if rest.is_empty() || rest == ":memory:" {
+        return ":memory:".to_owned();
+    }
+    rest.to_owned()
+}
+
+/// Introspect a live `SQLite` database at `url` into a set of [`Table`]s tagged
+/// [`Backend::Sqlite`] and marked `managed` — the `SQLite` counterpart of
+/// [`introspect_postgres`], producing the identical snapshot IR so a pulled snapshot
+/// and the model-derived snapshot are diffable by the same engine.
+///
+/// Framework-owned tables (`is_framework_table`), `SQLite` internal tables
+/// (`sqlite_*`), and the Diesel migrations table are excluded, mirroring the
+/// Postgres arm's unscoped-pull rule.
+///
+/// # Errors
+///
+/// Returns [`IntrospectError::ConnectionSqlite`] if the database file cannot be
+/// opened, or [`IntrospectError::Query`] if a catalog query/PRAGMA fails. Neither
+/// leaks the database URL.
+#[cfg(feature = "sqlite")]
+pub fn introspect_sqlite(url: &str) -> Result<Vec<Table>, IntrospectError> {
+    use diesel::{Connection as _, SqliteConnection};
+
+    let target = sqlite_target(url);
+    let mut conn = SqliteConnection::establish(&target)
+        .map_err(|_| IntrospectError::ConnectionSqlite { path: target })?;
+    sqlite::introspect(&mut conn)
+}
+
+/// `SQLite` catalog probes + IR assembly. All row DTOs and helpers live here so the
+/// default (Postgres) build never compiles a `SqliteConnection` reference.
+#[cfg(feature = "sqlite")]
+mod sqlite {
+    use std::collections::BTreeMap;
+
+    use autumn_schema_core::{
+        Backend, Column, ColumnDefault, ColumnType, ForeignKey, Index, SerialKind, Table,
+    };
+    use diesel::sql_types::{Integer, Nullable, Text};
+    use diesel::{QueryableByName, RunQueryDsl as _, SqliteConnection, sql_query};
+
+    use super::IntrospectError;
+
+    /// `(table_name, index_name)` identity for grouping index columns.
+    type IndexKey = (String, String);
+
+    #[derive(QueryableByName)]
+    struct TableRow {
+        #[diesel(sql_type = Text)]
+        name: String,
+        #[diesel(sql_type = Nullable<Text>)]
+        sql: Option<String>,
+    }
+
+    #[derive(QueryableByName)]
+    struct ColumnRow {
+        #[diesel(sql_type = Text)]
+        table_name: String,
+        #[diesel(sql_type = Text)]
+        column_name: String,
+        /// The declared type verbatim (`INTEGER`, `TEXT`, `REAL`, `BLOB`, …); may be
+        /// the empty string for a typeless `SQLite` column.
+        #[diesel(sql_type = Text)]
+        decl_type: String,
+        /// `PRAGMA table_info.notnull` (`0`/`1`).
+        #[diesel(sql_type = Integer)]
+        not_null: i32,
+        /// `PRAGMA table_info.dflt_value` (raw default text, `NULL` for none).
+        #[diesel(sql_type = Nullable<Text>)]
+        dflt_value: Option<String>,
+        /// `PRAGMA table_info.pk` — `0` for a non-key column, else the 1-based key
+        /// position.
+        #[diesel(sql_type = Integer)]
+        pk: i32,
+    }
+
+    #[derive(QueryableByName)]
+    struct IndexRow {
+        #[diesel(sql_type = Text)]
+        table_name: String,
+        #[diesel(sql_type = Text)]
+        index_name: String,
+        /// `PRAGMA index_list.unique` (`0`/`1`).
+        #[diesel(sql_type = Integer)]
+        is_unique: i32,
+        /// `PRAGMA index_list.origin` — `'c'` explicit CREATE INDEX, `'u'` UNIQUE
+        /// constraint, `'pk'` primary key.
+        #[diesel(sql_type = Text)]
+        origin: String,
+        /// `PRAGMA index_list.partial` (`0`/`1`).
+        #[diesel(sql_type = Integer)]
+        partial: i32,
+        /// The verbatim `CREATE [UNIQUE] INDEX …` statement from `sqlite_master`
+        /// (`NULL` for a constraint/PK auto-index, which has no standalone SQL).
+        #[diesel(sql_type = Nullable<Text>)]
+        index_sql: Option<String>,
+    }
+
+    #[derive(QueryableByName)]
+    struct IndexColumnRow {
+        #[diesel(sql_type = Text)]
+        table_name: String,
+        #[diesel(sql_type = Text)]
+        index_name: String,
+        #[diesel(sql_type = Integer)]
+        seqno: i32,
+        /// The indexed column name, or `NULL` for an expression key.
+        #[diesel(sql_type = Nullable<Text>)]
+        column_name: Option<String>,
+    }
+
+    #[derive(QueryableByName)]
+    struct ForeignKeyRow {
+        #[diesel(sql_type = Text)]
+        table_name: String,
+        #[diesel(sql_type = Text)]
+        foreign_table: String,
+        #[diesel(sql_type = Text)]
+        column_name: String,
+        /// The referenced column; `NULL` when the FK targets the referenced table's
+        /// PK implicitly (recovered as `id`, the Autumn convention).
+        #[diesel(sql_type = Nullable<Text>)]
+        foreign_column: Option<String>,
+    }
+
+    fn query_err(e: &diesel::result::Error) -> IntrospectError {
+        IntrospectError::Query(e.to_string())
+    }
+
+    /// Introspect every app table of an open `SQLite` connection into the IR. Keeps
+    /// the private row DTOs entirely inside this module (the outer `introspect_sqlite`
+    /// only opens the connection), so the default Postgres build compiles no `SQLite`
+    /// type into a public signature.
+    pub(super) fn introspect(conn: &mut SqliteConnection) -> Result<Vec<Table>, IntrospectError> {
+        let tables = list_tables(conn)?;
+        if tables.is_empty() {
+            return Ok(Vec::new());
+        }
+        let columns_by_table = fetch_columns(conn)?;
+        let indexes_by_table = fetch_indexes(conn)?;
+        let index_columns = fetch_index_columns(conn)?;
+        let fks_by_table = fetch_foreign_keys(conn)?;
+
+        let mut out = Vec::with_capacity(tables.len());
+        for (name, table_sql) in &tables {
+            out.push(build_table(
+                name,
+                table_sql.as_deref().unwrap_or_default(),
+                columns_by_table.get(name).map_or(&[][..], Vec::as_slice),
+                indexes_by_table.get(name).map_or(&[][..], Vec::as_slice),
+                &index_columns,
+                fks_by_table.get(name).map_or(&[][..], Vec::as_slice),
+            ));
+        }
+        Ok(out)
+    }
+
+    /// List app tables (name + `CREATE TABLE` SQL), excluding `SQLite` internal
+    /// tables, the Diesel migrations table, and framework-owned tables.
+    fn list_tables(
+        conn: &mut SqliteConnection,
+    ) -> Result<Vec<(String, Option<String>)>, IntrospectError> {
+        let rows: Vec<TableRow> = sql_query(
+            "SELECT name AS name, sql AS sql FROM sqlite_master \
+             WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+        )
+        .load(conn)
+        .map_err(|e| query_err(&e))?;
+        Ok(rows
+            .into_iter()
+            .filter(|r| !super::is_framework_table(&r.name))
+            .map(|r| (r.name, r.sql))
+            .collect())
+    }
+
+    /// Fetch every column of every table in one batched `pragma_table_info` join.
+    fn fetch_columns(
+        conn: &mut SqliteConnection,
+    ) -> Result<BTreeMap<String, Vec<ColumnRow>>, IntrospectError> {
+        let rows: Vec<ColumnRow> = sql_query(
+            "SELECT m.name AS table_name, ti.name AS column_name, ti.type AS decl_type, \
+             ti.\"notnull\" AS not_null, ti.dflt_value AS dflt_value, ti.pk AS pk \
+             FROM sqlite_master m JOIN pragma_table_info(m.name) ti \
+             WHERE m.type = 'table' AND m.name NOT LIKE 'sqlite_%' \
+             ORDER BY m.name, ti.cid",
+        )
+        .load(conn)
+        .map_err(|e| query_err(&e))?;
+        Ok(group_by(rows, |r| r.table_name.clone()))
+    }
+
+    /// Fetch every non-PK index of every table in one batched `pragma_index_list`
+    /// join, carrying each index's standalone `CREATE INDEX` SQL when it has one.
+    fn fetch_indexes(
+        conn: &mut SqliteConnection,
+    ) -> Result<BTreeMap<String, Vec<IndexRow>>, IntrospectError> {
+        let rows: Vec<IndexRow> = sql_query(
+            "SELECT m.name AS table_name, il.name AS index_name, il.\"unique\" AS is_unique, \
+             il.origin AS origin, il.partial AS partial, idx.sql AS index_sql \
+             FROM sqlite_master m JOIN pragma_index_list(m.name) il \
+             LEFT JOIN sqlite_master idx ON idx.type = 'index' AND idx.name = il.name \
+             WHERE m.type = 'table' AND m.name NOT LIKE 'sqlite_%' \
+             ORDER BY m.name, il.name",
+        )
+        .load(conn)
+        .map_err(|e| query_err(&e))?;
+        Ok(group_by(rows, |r| r.table_name.clone()))
+    }
+
+    /// Fetch the columns of every index in one batched `pragma_index_info` join,
+    /// grouped by `(table, index)` in key order.
+    fn fetch_index_columns(
+        conn: &mut SqliteConnection,
+    ) -> Result<BTreeMap<IndexKey, Vec<IndexColumnRow>>, IntrospectError> {
+        let mut rows: Vec<IndexColumnRow> = sql_query(
+            "SELECT m.name AS table_name, il.name AS index_name, ii.seqno AS seqno, \
+             ii.name AS column_name \
+             FROM sqlite_master m JOIN pragma_index_list(m.name) il \
+             JOIN pragma_index_info(il.name) ii \
+             WHERE m.type = 'table' AND m.name NOT LIKE 'sqlite_%' \
+             ORDER BY m.name, il.name, ii.seqno",
+        )
+        .load(conn)
+        .map_err(|e| query_err(&e))?;
+        rows.sort_by_key(|r| r.seqno);
+        let mut by_index: BTreeMap<IndexKey, Vec<IndexColumnRow>> = BTreeMap::new();
+        for row in rows {
+            by_index
+                .entry((row.table_name.clone(), row.index_name.clone()))
+                .or_default()
+                .push(row);
+        }
+        Ok(by_index)
+    }
+
+    /// Fetch single-column foreign keys (`seq = 0`) of every table in one batched
+    /// `pragma_foreign_key_list` join.
+    fn fetch_foreign_keys(
+        conn: &mut SqliteConnection,
+    ) -> Result<BTreeMap<String, Vec<ForeignKeyRow>>, IntrospectError> {
+        let rows: Vec<ForeignKeyRow> = sql_query(
+            "SELECT m.name AS table_name, fkl.\"table\" AS foreign_table, \
+             fkl.\"from\" AS column_name, fkl.\"to\" AS foreign_column \
+             FROM sqlite_master m JOIN pragma_foreign_key_list(m.name) fkl \
+             WHERE m.type = 'table' AND m.name NOT LIKE 'sqlite_%' AND fkl.seq = 0",
+        )
+        .load(conn)
+        .map_err(|e| query_err(&e))?;
+        Ok(group_by(rows, |r| r.table_name.clone()))
+    }
+
+    /// Group a flat row list into a per-table map, preserving row order within each
+    /// table (input already ordered by table then position).
+    fn group_by<T>(rows: Vec<T>, key: impl Fn(&T) -> String) -> BTreeMap<String, Vec<T>> {
+        let mut out: BTreeMap<String, Vec<T>> = BTreeMap::new();
+        for row in rows {
+            out.entry(key(&row)).or_default().push(row);
+        }
+        out
+    }
+
+    /// The `SQLite` type affinity of a declared type, per the `SQLite` type-affinity
+    /// determination rules (`SQLite` docs §3.1).
+    #[derive(PartialEq, Eq)]
+    enum Affinity {
+        Integer,
+        Text,
+        Blob,
+        Real,
+        Numeric,
+    }
+
+    fn affinity(decl_type: &str) -> Affinity {
+        let t = decl_type.to_ascii_uppercase();
+        if t.contains("INT") {
+            Affinity::Integer
+        } else if t.contains("CHAR") || t.contains("CLOB") || t.contains("TEXT") {
+            Affinity::Text
+        } else if t.is_empty() || t.contains("BLOB") {
+            Affinity::Blob
+        } else if t.contains("REAL") || t.contains("FLOA") || t.contains("DOUB") {
+            Affinity::Real
+        } else {
+            Affinity::Numeric
+        }
+    }
+
+    /// Normalize a raw `SQLite` `dflt_value` into a [`ColumnDefault`]. Recovers the
+    /// Autumn `Timestamp` convention default (`CURRENT_TIMESTAMP` → [`Now`]) and
+    /// preserves anything else verbatim.
+    fn sqlite_default(raw: Option<&str>) -> Option<ColumnDefault> {
+        let raw = raw?.trim();
+        if raw.is_empty() {
+            return None;
+        }
+        if raw.eq_ignore_ascii_case("CURRENT_TIMESTAMP") {
+            return Some(ColumnDefault::Now);
+        }
+        Some(ColumnDefault::Sql(raw.to_owned()))
+    }
+
+    /// Map a `SQLite` declared type + resolved default to an IR [`ColumnType`],
+    /// conservatively (fail-closed to [`Opaque`](ColumnType::Opaque) for a
+    /// non-cleanly-mappable NUMERIC-affinity type). A `CURRENT_TIMESTAMP` default
+    /// recovers the Autumn `Timestamp` convention (a `Timestamp` column is stored as
+    /// `TEXT DEFAULT CURRENT_TIMESTAMP`), keeping a model round-trip clean.
+    fn sqlite_column_type(decl_type: &str, default: Option<&ColumnDefault>) -> ColumnType {
+        if matches!(default, Some(ColumnDefault::Now)) {
+            return ColumnType::Timestamp;
+        }
+        match affinity(decl_type) {
+            Affinity::Integer => ColumnType::Int64,
+            Affinity::Text => ColumnType::Text,
+            Affinity::Real => ColumnType::Float64,
+            Affinity::Blob => ColumnType::Bytes,
+            // Fail-closed: a NUMERIC-affinity (or otherwise unmapped) declared type is
+            // preserved verbatim rather than guessed, matching the Postgres arm's
+            // `Opaque` floor. An empty declared type is BLOB affinity above, so this
+            // never produces an empty `pg_type`.
+            Affinity::Numeric => ColumnType::Opaque {
+                pg_type: decl_type.to_owned(),
+            },
+        }
+    }
+
+    /// Assemble one [`Table`] from its pre-fetched `SQLite` catalog rows. Pure.
+    fn build_table(
+        name: &str,
+        table_sql: &str,
+        columns: &[ColumnRow],
+        indexes: &[IndexRow],
+        index_columns: &BTreeMap<IndexKey, Vec<IndexColumnRow>>,
+        foreign_keys: &[ForeignKeyRow],
+    ) -> Table {
+        let mut table = Table::new(name, Backend::Sqlite);
+        table.managed = true;
+
+        // Primary key, in key order (`pk` is the 1-based key position).
+        let mut pk_cols: Vec<(i32, String)> = columns
+            .iter()
+            .filter(|c| c.pk > 0)
+            .map(|c| (c.pk, c.column_name.clone()))
+            .collect();
+        pk_cols.sort_by_key(|(ord, _)| *ord);
+        table.primary_key = pk_cols.into_iter().map(|(_, n)| n).collect();
+        let single_pk = table.primary_key.len() == 1;
+        // AUTOINCREMENT lives in the table's CREATE SQL (sqlite_sequence is empty
+        // until the first insert, so it cannot be relied on).
+        let autoincrement = table_sql.to_ascii_uppercase().contains("AUTOINCREMENT");
+
+        let (ir_indexes, unique_columns) = collapse_indexes(name, indexes, index_columns);
+        let fk_by_column: BTreeMap<&str, &ForeignKeyRow> = foreign_keys
+            .iter()
+            .map(|fk| (fk.column_name.as_str(), fk))
+            .collect();
+
+        for row in columns {
+            let is_pk = row.pk > 0;
+            let default = sqlite_default(row.dflt_value.as_deref());
+            let ty = sqlite_column_type(&row.decl_type, default.as_ref());
+            let mut column = Column::new(row.column_name.clone(), ty);
+            // A SQLite PRIMARY KEY column reports notnull=0 for an INTEGER rowid PK,
+            // but is effectively NOT NULL; the model always has non-null PKs, so force
+            // a PK column non-null for a clean round-trip.
+            column.nullable = row.not_null == 0 && !is_pk;
+            column.primary_key = is_pk;
+            column.unique = unique_columns.contains(row.column_name.as_str());
+            column.default = default;
+            // Serial marker: a single-column INTEGER PK of an AUTOINCREMENT table is
+            // the Autumn `BigSerial` id (SQLite has one 64-bit rowid — always
+            // BigSerial), symmetric with what the model parser records.
+            if is_pk
+                && single_pk
+                && autoincrement
+                && matches!(affinity(&row.decl_type), Affinity::Integer)
+            {
+                column.serial = Some(SerialKind::BigSerial);
+            }
+            if let Some(fk) = fk_by_column.get(row.column_name.as_str()) {
+                let foreign_column = fk.foreign_column.clone().unwrap_or_else(|| "id".to_owned());
+                column.references = Some(ForeignKey::new(fk.foreign_table.clone(), foreign_column));
+            }
+            table.columns.push(column);
+        }
+
+        table.indexes = ir_indexes;
+        // Table-level CHECK extraction from the raw CREATE TABLE SQL is deferred (see
+        // the module note), so `checks` is left empty for SQLite.
+        table
+    }
+
+    /// Map `SQLite` index rows into IR [`Index`]es plus the set of columns covered by a
+    /// single-column simple unique index (mirroring the Postgres arm's
+    /// `collapse_indexes`). A partial or expression index is retained verbatim via its
+    /// `CREATE INDEX` SQL; a plain index is representable by its columns. The primary
+    /// key auto-index (`origin = 'pk'`) is skipped (the PK is modeled separately).
+    fn collapse_indexes(
+        table_name: &str,
+        rows: &[IndexRow],
+        index_columns: &BTreeMap<IndexKey, Vec<IndexColumnRow>>,
+    ) -> (Vec<Index>, std::collections::BTreeSet<String>) {
+        let mut indexes = Vec::new();
+        let mut unique_columns = std::collections::BTreeSet::new();
+        for row in rows {
+            if row.origin == "pk" {
+                continue;
+            }
+            let cols = index_columns
+                .get(&(table_name.to_owned(), row.index_name.clone()))
+                .map_or(&[][..], Vec::as_slice);
+            let has_expression = cols.iter().any(|c| c.column_name.is_none());
+            let key_columns: Vec<String> =
+                cols.iter().filter_map(|c| c.column_name.clone()).collect();
+            let is_unique = row.is_unique != 0;
+            let is_partial = row.partial != 0;
+            let simple = !is_partial && !has_expression;
+            if simple && is_unique && key_columns.len() == 1 {
+                unique_columns.insert(key_columns[0].clone());
+            }
+            // A partial or expression index is retained verbatim via its CREATE INDEX
+            // SQL (when present); a plain index is representable by its columns.
+            let definition = if simple { None } else { row.index_sql.clone() };
+            indexes.push(Index {
+                name: row.index_name.clone(),
+                columns: key_columns,
+                unique: is_unique,
+                definition,
+                is_partial,
+                key_columns: Vec::new(),
+            });
+        }
+        (indexes, unique_columns)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn affinity_maps_the_common_declared_types() {
+            assert!(matches!(affinity("INTEGER"), Affinity::Integer));
+            assert!(matches!(affinity("BIGINT"), Affinity::Integer));
+            assert!(matches!(affinity("TEXT"), Affinity::Text));
+            assert!(matches!(affinity("VARCHAR(255)"), Affinity::Text));
+            assert!(matches!(affinity("REAL"), Affinity::Real));
+            assert!(matches!(affinity("DOUBLE"), Affinity::Real));
+            assert!(matches!(affinity("BLOB"), Affinity::Blob));
+            assert!(matches!(affinity(""), Affinity::Blob));
+            assert!(matches!(affinity("NUMERIC"), Affinity::Numeric));
+            assert!(matches!(affinity("DECIMAL(10,2)"), Affinity::Numeric));
+        }
+
+        #[test]
+        fn column_type_is_conservative_and_recovers_conventions() {
+            assert_eq!(sqlite_column_type("INTEGER", None), ColumnType::Int64);
+            assert_eq!(sqlite_column_type("TEXT", None), ColumnType::Text);
+            assert_eq!(sqlite_column_type("REAL", None), ColumnType::Float64);
+            assert_eq!(sqlite_column_type("BLOB", None), ColumnType::Bytes);
+            // Convention recovery: a CURRENT_TIMESTAMP default → Timestamp.
+            assert_eq!(
+                sqlite_column_type("TEXT", Some(&ColumnDefault::Now)),
+                ColumnType::Timestamp
+            );
+            // Fail-closed: a NUMERIC-affinity declared type is preserved verbatim.
+            assert_eq!(
+                sqlite_column_type("NUMERIC", None),
+                ColumnType::Opaque {
+                    pg_type: "NUMERIC".to_owned()
+                }
+            );
+        }
+
+        #[test]
+        fn default_recovers_now_and_preserves_others() {
+            assert_eq!(sqlite_default(None), None);
+            assert_eq!(sqlite_default(Some("  ")), None);
+            assert_eq!(
+                sqlite_default(Some("CURRENT_TIMESTAMP")),
+                Some(ColumnDefault::Now)
+            );
+            assert_eq!(
+                sqlite_default(Some("'draft'")),
+                Some(ColumnDefault::Sql("'draft'".to_owned()))
+            );
+        }
+
+        fn col_row(
+            name: &str,
+            decl: &str,
+            not_null: i32,
+            dflt: Option<&str>,
+            pk: i32,
+        ) -> ColumnRow {
+            ColumnRow {
+                table_name: "posts".to_owned(),
+                column_name: name.to_owned(),
+                decl_type: decl.to_owned(),
+                not_null,
+                dflt_value: dflt.map(str::to_owned),
+                pk,
+            }
+        }
+
+        #[test]
+        fn build_table_marks_autoincrement_id_and_recovers_created_at() {
+            let columns = vec![
+                col_row("id", "INTEGER", 0, None, 1),
+                col_row("title", "TEXT", 1, None, 0),
+                col_row("body", "TEXT", 0, None, 0),
+                col_row("created_at", "TEXT", 1, Some("CURRENT_TIMESTAMP"), 0),
+            ];
+            let table_sql = "CREATE TABLE posts (id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                             title TEXT NOT NULL, body TEXT NULL, \
+                             created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)";
+            let table = build_table("posts", table_sql, &columns, &[], &BTreeMap::new(), &[]);
+            assert_eq!(table.primary_key, vec!["id".to_owned()]);
+
+            let id = table.columns.iter().find(|c| c.name == "id").unwrap();
+            assert_eq!(id.ty, ColumnType::Int64);
+            assert!(id.primary_key);
+            assert!(!id.nullable, "an INTEGER PK is forced non-null");
+            assert_eq!(id.serial, Some(SerialKind::BigSerial));
+
+            let body = table.columns.iter().find(|c| c.name == "body").unwrap();
+            assert!(body.nullable);
+
+            let created = table
+                .columns
+                .iter()
+                .find(|c| c.name == "created_at")
+                .unwrap();
+            assert_eq!(created.ty, ColumnType::Timestamp);
+            assert_eq!(created.default, Some(ColumnDefault::Now));
+            assert!(!created.nullable);
+        }
+
+        #[test]
+        fn build_table_plain_integer_pk_is_not_serial() {
+            // Without AUTOINCREMENT in the table SQL, an INTEGER PK is a plain rowid
+            // alias, not an Autumn BigSerial id → serial marker stays None.
+            let columns = vec![col_row("id", "INTEGER", 0, None, 1)];
+            let table_sql = "CREATE TABLE posts (id INTEGER PRIMARY KEY)";
+            let table = build_table("posts", table_sql, &columns, &[], &BTreeMap::new(), &[]);
+            let id = table.columns.iter().find(|c| c.name == "id").unwrap();
+            assert!(id.serial.is_none());
+        }
+
+        #[test]
+        fn collapse_indexes_simple_unique_sets_flag() {
+            let rows = vec![IndexRow {
+                table_name: "authors".to_owned(),
+                index_name: "idx_authors_email_unique".to_owned(),
+                is_unique: 1,
+                origin: "c".to_owned(),
+                partial: 0,
+                index_sql: Some(
+                    "CREATE UNIQUE INDEX idx_authors_email_unique ON authors (email)".to_owned(),
+                ),
+            }];
+            let mut index_columns = BTreeMap::new();
+            index_columns.insert(
+                ("authors".to_owned(), "idx_authors_email_unique".to_owned()),
+                vec![IndexColumnRow {
+                    table_name: "authors".to_owned(),
+                    index_name: "idx_authors_email_unique".to_owned(),
+                    seqno: 0,
+                    column_name: Some("email".to_owned()),
+                }],
+            );
+            let (indexes, unique_cols) = collapse_indexes("authors", &rows, &index_columns);
+            assert_eq!(indexes.len(), 1);
+            assert_eq!(indexes[0].columns, vec!["email".to_owned()]);
+            assert!(indexes[0].unique);
+            assert_eq!(
+                indexes[0].definition, None,
+                "a simple index carries no definition"
+            );
+            assert!(unique_cols.contains("email"));
+        }
+
+        #[test]
+        fn collapse_indexes_skips_pk_and_retains_partial_verbatim() {
+            let rows = vec![
+                IndexRow {
+                    table_name: "t".to_owned(),
+                    index_name: "sqlite_autoindex_t_1".to_owned(),
+                    is_unique: 1,
+                    origin: "pk".to_owned(),
+                    partial: 0,
+                    index_sql: None,
+                },
+                IndexRow {
+                    table_name: "t".to_owned(),
+                    index_name: "t_active_idx".to_owned(),
+                    is_unique: 0,
+                    origin: "c".to_owned(),
+                    partial: 1,
+                    index_sql: Some(
+                        "CREATE INDEX t_active_idx ON t (email) WHERE deleted_at IS NULL"
+                            .to_owned(),
+                    ),
+                },
+            ];
+            let mut index_columns = BTreeMap::new();
+            index_columns.insert(
+                ("t".to_owned(), "t_active_idx".to_owned()),
+                vec![IndexColumnRow {
+                    table_name: "t".to_owned(),
+                    index_name: "t_active_idx".to_owned(),
+                    seqno: 0,
+                    column_name: Some("email".to_owned()),
+                }],
+            );
+            let (indexes, _unique) = collapse_indexes("t", &rows, &index_columns);
+            assert_eq!(indexes.len(), 1, "the PK auto-index is skipped");
+            assert_eq!(indexes[0].name, "t_active_idx");
+            assert!(indexes[0].is_partial);
+            assert!(
+                indexes[0].definition.as_deref().unwrap().contains("WHERE"),
+                "a partial index is retained verbatim via its CREATE INDEX SQL"
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1259,6 +2035,142 @@ mod tests {
             true,
         );
         assert!(matches!(d, Some(ColumnDefault::Sql(_))));
+    }
+
+    #[test]
+    fn serial_kind_marker_distinguishes_bigserial_from_plain_bigint_pk() {
+        let pk = vec!["id".to_owned()];
+        // An int8 owned-sequence serial PK → BigSerial.
+        assert_eq!(
+            serial_kind_for(
+                Some("nextval('posts_id_seq'::regclass)"),
+                &ColumnType::Int64,
+                true,
+                &pk,
+                true
+            ),
+            Some(SerialKind::BigSerial)
+        );
+        // An int4 owned-sequence serial PK → Serial.
+        assert_eq!(
+            serial_kind_for(
+                Some("nextval('counters_id_seq'::regclass)"),
+                &ColumnType::Int32,
+                true,
+                &pk,
+                true
+            ),
+            Some(SerialKind::Serial)
+        );
+        // A plain BIGINT PRIMARY KEY (no default, no owned sequence) → None: this is
+        // the crux — it is NOT a BigSerial, and now the IR can tell them apart.
+        assert_eq!(
+            serial_kind_for(None, &ColumnType::Int64, true, &pk, false),
+            None
+        );
+        // A shared/custom (non-owned) sequence default → None (not a conventional
+        // owned serial).
+        assert_eq!(
+            serial_kind_for(
+                Some("nextval('global_ids'::regclass)"),
+                &ColumnType::Int64,
+                true,
+                &pk,
+                false
+            ),
+            None
+        );
+        // A non-PK serial column → None (not an id).
+        assert_eq!(
+            serial_kind_for(
+                Some("nextval('c_seq'::regclass)"),
+                &ColumnType::Int64,
+                false,
+                &[],
+                true
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn build_table_marks_bigserial_id_and_preserves_identity() {
+        let columns = vec![
+            // A conventional BIGSERIAL id (owns its sequence).
+            ColumnRow {
+                table_name: "t".to_owned(),
+                column_name: "id".to_owned(),
+                udt_name: "int8".to_owned(),
+                is_nullable: "NO".to_owned(),
+                column_default: Some("nextval('t_id_seq'::regclass)".to_owned()),
+                numeric_precision: None,
+                numeric_scale: None,
+                character_maximum_length: None,
+                domain_name: None,
+                domain_schema: None,
+                owns_sequence: true,
+                is_identity: "NO".to_owned(),
+                identity_generation: None,
+            },
+            // A GENERATED ALWAYS AS IDENTITY column (no default, is_identity=YES).
+            ColumnRow {
+                table_name: "t".to_owned(),
+                column_name: "seqno".to_owned(),
+                udt_name: "int8".to_owned(),
+                is_nullable: "NO".to_owned(),
+                column_default: None,
+                numeric_precision: None,
+                numeric_scale: None,
+                character_maximum_length: None,
+                domain_name: None,
+                domain_schema: None,
+                owns_sequence: false,
+                is_identity: "YES".to_owned(),
+                identity_generation: Some("ALWAYS".to_owned()),
+            },
+        ];
+        let pk = vec!["id".to_owned()];
+        let table = build_table("t", &columns, &pk, &[], &[], &[]);
+        let id = table.columns.iter().find(|c| c.name == "id").unwrap();
+        assert_eq!(id.serial, Some(SerialKind::BigSerial));
+        assert_eq!(
+            id.default, None,
+            "the owned int8 serial default is stripped"
+        );
+        assert!(id.identity.is_none());
+        let seqno = table.columns.iter().find(|c| c.name == "seqno").unwrap();
+        assert_eq!(
+            seqno.identity.as_deref(),
+            Some("ALWAYS"),
+            "an identity column preserves its generation clause verbatim"
+        );
+        assert!(
+            seqno.serial.is_none(),
+            "an identity column is not a serial (no owned nextval default)"
+        );
+    }
+
+    #[test]
+    fn collapse_indexes_nulls_not_distinct_unique_retained_verbatim() {
+        // A PG15+ `NULLS NOT DISTINCT` unique index (a bare CREATE UNIQUE INDEX, no
+        // backing constraint) must be RETAINED via `definition` so the clause
+        // round-trips — never collapsed to an ordinary unique index that drops it.
+        let def = "CREATE UNIQUE INDEX u_idx ON public.t USING btree (email) NULLS NOT DISTINCT";
+        let rows = vec![index_row(
+            "u_idx", true, "email", "email", false, false, def,
+        )];
+        let (indexes, unique_cols) = collapse_indexes(&rows);
+        assert_eq!(indexes.len(), 1);
+        assert_eq!(
+            indexes[0].definition.as_deref(),
+            Some(def),
+            "a NULLS NOT DISTINCT unique index must be retained verbatim via its definition"
+        );
+        assert!(
+            unique_cols.is_empty(),
+            "a NULLS NOT DISTINCT unique index is not a plain simple unique, so it \
+             sets no single-column unique flag"
+        );
     }
 
     #[test]
@@ -1649,6 +2561,8 @@ mod tests {
                 // The conventional BIGSERIAL id owns its sequence, so the nextval
                 // default is stripped to None below.
                 owns_sequence: true,
+                is_identity: "NO".to_owned(),
+                identity_generation: None,
             },
             ColumnRow {
                 table_name: "comments".to_owned(),
@@ -1662,6 +2576,8 @@ mod tests {
                 domain_name: None,
                 domain_schema: None,
                 owns_sequence: false,
+                is_identity: "NO".to_owned(),
+                identity_generation: None,
             },
         ];
         let pk = vec!["id".to_owned()];
@@ -1713,6 +2629,8 @@ mod tests {
             domain_name: None,
             domain_schema: None,
             owns_sequence: false,
+            is_identity: "NO".to_owned(),
+            identity_generation: None,
         }];
         let table = build_table("widgets", &columns, &[], &[], &[], &[]);
         let addr = table.columns.iter().find(|c| c.name == "addr").unwrap();
@@ -1743,6 +2661,8 @@ mod tests {
                 domain_name: Some("email_dom".to_owned()),
                 domain_schema: Some("public".to_owned()),
                 owns_sequence: false,
+                is_identity: "NO".to_owned(),
+                identity_generation: None,
             },
             // A non-domain column (`domain_name` NULL) maps exactly as before.
             ColumnRow {
@@ -1757,6 +2677,8 @@ mod tests {
                 domain_name: None,
                 domain_schema: None,
                 owns_sequence: false,
+                is_identity: "NO".to_owned(),
+                identity_generation: None,
             },
         ];
         let table = build_table("contacts", &columns, &[], &[], &[], &[]);
@@ -1795,6 +2717,8 @@ mod tests {
                 domain_name: None,
                 domain_schema: None,
                 owns_sequence: false,
+                is_identity: "NO".to_owned(),
+                identity_generation: None,
             },
             ColumnRow {
                 table_name: "labels".to_owned(),
@@ -1808,6 +2732,8 @@ mod tests {
                 domain_name: None,
                 domain_schema: None,
                 owns_sequence: false,
+                is_identity: "NO".to_owned(),
+                identity_generation: None,
             },
             ColumnRow {
                 table_name: "labels".to_owned(),
@@ -1821,6 +2747,8 @@ mod tests {
                 domain_name: None,
                 domain_schema: None,
                 owns_sequence: false,
+                is_identity: "NO".to_owned(),
+                identity_generation: None,
             },
         ];
         let table = build_table("labels", &columns, &[], &[], &[], &[]);
@@ -1865,6 +2793,8 @@ mod tests {
             domain_name: Some("code_dom".to_owned()),
             domain_schema: Some("public".to_owned()),
             owns_sequence: false,
+            is_identity: "NO".to_owned(),
+            identity_generation: None,
         }];
         let table = build_table("labels", &columns, &[], &[], &[], &[]);
         let code = table.columns.iter().find(|c| c.name == "code").unwrap();
@@ -1893,6 +2823,8 @@ mod tests {
             domain_name: Some("email_dom".to_owned()),
             domain_schema: Some("otherschema".to_owned()),
             owns_sequence: false,
+            is_identity: "NO".to_owned(),
+            identity_generation: None,
         }];
         let table = build_table("contacts", &columns, &[], &[], &[], &[]);
         let email = table.columns.iter().find(|c| c.name == "email").unwrap();
@@ -1921,6 +2853,8 @@ mod tests {
             domain_name: None,
             domain_schema: None,
             owns_sequence: false,
+            is_identity: "NO".to_owned(),
+            identity_generation: None,
         }];
         let fks = vec![ForeignKeyRow {
             table_name: "sessions".to_owned(),
@@ -1957,6 +2891,8 @@ mod tests {
             domain_name: None,
             domain_schema: None,
             owns_sequence: false,
+            is_identity: "NO".to_owned(),
+            identity_generation: None,
         }];
         let fks = vec![ForeignKeyRow {
             table_name: "comments".to_owned(),
@@ -1990,6 +2926,8 @@ mod tests {
             domain_name: None,
             domain_schema: None,
             owns_sequence: false,
+            is_identity: "NO".to_owned(),
+            identity_generation: None,
         }];
         let checks = vec![CheckRow {
             table_name: "products".to_owned(),
@@ -2019,6 +2957,8 @@ mod tests {
             domain_name: None,
             domain_schema: None,
             owns_sequence: false,
+            is_identity: "NO".to_owned(),
+            identity_generation: None,
         }];
         let table = build_table("products", &columns, &[], &[], &[], &[]);
         assert!(

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -286,16 +286,18 @@ struct ColumnRow {
     /// Only qualifies the emitted type when it is not `public`.
     #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
     domain_schema: Option<String>,
-    /// Whether this column **owns** the sequence backing its `nextval(...)`
-    /// default — the conventional `SERIAL`/`BIGSERIAL` shape, where Postgres links
-    /// the sequence to the column with an `OWNED BY` auto-dependency (`pg_depend`
-    /// `deptype = 'a'`). A `nextval(...)` default over a *shared*/custom sequence
-    /// that is **not** owned by the column reports `false`, so its raw default is
-    /// preserved verbatim rather than collapsed to a fresh owned `BIGSERIAL` on
+    /// Whether this column **owns the same sequence its `nextval(...)` default
+    /// allocates from** — the conventional `SERIAL`/`BIGSERIAL` shape, where the
+    /// sequence is both `OWNED BY` the column (`pg_depend` `deptype = 'a'`) AND the
+    /// sequence the column's default expression references (`pg_attrdef`
+    /// `deptype = 'n'`). A `nextval(...)` default over a *shared*/custom sequence the
+    /// column does not own — OR a column that still owns an OLD sequence but whose
+    /// default was repointed to a DIFFERENT one — reports `false`, so its raw default
+    /// is preserved verbatim rather than collapsed to a fresh owned `BIGSERIAL` on
     /// recreation (which would silently change ID-allocation behavior — see
     /// [`normalize_serial_pk_default`]). Detected via long-standing catalogs only
-    /// (`pg_depend` / `pg_class` / `pg_attribute`), so it is version-safe on every
-    /// supported Postgres (no PG15+ catalog columns).
+    /// (`pg_depend` / `pg_attrdef` / `pg_class` / `pg_attribute`), so it is
+    /// version-safe on every supported Postgres (no PG15+ catalog columns).
     #[diesel(sql_type = diesel::sql_types::Bool)]
     owns_sequence: bool,
     /// `information_schema.columns.is_identity` (`'YES'`/`'NO'`) — whether the
@@ -498,15 +500,25 @@ fn fetch_columns(
     // the output type is guaranteed `int4` regardless of the domain. The `AS <name>`
     // aliases keep the result column names aligned with the `ColumnRow` field bindings.
     //
-    // `owns_sequence` is an `EXISTS` over `pg_depend`: a serial column OWNS its
-    // sequence through an `OWNED BY` auto-dependency — a `pg_depend` row whose
-    // `deptype = 'a'` links a sequence (`pg_class.relkind = 'S'`, as `objid`) to
-    // this exact column (`refobjid = <table oid>`, `refobjsubid = <column
-    // attnum>`, `refclassid = classid = 'pg_class'::regclass`). This is the
-    // conventional `SERIAL`/`BIGSERIAL` shape. A `nextval(...)` default over a
-    // shared/custom sequence NOT owned by the column has no such row, so
-    // `owns_sequence` is `false` and the raw default is preserved. `pg_depend`
-    // exists in every supported Postgres, so this never breaks older servers.
+    // `owns_sequence` is an `EXISTS` over `pg_depend` that is `true` only when the
+    // column OWNS the SAME sequence its `nextval(...)` default allocates from — the
+    // conventional `SERIAL`/`BIGSERIAL` shape. It ties TWO dependencies to one
+    // sequence:
+    //   * OWNED BY (`deptype = 'a'`): a `pg_depend` row linking a sequence
+    //     (`pg_class.relkind = 'S'`, as `objid`) to this exact column
+    //     (`refobjid = <table oid>`, `refobjsubid = <column attnum>`).
+    //   * used-by-default (`deptype = 'n'`): a `pg_depend` row from the column's
+    //     default expression (`pg_attrdef`, `classid = 'pg_attrdef'::regclass`) to
+    //     that SAME sequence (`refobjid = seq.oid`).
+    // Requiring BOTH on the same sequence closes the brownfield hole where a column
+    // still owns an old sequence (`t_id_seq`, `deptype = 'a'`) but its default was
+    // repointed to a different one (`DEFAULT nextval('global_ids')`): the used-by
+    // dependency then targets `global_ids`, not the owned `t_id_seq`, so `EXISTS` is
+    // `false`, the raw `nextval('global_ids')` default is preserved verbatim (never
+    // stripped to a fresh owned `BIGSERIAL`), and the column classifies as
+    // `Some(Plain)`. A plain shared/custom-sequence PK (owns nothing) likewise has no
+    // `deptype = 'a'` row → `false` → preserved. `pg_depend`/`pg_attrdef` exist in
+    // every supported Postgres, so this never breaks older servers.
     let query = format!(
         "SELECT c.table_name, c.column_name, c.udt_name, c.is_nullable, c.column_default, \
          c.numeric_precision::integer AS numeric_precision, \
@@ -516,19 +528,24 @@ fn fetch_columns(
          c.is_identity, c.identity_generation, \
          EXISTS ( \
            SELECT 1 \
-           FROM pg_depend dep \
-           JOIN pg_class seq ON seq.oid = dep.objid AND seq.relkind = 'S' \
-           JOIN pg_class tbl ON tbl.oid = dep.refobjid \
+           FROM pg_class tbl \
            JOIN pg_namespace tn ON tn.oid = tbl.relnamespace \
            JOIN pg_attribute att \
-             ON att.attrelid = dep.refobjid AND att.attnum = dep.refobjsubid \
-           WHERE dep.classid = 'pg_class'::regclass \
-             AND dep.refclassid = 'pg_class'::regclass \
-             AND dep.deptype = 'a' \
-             AND dep.refobjsubid > 0 \
-             AND tn.nspname = 'public' \
+             ON att.attrelid = tbl.oid AND att.attname = c.column_name \
+           JOIN pg_attrdef ad ON ad.adrelid = tbl.oid AND ad.adnum = att.attnum \
+           JOIN pg_depend owned \
+             ON owned.refobjid = tbl.oid AND owned.refobjsubid = att.attnum \
+             AND owned.refclassid = 'pg_class'::regclass \
+             AND owned.classid = 'pg_class'::regclass \
+             AND owned.deptype = 'a' \
+           JOIN pg_class seq ON seq.oid = owned.objid AND seq.relkind = 'S' \
+           JOIN pg_depend usedby \
+             ON usedby.objid = ad.oid AND usedby.classid = 'pg_attrdef'::regclass \
+             AND usedby.refobjid = seq.oid AND usedby.refclassid = 'pg_class'::regclass \
+             AND usedby.deptype = 'n' \
+           WHERE tn.nspname = 'public' \
              AND tbl.relname = c.table_name \
-             AND att.attname = c.column_name \
+             AND att.attnum > 0 \
          ) AS owns_sequence \
          FROM information_schema.columns c \
          WHERE c.table_schema = 'public' AND c.table_name IN ({}) \
@@ -1138,14 +1155,16 @@ fn normalize_default(
 /// `BIGSERIAL` id round-trips against the model parser (whose `pk_kind_for` requires
 /// `default.is_none()` for a `BigSerial` PK).
 ///
-/// **Ownership is load-bearing**: only a *conventional* serial — where Postgres
-/// links the sequence to the column via an `OWNED BY` auto-dependency
-/// (`owns_sequence == true`, sourced from `pg_depend` `deptype = 'a'`) — is the
-/// default-less `BIGSERIAL` shape. A brownfield int8 PK backed by a **shared/custom**
-/// sequence it does NOT own (`id BIGINT PRIMARY KEY DEFAULT nextval('global_ids')`)
-/// is deliberately **not** stripped: stripping it would make recreation/rollback
-/// emit a fresh owned `BIGSERIAL` (a NEW sequence) instead of continuing to allocate
-/// from `global_ids` — a silent, wrong ID-allocation change. Its raw
+/// **Ownership is load-bearing**: only a *conventional* serial — where the column
+/// owns the SAME sequence its default allocates from (`owns_sequence == true`,
+/// requiring both the `OWNED BY` `deptype = 'a'` link AND the default's `pg_attrdef`
+/// `deptype = 'n'` reference to point at one sequence) — is the default-less
+/// `BIGSERIAL` shape. A brownfield int8 PK backed by a **shared/custom** sequence it
+/// does NOT own (`id BIGINT PRIMARY KEY DEFAULT nextval('global_ids')`), OR one that
+/// still owns an old sequence but whose default was repointed to a different one, is
+/// deliberately **not** stripped: stripping it would make recreation/rollback emit a
+/// fresh owned `BIGSERIAL` (a NEW sequence) instead of continuing to allocate from
+/// the sequence the default names — a silent, wrong ID-allocation change. Its raw
 /// `nextval(...)` default is preserved verbatim instead.
 ///
 /// A single-column **`SERIAL`** (int4) PK is deliberately **not** stripped (this
@@ -1790,6 +1809,74 @@ mod sqlite {
         }
     }
 
+    /// Whether the table's `CREATE TABLE` SQL declares an `AUTOINCREMENT` primary key.
+    ///
+    /// Detects the `AUTOINCREMENT` **keyword** as a word-bounded token, AFTER
+    /// neutralizing string literals (`'…'`) and quoted identifiers (`"…"`, `` `…` ``,
+    /// `[…]`), so neither a NAME containing the substring (`autoincrement_events`) nor
+    /// a string literal (`DEFAULT 'AUTOINCREMENT'`) nor a quoted identifier
+    /// (`"AUTOINCREMENT"`) is ever mistaken for the keyword. `SQLite`'s grammar only
+    /// permits the `AUTOINCREMENT` keyword inside an `INTEGER PRIMARY KEY
+    /// AUTOINCREMENT` column definition, so a genuine word-bounded keyword occurrence
+    /// unambiguously marks the table as auto-incrementing.
+    fn table_sql_has_autoincrement_keyword(table_sql: &str) -> bool {
+        const KW: &str = "AUTOINCREMENT";
+        let stripped = neutralize_sqlite_literals_and_quoted_idents(table_sql).to_ascii_uppercase();
+        let bytes = stripped.as_bytes();
+        let is_word = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+        let mut from = 0;
+        while let Some(rel) = stripped[from..].find(KW) {
+            let start = from + rel;
+            let end = start + KW.len();
+            let before_ok = start == 0 || !is_word(bytes[start - 1]);
+            let after_ok = end == bytes.len() || !is_word(bytes[end]);
+            if before_ok && after_ok {
+                return true;
+            }
+            from = start + 1;
+        }
+        false
+    }
+
+    /// Replace the CONTENTS (and delimiters) of `SQLite` string literals (`'…'`) and
+    /// quoted identifiers (`"…"`, `` `…` ``, `[…]`) with spaces, preserving all other
+    /// text positionally, so a keyword scan never matches inside a name or literal.
+    /// Doubled-delimiter escapes (`''`, `""`, ``` `` ```) keep the quote open. Pure.
+    fn neutralize_sqlite_literals_and_quoted_idents(sql: &str) -> String {
+        let mut out = String::with_capacity(sql.len());
+        let mut chars = sql.chars().peekable();
+        while let Some(c) = chars.next() {
+            let close = match c {
+                '\'' => Some('\''),
+                '"' => Some('"'),
+                '`' => Some('`'),
+                '[' => Some(']'),
+                _ => None,
+            };
+            let Some(close) = close else {
+                out.push(c);
+                continue;
+            };
+            out.push(' '); // opening delimiter
+            while let Some(n) = chars.next() {
+                if n == close {
+                    // A doubled delimiter is an escape (not for the `[…]` form) — stay
+                    // inside the quote.
+                    if close != ']' && chars.peek() == Some(&close) {
+                        chars.next();
+                        out.push(' ');
+                        out.push(' ');
+                        continue;
+                    }
+                    break;
+                }
+                out.push(' ');
+            }
+            out.push(' '); // closing delimiter
+        }
+        out
+    }
+
     /// Assemble one [`Table`] from its pre-fetched `SQLite` catalog rows. Pure.
     fn build_table(
         name: &str,
@@ -1812,8 +1899,10 @@ mod sqlite {
         table.primary_key = pk_cols.into_iter().map(|(_, n)| n).collect();
         let single_pk = table.primary_key.len() == 1;
         // AUTOINCREMENT lives in the table's CREATE SQL (sqlite_sequence is empty
-        // until the first insert, so it cannot be relied on).
-        let autoincrement = table_sql.to_ascii_uppercase().contains("AUTOINCREMENT");
+        // until the first insert, so it cannot be relied on). Matched as a KEYWORD
+        // token, not a substring, so a table/column name or literal containing the
+        // substring never misclassifies a plain rowid PK as a serial.
+        let autoincrement = table_sql_has_autoincrement_keyword(table_sql);
 
         let (ir_indexes, unique_columns) = collapse_indexes(name, indexes, index_columns);
         let fk_by_column: BTreeMap<&str, &ForeignKeyRow> = foreign_keys
@@ -2083,6 +2172,53 @@ mod sqlite {
             let columns = vec![col_row("id", "INTEGER", 0, None, 1)];
             let table_sql = "CREATE TABLE posts (id INTEGER PRIMARY KEY)";
             let table = build_table("posts", table_sql, &columns, &[], &BTreeMap::new(), &[]);
+            let id = table.columns.iter().find(|c| c.name == "id").unwrap();
+            assert_eq!(id.serial, Some(SerialKind::Plain));
+        }
+
+        #[test]
+        fn autoincrement_keyword_is_tokenized_not_substring_matched() {
+            assert!(table_sql_has_autoincrement_keyword(
+                "CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT)"
+            ));
+            assert!(table_sql_has_autoincrement_keyword(
+                "create table t (id integer primary key   autoincrement )"
+            ));
+            // A table NAME containing the substring is NOT a match.
+            assert!(!table_sql_has_autoincrement_keyword(
+                "CREATE TABLE autoincrement_events (id INTEGER PRIMARY KEY)"
+            ));
+            // A column NAME containing the substring is NOT a match.
+            assert!(!table_sql_has_autoincrement_keyword(
+                "CREATE TABLE t (autoincrement_flag INTEGER, id INTEGER PRIMARY KEY)"
+            ));
+            // A string-literal default equal to the keyword is NOT a match.
+            assert!(!table_sql_has_autoincrement_keyword(
+                "CREATE TABLE t (id INTEGER PRIMARY KEY, kind TEXT DEFAULT 'AUTOINCREMENT')"
+            ));
+            // A quoted identifier equal to the keyword is NOT a match.
+            assert!(!table_sql_has_autoincrement_keyword(
+                "CREATE TABLE t (\"AUTOINCREMENT\" INTEGER, id INTEGER PRIMARY KEY)"
+            ));
+            assert!(!table_sql_has_autoincrement_keyword(
+                "CREATE TABLE t (id INTEGER PRIMARY KEY, [AUTOINCREMENT] TEXT)"
+            ));
+        }
+
+        #[test]
+        fn build_table_autoincrement_substring_name_is_plain_not_serial() {
+            // A plain INTEGER PK in a table whose NAME contains the `autoincrement`
+            // substring must be `Some(Plain)`, never mis-flagged BigSerial.
+            let columns = vec![col_row("id", "INTEGER", 0, None, 1)];
+            let table_sql = "CREATE TABLE autoincrement_events (id INTEGER PRIMARY KEY)";
+            let table = build_table(
+                "autoincrement_events",
+                table_sql,
+                &columns,
+                &[],
+                &BTreeMap::new(),
+                &[],
+            );
             let id = table.columns.iter().find(|c| c.name == "id").unwrap();
             assert_eq!(id.serial, Some(SerialKind::Plain));
         }

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -1838,14 +1838,44 @@ mod sqlite {
         false
     }
 
-    /// Replace the CONTENTS (and delimiters) of `SQLite` string literals (`'…'`) and
-    /// quoted identifiers (`"…"`, `` `…` ``, `[…]`) with spaces, preserving all other
-    /// text positionally, so a keyword scan never matches inside a name or literal.
-    /// Doubled-delimiter escapes (`''`, `""`, ``` `` ```) keep the quote open. Pure.
+    /// Replace the CONTENTS (and delimiters) of `SQLite` string literals (`'…'`),
+    /// quoted identifiers (`"…"`, `` `…` ``, `[…]`), AND SQL comments (`-- …` to
+    /// end-of-line, `/* … */` block — `SQLite` preserves comments in
+    /// `sqlite_master.sql`) with spaces, preserving all other text positionally, so a
+    /// keyword scan never matches inside a name, literal, or comment. Doubled-delimiter
+    /// escapes (`''`, `""`, ``` `` ```) keep the quote open; block comments do not
+    /// nest (matching `SQLite`). Pure.
     fn neutralize_sqlite_literals_and_quoted_idents(sql: &str) -> String {
         let mut out = String::with_capacity(sql.len());
         let mut chars = sql.chars().peekable();
         while let Some(c) = chars.next() {
+            // `-- …` line comment → blank to end of line (the newline is preserved).
+            if c == '-' && chars.peek() == Some(&'-') {
+                out.push(' ');
+                while let Some(&n) = chars.peek() {
+                    if n == '\n' {
+                        break;
+                    }
+                    chars.next();
+                    out.push(' ');
+                }
+                continue;
+            }
+            // `/* … */` block comment (non-nesting) → blank through the closing `*/`.
+            if c == '/' && chars.peek() == Some(&'*') {
+                chars.next();
+                out.push(' ');
+                out.push(' ');
+                let mut prev_star = false;
+                for n in chars.by_ref() {
+                    out.push(' ');
+                    if prev_star && n == '/' {
+                        break;
+                    }
+                    prev_star = n == '*';
+                }
+                continue;
+            }
             let close = match c {
                 '\'' => Some('\''),
                 '"' => Some('"'),
@@ -2202,6 +2232,18 @@ mod sqlite {
             ));
             assert!(!table_sql_has_autoincrement_keyword(
                 "CREATE TABLE t (id INTEGER PRIMARY KEY, [AUTOINCREMENT] TEXT)"
+            ));
+            // A block comment mentioning the keyword is NOT a match.
+            assert!(!table_sql_has_autoincrement_keyword(
+                "CREATE TABLE t (id INTEGER PRIMARY KEY /* AUTOINCREMENT */)"
+            ));
+            // A line comment mentioning the keyword is NOT a match.
+            assert!(!table_sql_has_autoincrement_keyword(
+                "CREATE TABLE t (id INTEGER PRIMARY KEY -- AUTOINCREMENT\n)"
+            ));
+            // A genuine keyword AFTER a block comment still matches.
+            assert!(table_sql_has_autoincrement_keyword(
+                "CREATE TABLE t (id INTEGER /* pk */ PRIMARY KEY AUTOINCREMENT)"
             ));
         }
 

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -1291,6 +1291,100 @@ fn sqlite_target(url: &str) -> String {
     rest.to_owned()
 }
 
+/// Classify a resolved `SQLite` target for the create-on-open existence guard:
+/// `Some(path)` is a concrete filesystem path that must be checked for existence
+/// (bare path or a `file:` URI with a real path); `None` is an in-memory database
+/// (nothing to check).
+///
+/// `SQLite`'s `sqlite3_open` CREATES a missing file, so a typo'd path (bare OR inside
+/// a `file:` URI) would otherwise pull zero tables and overwrite the snapshot. Only
+/// genuine in-memory targets are exempt: `:memory:`, `file::memory:` (and its
+/// shared-cache `?cache=shared` form), and any `file:` URI carrying `mode=memory`.
+/// For a `file:` URI with a real path the path is parsed out — the `file:` scheme
+/// stripped (handling `file:p`, `file:/p`, `file://host/p`, `file:///p`), the `?query`
+/// separator honored, and the path percent-decoded — then existence-checked like a
+/// bare path.
+#[cfg(feature = "sqlite")]
+fn sqlite_existence_check_path(target: &str) -> Option<String> {
+    if target.is_empty() || target == ":memory:" {
+        return None;
+    }
+    let Some(rest) = target.strip_prefix("file:") else {
+        // A bare filesystem path.
+        return Some(target.to_owned());
+    };
+    // Split off the `?query` (URI parameters like `mode=`, `cache=`).
+    let (path_part, query) = rest.split_once('?').unwrap_or((rest, ""));
+    // Strip an optional authority: `file://host/path` / `file:///path`.
+    let path_part = path_part.strip_prefix("//").map_or(path_part, |after| {
+        after.find('/').map_or(after, |idx| &after[idx..])
+    });
+    // In-memory forms are exempt (no file to check).
+    let is_memory = path_part == ":memory:"
+        || query
+            .split('&')
+            .any(|kv| kv.trim().eq_ignore_ascii_case("mode=memory"));
+    if is_memory {
+        return None;
+    }
+    let decoded = percent_encoding::percent_decode_str(path_part)
+        .decode_utf8_lossy()
+        .into_owned();
+    Some(decoded)
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+mod target_tests {
+    use super::sqlite_existence_check_path;
+
+    #[test]
+    fn existence_check_path_parses_files_and_exempts_memory() {
+        // In-memory targets: no file to check.
+        for mem in [
+            ":memory:",
+            "",
+            "file::memory:",
+            "file::memory:?cache=shared",
+            "file:app.db?mode=memory",
+            "file:app.db?cache=shared&mode=memory",
+        ] {
+            assert_eq!(
+                sqlite_existence_check_path(mem),
+                None,
+                "{mem} is in-memory (exempt)"
+            );
+        }
+        // Bare filesystem path.
+        assert_eq!(
+            sqlite_existence_check_path("/srv/app.db"),
+            Some("/srv/app.db".to_owned())
+        );
+        // `file:` URI forms → the real path is parsed out (scheme/authority/query
+        // stripped, percent-decoded).
+        assert_eq!(
+            sqlite_existence_check_path("file:/srv/app.db"),
+            Some("/srv/app.db".to_owned())
+        );
+        assert_eq!(
+            sqlite_existence_check_path("file:///srv/app.db"),
+            Some("/srv/app.db".to_owned())
+        );
+        assert_eq!(
+            sqlite_existence_check_path("file://localhost/srv/app.db"),
+            Some("/srv/app.db".to_owned())
+        );
+        assert_eq!(
+            sqlite_existence_check_path("file:app.db?mode=ro"),
+            Some("app.db".to_owned())
+        );
+        assert_eq!(
+            sqlite_existence_check_path("file:/srv/my%20app.db"),
+            Some("/srv/my app.db".to_owned()),
+            "percent-decoded"
+        );
+    }
+}
+
 /// Introspect a live `SQLite` database at `url` into a set of [`Table`]s tagged
 /// [`Backend::Sqlite`] and marked `managed` — the `SQLite` counterpart of
 /// [`introspect_postgres`], producing the identical snapshot IR so a pulled snapshot
@@ -1310,19 +1404,16 @@ pub fn introspect_sqlite(url: &str) -> Result<Vec<Table>, IntrospectError> {
     use diesel::{Connection as _, SqliteConnection};
 
     let target = sqlite_target(url);
-    // Guard against SQLite's create-if-missing behavior: `establish` on a
-    // nonexistent file SUCCEEDS against a brand-new EMPTY database, so a typo'd or
-    // missing DB path would otherwise pull ZERO tables and (on a non-dry-run pull)
-    // silently overwrite the checked-in snapshot with an empty one. For a plain
-    // file-backed target, require the file to already exist. `:memory:` and `file:`
-    // URI forms (which may legitimately encode `mode=`/shared-cache/`:memory:`
-    // semantics) are exempt — they are not plain filesystem paths and are left to
-    // diesel to open.
-    if target != ":memory:"
-        && !target.starts_with("file:")
-        && !std::path::Path::new(&target).exists()
+    // Guard against SQLite's create-if-missing behavior: `establish` on a nonexistent
+    // file SUCCEEDS against a brand-new EMPTY database, so a typo'd or missing DB path
+    // would otherwise pull ZERO tables and (on a non-dry-run pull) silently overwrite
+    // the checked-in snapshot with an empty one. Require a concrete file-backed target
+    // (bare path OR a `file:` URI with a real path) to already exist; genuine
+    // in-memory targets have no file to check and are exempt.
+    if let Some(path) = sqlite_existence_check_path(&target)
+        && !std::path::Path::new(&path).exists()
     {
-        return Err(IntrospectError::ConnectionSqlite { path: target });
+        return Err(IntrospectError::ConnectionSqlite { path });
     }
     let mut conn = SqliteConnection::establish(&target)
         .map_err(|_| IntrospectError::ConnectionSqlite { path: target })?;

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -1261,6 +1261,16 @@ fn serial_kind_for(
 //   AUTOINCREMENT id is always recorded as `BigSerial` (there is no int4 serial).
 // - **FK on-update/on-delete actions, composite FKs, expression/collation index
 //   attributes**: same deferrals as the Postgres arm.
+// - **Composite inline `UNIQUE(a, b)` constraints**: a table-level UNIQUE-constraint
+//   auto-index (`sqlite_autoindex_*`) cannot be recorded — its name is un-creatable
+//   (`SQLite` refuses `CREATE … "sqlite_…"`) and the IR has no table-level
+//   unique-constraint node — so a composite inline `UNIQUE` is skipped (a
+//   single-column inline `UNIQUE` IS captured, as the column's `unique` flag). Rare
+//   brownfield shape; not tracked in the snapshot.
+// - **Generated columns' expressions**: generated columns are PRESERVED (read via
+//   `pragma_table_xinfo`, never dropped), but their `GENERATED ALWAYS AS (...)`
+//   expression is not captured — a generated column round-trips as an ordinary column
+//   of its declared type. Full verbatim re-emission is future work.
 
 /// Resolve a `sqlite:`/`sqlite://`/`file:` URL (or a bare path) to the concrete
 /// target [`diesel::SqliteConnection::establish`] expects, mirroring autumn-web's
@@ -1364,6 +1374,13 @@ mod sqlite {
         /// position.
         #[diesel(sql_type = Integer)]
         pk: i32,
+        /// `PRAGMA table_xinfo.hidden` — `0` = ordinary column, `1` = hidden column
+        /// (virtual-table / `WITHOUT ROWID` internal — not a user column), `2` =
+        /// `VIRTUAL` generated column, `3` = `STORED` generated column. Read via
+        /// `table_xinfo` (NOT `table_info`, which OMITS generated columns entirely and
+        /// would silently drop them from the pull).
+        #[diesel(sql_type = Integer)]
+        hidden: i32,
     }
 
     #[derive(QueryableByName)]
@@ -1504,14 +1521,21 @@ mod sqlite {
         })
     }
 
-    /// Fetch every column of every table in one batched `pragma_table_info` join.
+    /// Fetch every column of every table in one batched `pragma_table_xinfo` join.
+    ///
+    /// Uses `table_xinfo` (not `table_info`) BECAUSE the latter OMITS generated
+    /// columns, so a pull would silently drop them and a recreate would omit the
+    /// column (a fail-closed violation). `table_xinfo` includes them with a `hidden`
+    /// discriminator so [`build_table`] can preserve generated columns instead of
+    /// dropping them.
     fn fetch_columns(
         conn: &mut SqliteConnection,
     ) -> Result<BTreeMap<String, Vec<ColumnRow>>, IntrospectError> {
         let rows: Vec<ColumnRow> = sql_query(
             "SELECT m.name AS table_name, ti.name AS column_name, ti.type AS decl_type, \
-             ti.\"notnull\" AS not_null, ti.dflt_value AS dflt_value, ti.pk AS pk \
-             FROM sqlite_master m JOIN pragma_table_info(m.name) ti \
+             ti.\"notnull\" AS not_null, ti.dflt_value AS dflt_value, ti.pk AS pk, \
+             ti.hidden AS hidden \
+             FROM sqlite_master m JOIN pragma_table_xinfo(m.name) ti \
              WHERE m.type = 'table' AND m.name NOT LIKE 'sqlite_%' \
              ORDER BY m.name, ti.cid",
         )
@@ -1707,6 +1731,18 @@ mod sqlite {
             .collect();
 
         for row in columns {
+            // `hidden = 1` is an internal hidden column (virtual-table / rowid
+            // machinery), never a user column — skip it. `hidden = 2` (VIRTUAL) / `3`
+            // (STORED) are GENERATED columns: they are included (via `table_xinfo`) so
+            // they are NEVER silently dropped from the pull. NOTE (DEFERRED): the
+            // generation EXPRESSION is not captured here, so a generated column
+            // round-trips as an ordinary column of its declared type — enough to keep
+            // it in the snapshot (doctor/dry-run see it, a recreate no longer omits
+            // it), but full generated-column fidelity (verbatim `GENERATED ALWAYS AS
+            // (...)` re-emission) is future work.
+            if row.hidden == 1 {
+                continue;
+            }
             let is_pk = row.pk > 0;
             let default = sqlite_default(row.dflt_value.as_deref());
             let ty = sqlite_column_type(&row.decl_type, default.as_ref());
@@ -1752,15 +1788,22 @@ mod sqlite {
     /// `CREATE INDEX` SQL; a plain index is representable by its columns. The primary
     /// key auto-index (`origin = 'pk'`) is skipped (the PK is modeled separately).
     ///
-    /// A `UNIQUE`-constraint auto-index (`origin = 'u'`, e.g. an inline `col TEXT
-    /// UNIQUE` or a table-level `UNIQUE(a, b)` — named `sqlite_autoindex_<table>_<n>`)
-    /// has **no** standalone `CREATE INDEX` statement in `sqlite_master` and therefore
-    /// **cannot be `DROP INDEX`ed** — it is owned by the constraint. It is treated
-    /// like the Postgres arm's constraint-owned unique index: retained verbatim via a
-    /// synthesized `definition` (so a *model* diff never emits an undroppable
-    /// `DropIndex` for a brownfield inline-`UNIQUE`), with its `key_columns` recorded
-    /// (so it still covers a matching `#[unique]` model, yielding a clean round-trip).
-    /// A single-column `origin = 'u'` also marks the column `unique = true`.
+    /// A `UNIQUE`-constraint auto-index (`origin = 'u'`, named
+    /// `sqlite_autoindex_<table>_<n>`) has **no** standalone `CREATE INDEX` statement
+    /// and is owned by the constraint — it cannot be `DROP INDEX`ed, and `SQLite`
+    /// refuses to `CREATE` any object named `sqlite_*`, so it must **never** appear as
+    /// an [`Index`] in the IR (the emitter would try to re-`CREATE` it by name on a
+    /// table rebuild / `DropTable` rollback and produce illegal `CREATE … "sqlite_…"`
+    /// DDL). Instead:
+    /// * a **single-column** inline `col TEXT UNIQUE` is represented purely as the
+    ///   column's `unique = true` flag (no [`Index`] object) — a matching `#[unique]`
+    ///   model is recognized as already satisfied (clean diff, no `DropIndex`, no
+    ///   `sqlite_`-named `CREATE`);
+    /// * a **composite** table-level `UNIQUE(a, b)` cannot be represented (the IR has
+    ///   no table-level unique-constraint node, and the model DSL cannot express it),
+    ///   so it is **skipped entirely** rather than synthesized as a `sqlite_`-named
+    ///   index (DEFERRED: composite inline-`UNIQUE` fidelity — a rare brownfield shape
+    ///   — is not tracked in the snapshot; see the module note).
     fn collapse_indexes(
         table_name: &str,
         rows: &[IndexRow],
@@ -1781,23 +1824,13 @@ mod sqlite {
             let is_unique = row.is_unique != 0;
             let is_partial = row.partial != 0;
 
-            // A UNIQUE-constraint auto-index (`origin = 'u'`) is owned by the
-            // constraint and cannot be dropped independently; retain it verbatim via
-            // a synthesized definition and record its key columns (see the fn note).
+            // A UNIQUE-constraint auto-index (`origin = 'u'`) is NEVER emitted as an
+            // Index (its `sqlite_*` name is un-creatable and un-droppable). A single
+            // column becomes the column's `unique` flag; a composite one is skipped.
             if row.origin == "u" {
                 if is_unique && !has_expression && key_columns.len() == 1 {
                     unique_columns.insert(key_columns[0].clone());
                 }
-                let definition =
-                    synthesized_unique_constraint_ddl(&row.index_name, table_name, &key_columns);
-                indexes.push(Index {
-                    name: row.index_name.clone(),
-                    columns: key_columns.clone(),
-                    unique: is_unique,
-                    definition: Some(definition),
-                    is_partial,
-                    key_columns,
-                });
                 continue;
             }
 
@@ -1818,20 +1851,6 @@ mod sqlite {
             });
         }
         (indexes, unique_columns)
-    }
-
-    /// Reconstruct a deterministic `CREATE UNIQUE INDEX` statement for a
-    /// `UNIQUE`-constraint auto-index (which has no stored SQL of its own), used only
-    /// as the retained index's `definition` identity token — it is never emitted as
-    /// real DDL (the index is retained, never recreated). Deterministic so a re-pull
-    /// is byte-stable and two authoritative introspections compare equal.
-    fn synthesized_unique_constraint_ddl(name: &str, table: &str, cols: &[String]) -> String {
-        let col_list = cols
-            .iter()
-            .map(|c| format!("\"{c}\""))
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("CREATE UNIQUE INDEX \"{name}\" ON \"{table}\" ({col_list})")
     }
 
     #[cfg(test)]
@@ -1917,6 +1936,16 @@ mod sqlite {
                 not_null,
                 dflt_value: dflt.map(str::to_owned),
                 pk,
+                hidden: 0,
+            }
+        }
+
+        /// A `ColumnRow` with an explicit `table_xinfo.hidden` discriminator (`2` =
+        /// VIRTUAL generated, `3` = STORED generated, `1` = internal hidden).
+        fn col_row_hidden(name: &str, decl: &str, hidden: i32) -> ColumnRow {
+            ColumnRow {
+                hidden,
+                ..col_row(name, decl, 0, None, 0)
             }
         }
 
@@ -1965,6 +1994,33 @@ mod sqlite {
             let table = build_table("posts", table_sql, &columns, &[], &BTreeMap::new(), &[]);
             let id = table.columns.iter().find(|c| c.name == "id").unwrap();
             assert_eq!(id.serial, Some(SerialKind::Plain));
+        }
+
+        #[test]
+        fn build_table_preserves_generated_columns_and_skips_internal_hidden() {
+            // `table_xinfo` surfaces generated columns (hidden 2 = VIRTUAL, 3 =
+            // STORED); they must be PRESERVED (never silently dropped), while a truly
+            // internal hidden column (hidden = 1) is skipped.
+            let columns = vec![
+                col_row("id", "INTEGER", 0, None, 1),
+                col_row("first", "TEXT", 1, None, 0),
+                col_row_hidden("full_stored", "TEXT", 3),
+                col_row_hidden("full_virtual", "TEXT", 2),
+                col_row_hidden("internal", "TEXT", 1),
+            ];
+            let table_sql = "CREATE TABLE posts (id INTEGER PRIMARY KEY, first TEXT NOT NULL, \
+                             full_stored TEXT GENERATED ALWAYS AS (first) STORED, \
+                             full_virtual TEXT GENERATED ALWAYS AS (first) VIRTUAL)";
+            let table = build_table("posts", table_sql, &columns, &[], &BTreeMap::new(), &[]);
+            let names: Vec<&str> = table.columns.iter().map(|c| c.name.as_str()).collect();
+            assert!(
+                names.contains(&"full_stored") && names.contains(&"full_virtual"),
+                "generated columns must be preserved, not dropped: {names:?}"
+            );
+            assert!(
+                !names.contains(&"internal"),
+                "an internal hidden column (hidden = 1) is skipped: {names:?}"
+            );
         }
 
         #[test]
@@ -2044,12 +2100,12 @@ mod sqlite {
         }
 
         #[test]
-        fn collapse_indexes_unique_constraint_autoindex_is_retained_not_droppable() {
-            // A `col TEXT UNIQUE` inline constraint produces a `sqlite_autoindex_*`
-            // (origin = 'u') with NO standalone CREATE INDEX SQL. It must be retained
-            // via a synthesized definition (so a model diff never emits an undroppable
-            // DropIndex) and carry its key columns (so it covers a matching
-            // `#[unique]` model), and mark the column unique.
+        fn collapse_indexes_single_col_unique_autoindex_becomes_column_flag_not_index() {
+            // A single-column `col TEXT UNIQUE` inline constraint produces a
+            // `sqlite_autoindex_*` (origin = 'u') with NO standalone CREATE INDEX SQL.
+            // Its `sqlite_*` name is un-creatable AND un-droppable, so it must produce
+            // NO Index object (only the column's `unique` flag) — otherwise the
+            // emitter would try to re-CREATE / DROP `sqlite_autoindex_*` on a rebuild.
             let rows = vec![IndexRow {
                 table_name: "accounts".to_owned(),
                 index_name: "sqlite_autoindex_accounts_1".to_owned(),
@@ -2072,21 +2128,59 @@ mod sqlite {
                 }],
             );
             let (indexes, unique_cols) = collapse_indexes("accounts", &rows, &index_columns);
-            assert_eq!(indexes.len(), 1);
-            assert!(unique_cols.contains("email"), "the column is marked unique");
-            let idx = &indexes[0];
-            assert!(idx.unique);
-            assert_eq!(
-                idx.key_columns,
-                vec!["email".to_owned()],
-                "key columns recorded"
-            );
-            let def = idx.definition.as_deref().expect(
-                "a constraint autoindex carries a synthesized definition (retained, not droppable)",
+            assert!(
+                indexes.is_empty(),
+                "a UNIQUE-constraint autoindex is NEVER an Index (its sqlite_* name is \
+                 un-creatable/un-droppable): {indexes:?}"
             );
             assert!(
-                def.contains("CREATE UNIQUE INDEX") && def.contains("email"),
-                "definition reconstructs the constraint index: {def}"
+                unique_cols.contains("email"),
+                "it is represented purely as the column's unique flag"
+            );
+        }
+
+        #[test]
+        fn collapse_indexes_composite_unique_autoindex_is_skipped() {
+            // A composite table-level `UNIQUE(a, b)` autoindex (origin = 'u') cannot be
+            // represented (no table-level unique node in the IR, un-creatable name), so
+            // it is skipped entirely — never synthesized as a `sqlite_`-named index.
+            let rows = vec![IndexRow {
+                table_name: "memberships".to_owned(),
+                index_name: "sqlite_autoindex_memberships_1".to_owned(),
+                is_unique: 1,
+                origin: "u".to_owned(),
+                partial: 0,
+                index_sql: None,
+            }];
+            let mut index_columns = BTreeMap::new();
+            index_columns.insert(
+                (
+                    "memberships".to_owned(),
+                    "sqlite_autoindex_memberships_1".to_owned(),
+                ),
+                vec![
+                    IndexColumnRow {
+                        table_name: "memberships".to_owned(),
+                        index_name: "sqlite_autoindex_memberships_1".to_owned(),
+                        seqno: 0,
+                        column_name: Some("org_id".to_owned()),
+                    },
+                    IndexColumnRow {
+                        table_name: "memberships".to_owned(),
+                        index_name: "sqlite_autoindex_memberships_1".to_owned(),
+                        seqno: 1,
+                        column_name: Some("user_id".to_owned()),
+                    },
+                ],
+            );
+            let (indexes, unique_cols) = collapse_indexes("memberships", &rows, &index_columns);
+            assert!(
+                indexes.is_empty(),
+                "composite UNIQUE autoindex is skipped: {indexes:?}"
+            );
+            assert!(
+                unique_cols.is_empty(),
+                "a composite UNIQUE marks no single column unique"
             );
         }
 

--- a/autumn-cli/src/schema/introspect.rs
+++ b/autumn-cli/src/schema/introspect.rs
@@ -897,6 +897,7 @@ fn build_table(
             is_pk,
             primary_key,
             row.owns_sequence,
+            row.is_identity.eq_ignore_ascii_case("YES"),
         );
         // Identity marker: preserve a `GENERATED { ALWAYS | BY DEFAULT } AS
         // IDENTITY` column's generation clause verbatim so it round-trips a pull
@@ -1186,19 +1187,38 @@ fn serial_kind_for(
     is_primary_key: bool,
     primary_key: &[String],
     owns_sequence: bool,
+    is_identity: bool,
 ) -> Option<SerialKind> {
-    if !is_primary_key || primary_key.len() != 1 || !owns_sequence {
+    // The serial-vs-plain distinction only applies to a single-column INTEGER
+    // primary key. A composite/non-PK column, a non-integer PK (e.g. a UUID id), or
+    // a `GENERATED … AS IDENTITY` column (whose id-generation is carried by the
+    // separate `identity` marker) leaves this `None` — "not applicable", which the
+    // diff treats as compatible.
+    if !is_primary_key
+        || primary_key.len() != 1
+        || is_identity
+        || !matches!(ty, ColumnType::Int32 | ColumnType::Int64)
+    {
         return None;
     }
-    let lowered = raw_default?.trim().to_ascii_lowercase();
-    if !lowered.starts_with("nextval(") {
-        return None;
+    // An owned `nextval(...)` default is a `SERIAL`/`BIGSERIAL` id (distinguished by
+    // int4 vs int8). Computed from the RAW default (before `normalize_default`
+    // strips an int8 owned-serial default to `None`).
+    if owns_sequence
+        && raw_default
+            .map(|d| d.trim().to_ascii_lowercase())
+            .is_some_and(|d| d.starts_with("nextval("))
+    {
+        return Some(match ty {
+            ColumnType::Int32 => SerialKind::Serial,
+            _ => SerialKind::BigSerial,
+        });
     }
-    match ty {
-        ColumnType::Int64 => Some(SerialKind::BigSerial),
-        ColumnType::Int32 => Some(SerialKind::Serial),
-        _ => None,
-    }
+    // A single-column integer PK that owns no sequence is a genuine plain,
+    // manually-assigned id. Emit an EXPLICIT `Plain` marker (never `None`, which is
+    // reserved for legacy/unknown) so a plain-int-PK ↔ serial mismatch surfaces as
+    // drift while a legacy snapshot (marker absent) stays compatible.
+    Some(SerialKind::Plain)
 }
 
 // ===========================================================================
@@ -1280,6 +1300,20 @@ pub fn introspect_sqlite(url: &str) -> Result<Vec<Table>, IntrospectError> {
     use diesel::{Connection as _, SqliteConnection};
 
     let target = sqlite_target(url);
+    // Guard against SQLite's create-if-missing behavior: `establish` on a
+    // nonexistent file SUCCEEDS against a brand-new EMPTY database, so a typo'd or
+    // missing DB path would otherwise pull ZERO tables and (on a non-dry-run pull)
+    // silently overwrite the checked-in snapshot with an empty one. For a plain
+    // file-backed target, require the file to already exist. `:memory:` and `file:`
+    // URI forms (which may legitimately encode `mode=`/shared-cache/`:memory:`
+    // semantics) are exempt — they are not plain filesystem paths and are left to
+    // diesel to open.
+    if target != ":memory:"
+        && !target.starts_with("file:")
+        && !std::path::Path::new(&target).exists()
+    {
+        return Err(IntrospectError::ConnectionSqlite { path: target });
+    }
     let mut conn = SqliteConnection::establish(&target)
         .map_err(|_| IntrospectError::ConnectionSqlite { path: target })?;
     sqlite::introspect(&mut conn)
@@ -1414,7 +1448,13 @@ mod sqlite {
     }
 
     /// List app tables (name + `CREATE TABLE` SQL), excluding `SQLite` internal
-    /// tables, the Diesel migrations table, and framework-owned tables.
+    /// tables, the Diesel migrations table, framework-owned tables, and **FTS5
+    /// search-index tables** — the `CREATE VIRTUAL TABLE "<table>__fts" USING fts5(…)`
+    /// index a `--searchable` model generates (issue #1910) plus its internal shadow
+    /// tables (`<vtab>_data`/`_idx`/`_content`/`_docsize`/`_config`). Those are stored
+    /// in `sqlite_master` as `type = 'table'` with non-`sqlite_` names, but the model
+    /// parser never emits them, so pulling them as managed application tables would
+    /// make a follow-up `schema diff`/doctor report/drop the search-index state.
     fn list_tables(
         conn: &mut SqliteConnection,
     ) -> Result<Vec<(String, Option<String>)>, IntrospectError> {
@@ -1424,11 +1464,44 @@ mod sqlite {
         )
         .load(conn)
         .map_err(|e| query_err(&e))?;
+        // Virtual tables (their `sql` starts with `CREATE VIRTUAL TABLE`) are never
+        // model-expressible; collect them so their FTS5 shadow tables can be
+        // excluded alongside the vtab itself.
+        let virtual_tables: Vec<String> = rows
+            .iter()
+            .filter(|r| r.sql.as_deref().is_some_and(is_create_virtual_table))
+            .map(|r| r.name.clone())
+            .collect();
         Ok(rows
             .into_iter()
-            .filter(|r| !super::is_framework_table(&r.name))
+            .filter(|r| {
+                !super::is_framework_table(&r.name)
+                    && !is_virtual_or_fts5_shadow_table(&r.name, &virtual_tables)
+            })
             .map(|r| (r.name, r.sql))
             .collect())
+    }
+
+    /// Whether `sql` is a `CREATE VIRTUAL TABLE …` statement (an FTS5 search index or
+    /// any other module-backed vtab) — none of which the model parser can express.
+    fn is_create_virtual_table(sql: &str) -> bool {
+        sql.trim_start()
+            .to_ascii_uppercase()
+            .starts_with("CREATE VIRTUAL TABLE")
+    }
+
+    /// The FTS5 internal shadow-table suffixes appended to the virtual-table name.
+    const FTS5_SHADOW_SUFFIXES: [&str; 5] = ["_data", "_idx", "_content", "_docsize", "_config"];
+
+    /// Whether `name` is one of the `virtual_tables` itself or one of its FTS5 shadow
+    /// tables (`<vtab>` + a [`FTS5_SHADOW_SUFFIXES`] suffix).
+    fn is_virtual_or_fts5_shadow_table(name: &str, virtual_tables: &[String]) -> bool {
+        virtual_tables.iter().any(|vtab| {
+            name == vtab
+                || FTS5_SHADOW_SUFFIXES
+                    .iter()
+                    .any(|suffix| name == format!("{vtab}{suffix}"))
+        })
     }
 
     /// Fetch every column of every table in one batched `pragma_table_info` join.
@@ -1491,8 +1564,19 @@ mod sqlite {
         Ok(by_index)
     }
 
-    /// Fetch single-column foreign keys (`seq = 0`) of every table in one batched
+    /// Fetch **single-column** foreign keys of every table in one batched
     /// `pragma_foreign_key_list` join.
+    ///
+    /// `pragma_foreign_key_list` returns one row PER referencing column, grouped by
+    /// the `id` column and ordered by `seq`; a composite (multi-column) FK spans
+    /// several rows sharing the same `id`. The IR [`ForeignKey`] is single-column
+    /// only, and the model parser never emits a composite FK, so — matching the
+    /// fail-closed posture of the Postgres arm (which defers composite FKs) — a
+    /// composite FK is **omitted entirely** here rather than flattened to a wrong
+    /// single-column FK (which would cause spurious drift / an incorrect recreate).
+    /// The `fkl.id NOT IN (… seq > 0 …)` predicate drops every `id` group that has
+    /// any `seq > 0` row, keeping only genuinely single-column FKs (the surviving
+    /// `seq = 0` rows).
     fn fetch_foreign_keys(
         conn: &mut SqliteConnection,
     ) -> Result<BTreeMap<String, Vec<ForeignKeyRow>>, IntrospectError> {
@@ -1500,7 +1584,9 @@ mod sqlite {
             "SELECT m.name AS table_name, fkl.\"table\" AS foreign_table, \
              fkl.\"from\" AS column_name, fkl.\"to\" AS foreign_column \
              FROM sqlite_master m JOIN pragma_foreign_key_list(m.name) fkl \
-             WHERE m.type = 'table' AND m.name NOT LIKE 'sqlite_%' AND fkl.seq = 0",
+             WHERE m.type = 'table' AND m.name NOT LIKE 'sqlite_%' AND fkl.seq = 0 \
+             AND fkl.id NOT IN ( \
+               SELECT fkl2.id FROM pragma_foreign_key_list(m.name) fkl2 WHERE fkl2.seq > 0)",
         )
         .load(conn)
         .map_err(|e| query_err(&e))?;
@@ -1546,9 +1632,17 @@ mod sqlite {
     /// Normalize a raw `SQLite` `dflt_value` into a [`ColumnDefault`]. Recovers the
     /// Autumn `Timestamp` convention default (`CURRENT_TIMESTAMP` → [`Now`]) and
     /// preserves anything else verbatim.
+    ///
+    /// `pragma_table_info.dflt_value` reports the literal keyword `NULL` (bareword,
+    /// any case) for a `DEFAULT NULL` clause — which is semantically "no default",
+    /// the same as a column with no `DEFAULT` at all. Capturing it as a real
+    /// `Sql("NULL")` default would create spurious drift against a model column that
+    /// simply has no default, so a bareword `NULL` maps to `None`. A **quoted**
+    /// `'NULL'` (the 4-character text value) is a genuine string default and is
+    /// preserved verbatim — only the unquoted keyword means "no default".
     fn sqlite_default(raw: Option<&str>) -> Option<ColumnDefault> {
         let raw = raw?.trim();
-        if raw.is_empty() {
+        if raw.is_empty() || raw.eq_ignore_ascii_case("NULL") {
             return None;
         }
         if raw.eq_ignore_ascii_case("CURRENT_TIMESTAMP") {
@@ -1624,15 +1718,20 @@ mod sqlite {
             column.primary_key = is_pk;
             column.unique = unique_columns.contains(row.column_name.as_str());
             column.default = default;
-            // Serial marker: a single-column INTEGER PK of an AUTOINCREMENT table is
-            // the Autumn `BigSerial` id (SQLite has one 64-bit rowid — always
-            // BigSerial), symmetric with what the model parser records.
-            if is_pk
-                && single_pk
-                && autoincrement
-                && matches!(affinity(&row.decl_type), Affinity::Integer)
-            {
-                column.serial = Some(SerialKind::BigSerial);
+            // Serial marker (three-state): a single-column INTEGER PK of an
+            // AUTOINCREMENT table is the Autumn `BigSerial` id (SQLite has one 64-bit
+            // rowid — always BigSerial), symmetric with what the model parser
+            // records. A single-column INTEGER PK WITHOUT `AUTOINCREMENT` is a
+            // genuine plain, manually-assigned id → an EXPLICIT `Plain` marker (never
+            // `None`, which is reserved for legacy/unknown snapshots) so a
+            // plain-int-PK ↔ `BigSerial`-model mismatch surfaces as drift while a
+            // legacy snapshot stays compatible.
+            if is_pk && single_pk && matches!(affinity(&row.decl_type), Affinity::Integer) {
+                column.serial = Some(if autoincrement {
+                    SerialKind::BigSerial
+                } else {
+                    SerialKind::Plain
+                });
             }
             if let Some(fk) = fk_by_column.get(row.column_name.as_str()) {
                 let foreign_column = fk.foreign_column.clone().unwrap_or_else(|| "id".to_owned());
@@ -1652,6 +1751,16 @@ mod sqlite {
     /// `collapse_indexes`). A partial or expression index is retained verbatim via its
     /// `CREATE INDEX` SQL; a plain index is representable by its columns. The primary
     /// key auto-index (`origin = 'pk'`) is skipped (the PK is modeled separately).
+    ///
+    /// A `UNIQUE`-constraint auto-index (`origin = 'u'`, e.g. an inline `col TEXT
+    /// UNIQUE` or a table-level `UNIQUE(a, b)` — named `sqlite_autoindex_<table>_<n>`)
+    /// has **no** standalone `CREATE INDEX` statement in `sqlite_master` and therefore
+    /// **cannot be `DROP INDEX`ed** — it is owned by the constraint. It is treated
+    /// like the Postgres arm's constraint-owned unique index: retained verbatim via a
+    /// synthesized `definition` (so a *model* diff never emits an undroppable
+    /// `DropIndex` for a brownfield inline-`UNIQUE`), with its `key_columns` recorded
+    /// (so it still covers a matching `#[unique]` model, yielding a clean round-trip).
+    /// A single-column `origin = 'u'` also marks the column `unique = true`.
     fn collapse_indexes(
         table_name: &str,
         rows: &[IndexRow],
@@ -1671,6 +1780,27 @@ mod sqlite {
                 cols.iter().filter_map(|c| c.column_name.clone()).collect();
             let is_unique = row.is_unique != 0;
             let is_partial = row.partial != 0;
+
+            // A UNIQUE-constraint auto-index (`origin = 'u'`) is owned by the
+            // constraint and cannot be dropped independently; retain it verbatim via
+            // a synthesized definition and record its key columns (see the fn note).
+            if row.origin == "u" {
+                if is_unique && !has_expression && key_columns.len() == 1 {
+                    unique_columns.insert(key_columns[0].clone());
+                }
+                let definition =
+                    synthesized_unique_constraint_ddl(&row.index_name, table_name, &key_columns);
+                indexes.push(Index {
+                    name: row.index_name.clone(),
+                    columns: key_columns.clone(),
+                    unique: is_unique,
+                    definition: Some(definition),
+                    is_partial,
+                    key_columns,
+                });
+                continue;
+            }
+
             let simple = !is_partial && !has_expression;
             if simple && is_unique && key_columns.len() == 1 {
                 unique_columns.insert(key_columns[0].clone());
@@ -1688,6 +1818,20 @@ mod sqlite {
             });
         }
         (indexes, unique_columns)
+    }
+
+    /// Reconstruct a deterministic `CREATE UNIQUE INDEX` statement for a
+    /// `UNIQUE`-constraint auto-index (which has no stored SQL of its own), used only
+    /// as the retained index's `definition` identity token — it is never emitted as
+    /// real DDL (the index is retained, never recreated). Deterministic so a re-pull
+    /// is byte-stable and two authoritative introspections compare equal.
+    fn synthesized_unique_constraint_ddl(name: &str, table: &str, cols: &[String]) -> String {
+        let col_list = cols
+            .iter()
+            .map(|c| format!("\"{c}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("CREATE UNIQUE INDEX \"{name}\" ON \"{table}\" ({col_list})")
     }
 
     #[cfg(test)]
@@ -1742,6 +1886,23 @@ mod sqlite {
             );
         }
 
+        #[test]
+        fn default_bareword_null_is_no_default_but_quoted_null_is_preserved() {
+            // A `DEFAULT NULL` clause surfaces as the bareword keyword `NULL`
+            // (any case, possibly padded), which is semantically "no default" — it
+            // must map to `None` so it never drifts against a model column that has
+            // no default.
+            assert_eq!(sqlite_default(Some("NULL")), None);
+            assert_eq!(sqlite_default(Some("null")), None);
+            assert_eq!(sqlite_default(Some("  Null  ")), None);
+            // A QUOTED `'NULL'` is the real 4-character text value, a genuine string
+            // default — it must survive verbatim.
+            assert_eq!(
+                sqlite_default(Some("'NULL'")),
+                Some(ColumnDefault::Sql("'NULL'".to_owned()))
+            );
+        }
+
         fn col_row(
             name: &str,
             decl: &str,
@@ -1793,14 +1954,17 @@ mod sqlite {
         }
 
         #[test]
-        fn build_table_plain_integer_pk_is_not_serial() {
+        fn build_table_plain_integer_pk_is_marked_plain() {
             // Without AUTOINCREMENT in the table SQL, an INTEGER PK is a plain rowid
-            // alias, not an Autumn BigSerial id → serial marker stays None.
+            // alias, not an Autumn BigSerial id → an EXPLICIT `Plain` marker (three-
+            // state: never `None`, which is reserved for legacy/unknown snapshots),
+            // so it drifts against a `BigSerial` model while a legacy snapshot stays
+            // compatible.
             let columns = vec![col_row("id", "INTEGER", 0, None, 1)];
             let table_sql = "CREATE TABLE posts (id INTEGER PRIMARY KEY)";
             let table = build_table("posts", table_sql, &columns, &[], &BTreeMap::new(), &[]);
             let id = table.columns.iter().find(|c| c.name == "id").unwrap();
-            assert!(id.serial.is_none());
+            assert_eq!(id.serial, Some(SerialKind::Plain));
         }
 
         #[test]
@@ -1877,6 +2041,85 @@ mod sqlite {
                 indexes[0].definition.as_deref().unwrap().contains("WHERE"),
                 "a partial index is retained verbatim via its CREATE INDEX SQL"
             );
+        }
+
+        #[test]
+        fn collapse_indexes_unique_constraint_autoindex_is_retained_not_droppable() {
+            // A `col TEXT UNIQUE` inline constraint produces a `sqlite_autoindex_*`
+            // (origin = 'u') with NO standalone CREATE INDEX SQL. It must be retained
+            // via a synthesized definition (so a model diff never emits an undroppable
+            // DropIndex) and carry its key columns (so it covers a matching
+            // `#[unique]` model), and mark the column unique.
+            let rows = vec![IndexRow {
+                table_name: "accounts".to_owned(),
+                index_name: "sqlite_autoindex_accounts_1".to_owned(),
+                is_unique: 1,
+                origin: "u".to_owned(),
+                partial: 0,
+                index_sql: None,
+            }];
+            let mut index_columns = BTreeMap::new();
+            index_columns.insert(
+                (
+                    "accounts".to_owned(),
+                    "sqlite_autoindex_accounts_1".to_owned(),
+                ),
+                vec![IndexColumnRow {
+                    table_name: "accounts".to_owned(),
+                    index_name: "sqlite_autoindex_accounts_1".to_owned(),
+                    seqno: 0,
+                    column_name: Some("email".to_owned()),
+                }],
+            );
+            let (indexes, unique_cols) = collapse_indexes("accounts", &rows, &index_columns);
+            assert_eq!(indexes.len(), 1);
+            assert!(unique_cols.contains("email"), "the column is marked unique");
+            let idx = &indexes[0];
+            assert!(idx.unique);
+            assert_eq!(
+                idx.key_columns,
+                vec!["email".to_owned()],
+                "key columns recorded"
+            );
+            let def = idx.definition.as_deref().expect(
+                "a constraint autoindex carries a synthesized definition (retained, not droppable)",
+            );
+            assert!(
+                def.contains("CREATE UNIQUE INDEX") && def.contains("email"),
+                "definition reconstructs the constraint index: {def}"
+            );
+        }
+
+        #[test]
+        fn create_virtual_table_and_fts5_shadow_detection() {
+            assert!(is_create_virtual_table(
+                "CREATE VIRTUAL TABLE \"posts__fts\" USING fts5(\"title\")"
+            ));
+            assert!(is_create_virtual_table(
+                "  create virtual table x using fts5(a)"
+            ));
+            assert!(!is_create_virtual_table(
+                "CREATE TABLE posts (id INTEGER PRIMARY KEY)"
+            ));
+
+            let vtabs = vec!["posts__fts".to_owned()];
+            // The vtab itself and each FTS5 shadow table are excluded.
+            for shadow in [
+                "posts__fts",
+                "posts__fts_data",
+                "posts__fts_idx",
+                "posts__fts_content",
+                "posts__fts_docsize",
+                "posts__fts_config",
+            ] {
+                assert!(
+                    is_virtual_or_fts5_shadow_table(shadow, &vtabs),
+                    "{shadow} must be excluded"
+                );
+            }
+            // A real application table (and a lookalike that is not a shadow) is kept.
+            assert!(!is_virtual_or_fts5_shadow_table("posts", &vtabs));
+            assert!(!is_virtual_or_fts5_shadow_table("posts__fts_other", &vtabs));
         }
     }
 }
@@ -2047,7 +2290,8 @@ mod tests {
                 &ColumnType::Int64,
                 true,
                 &pk,
-                true
+                true,
+                false
             ),
             Some(SerialKind::BigSerial)
         );
@@ -2058,27 +2302,31 @@ mod tests {
                 &ColumnType::Int32,
                 true,
                 &pk,
-                true
+                true,
+                false
             ),
             Some(SerialKind::Serial)
         );
-        // A plain BIGINT PRIMARY KEY (no default, no owned sequence) → None: this is
-        // the crux — it is NOT a BigSerial, and now the IR can tell them apart.
+        // A plain BIGINT PRIMARY KEY (no default, no owned sequence) → the EXPLICIT
+        // `Plain` marker (three-state): it is NOT a BigSerial, and the IR now tells
+        // them apart, while a legacy/unknown snapshot (marker absent) stays `None`.
         assert_eq!(
-            serial_kind_for(None, &ColumnType::Int64, true, &pk, false),
-            None
+            serial_kind_for(None, &ColumnType::Int64, true, &pk, false, false),
+            Some(SerialKind::Plain)
         );
-        // A shared/custom (non-owned) sequence default → None (not a conventional
-        // owned serial).
+        // A shared/custom (non-owned) sequence default is still a single-column
+        // integer PK with no OWNED sequence → the explicit `Plain` marker (it is not
+        // a conventional owned serial).
         assert_eq!(
             serial_kind_for(
                 Some("nextval('global_ids'::regclass)"),
                 &ColumnType::Int64,
                 true,
                 &pk,
+                false,
                 false
             ),
-            None
+            Some(SerialKind::Plain)
         );
         // A non-PK serial column → None (not an id).
         assert_eq!(
@@ -2087,8 +2335,20 @@ mod tests {
                 &ColumnType::Int64,
                 false,
                 &[],
-                true
+                true,
+                false
             ),
+            None
+        );
+        // A UUID PK → None (the serial-vs-plain distinction is integer-only).
+        assert_eq!(
+            serial_kind_for(None, &ColumnType::Uuid, true, &pk, false, false),
+            None
+        );
+        // A GENERATED … AS IDENTITY integer PK → None (its id-generation is carried
+        // by the separate `identity` marker, never the serial marker).
+        assert_eq!(
+            serial_kind_for(None, &ColumnType::Int64, true, &pk, false, true),
             None
         );
     }

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -389,9 +389,10 @@ fn run_snapshot(
 /// `--backend` override) — mirrors `schema migrate` / `schema doctor`, so the
 /// three commands can never derive the backend inconsistently for one profile.
 ///
-/// Postgres only in this slice: a resolved `SQLite` backend is refused loudly (no
-/// partial support, no partial write). Before writing, a **provider-lock** guard
-/// refuses to clobber an existing snapshot tagged for another backend.
+/// Both backends are supported: a resolved `SQLite` backend introspects via
+/// [`introspect::introspect_sqlite`] on the `sqlite` build (and is refused loudly on
+/// a default Postgres-only build). Before writing, a **provider-lock** guard refuses
+/// to clobber an existing snapshot tagged for another backend.
 fn run_pull(
     profile: Option<&str>,
     out: Option<&Path>,
@@ -430,16 +431,6 @@ fn pull_at(
         Backend::from,
     );
 
-    // SQLite introspection is a future slice of #1975 — fail loud, never partial.
-    if backend == Backend::Sqlite {
-        return Err(
-            "`autumn schema pull` currently supports Postgres only — SQLite database \
-             introspection is a future slice of the declarative-schema work (#1975). No \
-             snapshot was written."
-                .to_string(),
-        );
-    }
-
     let out_path = out.map_or_else(
         || project_root.join(SNAPSHOT_DEFAULT_PATH),
         Path::to_path_buf,
@@ -464,8 +455,26 @@ fn pull_at(
         ));
     }
 
-    // Introspect the live database into the IR.
-    let tables = introspect::introspect_postgres(&url).map_err(|e| e.to_string())?;
+    // Introspect the live database into the IR, dispatching on the resolved
+    // backend. Each arm references only its own connection type — the SQLite arm is
+    // compiled only under the `sqlite` backend-flip (see `introspect_sqlite`); a
+    // default (Postgres) build that somehow resolves a SQLite backend fails loudly
+    // rather than silently mis-introspecting.
+    let tables = match backend {
+        Backend::Postgres => introspect::introspect_postgres(&url).map_err(|e| e.to_string())?,
+        #[cfg(feature = "sqlite")]
+        Backend::Sqlite => introspect::introspect_sqlite(&url).map_err(|e| e.to_string())?,
+        #[cfg(not(feature = "sqlite"))]
+        Backend::Sqlite => {
+            return Err(
+                "`autumn schema pull` detected a SQLite backend, but this CLI build targets \
+                 Postgres only. Rebuild with `--features sqlite` to introspect a SQLite \
+                 database (the sqlite backend-flip must never be co-built with the default \
+                 Postgres backend). No snapshot was written."
+                    .to_string(),
+            );
+        }
+    };
     let snapshot = SchemaSnapshot::new(backend, tables);
 
     if dry_run {
@@ -1062,7 +1071,7 @@ mod tests {
     {{
       "name": "posts",
       "columns": [
-        {{ "name": "id", "ty": "Int64", "nullable": false, "primary_key": true, "unique": false, "default": null, "references": null }},
+        {{ "name": "id", "ty": "Int64", "nullable": false, "primary_key": true, "unique": false, "default": null, "references": null, "serial": "BigSerial" }},
         {{ "name": "title", "ty": "Text", "nullable": false, "primary_key": false, "unique": false, "default": null, "references": null }},
         {{ "name": "created_at", "ty": "Timestamp", "nullable": false, "primary_key": false, "unique": false, "default": "Now", "references": null }}
       ],

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -905,6 +905,7 @@ fn project_plan_target(baseline: &[Table], plan: &MigrationPlan) -> Vec<Table> {
             SchemaChange::PrimaryKeyChange { .. }
             | SchemaChange::ForeignKeyChange { .. }
             | SchemaChange::IdentityChange { .. }
+            | SchemaChange::UniqueChange { .. }
             | SchemaChange::DropTableBlockedByInboundFk { .. }
             | SchemaChange::AlterColumnTypeBlockedByFk { .. }
             | SchemaChange::AddForeignKeyToExistingColumn { .. }

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -905,7 +905,6 @@ fn project_plan_target(baseline: &[Table], plan: &MigrationPlan) -> Vec<Table> {
             SchemaChange::PrimaryKeyChange { .. }
             | SchemaChange::ForeignKeyChange { .. }
             | SchemaChange::IdentityChange { .. }
-            | SchemaChange::UniqueChange { .. }
             | SchemaChange::DropTableBlockedByInboundFk { .. }
             | SchemaChange::AlterColumnTypeBlockedByFk { .. }
             | SchemaChange::AddForeignKeyToExistingColumn { .. }

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -848,7 +848,7 @@ fn project_plan_target(baseline: &[Table], plan: &MigrationPlan) -> Vec<Table> {
                     // the same dependency test the down emitter uses to restore
                     // these indexes on rollback, so projection and rollback agree.
                     t.indexes
-                        .retain(|i| !diff::index_depends_on_column(i, &column.name));
+                        .retain(|i| !diff::index_depends_on_column(i, &column.name, plan.backend));
                 }
             }
             SchemaChange::AlterColumnType {

--- a/autumn-cli/src/schema/mod.rs
+++ b/autumn-cli/src/schema/mod.rs
@@ -904,6 +904,7 @@ fn project_plan_target(baseline: &[Table], plan: &MigrationPlan) -> Vec<Table> {
             // a no-op — never a panic.
             SchemaChange::PrimaryKeyChange { .. }
             | SchemaChange::ForeignKeyChange { .. }
+            | SchemaChange::IdentityChange { .. }
             | SchemaChange::DropTableBlockedByInboundFk { .. }
             | SchemaChange::AlterColumnTypeBlockedByFk { .. }
             | SchemaChange::AddForeignKeyToExistingColumn { .. }

--- a/autumn-cli/src/schema/parse.rs
+++ b/autumn-cli/src/schema/parse.rs
@@ -87,7 +87,9 @@
 
 use std::path::Path;
 
-use autumn_schema_core::{Backend, Column, ColumnDefault, ColumnType, ForeignKey, Index, Table};
+use autumn_schema_core::{
+    Backend, Column, ColumnDefault, ColumnType, ForeignKey, Index, SerialKind, Table,
+};
 
 use crate::generate::naming;
 
@@ -571,6 +573,23 @@ fn build_table(
         table.columns.push(created);
     }
 
+    // (3) Mark the single-column `BigSerial` convention id (an `Int64` PK with no
+    // explicit default — the synthesized `id` or an `#[id]` `i64` field) with the
+    // serial marker, SYMMETRICALLY with what database introspection records for a
+    // `BIGSERIAL` column. Without this the model side would carry `serial: None`
+    // while a pulled `BIGSERIAL` carries `Some(BigSerial)`, making an otherwise-clean
+    // model↔database round-trip diff spuriously report a primary-key change. A UUID
+    // PK (or a composite PK) is left `None`, matching introspection.
+    if let [pk_name] = table.primary_key.as_slice() {
+        let pk_name = pk_name.clone();
+        if let Some(pk) = table.columns.iter_mut().find(|c| c.name == pk_name)
+            && matches!(pk.ty, ColumnType::Int64)
+            && pk.default.is_none()
+        {
+            pk.serial = Some(SerialKind::BigSerial);
+        }
+    }
+
     // Index emission, mirroring `schema_edit::create_table_sql_*`:
     //  - every `references` column gets an auto-index (already folded into
     //    `plain_index_fields`);
@@ -764,6 +783,9 @@ mod tests {
         expected.managed = false;
         let mut id = Column::new("id", ColumnType::Int64);
         id.primary_key = true;
+        // The convention `BigSerial` id carries the serial marker (symmetric with
+        // what a pulled `BIGSERIAL` records), so a round-trip diff stays clean.
+        id.serial = Some(SerialKind::BigSerial);
         expected.columns.push(id);
         expected.columns.push(Column::new("name", ColumnType::Text));
         let mut created = Column::new("created_at", ColumnType::Timestamp);

--- a/autumn-cli/tests/integration/mod.rs
+++ b/autumn-cli/tests/integration/mod.rs
@@ -22,6 +22,8 @@ mod schema_migrate;
 #[cfg(feature = "sqlite")]
 mod schema_migrate_sqlite;
 mod schema_pull;
+#[cfg(feature = "sqlite")]
+mod schema_pull_sqlite;
 mod seed_model_linking;
 #[cfg(unix)]
 mod serve;

--- a/autumn-cli/tests/integration/schema_pull.rs
+++ b/autumn-cli/tests/integration/schema_pull.rs
@@ -1734,9 +1734,199 @@ async fn schema_pull_preserves_check_constraints() {
     assert_no_secret_leak(&doc_out, &doc_err);
 }
 
-/// `SQLite` introspection is a future slice: `schema pull` against a `SQLite` URL
-/// is refused loudly (no Docker needed — the refusal happens before any
-/// connection), names `SQLite`, and writes no snapshot.
+/// Parse a pulled snapshot's tables into `(table_name -> table JSON)` for precise
+/// per-column IR assertions.
+fn snapshot_columns(snap: &str) -> std::collections::BTreeMap<String, serde_json::Value> {
+    let doc: serde_json::Value = serde_json::from_str(snap).expect("snapshot is valid JSON");
+    let mut out = std::collections::BTreeMap::new();
+    for table in doc["tables"].as_array().expect("tables array") {
+        let name = table["name"].as_str().expect("table name").to_owned();
+        out.insert(name, table.clone());
+    }
+    out
+}
+
+/// Locate a column's JSON object within a pulled table's `columns` array.
+fn column_json<'a>(table: &'a serde_json::Value, column: &str) -> &'a serde_json::Value {
+    table["columns"]
+        .as_array()
+        .expect("columns array")
+        .iter()
+        .find(|c| c["name"].as_str() == Some(column))
+        .unwrap_or_else(|| panic!("column `{column}` not found in table"))
+}
+
+/// FIDELITY (#1975): the IR now distinguishes a plain, manually-assigned `BIGINT
+/// PRIMARY KEY` (no owned sequence) from an owned-sequence `BIGSERIAL` id — both of
+/// which previously collapsed to an indistinguishable `Int64` PK with no default. A
+/// pulled `BIGSERIAL` carries `serial: BigSerial`; a plain `BIGINT PK` carries no
+/// serial marker. Consequently a model (whose `#[id]` is always `BigSerial`)
+/// round-trips clean against the `BIGSERIAL` table but shows a refused primary-key
+/// change against the plain `BIGINT PK` table.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_pull_distinguishes_plain_bigint_pk_from_bigserial() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_serial_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_serial_shapes",
+        "CREATE TABLE serial_ids (id BIGSERIAL PRIMARY KEY, label TEXT NOT NULL, \
+         created_at TIMESTAMP NOT NULL DEFAULT now());\n\
+         CREATE TABLE plain_ids (id BIGINT PRIMARY KEY, label TEXT NOT NULL, \
+         created_at TIMESTAMP NOT NULL DEFAULT now());\n",
+        "DROP TABLE plain_ids;\nDROP TABLE serial_ids;\n",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    let (pull_out, pull_err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&pull_out, &pull_err);
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    let tables = snapshot_columns(&snap);
+
+    // THE CRUX: the pulled IR distinguishes the two id shapes.
+    let serial_id = column_json(&tables["serial_ids"], "id");
+    assert_eq!(
+        serial_id["serial"].as_str(),
+        Some("BigSerial"),
+        "a BIGSERIAL id must carry the serial marker: {serial_id}"
+    );
+    let plain_id = column_json(&tables["plain_ids"], "id");
+    assert!(
+        plain_id.get("serial").is_none(),
+        "a plain BIGINT PRIMARY KEY must carry NO serial marker: {plain_id}"
+    );
+
+    // A re-pull is byte-for-byte stable (the markers round-trip).
+    run_autumn_ok(&project, &["schema", "pull"], &envs);
+    let snap_after = std::fs::read_to_string(&snapshot_path).expect("second pull");
+    assert_eq!(snap, snap_after, "a re-pull must be byte-for-byte stable");
+
+    // A matching model for each table: SerialId round-trips CLEAN against the
+    // BIGSERIAL table, while PlainId (whose id is a convention BigSerial) shows a
+    // refused primary-key change against the plain BIGINT PK table.
+    write_models(
+        &project,
+        "#[autumn_web::model(managed)]\npub struct SerialId {\n    #[id]\n    pub id: i64,\n    \
+         pub label: String,\n    #[default]\n    pub created_at: chrono::NaiveDateTime,\n}\n\n\
+         #[autumn_web::model(managed)]\npub struct PlainId {\n    #[id]\n    pub id: i64,\n    \
+         pub label: String,\n    #[default]\n    pub created_at: chrono::NaiveDateTime,\n}\n",
+    );
+    let (diff_out, diff_err, code) = run_autumn(&project, &["schema", "diff"], &envs);
+    let combined = format!("{diff_out}{diff_err}");
+    assert_ne!(
+        code,
+        Some(0),
+        "a plain-BIGINT-PK vs BigSerial model must drift:\n{combined}"
+    );
+    assert!(
+        combined.contains("primary-key change") && combined.contains("plain_ids"),
+        "the drift is the plain_ids primary-key change (serial_ids matches):\n{combined}"
+    );
+    assert!(
+        !combined.contains("serial_ids"),
+        "the BIGSERIAL table round-trips clean — only plain_ids drifts:\n{combined}"
+    );
+    assert_no_secret_leak(&diff_out, &diff_err);
+}
+
+/// FIDELITY (#1975): a `GENERATED ALWAYS AS IDENTITY` column is preserved through a
+/// pull (its identity generation clause is recorded on the IR) instead of flattening
+/// to a plain integer column, so it round-trips byte-stably.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_pull_preserves_generated_as_identity() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_identity_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_identity",
+        "CREATE TABLE identity_rows (id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY, \
+         label TEXT NOT NULL);\n",
+        "DROP TABLE identity_rows;\n",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    let (pull_out, pull_err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&pull_out, &pull_err);
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    let tables = snapshot_columns(&snap);
+    let id = column_json(&tables["identity_rows"], "id");
+    assert_eq!(
+        id["identity"].as_str(),
+        Some("ALWAYS"),
+        "the identity generation clause is preserved verbatim: {id}"
+    );
+    // An identity column is not a serial (it has no owned nextval default).
+    assert!(
+        id.get("serial").is_none(),
+        "an identity column is not a serial: {id}"
+    );
+
+    // A re-pull is byte-for-byte stable (the identity marker round-trips).
+    run_autumn_ok(&project, &["schema", "pull"], &envs);
+    let snap_after = std::fs::read_to_string(&snapshot_path).expect("second pull");
+    assert_eq!(snap, snap_after, "a re-pull must be byte-for-byte stable");
+}
+
+/// FIDELITY (#1975): a PG15+ `NULLS NOT DISTINCT` unique index is retained verbatim
+/// via its `definition` (detected in the version-safe `pg_get_indexdef` text, never a
+/// PG15-only catalog column), so the clause round-trips instead of collapsing to an
+/// ordinary unique index. (Requires `PostgreSQL` ≥ 15; `start_postgres` pins
+/// `16-alpine`, so the clause is always available here.)
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_pull_retains_nulls_not_distinct_unique_index() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_nnd_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_nnd",
+        "CREATE TABLE nnd (id BIGSERIAL PRIMARY KEY, code TEXT);\n\
+         CREATE UNIQUE INDEX nnd_code_uniq ON nnd (code) NULLS NOT DISTINCT;\n",
+        "DROP TABLE nnd;\n",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    let (pull_out, pull_err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&pull_out, &pull_err);
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    assert!(
+        snap.contains("NULLS NOT DISTINCT"),
+        "the NULLS NOT DISTINCT clause is retained verbatim in the index definition: {snap}"
+    );
+
+    // A re-pull is byte-for-byte stable.
+    run_autumn_ok(&project, &["schema", "pull"], &envs);
+    let snap_after = std::fs::read_to_string(&snapshot_path).expect("second pull");
+    assert_eq!(snap, snap_after, "a re-pull must be byte-for-byte stable");
+}
+
+/// On a **default (Postgres-only) build**, `schema pull` against a `SQLite` URL is
+/// refused loudly (no Docker needed — the refusal happens before any connection),
+/// names `SQLite`, and writes no snapshot. On a `--features sqlite` build the pull
+/// instead introspects the `SQLite` database (covered by
+/// `schema_pull_sqlite::schema_pull_round_trips_models_through_a_sqlite_file`), so
+/// this refusal test is compiled only off the sqlite lane.
+#[cfg(not(feature = "sqlite"))]
 #[test]
 fn schema_pull_refuses_sqlite_backend() {
     let (_tmp, project) = fresh_project("pull_sqlite_refusal_app");

--- a/autumn-cli/tests/integration/schema_pull.rs
+++ b/autumn-cli/tests/integration/schema_pull.rs
@@ -1285,6 +1285,74 @@ async fn schema_pull_preserves_shared_sequence_int8_primary_key() {
     assert_no_secret_leak(&doc_out, &doc_err);
 }
 
+/// FIDELITY (brownfield repoint): a column that still OWNS an old sequence (its
+/// original `BIGSERIAL` `events_id_seq`) but whose default was REPOINTED to a
+/// DIFFERENT sequence (`ALTER COLUMN id SET DEFAULT nextval('global_ids')`) must have
+/// its `nextval('global_ids')` default PRESERVED — the `owns_sequence` probe ties
+/// ownership to the sequence the default actually allocates from, so it does NOT
+/// strip the default to a fresh owned `BIGSERIAL` (which would abandon `global_ids`
+/// and silently change ID allocation). The column classifies as a plain PK carrying a
+/// shared-sequence default (`serial` marker NOT `BigSerial`).
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers); run with -- --ignored"]
+async fn schema_pull_preserves_repointed_shared_sequence_default() {
+    let (_container, host, port) = start_postgres().await;
+    let url = format!("postgres://postgres:{SECRET_PW}@{host}:{port}/postgres");
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    let (_tmp, project) = fresh_project("pull_repointed_seq_app");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    // `events` starts as BIGSERIAL (owns `events_id_seq`), then its default is
+    // repointed to a standalone `global_ids` while `events_id_seq` stays owned.
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_repoint",
+        "CREATE TABLE events (id BIGSERIAL PRIMARY KEY, label TEXT NOT NULL);\n\
+         CREATE SEQUENCE global_ids;\n\
+         ALTER TABLE events ALTER COLUMN id SET DEFAULT nextval('global_ids');",
+        "DROP TABLE events;\nDROP SEQUENCE global_ids;",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    let (out, err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&out, &err);
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    let tables = snapshot_columns(&snap);
+    let id = column_json(&tables["events"], "id");
+
+    // The repointed default is PRESERVED verbatim (NOT stripped to None).
+    assert!(
+        snap.contains("global_ids"),
+        "the repointed nextval('global_ids') default is preserved (not stripped): {snap}"
+    );
+    let default_sql = id["default"]["Sql"].as_str().unwrap_or_default();
+    assert!(
+        default_sql.contains("global_ids"),
+        "the id column keeps its nextval('global_ids') default: {id}"
+    );
+    // The column is NOT a conventional owned BigSerial (its default no longer draws
+    // from the sequence it owns).
+    assert_ne!(
+        id["serial"].as_str(),
+        Some("BigSerial"),
+        "a repointed-default PK is NOT a BigSerial: {id}"
+    );
+
+    // Re-pull byte-stable + doctor clean.
+    let (pull2_out, pull2_err) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert_no_secret_leak(&pull2_out, &pull2_err);
+    let snap_after = std::fs::read_to_string(&snapshot_path).expect("second pull");
+    assert_eq!(snap, snap_after, "a re-pull must be byte-for-byte stable");
+    let (doc_out, doc_err) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor is clean with the preserved repointed-sequence default:\n{doc_out}"
+    );
+    assert_no_secret_leak(&doc_out, &doc_err);
+}
+
 /// A brownfield single-column **UUID** primary key whose default is NOT the Autumn
 /// convention `gen_random_uuid()` — here a UUID PK with **no** default at all — must
 /// pull back preserving "no default", NOT the convention `gen_random_uuid()`. The

--- a/autumn-cli/tests/integration/schema_pull.rs
+++ b/autumn-cli/tests/integration/schema_pull.rs
@@ -1759,8 +1759,8 @@ fn column_json<'a>(table: &'a serde_json::Value, column: &str) -> &'a serde_json
 /// FIDELITY (#1975): the IR now distinguishes a plain, manually-assigned `BIGINT
 /// PRIMARY KEY` (no owned sequence) from an owned-sequence `BIGSERIAL` id — both of
 /// which previously collapsed to an indistinguishable `Int64` PK with no default. A
-/// pulled `BIGSERIAL` carries `serial: BigSerial`; a plain `BIGINT PK` carries no
-/// serial marker. Consequently a model (whose `#[id]` is always `BigSerial`)
+/// pulled `BIGSERIAL` carries `serial: BigSerial`; a plain `BIGINT PK` carries the
+/// explicit `serial: Plain` marker. Consequently a model (whose `#[id]` is always `BigSerial`)
 /// round-trips clean against the `BIGSERIAL` table but shows a refused primary-key
 /// change against the plain `BIGINT PK` table.
 #[tokio::test]
@@ -1798,9 +1798,11 @@ async fn schema_pull_distinguishes_plain_bigint_pk_from_bigserial() {
         "a BIGSERIAL id must carry the serial marker: {serial_id}"
     );
     let plain_id = column_json(&tables["plain_ids"], "id");
-    assert!(
-        plain_id.get("serial").is_none(),
-        "a plain BIGINT PRIMARY KEY must carry NO serial marker: {plain_id}"
+    assert_eq!(
+        plain_id["serial"].as_str(),
+        Some("Plain"),
+        "a plain BIGINT PRIMARY KEY must carry the EXPLICIT Plain marker (three-state: \
+         never absent, which is reserved for legacy/unknown snapshots): {plain_id}"
     );
 
     // A re-pull is byte-for-byte stable (the markers round-trip).

--- a/autumn-cli/tests/integration/schema_pull_sqlite.rs
+++ b/autumn-cli/tests/integration/schema_pull_sqlite.rs
@@ -1,0 +1,188 @@
+//! `SQLite` integration test for `autumn schema pull` (issue #1975).
+//!
+//! Compiles and runs **only** under the non-default `sqlite` cargo feature (the
+//! backend-flip). A default `cargo test -p autumn-cli` neither compiles nor requires
+//! this file — it is `#[cfg(feature = "sqlite")]`-gated in `tests/integration/mod.rs`
+//! and additionally guarded here.
+//!
+//! Unlike the Postgres pull suite this needs **no Docker**: it drives the real
+//! binary end-to-end against a temp-FILE `SQLite` database (not `:memory:`, which the
+//! runtime rejects for registered migrations):
+//!
+//!   `cargo test -p autumn-cli --no-default-features --features sqlite --test cli_tests schema_pull_sqlite`
+#![cfg(feature = "sqlite")]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const fn autumn_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_autumn")
+}
+
+fn run_autumn(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String, Option<i32>) {
+    let output = Command::new(autumn_bin())
+        .args(args)
+        .current_dir(dir)
+        .envs(envs.iter().copied())
+        .output()
+        .expect("failed to run autumn");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code(),
+    )
+}
+
+fn run_autumn_ok(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> (String, String) {
+    let (stdout, stderr, code) = run_autumn(dir, args, envs);
+    assert_eq!(
+        code,
+        Some(0),
+        "autumn {args:?} failed (exit={code:?})\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    (stdout, stderr)
+}
+
+fn fresh_project(name: &str) -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run_autumn_ok(tmp.path(), &["new", name], &[]);
+    let project = tmp.path().join(name);
+    (tmp, project)
+}
+
+/// Overwrite the project's single-file models, dropping any scaffolded
+/// `src/models/` directory so the single-file layout resolves.
+fn write_models(project: &Path, content: &str) {
+    let src = project.join("src");
+    let _ = std::fs::remove_dir_all(src.join("models"));
+    std::fs::write(src.join("models.rs"), content).expect("write models.rs");
+}
+
+/// Two well-behaved models exercising the full clean-round-trip `SQLite` type surface:
+/// a `BigSerial` id (→ `INTEGER PRIMARY KEY AUTOINCREMENT`), a unique column (→ a
+/// standalone `CREATE UNIQUE INDEX`), a foreign key (`Post.author_id → authors`, →
+/// an auto-index + `REFERENCES`), a nullable column, a `f64` (→ `REAL`), plain text
+/// columns, and the synthesized `created_at` (→ `TEXT DEFAULT CURRENT_TIMESTAMP`,
+/// recovered as a `Timestamp` with a `Now` default).
+const MODELS: &str = r"
+#[autumn_web::model(managed)]
+pub struct Author {
+    #[id]
+    pub id: i64,
+    #[unique]
+    pub email: String,
+    pub name: String,
+}
+
+#[autumn_web::model(managed)]
+pub struct Post {
+    #[id]
+    pub id: i64,
+    pub title: String,
+    pub body: Option<String>,
+    pub rating: f64,
+    #[references(authors)]
+    pub author_id: i64,
+}
+";
+
+/// THE ACCEPTANCE: a schema built from `#[model]` structs, migrated into a live
+/// `SQLite` file, then `schema pull`ed back, produces a snapshot a subsequent
+/// `schema diff` reports as EMPTY — the `SQLite`-introspected snapshot is byte-faithful
+/// to what the models produce, so the round-trip is clean. Also asserts `doctor`
+/// agrees the database matches the pulled snapshot.
+#[test]
+fn schema_pull_round_trips_models_through_a_sqlite_file() {
+    let (_tmp, project) = fresh_project("pull_sqlite_roundtrip");
+    let db_path = project.join("app.db");
+    let url = format!("sqlite://{}", db_path.display());
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    // 1. Declare the models + an empty baseline snapshot (Sqlite-tagged), generate
+    //    the CREATE-TABLE migration, and apply it into the SQLite file.
+    write_models(&project, MODELS);
+    std::fs::write(project.join("empty_models.rs"), "").expect("empty models");
+    run_autumn_ok(
+        &project,
+        &[
+            "schema",
+            "snapshot",
+            "--from",
+            "empty_models.rs",
+            "--backend",
+            "sqlite",
+        ],
+        &envs,
+    );
+    run_autumn_ok(
+        &project,
+        &["schema", "diff", "--write-migration", "--name", "init"],
+        &envs,
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+    assert!(db_path.is_file(), "sqlite db file created");
+
+    // 2. Pull the live SQLite database back into the snapshot, OVERWRITING the
+    //    model-derived baseline with the DB-introspected one.
+    let (pull_out, _) = run_autumn_ok(&project, &["schema", "pull"], &envs);
+    assert!(
+        pull_out.contains("pulled schema snapshot") && pull_out.contains("2 table(s)"),
+        "pull reports the table count: {pull_out}"
+    );
+
+    // 3. The pulled snapshot faithfully carries the SQLite shapes.
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    assert!(
+        snap.contains("\"backend\": \"Sqlite\""),
+        "sqlite-tagged: {snap}"
+    );
+    assert!(
+        snap.contains("\"name\": \"authors\""),
+        "authors table: {snap}"
+    );
+    assert!(snap.contains("\"name\": \"posts\""), "posts table: {snap}");
+    // The AUTOINCREMENT id is recovered as a BigSerial serial marker.
+    assert!(
+        snap.contains("\"serial\": \"BigSerial\""),
+        "the INTEGER PRIMARY KEY AUTOINCREMENT id carries the serial marker: {snap}"
+    );
+    // The FK, the unique index, and the created_at Timestamp recovery all survive.
+    assert!(
+        snap.contains("\"table\": \"authors\""),
+        "the FK references authors: {snap}"
+    );
+    assert!(
+        snap.contains("idx_authors_email_unique"),
+        "unique index preserved: {snap}"
+    );
+    assert!(
+        snap.contains("\"Timestamp\"") && snap.contains("\"Now\""),
+        "created_at recovered as a Timestamp with a Now default: {snap}"
+    );
+    // No framework/bookkeeping tables leaked.
+    assert!(
+        !snap.contains("__diesel_schema_migrations") && !snap.contains("sqlite_sequence"),
+        "no framework/internal tables: {snap}"
+    );
+
+    // 4. THE ACCEPTANCE: `schema diff` (models vs the pulled snapshot) reports no
+    //    changes — the SQLite round-trip is clean.
+    let (diff_out, _) = run_autumn_ok(&project, &["schema", "diff"], &envs);
+    assert!(
+        diff_out.contains("No schema changes"),
+        "the SQLite round-trip must yield an empty diff:\n{diff_out}"
+    );
+
+    // 5. A re-pull is byte-for-byte stable.
+    run_autumn_ok(&project, &["schema", "pull"], &envs);
+    let snap_after = std::fs::read_to_string(&snapshot_path).expect("second pull");
+    assert_eq!(snap, snap_after, "a re-pull must be byte-for-byte stable");
+
+    // 6. doctor agrees the database matches the pulled snapshot baseline.
+    let (doc_out, _) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor reports the SQLite DB matches the snapshot:\n{doc_out}"
+    );
+}

--- a/autumn-cli/tests/integration/schema_pull_sqlite.rs
+++ b/autumn-cli/tests/integration/schema_pull_sqlite.rs
@@ -497,6 +497,92 @@ fn schema_pull_excludes_fts5_search_tables() {
     );
 }
 
+/// CONTRACT (Codex review): `AUTOINCREMENT` is matched as a KEYWORD, not a substring
+/// — a table whose NAME contains the `autoincrement` substring but whose PK is a plain
+/// `INTEGER PRIMARY KEY` pulls as `Some(Plain)` (never `BigSerial`), round-trips clean
+/// (doctor), and its rebuild/rollback DDL never fabricates an `AUTOINCREMENT`.
+#[test]
+fn schema_pull_autoincrement_substring_name_is_not_serial() {
+    let (_tmp, project) = fresh_project("pull_sqlite_ai_name");
+    let db_path = project.join("app.db");
+    let url = format!("sqlite://{}", db_path.display());
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_ai_name",
+        "CREATE TABLE autoincrement_events (\
+           id INTEGER PRIMARY KEY, \
+           name TEXT NOT NULL, \
+           created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP);\n",
+        "DROP TABLE autoincrement_events;\n",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+    run_autumn_ok(&project, &["schema", "pull"], &envs);
+
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    let events = table_json(&snap, "autoincrement_events");
+    let id = column_json(&events, "id");
+    assert_eq!(
+        id["serial"].as_str(),
+        Some("Plain"),
+        "a plain INTEGER PK in an `autoincrement`-named table is Plain, not BigSerial: {id}"
+    );
+
+    // Re-pull byte-stable + doctor clean.
+    run_autumn_ok(&project, &["schema", "pull"], &envs);
+    let snap_after = std::fs::read_to_string(&snapshot_path).expect("second pull");
+    assert_eq!(snap, snap_after, "a re-pull is byte-stable");
+    let (doc_out, _) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor is clean:\n{doc_out}"
+    );
+
+    // Dropping the table: the down leg recreates it WITHOUT a fabricated AUTOINCREMENT.
+    write_models(&project, "");
+    run_autumn_ok(
+        &project,
+        &[
+            "schema",
+            "diff",
+            "--write-migration",
+            "--name",
+            "drop_ai",
+            "--allow-destructive",
+        ],
+        &envs,
+    );
+    let mig_dir = std::fs::read_dir(project.join("migrations"))
+        .expect("migrations dir")
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .find(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with("_drop_ai"))
+        })
+        .expect("drop_ai migration written");
+    let down = std::fs::read_to_string(mig_dir.join("down.sql")).expect("down.sql");
+    // NOTE: the table NAME contains the `autoincrement` substring, so assert on the
+    // KEYWORD form (`… KEY AUTOINCREMENT`), not the bare substring. A plain PK renders
+    // a table-level `PRIMARY KEY (id)`, never a column-level `AUTOINCREMENT`.
+    assert!(
+        down.contains("CREATE TABLE autoincrement_events"),
+        "the rollback recreates the table: {down}"
+    );
+    assert!(
+        !down.to_uppercase().contains("KEY AUTOINCREMENT"),
+        "the rollback must NOT fabricate a column-level AUTOINCREMENT:\n{down}"
+    );
+    assert!(
+        down.contains("PRIMARY KEY (id)"),
+        "the plain PK is recreated as a table-level PRIMARY KEY (id):\n{down}"
+    );
+}
+
 /// CONTRACT (Codex review): a generated column (`GENERATED ALWAYS AS (...)
 /// STORED`/`VIRTUAL`) must NOT be silently dropped by the pull — `pragma_table_info`
 /// omits generated columns (a fail-closed violation), so the pull reads

--- a/autumn-cli/tests/integration/schema_pull_sqlite.rs
+++ b/autumn-cli/tests/integration/schema_pull_sqlite.rs
@@ -361,16 +361,19 @@ fn schema_pull_omits_composite_fk_and_ignores_default_null() {
     );
 }
 
-/// CONTRACT (Codex review): a brownfield inline `col TEXT UNIQUE` constraint pulls
-/// as a retained (non-droppable) `sqlite_autoindex_*` unique index, so a matching
-/// `#[unique]` model round-trips to an EMPTY diff — the undroppable auto-index is
-/// never `DROP INDEX`ed (which `SQLite` rejects).
+/// CONTRACT (Codex review, #1975 option A): a brownfield single-column inline
+/// `col TEXT UNIQUE` folds into `Column.unique` (its un-creatable/un-droppable
+/// `sqlite_autoindex_*` is never an Index). A matching `#[unique]` model round-trips
+/// to an EMPTY diff (coverage-suppressed — no `AddIndex`, no `guard_plan` refusal, no
+/// `sqlite_`-named / `DROP INDEX`), AND a rebuild / `DropTable` rollback RE-EMITS
+/// inline `UNIQUE` so uniqueness is never silently dropped.
 #[test]
-fn schema_pull_brownfield_inline_unique_round_trips_clean() {
+fn schema_pull_brownfield_inline_unique_round_trips_and_preserves_uniqueness() {
     let (_tmp, project) = fresh_project("pull_sqlite_inline_unique");
     let db_path = project.join("app.db");
     let url = format!("sqlite://{}", db_path.display());
     let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
 
     write_models(&project, "");
     write_raw_migration(
@@ -385,8 +388,14 @@ fn schema_pull_brownfield_inline_unique_round_trips_clean() {
     run_autumn_ok(&project, &["schema", "migrate"], &envs);
     run_autumn_ok(&project, &["schema", "pull"], &envs);
 
-    // A natural model matching the brownfield table (the inline UNIQUE becomes
-    // `#[unique]`, which the parser emits as `idx_accounts_email_unique`).
+    // The inline UNIQUE is folded to Column.unique — never a sqlite_autoindex Index.
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    assert!(
+        !snap.to_lowercase().contains("sqlite_autoindex"),
+        "the un-creatable constraint auto-index is never an Index: {snap}"
+    );
+
+    // A `#[unique] email` model round-trips CLEAN (coverage-suppressed).
     write_models(
         &project,
         "#[autumn_web::model(managed)]\npub struct Account {\n    #[id]\n    pub id: i64,\n    \
@@ -397,18 +406,15 @@ fn schema_pull_brownfield_inline_unique_round_trips_clean() {
     assert_eq!(code, Some(0), "the diff must succeed:\n{combined}");
     assert!(
         combined.contains("No schema changes"),
-        "a brownfield inline-UNIQUE table round-trips clean against the matching model:\n{combined}"
+        "the model #[unique] is already satisfied (clean diff, no AddIndex):\n{combined}"
     );
     assert!(
         !combined.contains("DROP INDEX") && !combined.to_uppercase().contains("SQLITE_AUTOINDEX"),
-        "the undroppable UNIQUE-constraint auto-index is never dropped:\n{combined}"
+        "no undroppable auto-index is dropped:\n{combined}"
     );
 
-    // The rebuild / DropTable-rollback path must NEVER emit a `CREATE … "sqlite_…"`
-    // (SQLite refuses to create `sqlite_`-prefixed objects). Drop the model entirely
-    // so the migration's up = DROP TABLE and down = CREATE TABLE accounts (restored
-    // from the pulled baseline) — then assert neither leg emits any `sqlite_`-named
-    // statement.
+    // The DropTable rollback re-emits the table WITH inline UNIQUE (uniqueness
+    // preserved) and never names a `sqlite_`-prefixed object.
     write_models(&project, "");
     run_autumn_ok(
         &project,
@@ -437,12 +443,14 @@ fn schema_pull_brownfield_inline_unique_round_trips_clean() {
     for (leg, sql) in [("up", &up), ("down", &down)] {
         assert!(
             !sql.to_lowercase().contains("sqlite_"),
-            "the {leg} leg must emit no `sqlite_`-named statement (un-creatable):\n{sql}"
+            "the {leg} leg must emit no `sqlite_`-named statement:\n{sql}"
         );
     }
     assert!(
-        down.contains("CREATE TABLE accounts"),
-        "the down leg restores the accounts table: {down}"
+        down.contains("CREATE TABLE accounts")
+            && down.to_uppercase().contains("EMAIL TEXT")
+            && down.to_uppercase().contains("UNIQUE"),
+        "the down leg restores accounts WITH the inline UNIQUE (uniqueness preserved):\n{down}"
     );
 }
 

--- a/autumn-cli/tests/integration/schema_pull_sqlite.rs
+++ b/autumn-cli/tests/integration/schema_pull_sqlite.rs
@@ -86,6 +86,26 @@ pub struct Post {
 }
 ";
 
+/// A model exercising the AFFINITY-collapsing `SQLite` type surface (issue #1975): a
+/// `bool`, `i32`, `i64`, `f32`, `f64`, and a plain (non-`CURRENT_TIMESTAMP`)
+/// `Timestamp` field. The emitter renders `bool`/`i32`/`i64` → `INTEGER`,
+/// `f32`/`f64` → `REAL`, and the plain `Timestamp` → `TEXT`, so a pull cannot
+/// recover the original variant — WITHOUT affinity-aware diffing every one of these
+/// would drift on every pull. The `schema diff` must be EMPTY.
+const AFFINITY_MODEL: &str = r"
+#[autumn_web::model(managed)]
+pub struct Metric {
+    #[id]
+    pub id: i64,
+    pub enabled: bool,
+    pub small: i32,
+    pub big: i64,
+    pub ratio32: f32,
+    pub ratio64: f64,
+    pub scheduled_at: chrono::NaiveDateTime,
+}
+";
+
 /// THE ACCEPTANCE: a schema built from `#[model]` structs, migrated into a live
 /// `SQLite` file, then `schema pull`ed back, produces a snapshot a subsequent
 /// `schema diff` reports as EMPTY — the `SQLite`-introspected snapshot is byte-faithful
@@ -184,6 +204,56 @@ fn schema_pull_round_trips_models_through_a_sqlite_file() {
     assert!(
         doc_out.contains("database schema matches the snapshot baseline"),
         "doctor reports the SQLite DB matches the snapshot:\n{doc_out}"
+    );
+}
+
+/// THE AFFINITY ACCEPTANCE (issue #1975): a model whose `bool`/`i32`/`i64`/`f32`/
+/// `f64`/plain-`Timestamp` fields the `SQLite` emitter COLLAPSES onto shared declared
+/// types (`INTEGER`/`REAL`/`TEXT`) migrates into a temp-file `SQLite` DB, is
+/// `schema pull`ed back, and `schema diff` reports NO changes — the affinity-aware
+/// type comparison treats the pulled `Int64`/`Float64`/`Text` as equivalent to the
+/// model's `Bool`/`Int32`/`Float32`/`Timestamp`. Before the fix this drifted on
+/// every pull.
+#[test]
+fn schema_pull_affinity_collapsed_types_round_trip_clean() {
+    let (_tmp, project) = fresh_project("pull_sqlite_affinity");
+    let db_path = project.join("app.db");
+    let url = format!("sqlite://{}", db_path.display());
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    write_models(&project, AFFINITY_MODEL);
+    std::fs::write(project.join("empty_models.rs"), "").expect("empty models");
+    run_autumn_ok(
+        &project,
+        &[
+            "schema",
+            "snapshot",
+            "--from",
+            "empty_models.rs",
+            "--backend",
+            "sqlite",
+        ],
+        &envs,
+    );
+    run_autumn_ok(
+        &project,
+        &["schema", "diff", "--write-migration", "--name", "init"],
+        &envs,
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+    run_autumn_ok(&project, &["schema", "pull"], &envs);
+
+    // THE ACCEPTANCE: the affinity-collapsed types round-trip to an EMPTY diff.
+    let (diff_out, _) = run_autumn_ok(&project, &["schema", "diff"], &envs);
+    assert!(
+        diff_out.contains("No schema changes"),
+        "affinity-collapsed SQLite types must round-trip clean:\n{diff_out}"
+    );
+    // doctor agrees (bidirectional drift check) — no spurious type-change drift.
+    let (doc_out, _) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor sees no drift for the affinity-collapsed types:\n{doc_out}"
     );
 }
 
@@ -333,6 +403,47 @@ fn schema_pull_brownfield_inline_unique_round_trips_clean() {
         !combined.contains("DROP INDEX") && !combined.to_uppercase().contains("SQLITE_AUTOINDEX"),
         "the undroppable UNIQUE-constraint auto-index is never dropped:\n{combined}"
     );
+
+    // The rebuild / DropTable-rollback path must NEVER emit a `CREATE … "sqlite_…"`
+    // (SQLite refuses to create `sqlite_`-prefixed objects). Drop the model entirely
+    // so the migration's up = DROP TABLE and down = CREATE TABLE accounts (restored
+    // from the pulled baseline) — then assert neither leg emits any `sqlite_`-named
+    // statement.
+    write_models(&project, "");
+    run_autumn_ok(
+        &project,
+        &[
+            "schema",
+            "diff",
+            "--write-migration",
+            "--name",
+            "drop_accounts",
+            "--allow-destructive",
+        ],
+        &envs,
+    );
+    let mig_dir = std::fs::read_dir(project.join("migrations"))
+        .expect("migrations dir")
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .find(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with("_drop_accounts"))
+        })
+        .expect("drop_accounts migration written");
+    let up = std::fs::read_to_string(mig_dir.join("up.sql")).expect("up.sql");
+    let down = std::fs::read_to_string(mig_dir.join("down.sql")).expect("down.sql");
+    for (leg, sql) in [("up", &up), ("down", &down)] {
+        assert!(
+            !sql.to_lowercase().contains("sqlite_"),
+            "the {leg} leg must emit no `sqlite_`-named statement (un-creatable):\n{sql}"
+        );
+    }
+    assert!(
+        down.contains("CREATE TABLE accounts"),
+        "the down leg restores the accounts table: {down}"
+    );
 }
 
 /// CONTRACT (Codex review): FTS5 search-index tables — the `CREATE VIRTUAL TABLE
@@ -383,6 +494,51 @@ fn schema_pull_excludes_fts5_search_tables() {
     assert!(
         combined.contains("No schema changes"),
         "a searchable app pulls clean (FTS tables excluded):\n{combined}"
+    );
+}
+
+/// CONTRACT (Codex review): a generated column (`GENERATED ALWAYS AS (...)
+/// STORED`/`VIRTUAL`) must NOT be silently dropped by the pull — `pragma_table_info`
+/// omits generated columns (a fail-closed violation), so the pull reads
+/// `pragma_table_xinfo` and preserves them.
+#[test]
+fn schema_pull_preserves_generated_columns() {
+    let (_tmp, project) = fresh_project("pull_sqlite_generated");
+    let db_path = project.join("app.db");
+    let url = format!("sqlite://{}", db_path.display());
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_generated",
+        "CREATE TABLE people (\
+           id INTEGER PRIMARY KEY AUTOINCREMENT, \
+           first TEXT NOT NULL, \
+           last TEXT NOT NULL, \
+           full_stored TEXT GENERATED ALWAYS AS (first || ' ' || last) STORED, \
+           full_virtual TEXT GENERATED ALWAYS AS (first || ' ' || last) VIRTUAL);\n",
+        "DROP TABLE people;\n",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+    run_autumn_ok(&project, &["schema", "pull"], &envs);
+
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    let people = table_json(&snap, "people");
+    for gen_col in ["full_stored", "full_virtual"] {
+        // `column_json` panics if the column is absent — asserting it is preserved.
+        let _ = column_json(&people, gen_col);
+    }
+
+    // A re-pull is byte-for-byte stable, and doctor sees no drift.
+    run_autumn_ok(&project, &["schema", "pull"], &envs);
+    let snap_after = std::fs::read_to_string(&snapshot_path).expect("second pull");
+    assert_eq!(snap, snap_after, "a re-pull is byte-stable");
+    let (doc_out, _) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor is clean with generated columns preserved:\n{doc_out}"
     );
 }
 

--- a/autumn-cli/tests/integration/schema_pull_sqlite.rs
+++ b/autumn-cli/tests/integration/schema_pull_sqlite.rs
@@ -186,3 +186,239 @@ fn schema_pull_round_trips_models_through_a_sqlite_file() {
         "doctor reports the SQLite DB matches the snapshot:\n{doc_out}"
     );
 }
+
+/// Write a hand-authored raw-SQL migration under `migrations/<name>/{up,down}.sql`
+/// so a brownfield DB shape (composite FKs, `DEFAULT NULL`, inline `UNIQUE`, FTS5)
+/// the model DSL cannot generate can be applied via `schema migrate`.
+fn write_raw_migration(project: &Path, name: &str, up_sql: &str, down_sql: &str) {
+    let dir = project.join("migrations").join(name);
+    std::fs::create_dir_all(&dir).expect("mkdir migration");
+    std::fs::write(dir.join("up.sql"), up_sql).expect("up.sql");
+    std::fs::write(dir.join("down.sql"), down_sql).expect("down.sql");
+}
+
+/// Parse the pulled snapshot and return the named table's JSON object.
+fn table_json(snap: &str, table: &str) -> serde_json::Value {
+    let root: serde_json::Value = serde_json::from_str(snap).expect("snapshot JSON");
+    root["tables"]
+        .as_array()
+        .expect("tables array")
+        .iter()
+        .find(|t| t["name"] == table)
+        .unwrap_or_else(|| panic!("table {table} not in snapshot: {snap}"))
+        .clone()
+}
+
+/// The named column object within a table JSON value.
+fn column_json<'a>(table: &'a serde_json::Value, column: &str) -> &'a serde_json::Value {
+    table["columns"]
+        .as_array()
+        .expect("columns array")
+        .iter()
+        .find(|c| c["name"] == column)
+        .unwrap_or_else(|| panic!("column {column} not found: {table}"))
+}
+
+/// CONTRACT (Gemini review): a composite (multi-column) foreign key is OMITTED
+/// entirely from the pulled IR (the IR `ForeignKey` is single-column only, and the
+/// fail-closed posture skips what it cannot faithfully represent), a single-column
+/// FK is preserved, a `DEFAULT NULL` bareword maps to NO default, and a quoted
+/// `'NULL'` string default is preserved verbatim.
+#[test]
+fn schema_pull_omits_composite_fk_and_ignores_default_null() {
+    let (_tmp, project) = fresh_project("pull_sqlite_fk_defaults");
+    let db_path = project.join("app.db");
+    let url = format!("sqlite://{}", db_path.display());
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_brownfield_fks",
+        "CREATE TABLE orgs (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL);\n\
+         CREATE TABLE parents (org_id INTEGER NOT NULL, slug TEXT NOT NULL, \
+         PRIMARY KEY (org_id, slug));\n\
+         CREATE TABLE children (\
+           id INTEGER PRIMARY KEY AUTOINCREMENT, \
+           org_id INTEGER NOT NULL, \
+           parent_slug TEXT NOT NULL, \
+           owner_id INTEGER REFERENCES orgs(id), \
+           note TEXT DEFAULT NULL, \
+           label TEXT DEFAULT 'NULL', \
+           FOREIGN KEY (org_id, parent_slug) REFERENCES parents(org_id, slug));\n",
+        "DROP TABLE children;\nDROP TABLE parents;\nDROP TABLE orgs;\n",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+
+    run_autumn_ok(&project, &["schema", "pull"], &envs);
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    let children = table_json(&snap, "children");
+
+    // The single-column FK survives.
+    let owner = column_json(&children, "owner_id");
+    assert_eq!(
+        owner["references"]["table"].as_str(),
+        Some("orgs"),
+        "the single-column FK is preserved: {owner}"
+    );
+    // The composite FK is omitted — NEITHER of its columns carries a `references`.
+    for col in ["org_id", "parent_slug"] {
+        let c = column_json(&children, col);
+        assert!(
+            c.get("references").is_none() || c["references"].is_null(),
+            "the composite FK column {col} must carry no single-column FK: {c}"
+        );
+    }
+    // `DEFAULT NULL` bareword → no default; quoted `'NULL'` → preserved.
+    let note = column_json(&children, "note");
+    assert!(
+        note.get("default").is_none() || note["default"].is_null(),
+        "DEFAULT NULL maps to no default: {note}"
+    );
+    let label = column_json(&children, "label");
+    assert_eq!(
+        label["default"]["Sql"].as_str(),
+        Some("'NULL'"),
+        "a quoted 'NULL' string default is preserved: {label}"
+    );
+
+    // No spurious drift from the omitted composite FK / normalized defaults.
+    let (doc_out, _) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor is clean after the pull:\n{doc_out}"
+    );
+}
+
+/// CONTRACT (Codex review): a brownfield inline `col TEXT UNIQUE` constraint pulls
+/// as a retained (non-droppable) `sqlite_autoindex_*` unique index, so a matching
+/// `#[unique]` model round-trips to an EMPTY diff — the undroppable auto-index is
+/// never `DROP INDEX`ed (which `SQLite` rejects).
+#[test]
+fn schema_pull_brownfield_inline_unique_round_trips_clean() {
+    let (_tmp, project) = fresh_project("pull_sqlite_inline_unique");
+    let db_path = project.join("app.db");
+    let url = format!("sqlite://{}", db_path.display());
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_inline_unique",
+        "CREATE TABLE accounts (\
+           id INTEGER PRIMARY KEY AUTOINCREMENT, \
+           email TEXT NOT NULL UNIQUE, \
+           created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP);\n",
+        "DROP TABLE accounts;\n",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+    run_autumn_ok(&project, &["schema", "pull"], &envs);
+
+    // A natural model matching the brownfield table (the inline UNIQUE becomes
+    // `#[unique]`, which the parser emits as `idx_accounts_email_unique`).
+    write_models(
+        &project,
+        "#[autumn_web::model(managed)]\npub struct Account {\n    #[id]\n    pub id: i64,\n    \
+         #[unique]\n    pub email: String,\n}\n",
+    );
+    let (diff_out, diff_err, code) = run_autumn(&project, &["schema", "diff"], &envs);
+    let combined = format!("{diff_out}{diff_err}");
+    assert_eq!(code, Some(0), "the diff must succeed:\n{combined}");
+    assert!(
+        combined.contains("No schema changes"),
+        "a brownfield inline-UNIQUE table round-trips clean against the matching model:\n{combined}"
+    );
+    assert!(
+        !combined.contains("DROP INDEX") && !combined.to_uppercase().contains("SQLITE_AUTOINDEX"),
+        "the undroppable UNIQUE-constraint auto-index is never dropped:\n{combined}"
+    );
+}
+
+/// CONTRACT (Codex review): FTS5 search-index tables — the `CREATE VIRTUAL TABLE
+/// "<table>__fts"` a `--searchable` model generates plus its `_data`/`_idx`/
+/// `_docsize`/`_config` shadow tables — are excluded from the pull, so a searchable
+/// app pulls clean (no `__fts*` tables, no spurious drift).
+#[test]
+fn schema_pull_excludes_fts5_search_tables() {
+    let (_tmp, project) = fresh_project("pull_sqlite_fts5");
+    let db_path = project.join("app.db");
+    let url = format!("sqlite://{}", db_path.display());
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_fts5",
+        "CREATE TABLE posts (\
+           id INTEGER PRIMARY KEY AUTOINCREMENT, \
+           title TEXT NOT NULL, \
+           created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP);\n\
+         CREATE VIRTUAL TABLE \"posts__fts\" USING fts5(\"title\", content='posts', content_rowid='id');\n",
+        "DROP TABLE posts;\n",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+    run_autumn_ok(&project, &["schema", "pull"], &envs);
+
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    assert!(
+        snap.contains("\"name\": \"posts\""),
+        "the base table is pulled: {snap}"
+    );
+    assert!(
+        !snap.contains("__fts"),
+        "no FTS5 virtual/shadow tables leak into the snapshot: {snap}"
+    );
+
+    // A matching model round-trips clean — the search index never shows as drift.
+    write_models(
+        &project,
+        "#[autumn_web::model(managed)]\npub struct Post {\n    #[id]\n    pub id: i64,\n    \
+         pub title: String,\n}\n",
+    );
+    let (diff_out, diff_err, code) = run_autumn(&project, &["schema", "diff"], &envs);
+    let combined = format!("{diff_out}{diff_err}");
+    assert_eq!(code, Some(0), "the diff must succeed:\n{combined}");
+    assert!(
+        combined.contains("No schema changes"),
+        "a searchable app pulls clean (FTS tables excluded):\n{combined}"
+    );
+}
+
+/// CONTRACT (Codex review): a `schema pull` against a NONEXISTENT sqlite file must
+/// error clearly (`SQLite` would otherwise create-on-open an empty DB and a non-dry-run
+/// pull would overwrite the checked-in snapshot with zero tables). It must NOT create
+/// the file NOR overwrite an existing snapshot.
+#[test]
+fn schema_pull_errors_on_missing_sqlite_file() {
+    let (_tmp, project) = fresh_project("pull_sqlite_missing");
+    let missing = project.join("does-not-exist.db");
+    let url = format!("sqlite://{}", missing.display());
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    // Seed a non-empty, sqlite-tagged snapshot we can prove is not clobbered.
+    std::fs::create_dir_all(project.join(".autumn")).expect("mkdir .autumn");
+    let sentinel = "{\"backend\":\"Sqlite\",\"tables\":[{\"name\":\"sentinel\",\"managed\":true,\"columns\":[],\"indexes\":[],\"checks\":[],\"primary_key\":[]}]}";
+    std::fs::write(&snapshot_path, sentinel).expect("seed snapshot");
+
+    let (out, err, code) = run_autumn(&project, &["schema", "pull"], &envs);
+    let combined = format!("{out}{err}");
+    assert_ne!(
+        code,
+        Some(0),
+        "pull against a missing file must fail:\n{combined}"
+    );
+    assert!(
+        combined.contains("could not open the SQLite database")
+            && combined.contains("does-not-exist.db"),
+        "the error names the missing file:\n{combined}"
+    );
+    assert!(!missing.exists(), "the missing DB file must NOT be created");
+    assert_eq!(
+        std::fs::read_to_string(&snapshot_path).expect("snapshot"),
+        sentinel,
+        "the existing snapshot must NOT be overwritten"
+    );
+}

--- a/autumn-cli/tests/integration/schema_pull_sqlite.rs
+++ b/autumn-cli/tests/integration/schema_pull_sqlite.rs
@@ -542,6 +542,94 @@ fn schema_pull_preserves_generated_columns() {
     );
 }
 
+/// CONTRACT (Codex review): a retained `SQLite` partial index references its
+/// WHERE-predicate column only in its verbatim `definition`. Dropping that column
+/// must PRUNE the index (not leave an orphan that references a missing column), so
+/// the generated table-rebuild migration APPLIES cleanly — `SQLite` would otherwise
+/// reject the rebuild that recreates `... WHERE deleted_at IS NULL` on a table with
+/// no `deleted_at`.
+#[test]
+fn schema_pull_dropping_partial_index_predicate_column_prunes_the_index() {
+    let (_tmp, project) = fresh_project("pull_sqlite_partial_idx");
+    let db_path = project.join("app.db");
+    let url = format!("sqlite://{}", db_path.display());
+    let envs = [("AUTUMN_DATABASE__URL", url.as_str())];
+
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_partial",
+        "CREATE TABLE notes (\
+           id INTEGER PRIMARY KEY AUTOINCREMENT, \
+           email TEXT NOT NULL, \
+           deleted_at TEXT, \
+           created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP);\n\
+         CREATE INDEX notes_email_active ON notes (email) WHERE deleted_at IS NULL;\n",
+        "DROP TABLE notes;\n",
+    );
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+    run_autumn_ok(&project, &["schema", "pull"], &envs);
+
+    // A model that DROPS `deleted_at` (the partial index's predicate column). The
+    // model cannot express the partial index, so it is retained — and the column drop
+    // must prune it during the rebuild.
+    write_models(
+        &project,
+        "#[autumn_web::model(managed)]\npub struct Note {\n    #[id]\n    pub id: i64,\n    \
+         pub email: String,\n}\n",
+    );
+    run_autumn_ok(
+        &project,
+        &[
+            "schema",
+            "diff",
+            "--write-migration",
+            "--name",
+            "drop_deleted_at",
+            "--allow-destructive",
+        ],
+        &envs,
+    );
+
+    // The generated up.sql must NOT recreate the orphaned partial index.
+    let mig_dir = std::fs::read_dir(project.join("migrations"))
+        .expect("migrations dir")
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .find(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with("_drop_deleted_at"))
+        })
+        .expect("drop migration written");
+    let up = std::fs::read_to_string(mig_dir.join("up.sql")).expect("up.sql");
+    // The orphaned partial index is DROPPED (before the column drop), never left
+    // referencing the missing column nor recreated with its `WHERE deleted_at` clause.
+    assert!(
+        up.contains("DROP INDEX") && up.contains("notes_email_active"),
+        "the partial index depending on the dropped column is dropped first:\n{up}"
+    );
+    assert!(
+        !up.contains("CREATE INDEX \"notes_email_active\"")
+            && !up.contains("CREATE INDEX notes_email_active"),
+        "the orphaned partial index is NOT recreated:\n{up}"
+    );
+    // `DROP INDEX` must precede the `DROP COLUMN` (SQLite rejects DROP COLUMN while a
+    // live index references the column).
+    if let (Some(di), Some(dc)) = (up.find("DROP INDEX"), up.find("DROP COLUMN")) {
+        assert!(di < dc, "DROP INDEX must come before DROP COLUMN:\n{up}");
+    }
+
+    // THE PROOF: the rebuild migration APPLIES cleanly (an orphaned partial index
+    // referencing the missing `deleted_at` would make SQLite reject the rebuild).
+    run_autumn_ok(&project, &["schema", "migrate"], &envs);
+    let (doc_out, _) = run_autumn_ok(&project, &["schema", "doctor"], &envs);
+    assert!(
+        doc_out.contains("database schema matches the snapshot baseline"),
+        "doctor is clean after the column drop + index prune:\n{doc_out}"
+    );
+}
+
 /// CONTRACT (Codex review): a `schema pull` against a NONEXISTENT sqlite file must
 /// error clearly (`SQLite` would otherwise create-on-open an empty DB and a non-dry-run
 /// pull would overwrite the checked-in snapshot with zero tables). It must NOT create
@@ -576,5 +664,79 @@ fn schema_pull_errors_on_missing_sqlite_file() {
         std::fs::read_to_string(&snapshot_path).expect("snapshot"),
         sentinel,
         "the existing snapshot must NOT be overwritten"
+    );
+}
+
+/// CONTRACT (Codex review): the create-on-open guard must also cover `file:` URIs —
+/// a `file:` URI with a MISSING path must error (not create-on-open + clobber the
+/// snapshot), while a `file:` URI pointing at a REAL DB pulls normally.
+#[test]
+fn schema_pull_file_uri_missing_path_errors_but_real_path_pulls() {
+    let (_tmp, project) = fresh_project("pull_sqlite_file_uri");
+    let db_path = project.join("app.db");
+    let snapshot_path = project.join(".autumn/schema-snapshot.json");
+
+    // First build a real DB via a bare-path migration.
+    let bare_url = format!("sqlite://{}", db_path.display());
+    write_models(&project, "");
+    write_raw_migration(
+        &project,
+        "20260101000000_one",
+        "CREATE TABLE widgets (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL);\n",
+        "DROP TABLE widgets;\n",
+    );
+    run_autumn_ok(
+        &project,
+        &["schema", "migrate"],
+        &[("AUTUMN_DATABASE__URL", &bare_url)],
+    );
+    assert!(db_path.is_file(), "real DB created");
+
+    // (a) A `file:` URI with a MISSING path must ERROR and not create the file.
+    let missing = project.join("nope.db");
+    let missing_uri = format!("file:{}", missing.display());
+    std::fs::create_dir_all(project.join(".autumn")).expect("mkdir .autumn");
+    let sentinel = "{\"backend\":\"Sqlite\",\"tables\":[{\"name\":\"sentinel\",\"managed\":true,\"columns\":[],\"indexes\":[],\"checks\":[],\"primary_key\":[]}]}";
+    std::fs::write(&snapshot_path, sentinel).expect("seed snapshot");
+    let (out, err, code) = run_autumn(
+        &project,
+        &["schema", "pull"],
+        &[("AUTUMN_DATABASE__URL", &missing_uri)],
+    );
+    let combined = format!("{out}{err}");
+    assert_ne!(
+        code,
+        Some(0),
+        "a file: URI with a missing path must fail:\n{combined}"
+    );
+    assert!(
+        combined.contains("could not open the SQLite database") && combined.contains("nope.db"),
+        "the error names the missing file: {combined}"
+    );
+    assert!(
+        !missing.exists(),
+        "the missing file: URI DB must NOT be created"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&snapshot_path).expect("snapshot"),
+        sentinel,
+        "the snapshot must NOT be overwritten by the failed file: pull"
+    );
+
+    // (b) A `file:` URI pointing at the REAL DB pulls normally.
+    let real_uri = format!("file:{}", db_path.display());
+    let (pull_out, _) = run_autumn_ok(
+        &project,
+        &["schema", "pull"],
+        &[("AUTUMN_DATABASE__URL", &real_uri)],
+    );
+    assert!(
+        pull_out.contains("pulled schema snapshot") && pull_out.contains("1 table(s)"),
+        "a file: URI at a real DB pulls: {pull_out}"
+    );
+    let snap = std::fs::read_to_string(&snapshot_path).expect("pulled snapshot");
+    assert!(
+        snap.contains("\"name\": \"widgets\""),
+        "widgets pulled: {snap}"
     );
 }

--- a/autumn-schema-core/src/lib.rs
+++ b/autumn-schema-core/src/lib.rs
@@ -514,6 +514,30 @@ impl IdKind {
     }
 }
 
+/// Distinguishes an owned-sequence auto-increment integer primary key from a
+/// plain, manually-assigned integer primary key of the same storage width.
+///
+/// Without this marker a `BIGINT PRIMARY KEY` (a plain, manually-assigned id) and
+/// a `BIGSERIAL` (an owned-sequence auto-increment id) both land in the IR as
+/// `Column { ty: Int64, primary_key: true, default: None }` — indistinguishable —
+/// so `schema pull` / `schema diff` could not tell a brownfield plain-int PK from
+/// a generated serial id. It is populated **symmetrically** by the model parser
+/// (for a convention `BigSerial` id) and by database introspection (only when the
+/// pulled column genuinely owns its sequence), so a model↔database diff of matching
+/// schemas stays empty while a genuine plain-`BIGINT PK` vs `BIGSERIAL` mismatch
+/// surfaces as drift. See [`Column::serial`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SerialKind {
+    /// `SERIAL` (int4) — an owned-sequence auto-increment 32-bit id. Only ever
+    /// produced by brownfield introspection (the model `#[id]` is always
+    /// `BigSerial` or `Uuid`).
+    Serial,
+    /// `BIGSERIAL` (int8) — an owned-sequence auto-increment 64-bit id, the Autumn
+    /// model `#[id]` convention. On `SQLite` this is an `INTEGER PRIMARY KEY
+    /// AUTOINCREMENT` column.
+    BigSerial,
+}
+
 /// A foreign-key relationship carried by a [`Column`] (see [`Column::references`]).
 ///
 /// A `references` column stores an [`Int64`](ColumnType::Int64); its FK-ness is
@@ -562,6 +586,24 @@ pub struct Column {
     pub default: Option<ColumnDefault>,
     /// The foreign-key relationship, if this column is a `references` column.
     pub references: Option<ForeignKey>,
+    /// The auto-increment id-generation strategy of an owned-sequence integer
+    /// primary key, distinguishing a generated `SERIAL`/`BIGSERIAL` id from a plain
+    /// manually-assigned `INTEGER`/`BIGINT` primary key of the same storage width
+    /// (see [`SerialKind`]). `None` for every non-serial column — including a
+    /// plain-int PK with no owned sequence. Populated symmetrically by the model
+    /// parser and by database introspection so a matching model↔database diff stays
+    /// empty. Defaults to `None` and is skipped when serializing, so snapshots
+    /// written before this field existed stay byte-identical.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub serial: Option<SerialKind>,
+    /// A preserved `GENERATED { ALWAYS | BY DEFAULT } AS IDENTITY` clause — the
+    /// verbatim `identity_generation` (`"ALWAYS"` / `"BY DEFAULT"`) of a Postgres
+    /// identity column — so an identity column round-trips through `schema pull`
+    /// instead of flattening to a plain integer column. `None` for every
+    /// non-identity column. Defaults to `None` and is skipped when serializing, so
+    /// pre-existing snapshots stay byte-identical.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity: Option<String>,
 }
 
 impl Column {
@@ -577,6 +619,8 @@ impl Column {
             unique: false,
             default: None,
             references: None,
+            serial: None,
+            identity: None,
         }
     }
 }
@@ -1259,6 +1303,8 @@ mod tests {
         let col = Column::new("name", ColumnType::Text);
         assert!(!col.nullable && !col.primary_key && !col.unique);
         assert!(col.default.is_none() && col.references.is_none());
+        // The serial / identity markers default to absent (a plain column).
+        assert!(col.serial.is_none() && col.identity.is_none());
 
         let table = Table::new("widgets", Backend::Sqlite);
         assert!(table.managed);
@@ -1267,5 +1313,39 @@ mod tests {
 
         let schema = Schema::new(Backend::Sqlite);
         assert!(schema.tables.is_empty());
+    }
+
+    #[test]
+    fn serial_and_identity_markers_are_serde_backward_compatible() {
+        // A plain column (both markers absent) serializes WITHOUT the new keys, so
+        // snapshots written before the fields existed stay byte-identical.
+        let plain = Column::new("id", ColumnType::Int64);
+        let json = serde_json::to_string(&plain).expect("serialize");
+        assert!(
+            !json.contains("serial") && !json.contains("identity"),
+            "absent markers must be omitted from the serialized form: {json}"
+        );
+
+        // A pre-existing snapshot JSON with neither key deserializes to `None`.
+        let legacy = r#"{"name":"id","ty":"Int64","nullable":false,"primary_key":true,"unique":false,"default":null,"references":null}"#;
+        let back: Column = serde_json::from_str(legacy).expect("deserialize legacy");
+        assert!(back.serial.is_none() && back.identity.is_none());
+
+        // A populated marker round-trips.
+        let mut serial_id = Column::new("id", ColumnType::Int64);
+        serial_id.primary_key = true;
+        serial_id.serial = Some(SerialKind::BigSerial);
+        let mut identity_col = Column::new("n", ColumnType::Int64);
+        identity_col.identity = Some("ALWAYS".to_owned());
+        for col in [&serial_id, &identity_col] {
+            let json = serde_json::to_string(col).expect("serialize");
+            let back: Column = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(*col, back);
+        }
+        assert!(
+            serde_json::to_string(&serial_id)
+                .unwrap()
+                .contains("BigSerial")
+        );
     }
 }

--- a/autumn-schema-core/src/lib.rs
+++ b/autumn-schema-core/src/lib.rs
@@ -536,6 +536,19 @@ pub enum SerialKind {
     /// model `#[id]` convention. On `SQLite` this is an `INTEGER PRIMARY KEY
     /// AUTOINCREMENT` column.
     BigSerial,
+    /// A **plain**, manually-assigned single-column integer primary key with **no**
+    /// owned sequence — a genuine `INTEGER`/`BIGINT PRIMARY KEY` (Postgres) or a
+    /// non-`AUTOINCREMENT` `INTEGER PRIMARY KEY` (`SQLite`). Emitted **only** by
+    /// database introspection.
+    ///
+    /// It is deliberately distinct from `None`: `None` means the marker is *unknown*
+    /// — a snapshot written before this field existed (serde default) — whereas
+    /// `Plain` is an **explicit** "introspected, and it genuinely owns no sequence"
+    /// signal. The diff treats `None` on either side as compatible (never drift), so
+    /// a legacy snapshot keeps round-tripping clean; a `Plain` vs `BigSerial`
+    /// mismatch (both explicit) still surfaces as real drift. The model parser never
+    /// emits `Plain` (its `#[id]` is always `BigSerial` or `Uuid`).
+    Plain,
 }
 
 /// A foreign-key relationship carried by a [`Column`] (see [`Column::references`]).

--- a/autumn-schema-core/src/lib.rs
+++ b/autumn-schema-core/src/lib.rs
@@ -44,6 +44,51 @@ pub enum Backend {
     Sqlite,
 }
 
+/// A `SQLite` **type-affinity class** — the five storage-affinity buckets `SQLite`
+/// assigns a column from its declared type (`SQLite` docs §3.1).
+///
+/// Because `SQLite` stores only the declared-type string, distinct IR
+/// [`ColumnType`]s that the emitter renders to the same declared type share an
+/// affinity class and are indistinguishable after a pull; the diff compares by this
+/// class on the `SQLite` backend (see [`ColumnType::sqlite_affinity`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SqliteAffinity {
+    /// Declared type contains `INT` (e.g. `INTEGER`, `BIGINT`).
+    Integer,
+    /// Declared type contains `CHAR`, `CLOB`, or `TEXT`.
+    Text,
+    /// Declared type contains `BLOB`, or is empty.
+    Blob,
+    /// Declared type contains `REAL`, `FLOA`, or `DOUB`.
+    Real,
+    /// Anything else (e.g. `NUMERIC`, `DECIMAL`) — the ambiguous catch-all.
+    Numeric,
+}
+
+/// Compute the `SQLite` type-affinity class of a declared-type string.
+///
+/// Follows `SQLite`'s canonical affinity-determination algorithm (docs §3.1),
+/// matched in order (case-insensitively): contains `INT` →
+/// [`Integer`](SqliteAffinity::Integer); contains `CHAR`/`CLOB`/`TEXT` →
+/// [`Text`](SqliteAffinity::Text); contains `BLOB` or empty →
+/// [`Blob`](SqliteAffinity::Blob); contains `REAL`/`FLOA`/`DOUB` →
+/// [`Real`](SqliteAffinity::Real); otherwise [`Numeric`](SqliteAffinity::Numeric).
+#[must_use]
+pub fn sqlite_affinity(declared_type: &str) -> SqliteAffinity {
+    let t = declared_type.to_ascii_uppercase();
+    if t.contains("INT") {
+        SqliteAffinity::Integer
+    } else if t.contains("CHAR") || t.contains("CLOB") || t.contains("TEXT") {
+        SqliteAffinity::Text
+    } else if t.is_empty() || t.contains("BLOB") {
+        SqliteAffinity::Blob
+    } else if t.contains("REAL") || t.contains("FLOA") || t.contains("DOUB") {
+        SqliteAffinity::Real
+    } else {
+        SqliteAffinity::Numeric
+    }
+}
+
 /// A logical, dialect-independent column type.
 ///
 /// This is the canonical vocabulary the IR speaks in; the concrete Rust type,
@@ -241,6 +286,25 @@ impl ColumnType {
                 Self::Opaque { pg_type } => pg_type.clone(),
             },
         }
+    }
+
+    /// The `SQLite` **type-affinity class** of this column type, derived from the
+    /// declared type the emitter renders on `SQLite` ([`sql_type`](Self::sql_type)
+    /// with [`Backend::Sqlite`]) via [`sqlite_affinity`].
+    ///
+    /// Because `SQLite` stores only the declared-type STRING (and applies affinity
+    /// rules), the emitter collapses several distinct IR types onto the same
+    /// declared type — `Int32`/`Int64`/`Bool` → `INTEGER`, `Float32`/`Float64` →
+    /// `REAL`, `Text`/`Uuid`/`Timestamp`/`TimestampTz`/`Decimal`/`Attachment`/`Enum`
+    /// → `TEXT`, `Bytes` → `BLOB` — so a pulled `SQLite` snapshot cannot recover the
+    /// original variant. The diff uses THIS class (not exact [`ColumnType`]
+    /// equality) on the `SQLite` backend so a matching model↔pull round-trips clean
+    /// while a genuine class change (e.g. `INTEGER`→`TEXT`) still drifts. Deriving it
+    /// from the rendered declared type keeps it automatically consistent with
+    /// whatever the emitter produces.
+    #[must_use]
+    pub fn sqlite_affinity(&self) -> SqliteAffinity {
+        sqlite_affinity(&self.sql_type(Backend::Sqlite))
     }
 
     /// Whether this type's rendered Rust model type has a working diesel
@@ -959,6 +1023,47 @@ mod tests {
                 expected,
                 "sqlite sql_type for {ct:?}"
             );
+        }
+    }
+
+    #[test]
+    fn sqlite_affinity_of_declared_type_follows_the_canonical_algorithm() {
+        for (decl, expected) in [
+            ("INTEGER", SqliteAffinity::Integer),
+            ("BIGINT", SqliteAffinity::Integer),
+            ("TINYINT", SqliteAffinity::Integer),
+            ("VARCHAR(255)", SqliteAffinity::Text),
+            ("CLOB", SqliteAffinity::Text),
+            ("TEXT", SqliteAffinity::Text),
+            ("", SqliteAffinity::Blob),
+            ("BLOB", SqliteAffinity::Blob),
+            ("REAL", SqliteAffinity::Real),
+            ("FLOAT", SqliteAffinity::Real),
+            ("DOUBLE PRECISION", SqliteAffinity::Real),
+            ("NUMERIC", SqliteAffinity::Numeric),
+            ("DECIMAL(10,2)", SqliteAffinity::Numeric),
+            ("BOOLEAN", SqliteAffinity::Numeric),
+        ] {
+            assert_eq!(sqlite_affinity(decl), expected, "affinity of {decl:?}");
+        }
+    }
+
+    #[test]
+    fn column_type_sqlite_affinity_class_collapses_the_emitter_groups() {
+        use SqliteAffinity::{Blob, Integer, Real, Text};
+        for (ct, expected) in [
+            (ColumnType::Int32, Integer),
+            (ColumnType::Int64, Integer),
+            (ColumnType::Bool, Integer),
+            (ColumnType::Float32, Real),
+            (ColumnType::Float64, Real),
+            (ColumnType::Text, Text),
+            (ColumnType::Uuid, Text),
+            (ColumnType::Timestamp, Text),
+            (ColumnType::TimestampTz, Text),
+            (ColumnType::Bytes, Blob),
+        ] {
+            assert_eq!(ct.sqlite_affinity(), expected, "affinity class of {ct:?}");
         }
     }
 


### PR DESCRIPTION
Part of #1975

## Before / After (plain language)

**`autumn schema pull` on SQLite.** Before, pulling against a `sqlite://` URL was refused ("Postgres only — a future slice"). After, a `--features sqlite` build introspects a live SQLite database into the same snapshot IR as Postgres does: a schema built from `#[model]` structs, migrated into a SQLite file, then pulled back, produces a snapshot a subsequent `schema diff` reports as **empty** — a clean round-trip. (A SQLite backend on a default Postgres-only build still refuses loudly, telling you to rebuild with `--features sqlite`.)

**`autumn schema doctor` on SQLite.** Before, the database-schema-drift check skipped any non-Postgres backend. After, on a `--features sqlite` build it introspects the live SQLite database and diffs it against the checked-in snapshot, exactly like the Postgres path — and stays offline-safe (an unreachable/absent database is a WARN, never a hard failure).

**What the IR now distinguishes.** Three brownfield shapes that previously round-tripped lossily:

- **Plain `BIGINT PRIMARY KEY` vs `BIGSERIAL`.** Both used to collapse to an indistinguishable `Int64` PK with no default. Now a pulled `BIGSERIAL` (owned-sequence auto-increment) carries a `serial: BigSerial` marker while a plain, manually-assigned `BIGINT PK` carries none — so a model (whose `#[id]` is always `BigSerial`) round-trips clean against the `BIGSERIAL` table but correctly shows drift against the plain `BIGINT PK` table. On SQLite the same marker recovers an `INTEGER PRIMARY KEY AUTOINCREMENT` id.
- **`GENERATED { ALWAYS | BY DEFAULT } AS IDENTITY`** columns are now preserved (their identity clause is recorded on the IR) instead of flattening to a plain integer column, so they round-trip byte-stably.
- **PG15+ `NULLS NOT DISTINCT`** unique indexes are retained verbatim via their index definition, so the clause round-trips.

## How

- **`autumn-schema-core`** — a `SerialKind` enum plus two serde-backward-compatible `Column` fields (`serial`, `identity`), both `#[serde(default, skip_serializing_if)]` so pre-existing snapshots stay byte-identical.
- **Symmetry (the load-bearing invariant)** — the model parser (`parse.rs`) marks a convention `BigSerial` id (single-column `Int64` PK, no default) with the same marker database introspection records for a `BIGSERIAL`, so a model↔database diff of matching schemas stays empty. `diff_table` treats a plain-int-PK ↔ serial-PK change as a refused `PrimaryKeyChange` (creating/dropping an owned sequence is out of scope for an auto-generated migration).
- **Postgres introspection (`introspect.rs`)** — the serial marker (from the existing `pg_depend` owned-sequence signal), the identity clause (`information_schema.columns.is_identity`/`identity_generation`), and `NULLS NOT DISTINCT` retention (detected in the version-safe `pg_get_indexdef` text, never a PG15-only catalog column).
- **SQLite introspection (`introspect.rs`, gated on the `sqlite` backend-flip)** — a batched `sqlite_master` + `pragma_*` introspection (one query per catalog), a conservative fail-closed affinity→`ColumnType` mapping (unmapped types preserved as `Opaque`), convention recovery for the AUTOINCREMENT `BigSerial` id and the `CURRENT_TIMESTAMP` `created_at` default, and single-column FK / unique / partial-index handling.
- **Dispatch** — `schema pull` (`mod.rs`) and `doctor`'s database-schema-drift check select the introspector by resolved backend, with `#[cfg]` arms so each lane references only its own connection type.

## Testing

- `cargo fmt --all -- --check`, and `clippy -D warnings` on **both** lanes (default pg + `--no-default-features --features sqlite`), run with stable **1.97.0** (so the 1.97-only `doc_markdown` / `needless_pass_by_value` lints are caught) — all clean.
- `cargo test -p autumn-schema-core`, `-p autumn-cli --test cli_tests` (pg lane), and the SQLite lane cli_tests — all green.
- New **Docker-free** SQLite round-trip integration test (temp-file DB), and three pg testcontainer `#[ignore]` fidelity tests (plain-BIGINT-vs-BIGSERIAL, GENERATED AS IDENTITY, NULLS NOT DISTINCT) — all **run and pass** against a Postgres 16 testcontainer, alongside the full pre-existing `schema_pull` / `schema_migrate` Docker suites (no regressions).
- `cargo build --workspace` — clean.

## Deferred (recorded epic dispositions, not implemented here)

- **SQLite table-level `CHECK` constraints** — parsing a `CHECK (...)` predicate out of the raw `CREATE TABLE` SQL is deferred (SQLite exposes no catalog view for it, unlike Postgres `pg_get_constraintdef`); `checks` is left empty for SQLite.
- **DDL emitter for BIGINT-vs-BIGSERIAL / identity** — the IR now distinguishes them and the diff is drift-aware, but re-rendering a plain `BIGINT PK`→`BIGSERIAL` conversion (a sequence create/drop) or emitting the identity clause back into generated DDL is out of scope; the plain↔serial change is refused rather than auto-migrated.
- **`SERIAL` vs `BIGSERIAL` on SQLite** — SQLite has a single 64-bit rowid, so an AUTOINCREMENT id is always recorded as `BigSerial`.
- Unchanged from the existing Postgres arm's documented deferrals: FK on-delete/on-update actions, quoted/reserved-word identifiers, CHECK `NO INHERIT`/`NOT VALID` suffixes, non-PK serial owned sequences, `GENERATED ... STORED` columns, general datetime/typmod precision, enum-CHECK recovery, composite/multi-column FKs, and long-identifier unique-index truncation.

Note: the environment's MSRV toolchain (1.88.0) is not installed here; build/test ran on the active 1.97.0 override (a superset), and clippy was run explicitly on 1.97.0 per the stricter-lint gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXhAnjt2N4xCXkKy78Diyq)_