### PR TITLE
deploy CLI: accept plugin-owned config roots under strict_config

### DIFF
--- a/autumn-cli/src/deploy.rs
+++ b/autumn-cli/src/deploy.rs
@@ -861,7 +861,14 @@ pub fn run(action: DeployAction) -> Result<(), DeployError> {
     // Ambient load (the operator's shell profile, `dev` by default): used ONLY to
     // read `[deploy]` and compute `resolved` — in particular `resolved.profile`,
     // the profile the deployed service will actually boot under (default `prod`).
-    let ambient_config = AutumnConfig::load().map_err(|e| DeployError::Config(e.to_string()))?;
+    // Lenient-unknown-roots load (#2063): the deploy CLI structurally cannot
+    // know an app's plugin set (no AppBuilder, no plugin-crate dep), so it must
+    // NOT fail-close on a plugin-owned top-level config table (e.g. `[media]`)
+    // under `strict_config`. It keeps strict validation of every core section
+    // it DOES own; app boot — which knows the plugin set via the `config_section`
+    // seam — remains the strict gate for plugin roots.
+    let ambient_config = AutumnConfig::load_lenient_unknown_roots()
+        .map_err(|e| DeployError::Config(e.to_string()))?;
     let deploy_cfg = ambient_config.deploy.unwrap_or_default();
     let resolved = ResolvedDeployConfig::resolve(&deploy_cfg, &resolve_project_name())
         .map_err(DeployError::Config)?;
@@ -1155,7 +1162,11 @@ impl<E: Env> Env for ForcedProfileEnv<E> {
 /// matching `AutumnConfig::load()`.
 fn load_runtime_config(resolved: &ResolvedDeployConfig) -> Result<AutumnConfig, DeployError> {
     let forced = deploy_profile_env_overlay(&resolved.profile)?;
-    AutumnConfig::load_with_env(&forced).map_err(|e| DeployError::Config(e.to_string()))
+    // Lenient unknown top-level roots (#2063): keep strict validation of the
+    // core sections the CLI knows while accepting plugin-owned roots (e.g.
+    // `[media]`) as opaque — app boot stays the authoritative strict gate.
+    AutumnConfig::load_with_env_lenient_unknown_roots(&forced)
+        .map_err(|e| DeployError::Config(e.to_string()))
 }
 
 /// Build the profile-aware env overlay that [`load_runtime_config`] resolves the

--- a/autumn-cli/src/doctor.rs
+++ b/autumn-cli/src/doctor.rs
@@ -5945,21 +5945,32 @@ fn resolve_deploy_doctor_config(
     (deploy_cfg, None)
 }
 
-/// Strict-load guard mirroring what `autumn deploy check` does
+/// Load guard mirroring what `autumn deploy check` does
 /// (`deploy.rs::load_runtime_config`): attempt to load the full runtime
 /// [`autumn_web::config::AutumnConfig`] under the DEPLOY profile via the SAME
-/// `AutumnConfig::load_with_env` call, using the profile-forced env overlay
-/// (`deploy::deploy_profile_env_overlay`) the caller already built.
+/// `AutumnConfig::load_with_env_lenient_unknown_roots` call, using the
+/// profile-forced env overlay (`deploy::deploy_profile_env_overlay`) the caller
+/// already built.
 ///
 /// `run()`'s deploy value graders build the merged TOML table with
 /// [`get_merged_toml_table_runtime`], whose profile-override read swallows a
 /// parse/IO error with `.ok()` — so a MALFORMED or unreadable
 /// `autumn-<profile>.toml` override is silently DROPPED and doctor grades only
 /// the base values, PASSING `--strict`. `autumn deploy check`, by contrast,
-/// loads `AutumnConfig::load_with_env` under the deploy profile and FAILS on the
-/// same override. This guard closes that gap: when the deploy-profile load
-/// errors it returns a FAILING `deploy_config` check reporting the load error;
-/// when it succeeds it returns `None` and the existing value grading proceeds.
+/// loads the config under the deploy profile and FAILS on the same override.
+/// This guard closes that gap: when the deploy-profile load errors it returns a
+/// FAILING `deploy_config` check reporting the load error; when it succeeds it
+/// returns `None` and the existing value grading proceeds.
+///
+/// Lenient toward unknown top-level roots (#2063): as of the deploy CLI's move
+/// to `AutumnConfig::load_with_env_lenient_unknown_roots`
+/// (`deploy.rs::load_runtime_config`), `autumn deploy check`/`up` accept a
+/// plugin-owned top-level root (e.g. `[media]`) as opaque and defer to app boot.
+/// This guard MUST use the SAME lenient loader so `doctor --strict` and `deploy
+/// check` agree: a plugin root that passes `deploy check` no longer FAILS the
+/// doctor deploy-config check. Malformed TOML and typos inside a KNOWN/core
+/// section stay fatal in the lenient loader, so those still fail here exactly as
+/// they fail `deploy check`.
 ///
 /// Additive: on a well-formed, deployable config the load succeeds — that is
 /// exactly what lets `autumn deploy check` pass — so this never newly fails a
@@ -5968,7 +5979,7 @@ fn deploy_profile_config_load_check(
     deploy_profile_raw: &str,
     env: &dyn autumn_web::config::Env,
 ) -> Option<CheckResult> {
-    match autumn_web::config::AutumnConfig::load_with_env(env) {
+    match autumn_web::config::AutumnConfig::load_with_env_lenient_unknown_roots(env) {
         Ok(_) => None,
         Err(err) => Some(CheckResult {
             name: "deploy_config",
@@ -6376,16 +6387,20 @@ pub fn run(opts: DoctorOptions) {
                 Ok(e) => Box::new(e),
                 Err(_) => Box::new(autumn_web::config::OsEnv),
             };
-        // STRICT-LOAD GUARD (Codex review): the value graders below build
+        // LOAD GUARD (Codex review): the value graders below build
         // `merged_deploy_toml` via `get_merged_toml_table_runtime`, whose
         // profile-override read swallows a parse/IO error with `.ok()` — so a
         // MALFORMED or unreadable `autumn-<profile>.toml` override is silently
         // DROPPED and doctor would grade only the base values and PASS `--strict`,
-        // while `autumn deploy check` (which loads `AutumnConfig::load_with_env`
-        // under the deploy profile) FAILS on the same file. Mirror `deploy check`'s
-        // exact load here — through the SAME profile-forced `deploy_denv` overlay
-        // `load_runtime_config` uses — and surface any error as a failing
-        // `deploy_config` check so the two agree. On a well-formed (deployable)
+        // while `autumn deploy check` (which loads the config under the deploy
+        // profile) FAILS on the same file. Mirror `deploy check`'s exact load
+        // here — the SAME lenient loader
+        // (`AutumnConfig::load_with_env_lenient_unknown_roots`, #2063) through the
+        // SAME profile-forced `deploy_denv` overlay `load_runtime_config` uses —
+        // and surface any error as a failing `deploy_config` check so the two
+        // agree: a plugin-owned top-level root like `[media]` that passes `deploy
+        // check` no longer FAILS `doctor --strict`, while malformed TOML and
+        // known-section typos stay fatal in both. On a well-formed (deployable)
         // config the load succeeds, so this never newly fails a valid override;
         // the existing value grading below proceeds unchanged.
         if let Some(check) =
@@ -15400,8 +15415,8 @@ redirect_uri = "http://localhost/callback"
     /// `get_merged_toml_table_runtime`, whose profile-override read uses `.ok()`,
     /// so a MALFORMED `autumn-<profile>.toml` is silently dropped — doctor would
     /// then grade only the base values and PASS `--strict`, while `autumn deploy
-    /// check` (which loads `AutumnConfig::load_with_env` under the deploy profile)
-    /// FAILS on the same file. `deploy_profile_config_load_check` closes that gap:
+    /// check` (which loads the config under the deploy profile) FAILS on the same
+    /// file. `deploy_profile_config_load_check` closes that gap:
     /// a malformed deploy-profile override FAILS the `deploy_config` check; a
     /// well-formed one does NOT newly fail. Uses an `AUTUMN_MANIFEST_DIR`-scoped
     /// `MockEnv` (the same mechanism the runtime's own config tests use) so
@@ -15460,6 +15475,61 @@ redirect_uri = "http://localhost/callback"
         assert!(
             deploy_profile_config_load_check("prod", &env).is_none(),
             "a well-formed autumn-prod.toml must not newly fail the deploy_config check"
+        );
+    }
+
+    /// Codex review (P2, #2067): the deploy CLI now loads config leniently toward
+    /// unknown top-level roots (`deploy.rs::load_runtime_config` uses
+    /// `AutumnConfig::load_with_env_lenient_unknown_roots`), so `autumn deploy
+    /// check`/`up` accept a plugin-owned root like `[media]` under `strict_config`
+    /// and defer to app boot. `deploy_profile_config_load_check` must mirror that
+    /// SAME lenient loader, or `doctor --strict` would turn the very config
+    /// `deploy check` passes into a FAILING `deploy_config` check — the two
+    /// deploy workflows disagreeing. This asserts a `[media]` + `strict_config`
+    /// project does NOT fail the doctor deploy-config guard, while a typo inside a
+    /// KNOWN section (`[database] primry_url`) still FAILS it (leniency is scoped
+    /// to unknown top-level roots only, matching the loader-level guarantee).
+    #[test]
+    fn plugin_owned_root_does_not_fail_deploy_config_load_check_but_known_typo_does() {
+        use autumn_web::config::MockEnv;
+        let dir = tempfile::tempdir().unwrap();
+        // `[deploy] profile = "prod"`, `strict_config` on, plus a plugin-owned
+        // `[media]` top-level root the CLI cannot know about — exactly the case
+        // #2067 made lenient for `autumn deploy check`.
+        std::fs::write(
+            dir.path().join("autumn.toml"),
+            "[server]\nstrict_config = true\n\n\
+             [deploy]\nhost = \"deploy.example.com\"\nprofile = \"prod\"\n\n\
+             [media]\nmediamtx_host = \"cdn.example\"\n",
+        )
+        .unwrap();
+        let env = MockEnv::new()
+            .with("AUTUMN_MANIFEST_DIR", dir.path().to_str().unwrap())
+            .with("AUTUMN_ENV", "prod");
+
+        // The plugin root must NOT fail the doctor deploy-config guard — this is
+        // the config `autumn deploy check` passes, so `doctor --strict` must agree.
+        assert!(
+            deploy_profile_config_load_check("prod", &env).is_none(),
+            "a plugin-owned [media] top-level root under strict_config must not fail \
+             the deploy_config load check (it passes `autumn deploy check`)"
+        );
+
+        // But a typo INSIDE a known/core section stays fatal in the lenient loader,
+        // so the doctor guard still FAILS it — exactly as `autumn deploy check` does.
+        std::fs::write(
+            dir.path().join("autumn.toml"),
+            "[server]\nstrict_config = true\n\n\
+             [deploy]\nhost = \"deploy.example.com\"\nprofile = \"prod\"\n\n\
+             [database]\nprimry_url = \"postgres://localhost/db\"\n",
+        )
+        .unwrap();
+        let check = deploy_profile_config_load_check("prod", &env)
+            .expect("a known-section typo must still fail the deploy_config load check");
+        assert_eq!(check.name, "deploy_config");
+        assert!(
+            matches!(check.status, CheckStatus::Fail),
+            "the known-section typo must FAIL, not pass"
         );
     }
 

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -2666,6 +2666,33 @@ fn unknown_key_was_previously_strict(schema_parent: &str) -> bool {
     schema_parent == "profile" || PRE_1890_STRICT_PARENTS.contains(&schema_parent)
 }
 
+/// Policy for how the strict unknown-key check treats a genuinely-unknown
+/// TOP-LEVEL config root — an unknown key whose schema parent is the document
+/// root `""` (e.g. a plugin-owned `[media]` section that no core-schema key
+/// covers).
+///
+/// App boot uses [`Strict`](UnknownRootPolicy::Strict): an unknown top-level
+/// root is a hard error, exactly as before. Tooling that structurally cannot
+/// know the application's plugin set — the deploy CLI, which has no
+/// `AppBuilder`, no plugin list, and no plugin-crate dependency — uses
+/// [`LenientWarn`](UnknownRootPolicy::LenientWarn): unknown top-level roots are
+/// accepted as opaque with a single doctor-style warning, because app boot
+/// (which DOES know the plugin set via the `config_section` seam / #2061 /
+/// #1974) remains the authoritative strict gate for plugin-owned roots (#2063).
+///
+/// The leniency is scoped to top-level roots ONLY: unknown keys INSIDE a known
+/// section (schema parent != `""`, e.g. a `[database] primry_url` typo) keep
+/// their normal (hard) classification under both policies, and malformed TOML
+/// still fails everywhere.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UnknownRootPolicy {
+    /// Unknown top-level roots hard-fail (the app-boot path).
+    Strict,
+    /// Unknown top-level roots are accepted as opaque with one warning (the
+    /// deploy-CLI config-load path).
+    LenientWarn,
+}
+
 /// Child schema keys for config sections whose `Deserialize` is OPAQUE to the
 /// schema walker and must be declared by hand.
 ///
@@ -3043,6 +3070,36 @@ impl AutumnConfig {
     /// Panics if the internally-built TOML table fails to re-serialize
     /// (should never happen with well-formed profile defaults).
     pub fn load() -> Result<Self, ConfigError> {
+        Self::load_policy(UnknownRootPolicy::Strict)
+    }
+
+    /// Like [`load`](Self::load), but accepts unknown TOP-LEVEL config roots as
+    /// opaque-with-a-warning instead of hard-failing.
+    ///
+    /// For tooling that cannot know the application's plugin set (e.g. the
+    /// deploy CLI). Keeps STRICT validation of every known/core section
+    /// `AutumnConfig` owns (`[server]`, `[database]`, `[deploy]`, …) — including
+    /// child-key typos inside them — and still fails on malformed TOML; only a
+    /// genuinely-unknown top-level root (very likely a plugin-owned table such
+    /// as `[media]`) is spared, with a single doctor-style warning. App boot
+    /// remains the authoritative strict gate for plugin-owned roots (see the
+    /// `config_section` seam / #2061 / #1974 / #2063).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError::Io`] if a config file cannot be read,
+    /// [`ConfigError::Parse`] if a file contains invalid TOML, or
+    /// [`ConfigError::Validation`] if a value is invalid (including an unknown
+    /// key inside a known section under `strict_config`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internally-built TOML table fails to re-serialize.
+    pub fn load_lenient_unknown_roots() -> Result<Self, ConfigError> {
+        Self::load_policy(UnknownRootPolicy::LenientWarn)
+    }
+
+    fn load_policy(root_policy: UnknownRootPolicy) -> Result<Self, ConfigError> {
         // Feed a project-root `.env` into the `AUTUMN_*` env layer before
         // resolving config from the real environment. Rather than mutating the
         // process environment, `.env` values are layered *under* the real
@@ -3059,7 +3116,11 @@ impl AutumnConfig {
         let vars = crate::dotenv::resolve_dotenv_vars(&dir, &profile, &base)
             .map_err(|e| ConfigError::Dotenv(e.to_string()))?;
         let env = crate::dotenv::DotenvEnv::new(&base, vars);
-        Self::load_with_env(&env)
+        // The zero-arg loaders (`load` / `load_lenient_unknown_roots`) have no
+        // AppBuilder and therefore no plugin-declared config roots; plugin roots
+        // arrive only via `TomlEnvConfigLoader::with_plugin_config_roots` →
+        // `load_with_env_and_plugin_roots`. Pass an empty set here.
+        Self::load_with_env_and_plugin_roots_policy(&env, &BTreeSet::new(), root_policy)
     }
 
     /// Load configuration with profile-aware layering, using a provided
@@ -3073,7 +3134,11 @@ impl AutumnConfig {
     /// # Panics
     /// Panics if the internally-built TOML table fails to re-serialize.
     pub fn load_with_env(env: &dyn Env) -> Result<Self, ConfigError> {
-        Self::load_with_env_and_plugin_roots(env, &BTreeSet::new())
+        Self::load_with_env_and_plugin_roots_policy(
+            env,
+            &BTreeSet::new(),
+            UnknownRootPolicy::Strict,
+        )
     }
 
     /// Like [`load_with_env`](Self::load_with_env), but treats each top-level
@@ -3105,6 +3170,54 @@ impl AutumnConfig {
     pub fn load_with_env_and_plugin_roots(
         env: &dyn Env,
         plugin_config_roots: &BTreeSet<String>,
+    ) -> Result<Self, ConfigError> {
+        Self::load_with_env_and_plugin_roots_policy(
+            env,
+            plugin_config_roots,
+            UnknownRootPolicy::Strict,
+        )
+    }
+
+    /// Like [`load_with_env`](Self::load_with_env), but accepts unknown
+    /// TOP-LEVEL config roots as opaque-with-a-warning instead of hard-failing.
+    ///
+    /// For tooling that cannot know the application's plugin set (e.g. the
+    /// deploy CLI). Keeps STRICT validation of every known/core section — and
+    /// of child-key typos inside them — and still fails on malformed TOML; only
+    /// a genuinely-unknown top-level root (very likely a plugin-owned table such
+    /// as `[media]`) is spared, with a single doctor-style warning. App boot
+    /// remains the authoritative strict gate for plugin-owned roots (see the
+    /// `config_section` seam / #2061 / #1974 / #2063).
+    ///
+    /// # Errors
+    /// Returns [`ConfigError::Io`] if a config file cannot be read,
+    /// [`ConfigError::Parse`] if a file contains invalid TOML, or
+    /// [`ConfigError::Validation`] if a value is invalid (including an unknown
+    /// key inside a known section under `strict_config`).
+    ///
+    /// # Panics
+    /// Panics if the internally-built TOML table fails to re-serialize.
+    pub fn load_with_env_lenient_unknown_roots(env: &dyn Env) -> Result<Self, ConfigError> {
+        Self::load_with_env_and_plugin_roots_policy(
+            env,
+            &BTreeSet::new(),
+            UnknownRootPolicy::LenientWarn,
+        )
+    }
+
+    /// Shared config-loading worker threading BOTH the plugin-declared config
+    /// roots (#2061) AND the unknown-top-level-root policy (#2063).
+    ///
+    /// The two knobs are orthogonal: `plugin_config_roots` exempts SPECIFIC
+    /// declared table roots (they produce no error to classify), while
+    /// `root_policy` decides whether the REMAINING unknown top-level roots
+    /// hard-fail ([`Strict`](UnknownRootPolicy::Strict), app boot) or are
+    /// accepted opaque-with-a-warning
+    /// ([`LenientWarn`](UnknownRootPolicy::LenientWarn), the deploy CLI).
+    fn load_with_env_and_plugin_roots_policy(
+        env: &dyn Env,
+        plugin_config_roots: &BTreeSet<String>,
+        root_policy: UnknownRootPolicy,
     ) -> Result<Self, ConfigError> {
         let selected_profile_input = resolve_profile_input(env);
         let profile =
@@ -3161,7 +3274,12 @@ impl AutumnConfig {
                 || env
                     .var("AUTUMN_SERVER__STRICT_CONFIG_ENFORCE_ALL")
                     .is_ok_and(|v| v == "true" || v == "1");
-            Self::run_strict_unknown_key_check(&toml_str, enforce_all, plugin_config_roots)?;
+            Self::run_strict_unknown_key_check(
+                &toml_str,
+                enforce_all,
+                plugin_config_roots,
+                root_policy,
+            )?;
         }
 
         // ── Deprecation channel (purely additive; never mutates `config`). ──────
@@ -3232,18 +3350,55 @@ impl AutumnConfig {
         toml_str: &str,
         enforce_all: bool,
         plugin_config_roots: &BTreeSet<String>,
+        root_policy: UnknownRootPolicy,
     ) -> Result<(), ConfigError> {
         let schema = Self::get_schema_keys();
         let errors = Self::validate_toml_detailed(toml_str, &schema, plugin_config_roots);
 
         let mut hard_errors = Vec::new();
         let mut warn_only = Vec::new();
+        let mut opaque_roots = Vec::new();
         for (path, sug, schema_parent) in errors {
+            // Deploy-CLI leniency (#2063): a genuinely-unknown TOP-LEVEL root
+            // (its schema parent is the document root `""`) is accepted as
+            // opaque rather than failing — it is almost certainly a
+            // plugin-owned config table (e.g. `[media]`) the CLI structurally
+            // cannot know about, and app boot stays the strict gate for it.
+            // ONLY the root is spared: an unknown key inside a KNOWN section
+            // (schema_parent != "") falls through to its normal classification
+            // below, so a `[database] primry_url` typo still hard-fails. The
+            // app-boot path passes `Strict`, so its behavior is unchanged.
+            if root_policy == UnknownRootPolicy::LenientWarn && schema_parent.is_empty() {
+                opaque_roots.push(path);
+                continue;
+            }
             if enforce_all || unknown_key_was_previously_strict(&schema_parent) {
                 hard_errors.push((path, sug));
             } else {
                 warn_only.push((path, sug));
             }
+        }
+
+        // Deploy-CLI opaque top-level roots (#2063): surface exactly one
+        // doctor-style line (never fatal) so an accepted plugin root is
+        // observable and a typo'd root is not silently swallowed — it will be
+        // rejected authoritatively when the app itself boots. `eprintln!`
+        // guarantees visibility before a tracing subscriber is installed; the
+        // `tracing::warn!` keeps structured output for apps that pre-install one.
+        if !opaque_roots.is_empty() {
+            let roots = opaque_roots.join(", ");
+            let count = opaque_roots.len();
+            eprintln!(
+                "deploy config: accepting {count} unknown top-level config section(s) as \
+                 opaque (validated at app boot): {roots} — if one of these is a typo it \
+                 will be rejected when the app starts."
+            );
+            tracing::warn!(
+                unknown_top_level_roots = roots.as_str(),
+                count,
+                "deploy config: accepting unknown top-level config section(s) as opaque; \
+                 app boot remains the strict gate for plugin-owned roots (#2063)"
+            );
         }
 
         // Warn-first rollout (#1890): unknown keys in sections that only became
@@ -7998,6 +8153,122 @@ mod tests {
         assert!(res.is_err());
         let err_str = format!("{:?}", res.err().unwrap());
         assert!(err_str.contains("primry_url"));
+    }
+
+    // #2063 helper: a `prod`, manifest-scoped env with `strict_config` sourced
+    // from the on-disk `autumn.toml`. `prod` is pinned (not `dev`) so the
+    // dev-only injected `[storage]` smart-default can't masquerade as an unknown
+    // top-level root and skew these assertions — same reason the #1890 tests do.
+    fn strict_prod_env_2063(temp: &std::path::Path) -> FakeEnv {
+        FakeEnv(
+            [
+                ("AUTUMN_ENV".to_owned(), "prod".to_owned()),
+                (
+                    "AUTUMN_MANIFEST_DIR".to_owned(),
+                    temp.to_str().unwrap().to_owned(),
+                ),
+            ]
+            .into(),
+        )
+    }
+
+    // #2063: the deploy CLI's lenient-unknown-roots load accepts a plugin-owned
+    // top-level config table (`[media]`) under `strict_config` — the CLI cannot
+    // know the app's plugin set — while the STRICT (app-boot) load still rejects
+    // it, so app boot remains the authoritative strict gate for plugin roots.
+    #[test]
+    fn deploy_cli_lenient_accepts_plugin_owned_top_level_root() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("autumn.toml"),
+            "[server]\nstrict_config = true\n\n[media]\nmediamtx_host = \"cdn.example\"\n",
+        )
+        .unwrap();
+        let env = strict_prod_env_2063(temp.path());
+
+        // App boot stays strict: an unknown `[media]` root is a hard error.
+        let strict = AutumnConfig::load_with_env(&env);
+        assert!(
+            strict.is_err(),
+            "app boot must stay strict for unknown plugin roots: {strict:?}"
+        );
+        let strict_err = format!("{:?}", strict.err().unwrap());
+        assert!(
+            strict_err.contains("media"),
+            "strict error should name the unknown root: {strict_err}"
+        );
+
+        // Deploy CLI accepts it as opaque (warn, not fail) so the project deploys.
+        let lenient = AutumnConfig::load_with_env_lenient_unknown_roots(&env);
+        assert!(
+            lenient.is_ok(),
+            "deploy CLI must accept plugin-owned [media] under strict_config: {lenient:?}"
+        );
+    }
+
+    // #2063: any genuinely-unknown top-level root (not just `[media]`) is
+    // warn-not-fail under the lenient CLI load, and still fatal under app boot.
+    #[test]
+    fn deploy_cli_lenient_accepts_arbitrary_unknown_top_level_root() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("autumn.toml"),
+            "[server]\nstrict_config = true\n\n[definitely_not_a_root]\nx = 1\n",
+        )
+        .unwrap();
+        let env = strict_prod_env_2063(temp.path());
+
+        assert!(
+            AutumnConfig::load_with_env(&env).is_err(),
+            "app boot must reject an unknown top-level root"
+        );
+        assert!(
+            AutumnConfig::load_with_env_lenient_unknown_roots(&env).is_ok(),
+            "deploy CLI must accept an unknown top-level root as opaque"
+        );
+    }
+
+    // #2063: leniency is scoped to top-level ROOTS only. A typo INSIDE a known
+    // section (`[database] primry_url`) stays a hard error even under the lenient
+    // CLI load — the CLI does not soften validation of sections it knows.
+    #[test]
+    fn deploy_cli_lenient_still_rejects_known_section_typo() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("autumn.toml"),
+            "[server]\nstrict_config = true\n\n[database]\nprimry_url = \"postgres://localhost/db\"\n",
+        )
+        .unwrap();
+        let env = strict_prod_env_2063(temp.path());
+
+        let res = AutumnConfig::load_with_env_lenient_unknown_roots(&env);
+        assert!(
+            res.is_err(),
+            "known-section typo must still hard-fail under the lenient CLI load: {res:?}"
+        );
+        let err = format!("{:?}", res.err().unwrap());
+        assert!(
+            err.contains("primry_url"),
+            "error should name the known-section typo: {err}"
+        );
+    }
+
+    // #2063: malformed TOML is fatal everywhere — the lenient policy never
+    // softens a parse failure.
+    #[test]
+    fn deploy_cli_lenient_still_rejects_malformed_toml() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("autumn.toml"),
+            "[server]\nstrict_config = true\n\nthis is not = = valid toml\n",
+        )
+        .unwrap();
+        let env = strict_prod_env_2063(temp.path());
+
+        assert!(
+            AutumnConfig::load_with_env_lenient_unknown_roots(&env).is_err(),
+            "malformed TOML must still fail under the lenient CLI load"
+        );
     }
 
     // 7a (#1890): a typo in a section that ONLY became strictly validated by the

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -3390,14 +3390,17 @@ impl AutumnConfig {
             let count = opaque_roots.len();
             eprintln!(
                 "deploy config: accepting {count} unknown top-level config section(s) as \
-                 opaque (validated at app boot): {roots} — if one of these is a typo it \
-                 will be rejected when the app starts."
+                 opaque — the deployed app runs the authoritative strict check, so each must \
+                 be a section the app declares (e.g. a plugin config table) or the app will \
+                 reject it at boot: {roots}. A typo here will make the app fail to start."
             );
             tracing::warn!(
                 unknown_top_level_roots = roots.as_str(),
                 count,
-                "deploy config: accepting unknown top-level config section(s) as opaque; \
-                 app boot remains the strict gate for plugin-owned roots (#2063)"
+                "deploy config: accepting unknown top-level config section(s) as opaque; the \
+                 deployed app runs the authoritative strict check, so each must be a section \
+                 the app declares (e.g. a plugin config table) or it will reject it at boot — \
+                 a typo here will make the app fail to start (#2063)"
             );
         }
 

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -2824,7 +2824,7 @@ impl AutumnConfig {
     ) -> Vec<(String, Option<String>)> {
         Self::validate_toml_detailed(content, schema, &BTreeSet::new())
             .into_iter()
-            .map(|(path, sug, _parent, _is_table)| (path, sug))
+            .map(|(path, sug, _parent, _is_table, _is_top_level)| (path, sug))
             .collect()
     }
 
@@ -2832,12 +2832,20 @@ impl AutumnConfig {
     /// profile-stripped schema parent path (computed from path SEGMENTS, so it is
     /// correct even for quoted dotted profile names like
     /// `[profile."prod.eu".server]`) AND whether the offending TOML value was
-    /// itself a table (`is_table`). Used by strict-config classification;
-    /// `validate_toml` maps this down to `(path, suggestion)`.
+    /// itself a table (`is_table`), AND whether the offending key sat at the
+    /// STRUCTURAL document top level (`is_top_level`, i.e. its parent path was
+    /// empty at push time). Used by strict-config classification; `validate_toml`
+    /// maps this down to `(path, suggestion)`.
     ///
     /// The `is_table` flag lets the deploy-CLI leniency (#2067) demote ONLY a
     /// true top-level TABLE root, mirroring the app-boot `config_section` seam
     /// (#2061) which exempts a registered plugin root only when `val.is_table()`.
+    ///
+    /// The `is_top_level` flag carries the same STRUCTURAL top-level signal the
+    /// app-boot exemption uses (`path.is_empty()`), so deploy leniency can tell a
+    /// genuine top-level root from a profile-prefixed one WITHOUT inspecting the
+    /// rendered dotted `path` string — which is ambiguous, since a quoted top-level
+    /// key like `["my.plugin"]` and a 2-level path both render `my.plugin`.
     ///
     /// `plugin_config_roots` lists top-level roots a plugin has declared via
     /// [`config_section`](crate::app::AppBuilder::config_section): each is
@@ -2848,7 +2856,7 @@ impl AutumnConfig {
         content: &str,
         schema: &HashMap<String, HashSet<String>>,
         plugin_config_roots: &BTreeSet<String>,
-    ) -> Vec<(String, Option<String>, String, bool)> {
+    ) -> Vec<(String, Option<String>, String, bool, bool)> {
         let Ok(table) = toml::from_str::<toml::Table>(content) else {
             return Vec::new();
         };
@@ -2865,7 +2873,7 @@ impl AutumnConfig {
         path: &mut Vec<String>,
         schema: &HashMap<String, HashSet<String>>,
         plugin_config_roots: &BTreeSet<String>,
-        errors: &mut Vec<(String, Option<String>, String, bool)>,
+        errors: &mut Vec<(String, Option<String>, String, bool, bool)>,
     ) {
         let mut schema_path_parts = Vec::new();
         if path.len() >= 2 && path[0] == "profile" {
@@ -2976,7 +2984,13 @@ impl AutumnConfig {
                         sug_parts.join(".")
                     });
 
-                    errors.push((full_path, suggestion, schema_path.clone(), val.is_table()));
+                    errors.push((
+                        full_path,
+                        suggestion,
+                        schema_path.clone(),
+                        val.is_table(),
+                        path.is_empty(),
+                    ));
                 }
             }
         } else if path.len() == 1 && path[0] == "profile" {
@@ -2993,6 +3007,7 @@ impl AutumnConfig {
                         None,
                         schema_path.clone(),
                         val.is_table(),
+                        path.is_empty(),
                     ));
                 }
             }
@@ -3049,6 +3064,7 @@ impl AutumnConfig {
                         closest.map(String::from),
                         schema_path.clone(),
                         val.is_table(),
+                        path.is_empty(),
                     ));
                 }
             }
@@ -3373,7 +3389,7 @@ impl AutumnConfig {
         let mut hard_errors = Vec::new();
         let mut warn_only = Vec::new();
         let mut opaque_roots = Vec::new();
-        for (path, sug, schema_parent, is_table) in errors {
+        for (path, sug, schema_parent, is_table, is_top_level) in errors {
             // Deploy-CLI leniency (#2063/#2067): a genuinely-unknown TRUE
             // top-level root — one sitting directly at the document root, i.e.
             // whose ACTUAL path is a bare root key (no `profile.<name>` prefix)
@@ -3382,20 +3398,32 @@ impl AutumnConfig {
             // config table (e.g. `[media]`) the CLI structurally cannot know
             // about, and app boot stays the strict gate for it.
             //
-            // The gate is on the ACTUAL PATH being a true top-level root, NOT
-            // merely on `schema_parent.is_empty()`: `validate_toml_detailed`
-            // reports an EMPTY schema parent for a profile-prefixed section like
-            // `[profile.prod.media]` too (the profile prefix is stripped before
-            // root-schema validation, so `[profile.prod.media]` and top-level
-            // `[media]` both surface with schema parent `""` but distinct paths
-            // `"profile.prod.media"` vs `"media"`). Gating on the empty schema
-            // parent alone would wrongly soften a profile-prefixed plugin root
-            // and let `deploy check`/`up` pass — yet the deployed app, whose
-            // `config_section` seam (#2061) exempts ONLY the TRUE top-level
-            // `[media]` via `path.is_empty()`, still REJECTS `[profile.prod.media]`
-            // at boot. Requiring `!path.contains('.')` here mirrors that
-            // `path.is_empty()` exemption, so deploy and app boot AGREE: both
-            // accept top-level `[media]`, both reject `[profile.prod.media]`.
+            // Top-level-ness is STRUCTURAL, taken from the error's `is_top_level`
+            // flag (the offending key's parent path was empty at push time) — the
+            // SAME signal #2061's app-boot exemption keys on (`path.is_empty()`
+            // in `validate_toml_table`). It is deliberately NOT inferred from the
+            // rendered dotted `path` string: that string is AMBIGUOUS, because a
+            // legitimately quoted-dotted top-level key like `["my.plugin"]` (from
+            // `config_section("my.plugin")`) and a 2-level path both render
+            // `my.plugin`. The earlier `!path.contains('.')` heuristic therefore
+            // HARD-FAILED a quoted-dotted top-level plugin root at deploy even
+            // though app boot ACCEPTS it (its exemption keys on the RAW table key
+            // with `path.is_empty()`). Gating on `is_top_level` closes that gap:
+            // a quoted-dotted top-level table matches here exactly as it is
+            // exempted at boot.
+            //
+            // It is also NOT merely `schema_parent.is_empty()`:
+            // `validate_toml_detailed` reports an EMPTY schema parent for a
+            // profile-prefixed section like `[profile.prod.media]` too (the
+            // profile prefix is stripped before root-schema validation, so
+            // `[profile.prod.media]` and top-level `[media]` both surface with
+            // schema parent `""`). But a profile-prefixed section is pushed with a
+            // NON-EMPTY parent path (`["profile","prod"]`), so `is_top_level` is
+            // false for it — and the deployed app, whose `config_section` seam
+            // (#2061) exempts ONLY the TRUE top-level `[media]` via
+            // `path.is_empty()`, still REJECTS `[profile.prod.media]` at boot. So
+            // deploy and app boot AGREE: both accept top-level `[media]` /
+            // `["my.plugin"]`, both reject `[profile.prod.media]`.
             //
             // A profile-prefixed root therefore no longer matches this branch
             // and falls through to the normal (hard, since schema_parent `""` ∈
@@ -3418,7 +3446,7 @@ impl AutumnConfig {
             // rejects" gap this branch exists to close.
             if root_policy == UnknownRootPolicy::LenientWarn
                 && schema_parent.is_empty()
-                && !path.contains('.')
+                && is_top_level
                 && is_table
             {
                 opaque_roots.push(path);
@@ -8440,6 +8468,53 @@ mod tests {
         );
     }
 
+    // #2067: a legitimately quoted-dotted TOP-LEVEL table root — the valid TOML
+    // form of a plugin `config_section("my.plugin")`, whose top-level table is
+    // `["my.plugin"]` (a single quoted key that happens to contain a dot) — must
+    // be leniently ACCEPTED by the deploy CLI, because app boot ACCEPTS it too
+    // (the #2061 exemption keys on the RAW table key with `path.is_empty()`). The
+    // earlier `!path.contains('.')` heuristic wrongly HARD-FAILED it: the rendered
+    // dotted string `my.plugin` is ambiguous between a quoted top-level key and a
+    // 2-level path. Gating on the STRUCTURAL `is_top_level` (empty parent path)
+    // fixes it. Regression against that string-heuristic bug.
+    #[test]
+    fn deploy_cli_lenient_accepts_quoted_dotted_top_level_root() {
+        // `["my.plugin"]` is a quoted top-level key CONTAINING a dot (one
+        // structural top-level table), NOT the nested `[my.plugin]` two-level
+        // form — this is exactly what `config_section("my.plugin")` produces.
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("autumn.toml"),
+            "[server]\nstrict_config = true\n\n[\"my.plugin\"]\nenabled = true\n",
+        )
+        .unwrap();
+        let env = strict_prod_env_2063(temp.path());
+
+        let lenient = AutumnConfig::load_with_env_lenient_unknown_roots(&env);
+        assert!(
+            lenient.is_ok(),
+            "deploy CLI must leniently accept a quoted-dotted TOP-LEVEL table root \
+             ([\"my.plugin\"]) — it is a true top-level plugin root the app accepts at \
+             boot, and top-level-ness is structural (empty parent path), not \
+             `path.contains('.')`: {lenient:?}"
+        );
+
+        // Inline-table form of the same quoted-dotted top-level root is
+        // equivalent. It is written BEFORE the `[server]` header so it binds at
+        // the document top level, not inside `[server]`.
+        let temp2 = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp2.path().join("autumn.toml"),
+            "\"my.plugin\" = { enabled = true }\n\n[server]\nstrict_config = true\n",
+        )
+        .unwrap();
+        let env2 = strict_prod_env_2063(temp2.path());
+        assert!(
+            AutumnConfig::load_with_env_lenient_unknown_roots(&env2).is_ok(),
+            "deploy CLI must accept the inline-table quoted-dotted top-level root too"
+        );
+    }
+
     // 7a (#1890): a typo in a section that ONLY became strictly validated by the
     // schema-walk fix (here `[log]`, declared after `database`) must WARN, not
     // fail, during the one-release warn-first rollout.
@@ -8593,6 +8668,31 @@ mod tests {
         assert!(
             res.is_ok(),
             "a registered [media] root must boot under strict_config: {res:?}"
+        );
+    }
+
+    // #2067 boot/deploy parity: a registered QUOTED-DOTTED plugin root — the app
+    // form of `config_section("my.plugin")`, whose top-level table is
+    // `["my.plugin"]` — is exempted at app-boot strict too. The exemption keys on
+    // the RAW table key (`plugin_config_roots.contains("my.plugin")`) with
+    // `path.is_empty()`, so the dot in the key name is irrelevant. This documents
+    // that deploy leniency (which now derives top-level-ness structurally) and
+    // app boot agree on quoted-dotted top-level roots.
+    #[test]
+    fn strict_config_accepts_quoted_dotted_registered_plugin_root() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("autumn.toml"),
+            "[\"my.plugin\"]\nenabled = true\n[\"my.plugin\".nested]\nx = 1\n",
+        )
+        .unwrap();
+
+        let env = strict_prod_env(temp.path(), false);
+        let res = AutumnConfig::load_with_env_and_plugin_roots(&env, &plugin_roots(&["my.plugin"]));
+        assert!(
+            res.is_ok(),
+            "a registered quoted-dotted top-level root ([\"my.plugin\"]) must boot \
+             under strict_config, exactly as deploy leniency accepts it: {res:?}"
         );
     }
 

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -2824,15 +2824,20 @@ impl AutumnConfig {
     ) -> Vec<(String, Option<String>)> {
         Self::validate_toml_detailed(content, schema, &BTreeSet::new())
             .into_iter()
-            .map(|(path, sug, _parent)| (path, sug))
+            .map(|(path, sug, _parent, _is_table)| (path, sug))
             .collect()
     }
 
     /// Like [`validate_toml`](Self::validate_toml), but also returns each error's
     /// profile-stripped schema parent path (computed from path SEGMENTS, so it is
     /// correct even for quoted dotted profile names like
-    /// `[profile."prod.eu".server]`). Used by strict-config classification;
+    /// `[profile."prod.eu".server]`) AND whether the offending TOML value was
+    /// itself a table (`is_table`). Used by strict-config classification;
     /// `validate_toml` maps this down to `(path, suggestion)`.
+    ///
+    /// The `is_table` flag lets the deploy-CLI leniency (#2067) demote ONLY a
+    /// true top-level TABLE root, mirroring the app-boot `config_section` seam
+    /// (#2061) which exempts a registered plugin root only when `val.is_table()`.
     ///
     /// `plugin_config_roots` lists top-level roots a plugin has declared via
     /// [`config_section`](crate::app::AppBuilder::config_section): each is
@@ -2843,7 +2848,7 @@ impl AutumnConfig {
         content: &str,
         schema: &HashMap<String, HashSet<String>>,
         plugin_config_roots: &BTreeSet<String>,
-    ) -> Vec<(String, Option<String>, String)> {
+    ) -> Vec<(String, Option<String>, String, bool)> {
         let Ok(table) = toml::from_str::<toml::Table>(content) else {
             return Vec::new();
         };
@@ -2860,7 +2865,7 @@ impl AutumnConfig {
         path: &mut Vec<String>,
         schema: &HashMap<String, HashSet<String>>,
         plugin_config_roots: &BTreeSet<String>,
-        errors: &mut Vec<(String, Option<String>, String)>,
+        errors: &mut Vec<(String, Option<String>, String, bool)>,
     ) {
         let mut schema_path_parts = Vec::new();
         if path.len() >= 2 && path[0] == "profile" {
@@ -2971,7 +2976,7 @@ impl AutumnConfig {
                         sug_parts.join(".")
                     });
 
-                    errors.push((full_path, suggestion, schema_path.clone()));
+                    errors.push((full_path, suggestion, schema_path.clone(), val.is_table()));
                 }
             }
         } else if path.len() == 1 && path[0] == "profile" {
@@ -2983,7 +2988,12 @@ impl AutumnConfig {
                 } else {
                     let mut full_path_parts = path.clone();
                     full_path_parts.push(k.clone());
-                    errors.push((full_path_parts.join("."), None, schema_path.clone()));
+                    errors.push((
+                        full_path_parts.join("."),
+                        None,
+                        schema_path.clone(),
+                        val.is_table(),
+                    ));
                 }
             }
         } else if path.is_empty() {
@@ -3034,7 +3044,12 @@ impl AutumnConfig {
                             closest = Some(valid_key);
                         }
                     }
-                    errors.push((k.clone(), closest.map(String::from), schema_path.clone()));
+                    errors.push((
+                        k.clone(),
+                        closest.map(String::from),
+                        schema_path.clone(),
+                        val.is_table(),
+                    ));
                 }
             }
         }
@@ -3358,7 +3373,7 @@ impl AutumnConfig {
         let mut hard_errors = Vec::new();
         let mut warn_only = Vec::new();
         let mut opaque_roots = Vec::new();
-        for (path, sug, schema_parent) in errors {
+        for (path, sug, schema_parent, is_table) in errors {
             // Deploy-CLI leniency (#2063/#2067): a genuinely-unknown TRUE
             // top-level root — one sitting directly at the document root, i.e.
             // whose ACTUAL path is a bare root key (no `profile.<name>` prefix)
@@ -3389,9 +3404,22 @@ impl AutumnConfig {
             // key inside a KNOWN section (schema_parent != "") also falls
             // through, so a `[database] primry_url` typo still hard-fails. The
             // app-boot path passes `Strict`, so its behavior is unchanged.
+            //
+            // Leniency additionally requires the root's TOML value to be a TABLE
+            // (`is_table`), mirroring the #2061 `config_section` app-boot
+            // exemption, which accepts a registered plugin root only when
+            // `val.is_table()`. A non-table true-top-level root — a scalar or
+            // array like `media = "enabled"` / `media = ["a", "b"]` — is a
+            // malformed section nothing would deserialize, so it does NOT match
+            // here and falls through to the normal (hard) classification →
+            // strict rejection at deploy, EXACTLY as the deployed app rejects it
+            // at boot. Without this check deploy would accept a non-table root
+            // that app boot rejects, reopening the "deploy accepts what boot
+            // rejects" gap this branch exists to close.
             if root_policy == UnknownRootPolicy::LenientWarn
                 && schema_parent.is_empty()
                 && !path.contains('.')
+                && is_table
             {
                 opaque_roots.push(path);
                 continue;
@@ -8354,6 +8382,61 @@ mod tests {
         assert!(
             err.contains("definitely_unknown"),
             "error should name the profile-prefixed unknown root: {err}"
+        );
+    }
+
+    // #2067: the lenient deploy-CLI demotion applies ONLY to a true top-level
+    // root whose TOML value is a TABLE. A registered/unknown root written as a
+    // SCALAR (`media = "enabled"`) or an ARRAY (`media = ["a", "b"]`) is a
+    // malformed section nothing would deserialize, so it must HARD-FAIL under
+    // the lenient CLI load too — exactly as the deployed app rejects it at boot
+    // (the #2061 `config_section` seam exempts a plugin root only when
+    // `val.is_table()`). Without the `is_table` gate deploy would accept a
+    // non-table root that app boot rejects.
+    #[test]
+    fn deploy_cli_lenient_still_rejects_non_table_root() {
+        // Scalar root: `media = "enabled"`.
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("autumn.toml"),
+            "[server]\nstrict_config = true\n\nmedia = \"enabled\"\n",
+        )
+        .unwrap();
+        let env = strict_prod_env_2063(temp.path());
+
+        let res = AutumnConfig::load_with_env_lenient_unknown_roots(&env);
+        assert!(
+            res.is_err(),
+            "a SCALAR top-level root (media = \"enabled\") must hard-fail under the \
+             lenient CLI load — it is not a table and the deployed app rejects it at \
+             boot: {res:?}"
+        );
+        let err = format!("{:?}", res.err().unwrap());
+        assert!(
+            err.contains("media"),
+            "error should name the non-table root: {err}"
+        );
+
+        // Array root: `media = ["a", "b"]`.
+        let temp2 = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp2.path().join("autumn.toml"),
+            "[server]\nstrict_config = true\n\nmedia = [\"a\", \"b\"]\n",
+        )
+        .unwrap();
+        let env2 = strict_prod_env_2063(temp2.path());
+
+        let res2 = AutumnConfig::load_with_env_lenient_unknown_roots(&env2);
+        assert!(
+            res2.is_err(),
+            "an ARRAY top-level root (media = [\"a\", \"b\"]) must hard-fail under the \
+             lenient CLI load — it is not a table and the deployed app rejects it at \
+             boot: {res2:?}"
+        );
+        let err2 = format!("{:?}", res2.err().unwrap());
+        assert!(
+            err2.contains("media"),
+            "error should name the non-table root: {err2}"
         );
     }
 

--- a/autumn/src/config.rs
+++ b/autumn/src/config.rs
@@ -3359,16 +3359,40 @@ impl AutumnConfig {
         let mut warn_only = Vec::new();
         let mut opaque_roots = Vec::new();
         for (path, sug, schema_parent) in errors {
-            // Deploy-CLI leniency (#2063): a genuinely-unknown TOP-LEVEL root
-            // (its schema parent is the document root `""`) is accepted as
-            // opaque rather than failing — it is almost certainly a
-            // plugin-owned config table (e.g. `[media]`) the CLI structurally
-            // cannot know about, and app boot stays the strict gate for it.
-            // ONLY the root is spared: an unknown key inside a KNOWN section
-            // (schema_parent != "") falls through to its normal classification
-            // below, so a `[database] primry_url` typo still hard-fails. The
+            // Deploy-CLI leniency (#2063/#2067): a genuinely-unknown TRUE
+            // top-level root — one sitting directly at the document root, i.e.
+            // whose ACTUAL path is a bare root key (no `profile.<name>` prefix)
+            // AND whose schema parent is the document root `""` — is accepted as
+            // opaque rather than failing. It is almost certainly a plugin-owned
+            // config table (e.g. `[media]`) the CLI structurally cannot know
+            // about, and app boot stays the strict gate for it.
+            //
+            // The gate is on the ACTUAL PATH being a true top-level root, NOT
+            // merely on `schema_parent.is_empty()`: `validate_toml_detailed`
+            // reports an EMPTY schema parent for a profile-prefixed section like
+            // `[profile.prod.media]` too (the profile prefix is stripped before
+            // root-schema validation, so `[profile.prod.media]` and top-level
+            // `[media]` both surface with schema parent `""` but distinct paths
+            // `"profile.prod.media"` vs `"media"`). Gating on the empty schema
+            // parent alone would wrongly soften a profile-prefixed plugin root
+            // and let `deploy check`/`up` pass — yet the deployed app, whose
+            // `config_section` seam (#2061) exempts ONLY the TRUE top-level
+            // `[media]` via `path.is_empty()`, still REJECTS `[profile.prod.media]`
+            // at boot. Requiring `!path.contains('.')` here mirrors that
+            // `path.is_empty()` exemption, so deploy and app boot AGREE: both
+            // accept top-level `[media]`, both reject `[profile.prod.media]`.
+            //
+            // A profile-prefixed root therefore no longer matches this branch
+            // and falls through to the normal (hard, since schema_parent `""` ∈
+            // PRE_1890_STRICT_PARENTS) classification below → strict rejection at
+            // deploy, matching app boot. ONLY a true root is spared: an unknown
+            // key inside a KNOWN section (schema_parent != "") also falls
+            // through, so a `[database] primry_url` typo still hard-fails. The
             // app-boot path passes `Strict`, so its behavior is unchanged.
-            if root_policy == UnknownRootPolicy::LenientWarn && schema_parent.is_empty() {
+            if root_policy == UnknownRootPolicy::LenientWarn
+                && schema_parent.is_empty()
+                && !path.contains('.')
+            {
                 opaque_roots.push(path);
                 continue;
             }
@@ -8271,6 +8295,65 @@ mod tests {
         assert!(
             AutumnConfig::load_with_env_lenient_unknown_roots(&env).is_err(),
             "malformed TOML must still fail under the lenient CLI load"
+        );
+    }
+
+    // #2067: the lenient deploy-CLI load must NOT soften a PROFILE-PREFIXED
+    // unknown root like `[profile.prod.media]`. Its schema parent is empty
+    // (the profile prefix is stripped before root-schema validation), but its
+    // actual path (`profile.prod.media`) is not a true top-level root — so it
+    // stays strict and hard-fails, exactly as the deployed app rejects it at
+    // boot (the `config_section` seam exempts ONLY the true top-level `[media]`
+    // via `path.is_empty()`). Otherwise deploy would pass while remote boot
+    // fails.
+    #[test]
+    fn deploy_cli_lenient_still_rejects_profile_prefixed_root() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("autumn.toml"),
+            "[server]\nstrict_config = true\n\n[profile.prod.media]\nmediamtx_host = \"cdn.example\"\n",
+        )
+        .unwrap();
+        let env = strict_prod_env_2063(temp.path());
+
+        let res = AutumnConfig::load_with_env_lenient_unknown_roots(&env);
+        assert!(
+            res.is_err(),
+            "a profile-prefixed root ([profile.prod.media]) must stay strict under \
+             the lenient CLI load — it is not a true top-level root and the deployed \
+             app rejects it at boot: {res:?}"
+        );
+        let err = format!("{:?}", res.err().unwrap());
+        assert!(
+            err.contains("media"),
+            "error should name the profile-prefixed root: {err}"
+        );
+    }
+
+    // #2067: the profile-prefix strictness is not media-specific — a
+    // profile-prefixed genuinely-unknown NON-plugin root
+    // (`[profile.prod.definitely_unknown]`) also stays a hard error under the
+    // lenient CLI load; only TRUE top-level roots are ever softened.
+    #[test]
+    fn deploy_cli_lenient_still_rejects_profile_prefixed_unknown_root() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("autumn.toml"),
+            "[server]\nstrict_config = true\n\n[profile.prod.definitely_unknown]\nx = 1\n",
+        )
+        .unwrap();
+        let env = strict_prod_env_2063(temp.path());
+
+        let res = AutumnConfig::load_with_env_lenient_unknown_roots(&env);
+        assert!(
+            res.is_err(),
+            "a profile-prefixed unknown root must stay strict under the lenient CLI \
+             load: {res:?}"
+        );
+        let err = format!("{:?}", res.err().unwrap());
+        assert!(
+            err.contains("definitely_unknown"),
+            "error should name the profile-prefixed unknown root: {err}"
         );
     }
 


### PR DESCRIPTION
Closes #2063

## Before / After (plain language)

**Before:** the standalone `autumn` deploy CLI aborts with `Strict config check failed. Unknown keys in configuration: unknown key "media"` when it runs against a project that has a plugin-owned top-level config table (e.g. `[media]`) with `server.strict_config = true`. The CLI loads `AutumnConfig` and runs the same strict unknown-key check as app boot, but it structurally cannot know the app's plugin set (no `AppBuilder`, no plugin list, no plugin-crate dependency), so it fail-closes on a section it has no way to recognize — making the project undeployable via the CLI.

**After:** the CLI accepts unknown *top-level* config roots as opaque with a single doctor-style warning, while keeping **strict** validation of every core section it does own (`[server]`, `[database]`, `[deploy]`, …) — including child-key typos inside them — and still failing on malformed TOML. App boot is unchanged and — via the #2061 `config_section` seam — remains the authoritative strict gate for plugin-owned roots. So `autumn deploy` works on a `[media]` + `strict_config=true` project, and a genuinely-typo'd root is still caught (loudly at deploy, fatally at app boot).

Example warning:
```
deploy config: accepting 1 unknown top-level config section(s) as opaque (validated at app boot): media — if one of these is a typo it will be rejected when the app starts.
```

## How

An additive `UnknownRootPolicy { Strict, LenientWarn }` is threaded into the shared strict unknown-key check (`autumn/src/config.rs`):

- **`Strict`** (unchanged app-boot behavior): an unknown top-level root (schema parent == the document root `""`) hard-fails, exactly as before.
- **`LenientWarn`** (deploy CLI only): a genuinely-unknown top-level root is collected and surfaced once via `tracing::warn!` + `eprintln!`, never fatal. Everything else is untouched — malformed TOML still errors, and an unknown key **inside** a known section (schema parent != `""`, e.g. `[database] primry_url`) keeps its existing hard classification.

The leniency is opted into **only** by the CLI's config-load path. Two new public load variants — `AutumnConfig::load_lenient_unknown_roots()` and `load_with_env_lenient_unknown_roots(env)` — delegate to policy-parametrized internals; app-boot callers (`load()` / `load_with_env()`) keep passing `Strict`, so app boot is byte-identical. `autumn-cli/src/deploy.rs` wires its two config-load sites (`run()`'s ambient load and `load_runtime_config()`) to the lenient variants. No plugin-crate dependency is added.

The design was **user-ratified** (via the coordinator): the deploy CLI keeps strict validation over the sections it actually knows, and treats unknown top-level roots as opaque-accepted (a warning, not fatal), because app boot is the strict gate for plugin roots.

## Tests

`autumn/src/config.rs` unit tests (temp-file + FakeEnv, `AUTUMN_ENV=prod`):
- `[media]` + `strict_config=true` → lenient load **Ok**, strict load **Err** (app path unchanged).
- arbitrary unknown root `[definitely_not_a_root]` → lenient **Ok**, strict **Err**.
- known-section typo `[database] primry_url` → lenient **still Err** (fatal).
- malformed TOML → **still Err**.

A CLI-level `[media]`-under-strict test would need the full Docker/ssh `deploy_e2e` harness (a real deploy env); since `deploy.rs` only calls the two new load functions, the `config.rs`-level tests exercise the exact behavior. Noted rather than added.

## Verification

- `cargo +stable fmt --all -- --check` — clean
- `cargo +stable clippy -p autumn-web -p autumn-cli --all-targets -- -D warnings` — clean (exit 0)
- `cargo +1.97 test -p autumn-web --lib config::` — **492 passed; 0 failed** (incl. the 4 new tests)

## Notes / overlap

- Independent of, but lightly overlaps, **PR #2061** (`feat/plugin-config-section-seam`) — both touch the strict check in `autumn/src/config.rs`. Expect a light rebase whichever merges second.
- **Docs (batch 6):** the guide-worthy bit is the model — *the deploy CLI is lenient on unknown top-level roots, and app boot is the strict gate for plugin-owned config roots.*

---
_Generated by [Claude Code](https://claude.ai/code/session_019M6jVUM5hHR8AKzLgmxBxr)_